### PR TITLE
Fixes zone/region labels setup and kubelet stucking on startup if credentials stored in secret for legacy vSphere cloudprovider.

### DIFF
--- a/staging/src/k8s.io/legacy-cloud-providers/vsphere/vsphere.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/vsphere/vsphere.go
@@ -904,6 +904,10 @@ func (vs *VSphere) LoadBalancer() (cloudprovider.LoadBalancer, bool) {
 
 func (vs *VSphere) isZoneEnabled() bool {
 	isEnabled := vs.cfg != nil && vs.cfg.Labels.Zone != "" && vs.cfg.Labels.Region != ""
+	// Return false within kubelet in case of credentials stored in secret.
+	// Otherwise kubelet will not be able to obtain zone labels from vSphere and create initial node
+	// due to no credentials at this step.
+	// See https://github.com/kubernetes/kubernetes/blob/b960f7a0e04687c17e0b0801e17e7cab89f273cc/pkg/kubelet/kubelet_node_status.go#L384-L386
 	if isEnabled && vs.isSecretInfoProvided && vs.nodeManager.credentialManager == nil {
 		klog.V(1).Info("Zones can not be populated now due to credentials in Secret, skip.")
 		return false

--- a/staging/src/k8s.io/legacy-cloud-providers/vsphere/vsphere.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/vsphere/vsphere.go
@@ -24,8 +24,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"net"
 	"net/url"
@@ -46,6 +44,8 @@ import (
 	"github.com/vmware/govmomi/vim25/mo"
 	vmwaretypes "github.com/vmware/govmomi/vim25/types"
 	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8stypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/informers"

--- a/staging/src/k8s.io/legacy-cloud-providers/vsphere/vsphere.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/vsphere/vsphere.go
@@ -896,7 +896,12 @@ func (vs *VSphere) LoadBalancer() (cloudprovider.LoadBalancer, bool) {
 }
 
 func (vs *VSphere) isZoneEnabled() bool {
-	return vs.cfg != nil && vs.cfg.Labels.Zone != "" && vs.cfg.Labels.Region != ""
+	isEnabled := vs.cfg != nil && vs.cfg.Labels.Zone != "" && vs.cfg.Labels.Region != ""
+	if isEnabled && vs.isSecretInfoProvided && vs.nodeManager.credentialManager == nil {
+		klog.V(1).Info("Zones can not be populated now due to credentials in Secret, skip.")
+		return false
+	}
+	return isEnabled
 }
 
 // Zones returns an implementation of Zones for vSphere.


### PR DESCRIPTION
#### What this PR does / why we need it:
Disables attempts of obtaining zones within kubelet during initial node registration by vSphere provider if credentials stored in secret.
Setting zone and region labels for node moved to KCM in such case.

If credentials stored in cloud-provider config file as plaintext current behaviour does not change.

#### Which issue(s) this PR fixes:
Fixes #75175. Kubelet does not stucking on startup with this patch. Zone labels populates for nodes during KCM startup.

#### Notes:
For proper functioning ClusterRole + ClusterRoleBinding need to be created if RBAC is in use. This should be documented somewhere, would be awesome if anybody will point me a good place for this. In case of lack of permissions labels will not be set.

#### What type of PR is this?
/kind bug
/sig cloud-provider

/assing @andrewsykim

#### Does this PR introduce a user-facing change?
```release-note
Fixed bug with leads to Node goes "Not-ready" state when credentials for vCenter stored in a secret and Zones feature is in use.
Zone labels setup moved to KCM component, kubelet skips this step during startup in such case. If credentials stored in cloud-provider config file as plaintext current behaviour does not change and no action required.

Action required: For proper functioning "kube-system:vsphere-legacy-cloud-provider" should be allowed to update node object if vCenter credentials stored in secret and Zone feature used.
```

