### PR TITLE
Makes kube-proxy flags take precedence on proxy config

### DIFF
--- a/cmd/kube-proxy/app/server.go
+++ b/cmd/kube-proxy/app/server.go
@@ -236,7 +236,6 @@ func (o *Options) Complete(fs *pflag.FlagSet) error {
 			return fmt.Errorf("Kube-proxy flags conflict: %v", conflictFields)
 		}
 
-		// make flags take precedence
 		mergo.Merge(c, o.config)
 		o.config = c
 

--- a/cmd/kube-proxy/app/server.go
+++ b/cmd/kube-proxy/app/server.go
@@ -473,8 +473,7 @@ func (o *Options) detectConfigConflict(config interface{}, fs *pflag.FlagSet) []
 			continue
 		}
 		if tag, set := fieldType.Tag.Lookup("flag"); set {
-			flag := fs.Lookup(tag)
-			if flag != nil && flag.Changed {
+			if fs.Changed(tag) {
 				conflictFields = append(conflictFields, tag)
 			}
 		} else if field.Kind() == reflect.Struct {

--- a/cmd/kube-proxy/app/server.go
+++ b/cmd/kube-proxy/app/server.go
@@ -28,6 +28,7 @@ import (
 	"time"
 
 	"github.com/fsnotify/fsnotify"
+	"github.com/imdario/mergo"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 
@@ -228,6 +229,8 @@ func (o *Options) Complete() error {
 		if err != nil {
 			return err
 		}
+		// make flags take precedence
+		mergo.Merge(c, o.config, mergo.WithOverride)
 		o.config = c
 
 		if err := o.initWatcher(); err != nil {

--- a/cmd/kube-proxy/app/server_test.go
+++ b/cmd/kube-proxy/app/server_test.go
@@ -656,7 +656,6 @@ clusterCIDR: "%s"`, value))
 
 	testCases := []struct {
 		name        string
-		proxyServer proxyRun
 		flagValue   string
 		configValue string
 		expectValue string
@@ -686,6 +685,13 @@ clusterCIDR: "%s"`, value))
 		{
 			name:        "detect flag and config conflict",
 			flagValue:   "2.2.0.0/16",
+			configValue: "1.1.0.0/16",
+			expectValue: "",
+			expectError: fmt.Errorf("Kube-proxy flags conflict: [cluster-cidr]"),
+		},
+		{
+			name:        "detect flag and config conflict with same value",
+			flagValue:   "1.1.0.0/16",
 			configValue: "1.1.0.0/16",
 			expectValue: "",
 			expectError: fmt.Errorf("Kube-proxy flags conflict: [cluster-cidr]"),
@@ -747,7 +753,6 @@ kind: KubeProxyConfiguration
 
 	testCases := []struct {
 		name        string
-		proxyServer proxyRun
 		args        []string
 		config      string
 		expectError error

--- a/go.mod
+++ b/go.mod
@@ -57,6 +57,7 @@ require (
 	github.com/hashicorp/golang-lru v0.5.1
 	github.com/heketi/heketi v10.2.0+incompatible
 	github.com/heketi/tests v0.0.0-20151005000721-f3775cbcefd6 // indirect
+	github.com/imdario/mergo v0.3.5
 	github.com/ishidawataru/sctp v0.0.0-20190723014705-7c296d48a2b5
 	github.com/json-iterator/go v1.1.10
 	github.com/libopenstorage/openstorage v1.0.0

--- a/pkg/proxy/apis/config/types.go
+++ b/pkg/proxy/apis/config/types.go
@@ -30,15 +30,15 @@ import (
 type KubeProxyIPTablesConfiguration struct {
 	// masqueradeBit is the bit of the iptables fwmark space to use for SNAT if using
 	// the pure iptables proxy mode. Values must be within the range [0, 31].
-	MasqueradeBit *int32
+	MasqueradeBit *int32 `flag:"iptables-masquerade-bit"`
 	// masqueradeAll tells kube-proxy to SNAT everything if using the pure iptables proxy mode.
-	MasqueradeAll bool
+	MasqueradeAll bool `flag:"masquerade-all"`
 	// syncPeriod is the period that iptables rules are refreshed (e.g. '5s', '1m',
 	// '2h22m').  Must be greater than 0.
-	SyncPeriod metav1.Duration
+	SyncPeriod metav1.Duration `flag:"iptables-sync-period"`
 	// minSyncPeriod is the minimum period that iptables rules are refreshed (e.g. '5s', '1m',
 	// '2h22m').
-	MinSyncPeriod metav1.Duration
+	MinSyncPeriod metav1.Duration `flag:"iptables-min-sync-period"`
 }
 
 // KubeProxyIPVSConfiguration contains ipvs-related configuration
@@ -46,27 +46,27 @@ type KubeProxyIPTablesConfiguration struct {
 type KubeProxyIPVSConfiguration struct {
 	// syncPeriod is the period that ipvs rules are refreshed (e.g. '5s', '1m',
 	// '2h22m').  Must be greater than 0.
-	SyncPeriod metav1.Duration
+	SyncPeriod metav1.Duration `flag:"ipvs-sync-period"`
 	// minSyncPeriod is the minimum period that ipvs rules are refreshed (e.g. '5s', '1m',
 	// '2h22m').
-	MinSyncPeriod metav1.Duration
+	MinSyncPeriod metav1.Duration `flag:"ipvs-min-sync-period"`
 	// ipvs scheduler
-	Scheduler string
+	Scheduler string `flag:"ipvs-scheduler"`
 	// excludeCIDRs is a list of CIDR's which the ipvs proxier should not touch
 	// when cleaning up ipvs services.
-	ExcludeCIDRs []string
+	ExcludeCIDRs []string `flag:"ipvs-exclude-cidrs"`
 	// strict ARP configure arp_ignore and arp_announce to avoid answering ARP queries
 	// from kube-ipvs0 interface
-	StrictARP bool
+	StrictARP bool `flag:"ipvs-strict-arp"`
 	// tcpTimeout is the timeout value used for idle IPVS TCP sessions.
 	// The default value is 0, which preserves the current timeout value on the system.
-	TCPTimeout metav1.Duration
+	TCPTimeout metav1.Duration `flag:"ipvs-tcp-timeout"`
 	// tcpFinTimeout is the timeout value used for IPVS TCP sessions after receiving a FIN.
 	// The default value is 0, which preserves the current timeout value on the system.
-	TCPFinTimeout metav1.Duration
+	TCPFinTimeout metav1.Duration `flag:"ipvs-tcpfin-timeout"`
 	// udpTimeout is the timeout value used for IPVS UDP packets.
 	// The default value is 0, which preserves the current timeout value on the system.
-	UDPTimeout metav1.Duration
+	UDPTimeout metav1.Duration `flag:"ipvs-udp-timeout"`
 }
 
 // KubeProxyConntrackConfiguration contains conntrack settings for
@@ -74,17 +74,17 @@ type KubeProxyIPVSConfiguration struct {
 type KubeProxyConntrackConfiguration struct {
 	// maxPerCore is the maximum number of NAT connections to track
 	// per CPU core (0 to leave the limit as-is and ignore min).
-	MaxPerCore *int32
+	MaxPerCore *int32 `flag:"conntrack-max-per-core"`
 	// min is the minimum value of connect-tracking records to allocate,
 	// regardless of maxPerCore (set maxPerCore=0 to leave the limit as-is).
-	Min *int32
+	Min *int32 `flag:"conntrack-min"`
 	// tcpEstablishedTimeout is how long an idle TCP connection will be kept open
 	// (e.g. '2s').  Must be greater than 0 to set.
-	TCPEstablishedTimeout *metav1.Duration
+	TCPEstablishedTimeout *metav1.Duration `flag:"conntrack-tcp-timeout-established"`
 	// tcpCloseWaitTimeout is how long an idle conntrack entry
 	// in CLOSE_WAIT state will remain in the conntrack
 	// table. (e.g. '60s'). Must be greater than 0 to set.
-	TCPCloseWaitTimeout *metav1.Duration
+	TCPCloseWaitTimeout *metav1.Duration `flag:"conntrack-tcp-timeout-close-wait"`
 }
 
 // KubeProxyWinkernelConfiguration contains Windows/HNS settings for
@@ -109,26 +109,26 @@ type KubeProxyConfiguration struct {
 	metav1.TypeMeta
 
 	// featureGates is a map of feature names to bools that enable or disable alpha/experimental features.
-	FeatureGates map[string]bool
+	FeatureGates map[string]bool `flag:"feature-gates"`
 
 	// bindAddress is the IP address for the proxy server to serve on (set to 0.0.0.0
 	// for all interfaces)
-	BindAddress string
+	BindAddress string `flag:"bind-address"`
 	// healthzBindAddress is the IP address and port for the health check server to serve on,
 	// defaulting to 0.0.0.0:10256
-	HealthzBindAddress string
+	HealthzBindAddress string `flag:"healthz-bind-address"`
 	// metricsBindAddress is the IP address and port for the metrics server to serve on,
 	// defaulting to 127.0.0.1:10249 (set to 0.0.0.0 for all interfaces)
-	MetricsBindAddress string
+	MetricsBindAddress string `flag:"metrics-bind-address"`
 	// BindAddressHardFail, if true, kube-proxy will treat failure to bind to a port as fatal and exit
-	BindAddressHardFail bool
+	BindAddressHardFail bool `flag:"bind-address-hard-fail"`
 	// enableProfiling enables profiling via web interface on /debug/pprof handler.
 	// Profiling handlers will be handled by metrics server.
-	EnableProfiling bool
+	EnableProfiling bool `flag:"profiling"`
 	// clusterCIDR is the CIDR range of the pods in the cluster. It is used to
 	// bridge traffic coming from outside of the cluster. If not provided,
 	// no off-cluster bridging will be performed.
-	ClusterCIDR string
+	ClusterCIDR string `flag:"cluster-cidr"`
 	// hostnameOverride, if non-empty, will be used as the identity instead of the actual hostname.
 	HostnameOverride string
 	// clientConnection specifies the kubeconfig file and client connection settings for the proxy
@@ -140,20 +140,20 @@ type KubeProxyConfiguration struct {
 	IPVS KubeProxyIPVSConfiguration
 	// oomScoreAdj is the oom-score-adj value for kube-proxy process. Values must be within
 	// the range [-1000, 1000]
-	OOMScoreAdj *int32
+	OOMScoreAdj *int32 `flag:"oom-score-adj"`
 	// mode specifies which proxy mode to use.
-	Mode ProxyMode
+	Mode ProxyMode `flag:"proxy-mode"`
 	// portRange is the range of host ports (beginPort-endPort, inclusive) that may be consumed
 	// in order to proxy service traffic. If unspecified (0-0) then ports will be randomly chosen.
-	PortRange string
+	PortRange string `flag:"proxy-port-range"`
 	// udpIdleTimeout is how long an idle UDP connection will be kept open (e.g. '250ms', '2s').
 	// Must be greater than 0. Only applicable for proxyMode=userspace.
-	UDPIdleTimeout metav1.Duration
+	UDPIdleTimeout metav1.Duration `flag:"udp-timeout"`
 	// conntrack contains conntrack-related configuration options.
 	Conntrack KubeProxyConntrackConfiguration
 	// configSyncPeriod is how often configuration from the apiserver is refreshed. Must be greater
 	// than 0.
-	ConfigSyncPeriod metav1.Duration
+	ConfigSyncPeriod metav1.Duration `flag:"config-sync-period"`
 	// nodePortAddresses is the --nodeport-addresses value for kube-proxy process. Values must be valid
 	// IP blocks. These values are as a parameter to select the interfaces where nodeport works.
 	// In case someone would like to expose a service on localhost for local visit and some other interfaces for
@@ -161,13 +161,13 @@ type KubeProxyConfiguration struct {
 	// If set it to "127.0.0.0/8", kube-proxy will only select the loopback interface for NodePort.
 	// If set it to a non-zero IP block, kube-proxy will filter that down to just the IPs that applied to the node.
 	// An empty string slice is meant to select all network interfaces.
-	NodePortAddresses []string
+	NodePortAddresses []string `flag:"nodeport-addresses"`
 	// winkernel contains winkernel-related configuration options.
 	Winkernel KubeProxyWinkernelConfiguration
 	// ShowHiddenMetricsForVersion is the version for which you want to show hidden metrics.
-	ShowHiddenMetricsForVersion string
+	ShowHiddenMetricsForVersion string `flag:"show-hidden-metrics-for-version"`
 	// DetectLocalMode determines mode to use for detecting local traffic, defaults to LocalModeClusterCIDR
-	DetectLocalMode LocalMode
+	DetectLocalMode LocalMode `flag:"detect-local-mode"`
 }
 
 // ProxyMode represents modes used by the Kubernetes proxy server. Currently, three modes of proxy are available in

--- a/staging/src/k8s.io/component-base/config/types.go
+++ b/staging/src/k8s.io/component-base/config/types.go
@@ -23,17 +23,17 @@ import (
 // ClientConnectionConfiguration contains details for constructing a client.
 type ClientConnectionConfiguration struct {
 	// kubeconfig is the path to a KubeConfig file.
-	Kubeconfig string
+	Kubeconfig string `flag:"kubeconfig"`
 	// acceptContentTypes defines the Accept header sent by clients when connecting to a server, overriding the
 	// default value of 'application/json'. This field will control all connections to the server used by a particular
 	// client.
 	AcceptContentTypes string
 	// contentType is the content type used when sending data to the server from this client.
-	ContentType string
+	ContentType string `flag:"kube-api-content-type"`
 	// qps controls the number of queries per second allowed for this connection.
-	QPS float32
+	QPS float32 `flag:"kube-api-qps"`
 	// burst allows extra queries to accumulate when a client is exceeding its rate.
-	Burst int32
+	Burst int32 `flag:"kube-api-burst"`
 }
 
 // LeaderElectionConfiguration defines the configuration of leader election

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -679,6 +679,7 @@ github.com/hpcloud/tail/watch
 github.com/hpcloud/tail/winfile
 # github.com/ianlancetaylor/demangle => github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6
 # github.com/imdario/mergo v0.3.5 => github.com/imdario/mergo v0.3.5
+## explicit
 github.com/imdario/mergo
 # github.com/imdario/mergo => github.com/imdario/mergo v0.3.5
 # github.com/inconshreveable/mousetrap v1.0.0 => github.com/inconshreveable/mousetrap v1.0.0


### PR DESCRIPTION
Signed-off-by: Hanlin Shi <shihanlin9@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Kube-proxy flags are silently ignored when `--config` is set. This PR makes flags take precedence on the proxy component configuration.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #98302 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Make kube-proxy flags take precedence on kube-proxy component configuration.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
