### PR TITLE
Stop unsetting the golang buildid

### DIFF
--- a/hack/lib/golang.sh
+++ b/hack/lib/golang.sh
@@ -794,7 +794,7 @@ kube::golang::build_binaries() {
     # Disable SC2153 for this, as it will throw a warning that the local
     # variable goldflags will exist, and it suggest changing it to this.
     # shellcheck disable=SC2153
-    goldflags="${GOLDFLAGS=-s -w -buildid=} $(kube::version::ldflags)"
+    goldflags="${GOLDFLAGS=-s -w} $(kube::version::ldflags)"
     goasmflags="-trimpath=${KUBE_ROOT}"
     gogcflags="${GOGCFLAGS:-} -trimpath=${KUBE_ROOT}"
 


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:
Golang fixed the issue with the non-reproducible buildid already in
v1.15.3:

https://github.com/golang/go/commit/c5f692021279ee4c6426130f4525d8053fffcbcf
https://github.com/golang/go/commit/a3e965ce8addeb6a0b690069522a0487f68ee316

This means we can now use the internal buildid instead of the unset one.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Refers to https://github.com/kubernetes/kubernetes/issues/70131

#### Special notes for your reviewer:

##### Test on `master` branch

```
> make WHAT=cmd/kubelet
…
> go tool buildid _output/bin/kubelet

```

#####  Test on `buildid` branch

```
> make WHAT=cmd/kubelet
+++ [0423 10:26:24] Building go targets for linux/amd64:
    cmd/kubelet
> go tool buildid _output/bin/kubelet
0oMZ_UAUmsE2HAg3XxQm/UH7pCHVqniKSJmfPqMZ9/76lL92cbUZ0w-3Bq1duL/2odFp5t3xbz00pQXvggW
```

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Official binaries now include the golang generated build ID (`buildid`) instead of an empty string.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
None
```
/sig release
/priority important-soon