### PR TITLE
fixes potential goroutine leak in go-client due to blocking by errorChan

### DIFF
--- a/staging/src/k8s.io/client-go/tools/remotecommand/v1.go
+++ b/staging/src/k8s.io/client-go/tools/remotecommand/v1.go
@@ -50,7 +50,7 @@ func newStreamProtocolV1(options StreamOptions) streamProtocolHandler {
 
 func (p *streamProtocolV1) stream(conn streamCreator) error {
 	doneChan := make(chan struct{}, 2)
-	errorChan := make(chan error)
+	errorChan := make(chan error, 1)
 
 	cp := func(s string, dst io.Writer, src io.Reader) {
 		klog.V(6).Infof("Copying %s", s)


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Fixes potential edge case which could result in a goroutine leak, applies general best practice for working with channels 

#### Special notes for your reviewer:

A goroutine leak could occur in the following edge case scenario:

1. Either of the below conditions evaluate to true

```go
if err != nil && err != io.EOF {
			errorChan <- fmt.Errorf("Error reading from error stream: %s", err)
			return
		}
		if len(message) > 0 {
			errorChan <- fmt.Errorf("Error executing remote command: %s", message)
			return
		}
```

2. Either the first case below is triggered first, or both at the same time and the scheduler decides to run the first one

```go
	for {
		select {
		case <-doneChan:
			completedStreams++
			if completedStreams == waitCount {
				break Loop
			}
		case err := <-errorChan:
			return err
		}
	}
```

In that case `errorChan` would be blocking the anonymous goroutine, which would end up hanging unnecessarily 

#### Does this PR introduce a user-facing change?

NONE

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

