### PR TITLE
code-generator/register-gen: groupName can't override

### DIFF
--- a/staging/src/k8s.io/code-generator/cmd/register-gen/generators/packages.go
+++ b/staging/src/k8s.io/code-generator/cmd/register-gen/generators/packages.go
@@ -82,7 +82,7 @@ func Packages(context *generator.Context, arguments *args.GeneratorArgs) generat
 
 			// if there is a comment of the form "// +groupName=somegroup" or "// +groupName=somegroup.foo.bar.io",
 			// extract the fully qualified API group name from it and overwrite the group inferred from the package path
-			if override := types.ExtractCommentTags("+", pkg.DocComments)["groupName"]; override != nil {
+			if override := types.ExtractCommentTags("+", pkg.Comments)["groupName"]; override != nil {
 				groupName := override[0]
 				klog.V(5).Infof("overriding the group name with = %s", groupName)
 				gv.Group = clientgentypes.Group(groupName)


### PR DESCRIPTION
Signed-off-by: cuisongliu <cuisongliu@qq.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

when I use `code-generator` to generator code . at `doc.go`  add Comments  `// +groupName=xxx` ,I found not override this `groupName`. 
`types.ExtractCommentTags("+", pkg.DocComments)["groupName"]`  fix to `types.ExtractCommentTags("+", pkg.Comments)["groupName"]` is right


```
NONE