### PR TITLE
code cleanup for pkg/controller

### DIFF
--- a/pkg/controller/endpointslice/endpointslice_tracker.go
+++ b/pkg/controller/endpointslice/endpointslice_tracker.go
@@ -186,7 +186,7 @@ func (est *endpointSliceTracker) generationsForSliceUnsafe(endpointSlice *discov
 // getServiceNN returns a namespaced name for the Service corresponding to the
 // provided EndpointSlice.
 func getServiceNN(endpointSlice *discovery.EndpointSlice) types.NamespacedName {
-	serviceName, _ := endpointSlice.Labels[discovery.LabelServiceName]
+	serviceName := endpointSlice.Labels[discovery.LabelServiceName]
 	return types.NamespacedName{Name: serviceName, Namespace: endpointSlice.Namespace}
 }
 
@@ -199,6 +199,6 @@ func managedByChanged(endpointSlice1, endpointSlice2 *discovery.EndpointSlice) b
 // managedByController returns true if the controller of the provided
 // EndpointSlices is the EndpointSlice controller.
 func managedByController(endpointSlice *discovery.EndpointSlice) bool {
-	managedBy, _ := endpointSlice.Labels[discovery.LabelManagedBy]
+	managedBy := endpointSlice.Labels[discovery.LabelManagedBy]
 	return managedBy == controllerName
 }

--- a/pkg/controller/endpointslice/utils.go
+++ b/pkg/controller/endpointslice/utils.go
@@ -21,7 +21,6 @@ import (
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
-	v1 "k8s.io/api/core/v1"
 	discovery "k8s.io/api/discovery/v1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -276,9 +275,9 @@ func setEndpointSliceLabels(epSlice *discovery.EndpointSlice, service *corev1.Se
 
 	// add or remove headless label depending on the service Type
 	if !helper.IsServiceIPSet(service) {
-		svcLabels[v1.IsHeadlessService] = ""
+		svcLabels[corev1.IsHeadlessService] = ""
 	} else {
-		delete(svcLabels, v1.IsHeadlessService)
+		delete(svcLabels, corev1.IsHeadlessService)
 	}
 
 	// override endpoint slices reserved labels
@@ -292,7 +291,7 @@ func setEndpointSliceLabels(epSlice *discovery.EndpointSlice, service *corev1.Se
 func IsReservedLabelKey(label string) bool {
 	if label == discovery.LabelServiceName ||
 		label == discovery.LabelManagedBy ||
-		label == v1.IsHeadlessService {
+		label == corev1.IsHeadlessService {
 		return true
 	}
 	return false

--- a/pkg/controller/endpointslicemirroring/utils_test.go
+++ b/pkg/controller/endpointslicemirroring/utils_test.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
-	v1 "k8s.io/api/core/v1"
 	discovery "k8s.io/api/discovery/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -35,19 +34,19 @@ import (
 
 func TestNewEndpointSlice(t *testing.T) {
 	portName := "foo"
-	protocol := v1.ProtocolTCP
+	protocol := corev1.ProtocolTCP
 
 	ports := []discovery.EndpointPort{{Name: &portName, Protocol: &protocol}}
 	addrType := discovery.AddressTypeIPv4
 	gvk := schema.GroupVersionKind{Version: "v1", Kind: "Endpoints"}
 
-	endpoints := v1.Endpoints{
+	endpoints := corev1.Endpoints{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "foo",
 			Namespace: "test",
 		},
-		Subsets: []v1.EndpointSubset{{
-			Ports: []v1.EndpointPort{{Port: 80}},
+		Subsets: []corev1.EndpointSubset{{
+			Ports: []corev1.EndpointPort{{Port: 80}},
 		}},
 	}
 	ownerRef := metav1.NewControllerRef(&endpoints, gvk)
@@ -191,11 +190,11 @@ func TestNewEndpointSlice(t *testing.T) {
 
 func TestAddressToEndpoint(t *testing.T) {
 	//name: "simple + gate enabled",
-	epAddress := v1.EndpointAddress{
+	epAddress := corev1.EndpointAddress{
 		IP:       "10.1.2.3",
 		Hostname: "foo",
 		NodeName: utilpointer.StringPtr("node-abc"),
-		TargetRef: &v1.ObjectReference{
+		TargetRef: &corev1.ObjectReference{
 			APIVersion: "v1",
 			Kind:       "Pod",
 			Namespace:  "default",
@@ -209,7 +208,7 @@ func TestAddressToEndpoint(t *testing.T) {
 		Conditions: discovery.EndpointConditions{
 			Ready: utilpointer.BoolPtr(true),
 		},
-		TargetRef: &v1.ObjectReference{
+		TargetRef: &corev1.ObjectReference{
 			APIVersion: "v1",
 			Kind:       "Pod",
 			Namespace:  "default",

--- a/pkg/controller/garbagecollector/garbagecollector.go
+++ b/pkg/controller/garbagecollector/garbagecollector.go
@@ -45,9 +45,6 @@ import (
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/controller-manager/pkg/informerfactory"
 	"k8s.io/kubernetes/pkg/controller/apis/config/scheme"
-
-	// import known versions
-	_ "k8s.io/client-go/kubernetes"
 )
 
 // ResourceResyncTime defines the resync period of the garbage collector's informers.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
https://staticcheck.io/docs/checks#S1005
S1005 – Drop unnecessary use of the blank identifier
https://staticcheck.io/docs/checks#ST1019
ST1019 – Importing the same package multiple times
```
k8s.io/kubernetes/pkg/controller/endpointslice/utils.go:23:2: package "k8s.io/api/core/v1" is being imported more than once (ST1019)
k8s.io/kubernetes/pkg/controller/endpointslice/utils.go:24:2: other import of "k8s.io/api/core/v1"
k8s.io/kubernetes/pkg/controller/endpointslicemirroring/utils_test.go:24:2: package "k8s.io/api/core/v1" is being imported more than once (ST1019)
k8s.io/kubernetes/pkg/controller/endpointslicemirroring/utils_test.go:25:2: other import of "k8s.io/api/core/v1"
k8s.io/kubernetes/pkg/controller/garbagecollector/garbagecollector.go:40:2: package "k8s.io/client-go/kubernetes" is being imported more than once (ST1019)
k8s.io/kubernetes/pkg/controller/garbagecollector/garbagecollector.go:50:2: other import of "k8s.io/client-go/kubernetes"
k8s.io/kubernetes/pkg/controller/endpointslicemirroring/endpointslice_tracker.go:189:2: unnecessary assignment to the blank identifier (S1005)
k8s.io/kubernetes/pkg/controller/endpointslicemirroring/endpointslice_tracker.go:202:2: unnecessary assignment to the blank identifier (S1005)
```
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
