### PR TITLE
Migrate pkg/util/resizefs logs to structured logging

### DIFF
--- a/pkg/util/resizefs/resizefs_linux.go
+++ b/pkg/util/resizefs/resizefs_linux.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 
 	"k8s.io/klog/v2"
-	"k8s.io/mount-utils"
 )
 
 // ResizeFs Provides support for resizing file systems
@@ -50,7 +49,7 @@ func (resizefs *ResizeFs) Resize(devicePath string, deviceMountPath string) (boo
 		return false, nil
 	}
 
-	klog.V(3).Infof("ResizeFS.Resize - Expanding mounted volume %s", devicePath)
+	klog.V(3).InfoS("ResizeFS.Resize - Expanding mounted volume", "devicePath", devicePath)
 	switch format {
 	case "ext3", "ext4":
 		return resizefs.extResize(devicePath)
@@ -63,7 +62,7 @@ func (resizefs *ResizeFs) Resize(devicePath string, deviceMountPath string) (boo
 func (resizefs *ResizeFs) extResize(devicePath string) (bool, error) {
 	output, err := resizefs.mounter.Exec.Command("resize2fs", devicePath).CombinedOutput()
 	if err == nil {
-		klog.V(2).Infof("Device %s resized successfully", devicePath)
+		klog.V(2).InfoS("Device resized successfully", "devicePath", devicePath)
 		return true, nil
 	}
 
@@ -77,7 +76,7 @@ func (resizefs *ResizeFs) xfsResize(deviceMountPath string) (bool, error) {
 	output, err := resizefs.mounter.Exec.Command("xfs_growfs", args...).CombinedOutput()
 
 	if err == nil {
-		klog.V(2).Infof("Device %s resized successfully", deviceMountPath)
+		klog.V(2).InfoS("Device resized successfully", "deviceMountPath", deviceMountPath)
 		return true, nil
 	}
 


### PR DESCRIPTION
in pkg/util/resizefs/resizefs_linux.go

- log event of 'ResizeFS.Resize - Expanding mounted volume'

in pkg/util/resizefs/resizefs_linux.go

- log event of 'Device resized successfully'

in pkg/util/resizefs/resizefs_linux.go

- log event of 'Device resized successfully'




**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it:**

Ref:

- [keps/sig-instrumentation/1602-structured-logging](https://github.com/kubernetes/enhancements/tree/master/keps/sig-instrumentation/1602-structured-logging)

- [Structured Logging migration instructions](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-instrumentation/migration-to-structured-logging.md)


**Does this PR introduce a user-facing change?:**

```release-note
Migrate some pkg/util/resizefs log messages to structured logging
```