### PR TITLE
Walk back on a sig-network conformance test

### DIFF
--- a/test/conformance/testdata/conformance.yaml
+++ b/test/conformance/testdata/conformance.yaml
@@ -1233,14 +1233,6 @@
     update, and delete actions.
   release: v1.21
   file: test/e2e/network/endpointslicemirroring.go
-- testname: Scheduling, HostPort matching and HostIP and Protocol not-matching
-  codename: '[sig-network] HostPort validates that there is no conflict between pods
-    with same hostPort but different hostIP and protocol [LinuxOnly] [Conformance]'
-  description: Pods with the same HostPort value MUST be able to be scheduled to the
-    same node if the HostIP or Protocol is different. This test is marked LinuxOnly
-    since hostNetwork is not supported on Windows.
-  release: v1.16, v1.21
-  file: test/e2e/network/hostport.go
 - testname: Ingress API
   codename: '[sig-network] Ingress API should support creating Ingress API operations
     [Conformance]'

--- a/test/e2e/network/hostport.go
+++ b/test/e2e/network/hostport.go
@@ -58,7 +58,7 @@ var _ = common.SIGDescribe("HostPort", func() {
 		Windows.
 	*/
 
-	framework.ConformanceIt("validates that there is no conflict between pods with same hostPort but different hostIP and protocol [LinuxOnly]", func() {
+	ginkgo.It("validates that there is no conflict between pods with same hostPort but different hostIP and protocol [LinuxOnly]", func() {
 
 		localhost := "127.0.0.1"
 		family := v1.IPv4Protocol


### PR DESCRIPTION
By definition, this test needs 2 different IPs on the same node. We cannot add this new
restriction that we never had before for a conformance test.

Found independently twice:
- https://github.com/cri-o/cri-o/pull/4526#issue-564289326
- https://github.com/kubernetes/kubernetes/pull/100509#issuecomment-805652836

Signed-off-by: Davanum Srinivas <davanum@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
