### PR TITLE
job controller: don't mutate shared cache object

### DIFF
--- a/pkg/controller/job/job_controller.go
+++ b/pkg/controller/job/job_controller.go
@@ -462,7 +462,8 @@ func (jm *Controller) syncJob(key string) (bool, error) {
 		}
 		return false, err
 	}
-	job := *sharedJob
+	// make a copy so we don't mutate the shared cache
+	job := *sharedJob.DeepCopy()
 
 	// if job was finished previously, we don't want to redo the termination
 	if IsJobFinished(&job) {

--- a/test/integration/job/job_test.go
+++ b/test/integration/job/job_test.go
@@ -278,7 +278,6 @@ func TestSuspendJob(t *testing.T) {
 		wantReason string
 	}
 	testCases := []struct {
-		short       bool
 		featureGate bool
 		create      step
 		update      step
@@ -286,7 +285,6 @@ func TestSuspendJob(t *testing.T) {
 		// Exhaustively test all combinations other than trivial true->true and
 		// false->false cases.
 		{
-			short:       true,
 			featureGate: true,
 			create:      step{flag: false, wantActive: 2},
 			update:      step{flag: true, wantActive: 0, wantStatus: v1.ConditionTrue, wantReason: "Suspended"},
@@ -311,9 +309,6 @@ func TestSuspendJob(t *testing.T) {
 	for _, tc := range testCases {
 		name := fmt.Sprintf("feature=%v,create=%v,update=%v", tc.featureGate, tc.create.flag, tc.update.flag)
 		t.Run(name, func(t *testing.T) {
-			if testing.Short() && !tc.short {
-				t.Skip("skipping expensive subtest")
-			}
 			defer featuregatetesting.SetFeatureGateDuringTest(t, feature.DefaultFeatureGate, features.SuspendJob, tc.featureGate)()
 
 			closeFn, restConfig, clientSet, ns := setup(t, "suspend")


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind failing-test

#### What this PR does / why we need it:

The Job controller has been mutating the shared cache for a loooong time, but I guess no one noticed this. When I tried to reproduce the failing integration test report https://github.com/kubernetes/kubernetes/issues/100551 locally, after several hours of very frustrating debugging, I noticed the mutation detector catching this bug. I believe this is also the true root cause of this bug, so to confirm this, I've modified the TestSuspendJob integration test to run _all_ subtests in pre-submit (previously, only the first subtest was run in pre-submit, the others were run in post-submit). If this PR's CI signals are green, we should be good.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #100551

#### Special notes for your reviewer:

/cc @alculquicondor @soltysh @ahg-g 
/sig apps

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
