### PR TITLE
Write ReplicaSet List and DeleteCollection test +2 endpoints

### DIFF
--- a/test/e2e/apps/replica_set.go
+++ b/test/e2e/apps/replica_set.go
@@ -509,7 +509,7 @@ func listRSDeleteCollection(f *framework.Framework) {
 	ns := f.Namespace.Name
 	c := f.ClientSet
 	rsClient := f.ClientSet.AppsV1().ReplicaSets(ns)
-	zero := int64(0)
+	one := int64(1)
 	rsName := "test-rs"
 	replicas := int32(3)
 	e2eValue := rand.String(5)
@@ -539,7 +539,7 @@ func listRSDeleteCollection(f *framework.Framework) {
 	framework.ExpectEqual(len(rsList.Items), 1, "filtered list wasn't found")
 
 	ginkgo.By("DeleteCollection of the ReplicaSets")
-	err = rsClient.DeleteCollection(context.TODO(), metav1.DeleteOptions{GracePeriodSeconds: &zero}, metav1.ListOptions{LabelSelector: "e2e=" + e2eValue})
+	err = rsClient.DeleteCollection(context.TODO(), metav1.DeleteOptions{GracePeriodSeconds: &one}, metav1.ListOptions{LabelSelector: "e2e=" + e2eValue})
 	framework.ExpectNoError(err, "failed to delete ReplicaSets")
 
 	ginkgo.By("After DeleteCollection verify that ReplicaSets have been deleted")


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it:**
This PR adds a test to test the following untested endpoints:
- listAppsV1ReplicaSetForAllNamespaces
- deleteAppsV1CollectionNamespacedReplicaSet

**Which issue(s) this PR fixes:**
Fixes #100546
**Testgrid Link:**
[Test](https://k8s-testgrid.appspot.com/sig-release-master-blocking#gce-cos-master-default&&width=5&include-filter-by-regex=delete.a.collection.of.ReplicaSets&graph-metrics=test-duration-minutes)


**Special notes for your reviewer:**
Adds +2 endpoint test coverage (good for conformance)

**Does this PR introduce a user-facing change?:**
```
NONE

```

**Release note:**
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:**
```
NONE

```

/sig testing
/sig architecture
/area conformance