### PR TITLE
cleanup: fix empty critical section to defer the unlock

### DIFF
--- a/pkg/volume/glusterfs/glusterfs.go
+++ b/pkg/volume/glusterfs/glusterfs.go
@@ -581,7 +581,7 @@ func (plugin *glusterfsPlugin) collectGids(className string, gidTable *MinMaxAll
 func (plugin *glusterfsPlugin) getGidTable(className string, min int, max int) (*MinMaxAllocator, error) {
 	plugin.gidTableLock.Lock()
 	gidTable, ok := plugin.gidTable[className]
-	plugin.gidTableLock.Unlock()
+	defer plugin.gidTableLock.Unlock()
 
 	if ok {
 		err := gidTable.SetRange(min, max)


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
SA2001 – Empty critical section, did you mean to defer the unlock?
https://staticcheck.io/docs/checks#SA2001

#### Which issue(s) this PR fixes:
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
