### PR TITLE
Add type logging to certificate manager

### DIFF
--- a/staging/src/k8s.io/client-go/util/certificate/certificate_manager_test.go
+++ b/staging/src/k8s.io/client-go/util/certificate/certificate_manager_test.go
@@ -279,6 +279,7 @@ func TestSetRotationDeadline(t *testing.T) {
 				getTemplate: func() *x509.CertificateRequest { return &x509.CertificateRequest{} },
 				usages:      []certificatesv1.KeyUsage{},
 				now:         func() time.Time { return now },
+				logf:        t.Logf,
 			}
 			jitteryDuration = func(float64) time.Duration { return time.Duration(float64(tc.notAfter.Sub(tc.notBefore)) * 0.7) }
 			lowerBound := tc.notBefore.Add(time.Duration(float64(tc.notAfter.Sub(tc.notBefore)) * 0.7))
@@ -451,6 +452,7 @@ func TestCertSatisfiesTemplate(t *testing.T) {
 				cert:        tlsCert,
 				getTemplate: func() *x509.CertificateRequest { return tc.template },
 				now:         time.Now,
+				logf:        t.Logf,
 			}
 
 			result := m.certSatisfiesTemplate()
@@ -475,7 +477,8 @@ func TestRotateCertCreateCSRError(t *testing.T) {
 		clientsetFn: func(_ *tls.Certificate) (clientset.Interface, error) {
 			return newClientset(fakeClient{failureType: createError}), nil
 		},
-		now: func() time.Time { return now },
+		now:  func() time.Time { return now },
+		logf: t.Logf,
 	}
 
 	if success, err := m.rotateCerts(); success {
@@ -499,7 +502,8 @@ func TestRotateCertWaitingForResultError(t *testing.T) {
 		clientsetFn: func(_ *tls.Certificate) (clientset.Interface, error) {
 			return newClientset(fakeClient{failureType: watchError}), nil
 		},
-		now: func() time.Time { return now },
+		now:  func() time.Time { return now },
+		logf: t.Logf,
 	}
 
 	defer func(t time.Duration) { certificateWaitTimeout = t }(certificateWaitTimeout)
@@ -1058,6 +1062,7 @@ func TestRotationLogsDuration(t *testing.T) {
 		},
 		certificateRotation: &h,
 		now:                 func() time.Time { return now },
+		logf:                t.Logf,
 	}
 	ok, err := m.rotateCerts()
 	if err != nil || !ok {


### PR DESCRIPTION
Kubelet cert rotation involves two certificate manager instances (one for client and one for server certs) and the log lines are
identical and confusing. Since certificate manager is a utility library it is also inappropriate to simply assume klog output is
sufficient.

certificate.Manager now accepts a Name and Logf function on its config struct to identify the purpose of the manager and to
provide a way to redirect where output should go. If Name is absent, the name is defaulted from the SignerName, and if that
is not found then the name is set to "client auth" if that is a provided key usage, or "certificate" otherwise. If Logf is
not provided it defaults to klog.V(2). as today. The name is printed in "foo: bar" form on every line, but can be converted to structured logging in the future. The log level is not customizable and it is up to the caller to decide whether that is an issue.

Some log messages are slightly cleaned up to more clearly indicate their intent. One log message is removed in a utility function that was already at v(4) and less likely to be needed.

The default behavior of the certificate manager is as before and the kubelet now identifies the server and client signerName as
separate entities:

```
I0414 19:07:33.590419    1539 certificate_manager.go:263] kubernetes.io/kube-apiserver-client-kubelet: Rotating certificates
E0414 19:07:33.594154    1539 certificate_manager.go:464] kubernetes.io/kube-apiserver-client-kubelet: Failed while requesting a signed certificate from the control plane: cannot create certificate signing request: Post "https://...
```

/kind bug
/kind cleanup

```release-note
The kubelet now reports distinguishes log messages about certificate rotation for its client cert and server cert separately to make debugging problems with one or the other easier.
```

```docs

```