### PR TITLE
Additional CVE-2021-3121 fix

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity_proto.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity_proto.go
@@ -166,7 +166,7 @@ func (m *Quantity) Unmarshal(data []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthGenerated
 			}
 			if (iNdEx + skippy) > l {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Since `apimachinery/pkg/api/resource/quantity_proto.go` is not generated by
the protobuf compiler, it needs the fix for CVE-2021-3121 to be applied by
hand.

#### Which issue(s) this PR fixes:
N/A

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```