### PR TITLE
Automated cherry pick of #100678: apf: exempt probes /healthz /livez /readyz

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/apis/flowcontrol/bootstrap/default.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/flowcontrol/bootstrap/default.go
@@ -64,6 +64,7 @@ var (
 	}
 	SuggestedFlowSchemas = []*flowcontrol.FlowSchema{
 		SuggestedFlowSchemaSystemNodes,               // references "system" priority-level
+		SuggestedFlowSchemaProbes,                    // references "exempt" priority-level
 		SuggestedFlowSchemaSystemLeaderElection,      // references "leader-election" priority-level
 		SuggestedFlowSchemaWorkloadLeaderElection,    // references "leader-election" priority-level
 		SuggestedFlowSchemaKubeControllerManager,     // references "workload-high" priority-level
@@ -391,6 +392,19 @@ var (
 				nonResourceRule(
 					[]string{flowcontrol.VerbAll},
 					[]string{flowcontrol.NonResourceAll}),
+			},
+		},
+	)
+	// the following flow schema exempts probes
+	SuggestedFlowSchemaProbes = newFlowSchema(
+		"probes", "exempt", 2,
+		"", // distinguisherMethodType
+		flowcontrol.PolicyRulesWithSubjects{
+			Subjects: groups(user.AllUnauthenticated, user.AllAuthenticated),
+			NonResourceRules: []flowcontrol.NonResourcePolicyRule{
+				nonResourceRule(
+					[]string{"get"},
+					[]string{"/healthz", "/readyz", "/livez"}),
 			},
 		},
 	)


### PR DESCRIPTION
Cherry pick of #100678 on release-1.21.

#100678: apf: exempt probes /healthz /livez /readyz

Why we need the back port:
kubelet liveness probe gets a 429 response (the priority level is saturated due to load or degradation) and this may cause kubelet to restart the apiserver instance. This PR will will prevent restarting of "healthy" kube-apiserver instance(s)

```release-note
Fixes a regression in 1.20+ default configurations in the priority and fairness API server filter by exempting all probes (/readyz, /healthz, /livez) to prevent restarting of "healthy" kube-apiserver instance(s) by kubelet.
```
