### PR TITLE
Automated cherry pick of #101104: kubeadm: Bump minimum supported versions and add etcd version

### DIFF
--- a/cmd/kubeadm/app/constants/constants.go
+++ b/cmd/kubeadm/app/constants/constants.go
@@ -440,13 +440,13 @@ var (
 	ControlPlaneComponents = []string{KubeAPIServer, KubeControllerManager, KubeScheduler}
 
 	// MinimumControlPlaneVersion specifies the minimum control plane version kubeadm can deploy
-	MinimumControlPlaneVersion = version.MustParseSemantic("v1.20.0")
+	MinimumControlPlaneVersion = version.MustParseSemantic("v1.21.0")
 
 	// MinimumKubeletVersion specifies the minimum version of kubelet which kubeadm supports
-	MinimumKubeletVersion = version.MustParseSemantic("v1.20.0")
+	MinimumKubeletVersion = version.MustParseSemantic("v1.21.0")
 
 	// CurrentKubernetesVersion specifies current Kubernetes version supported by kubeadm
-	CurrentKubernetesVersion = version.MustParseSemantic("v1.21.0")
+	CurrentKubernetesVersion = version.MustParseSemantic("v1.22.0")
 
 	// SupportedEtcdVersion lists officially supported etcd versions with corresponding Kubernetes releases
 	SupportedEtcdVersion = map[uint8]string{
@@ -460,6 +460,7 @@ var (
 		20: "3.4.13-0",
 		21: "3.4.13-0",
 		22: "3.4.13-0",
+		23: "3.4.13-0",
 	}
 
 	// KubeadmCertsClusterRoleName sets the name for the ClusterRole that allows


### PR DESCRIPTION
Cherry pick of #101104 on release-1.21.

#101104: kubeadm: Bump minimum supported versions and add etcd version

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.