### PR TITLE
prevent zap handle duration as time first: npe

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/server/httplog/httplog.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/httplog/httplog.go
@@ -156,7 +156,7 @@ func (rl *respLogger) Addf(format string, data ...interface{}) {
 }
 
 func (rl *respLogger) LogArgs() []interface{} {
-	latency := time.Since(rl.startTime)
+	latency := int64(time.Since(rl.startTime))
 	if rl.hijacked {
 		return []interface{}{
 			"verb", rl.req.Method,


### PR DESCRIPTION
#### What type of PR is this?
/kind bug


#### What this PR does / why we need it:

To make sure the latency here is int64.
zap handle Duration wrongly in the old version.

#### Which issue(s) this PR fixes:
Fixes #100739

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
None
```