### PR TITLE
1.24: kubelet: remove --redirect-container-streaming flag

### DIFF
--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -866,15 +866,14 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
 
 	// inherited features from generic apiserver, relisted here to get a conflict if it is changed
 	// unintentionally on either side:
-	genericfeatures.StreamingProxyRedirects: {Default: true, PreRelease: featuregate.Deprecated},
-	genericfeatures.ValidateProxyRedirects:  {Default: true, PreRelease: featuregate.Beta},
-	genericfeatures.AdvancedAuditing:        {Default: true, PreRelease: featuregate.GA},
-	genericfeatures.APIResponseCompression:  {Default: true, PreRelease: featuregate.Beta},
-	genericfeatures.APIListChunking:         {Default: true, PreRelease: featuregate.Beta},
-	genericfeatures.DryRun:                  {Default: true, PreRelease: featuregate.GA},
-	genericfeatures.ServerSideApply:         {Default: true, PreRelease: featuregate.GA},
-	genericfeatures.APIPriorityAndFairness:  {Default: true, PreRelease: featuregate.Beta},
-	genericfeatures.WarningHeaders:          {Default: true, PreRelease: featuregate.Beta},
+	genericfeatures.ValidateProxyRedirects: {Default: true, PreRelease: featuregate.Beta},
+	genericfeatures.AdvancedAuditing:       {Default: true, PreRelease: featuregate.GA},
+	genericfeatures.APIResponseCompression: {Default: true, PreRelease: featuregate.Beta},
+	genericfeatures.APIListChunking:        {Default: true, PreRelease: featuregate.Beta},
+	genericfeatures.DryRun:                 {Default: true, PreRelease: featuregate.GA},
+	genericfeatures.ServerSideApply:        {Default: true, PreRelease: featuregate.GA},
+	genericfeatures.APIPriorityAndFairness: {Default: true, PreRelease: featuregate.Beta},
+	genericfeatures.WarningHeaders:         {Default: true, PreRelease: featuregate.Beta},
 
 	// features that enable backwards compatibility but are scheduled to be removed
 	// ...

--- a/pkg/registry/core/pod/rest/subresources.go
+++ b/pkg/registry/core/pod/rest/subresources.go
@@ -193,7 +193,7 @@ func (r *PortForwardREST) Connect(ctx context.Context, name string, opts runtime
 
 func newThrottledUpgradeAwareProxyHandler(location *url.URL, transport http.RoundTripper, wrapTransport, upgradeRequired, interceptRedirects bool, responder rest.Responder) *proxy.UpgradeAwareHandler {
 	handler := proxy.NewUpgradeAwareHandler(location, transport, wrapTransport, upgradeRequired, proxy.NewErrorResponder(responder))
-	handler.InterceptRedirects = interceptRedirects && utilfeature.DefaultFeatureGate.Enabled(genericfeatures.StreamingProxyRedirects)
+	handler.InterceptRedirects = false
 	handler.RequireSameHostRedirects = utilfeature.DefaultFeatureGate.Enabled(genericfeatures.ValidateProxyRedirects)
 	handler.MaxBytesPerSec = capabilities.Get().PerConnectionBandwidthLimitBytesPerSec
 	return handler

--- a/staging/src/k8s.io/kube-aggregator/pkg/apiserver/handler_proxy.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/apiserver/handler_proxy.go
@@ -221,7 +221,7 @@ func maybeWrapForConnectionUpgrades(restConfig *restclient.Config, rt http.Round
 	if err != nil {
 		return nil, true, err
 	}
-	followRedirects := utilfeature.DefaultFeatureGate.Enabled(genericfeatures.StreamingProxyRedirects)
+	followRedirects := false
 	requireSameHostRedirects := utilfeature.DefaultFeatureGate.Enabled(genericfeatures.ValidateProxyRedirects)
 	upgradeRoundTripper := spdy.NewRoundTripper(tlsConfig, followRedirects, requireSameHostRedirects)
 	wrappedRT, err := restclient.HTTPWrappersForConfig(restConfig, upgradeRoundTripper)


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
```
--redirect-container-streaming is no longer functional. The flag will be removed in v1.24
```
refer to https://github.com/kubernetes/kubernetes/pull/100901#issuecomment-828846144
The flag will be removed in v1.24.

#### Which issue(s) this PR fixes:
part of https://github.com/kubernetes/enhancements/issues/1558
follow up of ##95935

#### Special notes for your reviewer:
The default behavior (proxy streaming requests through the kubelet) will be the only supported option.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
