### PR TITLE
Fail fast when image is specified without tag

### DIFF
--- a/test/e2e/testing-manifests/storage-csi/mock/csi-mock-proxy.yaml
+++ b/test/e2e/testing-manifests/storage-csi/mock/csi-mock-proxy.yaml
@@ -73,7 +73,7 @@ spec:
         # test for directories or create them. It needs additional privileges
         # for that.
         - name: busybox
-          image: k8s.gcr.io/busybox
+          image: k8s.gcr.io/e2e-test-images/busybox:1.29-1
           securityContext:
             privileged: true
           command:

--- a/test/utils/image/manifest.go
+++ b/test/utils/image/manifest.go
@@ -387,6 +387,8 @@ func ReplaceRegistryInImageURL(imageURL string) (string, error) {
 	switch registryAndUser {
 	case "gcr.io/kubernetes-e2e-test-images":
 		registryAndUser = e2eRegistry
+	case "k8s.gcr.io/e2e-test-images":
+		registryAndUser = promoterE2eRegistry
 	case "k8s.gcr.io":
 		registryAndUser = gcRegistry
 	case "k8s.gcr.io/sig-storage":

--- a/test/utils/image/manifest.go
+++ b/test/utils/image/manifest.go
@@ -373,6 +373,9 @@ func ReplaceRegistryInImageURL(imageURL string) (string, error) {
 			}
 		}
 		last := strings.SplitN(parts[countParts-1], ":", 2)
+		if len(last) == 1 {
+			return "", fmt.Errorf("image %q is required to be in an image:tag format", imageURL)
+		}
 		config := getRepositoryMappedConfig(index, Config{
 			registry: parts[0],
 			name:     strings.Join([]string{strings.Join(parts[1:countParts-1], "/"), last[0]}, "/"),


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
~~Currently when replacing images we assume an image is in the form `image:tag` but there are cases where this is not true. This PR defaults tag to `:latest` when not specified.~~
This PR changes image replace code such that it requires `image:tag` format. 

#### Special notes for your reviewer:
/assign @smarterclayton 

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
