### PR TITLE
pkg/scheduler: drop Resource.ResourceList() method

### DIFF
--- a/pkg/scheduler/framework/types.go
+++ b/pkg/scheduler/framework/types.go
@@ -25,15 +25,13 @@ import (
 	"sync/atomic"
 	"time"
 
-	"k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/resource"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/sets"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/klog/v2"
-	v1helper "k8s.io/kubernetes/pkg/apis/core/v1/helper"
 	"k8s.io/kubernetes/pkg/features"
 	schedutil "k8s.io/kubernetes/pkg/scheduler/util"
 )
@@ -494,24 +492,6 @@ func (r *Resource) Add(rl v1.ResourceList) {
 			}
 		}
 	}
-}
-
-// ResourceList returns a resource list of this resource.
-func (r *Resource) ResourceList() v1.ResourceList {
-	result := v1.ResourceList{
-		v1.ResourceCPU:              *resource.NewMilliQuantity(r.MilliCPU, resource.DecimalSI),
-		v1.ResourceMemory:           *resource.NewQuantity(r.Memory, resource.BinarySI),
-		v1.ResourcePods:             *resource.NewQuantity(int64(r.AllowedPodNumber), resource.BinarySI),
-		v1.ResourceEphemeralStorage: *resource.NewQuantity(r.EphemeralStorage, resource.BinarySI),
-	}
-	for rName, rQuant := range r.ScalarResources {
-		if v1helper.IsHugePageResourceName(rName) {
-			result[rName] = *resource.NewQuantity(rQuant, resource.BinarySI)
-		} else {
-			result[rName] = *resource.NewQuantity(rQuant, resource.DecimalSI)
-		}
-	}
-	return result
 }
 
 // Clone returns a copy of this resource.

--- a/pkg/scheduler/framework/types_test.go
+++ b/pkg/scheduler/framework/types_test.go
@@ -23,7 +23,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -66,54 +66,6 @@ func TestNewResource(t *testing.T) {
 			r := NewResource(test.resourceList)
 			if !reflect.DeepEqual(test.expected, r) {
 				t.Errorf("expected: %#v, got: %#v", test.expected, r)
-			}
-		})
-	}
-}
-
-func TestResourceList(t *testing.T) {
-	tests := []struct {
-		resource *Resource
-		expected v1.ResourceList
-	}{
-		{
-			resource: &Resource{},
-			expected: map[v1.ResourceName]resource.Quantity{
-				v1.ResourceCPU:              *resource.NewScaledQuantity(0, -3),
-				v1.ResourceMemory:           *resource.NewQuantity(0, resource.BinarySI),
-				v1.ResourcePods:             *resource.NewQuantity(0, resource.BinarySI),
-				v1.ResourceEphemeralStorage: *resource.NewQuantity(0, resource.BinarySI),
-			},
-		},
-		{
-			resource: &Resource{
-				MilliCPU:         4,
-				Memory:           2000,
-				EphemeralStorage: 5000,
-				AllowedPodNumber: 80,
-				ScalarResources: map[v1.ResourceName]int64{
-					"scalar.test/scalar1":        1,
-					"hugepages-test":             2,
-					"attachable-volumes-aws-ebs": 39,
-				},
-			},
-			expected: map[v1.ResourceName]resource.Quantity{
-				v1.ResourceCPU:                      *resource.NewScaledQuantity(4, -3),
-				v1.ResourceMemory:                   *resource.NewQuantity(2000, resource.BinarySI),
-				v1.ResourcePods:                     *resource.NewQuantity(80, resource.BinarySI),
-				v1.ResourceEphemeralStorage:         *resource.NewQuantity(5000, resource.BinarySI),
-				"scalar.test/" + "scalar1":          *resource.NewQuantity(1, resource.DecimalSI),
-				"attachable-volumes-aws-ebs":        *resource.NewQuantity(39, resource.DecimalSI),
-				v1.ResourceHugePagesPrefix + "test": *resource.NewQuantity(2, resource.BinarySI),
-			},
-		},
-	}
-
-	for i, test := range tests {
-		t.Run(fmt.Sprintf("case_%d", i), func(t *testing.T) {
-			rl := test.resource.ResourceList()
-			if !reflect.DeepEqual(test.expected, rl) {
-				t.Errorf("expected: %#v, got: %#v", test.expected, rl)
 			}
 		})
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

The method is used only for testing purposes. Given `Resource` data type
exposes all its fields, any invoker of `ResourceList` that is still
using the method outside of kubernetes/kubernetes can still either
copy paste the original implementation or implement a custom method
that's converting resources into proper `Quantity` data type.

Given the hugepage resource is a scalar resource, it's sufficient
the underlying code under `fit_test.go` to take into account any
extended resources. For `predicate_test.go`, the hugepage
resource does not play any role as the General predicates test cases
does not set any scaler resource at all.

Additionally, by removing `ResourceList` method, `pkg/scheduler/framework`
can get rid of dependency on `k8s.io/kubernetes/pkg/apis/core/v1/helper`.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

Part of https://github.com/kubernetes/kubernetes/issues/91782 effort

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
