### PR TITLE
Automated cherry pick of #100254: apf: handle error from PollImmediateUntil

### DIFF
--- a/pkg/registry/flowcontrol/rest/storage_flowcontrol.go
+++ b/pkg/registry/flowcontrol/rest/storage_flowcontrol.go
@@ -100,7 +100,7 @@ func (p RESTStorageProvider) PostStartHook() (string, genericapiserver.PostStart
 		flowcontrolClientSet := flowcontrolclient.NewForConfigOrDie(hookContext.LoopbackClientConfig)
 		go func() {
 			const retryCreatingSuggestedSettingsInterval = time.Second
-			_ = wait.PollImmediateUntil(
+			err := wait.PollImmediateUntil(
 				retryCreatingSuggestedSettingsInterval,
 				func() (bool, error) {
 					should, err := shouldEnsureSuggested(flowcontrolClientSet)
@@ -122,6 +122,17 @@ func (p RESTStorageProvider) PostStartHook() (string, genericapiserver.PostStart
 					return true, nil
 				},
 				hookContext.StopCh)
+			if err != nil {
+				klog.ErrorS(err, "Ensuring suggested configuration failed")
+
+				// We should not attempt creation of mandatory objects if ensuring the suggested
+				// configuration resulted in an error.
+				// This only happens when the stop channel is closed.
+				// We rely on the presence of the "exempt" priority level configuration object in the cluster
+				// to indicate whether we should ensure suggested configuration.
+				return
+			}
+
 			const retryCreatingMandatorySettingsInterval = time.Minute
 			_ = wait.PollImmediateUntil(
 				retryCreatingMandatorySettingsInterval,
@@ -129,7 +140,7 @@ func (p RESTStorageProvider) PostStartHook() (string, genericapiserver.PostStart
 					if err := upgrade(
 						flowcontrolClientSet,
 						flowcontrolbootstrap.MandatoryFlowSchemas,
-						// Note: the "exempt" priority-level is supposed tobe the last item in the pre-defined
+						// Note: the "exempt" priority-level is supposed to be the last item in the pre-defined
 						// list, so that a crash in the midst of the first kube-apiserver startup does not prevent
 						// the full initial set of objects from being created.
 						flowcontrolbootstrap.MandatoryPriorityLevelConfigurations,


### PR DESCRIPTION
Cherry pick of #100254 on release-1.20.

#100254: apf: handle error from PollImmediateUntil

This bug is unlikely to occur but when it does the severity can be high, for more details see the explanation in the original PR: https://github.com/kubernetes/kubernetes/pull/100254#issuecomment-804353608
