### PR TITLE
cleanup: replace x.Sub(time.Now()) with time.Until(x) in e2e test

### DIFF
--- a/test/e2e/node/kubelet_perf.go
+++ b/test/e2e/node/kubelet_perf.go
@@ -92,7 +92,7 @@ func runResourceTrackingTest(f *framework.Framework, podsPerNode int, nodeNames 
 	// entries if we plan to monitor longer (e.g., 8 hours).
 	deadline := time.Now().Add(monitoringTime)
 	for time.Now().Before(deadline) {
-		timeLeft := deadline.Sub(time.Now())
+		timeLeft := time.Until(deadline)
 		framework.Logf("Still running...%v left", timeLeft)
 		if timeLeft < reportingPeriod {
 			time.Sleep(timeLeft)

--- a/test/e2e_node/resource_usage_test.go
+++ b/test/e2e_node/resource_usage_test.go
@@ -169,7 +169,7 @@ func runResourceUsageTest(f *framework.Framework, rc *ResourceCollector, testArg
 	// entries if we plan to monitor longer (e.g., 8 hours).
 	deadline := time.Now().Add(monitoringTime)
 	for time.Now().Before(deadline) {
-		timeLeft := deadline.Sub(time.Now())
+		timeLeft := time.Until(deadline)
 		framework.Logf("Still running...%v left", timeLeft)
 		if timeLeft < reportingPeriod {
 			time.Sleep(timeLeft)


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
S1024 – Replace x.Sub(time.Now()) with time.Until(x)
https://staticcheck.io/docs/checks#S1024

#### Which issue(s) this PR fixes:
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
