### PR TITLE
Automated cherry pick of #101377: Fix validation in kubectl create ingress

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_ingress.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_ingress.go
@@ -160,7 +160,7 @@ func NewCmdCreateIngress(f cmdutil.Factory, ioStreams genericclioptions.IOStream
 	cmd.Flags().StringVar(&o.IngressClass, "class", o.IngressClass, "Ingress Class to be used")
 	cmd.Flags().StringArrayVar(&o.Rules, "rule", o.Rules, "Rule in format host/path=service:port[,tls=secretname]. Paths containing the leading character '*' are considered pathType=Prefix. tls argument is optional.")
 	cmd.Flags().StringVar(&o.DefaultBackend, "default-backend", o.DefaultBackend, "Default service for backend, in format of svcname:port")
-	cmd.Flags().StringArrayVar(&o.Annotations, "annotation", o.Annotations, "Annotation to insert in the ingress object, in the format annotation=value")
+	cmd.Flags().StringArrayVar(&o.Annotations, "annotation", o.Annotations, "Annotation to insert in the ingress object, in the format annotation=[value]")
 	cmdutil.AddFieldManagerFlagVar(cmd, &o.FieldManager, "kubectl-create")
 
 	return cmd
@@ -232,6 +232,12 @@ func (o *CreateIngressOptions) Validate() error {
 		}
 	}
 
+	for _, annotation := range o.Annotations {
+		if an := strings.SplitN(annotation, "=", 2); len(an) != 2 {
+			return fmt.Errorf("annotation %s is invalid and should be in format key=[value]", annotation)
+		}
+	}
+
 	if len(o.DefaultBackend) > 0 && len(strings.Split(o.DefaultBackend, ":")) != 2 {
 		return fmt.Errorf("default-backend should be in format servicename:serviceport")
 	}
@@ -289,8 +295,8 @@ func (o *CreateIngressOptions) createIngress() *networkingv1.Ingress {
 }
 
 func (o *CreateIngressOptions) buildAnnotations() map[string]string {
-	var annotations map[string]string
-	annotations = make(map[string]string)
+
+	var annotations = make(map[string]string)
 
 	for _, annotation := range o.Annotations {
 		an := strings.SplitN(annotation, "=", 2)

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_ingress.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_ingress.go
@@ -160,7 +160,7 @@ func NewCmdCreateIngress(f cmdutil.Factory, ioStreams genericclioptions.IOStream
 	cmd.Flags().StringVar(&o.IngressClass, "class", o.IngressClass, "Ingress Class to be used")
 	cmd.Flags().StringArrayVar(&o.Rules, "rule", o.Rules, "Rule in format host/path=service:port[,tls=secretname]. Paths containing the leading character '*' are considered pathType=Prefix. tls argument is optional.")
 	cmd.Flags().StringVar(&o.DefaultBackend, "default-backend", o.DefaultBackend, "Default service for backend, in format of svcname:port")
-	cmd.Flags().StringArrayVar(&o.Annotations, "annotation", o.Annotations, "Annotation to insert in the ingress object, in the format annotation=[value]")
+	cmd.Flags().StringArrayVar(&o.Annotations, "annotation", o.Annotations, "Annotation to insert in the ingress object, in the format annotation=value")
 	cmdutil.AddFieldManagerFlagVar(cmd, &o.FieldManager, "kubectl-create")
 
 	return cmd

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_ingress_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_ingress_test.go
@@ -30,6 +30,7 @@ func TestCreateIngressValidation(t *testing.T) {
 		defaultbackend string
 		ingressclass   string
 		rules          []string
+		annotations    []string
 		expected       string
 	}{
 		"no default backend and rule": {
@@ -48,6 +49,22 @@ func TestCreateIngressValidation(t *testing.T) {
 		"default backend is ok": {
 			defaultbackend: "xpto:4444",
 			expected:       "",
+		},
+		"invalid annotation": {
+			defaultbackend: "xpto:4444",
+			annotations: []string{
+				"key1=value1",
+				"key2",
+			},
+			expected: "annotation key2 is invalid and should be in format key=[value]",
+		},
+		"valid annotations": {
+			defaultbackend: "xpto:4444",
+			annotations: []string{
+				"key1=value1",
+				"key2=",
+			},
+			expected: "",
 		},
 		"multiple conformant rules": {
 			rules: []string{
@@ -122,6 +139,7 @@ func TestCreateIngressValidation(t *testing.T) {
 				DefaultBackend: tc.defaultbackend,
 				Rules:          tc.rules,
 				IngressClass:   tc.ingressclass,
+				Annotations:    tc.annotations,
 			}
 
 			err := o.Validate()


### PR DESCRIPTION
Cherry pick of #101377 on release-1.20.

#101377: Fix validation in kubectl create ingress

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.