### PR TITLE
e2e: use kubelet 10248 as health check port instead of 10255

### DIFF
--- a/test/e2e_node/conformance/run_test.sh
+++ b/test/e2e_node/conformance/run_test.sh
@@ -126,10 +126,10 @@ start_kubelet() {
   fi
 }
 
-# wait_kubelet retries for 10 times for kubelet to be ready by checking http://127.0.0.1:10255/healthz.
+# wait_kubelet retries for 10 times for kubelet to be ready by checking http://127.0.0.1:10248/healthz.
 wait_kubelet() {
   echo "Health checking kubelet..."
-  healthCheckURL=http://127.0.0.1:10255/healthz
+  healthCheckURL=http://127.0.0.1:10248/healthz
   local maxRetry=10
   local cur=1
   while [ $cur -le $maxRetry ]; do

--- a/test/e2e_node/services/kubelet.go
+++ b/test/e2e_node/services/kubelet.go
@@ -87,11 +87,11 @@ func RunKubelet() {
 
 const (
 	// Ports of different e2e services.
-	kubeletReadOnlyPort = "10255"
+	kubeletHealthCheckPort = "10248"
 	// KubeletRootDirectory specifies the directory where the kubelet runtime information is stored.
 	KubeletRootDirectory = "/var/lib/kubelet"
 	// Health check url of kubelet
-	kubeletHealthCheckURL = "http://127.0.0.1:" + kubeletReadOnlyPort + "/healthz"
+	kubeletHealthCheckURL = "http://127.0.0.1:" + kubeletHealthCheckPort + "/healthz"
 )
 
 // startKubelet starts the Kubelet in a separate process or returns an error

--- a/test/e2e_node/util.go
+++ b/test/e2e_node/util.go
@@ -71,8 +71,8 @@ const (
 	defaultPodResourcesPath    = "/var/lib/kubelet/pod-resources"
 	defaultPodResourcesTimeout = 10 * time.Second
 	defaultPodResourcesMaxSize = 1024 * 1024 * 16 // 16 Mb
-	kubeletReadOnlyPort        = "10255"
-	kubeletHealthCheckURL      = "http://127.0.0.1:" + kubeletReadOnlyPort + "/healthz"
+	kubeletHealthCheckPort     = "10248"
+	kubeletHealthCheckURL      = "http://127.0.0.1:" + kubeletHealthCheckPort + "/healthz"
 )
 
 func getNodeSummary() (*stats.Summary, error) {


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
`healthCheckURL=http://127.0.0.1:10248/healthz`
instead of 
`healthCheckURL=http://127.0.0.1:10255/healthz`

#### Which issue(s) this PR fixes:
xrefs #12968:  deprecate Kubelet Read-only port (in the future)

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
None
```