### PR TITLE
Migrate pkg/util/iptables logs to structured logging

### DIFF
--- a/pkg/util/iptables/iptables.go
+++ b/pkg/util/iptables/iptables.go
@@ -348,7 +348,7 @@ func (runner *runner) SaveInto(table Table, buffer *bytes.Buffer) error {
 	// run and return
 	iptablesSaveCmd := iptablesSaveCommand(runner.protocol)
 	args := []string{"-t", string(table)}
-	klog.V(4).Infof("running %s %v", iptablesSaveCmd, args)
+	klog.V(4).InfoS("running iptables save command", "iptablesCmd", iptablesSaveCmd, "args", args)
 	cmd := runner.exec.Command(iptablesSaveCmd, args...)
 	cmd.SetStdout(buffer)
 	stderrBuffer := bytes.NewBuffer(nil)
@@ -405,7 +405,7 @@ func (runner *runner) restoreInternal(args []string, data []byte, flush FlushFla
 		trace.Step("Locks grabbed")
 		defer func(locker iptablesLocker) {
 			if err := locker.Close(); err != nil {
-				klog.Errorf("Failed to close iptables locks: %v", err)
+				klog.ErrorS(err,"Failed to close iptables locks")
 			}
 		}(locker)
 	}
@@ -413,7 +413,7 @@ func (runner *runner) restoreInternal(args []string, data []byte, flush FlushFla
 	// run the command and return the output or an error including the output and error
 	fullArgs := append(runner.restoreWaitFlag, args...)
 	iptablesRestoreCmd := iptablesRestoreCommand(runner.protocol)
-	klog.V(4).Infof("running %s %v", iptablesRestoreCmd, fullArgs)
+	klog.V(4).InfoS("running iptables restore command", "iptablesCmd", iptablesRestoreCmd, "args", fullArgs)
 	cmd := runner.exec.Command(iptablesRestoreCmd, fullArgs...)
 	cmd.SetStdin(bytes.NewBuffer(data))
 	b, err := cmd.CombinedOutput()
@@ -453,7 +453,7 @@ func (runner *runner) runContext(ctx context.Context, op operation, args []strin
 	iptablesCmd := iptablesCommand(runner.protocol)
 	fullArgs := append(runner.waitFlag, string(op))
 	fullArgs = append(fullArgs, args...)
-	klog.V(5).Infof("running iptables: %s %v", iptablesCmd, fullArgs)
+	klog.V(5).Infof("running iptables command", "iptablesCmd", iptablesCmd, "args", fullArgs)
 	if ctx == nil {
 		return runner.exec.Command(iptablesCmd, fullArgs...).CombinedOutput()
 	}
@@ -481,7 +481,7 @@ func trimhex(s string) string {
 // of hack and half-measures.  We should nix this ASAP.
 func (runner *runner) checkRuleWithoutCheck(table Table, chain Chain, args ...string) (bool, error) {
 	iptablesSaveCmd := iptablesSaveCommand(runner.protocol)
-	klog.V(1).Infof("running %s -t %s", iptablesSaveCmd, string(table))
+	klog.V(1).InfoS("running iptables save command", "iptablesCmd", iptablesSaveCmd, "args", string(table))
 	out, err := runner.exec.Command(iptablesSaveCmd, "-t", string(table)).CombinedOutput()
 	if err != nil {
 		return false, fmt.Errorf("error checking rule: %v", err)
@@ -520,7 +520,7 @@ func (runner *runner) checkRuleWithoutCheck(table Table, chain Chain, args ...st
 		if sets.NewString(fields...).IsSuperset(argset) {
 			return true, nil
 		}
-		klog.V(5).Infof("DBG: fields is not a superset of args: fields=%v  args=%v", fields, args)
+		klog.V(5).InfoS("DBG: fields is not a superset of args", "fields", fields, "args", args)
 	}
 
 	return false, nil
@@ -561,7 +561,7 @@ func (runner *runner) Monitor(canary Chain, tables []Table, reloadFunc func(), i
 		_ = utilwait.PollImmediateUntil(interval, func() (bool, error) {
 			for _, table := range tables {
 				if _, err := runner.EnsureChain(table, canary); err != nil {
-					klog.Warningf("Could not set up iptables canary %s/%s: %v", string(table), string(canary), err)
+					klog.ErrorS(err, "Could not set up iptables canary", "table", string(table), "canary", string(canary))
 					return false, nil
 				}
 			}
@@ -573,10 +573,10 @@ func (runner *runner) Monitor(canary Chain, tables []Table, reloadFunc func(), i
 			if exists, err := runner.chainExists(tables[0], canary); exists {
 				return false, nil
 			} else if isResourceError(err) {
-				klog.Warningf("Could not check for iptables canary %s/%s: %v", string(tables[0]), string(canary), err)
+				klog.ErrorS(err, "Could not check for iptables canary", "tables", string(tables[0]), "canary", string(canary))
 				return false, nil
 			}
-			klog.V(2).Infof("iptables canary %s/%s deleted", string(tables[0]), string(canary))
+			klog.V(2).InfoS("iptables canary deleted", "tables", string(tables[0]), "canary", string(canary))
 
 			// Wait for the other canaries to be deleted too before returning
 			// so we don't start reloading too soon.
@@ -589,7 +589,7 @@ func (runner *runner) Monitor(canary Chain, tables []Table, reloadFunc func(), i
 				return true, nil
 			})
 			if err != nil {
-				klog.Warning("Inconsistent iptables state detected.")
+				klog.InfoS("Inconsistent iptables state detected.")
 			}
 			return true, nil
 		}, stopCh)
@@ -602,7 +602,7 @@ func (runner *runner) Monitor(canary Chain, tables []Table, reloadFunc func(), i
 			return
 		}
 
-		klog.V(2).Infof("Reloading after iptables flush")
+		klog.V(2).InfoS("Reloading after iptables flush")
 		reloadFunc()
 	}
 }
@@ -685,11 +685,11 @@ func getIPTablesRestoreWaitFlag(version *utilversion.Version, exec utilexec.Inte
 	// --version, assume it also supports --wait
 	vstring, err := getIPTablesRestoreVersionString(exec, protocol)
 	if err != nil || vstring == "" {
-		klog.V(3).Infof("couldn't get iptables-restore version; assuming it doesn't support --wait")
+		klog.V(3).InfoS("couldn't get iptables-restore version; assuming it doesn't support --wait")
 		return nil
 	}
 	if _, err := utilversion.ParseGeneric(vstring); err != nil {
-		klog.V(3).Infof("couldn't parse iptables-restore version; assuming it doesn't support --wait")
+		klog.V(3).InfoS("couldn't parse iptables-restore version; assuming it doesn't support --wait")
 		return nil
 	}
 	return []string{WaitString}


### PR DESCRIPTION
in pkg/util/iptables/iptables.go

- log event of 'running iptables save command'

in pkg/util/iptables/iptables.go

- log event of 'Failed to close iptabels locks'

in pkg/util/iptables/iptables.go

- log event of 'running ipdtables restore command'

in pkg/util/iptables/iptables.go

- log event of 'running iptables command'

in pkg/util/iptables/iptables.go

- log event of 'running iptables save command'

in pkg/util/iptables/iptables.go

- log event of 'DBG: fields is not superset od args'

in pkg/util/iptables/iptables.go

- log event of 'could not set up iptables  canary'

in pkg/util/iptables/iptables.go

- log event of 'could not check for iptables canary'

in pkg/util/iptables/iptables.go

- log event of 'iptables canary deleted'

in pkg/util/iptables/iptables.go

- log event of 'Inconsistent iptables state detected'

in pkg/util/iptables/iptables.go

- log event of 'Reloading after iptables flush'

in pkg/util/iptables/iptables.go

- log event of 'couldn't get iptables-restore version; assuming it doesn't support --wait'

in pkg/util/iptables/iptables.go

- log event of 'couldn't parse iptables-restore version; assuming it doesn't support --wait'


**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it:**

Ref:

- [keps/sig-instrumentation/1602-structured-logging](https://github.com/kubernetes/enhancements/tree/master/keps/sig-instrumentation/1602-structured-logging)

- [Structured Logging migration instructions](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-instrumentation/migration-to-structured-logging.md)


**Does this PR introduce a user-facing change?:**

```release-note
Migrate some pkg/util/iptables log messages to structured logging
```