### PR TITLE
fix multi running container for the same pod.Spec.Containers

### DIFF
--- a/pkg/kubelet/container/runtime.go
+++ b/pkg/kubelet/container/runtime.go
@@ -346,6 +346,18 @@ func (podStatus *PodStatus) FindContainerStatusByName(containerName string) *Sta
 	return nil
 }
 
+// GetAllContainerStatusesByName return all running container status in the pod status with the given name.
+// the containers have already been sorted by CreatedAt
+func (podStatus *PodStatus) GetAllContainerStatusesByName(containerName string) []*Status {
+	var containerStatuses []*Status
+	for _, containerStatus := range podStatus.ContainerStatuses {
+		if containerStatus.Name == containerName {
+			containerStatuses = append(containerStatuses, containerStatus)
+		}
+	}
+	return containerStatuses
+}
+
 // GetRunningContainerStatuses returns container status of all the running containers in a pod
 func (podStatus *PodStatus) GetRunningContainerStatuses() []*Status {
 	runningContainerStatuses := []*Status{}

--- a/pkg/kubelet/kuberuntime/kuberuntime_manager_test.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_manager_test.go
@@ -691,7 +691,7 @@ func makeBasePodAndStatus() (*v1.Pod, *kubecontainer.PodStatus) {
 			{
 				Id:       "sandboxID",
 				State:    runtimeapi.PodSandboxState_SANDBOX_READY,
-				Metadata: &runtimeapi.PodSandboxMetadata{Name: pod.Name, Namespace: pod.Namespace, Uid: "sandboxuid", Attempt: uint32(0)},
+				Metadata: &runtimeapi.PodSandboxMetadata{Name: pod.Name, Namespace: pod.Namespace, Uid: "sandboxuid", Attempt: 0},
 				Network:  &runtimeapi.PodSandboxNetworkStatus{Ip: "10.0.0.1"},
 			},
 		},
@@ -747,7 +747,7 @@ func TestComputePodActions(t *testing.T) {
 			actions: podActions{
 				KillPod:           true,
 				CreateSandbox:     true,
-				Attempt:           uint32(0),
+				Attempt:           0,
 				ContainersToStart: []int{0, 1, 2},
 				ContainersToKill:  getKillMap(basePod, baseStatus, []int{}),
 			},
@@ -806,7 +806,7 @@ func TestComputePodActions(t *testing.T) {
 				KillPod:           true,
 				CreateSandbox:     true,
 				SandboxID:         baseStatus.SandboxStatuses[0].Id,
-				Attempt:           uint32(1),
+				Attempt:           1,
 				ContainersToStart: []int{0, 1, 2},
 				ContainersToKill:  getKillMap(basePod, baseStatus, []int{}),
 			},
@@ -822,7 +822,7 @@ func TestComputePodActions(t *testing.T) {
 				KillPod:           true,
 				CreateSandbox:     true,
 				SandboxID:         baseStatus.SandboxStatuses[0].Id,
-				Attempt:           uint32(1),
+				Attempt:           1,
 				ContainersToStart: []int{0, 2},
 				ContainersToKill:  getKillMap(basePod, baseStatus, []int{}),
 			},
@@ -835,7 +835,7 @@ func TestComputePodActions(t *testing.T) {
 				KillPod:           true,
 				CreateSandbox:     true,
 				SandboxID:         baseStatus.SandboxStatuses[0].Id,
-				Attempt:           uint32(1),
+				Attempt:           1,
 				ContainersToStart: []int{0, 1, 2},
 				ContainersToKill:  getKillMap(basePod, baseStatus, []int{}),
 			},
@@ -892,7 +892,7 @@ func TestComputePodActions(t *testing.T) {
 			mutateStatusFn: func(status *kubecontainer.PodStatus) {
 				// no ready sandbox
 				status.SandboxStatuses[0].State = runtimeapi.PodSandboxState_SANDBOX_NOTREADY
-				status.SandboxStatuses[0].Metadata.Attempt = uint32(1)
+				status.SandboxStatuses[0].Metadata.Attempt = 1
 				// all containers exited
 				for i := range status.ContainerStatuses {
 					status.ContainerStatuses[i].State = kubecontainer.ContainerStateExited
@@ -901,7 +901,7 @@ func TestComputePodActions(t *testing.T) {
 			},
 			actions: podActions{
 				SandboxID:         baseStatus.SandboxStatuses[0].Id,
-				Attempt:           uint32(2),
+				Attempt:           2,
 				CreateSandbox:     false,
 				KillPod:           true,
 				ContainersToStart: []int{},
@@ -915,7 +915,7 @@ func TestComputePodActions(t *testing.T) {
 			mutateStatusFn: func(status *kubecontainer.PodStatus) {
 				// no ready sandbox
 				status.SandboxStatuses[0].State = runtimeapi.PodSandboxState_SANDBOX_NOTREADY
-				status.SandboxStatuses[0].Metadata.Attempt = uint32(1)
+				status.SandboxStatuses[0].Metadata.Attempt = 1
 				// all containers succeeded
 				for i := range status.ContainerStatuses {
 					status.ContainerStatuses[i].State = kubecontainer.ContainerStateExited
@@ -924,7 +924,7 @@ func TestComputePodActions(t *testing.T) {
 			},
 			actions: podActions{
 				SandboxID:         baseStatus.SandboxStatuses[0].Id,
-				Attempt:           uint32(2),
+				Attempt:           2,
 				CreateSandbox:     false,
 				KillPod:           true,
 				ContainersToStart: []int{},
@@ -938,13 +938,13 @@ func TestComputePodActions(t *testing.T) {
 			mutateStatusFn: func(status *kubecontainer.PodStatus) {
 				// no ready sandbox
 				status.SandboxStatuses[0].State = runtimeapi.PodSandboxState_SANDBOX_NOTREADY
-				status.SandboxStatuses[0].Metadata.Attempt = uint32(2)
+				status.SandboxStatuses[0].Metadata.Attempt = 2
 				// no visible containers
 				status.ContainerStatuses = []*kubecontainer.Status{}
 			},
 			actions: podActions{
 				SandboxID:         baseStatus.SandboxStatuses[0].Id,
-				Attempt:           uint32(3),
+				Attempt:           3,
 				CreateSandbox:     true,
 				KillPod:           true,
 				ContainersToStart: []int{0, 1, 2},
@@ -1053,7 +1053,7 @@ func TestComputePodActionsWithInitContainers(t *testing.T) {
 				KillPod:                  true,
 				CreateSandbox:            true,
 				SandboxID:                baseStatus.SandboxStatuses[0].Id,
-				Attempt:                  uint32(1),
+				Attempt:                  1,
 				NextInitContainerToStart: &basePod.Spec.InitContainers[0],
 				ContainersToStart:        []int{},
 				ContainersToKill:         getKillMapWithInitContainers(basePod, baseStatus, []int{}),
@@ -1140,7 +1140,7 @@ func TestComputePodActionsWithInitContainers(t *testing.T) {
 				KillPod:           true,
 				CreateSandbox:     false,
 				SandboxID:         baseStatus.SandboxStatuses[0].Id,
-				Attempt:           uint32(1),
+				Attempt:           1,
 				ContainersToStart: []int{},
 				ContainersToKill:  getKillMapWithInitContainers(basePod, baseStatus, []int{}),
 			},
@@ -1155,7 +1155,7 @@ func TestComputePodActionsWithInitContainers(t *testing.T) {
 				KillPod:                  true,
 				CreateSandbox:            true,
 				SandboxID:                baseStatus.SandboxStatuses[0].Id,
-				Attempt:                  uint32(1),
+				Attempt:                  1,
 				NextInitContainerToStart: &basePod.Spec.InitContainers[0],
 				ContainersToStart:        []int{},
 				ContainersToKill:         getKillMapWithInitContainers(basePod, baseStatus, []int{}),
@@ -1171,7 +1171,7 @@ func TestComputePodActionsWithInitContainers(t *testing.T) {
 				KillPod:                  true,
 				CreateSandbox:            true,
 				SandboxID:                baseStatus.SandboxStatuses[0].Id,
-				Attempt:                  uint32(1),
+				Attempt:                  1,
 				NextInitContainerToStart: &basePod.Spec.InitContainers[0],
 				ContainersToStart:        []int{},
 				ContainersToKill:         getKillMapWithInitContainers(basePod, baseStatus, []int{}),
@@ -1313,7 +1313,7 @@ func TestComputePodActionsWithInitAndEphemeralContainers(t *testing.T) {
 				KillPod:                  true,
 				CreateSandbox:            true,
 				SandboxID:                baseStatus.SandboxStatuses[0].Id,
-				Attempt:                  uint32(1),
+				Attempt:                  1,
 				NextInitContainerToStart: &basePod.Spec.InitContainers[0],
 				ContainersToStart:        []int{},
 				ContainersToKill:         getKillMapWithInitContainers(basePod, baseStatus, []int{}),
@@ -1328,7 +1328,7 @@ func TestComputePodActionsWithInitAndEphemeralContainers(t *testing.T) {
 				KillPod:                  true,
 				CreateSandbox:            true,
 				SandboxID:                baseStatus.SandboxStatuses[0].Id,
-				Attempt:                  uint32(1),
+				Attempt:                  1,
 				NextInitContainerToStart: &basePod.Spec.InitContainers[0],
 				ContainersToStart:        []int{},
 				ContainersToKill:         getKillMapWithInitContainers(basePod, baseStatus, []int{}),
@@ -1371,6 +1371,91 @@ func TestComputePodActionsWithInitAndEphemeralContainers(t *testing.T) {
 		actions := m.computePodActions(pod, status)
 		verifyActions(t, &test.actions, &actions, desc)
 	}
+}
+
+func TestComputePodActionsWithMultiRunningContainer(t *testing.T) {
+	_, _, m, err := createTestRuntimeManager()
+	require.NoError(t, err)
+	pod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			UID:       "12345678",
+			Name:      "foo",
+			Namespace: "foo-ns",
+		},
+		Spec: v1.PodSpec{
+			Containers: []v1.Container{
+				{
+					Name:  "foo1",
+					Image: "busybox",
+				},
+			},
+		},
+	}
+
+	status := &kubecontainer.PodStatus{
+		ID:        pod.UID,
+		Name:      pod.Name,
+		Namespace: pod.Namespace,
+		SandboxStatuses: []*runtimeapi.PodSandboxStatus{
+			{
+				Id:       "sandboxID",
+				State:    runtimeapi.PodSandboxState_SANDBOX_READY,
+				Metadata: &runtimeapi.PodSandboxMetadata{Name: pod.Name, Namespace: pod.Namespace, Uid: "sandboxuid", Attempt: 0},
+				Network:  &runtimeapi.PodSandboxNetworkStatus{Ip: "10.0.0.1"},
+			},
+		},
+		ContainerStatuses: []*kubecontainer.Status{
+			{
+				ID:   kubecontainer.ContainerID{ID: "id1"},
+				Name: "foo1", State: kubecontainer.ContainerStateRunning,
+				Hash: kubecontainer.HashContainer(&pod.Spec.Containers[0]),
+			},
+			{
+				ID:   kubecontainer.ContainerID{ID: "id2"},
+				Name: "foo1", State: kubecontainer.ContainerStateRunning,
+				Hash: kubecontainer.HashContainer(&pod.Spec.Containers[0]),
+			},
+			{
+				ID:   kubecontainer.ContainerID{ID: "id3"},
+				Name: "foo1", State: kubecontainer.ContainerStateRunning,
+				Hash: kubecontainer.HashContainer(&pod.Spec.Containers[0]),
+			},
+			{
+				ID:   kubecontainer.ContainerID{ID: "id4"},
+				Name: "foo1", State: kubecontainer.ContainerStateExited,
+				Hash: kubecontainer.HashContainer(&pod.Spec.Containers[0]),
+			},
+		},
+	}
+
+	expectation := podActions{
+		KillPod:           false,
+		CreateSandbox:     false,
+		SandboxID:         status.SandboxStatuses[0].Id,
+		Attempt:           0,
+		ContainersToStart: []int{},
+		ContainersToKill: map[kubecontainer.ContainerID]containerToKillInfo{
+			{ID: "id2"}: {container: &pod.Spec.Containers[0], name: "foo1"},
+			{ID: "id3"}: {container: &pod.Spec.Containers[0], name: "foo1"},
+		},
+	}
+	actions := m.computePodActions(pod, status)
+	verifyActions(t, &expectation, &actions, "kill other running containers")
+
+	expectation = podActions{
+		KillPod:           false,
+		CreateSandbox:     false,
+		SandboxID:         status.SandboxStatuses[0].Id,
+		Attempt:           0,
+		ContainersToStart: []int{0},
+		ContainersToKill: map[kubecontainer.ContainerID]containerToKillInfo{
+			{ID: "id2"}: {container: &pod.Spec.Containers[0], name: "foo1"},
+			{ID: "id3"}: {container: &pod.Spec.Containers[0], name: "foo1"},
+		},
+	}
+	status.ContainerStatuses[0].State = kubecontainer.ContainerStateExited
+	actions = m.computePodActions(pod, status)
+	verifyActions(t, &expectation, &actions, "kill all running containers")
 }
 
 func TestSyncPodWithSandboxAndDeletedPod(t *testing.T) {


### PR DESCRIPTION

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

![image](https://user-images.githubusercontent.com/6782068/115108663-466e0380-9fa4-11eb-8498-4785c03a7d12.png)

>  I0412 14:30:49.476501 2665331 kuberuntime_container.go:412] ContainerStatus for 4705f32c460eba4e7327068d4c2748be1bc3e731f5641c93ffe75d82bf680834 error: rpc error: code = Unknown desc = Error: No such container: 4705f32c460eba4e7327068d4c2748be1bc3e731f5641c93ffe75d82bf680834
 
> E0412 14:33:42.738180 2665331 remote_runtime.go:222] StartContainer "4705f32c460eba4e7327068d4c2748be1bc3e731f5641c93ffe75d82bf680834" from runtime service failed: rpc error: code = DeadlineExceeded desc = context deadline exceeded

when docker response time out, the status of container is `Unknown`, and kubelet will try to create a new container with restart+1. There may end up with two same running container with different restart count, and kubelet can never kill the older one.

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
/sig node