### PR TITLE
Fix bug the default value of `DNSPolicy` should be `Default` when `HostNetwork` is true

### DIFF
--- a/pkg/apis/core/v1/defaults.go
+++ b/pkg/apis/core/v1/defaults.go
@@ -184,7 +184,11 @@ func SetDefaults_PodSpec(obj *v1.PodSpec) {
 	// In most cases the new defaulted field can added to SetDefaults_Pod instead of here, so
 	// that it only materializes in the Pod object and not all objects with a PodSpec field.
 	if obj.DNSPolicy == "" {
-		obj.DNSPolicy = v1.DNSClusterFirst
+		if obj.HostNetwork {
+			obj.DNSPolicy = v1.DNSDefault
+		} else {
+			obj.DNSPolicy = v1.DNSClusterFirst
+		}
 	}
 	if obj.RestartPolicy == "" {
 		obj.RestartPolicy = v1.RestartPolicyAlways


### PR DESCRIPTION
**What type of PR is this?**

> /kind bug

**What this PR does / why we need it**:
Fix bug the default value of  `DNSPolicy` should be `Default` when `HostNetwork` is true

```
// DNSClusterFirst indicates that the pod should use cluster DNS
// first unless hostNetwork is true, if it is available, then
// fall back on the default (as determined by kubelet) DNS settings.
DNSClusterFirst DNSPolicy = "ClusterFirst"
```
According to this comment, when the `HostNetwork` is true, `DNSPolicy` should be `Default` instead of `ClusterFirst`
- pkg/apis/core/v1/defaults.go

**Which issue(s) this PR fixes**:
Fix bug the default value of  `DNSPolicy` should be `Default` when `HostNetwork` is true


**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```
None
```
