### PR TITLE
use a non-deprecated API to check kube-proxy

### DIFF
--- a/test/cmd/proxy.sh
+++ b/test/cmd/proxy.sh
@@ -38,7 +38,7 @@ run_kubectl_local_proxy_tests() {
   # Make sure the in-development api is accessible by default
   start-proxy
   check-curl-proxy-code /apis 200
-  check-curl-proxy-code /apis/extensions/ 200
+  check-curl-proxy-code /apis/apps/ 200
   stop-proxy
 
   # Custom paths let you see everything.


### PR DESCRIPTION
found in https://github.com/kubernetes/kubernetes/pull/99840

This caused `For address 127.0.0.1:42049/apis/extensions/, got 404 but wanted 200` which failed integration tests.