### PR TITLE
kubeadm: upgrade etcd to 3.4.13-3

### DIFF
--- a/cluster/gce/manifests/etcd.manifest
+++ b/cluster/gce/manifests/etcd.manifest
@@ -18,7 +18,7 @@
     {
     "name": "etcd-container",
     {{security_context}}
-    "image": "{{ pillar.get('etcd_docker_repository', 'k8s.gcr.io/etcd') }}:{{ pillar.get('etcd_docker_tag', '3.4.13-0') }}",
+    "image": "{{ pillar.get('etcd_docker_repository', 'k8s.gcr.io/etcd') }}:{{ pillar.get('etcd_docker_tag', '3.4.13-3') }}",
     "resources": {
       "requests": {
         "cpu": {{ cpulimit }}

--- a/cluster/gce/upgrade-aliases.sh
+++ b/cluster/gce/upgrade-aliases.sh
@@ -170,7 +170,7 @@ export KUBE_GCE_ENABLE_IP_ALIASES=true
 export SECONDARY_RANGE_NAME="pods-default"
 export STORAGE_BACKEND="etcd3"
 export STORAGE_MEDIA_TYPE="application/vnd.kubernetes.protobuf"
-export ETCD_IMAGE=3.4.13-0
+export ETCD_IMAGE=3.4.13-3
 export ETCD_VERSION=3.4.13
 
 # Upgrade master with updated kube envs

--- a/cmd/kubeadm/app/constants/constants.go
+++ b/cmd/kubeadm/app/constants/constants.go
@@ -290,7 +290,7 @@ const (
 	MinExternalEtcdVersion = "3.2.18"
 
 	// DefaultEtcdVersion indicates the default etcd version that kubeadm uses
-	DefaultEtcdVersion = "3.4.13-0"
+	DefaultEtcdVersion = "3.4.13-3"
 
 	// Etcd defines variable used internally when referring to etcd component
 	Etcd = "etcd"
@@ -459,8 +459,8 @@ var (
 		19: "3.4.13-0",
 		20: "3.4.13-0",
 		21: "3.4.13-0",
-		22: "3.4.13-0",
-		23: "3.4.13-0",
+		22: "3.4.13-3",
+		23: "3.4.13-3",
 	}
 
 	// KubeadmCertsClusterRoleName sets the name for the ClusterRole that allows


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
https://github.com/kubernetes/kubernetes/blob/f4801a7c85d5599966305b3bf4a997303dc2f990/cluster/images/etcd/Makefile#L32-L37
Why we still use  3.4.13-0 here? Is there a special reason?

#### Which issue(s) this PR fixes:
xref #45506 
During investigation etcd versions matrix, I find the revision here is still 3.4.13-0.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
kubeadm upgrade etcd to 3.4.13-3
```
