### PR TITLE
bump the deprecated version to 1.22

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/metrics/metrics.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/metrics/metrics.go
@@ -46,7 +46,7 @@ var (
 	etcdObjectCounts = compbasemetrics.NewGaugeVec(
 		&compbasemetrics.GaugeOpts{
 			Name:              "etcd_object_counts",
-			DeprecatedVersion: "1.21.0",
+			DeprecatedVersion: "1.22.0",
 			Help:              "Number of stored objects at the time of last check split by kind. This metric is replaced by apiserver_storage_object_counts.",
 			StabilityLevel:    compbasemetrics.ALPHA,
 		},


### PR DESCRIPTION
#### What type of PR is this?

/kind bug


#### What this PR does / why we need it:

We shouldn't be hiding etcd_object_counts until the release after v1.22.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #100621


```release-note
NONE
```
