### PR TITLE
Automated cherry pick of #99729: Only system-node-critical pods should be OOM Killed last

### DIFF
--- a/pkg/kubelet/qos/policy.go
+++ b/pkg/kubelet/qos/policy.go
@@ -38,8 +38,8 @@ const (
 // and 1000. Containers with higher OOM scores are killed if the system runs out of memory.
 // See https://lwn.net/Articles/391222/ for more information.
 func GetContainerOOMScoreAdjust(pod *v1.Pod, container *v1.Container, memoryCapacity int64) int {
-	if types.IsCriticalPod(pod) {
-		// Critical pods should be the last to get killed.
+	if types.IsNodeCriticalPod(pod) {
+		// Only node critical pod should be the last to get killed.
 		return guaranteedOOMScoreAdj
 	}
 

--- a/pkg/kubelet/qos/policy_test.go
+++ b/pkg/kubelet/qos/policy_test.go
@@ -139,9 +139,24 @@ var (
 
 	systemCritical = scheduling.SystemCriticalPriority
 
-	critical = v1.Pod{
+	clusterCritical = v1.Pod{
 		Spec: v1.PodSpec{
-			Priority: &systemCritical,
+			PriorityClassName: scheduling.SystemClusterCritical,
+			Priority:          &systemCritical,
+			Containers: []v1.Container{
+				{
+					Resources: v1.ResourceRequirements{},
+				},
+			},
+		},
+	}
+
+	systemNodeCritical = scheduling.SystemCriticalPriority + 1000
+
+	nodeCritical = v1.Pod{
+		Spec: v1.PodSpec{
+			PriorityClassName: scheduling.SystemNodeCritical,
+			Priority:          &systemNodeCritical,
 			Containers: []v1.Container{
 				{
 					Resources: v1.ResourceRequirements{},
@@ -203,7 +218,13 @@ func TestGetContainerOOMScoreAdjust(t *testing.T) {
 			highOOMScoreAdj: 3,
 		},
 		{
-			pod:             &critical,
+			pod:             &clusterCritical,
+			memoryCapacity:  4000000000,
+			lowOOMScoreAdj:  1000,
+			highOOMScoreAdj: 1000,
+		},
+		{
+			pod:             &nodeCritical,
 			memoryCapacity:  4000000000,
 			lowOOMScoreAdj:  -997,
 			highOOMScoreAdj: -997,

--- a/pkg/kubelet/types/pod_update.go
+++ b/pkg/kubelet/types/pod_update.go
@@ -179,3 +179,8 @@ func Preemptable(preemptor, preemptee *v1.Pod) bool {
 func IsCriticalPodBasedOnPriority(priority int32) bool {
 	return priority >= scheduling.SystemCriticalPriority
 }
+
+// IsNodeCriticalPod checks if the given pod is a system-node-critical
+func IsNodeCriticalPod(pod *v1.Pod) bool {
+	return IsCriticalPod(pod) && (pod.Spec.PriorityClassName == scheduling.SystemNodeCritical)
+}


### PR DESCRIPTION
Cherry pick of #99729 on release-1.20.

#99729: Only system-node-critical pods should be OOM Killed last

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.


```release-note
System-cluster-critical pods should not get a low OOM Score. 

As of now both system-node-critical and system-cluster-critical pods have -997 OOM score, making them one of the last processes to be OOMKilled. By definition system-cluster-critical pods can be scheduled elsewhere if there is a resource crunch on the node where as system-node-critical pods cannot be rescheduled. This was the reason for system-node-critical to have higher priority value than system-cluster-critical.  This change allows only system-node-critical priority class to have low OOMScore.

action required
If the user wants to have the pod to be OOMKilled last and the pod has system-cluster-critical priority class, it has to be changed to system-node-critical priority class to preserve the existing behavior
```