### PR TITLE
GIT-100367: cleanup usage of Deprecated io/ioutil 

### DIFF
--- a/cluster/gce/gci/apiserver_kms_test.go
+++ b/cluster/gce/gci/apiserver_kms_test.go
@@ -20,7 +20,6 @@ import (
 	"bytes"
 	"encoding/base64"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -128,7 +127,7 @@ func TestEncryptionProviderConfig(t *testing.T) {
 		c.t.Fatalf("Expected encryption provider config to be written to %s, but stat failed with error: %v", p, err)
 	}
 
-	got, err := ioutil.ReadFile(p)
+	got, err := os.ReadFile(p)
 	if err != nil {
 		c.t.Fatalf("Failed to read encryption provider config %s", p)
 	}

--- a/cluster/gce/gci/append_or_replace_prefixed_line_test.go
+++ b/cluster/gce/gci/append_or_replace_prefixed_line_test.go
@@ -18,7 +18,6 @@ package gci
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"testing"
@@ -155,7 +154,7 @@ jelloworld
 	}
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
-			f, err := ioutil.TempFile("", "append_or_replace_test")
+			f, err := os.CreateTemp("", "append_or_replace_test")
 			if err != nil {
 				t.Fatalf("Failed to create temp file: %v", err)
 			}
@@ -170,7 +169,7 @@ jelloworld
 			if err != nil {
 				t.Fatalf("Failed to run command: %v: %s", err, stderr)
 			}
-			got, err := ioutil.ReadFile(f.Name())
+			got, err := os.ReadFile(f.Name())
 			if err != nil {
 				t.Fatalf("Failed to read file contents: %v", err)
 			}

--- a/cluster/gce/gci/audit_policy_test.go
+++ b/cluster/gce/gci/audit_policy_test.go
@@ -18,7 +18,7 @@ package gci
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -40,7 +40,7 @@ func init() {
 }
 
 func TestCreateMasterAuditPolicy(t *testing.T) {
-	baseDir, err := ioutil.TempDir("", "configure-helper-test") // cleaned up by c.tearDown()
+	baseDir, err := os.MkdirTemp("", "configure-helper-test") // cleaned up by c.tearDown()
 	require.NoError(t, err, "Failed to create temp directory")
 
 	policyFile := filepath.Join(baseDir, "audit_policy.yaml")

--- a/cluster/gce/gci/configure_helper_test.go
+++ b/cluster/gce/gci/configure_helper_test.go
@@ -19,7 +19,6 @@ package gci
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -56,7 +55,7 @@ func newManifestTestCase(t *testing.T, manifest, funcName string, auxManifests [
 		manifestFuncName: funcName,
 	}
 
-	d, err := ioutil.TempDir("", "configure-helper-test")
+	d, err := os.MkdirTemp("", "configure-helper-test")
 	if err != nil {
 		c.t.Fatalf("Failed to create temp directory: %v", err)
 	}
@@ -143,7 +142,7 @@ func (c *ManifestTestCase) mustCreateEnv(env interface{}, target string, templat
 }
 
 func (c *ManifestTestCase) mustLoadPodFromManifest() {
-	json, err := ioutil.ReadFile(c.manifestDestination)
+	json, err := os.ReadFile(c.manifestDestination)
 	if err != nil {
 		c.t.Fatalf("Failed to read manifest: %s, %v", c.manifestDestination, err)
 	}

--- a/cluster/images/conformance/go-runner/e2erunner.go
+++ b/cluster/images/conformance/go-runner/e2erunner.go
@@ -18,7 +18,6 @@ package main
 
 import (
 	"io"
-	"io/ioutil"
 	"log"
 	"os"
 	"os/signal"
@@ -115,7 +114,7 @@ func saveResults(resultsDir string) error {
 	}
 
 	return errors.Wrap(
-		ioutil.WriteFile(doneFile, []byte(resultsTarball), os.FileMode(0777)),
+		os.WriteFile(doneFile, []byte(resultsTarball), os.FileMode(0777)),
 		"writing donefile",
 	)
 }

--- a/cluster/images/conformance/go-runner/tar_test.go
+++ b/cluster/images/conformance/go-runner/tar_test.go
@@ -21,7 +21,6 @@ import (
 	"compress/gzip"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -32,7 +31,7 @@ import (
 )
 
 func TestTar(t *testing.T) {
-	tmp, err := ioutil.TempDir("", "testtar")
+	tmp, err := os.MkdirTemp("", "testtar")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -41,13 +40,13 @@ func TestTar(t *testing.T) {
 	if err := os.Mkdir(filepath.Join(tmp, "subdir"), os.FileMode(0755)); err != nil {
 		t.Fatal(err)
 	}
-	if err := ioutil.WriteFile(filepath.Join(tmp, "file1"), []byte(`file1 data`), os.FileMode(0644)); err != nil {
+	if err := os.WriteFile(filepath.Join(tmp, "file1"), []byte(`file1 data`), os.FileMode(0644)); err != nil {
 		t.Fatal(err)
 	}
-	if err := ioutil.WriteFile(filepath.Join(tmp, "file2"), []byte(`file2 data`), os.FileMode(0644)); err != nil {
+	if err := os.WriteFile(filepath.Join(tmp, "file2"), []byte(`file2 data`), os.FileMode(0644)); err != nil {
 		t.Fatal(err)
 	}
-	if err := ioutil.WriteFile(filepath.Join(tmp, "subdir", "file4"), []byte(`file4 data`), os.FileMode(0644)); err != nil {
+	if err := os.WriteFile(filepath.Join(tmp, "subdir", "file4"), []byte(`file4 data`), os.FileMode(0644)); err != nil {
 		t.Fatal(err)
 	}
 
@@ -140,7 +139,7 @@ func readAllTar(tarPath string) (map[string]string, error) {
 			return nil, err
 		}
 
-		b, err := ioutil.ReadAll(tr)
+		b, err := io.ReadAll(tr)
 		if err != nil {
 			return nil, err
 		}

--- a/cluster/images/etcd/migrate/data_dir.go
+++ b/cluster/images/etcd/migrate/data_dir.go
@@ -19,7 +19,6 @@ package main
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -128,7 +127,7 @@ func (v *VersionFile) Exists() (bool, error) {
 
 // Read parses the version.txt file and returns it's contents.
 func (v *VersionFile) Read() (*EtcdVersionPair, error) {
-	data, err := ioutil.ReadFile(v.path)
+	data, err := os.ReadFile(v.path)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read version file %s: %v", v.path, err)
 	}
@@ -143,7 +142,7 @@ func (v *VersionFile) Read() (*EtcdVersionPair, error) {
 // Write creates or overwrites the contents of the version.txt file with the given EtcdVersionPair.
 func (v *VersionFile) Write(vp *EtcdVersionPair) error {
 	data := []byte(fmt.Sprintf("%s/%s", vp.version, vp.storageVersion))
-	return ioutil.WriteFile(v.path, data, 0666)
+	return os.WriteFile(v.path, data, 0666)
 }
 
 func exists(path string) (bool, error) {

--- a/cluster/images/etcd/migrate/data_dir_test.go
+++ b/cluster/images/etcd/migrate/data_dir_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package main
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -156,7 +155,7 @@ func TestBackup(t *testing.T) {
 }
 
 func newTestPath(t *testing.T) string {
-	path, err := ioutil.TempDir("", "etcd-migrate-test-")
+	path, err := os.MkdirTemp("", "etcd-migrate-test-")
 	if err != nil {
 		t.Fatalf("Failed to create tmp dir for test: %v", err)
 	}

--- a/cluster/images/etcd/migrate/integration_test.go
+++ b/cluster/images/etcd/migrate/integration_test.go
@@ -27,7 +27,6 @@ import (
 	"encoding/pem"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"math/big"
 	"net"
 	"os"
@@ -290,13 +289,13 @@ func getOrCreateTestCertFiles(certFileName, keyFileName string, spec TestCertSpe
 	}
 
 	os.MkdirAll(filepath.Dir(certFileName), os.FileMode(0777))
-	err = ioutil.WriteFile(certFileName, certPem, os.FileMode(0777))
+	err = os.WriteFile(certFileName, certPem, os.FileMode(0777))
 	if err != nil {
 		return err
 	}
 
 	os.MkdirAll(filepath.Dir(keyFileName), os.FileMode(0777))
-	err = ioutil.WriteFile(keyFileName, keyPem, os.FileMode(0777))
+	err = os.WriteFile(keyFileName, keyPem, os.FileMode(0777))
 	if err != nil {
 		return err
 	}

--- a/cmd/clicheck/check_cli_conventions.go
+++ b/cmd/clicheck/check_cli_conventions.go
@@ -18,7 +18,7 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 
 	"k8s.io/kubectl/pkg/cmd"
@@ -28,7 +28,7 @@ import (
 func main() {
 	var errorCount int
 
-	kubectl := cmd.NewKubectlCommand(os.Stdin, ioutil.Discard, ioutil.Discard)
+	kubectl := cmd.NewKubectlCommand(os.Stdin, io.Discard, io.Discard)
 	errors := cmdsanity.RunCmdChecks(kubectl, cmdsanity.AllCmdChecks, []string{})
 	for _, err := range errors {
 		errorCount++

--- a/cmd/gendocs/gen_kubectl_docs.go
+++ b/cmd/gendocs/gen_kubectl_docs.go
@@ -18,7 +18,7 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 
 	"github.com/spf13/cobra/doc"
@@ -45,7 +45,7 @@ func main() {
 	// Set environment variables used by kubectl so the output is consistent,
 	// regardless of where we run.
 	os.Setenv("HOME", "/home/username")
-	// TODO os.Stdin should really be something like ioutil.Discard, but a Reader
-	kubectl := cmd.NewKubectlCommand(os.Stdin, ioutil.Discard, ioutil.Discard)
+	// TODO os.Stdin should really be something like io.Discard, but a Reader
+	kubectl := cmd.NewKubectlCommand(os.Stdin, io.Discard, io.Discard)
 	doc.GenMarkdownTree(kubectl, outDir)
 }

--- a/cmd/genkubedocs/postprocessing.go
+++ b/cmd/genkubedocs/postprocessing.go
@@ -17,7 +17,7 @@ limitations under the License.
 package main
 
 import (
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -38,14 +38,14 @@ func MarkdownPostProcessing(cmd *cobra.Command, dir string, processor func(strin
 	basename := strings.Replace(cmd.CommandPath(), " ", "_", -1) + ".md"
 	filename := filepath.Join(dir, basename)
 
-	markdownBytes, err := ioutil.ReadFile(filename)
+	markdownBytes, err := os.ReadFile(filename)
 	if err != nil {
 		return err
 	}
 
 	processedMarkDown := processor(string(markdownBytes))
 
-	return ioutil.WriteFile(filename, []byte(processedMarkDown), 0644)
+	return os.WriteFile(filename, []byte(processedMarkDown), 0644)
 }
 
 // cleanupForInclude parts of markdown that will make difficult to use it as include in the website:

--- a/cmd/genman/gen_kube_man.go
+++ b/cmd/genman/gen_kube_man.go
@@ -19,7 +19,7 @@ package main
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"strings"
 
@@ -96,8 +96,8 @@ func main() {
 		}
 	case "kubectl":
 		// generate manpage for kubectl
-		// TODO os.Stdin should really be something like ioutil.Discard, but a Reader
-		kubectl := kubectlcmd.NewKubectlCommand(os.Stdin, ioutil.Discard, ioutil.Discard)
+		// TODO os.Stdin should really be something like io.Discard, but a Reader
+		kubectl := kubectlcmd.NewKubectlCommand(os.Stdin, io.Discard, io.Discard)
 		genMarkdown(kubectl, "", outDir)
 		for _, c := range kubectl.Commands() {
 			genMarkdown(c, "kubectl", outDir)

--- a/cmd/genyaml/gen_kubectl_yaml.go
+++ b/cmd/genyaml/gen_kubectl_yaml.go
@@ -19,7 +19,7 @@ package main
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"strings"
 
@@ -65,7 +65,7 @@ func main() {
 	// Set environment variables used by kubectl so the output is consistent,
 	// regardless of where we run.
 	os.Setenv("HOME", "/home/username")
-	kubectl := cmd.NewKubectlCommand(bytes.NewReader(nil), ioutil.Discard, ioutil.Discard)
+	kubectl := cmd.NewKubectlCommand(bytes.NewReader(nil), io.Discard, io.Discard)
 	genYaml(kubectl, "", outDir)
 	for _, c := range kubectl.Commands() {
 		genYaml(c, "kubectl", outDir)

--- a/cmd/importverifier/importverifier.go
+++ b/cmd/importverifier/importverifier.go
@@ -21,7 +21,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"os"
 	"os/exec"
@@ -216,7 +215,7 @@ func main() {
 }
 
 func loadImportRestrictions(configFile string) ([]ImportRestriction, error) {
-	config, err := ioutil.ReadFile(configFile)
+	config, err := os.ReadFile(configFile)
 	if err != nil {
 		return nil, fmt.Errorf("failed to load configuration from %s: %v", configFile, err)
 	}

--- a/cmd/kube-controller-manager/app/testing/testserver.go
+++ b/cmd/kube-controller-manager/app/testing/testserver.go
@@ -19,7 +19,6 @@ package testing
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"os"
 	"time"
@@ -73,7 +72,7 @@ func StartTestServer(t Logger, customFlags []string) (result TestServer, err err
 		}
 	}()
 
-	result.TmpDir, err = ioutil.TempDir("", "kube-controller-manager")
+	result.TmpDir, err = os.MkdirTemp("", "kube-controller-manager")
 	if err != nil {
 		return result, fmt.Errorf("failed to create temp dir: %v", err)
 	}

--- a/cmd/kubeadm/app/apis/kubeadm/validation/validation_test.go
+++ b/cmd/kubeadm/app/apis/kubeadm/validation/validation_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package validation
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -949,7 +948,7 @@ func TestValidateDiscoveryTokenAPIServer(t *testing.T) {
 }
 
 func TestValidateDiscoveryKubeConfigPath(t *testing.T) {
-	tmpfile, err := ioutil.TempFile("/tmp", "test_discovery_file")
+	tmpfile, err := os.CreateTemp("/tmp", "test_discovery_file")
 	if err != nil {
 		t.Errorf("Error creating temporary file: %v", err)
 	}

--- a/cmd/kubeadm/app/cmd/alpha/kubeconfig_test.go
+++ b/cmd/kubeadm/app/cmd/alpha/kubeconfig_test.go
@@ -19,7 +19,6 @@ package alpha
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -70,7 +69,7 @@ func generateTestKubeadmConfig(dir, id, certDir, clusterName string) (string, er
 	}
 	buf.Write(data)
 
-	err = ioutil.WriteFile(cfgPath, buf.Bytes(), 0644)
+	err = os.WriteFile(cfgPath, buf.Bytes(), 0644)
 	return cfgPath, err
 }
 

--- a/cmd/kubeadm/app/cmd/config.go
+++ b/cmd/kubeadm/app/cmd/config.go
@@ -21,7 +21,7 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
+	"os"
 	"sort"
 	"strings"
 
@@ -250,7 +250,7 @@ func newCmdConfigMigrate(out io.Writer) *cobra.Command {
 				return errors.New("the --old-config flag is mandatory")
 			}
 
-			oldCfgBytes, err := ioutil.ReadFile(oldCfgPath)
+			oldCfgBytes, err := os.ReadFile(oldCfgPath)
 			if err != nil {
 				return err
 			}
@@ -263,7 +263,7 @@ func newCmdConfigMigrate(out io.Writer) *cobra.Command {
 			if newCfgPath == "" {
 				fmt.Fprint(out, string(outputBytes))
 			} else {
-				if err := ioutil.WriteFile(newCfgPath, outputBytes, 0644); err != nil {
+				if err := os.WriteFile(newCfgPath, outputBytes, 0644); err != nil {
 					return errors.Wrapf(err, "failed to write the new configuration to the file %q", newCfgPath)
 				}
 			}

--- a/cmd/kubeadm/app/cmd/config_test.go
+++ b/cmd/kubeadm/app/cmd/config_test.go
@@ -20,7 +20,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -108,14 +107,14 @@ func TestImagesListRunWithCustomConfigPath(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
-			tmpDir, err := ioutil.TempDir("", "kubeadm-images-test")
+			tmpDir, err := os.MkdirTemp("", "kubeadm-images-test")
 			if err != nil {
 				t.Fatalf("Unable to create temporary directory: %v", err)
 			}
 			defer os.RemoveAll(tmpDir)
 
 			configFilePath := filepath.Join(tmpDir, "test-config-file")
-			if err := ioutil.WriteFile(configFilePath, tc.configContents, 0644); err != nil {
+			if err := os.WriteFile(configFilePath, tc.configContents, 0644); err != nil {
 				t.Fatalf("Failed writing a config file: %v", err)
 			}
 
@@ -410,12 +409,12 @@ func TestMigrate(t *testing.T) {
 // Returns the name of the file created and a cleanup callback
 func tempConfig(t *testing.T, config []byte) (string, func()) {
 	t.Helper()
-	tmpDir, err := ioutil.TempDir("", "kubeadm-migration-test")
+	tmpDir, err := os.MkdirTemp("", "kubeadm-migration-test")
 	if err != nil {
 		t.Fatalf("Unable to create temporary directory: %v", err)
 	}
 	configFilePath := filepath.Join(tmpDir, "test-config-file")
-	if err := ioutil.WriteFile(configFilePath, config, 0644); err != nil {
+	if err := os.WriteFile(configFilePath, config, 0644); err != nil {
 		os.RemoveAll(tmpDir)
 		t.Fatalf("Failed writing a config file: %v", err)
 	}

--- a/cmd/kubeadm/app/cmd/init_test.go
+++ b/cmd/kubeadm/app/cmd/init_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package cmd
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -49,7 +48,7 @@ controlPlaneEndpoint: "3.4.5.6"
 
 func TestNewInitData(t *testing.T) {
 	// create temp directory
-	tmpDir, err := ioutil.TempDir("", "kubeadm-init-test")
+	tmpDir, err := os.MkdirTemp("", "kubeadm-init-test")
 	if err != nil {
 		t.Errorf("Unable to create temporary directory: %v", err)
 	}

--- a/cmd/kubeadm/app/cmd/join_test.go
+++ b/cmd/kubeadm/app/cmd/join_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package cmd
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -46,7 +45,7 @@ nodeRegistration:
 
 func TestNewJoinData(t *testing.T) {
 	// create temp directory
-	tmpDir, err := ioutil.TempDir("", "kubeadm-join-test")
+	tmpDir, err := os.MkdirTemp("", "kubeadm-join-test")
 	if err != nil {
 		t.Errorf("Unable to create temporary directory: %v", err)
 	}

--- a/cmd/kubeadm/app/cmd/phases/reset/cleanupnode_test.go
+++ b/cmd/kubeadm/app/cmd/phases/reset/cleanupnode_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package phases
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -149,7 +148,7 @@ func TestConfigDirCleaner(t *testing.T) {
 			t.Logf("Running test: %s", name)
 
 			// Create a temporary directory for our fake config dir:
-			tmpDir, err := ioutil.TempDir("", "kubeadm-reset-test")
+			tmpDir, err := os.MkdirTemp("", "kubeadm-reset-test")
 			if err != nil {
 				t.Errorf("Unable to create temporary directory: %s", err)
 			}

--- a/cmd/kubeadm/app/cmd/phases/reset/removeetcdmember_test.go
+++ b/cmd/kubeadm/app/cmd/phases/reset/removeetcdmember_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package phases
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -103,7 +102,7 @@ func TestGetEtcdDataDir(t *testing.T) {
 
 			manifestPath := filepath.Join(tmpdir, "etcd.yaml")
 			if test.writeManifest {
-				err := ioutil.WriteFile(manifestPath, []byte(test.podYaml), 0644)
+				err := os.WriteFile(manifestPath, []byte(test.podYaml), 0644)
 				if err != nil {
 					t.Fatalf(dedent.Dedent("failed to write pod manifest\n%s\n\tfatal error: %v"), name, err)
 				}

--- a/cmd/kubeadm/app/cmd/token_test.go
+++ b/cmd/kubeadm/app/cmd/token_test.go
@@ -18,7 +18,6 @@ package cmd
 
 import (
 	"bytes"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -198,7 +197,7 @@ func TestNewCmdToken(t *testing.T) {
 	var buf, bufErr bytes.Buffer
 	testConfigTokenFile := "test-config-file"
 
-	tmpDir, err := ioutil.TempDir("", "kubeadm-token-test")
+	tmpDir, err := os.MkdirTemp("", "kubeadm-token-test")
 	if err != nil {
 		t.Errorf("Unable to create temporary directory: %v", err)
 	}
@@ -266,7 +265,7 @@ func TestNewCmdToken(t *testing.T) {
 func TestGetClientset(t *testing.T) {
 	testConfigTokenFile := "test-config-file"
 
-	tmpDir, err := ioutil.TempDir("", "kubeadm-token-test")
+	tmpDir, err := os.MkdirTemp("", "kubeadm-token-test")
 	if err != nil {
 		t.Errorf("Unable to create temporary directory: %v", err)
 	}
@@ -302,7 +301,7 @@ func TestGetClientset(t *testing.T) {
 func TestRunDeleteTokens(t *testing.T) {
 	var buf bytes.Buffer
 
-	tmpDir, err := ioutil.TempDir("", "kubeadm-token-test")
+	tmpDir, err := os.MkdirTemp("", "kubeadm-token-test")
 	if err != nil {
 		t.Errorf("Unable to create temporary directory: %v", err)
 	}

--- a/cmd/kubeadm/app/cmd/upgrade/common.go
+++ b/cmd/kubeadm/app/cmd/upgrade/common.go
@@ -21,7 +21,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"strings"
 	"time"
@@ -75,7 +74,7 @@ func loadConfig(cfgPath string, client clientset.Interface, skipComponentConfigs
 	}
 
 	// Otherwise, we have a config file. Let's load it.
-	configBytes, err := ioutil.ReadFile(cfgPath)
+	configBytes, err := os.ReadFile(cfgPath)
 	if err != nil {
 		return nil, false, errors.Wrapf(err, "unable to load config from file %q", cfgPath)
 	}

--- a/cmd/kubeadm/app/cmd/upgrade/diff.go
+++ b/cmd/kubeadm/app/cmd/upgrade/diff.go
@@ -18,7 +18,7 @@ package upgrade
 
 import (
 	"io"
-	"io/ioutil"
+	"os"
 
 	"github.com/pkg/errors"
 	"github.com/pmezard/go-difflib/difflib"
@@ -143,7 +143,7 @@ func runDiff(flags *diffFlags, args []string) error {
 		if path == "" {
 			return errors.New("empty manifest path")
 		}
-		existingManifest, err := ioutil.ReadFile(path)
+		existingManifest, err := os.ReadFile(path)
 		if err != nil {
 			return err
 		}

--- a/cmd/kubeadm/app/cmd/upgrade/plan.go
+++ b/cmd/kubeadm/app/cmd/upgrade/plan.go
@@ -19,7 +19,6 @@ package upgrade
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"sort"
 	"strings"
@@ -193,7 +192,7 @@ func getComponentConfigVersionStates(cfg *kubeadmapi.ClusterConfiguration, clien
 	docmap := kubeadmapi.DocumentMap{}
 
 	if cfgPath != "" {
-		bytes, err := ioutil.ReadFile(cfgPath)
+		bytes, err := os.ReadFile(cfgPath)
 		if err != nil {
 			return nil, errors.Wrapf(err, "unable to read config file %q", cfgPath)
 		}

--- a/cmd/kubeadm/app/constants/constants.go
+++ b/cmd/kubeadm/app/constants/constants.go
@@ -18,7 +18,6 @@ package constants
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net"
 	"os"
 	"path"
@@ -555,7 +554,7 @@ func CreateTempDirForKubeadm(kubernetesDir, dirName string) (string, error) {
 		return "", errors.Wrapf(err, "failed to create directory %q", tempDir)
 	}
 
-	tempDir, err := ioutil.TempDir(tempDir, dirName)
+	tempDir, err := os.MkdirTemp(tempDir, dirName)
 	if err != nil {
 		return "", errors.Wrap(err, "couldn't create a temporary directory")
 	}

--- a/cmd/kubeadm/app/phases/bootstraptoken/clusterinfo/clusterinfo_test.go
+++ b/cmd/kubeadm/app/phases/bootstraptoken/clusterinfo/clusterinfo_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package clusterinfo
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 	"text/template"
@@ -80,7 +79,7 @@ func TestCreateBootstrapConfigMapIfNotExists(t *testing.T) {
 	}
 
 	for _, server := range servers {
-		file, err := ioutil.TempFile("", "")
+		file, err := os.CreateTemp("", "")
 		if err != nil {
 			t.Fatalf("could not create tempfile: %v", err)
 		}

--- a/cmd/kubeadm/app/phases/controlplane/volumes_test.go
+++ b/cmd/kubeadm/app/phases/controlplane/volumes_test.go
@@ -18,7 +18,6 @@ package controlplane
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"reflect"
 	"testing"
@@ -506,7 +505,7 @@ func TestGetHostPathVolumesForTheControlPlane(t *testing.T) {
 		},
 	}
 
-	tmpdir, err := ioutil.TempDir("", "")
+	tmpdir, err := os.MkdirTemp("", "")
 	if err != nil {
 		t.Fatalf("Couldn't create tmpdir")
 	}

--- a/cmd/kubeadm/app/phases/copycerts/copycerts.go
+++ b/cmd/kubeadm/app/phases/copycerts/copycerts.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"encoding/hex"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"strings"
@@ -171,7 +170,7 @@ func getSecretOwnerRef(client clientset.Interface, tokenID string) ([]metav1.Own
 }
 
 func loadAndEncryptCert(certPath string, key []byte) ([]byte, error) {
-	cert, err := ioutil.ReadFile(certPath)
+	cert, err := os.ReadFile(certPath)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/kubeadm/app/phases/copycerts/copycerts_test.go
+++ b/cmd/kubeadm/app/phases/copycerts/copycerts_test.go
@@ -19,7 +19,6 @@ package copycerts
 import (
 	"context"
 	"encoding/hex"
-	"io/ioutil"
 	"os"
 	"path"
 	"regexp"
@@ -60,7 +59,7 @@ func TestGetDataFromInitConfig(t *testing.T) {
 
 	certs := certsToTransfer(cfg)
 	for name, path := range certs {
-		if err := ioutil.WriteFile(path, certData, 0644); err != nil {
+		if err := os.WriteFile(path, certData, 0644); err != nil {
 			t.Fatalf(dedent.Dedent("failed to write cert: %s\nfatal error: %v"), name, err)
 		}
 	}
@@ -190,7 +189,7 @@ func TestUploadCerts(t *testing.T) {
 		if err != nil {
 			t.Fatalf("error decrypting secret data: %v", err)
 		}
-		diskCertData, err := ioutil.ReadFile(certPath)
+		diskCertData, err := os.ReadFile(certPath)
 		if err != nil {
 			t.Fatalf("error reading certificate from disk: %v", err)
 		}
@@ -234,7 +233,7 @@ func TestDownloadCerts(t *testing.T) {
 	const certFileMode = 0644
 
 	for certName, certPath := range certsToTransfer(initForDownloadConfiguration) {
-		diskCertData, err := ioutil.ReadFile(certPath)
+		diskCertData, err := os.ReadFile(certPath)
 		if err != nil {
 			t.Errorf("error reading certificate from disk: %v", err)
 		}

--- a/cmd/kubeadm/app/phases/kubelet/flags.go
+++ b/cmd/kubeadm/app/phases/kubelet/flags.go
@@ -18,7 +18,6 @@ package kubelet
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -121,7 +120,7 @@ func writeKubeletFlagBytesToDisk(b []byte, kubeletDir string) error {
 	if err := os.MkdirAll(kubeletDir, 0700); err != nil {
 		return errors.Wrapf(err, "failed to create directory %q", kubeletDir)
 	}
-	if err := ioutil.WriteFile(kubeletEnvFilePath, b, 0644); err != nil {
+	if err := os.WriteFile(kubeletEnvFilePath, b, 0644); err != nil {
 		return errors.Wrapf(err, "failed to write kubelet configuration to the file %q", kubeletEnvFilePath)
 	}
 	return nil

--- a/cmd/kubeadm/app/phases/upgrade/compute_test.go
+++ b/cmd/kubeadm/app/phases/upgrade/compute_test.go
@@ -18,7 +18,6 @@ package upgrade
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"reflect"
 	"strings"
@@ -699,13 +698,13 @@ func TestGetAvailableUpgrades(t *testing.T) {
 				},
 			})
 
-			manifestsDir, err := ioutil.TempDir("", "GetAvailableUpgrades-test-manifests")
+			manifestsDir, err := os.MkdirTemp("", "GetAvailableUpgrades-test-manifests")
 			if err != nil {
 				t.Fatalf("Unable to create temporary directory: %v", err)
 			}
 			defer os.RemoveAll(manifestsDir)
 
-			if err = ioutil.WriteFile(constants.GetStaticPodFilepath(constants.Etcd, manifestsDir), []byte(etcdStaticPod), 0644); err != nil {
+			if err = os.WriteFile(constants.GetStaticPodFilepath(constants.Etcd, manifestsDir), []byte(etcdStaticPod), 0644); err != nil {
 				t.Fatalf("Unable to create test static pod manifest: %v", err)
 			}
 

--- a/cmd/kubeadm/app/preflight/checks.go
+++ b/cmd/kubeadm/app/preflight/checks.go
@@ -24,7 +24,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"net/url"
@@ -748,7 +747,7 @@ func (evc ExternalEtcdVersionCheck) Check() (warnings, errorList []error) {
 func (evc ExternalEtcdVersionCheck) configRootCAs(config *tls.Config) (*tls.Config, error) {
 	var CACertPool *x509.CertPool
 	if evc.Etcd.External.CAFile != "" {
-		CACert, err := ioutil.ReadFile(evc.Etcd.External.CAFile)
+		CACert, err := os.ReadFile(evc.Etcd.External.CAFile)
 		if err != nil {
 			return nil, errors.Wrapf(err, "couldn't load external etcd's server certificate %s", evc.Etcd.External.CAFile)
 		}

--- a/cmd/kubeadm/app/util/config/cluster_test.go
+++ b/cmd/kubeadm/app/util/config/cluster_test.go
@@ -18,7 +18,6 @@ package config
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -197,7 +196,7 @@ G+2/lm8TaVjoU7Fi5Ka5G5HY2GLaR7P+IxYcrMHCl62Y7Rqcrnc=
 }
 
 func TestGetNodeNameFromKubeletConfig(t *testing.T) {
-	tmpdir, err := ioutil.TempDir("", "")
+	tmpdir, err := os.MkdirTemp("", "")
 	if err != nil {
 		t.Fatalf("Couldn't create tmpdir")
 	}
@@ -244,7 +243,7 @@ func TestGetNodeNameFromKubeletConfig(t *testing.T) {
 		t.Run(rt.name, func(t2 *testing.T) {
 			if len(rt.pemContent) > 0 {
 				pemPath := filepath.Join(tmpdir, "kubelet.pem")
-				err := ioutil.WriteFile(pemPath, rt.pemContent, 0644)
+				err := os.WriteFile(pemPath, rt.pemContent, 0644)
 				if err != nil {
 					t.Errorf("Couldn't create pem file: %v", err)
 					return
@@ -253,7 +252,7 @@ func TestGetNodeNameFromKubeletConfig(t *testing.T) {
 			}
 
 			kubeconfigPath := filepath.Join(tmpdir, kubeadmconstants.KubeletKubeConfigFileName)
-			err := ioutil.WriteFile(kubeconfigPath, rt.kubeconfigContent, 0644)
+			err := os.WriteFile(kubeconfigPath, rt.kubeconfigContent, 0644)
 			if err != nil {
 				t.Errorf("Couldn't create kubeconfig: %v", err)
 				return
@@ -276,7 +275,7 @@ func TestGetNodeNameFromKubeletConfig(t *testing.T) {
 }
 
 func TestGetNodeRegistration(t *testing.T) {
-	tmpdir, err := ioutil.TempDir("", "")
+	tmpdir, err := os.MkdirTemp("", "")
 	if err != nil {
 		t.Fatalf("Couldn't create tmpdir")
 	}
@@ -318,7 +317,7 @@ func TestGetNodeRegistration(t *testing.T) {
 		t.Run(rt.name, func(t2 *testing.T) {
 			cfgPath := filepath.Join(tmpdir, kubeadmconstants.KubeletKubeConfigFileName)
 			if len(rt.fileContents) > 0 {
-				err := ioutil.WriteFile(cfgPath, rt.fileContents, 0644)
+				err := os.WriteFile(cfgPath, rt.fileContents, 0644)
 				if err != nil {
 					t.Errorf("Couldn't create file")
 					return
@@ -514,7 +513,7 @@ func TestGetAPIEndpointWithBackoff(t *testing.T) {
 }
 
 func TestGetInitConfigurationFromCluster(t *testing.T) {
-	tmpdir, err := ioutil.TempDir("", "")
+	tmpdir, err := os.MkdirTemp("", "")
 	if err != nil {
 		t.Fatalf("Couldn't create tmpdir")
 	}
@@ -703,7 +702,7 @@ func TestGetInitConfigurationFromCluster(t *testing.T) {
 		t.Run(rt.name, func(t *testing.T) {
 			cfgPath := filepath.Join(tmpdir, kubeadmconstants.KubeletKubeConfigFileName)
 			if len(rt.fileContents) > 0 {
-				err := ioutil.WriteFile(cfgPath, rt.fileContents, 0644)
+				err := os.WriteFile(cfgPath, rt.fileContents, 0644)
 				if err != nil {
 					t.Errorf("Couldn't create file")
 					return

--- a/cmd/kubeadm/app/util/config/initconfiguration.go
+++ b/cmd/kubeadm/app/util/config/initconfiguration.go
@@ -19,8 +19,8 @@ package config
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"net"
+	"os"
 	"strconv"
 
 	"github.com/pkg/errors"
@@ -245,7 +245,7 @@ func DefaultedInitConfiguration(versionedInitCfg *kubeadmapiv1beta2.InitConfigur
 func LoadInitConfigurationFromFile(cfgPath string) (*kubeadmapi.InitConfiguration, error) {
 	klog.V(1).Infof("loading configuration from %q", cfgPath)
 
-	b, err := ioutil.ReadFile(cfgPath)
+	b, err := os.ReadFile(cfgPath)
 	if err != nil {
 		return nil, errors.Wrapf(err, "unable to read config from %q ", cfgPath)
 	}

--- a/cmd/kubeadm/app/util/config/initconfiguration_test.go
+++ b/cmd/kubeadm/app/util/config/initconfiguration_test.go
@@ -18,7 +18,6 @@ package config
 
 import (
 	"bytes"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -32,7 +31,7 @@ import (
 
 func TestLoadInitConfigurationFromFile(t *testing.T) {
 	// Create temp folder for the test case
-	tmpdir, err := ioutil.TempDir("", "")
+	tmpdir, err := os.MkdirTemp("", "")
 	if err != nil {
 		t.Fatalf("Couldn't create tmpdir: %v", err)
 	}
@@ -83,7 +82,7 @@ func TestLoadInitConfigurationFromFile(t *testing.T) {
 	for _, rt := range tests {
 		t.Run(rt.name, func(t2 *testing.T) {
 			cfgPath := filepath.Join(tmpdir, rt.name)
-			err := ioutil.WriteFile(cfgPath, rt.fileContents, 0644)
+			err := os.WriteFile(cfgPath, rt.fileContents, 0644)
 			if err != nil {
 				t.Errorf("Couldn't create file: %v", err)
 				return

--- a/cmd/kubeadm/app/util/config/joinconfiguration.go
+++ b/cmd/kubeadm/app/util/config/joinconfiguration.go
@@ -17,7 +17,7 @@ limitations under the License.
 package config
 
 import (
-	"io/ioutil"
+	"os"
 
 	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -73,7 +73,7 @@ func LoadOrDefaultJoinConfiguration(cfgPath string, defaultversionedcfg *kubeadm
 func LoadJoinConfigurationFromFile(cfgPath string) (*kubeadmapi.JoinConfiguration, error) {
 	klog.V(1).Infof("loading configuration from %q", cfgPath)
 
-	b, err := ioutil.ReadFile(cfgPath)
+	b, err := os.ReadFile(cfgPath)
 	if err != nil {
 		return nil, errors.Wrapf(err, "unable to read config from %q ", cfgPath)
 	}

--- a/cmd/kubeadm/app/util/config/joinconfiguration_test.go
+++ b/cmd/kubeadm/app/util/config/joinconfiguration_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package config
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -27,7 +26,7 @@ import (
 
 func TestLoadJoinConfigurationFromFile(t *testing.T) {
 	// Create temp folder for the test case
-	tmpdir, err := ioutil.TempDir("", "")
+	tmpdir, err := os.MkdirTemp("", "")
 	if err != nil {
 		t.Fatalf("Couldn't create tmpdir: %v", err)
 	}
@@ -94,7 +93,7 @@ func TestLoadJoinConfigurationFromFile(t *testing.T) {
 	for _, rt := range tests {
 		t.Run(rt.name, func(t2 *testing.T) {
 			cfgPath := filepath.Join(tmpdir, rt.name)
-			err := ioutil.WriteFile(cfgPath, []byte(rt.fileContents), 0644)
+			err := os.WriteFile(cfgPath, []byte(rt.fileContents), 0644)
 			if err != nil {
 				t.Errorf("Couldn't create file: %v", err)
 				return

--- a/cmd/kubeadm/app/util/config/strict/strict_test.go
+++ b/cmd/kubeadm/app/util/config/strict/strict_test.go
@@ -17,7 +17,7 @@ limitations under the License.
 package strict
 
 import (
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -142,7 +142,7 @@ func TestVerifyUnmarshalStrict(t *testing.T) {
 
 	for _, test := range testFiles {
 		t.Run(test.fileName, func(t *testing.T) {
-			bytes, err := ioutil.ReadFile(filepath.Join(pathTestData, test.fileName))
+			bytes, err := os.ReadFile(filepath.Join(pathTestData, test.fileName))
 			if err != nil {
 				t.Fatalf("couldn't read test data: %v", err)
 			}

--- a/cmd/kubeadm/app/util/kubeconfig/kubeconfig.go
+++ b/cmd/kubeadm/app/util/kubeconfig/kubeconfig.go
@@ -18,7 +18,7 @@ package kubeconfig
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
@@ -151,7 +151,7 @@ func EnsureAuthenticationInfoAreEmbedded(config *clientcmdapi.Config) error {
 	}
 
 	if len(authInfo.ClientCertificateData) == 0 && len(authInfo.ClientCertificate) != 0 {
-		clientCert, err := ioutil.ReadFile(authInfo.ClientCertificate)
+		clientCert, err := os.ReadFile(authInfo.ClientCertificate)
 		if err != nil {
 			return errors.Wrap(err, "error while reading client cert file defined in kubeconfig")
 		}
@@ -159,7 +159,7 @@ func EnsureAuthenticationInfoAreEmbedded(config *clientcmdapi.Config) error {
 		authInfo.ClientCertificate = ""
 	}
 	if len(authInfo.ClientKeyData) == 0 && len(authInfo.ClientKey) != 0 {
-		clientKey, err := ioutil.ReadFile(authInfo.ClientKey)
+		clientKey, err := os.ReadFile(authInfo.ClientKey)
 		if err != nil {
 			return errors.Wrap(err, "error while reading client key file defined in kubeconfig")
 		}
@@ -178,7 +178,7 @@ func EnsureCertificateAuthorityIsEmbedded(cluster *clientcmdapi.Cluster) error {
 	}
 
 	if len(cluster.CertificateAuthorityData) == 0 && len(cluster.CertificateAuthority) != 0 {
-		ca, err := ioutil.ReadFile(cluster.CertificateAuthority)
+		ca, err := os.ReadFile(cluster.CertificateAuthority)
 		if err != nil {
 			return errors.Wrap(err, "error while reading certificate authority file defined in kubeconfig")
 		}

--- a/cmd/kubeadm/app/util/patches/patches_test.go
+++ b/cmd/kubeadm/app/util/patches/patches_test.go
@@ -18,7 +18,7 @@ package patches
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -165,13 +165,13 @@ func TestCreatePatchSet(t *testing.T) {
 }
 
 func TestGetPatchSetsForPathMustBeDirectory(t *testing.T) {
-	tempFile, err := ioutil.TempFile("", "test-file")
+	tempFile, err := os.CreateTemp("", "test-file")
 	if err != nil {
 		t.Errorf("error creating temporary file: %v", err)
 	}
 	defer os.Remove(tempFile.Name())
 
-	_, _, _, err = getPatchSetsFromPath(tempFile.Name(), testKnownTargets, ioutil.Discard)
+	_, _, _, err = getPatchSetsFromPath(tempFile.Name(), testKnownTargets, io.Discard)
 	if err == nil {
 		t.Fatalf("expected error for non-directory path %q", tempFile.Name())
 	}
@@ -230,7 +230,7 @@ func TestGetPatchSetsForPath(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			tempDir, err := ioutil.TempDir("", testDirPattern)
+			tempDir, err := os.MkdirTemp("", testDirPattern)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -238,13 +238,13 @@ func TestGetPatchSetsForPath(t *testing.T) {
 
 			for _, file := range tc.filesToWrite {
 				filePath := filepath.Join(tempDir, file)
-				err := ioutil.WriteFile(filePath, []byte(tc.patchData), 0644)
+				err := os.WriteFile(filePath, []byte(tc.patchData), 0644)
 				if err != nil {
 					t.Fatalf("could not write temporary file %q", filePath)
 				}
 			}
 
-			patchSets, patchFiles, ignoredFiles, err := getPatchSetsFromPath(tempDir, testKnownTargets, ioutil.Discard)
+			patchSets, patchFiles, ignoredFiles, err := getPatchSetsFromPath(tempDir, testKnownTargets, io.Discard)
 			if (err != nil) != tc.expectedError {
 				t.Fatalf("expected error: %v, got: %v, error: %v", tc.expectedError, err != nil, err)
 			}
@@ -358,7 +358,7 @@ func TestGetPatchManagerForPath(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			tempDir, err := ioutil.TempDir("", testDirPattern)
+			tempDir, err := os.MkdirTemp("", testDirPattern)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -366,7 +366,7 @@ func TestGetPatchManagerForPath(t *testing.T) {
 
 			for _, file := range tc.files {
 				filePath := filepath.Join(tempDir, file.name)
-				err := ioutil.WriteFile(filePath, []byte(file.data), 0644)
+				err := os.WriteFile(filePath, []byte(file.data), 0644)
 				if err != nil {
 					t.Fatalf("could not write temporary file %q", filePath)
 				}
@@ -393,7 +393,7 @@ func TestGetPatchManagerForPath(t *testing.T) {
 }
 
 func TestGetPatchManagerForPathCache(t *testing.T) {
-	tempDir, err := ioutil.TempDir("", testDirPattern)
+	tempDir, err := os.MkdirTemp("", testDirPattern)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/kubeadm/app/util/pkiutil/pki_helpers_test.go
+++ b/cmd/kubeadm/app/util/pkiutil/pki_helpers_test.go
@@ -23,7 +23,6 @@ import (
 	"crypto/rand"
 	"crypto/x509"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"os"
 	"reflect"
@@ -174,7 +173,7 @@ func TestHasServerAuth(t *testing.T) {
 }
 
 func TestWriteCertAndKey(t *testing.T) {
-	tmpdir, err := ioutil.TempDir("", "")
+	tmpdir, err := os.MkdirTemp("", "")
 	if err != nil {
 		t.Fatalf("Couldn't create tmpdir")
 	}
@@ -191,7 +190,7 @@ func TestWriteCertAndKey(t *testing.T) {
 }
 
 func TestWriteCert(t *testing.T) {
-	tmpdir, err := ioutil.TempDir("", "")
+	tmpdir, err := os.MkdirTemp("", "")
 	if err != nil {
 		t.Fatalf("Couldn't create tmpdir")
 	}
@@ -208,7 +207,7 @@ func TestWriteCert(t *testing.T) {
 }
 
 func TestWriteCertBundle(t *testing.T) {
-	tmpdir, err := ioutil.TempDir("", "")
+	tmpdir, err := os.MkdirTemp("", "")
 	if err != nil {
 		t.Fatalf("Couldn't create tmpdir")
 	}
@@ -223,7 +222,7 @@ func TestWriteCertBundle(t *testing.T) {
 }
 
 func TestWriteKey(t *testing.T) {
-	tmpdir, err := ioutil.TempDir("", "")
+	tmpdir, err := os.MkdirTemp("", "")
 	if err != nil {
 		t.Fatalf("Couldn't create tmpdir")
 	}
@@ -239,7 +238,7 @@ func TestWriteKey(t *testing.T) {
 }
 
 func TestWritePublicKey(t *testing.T) {
-	tmpdir, err := ioutil.TempDir("", "")
+	tmpdir, err := os.MkdirTemp("", "")
 	if err != nil {
 		t.Fatalf("Couldn't create tmpdir")
 	}
@@ -255,7 +254,7 @@ func TestWritePublicKey(t *testing.T) {
 }
 
 func TestCertOrKeyExist(t *testing.T) {
-	tmpdir, err := ioutil.TempDir("", "")
+	tmpdir, err := os.MkdirTemp("", "")
 	if err != nil {
 		t.Fatalf("Couldn't create tmpdir")
 	}
@@ -304,7 +303,7 @@ func TestCertOrKeyExist(t *testing.T) {
 }
 
 func TestTryLoadCertAndKeyFromDisk(t *testing.T) {
-	tmpdir, err := ioutil.TempDir("", "")
+	tmpdir, err := os.MkdirTemp("", "")
 	if err != nil {
 		t.Fatalf("Couldn't create tmpdir")
 	}
@@ -352,7 +351,7 @@ func TestTryLoadCertAndKeyFromDisk(t *testing.T) {
 }
 
 func TestTryLoadCertFromDisk(t *testing.T) {
-	tmpdir, err := ioutil.TempDir("", "")
+	tmpdir, err := os.MkdirTemp("", "")
 	if err != nil {
 		t.Fatalf("Couldn't create tmpdir")
 	}
@@ -406,7 +405,7 @@ func TestTryLoadCertFromDisk(t *testing.T) {
 }
 
 func TestTryLoadCertChainFromDisk(t *testing.T) {
-	tmpdir, err := ioutil.TempDir("", "")
+	tmpdir, err := os.MkdirTemp("", "")
 	if err != nil {
 		t.Fatalf("Couldn't create tmpdir")
 	}
@@ -506,7 +505,7 @@ func TestTryLoadKeyFromDisk(t *testing.T) {
 	}
 	for _, rt := range tests {
 		t.Run(rt.desc, func(t *testing.T) {
-			tmpdir, err := ioutil.TempDir("", "")
+			tmpdir, err := os.MkdirTemp("", "")
 			if err != nil {
 				t.Fatalf("Couldn't create tmpdir")
 			}
@@ -853,7 +852,7 @@ func TestRemoveDuplicateAltNames(t *testing.T) {
 }
 
 func TestVerifyCertChain(t *testing.T) {
-	tmpdir, err := ioutil.TempDir("", "")
+	tmpdir, err := os.MkdirTemp("", "")
 	if err != nil {
 		t.Fatalf("Couldn't create tmpdir")
 	}

--- a/cmd/kubeadm/app/util/staticpod/utils.go
+++ b/cmd/kubeadm/app/util/staticpod/utils.go
@@ -20,7 +20,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math"
 	"net/url"
 	"os"
@@ -207,7 +206,7 @@ func WriteStaticPodToDisk(componentName, manifestDir string, pod v1.Pod) error {
 
 	filename := kubeadmconstants.GetStaticPodFilepath(componentName, manifestDir)
 
-	if err := ioutil.WriteFile(filename, serialized, 0600); err != nil {
+	if err := os.WriteFile(filename, serialized, 0600); err != nil {
 		return errors.Wrapf(err, "failed to write static pod manifest file for %q (%q)", componentName, filename)
 	}
 
@@ -216,7 +215,7 @@ func WriteStaticPodToDisk(componentName, manifestDir string, pod v1.Pod) error {
 
 // ReadStaticPodFromDisk reads a static pod file from disk
 func ReadStaticPodFromDisk(manifestPath string) (*v1.Pod, error) {
-	buf, err := ioutil.ReadFile(manifestPath)
+	buf, err := os.ReadFile(manifestPath)
 	if err != nil {
 		return &v1.Pod{}, errors.Wrapf(err, "failed to read manifest for %q", manifestPath)
 	}
@@ -350,11 +349,11 @@ func GetEtcdProbeEndpoint(cfg *kubeadmapi.Etcd, isIPv6 bool) (string, int, v1.UR
 
 // ManifestFilesAreEqual compares 2 files. It returns true if their contents are equal, false otherwise
 func ManifestFilesAreEqual(path1, path2 string) (bool, error) {
-	content1, err := ioutil.ReadFile(path1)
+	content1, err := os.ReadFile(path1)
 	if err != nil {
 		return false, err
 	}
-	content2, err := ioutil.ReadFile(path2)
+	content2, err := os.ReadFile(path2)
 	if err != nil {
 		return false, err
 	}

--- a/cmd/linkcheck/links.go
+++ b/cmd/linkcheck/links.go
@@ -23,7 +23,6 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -81,7 +80,7 @@ func newWalkFunc(invalidLink *bool, client *http.Client) filepath.WalkFunc {
 			return nil
 		}
 
-		fileBytes, err := ioutil.ReadFile(filePath)
+		fileBytes, err := os.ReadFile(filePath)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup


#### What this PR does / why we need it:
Starting 1.16 of Golang `io/ioutil` has been deprecated and the functionality has been reimplemented in other suitable packages. This PR aims to cleanup the usages of deprecated `io/ioutil` across the repo.

xref:  https://golang.org/doc/go1.16#ioutil

#### Which issue(s) this PR fixes:
Fixes #100367

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
NA

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
NA