### PR TITLE
Migrate pkg/util/node logs to structured logging

### DIFF
--- a/pkg/util/node/node.go
+++ b/pkg/util/node/node.go
@@ -158,18 +158,18 @@ func GetNodeIP(client clientset.Interface, name string) net.IP {
 	err := wait.ExponentialBackoff(backoff, func() (bool, error) {
 		node, err := client.CoreV1().Nodes().Get(context.TODO(), name, metav1.GetOptions{})
 		if err != nil {
-			klog.Errorf("Failed to retrieve node info: %v", err)
+			klog.ErrorS(err,"Failed to retrieve node info")
 			return false, nil
 		}
 		nodeIP, err = GetNodeHostIP(node)
 		if err != nil {
-			klog.Errorf("Failed to retrieve node IP: %v", err)
+			klog.ErrorS(err,"Failed to retrieve node IP")
 			return false, err
 		}
 		return true, nil
 	})
 	if err == nil {
-		klog.Infof("Successfully retrieved node IP: %v", nodeIP)
+		klog.InfoS("Successfully retrieved node IP", "nodeIP", nodeIP)
 	}
 	return nodeIP
 }
@@ -284,7 +284,7 @@ func PatchNodeCIDRs(c clientset.Interface, node types.NodeName, cidrs []string) 
 	if err != nil {
 		return fmt.Errorf("failed to json.Marshal CIDR: %v", err)
 	}
-	klog.V(4).Infof("cidrs patch bytes are:%s", string(patchBytes))
+	klog.V(4).InfoS("Success to json.Marshal cidrs patch", "patchBytes", string(patchBytes))
 	if _, err := c.CoreV1().Nodes().Patch(context.TODO(), string(node), types.StrategicMergePatchType, patchBytes, metav1.PatchOptions{}); err != nil {
 		return fmt.Errorf("failed to patch node CIDR: %v", err)
 	}


### PR DESCRIPTION
in pkg/util/node/node.go

- log event of 'Failed to retrieve node info'

in pkg/util/node/node.go

- log event of 'Failed to get pod stats'

in pkg/util/node/node.go

- log event of 'Successfully retrieved node IP'

in pkg/util/node/node.go

- log event of 'Success to json.Marshal cidrs patch'

**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it:**

Ref:

- [keps/sig-instrumentation/1602-structured-logging](https://github.com/kubernetes/enhancements/tree/master/keps/sig-instrumentation/1602-structured-logging)

- [Structured Logging migration instructions](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-instrumentation/migration-to-structured-logging.md)


**Does this PR introduce a user-facing change?:**

```release-note
Migrate some util/node log messages to structured logging
```