### PR TITLE
Drop post-vendor sorting of modules.txt

### DIFF
--- a/hack/update-vendor.sh
+++ b/hack/update-vendor.sh
@@ -366,20 +366,6 @@ done
 kube::log::status "vendor: running 'go mod vendor'"
 go mod vendor >>"${LOG_FILE}" 2>&1
 
-# sort recorded packages for a given vendored dependency in modules.txt.
-# `go mod vendor` outputs in imported order, which means slight go changes (or different platforms) can result in a differently ordered modules.txt.
-# 1. prefix '#' lines with the module name and capture the module name
-# 2. prefix '##' with the most recently captured module name
-# 3. output other lines as-is
-# sort lines
-# strip anything before '#'
-awk '{
-  if($1=="#")       { current_module=$2; print $2 " " $0;      }
-  else if($1=="##") { print current_module " " $0; }
-  else              { print }
-}' < vendor/modules.txt | sort -k1,1 -s | sed 's/[^#]*#/#/' > "${TMP_DIR}/modules.txt.tmp"
-mv "${TMP_DIR}/modules.txt.tmp" vendor/modules.txt
-
 # create a symlink in vendor directory pointing to the staging components.
 # This lets other packages and tools use the local staging components as if they were vendored.
 for repo in $(kube::util::list_staging_repos); do

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,19 +1,10 @@
 # bitbucket.org/bertimus9/systemstat v0.0.0-20180207000608-0eeff89b0690 => bitbucket.org/bertimus9/systemstat v0.0.0-20180207000608-0eeff89b0690
 ## explicit
 bitbucket.org/bertimus9/systemstat
-# bitbucket.org/bertimus9/systemstat => bitbucket.org/bertimus9/systemstat v0.0.0-20180207000608-0eeff89b0690
 # cloud.google.com/go v0.54.0 => cloud.google.com/go v0.54.0
-# cloud.google.com/go => cloud.google.com/go v0.54.0
-# cloud.google.com/go/bigquery => cloud.google.com/go/bigquery v1.4.0
 cloud.google.com/go/compute/metadata
-# cloud.google.com/go/datastore => cloud.google.com/go/datastore v1.1.0
-# cloud.google.com/go/firestore => cloud.google.com/go/firestore v1.1.0
-# cloud.google.com/go/pubsub => cloud.google.com/go/pubsub v1.2.0
-# cloud.google.com/go/storage => cloud.google.com/go/storage v1.6.0
-# dmitri.shuralyov.com/gpu/mtl => dmitri.shuralyov.com/gpu/mtl v0.0.0-20201218220906-28db891af037
 # github.com/Azure/azure-sdk-for-go v43.0.0+incompatible => github.com/Azure/azure-sdk-for-go v43.0.0+incompatible
 ## explicit
-# github.com/Azure/azure-sdk-for-go => github.com/Azure/azure-sdk-for-go v43.0.0+incompatible
 github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2019-12-01/compute
 github.com/Azure/azure-sdk-for-go/services/containerregistry/mgmt/2019-05-01/containerregistry
 github.com/Azure/azure-sdk-for-go/services/containerservice/mgmt/2020-04-01/containerservice
@@ -24,44 +15,31 @@ github.com/Azure/azure-sdk-for-go/storage
 github.com/Azure/azure-sdk-for-go/version
 # github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78 => github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78
 github.com/Azure/go-ansiterm
-# github.com/Azure/go-ansiterm => github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78
 github.com/Azure/go-ansiterm/winterm
 # github.com/Azure/go-autorest v14.2.0+incompatible => github.com/Azure/go-autorest v14.2.0+incompatible
 github.com/Azure/go-autorest
-# github.com/Azure/go-autorest => github.com/Azure/go-autorest v14.2.0+incompatible
 # github.com/Azure/go-autorest/autorest v0.11.12 => github.com/Azure/go-autorest/autorest v0.11.12
 ## explicit
 github.com/Azure/go-autorest/autorest
-# github.com/Azure/go-autorest/autorest => github.com/Azure/go-autorest/autorest v0.11.12
+github.com/Azure/go-autorest/autorest/azure
 # github.com/Azure/go-autorest/autorest/adal v0.9.5 => github.com/Azure/go-autorest/autorest/adal v0.9.5
 ## explicit
 github.com/Azure/go-autorest/autorest/adal
-# github.com/Azure/go-autorest/autorest/adal => github.com/Azure/go-autorest/autorest/adal v0.9.5
-github.com/Azure/go-autorest/autorest/azure
 # github.com/Azure/go-autorest/autorest/date v0.3.0 => github.com/Azure/go-autorest/autorest/date v0.3.0
 github.com/Azure/go-autorest/autorest/date
-# github.com/Azure/go-autorest/autorest/date => github.com/Azure/go-autorest/autorest/date v0.3.0
 # github.com/Azure/go-autorest/autorest/mocks v0.4.1 => github.com/Azure/go-autorest/autorest/mocks v0.4.1
 github.com/Azure/go-autorest/autorest/mocks
-# github.com/Azure/go-autorest/autorest/mocks => github.com/Azure/go-autorest/autorest/mocks v0.4.1
 # github.com/Azure/go-autorest/autorest/to v0.2.0 => github.com/Azure/go-autorest/autorest/to v0.2.0
 ## explicit
 github.com/Azure/go-autorest/autorest/to
-# github.com/Azure/go-autorest/autorest/to => github.com/Azure/go-autorest/autorest/to v0.2.0
 # github.com/Azure/go-autorest/autorest/validation v0.1.0 => github.com/Azure/go-autorest/autorest/validation v0.1.0
 github.com/Azure/go-autorest/autorest/validation
-# github.com/Azure/go-autorest/autorest/validation => github.com/Azure/go-autorest/autorest/validation v0.1.0
 # github.com/Azure/go-autorest/logger v0.2.0 => github.com/Azure/go-autorest/logger v0.2.0
 github.com/Azure/go-autorest/logger
-# github.com/Azure/go-autorest/logger => github.com/Azure/go-autorest/logger v0.2.0
 # github.com/Azure/go-autorest/tracing v0.6.0 => github.com/Azure/go-autorest/tracing v0.6.0
 github.com/Azure/go-autorest/tracing
-# github.com/Azure/go-autorest/tracing => github.com/Azure/go-autorest/tracing v0.6.0
-# github.com/BurntSushi/toml => github.com/BurntSushi/toml v0.3.1
-# github.com/BurntSushi/xgb => github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802
 # github.com/GoogleCloudPlatform/k8s-cloud-provider v0.0.0-20200415212048-7901bc822317 => github.com/GoogleCloudPlatform/k8s-cloud-provider v0.0.0-20200415212048-7901bc822317
 ## explicit
-# github.com/GoogleCloudPlatform/k8s-cloud-provider => github.com/GoogleCloudPlatform/k8s-cloud-provider v0.0.0-20200415212048-7901bc822317
 github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud
 github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/filter
 github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/meta
@@ -69,20 +47,16 @@ github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/mock
 # github.com/JeffAshton/win_pdh v0.0.0-20161109143554-76bb4ee9f0ab => github.com/JeffAshton/win_pdh v0.0.0-20161109143554-76bb4ee9f0ab
 ## explicit
 github.com/JeffAshton/win_pdh
-# github.com/JeffAshton/win_pdh => github.com/JeffAshton/win_pdh v0.0.0-20161109143554-76bb4ee9f0ab
 # github.com/MakeNowJust/heredoc v0.0.0-20170808103936-bb23615498cd => github.com/MakeNowJust/heredoc v0.0.0-20170808103936-bb23615498cd
 github.com/MakeNowJust/heredoc
-# github.com/MakeNowJust/heredoc => github.com/MakeNowJust/heredoc v0.0.0-20170808103936-bb23615498cd
 # github.com/Microsoft/go-winio v0.4.15 => github.com/Microsoft/go-winio v0.4.15
 ## explicit
 github.com/Microsoft/go-winio
-# github.com/Microsoft/go-winio => github.com/Microsoft/go-winio v0.4.15
 github.com/Microsoft/go-winio/pkg/guid
 github.com/Microsoft/go-winio/vhd
 # github.com/Microsoft/hcsshim v0.8.10-0.20200715222032-5eafd1556990 => github.com/Microsoft/hcsshim v0.8.10-0.20200715222032-5eafd1556990
 ## explicit
 github.com/Microsoft/hcsshim
-# github.com/Microsoft/hcsshim => github.com/Microsoft/hcsshim v0.8.10-0.20200715222032-5eafd1556990
 github.com/Microsoft/hcsshim/hcn
 github.com/Microsoft/hcsshim/internal/cni
 github.com/Microsoft/hcsshim/internal/cow
@@ -106,34 +80,20 @@ github.com/Microsoft/hcsshim/internal/wclayer
 github.com/Microsoft/hcsshim/osversion
 # github.com/NYTimes/gziphandler v1.1.1 => github.com/NYTimes/gziphandler v1.1.1
 github.com/NYTimes/gziphandler
-# github.com/NYTimes/gziphandler => github.com/NYTimes/gziphandler v1.1.1
 # github.com/PuerkitoBio/purell v1.1.1 => github.com/PuerkitoBio/purell v1.1.1
 ## explicit
 github.com/PuerkitoBio/purell
-# github.com/PuerkitoBio/purell => github.com/PuerkitoBio/purell v1.1.1
 # github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 => github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578
 github.com/PuerkitoBio/urlesc
-# github.com/PuerkitoBio/urlesc => github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578
-# github.com/agnivade/levenshtein => github.com/agnivade/levenshtein v1.0.1
-# github.com/ajstarks/svgo => github.com/ajstarks/svgo v0.0.0-20180226025133-644b8db467af
-# github.com/alecthomas/template => github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751
-# github.com/alecthomas/units => github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4
-# github.com/andreyvit/diff => github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883
 # github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e => github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e
 ## explicit
 github.com/armon/circbuf
-# github.com/armon/circbuf => github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e
-# github.com/armon/go-metrics => github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da
-# github.com/armon/go-radix => github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310
 # github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a => github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a
 github.com/asaskevich/govalidator
-# github.com/asaskevich/govalidator => github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a
 # github.com/auth0/go-jwt-middleware v0.0.0-20170425171159-5493cabe49f7 => github.com/auth0/go-jwt-middleware v0.0.0-20170425171159-5493cabe49f7
 ## explicit
-# github.com/auth0/go-jwt-middleware => github.com/auth0/go-jwt-middleware v0.0.0-20170425171159-5493cabe49f7
 # github.com/aws/aws-sdk-go v1.35.24 => github.com/aws/aws-sdk-go v1.35.24
 ## explicit
-# github.com/aws/aws-sdk-go => github.com/aws/aws-sdk-go v1.35.24
 github.com/aws/aws-sdk-go/aws
 github.com/aws/aws-sdk-go/aws/awserr
 github.com/aws/aws-sdk-go/aws/awsutil
@@ -178,43 +138,26 @@ github.com/aws/aws-sdk-go/service/kms
 github.com/aws/aws-sdk-go/service/sts
 github.com/aws/aws-sdk-go/service/sts/stsiface
 # github.com/beorn7/perks v1.0.1 => github.com/beorn7/perks v1.0.1
-# github.com/beorn7/perks => github.com/beorn7/perks v1.0.1
 github.com/beorn7/perks/quantile
-# github.com/bgentry/speakeasy => github.com/bgentry/speakeasy v0.1.0
-# github.com/bifurcation/mint => github.com/bifurcation/mint v0.0.0-20180715133206-93c51c6ce115
-# github.com/bketelsen/crypt => github.com/bketelsen/crypt v0.0.3-0.20200106085610-5cbc8cc4026c
 # github.com/blang/semver v3.5.1+incompatible => github.com/blang/semver v3.5.1+incompatible
 ## explicit
 github.com/blang/semver
-# github.com/blang/semver => github.com/blang/semver v3.5.1+incompatible
 # github.com/boltdb/bolt v1.3.1 => github.com/boltdb/bolt v1.3.1
 ## explicit
-# github.com/boltdb/bolt => github.com/boltdb/bolt v1.3.1
 # github.com/caddyserver/caddy v1.0.3 => github.com/caddyserver/caddy v1.0.3
-# github.com/caddyserver/caddy => github.com/caddyserver/caddy v1.0.3
 github.com/caddyserver/caddy/caddyfile
-# github.com/cenkalti/backoff => github.com/cenkalti/backoff v2.1.1+incompatible
-# github.com/census-instrumentation/opencensus-proto => github.com/census-instrumentation/opencensus-proto v0.2.1
 # github.com/cespare/xxhash/v2 v2.1.1 => github.com/cespare/xxhash/v2 v2.1.1
 github.com/cespare/xxhash/v2
-# github.com/cespare/xxhash/v2 => github.com/cespare/xxhash/v2 v2.1.1
 # github.com/chai2010/gettext-go v0.0.0-20160711120539-c6fed771bfd5 => github.com/chai2010/gettext-go v0.0.0-20160711120539-c6fed771bfd5
-# github.com/chai2010/gettext-go => github.com/chai2010/gettext-go v0.0.0-20160711120539-c6fed771bfd5
 github.com/chai2010/gettext-go/gettext
 github.com/chai2010/gettext-go/gettext/mo
 github.com/chai2010/gettext-go/gettext/plural
 github.com/chai2010/gettext-go/gettext/po
 # github.com/checkpoint-restore/go-criu/v4 v4.1.0 => github.com/checkpoint-restore/go-criu/v4 v4.1.0
 github.com/checkpoint-restore/go-criu/v4
-# github.com/checkpoint-restore/go-criu/v4 => github.com/checkpoint-restore/go-criu/v4 v4.1.0
 github.com/checkpoint-restore/go-criu/v4/rpc
-# github.com/cheekybits/genny => github.com/cheekybits/genny v0.0.0-20170328200008-9127e812e1e9
-# github.com/chzyer/logex => github.com/chzyer/logex v1.1.10
-# github.com/chzyer/readline => github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e
-# github.com/chzyer/test => github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1
 # github.com/cilium/ebpf v0.2.0 => github.com/cilium/ebpf v0.2.0
 github.com/cilium/ebpf
-# github.com/cilium/ebpf => github.com/cilium/ebpf v0.2.0
 github.com/cilium/ebpf/asm
 github.com/cilium/ebpf/internal
 github.com/cilium/ebpf/internal/btf
@@ -222,20 +165,14 @@ github.com/cilium/ebpf/internal/unix
 # github.com/clusterhq/flocker-go v0.0.0-20160920122132-2b8b7259d313 => github.com/clusterhq/flocker-go v0.0.0-20160920122132-2b8b7259d313
 ## explicit
 github.com/clusterhq/flocker-go
-# github.com/clusterhq/flocker-go => github.com/clusterhq/flocker-go v0.0.0-20160920122132-2b8b7259d313
-# github.com/cockroachdb/datadriven => github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa
 # github.com/container-storage-interface/spec v1.3.0 => github.com/container-storage-interface/spec v1.3.0
 ## explicit
-# github.com/container-storage-interface/spec => github.com/container-storage-interface/spec v1.3.0
 github.com/container-storage-interface/spec/lib/go/csi
 # github.com/containerd/cgroups v0.0.0-20200531161412-0dbf7f05ba59 => github.com/containerd/cgroups v0.0.0-20200531161412-0dbf7f05ba59
-# github.com/containerd/cgroups => github.com/containerd/cgroups v0.0.0-20200531161412-0dbf7f05ba59
 github.com/containerd/cgroups/stats/v1
 # github.com/containerd/console v1.0.1 => github.com/containerd/console v1.0.1
 github.com/containerd/console
-# github.com/containerd/console => github.com/containerd/console v1.0.1
 # github.com/containerd/containerd v1.4.4 => github.com/containerd/containerd v1.4.4
-# github.com/containerd/containerd => github.com/containerd/containerd v1.4.4
 github.com/containerd/containerd/api/services/containers/v1
 github.com/containerd/containerd/api/services/tasks/v1
 github.com/containerd/containerd/api/services/version/v1
@@ -248,16 +185,10 @@ github.com/containerd/containerd/log
 github.com/containerd/containerd/namespaces
 github.com/containerd/containerd/pkg/dialer
 github.com/containerd/containerd/platforms
-# github.com/containerd/continuity => github.com/containerd/continuity v0.0.0-20190426062206-aaeac12a7ffc
-# github.com/containerd/fifo => github.com/containerd/fifo v0.0.0-20190226154929-a9fb20d87448
-# github.com/containerd/go-runc => github.com/containerd/go-runc v0.0.0-20180907222934-5a6d9f37cfa3
 # github.com/containerd/ttrpc v1.0.2 => github.com/containerd/ttrpc v1.0.2
 github.com/containerd/ttrpc
-# github.com/containerd/ttrpc => github.com/containerd/ttrpc v1.0.2
-# github.com/containerd/typeurl => github.com/containerd/typeurl v1.0.1
 # github.com/containernetworking/cni v0.8.0 => github.com/containernetworking/cni v0.8.0
 ## explicit
-# github.com/containernetworking/cni => github.com/containernetworking/cni v0.8.0
 github.com/containernetworking/cni/libcni
 github.com/containernetworking/cni/pkg/invoke
 github.com/containernetworking/cni/pkg/types
@@ -267,60 +198,43 @@ github.com/containernetworking/cni/pkg/utils
 github.com/containernetworking/cni/pkg/version
 # github.com/coredns/corefile-migration v1.0.11 => github.com/coredns/corefile-migration v1.0.11
 ## explicit
-# github.com/coredns/corefile-migration => github.com/coredns/corefile-migration v1.0.11
 github.com/coredns/corefile-migration/migration
 github.com/coredns/corefile-migration/migration/corefile
-# github.com/coreos/bbolt => github.com/coreos/bbolt v1.3.2
-# github.com/coreos/etcd => github.com/coreos/etcd v3.3.13+incompatible
 # github.com/coreos/go-oidc v2.1.0+incompatible => github.com/coreos/go-oidc v2.1.0+incompatible
 ## explicit
 github.com/coreos/go-oidc
-# github.com/coreos/go-oidc => github.com/coreos/go-oidc v2.1.0+incompatible
 # github.com/coreos/go-semver v0.3.0 => github.com/coreos/go-semver v0.3.0
-# github.com/coreos/go-semver => github.com/coreos/go-semver v0.3.0
 github.com/coreos/go-semver/semver
 # github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e => github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e
 ## explicit
-# github.com/coreos/go-systemd => github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e
 github.com/coreos/go-systemd/daemon
 github.com/coreos/go-systemd/journal
 github.com/coreos/go-systemd/util
 # github.com/coreos/go-systemd/v22 v22.1.0 => github.com/coreos/go-systemd/v22 v22.1.0
-# github.com/coreos/go-systemd/v22 => github.com/coreos/go-systemd/v22 v22.1.0
 github.com/coreos/go-systemd/v22/dbus
 # github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f => github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f
 ## explicit
-# github.com/coreos/pkg => github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f
 github.com/coreos/pkg/capnslog
 github.com/coreos/pkg/dlopen
 # github.com/cpuguy83/go-md2man/v2 v2.0.0 => github.com/cpuguy83/go-md2man/v2 v2.0.0
 ## explicit
-# github.com/cpuguy83/go-md2man/v2 => github.com/cpuguy83/go-md2man/v2 v2.0.0
 github.com/cpuguy83/go-md2man/v2/md2man
-# github.com/creack/pty => github.com/creack/pty v1.1.11
 # github.com/cyphar/filepath-securejoin v0.2.2 => github.com/cyphar/filepath-securejoin v0.2.2
 github.com/cyphar/filepath-securejoin
-# github.com/cyphar/filepath-securejoin => github.com/cyphar/filepath-securejoin v0.2.2
 # github.com/davecgh/go-spew v1.1.1 => github.com/davecgh/go-spew v1.1.1
 ## explicit
-# github.com/davecgh/go-spew => github.com/davecgh/go-spew v1.1.1
 github.com/davecgh/go-spew/spew
 # github.com/daviddengcn/go-colortext v0.0.0-20160507010035-511bcaf42ccd => github.com/daviddengcn/go-colortext v0.0.0-20160507010035-511bcaf42ccd
 github.com/daviddengcn/go-colortext
-# github.com/daviddengcn/go-colortext => github.com/daviddengcn/go-colortext v0.0.0-20160507010035-511bcaf42ccd
 # github.com/dgrijalva/jwt-go v3.2.0+incompatible => github.com/dgrijalva/jwt-go v3.2.0+incompatible
 github.com/dgrijalva/jwt-go
-# github.com/dgrijalva/jwt-go => github.com/dgrijalva/jwt-go v3.2.0+incompatible
-# github.com/dnaeon/go-vcr => github.com/dnaeon/go-vcr v1.0.1
 # github.com/docker/distribution v2.7.1+incompatible => github.com/docker/distribution v2.7.1+incompatible
 ## explicit
-# github.com/docker/distribution => github.com/docker/distribution v2.7.1+incompatible
 github.com/docker/distribution/digestset
 github.com/docker/distribution/reference
 github.com/docker/distribution/registry/api/errcode
 # github.com/docker/docker v20.10.2+incompatible => github.com/docker/docker v20.10.2+incompatible
 ## explicit
-# github.com/docker/docker => github.com/docker/docker v20.10.2+incompatible
 github.com/docker/docker/api
 github.com/docker/docker/api/types
 github.com/docker/docker/api/types/blkiodev
@@ -343,103 +257,62 @@ github.com/docker/docker/pkg/jsonmessage
 github.com/docker/docker/pkg/stdcopy
 # github.com/docker/go-connections v0.4.0 => github.com/docker/go-connections v0.4.0
 ## explicit
-# github.com/docker/go-connections => github.com/docker/go-connections v0.4.0
 github.com/docker/go-connections/nat
 github.com/docker/go-connections/sockets
 github.com/docker/go-connections/tlsconfig
 # github.com/docker/go-units v0.4.0 => github.com/docker/go-units v0.4.0
 ## explicit
 github.com/docker/go-units
-# github.com/docker/go-units => github.com/docker/go-units v0.4.0
-# github.com/docopt/docopt-go => github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815
 # github.com/dustin/go-humanize v1.0.0 => github.com/dustin/go-humanize v1.0.0
 github.com/dustin/go-humanize
-# github.com/dustin/go-humanize => github.com/dustin/go-humanize v1.0.0
 # github.com/elazarl/goproxy v0.0.0-20180725130230-947c36da3153 => github.com/elazarl/goproxy v0.0.0-20180725130230-947c36da3153
 ## explicit
 github.com/elazarl/goproxy
-# github.com/elazarl/goproxy => github.com/elazarl/goproxy v0.0.0-20180725130230-947c36da3153
 # github.com/emicklei/go-restful v2.9.5+incompatible => github.com/emicklei/go-restful v2.9.5+incompatible
 ## explicit
 github.com/emicklei/go-restful
-# github.com/emicklei/go-restful => github.com/emicklei/go-restful v2.9.5+incompatible
 github.com/emicklei/go-restful/log
-# github.com/envoyproxy/go-control-plane => github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473
-# github.com/envoyproxy/protoc-gen-validate => github.com/envoyproxy/protoc-gen-validate v0.1.0
 # github.com/euank/go-kmsg-parser v2.0.0+incompatible => github.com/euank/go-kmsg-parser v2.0.0+incompatible
-# github.com/euank/go-kmsg-parser => github.com/euank/go-kmsg-parser v2.0.0+incompatible
 github.com/euank/go-kmsg-parser/kmsgparser
 # github.com/evanphx/json-patch v4.9.0+incompatible => github.com/evanphx/json-patch v4.9.0+incompatible
 ## explicit
 github.com/evanphx/json-patch
-# github.com/evanphx/json-patch => github.com/evanphx/json-patch v4.9.0+incompatible
 # github.com/exponent-io/jsonpath v0.0.0-20151013193312-d6023ce2651d => github.com/exponent-io/jsonpath v0.0.0-20151013193312-d6023ce2651d
 github.com/exponent-io/jsonpath
-# github.com/exponent-io/jsonpath => github.com/exponent-io/jsonpath v0.0.0-20151013193312-d6023ce2651d
 # github.com/fatih/camelcase v1.0.0 => github.com/fatih/camelcase v1.0.0
 github.com/fatih/camelcase
-# github.com/fatih/camelcase => github.com/fatih/camelcase v1.0.0
-# github.com/fatih/color => github.com/fatih/color v1.7.0
-# github.com/flynn/go-shlex => github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568
-# github.com/fogleman/gg => github.com/fogleman/gg v1.2.1-0.20190220221249-0403632d5b90
 # github.com/form3tech-oss/jwt-go v3.2.2+incompatible => github.com/form3tech-oss/jwt-go v3.2.2+incompatible
 github.com/form3tech-oss/jwt-go
-# github.com/form3tech-oss/jwt-go => github.com/form3tech-oss/jwt-go v3.2.2+incompatible
 # github.com/fsnotify/fsnotify v1.4.9 => github.com/fsnotify/fsnotify v1.4.9
 ## explicit
 github.com/fsnotify/fsnotify
-# github.com/fsnotify/fsnotify => github.com/fsnotify/fsnotify v1.4.9
 # github.com/fvbommel/sortorder v1.0.1 => github.com/fvbommel/sortorder v1.0.1
 github.com/fvbommel/sortorder
-# github.com/fvbommel/sortorder => github.com/fvbommel/sortorder v1.0.1
-# github.com/ghodss/yaml => github.com/ghodss/yaml v1.0.0
-# github.com/go-acme/lego => github.com/go-acme/lego v2.5.0+incompatible
 # github.com/go-bindata/go-bindata v3.1.1+incompatible => github.com/go-bindata/go-bindata v3.1.1+incompatible
 ## explicit
 github.com/go-bindata/go-bindata
-# github.com/go-bindata/go-bindata => github.com/go-bindata/go-bindata v3.1.1+incompatible
 github.com/go-bindata/go-bindata/go-bindata
 # github.com/go-errors/errors v1.0.1 => github.com/go-errors/errors v1.0.1
 github.com/go-errors/errors
-# github.com/go-errors/errors => github.com/go-errors/errors v1.0.1
-# github.com/go-gl/glfw/v3.3/glfw => github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4
-# github.com/go-kit/kit => github.com/go-kit/kit v0.9.0
-# github.com/go-logfmt/logfmt => github.com/go-logfmt/logfmt v0.4.0
 # github.com/go-logr/logr v0.4.0 => github.com/go-logr/logr v0.4.0
 github.com/go-logr/logr
-# github.com/go-logr/logr => github.com/go-logr/logr v0.4.0
-# github.com/go-openapi/analysis => github.com/go-openapi/analysis v0.19.5
-# github.com/go-openapi/errors => github.com/go-openapi/errors v0.19.2
 # github.com/go-openapi/jsonpointer v0.19.3 => github.com/go-openapi/jsonpointer v0.19.3
 github.com/go-openapi/jsonpointer
-# github.com/go-openapi/jsonpointer => github.com/go-openapi/jsonpointer v0.19.3
 # github.com/go-openapi/jsonreference v0.19.3 => github.com/go-openapi/jsonreference v0.19.3
 github.com/go-openapi/jsonreference
-# github.com/go-openapi/jsonreference => github.com/go-openapi/jsonreference v0.19.3
-# github.com/go-openapi/loads => github.com/go-openapi/loads v0.19.4
-# github.com/go-openapi/runtime => github.com/go-openapi/runtime v0.19.4
 # github.com/go-openapi/spec v0.19.5 => github.com/go-openapi/spec v0.19.5
 github.com/go-openapi/spec
-# github.com/go-openapi/spec => github.com/go-openapi/spec v0.19.5
-# github.com/go-openapi/strfmt => github.com/go-openapi/strfmt v0.19.5
 # github.com/go-openapi/swag v0.19.5 => github.com/go-openapi/swag v0.19.5
 github.com/go-openapi/swag
-# github.com/go-openapi/swag => github.com/go-openapi/swag v0.19.5
-# github.com/go-openapi/validate => github.com/go-openapi/validate v0.19.8
 # github.com/go-ozzo/ozzo-validation v3.5.0+incompatible => github.com/go-ozzo/ozzo-validation v3.5.0+incompatible
 ## explicit
 github.com/go-ozzo/ozzo-validation
-# github.com/go-ozzo/ozzo-validation => github.com/go-ozzo/ozzo-validation v3.5.0+incompatible
 github.com/go-ozzo/ozzo-validation/is
-# github.com/go-stack/stack => github.com/go-stack/stack v1.8.0
-# github.com/gobuffalo/here => github.com/gobuffalo/here v0.6.0
 # github.com/godbus/dbus/v5 v5.0.3 => github.com/godbus/dbus/v5 v5.0.3
 ## explicit
 github.com/godbus/dbus/v5
-# github.com/godbus/dbus/v5 => github.com/godbus/dbus/v5 v5.0.3
 # github.com/gogo/protobuf v1.3.2 => github.com/gogo/protobuf v1.3.2
 ## explicit
-# github.com/gogo/protobuf => github.com/gogo/protobuf v1.3.2
 github.com/gogo/protobuf/gogoproto
 github.com/gogo/protobuf/plugin/compare
 github.com/gogo/protobuf/plugin/defaultcheck
@@ -467,19 +340,14 @@ github.com/gogo/protobuf/sortkeys
 github.com/gogo/protobuf/types
 github.com/gogo/protobuf/vanity
 github.com/gogo/protobuf/vanity/command
-# github.com/golang/freetype => github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0
-# github.com/golang/glog => github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
 # github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e => github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e
 ## explicit
-# github.com/golang/groupcache => github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e
 github.com/golang/groupcache/lru
 # github.com/golang/mock v1.4.4 => github.com/golang/mock v1.4.4
 ## explicit
-# github.com/golang/mock => github.com/golang/mock v1.4.4
 github.com/golang/mock/gomock
 # github.com/golang/protobuf v1.4.3 => github.com/golang/protobuf v1.4.3
 ## explicit
-# github.com/golang/protobuf => github.com/golang/protobuf v1.4.3
 github.com/golang/protobuf/jsonpb
 github.com/golang/protobuf/proto
 github.com/golang/protobuf/protoc-gen-go/descriptor
@@ -491,13 +359,10 @@ github.com/golang/protobuf/ptypes/any
 github.com/golang/protobuf/ptypes/duration
 github.com/golang/protobuf/ptypes/timestamp
 github.com/golang/protobuf/ptypes/wrappers
-# github.com/golangplus/testing => github.com/golangplus/testing v0.0.0-20180327235837-af21d9c3145e
 # github.com/google/btree v1.0.0 => github.com/google/btree v1.0.0
 github.com/google/btree
-# github.com/google/btree => github.com/google/btree v1.0.0
 # github.com/google/cadvisor v0.39.0 => github.com/google/cadvisor v0.39.0
 ## explicit
-# github.com/google/cadvisor => github.com/google/cadvisor v0.39.0
 github.com/google/cadvisor/accelerators
 github.com/google/cadvisor/cache/memory
 github.com/google/cadvisor/client/v2
@@ -544,7 +409,6 @@ github.com/google/cadvisor/watcher
 github.com/google/cadvisor/zfs
 # github.com/google/go-cmp v0.5.2 => github.com/google/go-cmp v0.5.2
 ## explicit
-# github.com/google/go-cmp => github.com/google/go-cmp v0.5.2
 github.com/google/go-cmp/cmp
 github.com/google/go-cmp/cmp/cmpopts
 github.com/google/go-cmp/cmp/internal/diff
@@ -554,30 +418,21 @@ github.com/google/go-cmp/cmp/internal/value
 # github.com/google/gofuzz v1.1.0 => github.com/google/gofuzz v1.1.0
 ## explicit
 github.com/google/gofuzz
-# github.com/google/gofuzz => github.com/google/gofuzz v1.1.0
-# github.com/google/martian => github.com/google/martian v2.1.0+incompatible
-# github.com/google/pprof => github.com/google/pprof v0.0.0-20200229191704-1ebb73c60ed3
-# github.com/google/renameio => github.com/google/renameio v0.1.0
 # github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 => github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
 github.com/google/shlex
-# github.com/google/shlex => github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
 # github.com/google/uuid v1.1.2 => github.com/google/uuid v1.1.2
 ## explicit
 github.com/google/uuid
-# github.com/google/uuid => github.com/google/uuid v1.1.2
 # github.com/googleapis/gax-go/v2 v2.0.5 => github.com/googleapis/gax-go/v2 v2.0.5
 github.com/googleapis/gax-go/v2
-# github.com/googleapis/gax-go/v2 => github.com/googleapis/gax-go/v2 v2.0.5
 # github.com/googleapis/gnostic v0.5.1 => github.com/googleapis/gnostic v0.5.1
 ## explicit
-# github.com/googleapis/gnostic => github.com/googleapis/gnostic v0.5.1
 github.com/googleapis/gnostic/compiler
 github.com/googleapis/gnostic/extensions
 github.com/googleapis/gnostic/jsonschema
 github.com/googleapis/gnostic/openapiv2
 # github.com/gophercloud/gophercloud v0.1.0 => github.com/gophercloud/gophercloud v0.1.0
 github.com/gophercloud/gophercloud
-# github.com/gophercloud/gophercloud => github.com/gophercloud/gophercloud v0.1.0
 github.com/gophercloud/gophercloud/openstack
 github.com/gophercloud/gophercloud/openstack/blockstorage/extensions/volumeactions
 github.com/gophercloud/gophercloud/openstack/blockstorage/v1/volumes
@@ -608,46 +463,25 @@ github.com/gophercloud/gophercloud/openstack/networking/v2/networks
 github.com/gophercloud/gophercloud/openstack/networking/v2/ports
 github.com/gophercloud/gophercloud/openstack/utils
 github.com/gophercloud/gophercloud/pagination
-# github.com/gopherjs/gopherjs => github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1
-# github.com/gorilla/mux => github.com/gorilla/mux v1.8.0
 # github.com/gorilla/websocket v1.4.2 => github.com/gorilla/websocket v1.4.2
 github.com/gorilla/websocket
-# github.com/gorilla/websocket => github.com/gorilla/websocket v1.4.2
 # github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7 => github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7
 github.com/gregjones/httpcache
-# github.com/gregjones/httpcache => github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7
 github.com/gregjones/httpcache/diskcache
 # github.com/grpc-ecosystem/go-grpc-middleware v1.0.1-0.20190118093823-f849b5445de4 => github.com/grpc-ecosystem/go-grpc-middleware v1.0.1-0.20190118093823-f849b5445de4
 github.com/grpc-ecosystem/go-grpc-middleware
-# github.com/grpc-ecosystem/go-grpc-middleware => github.com/grpc-ecosystem/go-grpc-middleware v1.0.1-0.20190118093823-f849b5445de4
 # github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0 => github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0
 github.com/grpc-ecosystem/go-grpc-prometheus
-# github.com/grpc-ecosystem/go-grpc-prometheus => github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0
 # github.com/grpc-ecosystem/grpc-gateway v1.9.5 => github.com/grpc-ecosystem/grpc-gateway v1.9.5
-# github.com/grpc-ecosystem/grpc-gateway => github.com/grpc-ecosystem/grpc-gateway v1.9.5
 github.com/grpc-ecosystem/grpc-gateway/internal
 github.com/grpc-ecosystem/grpc-gateway/runtime
 github.com/grpc-ecosystem/grpc-gateway/utilities
-# github.com/hashicorp/consul/api => github.com/hashicorp/consul/api v1.1.0
-# github.com/hashicorp/consul/sdk => github.com/hashicorp/consul/sdk v0.1.1
-# github.com/hashicorp/errwrap => github.com/hashicorp/errwrap v1.0.0
-# github.com/hashicorp/go-cleanhttp => github.com/hashicorp/go-cleanhttp v0.5.1
-# github.com/hashicorp/go-immutable-radix => github.com/hashicorp/go-immutable-radix v1.0.0
-# github.com/hashicorp/go-msgpack => github.com/hashicorp/go-msgpack v0.5.3
-# github.com/hashicorp/go-multierror => github.com/hashicorp/go-multierror v1.0.0
-# github.com/hashicorp/go-rootcerts => github.com/hashicorp/go-rootcerts v1.0.0
-# github.com/hashicorp/go-sockaddr => github.com/hashicorp/go-sockaddr v1.0.0
-# github.com/hashicorp/go-syslog => github.com/hashicorp/go-syslog v1.0.0
-# github.com/hashicorp/go-uuid => github.com/hashicorp/go-uuid v1.0.1
-# github.com/hashicorp/go.net => github.com/hashicorp/go.net v0.0.1
 # github.com/hashicorp/golang-lru v0.5.1 => github.com/hashicorp/golang-lru v0.5.1
 ## explicit
 github.com/hashicorp/golang-lru
-# github.com/hashicorp/golang-lru => github.com/hashicorp/golang-lru v0.5.1
 github.com/hashicorp/golang-lru/simplelru
 # github.com/hashicorp/hcl v1.0.0 => github.com/hashicorp/hcl v1.0.0
 github.com/hashicorp/hcl
-# github.com/hashicorp/hcl => github.com/hashicorp/hcl v1.0.0
 github.com/hashicorp/hcl/hcl/ast
 github.com/hashicorp/hcl/hcl/parser
 github.com/hashicorp/hcl/hcl/printer
@@ -657,67 +491,37 @@ github.com/hashicorp/hcl/hcl/token
 github.com/hashicorp/hcl/json/parser
 github.com/hashicorp/hcl/json/scanner
 github.com/hashicorp/hcl/json/token
-# github.com/hashicorp/logutils => github.com/hashicorp/logutils v1.0.0
-# github.com/hashicorp/mdns => github.com/hashicorp/mdns v1.0.0
-# github.com/hashicorp/memberlist => github.com/hashicorp/memberlist v0.1.3
-# github.com/hashicorp/serf => github.com/hashicorp/serf v0.8.2
 # github.com/heketi/heketi v10.2.0+incompatible => github.com/heketi/heketi v10.2.0+incompatible
 ## explicit
-# github.com/heketi/heketi => github.com/heketi/heketi v10.2.0+incompatible
 github.com/heketi/heketi/client/api/go-client
 github.com/heketi/heketi/pkg/glusterfs/api
 github.com/heketi/heketi/pkg/utils
 # github.com/heketi/tests v0.0.0-20151005000721-f3775cbcefd6 => github.com/heketi/tests v0.0.0-20151005000721-f3775cbcefd6
 ## explicit
-# github.com/heketi/tests => github.com/heketi/tests v0.0.0-20151005000721-f3775cbcefd6
 # github.com/hpcloud/tail v1.0.0 => github.com/hpcloud/tail v1.0.0
 github.com/hpcloud/tail
-# github.com/hpcloud/tail => github.com/hpcloud/tail v1.0.0
 github.com/hpcloud/tail/ratelimiter
 github.com/hpcloud/tail/util
 github.com/hpcloud/tail/watch
 github.com/hpcloud/tail/winfile
-# github.com/ianlancetaylor/demangle => github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6
 # github.com/imdario/mergo v0.3.5 => github.com/imdario/mergo v0.3.5
 github.com/imdario/mergo
-# github.com/imdario/mergo => github.com/imdario/mergo v0.3.5
 # github.com/inconshreveable/mousetrap v1.0.0 => github.com/inconshreveable/mousetrap v1.0.0
 github.com/inconshreveable/mousetrap
-# github.com/inconshreveable/mousetrap => github.com/inconshreveable/mousetrap v1.0.0
 # github.com/ishidawataru/sctp v0.0.0-20190723014705-7c296d48a2b5 => github.com/ishidawataru/sctp v0.0.0-20190723014705-7c296d48a2b5
 ## explicit
 github.com/ishidawataru/sctp
-# github.com/ishidawataru/sctp => github.com/ishidawataru/sctp v0.0.0-20190723014705-7c296d48a2b5
-# github.com/jimstudt/http-authentication => github.com/jimstudt/http-authentication v0.0.0-20140401203705-3eca13d6893a
 # github.com/jmespath/go-jmespath v0.4.0 => github.com/jmespath/go-jmespath v0.4.0
 github.com/jmespath/go-jmespath
-# github.com/jmespath/go-jmespath => github.com/jmespath/go-jmespath v0.4.0
-# github.com/jmespath/go-jmespath/internal/testify => github.com/jmespath/go-jmespath/internal/testify v1.5.1
 # github.com/jonboulle/clockwork v0.1.0 => github.com/jonboulle/clockwork v0.1.0
 github.com/jonboulle/clockwork
-# github.com/jonboulle/clockwork => github.com/jonboulle/clockwork v0.1.0
 # github.com/json-iterator/go v1.1.10 => github.com/json-iterator/go v1.1.10
 ## explicit
 github.com/json-iterator/go
-# github.com/json-iterator/go => github.com/json-iterator/go v1.1.10
-# github.com/jstemmer/go-junit-report => github.com/jstemmer/go-junit-report v0.9.1
-# github.com/jtolds/gls => github.com/jtolds/gls v4.20.0+incompatible
-# github.com/julienschmidt/httprouter => github.com/julienschmidt/httprouter v1.2.0
-# github.com/jung-kurt/gofpdf => github.com/jung-kurt/gofpdf v1.0.3-0.20190309125859-24315acbbda5
 # github.com/karrick/godirwalk v1.16.1 => github.com/karrick/godirwalk v1.16.1
 github.com/karrick/godirwalk
-# github.com/karrick/godirwalk => github.com/karrick/godirwalk v1.16.1
-# github.com/kisielk/errcheck => github.com/kisielk/errcheck v1.5.0
-# github.com/kisielk/gotool => github.com/kisielk/gotool v1.0.0
-# github.com/klauspost/cpuid => github.com/klauspost/cpuid v1.2.0
-# github.com/konsorten/go-windows-terminal-sequences => github.com/konsorten/go-windows-terminal-sequences v1.0.2
-# github.com/kr/logfmt => github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515
-# github.com/kr/pretty => github.com/kr/pretty v0.2.0
-# github.com/kr/text => github.com/kr/text v0.2.0
-# github.com/kylelemons/godebug => github.com/kylelemons/godebug v0.0.0-20170820004349-d65d576e9348
 # github.com/libopenstorage/openstorage v1.0.0 => github.com/libopenstorage/openstorage v1.0.0
 ## explicit
-# github.com/libopenstorage/openstorage => github.com/libopenstorage/openstorage v1.0.0
 github.com/libopenstorage/openstorage/api
 github.com/libopenstorage/openstorage/api/client
 github.com/libopenstorage/openstorage/api/client/volume
@@ -727,111 +531,66 @@ github.com/libopenstorage/openstorage/pkg/units
 github.com/libopenstorage/openstorage/volume
 # github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de => github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de
 github.com/liggitt/tabwriter
-# github.com/liggitt/tabwriter => github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de
 # github.com/lithammer/dedent v1.1.0 => github.com/lithammer/dedent v1.1.0
 ## explicit
 github.com/lithammer/dedent
-# github.com/lithammer/dedent => github.com/lithammer/dedent v1.1.0
 # github.com/lpabon/godbc v0.1.1 => github.com/lpabon/godbc v0.1.1
 ## explicit
-# github.com/lpabon/godbc => github.com/lpabon/godbc v0.1.1
-# github.com/lucas-clemente/aes12 => github.com/lucas-clemente/aes12 v0.0.0-20171027163421-cd47fb39b79f
-# github.com/lucas-clemente/quic-clients => github.com/lucas-clemente/quic-clients v0.1.0
-# github.com/lucas-clemente/quic-go => github.com/lucas-clemente/quic-go v0.10.2
-# github.com/lucas-clemente/quic-go-certificates => github.com/lucas-clemente/quic-go-certificates v0.0.0-20160823095156-d2f86524cced
 # github.com/magiconair/properties v1.8.1 => github.com/magiconair/properties v1.8.1
 github.com/magiconair/properties
-# github.com/magiconair/properties => github.com/magiconair/properties v1.8.1
 # github.com/mailru/easyjson v0.7.0 => github.com/mailru/easyjson v0.7.0
-# github.com/mailru/easyjson => github.com/mailru/easyjson v0.7.0
 github.com/mailru/easyjson/buffer
 github.com/mailru/easyjson/jlexer
 github.com/mailru/easyjson/jwriter
-# github.com/markbates/pkger => github.com/markbates/pkger v0.17.1
-# github.com/marten-seemann/qtls => github.com/marten-seemann/qtls v0.2.3
-# github.com/mattn/go-colorable => github.com/mattn/go-colorable v0.0.9
-# github.com/mattn/go-isatty => github.com/mattn/go-isatty v0.0.4
-# github.com/mattn/go-runewidth => github.com/mattn/go-runewidth v0.0.7
 # github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369 => github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369
-# github.com/matttproud/golang_protobuf_extensions => github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369
 github.com/matttproud/golang_protobuf_extensions/pbutil
-# github.com/mholt/certmagic => github.com/mholt/certmagic v0.6.2-0.20190624175158-6a42ef9fe8c2
 # github.com/miekg/dns v1.1.35 => github.com/miekg/dns v1.1.35
 ## explicit
 github.com/miekg/dns
-# github.com/miekg/dns => github.com/miekg/dns v1.1.35
 # github.com/mindprince/gonvml v0.0.0-20190828220739-9ebdce4bb989 => github.com/mindprince/gonvml v0.0.0-20190828220739-9ebdce4bb989
 github.com/mindprince/gonvml
-# github.com/mindprince/gonvml => github.com/mindprince/gonvml v0.0.0-20190828220739-9ebdce4bb989
 # github.com/mistifyio/go-zfs v2.1.2-0.20190413222219-f784269be439+incompatible => github.com/mistifyio/go-zfs v2.1.2-0.20190413222219-f784269be439+incompatible
 github.com/mistifyio/go-zfs
-# github.com/mistifyio/go-zfs => github.com/mistifyio/go-zfs v2.1.2-0.20190413222219-f784269be439+incompatible
-# github.com/mitchellh/cli => github.com/mitchellh/cli v1.0.0
-# github.com/mitchellh/go-homedir => github.com/mitchellh/go-homedir v1.1.0
-# github.com/mitchellh/go-testing-interface => github.com/mitchellh/go-testing-interface v1.0.0
 # github.com/mitchellh/go-wordwrap v1.0.0 => github.com/mitchellh/go-wordwrap v1.0.0
 github.com/mitchellh/go-wordwrap
-# github.com/mitchellh/go-wordwrap => github.com/mitchellh/go-wordwrap v1.0.0
-# github.com/mitchellh/gox => github.com/mitchellh/gox v0.4.0
-# github.com/mitchellh/iochan => github.com/mitchellh/iochan v1.0.0
 # github.com/mitchellh/mapstructure v1.1.2 => github.com/mitchellh/mapstructure v1.1.2
 github.com/mitchellh/mapstructure
-# github.com/mitchellh/mapstructure => github.com/mitchellh/mapstructure v1.1.2
 # github.com/moby/ipvs v1.0.1 => github.com/moby/ipvs v1.0.1
 ## explicit
 github.com/moby/ipvs
-# github.com/moby/ipvs => github.com/moby/ipvs v1.0.1
 # github.com/moby/spdystream v0.2.0 => github.com/moby/spdystream v0.2.0
 github.com/moby/spdystream
-# github.com/moby/spdystream => github.com/moby/spdystream v0.2.0
 github.com/moby/spdystream/spdy
 # github.com/moby/sys/mountinfo v0.4.0 => github.com/moby/sys/mountinfo v0.4.0
 github.com/moby/sys/mountinfo
-# github.com/moby/sys/mountinfo => github.com/moby/sys/mountinfo v0.4.0
 # github.com/moby/term v0.0.0-20201216013528-df9cb8a40635 => github.com/moby/term v0.0.0-20201216013528-df9cb8a40635
 github.com/moby/term
-# github.com/moby/term => github.com/moby/term v0.0.0-20201216013528-df9cb8a40635
 github.com/moby/term/windows
 # github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd => github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd
 github.com/modern-go/concurrent
-# github.com/modern-go/concurrent => github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd
 # github.com/modern-go/reflect2 v1.0.1 => github.com/modern-go/reflect2 v1.0.1
 github.com/modern-go/reflect2
-# github.com/modern-go/reflect2 => github.com/modern-go/reflect2 v1.0.1
 # github.com/mohae/deepcopy v0.0.0-20170603005431-491d3605edfb => github.com/mohae/deepcopy v0.0.0-20170603005431-491d3605edfb
 ## explicit
 github.com/mohae/deepcopy
-# github.com/mohae/deepcopy => github.com/mohae/deepcopy v0.0.0-20170603005431-491d3605edfb
 # github.com/monochromegane/go-gitignore v0.0.0-20200626010858-205db1a8cc00 => github.com/monochromegane/go-gitignore v0.0.0-20200626010858-205db1a8cc00
 github.com/monochromegane/go-gitignore
-# github.com/monochromegane/go-gitignore => github.com/monochromegane/go-gitignore v0.0.0-20200626010858-205db1a8cc00
 # github.com/morikuni/aec v1.0.0 => github.com/morikuni/aec v1.0.0
 github.com/morikuni/aec
-# github.com/morikuni/aec => github.com/morikuni/aec v1.0.0
 # github.com/mrunalp/fileutils v0.5.0 => github.com/mrunalp/fileutils v0.5.0
 ## explicit
 github.com/mrunalp/fileutils
-# github.com/mrunalp/fileutils => github.com/mrunalp/fileutils v0.5.0
 # github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 => github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822
 ## explicit
 github.com/munnerz/goautoneg
-# github.com/munnerz/goautoneg => github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822
 # github.com/mvdan/xurls v1.1.0 => github.com/mvdan/xurls v1.1.0
 ## explicit
 github.com/mvdan/xurls
-# github.com/mvdan/xurls => github.com/mvdan/xurls v1.1.0
-# github.com/mwitkow/go-conntrack => github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223
 # github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f => github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f
-# github.com/mxk/go-flowrate => github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f
 github.com/mxk/go-flowrate/flowrate
-# github.com/naoina/go-stringutil => github.com/naoina/go-stringutil v0.1.0
-# github.com/naoina/toml => github.com/naoina/toml v0.1.1
-# github.com/niemeyer/pretty => github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e
-# github.com/olekukonko/tablewriter => github.com/olekukonko/tablewriter v0.0.4
 # github.com/onsi/ginkgo v1.11.0 => github.com/onsi/ginkgo v1.11.0
 ## explicit
 github.com/onsi/ginkgo
-# github.com/onsi/ginkgo => github.com/onsi/ginkgo v1.11.0
 github.com/onsi/ginkgo/config
 github.com/onsi/ginkgo/ginkgo
 github.com/onsi/ginkgo/ginkgo/convert
@@ -859,7 +618,6 @@ github.com/onsi/ginkgo/types
 # github.com/onsi/gomega v1.7.0 => github.com/onsi/gomega v1.7.0
 ## explicit
 github.com/onsi/gomega
-# github.com/onsi/gomega => github.com/onsi/gomega v1.7.0
 github.com/onsi/gomega/format
 github.com/onsi/gomega/gstruct
 github.com/onsi/gomega/gstruct/errors
@@ -876,14 +634,11 @@ github.com/onsi/gomega/types
 # github.com/opencontainers/go-digest v1.0.0 => github.com/opencontainers/go-digest v1.0.0
 ## explicit
 github.com/opencontainers/go-digest
-# github.com/opencontainers/go-digest => github.com/opencontainers/go-digest v1.0.0
 # github.com/opencontainers/image-spec v1.0.1 => github.com/opencontainers/image-spec v1.0.1
-# github.com/opencontainers/image-spec => github.com/opencontainers/image-spec v1.0.1
 github.com/opencontainers/image-spec/specs-go
 github.com/opencontainers/image-spec/specs-go/v1
 # github.com/opencontainers/runc v1.0.0-rc93 => github.com/opencontainers/runc v1.0.0-rc93
 ## explicit
-# github.com/opencontainers/runc => github.com/opencontainers/runc v1.0.0-rc93
 github.com/opencontainers/runc/libcontainer
 github.com/opencontainers/runc/libcontainer/apparmor
 github.com/opencontainers/runc/libcontainer/capabilities
@@ -909,36 +664,26 @@ github.com/opencontainers/runc/libcontainer/user
 github.com/opencontainers/runc/libcontainer/utils
 github.com/opencontainers/runc/types
 # github.com/opencontainers/runtime-spec v1.0.3-0.20200929063507-e6143ca7d51d => github.com/opencontainers/runtime-spec v1.0.3-0.20200929063507-e6143ca7d51d
-# github.com/opencontainers/runtime-spec => github.com/opencontainers/runtime-spec v1.0.3-0.20200929063507-e6143ca7d51d
 github.com/opencontainers/runtime-spec/specs-go
 # github.com/opencontainers/selinux v1.8.0 => github.com/opencontainers/selinux v1.8.0
 ## explicit
-# github.com/opencontainers/selinux => github.com/opencontainers/selinux v1.8.0
 github.com/opencontainers/selinux/go-selinux
 github.com/opencontainers/selinux/go-selinux/label
 github.com/opencontainers/selinux/pkg/pwalk
-# github.com/pascaldekloe/goe => github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c
 # github.com/pelletier/go-toml v1.2.0 => github.com/pelletier/go-toml v1.2.0
 github.com/pelletier/go-toml
-# github.com/pelletier/go-toml => github.com/pelletier/go-toml v1.2.0
 # github.com/peterbourgon/diskv v2.0.1+incompatible => github.com/peterbourgon/diskv v2.0.1+incompatible
 github.com/peterbourgon/diskv
-# github.com/peterbourgon/diskv => github.com/peterbourgon/diskv v2.0.1+incompatible
 # github.com/pkg/errors v0.9.1 => github.com/pkg/errors v0.9.1
 ## explicit
 github.com/pkg/errors
-# github.com/pkg/errors => github.com/pkg/errors v0.9.1
 # github.com/pmezard/go-difflib v1.0.0 => github.com/pmezard/go-difflib v1.0.0
 ## explicit
-# github.com/pmezard/go-difflib => github.com/pmezard/go-difflib v1.0.0
 github.com/pmezard/go-difflib/difflib
-# github.com/posener/complete => github.com/posener/complete v1.1.1
 # github.com/pquerna/cachecontrol v0.0.0-20171018203845-0dec1b30a021 => github.com/pquerna/cachecontrol v0.0.0-20171018203845-0dec1b30a021
 github.com/pquerna/cachecontrol
-# github.com/pquerna/cachecontrol => github.com/pquerna/cachecontrol v0.0.0-20171018203845-0dec1b30a021
 github.com/pquerna/cachecontrol/cacheobject
 # github.com/prometheus/client_golang v1.7.1 => github.com/prometheus/client_golang v1.7.1
-# github.com/prometheus/client_golang => github.com/prometheus/client_golang v1.7.1
 github.com/prometheus/client_golang/prometheus
 github.com/prometheus/client_golang/prometheus/internal
 github.com/prometheus/client_golang/prometheus/promhttp
@@ -946,133 +691,91 @@ github.com/prometheus/client_golang/prometheus/testutil
 github.com/prometheus/client_golang/prometheus/testutil/promlint
 # github.com/prometheus/client_model v0.2.0 => github.com/prometheus/client_model v0.2.0
 ## explicit
-# github.com/prometheus/client_model => github.com/prometheus/client_model v0.2.0
 github.com/prometheus/client_model/go
 # github.com/prometheus/common v0.10.0 => github.com/prometheus/common v0.10.0
 ## explicit
-# github.com/prometheus/common => github.com/prometheus/common v0.10.0
 github.com/prometheus/common/expfmt
 github.com/prometheus/common/internal/bitbucket.org/ww/goautoneg
 github.com/prometheus/common/model
 # github.com/prometheus/procfs v0.2.0 => github.com/prometheus/procfs v0.2.0
 github.com/prometheus/procfs
-# github.com/prometheus/procfs => github.com/prometheus/procfs v0.2.0
 github.com/prometheus/procfs/internal/fs
 github.com/prometheus/procfs/internal/util
 # github.com/quobyte/api v0.1.8 => github.com/quobyte/api v0.1.8
 ## explicit
 github.com/quobyte/api
-# github.com/quobyte/api => github.com/quobyte/api v0.1.8
-# github.com/remyoudompheng/bigfft => github.com/remyoudompheng/bigfft v0.0.0-20170806203942-52369c62f446
 # github.com/robfig/cron v1.1.0 => github.com/robfig/cron v1.1.0
 ## explicit
 github.com/robfig/cron
-# github.com/robfig/cron => github.com/robfig/cron v1.1.0
-# github.com/rogpeppe/fastuuid => github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af
-# github.com/rogpeppe/go-internal => github.com/rogpeppe/go-internal v1.3.0
 # github.com/rubiojr/go-vhd v0.0.0-20200706105327-02e210299021 => github.com/rubiojr/go-vhd v0.0.0-20200706105327-02e210299021
-# github.com/rubiojr/go-vhd => github.com/rubiojr/go-vhd v0.0.0-20200706105327-02e210299021
 github.com/rubiojr/go-vhd/vhd
 # github.com/russross/blackfriday v1.5.2 => github.com/russross/blackfriday v1.5.2
 github.com/russross/blackfriday
-# github.com/russross/blackfriday => github.com/russross/blackfriday v1.5.2
 # github.com/russross/blackfriday/v2 v2.0.1 => github.com/russross/blackfriday/v2 v2.0.1
 github.com/russross/blackfriday/v2
-# github.com/russross/blackfriday/v2 => github.com/russross/blackfriday/v2 v2.0.1
-# github.com/ryanuber/columnize => github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f
 # github.com/satori/go.uuid v1.2.0 => github.com/satori/go.uuid v1.2.0
 github.com/satori/go.uuid
-# github.com/satori/go.uuid => github.com/satori/go.uuid v1.2.0
-# github.com/sean-/seed => github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529
 # github.com/seccomp/libseccomp-golang v0.9.1 => github.com/seccomp/libseccomp-golang v0.9.1
 github.com/seccomp/libseccomp-golang
-# github.com/seccomp/libseccomp-golang => github.com/seccomp/libseccomp-golang v0.9.1
-# github.com/sergi/go-diff => github.com/sergi/go-diff v1.1.0
 # github.com/shurcooL/sanitized_anchor_name v1.0.0 => github.com/shurcooL/sanitized_anchor_name v1.0.0
 github.com/shurcooL/sanitized_anchor_name
-# github.com/shurcooL/sanitized_anchor_name => github.com/shurcooL/sanitized_anchor_name v1.0.0
 # github.com/sirupsen/logrus v1.7.0 => github.com/sirupsen/logrus v1.7.0
 github.com/sirupsen/logrus
-# github.com/sirupsen/logrus => github.com/sirupsen/logrus v1.7.0
-# github.com/smartystreets/assertions => github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d
-# github.com/smartystreets/goconvey => github.com/smartystreets/goconvey v1.6.4
 # github.com/soheilhy/cmux v0.1.4 => github.com/soheilhy/cmux v0.1.4
 github.com/soheilhy/cmux
-# github.com/soheilhy/cmux => github.com/soheilhy/cmux v0.1.4
 # github.com/spf13/afero v1.2.2 => github.com/spf13/afero v1.2.2
 ## explicit
 github.com/spf13/afero
-# github.com/spf13/afero => github.com/spf13/afero v1.2.2
 github.com/spf13/afero/mem
 # github.com/spf13/cast v1.3.0 => github.com/spf13/cast v1.3.0
 github.com/spf13/cast
-# github.com/spf13/cast => github.com/spf13/cast v1.3.0
 # github.com/spf13/cobra v1.1.1 => github.com/spf13/cobra v1.1.1
 ## explicit
 github.com/spf13/cobra
-# github.com/spf13/cobra => github.com/spf13/cobra v1.1.1
 github.com/spf13/cobra/doc
 # github.com/spf13/jwalterweatherman v1.1.0 => github.com/spf13/jwalterweatherman v1.1.0
 ## explicit
 github.com/spf13/jwalterweatherman
-# github.com/spf13/jwalterweatherman => github.com/spf13/jwalterweatherman v1.1.0
 # github.com/spf13/pflag v1.0.5 => github.com/spf13/pflag v1.0.5
 ## explicit
 github.com/spf13/pflag
-# github.com/spf13/pflag => github.com/spf13/pflag v1.0.5
 # github.com/spf13/viper v1.7.0 => github.com/spf13/viper v1.7.0
 ## explicit
 github.com/spf13/viper
-# github.com/spf13/viper => github.com/spf13/viper v1.7.0
-# github.com/stoewer/go-strcase => github.com/stoewer/go-strcase v1.2.0
 # github.com/storageos/go-api v2.2.0+incompatible => github.com/storageos/go-api v2.2.0+incompatible
 ## explicit
 github.com/storageos/go-api
-# github.com/storageos/go-api => github.com/storageos/go-api v2.2.0+incompatible
 github.com/storageos/go-api/netutil
 github.com/storageos/go-api/serror
 github.com/storageos/go-api/types
 # github.com/stretchr/objx v0.2.0 => github.com/stretchr/objx v0.2.0
 github.com/stretchr/objx
-# github.com/stretchr/objx => github.com/stretchr/objx v0.2.0
 # github.com/stretchr/testify v1.6.1 => github.com/stretchr/testify v1.6.1
 ## explicit
-# github.com/stretchr/testify => github.com/stretchr/testify v1.6.1
 github.com/stretchr/testify/assert
 github.com/stretchr/testify/mock
 github.com/stretchr/testify/require
 # github.com/subosito/gotenv v1.2.0 => github.com/subosito/gotenv v1.2.0
 github.com/subosito/gotenv
-# github.com/subosito/gotenv => github.com/subosito/gotenv v1.2.0
 # github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635 => github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635
-# github.com/syndtr/gocapability => github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635
 github.com/syndtr/gocapability/capability
 # github.com/thecodeteam/goscaleio v0.1.0 => github.com/thecodeteam/goscaleio v0.1.0
 ## explicit
 github.com/thecodeteam/goscaleio
-# github.com/thecodeteam/goscaleio => github.com/thecodeteam/goscaleio v0.1.0
 github.com/thecodeteam/goscaleio/types/v1
-# github.com/tidwall/pretty => github.com/tidwall/pretty v1.0.0
 # github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5 => github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5
-# github.com/tmc/grpc-websocket-proxy => github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5
 github.com/tmc/grpc-websocket-proxy/wsproxy
-# github.com/urfave/cli => github.com/urfave/cli v1.22.2
 # github.com/urfave/negroni v1.0.0 => github.com/urfave/negroni v1.0.0
 ## explicit
-# github.com/urfave/negroni => github.com/urfave/negroni v1.0.0
-# github.com/vektah/gqlparser => github.com/vektah/gqlparser v1.1.2
 # github.com/vishvananda/netlink v1.1.0 => github.com/vishvananda/netlink v1.1.0
 ## explicit
 github.com/vishvananda/netlink
-# github.com/vishvananda/netlink => github.com/vishvananda/netlink v1.1.0
 github.com/vishvananda/netlink/nl
 # github.com/vishvananda/netns v0.0.0-20200728191858-db3c7e526aae => github.com/vishvananda/netns v0.0.0-20200728191858-db3c7e526aae
 github.com/vishvananda/netns
-# github.com/vishvananda/netns => github.com/vishvananda/netns v0.0.0-20200728191858-db3c7e526aae
 # github.com/vmware/govmomi v0.20.3 => github.com/vmware/govmomi v0.20.3
 ## explicit
 github.com/vmware/govmomi
-# github.com/vmware/govmomi => github.com/vmware/govmomi v0.20.3
 github.com/vmware/govmomi/find
 github.com/vmware/govmomi/list
 github.com/vmware/govmomi/lookup
@@ -1107,20 +810,14 @@ github.com/vmware/govmomi/vim25/types
 github.com/vmware/govmomi/vim25/xml
 # github.com/willf/bitset v1.1.11 => github.com/willf/bitset v1.1.11
 github.com/willf/bitset
-# github.com/willf/bitset => github.com/willf/bitset v1.1.11
 # github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2 => github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2
 github.com/xiang90/probing
-# github.com/xiang90/probing => github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2
 # github.com/xlab/treeprint v0.0.0-20181112141820-a009c3971eca => github.com/xlab/treeprint v0.0.0-20181112141820-a009c3971eca
 github.com/xlab/treeprint
-# github.com/xlab/treeprint => github.com/xlab/treeprint v0.0.0-20181112141820-a009c3971eca
-# github.com/yuin/goldmark => github.com/yuin/goldmark v1.2.1
 # go.etcd.io/bbolt v1.3.5 => go.etcd.io/bbolt v1.3.5
 go.etcd.io/bbolt
-# go.etcd.io/bbolt => go.etcd.io/bbolt v1.3.5
 # go.etcd.io/etcd v0.5.0-alpha.5.0.20200910180754-dd1b699fc489 => go.etcd.io/etcd v0.5.0-alpha.5.0.20200910180754-dd1b699fc489
 ## explicit
-# go.etcd.io/etcd => go.etcd.io/etcd v0.5.0-alpha.5.0.20200910180754-dd1b699fc489
 go.etcd.io/etcd/auth
 go.etcd.io/etcd/auth/authpb
 go.etcd.io/etcd/client
@@ -1204,10 +901,8 @@ go.etcd.io/etcd/raft/tracker
 go.etcd.io/etcd/version
 go.etcd.io/etcd/wal
 go.etcd.io/etcd/wal/walpb
-# go.mongodb.org/mongo-driver => go.mongodb.org/mongo-driver v1.1.2
 # go.opencensus.io v0.22.3 => go.opencensus.io v0.22.3
 go.opencensus.io
-# go.opencensus.io => go.opencensus.io v0.22.3
 go.opencensus.io/internal
 go.opencensus.io/internal/tagencoding
 go.opencensus.io/metric/metricdata
@@ -1224,7 +919,6 @@ go.opencensus.io/trace/internal
 go.opencensus.io/trace/propagation
 go.opencensus.io/trace/tracestate
 # go.starlark.net v0.0.0-20200306205701-8dd3e2ee1dd5 => go.starlark.net v0.0.0-20200306205701-8dd3e2ee1dd5
-# go.starlark.net => go.starlark.net v0.0.0-20200306205701-8dd3e2ee1dd5
 go.starlark.net/internal/compile
 go.starlark.net/internal/spell
 go.starlark.net/resolve
@@ -1233,14 +927,10 @@ go.starlark.net/starlarkstruct
 go.starlark.net/syntax
 # go.uber.org/atomic v1.6.0 => go.uber.org/atomic v1.6.0
 go.uber.org/atomic
-# go.uber.org/atomic => go.uber.org/atomic v1.6.0
 # go.uber.org/multierr v1.5.0 => go.uber.org/multierr v1.5.0
 go.uber.org/multierr
-# go.uber.org/multierr => go.uber.org/multierr v1.5.0
-# go.uber.org/tools => go.uber.org/tools v0.0.0-20190618225709-2cfd321de3ee
 # go.uber.org/zap v1.16.0 => go.uber.org/zap v1.16.0
 go.uber.org/zap
-# go.uber.org/zap => go.uber.org/zap v1.16.0
 go.uber.org/zap/buffer
 go.uber.org/zap/internal/bufferpool
 go.uber.org/zap/internal/color
@@ -1248,7 +938,6 @@ go.uber.org/zap/internal/exit
 go.uber.org/zap/zapcore
 # golang.org/x/crypto v0.0.0-20210220033148-5ea612d1eb83 => golang.org/x/crypto v0.0.0-20210220033148-5ea612d1eb83
 ## explicit
-# golang.org/x/crypto => golang.org/x/crypto v0.0.0-20210220033148-5ea612d1eb83
 golang.org/x/crypto/bcrypt
 golang.org/x/crypto/blowfish
 golang.org/x/crypto/chacha20
@@ -1268,17 +957,11 @@ golang.org/x/crypto/ssh
 golang.org/x/crypto/ssh/internal/bcrypt_pbkdf
 # golang.org/x/exp v0.0.0-20210220032938-85be41e4509f => golang.org/x/exp v0.0.0-20210220032938-85be41e4509f
 ## explicit
-# golang.org/x/exp => golang.org/x/exp v0.0.0-20210220032938-85be41e4509f
-# golang.org/x/image => golang.org/x/image v0.0.0-20190802002840-cff245a6509b
-# golang.org/x/lint => golang.org/x/lint v0.0.0-20200302205851-738671d3881b
-# golang.org/x/mobile => golang.org/x/mobile v0.0.0-20201217150744-e6ae53a27f4f
 # golang.org/x/mod v0.3.1-0.20200828183125-ce943fd02449 => golang.org/x/mod v0.3.1-0.20200828183125-ce943fd02449
-# golang.org/x/mod => golang.org/x/mod v0.3.1-0.20200828183125-ce943fd02449
 golang.org/x/mod/module
 golang.org/x/mod/semver
 # golang.org/x/net v0.0.0-20210224082022-3d97a244fca7 => golang.org/x/net v0.0.0-20210224082022-3d97a244fca7
 ## explicit
-# golang.org/x/net => golang.org/x/net v0.0.0-20210224082022-3d97a244fca7
 golang.org/x/net/bpf
 golang.org/x/net/context
 golang.org/x/net/context/ctxhttp
@@ -1301,17 +984,14 @@ golang.org/x/net/websocket
 # golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d => golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d
 ## explicit
 golang.org/x/oauth2
-# golang.org/x/oauth2 => golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d
 golang.org/x/oauth2/google
 golang.org/x/oauth2/internal
 golang.org/x/oauth2/jws
 golang.org/x/oauth2/jwt
 # golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9 => golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9
-# golang.org/x/sync => golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9
 golang.org/x/sync/singleflight
 # golang.org/x/sys v0.0.0-20210225134936-a50acf3fe073 => golang.org/x/sys v0.0.0-20210225134936-a50acf3fe073
 ## explicit
-# golang.org/x/sys => golang.org/x/sys v0.0.0-20210225134936-a50acf3fe073
 golang.org/x/sys/cpu
 golang.org/x/sys/execabs
 golang.org/x/sys/internal/unsafeheader
@@ -1324,9 +1004,7 @@ golang.org/x/sys/windows/svc/mgr
 # golang.org/x/term v0.0.0-20210220032956-6a3ed077a48d => golang.org/x/term v0.0.0-20210220032956-6a3ed077a48d
 ## explicit
 golang.org/x/term
-# golang.org/x/term => golang.org/x/term v0.0.0-20210220032956-6a3ed077a48d
 # golang.org/x/text v0.3.4 => golang.org/x/text v0.3.4
-# golang.org/x/text => golang.org/x/text v0.3.4
 golang.org/x/text/encoding
 golang.org/x/text/encoding/charmap
 golang.org/x/text/encoding/htmlindex
@@ -1350,11 +1028,9 @@ golang.org/x/text/unicode/norm
 golang.org/x/text/width
 # golang.org/x/time v0.0.0-20210220033141-f8bda1e9f3ba => golang.org/x/time v0.0.0-20210220033141-f8bda1e9f3ba
 ## explicit
-# golang.org/x/time => golang.org/x/time v0.0.0-20210220033141-f8bda1e9f3ba
 golang.org/x/time/rate
 # golang.org/x/tools v0.1.0 => golang.org/x/tools v0.1.0
 ## explicit
-# golang.org/x/tools => golang.org/x/tools v0.1.0
 golang.org/x/tools/benchmark/parse
 golang.org/x/tools/container/intsets
 golang.org/x/tools/go/ast/astutil
@@ -1375,11 +1051,9 @@ golang.org/x/tools/internal/packagesinternal
 golang.org/x/tools/internal/typesinternal
 # golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 => golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1
 golang.org/x/xerrors
-# golang.org/x/xerrors => golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1
 golang.org/x/xerrors/internal
 # gonum.org/v1/gonum v0.6.2 => gonum.org/v1/gonum v0.6.2
 ## explicit
-# gonum.org/v1/gonum => gonum.org/v1/gonum v0.6.2
 gonum.org/v1/gonum/blas
 gonum.org/v1/gonum/blas/blas64
 gonum.org/v1/gonum/blas/cblas128
@@ -1412,11 +1086,8 @@ gonum.org/v1/gonum/lapack/lapack64
 gonum.org/v1/gonum/mat
 # gonum.org/v1/netlib v0.0.0-20190331212654-76723241ea4e => gonum.org/v1/netlib v0.0.0-20190331212654-76723241ea4e
 ## explicit
-# gonum.org/v1/netlib => gonum.org/v1/netlib v0.0.0-20190331212654-76723241ea4e
-# gonum.org/v1/plot => gonum.org/v1/plot v0.0.0-20190515093506-e2840ee46a6b
 # google.golang.org/api v0.20.0 => google.golang.org/api v0.20.0
 ## explicit
-# google.golang.org/api => google.golang.org/api v0.20.0
 google.golang.org/api/compute/v0.alpha
 google.golang.org/api/compute/v0.beta
 google.golang.org/api/compute/v1
@@ -1436,7 +1107,6 @@ google.golang.org/api/transport/http/internal/propagation
 # google.golang.org/appengine v1.6.5 => google.golang.org/appengine v1.6.5
 ## explicit
 google.golang.org/appengine
-# google.golang.org/appengine => google.golang.org/appengine v1.6.5
 google.golang.org/appengine/internal
 google.golang.org/appengine/internal/app_identity
 google.golang.org/appengine/internal/base
@@ -1447,14 +1117,12 @@ google.golang.org/appengine/internal/remote_api
 google.golang.org/appengine/internal/urlfetch
 google.golang.org/appengine/urlfetch
 # google.golang.org/genproto v0.0.0-20201110150050-8816d57aaa9a => google.golang.org/genproto v0.0.0-20201110150050-8816d57aaa9a
-# google.golang.org/genproto => google.golang.org/genproto v0.0.0-20201110150050-8816d57aaa9a
 google.golang.org/genproto/googleapis/api/httpbody
 google.golang.org/genproto/googleapis/rpc/status
 google.golang.org/genproto/protobuf/field_mask
 # google.golang.org/grpc v1.27.1 => google.golang.org/grpc v1.27.1
 ## explicit
 google.golang.org/grpc
-# google.golang.org/grpc => google.golang.org/grpc v1.27.1
 google.golang.org/grpc/attributes
 google.golang.org/grpc/backoff
 google.golang.org/grpc/balancer
@@ -1495,7 +1163,6 @@ google.golang.org/grpc/stats
 google.golang.org/grpc/status
 google.golang.org/grpc/tap
 # google.golang.org/protobuf v1.25.0 => google.golang.org/protobuf v1.25.0
-# google.golang.org/protobuf => google.golang.org/protobuf v1.25.0
 google.golang.org/protobuf/encoding/protojson
 google.golang.org/protobuf/encoding/prototext
 google.golang.org/protobuf/encoding/protowire
@@ -1531,57 +1198,37 @@ google.golang.org/protobuf/types/known/fieldmaskpb
 google.golang.org/protobuf/types/known/timestamppb
 google.golang.org/protobuf/types/known/wrapperspb
 google.golang.org/protobuf/types/pluginpb
-# gopkg.in/alecthomas/kingpin.v2 => gopkg.in/alecthomas/kingpin.v2 v2.2.6
-# gopkg.in/check.v1 => gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f
-# gopkg.in/cheggaaa/pb.v1 => gopkg.in/cheggaaa/pb.v1 v1.0.25
-# gopkg.in/errgo.v2 => gopkg.in/errgo.v2 v2.1.0
 # gopkg.in/fsnotify.v1 v1.4.7 => gopkg.in/fsnotify.v1 v1.4.7
 gopkg.in/fsnotify.v1
-# gopkg.in/fsnotify.v1 => gopkg.in/fsnotify.v1 v1.4.7
 # gopkg.in/gcfg.v1 v1.2.0 => gopkg.in/gcfg.v1 v1.2.0
 ## explicit
 gopkg.in/gcfg.v1
-# gopkg.in/gcfg.v1 => gopkg.in/gcfg.v1 v1.2.0
 gopkg.in/gcfg.v1/scanner
 gopkg.in/gcfg.v1/token
 gopkg.in/gcfg.v1/types
 # gopkg.in/inf.v0 v0.9.1 => gopkg.in/inf.v0 v0.9.1
 gopkg.in/inf.v0
-# gopkg.in/inf.v0 => gopkg.in/inf.v0 v0.9.1
 # gopkg.in/ini.v1 v1.51.0 => gopkg.in/ini.v1 v1.51.0
 gopkg.in/ini.v1
-# gopkg.in/ini.v1 => gopkg.in/ini.v1 v1.51.0
-# gopkg.in/mcuadros/go-syslog.v2 => gopkg.in/mcuadros/go-syslog.v2 v2.2.1
 # gopkg.in/natefinch/lumberjack.v2 v2.0.0 => gopkg.in/natefinch/lumberjack.v2 v2.0.0
 gopkg.in/natefinch/lumberjack.v2
-# gopkg.in/natefinch/lumberjack.v2 => gopkg.in/natefinch/lumberjack.v2 v2.0.0
-# gopkg.in/resty.v1 => gopkg.in/resty.v1 v1.12.0
 # gopkg.in/square/go-jose.v2 v2.2.2 => gopkg.in/square/go-jose.v2 v2.2.2
 ## explicit
 gopkg.in/square/go-jose.v2
-# gopkg.in/square/go-jose.v2 => gopkg.in/square/go-jose.v2 v2.2.2
 gopkg.in/square/go-jose.v2/cipher
 gopkg.in/square/go-jose.v2/json
 gopkg.in/square/go-jose.v2/jwt
 # gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 => gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7
 gopkg.in/tomb.v1
-# gopkg.in/tomb.v1 => gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7
 # gopkg.in/warnings.v0 v0.1.1 => gopkg.in/warnings.v0 v0.1.1
 gopkg.in/warnings.v0
-# gopkg.in/warnings.v0 => gopkg.in/warnings.v0 v0.1.1
 # gopkg.in/yaml.v2 v2.4.0 => gopkg.in/yaml.v2 v2.4.0
 ## explicit
 gopkg.in/yaml.v2
-# gopkg.in/yaml.v2 => gopkg.in/yaml.v2 v2.4.0
 # gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776 => gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776
 gopkg.in/yaml.v3
-# gopkg.in/yaml.v3 => gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776
-# gotest.tools => gotest.tools v2.2.0+incompatible
-# gotest.tools/v3 => gotest.tools/v3 v3.0.3
-# honnef.co/go/tools => honnef.co/go/tools v0.0.1-2020.1.3
 # k8s.io/api v0.0.0 => ./staging/src/k8s.io/api
 ## explicit
-# k8s.io/api => ./staging/src/k8s.io/api
 k8s.io/api/admission/v1
 k8s.io/api/admission/v1beta1
 k8s.io/api/admissionregistration/v1
@@ -1630,7 +1277,6 @@ k8s.io/api/storage/v1alpha1
 k8s.io/api/storage/v1beta1
 # k8s.io/apiextensions-apiserver v0.0.0 => ./staging/src/k8s.io/apiextensions-apiserver
 ## explicit
-# k8s.io/apiextensions-apiserver => ./staging/src/k8s.io/apiextensions-apiserver
 k8s.io/apiextensions-apiserver/pkg/apihelpers
 k8s.io/apiextensions-apiserver/pkg/apis/apiextensions
 k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/install
@@ -1675,7 +1321,6 @@ k8s.io/apiextensions-apiserver/test/integration
 k8s.io/apiextensions-apiserver/test/integration/fixtures
 # k8s.io/apimachinery v0.0.0 => ./staging/src/k8s.io/apimachinery
 ## explicit
-# k8s.io/apimachinery => ./staging/src/k8s.io/apimachinery
 k8s.io/apimachinery/pkg/api/apitesting
 k8s.io/apimachinery/pkg/api/apitesting/fuzzer
 k8s.io/apimachinery/pkg/api/apitesting/naming
@@ -1748,7 +1393,6 @@ k8s.io/apimachinery/third_party/forked/golang/netutil
 k8s.io/apimachinery/third_party/forked/golang/reflect
 # k8s.io/apiserver v0.0.0 => ./staging/src/k8s.io/apiserver
 ## explicit
-# k8s.io/apiserver => ./staging/src/k8s.io/apiserver
 k8s.io/apiserver/pkg/admission
 k8s.io/apiserver/pkg/admission/configuration
 k8s.io/apiserver/pkg/admission/initializer
@@ -1899,13 +1543,11 @@ k8s.io/apiserver/plugin/pkg/authenticator/token/webhook
 k8s.io/apiserver/plugin/pkg/authorizer/webhook
 # k8s.io/cli-runtime v0.0.0 => ./staging/src/k8s.io/cli-runtime
 ## explicit
-# k8s.io/cli-runtime => ./staging/src/k8s.io/cli-runtime
 k8s.io/cli-runtime/pkg/genericclioptions
 k8s.io/cli-runtime/pkg/printers
 k8s.io/cli-runtime/pkg/resource
 # k8s.io/client-go v0.0.0 => ./staging/src/k8s.io/client-go
 ## explicit
-# k8s.io/client-go => ./staging/src/k8s.io/client-go
 k8s.io/client-go/applyconfigurations
 k8s.io/client-go/applyconfigurations/admissionregistration/v1
 k8s.io/client-go/applyconfigurations/admissionregistration/v1beta1
@@ -2206,7 +1848,6 @@ k8s.io/client-go/util/workqueue
 # k8s.io/cloud-provider v0.0.0 => ./staging/src/k8s.io/cloud-provider
 ## explicit
 k8s.io/cloud-provider
-# k8s.io/cloud-provider => ./staging/src/k8s.io/cloud-provider
 k8s.io/cloud-provider/api
 k8s.io/cloud-provider/app
 k8s.io/cloud-provider/app/config
@@ -2230,7 +1871,6 @@ k8s.io/cloud-provider/volume/errors
 k8s.io/cloud-provider/volume/helpers
 # k8s.io/cluster-bootstrap v0.0.0 => ./staging/src/k8s.io/cluster-bootstrap
 ## explicit
-# k8s.io/cluster-bootstrap => ./staging/src/k8s.io/cluster-bootstrap
 k8s.io/cluster-bootstrap/token/api
 k8s.io/cluster-bootstrap/token/jws
 k8s.io/cluster-bootstrap/token/util
@@ -2238,7 +1878,6 @@ k8s.io/cluster-bootstrap/util/secrets
 k8s.io/cluster-bootstrap/util/tokens
 # k8s.io/code-generator v0.0.0 => ./staging/src/k8s.io/code-generator
 ## explicit
-# k8s.io/code-generator => ./staging/src/k8s.io/code-generator
 k8s.io/code-generator/cmd/go-to-protobuf
 k8s.io/code-generator/cmd/go-to-protobuf/protobuf
 k8s.io/code-generator/cmd/go-to-protobuf/protoc-gen-gogo
@@ -2246,7 +1885,6 @@ k8s.io/code-generator/pkg/util
 k8s.io/code-generator/third_party/forked/golang/reflect
 # k8s.io/component-base v0.0.0 => ./staging/src/k8s.io/component-base
 ## explicit
-# k8s.io/component-base => ./staging/src/k8s.io/component-base
 k8s.io/component-base/cli/flag
 k8s.io/component-base/cli/globalflag
 k8s.io/component-base/codec
@@ -2277,7 +1915,6 @@ k8s.io/component-base/version
 k8s.io/component-base/version/verflag
 # k8s.io/component-helpers v0.0.0 => ./staging/src/k8s.io/component-helpers
 ## explicit
-# k8s.io/component-helpers => ./staging/src/k8s.io/component-helpers
 k8s.io/component-helpers/apimachinery/lease
 k8s.io/component-helpers/apps/poddisruptionbudget
 k8s.io/component-helpers/auth/rbac/reconciliation
@@ -2288,7 +1925,6 @@ k8s.io/component-helpers/scheduling/corev1/nodeaffinity
 k8s.io/component-helpers/storage/volume
 # k8s.io/controller-manager v0.0.0 => ./staging/src/k8s.io/controller-manager
 ## explicit
-# k8s.io/controller-manager => ./staging/src/k8s.io/controller-manager
 k8s.io/controller-manager/app
 k8s.io/controller-manager/config
 k8s.io/controller-manager/config/v1alpha1
@@ -2302,18 +1938,15 @@ k8s.io/controller-manager/pkg/leadermigration/config
 k8s.io/controller-manager/pkg/leadermigration/options
 # k8s.io/cri-api v0.0.0 => ./staging/src/k8s.io/cri-api
 ## explicit
-# k8s.io/cri-api => ./staging/src/k8s.io/cri-api
 k8s.io/cri-api/pkg/apis
 k8s.io/cri-api/pkg/apis/runtime/v1alpha2
 k8s.io/cri-api/pkg/apis/testing
 # k8s.io/csi-translation-lib v0.0.0 => ./staging/src/k8s.io/csi-translation-lib
 ## explicit
 k8s.io/csi-translation-lib
-# k8s.io/csi-translation-lib => ./staging/src/k8s.io/csi-translation-lib
 k8s.io/csi-translation-lib/plugins
 # k8s.io/gengo v0.0.0-20201214224949-b6c5ce23f027 => k8s.io/gengo v0.0.0-20201214224949-b6c5ce23f027
 ## explicit
-# k8s.io/gengo => k8s.io/gengo v0.0.0-20201214224949-b6c5ce23f027
 k8s.io/gengo/args
 k8s.io/gengo/examples/deepcopy-gen/generators
 k8s.io/gengo/examples/defaulter-gen/generators
@@ -2326,15 +1959,12 @@ k8s.io/gengo/parser
 k8s.io/gengo/types
 # k8s.io/heapster v1.2.0-beta.1 => k8s.io/heapster v1.2.0-beta.1
 ## explicit
-# k8s.io/heapster => k8s.io/heapster v1.2.0-beta.1
 k8s.io/heapster/metrics/api/v1/types
 # k8s.io/klog/v2 v2.8.0 => k8s.io/klog/v2 v2.8.0
 ## explicit
 k8s.io/klog/v2
-# k8s.io/klog/v2 => k8s.io/klog/v2 v2.8.0
 # k8s.io/kube-aggregator v0.0.0 => ./staging/src/k8s.io/kube-aggregator
 ## explicit
-# k8s.io/kube-aggregator => ./staging/src/k8s.io/kube-aggregator
 k8s.io/kube-aggregator/pkg/apis/apiregistration
 k8s.io/kube-aggregator/pkg/apis/apiregistration/install
 k8s.io/kube-aggregator/pkg/apis/apiregistration/v1
@@ -2364,11 +1994,9 @@ k8s.io/kube-aggregator/pkg/registry/apiservice/etcd
 k8s.io/kube-aggregator/pkg/registry/apiservice/rest
 # k8s.io/kube-controller-manager v0.0.0 => ./staging/src/k8s.io/kube-controller-manager
 ## explicit
-# k8s.io/kube-controller-manager => ./staging/src/k8s.io/kube-controller-manager
 k8s.io/kube-controller-manager/config/v1alpha1
 # k8s.io/kube-openapi v0.0.0-20210421082810-95288971da7e => k8s.io/kube-openapi v0.0.0-20210421082810-95288971da7e
 ## explicit
-# k8s.io/kube-openapi => k8s.io/kube-openapi v0.0.0-20210421082810-95288971da7e
 k8s.io/kube-openapi/cmd/openapi-gen
 k8s.io/kube-openapi/cmd/openapi-gen/args
 k8s.io/kube-openapi/pkg/aggregator
@@ -2390,17 +2018,14 @@ k8s.io/kube-openapi/pkg/validation/strfmt/bson
 k8s.io/kube-openapi/pkg/validation/validate
 # k8s.io/kube-proxy v0.0.0 => ./staging/src/k8s.io/kube-proxy
 ## explicit
-# k8s.io/kube-proxy => ./staging/src/k8s.io/kube-proxy
 k8s.io/kube-proxy/config/v1alpha1
 # k8s.io/kube-scheduler v0.0.0 => ./staging/src/k8s.io/kube-scheduler
 ## explicit
-# k8s.io/kube-scheduler => ./staging/src/k8s.io/kube-scheduler
 k8s.io/kube-scheduler/config/v1
 k8s.io/kube-scheduler/config/v1beta1
 k8s.io/kube-scheduler/extender/v1
 # k8s.io/kubectl v0.0.0 => ./staging/src/k8s.io/kubectl
 ## explicit
-# k8s.io/kubectl => ./staging/src/k8s.io/kubectl
 k8s.io/kubectl/pkg/apps
 k8s.io/kubectl/pkg/cmd
 k8s.io/kubectl/pkg/cmd/annotate
@@ -2484,7 +2109,6 @@ k8s.io/kubectl/pkg/util/term
 k8s.io/kubectl/pkg/validation
 # k8s.io/kubelet v0.0.0 => ./staging/src/k8s.io/kubelet
 ## explicit
-# k8s.io/kubelet => ./staging/src/k8s.io/kubelet
 k8s.io/kubelet/config/v1alpha1
 k8s.io/kubelet/config/v1beta1
 k8s.io/kubelet/pkg/apis
@@ -2498,7 +2122,6 @@ k8s.io/kubelet/pkg/apis/podresources/v1alpha1
 k8s.io/kubelet/pkg/apis/stats/v1alpha1
 # k8s.io/legacy-cloud-providers v0.0.0 => ./staging/src/k8s.io/legacy-cloud-providers
 ## explicit
-# k8s.io/legacy-cloud-providers => ./staging/src/k8s.io/legacy-cloud-providers
 k8s.io/legacy-cloud-providers/aws
 k8s.io/legacy-cloud-providers/azure
 k8s.io/legacy-cloud-providers/azure/auth
@@ -2544,7 +2167,6 @@ k8s.io/legacy-cloud-providers/vsphere/vclib
 k8s.io/legacy-cloud-providers/vsphere/vclib/diskmanagers
 # k8s.io/metrics v0.0.0 => ./staging/src/k8s.io/metrics
 ## explicit
-# k8s.io/metrics => ./staging/src/k8s.io/metrics
 k8s.io/metrics/pkg/apis/custom_metrics
 k8s.io/metrics/pkg/apis/custom_metrics/v1beta1
 k8s.io/metrics/pkg/apis/custom_metrics/v1beta2
@@ -2568,10 +2190,8 @@ k8s.io/metrics/pkg/client/external_metrics/fake
 # k8s.io/mount-utils v0.0.0 => ./staging/src/k8s.io/mount-utils
 ## explicit
 k8s.io/mount-utils
-# k8s.io/mount-utils => ./staging/src/k8s.io/mount-utils
 # k8s.io/sample-apiserver v0.0.0 => ./staging/src/k8s.io/sample-apiserver
 ## explicit
-# k8s.io/sample-apiserver => ./staging/src/k8s.io/sample-apiserver
 k8s.io/sample-apiserver/pkg/admission/plugin/banflunder
 k8s.io/sample-apiserver/pkg/admission/wardleinitializer
 k8s.io/sample-apiserver/pkg/apis/wardle
@@ -2596,15 +2216,11 @@ k8s.io/sample-apiserver/pkg/generated/openapi
 k8s.io/sample-apiserver/pkg/registry
 k8s.io/sample-apiserver/pkg/registry/wardle/fischer
 k8s.io/sample-apiserver/pkg/registry/wardle/flunder
-# k8s.io/sample-cli-plugin => ./staging/src/k8s.io/sample-cli-plugin
-# k8s.io/sample-controller => ./staging/src/k8s.io/sample-controller
 # k8s.io/system-validators v1.4.0 => k8s.io/system-validators v1.4.0
 ## explicit
-# k8s.io/system-validators => k8s.io/system-validators v1.4.0
 k8s.io/system-validators/validators
 # k8s.io/utils v0.0.0-20201110183641-67b214c5f920 => k8s.io/utils v0.0.0-20201110183641-67b214c5f920
 ## explicit
-# k8s.io/utils => k8s.io/utils v0.0.0-20201110183641-67b214c5f920
 k8s.io/utils/buffer
 k8s.io/utils/clock
 k8s.io/utils/exec
@@ -2621,18 +2237,10 @@ k8s.io/utils/path
 k8s.io/utils/pointer
 k8s.io/utils/strings
 k8s.io/utils/trace
-# modernc.org/cc => modernc.org/cc v1.0.0
-# modernc.org/golex => modernc.org/golex v1.0.0
-# modernc.org/mathutil => modernc.org/mathutil v1.0.0
-# modernc.org/strutil => modernc.org/strutil v1.0.0
-# modernc.org/xc => modernc.org/xc v1.0.0
-# rsc.io/pdf => rsc.io/pdf v0.1.1
 # sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.15 => sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.15
-# sigs.k8s.io/apiserver-network-proxy/konnectivity-client => sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.15
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client/pkg/client
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client/proto/client
 # sigs.k8s.io/kustomize/api v0.8.8 => sigs.k8s.io/kustomize/api v0.8.8
-# sigs.k8s.io/kustomize/api => sigs.k8s.io/kustomize/api v0.8.8
 sigs.k8s.io/kustomize/api/builtins
 sigs.k8s.io/kustomize/api/filesys
 sigs.k8s.io/kustomize/api/filters/annotations
@@ -2676,12 +2284,9 @@ sigs.k8s.io/kustomize/api/resid
 sigs.k8s.io/kustomize/api/resmap
 sigs.k8s.io/kustomize/api/resource
 sigs.k8s.io/kustomize/api/types
-# sigs.k8s.io/kustomize/cmd/config => sigs.k8s.io/kustomize/cmd/config v0.9.10
 # sigs.k8s.io/kustomize/kustomize/v4 v4.1.2 => sigs.k8s.io/kustomize/kustomize/v4 v4.1.2
-# sigs.k8s.io/kustomize/kustomize/v4 => sigs.k8s.io/kustomize/kustomize/v4 v4.1.2
 sigs.k8s.io/kustomize/kustomize/v4/commands/build
 # sigs.k8s.io/kustomize/kyaml v0.10.17 => sigs.k8s.io/kustomize/kyaml v0.10.17
-# sigs.k8s.io/kustomize/kyaml => sigs.k8s.io/kustomize/kyaml v0.10.17
 sigs.k8s.io/kustomize/kyaml/comments
 sigs.k8s.io/kustomize/kyaml/errors
 sigs.k8s.io/kustomize/kyaml/ext
@@ -2713,7 +2318,6 @@ sigs.k8s.io/kustomize/kyaml/yaml/schema
 sigs.k8s.io/kustomize/kyaml/yaml/walk
 # sigs.k8s.io/structured-merge-diff/v4 v4.1.1 => sigs.k8s.io/structured-merge-diff/v4 v4.1.1
 ## explicit
-# sigs.k8s.io/structured-merge-diff/v4 => sigs.k8s.io/structured-merge-diff/v4 v4.1.1
 sigs.k8s.io/structured-merge-diff/v4/fieldpath
 sigs.k8s.io/structured-merge-diff/v4/merge
 sigs.k8s.io/structured-merge-diff/v4/schema
@@ -2722,4 +2326,400 @@ sigs.k8s.io/structured-merge-diff/v4/value
 # sigs.k8s.io/yaml v1.2.0 => sigs.k8s.io/yaml v1.2.0
 ## explicit
 sigs.k8s.io/yaml
+# bitbucket.org/bertimus9/systemstat => bitbucket.org/bertimus9/systemstat v0.0.0-20180207000608-0eeff89b0690
+# cloud.google.com/go => cloud.google.com/go v0.54.0
+# cloud.google.com/go/bigquery => cloud.google.com/go/bigquery v1.4.0
+# cloud.google.com/go/datastore => cloud.google.com/go/datastore v1.1.0
+# cloud.google.com/go/firestore => cloud.google.com/go/firestore v1.1.0
+# cloud.google.com/go/pubsub => cloud.google.com/go/pubsub v1.2.0
+# cloud.google.com/go/storage => cloud.google.com/go/storage v1.6.0
+# dmitri.shuralyov.com/gpu/mtl => dmitri.shuralyov.com/gpu/mtl v0.0.0-20201218220906-28db891af037
+# github.com/Azure/azure-sdk-for-go => github.com/Azure/azure-sdk-for-go v43.0.0+incompatible
+# github.com/Azure/go-ansiterm => github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78
+# github.com/Azure/go-autorest => github.com/Azure/go-autorest v14.2.0+incompatible
+# github.com/Azure/go-autorest/autorest => github.com/Azure/go-autorest/autorest v0.11.12
+# github.com/Azure/go-autorest/autorest/adal => github.com/Azure/go-autorest/autorest/adal v0.9.5
+# github.com/Azure/go-autorest/autorest/date => github.com/Azure/go-autorest/autorest/date v0.3.0
+# github.com/Azure/go-autorest/autorest/mocks => github.com/Azure/go-autorest/autorest/mocks v0.4.1
+# github.com/Azure/go-autorest/autorest/to => github.com/Azure/go-autorest/autorest/to v0.2.0
+# github.com/Azure/go-autorest/autorest/validation => github.com/Azure/go-autorest/autorest/validation v0.1.0
+# github.com/Azure/go-autorest/logger => github.com/Azure/go-autorest/logger v0.2.0
+# github.com/Azure/go-autorest/tracing => github.com/Azure/go-autorest/tracing v0.6.0
+# github.com/BurntSushi/toml => github.com/BurntSushi/toml v0.3.1
+# github.com/BurntSushi/xgb => github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802
+# github.com/GoogleCloudPlatform/k8s-cloud-provider => github.com/GoogleCloudPlatform/k8s-cloud-provider v0.0.0-20200415212048-7901bc822317
+# github.com/JeffAshton/win_pdh => github.com/JeffAshton/win_pdh v0.0.0-20161109143554-76bb4ee9f0ab
+# github.com/MakeNowJust/heredoc => github.com/MakeNowJust/heredoc v0.0.0-20170808103936-bb23615498cd
+# github.com/Microsoft/go-winio => github.com/Microsoft/go-winio v0.4.15
+# github.com/Microsoft/hcsshim => github.com/Microsoft/hcsshim v0.8.10-0.20200715222032-5eafd1556990
+# github.com/NYTimes/gziphandler => github.com/NYTimes/gziphandler v1.1.1
+# github.com/PuerkitoBio/purell => github.com/PuerkitoBio/purell v1.1.1
+# github.com/PuerkitoBio/urlesc => github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578
+# github.com/agnivade/levenshtein => github.com/agnivade/levenshtein v1.0.1
+# github.com/ajstarks/svgo => github.com/ajstarks/svgo v0.0.0-20180226025133-644b8db467af
+# github.com/alecthomas/template => github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751
+# github.com/alecthomas/units => github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4
+# github.com/andreyvit/diff => github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883
+# github.com/armon/circbuf => github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e
+# github.com/armon/go-metrics => github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da
+# github.com/armon/go-radix => github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310
+# github.com/asaskevich/govalidator => github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a
+# github.com/auth0/go-jwt-middleware => github.com/auth0/go-jwt-middleware v0.0.0-20170425171159-5493cabe49f7
+# github.com/aws/aws-sdk-go => github.com/aws/aws-sdk-go v1.35.24
+# github.com/beorn7/perks => github.com/beorn7/perks v1.0.1
+# github.com/bgentry/speakeasy => github.com/bgentry/speakeasy v0.1.0
+# github.com/bifurcation/mint => github.com/bifurcation/mint v0.0.0-20180715133206-93c51c6ce115
+# github.com/bketelsen/crypt => github.com/bketelsen/crypt v0.0.3-0.20200106085610-5cbc8cc4026c
+# github.com/blang/semver => github.com/blang/semver v3.5.1+incompatible
+# github.com/boltdb/bolt => github.com/boltdb/bolt v1.3.1
+# github.com/caddyserver/caddy => github.com/caddyserver/caddy v1.0.3
+# github.com/cenkalti/backoff => github.com/cenkalti/backoff v2.1.1+incompatible
+# github.com/census-instrumentation/opencensus-proto => github.com/census-instrumentation/opencensus-proto v0.2.1
+# github.com/cespare/xxhash/v2 => github.com/cespare/xxhash/v2 v2.1.1
+# github.com/chai2010/gettext-go => github.com/chai2010/gettext-go v0.0.0-20160711120539-c6fed771bfd5
+# github.com/checkpoint-restore/go-criu/v4 => github.com/checkpoint-restore/go-criu/v4 v4.1.0
+# github.com/cheekybits/genny => github.com/cheekybits/genny v0.0.0-20170328200008-9127e812e1e9
+# github.com/chzyer/logex => github.com/chzyer/logex v1.1.10
+# github.com/chzyer/readline => github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e
+# github.com/chzyer/test => github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1
+# github.com/cilium/ebpf => github.com/cilium/ebpf v0.2.0
+# github.com/clusterhq/flocker-go => github.com/clusterhq/flocker-go v0.0.0-20160920122132-2b8b7259d313
+# github.com/cockroachdb/datadriven => github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa
+# github.com/container-storage-interface/spec => github.com/container-storage-interface/spec v1.3.0
+# github.com/containerd/cgroups => github.com/containerd/cgroups v0.0.0-20200531161412-0dbf7f05ba59
+# github.com/containerd/console => github.com/containerd/console v1.0.1
+# github.com/containerd/containerd => github.com/containerd/containerd v1.4.4
+# github.com/containerd/continuity => github.com/containerd/continuity v0.0.0-20190426062206-aaeac12a7ffc
+# github.com/containerd/fifo => github.com/containerd/fifo v0.0.0-20190226154929-a9fb20d87448
+# github.com/containerd/go-runc => github.com/containerd/go-runc v0.0.0-20180907222934-5a6d9f37cfa3
+# github.com/containerd/ttrpc => github.com/containerd/ttrpc v1.0.2
+# github.com/containerd/typeurl => github.com/containerd/typeurl v1.0.1
+# github.com/containernetworking/cni => github.com/containernetworking/cni v0.8.0
+# github.com/coredns/corefile-migration => github.com/coredns/corefile-migration v1.0.11
+# github.com/coreos/bbolt => github.com/coreos/bbolt v1.3.2
+# github.com/coreos/etcd => github.com/coreos/etcd v3.3.13+incompatible
+# github.com/coreos/go-oidc => github.com/coreos/go-oidc v2.1.0+incompatible
+# github.com/coreos/go-semver => github.com/coreos/go-semver v0.3.0
+# github.com/coreos/go-systemd => github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e
+# github.com/coreos/go-systemd/v22 => github.com/coreos/go-systemd/v22 v22.1.0
+# github.com/coreos/pkg => github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f
+# github.com/cpuguy83/go-md2man/v2 => github.com/cpuguy83/go-md2man/v2 v2.0.0
+# github.com/creack/pty => github.com/creack/pty v1.1.11
+# github.com/cyphar/filepath-securejoin => github.com/cyphar/filepath-securejoin v0.2.2
+# github.com/davecgh/go-spew => github.com/davecgh/go-spew v1.1.1
+# github.com/daviddengcn/go-colortext => github.com/daviddengcn/go-colortext v0.0.0-20160507010035-511bcaf42ccd
+# github.com/dgrijalva/jwt-go => github.com/dgrijalva/jwt-go v3.2.0+incompatible
+# github.com/dnaeon/go-vcr => github.com/dnaeon/go-vcr v1.0.1
+# github.com/docker/distribution => github.com/docker/distribution v2.7.1+incompatible
+# github.com/docker/docker => github.com/docker/docker v20.10.2+incompatible
+# github.com/docker/go-connections => github.com/docker/go-connections v0.4.0
+# github.com/docker/go-units => github.com/docker/go-units v0.4.0
+# github.com/docopt/docopt-go => github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815
+# github.com/dustin/go-humanize => github.com/dustin/go-humanize v1.0.0
+# github.com/elazarl/goproxy => github.com/elazarl/goproxy v0.0.0-20180725130230-947c36da3153
+# github.com/emicklei/go-restful => github.com/emicklei/go-restful v2.9.5+incompatible
+# github.com/envoyproxy/go-control-plane => github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473
+# github.com/envoyproxy/protoc-gen-validate => github.com/envoyproxy/protoc-gen-validate v0.1.0
+# github.com/euank/go-kmsg-parser => github.com/euank/go-kmsg-parser v2.0.0+incompatible
+# github.com/evanphx/json-patch => github.com/evanphx/json-patch v4.9.0+incompatible
+# github.com/exponent-io/jsonpath => github.com/exponent-io/jsonpath v0.0.0-20151013193312-d6023ce2651d
+# github.com/fatih/camelcase => github.com/fatih/camelcase v1.0.0
+# github.com/fatih/color => github.com/fatih/color v1.7.0
+# github.com/flynn/go-shlex => github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568
+# github.com/fogleman/gg => github.com/fogleman/gg v1.2.1-0.20190220221249-0403632d5b90
+# github.com/form3tech-oss/jwt-go => github.com/form3tech-oss/jwt-go v3.2.2+incompatible
+# github.com/fsnotify/fsnotify => github.com/fsnotify/fsnotify v1.4.9
+# github.com/fvbommel/sortorder => github.com/fvbommel/sortorder v1.0.1
+# github.com/ghodss/yaml => github.com/ghodss/yaml v1.0.0
+# github.com/go-acme/lego => github.com/go-acme/lego v2.5.0+incompatible
+# github.com/go-bindata/go-bindata => github.com/go-bindata/go-bindata v3.1.1+incompatible
+# github.com/go-errors/errors => github.com/go-errors/errors v1.0.1
+# github.com/go-gl/glfw/v3.3/glfw => github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4
+# github.com/go-kit/kit => github.com/go-kit/kit v0.9.0
+# github.com/go-logfmt/logfmt => github.com/go-logfmt/logfmt v0.4.0
+# github.com/go-logr/logr => github.com/go-logr/logr v0.4.0
+# github.com/go-openapi/analysis => github.com/go-openapi/analysis v0.19.5
+# github.com/go-openapi/errors => github.com/go-openapi/errors v0.19.2
+# github.com/go-openapi/jsonpointer => github.com/go-openapi/jsonpointer v0.19.3
+# github.com/go-openapi/jsonreference => github.com/go-openapi/jsonreference v0.19.3
+# github.com/go-openapi/loads => github.com/go-openapi/loads v0.19.4
+# github.com/go-openapi/runtime => github.com/go-openapi/runtime v0.19.4
+# github.com/go-openapi/spec => github.com/go-openapi/spec v0.19.5
+# github.com/go-openapi/strfmt => github.com/go-openapi/strfmt v0.19.5
+# github.com/go-openapi/swag => github.com/go-openapi/swag v0.19.5
+# github.com/go-openapi/validate => github.com/go-openapi/validate v0.19.8
+# github.com/go-ozzo/ozzo-validation => github.com/go-ozzo/ozzo-validation v3.5.0+incompatible
+# github.com/go-stack/stack => github.com/go-stack/stack v1.8.0
+# github.com/gobuffalo/here => github.com/gobuffalo/here v0.6.0
+# github.com/godbus/dbus/v5 => github.com/godbus/dbus/v5 v5.0.3
+# github.com/gogo/protobuf => github.com/gogo/protobuf v1.3.2
+# github.com/golang/freetype => github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0
+# github.com/golang/glog => github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
+# github.com/golang/groupcache => github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e
+# github.com/golang/mock => github.com/golang/mock v1.4.4
+# github.com/golang/protobuf => github.com/golang/protobuf v1.4.3
+# github.com/golangplus/testing => github.com/golangplus/testing v0.0.0-20180327235837-af21d9c3145e
+# github.com/google/btree => github.com/google/btree v1.0.0
+# github.com/google/cadvisor => github.com/google/cadvisor v0.39.0
+# github.com/google/go-cmp => github.com/google/go-cmp v0.5.2
+# github.com/google/gofuzz => github.com/google/gofuzz v1.1.0
+# github.com/google/martian => github.com/google/martian v2.1.0+incompatible
+# github.com/google/pprof => github.com/google/pprof v0.0.0-20200229191704-1ebb73c60ed3
+# github.com/google/renameio => github.com/google/renameio v0.1.0
+# github.com/google/shlex => github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
+# github.com/google/uuid => github.com/google/uuid v1.1.2
+# github.com/googleapis/gax-go/v2 => github.com/googleapis/gax-go/v2 v2.0.5
+# github.com/googleapis/gnostic => github.com/googleapis/gnostic v0.5.1
+# github.com/gophercloud/gophercloud => github.com/gophercloud/gophercloud v0.1.0
+# github.com/gopherjs/gopherjs => github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1
+# github.com/gorilla/mux => github.com/gorilla/mux v1.8.0
+# github.com/gorilla/websocket => github.com/gorilla/websocket v1.4.2
+# github.com/gregjones/httpcache => github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7
+# github.com/grpc-ecosystem/go-grpc-middleware => github.com/grpc-ecosystem/go-grpc-middleware v1.0.1-0.20190118093823-f849b5445de4
+# github.com/grpc-ecosystem/go-grpc-prometheus => github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0
+# github.com/grpc-ecosystem/grpc-gateway => github.com/grpc-ecosystem/grpc-gateway v1.9.5
+# github.com/hashicorp/consul/api => github.com/hashicorp/consul/api v1.1.0
+# github.com/hashicorp/consul/sdk => github.com/hashicorp/consul/sdk v0.1.1
+# github.com/hashicorp/errwrap => github.com/hashicorp/errwrap v1.0.0
+# github.com/hashicorp/go-cleanhttp => github.com/hashicorp/go-cleanhttp v0.5.1
+# github.com/hashicorp/go-immutable-radix => github.com/hashicorp/go-immutable-radix v1.0.0
+# github.com/hashicorp/go-msgpack => github.com/hashicorp/go-msgpack v0.5.3
+# github.com/hashicorp/go-multierror => github.com/hashicorp/go-multierror v1.0.0
+# github.com/hashicorp/go-rootcerts => github.com/hashicorp/go-rootcerts v1.0.0
+# github.com/hashicorp/go-sockaddr => github.com/hashicorp/go-sockaddr v1.0.0
+# github.com/hashicorp/go-syslog => github.com/hashicorp/go-syslog v1.0.0
+# github.com/hashicorp/go-uuid => github.com/hashicorp/go-uuid v1.0.1
+# github.com/hashicorp/go.net => github.com/hashicorp/go.net v0.0.1
+# github.com/hashicorp/golang-lru => github.com/hashicorp/golang-lru v0.5.1
+# github.com/hashicorp/hcl => github.com/hashicorp/hcl v1.0.0
+# github.com/hashicorp/logutils => github.com/hashicorp/logutils v1.0.0
+# github.com/hashicorp/mdns => github.com/hashicorp/mdns v1.0.0
+# github.com/hashicorp/memberlist => github.com/hashicorp/memberlist v0.1.3
+# github.com/hashicorp/serf => github.com/hashicorp/serf v0.8.2
+# github.com/heketi/heketi => github.com/heketi/heketi v10.2.0+incompatible
+# github.com/heketi/tests => github.com/heketi/tests v0.0.0-20151005000721-f3775cbcefd6
+# github.com/hpcloud/tail => github.com/hpcloud/tail v1.0.0
+# github.com/ianlancetaylor/demangle => github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6
+# github.com/imdario/mergo => github.com/imdario/mergo v0.3.5
+# github.com/inconshreveable/mousetrap => github.com/inconshreveable/mousetrap v1.0.0
+# github.com/ishidawataru/sctp => github.com/ishidawataru/sctp v0.0.0-20190723014705-7c296d48a2b5
+# github.com/jimstudt/http-authentication => github.com/jimstudt/http-authentication v0.0.0-20140401203705-3eca13d6893a
+# github.com/jmespath/go-jmespath => github.com/jmespath/go-jmespath v0.4.0
+# github.com/jmespath/go-jmespath/internal/testify => github.com/jmespath/go-jmespath/internal/testify v1.5.1
+# github.com/jonboulle/clockwork => github.com/jonboulle/clockwork v0.1.0
+# github.com/json-iterator/go => github.com/json-iterator/go v1.1.10
+# github.com/jstemmer/go-junit-report => github.com/jstemmer/go-junit-report v0.9.1
+# github.com/jtolds/gls => github.com/jtolds/gls v4.20.0+incompatible
+# github.com/julienschmidt/httprouter => github.com/julienschmidt/httprouter v1.2.0
+# github.com/jung-kurt/gofpdf => github.com/jung-kurt/gofpdf v1.0.3-0.20190309125859-24315acbbda5
+# github.com/karrick/godirwalk => github.com/karrick/godirwalk v1.16.1
+# github.com/kisielk/errcheck => github.com/kisielk/errcheck v1.5.0
+# github.com/kisielk/gotool => github.com/kisielk/gotool v1.0.0
+# github.com/klauspost/cpuid => github.com/klauspost/cpuid v1.2.0
+# github.com/konsorten/go-windows-terminal-sequences => github.com/konsorten/go-windows-terminal-sequences v1.0.2
+# github.com/kr/logfmt => github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515
+# github.com/kr/pretty => github.com/kr/pretty v0.2.0
+# github.com/kr/text => github.com/kr/text v0.2.0
+# github.com/kylelemons/godebug => github.com/kylelemons/godebug v0.0.0-20170820004349-d65d576e9348
+# github.com/libopenstorage/openstorage => github.com/libopenstorage/openstorage v1.0.0
+# github.com/liggitt/tabwriter => github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de
+# github.com/lithammer/dedent => github.com/lithammer/dedent v1.1.0
+# github.com/lpabon/godbc => github.com/lpabon/godbc v0.1.1
+# github.com/lucas-clemente/aes12 => github.com/lucas-clemente/aes12 v0.0.0-20171027163421-cd47fb39b79f
+# github.com/lucas-clemente/quic-clients => github.com/lucas-clemente/quic-clients v0.1.0
+# github.com/lucas-clemente/quic-go => github.com/lucas-clemente/quic-go v0.10.2
+# github.com/lucas-clemente/quic-go-certificates => github.com/lucas-clemente/quic-go-certificates v0.0.0-20160823095156-d2f86524cced
+# github.com/magiconair/properties => github.com/magiconair/properties v1.8.1
+# github.com/mailru/easyjson => github.com/mailru/easyjson v0.7.0
+# github.com/markbates/pkger => github.com/markbates/pkger v0.17.1
+# github.com/marten-seemann/qtls => github.com/marten-seemann/qtls v0.2.3
+# github.com/mattn/go-colorable => github.com/mattn/go-colorable v0.0.9
+# github.com/mattn/go-isatty => github.com/mattn/go-isatty v0.0.4
+# github.com/mattn/go-runewidth => github.com/mattn/go-runewidth v0.0.7
+# github.com/matttproud/golang_protobuf_extensions => github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369
+# github.com/mholt/certmagic => github.com/mholt/certmagic v0.6.2-0.20190624175158-6a42ef9fe8c2
+# github.com/miekg/dns => github.com/miekg/dns v1.1.35
+# github.com/mindprince/gonvml => github.com/mindprince/gonvml v0.0.0-20190828220739-9ebdce4bb989
+# github.com/mistifyio/go-zfs => github.com/mistifyio/go-zfs v2.1.2-0.20190413222219-f784269be439+incompatible
+# github.com/mitchellh/cli => github.com/mitchellh/cli v1.0.0
+# github.com/mitchellh/go-homedir => github.com/mitchellh/go-homedir v1.1.0
+# github.com/mitchellh/go-testing-interface => github.com/mitchellh/go-testing-interface v1.0.0
+# github.com/mitchellh/go-wordwrap => github.com/mitchellh/go-wordwrap v1.0.0
+# github.com/mitchellh/gox => github.com/mitchellh/gox v0.4.0
+# github.com/mitchellh/iochan => github.com/mitchellh/iochan v1.0.0
+# github.com/mitchellh/mapstructure => github.com/mitchellh/mapstructure v1.1.2
+# github.com/moby/ipvs => github.com/moby/ipvs v1.0.1
+# github.com/moby/spdystream => github.com/moby/spdystream v0.2.0
+# github.com/moby/sys/mountinfo => github.com/moby/sys/mountinfo v0.4.0
+# github.com/moby/term => github.com/moby/term v0.0.0-20201216013528-df9cb8a40635
+# github.com/modern-go/concurrent => github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd
+# github.com/modern-go/reflect2 => github.com/modern-go/reflect2 v1.0.1
+# github.com/mohae/deepcopy => github.com/mohae/deepcopy v0.0.0-20170603005431-491d3605edfb
+# github.com/monochromegane/go-gitignore => github.com/monochromegane/go-gitignore v0.0.0-20200626010858-205db1a8cc00
+# github.com/morikuni/aec => github.com/morikuni/aec v1.0.0
+# github.com/mrunalp/fileutils => github.com/mrunalp/fileutils v0.5.0
+# github.com/munnerz/goautoneg => github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822
+# github.com/mvdan/xurls => github.com/mvdan/xurls v1.1.0
+# github.com/mwitkow/go-conntrack => github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223
+# github.com/mxk/go-flowrate => github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f
+# github.com/naoina/go-stringutil => github.com/naoina/go-stringutil v0.1.0
+# github.com/naoina/toml => github.com/naoina/toml v0.1.1
+# github.com/niemeyer/pretty => github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e
+# github.com/olekukonko/tablewriter => github.com/olekukonko/tablewriter v0.0.4
+# github.com/onsi/ginkgo => github.com/onsi/ginkgo v1.11.0
+# github.com/onsi/gomega => github.com/onsi/gomega v1.7.0
+# github.com/opencontainers/go-digest => github.com/opencontainers/go-digest v1.0.0
+# github.com/opencontainers/image-spec => github.com/opencontainers/image-spec v1.0.1
+# github.com/opencontainers/runc => github.com/opencontainers/runc v1.0.0-rc93
+# github.com/opencontainers/runtime-spec => github.com/opencontainers/runtime-spec v1.0.3-0.20200929063507-e6143ca7d51d
+# github.com/opencontainers/selinux => github.com/opencontainers/selinux v1.8.0
+# github.com/pascaldekloe/goe => github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c
+# github.com/pelletier/go-toml => github.com/pelletier/go-toml v1.2.0
+# github.com/peterbourgon/diskv => github.com/peterbourgon/diskv v2.0.1+incompatible
+# github.com/pkg/errors => github.com/pkg/errors v0.9.1
+# github.com/pmezard/go-difflib => github.com/pmezard/go-difflib v1.0.0
+# github.com/posener/complete => github.com/posener/complete v1.1.1
+# github.com/pquerna/cachecontrol => github.com/pquerna/cachecontrol v0.0.0-20171018203845-0dec1b30a021
+# github.com/prometheus/client_golang => github.com/prometheus/client_golang v1.7.1
+# github.com/prometheus/client_model => github.com/prometheus/client_model v0.2.0
+# github.com/prometheus/common => github.com/prometheus/common v0.10.0
+# github.com/prometheus/procfs => github.com/prometheus/procfs v0.2.0
+# github.com/quobyte/api => github.com/quobyte/api v0.1.8
+# github.com/remyoudompheng/bigfft => github.com/remyoudompheng/bigfft v0.0.0-20170806203942-52369c62f446
+# github.com/robfig/cron => github.com/robfig/cron v1.1.0
+# github.com/rogpeppe/fastuuid => github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af
+# github.com/rogpeppe/go-internal => github.com/rogpeppe/go-internal v1.3.0
+# github.com/rubiojr/go-vhd => github.com/rubiojr/go-vhd v0.0.0-20200706105327-02e210299021
+# github.com/russross/blackfriday => github.com/russross/blackfriday v1.5.2
+# github.com/russross/blackfriday/v2 => github.com/russross/blackfriday/v2 v2.0.1
+# github.com/ryanuber/columnize => github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f
+# github.com/satori/go.uuid => github.com/satori/go.uuid v1.2.0
+# github.com/sean-/seed => github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529
+# github.com/seccomp/libseccomp-golang => github.com/seccomp/libseccomp-golang v0.9.1
+# github.com/sergi/go-diff => github.com/sergi/go-diff v1.1.0
+# github.com/shurcooL/sanitized_anchor_name => github.com/shurcooL/sanitized_anchor_name v1.0.0
+# github.com/sirupsen/logrus => github.com/sirupsen/logrus v1.7.0
+# github.com/smartystreets/assertions => github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d
+# github.com/smartystreets/goconvey => github.com/smartystreets/goconvey v1.6.4
+# github.com/soheilhy/cmux => github.com/soheilhy/cmux v0.1.4
+# github.com/spf13/afero => github.com/spf13/afero v1.2.2
+# github.com/spf13/cast => github.com/spf13/cast v1.3.0
+# github.com/spf13/cobra => github.com/spf13/cobra v1.1.1
+# github.com/spf13/jwalterweatherman => github.com/spf13/jwalterweatherman v1.1.0
+# github.com/spf13/pflag => github.com/spf13/pflag v1.0.5
+# github.com/spf13/viper => github.com/spf13/viper v1.7.0
+# github.com/stoewer/go-strcase => github.com/stoewer/go-strcase v1.2.0
+# github.com/storageos/go-api => github.com/storageos/go-api v2.2.0+incompatible
+# github.com/stretchr/objx => github.com/stretchr/objx v0.2.0
+# github.com/stretchr/testify => github.com/stretchr/testify v1.6.1
+# github.com/subosito/gotenv => github.com/subosito/gotenv v1.2.0
+# github.com/syndtr/gocapability => github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635
+# github.com/thecodeteam/goscaleio => github.com/thecodeteam/goscaleio v0.1.0
+# github.com/tidwall/pretty => github.com/tidwall/pretty v1.0.0
+# github.com/tmc/grpc-websocket-proxy => github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5
+# github.com/urfave/cli => github.com/urfave/cli v1.22.2
+# github.com/urfave/negroni => github.com/urfave/negroni v1.0.0
+# github.com/vektah/gqlparser => github.com/vektah/gqlparser v1.1.2
+# github.com/vishvananda/netlink => github.com/vishvananda/netlink v1.1.0
+# github.com/vishvananda/netns => github.com/vishvananda/netns v0.0.0-20200728191858-db3c7e526aae
+# github.com/vmware/govmomi => github.com/vmware/govmomi v0.20.3
+# github.com/willf/bitset => github.com/willf/bitset v1.1.11
+# github.com/xiang90/probing => github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2
+# github.com/xlab/treeprint => github.com/xlab/treeprint v0.0.0-20181112141820-a009c3971eca
+# github.com/yuin/goldmark => github.com/yuin/goldmark v1.2.1
+# go.etcd.io/bbolt => go.etcd.io/bbolt v1.3.5
+# go.etcd.io/etcd => go.etcd.io/etcd v0.5.0-alpha.5.0.20200910180754-dd1b699fc489
+# go.mongodb.org/mongo-driver => go.mongodb.org/mongo-driver v1.1.2
+# go.opencensus.io => go.opencensus.io v0.22.3
+# go.starlark.net => go.starlark.net v0.0.0-20200306205701-8dd3e2ee1dd5
+# go.uber.org/atomic => go.uber.org/atomic v1.6.0
+# go.uber.org/multierr => go.uber.org/multierr v1.5.0
+# go.uber.org/tools => go.uber.org/tools v0.0.0-20190618225709-2cfd321de3ee
+# go.uber.org/zap => go.uber.org/zap v1.16.0
+# golang.org/x/crypto => golang.org/x/crypto v0.0.0-20210220033148-5ea612d1eb83
+# golang.org/x/exp => golang.org/x/exp v0.0.0-20210220032938-85be41e4509f
+# golang.org/x/image => golang.org/x/image v0.0.0-20190802002840-cff245a6509b
+# golang.org/x/lint => golang.org/x/lint v0.0.0-20200302205851-738671d3881b
+# golang.org/x/mobile => golang.org/x/mobile v0.0.0-20201217150744-e6ae53a27f4f
+# golang.org/x/mod => golang.org/x/mod v0.3.1-0.20200828183125-ce943fd02449
+# golang.org/x/net => golang.org/x/net v0.0.0-20210224082022-3d97a244fca7
+# golang.org/x/oauth2 => golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d
+# golang.org/x/sync => golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9
+# golang.org/x/sys => golang.org/x/sys v0.0.0-20210225134936-a50acf3fe073
+# golang.org/x/term => golang.org/x/term v0.0.0-20210220032956-6a3ed077a48d
+# golang.org/x/text => golang.org/x/text v0.3.4
+# golang.org/x/time => golang.org/x/time v0.0.0-20210220033141-f8bda1e9f3ba
+# golang.org/x/tools => golang.org/x/tools v0.1.0
+# golang.org/x/xerrors => golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1
+# gonum.org/v1/gonum => gonum.org/v1/gonum v0.6.2
+# gonum.org/v1/netlib => gonum.org/v1/netlib v0.0.0-20190331212654-76723241ea4e
+# gonum.org/v1/plot => gonum.org/v1/plot v0.0.0-20190515093506-e2840ee46a6b
+# google.golang.org/api => google.golang.org/api v0.20.0
+# google.golang.org/appengine => google.golang.org/appengine v1.6.5
+# google.golang.org/genproto => google.golang.org/genproto v0.0.0-20201110150050-8816d57aaa9a
+# google.golang.org/grpc => google.golang.org/grpc v1.27.1
+# google.golang.org/protobuf => google.golang.org/protobuf v1.25.0
+# gopkg.in/alecthomas/kingpin.v2 => gopkg.in/alecthomas/kingpin.v2 v2.2.6
+# gopkg.in/check.v1 => gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f
+# gopkg.in/cheggaaa/pb.v1 => gopkg.in/cheggaaa/pb.v1 v1.0.25
+# gopkg.in/errgo.v2 => gopkg.in/errgo.v2 v2.1.0
+# gopkg.in/fsnotify.v1 => gopkg.in/fsnotify.v1 v1.4.7
+# gopkg.in/gcfg.v1 => gopkg.in/gcfg.v1 v1.2.0
+# gopkg.in/inf.v0 => gopkg.in/inf.v0 v0.9.1
+# gopkg.in/ini.v1 => gopkg.in/ini.v1 v1.51.0
+# gopkg.in/mcuadros/go-syslog.v2 => gopkg.in/mcuadros/go-syslog.v2 v2.2.1
+# gopkg.in/natefinch/lumberjack.v2 => gopkg.in/natefinch/lumberjack.v2 v2.0.0
+# gopkg.in/resty.v1 => gopkg.in/resty.v1 v1.12.0
+# gopkg.in/square/go-jose.v2 => gopkg.in/square/go-jose.v2 v2.2.2
+# gopkg.in/tomb.v1 => gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7
+# gopkg.in/warnings.v0 => gopkg.in/warnings.v0 v0.1.1
+# gopkg.in/yaml.v2 => gopkg.in/yaml.v2 v2.4.0
+# gopkg.in/yaml.v3 => gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776
+# gotest.tools => gotest.tools v2.2.0+incompatible
+# gotest.tools/v3 => gotest.tools/v3 v3.0.3
+# honnef.co/go/tools => honnef.co/go/tools v0.0.1-2020.1.3
+# k8s.io/api => ./staging/src/k8s.io/api
+# k8s.io/apiextensions-apiserver => ./staging/src/k8s.io/apiextensions-apiserver
+# k8s.io/apimachinery => ./staging/src/k8s.io/apimachinery
+# k8s.io/apiserver => ./staging/src/k8s.io/apiserver
+# k8s.io/cli-runtime => ./staging/src/k8s.io/cli-runtime
+# k8s.io/client-go => ./staging/src/k8s.io/client-go
+# k8s.io/cloud-provider => ./staging/src/k8s.io/cloud-provider
+# k8s.io/cluster-bootstrap => ./staging/src/k8s.io/cluster-bootstrap
+# k8s.io/code-generator => ./staging/src/k8s.io/code-generator
+# k8s.io/component-base => ./staging/src/k8s.io/component-base
+# k8s.io/component-helpers => ./staging/src/k8s.io/component-helpers
+# k8s.io/controller-manager => ./staging/src/k8s.io/controller-manager
+# k8s.io/cri-api => ./staging/src/k8s.io/cri-api
+# k8s.io/csi-translation-lib => ./staging/src/k8s.io/csi-translation-lib
+# k8s.io/gengo => k8s.io/gengo v0.0.0-20201214224949-b6c5ce23f027
+# k8s.io/heapster => k8s.io/heapster v1.2.0-beta.1
+# k8s.io/klog/v2 => k8s.io/klog/v2 v2.8.0
+# k8s.io/kube-aggregator => ./staging/src/k8s.io/kube-aggregator
+# k8s.io/kube-controller-manager => ./staging/src/k8s.io/kube-controller-manager
+# k8s.io/kube-openapi => k8s.io/kube-openapi v0.0.0-20210421082810-95288971da7e
+# k8s.io/kube-proxy => ./staging/src/k8s.io/kube-proxy
+# k8s.io/kube-scheduler => ./staging/src/k8s.io/kube-scheduler
+# k8s.io/kubectl => ./staging/src/k8s.io/kubectl
+# k8s.io/kubelet => ./staging/src/k8s.io/kubelet
+# k8s.io/legacy-cloud-providers => ./staging/src/k8s.io/legacy-cloud-providers
+# k8s.io/metrics => ./staging/src/k8s.io/metrics
+# k8s.io/mount-utils => ./staging/src/k8s.io/mount-utils
+# k8s.io/sample-apiserver => ./staging/src/k8s.io/sample-apiserver
+# k8s.io/sample-cli-plugin => ./staging/src/k8s.io/sample-cli-plugin
+# k8s.io/sample-controller => ./staging/src/k8s.io/sample-controller
+# k8s.io/system-validators => k8s.io/system-validators v1.4.0
+# k8s.io/utils => k8s.io/utils v0.0.0-20201110183641-67b214c5f920
+# modernc.org/cc => modernc.org/cc v1.0.0
+# modernc.org/golex => modernc.org/golex v1.0.0
+# modernc.org/mathutil => modernc.org/mathutil v1.0.0
+# modernc.org/strutil => modernc.org/strutil v1.0.0
+# modernc.org/xc => modernc.org/xc v1.0.0
+# rsc.io/pdf => rsc.io/pdf v0.1.1
+# sigs.k8s.io/apiserver-network-proxy/konnectivity-client => sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.15
+# sigs.k8s.io/kustomize/api => sigs.k8s.io/kustomize/api v0.8.8
+# sigs.k8s.io/kustomize/cmd/config => sigs.k8s.io/kustomize/cmd/config v0.9.10
+# sigs.k8s.io/kustomize/kustomize/v4 => sigs.k8s.io/kustomize/kustomize/v4 v4.1.2
+# sigs.k8s.io/kustomize/kyaml => sigs.k8s.io/kustomize/kyaml v0.10.17
+# sigs.k8s.io/structured-merge-diff/v4 => sigs.k8s.io/structured-merge-diff/v4 v4.1.1
 # sigs.k8s.io/yaml => sigs.k8s.io/yaml v1.2.0


### PR DESCRIPTION
This was required prior to https://go-review.googlesource.com/c/go/+/174527 to ensure
consistent ordering across platforms, but is not required in go 1.13+.

/kind cleanup

xref https://github.com/golang/go/issues/45649#issuecomment-823717669

```release-note
NONE
```

/cc @dims