### PR TITLE
migrate log in pkg/volume/flexvolume/attacher.go

### DIFF
--- a/pkg/volume/flexvolume/attacher.go
+++ b/pkg/volume/flexvolume/attacher.go
@@ -112,7 +112,7 @@ func (a *flexVolumeAttacher) VolumesAreAttached(specs []*volume.Spec, nodeName t
 		} else if err == nil {
 			if !status.Attached {
 				volumesAttachedCheck[spec] = false
-				klog.V(2).Infof("VolumesAreAttached: check volume (%q) is no longer attached", spec.Name())
+				klog.V(2).InfoS("VolumesAreAttached: check volume is no longer attached", "volume", spec.Name())
 			}
 		} else {
 			return nil, err


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Ref:

* [keps/sig-instrumentation/1602-structured-logging](https://github.com/kubernetes/enhancements/tree/master/keps/sig-instrumentation/1602-structured-logging)
* [Structured Logging migration instructions](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-instrumentation/migration-to-structured-logging.md)

**Does this PR introduce a user-facing change?**:

```release-note
Migrate some log messages to structured logging in pkg/volume/flexvolume/attacher.go.
```

/sig instrumentation