### PR TITLE
Automated cherry pick of #98571: Stop probing a pod during graceful shutdown

### DIFF
--- a/pkg/kubelet/prober/worker_test.go
+++ b/pkg/kubelet/prober/worker_test.go
@@ -59,25 +59,47 @@ func TestDoProbe(t *testing.T) {
 		failedStatus.Phase = v1.PodFailed
 
 		tests := []struct {
-			probe          v1.Probe
-			podStatus      *v1.PodStatus
-			expectContinue bool
-			expectSet      bool
-			expectedResult results.Result
+			probe                v1.Probe
+			podStatus            *v1.PodStatus
+			expectContinue       map[string]bool
+			expectSet            bool
+			expectedResult       results.Result
+			setDeletionTimestamp bool
 		}{
 			{ // No status.
-				expectContinue: true,
+				expectContinue: map[string]bool{
+					liveness.String():  true,
+					readiness.String(): true,
+					startup.String():   true,
+				},
 			},
 			{ // Pod failed
 				podStatus: &failedStatus,
 			},
+			{ // Pod deletion
+				podStatus:            &runningStatus,
+				setDeletionTimestamp: true,
+				expectSet:            true,
+				expectContinue: map[string]bool{
+					readiness.String(): true,
+				},
+				expectedResult: results.Success,
+			},
 			{ // No container status
-				podStatus:      &otherStatus,
-				expectContinue: true,
+				podStatus: &otherStatus,
+				expectContinue: map[string]bool{
+					liveness.String():  true,
+					readiness.String(): true,
+					startup.String():   true,
+				},
 			},
 			{ // Container waiting
-				podStatus:      &pendingStatus,
-				expectContinue: true,
+				podStatus: &pendingStatus,
+				expectContinue: map[string]bool{
+					liveness.String():  true,
+					readiness.String(): true,
+					startup.String():   true,
+				},
 				expectSet:      true,
 				expectedResult: results.Failure,
 			},
@@ -87,8 +109,12 @@ func TestDoProbe(t *testing.T) {
 				expectedResult: results.Failure,
 			},
 			{ // Probe successful.
-				podStatus:      &runningStatus,
-				expectContinue: true,
+				podStatus: &runningStatus,
+				expectContinue: map[string]bool{
+					liveness.String():  true,
+					readiness.String(): true,
+					startup.String():   true,
+				},
 				expectSet:      true,
 				expectedResult: results.Success,
 			},
@@ -97,7 +123,11 @@ func TestDoProbe(t *testing.T) {
 				probe: v1.Probe{
 					InitialDelaySeconds: -100,
 				},
-				expectContinue: true,
+				expectContinue: map[string]bool{
+					liveness.String():  true,
+					readiness.String(): true,
+					startup.String():   true,
+				},
 				expectSet:      true,
 				expectedResult: results.Success,
 			},
@@ -108,8 +138,12 @@ func TestDoProbe(t *testing.T) {
 			if test.podStatus != nil {
 				m.statusManager.SetPodStatus(w.pod, *test.podStatus)
 			}
-			if c := w.doProbe(); c != test.expectContinue {
-				t.Errorf("[%s-%d] Expected continue to be %v but got %v", probeType, i, test.expectContinue, c)
+			if test.setDeletionTimestamp {
+				now := metav1.Now()
+				w.pod.ObjectMeta.DeletionTimestamp = &now
+			}
+			if c := w.doProbe(); c != test.expectContinue[probeType.String()] {
+				t.Errorf("[%s-%d] Expected continue to be %v but got %v", probeType, i, test.expectContinue[probeType.String()], c)
 			}
 			result, ok := resultsManager(m, probeType).Get(testContainerID)
 			if ok != test.expectSet {
@@ -301,6 +335,12 @@ func expectContinue(t *testing.T, w *worker, c bool, msg string) {
 	}
 }
 
+func expectStop(t *testing.T, w *worker, c bool, msg string) {
+	if c {
+		t.Errorf("[%s - %s] Expected to stop, but did not", w.probeType, msg)
+	}
+}
+
 func resultsManager(m *manager, probeType probeType) results.Manager {
 	switch probeType {
 	case readiness:
@@ -470,6 +510,6 @@ func TestStartupProbeDisabledByStarted(t *testing.T) {
 	// startupProbe fails, but is disabled
 	m.prober.exec = fakeExecProber{probe.Failure, nil}
 	msg = "Started, probe failure, result success"
-	expectContinue(t, w, w.doProbe(), msg)
+	expectStop(t, w, w.doProbe(), msg)
 	expectResult(t, w, results.Success, msg)
 }


### PR DESCRIPTION
Cherry pick of #98571 on release-1.18.

#98571: Stop probing a pod during graceful shutdown

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.