### PR TITLE
vSphere: Return useful errors from parameter validation

### DIFF
--- a/staging/src/k8s.io/legacy-cloud-providers/vsphere/vclib/custom_errors.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/vsphere/vclib/custom_errors.go
@@ -20,20 +20,18 @@ import "errors"
 
 // Error Messages
 const (
-	FileAlreadyExistErrMsg     = "File requested already exist"
-	NoDiskUUIDFoundErrMsg      = "No disk UUID found"
-	NoDevicesFoundErrMsg       = "No devices found"
-	DiskNotFoundErrMsg         = "No vSphere disk ID found"
-	InvalidVolumeOptionsErrMsg = "VolumeOptions verification failed"
-	NoVMFoundErrMsg            = "No VM found"
+	FileAlreadyExistErrMsg = "File requested already exist"
+	NoDiskUUIDFoundErrMsg  = "No disk UUID found"
+	NoDevicesFoundErrMsg   = "No devices found"
+	DiskNotFoundErrMsg     = "No vSphere disk ID found"
+	NoVMFoundErrMsg        = "No VM found"
 )
 
 // Error constants
 var (
-	ErrFileAlreadyExist     = errors.New(FileAlreadyExistErrMsg)
-	ErrNoDiskUUIDFound      = errors.New(NoDiskUUIDFoundErrMsg)
-	ErrNoDevicesFound       = errors.New(NoDevicesFoundErrMsg)
-	ErrNoDiskIDFound        = errors.New(DiskNotFoundErrMsg)
-	ErrInvalidVolumeOptions = errors.New(InvalidVolumeOptionsErrMsg)
-	ErrNoVMFound            = errors.New(NoVMFoundErrMsg)
+	ErrFileAlreadyExist = errors.New(FileAlreadyExistErrMsg)
+	ErrNoDiskUUIDFound  = errors.New(NoDiskUUIDFoundErrMsg)
+	ErrNoDevicesFound   = errors.New(NoDevicesFoundErrMsg)
+	ErrNoDiskIDFound    = errors.New(DiskNotFoundErrMsg)
+	ErrNoVMFound        = errors.New(NoVMFoundErrMsg)
 )

--- a/staging/src/k8s.io/legacy-cloud-providers/vsphere/vclib/diskmanagers/virtualdisk.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/vsphere/vclib/diskmanagers/virtualdisk.go
@@ -64,9 +64,9 @@ func (virtualDisk *VirtualDisk) Create(ctx context.Context, datastore *vclib.Dat
 	if virtualDisk.VolumeOptions.DiskFormat == "" {
 		virtualDisk.VolumeOptions.DiskFormat = vclib.ThinDiskType
 	}
-	if !virtualDisk.VolumeOptions.VerifyVolumeOptions() {
-		klog.Error("VolumeOptions verification failed. volumeOptions: ", virtualDisk.VolumeOptions)
-		return "", vclib.ErrInvalidVolumeOptions
+	if err := virtualDisk.VolumeOptions.VerifyVolumeOptions(); err != nil {
+		klog.Errorf("VolumeOptions verification failed: %s (options: %+v)", err, virtualDisk.VolumeOptions)
+		return "", fmt.Errorf("validation of parameters failed: %s", err)
 	}
 	if virtualDisk.VolumeOptions.StoragePolicyID != "" && virtualDisk.VolumeOptions.StoragePolicyName != "" {
 		return "", fmt.Errorf("Storage Policy ID and Storage Policy Name both set, Please set only one parameter")

--- a/staging/src/k8s.io/legacy-cloud-providers/vsphere/vclib/volumeoptions.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/vsphere/vclib/volumeoptions.go
@@ -17,6 +17,7 @@ limitations under the License.
 package vclib
 
 import (
+	"fmt"
 	"strings"
 
 	"k8s.io/api/core/v1"
@@ -90,21 +91,21 @@ func CheckControllerSupported(ctrlType string) bool {
 }
 
 // VerifyVolumeOptions checks if volumeOptions.SCIControllerType is valid controller type
-func (volumeOptions VolumeOptions) VerifyVolumeOptions() bool {
+func (volumeOptions VolumeOptions) VerifyVolumeOptions() error {
 	// Validate only if SCSIControllerType is set by user.
 	// Default value is set later in virtualDiskManager.Create and vmDiskManager.Create
 	if volumeOptions.SCSIControllerType != "" {
 		isValid := CheckControllerSupported(volumeOptions.SCSIControllerType)
 		if !isValid {
-			return false
+			return fmt.Errorf("invalid scsiControllerType: %s", volumeOptions.SCSIControllerType)
 		}
 	}
 	// ThinDiskType is the default, so skip the validation.
 	if volumeOptions.DiskFormat != ThinDiskType {
 		isValid := CheckDiskFormatSupported(volumeOptions.DiskFormat)
 		if !isValid {
-			return false
+			return fmt.Errorf("invalid diskFormat: %s", volumeOptions.DiskFormat)
 		}
 	}
-	return true
+	return nil
 }


### PR DESCRIPTION
/kind cleanup
(?)

#### What this PR does / why we need it:
Returning `"VolumeOptions verification failed"` when StorageClass parameter validation failed is not really useful. It does not tell which parameter is wrong and what is a VolumeOption at all.

Trying to return something more useful here.


With this PR:
`
  Warning  ProvisioningFailed  9s    persistentvolume-controller  Failed to provision volume with StorageClass "test": validation of parameters failed: invalid diskFormat: foo
`

Instead of:
`
Failed to provision volume with StorageClass "test": VolumeOptions verification failed
`

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
