### PR TITLE
fix kube-scheduler README.md url broken

### DIFF
--- a/staging/src/k8s.io/kube-scheduler/README.md
+++ b/staging/src/k8s.io/kube-scheduler/README.md
@@ -1,6 +1,6 @@
 # kube-scheduler
 
-Implements [KEP 14 - Moving ComponentConfig API types to staging repos](https://git.k8s.io/enhancements/keps/sig-cluster-lifecycle/wgs/0014-20180707-componentconfig-api-types-to-staging.md#kube-scheduler-changes)
+Implements [KEP 14 - Moving ComponentConfig API types to staging repos](https://github.com/kubernetes/enhancements/tree/master/keps/sig-cluster-lifecycle/wgs/115-componentconfig#kube-scheduler-changes)
 
 This repo provides external, versioned ComponentConfig API types for configuring the kube-scheduler.
 These external types can easily be vendored and used by any third-party tool writing Kubernetes


### PR DESCRIPTION
/kind documentation