### PR TITLE
Kube-proxy/ipvs; Use go "net" lib to get nodeIPs

### DIFF
--- a/pkg/proxy/ipvs/netlink.go
+++ b/pkg/proxy/ipvs/netlink.go
@@ -32,7 +32,12 @@ type NetLinkHandle interface {
 	DeleteDummyDevice(devName string) error
 	// ListBindAddress will list all IP addresses which are bound in a given interface
 	ListBindAddress(devName string) ([]string, error)
-	// GetLocalAddresses returns all unique local type IP addresses based on specified device and filter device
-	// If device is not specified, it will list all unique local type addresses except filter device addresses
-	GetLocalAddresses(dev, filterDev string) (sets.String, error)
+	// GetAllLocalAddresses return all local addresses on the node.
+	// Only the addresses of the current family are returned.
+	// IPv6 link-local and loopback addresses are excluded.
+	GetAllLocalAddresses() (sets.String, error)
+	// GetLocalAddresses return all local addresses for an interface.
+	// Only the addresses of the current family are returned.
+	// IPv6 link-local and loopback addresses are excluded.
+	GetLocalAddresses(dev string) (sets.String, error)
 }

--- a/pkg/proxy/ipvs/netlink_linux.go
+++ b/pkg/proxy/ipvs/netlink_linux.go
@@ -21,8 +21,10 @@ package ipvs
 
 import (
 	"fmt"
+	"net"
 
 	"k8s.io/apimachinery/pkg/util/sets"
+	utilproxy "k8s.io/kubernetes/pkg/proxy/util"
 	netutils "k8s.io/utils/net"
 
 	"github.com/vishvananda/netlink"
@@ -124,72 +126,41 @@ func (h *netlinkHandle) ListBindAddress(devName string) ([]string, error) {
 	return ips, nil
 }
 
-// GetLocalAddresses lists all LOCAL type IP addresses from host based on filter device.
-// If dev is not specified, it's equivalent to exec:
-// $ ip route show table local type local proto kernel
-// 10.0.0.1 dev kube-ipvs0  scope host  src 10.0.0.1
-// 10.0.0.10 dev kube-ipvs0  scope host  src 10.0.0.10
-// 10.0.0.252 dev kube-ipvs0  scope host  src 10.0.0.252
-// 100.106.89.164 dev eth0  scope host  src 100.106.89.164
-// 127.0.0.0/8 dev lo  scope host  src 127.0.0.1
-// 127.0.0.1 dev lo  scope host  src 127.0.0.1
-// 172.17.0.1 dev docker0  scope host  src 172.17.0.1
-// 192.168.122.1 dev virbr0  scope host  src 192.168.122.1
-// Then cut the unique src IP fields,
-// --> result set: [10.0.0.1, 10.0.0.10, 10.0.0.252, 100.106.89.164, 127.0.0.1, 172.17.0.1, 192.168.122.1]
-
-// If dev is specified, it's equivalent to exec:
-// $ ip route show table local type local proto kernel dev kube-ipvs0
-// 10.0.0.1  scope host  src 10.0.0.1
-// 10.0.0.10  scope host  src 10.0.0.10
-// Then cut the unique src IP fields,
-// --> result set: [10.0.0.1, 10.0.0.10]
-
-// If filterDev is specified, the result will discard route of specified device and cut src from other routes.
-func (h *netlinkHandle) GetLocalAddresses(dev, filterDev string) (sets.String, error) {
-	chosenLinkIndex, filterLinkIndex := -1, -1
-	if dev != "" {
-		link, err := h.LinkByName(dev)
-		if err != nil {
-			return nil, fmt.Errorf("error get device %s, err: %v", dev, err)
-		}
-		chosenLinkIndex = link.Attrs().Index
-	} else if filterDev != "" {
-		link, err := h.LinkByName(filterDev)
-		if err != nil {
-			return nil, fmt.Errorf("error get filter device %s, err: %v", filterDev, err)
-		}
-		filterLinkIndex = link.Attrs().Index
-	}
-
-	routeFilter := &netlink.Route{
-		Table:    unix.RT_TABLE_LOCAL,
-		Type:     unix.RTN_LOCAL,
-		Protocol: unix.RTPROT_KERNEL,
-	}
-	filterMask := netlink.RT_FILTER_TABLE | netlink.RT_FILTER_TYPE | netlink.RT_FILTER_PROTOCOL
-
-	// find chosen device
-	if chosenLinkIndex != -1 {
-		routeFilter.LinkIndex = chosenLinkIndex
-		filterMask |= netlink.RT_FILTER_OIF
-	}
-	routes, err := h.RouteListFiltered(netlink.FAMILY_ALL, routeFilter, filterMask)
+// GetAllLocalAddresses return all local addresses on the node.
+// Only the addresses of the current family are returned.
+// IPv6 link-local and loopback addresses are excluded.
+func (h *netlinkHandle) GetAllLocalAddresses() (sets.String, error) {
+	addr, err := net.InterfaceAddrs()
 	if err != nil {
-		return nil, fmt.Errorf("error list route table, err: %v", err)
+		return nil, fmt.Errorf("Could not get addresses: %v", err)
 	}
-	res := sets.NewString()
-	for _, route := range routes {
-		if route.LinkIndex == filterLinkIndex {
-			continue
-		}
-		if h.isIPv6 {
-			if route.Dst.IP.To4() == nil && !route.Dst.IP.IsLinkLocalUnicast() {
-				res.Insert(route.Dst.IP.String())
-			}
-		} else if route.Src != nil {
-			res.Insert(route.Src.String())
-		}
+	return utilproxy.AddressSet(h.isValidForSet, addr), nil
+}
+
+// GetLocalAddresses return all local addresses for an interface.
+// Only the addresses of the current family are returned.
+// IPv6 link-local and loopback addresses are excluded.
+func (h *netlinkHandle) GetLocalAddresses(dev string) (sets.String, error) {
+	ifi, err := net.InterfaceByName(dev)
+	if err != nil {
+		return nil, fmt.Errorf("Could not get interface %s: %v", dev, err)
 	}
-	return res, nil
+	addr, err := ifi.Addrs()
+	if err != nil {
+		return nil, fmt.Errorf("Can't get addresses from %s: %v", ifi.Name, err)
+	}
+	return utilproxy.AddressSet(h.isValidForSet, addr), nil
+}
+
+func (h *netlinkHandle) isValidForSet(ip net.IP) bool {
+	if h.isIPv6 != netutils.IsIPv6(ip) {
+		return false
+	}
+	if h.isIPv6 && ip.IsLinkLocalUnicast() {
+		return false
+	}
+	if ip.IsLoopback() {
+		return false
+	}
+	return true
 }

--- a/pkg/proxy/ipvs/netlink_unsupported.go
+++ b/pkg/proxy/ipvs/netlink_unsupported.go
@@ -21,44 +21,57 @@ package ipvs
 
 import (
 	"fmt"
+	"net"
 
 	"k8s.io/apimachinery/pkg/util/sets"
 )
 
-type emptyHandle struct {
+// The type must match the one in proxier_test.go
+type netlinkHandle struct {
+	isIPv6 bool
 }
 
 // NewNetLinkHandle will create an EmptyHandle
 func NewNetLinkHandle(ipv6 bool) NetLinkHandle {
-	return &emptyHandle{}
+	return &netlinkHandle{}
 }
 
 // EnsureAddressBind checks if address is bound to the interface and, if not, binds it. If the address is already bound, return true.
-func (h *emptyHandle) EnsureAddressBind(address, devName string) (exist bool, err error) {
+func (h *netlinkHandle) EnsureAddressBind(address, devName string) (exist bool, err error) {
 	return false, fmt.Errorf("netlink not supported for this platform")
 }
 
 // UnbindAddress unbind address from the interface
-func (h *emptyHandle) UnbindAddress(address, devName string) error {
+func (h *netlinkHandle) UnbindAddress(address, devName string) error {
 	return fmt.Errorf("netlink not supported for this platform")
 }
 
 // EnsureDummyDevice is part of interface
-func (h *emptyHandle) EnsureDummyDevice(devName string) (bool, error) {
+func (h *netlinkHandle) EnsureDummyDevice(devName string) (bool, error) {
 	return false, fmt.Errorf("netlink is not supported in this platform")
 }
 
 // DeleteDummyDevice is part of interface.
-func (h *emptyHandle) DeleteDummyDevice(devName string) error {
+func (h *netlinkHandle) DeleteDummyDevice(devName string) error {
 	return fmt.Errorf("netlink is not supported in this platform")
 }
 
 // ListBindAddress is part of interface.
-func (h *emptyHandle) ListBindAddress(devName string) ([]string, error) {
+func (h *netlinkHandle) ListBindAddress(devName string) ([]string, error) {
+	return nil, fmt.Errorf("netlink is not supported in this platform")
+}
+
+// GetAllLocalAddresses is part of interface.
+func (h *netlinkHandle) GetAllLocalAddresses() (sets.String, error) {
 	return nil, fmt.Errorf("netlink is not supported in this platform")
 }
 
 // GetLocalAddresses is part of interface.
-func (h *emptyHandle) GetLocalAddresses(dev, filterDev string) (sets.String, error) {
+func (h *netlinkHandle) GetLocalAddresses(dev string) (sets.String, error) {
 	return nil, fmt.Errorf("netlink is not supported in this platform")
+}
+
+// Must match the one in proxier_test.go
+func (h *netlinkHandle) isValidForSet(ip net.IP) bool {
+	return false
 }

--- a/pkg/proxy/ipvs/testing/fake_test.go
+++ b/pkg/proxy/ipvs/testing/fake_test.go
@@ -27,22 +27,22 @@ func TestSetGetLocalAddresses(t *testing.T) {
 	fake := NewFakeNetlinkHandle()
 	fake.SetLocalAddresses("eth0", "1.2.3.4")
 	expected := sets.NewString("1.2.3.4")
-	addr, _ := fake.GetLocalAddresses("eth0", "")
+	addr, _ := fake.GetLocalAddresses("eth0")
 	if !reflect.DeepEqual(expected, addr) {
 		t.Errorf("Unexpected mismatch, expected: %v, got: %v", expected, addr)
 	}
-	list, _ := fake.GetLocalAddresses("", "")
+	list, _ := fake.GetAllLocalAddresses()
 	if !reflect.DeepEqual(expected, list) {
 		t.Errorf("Unexpected mismatch, expected: %v, got: %v", expected, list)
 	}
 	fake.SetLocalAddresses("lo", "127.0.0.1")
-	expected = sets.NewString("127.0.0.1")
-	addr, _ = fake.GetLocalAddresses("lo", "")
+	expected = sets.NewString()
+	addr, _ = fake.GetLocalAddresses("lo")
 	if !reflect.DeepEqual(expected, addr) {
 		t.Errorf("Unexpected mismatch, expected: %v, got: %v", expected, addr)
 	}
-	list, _ = fake.GetLocalAddresses("", "")
-	expected = sets.NewString("1.2.3.4", "127.0.0.1")
+	list, _ = fake.GetAllLocalAddresses()
+	expected = sets.NewString("1.2.3.4")
 	if !reflect.DeepEqual(expected, list) {
 		t.Errorf("Unexpected mismatch, expected: %v, got: %v", expected, list)
 	}

--- a/pkg/proxy/util/utils.go
+++ b/pkg/proxy/util/utils.go
@@ -252,6 +252,27 @@ func GetNodeAddresses(cidrs []string, nw NetworkInterfacer) (sets.String, error)
 	return uniqueAddressList, nil
 }
 
+// AddressSet validates the addresses in the slice using the "isValid" function.
+// Addresses that pass the validation are returned as a string Set.
+func AddressSet(isValid func(ip net.IP) bool, addrs []net.Addr) sets.String {
+	ips := sets.NewString()
+	for _, a := range addrs {
+		var ip net.IP
+		switch v := a.(type) {
+		case *net.IPAddr:
+			ip = v.IP
+		case *net.IPNet:
+			ip = v.IP
+		default:
+			continue
+		}
+		if isValid(ip) {
+			ips.Insert(ip.String())
+		}
+	}
+	return ips
+}
+
 // LogAndEmitIncorrectIPVersionEvent logs and emits incorrect IP version event.
 func LogAndEmitIncorrectIPVersionEvent(recorder events.EventRecorder, fieldName, fieldValue, svcNamespace, svcName string, svcUID types.UID) {
 	errMsg := fmt.Sprintf("%s in %s has incorrect IP version", fieldValue, fieldName)


### PR DESCRIPTION

#### What type of PR is this?

/kind bug
/kind cleanup

#### What this PR does / why we need it:

To get node addresses to be used for nodePorts using netlink to read the local routing table was unnecessary complex and caused problems with older kernels as reported in #93858.

Using the go `net` library makes the code cleaner and more maintainable while reducing dependencies.

#### Which issue(s) this PR fixes:

Fixes #93858

#### Special notes for your reviewer:

I have limit the update to one file.

The "NetLinkHandle" in the `realIPGetter` is not really needed but unfortunately the unit tests are using the `realIPGetter` with a fake NetLinkHandle. So to limit the size of the PR (and the risk of mistakes) I let it be.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

N/A
