### PR TITLE
change http code to 400 for invalid resourceVersion for GET rest apis

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher.go
@@ -554,7 +554,7 @@ func (c *Cacher) Get(ctx context.Context, key string, opts storage.GetOptions, o
 	// fresh as the given resourceVersion.
 	getRV, err := c.versioner.ParseResourceVersion(opts.ResourceVersion)
 	if err != nil {
-		return err
+		return errors.NewBadRequest(fmt.Sprintf("invalid resource version: %v", err))
 	}
 
 	if getRV == 0 && !c.ready.check() {

--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/store.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/store.go
@@ -825,7 +825,7 @@ func (s *store) WatchList(ctx context.Context, key string, opts storage.ListOpti
 func (s *store) watch(ctx context.Context, key string, opts storage.ListOptions, recursive bool) (watch.Interface, error) {
 	rev, err := s.versioner.ParseResourceVersion(opts.ResourceVersion)
 	if err != nil {
-		return nil, err
+		return nil, apierrors.NewBadRequest(fmt.Sprintf("invalid resource version: %v", err))
 	}
 	key = path.Join(s.pathPrefix, key)
 	return s.watcher.Watch(ctx, key, int64(rev), recursive, opts.ProgressNotify, opts.Predicate)


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
Fixes #101350

#### Special notes for your reviewer:
NewInvalidError is 500?
change to "errors.NewBadRequest" to be 400

#### Does this PR introduce a user-facing change?
```release-note
return 400 for invalid resourceVersion in GET REST APIs
```