### PR TITLE
Prevent double dollar expansion when it is not followed by an actual variable reference

### DIFF
--- a/third_party/forked/golang/expansion/expand.go
+++ b/third_party/forked/golang/expansion/expand.go
@@ -81,8 +81,18 @@ func Expand(input string, mapping func(string) string) string {
 func tryReadVariableName(input string) (string, bool, int) {
 	switch input[0] {
 	case operator:
-		// Escaped operator; return it.
-		return input[0:1], false, 1
+		// Check whether the operator is followed by a variable reference
+		if len(input) > 1 && input[1] == referenceOpener {
+			// Scan to expression closer
+			for i := 2; i < len(input); i++ {
+				if input[i] == referenceCloser {
+					// Complete reference found; return the reference, effectively escaping it.
+					return input[0:i], false, i
+				}
+			}
+		}
+		// Incomplete reference; return the (original) operator and do not advance any extra steps
+		return string(operator), false, 0
 	case referenceOpener:
 		// Scan to expression closer
 		for i := 1; i < len(input); i++ {

--- a/third_party/forked/golang/expansion/expand_test.go
+++ b/third_party/forked/golang/expansion/expand_test.go
@@ -132,7 +132,7 @@ func doExpansionTest(t *testing.T, mapping func(string) string) {
 		{
 			name:     "mixed in escapes",
 			input:    "f000-$$VAR_A",
-			expected: "f000-$VAR_A",
+			expected: "f000-$$VAR_A",
 		},
 		{
 			name:     "backslash escape ignored",
@@ -202,22 +202,32 @@ func doExpansionTest(t *testing.T, mapping func(string) string) {
 		{
 			name:     "multiple (even) operators, var undefined",
 			input:    "$$$$$$(BIG_MONEY)",
-			expected: "$$$(BIG_MONEY)",
+			expected: "$$$$$(BIG_MONEY)",
 		},
 		{
 			name:     "multiple (even) operators, var defined",
 			input:    "$$$$$$(VAR_A)",
-			expected: "$$$(VAR_A)",
+			expected: "$$$$$(VAR_A)",
 		},
 		{
 			name:     "multiple (odd) operators, var undefined",
 			input:    "$$$$$$$(GOOD_ODDS)",
-			expected: "$$$$(GOOD_ODDS)",
+			expected: "$$$$$$(GOOD_ODDS)",
 		},
 		{
 			name:     "multiple (odd) operators, var defined",
 			input:    "$$$$$$$(VAR_A)",
-			expected: "$$$A",
+			expected: "$$$$$$(VAR_A)",
+		},
+		{
+			name:     "multiple (even) operators, without variable",
+			input:    "$$",
+			expected: "$$",
+		},
+		{
+			name:     "multiple (odd) operators, without variable",
+			input:    "$$$",
+			expected: "$$$",
 		},
 		{
 			name:     "missing open expression",
@@ -268,6 +278,16 @@ func doExpansionTest(t *testing.T, mapping func(string) string) {
 			name:     "escaped operators in variable names are not escaped",
 			input:    "$(foo$$var)",
 			expected: "$(foo$$var)",
+		},
+		{
+			name:     "empty variable reference",
+			input:    "$()",
+			expected: "$()",
+		},
+		{
+			name:     "escaped empty variable reference",
+			input:    "$$()",
+			expected: "$()",
 		},
 		{
 			name:     "newline not expanded",


### PR DESCRIPTION
/kind bug
/kind api-change

#### What this PR does / why we need it:

It prevents the unneeded expansion of double dollars signs when they are not part of a complete variable reference.
https://github.com/kubernetes/kubernetes/issues/101137

#### Which issue(s) this PR fixes:

Fixes #101137

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
- Double dollar signs, when they are not part of an actual variable reference, will not be escaped anymore in a container's args, env and command.
```
