### PR TITLE
apply test for manager limit to only use v1 apis

### DIFF
--- a/test/integration/apiserver/apply/apply_test.go
+++ b/test/integration/apiserver/apply/apply_test.go
@@ -403,12 +403,8 @@ func TestApplyGroupsManySeparateUpdates(t *testing.T) {
 
 	for i := 0; i < 20; i++ {
 		unique := fmt.Sprintf("updater%v", i)
-		version := "v1"
-		if i%2 == 0 {
-			version = "v1beta1"
-		}
 		object, err = client.CoreV1().RESTClient().Patch(types.MergePatchType).
-			AbsPath("/apis/admissionregistration.k8s.io/"+version).
+			AbsPath("/apis/admissionregistration.k8s.io/v1").
 			Resource("validatingwebhookconfigurations").
 			Name("webhook").
 			Param("fieldManager", unique).


### PR DESCRIPTION
found in https://github.com/kubernetes/kubernetes/pull/99840

This updates the apply ownership test to use a GA API instead of a v1beta1 API that is removed in 1.22

/kind clean
/priority important-soon
@kubernetes/sig-api-machinery-pr-reviews 
/assign @apelisse 

```release-note
NONE
```