### PR TITLE
Revert "fieldmanager: Strip managedfields BEFORE we update the timestamp"

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/fieldmanager.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/fieldmanager.go
@@ -99,8 +99,8 @@ func NewDefaultCRDFieldManager(typeConverter TypeConverter, objectConverter runt
 
 // newDefaultFieldManager is a helper function which wraps a Manager with certain default logic.
 func newDefaultFieldManager(f Manager, typeConverter TypeConverter, objectConverter runtime.ObjectConvertor, objectCreater runtime.ObjectCreater, kind schema.GroupVersionKind, ignoreManagedFieldsFromRequestObject bool) *FieldManager {
-	f = NewManagedFieldsUpdater(f)
 	f = NewStripMetaManager(f)
+	f = NewManagedFieldsUpdater(f)
 	f = NewBuildManagerInfoManager(f, kind.GroupVersion())
 	f = NewCapManagersManager(f, DefaultMaxUpdateManagers)
 	f = NewProbabilisticSkipNonAppliedManager(f, objectCreater, kind, DefaultTrackOnCreateProbability)

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/fieldmanager_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/fieldmanager_test.go
@@ -770,7 +770,6 @@ func TestNoOpChanges(t *testing.T) {
 			"labels": {
 				"a": "b"
 			},
-			"creationTimestamp": null,
 		}
 	}`), &obj.Object); err != nil {
 		t.Fatalf("error decoding YAML: %v", err)


### PR DESCRIPTION
Reverts kubernetes/kubernetes#100032

for testing