### PR TITLE
cherry pick #100341 #98576 on 1.20 to enable SSA with APIService

### DIFF
--- a/cmd/kube-apiserver/app/aggregator.go
+++ b/cmd/kube-apiserver/app/aggregator.go
@@ -67,6 +67,9 @@ func createAggregatorConfig(
 	genericConfig := kubeAPIServerConfig
 	genericConfig.PostStartHooks = map[string]genericapiserver.PostStartHookConfigEntry{}
 	genericConfig.RESTOptionsGetter = nil
+	// prevent generic API server from installing the OpenAPI handler. Aggregator server
+	// has its own customized OpenAPI handler.
+	genericConfig.SkipOpenAPIInstallation = true
 
 	if utilfeature.DefaultFeatureGate.Enabled(genericfeatures.StorageVersionAPI) &&
 		utilfeature.DefaultFeatureGate.Enabled(genericfeatures.APIServerIdentity) {

--- a/pkg/apis/core/v1/zz_generated.defaults.go
+++ b/pkg/apis/core/v1/zz_generated.defaults.go
@@ -915,6 +915,12 @@ func SetObjectDefaults_SecretList(in *v1.SecretList) {
 
 func SetObjectDefaults_Service(in *v1.Service) {
 	SetDefaults_Service(in)
+	for i := range in.Spec.Ports {
+		a := &in.Spec.Ports[i]
+		if a.Protocol == "" {
+			a.Protocol = "TCP"
+		}
+	}
 }
 
 func SetObjectDefaults_ServiceList(in *v1.ServiceList) {

--- a/pkg/apis/core/v1/zz_generated.defaults.go
+++ b/pkg/apis/core/v1/zz_generated.defaults.go
@@ -917,7 +917,7 @@ func SetObjectDefaults_Service(in *v1.Service) {
 	SetDefaults_Service(in)
 	for i := range in.Spec.Ports {
 		a := &in.Spec.Ports[i]
-		if a.Protocol == "" {
+		if reflect.ValueOf(a.Protocol).IsZero() {
 			a.Protocol = "TCP"
 		}
 	}

--- a/staging/src/k8s.io/api/core/v1/generated.proto
+++ b/staging/src/k8s.io/api/core/v1/generated.proto
@@ -4753,6 +4753,7 @@ message ServicePort {
 
   // The IP protocol for this port. Supports "TCP", "UDP", and "SCTP".
   // Default is TCP.
+  // +default="TCP"
   // +optional
   optional string protocol = 2;
 

--- a/staging/src/k8s.io/api/core/v1/types.go
+++ b/staging/src/k8s.io/api/core/v1/types.go
@@ -4264,6 +4264,7 @@ type ServicePort struct {
 
 	// The IP protocol for this port. Supports "TCP", "UDP", and "SCTP".
 	// Default is TCP.
+	// +default="TCP"
 	// +optional
 	Protocol Protocol `json:"protocol,omitempty" protobuf:"bytes,2,opt,name=protocol,casttype=Protocol"`
 

--- a/staging/src/k8s.io/apiserver/pkg/server/config.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/config.go
@@ -165,6 +165,8 @@ type Config struct {
 	Serializer runtime.NegotiatedSerializer
 	// OpenAPIConfig will be used in generating OpenAPI spec. This is nil by default. Use DefaultOpenAPIConfig for "working" defaults.
 	OpenAPIConfig *openapicommon.Config
+	// SkipOpenAPIInstallation avoids installing the OpenAPI handler if set to true.
+	SkipOpenAPIInstallation bool
 
 	// RESTOptionsGetter is used to construct RESTStorage types via the generic registry.
 	RESTOptionsGetter genericregistry.RESTOptionsGetter
@@ -571,7 +573,8 @@ func (c completedConfig) New(name string, delegationTarget DelegationTarget) (*G
 
 		listedPathProvider: apiServerHandler,
 
-		openAPIConfig: c.OpenAPIConfig,
+		openAPIConfig:           c.OpenAPIConfig,
+		skipOpenAPIInstallation: c.SkipOpenAPIInstallation,
 
 		postStartHooks:         map[string]postStartHookEntry{},
 		preShutdownHooks:       map[string]preShutdownHookEntry{},

--- a/staging/src/k8s.io/apiserver/pkg/server/genericapiserver.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/genericapiserver.go
@@ -133,8 +133,14 @@ type GenericAPIServer struct {
 	// Enable swagger and/or OpenAPI if these configs are non-nil.
 	openAPIConfig *openapicommon.Config
 
+	// SkipOpenAPIInstallation indicates not to install the OpenAPI handler
+	// during PrepareRun.
+	// Set this to true when the specific API Server has its own OpenAPI handler
+	// (e.g. kube-aggregator)
+	skipOpenAPIInstallation bool
+
 	// OpenAPIVersionedService controls the /openapi/v2 endpoint, and can be used to update the served spec.
-	// It is set during PrepareRun.
+	// It is set during PrepareRun if `openAPIConfig` is non-nil unless `skipOpenAPIInstallation` is true.
 	OpenAPIVersionedService *handler.OpenAPIService
 
 	// StaticOpenAPISpec is the spec derived from the restful container endpoints.
@@ -289,7 +295,7 @@ type preparedGenericAPIServer struct {
 func (s *GenericAPIServer) PrepareRun() preparedGenericAPIServer {
 	s.delegationTarget.PrepareRun()
 
-	if s.openAPIConfig != nil {
+	if s.openAPIConfig != nil && !s.skipOpenAPIInstallation {
 		s.OpenAPIVersionedService, s.StaticOpenAPISpec = routes.OpenAPI{
 			Config: s.openAPIConfig,
 		}.Install(s.Handler.GoRestfulContainer, s.Handler.NonGoRestfulMux)

--- a/staging/src/k8s.io/kube-aggregator/pkg/apiserver/apiserver.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/apiserver/apiserver.go
@@ -163,11 +163,6 @@ func (cfg *Config) Complete() CompletedConfig {
 
 // NewWithDelegate returns a new instance of APIAggregator from the given config.
 func (c completedConfig) NewWithDelegate(delegationTarget genericapiserver.DelegationTarget) (*APIAggregator, error) {
-	// Prevent generic API server to install OpenAPI handler. Aggregator server
-	// has its own customized OpenAPI handler.
-	openAPIConfig := c.GenericConfig.OpenAPIConfig
-	c.GenericConfig.OpenAPIConfig = nil
-
 	genericServer, err := c.GenericConfig.New("kube-aggregator", delegationTarget)
 	if err != nil {
 		return nil, err
@@ -191,7 +186,7 @@ func (c completedConfig) NewWithDelegate(delegationTarget genericapiserver.Deleg
 		lister:                     informerFactory.Apiregistration().V1().APIServices().Lister(),
 		APIRegistrationInformers:   informerFactory,
 		serviceResolver:            c.ExtraConfig.ServiceResolver,
-		openAPIConfig:              openAPIConfig,
+		openAPIConfig:              c.GenericConfig.OpenAPIConfig,
 		egressSelector:             c.GenericConfig.EgressSelector,
 		proxyCurrentCertKeyContent: func() (bytes []byte, bytes2 []byte) { return nil, nil },
 	}

--- a/staging/src/k8s.io/kube-aggregator/pkg/cmd/server/start.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/cmd/server/start.go
@@ -142,6 +142,9 @@ func (o AggregatorOptions) RunAggregator(stopCh <-chan struct{}) error {
 	)
 	serverConfig.OpenAPIConfig = genericapiserver.DefaultOpenAPIConfig(openapi.GetOpenAPIDefinitions, openapinamer.NewDefinitionNamer(aggregatorscheme.Scheme))
 	serverConfig.OpenAPIConfig.Info.Title = "kube-aggregator"
+	// prevent generic API server from installing the OpenAPI handler. Aggregator server
+	// has its own customized OpenAPI handler.
+	serverConfig.SkipOpenAPIInstallation = true
 
 	serviceResolver := apiserver.NewClusterIPServiceResolver(serverConfig.SharedInformerFactory.Core().V1().Services().Lister())
 

--- a/test/integration/apiserver/apply/status_test.go
+++ b/test/integration/apiserver/apply/status_test.go
@@ -156,8 +156,17 @@ func TestApplyStatus(t *testing.T) {
 					namespace = ""
 				}
 				name := newObj.GetName()
+
+				// etcd test stub data doesn't contain apiVersion/kind (!), but apply requires it
+				newObj.SetGroupVersionKind(mapping.GroupVersionKind)
+				createData, err := json.Marshal(newObj.Object)
+				if err != nil {
+					t.Fatal(err)
+				}
+
 				rsc := dynamicClient.Resource(mapping.Resource).Namespace(namespace)
-				_, err := rsc.Create(context.TODO(), &newObj, metav1.CreateOptions{FieldManager: "create_test"})
+				// apply to create
+				_, err = rsc.Patch(context.TODO(), name, types.ApplyPatchType, []byte(createData), metav1.PatchOptions{FieldManager: "create_test"})
 				if err != nil {
 					t.Fatal(err)
 				}

--- a/test/integration/apiserver/apply/status_test.go
+++ b/test/integration/apiserver/apply/status_test.go
@@ -60,15 +60,7 @@ var statusData = map[schema.GroupVersionResource]string{
 	gvr("internal.apiserver.k8s.io", "v1alpha1", "storageversions"):     `{"status": {"commonEncodingVersion":"v1","storageVersions":[{"apiServerID":"1","decodableVersions":["v1","v2"],"encodingVersion":"v1"}],"conditions":[{"type":"AllEncodingVersionsEqual","status":"True","lastTransitionTime":"2020-01-01T00:00:00Z","reason":"allEncodingVersionsEqual","message":"all encoding versions are set to v1"}]}}`,
 }
 
-const statusDefault = `{"status": {"conditions": [{"type": "MyStatus", "status":"true"}]}}`
-
-// DO NOT ADD TO THIS LIST.
-// This list is used to ignore known bugs. We shouldn't introduce new bugs.
-var ignoreList = map[schema.GroupVersionResource]struct{}{
-	// TODO(#89264): apiservices doesn't work because the openapi is not routed properly.
-	gvr("apiregistration.k8s.io", "v1beta1", "apiservices"): {},
-	gvr("apiregistration.k8s.io", "v1", "apiservices"):      {},
-}
+const statusDefault = `{"status": {"conditions": [{"type": "MyStatus", "status":"True"}]}}`
 
 // Some status-only APIs have empty object on creation. Therefore we don't expect create_test
 // managedFields for these APIs
@@ -146,9 +138,6 @@ func TestApplyStatus(t *testing.T) {
 				t.Fatal(err)
 			}
 			t.Run(mapping.Resource.String(), func(t *testing.T) {
-				if _, ok := ignoreList[mapping.Resource]; ok {
-					t.Skip()
-				}
 				status, ok := statusData[mapping.Resource]
 				if !ok {
 					status = statusDefault

--- a/test/integration/apiserver/apply/status_test.go
+++ b/test/integration/apiserver/apply/status_test.go
@@ -62,12 +62,6 @@ var statusData = map[schema.GroupVersionResource]string{
 
 const statusDefault = `{"status": {"conditions": [{"type": "MyStatus", "status":"True"}]}}`
 
-// Some status-only APIs have empty object on creation. Therefore we don't expect create_test
-// managedFields for these APIs
-var ignoreCreateManagementList = map[schema.GroupVersionResource]struct{}{
-	gvr("internal.apiserver.k8s.io", "v1alpha1", "storageversions"): {},
-}
-
 func gvr(g, v, r string) schema.GroupVersionResource {
 	return schema.GroupVersionResource{Group: g, Version: v, Resource: r}
 }
@@ -205,11 +199,7 @@ func TestApplyStatus(t *testing.T) {
 					t.Fatalf("Couldn't find apply_status_test: %v", managedFields)
 				}
 				if !findManager(managedFields, "create_test") {
-					if _, ok := ignoreCreateManagementList[mapping.Resource]; !ok {
-						t.Fatalf("Couldn't find create_test: %v", managedFields)
-					}
-				} else if _, ok := ignoreCreateManagementList[mapping.Resource]; ok {
-					t.Fatalf("found create_test in ignoreCreateManagementList resource: %v", managedFields)
+					t.Fatalf("Couldn't find create_test: %v", managedFields)
 				}
 
 				if err := rsc.Delete(context.TODO(), name, *metav1.NewDeleteOptions(0)); err != nil {


### PR DESCRIPTION
Cherry pick of #100341 #98576 on release-1.20.

#100341: Add ability to skip OpenAPI handler installation
#98576: Declare TCP default for service port protocol
https://github.com/kubernetes/kubernetes/pull/99014/commits/801aaac2b6f86c68b368692515ebff22cf18f68a (from #99014)


fixes #99046

```release-note
Fixes using server-side apply with APIService resources
```