### PR TITLE
Add secret protection

### DIFF
--- a/cmd/kube-controller-manager/app/controllermanager.go
+++ b/cmd/kube-controller-manager/app/controllermanager.go
@@ -441,6 +441,7 @@ func NewControllerInitializers(loopMode ControllerLoopMode) map[string]InitFunc 
 	controllers["clusterrole-aggregation"] = startClusterRoleAggregrationController
 	controllers["pvc-protection"] = startPVCProtectionController
 	controllers["pv-protection"] = startPVProtectionController
+	controllers["secret-protection"] = startSecretProtectionController
 	controllers["ttl-after-finished"] = startTTLAfterFinishedController
 	controllers["root-ca-cert-publisher"] = startRootCACertPublisher
 	controllers["ephemeral-volume"] = startEphemeralVolumeController

--- a/cmd/kube-controller-manager/app/core.go
+++ b/cmd/kube-controller-manager/app/core.go
@@ -64,6 +64,7 @@ import (
 	persistentvolumecontroller "k8s.io/kubernetes/pkg/controller/volume/persistentvolume"
 	"k8s.io/kubernetes/pkg/controller/volume/pvcprotection"
 	"k8s.io/kubernetes/pkg/controller/volume/pvprotection"
+	"k8s.io/kubernetes/pkg/controller/volume/secretprotection"
 	"k8s.io/kubernetes/pkg/features"
 	quotainstall "k8s.io/kubernetes/pkg/quota/v1/install"
 	"k8s.io/kubernetes/pkg/volume/csimigration"
@@ -590,6 +591,17 @@ func startPVProtectionController(ctx ControllerContext) (http.Handler, bool, err
 	go pvprotection.NewPVProtectionController(
 		ctx.InformerFactory.Core().V1().PersistentVolumes(),
 		ctx.ClientBuilder.ClientOrDie("pv-protection-controller"),
+		utilfeature.DefaultFeatureGate.Enabled(features.StorageObjectInUseProtection),
+	).Run(1, ctx.Stop)
+	return nil, true, nil
+}
+
+func startSecretProtectionController(ctx ControllerContext) (http.Handler, bool, error) {
+	go secretprotection.NewSecretProtectionController(
+		ctx.InformerFactory.Core().V1().Secrets(),
+		ctx.InformerFactory.Core().V1().Pods(),
+		ctx.InformerFactory.Core().V1().PersistentVolumes(),
+		ctx.ClientBuilder.ClientOrDie("secret-protection-controller"),
 		utilfeature.DefaultFeatureGate.Enabled(features.StorageObjectInUseProtection),
 	).Run(1, ctx.Stop)
 	return nil, true, nil

--- a/cmd/kube-controller-manager/app/core.go
+++ b/cmd/kube-controller-manager/app/core.go
@@ -601,6 +601,8 @@ func startSecretProtectionController(ctx ControllerContext) (http.Handler, bool,
 		ctx.InformerFactory.Core().V1().Secrets(),
 		ctx.InformerFactory.Core().V1().Pods(),
 		ctx.InformerFactory.Core().V1().PersistentVolumes(),
+		ctx.InformerFactory.Core().V1().PersistentVolumeClaims(),
+		ctx.InformerFactory.Storage().V1().StorageClasses(),
 		ctx.ClientBuilder.ClientOrDie("secret-protection-controller"),
 		utilfeature.DefaultFeatureGate.Enabled(features.StorageObjectInUseProtection),
 	).Run(1, ctx.Stop)

--- a/pkg/controller/volume/secretprotection/secret_protection_controller.go
+++ b/pkg/controller/volume/secretprotection/secret_protection_controller.go
@@ -1,0 +1,520 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package secretprotection
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
+	coreinformers "k8s.io/client-go/informers/core/v1"
+	clientset "k8s.io/client-go/kubernetes"
+	corelisters "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/workqueue"
+	"k8s.io/component-base/metrics/prometheus/ratelimiter"
+	"k8s.io/klog/v2"
+	"k8s.io/kubernetes/pkg/controller/volume/protectionutil"
+	"k8s.io/kubernetes/pkg/util/slice"
+	volumeutil "k8s.io/kubernetes/pkg/volume/util"
+)
+
+// Controller is controller that removes SecretProtectionFinalizer
+// from secrets that are used by no other resources.
+type Controller struct {
+	client clientset.Interface
+
+	secretLister       corelisters.SecretLister
+	secretListerSynced cache.InformerSynced
+
+	podLister       corelisters.PodLister
+	podListerSynced cache.InformerSynced
+
+	pvLister       corelisters.PersistentVolumeLister
+	pvListerSynced cache.InformerSynced
+
+	queue workqueue.RateLimitingInterface
+
+	// allows overriding of StorageObjectInUseProtection feature Enabled/Disabled for testing
+	storageObjectInUseProtectionEnabled bool
+}
+
+// NewSecretProtectionController returns a new instance of SecretProtectionController.
+func NewSecretProtectionController(secretInformer coreinformers.SecretInformer, podInformer coreinformers.PodInformer, pvInformer coreinformers.PersistentVolumeInformer, cl clientset.Interface, storageObjectInUseProtectionFeatureEnabled bool) *Controller {
+	e := &Controller{
+		client:                              cl,
+		queue:                               workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "secretprotection"),
+		storageObjectInUseProtectionEnabled: storageObjectInUseProtectionFeatureEnabled,
+	}
+	if cl != nil && cl.CoreV1().RESTClient().GetRateLimiter() != nil {
+		ratelimiter.RegisterMetricAndTrackRateLimiterUsage("secret_protection_controller", cl.CoreV1().RESTClient().GetRateLimiter())
+	}
+
+	e.secretLister = secretInformer.Lister()
+	e.secretListerSynced = secretInformer.Informer().HasSynced
+	secretInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc: e.secretAddedUpdated,
+		UpdateFunc: func(old, new interface{}) {
+			e.secretAddedUpdated(new)
+		},
+	})
+
+	e.podLister = podInformer.Lister()
+	e.podListerSynced = podInformer.Informer().HasSynced
+	podInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj interface{}) {
+			e.podAddedDeletedUpdated(nil, obj, false)
+		},
+		DeleteFunc: func(obj interface{}) {
+			e.podAddedDeletedUpdated(nil, obj, true)
+		},
+		UpdateFunc: func(old, new interface{}) {
+			e.podAddedDeletedUpdated(old, new, false)
+		},
+	})
+
+	e.pvLister = pvInformer.Lister()
+	e.pvListerSynced = pvInformer.Informer().HasSynced
+	pvInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj interface{}) {
+			e.pvAddedDeletedUpdated(nil, obj, false)
+		},
+		DeleteFunc: func(obj interface{}) {
+			e.pvAddedDeletedUpdated(nil, obj, true)
+		},
+		UpdateFunc: func(old, new interface{}) {
+			e.pvAddedDeletedUpdated(old, new, false)
+		},
+	})
+
+	return e
+}
+
+// Run runs the controller goroutines.
+func (c *Controller) Run(workers int, stopCh <-chan struct{}) {
+	defer utilruntime.HandleCrash()
+	defer c.queue.ShutDown()
+
+	klog.InfoS("Starting secret protection controller")
+	defer klog.InfoS("Shutting down secret protection controller")
+
+	if !cache.WaitForNamedCacheSync("secret protection", stopCh, c.secretListerSynced, c.podListerSynced) {
+		return
+	}
+
+	for i := 0; i < workers; i++ {
+		go wait.Until(c.runWorker, time.Second, stopCh)
+	}
+
+	<-stopCh
+}
+
+func (c *Controller) runWorker() {
+	for c.processNextWorkItem() {
+	}
+}
+
+// processNextWorkItem deals with one secretKey off the queue.  It returns false when it's time to quit.
+func (c *Controller) processNextWorkItem() bool {
+	secretKey, quit := c.queue.Get()
+	if quit {
+		return false
+	}
+	defer c.queue.Done(secretKey)
+
+	secretNamespace, secretName, err := cache.SplitMetaNamespaceKey(secretKey.(string))
+	if err != nil {
+		utilruntime.HandleError(fmt.Errorf("error parsing secret key %q: %v", secretKey, err))
+		return true
+	}
+
+	err = c.processSecret(secretNamespace, secretName)
+	if err == nil {
+		c.queue.Forget(secretKey)
+		return true
+	}
+
+	utilruntime.HandleError(fmt.Errorf("secret %v failed with : %v", secretKey, err))
+	c.queue.AddRateLimited(secretKey)
+
+	return true
+}
+
+func (c *Controller) processSecret(secretNamespace, secretName string) error {
+	klog.V(4).InfoS("Processing secret", "secret", klog.KRef(secretNamespace, secretName))
+	startTime := time.Now()
+	defer func() {
+		klog.V(4).InfoS("Finished processing secret", "secret", klog.KRef(secretNamespace, secretName), "duration", time.Since(startTime))
+	}()
+
+	secret, err := c.secretLister.Secrets(secretNamespace).Get(secretName)
+	if apierrors.IsNotFound(err) {
+		klog.V(4).InfoS("Secret not found, ignoring", "secret", klog.KRef(secretNamespace, secretName))
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+
+	if protectionutil.IsDeletionCandidate(secret, volumeutil.SecretProtectionFinalizer) {
+		// secret should be deleted. Check if it's used and remove finalizer if
+		// it's not.
+		isUsed, err := c.isBeingUsed(secret)
+		if err != nil {
+			return err
+		}
+		if !isUsed {
+			return c.removeFinalizer(secret)
+		}
+		klog.V(2).InfoS("Keeping secret because it is being used", "secret", klog.KObj(secret))
+	}
+
+	if protectionutil.NeedToAddFinalizer(secret, volumeutil.SecretProtectionFinalizer) {
+		// secret is not being deleted -> it should have the finalizer. The
+		// finalizer should be added by admission plugin, this is just to add
+		// the finalizer to old secrets that were created before the admission
+		// plugin was enabled.
+		return c.addFinalizer(secret)
+	}
+	return nil
+}
+
+func (c *Controller) addFinalizer(secret *v1.Secret) error {
+	// Skip adding Finalizer in case the StorageObjectInUseProtection feature is not enabled
+	if !c.storageObjectInUseProtectionEnabled {
+		return nil
+	}
+	secretClone := secret.DeepCopy()
+	secretClone.ObjectMeta.Finalizers = append(secretClone.ObjectMeta.Finalizers, volumeutil.SecretProtectionFinalizer)
+	_, err := c.client.CoreV1().Secrets(secretClone.Namespace).Update(context.TODO(), secretClone, metav1.UpdateOptions{})
+	if err != nil {
+		klog.ErrorS(err, "Error adding protection finalizer to secret", "secret", klog.KObj(secret))
+		return err
+	}
+	klog.V(3).InfoS("Added protection finalizer to secret", "secret", klog.KObj(secret))
+	return nil
+}
+
+func (c *Controller) removeFinalizer(secret *v1.Secret) error {
+	secretClone := secret.DeepCopy()
+	secretClone.ObjectMeta.Finalizers = slice.RemoveString(secretClone.ObjectMeta.Finalizers, volumeutil.SecretProtectionFinalizer, nil)
+	_, err := c.client.CoreV1().Secrets(secretClone.Namespace).Update(context.TODO(), secretClone, metav1.UpdateOptions{})
+	if err != nil {
+		klog.ErrorS(err, "Error removing protection finalizer from secret", "secret", klog.KObj(secret))
+		return err
+	}
+	klog.V(3).InfoS("Removed protection finalizer from secret", "secret", klog.KObj(secret))
+	return nil
+}
+
+func (c *Controller) isBeingUsed(secret *v1.Secret) (bool, error) {
+	// Look for Pods and PVs using secret in the Informer's cache. If one is found the
+	// correct decision to keep secret is taken without doing an expensive live
+	// list.
+	if inUse, err := c.askInformer(secret); err != nil {
+		// No need to return because a live list will follow.
+		klog.Error(err)
+	} else if inUse {
+		return true, nil
+	}
+
+	// Even if no Pod and PV using secret was found in the Informer's cache it doesn't
+	// mean such a Pod or a PV doesn't exist: it might just not be in the cache yet. To
+	// be 100% confident that it is safe to delete secret make sure no Pod is using
+	// it among those returned by a live list.
+	if inUse, err := c.askAPIServer(secret); err != nil {
+		klog.Error(err)
+	} else if inUse {
+		return true, nil
+	}
+
+	return false, nil
+}
+
+func (c *Controller) askInformer(secret *v1.Secret) (bool, error) {
+	klog.V(4).InfoS("Looking for Pods using secret in the Informer's cache", "secret", klog.KObj(secret))
+
+	pods, err := c.podLister.List(labels.NewSelector())
+	if err != nil {
+		return false, fmt.Errorf("cache-based list of pods failed while processing %s/%s: %s", secret.Namespace, secret.Name, err.Error())
+	}
+	for _, pod := range pods {
+		if c.podUsesSecret(pod, secret) {
+			return true, nil
+		}
+	}
+
+	klog.V(4).InfoS("Looking for PVs using secret in the Informer's cache", "secret", klog.KObj(secret))
+
+	pvs, err := c.pvLister.List(labels.NewSelector())
+	if err != nil {
+		return false, fmt.Errorf("cache-based list of PVs failed while processing %s/%s: %s", secret.Namespace, secret.Name, err.Error())
+	}
+	for _, pv := range pvs {
+		if c.pvUsesSecret(pv, secret) {
+			return true, nil
+		}
+	}
+
+	klog.V(4).InfoS("No Pod and PV using secret was found in the Informer's cache", "secret", klog.KObj(secret))
+	return false, nil
+}
+
+func (c *Controller) askAPIServer(secret *v1.Secret) (bool, error) {
+	klog.V(4).InfoS("Looking for Pods using secret with a live list", "secret", klog.KObj(secret))
+
+	podsList, err := c.client.CoreV1().Pods(secret.Namespace).List(context.TODO(), metav1.ListOptions{})
+	if err != nil {
+		return false, fmt.Errorf("live list of pods failed: %s", err.Error())
+	}
+
+	for _, pod := range podsList.Items {
+		if c.podUsesSecret(&pod, secret) {
+			return true, nil
+		}
+	}
+
+	klog.V(4).InfoS("Looking for PVs using secret with a live list", "secret", klog.KObj(secret))
+	pvsList, err := c.client.CoreV1().PersistentVolumes().List(context.TODO(), metav1.ListOptions{})
+	if err != nil {
+		return false, fmt.Errorf("live list of PVs failed: %s", err.Error())
+	}
+
+	for _, pv := range pvsList.Items {
+		if c.pvUsesSecret(&pv, secret) {
+			return true, nil
+		}
+	}
+
+	klog.V(2).InfoS("secret is unused", "secret", klog.KObj(secret))
+	return false, nil
+}
+
+func (c *Controller) podUsesSecret(pod *v1.Pod, secret *v1.Secret) bool {
+	// Check whether secret is used by pod only if pod is scheduled, because
+	// kubelet sees pods after they have been scheduled and it won't allow
+	// starting a pod referencing a secret with a non-nil deletionTimestamp.
+	// TODO: Check if above is also correct for secret.
+	if pod.Spec.NodeName != "" {
+		for _, volume := range pod.Spec.Volumes {
+			if podIsShutDown(pod) {
+				continue
+			}
+			// Check if referenced from volume.Secret
+			if volume.Secret != nil && volume.Secret.SecretName == secret.Name {
+				klog.V(2).InfoS("Pod uses Secret", "pod", klog.KObj(pod), "secret", klog.KObj(secret))
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func (c *Controller) pvUsesSecret(pv *v1.PersistentVolume, secret *v1.Secret) bool {
+	secretKey := fmt.Sprintf("%s/%s", secret.Namespace, secret.Name)
+	for _, secretKeyUsed := range getSecretsUsedByPV(pv) {
+		if secretKey == secretKeyUsed {
+			klog.V(2).InfoS("PV uses Secret", "pv", klog.KObj(pv), "secret", klog.KObj(secret))
+			return true
+		}
+	}
+
+	return false
+}
+
+// podIsShutDown returns true if kubelet is done with the pod or
+// it was force-deleted.
+func podIsShutDown(pod *v1.Pod) bool {
+	// A pod that has a deletionTimestamp and a zero
+	// deletionGracePeriodSeconds
+	// a) has been processed by kubelet and was set up for deletion
+	//    by the apiserver:
+	//    - canBeDeleted has verified that volumes were unpublished
+	//      https://github.com/kubernetes/kubernetes/blob/5404b5a28a2114299608bab00e4292960dd864a0/pkg/kubelet/kubelet_pods.go#L980
+	//    - deletionGracePeriodSeconds was set via a delete
+	//      with zero GracePeriodSeconds
+	//      https://github.com/kubernetes/kubernetes/blob/5404b5a28a2114299608bab00e4292960dd864a0/pkg/kubelet/status/status_manager.go#L580-L592
+	// or
+	// b) was force-deleted.
+	//
+	// It's now just waiting for garbage collection. We could wait
+	// for it to actually get removed, but that may be blocked by
+	// finalizers for the pod and thus get delayed.
+	//
+	// Worse, it is possible that there is a cyclic dependency
+	// (pod finalizer waits for secret to get removed, secret protection
+	// controller waits for pod to get removed).  By considering
+	// the secret unused in this case, we allow the secret to get
+	// removed and break such a cycle.
+	//
+	// Therefore it is better to proceed with secret removal,
+	// which is safe (case a) and/or desirable (case b).
+	return pod.DeletionTimestamp != nil && pod.DeletionGracePeriodSeconds != nil && *pod.DeletionGracePeriodSeconds == 0
+}
+
+// secretAddedUpdated reacts to secret added/updated events
+func (c *Controller) secretAddedUpdated(obj interface{}) {
+	secret, ok := obj.(*v1.Secret)
+	if !ok {
+		utilruntime.HandleError(fmt.Errorf("Secret informer returned non-secret object: %#v", obj))
+		return
+	}
+	key, err := cache.MetaNamespaceKeyFunc(secret)
+	if err != nil {
+		utilruntime.HandleError(fmt.Errorf("couldn't get key for secret %#v: %v", secret, err))
+		return
+	}
+	klog.V(4).InfoS("Got event on secret", key)
+
+	if protectionutil.NeedToAddFinalizer(secret, volumeutil.SecretProtectionFinalizer) || protectionutil.IsDeletionCandidate(secret, volumeutil.SecretProtectionFinalizer) {
+		c.queue.Add(key)
+	}
+}
+
+// podAddedDeletedUpdated reacts to Pod events
+func (c *Controller) podAddedDeletedUpdated(old, new interface{}, deleted bool) {
+	if pod := c.parsePod(new); pod != nil {
+		c.enqueueSecretsForPod(pod, deleted)
+
+		// An update notification might mask the deletion of a pod X and the
+		// following creation of a pod Y with the same namespaced name as X. If
+		// that's the case X needs to be processed as well to handle the case
+		// where it is blocking deletion of a secret not referenced by Y, otherwise
+		// such secret will never be deleted.
+		if oldPod := c.parsePod(old); oldPod != nil && oldPod.UID != pod.UID {
+			c.enqueueSecretsForPod(oldPod, true)
+		}
+	}
+}
+
+func (*Controller) parsePod(obj interface{}) *v1.Pod {
+	if obj == nil {
+		return nil
+	}
+	pod, ok := obj.(*v1.Pod)
+	if !ok {
+		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
+		if !ok {
+			utilruntime.HandleError(fmt.Errorf("couldn't get object from tombstone %#v", obj))
+			return nil
+		}
+		pod, ok = tombstone.Obj.(*v1.Pod)
+		if !ok {
+			utilruntime.HandleError(fmt.Errorf("tombstone contained object that is not a Pod %#v", obj))
+			return nil
+		}
+	}
+	return pod
+}
+
+func (c *Controller) enqueueSecretsForPod(pod *v1.Pod, deleted bool) {
+	// Filter out pods that can't help us to remove a finalizer on Secret
+	if !deleted && !volumeutil.IsPodTerminated(pod, pod.Status) && pod.Spec.NodeName != "" {
+		return
+	}
+
+	klog.V(4).InfoS("Enqueuing Secrets for Pod", "pod", klog.KObj(pod), "podUID", pod.UID)
+
+	// Enqueue all Secrets that the pod uses
+	for _, volume := range pod.Spec.Volumes {
+		switch {
+		case volume.Secret != nil:
+			c.queue.Add(pod.Namespace + "/" + volume.Secret.SecretName)
+		}
+	}
+}
+
+// pvAddedDeletedUpdated reacts to PV events
+func (c *Controller) pvAddedDeletedUpdated(old, new interface{}, deleted bool) {
+	if pv := c.parsePV(new); pv != nil {
+		c.enqueueSecretsForPV(pv, deleted)
+
+		// An update notification might mask the deletion of a pv X and the
+		// following creation of a pv Y with the same namespaced name as X. If
+		// that's the case X needs to be processed as well to handle the case
+		// where it is blocking deletion of a secret not referenced by Y, otherwise
+		// such secret will never be deleted.
+		if oldPV := c.parsePV(old); oldPV != nil && oldPV.UID != pv.UID {
+			c.enqueueSecretsForPV(oldPV, true)
+		}
+	}
+}
+
+func (*Controller) parsePV(obj interface{}) *v1.PersistentVolume {
+	if obj == nil {
+		return nil
+	}
+	pv, ok := obj.(*v1.PersistentVolume)
+	if !ok {
+		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
+		if !ok {
+			utilruntime.HandleError(fmt.Errorf("couldn't get object from tombstone %#v", obj))
+			return nil
+		}
+		pv, ok = tombstone.Obj.(*v1.PersistentVolume)
+		if !ok {
+			utilruntime.HandleError(fmt.Errorf("tombstone contained object that is not a PV %#v", obj))
+			return nil
+		}
+	}
+	return pv
+}
+
+func (c *Controller) enqueueSecretsForPV(pv *v1.PersistentVolume, deleted bool) {
+	klog.V(4).InfoS("Enqueuing Secrets for PV", "pv", klog.KObj(pv), "pvUID", pv.UID)
+	// Enqueue all Secrets that the PV uses
+	for _, secretKey := range getSecretsUsedByPV(pv) {
+		c.queue.Add(secretKey)
+	}
+}
+
+func getSecretsUsedByPV(pv *v1.PersistentVolume) []string {
+	secretKeys := []string{}
+
+	switch {
+	case pv.Spec.PersistentVolumeSource.CSI != nil:
+		csi := pv.Spec.PersistentVolumeSource.CSI
+
+		if csi.ControllerPublishSecretRef != nil {
+			secretKeys = append(secretKeys, fmt.Sprintf("%s/%s",
+				csi.ControllerPublishSecretRef.Namespace, csi.ControllerPublishSecretRef.Name))
+		}
+
+		if csi.NodeStageSecretRef != nil {
+			secretKeys = append(secretKeys, fmt.Sprintf("%s/%s",
+				csi.NodeStageSecretRef.Namespace, csi.NodeStageSecretRef.Name))
+		}
+
+		if csi.NodePublishSecretRef != nil {
+			secretKeys = append(secretKeys, fmt.Sprintf("%s/%s",
+				csi.NodePublishSecretRef.Namespace, csi.NodePublishSecretRef.Name))
+		}
+
+		if csi.ControllerExpandSecretRef != nil {
+			secretKeys = append(secretKeys, fmt.Sprintf("%s/%s",
+				csi.ControllerExpandSecretRef.Namespace, csi.ControllerExpandSecretRef.Name))
+		}
+	}
+
+	return secretKeys
+}

--- a/pkg/controller/volume/secretprotection/secret_protection_controller_test.go
+++ b/pkg/controller/volume/secretprotection/secret_protection_controller_test.go
@@ -1,0 +1,708 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package secretprotection
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/davecgh/go-spew/spew"
+
+	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes/fake"
+	clienttesting "k8s.io/client-go/testing"
+	"k8s.io/klog/v2"
+	api "k8s.io/kubernetes/pkg/apis/core"
+	"k8s.io/kubernetes/pkg/controller"
+	volumeutil "k8s.io/kubernetes/pkg/volume/util"
+)
+
+type reaction struct {
+	verb      string
+	resource  string
+	reactorfn clienttesting.ReactionFunc
+}
+
+const (
+	defaultNS         = "default"
+	defaultPVName     = "pv1"
+	defaultSecretName = "secret1"
+	defaultPodName    = "pod1"
+	defaultNodeName   = "node1"
+	defaultUID        = "uid1"
+)
+
+func pod() *v1.Pod {
+	return &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      defaultPodName,
+			Namespace: defaultNS,
+			UID:       defaultUID,
+		},
+		Spec: v1.PodSpec{
+			NodeName: defaultNodeName,
+		},
+		Status: v1.PodStatus{
+			Phase: v1.PodPending,
+		},
+	}
+}
+
+func unscheduled(pod *v1.Pod) *v1.Pod {
+	pod.Spec.NodeName = ""
+	return pod
+}
+
+func withSecret(secretName string, pod *v1.Pod) *v1.Pod {
+	volume := v1.Volume{
+		Name: secretName,
+		VolumeSource: v1.VolumeSource{
+			Secret: &v1.SecretVolumeSource{
+				SecretName: secretName,
+			},
+		},
+	}
+	pod.Spec.Volumes = append(pod.Spec.Volumes, volume)
+	return pod
+}
+
+func withEmptyDir(pod *v1.Pod) *v1.Pod {
+	volume := v1.Volume{
+		Name: "emptyDir",
+		VolumeSource: v1.VolumeSource{
+			EmptyDir: &v1.EmptyDirVolumeSource{},
+		},
+	}
+	pod.Spec.Volumes = append(pod.Spec.Volumes, volume)
+	return pod
+}
+
+func withStatus(phase v1.PodPhase, pod *v1.Pod) *v1.Pod {
+	pod.Status.Phase = phase
+	return pod
+}
+
+func withUID(uid types.UID, pod *v1.Pod) *v1.Pod {
+	pod.ObjectMeta.UID = uid
+	return pod
+}
+
+func csiPV() *v1.PersistentVolume {
+	return &v1.PersistentVolume{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      defaultPVName,
+			Namespace: defaultNS,
+			UID:       defaultUID,
+		},
+		Spec: v1.PersistentVolumeSpec{
+			PersistentVolumeSource: v1.PersistentVolumeSource{
+				CSI: &v1.CSIPersistentVolumeSource{},
+			},
+		},
+		Status: v1.PersistentVolumeStatus{
+			Phase: v1.VolumeAvailable,
+		},
+	}
+}
+
+func withControllerPublishSecret(secretName string, csiPV *v1.PersistentVolume) *v1.PersistentVolume {
+	csiPV.Spec.PersistentVolumeSource.CSI.ControllerPublishSecretRef = &v1.SecretReference{Namespace: defaultNS, Name: secretName}
+	return csiPV
+}
+
+func withNodeStageSecret(secretName string, csiPV *v1.PersistentVolume) *v1.PersistentVolume {
+	csiPV.Spec.PersistentVolumeSource.CSI.NodeStageSecretRef = &v1.SecretReference{Namespace: defaultNS, Name: secretName}
+	return csiPV
+}
+
+func withNodePublishSecret(secretName string, csiPV *v1.PersistentVolume) *v1.PersistentVolume {
+	csiPV.Spec.PersistentVolumeSource.CSI.NodePublishSecretRef = &v1.SecretReference{Namespace: defaultNS, Name: secretName}
+	return csiPV
+}
+
+func withControllerExpandSecret(secretName string, csiPV *v1.PersistentVolume) *v1.PersistentVolume {
+	csiPV.Spec.PersistentVolumeSource.CSI.ControllerExpandSecretRef = &v1.SecretReference{Namespace: defaultNS, Name: secretName}
+	return csiPV
+}
+
+func withVolumeStatus(phase v1.PersistentVolumePhase, pv *v1.PersistentVolume) *v1.PersistentVolume {
+	pv.Status.Phase = phase
+	return pv
+}
+
+func withPVUID(uid types.UID, pv *v1.PersistentVolume) *v1.PersistentVolume {
+	pv.ObjectMeta.UID = uid
+	return pv
+}
+
+func secret() *v1.Secret {
+	return &v1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      defaultSecretName,
+			Namespace: defaultNS,
+		},
+	}
+}
+
+func withProtectionFinalizer(secret *v1.Secret) *v1.Secret {
+	secret.Finalizers = append(secret.Finalizers, volumeutil.SecretProtectionFinalizer)
+	return secret
+}
+
+func deleted(secret *v1.Secret) *v1.Secret {
+	secret.DeletionTimestamp = &metav1.Time{}
+	return secret
+}
+
+func generateUpdateErrorFunc(t *testing.T, failures int) clienttesting.ReactionFunc {
+	i := 0
+	return func(action clienttesting.Action) (bool, runtime.Object, error) {
+		i++
+		if i <= failures {
+			// Update fails
+			update, ok := action.(clienttesting.UpdateAction)
+
+			if !ok {
+				t.Fatalf("Reactor got non-update action: %+v", action)
+			}
+			acc, _ := meta.Accessor(update.GetObject())
+			return true, nil, apierrors.NewForbidden(update.GetResource().GroupResource(), acc.GetName(), errors.New("Mock error"))
+		}
+		// Update succeeds
+		return false, nil, nil
+	}
+}
+
+func TestSecretProtectionController(t *testing.T) {
+	secretGVR := api.Resource("secrets").WithVersion("v1")
+	podGVR := api.Resource("pods").WithVersion("v1")
+	podGVK := api.Kind("Pod").WithVersion("v1")
+	pvGVR := api.Resource("persistentvolumes").WithVersion("v1")
+	pvGVK := api.Kind("PersistentVolume").WithVersion("v1")
+
+	tests := []struct {
+		name string
+		// Object to insert into fake kubeclient before the test starts.
+		initialObjects []runtime.Object
+		// Whether not to insert the content of initialObjects into the
+		// informers before the test starts. Set it to true to simulate the case
+		// where informers have not been notified yet of certain API objects.
+		informersAreLate bool
+		// Optional client reactors.
+		reactors []reaction
+		// Secret event to simulate. This secret will be automatically added to
+		// initialObjects.
+		updatedSecret *v1.Secret
+		// Pod event to simulate. This Pod will be automatically added to
+		// initialObjects.
+		updatedPod *v1.Pod
+		// Pod event to simulate. This Pod is *not* added to
+		// initialObjects.
+		deletedPod *v1.Pod
+		// PV event to simulate. This PV will be automatically added to
+		// initialObjects.
+		updatedPV *v1.PersistentVolume
+		// PV event to simulate. This PV is *not* added to
+		// initialObjects.
+		deletedPV *v1.PersistentVolume
+		// List of expected kubeclient actions that should happen during the
+		// test.
+		expectedActions                     []clienttesting.Action
+		storageObjectInUseProtectionEnabled bool
+	}{
+		//
+		// Secret events
+		//
+		{
+			name:          "StorageObjectInUseProtection Enabled, Secret without finalizer -> finalizer is added",
+			updatedSecret: secret(),
+			expectedActions: []clienttesting.Action{
+				clienttesting.NewUpdateAction(secretGVR, defaultNS, withProtectionFinalizer(secret())),
+			},
+			storageObjectInUseProtectionEnabled: true,
+		},
+		{
+			name:                                "StorageObjectInUseProtection Disabled, secret without finalizer -> finalizer is not added",
+			updatedSecret:                       secret(),
+			expectedActions:                     []clienttesting.Action{},
+			storageObjectInUseProtectionEnabled: false,
+		},
+		{
+			name:                                "secret with finalizer -> no action",
+			updatedSecret:                       withProtectionFinalizer(secret()),
+			expectedActions:                     []clienttesting.Action{},
+			storageObjectInUseProtectionEnabled: true,
+		},
+		{
+			name:          "saving secret finalizer fails -> controller retries",
+			updatedSecret: secret(),
+			reactors: []reaction{
+				{
+					verb:     "update",
+					resource: "secrets",
+					// update fails twice
+					reactorfn: generateUpdateErrorFunc(t, 2),
+				},
+			},
+			expectedActions: []clienttesting.Action{
+				// This fails
+				clienttesting.NewUpdateAction(secretGVR, defaultNS, withProtectionFinalizer(secret())),
+				// This fails too
+				clienttesting.NewUpdateAction(secretGVR, defaultNS, withProtectionFinalizer(secret())),
+				// This succeeds
+				clienttesting.NewUpdateAction(secretGVR, defaultNS, withProtectionFinalizer(secret())),
+			},
+			storageObjectInUseProtectionEnabled: true,
+		},
+		{
+			name:          "StorageObjectInUseProtection Enabled, deleted secret with finalizer -> finalizer is removed",
+			updatedSecret: deleted(withProtectionFinalizer(secret())),
+			expectedActions: []clienttesting.Action{
+				clienttesting.NewListAction(podGVR, podGVK, defaultNS, metav1.ListOptions{}),
+				clienttesting.NewRootListAction(pvGVR, pvGVK, metav1.ListOptions{}),
+				clienttesting.NewUpdateAction(secretGVR, defaultNS, deleted(secret())),
+			},
+			storageObjectInUseProtectionEnabled: true,
+		},
+		{
+			name:          "StorageObjectInUseProtection Disabled, deleted secret with finalizer -> finalizer is removed",
+			updatedSecret: deleted(withProtectionFinalizer(secret())),
+			expectedActions: []clienttesting.Action{
+				clienttesting.NewListAction(podGVR, podGVK, defaultNS, metav1.ListOptions{}),
+				clienttesting.NewRootListAction(pvGVR, pvGVK, metav1.ListOptions{}),
+				clienttesting.NewUpdateAction(secretGVR, defaultNS, deleted(secret())),
+			},
+			storageObjectInUseProtectionEnabled: false,
+		},
+		{
+			name:          "finalizer removal fails -> controller retries",
+			updatedSecret: deleted(withProtectionFinalizer(secret())),
+			reactors: []reaction{
+				{
+					verb:     "update",
+					resource: "secrets",
+					// update fails twice
+					reactorfn: generateUpdateErrorFunc(t, 2),
+				},
+			},
+			expectedActions: []clienttesting.Action{
+				clienttesting.NewListAction(podGVR, podGVK, defaultNS, metav1.ListOptions{}),
+				clienttesting.NewRootListAction(pvGVR, pvGVK, metav1.ListOptions{}),
+				// Fails
+				clienttesting.NewUpdateAction(secretGVR, defaultNS, deleted(secret())),
+				clienttesting.NewListAction(podGVR, podGVK, defaultNS, metav1.ListOptions{}),
+				clienttesting.NewRootListAction(pvGVR, pvGVK, metav1.ListOptions{}),
+				// Fails too
+				clienttesting.NewUpdateAction(secretGVR, defaultNS, deleted(secret())),
+				clienttesting.NewListAction(podGVR, podGVK, defaultNS, metav1.ListOptions{}),
+				clienttesting.NewRootListAction(pvGVR, pvGVK, metav1.ListOptions{}),
+				// Succeeds
+				clienttesting.NewUpdateAction(secretGVR, defaultNS, deleted(secret())),
+			},
+			storageObjectInUseProtectionEnabled: true,
+		},
+		// blocked or not blocked related to references from pod
+		{
+			name: "deleted secret with finalizer + pod with the secret exists -> finalizer is not removed",
+			initialObjects: []runtime.Object{
+				withSecret(defaultSecretName, pod()),
+			},
+			updatedSecret:   deleted(withProtectionFinalizer(secret())),
+			expectedActions: []clienttesting.Action{},
+		},
+		{
+			name: "deleted secret with finalizer + pod with unrelated secret and EmptyDir exists -> finalizer is removed",
+			initialObjects: []runtime.Object{
+				withEmptyDir(withSecret("unrelatedSecret", pod())),
+			},
+			updatedSecret: deleted(withProtectionFinalizer(secret())),
+			expectedActions: []clienttesting.Action{
+				clienttesting.NewListAction(podGVR, podGVK, defaultNS, metav1.ListOptions{}),
+				clienttesting.NewRootListAction(pvGVR, pvGVK, metav1.ListOptions{}),
+				clienttesting.NewUpdateAction(secretGVR, defaultNS, deleted(secret())),
+			},
+			storageObjectInUseProtectionEnabled: true,
+		},
+		{
+			name: "deleted secret with finalizer + pod with the secret finished but is not deleted -> finalizer is not removed",
+			initialObjects: []runtime.Object{
+				withStatus(v1.PodFailed, withSecret(defaultSecretName, pod())),
+			},
+			updatedSecret:                       deleted(withProtectionFinalizer(secret())),
+			expectedActions:                     []clienttesting.Action{},
+			storageObjectInUseProtectionEnabled: true,
+		},
+		{
+			name: "deleted secret with finalizer + pod with the secret exists but is not in the Informer's cache yet -> finalizer is not removed",
+			initialObjects: []runtime.Object{
+				withSecret(defaultSecretName, pod()),
+			},
+			informersAreLate: true,
+			updatedSecret:    deleted(withProtectionFinalizer(secret())),
+			expectedActions: []clienttesting.Action{
+				clienttesting.NewListAction(podGVR, podGVK, defaultNS, metav1.ListOptions{}),
+			},
+			storageObjectInUseProtectionEnabled: true,
+		},
+		// blocked or not blocked related to references from PV
+		{
+			name: "deleted secret with finalizer + CSI PV with the controller publish secret exists -> finalizer is not removed",
+			initialObjects: []runtime.Object{
+				withControllerPublishSecret(defaultSecretName, csiPV()),
+			},
+			updatedSecret:   deleted(withProtectionFinalizer(secret())),
+			expectedActions: []clienttesting.Action{},
+		},
+		{
+			name: "deleted secret with finalizer + CSI PV with the node stage secret exists -> finalizer is not removed",
+			initialObjects: []runtime.Object{
+				withNodeStageSecret(defaultSecretName, csiPV()),
+			},
+			updatedSecret:   deleted(withProtectionFinalizer(secret())),
+			expectedActions: []clienttesting.Action{},
+		},
+		{
+			name: "deleted secret with finalizer + CSI PV with the node publish secret exists -> finalizer is not removed",
+			initialObjects: []runtime.Object{
+				withNodePublishSecret(defaultSecretName, csiPV()),
+			},
+			updatedSecret:   deleted(withProtectionFinalizer(secret())),
+			expectedActions: []clienttesting.Action{},
+		},
+		{
+			name: "deleted secret with finalizer + CSI PV with unrelated secret set to node publish secret -> finalizer is removed",
+			initialObjects: []runtime.Object{
+				withNodePublishSecret("UnrelatedSecret", csiPV()),
+			},
+			updatedSecret: deleted(withProtectionFinalizer(secret())),
+			expectedActions: []clienttesting.Action{
+				clienttesting.NewListAction(podGVR, podGVK, defaultNS, metav1.ListOptions{}),
+				clienttesting.NewRootListAction(pvGVR, pvGVK, metav1.ListOptions{}),
+				clienttesting.NewUpdateAction(secretGVR, defaultNS, deleted(secret())),
+			},
+			storageObjectInUseProtectionEnabled: true,
+		},
+		{
+			name: "deleted secret with finalizer + CSI PV with the node stage secret is requested to delete but is not deleted -> finalizer is not removed",
+			initialObjects: []runtime.Object{
+				withVolumeStatus(v1.VolumeReleased, withNodeStageSecret(defaultSecretName, csiPV())),
+			},
+			updatedSecret:                       deleted(withProtectionFinalizer(secret())),
+			expectedActions:                     []clienttesting.Action{},
+			storageObjectInUseProtectionEnabled: true,
+		},
+		{
+			name: "deleted secret with finalizer + CSI PV with the controller publish secret exists but is not in the Informer's cache yet -> finalizer is not removed",
+			initialObjects: []runtime.Object{
+				withControllerPublishSecret(defaultSecretName, csiPV()),
+			},
+			informersAreLate: true,
+			updatedSecret:    deleted(withProtectionFinalizer(secret())),
+			expectedActions: []clienttesting.Action{
+				clienttesting.NewListAction(podGVR, podGVK, defaultNS, metav1.ListOptions{}),
+				clienttesting.NewRootListAction(pvGVR, pvGVK, metav1.ListOptions{}),
+			},
+			storageObjectInUseProtectionEnabled: true,
+		},
+		{
+			name: "deleted secret with finalizer + CSI PV with the controller expand secret exists but is not in the Informer's cache yet -> finalizer is not removed",
+			initialObjects: []runtime.Object{
+				withControllerExpandSecret(defaultSecretName, csiPV()),
+			},
+			informersAreLate: true,
+			updatedSecret:    deleted(withProtectionFinalizer(secret())),
+			expectedActions: []clienttesting.Action{
+				clienttesting.NewListAction(podGVR, podGVK, defaultNS, metav1.ListOptions{}),
+				clienttesting.NewRootListAction(pvGVR, pvGVK, metav1.ListOptions{}),
+			},
+			storageObjectInUseProtectionEnabled: true,
+		},
+		//
+		// Pod events
+		//
+		{
+			name: "updated running Pod -> no action",
+			initialObjects: []runtime.Object{
+				deleted(withProtectionFinalizer(secret())),
+			},
+			updatedPod:                          withStatus(v1.PodRunning, withSecret(defaultSecretName, pod())),
+			expectedActions:                     []clienttesting.Action{},
+			storageObjectInUseProtectionEnabled: true,
+		},
+		{
+			name: "updated finished Pod -> finalizer is not removed",
+			initialObjects: []runtime.Object{
+				deleted(withProtectionFinalizer(secret())),
+			},
+			updatedPod:                          withStatus(v1.PodSucceeded, withSecret(defaultSecretName, pod())),
+			expectedActions:                     []clienttesting.Action{},
+			storageObjectInUseProtectionEnabled: true,
+		},
+		{
+			name: "updated unscheduled Pod -> finalizer is removed",
+			initialObjects: []runtime.Object{
+				deleted(withProtectionFinalizer(secret())),
+			},
+			updatedPod: unscheduled(withSecret(defaultSecretName, pod())),
+			expectedActions: []clienttesting.Action{
+				clienttesting.NewListAction(podGVR, podGVK, defaultNS, metav1.ListOptions{}),
+				clienttesting.NewRootListAction(pvGVR, pvGVK, metav1.ListOptions{}),
+				clienttesting.NewUpdateAction(secretGVR, defaultNS, deleted(secret())),
+			},
+			storageObjectInUseProtectionEnabled: true,
+		},
+		{
+			name: "deleted running Pod -> finalizer is removed",
+			initialObjects: []runtime.Object{
+				deleted(withProtectionFinalizer(secret())),
+			},
+			deletedPod: withStatus(v1.PodRunning, withSecret(defaultSecretName, pod())),
+			expectedActions: []clienttesting.Action{
+				clienttesting.NewListAction(podGVR, podGVK, defaultNS, metav1.ListOptions{}),
+				clienttesting.NewRootListAction(pvGVR, pvGVK, metav1.ListOptions{}),
+				clienttesting.NewUpdateAction(secretGVR, defaultNS, deleted(secret())),
+			},
+			storageObjectInUseProtectionEnabled: true,
+		},
+		{
+			name: "pod delete and create with same namespaced name seen as an update, old pod used deleted secret -> finalizer is removed",
+			initialObjects: []runtime.Object{
+				deleted(withProtectionFinalizer(secret())),
+			},
+			deletedPod: withSecret(defaultSecretName, pod()),
+			updatedPod: withUID("uid2", pod()),
+			expectedActions: []clienttesting.Action{
+				clienttesting.NewListAction(podGVR, podGVK, defaultNS, metav1.ListOptions{}),
+				clienttesting.NewRootListAction(pvGVR, pvGVK, metav1.ListOptions{}),
+				clienttesting.NewUpdateAction(secretGVR, defaultNS, deleted(secret())),
+			},
+			storageObjectInUseProtectionEnabled: true,
+		},
+		{
+			name: "pod delete and create with same namespaced name seen as an update, old pod used non-deleted secret -> finalizer is not removed",
+			initialObjects: []runtime.Object{
+				// Not deleted
+				withProtectionFinalizer(secret()),
+			},
+			deletedPod:                          withSecret(defaultSecretName, pod()),
+			updatedPod:                          withUID("uid2", pod()),
+			expectedActions:                     []clienttesting.Action{},
+			storageObjectInUseProtectionEnabled: true,
+		},
+		{
+			name: "pod delete and create with same namespaced name seen as an update, both pods reference deleted secret -> finalizer is not removed",
+			initialObjects: []runtime.Object{
+				deleted(withProtectionFinalizer(secret())),
+			},
+			deletedPod:                          withSecret(defaultSecretName, pod()),
+			updatedPod:                          withUID("uid2", withSecret(defaultSecretName, pod())),
+			expectedActions:                     []clienttesting.Action{},
+			storageObjectInUseProtectionEnabled: true,
+		},
+		{
+			name: "pod update from unscheduled to scheduled, deleted secret is referenced -> finalizer is not removed",
+			initialObjects: []runtime.Object{
+				deleted(withProtectionFinalizer(secret())),
+			},
+			deletedPod:                          unscheduled(withSecret(defaultSecretName, pod())),
+			updatedPod:                          withSecret(defaultSecretName, pod()),
+			expectedActions:                     []clienttesting.Action{},
+			storageObjectInUseProtectionEnabled: true,
+		},
+		//
+		// PV events
+		//
+		{
+			name: "updated PV status -> no action",
+			initialObjects: []runtime.Object{
+				deleted(withProtectionFinalizer(secret())),
+			},
+			updatedPV:                           withVolumeStatus(v1.VolumeBound, withNodeStageSecret(defaultSecretName, csiPV())),
+			expectedActions:                     []clienttesting.Action{},
+			storageObjectInUseProtectionEnabled: true,
+		},
+		{
+			name: "PV delete and create seen as an update, old PV used deleted secret -> finalizer is removed",
+			initialObjects: []runtime.Object{
+				deleted(withProtectionFinalizer(secret())),
+			},
+			deletedPV: withNodeStageSecret(defaultSecretName, csiPV()),
+			updatedPV: withPVUID("uid2", csiPV()),
+			expectedActions: []clienttesting.Action{
+				clienttesting.NewListAction(podGVR, podGVK, defaultNS, metav1.ListOptions{}),
+				clienttesting.NewRootListAction(pvGVR, pvGVK, metav1.ListOptions{}),
+				clienttesting.NewUpdateAction(secretGVR, defaultNS, deleted(secret())),
+			},
+			storageObjectInUseProtectionEnabled: true,
+		},
+		{
+			name: "PV delete and create seen as an update, old PV used non-deleted secret -> finalizer is not removed",
+			initialObjects: []runtime.Object{
+				// Not deleted
+				withProtectionFinalizer(secret()),
+			},
+			deletedPV:                           withNodeStageSecret(defaultSecretName, csiPV()),
+			updatedPV:                           withPVUID("uid2", csiPV()),
+			expectedActions:                     []clienttesting.Action{},
+			storageObjectInUseProtectionEnabled: true,
+		},
+		{
+			name: "PV delete and create seen as an update, both PVs reference deleted secret -> finalizer is not removed",
+			initialObjects: []runtime.Object{
+				deleted(withProtectionFinalizer(secret())),
+			},
+			deletedPV:                           withNodePublishSecret(defaultSecretName, csiPV()),
+			updatedPV:                           withPVUID("uid2", withControllerPublishSecret(defaultSecretName, csiPV())),
+			expectedActions:                     []clienttesting.Action{},
+			storageObjectInUseProtectionEnabled: true,
+		},
+	}
+
+	for _, test := range tests {
+		// Create initial data for client and informers.
+		var (
+			clientObjs    []runtime.Object
+			informersObjs []runtime.Object
+		)
+		if test.updatedSecret != nil {
+			clientObjs = append(clientObjs, test.updatedSecret)
+			informersObjs = append(informersObjs, test.updatedSecret)
+		}
+		if test.updatedPod != nil {
+			clientObjs = append(clientObjs, test.updatedPod)
+			informersObjs = append(informersObjs, test.updatedPod)
+		}
+		if test.updatedPV != nil {
+			clientObjs = append(clientObjs, test.updatedPV)
+			informersObjs = append(informersObjs, test.updatedPV)
+		}
+		clientObjs = append(clientObjs, test.initialObjects...)
+		if !test.informersAreLate {
+			informersObjs = append(informersObjs, test.initialObjects...)
+		}
+
+		// Create client with initial data
+		client := fake.NewSimpleClientset(clientObjs...)
+
+		// Create informers
+		informers := informers.NewSharedInformerFactory(client, controller.NoResyncPeriodFunc())
+		secretInformer := informers.Core().V1().Secrets()
+		podInformer := informers.Core().V1().Pods()
+		pvInformer := informers.Core().V1().PersistentVolumes()
+
+		// Create the controller
+		ctrl := NewSecretProtectionController(secretInformer, podInformer, pvInformer, client, test.storageObjectInUseProtectionEnabled)
+
+		// Populate the informers with initial objects so the controller can
+		// Get() and List() it.
+		for _, obj := range informersObjs {
+			switch obj.(type) {
+			case *v1.Secret:
+				secretInformer.Informer().GetStore().Add(obj)
+			case *v1.Pod:
+				podInformer.Informer().GetStore().Add(obj)
+			case *v1.PersistentVolume:
+				pvInformer.Informer().GetStore().Add(obj)
+			default:
+				t.Fatalf("Unknown initalObject type: %+v", obj)
+			}
+		}
+
+		// Add reactor to inject test errors.
+		for _, reactor := range test.reactors {
+			client.Fake.PrependReactor(reactor.verb, reactor.resource, reactor.reactorfn)
+		}
+
+		// Start the test by simulating an event
+		if test.updatedSecret != nil {
+			ctrl.secretAddedUpdated(test.updatedSecret)
+		}
+		switch {
+		case test.deletedPod != nil && test.updatedPod != nil && test.deletedPod.Namespace == test.updatedPod.Namespace && test.deletedPod.Name == test.updatedPod.Name:
+			ctrl.podAddedDeletedUpdated(test.deletedPod, test.updatedPod, false)
+		case test.updatedPod != nil:
+			ctrl.podAddedDeletedUpdated(nil, test.updatedPod, false)
+		case test.deletedPod != nil:
+			ctrl.podAddedDeletedUpdated(nil, test.deletedPod, true)
+		case test.deletedPV != nil && test.updatedPV != nil && test.deletedPV.Name == test.updatedPV.Name:
+			ctrl.pvAddedDeletedUpdated(test.deletedPV, test.updatedPV, false)
+		case test.updatedPV != nil:
+			ctrl.pvAddedDeletedUpdated(nil, test.updatedPV, false)
+		case test.deletedPV != nil:
+			ctrl.pvAddedDeletedUpdated(nil, test.deletedPV, true)
+		}
+
+		// Process the controller queue until we get expected results
+		timeout := time.Now().Add(10 * time.Second)
+		lastReportedActionCount := 0
+		for {
+			if time.Now().After(timeout) {
+				t.Errorf("Test %q: timed out", test.name)
+				break
+			}
+			if ctrl.queue.Len() > 0 {
+				klog.V(5).Infof("Test %q: %d events queue, processing one", test.name, ctrl.queue.Len())
+				ctrl.processNextWorkItem()
+			}
+			if ctrl.queue.Len() > 0 {
+				// There is still some work in the queue, process it now
+				continue
+			}
+			currentActionCount := len(client.Actions())
+			if currentActionCount < len(test.expectedActions) {
+				// Do not log every wait, only when the action count changes.
+				if lastReportedActionCount < currentActionCount {
+					klog.V(5).Infof("Test %q: got %d actions out of %d, waiting for the rest", test.name, currentActionCount, len(test.expectedActions))
+					lastReportedActionCount = currentActionCount
+				}
+				// The test expected more to happen, wait for the actions.
+				// Most probably it's exponential backoff
+				time.Sleep(10 * time.Millisecond)
+				continue
+			}
+			break
+		}
+		actions := client.Actions()
+		for i, action := range actions {
+			if len(test.expectedActions) < i+1 {
+				t.Errorf("Test %q: %d unexpected actions: %+v", test.name, len(actions)-len(test.expectedActions), spew.Sdump(actions[i:]))
+				break
+			}
+
+			expectedAction := test.expectedActions[i]
+			if !reflect.DeepEqual(expectedAction, action) {
+				t.Errorf("Test %q: action %d\nExpected:\n%s\ngot:\n%s", test.name, i, spew.Sdump(expectedAction), spew.Sdump(action))
+			}
+		}
+
+		if len(test.expectedActions) > len(actions) {
+			t.Errorf("Test %q: %d additional expected actions", test.name, len(test.expectedActions)-len(actions))
+			for _, a := range test.expectedActions[len(actions):] {
+				t.Logf("    %+v", a)
+			}
+		}
+
+	}
+}

--- a/pkg/volume/util/finalizer.go
+++ b/pkg/volume/util/finalizer.go
@@ -22,4 +22,7 @@ const (
 
 	// PVProtectionFinalizer is the name of finalizer on PVs that are bound by PVCs
 	PVProtectionFinalizer = "kubernetes.io/pv-protection"
+
+	// SecretProtectionFinalizer is the name of finalizer on secrets that are consumed by the other resources
+	SecretProtectionFinalizer = "kubernetes.io/secret-protection"
 )

--- a/plugin/pkg/admission/storage/storageobjectinuseprotection/admission_test.go
+++ b/plugin/pkg/admission/storage/storageobjectinuseprotection/admission_test.go
@@ -50,11 +50,25 @@ func TestAdmit(t *testing.T) {
 			Name: "pv",
 		},
 	}
+
+	secret := &api.Secret{
+		TypeMeta: metav1.TypeMeta{
+			Kind: "Secret",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "secret",
+			Namespace: "ns",
+		},
+	}
+
 	claimWithFinalizer := claim.DeepCopy()
 	claimWithFinalizer.Finalizers = []string{volumeutil.PVCProtectionFinalizer}
 
 	pvWithFinalizer := pv.DeepCopy()
 	pvWithFinalizer.Finalizers = []string{volumeutil.PVProtectionFinalizer}
+
+	secretWithFinalizer := secret.DeepCopy()
+	secretWithFinalizer.Finalizers = []string{volumeutil.SecretProtectionFinalizer}
 
 	tests := []struct {
 		name           string
@@ -111,6 +125,30 @@ func TestAdmit(t *testing.T) {
 			pv,
 			false,
 			pv.Namespace,
+		},
+		{
+			"create -> add finalizer",
+			api.SchemeGroupVersion.WithResource("secrets"),
+			secret,
+			secretWithFinalizer,
+			true,
+			secret.Namespace,
+		},
+		{
+			"finalizer already exists -> no new finalizer",
+			api.SchemeGroupVersion.WithResource("secrets"),
+			secretWithFinalizer,
+			secretWithFinalizer,
+			true,
+			secretWithFinalizer.Namespace,
+		},
+		{
+			"disabled feature -> no finalizer",
+			api.SchemeGroupVersion.WithResource("secrets"),
+			secret,
+			secret,
+			false,
+			secret.Namespace,
 		},
 	}
 

--- a/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/controller_policy.go
+++ b/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/controller_policy.go
@@ -397,6 +397,8 @@ func buildControllerRoles() ([]rbacv1.ClusterRole, []rbacv1.ClusterRoleBinding) 
 			rbacv1helpers.NewRule("get", "list", "watch", "update").Groups(legacyGroup).Resources("secrets").RuleOrDie(),
 			rbacv1helpers.NewRule("list", "watch", "get").Groups(legacyGroup).Resources("pods").RuleOrDie(),
 			rbacv1helpers.NewRule("list", "watch", "get").Groups(legacyGroup).Resources("persistentvolumes").RuleOrDie(),
+			rbacv1helpers.NewRule("list", "get").Groups(legacyGroup).Resources("persistentvolumeclaims").RuleOrDie(),
+			rbacv1helpers.NewRule("list", "get").Groups(storageGroup).Resources("storageclasses").RuleOrDie(),
 			eventsRule(),
 		},
 	})

--- a/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/controller_policy.go
+++ b/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/controller_policy.go
@@ -391,6 +391,15 @@ func buildControllerRoles() ([]rbacv1.ClusterRole, []rbacv1.ClusterRoleBinding) 
 			eventsRule(),
 		},
 	})
+	addControllerRole(&controllerRoles, &controllerRoleBindings, rbacv1.ClusterRole{
+		ObjectMeta: metav1.ObjectMeta{Name: saRolePrefix + "secret-protection-controller"},
+		Rules: []rbacv1.PolicyRule{
+			rbacv1helpers.NewRule("get", "list", "watch", "update").Groups(legacyGroup).Resources("secrets").RuleOrDie(),
+			rbacv1helpers.NewRule("list", "watch", "get").Groups(legacyGroup).Resources("pods").RuleOrDie(),
+			rbacv1helpers.NewRule("list", "watch", "get").Groups(legacyGroup).Resources("persistentvolumes").RuleOrDie(),
+			eventsRule(),
+		},
+	})
 	if utilfeature.DefaultFeatureGate.Enabled(features.TTLAfterFinished) {
 		addControllerRole(&controllerRoles, &controllerRoleBindings, rbacv1.ClusterRole{
 			ObjectMeta: metav1.ObjectMeta{Name: saRolePrefix + "ttl-after-finished-controller"},

--- a/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/testdata/controller-roles.yaml
+++ b/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/testdata/controller-roles.yaml
@@ -1326,6 +1326,20 @@ items:
     - watch
   - apiGroups:
     - ""
+    resources:
+    - persistentvolumeclaims
+    verbs:
+    - get
+    - list
+  - apiGroups:
+    - storage.k8s.io
+    resources:
+    - storageclasses
+    verbs:
+    - get
+    - list
+  - apiGroups:
+    - ""
     - events.k8s.io
     resources:
     - events

--- a/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/testdata/controller-roles.yaml
+++ b/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/testdata/controller-roles.yaml
@@ -1297,6 +1297,50 @@ items:
     creationTimestamp: null
     labels:
       kubernetes.io/bootstrapping: rbac-defaults
+    name: system:controller:secret-protection-controller
+  rules:
+  - apiGroups:
+    - ""
+    resources:
+    - secrets
+    verbs:
+    - get
+    - list
+    - update
+    - watch
+  - apiGroups:
+    - ""
+    resources:
+    - pods
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - ""
+    resources:
+    - persistentvolumes
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - ""
+    - events.k8s.io
+    resources:
+    - events
+    verbs:
+    - create
+    - patch
+    - update
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: ClusterRole
+  metadata:
+    annotations:
+      rbac.authorization.kubernetes.io/autoupdate: "true"
+    creationTimestamp: null
+    labels:
+      kubernetes.io/bootstrapping: rbac-defaults
     name: system:controller:service-account-controller
   rules:
   - apiGroups:

--- a/test/e2e/storage/secret_protection.go
+++ b/test/e2e/storage/secret_protection.go
@@ -1,0 +1,215 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package storage
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/onsi/ginkgo"
+	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/uuid"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/kubernetes/pkg/util/slice"
+	volumeutil "k8s.io/kubernetes/pkg/volume/util"
+	"k8s.io/kubernetes/test/e2e/framework"
+	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
+	e2epv "k8s.io/kubernetes/test/e2e/framework/pv"
+	"k8s.io/kubernetes/test/e2e/storage/utils"
+)
+
+type csiSecretType string
+
+const (
+	controllerPublishSecret csiSecretType = "ControllerPublishSecret"
+	nodeStageSecret         csiSecretType = "NodeStageSecret"
+	nodePublishSecret       csiSecretType = "NodePublishSecret"
+	controllerExpandSecret  csiSecretType = "ControllerExpandSecret"
+
+	// secretDeleteTimeout is how long to wait for a secret to be deleted.
+	secretDeleteTimeout = 1 * time.Minute
+	// secretDeleteTimeout is how long to wait for a (portected) secret not to be deleted.
+	secretNotDeletedTimeout = 5 * time.Second
+)
+
+var _ = utils.SIGDescribe("Secret Protection", func() {
+	var (
+		err    error
+		secret *v1.Secret
+	)
+
+	f := framework.NewDefaultFramework("secret-protection")
+
+	ginkgo.BeforeEach(func() {
+		framework.ExpectNoError(framework.WaitForAllNodesSchedulable(f.ClientSet, framework.TestContext.NodeSchedulableTimeout))
+
+		secret = &v1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: f.Namespace.Name,
+				Name:      "protect-secret-" + string(uuid.NewUUID()),
+			},
+			Data: map[string][]byte{
+				"data-1": []byte("value-1\n"),
+			},
+		}
+
+		ginkgo.By("Creating a secret")
+		if secret, err = f.ClientSet.CoreV1().Secrets(f.Namespace.Name).Create(context.TODO(), secret, metav1.CreateOptions{}); err != nil {
+			framework.Failf("unable to create test secret %s: %v", secret.Name, err)
+		}
+
+		ginkgo.By("Checking that Secret Protection finalizer is set")
+		framework.ExpectEqual(slice.ContainsString(secret.ObjectMeta.Finalizers, volumeutil.SecretProtectionFinalizer, nil), true, "Secret Protection finalizer(%v) is not set in %v", volumeutil.SecretProtectionFinalizer, secret.ObjectMeta.Finalizers)
+
+	})
+
+	ginkgo.It("Verify \"immediate\" deletion of a secret that is not used", func() {
+		ginkgo.By("Deleting the secret")
+		err = f.ClientSet.CoreV1().Secrets(f.Namespace.Name).Delete(context.TODO(), secret.Name, metav1.DeleteOptions{})
+		framework.ExpectNoError(err, "Error deleting secret")
+
+		ginkgo.By("Waiting for the unprotected secret to be deleted")
+		err = waitForSecretDeleted(f.ClientSet, f.Namespace.Name, secret.Name, framework.Poll, secretDeleteTimeout)
+		framework.ExpectNoError(err, "Error waiting for secret deleted")
+	})
+
+	ginkgo.It("Verify that secret used by a Pod is not removed immediately", func() {
+		ginkgo.By("Creating a pod using the secret")
+		podConfig := &e2epod.Config{
+			NS:      f.Namespace.Name,
+			ImageID: e2epod.GetDefaultTestImageID(),
+			InlineVolumeSources: []*v1.VolumeSource{
+				{
+					Secret: &v1.SecretVolumeSource{
+						SecretName: secret.Name,
+					},
+				},
+			},
+		}
+		pod, err := e2epod.CreateSecPod(f.ClientSet, podConfig, f.Timeouts.PodStartShort)
+		framework.ExpectNoError(err, "Error creating secret")
+
+		ginkgo.By("Deleting the secret")
+		err = f.ClientSet.CoreV1().Secrets(f.Namespace.Name).Delete(context.TODO(), secret.Name, metav1.DeleteOptions{})
+		framework.ExpectNoError(err, "Error deleting secret")
+
+		ginkgo.By("Waiting for the protected secret not to be deleted")
+		err = waitForSecretDeleted(f.ClientSet, f.Namespace.Name, secret.Name, framework.Poll, secretNotDeletedTimeout)
+		framework.ExpectError(err, "Protected Secret is unexpectedly deleted")
+
+		ginkgo.By("Deleting the pod using the secret")
+		err = e2epod.DeletePodWithWait(f.ClientSet, pod)
+
+		ginkgo.By("Waiting for the unprotected secret to be deleted")
+		err = waitForSecretDeleted(f.ClientSet, f.Namespace.Name, secret.Name, framework.Poll, secretDeleteTimeout)
+		framework.ExpectNoError(err, "Error waiting for secret deleted")
+	})
+
+	ginkgo.It("Verify that secret used by a CSI PV as controllerPublishSecret is not removed immediately", func() {
+		testDeleteSecretUsedByPV(f.ClientSet, f.Namespace.Name, secret.Name, controllerPublishSecret)
+	})
+
+	ginkgo.It("Verify that secret used by a CSI PV as nodeStageSecret is not removed immediately", func() {
+		testDeleteSecretUsedByPV(f.ClientSet, f.Namespace.Name, secret.Name, nodeStageSecret)
+	})
+
+	ginkgo.It("Verify that secret used by a CSI PV as nodePublishSecret is not removed immediately", func() {
+		testDeleteSecretUsedByPV(f.ClientSet, f.Namespace.Name, secret.Name, nodePublishSecret)
+	})
+
+	ginkgo.It("Verify that secret used by a CSI PV as controllerExpandSecret is not removed immediately", func() {
+		testDeleteSecretUsedByPV(f.ClientSet, f.Namespace.Name, secret.Name, controllerExpandSecret)
+	})
+})
+
+func testDeleteSecretUsedByPV(cs clientset.Interface, namespace, secretName string, secretType csiSecretType) {
+	ginkgo.By(fmt.Sprintf("Creating a CSI PV using the secret as %v", secretType))
+	pv := createPVUsingSecret(cs, namespace, secretName, secretType)
+
+	ginkgo.By("Deleting the secret")
+	err := cs.CoreV1().Secrets(namespace).Delete(context.TODO(), secretName, metav1.DeleteOptions{})
+	framework.ExpectNoError(err, "Error deleting secret")
+
+	ginkgo.By("Waiting for the protected secret not to be deleted")
+	err = waitForSecretDeleted(cs, namespace, secretName, framework.Poll, secretNotDeletedTimeout)
+	framework.ExpectError(err, "Protected Secret is unexpectedly deleted")
+
+	ginkgo.By("Deleting the PV using the secret")
+	err = e2epv.DeletePersistentVolume(cs, pv.Name)
+	framework.ExpectNoError(err, "Failed to delete PV")
+
+	ginkgo.By("Waiting for the unprotected secret to be deleted")
+	err = waitForSecretDeleted(cs, namespace, secretName, framework.Poll, secretDeleteTimeout)
+	framework.ExpectNoError(err, "Error waiting for secret deleted")
+}
+
+func createPVUsingSecret(cs clientset.Interface, namespace, secretName string, secretType csiSecretType) *v1.PersistentVolume {
+	secretRef := &v1.SecretReference{
+		Namespace: namespace,
+		Name:      secretName,
+	}
+	csiVolSource := &v1.CSIPersistentVolumeSource{
+		Driver:       "com.example.dummy",
+		VolumeHandle: string(uuid.NewUUID()),
+	}
+
+	switch secretType {
+	case controllerPublishSecret:
+		csiVolSource.ControllerPublishSecretRef = secretRef
+	case nodeStageSecret:
+		csiVolSource.NodeStageSecretRef = secretRef
+	case nodePublishSecret:
+		csiVolSource.NodePublishSecretRef = secretRef
+	case controllerExpandSecret:
+		csiVolSource.ControllerExpandSecretRef = secretRef
+	default:
+		framework.Failf("Unkown secretType %v is specified", secretType)
+	}
+
+	pvConfig := e2epv.PersistentVolumeConfig{
+		PVSource: v1.PersistentVolumeSource{
+			CSI: csiVolSource,
+		},
+	}
+
+	pv := e2epv.MakePersistentVolume(pvConfig)
+	pv, err := e2epv.CreatePV(cs, pv)
+	framework.ExpectNoError(err, "Error creating secret")
+
+	return pv
+}
+
+// waitForSecretDeleted waits for a Secret to get deleted or until timeout occurs, whichever comes first.
+func waitForSecretDeleted(c clientset.Interface, namespace, secretName string, poll, timeout time.Duration) error {
+	framework.Logf("Waiting up to %v for Secret %s to get deleted", timeout, secretName)
+	for start := time.Now(); time.Since(start) < timeout; time.Sleep(poll) {
+		_, err := c.CoreV1().Secrets(namespace).Get(context.TODO(), secretName, metav1.GetOptions{})
+		if err == nil {
+			framework.Logf("Secret %s found (%v)", secretName, time.Since(start))
+			continue
+		}
+		if apierrors.IsNotFound(err) {
+			framework.Logf("Secret %s was removed", secretName)
+			return nil
+		}
+		framework.Logf("Get secret %s in failed, ignoring for %v: %v", secretName, poll, err)
+	}
+	return fmt.Errorf("Secret %s still exists within %v", secretName, timeout)
+}


### PR DESCRIPTION
#### What type of PR is this?
This PR adds secret-protection for protecting secret from deletion while it is in-use.

/kind feature

#### What this PR does / why we need it:
In the current k8s implementation, secret can be deleted while it is still used by other resources.
This will cause such issues that volume is failed to delete because secret needed for delete the volume is deleted before volume deletion.

#### Which issue(s) this PR fixes:

Fixes #101130

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Deletion of a secret is blocked until all pods and PVs that are using the secret are deleted.   
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
