### PR TITLE
Structured Logging migration: modify logs for kinds of kuberentes volumes

### DIFF
--- a/pkg/volume/cinder/attacher_test.go
+++ b/pkg/volume/cinder/attacher_test.go
@@ -34,7 +34,6 @@ import (
 	"sort"
 
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/klog/v2"
 )
 
 const (
@@ -470,7 +469,7 @@ func (testcase *testcase) AttachDisk(instanceID, volumeID string) (string, error
 		return "", errors.New("unexpected AttachDisk call: wrong instanceID")
 	}
 
-	klog.V(4).Infof("AttachDisk call: %s, %s, returning %q, %v", volumeID, instanceID, expected.retDeviceName, expected.ret)
+	testcase.t.Logf("AttachDisk call: %s, %s, returning %q, %v", volumeID, instanceID, expected.retDeviceName, expected.ret)
 
 	testcase.attachOrDetach = &attachStatus
 	return expected.retDeviceName, expected.ret
@@ -496,7 +495,7 @@ func (testcase *testcase) DetachDisk(instanceID, volumeID string) error {
 		return errors.New("unexpected DetachDisk call: wrong instanceID")
 	}
 
-	klog.V(4).Infof("DetachDisk call: %s, %s, returning %v", volumeID, instanceID, expected.ret)
+	testcase.t.Logf("DetachDisk call: %s, %s, returning %v", volumeID, instanceID, expected.ret)
 
 	testcase.attachOrDetach = &detachStatus
 	return expected.ret
@@ -506,11 +505,11 @@ func (testcase *testcase) OperationPending(diskName string) (bool, string, error
 	expected := &testcase.operationPending
 
 	if expected.volumeStatus == VolumeStatusPending {
-		klog.V(4).Infof("OperationPending call: %s, returning %v, %v, %v", diskName, expected.pending, expected.volumeStatus, expected.ret)
+		testcase.t.Logf("OperationPending call: %s, returning %v, %v, %v", diskName, expected.pending, expected.volumeStatus, expected.ret)
 		return true, expected.volumeStatus, expected.ret
 	}
 
-	klog.V(4).Infof("OperationPending call: %s, returning %v, %v, %v", diskName, expected.pending, expected.volumeStatus, expected.ret)
+	testcase.t.Logf("OperationPending call: %s, returning %v, %v, %v", diskName, expected.pending, expected.volumeStatus, expected.ret)
 
 	return false, expected.volumeStatus, expected.ret
 }
@@ -544,7 +543,7 @@ func (testcase *testcase) DiskIsAttached(instanceID, volumeID string) (bool, err
 		return false, errors.New("unexpected DiskIsAttached call: wrong instanceID")
 	}
 
-	klog.V(4).Infof("DiskIsAttached call: %s, %s, returning %v, %v", volumeID, instanceID, expected.isAttached, expected.ret)
+	testcase.t.Logf("DiskIsAttached call: %s, %s, returning %v, %v", volumeID, instanceID, expected.isAttached, expected.ret)
 
 	return expected.isAttached, expected.ret
 }
@@ -568,7 +567,7 @@ func (testcase *testcase) GetAttachmentDiskPath(instanceID, volumeID string) (st
 		return "", errors.New("unexpected GetAttachmentDiskPath call: wrong instanceID")
 	}
 
-	klog.V(4).Infof("GetAttachmentDiskPath call: %s, %s, returning %v, %v", volumeID, instanceID, expected.retPath, expected.ret)
+	testcase.t.Logf("GetAttachmentDiskPath call: %s, %s, returning %v, %v", volumeID, instanceID, expected.retPath, expected.ret)
 
 	return expected.retPath, expected.ret
 }
@@ -612,7 +611,7 @@ func (testcase *testcase) DiskIsAttachedByName(nodeName types.NodeName, volumeID
 		return false, instanceID, errors.New("unexpected DiskIsAttachedByName call: wrong instanceID")
 	}
 
-	klog.V(4).Infof("DiskIsAttachedByName call: %s, %s, returning %v, %v, %v", volumeID, nodeName, expected.isAttached, expected.instanceID, expected.ret)
+	testcase.t.Logf("DiskIsAttachedByName call: %s, %s, returning %v, %v, %v", volumeID, nodeName, expected.isAttached, expected.instanceID, expected.ret)
 
 	return expected.isAttached, expected.instanceID, expected.ret
 }
@@ -670,7 +669,7 @@ func (testcase *testcase) DisksAreAttached(instanceID string, volumeIDs []string
 		return areAttached, errors.New("unexpected DisksAreAttached call: wrong instanceID")
 	}
 
-	klog.V(4).Infof("DisksAreAttached call: %v, %s, returning %v, %v", volumeIDs, instanceID, expected.areAttached, expected.ret)
+	testcase.t.Logf("DisksAreAttached call: %v, %s, returning %v, %v", volumeIDs, instanceID, expected.areAttached, expected.ret)
 
 	return expected.areAttached, expected.ret
 }
@@ -700,7 +699,7 @@ func (testcase *testcase) DisksAreAttachedByName(nodeName types.NodeName, volume
 		return areAttached, errors.New("unexpected DisksAreAttachedByName call: wrong instanceID")
 	}
 
-	klog.V(4).Infof("DisksAreAttachedByName call: %v, %s, returning %v, %v", volumeIDs, nodeName, expected.areAttached, expected.ret)
+	testcase.t.Logf("DisksAreAttachedByName call: %v, %s, returning %v, %v", volumeIDs, nodeName, expected.areAttached, expected.ret)
 
 	return expected.areAttached, expected.ret
 }

--- a/pkg/volume/nfs/nfs.go
+++ b/pkg/volume/nfs/nfs.go
@@ -245,7 +245,7 @@ func (nfsMounter *nfsMounter) SetUp(mounterArgs volume.MounterArgs) error {
 
 func (nfsMounter *nfsMounter) SetUpAt(dir string, mounterArgs volume.MounterArgs) error {
 	notMnt, err := mount.IsNotMountPoint(nfsMounter.mounter, dir)
-	klog.V(4).Infof("NFS mount set up: %s %v %v", dir, !notMnt, err)
+	klog.V(4).InfoS("NFS mount set up", "path", dir, "isMountPoint", !notMnt, "err", err)
 	if err != nil && !os.IsNotExist(err) {
 		return err
 	}
@@ -265,22 +265,22 @@ func (nfsMounter *nfsMounter) SetUpAt(dir string, mounterArgs volume.MounterArgs
 	if err != nil {
 		notMnt, mntErr := mount.IsNotMountPoint(nfsMounter.mounter, dir)
 		if mntErr != nil {
-			klog.Errorf("IsNotMountPoint check failed: %v", mntErr)
+			klog.ErrorS(mntErr, "IsNotMountPoint check failed")
 			return err
 		}
 		if !notMnt {
 			if mntErr = nfsMounter.mounter.Unmount(dir); mntErr != nil {
-				klog.Errorf("Failed to unmount: %v", mntErr)
+				klog.ErrorS(mntErr, "Failed to unmount")
 				return err
 			}
 			notMnt, mntErr := mount.IsNotMountPoint(nfsMounter.mounter, dir)
 			if mntErr != nil {
-				klog.Errorf("IsNotMountPoint check failed: %v", mntErr)
+				klog.ErrorS(mntErr, "IsNotMountPoint check failed")
 				return err
 			}
 			if !notMnt {
 				// This is very odd, we don't expect it.  We'll try again next sync loop.
-				klog.Errorf("%s is still mounted, despite call to unmount().  Will try again next sync loop.", dir)
+				klog.ErrorS(nil, "Path is still mounted, despite call to unmount().  Will try again next sync loop.", "path", dir)
 				return err
 			}
 		}
@@ -306,7 +306,7 @@ func (c *nfsUnmounter) TearDownAt(dir string) error {
 	// NFS server and kubelet may not be able to do lstat/stat() there.
 	forceUnmounter, ok := c.mounter.(mount.MounterForceUnmounter)
 	if ok {
-		klog.V(4).Infof("Using force unmounter interface")
+		klog.V(4).InfoS("Using force unmounter interface")
 		return mount.CleanupMountWithForce(dir, forceUnmounter, true /* extensiveMountPointCheck */, unMountTimeout)
 	}
 	return mount.CleanupMountPoint(dir, c.mounter, true /* extensiveMountPointCheck */)


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
Structured Logging migration: modify logs for kinds of kuberentes volumes.
xref:
https://github.com/kubernetes/enhancements/tree/master/keps/sig-instrumentation/1602-structured-logging
https://github.com/kubernetes/community/blob/master/contributors/devel/sig-instrumentation/migration-to-structured-logging.md

#### Which issue(s) this PR fixes:
Fixes #

#### Special notes for your reviewer:
part of kubernetes/enhancements#1602
As it is related to log, change the log here to structured log.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

