### PR TITLE
Use GKE specific configuration for kube-apiserver SNI cert

### DIFF
--- a/cluster/gce/gci/configure-helper.sh
+++ b/cluster/gce/gci/configure-helper.sh
@@ -1269,9 +1269,12 @@ EOF
 function create-kubeconfig {
   local component=$1
   local token=$2
-  echo "Creating kubeconfig file for component ${component}"
-  mkdir -p "/etc/srv/kubernetes/${component}"
-  cat <<EOF >"/etc/srv/kubernetes/${component}/kubeconfig"
+  if [[ -e "${KUBE_HOME}/bin/gke-internal-configure-helper.sh" ]]; then
+    gke-internal-create-kubeconfig "${component}" "${token}"
+  else
+    echo "Creating kubeconfig file for component ${component}"
+    mkdir -p "/etc/srv/kubernetes/${component}"
+    cat <<EOF >"/etc/srv/kubernetes/${component}/kubeconfig"
 apiVersion: v1
 kind: Config
 users:
@@ -1290,6 +1293,7 @@ contexts:
   name: ${component}
 current-context: ${component}
 EOF
+  fi
 }
 
 # Arg 1: the IP address of the API server

--- a/cluster/gce/gci/configure-helper.sh
+++ b/cluster/gce/gci/configure-helper.sh
@@ -1269,12 +1269,9 @@ EOF
 function create-kubeconfig {
   local component=$1
   local token=$2
-  if [[ -e "${KUBE_HOME}/bin/gke-internal-configure-helper.sh" ]]; then
-    gke-internal-create-kubeconfig "${component}" "${token}"
-  else
-    echo "Creating kubeconfig file for component ${component}"
-    mkdir -p "/etc/srv/kubernetes/${component}"
-    cat <<EOF >"/etc/srv/kubernetes/${component}/kubeconfig"
+  echo "Creating kubeconfig file for component ${component}"
+  mkdir -p "/etc/srv/kubernetes/${component}"
+  cat <<EOF >"/etc/srv/kubernetes/${component}/kubeconfig"
 apiVersion: v1
 kind: Config
 users:
@@ -1293,7 +1290,6 @@ contexts:
   name: ${component}
 current-context: ${component}
 EOF
-  fi
 }
 
 # Arg 1: the IP address of the API server

--- a/cluster/gce/gci/configure-kubeapiserver.sh
+++ b/cluster/gce/gci/configure-kubeapiserver.sh
@@ -95,6 +95,9 @@ function start-kube-apiserver {
   if [[ -n "${TLS_CIPHER_SUITES:-}" ]]; then
     params+=" --tls-cipher-suites=${TLS_CIPHER_SUITES}"
   fi
+  if [[ -e "${KUBE_HOME}/bin/gke-internal-configure-helper.sh" ]]; then
+    gke-kube-apiserver-internal-sni-param params
+  fi
   params+=" --kubelet-preferred-address-types=InternalIP,ExternalIP,Hostname"
   if [[ -s "${REQUESTHEADER_CA_CERT_PATH:-}" ]]; then
     params+=" --requestheader-client-ca-file=${REQUESTHEADER_CA_CERT_PATH}"

--- a/cluster/gce/gci/configure-kubeapiserver.sh
+++ b/cluster/gce/gci/configure-kubeapiserver.sh
@@ -96,7 +96,7 @@ function start-kube-apiserver {
     params+=" --tls-cipher-suites=${TLS_CIPHER_SUITES}"
   fi
   if [[ -e "${KUBE_HOME}/bin/gke-internal-configure-helper.sh" ]]; then
-    gke-kube-apiserver-internal-sni-param params
+    params+=" $(gke-kube-apiserver-internal-sni-param)"
   fi
   params+=" --kubelet-preferred-address-types=InternalIP,ExternalIP,Hostname"
   if [[ -s "${REQUESTHEADER_CA_CERT_PATH:-}" ]]; then


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
Allow GKE to configure VM start up differently.
More specifically, kube-apiserver SNI cert configuration is changed for GKE.

#### Which issue(s) this PR fixes:
N/A

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs

```
