### PR TITLE
fix oom score: ensure burstable pods have a higher score

### DIFF
--- a/pkg/kubelet/qos/policy.go
+++ b/pkg/kubelet/qos/policy.go
@@ -61,10 +61,10 @@ func GetContainerOOMScoreAdjust(pod *v1.Pod, container *v1.Container, memoryCapa
 	// Note that this is a heuristic, it won't work if a container has many small processes.
 	memoryRequest := container.Resources.Requests.Memory().Value()
 	oomScoreAdjust := 1000 - (1000*memoryRequest)/memoryCapacity
-	// A guaranteed pod using 100% of memory can have an OOM score of 10. Ensure
-	// that burstable pods have a higher OOM score adjustment.
-	if int(oomScoreAdjust) < (1000 + guaranteedOOMScoreAdj) {
-		return (1000 + guaranteedOOMScoreAdj)
+	// A guaranteed pod using 100% of memory can have an OOM score of 1000+guaranteedOOMScoreAdj.
+	// Ensure that burstable pods have a higher OOM score adjustment.
+	if int(oomScoreAdjust) <= (1000 + guaranteedOOMScoreAdj) {
+		return (1000 + guaranteedOOMScoreAdj + 1)
 	}
 	// Give burstable pods a higher chance of survival over besteffort pods.
 	if int(oomScoreAdjust) == besteffortOOMScoreAdj {

--- a/pkg/kubelet/qos/policy_test.go
+++ b/pkg/kubelet/qos/policy_test.go
@@ -199,8 +199,8 @@ func TestGetContainerOOMScoreAdjust(t *testing.T) {
 		{
 			pod:             &requestNoLimit,
 			memoryCapacity:  standardMemoryAmount,
-			lowOOMScoreAdj:  3,
-			highOOMScoreAdj: 3,
+			lowOOMScoreAdj:  4,
+			highOOMScoreAdj: 4,
 		},
 		{
 			pod:             &critical,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
The code does match the comment above. We expect that burstable pods have higher OOM score
 than guaranteed pods but the code result is `>=`.

The initial commit [f48c836](https://github.com/kubernetes/kubernetes/commit/f48c83600cbc3df8042f01db24e8869cf962a5f4#diff-28a2444beb8180d616b54452cc633120796284b69bb1b227ef40ab1390c25846R63) is correct
 since at that time the OOM score adjust for guaranteed is `-999`. So max oom score for guranteed
containers is 1. So it set 2 as minimum oom score adjust for burstable pods.

Commit f884180 changed guaranteedOOMScoreAdj from -999 to -998. Then minimum oom score
 for burstable pods should be 3. 

Later commits just change `return 2` to `return (1000 + guaranteedOOMScoreAdj)`. It should be
 `return (1000 + guaranteedOOMScoreAdj + 1)`

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
