### PR TITLE
Cherry pick #574 from Cloud Provider Azure: do not tag user created public IPs

### DIFF
--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_loadbalancer_test.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_loadbalancer_test.go
@@ -447,74 +447,91 @@ func TestEnsureLoadBalancerDeleted(t *testing.T) {
 
 func TestServiceOwnsPublicIP(t *testing.T) {
 	tests := []struct {
-		desc        string
-		pip         *network.PublicIPAddress
-		clusterName string
-		serviceName string
-		expected    bool
+		desc                    string
+		pip                     *network.PublicIPAddress
+		clusterName             string
+		serviceName             string
+		serviceLBIP             string
+		expectedOwns            bool
+		expectedUserAssignedPIP bool
 	}{
 		{
-			desc:        "false should be returned when pip is nil",
-			clusterName: "kubernetes",
-			serviceName: "nginx",
-			expected:    false,
+			desc:         "false should be returned when pip is nil",
+			clusterName:  "kubernetes",
+			serviceName:  "nginx",
+			expectedOwns: false,
 		},
 		{
 			desc: "false should be returned when service name tag doesn't match",
 			pip: &network.PublicIPAddress{
 				Tags: map[string]*string{
-					serviceTagKey: to.StringPtr("nginx"),
+					serviceTagKey: to.StringPtr("default/nginx"),
+				},
+				PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
+					IPAddress: to.StringPtr("1.2.3.4"),
 				},
 			},
-			serviceName: "web",
-			expected:    false,
+			serviceName:  "web",
+			expectedOwns: false,
 		},
 		{
 			desc: "true should be returned when service name tag matches and cluster name tag is not set",
 			pip: &network.PublicIPAddress{
 				Tags: map[string]*string{
-					serviceTagKey: to.StringPtr("nginx"),
+					serviceTagKey: to.StringPtr("default/nginx"),
+				},
+				PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
+					IPAddress: to.StringPtr("1.2.3.4"),
 				},
 			},
-			clusterName: "kubernetes",
-			serviceName: "nginx",
-			expected:    true,
+			clusterName:  "kubernetes",
+			serviceName:  "nginx",
+			expectedOwns: true,
 		},
 		{
 			desc: "false should be returned when cluster name doesn't match",
 			pip: &network.PublicIPAddress{
 				Tags: map[string]*string{
-					serviceTagKey:  to.StringPtr("nginx"),
+					serviceTagKey:  to.StringPtr("default/nginx"),
 					clusterNameKey: to.StringPtr("kubernetes"),
 				},
+				PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
+					IPAddress: to.StringPtr("1.2.3.4"),
+				},
 			},
-			clusterName: "k8s",
-			serviceName: "nginx",
-			expected:    false,
+			clusterName:  "k8s",
+			serviceName:  "nginx",
+			expectedOwns: false,
 		},
 		{
 			desc: "false should be returned when cluster name matches while service name doesn't match",
 			pip: &network.PublicIPAddress{
 				Tags: map[string]*string{
-					serviceTagKey:  to.StringPtr("web"),
+					serviceTagKey:  to.StringPtr("default/web"),
 					clusterNameKey: to.StringPtr("kubernetes"),
 				},
+				PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
+					IPAddress: to.StringPtr("1.2.3.4"),
+				},
 			},
-			clusterName: "kubernetes",
-			serviceName: "nginx",
-			expected:    false,
+			clusterName:  "kubernetes",
+			serviceName:  "nginx",
+			expectedOwns: false,
 		},
 		{
 			desc: "true should be returned when both service name tag and cluster name match",
 			pip: &network.PublicIPAddress{
 				Tags: map[string]*string{
-					serviceTagKey:  to.StringPtr("nginx"),
+					serviceTagKey:  to.StringPtr("default/nginx"),
 					clusterNameKey: to.StringPtr("kubernetes"),
 				},
+				PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
+					IPAddress: to.StringPtr("1.2.3.4"),
+				},
 			},
-			clusterName: "kubernetes",
-			serviceName: "nginx",
-			expected:    true,
+			clusterName:  "kubernetes",
+			serviceName:  "nginx",
+			expectedOwns: true,
 		},
 		{
 			desc: "false should be returned when the tag is empty",
@@ -523,22 +540,29 @@ func TestServiceOwnsPublicIP(t *testing.T) {
 					serviceTagKey:  to.StringPtr(""),
 					clusterNameKey: to.StringPtr("kubernetes"),
 				},
+				PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
+					IPAddress: to.StringPtr("1.2.3.4"),
+				},
 			},
-			clusterName: "kubernetes",
-			serviceName: "nginx",
-			expected:    false,
+			clusterName:             "kubernetes",
+			serviceName:             "nginx",
+			expectedOwns:            false,
+			expectedUserAssignedPIP: true,
 		},
 		{
 			desc: "true should be returned if there is a match among a multi-service tag",
 			pip: &network.PublicIPAddress{
 				Tags: map[string]*string{
-					serviceTagKey:  to.StringPtr("nginx1,nginx2"),
+					serviceTagKey:  to.StringPtr("default/nginx1,default/nginx2"),
 					clusterNameKey: to.StringPtr("kubernetes"),
 				},
+				PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
+					IPAddress: to.StringPtr("1.2.3.4"),
+				},
 			},
-			clusterName: "kubernetes",
-			serviceName: "nginx1",
-			expected:    true,
+			clusterName:  "kubernetes",
+			serviceName:  "nginx1",
+			expectedOwns: true,
 		},
 		{
 			desc: "false should be returned if there is not a match among a multi-service tag",
@@ -547,16 +571,59 @@ func TestServiceOwnsPublicIP(t *testing.T) {
 					serviceTagKey:  to.StringPtr("default/nginx1,default/nginx2"),
 					clusterNameKey: to.StringPtr("kubernetes"),
 				},
+				PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
+					IPAddress: to.StringPtr("1.2.3.4"),
+				},
 			},
-			clusterName: "kubernetes",
-			serviceName: "nginx3",
-			expected:    false,
+			clusterName:  "kubernetes",
+			serviceName:  "nginx3",
+			expectedOwns: false,
+		},
+		{
+			desc: "true should be returned if the load balancer IP is matched even if the svc name is not included in the tag",
+			pip: &network.PublicIPAddress{
+				Tags: map[string]*string{
+					serviceTagKey:  to.StringPtr(""),
+					clusterNameKey: to.StringPtr("kubernetes"),
+				},
+				PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
+					IPAddress: to.StringPtr("1.2.3.4"),
+				},
+			},
+			clusterName:             "kubernetes",
+			serviceName:             "nginx3",
+			serviceLBIP:             "1.2.3.4",
+			expectedOwns:            true,
+			expectedUserAssignedPIP: true,
+		},
+		{
+			desc: "true should be returned if the load balancer IP is not matched but the svc name is included in the tag",
+			pip: &network.PublicIPAddress{
+				Tags: map[string]*string{
+					serviceTagKey:  to.StringPtr("default/nginx1,default/nginx2"),
+					clusterNameKey: to.StringPtr("kubernetes"),
+				},
+				PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
+					IPAddress: to.StringPtr("1.2.3.4"),
+				},
+			},
+			clusterName:  "kubernetes",
+			serviceName:  "nginx1",
+			serviceLBIP:  "1.1.1.1",
+			expectedOwns: true,
 		},
 	}
 
 	for i, c := range tests {
-		actual := serviceOwnsPublicIP(c.pip, c.clusterName, c.serviceName)
-		assert.Equal(t, c.expected, actual, "TestCase[%d]: %s", i, c.desc)
+		t.Run(c.desc, func(t *testing.T) {
+			service := getTestService(c.serviceName, v1.ProtocolTCP, nil, false, 80)
+			if c.serviceLBIP != "" {
+				service.Spec.LoadBalancerIP = c.serviceLBIP
+			}
+			owns, isUserAssignedPIP := serviceOwnsPublicIP(&service, c.pip, c.clusterName)
+			assert.Equal(t, c.expectedOwns, owns, "TestCase[%d]: %s", i, c.desc)
+			assert.Equal(t, c.expectedUserAssignedPIP, isUserAssignedPIP, "TestCase[%d]: %s", i, c.desc)
+		})
 	}
 }
 
@@ -619,11 +686,13 @@ func TestShouldReleaseExistingOwnedPublicIP(t *testing.T) {
 
 	tests := []struct {
 		desc                  string
+		desiredPipName        string
 		existingPip           network.PublicIPAddress
+		ipTagRequest          serviceIPTagRequest
+		tags                  map[string]*string
 		lbShouldExist         bool
 		lbIsInternal          bool
-		desiredPipName        string
-		ipTagRequest          serviceIPTagRequest
+		isUserAssignedPIP     bool
 		expectedShouldRelease bool
 	}{
 		{
@@ -715,11 +784,51 @@ func TestShouldReleaseExistingOwnedPublicIP(t *testing.T) {
 			},
 			expectedShouldRelease: true,
 		},
+		{
+			desc:           "should delete orphaned managed public IP",
+			existingPip:    existingPipWithTag,
+			lbShouldExist:  false,
+			lbIsInternal:   false,
+			desiredPipName: *existingPipWithTag.Name,
+			tags:           map[string]*string{serviceTagKey: to.StringPtr("")},
+			ipTagRequest: serviceIPTagRequest{
+				IPTagsRequestedByAnnotation: true,
+				IPTags:                      existingPipWithTag.PublicIPAddressPropertiesFormat.IPTags,
+			},
+			expectedShouldRelease: true,
+		},
+		{
+			desc:           "should not delete managed public IP which has references",
+			existingPip:    existingPipWithTag,
+			lbShouldExist:  false,
+			lbIsInternal:   false,
+			desiredPipName: *existingPipWithTag.Name,
+			tags:           map[string]*string{serviceTagKey: to.StringPtr("svc1")},
+			ipTagRequest: serviceIPTagRequest{
+				IPTagsRequestedByAnnotation: true,
+				IPTags:                      existingPipWithTag.PublicIPAddressPropertiesFormat.IPTags,
+			},
+		},
+		{
+			desc:           "should not delete orphaned unmanaged public IP",
+			existingPip:    existingPipWithTag,
+			lbShouldExist:  false,
+			lbIsInternal:   false,
+			desiredPipName: *existingPipWithTag.Name,
+			tags:           map[string]*string{serviceTagKey: to.StringPtr("")},
+			ipTagRequest: serviceIPTagRequest{
+				IPTagsRequestedByAnnotation: true,
+				IPTags:                      existingPipWithTag.PublicIPAddressPropertiesFormat.IPTags,
+			},
+			isUserAssignedPIP: true,
+		},
 	}
 
 	for i, c := range tests {
-
-		actualShouldRelease := shouldReleaseExistingOwnedPublicIP(&c.existingPip, c.lbShouldExist, c.lbIsInternal, c.desiredPipName, "default/test1", c.ipTagRequest)
+		if c.tags != nil {
+			c.existingPip.Tags = c.tags
+		}
+		actualShouldRelease := shouldReleaseExistingOwnedPublicIP(&c.existingPip, c.lbShouldExist, c.lbIsInternal, c.isUserAssignedPIP, c.desiredPipName, c.ipTagRequest)
 		assert.Equal(t, c.expectedShouldRelease, actualShouldRelease, "TestCase[%d]: %s", i, c.desc)
 	}
 }
@@ -2515,11 +2624,11 @@ func TestReconcilePublicIP(t *testing.T) {
 
 	testCases := []struct {
 		desc                        string
-		wantLb                      bool
+		expectedID                  string
 		annotations                 map[string]string
 		existingPIPs                []network.PublicIPAddress
-		expectedID                  string
 		expectedPIP                 *network.PublicIPAddress
+		wantLb                      bool
 		expectedError               bool
 		expectedCreateOrUpdateCount int
 		expectedDeleteCount         int
@@ -2548,6 +2657,9 @@ func TestReconcilePublicIP(t *testing.T) {
 				{
 					Name: to.StringPtr("pip1"),
 					Tags: map[string]*string{"service": to.StringPtr("default/test1")},
+					PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
+						IPAddress: to.StringPtr("1.2.3.4"),
+					},
 				},
 			},
 			expectedID: "/subscriptions/subscription/resourceGroups/rg/providers/" +
@@ -2581,14 +2693,23 @@ func TestReconcilePublicIP(t *testing.T) {
 				{
 					Name: to.StringPtr("pip1"),
 					Tags: map[string]*string{"service": to.StringPtr("default/test1")},
+					PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
+						IPAddress: to.StringPtr("1.2.3.4"),
+					},
 				},
 				{
 					Name: to.StringPtr("pip2"),
 					Tags: map[string]*string{"service": to.StringPtr("default/test1")},
+					PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
+						IPAddress: to.StringPtr("1.2.3.4"),
+					},
 				},
 				{
 					Name: to.StringPtr("testPIP"),
 					Tags: map[string]*string{"service": to.StringPtr("default/test1")},
+					PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
+						IPAddress: to.StringPtr("1.2.3.4"),
+					},
 				},
 			},
 			expectedPIP: &network.PublicIPAddress{
@@ -2596,8 +2717,8 @@ func TestReconcilePublicIP(t *testing.T) {
 				Name: to.StringPtr("testPIP"),
 				Tags: map[string]*string{"service": to.StringPtr("default/test1")},
 				PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
-					PublicIPAllocationMethod: network.Static,
-					PublicIPAddressVersion:   network.IPv4,
+					PublicIPAddressVersion: network.IPv4,
+					IPAddress:              to.StringPtr("1.2.3.4"),
 				},
 			},
 			expectedCreateOrUpdateCount: 1,
@@ -2611,14 +2732,23 @@ func TestReconcilePublicIP(t *testing.T) {
 				{
 					Name: to.StringPtr("pip1"),
 					Tags: map[string]*string{"service": to.StringPtr("default/test1")},
+					PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
+						IPAddress: to.StringPtr("1.2.3.4"),
+					},
 				},
 				{
 					Name: to.StringPtr("pip2"),
 					Tags: map[string]*string{"service": to.StringPtr("default/test1,default/test2")},
+					PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
+						IPAddress: to.StringPtr("1.2.3.4"),
+					},
 				},
 				{
 					Name: to.StringPtr("testPIP"),
 					Tags: map[string]*string{"service": to.StringPtr("default/test1")},
+					PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
+						IPAddress: to.StringPtr("1.2.3.4"),
+					},
 				},
 			},
 			expectedPIP: &network.PublicIPAddress{
@@ -2626,8 +2756,8 @@ func TestReconcilePublicIP(t *testing.T) {
 				Name: to.StringPtr("testPIP"),
 				Tags: map[string]*string{"service": to.StringPtr("default/test1")},
 				PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
-					PublicIPAllocationMethod: network.Static,
-					PublicIPAddressVersion:   network.IPv4,
+					PublicIPAddressVersion: network.IPv4,
+					IPAddress:              to.StringPtr("1.2.3.4"),
 				},
 			},
 			expectedCreateOrUpdateCount: 1,
@@ -2644,14 +2774,23 @@ func TestReconcilePublicIP(t *testing.T) {
 				{
 					Name: to.StringPtr("pip1"),
 					Tags: map[string]*string{"service": to.StringPtr("default/test1")},
+					PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
+						IPAddress: to.StringPtr("1.2.3.4"),
+					},
 				},
 				{
 					Name: to.StringPtr("pip2"),
 					Tags: map[string]*string{"service": to.StringPtr("default/test1")},
+					PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
+						IPAddress: to.StringPtr("1.2.3.4"),
+					},
 				},
 				{
 					Name: to.StringPtr("testPIP"),
 					Tags: map[string]*string{"service": to.StringPtr("default/test1")},
+					PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
+						IPAddress: to.StringPtr("1.2.3.4"),
+					},
 				},
 			},
 			expectedPIP: &network.PublicIPAddress{
@@ -2692,6 +2831,7 @@ func TestReconcilePublicIP(t *testing.T) {
 								Tag:       to.StringPtr("tag1value"),
 							},
 						},
+						IPAddress: to.StringPtr("1.2.3.4"),
 					},
 				},
 			},
@@ -2708,6 +2848,7 @@ func TestReconcilePublicIP(t *testing.T) {
 							Tag:       to.StringPtr("tag1value"),
 						},
 					},
+					IPAddress: to.StringPtr("1.2.3.4"),
 				},
 			},
 			expectedCreateOrUpdateCount: 1,
@@ -2720,21 +2861,30 @@ func TestReconcilePublicIP(t *testing.T) {
 			existingPIPs: []network.PublicIPAddress{
 				{
 					Name: to.StringPtr("pip1"),
+					PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
+						IPAddress: to.StringPtr("1.2.3.4"),
+					},
 				},
 				{
 					Name: to.StringPtr("pip2"),
 					Tags: map[string]*string{"service": to.StringPtr("default/test1")},
+					PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
+						IPAddress: to.StringPtr("1.2.3.4"),
+					},
 				},
 				{
 					Name: to.StringPtr("testPIP"),
+					PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
+						IPAddress: to.StringPtr("1.2.3.4"),
+					},
 				},
 			},
 			expectedPIP: &network.PublicIPAddress{
 				ID:   to.StringPtr("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/testPIP"),
 				Name: to.StringPtr("testPIP"),
 				PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
-					PublicIPAllocationMethod: network.Static,
-					PublicIPAddressVersion:   network.IPv4,
+					PublicIPAddressVersion: network.IPv4,
+					IPAddress:              to.StringPtr("1.2.3.4"),
 				},
 			},
 			expectedCreateOrUpdateCount: 1,
@@ -2747,6 +2897,9 @@ func TestReconcilePublicIP(t *testing.T) {
 				{
 					Name: to.StringPtr("pip1"),
 					Tags: map[string]*string{serviceTagKey: to.StringPtr("default/test1,default/test2")},
+					PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
+						IPAddress: to.StringPtr("1.2.3.4"),
+					},
 				},
 			},
 			expectedCreateOrUpdateCount: 1,
@@ -2754,91 +2907,93 @@ func TestReconcilePublicIP(t *testing.T) {
 	}
 
 	for i, test := range testCases {
-		deletedPips := make(map[string]bool)
-		savedPips := make(map[string]network.PublicIPAddress)
-		createOrUpdateCount := 0
-		var m sync.Mutex
-		az := GetTestCloud(ctrl)
-		mockPIPsClient := az.PublicIPAddressesClient.(*mockpublicipclient.MockInterface)
-		creator := mockPIPsClient.EXPECT().CreateOrUpdate(gomock.Any(), "rg", gomock.Any(), gomock.Any()).AnyTimes()
-		creator.DoAndReturn(func(ctx context.Context, resourceGroupName string, publicIPAddressName string, parameters network.PublicIPAddress) *retry.Error {
-			m.Lock()
-			deletedPips[publicIPAddressName] = false
-			savedPips[publicIPAddressName] = parameters
-			createOrUpdateCount++
-			m.Unlock()
-			return nil
-		})
-
-		mockPIPsClient.EXPECT().List(gomock.Any(), "rg").Return(test.existingPIPs, nil).AnyTimes()
-		if i == 2 {
-			mockPIPsClient.EXPECT().Get(gomock.Any(), "rg", "testCluster-atest1", gomock.Any()).Return(network.PublicIPAddress{}, &retry.Error{HTTPStatusCode: http.StatusNotFound}).Times(1)
-			mockPIPsClient.EXPECT().Get(gomock.Any(), "rg", "testCluster-atest1", gomock.Any()).Return(network.PublicIPAddress{ID: to.StringPtr("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/testCluster-atest1")}, nil).Times(1)
-		}
-		service := getTestService("test1", v1.ProtocolTCP, nil, false, 80)
-		service.Annotations = test.annotations
-		for _, pip := range test.existingPIPs {
-			savedPips[*pip.Name] = pip
-			getter := mockPIPsClient.EXPECT().Get(gomock.Any(), "rg", *pip.Name, gomock.Any()).AnyTimes()
-			getter.DoAndReturn(func(ctx context.Context, resourceGroupName string, publicIPAddressName string, expand string) (result network.PublicIPAddress, rerr *retry.Error) {
+		t.Run(test.desc, func(t *testing.T) {
+			deletedPips := make(map[string]bool)
+			savedPips := make(map[string]network.PublicIPAddress)
+			createOrUpdateCount := 0
+			var m sync.Mutex
+			az := GetTestCloud(ctrl)
+			mockPIPsClient := az.PublicIPAddressesClient.(*mockpublicipclient.MockInterface)
+			creator := mockPIPsClient.EXPECT().CreateOrUpdate(gomock.Any(), "rg", gomock.Any(), gomock.Any()).AnyTimes()
+			creator.DoAndReturn(func(ctx context.Context, resourceGroupName string, publicIPAddressName string, parameters network.PublicIPAddress) *retry.Error {
 				m.Lock()
-				deletedValue, deletedContains := deletedPips[publicIPAddressName]
-				savedPipValue, savedPipContains := savedPips[publicIPAddressName]
-				m.Unlock()
-
-				if (!deletedContains || !deletedValue) && savedPipContains {
-					return savedPipValue, nil
-				}
-
-				return network.PublicIPAddress{}, &retry.Error{HTTPStatusCode: http.StatusNotFound}
-
-			})
-			deleter := mockPIPsClient.EXPECT().Delete(gomock.Any(), "rg", *pip.Name).Return(nil).AnyTimes()
-			deleter.Do(func(ctx context.Context, resourceGroupName string, publicIPAddressName string) *retry.Error {
-				m.Lock()
-				deletedPips[publicIPAddressName] = true
+				deletedPips[publicIPAddressName] = false
+				savedPips[publicIPAddressName] = parameters
+				createOrUpdateCount++
 				m.Unlock()
 				return nil
 			})
 
-			err := az.PublicIPAddressesClient.CreateOrUpdate(context.TODO(), "rg", to.String(pip.Name), pip)
-			if err != nil {
-				t.Fatalf("TestCase[%d] meets unexpected error: %v", i, err)
+			mockPIPsClient.EXPECT().List(gomock.Any(), "rg").Return(test.existingPIPs, nil).AnyTimes()
+			if i == 2 {
+				mockPIPsClient.EXPECT().Get(gomock.Any(), "rg", "testCluster-atest1", gomock.Any()).Return(network.PublicIPAddress{}, &retry.Error{HTTPStatusCode: http.StatusNotFound}).Times(1)
+				mockPIPsClient.EXPECT().Get(gomock.Any(), "rg", "testCluster-atest1", gomock.Any()).Return(network.PublicIPAddress{ID: to.StringPtr("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/testCluster-atest1")}, nil).Times(1)
 			}
+			service := getTestService("test1", v1.ProtocolTCP, nil, false, 80)
+			service.Annotations = test.annotations
+			for _, pip := range test.existingPIPs {
+				savedPips[*pip.Name] = pip
+				getter := mockPIPsClient.EXPECT().Get(gomock.Any(), "rg", *pip.Name, gomock.Any()).AnyTimes()
+				getter.DoAndReturn(func(ctx context.Context, resourceGroupName string, publicIPAddressName string, expand string) (result network.PublicIPAddress, rerr *retry.Error) {
+					m.Lock()
+					deletedValue, deletedContains := deletedPips[publicIPAddressName]
+					savedPipValue, savedPipContains := savedPips[publicIPAddressName]
+					m.Unlock()
 
-			// Clear create or update count to prepare for main execution
-			createOrUpdateCount = 0
-		}
-		pip, err := az.reconcilePublicIP("testCluster", &service, "", test.wantLb)
-		if !test.expectedError {
-			assert.Equal(t, nil, err, "TestCase[%d]: %s", i, test.desc)
-		}
-		if test.expectedID != "" {
-			assert.Equal(t, test.expectedID, to.String(pip.ID), "TestCase[%d]: %s", i, test.desc)
-		} else if test.expectedPIP != nil && test.expectedPIP.Name != nil {
-			assert.Equal(t, *test.expectedPIP.Name, *pip.Name, "TestCase[%d]: %s", i, test.desc)
+					if (!deletedContains || !deletedValue) && savedPipContains {
+						return savedPipValue, nil
+					}
 
-			if test.expectedPIP.PublicIPAddressPropertiesFormat != nil {
-				sortIPTags(test.expectedPIP.PublicIPAddressPropertiesFormat.IPTags)
+					return network.PublicIPAddress{}, &retry.Error{HTTPStatusCode: http.StatusNotFound}
+
+				})
+				deleter := mockPIPsClient.EXPECT().Delete(gomock.Any(), "rg", *pip.Name).Return(nil).AnyTimes()
+				deleter.Do(func(ctx context.Context, resourceGroupName string, publicIPAddressName string) *retry.Error {
+					m.Lock()
+					deletedPips[publicIPAddressName] = true
+					m.Unlock()
+					return nil
+				})
+
+				err := az.PublicIPAddressesClient.CreateOrUpdate(context.TODO(), "rg", to.String(pip.Name), pip)
+				if err != nil {
+					t.Fatalf("TestCase[%d] meets unexpected error: %v", i, err)
+				}
+
+				// Clear create or update count to prepare for main execution
+				createOrUpdateCount = 0
 			}
-
-			if pip.PublicIPAddressPropertiesFormat != nil {
-				sortIPTags(pip.PublicIPAddressPropertiesFormat.IPTags)
+			pip, err := az.reconcilePublicIP("testCluster", &service, "", test.wantLb)
+			if !test.expectedError {
+				assert.Equal(t, nil, err, "TestCase[%d]: %s", i, test.desc)
 			}
+			if test.expectedID != "" {
+				assert.Equal(t, test.expectedID, to.String(pip.ID), "TestCase[%d]: %s", i, test.desc)
+			} else if test.expectedPIP != nil && test.expectedPIP.Name != nil {
+				assert.Equal(t, *test.expectedPIP.Name, *pip.Name, "TestCase[%d]: %s", i, test.desc)
 
-			assert.Equal(t, test.expectedPIP.PublicIPAddressPropertiesFormat, pip.PublicIPAddressPropertiesFormat, "TestCase[%d]: %s", i, test.desc)
+				if test.expectedPIP.PublicIPAddressPropertiesFormat != nil {
+					sortIPTags(test.expectedPIP.PublicIPAddressPropertiesFormat.IPTags)
+				}
 
-		}
-		assert.Equal(t, test.expectedCreateOrUpdateCount, createOrUpdateCount, "TestCase[%d]: %s", i, test.desc)
-		assert.Equal(t, test.expectedError, err != nil, "TestCase[%d]: %s", i, test.desc)
+				if pip.PublicIPAddressPropertiesFormat != nil {
+					sortIPTags(pip.PublicIPAddressPropertiesFormat.IPTags)
+				}
 
-		deletedCount := 0
-		for _, deleted := range deletedPips {
-			if deleted {
-				deletedCount++
+				assert.Equal(t, test.expectedPIP.PublicIPAddressPropertiesFormat, pip.PublicIPAddressPropertiesFormat, "TestCase[%d]: %s", i, test.desc)
+
 			}
-		}
-		assert.Equal(t, test.expectedDeleteCount, deletedCount, "TestCase[%d]: %s", i, test.desc)
+			assert.Equal(t, test.expectedCreateOrUpdateCount, createOrUpdateCount, "TestCase[%d]: %s", i, test.desc)
+			assert.Equal(t, test.expectedError, err != nil, "TestCase[%d]: %s", i, test.desc)
+
+			deletedCount := 0
+			for _, deleted := range deletedPips {
+				if deleted {
+					deletedCount++
+				}
+			}
+			assert.Equal(t, test.expectedDeleteCount, deletedCount, "TestCase[%d]: %s", i, test.desc)
+		})
 	}
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

/kind bug

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

The user-created services could be deleted accidentally because we delete the pip by checking if the service tags on it are empty. This fix solves the issue by not tagging the user-created pips.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes-sigs/cloud-provider-azure/issues/573

#### Special notes for your reviewer:

Cherry-picked from https://github.com/kubernetes-sigs/cloud-provider-azure/pull/574

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
fix: not delete existing pip when service is deleted
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

/triage accepted
/priority important-soon
/sig cloud-provider
/area provider/azure

cc @feiskyer 