### PR TITLE
gce configure containerd default_runtime_name

### DIFF
--- a/cluster/gce/gci/configure-helper.sh
+++ b/cluster/gce/gci/configure-helper.sh
@@ -3019,21 +3019,28 @@ EOF
     fi
   fi
   cat > "${config_path}" <<EOF
+version = 2
+# Kubernetes requires the cri plugin.
+required_plugins = ["io.containerd.grpc.v1.cri"]
 # Kubernetes doesn't use containerd restart manager.
-disabled_plugins = ["restart"]
+disabled_plugins = ["io.containerd.internal.v1.restart"]
 oom_score = -999
 
 [debug]
   level = "${CONTAINERD_LOG_LEVEL:-"info"}"
 
-[plugins.cri]
+[plugins."io.containerd.grpc.v1.cri"]
   stream_server_address = "127.0.0.1"
   max_container_log_line_size = ${CONTAINERD_MAX_CONTAINER_LOG_LINE:-262144}
-[plugins.cri.cni]
+[plugins."io.containerd.grpc.v1.cri".cni]
   bin_dir = "${KUBE_HOME}/bin"
   conf_dir = "/etc/cni/net.d"
   conf_template = "${cni_template_path}"
-[plugins.cri.registry.mirrors."docker.io"]
+[plugins."io.containerd.grpc.v1.cri".containerd]
+  default_runtime_name = "runc"
+[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc]
+  runtime_type = "io.containerd.runc.v2"
+[plugins."io.containerd.grpc.v1.cri".registry.mirrors."docker.io"]
   endpoint = ["https://mirror.gcr.io","https://registry-1.docker.io"]
 EOF
 
@@ -3041,8 +3048,8 @@ EOF
   cat >> "${config_path}" <<EOF
 # Setup a runtime with the magic name ("test-handler") used for Kubernetes
 # runtime class tests ...
-[plugins.cri.containerd.runtimes.test-handler]
-  runtime_type = "io.containerd.runtime.v1.linux"
+[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.test-handler]
+  runtime_type = "io.containerd.runc.v2"
 EOF
   fi
 


### PR DESCRIPTION
The presubmit job ipull-kubernetes-e2e-gce-ubuntu-containerd is failing to complete the installation since we bumped the containerd version to 1.5.0

https://testgrid.k8s.io/google-gce#pull-kubernetes-e2e-gce-ubuntu-containerd&width=5

The health-monitor.sh script fails with:
```
time="2021-04-10T20:32:25Z" level=fatal msg="listing pod sandboxes: rpc error: code = Unimplemented desc = unknown service runtime.v1alpha2.RuntimeService"
```

and containerd complains about: 
```
time="2021-04-10T20:32:25.933005839Z" level=warning msg="failed to load plugin io.containerd.grpc.v1.cri" error="invalid plugin config: no corresponding runtime configured in `runtimes` for `default_runtime_name`
```

/kind bug
```release-note
NONE
```

Fixes #100978 