### PR TITLE
Add basic reconciliation metrics to controllers

### DIFF
--- a/cmd/kube-controller-manager/app/controllermanager.go
+++ b/cmd/kube-controller-manager/app/controllermanager.go
@@ -63,9 +63,9 @@ import (
 	"k8s.io/controller-manager/pkg/informerfactory"
 	"k8s.io/controller-manager/pkg/leadermigration"
 	"k8s.io/klog/v2"
-
 	"k8s.io/kubernetes/cmd/kube-controller-manager/app/config"
 	"k8s.io/kubernetes/cmd/kube-controller-manager/app/options"
+	"k8s.io/kubernetes/pkg/controller"
 	kubectrlmgrconfig "k8s.io/kubernetes/pkg/controller/apis/config"
 	serviceaccountcontroller "k8s.io/kubernetes/pkg/controller/serviceaccount"
 	"k8s.io/kubernetes/pkg/serviceaccount"
@@ -217,6 +217,7 @@ func Run(c *config.CompletedConfig, stopCh <-chan struct{}) error {
 
 	run := func(ctx context.Context, startSATokenController InitFunc, initializersFunc ControllerInitializersFunc) {
 
+		controller.RegisterMetrics()
 		controllerContext, err := CreateControllerContext(c, rootClientBuilder, clientBuilder, ctx.Done())
 		if err != nil {
 			klog.Fatalf("error building controller context: %v", err)

--- a/pkg/controller/certificates/certificate_controller.go
+++ b/pkg/controller/certificates/certificate_controller.go
@@ -143,7 +143,8 @@ func (cc *CertificateController) processNextWorkItem() bool {
 	}
 	defer cc.queue.Done(cKey)
 
-	if err := cc.syncFunc(cKey.(string)); err != nil {
+	err := controller.RunSyncAndRecord(fmt.Sprintf("%s_%s", "certificate", cc.name), cKey.(string), cc.syncFunc)
+	if err != nil {
 		cc.queue.AddRateLimited(cKey)
 		if _, ignorable := err.(ignorableError); !ignorable {
 			utilruntime.HandleError(fmt.Errorf("Sync %v failed with : %v", cKey, err))

--- a/pkg/controller/clusterroleaggregation/clusterroleaggregation_controller.go
+++ b/pkg/controller/clusterroleaggregation/clusterroleaggregation_controller.go
@@ -62,7 +62,9 @@ func NewClusterRoleAggregation(clusterRoleInformer rbacinformers.ClusterRoleInfo
 
 		queue: workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "ClusterRoleAggregator"),
 	}
-	c.syncHandler = c.syncClusterRole
+	// note: the name doesn't match the workqueue name so that it is more consistent with
+	// the other controller names -- e.g. "certificate".
+	c.syncHandler = controller.SyncAndRecord("clusterroleaggregator", c.syncClusterRole)
 
 	clusterRoleInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {

--- a/pkg/controller/daemon/daemon_controller.go
+++ b/pkg/controller/daemon/daemon_controller.go
@@ -201,7 +201,7 @@ func NewDaemonSetsController(
 	dsc.nodeStoreSynced = nodeInformer.Informer().HasSynced
 	dsc.nodeLister = nodeInformer.Lister()
 
-	dsc.syncHandler = dsc.syncDaemonSet
+	dsc.syncHandler = controller.SyncAndRecord("daemonset", dsc.syncDaemonSet)
 	dsc.enqueueDaemonSet = dsc.enqueue
 
 	dsc.failedPodsBackoff = failedPodsBackoff

--- a/pkg/controller/deployment/deployment_controller.go
+++ b/pkg/controller/deployment/deployment_controller.go
@@ -133,7 +133,7 @@ func NewDeploymentController(dInformer appsinformers.DeploymentInformer, rsInfor
 		DeleteFunc: dc.deletePod,
 	})
 
-	dc.syncHandler = dc.syncDeployment
+	dc.syncHandler = controller.SyncAndRecord("deployment", dc.syncDeployment)
 	dc.enqueueDeployment = dc.enqueue
 
 	dc.dLister = dInformer.Lister()

--- a/pkg/controller/disruption/disruption.go
+++ b/pkg/controller/disruption/disruption.go
@@ -525,7 +525,7 @@ func (dc *DisruptionController) processNextWorkItem() bool {
 	}
 	defer dc.queue.Done(dKey)
 
-	err := dc.sync(dKey.(string))
+	err := controller.RunSyncAndRecord("disruption", dKey.(string), dc.sync)
 	if err == nil {
 		dc.queue.Forget(dKey)
 		return true

--- a/pkg/controller/endpoint/endpoints_controller.go
+++ b/pkg/controller/endpoint/endpoints_controller.go
@@ -353,7 +353,7 @@ func (e *Controller) processNextWorkItem() bool {
 	}
 	defer e.queue.Done(eKey)
 
-	err := e.syncService(eKey.(string))
+	err := controller.RunSyncAndRecord("endpoints", eKey.(string), e.syncService)
 	e.handleErr(err, eKey)
 
 	return true

--- a/pkg/controller/endpointslice/endpointslice_controller.go
+++ b/pkg/controller/endpointslice/endpointslice_controller.go
@@ -288,7 +288,7 @@ func (c *Controller) processNextWorkItem() bool {
 	}
 	defer c.queue.Done(cKey)
 
-	err := c.syncService(cKey.(string))
+	err := controller.RunSyncAndRecord("endpointslice", cKey.(string), c.syncService)
 	c.handleErr(err, cKey)
 
 	return true

--- a/pkg/controller/endpointslicemirroring/endpointslicemirroring_controller.go
+++ b/pkg/controller/endpointslicemirroring/endpointslicemirroring_controller.go
@@ -240,7 +240,7 @@ func (c *Controller) processNextWorkItem() bool {
 	}
 	defer c.queue.Done(cKey)
 
-	err := c.syncEndpoints(cKey.(string))
+	err := controller.RunSyncAndRecord("endpointslicemirroring", cKey.(string), c.syncEndpoints)
 	c.handleErr(err, cKey)
 
 	return true

--- a/pkg/controller/job/job_controller.go
+++ b/pkg/controller/job/job_controller.go
@@ -156,7 +156,7 @@ func NewController(podInformer coreinformers.PodInformer, jobInformer batchinfor
 
 	jm.updateStatusHandler = jm.updateJobStatus
 	jm.patchJobHandler = jm.patchJob
-	jm.syncHandler = jm.syncJob
+	jm.syncHandler = controller.SyncAndRecordWithBool("job", jm.syncJob)
 
 	metrics.Register()
 

--- a/pkg/controller/metrics.go
+++ b/pkg/controller/metrics.go
@@ -1,0 +1,118 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"sync"
+	"time"
+
+	"k8s.io/component-base/metrics"
+	"k8s.io/component-base/metrics/legacyregistry"
+	"k8s.io/klog/v2"
+)
+
+const controllerNamespace = "controller"
+
+var (
+	ReconciliationDurations = metrics.NewHistogramVec(
+		&metrics.HistogramOpts{
+			Namespace:      controllerNamespace,
+			Name:           "reconcile_time_seconds",
+			Help:           "Duration of a sync of a controller's resource",
+			StabilityLevel: metrics.ALPHA,
+			Buckets:        metrics.ExponentialBuckets(0.001, 2, 15),
+		},
+		[]string{"controller", "status"},
+	)
+)
+
+var registerMetrics sync.Once
+
+// RegisterMetrics registers the controller metrics
+func RegisterMetrics() {
+	registerMetrics.Do(func() {
+		legacyregistry.MustRegister(ReconciliationDurations)
+	})
+}
+
+// SyncAndRecord wraps syncFn with a function, recording its result and duration as a metric.
+func SyncAndRecord(
+	controllerName string, syncFn func(string) error) func(string) error {
+	return func(key string) error {
+		return RunSyncAndRecord(controllerName, key, syncFn)
+	}
+}
+
+// RunSyncAndRecord runs syncFn with key, recording the reconcile time and results
+func RunSyncAndRecord(
+	controllerName string, key string, syncFn func(string) error) error {
+	startTime := time.Now()
+	err := syncFn(key)
+	recordSyncResult(controllerName, startTime, err)
+	return err
+}
+
+// SyncAndRecordWithBool wraps syncFn with a function, recording its result and duration as a metric.
+func SyncAndRecordWithBool(
+	controllerName string, syncFn func(string) (bool, error)) func(string) (bool, error) {
+	return func(key string) (bool, error) {
+		return RunSyncAndRecordWithBool(controllerName, key, syncFn)
+	}
+}
+
+// RunSyncAndRecordWithBool runs syncFn with key, recording the reconcile time and results
+func RunSyncAndRecordWithBool(
+	controllerName string, key string, syncFn func(string) (bool, error)) (bool, error) {
+	startTime := time.Now()
+	bool, err := syncFn(key)
+	recordSyncResult(controllerName, startTime, err)
+	return bool, err
+}
+
+// SyncAndRecordAll wraps syncFn with a function, recording its result and duration as a metric.
+func SyncAndRecordAll(controllerName string, syncFn func() error) func() {
+	return func() {
+		RunSyncAndRecordAll(controllerName, syncFn)
+	}
+}
+
+// RunSyncAndRecordAll runs syncFn, recording the reconcile time and results
+func RunSyncAndRecordAll(controllerName string, syncFn func() error) {
+	startTime := time.Now()
+	err := syncFn()
+	recordSyncResult(controllerName, startTime, err)
+}
+
+const (
+	// success indicates a successful sync operation
+	success = "success"
+	// failed indicates a failed sync operation
+	failed = "failed"
+)
+
+// recordSyncResult records the results of a controller sync operation
+func recordSyncResult(controllerName string, startTime time.Time, err error) {
+	status := success
+	if err != nil {
+		status = failed
+	}
+	syncDuration := time.Since(startTime).Seconds()
+
+	ReconciliationDurations.WithLabelValues(controllerName, status).Observe(syncDuration)
+	klog.V(4).Infof("Controller %s finished syncing in %.3f seconds with status %s",
+		controllerName, syncDuration, status)
+}

--- a/pkg/controller/namespace/namespace_controller.go
+++ b/pkg/controller/namespace/namespace_controller.go
@@ -145,7 +145,7 @@ func (nm *NamespaceController) worker() {
 		}
 		defer nm.queue.Done(key)
 
-		err := nm.syncNamespaceFromKey(key.(string))
+		err := controller.RunSyncAndRecord("namespace", key.(string), nm.syncNamespaceFromKey)
 		if err == nil {
 			// no error, forget this entry and return
 			nm.queue.Forget(key)

--- a/pkg/controller/podautoscaler/horizontal.go
+++ b/pkg/controller/podautoscaler/horizontal.go
@@ -222,7 +222,7 @@ func (a *HorizontalController) processNextWorkItem() bool {
 	}
 	defer a.queue.Done(key)
 
-	deleted, err := a.reconcileKey(key.(string))
+	deleted, err := controller.RunSyncAndRecordWithBool("horizontalpodautoscaler", key.(string), a.reconcileKey)
 	if err != nil {
 		utilruntime.HandleError(err)
 	}

--- a/pkg/controller/replicaset/replica_set.go
+++ b/pkg/controller/replicaset/replica_set.go
@@ -164,7 +164,7 @@ func NewBaseController(rsInformer appsinformers.ReplicaSetInformer, podInformer 
 	rsc.podLister = podInformer.Lister()
 	rsc.podListerSynced = podInformer.Informer().HasSynced
 
-	rsc.syncHandler = rsc.syncReplicaSet
+	rsc.syncHandler = controller.SyncAndRecord("replicaset", rsc.syncReplicaSet)
 
 	return rsc
 }

--- a/pkg/controller/resourcequota/resource_quota_controller.go
+++ b/pkg/controller/resourcequota/resource_quota_controller.go
@@ -114,7 +114,7 @@ func NewController(options *ControllerOptions) (*Controller, error) {
 		registry:            options.Registry,
 	}
 	// set the synchronization handler
-	rq.syncHandler = rq.syncResourceQuotaFromKey
+	rq.syncHandler = controller.SyncAndRecord("resourcequota", rq.syncResourceQuotaFromKey)
 
 	options.ResourceQuotaInformer.Informer().AddEventHandlerWithResyncPeriod(
 		cache.ResourceEventHandlerFuncs{

--- a/pkg/controller/serviceaccount/serviceaccounts_controller.go
+++ b/pkg/controller/serviceaccount/serviceaccounts_controller.go
@@ -34,6 +34,7 @@ import (
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/component-base/metrics/prometheus/ratelimiter"
 	"k8s.io/klog/v2"
+	"k8s.io/kubernetes/pkg/controller"
 )
 
 // ServiceAccountsControllerOptions contains options for running a ServiceAccountsController
@@ -87,7 +88,7 @@ func NewServiceAccountsController(saInformer coreinformers.ServiceAccountInforme
 	e.nsLister = nsInformer.Lister()
 	e.nsListerSynced = nsInformer.Informer().HasSynced
 
-	e.syncHandler = e.syncNamespace
+	e.syncHandler = controller.SyncAndRecord("serviceaccount", e.syncNamespace)
 
 	return e, nil
 }

--- a/pkg/controller/statefulset/stateful_set.go
+++ b/pkg/controller/statefulset/stateful_set.go
@@ -409,7 +409,8 @@ func (ssc *StatefulSetController) processNextWorkItem() bool {
 		return false
 	}
 	defer ssc.queue.Done(key)
-	if err := ssc.sync(key.(string)); err != nil {
+	err := controller.RunSyncAndRecord("statefulset", key.(string), ssc.sync)
+	if err != nil {
 		utilruntime.HandleError(fmt.Errorf("error syncing StatefulSet %v, requeuing: %v", key.(string), err))
 		ssc.queue.AddRateLimited(key)
 	} else {


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

This adds a histogram metric to various controllers, `controller_reconcile_time_seconds`.

Example output:
```
# HELP controller_reconcile_time_seconds [ALPHA] Duration of a sync of a controller's resource
# TYPE controller_reconcile_time_seconds histogram
controller_reconcile_time_seconds_bucket{controller="statefulset",status="error",le="0.001"} 0
controller_reconcile_time_seconds_bucket{controller="statefulset",status="error",le="0.002"} 0
controller_reconcile_time_seconds_bucket{controller="statefulset",status="error",le="0.004"} 0
controller_reconcile_time_seconds_bucket{controller="statefulset",status="error",le="0.008"} 0
controller_reconcile_time_seconds_bucket{controller="statefulset",status="error",le="0.016"} 0
controller_reconcile_time_seconds_bucket{controller="statefulset",status="error",le="0.032"} 6
controller_reconcile_time_seconds_bucket{controller="statefulset",status="error",le="0.064"} 8
controller_reconcile_time_seconds_bucket{controller="statefulset",status="error",le="0.128"} 16
controller_reconcile_time_seconds_bucket{controller="statefulset",status="error",le="0.256"} 37
controller_reconcile_time_seconds_bucket{controller="statefulset",status="error",le="0.512"} 47
controller_reconcile_time_seconds_bucket{controller="statefulset",status="error",le="1.024"} 49
controller_reconcile_time_seconds_bucket{controller="statefulset",status="error",le="2.048"} 49
controller_reconcile_time_seconds_bucket{controller="statefulset",status="error",le="4.096"} 49
controller_reconcile_time_seconds_bucket{controller="statefulset",status="error",le="8.192"} 49
controller_reconcile_time_seconds_bucket{controller="statefulset",status="error",le="16.384"} 49
controller_reconcile_time_seconds_bucket{controller="statefulset",status="error",le="+Inf"} 49
controller_reconcile_time_seconds_sum{controller="statefulset",status="error"} 9.560064066000002
controller_reconcile_time_seconds_count{controller="statefulset",status="error"} 49
controller_reconcile_time_seconds_bucket{controller="statefulset",status="success",le="0.001"} 9
controller_reconcile_time_seconds_bucket{controller="statefulset",status="success",le="0.002"} 62
controller_reconcile_time_seconds_bucket{controller="statefulset",status="success",le="0.004"} 222
controller_reconcile_time_seconds_bucket{controller="statefulset",status="success",le="0.008"} 266
controller_reconcile_time_seconds_bucket{controller="statefulset",status="success",le="0.016"} 280
controller_reconcile_time_seconds_bucket{controller="statefulset",status="success",le="0.032"} 307
controller_reconcile_time_seconds_bucket{controller="statefulset",status="success",le="0.064"} 328
controller_reconcile_time_seconds_bucket{controller="statefulset",status="success",le="0.128"} 341
controller_reconcile_time_seconds_bucket{controller="statefulset",status="success",le="0.256"} 347
controller_reconcile_time_seconds_bucket{controller="statefulset",status="success",le="0.512"} 347
controller_reconcile_time_seconds_bucket{controller="statefulset",status="success",le="1.024"} 352
controller_reconcile_time_seconds_bucket{controller="statefulset",status="success",le="2.048"} 352
controller_reconcile_time_seconds_bucket{controller="statefulset",status="success",le="4.096"} 352
controller_reconcile_time_seconds_bucket{controller="statefulset",status="success",le="8.192"} 352
controller_reconcile_time_seconds_bucket{controller="statefulset",status="success",le="16.384"} 352
controller_reconcile_time_seconds_bucket{controller="statefulset",status="success",le="+Inf"} 352
controller_reconcile_time_seconds_sum{controller="statefulset",status="success"} 8.841072798
controller_reconcile_time_seconds_count{controller="statefulset",status="success"} 352
```

#### Does this PR introduce a user-facing change?
```release-note
adds reconciliation metrics for kube-controller-manager.
```