### PR TITLE
Limit image spec's hash length

### DIFF
--- a/test/utils/image/manifest.go
+++ b/test/utils/image/manifest.go
@@ -306,7 +306,7 @@ func getRepositoryMappedConfig(index int, config Config, repo string) Config {
 
 	h := sha256.New()
 	h.Write([]byte(pullSpec))
-	hash := base64.RawURLEncoding.EncodeToString(h.Sum(nil)[:16])
+	hash := base64.RawURLEncoding.EncodeToString(h.Sum(nil))[:16]
 
 	shortName := reCharSafe.ReplaceAllLiteralString(pullSpec, "-")
 	shortName = reDashes.ReplaceAllLiteralString(shortName, "-")

--- a/test/utils/image/manifest_test.go
+++ b/test/utils/image/manifest_test.go
@@ -149,7 +149,7 @@ func TestGetMappedImageConfigs(t *testing.T) {
 		actual[source.GetE2EImage()] = mapping.GetE2EImage()
 	}
 	expected := map[string]string{
-		"docker.io/source/repo:1.0": "quay.io/repo/for-test:e2e-0-docker-io-source-repo-1-0-72R4aXm7YnxQ4_ekf1DrFA",
+		"docker.io/source/repo:1.0": "quay.io/repo/for-test:e2e-0-docker-io-source-repo-1-0-72R4aXm7YnxQ4_ek",
 	}
 	if !reflect.DeepEqual(expected, actual) {
 		t.Fatal(diff.ObjectReflectDiff(expected, actual))


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
To be able to properly limit the length of hash string we should limit after encoding to base, not before.

#### Special notes for your reviewer:
/assign @smarterclayton 

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
