### PR TITLE
improve the readability of log

### DIFF
--- a/pkg/proxy/iptables/proxier.go
+++ b/pkg/proxy/iptables/proxier.go
@@ -1606,7 +1606,7 @@ func (proxier *Proxier) syncProxyRules() {
 	numberNatIptablesRules := utilproxy.CountBytesLines(proxier.natRules.Bytes())
 	metrics.IptablesRulesTotal.WithLabelValues(string(utiliptables.TableNAT)).Set(float64(numberNatIptablesRules))
 
-	klog.V(5).InfoS("Restoring iptables", "rules", proxier.iptablesData.Bytes())
+	klog.V(5).InfoS("Restoring iptables", "rules", string(proxier.iptablesData.Bytes()))
 	err = proxier.iptables.RestoreAll(proxier.iptablesData.Bytes(), utiliptables.NoFlushTables, utiliptables.RestoreCounters)
 	if err != nil {
 		klog.ErrorS(err, "Failed to execute iptables-restore")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Improve the readability of kube-proxy log.

before change:
```
I0407 14:16:29.804691   19372 proxier.go:1609] "Restoring iptables" rules=[42 102 105 108 116 101 114 10 58 75 85 66 69 45 83 69 82 86 73 67 69 83 32 45 32 91 48 58 48 93 10 58 75 85 66 69 45 69 88 84 69 82 78 65 76 45 83 69 82 86 73 67 69 83 32 45 32 91 48 58 48 93 10 58 75 85 66 69 45 70 79 82 87 65 82 68 32 45 32 91 48 58 48 93 10 58 75 85 66 69 45 78 79 68 69 80 79 82 84 83 32 45 32 91 48 58 48 93 10 45 65 32 75 85 66 69 45 83 69 82 86 73 67 69 83 32 45 109 32 99 111 109 109 101 110 116 32 45 45 99 111 109 109 101 110 116 32 34 104 105 118 101 115 101 99 47 99 108 117 115 116 101 114 45 108 105 110 107 58 112 114 111 120 121 32 104 97 115 32 110 111 32 101 110 100 112 111 105 110 116 115 34 32 45 109 32 116 99 112 32 45 112 32 116 99 112 32 45 100 32 49 48 46 50 53 52 46 50 48 48 46 49 48 54 47 51 50 32 45 45 100 112 111 114 116 32 49 48 56 48 32 45 106 32 82 69 74 69 67 84 10 45 65 32 75 85 66 69 45 83 69 82 86 73 67 69 83 32 45 109 32 99 111 109 109 101 110 116 32 45 45 99 111 109 109 101 110 116 32 34 100 101 102 97 117 108 116 47 107 117 98 101 114 110 101 116 101 115 58 104 116 116 112 115 32 104 97 115 32 110 111 32 101 110 100 112 111 105 110 116 115 34 32 45 109 32 116 99 112 32 45 112 32 116 99 112 32 45 100 32 49 48 46 50 53 52 46 48 46 49 47 51 50 32 45 45 100 112 111 114 116 32 52 52 51 32 45 106 32 82 69 74 69 67 84 10 45 65 32 75 85 66 69 45 83 69 82 86 73 67 69 83 32 45 109 32 99 111 109 109 101 110 116 32 45 45 99 111 109 109 101 110 116 32 34 104 105 118 101 115 101 99 47 99 108 117 115 116 101 114 45 108 105 110 107 58 99 108 117 115 116 101 114 45 108 105 110 107 32 104 97 115 32 110 111 32 101 110 100 112 111 105 110 116 115 34 32 45 109 32 116 99 112 32 45 112 32 116 99 112 32 45 100 32 49 48 46 50 53 52 46 50 48 48 46 49 48 54 47 51 50 32 45 45 100 112 111 114 116 32 57 48 48 49 32 45 106 32 82 69 74 69 67 84 10 45 65 32 75 85 66 69 45 70 79 82 87 65 82 68 32 45 109 32 99 111 110 110 116 114 97 99 107 32 45 45 99 116 115 116 97 116 101 32 73 78 86 65 76 73 68 32 45 106 32 68 82 79 80 10 45 65 32 75 85 66 69 45 70 79 82 87 65 82 68 32 45 109 32 99 111 109 109 101 110 116 32 45 45 99 111 109 109 101 110 116 32 34 107 117 98 101 114 110 101 116 101 115 32 102 111 114 119 97 114 100 105 110 103 32 114 117 108 101 115 34 32 45 109 32 109 97 114 107 32 45 45 109 97 114 107 32 48 120 48 48 48 48 52 48 48 48 47 48 120 48 48 48 48 52 48 48 48 32 45 106 32 65 67 67 69 80 84 10 45 65 32 75 85 66 69 45 70 79 82 87 65 82 68 32 45 109 32 99 111 109 109 101 110 116 32 45 45 99 111 109 109 101 110 116 32 34 107 117 98 101 114 110 101 116 101 115 32 102 111 114 119 97 114 100 105 110 103 32 99 111 110 110 116 114 97 99 107 32 112 111 100 32 115 111 117 114 99 101 32 114 117 108 101 34 32 45 109 32 99 111 110 110 116 114 97 99 107 32 45 45 99 116 115 116 97 116 101 32 82 69 76 65 84 69 68 44 69 83 84 65 66 76 73 83 72 69 68 32 45 106 32 65 67 67 69 80 84 10 45 65 32 75 85 66 69 45 70 79 82 87 65 82 68 32 45 109 32 99 111 109 109 101 110 116 32 45 45 99 111 109 109 101 110 116 32 34 107 117 98 101 114 110 101 116 101 115 32 102 111 114 119 97 114 100 105 110 103 32 99 111 110 110 116 114 97 99 107 32 112 111 100 32 100 101 115 116 105 110 97 116 105 111 110 32 114 117 108 101 34 32 45 109 32 99 111 110 110 116 114 97 99 107 32 45 45 99 116 115 116 97 116 101 32 82 69 76 65 84 69 68 44 69 83 84 65 66 76 73 83 72 69 68 32 45 106 32 65 67 67 69 80 84 10 67 79 77 77 73 84 10 42 110 97 116 10 58 75 85 66 69 45 83 69 82 86 73 67 69 83 32 45 32 91 48 58 48 93 10 58 75 85 66 69 45 78 79 68 69 80 79 82 84 83 32 45 32 91 48 58 48 93 10 58 75 85 66 69 45 80 79 83 84 82 79 85 84 73 78 71 32 45 32 91 48 58 48 93 10 58 75 85 66 69 45 77 65 82 75 45 77 65 83 81 32 45 32 91 48 58 48 93 10 45 65 32 75 85 66 69 45 80 79 83 84 82 79 85 84 73 78 71 32 45 109 32 109 97 114 107 32 33 32 45 45 109 97 114 107 32 48 120 48 48 48 48 52 48 48 48 47 48 120 48 48 48 48 52 48 48 48 32 45 106 32 82 69 84 85 82 78 10 45 65 32 75 85 66 69 45 80 79 83 84 82 79 85 84 73 78 71 32 45 106 32 77 65 82 75 32 45 45 120 111 114 45 109 97 114 107 32 48 120 48 48 48 48 52 48 48 48 10 45 65 32 75 85 66 69 45 80 79 83 84 82 79 85 84 73 78 71 32 45 109 32 99 111 109 109 101 110 116 32 45 45 99 111 109 109 101 110 116 32 34 107 117 98 101 114 110 101 116 101 115 32 115 101 114 118 105 99 101 32 116 114 97 102 102 105 99 32 114 101 113 117 105 114 105 110 103 32 83 78 65 84 34 32 45 106 32 77 65 83 81 85 69 82 65 68 69 10 45 65 32 75 85 66 69 45 77 65 82 75 45 77 65 83 81 32 45 106 32 77 65 82 75 32 45 45 111 114 45 109 97 114 107 32 48 120 48 48 48 48 52 48 48 48 10 45 65 32 75 85 66 69 45 83 69 82 86 73 67 69 83 32 45 109 32 99 111 109 109 101 110 116 32 45 45 99 111 109 109 101 110 116 32 34 107 117 98 101 114 110 101 116 101 115 32 115 101 114 118 105 99 101 32 110 111 100 101 112 111 114 116 115 59 32 78 79 84 69 58 32 116 104 105 115 32 109 117 115 116 32 98 101 32 116 104 101 32 108 97 115 116 32 114 117 108 101 32 105 110 32 116 104 105 115 32 99 104 97 105 110 34 32 45 109 32 97 100 100 114 116 121 112 101 32 45 45 100 115 116 45 116 121 112 101 32 76 79 67 65 76 32 45 106 32 75 85 66 69 45 78 79 68 69 80 79 82 84 83 10 67 79 77 77 73 84 10]
```
after change:
```
I0407 14:46:38.348661   24496 proxier.go:1609] "Restoring iptables" rules="*filter\n:KUBE-SERVICES - [0:0]\n:KUBE-EXTERNAL-SERVICES - [0:0]\n:KUBE-FORWARD - [0:0]\n:KUBE-NODEPORTS - [0:0]\n-A KUBE-SERVICES -m comment --comment \"default/kubernetes:https has no endpoints\" -m tcp -p tcp -d 10.254.0.1/32 --dport 443 -j REJECT\n-A KUBE-SERVICES -m comment --comment \"hivesec/cluster-link:cluster-link has no endpoints\" -m tcp -p tcp -d 10.254.200.106/32 --dport 9001 -j REJECT\n-A KUBE-SERVICES -m comment --comment \"hivesec/cluster-link:proxy has no endpoints\" -m tcp -p tcp -d 10.254.200.106/32 --dport 1080 -j REJECT\n-A KUBE-FORWARD -m conntrack --ctstate INVALID -j DROP\n-A KUBE-FORWARD -m comment --comment \"kubernetes forwarding rules\" -m mark --mark 0x00004000/0x00004000 -j ACCEPT\n-A KUBE-FORWARD -m comment --comment \"kubernetes forwarding conntrack pod source rule\" -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT\n-A KUBE-FORWARD -m comment --comment \"kubernetes forwarding conntrack pod destination rule\" -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT\nCOMMIT\n*nat\n:KUBE-SERVICES - [0:0]\n:KUBE-NODEPORTS - [0:0]\n:KUBE-POSTROUTING - [0:0]\n:KUBE-MARK-MASQ - [0:0]\n-A KUBE-POSTROUTING -m mark ! --mark 0x00004000/0x00004000 -j RETURN\n-A KUBE-POSTROUTING -j MARK --xor-mark 0x00004000\n-A KUBE-POSTROUTING -m comment --comment \"kubernetes service traffic requiring SNAT\" -j MASQUERADE\n-A KUBE-MARK-MASQ -j MARK --or-mark 0x00004000\n-A KUBE-SERVICES -m comment --comment \"kubernetes service nodeports; NOTE: this must be the last rule in this chain\" -m addrtype --dst-type LOCAL -j KUBE-NODEPORTS\nCOMMIT\n"
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
