### PR TITLE
Adding stack-type to gce cloud config (to be used for dual stack in legacy-cloud-providers gce code)

### DIFF
--- a/cluster/gce/gci/configure-helper.sh
+++ b/cluster/gce/gci/configure-helper.sh
@@ -820,6 +820,12 @@ EOF
 network-project-id = ${NETWORK_PROJECT_ID}
 EOF
   fi
+  if [[ -n "${STACK_TYPE:-}" ]]; then
+    use_cloud_config="true"
+    cat <<EOF >>/etc/gce.conf
+stack-type = ${STACK_TYPE}
+EOF
+  fi
   if [[ -n "${NODE_NETWORK:-}" ]]; then
     use_cloud_config="true"
     cat <<EOF >>/etc/gce.conf


### PR DESCRIPTION
Adding stack-type to gce cloud config (to be used for dual stack in legacy-cloud-providers gce code)

#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
We need to pass STACK_TYPE to k8s to be able to populate IPV6 addresses when dual stack is enabled.

```release-note
NONE
```