### PR TITLE
remove redundant \t in network e2e

### DIFF
--- a/test/e2e/network/netpol/truthtable.go
+++ b/test/e2e/network/netpol/truthtable.go
@@ -151,7 +151,7 @@ func (tt *TruthTable) Compare(other *TruthTable) *TruthTable {
 
 // PrettyPrint produces a nice visual representation.
 func (tt *TruthTable) PrettyPrint(indent string) string {
-	header := indent + strings.Join(append([]string{"-\t"}, tt.Tos...), "\t")
+	header := indent + strings.Join(append([]string{"-"}, tt.Tos...), "\t")
 	lines := []string{header}
 	for _, from := range tt.Froms {
 		line := []string{from}
@@ -163,7 +163,7 @@ func (tt *TruthTable) PrettyPrint(indent string) string {
 			} else if val {
 				mark = "."
 			}
-			line = append(line, mark+"\t")
+			line = append(line, mark)
 		}
 		lines = append(lines, indent+strings.Join(line, "\t"))
 	}


### PR DESCRIPTION
strings.Join() always add \t between words.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

