### PR TITLE
[WIP] Disable attempts of obtaining zones for legacy vSphere provider if credentials stored in secret.

### DIFF
--- a/staging/src/k8s.io/legacy-cloud-providers/vsphere/vsphere.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/vsphere/vsphere.go
@@ -894,7 +894,12 @@ func (vs *VSphere) LoadBalancer() (cloudprovider.LoadBalancer, bool) {
 }
 
 func (vs *VSphere) isZoneEnabled() bool {
-	return vs.cfg != nil && vs.cfg.Labels.Zone != "" && vs.cfg.Labels.Region != ""
+	isEnabled := vs.cfg != nil && vs.cfg.Labels.Zone != "" && vs.cfg.Labels.Region != ""
+	if isEnabled && vs.isSecretInfoProvided && vs.nodeManager.credentialManager == nil {
+		klog.V(1).Info("Zones can not be populated now due to credentials in Secret, skip.")
+		return false
+	}
+	return isEnabled
 }
 
 // Zones returns an implementation of Zones for vSphere.

--- a/staging/src/k8s.io/legacy-cloud-providers/vsphere/vsphere_test.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/vsphere/vsphere_test.go
@@ -371,6 +371,62 @@ func TestZonesNoConfig(t *testing.T) {
 	}
 }
 
+func TestZonesWithCredsInSecret(t *testing.T) {
+	noSecretCfg, err := readConfig(strings.NewReader(`
+[Global]
+user = "vsphere-creds"
+password = "kube-system"
+insecure-flag = "1"
+[Workspace]
+server = "vcenter.example.com"
+datacenter = "LAB"
+default-datastore = "datastore"
+folder = "/LAB/vm/lab-gxjfk"
+[VirtualCenter "vcenter.example.com"]
+datacenters = "LAB"
+[Labels]
+region = "kube-region"
+zone = "kube-zone"
+`))
+	vsphere, err := buildVSphereFromConfig(noSecretCfg)
+	if err != nil {
+		t.Fatalf("Should succeed when a valid config is provided: %s", err)
+	}
+	_, ok := vsphere.Zones()
+	if !ok {
+		t.Fatalf("Zones should return true with plain text credentials")
+	}
+
+	// Return false in case if secret provided but no informers (no NodeManager.credentialManager basically) set up.
+	// Such situation happens during kubelet startup process, when InitialNode creates.
+	// See https://github.com/kubernetes/kubernetes/issues/75175
+	// and https://github.com/kubernetes/kubernetes/blob/master/pkg/kubelet/kubelet_node_status.go#L418
+	withSecretCfg, err := readConfig(strings.NewReader(`
+[Global]
+secret-name = "vsphere-creds"
+secret-namespace = "kube-system"
+insecure-flag = "1"
+[Workspace]
+server = "vcenter.example.com"
+datacenter = "LAB"
+default-datastore = "datastore_big"
+folder = "/LAB/vm/lab-gxjfk"
+[VirtualCenter "vcenter.example.com"]
+datacenters = "LAB"
+[Labels]
+region = "kube-region"
+zone = "kube-zone"
+`))
+	vsphere, err = buildVSphereFromConfig(withSecretCfg)
+	if err != nil {
+		t.Fatalf("Should succeed when a valid config is provided: %s", err)
+	}
+	_, ok = vsphere.Zones()
+	if ok {
+		t.Fatalf("Zones should return false with plain credentials in secret")
+	}
+}
+
 func TestZones(t *testing.T) {
 	// Any context will do
 	ctx := context.Background()


### PR DESCRIPTION
#### What this PR does / why we need it:
Disables attempts of obtaining zones for legacy vSphere provider if credentials stored in secret.

#### Which issue(s) this PR fixes:
Partially solves #75175. Kubelet does not stucking on startup with this patch. Zones doesn't come up though. 
Gonna look if this zones might be populated with KCM, not sure in this for now.


#### What type of PR is this?
/kind bug
/sig cloudprovider
/sig vmware

cc @andrewsykim




