### PR TITLE
Ensure that serialization is safe for concurrency

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/encode_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/encode_test.go
@@ -1,0 +1,100 @@
+package v1
+
+import (
+	reflect "reflect"
+	"sync"
+	"testing"
+)
+
+func TestUnsafeConversionWithRealObjects(t *testing.T) {
+	m := &PartialObjectMetadata{
+		ObjectMeta: ObjectMeta{
+			Name: "object",
+			Annotations: map[string]string{
+				"a": "1",
+			},
+		},
+	}
+
+	obj, err := scheme.UnsafeConvertToVersion(m, SchemeGroupVersion)
+	if err != nil {
+		t.Fatal(err)
+	}
+	converted, ok := obj.(*PartialObjectMetadata)
+	if !ok {
+		t.Fatal(err)
+	}
+	if expect, actual := reflect.ValueOf(m).Pointer(), reflect.ValueOf(converted).Pointer(); expect == actual {
+		t.Errorf("UnsafeConvertToVersion should not return the same object because we mutate TypeMeta, %d vs %d", expect, actual)
+	}
+
+	if expect, actual := reflect.ValueOf(m.Annotations).Pointer(), reflect.ValueOf(converted.Annotations).Pointer(); expect != actual {
+		t.Errorf("UnsafeConvertToVersion should reference the same nested fields, %d vs %d", expect, actual)
+	}
+}
+
+func BenchmarkUnsafeConversionWithRealObjects(b *testing.B) {
+	m := &PartialObjectMetadata{
+		ObjectMeta: ObjectMeta{
+			Name: "object",
+			Annotations: map[string]string{
+				"a": "1",
+			},
+		},
+	}
+
+	for i := 0; i < b.N; i++ {
+		obj, err := scheme.UnsafeConvertToVersion(m, SchemeGroupVersion)
+		if err != nil {
+			b.Fatal(err)
+		}
+		_, ok := obj.(*PartialObjectMetadata)
+		if !ok {
+			b.Fatal(err)
+		}
+	}
+}
+
+func TestUnsafeConversionConcurrently(t *testing.T) {
+	m := &PartialObjectMetadata{
+		ObjectMeta: ObjectMeta{
+			Name: "object",
+			Annotations: map[string]string{
+				"a": "1",
+			},
+		},
+	}
+
+	iterations := 10
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iterations; i++ {
+			obj, err := scheme.UnsafeConvertToVersion(m, SchemeGroupVersion)
+			if err != nil {
+				t.Error(err)
+				return
+			}
+			_, ok := obj.(*PartialObjectMetadata)
+			if !ok {
+				t.Errorf("unknown type %T", obj)
+			}
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iterations; i++ {
+			obj, err := scheme.UnsafeConvertToVersion(m, SchemeGroupVersion)
+			if err != nil {
+				t.Error(err)
+				return
+			}
+			_, ok := obj.(*PartialObjectMetadata)
+			if !ok {
+				t.Errorf("unknown type %T", obj)
+			}
+		}
+	}()
+	wg.Wait()
+}

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/watch.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/watch.go
@@ -39,6 +39,8 @@ type WatchEvent struct {
 	Object runtime.RawExtension `json:"object" protobuf:"bytes,2,opt,name=object"`
 }
 
+func (e *WatchEvent) GetObjectKind() schema.ObjectKind { return schema.EmptyObjectKind }
+
 func Convert_watch_Event_To_v1_WatchEvent(in *watch.Event, out *WatchEvent, s conversion.Scope) error {
 	out.Type = string(in.Type)
 	switch t := in.Object.(type) {
@@ -79,7 +81,7 @@ func Convert_v1_WatchEvent_To_v1_InternalEvent(in *WatchEvent, out *InternalEven
 type InternalEvent watch.Event
 
 func (e *InternalEvent) GetObjectKind() schema.ObjectKind { return schema.EmptyObjectKind }
-func (e *WatchEvent) GetObjectKind() schema.ObjectKind    { return schema.EmptyObjectKind }
+
 func (e *InternalEvent) DeepCopyObject() runtime.Object {
 	if c := e.DeepCopy(); c != nil {
 		return c

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/schema/interfaces.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/schema/interfaces.go
@@ -28,7 +28,8 @@ type ObjectKind interface {
 	GroupVersionKind() GroupVersionKind
 }
 
-// EmptyObjectKind implements the ObjectKind interface as a noop
+// EmptyObjectKind implements the ObjectKind interface as a noop. These types cannot be
+// directly converted but may be used in the serialization logic.
 var EmptyObjectKind = emptyObjectKind{}
 
 type emptyObjectKind struct{}
@@ -38,3 +39,7 @@ func (emptyObjectKind) SetGroupVersionKind(gvk GroupVersionKind) {}
 
 // GroupVersionKind implements the ObjectKind interface
 func (emptyObjectKind) GroupVersionKind() GroupVersionKind { return GroupVersionKind{} }
+
+// ObjectDoesNotSupportMutationOfGVK marks this object as not being fully capable of
+// GVK behavior, which is expected for objects without an object kind.
+func (emptyObjectKind) ObjectDoesNotSupportMutationOfGVK() {}

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/scheme_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/scheme_test.go
@@ -868,8 +868,8 @@ func TestConvertToVersion(t *testing.T) {
 				if !reflect.DeepEqual(unsafe, test.out) {
 					t.Fatalf("unexpected unsafe: %s", diff.ObjectReflectDiff(unsafe, test.out))
 				}
-				if unsafe != test.in {
-					t.Fatalf("UnsafeConvertToVersion should return same object: %#v", unsafe)
+				if unsafe == test.in {
+					t.Fatalf("UnsafeConvertToVersion should not return the same object since it may mutate GVK: %#v", unsafe)
 				}
 				return
 			}

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/openapi/testing/types.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/openapi/testing/types.go
@@ -39,3 +39,5 @@ func (t TestType) GroupVersionKind() schema.GroupVersionKind {
 		Kind:    "TestType",
 	}
 }
+
+func (t TestType) ObjectDoesNotSupportMutationOfGVK() {}


### PR DESCRIPTION
UnsafeConvertToVersion does not ensure that the target kind mutation is safe for concurrent serialization of the same object. To fix this, formalize rules on which objects can be used in a Scheme:
    
1. (existing) They must implement Object which includes the GetObjectKind() method.
2. (new) Unless they expose the ObjectDoesNotSupportMutationOfGVK() marker, they must round trip a GVK and prove at AddKnownType() insertion time that a shallow-copy of the type struct does not impact the original object.
    
These rules are an extension of our current behavior because we expect an embedded TypeMeta struct in some of our accessors, but we make them explicit now in order to maintain the no-op conversion efficiency (bypass a full DeepCopy). All in-tree violations of these rules were using EmptyObjectKind which had this behavior already.
    
To fix the concurrency issue we perform a shallow copy during convertToVersion if and only if we are not dealing with a new object and we don't need to deep copy (as we would during ConvertToVersion). Clean up the logic so it more clearly indicates when we must copy (before we invoke setTargetKind and when we don't have a new object). The performance cost of this in the non-deepcopy case is a single additional allocation during the no-op conversion in clients (from 2 to 3).
    
After these changes UnsafeConvertToVersion always returns a new object and is always safe for concurrent use within encoders. The addition of the new validation rules when registering a type ensures no one is caught by surprise, and if someone is not shallow copying they must in order to remain safe.

/kind bug
/kind flake

Fixes #82497

```release-note
Fix a race condition when concurrently serializing the same Kube object. Encoding the same object is now safe for multiple goroutines.
```

```docs

```