### PR TITLE
Automated cherry pick of #96882: Make parallel build memory threshold configurable

### DIFF
--- a/hack/lib/golang.sh
+++ b/hack/lib/golang.sh
@@ -305,9 +305,10 @@ readonly KUBE_TEST_SERVER_BINARIES=("${KUBE_TEST_SERVER_TARGETS[@]##*/}")
 readonly KUBE_TEST_SERVER_PLATFORMS=("${KUBE_SERVER_PLATFORMS[@]:+"${KUBE_SERVER_PLATFORMS[@]}"}")
 
 # Gigabytes necessary for parallel platform builds.
-# As of January 2018, RAM usage is exceeding 30G
-# Setting to 40 to provide some headroom
-readonly KUBE_PARALLEL_BUILD_MEMORY=40
+# As of January 2018, RAM usage is exceeding 30G.
+# This variable can be overwritten at your own risk.
+# It's defaulting to 40G to provide some headroom
+readonly KUBE_PARALLEL_BUILD_MEMORY=${KUBE_PARALLEL_BUILD_MEMORY:-40}
 
 readonly KUBE_ALL_TARGETS=(
   "${KUBE_SERVER_TARGETS[@]}"


### PR DESCRIPTION
Cherry pick of #96882 on release-1.20.

#96882: Make parallel build memory threshold configurable

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.