### PR TITLE
Fix mounting NFS resources in IPv6 bare-metal environment #101066

### DIFF
--- a/pkg/volume/nfs/nfs.go
+++ b/pkg/volume/nfs/nfs.go
@@ -18,7 +18,7 @@ package nfs
 
 import (
 	"fmt"
-	"net"
+	netutil "k8s.io/utils/net"
 	"os"
 	"runtime"
 	"time"
@@ -122,10 +122,6 @@ func (plugin *nfsPlugin) newMounterInternal(spec *volume.Spec, pod *v1.Pod, moun
 	if err != nil {
 		return nil, err
 	}
-	// wrap ipv6 into `[ ]`
-	if net.ParseIP(source.Server).To16() != nil {
-		source.Server = fmt.Sprintf("[%s]", source.Server)
-	}
 	return &nfsMounter{
 		nfs: &nfs{
 			volName:         spec.Name(),
@@ -134,7 +130,7 @@ func (plugin *nfsPlugin) newMounterInternal(spec *volume.Spec, pod *v1.Pod, moun
 			plugin:          plugin,
 			MetricsProvider: volume.NewMetricsStatFS(getPath(pod.UID, spec.Name(), plugin.host)),
 		},
-		server:       source.Server,
+		server:       getServerFromSource(source),
 		exportPath:   source.Path,
 		readOnly:     readOnly,
 		mountOptions: util.MountOptionFromSpec(spec),
@@ -325,4 +321,11 @@ func getVolumeSource(spec *volume.Spec) (*v1.NFSVolumeSource, bool, error) {
 	}
 
 	return nil, false, fmt.Errorf("Spec does not reference a NFS volume type")
+}
+
+func getServerFromSource(source *v1.NFSVolumeSource) string {
+	if netutil.IsIPv6String(source.Server) {
+		return fmt.Sprintf("[%s]", source.Server)
+	}
+	return source.Server
 }

--- a/pkg/volume/nfs/nfs.go
+++ b/pkg/volume/nfs/nfs.go
@@ -18,6 +18,7 @@ package nfs
 
 import (
 	"fmt"
+	"net"
 	"os"
 	"runtime"
 	"time"
@@ -121,7 +122,10 @@ func (plugin *nfsPlugin) newMounterInternal(spec *volume.Spec, pod *v1.Pod, moun
 	if err != nil {
 		return nil, err
 	}
-
+	// wrap ipv6 into `[ ]`
+	if net.ParseIP(source.Server).To16() != nil {
+		source.Server = fmt.Sprintf("[%s]", source.Server)
+	}
 	return &nfsMounter{
 		nfs: &nfs{
 			volName:         spec.Name(),

--- a/pkg/volume/nfs/nfs_test.go
+++ b/pkg/volume/nfs/nfs_test.go
@@ -96,7 +96,7 @@ func TestRecycler(t *testing.T) {
 	}
 }
 
-func doTestPlugin(t *testing.T, spec *volume.Spec) {
+func doTestPlugin(t *testing.T, spec *volume.Spec, expectedDevice string) {
 	tmpDir, err := utiltesting.MkTmpdir("nfs_test")
 	if err != nil {
 		t.Fatalf("error creating temp dir: %v", err)
@@ -146,9 +146,6 @@ func doTestPlugin(t *testing.T, spec *volume.Spec) {
 		if mntDevs[0].Type != "nfs" {
 			t.Errorf("unexpected type of mounted devices. expected: %v, got %v", "nfs", mntDevs[0].Type)
 		}
-		src, _, _ := getVolumeSource(spec)
-		srvr := getServerFromSource(src)
-		expectedDevice := fmt.Sprintf("%s:%s", srvr, src.Path)
 		if mntDevs[0].Device != expectedDevice {
 			t.Errorf("unexpected nfs device, expected %q, got: %q", expectedDevice, mntDevs[0].Device)
 		}
@@ -195,7 +192,7 @@ func TestPluginVolume(t *testing.T) {
 		Name:         "vol1",
 		VolumeSource: v1.VolumeSource{NFS: &v1.NFSVolumeSource{Server: "localhost", Path: "/somepath", ReadOnly: false}},
 	}
-	doTestPlugin(t, volume.NewSpecFromVolume(vol))
+	doTestPlugin(t, volume.NewSpecFromVolume(vol), "localhost:/somepath")
 }
 
 func TestIPV6VolumeSource(t *testing.T) {
@@ -203,7 +200,7 @@ func TestIPV6VolumeSource(t *testing.T) {
 		Name:         "vol1",
 		VolumeSource: v1.VolumeSource{NFS: &v1.NFSVolumeSource{Server: "0:0:0:0:0:0:0:1", Path: "/somepath", ReadOnly: false}},
 	}
-	doTestPlugin(t, volume.NewSpecFromVolume(vol))
+	doTestPlugin(t, volume.NewSpecFromVolume(vol), "[0:0:0:0:0:0:0:1]:/somepath")
 }
 
 func TestIPV4VolumeSource(t *testing.T) {
@@ -211,7 +208,7 @@ func TestIPV4VolumeSource(t *testing.T) {
 		Name:         "vol1",
 		VolumeSource: v1.VolumeSource{NFS: &v1.NFSVolumeSource{Server: "127.0.0.1", Path: "/somepath", ReadOnly: false}},
 	}
-	doTestPlugin(t, volume.NewSpecFromVolume(vol))
+	doTestPlugin(t, volume.NewSpecFromVolume(vol), "127.0.0.1:/somepath")
 }
 
 func TestPluginPersistentVolume(t *testing.T) {
@@ -226,7 +223,7 @@ func TestPluginPersistentVolume(t *testing.T) {
 		},
 	}
 
-	doTestPlugin(t, volume.NewSpecFromPersistentVolume(vol, false))
+	doTestPlugin(t, volume.NewSpecFromPersistentVolume(vol, false), "localhost:/somepath")
 }
 
 func TestPersistentClaimReadOnlyFlag(t *testing.T) {

--- a/pkg/volume/nfs/nfs_test.go
+++ b/pkg/volume/nfs/nfs_test.go
@@ -181,6 +181,14 @@ func TestPluginVolume(t *testing.T) {
 	doTestPlugin(t, volume.NewSpecFromVolume(vol))
 }
 
+func TestIPV6VolumeSource(t *testing.T) {
+	vol := &v1.Volume{
+		Name:         "vol1",
+		VolumeSource: v1.VolumeSource{NFS: &v1.NFSVolumeSource{Server: "0:0:0:0:0:0:0:1", Path: "/somepath", ReadOnly: false}},
+	}
+	doTestPlugin(t, volume.NewSpecFromVolume(vol))
+}
+
 func TestPluginPersistentVolume(t *testing.T) {
 	vol := &v1.PersistentVolume{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/volume/nfs/nfs_test.go
+++ b/pkg/volume/nfs/nfs_test.go
@@ -18,6 +18,7 @@ package nfs
 
 import (
 	"fmt"
+	"net"
 	"os"
 	"testing"
 
@@ -117,6 +118,18 @@ func doTestPlugin(t *testing.T, spec *volume.Spec) {
 	}
 	if mounter == nil {
 		t.Errorf("Got a nil Mounter")
+	}
+	if nfsm, ok := mounter.(*nfsMounter); ok {
+		srvr := nfsm.server
+		vol, _, _ := getVolumeSource(spec)
+		expectedSrvr := vol.Server
+		// check cluster IP version
+		if net.ParseIP(expectedSrvr).To16() != nil {
+			expectedSrvr = fmt.Sprintf("[%s]", expectedSrvr)
+		}
+		if srvr != expectedSrvr {
+			t.Errorf("Unexpected nfs server, expected %q, got: %q", expectedSrvr, srvr)
+		}
 	}
 	volumePath := mounter.GetPath()
 	expectedPath := fmt.Sprintf("%s/pods/poduid/volumes/kubernetes.io~nfs/vol1", tmpDir)

--- a/pkg/volume/nfs/nfs_test.go
+++ b/pkg/volume/nfs/nfs_test.go
@@ -189,6 +189,14 @@ func TestIPV6VolumeSource(t *testing.T) {
 	doTestPlugin(t, volume.NewSpecFromVolume(vol))
 }
 
+func TestIPV4VolumeSource(t *testing.T) {
+	vol := &v1.Volume{
+		Name:         "vol1",
+		VolumeSource: v1.VolumeSource{NFS: &v1.NFSVolumeSource{Server: "127.0.0.1", Path: "/somepath", ReadOnly: false}},
+	}
+	doTestPlugin(t, volume.NewSpecFromVolume(vol))
+}
+
 func TestPluginPersistentVolume(t *testing.T) {
 	vol := &v1.PersistentVolume{
 		ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind storage
/label nfs
/label ipv6

#### What this PR does / why we need it:

Fix mounting `nfs` volumes in `ipv6` environment. 

#### Which issue(s) this PR fixes:

Fixes #101066 

#### Special notes for your reviewer:
Enclose only ipv6 within `[ ]`.

```release-note
Fixed mounting of NFS volumes when IPv6 address is used as a server.
```
