### PR TITLE
Fix Job describe for completion mode

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/describe/describe.go
+++ b/staging/src/k8s.io/kubectl/pkg/describe/describe.go
@@ -2166,7 +2166,7 @@ func describeJob(job *batchv1.Job, events *corev1.EventList) (string, error) {
 			w.Write(LEVEL_0, "Completions:\t<unset>\n")
 		}
 		if job.Spec.CompletionMode != nil {
-			w.Write(LEVEL_0, "Completion Mode:\t%s\n", job.Spec.CompletionMode)
+			w.Write(LEVEL_0, "Completion Mode:\t%s\n", *job.Spec.CompletionMode)
 		}
 		if job.Status.StartTime != nil {
 			w.Write(LEVEL_0, "Start Time:\t%s\n", job.Status.StartTime.Time.Format(time.RFC1123Z))


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Show the completion mode value instead of pointer.

#### Does this PR introduce a user-facing change?

```release-note
Fix display of Job completion mode in kubectl describe
```

/sig apps