### PR TITLE
statefulset pods whose terminationGracePeriodSeconds is 0 didn't migr…

### DIFF
--- a/pkg/controller/nodelifecycle/scheduler/timed_workers.go
+++ b/pkg/controller/nodelifecycle/scheduler/timed_workers.go
@@ -99,7 +99,10 @@ func (q *TimedWorkerQueue) getWrappedWorkerFunc(key string) func(args *WorkArgs)
 		if err == nil {
 			// To avoid duplicated calls we keep the key in the queue, to prevent
 			// subsequent additions.
-			q.workers[key] = nil
+			// Add the judgment to resolve the conflict with CancelWork() and AddWork().
+			if _, ok := q.workers[key]; ok {
+				q.workers[key] = nil
+			}
 		} else {
 			delete(q.workers, key)
 		}


### PR DESCRIPTION
…ate when node is not-ready

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
/sig apps

#### What this PR does / why we need it:
This PR resolved the problem as follow.
- what happened:
I set statefulset pods' terminationGracePeriodSeconds to 0s.
When the node is down, statefulset pods don't migrate, and state is still running.
```
[root@paas-controller-3:/home/ubuntu]$ kubectl get po -n opcs -o wide | grep sentinel
96a1f5f3-6a3c-454c-8781-3e82974cef22-sentinel-0                   1/1     Running             0          104s    172.33.0.39   194.246.9.3   <none>           <none>
```
logs:
```
I0325 16:41:25.872017    4110 timed_workers.go:110] Adding TimedWorkerQueue item opcs/96a1f5f3-6a3c-454c-8781-3e82974cef22-sentinel-0 at 2021-03-25 16:41:25.871223734 +0800 CST m=+5554.854153930 to be fired at 2021-03-25 16:46:25.871223734 +0800 CST m=+5854.854153930
W0325 16:41:25.872024    4110 timed_workers.go:115] Trying to add already existing work for &{NamespacedName:opcs/96a1f5f3-6a3c-454c-8781-3e82974cef22-sentinel-0}. Skipping.
```
- I did a analysis as follow:
Because the pod is deleted immediatly, and pod is not found. Then the command  ' cancelWorkWithEvent() '  in func handlePodUpdate() is executed before the command  ' q.workers[key] = nil '  in func getWrappedWorkerFunc().
So the TimedWorkerQueue cache is wrong. Some time later, to migrate the pod with same name, adding work will failed, and the pod will not be deleted.
>> pkg/controller/nodelifecycle/node_lifecycle_controller.go
```
		DeleteFunc: func(obj interface{}) {
                        ...
			nc.podUpdated(pod, nil)
			if nc.taintManager != nil {
				nc.taintManager.PodUpdated(pod, nil)
			}
                },
```
>> pkg/controller/nodelifecycle/scheduler/taint_manager.go
```
func (tc *NoExecuteTaintManager) handlePodUpdate(podUpdate podUpdateItem) {
	pod, err := tc.getPod(podUpdate.podName, podUpdate.podNamespace)
	if err != nil {
		if apierrors.IsNotFound(err) {
			// Delete
			podNamespacedName := types.NamespacedName{Namespace: podUpdate.podNamespace, Name: podUpdate.podName}
			klog.V(4).InfoS("Noticed pod deletion", "pod", podNamespacedName)
			tc.cancelWorkWithEvent(podNamespacedName)
			return
		}
	}
}
```
>> pkg/controller/nodelifecycle/scheduler/timed_workers.go
```
func (q *TimedWorkerQueue) getWrappedWorkerFunc(key string) func(args *WorkArgs) error {
	return func(args *WorkArgs) error {
		err := q.workFunc(args)
		q.Lock()
		defer q.Unlock()
		if err == nil {
			// To avoid duplicated calls we keep the key in the queue, to prevent
			// subsequent additions.
			// Add the judgment to resolve the conflict with CancelWork()
			if _, ok := q.workers[key]; ok {
				q.workers[key] = nil
			}
		} else {
			delete(q.workers, key)
		}
		return err
	}
}
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #https://github.com/kubernetes/kubernetes/issues/100607

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
