### PR TITLE
Adds unit tests for pkg/kubelet/cm/cpumanager/topology

### DIFF
--- a/pkg/kubelet/cm/cpumanager/topology/topology_test.go
+++ b/pkg/kubelet/cm/cpumanager/topology/topology_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	cadvisorapi "github.com/google/cadvisor/info/v1"
+	"k8s.io/kubernetes/pkg/kubelet/cm/cpuset"
 )
 
 func Test_Discover(t *testing.T) {
@@ -200,6 +201,408 @@ func Test_Discover(t *testing.T) {
 			}
 			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("Discover() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCPUDetailsKeepOnly(t *testing.T) {
+
+	var details CPUDetails
+	details = map[int]CPUInfo{
+		0: {},
+		1: {},
+		2: {},
+	}
+
+	tests := []struct {
+		name string
+		cpus cpuset.CPUSet
+		want CPUDetails
+	}{{
+		name: "cpus is in CPUDetails.",
+		cpus: cpuset.NewCPUSet(0, 1),
+		want: map[int]CPUInfo{
+			0: {},
+			1: {},
+		},
+	}, {
+		name: "cpus is not in CPUDetails.",
+		cpus: cpuset.NewCPUSet(3),
+		want: CPUDetails{},
+	}}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := details.KeepOnly(tt.cpus)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("KeepOnly() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCPUDetailsNUMANodes(t *testing.T) {
+
+	tests := []struct {
+		name    string
+		details CPUDetails
+		want    cpuset.CPUSet
+	}{{
+		name: "Get CPUset of NUMANode IDs",
+		details: map[int]CPUInfo{
+			0: {NUMANodeID: 0},
+			1: {NUMANodeID: 0},
+			2: {NUMANodeID: 1},
+			3: {NUMANodeID: 1},
+		},
+		want: cpuset.NewCPUSet(0, 1),
+	}}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.details.NUMANodes()
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("NUMANodes() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCPUDetailsNUMANodesInSockets(t *testing.T) {
+
+	var details1 CPUDetails
+	details1 = map[int]CPUInfo{
+		0: {SocketID: 0, NUMANodeID: 0},
+		1: {SocketID: 1, NUMANodeID: 0},
+		2: {SocketID: 2, NUMANodeID: 1},
+		3: {SocketID: 3, NUMANodeID: 1},
+	}
+
+	// poorly designed mainboards
+	var details2 CPUDetails
+	details2 = map[int]CPUInfo{
+		0: {SocketID: 0, NUMANodeID: 0},
+		1: {SocketID: 0, NUMANodeID: 1},
+		2: {SocketID: 1, NUMANodeID: 2},
+		3: {SocketID: 1, NUMANodeID: 3},
+	}
+
+	tests := []struct {
+		name    string
+		details CPUDetails
+		ids     []int
+		want    cpuset.CPUSet
+	}{{
+		name:    "Socket IDs is in CPUDetails.",
+		details: details1,
+		ids:     []int{0, 1, 2},
+		want:    cpuset.NewCPUSet(0, 1),
+	}, {
+		name:    "Socket IDs is not in CPUDetails.",
+		details: details1,
+		ids:     []int{4},
+		want:    cpuset.NewCPUSet(),
+	}, {
+		name:    "Socket IDs is in CPUDetails. (poorly designed mainboards)",
+		details: details2,
+		ids:     []int{0},
+		want:    cpuset.NewCPUSet(0, 1),
+	}, {
+		name:    "Socket IDs is not in CPUDetails. (poorly designed mainboards)",
+		details: details2,
+		ids:     []int{3},
+		want:    cpuset.NewCPUSet(),
+	}}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.details.NUMANodesInSockets(tt.ids...)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("NUMANodesInSockets() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCPUDetailsSockets(t *testing.T) {
+
+	tests := []struct {
+		name    string
+		details CPUDetails
+		want    cpuset.CPUSet
+	}{{
+		name: "Get CPUset of Socket IDs",
+		details: map[int]CPUInfo{
+			0: {SocketID: 0},
+			1: {SocketID: 0},
+			2: {SocketID: 1},
+			3: {SocketID: 1},
+		},
+		want: cpuset.NewCPUSet(0, 1),
+	}}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.details.Sockets()
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("Sockets() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCPUDetailsCPUsInSockets(t *testing.T) {
+
+	var details CPUDetails
+	details = map[int]CPUInfo{
+		0: {SocketID: 0},
+		1: {SocketID: 0},
+		2: {SocketID: 1},
+		3: {SocketID: 2},
+	}
+
+	tests := []struct {
+		name string
+		ids  []int
+		want cpuset.CPUSet
+	}{{
+		name: "Socket IDs is in CPUDetails.",
+		ids:  []int{0, 1},
+		want: cpuset.NewCPUSet(0, 1, 2),
+	}, {
+		name: "Socket IDs is not in CPUDetails.",
+		ids:  []int{3},
+		want: cpuset.NewCPUSet(),
+	}}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := details.CPUsInSockets(tt.ids...)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("CPUsInSockets() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCPUDetailsSocketsInNUMANodes(t *testing.T) {
+
+	var details CPUDetails
+	details = map[int]CPUInfo{
+		0: {NUMANodeID: 0, SocketID: 0},
+		1: {NUMANodeID: 0, SocketID: 1},
+		2: {NUMANodeID: 1, SocketID: 2},
+		3: {NUMANodeID: 2, SocketID: 3},
+	}
+
+	tests := []struct {
+		name string
+		ids  []int
+		want cpuset.CPUSet
+	}{{
+		name: "NUMANodes IDs is in CPUDetails.",
+		ids:  []int{0, 1},
+		want: cpuset.NewCPUSet(0, 1, 2),
+	}, {
+		name: "NUMANodes IDs is not in CPUDetails.",
+		ids:  []int{3},
+		want: cpuset.NewCPUSet(),
+	}}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := details.SocketsInNUMANodes(tt.ids...)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("SocketsInNUMANodes() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCPUDetailsCores(t *testing.T) {
+
+	tests := []struct {
+		name    string
+		details CPUDetails
+		want    cpuset.CPUSet
+	}{{
+		name: "Get CPUset of Cores",
+		details: map[int]CPUInfo{
+			0: {CoreID: 0},
+			1: {CoreID: 0},
+			2: {CoreID: 1},
+			3: {CoreID: 1},
+		},
+		want: cpuset.NewCPUSet(0, 1),
+	}}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.details.Cores()
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("Cores() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCPUDetailsCoresInNUMANodes(t *testing.T) {
+
+	var details CPUDetails
+	details = map[int]CPUInfo{
+		0: {NUMANodeID: 0, CoreID: 0},
+		1: {NUMANodeID: 0, CoreID: 1},
+		2: {NUMANodeID: 1, CoreID: 2},
+		3: {NUMANodeID: 2, CoreID: 3},
+	}
+
+	tests := []struct {
+		name string
+		ids  []int
+		want cpuset.CPUSet
+	}{{
+		name: "NUMANodes IDs is in CPUDetails.",
+		ids:  []int{0, 1},
+		want: cpuset.NewCPUSet(0, 1, 2),
+	}, {
+		name: "NUMANodes IDs is not in CPUDetails.",
+		ids:  []int{3},
+		want: cpuset.NewCPUSet(),
+	}}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := details.CoresInNUMANodes(tt.ids...)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("CoresInNUMANodes() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCPUDetailsCoresInSockets(t *testing.T) {
+
+	var details CPUDetails
+	details = map[int]CPUInfo{
+		0: {SocketID: 0, CoreID: 0},
+		1: {SocketID: 0, CoreID: 1},
+		2: {SocketID: 1, CoreID: 2},
+		3: {SocketID: 2, CoreID: 3},
+	}
+
+	tests := []struct {
+		name string
+		ids  []int
+		want cpuset.CPUSet
+	}{{
+		name: "Socket IDs is in CPUDetails.",
+		ids:  []int{0, 1},
+		want: cpuset.NewCPUSet(0, 1, 2),
+	}, {
+		name: "Socket IDs is not in CPUDetails.",
+		ids:  []int{3},
+		want: cpuset.NewCPUSet(),
+	}}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := details.CoresInSockets(tt.ids...)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("CoresInSockets() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCPUDetailsCPUs(t *testing.T) {
+
+	tests := []struct {
+		name    string
+		details CPUDetails
+		want    cpuset.CPUSet
+	}{{
+		name: "Get CPUset of CPUs",
+		details: map[int]CPUInfo{
+			0: {},
+			1: {},
+		},
+		want: cpuset.NewCPUSet(0, 1),
+	}}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.details.CPUs()
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("CPUs() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCPUDetailsCPUsInNUMANodes(t *testing.T) {
+
+	var details CPUDetails
+	details = map[int]CPUInfo{
+		0: {NUMANodeID: 0},
+		1: {NUMANodeID: 0},
+		2: {NUMANodeID: 1},
+		3: {NUMANodeID: 2},
+	}
+
+	tests := []struct {
+		name string
+		ids  []int
+		want cpuset.CPUSet
+	}{{
+		name: "NUMANode IDs is in CPUDetails.",
+		ids:  []int{0, 1},
+		want: cpuset.NewCPUSet(0, 1, 2),
+	}, {
+		name: "NUMANode IDs is not in CPUDetails.",
+		ids:  []int{3},
+		want: cpuset.NewCPUSet(),
+	}}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := details.CPUsInNUMANodes(tt.ids...)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("CPUsInNUMANodes() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCPUDetailsCPUsInCores(t *testing.T) {
+
+	var details CPUDetails
+	details = map[int]CPUInfo{
+		0: {CoreID: 0},
+		1: {CoreID: 0},
+		2: {CoreID: 1},
+		3: {CoreID: 2},
+	}
+
+	tests := []struct {
+		name string
+		ids  []int
+		want cpuset.CPUSet
+	}{{
+		name: "Core IDs is in CPUDetails.",
+		ids:  []int{0, 1},
+		want: cpuset.NewCPUSet(0, 1, 2),
+	}, {
+		name: "Core IDs is not in CPUDetails.",
+		ids:  []int{3},
+		want: cpuset.NewCPUSet(),
+	}}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := details.CPUsInCores(tt.ids...)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("CPUsInCores() = %v, want %v", got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
This PR adds unit tests for pkg/kubelet/cm/cpumanager/topology/topology.go.
The test coverage of topology.go is 23.1%:
```
$ go test -cover topology.go topology_test.go
ok      command-line-arguments  0.002s  coverage: 23.1% of statements
```

This PR is improve test coverage as follows: 
```
$ go test -cover topology.go topology_test.go
ok      command-line-arguments  0.002s  coverage: 92.3% of statements
```

#### Does this PR introduce a user-facing change?
```release-note
NONE
```