### PR TITLE
Increase the container deletor buffer limit for kubelet run on bare metal

### DIFF
--- a/pkg/kubelet/pod_container_deletor.go
+++ b/pkg/kubelet/pod_container_deletor.go
@@ -25,9 +25,12 @@ import (
 )
 
 const (
-	// The limit on the number of buffered container deletion requests
-	// This number is a bit arbitrary and may be adjusted in the future.
-	containerDeletorBufferLimit = 50
+	// The limit on the number of buffered container deletion requests,
+	// On bare metal, a node will run hundreds of containers,
+	// In the scenario where all the pods on the node are upgraded at the same time,
+	// some container's cleanup events will be discarded because of the BufferLimit is too small,
+	// so increase the BufferLimit to 500
+	containerDeletorBufferLimit = 500
 )
 
 type containerStatusbyCreatedList []*kubecontainer.Status


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
when kubelet run on bare metal, hundreds of pods will run on one node, 
When all pods on this node are deleted in a short period of time, kubelet may print a "Failed to issue the request to remove container" error, and some containers will not be cleaned up.

![image](https://user-images.githubusercontent.com/1468240/114490273-227a8d00-9c47-11eb-99cb-0c5cbc2ba7a0.png)


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Increase the container deletor buffer limit for kubelet run on bare metal.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
