### PR TITLE
Bug: Extend APIService e2e testing of endpoints

### DIFF
--- a/test/conformance/testdata/conformance.yaml
+++ b/test/conformance/testdata/conformance.yaml
@@ -634,7 +634,7 @@
     API Server using the current Aggregator [Conformance]'
   description: Ensure that the sample-apiserver code from 1.17 and compiled against
     1.17 will work on the current Aggregator/API-Server.
-  release: v1.17, v1.21
+  release: v1.17, v1.21, v1.22
   file: test/e2e/apimachinery/aggregator.go
 - testname: Custom Resource Definition Conversion Webhook, convert mixed version list
   codename: '[sig-api-machinery] CustomResourceConversionWebhook [Privileged:ClusterAdmin]


### PR DESCRIPTION
After testing and validating two extra endpoints for APIService Status (for e2e conformance), the test tries to delete the APIService the test resources at which point the the test will flake.

```
STEP: patch the APIService                                                                                                                                                    
Mar 24 11:46:26.809: INFO: APIService labels: map[apiservice:patched]                                                                                                         
Mar 24 11:46:26.812: INFO: APIService labels: map[apiservice:patched]                                                                                                         
STEP: updating the APIService Status                                                                                                                                          
Mar 24 11:46:26.828: INFO: updatedStatus.Conditions: []v1.APIServiceCondition{v1.APIServiceCondition{Type:"Available", Status:"True", LastTransitionTime:v1.Time{Time:time.Tim
e{wall:0x0, ext:63752136385, loc:(*time.Location)(0x8679820)}}, Reason:"Passed", Message:"all checks passed"}, v1.APIServiceCondition{Type:"StatusUpdate", Status:"True", Last
TransitionTime:v1.Time{Time:time.Time{wall:0x0, ext:0, loc:(*time.Location)(nil)}}, Reason:"E2E", Message:"Set from e2e test"}}                                               
STEP: watching for the APIService to be updated                                                                                                                               
Mar 24 11:46:26.830: INFO: Observed APIService v1alpha1.wardle.example.com with Labels: map[apiservice:patched] & Conditions: [{Available True 2021-03-24 11:46:25 +1300 NZDT Passed all checks passed} {StatusUpdate True 0001-01-01 00:00:00 +0000 UTC E2E Set from e2e test}]                                                                            
Mar 24 11:46:26.830: INFO: Found APIService v1alpha1.wardle.example.com with Labels: map[apiservice:patched] & Conditions: [{Available True 2021-03-24 11:46:25 +1300 NZDT Pas
sed all checks passed} {StatusUpdate True 0001-01-01 00:00:00 +0000 UTC E2E Set from e2e test}]                                                                               
Mar 24 11:46:26.831: INFO: APIService Status for v1alpha1.wardle.example.com has been updated                                                                                 
STEP: Patch APIService Status                                                                                                                                                 
STEP: watching for the APIService to be patched                                                                                                                               
Mar 24 11:46:26.837: INFO: Observed APIService v1alpha1.wardle.example.com with Labels: map[apiservice:patched] & Conditions: [{Available True 2021-03-24 11:46:25 +1300 NZDT 
Passed all checks passed} {StatusUpdate True 0001-01-01 00:00:00 +0000 UTC E2E Set from e2e test}]                                                                            
Mar 24 11:46:26.837: INFO: Observed APIService v1alpha1.wardle.example.com with Labels: map[apiservice:patched] & Conditions: [{Available True 2021-03-24 11:46:25 +1300 NZDT 
Passed all checks passed} {StatusUpdate True 0001-01-01 00:00:00 +0000 UTC E2E Set from e2e test}]                                                                            
Mar 24 11:46:26.837: INFO: Found APIService v1alpha1.wardle.example.com with Labels: map[apiservice:patched] & Conditions: [{StatusPatched True 0001-01-01 00:00:00 +0000 UTC 
 }]                                                                                                                                                                           
Mar 24 11:46:26.837: INFO: APIService Status for v1alpha1.wardle.example.com has been patched                                                                                 
Mar 24 11:46:26.860: FAIL: deleting flunders([{map[apiVersion:wardle.example.com/v1alpha1 kind:Flunder metadata:map[creationTimestamp:2021-03-23T22:46:26Z name:dynamic-flunde
r-782802333 namespace:aggregator-2521 resourceVersion:4 selfLink:/apis/wardle.example.com/v1alpha1/namespaces/aggregator-2521/flunders/dynamic-flunder-782802333 uid:566de910-
f6dd-4254-942c-43fadf284431] spec:map[] status:map[]]}]) using dynamic client but received unexpected error:                                                                  
the server is currently unable to handle the request 
```
#### Special notes for your reviewer:
This test flake was discussed in the conformance meeting (23 March) with the feedback that it is likely an issue with kubelet.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
NONE
```

/hold
/sig api-machinery



