### PR TITLE
Add a namespace label to admission metrics and expand histogram range to 0-10s

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/admission/metrics/metrics.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/metrics/metrics.go
@@ -46,7 +46,7 @@ const (
 
 var (
 	// Use buckets ranging from 5 ms to 2.5 seconds (admission webhooks timeout at 30 seconds by default).
-	latencyBuckets       = []float64{0.005, 0.025, 0.1, 0.5, 2.5}
+	latencyBuckets       = []float64{0.005, 0.025, 0.1, 0.5, 2.5, 5.0, 10.0}
 	latencySummaryMaxAge = 5 * time.Hour
 
 	// Metrics provides access to all admission metrics.
@@ -126,17 +126,17 @@ func newAdmissionMetrics() *AdmissionMetrics {
 	// Admission metrics for a step of the admission flow. The entire admission flow is broken down into a series of steps
 	// Each step is identified by a distinct type label value.
 	step := newMetricSet("step",
-		[]string{"type", "operation", "rejected"},
+		[]string{"type", "operation", "rejected", "namespace"},
 		"Admission sub-step %s, broken out for each operation and API resource and step type (validate or admit).", true)
 
 	// Built-in admission controller metrics. Each admission controller is identified by name.
 	controller := newMetricSet("controller",
-		[]string{"name", "type", "operation", "rejected"},
+		[]string{"name", "type", "operation", "rejected", "namespace"},
 		"Admission controller %s, identified by name and broken out for each operation and API resource and type (validate or admit).", false)
 
 	// Admission webhook metrics. Each webhook is identified by name.
 	webhook := newMetricSet("webhook",
-		[]string{"name", "type", "operation", "rejected"},
+		[]string{"name", "type", "operation", "rejected", "namespace"},
 		"Admission webhook %s, identified by name and broken out for each operation and API resource and type (validate or admit).", false)
 
 	webhookRejection := metrics.NewCounterVec(
@@ -147,7 +147,7 @@ func newAdmissionMetrics() *AdmissionMetrics {
 			Help:           "Admission webhook rejection count, identified by name and broken out for each admission type (validating or admit) and operation. Additional labels specify an error type (calling_webhook_error or apiserver_internal_error if an error occurred; no_error otherwise) and optionally a non-zero rejection code if the webhook rejects the request with an HTTP status code (honored by the apiserver when the code is greater or equal to 400). Codes greater than 600 are truncated to 600, to keep the metrics cardinality bounded.",
 			StabilityLevel: metrics.ALPHA,
 		},
-		[]string{"name", "type", "operation", "error_type", "rejection_code"})
+		[]string{"name", "type", "operation", "error_type", "rejection_code", "namespace"})
 
 	step.mustRegister()
 	controller.mustRegister()
@@ -164,17 +164,17 @@ func (m *AdmissionMetrics) reset() {
 
 // ObserveAdmissionStep records admission related metrics for a admission step, identified by step type.
 func (m *AdmissionMetrics) ObserveAdmissionStep(ctx context.Context, elapsed time.Duration, rejected bool, attr admission.Attributes, stepType string, extraLabels ...string) {
-	m.step.observe(ctx, elapsed, append(extraLabels, stepType, string(attr.GetOperation()), strconv.FormatBool(rejected))...)
+	m.step.observe(ctx, elapsed, append(extraLabels, stepType, string(attr.GetOperation()), strconv.FormatBool(rejected), attr.GetNamespace())...)
 }
 
 // ObserveAdmissionController records admission related metrics for a built-in admission controller, identified by it's plugin handler name.
 func (m *AdmissionMetrics) ObserveAdmissionController(ctx context.Context, elapsed time.Duration, rejected bool, attr admission.Attributes, stepType string, extraLabels ...string) {
-	m.controller.observe(ctx, elapsed, append(extraLabels, stepType, string(attr.GetOperation()), strconv.FormatBool(rejected))...)
+	m.controller.observe(ctx, elapsed, append(extraLabels, stepType, string(attr.GetOperation()), strconv.FormatBool(rejected), attr.GetNamespace())...)
 }
 
 // ObserveWebhook records admission related metrics for a admission webhook.
 func (m *AdmissionMetrics) ObserveWebhook(ctx context.Context, elapsed time.Duration, rejected bool, attr admission.Attributes, stepType string, extraLabels ...string) {
-	m.webhook.observe(ctx, elapsed, append(extraLabels, stepType, string(attr.GetOperation()), strconv.FormatBool(rejected))...)
+	m.webhook.observe(ctx, elapsed, append(extraLabels, stepType, string(attr.GetOperation()), strconv.FormatBool(rejected), attr.GetNamespace())...)
 }
 
 // ObserveWebhookRejection records admission related metrics for an admission webhook rejection.
@@ -184,7 +184,7 @@ func (m *AdmissionMetrics) ObserveWebhookRejection(ctx context.Context, name, st
 	if rejectionCode > 600 {
 		rejectionCode = 600
 	}
-	m.webhookRejection.WithContext(ctx).WithLabelValues(name, stepType, operation, string(errorType), strconv.Itoa(rejectionCode)).Inc()
+	m.webhookRejection.WithContext(ctx).WithLabelValues(name, stepType, operation, string(errorType), strconv.Itoa(rejectionCode), attr.GetNamespace()).Inc()
 }
 
 type metricSet struct {

--- a/staging/src/k8s.io/apiserver/pkg/admission/metrics/metrics.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/metrics/metrics.go
@@ -45,7 +45,7 @@ const (
 )
 
 var (
-	// Use buckets ranging from 5 ms to 2.5 seconds (admission webhooks timeout at 30 seconds by default).
+	// Use buckets ranging from 5 ms to 10 seconds (admission webhooks timeout at 30 seconds by default).
 	latencyBuckets       = []float64{0.005, 0.025, 0.1, 0.5, 2.5, 5.0, 10.0}
 	latencySummaryMaxAge = 5 * time.Hour
 

--- a/staging/src/k8s.io/apiserver/pkg/admission/metrics/metrics.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/metrics/metrics.go
@@ -178,13 +178,13 @@ func (m *AdmissionMetrics) ObserveWebhook(ctx context.Context, elapsed time.Dura
 }
 
 // ObserveWebhookRejection records admission related metrics for an admission webhook rejection.
-func (m *AdmissionMetrics) ObserveWebhookRejection(ctx context.Context, name, stepType, operation string, errorType WebhookRejectionErrorType, rejectionCode int) {
+func (m *AdmissionMetrics) ObserveWebhookRejection(ctx context.Context, name, stepType string, attr admission.Attributes, errorType WebhookRejectionErrorType, rejectionCode int) {
 	// We truncate codes greater than 600 to keep the cardinality bounded.
 	// This should be rarely done by a malfunctioning webhook server.
 	if rejectionCode > 600 {
 		rejectionCode = 600
 	}
-	m.webhookRejection.WithContext(ctx).WithLabelValues(name, stepType, operation, string(errorType), strconv.Itoa(rejectionCode), attr.GetNamespace()).Inc()
+	m.webhookRejection.WithContext(ctx).WithLabelValues(name, stepType, string(attr.GetOperation()), string(errorType), strconv.Itoa(rejectionCode), attr.GetNamespace()).Inc()
 }
 
 type metricSet struct {

--- a/staging/src/k8s.io/apiserver/pkg/admission/metrics/metrics_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/metrics/metrics_test.go
@@ -47,6 +47,7 @@ func TestObserveAdmissionStep(t *testing.T) {
 		"operation": string(admission.Create),
 		"type":      "admit",
 		"rejected":  "false",
+		"namespace": "ns",
 	}
 	expectHistogramCountTotal(t, "apiserver_admission_step_admission_duration_seconds", wantLabels, 1)
 	expectFindMetric(t, "apiserver_admission_step_admission_duration_seconds_summary", wantLabels)
@@ -70,6 +71,7 @@ func TestObserveAdmissionController(t *testing.T) {
 		"operation": string(admission.Create),
 		"type":      "admit",
 		"rejected":  "false",
+		"namespace": "ns",
 	}
 	expectHistogramCountTotal(t, "apiserver_admission_controller_admission_duration_seconds", wantLabels, 1)
 
@@ -85,6 +87,7 @@ func TestObserveWebhook(t *testing.T) {
 		"operation": string(admission.Create),
 		"type":      "admit",
 		"rejected":  "false",
+		"namespace": "ns",
 	}
 	expectHistogramCountTotal(t, "apiserver_admission_webhook_admission_duration_seconds", wantLabels, 1)
 }
@@ -100,6 +103,7 @@ func TestObserveWebhookRejection(t *testing.T) {
 		"type":           "admit",
 		"error_type":     "no_error",
 		"rejection_code": "500",
+		"namespace":      "ns",
 	}
 	wantLabels600 := map[string]string{
 		"name":           "x",
@@ -107,6 +111,7 @@ func TestObserveWebhookRejection(t *testing.T) {
 		"type":           "admit",
 		"error_type":     "no_error",
 		"rejection_code": "600",
+		"namespace":      "ns",
 	}
 	wantLabelsCallingWebhookError := map[string]string{
 		"name":           "x",
@@ -114,6 +119,7 @@ func TestObserveWebhookRejection(t *testing.T) {
 		"type":           "validate",
 		"error_type":     "calling_webhook_error",
 		"rejection_code": "0",
+		"namespace":      "ns",
 	}
 	expectCounterValue(t, "apiserver_admission_webhook_rejection_count", wantLabels, 1)
 	expectCounterValue(t, "apiserver_admission_webhook_rejection_count", wantLabels600, 1)

--- a/staging/src/k8s.io/apiserver/pkg/admission/metrics/metrics_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/metrics/metrics_test.go
@@ -94,9 +94,9 @@ func TestObserveWebhook(t *testing.T) {
 
 func TestObserveWebhookRejection(t *testing.T) {
 	Metrics.reset()
-	Metrics.ObserveWebhookRejection(context.TODO(), "x", stepAdmit, string(admission.Create), WebhookRejectionNoError, 500)
-	Metrics.ObserveWebhookRejection(context.TODO(), "x", stepAdmit, string(admission.Create), WebhookRejectionNoError, 654)
-	Metrics.ObserveWebhookRejection(context.TODO(), "x", stepValidate, string(admission.Update), WebhookRejectionCallingWebhookError, 0)
+	Metrics.ObserveWebhookRejection(context.TODO(), "x", stepAdmit, attr, WebhookRejectionNoError, 500)
+	Metrics.ObserveWebhookRejection(context.TODO(), "x", stepAdmit, attr, WebhookRejectionNoError, 654)
+	Metrics.ObserveWebhookRejection(context.TODO(), "x", stepValidate, attr, WebhookRejectionCallingWebhookError, 0)
 	wantLabels := map[string]string{
 		"name":           "x",
 		"operation":      string(admission.Create),
@@ -115,7 +115,7 @@ func TestObserveWebhookRejection(t *testing.T) {
 	}
 	wantLabelsCallingWebhookError := map[string]string{
 		"name":           "x",
-		"operation":      string(admission.Update),
+		"operation":      string(admission.Create),
 		"type":           "validate",
 		"error_type":     "calling_webhook_error",
 		"rejection_code": "0",

--- a/staging/src/k8s.io/apiserver/pkg/admission/metrics/metrics_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/metrics/metrics_test.go
@@ -96,7 +96,7 @@ func TestObserveWebhookRejection(t *testing.T) {
 	Metrics.reset()
 	Metrics.ObserveWebhookRejection(context.TODO(), "x", stepAdmit, attr, WebhookRejectionNoError, 500)
 	Metrics.ObserveWebhookRejection(context.TODO(), "x", stepAdmit, attr, WebhookRejectionNoError, 654)
-	Metrics.ObserveWebhookRejection(context.TODO(), "x", stepValidate, attr, WebhookRejectionCallingWebhookError, 0)
+	Metrics.ObserveWebhookRejection(context.TODO(), "x", stepValidate, admission.NewAttributesRecord(nil, nil, kind, "ns", "name", resource, "subresource", admission.Update, &metav1.UpdateOptions{}, false, nil), WebhookRejectionCallingWebhookError, 0)
 	wantLabels := map[string]string{
 		"name":           "x",
 		"operation":      string(admission.Create),
@@ -115,7 +115,7 @@ func TestObserveWebhookRejection(t *testing.T) {
 	}
 	wantLabelsCallingWebhookError := map[string]string{
 		"name":           "x",
-		"operation":      string(admission.Create),
+		"operation":      string(admission.Update),
 		"type":           "validate",
 		"error_type":     "calling_webhook_error",
 		"rejection_code": "0",

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/mutating/dispatcher.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/mutating/dispatcher.go
@@ -142,14 +142,14 @@ func (a *mutatingDispatcher) Dispatch(ctx context.Context, attr admission.Attrib
 			case *webhookutil.ErrCallingWebhook:
 				if !ignoreClientCallFailures {
 					rejected = true
-					admissionmetrics.Metrics.ObserveWebhookRejection(ctx, hook.Name, "admit", string(versionedAttr.Attributes.GetOperation()), admissionmetrics.WebhookRejectionCallingWebhookError, 0)
+					admissionmetrics.Metrics.ObserveWebhookRejection(ctx, hook.Name, "admit", versionedAttr.Attributes, admissionmetrics.WebhookRejectionCallingWebhookError, 0)
 				}
 			case *webhookutil.ErrWebhookRejection:
 				rejected = true
-				admissionmetrics.Metrics.ObserveWebhookRejection(ctx, hook.Name, "admit", string(versionedAttr.Attributes.GetOperation()), admissionmetrics.WebhookRejectionNoError, int(err.Status.ErrStatus.Code))
+				admissionmetrics.Metrics.ObserveWebhookRejection(ctx, hook.Name, "admit", versionedAttr.Attributes, admissionmetrics.WebhookRejectionNoError, int(err.Status.ErrStatus.Code))
 			default:
 				rejected = true
-				admissionmetrics.Metrics.ObserveWebhookRejection(ctx, hook.Name, "admit", string(versionedAttr.Attributes.GetOperation()), admissionmetrics.WebhookRejectionAPIServerInternalError, 0)
+				admissionmetrics.Metrics.ObserveWebhookRejection(ctx, hook.Name, "admit", versionedAttr.Attributes, admissionmetrics.WebhookRejectionAPIServerInternalError, 0)
 			}
 		}
 		admissionmetrics.Metrics.ObserveWebhook(ctx, time.Since(t), rejected, versionedAttr.Attributes, "admit", hook.Name)

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/validating/dispatcher.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/validating/dispatcher.go
@@ -109,14 +109,14 @@ func (d *validatingDispatcher) Dispatch(ctx context.Context, attr admission.Attr
 				case *webhookutil.ErrCallingWebhook:
 					if !ignoreClientCallFailures {
 						rejected = true
-						admissionmetrics.Metrics.ObserveWebhookRejection(ctx, hook.Name, "validating", string(versionedAttr.Attributes.GetOperation()), admissionmetrics.WebhookRejectionCallingWebhookError, 0)
+						admissionmetrics.Metrics.ObserveWebhookRejection(ctx, hook.Name, "validating", versionedAttr.Attributes, admissionmetrics.WebhookRejectionCallingWebhookError, 0)
 					}
 				case *webhookutil.ErrWebhookRejection:
 					rejected = true
-					admissionmetrics.Metrics.ObserveWebhookRejection(ctx, hook.Name, "validating", string(versionedAttr.Attributes.GetOperation()), admissionmetrics.WebhookRejectionNoError, int(err.Status.ErrStatus.Code))
+					admissionmetrics.Metrics.ObserveWebhookRejection(ctx, hook.Name, "validating", versionedAttr.Attributes, admissionmetrics.WebhookRejectionNoError, int(err.Status.ErrStatus.Code))
 				default:
 					rejected = true
-					admissionmetrics.Metrics.ObserveWebhookRejection(ctx, hook.Name, "validating", string(versionedAttr.Attributes.GetOperation()), admissionmetrics.WebhookRejectionAPIServerInternalError, 0)
+					admissionmetrics.Metrics.ObserveWebhookRejection(ctx, hook.Name, "validating", versionedAttr.Attributes, admissionmetrics.WebhookRejectionAPIServerInternalError, 0)
 				}
 			}
 			admissionmetrics.Metrics.ObserveWebhook(ctx, time.Since(t), rejected, versionedAttr.Attributes, "validating", hook.Name)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

Improve admission webhook metrics.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #100871

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
- Add a namespace label for all apiserver_admission_* metrics.
- Expand the histogram range to 0-10s for all apiserver_admission_*_duration_seconds metrics.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
