### PR TITLE
fix conformance check as `go run` ignores go modules

### DIFF
--- a/hack/verify-conformance-requirements.sh
+++ b/hack/verify-conformance-requirements.sh
@@ -26,6 +26,11 @@ KUBE_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
 source "${KUBE_ROOT}/hack/lib/init.sh"
 source "${KUBE_ROOT}/hack/lib/util.sh"
 
+# Explicitly opt into go modules, even though we're inside a GOPATH directory
+export GO111MODULE=on
+# Explicitly set GOFLAGS to ignore vendor, since GOFLAGS=-mod=vendor breaks dependency resolution while rebuilding vendor
+export GOFLAGS=-mod=mod
+
 kube::golang::verify_go_version
 
 cd "${KUBE_ROOT}"


### PR DESCRIPTION
/kind failing-test

The failed test output is in the bottom from running `make verify`. 

The root cause is at

`line 35: if ! failedLint=$(go run "${KUBE_ROOT}"/hack/conformance/check_conformance_test_requirements.go "${KUBE_ROOT}"/test/e2e/)`

In my machine with `go env GOVERSION==go1.16`, it resulted like `go run` ignored the local `vendor` directory and gomod, but trying to find dependencies in "$GOPATH/src", which definitely is a legacy behavior.

I compared to other scripts and found the convention is GO111MODULE needs to be explicitly turned on. So I added it here as the fix.


Failed test output:

```
Verifying verify-conformance-requirements.sh

+++ Running case: verify.conformance-requirements
+++ working dir: /home/huazhihao/kubernetes
+++ command: bash "hack/make-rules/../../hack/verify-conformance-requirements.sh"
hack/conformance/check_conformance_test_requirements.go:29:2: cannot find package "github.com/pkg/errors" in any of:
	/usr/local/go/src/github.com/pkg/errors (from $GOROOT)
	/home/huazhihao/go/src/github.com/pkg/errors (from $GOPATH)
hack/conformance/check_conformance_test_requirements.go:30:2: cannot find package "github.com/spf13/cobra" in any of:
	/usr/local/go/src/github.com/spf13/cobra (from $GOROOT)
	/home/huazhihao/go/src/github.com/spf13/cobra (from $GOPATH)
Errors from lint:


Please review the above warnings.

+++ exit code: 1
+++ error: 1
FAILED   verify-conformance-requirements.sh	0s
```
