### PR TITLE
GCE Windows: Use authenticated HTTP GET against GCS if VM has cloud-p…

### DIFF
--- a/cluster/gce/windows/common.psm1
+++ b/cluster/gce/windows/common.psm1
@@ -248,7 +248,7 @@ function Get-RemoteFile {
     $httpResponseMessage.Wait()
     if (-not $httpResponseMessage.IsCanceled) {
       # Check if the request was successful.
-      # 
+      #
       # DO NOT replace with EnsureSuccessStatusCode(), it prints the
       # OAuth2 bearer token.
       if (-not $httpResponseMessage.Result.IsSuccessStatusCode) {
@@ -295,7 +295,7 @@ function Check-StorageScope {
   While($true) {
     $data = Get-InstanceMetadata -Key "service-accounts/default/scopes"
     if ($data) {
-      return ($data -match "auth/devstorage")
+      return ($data -match "auth/devstorage") -or ($data -match "auth/cloud-platform")
     }
     Start-Sleep -Seconds 1
   }


### PR DESCRIPTION
…latform scope.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
The `Check-StorageScope` cmdlet in GCE Windows startup script will only insert the OAuth2 bearer token if the VM has the devstorage api scope. The problem with this is GCP also allows for VMs to have `cloud-platform` scope which is shorthand for nearly all other GCP scopes. See https://developers.google.com/identity/protocols/oauth2/scopes#storage for acceptable scopes for accessing the GCS API. This change also adds a condition to check if `cloud-platform` API scope is set.

This issue is potentially serious since some artifacts may not be accessible without authentication.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #101169

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
