### PR TITLE
Update event-exporter and prometheus-to-sd versions in cluster addons

### DIFF
--- a/cluster/addons/fluentd-gcp/event-exporter.yaml
+++ b/cluster/addons/fluentd-gcp/event-exporter.yaml
@@ -29,11 +29,11 @@ subjects:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: event-exporter-v0.3.1
+  name: event-exporter-v0.3.4
   namespace: kube-system
   labels:
     k8s-app: event-exporter
-    version: v0.3.1
+    version: v0.3.4
     kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
 spec:
@@ -41,23 +41,23 @@ spec:
   selector:
     matchLabels:
       k8s-app: event-exporter
-      version: v0.3.1
+      version: v0.3.4
   template:
     metadata:
       labels:
         k8s-app: event-exporter
-        version: v0.3.1
+        version: v0.3.4
     spec:
       serviceAccountName: event-exporter-sa
       containers:
       - name: event-exporter
-        image: k8s.gcr.io/event-exporter:v0.3.1
+        image: gke.gcr.io/event-exporter:v0.3.4-gke.0
         command:
         - /event-exporter
         - -sink-opts=-stackdriver-resource-model={{ exporter_sd_resource_model }} -endpoint={{ exporter_sd_endpoint }}
       # BEGIN_PROMETHEUS_TO_SD
       - name: prometheus-to-sd-exporter
-        image: k8s.gcr.io/prometheus-to-sd:v0.7.2
+        image: gke.gcr.io/prometheus-to-sd:v0.11.1-gke.1
         command:
           - /monitor
           - --stackdriver-prefix={{ prometheus_to_sd_prefix }}/addons

--- a/cluster/addons/fluentd-gcp/fluentd-gcp-ds.yaml
+++ b/cluster/addons/fluentd-gcp/fluentd-gcp-ds.yaml
@@ -79,7 +79,7 @@ spec:
               fi;
       # BEGIN_PROMETHEUS_TO_SD
       - name: prometheus-to-sd-exporter
-        image: k8s.gcr.io/prometheus-to-sd:v0.5.0
+        image: k8s.gcr.io/prometheus-to-sd:v0.11.1
         command:
           - /monitor
           - --stackdriver-prefix={{ prometheus_to_sd_prefix }}/addons

--- a/cluster/addons/metadata-proxy/gce/metadata-proxy.yaml
+++ b/cluster/addons/metadata-proxy/gce/metadata-proxy.yaml
@@ -57,7 +57,7 @@ spec:
             cpu: "30m"
       # BEGIN_PROMETHEUS_TO_SD
       - name: prometheus-to-sd-exporter
-        image: k8s.gcr.io/prometheus-to-sd:v0.5.0
+        image: gke.gcr.io/prometheus-to-sd:v0.11.1-gke.1
         # Request and limit resources to get guaranteed QoS.
         resources:
           requests:


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

We want a newer verison of client-go so that these addons aren't broken.
Currently, both prometheus-to-sd and event exporter use v1.12 of client-go, which would break.

New prometheus-to-sd version of client-go: v1.17.5
New event-exporter version of client-go: v1.17.3

#### Which issue(s) this PR fixes:
Fixes #101341

#### Does this PR introduce a user-facing change?
```release-note
None
```

/assign @logicalhan @serathius 