### PR TITLE
Automated cherry pick of #101093: Fix `startupProbe` behaviour changed

### DIFF
--- a/pkg/kubelet/prober/worker.go
+++ b/pkg/kubelet/prober/worker.go
@@ -250,8 +250,9 @@ func (w *worker) doProbe() (keepGoing bool) {
 
 	if c.Started != nil && *c.Started {
 		// Stop probing for startup once container has started.
+		// we keep it running to make sure it will work for restarted container.
 		if w.probeType == startup {
-			return false
+			return true
 		}
 	} else {
 		// Disable other probes until container has started.

--- a/pkg/kubelet/prober/worker_test.go
+++ b/pkg/kubelet/prober/worker_test.go
@@ -333,12 +333,6 @@ func expectContinue(t *testing.T, w *worker, c bool, msg string) {
 	}
 }
 
-func expectStop(t *testing.T, w *worker, c bool, msg string) {
-	if c {
-		t.Errorf("[%s - %s] Expected to stop, but did not", w.probeType, msg)
-	}
-}
-
 func resultsManager(m *manager, probeType probeType) results.Manager {
 	switch probeType {
 	case readiness:
@@ -508,6 +502,6 @@ func TestStartupProbeDisabledByStarted(t *testing.T) {
 	// startupProbe fails, but is disabled
 	m.prober.exec = fakeExecProber{probe.Failure, nil}
 	msg = "Started, probe failure, result success"
-	expectStop(t, w, w.doProbe(), msg)
+	expectContinue(t, w, w.doProbe(), msg)
 	expectResult(t, w, results.Success, msg)
 }


### PR DESCRIPTION
Cherry pick of #101093 on release-1.21.

#101093: Fix `startupProbe` behaviour changed

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
Fixed a regression in 1.21 where startupProbe stopped working after a container's first restart
```