### PR TITLE
update more integration tests for v1beta1 removal

### DIFF
--- a/test/integration/apiserver/print_test.go
+++ b/test/integration/apiserver/print_test.go
@@ -124,28 +124,6 @@ var missingHanlders = sets.NewString(
 	"AuditSink",
 )
 
-// known types that are no longer served we should tolerate restmapper errors for
-var unservedTypes = map[schema.GroupVersionKind]bool{
-	{Group: "extensions", Version: "v1beta1", Kind: "ControllerRevision"}: true,
-	{Group: "extensions", Version: "v1beta1", Kind: "DaemonSet"}:          true,
-	{Group: "extensions", Version: "v1beta1", Kind: "Deployment"}:         true,
-	{Group: "extensions", Version: "v1beta1", Kind: "NetworkPolicy"}:      true,
-	{Group: "extensions", Version: "v1beta1", Kind: "PodSecurityPolicy"}:  true,
-	{Group: "extensions", Version: "v1beta1", Kind: "ReplicaSet"}:         true,
-
-	{Group: "apps", Version: "v1beta1", Kind: "ControllerRevision"}: true,
-	{Group: "apps", Version: "v1beta1", Kind: "DaemonSet"}:          true,
-	{Group: "apps", Version: "v1beta1", Kind: "Deployment"}:         true,
-	{Group: "apps", Version: "v1beta1", Kind: "ReplicaSet"}:         true,
-	{Group: "apps", Version: "v1beta1", Kind: "StatefulSet"}:        true,
-
-	{Group: "apps", Version: "v1beta2", Kind: "ControllerRevision"}: true,
-	{Group: "apps", Version: "v1beta2", Kind: "DaemonSet"}:          true,
-	{Group: "apps", Version: "v1beta2", Kind: "Deployment"}:         true,
-	{Group: "apps", Version: "v1beta2", Kind: "ReplicaSet"}:         true,
-	{Group: "apps", Version: "v1beta2", Kind: "StatefulSet"}:        true,
-}
-
 func TestServerSidePrint(t *testing.T) {
 	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.CSIStorageCapacity, true)()
 
@@ -218,10 +196,8 @@ func TestServerSidePrint(t *testing.T) {
 		// read table definition as returned by the server
 		mapping, err := mapper.RESTMapping(gvk.GroupKind(), gvk.Version)
 		if err != nil {
-			if unservedTypes[gvk] {
-				continue
-			}
-			t.Errorf("unexpected error getting mapping for GVK %s: %v", gvk, err)
+			// if we have no mapping, we aren't serving it and we don't need to check its printer.
+			t.Logf("unexpected error getting mapping for GVK %s: %v", gvk, err)
 			continue
 		}
 		client, err := factory.ClientForMapping(mapping)

--- a/test/integration/master/kube_apiserver_test.go
+++ b/test/integration/master/kube_apiserver_test.go
@@ -199,7 +199,7 @@ func TestOpenAPIApiextensionsOverlapProtection(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	crdPath, exist, err := getOpenAPIPath(apiextensionsclient, `/apis/apiextensions.k8s.io/v1beta1/customresourcedefinitions/{name}`)
+	crdPath, exist, err := getOpenAPIPath(apiextensionsclient, `/apis/apiextensions.k8s.io/v1/customresourcedefinitions/{name}`)
 	if err != nil {
 		t.Fatalf("unexpected error getting CRD OpenAPI path: %v", err)
 	}
@@ -224,7 +224,7 @@ func TestOpenAPIApiextensionsOverlapProtection(t *testing.T) {
 			},
 			Versions: []apiextensionsv1.CustomResourceDefinitionVersion{
 				{
-					Name:    "v1beta1",
+					Name:    "v1",
 					Served:  true,
 					Storage: true,
 					Schema: &apiextensionsv1.CustomResourceValidation{
@@ -247,7 +247,7 @@ func TestOpenAPIApiextensionsOverlapProtection(t *testing.T) {
 	}
 
 	// Expect the CRD path to not change
-	path, _, err := getOpenAPIPath(apiextensionsclient, `/apis/apiextensions.k8s.io/v1beta1/customresourcedefinitions/{name}`)
+	path, _, err := getOpenAPIPath(apiextensionsclient, `/apis/apiextensions.k8s.io/v1/customresourcedefinitions/{name}`)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -289,7 +289,7 @@ func TestOpenAPIApiextensionsOverlapProtection(t *testing.T) {
 			},
 			Versions: []apiextensionsv1.CustomResourceDefinitionVersion{
 				{
-					Name:    "v1beta1",
+					Name:    "v1",
 					Served:  true,
 					Storage: true,
 					Schema: &apiextensionsv1.CustomResourceValidation{
@@ -312,7 +312,7 @@ func TestOpenAPIApiextensionsOverlapProtection(t *testing.T) {
 	}
 
 	// Expect the apiextensions definition to not change, since the overlapping definition will get renamed.
-	apiextensionsDefinition, exist, err := getOpenAPIDefinition(apiextensionsclient, `io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.CustomResourceDefinition`)
+	apiextensionsDefinition, exist, err := getOpenAPIDefinition(apiextensionsclient, `io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceDefinition`)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/test/integration/master/synthetic_master_test.go
+++ b/test/integration/master/synthetic_master_test.go
@@ -93,10 +93,6 @@ func TestAppsPrefix(t *testing.T) {
 	testPrefix(t, "/apis/apps/")
 }
 
-func TestExtensionsPrefix(t *testing.T) {
-	testPrefix(t, "/apis/extensions/")
-}
-
 func TestKubernetesService(t *testing.T) {
 	config := framework.NewMasterConfig()
 	_, _, closeFn := framework.RunAMaster(config)


### PR DESCRIPTION
1. server-side printing update to skip removed APIs
2. remove an outdated extensions group test
3. update openapi overlap for CRD v1

related to https://github.com/kubernetes/kubernetes/pull/99840

/kind cleanup
/priority important-soon
@kubernetes/sig-api-machinery-pr-reviews 

```release-note
NONE
```