### PR TITLE
pause image: Uses kube-cross image to build Windows binaries

### DIFF
--- a/build/dependencies.yaml
+++ b/build/dependencies.yaml
@@ -160,7 +160,7 @@ dependencies:
       match: __default_go_runner_version=
 
   - name: "k8s.gcr.io/pause"
-    version: 3.5
+    version: 3.6
     refPaths:
     - path: build/pause/Makefile
       match: TAG =

--- a/build/pause/Makefile
+++ b/build/pause/Makefile
@@ -17,7 +17,7 @@
 REGISTRY ?= staging-k8s.gcr.io
 IMAGE = $(REGISTRY)/pause
 
-TAG = 3.5
+TAG = 3.6
 REV = $(shell git describe --contains --always --match='v*')
 
 # Architectures supported: amd64, arm, arm64, ppc64le and s390x
@@ -40,12 +40,8 @@ ALL_OS_ARCH.windows = $(foreach arch, $(ALL_ARCH.windows), $(foreach osversion, 
 ALL_OS_ARCH = $(foreach os, $(ALL_OS), ${ALL_OS_ARCH.${os}})
 
 CFLAGS = -Os -Wall -Werror -static -DVERSION=v$(TAG)-$(REV)
-KUBE_CROSS_IMAGE.linux ?= k8s.gcr.io/build-image/kube-cross
-KUBE_CROSS_VERSION.linux ?= $(shell cat ../build-image/cross/VERSION)
-KUBE_CROSS_IMAGE.windows ?= dockcross/windows-static-x64
-KUBE_CROSS_VERSION.windows ?= latest
-KUBE_CROSS_IMAGE := ${KUBE_CROSS_IMAGE.${OS}}
-KUBE_CROSS_VERSION := ${KUBE_CROSS_VERSION.${OS}}
+KUBE_CROSS_IMAGE ?= k8s.gcr.io/build-image/kube-cross
+KUBE_CROSS_VERSION ?= $(shell cat ../build-image/cross/VERSION)
 
 # NOTE(claudiub): The Windows pause image also requires the wincat binary we're compiling for the
 # port-forwarding scenarios. If it's no longer necessary, it can be removed.
@@ -64,7 +60,7 @@ EXTENSION := ${EXTENSION.${OS}}
 # The manifest command is still experimental as of Docker 18.09.3
 export DOCKER_CLI_EXPERIMENTAL=enabled
 
-TRIPLE.windows-amd64 := x86_64-w64-mingw32.static
+TRIPLE.windows-amd64 := x86_64-w64-mingw32
 TRIPLE.linux-amd64 := x86_64-linux-gnu
 TRIPLE.linux-arm := arm-linux-gnueabihf
 TRIPLE.linux-arm64 := aarch64-linux-gnu


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind cleanup
/sig windows

/priority important-soon

#### What this PR does / why we need it:

``kube-cross:v1.16.3-1`` contains ``x86_64-w64-mingw32``, which will allow us to build Windows binaries. With this, we won't have to rely on the dockerhub image ``dockcross/windows-static-x64``.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #99360
Depends On: https://github.com/kubernetes/release/pull/1978

#### Special notes for your reviewer:

Image Building logs: https://paste.ubuntu.com/p/26QWZXwyP5/

Published image sample: ``claudiubelu/pause:3.6``
Running the image:

```
atuvenie@ubuntu:~/release/images/build/cross$ docker --tlsverify --tlscacert ~/.docker-${os_version}/ca.pem --tlscert ~/.docker-${os_version}/cert.pem --tlskey ~/.docker-${os_version}/key.pem -H "tcp://img-promoter-1809.eastus.cloudapp.azure.com:2376" pull claudiubelu/pause:3.6
3.6: Pulling from claudiubelu/pause
a11c4ca8f1ba: Already exists
8c70accf979e: Pull complete
8a13d1c556cb: Pull complete
9a7a79f01078: Pull complete
Digest: sha256:b8194fced735f5f11958f8fbbf3aa5aa86123283729c35ff1d13ed72bcb86639
Status: Downloaded newer image for claudiubelu/pause:3.6
docker.io/claudiubelu/pause:3.6
atuvenie@ubuntu:~/release/images/build/cross$ docker --tlsverify --tlscacert ~/.docker-${os_version}/ca.pem --tlscert ~/.docker-${os_version}/cert.pem --tlskey ~/.docker-${os_version}/key.pem -H "tcp://img-promoter-1809.eastus.cloudapp.azure.com:2376" run --rm -ti claudiubelu/pause:3.6
Shutting down, got signal
^C

```

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
