### PR TITLE
Migrate kubelet to use v1 Event API

### DIFF
--- a/pkg/kubelet/network/dns/dns.go
+++ b/pkg/kubelet/network/dns/dns.go
@@ -25,7 +25,6 @@ import (
 	"path/filepath"
 	"strings"
 
-	"k8s.io/api/core/v1"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/client-go/tools/record"
 	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
@@ -122,7 +121,7 @@ func (c *Configurer) formDNSSearchFitsLimits(composedSearch []string, pod *v1.Po
 
 	if limitsExceeded {
 		err := fmt.Errorf("Search Line limits were exceeded, some search paths have been omitted, the applied search line is: %s", strings.Join(composedSearch, " "))
-		c.recorder.Event(pod, v1.EventTypeWarning, "DNSConfigForming", err.Error())
+		c.recorder.Eventf(pod, nil, v1.EventTypeWarning, "DNSConfigForming", "DNSConfigForming", err.Error())
 		klog.ErrorS(err, "Search Line limits exceeded")
 	}
 	return composedSearch
@@ -132,7 +131,7 @@ func (c *Configurer) formDNSNameserversFitsLimits(nameservers []string, pod *v1.
 	if len(nameservers) > validation.MaxDNSNameservers {
 		nameservers = nameservers[0:validation.MaxDNSNameservers]
 		err := fmt.Errorf("Nameserver limits were exceeded, some nameservers have been omitted, the applied nameserver line is: %s", strings.Join(nameservers, " "))
-		c.recorder.Event(pod, v1.EventTypeWarning, "DNSConfigForming", err.Error())
+		c.recorder.Eventf(pod, nil, v1.EventTypeWarning, "DNSConfigForming", "DNSConfigForming", err.Error())
 		klog.ErrorS(err, "Nameserver limits exceeded")
 	}
 	return nameservers

--- a/test/conformance/testdata/conformance.yaml
+++ b/test/conformance/testdata/conformance.yaml
@@ -2118,6 +2118,30 @@
     support running as UID / GID, or privilege escalation.'
   release: v1.15
   file: test/e2e/common/node/security_context.go
+- testname: Sysctls, reject invalid sysctls
+  codename: '[sig-node] Sysctls [LinuxOnly] [NodeFeature:Sysctls] should reject invalid
+    sysctls [MinimumKubeletVersion:1.21] [Conformance]'
+  description: 'Pod is created with one valid and two invalid sysctls. Pod should
+    not apply invalid sysctls. [LinuxOnly]: This test is marked as LinuxOnly since
+    Windows does not support sysctls'
+  release: v1.21
+  file: test/e2e/common/node/sysctl.go
+- testname: Sysctl, test sysctls
+  codename: '[sig-node] Sysctls [LinuxOnly] [NodeFeature:Sysctls] should support sysctls
+    [MinimumKubeletVersion:1.21] [Conformance]'
+  description: 'Pod is created with kernel.shm_rmid_forced sysctl. Kernel.shm_rmid_forced
+    must be set to 1 [LinuxOnly]: This test is marked as LinuxOnly since Windows does
+    not support sysctls'
+  release: v1.21
+  file: test/e2e/common/node/sysctl.go
+- testname: Sysctl, allow specified unsafe sysctls
+  codename: '[sig-node] Sysctls [LinuxOnly] [NodeFeature:Sysctls] should support unsafe
+    sysctls which are actually allowed [MinimumKubeletVersion:1.21] [Conformance]'
+  description: 'Pod is created with kernel.shm_rmid_forced. Should allow unsafe sysctls
+    that are specified. [LinuxOnly]: This test is marked as LinuxOnly since Windows
+    does not support sysctls'
+  release: v1.21
+  file: test/e2e/common/node/sysctl.go
 - testname: Environment variables, expansion
   codename: '[sig-node] Variable Expansion should allow composing env vars into new
     env vars [NodeConformance] [Conformance]'

--- a/test/e2e/common/node/sysctl.go
+++ b/test/e2e/common/node/sysctl.go
@@ -65,7 +65,13 @@ var _ = SIGDescribe("Sysctls [LinuxOnly] [NodeFeature:Sysctls]", func() {
 		podClient = f.PodClient()
 	})
 
-	ginkgo.It("should support sysctls", func() {
+	/*
+	  Release: v1.21
+	  Testname: Sysctl, test sysctls
+	  Description: Pod is created with kernel.shm_rmid_forced sysctl. Kernel.shm_rmid_forced must be set to 1
+	  [LinuxOnly]: This test is marked as LinuxOnly since Windows does not support sysctls
+	*/
+	framework.ConformanceIt("should support sysctls [MinimumKubeletVersion:1.21]", func() {
 		pod := testPod()
 		pod.Spec.SecurityContext = &v1.PodSecurityContext{
 			Sysctls: []v1.Sysctl{
@@ -105,7 +111,13 @@ var _ = SIGDescribe("Sysctls [LinuxOnly] [NodeFeature:Sysctls]", func() {
 		gomega.Expect(log).To(gomega.ContainSubstring("kernel.shm_rmid_forced = 1"))
 	})
 
-	ginkgo.It("should support unsafe sysctls which are actually whitelisted", func() {
+	/*
+	  Release: v1.21
+	  Testname: Sysctl, allow specified unsafe sysctls
+	  Description: Pod is created with kernel.shm_rmid_forced. Should allow unsafe sysctls that are specified.
+	  [LinuxOnly]: This test is marked as LinuxOnly since Windows does not support sysctls
+	*/
+	framework.ConformanceIt("should support unsafe sysctls which are actually allowed [MinimumKubeletVersion:1.21]", func() {
 		pod := testPod()
 		pod.Spec.SecurityContext = &v1.PodSecurityContext{
 			Sysctls: []v1.Sysctl{
@@ -145,7 +157,13 @@ var _ = SIGDescribe("Sysctls [LinuxOnly] [NodeFeature:Sysctls]", func() {
 		gomega.Expect(log).To(gomega.ContainSubstring("kernel.shm_rmid_forced = 1"))
 	})
 
-	ginkgo.It("should reject invalid sysctls", func() {
+	/*
+		Release: v1.21
+		Testname: Sysctls, reject invalid sysctls
+		Description: Pod is created with one valid and two invalid sysctls. Pod should not apply invalid sysctls.
+		[LinuxOnly]: This test is marked as LinuxOnly since Windows does not support sysctls
+	*/
+	framework.ConformanceIt("should reject invalid sysctls [MinimumKubeletVersion:1.21]", func() {
 		pod := testPod()
 		pod.Spec.SecurityContext = &v1.PodSecurityContext{
 			Sysctls: []v1.Sysctl{
@@ -180,7 +198,7 @@ var _ = SIGDescribe("Sysctls [LinuxOnly] [NodeFeature:Sysctls]", func() {
 		gomega.Expect(err.Error()).NotTo(gomega.ContainSubstring("kernel.shmmax"))
 	})
 
-	ginkgo.It("should not launch unsafe, but not explicitly enabled sysctls on the node", func() {
+	ginkgo.It("should not launch unsafe, but not explicitly enabled sysctls on the node [MinimumKubeletVersion:1.21]", func() {
 		pod := testPod()
 		pod.Spec.SecurityContext = &v1.PodSecurityContext{
 			Sysctls: []v1.Sysctl{


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
 this migrate the kubelet to events.k8s.io v1
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
Ref kubernetes/enhancements#383
#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- [KEP]: <https://github.com/kubernetes/enhancements/tree/master/keps/sig-instrumentation/383-new-event-api-ga-graduation>
```
