### PR TITLE
clarify RBAC API documentation

### DIFF
--- a/pkg/apis/rbac/types.go
+++ b/pkg/apis/rbac/types.go
@@ -43,7 +43,7 @@ const (
 // PolicyRule holds information that describes a policy rule, but does not contain information
 // about who the rule applies to or which namespace the rule applies to.
 type PolicyRule struct {
-	// Verbs is a list of Verbs that apply to ALL the ResourceKinds and AttributeRestrictions contained in this rule.  VerbAll represents all kinds.
+	// Verbs is a list of Verbs that apply to ALL the ResourceKinds and AttributeRestrictions contained in this rule. '*' represents all verbs.
 	Verbs []string
 
 	// APIGroups is the name of the APIGroup that contains the resources.

--- a/staging/src/k8s.io/api/rbac/v1/generated.proto
+++ b/staging/src/k8s.io/api/rbac/v1/generated.proto
@@ -92,7 +92,7 @@ message ClusterRoleList {
 // PolicyRule holds information that describes a policy rule, but does not contain information
 // about who the rule applies to or which namespace the rule applies to.
 message PolicyRule {
-  // Verbs is a list of Verbs that apply to ALL the ResourceKinds and AttributeRestrictions contained in this rule.  VerbAll represents all kinds.
+  // Verbs is a list of Verbs that apply to ALL the ResourceKinds and AttributeRestrictions contained in this rule. '*' represents all verbs.
   repeated string verbs = 1;
 
   // APIGroups is the name of the APIGroup that contains the resources.  If multiple API groups are specified, any action requested against one of
@@ -100,7 +100,7 @@ message PolicyRule {
   // +optional
   repeated string apiGroups = 2;
 
-  // Resources is a list of resources this rule applies to.  ResourceAll represents all resources.
+  // Resources is a list of resources this rule applies to. '*' represents all resources.
   // +optional
   repeated string resources = 3;
 

--- a/staging/src/k8s.io/api/rbac/v1/types.go
+++ b/staging/src/k8s.io/api/rbac/v1/types.go
@@ -47,14 +47,14 @@ const (
 // PolicyRule holds information that describes a policy rule, but does not contain information
 // about who the rule applies to or which namespace the rule applies to.
 type PolicyRule struct {
-	// Verbs is a list of Verbs that apply to ALL the ResourceKinds and AttributeRestrictions contained in this rule.  VerbAll represents all kinds.
+	// Verbs is a list of Verbs that apply to ALL the ResourceKinds and AttributeRestrictions contained in this rule. '*' represents all verbs.
 	Verbs []string `json:"verbs" protobuf:"bytes,1,rep,name=verbs"`
 
 	// APIGroups is the name of the APIGroup that contains the resources.  If multiple API groups are specified, any action requested against one of
 	// the enumerated resources in any API group will be allowed.
 	// +optional
 	APIGroups []string `json:"apiGroups,omitempty" protobuf:"bytes,2,rep,name=apiGroups"`
-	// Resources is a list of resources this rule applies to.  ResourceAll represents all resources.
+	// Resources is a list of resources this rule applies to. '*' represents all resources.
 	// +optional
 	Resources []string `json:"resources,omitempty" protobuf:"bytes,3,rep,name=resources"`
 	// ResourceNames is an optional white list of names that the rule applies to.  An empty set means that everything is allowed.

--- a/staging/src/k8s.io/api/rbac/v1/types_swagger_doc_generated.go
+++ b/staging/src/k8s.io/api/rbac/v1/types_swagger_doc_generated.go
@@ -80,9 +80,9 @@ func (ClusterRoleList) SwaggerDoc() map[string]string {
 
 var map_PolicyRule = map[string]string{
 	"":                "PolicyRule holds information that describes a policy rule, but does not contain information about who the rule applies to or which namespace the rule applies to.",
-	"verbs":           "Verbs is a list of Verbs that apply to ALL the ResourceKinds and AttributeRestrictions contained in this rule.  VerbAll represents all kinds.",
+	"verbs":           "Verbs is a list of Verbs that apply to ALL the ResourceKinds and AttributeRestrictions contained in this rule. '*' represents all verbs.",
 	"apiGroups":       "APIGroups is the name of the APIGroup that contains the resources.  If multiple API groups are specified, any action requested against one of the enumerated resources in any API group will be allowed.",
-	"resources":       "Resources is a list of resources this rule applies to.  ResourceAll represents all resources.",
+	"resources":       "Resources is a list of resources this rule applies to. '*' represents all resources.",
 	"resourceNames":   "ResourceNames is an optional white list of names that the rule applies to.  An empty set means that everything is allowed.",
 	"nonResourceURLs": "NonResourceURLs is a set of partial urls that a user should have access to.  *s are allowed, but only as the full, final step in the path Since non-resource URLs are not namespaced, this field is only applicable for ClusterRoles referenced from a ClusterRoleBinding. Rules can either apply to API resources (such as \"pods\" or \"secrets\") or non-resource URL paths (such as \"/api\"),  but not both.",
 }

--- a/staging/src/k8s.io/api/rbac/v1alpha1/generated.proto
+++ b/staging/src/k8s.io/api/rbac/v1alpha1/generated.proto
@@ -96,7 +96,7 @@ message ClusterRoleList {
 // PolicyRule holds information that describes a policy rule, but does not contain information
 // about who the rule applies to or which namespace the rule applies to.
 message PolicyRule {
-  // Verbs is a list of Verbs that apply to ALL the ResourceKinds and AttributeRestrictions contained in this rule.  VerbAll represents all kinds.
+  // Verbs is a list of Verbs that apply to ALL the ResourceKinds and AttributeRestrictions contained in this rule. '*' represents all verbs.
   repeated string verbs = 1;
 
   // APIGroups is the name of the APIGroup that contains the resources.  If multiple API groups are specified, any action requested against one of
@@ -104,7 +104,7 @@ message PolicyRule {
   // +optional
   repeated string apiGroups = 3;
 
-  // Resources is a list of resources this rule applies to.  ResourceAll represents all resources.
+  // Resources is a list of resources this rule applies to. '*' represents all resources.
   // +optional
   repeated string resources = 4;
 

--- a/staging/src/k8s.io/api/rbac/v1alpha1/types.go
+++ b/staging/src/k8s.io/api/rbac/v1alpha1/types.go
@@ -47,14 +47,14 @@ const (
 // PolicyRule holds information that describes a policy rule, but does not contain information
 // about who the rule applies to or which namespace the rule applies to.
 type PolicyRule struct {
-	// Verbs is a list of Verbs that apply to ALL the ResourceKinds and AttributeRestrictions contained in this rule.  VerbAll represents all kinds.
+	// Verbs is a list of Verbs that apply to ALL the ResourceKinds and AttributeRestrictions contained in this rule. '*' represents all verbs.
 	Verbs []string `json:"verbs" protobuf:"bytes,1,rep,name=verbs"`
 
 	// APIGroups is the name of the APIGroup that contains the resources.  If multiple API groups are specified, any action requested against one of
 	// the enumerated resources in any API group will be allowed.
 	// +optional
 	APIGroups []string `json:"apiGroups,omitempty" protobuf:"bytes,3,rep,name=apiGroups"`
-	// Resources is a list of resources this rule applies to.  ResourceAll represents all resources.
+	// Resources is a list of resources this rule applies to. '*' represents all resources.
 	// +optional
 	Resources []string `json:"resources,omitempty" protobuf:"bytes,4,rep,name=resources"`
 	// ResourceNames is an optional white list of names that the rule applies to.  An empty set means that everything is allowed.

--- a/staging/src/k8s.io/api/rbac/v1alpha1/types_swagger_doc_generated.go
+++ b/staging/src/k8s.io/api/rbac/v1alpha1/types_swagger_doc_generated.go
@@ -80,9 +80,9 @@ func (ClusterRoleList) SwaggerDoc() map[string]string {
 
 var map_PolicyRule = map[string]string{
 	"":                "PolicyRule holds information that describes a policy rule, but does not contain information about who the rule applies to or which namespace the rule applies to.",
-	"verbs":           "Verbs is a list of Verbs that apply to ALL the ResourceKinds and AttributeRestrictions contained in this rule.  VerbAll represents all kinds.",
+	"verbs":           "Verbs is a list of Verbs that apply to ALL the ResourceKinds and AttributeRestrictions contained in this rule. '*' represents all verbs.",
 	"apiGroups":       "APIGroups is the name of the APIGroup that contains the resources.  If multiple API groups are specified, any action requested against one of the enumerated resources in any API group will be allowed.",
-	"resources":       "Resources is a list of resources this rule applies to.  ResourceAll represents all resources.",
+	"resources":       "Resources is a list of resources this rule applies to. '*' represents all resources.",
 	"resourceNames":   "ResourceNames is an optional white list of names that the rule applies to.  An empty set means that everything is allowed.",
 	"nonResourceURLs": "NonResourceURLs is a set of partial urls that a user should have access to.  *s are allowed, but only as the full, final step in the path Since non-resource URLs are not namespaced, this field is only applicable for ClusterRoles referenced from a ClusterRoleBinding. Rules can either apply to API resources (such as \"pods\" or \"secrets\") or non-resource URL paths (such as \"/api\"),  but not both.",
 }

--- a/staging/src/k8s.io/api/rbac/v1beta1/generated.proto
+++ b/staging/src/k8s.io/api/rbac/v1beta1/generated.proto
@@ -96,7 +96,7 @@ message ClusterRoleList {
 // PolicyRule holds information that describes a policy rule, but does not contain information
 // about who the rule applies to or which namespace the rule applies to.
 message PolicyRule {
-  // Verbs is a list of Verbs that apply to ALL the ResourceKinds and AttributeRestrictions contained in this rule.  VerbAll represents all kinds.
+  // Verbs is a list of Verbs that apply to ALL the ResourceKinds and AttributeRestrictions contained in this rule. '*' represents all verbs.
   repeated string verbs = 1;
 
   // APIGroups is the name of the APIGroup that contains the resources.  If multiple API groups are specified, any action requested against one of

--- a/staging/src/k8s.io/api/rbac/v1beta1/types.go
+++ b/staging/src/k8s.io/api/rbac/v1beta1/types.go
@@ -47,7 +47,7 @@ const (
 // PolicyRule holds information that describes a policy rule, but does not contain information
 // about who the rule applies to or which namespace the rule applies to.
 type PolicyRule struct {
-	// Verbs is a list of Verbs that apply to ALL the ResourceKinds and AttributeRestrictions contained in this rule.  VerbAll represents all kinds.
+	// Verbs is a list of Verbs that apply to ALL the ResourceKinds and AttributeRestrictions contained in this rule. '*' represents all verbs.
 	Verbs []string `json:"verbs" protobuf:"bytes,1,rep,name=verbs"`
 
 	// APIGroups is the name of the APIGroup that contains the resources.  If multiple API groups are specified, any action requested against one of

--- a/staging/src/k8s.io/api/rbac/v1beta1/types_swagger_doc_generated.go
+++ b/staging/src/k8s.io/api/rbac/v1beta1/types_swagger_doc_generated.go
@@ -80,7 +80,7 @@ func (ClusterRoleList) SwaggerDoc() map[string]string {
 
 var map_PolicyRule = map[string]string{
 	"":                "PolicyRule holds information that describes a policy rule, but does not contain information about who the rule applies to or which namespace the rule applies to.",
-	"verbs":           "Verbs is a list of Verbs that apply to ALL the ResourceKinds and AttributeRestrictions contained in this rule.  VerbAll represents all kinds.",
+	"verbs":           "Verbs is a list of Verbs that apply to ALL the ResourceKinds and AttributeRestrictions contained in this rule. '*' represents all verbs.",
 	"apiGroups":       "APIGroups is the name of the APIGroup that contains the resources.  If multiple API groups are specified, any action requested against one of the enumerated resources in any API group will be allowed.",
 	"resources":       "Resources is a list of resources this rule applies to.  '*' represents all resources in the specified apiGroups. '*/foo' represents the subresource 'foo' for all resources in the specified apiGroups.",
 	"resourceNames":   "ResourceNames is an optional white list of names that the rule applies to.  An empty set means that everything is allowed.",


### PR DESCRIPTION
(Resource|Verb)All are meaningless in the context of openapi spec. I saw
ResourceAll used in an RBAC policy.


/kind documentation
/sig auth

```release-note
NONE
```