### PR TITLE
Bugfix: prevent daemon controller to adopt controller revisions of ot…

### DIFF
--- a/pkg/controller/controller_ref_manager.go
+++ b/pkg/controller/controller_ref_manager.go
@@ -108,7 +108,7 @@ func (m *BaseControllerRefManager) ClaimObject(ctx context.Context, obj metav1.O
 		return false, nil
 	}
 
-	if m.Controller.GetNamespace() != obj.GetNamespace() {
+	if len(m.Controller.GetNamespace()) > 0 && m.Controller.GetNamespace() != obj.GetNamespace() {
 		// Ignore if namespace not match
 		return false, nil
 	}

--- a/pkg/controller/controller_ref_manager.go
+++ b/pkg/controller/controller_ref_manager.go
@@ -107,6 +107,12 @@ func (m *BaseControllerRefManager) ClaimObject(ctx context.Context, obj metav1.O
 		// Ignore if the object is being deleted
 		return false, nil
 	}
+
+	if m.Controller.GetNamespace() != obj.GetNamespace() {
+		// Ignore if namespace not match
+		return false, nil
+	}
+
 	// Selector matches. Try to adopt.
 	if err := adopt(ctx, obj); err != nil {
 		// If the pod no longer exists, ignore the error.

--- a/pkg/controller/daemon/daemon_controller_test.go
+++ b/pkg/controller/daemon/daemon_controller_test.go
@@ -225,6 +225,19 @@ func addFailedPods(podStore cache.Store, nodeName string, label map[string]strin
 	}
 }
 
+func newControllerRevision(name string, namespace string, label map[string]string,
+	ownerReferences []metav1.OwnerReference) *apps.ControllerRevision {
+	return &apps.ControllerRevision{
+		TypeMeta: metav1.TypeMeta{APIVersion: "apps/v1"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            name,
+			Labels:          label,
+			Namespace:       namespace,
+			OwnerReferences: ownerReferences,
+		},
+	}
+}
+
 type fakePodControl struct {
 	sync.Mutex
 	*controller.FakePodControl

--- a/pkg/controller/daemon/update.go
+++ b/pkg/controller/daemon/update.go
@@ -406,7 +406,7 @@ func (dsc *DaemonSetsController) controlledHistories(ctx context.Context, ds *ap
 
 	// List all histories to include those that don't match the selector anymore
 	// but have a ControllerRef pointing to the controller.
-	histories, err := dsc.historyLister.List(labels.Everything())
+	histories, err := dsc.historyLister.ControllerRevisions(ds.Namespace).List(labels.Everything())
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
Solve DaemonSet Controller bug

#### Which issue(s) this PR fixes:
Fixes #101249

#### Special notes for your reviewer:
If the bug meets the case which is fixed by this [PR](https://github.com/kubernetes/kubernetes/pull/92743),
unexpected deletions of A's children(Pods, ControllerRevisions and so on) may happen, which can be much serious.

```release-note
NONE
```
