### PR TITLE
Automated cherry pick of #100606 #100660 upstream release 1.21

### DIFF
--- a/hack/verify-typecheck-providerless.sh
+++ b/hack/verify-typecheck-providerless.sh
@@ -35,3 +35,10 @@ if _out="$(go list -mod=readonly -tags "providerless" -e -json  k8s.io/kubernete
     echo "Verify typecheck for providerless tag failed. Found restricted packages." >&2
     exit 1
 fi
+if _out="$(go list -mod=readonly -tags "providerless" -e -json  k8s.io/kubernetes/cmd/kube-apiserver/... \
+  | grep -e Azure/azure-sdk-for-go -e github.com/aws/aws-sdk-go -e google.golang.org/api \
+         -e Azure/go-autorest -e oauth2/google)"; then
+    echo "${_out}" >&2
+    echo "Verify typecheck for providerless tag failed. Found restricted packages." >&2
+    exit 1
+fi

--- a/staging/src/k8s.io/client-go/plugin/pkg/client/auth/plugins.go
+++ b/staging/src/k8s.io/client-go/plugin/pkg/client/auth/plugins.go
@@ -1,5 +1,3 @@
-// +build providerless
-
 /*
 Copyright 2016 The Kubernetes Authors.
 

--- a/staging/src/k8s.io/client-go/plugin/pkg/client/auth/plugins_providers.go
+++ b/staging/src/k8s.io/client-go/plugin/pkg/client/auth/plugins_providers.go
@@ -1,4 +1,4 @@
-// +build providerless
+// +build !providerless
 
 /*
 Copyright 2016 The Kubernetes Authors.
@@ -19,6 +19,8 @@ limitations under the License.
 package auth
 
 import (
-	// Initialize common client auth plugins.
-	_ "k8s.io/client-go/plugin/pkg/client/auth/oidc"
+	// Initialize client auth plugins for cloud providers.
+	_ "k8s.io/client-go/plugin/pkg/client/auth/azure"
+	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
+	_ "k8s.io/client-go/plugin/pkg/client/auth/openstack"
 )


### PR DESCRIPTION
Cherry pick of #100606 and #100660 on release-1.21.

#100606: providerless tag for client-go auth plugins
#100660: Common auth plugins should always be available

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.