### PR TITLE
Migrate pkg/util/conntrack logs to structured logging

### DIFF
--- a/pkg/util/conntrack/conntrack.go
+++ b/pkg/util/conntrack/conntrack.go
@@ -63,12 +63,12 @@ func Exec(execer exec.Interface, parameters ...string) error {
 	if err != nil {
 		return fmt.Errorf("error looking for path of conntrack: %v", err)
 	}
-	klog.V(4).Infof("Clearing conntrack entries %v", parameters)
+	klog.V(4).InfoS("Clearing conntrack entries", "parameters", parameters)
 	output, err := execer.Command(conntrackPath, parameters...).CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("conntrack command returned: %q, error message: %s", string(output), err)
 	}
-	klog.V(4).Infof("Conntrack entries deleted %s", string(output))
+	klog.V(4).InfoS("Conntrack entries deleted", "entriesDeleted", string(output))
 	return nil
 }
 


### PR DESCRIPTION
in pkg/util/conntrack/conntrack.go

- log event of 'Clearing conntrack entries'

in pkg/util/conntrack/conntrack.go

- log event of 'Conntrack entries deleted'




**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it:**

Ref:

- [keps/sig-instrumentation/1602-structured-logging](https://github.com/kubernetes/enhancements/tree/master/keps/sig-instrumentation/1602-structured-logging)

- [Structured Logging migration instructions](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-instrumentation/migration-to-structured-logging.md)


**Does this PR introduce a user-facing change?:**

```release-note
Migrate some pkg/util/conntrack log messages to structured logging
```