### PR TITLE
kubelet: add optional synchronization to podKiller KillPod and fix race in HandlePodCleanups

### DIFF
--- a/pkg/kubelet/kubelet_test.go
+++ b/pkg/kubelet/kubelet_test.go
@@ -1622,7 +1622,9 @@ func TestDoesNotDeletePodDirsForTerminatedPods(t *testing.T) {
 
 func TestDoesNotDeletePodDirsIfContainerIsRunning(t *testing.T) {
 	testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled */)
+	go testKubelet.kubelet.podKiller.PerformPodKillingWork()
 	defer testKubelet.Cleanup()
+	defer testKubelet.kubelet.podKiller.Close()
 	runningPod := &kubecontainer.Pod{
 		ID:        "12345678",
 		Name:      "pod1",


### PR DESCRIPTION
#### What type of PR is this?
/kind bug
/sig node
/priority important-soon

#### What this PR does / why we need it:
HandlePodCleanups is racing to try and cleanup pods when they are already being killed. This leads to problems with volume unmounts and cgroup removals, such as cgroups or volumes being busy. This patch changes the podkiller to return a channel to optionally allow the caller to block on the pod kill.

The following source is the racing block:
https://github.com/kubernetes/kubernetes/blob/6af7eb6d494d8f742e18a3b965053e3a518bf6d7/pkg/kubelet/kubelet_pods.go#L1110-L1114

This comment is important:
https://github.com/kubernetes/kubernetes/blob/6af7eb6d494d8f742e18a3b965053e3a518bf6d7/pkg/kubelet/kubelet_pods.go#L1117-L1120

If the pod is already in the kill goroutine then kl.podKiller.KillPod is a no-op. The patch changes the behavior to return the channel and synchronizes with a WaitGroup, so the kill pods happen in parallel, but block until they are done.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:
cc @ehashman @sjenning @mrunalp @harche @derekwaynecarr 

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
