### PR TITLE
the PDB conformance test failed on kubelet 1.20 and 1.19

### DIFF
--- a/test/conformance/testdata/conformance.yaml
+++ b/test/conformance/testdata/conformance.yaml
@@ -707,7 +707,7 @@
 - testname: 'PodDisruptionBudget: block an eviction until the PDB is updated to allow
     it'
   codename: '[sig-apps] DisruptionController should block an eviction until the PDB
-    is updated to allow it [Conformance]'
+    is updated to allow it [MinimumKubeletVersion:1.21] [Conformance]'
   description: Eviction API must block an eviction until the PDB is updated to allow
     it
   release: v1.22

--- a/test/e2e/apps/disruption.go
+++ b/test/e2e/apps/disruption.go
@@ -319,7 +319,7 @@ var _ = SIGDescribe("DisruptionController", func() {
 		Testname: PodDisruptionBudget: block an eviction until the PDB is updated to allow it
 		Description: Eviction API must block an eviction until the PDB is updated to allow it
 	*/
-	framework.ConformanceIt("should block an eviction until the PDB is updated to allow it", func() {
+	framework.ConformanceIt("should block an eviction until the PDB is updated to allow it [MinimumKubeletVersion:1.21]", func() {
 		ginkgo.By("Creating a pdb that targets all three pods in a test replica set")
 		createPDBMinAvailableOrDie(cs, ns, defaultName, intstr.FromInt(3), defaultLabels)
 		createReplicaSetOrDie(cs, ns, 3, false)


### PR DESCRIPTION
#### What type of PR is this?
/kind failing-test
#### What this PR does / why we need it:
PDB conformance test failed on kubelet 1.20 and 1.19
PDB was GAed in 1.21 and there may be some changes. (Or we need to fix the problem in 1.19-1.20)

#### Which issue(s) this PR fixes:
Fixes #101231

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
None
```
