### PR TITLE
code cleanup for pkg volume csi

### DIFF
--- a/pkg/volume/csi/csi_mounter_test.go
+++ b/pkg/volume/csi/csi_mounter_test.go
@@ -35,9 +35,7 @@ import (
 	authenticationv1 "k8s.io/api/authentication/v1"
 	api "k8s.io/api/core/v1"
 	storage "k8s.io/api/storage/v1"
-	storagev1 "k8s.io/api/storage/v1"
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -225,7 +223,7 @@ func TestMounterSetUp(t *testing.T) {
 					DetachError: nil,
 				},
 			}
-			_, err = csiMounter.k8s.StorageV1().VolumeAttachments().Create(context.TODO(), attachment, metav1.CreateOptions{})
+			_, err = csiMounter.k8s.StorageV1().VolumeAttachments().Create(context.TODO(), attachment, meta.CreateOptions{})
 			if err != nil {
 				t.Fatalf("failed to setup VolumeAttachment: %v", err)
 			}
@@ -352,7 +350,7 @@ func TestMounterSetUpSimple(t *testing.T) {
 
 			attachID := getAttachmentName(csiMounter.volumeID, string(csiMounter.driverName), string(plug.host.GetNodeName()))
 			attachment := makeTestAttachment(attachID, "test-node", csiMounter.spec.Name())
-			_, err = csiMounter.k8s.StorageV1().VolumeAttachments().Create(context.TODO(), attachment, metav1.CreateOptions{})
+			_, err = csiMounter.k8s.StorageV1().VolumeAttachments().Create(context.TODO(), attachment, meta.CreateOptions{})
 			if err != nil {
 				t.Fatalf("failed to setup VolumeAttachment: %v", err)
 			}
@@ -480,7 +478,7 @@ func TestMounterSetupWithStatusTracking(t *testing.T) {
 			if tc.createAttachment {
 				attachID := getAttachmentName(csiMounter.volumeID, string(csiMounter.driverName), string(plug.host.GetNodeName()))
 				attachment := makeTestAttachment(attachID, "test-node", csiMounter.spec.Name())
-				_, err = csiMounter.k8s.StorageV1().VolumeAttachments().Create(context.TODO(), attachment, metav1.CreateOptions{})
+				_, err = csiMounter.k8s.StorageV1().VolumeAttachments().Create(context.TODO(), attachment, meta.CreateOptions{})
 				if err != nil {
 					t.Fatalf("failed to setup VolumeAttachment: %v", err)
 				}
@@ -594,7 +592,7 @@ func TestMounterSetUpWithInline(t *testing.T) {
 			if csiMounter.volumeLifecycleMode == storage.VolumeLifecyclePersistent {
 				attachID := getAttachmentName(csiMounter.volumeID, string(csiMounter.driverName), string(plug.host.GetNodeName()))
 				attachment := makeTestAttachment(attachID, "test-node", csiMounter.spec.Name())
-				_, err = csiMounter.k8s.StorageV1().VolumeAttachments().Create(context.TODO(), attachment, metav1.CreateOptions{})
+				_, err = csiMounter.k8s.StorageV1().VolumeAttachments().Create(context.TODO(), attachment, meta.CreateOptions{})
 				if err != nil {
 					t.Fatalf("failed to setup VolumeAttachment: %v", err)
 				}
@@ -827,7 +825,7 @@ func TestMounterSetUpWithFSGroup(t *testing.T) {
 		attachID := getAttachmentName(csiMounter.volumeID, string(csiMounter.driverName), string(plug.host.GetNodeName()))
 		attachment := makeTestAttachment(attachID, "test-node", pvName)
 
-		_, err = csiMounter.k8s.StorageV1().VolumeAttachments().Create(context.TODO(), attachment, metav1.CreateOptions{})
+		_, err = csiMounter.k8s.StorageV1().VolumeAttachments().Create(context.TODO(), attachment, meta.CreateOptions{})
 		if err != nil {
 			t.Errorf("failed to setup VolumeAttachment: %v", err)
 			continue
@@ -950,28 +948,28 @@ func TestPodServiceAccountTokenAttrs(t *testing.T) {
 
 	tests := []struct {
 		desc              string
-		driver            *storagev1.CSIDriver
+		driver            *storage.CSIDriver
 		volumeContext     map[string]string
 		wantVolumeContext map[string]string
 	}{
 		{
 			desc: "csi driver has no ServiceAccountToken",
-			driver: &storagev1.CSIDriver{
+			driver: &storage.CSIDriver{
 				ObjectMeta: meta.ObjectMeta{
 					Name: testDriver,
 				},
-				Spec: storagev1.CSIDriverSpec{},
+				Spec: storage.CSIDriverSpec{},
 			},
 			wantVolumeContext: nil,
 		},
 		{
 			desc: "one token with empty string as audience",
-			driver: &storagev1.CSIDriver{
+			driver: &storage.CSIDriver{
 				ObjectMeta: meta.ObjectMeta{
 					Name: testDriver,
 				},
-				Spec: storagev1.CSIDriverSpec{
-					TokenRequests: []storagev1.TokenRequest{
+				Spec: storage.CSIDriverSpec{
+					TokenRequests: []storage.TokenRequest{
 						{
 							Audience: "",
 						},
@@ -982,12 +980,12 @@ func TestPodServiceAccountTokenAttrs(t *testing.T) {
 		},
 		{
 			desc: "one token with non-empty string as audience",
-			driver: &storagev1.CSIDriver{
+			driver: &storage.CSIDriver{
 				ObjectMeta: meta.ObjectMeta{
 					Name: testDriver,
 				},
-				Spec: storagev1.CSIDriverSpec{
-					TokenRequests: []storagev1.TokenRequest{
+				Spec: storage.CSIDriverSpec{
+					TokenRequests: []storage.TokenRequest{
 						{
 							Audience: gcp,
 						},
@@ -1017,7 +1015,7 @@ func TestPodServiceAccountTokenAttrs(t *testing.T) {
 					tr.Spec.Audiences = []string{"api"}
 				}
 				tr.Status.Token = fmt.Sprintf("%v:%v:%d:%v", action.GetNamespace(), testAccount, *tr.Spec.ExpirationSeconds, tr.Spec.Audiences)
-				tr.Status.ExpirationTimestamp = metav1.NewTime(time.Unix(1, 1))
+				tr.Status.ExpirationTimestamp = meta.NewTime(time.Unix(1, 1))
 				return true, tr, nil
 			}))
 			plug, tmpDir := newTestPlugin(t, client)

--- a/pkg/volume/csi/csi_plugin_test.go
+++ b/pkg/volume/csi/csi_plugin_test.go
@@ -27,9 +27,7 @@ import (
 	api "k8s.io/api/core/v1"
 	v1 "k8s.io/api/core/v1"
 	storage "k8s.io/api/storage/v1"
-	storagev1 "k8s.io/api/storage/v1"
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
@@ -68,7 +66,7 @@ func newTestPluginWithVolumeHost(t *testing.T, client *fakeclient.Clientset, hos
 	}
 
 	client.Tracker().Add(&v1.Node{
-		ObjectMeta: metav1.ObjectMeta{
+		ObjectMeta: meta.ObjectMeta{
 			Name: "fakeNode",
 		},
 		Spec: v1.NodeSpec{},
@@ -284,8 +282,8 @@ func TestPluginGetVolumeName(t *testing.T) {
 func TestPluginGetVolumeNameWithInline(t *testing.T) {
 	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.CSIInlineVolume, true)()
 
-	modes := []storagev1.VolumeLifecycleMode{
-		storagev1.VolumeLifecyclePersistent,
+	modes := []storage.VolumeLifecycleMode{
+		storage.VolumeLifecyclePersistent,
 	}
 	driver := getTestCSIDriver(testDriver, nil, nil, modes)
 	client := fakeclient.NewSimpleClientset(driver)
@@ -517,7 +515,7 @@ func TestPluginConstructVolumeSpecWithInline(t *testing.T) {
 		volHandle  string
 		podUID     types.UID
 		shouldFail bool
-		modes      []storagev1.VolumeLifecycleMode
+		modes      []storage.VolumeLifecycleMode
 	}{
 		{
 			name:       "construct spec1 from persistent spec",
@@ -525,7 +523,7 @@ func TestPluginConstructVolumeSpecWithInline(t *testing.T) {
 			volHandle:  "testvol-handle1",
 			originSpec: volume.NewSpecFromPersistentVolume(makeTestPV("test.vol.id", 20, testDriver, "testvol-handle1"), true),
 			podUID:     types.UID(fmt.Sprintf("%08X", rand.Uint64())),
-			modes:      []storagev1.VolumeLifecycleMode{storagev1.VolumeLifecyclePersistent},
+			modes:      []storage.VolumeLifecycleMode{storage.VolumeLifecyclePersistent},
 		},
 		{
 			name:       "construct spec2 from persistent spec",
@@ -533,7 +531,7 @@ func TestPluginConstructVolumeSpecWithInline(t *testing.T) {
 			volHandle:  "handle2",
 			originSpec: volume.NewSpecFromPersistentVolume(makeTestPV("spec2", 20, testDriver, "handle2"), true),
 			podUID:     types.UID(fmt.Sprintf("%08X", rand.Uint64())),
-			modes:      []storagev1.VolumeLifecycleMode{storagev1.VolumeLifecyclePersistent},
+			modes:      []storage.VolumeLifecycleMode{storage.VolumeLifecyclePersistent},
 		},
 		{
 			name:       "construct spec2 from persistent spec, missing mode",
@@ -541,7 +539,7 @@ func TestPluginConstructVolumeSpecWithInline(t *testing.T) {
 			volHandle:  "handle2",
 			originSpec: volume.NewSpecFromPersistentVolume(makeTestPV("spec2", 20, testDriver, "handle2"), true),
 			podUID:     types.UID(fmt.Sprintf("%08X", rand.Uint64())),
-			modes:      []storagev1.VolumeLifecycleMode{},
+			modes:      []storage.VolumeLifecycleMode{},
 			shouldFail: true,
 		},
 		{
@@ -549,21 +547,21 @@ func TestPluginConstructVolumeSpecWithInline(t *testing.T) {
 			specVolID:  "volspec",
 			originSpec: volume.NewSpecFromVolume(makeTestVol("volspec", testDriver)),
 			podUID:     types.UID(fmt.Sprintf("%08X", rand.Uint64())),
-			modes:      []storagev1.VolumeLifecycleMode{storagev1.VolumeLifecycleEphemeral},
+			modes:      []storage.VolumeLifecycleMode{storage.VolumeLifecycleEphemeral},
 		},
 		{
 			name:       "construct spec from volume spec2",
 			specVolID:  "volspec2",
 			originSpec: volume.NewSpecFromVolume(makeTestVol("volspec2", testDriver)),
 			podUID:     types.UID(fmt.Sprintf("%08X", rand.Uint64())),
-			modes:      []storagev1.VolumeLifecycleMode{storagev1.VolumeLifecycleEphemeral},
+			modes:      []storage.VolumeLifecycleMode{storage.VolumeLifecycleEphemeral},
 		},
 		{
 			name:       "construct spec from volume spec2, missing mode",
 			specVolID:  "volspec2",
 			originSpec: volume.NewSpecFromVolume(makeTestVol("volspec2", testDriver)),
 			podUID:     types.UID(fmt.Sprintf("%08X", rand.Uint64())),
-			modes:      []storagev1.VolumeLifecycleMode{},
+			modes:      []storage.VolumeLifecycleMode{},
 			shouldFail: true,
 		},
 		{
@@ -653,7 +651,7 @@ func TestPluginNewMounter(t *testing.T) {
 		spec                *volume.Spec
 		podUID              types.UID
 		namespace           string
-		volumeLifecycleMode storagev1.VolumeLifecycleMode
+		volumeLifecycleMode storage.VolumeLifecycleMode
 		shouldFail          bool
 	}{
 		{
@@ -661,14 +659,14 @@ func TestPluginNewMounter(t *testing.T) {
 			spec:                volume.NewSpecFromPersistentVolume(makeTestPV("test-pv1", 20, testDriver, testVol), true),
 			podUID:              types.UID(fmt.Sprintf("%08X", rand.Uint64())),
 			namespace:           "test-ns1",
-			volumeLifecycleMode: storagev1.VolumeLifecyclePersistent,
+			volumeLifecycleMode: storage.VolumeLifecyclePersistent,
 		},
 		{
 			name:                "mounter from volume source",
 			spec:                volume.NewSpecFromVolume(makeTestVol("test-vol1", testDriver)),
 			podUID:              types.UID(fmt.Sprintf("%08X", rand.Uint64())),
 			namespace:           "test-ns2",
-			volumeLifecycleMode: storagev1.VolumeLifecycleEphemeral,
+			volumeLifecycleMode: storage.VolumeLifecycleEphemeral,
 			shouldFail:          true, // csi inline not enabled
 		},
 		{
@@ -760,22 +758,22 @@ func TestPluginNewMounter(t *testing.T) {
 
 func TestPluginNewMounterWithInline(t *testing.T) {
 	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.CSIInlineVolume, true)()
-	bothModes := []storagev1.VolumeLifecycleMode{
-		storagev1.VolumeLifecycleEphemeral,
-		storagev1.VolumeLifecyclePersistent,
+	bothModes := []storage.VolumeLifecycleMode{
+		storage.VolumeLifecycleEphemeral,
+		storage.VolumeLifecyclePersistent,
 	}
-	persistentMode := []storagev1.VolumeLifecycleMode{
-		storagev1.VolumeLifecyclePersistent,
+	persistentMode := []storage.VolumeLifecycleMode{
+		storage.VolumeLifecyclePersistent,
 	}
-	ephemeralMode := []storagev1.VolumeLifecycleMode{
-		storagev1.VolumeLifecycleEphemeral,
+	ephemeralMode := []storage.VolumeLifecycleMode{
+		storage.VolumeLifecycleEphemeral,
 	}
 	tests := []struct {
 		name                string
 		spec                *volume.Spec
 		podUID              types.UID
 		namespace           string
-		volumeLifecycleMode storagev1.VolumeLifecycleMode
+		volumeLifecycleMode storage.VolumeLifecycleMode
 		shouldFail          bool
 	}{
 		{
@@ -796,18 +794,18 @@ func TestPluginNewMounterWithInline(t *testing.T) {
 			spec:                volume.NewSpecFromPersistentVolume(makeTestPV("test-pv1", 20, testDriver, testVol), true),
 			podUID:              types.UID(fmt.Sprintf("%08X", rand.Uint64())),
 			namespace:           "test-ns1",
-			volumeLifecycleMode: storagev1.VolumeLifecyclePersistent,
+			volumeLifecycleMode: storage.VolumeLifecyclePersistent,
 		},
 		{
 			name:                "mounter with volume source",
 			spec:                volume.NewSpecFromVolume(makeTestVol("test-vol1", testDriver)),
 			podUID:              types.UID(fmt.Sprintf("%08X", rand.Uint64())),
 			namespace:           "test-ns2",
-			volumeLifecycleMode: storagev1.VolumeLifecycleEphemeral,
+			volumeLifecycleMode: storage.VolumeLifecycleEphemeral,
 		},
 	}
 
-	runAll := func(t *testing.T, supported []storagev1.VolumeLifecycleMode) {
+	runAll := func(t *testing.T, supported []storage.VolumeLifecycleMode) {
 		for _, test := range tests {
 			t.Run(test.name, func(t *testing.T) {
 				driver := getTestCSIDriver(testDriver, nil, nil, supported)
@@ -1097,7 +1095,7 @@ func TestPluginFindAttachablePlugin(t *testing.T) {
 			client := fakeclient.NewSimpleClientset(
 				getTestCSIDriver(test.driverName, nil, &test.canAttach, nil),
 				&v1.Node{
-					ObjectMeta: metav1.ObjectMeta{
+					ObjectMeta: meta.ObjectMeta{
 						Name: "fakeNode",
 					},
 					Spec: v1.NodeSpec{},
@@ -1224,7 +1222,7 @@ func TestPluginFindDeviceMountablePluginBySpec(t *testing.T) {
 
 			client := fakeclient.NewSimpleClientset(
 				&v1.Node{
-					ObjectMeta: metav1.ObjectMeta{
+					ObjectMeta: meta.ObjectMeta{
 						Name: "fakeNode",
 					},
 					Spec: v1.NodeSpec{},

--- a/pkg/volume/csi/csi_test.go
+++ b/pkg/volume/csi/csi_test.go
@@ -25,11 +25,8 @@ import (
 	"time"
 
 	api "k8s.io/api/core/v1"
-	v1 "k8s.io/api/core/v1"
 	storage "k8s.io/api/storage/v1"
-	storagev1 "k8s.io/api/storage/v1"
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -47,7 +44,7 @@ import (
 // based on operations from the volume manager/reconciler/operation executor
 func TestCSI_VolumeAll(t *testing.T) {
 	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.CSIInlineVolume, true)()
-	defaultFSGroupPolicy := storagev1.ReadWriteOnceWithFSTypeFSGroupPolicy
+	defaultFSGroupPolicy := storage.ReadWriteOnceWithFSTypeFSGroupPolicy
 
 	tests := []struct {
 		name                            string
@@ -259,18 +256,18 @@ func TestCSI_VolumeAll(t *testing.T) {
 			objs := []runtime.Object{}
 			if test.driverSpec != nil {
 				driverInfo = &storage.CSIDriver{
-					ObjectMeta: metav1.ObjectMeta{
+					ObjectMeta: meta.ObjectMeta{
 						Name: test.driver,
 					},
 					Spec: *test.driverSpec,
 				}
 				objs = append(objs, driverInfo)
 			}
-			objs = append(objs, &v1.Node{
-				ObjectMeta: metav1.ObjectMeta{
+			objs = append(objs, &api.Node{
+				ObjectMeta: meta.ObjectMeta{
 					Name: "fakeNode",
 				},
-				Spec: v1.NodeSpec{},
+				Spec: api.NodeSpec{},
 			})
 
 			client := fakeclient.NewSimpleClientset(objs...)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
ST1019 – Importing the same package multiple times
https://staticcheck.io/docs/checks#ST1019
```
k8s.io/kubernetes/pkg/volume/csi/csi_mounter_test.go:37:2: package "k8s.io/api/storage/v1" is being imported more than once (ST1019)
k8s.io/kubernetes/pkg/volume/csi/csi_mounter_test.go:38:2: other import of "k8s.io/api/storage/v1"
k8s.io/kubernetes/pkg/volume/csi/csi_mounter_test.go:39:2: package "k8s.io/apimachinery/pkg/apis/meta/v1" is being imported more than once (ST1019)
k8s.io/kubernetes/pkg/volume/csi/csi_plugin_test.go:27:2: package "k8s.io/api/core/v1" is being imported more than once (ST1019)
k8s.io/kubernetes/pkg/volume/csi/csi_plugin_test.go:28:2: other import of "k8s.io/api/core/v1"
k8s.io/kubernetes/pkg/volume/csi/csi_plugin_test.go:30:2: package "k8s.io/apimachinery/pkg/apis/meta/v1" is being imported more than once (ST1019)
k8s.io/kubernetes/pkg/volume/csi/csi_plugin_test.go:31:2: other import of "k8s.io/apimachinery/pkg/apis/meta/v1"
k8s.io/kubernetes/pkg/volume/csi/csi_test.go:27:2: package "k8s.io/api/core/v1" is being imported more than once (ST1019)
k8s.io/kubernetes/pkg/volume/csi/csi_test.go:28:2: other import of "k8s.io/api/core/v1"
k8s.io/kubernetes/pkg/volume/csi/csi_test.go:29:2: package "k8s.io/api/storage/v1" is being imported more than once (ST1019)
k8s.io/kubernetes/pkg/volume/csi/csi_test.go:30:2: other import of "k8s.io/api/storage/v1"
k8s.io/kubernetes/pkg/volume/csi/csi_test.go:31:2: package "k8s.io/apimachinery/pkg/apis/meta/v1" is being imported more than once (ST1019)
k8s.io/kubernetes/pkg/volume/csi/csi_test.go:32:2: other import of "k8s.io/apimachinery/pkg/apis/meta/v1"
```
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
