### PR TITLE
Remove redundant checks

### DIFF
--- a/pkg/scheduler/framework/plugins/volumezone/volume_zone.go
+++ b/pkg/scheduler/framework/plugins/volumezone/volume_zone.go
@@ -116,10 +116,6 @@ func (pl *VolumeZone) Filter(ctx context.Context, _ *framework.CycleState, pod *
 			return framework.AsStatus(err)
 		}
 
-		if pvc == nil {
-			return framework.NewStatus(framework.Error, fmt.Sprintf("PersistentVolumeClaim was not found: %q", pvcName))
-		}
-
 		pvName := pvc.Spec.VolumeName
 		if pvName == "" {
 			scName := storagehelpers.GetPersistentVolumeClaimClass(pvc)
@@ -146,10 +142,6 @@ func (pl *VolumeZone) Filter(ctx context.Context, _ *framework.CycleState, pod *
 		pv, err := pl.pvLister.Get(pvName)
 		if err != nil {
 			return framework.AsStatus(err)
-		}
-
-		if pv == nil {
-			return framework.NewStatus(framework.Error, fmt.Sprintf("PersistentVolume was not found: %q", pvName))
 		}
 
 		for k, v := range pv.ObjectMeta.Labels {


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
[https://github.com/kubernetes/kubernetes/blob/master/pkg/scheduler/framework/plugins/volumezone/volume_zone.go](url)
The err returned by lister.Get contains "not found", so there is no need to check "if pvc == nil" .
```
		pvc, err := pl.pvcLister.PersistentVolumeClaims(pod.Namespace).Get(pvcName)
		if err != nil {
			return framework.AsStatus(err)
		}
		if pvc == nil {
			return framework.NewStatus(framework.Error, fmt.Sprintf("PersistentVolumeClaim was not found: %q", pvcName))
		}
```

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
None
```
#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.: