### PR TITLE
Bump metrics server to use 0.4.4 image.

### DIFF
--- a/cluster/addons/metrics-server/metrics-server-deployment.yaml
+++ b/cluster/addons/metrics-server/metrics-server-deployment.yaml
@@ -23,24 +23,23 @@ data:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: metrics-server-v0.3.7
+  name: metrics-server-v0.4.4
   namespace: kube-system
   labels:
     k8s-app: metrics-server
-    kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
-    version: v0.3.7
+    version: v0.4.4
 spec:
   selector:
     matchLabels:
       k8s-app: metrics-server
-      version: v0.3.7
+      version: v0.4.4
   template:
     metadata:
       name: metrics-server
       labels:
         k8s-app: metrics-server
-        version: v0.3.7
+        version: v0.4.4
     spec:
       securityContext:
         seccompProfile:
@@ -51,7 +50,7 @@ spec:
         kubernetes.io/os: linux
       containers:
       - name: metrics-server
-        image: k8s.gcr.io/metrics-server/metrics-server:v0.3.7
+        image: k8s.gcr.io/metrics-server/metrics-server:v0.4.4
         command:
         - /metrics-server
         - --metric-resolution=30s
@@ -60,10 +59,15 @@ spec:
         - --kubelet-port=10255
         - --deprecated-kubelet-completely-insecure=true
         - --kubelet-preferred-address-types=InternalIP,Hostname,InternalDNS,ExternalDNS,ExternalIP
+        - --cert-dir=/tmp
+        - --secure-port=443
         ports:
         - containerPort: 443
           name: https
           protocol: TCP
+        volumeMounts:
+        - mountPath: /tmp
+          name: tmp-dir
       - name: metrics-server-nanny
         image: k8s.gcr.io/addon-resizer:1.8.11
         resources:
@@ -93,7 +97,7 @@ spec:
           - --memory={{ base_metrics_server_memory }}
           - --extra-memory={{ metrics_server_memory_per_node }}Mi
           - --threshold=5
-          - --deployment=metrics-server-v0.3.7
+          - --deployment=metrics-server-v0.4.4
           - --container=metrics-server
           - --poll-period=300000
           - --estimator=exponential
@@ -103,9 +107,11 @@ spec:
           # Use kube-apiserver metrics to avoid periodically listing nodes.
           - --use-metrics=true
       volumes:
-        - name: metrics-server-config-volume
-          configMap:
-            name: metrics-server-config
+      - name: metrics-server-config-volume
+        configMap:
+          name: metrics-server-config
+      - emptyDir: {}
+        name: tmp-dir
       tolerations:
         - key: "CriticalAddonsOnly"
           operator: "Exists"


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

/kind deprecation

#### What this PR does / why we need it:

Metrics server 0.3.6 used deprecated authorization.k8s.io/v1beta1 subjectaccessreviews API version. 0.4.4 uses v1 instead.

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Metrics Server updated to use 0.4.4 image that doesn't depend on deprecated authorization.k8s.io/v1beta1 subjectaccessreviews API version.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

@liggitt @serathius 