### PR TITLE
Add missing clientset to EBS storage e2e test

### DIFF
--- a/test/e2e/storage/volume_provisioning.go
+++ b/test/e2e/storage/volume_provisioning.go
@@ -825,6 +825,7 @@ var _ = utils.SIGDescribe("Dynamic Provisioning", func() {
 		ginkgo.It("should report an error and create no PV", func() {
 			e2eskipper.SkipUnlessProviderIs("aws")
 			test := testsuites.StorageClassTest{
+				Client:      c,
 				Name:        "AWS EBS with invalid KMS key",
 				Provisioner: "kubernetes.io/aws-ebs",
 				Timeouts:    f.Timeouts,


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/kind failing-test

#### What this PR does / why we need it:

A [recent refactoring](https://github.com/kubernetes/kubernetes/pull/99888/files#diff-4597e4e0757b5ff144911e8a4d49e462f56dfb0eeef553db15c4d2844bb7be76R836) of these tests to use common pod functions requires that the `StorageClassTest`'s `Client` be set.
This updates the "Invalid AWS KMS key" test to set its `Client` similar to other tests in the file.

I discovered while enabling these e2e tests in a [kOps PR](https://github.com/kubernetes/kops/pull/10847), see the test failure [here](https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/kops/10847/pull-kops-e2e-kubernetes-aws/1385940729863344128#1:build-log.txt%3A32907) failing this assertion:

https://github.com/kubernetes/kubernetes/blob/6067d8556a017102fcd92c6a06738524c36847a9/test/e2e/storage/testsuites/provisioning.go#L318-L322

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
