### PR TITLE
kubeadm set --container-runtime-endpoint with prefix 'unix://'

### DIFF
--- a/cmd/kubeadm/app/apis/kubeadm/v1beta2/doc.go
+++ b/cmd/kubeadm/app/apis/kubeadm/v1beta2/doc.go
@@ -167,7 +167,7 @@ limitations under the License.
 // 	  - system:bootstrappers:kubeadm:default-node-token
 // 	nodeRegistration:
 // 	  name: "ec2-10-100-0-1"
-// 	  criSocket: "/var/run/dockershim.sock"
+// 	  criSocket: "unix:///var/run/dockershim.sock"
 // 	  taints:
 // 	  - key: "kubeadmNode"
 // 	    value: "master"

--- a/cmd/kubeadm/app/apis/kubeadm/v1beta3/doc.go
+++ b/cmd/kubeadm/app/apis/kubeadm/v1beta3/doc.go
@@ -166,7 +166,7 @@ limitations under the License.
 // 	  - system:bootstrappers:kubeadm:default-node-token
 // 	nodeRegistration:
 // 	  name: "ec2-10-100-0-1"
-// 	  criSocket: "/var/run/dockershim.sock"
+// 	  criSocket: "unix:///var/run/dockershim.sock"
 // 	  taints:
 // 	  - key: "kubeadmNode"
 // 	    value: "master"

--- a/cmd/kubeadm/app/apis/kubeadm/validation/validation_test.go
+++ b/cmd/kubeadm/app/apis/kubeadm/validation/validation_test.go
@@ -601,7 +601,7 @@ func TestValidateJoinConfiguration(t *testing.T) {
 			},
 			NodeRegistration: kubeadmapi.NodeRegistrationOptions{
 				Name:      "aaa",
-				CRISocket: "/var/run/dockershim.sock",
+				CRISocket: "unix:///var/run/dockershim.sock",
 			},
 		}, true},
 		{&kubeadmapi.JoinConfiguration{ // Pass with JoinControlPlane
@@ -616,7 +616,7 @@ func TestValidateJoinConfiguration(t *testing.T) {
 			},
 			NodeRegistration: kubeadmapi.NodeRegistrationOptions{
 				Name:      "aaa",
-				CRISocket: "/var/run/dockershim.sock",
+				CRISocket: "unix:///var/run/dockershim.sock",
 			},
 			ControlPlane: &kubeadmapi.JoinControlPlane{
 				LocalAPIEndpoint: kubeadmapi.APIEndpoint{
@@ -637,7 +637,7 @@ func TestValidateJoinConfiguration(t *testing.T) {
 			},
 			NodeRegistration: kubeadmapi.NodeRegistrationOptions{
 				Name:      "aaa",
-				CRISocket: "/var/run/dockershim.sock",
+				CRISocket: "unix:///var/run/dockershim.sock",
 			},
 			ControlPlane: &kubeadmapi.JoinControlPlane{
 				LocalAPIEndpoint: kubeadmapi.APIEndpoint{

--- a/cmd/kubeadm/app/constants/constants.go
+++ b/cmd/kubeadm/app/constants/constants.go
@@ -240,7 +240,7 @@ const (
 	AnnotationKubeadmCRISocket = "kubeadm.alpha.kubernetes.io/cri-socket"
 
 	// UnknownCRISocket defines the undetected or unknown CRI socket
-	UnknownCRISocket = "/var/run/unknown.sock"
+	UnknownCRISocket = "unix:///var/run/unknown.sock"
 
 	// KubeadmConfigConfigMap specifies in what ConfigMap in the kube-system namespace the `kubeadm init` configuration should be stored
 	KubeadmConfigConfigMap = "kubeadm-config"

--- a/cmd/kubeadm/app/constants/constants_unix.go
+++ b/cmd/kubeadm/app/constants/constants_unix.go
@@ -20,5 +20,5 @@ package constants
 
 const (
 	// DefaultDockerCRISocket defines the default Docker CRI socket
-	DefaultDockerCRISocket = "/var/run/dockershim.sock"
+	DefaultDockerCRISocket = "unix:///var/run/dockershim.sock"
 )

--- a/cmd/kubeadm/app/phases/kubelet/flags_test.go
+++ b/cmd/kubeadm/app/phases/kubelet/flags_test.go
@@ -35,7 +35,7 @@ func TestBuildKubeletArgMap(t *testing.T) {
 			name: "the simplest case",
 			opts: kubeletFlagsOpts{
 				nodeRegOpts: &kubeadmapi.NodeRegistrationOptions{
-					CRISocket: "/var/run/dockershim.sock",
+					CRISocket: "unix:///var/run/dockershim.sock",
 					Taints: []v1.Taint{ // This should be ignored as registerTaintsUsingFlags is false
 						{
 							Key:    "foo",
@@ -53,7 +53,7 @@ func TestBuildKubeletArgMap(t *testing.T) {
 			name: "hostname override from NodeRegistrationOptions.Name",
 			opts: kubeletFlagsOpts{
 				nodeRegOpts: &kubeadmapi.NodeRegistrationOptions{
-					CRISocket: "/var/run/dockershim.sock",
+					CRISocket: "unix:///var/run/dockershim.sock",
 					Name:      "override-name",
 				},
 			},
@@ -66,7 +66,7 @@ func TestBuildKubeletArgMap(t *testing.T) {
 			name: "hostname override from NodeRegistrationOptions.KubeletExtraArgs",
 			opts: kubeletFlagsOpts{
 				nodeRegOpts: &kubeadmapi.NodeRegistrationOptions{
-					CRISocket:        "/var/run/dockershim.sock",
+					CRISocket:        "unix:///var/run/dockershim.sock",
 					KubeletExtraArgs: map[string]string{"hostname-override": "override-name"},
 				},
 			},
@@ -79,19 +79,19 @@ func TestBuildKubeletArgMap(t *testing.T) {
 			name: "external CRI runtime",
 			opts: kubeletFlagsOpts{
 				nodeRegOpts: &kubeadmapi.NodeRegistrationOptions{
-					CRISocket: "/var/run/containerd.sock",
+					CRISocket: "unix:///var/run/containerd/containerd.sock",
 				},
 			},
 			expected: map[string]string{
 				"container-runtime":          "remote",
-				"container-runtime-endpoint": "/var/run/containerd.sock",
+				"container-runtime-endpoint": "unix:///var/run/containerd/containerd.sock",
 			},
 		},
 		{
 			name: "register with taints",
 			opts: kubeletFlagsOpts{
 				nodeRegOpts: &kubeadmapi.NodeRegistrationOptions{
-					CRISocket: "/var/run/containerd.sock",
+					CRISocket: "unix:///var/run/containerd/containerd.sock",
 					Taints: []v1.Taint{
 						{
 							Key:    "foo",
@@ -109,7 +109,7 @@ func TestBuildKubeletArgMap(t *testing.T) {
 			},
 			expected: map[string]string{
 				"container-runtime":          "remote",
-				"container-runtime-endpoint": "/var/run/containerd.sock",
+				"container-runtime-endpoint": "unix:///var/run/containerd/containerd.sock",
 				"register-with-taints":       "foo=bar:baz,key=val:eff",
 			},
 		},
@@ -117,7 +117,7 @@ func TestBuildKubeletArgMap(t *testing.T) {
 			name: "pause image is set",
 			opts: kubeletFlagsOpts{
 				nodeRegOpts: &kubeadmapi.NodeRegistrationOptions{
-					CRISocket: "/var/run/dockershim.sock",
+					CRISocket: "unix:///var/run/dockershim.sock",
 				},
 				pauseImage: "gcr.io/pause:3.5",
 			},

--- a/cmd/kubeadm/app/phases/patchnode/patchnode_test.go
+++ b/cmd/kubeadm/app/phases/patchnode/patchnode_test.go
@@ -40,20 +40,20 @@ func TestAnnotateCRISocket(t *testing.T) {
 		{
 			name:                       "CRI-socket annotation missing",
 			currentCRISocketAnnotation: "",
-			newCRISocketAnnotation:     "/run/containerd/containerd.sock",
-			expectedPatch:              `{"metadata":{"annotations":{"kubeadm.alpha.kubernetes.io/cri-socket":"/run/containerd/containerd.sock"}}}`,
+			newCRISocketAnnotation:     "unix:///run/containerd/containerd.sock",
+			expectedPatch:              `{"metadata":{"annotations":{"kubeadm.alpha.kubernetes.io/cri-socket":"unix:///run/containerd/containerd.sock"}}}`,
 		},
 		{
 			name:                       "CRI-socket annotation already exists",
-			currentCRISocketAnnotation: "/run/containerd/containerd.sock",
-			newCRISocketAnnotation:     "/run/containerd/containerd.sock",
+			currentCRISocketAnnotation: "unix:///run/containerd/containerd.sock",
+			newCRISocketAnnotation:     "unix:///run/containerd/containerd.sock",
 			expectedPatch:              `{}`,
 		},
 		{
 			name:                       "CRI-socket annotation needs to be updated",
-			currentCRISocketAnnotation: "/var/run/dockershim.sock",
-			newCRISocketAnnotation:     "/run/containerd/containerd.sock",
-			expectedPatch:              `{"metadata":{"annotations":{"kubeadm.alpha.kubernetes.io/cri-socket":"/run/containerd/containerd.sock"}}}`,
+			currentCRISocketAnnotation: "unix:///var/run/dockershim.sock",
+			newCRISocketAnnotation:     "unix:///run/containerd/containerd.sock",
+			expectedPatch:              `{"metadata":{"annotations":{"kubeadm.alpha.kubernetes.io/cri-socket":"unix:///run/containerd/containerd.sock"}}}`,
 		},
 	}
 

--- a/cmd/kubeadm/app/util/marshal_test.go
+++ b/cmd/kubeadm/app/util/marshal_test.go
@@ -117,7 +117,7 @@ func TestMarshalUnmarshalToYamlForCodecs(t *testing.T) {
 		},
 		NodeRegistration: kubeadmapiv1.NodeRegistrationOptions{
 			Name:      "testNode",
-			CRISocket: "/var/run/cri.sock",
+			CRISocket: "unix:///var/run/cri.sock",
 		},
 		BootstrapTokens: []kubeadmapiv1.BootstrapToken{
 			{

--- a/cmd/kubeadm/app/util/runtime/runtime.go
+++ b/cmd/kubeadm/app/util/runtime/runtime.go
@@ -17,8 +17,6 @@ limitations under the License.
 package util
 
 import (
-	"path/filepath"
-	goruntime "runtime"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -56,12 +54,6 @@ func NewContainerRuntime(execer utilsexec.Interface, criSocket string) (Containe
 
 	if criSocket != constants.DefaultDockerCRISocket {
 		toolName = "crictl"
-		// !!! temporary work around crictl warning:
-		// Using "unix:///var/run/crio/crio.sock" as endpoint is deprecated,
-		// please consider using full url format "unix:///var/run/crio/crio.sock"
-		if filepath.IsAbs(criSocket) && goruntime.GOOS != "windows" {
-			criSocket = "unix://" + criSocket
-		}
 		runtime = &CRIRuntime{execer, criSocket}
 	} else {
 		toolName = "docker"

--- a/cmd/kubeadm/app/util/runtime/runtime.go
+++ b/cmd/kubeadm/app/util/runtime/runtime.go
@@ -57,7 +57,7 @@ func NewContainerRuntime(execer utilsexec.Interface, criSocket string) (Containe
 	if criSocket != constants.DefaultDockerCRISocket {
 		toolName = "crictl"
 		// !!! temporary work around crictl warning:
-		// Using "/var/run/crio/crio.sock" as endpoint is deprecated,
+		// Using "unix:///var/run/crio/crio.sock" as endpoint is deprecated,
 		// please consider using full url format "unix:///var/run/crio/crio.sock"
 		if filepath.IsAbs(criSocket) && goruntime.GOOS != "windows" {
 			criSocket = "unix://" + criSocket
@@ -197,7 +197,7 @@ func detectCRISocketImpl(isSocket func(string) bool) (string, error) {
 	foundCRISockets := []string{}
 	knownCRISockets := []string{
 		// Docker and containerd sockets are special cased below, hence not to be included here
-		"/var/run/crio/crio.sock",
+		"unix:///var/run/crio/crio.sock",
 	}
 
 	if isSocket(dockerSocket) {

--- a/cmd/kubeadm/app/util/runtime/runtime_test.go
+++ b/cmd/kubeadm/app/util/runtime/runtime_test.go
@@ -47,7 +47,7 @@ func TestNewContainerRuntime(t *testing.T) {
 	}{
 		{"valid: default cri socket", execLookPathOK, constants.DefaultDockerCRISocket, true, false},
 		{"valid: cri-o socket url", execLookPathOK, "unix:///var/run/crio/crio.sock", false, false},
-		// not suggested
+		// without unix:// scheme
 		{"valid: cri-o socket path", execLookPathOK, "/var/run/crio/crio.sock", false, false},
 		{"invalid: no crictl", execLookPathErr, "unix:///var/run/crio/crio.sock", false, true},
 	}

--- a/cmd/kubeadm/app/util/runtime/runtime_test.go
+++ b/cmd/kubeadm/app/util/runtime/runtime_test.go
@@ -47,6 +47,7 @@ func TestNewContainerRuntime(t *testing.T) {
 	}{
 		{"valid: default cri socket", execLookPathOK, constants.DefaultDockerCRISocket, true, false},
 		{"valid: cri-o socket url", execLookPathOK, "unix:///var/run/crio/crio.sock", false, false},
+		// not suggested
 		{"valid: cri-o socket path", execLookPathOK, "/var/run/crio/crio.sock", false, false},
 		{"invalid: no crictl", execLookPathErr, "unix:///var/run/crio/crio.sock", false, true},
 	}
@@ -402,29 +403,29 @@ func TestDetectCRISocketImpl(t *testing.T) {
 		},
 		{
 			name:            "One valid CRI socket leads to success",
-			existingSockets: []string{"/var/run/crio/crio.sock"},
+			existingSockets: []string{"unix:///var/run/crio/crio.sock"},
 			expectedError:   false,
-			expectedSocket:  "/var/run/crio/crio.sock",
+			expectedSocket:  "unix:///var/run/crio/crio.sock",
 		},
 		{
 			name:            "Correct Docker CRI socket is returned",
-			existingSockets: []string{"/var/run/docker.sock"},
+			existingSockets: []string{"unix:///var/run/docker.sock"},
 			expectedError:   false,
 			expectedSocket:  constants.DefaultDockerCRISocket,
 		},
 		{
 			name: "CRI and Docker sockets lead to an error",
 			existingSockets: []string{
-				"/var/run/docker.sock",
-				"/var/run/crio/crio.sock",
+				"unix:///var/run/docker.sock",
+				"unix:///var/run/crio/crio.sock",
 			},
 			expectedError: true,
 		},
 		{
 			name: "Docker and containerd lead to Docker being used",
 			existingSockets: []string{
-				"/var/run/docker.sock",
-				"/run/containerd/containerd.sock",
+				"unix:///var/run/docker.sock",
+				"unix:///run/containerd/containerd.sock",
 			},
 			expectedError:  false,
 			expectedSocket: constants.DefaultDockerCRISocket,
@@ -432,8 +433,8 @@ func TestDetectCRISocketImpl(t *testing.T) {
 		{
 			name: "A couple of CRI sockets lead to an error",
 			existingSockets: []string{
-				"/var/run/crio/crio.sock",
-				"/run/containerd/containerd.sock",
+				"unix:///var/run/crio/crio.sock",
+				"unix:///run/containerd/containerd.sock",
 			},
 			expectedError: true,
 		},

--- a/cmd/kubeadm/app/util/runtime/runtime_unix.go
+++ b/cmd/kubeadm/app/util/runtime/runtime_unix.go
@@ -21,6 +21,8 @@ package util
 import (
 	"net"
 	"net/url"
+
+	"k8s.io/klog/v2"
 )
 
 const (
@@ -34,8 +36,11 @@ func isExistingSocket(path string) bool {
 	if err != nil {
 		return false
 	}
-	// remove it later if we don't support the path anymore
-	if u.Scheme == "" {
+	// TODO: remove this warning and Scheme override once paths without scheme are not supported
+	if u.Scheme != "unix" {
+		klog.Warningf("The Unix socket path %q must be prefixed with \"unix://\". "+
+			"In future releases this can cause an error on the side of the kubelet. "+
+			"Please update your configuration", path)
 		u.Scheme = "unix"
 	}
 	c, err := net.Dial(u.Scheme, u.Path)

--- a/cmd/kubeadm/app/util/runtime/runtime_windows.go
+++ b/cmd/kubeadm/app/util/runtime/runtime_windows.go
@@ -23,8 +23,8 @@ import (
 )
 
 const (
-	dockerSocket     = "//./pipe/docker_engine"         // The Docker socket is not CRI compatible
-	containerdSocket = "//./pipe/containerd-containerd" // Proposed containerd named pipe for Windows
+	dockerSocket     = "npipe:////./pipe/docker_engine"         // The Docker socket is not CRI compatible
+	containerdSocket = "npipe:////./pipe/containerd-containerd" // Proposed containerd named pipe for Windows
 )
 
 // isExistingSocket checks if path exists and is domain socket


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
kubeadm auto-detect the cri like below:
```
I0326 14:02:29.160784 1730154 initconfiguration.go:104] detected and using CRI socket: /run/containerd/containerd.sock
```
However, kubelet raises a warning

> Mar 26 14:27:17 daocloud-1 kubelet[1738482]: W0326 14:27:17.285509 1738482 util_unix.go:103] Using "/run/containerd/containerd.sock" as endpoint is deprecated, please consider using full url format "unix:///run/containerd/containerd.sock".


#### Which issue(s) this PR fixes:
Fixes kubernetes/kubeadm#2426


#### Special notes for your reviewer:
avoid the warning for `kubeadm + containerd` init/join.

similar case: https://github.com/kubernetes/kubernetes/blob/ca916183dbea4873be9dd13ce9372cc07a2af4db/cluster/gce/config-test.sh#L113 are using 'unix:///run/containerd/containerd.sock'

#### Does this PR introduce a user-facing change?
```release-note
ACTION REQUIRED: For existing clusters must "kubectl edit no node-name" and modify the "kubeadm.alpha.kubernetes.io/cri-socket" annotation value for all nodes.
```

> kubeadm: modify the default CRI socket paths on Linux to always be prefixed with "unix://". The kubelet has deprecated sockets without "unix://" it might start erroring out in future releases. For new clusters please update your kubeadm configuration file / command-line flags. For existing clusters must "kubectl edit no node-name" and modify the "kubeadm.alpha.kubernetes.io/cri-socket" annotation value for all nodes.
