### PR TITLE
cherry pick  #100341 #98576 #95836 on 1.18 to enable SSA with APIService

### DIFF
--- a/cmd/kube-apiserver/app/aggregator.go
+++ b/cmd/kube-apiserver/app/aggregator.go
@@ -67,6 +67,9 @@ func createAggregatorConfig(
 	genericConfig := kubeAPIServerConfig
 	genericConfig.PostStartHooks = map[string]genericapiserver.PostStartHookConfigEntry{}
 	genericConfig.RESTOptionsGetter = nil
+	// prevent generic API server from installing the OpenAPI handler. Aggregator server
+	// has its own customized OpenAPI handler.
+	genericConfig.SkipOpenAPIInstallation = true
 
 	// override genericConfig.AdmissionControl with kube-aggregator's scheme,
 	// because aggregator apiserver should use its own scheme to convert its own resources.

--- a/staging/src/k8s.io/apimachinery/pkg/util/yaml/BUILD
+++ b/staging/src/k8s.io/apimachinery/pkg/util/yaml/BUILD
@@ -18,8 +18,8 @@ go_library(
     importmap = "k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/util/yaml",
     importpath = "k8s.io/apimachinery/pkg/util/yaml",
     deps = [
-        "//vendor/k8s.io/klog:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/json:go_default_library",
+        "//vendor/k8s.io/klog:go_default_library",
         "//vendor/sigs.k8s.io/yaml:go_default_library",
     ],
 )

--- a/staging/src/k8s.io/apimachinery/pkg/util/yaml/BUILD
+++ b/staging/src/k8s.io/apimachinery/pkg/util/yaml/BUILD
@@ -19,6 +19,7 @@ go_library(
     importpath = "k8s.io/apimachinery/pkg/util/yaml",
     deps = [
         "//vendor/k8s.io/klog:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/util/json:go_default_library",
         "//vendor/sigs.k8s.io/yaml:go_default_library",
     ],
 )

--- a/staging/src/k8s.io/apimachinery/pkg/util/yaml/decoder.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/yaml/decoder.go
@@ -26,9 +26,40 @@ import (
 	"strings"
 	"unicode"
 
+	jsonutil "k8s.io/apimachinery/pkg/util/json"
 	"k8s.io/klog"
+
 	"sigs.k8s.io/yaml"
 )
+
+// Unmarshal unmarshals the given data
+// If v is a *map[string]interface{}, *[]interface{}, or *interface{} numbers
+// are converted to int64 or float64
+func Unmarshal(data []byte, v interface{}) error {
+	preserveIntFloat := func(d *json.Decoder) *json.Decoder {
+		d.UseNumber()
+		return d
+	}
+	switch v := v.(type) {
+	case *map[string]interface{}:
+		if err := yaml.Unmarshal(data, v, preserveIntFloat); err != nil {
+			return err
+		}
+		return jsonutil.ConvertMapNumbers(*v, 0)
+	case *[]interface{}:
+		if err := yaml.Unmarshal(data, v, preserveIntFloat); err != nil {
+			return err
+		}
+		return jsonutil.ConvertSliceNumbers(*v, 0)
+	case *interface{}:
+		if err := yaml.Unmarshal(data, v, preserveIntFloat); err != nil {
+			return err
+		}
+		return jsonutil.ConvertInterfaceNumbers(v, 0)
+	default:
+		return yaml.Unmarshal(data, v)
+	}
+}
 
 // ToJSON converts a single YAML document into a JSON document
 // or returns an error. If the document appears to be JSON the

--- a/staging/src/k8s.io/apimachinery/pkg/util/yaml/decoder_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/yaml/decoder_test.go
@@ -403,3 +403,44 @@ stuff: 1
 		t.Fatalf("expected %q to be of type YAMLSyntaxError", err.Error())
 	}
 }
+
+func TestUnmarshal(t *testing.T) {
+	mapWithIntegerBytes := []byte(`replicas: 1`)
+	mapWithInteger := make(map[string]interface{})
+	if err := Unmarshal(mapWithIntegerBytes, &mapWithInteger); err != nil {
+		t.Fatalf("unexpected error unmarshaling yaml: %v", err)
+	}
+	if _, ok := mapWithInteger["replicas"].(int64); !ok {
+		t.Fatalf(`Expected number in map to be int64 but got "%T"`, mapWithInteger["replicas"])
+	}
+
+	sliceWithIntegerBytes := []byte(`- 1`)
+	var sliceWithInteger []interface{}
+	if err := Unmarshal(sliceWithIntegerBytes, &sliceWithInteger); err != nil {
+		t.Fatalf("unexpected error unmarshaling yaml: %v", err)
+	}
+	if _, ok := sliceWithInteger[0].(int64); !ok {
+		t.Fatalf(`Expected number in slice to be int64 but got "%T"`, sliceWithInteger[0])
+	}
+
+	integerBytes := []byte(`1`)
+	var integer interface{}
+	if err := Unmarshal(integerBytes, &integer); err != nil {
+		t.Fatalf("unexpected error unmarshaling yaml: %v", err)
+	}
+	if _, ok := integer.(int64); !ok {
+		t.Fatalf(`Expected number to be int64 but got "%T"`, integer)
+	}
+
+	otherTypeBytes := []byte(`123: 2`)
+	otherType := make(map[int]interface{})
+	if err := Unmarshal(otherTypeBytes, &otherType); err != nil {
+		t.Fatalf("unexpected error unmarshaling yaml: %v", err)
+	}
+	if _, ok := otherType[123].(int64); ok {
+		t.Fatalf(`Expected number not to be converted to int64`)
+	}
+	if _, ok := otherType[123].(float64); !ok {
+		t.Fatalf(`Expected number to be float64 but got "%T"`, otherType[123])
+	}
+}

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/BUILD
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/BUILD
@@ -86,6 +86,7 @@ go_library(
         "//staging/src/k8s.io/apimachinery/pkg/util/sets:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/strategicpatch:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/validation/field:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/util/yaml:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/watch:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/admission:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/audit:go_default_library",
@@ -107,7 +108,6 @@ go_library(
         "//vendor/google.golang.org/grpc/status:go_default_library",
         "//vendor/k8s.io/klog:go_default_library",
         "//vendor/k8s.io/utils/trace:go_default_library",
-        "//vendor/sigs.k8s.io/yaml:go_default_library",
     ],
 )
 

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/patch.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/patch.go
@@ -38,6 +38,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/strategicpatch"
 	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/apimachinery/pkg/util/yaml"
 	"k8s.io/apiserver/pkg/admission"
 	"k8s.io/apiserver/pkg/audit"
 	"k8s.io/apiserver/pkg/authorization/authorizer"
@@ -49,7 +50,6 @@ import (
 	"k8s.io/apiserver/pkg/util/dryrun"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	utiltrace "k8s.io/utils/trace"
-	"sigs.k8s.io/yaml"
 )
 
 const (

--- a/staging/src/k8s.io/apiserver/pkg/server/config.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/config.go
@@ -160,6 +160,8 @@ type Config struct {
 	Serializer runtime.NegotiatedSerializer
 	// OpenAPIConfig will be used in generating OpenAPI spec. This is nil by default. Use DefaultOpenAPIConfig for "working" defaults.
 	OpenAPIConfig *openapicommon.Config
+	// SkipOpenAPIInstallation avoids installing the OpenAPI handler if set to true.
+	SkipOpenAPIInstallation bool
 
 	// RESTOptionsGetter is used to construct RESTStorage types via the generic registry.
 	RESTOptionsGetter genericregistry.RESTOptionsGetter
@@ -558,7 +560,8 @@ func (c completedConfig) New(name string, delegationTarget DelegationTarget) (*G
 
 		listedPathProvider: apiServerHandler,
 
-		openAPIConfig: c.OpenAPIConfig,
+		openAPIConfig:           c.OpenAPIConfig,
+		skipOpenAPIInstallation: c.SkipOpenAPIInstallation,
 
 		postStartHooks:         map[string]postStartHookEntry{},
 		preShutdownHooks:       map[string]preShutdownHookEntry{},

--- a/staging/src/k8s.io/apiserver/pkg/server/genericapiserver.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/genericapiserver.go
@@ -129,8 +129,14 @@ type GenericAPIServer struct {
 	// Enable swagger and/or OpenAPI if these configs are non-nil.
 	openAPIConfig *openapicommon.Config
 
+	// SkipOpenAPIInstallation indicates not to install the OpenAPI handler
+	// during PrepareRun.
+	// Set this to true when the specific API Server has its own OpenAPI handler
+	// (e.g. kube-aggregator)
+	skipOpenAPIInstallation bool
+
 	// OpenAPIVersionedService controls the /openapi/v2 endpoint, and can be used to update the served spec.
-	// It is set during PrepareRun.
+	// It is set during PrepareRun if `openAPIConfig` is non-nil unless `skipOpenAPIInstallation` is true.
 	OpenAPIVersionedService *handler.OpenAPIService
 
 	// StaticOpenAPISpec is the spec derived from the restful container endpoints.
@@ -283,7 +289,7 @@ type preparedGenericAPIServer struct {
 func (s *GenericAPIServer) PrepareRun() preparedGenericAPIServer {
 	s.delegationTarget.PrepareRun()
 
-	if s.openAPIConfig != nil {
+	if s.openAPIConfig != nil && !s.skipOpenAPIInstallation {
 		s.OpenAPIVersionedService, s.StaticOpenAPISpec = routes.OpenAPI{
 			Config: s.openAPIConfig,
 		}.Install(s.Handler.GoRestfulContainer, s.Handler.NonGoRestfulMux)

--- a/staging/src/k8s.io/kube-aggregator/pkg/apiserver/apiserver.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/apiserver/apiserver.go
@@ -158,11 +158,6 @@ func (cfg *Config) Complete() CompletedConfig {
 
 // NewWithDelegate returns a new instance of APIAggregator from the given config.
 func (c completedConfig) NewWithDelegate(delegationTarget genericapiserver.DelegationTarget) (*APIAggregator, error) {
-	// Prevent generic API server to install OpenAPI handler. Aggregator server
-	// has its own customized OpenAPI handler.
-	openAPIConfig := c.GenericConfig.OpenAPIConfig
-	c.GenericConfig.OpenAPIConfig = nil
-
 	genericServer, err := c.GenericConfig.New("kube-aggregator", delegationTarget)
 	if err != nil {
 		return nil, err
@@ -188,7 +183,7 @@ func (c completedConfig) NewWithDelegate(delegationTarget genericapiserver.Deleg
 		lister:                   informerFactory.Apiregistration().V1().APIServices().Lister(),
 		APIRegistrationInformers: informerFactory,
 		serviceResolver:          c.ExtraConfig.ServiceResolver,
-		openAPIConfig:            openAPIConfig,
+		openAPIConfig:            c.GenericConfig.OpenAPIConfig,
 		egressSelector:           c.GenericConfig.EgressSelector,
 	}
 

--- a/test/integration/apiserver/apply/status_test.go
+++ b/test/integration/apiserver/apply/status_test.go
@@ -57,15 +57,7 @@ var statusData = map[schema.GroupVersionResource]string{
 	gvr("certificates.k8s.io", "v1beta1", "certificatesigningrequests"): `{"status": {"conditions": [{"type": "MyStatus"}]}}`,
 }
 
-const statusDefault = `{"status": {"conditions": [{"type": "MyStatus", "status":"true"}]}}`
-
-// DO NOT ADD TO THIS LIST.
-// This list is used to ignore known bugs. We shouldn't introduce new bugs.
-var ignoreList = map[schema.GroupVersionResource]struct{}{
-	// TODO(#89264): apiservices doesn't work because the openapi is not routed properly.
-	gvr("apiregistration.k8s.io", "v1beta1", "apiservices"): {},
-	gvr("apiregistration.k8s.io", "v1", "apiservices"):      {},
-}
+const statusDefault = `{"status": {"conditions": [{"type": "MyStatus", "status":"True"}]}}`
 
 func gvr(g, v, r string) schema.GroupVersionResource {
 	return schema.GroupVersionResource{Group: g, Version: v, Resource: r}
@@ -137,9 +129,6 @@ func TestApplyStatus(t *testing.T) {
 				t.Fatal(err)
 			}
 			t.Run(mapping.Resource.String(), func(t *testing.T) {
-				if _, ok := ignoreList[mapping.Resource]; ok {
-					t.Skip()
-				}
 				status, ok := statusData[mapping.Resource]
 				if !ok {
 					status = statusDefault

--- a/test/integration/apiserver/apply/status_test.go
+++ b/test/integration/apiserver/apply/status_test.go
@@ -147,8 +147,17 @@ func TestApplyStatus(t *testing.T) {
 					namespace = ""
 				}
 				name := newObj.GetName()
+
+				// etcd test stub data doesn't contain apiVersion/kind (!), but apply requires it
+				newObj.SetGroupVersionKind(mapping.GroupVersionKind)
+				createData, err := json.Marshal(newObj.Object)
+				if err != nil {
+					t.Fatal(err)
+				}
+
 				rsc := dynamicClient.Resource(mapping.Resource).Namespace(namespace)
-				_, err := rsc.Create(context.TODO(), &newObj, metav1.CreateOptions{FieldManager: "create_test"})
+				// apply to create
+				_, err = rsc.Patch(context.TODO(), name, types.ApplyPatchType, []byte(createData), metav1.PatchOptions{FieldManager: "create_test"})
 				if err != nil {
 					t.Fatal(err)
 				}

--- a/test/integration/etcd/data.go
+++ b/test/integration/etcd/data.go
@@ -44,7 +44,7 @@ func GetEtcdStorageDataForNamespace(namespace string) map[schema.GroupVersionRes
 			ExpectedEtcdPath: "/registry/configmaps/" + namespace + "/cm1",
 		},
 		gvr("", "v1", "services"): {
-			Stub:             `{"metadata": {"name": "service1"}, "spec": {"externalName": "service1name", "ports": [{"port": 10000, "targetPort": 11000}], "selector": {"test": "data"}}}`,
+			Stub:             `{"metadata": {"name": "service1"}, "spec": {"externalName": "service1name", "ports": [{"port": 10000, "targetPort": 11000, "protocol":"TCP"}], "selector": {"test": "data"}}}`,
 			ExpectedEtcdPath: "/registry/services/specs/" + namespace + "/service1",
 		},
 		gvr("", "v1", "podtemplates"): {


### PR DESCRIPTION
Cherry pick of #100341 #98576 #95836 on release-1.18.

#100341: Add ability to skip OpenAPI handler installation
* The [line](https://github.com/kubernetes/kubernetes/commit/66d2f4359efadd2cf85f9d901676f2ea28555951#diff-e7ff48774cfb26a502cd0486130dd008784e6ce27fe81f16a9b534786ae103e8R145-R147) that skips open API Installation in the kube-aggregator has been removed because OpenAPI generation does not exist in kube-aggregator until 1.19.

#98576: Declare TCP default for service port protocol
* The [commit](https://github.com/kubernetes/kubernetes/pull/98576/commits/dab511224020f6f7a896560d7c48770187a683c1) declaring TCP as the default protocol has been removed because it uses features implemented in #96480 that do not exist in 1.18.
* A [line](https://github.com/kubernetes/kubernetes/pull/100715/commits/5ebc98dfb9011ea6d80fcfa692e8e6bf37d06428#diff-1083ad1d288464507552098a30e5f816d56c19f15edf36aaae46afdf43fe1ecdR47) has been added to set the protocol of the service object in the etcd data stub in order to account for SSA's inability to set a default protocol in 1.18

#95836: Add yaml util to unmarshal numbers into int/float 

fixes #99046

```release-note
Fixes using server-side apply with APIService resources
```