### PR TITLE
migrate pkg/controller/serviceaccount logs to structured logging

### DIFF
--- a/pkg/controller/serviceaccount/serviceaccounts_controller.go
+++ b/pkg/controller/serviceaccount/serviceaccounts_controller.go
@@ -114,8 +114,8 @@ func (c *ServiceAccountsController) Run(workers int, stopCh <-chan struct{}) {
 	defer utilruntime.HandleCrash()
 	defer c.queue.ShutDown()
 
-	klog.Infof("Starting service account controller")
-	defer klog.Infof("Shutting down service account controller")
+	klog.InfoS("Starting service account controller")
+	defer klog.InfoS("Shutting down service account controller")
 
 	if !cache.WaitForNamedCacheSync("service account", stopCh, c.saListerSynced, c.nsListerSynced) {
 		return
@@ -185,7 +185,7 @@ func (c *ServiceAccountsController) processNextWorkItem() bool {
 func (c *ServiceAccountsController) syncNamespace(key string) error {
 	startTime := time.Now()
 	defer func() {
-		klog.V(4).Infof("Finished syncing namespace %q (%v)", key, time.Since(startTime))
+		klog.V(4).InfoS("Finished syncing namespace", "namespace", key, "startDuration", time.Since(startTime))
 	}()
 
 	ns, err := c.nsLister.Get(key)

--- a/pkg/controller/serviceaccount/tokens_controller.go
+++ b/pkg/controller/serviceaccount/tokens_controller.go
@@ -174,13 +174,13 @@ func (e *TokensController) Run(workers int, stopCh <-chan struct{}) {
 		return
 	}
 
-	klog.V(5).Infof("Starting workers")
+	klog.V(5).InfoS("Starting workers")
 	for i := 0; i < workers; i++ {
 		go wait.Until(e.syncServiceAccount, 0, stopCh)
 		go wait.Until(e.syncSecret, 0, stopCh)
 	}
 	<-stopCh
-	klog.V(1).Infof("Shutting down")
+	klog.V(1).InfoS("Shutting down")
 }
 
 func (e *TokensController) queueServiceAccountSync(obj interface{}) {
@@ -208,7 +208,7 @@ func (e *TokensController) retryOrForget(queue workqueue.RateLimitingInterface, 
 		return
 	}
 
-	klog.V(4).Infof("retried %d times: %#v", requeueCount, key)
+	klog.V(4).InfoS("Retried times", "requeueCount", requeueCount, "serviceAccountKey", key)
 	queue.Forget(key)
 }
 
@@ -238,28 +238,28 @@ func (e *TokensController) syncServiceAccount() {
 
 	saInfo, err := parseServiceAccountKey(key)
 	if err != nil {
-		klog.Error(err)
+		klog.ErrorS(err, "Error parsing serviceAccountQueueKey")
 		return
 	}
 
 	sa, err := e.getServiceAccount(saInfo.namespace, saInfo.name, saInfo.uid, false)
 	switch {
 	case err != nil:
-		klog.Error(err)
+		klog.ErrorS(err, "Error getting serviceaccount")
 		retry = true
 	case sa == nil:
 		// service account no longer exists, so delete related tokens
-		klog.V(4).Infof("syncServiceAccount(%s/%s), service account deleted, removing tokens", saInfo.namespace, saInfo.name)
+		klog.V(4).InfoS("SyncServiceAccount, serviceaccount deleted, removing tokens", "serviceaccount", klog.KRef(saInfo.namespace, saInfo.name))
 		sa = &v1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Namespace: saInfo.namespace, Name: saInfo.name, UID: saInfo.uid}}
 		retry, err = e.deleteTokens(sa)
 		if err != nil {
-			klog.Errorf("error deleting serviceaccount tokens for %s/%s: %v", saInfo.namespace, saInfo.name, err)
+			klog.ErrorS(err, "Error deleting serviceaccount tokens", "serviceaccount", klog.KRef(saInfo.namespace, saInfo.name))
 		}
 	default:
 		// ensure a token exists and is referenced by this service account
 		retry, err = e.ensureReferencedToken(sa)
 		if err != nil {
-			klog.Errorf("error synchronizing serviceaccount %s/%s: %v", saInfo.namespace, saInfo.name, err)
+			klog.ErrorS(err, "Error synchronizing serviceaccount", "serviceaccount", klog.KRef(saInfo.namespace, saInfo.name))
 		}
 	}
 }
@@ -279,14 +279,14 @@ func (e *TokensController) syncSecret() {
 
 	secretInfo, err := parseSecretQueueKey(key)
 	if err != nil {
-		klog.Error(err)
+		klog.ErrorS(err, "Error parsing secretQueueKey")
 		return
 	}
 
 	secret, err := e.getSecret(secretInfo.namespace, secretInfo.name, secretInfo.uid, false)
 	switch {
 	case err != nil:
-		klog.Error(err)
+		klog.ErrorS(err, "Error getting secret")
 		retry = true
 	case secret == nil:
 		// If the service account exists
@@ -295,7 +295,7 @@ func (e *TokensController) syncSecret() {
 			if err := clientretry.RetryOnConflict(RemoveTokenBackoff, func() error {
 				return e.removeSecretReference(secretInfo.namespace, secretInfo.saName, secretInfo.saUID, secretInfo.name)
 			}); err != nil {
-				klog.Error(err)
+				klog.ErrorS(err, "Error removing secret", "serviceaccount", klog.KRef(secretInfo.namespace, secretInfo.saName), "secret", klog.KRef(secretInfo.namespace, secretInfo.name))
 			}
 		}
 	default:
@@ -303,19 +303,19 @@ func (e *TokensController) syncSecret() {
 		sa, saErr := e.getServiceAccount(secretInfo.namespace, secretInfo.saName, secretInfo.saUID, true)
 		switch {
 		case saErr != nil:
-			klog.Error(saErr)
+			klog.ErrorS(saErr, "Error getting serviceaccount")
 			retry = true
 		case sa == nil:
 			// Delete token
-			klog.V(4).Infof("syncSecret(%s/%s), service account does not exist, deleting token", secretInfo.namespace, secretInfo.name)
+			klog.V(4).InfoS("SyncSecret, serviceaccount does not exist, deleting token", "secret", klog.KRef(secretInfo.namespace, secretInfo.name))
 			if retriable, err := e.deleteToken(secretInfo.namespace, secretInfo.name, secretInfo.uid); err != nil {
-				klog.Errorf("error deleting serviceaccount token %s/%s for service account %s: %v", secretInfo.namespace, secretInfo.name, secretInfo.saName, err)
+				klog.ErrorS(err, "Error deleting serviceaccount token for serviceaccount", "secret", klog.KRef(secretInfo.namespace, secretInfo.name), "serviceaccount", secretInfo.saName)
 				retry = retriable
 			}
 		default:
 			// Update token if needed
 			if retriable, err := e.generateTokenIfNeeded(sa, secret); err != nil {
-				klog.Errorf("error populating serviceaccount token %s/%s for service account %s: %v", secretInfo.namespace, secretInfo.name, secretInfo.saName, err)
+				klog.ErrorS(err, "Error populating serviceaccount token for service accoun", "secret", klog.KRef(secretInfo.namespace, secretInfo.name), "serviceaccount", secretInfo.saName)
 				retry = retriable
 			}
 		}
@@ -377,7 +377,7 @@ func (e *TokensController) ensureReferencedToken(serviceAccount *v1.ServiceAccou
 	}
 	if liveServiceAccount.ResourceVersion != serviceAccount.ResourceVersion {
 		// Retry if our liveServiceAccount doesn't match our cache's resourceVersion (either the live lookup or our cache are stale)
-		klog.V(4).Infof("liveServiceAccount.ResourceVersion (%s) does not match cache (%s), retrying", liveServiceAccount.ResourceVersion, serviceAccount.ResourceVersion)
+		klog.V(4).InfoS("LiveServiceAccount.ResourceVersion (%s) does not match cache (%s), retrying", liveServiceAccount.ResourceVersion, serviceAccount.ResourceVersion)
 		return true, nil
 	}
 
@@ -460,10 +460,10 @@ func (e *TokensController) ensureReferencedToken(serviceAccount *v1.ServiceAccou
 
 	if !addedReference {
 		// we weren't able to use the token, try to clean it up.
-		klog.V(2).Infof("deleting secret %s/%s because reference couldn't be added (%v)", secret.Namespace, secret.Name, err)
+		klog.V(2).InfoS("Deleting secret because reference couldn't be added", "secret", klog.KObj(secret), "err", err)
 		deleteOpts := metav1.DeleteOptions{Preconditions: &metav1.Preconditions{UID: &createdToken.UID}}
 		if err := e.client.CoreV1().Secrets(createdToken.Namespace).Delete(context.TODO(), createdToken.Name, deleteOpts); err != nil {
-			klog.Error(err) // if we fail, just log it
+			klog.ErrorS(err, "Error deleting secret", "secret", klog.KObj(createdToken)) // if we fail, just log it
 		}
 	}
 
@@ -529,7 +529,7 @@ func (e *TokensController) generateTokenIfNeeded(serviceAccount *v1.ServiceAccou
 	if liveSecret.ResourceVersion != cachedSecret.ResourceVersion {
 		// our view of the secret is not up to date
 		// we'll get notified of an update event later and get to try again
-		klog.V(2).Infof("secret %s/%s is not up to date, skipping token population", liveSecret.Namespace, liveSecret.Name)
+		klog.V(2).InfoS("Secret is not up to date, skipping token population", klog.KObj(liveSecret))
 		return false, nil
 	}
 

--- a/pkg/controller/serviceaccount/tokens_controller_test.go
+++ b/pkg/controller/serviceaccount/tokens_controller_test.go
@@ -568,8 +568,7 @@ func TestTokenCreation(t *testing.T) {
 	}
 
 	for k, tc := range testcases {
-		klog.Infof(k)
-
+		klog.InfoS(k)
 		// Re-seed to reset name generation
 		utilrand.Seed(1)
 
@@ -589,37 +588,53 @@ func TestTokenCreation(t *testing.T) {
 		}
 
 		if tc.ExistingServiceAccount != nil {
-			serviceAccounts.Add(tc.ExistingServiceAccount)
+			if err = serviceAccounts.Add(tc.ExistingServiceAccount); err != nil {
+				t.Fatalf("serviceAccounts could not add %v,err %v", tc.ExistingServiceAccount, err)
+			}
 		}
 		for _, s := range tc.ExistingSecrets {
-			secrets.Add(s)
+			if err = secrets.Add(s); err != nil {
+				t.Fatalf("secrets could not add %v,err %v", s, err)
+			}
 		}
 
 		if tc.AddedServiceAccount != nil {
-			serviceAccounts.Add(tc.AddedServiceAccount)
+			if err = serviceAccounts.Add(tc.AddedServiceAccount); err != nil {
+				t.Fatalf("serviceAccounts could not add %v,err %v", tc.AddedServiceAccount, err)
+			}
 			controller.queueServiceAccountSync(tc.AddedServiceAccount)
 		}
 		if tc.UpdatedServiceAccount != nil {
-			serviceAccounts.Add(tc.UpdatedServiceAccount)
+			if err = serviceAccounts.Add(tc.UpdatedServiceAccount); err != nil {
+				t.Fatalf("serviceAccounts could not add %v,err %v", tc.UpdatedServiceAccount, err)
+			}
 			controller.queueServiceAccountUpdateSync(nil, tc.UpdatedServiceAccount)
 		}
 		if tc.DeletedServiceAccount != nil {
-			serviceAccounts.Delete(tc.DeletedServiceAccount)
+			if err = serviceAccounts.Delete(tc.DeletedServiceAccount); err != nil {
+				t.Fatalf("serviceAccounts could not delete %v,err %v", tc.DeletedServiceAccount, err)
+			}
 			controller.queueServiceAccountSync(tc.DeletedServiceAccount)
 		}
 		if tc.AddedSecret != nil {
-			secrets.Add(tc.AddedSecret)
+			if err = secrets.Add(tc.AddedSecret); err != nil {
+				t.Fatalf("secrets could not add %v,err %v", tc.AddedSecret, err)
+			}
 			controller.queueSecretSync(tc.AddedSecret)
 		}
 		if tc.AddedSecretLocal != nil {
 			controller.updatedSecrets.Mutation(tc.AddedSecretLocal)
 		}
 		if tc.UpdatedSecret != nil {
-			secrets.Add(tc.UpdatedSecret)
+			if err = secrets.Add(tc.UpdatedSecret); err != nil {
+				t.Fatalf("secrets could not add %v,err %v", tc.UpdatedSecret, err)
+			}
 			controller.queueSecretUpdateSync(nil, tc.UpdatedSecret)
 		}
 		if tc.DeletedSecret != nil {
-			secrets.Delete(tc.DeletedSecret)
+			if err = secrets.Delete(tc.DeletedSecret); err != nil {
+				t.Fatalf("secrets could not delete %v,err %v", tc.DeletedSecret, err)
+			}
 			controller.queueSecretSync(tc.DeletedSecret)
 		}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
part of kubernetes/enhancements#1602
ref https://github.com/kubernetes/community/blob/master/contributors/devel/sig-instrumentation/migration-to-structured-logging.md

Fix staticcheck by the way
```
tokens_controller_test.go:590:23: Error return value of `serviceAccounts.Add` is not checked (errcheck)
tokens_controller_test.go:593:15: Error return value of `secrets.Add` is not checked (errcheck)
tokens_controller_test.go:597:23: Error return value of `serviceAccounts.Add` is not checked (errcheck)
tokens_controller_test.go:601:23: Error return value of `serviceAccounts.Add` is not checked (errcheck)
tokens_controller_test.go:605:26: Error return value of `serviceAccounts.Delete` is not checked (errcheck)
tokens_controller_test.go:609:15: Error return value of `secrets.Add` is not checked (errcheck)
tokens_controller_test.go:616:15: Error return value of `secrets.Add` is not checked (errcheck)
tokens_controller_test.go:620:18: Error return value of `secrets.Delete` is not checked (errcheck)
```
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
