### PR TITLE
      TestGetPatchSetsForPathMustBeDirectory: Ensure the error type is os.PathError

### DIFF
--- a/cmd/kubeadm/app/util/patches/patches.go
+++ b/cmd/kubeadm/app/util/patches/patches.go
@@ -283,7 +283,11 @@ func getPatchSetsFromPath(targetPath string, knownTargets []string, output io.Wr
 		goto return_path_error
 	}
 	if !info.IsDir() {
-		err = errors.New("not a directory")
+		err = &os.PathError{
+			Op:   "getPatchSetsFromPath",
+			Path: info.Name(),
+			Err:  errors.New("not a directory"),
+		}
 		goto return_path_error
 	}
 

--- a/cmd/kubeadm/app/util/patches/patches_test.go
+++ b/cmd/kubeadm/app/util/patches/patches_test.go
@@ -24,6 +24,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/pkg/errors"
 	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 )
@@ -165,15 +166,16 @@ func TestCreatePatchSet(t *testing.T) {
 }
 
 func TestGetPatchSetsForPathMustBeDirectory(t *testing.T) {
-	tempFile, err := ioutil.TempFile("", "test-file")
+	tempFile, err := os.CreateTemp("", "test-file")
 	if err != nil {
 		t.Errorf("error creating temporary file: %v", err)
 	}
 	defer os.Remove(tempFile.Name())
 
 	_, _, _, err = getPatchSetsFromPath(tempFile.Name(), testKnownTargets, ioutil.Discard)
-	if err == nil {
-		t.Fatalf("expected error for non-directory path %q", tempFile.Name())
+	var pathErr *os.PathError
+	if !errors.As(err, &pathErr) {
+		t.Fatalf("expected os.PathError for non-directory path %q, but got %v", tempFile.Name(), err)
 	}
 }
 


### PR DESCRIPTION
Ensure the tested error is an os.PathError instead of only non-nil.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug

/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

Improve the robustness of tests.


#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```


