### PR TITLE
add --all-namespaces to kubectl annotate,label

### DIFF
--- a/hack/testdata/CRD/foo-2.yaml
+++ b/hack/testdata/CRD/foo-2.yaml
@@ -1,0 +1,12 @@
+kind: Foo
+apiVersion: company.com/v1
+metadata:
+  name: second-instance
+  namespace: default
+  labels:
+    pruneGroup: "true"
+someField: field1
+otherField: field2
+nestedField:
+  someSubfield: subfield1
+  otherSubfield: subfield2

--- a/staging/src/k8s.io/kubectl/pkg/cmd/annotate/annotate.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/annotate/annotate.go
@@ -59,6 +59,7 @@ type AnnotateOptions struct {
 	dryRunVerifier  *resource.DryRunVerifier
 	fieldManager    string
 	all             bool
+	allNamespaces   bool
 	resourceVersion string
 	selector        string
 	fieldSelector   string
@@ -150,6 +151,7 @@ func NewCmdAnnotate(parent string, f cmdutil.Factory, ioStreams genericclioption
 	cmd.Flags().StringVarP(&o.selector, "selector", "l", o.selector, "Selector (label query) to filter on, not including uninitialized ones, supports '=', '==', and '!='.(e.g. -l key1=value1,key2=value2).")
 	cmd.Flags().StringVar(&o.fieldSelector, "field-selector", o.fieldSelector, "Selector (field query) to filter on, supports '=', '==', and '!='.(e.g. --field-selector key1=value1,key2=value2). The server only supports a limited number of field queries per type.")
 	cmd.Flags().BoolVar(&o.all, "all", o.all, "Select all resources, including uninitialized ones, in the namespace of the specified resource types.")
+	cmd.Flags().BoolVarP(&o.allNamespaces, "all-namespaces", "A", o.allNamespaces, "If true, check the specified action in all namespaces.")
 	cmd.Flags().StringVar(&o.resourceVersion, "resource-version", o.resourceVersion, i18n.T("If non-empty, the annotation update will only succeed if this is the current resource-version for the object. Only valid when specifying a single resource."))
 	usage := "identifying the resource to update the annotation"
 	cmdutil.AddFilenameOptionFlags(cmd, &o.FilenameOptions, usage)
@@ -257,6 +259,7 @@ func (o AnnotateOptions) RunAnnotate() error {
 	if !o.local {
 		b = b.LabelSelectorParam(o.selector).
 			FieldSelectorParam(o.fieldSelector).
+			AllNamespaces(o.allNamespaces).
 			ResourceTypeOrNameArgs(o.all, o.resources...).
 			Latest()
 	}

--- a/staging/src/k8s.io/kubectl/pkg/cmd/label/label.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/label/label.go
@@ -58,6 +58,7 @@ type LabelOptions struct {
 	local           bool
 	dryRunStrategy  cmdutil.DryRunStrategy
 	all             bool
+	allNamespaces   bool
 	resourceVersion string
 	selector        string
 	fieldSelector   string
@@ -147,6 +148,7 @@ func NewCmdLabel(f cmdutil.Factory, ioStreams genericclioptions.IOStreams) *cobr
 	cmd.Flags().StringVarP(&o.selector, "selector", "l", o.selector, "Selector (label query) to filter on, not including uninitialized ones, supports '=', '==', and '!='.(e.g. -l key1=value1,key2=value2).")
 	cmd.Flags().StringVar(&o.fieldSelector, "field-selector", o.fieldSelector, "Selector (field query) to filter on, supports '=', '==', and '!='.(e.g. --field-selector key1=value1,key2=value2). The server only supports a limited number of field queries per type.")
 	cmd.Flags().BoolVar(&o.all, "all", o.all, "Select all resources, including uninitialized ones, in the namespace of the specified resource types")
+	cmd.Flags().BoolVarP(&o.allNamespaces, "all-namespaces", "A", o.allNamespaces, "If true, check the specified action in all namespaces.")
 	cmd.Flags().StringVar(&o.resourceVersion, "resource-version", o.resourceVersion, i18n.T("If non-empty, the labels update will only succeed if this is the current resource-version for the object. Only valid when specifying a single resource."))
 	usage := "identifying the resource to update the labels"
 	cmdutil.AddFilenameOptionFlags(cmd, &o.FilenameOptions, usage)
@@ -249,6 +251,7 @@ func (o *LabelOptions) RunLabel() error {
 	if !o.local {
 		b = b.LabelSelectorParam(o.selector).
 			FieldSelectorParam(o.fieldSelector).
+			AllNamespaces(o.allNamespaces).
 			ResourceTypeOrNameArgs(o.all, o.resources...).
 			Latest()
 	}

--- a/test/cmd/crd.sh
+++ b/test/cmd/crd.sh
@@ -245,6 +245,7 @@ run_non_native_resource_tests() {
 
   # Test that we can create a new resource of type Foo
   kubectl "${kube_flags[@]}" create -f hack/testdata/CRD/foo.yaml "${kube_flags[@]}"
+  kubectl "${kube_flags[@]}" create -f hack/testdata/CRD/foo-2.yaml "${kube_flags[@]}"
 
   # Test that we can list this new custom resource
   kube::test::get_object_assert foos "{{range.items}}{{$id_field}}:{{end}}" 'test:'
@@ -305,11 +306,19 @@ run_non_native_resource_tests() {
   kube::log::status "Testing CustomResource labeling"
   kubectl "${kube_flags[@]}" label foos --all listlabel=true
   kubectl "${kube_flags[@]}" label foo/test itemlabel=true
+  kubectl "${kube_flags[@]}" label --all --all-namespaces foo allnsLabel=true
+  # make sure all instances in different namespaces got the annotation
+  kubectl "${kube_flags[@]}" get foo/test -oyaml | grep allnsLabel
+  kubectl "${kube_flags[@]}" get -n default foo -oyaml | grep allnsLabel
 
   # Test annotating
   kube::log::status "Testing CustomResource annotating"
   kubectl "${kube_flags[@]}" annotate foos --all listannotation=true
   kubectl "${kube_flags[@]}" annotate foo/test itemannotation=true
+  kubectl "${kube_flags[@]}" annotate --all --all-namespaces foo allnsannotation=true
+  # make sure all instances in different namespaces got the annotation
+  kubectl "${kube_flags[@]}" get foo/test -oyaml | grep allnsannotation
+  kubectl "${kube_flags[@]}" get -n default foo -oyaml | grep allnsannotation
 
   # Test describing
   kube::log::status "Testing CustomResource describing"


### PR DESCRIPTION
I'd like to be able to use the standard `--all-namespaces`, `-A` flag with `kubectl annotate` and `kubectl label`.  It appears to be an oversight.  This leverages our standard builder to add the functionality.

/kind cleanup
/priority important-soon
@kubernetes/sig-cli-misc 

```release-note
NONE
```