### PR TITLE
e2e: deflake test by not relying on events

### DIFF
--- a/test/e2e/framework/events/events.go
+++ b/test/e2e/framework/events/events.go
@@ -31,6 +31,7 @@ import (
 type Action func() error
 
 // WaitTimeoutForEvent waits the given timeout duration for an event to occur.
+// Please note delivery of events is not guaranteed. Asserting on events can lead to flaky tests.
 func WaitTimeoutForEvent(c clientset.Interface, namespace, eventSelector, msg string, timeout time.Duration) error {
 	interval := 2 * time.Second
 	return wait.PollImmediate(interval, timeout, eventOccurred(c, namespace, eventSelector, msg))


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/kind flake

#### What this PR does / why we need it:

This PR removes the reliance of an e2e test on events as events are unreliable, see #71646. Additionally, I inlined a function that is used in only one place.

#### Which issue(s) this PR fixes:

#71646 Identify e2e tests that rely on events and thus flaky, rewrite to avoid

#### Special notes for your reviewer:

This is my first contribution to Kubernetes. I am happy about feedback. Change validation:
```bash
# Setup kind cluster
kubetest2 kind --up --cluster-name kubetest2 --config kind-config.yml
# Run test
export KUBECONFIG=~/.kube/config
go test -timeout=0 -v ./test/e2e -provider=skeleton -context kind-kubetest2 -ginkgo.v \
  -ginkgo.focus="should reject a Pod requesting a RuntimeClass with an unconfigured handler \[NodeFeature:RuntimeHandler\]"
```

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
