### PR TITLE
allow multiple of --service-account-issuer

### DIFF
--- a/cmd/kube-apiserver/app/options/validation.go
+++ b/cmd/kube-apiserver/app/options/validation.go
@@ -113,7 +113,7 @@ func validateTokenRequest(options *ServerRunOptions) []error {
 	var errs []error
 
 	enableAttempted := options.ServiceAccountSigningKeyFile != "" ||
-		options.Authentication.ServiceAccounts.Issuer != "" ||
+		(len(options.Authentication.ServiceAccounts.Issuers) != 0 && options.Authentication.ServiceAccounts.Issuers[0] != "") ||
 		len(options.Authentication.APIAudiences) != 0
 
 	enableSucceeded := options.ServiceAccountIssuer != nil

--- a/cmd/kube-apiserver/app/server.go
+++ b/cmd/kube-apiserver/app/server.go
@@ -416,7 +416,7 @@ func CreateKubeAPIServerConfig(
 		pubKeys = append(pubKeys, keys...)
 	}
 	// Plumb the required metadata through ExtraConfig.
-	config.ExtraConfig.ServiceAccountIssuerURL = s.Authentication.ServiceAccounts.Issuer
+	config.ExtraConfig.ServiceAccountIssuerURL = s.Authentication.ServiceAccounts.Issuers[0]
 	config.ExtraConfig.ServiceAccountJWKSURI = s.Authentication.ServiceAccounts.JWKSURI
 	config.ExtraConfig.ServiceAccountPublicKeys = pubKeys
 
@@ -633,7 +633,7 @@ func Complete(s *options.ServerRunOptions) (completedServerRunOptions, error) {
 		}
 	}
 
-	if s.ServiceAccountSigningKeyFile != "" && s.Authentication.ServiceAccounts.Issuer != "" {
+	if s.ServiceAccountSigningKeyFile != "" && len(s.Authentication.ServiceAccounts.Issuers) != 0 && s.Authentication.ServiceAccounts.Issuers[0] != "" {
 		sk, err := keyutil.PrivateKeyFromFile(s.ServiceAccountSigningKeyFile)
 		if err != nil {
 			return options, fmt.Errorf("failed to parse service-account-issuer-key-file: %v", err)
@@ -655,7 +655,7 @@ func Complete(s *options.ServerRunOptions) (completedServerRunOptions, error) {
 			}
 		}
 
-		s.ServiceAccountIssuer, err = serviceaccount.JWTTokenGenerator(s.Authentication.ServiceAccounts.Issuer, sk)
+		s.ServiceAccountIssuer, err = serviceaccount.JWTTokenGenerator(s.Authentication.ServiceAccounts.Issuers[0], sk)
 		if err != nil {
 			return options, fmt.Errorf("failed to build token generator: %v", err)
 		}

--- a/pkg/kubeapiserver/options/authentication.go
+++ b/pkg/kubeapiserver/options/authentication.go
@@ -87,7 +87,7 @@ type OIDCAuthenticationOptions struct {
 type ServiceAccountAuthenticationOptions struct {
 	KeyFiles         []string
 	Lookup           bool
-	Issuer           string
+	Issuers          []string
 	JWKSURI          string
 	MaxExpiration    time.Duration
 	ExtendExpiration bool
@@ -191,14 +191,29 @@ func (o *BuiltInAuthenticationOptions) Validate() []error {
 		allErrors = append(allErrors, fmt.Errorf("oidc-issuer-url and oidc-client-id should be specified together"))
 	}
 
-	if o.ServiceAccounts != nil && len(o.ServiceAccounts.Issuer) > 0 && strings.Contains(o.ServiceAccounts.Issuer, ":") {
-		if _, err := url.Parse(o.ServiceAccounts.Issuer); err != nil {
-			allErrors = append(allErrors, fmt.Errorf("service-account-issuer contained a ':' but was not a valid URL: %v", err))
+	if o.ServiceAccounts != nil && len(o.ServiceAccounts.Issuers) > 0 {
+		seen := make(map[string]bool)
+		for _, issuer := range o.ServiceAccounts.Issuers {
+			if strings.Contains(issuer, ":") {
+				if _, err := url.Parse(issuer); err != nil {
+					allErrors = append(allErrors, fmt.Errorf("service-account-issuer %q contained a ':' but was not a valid URL: %v", issuer, err))
+					continue
+				}
+			}
+			if issuer == "" {
+				allErrors = append(allErrors, fmt.Errorf("service-account-issuer should not be an empty string"))
+				continue
+			}
+			if seen[issuer] {
+				allErrors = append(allErrors, fmt.Errorf("service-account-issuer %q is already specified", issuer))
+				continue
+			}
+			seen[issuer] = true
 		}
 	}
 
 	if o.ServiceAccounts != nil {
-		if len(o.ServiceAccounts.Issuer) == 0 {
+		if len(o.ServiceAccounts.Issuers) == 0 {
 			allErrors = append(allErrors, errors.New("service-account-issuer is a required flag"))
 		}
 		if len(o.ServiceAccounts.KeyFiles) == 0 {
@@ -308,7 +323,7 @@ func (o *BuiltInAuthenticationOptions) AddFlags(fs *pflag.FlagSet) {
 		fs.BoolVar(&o.ServiceAccounts.Lookup, "service-account-lookup", o.ServiceAccounts.Lookup,
 			"If true, validate ServiceAccount tokens exist in etcd as part of authentication.")
 
-		fs.StringVar(&o.ServiceAccounts.Issuer, "service-account-issuer", o.ServiceAccounts.Issuer, ""+
+		fs.StringArrayVar(&o.ServiceAccounts.Issuers, "service-account-issuer", o.ServiceAccounts.Issuers, ""+
 			"Identifier of the service account token issuer. The issuer will assert this identifier "+
 			"in \"iss\" claim of issued tokens. This value is a string or URI. If this option is not "+
 			"a valid URI per the OpenID Discovery 1.0 spec, the ServiceAccountIssuerDiscovery feature "+
@@ -316,7 +331,9 @@ func (o *BuiltInAuthenticationOptions) AddFlags(fs *pflag.FlagSet) {
 			"that this value comply with the OpenID spec: https://openid.net/specs/openid-connect-discovery-1_0.html. "+
 			"In practice, this means that service-account-issuer must be an https URL. It is also highly "+
 			"recommended that this URL be capable of serving OpenID discovery documents at "+
-			"{service-account-issuer}/.well-known/openid-configuration.")
+			"{service-account-issuer}/.well-known/openid-configuration. "+
+			"When this flag is specified multiple times, the first is used to generate tokens "+
+			"and all are used to determine which issuers are accepted.")
 
 		fs.StringVar(&o.ServiceAccounts.JWKSURI, "service-account-jwks-uri", o.ServiceAccounts.JWKSURI, ""+
 			"Overrides the URI for the JSON Web Key Set in the discovery doc served at "+
@@ -406,11 +423,11 @@ func (o *BuiltInAuthenticationOptions) ToAuthenticationConfig() (kubeauthenticat
 
 	ret.APIAudiences = o.APIAudiences
 	if o.ServiceAccounts != nil {
-		if o.ServiceAccounts.Issuer != "" && len(o.APIAudiences) == 0 {
-			ret.APIAudiences = authenticator.Audiences{o.ServiceAccounts.Issuer}
+		if len(o.ServiceAccounts.Issuers) != 0 && len(o.APIAudiences) == 0 {
+			ret.APIAudiences = authenticator.Audiences(o.ServiceAccounts.Issuers)
 		}
 		ret.ServiceAccountKeyFiles = o.ServiceAccounts.KeyFiles
-		ret.ServiceAccountIssuer = o.ServiceAccounts.Issuer
+		ret.ServiceAccountIssuers = o.ServiceAccounts.Issuers
 		ret.ServiceAccountLookup = o.ServiceAccounts.Lookup
 	}
 
@@ -464,8 +481,8 @@ func (o *BuiltInAuthenticationOptions) ApplyTo(authInfo *genericapiserver.Authen
 	}
 
 	authInfo.APIAudiences = o.APIAudiences
-	if o.ServiceAccounts != nil && o.ServiceAccounts.Issuer != "" && len(o.APIAudiences) == 0 {
-		authInfo.APIAudiences = authenticator.Audiences{o.ServiceAccounts.Issuer}
+	if o.ServiceAccounts != nil && len(o.ServiceAccounts.Issuers) != 0 && len(o.APIAudiences) == 0 {
+		authInfo.APIAudiences = authenticator.Audiences(o.ServiceAccounts.Issuers)
 	}
 
 	authenticatorConfig.ServiceAccountTokenGetter = serviceaccountcontroller.NewGetterFromClient(

--- a/pkg/kubeapiserver/options/authentication_test.go
+++ b/pkg/kubeapiserver/options/authentication_test.go
@@ -51,33 +51,9 @@ func TestAuthenticationValidate(t *testing.T) {
 				ClientID:      "testClientID",
 			},
 			testSA: &ServiceAccountAuthenticationOptions{
-				Issuer:   "http://foo.bar.com",
+				Issuers:  []string{"http://foo.bar.com"},
 				KeyFiles: []string{"testkeyfile1", "testkeyfile2"},
 			},
-		},
-		{
-			name: "test when OIDC and ServiceAccounts are invalid",
-			testOIDC: &OIDCAuthenticationOptions{
-				UsernameClaim: "sub",
-				SigningAlgs:   []string{"RS256"},
-				IssuerURL:     "testIssuerURL",
-			},
-			testSA: &ServiceAccountAuthenticationOptions{
-				Issuer: "http://foo.bar.com",
-			},
-			expectErr: "oidc-issuer-url and oidc-client-id should be specified together",
-		},
-		{
-			name: "test when OIDC and ServiceAccounts are invalid",
-			testOIDC: &OIDCAuthenticationOptions{
-				UsernameClaim: "sub",
-				SigningAlgs:   []string{"RS256"},
-				IssuerURL:     "testIssuerURL",
-			},
-			testSA: &ServiceAccountAuthenticationOptions{
-				Issuer: "http://foo.bar.com",
-			},
-			expectErr: "service-account-key-file is a required flag",
 		},
 		{
 			name: "test when OIDC is invalid",
@@ -87,13 +63,13 @@ func TestAuthenticationValidate(t *testing.T) {
 				IssuerURL:     "testIssuerURL",
 			},
 			testSA: &ServiceAccountAuthenticationOptions{
-				Issuer:   "http://foo.bar.com",
+				Issuers:  []string{"http://foo.bar.com"},
 				KeyFiles: []string{"testkeyfile1", "testkeyfile2"},
 			},
 			expectErr: "oidc-issuer-url and oidc-client-id should be specified together",
 		},
 		{
-			name: "test when ServiceAccount is invalid",
+			name: "test when ServiceAccounts doesn't have key file",
 			testOIDC: &OIDCAuthenticationOptions{
 				UsernameClaim: "sub",
 				SigningAlgs:   []string{"RS256"},
@@ -101,9 +77,61 @@ func TestAuthenticationValidate(t *testing.T) {
 				ClientID:      "testClientID",
 			},
 			testSA: &ServiceAccountAuthenticationOptions{
-				Issuer: "http://[::1]:namedport",
+				Issuers: []string{"http://foo.bar.com"},
 			},
-			expectErr: "service-account-issuer contained a ':' but was not a valid URL",
+			expectErr: "service-account-key-file is a required flag",
+		},
+		{
+			name: "test when ServiceAccounts doesn't have issuer",
+			testOIDC: &OIDCAuthenticationOptions{
+				UsernameClaim: "sub",
+				SigningAlgs:   []string{"RS256"},
+				IssuerURL:     "testIssuerURL",
+				ClientID:      "testClientID",
+			},
+			testSA: &ServiceAccountAuthenticationOptions{
+				Issuers: []string{},
+			},
+			expectErr: "service-account-issuer is a required flag",
+		},
+		{
+			name: "test when ServiceAccounts has empty string as issuer",
+			testOIDC: &OIDCAuthenticationOptions{
+				UsernameClaim: "sub",
+				SigningAlgs:   []string{"RS256"},
+				IssuerURL:     "testIssuerURL",
+				ClientID:      "testClientID",
+			},
+			testSA: &ServiceAccountAuthenticationOptions{
+				Issuers: []string{""},
+			},
+			expectErr: "service-account-issuer should not be an empty string",
+		},
+		{
+			name: "test when ServiceAccounts has duplicate issuers",
+			testOIDC: &OIDCAuthenticationOptions{
+				UsernameClaim: "sub",
+				SigningAlgs:   []string{"RS256"},
+				IssuerURL:     "testIssuerURL",
+				ClientID:      "testClientID",
+			},
+			testSA: &ServiceAccountAuthenticationOptions{
+				Issuers: []string{"http://foo.bar.com", "http://foo.bar.com"},
+			},
+			expectErr: "service-account-issuer \"http://foo.bar.com\" is already specified",
+		},
+		{
+			name: "test when ServiceAccount has bad issuer",
+			testOIDC: &OIDCAuthenticationOptions{
+				UsernameClaim: "sub",
+				SigningAlgs:   []string{"RS256"},
+				IssuerURL:     "testIssuerURL",
+				ClientID:      "testClientID",
+			},
+			testSA: &ServiceAccountAuthenticationOptions{
+				Issuers: []string{"http://[::1]:namedport"},
+			},
+			expectErr: "service-account-issuer \"http://[::1]:namedport\" contained a ':' but was not a valid URL",
 		},
 	}
 
@@ -154,8 +182,8 @@ func TestToAuthenticationConfig(t *testing.T) {
 			AllowedNames:        []string{"kube-aggregator"},
 		},
 		ServiceAccounts: &ServiceAccountAuthenticationOptions{
-			Lookup: true,
-			Issuer: "http://foo.bar.com",
+			Lookup:  true,
+			Issuers: []string{"http://foo.bar.com"},
 		},
 		TokenFile: &TokenFileAuthenticationOptions{
 			TokenFile: "/testTokenFile",
@@ -176,7 +204,7 @@ func TestToAuthenticationConfig(t *testing.T) {
 		OIDCUsernameClaim:           "sub",
 		OIDCSigningAlgs:             []string{"RS256"},
 		ServiceAccountLookup:        true,
-		ServiceAccountIssuer:        "http://foo.bar.com",
+		ServiceAccountIssuers:       []string{"http://foo.bar.com"},
 		WebhookTokenAuthnConfigFile: "/token-webhook-config",
 		WebhookTokenAuthnCacheTTL:   180000000000,
 

--- a/pkg/serviceaccount/jwt.go
+++ b/pkg/serviceaccount/jwt.go
@@ -224,9 +224,13 @@ func (j *jwtTokenGenerator) GenerateToken(claims *jwt.Claims, privateClaims inte
 // JWTTokenAuthenticator authenticates tokens as JWT tokens produced by JWTTokenGenerator
 // Token signatures are verified using each of the given public keys until one works (allowing key rotation)
 // If lookup is true, the service account and secret referenced as claims inside the token are retrieved and verified with the provided ServiceAccountTokenGetter
-func JWTTokenAuthenticator(iss string, keys []interface{}, implicitAuds authenticator.Audiences, validator Validator) authenticator.Token {
+func JWTTokenAuthenticator(issuers []string, keys []interface{}, implicitAuds authenticator.Audiences, validator Validator) authenticator.Token {
+	issuersMap := make(map[string]bool)
+	for _, issuer := range issuers {
+		issuersMap[issuer] = true
+	}
 	return &jwtTokenAuthenticator{
-		iss:          iss,
+		issuers:      issuersMap,
 		keys:         keys,
 		implicitAuds: implicitAuds,
 		validator:    validator,
@@ -234,7 +238,7 @@ func JWTTokenAuthenticator(iss string, keys []interface{}, implicitAuds authenti
 }
 
 type jwtTokenAuthenticator struct {
-	iss          string
+	issuers      map[string]bool
 	keys         []interface{}
 	validator    Validator
 	implicitAuds authenticator.Audiences
@@ -340,9 +344,5 @@ func (j *jwtTokenAuthenticator) hasCorrectIssuer(tokenData string) bool {
 	if err := json.Unmarshal(payload, &claims); err != nil {
 		return false
 	}
-	if claims.Issuer != j.iss {
-		return false
-	}
-	return true
-
+	return j.issuers[claims.Issuer]
 }

--- a/staging/src/k8s.io/apiserver/pkg/authentication/authenticatorfactory/loopback.go
+++ b/staging/src/k8s.io/apiserver/pkg/authentication/authenticatorfactory/loopback.go
@@ -24,6 +24,6 @@ import (
 )
 
 // NewFromTokens returns an authenticator.Request or an error
-func NewFromTokens(tokens map[string]*user.DefaultInfo) authenticator.Request {
-	return bearertoken.New(tokenfile.New(tokens))
+func NewFromTokens(tokens map[string]*user.DefaultInfo, audiences authenticator.Audiences) authenticator.Request {
+	return bearertoken.New(authenticator.WrapAudienceAgnosticToken(audiences, tokenfile.New(tokens)))
 }

--- a/staging/src/k8s.io/apiserver/pkg/server/config.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/config.go
@@ -858,7 +858,7 @@ func AuthorizeClientBearerToken(loopback *restclient.Config, authn *Authenticati
 		Groups: []string{user.SystemPrivilegedGroup},
 	}
 
-	tokenAuthenticator := authenticatorfactory.NewFromTokens(tokens)
+	tokenAuthenticator := authenticatorfactory.NewFromTokens(tokens, authn.APIAudiences)
 	authn.Authenticator = authenticatorunion.New(tokenAuthenticator, authn.Authenticator)
 
 	tokenAuthorizer := authorizerfactory.NewPrivilegedGroups(user.SystemPrivilegedGroup)

--- a/test/integration/auth/dynamic_client_test.go
+++ b/test/integration/auth/dynamic_client_test.go
@@ -69,7 +69,7 @@ func TestDynamicClientBuilder(t *testing.T) {
 			if opts.Authentication.ServiceAccounts == nil {
 				opts.Authentication.ServiceAccounts = &kubeoptions.ServiceAccountAuthenticationOptions{}
 			}
-			opts.Authentication.ServiceAccounts.Issuer = iss
+			opts.Authentication.ServiceAccounts.Issuers = []string{iss}
 			opts.Authentication.ServiceAccounts.KeyFiles = []string{tmpfile.Name()}
 		},
 		ModifyServerConfig: func(config *controlplane.Config) {

--- a/test/integration/auth/svcaccttoken_test.go
+++ b/test/integration/auth/svcaccttoken_test.go
@@ -54,6 +54,7 @@ import (
 	"k8s.io/kubernetes/test/integration/framework"
 )
 
+// This key is for testing purposes only and is not considered secure.
 const ecdsaPrivateKey = `-----BEGIN EC PRIVATE KEY-----
 MHcCAQEEIEZmTmUhuanLjPA2CLquXivuwBDHTt5XYwgIr/kA1LtRoAoGCCqGSM49
 AwEHoUQDQgAEH6cuzP8XuD5wal6wf9M6xDljTOPLX2i8uIp/C/ASqiIGUeeKQtX0
@@ -87,7 +88,7 @@ func TestServiceAccountTokenCreate(t *testing.T) {
 	masterConfig.GenericConfig.Authentication.APIAudiences = aud
 	masterConfig.GenericConfig.Authentication.Authenticator = bearertoken.New(
 		serviceaccount.JWTTokenAuthenticator(
-			iss,
+			[]string{iss},
 			[]interface{}{&pk},
 			aud,
 			serviceaccount.NewValidator(serviceaccountgetter.NewGetterFromClient(

--- a/test/integration/framework/master_utils.go
+++ b/test/integration/framework/master_utils.go
@@ -172,7 +172,7 @@ func startApiserverOrDie(controlPlaneConfig *controlplane.Config, incomingServer
 		Groups: []string{user.SystemPrivilegedGroup},
 	}
 
-	tokenAuthenticator := authenticatorfactory.NewFromTokens(tokens)
+	tokenAuthenticator := authenticatorfactory.NewFromTokens(tokens, controlPlaneConfig.GenericConfig.Authentication.APIAudiences)
 	if controlPlaneConfig.GenericConfig.Authentication.Authenticator == nil {
 		controlPlaneConfig.GenericConfig.Authentication.Authenticator = authenticatorunion.New(tokenAuthenticator, authauthenticator.RequestFunc(alwaysEmpty))
 	} else {

--- a/test/integration/framework/test_server.go
+++ b/test/integration/framework/test_server.go
@@ -29,6 +29,7 @@ import (
 	"github.com/google/uuid"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/wait"
 	genericapiserver "k8s.io/apiserver/pkg/server"
 	genericapiserveroptions "k8s.io/apiserver/pkg/server/options"
@@ -40,6 +41,13 @@ import (
 	"k8s.io/kubernetes/pkg/controlplane"
 	"k8s.io/kubernetes/test/utils"
 )
+
+// This key is for testing purposes only and is not considered secure.
+const ecdsaPrivateKey = `-----BEGIN EC PRIVATE KEY-----
+MHcCAQEEIEZmTmUhuanLjPA2CLquXivuwBDHTt5XYwgIr/kA1LtRoAoGCCqGSM49
+AwEHoUQDQgAEH6cuzP8XuD5wal6wf9M6xDljTOPLX2i8uIp/C/ASqiIGUeeKQtX0
+/IR3qCXyThP/dbCiHrF3v1cuhBOHY8CLVg==
+-----END EC PRIVATE KEY-----`
 
 // TestServerSetup holds configuration information for a kube-apiserver test server.
 type TestServerSetup struct {
@@ -86,10 +94,20 @@ func StartTestServer(t *testing.T, stopCh <-chan struct{}, setup TestServerSetup
 		t.Fatal(err)
 	}
 
+	saSigningKeyFile, err := ioutil.TempFile("/tmp", "insecure_test_key")
+	if err != nil {
+		t.Fatalf("create temp file failed: %v", err)
+	}
+	defer os.RemoveAll(saSigningKeyFile.Name())
+	if err = ioutil.WriteFile(saSigningKeyFile.Name(), []byte(ecdsaPrivateKey), 0666); err != nil {
+		t.Fatalf("write file %s failed: %v", saSigningKeyFile.Name(), err)
+	}
+
 	kubeAPIServerOptions := options.NewServerRunOptions()
 	kubeAPIServerOptions.SecureServing.Listener = listener
 	kubeAPIServerOptions.SecureServing.BindAddress = net.ParseIP("127.0.0.1")
 	kubeAPIServerOptions.SecureServing.ServerCert.CertDirectory = certDir
+	kubeAPIServerOptions.ServiceAccountSigningKeyFile = saSigningKeyFile.Name()
 	kubeAPIServerOptions.Etcd.StorageConfig.Prefix = path.Join("/", uuid.New().String(), "registry")
 	kubeAPIServerOptions.Etcd.StorageConfig.Transport.ServerList = []string{GetEtcdURL()}
 	kubeAPIServerOptions.ServiceClusterIPRanges = defaultServiceClusterIPRange.String()
@@ -98,6 +116,9 @@ func StartTestServer(t *testing.T, stopCh <-chan struct{}, setup TestServerSetup
 	kubeAPIServerOptions.Authentication.RequestHeader.ExtraHeaderPrefixes = []string{"X-Remote-Extra-"}
 	kubeAPIServerOptions.Authentication.RequestHeader.AllowedNames = []string{"kube-aggregator"}
 	kubeAPIServerOptions.Authentication.RequestHeader.ClientCAFile = proxyCACertFile.Name()
+	kubeAPIServerOptions.Authentication.APIAudiences = []string{"https://foo.bar.example.com"}
+	kubeAPIServerOptions.Authentication.ServiceAccounts.Issuers = []string{"https://foo.bar.example.com"}
+	kubeAPIServerOptions.Authentication.ServiceAccounts.KeyFiles = []string{saSigningKeyFile.Name()}
 	kubeAPIServerOptions.Authentication.ClientCert.ClientCA = clientCACertFile.Name()
 	kubeAPIServerOptions.Authorization.Modes = []string{"Node", "RBAC"}
 
@@ -109,6 +130,11 @@ func StartTestServer(t *testing.T, stopCh <-chan struct{}, setup TestServerSetup
 	if err != nil {
 		t.Fatal(err)
 	}
+
+	if errs := completedOptions.Validate(); len(errs) != 0 {
+		t.Fatalf("failed to validate ServerRunOptions: %v", utilerrors.NewAggregate(errs))
+	}
+
 	tunneler, proxyTransport, err := app.CreateNodeDialer(completedOptions)
 	if err != nil {
 		t.Fatal(err)

--- a/test/integration/serviceaccount/service_account_test.go
+++ b/test/integration/serviceaccount/service_account_test.go
@@ -395,7 +395,7 @@ func startServiceAccountTestServer(t *testing.T) (*clientset.Clientset, restclie
 		externalInformers.Core().V1().ServiceAccounts().Lister(),
 		externalInformers.Core().V1().Pods().Lister(),
 	)
-	serviceAccountTokenAuth := serviceaccount.JWTTokenAuthenticator(serviceaccount.LegacyIssuer, []interface{}{&serviceAccountKey.PublicKey}, nil, serviceaccount.NewLegacyValidator(true, serviceAccountTokenGetter))
+	serviceAccountTokenAuth := serviceaccount.JWTTokenAuthenticator([]string{serviceaccount.LegacyIssuer}, []interface{}{&serviceAccountKey.PublicKey}, nil, serviceaccount.NewLegacyValidator(true, serviceAccountTokenGetter))
 	authenticator := union.New(
 		bearertoken.New(rootTokenAuth),
 		bearertoken.New(serviceAccountTokenAuth),


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/kind api-change

#### What this PR does / why we need it:
change the issuer in a non-disruptive way

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
-->
```release-note
kube-apiserver: `--service-account-issuer` can be specified multiple times now, to enable non-disruptive change of issuer.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs
- [KEP]: https://github.com/kubernetes/enhancements/tree/master/keps/sig-auth/1205-bound-service-account-tokens
```
