### PR TITLE
Remove dependency from pkg/util/slice from kubeproxy

### DIFF
--- a/pkg/proxy/userspace/roundrobin.go
+++ b/pkg/proxy/userspace/roundrobin.go
@@ -20,7 +20,6 @@ import (
 	"errors"
 	"fmt"
 	"net"
-	"reflect"
 	"sync"
 	"time"
 
@@ -30,7 +29,6 @@ import (
 	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/pkg/proxy"
 	"k8s.io/kubernetes/pkg/proxy/util"
-	"k8s.io/kubernetes/pkg/util/slice"
 )
 
 var (
@@ -263,7 +261,7 @@ func (lb *LoadBalancerRR) OnEndpointsUpdate(oldEndpoints, endpoints *v1.Endpoint
 			curEndpoints = state.endpoints
 		}
 
-		if !exists || state == nil || len(curEndpoints) != len(newEndpoints) || !slicesEquiv(slice.CopyStrings(curEndpoints), newEndpoints) {
+		if !exists || state == nil || len(curEndpoints) != len(newEndpoints) || !util.SlicesEquiv(util.SliceCopyStrings(curEndpoints), newEndpoints) {
 			klog.V(1).Infof("LoadBalancerRR: Setting endpoints for %s to %+v", svcPort, newEndpoints)
 			lb.removeStaleAffinity(svcPort, newEndpoints)
 			// OnEndpointsUpdate can be called without NewService being called externally.
@@ -313,17 +311,6 @@ func (lb *LoadBalancerRR) OnEndpointsDelete(endpoints *v1.Endpoints) {
 }
 
 func (lb *LoadBalancerRR) OnEndpointsSynced() {
-}
-
-// Tests whether two slices are equivalent.  This sorts both slices in-place.
-func slicesEquiv(lhs, rhs []string) bool {
-	if len(lhs) != len(rhs) {
-		return false
-	}
-	if reflect.DeepEqual(slice.SortStrings(lhs), slice.SortStrings(rhs)) {
-		return true
-	}
-	return false
 }
 
 func (lb *LoadBalancerRR) CleanupStaleStickySessions(svcPort proxy.ServicePortName) {

--- a/pkg/proxy/util/utils.go
+++ b/pkg/proxy/util/utils.go
@@ -23,6 +23,8 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"reflect"
+	"sort"
 	"strconv"
 
 	v1 "k8s.io/api/core/v1"
@@ -498,4 +500,25 @@ func RevertPorts(replacementPortsMap, originalPortsMap map[utilnet.LocalPort]uti
 // CountBytesLines counts the number of lines in a bytes slice
 func CountBytesLines(b []byte) int {
 	return bytes.Count(b, []byte{'\n'})
+}
+
+// SlicesEquiv Tests whether two slices are equivalent.  This sorts both slices in-place.
+func SlicesEquiv(lhs, rhs []string) bool {
+	if len(lhs) != len(rhs) {
+		return false
+	}
+	sort.Strings(lhs)
+	sort.Strings(rhs)
+	return reflect.DeepEqual(lhs, rhs)
+}
+
+// SliceCopyStrings copies the contents of the specified string slice
+// into a new slice.
+func SliceCopyStrings(s []string) []string {
+	if s == nil {
+		return nil
+	}
+	c := make([]string, len(s))
+	copy(c, s)
+	return c
 }

--- a/pkg/proxy/util/utils_test.go
+++ b/pkg/proxy/util/utils_test.go
@@ -1269,3 +1269,67 @@ func randSeq() string {
 	}
 	return string(b)
 }
+
+func TestCopyStrings(t *testing.T) {
+	var src1 []string
+	dest1 := SliceCopyStrings(src1)
+
+	if !reflect.DeepEqual(src1, dest1) {
+		t.Errorf("%v and %v are not equal", src1, dest1)
+	}
+
+	src2 := []string{}
+	dest2 := SliceCopyStrings(src2)
+
+	if !reflect.DeepEqual(src2, dest2) {
+		t.Errorf("%v and %v are not equal", src2, dest2)
+	}
+
+	src3 := []string{"a", "c", "b"}
+	dest3 := SliceCopyStrings(src3)
+
+	if !reflect.DeepEqual(src3, dest3) {
+		t.Errorf("%v and %v are not equal", src3, dest3)
+	}
+
+	src3[0] = "A"
+	if reflect.DeepEqual(src3, dest3) {
+		t.Errorf("CopyStrings didn't make a copy")
+	}
+}
+
+func TestSlicesEquiv(t *testing.T) {
+	testCases := []struct {
+		name     string
+		lhs      []string
+		rhs      []string
+		expected bool
+	}{
+		{
+			name:     "different lenghts",
+			lhs:      []string{"a", "b"},
+			rhs:      []string{"a", "b", "c"},
+			expected: false,
+		},
+		{
+			name:     "different values",
+			rhs:      []string{"a", "b"},
+			lhs:      []string{"a", "c"},
+			expected: false,
+		},
+		{
+			name:     "same values unordered",
+			rhs:      []string{"a", "b", "c", "d"},
+			lhs:      []string{"d", "b", "c", "a"},
+			expected: true,
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			got := SlicesEquiv(testCase.lhs, testCase.rhs)
+			if got != testCase.expected {
+				t.Fatalf("expected: %t, got: %t", testCase.expected, got)
+			}
+		})
+	}
+}

--- a/pkg/proxy/winuserspace/roundrobin.go
+++ b/pkg/proxy/winuserspace/roundrobin.go
@@ -20,7 +20,6 @@ import (
 	"errors"
 	"fmt"
 	"net"
-	"reflect"
 	"sync"
 	"time"
 
@@ -29,7 +28,6 @@ import (
 	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/pkg/proxy"
 	"k8s.io/kubernetes/pkg/proxy/util"
-	"k8s.io/kubernetes/pkg/util/slice"
 )
 
 var (
@@ -256,7 +254,7 @@ func (lb *LoadBalancerRR) OnEndpointsUpdate(oldEndpoints, endpoints *v1.Endpoint
 			curEndpoints = state.endpoints
 		}
 
-		if !exists || state == nil || len(curEndpoints) != len(newEndpoints) || !slicesEquiv(slice.CopyStrings(curEndpoints), newEndpoints) {
+		if !exists || state == nil || len(curEndpoints) != len(newEndpoints) || !util.SlicesEquiv(util.SliceCopyStrings(curEndpoints), newEndpoints) {
 			klog.V(1).Infof("LoadBalancerRR: Setting endpoints for %s to %+v", svcPort, newEndpoints)
 			lb.updateAffinityMap(svcPort, newEndpoints)
 			// OnEndpointsUpdate can be called without NewService being called externally.
@@ -304,17 +302,6 @@ func (lb *LoadBalancerRR) OnEndpointsDelete(endpoints *v1.Endpoints) {
 }
 
 func (lb *LoadBalancerRR) OnEndpointsSynced() {
-}
-
-// Tests whether two slices are equivalent.  This sorts both slices in-place.
-func slicesEquiv(lhs, rhs []string) bool {
-	if len(lhs) != len(rhs) {
-		return false
-	}
-	if reflect.DeepEqual(slice.SortStrings(lhs), slice.SortStrings(rhs)) {
-		return true
-	}
-	return false
 }
 
 func (lb *LoadBalancerRR) CleanupStaleStickySessions(svcPort proxy.ServicePortName) {

--- a/pkg/util/slice/slice.go
+++ b/pkg/util/slice/slice.go
@@ -21,17 +21,6 @@ import (
 	"sort"
 )
 
-// CopyStrings copies the contents of the specified string slice
-// into a new slice.
-func CopyStrings(s []string) []string {
-	if s == nil {
-		return nil
-	}
-	c := make([]string, len(s))
-	copy(c, s)
-	return c
-}
-
 // SortStrings sorts the specified string slice in place. It returns the same
 // slice that was provided in order to facilitate method chaining.
 func SortStrings(s []string) []string {

--- a/pkg/util/slice/slice_test.go
+++ b/pkg/util/slice/slice_test.go
@@ -21,34 +21,6 @@ import (
 	"testing"
 )
 
-func TestCopyStrings(t *testing.T) {
-	var src1 []string
-	dest1 := CopyStrings(src1)
-
-	if !reflect.DeepEqual(src1, dest1) {
-		t.Errorf("%v and %v are not equal", src1, dest1)
-	}
-
-	src2 := []string{}
-	dest2 := CopyStrings(src2)
-
-	if !reflect.DeepEqual(src2, dest2) {
-		t.Errorf("%v and %v are not equal", src2, dest2)
-	}
-
-	src3 := []string{"a", "c", "b"}
-	dest3 := CopyStrings(src3)
-
-	if !reflect.DeepEqual(src3, dest3) {
-		t.Errorf("%v and %v are not equal", src3, dest3)
-	}
-
-	src3[0] = "A"
-	if reflect.DeepEqual(src3, dest3) {
-		t.Errorf("CopyStrings didn't make a copy")
-	}
-}
-
 func TestSortStrings(t *testing.T) {
 	src := []string{"a", "c", "b"}
 	dest := SortStrings(src)


### PR DESCRIPTION
Signed-off-by: Ricardo Pchevuzinske Katz <ricardo.katz@gmail.com>


#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
Remove dependency from pkg/util/slice from kubeproxy

#### Which issue(s) this PR fixes:
Part of #92369 

#### Special notes for your reviewer:
I was going to move this to k8s.io/utils, which didn't seems like a very popular solution. So:

* The code from `SlicesEquiv` repeats twice, so moved to proxy/util (internal utilities)
* This function above also simply does a sort in place then reflect.DeepEqual, so I've added some unit tests (non existent before). The function before this used slice.SortStrings which now is only used by pkg/volume/util/util_test.go (and maybe should be removed)

* slice.CopyString is a 8 line function used twice in kube-proxy, so it was better to move to util as well, and also its unit tests. This function was removed from pkg/util as a cleanup (it was only used by kproxy)


#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
