### PR TITLE
e2e/network/firewall: don't assume nodes are exposed externally

### DIFF
--- a/test/e2e/network/firewall.go
+++ b/test/e2e/network/firewall.go
@@ -218,8 +218,10 @@ var _ = common.SIGDescribe("Firewall rule", func() {
 
 		ginkgo.By("Checking well known ports on master and nodes are not exposed externally")
 		nodeAddr := e2enode.FirstAddress(nodes, v1.NodeExternalIP)
-		if nodeAddr == "" {
-			framework.Failf("did not find any node addresses")
+		if nodeAddr != "" {
+			assertNotReachableHTTPTimeout(nodeAddr, "/", ports.KubeletPort, firewallTestTCPTimeout, false)
+			assertNotReachableHTTPTimeout(nodeAddr, "/", ports.KubeletReadOnlyPort, firewallTestTCPTimeout, false)
+			assertNotReachableHTTPTimeout(nodeAddr, "/", ports.ProxyStatusPort, firewallTestTCPTimeout, false)
 		}
 
 		controlPlaneAddresses := framework.GetControlPlaneAddresses(cs)
@@ -227,9 +229,6 @@ var _ = common.SIGDescribe("Firewall rule", func() {
 			assertNotReachableHTTPTimeout(instanceAddress, "/healthz", ports.KubeControllerManagerPort, firewallTestTCPTimeout, true)
 			assertNotReachableHTTPTimeout(instanceAddress, "/healthz", kubeschedulerconfig.DefaultKubeSchedulerPort, firewallTestTCPTimeout, true)
 		}
-		assertNotReachableHTTPTimeout(nodeAddr, "/", ports.KubeletPort, firewallTestTCPTimeout, false)
-		assertNotReachableHTTPTimeout(nodeAddr, "/", ports.KubeletReadOnlyPort, firewallTestTCPTimeout, false)
-		assertNotReachableHTTPTimeout(nodeAddr, "/", ports.ProxyStatusPort, firewallTestTCPTimeout, false)
 	})
 })
 


### PR DESCRIPTION
If no nodes have NodeExternalIP addresses, then clearly none of the
services are exposed externally, and the test should succeed.
Seen in OpenShift CI.

See https://bugzilla.redhat.com/show_bug.cgi?id=1952460 for more info. OpenShift CI cluster nodes do not have NodeExternalIPs.

```release-note
NONE
```