### PR TITLE
Add subresource support to client-go apply extract

### DIFF
--- a/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1/mutatingwebhookconfiguration.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1/mutatingwebhookconfiguration.go
@@ -57,8 +57,19 @@ func MutatingWebhookConfiguration(name string) *MutatingWebhookConfigurationAppl
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
 func ExtractMutatingWebhookConfiguration(mutatingWebhookConfiguration *apiadmissionregistrationv1.MutatingWebhookConfiguration, fieldManager string) (*MutatingWebhookConfigurationApplyConfiguration, error) {
+	return extractMutatingWebhookConfiguration(mutatingWebhookConfiguration, fieldManager, "")
+}
+
+// ExtractMutatingWebhookConfigurationStatus is the same as ExtractMutatingWebhookConfiguration except
+// that it extracts the status subresource applied configuration.
+// Experimental!
+func ExtractMutatingWebhookConfigurationStatus(mutatingWebhookConfiguration *apiadmissionregistrationv1.MutatingWebhookConfiguration, fieldManager string) (*MutatingWebhookConfigurationApplyConfiguration, error) {
+	return extractMutatingWebhookConfiguration(mutatingWebhookConfiguration, fieldManager, "status")
+}
+
+func extractMutatingWebhookConfiguration(mutatingWebhookConfiguration *apiadmissionregistrationv1.MutatingWebhookConfiguration, fieldManager string, subresource string) (*MutatingWebhookConfigurationApplyConfiguration, error) {
 	b := &MutatingWebhookConfigurationApplyConfiguration{}
-	err := managedfields.ExtractInto(mutatingWebhookConfiguration, internal.Parser().Type("io.k8s.api.admissionregistration.v1.MutatingWebhookConfiguration"), fieldManager, b)
+	err := managedfields.ExtractInto(mutatingWebhookConfiguration, internal.Parser().Type("io.k8s.api.admissionregistration.v1.MutatingWebhookConfiguration"), fieldManager, b, subresource)
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1/validatingwebhookconfiguration.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1/validatingwebhookconfiguration.go
@@ -57,8 +57,19 @@ func ValidatingWebhookConfiguration(name string) *ValidatingWebhookConfiguration
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
 func ExtractValidatingWebhookConfiguration(validatingWebhookConfiguration *apiadmissionregistrationv1.ValidatingWebhookConfiguration, fieldManager string) (*ValidatingWebhookConfigurationApplyConfiguration, error) {
+	return extractValidatingWebhookConfiguration(validatingWebhookConfiguration, fieldManager, "")
+}
+
+// ExtractValidatingWebhookConfigurationStatus is the same as ExtractValidatingWebhookConfiguration except
+// that it extracts the status subresource applied configuration.
+// Experimental!
+func ExtractValidatingWebhookConfigurationStatus(validatingWebhookConfiguration *apiadmissionregistrationv1.ValidatingWebhookConfiguration, fieldManager string) (*ValidatingWebhookConfigurationApplyConfiguration, error) {
+	return extractValidatingWebhookConfiguration(validatingWebhookConfiguration, fieldManager, "status")
+}
+
+func extractValidatingWebhookConfiguration(validatingWebhookConfiguration *apiadmissionregistrationv1.ValidatingWebhookConfiguration, fieldManager string, subresource string) (*ValidatingWebhookConfigurationApplyConfiguration, error) {
 	b := &ValidatingWebhookConfigurationApplyConfiguration{}
-	err := managedfields.ExtractInto(validatingWebhookConfiguration, internal.Parser().Type("io.k8s.api.admissionregistration.v1.ValidatingWebhookConfiguration"), fieldManager, b)
+	err := managedfields.ExtractInto(validatingWebhookConfiguration, internal.Parser().Type("io.k8s.api.admissionregistration.v1.ValidatingWebhookConfiguration"), fieldManager, b, subresource)
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1beta1/mutatingwebhookconfiguration.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1beta1/mutatingwebhookconfiguration.go
@@ -57,8 +57,19 @@ func MutatingWebhookConfiguration(name string) *MutatingWebhookConfigurationAppl
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
 func ExtractMutatingWebhookConfiguration(mutatingWebhookConfiguration *admissionregistrationv1beta1.MutatingWebhookConfiguration, fieldManager string) (*MutatingWebhookConfigurationApplyConfiguration, error) {
+	return extractMutatingWebhookConfiguration(mutatingWebhookConfiguration, fieldManager, "")
+}
+
+// ExtractMutatingWebhookConfigurationStatus is the same as ExtractMutatingWebhookConfiguration except
+// that it extracts the status subresource applied configuration.
+// Experimental!
+func ExtractMutatingWebhookConfigurationStatus(mutatingWebhookConfiguration *admissionregistrationv1beta1.MutatingWebhookConfiguration, fieldManager string) (*MutatingWebhookConfigurationApplyConfiguration, error) {
+	return extractMutatingWebhookConfiguration(mutatingWebhookConfiguration, fieldManager, "status")
+}
+
+func extractMutatingWebhookConfiguration(mutatingWebhookConfiguration *admissionregistrationv1beta1.MutatingWebhookConfiguration, fieldManager string, subresource string) (*MutatingWebhookConfigurationApplyConfiguration, error) {
 	b := &MutatingWebhookConfigurationApplyConfiguration{}
-	err := managedfields.ExtractInto(mutatingWebhookConfiguration, internal.Parser().Type("io.k8s.api.admissionregistration.v1beta1.MutatingWebhookConfiguration"), fieldManager, b)
+	err := managedfields.ExtractInto(mutatingWebhookConfiguration, internal.Parser().Type("io.k8s.api.admissionregistration.v1beta1.MutatingWebhookConfiguration"), fieldManager, b, subresource)
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1beta1/validatingwebhookconfiguration.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1beta1/validatingwebhookconfiguration.go
@@ -57,8 +57,19 @@ func ValidatingWebhookConfiguration(name string) *ValidatingWebhookConfiguration
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
 func ExtractValidatingWebhookConfiguration(validatingWebhookConfiguration *admissionregistrationv1beta1.ValidatingWebhookConfiguration, fieldManager string) (*ValidatingWebhookConfigurationApplyConfiguration, error) {
+	return extractValidatingWebhookConfiguration(validatingWebhookConfiguration, fieldManager, "")
+}
+
+// ExtractValidatingWebhookConfigurationStatus is the same as ExtractValidatingWebhookConfiguration except
+// that it extracts the status subresource applied configuration.
+// Experimental!
+func ExtractValidatingWebhookConfigurationStatus(validatingWebhookConfiguration *admissionregistrationv1beta1.ValidatingWebhookConfiguration, fieldManager string) (*ValidatingWebhookConfigurationApplyConfiguration, error) {
+	return extractValidatingWebhookConfiguration(validatingWebhookConfiguration, fieldManager, "status")
+}
+
+func extractValidatingWebhookConfiguration(validatingWebhookConfiguration *admissionregistrationv1beta1.ValidatingWebhookConfiguration, fieldManager string, subresource string) (*ValidatingWebhookConfigurationApplyConfiguration, error) {
 	b := &ValidatingWebhookConfigurationApplyConfiguration{}
-	err := managedfields.ExtractInto(validatingWebhookConfiguration, internal.Parser().Type("io.k8s.api.admissionregistration.v1beta1.ValidatingWebhookConfiguration"), fieldManager, b)
+	err := managedfields.ExtractInto(validatingWebhookConfiguration, internal.Parser().Type("io.k8s.api.admissionregistration.v1beta1.ValidatingWebhookConfiguration"), fieldManager, b, subresource)
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/apiserverinternal/v1alpha1/storageversion.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/apiserverinternal/v1alpha1/storageversion.go
@@ -58,8 +58,19 @@ func StorageVersion(name string) *StorageVersionApplyConfiguration {
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
 func ExtractStorageVersion(storageVersion *v1alpha1.StorageVersion, fieldManager string) (*StorageVersionApplyConfiguration, error) {
+	return extractStorageVersion(storageVersion, fieldManager, "")
+}
+
+// ExtractStorageVersionStatus is the same as ExtractStorageVersion except
+// that it extracts the status subresource applied configuration.
+// Experimental!
+func ExtractStorageVersionStatus(storageVersion *v1alpha1.StorageVersion, fieldManager string) (*StorageVersionApplyConfiguration, error) {
+	return extractStorageVersion(storageVersion, fieldManager, "status")
+}
+
+func extractStorageVersion(storageVersion *v1alpha1.StorageVersion, fieldManager string, subresource string) (*StorageVersionApplyConfiguration, error) {
 	b := &StorageVersionApplyConfiguration{}
-	err := managedfields.ExtractInto(storageVersion, internal.Parser().Type("io.k8s.api.apiserverinternal.v1alpha1.StorageVersion"), fieldManager, b)
+	err := managedfields.ExtractInto(storageVersion, internal.Parser().Type("io.k8s.api.apiserverinternal.v1alpha1.StorageVersion"), fieldManager, b, subresource)
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/apps/v1/controllerrevision.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/apps/v1/controllerrevision.go
@@ -60,8 +60,19 @@ func ControllerRevision(name, namespace string) *ControllerRevisionApplyConfigur
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
 func ExtractControllerRevision(controllerRevision *appsv1.ControllerRevision, fieldManager string) (*ControllerRevisionApplyConfiguration, error) {
+	return extractControllerRevision(controllerRevision, fieldManager, "")
+}
+
+// ExtractControllerRevisionStatus is the same as ExtractControllerRevision except
+// that it extracts the status subresource applied configuration.
+// Experimental!
+func ExtractControllerRevisionStatus(controllerRevision *appsv1.ControllerRevision, fieldManager string) (*ControllerRevisionApplyConfiguration, error) {
+	return extractControllerRevision(controllerRevision, fieldManager, "status")
+}
+
+func extractControllerRevision(controllerRevision *appsv1.ControllerRevision, fieldManager string, subresource string) (*ControllerRevisionApplyConfiguration, error) {
 	b := &ControllerRevisionApplyConfiguration{}
-	err := managedfields.ExtractInto(controllerRevision, internal.Parser().Type("io.k8s.api.apps.v1.ControllerRevision"), fieldManager, b)
+	err := managedfields.ExtractInto(controllerRevision, internal.Parser().Type("io.k8s.api.apps.v1.ControllerRevision"), fieldManager, b, subresource)
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/apps/v1/daemonset.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/apps/v1/daemonset.go
@@ -59,8 +59,19 @@ func DaemonSet(name, namespace string) *DaemonSetApplyConfiguration {
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
 func ExtractDaemonSet(daemonSet *apiappsv1.DaemonSet, fieldManager string) (*DaemonSetApplyConfiguration, error) {
+	return extractDaemonSet(daemonSet, fieldManager, "")
+}
+
+// ExtractDaemonSetStatus is the same as ExtractDaemonSet except
+// that it extracts the status subresource applied configuration.
+// Experimental!
+func ExtractDaemonSetStatus(daemonSet *apiappsv1.DaemonSet, fieldManager string) (*DaemonSetApplyConfiguration, error) {
+	return extractDaemonSet(daemonSet, fieldManager, "status")
+}
+
+func extractDaemonSet(daemonSet *apiappsv1.DaemonSet, fieldManager string, subresource string) (*DaemonSetApplyConfiguration, error) {
 	b := &DaemonSetApplyConfiguration{}
-	err := managedfields.ExtractInto(daemonSet, internal.Parser().Type("io.k8s.api.apps.v1.DaemonSet"), fieldManager, b)
+	err := managedfields.ExtractInto(daemonSet, internal.Parser().Type("io.k8s.api.apps.v1.DaemonSet"), fieldManager, b, subresource)
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/apps/v1/deployment.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/apps/v1/deployment.go
@@ -59,8 +59,19 @@ func Deployment(name, namespace string) *DeploymentApplyConfiguration {
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
 func ExtractDeployment(deployment *apiappsv1.Deployment, fieldManager string) (*DeploymentApplyConfiguration, error) {
+	return extractDeployment(deployment, fieldManager, "")
+}
+
+// ExtractDeploymentStatus is the same as ExtractDeployment except
+// that it extracts the status subresource applied configuration.
+// Experimental!
+func ExtractDeploymentStatus(deployment *apiappsv1.Deployment, fieldManager string) (*DeploymentApplyConfiguration, error) {
+	return extractDeployment(deployment, fieldManager, "status")
+}
+
+func extractDeployment(deployment *apiappsv1.Deployment, fieldManager string, subresource string) (*DeploymentApplyConfiguration, error) {
 	b := &DeploymentApplyConfiguration{}
-	err := managedfields.ExtractInto(deployment, internal.Parser().Type("io.k8s.api.apps.v1.Deployment"), fieldManager, b)
+	err := managedfields.ExtractInto(deployment, internal.Parser().Type("io.k8s.api.apps.v1.Deployment"), fieldManager, b, subresource)
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/apps/v1/replicaset.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/apps/v1/replicaset.go
@@ -59,8 +59,19 @@ func ReplicaSet(name, namespace string) *ReplicaSetApplyConfiguration {
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
 func ExtractReplicaSet(replicaSet *apiappsv1.ReplicaSet, fieldManager string) (*ReplicaSetApplyConfiguration, error) {
+	return extractReplicaSet(replicaSet, fieldManager, "")
+}
+
+// ExtractReplicaSetStatus is the same as ExtractReplicaSet except
+// that it extracts the status subresource applied configuration.
+// Experimental!
+func ExtractReplicaSetStatus(replicaSet *apiappsv1.ReplicaSet, fieldManager string) (*ReplicaSetApplyConfiguration, error) {
+	return extractReplicaSet(replicaSet, fieldManager, "status")
+}
+
+func extractReplicaSet(replicaSet *apiappsv1.ReplicaSet, fieldManager string, subresource string) (*ReplicaSetApplyConfiguration, error) {
 	b := &ReplicaSetApplyConfiguration{}
-	err := managedfields.ExtractInto(replicaSet, internal.Parser().Type("io.k8s.api.apps.v1.ReplicaSet"), fieldManager, b)
+	err := managedfields.ExtractInto(replicaSet, internal.Parser().Type("io.k8s.api.apps.v1.ReplicaSet"), fieldManager, b, subresource)
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/apps/v1/statefulset.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/apps/v1/statefulset.go
@@ -59,8 +59,19 @@ func StatefulSet(name, namespace string) *StatefulSetApplyConfiguration {
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
 func ExtractStatefulSet(statefulSet *apiappsv1.StatefulSet, fieldManager string) (*StatefulSetApplyConfiguration, error) {
+	return extractStatefulSet(statefulSet, fieldManager, "")
+}
+
+// ExtractStatefulSetStatus is the same as ExtractStatefulSet except
+// that it extracts the status subresource applied configuration.
+// Experimental!
+func ExtractStatefulSetStatus(statefulSet *apiappsv1.StatefulSet, fieldManager string) (*StatefulSetApplyConfiguration, error) {
+	return extractStatefulSet(statefulSet, fieldManager, "status")
+}
+
+func extractStatefulSet(statefulSet *apiappsv1.StatefulSet, fieldManager string, subresource string) (*StatefulSetApplyConfiguration, error) {
 	b := &StatefulSetApplyConfiguration{}
-	err := managedfields.ExtractInto(statefulSet, internal.Parser().Type("io.k8s.api.apps.v1.StatefulSet"), fieldManager, b)
+	err := managedfields.ExtractInto(statefulSet, internal.Parser().Type("io.k8s.api.apps.v1.StatefulSet"), fieldManager, b, subresource)
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/apps/v1beta1/controllerrevision.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/apps/v1beta1/controllerrevision.go
@@ -60,8 +60,19 @@ func ControllerRevision(name, namespace string) *ControllerRevisionApplyConfigur
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
 func ExtractControllerRevision(controllerRevision *v1beta1.ControllerRevision, fieldManager string) (*ControllerRevisionApplyConfiguration, error) {
+	return extractControllerRevision(controllerRevision, fieldManager, "")
+}
+
+// ExtractControllerRevisionStatus is the same as ExtractControllerRevision except
+// that it extracts the status subresource applied configuration.
+// Experimental!
+func ExtractControllerRevisionStatus(controllerRevision *v1beta1.ControllerRevision, fieldManager string) (*ControllerRevisionApplyConfiguration, error) {
+	return extractControllerRevision(controllerRevision, fieldManager, "status")
+}
+
+func extractControllerRevision(controllerRevision *v1beta1.ControllerRevision, fieldManager string, subresource string) (*ControllerRevisionApplyConfiguration, error) {
 	b := &ControllerRevisionApplyConfiguration{}
-	err := managedfields.ExtractInto(controllerRevision, internal.Parser().Type("io.k8s.api.apps.v1beta1.ControllerRevision"), fieldManager, b)
+	err := managedfields.ExtractInto(controllerRevision, internal.Parser().Type("io.k8s.api.apps.v1beta1.ControllerRevision"), fieldManager, b, subresource)
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/apps/v1beta1/deployment.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/apps/v1beta1/deployment.go
@@ -59,8 +59,19 @@ func Deployment(name, namespace string) *DeploymentApplyConfiguration {
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
 func ExtractDeployment(deployment *appsv1beta1.Deployment, fieldManager string) (*DeploymentApplyConfiguration, error) {
+	return extractDeployment(deployment, fieldManager, "")
+}
+
+// ExtractDeploymentStatus is the same as ExtractDeployment except
+// that it extracts the status subresource applied configuration.
+// Experimental!
+func ExtractDeploymentStatus(deployment *appsv1beta1.Deployment, fieldManager string) (*DeploymentApplyConfiguration, error) {
+	return extractDeployment(deployment, fieldManager, "status")
+}
+
+func extractDeployment(deployment *appsv1beta1.Deployment, fieldManager string, subresource string) (*DeploymentApplyConfiguration, error) {
 	b := &DeploymentApplyConfiguration{}
-	err := managedfields.ExtractInto(deployment, internal.Parser().Type("io.k8s.api.apps.v1beta1.Deployment"), fieldManager, b)
+	err := managedfields.ExtractInto(deployment, internal.Parser().Type("io.k8s.api.apps.v1beta1.Deployment"), fieldManager, b, subresource)
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/apps/v1beta1/statefulset.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/apps/v1beta1/statefulset.go
@@ -59,8 +59,19 @@ func StatefulSet(name, namespace string) *StatefulSetApplyConfiguration {
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
 func ExtractStatefulSet(statefulSet *appsv1beta1.StatefulSet, fieldManager string) (*StatefulSetApplyConfiguration, error) {
+	return extractStatefulSet(statefulSet, fieldManager, "")
+}
+
+// ExtractStatefulSetStatus is the same as ExtractStatefulSet except
+// that it extracts the status subresource applied configuration.
+// Experimental!
+func ExtractStatefulSetStatus(statefulSet *appsv1beta1.StatefulSet, fieldManager string) (*StatefulSetApplyConfiguration, error) {
+	return extractStatefulSet(statefulSet, fieldManager, "status")
+}
+
+func extractStatefulSet(statefulSet *appsv1beta1.StatefulSet, fieldManager string, subresource string) (*StatefulSetApplyConfiguration, error) {
 	b := &StatefulSetApplyConfiguration{}
-	err := managedfields.ExtractInto(statefulSet, internal.Parser().Type("io.k8s.api.apps.v1beta1.StatefulSet"), fieldManager, b)
+	err := managedfields.ExtractInto(statefulSet, internal.Parser().Type("io.k8s.api.apps.v1beta1.StatefulSet"), fieldManager, b, subresource)
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/apps/v1beta2/controllerrevision.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/apps/v1beta2/controllerrevision.go
@@ -60,8 +60,19 @@ func ControllerRevision(name, namespace string) *ControllerRevisionApplyConfigur
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
 func ExtractControllerRevision(controllerRevision *v1beta2.ControllerRevision, fieldManager string) (*ControllerRevisionApplyConfiguration, error) {
+	return extractControllerRevision(controllerRevision, fieldManager, "")
+}
+
+// ExtractControllerRevisionStatus is the same as ExtractControllerRevision except
+// that it extracts the status subresource applied configuration.
+// Experimental!
+func ExtractControllerRevisionStatus(controllerRevision *v1beta2.ControllerRevision, fieldManager string) (*ControllerRevisionApplyConfiguration, error) {
+	return extractControllerRevision(controllerRevision, fieldManager, "status")
+}
+
+func extractControllerRevision(controllerRevision *v1beta2.ControllerRevision, fieldManager string, subresource string) (*ControllerRevisionApplyConfiguration, error) {
 	b := &ControllerRevisionApplyConfiguration{}
-	err := managedfields.ExtractInto(controllerRevision, internal.Parser().Type("io.k8s.api.apps.v1beta2.ControllerRevision"), fieldManager, b)
+	err := managedfields.ExtractInto(controllerRevision, internal.Parser().Type("io.k8s.api.apps.v1beta2.ControllerRevision"), fieldManager, b, subresource)
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/apps/v1beta2/daemonset.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/apps/v1beta2/daemonset.go
@@ -59,8 +59,19 @@ func DaemonSet(name, namespace string) *DaemonSetApplyConfiguration {
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
 func ExtractDaemonSet(daemonSet *appsv1beta2.DaemonSet, fieldManager string) (*DaemonSetApplyConfiguration, error) {
+	return extractDaemonSet(daemonSet, fieldManager, "")
+}
+
+// ExtractDaemonSetStatus is the same as ExtractDaemonSet except
+// that it extracts the status subresource applied configuration.
+// Experimental!
+func ExtractDaemonSetStatus(daemonSet *appsv1beta2.DaemonSet, fieldManager string) (*DaemonSetApplyConfiguration, error) {
+	return extractDaemonSet(daemonSet, fieldManager, "status")
+}
+
+func extractDaemonSet(daemonSet *appsv1beta2.DaemonSet, fieldManager string, subresource string) (*DaemonSetApplyConfiguration, error) {
 	b := &DaemonSetApplyConfiguration{}
-	err := managedfields.ExtractInto(daemonSet, internal.Parser().Type("io.k8s.api.apps.v1beta2.DaemonSet"), fieldManager, b)
+	err := managedfields.ExtractInto(daemonSet, internal.Parser().Type("io.k8s.api.apps.v1beta2.DaemonSet"), fieldManager, b, subresource)
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/apps/v1beta2/deployment.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/apps/v1beta2/deployment.go
@@ -59,8 +59,19 @@ func Deployment(name, namespace string) *DeploymentApplyConfiguration {
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
 func ExtractDeployment(deployment *appsv1beta2.Deployment, fieldManager string) (*DeploymentApplyConfiguration, error) {
+	return extractDeployment(deployment, fieldManager, "")
+}
+
+// ExtractDeploymentStatus is the same as ExtractDeployment except
+// that it extracts the status subresource applied configuration.
+// Experimental!
+func ExtractDeploymentStatus(deployment *appsv1beta2.Deployment, fieldManager string) (*DeploymentApplyConfiguration, error) {
+	return extractDeployment(deployment, fieldManager, "status")
+}
+
+func extractDeployment(deployment *appsv1beta2.Deployment, fieldManager string, subresource string) (*DeploymentApplyConfiguration, error) {
 	b := &DeploymentApplyConfiguration{}
-	err := managedfields.ExtractInto(deployment, internal.Parser().Type("io.k8s.api.apps.v1beta2.Deployment"), fieldManager, b)
+	err := managedfields.ExtractInto(deployment, internal.Parser().Type("io.k8s.api.apps.v1beta2.Deployment"), fieldManager, b, subresource)
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/apps/v1beta2/replicaset.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/apps/v1beta2/replicaset.go
@@ -59,8 +59,19 @@ func ReplicaSet(name, namespace string) *ReplicaSetApplyConfiguration {
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
 func ExtractReplicaSet(replicaSet *appsv1beta2.ReplicaSet, fieldManager string) (*ReplicaSetApplyConfiguration, error) {
+	return extractReplicaSet(replicaSet, fieldManager, "")
+}
+
+// ExtractReplicaSetStatus is the same as ExtractReplicaSet except
+// that it extracts the status subresource applied configuration.
+// Experimental!
+func ExtractReplicaSetStatus(replicaSet *appsv1beta2.ReplicaSet, fieldManager string) (*ReplicaSetApplyConfiguration, error) {
+	return extractReplicaSet(replicaSet, fieldManager, "status")
+}
+
+func extractReplicaSet(replicaSet *appsv1beta2.ReplicaSet, fieldManager string, subresource string) (*ReplicaSetApplyConfiguration, error) {
 	b := &ReplicaSetApplyConfiguration{}
-	err := managedfields.ExtractInto(replicaSet, internal.Parser().Type("io.k8s.api.apps.v1beta2.ReplicaSet"), fieldManager, b)
+	err := managedfields.ExtractInto(replicaSet, internal.Parser().Type("io.k8s.api.apps.v1beta2.ReplicaSet"), fieldManager, b, subresource)
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/apps/v1beta2/statefulset.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/apps/v1beta2/statefulset.go
@@ -59,8 +59,19 @@ func StatefulSet(name, namespace string) *StatefulSetApplyConfiguration {
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
 func ExtractStatefulSet(statefulSet *appsv1beta2.StatefulSet, fieldManager string) (*StatefulSetApplyConfiguration, error) {
+	return extractStatefulSet(statefulSet, fieldManager, "")
+}
+
+// ExtractStatefulSetStatus is the same as ExtractStatefulSet except
+// that it extracts the status subresource applied configuration.
+// Experimental!
+func ExtractStatefulSetStatus(statefulSet *appsv1beta2.StatefulSet, fieldManager string) (*StatefulSetApplyConfiguration, error) {
+	return extractStatefulSet(statefulSet, fieldManager, "status")
+}
+
+func extractStatefulSet(statefulSet *appsv1beta2.StatefulSet, fieldManager string, subresource string) (*StatefulSetApplyConfiguration, error) {
 	b := &StatefulSetApplyConfiguration{}
-	err := managedfields.ExtractInto(statefulSet, internal.Parser().Type("io.k8s.api.apps.v1beta2.StatefulSet"), fieldManager, b)
+	err := managedfields.ExtractInto(statefulSet, internal.Parser().Type("io.k8s.api.apps.v1beta2.StatefulSet"), fieldManager, b, subresource)
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/autoscaling/v1/horizontalpodautoscaler.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/autoscaling/v1/horizontalpodautoscaler.go
@@ -59,8 +59,19 @@ func HorizontalPodAutoscaler(name, namespace string) *HorizontalPodAutoscalerApp
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
 func ExtractHorizontalPodAutoscaler(horizontalPodAutoscaler *apiautoscalingv1.HorizontalPodAutoscaler, fieldManager string) (*HorizontalPodAutoscalerApplyConfiguration, error) {
+	return extractHorizontalPodAutoscaler(horizontalPodAutoscaler, fieldManager, "")
+}
+
+// ExtractHorizontalPodAutoscalerStatus is the same as ExtractHorizontalPodAutoscaler except
+// that it extracts the status subresource applied configuration.
+// Experimental!
+func ExtractHorizontalPodAutoscalerStatus(horizontalPodAutoscaler *apiautoscalingv1.HorizontalPodAutoscaler, fieldManager string) (*HorizontalPodAutoscalerApplyConfiguration, error) {
+	return extractHorizontalPodAutoscaler(horizontalPodAutoscaler, fieldManager, "status")
+}
+
+func extractHorizontalPodAutoscaler(horizontalPodAutoscaler *apiautoscalingv1.HorizontalPodAutoscaler, fieldManager string, subresource string) (*HorizontalPodAutoscalerApplyConfiguration, error) {
 	b := &HorizontalPodAutoscalerApplyConfiguration{}
-	err := managedfields.ExtractInto(horizontalPodAutoscaler, internal.Parser().Type("io.k8s.api.autoscaling.v1.HorizontalPodAutoscaler"), fieldManager, b)
+	err := managedfields.ExtractInto(horizontalPodAutoscaler, internal.Parser().Type("io.k8s.api.autoscaling.v1.HorizontalPodAutoscaler"), fieldManager, b, subresource)
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/autoscaling/v2beta1/horizontalpodautoscaler.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/autoscaling/v2beta1/horizontalpodautoscaler.go
@@ -59,8 +59,19 @@ func HorizontalPodAutoscaler(name, namespace string) *HorizontalPodAutoscalerApp
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
 func ExtractHorizontalPodAutoscaler(horizontalPodAutoscaler *autoscalingv2beta1.HorizontalPodAutoscaler, fieldManager string) (*HorizontalPodAutoscalerApplyConfiguration, error) {
+	return extractHorizontalPodAutoscaler(horizontalPodAutoscaler, fieldManager, "")
+}
+
+// ExtractHorizontalPodAutoscalerStatus is the same as ExtractHorizontalPodAutoscaler except
+// that it extracts the status subresource applied configuration.
+// Experimental!
+func ExtractHorizontalPodAutoscalerStatus(horizontalPodAutoscaler *autoscalingv2beta1.HorizontalPodAutoscaler, fieldManager string) (*HorizontalPodAutoscalerApplyConfiguration, error) {
+	return extractHorizontalPodAutoscaler(horizontalPodAutoscaler, fieldManager, "status")
+}
+
+func extractHorizontalPodAutoscaler(horizontalPodAutoscaler *autoscalingv2beta1.HorizontalPodAutoscaler, fieldManager string, subresource string) (*HorizontalPodAutoscalerApplyConfiguration, error) {
 	b := &HorizontalPodAutoscalerApplyConfiguration{}
-	err := managedfields.ExtractInto(horizontalPodAutoscaler, internal.Parser().Type("io.k8s.api.autoscaling.v2beta1.HorizontalPodAutoscaler"), fieldManager, b)
+	err := managedfields.ExtractInto(horizontalPodAutoscaler, internal.Parser().Type("io.k8s.api.autoscaling.v2beta1.HorizontalPodAutoscaler"), fieldManager, b, subresource)
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/autoscaling/v2beta2/horizontalpodautoscaler.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/autoscaling/v2beta2/horizontalpodautoscaler.go
@@ -59,8 +59,19 @@ func HorizontalPodAutoscaler(name, namespace string) *HorizontalPodAutoscalerApp
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
 func ExtractHorizontalPodAutoscaler(horizontalPodAutoscaler *autoscalingv2beta2.HorizontalPodAutoscaler, fieldManager string) (*HorizontalPodAutoscalerApplyConfiguration, error) {
+	return extractHorizontalPodAutoscaler(horizontalPodAutoscaler, fieldManager, "")
+}
+
+// ExtractHorizontalPodAutoscalerStatus is the same as ExtractHorizontalPodAutoscaler except
+// that it extracts the status subresource applied configuration.
+// Experimental!
+func ExtractHorizontalPodAutoscalerStatus(horizontalPodAutoscaler *autoscalingv2beta2.HorizontalPodAutoscaler, fieldManager string) (*HorizontalPodAutoscalerApplyConfiguration, error) {
+	return extractHorizontalPodAutoscaler(horizontalPodAutoscaler, fieldManager, "status")
+}
+
+func extractHorizontalPodAutoscaler(horizontalPodAutoscaler *autoscalingv2beta2.HorizontalPodAutoscaler, fieldManager string, subresource string) (*HorizontalPodAutoscalerApplyConfiguration, error) {
 	b := &HorizontalPodAutoscalerApplyConfiguration{}
-	err := managedfields.ExtractInto(horizontalPodAutoscaler, internal.Parser().Type("io.k8s.api.autoscaling.v2beta2.HorizontalPodAutoscaler"), fieldManager, b)
+	err := managedfields.ExtractInto(horizontalPodAutoscaler, internal.Parser().Type("io.k8s.api.autoscaling.v2beta2.HorizontalPodAutoscaler"), fieldManager, b, subresource)
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/batch/v1/cronjob.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/batch/v1/cronjob.go
@@ -59,8 +59,19 @@ func CronJob(name, namespace string) *CronJobApplyConfiguration {
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
 func ExtractCronJob(cronJob *apibatchv1.CronJob, fieldManager string) (*CronJobApplyConfiguration, error) {
+	return extractCronJob(cronJob, fieldManager, "")
+}
+
+// ExtractCronJobStatus is the same as ExtractCronJob except
+// that it extracts the status subresource applied configuration.
+// Experimental!
+func ExtractCronJobStatus(cronJob *apibatchv1.CronJob, fieldManager string) (*CronJobApplyConfiguration, error) {
+	return extractCronJob(cronJob, fieldManager, "status")
+}
+
+func extractCronJob(cronJob *apibatchv1.CronJob, fieldManager string, subresource string) (*CronJobApplyConfiguration, error) {
 	b := &CronJobApplyConfiguration{}
-	err := managedfields.ExtractInto(cronJob, internal.Parser().Type("io.k8s.api.batch.v1.CronJob"), fieldManager, b)
+	err := managedfields.ExtractInto(cronJob, internal.Parser().Type("io.k8s.api.batch.v1.CronJob"), fieldManager, b, subresource)
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/batch/v1/job.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/batch/v1/job.go
@@ -59,8 +59,19 @@ func Job(name, namespace string) *JobApplyConfiguration {
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
 func ExtractJob(job *apibatchv1.Job, fieldManager string) (*JobApplyConfiguration, error) {
+	return extractJob(job, fieldManager, "")
+}
+
+// ExtractJobStatus is the same as ExtractJob except
+// that it extracts the status subresource applied configuration.
+// Experimental!
+func ExtractJobStatus(job *apibatchv1.Job, fieldManager string) (*JobApplyConfiguration, error) {
+	return extractJob(job, fieldManager, "status")
+}
+
+func extractJob(job *apibatchv1.Job, fieldManager string, subresource string) (*JobApplyConfiguration, error) {
 	b := &JobApplyConfiguration{}
-	err := managedfields.ExtractInto(job, internal.Parser().Type("io.k8s.api.batch.v1.Job"), fieldManager, b)
+	err := managedfields.ExtractInto(job, internal.Parser().Type("io.k8s.api.batch.v1.Job"), fieldManager, b, subresource)
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/batch/v1beta1/cronjob.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/batch/v1beta1/cronjob.go
@@ -59,8 +59,19 @@ func CronJob(name, namespace string) *CronJobApplyConfiguration {
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
 func ExtractCronJob(cronJob *batchv1beta1.CronJob, fieldManager string) (*CronJobApplyConfiguration, error) {
+	return extractCronJob(cronJob, fieldManager, "")
+}
+
+// ExtractCronJobStatus is the same as ExtractCronJob except
+// that it extracts the status subresource applied configuration.
+// Experimental!
+func ExtractCronJobStatus(cronJob *batchv1beta1.CronJob, fieldManager string) (*CronJobApplyConfiguration, error) {
+	return extractCronJob(cronJob, fieldManager, "status")
+}
+
+func extractCronJob(cronJob *batchv1beta1.CronJob, fieldManager string, subresource string) (*CronJobApplyConfiguration, error) {
 	b := &CronJobApplyConfiguration{}
-	err := managedfields.ExtractInto(cronJob, internal.Parser().Type("io.k8s.api.batch.v1beta1.CronJob"), fieldManager, b)
+	err := managedfields.ExtractInto(cronJob, internal.Parser().Type("io.k8s.api.batch.v1beta1.CronJob"), fieldManager, b, subresource)
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/certificates/v1/certificatesigningrequest.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/certificates/v1/certificatesigningrequest.go
@@ -58,8 +58,19 @@ func CertificateSigningRequest(name string) *CertificateSigningRequestApplyConfi
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
 func ExtractCertificateSigningRequest(certificateSigningRequest *apicertificatesv1.CertificateSigningRequest, fieldManager string) (*CertificateSigningRequestApplyConfiguration, error) {
+	return extractCertificateSigningRequest(certificateSigningRequest, fieldManager, "")
+}
+
+// ExtractCertificateSigningRequestStatus is the same as ExtractCertificateSigningRequest except
+// that it extracts the status subresource applied configuration.
+// Experimental!
+func ExtractCertificateSigningRequestStatus(certificateSigningRequest *apicertificatesv1.CertificateSigningRequest, fieldManager string) (*CertificateSigningRequestApplyConfiguration, error) {
+	return extractCertificateSigningRequest(certificateSigningRequest, fieldManager, "status")
+}
+
+func extractCertificateSigningRequest(certificateSigningRequest *apicertificatesv1.CertificateSigningRequest, fieldManager string, subresource string) (*CertificateSigningRequestApplyConfiguration, error) {
 	b := &CertificateSigningRequestApplyConfiguration{}
-	err := managedfields.ExtractInto(certificateSigningRequest, internal.Parser().Type("io.k8s.api.certificates.v1.CertificateSigningRequest"), fieldManager, b)
+	err := managedfields.ExtractInto(certificateSigningRequest, internal.Parser().Type("io.k8s.api.certificates.v1.CertificateSigningRequest"), fieldManager, b, subresource)
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/certificates/v1beta1/certificatesigningrequest.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/certificates/v1beta1/certificatesigningrequest.go
@@ -58,8 +58,19 @@ func CertificateSigningRequest(name string) *CertificateSigningRequestApplyConfi
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
 func ExtractCertificateSigningRequest(certificateSigningRequest *certificatesv1beta1.CertificateSigningRequest, fieldManager string) (*CertificateSigningRequestApplyConfiguration, error) {
+	return extractCertificateSigningRequest(certificateSigningRequest, fieldManager, "")
+}
+
+// ExtractCertificateSigningRequestStatus is the same as ExtractCertificateSigningRequest except
+// that it extracts the status subresource applied configuration.
+// Experimental!
+func ExtractCertificateSigningRequestStatus(certificateSigningRequest *certificatesv1beta1.CertificateSigningRequest, fieldManager string) (*CertificateSigningRequestApplyConfiguration, error) {
+	return extractCertificateSigningRequest(certificateSigningRequest, fieldManager, "status")
+}
+
+func extractCertificateSigningRequest(certificateSigningRequest *certificatesv1beta1.CertificateSigningRequest, fieldManager string, subresource string) (*CertificateSigningRequestApplyConfiguration, error) {
 	b := &CertificateSigningRequestApplyConfiguration{}
-	err := managedfields.ExtractInto(certificateSigningRequest, internal.Parser().Type("io.k8s.api.certificates.v1beta1.CertificateSigningRequest"), fieldManager, b)
+	err := managedfields.ExtractInto(certificateSigningRequest, internal.Parser().Type("io.k8s.api.certificates.v1beta1.CertificateSigningRequest"), fieldManager, b, subresource)
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/coordination/v1/lease.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/coordination/v1/lease.go
@@ -58,8 +58,19 @@ func Lease(name, namespace string) *LeaseApplyConfiguration {
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
 func ExtractLease(lease *apicoordinationv1.Lease, fieldManager string) (*LeaseApplyConfiguration, error) {
+	return extractLease(lease, fieldManager, "")
+}
+
+// ExtractLeaseStatus is the same as ExtractLease except
+// that it extracts the status subresource applied configuration.
+// Experimental!
+func ExtractLeaseStatus(lease *apicoordinationv1.Lease, fieldManager string) (*LeaseApplyConfiguration, error) {
+	return extractLease(lease, fieldManager, "status")
+}
+
+func extractLease(lease *apicoordinationv1.Lease, fieldManager string, subresource string) (*LeaseApplyConfiguration, error) {
 	b := &LeaseApplyConfiguration{}
-	err := managedfields.ExtractInto(lease, internal.Parser().Type("io.k8s.api.coordination.v1.Lease"), fieldManager, b)
+	err := managedfields.ExtractInto(lease, internal.Parser().Type("io.k8s.api.coordination.v1.Lease"), fieldManager, b, subresource)
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/coordination/v1beta1/lease.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/coordination/v1beta1/lease.go
@@ -58,8 +58,19 @@ func Lease(name, namespace string) *LeaseApplyConfiguration {
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
 func ExtractLease(lease *coordinationv1beta1.Lease, fieldManager string) (*LeaseApplyConfiguration, error) {
+	return extractLease(lease, fieldManager, "")
+}
+
+// ExtractLeaseStatus is the same as ExtractLease except
+// that it extracts the status subresource applied configuration.
+// Experimental!
+func ExtractLeaseStatus(lease *coordinationv1beta1.Lease, fieldManager string) (*LeaseApplyConfiguration, error) {
+	return extractLease(lease, fieldManager, "status")
+}
+
+func extractLease(lease *coordinationv1beta1.Lease, fieldManager string, subresource string) (*LeaseApplyConfiguration, error) {
 	b := &LeaseApplyConfiguration{}
-	err := managedfields.ExtractInto(lease, internal.Parser().Type("io.k8s.api.coordination.v1beta1.Lease"), fieldManager, b)
+	err := managedfields.ExtractInto(lease, internal.Parser().Type("io.k8s.api.coordination.v1beta1.Lease"), fieldManager, b, subresource)
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/componentstatus.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/componentstatus.go
@@ -57,8 +57,19 @@ func ComponentStatus(name string) *ComponentStatusApplyConfiguration {
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
 func ExtractComponentStatus(componentStatus *apicorev1.ComponentStatus, fieldManager string) (*ComponentStatusApplyConfiguration, error) {
+	return extractComponentStatus(componentStatus, fieldManager, "")
+}
+
+// ExtractComponentStatusStatus is the same as ExtractComponentStatus except
+// that it extracts the status subresource applied configuration.
+// Experimental!
+func ExtractComponentStatusStatus(componentStatus *apicorev1.ComponentStatus, fieldManager string) (*ComponentStatusApplyConfiguration, error) {
+	return extractComponentStatus(componentStatus, fieldManager, "status")
+}
+
+func extractComponentStatus(componentStatus *apicorev1.ComponentStatus, fieldManager string, subresource string) (*ComponentStatusApplyConfiguration, error) {
 	b := &ComponentStatusApplyConfiguration{}
-	err := managedfields.ExtractInto(componentStatus, internal.Parser().Type("io.k8s.api.core.v1.ComponentStatus"), fieldManager, b)
+	err := managedfields.ExtractInto(componentStatus, internal.Parser().Type("io.k8s.api.core.v1.ComponentStatus"), fieldManager, b, subresource)
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/configmap.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/configmap.go
@@ -60,8 +60,19 @@ func ConfigMap(name, namespace string) *ConfigMapApplyConfiguration {
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
 func ExtractConfigMap(configMap *corev1.ConfigMap, fieldManager string) (*ConfigMapApplyConfiguration, error) {
+	return extractConfigMap(configMap, fieldManager, "")
+}
+
+// ExtractConfigMapStatus is the same as ExtractConfigMap except
+// that it extracts the status subresource applied configuration.
+// Experimental!
+func ExtractConfigMapStatus(configMap *corev1.ConfigMap, fieldManager string) (*ConfigMapApplyConfiguration, error) {
+	return extractConfigMap(configMap, fieldManager, "status")
+}
+
+func extractConfigMap(configMap *corev1.ConfigMap, fieldManager string, subresource string) (*ConfigMapApplyConfiguration, error) {
 	b := &ConfigMapApplyConfiguration{}
-	err := managedfields.ExtractInto(configMap, internal.Parser().Type("io.k8s.api.core.v1.ConfigMap"), fieldManager, b)
+	err := managedfields.ExtractInto(configMap, internal.Parser().Type("io.k8s.api.core.v1.ConfigMap"), fieldManager, b, subresource)
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/endpoints.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/endpoints.go
@@ -58,8 +58,19 @@ func Endpoints(name, namespace string) *EndpointsApplyConfiguration {
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
 func ExtractEndpoints(endpoints *apicorev1.Endpoints, fieldManager string) (*EndpointsApplyConfiguration, error) {
+	return extractEndpoints(endpoints, fieldManager, "")
+}
+
+// ExtractEndpointsStatus is the same as ExtractEndpoints except
+// that it extracts the status subresource applied configuration.
+// Experimental!
+func ExtractEndpointsStatus(endpoints *apicorev1.Endpoints, fieldManager string) (*EndpointsApplyConfiguration, error) {
+	return extractEndpoints(endpoints, fieldManager, "status")
+}
+
+func extractEndpoints(endpoints *apicorev1.Endpoints, fieldManager string, subresource string) (*EndpointsApplyConfiguration, error) {
 	b := &EndpointsApplyConfiguration{}
-	err := managedfields.ExtractInto(endpoints, internal.Parser().Type("io.k8s.api.core.v1.Endpoints"), fieldManager, b)
+	err := managedfields.ExtractInto(endpoints, internal.Parser().Type("io.k8s.api.core.v1.Endpoints"), fieldManager, b, subresource)
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/event.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/event.go
@@ -71,8 +71,19 @@ func Event(name, namespace string) *EventApplyConfiguration {
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
 func ExtractEvent(event *apicorev1.Event, fieldManager string) (*EventApplyConfiguration, error) {
+	return extractEvent(event, fieldManager, "")
+}
+
+// ExtractEventStatus is the same as ExtractEvent except
+// that it extracts the status subresource applied configuration.
+// Experimental!
+func ExtractEventStatus(event *apicorev1.Event, fieldManager string) (*EventApplyConfiguration, error) {
+	return extractEvent(event, fieldManager, "status")
+}
+
+func extractEvent(event *apicorev1.Event, fieldManager string, subresource string) (*EventApplyConfiguration, error) {
 	b := &EventApplyConfiguration{}
-	err := managedfields.ExtractInto(event, internal.Parser().Type("io.k8s.api.core.v1.Event"), fieldManager, b)
+	err := managedfields.ExtractInto(event, internal.Parser().Type("io.k8s.api.core.v1.Event"), fieldManager, b, subresource)
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/limitrange.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/limitrange.go
@@ -58,8 +58,19 @@ func LimitRange(name, namespace string) *LimitRangeApplyConfiguration {
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
 func ExtractLimitRange(limitRange *apicorev1.LimitRange, fieldManager string) (*LimitRangeApplyConfiguration, error) {
+	return extractLimitRange(limitRange, fieldManager, "")
+}
+
+// ExtractLimitRangeStatus is the same as ExtractLimitRange except
+// that it extracts the status subresource applied configuration.
+// Experimental!
+func ExtractLimitRangeStatus(limitRange *apicorev1.LimitRange, fieldManager string) (*LimitRangeApplyConfiguration, error) {
+	return extractLimitRange(limitRange, fieldManager, "status")
+}
+
+func extractLimitRange(limitRange *apicorev1.LimitRange, fieldManager string, subresource string) (*LimitRangeApplyConfiguration, error) {
 	b := &LimitRangeApplyConfiguration{}
-	err := managedfields.ExtractInto(limitRange, internal.Parser().Type("io.k8s.api.core.v1.LimitRange"), fieldManager, b)
+	err := managedfields.ExtractInto(limitRange, internal.Parser().Type("io.k8s.api.core.v1.LimitRange"), fieldManager, b, subresource)
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/namespace.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/namespace.go
@@ -58,8 +58,19 @@ func Namespace(name string) *NamespaceApplyConfiguration {
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
 func ExtractNamespace(namespace *apicorev1.Namespace, fieldManager string) (*NamespaceApplyConfiguration, error) {
+	return extractNamespace(namespace, fieldManager, "")
+}
+
+// ExtractNamespaceStatus is the same as ExtractNamespace except
+// that it extracts the status subresource applied configuration.
+// Experimental!
+func ExtractNamespaceStatus(namespace *apicorev1.Namespace, fieldManager string) (*NamespaceApplyConfiguration, error) {
+	return extractNamespace(namespace, fieldManager, "status")
+}
+
+func extractNamespace(namespace *apicorev1.Namespace, fieldManager string, subresource string) (*NamespaceApplyConfiguration, error) {
 	b := &NamespaceApplyConfiguration{}
-	err := managedfields.ExtractInto(namespace, internal.Parser().Type("io.k8s.api.core.v1.Namespace"), fieldManager, b)
+	err := managedfields.ExtractInto(namespace, internal.Parser().Type("io.k8s.api.core.v1.Namespace"), fieldManager, b, subresource)
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/node.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/node.go
@@ -58,8 +58,19 @@ func Node(name string) *NodeApplyConfiguration {
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
 func ExtractNode(node *apicorev1.Node, fieldManager string) (*NodeApplyConfiguration, error) {
+	return extractNode(node, fieldManager, "")
+}
+
+// ExtractNodeStatus is the same as ExtractNode except
+// that it extracts the status subresource applied configuration.
+// Experimental!
+func ExtractNodeStatus(node *apicorev1.Node, fieldManager string) (*NodeApplyConfiguration, error) {
+	return extractNode(node, fieldManager, "status")
+}
+
+func extractNode(node *apicorev1.Node, fieldManager string, subresource string) (*NodeApplyConfiguration, error) {
 	b := &NodeApplyConfiguration{}
-	err := managedfields.ExtractInto(node, internal.Parser().Type("io.k8s.api.core.v1.Node"), fieldManager, b)
+	err := managedfields.ExtractInto(node, internal.Parser().Type("io.k8s.api.core.v1.Node"), fieldManager, b, subresource)
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/persistentvolume.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/persistentvolume.go
@@ -58,8 +58,19 @@ func PersistentVolume(name string) *PersistentVolumeApplyConfiguration {
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
 func ExtractPersistentVolume(persistentVolume *apicorev1.PersistentVolume, fieldManager string) (*PersistentVolumeApplyConfiguration, error) {
+	return extractPersistentVolume(persistentVolume, fieldManager, "")
+}
+
+// ExtractPersistentVolumeStatus is the same as ExtractPersistentVolume except
+// that it extracts the status subresource applied configuration.
+// Experimental!
+func ExtractPersistentVolumeStatus(persistentVolume *apicorev1.PersistentVolume, fieldManager string) (*PersistentVolumeApplyConfiguration, error) {
+	return extractPersistentVolume(persistentVolume, fieldManager, "status")
+}
+
+func extractPersistentVolume(persistentVolume *apicorev1.PersistentVolume, fieldManager string, subresource string) (*PersistentVolumeApplyConfiguration, error) {
 	b := &PersistentVolumeApplyConfiguration{}
-	err := managedfields.ExtractInto(persistentVolume, internal.Parser().Type("io.k8s.api.core.v1.PersistentVolume"), fieldManager, b)
+	err := managedfields.ExtractInto(persistentVolume, internal.Parser().Type("io.k8s.api.core.v1.PersistentVolume"), fieldManager, b, subresource)
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/persistentvolumeclaim.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/persistentvolumeclaim.go
@@ -59,8 +59,19 @@ func PersistentVolumeClaim(name, namespace string) *PersistentVolumeClaimApplyCo
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
 func ExtractPersistentVolumeClaim(persistentVolumeClaim *apicorev1.PersistentVolumeClaim, fieldManager string) (*PersistentVolumeClaimApplyConfiguration, error) {
+	return extractPersistentVolumeClaim(persistentVolumeClaim, fieldManager, "")
+}
+
+// ExtractPersistentVolumeClaimStatus is the same as ExtractPersistentVolumeClaim except
+// that it extracts the status subresource applied configuration.
+// Experimental!
+func ExtractPersistentVolumeClaimStatus(persistentVolumeClaim *apicorev1.PersistentVolumeClaim, fieldManager string) (*PersistentVolumeClaimApplyConfiguration, error) {
+	return extractPersistentVolumeClaim(persistentVolumeClaim, fieldManager, "status")
+}
+
+func extractPersistentVolumeClaim(persistentVolumeClaim *apicorev1.PersistentVolumeClaim, fieldManager string, subresource string) (*PersistentVolumeClaimApplyConfiguration, error) {
 	b := &PersistentVolumeClaimApplyConfiguration{}
-	err := managedfields.ExtractInto(persistentVolumeClaim, internal.Parser().Type("io.k8s.api.core.v1.PersistentVolumeClaim"), fieldManager, b)
+	err := managedfields.ExtractInto(persistentVolumeClaim, internal.Parser().Type("io.k8s.api.core.v1.PersistentVolumeClaim"), fieldManager, b, subresource)
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/pod.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/pod.go
@@ -59,8 +59,19 @@ func Pod(name, namespace string) *PodApplyConfiguration {
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
 func ExtractPod(pod *apicorev1.Pod, fieldManager string) (*PodApplyConfiguration, error) {
+	return extractPod(pod, fieldManager, "")
+}
+
+// ExtractPodStatus is the same as ExtractPod except
+// that it extracts the status subresource applied configuration.
+// Experimental!
+func ExtractPodStatus(pod *apicorev1.Pod, fieldManager string) (*PodApplyConfiguration, error) {
+	return extractPod(pod, fieldManager, "status")
+}
+
+func extractPod(pod *apicorev1.Pod, fieldManager string, subresource string) (*PodApplyConfiguration, error) {
 	b := &PodApplyConfiguration{}
-	err := managedfields.ExtractInto(pod, internal.Parser().Type("io.k8s.api.core.v1.Pod"), fieldManager, b)
+	err := managedfields.ExtractInto(pod, internal.Parser().Type("io.k8s.api.core.v1.Pod"), fieldManager, b, subresource)
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/podtemplate.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/podtemplate.go
@@ -58,8 +58,19 @@ func PodTemplate(name, namespace string) *PodTemplateApplyConfiguration {
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
 func ExtractPodTemplate(podTemplate *apicorev1.PodTemplate, fieldManager string) (*PodTemplateApplyConfiguration, error) {
+	return extractPodTemplate(podTemplate, fieldManager, "")
+}
+
+// ExtractPodTemplateStatus is the same as ExtractPodTemplate except
+// that it extracts the status subresource applied configuration.
+// Experimental!
+func ExtractPodTemplateStatus(podTemplate *apicorev1.PodTemplate, fieldManager string) (*PodTemplateApplyConfiguration, error) {
+	return extractPodTemplate(podTemplate, fieldManager, "status")
+}
+
+func extractPodTemplate(podTemplate *apicorev1.PodTemplate, fieldManager string, subresource string) (*PodTemplateApplyConfiguration, error) {
 	b := &PodTemplateApplyConfiguration{}
-	err := managedfields.ExtractInto(podTemplate, internal.Parser().Type("io.k8s.api.core.v1.PodTemplate"), fieldManager, b)
+	err := managedfields.ExtractInto(podTemplate, internal.Parser().Type("io.k8s.api.core.v1.PodTemplate"), fieldManager, b, subresource)
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/replicationcontroller.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/replicationcontroller.go
@@ -59,8 +59,19 @@ func ReplicationController(name, namespace string) *ReplicationControllerApplyCo
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
 func ExtractReplicationController(replicationController *apicorev1.ReplicationController, fieldManager string) (*ReplicationControllerApplyConfiguration, error) {
+	return extractReplicationController(replicationController, fieldManager, "")
+}
+
+// ExtractReplicationControllerStatus is the same as ExtractReplicationController except
+// that it extracts the status subresource applied configuration.
+// Experimental!
+func ExtractReplicationControllerStatus(replicationController *apicorev1.ReplicationController, fieldManager string) (*ReplicationControllerApplyConfiguration, error) {
+	return extractReplicationController(replicationController, fieldManager, "status")
+}
+
+func extractReplicationController(replicationController *apicorev1.ReplicationController, fieldManager string, subresource string) (*ReplicationControllerApplyConfiguration, error) {
 	b := &ReplicationControllerApplyConfiguration{}
-	err := managedfields.ExtractInto(replicationController, internal.Parser().Type("io.k8s.api.core.v1.ReplicationController"), fieldManager, b)
+	err := managedfields.ExtractInto(replicationController, internal.Parser().Type("io.k8s.api.core.v1.ReplicationController"), fieldManager, b, subresource)
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/resourcequota.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/resourcequota.go
@@ -59,8 +59,19 @@ func ResourceQuota(name, namespace string) *ResourceQuotaApplyConfiguration {
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
 func ExtractResourceQuota(resourceQuota *apicorev1.ResourceQuota, fieldManager string) (*ResourceQuotaApplyConfiguration, error) {
+	return extractResourceQuota(resourceQuota, fieldManager, "")
+}
+
+// ExtractResourceQuotaStatus is the same as ExtractResourceQuota except
+// that it extracts the status subresource applied configuration.
+// Experimental!
+func ExtractResourceQuotaStatus(resourceQuota *apicorev1.ResourceQuota, fieldManager string) (*ResourceQuotaApplyConfiguration, error) {
+	return extractResourceQuota(resourceQuota, fieldManager, "status")
+}
+
+func extractResourceQuota(resourceQuota *apicorev1.ResourceQuota, fieldManager string, subresource string) (*ResourceQuotaApplyConfiguration, error) {
 	b := &ResourceQuotaApplyConfiguration{}
-	err := managedfields.ExtractInto(resourceQuota, internal.Parser().Type("io.k8s.api.core.v1.ResourceQuota"), fieldManager, b)
+	err := managedfields.ExtractInto(resourceQuota, internal.Parser().Type("io.k8s.api.core.v1.ResourceQuota"), fieldManager, b, subresource)
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/secret.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/secret.go
@@ -61,8 +61,19 @@ func Secret(name, namespace string) *SecretApplyConfiguration {
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
 func ExtractSecret(secret *corev1.Secret, fieldManager string) (*SecretApplyConfiguration, error) {
+	return extractSecret(secret, fieldManager, "")
+}
+
+// ExtractSecretStatus is the same as ExtractSecret except
+// that it extracts the status subresource applied configuration.
+// Experimental!
+func ExtractSecretStatus(secret *corev1.Secret, fieldManager string) (*SecretApplyConfiguration, error) {
+	return extractSecret(secret, fieldManager, "status")
+}
+
+func extractSecret(secret *corev1.Secret, fieldManager string, subresource string) (*SecretApplyConfiguration, error) {
 	b := &SecretApplyConfiguration{}
-	err := managedfields.ExtractInto(secret, internal.Parser().Type("io.k8s.api.core.v1.Secret"), fieldManager, b)
+	err := managedfields.ExtractInto(secret, internal.Parser().Type("io.k8s.api.core.v1.Secret"), fieldManager, b, subresource)
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/service.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/service.go
@@ -59,8 +59,19 @@ func Service(name, namespace string) *ServiceApplyConfiguration {
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
 func ExtractService(service *apicorev1.Service, fieldManager string) (*ServiceApplyConfiguration, error) {
+	return extractService(service, fieldManager, "")
+}
+
+// ExtractServiceStatus is the same as ExtractService except
+// that it extracts the status subresource applied configuration.
+// Experimental!
+func ExtractServiceStatus(service *apicorev1.Service, fieldManager string) (*ServiceApplyConfiguration, error) {
+	return extractService(service, fieldManager, "status")
+}
+
+func extractService(service *apicorev1.Service, fieldManager string, subresource string) (*ServiceApplyConfiguration, error) {
 	b := &ServiceApplyConfiguration{}
-	err := managedfields.ExtractInto(service, internal.Parser().Type("io.k8s.api.core.v1.Service"), fieldManager, b)
+	err := managedfields.ExtractInto(service, internal.Parser().Type("io.k8s.api.core.v1.Service"), fieldManager, b, subresource)
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/serviceaccount.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/serviceaccount.go
@@ -60,8 +60,19 @@ func ServiceAccount(name, namespace string) *ServiceAccountApplyConfiguration {
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
 func ExtractServiceAccount(serviceAccount *apicorev1.ServiceAccount, fieldManager string) (*ServiceAccountApplyConfiguration, error) {
+	return extractServiceAccount(serviceAccount, fieldManager, "")
+}
+
+// ExtractServiceAccountStatus is the same as ExtractServiceAccount except
+// that it extracts the status subresource applied configuration.
+// Experimental!
+func ExtractServiceAccountStatus(serviceAccount *apicorev1.ServiceAccount, fieldManager string) (*ServiceAccountApplyConfiguration, error) {
+	return extractServiceAccount(serviceAccount, fieldManager, "status")
+}
+
+func extractServiceAccount(serviceAccount *apicorev1.ServiceAccount, fieldManager string, subresource string) (*ServiceAccountApplyConfiguration, error) {
 	b := &ServiceAccountApplyConfiguration{}
-	err := managedfields.ExtractInto(serviceAccount, internal.Parser().Type("io.k8s.api.core.v1.ServiceAccount"), fieldManager, b)
+	err := managedfields.ExtractInto(serviceAccount, internal.Parser().Type("io.k8s.api.core.v1.ServiceAccount"), fieldManager, b, subresource)
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/discovery/v1/endpointslice.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/discovery/v1/endpointslice.go
@@ -60,8 +60,19 @@ func EndpointSlice(name, namespace string) *EndpointSliceApplyConfiguration {
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
 func ExtractEndpointSlice(endpointSlice *discoveryv1.EndpointSlice, fieldManager string) (*EndpointSliceApplyConfiguration, error) {
+	return extractEndpointSlice(endpointSlice, fieldManager, "")
+}
+
+// ExtractEndpointSliceStatus is the same as ExtractEndpointSlice except
+// that it extracts the status subresource applied configuration.
+// Experimental!
+func ExtractEndpointSliceStatus(endpointSlice *discoveryv1.EndpointSlice, fieldManager string) (*EndpointSliceApplyConfiguration, error) {
+	return extractEndpointSlice(endpointSlice, fieldManager, "status")
+}
+
+func extractEndpointSlice(endpointSlice *discoveryv1.EndpointSlice, fieldManager string, subresource string) (*EndpointSliceApplyConfiguration, error) {
 	b := &EndpointSliceApplyConfiguration{}
-	err := managedfields.ExtractInto(endpointSlice, internal.Parser().Type("io.k8s.api.discovery.v1.EndpointSlice"), fieldManager, b)
+	err := managedfields.ExtractInto(endpointSlice, internal.Parser().Type("io.k8s.api.discovery.v1.EndpointSlice"), fieldManager, b, subresource)
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/discovery/v1beta1/endpointslice.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/discovery/v1beta1/endpointslice.go
@@ -60,8 +60,19 @@ func EndpointSlice(name, namespace string) *EndpointSliceApplyConfiguration {
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
 func ExtractEndpointSlice(endpointSlice *v1beta1.EndpointSlice, fieldManager string) (*EndpointSliceApplyConfiguration, error) {
+	return extractEndpointSlice(endpointSlice, fieldManager, "")
+}
+
+// ExtractEndpointSliceStatus is the same as ExtractEndpointSlice except
+// that it extracts the status subresource applied configuration.
+// Experimental!
+func ExtractEndpointSliceStatus(endpointSlice *v1beta1.EndpointSlice, fieldManager string) (*EndpointSliceApplyConfiguration, error) {
+	return extractEndpointSlice(endpointSlice, fieldManager, "status")
+}
+
+func extractEndpointSlice(endpointSlice *v1beta1.EndpointSlice, fieldManager string, subresource string) (*EndpointSliceApplyConfiguration, error) {
 	b := &EndpointSliceApplyConfiguration{}
-	err := managedfields.ExtractInto(endpointSlice, internal.Parser().Type("io.k8s.api.discovery.v1beta1.EndpointSlice"), fieldManager, b)
+	err := managedfields.ExtractInto(endpointSlice, internal.Parser().Type("io.k8s.api.discovery.v1beta1.EndpointSlice"), fieldManager, b, subresource)
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/events/v1/event.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/events/v1/event.go
@@ -72,8 +72,19 @@ func Event(name, namespace string) *EventApplyConfiguration {
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
 func ExtractEvent(event *apieventsv1.Event, fieldManager string) (*EventApplyConfiguration, error) {
+	return extractEvent(event, fieldManager, "")
+}
+
+// ExtractEventStatus is the same as ExtractEvent except
+// that it extracts the status subresource applied configuration.
+// Experimental!
+func ExtractEventStatus(event *apieventsv1.Event, fieldManager string) (*EventApplyConfiguration, error) {
+	return extractEvent(event, fieldManager, "status")
+}
+
+func extractEvent(event *apieventsv1.Event, fieldManager string, subresource string) (*EventApplyConfiguration, error) {
 	b := &EventApplyConfiguration{}
-	err := managedfields.ExtractInto(event, internal.Parser().Type("io.k8s.api.events.v1.Event"), fieldManager, b)
+	err := managedfields.ExtractInto(event, internal.Parser().Type("io.k8s.api.events.v1.Event"), fieldManager, b, subresource)
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/events/v1beta1/event.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/events/v1beta1/event.go
@@ -72,8 +72,19 @@ func Event(name, namespace string) *EventApplyConfiguration {
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
 func ExtractEvent(event *eventsv1beta1.Event, fieldManager string) (*EventApplyConfiguration, error) {
+	return extractEvent(event, fieldManager, "")
+}
+
+// ExtractEventStatus is the same as ExtractEvent except
+// that it extracts the status subresource applied configuration.
+// Experimental!
+func ExtractEventStatus(event *eventsv1beta1.Event, fieldManager string) (*EventApplyConfiguration, error) {
+	return extractEvent(event, fieldManager, "status")
+}
+
+func extractEvent(event *eventsv1beta1.Event, fieldManager string, subresource string) (*EventApplyConfiguration, error) {
 	b := &EventApplyConfiguration{}
-	err := managedfields.ExtractInto(event, internal.Parser().Type("io.k8s.api.events.v1beta1.Event"), fieldManager, b)
+	err := managedfields.ExtractInto(event, internal.Parser().Type("io.k8s.api.events.v1beta1.Event"), fieldManager, b, subresource)
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/extensions/v1beta1/daemonset.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/extensions/v1beta1/daemonset.go
@@ -59,8 +59,19 @@ func DaemonSet(name, namespace string) *DaemonSetApplyConfiguration {
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
 func ExtractDaemonSet(daemonSet *extensionsv1beta1.DaemonSet, fieldManager string) (*DaemonSetApplyConfiguration, error) {
+	return extractDaemonSet(daemonSet, fieldManager, "")
+}
+
+// ExtractDaemonSetStatus is the same as ExtractDaemonSet except
+// that it extracts the status subresource applied configuration.
+// Experimental!
+func ExtractDaemonSetStatus(daemonSet *extensionsv1beta1.DaemonSet, fieldManager string) (*DaemonSetApplyConfiguration, error) {
+	return extractDaemonSet(daemonSet, fieldManager, "status")
+}
+
+func extractDaemonSet(daemonSet *extensionsv1beta1.DaemonSet, fieldManager string, subresource string) (*DaemonSetApplyConfiguration, error) {
 	b := &DaemonSetApplyConfiguration{}
-	err := managedfields.ExtractInto(daemonSet, internal.Parser().Type("io.k8s.api.extensions.v1beta1.DaemonSet"), fieldManager, b)
+	err := managedfields.ExtractInto(daemonSet, internal.Parser().Type("io.k8s.api.extensions.v1beta1.DaemonSet"), fieldManager, b, subresource)
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/extensions/v1beta1/deployment.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/extensions/v1beta1/deployment.go
@@ -59,8 +59,19 @@ func Deployment(name, namespace string) *DeploymentApplyConfiguration {
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
 func ExtractDeployment(deployment *extensionsv1beta1.Deployment, fieldManager string) (*DeploymentApplyConfiguration, error) {
+	return extractDeployment(deployment, fieldManager, "")
+}
+
+// ExtractDeploymentStatus is the same as ExtractDeployment except
+// that it extracts the status subresource applied configuration.
+// Experimental!
+func ExtractDeploymentStatus(deployment *extensionsv1beta1.Deployment, fieldManager string) (*DeploymentApplyConfiguration, error) {
+	return extractDeployment(deployment, fieldManager, "status")
+}
+
+func extractDeployment(deployment *extensionsv1beta1.Deployment, fieldManager string, subresource string) (*DeploymentApplyConfiguration, error) {
 	b := &DeploymentApplyConfiguration{}
-	err := managedfields.ExtractInto(deployment, internal.Parser().Type("io.k8s.api.extensions.v1beta1.Deployment"), fieldManager, b)
+	err := managedfields.ExtractInto(deployment, internal.Parser().Type("io.k8s.api.extensions.v1beta1.Deployment"), fieldManager, b, subresource)
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/extensions/v1beta1/ingress.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/extensions/v1beta1/ingress.go
@@ -59,8 +59,19 @@ func Ingress(name, namespace string) *IngressApplyConfiguration {
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
 func ExtractIngress(ingress *extensionsv1beta1.Ingress, fieldManager string) (*IngressApplyConfiguration, error) {
+	return extractIngress(ingress, fieldManager, "")
+}
+
+// ExtractIngressStatus is the same as ExtractIngress except
+// that it extracts the status subresource applied configuration.
+// Experimental!
+func ExtractIngressStatus(ingress *extensionsv1beta1.Ingress, fieldManager string) (*IngressApplyConfiguration, error) {
+	return extractIngress(ingress, fieldManager, "status")
+}
+
+func extractIngress(ingress *extensionsv1beta1.Ingress, fieldManager string, subresource string) (*IngressApplyConfiguration, error) {
 	b := &IngressApplyConfiguration{}
-	err := managedfields.ExtractInto(ingress, internal.Parser().Type("io.k8s.api.extensions.v1beta1.Ingress"), fieldManager, b)
+	err := managedfields.ExtractInto(ingress, internal.Parser().Type("io.k8s.api.extensions.v1beta1.Ingress"), fieldManager, b, subresource)
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/extensions/v1beta1/networkpolicy.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/extensions/v1beta1/networkpolicy.go
@@ -58,8 +58,19 @@ func NetworkPolicy(name, namespace string) *NetworkPolicyApplyConfiguration {
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
 func ExtractNetworkPolicy(networkPolicy *extensionsv1beta1.NetworkPolicy, fieldManager string) (*NetworkPolicyApplyConfiguration, error) {
+	return extractNetworkPolicy(networkPolicy, fieldManager, "")
+}
+
+// ExtractNetworkPolicyStatus is the same as ExtractNetworkPolicy except
+// that it extracts the status subresource applied configuration.
+// Experimental!
+func ExtractNetworkPolicyStatus(networkPolicy *extensionsv1beta1.NetworkPolicy, fieldManager string) (*NetworkPolicyApplyConfiguration, error) {
+	return extractNetworkPolicy(networkPolicy, fieldManager, "status")
+}
+
+func extractNetworkPolicy(networkPolicy *extensionsv1beta1.NetworkPolicy, fieldManager string, subresource string) (*NetworkPolicyApplyConfiguration, error) {
 	b := &NetworkPolicyApplyConfiguration{}
-	err := managedfields.ExtractInto(networkPolicy, internal.Parser().Type("io.k8s.api.extensions.v1beta1.NetworkPolicy"), fieldManager, b)
+	err := managedfields.ExtractInto(networkPolicy, internal.Parser().Type("io.k8s.api.extensions.v1beta1.NetworkPolicy"), fieldManager, b, subresource)
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/extensions/v1beta1/podsecuritypolicy.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/extensions/v1beta1/podsecuritypolicy.go
@@ -57,8 +57,19 @@ func PodSecurityPolicy(name string) *PodSecurityPolicyApplyConfiguration {
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
 func ExtractPodSecurityPolicy(podSecurityPolicy *extensionsv1beta1.PodSecurityPolicy, fieldManager string) (*PodSecurityPolicyApplyConfiguration, error) {
+	return extractPodSecurityPolicy(podSecurityPolicy, fieldManager, "")
+}
+
+// ExtractPodSecurityPolicyStatus is the same as ExtractPodSecurityPolicy except
+// that it extracts the status subresource applied configuration.
+// Experimental!
+func ExtractPodSecurityPolicyStatus(podSecurityPolicy *extensionsv1beta1.PodSecurityPolicy, fieldManager string) (*PodSecurityPolicyApplyConfiguration, error) {
+	return extractPodSecurityPolicy(podSecurityPolicy, fieldManager, "status")
+}
+
+func extractPodSecurityPolicy(podSecurityPolicy *extensionsv1beta1.PodSecurityPolicy, fieldManager string, subresource string) (*PodSecurityPolicyApplyConfiguration, error) {
 	b := &PodSecurityPolicyApplyConfiguration{}
-	err := managedfields.ExtractInto(podSecurityPolicy, internal.Parser().Type("io.k8s.api.extensions.v1beta1.PodSecurityPolicy"), fieldManager, b)
+	err := managedfields.ExtractInto(podSecurityPolicy, internal.Parser().Type("io.k8s.api.extensions.v1beta1.PodSecurityPolicy"), fieldManager, b, subresource)
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/extensions/v1beta1/replicaset.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/extensions/v1beta1/replicaset.go
@@ -59,8 +59,19 @@ func ReplicaSet(name, namespace string) *ReplicaSetApplyConfiguration {
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
 func ExtractReplicaSet(replicaSet *extensionsv1beta1.ReplicaSet, fieldManager string) (*ReplicaSetApplyConfiguration, error) {
+	return extractReplicaSet(replicaSet, fieldManager, "")
+}
+
+// ExtractReplicaSetStatus is the same as ExtractReplicaSet except
+// that it extracts the status subresource applied configuration.
+// Experimental!
+func ExtractReplicaSetStatus(replicaSet *extensionsv1beta1.ReplicaSet, fieldManager string) (*ReplicaSetApplyConfiguration, error) {
+	return extractReplicaSet(replicaSet, fieldManager, "status")
+}
+
+func extractReplicaSet(replicaSet *extensionsv1beta1.ReplicaSet, fieldManager string, subresource string) (*ReplicaSetApplyConfiguration, error) {
 	b := &ReplicaSetApplyConfiguration{}
-	err := managedfields.ExtractInto(replicaSet, internal.Parser().Type("io.k8s.api.extensions.v1beta1.ReplicaSet"), fieldManager, b)
+	err := managedfields.ExtractInto(replicaSet, internal.Parser().Type("io.k8s.api.extensions.v1beta1.ReplicaSet"), fieldManager, b, subresource)
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1alpha1/flowschema.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1alpha1/flowschema.go
@@ -58,8 +58,19 @@ func FlowSchema(name string) *FlowSchemaApplyConfiguration {
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
 func ExtractFlowSchema(flowSchema *flowcontrolv1alpha1.FlowSchema, fieldManager string) (*FlowSchemaApplyConfiguration, error) {
+	return extractFlowSchema(flowSchema, fieldManager, "")
+}
+
+// ExtractFlowSchemaStatus is the same as ExtractFlowSchema except
+// that it extracts the status subresource applied configuration.
+// Experimental!
+func ExtractFlowSchemaStatus(flowSchema *flowcontrolv1alpha1.FlowSchema, fieldManager string) (*FlowSchemaApplyConfiguration, error) {
+	return extractFlowSchema(flowSchema, fieldManager, "status")
+}
+
+func extractFlowSchema(flowSchema *flowcontrolv1alpha1.FlowSchema, fieldManager string, subresource string) (*FlowSchemaApplyConfiguration, error) {
 	b := &FlowSchemaApplyConfiguration{}
-	err := managedfields.ExtractInto(flowSchema, internal.Parser().Type("io.k8s.api.flowcontrol.v1alpha1.FlowSchema"), fieldManager, b)
+	err := managedfields.ExtractInto(flowSchema, internal.Parser().Type("io.k8s.api.flowcontrol.v1alpha1.FlowSchema"), fieldManager, b, subresource)
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1alpha1/prioritylevelconfiguration.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1alpha1/prioritylevelconfiguration.go
@@ -58,8 +58,19 @@ func PriorityLevelConfiguration(name string) *PriorityLevelConfigurationApplyCon
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
 func ExtractPriorityLevelConfiguration(priorityLevelConfiguration *flowcontrolv1alpha1.PriorityLevelConfiguration, fieldManager string) (*PriorityLevelConfigurationApplyConfiguration, error) {
+	return extractPriorityLevelConfiguration(priorityLevelConfiguration, fieldManager, "")
+}
+
+// ExtractPriorityLevelConfigurationStatus is the same as ExtractPriorityLevelConfiguration except
+// that it extracts the status subresource applied configuration.
+// Experimental!
+func ExtractPriorityLevelConfigurationStatus(priorityLevelConfiguration *flowcontrolv1alpha1.PriorityLevelConfiguration, fieldManager string) (*PriorityLevelConfigurationApplyConfiguration, error) {
+	return extractPriorityLevelConfiguration(priorityLevelConfiguration, fieldManager, "status")
+}
+
+func extractPriorityLevelConfiguration(priorityLevelConfiguration *flowcontrolv1alpha1.PriorityLevelConfiguration, fieldManager string, subresource string) (*PriorityLevelConfigurationApplyConfiguration, error) {
 	b := &PriorityLevelConfigurationApplyConfiguration{}
-	err := managedfields.ExtractInto(priorityLevelConfiguration, internal.Parser().Type("io.k8s.api.flowcontrol.v1alpha1.PriorityLevelConfiguration"), fieldManager, b)
+	err := managedfields.ExtractInto(priorityLevelConfiguration, internal.Parser().Type("io.k8s.api.flowcontrol.v1alpha1.PriorityLevelConfiguration"), fieldManager, b, subresource)
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1beta1/flowschema.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1beta1/flowschema.go
@@ -58,8 +58,19 @@ func FlowSchema(name string) *FlowSchemaApplyConfiguration {
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
 func ExtractFlowSchema(flowSchema *flowcontrolv1beta1.FlowSchema, fieldManager string) (*FlowSchemaApplyConfiguration, error) {
+	return extractFlowSchema(flowSchema, fieldManager, "")
+}
+
+// ExtractFlowSchemaStatus is the same as ExtractFlowSchema except
+// that it extracts the status subresource applied configuration.
+// Experimental!
+func ExtractFlowSchemaStatus(flowSchema *flowcontrolv1beta1.FlowSchema, fieldManager string) (*FlowSchemaApplyConfiguration, error) {
+	return extractFlowSchema(flowSchema, fieldManager, "status")
+}
+
+func extractFlowSchema(flowSchema *flowcontrolv1beta1.FlowSchema, fieldManager string, subresource string) (*FlowSchemaApplyConfiguration, error) {
 	b := &FlowSchemaApplyConfiguration{}
-	err := managedfields.ExtractInto(flowSchema, internal.Parser().Type("io.k8s.api.flowcontrol.v1beta1.FlowSchema"), fieldManager, b)
+	err := managedfields.ExtractInto(flowSchema, internal.Parser().Type("io.k8s.api.flowcontrol.v1beta1.FlowSchema"), fieldManager, b, subresource)
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1beta1/prioritylevelconfiguration.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1beta1/prioritylevelconfiguration.go
@@ -58,8 +58,19 @@ func PriorityLevelConfiguration(name string) *PriorityLevelConfigurationApplyCon
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
 func ExtractPriorityLevelConfiguration(priorityLevelConfiguration *flowcontrolv1beta1.PriorityLevelConfiguration, fieldManager string) (*PriorityLevelConfigurationApplyConfiguration, error) {
+	return extractPriorityLevelConfiguration(priorityLevelConfiguration, fieldManager, "")
+}
+
+// ExtractPriorityLevelConfigurationStatus is the same as ExtractPriorityLevelConfiguration except
+// that it extracts the status subresource applied configuration.
+// Experimental!
+func ExtractPriorityLevelConfigurationStatus(priorityLevelConfiguration *flowcontrolv1beta1.PriorityLevelConfiguration, fieldManager string) (*PriorityLevelConfigurationApplyConfiguration, error) {
+	return extractPriorityLevelConfiguration(priorityLevelConfiguration, fieldManager, "status")
+}
+
+func extractPriorityLevelConfiguration(priorityLevelConfiguration *flowcontrolv1beta1.PriorityLevelConfiguration, fieldManager string, subresource string) (*PriorityLevelConfigurationApplyConfiguration, error) {
 	b := &PriorityLevelConfigurationApplyConfiguration{}
-	err := managedfields.ExtractInto(priorityLevelConfiguration, internal.Parser().Type("io.k8s.api.flowcontrol.v1beta1.PriorityLevelConfiguration"), fieldManager, b)
+	err := managedfields.ExtractInto(priorityLevelConfiguration, internal.Parser().Type("io.k8s.api.flowcontrol.v1beta1.PriorityLevelConfiguration"), fieldManager, b, subresource)
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/imagepolicy/v1alpha1/imagereview.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/imagepolicy/v1alpha1/imagereview.go
@@ -58,8 +58,19 @@ func ImageReview(name string) *ImageReviewApplyConfiguration {
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
 func ExtractImageReview(imageReview *imagepolicyv1alpha1.ImageReview, fieldManager string) (*ImageReviewApplyConfiguration, error) {
+	return extractImageReview(imageReview, fieldManager, "")
+}
+
+// ExtractImageReviewStatus is the same as ExtractImageReview except
+// that it extracts the status subresource applied configuration.
+// Experimental!
+func ExtractImageReviewStatus(imageReview *imagepolicyv1alpha1.ImageReview, fieldManager string) (*ImageReviewApplyConfiguration, error) {
+	return extractImageReview(imageReview, fieldManager, "status")
+}
+
+func extractImageReview(imageReview *imagepolicyv1alpha1.ImageReview, fieldManager string, subresource string) (*ImageReviewApplyConfiguration, error) {
 	b := &ImageReviewApplyConfiguration{}
-	err := managedfields.ExtractInto(imageReview, internal.Parser().Type("io.k8s.api.imagepolicy.v1alpha1.ImageReview"), fieldManager, b)
+	err := managedfields.ExtractInto(imageReview, internal.Parser().Type("io.k8s.api.imagepolicy.v1alpha1.ImageReview"), fieldManager, b, subresource)
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/networking/v1/ingress.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/networking/v1/ingress.go
@@ -59,8 +59,19 @@ func Ingress(name, namespace string) *IngressApplyConfiguration {
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
 func ExtractIngress(ingress *apinetworkingv1.Ingress, fieldManager string) (*IngressApplyConfiguration, error) {
+	return extractIngress(ingress, fieldManager, "")
+}
+
+// ExtractIngressStatus is the same as ExtractIngress except
+// that it extracts the status subresource applied configuration.
+// Experimental!
+func ExtractIngressStatus(ingress *apinetworkingv1.Ingress, fieldManager string) (*IngressApplyConfiguration, error) {
+	return extractIngress(ingress, fieldManager, "status")
+}
+
+func extractIngress(ingress *apinetworkingv1.Ingress, fieldManager string, subresource string) (*IngressApplyConfiguration, error) {
 	b := &IngressApplyConfiguration{}
-	err := managedfields.ExtractInto(ingress, internal.Parser().Type("io.k8s.api.networking.v1.Ingress"), fieldManager, b)
+	err := managedfields.ExtractInto(ingress, internal.Parser().Type("io.k8s.api.networking.v1.Ingress"), fieldManager, b, subresource)
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/networking/v1/ingressclass.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/networking/v1/ingressclass.go
@@ -57,8 +57,19 @@ func IngressClass(name string) *IngressClassApplyConfiguration {
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
 func ExtractIngressClass(ingressClass *apinetworkingv1.IngressClass, fieldManager string) (*IngressClassApplyConfiguration, error) {
+	return extractIngressClass(ingressClass, fieldManager, "")
+}
+
+// ExtractIngressClassStatus is the same as ExtractIngressClass except
+// that it extracts the status subresource applied configuration.
+// Experimental!
+func ExtractIngressClassStatus(ingressClass *apinetworkingv1.IngressClass, fieldManager string) (*IngressClassApplyConfiguration, error) {
+	return extractIngressClass(ingressClass, fieldManager, "status")
+}
+
+func extractIngressClass(ingressClass *apinetworkingv1.IngressClass, fieldManager string, subresource string) (*IngressClassApplyConfiguration, error) {
 	b := &IngressClassApplyConfiguration{}
-	err := managedfields.ExtractInto(ingressClass, internal.Parser().Type("io.k8s.api.networking.v1.IngressClass"), fieldManager, b)
+	err := managedfields.ExtractInto(ingressClass, internal.Parser().Type("io.k8s.api.networking.v1.IngressClass"), fieldManager, b, subresource)
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/networking/v1/networkpolicy.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/networking/v1/networkpolicy.go
@@ -58,8 +58,19 @@ func NetworkPolicy(name, namespace string) *NetworkPolicyApplyConfiguration {
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
 func ExtractNetworkPolicy(networkPolicy *apinetworkingv1.NetworkPolicy, fieldManager string) (*NetworkPolicyApplyConfiguration, error) {
+	return extractNetworkPolicy(networkPolicy, fieldManager, "")
+}
+
+// ExtractNetworkPolicyStatus is the same as ExtractNetworkPolicy except
+// that it extracts the status subresource applied configuration.
+// Experimental!
+func ExtractNetworkPolicyStatus(networkPolicy *apinetworkingv1.NetworkPolicy, fieldManager string) (*NetworkPolicyApplyConfiguration, error) {
+	return extractNetworkPolicy(networkPolicy, fieldManager, "status")
+}
+
+func extractNetworkPolicy(networkPolicy *apinetworkingv1.NetworkPolicy, fieldManager string, subresource string) (*NetworkPolicyApplyConfiguration, error) {
 	b := &NetworkPolicyApplyConfiguration{}
-	err := managedfields.ExtractInto(networkPolicy, internal.Parser().Type("io.k8s.api.networking.v1.NetworkPolicy"), fieldManager, b)
+	err := managedfields.ExtractInto(networkPolicy, internal.Parser().Type("io.k8s.api.networking.v1.NetworkPolicy"), fieldManager, b, subresource)
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/networking/v1beta1/ingress.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/networking/v1beta1/ingress.go
@@ -59,8 +59,19 @@ func Ingress(name, namespace string) *IngressApplyConfiguration {
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
 func ExtractIngress(ingress *networkingv1beta1.Ingress, fieldManager string) (*IngressApplyConfiguration, error) {
+	return extractIngress(ingress, fieldManager, "")
+}
+
+// ExtractIngressStatus is the same as ExtractIngress except
+// that it extracts the status subresource applied configuration.
+// Experimental!
+func ExtractIngressStatus(ingress *networkingv1beta1.Ingress, fieldManager string) (*IngressApplyConfiguration, error) {
+	return extractIngress(ingress, fieldManager, "status")
+}
+
+func extractIngress(ingress *networkingv1beta1.Ingress, fieldManager string, subresource string) (*IngressApplyConfiguration, error) {
 	b := &IngressApplyConfiguration{}
-	err := managedfields.ExtractInto(ingress, internal.Parser().Type("io.k8s.api.networking.v1beta1.Ingress"), fieldManager, b)
+	err := managedfields.ExtractInto(ingress, internal.Parser().Type("io.k8s.api.networking.v1beta1.Ingress"), fieldManager, b, subresource)
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/networking/v1beta1/ingressclass.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/networking/v1beta1/ingressclass.go
@@ -57,8 +57,19 @@ func IngressClass(name string) *IngressClassApplyConfiguration {
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
 func ExtractIngressClass(ingressClass *networkingv1beta1.IngressClass, fieldManager string) (*IngressClassApplyConfiguration, error) {
+	return extractIngressClass(ingressClass, fieldManager, "")
+}
+
+// ExtractIngressClassStatus is the same as ExtractIngressClass except
+// that it extracts the status subresource applied configuration.
+// Experimental!
+func ExtractIngressClassStatus(ingressClass *networkingv1beta1.IngressClass, fieldManager string) (*IngressClassApplyConfiguration, error) {
+	return extractIngressClass(ingressClass, fieldManager, "status")
+}
+
+func extractIngressClass(ingressClass *networkingv1beta1.IngressClass, fieldManager string, subresource string) (*IngressClassApplyConfiguration, error) {
 	b := &IngressClassApplyConfiguration{}
-	err := managedfields.ExtractInto(ingressClass, internal.Parser().Type("io.k8s.api.networking.v1beta1.IngressClass"), fieldManager, b)
+	err := managedfields.ExtractInto(ingressClass, internal.Parser().Type("io.k8s.api.networking.v1beta1.IngressClass"), fieldManager, b, subresource)
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/node/v1/runtimeclass.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/node/v1/runtimeclass.go
@@ -59,8 +59,19 @@ func RuntimeClass(name string) *RuntimeClassApplyConfiguration {
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
 func ExtractRuntimeClass(runtimeClass *apinodev1.RuntimeClass, fieldManager string) (*RuntimeClassApplyConfiguration, error) {
+	return extractRuntimeClass(runtimeClass, fieldManager, "")
+}
+
+// ExtractRuntimeClassStatus is the same as ExtractRuntimeClass except
+// that it extracts the status subresource applied configuration.
+// Experimental!
+func ExtractRuntimeClassStatus(runtimeClass *apinodev1.RuntimeClass, fieldManager string) (*RuntimeClassApplyConfiguration, error) {
+	return extractRuntimeClass(runtimeClass, fieldManager, "status")
+}
+
+func extractRuntimeClass(runtimeClass *apinodev1.RuntimeClass, fieldManager string, subresource string) (*RuntimeClassApplyConfiguration, error) {
 	b := &RuntimeClassApplyConfiguration{}
-	err := managedfields.ExtractInto(runtimeClass, internal.Parser().Type("io.k8s.api.node.v1.RuntimeClass"), fieldManager, b)
+	err := managedfields.ExtractInto(runtimeClass, internal.Parser().Type("io.k8s.api.node.v1.RuntimeClass"), fieldManager, b, subresource)
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/node/v1alpha1/runtimeclass.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/node/v1alpha1/runtimeclass.go
@@ -57,8 +57,19 @@ func RuntimeClass(name string) *RuntimeClassApplyConfiguration {
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
 func ExtractRuntimeClass(runtimeClass *nodev1alpha1.RuntimeClass, fieldManager string) (*RuntimeClassApplyConfiguration, error) {
+	return extractRuntimeClass(runtimeClass, fieldManager, "")
+}
+
+// ExtractRuntimeClassStatus is the same as ExtractRuntimeClass except
+// that it extracts the status subresource applied configuration.
+// Experimental!
+func ExtractRuntimeClassStatus(runtimeClass *nodev1alpha1.RuntimeClass, fieldManager string) (*RuntimeClassApplyConfiguration, error) {
+	return extractRuntimeClass(runtimeClass, fieldManager, "status")
+}
+
+func extractRuntimeClass(runtimeClass *nodev1alpha1.RuntimeClass, fieldManager string, subresource string) (*RuntimeClassApplyConfiguration, error) {
 	b := &RuntimeClassApplyConfiguration{}
-	err := managedfields.ExtractInto(runtimeClass, internal.Parser().Type("io.k8s.api.node.v1alpha1.RuntimeClass"), fieldManager, b)
+	err := managedfields.ExtractInto(runtimeClass, internal.Parser().Type("io.k8s.api.node.v1alpha1.RuntimeClass"), fieldManager, b, subresource)
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/node/v1beta1/runtimeclass.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/node/v1beta1/runtimeclass.go
@@ -59,8 +59,19 @@ func RuntimeClass(name string) *RuntimeClassApplyConfiguration {
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
 func ExtractRuntimeClass(runtimeClass *nodev1beta1.RuntimeClass, fieldManager string) (*RuntimeClassApplyConfiguration, error) {
+	return extractRuntimeClass(runtimeClass, fieldManager, "")
+}
+
+// ExtractRuntimeClassStatus is the same as ExtractRuntimeClass except
+// that it extracts the status subresource applied configuration.
+// Experimental!
+func ExtractRuntimeClassStatus(runtimeClass *nodev1beta1.RuntimeClass, fieldManager string) (*RuntimeClassApplyConfiguration, error) {
+	return extractRuntimeClass(runtimeClass, fieldManager, "status")
+}
+
+func extractRuntimeClass(runtimeClass *nodev1beta1.RuntimeClass, fieldManager string, subresource string) (*RuntimeClassApplyConfiguration, error) {
 	b := &RuntimeClassApplyConfiguration{}
-	err := managedfields.ExtractInto(runtimeClass, internal.Parser().Type("io.k8s.api.node.v1beta1.RuntimeClass"), fieldManager, b)
+	err := managedfields.ExtractInto(runtimeClass, internal.Parser().Type("io.k8s.api.node.v1beta1.RuntimeClass"), fieldManager, b, subresource)
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/policy/v1/eviction.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/policy/v1/eviction.go
@@ -58,8 +58,19 @@ func Eviction(name, namespace string) *EvictionApplyConfiguration {
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
 func ExtractEviction(eviction *policyv1.Eviction, fieldManager string) (*EvictionApplyConfiguration, error) {
+	return extractEviction(eviction, fieldManager, "")
+}
+
+// ExtractEvictionStatus is the same as ExtractEviction except
+// that it extracts the status subresource applied configuration.
+// Experimental!
+func ExtractEvictionStatus(eviction *policyv1.Eviction, fieldManager string) (*EvictionApplyConfiguration, error) {
+	return extractEviction(eviction, fieldManager, "status")
+}
+
+func extractEviction(eviction *policyv1.Eviction, fieldManager string, subresource string) (*EvictionApplyConfiguration, error) {
 	b := &EvictionApplyConfiguration{}
-	err := managedfields.ExtractInto(eviction, internal.Parser().Type("io.k8s.api.policy.v1.Eviction"), fieldManager, b)
+	err := managedfields.ExtractInto(eviction, internal.Parser().Type("io.k8s.api.policy.v1.Eviction"), fieldManager, b, subresource)
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/policy/v1/poddisruptionbudget.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/policy/v1/poddisruptionbudget.go
@@ -59,8 +59,19 @@ func PodDisruptionBudget(name, namespace string) *PodDisruptionBudgetApplyConfig
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
 func ExtractPodDisruptionBudget(podDisruptionBudget *apipolicyv1.PodDisruptionBudget, fieldManager string) (*PodDisruptionBudgetApplyConfiguration, error) {
+	return extractPodDisruptionBudget(podDisruptionBudget, fieldManager, "")
+}
+
+// ExtractPodDisruptionBudgetStatus is the same as ExtractPodDisruptionBudget except
+// that it extracts the status subresource applied configuration.
+// Experimental!
+func ExtractPodDisruptionBudgetStatus(podDisruptionBudget *apipolicyv1.PodDisruptionBudget, fieldManager string) (*PodDisruptionBudgetApplyConfiguration, error) {
+	return extractPodDisruptionBudget(podDisruptionBudget, fieldManager, "status")
+}
+
+func extractPodDisruptionBudget(podDisruptionBudget *apipolicyv1.PodDisruptionBudget, fieldManager string, subresource string) (*PodDisruptionBudgetApplyConfiguration, error) {
 	b := &PodDisruptionBudgetApplyConfiguration{}
-	err := managedfields.ExtractInto(podDisruptionBudget, internal.Parser().Type("io.k8s.api.policy.v1.PodDisruptionBudget"), fieldManager, b)
+	err := managedfields.ExtractInto(podDisruptionBudget, internal.Parser().Type("io.k8s.api.policy.v1.PodDisruptionBudget"), fieldManager, b, subresource)
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/policy/v1beta1/eviction.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/policy/v1beta1/eviction.go
@@ -58,8 +58,19 @@ func Eviction(name, namespace string) *EvictionApplyConfiguration {
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
 func ExtractEviction(eviction *v1beta1.Eviction, fieldManager string) (*EvictionApplyConfiguration, error) {
+	return extractEviction(eviction, fieldManager, "")
+}
+
+// ExtractEvictionStatus is the same as ExtractEviction except
+// that it extracts the status subresource applied configuration.
+// Experimental!
+func ExtractEvictionStatus(eviction *v1beta1.Eviction, fieldManager string) (*EvictionApplyConfiguration, error) {
+	return extractEviction(eviction, fieldManager, "status")
+}
+
+func extractEviction(eviction *v1beta1.Eviction, fieldManager string, subresource string) (*EvictionApplyConfiguration, error) {
 	b := &EvictionApplyConfiguration{}
-	err := managedfields.ExtractInto(eviction, internal.Parser().Type("io.k8s.api.policy.v1beta1.Eviction"), fieldManager, b)
+	err := managedfields.ExtractInto(eviction, internal.Parser().Type("io.k8s.api.policy.v1beta1.Eviction"), fieldManager, b, subresource)
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/policy/v1beta1/poddisruptionbudget.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/policy/v1beta1/poddisruptionbudget.go
@@ -59,8 +59,19 @@ func PodDisruptionBudget(name, namespace string) *PodDisruptionBudgetApplyConfig
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
 func ExtractPodDisruptionBudget(podDisruptionBudget *policyv1beta1.PodDisruptionBudget, fieldManager string) (*PodDisruptionBudgetApplyConfiguration, error) {
+	return extractPodDisruptionBudget(podDisruptionBudget, fieldManager, "")
+}
+
+// ExtractPodDisruptionBudgetStatus is the same as ExtractPodDisruptionBudget except
+// that it extracts the status subresource applied configuration.
+// Experimental!
+func ExtractPodDisruptionBudgetStatus(podDisruptionBudget *policyv1beta1.PodDisruptionBudget, fieldManager string) (*PodDisruptionBudgetApplyConfiguration, error) {
+	return extractPodDisruptionBudget(podDisruptionBudget, fieldManager, "status")
+}
+
+func extractPodDisruptionBudget(podDisruptionBudget *policyv1beta1.PodDisruptionBudget, fieldManager string, subresource string) (*PodDisruptionBudgetApplyConfiguration, error) {
 	b := &PodDisruptionBudgetApplyConfiguration{}
-	err := managedfields.ExtractInto(podDisruptionBudget, internal.Parser().Type("io.k8s.api.policy.v1beta1.PodDisruptionBudget"), fieldManager, b)
+	err := managedfields.ExtractInto(podDisruptionBudget, internal.Parser().Type("io.k8s.api.policy.v1beta1.PodDisruptionBudget"), fieldManager, b, subresource)
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/policy/v1beta1/podsecuritypolicy.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/policy/v1beta1/podsecuritypolicy.go
@@ -57,8 +57,19 @@ func PodSecurityPolicy(name string) *PodSecurityPolicyApplyConfiguration {
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
 func ExtractPodSecurityPolicy(podSecurityPolicy *policyv1beta1.PodSecurityPolicy, fieldManager string) (*PodSecurityPolicyApplyConfiguration, error) {
+	return extractPodSecurityPolicy(podSecurityPolicy, fieldManager, "")
+}
+
+// ExtractPodSecurityPolicyStatus is the same as ExtractPodSecurityPolicy except
+// that it extracts the status subresource applied configuration.
+// Experimental!
+func ExtractPodSecurityPolicyStatus(podSecurityPolicy *policyv1beta1.PodSecurityPolicy, fieldManager string) (*PodSecurityPolicyApplyConfiguration, error) {
+	return extractPodSecurityPolicy(podSecurityPolicy, fieldManager, "status")
+}
+
+func extractPodSecurityPolicy(podSecurityPolicy *policyv1beta1.PodSecurityPolicy, fieldManager string, subresource string) (*PodSecurityPolicyApplyConfiguration, error) {
 	b := &PodSecurityPolicyApplyConfiguration{}
-	err := managedfields.ExtractInto(podSecurityPolicy, internal.Parser().Type("io.k8s.api.policy.v1beta1.PodSecurityPolicy"), fieldManager, b)
+	err := managedfields.ExtractInto(podSecurityPolicy, internal.Parser().Type("io.k8s.api.policy.v1beta1.PodSecurityPolicy"), fieldManager, b, subresource)
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/rbac/v1/clusterrole.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/rbac/v1/clusterrole.go
@@ -58,8 +58,19 @@ func ClusterRole(name string) *ClusterRoleApplyConfiguration {
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
 func ExtractClusterRole(clusterRole *apirbacv1.ClusterRole, fieldManager string) (*ClusterRoleApplyConfiguration, error) {
+	return extractClusterRole(clusterRole, fieldManager, "")
+}
+
+// ExtractClusterRoleStatus is the same as ExtractClusterRole except
+// that it extracts the status subresource applied configuration.
+// Experimental!
+func ExtractClusterRoleStatus(clusterRole *apirbacv1.ClusterRole, fieldManager string) (*ClusterRoleApplyConfiguration, error) {
+	return extractClusterRole(clusterRole, fieldManager, "status")
+}
+
+func extractClusterRole(clusterRole *apirbacv1.ClusterRole, fieldManager string, subresource string) (*ClusterRoleApplyConfiguration, error) {
 	b := &ClusterRoleApplyConfiguration{}
-	err := managedfields.ExtractInto(clusterRole, internal.Parser().Type("io.k8s.api.rbac.v1.ClusterRole"), fieldManager, b)
+	err := managedfields.ExtractInto(clusterRole, internal.Parser().Type("io.k8s.api.rbac.v1.ClusterRole"), fieldManager, b, subresource)
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/rbac/v1/clusterrolebinding.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/rbac/v1/clusterrolebinding.go
@@ -58,8 +58,19 @@ func ClusterRoleBinding(name string) *ClusterRoleBindingApplyConfiguration {
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
 func ExtractClusterRoleBinding(clusterRoleBinding *apirbacv1.ClusterRoleBinding, fieldManager string) (*ClusterRoleBindingApplyConfiguration, error) {
+	return extractClusterRoleBinding(clusterRoleBinding, fieldManager, "")
+}
+
+// ExtractClusterRoleBindingStatus is the same as ExtractClusterRoleBinding except
+// that it extracts the status subresource applied configuration.
+// Experimental!
+func ExtractClusterRoleBindingStatus(clusterRoleBinding *apirbacv1.ClusterRoleBinding, fieldManager string) (*ClusterRoleBindingApplyConfiguration, error) {
+	return extractClusterRoleBinding(clusterRoleBinding, fieldManager, "status")
+}
+
+func extractClusterRoleBinding(clusterRoleBinding *apirbacv1.ClusterRoleBinding, fieldManager string, subresource string) (*ClusterRoleBindingApplyConfiguration, error) {
 	b := &ClusterRoleBindingApplyConfiguration{}
-	err := managedfields.ExtractInto(clusterRoleBinding, internal.Parser().Type("io.k8s.api.rbac.v1.ClusterRoleBinding"), fieldManager, b)
+	err := managedfields.ExtractInto(clusterRoleBinding, internal.Parser().Type("io.k8s.api.rbac.v1.ClusterRoleBinding"), fieldManager, b, subresource)
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/rbac/v1/role.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/rbac/v1/role.go
@@ -58,8 +58,19 @@ func Role(name, namespace string) *RoleApplyConfiguration {
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
 func ExtractRole(role *apirbacv1.Role, fieldManager string) (*RoleApplyConfiguration, error) {
+	return extractRole(role, fieldManager, "")
+}
+
+// ExtractRoleStatus is the same as ExtractRole except
+// that it extracts the status subresource applied configuration.
+// Experimental!
+func ExtractRoleStatus(role *apirbacv1.Role, fieldManager string) (*RoleApplyConfiguration, error) {
+	return extractRole(role, fieldManager, "status")
+}
+
+func extractRole(role *apirbacv1.Role, fieldManager string, subresource string) (*RoleApplyConfiguration, error) {
 	b := &RoleApplyConfiguration{}
-	err := managedfields.ExtractInto(role, internal.Parser().Type("io.k8s.api.rbac.v1.Role"), fieldManager, b)
+	err := managedfields.ExtractInto(role, internal.Parser().Type("io.k8s.api.rbac.v1.Role"), fieldManager, b, subresource)
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/rbac/v1/rolebinding.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/rbac/v1/rolebinding.go
@@ -59,8 +59,19 @@ func RoleBinding(name, namespace string) *RoleBindingApplyConfiguration {
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
 func ExtractRoleBinding(roleBinding *apirbacv1.RoleBinding, fieldManager string) (*RoleBindingApplyConfiguration, error) {
+	return extractRoleBinding(roleBinding, fieldManager, "")
+}
+
+// ExtractRoleBindingStatus is the same as ExtractRoleBinding except
+// that it extracts the status subresource applied configuration.
+// Experimental!
+func ExtractRoleBindingStatus(roleBinding *apirbacv1.RoleBinding, fieldManager string) (*RoleBindingApplyConfiguration, error) {
+	return extractRoleBinding(roleBinding, fieldManager, "status")
+}
+
+func extractRoleBinding(roleBinding *apirbacv1.RoleBinding, fieldManager string, subresource string) (*RoleBindingApplyConfiguration, error) {
 	b := &RoleBindingApplyConfiguration{}
-	err := managedfields.ExtractInto(roleBinding, internal.Parser().Type("io.k8s.api.rbac.v1.RoleBinding"), fieldManager, b)
+	err := managedfields.ExtractInto(roleBinding, internal.Parser().Type("io.k8s.api.rbac.v1.RoleBinding"), fieldManager, b, subresource)
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/rbac/v1alpha1/clusterrole.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/rbac/v1alpha1/clusterrole.go
@@ -58,8 +58,19 @@ func ClusterRole(name string) *ClusterRoleApplyConfiguration {
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
 func ExtractClusterRole(clusterRole *rbacv1alpha1.ClusterRole, fieldManager string) (*ClusterRoleApplyConfiguration, error) {
+	return extractClusterRole(clusterRole, fieldManager, "")
+}
+
+// ExtractClusterRoleStatus is the same as ExtractClusterRole except
+// that it extracts the status subresource applied configuration.
+// Experimental!
+func ExtractClusterRoleStatus(clusterRole *rbacv1alpha1.ClusterRole, fieldManager string) (*ClusterRoleApplyConfiguration, error) {
+	return extractClusterRole(clusterRole, fieldManager, "status")
+}
+
+func extractClusterRole(clusterRole *rbacv1alpha1.ClusterRole, fieldManager string, subresource string) (*ClusterRoleApplyConfiguration, error) {
 	b := &ClusterRoleApplyConfiguration{}
-	err := managedfields.ExtractInto(clusterRole, internal.Parser().Type("io.k8s.api.rbac.v1alpha1.ClusterRole"), fieldManager, b)
+	err := managedfields.ExtractInto(clusterRole, internal.Parser().Type("io.k8s.api.rbac.v1alpha1.ClusterRole"), fieldManager, b, subresource)
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/rbac/v1alpha1/clusterrolebinding.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/rbac/v1alpha1/clusterrolebinding.go
@@ -58,8 +58,19 @@ func ClusterRoleBinding(name string) *ClusterRoleBindingApplyConfiguration {
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
 func ExtractClusterRoleBinding(clusterRoleBinding *rbacv1alpha1.ClusterRoleBinding, fieldManager string) (*ClusterRoleBindingApplyConfiguration, error) {
+	return extractClusterRoleBinding(clusterRoleBinding, fieldManager, "")
+}
+
+// ExtractClusterRoleBindingStatus is the same as ExtractClusterRoleBinding except
+// that it extracts the status subresource applied configuration.
+// Experimental!
+func ExtractClusterRoleBindingStatus(clusterRoleBinding *rbacv1alpha1.ClusterRoleBinding, fieldManager string) (*ClusterRoleBindingApplyConfiguration, error) {
+	return extractClusterRoleBinding(clusterRoleBinding, fieldManager, "status")
+}
+
+func extractClusterRoleBinding(clusterRoleBinding *rbacv1alpha1.ClusterRoleBinding, fieldManager string, subresource string) (*ClusterRoleBindingApplyConfiguration, error) {
 	b := &ClusterRoleBindingApplyConfiguration{}
-	err := managedfields.ExtractInto(clusterRoleBinding, internal.Parser().Type("io.k8s.api.rbac.v1alpha1.ClusterRoleBinding"), fieldManager, b)
+	err := managedfields.ExtractInto(clusterRoleBinding, internal.Parser().Type("io.k8s.api.rbac.v1alpha1.ClusterRoleBinding"), fieldManager, b, subresource)
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/rbac/v1alpha1/role.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/rbac/v1alpha1/role.go
@@ -58,8 +58,19 @@ func Role(name, namespace string) *RoleApplyConfiguration {
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
 func ExtractRole(role *rbacv1alpha1.Role, fieldManager string) (*RoleApplyConfiguration, error) {
+	return extractRole(role, fieldManager, "")
+}
+
+// ExtractRoleStatus is the same as ExtractRole except
+// that it extracts the status subresource applied configuration.
+// Experimental!
+func ExtractRoleStatus(role *rbacv1alpha1.Role, fieldManager string) (*RoleApplyConfiguration, error) {
+	return extractRole(role, fieldManager, "status")
+}
+
+func extractRole(role *rbacv1alpha1.Role, fieldManager string, subresource string) (*RoleApplyConfiguration, error) {
 	b := &RoleApplyConfiguration{}
-	err := managedfields.ExtractInto(role, internal.Parser().Type("io.k8s.api.rbac.v1alpha1.Role"), fieldManager, b)
+	err := managedfields.ExtractInto(role, internal.Parser().Type("io.k8s.api.rbac.v1alpha1.Role"), fieldManager, b, subresource)
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/rbac/v1alpha1/rolebinding.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/rbac/v1alpha1/rolebinding.go
@@ -59,8 +59,19 @@ func RoleBinding(name, namespace string) *RoleBindingApplyConfiguration {
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
 func ExtractRoleBinding(roleBinding *rbacv1alpha1.RoleBinding, fieldManager string) (*RoleBindingApplyConfiguration, error) {
+	return extractRoleBinding(roleBinding, fieldManager, "")
+}
+
+// ExtractRoleBindingStatus is the same as ExtractRoleBinding except
+// that it extracts the status subresource applied configuration.
+// Experimental!
+func ExtractRoleBindingStatus(roleBinding *rbacv1alpha1.RoleBinding, fieldManager string) (*RoleBindingApplyConfiguration, error) {
+	return extractRoleBinding(roleBinding, fieldManager, "status")
+}
+
+func extractRoleBinding(roleBinding *rbacv1alpha1.RoleBinding, fieldManager string, subresource string) (*RoleBindingApplyConfiguration, error) {
 	b := &RoleBindingApplyConfiguration{}
-	err := managedfields.ExtractInto(roleBinding, internal.Parser().Type("io.k8s.api.rbac.v1alpha1.RoleBinding"), fieldManager, b)
+	err := managedfields.ExtractInto(roleBinding, internal.Parser().Type("io.k8s.api.rbac.v1alpha1.RoleBinding"), fieldManager, b, subresource)
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/rbac/v1beta1/clusterrole.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/rbac/v1beta1/clusterrole.go
@@ -58,8 +58,19 @@ func ClusterRole(name string) *ClusterRoleApplyConfiguration {
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
 func ExtractClusterRole(clusterRole *rbacv1beta1.ClusterRole, fieldManager string) (*ClusterRoleApplyConfiguration, error) {
+	return extractClusterRole(clusterRole, fieldManager, "")
+}
+
+// ExtractClusterRoleStatus is the same as ExtractClusterRole except
+// that it extracts the status subresource applied configuration.
+// Experimental!
+func ExtractClusterRoleStatus(clusterRole *rbacv1beta1.ClusterRole, fieldManager string) (*ClusterRoleApplyConfiguration, error) {
+	return extractClusterRole(clusterRole, fieldManager, "status")
+}
+
+func extractClusterRole(clusterRole *rbacv1beta1.ClusterRole, fieldManager string, subresource string) (*ClusterRoleApplyConfiguration, error) {
 	b := &ClusterRoleApplyConfiguration{}
-	err := managedfields.ExtractInto(clusterRole, internal.Parser().Type("io.k8s.api.rbac.v1beta1.ClusterRole"), fieldManager, b)
+	err := managedfields.ExtractInto(clusterRole, internal.Parser().Type("io.k8s.api.rbac.v1beta1.ClusterRole"), fieldManager, b, subresource)
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/rbac/v1beta1/clusterrolebinding.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/rbac/v1beta1/clusterrolebinding.go
@@ -58,8 +58,19 @@ func ClusterRoleBinding(name string) *ClusterRoleBindingApplyConfiguration {
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
 func ExtractClusterRoleBinding(clusterRoleBinding *rbacv1beta1.ClusterRoleBinding, fieldManager string) (*ClusterRoleBindingApplyConfiguration, error) {
+	return extractClusterRoleBinding(clusterRoleBinding, fieldManager, "")
+}
+
+// ExtractClusterRoleBindingStatus is the same as ExtractClusterRoleBinding except
+// that it extracts the status subresource applied configuration.
+// Experimental!
+func ExtractClusterRoleBindingStatus(clusterRoleBinding *rbacv1beta1.ClusterRoleBinding, fieldManager string) (*ClusterRoleBindingApplyConfiguration, error) {
+	return extractClusterRoleBinding(clusterRoleBinding, fieldManager, "status")
+}
+
+func extractClusterRoleBinding(clusterRoleBinding *rbacv1beta1.ClusterRoleBinding, fieldManager string, subresource string) (*ClusterRoleBindingApplyConfiguration, error) {
 	b := &ClusterRoleBindingApplyConfiguration{}
-	err := managedfields.ExtractInto(clusterRoleBinding, internal.Parser().Type("io.k8s.api.rbac.v1beta1.ClusterRoleBinding"), fieldManager, b)
+	err := managedfields.ExtractInto(clusterRoleBinding, internal.Parser().Type("io.k8s.api.rbac.v1beta1.ClusterRoleBinding"), fieldManager, b, subresource)
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/rbac/v1beta1/role.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/rbac/v1beta1/role.go
@@ -58,8 +58,19 @@ func Role(name, namespace string) *RoleApplyConfiguration {
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
 func ExtractRole(role *rbacv1beta1.Role, fieldManager string) (*RoleApplyConfiguration, error) {
+	return extractRole(role, fieldManager, "")
+}
+
+// ExtractRoleStatus is the same as ExtractRole except
+// that it extracts the status subresource applied configuration.
+// Experimental!
+func ExtractRoleStatus(role *rbacv1beta1.Role, fieldManager string) (*RoleApplyConfiguration, error) {
+	return extractRole(role, fieldManager, "status")
+}
+
+func extractRole(role *rbacv1beta1.Role, fieldManager string, subresource string) (*RoleApplyConfiguration, error) {
 	b := &RoleApplyConfiguration{}
-	err := managedfields.ExtractInto(role, internal.Parser().Type("io.k8s.api.rbac.v1beta1.Role"), fieldManager, b)
+	err := managedfields.ExtractInto(role, internal.Parser().Type("io.k8s.api.rbac.v1beta1.Role"), fieldManager, b, subresource)
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/rbac/v1beta1/rolebinding.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/rbac/v1beta1/rolebinding.go
@@ -59,8 +59,19 @@ func RoleBinding(name, namespace string) *RoleBindingApplyConfiguration {
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
 func ExtractRoleBinding(roleBinding *rbacv1beta1.RoleBinding, fieldManager string) (*RoleBindingApplyConfiguration, error) {
+	return extractRoleBinding(roleBinding, fieldManager, "")
+}
+
+// ExtractRoleBindingStatus is the same as ExtractRoleBinding except
+// that it extracts the status subresource applied configuration.
+// Experimental!
+func ExtractRoleBindingStatus(roleBinding *rbacv1beta1.RoleBinding, fieldManager string) (*RoleBindingApplyConfiguration, error) {
+	return extractRoleBinding(roleBinding, fieldManager, "status")
+}
+
+func extractRoleBinding(roleBinding *rbacv1beta1.RoleBinding, fieldManager string, subresource string) (*RoleBindingApplyConfiguration, error) {
 	b := &RoleBindingApplyConfiguration{}
-	err := managedfields.ExtractInto(roleBinding, internal.Parser().Type("io.k8s.api.rbac.v1beta1.RoleBinding"), fieldManager, b)
+	err := managedfields.ExtractInto(roleBinding, internal.Parser().Type("io.k8s.api.rbac.v1beta1.RoleBinding"), fieldManager, b, subresource)
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/scheduling/v1/priorityclass.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/scheduling/v1/priorityclass.go
@@ -61,8 +61,19 @@ func PriorityClass(name string) *PriorityClassApplyConfiguration {
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
 func ExtractPriorityClass(priorityClass *schedulingv1.PriorityClass, fieldManager string) (*PriorityClassApplyConfiguration, error) {
+	return extractPriorityClass(priorityClass, fieldManager, "")
+}
+
+// ExtractPriorityClassStatus is the same as ExtractPriorityClass except
+// that it extracts the status subresource applied configuration.
+// Experimental!
+func ExtractPriorityClassStatus(priorityClass *schedulingv1.PriorityClass, fieldManager string) (*PriorityClassApplyConfiguration, error) {
+	return extractPriorityClass(priorityClass, fieldManager, "status")
+}
+
+func extractPriorityClass(priorityClass *schedulingv1.PriorityClass, fieldManager string, subresource string) (*PriorityClassApplyConfiguration, error) {
 	b := &PriorityClassApplyConfiguration{}
-	err := managedfields.ExtractInto(priorityClass, internal.Parser().Type("io.k8s.api.scheduling.v1.PriorityClass"), fieldManager, b)
+	err := managedfields.ExtractInto(priorityClass, internal.Parser().Type("io.k8s.api.scheduling.v1.PriorityClass"), fieldManager, b, subresource)
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/scheduling/v1alpha1/priorityclass.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/scheduling/v1alpha1/priorityclass.go
@@ -61,8 +61,19 @@ func PriorityClass(name string) *PriorityClassApplyConfiguration {
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
 func ExtractPriorityClass(priorityClass *v1alpha1.PriorityClass, fieldManager string) (*PriorityClassApplyConfiguration, error) {
+	return extractPriorityClass(priorityClass, fieldManager, "")
+}
+
+// ExtractPriorityClassStatus is the same as ExtractPriorityClass except
+// that it extracts the status subresource applied configuration.
+// Experimental!
+func ExtractPriorityClassStatus(priorityClass *v1alpha1.PriorityClass, fieldManager string) (*PriorityClassApplyConfiguration, error) {
+	return extractPriorityClass(priorityClass, fieldManager, "status")
+}
+
+func extractPriorityClass(priorityClass *v1alpha1.PriorityClass, fieldManager string, subresource string) (*PriorityClassApplyConfiguration, error) {
 	b := &PriorityClassApplyConfiguration{}
-	err := managedfields.ExtractInto(priorityClass, internal.Parser().Type("io.k8s.api.scheduling.v1alpha1.PriorityClass"), fieldManager, b)
+	err := managedfields.ExtractInto(priorityClass, internal.Parser().Type("io.k8s.api.scheduling.v1alpha1.PriorityClass"), fieldManager, b, subresource)
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/scheduling/v1beta1/priorityclass.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/scheduling/v1beta1/priorityclass.go
@@ -61,8 +61,19 @@ func PriorityClass(name string) *PriorityClassApplyConfiguration {
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
 func ExtractPriorityClass(priorityClass *v1beta1.PriorityClass, fieldManager string) (*PriorityClassApplyConfiguration, error) {
+	return extractPriorityClass(priorityClass, fieldManager, "")
+}
+
+// ExtractPriorityClassStatus is the same as ExtractPriorityClass except
+// that it extracts the status subresource applied configuration.
+// Experimental!
+func ExtractPriorityClassStatus(priorityClass *v1beta1.PriorityClass, fieldManager string) (*PriorityClassApplyConfiguration, error) {
+	return extractPriorityClass(priorityClass, fieldManager, "status")
+}
+
+func extractPriorityClass(priorityClass *v1beta1.PriorityClass, fieldManager string, subresource string) (*PriorityClassApplyConfiguration, error) {
 	b := &PriorityClassApplyConfiguration{}
-	err := managedfields.ExtractInto(priorityClass, internal.Parser().Type("io.k8s.api.scheduling.v1beta1.PriorityClass"), fieldManager, b)
+	err := managedfields.ExtractInto(priorityClass, internal.Parser().Type("io.k8s.api.scheduling.v1beta1.PriorityClass"), fieldManager, b, subresource)
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/storage/v1/csidriver.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/storage/v1/csidriver.go
@@ -57,8 +57,19 @@ func CSIDriver(name string) *CSIDriverApplyConfiguration {
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
 func ExtractCSIDriver(cSIDriver *apistoragev1.CSIDriver, fieldManager string) (*CSIDriverApplyConfiguration, error) {
+	return extractCSIDriver(cSIDriver, fieldManager, "")
+}
+
+// ExtractCSIDriverStatus is the same as ExtractCSIDriver except
+// that it extracts the status subresource applied configuration.
+// Experimental!
+func ExtractCSIDriverStatus(cSIDriver *apistoragev1.CSIDriver, fieldManager string) (*CSIDriverApplyConfiguration, error) {
+	return extractCSIDriver(cSIDriver, fieldManager, "status")
+}
+
+func extractCSIDriver(cSIDriver *apistoragev1.CSIDriver, fieldManager string, subresource string) (*CSIDriverApplyConfiguration, error) {
 	b := &CSIDriverApplyConfiguration{}
-	err := managedfields.ExtractInto(cSIDriver, internal.Parser().Type("io.k8s.api.storage.v1.CSIDriver"), fieldManager, b)
+	err := managedfields.ExtractInto(cSIDriver, internal.Parser().Type("io.k8s.api.storage.v1.CSIDriver"), fieldManager, b, subresource)
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/storage/v1/csinode.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/storage/v1/csinode.go
@@ -57,8 +57,19 @@ func CSINode(name string) *CSINodeApplyConfiguration {
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
 func ExtractCSINode(cSINode *apistoragev1.CSINode, fieldManager string) (*CSINodeApplyConfiguration, error) {
+	return extractCSINode(cSINode, fieldManager, "")
+}
+
+// ExtractCSINodeStatus is the same as ExtractCSINode except
+// that it extracts the status subresource applied configuration.
+// Experimental!
+func ExtractCSINodeStatus(cSINode *apistoragev1.CSINode, fieldManager string) (*CSINodeApplyConfiguration, error) {
+	return extractCSINode(cSINode, fieldManager, "status")
+}
+
+func extractCSINode(cSINode *apistoragev1.CSINode, fieldManager string, subresource string) (*CSINodeApplyConfiguration, error) {
 	b := &CSINodeApplyConfiguration{}
-	err := managedfields.ExtractInto(cSINode, internal.Parser().Type("io.k8s.api.storage.v1.CSINode"), fieldManager, b)
+	err := managedfields.ExtractInto(cSINode, internal.Parser().Type("io.k8s.api.storage.v1.CSINode"), fieldManager, b, subresource)
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/storage/v1/storageclass.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/storage/v1/storageclass.go
@@ -65,8 +65,19 @@ func StorageClass(name string) *StorageClassApplyConfiguration {
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
 func ExtractStorageClass(storageClass *storagev1.StorageClass, fieldManager string) (*StorageClassApplyConfiguration, error) {
+	return extractStorageClass(storageClass, fieldManager, "")
+}
+
+// ExtractStorageClassStatus is the same as ExtractStorageClass except
+// that it extracts the status subresource applied configuration.
+// Experimental!
+func ExtractStorageClassStatus(storageClass *storagev1.StorageClass, fieldManager string) (*StorageClassApplyConfiguration, error) {
+	return extractStorageClass(storageClass, fieldManager, "status")
+}
+
+func extractStorageClass(storageClass *storagev1.StorageClass, fieldManager string, subresource string) (*StorageClassApplyConfiguration, error) {
 	b := &StorageClassApplyConfiguration{}
-	err := managedfields.ExtractInto(storageClass, internal.Parser().Type("io.k8s.api.storage.v1.StorageClass"), fieldManager, b)
+	err := managedfields.ExtractInto(storageClass, internal.Parser().Type("io.k8s.api.storage.v1.StorageClass"), fieldManager, b, subresource)
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/storage/v1/volumeattachment.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/storage/v1/volumeattachment.go
@@ -58,8 +58,19 @@ func VolumeAttachment(name string) *VolumeAttachmentApplyConfiguration {
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
 func ExtractVolumeAttachment(volumeAttachment *apistoragev1.VolumeAttachment, fieldManager string) (*VolumeAttachmentApplyConfiguration, error) {
+	return extractVolumeAttachment(volumeAttachment, fieldManager, "")
+}
+
+// ExtractVolumeAttachmentStatus is the same as ExtractVolumeAttachment except
+// that it extracts the status subresource applied configuration.
+// Experimental!
+func ExtractVolumeAttachmentStatus(volumeAttachment *apistoragev1.VolumeAttachment, fieldManager string) (*VolumeAttachmentApplyConfiguration, error) {
+	return extractVolumeAttachment(volumeAttachment, fieldManager, "status")
+}
+
+func extractVolumeAttachment(volumeAttachment *apistoragev1.VolumeAttachment, fieldManager string, subresource string) (*VolumeAttachmentApplyConfiguration, error) {
 	b := &VolumeAttachmentApplyConfiguration{}
-	err := managedfields.ExtractInto(volumeAttachment, internal.Parser().Type("io.k8s.api.storage.v1.VolumeAttachment"), fieldManager, b)
+	err := managedfields.ExtractInto(volumeAttachment, internal.Parser().Type("io.k8s.api.storage.v1.VolumeAttachment"), fieldManager, b, subresource)
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/storage/v1alpha1/csistoragecapacity.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/storage/v1alpha1/csistoragecapacity.go
@@ -62,8 +62,19 @@ func CSIStorageCapacity(name, namespace string) *CSIStorageCapacityApplyConfigur
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
 func ExtractCSIStorageCapacity(cSIStorageCapacity *v1alpha1.CSIStorageCapacity, fieldManager string) (*CSIStorageCapacityApplyConfiguration, error) {
+	return extractCSIStorageCapacity(cSIStorageCapacity, fieldManager, "")
+}
+
+// ExtractCSIStorageCapacityStatus is the same as ExtractCSIStorageCapacity except
+// that it extracts the status subresource applied configuration.
+// Experimental!
+func ExtractCSIStorageCapacityStatus(cSIStorageCapacity *v1alpha1.CSIStorageCapacity, fieldManager string) (*CSIStorageCapacityApplyConfiguration, error) {
+	return extractCSIStorageCapacity(cSIStorageCapacity, fieldManager, "status")
+}
+
+func extractCSIStorageCapacity(cSIStorageCapacity *v1alpha1.CSIStorageCapacity, fieldManager string, subresource string) (*CSIStorageCapacityApplyConfiguration, error) {
 	b := &CSIStorageCapacityApplyConfiguration{}
-	err := managedfields.ExtractInto(cSIStorageCapacity, internal.Parser().Type("io.k8s.api.storage.v1alpha1.CSIStorageCapacity"), fieldManager, b)
+	err := managedfields.ExtractInto(cSIStorageCapacity, internal.Parser().Type("io.k8s.api.storage.v1alpha1.CSIStorageCapacity"), fieldManager, b, subresource)
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/storage/v1alpha1/volumeattachment.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/storage/v1alpha1/volumeattachment.go
@@ -58,8 +58,19 @@ func VolumeAttachment(name string) *VolumeAttachmentApplyConfiguration {
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
 func ExtractVolumeAttachment(volumeAttachment *storagev1alpha1.VolumeAttachment, fieldManager string) (*VolumeAttachmentApplyConfiguration, error) {
+	return extractVolumeAttachment(volumeAttachment, fieldManager, "")
+}
+
+// ExtractVolumeAttachmentStatus is the same as ExtractVolumeAttachment except
+// that it extracts the status subresource applied configuration.
+// Experimental!
+func ExtractVolumeAttachmentStatus(volumeAttachment *storagev1alpha1.VolumeAttachment, fieldManager string) (*VolumeAttachmentApplyConfiguration, error) {
+	return extractVolumeAttachment(volumeAttachment, fieldManager, "status")
+}
+
+func extractVolumeAttachment(volumeAttachment *storagev1alpha1.VolumeAttachment, fieldManager string, subresource string) (*VolumeAttachmentApplyConfiguration, error) {
 	b := &VolumeAttachmentApplyConfiguration{}
-	err := managedfields.ExtractInto(volumeAttachment, internal.Parser().Type("io.k8s.api.storage.v1alpha1.VolumeAttachment"), fieldManager, b)
+	err := managedfields.ExtractInto(volumeAttachment, internal.Parser().Type("io.k8s.api.storage.v1alpha1.VolumeAttachment"), fieldManager, b, subresource)
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/storage/v1beta1/csidriver.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/storage/v1beta1/csidriver.go
@@ -57,8 +57,19 @@ func CSIDriver(name string) *CSIDriverApplyConfiguration {
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
 func ExtractCSIDriver(cSIDriver *storagev1beta1.CSIDriver, fieldManager string) (*CSIDriverApplyConfiguration, error) {
+	return extractCSIDriver(cSIDriver, fieldManager, "")
+}
+
+// ExtractCSIDriverStatus is the same as ExtractCSIDriver except
+// that it extracts the status subresource applied configuration.
+// Experimental!
+func ExtractCSIDriverStatus(cSIDriver *storagev1beta1.CSIDriver, fieldManager string) (*CSIDriverApplyConfiguration, error) {
+	return extractCSIDriver(cSIDriver, fieldManager, "status")
+}
+
+func extractCSIDriver(cSIDriver *storagev1beta1.CSIDriver, fieldManager string, subresource string) (*CSIDriverApplyConfiguration, error) {
 	b := &CSIDriverApplyConfiguration{}
-	err := managedfields.ExtractInto(cSIDriver, internal.Parser().Type("io.k8s.api.storage.v1beta1.CSIDriver"), fieldManager, b)
+	err := managedfields.ExtractInto(cSIDriver, internal.Parser().Type("io.k8s.api.storage.v1beta1.CSIDriver"), fieldManager, b, subresource)
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/storage/v1beta1/csinode.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/storage/v1beta1/csinode.go
@@ -57,8 +57,19 @@ func CSINode(name string) *CSINodeApplyConfiguration {
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
 func ExtractCSINode(cSINode *storagev1beta1.CSINode, fieldManager string) (*CSINodeApplyConfiguration, error) {
+	return extractCSINode(cSINode, fieldManager, "")
+}
+
+// ExtractCSINodeStatus is the same as ExtractCSINode except
+// that it extracts the status subresource applied configuration.
+// Experimental!
+func ExtractCSINodeStatus(cSINode *storagev1beta1.CSINode, fieldManager string) (*CSINodeApplyConfiguration, error) {
+	return extractCSINode(cSINode, fieldManager, "status")
+}
+
+func extractCSINode(cSINode *storagev1beta1.CSINode, fieldManager string, subresource string) (*CSINodeApplyConfiguration, error) {
 	b := &CSINodeApplyConfiguration{}
-	err := managedfields.ExtractInto(cSINode, internal.Parser().Type("io.k8s.api.storage.v1beta1.CSINode"), fieldManager, b)
+	err := managedfields.ExtractInto(cSINode, internal.Parser().Type("io.k8s.api.storage.v1beta1.CSINode"), fieldManager, b, subresource)
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/storage/v1beta1/csistoragecapacity.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/storage/v1beta1/csistoragecapacity.go
@@ -62,8 +62,19 @@ func CSIStorageCapacity(name, namespace string) *CSIStorageCapacityApplyConfigur
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
 func ExtractCSIStorageCapacity(cSIStorageCapacity *v1beta1.CSIStorageCapacity, fieldManager string) (*CSIStorageCapacityApplyConfiguration, error) {
+	return extractCSIStorageCapacity(cSIStorageCapacity, fieldManager, "")
+}
+
+// ExtractCSIStorageCapacityStatus is the same as ExtractCSIStorageCapacity except
+// that it extracts the status subresource applied configuration.
+// Experimental!
+func ExtractCSIStorageCapacityStatus(cSIStorageCapacity *v1beta1.CSIStorageCapacity, fieldManager string) (*CSIStorageCapacityApplyConfiguration, error) {
+	return extractCSIStorageCapacity(cSIStorageCapacity, fieldManager, "status")
+}
+
+func extractCSIStorageCapacity(cSIStorageCapacity *v1beta1.CSIStorageCapacity, fieldManager string, subresource string) (*CSIStorageCapacityApplyConfiguration, error) {
 	b := &CSIStorageCapacityApplyConfiguration{}
-	err := managedfields.ExtractInto(cSIStorageCapacity, internal.Parser().Type("io.k8s.api.storage.v1beta1.CSIStorageCapacity"), fieldManager, b)
+	err := managedfields.ExtractInto(cSIStorageCapacity, internal.Parser().Type("io.k8s.api.storage.v1beta1.CSIStorageCapacity"), fieldManager, b, subresource)
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/storage/v1beta1/storageclass.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/storage/v1beta1/storageclass.go
@@ -65,8 +65,19 @@ func StorageClass(name string) *StorageClassApplyConfiguration {
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
 func ExtractStorageClass(storageClass *v1beta1.StorageClass, fieldManager string) (*StorageClassApplyConfiguration, error) {
+	return extractStorageClass(storageClass, fieldManager, "")
+}
+
+// ExtractStorageClassStatus is the same as ExtractStorageClass except
+// that it extracts the status subresource applied configuration.
+// Experimental!
+func ExtractStorageClassStatus(storageClass *v1beta1.StorageClass, fieldManager string) (*StorageClassApplyConfiguration, error) {
+	return extractStorageClass(storageClass, fieldManager, "status")
+}
+
+func extractStorageClass(storageClass *v1beta1.StorageClass, fieldManager string, subresource string) (*StorageClassApplyConfiguration, error) {
 	b := &StorageClassApplyConfiguration{}
-	err := managedfields.ExtractInto(storageClass, internal.Parser().Type("io.k8s.api.storage.v1beta1.StorageClass"), fieldManager, b)
+	err := managedfields.ExtractInto(storageClass, internal.Parser().Type("io.k8s.api.storage.v1beta1.StorageClass"), fieldManager, b, subresource)
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/storage/v1beta1/volumeattachment.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/storage/v1beta1/volumeattachment.go
@@ -58,8 +58,19 @@ func VolumeAttachment(name string) *VolumeAttachmentApplyConfiguration {
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
 func ExtractVolumeAttachment(volumeAttachment *storagev1beta1.VolumeAttachment, fieldManager string) (*VolumeAttachmentApplyConfiguration, error) {
+	return extractVolumeAttachment(volumeAttachment, fieldManager, "")
+}
+
+// ExtractVolumeAttachmentStatus is the same as ExtractVolumeAttachment except
+// that it extracts the status subresource applied configuration.
+// Experimental!
+func ExtractVolumeAttachmentStatus(volumeAttachment *storagev1beta1.VolumeAttachment, fieldManager string) (*VolumeAttachmentApplyConfiguration, error) {
+	return extractVolumeAttachment(volumeAttachment, fieldManager, "status")
+}
+
+func extractVolumeAttachment(volumeAttachment *storagev1beta1.VolumeAttachment, fieldManager string, subresource string) (*VolumeAttachmentApplyConfiguration, error) {
 	b := &VolumeAttachmentApplyConfiguration{}
-	err := managedfields.ExtractInto(volumeAttachment, internal.Parser().Type("io.k8s.api.storage.v1beta1.VolumeAttachment"), fieldManager, b)
+	err := managedfields.ExtractInto(volumeAttachment, internal.Parser().Type("io.k8s.api.storage.v1beta1.VolumeAttachment"), fieldManager, b, subresource)
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/code-generator/cmd/applyconfiguration-gen/generators/applyconfiguration.go
+++ b/staging/src/k8s.io/code-generator/cmd/applyconfiguration-gen/generators/applyconfiguration.go
@@ -102,7 +102,7 @@ func (g *applyConfigurationGenerator) GenerateType(c *generator.Context, t *type
 			sw.Do(clientgenTypeConstructorNamespaced, typeParams)
 		}
 		if typeParams.OpenAPIType != nil {
-			g.generateClientgenExtract(sw, typeParams)
+			g.generateClientgenExtract(sw, typeParams, !typeParams.Tags.NoStatus)
 		}
 	} else {
 		sw.Do(constructor, typeParams)
@@ -317,7 +317,7 @@ func $.ApplyConfig.Type|public$() *$.ApplyConfig.ApplyConfiguration|public$ {
 }
 `
 
-func (g *applyConfigurationGenerator) generateClientgenExtract(sw *generator.SnippetWriter, typeParams TypeParams) {
+func (g *applyConfigurationGenerator) generateClientgenExtract(sw *generator.SnippetWriter, typeParams TypeParams, includeStatus bool) {
 	sw.Do(`
 // Extract$.ApplyConfig.Type|public$ extracts the applied configuration owned by fieldManager from
 // $.Struct|private$. If no managedFields are found in $.Struct|private$ for fieldManager, a
@@ -330,9 +330,23 @@ func (g *applyConfigurationGenerator) generateClientgenExtract(sw *generator.Sni
 // Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
-func Extract$.ApplyConfig.Type|public$($.Struct|private$ *$.Struct|raw$, fieldManager string) (*$.ApplyConfig.ApplyConfiguration|public$ , error) {
+func Extract$.ApplyConfig.Type|public$($.Struct|private$ *$.Struct|raw$, fieldManager string) (*$.ApplyConfig.ApplyConfiguration|public$, error) {
+	return extract$.ApplyConfig.Type|public$($.Struct|private$, fieldManager, "")
+}`, typeParams)
+	if includeStatus {
+		sw.Do(`
+// Extract$.ApplyConfig.Type|public$Status is the same as Extract$.ApplyConfig.Type|public$ except
+// that it extracts the status subresource applied configuration.
+// Experimental!
+func Extract$.ApplyConfig.Type|public$Status($.Struct|private$ *$.Struct|raw$, fieldManager string) (*$.ApplyConfig.ApplyConfiguration|public$, error) {
+	return extract$.ApplyConfig.Type|public$($.Struct|private$, fieldManager, "status")
+}
+`, typeParams)
+	}
+	sw.Do(`
+func extract$.ApplyConfig.Type|public$($.Struct|private$ *$.Struct|raw$, fieldManager string, subresource string) (*$.ApplyConfig.ApplyConfiguration|public$, error) {
 	b := &$.ApplyConfig.ApplyConfiguration|public${}
-	err := $.ExtractInto|raw$($.Struct|private$, $.ParserFunc|raw$().Type("$.OpenAPIType$"), fieldManager, b)
+	err := $.ExtractInto|raw$($.Struct|private$, $.ParserFunc|raw$().Type("$.OpenAPIType$"), fieldManager, b, subresource)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

https://github.com/kubernetes/kubernetes/pull/98377 adds subresource support to server side apply. This leverages that support in the client-go apply "Extract" functions.

#### Special notes for your reviewer:

Based on https://github.com/kubernetes/kubernetes/pull/100970 until it merges

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

/sig api-machinery
/priority important-longterm
/cc @apelisse @Jefftree 
