### PR TITLE
Remove SELinuxOptions double setup in pod spec

### DIFF
--- a/test/e2e/framework/pod/create.go
+++ b/test/e2e/framework/pod/create.go
@@ -249,9 +249,6 @@ func MakePodSpec(podConfig *Config) *v1.PodSpec {
 	podSpec.Containers[0].VolumeMounts = volumeMounts
 	podSpec.Containers[0].VolumeDevices = volumeDevices
 	podSpec.Volumes = volumes
-	if runtime.GOOS != "windows" {
-		podSpec.SecurityContext.SELinuxOptions = podConfig.SeLinuxLabel
-	}
 
 	SetNodeSelection(podSpec, podConfig.NodeSelection)
 	return podSpec


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area test

#### What this PR does / why we need it:

In the pod spec setup for tests removes configuration options on the pod that were set before, ref https://github.com/kubernetes/kubernetes/pull/99888/files#r596637806


#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

/cc @jingxu97 