### PR TITLE
Automated cherry pick of #99336: pkg/kubelet: improve the node informer sync check

### DIFF
--- a/pkg/kubelet/config/apiserver.go
+++ b/pkg/kubelet/config/apiserver.go
@@ -17,21 +17,42 @@ limitations under the License.
 package config
 
 import (
-	"k8s.io/api/core/v1"
+	"time"
+
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
+	"k8s.io/klog"
 	api "k8s.io/kubernetes/pkg/apis/core"
 	kubetypes "k8s.io/kubernetes/pkg/kubelet/types"
 )
 
+// WaitForAPIServerSyncPeriod is the period between checks for the node list/watch initial sync
+const WaitForAPIServerSyncPeriod = 1 * time.Second
+
 // NewSourceApiserver creates a config source that watches and pulls from the apiserver.
-func NewSourceApiserver(c clientset.Interface, nodeName types.NodeName, updates chan<- interface{}) {
+func NewSourceApiserver(c clientset.Interface, nodeName types.NodeName, nodeHasSynced func() bool, updates chan<- interface{}) {
 	lw := cache.NewListWatchFromClient(c.CoreV1().RESTClient(), "pods", metav1.NamespaceAll, fields.OneTermEqualSelector(api.PodHostField, string(nodeName)))
-	newSourceApiserverFromLW(lw, updates)
+
+	// The Reflector responsible for watching pods at the apiserver should be run only after
+	// the node sync with the apiserver has completed.
+	klog.Info("Waiting for node sync before watching apiserver pods")
+	go func() {
+		for {
+			if nodeHasSynced() {
+				klog.V(4).Info("node sync completed")
+				break
+			}
+			time.Sleep(WaitForAPIServerSyncPeriod)
+			klog.V(4).Info("node sync has not completed yet")
+		}
+		klog.Info("Watching apiserver")
+		newSourceApiserverFromLW(lw, updates)
+	}()
 }
 
 // newSourceApiserverFromLW holds creates a config source that watches and pulls from the apiserver.

--- a/pkg/kubelet/kubelet_getters.go
+++ b/pkg/kubelet/kubelet_getters.go
@@ -22,7 +22,6 @@ import (
 	"io/ioutil"
 	"net"
 	"path/filepath"
-	"time"
 
 	cadvisorapiv1 "github.com/google/cadvisor/info/v1"
 	"k8s.io/klog"
@@ -31,7 +30,6 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/kubernetes/pkg/kubelet/cm"
 	"k8s.io/kubernetes/pkg/kubelet/config"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
@@ -234,15 +232,6 @@ func (kl *Kubelet) GetNode() (*v1.Node, error) {
 	if kl.kubeClient == nil {
 		return kl.initialNode(context.TODO())
 	}
-	// if we have a valid kube client, we wait for initial lister to sync
-	if !kl.nodeHasSynced() {
-		err := wait.PollImmediate(time.Second, maxWaitForAPIServerSync, func() (bool, error) {
-			return kl.nodeHasSynced(), nil
-		})
-		if err != nil {
-			return nil, fmt.Errorf("nodes have not yet been read at least once, cannot construct node object")
-		}
-	}
 	return kl.nodeLister.Get(string(kl.nodeName))
 }
 
@@ -253,7 +242,7 @@ func (kl *Kubelet) GetNode() (*v1.Node, error) {
 // zero capacity, and the default labels.
 func (kl *Kubelet) getNodeAnyWay() (*v1.Node, error) {
 	if kl.kubeClient != nil {
-		if n, err := kl.GetNode(); err == nil {
+		if n, err := kl.nodeLister.Get(string(kl.nodeName)); err == nil {
 			return n, nil
 		}
 	}


### PR DESCRIPTION
Cherry pick of #99336 on release-1.18.

#99336: pkg/kubelet: improve the node informer sync check

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
kubelet: fixes a performance regression in 1.18.16 when waiting for a synchronization of the node list with the kube-apiserver
```