### PR TITLE
Fix bash completion for multiple resource names

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/cmd.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/cmd.go
@@ -160,7 +160,7 @@ __kubectl_get_resource()
       __kubectl_get_resource_helper "" "$cur"
       return # the return status is that of the last command executed in the function body
     fi
-    __kubectl_parse_get "${nouns[${#nouns[@]} -1]}"
+    __kubectl_parse_get "${nouns[0]}"
 }
 
 # Same as __kubectl_get_resource (without s) but allows completion for multiple, comma-separated resource names.
@@ -181,7 +181,7 @@ __kubectl_get_resources()
       __kubectl_get_resource_helper "$HEAD" "$TAIL"
       return # the return status is that of the last command executed in the function body
     fi
-    __kubectl_parse_get "${nouns[${#nouns[@]} -1]}"
+    __kubectl_parse_get "${nouns[0]}"
 }
 
 __kubectl_get_resource_helper()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
/sig cli
<!--
Add one of the following kinds:

/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
kubectl supports listing multiple resources with one call by naming them separated by spaces:
```bash
$ kubectl get pods pod-a pod-b
NAME    READY   STATUS    RESTARTS   AGE
pod-a   2/2     Running   2          466d
pod-b   2/2     Running   2          466d
```

However, the bash-completion for this did not work. It tried to use the last noun as the resource type.
E.g. `kubectl get pods pod-a `<kbd>tab</kbd> would try to list all `pod-a`s instead of all pods.

This is also true for `kubectl delete`, `kubectl edit`, etc.


#### Special notes for your reviewer:

If you want to try this on your machine, building this branch is not enough:
After running `make kubectl` you need to run `source <(./_output/bin/kubectl completion bash)` then you can try the new completion (with your locally installed kubectl)

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
kubectl: fix bash-completion for multiple resource names
```
