### PR TITLE
Fix staticcheck failures for vendor/k8s.io/apiserver/pkg/registry/rest/resttest

### DIFF
--- a/hack/.staticcheck_failures
+++ b/hack/.staticcheck_failures
@@ -8,7 +8,6 @@ vendor/k8s.io/apimachinery/pkg/util/strategicpatch
 vendor/k8s.io/apimachinery/pkg/util/wait
 vendor/k8s.io/apiserver/pkg/endpoints/filters
 vendor/k8s.io/apiserver/pkg/endpoints/metrics
-vendor/k8s.io/apiserver/pkg/registry/rest/resttest
 vendor/k8s.io/apiserver/pkg/server/dynamiccertificates
 vendor/k8s.io/apiserver/pkg/server/filters
 vendor/k8s.io/apiserver/pkg/server/httplog


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Part of #92402

```
vendor/k8s.io/apiserver/pkg/registry/rest/resttest/resttest.go:915:18: func (*Tester).testDeleteWithResourceVersion is unused (U1000)
```

#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:


```docs

```
