### PR TITLE
include description of what kube-root-ca.crt can be used to verify

### DIFF
--- a/pkg/controller/certificates/rootcacertpublisher/publisher.go
+++ b/pkg/controller/certificates/rootcacertpublisher/publisher.go
@@ -38,7 +38,12 @@ import (
 
 // RootCACertConfigMapName is name of the configmap which stores certificates
 // to access api-server
-const RootCACertConfigMapName = "kube-root-ca.crt"
+const (
+	RootCACertConfigMapName = "kube-root-ca.crt"
+	DescriptionAnnotation   = "kubernetes.io/description"
+	Description             = "Contains a CA bundle that can be used to verify the kube-apiserver when using internal endpoints such as the internal service IP or kubernetes.default.svc. " +
+		"No other usage is guaranteed across distributions of Kubernetes clusters."
+)
 
 func init() {
 	registerMetrics()
@@ -186,7 +191,8 @@ func (c *Publisher) syncNamespace(ns string) (err error) {
 	case apierrors.IsNotFound(err):
 		_, err = c.client.CoreV1().ConfigMaps(ns).Create(context.TODO(), &v1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: RootCACertConfigMapName,
+				Name:        RootCACertConfigMapName,
+				Annotations: map[string]string{DescriptionAnnotation: Description},
 			},
 			Data: map[string]string{
 				"ca.crt": string(c.rootCA),
@@ -205,13 +211,18 @@ func (c *Publisher) syncNamespace(ns string) (err error) {
 		"ca.crt": string(c.rootCA),
 	}
 
-	if reflect.DeepEqual(cm.Data, data) {
+	// ensure the data and the one annotation describing usage of this configmap match.
+	if reflect.DeepEqual(cm.Data, data) && len(cm.Annotations[DescriptionAnnotation]) > 0 {
 		return nil
 	}
 
 	// copy so we don't modify the cache's instance of the configmap
 	cm = cm.DeepCopy()
 	cm.Data = data
+	if cm.Annotations == nil {
+		cm.Annotations = map[string]string{}
+	}
+	cm.Annotations[DescriptionAnnotation] = Description
 
 	_, err = c.client.CoreV1().ConfigMaps(ns).Update(context.TODO(), cm, metav1.UpdateOptions{})
 	return err


### PR DESCRIPTION
Clarifies what configmap/kube-root-ca.crt can be used to verify using an annotation present on each configmap so that consumers can know via direction inspection what is guaranteed behavior and what is distribution specific.  Also adds a test to ensure that the update functions as expected.

This originated out of confusion about what this configmap is guaranteed to verify across kubernetes distributions.

/kind documentation
/kind  bug
/priority important-soon
@kubernetes/sig-auth-bugs 

```release-note
NONE
```