### PR TITLE
Remove unused CreatePodsOnNode function

### DIFF
--- a/pkg/controller/daemon/daemon_controller_test.go
+++ b/pkg/controller/daemon/daemon_controller_test.go
@@ -241,37 +241,6 @@ func newFakePodControl() *fakePodControl {
 	}
 }
 
-func (f *fakePodControl) CreatePodsOnNode(nodeName, namespace string, template *v1.PodTemplateSpec, object runtime.Object, controllerRef *metav1.OwnerReference) error {
-	f.Lock()
-	defer f.Unlock()
-	if err := f.FakePodControl.CreatePodsOnNode(nodeName, namespace, template, object, controllerRef); err != nil {
-		return fmt.Errorf("failed to create pod on node %q", nodeName)
-	}
-
-	pod := &v1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			Labels:       template.Labels,
-			Namespace:    namespace,
-			GenerateName: fmt.Sprintf("%s-", nodeName),
-		},
-	}
-
-	template.Spec.DeepCopyInto(&pod.Spec)
-	if len(nodeName) != 0 {
-		pod.Spec.NodeName = nodeName
-	}
-	pod.Name = names.SimpleNameGenerator.GenerateName(fmt.Sprintf("%s-", nodeName))
-
-	f.podStore.Update(pod)
-	f.podIDMap[pod.Name] = pod
-
-	ds := object.(*apps.DaemonSet)
-	dsKey, _ := controller.KeyFunc(ds)
-	f.expectations.CreationObserved(dsKey)
-
-	return nil
-}
-
 func (f *fakePodControl) CreatePodsWithControllerRef(namespace string, template *v1.PodTemplateSpec, object runtime.Object, controllerRef *metav1.OwnerReference) error {
 	f.Lock()
 	defer f.Unlock()

--- a/pkg/controller/replication/conversion.go
+++ b/pkg/controller/replication/conversion.go
@@ -342,11 +342,6 @@ func (pc podControlAdapter) CreatePods(namespace string, template *v1.PodTemplat
 	return errors.New("CreatePods() is not implemented for podControlAdapter")
 }
 
-func (pc podControlAdapter) CreatePodsOnNode(nodeName, namespace string, template *v1.PodTemplateSpec, object runtime.Object, controllerRef *metav1.OwnerReference) error {
-	// This is not used by RSC.
-	return errors.New("CreatePodsOnNode() is not implemented for podControlAdapter")
-}
-
 func (pc podControlAdapter) CreatePodsWithControllerRef(namespace string, template *v1.PodTemplateSpec, object runtime.Object, controllerRef *metav1.OwnerReference) error {
 	rc, err := convertRStoRC(object.(*apps.ReplicaSet))
 	if err != nil {


### PR DESCRIPTION
Remnant of old daemonset controller

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Remove unused function that is a remnant of the old daemonset controller.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

/sig apps