### PR TITLE
Adding support for complex json paths in AdditionalPrinterColumns

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/registry/customresource/tableconvertor/tableconvertor_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/registry/customresource/tableconvertor/tableconvertor_test.go
@@ -252,7 +252,7 @@ func Test_convertor_ConvertToTable(t *testing.T) {
 							"foo",
 							`["foo"]`,
 							`["bar","baz"]`,
-							`["foo"]`, // TODO: TableConverter should be changed so that the response is this: `["foo"] ["bar","baz"]`,
+							`[["foo"],["bar","baz"]]`,
 						},
 						Object: runtime.RawExtension{
 							Object: &unstructured.Unstructured{
@@ -325,7 +325,7 @@ func Test_convertor_ConvertToTable(t *testing.T) {
 							"1",
 							"[1]",
 							"[2,3]",
-							"[1]", // TODO: TableConverter should be changed so that the response is this: `[1] [2,3]`,
+							"[[1],[2,3]]",
 						},
 						Object: runtime.RawExtension{
 							Object: &unstructured.Unstructured{


### PR DESCRIPTION
#### What type of PR is this?
/kind bug
/kind cleanup

#### What this PR does / why we need it:
This adds support for printing the results of complex json paths that return more than 1 result. This is a follow up that was heavily inspired by @nikhita's work on https://github.com/kubernetes/kubernetes/pull/67079.  

#### Which issue(s) this PR fixes:
Fixes https://github.com/kubernetes/kubectl/issues/517

#### Special notes for your reviewer:
I added some logic that would print a maximum of 3 elements followed by + n more. This would be _very_ helpful for Gateway API where we're anticipating lists that could have dozens of entries in some cases.

#### Does this PR introduce a user-facing change?
```release-note
AdditionalPrinterColumns now supports printing more than the first matching result for json paths.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
There's more context in the [original sig-api-machinery thread](https://groups.google.com/g/kubernetes-sig-api-machinery/c/GxXWe6T8DoM) where I asked about this.

/cc @nikhita @thockin 
/assign @smarterclayton 