### PR TITLE
Chain the field manager creation calls in newDefaultFieldManager 

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/fieldmanager.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/fieldmanager.go
@@ -99,15 +99,20 @@ func NewDefaultCRDFieldManager(typeConverter TypeConverter, objectConverter runt
 
 // newDefaultFieldManager is a helper function which wraps a Manager with certain default logic.
 func newDefaultFieldManager(f Manager, typeConverter TypeConverter, objectConverter runtime.ObjectConvertor, objectCreater runtime.ObjectCreater, kind schema.GroupVersionKind, ignoreManagedFieldsFromRequestObject bool) *FieldManager {
-	f = NewManagedFieldsUpdater(f)
-	f = NewStripMetaManager(f)
-	f = NewBuildManagerInfoManager(f, kind.GroupVersion())
-	f = NewCapManagersManager(f, DefaultMaxUpdateManagers)
-	f = NewProbabilisticSkipNonAppliedManager(f, objectCreater, kind, DefaultTrackOnCreateProbability)
-	f = NewLastAppliedManager(f, typeConverter, objectConverter, kind.GroupVersion())
-	f = NewLastAppliedUpdater(f)
-
-	return NewFieldManager(f, ignoreManagedFieldsFromRequestObject)
+	return NewFieldManager(
+		NewLastAppliedUpdater(
+			NewLastAppliedManager(
+				NewProbabilisticSkipNonAppliedManager(
+					NewCapManagersManager(
+						NewBuildManagerInfoManager(
+							NewManagedFieldsUpdater(
+								NewStripMetaManager(f),
+							), kind.GroupVersion(),
+						), DefaultMaxUpdateManagers,
+					), objectCreater, kind, DefaultTrackOnCreateProbability,
+				), typeConverter, objectConverter, kind.GroupVersion()),
+		), ignoreManagedFieldsFromRequestObject,
+	)
 }
 
 // DecodeManagedFields converts ManagedFields from the wire format (api format)

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/fieldmanager_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/fieldmanager_test.go
@@ -112,12 +112,17 @@ func NewTestFieldManager(gvk schema.GroupVersionKind, ignoreManagedFieldsFromReq
 	live := &unstructured.Unstructured{}
 	live.SetKind(gvk.Kind)
 	live.SetAPIVersion(gvk.GroupVersion().String())
-	f = NewStripMetaManager(f)
-	f = NewManagedFieldsUpdater(f)
-	f = NewBuildManagerInfoManager(f, gvk.GroupVersion())
-	f = NewProbabilisticSkipNonAppliedManager(f, &fakeObjectCreater{gvk: gvk}, gvk, DefaultTrackOnCreateProbability)
-	f = NewLastAppliedManager(f, typeConverter, objectConverter, gvk.GroupVersion())
-	f = NewLastAppliedUpdater(f)
+	f = NewLastAppliedUpdater(
+		NewLastAppliedManager(
+			NewProbabilisticSkipNonAppliedManager(
+				NewBuildManagerInfoManager(
+					NewManagedFieldsUpdater(
+						NewStripMetaManager(f),
+					), gvk.GroupVersion(),
+				), &fakeObjectCreater{gvk: gvk}, gvk, DefaultTrackOnCreateProbability,
+			), typeConverter, objectConverter, gvk.GroupVersion(),
+		),
+	)
 	if chainFieldManager != nil {
 		f = chainFieldManager(f)
 	}


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
* Reverts an erroneous reordering of fieldmanager creation steps in `newDefaultFieldmanager` (#100032)

* Inlines/chains the field manager creation steps in both `newDefualtFieldManager` and `NewTestFieldManager` to be explicit about the order of operations.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #101019


#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Chain the field manager creation calls in newDefaultFieldManager 
```


