### PR TITLE
e2e: reduce pods used in shared local pv test

### DIFF
--- a/test/e2e/storage/persistent_volumes-local.go
+++ b/test/e2e/storage/persistent_volumes-local.go
@@ -658,7 +658,7 @@ var _ = utils.SIGDescribe("PersistentVolumes-local ", func() {
 			var (
 				pvc   *v1.PersistentVolumeClaim
 				pods  = map[string]*v1.Pod{}
-				count = 50
+				count = 2
 				err   error
 			)
 			pvc = e2epv.MakePersistentVolumeClaim(makeLocalPVCConfig(config, DirectoryLocalVolumeType), config.ns)


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
This test currently starts 50 pods to share a local PV.  However, there is no rationale in the original PR (https://github.com/kubernetes/kubernetes/pull/74716) for the choice of this number.

All 50 of these pods start on the some node causing unneeded heavy load.

It seems to me, the point of the test is just to ensure that two pods sharing the same local PV can schedule and run on the node.

Thus, this PR reduces the number of test pods to 2.

```release-note
NONE
```