### PR TITLE
fix bugs of container cpu shares when cpu request set to zero

### DIFF
--- a/pkg/kubelet/kuberuntime/kuberuntime_container_linux.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_container_linux.go
@@ -52,7 +52,7 @@ func (m *kubeGenericRuntimeManager) generateLinuxContainerConfig(container *v1.C
 
 	// set linux container resources
 	var cpuShares int64
-	cpuRequest := container.Resources.Requests.Cpu()
+	cpuRequest, cpuRequestExists := container.Resources.Requests[v1.ResourceCPU]
 	cpuLimit := container.Resources.Limits.Cpu()
 	memoryLimit := container.Resources.Limits.Memory().Value()
 	oomScoreAdj := int64(qos.GetContainerOOMScoreAdjust(pod, container,
@@ -60,7 +60,7 @@ func (m *kubeGenericRuntimeManager) generateLinuxContainerConfig(container *v1.C
 	// If request is not specified, but limit is, we want request to default to limit.
 	// API server does this for new containers, but we repeat this logic in Kubelet
 	// for containers running on existing Kubernetes clusters.
-	if cpuRequest.IsZero() && !cpuLimit.IsZero() {
+	if !cpuRequestExists && !cpuLimit.IsZero() {
 		cpuShares = milliCPUToShares(cpuLimit.MilliValue())
 	} else {
 		// if cpuRequest.Amount is nil, then milliCPUToShares will return the minimal number


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:
For container resources, if limits are specified, but requests are not, default requests are set to limits in API server, and kubelet repeat this logic for containers running on existing Kubernetes cluster, but it works with some mistake for cpu. 
Actually, if cpu request is set to zero (instead of not specified), kubelet will also consider it as equal to limits, and set cpu shares as to limit instead of 2 (minShares). 
This is unexpected, think that if we have 2 containers, one with requests set as:

    limits:
        cpu: "4"
      requests:
        cpu: "2"

and the other with requests set as:

    limits:
        cpu: "4"
      requests:
        cpu: "0"

the cpu shares (in container level cgroup) for first one would be set as 2048 while the latter as 4096
but the expected cpu shares would be 2048 and 2 instead

**Does this PR introduce a user-facing change?**:

```release-note
fix bugs of container cpu shares setting when cpu request set to zero
```


