### PR TITLE
Label provisioned GCE PDs with cluster ID

### DIFF
--- a/pkg/volume/gcepd/attacher_test.go
+++ b/pkg/volume/gcepd/attacher_test.go
@@ -597,12 +597,12 @@ func (testcase *testcase) BulkDisksAreAttached(diskByNodes map[types.NodeName][]
 	return verifiedDisksByNodes, nil
 }
 
-func (testcase *testcase) CreateDisk(name string, diskType string, zone string, sizeGb int64, tags map[string]string) (*gce.Disk, error) {
-	return nil, errors.New("not implemented")
+func (testcase *testcase) CreateDisk(name string, diskType string, zone string, sizeGb int64, tags map[string]string, labels map[string]string) (*gce.Disk, error) {
+	return nil, errors.New("Not implemented")
 }
 
-func (testcase *testcase) CreateRegionalDisk(name string, diskType string, replicaZones sets.String, sizeGb int64, tags map[string]string) (*gce.Disk, error) {
-	return nil, errors.New("not implemented")
+func (testcase *testcase) CreateRegionalDisk(name string, diskType string, replicaZones sets.String, sizeGb int64, tags map[string]string, labels map[string]string) (*gce.Disk, error) {
+	return nil, errors.New("Not implemented")
 }
 
 func (testcase *testcase) DeleteDisk(diskToDelete string) error {

--- a/test/e2e/framework/providers/gce/gce.go
+++ b/test/e2e/framework/providers/gce/gce.go
@@ -238,7 +238,8 @@ func (p *Provider) CreatePD(zone string) (string, error) {
 	}
 
 	tags := map[string]string{}
-	if _, err := p.gceCloud.CreateDisk(pdName, gcecloud.DiskTypeStandard, zone, 2 /* sizeGb */, tags); err != nil {
+	labels := map[string]string{}
+	if _, err := p.gceCloud.CreateDisk(pdName, gcecloud.DiskTypeStandard, zone, 2 /* sizeGb */, tags, labels); err != nil {
 		return "", err
 	}
 	return pdName, nil


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
This makes the newly provisioned GCE disks to be labelled byt the 'kubernetes-io-<Cluster ID> = "owned"' label. It makes it easier to identify "leaked" resources after the cluster is taken down. The disks are currently prefixed with the cluster name but since there is a limit imposed on the name length it might (and sometimes gets) truncated causing any mechanism relying on the PD names to correspond to cluster name unreliable

#### Special notes for your reviewer:
I understand the code I'm changing is deprecated. I consider the change to be small and useful enough to be considered for inclusion.

#### Does this PR introduce a user-facing change?
```release-note
The dynamically provisioned disks in GCE are automatically labelled with 'kubernetes-io-<Cluster ID> = "owned"' label.
```
