### PR TITLE
kubeadm: Bump minimum supported versions and add etcd version for 1.2…

### DIFF
--- a/cmd/kubeadm/app/constants/constants.go
+++ b/cmd/kubeadm/app/constants/constants.go
@@ -440,13 +440,13 @@ var (
 	ControlPlaneComponents = []string{KubeAPIServer, KubeControllerManager, KubeScheduler}
 
 	// MinimumControlPlaneVersion specifies the minimum control plane version kubeadm can deploy
-	MinimumControlPlaneVersion = version.MustParseSemantic("v1.20.0")
+	MinimumControlPlaneVersion = version.MustParseSemantic("v1.21.0")
 
 	// MinimumKubeletVersion specifies the minimum version of kubelet which kubeadm supports
-	MinimumKubeletVersion = version.MustParseSemantic("v1.20.0")
+	MinimumKubeletVersion = version.MustParseSemantic("v1.21.0")
 
 	// CurrentKubernetesVersion specifies current Kubernetes version supported by kubeadm
-	CurrentKubernetesVersion = version.MustParseSemantic("v1.21.0")
+	CurrentKubernetesVersion = version.MustParseSemantic("v1.22.0")
 
 	// SupportedEtcdVersion lists officially supported etcd versions with corresponding Kubernetes releases
 	SupportedEtcdVersion = map[uint8]string{
@@ -460,6 +460,7 @@ var (
 		20: "3.4.13-0",
 		21: "3.4.13-0",
 		22: "3.4.13-0",
+		23: "3.4.13-0",
 	}
 
 	// KubeadmCertsClusterRoleName sets the name for the ClusterRole that allows


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

It's my first PR, thanks for the opportunity!

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
https://github.com/kubernetes/kubeadm/issues/2440

Clean up 1.22 housekeeping tasks:  
- ``Bump minimum supported versions and add etcd version for 1.22 and placeholder for 1.23``

#### Does this PR introduce a user-facing change?
```
None
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs
None
```
