### PR TITLE
Fixes references to RFCs

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/api/validation/generic.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/validation/generic.go
@@ -41,7 +41,7 @@ func NameIsDNSSubdomain(name string, prefix bool) []string {
 	return validation.IsDNS1123Subdomain(name)
 }
 
-// NameIsDNSLabel is a ValidateNameFunc for names that must be a RFC 1123 label.
+// NameIsDNSLabel is a ValidateNameFunc for names that must be a DNS label (RFC 1123).
 func NameIsDNSLabel(name string, prefix bool) []string {
 	if prefix {
 		name = maskTrailingDash(name)
@@ -49,7 +49,7 @@ func NameIsDNSLabel(name string, prefix bool) []string {
 	return validation.IsDNS1123Label(name)
 }
 
-// NameIsDNS1035Label is a ValidateNameFunc for names that must be a RFC 1035 label.
+// NameIsDNS1035Label is a ValidateNameFunc for names that must be a DNS label (RFC 1035).
 func NameIsDNS1035Label(name string, prefix bool) []string {
 	if prefix {
 		name = maskTrailingDash(name)

--- a/staging/src/k8s.io/apimachinery/pkg/api/validation/generic.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/validation/generic.go
@@ -41,7 +41,7 @@ func NameIsDNSSubdomain(name string, prefix bool) []string {
 	return validation.IsDNS1123Subdomain(name)
 }
 
-// NameIsDNSLabel is a ValidateNameFunc for names that must be a DNS 1123 label.
+// NameIsDNSLabel is a ValidateNameFunc for names that must be a RFC 1123 label.
 func NameIsDNSLabel(name string, prefix bool) []string {
 	if prefix {
 		name = maskTrailingDash(name)
@@ -49,7 +49,7 @@ func NameIsDNSLabel(name string, prefix bool) []string {
 	return validation.IsDNS1123Label(name)
 }
 
-// NameIsDNS1035Label is a ValidateNameFunc for names that must be a DNS 952 label.
+// NameIsDNS1035Label is a ValidateNameFunc for names that must be a RFC 1035 label.
 func NameIsDNS1035Label(name string, prefix bool) []string {
 	if prefix {
 		name = maskTrailingDash(name)


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:

The docs reference "DNS 952" which does not seem correct. Correct would be RFC 1035, I assume? At least I can't find anything that'd match "952".
Another one references "DNS 1123" which should be RFC 1123.

Had me confused for a while.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

