### PR TITLE
kubelet_running_pods shows number of pods that have a running pod sandbox

### DIFF
--- a/pkg/kubelet/metrics/metrics.go
+++ b/pkg/kubelet/metrics/metrics.go
@@ -412,12 +412,13 @@ var (
 		[]string{"runtime_handler"},
 	)
 
-	// RunningPodCount is a gauge that tracks the number of Pods currently running
+	// RunningPodCount is a gauge that tracks the number of Pods currently with a running sandbox
+	// It is used to expose the kubelet internal state: how many pods have running containers in the container runtime, and mainly for debugging purpose.
 	RunningPodCount = metrics.NewGauge(
 		&metrics.GaugeOpts{
 			Subsystem:      KubeletSubsystem,
 			Name:           RunningPodsKey,
-			Help:           "Number of pods currently running",
+			Help:           "Number of pods that have a running pod sandbox",
 			StabilityLevel: metrics.ALPHA,
 		},
 	)

--- a/pkg/kubelet/pleg/generic_test.go
+++ b/pkg/kubelet/pleg/generic_test.go
@@ -702,7 +702,7 @@ kubelet_running_containers{container_state="unknown"} 2
 			name:        "test pod count",
 			metricsName: "kubelet_running_pods",
 			wants: `
-# HELP kubelet_running_pods [ALPHA] Number of pods currently running
+# HELP kubelet_running_pods [ALPHA] Number of pods that have a running pod sandbox
 # TYPE kubelet_running_pods gauge
 kubelet_running_pods 2
 `,


### PR DESCRIPTION
#### What type of PR is this?
/kind documentation

#### What this PR does / why we need it:
To make it much clearer:

`Number of pods currently running`
to
`Number of pods that have a running pod sandbox`

#### Which issue(s) this PR fixes:
Fixes #99624

#### Special notes for your reviewer:
https://github.com/kubernetes/kubernetes/issues/99624#issuecomment-823412461
> IIRC, kubelet_running_pods is not intended to reflect the pod phase in the API server.
> 
> It is used to expose the kubelet internal state: how many pods have running containers in the container runtime, and mainly for debugging purpose.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```