### PR TITLE
Automated cherry pick of #101021 Switch fluentd-gcp-scaler policy to non deprecated api #101238 Add required fields to fluentd-gcp-scaler-policy CRD

### DIFF
--- a/cluster/addons/fluentd-gcp/scaler-policy.yaml
+++ b/cluster/addons/fluentd-gcp/scaler-policy.yaml
@@ -8,6 +8,12 @@ spec:
   group: scalingpolicy.kope.io
   versions:
     - name: v1alpha1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          x-kubernetes-preserve-unknown-fields: true
   names:
     kind: ScalingPolicy
     plural: scalingpolicies

--- a/cluster/addons/fluentd-gcp/scaler-policy.yaml
+++ b/cluster/addons/fluentd-gcp/scaler-policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: scalingpolicies.scalingpolicy.kope.io
@@ -6,7 +6,8 @@ metadata:
     addonmanager.kubernetes.io/mode: Reconcile
 spec:
   group: scalingpolicy.kope.io
-  version: v1alpha1
+  versions:
+    - name: v1alpha1
   names:
     kind: ScalingPolicy
     plural: scalingpolicies


### PR DESCRIPTION
Cherry pick of #101021 #100660 on release-1.21.

#101021: Switch fluentd-gcp-scaler policy to non deprecated api
#101238: Add required fields to fluentd-gcp-scaler-policy CRD

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.