### PR TITLE
[WIP] Wire contexts through to KCM controllers

### DIFF
--- a/cmd/kube-controller-manager/app/apps.go
+++ b/cmd/kube-controller-manager/app/apps.go
@@ -49,7 +49,7 @@ func startDaemonSetController(ctx context.Context, controllerContext ControllerC
 	if err != nil {
 		return nil, true, fmt.Errorf("error creating DaemonSets controller: %v", err)
 	}
-	go dsc.Run(int(controllerContext.ComponentConfig.DaemonSetController.ConcurrentDaemonSetSyncs), controllerContext.Stop)
+	go dsc.Run(ctx, int(controllerContext.ComponentConfig.DaemonSetController.ConcurrentDaemonSetSyncs), controllerContext.Stop)
 	return nil, true, nil
 }
 
@@ -63,7 +63,7 @@ func startStatefulSetController(ctx context.Context, controllerContext Controlle
 		controllerContext.InformerFactory.Core().V1().PersistentVolumeClaims(),
 		controllerContext.InformerFactory.Apps().V1().ControllerRevisions(),
 		controllerContext.ClientBuilder.ClientOrDie("statefulset-controller"),
-	).Run(int(controllerContext.ComponentConfig.StatefulSetController.ConcurrentStatefulSetSyncs), controllerContext.Stop)
+	).Run(ctx, int(controllerContext.ComponentConfig.StatefulSetController.ConcurrentStatefulSetSyncs), controllerContext.Stop)
 	return nil, true, nil
 }
 
@@ -76,7 +76,7 @@ func startReplicaSetController(ctx context.Context, controllerContext Controller
 		controllerContext.InformerFactory.Core().V1().Pods(),
 		controllerContext.ClientBuilder.ClientOrDie("replicaset-controller"),
 		replicaset.BurstReplicas,
-	).Run(int(controllerContext.ComponentConfig.ReplicaSetController.ConcurrentRSSyncs), controllerContext.Stop)
+	).Run(ctx, int(controllerContext.ComponentConfig.ReplicaSetController.ConcurrentRSSyncs), controllerContext.Stop)
 	return nil, true, nil
 }
 
@@ -93,6 +93,6 @@ func startDeploymentController(ctx context.Context, controllerContext Controller
 	if err != nil {
 		return nil, true, fmt.Errorf("error creating Deployment controller: %v", err)
 	}
-	go dc.Run(int(controllerContext.ComponentConfig.DeploymentController.ConcurrentDeploymentSyncs), controllerContext.Stop)
+	go dc.Run(ctx, int(controllerContext.ComponentConfig.DeploymentController.ConcurrentDeploymentSyncs), controllerContext.Stop)
 	return nil, true, nil
 }

--- a/cmd/kube-controller-manager/app/apps.go
+++ b/cmd/kube-controller-manager/app/apps.go
@@ -21,6 +21,7 @@ limitations under the License.
 package app
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"time"
@@ -33,65 +34,65 @@ import (
 	"k8s.io/kubernetes/pkg/controller/statefulset"
 )
 
-func startDaemonSetController(ctx ControllerContext) (http.Handler, bool, error) {
-	if !ctx.AvailableResources[schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "daemonsets"}] {
+func startDaemonSetController(ctx context.Context, controllerContext ControllerContext) (http.Handler, bool, error) {
+	if !controllerContext.AvailableResources[schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "daemonsets"}] {
 		return nil, false, nil
 	}
 	dsc, err := daemon.NewDaemonSetsController(
-		ctx.InformerFactory.Apps().V1().DaemonSets(),
-		ctx.InformerFactory.Apps().V1().ControllerRevisions(),
-		ctx.InformerFactory.Core().V1().Pods(),
-		ctx.InformerFactory.Core().V1().Nodes(),
-		ctx.ClientBuilder.ClientOrDie("daemon-set-controller"),
+		controllerContext.InformerFactory.Apps().V1().DaemonSets(),
+		controllerContext.InformerFactory.Apps().V1().ControllerRevisions(),
+		controllerContext.InformerFactory.Core().V1().Pods(),
+		controllerContext.InformerFactory.Core().V1().Nodes(),
+		controllerContext.ClientBuilder.ClientOrDie("daemon-set-controller"),
 		flowcontrol.NewBackOff(1*time.Second, 15*time.Minute),
 	)
 	if err != nil {
 		return nil, true, fmt.Errorf("error creating DaemonSets controller: %v", err)
 	}
-	go dsc.Run(int(ctx.ComponentConfig.DaemonSetController.ConcurrentDaemonSetSyncs), ctx.Stop)
+	go dsc.Run(int(controllerContext.ComponentConfig.DaemonSetController.ConcurrentDaemonSetSyncs), controllerContext.Stop)
 	return nil, true, nil
 }
 
-func startStatefulSetController(ctx ControllerContext) (http.Handler, bool, error) {
-	if !ctx.AvailableResources[schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "statefulsets"}] {
+func startStatefulSetController(ctx context.Context, controllerContext ControllerContext) (http.Handler, bool, error) {
+	if !controllerContext.AvailableResources[schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "statefulsets"}] {
 		return nil, false, nil
 	}
 	go statefulset.NewStatefulSetController(
-		ctx.InformerFactory.Core().V1().Pods(),
-		ctx.InformerFactory.Apps().V1().StatefulSets(),
-		ctx.InformerFactory.Core().V1().PersistentVolumeClaims(),
-		ctx.InformerFactory.Apps().V1().ControllerRevisions(),
-		ctx.ClientBuilder.ClientOrDie("statefulset-controller"),
-	).Run(int(ctx.ComponentConfig.StatefulSetController.ConcurrentStatefulSetSyncs), ctx.Stop)
+		controllerContext.InformerFactory.Core().V1().Pods(),
+		controllerContext.InformerFactory.Apps().V1().StatefulSets(),
+		controllerContext.InformerFactory.Core().V1().PersistentVolumeClaims(),
+		controllerContext.InformerFactory.Apps().V1().ControllerRevisions(),
+		controllerContext.ClientBuilder.ClientOrDie("statefulset-controller"),
+	).Run(int(controllerContext.ComponentConfig.StatefulSetController.ConcurrentStatefulSetSyncs), controllerContext.Stop)
 	return nil, true, nil
 }
 
-func startReplicaSetController(ctx ControllerContext) (http.Handler, bool, error) {
-	if !ctx.AvailableResources[schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "replicasets"}] {
+func startReplicaSetController(ctx context.Context, controllerContext ControllerContext) (http.Handler, bool, error) {
+	if !controllerContext.AvailableResources[schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "replicasets"}] {
 		return nil, false, nil
 	}
 	go replicaset.NewReplicaSetController(
-		ctx.InformerFactory.Apps().V1().ReplicaSets(),
-		ctx.InformerFactory.Core().V1().Pods(),
-		ctx.ClientBuilder.ClientOrDie("replicaset-controller"),
+		controllerContext.InformerFactory.Apps().V1().ReplicaSets(),
+		controllerContext.InformerFactory.Core().V1().Pods(),
+		controllerContext.ClientBuilder.ClientOrDie("replicaset-controller"),
 		replicaset.BurstReplicas,
-	).Run(int(ctx.ComponentConfig.ReplicaSetController.ConcurrentRSSyncs), ctx.Stop)
+	).Run(int(controllerContext.ComponentConfig.ReplicaSetController.ConcurrentRSSyncs), controllerContext.Stop)
 	return nil, true, nil
 }
 
-func startDeploymentController(ctx ControllerContext) (http.Handler, bool, error) {
-	if !ctx.AvailableResources[schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"}] {
+func startDeploymentController(ctx context.Context, controllerContext ControllerContext) (http.Handler, bool, error) {
+	if !controllerContext.AvailableResources[schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"}] {
 		return nil, false, nil
 	}
 	dc, err := deployment.NewDeploymentController(
-		ctx.InformerFactory.Apps().V1().Deployments(),
-		ctx.InformerFactory.Apps().V1().ReplicaSets(),
-		ctx.InformerFactory.Core().V1().Pods(),
-		ctx.ClientBuilder.ClientOrDie("deployment-controller"),
+		controllerContext.InformerFactory.Apps().V1().Deployments(),
+		controllerContext.InformerFactory.Apps().V1().ReplicaSets(),
+		controllerContext.InformerFactory.Core().V1().Pods(),
+		controllerContext.ClientBuilder.ClientOrDie("deployment-controller"),
 	)
 	if err != nil {
 		return nil, true, fmt.Errorf("error creating Deployment controller: %v", err)
 	}
-	go dc.Run(int(ctx.ComponentConfig.DeploymentController.ConcurrentDeploymentSyncs), ctx.Stop)
+	go dc.Run(int(controllerContext.ComponentConfig.DeploymentController.ConcurrentDeploymentSyncs), controllerContext.Stop)
 	return nil, true, nil
 }

--- a/cmd/kube-controller-manager/app/autoscaling.go
+++ b/cmd/kube-controller-manager/app/autoscaling.go
@@ -21,6 +21,7 @@ limitations under the License.
 package app
 
 import (
+	"context"
 	"net/http"
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -34,17 +35,17 @@ import (
 	"k8s.io/metrics/pkg/client/external_metrics"
 )
 
-func startHPAController(ctx ControllerContext) (http.Handler, bool, error) {
-	if !ctx.AvailableResources[schema.GroupVersionResource{Group: "autoscaling", Version: "v1", Resource: "horizontalpodautoscalers"}] {
+func startHPAController(ctx context.Context, controllerContext ControllerContext) (http.Handler, bool, error) {
+	if !controllerContext.AvailableResources[schema.GroupVersionResource{Group: "autoscaling", Version: "v1", Resource: "horizontalpodautoscalers"}] {
 		return nil, false, nil
 	}
 
-	if ctx.ComponentConfig.HPAController.HorizontalPodAutoscalerUseRESTClients {
+	if controllerContext.ComponentConfig.HPAController.HorizontalPodAutoscalerUseRESTClients {
 		// use the new-style clients if support for custom metrics is enabled
-		return startHPAControllerWithRESTClient(ctx)
+		return startHPAControllerWithRESTClient(controllerContext)
 	}
 
-	return startHPAControllerWithLegacyClient(ctx)
+	return startHPAControllerWithLegacyClient(controllerContext)
 }
 
 func startHPAControllerWithRESTClient(ctx ControllerContext) (http.Handler, bool, error) {

--- a/cmd/kube-controller-manager/app/batch.go
+++ b/cmd/kube-controller-manager/app/batch.go
@@ -40,7 +40,7 @@ func startJobController(ctx context.Context, controllerContext ControllerContext
 		controllerContext.InformerFactory.Core().V1().Pods(),
 		controllerContext.InformerFactory.Batch().V1().Jobs(),
 		controllerContext.ClientBuilder.ClientOrDie("job-controller"),
-	).Run(int(controllerContext.ComponentConfig.JobController.ConcurrentJobSyncs), controllerContext.Stop)
+	).Run(ctx, int(controllerContext.ComponentConfig.JobController.ConcurrentJobSyncs), controllerContext.Stop)
 	return nil, true, nil
 }
 
@@ -65,6 +65,6 @@ func startCronJobController(ctx context.Context, controllerContext ControllerCon
 	if err != nil {
 		return nil, true, fmt.Errorf("error creating CronJob controller: %v", err)
 	}
-	go cjc.Run(controllerContext.Stop)
+	go cjc.Run(ctx, controllerContext.Stop)
 	return nil, true, nil
 }

--- a/cmd/kube-controller-manager/app/bootstrap.go
+++ b/cmd/kube-controller-manager/app/bootstrap.go
@@ -17,6 +17,7 @@ limitations under the License.
 package app
 
 import (
+	"context"
 	"fmt"
 
 	"net/http"
@@ -24,29 +25,29 @@ import (
 	"k8s.io/kubernetes/pkg/controller/bootstrap"
 )
 
-func startBootstrapSignerController(ctx ControllerContext) (http.Handler, bool, error) {
+func startBootstrapSignerController(ctx context.Context, controllerContext ControllerContext) (http.Handler, bool, error) {
 	bsc, err := bootstrap.NewSigner(
-		ctx.ClientBuilder.ClientOrDie("bootstrap-signer"),
-		ctx.InformerFactory.Core().V1().Secrets(),
-		ctx.InformerFactory.Core().V1().ConfigMaps(),
+		controllerContext.ClientBuilder.ClientOrDie("bootstrap-signer"),
+		controllerContext.InformerFactory.Core().V1().Secrets(),
+		controllerContext.InformerFactory.Core().V1().ConfigMaps(),
 		bootstrap.DefaultSignerOptions(),
 	)
 	if err != nil {
 		return nil, true, fmt.Errorf("error creating BootstrapSigner controller: %v", err)
 	}
-	go bsc.Run(ctx.Stop)
+	go bsc.Run(controllerContext.Stop)
 	return nil, true, nil
 }
 
-func startTokenCleanerController(ctx ControllerContext) (http.Handler, bool, error) {
+func startTokenCleanerController(ctx context.Context, controllerContext ControllerContext) (http.Handler, bool, error) {
 	tcc, err := bootstrap.NewTokenCleaner(
-		ctx.ClientBuilder.ClientOrDie("token-cleaner"),
-		ctx.InformerFactory.Core().V1().Secrets(),
+		controllerContext.ClientBuilder.ClientOrDie("token-cleaner"),
+		controllerContext.InformerFactory.Core().V1().Secrets(),
 		bootstrap.DefaultTokenCleanerOptions(),
 	)
 	if err != nil {
 		return nil, true, fmt.Errorf("error creating TokenCleaner controller: %v", err)
 	}
-	go tcc.Run(ctx.Stop)
+	go tcc.Run(controllerContext.Stop)
 	return nil, true, nil
 }

--- a/cmd/kube-controller-manager/app/bootstrap.go
+++ b/cmd/kube-controller-manager/app/bootstrap.go
@@ -35,7 +35,7 @@ func startBootstrapSignerController(ctx context.Context, controllerContext Contr
 	if err != nil {
 		return nil, true, fmt.Errorf("error creating BootstrapSigner controller: %v", err)
 	}
-	go bsc.Run(controllerContext.Stop)
+	go bsc.Run(ctx, controllerContext.Stop)
 	return nil, true, nil
 }
 
@@ -48,6 +48,6 @@ func startTokenCleanerController(ctx context.Context, controllerContext Controll
 	if err != nil {
 		return nil, true, fmt.Errorf("error creating TokenCleaner controller: %v", err)
 	}
-	go tcc.Run(controllerContext.Stop)
+	go tcc.Run(ctx, controllerContext.Stop)
 	return nil, true, nil
 }

--- a/cmd/kube-controller-manager/app/certificates.go
+++ b/cmd/kube-controller-manager/app/certificates.go
@@ -58,7 +58,7 @@ func startCSRSigningController(ctx context.Context, controllerContext Controller
 		if err != nil {
 			return nil, false, fmt.Errorf("failed to start kubernetes.io/kubelet-serving certificate controller: %v", err)
 		}
-		go kubeletServingSigner.Run(5, controllerContext.Stop)
+		go kubeletServingSigner.Run(ctx, 5, controllerContext.Stop)
 	} else {
 		klog.V(2).Infof("skipping CSR signer controller %q because specific files were specified for other signers and not this one.", "kubernetes.io/kubelet-serving")
 	}
@@ -68,7 +68,7 @@ func startCSRSigningController(ctx context.Context, controllerContext Controller
 		if err != nil {
 			return nil, false, fmt.Errorf("failed to start kubernetes.io/kube-apiserver-client-kubelet certificate controller: %v", err)
 		}
-		go kubeletClientSigner.Run(5, controllerContext.Stop)
+		go kubeletClientSigner.Run(ctx, 5, controllerContext.Stop)
 	} else {
 		klog.V(2).Infof("skipping CSR signer controller %q because specific files were specified for other signers and not this one.", "kubernetes.io/kube-apiserver-client-kubelet")
 	}
@@ -78,7 +78,7 @@ func startCSRSigningController(ctx context.Context, controllerContext Controller
 		if err != nil {
 			return nil, false, fmt.Errorf("failed to start kubernetes.io/kube-apiserver-client certificate controller: %v", err)
 		}
-		go kubeAPIServerClientSigner.Run(5, controllerContext.Stop)
+		go kubeAPIServerClientSigner.Run(ctx, 5, controllerContext.Stop)
 	} else {
 		klog.V(2).Infof("skipping CSR signer controller %q because specific files were specified for other signers and not this one.", "kubernetes.io/kube-apiserver-client")
 	}
@@ -88,7 +88,7 @@ func startCSRSigningController(ctx context.Context, controllerContext Controller
 		if err != nil {
 			return nil, false, fmt.Errorf("failed to start kubernetes.io/legacy-unknown certificate controller: %v", err)
 		}
-		go legacyUnknownSigner.Run(5, controllerContext.Stop)
+		go legacyUnknownSigner.Run(ctx, 5, controllerContext.Stop)
 	} else {
 		klog.V(2).Infof("skipping CSR signer controller %q because specific files were specified for other signers and not this one.", "kubernetes.io/legacy-unknown")
 	}
@@ -177,7 +177,7 @@ func startCSRApprovingController(ctx context.Context, controllerContext Controll
 		controllerContext.ClientBuilder.ClientOrDie("certificate-controller"),
 		controllerContext.InformerFactory.Certificates().V1().CertificateSigningRequests(),
 	)
-	go approver.Run(5, controllerContext.Stop)
+	go approver.Run(ctx, 5, controllerContext.Stop)
 
 	return nil, true, nil
 }
@@ -187,7 +187,7 @@ func startCSRCleanerController(ctx context.Context, controllerContext Controller
 		controllerContext.ClientBuilder.ClientOrDie("certificate-controller").CertificatesV1().CertificateSigningRequests(),
 		controllerContext.InformerFactory.Certificates().V1().CertificateSigningRequests(),
 	)
-	go cleaner.Run(1, controllerContext.Stop)
+	go cleaner.Run(ctx, 1, controllerContext.Stop)
 	return nil, true, nil
 }
 
@@ -213,6 +213,6 @@ func startRootCACertPublisher(ctx context.Context, controllerContext ControllerC
 	if err != nil {
 		return nil, true, fmt.Errorf("error creating root CA certificate publisher: %v", err)
 	}
-	go sac.Run(1, controllerContext.Stop)
+	go sac.Run(ctx, 1, controllerContext.Stop)
 	return nil, true, nil
 }

--- a/cmd/kube-controller-manager/app/certificates.go
+++ b/cmd/kube-controller-manager/app/certificates.go
@@ -21,6 +21,7 @@ limitations under the License.
 package app
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 
@@ -33,61 +34,61 @@ import (
 	csrsigningconfig "k8s.io/kubernetes/pkg/controller/certificates/signer/config"
 )
 
-func startCSRSigningController(ctx ControllerContext) (http.Handler, bool, error) {
+func startCSRSigningController(ctx context.Context, controllerContext ControllerContext) (http.Handler, bool, error) {
 	gvr := schema.GroupVersionResource{Group: "certificates.k8s.io", Version: "v1", Resource: "certificatesigningrequests"}
-	if !ctx.AvailableResources[gvr] {
+	if !controllerContext.AvailableResources[gvr] {
 		klog.Warningf("Resource %s is not available now", gvr.String())
 		return nil, false, nil
 	}
-	missingSingleSigningFile := ctx.ComponentConfig.CSRSigningController.ClusterSigningCertFile == "" || ctx.ComponentConfig.CSRSigningController.ClusterSigningKeyFile == ""
-	if missingSingleSigningFile && !anySpecificFilesSet(ctx.ComponentConfig.CSRSigningController) {
+	missingSingleSigningFile := controllerContext.ComponentConfig.CSRSigningController.ClusterSigningCertFile == "" || controllerContext.ComponentConfig.CSRSigningController.ClusterSigningKeyFile == ""
+	if missingSingleSigningFile && !anySpecificFilesSet(controllerContext.ComponentConfig.CSRSigningController) {
 		klog.V(2).Info("skipping CSR signer controller because no csr cert/key was specified")
 		return nil, false, nil
 	}
-	if !missingSingleSigningFile && anySpecificFilesSet(ctx.ComponentConfig.CSRSigningController) {
+	if !missingSingleSigningFile && anySpecificFilesSet(controllerContext.ComponentConfig.CSRSigningController) {
 		return nil, false, fmt.Errorf("cannot specify default and per controller certs at the same time")
 	}
 
-	c := ctx.ClientBuilder.ClientOrDie("certificate-controller")
-	csrInformer := ctx.InformerFactory.Certificates().V1().CertificateSigningRequests()
-	certTTL := ctx.ComponentConfig.CSRSigningController.ClusterSigningDuration.Duration
+	c := controllerContext.ClientBuilder.ClientOrDie("certificate-controller")
+	csrInformer := controllerContext.InformerFactory.Certificates().V1().CertificateSigningRequests()
+	certTTL := controllerContext.ComponentConfig.CSRSigningController.ClusterSigningDuration.Duration
 
-	if kubeletServingSignerCertFile, kubeletServingSignerKeyFile := getKubeletServingSignerFiles(ctx.ComponentConfig.CSRSigningController); len(kubeletServingSignerCertFile) > 0 || len(kubeletServingSignerKeyFile) > 0 {
+	if kubeletServingSignerCertFile, kubeletServingSignerKeyFile := getKubeletServingSignerFiles(controllerContext.ComponentConfig.CSRSigningController); len(kubeletServingSignerCertFile) > 0 || len(kubeletServingSignerKeyFile) > 0 {
 		kubeletServingSigner, err := signer.NewKubeletServingCSRSigningController(c, csrInformer, kubeletServingSignerCertFile, kubeletServingSignerKeyFile, certTTL)
 		if err != nil {
 			return nil, false, fmt.Errorf("failed to start kubernetes.io/kubelet-serving certificate controller: %v", err)
 		}
-		go kubeletServingSigner.Run(5, ctx.Stop)
+		go kubeletServingSigner.Run(5, controllerContext.Stop)
 	} else {
 		klog.V(2).Infof("skipping CSR signer controller %q because specific files were specified for other signers and not this one.", "kubernetes.io/kubelet-serving")
 	}
 
-	if kubeletClientSignerCertFile, kubeletClientSignerKeyFile := getKubeletClientSignerFiles(ctx.ComponentConfig.CSRSigningController); len(kubeletClientSignerCertFile) > 0 || len(kubeletClientSignerKeyFile) > 0 {
+	if kubeletClientSignerCertFile, kubeletClientSignerKeyFile := getKubeletClientSignerFiles(controllerContext.ComponentConfig.CSRSigningController); len(kubeletClientSignerCertFile) > 0 || len(kubeletClientSignerKeyFile) > 0 {
 		kubeletClientSigner, err := signer.NewKubeletClientCSRSigningController(c, csrInformer, kubeletClientSignerCertFile, kubeletClientSignerKeyFile, certTTL)
 		if err != nil {
 			return nil, false, fmt.Errorf("failed to start kubernetes.io/kube-apiserver-client-kubelet certificate controller: %v", err)
 		}
-		go kubeletClientSigner.Run(5, ctx.Stop)
+		go kubeletClientSigner.Run(5, controllerContext.Stop)
 	} else {
 		klog.V(2).Infof("skipping CSR signer controller %q because specific files were specified for other signers and not this one.", "kubernetes.io/kube-apiserver-client-kubelet")
 	}
 
-	if kubeAPIServerSignerCertFile, kubeAPIServerSignerKeyFile := getKubeAPIServerClientSignerFiles(ctx.ComponentConfig.CSRSigningController); len(kubeAPIServerSignerCertFile) > 0 || len(kubeAPIServerSignerKeyFile) > 0 {
+	if kubeAPIServerSignerCertFile, kubeAPIServerSignerKeyFile := getKubeAPIServerClientSignerFiles(controllerContext.ComponentConfig.CSRSigningController); len(kubeAPIServerSignerCertFile) > 0 || len(kubeAPIServerSignerKeyFile) > 0 {
 		kubeAPIServerClientSigner, err := signer.NewKubeAPIServerClientCSRSigningController(c, csrInformer, kubeAPIServerSignerCertFile, kubeAPIServerSignerKeyFile, certTTL)
 		if err != nil {
 			return nil, false, fmt.Errorf("failed to start kubernetes.io/kube-apiserver-client certificate controller: %v", err)
 		}
-		go kubeAPIServerClientSigner.Run(5, ctx.Stop)
+		go kubeAPIServerClientSigner.Run(5, controllerContext.Stop)
 	} else {
 		klog.V(2).Infof("skipping CSR signer controller %q because specific files were specified for other signers and not this one.", "kubernetes.io/kube-apiserver-client")
 	}
 
-	if legacyUnknownSignerCertFile, legacyUnknownSignerKeyFile := getLegacyUnknownSignerFiles(ctx.ComponentConfig.CSRSigningController); len(legacyUnknownSignerCertFile) > 0 || len(legacyUnknownSignerKeyFile) > 0 {
+	if legacyUnknownSignerCertFile, legacyUnknownSignerKeyFile := getLegacyUnknownSignerFiles(controllerContext.ComponentConfig.CSRSigningController); len(legacyUnknownSignerCertFile) > 0 || len(legacyUnknownSignerKeyFile) > 0 {
 		legacyUnknownSigner, err := signer.NewLegacyUnknownCSRSigningController(c, csrInformer, legacyUnknownSignerCertFile, legacyUnknownSignerKeyFile, certTTL)
 		if err != nil {
 			return nil, false, fmt.Errorf("failed to start kubernetes.io/legacy-unknown certificate controller: %v", err)
 		}
-		go legacyUnknownSigner.Run(5, ctx.Stop)
+		go legacyUnknownSigner.Run(5, controllerContext.Stop)
 	} else {
 		klog.V(2).Infof("skipping CSR signer controller %q because specific files were specified for other signers and not this one.", "kubernetes.io/legacy-unknown")
 	}
@@ -165,53 +166,53 @@ func getLegacyUnknownSignerFiles(config csrsigningconfig.CSRSigningControllerCon
 	return config.ClusterSigningCertFile, config.ClusterSigningKeyFile
 }
 
-func startCSRApprovingController(ctx ControllerContext) (http.Handler, bool, error) {
+func startCSRApprovingController(ctx context.Context, controllerContext ControllerContext) (http.Handler, bool, error) {
 	gvr := schema.GroupVersionResource{Group: "certificates.k8s.io", Version: "v1", Resource: "certificatesigningrequests"}
-	if !ctx.AvailableResources[gvr] {
+	if !controllerContext.AvailableResources[gvr] {
 		klog.Warningf("Resource %s is not available now", gvr.String())
 		return nil, false, nil
 	}
 
 	approver := approver.NewCSRApprovingController(
-		ctx.ClientBuilder.ClientOrDie("certificate-controller"),
-		ctx.InformerFactory.Certificates().V1().CertificateSigningRequests(),
+		controllerContext.ClientBuilder.ClientOrDie("certificate-controller"),
+		controllerContext.InformerFactory.Certificates().V1().CertificateSigningRequests(),
 	)
-	go approver.Run(5, ctx.Stop)
+	go approver.Run(5, controllerContext.Stop)
 
 	return nil, true, nil
 }
 
-func startCSRCleanerController(ctx ControllerContext) (http.Handler, bool, error) {
+func startCSRCleanerController(ctx context.Context, controllerContext ControllerContext) (http.Handler, bool, error) {
 	cleaner := cleaner.NewCSRCleanerController(
-		ctx.ClientBuilder.ClientOrDie("certificate-controller").CertificatesV1().CertificateSigningRequests(),
-		ctx.InformerFactory.Certificates().V1().CertificateSigningRequests(),
+		controllerContext.ClientBuilder.ClientOrDie("certificate-controller").CertificatesV1().CertificateSigningRequests(),
+		controllerContext.InformerFactory.Certificates().V1().CertificateSigningRequests(),
 	)
-	go cleaner.Run(1, ctx.Stop)
+	go cleaner.Run(1, controllerContext.Stop)
 	return nil, true, nil
 }
 
-func startRootCACertPublisher(ctx ControllerContext) (http.Handler, bool, error) {
+func startRootCACertPublisher(ctx context.Context, controllerContext ControllerContext) (http.Handler, bool, error) {
 	var (
 		rootCA []byte
 		err    error
 	)
-	if ctx.ComponentConfig.SAController.RootCAFile != "" {
-		if rootCA, err = readCA(ctx.ComponentConfig.SAController.RootCAFile); err != nil {
-			return nil, true, fmt.Errorf("error parsing root-ca-file at %s: %v", ctx.ComponentConfig.SAController.RootCAFile, err)
+	if controllerContext.ComponentConfig.SAController.RootCAFile != "" {
+		if rootCA, err = readCA(controllerContext.ComponentConfig.SAController.RootCAFile); err != nil {
+			return nil, true, fmt.Errorf("error parsing root-ca-file at %s: %v", controllerContext.ComponentConfig.SAController.RootCAFile, err)
 		}
 	} else {
-		rootCA = ctx.ClientBuilder.ConfigOrDie("root-ca-cert-publisher").CAData
+		rootCA = controllerContext.ClientBuilder.ConfigOrDie("root-ca-cert-publisher").CAData
 	}
 
 	sac, err := rootcacertpublisher.NewPublisher(
-		ctx.InformerFactory.Core().V1().ConfigMaps(),
-		ctx.InformerFactory.Core().V1().Namespaces(),
-		ctx.ClientBuilder.ClientOrDie("root-ca-cert-publisher"),
+		controllerContext.InformerFactory.Core().V1().ConfigMaps(),
+		controllerContext.InformerFactory.Core().V1().Namespaces(),
+		controllerContext.ClientBuilder.ClientOrDie("root-ca-cert-publisher"),
 		rootCA,
 	)
 	if err != nil {
 		return nil, true, fmt.Errorf("error creating root CA certificate publisher: %v", err)
 	}
-	go sac.Run(1, ctx.Stop)
+	go sac.Run(1, controllerContext.Stop)
 	return nil, true, nil
 }

--- a/cmd/kube-controller-manager/app/controllermanager.go
+++ b/cmd/kube-controller-manager/app/controllermanager.go
@@ -219,7 +219,7 @@ func Run(c *config.CompletedConfig, stopCh <-chan struct{}) error {
 			klog.Fatalf("error building controller context: %v", err)
 		}
 		controllerInitializers := initializersFunc(controllerContext.LoopMode)
-		if err := StartControllers(controllerContext, startSATokenController, controllerInitializers, unsecuredMux); err != nil {
+		if err := StartControllers(ctx, controllerContext, startSATokenController, controllerInitializers, unsecuredMux); err != nil {
 			klog.Fatalf("error starting controllers: %v", err)
 		}
 
@@ -259,9 +259,9 @@ func Run(c *config.CompletedConfig, stopCh <-chan struct{}) error {
 
 		// Wrap saTokenControllerInitFunc to signal readiness for migration after starting
 		//  the controller.
-		startSATokenController = func(ctx ControllerContext) (http.Handler, bool, error) {
+		startSATokenController = func(ctx context.Context, controllerContext ControllerContext) (http.Handler, bool, error) {
 			defer close(leaderMigrator.MigrationReady)
-			return saTokenControllerInitFunc(ctx)
+			return saTokenControllerInitFunc(ctx, controllerContext)
 		}
 	}
 
@@ -367,7 +367,7 @@ func (c ControllerContext) IsControllerEnabled(name string) bool {
 // InitFunc is used to launch a particular controller.  It may run additional "should I activate checks".
 // Any error returned will cause the controller process to `Fatal`
 // The bool indicates whether the controller was enabled.
-type InitFunc func(ctx ControllerContext) (debuggingHandler http.Handler, enabled bool, err error)
+type InitFunc func(ctx context.Context, controllerCtx ControllerContext) (debuggingHandler http.Handler, enabled bool, err error)
 
 // ControllerInitializersFunc is used to create a collection of initializers
 //  given the loopMode.
@@ -533,31 +533,31 @@ func CreateControllerContext(s *config.CompletedConfig, rootClientBuilder, clien
 }
 
 // StartControllers starts a set of controllers with a specified ControllerContext
-func StartControllers(ctx ControllerContext, startSATokenController InitFunc, controllers map[string]InitFunc, unsecuredMux *mux.PathRecorderMux) error {
+func StartControllers(ctx context.Context, controllerCtx ControllerContext, startSATokenController InitFunc, controllers map[string]InitFunc, unsecuredMux *mux.PathRecorderMux) error {
 	// Always start the SA token controller first using a full-power client, since it needs to mint tokens for the rest
 	// If this fails, just return here and fail since other controllers won't be able to get credentials.
 	if startSATokenController != nil {
-		if _, _, err := startSATokenController(ctx); err != nil {
+		if _, _, err := startSATokenController(ctx, controllerCtx); err != nil {
 			return err
 		}
 	}
 
 	// Initialize the cloud provider with a reference to the clientBuilder only after token controller
 	// has started in case the cloud provider uses the client builder.
-	if ctx.Cloud != nil {
-		ctx.Cloud.Initialize(ctx.ClientBuilder, ctx.Stop)
+	if controllerCtx.Cloud != nil {
+		controllerCtx.Cloud.Initialize(controllerCtx.ClientBuilder, controllerCtx.Stop)
 	}
 
 	for controllerName, initFn := range controllers {
-		if !ctx.IsControllerEnabled(controllerName) {
+		if !controllerCtx.IsControllerEnabled(controllerName) {
 			klog.Warningf("%q is disabled", controllerName)
 			continue
 		}
 
-		time.Sleep(wait.Jitter(ctx.ComponentConfig.Generic.ControllerStartInterval.Duration, ControllerStartJitter))
+		time.Sleep(wait.Jitter(controllerCtx.ComponentConfig.Generic.ControllerStartInterval.Duration, ControllerStartJitter))
 
 		klog.V(1).Infof("Starting %q", controllerName)
-		debugHandler, started, err := initFn(ctx)
+		debugHandler, started, err := initFn(ctx, controllerCtx)
 		if err != nil {
 			klog.Errorf("Error starting %q", controllerName)
 			return err
@@ -584,25 +584,25 @@ type serviceAccountTokenControllerStarter struct {
 	rootClientBuilder clientbuilder.ControllerClientBuilder
 }
 
-func (c serviceAccountTokenControllerStarter) startServiceAccountTokenController(ctx ControllerContext) (http.Handler, bool, error) {
-	if !ctx.IsControllerEnabled(saTokenControllerName) {
+func (c serviceAccountTokenControllerStarter) startServiceAccountTokenController(ctx context.Context, controllerContext ControllerContext) (http.Handler, bool, error) {
+	if !controllerContext.IsControllerEnabled(saTokenControllerName) {
 		klog.Warningf("%q is disabled", saTokenControllerName)
 		return nil, false, nil
 	}
 
-	if len(ctx.ComponentConfig.SAController.ServiceAccountKeyFile) == 0 {
+	if len(controllerContext.ComponentConfig.SAController.ServiceAccountKeyFile) == 0 {
 		klog.Warningf("%q is disabled because there is no private key", saTokenControllerName)
 		return nil, false, nil
 	}
-	privateKey, err := keyutil.PrivateKeyFromFile(ctx.ComponentConfig.SAController.ServiceAccountKeyFile)
+	privateKey, err := keyutil.PrivateKeyFromFile(controllerContext.ComponentConfig.SAController.ServiceAccountKeyFile)
 	if err != nil {
 		return nil, true, fmt.Errorf("error reading key for service account token controller: %v", err)
 	}
 
 	var rootCA []byte
-	if ctx.ComponentConfig.SAController.RootCAFile != "" {
-		if rootCA, err = readCA(ctx.ComponentConfig.SAController.RootCAFile); err != nil {
-			return nil, true, fmt.Errorf("error parsing root-ca-file at %s: %v", ctx.ComponentConfig.SAController.RootCAFile, err)
+	if controllerContext.ComponentConfig.SAController.RootCAFile != "" {
+		if rootCA, err = readCA(controllerContext.ComponentConfig.SAController.RootCAFile); err != nil {
+			return nil, true, fmt.Errorf("error parsing root-ca-file at %s: %v", controllerContext.ComponentConfig.SAController.RootCAFile, err)
 		}
 	} else {
 		rootCA = c.rootClientBuilder.ConfigOrDie("tokens-controller").CAData
@@ -613,8 +613,8 @@ func (c serviceAccountTokenControllerStarter) startServiceAccountTokenController
 		return nil, false, fmt.Errorf("failed to build token generator: %v", err)
 	}
 	controller, err := serviceaccountcontroller.NewTokensController(
-		ctx.InformerFactory.Core().V1().ServiceAccounts(),
-		ctx.InformerFactory.Core().V1().Secrets(),
+		controllerContext.InformerFactory.Core().V1().ServiceAccounts(),
+		controllerContext.InformerFactory.Core().V1().Secrets(),
 		c.rootClientBuilder.ClientOrDie("tokens-controller"),
 		serviceaccountcontroller.TokensControllerOptions{
 			TokenGenerator: tokenGenerator,
@@ -624,10 +624,10 @@ func (c serviceAccountTokenControllerStarter) startServiceAccountTokenController
 	if err != nil {
 		return nil, true, fmt.Errorf("error creating Tokens controller: %v", err)
 	}
-	go controller.Run(int(ctx.ComponentConfig.SAController.ConcurrentSATokenSyncs), ctx.Stop)
+	go controller.Run(int(controllerContext.ComponentConfig.SAController.ConcurrentSATokenSyncs), controllerContext.Stop)
 
 	// start the first set of informers now so that other controllers can start
-	ctx.InformerFactory.Start(ctx.Stop)
+	controllerContext.InformerFactory.Start(controllerContext.Stop)
 
 	return nil, true, nil
 }

--- a/cmd/kube-controller-manager/app/discovery.go
+++ b/cmd/kube-controller-manager/app/discovery.go
@@ -21,33 +21,34 @@ limitations under the License.
 package app
 
 import (
+	"context"
 	"net/http"
 
 	endpointslicecontroller "k8s.io/kubernetes/pkg/controller/endpointslice"
 	endpointslicemirroringcontroller "k8s.io/kubernetes/pkg/controller/endpointslicemirroring"
 )
 
-func startEndpointSliceController(ctx ControllerContext) (http.Handler, bool, error) {
+func startEndpointSliceController(ctx context.Context, controllerContext ControllerContext) (http.Handler, bool, error) {
 	go endpointslicecontroller.NewController(
-		ctx.InformerFactory.Core().V1().Pods(),
-		ctx.InformerFactory.Core().V1().Services(),
-		ctx.InformerFactory.Core().V1().Nodes(),
-		ctx.InformerFactory.Discovery().V1().EndpointSlices(),
-		ctx.ComponentConfig.EndpointSliceController.MaxEndpointsPerSlice,
-		ctx.ClientBuilder.ClientOrDie("endpointslice-controller"),
-		ctx.ComponentConfig.EndpointSliceController.EndpointUpdatesBatchPeriod.Duration,
-	).Run(int(ctx.ComponentConfig.EndpointSliceController.ConcurrentServiceEndpointSyncs), ctx.Stop)
+		controllerContext.InformerFactory.Core().V1().Pods(),
+		controllerContext.InformerFactory.Core().V1().Services(),
+		controllerContext.InformerFactory.Core().V1().Nodes(),
+		controllerContext.InformerFactory.Discovery().V1().EndpointSlices(),
+		controllerContext.ComponentConfig.EndpointSliceController.MaxEndpointsPerSlice,
+		controllerContext.ClientBuilder.ClientOrDie("endpointslice-controller"),
+		controllerContext.ComponentConfig.EndpointSliceController.EndpointUpdatesBatchPeriod.Duration,
+	).Run(int(controllerContext.ComponentConfig.EndpointSliceController.ConcurrentServiceEndpointSyncs), controllerContext.Stop)
 	return nil, true, nil
 }
 
-func startEndpointSliceMirroringController(ctx ControllerContext) (http.Handler, bool, error) {
+func startEndpointSliceMirroringController(ctx context.Context, controllerContext ControllerContext) (http.Handler, bool, error) {
 	go endpointslicemirroringcontroller.NewController(
-		ctx.InformerFactory.Core().V1().Endpoints(),
-		ctx.InformerFactory.Discovery().V1().EndpointSlices(),
-		ctx.InformerFactory.Core().V1().Services(),
-		ctx.ComponentConfig.EndpointSliceMirroringController.MirroringMaxEndpointsPerSubset,
-		ctx.ClientBuilder.ClientOrDie("endpointslicemirroring-controller"),
-		ctx.ComponentConfig.EndpointSliceMirroringController.MirroringEndpointUpdatesBatchPeriod.Duration,
-	).Run(int(ctx.ComponentConfig.EndpointSliceMirroringController.MirroringConcurrentServiceEndpointSyncs), ctx.Stop)
+		controllerContext.InformerFactory.Core().V1().Endpoints(),
+		controllerContext.InformerFactory.Discovery().V1().EndpointSlices(),
+		controllerContext.InformerFactory.Core().V1().Services(),
+		controllerContext.ComponentConfig.EndpointSliceMirroringController.MirroringMaxEndpointsPerSubset,
+		controllerContext.ClientBuilder.ClientOrDie("endpointslicemirroring-controller"),
+		controllerContext.ComponentConfig.EndpointSliceMirroringController.MirroringEndpointUpdatesBatchPeriod.Duration,
+	).Run(int(controllerContext.ComponentConfig.EndpointSliceMirroringController.MirroringConcurrentServiceEndpointSyncs), controllerContext.Stop)
 	return nil, true, nil
 }

--- a/cmd/kube-controller-manager/app/policy.go
+++ b/cmd/kube-controller-manager/app/policy.go
@@ -21,6 +21,7 @@ limitations under the License.
 package app
 
 import (
+	"context"
 	"net/http"
 
 	"k8s.io/klog/v2"
@@ -32,31 +33,31 @@ import (
 	kubefeatures "k8s.io/kubernetes/pkg/features"
 )
 
-func startDisruptionController(ctx ControllerContext) (http.Handler, bool, error) {
+func startDisruptionController(ctx context.Context, controllerContext ControllerContext) (http.Handler, bool, error) {
 	if !utilfeature.DefaultFeatureGate.Enabled(kubefeatures.PodDisruptionBudget) {
 		klog.Infof("Refusing to start disruption because the PodDisruptionBudget feature is disabled")
 		return nil, false, nil
 	}
 
-	client := ctx.ClientBuilder.ClientOrDie("disruption-controller")
-	config := ctx.ClientBuilder.ConfigOrDie("disruption-controller")
+	client := controllerContext.ClientBuilder.ClientOrDie("disruption-controller")
+	config := controllerContext.ClientBuilder.ConfigOrDie("disruption-controller")
 	scaleKindResolver := scale.NewDiscoveryScaleKindResolver(client.Discovery())
-	scaleClient, err := scale.NewForConfig(config, ctx.RESTMapper, dynamic.LegacyAPIPathResolverFunc, scaleKindResolver)
+	scaleClient, err := scale.NewForConfig(config, controllerContext.RESTMapper, dynamic.LegacyAPIPathResolverFunc, scaleKindResolver)
 	if err != nil {
 		return nil, false, err
 	}
 
 	go disruption.NewDisruptionController(
-		ctx.InformerFactory.Core().V1().Pods(),
-		ctx.InformerFactory.Policy().V1().PodDisruptionBudgets(),
-		ctx.InformerFactory.Core().V1().ReplicationControllers(),
-		ctx.InformerFactory.Apps().V1().ReplicaSets(),
-		ctx.InformerFactory.Apps().V1().Deployments(),
-		ctx.InformerFactory.Apps().V1().StatefulSets(),
+		controllerContext.InformerFactory.Core().V1().Pods(),
+		controllerContext.InformerFactory.Policy().V1().PodDisruptionBudgets(),
+		controllerContext.InformerFactory.Core().V1().ReplicationControllers(),
+		controllerContext.InformerFactory.Apps().V1().ReplicaSets(),
+		controllerContext.InformerFactory.Apps().V1().Deployments(),
+		controllerContext.InformerFactory.Apps().V1().StatefulSets(),
 		client,
-		ctx.RESTMapper,
+		controllerContext.RESTMapper,
 		scaleClient,
 		client.Discovery(),
-	).Run(ctx.Stop)
+	).Run(controllerContext.Stop)
 	return nil, true, nil
 }

--- a/cmd/kube-controller-manager/app/policy.go
+++ b/cmd/kube-controller-manager/app/policy.go
@@ -58,6 +58,6 @@ func startDisruptionController(ctx context.Context, controllerContext Controller
 		controllerContext.RESTMapper,
 		scaleClient,
 		client.Discovery(),
-	).Run(controllerContext.Stop)
+	).Run(ctx, controllerContext.Stop)
 	return nil, true, nil
 }

--- a/cmd/kube-controller-manager/app/rbac.go
+++ b/cmd/kube-controller-manager/app/rbac.go
@@ -17,19 +17,20 @@ limitations under the License.
 package app
 
 import (
+	"context"
 	"net/http"
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/kubernetes/pkg/controller/clusterroleaggregation"
 )
 
-func startClusterRoleAggregrationController(ctx ControllerContext) (http.Handler, bool, error) {
-	if !ctx.AvailableResources[schema.GroupVersionResource{Group: "rbac.authorization.k8s.io", Version: "v1", Resource: "clusterroles"}] {
+func startClusterRoleAggregrationController(ctx context.Context, controllerContext ControllerContext) (http.Handler, bool, error) {
+	if !controllerContext.AvailableResources[schema.GroupVersionResource{Group: "rbac.authorization.k8s.io", Version: "v1", Resource: "clusterroles"}] {
 		return nil, false, nil
 	}
 	go clusterroleaggregation.NewClusterRoleAggregation(
-		ctx.InformerFactory.Rbac().V1().ClusterRoles(),
-		ctx.ClientBuilder.ClientOrDie("clusterrole-aggregation-controller").RbacV1(),
-	).Run(5, ctx.Stop)
+		controllerContext.InformerFactory.Rbac().V1().ClusterRoles(),
+		controllerContext.ClientBuilder.ClientOrDie("clusterrole-aggregation-controller").RbacV1(),
+	).Run(5, controllerContext.Stop)
 	return nil, true, nil
 }

--- a/cmd/kube-controller-manager/app/rbac.go
+++ b/cmd/kube-controller-manager/app/rbac.go
@@ -31,6 +31,6 @@ func startClusterRoleAggregrationController(ctx context.Context, controllerConte
 	go clusterroleaggregation.NewClusterRoleAggregation(
 		controllerContext.InformerFactory.Rbac().V1().ClusterRoles(),
 		controllerContext.ClientBuilder.ClientOrDie("clusterrole-aggregation-controller").RbacV1(),
-	).Run(5, controllerContext.Stop)
+	).Run(ctx, 5, controllerContext.Stop)
 	return nil, true, nil
 }

--- a/pkg/controller/bootstrap/tokencleaner.go
+++ b/pkg/controller/bootstrap/tokencleaner.go
@@ -111,7 +111,7 @@ func NewTokenCleaner(cl clientset.Interface, secrets coreinformers.SecretInforme
 }
 
 // Run runs controller loops and returns when they are done
-func (tc *TokenCleaner) Run(stopCh <-chan struct{}) {
+func (tc *TokenCleaner) Run(ctx context.Context, stopCh <-chan struct{}) {
 	defer utilruntime.HandleCrash()
 	defer tc.queue.ShutDown()
 
@@ -122,7 +122,7 @@ func (tc *TokenCleaner) Run(stopCh <-chan struct{}) {
 		return
 	}
 
-	go wait.Until(tc.worker, 10*time.Second, stopCh)
+	go wait.UntilWithContext(ctx, tc.worker, 10*time.Second)
 
 	<-stopCh
 }
@@ -137,20 +137,20 @@ func (tc *TokenCleaner) enqueueSecrets(obj interface{}) {
 }
 
 // worker runs a thread that dequeues secrets, handles them, and marks them done.
-func (tc *TokenCleaner) worker() {
-	for tc.processNextWorkItem() {
+func (tc *TokenCleaner) worker(ctx context.Context) {
+	for tc.processNextWorkItem(ctx) {
 	}
 }
 
 // processNextWorkItem deals with one key off the queue.  It returns false when it's time to quit.
-func (tc *TokenCleaner) processNextWorkItem() bool {
+func (tc *TokenCleaner) processNextWorkItem(ctx context.Context) bool {
 	key, quit := tc.queue.Get()
 	if quit {
 		return false
 	}
 	defer tc.queue.Done(key)
 
-	if err := tc.syncFunc(key.(string)); err != nil {
+	if err := tc.syncFunc(ctx, key.(string)); err != nil {
 		tc.queue.AddRateLimited(key)
 		utilruntime.HandleError(fmt.Errorf("Sync %v failed with : %v", key, err))
 		return true
@@ -160,7 +160,7 @@ func (tc *TokenCleaner) processNextWorkItem() bool {
 	return true
 }
 
-func (tc *TokenCleaner) syncFunc(key string) error {
+func (tc *TokenCleaner) syncFunc(ctx context.Context, key string) error {
 	startTime := time.Now()
 	defer func() {
 		klog.V(4).Infof("Finished syncing secret %q (%v)", key, time.Since(startTime))
@@ -182,12 +182,12 @@ func (tc *TokenCleaner) syncFunc(key string) error {
 	}
 
 	if ret.Type == bootstrapapi.SecretTypeBootstrapToken {
-		tc.evalSecret(ret)
+		tc.evalSecret(ctx, ret)
 	}
 	return nil
 }
 
-func (tc *TokenCleaner) evalSecret(o interface{}) {
+func (tc *TokenCleaner) evalSecret(ctx context.Context, o interface{}) {
 	secret := o.(*v1.Secret)
 	ttl, alreadyExpired := bootstrapsecretutil.GetExpiration(secret, time.Now())
 	if alreadyExpired {
@@ -196,7 +196,7 @@ func (tc *TokenCleaner) evalSecret(o interface{}) {
 		if len(secret.UID) > 0 {
 			options.Preconditions = &metav1.Preconditions{UID: &secret.UID}
 		}
-		err := tc.client.CoreV1().Secrets(secret.Namespace).Delete(context.TODO(), secret.Name, options)
+		err := tc.client.CoreV1().Secrets(secret.Namespace).Delete(ctx, secret.Name, options)
 		// NotFound isn't a real error (it's already been deleted)
 		// Conflict isn't a real error (the UID precondition failed)
 		if err != nil && !apierrors.IsConflict(err) && !apierrors.IsNotFound(err) {

--- a/pkg/controller/certificates/certificate_controller.go
+++ b/pkg/controller/certificates/certificate_controller.go
@@ -19,6 +19,7 @@ limitations under the License.
 package certificates
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -48,7 +49,7 @@ type CertificateController struct {
 	csrLister  certificateslisters.CertificateSigningRequestLister
 	csrsSynced cache.InformerSynced
 
-	handler func(*certificates.CertificateSigningRequest) error
+	handler func(context.Context, *certificates.CertificateSigningRequest) error
 
 	queue workqueue.RateLimitingInterface
 }
@@ -57,7 +58,7 @@ func NewCertificateController(
 	name string,
 	kubeClient clientset.Interface,
 	csrInformer certificatesinformers.CertificateSigningRequestInformer,
-	handler func(*certificates.CertificateSigningRequest) error,
+	handler func(context.Context, *certificates.CertificateSigningRequest) error,
 ) *CertificateController {
 	// Send events to the apiserver
 	eventBroadcaster := record.NewBroadcaster()
@@ -111,7 +112,7 @@ func NewCertificateController(
 }
 
 // Run the main goroutine responsible for watching and syncing jobs.
-func (cc *CertificateController) Run(workers int, stopCh <-chan struct{}) {
+func (cc *CertificateController) Run(ctx context.Context, workers int, stopCh <-chan struct{}) {
 	defer utilruntime.HandleCrash()
 	defer cc.queue.ShutDown()
 
@@ -123,27 +124,27 @@ func (cc *CertificateController) Run(workers int, stopCh <-chan struct{}) {
 	}
 
 	for i := 0; i < workers; i++ {
-		go wait.Until(cc.worker, time.Second, stopCh)
+		go wait.UntilWithContext(ctx, cc.worker, time.Second)
 	}
 
 	<-stopCh
 }
 
 // worker runs a thread that dequeues CSRs, handles them, and marks them done.
-func (cc *CertificateController) worker() {
-	for cc.processNextWorkItem() {
+func (cc *CertificateController) worker(ctx context.Context) {
+	for cc.processNextWorkItem(ctx) {
 	}
 }
 
 // processNextWorkItem deals with one key off the queue.  It returns false when it's time to quit.
-func (cc *CertificateController) processNextWorkItem() bool {
+func (cc *CertificateController) processNextWorkItem(ctx context.Context) bool {
 	cKey, quit := cc.queue.Get()
 	if quit {
 		return false
 	}
 	defer cc.queue.Done(cKey)
 
-	if err := cc.syncFunc(cKey.(string)); err != nil {
+	if err := cc.syncFunc(ctx, cKey.(string)); err != nil {
 		cc.queue.AddRateLimited(cKey)
 		if _, ignorable := err.(ignorableError); !ignorable {
 			utilruntime.HandleError(fmt.Errorf("Sync %v failed with : %v", cKey, err))
@@ -167,7 +168,7 @@ func (cc *CertificateController) enqueueCertificateRequest(obj interface{}) {
 	cc.queue.Add(key)
 }
 
-func (cc *CertificateController) syncFunc(key string) error {
+func (cc *CertificateController) syncFunc(ctx context.Context, key string) error {
 	startTime := time.Now()
 	defer func() {
 		klog.V(4).Infof("Finished syncing certificate request %q (%v)", key, time.Since(startTime))
@@ -188,7 +189,7 @@ func (cc *CertificateController) syncFunc(key string) error {
 
 	// need to operate on a copy so we don't mutate the csr in the shared cache
 	csr = csr.DeepCopy()
-	return cc.handler(csr)
+	return cc.handler(ctx, csr)
 }
 
 // IgnorableError returns an error that we shouldn't handle (i.e. log) because

--- a/pkg/controller/certificates/cleaner/cleaner.go
+++ b/pkg/controller/certificates/cleaner/cleaner.go
@@ -76,40 +76,40 @@ func NewCSRCleanerController(
 }
 
 // Run the main goroutine responsible for watching and syncing jobs.
-func (ccc *CSRCleanerController) Run(workers int, stopCh <-chan struct{}) {
+func (ccc *CSRCleanerController) Run(ctx context.Context, workers int, stopCh <-chan struct{}) {
 	defer utilruntime.HandleCrash()
 
 	klog.Infof("Starting CSR cleaner controller")
 	defer klog.Infof("Shutting down CSR cleaner controller")
 
 	for i := 0; i < workers; i++ {
-		go wait.Until(ccc.worker, pollingInterval, stopCh)
+		go wait.UntilWithContext(ctx, ccc.worker, pollingInterval)
 	}
 
 	<-stopCh
 }
 
 // worker runs a thread that dequeues CSRs, handles them, and marks them done.
-func (ccc *CSRCleanerController) worker() {
+func (ccc *CSRCleanerController) worker(ctx context.Context) {
 	csrs, err := ccc.csrLister.List(labels.Everything())
 	if err != nil {
 		klog.Errorf("Unable to list CSRs: %v", err)
 		return
 	}
 	for _, csr := range csrs {
-		if err := ccc.handle(csr); err != nil {
+		if err := ccc.handle(ctx, csr); err != nil {
 			klog.Errorf("Error while attempting to clean CSR %q: %v", csr.Name, err)
 		}
 	}
 }
 
-func (ccc *CSRCleanerController) handle(csr *capi.CertificateSigningRequest) error {
+func (ccc *CSRCleanerController) handle(ctx context.Context, csr *capi.CertificateSigningRequest) error {
 	isIssuedExpired, err := isIssuedExpired(csr)
 	if err != nil {
 		return err
 	}
 	if isIssuedPastDeadline(csr) || isDeniedPastDeadline(csr) || isFailedPastDeadline(csr) || isPendingPastDeadline(csr) || isIssuedExpired {
-		if err := ccc.csrClient.Delete(context.TODO(), csr.Name, metav1.DeleteOptions{}); err != nil {
+		if err := ccc.csrClient.Delete(ctx, csr.Name, metav1.DeleteOptions{}); err != nil {
 			return fmt.Errorf("unable to delete CSR %q: %v", csr.Name, err)
 		}
 	}

--- a/pkg/controller/certificates/rootcacertpublisher/publisher.go
+++ b/pkg/controller/certificates/rootcacertpublisher/publisher.go
@@ -89,7 +89,7 @@ type Publisher struct {
 	rootCA []byte
 
 	// To allow injection for testing.
-	syncHandler func(key string) error
+	syncHandler func(ctx context.Context, key string) error
 
 	cmLister       corelisters.ConfigMapLister
 	cmListerSynced cache.InformerSynced
@@ -100,7 +100,7 @@ type Publisher struct {
 }
 
 // Run starts process
-func (c *Publisher) Run(workers int, stopCh <-chan struct{}) {
+func (c *Publisher) Run(ctx context.Context, workers int, stopCh <-chan struct{}) {
 	defer utilruntime.HandleCrash()
 	defer c.queue.ShutDown()
 
@@ -112,7 +112,7 @@ func (c *Publisher) Run(workers int, stopCh <-chan struct{}) {
 	}
 
 	for i := 0; i < workers; i++ {
-		go wait.Until(c.runWorker, time.Second, stopCh)
+		go wait.UntilWithContext(ctx, c.runWorker, time.Second)
 	}
 
 	<-stopCh
@@ -155,21 +155,21 @@ func (c *Publisher) namespaceUpdated(oldObj interface{}, newObj interface{}) {
 	c.queue.Add(newNamespace.Name)
 }
 
-func (c *Publisher) runWorker() {
-	for c.processNextWorkItem() {
+func (c *Publisher) runWorker(ctx context.Context, ) {
+	for c.processNextWorkItem(ctx) {
 	}
 }
 
 // processNextWorkItem deals with one key off the queue. It returns false when
 // it's time to quit.
-func (c *Publisher) processNextWorkItem() bool {
+func (c *Publisher) processNextWorkItem(ctx context.Context, ) bool {
 	key, quit := c.queue.Get()
 	if quit {
 		return false
 	}
 	defer c.queue.Done(key)
 
-	if err := c.syncHandler(key.(string)); err != nil {
+	if err := c.syncHandler(ctx, key.(string)); err != nil {
 		utilruntime.HandleError(fmt.Errorf("syncing %q failed: %v", key, err))
 		c.queue.AddRateLimited(key)
 		return true
@@ -179,7 +179,7 @@ func (c *Publisher) processNextWorkItem() bool {
 	return true
 }
 
-func (c *Publisher) syncNamespace(ns string) (err error) {
+func (c *Publisher) syncNamespace(ctx context.Context, ns string) (err error) {
 	startTime := time.Now()
 	defer func() {
 		recordMetrics(startTime, ns, err)
@@ -189,7 +189,7 @@ func (c *Publisher) syncNamespace(ns string) (err error) {
 	cm, err := c.cmLister.ConfigMaps(ns).Get(RootCACertConfigMapName)
 	switch {
 	case apierrors.IsNotFound(err):
-		_, err = c.client.CoreV1().ConfigMaps(ns).Create(context.TODO(), &v1.ConfigMap{
+		_, err = c.client.CoreV1().ConfigMaps(ns).Create(ctx, &v1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:        RootCACertConfigMapName,
 				Annotations: map[string]string{DescriptionAnnotation: Description},
@@ -224,7 +224,7 @@ func (c *Publisher) syncNamespace(ns string) (err error) {
 	}
 	cm.Annotations[DescriptionAnnotation] = Description
 
-	_, err = c.client.CoreV1().ConfigMaps(ns).Update(context.TODO(), cm, metav1.UpdateOptions{})
+	_, err = c.client.CoreV1().ConfigMaps(ns).Update(ctx, cm, metav1.UpdateOptions{})
 	return err
 }
 

--- a/pkg/controller/certificates/signer/signer.go
+++ b/pkg/controller/certificates/signer/signer.go
@@ -103,10 +103,10 @@ func NewCSRSigningController(
 }
 
 // Run the main goroutine responsible for watching and syncing jobs.
-func (c *CSRSigningController) Run(workers int, stopCh <-chan struct{}) {
-	go c.dynamicCertReloader.Run(workers, stopCh)
+func (c *CSRSigningController) Run(ctx context.Context, workers int, stopCh <-chan struct{}) {
+	go c.dynamicCertReloader.Run(ctx, workers, stopCh)
 
-	c.certificateController.Run(workers, stopCh)
+	c.certificateController.Run(ctx, workers, stopCh)
 }
 
 type isRequestForSignerFunc func(req *x509.CertificateRequest, usages []capi.KeyUsage, signerName string) (bool, error)
@@ -141,7 +141,7 @@ func newSigner(signerName, caFile, caKeyFile string, client clientset.Interface,
 	return ret, nil
 }
 
-func (s *signer) handle(csr *capi.CertificateSigningRequest) error {
+func (s *signer) handle(ctx context.Context, csr *capi.CertificateSigningRequest) error {
 	// Ignore unapproved or failed requests
 	if !certificates.IsCertificateRequestApproved(csr) || certificates.HasTrueCondition(csr, capi.CertificateFailed) {
 		return nil
@@ -164,7 +164,7 @@ func (s *signer) handle(csr *capi.CertificateSigningRequest) error {
 			Message:        err.Error(),
 			LastUpdateTime: metav1.Now(),
 		})
-		_, err = s.client.CertificatesV1().CertificateSigningRequests().UpdateStatus(context.TODO(), csr, metav1.UpdateOptions{})
+		_, err = s.client.CertificatesV1().CertificateSigningRequests().UpdateStatus(ctx, csr, metav1.UpdateOptions{})
 		if err != nil {
 			return fmt.Errorf("error adding failure condition for csr: %v", err)
 		}
@@ -178,7 +178,7 @@ func (s *signer) handle(csr *capi.CertificateSigningRequest) error {
 		return fmt.Errorf("error auto signing csr: %v", err)
 	}
 	csr.Status.Certificate = cert
-	_, err = s.client.CertificatesV1().CertificateSigningRequests().UpdateStatus(context.TODO(), csr, metav1.UpdateOptions{})
+	_, err = s.client.CertificatesV1().CertificateSigningRequests().UpdateStatus(ctx, csr, metav1.UpdateOptions{})
 	if err != nil {
 		return fmt.Errorf("error updating signature for csr: %v", err)
 	}

--- a/pkg/controller/clusterroleaggregation/clusterroleaggregation_controller.go
+++ b/pkg/controller/clusterroleaggregation/clusterroleaggregation_controller.go
@@ -49,7 +49,7 @@ type ClusterRoleAggregationController struct {
 	clusterRoleLister  rbaclisters.ClusterRoleLister
 	clusterRolesSynced cache.InformerSynced
 
-	syncHandler func(key string) error
+	syncHandler func(ctx context.Context, key string) error
 	queue       workqueue.RateLimitingInterface
 }
 
@@ -78,7 +78,7 @@ func NewClusterRoleAggregation(clusterRoleInformer rbacinformers.ClusterRoleInfo
 	return c
 }
 
-func (c *ClusterRoleAggregationController) syncClusterRole(key string) error {
+func (c *ClusterRoleAggregationController) syncClusterRole(ctx context.Context, key string) error {
 	_, name, err := cache.SplitMetaNamespaceKey(key)
 	if err != nil {
 		return err
@@ -126,36 +126,36 @@ func (c *ClusterRoleAggregationController) syncClusterRole(key string) error {
 	}
 
 	if utilfeature.DefaultFeatureGate.Enabled(features.ServerSideApply) {
-		err = c.applyClusterRoles(sharedClusterRole.Name, newPolicyRules)
+		err = c.applyClusterRoles(ctx, sharedClusterRole.Name, newPolicyRules)
 		if errors.IsUnsupportedMediaType(err) { // TODO: Remove this fallback at least one release after ServerSideApply GA
 			// When Server Side Apply is not enabled, fallback to Update. This is required when running
 			// 1.21 since api-server can be 1.20 during the upgrade/downgrade.
 			// Since Server Side Apply is enabled by default in Beta, this fallback only kicks in
 			// if the feature has been disabled using its feature flag.
-			err = c.updateClusterRoles(sharedClusterRole, newPolicyRules)
+			err = c.updateClusterRoles(ctx, sharedClusterRole, newPolicyRules)
 		}
 	} else {
-		err = c.updateClusterRoles(sharedClusterRole, newPolicyRules)
+		err = c.updateClusterRoles(ctx, sharedClusterRole, newPolicyRules)
 	}
 	return err
 }
 
-func (c *ClusterRoleAggregationController) applyClusterRoles(name string, newPolicyRules []rbacv1.PolicyRule) error {
+func (c *ClusterRoleAggregationController) applyClusterRoles(ctx context.Context, name string, newPolicyRules []rbacv1.PolicyRule) error {
 	clusterRoleApply := rbacv1ac.ClusterRole(name).
 		WithRules(toApplyPolicyRules(newPolicyRules)...)
 
 	opts := metav1.ApplyOptions{FieldManager: "clusterrole-aggregation-controller", Force: true}
-	_, err := c.clusterRoleClient.ClusterRoles().Apply(context.TODO(), clusterRoleApply, opts)
+	_, err := c.clusterRoleClient.ClusterRoles().Apply(ctx, clusterRoleApply, opts)
 	return err
 }
 
-func (c *ClusterRoleAggregationController) updateClusterRoles(sharedClusterRole *rbacv1.ClusterRole, newPolicyRules []rbacv1.PolicyRule) error {
+func (c *ClusterRoleAggregationController) updateClusterRoles(ctx context.Context, sharedClusterRole *rbacv1.ClusterRole, newPolicyRules []rbacv1.PolicyRule) error {
 	clusterRole := sharedClusterRole.DeepCopy()
 	clusterRole.Rules = nil
 	for _, rule := range newPolicyRules {
 		clusterRole.Rules = append(clusterRole.Rules, *rule.DeepCopy())
 	}
-	_, err := c.clusterRoleClient.ClusterRoles().Update(context.TODO(), clusterRole, metav1.UpdateOptions{})
+	_, err := c.clusterRoleClient.ClusterRoles().Update(ctx, clusterRole, metav1.UpdateOptions{})
 	return err
 }
 
@@ -187,7 +187,7 @@ func ruleExists(haystack []rbacv1.PolicyRule, needle rbacv1.PolicyRule) bool {
 }
 
 // Run starts the controller and blocks until stopCh is closed.
-func (c *ClusterRoleAggregationController) Run(workers int, stopCh <-chan struct{}) {
+func (c *ClusterRoleAggregationController) Run(ctx context.Context, workers int, stopCh <-chan struct{}) {
 	defer utilruntime.HandleCrash()
 	defer c.queue.ShutDown()
 
@@ -199,25 +199,25 @@ func (c *ClusterRoleAggregationController) Run(workers int, stopCh <-chan struct
 	}
 
 	for i := 0; i < workers; i++ {
-		go wait.Until(c.runWorker, time.Second, stopCh)
+		go wait.UntilWithContext(ctx, c.runWorker, time.Second)
 	}
 
 	<-stopCh
 }
 
-func (c *ClusterRoleAggregationController) runWorker() {
-	for c.processNextWorkItem() {
+func (c *ClusterRoleAggregationController) runWorker(ctx context.Context) {
+	for c.processNextWorkItem(ctx) {
 	}
 }
 
-func (c *ClusterRoleAggregationController) processNextWorkItem() bool {
+func (c *ClusterRoleAggregationController) processNextWorkItem(ctx context.Context) bool {
 	dsKey, quit := c.queue.Get()
 	if quit {
 		return false
 	}
 	defer c.queue.Done(dsKey)
 
-	err := c.syncHandler(dsKey.(string))
+	err := c.syncHandler(ctx, dsKey.(string))
 	if err == nil {
 		c.queue.Forget(dsKey)
 		return true

--- a/pkg/controller/deployment/deployment_controller.go
+++ b/pkg/controller/deployment/deployment_controller.go
@@ -72,7 +72,7 @@ type DeploymentController struct {
 	eventRecorder record.EventRecorder
 
 	// To allow injection of syncDeployment for testing.
-	syncHandler func(dKey string) error
+	syncHandler func(ctx context.Context, dKey string) error
 	// used for unit testing
 	enqueueDeployment func(deployment *apps.Deployment)
 
@@ -146,7 +146,7 @@ func NewDeploymentController(dInformer appsinformers.DeploymentInformer, rsInfor
 }
 
 // Run begins watching and syncing.
-func (dc *DeploymentController) Run(workers int, stopCh <-chan struct{}) {
+func (dc *DeploymentController) Run(ctx context.Context, workers int, stopCh <-chan struct{}) {
 	defer utilruntime.HandleCrash()
 	defer dc.queue.ShutDown()
 
@@ -158,7 +158,7 @@ func (dc *DeploymentController) Run(workers int, stopCh <-chan struct{}) {
 	}
 
 	for i := 0; i < workers; i++ {
-		go wait.Until(dc.worker, time.Second, stopCh)
+		go wait.UntilWithContext(ctx, dc.worker, time.Second)
 	}
 
 	<-stopCh
@@ -457,19 +457,19 @@ func (dc *DeploymentController) resolveControllerRef(namespace string, controlle
 
 // worker runs a worker thread that just dequeues items, processes them, and marks them done.
 // It enforces that the syncHandler is never invoked concurrently with the same key.
-func (dc *DeploymentController) worker() {
-	for dc.processNextWorkItem() {
+func (dc *DeploymentController) worker(ctx context.Context) {
+	for dc.processNextWorkItem(ctx) {
 	}
 }
 
-func (dc *DeploymentController) processNextWorkItem() bool {
+func (dc *DeploymentController) processNextWorkItem(ctx context.Context) bool {
 	key, quit := dc.queue.Get()
 	if quit {
 		return false
 	}
 	defer dc.queue.Done(key)
 
-	err := dc.syncHandler(key.(string))
+	err := dc.syncHandler(ctx, key.(string))
 	dc.handleErr(err, key)
 
 	return true
@@ -500,7 +500,7 @@ func (dc *DeploymentController) handleErr(err error, key interface{}) {
 // getReplicaSetsForDeployment uses ControllerRefManager to reconcile
 // ControllerRef by adopting and orphaning.
 // It returns the list of ReplicaSets that this Deployment should manage.
-func (dc *DeploymentController) getReplicaSetsForDeployment(d *apps.Deployment) ([]*apps.ReplicaSet, error) {
+func (dc *DeploymentController) getReplicaSetsForDeployment(ctx context.Context, d *apps.Deployment) ([]*apps.ReplicaSet, error) {
 	// List all ReplicaSets to find those we own but that no longer match our
 	// selector. They will be orphaned by ClaimReplicaSets().
 	rsList, err := dc.rsLister.ReplicaSets(d.Namespace).List(labels.Everything())
@@ -514,7 +514,7 @@ func (dc *DeploymentController) getReplicaSetsForDeployment(d *apps.Deployment) 
 	// If any adoptions are attempted, we should first recheck for deletion with
 	// an uncached quorum read sometime after listing ReplicaSets (see #42639).
 	canAdoptFunc := controller.RecheckDeletionTimestamp(func() (metav1.Object, error) {
-		fresh, err := dc.client.AppsV1().Deployments(d.Namespace).Get(context.TODO(), d.Name, metav1.GetOptions{})
+		fresh, err := dc.client.AppsV1().Deployments(d.Namespace).Get(ctx, d.Name, metav1.GetOptions{})
 		if err != nil {
 			return nil, err
 		}
@@ -565,7 +565,7 @@ func (dc *DeploymentController) getPodMapForDeployment(d *apps.Deployment, rsLis
 
 // syncDeployment will sync the deployment with the given key.
 // This function is not meant to be invoked concurrently with the same key.
-func (dc *DeploymentController) syncDeployment(key string) error {
+func (dc *DeploymentController) syncDeployment(ctx context.Context, key string) error {
 	namespace, name, err := cache.SplitMetaNamespaceKey(key)
 	if err != nil {
 		klog.ErrorS(err, "Failed to split meta namespace cache key", "cacheKey", key)
@@ -596,14 +596,14 @@ func (dc *DeploymentController) syncDeployment(key string) error {
 		dc.eventRecorder.Eventf(d, v1.EventTypeWarning, "SelectingAll", "This deployment is selecting all pods. A non-empty selector is required.")
 		if d.Status.ObservedGeneration < d.Generation {
 			d.Status.ObservedGeneration = d.Generation
-			dc.client.AppsV1().Deployments(d.Namespace).UpdateStatus(context.TODO(), d, metav1.UpdateOptions{})
+			dc.client.AppsV1().Deployments(d.Namespace).UpdateStatus(ctx, d, metav1.UpdateOptions{})
 		}
 		return nil
 	}
 
 	// List ReplicaSets owned by this Deployment, while reconciling ControllerRef
 	// through adoption/orphaning.
-	rsList, err := dc.getReplicaSetsForDeployment(d)
+	rsList, err := dc.getReplicaSetsForDeployment(ctx, d)
 	if err != nil {
 		return err
 	}

--- a/pkg/controller/endpoint/endpoints_controller.go
+++ b/pkg/controller/endpoint/endpoints_controller.go
@@ -182,7 +182,7 @@ type Controller struct {
 
 // Run will not return until stopCh is closed. workers determines how many
 // endpoints will be handled in parallel.
-func (e *Controller) Run(workers int, stopCh <-chan struct{}) {
+func (e *Controller) Run(ctx context.Context, workers int, stopCh <-chan struct{}) {
 	defer utilruntime.HandleCrash()
 	defer e.queue.ShutDown()
 
@@ -194,7 +194,7 @@ func (e *Controller) Run(workers int, stopCh <-chan struct{}) {
 	}
 
 	for i := 0; i < workers; i++ {
-		go wait.Until(e.worker, e.workerLoopPeriod, stopCh)
+		go wait.UntilWithContext(ctx, e.worker, e.workerLoopPeriod)
 	}
 
 	go func() {
@@ -335,19 +335,19 @@ func (e *Controller) onEndpointsDelete(obj interface{}) {
 // marks them done. You may run as many of these in parallel as you wish; the
 // workqueue guarantees that they will not end up processing the same service
 // at the same time.
-func (e *Controller) worker() {
-	for e.processNextWorkItem() {
+func (e *Controller) worker(ctx context.Context) {
+	for e.processNextWorkItem(ctx) {
 	}
 }
 
-func (e *Controller) processNextWorkItem() bool {
+func (e *Controller) processNextWorkItem(ctx context.Context) bool {
 	eKey, quit := e.queue.Get()
 	if quit {
 		return false
 	}
 	defer e.queue.Done(eKey)
 
-	err := e.syncService(eKey.(string))
+	err := e.syncService(ctx, eKey.(string))
 	e.handleErr(err, eKey)
 
 	return true
@@ -375,7 +375,7 @@ func (e *Controller) handleErr(err error, key interface{}) {
 	utilruntime.HandleError(err)
 }
 
-func (e *Controller) syncService(key string) error {
+func (e *Controller) syncService(ctx context.Context, key string) error {
 	startTime := time.Now()
 	defer func() {
 		klog.V(4).Infof("Finished syncing service %q endpoints. (%v)", key, time.Since(startTime))
@@ -396,7 +396,7 @@ func (e *Controller) syncService(key string) error {
 		// service is deleted. However, if we're down at the time when
 		// the service is deleted, we will miss that deletion, so this
 		// doesn't completely solve the problem. See #6877.
-		err = e.client.CoreV1().Endpoints(namespace).Delete(context.TODO(), name, metav1.DeleteOptions{})
+		err = e.client.CoreV1().Endpoints(namespace).Delete(ctx, name, metav1.DeleteOptions{})
 		if err != nil && !errors.IsNotFound(err) {
 			return err
 		}
@@ -553,10 +553,10 @@ func (e *Controller) syncService(key string) error {
 	klog.V(4).Infof("Update endpoints for %v/%v, ready: %d not ready: %d", service.Namespace, service.Name, totalReadyEps, totalNotReadyEps)
 	if createEndpoints {
 		// No previous endpoints, create them
-		_, err = e.client.CoreV1().Endpoints(service.Namespace).Create(context.TODO(), newEndpoints, metav1.CreateOptions{})
+		_, err = e.client.CoreV1().Endpoints(service.Namespace).Create(ctx, newEndpoints, metav1.CreateOptions{})
 	} else {
 		// Pre-existing
-		_, err = e.client.CoreV1().Endpoints(service.Namespace).Update(context.TODO(), newEndpoints, metav1.UpdateOptions{})
+		_, err = e.client.CoreV1().Endpoints(service.Namespace).Update(ctx, newEndpoints, metav1.UpdateOptions{})
 	}
 	if err != nil {
 		if createEndpoints && errors.IsForbidden(err) {

--- a/pkg/controller/resourcequota/resource_quota_controller.go
+++ b/pkg/controller/resourcequota/resource_quota_controller.go
@@ -88,7 +88,7 @@ type Controller struct {
 	// missingUsageQueue holds objects that are missing the initial usage information
 	missingUsageQueue workqueue.RateLimitingInterface
 	// To allow injection of syncUsage for testing.
-	syncHandler func(key string) error
+	syncHandler func(ctx context.Context, key string) error
 	// function that controls full recalculation of quota usage
 	resyncPeriod controller.ResyncPeriodFunc
 	// knows how to calculate usage
@@ -236,8 +236,8 @@ func (rq *Controller) addQuota(obj interface{}) {
 }
 
 // worker runs a worker thread that just dequeues items, processes them, and marks them done.
-func (rq *Controller) worker(queue workqueue.RateLimitingInterface) func() {
-	workFunc := func() bool {
+func (rq *Controller) worker(ctx context.Context, queue workqueue.RateLimitingInterface) func(context.Context) {
+	workFunc := func(ctx context.Context) bool {
 		key, quit := queue.Get()
 		if quit {
 			return true
@@ -245,7 +245,7 @@ func (rq *Controller) worker(queue workqueue.RateLimitingInterface) func() {
 		defer queue.Done(key)
 		rq.workerLock.RLock()
 		defer rq.workerLock.RUnlock()
-		err := rq.syncHandler(key.(string))
+		err := rq.syncHandler(ctx, key.(string))
 		if err == nil {
 			queue.Forget(key)
 			return false
@@ -255,9 +255,9 @@ func (rq *Controller) worker(queue workqueue.RateLimitingInterface) func() {
 		return false
 	}
 
-	return func() {
+	return func(ctx context.Context) {
 		for {
-			if quit := workFunc(); quit {
+			if quit := workFunc(ctx); quit {
 				klog.Infof("resource quota controller worker shutting down")
 				return
 			}
@@ -266,7 +266,7 @@ func (rq *Controller) worker(queue workqueue.RateLimitingInterface) func() {
 }
 
 // Run begins quota controller using the specified number of workers
-func (rq *Controller) Run(workers int, stopCh <-chan struct{}) {
+func (rq *Controller) Run(ctx context.Context, workers int, stopCh <-chan struct{}) {
 	defer utilruntime.HandleCrash()
 	defer rq.queue.ShutDown()
 
@@ -283,8 +283,8 @@ func (rq *Controller) Run(workers int, stopCh <-chan struct{}) {
 
 	// the workers that chug through the quota calculation backlog
 	for i := 0; i < workers; i++ {
-		go wait.Until(rq.worker(rq.queue), time.Second, stopCh)
-		go wait.Until(rq.worker(rq.missingUsageQueue), time.Second, stopCh)
+		go wait.UntilWithContext(ctx, rq.worker(ctx, rq.queue), time.Second)
+		go wait.UntilWithContext(ctx, rq.worker(ctx, rq.missingUsageQueue), time.Second)
 	}
 	// the timer for how often we do a full recalculation across all quotas
 	go wait.Until(func() { rq.enqueueAll() }, rq.resyncPeriod(), stopCh)
@@ -292,7 +292,7 @@ func (rq *Controller) Run(workers int, stopCh <-chan struct{}) {
 }
 
 // syncResourceQuotaFromKey syncs a quota key
-func (rq *Controller) syncResourceQuotaFromKey(key string) (err error) {
+func (rq *Controller) syncResourceQuotaFromKey(ctx context.Context, key string) (err error) {
 	startTime := time.Now()
 	defer func() {
 		klog.V(4).Infof("Finished syncing resource quota %q (%v)", key, time.Since(startTime))
@@ -311,11 +311,11 @@ func (rq *Controller) syncResourceQuotaFromKey(key string) (err error) {
 		klog.Infof("Unable to retrieve resource quota %v from store: %v", key, err)
 		return err
 	}
-	return rq.syncResourceQuota(resourceQuota)
+	return rq.syncResourceQuota(ctx, resourceQuota)
 }
 
 // syncResourceQuota runs a complete sync of resource quota status across all known kinds
-func (rq *Controller) syncResourceQuota(resourceQuota *v1.ResourceQuota) (err error) {
+func (rq *Controller) syncResourceQuota(ctx context.Context, resourceQuota *v1.ResourceQuota) (err error) {
 	// quota is dirty if any part of spec hard limits differs from the status hard limits
 	statusLimitsDirty := !apiequality.Semantic.DeepEqual(resourceQuota.Spec.Hard, resourceQuota.Status.Hard)
 
@@ -357,7 +357,7 @@ func (rq *Controller) syncResourceQuota(resourceQuota *v1.ResourceQuota) (err er
 
 	// there was a change observed by this controller that requires we update quota
 	if dirty {
-		_, err = rq.rqClient.ResourceQuotas(usage.Namespace).UpdateStatus(context.TODO(), usage, metav1.UpdateOptions{})
+		_, err = rq.rqClient.ResourceQuotas(usage.Namespace).UpdateStatus(ctx, usage, metav1.UpdateOptions{})
 		if err != nil {
 			errs = append(errs, err)
 		}

--- a/pkg/controller/serviceaccount/serviceaccounts_controller.go
+++ b/pkg/controller/serviceaccount/serviceaccounts_controller.go
@@ -98,7 +98,7 @@ type ServiceAccountsController struct {
 	serviceAccountsToEnsure []v1.ServiceAccount
 
 	// To allow injection for testing.
-	syncHandler func(key string) error
+	syncHandler func(ctx context.Context, key string) error
 
 	saLister       corelisters.ServiceAccountLister
 	saListerSynced cache.InformerSynced
@@ -110,7 +110,7 @@ type ServiceAccountsController struct {
 }
 
 // Run runs the ServiceAccountsController blocks until receiving signal from stopCh.
-func (c *ServiceAccountsController) Run(workers int, stopCh <-chan struct{}) {
+func (c *ServiceAccountsController) Run(ctx context.Context, workers int, stopCh <-chan struct{}) {
 	defer utilruntime.HandleCrash()
 	defer c.queue.ShutDown()
 
@@ -122,7 +122,7 @@ func (c *ServiceAccountsController) Run(workers int, stopCh <-chan struct{}) {
 	}
 
 	for i := 0; i < workers; i++ {
-		go wait.Until(c.runWorker, time.Second, stopCh)
+		go wait.UntilWithContext(ctx, c.runWorker, time.Second)
 	}
 
 	<-stopCh
@@ -158,20 +158,20 @@ func (c *ServiceAccountsController) namespaceUpdated(oldObj interface{}, newObj 
 	c.queue.Add(newNamespace.Name)
 }
 
-func (c *ServiceAccountsController) runWorker() {
-	for c.processNextWorkItem() {
+func (c *ServiceAccountsController) runWorker(ctx context.Context) {
+	for c.processNextWorkItem(ctx) {
 	}
 }
 
 // processNextWorkItem deals with one key off the queue.  It returns false when it's time to quit.
-func (c *ServiceAccountsController) processNextWorkItem() bool {
+func (c *ServiceAccountsController) processNextWorkItem(ctx context.Context) bool {
 	key, quit := c.queue.Get()
 	if quit {
 		return false
 	}
 	defer c.queue.Done(key)
 
-	err := c.syncHandler(key.(string))
+	err := c.syncHandler(ctx, key.(string))
 	if err == nil {
 		c.queue.Forget(key)
 		return true
@@ -182,7 +182,7 @@ func (c *ServiceAccountsController) processNextWorkItem() bool {
 
 	return true
 }
-func (c *ServiceAccountsController) syncNamespace(key string) error {
+func (c *ServiceAccountsController) syncNamespace(ctx context.Context, key string) error {
 	startTime := time.Now()
 	defer func() {
 		klog.V(4).Infof("Finished syncing namespace %q (%v)", key, time.Since(startTime))
@@ -213,7 +213,7 @@ func (c *ServiceAccountsController) syncNamespace(key string) error {
 		// TODO eliminate this once the fake client can handle creation without NS
 		sa.Namespace = ns.Name
 
-		if _, err := c.client.CoreV1().ServiceAccounts(ns.Name).Create(context.TODO(), &sa, metav1.CreateOptions{}); err != nil && !apierrors.IsAlreadyExists(err) {
+		if _, err := c.client.CoreV1().ServiceAccounts(ns.Name).Create(ctx, &sa, metav1.CreateOptions{}); err != nil && !apierrors.IsAlreadyExists(err) {
 			// we can safely ignore terminating namespace errors
 			if !apierrors.HasStatusCause(err, v1.NamespaceTerminatingCause) {
 				createFailures = append(createFailures, err)

--- a/pkg/controller/storageversiongc/gc_controller.go
+++ b/pkg/controller/storageversiongc/gc_controller.go
@@ -78,7 +78,7 @@ func NewStorageVersionGC(clientset kubernetes.Interface, leaseInformer coordinfo
 }
 
 // Run starts one worker.
-func (c *Controller) Run(stopCh <-chan struct{}) {
+func (c *Controller) Run(ctx context.Context, stopCh <-chan struct{}) {
 	defer utilruntime.HandleCrash()
 	defer c.leaseQueue.ShutDown()
 	defer c.storageVersionQueue.ShutDown()
@@ -96,25 +96,25 @@ func (c *Controller) Run(stopCh <-chan struct{}) {
 	// runLeaseWorker handles legit identity lease deletion, while runStorageVersionWorker
 	// handles storageversion creation/update with non-existing id. The latter should rarely
 	// happen. It's okay for the two workers to conflict on update.
-	go wait.Until(c.runLeaseWorker, time.Second, stopCh)
-	go wait.Until(c.runStorageVersionWorker, time.Second, stopCh)
+	go wait.UntilWithContext(ctx, c.runLeaseWorker, time.Second)
+	go wait.UntilWithContext(ctx, c.runStorageVersionWorker, time.Second)
 
 	<-stopCh
 }
 
-func (c *Controller) runLeaseWorker() {
-	for c.processNextLease() {
+func (c *Controller) runLeaseWorker(ctx context.Context) {
+	for c.processNextLease(ctx) {
 	}
 }
 
-func (c *Controller) processNextLease() bool {
+func (c *Controller) processNextLease(ctx context.Context) bool {
 	key, quit := c.leaseQueue.Get()
 	if quit {
 		return false
 	}
 	defer c.leaseQueue.Done(key)
 
-	err := c.processDeletedLease(key.(string))
+	err := c.processDeletedLease(ctx, key.(string))
 	if err == nil {
 		c.leaseQueue.Forget(key)
 		return true
@@ -125,19 +125,19 @@ func (c *Controller) processNextLease() bool {
 	return true
 }
 
-func (c *Controller) runStorageVersionWorker() {
-	for c.processNextStorageVersion() {
+func (c *Controller) runStorageVersionWorker(ctx context.Context) {
+	for c.processNextStorageVersion(ctx) {
 	}
 }
 
-func (c *Controller) processNextStorageVersion() bool {
+func (c *Controller) processNextStorageVersion(ctx context.Context) bool {
 	key, quit := c.storageVersionQueue.Get()
 	if quit {
 		return false
 	}
 	defer c.storageVersionQueue.Done(key)
 
-	err := c.syncStorageVersion(key.(string))
+	err := c.syncStorageVersion(ctx, key.(string))
 	if err == nil {
 		c.storageVersionQueue.Forget(key)
 		return true
@@ -148,8 +148,8 @@ func (c *Controller) processNextStorageVersion() bool {
 	return true
 }
 
-func (c *Controller) processDeletedLease(name string) error {
-	_, err := c.kubeclientset.CoordinationV1().Leases(metav1.NamespaceSystem).Get(context.TODO(), name, metav1.GetOptions{})
+func (c *Controller) processDeletedLease(ctx context.Context, name string) error {
+	_, err := c.kubeclientset.CoordinationV1().Leases(metav1.NamespaceSystem).Get(ctx, name, metav1.GetOptions{})
 	// the lease isn't deleted, nothing we need to do here
 	if err == nil {
 		return nil
@@ -158,7 +158,7 @@ func (c *Controller) processDeletedLease(name string) error {
 		return err
 	}
 	// the frequency of this call won't be too high because we only trigger on identity lease deletions
-	storageVersionList, err := c.kubeclientset.InternalV1alpha1().StorageVersions().List(context.TODO(), metav1.ListOptions{})
+	storageVersionList, err := c.kubeclientset.InternalV1alpha1().StorageVersions().List(ctx, metav1.ListOptions{})
 	if err != nil {
 		return err
 	}
@@ -177,7 +177,7 @@ func (c *Controller) processDeletedLease(name string) error {
 		if !hasStaleRecord {
 			continue
 		}
-		if err := c.updateOrDeleteStorageVersion(&sv, serverStorageVersions); err != nil {
+		if err := c.updateOrDeleteStorageVersion(ctx, &sv, serverStorageVersions); err != nil {
 			errors = append(errors, err)
 		}
 	}
@@ -185,8 +185,8 @@ func (c *Controller) processDeletedLease(name string) error {
 	return utilerrors.NewAggregate(errors)
 }
 
-func (c *Controller) syncStorageVersion(name string) error {
-	sv, err := c.kubeclientset.InternalV1alpha1().StorageVersions().Get(context.TODO(), name, metav1.GetOptions{})
+func (c *Controller) syncStorageVersion(ctx context.Context, name string) error {
+	sv, err := c.kubeclientset.InternalV1alpha1().StorageVersions().Get(ctx, name, metav1.GetOptions{})
 	if apierrors.IsNotFound(err) {
 		// The problematic storage version that was added/updated recently is gone.
 		// Nothing we need to do here.
@@ -199,7 +199,7 @@ func (c *Controller) syncStorageVersion(name string) error {
 	hasInvalidID := false
 	var serverStorageVersions []apiserverinternalv1alpha1.ServerStorageVersion
 	for _, v := range sv.Status.StorageVersions {
-		lease, err := c.kubeclientset.CoordinationV1().Leases(metav1.NamespaceSystem).Get(context.TODO(), v.APIServerID, metav1.GetOptions{})
+		lease, err := c.kubeclientset.CoordinationV1().Leases(metav1.NamespaceSystem).Get(ctx, v.APIServerID, metav1.GetOptions{})
 		if err != nil || lease == nil || lease.Labels == nil ||
 			lease.Labels[controlplane.IdentityLeaseComponentLabelKey] != controlplane.KubeAPIServer {
 			// We cannot find a corresponding identity lease from apiserver as well.
@@ -212,7 +212,7 @@ func (c *Controller) syncStorageVersion(name string) error {
 	if !hasInvalidID {
 		return nil
 	}
-	return c.updateOrDeleteStorageVersion(sv, serverStorageVersions)
+	return c.updateOrDeleteStorageVersion(ctx, sv, serverStorageVersions)
 }
 
 func (c *Controller) onAddStorageVersion(obj interface{}) {
@@ -266,14 +266,14 @@ func (c *Controller) enqueueLease(obj *coordinationv1.Lease) {
 	c.leaseQueue.Add(obj.Name)
 }
 
-func (c *Controller) updateOrDeleteStorageVersion(sv *apiserverinternalv1alpha1.StorageVersion, serverStorageVersions []apiserverinternalv1alpha1.ServerStorageVersion) error {
+func (c *Controller) updateOrDeleteStorageVersion(ctx context.Context, sv *apiserverinternalv1alpha1.StorageVersion, serverStorageVersions []apiserverinternalv1alpha1.ServerStorageVersion) error {
 	if len(serverStorageVersions) == 0 {
 		return c.kubeclientset.InternalV1alpha1().StorageVersions().Delete(
-			context.TODO(), sv.Name, metav1.DeleteOptions{})
+			ctx, sv.Name, metav1.DeleteOptions{})
 	}
 	sv.Status.StorageVersions = serverStorageVersions
 	storageversion.SetCommonEncodingVersion(sv)
 	_, err := c.kubeclientset.InternalV1alpha1().StorageVersions().UpdateStatus(
-		context.TODO(), sv, metav1.UpdateOptions{})
+		ctx, sv, metav1.UpdateOptions{})
 	return err
 }

--- a/pkg/controller/ttl/ttl_controller.go
+++ b/pkg/controller/ttl/ttl_controller.go
@@ -114,7 +114,7 @@ var (
 )
 
 // Run begins watching and syncing.
-func (ttlc *Controller) Run(workers int, stopCh <-chan struct{}) {
+func (ttlc *Controller) Run(ctx context.Context, workers int, stopCh <-chan struct{}) {
 	defer utilruntime.HandleCrash()
 	defer ttlc.queue.ShutDown()
 
@@ -126,7 +126,7 @@ func (ttlc *Controller) Run(workers int, stopCh <-chan struct{}) {
 	}
 
 	for i := 0; i < workers; i++ {
-		go wait.Until(ttlc.worker, time.Second, stopCh)
+		go wait.UntilWithContext(ctx, ttlc.worker, time.Second)
 	}
 
 	<-stopCh
@@ -201,19 +201,19 @@ func (ttlc *Controller) enqueueNode(node *v1.Node) {
 	ttlc.queue.Add(key)
 }
 
-func (ttlc *Controller) worker() {
-	for ttlc.processItem() {
+func (ttlc *Controller) worker(ctx context.Context) {
+	for ttlc.processItem(ctx) {
 	}
 }
 
-func (ttlc *Controller) processItem() bool {
+func (ttlc *Controller) processItem(ctx context.Context, ) bool {
 	key, quit := ttlc.queue.Get()
 	if quit {
 		return false
 	}
 	defer ttlc.queue.Done(key)
 
-	err := ttlc.updateNodeIfNeeded(key.(string))
+	err := ttlc.updateNodeIfNeeded(ctx, key.(string))
 	if err == nil {
 		ttlc.queue.Forget(key)
 		return true
@@ -254,7 +254,7 @@ func setIntAnnotation(node *v1.Node, annotationKey string, value int) {
 	node.Annotations[annotationKey] = strconv.Itoa(value)
 }
 
-func (ttlc *Controller) patchNodeWithAnnotation(node *v1.Node, annotationKey string, value int) error {
+func (ttlc *Controller) patchNodeWithAnnotation(ctx context.Context, node *v1.Node, annotationKey string, value int) error {
 	oldData, err := json.Marshal(node)
 	if err != nil {
 		return err
@@ -268,7 +268,7 @@ func (ttlc *Controller) patchNodeWithAnnotation(node *v1.Node, annotationKey str
 	if err != nil {
 		return err
 	}
-	_, err = ttlc.kubeClient.CoreV1().Nodes().Patch(context.TODO(), node.Name, types.StrategicMergePatchType, patchBytes, metav1.PatchOptions{})
+	_, err = ttlc.kubeClient.CoreV1().Nodes().Patch(ctx, node.Name, types.StrategicMergePatchType, patchBytes, metav1.PatchOptions{})
 	if err != nil {
 		klog.V(2).InfoS("Failed to change ttl annotation for node", "node", klog.KObj(node), "err", err)
 		return err
@@ -277,7 +277,7 @@ func (ttlc *Controller) patchNodeWithAnnotation(node *v1.Node, annotationKey str
 	return nil
 }
 
-func (ttlc *Controller) updateNodeIfNeeded(key string) error {
+func (ttlc *Controller) updateNodeIfNeeded(ctx context.Context, key string) error {
 	node, err := ttlc.nodeStore.Get(key)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
@@ -292,5 +292,5 @@ func (ttlc *Controller) updateNodeIfNeeded(key string) error {
 		return nil
 	}
 
-	return ttlc.patchNodeWithAnnotation(node.DeepCopy(), v1.ObjectTTLAnnotationKey, desiredTTL)
+	return ttlc.patchNodeWithAnnotation(ctx, node.DeepCopy(), v1.ObjectTTLAnnotationKey, desiredTTL)
 }

--- a/pkg/controller/ttlafterfinished/ttlafterfinished_controller.go
+++ b/pkg/controller/ttlafterfinished/ttlafterfinished_controller.go
@@ -102,7 +102,7 @@ func New(jobInformer batchinformers.JobInformer, client clientset.Interface) *Co
 }
 
 // Run starts the workers to clean up Jobs.
-func (tc *Controller) Run(workers int, stopCh <-chan struct{}) {
+func (tc *Controller) Run(ctx context.Context, workers int, stopCh <-chan struct{}) {
 	defer utilruntime.HandleCrash()
 	defer tc.queue.ShutDown()
 
@@ -114,7 +114,7 @@ func (tc *Controller) Run(workers int, stopCh <-chan struct{}) {
 	}
 
 	for i := 0; i < workers; i++ {
-		go wait.Until(tc.worker, time.Second, stopCh)
+		go wait.UntilWithContext(ctx, tc.worker, time.Second)
 	}
 
 	<-stopCh
@@ -159,19 +159,19 @@ func (tc *Controller) enqueueAfter(job *batch.Job, after time.Duration) {
 	tc.queue.AddAfter(key, after)
 }
 
-func (tc *Controller) worker() {
-	for tc.processNextWorkItem() {
+func (tc *Controller) worker(ctx context.Context) {
+	for tc.processNextWorkItem(ctx) {
 	}
 }
 
-func (tc *Controller) processNextWorkItem() bool {
+func (tc *Controller) processNextWorkItem(ctx context.Context) bool {
 	key, quit := tc.queue.Get()
 	if quit {
 		return false
 	}
 	defer tc.queue.Done(key)
 
-	err := tc.processJob(key.(string))
+	err := tc.processJob(ctx, key.(string))
 	tc.handleErr(err, key)
 
 	return true
@@ -192,7 +192,7 @@ func (tc *Controller) handleErr(err error, key interface{}) {
 // its TTL hasn't expired, it will be added to the queue after the TTL is expected
 // to expire.
 // This function is not meant to be invoked concurrently with the same key.
-func (tc *Controller) processJob(key string) error {
+func (tc *Controller) processJob(ctx context.Context, key string) error {
 	namespace, name, err := cache.SplitMetaNamespaceKey(key)
 	if err != nil {
 		return err
@@ -218,7 +218,7 @@ func (tc *Controller) processJob(key string) error {
 	// Before deleting the Job, do a final sanity check.
 	// If TTL is modified before we do this check, we cannot be sure if the TTL truly expires.
 	// The latest Job may have a different UID, but it's fine because the checks will be run again.
-	fresh, err := tc.client.BatchV1().Jobs(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+	fresh, err := tc.client.BatchV1().Jobs(namespace).Get(ctx, name, metav1.GetOptions{})
 	if errors.IsNotFound(err) {
 		return nil
 	}
@@ -239,7 +239,7 @@ func (tc *Controller) processJob(key string) error {
 		Preconditions:     &metav1.Preconditions{UID: &fresh.UID},
 	}
 	klog.V(4).Infof("Cleaning up Job %s/%s", namespace, name)
-	if err := tc.client.BatchV1().Jobs(fresh.Namespace).Delete(context.TODO(), fresh.Name, options); err != nil {
+	if err := tc.client.BatchV1().Jobs(fresh.Namespace).Delete(ctx, fresh.Name, options); err != nil {
 		return err
 	}
 	metrics.JobDeletionDurationSeconds.Observe(time.Since(*expiredAt).Seconds())

--- a/pkg/controller/volume/expand/expand_controller.go
+++ b/pkg/controller/volume/expand/expand_controller.go
@@ -60,7 +60,7 @@ const (
 
 // ExpandController expands the pvs
 type ExpandController interface {
-	Run(stopCh <-chan struct{})
+	Run(ctx context.Context, stopCh <-chan struct{})
 }
 
 // CSINameTranslator can get the CSI Driver name based on the in-tree plugin name
@@ -188,14 +188,14 @@ func (expc *expandController) enqueuePVC(obj interface{}) {
 	}
 }
 
-func (expc *expandController) processNextWorkItem() bool {
+func (expc *expandController) processNextWorkItem(ctx context.Context) bool {
 	key, shutdown := expc.queue.Get()
 	if shutdown {
 		return false
 	}
 	defer expc.queue.Done(key)
 
-	err := expc.syncHandler(key.(string))
+	err := expc.syncHandler(ctx, key.(string))
 	if err == nil {
 		expc.queue.Forget(key)
 		return true
@@ -209,7 +209,7 @@ func (expc *expandController) processNextWorkItem() bool {
 
 // syncHandler performs actual expansion of volume. If an error is returned
 // from this function - PVC will be requeued for resizing.
-func (expc *expandController) syncHandler(key string) error {
+func (expc *expandController) syncHandler(ctx context.Context, key string) error {
 	namespace, name, err := kcache.SplitMetaNamespaceKey(key)
 	if err != nil {
 		return err
@@ -223,7 +223,7 @@ func (expc *expandController) syncHandler(key string) error {
 		return err
 	}
 
-	pv, err := expc.getPersistentVolume(pvc)
+	pv, err := expc.getPersistentVolume(ctx, pvc)
 	if err != nil {
 		klog.V(5).Infof("Error getting Persistent Volume for PVC %q (uid: %q) from informer : %v", util.GetPersistentVolumeClaimQualifiedName(pvc), pvc.UID, err)
 		return err
@@ -320,7 +320,7 @@ func (expc *expandController) expand(pvc *v1.PersistentVolumeClaim, pv *v1.Persi
 }
 
 // TODO make concurrency configurable (workers/threadiness argument). previously, nestedpendingoperations spawned unlimited goroutines
-func (expc *expandController) Run(stopCh <-chan struct{}) {
+func (expc *expandController) Run(ctx context.Context, stopCh <-chan struct{}) {
 	defer runtime.HandleCrash()
 	defer expc.queue.ShutDown()
 
@@ -332,20 +332,20 @@ func (expc *expandController) Run(stopCh <-chan struct{}) {
 	}
 
 	for i := 0; i < defaultWorkerCount; i++ {
-		go wait.Until(expc.runWorker, time.Second, stopCh)
+		go wait.UntilWithContext(ctx, expc.runWorker, time.Second)
 	}
 
 	<-stopCh
 }
 
-func (expc *expandController) runWorker() {
-	for expc.processNextWorkItem() {
+func (expc *expandController) runWorker(ctx context.Context) {
+	for expc.processNextWorkItem(ctx) {
 	}
 }
 
-func (expc *expandController) getPersistentVolume(pvc *v1.PersistentVolumeClaim) (*v1.PersistentVolume, error) {
+func (expc *expandController) getPersistentVolume(ctx context.Context, pvc *v1.PersistentVolumeClaim) (*v1.PersistentVolume, error) {
 	volumeName := pvc.Spec.VolumeName
-	pv, err := expc.kubeClient.CoreV1().PersistentVolumes().Get(context.TODO(), volumeName, metav1.GetOptions{})
+	pv, err := expc.kubeClient.CoreV1().PersistentVolumes().Get(ctx, volumeName, metav1.GetOptions{})
 
 	if err != nil {
 		return nil, fmt.Errorf("failed to get PV %q: %v", volumeName, err)

--- a/pkg/controller/volume/persistentvolume/pv_controller.go
+++ b/pkg/controller/volume/persistentvolume/pv_controller.go
@@ -249,12 +249,12 @@ type PersistentVolumeController struct {
 // these events.
 // For easier readability, it was split into syncUnboundClaim and syncBoundClaim
 // methods.
-func (ctrl *PersistentVolumeController) syncClaim(claim *v1.PersistentVolumeClaim) error {
+func (ctrl *PersistentVolumeController) syncClaim(ctx context.Context, claim *v1.PersistentVolumeClaim) error {
 	klog.V(4).Infof("synchronizing PersistentVolumeClaim[%s]: %s", claimToClaimKey(claim), getClaimStatusForLogging(claim))
 
 	// Set correct "migrated-to" annotations on PVC and update in API server if
 	// necessary
-	newClaim, err := ctrl.updateClaimMigrationAnnotations(claim)
+	newClaim, err := ctrl.updateClaimMigrationAnnotations(ctx, claim)
 	if err != nil {
 		// Nothing was saved; we will fall back into the same
 		// condition in the next call to this method
@@ -263,7 +263,7 @@ func (ctrl *PersistentVolumeController) syncClaim(claim *v1.PersistentVolumeClai
 	claim = newClaim
 
 	if !metav1.HasAnnotation(claim.ObjectMeta, pvutil.AnnBindCompleted) {
-		return ctrl.syncUnboundClaim(claim)
+		return ctrl.syncUnboundClaim(ctx, claim)
 	} else {
 		return ctrl.syncBoundClaim(claim)
 	}
@@ -330,7 +330,7 @@ func (ctrl *PersistentVolumeController) emitEventForUnboundDelayBindingClaim(cla
 
 // syncUnboundClaim is the main controller method to decide what to do with an
 // unbound claim.
-func (ctrl *PersistentVolumeController) syncUnboundClaim(claim *v1.PersistentVolumeClaim) error {
+func (ctrl *PersistentVolumeController) syncUnboundClaim(ctx context.Context, claim *v1.PersistentVolumeClaim) error {
 	// This is a new PVC that has not completed binding
 	// OBSERVATION: pvc is "Pending"
 	if claim.Spec.VolumeName == "" {
@@ -356,7 +356,7 @@ func (ctrl *PersistentVolumeController) syncUnboundClaim(claim *v1.PersistentVol
 					return err
 				}
 			case storagehelpers.GetPersistentVolumeClaimClass(claim) != "":
-				if err = ctrl.provisionClaim(claim); err != nil {
+				if err = ctrl.provisionClaim(ctx, claim); err != nil {
 					return err
 				}
 				return nil
@@ -539,12 +539,12 @@ func (ctrl *PersistentVolumeController) syncBoundClaim(claim *v1.PersistentVolum
 // It's invoked by appropriate cache.Controller callbacks when a volume is
 // created, updated or periodically synced. We do not differentiate between
 // these events.
-func (ctrl *PersistentVolumeController) syncVolume(volume *v1.PersistentVolume) error {
+func (ctrl *PersistentVolumeController) syncVolume(ctx context.Context, volume *v1.PersistentVolume) error {
 	klog.V(4).Infof("synchronizing PersistentVolume[%s]: %s", volume.Name, getVolumeStatusForLogging(volume))
 
 	// Set correct "migrated-to" annotations on PV and update in API server if
 	// necessary
-	newVolume, err := ctrl.updateVolumeMigrationAnnotations(volume)
+	newVolume, err := ctrl.updateVolumeMigrationAnnotations(ctx, volume)
 	if err != nil {
 		// Nothing was saved; we will fall back into the same
 		// condition in the next call to this method
@@ -1439,7 +1439,7 @@ func (ctrl *PersistentVolumeController) doDeleteVolume(volume *v1.PersistentVolu
 
 // provisionClaim starts new asynchronous operation to provision a claim if
 // provisioning is enabled.
-func (ctrl *PersistentVolumeController) provisionClaim(claim *v1.PersistentVolumeClaim) error {
+func (ctrl *PersistentVolumeController) provisionClaim(ctx context.Context, claim *v1.PersistentVolumeClaim) error {
 	if !ctrl.enableDynamicProvisioning {
 		return nil
 	}
@@ -1462,9 +1462,9 @@ func (ctrl *PersistentVolumeController) provisionClaim(claim *v1.PersistentVolum
 		ctrl.operationTimestamps.AddIfNotExist(claimKey, ctrl.getProvisionerName(plugin, storageClass), "provision")
 		var err error
 		if plugin == nil {
-			_, err = ctrl.provisionClaimOperationExternal(claim, storageClass)
+			_, err = ctrl.provisionClaimOperationExternal(ctx, claim, storageClass)
 		} else {
-			_, err = ctrl.provisionClaimOperation(claim, plugin, storageClass)
+			_, err = ctrl.provisionClaimOperation(ctx, claim, plugin, storageClass)
 		}
 		// if error happened, record an error count metric
 		// timestamp entry will remain in cache until a success binding has happened
@@ -1479,7 +1479,8 @@ func (ctrl *PersistentVolumeController) provisionClaim(claim *v1.PersistentVolum
 // provisionClaimOperation provisions a volume. This method is running in
 // standalone goroutine and already has all necessary locks.
 func (ctrl *PersistentVolumeController) provisionClaimOperation(
-	claim *v1.PersistentVolumeClaim,
+	ctx context.Context,
+claim *v1.PersistentVolumeClaim,
 	plugin vol.ProvisionableVolumePlugin,
 	storageClass *storage.StorageClass) (string, error) {
 	claimClass := storagehelpers.GetPersistentVolumeClaimClass(claim)
@@ -1501,7 +1502,7 @@ func (ctrl *PersistentVolumeController) provisionClaimOperation(
 	klog.V(4).Infof("provisionClaimOperation [%s]: plugin name: %s, provisioner name: %s", claimToClaimKey(claim), pluginName, provisionerName)
 
 	// Add provisioner annotation to be consistent with external provisioner workflow
-	newClaim, err := ctrl.setClaimProvisioner(claim, provisionerName)
+	newClaim, err := ctrl.setClaimProvisioner(ctx, claim, provisionerName)
 	if err != nil {
 		// Save failed, the controller will retry in the next sync
 		klog.V(2).Infof("error saving claim %s: %v", claimToClaimKey(claim), err)
@@ -1684,6 +1685,7 @@ func (ctrl *PersistentVolumeController) provisionClaimOperation(
 // provisionClaimOperationExternal provisions a volume using external provisioner async-ly
 // This method will be running in a standalone go-routine scheduled in "provisionClaim"
 func (ctrl *PersistentVolumeController) provisionClaimOperationExternal(
+	ctx context.Context,
 	claim *v1.PersistentVolumeClaim,
 	storageClass *storage.StorageClass) (string, error) {
 	claimClass := storagehelpers.GetPersistentVolumeClaimClass(claim)
@@ -1702,7 +1704,7 @@ func (ctrl *PersistentVolumeController) provisionClaimOperationExternal(
 		}
 	}
 	// Add provisioner annotation so external provisioners know when to start
-	newClaim, err := ctrl.setClaimProvisioner(claim, provisionerName)
+	newClaim, err := ctrl.setClaimProvisioner(ctx, claim, provisionerName)
 	if err != nil {
 		// Save failed, the controller will retry in the next sync
 		klog.V(2).Infof("error saving claim %s: %v", claimToClaimKey(claim), err)

--- a/pkg/controller/volume/persistentvolume/pv_controller_base.go
+++ b/pkg/controller/volume/persistentvolume/pv_controller_base.go
@@ -204,7 +204,7 @@ func (ctrl *PersistentVolumeController) storeClaimUpdate(claim interface{}) (boo
 
 // updateVolume runs in worker thread and handles "volume added",
 // "volume updated" and "periodic sync" events.
-func (ctrl *PersistentVolumeController) updateVolume(volume *v1.PersistentVolume) {
+func (ctrl *PersistentVolumeController) updateVolume(ctx context.Context, volume *v1.PersistentVolume) {
 	// Store the new volume version in the cache and do not process it if this
 	// is an old version.
 	new, err := ctrl.storeVolumeUpdate(volume)
@@ -215,7 +215,7 @@ func (ctrl *PersistentVolumeController) updateVolume(volume *v1.PersistentVolume
 		return
 	}
 
-	err = ctrl.syncVolume(volume)
+	err = ctrl.syncVolume(ctx, volume)
 	if err != nil {
 		if errors.IsConflict(err) {
 			// Version conflict error happens quite often and the controller
@@ -252,7 +252,7 @@ func (ctrl *PersistentVolumeController) deleteVolume(volume *v1.PersistentVolume
 
 // updateClaim runs in worker thread and handles "claim added",
 // "claim updated" and "periodic sync" events.
-func (ctrl *PersistentVolumeController) updateClaim(claim *v1.PersistentVolumeClaim) {
+func (ctrl *PersistentVolumeController) updateClaim(ctx context.Context, claim *v1.PersistentVolumeClaim) {
 	// Store the new claim version in the cache and do not process it if this is
 	// an old version.
 	new, err := ctrl.storeClaimUpdate(claim)
@@ -262,7 +262,7 @@ func (ctrl *PersistentVolumeController) updateClaim(claim *v1.PersistentVolumeCl
 	if !new {
 		return
 	}
-	err = ctrl.syncClaim(claim)
+	err = ctrl.syncClaim(ctx, claim)
 	if err != nil {
 		if errors.IsConflict(err) {
 			// Version conflict error happens quite often and the controller
@@ -300,7 +300,7 @@ func (ctrl *PersistentVolumeController) deleteClaim(claim *v1.PersistentVolumeCl
 }
 
 // Run starts all of this controller's control loops
-func (ctrl *PersistentVolumeController) Run(stopCh <-chan struct{}) {
+func (ctrl *PersistentVolumeController) Run(ctx context.Context, stopCh <-chan struct{}) {
 	defer utilruntime.HandleCrash()
 	defer ctrl.claimQueue.ShutDown()
 	defer ctrl.volumeQueue.ShutDown()
@@ -315,15 +315,15 @@ func (ctrl *PersistentVolumeController) Run(stopCh <-chan struct{}) {
 	ctrl.initializeCaches(ctrl.volumeLister, ctrl.claimLister)
 
 	go wait.Until(ctrl.resync, ctrl.resyncPeriod, stopCh)
-	go wait.Until(ctrl.volumeWorker, time.Second, stopCh)
-	go wait.Until(ctrl.claimWorker, time.Second, stopCh)
+	go wait.UntilWithContext(ctx, ctrl.volumeWorker, time.Second)
+	go wait.UntilWithContext(ctx, ctrl.claimWorker, time.Second)
 
 	metrics.Register(ctrl.volumes.store, ctrl.claims, &ctrl.volumePluginMgr)
 
 	<-stopCh
 }
 
-func (ctrl *PersistentVolumeController) updateClaimMigrationAnnotations(claim *v1.PersistentVolumeClaim) (*v1.PersistentVolumeClaim, error) {
+func (ctrl *PersistentVolumeController) updateClaimMigrationAnnotations(ctx context.Context, claim *v1.PersistentVolumeClaim) (*v1.PersistentVolumeClaim, error) {
 	// TODO: update[Claim|Volume]MigrationAnnotations can be optimized to not
 	// copy the claim/volume if no modifications are required. Though this
 	// requires some refactoring as well as an interesting change in the
@@ -335,7 +335,7 @@ func (ctrl *PersistentVolumeController) updateClaimMigrationAnnotations(claim *v
 	if !modified {
 		return claimClone, nil
 	}
-	newClaim, err := ctrl.kubeClient.CoreV1().PersistentVolumeClaims(claimClone.Namespace).Update(context.TODO(), claimClone, metav1.UpdateOptions{})
+	newClaim, err := ctrl.kubeClient.CoreV1().PersistentVolumeClaims(claimClone.Namespace).Update(ctx, claimClone, metav1.UpdateOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("persistent Volume Controller can't anneal migration annotations: %v", err)
 	}
@@ -346,13 +346,13 @@ func (ctrl *PersistentVolumeController) updateClaimMigrationAnnotations(claim *v
 	return newClaim, nil
 }
 
-func (ctrl *PersistentVolumeController) updateVolumeMigrationAnnotations(volume *v1.PersistentVolume) (*v1.PersistentVolume, error) {
+func (ctrl *PersistentVolumeController) updateVolumeMigrationAnnotations(ctx context.Context, volume *v1.PersistentVolume) (*v1.PersistentVolume, error) {
 	volumeClone := volume.DeepCopy()
 	modified := updateMigrationAnnotations(ctrl.csiMigratedPluginManager, ctrl.translator, volumeClone.Annotations, pvutil.AnnDynamicallyProvisioned)
 	if !modified {
 		return volumeClone, nil
 	}
-	newVol, err := ctrl.kubeClient.CoreV1().PersistentVolumes().Update(context.TODO(), volumeClone, metav1.UpdateOptions{})
+	newVol, err := ctrl.kubeClient.CoreV1().PersistentVolumes().Update(ctx, volumeClone, metav1.UpdateOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("persistent Volume Controller can't anneal migration annotations: %v", err)
 	}
@@ -408,7 +408,7 @@ func updateMigrationAnnotations(cmpm CSIMigratedPluginManager, translator CSINam
 
 // volumeWorker processes items from volumeQueue. It must run only once,
 // syncVolume is not assured to be reentrant.
-func (ctrl *PersistentVolumeController) volumeWorker() {
+func (ctrl *PersistentVolumeController) volumeWorker(ctx context.Context) {
 	workFunc := func() bool {
 		keyObj, quit := ctrl.volumeQueue.Get()
 		if quit {
@@ -427,7 +427,7 @@ func (ctrl *PersistentVolumeController) volumeWorker() {
 		if err == nil {
 			// The volume still exists in informer cache, the event must have
 			// been add/update/sync
-			ctrl.updateVolume(volume)
+			ctrl.updateVolume(ctx, volume)
 			return false
 		}
 		if !errors.IsNotFound(err) {
@@ -466,7 +466,7 @@ func (ctrl *PersistentVolumeController) volumeWorker() {
 
 // claimWorker processes items from claimQueue. It must run only once,
 // syncClaim is not reentrant.
-func (ctrl *PersistentVolumeController) claimWorker() {
+func (ctrl *PersistentVolumeController) claimWorker(ctx context.Context) {
 	workFunc := func() bool {
 		keyObj, quit := ctrl.claimQueue.Get()
 		if quit {
@@ -485,7 +485,7 @@ func (ctrl *PersistentVolumeController) claimWorker() {
 		if err == nil {
 			// The claim still exists in informer cache, the event must have
 			// been add/update/sync
-			ctrl.updateClaim(claim)
+			ctrl.updateClaim(ctx, claim)
 			return false
 		}
 		if !errors.IsNotFound(err) {
@@ -548,7 +548,7 @@ func (ctrl *PersistentVolumeController) resync() {
 
 // setClaimProvisioner saves
 // claim.Annotations[pvutil.AnnStorageProvisioner] = class.Provisioner
-func (ctrl *PersistentVolumeController) setClaimProvisioner(claim *v1.PersistentVolumeClaim, provisionerName string) (*v1.PersistentVolumeClaim, error) {
+func (ctrl *PersistentVolumeController) setClaimProvisioner(ctx context.Context, claim *v1.PersistentVolumeClaim, provisionerName string) (*v1.PersistentVolumeClaim, error) {
 	if val, ok := claim.Annotations[pvutil.AnnStorageProvisioner]; ok && val == provisionerName {
 		// annotation is already set, nothing to do
 		return claim, nil
@@ -559,7 +559,7 @@ func (ctrl *PersistentVolumeController) setClaimProvisioner(claim *v1.Persistent
 	claimClone := claim.DeepCopy()
 	metav1.SetMetaDataAnnotation(&claimClone.ObjectMeta, pvutil.AnnStorageProvisioner, provisionerName)
 	updateMigrationAnnotations(ctrl.csiMigratedPluginManager, ctrl.translator, claimClone.Annotations, pvutil.AnnStorageProvisioner)
-	newClaim, err := ctrl.kubeClient.CoreV1().PersistentVolumeClaims(claim.Namespace).Update(context.TODO(), claimClone, metav1.UpdateOptions{})
+	newClaim, err := ctrl.kubeClient.CoreV1().PersistentVolumeClaims(claim.Namespace).Update(ctx, claimClone, metav1.UpdateOptions{})
 	if err != nil {
 		return newClaim, err
 	}

--- a/pkg/controller/volume/pvprotection/pv_protection_controller.go
+++ b/pkg/controller/volume/pvprotection/pv_protection_controller.go
@@ -76,7 +76,7 @@ func NewPVProtectionController(pvInformer coreinformers.PersistentVolumeInformer
 }
 
 // Run runs the controller goroutines.
-func (c *Controller) Run(workers int, stopCh <-chan struct{}) {
+func (c *Controller) Run(ctx context.Context, workers int, stopCh <-chan struct{}) {
 	defer utilruntime.HandleCrash()
 	defer c.queue.ShutDown()
 
@@ -88,19 +88,19 @@ func (c *Controller) Run(workers int, stopCh <-chan struct{}) {
 	}
 
 	for i := 0; i < workers; i++ {
-		go wait.Until(c.runWorker, time.Second, stopCh)
+		go wait.UntilWithContext(ctx, c.runWorker, time.Second)
 	}
 
 	<-stopCh
 }
 
-func (c *Controller) runWorker() {
-	for c.processNextWorkItem() {
+func (c *Controller) runWorker(ctx context.Context) {
+	for c.processNextWorkItem(ctx) {
 	}
 }
 
 // processNextWorkItem deals with one pvcKey off the queue.  It returns false when it's time to quit.
-func (c *Controller) processNextWorkItem() bool {
+func (c *Controller) processNextWorkItem(ctx context.Context) bool {
 	pvKey, quit := c.queue.Get()
 	if quit {
 		return false
@@ -109,7 +109,7 @@ func (c *Controller) processNextWorkItem() bool {
 
 	pvName := pvKey.(string)
 
-	err := c.processPV(pvName)
+	err := c.processPV(ctx, pvName)
 	if err == nil {
 		c.queue.Forget(pvKey)
 		return true
@@ -121,7 +121,7 @@ func (c *Controller) processNextWorkItem() bool {
 	return true
 }
 
-func (c *Controller) processPV(pvName string) error {
+func (c *Controller) processPV(ctx context.Context, pvName string) error {
 	klog.V(4).Infof("Processing PV %s", pvName)
 	startTime := time.Now()
 	defer func() {
@@ -142,7 +142,7 @@ func (c *Controller) processPV(pvName string) error {
 		// it's not.
 		isUsed := c.isBeingUsed(pv)
 		if !isUsed {
-			return c.removeFinalizer(pv)
+			return c.removeFinalizer(ctx, pv)
 		}
 	}
 
@@ -151,19 +151,19 @@ func (c *Controller) processPV(pvName string) error {
 		// finalizer should be added by admission plugin, this is just to add
 		// the finalizer to old PVs that were created before the admission
 		// plugin was enabled.
-		return c.addFinalizer(pv)
+		return c.addFinalizer(ctx, pv)
 	}
 	return nil
 }
 
-func (c *Controller) addFinalizer(pv *v1.PersistentVolume) error {
+func (c *Controller) addFinalizer(ctx context.Context, pv *v1.PersistentVolume) error {
 	// Skip adding Finalizer in case the StorageObjectInUseProtection feature is not enabled
 	if !c.storageObjectInUseProtectionEnabled {
 		return nil
 	}
 	pvClone := pv.DeepCopy()
 	pvClone.ObjectMeta.Finalizers = append(pvClone.ObjectMeta.Finalizers, volumeutil.PVProtectionFinalizer)
-	_, err := c.client.CoreV1().PersistentVolumes().Update(context.TODO(), pvClone, metav1.UpdateOptions{})
+	_, err := c.client.CoreV1().PersistentVolumes().Update(ctx, pvClone, metav1.UpdateOptions{})
 	if err != nil {
 		klog.V(3).Infof("Error adding protection finalizer to PV %s: %v", pv.Name, err)
 		return err
@@ -172,10 +172,10 @@ func (c *Controller) addFinalizer(pv *v1.PersistentVolume) error {
 	return nil
 }
 
-func (c *Controller) removeFinalizer(pv *v1.PersistentVolume) error {
+func (c *Controller) removeFinalizer(ctx context.Context, pv *v1.PersistentVolume) error {
 	pvClone := pv.DeepCopy()
 	pvClone.ObjectMeta.Finalizers = slice.RemoveString(pvClone.ObjectMeta.Finalizers, volumeutil.PVProtectionFinalizer, nil)
-	_, err := c.client.CoreV1().PersistentVolumes().Update(context.TODO(), pvClone, metav1.UpdateOptions{})
+	_, err := c.client.CoreV1().PersistentVolumes().Update(ctx, pvClone, metav1.UpdateOptions{})
 	if err != nil {
 		klog.V(3).Infof("Error removing protection finalizer from PV %s: %v", pv.Name, err)
 		return err

--- a/staging/src/k8s.io/apiserver/pkg/server/dynamiccertificates/dynamic_cafile_content.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/dynamiccertificates/dynamic_cafile_content.go
@@ -18,6 +18,7 @@ package dynamiccertificates
 
 import (
 	"bytes"
+	"context"
 	"crypto/x509"
 	"fmt"
 	"io/ioutil"
@@ -53,7 +54,7 @@ type ControllerRunner interface {
 	RunOnce() error
 
 	// Run should be called a go .Run
-	Run(workers int, stopCh <-chan struct{})
+	Run(ctx context.Context, workers int, stopCh <-chan struct{})
 }
 
 // DynamicFileCAContent provies a CAContentProvider that can dynamically react to new file content
@@ -160,7 +161,7 @@ func (c *DynamicFileCAContent) RunOnce() error {
 }
 
 // Run starts the kube-apiserver and blocks until stopCh is closed.
-func (c *DynamicFileCAContent) Run(workers int, stopCh <-chan struct{}) {
+func (c *DynamicFileCAContent) Run(ctx context.Context, workers int, stopCh <-chan struct{}) {
 	defer utilruntime.HandleCrash()
 	defer c.queue.ShutDown()
 

--- a/staging/src/k8s.io/apiserver/pkg/server/dynamiccertificates/dynamic_serving_content.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/dynamiccertificates/dynamic_serving_content.go
@@ -17,6 +17,7 @@ limitations under the License.
 package dynamiccertificates
 
 import (
+	"context"
 	"crypto/tls"
 	"fmt"
 	"io/ioutil"
@@ -123,7 +124,7 @@ func (c *DynamicCertKeyPairContent) RunOnce() error {
 }
 
 // Run starts the controller and blocks until stopCh is closed.
-func (c *DynamicCertKeyPairContent) Run(workers int, stopCh <-chan struct{}) {
+func (c *DynamicCertKeyPairContent) Run(ctx context.Context, workers int, stopCh <-chan struct{}) {
 	defer utilruntime.HandleCrash()
 	defer c.queue.ShutDown()
 

--- a/staging/src/k8s.io/cloud-provider/controllers/nodelifecycle/node_lifecycle_controller.go
+++ b/staging/src/k8s.io/cloud-provider/controllers/nodelifecycle/node_lifecycle_controller.go
@@ -103,7 +103,7 @@ func NewCloudNodeLifecycleController(
 
 // Run starts the main loop for this controller. Run is blocking so should
 // be called via a goroutine
-func (c *CloudNodeLifecycleController) Run(stopCh <-chan struct{}) {
+func (c *CloudNodeLifecycleController) Run(ctx context.Context, stopCh <-chan struct{}) {
 	defer utilruntime.HandleCrash()
 
 	// The following loops run communicate with the APIServer with a worst case complexity
@@ -112,13 +112,13 @@ func (c *CloudNodeLifecycleController) Run(stopCh <-chan struct{}) {
 
 	// Start a loop to periodically check if any nodes have been
 	// deleted or shutdown from the cloudprovider
-	wait.Until(c.MonitorNodes, c.nodeMonitorPeriod, stopCh)
+	wait.UntilWithContext(ctx, c.MonitorNodes, c.nodeMonitorPeriod)
 }
 
 // MonitorNodes checks to see if nodes in the cluster have been deleted
 // or shutdown. If deleted, it deletes the node resource. If shutdown it
 // applies a shutdown taint to the node
-func (c *CloudNodeLifecycleController) MonitorNodes() {
+func (c *CloudNodeLifecycleController) MonitorNodes(ctx context.Context) {
 	nodes, err := c.nodeLister.List(labels.Everything())
 	if err != nil {
 		klog.Errorf("error listing nodes from cache: %s", err)
@@ -143,7 +143,7 @@ func (c *CloudNodeLifecycleController) MonitorNodes() {
 
 		// At this point the node has NotReady status, we need to check if the node has been removed
 		// from the cloud provider. If node cannot be found in cloudprovider, then delete the node
-		exists, err := ensureNodeExistsByProviderID(context.TODO(), c.cloud, node)
+		exists, err := ensureNodeExistsByProviderID(ctx, c.cloud, node)
 		if err != nil {
 			klog.Errorf("error checking if node %s exists: %v", node.Name, err)
 			continue
@@ -164,14 +164,14 @@ func (c *CloudNodeLifecycleController) MonitorNodes() {
 			c.recorder.Eventf(ref, v1.EventTypeNormal, deleteNodeEvent,
 				"Deleting node %s because it does not exist in the cloud provider", node.Name)
 
-			if err := c.kubeClient.CoreV1().Nodes().Delete(context.TODO(), node.Name, metav1.DeleteOptions{}); err != nil {
+			if err := c.kubeClient.CoreV1().Nodes().Delete(ctx, node.Name, metav1.DeleteOptions{}); err != nil {
 				klog.Errorf("unable to delete node %q: %v", node.Name, err)
 			}
 		} else {
 			// Node exists. We need to check this to get taint working in similar in all cloudproviders
 			// current problem is that shutdown nodes are not working in similar way ie. all cloudproviders
 			// does not delete node from kubernetes cluster when instance it is shutdown see issue #46442
-			shutdown, err := shutdownInCloudProvider(context.TODO(), c.cloud, node)
+			shutdown, err := shutdownInCloudProvider(ctx, c.cloud, node)
 			if err != nil {
 				klog.Errorf("error checking if node %s is shutdown: %v", node.Name, err)
 			}

--- a/staging/src/k8s.io/cloud-provider/controllers/route/route_controller.go
+++ b/staging/src/k8s.io/cloud-provider/controllers/route/route_controller.go
@@ -94,7 +94,7 @@ func New(routes cloudprovider.Routes, kubeClient clientset.Interface, nodeInform
 	return rc
 }
 
-func (rc *RouteController) Run(stopCh <-chan struct{}, syncPeriod time.Duration) {
+func (rc *RouteController) Run(ctx context.Context, stopCh <-chan struct{}, syncPeriod time.Duration) {
 	defer utilruntime.HandleCrash()
 
 	klog.Info("Starting route controller")
@@ -114,7 +114,7 @@ func (rc *RouteController) Run(stopCh <-chan struct{}, syncPeriod time.Duration)
 	// We should have a watch on node and if we observe a new node (with CIDR?)
 	// trigger reconciliation for that node.
 	go wait.NonSlidingUntil(func() {
-		if err := rc.reconcileNodeRoutes(); err != nil {
+		if err := rc.reconcileNodeRoutes(ctx); err != nil {
 			klog.Errorf("Couldn't reconcile node routes: %v", err)
 		}
 	}, syncPeriod, stopCh)
@@ -122,8 +122,8 @@ func (rc *RouteController) Run(stopCh <-chan struct{}, syncPeriod time.Duration)
 	<-stopCh
 }
 
-func (rc *RouteController) reconcileNodeRoutes() error {
-	routeList, err := rc.routes.ListRoutes(context.TODO(), rc.clusterName)
+func (rc *RouteController) reconcileNodeRoutes(ctx context.Context) error {
+	routeList, err := rc.routes.ListRoutes(ctx, rc.clusterName)
 	if err != nil {
 		return fmt.Errorf("error listing routes: %v", err)
 	}
@@ -131,10 +131,10 @@ func (rc *RouteController) reconcileNodeRoutes() error {
 	if err != nil {
 		return fmt.Errorf("error listing nodes: %v", err)
 	}
-	return rc.reconcile(nodes, routeList)
+	return rc.reconcile(ctx, nodes, routeList)
 }
 
-func (rc *RouteController) reconcile(nodes []*v1.Node, routes []*cloudprovider.Route) error {
+func (rc *RouteController) reconcile(ctx context.Context, nodes []*v1.Node, routes []*cloudprovider.Route) error {
 	var l sync.Mutex
 	// for each node a map of podCIDRs and their created status
 	nodeRoutesStatuses := make(map[types.NodeName]map[string]bool)
@@ -191,7 +191,7 @@ func (rc *RouteController) reconcile(nodes []*v1.Node, routes []*cloudprovider.R
 					// CreateRoute calls in flight.
 					rateLimiter <- struct{}{}
 					klog.Infof("Creating route for node %s %s with hint %s, throttled %v", nodeName, route.DestinationCIDR, nameHint, time.Since(startTime))
-					err := rc.routes.CreateRoute(context.TODO(), rc.clusterName, nameHint, route)
+					err := rc.routes.CreateRoute(ctx, rc.clusterName, nameHint, route)
 					<-rateLimiter
 					if err != nil {
 						msg := fmt.Sprintf("Could not create route %s %s for node %s after %v: %v", nameHint, route.DestinationCIDR, nodeName, time.Since(startTime), err)
@@ -244,7 +244,7 @@ func (rc *RouteController) reconcile(nodes []*v1.Node, routes []*cloudprovider.R
 					// respect the rate limiter
 					rateLimiter <- struct{}{}
 					klog.Infof("Deleting route %s %s", route.Name, route.DestinationCIDR)
-					if err := rc.routes.DeleteRoute(context.TODO(), rc.clusterName, route); err != nil {
+					if err := rc.routes.DeleteRoute(ctx, rc.clusterName, route); err != nil {
 						klog.Errorf("Could not delete route %s %s after %v: %v", route.Name, route.DestinationCIDR, time.Since(startTime), err)
 					} else {
 						klog.Infof("Deleted route %s %s after %v", route.Name, route.DestinationCIDR, time.Since(startTime))

--- a/staging/src/k8s.io/cloud-provider/controllers/service/controller.go
+++ b/staging/src/k8s.io/cloud-provider/controllers/service/controller.go
@@ -223,7 +223,7 @@ func (s *Controller) enqueueService(obj interface{}) {
 //
 // It's an error to call Run() more than once for a given ServiceController
 // object.
-func (s *Controller) Run(stopCh <-chan struct{}, workers int) {
+func (s *Controller) Run(ctx context.Context, stopCh <-chan struct{}, workers int) {
 	defer runtime.HandleCrash()
 	defer s.queue.ShutDown()
 
@@ -235,10 +235,10 @@ func (s *Controller) Run(stopCh <-chan struct{}, workers int) {
 	}
 
 	for i := 0; i < workers; i++ {
-		go wait.Until(s.worker, time.Second, stopCh)
+		go wait.UntilWithContext(ctx, s.worker, time.Second)
 	}
 
-	go s.nodeSyncLoop(workers)
+	go s.nodeSyncLoop(ctx, workers)
 	go wait.Until(s.triggerNodeSync, nodeSyncPeriod, stopCh)
 
 	<-stopCh
@@ -276,29 +276,29 @@ func (s *Controller) triggerNodeSync() {
 
 // worker runs a worker thread that just dequeues items, processes them, and marks them done.
 // It enforces that the syncHandler is never invoked concurrently with the same key.
-func (s *Controller) worker() {
-	for s.processNextWorkItem() {
+func (s *Controller) worker(ctx context.Context) {
+	for s.processNextWorkItem(ctx) {
 	}
 }
 
 // nodeSyncLoop takes nodeSync signal and triggers nodeSync
-func (s *Controller) nodeSyncLoop(workers int) {
+func (s *Controller) nodeSyncLoop(ctx context.Context, workers int) {
 	klog.V(4).Info("nodeSyncLoop Started")
 	for range s.nodeSyncCh {
 		klog.V(4).Info("nodeSync has been triggered")
-		s.nodeSyncInternal(workers)
+		s.nodeSyncInternal(ctx, workers)
 	}
 	klog.V(2).Info("s.nodeSyncCh is closed. Exiting nodeSyncLoop")
 }
 
-func (s *Controller) processNextWorkItem() bool {
+func (s *Controller) processNextWorkItem(ctx context.Context) bool {
 	key, quit := s.queue.Get()
 	if quit {
 		return false
 	}
 	defer s.queue.Done(key)
 
-	err := s.syncService(key.(string))
+	err := s.syncService(ctx, key.(string))
 	if err == nil {
 		s.queue.Forget(key)
 		return true
@@ -325,7 +325,7 @@ func (s *Controller) init() error {
 
 // processServiceCreateOrUpdate operates loadbalancers for the incoming service accordingly.
 // Returns an error if processing the service update failed.
-func (s *Controller) processServiceCreateOrUpdate(service *v1.Service, key string) error {
+func (s *Controller) processServiceCreateOrUpdate(ctx context.Context, service *v1.Service, key string) error {
 	// TODO(@MrHohn): Remove the cache once we get rid of the non-finalizer deletion
 	// path. Ref https://github.com/kubernetes/enhancements/issues/980.
 	cachedService := s.cache.getOrCreate(key)
@@ -333,14 +333,14 @@ func (s *Controller) processServiceCreateOrUpdate(service *v1.Service, key strin
 		// This happens only when a service is deleted and re-created
 		// in a short period, which is only possible when it doesn't
 		// contain finalizer.
-		if err := s.processLoadBalancerDelete(cachedService.state, key); err != nil {
+		if err := s.processLoadBalancerDelete(ctx, cachedService.state, key); err != nil {
 			return err
 		}
 	}
 	// Always cache the service, we need the info for service deletion in case
 	// when load balancer cleanup is not handled via finalizer.
 	cachedService.state = service
-	op, err := s.syncLoadBalancerIfNeeded(service, key)
+	op, err := s.syncLoadBalancerIfNeeded(ctx, service, key)
 	if err != nil {
 		s.eventRecorder.Eventf(service, v1.EventTypeWarning, "SyncLoadBalancerFailed", "Error syncing load balancer: %v", err)
 		return err
@@ -363,7 +363,7 @@ const (
 // syncLoadBalancerIfNeeded ensures that service's status is synced up with loadbalancer
 // i.e. creates loadbalancer for service if requested and deletes loadbalancer if the service
 // doesn't want a loadbalancer no more. Returns whatever error occurred.
-func (s *Controller) syncLoadBalancerIfNeeded(service *v1.Service, key string) (loadBalancerOperation, error) {
+func (s *Controller) syncLoadBalancerIfNeeded(ctx context.Context, service *v1.Service, key string) (loadBalancerOperation, error) {
 	// Note: It is safe to just call EnsureLoadBalancer.  But, on some clouds that requires a delete & create,
 	// which may involve service interruption.  Also, we would like user-friendly events.
 
@@ -377,14 +377,14 @@ func (s *Controller) syncLoadBalancerIfNeeded(service *v1.Service, key string) (
 		// Delete the load balancer if service no longer wants one, or if service needs cleanup.
 		op = deleteLoadBalancer
 		newStatus = &v1.LoadBalancerStatus{}
-		_, exists, err := s.balancer.GetLoadBalancer(context.TODO(), s.clusterName, service)
+		_, exists, err := s.balancer.GetLoadBalancer(ctx, s.clusterName, service)
 		if err != nil {
 			return op, fmt.Errorf("failed to check if load balancer exists before cleanup: %v", err)
 		}
 		if exists {
 			klog.V(2).Infof("Deleting existing load balancer for service %s", key)
 			s.eventRecorder.Event(service, v1.EventTypeNormal, "DeletingLoadBalancer", "Deleting load balancer")
-			if err := s.balancer.EnsureLoadBalancerDeleted(context.TODO(), s.clusterName, service); err != nil {
+			if err := s.balancer.EnsureLoadBalancerDeleted(ctx, s.clusterName, service); err != nil {
 				return op, fmt.Errorf("failed to delete load balancer: %v", err)
 			}
 		}
@@ -404,7 +404,7 @@ func (s *Controller) syncLoadBalancerIfNeeded(service *v1.Service, key string) (
 		if err := s.addFinalizer(service); err != nil {
 			return op, fmt.Errorf("failed to add load balancer cleanup finalizer: %v", err)
 		}
-		newStatus, err = s.ensureLoadBalancer(service)
+		newStatus, err = s.ensureLoadBalancer(ctx, service)
 		if err != nil {
 			if err == cloudprovider.ImplementedElsewhere {
 				// ImplementedElsewhere indicates that the ensureLoadBalancer is a nop and the
@@ -435,7 +435,7 @@ func (s *Controller) syncLoadBalancerIfNeeded(service *v1.Service, key string) (
 	return op, nil
 }
 
-func (s *Controller) ensureLoadBalancer(service *v1.Service) (*v1.LoadBalancerStatus, error) {
+func (s *Controller) ensureLoadBalancer(ctx context.Context, service *v1.Service) (*v1.LoadBalancerStatus, error) {
 	nodes, err := listWithPredicate(s.nodeLister, s.getNodeConditionPredicate())
 	if err != nil {
 		return nil, err
@@ -449,7 +449,7 @@ func (s *Controller) ensureLoadBalancer(service *v1.Service) (*v1.LoadBalancerSt
 	// - Only one protocol supported per service
 	// - Not all cloud providers support all protocols and the next step is expected to return
 	//   an error for unsupported protocols
-	return s.balancer.EnsureLoadBalancer(context.TODO(), s.clusterName, service, nodes)
+	return s.balancer.EnsureLoadBalancer(ctx, s.clusterName, service, nodes)
 }
 
 // ListKeys implements the interface required by DeltaFIFO to list the keys we
@@ -713,7 +713,7 @@ func nodeReadyConditionStatus(node *v1.Node) v1.ConditionStatus {
 
 // nodeSyncInternal handles updating the hosts pointed to by all load
 // balancers whenever the set of nodes in the cluster changes.
-func (s *Controller) nodeSyncInternal(workers int) {
+func (s *Controller) nodeSyncInternal(ctx context.Context, workers int) {
 	startTime := time.Now()
 	defer func() {
 		latency := time.Since(startTime).Seconds()
@@ -724,7 +724,7 @@ func (s *Controller) nodeSyncInternal(workers int) {
 	if !s.needFullSyncAndUnmark() {
 		// The set of nodes in the cluster hasn't changed, but we can retry
 		// updating any services that we failed to update last time around.
-		s.servicesToUpdate = s.updateLoadBalancerHosts(s.servicesToUpdate, workers)
+		s.servicesToUpdate = s.updateLoadBalancerHosts(ctx, s.servicesToUpdate, workers)
 		return
 	}
 	klog.V(2).Infof("Syncing backends for all LB services.")
@@ -733,13 +733,13 @@ func (s *Controller) nodeSyncInternal(workers int) {
 	// round.
 	s.servicesToUpdate = s.cache.allServices()
 	numServices := len(s.servicesToUpdate)
-	s.servicesToUpdate = s.updateLoadBalancerHosts(s.servicesToUpdate, workers)
+	s.servicesToUpdate = s.updateLoadBalancerHosts(ctx, s.servicesToUpdate, workers)
 	klog.V(2).Infof("Successfully updated %d out of %d load balancers to direct traffic to the updated set of nodes",
 		numServices-len(s.servicesToUpdate), numServices)
 }
 
 // nodeSyncService syncs the nodes for one load balancer type service
-func (s *Controller) nodeSyncService(svc *v1.Service) bool {
+func (s *Controller) nodeSyncService(ctx context.Context, svc *v1.Service) bool {
 	if svc == nil || !wantsLoadBalancer(svc) {
 		return false
 	}
@@ -750,7 +750,7 @@ func (s *Controller) nodeSyncService(svc *v1.Service) bool {
 		return true
 	}
 
-	if err := s.lockedUpdateLoadBalancerHosts(svc, hosts); err != nil {
+	if err := s.lockedUpdateLoadBalancerHosts(ctx, svc, hosts); err != nil {
 		runtime.HandleError(fmt.Errorf("failed to update load balancer hosts for service %s/%s: %v", svc.Namespace, svc.Name, err))
 		return true
 	}
@@ -761,13 +761,13 @@ func (s *Controller) nodeSyncService(svc *v1.Service) bool {
 // updateLoadBalancerHosts updates all existing load balancers so that
 // they will match the latest list of nodes with input number of workers.
 // Returns the list of services that couldn't be updated.
-func (s *Controller) updateLoadBalancerHosts(services []*v1.Service, workers int) (servicesToRetry []*v1.Service) {
+func (s *Controller) updateLoadBalancerHosts(ctx context.Context, services []*v1.Service, workers int) (servicesToRetry []*v1.Service) {
 	klog.V(4).Infof("Running updateLoadBalancerHosts(len(services)==%d, workers==%d)", len(services), workers)
 
 	// lock for servicesToRetry
 	lock := sync.Mutex{}
 	doWork := func(piece int) {
-		if shouldRetry := s.nodeSyncService(services[piece]); !shouldRetry {
+		if shouldRetry := s.nodeSyncService(ctx, services[piece]); !shouldRetry {
 			return
 		}
 		lock.Lock()
@@ -775,14 +775,14 @@ func (s *Controller) updateLoadBalancerHosts(services []*v1.Service, workers int
 		servicesToRetry = append(servicesToRetry, services[piece])
 	}
 
-	workqueue.ParallelizeUntil(context.TODO(), workers, len(services), doWork)
+	workqueue.ParallelizeUntil(ctx, workers, len(services), doWork)
 	klog.V(4).Infof("Finished updateLoadBalancerHosts")
 	return servicesToRetry
 }
 
 // Updates the load balancer of a service, assuming we hold the mutex
 // associated with the service.
-func (s *Controller) lockedUpdateLoadBalancerHosts(service *v1.Service, hosts []*v1.Node) error {
+func (s *Controller) lockedUpdateLoadBalancerHosts(ctx context.Context, service *v1.Service, hosts []*v1.Node) error {
 	startTime := time.Now()
 	defer func() {
 		latency := time.Since(startTime).Seconds()
@@ -792,7 +792,7 @@ func (s *Controller) lockedUpdateLoadBalancerHosts(service *v1.Service, hosts []
 
 	klog.V(2).Infof("Updating backends for load balancer %s/%s with node set: %v", service.Namespace, service.Name, nodeNames(hosts))
 	// This operation doesn't normally take very long (and happens pretty often), so we only record the final event
-	err := s.balancer.UpdateLoadBalancer(context.TODO(), s.clusterName, service, hosts)
+	err := s.balancer.UpdateLoadBalancer(ctx, s.clusterName, service, hosts)
 	if err == nil {
 		// If there are no available nodes for LoadBalancer service, make a EventTypeWarning event for it.
 		if len(hosts) == 0 {
@@ -809,7 +809,7 @@ func (s *Controller) lockedUpdateLoadBalancerHosts(service *v1.Service, hosts []
 		return nil
 	}
 	// It's only an actual error if the load balancer still exists.
-	if _, exists, err := s.balancer.GetLoadBalancer(context.TODO(), s.clusterName, service); err != nil {
+	if _, exists, err := s.balancer.GetLoadBalancer(ctx, s.clusterName, service); err != nil {
 		runtime.HandleError(fmt.Errorf("failed to check if load balancer exists for service %s/%s: %v", service.Namespace, service.Name, err))
 	} else if !exists {
 		return nil
@@ -831,7 +831,7 @@ func loadBalancerIPsAreEqual(oldService, newService *v1.Service) bool {
 // syncService will sync the Service with the given key if it has had its expectations fulfilled,
 // meaning it did not expect to see any more of its pods created or deleted. This function is not meant to be
 // invoked concurrently with the same key.
-func (s *Controller) syncService(key string) error {
+func (s *Controller) syncService(ctx context.Context, key string) error {
 	startTime := time.Now()
 	defer func() {
 		klog.V(4).Infof("Finished syncing service %q (%v)", key, time.Since(startTime))
@@ -847,17 +847,17 @@ func (s *Controller) syncService(key string) error {
 	switch {
 	case errors.IsNotFound(err):
 		// service absence in store means watcher caught the deletion, ensure LB info is cleaned
-		err = s.processServiceDeletion(key)
+		err = s.processServiceDeletion(ctx, key)
 	case err != nil:
 		runtime.HandleError(fmt.Errorf("Unable to retrieve service %v from store: %v", key, err))
 	default:
-		err = s.processServiceCreateOrUpdate(service, key)
+		err = s.processServiceCreateOrUpdate(ctx, service, key)
 	}
 
 	return err
 }
 
-func (s *Controller) processServiceDeletion(key string) error {
+func (s *Controller) processServiceDeletion(ctx context.Context, key string) error {
 	cachedService, ok := s.cache.get(key)
 	if !ok {
 		// Cache does not contains the key means:
@@ -867,20 +867,20 @@ func (s *Controller) processServiceDeletion(key string) error {
 		return nil
 	}
 	klog.V(2).Infof("Service %v has been deleted. Attempting to cleanup load balancer resources", key)
-	if err := s.processLoadBalancerDelete(cachedService.state, key); err != nil {
+	if err := s.processLoadBalancerDelete(ctx, cachedService.state, key); err != nil {
 		return err
 	}
 	s.cache.delete(key)
 	return nil
 }
 
-func (s *Controller) processLoadBalancerDelete(service *v1.Service, key string) error {
+func (s *Controller) processLoadBalancerDelete(ctx context.Context, service *v1.Service, key string) error {
 	// delete load balancer info only if the service type is LoadBalancer
 	if !wantsLoadBalancer(service) {
 		return nil
 	}
 	s.eventRecorder.Event(service, v1.EventTypeNormal, "DeletingLoadBalancer", "Deleting load balancer")
-	if err := s.balancer.EnsureLoadBalancerDeleted(context.TODO(), s.clusterName, service); err != nil {
+	if err := s.balancer.EnsureLoadBalancerDeleted(ctx, s.clusterName, service); err != nil {
 		s.eventRecorder.Eventf(service, v1.EventTypeWarning, "DeleteLoadBalancerFailed", "Error deleting load balancer: %v", err)
 		return err
 	}


### PR DESCRIPTION
#### What type of PR is this?
/kind design


#### What this PR does / why we need it:
This builds on https://github.com/kubernetes/kubernetes/pull/101125

This actually wires a `context.Context` through to all the controllers in KCM, so that they can use it in their client calls. Doing so will enable KCM to release its leader lock immediately when necessary.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
