### PR TITLE
Kubemark: print flags before start

### DIFF
--- a/cmd/kubemark/hollow-node.go
+++ b/cmd/kubemark/hollow-node.go
@@ -158,7 +158,7 @@ func newHollowNodeCommand() *cobra.Command {
 		Long: "kubemark",
 		Run: func(cmd *cobra.Command, args []string) {
 			verflag.PrintAndExitIfRequested()
-			run(s)
+			run(cmd, s)
 		},
 		Args: func(cmd *cobra.Command, args []string) error {
 			for _, arg := range args {
@@ -174,9 +174,10 @@ func newHollowNodeCommand() *cobra.Command {
 	return cmd
 }
 
-func run(config *hollowNodeConfig) {
-	// To help debugging, immediately log version
+func run(cmd *cobra.Command, config *hollowNodeConfig) {
+	// To help debugging, immediately log version and print flags.
 	klog.Infof("Version: %+v", version.Get())
+	cliflag.PrintFlags(cmd.Flags())
 
 	if !knownMorphs.Has(config.Morph) {
 		klog.Fatalf("Unknown morph: %v. Allowed values: %v", config.Morph, knownMorphs.List())


### PR DESCRIPTION
/kind feature

#### What this PR does / why we need it:
It makes the hollow-node to print flags before starting


#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Kubemark's hollow-node will now print flags before starting
```
