### PR TITLE
code cleanup for kubectl

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/autoscale/autoscale.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/autoscale/autoscale.go
@@ -121,7 +121,7 @@ func NewCmdAutoscale(f cmdutil.Factory, ioStreams genericclioptions.IOStreams) *
 	cmd.Flags().Int32Var(&o.Min, "min", -1, "The lower limit for the number of pods that can be set by the autoscaler. If it's not specified or negative, the server will apply a default value.")
 	cmd.Flags().Int32Var(&o.Max, "max", -1, "The upper limit for the number of pods that can be set by the autoscaler. Required.")
 	cmd.MarkFlagRequired("max")
-	cmd.Flags().Int32Var(&o.CPUPercent, "cpu-percent", -1, fmt.Sprintf("The target average CPU utilization (represented as a percent of requested CPU) over all the pods. If it's not specified or negative, a default autoscaling policy will be used."))
+	cmd.Flags().Int32Var(&o.CPUPercent, "cpu-percent", -1, "The target average CPU utilization (represented as a percent of requested CPU) over all the pods. If it's not specified or negative, a default autoscaling policy will be used.")
 	cmd.Flags().StringVar(&o.Name, "name", "", i18n.T("The name for the newly created object. If not specified, the name of the input resource will be used."))
 	cmdutil.AddDryRunFlag(cmd)
 	cmdutil.AddFilenameOptionFlags(cmd, o.FilenameOptions, "identifying the resource to autoscale.")

--- a/staging/src/k8s.io/kubectl/pkg/cmd/certificates/certificates.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/certificates/certificates.go
@@ -26,7 +26,6 @@ import (
 	certificatesv1 "k8s.io/api/certificates/v1"
 	certificatesv1beta1 "k8s.io/api/certificates/v1beta1"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -251,7 +250,7 @@ func (o *CertificateOptions) modifyCertificateCondition(builder *resource.Builde
 				default:
 					return fmt.Errorf("can only handle certificates.k8s.io CertificateSigningRequest objects, got %T", modifiedCSR)
 				}
-				if errors.IsConflict(err) && i < 10 {
+				if apierrors.IsConflict(err) && i < 10 {
 					if err := info.Get(); err != nil {
 						return err
 					}

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_ingress.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_ingress.go
@@ -320,8 +320,7 @@ func (o *CreateIngressOptions) buildIngressSpec() networkingv1.IngressSpec {
 }
 
 func (o *CreateIngressOptions) buildTLSRules() []networkingv1.IngressTLS {
-	var hostAlreadyPresent map[string]struct{}
-	hostAlreadyPresent = make(map[string]struct{})
+	hostAlreadyPresent := make(map[string]struct{})
 
 	ingressTLSs := []networkingv1.IngressTLS{}
 	var secret string

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_ingress_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_ingress_test.go
@@ -20,7 +20,6 @@ import (
 	"testing"
 
 	networkingv1 "k8s.io/api/networking/v1"
-	v1 "k8s.io/api/networking/v1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -192,7 +191,7 @@ func TestCreateIngress(t *testing.T) {
 							},
 						},
 					},
-					TLS: []v1.IngressTLS{},
+					TLS: []networkingv1.IngressTLS{},
 					Rules: []networkingv1.IngressRule{
 						{
 							Host: "",
@@ -245,7 +244,7 @@ func TestCreateIngress(t *testing.T) {
 							},
 						},
 					},
-					TLS: []v1.IngressTLS{
+					TLS: []networkingv1.IngressTLS{
 						{
 							SecretName: "secret1",
 						},
@@ -305,7 +304,7 @@ func TestCreateIngress(t *testing.T) {
 							},
 						},
 					},
-					TLS: []v1.IngressTLS{
+					TLS: []networkingv1.IngressTLS{
 						{
 							Hosts: []string{
 								"foo.com",
@@ -456,7 +455,7 @@ func TestCreateIngress(t *testing.T) {
 					},
 				},
 				Spec: networkingv1.IngressSpec{
-					TLS: []v1.IngressTLS{
+					TLS: []networkingv1.IngressTLS{
 						{
 							Hosts: []string{
 								"foo.com",

--- a/staging/src/k8s.io/kubectl/pkg/cmd/debug/debug_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/debug/debug_test.go
@@ -26,7 +26,6 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/spf13/cobra"
 	corev1 "k8s.io/api/core/v1"
-	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	cmdtesting "k8s.io/kubectl/pkg/cmd/testing"
@@ -1272,7 +1271,7 @@ func TestCompleteAndValidate(t *testing.T) {
 			args: "--image=busybox --env=FOO=BAR mypod",
 			wantOpts: &DebugOptions{
 				Args:           []string{},
-				Env:            []v1.EnvVar{{Name: "FOO", Value: "BAR"}},
+				Env:            []corev1.EnvVar{{Name: "FOO", Value: "BAR"}},
 				Image:          "busybox",
 				Namespace:      "test",
 				ShareProcesses: true,

--- a/staging/src/k8s.io/kubectl/pkg/cmd/get/get_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/get/get_test.go
@@ -19,7 +19,6 @@ package get
 import (
 	"bytes"
 	"encoding/json"
-	encjson "encoding/json"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -124,13 +123,13 @@ func TestGetUnknownSchemaObject(t *testing.T) {
 	for i, obj := range actual {
 		expectedJSON := runtime.EncodeOrDie(codec, expected[i])
 		expectedMap := map[string]interface{}{}
-		if err := encjson.Unmarshal([]byte(expectedJSON), &expectedMap); err != nil {
+		if err := json.Unmarshal([]byte(expectedJSON), &expectedMap); err != nil {
 			t.Fatal(err)
 		}
 
 		actualJSON := runtime.EncodeOrDie(codec, obj)
 		actualMap := map[string]interface{}{}
-		if err := encjson.Unmarshal([]byte(actualJSON), &actualMap); err != nil {
+		if err := json.Unmarshal([]byte(actualJSON), &actualMap); err != nil {
 			t.Fatal(err)
 		}
 
@@ -879,7 +878,7 @@ func TestGetSortedObjectsUnstructuredTable(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	unstructuredBytes, err := encjson.MarshalIndent(unstructuredMap, "", "  ")
+	unstructuredBytes, err := json.MarshalIndent(unstructuredMap, "", "  ")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/staging/src/k8s.io/kubectl/pkg/describe/describe.go
+++ b/staging/src/k8s.io/kubectl/pkg/describe/describe.go
@@ -53,7 +53,6 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 	schedulingv1 "k8s.io/api/scheduling/v1"
 	storagev1 "k8s.io/api/storage/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -413,7 +412,7 @@ func (d *NamespaceDescriber) Describe(namespace, name string, describerSettings 
 			return newList, nil
 		})
 	if err != nil {
-		if errors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			// Server does not support resource quotas.
 			// Not an error, will not show resource quotas information.
 			resourceQuotaList = nil
@@ -433,7 +432,7 @@ func (d *NamespaceDescriber) Describe(namespace, name string, describerSettings 
 			return newList, nil
 		})
 	if err != nil {
-		if errors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			// Server does not support limit ranges.
 			// Not an error, will not show limit ranges information.
 			limitRangeList = nil
@@ -3483,7 +3482,7 @@ func (d *NodeDescriber) Describe(namespace, name string, describerSettings Descr
 	}
 	nodeNonTerminatedPodsList, err := getPodsInChunks(d.CoreV1().Pods(namespace), initialOpts)
 	if err != nil {
-		if !errors.IsForbidden(err) {
+		if !apierrors.IsForbidden(err) {
 			return "", err
 		}
 		canViewPods = false


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
1. remove unnecessary use of fmt.Sprintf
2. remove repeated package import
```
k8s.io/kubernetes/staging/src/k8s.io/kubectl/pkg/cmd/autoscale/autoscale.go:126:57: unnecessary use of fmt.Sprintf (S1039)
k8s.io/kubernetes/staging/src/k8s.io/kubectl/pkg/cmd/certificates/certificates.go:29:2: package "k8s.io/apimachinery/pkg/api/errors" is being imported more than once (ST1019)
k8s.io/kubernetes/staging/src/k8s.io/kubectl/pkg/cmd/certificates/certificates.go:30:2: other import of "k8s.io/apimachinery/pkg/api/errors"
k8s.io/kubernetes/staging/src/k8s.io/kubectl/pkg/cmd/create/create_ingress.go:288:2: should merge variable declaration with assignment on next line (S1021)
k8s.io/kubernetes/staging/src/k8s.io/kubectl/pkg/cmd/create/create_ingress.go:317:2: should merge variable declaration with assignment on next line (S1021)
k8s.io/kubernetes/staging/src/k8s.io/kubectl/pkg/cmd/create/create_ingress_test.go:22:2: package "k8s.io/api/networking/v1" is being imported more than once (ST1019)
k8s.io/kubernetes/staging/src/k8s.io/kubectl/pkg/cmd/create/create_ingress_test.go:23:2: other import of "k8s.io/api/networking/v1"
k8s.io/kubernetes/staging/src/k8s.io/kubectl/pkg/cmd/debug/debug_test.go:28:2: package "k8s.io/api/core/v1" is being imported more than once (ST1019)
k8s.io/kubernetes/staging/src/k8s.io/kubectl/pkg/cmd/debug/debug_test.go:29:2: other import of "k8s.io/api/core/v1"
k8s.io/kubernetes/staging/src/k8s.io/kubectl/pkg/cmd/get/get_test.go:21:2: package "encoding/json" is being imported more than once (ST1019)
k8s.io/kubernetes/staging/src/k8s.io/kubectl/pkg/cmd/get/get_test.go:22:2: other import of "encoding/json"
k8s.io/kubernetes/staging/src/k8s.io/kubectl/pkg/describe/describe.go:55:2: package "k8s.io/apimachinery/pkg/api/errors" is being imported more than once (ST1019)
k8s.io/kubernetes/staging/src/k8s.io/kubectl/pkg/describe/describe.go:56:2: other import of "k8s.io/apimachinery/pkg/api/errors"
```
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
