### PR TITLE
test/integration/scheduler_perf: make sure each testCase and workload has a unique name

### DIFF
--- a/test/integration/scheduler_perf/scheduler_perf_test.go
+++ b/test/integration/scheduler_perf/scheduler_perf_test.go
@@ -111,15 +111,15 @@ func (tc *testCase) collectsMetrics() bool {
 	return false
 }
 
-func (tc *testCase) workloadNamesUnique() bool {
+func (tc *testCase) workloadNamesUnique() error {
 	workloadUniqueNames := map[string]bool{}
 	for _, w := range tc.Workloads {
 		if workloadUniqueNames[w.Name] {
-			return false
+			return fmt.Errorf("%s: workload name %s is not unique", tc.Name, w.Name)
 		}
 		workloadUniqueNames[w.Name] = true
 	}
-	return true
+	return nil
 }
 
 // workload is a subtest under a testCase that tests the scheduler performance
@@ -786,8 +786,8 @@ func validateTestCases(testCases []*testCase) error {
 		if len(tc.Workloads) == 0 {
 			return fmt.Errorf("%s: no workloads defined", tc.Name)
 		}
-		if !tc.workloadNamesUnique() {
-			return fmt.Errorf("%s: workload names are not unique", tc.Name)
+		if err := tc.workloadNamesUnique(); err != nil {
+			return err
 		}
 		if len(tc.WorkloadTemplate) == 0 {
 			return fmt.Errorf("%s: no ops defined", tc.Name)

--- a/test/integration/scheduler_perf/scheduler_perf_test.go
+++ b/test/integration/scheduler_perf/scheduler_perf_test.go
@@ -111,6 +111,17 @@ func (tc *testCase) collectsMetrics() bool {
 	return false
 }
 
+func (tc *testCase) workloadNamesUnique() bool {
+	workloadUniqueNames := map[string]bool{}
+	for _, w := range tc.Workloads {
+		if workloadUniqueNames[w.Name] {
+			return false
+		}
+		workloadUniqueNames[w.Name] = true
+	}
+	return true
+}
+
 // workload is a subtest under a testCase that tests the scheduler performance
 // for a certain ordering of ops. The set of nodes created and pods scheduled
 // in a workload may be heterogeneous.
@@ -766,9 +777,17 @@ func validateTestCases(testCases []*testCase) error {
 	if len(testCases) == 0 {
 		return fmt.Errorf("no test cases defined")
 	}
+	testCaseUniqueNames := map[string]bool{}
 	for _, tc := range testCases {
+		if testCaseUniqueNames[tc.Name] {
+			return fmt.Errorf("%s: name is not unique", tc.Name)
+		}
+		testCaseUniqueNames[tc.Name] = true
 		if len(tc.Workloads) == 0 {
 			return fmt.Errorf("%s: no workloads defined", tc.Name)
+		}
+		if !tc.workloadNamesUnique() {
+			return fmt.Errorf("%s: workload names are not unique", tc.Name)
 		}
 		if len(tc.WorkloadTemplate) == 0 {
 			return fmt.Errorf("%s: no ops defined", tc.Name)


### PR DESCRIPTION
/kind feature
#### What this PR does / why we need it:
Adds checks inside of scheduler_perf_test.go to ensure test case and workload names in performance-config.yaml are unique. 

#### Which issue(s) this PR fixes:
Fixes #93795 

#### Special notes for your reviewer:
This is my first contribution so let me know if there's anything I could've done differently.
#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
