### PR TITLE
remove GAed feature gates group: LegacyNodeRoleBehavior

### DIFF
--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -138,32 +138,6 @@ const (
 	// Enable pods to set sysctls on a pod
 	Sysctls featuregate.Feature = "Sysctls"
 
-	// owner @smarterclayton
-	// alpha: v1.16
-	// beta:  v1.19
-	// ga:  v1.21
-	//
-	// Enable legacy behavior to vary cluster functionality on the node-role.kubernetes.io labels. On by default (legacy), will be turned off in 1.18.
-	// Lock to false in v1.21 and remove in v1.22.
-	LegacyNodeRoleBehavior featuregate.Feature = "LegacyNodeRoleBehavior"
-
-	// owner @brendandburns
-	// kep: http://kep.k8s.io/1143
-	// alpha: v1.9
-	// beta:  v1.19
-	// ga:  v1.21
-	//
-	// Enable nodes to exclude themselves from service load balancers
-	ServiceNodeExclusion featuregate.Feature = "ServiceNodeExclusion"
-
-	// owner @smarterclayton
-	// alpha: v1.16
-	// beta:  v1.19
-	// ga:  v1.21
-	//
-	// Enable nodes to exclude themselves from network disruption checks
-	NodeDisruptionExclusion featuregate.Feature = "NodeDisruptionExclusion"
-
 	// owner: @pospispa
 	// GA: v1.11
 	//
@@ -792,8 +766,6 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
 	MemoryManager:                                  {Default: false, PreRelease: featuregate.Alpha},
 	CPUCFSQuotaPeriod:                              {Default: false, PreRelease: featuregate.Alpha},
 	TopologyManager:                                {Default: true, PreRelease: featuregate.Beta},
-	ServiceNodeExclusion:                           {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.23
-	NodeDisruptionExclusion:                        {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.22
 	StorageObjectInUseProtection:                   {Default: true, PreRelease: featuregate.GA},
 	SupportPodPidsLimit:                            {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.23
 	SupportNodePidsLimit:                           {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.23
@@ -894,6 +866,5 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
 
 	// features that enable backwards compatibility but are scheduled to be removed
 	// ...
-	HPAScaleToZero:         {Default: false, PreRelease: featuregate.Alpha},
-	LegacyNodeRoleBehavior: {Default: false, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.22
+	HPAScaleToZero: {Default: false, PreRelease: featuregate.Alpha},
 }

--- a/staging/src/k8s.io/controller-manager/pkg/features/kube_features.go
+++ b/staging/src/k8s.io/controller-manager/pkg/features/kube_features.go
@@ -27,23 +27,6 @@ const (
 	// // alpha: v1.4
 	// MyFeature() bool
 
-	// owner @smarterclayton
-	// alpha: v1.16
-	// beta:  v1.19
-	//
-	// Enable legacy behavior to vary cluster functionality on the node-role.kubernetes.io labels. On by default (legacy), will be turned off in 1.18.
-	// Original copy from k8s.io/kubernetes/pkg/features/kube_features.go
-	LegacyNodeRoleBehavior featuregate.Feature = "LegacyNodeRoleBehavior"
-
-	// owner @brendandburns
-	// alpha: v1.9
-	// beta:  v1.19
-	// ga:  v1.21
-	//
-	// Enable nodes to exclude themselves from service load balancers
-	// Original copy from k8s.io/kubernetes/pkg/features/kube_features.go
-	ServiceNodeExclusion featuregate.Feature = "ServiceNodeExclusion"
-
 	// owner: @khenidak
 	// alpha: v1.15
 	//
@@ -65,8 +48,6 @@ func SetupCurrentKubernetesSpecificFeatureGates(featuregates featuregate.Mutable
 // cloudPublicFeatureGates consists of cloud-specific feature keys.
 // To add a new feature, define a key for it at k8s.io/api/pkg/features and add it here.
 var cloudPublicFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
-	LegacyNodeRoleBehavior:           {Default: false, PreRelease: featuregate.GA, LockToDefault: true},
-	ServiceNodeExclusion:             {Default: true, PreRelease: featuregate.GA, LockToDefault: true},
 	IPv6DualStack:                    {Default: true, PreRelease: featuregate.Beta},
 	ControllerManagerLeaderMigration: {Default: false, PreRelease: featuregate.Alpha},
 }


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup
/sig network
/area kubelet

#### What this PR does / why we need it:
https://github.com/kubernetes/kubernetes/pull/97543#issuecomment-751732381
> Not GA'd feature gates should first be moved to GA and locked to the default (true for ServiceNodeExclusion and NodeDisruptionExclusion, false for LegacyNodeRoleBehavior per KEP) and then removed from kube_features.go in v1.22

#### Which issue(s) this PR fixes:
Fixes #94495 kubernetes/enhancements#1143

follow up of 1.21 PR #97543
/milestone 1.22

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs
- [KEP]: https://github.com/kubernetes/enhancements/tree/master/keps/sig-architecture/1143-node-role-labels
```