### PR TITLE
Prune sig-cli owners

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -195,31 +195,24 @@ aliases:
     - adtac
 
   sig-cli-maintainers:
-    - brendandburns
     - deads2k
     - janetkuo
     - seans3
     - monopole
-    - droot
     - apelisse
-    - mengqiy
-    - smarterclayton
     - soltysh
     - pwittrock
     - eddiezane
   # emeritus:
   # - adohe
+  # - brendandburns
+  # - droot
+  # - mengqiy
+  # - smarterclayton
   sig-cli:
     - brianpursley
-    - deads2k
-    - derekwaynecarr
     - dixudx
-    - dims
-    - mengqiy
-    - rootfs
     - seans3
-    - shiywang
-    - smarterclayton
     - soltysh
     - pwittrock
     - zhouya0


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This PR cleans up the sig-cli root owners. This was an ask as part of the CNCF annual reports. The identified folks no longer actively contribute to sig-cli.

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

@brendanburns @droot @mengqiy @smarterclayton @derekwaynecarr @dims @shiywang 

If you believe this is in error please let us know. Folks can always be added back.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
