### PR TITLE
Structured Logging migration: modify conntrack part logs of kube-proxy.

### DIFF
--- a/cmd/kube-proxy/app/conntrack.go
+++ b/cmd/kube-proxy/app/conntrack.go
@@ -49,7 +49,7 @@ func (rct realConntracker) SetMax(max int) error {
 	if err := rct.setIntSysCtl("nf_conntrack_max", max); err != nil {
 		return err
 	}
-	klog.Infof("Setting nf_conntrack_max to %d", max)
+	klog.InfoS("Setting nf_conntrack_max", "max", max)
 
 	// Linux does not support writing to /sys/module/nf_conntrack/parameters/hashsize
 	// when the writer process is not in the initial network namespace
@@ -80,7 +80,7 @@ func (rct realConntracker) SetMax(max int) error {
 		return errReadOnlySysFS
 	}
 	// TODO: generify this and sysctl to a new sysfs.WriteInt()
-	klog.Infof("Setting conntrack hashsize to %d", max/4)
+	klog.InfoS("Setting conntrack hashsize", "hashsize", max/4)
 	return writeIntStringFile("/sys/module/nf_conntrack/parameters/hashsize", max/4)
 }
 
@@ -97,7 +97,7 @@ func (realConntracker) setIntSysCtl(name string, value int) error {
 
 	sys := sysctl.New()
 	if val, _ := sys.GetSysctl(entry); val != value {
-		klog.Infof("Set sysctl '%v' to %v", entry, value)
+		klog.InfoS("Set sysctl", "entry", entry, "value", value)
 		if err := sys.SetSysctl(entry, value); err != nil {
 			return err
 		}
@@ -112,7 +112,7 @@ func isSysFSWritable() (bool, error) {
 	m := mount.New("" /* default mount path */)
 	mountPoints, err := m.List()
 	if err != nil {
-		klog.Errorf("failed to list mount points: %v", err)
+		klog.ErrorS(err,"Failed to list mount points")
 		return false, err
 	}
 
@@ -124,8 +124,7 @@ func isSysFSWritable() (bool, error) {
 		if len(mountPoint.Opts) > 0 && mountPoint.Opts[0] == permWritable {
 			return true, nil
 		}
-		klog.Errorf("sysfs is not writable: %+v (mount options are %v)",
-			mountPoint, mountPoint.Opts)
+		klog.ErrorS(nil,"sysfs is not writable", "mountPoint", mountPoint, "mountOptions", mountPoint.Opts)
 		return false, errReadOnlySysFS
 	}
 

--- a/cmd/kube-proxy/app/conntrack.go
+++ b/cmd/kube-proxy/app/conntrack.go
@@ -112,7 +112,7 @@ func isSysFSWritable() (bool, error) {
 	m := mount.New("" /* default mount path */)
 	mountPoints, err := m.List()
 	if err != nil {
-		klog.ErrorS(err,"Failed to list mount points")
+		klog.ErrorS(err, "Failed to list mount points")
 		return false, err
 	}
 
@@ -124,7 +124,7 @@ func isSysFSWritable() (bool, error) {
 		if len(mountPoint.Opts) > 0 && mountPoint.Opts[0] == permWritable {
 			return true, nil
 		}
-		klog.ErrorS(nil,"sysfs is not writable", "mountPoint", mountPoint, "mountOptions", mountPoint.Opts)
+		klog.ErrorS(nil, "Sysfs is not writable", "mountPoint", mountPoint, "mountOptions", mountPoint.Opts)
 		return false, errReadOnlySysFS
 	}
 


### PR DESCRIPTION
What type of PR is this?
/kind feature

What this PR does / why we need it:
Structured Logging migration: modify conntrack part logs of kube-proxy.
xref:
https://github.com/kubernetes/enhancements/tree/master/keps/sig-instrumentation/1602-structured-logging
https://github.com/kubernetes/community/blob/master/contributors/devel/sig-instrumentation/migration-to-structured-logging.md
Which issue(s) this PR fixes:
none

Special notes for your reviewer:
part of kubernetes/enhancements#1602
As it is related to log, change the log here to structured log.
Does this PR introduce a user-facing change?:
none
```release-note

NONE

```
