### PR TITLE
Update image base to `gcr.io/distroless/base-debian10:latest`

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/artifacts/simple-image/Dockerfile
+++ b/staging/src/k8s.io/apiextensions-apiserver/artifacts/simple-image/Dockerfile
@@ -12,6 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM gcr.io/distroless/base:latest
+FROM gcr.io/distroless/base-debian10:latest
 ADD apiextensions-apiserver /
 ENTRYPOINT ["/apiextensions-apiserver"]


### PR DESCRIPTION
This change:
* Updates the base image be based on `buster` (vs. the default `stretch`)
* Consumes the fix for [CVE-2021-3449](https://security-tracker.debian.org/tracker/CVE-2021-3449) in https://github.com/GoogleContainerTools/distroless/pull/700

/kind bug

```release-note
NONE
```