### PR TITLE
frequently flake ut: exec test should not run in Parallel as feature gate is not locked yet

### DIFF
--- a/pkg/kubelet/dockershim/exec_test.go
+++ b/pkg/kubelet/dockershim/exec_test.go
@@ -143,9 +143,9 @@ func TestExecInContainer(t *testing.T) {
 	var resize <-chan remotecommand.TerminalSize
 
 	for _, tc := range testcases {
+		// these tests cannot be run in parallel due to the fact that they are feature gate dependent
 		tc := tc
 		t.Run(tc.description, func(t *testing.T) {
-			t.Parallel()
 			defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.ExecProbeTimeout, tc.execProbeTimeout)()
 
 			mockClient := mockclient.NewMockInterface(ctrl)


### PR DESCRIPTION
#### What type of PR is this?
/kind flake

#### What this PR does / why we need it:
TestExecInContainer failed a lot in recent `pull-kubernetes-unit`.

#### Which issue(s) this PR fixes:
failed example: https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/100612/pull-kubernetes-unit/1381446475732488192

#### Special notes for your reviewer:

the flake is from #100200 which is merged 1 day ago.

The test case will run in only **6 seconds** without `t.Parallel()`.

#### Does this PR introduce a user-facing change?

```release-note
None
```
