### PR TITLE
no support endpointslice in linux userpace mode 

### DIFF
--- a/cmd/kube-proxy/app/server_others.go
+++ b/cmd/kube-proxy/app/server_others.go
@@ -364,6 +364,12 @@ func newProxyServer(
 		}
 	}
 
+	useEndpointSlices := utilfeature.DefaultFeatureGate.Enabled(features.EndpointSliceProxying)
+	if proxyMode == proxyModeUserspace {
+		// userspace mode doesn't support endpointslice.
+		useEndpointSlices = false
+	}
+
 	return &ProxyServer{
 		Client:                 client,
 		EventClient:            eventClient,
@@ -384,7 +390,7 @@ func newProxyServer(
 		OOMScoreAdj:            config.OOMScoreAdj,
 		ConfigSyncPeriod:       config.ConfigSyncPeriod.Duration,
 		HealthzServer:          healthzServer,
-		UseEndpointSlices:      utilfeature.DefaultFeatureGate.Enabled(features.EndpointSliceProxying),
+		UseEndpointSlices:      useEndpointSlices,
 	}, nil
 }
 

--- a/cmd/kube-proxy/app/server_windows.go
+++ b/cmd/kube-proxy/app/server_windows.go
@@ -160,7 +160,11 @@ func newProxyServer(config *proxyconfigapi.KubeProxyConfiguration, cleanupAndExi
 			return nil, fmt.Errorf("unable to create proxier: %v", err)
 		}
 	}
-
+	useEndpointSlices := utilfeature.DefaultFeatureGate.Enabled(features.WindowsEndpointSliceProxying)
+	if proxyMode == proxyModeUserspace {
+		// userspace mode doesn't support endpointslice.
+		useEndpointSlices = false
+	}
 	return &ProxyServer{
 		Client:              client,
 		EventClient:         eventClient,
@@ -175,7 +179,7 @@ func newProxyServer(config *proxyconfigapi.KubeProxyConfiguration, cleanupAndExi
 		OOMScoreAdj:         config.OOMScoreAdj,
 		ConfigSyncPeriod:    config.ConfigSyncPeriod.Duration,
 		HealthzServer:       healthzServer,
-		UseEndpointSlices:   utilfeature.DefaultFeatureGate.Enabled(features.WindowsEndpointSliceProxying),
+		UseEndpointSlices:   useEndpointSlices,
 	}, nil
 }
 


### PR DESCRIPTION
/kind bug

in userpace mode of linux, we have not implement endpointslice resource processing logic.
we need to watch endpoint as before in this mode.

Ref https://github.com/kubernetes/kubernetes/issues/100880#

```release-note
no support endpointslice in linux userpace mode 
```
