### PR TITLE
Add allowAutoIOPSPerGBIncrease to translated AWS EBS StorageClasses

### DIFF
--- a/staging/src/k8s.io/csi-translation-lib/plugins/aws_ebs_test.go
+++ b/staging/src/k8s.io/csi-translation-lib/plugins/aws_ebs_test.go
@@ -102,6 +102,11 @@ func TestTranslateEBSInTreeStorageClassToCSI(t *testing.T) {
 			sc:    NewStorageClass(map[string]string{"fstype": "ext3"}, nil),
 			expSc: NewStorageClass(map[string]string{"csi.storage.k8s.io/fstype": "ext3"}, nil),
 		},
+		{
+			name:  "translate with iops",
+			sc:    NewStorageClass(map[string]string{"iopsPerGB": "100"}, nil),
+			expSc: NewStorageClass(map[string]string{"iopsPerGB": "100", "allowautoiopspergbincrease": "true"}, nil),
+		},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
/kind bug

#### What this PR does / why we need it:
By default, AWS EBS CSI driver does not increase IOPS of a volume to the minimal value supported by AWS - such increase results in increased costs, which might be surprising. It returns an error instead ("increase `IOPSPerGB` or volume size").

In-tree volume plugin *does* increase the IOPS. In order to preserve this behavior of volumes migrated to CSI, the translated StorageClasses should include `allowAutoIOPSPerGBIncrease` option that allows the driver to increase IOPS as the in-tree volume plugin would do.


#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:
With this change, Kubernetes (external-provisioner) **requires** a version of AWS EBS CSI driver that understands `allowAutoIOPSPerGBIncrease` parameter.  At time of writing this PR, such release does not exist, but I believe it will be available when the next Kubernetes version is released (relevant changes were already merged there).

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
ACTION REQUIRED: CSI migration of AWS EBS volumes requires AWS EBS CSI driver ver. 1.0 that supports  `allowAutoIOPSPerGBIncrease` parameter in StorageClass.
```

cc @Jiawei0227 @msau42 @wongma7 @AndyXiangLi 
See also https://github.com/kubernetes-sigs/aws-ebs-csi-driver/pull/809 for details on the CSI driver side.

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
