### PR TITLE
Fix kubectl flake: Simple pod should return command exit codes

### DIFF
--- a/test/e2e/kubectl/kubectl.go
+++ b/test/e2e/kubectl/kubectl.go
@@ -109,6 +109,9 @@ var (
 	httpdImage    = imageutils.GetE2EImage(imageutils.Httpd)
 	busyboxImage  = imageutils.GetE2EImage(imageutils.BusyBox)
 	agnhostImage  = imageutils.GetE2EImage(imageutils.Agnhost)
+
+	// If this suite still flakes due to timeouts we should change this to framework.PodStartTimeout
+	podRunningTimeoutArg = fmt.Sprintf("--pod-running-timeout=%s", framework.PodStartShortTimeout.String())
 )
 
 var proxyRegexp = regexp.MustCompile("Starting to serve on 127.0.0.1:([0-9]+)")
@@ -387,7 +390,7 @@ var _ = SIGDescribe("Kubectl client", func() {
 
 		ginkgo.It("should support exec", func() {
 			ginkgo.By("executing a command in the container")
-			execOutput := framework.RunKubectlOrDie(ns, "exec", simplePodName, "echo", "running", "in", "container")
+			execOutput := framework.RunKubectlOrDie(ns, "exec", podRunningTimeoutArg, simplePodName, "--", "echo", "running", "in", "container")
 			if e, a := "running in container", strings.TrimSpace(execOutput); e != a {
 				framework.Failf("Unexpected kubectl exec output. Wanted %q, got %q", e, a)
 			}
@@ -397,11 +400,11 @@ var _ = SIGDescribe("Kubectl client", func() {
 			for i := 0; i < len(veryLongData); i++ {
 				veryLongData[i] = 'a'
 			}
-			execOutput = framework.RunKubectlOrDie(ns, "exec", simplePodName, "echo", string(veryLongData))
+			execOutput = framework.RunKubectlOrDie(ns, "exec", podRunningTimeoutArg, simplePodName, "--", "echo", string(veryLongData))
 			framework.ExpectEqual(string(veryLongData), strings.TrimSpace(execOutput), "Unexpected kubectl exec output")
 
 			ginkgo.By("executing a command in the container with noninteractive stdin")
-			execOutput = framework.NewKubectlCommand(ns, "exec", "-i", simplePodName, "cat").
+			execOutput = framework.NewKubectlCommand(ns, "exec", "-i", podRunningTimeoutArg, simplePodName, "--", "cat").
 				WithStdinData("abcd1234").
 				ExecOrDie(ns)
 			if e, a := "abcd1234", execOutput; e != a {
@@ -417,7 +420,7 @@ var _ = SIGDescribe("Kubectl client", func() {
 			defer closer.Close()
 
 			ginkgo.By("executing a command in the container with pseudo-interactive stdin")
-			execOutput = framework.NewKubectlCommand(ns, "exec", "-i", simplePodName, "sh").
+			execOutput = framework.NewKubectlCommand(ns, "exec", "-i", podRunningTimeoutArg, simplePodName, "--", "sh").
 				WithStdinReader(r).
 				ExecOrDie(ns)
 			if e, a := "hi", strings.TrimSpace(execOutput); e != a {
@@ -427,7 +430,7 @@ var _ = SIGDescribe("Kubectl client", func() {
 
 		ginkgo.It("should support exec using resource/name", func() {
 			ginkgo.By("executing a command in the container")
-			execOutput := framework.RunKubectlOrDie(ns, "exec", simplePodResourceName, "echo", "running", "in", "container")
+			execOutput := framework.RunKubectlOrDie(ns, "exec", podRunningTimeoutArg, simplePodResourceName, "--", "echo", "running", "in", "container")
 			if e, a := "running in container", strings.TrimSpace(execOutput); e != a {
 				framework.Failf("Unexpected kubectl exec output. Wanted %q, got %q", e, a)
 			}
@@ -447,7 +450,7 @@ var _ = SIGDescribe("Kubectl client", func() {
 			for _, proxyVar := range []string{"https_proxy", "HTTPS_PROXY"} {
 				proxyLogs.Reset()
 				ginkgo.By("Running kubectl via an HTTP proxy using " + proxyVar)
-				output := framework.NewKubectlCommand(ns, fmt.Sprintf("--namespace=%s", ns), "exec", "httpd", "echo", "running", "in", "container").
+				output := framework.NewKubectlCommand(ns, "exec", podRunningTimeoutArg, "httpd", "--", "echo", "running", "in", "container").
 					WithEnv(append(os.Environ(), fmt.Sprintf("%s=%s", proxyVar, proxyAddr))).
 					ExecOrDie(ns)
 
@@ -482,8 +485,8 @@ var _ = SIGDescribe("Kubectl client", func() {
 			host := fmt.Sprintf("--server=http://127.0.0.1:%d", port)
 			ginkgo.By("Running kubectl via kubectl proxy using " + host)
 			output := framework.NewKubectlCommand(
-				ns, host, fmt.Sprintf("--namespace=%s", ns),
-				"exec", "httpd", "echo", "running", "in", "container",
+				ns, host,
+				"exec", podRunningTimeoutArg, "httpd", "--", "echo", "running", "in", "container",
 			).ExecOrDie(ns)
 
 			// Verify we got the normal output captured by the exec server
@@ -493,53 +496,60 @@ var _ = SIGDescribe("Kubectl client", func() {
 			}
 		})
 
-		ginkgo.It("should return command exit codes", func() {
-			ginkgo.By("execing into a container with a successful command")
-			_, err := framework.NewKubectlCommand(ns, "exec", "httpd", "--", "/bin/sh", "-c", "exit 0").Exec()
-			framework.ExpectNoError(err)
+		ginkgo.Context("should return command exit codes", func() {
+			ginkgo.It("execing into a container with a successful command", func() {
+				_, err := framework.NewKubectlCommand(ns, "exec", "httpd", podRunningTimeoutArg, "--", "/bin/sh", "-c", "exit 0").Exec()
+				framework.ExpectNoError(err)
+			})
 
-			ginkgo.By("execing into a container with a failing command")
-			_, err = framework.NewKubectlCommand(ns, "exec", "httpd", "--", "/bin/sh", "-c", "exit 42").Exec()
-			ee, ok := err.(uexec.ExitError)
-			framework.ExpectEqual(ok, true)
-			framework.ExpectEqual(ee.ExitStatus(), 42)
+			ginkgo.It("execing into a container with a failing command", func() {
+				_, err := framework.NewKubectlCommand(ns, "exec", "httpd", podRunningTimeoutArg, "--", "/bin/sh", "-c", "exit 42").Exec()
+				ee, ok := err.(uexec.ExitError)
+				framework.ExpectEqual(ok, true)
+				framework.ExpectEqual(ee.ExitStatus(), 42)
+			})
 
-			ginkgo.By("running a successful command")
-			_, err = framework.NewKubectlCommand(ns, "run", "-i", "--image="+busyboxImage, "--restart=Never", "success", "--", "/bin/sh", "-c", "exit 0").Exec()
-			framework.ExpectNoError(err)
+			ginkgo.It("running a successful command", func() {
+				_, err := framework.NewKubectlCommand(ns, "run", "-i", "--image="+busyboxImage, "--restart=Never", podRunningTimeoutArg, "success", "--", "/bin/sh", "-c", "exit 0").Exec()
+				framework.ExpectNoError(err)
+			})
 
-			ginkgo.By("running a failing command")
-			_, err = framework.NewKubectlCommand(ns, "run", "-i", "--image="+busyboxImage, "--restart=Never", "failure-1", "--", "/bin/sh", "-c", "exit 42").Exec()
-			ee, ok = err.(uexec.ExitError)
-			framework.ExpectEqual(ok, true)
-			framework.ExpectEqual(ee.ExitStatus(), 42)
+			ginkgo.It("running a failing command", func() {
+				_, err := framework.NewKubectlCommand(ns, "run", "-i", "--image="+busyboxImage, "--restart=Never", podRunningTimeoutArg, "failure-1", "--", "/bin/sh", "-c", "exit 42").Exec()
+				ee, ok := err.(uexec.ExitError)
+				framework.ExpectEqual(ok, true)
+				framework.ExpectEqual(ee.ExitStatus(), 42)
+			})
 
-			ginkgo.By("running a failing command without --restart=Never")
-			_, err = framework.NewKubectlCommand(ns, "run", "-i", "--image="+busyboxImage, "--restart=OnFailure", "failure-2", "--", "/bin/sh", "-c", "cat && exit 42").
-				WithStdinData("abcd1234").
-				Exec()
-			ee, ok = err.(uexec.ExitError)
-			framework.ExpectEqual(ok, true)
-			if !strings.Contains(ee.String(), "timed out") {
-				framework.Failf("Missing expected 'timed out' error, got: %#v", ee)
-			}
+			ginkgo.It("[Slow] running a failing command without --restart=Never", func() {
+				_, err := framework.NewKubectlCommand(ns, "run", "-i", "--image="+busyboxImage, "--restart=OnFailure", podRunningTimeoutArg, "failure-2", "--", "/bin/sh", "-c", "cat && exit 42").
+					WithStdinData("abcd1234").
+					Exec()
+				ee, ok := err.(uexec.ExitError)
+				framework.ExpectEqual(ok, true)
+				if !strings.Contains(ee.String(), "timed out") {
+					framework.Failf("Missing expected 'timed out' error, got: %#v", ee)
+				}
+			})
 
-			ginkgo.By("running a failing command without --restart=Never, but with --rm")
-			_, err = framework.NewKubectlCommand(ns, "run", "-i", "--image="+busyboxImage, "--restart=OnFailure", "--rm", "failure-3", "--", "/bin/sh", "-c", "cat && exit 42").
-				WithStdinData("abcd1234").
-				Exec()
-			ee, ok = err.(uexec.ExitError)
-			framework.ExpectEqual(ok, true)
-			if !strings.Contains(ee.String(), "timed out") {
-				framework.Failf("Missing expected 'timed out' error, got: %#v", ee)
-			}
-			e2epod.WaitForPodToDisappear(f.ClientSet, ns, "failure-3", labels.Everything(), 2*time.Second, wait.ForeverTestTimeout)
+			ginkgo.It("[Slow] running a failing command without --restart=Never, but with --rm", func() {
+				_, err := framework.NewKubectlCommand(ns, "run", "-i", "--image="+busyboxImage, "--restart=OnFailure", "--rm", podRunningTimeoutArg, "failure-3", "--", "/bin/sh", "-c", "cat && exit 42").
+					WithStdinData("abcd1234").
+					Exec()
+				ee, ok := err.(uexec.ExitError)
+				framework.ExpectEqual(ok, true)
+				if !strings.Contains(ee.String(), "timed out") {
+					framework.Failf("Missing expected 'timed out' error, got: %#v", ee)
+				}
+				e2epod.WaitForPodToDisappear(f.ClientSet, ns, "failure-3", labels.Everything(), 2*time.Second, wait.ForeverTestTimeout)
+			})
 
-			ginkgo.By("running a failing command with --leave-stdin-open")
-			_, err = framework.NewKubectlCommand(ns, "run", "-i", "--image="+busyboxImage, "--restart=Never", "failure-4", "--leave-stdin-open", "--", "/bin/sh", "-c", "exit 42").
-				WithStdinData("abcd1234").
-				Exec()
-			framework.ExpectNoError(err)
+			ginkgo.It("[Slow] running a failing command with --leave-stdin-open", func() {
+				_, err := framework.NewKubectlCommand(ns, "run", "-i", "--image="+busyboxImage, "--restart=Never", podRunningTimeoutArg, "failure-4", "--leave-stdin-open", "--", "/bin/sh", "-c", "exit 42").
+					WithStdinData("abcd1234").
+					Exec()
+				framework.ExpectNoError(err)
+			})
 		})
 
 		ginkgo.It("should support inline execution and attach", func() {
@@ -556,7 +566,7 @@ var _ = SIGDescribe("Kubectl client", func() {
 
 			ginkgo.By("executing a command with run and attach with stdin")
 			// We wait for a non-empty line so we know kubectl has attached
-			framework.NewKubectlCommand(ns, "run", "run-test", "--image="+busyboxImage, "--restart=OnFailure", "--attach=true", "--stdin", "--", "sh", "-c", "echo -n read: && cat && echo 'stdin closed'").
+			framework.NewKubectlCommand(ns, "run", "run-test", "--image="+busyboxImage, "--restart=OnFailure", podRunningTimeoutArg, "--attach=true", "--stdin", "--", "sh", "-c", "echo -n read: && cat && echo 'stdin closed'").
 				WithStdinData("value\nabcd1234").
 				ExecOrDie(ns)
 
@@ -573,7 +583,7 @@ var _ = SIGDescribe("Kubectl client", func() {
 			// "stdin closed", but hasn't exited yet.
 			// We wait 10 seconds before printing to give time to kubectl to attach
 			// to the container, this does not solve the race though.
-			framework.NewKubectlCommand(ns, "run", "run-test-2", "--image="+busyboxImage, "--restart=OnFailure", "--attach=true", "--leave-stdin-open=true", "--", "sh", "-c", "cat && echo 'stdin closed'").
+			framework.NewKubectlCommand(ns, "run", "run-test-2", "--image="+busyboxImage, "--restart=OnFailure", podRunningTimeoutArg, "--attach=true", "--leave-stdin-open=true", "--", "sh", "-c", "cat && echo 'stdin closed'").
 				WithStdinData("abcd1234").
 				ExecOrDie(ns)
 
@@ -584,7 +594,7 @@ var _ = SIGDescribe("Kubectl client", func() {
 			gomega.Expect(c.CoreV1().Pods(ns).Delete(context.TODO(), "run-test-2", metav1.DeleteOptions{})).To(gomega.BeNil())
 
 			ginkgo.By("executing a command with run and attach with stdin with open stdin should remain running")
-			framework.NewKubectlCommand(ns, "run", "run-test-3", "--image="+busyboxImage, "--restart=OnFailure", "--attach=true", "--leave-stdin-open=true", "--stdin", "--", "sh", "-c", "cat && echo 'stdin closed'").
+			framework.NewKubectlCommand(ns, "run", "run-test-3", "--image="+busyboxImage, "--restart=OnFailure", podRunningTimeoutArg, "--attach=true", "--leave-stdin-open=true", "--stdin", "--", "sh", "-c", "cat && echo 'stdin closed'").
 				WithStdinData("abcd1234\n").
 				ExecOrDie(ns)
 
@@ -606,7 +616,7 @@ var _ = SIGDescribe("Kubectl client", func() {
 			podName := "run-log-test"
 
 			ginkgo.By("executing a command with run")
-			framework.RunKubectlOrDie(ns, "run", podName, "--image="+busyboxImage, "--restart=OnFailure", "--", "sh", "-c", "sleep 10; seq 100 | while read i; do echo $i; sleep 0.01; done; echo EOF")
+			framework.RunKubectlOrDie(ns, "run", podName, "--image="+busyboxImage, "--restart=OnFailure", podRunningTimeoutArg, "--", "sh", "-c", "sleep 10; seq 100 | while read i; do echo $i; sleep 0.01; done; echo EOF")
 
 			if !e2epod.CheckPodsRunningReadyOrSucceeded(c, ns, []string{podName}, framework.PodStartTimeout) {
 				framework.Failf("Pod for run-log-test was not ready")
@@ -909,7 +919,7 @@ metadata:
 		framework.ConformanceIt("should check if kubectl can dry-run update Pods", func() {
 			ginkgo.By("running the image " + httpdImage)
 			podName := "e2e-test-httpd-pod"
-			framework.RunKubectlOrDie(ns, "run", podName, "--image="+httpdImage, "--labels=run="+podName)
+			framework.RunKubectlOrDie(ns, "run", podName, "--image="+httpdImage, podRunningTimeoutArg, "--labels=run="+podName)
 
 			ginkgo.By("replace the image in the pod with server-side dry-run")
 			specImage := fmt.Sprintf(`{"spec":{"containers":[{"name": "%s","image": "%s"}]}}`, podName, busyboxImage)
@@ -1386,7 +1396,7 @@ metadata:
 		ginkgo.BeforeEach(func() {
 			ginkgo.By("creating an pod")
 			// Agnhost image generates logs for a total of 100 lines over 20s.
-			framework.RunKubectlOrDie(ns, "run", podName, "--image="+agnhostImage, "--restart=Never", "--", "logs-generator", "--log-lines-total", "100", "--run-duration", "20s")
+			framework.RunKubectlOrDie(ns, "run", podName, "--image="+agnhostImage, "--restart=Never", podRunningTimeoutArg, "--", "logs-generator", "--log-lines-total", "100", "--run-duration", "20s")
 		})
 		ginkgo.AfterEach(func() {
 			framework.RunKubectlOrDie(ns, "delete", "pod", podName)
@@ -1526,7 +1536,7 @@ metadata:
 		*/
 		framework.ConformanceIt("should create a pod from an image when restart is Never ", func() {
 			ginkgo.By("running the image " + httpdImage)
-			framework.RunKubectlOrDie(ns, "run", podName, "--restart=Never", "--image="+httpdImage)
+			framework.RunKubectlOrDie(ns, "run", podName, "--restart=Never", podRunningTimeoutArg, "--image="+httpdImage)
 			ginkgo.By("verifying the pod " + podName + " was created")
 			pod, err := c.CoreV1().Pods(ns).Get(context.TODO(), podName, metav1.GetOptions{})
 			if err != nil {
@@ -1560,7 +1570,7 @@ metadata:
 		*/
 		framework.ConformanceIt("should update a single-container pod's image ", func() {
 			ginkgo.By("running the image " + httpdImage)
-			framework.RunKubectlOrDie(ns, "run", podName, "--image="+httpdImage, "--labels=run="+podName)
+			framework.RunKubectlOrDie(ns, "run", podName, "--image="+httpdImage, podRunningTimeoutArg, "--labels=run="+podName)
 
 			ginkgo.By("verifying the pod " + podName + " is running")
 			label := labels.SelectorFromSet(labels.Set(map[string]string{"run": podName}))


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/kind flake

#### What this PR does / why we need it:

These tests are flaking because the [default](https://github.com/kubernetes/kubernetes/blob/2c1b0573c479d213f64db0e83c7d93d7895b8b4b/staging/src/k8s.io/kubectl/pkg/cmd/run/run.go#L92) kubectl pod running timeout is 1 minute. That is the time that kubectl will wait for a pod created by `kubectl run` or `kubectl create` to be started before it delete it.

There is an expectation that these e2e tests may require a little bit more time to start due to the busy testing environment. That is why the [default](https://github.com/kubernetes/kubernetes/blob/2c1b0573c479d213f64db0e83c7d93d7895b8b4b/test/e2e/framework/util.go#L92) pod start timeout in the e2e framework is 5 minutes.

We can see from the [kubelet logs](https://gcsweb.k8s.io/gcs/kubernetes-jenkins/pr-logs/pull/100490/pull-kubernetes-e2e-kind/1384412652561764352/artifacts/logs/kind-worker/) of [this job](https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/100490/pull-kubernetes-e2e-kind/1384412652561764352) that the `kuberuntime_manager` starts creating the pod sandbox at `08:13:26`.  A minute later at `08:14:33` the kubelet receives the delete request from the default timeout in kubectl. Shortly after at `08:14:35` the `kuberuntime_manager` is ready to start the container with the created sandbox but the delete is now in progress.

This particular test is using a 1mb busybox image so I think it's safe to say the issue with the scheduling and starting of the pod is external.

```
Apr 20 08:13:26 kind-worker kubelet[249]: I0420 08:13:26.531887     249 config.go:383] "Receiving a new pod" pod="kubectl-9107/failure-4"
Apr 20 08:13:26 kind-worker kubelet[249]: I0420 08:13:26.532165     249 kubelet.go:1939] "SyncLoop ADD" source="api" pods=[kubectl-9107/failure-4]
Apr 20 08:13:26 kind-worker kubelet[249]: I0420 08:13:26.532524     249 kubelet_pods.go:1520] "Generating pod status" pod="kubectl-9107/failure-4"
Apr 20 08:13:26 kind-worker kubelet[249]: I0420 08:13:26.538799     249 volume_manager.go:373] "Waiting for volumes to attach and mount for pod" pod="kubectl-9107/failure-4"
Apr 20 08:13:26 kind-worker kubelet[249]: I0420 08:13:26.550183     249 status_manager.go:586] "Patch status for pod" pod="kubectl-9107/failure-4" patchBytes=[123 34 109 101 116 97 100 97 116 97 34 58 123 34 117 105 100 34 58 34 55 52 102 101 53 52 55 56 45 98 99 51 53 45 52 100 57 51 45 97 48 49 50 45 53 49 56 54 53 53 97 100 54 102 50 50 34 125 44 34 115 116 97 116 117 115 34 58 123 34 36 115 101 116 69 108 101 109 101 110 116 79 114 100 101 114 47 99 111 110 100 105 116 105 111 110 115 34 58 91 123 34 116 121 112 101 34 58 34 73 110 105 116 105 97 108 105 122 101 100 34 125 44 123 34 116 121 112 101 34 58 34 82 101 97 100 121 34 125 44 123 34 116 121 112 101 34 58 34 67 111 110 116 97 105 110 101 114 115 82 101 97 100 121 34 125 44 123 34 116 121 112 101 34 58 34 80 111 100 83 99 104 101 100 117 108 101 100 34 125 93 44 34 99 111 110 100 105 116 105 111 110 115 34 58 91 123 34 108 97 115 116 80 114 111 98 101 84 105 109 101 34 58 110 117 108 108 44 34 108 97 115 116 84 114 97 110 115 105 116 105 111 110 84 105 109 101 34 58 34 50 48 50 49 45 48 52 45 50 48 84 48 56 58 49 51 58 50 54 90 34 44 34 115 116 97 116 117 115 34 58 34 84 114 117 101 34 44 34 116 121 112 101 34 58 34 73 110 105 116 105 97 108 105 122 101 100 34 125 44 123 34 108 97 115 116 80 114 111 98 101 84 105 109 101 34 58 110 117 108 108 44 34 108 97 115 116 84 114 97 110 115 105 116 105 111 110 84 105 109 101 34 58 34 50 48 50 49 45 48 52 45 50 48 84 48 56 58 49 51 58 50 54 90 34 44 34 109 101 115 115 97 103 101 34 58 34 99 111 110 116 97 105 110 101 114 115 32 119 105 116 104 32 117 110 114 101 97 100 121 32 115 116 97 116 117 115 58 32 91 102 97 105 108 117 114 101 45 52 93 34 44 34 114 101 97 115 111 110 34 58 34 67 111 110 116 97 105 110 101 114 115 78 111 116 82 101 97 100 121 34 44 34 115 116 97 116 117 115 34 58 34 70 97 108 115 101 34 44 34 116 121 112 101 34 58 34 82 101 97 100 121 34 125 44 123 34 108 97 115 116 80 114 111 98 101 84 105 109 101 34 58 110 117 108 108 44 34 108 97 115 116 84 114 97 110 115 105 116 105 111 110 84 105 109 101 34 58 34 50 48 50 49 45 48 52 45 50 48 84 48 56 58 49 51 58 50 54 90 34 44 34 109 101 115 115 97 103 101 34 58 34 99 111 110 116 97 105 110 101 114 115 32 119 105 116 104 32 117 110 114 101 97 100 121 32 115 116 97 116 117 115 58 32 91 102 97 105 108 117 114 101 45 52 93 34 44 34 114 101 97 115 111 110 34 58 34 67 111 110 116 97 105 110 101 114 115 78 111 116 82 101 97 100 121 34 44 34 115 116 97 116 117 115 34 58 34 70 97 108 115 101 34 44 34 116 121 112 101 34 58 34 67 111 110 116 97 105 110 101 114 115 82 101 97 100 121 34 125 93 44 34 99 111 110 116 97 105 110 101 114 83 116 97 116 117 115 101 115 34 58 91 123 34 105 109 97 103 101 34 58 34 107 56 115 46 103 99 114 46 105 111 47 101 50 101 45 116 101 115 116 45 105 109 97 103 101 115 47 98 117 115 121 98 111 120 58 49 46 50 57 45 49 34 44 34 105 109 97 103 101 73 68 34 58 34 34 44 34 108 97 115 116 83 116 97 116 101 34 58 123 125 44 34 110 97 109 101 34 58 34 102 97 105 108 117 114 101 45 52 34 44 34 114 101 97 100 121 34 58 102 97 108 115 101 44 34 114 101 115 116 97 114 116 67 111 117 110 116 34 58 48 44 34 115 116 97 114 116 101 100 34 58 102 97 108 115 101 44 34 115 116 97 116 101 34 58 123 34 119 97 105 116 105 110 103 34 58 123 34 114 101 97 115 111 110 34 58 34 67 111 110 116 97 105 110 101 114 67 114 101 97 116 105 110 103 34 125 125 125 93 44 34 104 111 115 116 73 80 34 58 34 49 55 50 46 49 56 46 48 46 50 34 44 34 115 116 97 114 116 84 105 109 101 34 58 34 50 48 50 49 45 48 52 45 50 48 84 48 56 58 49 51 58 50 54 90 34 125 125]
Apr 20 08:13:26 kind-worker kubelet[249]: I0420 08:13:26.550485     249 status_manager.go:595] "Status for pod updated successfully" pod="kubectl-9107/failure-4" statusVersion=1 status={Phase:Pending Conditions:[{Type:Initialized Status:True LastProbeTime:0001-01-01 00:00:00 +0000 UTC LastTransitionTime:2021-04-20 08:13:26 +0000 UTC Reason: Message:} {Type:Ready Status:False LastProbeTime:0001-01-01 00:00:00 +0000 UTC LastTransitionTime:2021-04-20 08:13:26 +0000 UTC Reason:ContainersNotReady Message:containers with unready status: [failure-4]} {Type:ContainersReady Status:False LastProbeTime:0001-01-01 00:00:00 +0000 UTC LastTransitionTime:2021-04-20 08:13:26 +0000 UTC Reason:ContainersNotReady Message:containers with unready status: [failure-4]} {Type:PodScheduled Status:True LastProbeTime:0001-01-01 00:00:00 +0000 UTC LastTransitionTime:2021-04-20 08:13:26 +0000 UTC Reason: Message:}] Message: Reason: NominatedNodeName: HostIP:172.18.0.2 PodIP: PodIPs:[] StartTime:2021-04-20 08:13:26 +0000 UTC InitContainerStatuses:[] ContainerStatuses:[{Name:failure-4 State:{Waiting:&ContainerStateWaiting{Reason:ContainerCreating,Message:,} Running:nil Terminated:nil} LastTerminationState:{Waiting:nil Running:nil Terminated:nil} Ready:false RestartCount:0 Image:k8s.gcr.io/e2e-test-images/busybox:1.29-1 ImageID: ContainerID: Started:0xc00184c2dc}] QOSClass:BestEffort EphemeralContainerStatuses:[]}
Apr 20 08:13:26 kind-worker kubelet[249]: I0420 08:13:26.552344     249 kubelet.go:1952] "SyncLoop RECONCILE" source="api" pods=[kubectl-9107/failure-4]
Apr 20 08:13:26 kind-worker kubelet[249]: I0420 08:13:26.586397     249 desired_state_of_world_populator.go:349] "Added volume to desired state" pod="kubectl-9107/failure-4" volumeName="kube-api-access-9zv2c" volumeSpecName="kube-api-access-9zv2c"
Apr 20 08:13:26 kind-worker kubelet[249]: I0420 08:13:26.668666     249 reconciler.go:224] "operationExecutor.VerifyControllerAttachedVolume started for volume \"kube-api-access-9zv2c\" (UniqueName: \"kubernetes.io/projected/74fe5478-bc35-4d93-a012-518655ad6f22-kube-api-access-9zv2c\") pod \"failure-4\" (UID: \"74fe5478-bc35-4d93-a012-518655ad6f22\") "
Apr 20 08:13:26 kind-worker kubelet[249]: I0420 08:13:26.769337     249 reconciler.go:254] "Starting operationExecutor.MountVolume for volume \"kube-api-access-9zv2c\" (UniqueName: \"kubernetes.io/projected/74fe5478-bc35-4d93-a012-518655ad6f22-kube-api-access-9zv2c\") pod \"failure-4\" (UID: \"74fe5478-bc35-4d93-a012-518655ad6f22\") "
Apr 20 08:13:26 kind-worker kubelet[249]: I0420 08:13:26.769514     249 reconciler.go:269] "operationExecutor.MountVolume started for volume \"kube-api-access-9zv2c\" (UniqueName: \"kubernetes.io/projected/74fe5478-bc35-4d93-a012-518655ad6f22-kube-api-access-9zv2c\") pod \"failure-4\" (UID: \"74fe5478-bc35-4d93-a012-518655ad6f22\") "
Apr 20 08:13:26 kind-worker kubelet[249]: I0420 08:13:26.779833     249 atomic_writer.go:178] pod kubectl-9107/failure-4 volume kube-api-access-9zv2c: performed write of new data to ts data directory: /var/lib/kubelet/pods/74fe5478-bc35-4d93-a012-518655ad6f22/volumes/kubernetes.io~projected/kube-api-access-9zv2c/..2021_04_20_08_13_26.526605850
Apr 20 08:13:26 kind-worker kubelet[249]: I0420 08:13:26.779946     249 operation_generator.go:698] MountVolume.SetUp succeeded for volume "kube-api-access-9zv2c" (UniqueName: "kubernetes.io/projected/74fe5478-bc35-4d93-a012-518655ad6f22-kube-api-access-9zv2c") pod "failure-4" (UID: "74fe5478-bc35-4d93-a012-518655ad6f22")
Apr 20 08:13:26 kind-worker kubelet[249]: I0420 08:13:26.840608     249 volume_manager.go:404] "All volumes are attached and mounted for pod" pod="kubectl-9107/failure-4"
Apr 20 08:13:26 kind-worker kubelet[249]: I0420 08:13:26.840673     249 kuberuntime_manager.go:460] "No sandbox for pod can be found. Need to start a new one" pod="kubectl-9107/failure-4"
Apr 20 08:13:26 kind-worker kubelet[249]: I0420 08:13:26.840707     249 kuberuntime_manager.go:705] "computePodActions got for pod" podActions={KillPod:true CreateSandbox:true SandboxID: Attempt:0 NextInitContainerToStart:nil ContainersToStart:[0] ContainersToKill:map[] EphemeralContainersToStart:[]} pod="kubectl-9107/failure-4"
Apr 20 08:13:26 kind-worker kubelet[249]: I0420 08:13:26.840750     249 kuberuntime_manager.go:714] "SyncPod received new pod, will create a sandbox for it" pod="kubectl-9107/failure-4"
Apr 20 08:13:26 kind-worker kubelet[249]: I0420 08:13:26.840772     249 kuberuntime_manager.go:721] "Stopping PodSandbox for pod, will start new one" pod="kubectl-9107/failure-4"
Apr 20 08:13:26 kind-worker kubelet[249]: I0420 08:13:26.840792     249 kuberuntime_manager.go:776] "Creating PodSandbox for pod" pod="kubectl-9107/failure-4"
Apr 20 08:14:33 kind-worker kubelet[249]: I0420 08:14:33.102274     249 kubelet.go:1955] "SyncLoop DELETE" source="api" pods=[kubectl-9107/failure-4]
Apr 20 08:14:33 kind-worker kubelet[249]: I0420 08:14:33.102487     249 kubelet.go:2043] "Pod has completed execution and should be deleted from the API server" pod="kubectl-9107/failure-4" syncType="update"
Apr 20 08:14:33 kind-worker kubelet[249]: I0420 08:14:33.104760     249 kubelet.go:1949] "SyncLoop REMOVE" source="api" pods=[kubectl-9107/failure-4]
Apr 20 08:14:33 kind-worker kubelet[249]: I0420 08:14:33.104836     249 kubelet.go:2148] "Failed to delete pod" pod="kubectl-9107/failure-4" err="pod not found"
Apr 20 08:14:33 kind-worker kubelet[249]: I0420 08:14:33.105621     249 status_manager.go:558] "Pod does not exist on the server" podUID=74fe5478-bc35-4d93-a012-518655ad6f22 pod="kubectl-9107/failure-4"
Apr 20 08:14:34 kind-worker kubelet[249]: I0420 08:14:34.855342     249 desired_state_of_world_populator.go:290] "Removing volume from desired state" pod="kubectl-9107/failure-4" podUID=74fe5478-bc35-4d93-a012-518655ad6f22 volumeName="kube-api-access-9zv2c"
Apr 20 08:14:35 kind-worker kubelet[249]: I0420 08:14:35.673223     249 kuberuntime_manager.go:798] "Created PodSandbox for pod" podSandboxID="e958992b1d3417b9905d75ff4be6b236655cdabf1b0b9688435b7c3b5552d2d8" pod="kubectl-9107/failure-4"
Apr 20 08:14:35 kind-worker kubelet[249]: I0420 08:14:35.673920     249 kuberuntime_manager.go:817] "Determined the ip for pod after sandbox changed" IPs=[10.244.1.149] pod="kubectl-9107/failure-4"
Apr 20 08:14:35 kind-worker kubelet[249]: I0420 08:14:35.674156     249 kuberuntime_manager.go:854] "Creating container in pod" containerType="container" container="&Container{Name:failure-4,Image:k8s.gcr.io/e2e-test-images/busybox:1.29-1,Command:[],Args:[/bin/sh -c exit 42],WorkingDir:,Ports:[]ContainerPort{},Env:[]EnvVar{},Resources:ResourceRequirements{Limits:ResourceList{},Requests:ResourceList{},},VolumeMounts:[]VolumeMount{VolumeMount{Name:kube-api-access-9zv2c,ReadOnly:true,MountPath:/var/run/secrets/kubernetes.io/serviceaccount,SubPath:,MountPropagation:nil,SubPathExpr:,},},LivenessProbe:nil,ReadinessProbe:nil,Lifecycle:nil,TerminationMessagePath:/dev/termination-log,ImagePullPolicy:IfNotPresent,SecurityContext:nil,Stdin:true,StdinOnce:false,TTY:false,EnvFrom:[]EnvFromSource{},TerminationMessagePolicy:File,VolumeDevices:[]VolumeDevice{},StartupProbe:nil,}" pod="kubectl-9107/failure-4"
Apr 20 08:14:35 kind-worker kubelet[249]: I0420 08:14:35.674792     249 kubelet_pods.go:152] "Creating hosts mount for container" pod="kubectl-9107/failure-4" containerName="failure-4" podIPs=[10.244.1.149] path=true
Apr 20 08:14:35 kind-worker kubelet[249]: I0420 08:14:35.674828     249 event.go:291] "Event occurred" object="kubectl-9107/failure-4" kind="Pod" apiVersion="v1" type="Normal" reason="Pulled" message="Container image \"k8s.gcr.io/e2e-test-images/busybox:1.29-1\" already present on machine"
Apr 20 08:14:35 kind-worker kubelet[249]: E0420 08:14:35.674846     249 kubelet_pods.go:160] "Mount cannot be satisfied for the container, because the volume is missing or the volume mounter (vol.Mounter) is nil" containerName="failure-4" ok=false volumeMounter={Name:kube-api-access-9zv2c ReadOnly:true MountPath:/var/run/secrets/kubernetes.io/serviceaccount SubPath: MountPropagation:<nil> SubPathExpr:}
Apr 20 08:14:35 kind-worker kubelet[249]: E0420 08:14:35.674931     249 kuberuntime_manager.go:864] container &Container{Name:failure-4,Image:k8s.gcr.io/e2e-test-images/busybox:1.29-1,Command:[],Args:[/bin/sh -c exit 42],WorkingDir:,Ports:[]ContainerPort{},Env:[]EnvVar{},Resources:ResourceRequirements{Limits:ResourceList{},Requests:ResourceList{},},VolumeMounts:[]VolumeMount{VolumeMount{Name:kube-api-access-9zv2c,ReadOnly:true,MountPath:/var/run/secrets/kubernetes.io/serviceaccount,SubPath:,MountPropagation:nil,SubPathExpr:,},},LivenessProbe:nil,ReadinessProbe:nil,Lifecycle:nil,TerminationMessagePath:/dev/termination-log,ImagePullPolicy:IfNotPresent,SecurityContext:nil,Stdin:true,StdinOnce:false,TTY:false,EnvFrom:[]EnvFromSource{},TerminationMessagePolicy:File,VolumeDevices:[]VolumeDevice{},StartupProbe:nil,} start failed in pod failure-4_kubectl-9107(74fe5478-bc35-4d93-a012-518655ad6f22): CreateContainerConfigError: cannot find volume "kube-api-access-9zv2c" to mount into container "failure-4"
Apr 20 08:14:35 kind-worker kubelet[249]: E0420 08:14:35.674979     249 pod_workers.go:190] "Error syncing pod, skipping" err="failed to \"StartContainer\" for \"failure-4\" with CreateContainerConfigError: \"cannot find volume \\\"kube-api-access-9zv2c\\\" to mount into container \\\"failure-4\\\"\"" pod="kubectl-9107/failure-4" podUID=74fe5478-bc35-4d93-a012-518655ad6f22
Apr 20 08:14:35 kind-worker kubelet[249]: I0420 08:14:35.675023     249 event.go:291] "Event occurred" object="kubectl-9107/failure-4" kind="Pod" apiVersion="v1" type="Warning" reason="Failed" message="Error: cannot find volume \"kube-api-access-9zv2c\" to mount into container \"failure-4\""
Apr 20 08:14:35 kind-worker kubelet[249]: I0420 08:14:35.693332     249 kuberuntime_manager.go:996] "getSandboxIDByPodUID got sandbox IDs for pod" podSandboxID=[e958992b1d3417b9905d75ff4be6b236655cdabf1b0b9688435b7c3b5552d2d8] pod="kubectl-9107/failure-4"
Apr 20 08:14:35 kind-worker kubelet[249]: E0420 08:14:35.694269     249 generic.go:389] "PLEG: Write status" pod="kubectl-9107/failure-4"
Apr 20 08:14:35 kind-worker kubelet[249]: E0420 08:14:35.733996     249 event.go:264] Server rejected event '&v1.Event{TypeMeta:v1.TypeMeta{Kind:"", APIVersion:""}, ObjectMeta:v1.ObjectMeta{Name:"failure-4.167782dcbf2b1f76", GenerateName:"", Namespace:"kubectl-9107", SelfLink:"", UID:"", ResourceVersion:"", Generation:0, CreationTimestamp:v1.Time{Time:time.Time{wall:0x0, ext:0, loc:(*time.Location)(nil)}}, DeletionTimestamp:(*v1.Time)(nil), DeletionGracePeriodSeconds:(*int64)(nil), Labels:map[string]string(nil), Annotations:map[string]string(nil), OwnerReferences:[]v1.OwnerReference(nil), Finalizers:[]string(nil), ClusterName:"", ManagedFields:[]v1.ManagedFieldsEntry(nil)}, InvolvedObject:v1.ObjectReference{Kind:"Pod", Namespace:"kubectl-9107", Name:"failure-4", UID:"74fe5478-bc35-4d93-a012-518655ad6f22", APIVersion:"v1", ResourceVersion:"36213", FieldPath:"spec.containers{failure-4}"}, Reason:"Pulled", Message:"Container image \"k8s.gcr.io/e2e-test-images/busybox:1.29-1\" already present on machine", Source:v1.EventSource{Component:"kubelet", Host:"kind-worker"}, FirstTimestamp:v1.Time{Time:time.Time{wall:0xc017c13ae836b176, ext:863612218864, loc:(*time.Location)(0x7534580)}}, LastTimestamp:v1.Time{Time:time.Time{wall:0xc017c13ae836b176, ext:863612218864, loc:(*time.Location)(0x7534580)}}, Count:1, Type:"Normal", EventTime:v1.MicroTime{Time:time.Time{wall:0x0, ext:0, loc:(*time.Location)(nil)}}, Series:(*v1.EventSeries)(nil), Action:"", Related:(*v1.ObjectReference)(nil), ReportingController:"", ReportingInstance:""}': 'namespaces "kubectl-9107" not found' (will not retry!)
Apr 20 08:14:35 kind-worker kubelet[249]: E0420 08:14:35.789232     249 event.go:264] Server rejected event '&v1.Event{TypeMeta:v1.TypeMeta{Kind:"", APIVersion:""}, ObjectMeta:v1.ObjectMeta{Name:"failure-4.167782dcbf2e198c", GenerateName:"", Namespace:"kubectl-9107", SelfLink:"", UID:"", ResourceVersion:"", Generation:0, CreationTimestamp:v1.Time{Time:time.Time{wall:0x0, ext:0, loc:(*time.Location)(nil)}}, DeletionTimestamp:(*v1.Time)(nil), DeletionGracePeriodSeconds:(*int64)(nil), Labels:map[string]string(nil), Annotations:map[string]string(nil), OwnerReferences:[]v1.OwnerReference(nil), Finalizers:[]string(nil), ClusterName:"", ManagedFields:[]v1.ManagedFieldsEntry(nil)}, InvolvedObject:v1.ObjectReference{Kind:"Pod", Namespace:"kubectl-9107", Name:"failure-4", UID:"74fe5478-bc35-4d93-a012-518655ad6f22", APIVersion:"v1", ResourceVersion:"36213", FieldPath:"spec.containers{failure-4}"}, Reason:"Failed", Message:"Error: cannot find volume \"kube-api-access-9zv2c\" to mount into container \"failure-4\"", Source:v1.EventSource{Component:"kubelet", Host:"kind-worker"}, FirstTimestamp:v1.Time{Time:time.Time{wall:0xc017c13ae839ab8c, ext:863612413950, loc:(*time.Location)(0x7534580)}}, LastTimestamp:v1.Time{Time:time.Time{wall:0xc017c13ae839ab8c, ext:863612413950, loc:(*time.Location)(0x7534580)}}, Count:1, Type:"Warning", EventTime:v1.MicroTime{Time:time.Time{wall:0x0, ext:0, loc:(*time.Location)(nil)}}, Series:(*v1.EventSeries)(nil), Action:"", Related:(*v1.ObjectReference)(nil), ReportingController:"", ReportingInstance:""}': 'namespaces "kubectl-9107" not found' (will not retry!)
Apr 20 08:14:36 kind-worker kubelet[249]: I0420 08:14:36.699112     249 kuberuntime_manager.go:996] "getSandboxIDByPodUID got sandbox IDs for pod" podSandboxID=[e958992b1d3417b9905d75ff4be6b236655cdabf1b0b9688435b7c3b5552d2d8] pod="kubectl-9107/failure-4"
Apr 20 08:14:36 kind-worker kubelet[249]: E0420 08:14:36.699786     249 generic.go:389] "PLEG: Write status" pod="kubectl-9107/failure-4"
```

This PR sets the kubectl `--pod-running-timeout` to match the 5 minutes of the e2e framework - giving the kubelet a bit more time to start up the pod.

#### Which issue(s) this PR fixes:

Fixes https://github.com/kubernetes/kubernetes/issues/98854

#### Special notes for your reviewer:

[These 3 tests](https://github.com/kubernetes/kubernetes/compare/master...eddiezane:ez/fix-kubectl-error-code-e2e-test?expand=1#diff-2427c9864b2b37563ae47e0f73d048c1bb4ea9ab367f803e9e044c117eb38f25R518-R539) rely on the kubectl timeout to kill the restarted pod. Fixing this has the unfortunate side effect of making these tests take the maximum 5 minutes each to run. We may need to rework or remove these tests.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
