### PR TITLE
Chore: Prevent nil panic upon nil etcd options

### DIFF
--- a/staging/src/k8s.io/sample-apiserver/pkg/cmd/server/start.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/cmd/server/start.go
@@ -120,7 +120,9 @@ func (o *WardleServerOptions) Config() (*apiserver.Config, error) {
 		return nil, fmt.Errorf("error creating self-signed certificates: %v", err)
 	}
 
-	o.RecommendedOptions.Etcd.StorageConfig.Paging = utilfeature.DefaultFeatureGate.Enabled(features.APIListChunking)
+	if o.RecommendedOptions.Etcd != nil {
+		o.RecommendedOptions.Etcd.StorageConfig.Paging = utilfeature.DefaultFeatureGate.Enabled(features.APIListChunking)
+	}
 
 	o.RecommendedOptions.ExtraAdmissionInitializers = func(c *genericapiserver.RecommendedConfig) ([]admission.PluginInitializer, error) {
 		client, err := clientset.NewForConfig(c.LoopbackClientConfig)


### PR DESCRIPTION

```release-note
NONE
```

an aggregated apiserver following sample-apiserver can be built & running w/o etcd backends. the apiserver library will be working perfectly w/o etcd if we fix this nil panic. telling from a few other codes in the code-space, passing a nil etcd options seems supported by design.

https://github.com/kubernetes/kubernetes/blob/50da4c6f610e3d2a4cdfa8b9e6da1645398bfc54/staging/src/k8s.io/apiserver/pkg/server/options/etcd.go#L82-L84
https://github.com/kubernetes/kubernetes/blob/50da4c6f610e3d2a4cdfa8b9e6da1645398bfc54/staging/src/k8s.io/apiserver/pkg/server/options/etcd.go#L194-L196



