### PR TITLE
kube-proxy flush TCP conntrack when switching endpoints

### DIFF
--- a/pkg/proxy/iptables/proxier.go
+++ b/pkg/proxy/iptables/proxier.go
@@ -754,13 +754,15 @@ func servicePortEndpointChainName(servicePortName string, protocol string, endpo
 	return utiliptables.Chain("KUBE-SEP-" + encoded[:16])
 }
 
-// After a UDP or SCTP endpoint has been removed, we must flush any pending conntrack entries to it, or else we
-// risk sending more traffic to it, all of which will be lost.
+// After an endpoint has been removed, we must flush any pending conntrack entries to it.
+// or for UDP and SCTP we risk sending more traffic to it, all of which will be lost.
+// In case of TCP, if the pod is still alive, it will keep current connections to the service alive,
+// despite the pod no longer belongs to the service.
 // This assumes the proxier mutex is held
 // TODO: move it to util
 func (proxier *Proxier) deleteEndpointConnections(connectionMap []proxy.ServiceEndpoint) {
 	for _, epSvcPair := range connectionMap {
-		if svcInfo, ok := proxier.serviceMap[epSvcPair.ServicePortName]; ok && conntrack.IsClearConntrackNeeded(svcInfo.Protocol()) {
+		if svcInfo, ok := proxier.serviceMap[epSvcPair.ServicePortName]; ok {
 			endpointIP := utilproxy.IPPart(epSvcPair.Endpoint)
 			nodePort := svcInfo.NodePort()
 			svcProto := svcInfo.Protocol()


### PR DESCRIPTION
When a TCP  endpoint is removed from the service, current
connections keep working, despite the endpoint no longer belong
to the service.
This is because the conntrack entries installed to map the service
to the endpoint are still present, kube-proxy must flush these
entries to avoid sending traffic to a pod that doesn't belong
to the service.

This is only needed for endpoins, because on the contrary to UDP
and SCTP, TCP is stateful, so stale conntrack entries can not
blackhole the traffic caused by stale conntrack entries on services.

/kind bug
/area kube-proxy

Fixes: #100698

```release-note
kube-proxy clear conntrack entries for TCP endpoints that are removed from the service.
```


