### PR TITLE
Remove kube-apiserver `--kubelet-https` flag

### DIFF
--- a/cmd/kube-apiserver/app/options/options.go
+++ b/cmd/kube-apiserver/app/options/options.go
@@ -238,10 +238,6 @@ func (s *ServerRunOptions) Flags() (fss cliflag.NamedFlagSets) {
 		"Example: '30000-32767'. Inclusive at both ends of the range.")
 
 	// Kubelet related flags:
-	kubeletHTTPS := true
-	fs.BoolVar(&kubeletHTTPS, "kubelet-https", kubeletHTTPS, "Use https for kubelet connections.")
-	fs.MarkDeprecated("kubelet-https", "API Server connections to kubelets always use https. This flag will be removed in 1.22.")
-
 	fs.StringSliceVar(&s.KubeletConfig.PreferredAddressTypes, "kubelet-preferred-address-types", s.KubeletConfig.PreferredAddressTypes,
 		"List of the preferred NodeAddressTypes to use for kubelet connections.")
 


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup
/kind api-change
/kind deprecation

#### What this PR does / why we need it:
API Server connections to kubelets always use https. This flag will be removed in 1.22.

#### Which issue(s) this PR fixes:
Fixes # None

#### Special notes for your reviewer:

```release-note
kube-apiserver: the deprecated `--kubelet-https` flag is removed. Connections to kubelets have used HTTPS unconditionally since 1.19.
```

#### Does this PR introduce a user-facing change?
```release-note
None
```
