### PR TITLE
Prevent nil-pointer exception when constructing PrinterFlags

### DIFF
--- a/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/json_yaml_flags.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/json_yaml_flags.go
@@ -65,6 +65,10 @@ func (f *JSONYamlPrintFlags) ToPrinter(outputFormat string) (printers.ResourcePr
 // AddFlags receives a *cobra.Command reference and binds
 // flags related to JSON or Yaml printing to it
 func (f *JSONYamlPrintFlags) AddFlags(c *cobra.Command) {
+	if f == nil {
+		return
+	}
+
 	c.Flags().BoolVar(&f.showManagedFields, "show-managed-fields", f.showManagedFields, "If true, keep the managedFields when printing objects in JSON or YAML format.")
 }
 


### PR DESCRIPTION
#### What type of PR is this?
/kind bug
/kind regression
/sig cli
/priority important-longterm

#### What this PR does / why we need it:
This is fixing potential nil-pointer exception when constructing PrinterFlags. 

We'll probably want to pick that to 1.21.1

#### Special notes for your reviewer:
/assign @sallyom 

#### Does this PR introduce a user-facing change?
<!--
```release-note
NONE
```
