### PR TITLE
Switch fluentd-gcp-scaler policy to non deprecated api.

### DIFF
--- a/cluster/addons/fluentd-gcp/scaler-policy.yaml
+++ b/cluster/addons/fluentd-gcp/scaler-policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: scalingpolicies.scalingpolicy.kope.io
@@ -6,7 +6,8 @@ metadata:
     addonmanager.kubernetes.io/mode: Reconcile
 spec:
   group: scalingpolicy.kope.io
-  version: v1alpha1
+  versions:
+    - name: v1alpha1
   names:
     kind: ScalingPolicy
     plural: scalingpolicies


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
Starting from Kubernetes 1.22 apiextensions.k8s.io/v1beta1 is removed.
Instead apiextensions.k8s.io/v1 should be used: https://kubernetes.io/docs/reference/using-api/deprecation-guide/#customresourcedefinition-v122

```release-note
NONE
```