### PR TITLE
Check if the interface value is nil, otherwise it will panic

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/version/version.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/version/version.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"reflect"
 
 	"github.com/spf13/cobra"
 	"sigs.k8s.io/yaml"
@@ -120,7 +121,7 @@ func (o *Options) Run() error {
 	clientVersion := version.Get()
 	versionInfo.ClientVersion = &clientVersion
 
-	if !o.ClientOnly && o.discoveryClient != nil {
+	if !o.ClientOnly && !reflect.ValueOf(o.discoveryClient).IsNil() {
 		// Always request fresh data from the server
 		o.discoveryClient.Invalidate()
 		serverVersion, serverErr = o.discoveryClient.ServerVersion()


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

While testing some other parts of kubectl, I've faced a weird panic on the command version:

```
   version_test.go:34: Unexpected error: no Auth Provider found for name "gcp"
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
        panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x28 pc=0x1b21b1a]

goroutine 55 [running]:
testing.tRunner.func1.2(0x1ed5d80, 0x2cd9000)
        /home/rkatz/go/1.16/src/testing/testing.go:1144 +0x332
testing.tRunner.func1(0xc000583c80)
        /home/rkatz/go/1.16/src/testing/testing.go:1147 +0x4b6
panic(0x1ed5d80, 0x2cd9000)
        /home/rkatz/go/1.16/src/runtime/panic.go:965 +0x1b9
k8s.io/client-go/discovery/cached/disk.(*CachedDiscoveryClient).Invalidate(0x0)
        /home/rkatz/archive/rkatz/codes/kubernetes/staging/src/k8s.io/client-go/discovery/cached/disk/cached_discovery.go:254 +0x3a
k8s.io/kubectl/pkg/cmd/version.(*Options).Run(0xc000515c88, 0x20da0ea, 0x14)
        /home/rkatz/archive/rkatz/codes/kubernetes/staging/src/k8s.io/kubectl/pkg/cmd/version/version.go:126 +0x928
k8s.io/kubectl/pkg/cmd/version.TestNewCmdVersionWithoutConfigFile(0xc000583c80)
        /home/rkatz/archive/rkatz/codes/kubernetes/staging/src/k8s.io/kubectl/pkg/cmd/version/version_test.go:42 +0x385
testing.tRunner(0xc000583c80, 0x2188240)
        /home/rkatz/go/1.16/src/testing/testing.go:1194 +0xef
created by testing.(*T).Run
        /home/rkatz/go/1.16/src/testing/testing.go:1239 +0x2b3
FAIL    k8s.io/kubectl/pkg/cmd/version  0.024s
FAIL
```

It happens because we use on the test t.Errorf and not t.Fatalf, and as I'm with my kubeconfig pointed to my GCP environment, it caused this error.

But it raised my attention to that panic happening where it shouldn't.

So I've figured out that we're checking if an interface is nil, which is not (instead of it's value that is nil). The interface is initialized on f.ToDiscoveryClient but because of GCP error its value is nil.

So we should maybe be checking the value and not the interface

```release-note
NONE
```
