### PR TITLE
Deprecate removal of CSI nodepublish path by kubelet (#101332)

### DIFF
--- a/pkg/volume/csi/csi_mounter.go
+++ b/pkg/volume/csi/csi_mounter.go
@@ -365,9 +365,11 @@ func (c *csiMountMgr) TearDownAt(dir string) error {
 		return errors.New(log("mounter.TearDownAt failed: %v", err))
 	}
 
-	// Deprecation: Removal of this mount directory MUST be done by
-	// the CSI plugin according to the spec. This will no longer be done
-	// directly as part of TearDown by the kubelet in the future.
+	// Deprecation: Removal of target_path provided in the NodePublish RPC call
+	// (in this case location `dir`) MUST be done by the CSI plugin according
+	// to the spec. This will no longer be done directly as part of TearDown
+	// by the kubelet in the future. Kubelet will only be responsible for
+	// removal of json data files it creates and parent directories.
 	if err := removeMountDir(c.plugin, dir); err != nil {
 		return errors.New(log("mounter.TearDownAt failed to clean mount dir [%s]: %v", dir, err))
 	}

--- a/pkg/volume/csi/csi_mounter.go
+++ b/pkg/volume/csi/csi_mounter.go
@@ -365,7 +365,9 @@ func (c *csiMountMgr) TearDownAt(dir string) error {
 		return errors.New(log("mounter.TearDownAt failed: %v", err))
 	}
 
-	// clean mount point dir
+	// Deprecation: Removal of this mount directory MUST be done by
+	// the CSI plugin according to the spec. This will no longer be done
+	// directly as part of TearDown by the kubelet in the future.
 	if err := removeMountDir(c.plugin, dir); err != nil {
 		return errors.New(log("mounter.TearDownAt failed to clean mount dir [%s]: %v", dir, err))
 	}
@@ -426,9 +428,6 @@ func removeMountDir(plug *csiPlugin, mountPath string) error {
 	}
 	if !mnt {
 		klog.V(4).Info(log("dir not mounted, deleting it [%s]", mountPath))
-		// Deprecation: Removal of this mountPath directory MUST be done by
-		// the CSI plugin according to the spec. This will no longer be done
-		// directly as part of TearDown by the kubelet in the future.
 		if err := os.Remove(mountPath); err != nil && !os.IsNotExist(err) {
 			return errors.New(log("failed to remove dir [%s]: %v", mountPath, err))
 		}

--- a/pkg/volume/csi/csi_mounter.go
+++ b/pkg/volume/csi/csi_mounter.go
@@ -426,6 +426,9 @@ func removeMountDir(plug *csiPlugin, mountPath string) error {
 	}
 	if !mnt {
 		klog.V(4).Info(log("dir not mounted, deleting it [%s]", mountPath))
+		// Deprecation: Removal of this mountPath directory MUST be done by
+		// the CSI plugin according to the spec. This will no longer be done
+		// directly as part of TearDown by the kubelet in the future.
 		if err := os.Remove(mountPath); err != nil && !os.IsNotExist(err) {
 			return errors.New(log("failed to remove dir [%s]: %v", mountPath, err))
 		}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug
/kind deprecation
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This deprecates removal of the CSI nodepublish path by kubelets. This must be handled by the CSI plugin.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #101332

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
Yes
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Removal of the CSI nodepublish path by the kubelet is deprecated. This must be done by the CSI plugin according to the CSI spec.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- [CSI spec]: https://github.com/container-storage-interface/spec/blob/da58351ba3d7baf850877be3425e76ff30645d33/spec.md#nodeunpublishvolume
```
