### PR TITLE
e2e create pods only on schedulable nodes

### DIFF
--- a/test/e2e/network/no_snat.go
+++ b/test/e2e/network/no_snat.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 
 	"k8s.io/kubernetes/test/e2e/framework"
+	e2enode "k8s.io/kubernetes/test/e2e/framework/node"
 	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
 	"k8s.io/kubernetes/test/e2e/network/common"
 	imageutils "k8s.io/kubernetes/test/utils/image"
@@ -65,10 +66,9 @@ var _ = common.SIGDescribe("NoSNAT [Feature:NoSNAT] [Slow]", func() {
 	ginkgo.It("Should be able to send traffic between Pods without SNAT", func() {
 		cs := f.ClientSet
 		pc := cs.CoreV1().Pods(f.Namespace.Name)
-		nc := cs.CoreV1().Nodes()
 
 		ginkgo.By("creating a test pod on each Node")
-		nodes, err := nc.List(context.TODO(), metav1.ListOptions{})
+		nodes, err := e2enode.GetReadySchedulableNodes(cs)
 		framework.ExpectNoError(err)
 		framework.ExpectNotEqual(len(nodes.Items), 0, "no Nodes in the cluster")
 


### PR DESCRIPTION
We were avoiding the scheduler using the pod.Spec.NodeName directly,
however, once we switched to using the node selector, the no_snat
e2e test started to fail because was trying to schedule pods on
nodes with taints, hence, failing the test.

/kind failing-test
```release-note
NONE
```

https://testgrid.k8s.io/sig-network-kind#sig-network-kind,%20IPv6,%20master
