### PR TITLE
skip some UT on mac for dockershim

### DIFF
--- a/pkg/kubelet/dockershim/docker_sandbox_linux_test.go
+++ b/pkg/kubelet/dockershim/docker_sandbox_linux_test.go
@@ -1,0 +1,38 @@
+// +build linux,!dockerless
+
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dockershim
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestSandboxHasLeastPrivilegesConfig tests that the sandbox is set with no-new-privileges
+// and it uses runtime/default seccomp profile.
+func TestSandboxHasLeastPrivilegesConfig(t *testing.T) {
+	ds, _, _ := newTestDockerService()
+	config := makeSandboxConfig("foo", "bar", "1", 0)
+
+	// test the default
+	createConfig, err := ds.makeSandboxDockerConfig(config, defaultSandboxImage)
+	assert.NoError(t, err)
+	assert.Equal(t, len(createConfig.HostConfig.SecurityOpt), 1, "sandbox should use runtime/default")
+	assert.Equal(t, "no-new-privileges", createConfig.HostConfig.SecurityOpt[0], "no-new-privileges not set")
+}

--- a/pkg/kubelet/dockershim/docker_sandbox_test.go
+++ b/pkg/kubelet/dockershim/docker_sandbox_test.go
@@ -156,19 +156,6 @@ func TestSandboxStatus(t *testing.T) {
 	assert.Error(t, err, fmt.Sprintf("status of sandbox: %+v", statusResp))
 }
 
-// TestSandboxHasLeastPrivilegesConfig tests that the sandbox is set with no-new-privileges
-// and it uses runtime/default seccomp profile.
-func TestSandboxHasLeastPrivilegesConfig(t *testing.T) {
-	ds, _, _ := newTestDockerService()
-	config := makeSandboxConfig("foo", "bar", "1", 0)
-
-	// test the default
-	createConfig, err := ds.makeSandboxDockerConfig(config, defaultSandboxImage)
-	assert.NoError(t, err)
-	assert.Equal(t, len(createConfig.HostConfig.SecurityOpt), 1, "sandbox should use runtime/default")
-	assert.Equal(t, "no-new-privileges", createConfig.HostConfig.SecurityOpt[0], "no-new-privileges not set")
-}
-
 // TestSandboxStatusAfterRestart tests that retrieving sandbox status returns
 // an IP address even if RunPodSandbox() was not yet called for this pod, as
 // would happen on kubelet restart

--- a/pkg/kubelet/dockershim/docker_stats_test.go
+++ b/pkg/kubelet/dockershim/docker_stats_test.go
@@ -1,4 +1,4 @@
-// +build !dockerless
+// +build linux,!dockerless
 
 /*
 Copyright 2019 The Kubernetes Authors.


### PR DESCRIPTION
#### What type of PR is this?
/kind failing-test

#### What this PR does / why we need it:
`make test KUBE_RACE=-race KUBE_TIMEOUT=--timeout=240s WHAT=./pkg/kubelet/dockershim  KUBE_COVER=y  GOFLAGS=-v
`

local UT running failed on ./pkg/kubelet/dockershim
Some cases are linux only. When unsupported logic is involved, the test case failed. 
It makes me fail to run UT on Mac.

#### Which issue(s) this PR fixes:

Fixes None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
None
```
