### PR TITLE
Add NetworkPolicy Endpoint to Ineligible endpoints

### DIFF
--- a/test/conformance/testdata/ineligible_endpoints.yaml
+++ b/test/conformance/testdata/ineligible_endpoints.yaml
@@ -232,3 +232,27 @@
 - endpoint: replaceStorageV1VolumeAttachmentStatus
   reason: vendor specific feature
   link: https://github.com/kubernetes/community/blame/master/contributors/devel/sig-architecture/conformance-tests.md#L64
+- endpoint: createNetworkingV1NamespacedNetworkPolicy
+  reason: optional feature
+  link: https://github.com/kubernetes/kubernetes/pull/100149#issuecomment-800501953
+- endpoint: readNetworkingV1NamespacedNetworkPolicy
+  reason: optional feature
+  link: https://github.com/kubernetes/kubernetes/pull/100149#issuecomment-800501953
+- endpoint: listNetworkingV1NamespacedNetworkPolicy
+  reason: optional feature
+  link: https://github.com/kubernetes/kubernetes/pull/100149#issuecomment-800501953
+- endpoint: listNetworkingV1NetworkPolicyForAllNamespaces
+  reason: optional feature
+  link: https://github.com/kubernetes/kubernetes/pull/100149#issuecomment-800501953
+- endpoint: patchNetworkingV1NamespacedNetworkPolicy
+  reason: optional feature
+  link: https://github.com/kubernetes/kubernetes/pull/100149#issuecomment-800501953
+- endpoint: replaceNetworkingV1NamespacedNetworkPolicy
+  reason: optional feature
+  link: https://github.com/kubernetes/kubernetes/pull/100149#issuecomment-800501953
+- endpoint: deleteNetworkingV1CollectionNamespacedNetworkPolicy
+  reason: optional feature
+  link: https://github.com/kubernetes/kubernetes/pull/100149#issuecomment-800501953
+- endpoint: deleteNetworkingV1NamespacedNetworkPolicy
+  reason: optional feature
+  link: https://github.com/kubernetes/kubernetes/pull/100149#issuecomment-800501953


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it:**
This PR adds the `NetworkPolicy` endpoints to the `Ineligible_endpoint.yaml` because the endpoints are a [optional feature](https://github.com/kubernetes/kubernetes/pull/100149#issuecomment-800501953)
- createNetworkingV1NamespacedNetworkPolicy
- readNetworkingV1NamespacedNetworkPolicy
- listNetworkingV1NamespacedNetworkPolicy
- listNetworkingV1NetworkPolicyForAllNamespaces
- patchNetworkingV1NamespacedNetworkPolicy
- replaceNetworkingV1NamespacedNetworkPolicy
- deleteNetworkingV1CollectionNamespacedNetworkPolicy
- deleteNetworkingV1NamespacedNetworkPolicy



**Special notes for your reviewer:**
As of 1.22 APISnoop [Ineligible endpoints](https://apisnoop.cncf.io/conformance-progress/ineligible-endpoints) are pulled from the community owned `inelegible_endpoint.yaml` file

**Does this PR introduce a user-facing change?:**
```
NONE

```

**Release note:**
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:**
```
NONE

```

/sig architecture
/area conformance