### PR TITLE
Prepare to relax the constraints of PodDNSConfig

### DIFF
--- a/pkg/api/pod/util.go
+++ b/pkg/api/pod/util.go
@@ -419,6 +419,15 @@ func GetValidationOptionsFromPodSpecAndMeta(podSpec, oldPodSpec *api.PodSpec, po
 
 		// if old spec used non-integer multiple of huge page unit size, we must allow it
 		opts.AllowIndivisibleHugePagesValues = usesIndivisibleHugePagesValues(oldPodSpec)
+
+		if oldPodSpec.DNSConfig != nil {
+			// if old spec is from the future, set AllowExpandedDNSConfig
+			// TODO: after 1.22, remove this
+			if len(oldPodSpec.DNSConfig.Searches) > apivalidation.MaxDNSSearchPathsLegacy ||
+				len(strings.Join(oldPodSpec.DNSConfig.Searches, " ")) > apivalidation.MaxDNSSearchListCharsLegacy {
+				opts.AllowExpandedDNSConfig = true
+			}
+		}
 	}
 	if oldPodMeta != nil && !opts.AllowInvalidPodDeletionCost {
 		// This is an update, so validate only if the existing object was valid.

--- a/pkg/kubelet/network/dns/dns.go
+++ b/pkg/kubelet/network/dns/dns.go
@@ -99,19 +99,19 @@ func omitDuplicates(strs []string) []string {
 func (c *Configurer) formDNSSearchFitsLimits(composedSearch []string, pod *v1.Pod) []string {
 	limitsExceeded := false
 
-	if len(composedSearch) > validation.MaxDNSSearchPaths {
+	if len(composedSearch) > validation.MaxDNSSearchPathsExpanded {
 		composedSearch = composedSearch[:validation.MaxDNSSearchPaths]
 		limitsExceeded = true
 	}
 
-	if resolvSearchLineStrLen := len(strings.Join(composedSearch, " ")); resolvSearchLineStrLen > validation.MaxDNSSearchListChars {
+	if resolvSearchLineStrLen := len(strings.Join(composedSearch, " ")); resolvSearchLineStrLen > validation.MaxDNSSearchListCharsExpanded {
 		cutDomainsNum := 0
 		cutDomainsLen := 0
 		for i := len(composedSearch) - 1; i >= 0; i-- {
 			cutDomainsLen += len(composedSearch[i]) + 1
 			cutDomainsNum++
 
-			if (resolvSearchLineStrLen - cutDomainsLen) <= validation.MaxDNSSearchListChars {
+			if (resolvSearchLineStrLen - cutDomainsLen) <= validation.MaxDNSSearchListCharsExpanded {
 				break
 			}
 		}
@@ -173,7 +173,7 @@ func (c *Configurer) CheckLimitsForResolvConf() {
 		return
 	}
 
-	domainCountLimit := validation.MaxDNSSearchPaths
+	domainCountLimit := validation.MaxDNSSearchPathsExpanded
 
 	if c.ClusterDomain != "" {
 		domainCountLimit -= 3
@@ -186,8 +186,8 @@ func (c *Configurer) CheckLimitsForResolvConf() {
 		return
 	}
 
-	if len(strings.Join(hostSearch, " ")) > validation.MaxDNSSearchListChars {
-		log := fmt.Sprintf("Resolv.conf file '%s' contains search line which length is more than allowed %d chars!", c.ResolverConfig, validation.MaxDNSSearchListChars)
+	if len(strings.Join(hostSearch, " ")) > validation.MaxDNSSearchListCharsExpanded {
+		log := fmt.Sprintf("Resolv.conf file '%s' contains search line which length is more than allowed %d chars!", c.ResolverConfig, validation.MaxDNSSearchListCharsExpanded)
 		c.recorder.Event(c.nodeRef, v1.EventTypeWarning, "CheckLimitsForResolvConf", log)
 		klog.V(4).InfoS("Check limits for resolv.conf failed", "eventlog", log)
 		return

--- a/pkg/kubelet/network/dns/dns_test.go
+++ b/pkg/kubelet/network/dns/dns_test.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/tools/record"
 	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+	"k8s.io/kubernetes/pkg/apis/core/validation"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -144,9 +145,9 @@ func TestFormDNSSearchFitsLimits(t *testing.T) {
 		},
 
 		{
-			[]string{"testNS.svc.TEST", "svc.TEST", "TEST", "AAA", "BBB", "CCC", "DDD"},
-			[]string{"testNS.svc.TEST", "svc.TEST", "TEST", "AAA", "BBB", "CCC"},
-			[]string{"Search Line limits were exceeded, some search paths have been omitted, the applied search line is: testNS.svc.TEST svc.TEST TEST AAA BBB CCC"},
+			[]string{"testNS.svc.TEST", "svc.TEST", "TEST", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28", "29", "30", "31", "32", "33"},
+			[]string{"testNS.svc.TEST", "svc.TEST", "TEST", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28", "29", "30", "31", "32"},
+			[]string{"Search Line limits were exceeded, some search paths have been omitted, the applied search line is: testNS.svc.TEST svc.TEST TEST 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32"},
 		},
 	}
 
@@ -445,8 +446,8 @@ func TestGetPodDNS(t *testing.T) {
 		t.Errorf("expected nameserver %s, got %v", clusterNS, options[0].DNS[0])
 	}
 	expLength := len(options[1].DNSSearch) + 3
-	if expLength > 6 {
-		expLength = 6
+	if expLength > validation.MaxDNSSearchPathsExpanded {
+		expLength = validation.MaxDNSSearchPathsExpanded
 	}
 	if len(options[0].DNSSearch) != expLength {
 		t.Errorf("expected prepend of cluster domain, got %+v", options[0].DNSSearch)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug
/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

This PR 
- prepares to relax the constraints of PodDNSConfig
- relaxes the constraints of resolv.conf in kubelet
- additionally, validates the length of the DNS search path in kubelet

More details,
this PR affects 
1. api-server validating already created Pod's DNSConfig to tolerate the Pod from the next release
1.  kubelet validating [`resolvConf`](https://github.com/kubernetes/kubernetes/blob/bb89384f3981bae3f1d507c340593514abc734bc/staging/src/k8s.io/kubelet/config/v1beta1/types.go#L516-L523) to allow expanded DNS config
1. kubelet to allow expanded DNS config when validating actual DNS resolver configuration composed of 
    - cluster domain suffixes(e.g. default.svc.cluster.local, svc.cluster.local, cluster.local)
    - kubelet's `resolvConf`
    - Pod's DNSConfig

Alternative: #100651 

Background: The limit of the number of DNS search paths and length of the DNS search list has been removed from libc.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes/kubernetes/issues/100582
Tracking issue: https://github.com/kubernetes/kubernetes/issues/100622

#### Special notes for your reviewer:

https://access.redhat.com/solutions/58028

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
kubelet: Allow expanded DNS configuration
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
