### PR TITLE
Fix a unit test failure in non English languages

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/diff/diff_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/diff/diff_test.go
@@ -54,6 +54,11 @@ func (f *FakeObject) Live() runtime.Object {
 func TestDiffProgram(t *testing.T) {
 	externalDiffCommands := [3]string{"diff", "diff -ruN", "diff --report-identical-files"}
 
+	if oriLang := os.Getenv("LANG"); oriLang != "C" {
+		os.Setenv("LANG", "C")
+		defer os.Setenv("LANG", oriLang)
+	}
+
 	for i, c := range externalDiffCommands {
 		os.Setenv("KUBECTL_EXTERNAL_DIFF", c)
 		streams, _, stdout, _ := genericclioptions.NewTestIOStreams()


### PR DESCRIPTION
#### What type of PR is this?
/kind failing-test

#### What this PR does / why we need it:
Fix a unit test failure in non English languages. For example, this is a result in Japanese language.
```
$ make test WHAT=./staging/src/k8s.io/kubectl/pkg/cmd/diff
[0402 07:24:05] Running tests without code coverage
FAIL: TestDiffProgram (0.00s)
    diff_test.go:73: stdout = "ファイル /dev/zero と /dev/zero は同一です\n", expected = Files /dev/zero and /dev/zero are identical
        "
FAIL
FAIL	k8s.io/kubernetes/staging/src/k8s.io/kubectl/pkg/cmd/diff	0.045s
FAIL
make: *** [Makefile:184: test] エラー 1
```

#### Which issue(s) this PR fixes:
NONE

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs

```
