### PR TITLE
Drop IsScalarResourceName check in GetNonzeroRequestForResource

### DIFF
--- a/pkg/scheduler/util/non_zero.go
+++ b/pkg/scheduler/util/non_zero.go
@@ -47,6 +47,9 @@ func GetNonzeroRequests(requests *v1.ResourceList) (int64, int64) {
 // GetNonzeroRequestForResource returns the default resource request if none is found or
 // what is provided on the request.
 func GetNonzeroRequestForResource(resource v1.ResourceName, requests *v1.ResourceList) int64 {
+	if requests == nil {
+		return 0
+	}
 	switch resource {
 	case v1.ResourceCPU:
 		// Override if un-set, but not if explicitly set to zero
@@ -72,13 +75,10 @@ func GetNonzeroRequestForResource(resource v1.ResourceName, requests *v1.Resourc
 		}
 		return quantity.Value()
 	default:
-		if IsScalarResourceName(resource) {
-			quantity, found := (*requests)[resource]
-			if !found {
-				return 0
-			}
-			return quantity.Value()
+		quantity, found := (*requests)[resource]
+		if !found {
+			return 0
 		}
+		return quantity.Value()
 	}
-	return 0
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

All invokers of GetNonzeroRequestForResource in k/k are either setting
the resource name to CPU/Memory or are checking if the requested
resource name is scalar after the invocation.
See https://github.com/search?q=org%3Akubernetes+GetNonzeroRequestForResource&type=code

Thus, it's unnecessary to check for scalar resource name again.
In the worst case, GetNonzeroRequestForResource returns non-zero
resource quantity which can be ignored by an invoker by running
IsResourceName helpers afterwards.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

Part of https://github.com/kubernetes/kubernetes/issues/91782 effort

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
