### PR TITLE
WIP: add per-connection TLS verification cache

### DIFF
--- a/cmd/kubelet/app/auth.go
+++ b/cmd/kubelet/app/auth.go
@@ -89,7 +89,7 @@ func BuildAuthn(client authenticationclient.TokenReviewInterface, authn kubeletc
 		authenticatorConfig.TokenAccessReviewClient = client
 	}
 
-	authenticator, _, err := authenticatorConfig.New()
+	authenticator, _, _, err := authenticatorConfig.New()
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pkg/kubeapiserver/authenticator/config.go
+++ b/pkg/kubeapiserver/authenticator/config.go
@@ -100,7 +100,7 @@ func (config Config) New() (authenticator.Request, *spec.SecurityDefinitions, er
 	// Add the front proxy authenticator if requested
 	if config.RequestHeaderConfig != nil {
 		requestHeaderAuthenticator := headerrequest.NewDynamicVerifyOptionsSecure(
-			config.RequestHeaderConfig.CAContentProvider.VerifyOptions,
+			config.RequestHeaderConfig.CAContentProvider,
 			config.RequestHeaderConfig.AllowedClientNames,
 			config.RequestHeaderConfig.UsernameHeaders,
 			config.RequestHeaderConfig.GroupHeaders,
@@ -111,7 +111,7 @@ func (config Config) New() (authenticator.Request, *spec.SecurityDefinitions, er
 
 	// X509 methods
 	if config.ClientCAContentProvider != nil {
-		certAuth := x509.NewDynamic(config.ClientCAContentProvider.VerifyOptions, x509.CommonNameUserConversion)
+		certAuth := x509.NewDynamic(config.ClientCAContentProvider, x509.CommonNameUserConversion)
 		authenticators = append(authenticators, certAuth)
 	}
 

--- a/pkg/kubeapiserver/options/authentication.go
+++ b/pkg/kubeapiserver/options/authentication.go
@@ -17,8 +17,10 @@ limitations under the License.
 package options
 
 import (
+	"context"
 	"errors"
 	"fmt"
+	"net"
 	"net/url"
 	"strings"
 	"time"
@@ -504,10 +506,12 @@ func (o *BuiltInAuthenticationOptions) ApplyTo(authInfo *genericapiserver.Authen
 		authenticatorConfig.CustomDial = egressDialer
 	}
 
-	authInfo.Authenticator, openAPIConfig.SecurityDefinitions, err = authenticatorConfig.New()
+	var connContextInitializers []func(ctx context.Context, c net.Conn) context.Context
+	authInfo.Authenticator, connContextInitializers, openAPIConfig.SecurityDefinitions, err = authenticatorConfig.New()
 	if err != nil {
 		return err
 	}
+	secureServing.ConnContextInitializers = append(secureServing.ConnContextInitializers, connContextInitializers...)
 
 	return nil
 }

--- a/staging/src/k8s.io/apiserver/pkg/authentication/authenticatorfactory/delegating.go
+++ b/staging/src/k8s.io/apiserver/pkg/authentication/authenticatorfactory/delegating.go
@@ -73,7 +73,7 @@ func (c DelegatingAuthenticatorConfig) New() (authenticator.Request, *spec.Secur
 	// Add the front proxy authenticator if requested
 	if c.RequestHeaderConfig != nil {
 		requestHeaderAuthenticator := headerrequest.NewDynamicVerifyOptionsSecure(
-			c.RequestHeaderConfig.CAContentProvider.VerifyOptions,
+			c.RequestHeaderConfig.CAContentProvider,
 			c.RequestHeaderConfig.AllowedClientNames,
 			c.RequestHeaderConfig.UsernameHeaders,
 			c.RequestHeaderConfig.GroupHeaders,
@@ -84,7 +84,7 @@ func (c DelegatingAuthenticatorConfig) New() (authenticator.Request, *spec.Secur
 
 	// x509 client cert auth
 	if c.ClientCertificateCAContentProvider != nil {
-		authenticators = append(authenticators, x509.NewDynamic(c.ClientCertificateCAContentProvider.VerifyOptions, x509.CommonNameUserConversion))
+		authenticators = append(authenticators, x509.NewDynamic(c.ClientCertificateCAContentProvider, x509.CommonNameUserConversion))
 	}
 
 	if c.TokenAccessReviewClient != nil {

--- a/staging/src/k8s.io/apiserver/pkg/authentication/request/headerrequest/requestheader.go
+++ b/staging/src/k8s.io/apiserver/pkg/authentication/request/headerrequest/requestheader.go
@@ -151,7 +151,7 @@ func NewSecure(clientCA string, proxyClientNames []string, nameHeaders []string,
 	), nil
 }
 
-func NewDynamicVerifyOptionsSecure(caProvider dynamiccertificates.CAContentProvider, proxyClientNames, nameHeaders, groupHeaders, extraHeaderPrefixes StringSliceProvider) authenticator.Request {
+func NewDynamicVerifyOptionsSecure(caProvider dynamiccertificates.CAContentProvider, proxyClientNames, nameHeaders, groupHeaders, extraHeaderPrefixes StringSliceProvider) *x509request.Verifier {
 	headerAuthenticator := NewDynamic(nameHeaders, groupHeaders, extraHeaderPrefixes)
 
 	return x509request.NewDynamicCAVerifier(caProvider, headerAuthenticator, proxyClientNames)

--- a/staging/src/k8s.io/apiserver/pkg/authentication/request/headerrequest/requestheader.go
+++ b/staging/src/k8s.io/apiserver/pkg/authentication/request/headerrequest/requestheader.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/apiserver/pkg/authentication/authenticator"
 	x509request "k8s.io/apiserver/pkg/authentication/request/x509"
 	"k8s.io/apiserver/pkg/authentication/user"
+	"k8s.io/apiserver/pkg/server/dynamiccertificates"
 	utilcert "k8s.io/client-go/util/cert"
 )
 
@@ -148,10 +149,10 @@ func NewSecure(clientCA string, proxyClientNames []string, nameHeaders []string,
 	), nil
 }
 
-func NewDynamicVerifyOptionsSecure(verifyOptionFn x509request.VerifyOptionFunc, proxyClientNames, nameHeaders, groupHeaders, extraHeaderPrefixes StringSliceProvider) authenticator.Request {
+func NewDynamicVerifyOptionsSecure(caProvider dynamiccertificates.CAContentProvider, proxyClientNames, nameHeaders, groupHeaders, extraHeaderPrefixes StringSliceProvider) authenticator.Request {
 	headerAuthenticator := NewDynamic(nameHeaders, groupHeaders, extraHeaderPrefixes)
 
-	return x509request.NewDynamicCAVerifier(verifyOptionFn, headerAuthenticator, proxyClientNames)
+	return x509request.NewDynamicCAVerifier(caProvider, headerAuthenticator, proxyClientNames)
 }
 
 func (a *requestHeaderAuthRequestHandler) AuthenticateRequest(req *http.Request) (*authenticator.Response, bool, error) {

--- a/staging/src/k8s.io/apiserver/pkg/authentication/request/headerrequest/requestheader.go
+++ b/staging/src/k8s.io/apiserver/pkg/authentication/request/headerrequest/requestheader.go
@@ -117,7 +117,9 @@ func NewSecure(clientCA string, proxyClientNames []string, nameHeaders []string,
 	if err != nil {
 		return nil, fmt.Errorf("error reading %s: %v", clientCA, err)
 	}
-	opts := x509request.DefaultVerifyOptions()
+	opts := x509.VerifyOptions{
+		KeyUsages: []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+	}
 	opts.Roots = x509.NewCertPool()
 	certs, err := utilcert.ParseCertsPEM(caData)
 	if err != nil {

--- a/staging/src/k8s.io/apiserver/pkg/authentication/request/x509/verify_options.go
+++ b/staging/src/k8s.io/apiserver/pkg/authentication/request/x509/verify_options.go
@@ -49,7 +49,7 @@ func NewStaticVerifierFromFile(clientCA string) (dynamiccertificates.CAContentPr
 
 	// Wrap with an x509 verifier
 	var err error
-	opts := DefaultVerifyOptions()
+	opts := defaultVerifyOptions()
 	opts.Roots, err = cert.NewPool(clientCA)
 	if err != nil {
 		return nil, fmt.Errorf("error loading certs from  %s: %v", clientCA, err)
@@ -78,4 +78,12 @@ type StaticStringSlice []string
 // Value returns the current string slice.  Callers should never mutate the returned value.
 func (s StaticStringSlice) Value() []string {
 	return s
+}
+
+// defaultVerifyOptions returns VerifyOptions that use the system root certificates, current time,
+// and requires certificates to be valid for client auth (x509.ExtKeyUsageClientAuth)
+func defaultVerifyOptions() x509.VerifyOptions {
+	return x509.VerifyOptions{
+		KeyUsages: []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+	}
 }

--- a/staging/src/k8s.io/apiserver/pkg/authentication/request/x509/x509_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/authentication/request/x509/x509_test.go
@@ -362,7 +362,7 @@ PKJQCs0CM0zkesktuLi/gFpuB0nEwyOgLg==
 )
 
 func TestX509(t *testing.T) {
-	multilevelOpts := DefaultVerifyOptions()
+	multilevelOpts := defaultVerifyOptions()
 	multilevelOpts.Roots = x509.NewCertPool()
 	multilevelOpts.Roots.AddCert(getCertsFromFile(t, "root")[0])
 
@@ -544,7 +544,7 @@ func TestX509(t *testing.T) {
 }
 
 func TestX509Verifier(t *testing.T) {
-	multilevelOpts := DefaultVerifyOptions()
+	multilevelOpts := defaultVerifyOptions()
 	multilevelOpts.Roots = x509.NewCertPool()
 	multilevelOpts.Roots.AddCert(getCertsFromFile(t, "root")[0])
 
@@ -701,17 +701,23 @@ func TestX509Verifier(t *testing.T) {
 	}
 }
 
-func getDefaultVerifyOptions(t *testing.T) x509.VerifyOptions {
-	options := DefaultVerifyOptions()
-	options.Roots = getRootCertPool(t)
-	return options
+func getDefaultVerifyOptions(t testing.TB) x509.VerifyOptions {
+	t.Helper()
+
+	opts := defaultVerifyOptions()
+	opts.Roots = getRootCertPool(t)
+	return opts
 }
 
-func getRootCertPool(t *testing.T) *x509.CertPool {
+func getRootCertPool(t testing.TB) *x509.CertPool {
+	t.Helper()
+
 	return getRootCertPoolFor(t, rootCACert)
 }
 
-func getRootCertPoolFor(t *testing.T, certs ...string) *x509.CertPool {
+func getRootCertPoolFor(t testing.TB, certs ...string) *x509.CertPool {
+	t.Helper()
+
 	pool := x509.NewCertPool()
 	for _, cert := range certs {
 		pool.AddCert(getCert(t, cert))
@@ -719,7 +725,9 @@ func getRootCertPoolFor(t *testing.T, certs ...string) *x509.CertPool {
 	return pool
 }
 
-func getCertsFromFile(t *testing.T, names ...string) []*x509.Certificate {
+func getCertsFromFile(t testing.TB, names ...string) []*x509.Certificate {
+	t.Helper()
+
 	certs := []*x509.Certificate{}
 	for _, name := range names {
 		filename := "testdata/" + name + ".pem"
@@ -732,7 +740,7 @@ func getCertsFromFile(t *testing.T, names ...string) []*x509.Certificate {
 	return certs
 }
 
-func getCert(t *testing.T, pemData string) *x509.Certificate {
+func getCert(t testing.TB, pemData string) *x509.Certificate {
 	t.Helper()
 
 	pemBlock, _ := pem.Decode([]byte(pemData))
@@ -744,7 +752,9 @@ func getCert(t *testing.T, pemData string) *x509.Certificate {
 	return cert
 }
 
-func getCerts(t *testing.T, pemData ...string) []*x509.Certificate {
+func getCerts(t testing.TB, pemData ...string) []*x509.Certificate {
+	t.Helper()
+
 	certs := []*x509.Certificate{}
 	for _, pemData := range pemData {
 		certs = append(certs, getCert(t, pemData))

--- a/staging/src/k8s.io/apiserver/pkg/server/config.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/config.go
@@ -17,6 +17,7 @@ limitations under the License.
 package server
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"net/http"
@@ -277,6 +278,9 @@ type SecureServingInfo struct {
 
 	// DisableHTTP2 indicates that http2 should not be enabled.
 	DisableHTTP2 bool
+
+	// ConnContextInitializer
+	ConnContextInitializers []func(ctx context.Context, c net.Conn) context.Context
 }
 
 type AuthenticationInfo struct {

--- a/staging/src/k8s.io/apiserver/pkg/server/options/authentication.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/authentication.go
@@ -359,7 +359,7 @@ func (s *DelegatingAuthenticationOptions) ApplyTo(authenticationInfo *server.Aut
 	}
 
 	// create authenticator
-	authenticator, securityDefinitions, err := cfg.New()
+	authenticator, connContextInitializers, securityDefinitions, err := cfg.New()
 	if err != nil {
 		return err
 	}
@@ -367,6 +367,7 @@ func (s *DelegatingAuthenticationOptions) ApplyTo(authenticationInfo *server.Aut
 	if openAPIConfig != nil {
 		openAPIConfig.SecurityDefinitions = securityDefinitions
 	}
+	servingInfo.ConnContextInitializers = append(servingInfo.ConnContextInitializers, connContextInitializers...)
 
 	return nil
 }


### PR DESCRIPTION
This is a draft. It needs a ton of cleanup and tests. Opening for some early CI runs.

Cache verification of client certs per connection. The cache is invalidated when:
* CAProvider reloads and pokes it's listeners. This is implemented with a generation sequence number.
* Current time passes the latest NotBefore in the cert chain (excluding anchors for now)
* Current time passes the latest NotAfter in the cert chain (excluding anchors for now)

Benchmarks:

```
$ go test -v -run='^$' -bench=.* -benchmem -benchtime 10s k8s.io/apiserver/pkg/authentication/request/x509
goos: linux
goarch: amd64
pkg: k8s.io/apiserver/pkg/authentication/request/x509
cpu: Intel(R) Xeon(R) W-2135 CPU @ 3.70GHz
BenchmarkX509Verifier
BenchmarkX509Verifier/cache=false
BenchmarkX509Verifier/cache=false/valid_client_cert
BenchmarkX509Verifier/cache=false/valid_client_cert-6            2036508              5768 ns/op            2770 B/op         20 allocs/op
BenchmarkX509Verifier/cache=false/multi-level,_valid
BenchmarkX509Verifier/cache=false/multi-level,_valid-6            473929             24264 ns/op            3987 B/op         68 allocs/op
BenchmarkX509Verifier/cache=true
BenchmarkX509Verifier/cache=true/multi-level,_valid
BenchmarkX509Verifier/cache=true/multi-level,_valid-6           57893798               245.5 ns/op             8 B/op          1 allocs/op
BenchmarkX509Verifier/cache=true/valid_client_cert
BenchmarkX509Verifier/cache=true/valid_client_cert-6            51217172               243.5 ns/op             8 B/op          1 allocs/op
PASS
```

Fixes #90533

```release-note
NONE
```