### PR TITLE
add a verify equivilant to prometheus visibility rules

### DIFF
--- a/hack/verify-prometheus-imports.sh
+++ b/hack/verify-prometheus-imports.sh
@@ -1,0 +1,144 @@
+#!/usr/bin/env bash
+
+# Copyright 2021 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This script validates that only a restricted set of packages are importing
+# github.com/prometheus/*
+
+# NOTE: this is not the same as verify-imports which can only verify
+# that within a particular package the imports made are allowed.
+#
+# This is also not the same thing as verify-import-boss, which is pretty
+# powerful for specifying restricted imports but does not scale to checking
+# the entire source tree well and is only enabled for specific packages.
+#
+# See: https://github.com/kubernetes/kubernetes/issues/99876
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+KUBE_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
+source "${KUBE_ROOT}/hack/lib/init.sh"
+source "${KUBE_ROOT}/hack/lib/util.sh"
+
+# See: https://github.com/kubernetes/kubernetes/issues/89267
+allowed_prometheus_importers=(
+  ./cluster/images/etcd-version-monitor/etcd-version-monitor.go
+  ./pkg/volume/util/operationexecutor/operation_generator_test.go
+  ./staging/src/k8s.io/component-base/metrics/collector.go
+  ./staging/src/k8s.io/component-base/metrics/collector_test.go
+  ./staging/src/k8s.io/component-base/metrics/counter.go
+  ./staging/src/k8s.io/component-base/metrics/counter_test.go
+  ./staging/src/k8s.io/component-base/metrics/desc.go
+  ./staging/src/k8s.io/component-base/metrics/gauge.go
+  ./staging/src/k8s.io/component-base/metrics/gauge_test.go
+  ./staging/src/k8s.io/component-base/metrics/histogram.go
+  ./staging/src/k8s.io/component-base/metrics/histogram_test.go
+  ./staging/src/k8s.io/component-base/metrics/http.go
+  ./staging/src/k8s.io/component-base/metrics/labels.go
+  ./staging/src/k8s.io/component-base/metrics/legacyregistry/registry.go
+  ./staging/src/k8s.io/component-base/metrics/metric.go
+  ./staging/src/k8s.io/component-base/metrics/opts.go
+  ./staging/src/k8s.io/component-base/metrics/processstarttime_others.go
+  ./staging/src/k8s.io/component-base/metrics/registry.go
+  ./staging/src/k8s.io/component-base/metrics/registry_test.go
+  ./staging/src/k8s.io/component-base/metrics/summary.go
+  ./staging/src/k8s.io/component-base/metrics/testutil/metrics.go
+  ./staging/src/k8s.io/component-base/metrics/testutil/metrics_test.go
+  ./staging/src/k8s.io/component-base/metrics/testutil/promlint.go
+  ./staging/src/k8s.io/component-base/metrics/testutil/testutil.go
+  ./staging/src/k8s.io/component-base/metrics/value.go
+  ./staging/src/k8s.io/component-base/metrics/wrappers.go
+  ./test/e2e/apimachinery/flowcontrol.go
+  ./test/e2e_node/dynamic_kubelet_config_test.go
+  ./test/e2e_node/resource_metrics_test.go
+  ./test/instrumentation/main_test.go
+  ./test/integration/apiserver/flowcontrol/concurrency_test.go
+  ./test/integration/metrics/metrics_test.go
+)
+
+# Go imports always involve a double quoted string of the package path
+# https://golang.org/ref/spec#Import_declarations
+#
+# If you *really* need a string literal that looks like "github.com/prometheus/.*"
+# somewhere else that actually isn't an import, you can use backticks / a raw 
+# string literal instead (which cannot be used in imports, only double quotes).
+#
+# NOTE: we previously had an implementation that checked for an actual import
+# as a post-processing step on the matching files, which is cheap enough and
+# accurate, except that it's difficult to guarantee we check for all supported
+# GOOS, GOARCH, and other build tags, and we want to prevent all imports.
+# So we dropped this, in favor of only the grep call.
+# See: https://github.com/kubernetes/kubernetes/pull/100552
+really_failing_files=()
+all_failing_files=()
+while IFS='' read -r filepath; do
+  # convert from file to package, and only insert unique results
+  # we want to minimize the amount of `go list` calls we need to make
+  if ! kube::util::array_contains "$filepath" "${allowed_prometheus_importers[@]}"; then
+    # record a failure if not
+    really_failing_files+=("$filepath")
+  fi
+  all_failing_files+=("$filepath")
+done < <(cd "${KUBE_ROOT}" && grep \
+  --exclude-dir={_output,vendor} \
+  --include='*.go' \
+  -R . \
+  -l \
+  -Ee '"github.com/prometheus/.*"' \
+| LC_ALL=C sort -u)
+
+# check for any files we're allowing to fail that are no longer failing, so we
+# can enforce that the list shrinks
+allowed_but_not_failing=()
+for allowed_file in "${allowed_prometheus_importers[@]}"; do
+  if ! kube::util::array_contains "$allowed_file" "${all_failing_files[@]}"; then
+    allowed_but_not_failing+=("$allowed_file")
+  fi
+done
+
+# we will exit with this at the end of the script depending on the checks below
+exit_code=0
+
+# check for files we've allow-listed that no longer need to be
+if [ -n "${allowed_but_not_failing[*]}" ]; then
+  {
+    echo "ERROR: Some files allow-listed to import prometheus are no longer failing and should be removed."
+    echo "Please remove these files from allowed_prometheus_importers in hack/verify-prometheus-imports.sh"
+    echo ""
+    echo "Non-failing but allow-listed files:"
+    for non_failing_file in "${allowed_but_not_failing[@]}"; do
+      echo "  ${non_failing_file}"
+    done
+  } >&2
+  exit_code=1
+fi
+# check for files that fail but are not allow-listed
+if [ -n "${really_failing_files[*]}" ]; then
+  {
+    echo "ERROR: Some files are importing packages under github.com/prometheus/* but are not allow-listed to do so."
+    echo ""
+    echo "See: https://github.com/kubernetes/kubernetes/issues/89267"
+    echo ""
+    echo "Failing files:"
+    for failing_file in "${really_failing_files[@]}"; do
+      echo "  ${failing_file}"
+    done
+  } >&2
+  exit_code=2
+fi
+
+exit "$exit_code"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug
(we should have been enforcing this, the previous solution was lost in https://github.com/kubernetes/kubernetes/pull/99561)

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Efficiently ensures that prometheus imports remain restricted per https://github.com/kubernetes/kubernetes/issues/89267 following the removal of bazel and visibility rules.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes/kubernetes/issues/99876

#### Special notes for your reviewer:

We do have multiple other tools for validating imports, unfortunately none of them are suitable for this task, there's more on this in the script comments.

The short version: `verify-imports` is not capable of handling for this use case and is intended to restrict the imports _within_ a package while `verify-import-boss` can technically express this but is far too expensive to run over the entire source tree and only checks specific directories.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- [KEP]: https://github.com/kubernetes/enhancements/issues/2420
```

/sig testing instrumentation
/triage accepted