### PR TITLE
rename some test funcs with incorrect "WithRetries" postfix

### DIFF
--- a/test/e2e/framework/resource/resources.go
+++ b/test/e2e/framework/resource/resources.go
@@ -91,7 +91,7 @@ func DeleteResourceAndWaitForGC(c clientset.Interface, kind schema.GroupKind, ns
 	falseVar := false
 	deleteOption := metav1.DeleteOptions{OrphanDependents: &falseVar}
 	startTime := time.Now()
-	if err := testutils.DeleteResourceWithRetries(c, kind, ns, name, deleteOption); err != nil {
+	if err := testutils.DeleteResource(c, kind, ns, name, deleteOption); err != nil {
 		return err
 	}
 	deleteTime := time.Since(startTime)

--- a/test/e2e/network/dns_scale_records.go
+++ b/test/e2e/network/dns_scale_records.go
@@ -67,7 +67,7 @@ var _ = common.SIGDescribe("[Feature:PerformanceDNS][Serial]", func() {
 		services := generateServicesInNamespaces(namespaces, maxServicesPerCluster)
 		createService := func(i int) {
 			defer ginkgo.GinkgoRecover()
-			framework.ExpectNoError(testutils.CreateServiceWithRetries(f.ClientSet, services[i].Namespace, services[i]))
+			framework.ExpectNoError(testutils.CreateService(f.ClientSet, services[i].Namespace, services[i]))
 		}
 		framework.Logf("Creating %v test services", maxServicesPerCluster)
 		workqueue.ParallelizeUntil(context.TODO(), parallelCreateServiceWorkers, len(services), createService)

--- a/test/integration/scheduler_perf/scheduler_test.go
+++ b/test/integration/scheduler_perf/scheduler_test.go
@@ -254,8 +254,8 @@ func (inputConfig *schedulerPerfConfig) generateNodes(config *testConfig) {
 
 // generatePods generates pods to be used for scheduling.
 func (inputConfig *schedulerPerfConfig) generatePods(config *testConfig) {
-	testutils.CreatePod(config.clientset, "sample", inputConfig.PodCount, config.mutatedPodTemplate)
-	testutils.CreatePod(config.clientset, "sample", config.numPods-inputConfig.PodCount, basePodTemplate)
+	testutils.CreatePods(config.clientset, "sample", inputConfig.PodCount, config.mutatedPodTemplate)
+	testutils.CreatePods(config.clientset, "sample", config.numPods-inputConfig.PodCount, basePodTemplate)
 }
 
 // generatePodAndNodeTopology is the wrapper function for modifying both pods and node objects.

--- a/test/utils/create_resources.go
+++ b/test/utils/create_resources.go
@@ -21,7 +21,6 @@ package utils
 import (
 	"context"
 	"fmt"
-	"time"
 
 	apps "k8s.io/api/apps/v1"
 	batch "k8s.io/api/batch/v1"
@@ -30,207 +29,148 @@ import (
 	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/wait"
 	clientset "k8s.io/client-go/kubernetes"
 )
 
-const (
-	// Parameters for retrying with exponential backoff.
-	retryBackoffInitialDuration = 100 * time.Millisecond
-	retryBackoffFactor          = 3
-	retryBackoffJitter          = 0
-	retryBackoffSteps           = 6
-)
-
-// Utility for retrying the given function with exponential backoff.
-func RetryWithExponentialBackOff(fn wait.ConditionFunc) error {
-	backoff := wait.Backoff{
-		Duration: retryBackoffInitialDuration,
-		Factor:   retryBackoffFactor,
-		Jitter:   retryBackoffJitter,
-		Steps:    retryBackoffSteps,
+func CreatePod(c clientset.Interface, namespace string, obj *v1.Pod) error {
+	if obj == nil {
+		return fmt.Errorf("object provided to create is empty")
 	}
-	return wait.ExponentialBackoff(backoff, fn)
+	_, err := c.CoreV1().Pods(namespace).Create(context.TODO(), obj, metav1.CreateOptions{})
+	if err == nil || apierrors.IsAlreadyExists(err) {
+		return nil
+	}
+	return fmt.Errorf("failed to create object: %v", err)
 }
 
-func CreatePodWithRetries(c clientset.Interface, namespace string, obj *v1.Pod) error {
+func CreateRC(c clientset.Interface, namespace string, obj *v1.ReplicationController) error {
 	if obj == nil {
-		return fmt.Errorf("Object provided to create is empty")
+		return fmt.Errorf("object provided to create is empty")
 	}
-	createFunc := func() (bool, error) {
-		_, err := c.CoreV1().Pods(namespace).Create(context.TODO(), obj, metav1.CreateOptions{})
-		if err == nil || apierrors.IsAlreadyExists(err) {
-			return true, nil
-		}
-		return false, fmt.Errorf("Failed to create object with non-retriable error: %v", err)
+	_, err := c.CoreV1().ReplicationControllers(namespace).Create(context.TODO(), obj, metav1.CreateOptions{})
+	if err == nil || apierrors.IsAlreadyExists(err) {
+		return nil
 	}
-	return RetryWithExponentialBackOff(createFunc)
+	return fmt.Errorf("failed to create object: %v", err)
 }
 
-func CreateRCWithRetries(c clientset.Interface, namespace string, obj *v1.ReplicationController) error {
+func CreateReplicaSet(c clientset.Interface, namespace string, obj *apps.ReplicaSet) error {
 	if obj == nil {
-		return fmt.Errorf("Object provided to create is empty")
+		return fmt.Errorf("object provided to create is empty")
 	}
-	createFunc := func() (bool, error) {
-		_, err := c.CoreV1().ReplicationControllers(namespace).Create(context.TODO(), obj, metav1.CreateOptions{})
-		if err == nil || apierrors.IsAlreadyExists(err) {
-			return true, nil
-		}
-		return false, fmt.Errorf("Failed to create object with non-retriable error: %v", err)
+	_, err := c.AppsV1().ReplicaSets(namespace).Create(context.TODO(), obj, metav1.CreateOptions{})
+	if err == nil || apierrors.IsAlreadyExists(err) {
+		return nil
 	}
-	return RetryWithExponentialBackOff(createFunc)
+	return fmt.Errorf("failed to create object: %v", err)
 }
 
-func CreateReplicaSetWithRetries(c clientset.Interface, namespace string, obj *apps.ReplicaSet) error {
+func CreateDeployment(c clientset.Interface, namespace string, obj *apps.Deployment) error {
 	if obj == nil {
-		return fmt.Errorf("Object provided to create is empty")
+		return fmt.Errorf("object provided to create is empty")
 	}
-	createFunc := func() (bool, error) {
-		_, err := c.AppsV1().ReplicaSets(namespace).Create(context.TODO(), obj, metav1.CreateOptions{})
-		if err == nil || apierrors.IsAlreadyExists(err) {
-			return true, nil
-		}
-		return false, fmt.Errorf("Failed to create object with non-retriable error: %v", err)
+	_, err := c.AppsV1().Deployments(namespace).Create(context.TODO(), obj, metav1.CreateOptions{})
+	if err == nil || apierrors.IsAlreadyExists(err) {
+		return nil
 	}
-	return RetryWithExponentialBackOff(createFunc)
+	return fmt.Errorf("failed to create object: %v", err)
 }
 
-func CreateDeploymentWithRetries(c clientset.Interface, namespace string, obj *apps.Deployment) error {
+func CreateDaemonSet(c clientset.Interface, namespace string, obj *apps.DaemonSet) error {
 	if obj == nil {
-		return fmt.Errorf("Object provided to create is empty")
+		return fmt.Errorf("object provided to create is empty")
 	}
-	createFunc := func() (bool, error) {
-		_, err := c.AppsV1().Deployments(namespace).Create(context.TODO(), obj, metav1.CreateOptions{})
-		if err == nil || apierrors.IsAlreadyExists(err) {
-			return true, nil
-		}
-		return false, fmt.Errorf("Failed to create object with non-retriable error: %v", err)
+	_, err := c.AppsV1().DaemonSets(namespace).Create(context.TODO(), obj, metav1.CreateOptions{})
+	if err == nil || apierrors.IsAlreadyExists(err) {
+		return nil
 	}
-	return RetryWithExponentialBackOff(createFunc)
+	return fmt.Errorf("failed to create object: %v", err)
 }
 
-func CreateDaemonSetWithRetries(c clientset.Interface, namespace string, obj *apps.DaemonSet) error {
+func CreateJob(c clientset.Interface, namespace string, obj *batch.Job) error {
 	if obj == nil {
-		return fmt.Errorf("Object provided to create is empty")
+		return fmt.Errorf("object provided to create is empty")
 	}
-	createFunc := func() (bool, error) {
-		_, err := c.AppsV1().DaemonSets(namespace).Create(context.TODO(), obj, metav1.CreateOptions{})
-		if err == nil || apierrors.IsAlreadyExists(err) {
-			return true, nil
-		}
-		return false, fmt.Errorf("Failed to create object with non-retriable error: %v", err)
+	_, err := c.BatchV1().Jobs(namespace).Create(context.TODO(), obj, metav1.CreateOptions{})
+	if err == nil || apierrors.IsAlreadyExists(err) {
+		return nil
 	}
-	return RetryWithExponentialBackOff(createFunc)
+	return fmt.Errorf("failed to create object with non-retriable error: %v", err)
 }
 
-func CreateJobWithRetries(c clientset.Interface, namespace string, obj *batch.Job) error {
+func CreateSecret(c clientset.Interface, namespace string, obj *v1.Secret) error {
 	if obj == nil {
-		return fmt.Errorf("Object provided to create is empty")
+		return fmt.Errorf("object provided to create is empty")
 	}
-	createFunc := func() (bool, error) {
-		_, err := c.BatchV1().Jobs(namespace).Create(context.TODO(), obj, metav1.CreateOptions{})
-		if err == nil || apierrors.IsAlreadyExists(err) {
-			return true, nil
-		}
-		return false, fmt.Errorf("Failed to create object with non-retriable error: %v", err)
+	_, err := c.CoreV1().Secrets(namespace).Create(context.TODO(), obj, metav1.CreateOptions{})
+	if err == nil || apierrors.IsAlreadyExists(err) {
+		return nil
 	}
-	return RetryWithExponentialBackOff(createFunc)
+	return fmt.Errorf("failed to create object with non-retriable error: %v", err)
 }
 
-func CreateSecretWithRetries(c clientset.Interface, namespace string, obj *v1.Secret) error {
+func CreateConfigMap(c clientset.Interface, namespace string, obj *v1.ConfigMap) error {
 	if obj == nil {
-		return fmt.Errorf("Object provided to create is empty")
+		return fmt.Errorf("object provided to create is empty")
 	}
-	createFunc := func() (bool, error) {
-		_, err := c.CoreV1().Secrets(namespace).Create(context.TODO(), obj, metav1.CreateOptions{})
-		if err == nil || apierrors.IsAlreadyExists(err) {
-			return true, nil
-		}
-		return false, fmt.Errorf("Failed to create object with non-retriable error: %v", err)
+	_, err := c.CoreV1().ConfigMaps(namespace).Create(context.TODO(), obj, metav1.CreateOptions{})
+	if err == nil || apierrors.IsAlreadyExists(err) {
+		return nil
 	}
-	return RetryWithExponentialBackOff(createFunc)
+	return fmt.Errorf("failed to create object with non-retriable error: %v", err)
 }
 
-func CreateConfigMapWithRetries(c clientset.Interface, namespace string, obj *v1.ConfigMap) error {
+func CreateService(c clientset.Interface, namespace string, obj *v1.Service) error {
 	if obj == nil {
-		return fmt.Errorf("Object provided to create is empty")
+		return fmt.Errorf("object provided to create is empty")
 	}
-	createFunc := func() (bool, error) {
-		_, err := c.CoreV1().ConfigMaps(namespace).Create(context.TODO(), obj, metav1.CreateOptions{})
-		if err == nil || apierrors.IsAlreadyExists(err) {
-			return true, nil
-		}
-		return false, fmt.Errorf("Failed to create object with non-retriable error: %v", err)
+	_, err := c.CoreV1().Services(namespace).Create(context.TODO(), obj, metav1.CreateOptions{})
+	if err == nil || apierrors.IsAlreadyExists(err) {
+		return nil
 	}
-	return RetryWithExponentialBackOff(createFunc)
+	return fmt.Errorf("failed to create object with non-retriable error: %v", err)
 }
 
-func CreateServiceWithRetries(c clientset.Interface, namespace string, obj *v1.Service) error {
+func CreateStorageClass(c clientset.Interface, obj *storage.StorageClass) error {
 	if obj == nil {
-		return fmt.Errorf("Object provided to create is empty")
+		return fmt.Errorf("object provided to create is empty")
 	}
-	createFunc := func() (bool, error) {
-		_, err := c.CoreV1().Services(namespace).Create(context.TODO(), obj, metav1.CreateOptions{})
-		if err == nil || apierrors.IsAlreadyExists(err) {
-			return true, nil
-		}
-		return false, fmt.Errorf("Failed to create object with non-retriable error: %v", err)
+	_, err := c.StorageV1().StorageClasses().Create(context.TODO(), obj, metav1.CreateOptions{})
+	if err == nil || apierrors.IsAlreadyExists(err) {
+		return nil
 	}
-	return RetryWithExponentialBackOff(createFunc)
+	return fmt.Errorf("failed to create object with non-retriable error: %v", err)
 }
 
-func CreateStorageClassWithRetries(c clientset.Interface, obj *storage.StorageClass) error {
+func CreateResourceQuota(c clientset.Interface, namespace string, obj *v1.ResourceQuota) error {
 	if obj == nil {
-		return fmt.Errorf("Object provided to create is empty")
+		return fmt.Errorf("object provided to create is empty")
 	}
-	createFunc := func() (bool, error) {
-		_, err := c.StorageV1().StorageClasses().Create(context.TODO(), obj, metav1.CreateOptions{})
-		if err == nil || apierrors.IsAlreadyExists(err) {
-			return true, nil
-		}
-		return false, fmt.Errorf("Failed to create object with non-retriable error: %v", err)
+	_, err := c.CoreV1().ResourceQuotas(namespace).Create(context.TODO(), obj, metav1.CreateOptions{})
+	if err == nil || apierrors.IsAlreadyExists(err) {
+		return nil
 	}
-	return RetryWithExponentialBackOff(createFunc)
+	return fmt.Errorf("failed to create object with non-retriable error: %v", err)
 }
 
-func CreateResourceQuotaWithRetries(c clientset.Interface, namespace string, obj *v1.ResourceQuota) error {
+func CreatePersistentVolume(c clientset.Interface, obj *v1.PersistentVolume) error {
 	if obj == nil {
-		return fmt.Errorf("Object provided to create is empty")
+		return fmt.Errorf("object provided to create is empty")
 	}
-	createFunc := func() (bool, error) {
-		_, err := c.CoreV1().ResourceQuotas(namespace).Create(context.TODO(), obj, metav1.CreateOptions{})
-		if err == nil || apierrors.IsAlreadyExists(err) {
-			return true, nil
-		}
-		return false, fmt.Errorf("Failed to create object with non-retriable error: %v", err)
+	_, err := c.CoreV1().PersistentVolumes().Create(context.TODO(), obj, metav1.CreateOptions{})
+	if err == nil || apierrors.IsAlreadyExists(err) {
+		return nil
 	}
-	return RetryWithExponentialBackOff(createFunc)
+	return fmt.Errorf("failed to create object with non-retriable error: %v", err)
 }
 
-func CreatePersistentVolumeWithRetries(c clientset.Interface, obj *v1.PersistentVolume) error {
+func CreatePersistentVolumeClaim(c clientset.Interface, namespace string, obj *v1.PersistentVolumeClaim) error {
 	if obj == nil {
-		return fmt.Errorf("Object provided to create is empty")
+		return fmt.Errorf("object provided to create is empty")
 	}
-	createFunc := func() (bool, error) {
-		_, err := c.CoreV1().PersistentVolumes().Create(context.TODO(), obj, metav1.CreateOptions{})
-		if err == nil || apierrors.IsAlreadyExists(err) {
-			return true, nil
-		}
-		return false, fmt.Errorf("Failed to create object with non-retriable error: %v", err)
+	_, err := c.CoreV1().PersistentVolumeClaims(namespace).Create(context.TODO(), obj, metav1.CreateOptions{})
+	if err == nil || apierrors.IsAlreadyExists(err) {
+		return nil
 	}
-	return RetryWithExponentialBackOff(createFunc)
-}
-
-func CreatePersistentVolumeClaimWithRetries(c clientset.Interface, namespace string, obj *v1.PersistentVolumeClaim) error {
-	if obj == nil {
-		return fmt.Errorf("Object provided to create is empty")
-	}
-	createFunc := func() (bool, error) {
-		_, err := c.CoreV1().PersistentVolumeClaims(namespace).Create(context.TODO(), obj, metav1.CreateOptions{})
-		if err == nil || apierrors.IsAlreadyExists(err) {
-			return true, nil
-		}
-		return false, fmt.Errorf("Failed to create object with non-retriable error: %v", err)
-	}
-	return RetryWithExponentialBackOff(createFunc)
+	return fmt.Errorf("failed to create object with non-retriable error: %v", err)
 }

--- a/test/utils/delete_resources.go
+++ b/test/utils/delete_resources.go
@@ -57,13 +57,10 @@ func deleteResource(c clientset.Interface, kind schema.GroupKind, namespace, nam
 	}
 }
 
-func DeleteResourceWithRetries(c clientset.Interface, kind schema.GroupKind, namespace, name string, options metav1.DeleteOptions) error {
-	deleteFunc := func() (bool, error) {
-		err := deleteResource(c, kind, namespace, name, options)
-		if err == nil || apierrors.IsNotFound(err) {
-			return true, nil
-		}
-		return false, fmt.Errorf("Failed to delete object with non-retriable error: %v", err)
+func DeleteResource(c clientset.Interface, kind schema.GroupKind, namespace, name string, options metav1.DeleteOptions) error {
+	err := deleteResource(c, kind, namespace, name, options)
+	if err == nil || apierrors.IsNotFound(err) {
+		return nil
 	}
-	return RetryWithExponentialBackOff(deleteFunc)
+	return fmt.Errorf("failed to delete object: %v", err)
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/area test

#### What this PR does / why we need it:

Along with #95495, semantically some functions no longer perform retrying.

For example, `CreatePodWithRetry` only does retry when the inner condition func (`createFunc()`) returns `false, nil`, but that's never achievable.

https://github.com/kubernetes/kubernetes/blob/bb89384f3981bae3f1d507c340593514abc734bc/test/utils/create_resources.go#L56-L68

So this PR renames their function names to avoid confusion, also removes over-wrapped functions to avoid confusion.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```