### PR TITLE
apf: fix data race in queueset

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/queueset/queueset.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/queueset/queueset.go
@@ -285,6 +285,11 @@ func (qs *queueSet) StartRequest(ctx context.Context, hashValue uint64, flowDist
 	// request's context's Done channel gets closed by the time
 	// the request is done being processed.
 	doneCh := ctx.Done()
+
+	// Retrieve the queueset configuration name while we have the lock
+	// and use it in the goroutine below.
+	configName := qs.qCfg.Name
+
 	if doneCh != nil {
 		qs.preCreateOrUnblockGoroutine()
 		go func() {
@@ -297,7 +302,7 @@ func (qs *queueSet) StartRequest(ctx context.Context, hashValue uint64, flowDist
 			// known that the count does not need to be accurate.
 			// BTW, the count only needs to be accurate in a test that
 			// uses FakeEventClock::Run().
-			klog.V(6).Infof("QS(%s): Context of request %q %#+v %#+v is Done", qs.qCfg.Name, fsName, descr1, descr2)
+			klog.V(6).Infof("QS(%s): Context of request %q %#+v %#+v is Done", configName, fsName, descr1, descr2)
 			qs.cancelWait(req)
 			qs.goroutineDoneOrBlocked()
 		}()


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind flake

#### What this PR does / why we need it:
Fixes a data race in apf 

#### Which issue(s) this PR fixes:
Fixes #98697

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
Fixes a regression in 1.20+ with a data race issue in the priority and fairness API server filter
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
