### PR TITLE
Surface kube config in scheduler framework handle

### DIFF
--- a/cmd/kube-scheduler/app/config/config.go
+++ b/cmd/kube-scheduler/app/config/config.go
@@ -41,6 +41,7 @@ type Config struct {
 	SecureServing          *apiserver.SecureServingInfo
 
 	Client          clientset.Interface
+	KubeConfig      *restclient.Config
 	InformerFactory informers.SharedInformerFactory
 
 	//lint:ignore SA1019 this deprecated field still needs to be used for now. It will be removed once the migration is done.

--- a/cmd/kube-scheduler/app/options/options.go
+++ b/cmd/kube-scheduler/app/options/options.go
@@ -289,6 +289,7 @@ func (o *Options) Config() (*schedulerappconfig.Config, error) {
 	}
 
 	c.Client = client
+	c.KubeConfig = kubeConfig
 	c.InformerFactory = scheduler.NewInformerFactory(client, 0)
 	c.LeaderElection = leaderElectionConfig
 

--- a/cmd/kube-scheduler/app/server.go
+++ b/cmd/kube-scheduler/app/server.go
@@ -323,6 +323,7 @@ func Setup(ctx context.Context, opts *options.Options, outOfTreeRegistryOptions 
 		cc.InformerFactory,
 		recorderFactory,
 		ctx.Done(),
+		scheduler.WithKubeConfig(cc.KubeConfig),
 		scheduler.WithProfiles(cc.ComponentConfig.Profiles...),
 		scheduler.WithAlgorithmSource(cc.ComponentConfig.AlgorithmSource),
 		scheduler.WithPercentageOfNodesToScore(cc.ComponentConfig.PercentageOfNodesToScore),

--- a/pkg/scheduler/factory.go
+++ b/pkg/scheduler/factory.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/client-go/informers"
 	clientset "k8s.io/client-go/kubernetes"
 	corelisters "k8s.io/client-go/listers/core/v1"
+	restclient "k8s.io/client-go/rest"
 	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/pkg/scheduler/algorithmprovider"
 	schedulerapi "k8s.io/kubernetes/pkg/scheduler/apis/config"
@@ -57,7 +58,8 @@ type Binder interface {
 // Configurator defines I/O, caching, and other functionality needed to
 // construct a new scheduler.
 type Configurator struct {
-	client clientset.Interface
+	client     clientset.Interface
+	kubeConfig *restclient.Config
 
 	recorderFactory profile.RecorderFactory
 
@@ -137,6 +139,7 @@ func (c *Configurator) create() (*Scheduler, error) {
 	clusterEventMap := make(map[framework.ClusterEvent]sets.String)
 	profiles, err := profile.NewMap(c.profiles, c.registry, c.recorderFactory,
 		frameworkruntime.WithClientSet(c.client),
+		frameworkruntime.WithKubeConfig(c.kubeConfig),
 		frameworkruntime.WithInformerFactory(c.informerFactory),
 		frameworkruntime.WithSnapshotSharedLister(c.nodeInfoSnapshot),
 		frameworkruntime.WithRunAllFilters(c.alwaysCheckAllPredicates),

--- a/pkg/scheduler/framework/interface.go
+++ b/pkg/scheduler/framework/interface.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/informers"
 	clientset "k8s.io/client-go/kubernetes"
+	restclient "k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/events"
 	"k8s.io/kubernetes/pkg/scheduler/apis/config"
 	"k8s.io/kubernetes/pkg/scheduler/internal/parallelize"
@@ -587,6 +588,9 @@ type Handle interface {
 
 	// ClientSet returns a kubernetes clientSet.
 	ClientSet() clientset.Interface
+
+	// KubeConfig returns the raw kube config.
+	KubeConfig() *restclient.Config
 
 	// EventRecorder returns an event recorder.
 	EventRecorder() events.EventRecorder

--- a/pkg/scheduler/framework/runtime/framework.go
+++ b/pkg/scheduler/framework/runtime/framework.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/informers"
 	clientset "k8s.io/client-go/kubernetes"
+	restclient "k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/events"
 	"k8s.io/component-helpers/scheduling/corev1"
 	"k8s.io/klog/v2"
@@ -92,6 +93,7 @@ type frameworkImpl struct {
 	permitPlugins         []framework.PermitPlugin
 
 	clientSet       clientset.Interface
+	kubeConfig      *restclient.Config
 	eventRecorder   events.EventRecorder
 	informerFactory informers.SharedInformerFactory
 
@@ -142,6 +144,7 @@ func (f *frameworkImpl) Extenders() []framework.Extender {
 
 type frameworkOptions struct {
 	clientSet            clientset.Interface
+	kubeConfig           *restclient.Config
 	eventRecorder        events.EventRecorder
 	informerFactory      informers.SharedInformerFactory
 	snapshotSharedLister framework.SharedLister
@@ -161,6 +164,13 @@ type Option func(*frameworkOptions)
 func WithClientSet(clientSet clientset.Interface) Option {
 	return func(o *frameworkOptions) {
 		o.clientSet = clientSet
+	}
+}
+
+// WithKubeConfig sets kubeConfig for the scheduling frameworkImpl.
+func WithKubeConfig(kubeConfig *restclient.Config) Option {
+	return func(o *frameworkOptions) {
+		o.kubeConfig = kubeConfig
 	}
 }
 
@@ -254,6 +264,7 @@ func NewFramework(r Registry, profile *config.KubeSchedulerProfile, opts ...Opti
 		pluginNameToWeightMap: make(map[string]int),
 		waitingPods:           newWaitingPodsMap(),
 		clientSet:             options.clientSet,
+		kubeConfig:            options.kubeConfig,
 		eventRecorder:         options.eventRecorder,
 		informerFactory:       options.informerFactory,
 		metricsRecorder:       options.metricsRecorder,
@@ -1147,6 +1158,11 @@ func (f *frameworkImpl) ListPlugins() map[string][]config.Plugin {
 // ClientSet returns a kubernetes clientset.
 func (f *frameworkImpl) ClientSet() clientset.Interface {
 	return f.clientSet
+}
+
+// KubeConfig returns a kubernetes config.
+func (f *frameworkImpl) KubeConfig() *restclient.Config {
+	return f.kubeConfig
 }
 
 // EventRecorder returns an event recorder.

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -32,6 +32,7 @@ import (
 	"k8s.io/client-go/informers"
 	coreinformers "k8s.io/client-go/informers/core/v1"
 	clientset "k8s.io/client-go/kubernetes"
+	restclient "k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
 	podutil "k8s.io/kubernetes/pkg/api/v1/pod"
@@ -89,6 +90,7 @@ type Scheduler struct {
 }
 
 type schedulerOptions struct {
+	kubeConfig               *restclient.Config
 	schedulerAlgorithmSource schedulerapi.SchedulerAlgorithmSource
 	percentageOfNodesToScore int32
 	podInitialBackoffSeconds int64
@@ -103,6 +105,13 @@ type schedulerOptions struct {
 
 // Option configures a Scheduler
 type Option func(*schedulerOptions)
+
+// WithKubeConfig sets the kube config for Scheduler.
+func WithKubeConfig(cfg *restclient.Config) Option {
+	return func(o *schedulerOptions) {
+		o.kubeConfig = cfg
+	}
+}
 
 // WithProfiles sets profiles for Scheduler. By default, there is one profile
 // with the name "default-scheduler".
@@ -214,6 +223,7 @@ func New(client clientset.Interface,
 
 	configurator := &Configurator{
 		client:                   client,
+		kubeConfig:               options.kubeConfig,
 		recorderFactory:          recorderFactory,
 		informerFactory:          informerFactory,
 		schedulerCache:           schedulerCache,

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -176,7 +176,8 @@ func TestSchedulerCreation(t *testing.T) {
 
 			stopCh := make(chan struct{})
 			defer close(stopCh)
-			s, err := New(client,
+			s, err := New(
+				client,
 				informerFactory,
 				profile.NewRecorderFactory(eventBroadcaster),
 				stopCh,
@@ -456,7 +457,8 @@ func TestSchedulerMultipleProfilesScheduling(t *testing.T) {
 	defer cancel()
 
 	informerFactory := informers.NewSharedInformerFactory(client, 0)
-	sched, err := New(client,
+	sched, err := New(
+		client,
 		informerFactory,
 		profile.NewRecorderFactory(broadcaster),
 		ctx.Done(),

--- a/test/integration/scheduler/framework_test.go
+++ b/test/integration/scheduler/framework_test.go
@@ -92,7 +92,7 @@ type BindPlugin struct {
 	numBindCalled         int
 	PluginName            string
 	bindStatus            *framework.Status
-	client                *clientset.Clientset
+	client                clientset.Interface
 	pluginInvokeEventChan chan pluginInvokeEvent
 }
 

--- a/test/integration/scheduler_perf/util.go
+++ b/test/integration/scheduler_perf/util.go
@@ -99,7 +99,7 @@ func mustSetupScheduler(config *config.KubeSchedulerConfiguration) (util.Shutdow
 
 	// Not all config options will be effective but only those mostly related with scheduler performance will
 	// be applied to start a scheduler, most of them are defined in `scheduler.schedulerOptions`.
-	_, podInformer, schedulerShutdown := util.StartScheduler(client, config)
+	_, podInformer, schedulerShutdown := util.StartScheduler(client, cfg, config)
 	fakePVControllerShutdown := util.StartFakePVController(client)
 
 	shutdownFunc := func() {

--- a/test/integration/util/util.go
+++ b/test/integration/util/util.go
@@ -75,7 +75,7 @@ func StartApiserver() (string, ShutdownFunc) {
 
 // StartScheduler configures and starts a scheduler given a handle to the clientSet interface
 // and event broadcaster. It returns the running scheduler, podInformer and the shutdown function to stop it.
-func StartScheduler(clientSet clientset.Interface, cfg *kubeschedulerconfig.KubeSchedulerConfiguration) (*scheduler.Scheduler, coreinformers.PodInformer, ShutdownFunc) {
+func StartScheduler(clientSet clientset.Interface, kubeConfig *restclient.Config, cfg *kubeschedulerconfig.KubeSchedulerConfiguration) (*scheduler.Scheduler, coreinformers.PodInformer, ShutdownFunc) {
 	ctx, cancel := context.WithCancel(context.Background())
 
 	informerFactory := scheduler.NewInformerFactory(clientSet, 0)
@@ -89,6 +89,7 @@ func StartScheduler(clientSet clientset.Interface, cfg *kubeschedulerconfig.Kube
 		informerFactory,
 		profile.NewRecorderFactory(evtBroadcaster),
 		ctx.Done(),
+		scheduler.WithKubeConfig(kubeConfig),
 		scheduler.WithProfiles(cfg.Profiles...),
 		scheduler.WithAlgorithmSource(cfg.AlgorithmSource),
 		scheduler.WithPercentageOfNodesToScore(cfg.PercentageOfNodesToScore),
@@ -159,7 +160,8 @@ type TestContext struct {
 	CloseFn         framework.CloseFunc
 	HTTPServer      *httptest.Server
 	NS              *v1.Namespace
-	ClientSet       *clientset.Clientset
+	ClientSet       clientset.Interface
+	KubeConfig      *restclient.Config
 	InformerFactory informers.SharedInformerFactory
 	Scheduler       *scheduler.Scheduler
 	Ctx             context.Context
@@ -349,14 +351,14 @@ func InitTestMaster(t *testing.T, nsPrefix string, admission admission.Interface
 	}
 
 	// 2. Create kubeclient
-	testCtx.ClientSet = clientset.NewForConfigOrDie(
-		&restclient.Config{
-			QPS: -1, Host: s.URL,
-			ContentConfig: restclient.ContentConfig{
-				GroupVersion: &schema.GroupVersion{Group: "", Version: "v1"},
-			},
+	kubeConfig := &restclient.Config{
+		QPS: -1, Host: s.URL,
+		ContentConfig: restclient.ContentConfig{
+			GroupVersion: &schema.GroupVersion{Group: "", Version: "v1"},
 		},
-	)
+	}
+	testCtx.KubeConfig = kubeConfig
+	testCtx.ClientSet = clientset.NewForConfigOrDie(kubeConfig)
 	return &testCtx
 }
 
@@ -403,6 +405,7 @@ func InitTestSchedulerWithOptions(
 	if policy != nil {
 		opts = append(opts, scheduler.WithAlgorithmSource(CreateAlgorithmSourceFromPolicy(policy, testCtx.ClientSet)))
 	}
+	opts = append(opts, scheduler.WithKubeConfig(testCtx.KubeConfig))
 	testCtx.Scheduler, err = scheduler.New(
 		testCtx.ClientSet,
 		testCtx.InformerFactory,


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/sig scheduling

#### What this PR does / why we need it:

Surface kube config in scheduler framework handle, so that developers can leverage this to build CRD informers easily.

#### Which issue(s) this PR fixes:

Fixes #96427

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
Kube config is now exposed in the scheduler framework handle. Out-of-tree plugins can leverage that to build CRD informers easily.
```