### PR TITLE
Update docs to reflect that the largest supported service subnet

### DIFF
--- a/cmd/kube-apiserver/app/options/options.go
+++ b/cmd/kube-apiserver/app/options/options.go
@@ -231,7 +231,8 @@ func (s *ServerRunOptions) Flags() (fss cliflag.NamedFlagSets) {
 
 	fs.StringVar(&s.ServiceClusterIPRanges, "service-cluster-ip-range", s.ServiceClusterIPRanges, ""+
 		"A CIDR notation IP range from which to assign service cluster IPs. This must not "+
-		"overlap with any IP ranges assigned to nodes or pods. Max of two dual-stack CIDRs is allowed.")
+		"overlap with any IP ranges assigned to nodes or pods. Max of two dual-stack CIDRs is allowed. "+
+		"The largest supported service subnet is /12 for IPv4 and /112 for IPv6.")
 
 	fs.Var(&s.ServiceNodePortRange, "service-node-port-range", ""+
 		"A port range to reserve for services with NodePort visibility. "+


### PR DESCRIPTION
#### What type of PR is this?
/kind documentation

#### What this PR does / why we need it:
The current message is like 
```
--service-cluster-ip-range string  A CIDR notation IP range from which to assign service cluster IPs. This must not overlap with any IP ranges assigned to nodes or pods. Max of two dual-stack CIDRs is allowed.
```
After some discussions below, I can summarize choices here:
1. ** Keep it as current**: no message about the largest scope or recommended
2. **Add the largest scope only**:  Adding `The largest supported service subnet is /12 for IPv4 and /112 for IPv6.`
3. **Add the recommended scope only**: Adding `The recommended service subnet is /16 for IPv4 and /112 for IPv6.`
4. **Add both largest and recommended**: Adding `The recommended service subnet is /16 for IPv4(no larger than /12) and /112 for IPv6(no larger than /112).`
5. **Add both, seperately**: Adding `The largest supported service subnet is /12 for IPv4 and /112 for IPv6. The recommended service subnet is /16 for IPv4 and /112 for IPv6.`

I prefer choice 2 or choice 4.

I open this PR since #91875 is not updated for a long time and need rebase.
After #95723 fixed kubernetes/kubeadm#2132, #91875 main part should be covered and [kubeadm part is done](https://github.com/kubernetes/kubeadm/issues/2132#issuecomment-775300850).

refer to https://github.com/kubernetes/kubernetes/pull/91875

#### Which issue(s) this PR fixes:

Fixes #91875

#### Special notes for your reviewer:
The  dual stack docs can be found in https://kubernetes.io/docs/setup/production-environment/tools/kubeadm/dual-stack-support/

Should we add the docs only? Or we need validate the CIDRs in apiserver and controller-manager?
/cc aojea Arvinderpal 
close this one if @Arvinderpal rebase the PR.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```