### PR TITLE
Fix Topology Aware Hints support for Kube-Proxy 

### DIFF
--- a/pkg/proxy/metaproxier/meta_proxier.go
+++ b/pkg/proxy/metaproxier/meta_proxier.go
@@ -216,3 +216,31 @@ func endpointsIPFamily(endpoints *v1.Endpoints) (*v1.IPFamily, error) {
 
 	return &ipv4, nil
 }
+
+// OnNodeAdd is called whenever creation of new node object is observed.
+func (proxier *metaProxier) OnNodeAdd(node *v1.Node) {
+	proxier.ipv4Proxier.OnNodeAdd(node)
+	proxier.ipv6Proxier.OnNodeAdd(node)
+}
+
+// OnNodeUpdate is called whenever modification of an existing
+// node object is observed.
+func (proxier *metaProxier) OnNodeUpdate(oldNode, node *v1.Node) {
+	proxier.ipv4Proxier.OnNodeUpdate(oldNode, node)
+	proxier.ipv6Proxier.OnNodeUpdate(oldNode, node)
+}
+
+// OnNodeDelete is called whenever deletion of an existing node
+// object is observed.
+func (proxier *metaProxier) OnNodeDelete(node *v1.Node) {
+	proxier.ipv4Proxier.OnNodeDelete(node)
+	proxier.ipv6Proxier.OnNodeDelete(node)
+
+}
+
+// OnNodeSynced is called once all the initial event handlers were
+// called and the state is fully propagated to local cache.
+func (proxier *metaProxier) OnNodeSynced() {
+	proxier.ipv4Proxier.OnNodeSynced()
+	proxier.ipv6Proxier.OnNodeSynced()
+}


### PR DESCRIPTION
/kind bug

#### What this PR does / why we need it:

Fix kube-proxy implementation of Topology Aware Hints,
implemented in https://github.com/kubernetes/kubernetes/pull/99522


```release-note
Fix regression in 1.21 in kube-proxy implementation of Topology Aware Hints
```

KEP: https://github.com/kubernetes/enhancements/blob/master/keps/sig-network/2433-topology-aware-hints
Enhancement Issue: kubernetes/enhancements#2433
/sig network

/priority critical-urgent


