### PR TITLE
Automated cherry pick of #100687: Switch to newer agnhost image

### DIFF
--- a/build/dependencies.yaml
+++ b/build/dependencies.yaml
@@ -27,7 +27,7 @@ dependencies:
 
   # then after merge and successful postsubmit image push / promotion, bump this
   - name: "agnhost: dependents"
-    version: "2.30"
+    version: "2.31"
     refPaths:
     - path: test/utils/image/manifest.go
       match: configs\[Agnhost\] = Config{promoterE2eRegistry, "agnhost", "\d+\.\d+"}

--- a/test/utils/image/manifest.go
+++ b/test/utils/image/manifest.go
@@ -213,7 +213,7 @@ const (
 
 func initImageConfigs() (map[int]Config, map[int]Config) {
 	configs := map[int]Config{}
-	configs[Agnhost] = Config{promoterE2eRegistry, "agnhost", "2.30"}
+	configs[Agnhost] = Config{promoterE2eRegistry, "agnhost", "2.31"}
 	configs[AgnhostPrivate] = Config{PrivateRegistry, "agnhost", "2.6"}
 	configs[AuthenticatedAlpine] = Config{gcAuthenticatedRegistry, "alpine", "3.7"}
 	configs[AuthenticatedWindowsNanoServer] = Config{gcAuthenticatedRegistry, "windows-nanoserver", "v1"}


### PR DESCRIPTION
Cherry pick of #100687 on release-1.21.

#100687: Switch to newer agnhost image

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.