### PR TITLE
code cleanup for pkg/registry

### DIFF
--- a/pkg/registry/apps/deployment/storage/storage_test.go
+++ b/pkg/registry/apps/deployment/storage/storage_test.go
@@ -25,7 +25,6 @@ import (
 	"testing"
 
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
-	"k8s.io/apimachinery/pkg/api/errors"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
@@ -279,7 +278,7 @@ func TestScaleUpdate(t *testing.T) {
 	update.ResourceVersion = deployment.ResourceVersion
 	update.Spec.Replicas = 15
 
-	if _, _, err = storage.Scale.Update(ctx, update.Name, rest.DefaultUpdatedObjectInfo(&update), rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc, false, &metav1.UpdateOptions{}); err != nil && !errors.IsConflict(err) {
+	if _, _, err = storage.Scale.Update(ctx, update.Name, rest.DefaultUpdatedObjectInfo(&update), rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc, false, &metav1.UpdateOptions{}); err != nil && !apierrors.IsConflict(err) {
 		t.Fatalf("unexpected error, expecting an update conflict but got %v", err)
 	}
 }
@@ -425,7 +424,7 @@ func TestEtcdCreateDeploymentRollbackNoDeployment(t *testing.T) {
 	if err == nil {
 		t.Fatalf("Expected not-found-error but got nothing")
 	}
-	if !errors.IsNotFound(storeerr.InterpretGetError(err, apps.Resource("deployments"), name)) {
+	if !apierrors.IsNotFound(storeerr.InterpretGetError(err, apps.Resource("deployments"), name)) {
 		t.Fatalf("Unexpected error returned: %#v", err)
 	}
 
@@ -433,7 +432,7 @@ func TestEtcdCreateDeploymentRollbackNoDeployment(t *testing.T) {
 	if err == nil {
 		t.Fatalf("Expected not-found-error but got nothing")
 	}
-	if !errors.IsNotFound(storeerr.InterpretGetError(err, apps.Resource("deployments"), name)) {
+	if !apierrors.IsNotFound(storeerr.InterpretGetError(err, apps.Resource("deployments"), name)) {
 		t.Fatalf("Unexpected error: %v", err)
 	}
 }

--- a/pkg/registry/apps/replicaset/storage/storage_test.go
+++ b/pkg/registry/apps/replicaset/storage/storage_test.go
@@ -23,7 +23,6 @@ import (
 	"testing"
 
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
-	"k8s.io/apimachinery/pkg/api/errors"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
@@ -342,7 +341,7 @@ func TestScaleUpdate(t *testing.T) {
 	update.ResourceVersion = rs.ResourceVersion
 	update.Spec.Replicas = 15
 
-	if _, _, err = storage.Scale.Update(ctx, update.Name, rest.DefaultUpdatedObjectInfo(&update), rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc, false, &metav1.UpdateOptions{}); err != nil && !errors.IsConflict(err) {
+	if _, _, err = storage.Scale.Update(ctx, update.Name, rest.DefaultUpdatedObjectInfo(&update), rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc, false, &metav1.UpdateOptions{}); err != nil && !apierrors.IsConflict(err) {
 		t.Fatalf("unexpected error, expecting an update conflict but got %v", err)
 	}
 }

--- a/pkg/registry/apps/statefulset/storage/storage_test.go
+++ b/pkg/registry/apps/statefulset/storage/storage_test.go
@@ -23,7 +23,6 @@ import (
 	"testing"
 
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
-	"k8s.io/apimachinery/pkg/api/errors"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
@@ -292,7 +291,7 @@ func TestScaleUpdate(t *testing.T) {
 	update.ResourceVersion = sts.ResourceVersion
 	update.Spec.Replicas = 15
 
-	if _, _, err = storage.Scale.Update(ctx, update.Name, rest.DefaultUpdatedObjectInfo(&update), rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc, false, &metav1.UpdateOptions{}); err != nil && !errors.IsConflict(err) {
+	if _, _, err = storage.Scale.Update(ctx, update.Name, rest.DefaultUpdatedObjectInfo(&update), rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc, false, &metav1.UpdateOptions{}); err != nil && !apierrors.IsConflict(err) {
 		t.Fatalf("unexpected error, expecting an update conflict but got %v", err)
 	}
 }

--- a/pkg/registry/core/service/ipallocator/controller/repair_test.go
+++ b/pkg/registry/core/service/ipallocator/controller/repair_test.go
@@ -23,7 +23,6 @@ import (
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
-	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
 	api "k8s.io/kubernetes/pkg/apis/core"
@@ -151,7 +150,7 @@ func TestRepairWithExisting(t *testing.T) {
 			Spec: corev1.ServiceSpec{
 				ClusterIP:  "192.168.1.1",
 				ClusterIPs: []string{"192.168.1.1"},
-				IPFamilies: []v1.IPFamily{v1.IPv4Protocol},
+				IPFamilies: []corev1.IPFamily{corev1.IPv4Protocol},
 			},
 		},
 		&corev1.Service{
@@ -159,7 +158,7 @@ func TestRepairWithExisting(t *testing.T) {
 			Spec: corev1.ServiceSpec{
 				ClusterIP:  "192.168.1.100",
 				ClusterIPs: []string{"192.168.1.100"},
-				IPFamilies: []v1.IPFamily{v1.IPv4Protocol},
+				IPFamilies: []corev1.IPFamily{corev1.IPv4Protocol},
 			},
 		},
 		&corev1.Service{ // outside CIDR, will be dropped
@@ -167,7 +166,7 @@ func TestRepairWithExisting(t *testing.T) {
 			Spec: corev1.ServiceSpec{
 				ClusterIP:  "192.168.0.1",
 				ClusterIPs: []string{"192.168.0.1"},
-				IPFamilies: []v1.IPFamily{v1.IPv4Protocol},
+				IPFamilies: []corev1.IPFamily{corev1.IPv4Protocol},
 			},
 		},
 		&corev1.Service{ // empty, ignored
@@ -182,7 +181,7 @@ func TestRepairWithExisting(t *testing.T) {
 			Spec: corev1.ServiceSpec{
 				ClusterIP:  "192.168.1.1",
 				ClusterIPs: []string{"192.168.1.1"},
-				IPFamilies: []v1.IPFamily{v1.IPv4Protocol},
+				IPFamilies: []corev1.IPFamily{corev1.IPv4Protocol},
 			},
 		},
 		&corev1.Service{ // headless
@@ -253,31 +252,31 @@ func makeIPNet(cidr string) *net.IPNet {
 func TestShouldWorkOnSecondary(t *testing.T) {
 	testCases := []struct {
 		name             string
-		expectedFamilies []v1.IPFamily
+		expectedFamilies []corev1.IPFamily
 		primaryNet       *net.IPNet
 		secondaryNet     *net.IPNet
 	}{
 		{
 			name:             "primary only (v4)",
-			expectedFamilies: []v1.IPFamily{v1.IPv4Protocol},
+			expectedFamilies: []corev1.IPFamily{corev1.IPv4Protocol},
 			primaryNet:       makeIPNet("10.0.0.0/16"),
 			secondaryNet:     nil,
 		},
 		{
 			name:             "primary only (v6)",
-			expectedFamilies: []v1.IPFamily{v1.IPv6Protocol},
+			expectedFamilies: []corev1.IPFamily{corev1.IPv6Protocol},
 			primaryNet:       makeIPNet("2000::/120"),
 			secondaryNet:     nil,
 		},
 		{
 			name:             "primary and secondary provided (v4,v6)",
-			expectedFamilies: []v1.IPFamily{v1.IPv4Protocol, v1.IPv6Protocol},
+			expectedFamilies: []corev1.IPFamily{corev1.IPv4Protocol, corev1.IPv6Protocol},
 			primaryNet:       makeIPNet("10.0.0.0/16"),
 			secondaryNet:     makeIPNet("2000::/120"),
 		},
 		{
 			name:             "primary and secondary provided (v6,v4)",
-			expectedFamilies: []v1.IPFamily{v1.IPv6Protocol, v1.IPv4Protocol},
+			expectedFamilies: []corev1.IPFamily{corev1.IPv6Protocol, corev1.IPv4Protocol},
 			primaryNet:       makeIPNet("2000::/120"),
 			secondaryNet:     makeIPNet("10.0.0.0/16"),
 		},
@@ -298,7 +297,7 @@ func TestShouldWorkOnSecondary(t *testing.T) {
 				t.Fatalf("expected to have allocator by family count:%v got %v", len(tc.expectedFamilies), len(repair.allocatorByFamily))
 			}
 
-			seen := make(map[v1.IPFamily]bool)
+			seen := make(map[corev1.IPFamily]bool)
 			for _, family := range tc.expectedFamilies {
 				familySeen := true
 
@@ -496,7 +495,7 @@ func TestRepairWithExistingDualStack(t *testing.T) {
 			Spec: corev1.ServiceSpec{
 				ClusterIP:  "192.168.1.1",
 				ClusterIPs: []string{"192.168.1.1", "2000::1"},
-				IPFamilies: []v1.IPFamily{v1.IPv4Protocol, v1.IPv6Protocol},
+				IPFamilies: []corev1.IPFamily{corev1.IPv4Protocol, corev1.IPv6Protocol},
 			},
 		},
 		&corev1.Service{
@@ -504,7 +503,7 @@ func TestRepairWithExistingDualStack(t *testing.T) {
 			Spec: corev1.ServiceSpec{
 				ClusterIP:  "2000::1",
 				ClusterIPs: []string{"2000::1", "192.168.1.100"},
-				IPFamilies: []v1.IPFamily{v1.IPv6Protocol, v1.IPv4Protocol},
+				IPFamilies: []corev1.IPFamily{corev1.IPv6Protocol, corev1.IPv4Protocol},
 			},
 		},
 		&corev1.Service{
@@ -512,7 +511,7 @@ func TestRepairWithExistingDualStack(t *testing.T) {
 			Spec: corev1.ServiceSpec{
 				ClusterIP:  "2000::2",
 				ClusterIPs: []string{"2000::2"},
-				IPFamilies: []v1.IPFamily{v1.IPv6Protocol},
+				IPFamilies: []corev1.IPFamily{corev1.IPv6Protocol},
 			},
 		},
 		&corev1.Service{
@@ -520,7 +519,7 @@ func TestRepairWithExistingDualStack(t *testing.T) {
 			Spec: corev1.ServiceSpec{
 				ClusterIP:  "192.168.1.90",
 				ClusterIPs: []string{"192.168.1.90"},
-				IPFamilies: []v1.IPFamily{v1.IPv4Protocol},
+				IPFamilies: []corev1.IPFamily{corev1.IPv4Protocol},
 			},
 		},
 		// outside CIDR, will be dropped
@@ -529,7 +528,7 @@ func TestRepairWithExistingDualStack(t *testing.T) {
 			Spec: corev1.ServiceSpec{
 				ClusterIP:  "192.168.0.1",
 				ClusterIPs: []string{"192.168.0.1"},
-				IPFamilies: []v1.IPFamily{v1.IPv4Protocol},
+				IPFamilies: []corev1.IPFamily{corev1.IPv4Protocol},
 			},
 		},
 		&corev1.Service{ // outside CIDR, will be dropped
@@ -537,7 +536,7 @@ func TestRepairWithExistingDualStack(t *testing.T) {
 			Spec: corev1.ServiceSpec{
 				ClusterIP:  "3000::1",
 				ClusterIPs: []string{"3000::1"},
-				IPFamilies: []v1.IPFamily{v1.IPv6Protocol},
+				IPFamilies: []corev1.IPFamily{corev1.IPv6Protocol},
 			},
 		},
 		&corev1.Service{
@@ -545,7 +544,7 @@ func TestRepairWithExistingDualStack(t *testing.T) {
 			Spec: corev1.ServiceSpec{
 				ClusterIP:  "192.168.0.1",
 				ClusterIPs: []string{"192.168.0.1", "3000::1"},
-				IPFamilies: []v1.IPFamily{v1.IPv4Protocol, v1.IPv6Protocol},
+				IPFamilies: []corev1.IPFamily{corev1.IPv4Protocol, corev1.IPv6Protocol},
 			},
 		},
 		&corev1.Service{
@@ -553,7 +552,7 @@ func TestRepairWithExistingDualStack(t *testing.T) {
 			Spec: corev1.ServiceSpec{
 				ClusterIP:  "3000::1",
 				ClusterIPs: []string{"3000::1", "192.168.0.1"},
-				IPFamilies: []v1.IPFamily{v1.IPv6Protocol, v1.IPv4Protocol},
+				IPFamilies: []corev1.IPFamily{corev1.IPv6Protocol, corev1.IPv4Protocol},
 			},
 		},
 
@@ -566,7 +565,7 @@ func TestRepairWithExistingDualStack(t *testing.T) {
 			Spec: corev1.ServiceSpec{
 				ClusterIP:  "192.168.1.1",
 				ClusterIPs: []string{"192.168.1.1"},
-				IPFamilies: []v1.IPFamily{v1.IPv4Protocol},
+				IPFamilies: []corev1.IPFamily{corev1.IPv4Protocol},
 			},
 		},
 		&corev1.Service{ // duplicate, dropped
@@ -574,7 +573,7 @@ func TestRepairWithExistingDualStack(t *testing.T) {
 			Spec: corev1.ServiceSpec{
 				ClusterIP:  "2000::2",
 				ClusterIPs: []string{"2000::2"},
-				IPFamilies: []v1.IPFamily{v1.IPv6Protocol},
+				IPFamilies: []corev1.IPFamily{corev1.IPv6Protocol},
 			},
 		},
 

--- a/pkg/registry/core/service/storage/storage.go
+++ b/pkg/registry/core/service/storage/storage.go
@@ -31,9 +31,7 @@ import (
 	"k8s.io/kubernetes/pkg/printers"
 	printersinternal "k8s.io/kubernetes/pkg/printers/internalversion"
 	printerstorage "k8s.io/kubernetes/pkg/printers/storage"
-	"k8s.io/kubernetes/pkg/registry/core/service"
 	registry "k8s.io/kubernetes/pkg/registry/core/service"
-	svcreg "k8s.io/kubernetes/pkg/registry/core/service"
 	"sigs.k8s.io/structured-merge-diff/v4/fieldpath"
 
 	netutil "k8s.io/utils/net"
@@ -68,7 +66,7 @@ func NewGenericREST(optsGetter generic.RESTOptionsGetter, serviceCIDR net.IPNet,
 	}
 
 	statusStore := *store
-	statusStrategy := service.NewServiceStatusStrategy(strategy)
+	statusStrategy := registry.NewServiceStatusStrategy(strategy)
 	statusStore.UpdateStrategy = statusStrategy
 	statusStore.ResetFieldsStrategy = statusStrategy
 
@@ -171,7 +169,7 @@ func (r *GenericREST) defaultOnReadService(service *api.Service) {
 	// We might find Services that were written before ClusterIP became plural.
 	// We still want to present a consistent view of them.
 	// NOTE: the args are (old, new)
-	svcreg.NormalizeClusterIPs(nil, service)
+	registry.NormalizeClusterIPs(nil, service)
 
 	// The rest of this does not apply unless dual-stack is enabled.
 	if !utilfeature.DefaultFeatureGate.Enabled(features.IPv6DualStack) {

--- a/pkg/registry/rbac/rest/storage_rbac.go
+++ b/pkg/registry/rbac/rest/storage_rbac.go
@@ -26,7 +26,6 @@ import (
 	rbacapiv1 "k8s.io/api/rbac/v1"
 	rbacapiv1alpha1 "k8s.io/api/rbac/v1alpha1"
 	rbacapiv1beta1 "k8s.io/api/rbac/v1beta1"
-	"k8s.io/apimachinery/pkg/api/errors"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -162,7 +161,7 @@ type PolicyData struct {
 }
 
 func isConflictOrServiceUnavailable(err error) bool {
-	return errors.IsConflict(err) || errors.IsServiceUnavailable(err)
+	return apierrors.IsConflict(err) || apierrors.IsServiceUnavailable(err)
 }
 
 func retryOnConflictOrServiceUnavailable(backoff wait.Backoff, fn func() error) error {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
ST1019 – Importing the same package multiple times
https://staticcheck.io/docs/checks#ST1019
```
k8s.io/kubernetes/pkg/registry/apps/deployment/storage/storage_test.go:28:2: package "k8s.io/apimachinery/pkg/api/errors" is being imported more than once (ST1019)
k8s.io/kubernetes/pkg/registry/apps/deployment/storage/storage_test.go:29:2: other import of "k8s.io/apimachinery/pkg/api/errors"
k8s.io/kubernetes/pkg/registry/apps/replicaset/storage/storage_test.go:26:2: package "k8s.io/apimachinery/pkg/api/errors" is being imported more than once (ST1019)
k8s.io/kubernetes/pkg/registry/apps/replicaset/storage/storage_test.go:27:2: other import of "k8s.io/apimachinery/pkg/api/errors"
k8s.io/kubernetes/pkg/registry/apps/statefulset/storage/storage_test.go:26:2: package "k8s.io/apimachinery/pkg/api/errors" is being imported more than once (ST1019)
k8s.io/kubernetes/pkg/registry/apps/statefulset/storage/storage_test.go:27:2: other import of "k8s.io/apimachinery/pkg/api/errors"
k8s.io/kubernetes/pkg/registry/core/service/ipallocator/controller/repair_test.go:25:2: package "k8s.io/api/core/v1" is being imported more than once (ST1019)
k8s.io/kubernetes/pkg/registry/core/service/ipallocator/controller/repair_test.go:26:2: other import of "k8s.io/api/core/v1"
k8s.io/kubernetes/pkg/registry/rbac/rest/storage_rbac.go:29:2: package "k8s.io/apimachinery/pkg/api/errors" is being imported more than once (ST1019)
k8s.io/kubernetes/pkg/registry/rbac/rest/storage_rbac.go:30:2: other import of "k8s.io/apimachinery/pkg/api/errors"
k8s.io/kubernetes/pkg/registry/core/service/storage/storage.go:34:2: package "k8s.io/kubernetes/pkg/registry/core/service" is being imported more than once (ST1019)
k8s.io/kubernetes/pkg/registry/core/service/storage/storage.go:35:2: other import of "k8s.io/kubernetes/pkg/registry/core/service"
k8s.io/kubernetes/pkg/registry/core/service/storage/storage.go:36:2: other import of "k8s.io/kubernetes/pkg/registry/core/service"
```
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
