### PR TITLE
e2e: Fix fsType check on in-tree volume tests for Kata Containers

### DIFF
--- a/test/e2e/framework/volume/fixtures.go
+++ b/test/e2e/framework/volume/fixtures.go
@@ -485,9 +485,14 @@ func testVolumeContent(f *framework.Framework, pod *v1.Pod, fsGroup *int64, fsTy
 
 				// Filesystem: check fsType
 				if fsType != "" {
-					ginkgo.By("Checking fsType is correct.")
-					_, err = framework.LookForStringInPodExec(pod.Namespace, pod.Name, []string{"grep", " " + dirName + " ", "/proc/mounts"}, fsType, time.Minute)
-					framework.ExpectNoError(err, "failed: getting the right fsType %s", fsType)
+					// Skip this checking if a Kata Containers pod because the filesystem type
+					// will not match fsType, instead it will be the backend used to share
+					// host filesystems. Currently the guest mounts virtiofs by default.
+					if pod.Spec.RuntimeClassName == nil || !strings.Contains(*pod.Spec.RuntimeClassName, "kata") {
+						ginkgo.By("Checking fsType is correct.")
+						_, err = framework.LookForStringInPodExec(pod.Namespace, pod.Name, []string{"grep", " " + dirName + " ", "/proc/mounts"}, fsType, time.Minute)
+						framework.ExpectNoError(err, "failed: getting the right fsType %s", fsType)
+					}
 				}
 			}
 		}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/sig testing
/sig storage

#### What this PR does / why we need it:

The fsType checking on some of in-tree volume tests should be skipped if the pod was mutate to use Kata Containers because the mounted filesytem on the VM won't match the expected fsType.

#### Which issue(s) this PR fixes:
Related to https://github.com/kubernetes/kubernetes/issues/100710

#### Special notes for your reviewer:

Perhaps ideally we should have an utils method to return whether a kata containers pod or not. I chose to keep it simple as this is my first PR to k8s and also I would like to hear feedback for the solution.

I tested in a cluster with OpenShift 4.7 (kubernetes 1.20) and Kata Containers 2.0.

Without this fix (output snipped):
```
# _output/bin/e2e.test -ginkgo.focus "\[sig-storage\] In-tree Volumes \[Driver: local\]\[LocalVolumeType: block\] \[Testpattern: Pre-provisioned PV \(ext4\)\] volumes should store data"
Mar 31 11:23:24.254: INFO: The --provider flag is not set. Continuing as if --provider=skeleton had been used.
I0331 11:23:24.254683 3865509 e2e.go:129] Starting e2e run "f079d51c-a5f5-4485-b99d-563d9c3fe64b" on Ginkgo node 1
{"msg":"Test Suite starting","total":1,"completed":0,"skipped":0,"failed":0}
Running Suite: Kubernetes e2e suite
===================================
Random Seed: 1617204202 - Will randomize all specs
Will run 1 of 5745 specs

Mar 31 11:23:24.266: INFO: >>> kubeConfig: /root/kubeconfig.quicklab
Mar 31 11:23:24.271: INFO: Waiting up to 30m0s for all (but 0) nodes to be schedulable
Mar 31 11:23:24.624: INFO: Waiting up to 10m0s for all pods (need at least 0) in namespace 'kube-system' to be running and ready
Mar 31 11:23:24.737: INFO: 0 / 0 pods in namespace 'kube-system' are running and ready (0 seconds elapsed)
Mar 31 11:23:24.737: INFO: expected 0 pod replicas in namespace 'kube-system', 0 are Running and Ready.
Mar 31 11:23:24.737: INFO: Waiting up to 5m0s for all daemonsets in namespace 'kube-system' to start
Mar 31 11:23:24.768: INFO: e2e test version: v1.21.0-beta.1.407+b11d0fbdd58394-dirty
Mar 31 11:23:24.792: INFO: kube-apiserver version: v1.20.0+5fbfd19
Mar 31 11:23:24.792: INFO: >>> kubeConfig: /root/kubeconfig.quicklab
Mar 31 11:23:24.848: INFO: Cluster IP family: ipv4
SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
------------------------------
[sig-storage] In-tree Volumes [Driver: local][LocalVolumeType: block] [Testpattern: Pre-provisioned PV (ext4)] volumes 
  should store data
  /root/go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/test/e2e/storage/testsuites/volumes.go:159
[BeforeEach] [Testpattern: Pre-provisioned PV (ext4)] volumes
  /root/go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/test/e2e/storage/framework/testsuite.go:51
[BeforeEach] [Testpattern: Pre-provisioned PV (ext4)] volumes
  /root/go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:185
STEP: Creating a kubernetes client
Mar 31 11:23:24.874: INFO: >>> kubeConfig: /root/kubeconfig.quicklab
STEP: Building a namespace api object, basename volume
Mar 31 11:23:25.285: INFO: No PodSecurityPolicies found; assuming PodSecurityPolicy is disabled.
STEP: Waiting for a default service account to be provisioned in namespace
[It] should store data
  /root/go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/test/e2e/storage/testsuites/volumes.go:159
Mar 31 11:23:25.378: INFO: In-tree plugin kubernetes.io/local-volume is not migrated, not validating any metrics
STEP: Creating block device on node "worker-2.katacontainers1.lab.upshift.rdu2.redhat.com" using path "/tmp/local-driver-49ab5020-f4d5-4c04-8095-43c1ff656031"
Mar 31 11:23:27.858: INFO: ExecWithOptions {Command:[nsenter --mount=/rootfs/proc/1/ns/mnt -- sh -c mkdir -p /tmp/local-driver-49ab5020-f4d5-4c04-8095-43c1ff656031 && dd if=/dev/zero of=/tmp/local-driver-49ab5020-f4d5-4c04-8095-43c1ff656031/file bs=4096 count=5120 && losetup -f /tmp/local-driver-49ab5020-f4d5-4c04-8095-43c1ff656031/file] Namespace:volume-1399 PodName:hostexec-worker-2.katacontainers1.lab.upshift.rdu2.redhat.qdt8j ContainerName:agnhost-container Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:true Quiet:false}
Mar 31 11:23:27.858: INFO: >>> kubeConfig: /root/kubeconfig.quicklab
Mar 31 11:23:28.373: INFO: ExecWithOptions {Command:[nsenter --mount=/rootfs/proc/1/ns/mnt -- sh -c E2E_LOOP_DEV=$(losetup | grep /tmp/local-driver-49ab5020-f4d5-4c04-8095-43c1ff656031/file | awk '{ print $1 }') 2>&1 > /dev/null && echo ${E2E_LOOP_DEV}] Namespace:volume-1399 PodName:hostexec-worker-2.katacontainers1.lab.upshift.rdu2.redhat.qdt8j ContainerName:agnhost-container Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:true Quiet:false}
Mar 31 11:23:28.373: INFO: >>> kubeConfig: /root/kubeconfig.quicklab
Mar 31 11:23:28.677: INFO: Creating resource for pre-provisioned PV
Mar 31 11:23:28.677: INFO: Creating PVC and PV
STEP: Creating a PVC followed by a PV
Mar 31 11:23:28.743: INFO: Waiting for PV local-d7sds to bind to PVC pvc-2qlqh
Mar 31 11:23:28.743: INFO: Waiting up to timeout=3m0s for PersistentVolumeClaims [pvc-2qlqh] to have phase Bound
Mar 31 11:23:28.770: INFO: PersistentVolumeClaim pvc-2qlqh found but phase is Pending instead of Bound.
Mar 31 11:23:30.801: INFO: PersistentVolumeClaim pvc-2qlqh found but phase is Pending instead of Bound.
Mar 31 11:23:32.834: INFO: PersistentVolumeClaim pvc-2qlqh found but phase is Pending instead of Bound.
Mar 31 11:23:35.022: INFO: PersistentVolumeClaim pvc-2qlqh found but phase is Pending instead of Bound.
Mar 31 11:23:47.972: INFO: Failed to get claim "pvc-2qlqh", retrying in 2s. Error: etcdserver: request timed out
Mar 31 11:23:50.106: INFO: PersistentVolumeClaim pvc-2qlqh found and phase=Bound (21.363347436s)
Mar 31 11:23:50.106: INFO: Waiting up to 3m0s for PersistentVolume local-d7sds to have phase Bound
Mar 31 11:23:50.137: INFO: PersistentVolume local-d7sds found and phase=Bound (30.86186ms)
STEP: starting local-injector
STEP: Writing text file contents in the container.
Mar 31 11:23:56.877: INFO: Running '/root/bin/kubectl --kubeconfig=/root/kubeconfig.quicklab --namespace=volume-1399 exec local-injector --namespace=volume-1399 -- /bin/sh -c echo 'Hello from local from namespace volume-1399' > /opt/0/index.html'
Mar 31 11:23:57.586: INFO: stderr: ""
Mar 31 11:23:57.586: INFO: stdout: ""
STEP: Checking that text file contents are perfect.
Mar 31 11:23:57.586: INFO: Running '/root/bin/kubectl --kubeconfig=/root/kubeconfig.quicklab --namespace=volume-1399 exec local-injector --namespace=volume-1399 -- cat /opt/0/index.html'
Mar 31 11:23:58.890: INFO: stderr: ""
Mar 31 11:23:58.890: INFO: stdout: "Hello from local from namespace volume-1399\n"
Mar 31 11:23:58.890: INFO: ExecWithOptions {Command:[/bin/sh -c test -d /opt/0] Namespace:volume-1399 PodName:local-injector ContainerName:local-injector Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false Quiet:false}
Mar 31 11:23:58.890: INFO: >>> kubeConfig: /root/kubeconfig.quicklab
Mar 31 11:23:59.322: INFO: ExecWithOptions {Command:[/bin/sh -c test -b /opt/0] Namespace:volume-1399 PodName:local-injector ContainerName:local-injector Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false Quiet:false}
Mar 31 11:23:59.322: INFO: >>> kubeConfig: /root/kubeconfig.quicklab
STEP: Checking fsType is correct.
Mar 31 11:23:59.960: INFO: Running '/root/bin/kubectl --kubeconfig=/root/kubeconfig.quicklab --namespace=volume-1399 exec local-injector --namespace=volume-1399 -- grep  /opt/0  /proc/mounts'
Mar 31 11:24:00.765: INFO: stderr: ""
Mar 31 11:24:00.765: INFO: stdout: "/dev/loop1 /opt/0 ext4 rw,seclabel,relatime 0 0\n"
STEP: Deleting pod local-injector in namespace volume-1399
Mar 31 11:24:00.864: INFO: Waiting for pod local-injector to disappear
Mar 31 11:24:00.954: INFO: Pod local-injector still exists
Mar 31 11:24:02.954: INFO: Waiting for pod local-injector to disappear
Mar 31 11:24:02.992: INFO: Pod local-injector still exists
Mar 31 11:24:04.955: INFO: Waiting for pod local-injector to disappear
Mar 31 11:24:04.987: INFO: Pod local-injector still exists
Mar 31 11:24:06.955: INFO: Waiting for pod local-injector to disappear
Mar 31 11:24:06.987: INFO: Pod local-injector still exists
Mar 31 11:24:08.954: INFO: Waiting for pod local-injector to disappear
Mar 31 11:24:08.987: INFO: Pod local-injector no longer exists
STEP: starting local-client
STEP: Checking that text file contents are perfect.
Mar 31 11:24:23.364: INFO: Running '/root/bin/kubectl --kubeconfig=/root/kubeconfig.quicklab --namespace=volume-1399 exec local-client --namespace=volume-1399 -- cat /opt/0/index.html'
Mar 31 11:24:23.966: INFO: stderr: ""
Mar 31 11:24:23.966: INFO: stdout: "Hello from local from namespace volume-1399\n"
Mar 31 11:24:23.967: INFO: ExecWithOptions {Command:[/bin/sh -c test -d /opt/0] Namespace:volume-1399 PodName:local-client ContainerName:local-client Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false Quiet:false}
Mar 31 11:24:23.967: INFO: >>> kubeConfig: /root/kubeconfig.quicklab
Mar 31 11:24:24.274: INFO: ExecWithOptions {Command:[/bin/sh -c test -b /opt/0] Namespace:volume-1399 PodName:local-client ContainerName:local-client Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false Quiet:false}
Mar 31 11:24:24.274: INFO: >>> kubeConfig: /root/kubeconfig.quicklab
STEP: Checking fsType is correct.
Mar 31 11:24:24.536: INFO: Running '/root/bin/kubectl --kubeconfig=/root/kubeconfig.quicklab --namespace=volume-1399 exec local-client --namespace=volume-1399 -- grep  /opt/0  /proc/mounts'
Mar 31 11:24:25.677: INFO: stderr: ""
Mar 31 11:24:25.677: INFO: stdout: "kataShared /opt/0 virtiofs rw,relatime 0 0\n"
Mar 31 11:24:27.678: INFO: Running '/root/bin/kubectl --kubeconfig=/root/kubeconfig.quicklab --namespace=volume-1399 exec local-client --namespace=volume-1399 -- grep  /opt/0  /proc/mounts'
Mar 31 11:24:28.519: INFO: stderr: ""
Mar 31 11:24:28.519: INFO: stdout: "kataShared /opt/0 virtiofs rw,relatime 0 0\n"
Mar 31 11:24:30.520: INFO: Running '/root/bin/kubectl --kubeconfig=/root/kubeconfig.quicklab --namespace=volume-1399 exec local-client --namespace=volume-1399 -- grep  /opt/0  /proc/mounts'
Mar 31 11:24:31.117: INFO: stderr: ""
Mar 31 11:24:31.117: INFO: stdout: "kataShared /opt/0 virtiofs rw,relatime 0 0\n"
Mar 31 11:24:33.118: INFO: Running '/root/bin/kubectl --kubeconfig=/root/kubeconfig.quicklab --namespace=volume-1399 exec local-client --namespace=volume-1399 -- grep  /opt/0  /proc/mounts'
Mar 31 11:24:34.381: INFO: stderr: ""
Mar 31 11:24:34.381: INFO: stdout: "kataShared /opt/0 virtiofs rw,relatime 0 0\n"
Mar 31 11:24:36.382: INFO: Running '/root/bin/kubectl --kubeconfig=/root/kubeconfig.quicklab --namespace=volume-1399 exec local-client --namespace=volume-1399 -- grep  /opt/0  /proc/mounts'
Mar 31 11:24:36.984: INFO: stderr: ""
Mar 31 11:24:36.984: INFO: stdout: "kataShared /opt/0 virtiofs rw,relatime 0 0\n"
Mar 31 11:24:38.985: INFO: Running '/root/bin/kubectl --kubeconfig=/root/kubeconfig.quicklab --namespace=volume-1399 exec local-client --namespace=volume-1399 -- grep  /opt/0  /proc/mounts'
Mar 31 11:24:39.916: INFO: stderr: ""
Mar 31 11:24:39.916: INFO: stdout: "kataShared /opt/0 virtiofs rw,relatime 0 0\n"
Mar 31 11:24:41.917: INFO: Running '/root/bin/kubectl --kubeconfig=/root/kubeconfig.quicklab --namespace=volume-1399 exec local-client --namespace=volume-1399 -- grep  /opt/0  /proc/mounts'
Mar 31 11:24:42.901: INFO: stderr: ""
Mar 31 11:24:42.901: INFO: stdout: "kataShared /opt/0 virtiofs rw,relatime 0 0\n"
Mar 31 11:24:44.901: INFO: Running '/root/bin/kubectl --kubeconfig=/root/kubeconfig.quicklab --namespace=volume-1399 exec local-client --namespace=volume-1399 -- grep  /opt/0  /proc/mounts'
Mar 31 11:24:45.660: INFO: stderr: ""
Mar 31 11:24:45.660: INFO: stdout: "kataShared /opt/0 virtiofs rw,relatime 0 0\n"
Mar 31 11:24:47.661: INFO: Running '/root/bin/kubectl --kubeconfig=/root/kubeconfig.quicklab --namespace=volume-1399 exec local-client --namespace=volume-1399 -- grep  /opt/0  /proc/mounts'
Mar 31 11:24:48.535: INFO: stderr: ""
Mar 31 11:24:48.535: INFO: stdout: "kataShared /opt/0 virtiofs rw,relatime 0 0\n"
Mar 31 11:24:50.537: INFO: Running '/root/bin/kubectl --kubeconfig=/root/kubeconfig.quicklab --namespace=volume-1399 exec local-client --namespace=volume-1399 -- grep  /opt/0  /proc/mounts'
Mar 31 11:24:51.491: INFO: stderr: ""
Mar 31 11:24:51.491: INFO: stdout: "kataShared /opt/0 virtiofs rw,relatime 0 0\n"
Mar 31 11:24:53.492: INFO: Running '/root/bin/kubectl --kubeconfig=/root/kubeconfig.quicklab --namespace=volume-1399 exec local-client --namespace=volume-1399 -- grep  /opt/0  /proc/mounts'
Mar 31 11:24:54.325: INFO: stderr: ""
Mar 31 11:24:54.325: INFO: stdout: "kataShared /opt/0 virtiofs rw,relatime 0 0\n"
Mar 31 11:24:56.327: INFO: Running '/root/bin/kubectl --kubeconfig=/root/kubeconfig.quicklab --namespace=volume-1399 exec local-client --namespace=volume-1399 -- grep  /opt/0  /proc/mounts'
Mar 31 11:24:57.050: INFO: stderr: ""
Mar 31 11:24:57.050: INFO: stdout: "kataShared /opt/0 virtiofs rw,relatime 0 0\n"
Mar 31 11:24:59.052: INFO: Running '/root/bin/kubectl --kubeconfig=/root/kubeconfig.quicklab --namespace=volume-1399 exec local-client --namespace=volume-1399 -- grep  /opt/0  /proc/mounts'
Mar 31 11:24:59.925: INFO: stderr: ""
Mar 31 11:24:59.925: INFO: stdout: "kataShared /opt/0 virtiofs rw,relatime 0 0\n"
Mar 31 11:25:01.926: INFO: Running '/root/bin/kubectl --kubeconfig=/root/kubeconfig.quicklab --namespace=volume-1399 exec local-client --namespace=volume-1399 -- grep  /opt/0  /proc/mounts'
Mar 31 11:25:02.724: INFO: stderr: ""
Mar 31 11:25:02.724: INFO: stdout: "kataShared /opt/0 virtiofs rw,relatime 0 0\n"
Mar 31 11:25:04.725: INFO: Running '/root/bin/kubectl --kubeconfig=/root/kubeconfig.quicklab --namespace=volume-1399 exec local-client --namespace=volume-1399 -- grep  /opt/0  /proc/mounts'
Mar 31 11:25:05.433: INFO: stderr: ""
Mar 31 11:25:05.433: INFO: stdout: "kataShared /opt/0 virtiofs rw,relatime 0 0\n"
Mar 31 11:25:07.434: INFO: Running '/root/bin/kubectl --kubeconfig=/root/kubeconfig.quicklab --namespace=volume-1399 exec local-client --namespace=volume-1399 -- grep  /opt/0  /proc/mounts'
Mar 31 11:25:08.206: INFO: stderr: ""
Mar 31 11:25:08.206: INFO: stdout: "kataShared /opt/0 virtiofs rw,relatime 0 0\n"
Mar 31 11:25:10.207: INFO: Running '/root/bin/kubectl --kubeconfig=/root/kubeconfig.quicklab --namespace=volume-1399 exec local-client --namespace=volume-1399 -- grep  /opt/0  /proc/mounts'
Mar 31 11:25:10.937: INFO: stderr: ""
Mar 31 11:25:10.937: INFO: stdout: "kataShared /opt/0 virtiofs rw,relatime 0 0\n"
Mar 31 11:25:12.937: INFO: Running '/root/bin/kubectl --kubeconfig=/root/kubeconfig.quicklab --namespace=volume-1399 exec local-client --namespace=volume-1399 -- grep  /opt/0  /proc/mounts'
Mar 31 11:25:14.290: INFO: stderr: ""
Mar 31 11:25:14.290: INFO: stdout: "kataShared /opt/0 virtiofs rw,relatime 0 0\n"
Mar 31 11:25:16.291: INFO: Running '/root/bin/kubectl --kubeconfig=/root/kubeconfig.quicklab --namespace=volume-1399 exec local-client --namespace=volume-1399 -- grep  /opt/0  /proc/mounts'
Mar 31 11:25:16.885: INFO: stderr: ""
Mar 31 11:25:16.885: INFO: stdout: "kataShared /opt/0 virtiofs rw,relatime 0 0\n"
Mar 31 11:25:18.886: INFO: Running '/root/bin/kubectl --kubeconfig=/root/kubeconfig.quicklab --namespace=volume-1399 exec local-client --namespace=volume-1399 -- grep  /opt/0  /proc/mounts'
Mar 31 11:25:19.784: INFO: stderr: ""
Mar 31 11:25:19.784: INFO: stdout: "kataShared /opt/0 virtiofs rw,relatime 0 0\n"
Mar 31 11:25:21.784: INFO: Running '/root/bin/kubectl --kubeconfig=/root/kubeconfig.quicklab --namespace=volume-1399 exec local-client --namespace=volume-1399 -- grep  /opt/0  /proc/mounts'
Mar 31 11:25:22.581: INFO: stderr: ""
Mar 31 11:25:22.581: INFO: stdout: "kataShared /opt/0 virtiofs rw,relatime 0 0\n"
Mar 31 11:25:24.581: FAIL: failed: getting the right fsType ext4
Unexpected error:
    <*errors.errorString | 0xc000b3d3d0>: {
        s: "Failed to find \"ext4\", last result: \"kataShared /opt/0 virtiofs rw,relatime 0 0\n\"",
    }
    Failed to find "ext4", last result: "kataShared /opt/0 virtiofs rw,relatime 0 0
    "
occurred

(...)
```

With this Fix (output snipped):
```
# _output/bin/e2e.test -ginkgo.focus "\[sig-storage\] In-tree Volumes \[Driver: local\]\[LocalVolumeType: block\] \[Testpattern: Pre-provisioned PV \(ext4\)\] volumes should store data"
Mar 31 11:14:18.703: INFO: The --provider flag is not set. Continuing as if --provider=skeleton had been used.
I0331 11:14:18.703844 3797106 e2e.go:129] Starting e2e run "3eefa2c3-cdac-47d7-8e98-6fb262a9cb97" on Ginkgo node 1
{"msg":"Test Suite starting","total":1,"completed":0,"skipped":0,"failed":0}
Running Suite: Kubernetes e2e suite
===================================
Random Seed: 1617203657 - Will randomize all specs
Will run 1 of 5745 specs

Mar 31 11:14:18.715: INFO: >>> kubeConfig: /root/kubeconfig.quicklab
Mar 31 11:14:18.720: INFO: Waiting up to 30m0s for all (but 0) nodes to be schedulable
Mar 31 11:14:18.913: INFO: Waiting up to 10m0s for all pods (need at least 0) in namespace 'kube-system' to be running and ready
Mar 31 11:14:19.039: INFO: 0 / 0 pods in namespace 'kube-system' are running and ready (0 seconds elapsed)
Mar 31 11:14:19.039: INFO: expected 0 pod replicas in namespace 'kube-system', 0 are Running and Ready.
Mar 31 11:14:19.039: INFO: Waiting up to 5m0s for all daemonsets in namespace 'kube-system' to start
Mar 31 11:14:19.078: INFO: e2e test version: v1.21.0-beta.1.408+b4fe1a98c66c63-dirty
Mar 31 11:14:19.099: INFO: kube-apiserver version: v1.20.0+5fbfd19
Mar 31 11:14:19.099: INFO: >>> kubeConfig: /root/kubeconfig.quicklab
Mar 31 11:14:19.128: INFO: Cluster IP family: ipv4
------------------------------
[sig-storage] In-tree Volumes [Driver: local][LocalVolumeType: block] [Testpattern: Pre-provisioned PV (ext4)] volumes 
  should store data
  /root/go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/test/e2e/storage/testsuites/volumes.go:159
[BeforeEach] [Testpattern: Pre-provisioned PV (ext4)] volumes
  /root/go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/test/e2e/storage/framework/testsuite.go:51
[BeforeEach] [Testpattern: Pre-provisioned PV (ext4)] volumes
  /root/go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:185

(...)

• [SLOW TEST:70.977 seconds]
[sig-storage] In-tree Volumes
/root/go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/test/e2e/storage/utils/framework.go:23
  [Driver: local][LocalVolumeType: block]
  /root/go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/test/e2e/storage/in_tree_volumes.go:58
    [Testpattern: Pre-provisioned PV (ext4)] volumes
    /root/go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/test/e2e/storage/framework/testsuite.go:50
      should store data
      /root/go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/test/e2e/storage/testsuites/volumes.go:159
------------------------------
{"msg":"PASSED [sig-storage] In-tree Volumes [Driver: local][LocalVolumeType: block] [Testpattern: Pre-provisioned PV (ext4)] volumes should store data","total":1,"completed":1,"skipped":2566,"failed":0}
Mar 31 11:15:30.147: INFO: Running AfterSuite actions on all nodes
Mar 31 11:15:30.147: INFO: Running AfterSuite actions on node 1
{"msg":"Test Suite completed","total":1,"completed":1,"skipped":5744,"failed":0}

Ran 1 of 5745 Specs in 71.434 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 5744 Skipped
PASS
```
