### PR TITLE
Automated cherry pick of #100804: add node handlers to the metaproxier

### DIFF
--- a/pkg/proxy/metaproxier/meta_proxier.go
+++ b/pkg/proxy/metaproxier/meta_proxier.go
@@ -216,3 +216,31 @@ func endpointsIPFamily(endpoints *v1.Endpoints) (*v1.IPFamily, error) {
 
 	return &ipv4, nil
 }
+
+// OnNodeAdd is called whenever creation of new node object is observed.
+func (proxier *metaProxier) OnNodeAdd(node *v1.Node) {
+	proxier.ipv4Proxier.OnNodeAdd(node)
+	proxier.ipv6Proxier.OnNodeAdd(node)
+}
+
+// OnNodeUpdate is called whenever modification of an existing
+// node object is observed.
+func (proxier *metaProxier) OnNodeUpdate(oldNode, node *v1.Node) {
+	proxier.ipv4Proxier.OnNodeUpdate(oldNode, node)
+	proxier.ipv6Proxier.OnNodeUpdate(oldNode, node)
+}
+
+// OnNodeDelete is called whenever deletion of an existing node
+// object is observed.
+func (proxier *metaProxier) OnNodeDelete(node *v1.Node) {
+	proxier.ipv4Proxier.OnNodeDelete(node)
+	proxier.ipv6Proxier.OnNodeDelete(node)
+
+}
+
+// OnNodeSynced is called once all the initial event handlers were
+// called and the state is fully propagated to local cache.
+func (proxier *metaProxier) OnNodeSynced() {
+	proxier.ipv4Proxier.OnNodeSynced()
+	proxier.ipv6Proxier.OnNodeSynced()
+}


### PR DESCRIPTION
Cherry pick of #100804 on release-1.21.

#100804: add node handlers to the metaproxier

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
Fix regression in 1.21 in kube-proxy implementation of Topology Aware Hints
```
