### PR TITLE
[WIP] queue wait with request deadline

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/queueset/fifo_list.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/queueset/fifo_list.go
@@ -1,0 +1,87 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package queueset
+
+import (
+	"container/list"
+)
+
+// removeFunc removes a designated element from the list.
+// The complexity of the runtime cost is O(1)
+type removeFunc func()
+
+// internal interface to abstract out the implementation details
+// of the underlying list used.
+type fifo interface {
+	// Enqueue enqueues the specified request into the list and
+	// returns a removeFunc function that can be used to remove the
+	// request from the list
+	Enqueue(request *request) removeFunc
+
+	// Dequeue pulls out the oldest request from the list.
+	Dequeue() (*request, bool)
+
+	// Length returns the number of requests in the list.
+	Length() int
+
+	// ForEach iterates through the list and executes the specified
+	// function for each request.
+	// The order is least recent to most recent.
+	ForEach(func(r *request))
+}
+
+type requestFIFO struct {
+	*list.List
+}
+
+func newRequestFIFO() fifo {
+	return &requestFIFO{
+		list.New(),
+	}
+}
+
+func (l *requestFIFO) Length() int {
+	return l.Len()
+}
+
+func (l *requestFIFO) Enqueue(request *request) removeFunc {
+	e := l.PushBack(request)
+	return func() { l.Remove(e) }
+}
+
+func (l *requestFIFO) Dequeue() (*request, bool) {
+	e := l.Front()
+	if e == nil {
+		return nil, false
+	}
+
+	request, ok := e.Value.(*request)
+	if !ok {
+		// we should never be here.
+		return nil, false
+	}
+
+	return request, true
+}
+
+func (l *requestFIFO) ForEach(f func(r *request)) {
+	for current := l.Front(); current != nil; current = current.Next() {
+		if r, ok := current.Value.(*request); ok {
+			f(r)
+		}
+	}
+}

--- a/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/queueset/queueset_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/queueset/queueset_test.go
@@ -217,7 +217,6 @@ func (ust *uniformScenarioThread) genCallK(k int) func(time.Time) {
 		ust.uss.counter.Add(1)
 		go func() {
 			ust.callK(k)
-			ust.uss.counter.Add(-1)
 		}()
 	}
 }
@@ -226,6 +225,7 @@ func (ust *uniformScenarioThread) callK(k int) {
 	if k >= ust.nCalls {
 		return
 	}
+
 	req, idle := ust.uss.qs.StartRequest(context.Background(), ust.uc.hash, "", ust.fsName, ust.uss.name, []int{ust.i, ust.j, k}, nil)
 	ust.uss.t.Logf("%s: %d, %d, %d got req=%p, idle=%v", ust.uss.clk.Now().Format(nsTimeFmt), ust.i, ust.j, k, req, idle)
 	if req == nil {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:
Before we merged  https://github.com/kubernetes/kubernetes/pull/96901, the request context used by priority and fairness was:
```
		ctx, cancel := context.WithCancel(ctx)
		req = req.WithContext(ctx)
```
and the context was cancelled after `60s` by the timeout filter.

Now, with 96901 merged, the request context used by apf is bound to the request deadline - it is either the time out specified by the user in the request URI or `60s`. 

Suggestions:
- we can use the deadline bound context of a request to determine how long a request waits in the queue before we reject it, instead of a fixed `15s` threshold we have today.
- inside `removeTimedOutRequestsFromQueueLocked`, we remove requests that have been sitting in the queue for more than `15s`. but there might be requests in the queue where wait time in queue is less than `15s` but have already got `504` from the upstream timeout filter because their timeout value is `10s` for example. These requests will be removed from the queue once their wait time in queue is more than `15s`.  (so these requests are occupying the queue more than they should, new arriving requests might be rejected with `queue-full` because of these `504` requests) 

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
