### PR TITLE
code cleanup for pkg/scheduler

### DIFF
--- a/pkg/scheduler/apis/config/v1beta1/defaults.go
+++ b/pkg/scheduler/apis/config/v1beta1/defaults.go
@@ -21,7 +21,6 @@ import (
 	"strconv"
 
 	corev1 "k8s.io/api/core/v1"
-	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apiserver/pkg/util/feature"
 	componentbaseconfigv1alpha1 "k8s.io/component-base/config/v1alpha1"
@@ -53,7 +52,7 @@ func SetDefaults_KubeSchedulerConfiguration(obj *v1beta1.KubeSchedulerConfigurat
 	// Only apply a default scheduler name when there is a single profile.
 	// Validation will ensure that every profile has a non-empty unique name.
 	if len(obj.Profiles) == 1 && obj.Profiles[0].SchedulerName == nil {
-		obj.Profiles[0].SchedulerName = pointer.StringPtr(v1.DefaultSchedulerName)
+		obj.Profiles[0].SchedulerName = pointer.StringPtr(corev1.DefaultSchedulerName)
 	}
 
 	// For Healthz and Metrics bind addresses, we want to check:

--- a/pkg/scheduler/framework/plugins/nodevolumelimits/csi.go
+++ b/pkg/scheduler/framework/plugins/nodevolumelimits/csi.go
@@ -75,7 +75,7 @@ func (pl *CSILimits) Filter(ctx context.Context, _ *framework.CycleState, pod *v
 
 	node := nodeInfo.Node()
 	if node == nil {
-		return framework.NewStatus(framework.Error, fmt.Sprintf("node not found"))
+		return framework.NewStatus(framework.Error, "node not found")
 	}
 
 	// If CSINode doesn't exist, the predicate may read the limits from Node object

--- a/pkg/scheduler/framework/plugins/nodevolumelimits/non_csi.go
+++ b/pkg/scheduler/framework/plugins/nodevolumelimits/non_csi.go
@@ -215,7 +215,7 @@ func (pl *nonCSILimits) Filter(ctx context.Context, _ *framework.CycleState, pod
 
 	node := nodeInfo.Node()
 	if node == nil {
-		return framework.NewStatus(framework.Error, fmt.Sprintf("node not found"))
+		return framework.NewStatus(framework.Error, "node not found")
 	}
 
 	var csiNode *storage.CSINode

--- a/pkg/scheduler/framework/plugins/selectorspread/selector_spread.go
+++ b/pkg/scheduler/framework/plugins/selectorspread/selector_spread.go
@@ -181,8 +181,7 @@ func (pl *SelectorSpread) PreScore(ctx context.Context, cycleState *framework.Cy
 	if skipSelectorSpread(pod) {
 		return nil
 	}
-	var selector labels.Selector
-	selector = helper.DefaultSelector(
+	selector := helper.DefaultSelector(
 		pod,
 		pl.services,
 		pl.replicationControllers,

--- a/pkg/scheduler/framework/plugins/volumezone/volume_zone.go
+++ b/pkg/scheduler/framework/plugins/volumezone/volume_zone.go
@@ -123,7 +123,7 @@ func (pl *VolumeZone) Filter(ctx context.Context, _ *framework.CycleState, pod *
 		if pvName == "" {
 			scName := storagehelpers.GetPersistentVolumeClaimClass(pvc)
 			if len(scName) == 0 {
-				return framework.NewStatus(framework.Error, fmt.Sprint("PersistentVolumeClaim had no pv name and storageClass name"))
+				return framework.NewStatus(framework.Error, "PersistentVolumeClaim had no pv name and storageClass name")
 			}
 
 			class, _ := pl.scLister.Get(scName)
@@ -139,7 +139,7 @@ func (pl *VolumeZone) Filter(ctx context.Context, _ *framework.CycleState, pod *
 				continue
 			}
 
-			return framework.NewStatus(framework.Error, fmt.Sprint("PersistentVolume had no name"))
+			return framework.NewStatus(framework.Error, "PersistentVolume had no name")
 		}
 
 		pv, err := pl.pvLister.Get(pvName)
@@ -155,7 +155,7 @@ func (pl *VolumeZone) Filter(ctx context.Context, _ *framework.CycleState, pod *
 			if !volumeZoneLabels.Has(k) {
 				continue
 			}
-			nodeV, _ := nodeConstraints[k]
+			nodeV := nodeConstraints[k]
 			volumeVSet, err := volumehelpers.LabelZonesToSet(v)
 			if err != nil {
 				klog.InfoS("Failed to parse label, ignoring the label", "label", fmt.Sprintf("%s:%s", k, v), "err", err)

--- a/pkg/scheduler/internal/queue/scheduling_queue.go
+++ b/pkg/scheduler/internal/queue/scheduling_queue.go
@@ -31,7 +31,7 @@ import (
 
 	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
-	ktypes "k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
@@ -773,7 +773,7 @@ type nominatedPodMap struct {
 	nominatedPods map[string][]*framework.PodInfo
 	// nominatedPodToNode is map keyed by a Pod UID to the node name where it is
 	// nominated.
-	nominatedPodToNode map[ktypes.UID]string
+	nominatedPodToNode map[types.UID]string
 
 	sync.RWMutex
 }
@@ -845,7 +845,7 @@ func (npm *nominatedPodMap) UpdateNominatedPod(oldPod *v1.Pod, newPodInfo *frame
 func NewPodNominator() framework.PodNominator {
 	return &nominatedPodMap{
 		nominatedPods:      make(map[string][]*framework.PodInfo),
-		nominatedPodToNode: make(map[ktypes.UID]string),
+		nominatedPodToNode: make(map[types.UID]string),
 	}
 }
 

--- a/pkg/scheduler/internal/queue/scheduling_queue_test.go
+++ b/pkg/scheduler/internal/queue/scheduling_queue_test.go
@@ -30,7 +30,6 @@ import (
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	ktypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/clock"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/component-base/metrics/testutil"
@@ -1670,7 +1669,7 @@ func TestBackOffFlow(t *testing.T) {
 		},
 	}
 
-	podID := ktypes.NamespacedName{
+	podID := types.NamespacedName{
 		Namespace: pod.Namespace,
 		Name:      pod.Name,
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
https://staticcheck.io/docs/checks
```
k8s.io/kubernetes/pkg/scheduler/apis/config/v1beta1/defaults.go:23:2: package "k8s.io/api/core/v1" is being imported more than once (ST1019)
k8s.io/kubernetes/pkg/scheduler/apis/config/v1beta1/defaults.go:24:2: other import of "k8s.io/api/core/v1"
k8s.io/kubernetes/pkg/scheduler/framework/plugins/nodevolumelimits/csi.go:78:47: unnecessary use of fmt.Sprintf (S1039)
k8s.io/kubernetes/pkg/scheduler/framework/plugins/nodevolumelimits/non_csi.go:218:47: unnecessary use of fmt.Sprintf (S1039)
k8s.io/kubernetes/pkg/scheduler/framework/plugins/selectorspread/selector_spread.go:184:2: should merge variable declaration with assignment on next line (S1021)
k8s.io/kubernetes/pkg/scheduler/framework/plugins/volumezone/volume_zone.go:126:49: unnecessary use of fmt.Sprint (S1039)
k8s.io/kubernetes/pkg/scheduler/framework/plugins/volumezone/volume_zone.go:142:48: unnecessary use of fmt.Sprint (S1039)
k8s.io/kubernetes/pkg/scheduler/framework/plugins/volumezone/volume_zone.go:158:4: unnecessary assignment to the blank identifier (S1005)
k8s.io/kubernetes/pkg/scheduler/internal/queue/scheduling_queue_test.go:30:2: package "k8s.io/apimachinery/pkg/types" is being imported more than once (ST1019)
k8s.io/kubernetes/pkg/scheduler/internal/queue/scheduling_queue_test.go:31:2: other import of "k8s.io/apimachinery/pkg/types"
```
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
