### PR TITLE
Promote NamespaceDefaultLabelName to GA

### DIFF
--- a/pkg/apis/core/v1/defaults_test.go
+++ b/pkg/apis/core/v1/defaults_test.go
@@ -1417,9 +1417,6 @@ func TestSetDefaultNamespace(t *testing.T) {
 }
 
 func TestSetDefaultNamespaceLabels(t *testing.T) {
-	// Although this is defaulted to true, it's still worth to enable the feature gate during the test
-	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.NamespaceDefaultLabelName, true)()
-
 	theNs := "default-ns-labels-are-great"
 	s := &v1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
@@ -1431,22 +1428,6 @@ func TestSetDefaultNamespaceLabels(t *testing.T) {
 
 	if s2.ObjectMeta.Labels[v1.LabelMetadataName] != theNs {
 		t.Errorf("Expected default namespace label value of %v, but got %v", theNs, s2.ObjectMeta.Labels[v1.LabelMetadataName])
-	}
-
-	// And let's disable the FG and check if it still defaults creating the labels
-	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.NamespaceDefaultLabelName, false)()
-
-	theNs = "default-ns-labels-are-not-that-great"
-	s = &v1.Namespace{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: theNs,
-		},
-	}
-	obj2 = roundTrip(t, runtime.Object(s))
-	s2 = obj2.(*v1.Namespace)
-
-	if _, ok := s2.ObjectMeta.Labels[v1.LabelMetadataName]; ok {
-		t.Errorf("Default namespace shouldn't exist here, as the feature gate is disabled %v", s)
 	}
 }
 

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -748,6 +748,7 @@ const (
 
 	// owner: @jayunit100 @abhiraut @rikatz
 	// beta: v1.21
+	// ga: v1.22
 	//
 	// Labels all namespaces with a default label "kubernetes.io/metadata.name: <namespaceName>"
 	NamespaceDefaultLabelName featuregate.Feature = "NamespaceDefaultLabelName"
@@ -869,7 +870,7 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
 	ServiceInternalTrafficPolicy:                   {Default: false, PreRelease: featuregate.Alpha},
 	SuspendJob:                                     {Default: false, PreRelease: featuregate.Alpha},
 	KubeletPodResourcesGetAllocatable:              {Default: false, PreRelease: featuregate.Alpha},
-	NamespaceDefaultLabelName:                      {Default: true, PreRelease: featuregate.Beta}, // graduate to GA and lock to default in 1.22, remove in 1.24
+	NamespaceDefaultLabelName:                      {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.24
 	CSIVolumeHealth:                                {Default: false, PreRelease: featuregate.Alpha},
 
 	// inherited features from generic apiserver, relisted here to get a conflict if it is changed


### PR DESCRIPTION
/kind feature


#### What this PR does / why we need it:
Promote NamespaceDefaultLabelName to GA
Follow-up to https://github.com/kubernetes/kubernetes/pull/96968


#### Does this PR introduce a user-facing change?
```release-note
Promote NamespaceDefaultLabelName to GA.  All Namespace API objects have a `kubernetes.io/metadata.name` label matching their metadata.name field to allow selecting any namespace by its name using a label selector.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
- [KEP]: https://github.com/kubernetes/enhancements/pull/2162
```
