### PR TITLE
e2e-kops: skip kube-dns autoscaling test after 1.20

### DIFF
--- a/test/e2e/autoscaling/dns_autoscaling.go
+++ b/test/e2e/autoscaling/dns_autoscaling.go
@@ -55,7 +55,7 @@ var _ = SIGDescribe("DNS horizontal autoscaling", func() {
 	var DNSParams3 DNSParamsLinear
 
 	ginkgo.BeforeEach(func() {
-		e2eskipper.SkipUnlessProviderIs("gce", "gke")
+		e2eskipper.SkipUnlessProviderIs("gke")
 		c = f.ClientSet
 
 		nodes, err := e2enode.GetReadySchedulableNodes(c)


### PR DESCRIPTION
#### What type of PR is this?
/kind flake

#### What this PR does / why we need it:

As kubernetes/kops@2844abd#diff-2983fab4084c9924c5b2b08ee707eb513c749db933e7b3481b8a746ddf033875, kops will migrate to coredns after 1.20.

#### Which issue(s) this PR fixes:
Fixes #100795

#### Special notes for your reviewer:
We should do a cleanup to remove all if needed.

Skip gce for current failures.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
