### PR TITLE
Promote setHostnameAsFQDN feature to GA

### DIFF
--- a/pkg/api/pod/util.go
+++ b/pkg/api/pod/util.go
@@ -584,11 +584,6 @@ func dropDisabledFields(
 		podSpec.PreemptionPolicy = nil
 	}
 
-	if !utilfeature.DefaultFeatureGate.Enabled(features.SetHostnameAsFQDN) && !setHostnameAsFQDNInUse(oldPodSpec) {
-		// Set SetHostnameAsFQDN to nil only if feature is disabled and it is not used
-		podSpec.SetHostnameAsFQDN = nil
-	}
-
 	dropDisabledPodAffinityTermFields(podSpec, oldPodSpec)
 }
 
@@ -881,14 +876,6 @@ func multiplePodIPsInUse(podStatus *api.PodStatus) bool {
 		return true
 	}
 	return false
-}
-
-// setHostnameAsFQDNInUse returns true if any pod's spec defines setHostnameAsFQDN field.
-func setHostnameAsFQDNInUse(podSpec *api.PodSpec) bool {
-	if podSpec == nil || podSpec.SetHostnameAsFQDN == nil {
-		return false
-	}
-	return *podSpec.SetHostnameAsFQDN
 }
 
 // SeccompAnnotationForField takes a pod seccomp profile field and returns the

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -581,6 +581,7 @@ const (
 	// owner: @javidiaz
 	// alpha: v1.19
 	// beta: v1.20
+	// GA: v1.22
 	//
 	// Allow setting the Fully Qualified Domain Name (FQDN) in the hostname of a Pod. If a Pod does not
 	// have FQDN, this feature has no effect.
@@ -844,7 +845,7 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
 	ExternalPolicyForExternalIP:                    {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.22
 	AnyVolumeDataSource:                            {Default: false, PreRelease: featuregate.Alpha},
 	DefaultPodTopologySpread:                       {Default: true, PreRelease: featuregate.Beta},
-	SetHostnameAsFQDN:                              {Default: true, PreRelease: featuregate.Beta},
+	SetHostnameAsFQDN:                              {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, //remove in 1.24
 	WinOverlay:                                     {Default: true, PreRelease: featuregate.Beta},
 	WinDSR:                                         {Default: false, PreRelease: featuregate.Alpha},
 	DisableAcceleratorUsageMetrics:                 {Default: true, PreRelease: featuregate.Beta},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
Promote SetHostnameAsFQDN feature to GA. This means we remove the feature gate.

/kind feature

**What this PR does / why we need it**:
This PR enables the feature SetHostnameAsFQDN by default and changes defines it as GA for v1.22. The corresponding KEP issue is https://github.com/kubernetes/enhancements/pull/2641

**Which issue(s) this PR fixes**:
Related to https://github.com/kubernetes/enhancements/issues/1797

**Does this PR introduce a user-facing change?**:
NONE
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
SetHostnameAsFQDN has been graduated to GA, which means feature cannot be disabled using a feature gate.
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

-[KEP]: https://github.com/kubernetes/enhancements/issues/1797

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```