### PR TITLE
WIP Nosnat hostnetwork tests 

### DIFF
--- a/test/e2e/network/no_snat.go
+++ b/test/e2e/network/no_snat.go
@@ -95,8 +95,8 @@ var _ = common.SIGDescribe("NoSNAT", func() {
 			wg.Add(1)
 			go func() {
 				defer ginkgo.GinkgoRecover()
+				defer wg.Done()
 				f.PodClient().CreateSync(testPod)
-				wg.Done()
 			}()
 		}
 		wg.Wait()
@@ -117,10 +117,10 @@ var _ = common.SIGDescribe("NoSNAT", func() {
 				wg.Add(1)
 				go func() {
 					defer ginkgo.GinkgoRecover()
+					defer wg.Done()
 					sourceIP, execPodIP := execSourceIPTest(sourcePod, targetAddr)
 					ginkgo.By("Verifying the preserved source ip")
 					framework.ExpectEqual(sourceIP, execPodIP)
-					wg.Done()
 				}()
 			}
 		}
@@ -197,8 +197,8 @@ var _ = common.SIGDescribe("NoSNAT", func() {
 			wg.Add(1)
 			go func() {
 				defer ginkgo.GinkgoRecover()
+				defer wg.Done()
 				f.PodClient().CreateSync(testPod)
-				wg.Done()
 			}()
 		}
 		wg.Wait()
@@ -219,10 +219,10 @@ var _ = common.SIGDescribe("NoSNAT", func() {
 				wg.Add(1)
 				go func() {
 					defer ginkgo.GinkgoRecover()
+					defer wg.Done()
 					sourceIP, execPodIP := execSourceIPTest(sourcePod, targetAddr)
 					ginkgo.By("Verifying the preserved source ip")
 					framework.ExpectEqual(sourceIP, execPodIP)
-					wg.Done()
 				}()
 			}
 		}

--- a/test/e2e/network/no_snat.go
+++ b/test/e2e/network/no_snat.go
@@ -57,7 +57,7 @@ func createTestPod(port string, hostNetwork bool) *v1.Pod {
 				{
 					Name:  noSNATTestName,
 					Image: imageutils.GetE2EImage(imageutils.Agnhost),
-					Args:  []string{"netexec", "--http-port", testPodPort},
+					Args:  []string{"netexec", "--http-port", port},
 				},
 			},
 			HostNetwork: hostNetwork,

--- a/test/e2e/network/no_snat.go
+++ b/test/e2e/network/no_snat.go
@@ -110,6 +110,7 @@ var _ = common.SIGDescribe("NoSNAT", func() {
 
 		// hit the /clientip endpoint on every other Pods to check if source ip is preserved
 		for _, sourcePod := range pods.Items {
+			sourcePod := sourcePod
 			for _, targetPod := range pods.Items {
 				if targetPod.Name == sourcePod.Name {
 					continue
@@ -157,6 +158,7 @@ var _ = common.SIGDescribe("NoSNAT", func() {
 
 		// hit the /clientip endpoint on every other Pods to check if source ip is preserved
 		for _, sourcePod := range pods.Items {
+			sourcePod := sourcePod
 			for _, targetPod := range pods.Items {
 				if targetPod.Name == sourcePod.Name {
 					continue
@@ -216,6 +218,7 @@ var _ = common.SIGDescribe("NoSNAT", func() {
 
 		// hit the /clientip endpoint on every other Pods to check if source ip is preserved
 		for _, sourcePod := range pods.Items {
+			sourcePod := sourcePod
 			for _, targetPod := range pods.Items {
 				if targetPod.Name == sourcePod.Name {
 					continue

--- a/test/e2e/network/no_snat.go
+++ b/test/e2e/network/no_snat.go
@@ -67,7 +67,7 @@ var (
 // Note: For those platforms that support Pods running in the host network (e.g. Linux):
 // pods in the host network of a node can communicate with all pods on all nodes without NAT
 // xref: https://kubernetes.io/docs/concepts/cluster-administration/networking/
-var _ = common.SIGDescribe("NoSNAT [Slow]", func() {
+var _ = common.SIGDescribe("NoSNAT", func() {
 	f := framework.NewDefaultFramework("no-snat-test")
 	ginkgo.It("Should be able to send traffic between Pods without SNAT", func() {
 		cs := f.ClientSet

--- a/test/e2e/network/no_snat.go
+++ b/test/e2e/network/no_snat.go
@@ -35,7 +35,8 @@ import (
 )
 
 const (
-	testPodPort    = "8080"
+	// try to use a no common port so it doesn't conflict using hostNetwork
+	testPodPort    = "8085"
 	noSNATTestName = "no-snat-test"
 )
 
@@ -60,8 +61,15 @@ var (
 )
 
 // This test verifies that a Pod on each node in a cluster can talk to Pods on every other node without SNAT.
-// We use the [Feature:NoSNAT] tag so that most jobs will skip this test by default.
-var _ = common.SIGDescribe("NoSNAT [Feature:NoSNAT] [Slow]", func() {
+// Kubernetes imposes the following fundamental requirements on any networking implementation
+// (barring any intentional network segmentation policies):
+//
+// pods on a node can communicate with all pods on all nodes without NAT
+// agents on a node (e.g. system daemons, kubelet) can communicate with all pods on that node
+// Note: For those platforms that support Pods running in the host network (e.g. Linux):
+// pods in the host network of a node can communicate with all pods on all nodes without NAT
+// xref: https://kubernetes.io/docs/concepts/cluster-administration/networking/
+var _ = common.SIGDescribe("NoSNAT [Slow]", func() {
 	f := framework.NewDefaultFramework("no-snat-test")
 	ginkgo.It("Should be able to send traffic between Pods without SNAT", func() {
 		cs := f.ClientSet

--- a/test/e2e/network/no_snat.go
+++ b/test/e2e/network/no_snat.go
@@ -148,6 +148,7 @@ var _ = common.SIGDescribe("NoSNAT", func() {
 		f.PodClient().CreateSync(testPod)
 		ginkgo.By("creating a hostnetwork test pod on the same Node")
 		testPodHost := createTestPod(testPodPort2, true)
+		e2epod.SetNodeSelection(&testPodHost.Spec, nodeSelection)
 		f.PodClient().CreateSync(testPodHost)
 
 		ginkgo.By("sending traffic from each pod to the others and checking that SNAT does not occur")


### PR DESCRIPTION

/kind bug
/kind cleanup

If we define a networking model, we should provides tests to verify that clusters meet the model.

https://kubernetes.io/docs/concepts/cluster-administration/networking/

> Kubernetes imposes the following fundamental requirements on any networking implementation (barring any intentional network segmentation policies):
> 
> pods on a node can communicate with all pods on all nodes without NAT
> agents on a node (e.g. system daemons, kubelet) can communicate with all pods on that node
> Note: For those platforms that support Pods running in the host network (e.g. Linux):
> 
> pods in the host network of a node can communicate with all pods on all nodes without NAT

Current tests were skipped.

We should also think in promoting them to Conformance

```release-note
NONE
```
