### PR TITLE
Upgrade addon-manager baseimage to debian-base v1.0.1

### DIFF
--- a/cluster/addons/addon-manager/CHANGELOG.md
+++ b/cluster/addons/addon-manager/CHANGELOG.md
@@ -1,3 +1,6 @@
+### Version 9.1.5 (Mon April 19 2021 Spencer Peterson <spencerjp@google.com>)
+ - Update baseimage to debian-base:v1.0.1.
+
 ### Version 9.1.4 (Wed February 10 2021 Jordan Liggitt <liggitt@google.com>)
  - Update kubectl to v1.20.2.
  - Fix a bug in leader election (https://github.com/kubernetes/kubernetes/issues/98966)

--- a/cluster/addons/addon-manager/Makefile
+++ b/cluster/addons/addon-manager/Makefile
@@ -15,10 +15,10 @@
 IMAGE=gcr.io/k8s-staging-addon-manager/kube-addon-manager
 ARCH?=amd64
 TEMP_DIR:=$(shell mktemp -d)
-VERSION=v9.1.4
+VERSION=v9.1.5
 KUBECTL_VERSION?=v1.20.2
 
-BASEIMAGE=k8s.gcr.io/debian-base-$(ARCH):v1.0.0
+BASEIMAGE=k8s.gcr.io/debian-base-$(ARCH):v1.0.1
 
 SUDO=$(if $(filter 0,$(shell id -u)),,sudo)
 


### PR DESCRIPTION
The previous base image, debian-base:v1.0.0, is affected by
CVE-2017-14062. This change upgrades to the most recent Debian stretch
image from the following command:

```
$ gcloud container images list-tags k8s.gcr.io/debian-base-amd64
DIGEST        TAGS    TIMESTAMP
7e9f2f88b813  v1.0.1  2020-02-18T13:18:50
d7be39e143d4  v2.0.0  2019-11-01T13:14:18
5f25d97ece90  v1.0.0  2019-03-25T10:59:09
dddca919baec  1.0.0   2019-03-25T09:43:09
```

This marks kube-addon-manager version 9.1.5.

/kind bug

#### Does this PR introduce a user-facing change?

```release-note
NONE
```