### PR TITLE
[1.21] Automated cherry pick of #101306: Additional CVE-2021-3121 fix

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity_proto.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity_proto.go
@@ -166,7 +166,7 @@ func (m *Quantity) Unmarshal(data []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthGenerated
 			}
 			if (iNdEx + skippy) > l {


### PR DESCRIPTION
Cherry pick of #101306 on release-1.21.

#101306: Additional CVE-2021-3121 fix

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
NONE
```