### PR TITLE
kube-apiserver --advertise-port to make kube-apiserver compatible with proxy on control-plane nodes

### DIFF
--- a/cmd/kube-apiserver/app/options/options_test.go
+++ b/cmd/kube-apiserver/app/options/options_test.go
@@ -52,6 +52,7 @@ func TestAddFlags(t *testing.T) {
 		"--enable-admission-plugins=AlwaysDeny",
 		"--admission-control-config-file=/admission-control-config",
 		"--advertise-address=192.168.10.10",
+		"--advertise-port=6443",
 		"--allow-privileged=false",
 		"--anonymous-auth=false",
 		"--apiserver-count=5",
@@ -129,6 +130,7 @@ func TestAddFlags(t *testing.T) {
 		AllowPrivileged:        false,
 		GenericServerRunOptions: &apiserveroptions.ServerRunOptions{
 			AdvertiseAddress:            net.ParseIP("192.168.10.10"),
+			AdvertisePort:               6443,
 			CorsAllowedOriginList:       []string{"10.10.10.100", "10.10.10.200"},
 			MaxRequestsInFlight:         400,
 			MaxMutatingRequestsInFlight: 200,

--- a/pkg/controlplane/controller.go
+++ b/pkg/controlplane/controller.go
@@ -91,6 +91,10 @@ func (c *completedConfig) NewBootstrapController(legacyRESTStorage corerest.Lega
 		klog.Fatalf("failed to get listener address: %v", err)
 	}
 
+	if c.GenericConfig.AdvertisePort > 0 {
+		publicServicePort = int(c.GenericConfig.AdvertisePort)
+	}
+
 	systemNamespaces := []string{metav1.NamespaceSystem, metav1.NamespacePublic, corev1.NamespaceNodeLease}
 
 	return &Controller{

--- a/staging/src/k8s.io/apiserver/pkg/server/config.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/config.go
@@ -215,6 +215,10 @@ type Config struct {
 	// If not specify any in flags, then genericapiserver will only enable defaultAPIResourceConfig.
 	MergedResourceConfig *serverstore.ResourceConfig
 
+	// AdvertisePort is used when the targetPort and port used in the kubernetes.default.svc service and
+	// endpoint is different than the one used for binding. This configuration is needed in case of a front proxy is
+	// used in front of kube-apiserver
+	AdvertisePort int
 	//===========================================================================
 	// values below here are targets for removal
 	//===========================================================================

--- a/staging/src/k8s.io/apiserver/pkg/server/options/server_run_options.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/server_run_options.go
@@ -34,6 +34,7 @@ import (
 // ServerRunOptions contains the options while running a generic api server.
 type ServerRunOptions struct {
 	AdvertiseAddress net.IP
+	AdvertisePort    int
 
 	CorsAllowedOriginList       []string
 	HSTSDirectives              []string
@@ -86,7 +87,7 @@ func (s *ServerRunOptions) ApplyTo(c *server.Config) error {
 	c.JSONPatchMaxCopyBytes = s.JSONPatchMaxCopyBytes
 	c.MaxRequestBodyBytes = s.MaxRequestBodyBytes
 	c.PublicAddress = s.AdvertiseAddress
-
+	c.AdvertisePort = s.AdvertisePort
 	return nil
 }
 
@@ -112,6 +113,9 @@ func (s *ServerRunOptions) DefaultAdvertiseAddress(secure *SecureServingOptions)
 func (s *ServerRunOptions) Validate() []error {
 	errors := []error{}
 
+	if s.AdvertisePort < 0 || s.AdvertisePort > 65535 {
+		errors = append(errors, fmt.Errorf("--advertise-port %v must be between 0 and 65535, inclusive. 0 for turning off", s.AdvertisePort))
+	}
 	if s.LivezGracePeriod < 0 {
 		errors = append(errors, fmt.Errorf("--livez-grace-period can not be a negative value"))
 	}
@@ -182,6 +186,10 @@ func (s *ServerRunOptions) AddUniversalFlags(fs *pflag.FlagSet) {
 		"address must be reachable by the rest of the cluster. If blank, the --bind-address "+
 		"will be used. If --bind-address is unspecified, the host's default interface will "+
 		"be used.")
+
+	fs.IntVar(&s.AdvertisePort, "advertise-port", s.AdvertisePort, ""+
+		"The targetPort used in the kubernetes.default.svc service and the port used in the "+
+		"connected endpoint object. If not specified the --secure-port or --port is used")
 
 	fs.StringSliceVar(&s.CorsAllowedOriginList, "cors-allowed-origins", s.CorsAllowedOriginList, ""+
 		"List of allowed origins for CORS, comma separated.  An allowed origin can be a regular "+

--- a/staging/src/k8s.io/apiserver/pkg/server/options/server_run_options_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/server_run_options_test.go
@@ -35,6 +35,7 @@ func TestServerRunOptionsValidate(t *testing.T) {
 			name: "Test when MaxRequestsInFlight is negative value",
 			testOptions: &ServerRunOptions{
 				AdvertiseAddress:            net.ParseIP("192.168.10.10"),
+				AdvertisePort:               443,
 				CorsAllowedOriginList:       []string{"10.10.10.100", "10.10.10.200"},
 				MaxRequestsInFlight:         -400,
 				MaxMutatingRequestsInFlight: 200,
@@ -49,6 +50,7 @@ func TestServerRunOptionsValidate(t *testing.T) {
 			name: "Test when MaxMutatingRequestsInFlight is negative value",
 			testOptions: &ServerRunOptions{
 				AdvertiseAddress:            net.ParseIP("192.168.10.10"),
+				AdvertisePort:               443,
 				CorsAllowedOriginList:       []string{"10.10.10.100", "10.10.10.200"},
 				MaxRequestsInFlight:         400,
 				MaxMutatingRequestsInFlight: -200,
@@ -63,6 +65,7 @@ func TestServerRunOptionsValidate(t *testing.T) {
 			name: "Test when RequestTimeout is negative value",
 			testOptions: &ServerRunOptions{
 				AdvertiseAddress:            net.ParseIP("192.168.10.10"),
+				AdvertisePort:               443,
 				CorsAllowedOriginList:       []string{"10.10.10.100", "10.10.10.200"},
 				MaxRequestsInFlight:         400,
 				MaxMutatingRequestsInFlight: 200,
@@ -77,6 +80,7 @@ func TestServerRunOptionsValidate(t *testing.T) {
 			name: "Test when MinRequestTimeout is negative value",
 			testOptions: &ServerRunOptions{
 				AdvertiseAddress:            net.ParseIP("192.168.10.10"),
+				AdvertisePort:               443,
 				CorsAllowedOriginList:       []string{"10.10.10.100", "10.10.10.200"},
 				MaxRequestsInFlight:         400,
 				MaxMutatingRequestsInFlight: 200,
@@ -91,6 +95,7 @@ func TestServerRunOptionsValidate(t *testing.T) {
 			name: "Test when JSONPatchMaxCopyBytes is negative value",
 			testOptions: &ServerRunOptions{
 				AdvertiseAddress:            net.ParseIP("192.168.10.10"),
+				AdvertisePort:               443,
 				CorsAllowedOriginList:       []string{"10.10.10.100", "10.10.10.200"},
 				MaxRequestsInFlight:         400,
 				MaxMutatingRequestsInFlight: 200,
@@ -105,6 +110,7 @@ func TestServerRunOptionsValidate(t *testing.T) {
 			name: "Test when MaxRequestBodyBytes is negative value",
 			testOptions: &ServerRunOptions{
 				AdvertiseAddress:            net.ParseIP("192.168.10.10"),
+				AdvertisePort:               443,
 				CorsAllowedOriginList:       []string{"10.10.10.100", "10.10.10.200"},
 				MaxRequestsInFlight:         400,
 				MaxMutatingRequestsInFlight: 200,
@@ -119,6 +125,7 @@ func TestServerRunOptionsValidate(t *testing.T) {
 			name: "Test when LivezGracePeriod is negative value",
 			testOptions: &ServerRunOptions{
 				AdvertiseAddress:            net.ParseIP("192.168.10.10"),
+				AdvertisePort:               443,
 				CorsAllowedOriginList:       []string{"10.10.10.100", "10.10.10.200"},
 				MaxRequestsInFlight:         400,
 				MaxMutatingRequestsInFlight: 200,
@@ -134,6 +141,7 @@ func TestServerRunOptionsValidate(t *testing.T) {
 			name: "Test when MinimalShutdownDuration is negative value",
 			testOptions: &ServerRunOptions{
 				AdvertiseAddress:            net.ParseIP("192.168.10.10"),
+				AdvertisePort:               443,
 				CorsAllowedOriginList:       []string{"10.10.10.100", "10.10.10.200"},
 				MaxRequestsInFlight:         400,
 				MaxMutatingRequestsInFlight: 200,
@@ -146,9 +154,11 @@ func TestServerRunOptionsValidate(t *testing.T) {
 			expectErr: "--shutdown-delay-duration can not be negative value",
 		},
 		{
+
 			name: "Test when HSTSHeaders is valid",
 			testOptions: &ServerRunOptions{
 				AdvertiseAddress:            net.ParseIP("192.168.10.10"),
+				AdvertisePort:               443,
 				CorsAllowedOriginList:       []string{"10.10.10.100", "10.10.10.200"},
 				HSTSDirectives:              []string{"fakevalue", "includeSubDomains", "preload"},
 				MaxRequestsInFlight:         400,
@@ -161,9 +171,26 @@ func TestServerRunOptionsValidate(t *testing.T) {
 			expectErr: "--strict-transport-security-directives invalid, allowed values: max-age=expireTime, includeSubDomains, preload. see https://tools.ietf.org/html/rfc6797#section-6.1 for more information",
 		},
 		{
+			name: "Test when AdvertisePort is too high value",
+			testOptions: &ServerRunOptions{
+				AdvertiseAddress:            net.ParseIP("192.168.10.10"),
+				AdvertisePort:               843235,
+				CorsAllowedOriginList:       []string{"10.10.10.100", "10.10.10.200"},
+				MaxRequestsInFlight:         400,
+				MaxMutatingRequestsInFlight: 200,
+				RequestTimeout:              time.Duration(2) * time.Minute,
+				MinRequestTimeout:           1800,
+				JSONPatchMaxCopyBytes:       10 * 1024 * 1024,
+				MaxRequestBodyBytes:         10 * 1024 * 1024,
+				ShutdownDelayDuration:       -time.Second,
+			},
+			expectErr: "--advertise-port 843235 must be between 0 and 65535, inclusive. 0 for turning off",
+		},
+		{
 			name: "Test when ServerRunOptions is valid",
 			testOptions: &ServerRunOptions{
 				AdvertiseAddress:            net.ParseIP("192.168.10.10"),
+				AdvertisePort:               443,
 				CorsAllowedOriginList:       []string{"10.10.10.100", "10.10.10.200"},
 				HSTSDirectives:              []string{"max-age=31536000", "includeSubDomains", "preload"},
 				MaxRequestsInFlight:         400,

--- a/test/integration/master/kube_apiserver_test.go
+++ b/test/integration/master/kube_apiserver_test.go
@@ -427,6 +427,26 @@ func getEndpointIPs(endpoints *corev1.Endpoints) []string {
 	return ips
 }
 
+// getEndpointPorts returns all the ports declared in an endpoints object
+func getEndpointPorts(endpoints *corev1.Endpoints) []int {
+	ports := make([]int, 0)
+	for _, subset := range endpoints.Subsets {
+		for _, port := range subset.Ports {
+			ports = append(ports, int(port.Port))
+		}
+	}
+	return ports
+}
+
+// getServiceTargetPorts returns all the targetPorts declared in a service object
+func getServiceTargetPorts(services *corev1.Service) []int {
+	ports := make([]int, 0)
+	for _, port := range services.Spec.Ports {
+		ports = append(ports, port.TargetPort.IntValue())
+	}
+	return ports
+}
+
 func verifyEndpointsWithIPs(servers []*kubeapiservertesting.TestServer, ips []string) bool {
 	listenAddresses := make([]string, 0)
 	for _, server := range servers {
@@ -609,6 +629,133 @@ func TestMultiMasterNodePortAllocation(t *testing.T) {
 		// Delete the service using the second API server
 		if err := clientAPIServers[1].CoreV1().Services(metav1.NamespaceDefault).Delete(context.TODO(), serviceObject.ObjectMeta.Name, metav1.DeleteOptions{}); err != nil {
 			t.Fatalf("got unexpected error: %v", err)
+		}
+	}
+
+	// shutdown the api servers
+	for _, server := range kubeAPIServers {
+		server.TearDownFn()
+	}
+
+}
+
+// TestMultiMasterDefaultPort tests that the bind port of the kube-apiserver is then used as targetPort in the kubernetes.default.svc server
+// and also as port in the kubernetes.default.svc endpoints
+func TestMultiMasterDefaultPort(t *testing.T) {
+	var kubeAPIServers []*kubeapiservertesting.TestServer
+	var clientAPIServers []*kubernetes.Clientset
+	etcd := framework.SharedEtcd()
+
+	instanceOptions := &kubeapiservertesting.TestServerInstanceOptions{
+		DisableStorageCleanup: true,
+	}
+
+	// cleanup the registry storage
+	defer registry.CleanupStorage()
+
+	// create 1 api servers and 1 clients: cannot test with multiple ones because then there would be a conflict as each one has a different bind port configured
+	for i := 0; i < 1; i++ {
+		// start master count api server
+		t.Logf("starting api server: %d", i)
+		server := kubeapiservertesting.StartTestServerOrDie(t, instanceOptions, []string{
+			"--endpoint-reconciler-type", "lease",
+			"--advertise-address", fmt.Sprintf("10.0.1.%v", i+1),
+		}, etcd)
+		kubeAPIServers = append(kubeAPIServers, server)
+
+		// verify kube API servers have registered and create a client
+		if err := wait.PollImmediate(3*time.Second, 2*time.Minute, func() (bool, error) {
+			client, err := kubernetes.NewForConfig(kubeAPIServers[i].ClientConfig)
+			if err != nil {
+				t.Logf("create client error: %v", err)
+				return false, nil
+			}
+			clientAPIServers = append(clientAPIServers, client)
+			services, err := client.CoreV1().Services("default").Get(context.TODO(), "kubernetes", metav1.GetOptions{})
+			if err != nil {
+				t.Logf("error fetching services: %v", err)
+				return false, nil
+			}
+			if !reflect.DeepEqual([]int{server.ServerOpts.SecureServing.BindPort}, getServiceTargetPorts(services)) {
+				t.Logf("error comparing target port in services with bind port set: Bind port %v vs targetPort %v", server.ServerOpts.SecureServing.BindPort, getServiceTargetPorts(services))
+				return false, nil
+			}
+			endpoints, err := client.CoreV1().Endpoints("default").Get(context.TODO(), "kubernetes", metav1.GetOptions{})
+			if err != nil {
+				t.Logf("error fetching endpoints: %v", err)
+				return false, nil
+			}
+			if !reflect.DeepEqual([]int{server.ServerOpts.SecureServing.BindPort}, getEndpointPorts(endpoints)) {
+				t.Logf("error comparing endpoints port with advertise-port: %v", getEndpointPorts(endpoints))
+				return false, nil
+			}
+			return true, nil
+		}); err != nil {
+			t.Fatalf("did not find only lease endpoints: %v", err)
+		}
+	}
+
+	// shutdown the api servers
+	for _, server := range kubeAPIServers {
+		server.TearDownFn()
+	}
+
+}
+
+// TestMultiMasterAdvertisePort tests that when using the --advertise-port the targetPort in the kubernetes.default.svc server
+// and also as port in the kubernetes.default.svc endpoints and it's the value specified there
+func TestMultiMasterAdvertisePort(t *testing.T) {
+	var kubeAPIServers []*kubeapiservertesting.TestServer
+	var clientAPIServers []*kubernetes.Clientset
+	etcd := framework.SharedEtcd()
+
+	instanceOptions := &kubeapiservertesting.TestServerInstanceOptions{
+		DisableStorageCleanup: true,
+	}
+
+	// cleanup the registry storage
+	defer registry.CleanupStorage()
+
+	// create 2 api servers and 2 clients
+	for i := 0; i < 2; i++ {
+		// start master count api server
+		t.Logf("starting api server: %d", i)
+		server := kubeapiservertesting.StartTestServerOrDie(t, instanceOptions, []string{
+			"--endpoint-reconciler-type", "lease",
+			"--advertise-address", fmt.Sprintf("10.0.1.%v", i+1),
+			"--advertise-port", "8443",
+		}, etcd)
+		kubeAPIServers = append(kubeAPIServers, server)
+
+		// verify kube API servers have registered and create a client
+		if err := wait.PollImmediate(3*time.Second, 2*time.Minute, func() (bool, error) {
+			client, err := kubernetes.NewForConfig(kubeAPIServers[i].ClientConfig)
+			if err != nil {
+				t.Logf("create client error: %v", err)
+				return false, nil
+			}
+			clientAPIServers = append(clientAPIServers, client)
+			services, err := client.CoreV1().Services("default").Get(context.TODO(), "kubernetes", metav1.GetOptions{})
+			if err != nil {
+				t.Logf("error fetching services: %v", err)
+				return false, nil
+			}
+			if !reflect.DeepEqual([]int{server.ServerOpts.GenericServerRunOptions.AdvertisePort}, getServiceTargetPorts(services)) {
+				t.Logf("error comparing target port in services with advertise-port set: %v", getServiceTargetPorts(services))
+				return false, nil
+			}
+			endpoints, err := client.CoreV1().Endpoints("default").Get(context.TODO(), "kubernetes", metav1.GetOptions{})
+			if err != nil {
+				t.Logf("error fetching endpoints: %v", err)
+				return false, nil
+			}
+			if !reflect.DeepEqual([]int{server.ServerOpts.GenericServerRunOptions.AdvertisePort}, getEndpointPorts(endpoints)) {
+				t.Logf("error comparing endpoints port with advertise-port: %v", getEndpointPorts(endpoints))
+				return false, nil
+			}
+			return true, nil
+		}); err != nil {
+			t.Fatalf("did not find only lease endpoints: %v", err)
 		}
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
When running a proxy (authenticating or not) on the same node of the kube-apiserver it's necessary to specifify the port that will be used in the kubernetes.default.svc service and endpoints because it might be different than the one used for binding

For example: kube-apiserver might be binded to 127.0.0.1:9443 and the proxy to 0.0.0.0:6443 


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
added --advertise-port on kube-apiserver to use in case the port used to access the kube-apiserver service is different than the one used to bind the process to
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

