### PR TITLE
Automated cherry pick of #100638: apf: fix data race in queueset

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/queueset/queueset.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/queueset/queueset.go
@@ -274,6 +274,11 @@ func (qs *queueSet) StartRequest(ctx context.Context, hashValue uint64, fsName s
 	// request's context's Done channel gets closed by the time
 	// the request is done being processed.
 	doneCh := ctx.Done()
+
+	// Retrieve the queueset configuration name while we have the lock
+	// and use it in the goroutine below.
+	configName := qs.qCfg.Name
+
 	if doneCh != nil {
 		qs.preCreateOrUnblockGoroutine()
 		go func() {
@@ -286,7 +291,7 @@ func (qs *queueSet) StartRequest(ctx context.Context, hashValue uint64, fsName s
 			// known that the count does not need to be accurate.
 			// BTW, the count only needs to be accurate in a test that
 			// uses FakeEventClock::Run().
-			klog.V(6).Infof("QS(%s): Context of request %q %#+v %#+v is Done", qs.qCfg.Name, fsName, descr1, descr2)
+			klog.V(6).Infof("QS(%s): Context of request %q %#+v %#+v is Done", configName, fsName, descr1, descr2)
 			qs.cancelWait(req)
 			qs.goroutineDoneOrBlocked()
 		}()


### PR DESCRIPTION
Cherry pick of #100638 on release-1.18.

#100638: apf: fix test flake

#### Which issue(s) this PR fixes:
Fixes #98697

```release-note
Fixes a regression in 1.20+ default configurations with a data race issue in the priority and fairness API server filter
```
