### PR TITLE
kubeadm:Use kubeadmapiv1.SchemeGroupVersion.String() instead of kubeadm.k8s.i…

### DIFF
--- a/cmd/kubeadm/app/cmd/alpha/kubeconfig_test.go
+++ b/cmd/kubeadm/app/cmd/alpha/kubeconfig_test.go
@@ -39,7 +39,7 @@ func generateTestKubeadmConfig(dir, id, certDir, clusterName string) (string, er
 	cfgPath := filepath.Join(dir, id)
 	initCfg := kubeadmapiv1.InitConfiguration{
 		TypeMeta: metav1.TypeMeta{
-			APIVersion: "kubeadm.k8s.io/v1beta3",
+			APIVersion: kubeadmapiv1.SchemeGroupVersion.String(),
 			Kind:       "InitConfiguration",
 		},
 		LocalAPIEndpoint: kubeadmapiv1.APIEndpoint{
@@ -49,7 +49,7 @@ func generateTestKubeadmConfig(dir, id, certDir, clusterName string) (string, er
 	}
 	clusterCfg := kubeadmapiv1.ClusterConfiguration{
 		TypeMeta: metav1.TypeMeta{
-			APIVersion: "kubeadm.k8s.io/v1beta3",
+			APIVersion: kubeadmapiv1.SchemeGroupVersion.String(),
 			Kind:       "ClusterConfiguration",
 		},
 		CertificatesDir:   certDir,

--- a/cmd/kubeadm/app/cmd/certs_test.go
+++ b/cmd/kubeadm/app/cmd/certs_test.go
@@ -378,18 +378,20 @@ func TestGenCSRConfig(t *testing.T) {
 
 	// A minimal kubeadm config with just enough values to avoid triggering
 	// auto-detection of config values at runtime.
-	var kubeadmConfig = `
-apiVersion: kubeadm.k8s.io/v1beta3
+	var kubeadmConfig = fmt.Sprintf(`
+apiVersion: %s
 kind: InitConfiguration
 localAPIEndpoint:
   advertiseAddress: 192.0.2.1
 nodeRegistration:
   criSocket: /path/to/dockershim.sock
 ---
-apiVersion: kubeadm.k8s.io/v1beta3
+apiVersion: %[1]s
 kind: ClusterConfiguration
 certificatesDir: /custom/config/certificates-dir
-kubernetesVersion: ` + kubeadmconstants.MinimumControlPlaneVersion.String()
+kubernetesVersion: %s`,
+		kubeadmapiv1.SchemeGroupVersion.String(),
+		kubeadmconstants.MinimumControlPlaneVersion.String())
 
 	tmpDir := testutil.SetupTempDir(t)
 	defer os.RemoveAll(tmpDir)

--- a/cmd/kubeadm/app/cmd/config_test.go
+++ b/cmd/kubeadm/app/cmd/config_test.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/lithammer/dedent"
 	"github.com/spf13/cobra"
+	kubeadmapiv1old "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1beta2"
 	kubeadmapiv1 "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1beta3"
 	outputapischeme "k8s.io/kubernetes/cmd/kubeadm/app/apis/output/scheme"
 	"k8s.io/kubernetes/cmd/kubeadm/app/constants"
@@ -81,10 +82,10 @@ func TestImagesListRunWithCustomConfigPath(t *testing.T) {
 				constants.CurrentKubernetesVersion.String(),
 			},
 			configContents: []byte(dedent.Dedent(fmt.Sprintf(`
-				apiVersion: kubeadm.k8s.io/v1beta3
+				apiVersion: %s
 				kind: ClusterConfiguration
 				kubernetesVersion: %s
-			`, constants.CurrentKubernetesVersion))),
+			`, kubeadmapiv1.SchemeGroupVersion.String(), constants.CurrentKubernetesVersion))),
 		},
 		{
 			name:               "use coredns",
@@ -93,10 +94,10 @@ func TestImagesListRunWithCustomConfigPath(t *testing.T) {
 				"coredns",
 			},
 			configContents: []byte(dedent.Dedent(fmt.Sprintf(`
-				apiVersion: kubeadm.k8s.io/v1beta3
+				apiVersion: %s
 				kind: ClusterConfiguration
 				kubernetesVersion: %s
-			`, constants.MinimumControlPlaneVersion))),
+			`, kubeadmapiv1.SchemeGroupVersion.String(), constants.MinimumControlPlaneVersion))),
 		},
 	}
 
@@ -382,11 +383,11 @@ func TestImagesPull(t *testing.T) {
 }
 
 func TestMigrate(t *testing.T) {
-	cfg := []byte(dedent.Dedent(`
+	cfg := []byte(dedent.Dedent(fmt.Sprintf(`
 		# This is intentionally testing an old API version. Sometimes this may be the latest version (if no old configs are supported).
-		apiVersion: kubeadm.k8s.io/v1beta2
+		apiVersion: %s
 		kind: InitConfiguration
-	`))
+	`, kubeadmapiv1old.SchemeGroupVersion.String())))
 	configFile, cleanup := tempConfig(t, cfg)
 	defer cleanup()
 

--- a/cmd/kubeadm/app/cmd/init_test.go
+++ b/cmd/kubeadm/app/cmd/init_test.go
@@ -17,18 +17,19 @@ limitations under the License.
 package cmd
 
 import (
+	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
 
 	"k8s.io/apimachinery/pkg/util/sets"
+	kubeadmapiv1 "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1beta3"
 	"k8s.io/kubernetes/cmd/kubeadm/app/cmd/options"
 )
 
-const (
-	testInitConfig = `---
-apiVersion: kubeadm.k8s.io/v1beta3
+var testInitConfig = fmt.Sprintf(`---
+apiVersion: %s
 kind: InitConfiguration
 localAPIEndpoint:
   advertiseAddress: "1.2.3.4"
@@ -41,11 +42,10 @@ nodeRegistration:
     - c
     - d
 ---
-apiVersion: kubeadm.k8s.io/v1beta3
+apiVersion: %[1]s
 kind: ClusterConfiguration
 controlPlaneEndpoint: "3.4.5.6"
-`
-)
+`, kubeadmapiv1.SchemeGroupVersion.String())
 
 func TestNewInitData(t *testing.T) {
 	// create temp directory

--- a/cmd/kubeadm/app/cmd/join_test.go
+++ b/cmd/kubeadm/app/cmd/join_test.go
@@ -17,18 +17,19 @@ limitations under the License.
 package cmd
 
 import (
+	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
 
 	"k8s.io/apimachinery/pkg/util/sets"
+	kubeadmapiv1 "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1beta3"
 	"k8s.io/kubernetes/cmd/kubeadm/app/cmd/options"
 	kubeconfigutil "k8s.io/kubernetes/cmd/kubeadm/app/util/kubeconfig"
 )
 
-const (
-	testJoinConfig = `apiVersion: kubeadm.k8s.io/v1beta3
+var testJoinConfig = fmt.Sprintf(`apiVersion: %s
 kind: JoinConfiguration
 discovery:
   bootstrapToken:
@@ -41,8 +42,7 @@ nodeRegistration:
   ignorePreflightErrors:
     - c
     - d
-`
-)
+`, kubeadmapiv1.SchemeGroupVersion.String())
 
 func TestNewJoinData(t *testing.T) {
 	// create temp directory

--- a/cmd/kubeadm/app/cmd/upgrade/common_test.go
+++ b/cmd/kubeadm/app/cmd/upgrade/common_test.go
@@ -18,9 +18,11 @@ package upgrade
 
 import (
 	"bytes"
+	"fmt"
 	"testing"
 
 	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
+	kubeadmapiv1 "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1beta3"
 )
 
 func TestEnforceRequirements(t *testing.T) {
@@ -89,9 +91,9 @@ func TestPrintConfiguration(t *testing.T) {
 					Type: kubeadmapi.CoreDNS,
 				},
 			},
-			expectedBytes: []byte(`[upgrade/config] Configuration used:
+			expectedBytes: []byte(fmt.Sprintf(`[upgrade/config] Configuration used:
 	apiServer: {}
-	apiVersion: kubeadm.k8s.io/v1beta3
+	apiVersion: %s
 	controllerManager: {}
 	dns:
 	  type: CoreDNS
@@ -102,7 +104,7 @@ func TestPrintConfiguration(t *testing.T) {
 	kubernetesVersion: v1.7.1
 	networking: {}
 	scheduler: {}
-`),
+`, kubeadmapiv1.SchemeGroupVersion.String())),
 		},
 		{
 			name: "cluster config with ServiceSubnet and external Etcd",
@@ -122,7 +124,7 @@ func TestPrintConfiguration(t *testing.T) {
 			},
 			expectedBytes: []byte(`[upgrade/config] Configuration used:
 	apiServer: {}
-	apiVersion: kubeadm.k8s.io/v1beta3
+	apiVersion: ` + kubeadmapiv1.SchemeGroupVersion.String() + `
 	controllerManager: {}
 	dns:
 	  type: CoreDNS

--- a/cmd/kubeadm/app/cmd/upgrade/diff_test.go
+++ b/cmd/kubeadm/app/cmd/upgrade/diff_test.go
@@ -17,11 +17,13 @@ limitations under the License.
 package upgrade
 
 import (
+	"fmt"
 	"io/ioutil"
 	"os"
 	"testing"
 
 	"github.com/pkg/errors"
+	kubeadmapiv1 "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1beta3"
 	"k8s.io/kubernetes/cmd/kubeadm/app/constants"
 )
 
@@ -43,9 +45,9 @@ func TestRunDiff(t *testing.T) {
 	currentVersion := "v" + constants.CurrentKubernetesVersion.String()
 
 	// create a temporary file with valid ClusterConfiguration
-	testUpgradeDiffConfigContents := []byte("apiVersion: kubeadm.k8s.io/v1beta3\n" +
-		"kind: ClusterConfiguration\n" +
-		"kubernetesVersion: " + currentVersion)
+	testUpgradeDiffConfigContents := []byte(fmt.Sprintf("apiVersion: %s\n"+
+		"kind: ClusterConfiguration\n"+
+		"kubernetesVersion: %s", kubeadmapiv1.SchemeGroupVersion.String(), currentVersion))
 	testUpgradeDiffConfig, err := createTestRunDiffFile(testUpgradeDiffConfigContents)
 	if err != nil {
 		t.Fatal(err)

--- a/cmd/kubeadm/app/componentconfigs/fakeconfig_test.go
+++ b/cmd/kubeadm/app/componentconfigs/fakeconfig_test.go
@@ -203,10 +203,10 @@ var (
 		yaml string
 		obj  kubeadmapiv1.ClusterConfiguration
 	}{
-		yaml: dedent.Dedent(`
+		yaml: dedent.Dedent(fmt.Sprintf(`
 			apiServer:
 			  timeoutForControlPlane: 4m
-			apiVersion: kubeadm.k8s.io/v1beta3
+			apiVersion: %s
 			certificatesDir: /etc/kubernetes/pki
 			clusterName: LeCluster
 			controllerManager: {}
@@ -222,7 +222,7 @@ var (
 			  dnsDomain: cluster.local
 			  serviceSubnet: 10.96.0.0/12
 			scheduler: {}
-		`),
+		`, kubeadmapiv1.SchemeGroupVersion.String())),
 		obj: kubeadmapiv1.ClusterConfiguration{
 			TypeMeta: metav1.TypeMeta{
 				APIVersion: kubeadmapiv1.SchemeGroupVersion.String(),
@@ -275,9 +275,9 @@ func TestConfigBaseMarshal(t *testing.T) {
 		}
 
 		got := strings.TrimSpace(string(b))
-		expected := strings.TrimSpace(dedent.Dedent(`
+		expected := strings.TrimSpace(dedent.Dedent(fmt.Sprintf(`
 			apiServer: {}
-			apiVersion: kubeadm.k8s.io/v1beta3
+			apiVersion: %s
 			clusterName: LeCluster
 			controllerManager: {}
 			dns:
@@ -287,7 +287,7 @@ func TestConfigBaseMarshal(t *testing.T) {
 			kubernetesVersion: 1.2.3
 			networking: {}
 			scheduler: {}
-		`))
+		`, kubeadmapiv1.SchemeGroupVersion.String())))
 
 		if expected != got {
 			t.Fatalf("Missmatch between expected and got:\nExpected:\n%s\n---\nGot:\n%s", expected, got)
@@ -326,10 +326,10 @@ func TestConfigBaseUnmarshal(t *testing.T) {
 
 func TestGeneratedConfigFromCluster(t *testing.T) {
 	fakeKnownContext(func() {
-		testYAML := dedent.Dedent(`
-			apiVersion: kubeadm.k8s.io/v1beta3
+		testYAML := dedent.Dedent(fmt.Sprintf(`
+			apiVersion: %s
 			kind: ClusterConfiguration
-		`)
+		`, kubeadmapiv1.SchemeGroupVersion.String()))
 		testYAMLHash := fmt.Sprintf("sha256:%x", sha256.Sum256([]byte(testYAML)))
 		// The SHA256 sum of "The quick brown fox jumps over the lazy dog"
 		const mismatchHash = "sha256:d7a8fbb307d7809469ca9abcb0082e4f8d5651e46d3cdb762d02d0bf37c9e592"
@@ -405,10 +405,10 @@ func runClusterConfigFromTest(t *testing.T, perform func(t *testing.T, in string
 			},
 			{
 				name: "Unknown kind returns an error",
-				in: dedent.Dedent(`
-					apiVersion: kubeadm.k8s.io/v1beta3
+				in: dedent.Dedent(fmt.Sprintf(`
+					apiVersion: %s
 					kind: Configuration
-				`),
+				`, kubeadmapiv1.SchemeGroupVersion.String())),
 				expectErr: true,
 			},
 			{

--- a/cmd/kubeadm/app/phases/upgrade/staticpods_test.go
+++ b/cmd/kubeadm/app/phases/upgrade/staticpods_test.go
@@ -34,6 +34,7 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 	certutil "k8s.io/client-go/util/cert"
 	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
+	kubeadmapiv1 "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1beta3"
 	"k8s.io/kubernetes/cmd/kubeadm/app/constants"
 	certsphase "k8s.io/kubernetes/cmd/kubeadm/app/phases/certs"
 	"k8s.io/kubernetes/cmd/kubeadm/app/phases/certs/renewal"
@@ -53,9 +54,10 @@ const (
 	waitForHashes        = "wait-for-hashes"
 	waitForHashChange    = "wait-for-hash-change"
 	waitForPodsWithLabel = "wait-for-pods-with-label"
+)
 
-	testConfiguration = `
-apiVersion: kubeadm.k8s.io/v1beta3
+var testConfiguration = fmt.Sprintf(`
+apiVersion: %s
 kind: InitConfiguration
 nodeRegistration:
   name: foo
@@ -67,26 +69,25 @@ bootstrapTokens:
 - token: ce3aa5.5ec8455bb76b379f
   ttl: 24h
 ---
-apiVersion: kubeadm.k8s.io/v1beta3
+apiVersion: %[1]s
 kind: ClusterConfiguration
 
 apiServer:
   certSANs: null
   extraArgs: null
-certificatesDir: %s
+certificatesDir: %%s
 etcd:
   local:
-    dataDir: %s
+    dataDir: %%s
     image: ""
 imageRepository: k8s.gcr.io
-kubernetesVersion: %s
+kubernetesVersion: %%s
 networking:
   dnsDomain: cluster.local
   podSubnet: ""
   serviceSubnet: 10.96.0.0/12
 useHyperKubeImage: false
-`
-)
+`, kubeadmapiv1.SchemeGroupVersion.String())
 
 // fakeWaiter is a fake apiclient.Waiter that returns errors it was initialized with
 type fakeWaiter struct {

--- a/cmd/kubeadm/app/util/config/cluster_test.go
+++ b/cmd/kubeadm/app/util/config/cluster_test.go
@@ -18,6 +18,7 @@ package config
 
 import (
 	"context"
+	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -37,6 +38,8 @@ import (
 	clientsetfake "k8s.io/client-go/kubernetes/fake"
 	clienttesting "k8s.io/client-go/testing"
 	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
+	kubeadmapiv1old "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1beta2"
+	kubeadmapiv1 "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1beta3"
 	"k8s.io/kubernetes/cmd/kubeadm/app/componentconfigs"
 	kubeadmconstants "k8s.io/kubernetes/cmd/kubeadm/app/constants"
 	testresources "k8s.io/kubernetes/cmd/kubeadm/test/resources"
@@ -46,24 +49,24 @@ var k8sVersionString = kubeadmconstants.MinimumControlPlaneVersion.String()
 var k8sVersion = version.MustParseGeneric(k8sVersionString)
 var nodeName = "mynode"
 var cfgFiles = map[string][]byte{
-	"InitConfiguration_v1beta2": []byte(`
-apiVersion: kubeadm.k8s.io/v1beta2
+	"InitConfiguration_v1beta2": []byte(fmt.Sprintf(`
+apiVersion: %s
 kind: InitConfiguration
-`),
-	"ClusterConfiguration_v1beta2": []byte(`
-apiVersion: kubeadm.k8s.io/v1beta2
+`, kubeadmapiv1old.SchemeGroupVersion.String())),
+	"ClusterConfiguration_v1beta2": []byte(fmt.Sprintf(`
+apiVersion: %s
 kind: ClusterConfiguration
-kubernetesVersion: ` + k8sVersionString + `
-`),
-	"InitConfiguration_v1beta3": []byte(`
-apiVersion: kubeadm.k8s.io/v1beta3
+kubernetesVersion: %s
+`, kubeadmapiv1old.SchemeGroupVersion.String(), k8sVersionString)),
+	"InitConfiguration_v1beta3": []byte(fmt.Sprintf(`
+apiVersion: %s
 kind: InitConfiguration
-`),
-	"ClusterConfiguration_v1beta3": []byte(`
-apiVersion: kubeadm.k8s.io/v1beta3
+`, kubeadmapiv1.SchemeGroupVersion.String())),
+	"ClusterConfiguration_v1beta3": []byte(fmt.Sprintf(`
+apiVersion: %s
 kind: ClusterConfiguration
-kubernetesVersion: ` + k8sVersionString + `
-`),
+kubernetesVersion: %s
+`, kubeadmapiv1.SchemeGroupVersion.String(), k8sVersionString)),
 	"Kube-proxy_componentconfig": []byte(`
 apiVersion: kubeproxy.config.k8s.io/v1alpha1
 kind: KubeProxyConfiguration

--- a/cmd/kubeadm/app/util/config/common_test.go
+++ b/cmd/kubeadm/app/util/config/common_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/lithammer/dedent"
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	kubeadmapiv1old "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1beta2"
 	kubeadmapiv1 "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1beta3"
 	"k8s.io/kubernetes/cmd/kubeadm/app/constants"
 	kubeadmutil "k8s.io/kubernetes/cmd/kubeadm/app/util"
@@ -209,17 +210,17 @@ func TestMigrateOldConfigFromFile(t *testing.T) {
 		},
 		{
 			desc: "bad config produces error",
-			oldCfg: dedent.Dedent(`
-			apiVersion: kubeadm.k8s.io/v1beta2
-			`),
+			oldCfg: dedent.Dedent(fmt.Sprintf(`
+			apiVersion: %s
+			`, kubeadmapiv1old.SchemeGroupVersion.String())),
 			expectErr: true,
 		},
 		{
 			desc: "InitConfiguration only gets migrated",
-			oldCfg: dedent.Dedent(`
-			apiVersion: kubeadm.k8s.io/v1beta2
+			oldCfg: dedent.Dedent(fmt.Sprintf(`
+			apiVersion: %s
 			kind: InitConfiguration
-			`),
+			`, kubeadmapiv1old.SchemeGroupVersion.String())),
 			expectedKinds: []string{
 				constants.InitConfigurationKind,
 				constants.ClusterConfigurationKind,
@@ -228,10 +229,10 @@ func TestMigrateOldConfigFromFile(t *testing.T) {
 		},
 		{
 			desc: "ClusterConfiguration only gets migrated",
-			oldCfg: dedent.Dedent(`
-			apiVersion: kubeadm.k8s.io/v1beta2
+			oldCfg: dedent.Dedent(fmt.Sprintf(`
+			apiVersion: %s
 			kind: ClusterConfiguration
-			`),
+			`, kubeadmapiv1old.SchemeGroupVersion.String())),
 			expectedKinds: []string{
 				constants.InitConfigurationKind,
 				constants.ClusterConfigurationKind,
@@ -240,15 +241,15 @@ func TestMigrateOldConfigFromFile(t *testing.T) {
 		},
 		{
 			desc: "JoinConfiguration only gets migrated",
-			oldCfg: dedent.Dedent(`
-			apiVersion: kubeadm.k8s.io/v1beta2
+			oldCfg: dedent.Dedent(fmt.Sprintf(`
+			apiVersion: %s
 			kind: JoinConfiguration
 			discovery:
 			  bootstrapToken:
 			    token: abcdef.0123456789abcdef
 			    apiServerEndpoint: kube-apiserver:6443
 			    unsafeSkipCAVerification: true
-			`),
+			`, kubeadmapiv1old.SchemeGroupVersion.String())),
 			expectedKinds: []string{
 				constants.JoinConfigurationKind,
 			},
@@ -256,13 +257,13 @@ func TestMigrateOldConfigFromFile(t *testing.T) {
 		},
 		{
 			desc: "Init + Cluster Configurations are migrated",
-			oldCfg: dedent.Dedent(`
-			apiVersion: kubeadm.k8s.io/v1beta2
+			oldCfg: dedent.Dedent(fmt.Sprintf(`
+			apiVersion: %s
 			kind: InitConfiguration
 			---
-			apiVersion: kubeadm.k8s.io/v1beta2
+			apiVersion: %[1]s
 			kind: ClusterConfiguration
-			`),
+			`, kubeadmapiv1old.SchemeGroupVersion.String())),
 			expectedKinds: []string{
 				constants.InitConfigurationKind,
 				constants.ClusterConfigurationKind,
@@ -271,18 +272,18 @@ func TestMigrateOldConfigFromFile(t *testing.T) {
 		},
 		{
 			desc: "Init + Join Configurations are migrated",
-			oldCfg: dedent.Dedent(`
-			apiVersion: kubeadm.k8s.io/v1beta2
+			oldCfg: dedent.Dedent(fmt.Sprintf(`
+			apiVersion: %s
 			kind: InitConfiguration
 			---
-			apiVersion: kubeadm.k8s.io/v1beta2
+			apiVersion: %[1]s
 			kind: JoinConfiguration
 			discovery:
 			  bootstrapToken:
 			    token: abcdef.0123456789abcdef
 			    apiServerEndpoint: kube-apiserver:6443
 			    unsafeSkipCAVerification: true
-			`),
+			`, kubeadmapiv1old.SchemeGroupVersion.String())),
 			expectedKinds: []string{
 				constants.InitConfigurationKind,
 				constants.ClusterConfigurationKind,
@@ -292,18 +293,18 @@ func TestMigrateOldConfigFromFile(t *testing.T) {
 		},
 		{
 			desc: "Cluster + Join Configurations are migrated",
-			oldCfg: dedent.Dedent(`
-			apiVersion: kubeadm.k8s.io/v1beta2
+			oldCfg: dedent.Dedent(fmt.Sprintf(`
+			apiVersion: %s
 			kind: ClusterConfiguration
 			---
-			apiVersion: kubeadm.k8s.io/v1beta2
+			apiVersion: %[1]s
 			kind: JoinConfiguration
 			discovery:
 			  bootstrapToken:
 			    token: abcdef.0123456789abcdef
 			    apiServerEndpoint: kube-apiserver:6443
 			    unsafeSkipCAVerification: true
-			`),
+			`, kubeadmapiv1old.SchemeGroupVersion.String())),
 			expectedKinds: []string{
 				constants.InitConfigurationKind,
 				constants.ClusterConfigurationKind,
@@ -313,21 +314,21 @@ func TestMigrateOldConfigFromFile(t *testing.T) {
 		},
 		{
 			desc: "Init + Cluster + Join Configurations are migrated",
-			oldCfg: dedent.Dedent(`
-			apiVersion: kubeadm.k8s.io/v1beta2
+			oldCfg: dedent.Dedent(fmt.Sprintf(`
+			apiVersion: %s
 			kind: InitConfiguration
 			---
-			apiVersion: kubeadm.k8s.io/v1beta2
+			apiVersion: %[1]s
 			kind: ClusterConfiguration
 			---
-			apiVersion: kubeadm.k8s.io/v1beta2
+			apiVersion: %[1]s
 			kind: JoinConfiguration
 			discovery:
 			  bootstrapToken:
 			    token: abcdef.0123456789abcdef
 			    apiServerEndpoint: kube-apiserver:6443
 			    unsafeSkipCAVerification: true
-			`),
+			`, kubeadmapiv1old.SchemeGroupVersion.String())),
 			expectedKinds: []string{
 				constants.InitConfigurationKind,
 				constants.ClusterConfigurationKind,
@@ -337,14 +338,14 @@ func TestMigrateOldConfigFromFile(t *testing.T) {
 		},
 		{
 			desc: "component configs are not migrated",
-			oldCfg: dedent.Dedent(`
-			apiVersion: kubeadm.k8s.io/v1beta2
+			oldCfg: dedent.Dedent(fmt.Sprintf(`
+			apiVersion: %s
 			kind: InitConfiguration
 			---
-			apiVersion: kubeadm.k8s.io/v1beta2
+			apiVersion: %[1]s
 			kind: ClusterConfiguration
 			---
-			apiVersion: kubeadm.k8s.io/v1beta2
+			apiVersion: %[1]s
 			kind: JoinConfiguration
 			discovery:
 			  bootstrapToken:
@@ -357,7 +358,7 @@ func TestMigrateOldConfigFromFile(t *testing.T) {
 			---
 			apiVersion: kubelet.config.k8s.io/v1beta1
 			kind: KubeletConfiguration
-			`),
+			`, kubeadmapiv1old.SchemeGroupVersion.String())),
 			expectedKinds: []string{
 				constants.InitConfigurationKind,
 				constants.ClusterConfigurationKind,

--- a/cmd/kubeadm/app/util/config/initconfiguration_test.go
+++ b/cmd/kubeadm/app/util/config/initconfiguration_test.go
@@ -118,7 +118,7 @@ func TestDefaultTaintsMarshaling(t *testing.T) {
 			desc: "Uninitialized nodeRegistration field produces a single taint (the master one)",
 			cfg: kubeadmapiv1.InitConfiguration{
 				TypeMeta: metav1.TypeMeta{
-					APIVersion: "kubeadm.k8s.io/v1beta3",
+					APIVersion: kubeadmapiv1.SchemeGroupVersion.String(),
 					Kind:       constants.InitConfigurationKind,
 				},
 			},
@@ -128,7 +128,7 @@ func TestDefaultTaintsMarshaling(t *testing.T) {
 			desc: "Uninitialized taints field produces a single taint (the master one)",
 			cfg: kubeadmapiv1.InitConfiguration{
 				TypeMeta: metav1.TypeMeta{
-					APIVersion: "kubeadm.k8s.io/v1beta3",
+					APIVersion: kubeadmapiv1.SchemeGroupVersion.String(),
 					Kind:       constants.InitConfigurationKind,
 				},
 				NodeRegistration: kubeadmapiv1.NodeRegistrationOptions{},
@@ -139,7 +139,7 @@ func TestDefaultTaintsMarshaling(t *testing.T) {
 			desc: "Forsing taints to an empty slice produces no taints",
 			cfg: kubeadmapiv1.InitConfiguration{
 				TypeMeta: metav1.TypeMeta{
-					APIVersion: "kubeadm.k8s.io/v1beta3",
+					APIVersion: kubeadmapiv1.SchemeGroupVersion.String(),
 					Kind:       constants.InitConfigurationKind,
 				},
 				NodeRegistration: kubeadmapiv1.NodeRegistrationOptions{
@@ -152,7 +152,7 @@ func TestDefaultTaintsMarshaling(t *testing.T) {
 			desc: "Custom taints are used",
 			cfg: kubeadmapiv1.InitConfiguration{
 				TypeMeta: metav1.TypeMeta{
-					APIVersion: "kubeadm.k8s.io/v1beta3",
+					APIVersion: kubeadmapiv1.SchemeGroupVersion.String(),
 					Kind:       constants.InitConfigurationKind,
 				},
 				NodeRegistration: kubeadmapiv1.NodeRegistrationOptions{

--- a/cmd/kubeadm/app/util/config/joinconfiguration_test.go
+++ b/cmd/kubeadm/app/util/config/joinconfiguration_test.go
@@ -17,12 +17,14 @@ limitations under the License.
 package config
 
 import (
+	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/lithammer/dedent"
+	kubeadmapiv1old "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1beta2"
 )
 
 func TestLoadJoinConfigurationFromFile(t *testing.T) {
@@ -45,16 +47,16 @@ func TestLoadJoinConfigurationFromFile(t *testing.T) {
 		},
 		{
 			name: "Invalid v1beta2 causes error",
-			fileContents: dedent.Dedent(`
-				apiVersion: kubeadm.k8s.io/v1beta2
+			fileContents: dedent.Dedent(fmt.Sprintf(`
+				apiVersion: %s
 				kind: JoinConfiguration
-			`),
+			`, kubeadmapiv1old.SchemeGroupVersion.String())),
 			expectErr: true,
 		},
 		{
 			name: "valid v1beta2 is loaded",
-			fileContents: dedent.Dedent(`
-				apiVersion: kubeadm.k8s.io/v1beta2
+			fileContents: dedent.Dedent(fmt.Sprintf(`
+				apiVersion: %s
 				kind: JoinConfiguration
 				caCertPath: /etc/kubernetes/pki/ca.crt
 				discovery:
@@ -64,7 +66,7 @@ func TestLoadJoinConfigurationFromFile(t *testing.T) {
 				    unsafeSkipCAVerification: true
 				  timeout: 5m0s
 				  tlsBootstrapToken: abcdef.0123456789abcdef
-			`),
+			`, kubeadmapiv1old.SchemeGroupVersion.String())),
 		},
 		{
 			name: "Invalid v1beta3 causes error",


### PR DESCRIPTION
Signed-off-by: wangyysde <net_use@bzhy.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
To smaller DIFFs when sending big API update PRs to change the latest API version,replaced kubeadm.k8s.io/v1beta3 with kubeadmapiv1.SchemeGroupVersion.String() .
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes kubernetes/kubeadm#2453

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
