### PR TITLE
Fix panic when killing container fails

### DIFF
--- a/pkg/kubelet/kuberuntime/kuberuntime_container.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_container.go
@@ -687,7 +687,8 @@ func (m *kubeGenericRuntimeManager) killContainersWithSyncResult(pod *v1.Pod, ru
 			killContainerResult := kubecontainer.NewSyncResult(kubecontainer.KillContainer, container.Name)
 			if err := m.killContainer(pod, container.ID, container.Name, "", reasonUnknown, gracePeriodOverride); err != nil {
 				killContainerResult.Fail(kubecontainer.ErrKillContainer, err.Error())
-				klog.ErrorS(err, "Kill container failed", "pod", klog.KObj(pod), "podUID", pod.UID,
+				// Use runningPod for logging as the pod passed in could be *nil*.
+				klog.ErrorS(err, "Kill container failed", "pod", klog.KRef(runningPod.Namespace, runningPod.Name), "podUID", runningPod.ID,
 					"containerName", container.Name, "containerID", container.ID)
 			}
 			containerResults <- killContainerResult


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Observed some panic logs in kubelet when running Kubernetes v1.21.0.
```
Apr 09 11:25:43 k8s01 kubelet[32695]: E0409 11:25:43.816993   32695 runtime.go:78] Observed a panic: "invalid memory address or nil pointer dereference" (runtime error: invalid memory address or nil pointer dereference)
Apr 09 11:25:43 k8s01 kubelet[32695]: goroutine 150290 [running]:
Apr 09 11:25:43 k8s01 kubelet[32695]: k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/util/runtime.logPanic(0x41d7a00, 0x738f320)
Apr 09 11:25:43 k8s01 kubelet[32695]:         /workspace/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:74 +0x95
Apr 09 11:25:43 k8s01 kubelet[32695]: k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/util/runtime.HandleCrash(0x0, 0x0, 0x0)
Apr 09 11:25:43 k8s01 kubelet[32695]:         /workspace/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:48 +0x86
Apr 09 11:25:43 k8s01 kubelet[32695]: panic(0x41d7a00, 0x738f320)
Apr 09 11:25:43 k8s01 kubelet[32695]:         /usr/local/go/src/runtime/panic.go:965 +0x1b9
Apr 09 11:25:43 k8s01 kubelet[32695]: k8s.io/kubernetes/pkg/kubelet/kuberuntime.(*kubeGenericRuntimeManager).killContainersWithSyncResult.func1(0xc00145e8d0, 0xc000de0b00, 0x0, 0x0, 0xc002993980, 0xc000b21ab0)
Apr 09 11:25:43 k8s01 kubelet[32695]:         /workspace/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/pkg/kubelet/kuberuntime/kuberuntime_container.go:690 +0x33a
Apr 09 11:25:43 k8s01 kubelet[32695]: created by k8s.io/kubernetes/pkg/kubelet/kuberuntime.(*kubeGenericRuntimeManager).killContainersWithSyncResult
Apr 09 11:25:43 k8s01 kubelet[32695]:         /workspace/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/pkg/kubelet/kuberuntime/kuberuntime_container.go:683 +0x105
Apr 09 11:25:43 k8s01 kubelet[32695]: E0409 11:25:43.817252   32695 runtime.go:78] Observed a panic: "invalid memory address or nil pointer dereference" (runtime error: invalid memory address or nil pointer dereference)
Apr 09 11:25:43 k8s01 kubelet[32695]: goroutine 150291 [running]:
Apr 09 11:25:43 k8s01 kubelet[32695]: k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/util/runtime.logPanic(0x41d7a00, 0x738f320)
Apr 09 11:25:43 k8s01 kubelet[32695]:         /workspace/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:74 +0x95
Apr 09 11:25:43 k8s01 kubelet[32695]: k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/util/runtime.HandleCrash(0x0, 0x0, 0x0)
Apr 09 11:25:43 k8s01 kubelet[32695]:         /workspace/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:48 +0x86
Apr 09 11:25:43 k8s01 kubelet[32695]: panic(0x41d7a00, 0x738f320)
Apr 09 11:25:43 k8s01 kubelet[32695]:         /usr/local/go/src/runtime/panic.go:965 +0x1b9
Apr 09 11:25:43 k8s01 kubelet[32695]: k8s.io/kubernetes/pkg/kubelet/kuberuntime.(*kubeGenericRuntimeManager).killContainersWithSyncResult.func1(0xc00145e8d0, 0xc000de0b00, 0x0, 0x0, 0xc002993980, 0xc000b21b20)
Apr 09 11:25:43 k8s01 kubelet[32695]:         /workspace/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/pkg/kubelet/kuberuntime/kuberuntime_container.go:690 +0x33a
Apr 09 11:25:43 k8s01 kubelet[32695]: created by k8s.io/kubernetes/pkg/kubelet/kuberuntime.(*kubeGenericRuntimeManager).killContainersWithSyncResult
Apr 09 11:25:43 k8s01 kubelet[32695]:         /workspace/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/pkg/kubelet/kuberuntime/kuberuntime_container.go:683 +0x105
```

It could happen when housekeeping cleans pods, in which situation `pod` will be set to `nil`.
https://github.com/kubernetes/kubernetes/blob/6af7eb6d494d8f742e18a3b965053e3a518bf6d7/pkg/kubelet/kubelet_pods.go#L1112
It should be introduced by https://github.com/kubernetes/kubernetes/commit/68457812f32f50811672a7c8f6f99307e5abeccf.

As `pod` could be `nil`, this patch fixes it by using `runningPod` for logging, which has same information.
With the patch, the log will be:
```
Apr 12 05:51:04 k8s01 kubelet[2466]: E0412 05:51:04.467589    2466 kuberuntime_container.go:691] "Kill container failed" err="rpc error: code = Unknown desc = Error: No such container: f5e9e8a4b23745326227c32543fdc6d427c56093fa907d1f3c6fb0e748dc2b99" pod="kube-system/antrea-agent-6pkcv" podUID=193c42b8-25ba-4471-8ef4-2f0f6341bf95 containerName="antrea-agent" containerID={Type:docker ID:f5e9e8a4b23745326227c32543fdc6d427c56093fa907d1f3c6fb0e748dc2b99}
Apr 12 05:51:04 k8s01 kubelet[2466]: E0412 05:51:04.467729    2466 kuberuntime_container.go:691] "Kill container failed" err="rpc error: code = Unknown desc = Error: No such container: 9ab066a4edd898fbb1c87a453f7a8dd8b0874f5a148ac2fea66d038af984fd10" pod="kube-system/antrea-agent-6pkcv" podUID=193c42b8-25ba-4471-8ef4-2f0f6341bf95 containerName="antrea-ovs" containerID={Type:docker ID:9ab066a4edd898fbb1c87a453f7a8dd8b0874f5a148ac2fea66d038af984fd10}
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fixes regression in 1.21 where kubelet can panic killing a container
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
