### PR TITLE
Tag structs as atomic

### DIFF
--- a/api/api-rules/violation_exceptions.list
+++ b/api/api-rules/violation_exceptions.list
@@ -256,14 +256,12 @@ API rule violation: list_type_missing,k8s.io/api/rbac/v1beta1,Role,Rules
 API rule violation: list_type_missing,k8s.io/api/rbac/v1beta1,RoleBinding,Subjects
 API rule violation: list_type_missing,k8s.io/api/storage/v1,CSINodeDriver,TopologyKeys
 API rule violation: list_type_missing,k8s.io/api/storage/v1,CSINodeSpec,Drivers
-API rule violation: list_type_missing,k8s.io/api/storage/v1,StorageClass,AllowedTopologies
 API rule violation: list_type_missing,k8s.io/api/storage/v1,StorageClass,MountOptions
 API rule violation: list_type_missing,k8s.io/api/storage/v1alpha1,CSIStorageCapacityList,Items
 API rule violation: list_type_missing,k8s.io/api/storage/v1beta1,CSIDriverSpec,VolumeLifecycleModes
 API rule violation: list_type_missing,k8s.io/api/storage/v1beta1,CSINodeDriver,TopologyKeys
 API rule violation: list_type_missing,k8s.io/api/storage/v1beta1,CSINodeSpec,Drivers
 API rule violation: list_type_missing,k8s.io/api/storage/v1beta1,CSIStorageCapacityList,Items
-API rule violation: list_type_missing,k8s.io/api/storage/v1beta1,StorageClass,AllowedTopologies
 API rule violation: list_type_missing,k8s.io/api/storage/v1beta1,StorageClass,MountOptions
 API rule violation: list_type_missing,k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1,ConversionRequest,Objects
 API rule violation: list_type_missing,k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1,ConversionResponse,ConvertedObjects

--- a/staging/src/k8s.io/api/autoscaling/v1/generated.proto
+++ b/staging/src/k8s.io/api/autoscaling/v1/generated.proto
@@ -85,6 +85,7 @@ message ContainerResourceMetricStatus {
 }
 
 // CrossVersionObjectReference contains enough information to let you identify the referred resource.
+// +structType=atomic
 message CrossVersionObjectReference {
   // Kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"
   optional string kind = 1;

--- a/staging/src/k8s.io/api/autoscaling/v1/types.go
+++ b/staging/src/k8s.io/api/autoscaling/v1/types.go
@@ -23,6 +23,7 @@ import (
 )
 
 // CrossVersionObjectReference contains enough information to let you identify the referred resource.
+// +structType=atomic
 type CrossVersionObjectReference struct {
 	// Kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"
 	Kind string `json:"kind" protobuf:"bytes,1,opt,name=kind"`

--- a/staging/src/k8s.io/api/core/v1/generated.proto
+++ b/staging/src/k8s.io/api/core/v1/generated.proto
@@ -498,6 +498,7 @@ message ConfigMapEnvSource {
 }
 
 // Selects a key from a ConfigMap.
+// +structType=atomic
 message ConfigMapKeySelector {
   // The ConfigMap to select from.
   optional LocalObjectReference localObjectReference = 1;
@@ -1010,6 +1011,7 @@ message EmptyDirVolumeSource {
 }
 
 // EndpointAddress is a tuple that describes single IP address.
+// +structType=atomic
 message EndpointAddress {
   // The IP of this endpoint.
   // May not be loopback (127.0.0.0/8), link-local (169.254.0.0/16),
@@ -1033,6 +1035,7 @@ message EndpointAddress {
 }
 
 // EndpointPort is a tuple that describes a single port.
+// +structType=atomic
 message EndpointPort {
   // The name of this port.  This must match the 'name' field in the
   // corresponding ServicePort.
@@ -2049,6 +2052,7 @@ message LoadBalancerStatus {
 
 // LocalObjectReference contains enough information to let you locate the
 // referenced object inside the same namespace.
+// +structType=atomic
 message LocalObjectReference {
   // Name of the referent.
   // More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
@@ -2330,6 +2334,7 @@ message NodeResources {
 // A node selector represents the union of the results of one or more label queries
 // over a set of nodes; that is, it represents the OR of the selectors represented
 // by the node selector terms.
+// +structType=atomic
 message NodeSelector {
   // Required. A list of node selector terms. The terms are ORed.
   repeated NodeSelectorTerm nodeSelectorTerms = 1;
@@ -2357,6 +2362,7 @@ message NodeSelectorRequirement {
 // A null or empty node selector term matches no objects. The requirements of
 // them are ANDed.
 // The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
+// +structType=atomic
 message NodeSelectorTerm {
   // A list of node selector requirements by node's labels.
   // +optional
@@ -2504,6 +2510,7 @@ message NodeSystemInfo {
 }
 
 // ObjectFieldSelector selects an APIVersioned field of an object.
+// +structType=atomic
 message ObjectFieldSelector {
   // Version of the schema the FieldPath is written in terms of, defaults to "v1".
   // +optional
@@ -2529,6 +2536,7 @@ message ObjectFieldSelector {
 // Instead of using this type, create a locally provided and used type that is well-focused on your reference.
 // For example, ServiceReferences for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533 .
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+// +structType=atomic
 message ObjectReference {
   // Kind of the referent.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
@@ -4178,6 +4186,7 @@ message ReplicationControllerStatus {
 }
 
 // ResourceFieldSelector represents container resources (cpu, memory) and their output format
+// +structType=atomic
 message ResourceFieldSelector {
   // Container name: required for volumes, optional for env vars
   // +optional
@@ -4380,6 +4389,7 @@ message ScaleIOVolumeSource {
 
 // A scope selector represents the AND of the selectors represented
 // by the scoped-resource selector requirements.
+// +structType=atomic
 message ScopeSelector {
   // A list of scope selector requirements by scope of the resources.
   // +optional
@@ -4475,6 +4485,7 @@ message SecretEnvSource {
 }
 
 // SecretKeySelector selects a key of a Secret.
+// +structType=atomic
 message SecretKeySelector {
   // The name of the secret in the pod's namespace to select from.
   optional LocalObjectReference localObjectReference = 1;
@@ -4525,6 +4536,7 @@ message SecretProjection {
 
 // SecretReference represents a Secret Reference. It has enough information to retrieve secret
 // in any namespace
+// +structType=atomic
 message SecretReference {
   // Name is unique within a namespace to reference a secret resource.
   // +optional
@@ -5246,6 +5258,7 @@ message TopologySelectorLabelRequirement {
 // The requirements of them are ANDed.
 // It provides a subset of functionality as NodeSelectorTerm.
 // This is an alpha feature and may change in the future.
+// +structType=atomic
 message TopologySelectorTerm {
   // A list of topology selector requirements by labels.
   // +optional
@@ -5312,6 +5325,7 @@ message TopologySpreadConstraint {
 
 // TypedLocalObjectReference contains enough information to let you locate the
 // typed referenced object inside the same namespace.
+// +structType=atomic
 message TypedLocalObjectReference {
   // APIGroup is the group for the resource being referenced.
   // If APIGroup is not specified, the specified Kind must be in the core API group.

--- a/staging/src/k8s.io/api/core/v1/types.go
+++ b/staging/src/k8s.io/api/core/v1/types.go
@@ -861,6 +861,7 @@ type CephFSVolumeSource struct {
 
 // SecretReference represents a Secret Reference. It has enough information to retrieve secret
 // in any namespace
+// +structType=atomic
 type SecretReference struct {
 	// Name is unique within a namespace to reference a secret resource.
 	// +optional
@@ -2629,6 +2630,7 @@ type NodeSelector struct {
 // A null or empty node selector term matches no objects. The requirements of
 // them are ANDed.
 // The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
+// +structType=atomic
 type NodeSelectorTerm struct {
 	// A list of node selector requirements by node's labels.
 	// +optional
@@ -4531,6 +4533,7 @@ type EndpointSubset struct {
 }
 
 // EndpointAddress is a tuple that describes single IP address.
+// +structType=atomic
 type EndpointAddress struct {
 	// The IP of this endpoint.
 	// May not be loopback (127.0.0.0/8), link-local (169.254.0.0/16),
@@ -4551,6 +4554,7 @@ type EndpointAddress struct {
 }
 
 // EndpointPort is a tuple that describes a single port.
+// +structType=atomic
 type EndpointPort struct {
 	// The name of this port.  This must match the 'name' field in the
 	// corresponding ServicePort.
@@ -5370,6 +5374,7 @@ type ServiceProxyOptions struct {
 // Instead of using this type, create a locally provided and used type that is well-focused on your reference.
 // For example, ServiceReferences for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533 .
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+// +structType=atomic
 type ObjectReference struct {
 	// Kind of the referent.
 	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
@@ -5409,6 +5414,7 @@ type ObjectReference struct {
 
 // LocalObjectReference contains enough information to let you locate the
 // referenced object inside the same namespace.
+// +structType=atomic
 type LocalObjectReference struct {
 	// Name of the referent.
 	// More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
@@ -5419,6 +5425,7 @@ type LocalObjectReference struct {
 
 // TypedLocalObjectReference contains enough information to let you locate the
 // typed referenced object inside the same namespace.
+// +structType=atomic
 type TypedLocalObjectReference struct {
 	// APIGroup is the group for the resource being referenced.
 	// If APIGroup is not specified, the specified Kind must be in the core API group.

--- a/staging/src/k8s.io/api/core/v1/types.go
+++ b/staging/src/k8s.io/api/core/v1/types.go
@@ -1948,6 +1948,7 @@ type EnvVarSource struct {
 }
 
 // ObjectFieldSelector selects an APIVersioned field of an object.
+// +structType=atomic
 type ObjectFieldSelector struct {
 	// Version of the schema the FieldPath is written in terms of, defaults to "v1".
 	// +optional
@@ -1957,6 +1958,7 @@ type ObjectFieldSelector struct {
 }
 
 // ResourceFieldSelector represents container resources (cpu, memory) and their output format
+// +structType=atomic
 type ResourceFieldSelector struct {
 	// Container name: required for volumes, optional for env vars
 	// +optional
@@ -1969,6 +1971,7 @@ type ResourceFieldSelector struct {
 }
 
 // Selects a key from a ConfigMap.
+// +structType=atomic
 type ConfigMapKeySelector struct {
 	// The ConfigMap to select from.
 	LocalObjectReference `json:",inline" protobuf:"bytes,1,opt,name=localObjectReference"`
@@ -1980,6 +1983,7 @@ type ConfigMapKeySelector struct {
 }
 
 // SecretKeySelector selects a key of a Secret.
+// +structType=atomic
 type SecretKeySelector struct {
 	// The name of the secret in the pod's namespace to select from.
 	LocalObjectReference `json:",inline" protobuf:"bytes,1,opt,name=localObjectReference"`
@@ -2616,6 +2620,7 @@ const (
 // A node selector represents the union of the results of one or more label queries
 // over a set of nodes; that is, it represents the OR of the selectors represented
 // by the node selector terms.
+// +structType=atomic
 type NodeSelector struct {
 	//Required. A list of node selector terms. The terms are ORed.
 	NodeSelectorTerms []NodeSelectorTerm `json:"nodeSelectorTerms" protobuf:"bytes,1,rep,name=nodeSelectorTerms"`
@@ -2668,7 +2673,10 @@ const (
 // The requirements of them are ANDed.
 // It provides a subset of functionality as NodeSelectorTerm.
 // This is an alpha feature and may change in the future.
+// +structType=atomic.
 type TopologySelectorTerm struct {
+	// Usage: Fields of type []TopologySelectorTerm must be listType=atomic.
+
 	// A list of topology selector requirements by labels.
 	// +optional
 	MatchLabelExpressions []TopologySelectorLabelRequirement `json:"matchLabelExpressions,omitempty" protobuf:"bytes,1,rep,name=matchLabelExpressions"`
@@ -5709,6 +5717,7 @@ type ResourceQuotaSpec struct {
 
 // A scope selector represents the AND of the selectors represented
 // by the scoped-resource selector requirements.
+// +structType=atomic
 type ScopeSelector struct {
 	// A list of scope selector requirements by scope of the resources.
 	// +optional

--- a/staging/src/k8s.io/api/core/v1/types.go
+++ b/staging/src/k8s.io/api/core/v1/types.go
@@ -2675,7 +2675,7 @@ const (
 // The requirements of them are ANDed.
 // It provides a subset of functionality as NodeSelectorTerm.
 // This is an alpha feature and may change in the future.
-// +structType=atomic.
+// +structType=atomic
 type TopologySelectorTerm struct {
 	// Usage: Fields of type []TopologySelectorTerm must be listType=atomic.
 

--- a/staging/src/k8s.io/api/discovery/v1/generated.proto
+++ b/staging/src/k8s.io/api/discovery/v1/generated.proto
@@ -115,6 +115,7 @@ message EndpointHints {
 }
 
 // EndpointPort represents a Port used by an EndpointSlice
+// +structType=atomic
 message EndpointPort {
   // The name of this port. All ports in an EndpointSlice must have a unique
   // name. If the EndpointSlice is dervied from a Kubernetes service, this

--- a/staging/src/k8s.io/api/discovery/v1/types.go
+++ b/staging/src/k8s.io/api/discovery/v1/types.go
@@ -153,6 +153,7 @@ type ForZone struct {
 }
 
 // EndpointPort represents a Port used by an EndpointSlice
+// +structType=atomic
 type EndpointPort struct {
 	// The name of this port. All ports in an EndpointSlice must have a unique
 	// name. If the EndpointSlice is dervied from a Kubernetes service, this

--- a/staging/src/k8s.io/api/rbac/v1/generated.proto
+++ b/staging/src/k8s.io/api/rbac/v1/generated.proto
@@ -164,6 +164,7 @@ message RoleList {
 }
 
 // RoleRef contains information that points to the role being used
+// +structType=atomic
 message RoleRef {
   // APIGroup is the group for the resource being referenced
   optional string apiGroup = 1;
@@ -177,6 +178,7 @@ message RoleRef {
 
 // Subject contains a reference to the object or user identities a role binding applies to.  This can either hold a direct API object reference,
 // or a value for non-objects such as user and group names.
+// +structType=atomic
 message Subject {
   // Kind of object being referenced. Values defined by this API group are "User", "Group", and "ServiceAccount".
   // If the Authorizer does not recognized the kind value, the Authorizer should report an error.

--- a/staging/src/k8s.io/api/rbac/v1/types.go
+++ b/staging/src/k8s.io/api/rbac/v1/types.go
@@ -70,6 +70,7 @@ type PolicyRule struct {
 
 // Subject contains a reference to the object or user identities a role binding applies to.  This can either hold a direct API object reference,
 // or a value for non-objects such as user and group names.
+// +structType=atomic
 type Subject struct {
 	// Kind of object being referenced. Values defined by this API group are "User", "Group", and "ServiceAccount".
 	// If the Authorizer does not recognized the kind value, the Authorizer should report an error.
@@ -88,6 +89,7 @@ type Subject struct {
 }
 
 // RoleRef contains information that points to the role being used
+// +structType=atomic
 type RoleRef struct {
 	// APIGroup is the group for the resource being referenced
 	APIGroup string `json:"apiGroup" protobuf:"bytes,1,opt,name=apiGroup"`

--- a/staging/src/k8s.io/api/storage/v1/generated.proto
+++ b/staging/src/k8s.io/api/storage/v1/generated.proto
@@ -319,6 +319,7 @@ message StorageClass {
   // An empty TopologySelectorTerm list means there is no topology restriction.
   // This field is only honored by servers that enable the VolumeScheduling feature.
   // +optional
+  // +listType=atomic
   repeated k8s.io.api.core.v1.TopologySelectorTerm allowedTopologies = 8;
 }
 

--- a/staging/src/k8s.io/api/storage/v1/types.go
+++ b/staging/src/k8s.io/api/storage/v1/types.go
@@ -71,6 +71,7 @@ type StorageClass struct {
 	// An empty TopologySelectorTerm list means there is no topology restriction.
 	// This field is only honored by servers that enable the VolumeScheduling feature.
 	// +optional
+	// +listType=atomic
 	AllowedTopologies []v1.TopologySelectorTerm `json:"allowedTopologies,omitempty" protobuf:"bytes,8,rep,name=allowedTopologies"`
 }
 

--- a/staging/src/k8s.io/api/storage/v1beta1/generated.proto
+++ b/staging/src/k8s.io/api/storage/v1beta1/generated.proto
@@ -412,6 +412,7 @@ message StorageClass {
   // An empty TopologySelectorTerm list means there is no topology restriction.
   // This field is only honored by servers that enable the VolumeScheduling feature.
   // +optional
+  // +listType=atomic
   repeated k8s.io.api.core.v1.TopologySelectorTerm allowedTopologies = 8;
 }
 

--- a/staging/src/k8s.io/api/storage/v1beta1/types.go
+++ b/staging/src/k8s.io/api/storage/v1beta1/types.go
@@ -75,6 +75,7 @@ type StorageClass struct {
 	// An empty TopologySelectorTerm list means there is no topology restriction.
 	// This field is only honored by servers that enable the VolumeScheduling feature.
 	// +optional
+	// +listType=atomic
 	AllowedTopologies []v1.TopologySelectorTerm `json:"allowedTopologies,omitempty" protobuf:"bytes,8,rep,name=allowedTopologies"`
 }
 

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/generated/openapi/zz_generated.openapi.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/generated/openapi/zz_generated.openapi.go
@@ -230,6 +230,11 @@ func schema_k8sio_api_autoscaling_v1_CrossVersionObjectReference(ref common.Refe
 				},
 				Required: []string{"kind", "name"},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"x-kubernetes-map-type": "atomic",
+				},
+			},
 		},
 	}
 }
@@ -2459,6 +2464,11 @@ func schema_pkg_apis_meta_v1_OwnerReference(ref common.ReferenceCallback) common
 					},
 				},
 				Required: []string{"apiVersion", "kind", "name", "uid"},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"x-kubernetes-map-type": "atomic",
+				},
 			},
 		},
 	}

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/generated.proto
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/generated.proto
@@ -788,6 +788,7 @@ message ObjectMeta {
 // OwnerReference contains enough information to let you identify an owning
 // object. An owning object must be in the same namespace as the dependent, or
 // be cluster-scoped, so there is no namespace field.
+// +structType=atomic
 message OwnerReference {
   // API version of the referent.
   optional string apiVersion = 5;

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/types.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/types.go
@@ -303,6 +303,7 @@ const (
 // OwnerReference contains enough information to let you identify an owning
 // object. An owning object must be in the same namespace as the dependent, or
 // be cluster-scoped, so there is no namespace field.
+// +structType=atomic
 type OwnerReference struct {
 	// API version of the referent.
 	APIVersion string `json:"apiVersion" protobuf:"bytes,5,opt,name=apiVersion"`

--- a/staging/src/k8s.io/client-go/applyconfigurations/internal/internal.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/internal/internal.go
@@ -1759,6 +1759,7 @@ var schemaYAML = typed.YAMLObject(`types:
       type:
         scalar: string
       default: ""
+    elementRelationship: atomic
 - name: io.k8s.api.autoscaling.v1.HorizontalPodAutoscaler
   map:
     fields:
@@ -3335,6 +3336,7 @@ var schemaYAML = typed.YAMLObject(`types:
     - name: optional
       type:
         scalar: boolean
+    elementRelationship: atomic
 - name: io.k8s.api.core.v1.ConfigMapNodeConfigSource
   map:
     fields:
@@ -3683,6 +3685,7 @@ var schemaYAML = typed.YAMLObject(`types:
     - name: targetRef
       type:
         namedType: io.k8s.api.core.v1.ObjectReference
+    elementRelationship: atomic
 - name: io.k8s.api.core.v1.EndpointPort
   map:
     fields:
@@ -3699,6 +3702,7 @@ var schemaYAML = typed.YAMLObject(`types:
     - name: protocol
       type:
         scalar: string
+    elementRelationship: atomic
 - name: io.k8s.api.core.v1.EndpointSubset
   map:
     fields:
@@ -4373,6 +4377,7 @@ var schemaYAML = typed.YAMLObject(`types:
     - name: name
       type:
         scalar: string
+    elementRelationship: atomic
 - name: io.k8s.api.core.v1.LocalVolumeSource
   map:
     fields:
@@ -4568,6 +4573,7 @@ var schemaYAML = typed.YAMLObject(`types:
           elementType:
             namedType: io.k8s.api.core.v1.NodeSelectorTerm
           elementRelationship: atomic
+    elementRelationship: atomic
 - name: io.k8s.api.core.v1.NodeSelectorRequirement
   map:
     fields:
@@ -4600,6 +4606,7 @@ var schemaYAML = typed.YAMLObject(`types:
           elementType:
             namedType: io.k8s.api.core.v1.NodeSelectorRequirement
           elementRelationship: atomic
+    elementRelationship: atomic
 - name: io.k8s.api.core.v1.NodeSpec
   map:
     fields:
@@ -4744,6 +4751,7 @@ var schemaYAML = typed.YAMLObject(`types:
       type:
         scalar: string
       default: ""
+    elementRelationship: atomic
 - name: io.k8s.api.core.v1.ObjectReference
   map:
     fields:
@@ -4768,6 +4776,7 @@ var schemaYAML = typed.YAMLObject(`types:
     - name: uid
       type:
         scalar: string
+    elementRelationship: atomic
 - name: io.k8s.api.core.v1.PersistentVolume
   map:
     fields:
@@ -5717,6 +5726,7 @@ var schemaYAML = typed.YAMLObject(`types:
       type:
         scalar: string
       default: ""
+    elementRelationship: atomic
 - name: io.k8s.api.core.v1.ResourceQuota
   map:
     fields:
@@ -5875,6 +5885,7 @@ var schemaYAML = typed.YAMLObject(`types:
           elementType:
             namedType: io.k8s.api.core.v1.ScopedResourceSelectorRequirement
           elementRelationship: atomic
+    elementRelationship: atomic
 - name: io.k8s.api.core.v1.ScopedResourceSelectorRequirement
   map:
     fields:
@@ -5958,6 +5969,7 @@ var schemaYAML = typed.YAMLObject(`types:
     - name: optional
       type:
         scalar: boolean
+    elementRelationship: atomic
 - name: io.k8s.api.core.v1.SecretProjection
   map:
     fields:
@@ -5982,6 +5994,7 @@ var schemaYAML = typed.YAMLObject(`types:
     - name: namespace
       type:
         scalar: string
+    elementRelationship: atomic
 - name: io.k8s.api.core.v1.SecretVolumeSource
   map:
     fields:
@@ -6345,6 +6358,7 @@ var schemaYAML = typed.YAMLObject(`types:
           elementType:
             namedType: io.k8s.api.core.v1.TopologySelectorLabelRequirement
           elementRelationship: atomic
+    elementRelationship: atomic
 - name: io.k8s.api.core.v1.TopologySpreadConstraint
   map:
     fields:
@@ -6377,6 +6391,7 @@ var schemaYAML = typed.YAMLObject(`types:
       type:
         scalar: string
       default: ""
+    elementRelationship: atomic
 - name: io.k8s.api.core.v1.Volume
   map:
     fields:
@@ -6634,6 +6649,7 @@ var schemaYAML = typed.YAMLObject(`types:
     - name: protocol
       type:
         scalar: string
+    elementRelationship: atomic
 - name: io.k8s.api.discovery.v1.EndpointSlice
   map:
     fields:
@@ -9504,6 +9520,7 @@ var schemaYAML = typed.YAMLObject(`types:
       type:
         scalar: string
       default: ""
+    elementRelationship: atomic
 - name: io.k8s.api.rbac.v1.Subject
   map:
     fields:
@@ -9521,6 +9538,7 @@ var schemaYAML = typed.YAMLObject(`types:
     - name: namespace
       type:
         scalar: string
+    elementRelationship: atomic
 - name: io.k8s.api.rbac.v1alpha1.AggregationRule
   map:
     fields:
@@ -10714,6 +10732,7 @@ var schemaYAML = typed.YAMLObject(`types:
       type:
         scalar: string
       default: ""
+    elementRelationship: atomic
 - name: io.k8s.apimachinery.pkg.apis.meta.v1.Preconditions
   map:
     fields:

--- a/staging/src/k8s.io/code-generator/examples/apiserver/openapi/zz_generated.openapi.go
+++ b/staging/src/k8s.io/code-generator/examples/apiserver/openapi/zz_generated.openapi.go
@@ -1528,6 +1528,11 @@ func schema_pkg_apis_meta_v1_OwnerReference(ref common.ReferenceCallback) common
 				},
 				Required: []string{"apiVersion", "kind", "name", "uid"},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"x-kubernetes-map-type": "atomic",
+				},
+			},
 		},
 	}
 }

--- a/staging/src/k8s.io/kube-aggregator/pkg/generated/openapi/zz_generated.openapi.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/generated/openapi/zz_generated.openapi.go
@@ -1531,6 +1531,11 @@ func schema_pkg_apis_meta_v1_OwnerReference(ref common.ReferenceCallback) common
 				},
 				Required: []string{"apiVersion", "kind", "name", "uid"},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"x-kubernetes-map-type": "atomic",
+				},
+			},
 		},
 	}
 }

--- a/staging/src/k8s.io/sample-apiserver/pkg/generated/openapi/zz_generated.openapi.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/generated/openapi/zz_generated.openapi.go
@@ -1529,6 +1529,11 @@ func schema_pkg_apis_meta_v1_OwnerReference(ref common.ReferenceCallback) common
 				},
 				Required: []string{"apiVersion", "kind", "name", "uid"},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"x-kubernetes-map-type": "atomic",
+				},
+			},
 		},
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:
See [review of all occurrences of the term "selector" in types.go files](https://docs.google.com/document/d/1jA39N3uvyDHheE-g8nLKbbnKkB3zhe4plAyl8qSdk_k/edit#heading=h.6e6lmpudp0ay)

Addresses comments from https://github.com/kubernetes/kubernetes/pull/100131

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes/kubernetes/issues/97970

Related to https://github.com/kubernetes/kubernetes/pull/97989

#### Special notes for your reviewer:

I'm not sure what kind of tests we need for these. There are already tests for the generic atomic annotation, I feel like we shouldn't need to test every instance of it. Some are transparent changes because the types are only used in lists that are already atomic.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
SSA treats certain structs as atomic
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

- KEP: https://github.com/kubernetes/enhancements/tree/master/keps/sig-api-machinery/555-server-side-apply
- Feature Issue: kubernetes/enhancements#555
- List of "selector" occurrences in types.go files: https://docs.google.com/document/d/1jA39N3uvyDHheE-g8nLKbbnKkB3zhe4plAyl8qSdk_k/edit
