### PR TITLE
Inject pkg/apis/core/v1 ResourceName helpers through ResourceNameQualifier from cmd/kube-scheduler

### DIFF
--- a/cmd/kube-scheduler/app/options/options.go
+++ b/cmd/kube-scheduler/app/options/options.go
@@ -47,6 +47,7 @@ import (
 	kubeschedulerconfig "k8s.io/kubernetes/pkg/scheduler/apis/config"
 	kubeschedulerscheme "k8s.io/kubernetes/pkg/scheduler/apis/config/scheme"
 	"k8s.io/kubernetes/pkg/scheduler/apis/config/validation"
+	"k8s.io/kubernetes/pkg/util/resources"
 )
 
 // Options has all the params needed to run a Scheduler
@@ -184,7 +185,7 @@ func (o *Options) ApplyTo(c *schedulerappconfig.Config) error {
 		if err != nil {
 			return err
 		}
-		if err := validation.ValidateKubeSchedulerConfiguration(cfg); err != nil {
+		if err := validation.ValidateKubeSchedulerConfiguration(cfg, resources.NewResourceNameQualifier()); err != nil {
 			return err
 		}
 
@@ -234,7 +235,7 @@ func emptySchedulerProfileConfig(profiles []kubeschedulerconfig.KubeSchedulerPro
 func (o *Options) Validate() []error {
 	var errs []error
 
-	if err := validation.ValidateKubeSchedulerConfiguration(&o.ComponentConfig); err != nil {
+	if err := validation.ValidateKubeSchedulerConfiguration(&o.ComponentConfig, resources.NewResourceNameQualifier()); err != nil {
 		errs = append(errs, err.Errors()...)
 	}
 	errs = append(errs, o.SecureServing.Validate()...)

--- a/cmd/kube-scheduler/app/server.go
+++ b/cmd/kube-scheduler/app/server.go
@@ -56,6 +56,7 @@ import (
 	"k8s.io/kubernetes/pkg/scheduler/framework/runtime"
 	"k8s.io/kubernetes/pkg/scheduler/metrics/resources"
 	"k8s.io/kubernetes/pkg/scheduler/profile"
+	resourcenamequalifier "k8s.io/kubernetes/pkg/util/resources"
 )
 
 // Option configures a framework.Registry.
@@ -246,7 +247,7 @@ func installMetricHandler(pathRecorderMux *mux.PathRecorderMux, informers inform
 	configz.InstallHandler(pathRecorderMux)
 	pathRecorderMux.Handle("/metrics", legacyregistry.HandlerWithReset())
 
-	resourceMetricsHandler := resources.Handler(informers.Core().V1().Pods().Lister())
+	resourceMetricsHandler := resources.Handler(informers.Core().V1().Pods().Lister(), resourcenamequalifier.NewResourceNameQualifier())
 	pathRecorderMux.HandleFunc("/metrics/resources", func(w http.ResponseWriter, req *http.Request) {
 		if !isLeader() {
 			return
@@ -329,6 +330,7 @@ func Setup(ctx context.Context, opts *options.Options, outOfTreeRegistryOptions 
 	sched, err := scheduler.New(cc.Client,
 		cc.InformerFactory,
 		recorderFactory,
+		resourcenamequalifier.NewResourceNameQualifier(),
 		ctx.Done(),
 		scheduler.WithKubeConfig(cc.KubeConfig),
 		scheduler.WithProfiles(cc.ComponentConfig.Profiles...),

--- a/pkg/kubelet/cm/devicemanager/manager_test.go
+++ b/pkg/kubelet/cm/devicemanager/manager_test.go
@@ -44,6 +44,7 @@ import (
 	"k8s.io/kubernetes/pkg/kubelet/lifecycle"
 	"k8s.io/kubernetes/pkg/kubelet/pluginmanager"
 	schedulerframework "k8s.io/kubernetes/pkg/scheduler/framework"
+	schedulerfakeframework "k8s.io/kubernetes/pkg/scheduler/framework/fake"
 )
 
 const (
@@ -866,6 +867,15 @@ func TestInitContainerDeviceAllocation(t *testing.T) {
 	as.Equal(0, normalCont1Devices.Intersection(normalCont2Devices).Len())
 }
 
+func getFakeResourceNameQualifier() schedulerframework.ResourceNameQualifier {
+	return &schedulerfakeframework.ResourceNameQualifier{
+		ExtendedResourceNames: []v1.ResourceName{
+			"domain1.com/resource1",
+			"domain2.com/resource2",
+		},
+	}
+}
+
 func TestUpdatePluginResources(t *testing.T) {
 	pod := &v1.Pod{}
 	pod.UID = types.UID("testPod")
@@ -907,7 +917,7 @@ func TestUpdatePluginResources(t *testing.T) {
 			},
 		},
 	}
-	nodeInfo := &schedulerframework.NodeInfo{}
+	nodeInfo := schedulerframework.NewNodeInfo(getFakeResourceNameQualifier())
 	nodeInfo.SetNode(cachedNode)
 
 	testManager.UpdatePluginResources(nodeInfo, &lifecycle.PodAdmitAttributes{Pod: pod})

--- a/pkg/scheduler/apis/config/testing/compatibility_test.go
+++ b/pkg/scheduler/apis/config/testing/compatibility_test.go
@@ -35,7 +35,17 @@ import (
 	"k8s.io/kubernetes/pkg/scheduler/algorithmprovider"
 	"k8s.io/kubernetes/pkg/scheduler/apis/config"
 	"k8s.io/kubernetes/pkg/scheduler/core"
+	"k8s.io/kubernetes/pkg/scheduler/framework"
+	fakeframework "k8s.io/kubernetes/pkg/scheduler/framework/fake"
 )
+
+func getFakeResourceNameQualifier() framework.ResourceNameQualifier {
+	return &fakeframework.ResourceNameQualifier{
+		ExtendedResourceNames: []v1.ResourceName{
+			"example.com/foo",
+		},
+	}
+}
 
 type testCase struct {
 	name          string
@@ -1381,6 +1391,7 @@ func TestCompatibility_v1_Scheduler(t *testing.T) {
 				client,
 				informerFactory,
 				recorderFactory,
+				getFakeResourceNameQualifier(),
 				make(chan struct{}),
 				scheduler.WithAlgorithmSource(algorithmSrc),
 			)
@@ -1556,6 +1567,7 @@ func TestAlgorithmProviderCompatibility(t *testing.T) {
 				client,
 				informerFactory,
 				recorderFactory,
+				getFakeResourceNameQualifier(),
 				make(chan struct{}),
 				opts...,
 			)
@@ -2121,6 +2133,7 @@ func TestPluginsConfigurationCompatibility(t *testing.T) {
 				client,
 				informerFactory,
 				recorderFactory,
+				getFakeResourceNameQualifier(),
 				make(chan struct{}),
 				scheduler.WithProfiles(config.KubeSchedulerProfile{
 					SchedulerName: v1.DefaultSchedulerName,

--- a/pkg/scheduler/apis/config/validation/validation_test.go
+++ b/pkg/scheduler/apis/config/validation/validation_test.go
@@ -22,10 +22,21 @@ import (
 	"testing"
 	"time"
 
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	componentbaseconfig "k8s.io/component-base/config"
 	"k8s.io/kubernetes/pkg/scheduler/apis/config"
+	"k8s.io/kubernetes/pkg/scheduler/framework"
+	fakeframework "k8s.io/kubernetes/pkg/scheduler/framework/fake"
 )
+
+func getFakeResourceNameQualifier() framework.ResourceNameQualifier {
+	return &fakeframework.ResourceNameQualifier{
+		ExtendedResourceNames: []v1.ResourceName{
+			"foo.com/bar",
+		},
+	}
+}
 
 func TestValidateKubeSchedulerConfiguration(t *testing.T) {
 	podInitialBackoffSeconds := int64(1)
@@ -298,7 +309,7 @@ func TestValidateKubeSchedulerConfiguration(t *testing.T) {
 
 	for name, scenario := range scenarios {
 		t.Run(name, func(t *testing.T) {
-			errs := ValidateKubeSchedulerConfiguration(scenario.config)
+			errs := ValidateKubeSchedulerConfiguration(scenario.config, getFakeResourceNameQualifier())
 			if errs == nil && scenario.expectedToFail {
 				t.Error("Unexpected success")
 			}
@@ -434,7 +445,7 @@ func TestValidatePolicy(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			actual := ValidatePolicy(test.policy)
+			actual := ValidatePolicy(test.policy, getFakeResourceNameQualifier())
 			if fmt.Sprint(test.expected) != fmt.Sprint(actual) {
 				t.Errorf("expected: %s, actual: %s", test.expected, actual)
 			}

--- a/pkg/scheduler/core/extender_test.go
+++ b/pkg/scheduler/core/extender_test.go
@@ -31,6 +31,7 @@ import (
 	clientsetfake "k8s.io/client-go/kubernetes/fake"
 	schedulerapi "k8s.io/kubernetes/pkg/scheduler/apis/config"
 	"k8s.io/kubernetes/pkg/scheduler/framework"
+	fakeframework "k8s.io/kubernetes/pkg/scheduler/framework/fake"
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/defaultbinder"
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/queuesort"
 	"k8s.io/kubernetes/pkg/scheduler/framework/runtime"
@@ -263,7 +264,7 @@ func TestGenericSchedulerWithExtenders(t *testing.T) {
 			for ii := range test.extenders {
 				extenders = append(extenders, &test.extenders[ii])
 			}
-			cache := internalcache.New(time.Duration(0), wait.NeverStop)
+			cache := internalcache.New(time.Duration(0), wait.NeverStop, fakeframework.NewNodeInfoWithEmptyResourceNameQualifier)
 			for _, name := range test.nodes {
 				cache.AddNode(createNode(name))
 			}

--- a/pkg/scheduler/core/generic_scheduler_test.go
+++ b/pkg/scheduler/core/generic_scheduler_test.go
@@ -42,6 +42,7 @@ import (
 	"k8s.io/kubernetes/pkg/features"
 	schedulerapi "k8s.io/kubernetes/pkg/scheduler/apis/config"
 	"k8s.io/kubernetes/pkg/scheduler/framework"
+	fakeframework "k8s.io/kubernetes/pkg/scheduler/framework/fake"
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/defaultbinder"
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/noderesources"
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/podtopologyspread"
@@ -968,7 +969,7 @@ func TestGenericScheduler(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			cache := internalcache.New(time.Duration(0), wait.NeverStop)
+			cache := internalcache.New(time.Duration(0), wait.NeverStop, fakeframework.NewNodeInfoWithEmptyResourceNameQualifier)
 			for _, pod := range test.pods {
 				cache.AddPod(pod)
 			}
@@ -990,7 +991,7 @@ func TestGenericScheduler(t *testing.T) {
 					cs.CoreV1().PersistentVolumes().Create(ctx, &pv, metav1.CreateOptions{})
 				}
 			}
-			snapshot := internalcache.NewSnapshot(test.pods, nodes)
+			snapshot := internalcache.NewSnapshot(test.pods, nodes, fakeframework.NewNodeInfoWithEmptyResourceNameQualifier)
 			fwk, err := st.NewFramework(
 				test.registerPlugins, "",
 				frameworkruntime.WithSnapshotSharedLister(snapshot),
@@ -1033,7 +1034,7 @@ func TestGenericScheduler(t *testing.T) {
 
 // makeScheduler makes a simple genericScheduler for testing.
 func makeScheduler(nodes []*v1.Node) *genericScheduler {
-	cache := internalcache.New(time.Duration(0), wait.NeverStop)
+	cache := internalcache.New(time.Duration(0), wait.NeverStop, fakeframework.NewNodeInfoWithEmptyResourceNameQualifier)
 	for _, n := range nodes {
 		cache.AddNode(n)
 	}
@@ -1306,7 +1307,7 @@ func TestZeroRequest(t *testing.T) {
 			client := clientsetfake.NewSimpleClientset()
 			informerFactory := informers.NewSharedInformerFactory(client, 0)
 
-			snapshot := internalcache.NewSnapshot(test.pods, test.nodes)
+			snapshot := internalcache.NewSnapshot(test.pods, test.nodes, fakeframework.NewNodeInfoWithEmptyResourceNameQualifier)
 
 			pluginRegistrations := []st.RegisterPluginFunc{
 				st.RegisterQueueSortPlugin(queuesort.Name, queuesort.New),
@@ -1491,7 +1492,7 @@ func TestPreferNominatedNodeFilterCallCounts(t *testing.T) {
 			// create three nodes in the cluster.
 			nodes := makeNodeList([]string{"node1", "node2", "node3"})
 			client := &clientsetfake.Clientset{}
-			cache := internalcache.New(time.Duration(0), wait.NeverStop)
+			cache := internalcache.New(time.Duration(0), wait.NeverStop, fakeframework.NewNodeInfoWithEmptyResourceNameQualifier)
 			for _, n := range nodes {
 				cache.AddNode(n)
 			}
@@ -1515,7 +1516,7 @@ func TestPreferNominatedNodeFilterCallCounts(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			snapshot := internalcache.NewSnapshot(nil, nodes)
+			snapshot := internalcache.NewSnapshot(nil, nodes, fakeframework.NewNodeInfoWithEmptyResourceNameQualifier)
 			scheduler := NewGenericScheduler(
 				cache,
 				snapshot,

--- a/pkg/scheduler/eventhandlers_test.go
+++ b/pkg/scheduler/eventhandlers_test.go
@@ -23,10 +23,10 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/kubernetes/pkg/scheduler/framework"
+	fakeframework "k8s.io/kubernetes/pkg/scheduler/framework/fake"
 	"k8s.io/kubernetes/pkg/scheduler/internal/cache"
 	"k8s.io/kubernetes/pkg/scheduler/internal/queue"
 	st "k8s.io/kubernetes/pkg/scheduler/testing"
@@ -207,7 +207,7 @@ func TestUpdatePodInCache(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
-			schedulerCache := cache.New(ttl, ctx.Done())
+			schedulerCache := cache.New(ttl, ctx.Done(), fakeframework.NewNodeInfoWithEmptyResourceNameQualifier)
 			schedulerQueue := queue.NewTestQueue(ctx, nil)
 			sched := &Scheduler{
 				SchedulerCache:  schedulerCache,
@@ -319,9 +319,12 @@ func TestPreCheckForNode(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			nodeInfo := framework.NewNodeInfo(tt.existingPods...)
+			nodeInfo := fakeframework.NewNodeInfoWithEmptyResourceNameQualifier()
+			for _, pod := range tt.existingPods {
+				nodeInfo.AddPod(pod)
+			}
 			nodeInfo.SetNode(tt.nodeFn())
-			preCheckFn := preCheckForNode(nodeInfo)
+			preCheckFn := preCheckForNode(nodeInfo, fakeframework.EmptyResourceNameQualifier())
 
 			var got []bool
 			for _, pod := range tt.pods {

--- a/pkg/scheduler/factory.go
+++ b/pkg/scheduler/factory.go
@@ -80,12 +80,13 @@ type Configurator struct {
 
 	podMaxBackoffSeconds int64
 
-	profiles          []schedulerapi.KubeSchedulerProfile
-	registry          frameworkruntime.Registry
-	nodeInfoSnapshot  *internalcache.Snapshot
-	extenders         []schedulerapi.Extender
-	frameworkCapturer FrameworkCapturer
-	parallellism      int32
+	profiles              []schedulerapi.KubeSchedulerProfile
+	registry              frameworkruntime.Registry
+	nodeInfoSnapshot      *internalcache.Snapshot
+	extenders             []schedulerapi.Extender
+	frameworkCapturer     FrameworkCapturer
+	parallellism          int32
+	resourceNameQualifier framework.ResourceNameQualifier
 }
 
 // create a scheduler from a set of registered plugins.
@@ -147,6 +148,7 @@ func (c *Configurator) create() (*Scheduler, error) {
 		frameworkruntime.WithCaptureProfile(frameworkruntime.CaptureProfile(c.frameworkCapturer)),
 		frameworkruntime.WithClusterEventMap(clusterEventMap),
 		frameworkruntime.WithParallelism(int(c.parallellism)),
+		frameworkruntime.WithResourceNameQualifier(c.resourceNameQualifier),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("initializing profiles: %v", err)
@@ -220,7 +222,7 @@ func (c *Configurator) createFromConfig(policy schedulerapi.Policy) (*Scheduler,
 	klog.V(2).InfoS("Creating scheduler from configuration", "policy", policy)
 
 	// validate the policy configuration
-	if err := validation.ValidatePolicy(policy); err != nil {
+	if err := validation.ValidatePolicy(policy, c.resourceNameQualifier); err != nil {
 		return nil, err
 	}
 

--- a/pkg/scheduler/factory_test.go
+++ b/pkg/scheduler/factory_test.go
@@ -38,6 +38,7 @@ import (
 	extenderv1 "k8s.io/kube-scheduler/extender/v1"
 	schedulerapi "k8s.io/kubernetes/pkg/scheduler/apis/config"
 	"k8s.io/kubernetes/pkg/scheduler/framework"
+	fakeframework "k8s.io/kubernetes/pkg/scheduler/framework/fake"
 	frameworkplugins "k8s.io/kubernetes/pkg/scheduler/framework/plugins"
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/defaultpreemption"
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/interpodaffinity"
@@ -404,6 +405,7 @@ func TestCreateFromConfig(t *testing.T) {
 				client,
 				informerFactory,
 				recorderFactory,
+				fakeframework.EmptyResourceNameQualifier(),
 				make(chan struct{}),
 				WithAlgorithmSource(createAlgorithmSourceFromPolicy(tc.configData, client)),
 				WithBuildFrameworkCapturer(func(p schedulerapi.KubeSchedulerProfile) {
@@ -472,7 +474,7 @@ func TestDefaultErrorFunc(t *testing.T) {
 			podInformer.Informer().GetStore().Add(testPod)
 
 			queue := internalqueue.NewPriorityQueue(nil, informerFactory, internalqueue.WithClock(clock.NewFakeClock(time.Now())))
-			schedulerCache := internalcache.New(30*time.Second, stopCh)
+			schedulerCache := internalcache.New(30*time.Second, stopCh, fakeframework.NewNodeInfoWithEmptyResourceNameQualifier)
 
 			queue.Add(testPod)
 			queue.Pop()
@@ -546,7 +548,7 @@ func TestDefaultErrorFunc_NodeNotFound(t *testing.T) {
 			podInformer.Informer().GetStore().Add(testPod)
 
 			queue := internalqueue.NewPriorityQueue(nil, informerFactory, internalqueue.WithClock(clock.NewFakeClock(time.Now())))
-			schedulerCache := internalcache.New(30*time.Second, stopCh)
+			schedulerCache := internalcache.New(30*time.Second, stopCh, fakeframework.NewNodeInfoWithEmptyResourceNameQualifier)
 
 			for i := range tt.nodes {
 				node := tt.nodes[i]
@@ -587,7 +589,7 @@ func TestDefaultErrorFunc_PodAlreadyBound(t *testing.T) {
 	podInformer.Informer().GetStore().Add(testPod)
 
 	queue := internalqueue.NewPriorityQueue(nil, informerFactory, internalqueue.WithClock(clock.NewFakeClock(time.Now())))
-	schedulerCache := internalcache.New(30*time.Second, stopCh)
+	schedulerCache := internalcache.New(30*time.Second, stopCh, fakeframework.NewNodeInfoWithEmptyResourceNameQualifier)
 
 	// Add node to schedulerCache no matter it's deleted in API server or not.
 	schedulerCache.AddNode(&nodeFoo)

--- a/pkg/scheduler/framework/fake/listers.go
+++ b/pkg/scheduler/framework/fake/listers.go
@@ -252,10 +252,10 @@ func (nodes NodeInfoLister) HavePodsWithRequiredAntiAffinityList() ([]*framework
 }
 
 // NewNodeInfoLister create a new fake NodeInfoLister from a slice of v1.Nodes.
-func NewNodeInfoLister(nodes []*v1.Node) framework.NodeInfoLister {
+func NewNodeInfoLister(nodes []*v1.Node, rnq framework.ResourceNameQualifier) framework.NodeInfoLister {
 	nodeInfoList := make([]*framework.NodeInfo, len(nodes))
 	for _, node := range nodes {
-		nodeInfo := framework.NewNodeInfo()
+		nodeInfo := framework.NewNodeInfo(rnq)
 		nodeInfo.SetNode(node)
 		nodeInfoList = append(nodeInfoList, nodeInfo)
 	}

--- a/pkg/scheduler/framework/fake/resourcename.go
+++ b/pkg/scheduler/framework/fake/resourcename.go
@@ -1,0 +1,73 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fake
+
+import (
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/kubernetes/pkg/scheduler/framework"
+)
+
+// ResourceNameQualifier implements ResourceNameQualifier interface
+// to inject explicit resource names of given kinds for testing purposes
+//
+// E.g.
+// &resourceNameQualifier{
+// 	ExtendedResourceNames: []v1.ResourceName{"scalar.test/scalar1"},
+// 	HugePageResourceNames: []v1.ResourceName{"hugepages-test"},
+// }
+//
+type ResourceNameQualifier struct {
+	ExtendedResourceNames         []v1.ResourceName
+	HugePageResourceNames         []v1.ResourceName
+	AttachableVolumeResourceNames []v1.ResourceName
+	PrefixedNativeResourceNames   []v1.ResourceName
+}
+
+func (rnq *ResourceNameQualifier) IsExtended(name v1.ResourceName) bool {
+	return inList(rnq.ExtendedResourceNames, name)
+}
+
+func (rnq *ResourceNameQualifier) IsHugePage(name v1.ResourceName) bool {
+	return inList(rnq.HugePageResourceNames, name)
+}
+
+func (rnq *ResourceNameQualifier) IsAttachableVolume(name v1.ResourceName) bool {
+	return inList(rnq.AttachableVolumeResourceNames, name)
+}
+
+func (rnq *ResourceNameQualifier) IsPrefixedNativeResource(name v1.ResourceName) bool {
+	return inList(rnq.PrefixedNativeResourceNames, name)
+}
+
+func inList(list []v1.ResourceName, item v1.ResourceName) bool {
+	for i := range list {
+		if list[i] == item {
+			return true
+		}
+	}
+	return false
+}
+
+var _ framework.ResourceNameQualifier = &ResourceNameQualifier{}
+
+func NewNodeInfoWithEmptyResourceNameQualifier() *framework.NodeInfo {
+	return framework.NewNodeInfo(&ResourceNameQualifier{})
+}
+
+func EmptyResourceNameQualifier() framework.ResourceNameQualifier {
+	return &ResourceNameQualifier{}
+}

--- a/pkg/scheduler/framework/interface.go
+++ b/pkg/scheduler/framework/interface.go
@@ -605,6 +605,9 @@ type Handle interface {
 
 	// Parallelizer returns a parallelizer holding parallelism for scheduler.
 	Parallelizer() parallelize.Parallelizer
+
+	// ResourceNameQualifier returns resource name qualifier for qualifying resource names
+	ResourceNameQualifier() ResourceNameQualifier
 }
 
 // PostFilterResult wraps needed info for scheduler framework to act upon PostFilter phase.
@@ -639,4 +642,13 @@ type PluginsRunner interface {
 	RunPreFilterExtensionAddPod(ctx context.Context, state *CycleState, podToSchedule *v1.Pod, podInfoToAdd *PodInfo, nodeInfo *NodeInfo) *Status
 	// RunPreFilterExtensionRemovePod calls the RemovePod interface for the set of configured PreFilter plugins.
 	RunPreFilterExtensionRemovePod(ctx context.Context, state *CycleState, podToSchedule *v1.Pod, podInfoToRemove *PodInfo, nodeInfo *NodeInfo) *Status
+}
+
+// ResourceNameQualifier abstracts helpers qualifying
+// of what kind a resource name is.
+type ResourceNameQualifier interface {
+	IsExtended(name v1.ResourceName) bool
+	IsHugePage(name v1.ResourceName) bool
+	IsAttachableVolume(name v1.ResourceName) bool
+	IsPrefixedNativeResource(name v1.ResourceName) bool
 }

--- a/pkg/scheduler/framework/plugins/imagelocality/image_locality_test.go
+++ b/pkg/scheduler/framework/plugins/imagelocality/image_locality_test.go
@@ -26,6 +26,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/kubernetes/pkg/scheduler/framework"
+	fakeframework "k8s.io/kubernetes/pkg/scheduler/framework/fake"
 	"k8s.io/kubernetes/pkg/scheduler/framework/runtime"
 	"k8s.io/kubernetes/pkg/scheduler/internal/cache"
 )
@@ -331,7 +332,7 @@ func TestImageLocalityPriority(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			snapshot := cache.NewSnapshot(nil, test.nodes)
+			snapshot := cache.NewSnapshot(nil, test.nodes, fakeframework.NewNodeInfoWithEmptyResourceNameQualifier)
 
 			state := framework.NewCycleState()
 			fh, _ := runtime.NewFramework(nil, nil, runtime.WithSnapshotSharedLister(snapshot))

--- a/pkg/scheduler/framework/plugins/interpodaffinity/filtering_test.go
+++ b/pkg/scheduler/framework/plugins/interpodaffinity/filtering_test.go
@@ -23,11 +23,12 @@ import (
 	"strings"
 	"testing"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/kubernetes/pkg/scheduler/apis/config"
 	"k8s.io/kubernetes/pkg/scheduler/framework"
+	fakeframework "k8s.io/kubernetes/pkg/scheduler/framework/fake"
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/feature"
 	plugintesting "k8s.io/kubernetes/pkg/scheduler/framework/plugins/testing"
 	"k8s.io/kubernetes/pkg/scheduler/internal/cache"
@@ -1010,7 +1011,7 @@ func TestRequiredAffinitySingleNode(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			ctx := context.Background()
-			snapshot := cache.NewSnapshot(test.pods, []*v1.Node{test.node})
+			snapshot := cache.NewSnapshot(test.pods, []*v1.Node{test.node}, fakeframework.NewNodeInfoWithEmptyResourceNameQualifier)
 			n := func(plArgs runtime.Object, fh framework.Handle) (framework.Plugin, error) {
 				return New(plArgs, fh, feature.Features{
 					EnablePodAffinityNamespaceSelector: !test.disableNSSelector,
@@ -1904,7 +1905,7 @@ func TestRequiredAffinityMultipleNodes(t *testing.T) {
 	for indexTest, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			ctx := context.Background()
-			snapshot := cache.NewSnapshot(test.pods, test.nodes)
+			snapshot := cache.NewSnapshot(test.pods, test.nodes, fakeframework.NewNodeInfoWithEmptyResourceNameQualifier)
 			n := func(plArgs runtime.Object, fh framework.Handle) (framework.Plugin, error) {
 				return New(plArgs, fh, feature.Features{})
 			}
@@ -1930,7 +1931,7 @@ func TestRequiredAffinityMultipleNodes(t *testing.T) {
 
 func TestPreFilterDisabled(t *testing.T) {
 	pod := &v1.Pod{}
-	nodeInfo := framework.NewNodeInfo()
+	nodeInfo := fakeframework.NewNodeInfoWithEmptyResourceNameQualifier()
 	node := v1.Node{}
 	nodeInfo.SetNode(&node)
 	n := func(plArgs runtime.Object, fh framework.Handle) (framework.Plugin, error) {
@@ -2203,7 +2204,7 @@ func TestPreFilterStateAddRemovePod(t *testing.T) {
 			ctx := context.Background()
 			// getMeta creates predicate meta data given the list of pods.
 			getState := func(pods []*v1.Pod) (*InterPodAffinity, *framework.CycleState, *preFilterState, *cache.Snapshot) {
-				snapshot := cache.NewSnapshot(pods, test.nodes)
+				snapshot := cache.NewSnapshot(pods, test.nodes, fakeframework.NewNodeInfoWithEmptyResourceNameQualifier)
 				n := func(plArgs runtime.Object, fh framework.Handle) (framework.Plugin, error) {
 					return New(plArgs, fh, feature.Features{})
 				}
@@ -2488,7 +2489,7 @@ func TestGetTPMapMatchingIncomingAffinityAntiAffinity(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			snapshot := cache.NewSnapshot(tt.existingPods, tt.nodes)
+			snapshot := cache.NewSnapshot(tt.existingPods, tt.nodes, fakeframework.NewNodeInfoWithEmptyResourceNameQualifier)
 			l, _ := snapshot.NodeInfos().List()
 			n := func(plArgs runtime.Object, fh framework.Handle) (framework.Plugin, error) {
 				return New(plArgs, fh, feature.Features{})

--- a/pkg/scheduler/framework/plugins/interpodaffinity/scoring_test.go
+++ b/pkg/scheduler/framework/plugins/interpodaffinity/scoring_test.go
@@ -22,11 +22,12 @@ import (
 	"strings"
 	"testing"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/kubernetes/pkg/scheduler/apis/config"
 	"k8s.io/kubernetes/pkg/scheduler/framework"
+	fakeframework "k8s.io/kubernetes/pkg/scheduler/framework/fake"
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/feature"
 	plugintesting "k8s.io/kubernetes/pkg/scheduler/framework/plugins/testing"
 	"k8s.io/kubernetes/pkg/scheduler/internal/cache"
@@ -748,7 +749,7 @@ func TestPreferredAffinity(t *testing.T) {
 					EnablePodAffinityNamespaceSelector: !test.disableNSSelector,
 				})
 			}
-			p := plugintesting.SetupPluginWithInformers(ctx, t, n, &config.InterPodAffinityArgs{HardPodAffinityWeight: 1}, cache.NewSnapshot(test.pods, test.nodes), namespaces)
+			p := plugintesting.SetupPluginWithInformers(ctx, t, n, &config.InterPodAffinityArgs{HardPodAffinityWeight: 1}, cache.NewSnapshot(test.pods, test.nodes, fakeframework.NewNodeInfoWithEmptyResourceNameQualifier), namespaces)
 			status := p.(framework.PreScorePlugin).PreScore(ctx, state, test.pod, test.nodes)
 			if !status.IsSuccess() {
 				if !strings.Contains(status.Message(), test.wantStatus.Message()) {
@@ -914,7 +915,7 @@ func TestPreferredAffinityWithHardPodAffinitySymmetricWeight(t *testing.T) {
 					EnablePodAffinityNamespaceSelector: !test.disableNSSelector,
 				})
 			}
-			p := plugintesting.SetupPluginWithInformers(ctx, t, n, &config.InterPodAffinityArgs{HardPodAffinityWeight: test.hardPodAffinityWeight}, cache.NewSnapshot(test.pods, test.nodes), namespaces)
+			p := plugintesting.SetupPluginWithInformers(ctx, t, n, &config.InterPodAffinityArgs{HardPodAffinityWeight: test.hardPodAffinityWeight}, cache.NewSnapshot(test.pods, test.nodes, fakeframework.NewNodeInfoWithEmptyResourceNameQualifier), namespaces)
 			status := p.(framework.PreScorePlugin).PreScore(ctx, state, test.pod, test.nodes)
 			if !status.IsSuccess() {
 				t.Errorf("unexpected error: %v", status)

--- a/pkg/scheduler/framework/plugins/nodeaffinity/node_affinity_test.go
+++ b/pkg/scheduler/framework/plugins/nodeaffinity/node_affinity_test.go
@@ -26,6 +26,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/kubernetes/pkg/scheduler/apis/config"
 	"k8s.io/kubernetes/pkg/scheduler/framework"
+	fakeframework "k8s.io/kubernetes/pkg/scheduler/framework/fake"
 	"k8s.io/kubernetes/pkg/scheduler/framework/runtime"
 	"k8s.io/kubernetes/pkg/scheduler/internal/cache"
 )
@@ -844,7 +845,7 @@ func TestNodeAffinity(t *testing.T) {
 				Name:   test.nodeName,
 				Labels: test.labels,
 			}}
-			nodeInfo := framework.NewNodeInfo()
+			nodeInfo := fakeframework.NewNodeInfoWithEmptyResourceNameQualifier()
 			nodeInfo.SetNode(&node)
 
 			p, err := New(&test.args, nil)
@@ -1071,7 +1072,7 @@ func TestNodeAffinityPriority(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			state := framework.NewCycleState()
-			fh, _ := runtime.NewFramework(nil, nil, runtime.WithSnapshotSharedLister(cache.NewSnapshot(nil, test.nodes)))
+			fh, _ := runtime.NewFramework(nil, nil, runtime.WithSnapshotSharedLister(cache.NewSnapshot(nil, test.nodes, fakeframework.NewNodeInfoWithEmptyResourceNameQualifier)))
 			p, err := New(&test.args, fh)
 			if err != nil {
 				t.Fatalf("Creating plugin: %v", err)

--- a/pkg/scheduler/framework/plugins/nodelabel/node_label_test.go
+++ b/pkg/scheduler/framework/plugins/nodelabel/node_label_test.go
@@ -24,6 +24,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/kubernetes/pkg/scheduler/apis/config"
 	"k8s.io/kubernetes/pkg/scheduler/framework"
+	fakeframework "k8s.io/kubernetes/pkg/scheduler/framework/fake"
 	"k8s.io/kubernetes/pkg/scheduler/framework/runtime"
 	"k8s.io/kubernetes/pkg/scheduler/internal/cache"
 )
@@ -120,7 +121,7 @@ func TestNodeLabelFilter(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			node := v1.Node{ObjectMeta: metav1.ObjectMeta{Labels: label}}
-			nodeInfo := framework.NewNodeInfo()
+			nodeInfo := fakeframework.NewNodeInfoWithEmptyResourceNameQualifier()
 			nodeInfo.SetNode(&node)
 
 			p, err := New(&test.args, nil)
@@ -247,7 +248,7 @@ func TestNodeLabelScore(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			state := framework.NewCycleState()
 			node := &v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "machine1", Labels: map[string]string{"foo": "", "bar": ""}}}
-			fh, _ := runtime.NewFramework(nil, nil, runtime.WithSnapshotSharedLister(cache.NewSnapshot(nil, []*v1.Node{node})))
+			fh, _ := runtime.NewFramework(nil, nil, runtime.WithSnapshotSharedLister(cache.NewSnapshot(nil, []*v1.Node{node}, fakeframework.NewNodeInfoWithEmptyResourceNameQualifier)))
 			p, err := New(&test.args, fh)
 			if err != nil {
 				t.Fatalf("Failed to create plugin: %+v", err)
@@ -267,7 +268,7 @@ func TestNodeLabelScore(t *testing.T) {
 func TestNodeLabelFilterWithoutNode(t *testing.T) {
 	var pod *v1.Pod
 	t.Run("node does not exist", func(t *testing.T) {
-		nodeInfo := framework.NewNodeInfo()
+		nodeInfo := fakeframework.NewNodeInfoWithEmptyResourceNameQualifier()
 		p, err := New(&config.NodeLabelArgs{}, nil)
 		if err != nil {
 			t.Fatalf("Failed to create plugin: %v", err)

--- a/pkg/scheduler/framework/plugins/nodename/node_name_test.go
+++ b/pkg/scheduler/framework/plugins/nodename/node_name_test.go
@@ -24,6 +24,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/kubernetes/pkg/scheduler/framework"
+	fakeframework "k8s.io/kubernetes/pkg/scheduler/framework/fake"
 )
 
 func TestNodeName(t *testing.T) {
@@ -69,7 +70,7 @@ func TestNodeName(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			nodeInfo := framework.NewNodeInfo()
+			nodeInfo := fakeframework.NewNodeInfoWithEmptyResourceNameQualifier()
 			nodeInfo.SetNode(test.node)
 
 			p, _ := New(nil, nil)

--- a/pkg/scheduler/framework/plugins/nodeports/node_ports_test.go
+++ b/pkg/scheduler/framework/plugins/nodeports/node_ports_test.go
@@ -27,7 +27,16 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/diff"
 	"k8s.io/kubernetes/pkg/scheduler/framework"
+	fakeframework "k8s.io/kubernetes/pkg/scheduler/framework/fake"
 )
+
+func newNodeInfoWithPods(pods ...*v1.Pod) *framework.NodeInfo {
+	ni := fakeframework.NewNodeInfoWithEmptyResourceNameQualifier()
+	for _, pod := range pods {
+		ni.AddPod(pod)
+	}
+	return ni
+}
 
 func newPod(host string, hostPortInfos ...string) *v1.Pod {
 	networkPorts := []v1.ContainerPort{}
@@ -62,85 +71,85 @@ func TestNodePorts(t *testing.T) {
 	}{
 		{
 			pod:      &v1.Pod{},
-			nodeInfo: framework.NewNodeInfo(),
+			nodeInfo: fakeframework.NewNodeInfoWithEmptyResourceNameQualifier(),
 			name:     "nothing running",
 		},
 		{
 			pod: newPod("m1", "UDP/127.0.0.1/8080"),
-			nodeInfo: framework.NewNodeInfo(
+			nodeInfo: newNodeInfoWithPods(
 				newPod("m1", "UDP/127.0.0.1/9090")),
 			name: "other port",
 		},
 		{
 			pod: newPod("m1", "UDP/127.0.0.1/8080"),
-			nodeInfo: framework.NewNodeInfo(
+			nodeInfo: newNodeInfoWithPods(
 				newPod("m1", "UDP/127.0.0.1/8080")),
 			name:       "same udp port",
 			wantStatus: framework.NewStatus(framework.Unschedulable, ErrReason),
 		},
 		{
 			pod: newPod("m1", "TCP/127.0.0.1/8080"),
-			nodeInfo: framework.NewNodeInfo(
+			nodeInfo: newNodeInfoWithPods(
 				newPod("m1", "TCP/127.0.0.1/8080")),
 			name:       "same tcp port",
 			wantStatus: framework.NewStatus(framework.Unschedulable, ErrReason),
 		},
 		{
 			pod: newPod("m1", "TCP/127.0.0.1/8080"),
-			nodeInfo: framework.NewNodeInfo(
+			nodeInfo: newNodeInfoWithPods(
 				newPod("m1", "TCP/127.0.0.2/8080")),
 			name: "different host ip",
 		},
 		{
 			pod: newPod("m1", "UDP/127.0.0.1/8080"),
-			nodeInfo: framework.NewNodeInfo(
+			nodeInfo: newNodeInfoWithPods(
 				newPod("m1", "TCP/127.0.0.1/8080")),
 			name: "different protocol",
 		},
 		{
 			pod: newPod("m1", "UDP/127.0.0.1/8000", "UDP/127.0.0.1/8080"),
-			nodeInfo: framework.NewNodeInfo(
+			nodeInfo: newNodeInfoWithPods(
 				newPod("m1", "UDP/127.0.0.1/8080")),
 			name:       "second udp port conflict",
 			wantStatus: framework.NewStatus(framework.Unschedulable, ErrReason),
 		},
 		{
 			pod: newPod("m1", "TCP/127.0.0.1/8001", "UDP/127.0.0.1/8080"),
-			nodeInfo: framework.NewNodeInfo(
+			nodeInfo: newNodeInfoWithPods(
 				newPod("m1", "TCP/127.0.0.1/8001", "UDP/127.0.0.1/8081")),
 			name:       "first tcp port conflict",
 			wantStatus: framework.NewStatus(framework.Unschedulable, ErrReason),
 		},
 		{
 			pod: newPod("m1", "TCP/0.0.0.0/8001"),
-			nodeInfo: framework.NewNodeInfo(
+			nodeInfo: newNodeInfoWithPods(
 				newPod("m1", "TCP/127.0.0.1/8001")),
 			name:       "first tcp port conflict due to 0.0.0.0 hostIP",
 			wantStatus: framework.NewStatus(framework.Unschedulable, ErrReason),
 		},
 		{
 			pod: newPod("m1", "TCP/10.0.10.10/8001", "TCP/0.0.0.0/8001"),
-			nodeInfo: framework.NewNodeInfo(
+			nodeInfo: newNodeInfoWithPods(
 				newPod("m1", "TCP/127.0.0.1/8001")),
 			name:       "TCP hostPort conflict due to 0.0.0.0 hostIP",
 			wantStatus: framework.NewStatus(framework.Unschedulable, ErrReason),
 		},
 		{
 			pod: newPod("m1", "TCP/127.0.0.1/8001"),
-			nodeInfo: framework.NewNodeInfo(
+			nodeInfo: newNodeInfoWithPods(
 				newPod("m1", "TCP/0.0.0.0/8001")),
 			name:       "second tcp port conflict to 0.0.0.0 hostIP",
 			wantStatus: framework.NewStatus(framework.Unschedulable, ErrReason),
 		},
 		{
 			pod: newPod("m1", "UDP/127.0.0.1/8001"),
-			nodeInfo: framework.NewNodeInfo(
+			nodeInfo: newNodeInfoWithPods(
 				newPod("m1", "TCP/0.0.0.0/8001")),
 			name: "second different protocol",
 		},
 		{
 			pod: newPod("m1", "UDP/127.0.0.1/8001"),
-			nodeInfo: framework.NewNodeInfo(
+			nodeInfo: newNodeInfoWithPods(
 				newPod("m1", "TCP/0.0.0.0/8001", "UDP/0.0.0.0/8001")),
 			name:       "UDP hostPort conflict due to 0.0.0.0 hostIP",
 			wantStatus: framework.NewStatus(framework.Unschedulable, ErrReason),
@@ -165,7 +174,7 @@ func TestNodePorts(t *testing.T) {
 
 func TestPreFilterDisabled(t *testing.T) {
 	pod := &v1.Pod{}
-	nodeInfo := framework.NewNodeInfo()
+	nodeInfo := fakeframework.NewNodeInfoWithEmptyResourceNameQualifier()
 	node := v1.Node{}
 	nodeInfo.SetNode(&node)
 	p, _ := New(nil, nil)

--- a/pkg/scheduler/framework/plugins/nodepreferavoidpods/node_prefer_avoid_pods_test.go
+++ b/pkg/scheduler/framework/plugins/nodepreferavoidpods/node_prefer_avoid_pods_test.go
@@ -24,6 +24,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/kubernetes/pkg/scheduler/framework"
+	fakeframework "k8s.io/kubernetes/pkg/scheduler/framework/fake"
 	"k8s.io/kubernetes/pkg/scheduler/framework/runtime"
 	"k8s.io/kubernetes/pkg/scheduler/internal/cache"
 )
@@ -144,7 +145,7 @@ func TestNodePreferAvoidPods(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			state := framework.NewCycleState()
-			fh, _ := runtime.NewFramework(nil, nil, runtime.WithSnapshotSharedLister(cache.NewSnapshot(nil, test.nodes)))
+			fh, _ := runtime.NewFramework(nil, nil, runtime.WithSnapshotSharedLister(cache.NewSnapshot(nil, test.nodes, fakeframework.NewNodeInfoWithEmptyResourceNameQualifier)))
 			p, _ := New(nil, fh)
 			var gotList framework.NodeScoreList
 			for _, n := range test.nodes {

--- a/pkg/scheduler/framework/plugins/noderesources/balanced_allocation_test.go
+++ b/pkg/scheduler/framework/plugins/noderesources/balanced_allocation_test.go
@@ -28,6 +28,7 @@ import (
 	featuregatetesting "k8s.io/component-base/featuregate/testing"
 	"k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/pkg/scheduler/framework"
+	fakeframework "k8s.io/kubernetes/pkg/scheduler/framework/fake"
 	"k8s.io/kubernetes/pkg/scheduler/framework/runtime"
 	"k8s.io/kubernetes/pkg/scheduler/internal/cache"
 )
@@ -380,7 +381,7 @@ func TestNodeResourcesBalancedAllocation(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			snapshot := cache.NewSnapshot(test.pods, test.nodes)
+			snapshot := cache.NewSnapshot(test.pods, test.nodes, fakeframework.NewNodeInfoWithEmptyResourceNameQualifier)
 			if len(test.pod.Spec.Volumes) > 0 {
 				maxVolumes := 5
 				nodeInfoList, _ := snapshot.NodeInfos().List()

--- a/pkg/scheduler/framework/plugins/noderesources/fit_test.go
+++ b/pkg/scheduler/framework/plugins/noderesources/fit_test.go
@@ -30,6 +30,8 @@ import (
 	"k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/pkg/scheduler/apis/config"
 	"k8s.io/kubernetes/pkg/scheduler/framework"
+	fakeframework "k8s.io/kubernetes/pkg/scheduler/framework/fake"
+	frameworkruntime "k8s.io/kubernetes/pkg/scheduler/framework/runtime"
 )
 
 var (
@@ -39,6 +41,22 @@ var (
 	kubernetesIOResourceB = v1.ResourceName("subdomain.kubernetes.io/something")
 	hugePageResourceA     = v1.ResourceName(v1.ResourceHugePagesPrefix + "2Mi")
 )
+
+func getFakeResourceNameQualifier() framework.ResourceNameQualifier {
+	return &fakeframework.ResourceNameQualifier{
+		ExtendedResourceNames: []v1.ResourceName{
+			extendedResourceA,
+			extendedResourceB,
+			kubernetesIOResourceA,
+			kubernetesIOResourceB,
+			v1.ResourceName("intel.com/foo"),
+			v1.ResourceName("intel.com/bar"),
+		},
+		HugePageResourceNames: []v1.ResourceName{
+			hugePageResourceA,
+		},
+	}
+}
 
 func makeResources(milliCPU, memory, pods, extendedA, storage, hugePageA int64) v1.NodeResources {
 	return v1.NodeResources{
@@ -105,6 +123,14 @@ func getErrReason(rn v1.ResourceName) string {
 	return fmt.Sprintf("Insufficient %v", rn)
 }
 
+func newNodeInfoWithPods(pods ...*v1.Pod) *framework.NodeInfo {
+	ni := framework.NewNodeInfo(getFakeResourceNameQualifier())
+	for _, pod := range pods {
+		ni.AddPod(pod)
+	}
+	return ni
+}
+
 func TestEnoughRequests(t *testing.T) {
 	enoughPodsTests := []struct {
 		pod                       *v1.Pod
@@ -116,14 +142,14 @@ func TestEnoughRequests(t *testing.T) {
 	}{
 		{
 			pod: &v1.Pod{},
-			nodeInfo: framework.NewNodeInfo(
+			nodeInfo: newNodeInfoWithPods(
 				newResourcePod(framework.Resource{MilliCPU: 10, Memory: 20})),
 			name:                      "no resources requested always fits",
 			wantInsufficientResources: []InsufficientResource{},
 		},
 		{
 			pod: newResourcePod(framework.Resource{MilliCPU: 1, Memory: 1}),
-			nodeInfo: framework.NewNodeInfo(
+			nodeInfo: newNodeInfoWithPods(
 				newResourcePod(framework.Resource{MilliCPU: 10, Memory: 20})),
 			name:                      "too many resources fails",
 			wantStatus:                framework.NewStatus(framework.Unschedulable, getErrReason(v1.ResourceCPU), getErrReason(v1.ResourceMemory)),
@@ -131,7 +157,7 @@ func TestEnoughRequests(t *testing.T) {
 		},
 		{
 			pod: newResourceInitPod(newResourcePod(framework.Resource{MilliCPU: 1, Memory: 1}), framework.Resource{MilliCPU: 3, Memory: 1}),
-			nodeInfo: framework.NewNodeInfo(
+			nodeInfo: newNodeInfoWithPods(
 				newResourcePod(framework.Resource{MilliCPU: 8, Memory: 19})),
 			name:                      "too many resources fails due to init container cpu",
 			wantStatus:                framework.NewStatus(framework.Unschedulable, getErrReason(v1.ResourceCPU)),
@@ -139,7 +165,7 @@ func TestEnoughRequests(t *testing.T) {
 		},
 		{
 			pod: newResourceInitPod(newResourcePod(framework.Resource{MilliCPU: 1, Memory: 1}), framework.Resource{MilliCPU: 3, Memory: 1}, framework.Resource{MilliCPU: 2, Memory: 1}),
-			nodeInfo: framework.NewNodeInfo(
+			nodeInfo: newNodeInfoWithPods(
 				newResourcePod(framework.Resource{MilliCPU: 8, Memory: 19})),
 			name:                      "too many resources fails due to highest init container cpu",
 			wantStatus:                framework.NewStatus(framework.Unschedulable, getErrReason(v1.ResourceCPU)),
@@ -147,7 +173,7 @@ func TestEnoughRequests(t *testing.T) {
 		},
 		{
 			pod: newResourceInitPod(newResourcePod(framework.Resource{MilliCPU: 1, Memory: 1}), framework.Resource{MilliCPU: 1, Memory: 3}),
-			nodeInfo: framework.NewNodeInfo(
+			nodeInfo: newNodeInfoWithPods(
 				newResourcePod(framework.Resource{MilliCPU: 9, Memory: 19})),
 			name:                      "too many resources fails due to init container memory",
 			wantStatus:                framework.NewStatus(framework.Unschedulable, getErrReason(v1.ResourceMemory)),
@@ -155,7 +181,7 @@ func TestEnoughRequests(t *testing.T) {
 		},
 		{
 			pod: newResourceInitPod(newResourcePod(framework.Resource{MilliCPU: 1, Memory: 1}), framework.Resource{MilliCPU: 1, Memory: 3}, framework.Resource{MilliCPU: 1, Memory: 2}),
-			nodeInfo: framework.NewNodeInfo(
+			nodeInfo: newNodeInfoWithPods(
 				newResourcePod(framework.Resource{MilliCPU: 9, Memory: 19})),
 			name:                      "too many resources fails due to highest init container memory",
 			wantStatus:                framework.NewStatus(framework.Unschedulable, getErrReason(v1.ResourceMemory)),
@@ -163,28 +189,28 @@ func TestEnoughRequests(t *testing.T) {
 		},
 		{
 			pod: newResourceInitPod(newResourcePod(framework.Resource{MilliCPU: 1, Memory: 1}), framework.Resource{MilliCPU: 1, Memory: 1}),
-			nodeInfo: framework.NewNodeInfo(
+			nodeInfo: newNodeInfoWithPods(
 				newResourcePod(framework.Resource{MilliCPU: 9, Memory: 19})),
 			name:                      "init container fits because it's the max, not sum, of containers and init containers",
 			wantInsufficientResources: []InsufficientResource{},
 		},
 		{
 			pod: newResourceInitPod(newResourcePod(framework.Resource{MilliCPU: 1, Memory: 1}), framework.Resource{MilliCPU: 1, Memory: 1}, framework.Resource{MilliCPU: 1, Memory: 1}),
-			nodeInfo: framework.NewNodeInfo(
+			nodeInfo: newNodeInfoWithPods(
 				newResourcePod(framework.Resource{MilliCPU: 9, Memory: 19})),
 			name:                      "multiple init containers fit because it's the max, not sum, of containers and init containers",
 			wantInsufficientResources: []InsufficientResource{},
 		},
 		{
 			pod: newResourcePod(framework.Resource{MilliCPU: 1, Memory: 1}),
-			nodeInfo: framework.NewNodeInfo(
+			nodeInfo: newNodeInfoWithPods(
 				newResourcePod(framework.Resource{MilliCPU: 5, Memory: 5})),
 			name:                      "both resources fit",
 			wantInsufficientResources: []InsufficientResource{},
 		},
 		{
 			pod: newResourcePod(framework.Resource{MilliCPU: 2, Memory: 1}),
-			nodeInfo: framework.NewNodeInfo(
+			nodeInfo: newNodeInfoWithPods(
 				newResourcePod(framework.Resource{MilliCPU: 9, Memory: 5})),
 			name:                      "one resource memory fits",
 			wantStatus:                framework.NewStatus(framework.Unschedulable, getErrReason(v1.ResourceCPU)),
@@ -192,7 +218,7 @@ func TestEnoughRequests(t *testing.T) {
 		},
 		{
 			pod: newResourcePod(framework.Resource{MilliCPU: 1, Memory: 2}),
-			nodeInfo: framework.NewNodeInfo(
+			nodeInfo: newNodeInfoWithPods(
 				newResourcePod(framework.Resource{MilliCPU: 5, Memory: 19})),
 			name:                      "one resource cpu fits",
 			wantStatus:                framework.NewStatus(framework.Unschedulable, getErrReason(v1.ResourceMemory)),
@@ -200,34 +226,34 @@ func TestEnoughRequests(t *testing.T) {
 		},
 		{
 			pod: newResourcePod(framework.Resource{MilliCPU: 5, Memory: 1}),
-			nodeInfo: framework.NewNodeInfo(
+			nodeInfo: newNodeInfoWithPods(
 				newResourcePod(framework.Resource{MilliCPU: 5, Memory: 19})),
 			name:                      "equal edge case",
 			wantInsufficientResources: []InsufficientResource{},
 		},
 		{
 			pod: newResourceInitPod(newResourcePod(framework.Resource{MilliCPU: 4, Memory: 1}), framework.Resource{MilliCPU: 5, Memory: 1}),
-			nodeInfo: framework.NewNodeInfo(
+			nodeInfo: newNodeInfoWithPods(
 				newResourcePod(framework.Resource{MilliCPU: 5, Memory: 19})),
 			name:                      "equal edge case for init container",
 			wantInsufficientResources: []InsufficientResource{},
 		},
 		{
 			pod:                       newResourcePod(framework.Resource{ScalarResources: map[v1.ResourceName]int64{extendedResourceA: 1}}),
-			nodeInfo:                  framework.NewNodeInfo(newResourcePod(framework.Resource{})),
+			nodeInfo:                  newNodeInfoWithPods(newResourcePod(framework.Resource{})),
 			name:                      "extended resource fits",
 			wantInsufficientResources: []InsufficientResource{},
 		},
 		{
 			pod:                       newResourceInitPod(newResourcePod(framework.Resource{}), framework.Resource{ScalarResources: map[v1.ResourceName]int64{extendedResourceA: 1}}),
-			nodeInfo:                  framework.NewNodeInfo(newResourcePod(framework.Resource{})),
+			nodeInfo:                  newNodeInfoWithPods(newResourcePod(framework.Resource{})),
 			name:                      "extended resource fits for init container",
 			wantInsufficientResources: []InsufficientResource{},
 		},
 		{
 			pod: newResourcePod(
 				framework.Resource{MilliCPU: 1, Memory: 1, ScalarResources: map[v1.ResourceName]int64{extendedResourceA: 10}}),
-			nodeInfo: framework.NewNodeInfo(
+			nodeInfo: newNodeInfoWithPods(
 				newResourcePod(framework.Resource{MilliCPU: 0, Memory: 0, ScalarResources: map[v1.ResourceName]int64{extendedResourceA: 0}})),
 			name:                      "extended resource capacity enforced",
 			wantStatus:                framework.NewStatus(framework.Unschedulable, getErrReason(extendedResourceA)),
@@ -236,7 +262,7 @@ func TestEnoughRequests(t *testing.T) {
 		{
 			pod: newResourceInitPod(newResourcePod(framework.Resource{}),
 				framework.Resource{MilliCPU: 1, Memory: 1, ScalarResources: map[v1.ResourceName]int64{extendedResourceA: 10}}),
-			nodeInfo: framework.NewNodeInfo(
+			nodeInfo: newNodeInfoWithPods(
 				newResourcePod(framework.Resource{MilliCPU: 0, Memory: 0, ScalarResources: map[v1.ResourceName]int64{extendedResourceA: 0}})),
 			name:                      "extended resource capacity enforced for init container",
 			wantStatus:                framework.NewStatus(framework.Unschedulable, getErrReason(extendedResourceA)),
@@ -245,7 +271,7 @@ func TestEnoughRequests(t *testing.T) {
 		{
 			pod: newResourcePod(
 				framework.Resource{MilliCPU: 1, Memory: 1, ScalarResources: map[v1.ResourceName]int64{extendedResourceA: 1}}),
-			nodeInfo: framework.NewNodeInfo(
+			nodeInfo: newNodeInfoWithPods(
 				newResourcePod(framework.Resource{MilliCPU: 0, Memory: 0, ScalarResources: map[v1.ResourceName]int64{extendedResourceA: 5}})),
 			name:                      "extended resource allocatable enforced",
 			wantStatus:                framework.NewStatus(framework.Unschedulable, getErrReason(extendedResourceA)),
@@ -254,7 +280,7 @@ func TestEnoughRequests(t *testing.T) {
 		{
 			pod: newResourceInitPod(newResourcePod(framework.Resource{}),
 				framework.Resource{MilliCPU: 1, Memory: 1, ScalarResources: map[v1.ResourceName]int64{extendedResourceA: 1}}),
-			nodeInfo: framework.NewNodeInfo(
+			nodeInfo: newNodeInfoWithPods(
 				newResourcePod(framework.Resource{MilliCPU: 0, Memory: 0, ScalarResources: map[v1.ResourceName]int64{extendedResourceA: 5}})),
 			name:                      "extended resource allocatable enforced for init container",
 			wantStatus:                framework.NewStatus(framework.Unschedulable, getErrReason(extendedResourceA)),
@@ -264,7 +290,7 @@ func TestEnoughRequests(t *testing.T) {
 			pod: newResourcePod(
 				framework.Resource{MilliCPU: 1, Memory: 1, ScalarResources: map[v1.ResourceName]int64{extendedResourceA: 3}},
 				framework.Resource{MilliCPU: 1, Memory: 1, ScalarResources: map[v1.ResourceName]int64{extendedResourceA: 3}}),
-			nodeInfo: framework.NewNodeInfo(
+			nodeInfo: newNodeInfoWithPods(
 				newResourcePod(framework.Resource{MilliCPU: 0, Memory: 0, ScalarResources: map[v1.ResourceName]int64{extendedResourceA: 2}})),
 			name:                      "extended resource allocatable enforced for multiple containers",
 			wantStatus:                framework.NewStatus(framework.Unschedulable, getErrReason(extendedResourceA)),
@@ -274,7 +300,7 @@ func TestEnoughRequests(t *testing.T) {
 			pod: newResourceInitPod(newResourcePod(framework.Resource{}),
 				framework.Resource{MilliCPU: 1, Memory: 1, ScalarResources: map[v1.ResourceName]int64{extendedResourceA: 3}},
 				framework.Resource{MilliCPU: 1, Memory: 1, ScalarResources: map[v1.ResourceName]int64{extendedResourceA: 3}}),
-			nodeInfo: framework.NewNodeInfo(
+			nodeInfo: newNodeInfoWithPods(
 				newResourcePod(framework.Resource{MilliCPU: 0, Memory: 0, ScalarResources: map[v1.ResourceName]int64{extendedResourceA: 2}})),
 			name:                      "extended resource allocatable admits multiple init containers",
 			wantInsufficientResources: []InsufficientResource{},
@@ -283,7 +309,7 @@ func TestEnoughRequests(t *testing.T) {
 			pod: newResourceInitPod(newResourcePod(framework.Resource{}),
 				framework.Resource{MilliCPU: 1, Memory: 1, ScalarResources: map[v1.ResourceName]int64{extendedResourceA: 6}},
 				framework.Resource{MilliCPU: 1, Memory: 1, ScalarResources: map[v1.ResourceName]int64{extendedResourceA: 3}}),
-			nodeInfo: framework.NewNodeInfo(
+			nodeInfo: newNodeInfoWithPods(
 				newResourcePod(framework.Resource{MilliCPU: 0, Memory: 0, ScalarResources: map[v1.ResourceName]int64{extendedResourceA: 2}})),
 			name:                      "extended resource allocatable enforced for multiple init containers",
 			wantStatus:                framework.NewStatus(framework.Unschedulable, getErrReason(extendedResourceA)),
@@ -292,7 +318,7 @@ func TestEnoughRequests(t *testing.T) {
 		{
 			pod: newResourcePod(
 				framework.Resource{MilliCPU: 1, Memory: 1, ScalarResources: map[v1.ResourceName]int64{extendedResourceB: 1}}),
-			nodeInfo: framework.NewNodeInfo(
+			nodeInfo: newNodeInfoWithPods(
 				newResourcePod(framework.Resource{MilliCPU: 0, Memory: 0})),
 			name:                      "extended resource allocatable enforced for unknown resource",
 			wantStatus:                framework.NewStatus(framework.Unschedulable, getErrReason(extendedResourceB)),
@@ -301,7 +327,7 @@ func TestEnoughRequests(t *testing.T) {
 		{
 			pod: newResourceInitPod(newResourcePod(framework.Resource{}),
 				framework.Resource{MilliCPU: 1, Memory: 1, ScalarResources: map[v1.ResourceName]int64{extendedResourceB: 1}}),
-			nodeInfo: framework.NewNodeInfo(
+			nodeInfo: newNodeInfoWithPods(
 				newResourcePod(framework.Resource{MilliCPU: 0, Memory: 0})),
 			name:                      "extended resource allocatable enforced for unknown resource for init container",
 			wantStatus:                framework.NewStatus(framework.Unschedulable, getErrReason(extendedResourceB)),
@@ -310,7 +336,7 @@ func TestEnoughRequests(t *testing.T) {
 		{
 			pod: newResourcePod(
 				framework.Resource{MilliCPU: 1, Memory: 1, ScalarResources: map[v1.ResourceName]int64{kubernetesIOResourceA: 10}}),
-			nodeInfo: framework.NewNodeInfo(
+			nodeInfo: newNodeInfoWithPods(
 				newResourcePod(framework.Resource{MilliCPU: 0, Memory: 0})),
 			name:                      "kubernetes.io resource capacity enforced",
 			wantStatus:                framework.NewStatus(framework.Unschedulable, getErrReason(kubernetesIOResourceA)),
@@ -319,7 +345,7 @@ func TestEnoughRequests(t *testing.T) {
 		{
 			pod: newResourceInitPod(newResourcePod(framework.Resource{}),
 				framework.Resource{MilliCPU: 1, Memory: 1, ScalarResources: map[v1.ResourceName]int64{kubernetesIOResourceB: 10}}),
-			nodeInfo: framework.NewNodeInfo(
+			nodeInfo: newNodeInfoWithPods(
 				newResourcePod(framework.Resource{MilliCPU: 0, Memory: 0})),
 			name:                      "kubernetes.io resource capacity enforced for init container",
 			wantStatus:                framework.NewStatus(framework.Unschedulable, getErrReason(kubernetesIOResourceB)),
@@ -328,7 +354,7 @@ func TestEnoughRequests(t *testing.T) {
 		{
 			pod: newResourcePod(
 				framework.Resource{MilliCPU: 1, Memory: 1, ScalarResources: map[v1.ResourceName]int64{hugePageResourceA: 10}}),
-			nodeInfo: framework.NewNodeInfo(
+			nodeInfo: newNodeInfoWithPods(
 				newResourcePod(framework.Resource{MilliCPU: 0, Memory: 0, ScalarResources: map[v1.ResourceName]int64{hugePageResourceA: 0}})),
 			name:                      "hugepages resource capacity enforced",
 			wantStatus:                framework.NewStatus(framework.Unschedulable, getErrReason(hugePageResourceA)),
@@ -337,7 +363,7 @@ func TestEnoughRequests(t *testing.T) {
 		{
 			pod: newResourceInitPod(newResourcePod(framework.Resource{}),
 				framework.Resource{MilliCPU: 1, Memory: 1, ScalarResources: map[v1.ResourceName]int64{hugePageResourceA: 10}}),
-			nodeInfo: framework.NewNodeInfo(
+			nodeInfo: newNodeInfoWithPods(
 				newResourcePod(framework.Resource{MilliCPU: 0, Memory: 0, ScalarResources: map[v1.ResourceName]int64{hugePageResourceA: 0}})),
 			name:                      "hugepages resource capacity enforced for init container",
 			wantStatus:                framework.NewStatus(framework.Unschedulable, getErrReason(hugePageResourceA)),
@@ -347,7 +373,7 @@ func TestEnoughRequests(t *testing.T) {
 			pod: newResourcePod(
 				framework.Resource{MilliCPU: 1, Memory: 1, ScalarResources: map[v1.ResourceName]int64{hugePageResourceA: 3}},
 				framework.Resource{MilliCPU: 1, Memory: 1, ScalarResources: map[v1.ResourceName]int64{hugePageResourceA: 3}}),
-			nodeInfo: framework.NewNodeInfo(
+			nodeInfo: newNodeInfoWithPods(
 				newResourcePod(framework.Resource{MilliCPU: 0, Memory: 0, ScalarResources: map[v1.ResourceName]int64{hugePageResourceA: 2}})),
 			name:                      "hugepages resource allocatable enforced for multiple containers",
 			wantStatus:                framework.NewStatus(framework.Unschedulable, getErrReason(hugePageResourceA)),
@@ -356,7 +382,7 @@ func TestEnoughRequests(t *testing.T) {
 		{
 			pod: newResourcePod(
 				framework.Resource{MilliCPU: 1, Memory: 1, ScalarResources: map[v1.ResourceName]int64{extendedResourceB: 1}}),
-			nodeInfo: framework.NewNodeInfo(newResourcePod(framework.Resource{MilliCPU: 0, Memory: 0})),
+			nodeInfo: newNodeInfoWithPods(newResourcePod(framework.Resource{MilliCPU: 0, Memory: 0})),
 			args: config.NodeResourcesFitArgs{
 				IgnoredResources: []string{"example.com/bbb"},
 			},
@@ -368,7 +394,7 @@ func TestEnoughRequests(t *testing.T) {
 				newResourcePod(framework.Resource{MilliCPU: 1, Memory: 1}),
 				v1.ResourceList{v1.ResourceCPU: resource.MustParse("3m"), v1.ResourceMemory: resource.MustParse("13")},
 			),
-			nodeInfo:                  framework.NewNodeInfo(newResourcePod(framework.Resource{MilliCPU: 5, Memory: 5})),
+			nodeInfo:                  newNodeInfoWithPods(newResourcePod(framework.Resource{MilliCPU: 5, Memory: 5})),
 			name:                      "resources + pod overhead fits",
 			wantInsufficientResources: []InsufficientResource{},
 		},
@@ -377,7 +403,7 @@ func TestEnoughRequests(t *testing.T) {
 				newResourcePod(framework.Resource{MilliCPU: 1, Memory: 1}),
 				v1.ResourceList{v1.ResourceCPU: resource.MustParse("1m"), v1.ResourceMemory: resource.MustParse("15")},
 			),
-			nodeInfo:                  framework.NewNodeInfo(newResourcePod(framework.Resource{MilliCPU: 5, Memory: 5})),
+			nodeInfo:                  newNodeInfoWithPods(newResourcePod(framework.Resource{MilliCPU: 5, Memory: 5})),
 			name:                      "requests + overhead does not fit for memory",
 			wantStatus:                framework.NewStatus(framework.Unschedulable, getErrReason(v1.ResourceMemory)),
 			wantInsufficientResources: []InsufficientResource{{v1.ResourceMemory, getErrReason(v1.ResourceMemory), 16, 5, 20}},
@@ -391,7 +417,7 @@ func TestEnoughRequests(t *testing.T) {
 						extendedResourceB:     1,
 						kubernetesIOResourceA: 1,
 					}}),
-			nodeInfo: framework.NewNodeInfo(newResourcePod(framework.Resource{MilliCPU: 0, Memory: 0})),
+			nodeInfo: newNodeInfoWithPods(newResourcePod(framework.Resource{MilliCPU: 0, Memory: 0})),
 			args: config.NodeResourcesFitArgs{
 				IgnoredResourceGroups: []string{"example.com"},
 			},
@@ -414,7 +440,14 @@ func TestEnoughRequests(t *testing.T) {
 			node := v1.Node{Status: v1.NodeStatus{Capacity: makeResources(10, 20, 32, 5, 20, 5).Capacity, Allocatable: makeAllocatableResources(10, 20, 32, 5, 20, 5)}}
 			test.nodeInfo.SetNode(&node)
 
-			p, err := NewFit(&test.args, nil)
+			f, err := frameworkruntime.NewFramework(nil, nil,
+				frameworkruntime.WithResourceNameQualifier(getFakeResourceNameQualifier()),
+			)
+			if err != nil {
+				t.Fatalf("Failed creating framework runtime: %v", err)
+			}
+
+			p, err := NewFit(&test.args, f)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -429,7 +462,9 @@ func TestEnoughRequests(t *testing.T) {
 				t.Errorf("status does not match: %v, want: %v", gotStatus, test.wantStatus)
 			}
 
-			gotInsufficientResources := fitsRequest(computePodResourceRequest(test.pod), test.nodeInfo, p.(*Fit).ignoredResources, p.(*Fit).ignoredResourceGroups)
+			rnq := getFakeResourceNameQualifier()
+
+			gotInsufficientResources := fitsRequest(computePodResourceRequest(test.pod, rnq), test.nodeInfo, p.(*Fit).ignoredResources, p.(*Fit).ignoredResourceGroups, rnq)
 			if !reflect.DeepEqual(gotInsufficientResources, test.wantInsufficientResources) {
 				t.Errorf("insufficient resources do not match: %+v, want: %v", gotInsufficientResources, test.wantInsufficientResources)
 			}
@@ -439,10 +474,18 @@ func TestEnoughRequests(t *testing.T) {
 
 func TestPreFilterDisabled(t *testing.T) {
 	pod := &v1.Pod{}
-	nodeInfo := framework.NewNodeInfo()
+	nodeInfo := framework.NewNodeInfo(getFakeResourceNameQualifier())
 	node := v1.Node{}
 	nodeInfo.SetNode(&node)
-	p, err := NewFit(&config.NodeResourcesFitArgs{}, nil)
+
+	f, err := frameworkruntime.NewFramework(nil, nil,
+		frameworkruntime.WithResourceNameQualifier(getFakeResourceNameQualifier()),
+	)
+	if err != nil {
+		t.Fatalf("Failed creating framework runtime: %v", err)
+	}
+
+	p, err := NewFit(&config.NodeResourcesFitArgs{}, f)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -464,25 +507,25 @@ func TestNotEnoughRequests(t *testing.T) {
 	}{
 		{
 			pod:        &v1.Pod{},
-			nodeInfo:   framework.NewNodeInfo(newResourcePod(framework.Resource{MilliCPU: 10, Memory: 20})),
+			nodeInfo:   newNodeInfoWithPods(newResourcePod(framework.Resource{MilliCPU: 10, Memory: 20})),
 			name:       "even without specified resources predicate fails when there's no space for additional pod",
 			wantStatus: framework.NewStatus(framework.Unschedulable, "Too many pods"),
 		},
 		{
 			pod:        newResourcePod(framework.Resource{MilliCPU: 1, Memory: 1}),
-			nodeInfo:   framework.NewNodeInfo(newResourcePod(framework.Resource{MilliCPU: 5, Memory: 5})),
+			nodeInfo:   newNodeInfoWithPods(newResourcePod(framework.Resource{MilliCPU: 5, Memory: 5})),
 			name:       "even if both resources fit predicate fails when there's no space for additional pod",
 			wantStatus: framework.NewStatus(framework.Unschedulable, "Too many pods"),
 		},
 		{
 			pod:        newResourcePod(framework.Resource{MilliCPU: 5, Memory: 1}),
-			nodeInfo:   framework.NewNodeInfo(newResourcePod(framework.Resource{MilliCPU: 5, Memory: 19})),
+			nodeInfo:   newNodeInfoWithPods(newResourcePod(framework.Resource{MilliCPU: 5, Memory: 19})),
 			name:       "even for equal edge case predicate fails when there's no space for additional pod",
 			wantStatus: framework.NewStatus(framework.Unschedulable, "Too many pods"),
 		},
 		{
 			pod:        newResourceInitPod(newResourcePod(framework.Resource{MilliCPU: 5, Memory: 1}), framework.Resource{MilliCPU: 5, Memory: 1}),
-			nodeInfo:   framework.NewNodeInfo(newResourcePod(framework.Resource{MilliCPU: 5, Memory: 19})),
+			nodeInfo:   newNodeInfoWithPods(newResourcePod(framework.Resource{MilliCPU: 5, Memory: 19})),
 			name:       "even for equal edge case predicate fails when there's no space for additional pod due to init container",
 			wantStatus: framework.NewStatus(framework.Unschedulable, "Too many pods"),
 		},
@@ -492,7 +535,14 @@ func TestNotEnoughRequests(t *testing.T) {
 			node := v1.Node{Status: v1.NodeStatus{Capacity: v1.ResourceList{}, Allocatable: makeAllocatableResources(10, 20, 1, 0, 0, 0)}}
 			test.nodeInfo.SetNode(&node)
 
-			p, err := NewFit(&config.NodeResourcesFitArgs{}, nil)
+			f, err := frameworkruntime.NewFramework(nil, nil,
+				frameworkruntime.WithResourceNameQualifier(getFakeResourceNameQualifier()),
+			)
+			if err != nil {
+				t.Fatalf("Failed creating framework runtime: %v", err)
+			}
+
+			p, err := NewFit(&config.NodeResourcesFitArgs{}, f)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -521,27 +571,27 @@ func TestStorageRequests(t *testing.T) {
 	}{
 		{
 			pod: newResourcePod(framework.Resource{MilliCPU: 1, Memory: 1}),
-			nodeInfo: framework.NewNodeInfo(
+			nodeInfo: newNodeInfoWithPods(
 				newResourcePod(framework.Resource{MilliCPU: 10, Memory: 10})),
 			name:       "due to container scratch disk",
 			wantStatus: framework.NewStatus(framework.Unschedulable, getErrReason(v1.ResourceCPU)),
 		},
 		{
 			pod: newResourcePod(framework.Resource{MilliCPU: 1, Memory: 1}),
-			nodeInfo: framework.NewNodeInfo(
+			nodeInfo: newNodeInfoWithPods(
 				newResourcePod(framework.Resource{MilliCPU: 2, Memory: 10})),
 			name: "pod fit",
 		},
 		{
 			pod: newResourcePod(framework.Resource{EphemeralStorage: 25}),
-			nodeInfo: framework.NewNodeInfo(
+			nodeInfo: newNodeInfoWithPods(
 				newResourcePod(framework.Resource{MilliCPU: 2, Memory: 2})),
 			name:       "storage ephemeral local storage request exceeds allocatable",
 			wantStatus: framework.NewStatus(framework.Unschedulable, getErrReason(v1.ResourceEphemeralStorage)),
 		},
 		{
 			pod: newResourceInitPod(newResourcePod(framework.Resource{EphemeralStorage: 25}), framework.Resource{EphemeralStorage: 25}),
-			nodeInfo: framework.NewNodeInfo(
+			nodeInfo: newNodeInfoWithPods(
 				newResourcePod(framework.Resource{MilliCPU: 2, Memory: 2})),
 			name: "ephemeral local storage request is ignored due to disabled feature gate",
 			features: map[featuregate.Feature]bool{
@@ -550,7 +600,7 @@ func TestStorageRequests(t *testing.T) {
 		},
 		{
 			pod: newResourcePod(framework.Resource{EphemeralStorage: 10}),
-			nodeInfo: framework.NewNodeInfo(
+			nodeInfo: newNodeInfoWithPods(
 				newResourcePod(framework.Resource{MilliCPU: 2, Memory: 2})),
 			name: "pod fits",
 		},
@@ -564,7 +614,14 @@ func TestStorageRequests(t *testing.T) {
 			node := v1.Node{Status: v1.NodeStatus{Capacity: makeResources(10, 20, 32, 5, 20, 5).Capacity, Allocatable: makeAllocatableResources(10, 20, 32, 5, 20, 5)}}
 			test.nodeInfo.SetNode(&node)
 
-			p, err := NewFit(&config.NodeResourcesFitArgs{}, nil)
+			f, err := frameworkruntime.NewFramework(nil, nil,
+				frameworkruntime.WithResourceNameQualifier(getFakeResourceNameQualifier()),
+			)
+			if err != nil {
+				t.Fatalf("Failed creating framework runtime: %v", err)
+			}
+
+			p, err := NewFit(&config.NodeResourcesFitArgs{}, f)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/scheduler/framework/plugins/noderesources/least_allocated_test.go
+++ b/pkg/scheduler/framework/plugins/noderesources/least_allocated_test.go
@@ -304,7 +304,7 @@ func TestNodeResourcesLeastAllocated(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			snapshot := cache.NewSnapshot(test.pods, test.nodes)
+			snapshot := cache.NewSnapshot(test.pods, test.nodes, newNodeInfoWithResourceNameQualifier)
 			fh, _ := runtime.NewFramework(nil, nil, runtime.WithSnapshotSharedLister(snapshot))
 			p, err := NewLeastAllocated(&test.args, fh)
 

--- a/pkg/scheduler/framework/plugins/noderesources/most_allocated_test.go
+++ b/pkg/scheduler/framework/plugins/noderesources/most_allocated_test.go
@@ -33,6 +33,10 @@ import (
 	"k8s.io/kubernetes/pkg/scheduler/internal/cache"
 )
 
+func newNodeInfoWithResourceNameQualifier() *framework.NodeInfo {
+	return framework.NewNodeInfo(getFakeResourceNameQualifier())
+}
+
 func TestNodeResourcesMostAllocated(t *testing.T) {
 	labels1 := map[string]string{
 		"foo": "bar",
@@ -264,7 +268,7 @@ func TestNodeResourcesMostAllocated(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			snapshot := cache.NewSnapshot(test.pods, test.nodes)
+			snapshot := cache.NewSnapshot(test.pods, test.nodes, newNodeInfoWithResourceNameQualifier)
 			fh, _ := runtime.NewFramework(nil, nil, runtime.WithSnapshotSharedLister(snapshot))
 			p, err := NewMostAllocated(&test.args, fh)
 

--- a/pkg/scheduler/framework/plugins/noderesources/requested_to_capacity_ratio_test.go
+++ b/pkg/scheduler/framework/plugins/noderesources/requested_to_capacity_ratio_test.go
@@ -68,7 +68,7 @@ func TestRequestedToCapacityRatio(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			state := framework.NewCycleState()
-			snapshot := cache.NewSnapshot(test.scheduledPods, test.nodes)
+			snapshot := cache.NewSnapshot(test.scheduledPods, test.nodes, newNodeInfoWithResourceNameQualifier)
 			fh, _ := runtime.NewFramework(nil, nil, runtime.WithSnapshotSharedLister(snapshot))
 			args := config.RequestedToCapacityRatioArgs{
 				Shape: []config.UtilizationShapePoint{
@@ -322,7 +322,7 @@ func TestResourceBinPackingSingleExtended(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			state := framework.NewCycleState()
-			snapshot := cache.NewSnapshot(test.pods, test.nodes)
+			snapshot := cache.NewSnapshot(test.pods, test.nodes, newNodeInfoWithResourceNameQualifier)
 			fh, _ := runtime.NewFramework(nil, nil, runtime.WithSnapshotSharedLister(snapshot))
 			args := config.RequestedToCapacityRatioArgs{
 				Shape: []config.UtilizationShapePoint{
@@ -565,7 +565,7 @@ func TestResourceBinPackingMultipleExtended(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			state := framework.NewCycleState()
-			snapshot := cache.NewSnapshot(test.pods, test.nodes)
+			snapshot := cache.NewSnapshot(test.pods, test.nodes, newNodeInfoWithResourceNameQualifier)
 			fh, _ := runtime.NewFramework(nil, nil, runtime.WithSnapshotSharedLister(snapshot))
 			args := config.RequestedToCapacityRatioArgs{
 				Shape: []config.UtilizationShapePoint{

--- a/pkg/scheduler/framework/plugins/nodeunschedulable/node_unschedulable_test.go
+++ b/pkg/scheduler/framework/plugins/nodeunschedulable/node_unschedulable_test.go
@@ -23,6 +23,7 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/kubernetes/pkg/scheduler/framework"
+	fakeframework "k8s.io/kubernetes/pkg/scheduler/framework/fake"
 )
 
 func TestNodeUnschedulable(t *testing.T) {
@@ -72,7 +73,7 @@ func TestNodeUnschedulable(t *testing.T) {
 	}
 
 	for _, test := range testCases {
-		nodeInfo := framework.NewNodeInfo()
+		nodeInfo := fakeframework.NewNodeInfoWithEmptyResourceNameQualifier()
 		nodeInfo.SetNode(test.node)
 
 		p, _ := New(nil, nil)

--- a/pkg/scheduler/framework/plugins/nodevolumelimits/csi_test.go
+++ b/pkg/scheduler/framework/plugins/nodevolumelimits/csi_test.go
@@ -47,6 +47,19 @@ const (
 	hostpathInTreePluginName = "kubernetes.io/hostpath"
 )
 
+func getFakeResourceNameQualifier() framework.ResourceNameQualifier {
+	return &fakeframework.ResourceNameQualifier{
+		AttachableVolumeResourceNames: []v1.ResourceName{
+			v1.ResourceName(volumeutil.EBSVolumeLimitKey),
+			v1.ResourceName(v1.ResourceAttachableVolumesPrefix + "csi-ebs.csi.aws.com"),
+			v1.ResourceName(v1.ResourceAttachableVolumesPrefix + "csi-pd.csi.storage.gke.io"),
+			v1.ResourceName(volumeutil.GCEVolumeLimitKey),
+			v1.ResourceName(volumeutil.AzureVolumeLimitKey),
+			v1.ResourceName(volumeutil.CinderVolumeLimitKey),
+		},
+	}
+}
+
 // getVolumeLimitKey returns a ResourceName by filter type
 func getVolumeLimitKey(filterType string) v1.ResourceName {
 	switch filterType {
@@ -459,12 +472,13 @@ func TestCSILimits(t *testing.T) {
 			}
 
 			p := &CSILimits{
-				csiNodeLister:        getFakeCSINodeLister(csiNode),
-				pvLister:             getFakeCSIPVLister(test.filterName, test.driverNames...),
-				pvcLister:            getFakeCSIPVCLister(test.filterName, "csi-sc", test.driverNames...),
-				scLister:             getFakeCSIStorageClassLister("csi-sc", test.driverNames[0]),
-				randomVolumeIDPrefix: rand.String(32),
-				translator:           csitrans.New(),
+				csiNodeLister:         getFakeCSINodeLister(csiNode),
+				pvLister:              getFakeCSIPVLister(test.filterName, test.driverNames...),
+				pvcLister:             getFakeCSIPVCLister(test.filterName, "csi-sc", test.driverNames...),
+				scLister:              getFakeCSIStorageClassLister("csi-sc", test.driverNames[0]),
+				randomVolumeIDPrefix:  rand.String(32),
+				translator:            csitrans.New(),
+				resourceNameQualifier: getFakeResourceNameQualifier(),
 			}
 			gotStatus := p.Filter(context.Background(), nil, test.newPod, node)
 			if !reflect.DeepEqual(gotStatus, test.wantStatus) {
@@ -579,7 +593,10 @@ func getFakeCSINodeLister(csiNode *storagev1.CSINode) fakeframework.CSINodeListe
 }
 
 func getNodeWithPodAndVolumeLimits(limitSource string, pods []*v1.Pod, limit int64, driverNames ...string) (*framework.NodeInfo, *storagev1.CSINode) {
-	nodeInfo := framework.NewNodeInfo(pods...)
+	nodeInfo := framework.NewNodeInfo(getFakeResourceNameQualifier())
+	for _, pod := range pods {
+		nodeInfo.AddPod(pod)
+	}
 	node := &v1.Node{
 		ObjectMeta: metav1.ObjectMeta{Name: "node-for-max-pd-test-1"},
 		Status: v1.NodeStatus{

--- a/pkg/scheduler/framework/plugins/nodevolumelimits/non_csi_test.go
+++ b/pkg/scheduler/framework/plugins/nodevolumelimits/non_csi_test.go
@@ -360,7 +360,14 @@ func TestAzureDiskLimits(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.test, func(t *testing.T) {
 			node, csiNode := getNodeWithPodAndVolumeLimits("node", test.existingPods, int64(test.maxVols), test.filterName)
-			p := newNonCSILimits(test.filterName, getFakeCSINodeLister(csiNode), getFakeCSIStorageClassLister(test.filterName, test.driverName), getFakePVLister(test.filterName), getFakePVCLister(test.filterName)).(framework.FilterPlugin)
+			p := newNonCSILimits(
+				test.filterName,
+				getFakeCSINodeLister(csiNode),
+				getFakeCSIStorageClassLister(test.filterName, test.driverName),
+				getFakePVLister(test.filterName),
+				getFakePVCLister(test.filterName),
+				getFakeResourceNameQualifier(),
+			).(framework.FilterPlugin)
 			gotStatus := p.Filter(context.Background(), nil, test.newPod, node)
 			if !reflect.DeepEqual(gotStatus, test.wantStatus) {
 				t.Errorf("status does not match: %v, want: %v", gotStatus, test.wantStatus)
@@ -427,7 +434,14 @@ func TestCinderLimits(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.test, func(t *testing.T) {
 			node, csiNode := getNodeWithPodAndVolumeLimits("node", test.existingPods, int64(test.maxVols), test.filterName)
-			p := newNonCSILimits(test.filterName, getFakeCSINodeLister(csiNode), getFakeCSIStorageClassLister(test.filterName, test.driverName), getFakePVLister(test.filterName), getFakePVCLister(test.filterName)).(framework.FilterPlugin)
+			p := newNonCSILimits(
+				test.filterName,
+				getFakeCSINodeLister(csiNode),
+				getFakeCSIStorageClassLister(test.filterName, test.driverName),
+				getFakePVLister(test.filterName),
+				getFakePVCLister(test.filterName),
+				getFakeResourceNameQualifier(),
+			).(framework.FilterPlugin)
 			gotStatus := p.Filter(context.Background(), nil, test.newPod, node)
 			if !reflect.DeepEqual(gotStatus, test.wantStatus) {
 				t.Errorf("status does not match: %v, want: %v", gotStatus, test.wantStatus)
@@ -834,7 +848,14 @@ func TestEBSLimits(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.test, func(t *testing.T) {
 			node, csiNode := getNodeWithPodAndVolumeLimits("node", test.existingPods, int64(test.maxVols), test.filterName)
-			p := newNonCSILimits(test.filterName, getFakeCSINodeLister(csiNode), getFakeCSIStorageClassLister(test.filterName, test.driverName), getFakePVLister(test.filterName), getFakePVCLister(test.filterName)).(framework.FilterPlugin)
+			p := newNonCSILimits(
+				test.filterName,
+				getFakeCSINodeLister(csiNode),
+				getFakeCSIStorageClassLister(test.filterName, test.driverName),
+				getFakePVLister(test.filterName),
+				getFakePVCLister(test.filterName),
+				getFakeResourceNameQualifier(),
+			).(framework.FilterPlugin)
 			gotStatus := p.Filter(context.Background(), nil, test.newPod, node)
 			if !reflect.DeepEqual(gotStatus, test.wantStatus) {
 				t.Errorf("status does not match: %v, want: %v", gotStatus, test.wantStatus)
@@ -1172,7 +1193,14 @@ func TestGCEPDLimits(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.test, func(t *testing.T) {
 			node, csiNode := getNodeWithPodAndVolumeLimits("node", test.existingPods, int64(test.maxVols), test.filterName)
-			p := newNonCSILimits(test.filterName, getFakeCSINodeLister(csiNode), getFakeCSIStorageClassLister(test.filterName, test.driverName), getFakePVLister(test.filterName), getFakePVCLister(test.filterName)).(framework.FilterPlugin)
+			p := newNonCSILimits(
+				test.filterName,
+				getFakeCSINodeLister(csiNode),
+				getFakeCSIStorageClassLister(test.filterName, test.driverName),
+				getFakePVLister(test.filterName),
+				getFakePVCLister(test.filterName),
+				getFakeResourceNameQualifier(),
+			).(framework.FilterPlugin)
 			gotStatus := p.Filter(context.Background(), nil, test.newPod, node)
 			if !reflect.DeepEqual(gotStatus, test.wantStatus) {
 				t.Errorf("status does not match: %v, want: %v", gotStatus, test.wantStatus)

--- a/pkg/scheduler/framework/plugins/nodevolumelimits/utils.go
+++ b/pkg/scheduler/framework/plugins/nodevolumelimits/utils.go
@@ -19,12 +19,11 @@ package nodevolumelimits
 import (
 	"strings"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	csilibplugins "k8s.io/csi-translation-lib/plugins"
-	v1helper "k8s.io/kubernetes/pkg/apis/core/v1/helper"
 	"k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/pkg/scheduler/framework"
 )
@@ -83,10 +82,10 @@ func isCSIMigrationOn(csiNode *storagev1.CSINode, pluginName string) bool {
 }
 
 // volumeLimits returns volume limits associated with the node.
-func volumeLimits(n *framework.NodeInfo) map[v1.ResourceName]int64 {
+func volumeLimits(rnq framework.ResourceNameQualifier, n *framework.NodeInfo) map[v1.ResourceName]int64 {
 	volumeLimits := map[v1.ResourceName]int64{}
 	for k, v := range n.Allocatable.ScalarResources {
-		if v1helper.IsAttachableVolumeResourceName(k) {
+		if rnq.IsAttachableVolume(k) {
 			volumeLimits[k] = v
 		}
 	}

--- a/pkg/scheduler/framework/plugins/selectorspread/selector_spread_perf_test.go
+++ b/pkg/scheduler/framework/plugins/selectorspread/selector_spread_perf_test.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/kubernetes/pkg/scheduler/framework"
+	fakeframework "k8s.io/kubernetes/pkg/scheduler/framework/fake"
 	"k8s.io/kubernetes/pkg/scheduler/framework/runtime"
 	"k8s.io/kubernetes/pkg/scheduler/internal/cache"
 	"k8s.io/kubernetes/pkg/scheduler/internal/parallelize"
@@ -54,7 +55,7 @@ func BenchmarkTestSelectorSpreadPriority(b *testing.B) {
 		b.Run(tt.name, func(b *testing.B) {
 			pod := st.MakePod().Name("p").Label("foo", "").Obj()
 			existingPods, allNodes, filteredNodes := st.MakeNodesAndPodsForEvenPodsSpread(pod.Labels, tt.existingPodsNum, tt.allNodesNum, tt.allNodesNum)
-			snapshot := cache.NewSnapshot(existingPods, allNodes)
+			snapshot := cache.NewSnapshot(existingPods, allNodes, fakeframework.NewNodeInfoWithEmptyResourceNameQualifier)
 			client := fake.NewSimpleClientset(
 				&v1.Service{Spec: v1.ServiceSpec{Selector: map[string]string{"foo": ""}}},
 			)

--- a/pkg/scheduler/framework/plugins/selectorspread/selector_spread_test.go
+++ b/pkg/scheduler/framework/plugins/selectorspread/selector_spread_test.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/client-go/informers"
 	clientsetfake "k8s.io/client-go/kubernetes/fake"
 	"k8s.io/kubernetes/pkg/scheduler/framework"
+	fakeframework "k8s.io/kubernetes/pkg/scheduler/framework/fake"
 	frameworkruntime "k8s.io/kubernetes/pkg/scheduler/framework/runtime"
 	"k8s.io/kubernetes/pkg/scheduler/internal/cache"
 )
@@ -370,7 +371,7 @@ func TestSelectorSpreadScore(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			nodes := makeNodeList(test.nodes)
-			snapshot := cache.NewSnapshot(test.pods, nodes)
+			snapshot := cache.NewSnapshot(test.pods, nodes, fakeframework.NewNodeInfoWithEmptyResourceNameQualifier)
 			ctx := context.Background()
 			informerFactory, err := populateAndStartInformers(ctx, test.rcs, test.rss, test.services, test.sss)
 			if err != nil {
@@ -626,7 +627,7 @@ func TestZoneSelectorSpreadPriority(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			nodes := makeLabeledNodeList(labeledNodes)
-			snapshot := cache.NewSnapshot(test.pods, nodes)
+			snapshot := cache.NewSnapshot(test.pods, nodes, fakeframework.NewNodeInfoWithEmptyResourceNameQualifier)
 			ctx := context.Background()
 			informerFactory, err := populateAndStartInformers(ctx, test.rcs, test.rss, test.services, test.sss)
 			if err != nil {

--- a/pkg/scheduler/framework/plugins/serviceaffinity/service_affinity_test.go
+++ b/pkg/scheduler/framework/plugins/serviceaffinity/service_affinity_test.go
@@ -162,7 +162,7 @@ func TestServiceAffinity(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			nodes := []*v1.Node{&node1, &node2, &node3, &node4, &node5}
-			snapshot := cache.NewSnapshot(test.pods, nodes)
+			snapshot := cache.NewSnapshot(test.pods, nodes, fakeframework.NewNodeInfoWithEmptyResourceNameQualifier)
 
 			p := &ServiceAffinity{
 				sharedLister:  snapshot,
@@ -385,7 +385,7 @@ func TestServiceAffinityScore(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			nodes := makeLabeledNodeList(test.nodes)
-			snapshot := cache.NewSnapshot(test.pods, nodes)
+			snapshot := cache.NewSnapshot(test.pods, nodes, fakeframework.NewNodeInfoWithEmptyResourceNameQualifier)
 			serviceLister := fakeframework.ServiceLister(test.services)
 
 			p := &ServiceAffinity{
@@ -497,7 +497,7 @@ func TestPreFilterStateAddRemovePod(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			// getMeta creates predicate meta data given the list of pods.
 			getState := func(pods []*v1.Pod) (*ServiceAffinity, *framework.CycleState, *preFilterState, *cache.Snapshot) {
-				snapshot := cache.NewSnapshot(pods, test.nodes)
+				snapshot := cache.NewSnapshot(pods, test.nodes, fakeframework.NewNodeInfoWithEmptyResourceNameQualifier)
 
 				p := &ServiceAffinity{
 					sharedLister:  snapshot,
@@ -608,7 +608,7 @@ func mustGetNodeInfo(t *testing.T, snapshot *cache.Snapshot, name string) *frame
 
 func TestPreFilterDisabled(t *testing.T) {
 	pod := &v1.Pod{}
-	nodeInfo := framework.NewNodeInfo()
+	nodeInfo := fakeframework.NewNodeInfoWithEmptyResourceNameQualifier()
 	node := v1.Node{}
 	nodeInfo.SetNode(&node)
 	p := &ServiceAffinity{

--- a/pkg/scheduler/framework/plugins/tainttoleration/taint_toleration_test.go
+++ b/pkg/scheduler/framework/plugins/tainttoleration/taint_toleration_test.go
@@ -24,6 +24,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/kubernetes/pkg/scheduler/framework"
+	fakeframework "k8s.io/kubernetes/pkg/scheduler/framework/fake"
 	"k8s.io/kubernetes/pkg/scheduler/framework/runtime"
 	"k8s.io/kubernetes/pkg/scheduler/internal/cache"
 )
@@ -229,7 +230,7 @@ func TestTaintTolerationScore(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			state := framework.NewCycleState()
-			snapshot := cache.NewSnapshot(nil, test.nodes)
+			snapshot := cache.NewSnapshot(nil, test.nodes, fakeframework.NewNodeInfoWithEmptyResourceNameQualifier)
 			fh, _ := runtime.NewFramework(nil, nil, runtime.WithSnapshotSharedLister(snapshot))
 
 			p, _ := New(nil, fh)
@@ -330,7 +331,7 @@ func TestTaintTolerationFilter(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			nodeInfo := framework.NewNodeInfo()
+			nodeInfo := fakeframework.NewNodeInfoWithEmptyResourceNameQualifier()
 			nodeInfo.SetNode(test.node)
 			p, _ := New(nil, nil)
 			gotStatus := p.(framework.FilterPlugin).Filter(context.Background(), nil, test.pod, nodeInfo)

--- a/pkg/scheduler/framework/plugins/volumebinding/volume_binding_test.go
+++ b/pkg/scheduler/framework/plugins/volumebinding/volume_binding_test.go
@@ -37,6 +37,7 @@ import (
 	"k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/pkg/scheduler/apis/config"
 	"k8s.io/kubernetes/pkg/scheduler/framework"
+	fakeframework "k8s.io/kubernetes/pkg/scheduler/framework/fake"
 	"k8s.io/kubernetes/pkg/scheduler/framework/runtime"
 	"k8s.io/utils/pointer"
 )
@@ -575,7 +576,7 @@ func TestVolumeBinding(t *testing.T) {
 			p := pl.(*VolumeBinding)
 			nodeInfos := make([]*framework.NodeInfo, 0)
 			for _, node := range item.nodes {
-				nodeInfo := framework.NewNodeInfo()
+				nodeInfo := fakeframework.NewNodeInfoWithEmptyResourceNameQualifier()
 				nodeInfo.SetNode(node)
 				nodeInfos = append(nodeInfos, nodeInfo)
 			}

--- a/pkg/scheduler/framework/plugins/volumerestrictions/volume_restrictions_test.go
+++ b/pkg/scheduler/framework/plugins/volumerestrictions/volume_restrictions_test.go
@@ -23,7 +23,16 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/kubernetes/pkg/scheduler/framework"
+	fakeframework "k8s.io/kubernetes/pkg/scheduler/framework/fake"
 )
+
+func newNodeInfoWithPods(pods ...*v1.Pod) *framework.NodeInfo {
+	ni := fakeframework.NewNodeInfoWithEmptyResourceNameQualifier()
+	for _, pod := range pods {
+		ni.AddPod(pod)
+	}
+	return ni
+}
 
 func TestGCEDiskConflicts(t *testing.T) {
 	volState := v1.PodSpec{
@@ -56,10 +65,10 @@ func TestGCEDiskConflicts(t *testing.T) {
 		name       string
 		wantStatus *framework.Status
 	}{
-		{&v1.Pod{}, framework.NewNodeInfo(), true, "nothing", nil},
-		{&v1.Pod{}, framework.NewNodeInfo(&v1.Pod{Spec: volState}), true, "one state", nil},
-		{&v1.Pod{Spec: volState}, framework.NewNodeInfo(&v1.Pod{Spec: volState}), false, "same state", errStatus},
-		{&v1.Pod{Spec: volState2}, framework.NewNodeInfo(&v1.Pod{Spec: volState}), true, "different state", nil},
+		{&v1.Pod{}, fakeframework.NewNodeInfoWithEmptyResourceNameQualifier(), true, "nothing", nil},
+		{&v1.Pod{}, newNodeInfoWithPods(&v1.Pod{Spec: volState}), true, "one state", nil},
+		{&v1.Pod{Spec: volState}, newNodeInfoWithPods(&v1.Pod{Spec: volState}), false, "same state", errStatus},
+		{&v1.Pod{Spec: volState2}, newNodeInfoWithPods(&v1.Pod{Spec: volState}), true, "different state", nil},
 	}
 
 	for _, test := range tests {
@@ -104,10 +113,10 @@ func TestAWSDiskConflicts(t *testing.T) {
 		name       string
 		wantStatus *framework.Status
 	}{
-		{&v1.Pod{}, framework.NewNodeInfo(), true, "nothing", nil},
-		{&v1.Pod{}, framework.NewNodeInfo(&v1.Pod{Spec: volState}), true, "one state", nil},
-		{&v1.Pod{Spec: volState}, framework.NewNodeInfo(&v1.Pod{Spec: volState}), false, "same state", errStatus},
-		{&v1.Pod{Spec: volState2}, framework.NewNodeInfo(&v1.Pod{Spec: volState}), true, "different state", nil},
+		{&v1.Pod{}, fakeframework.NewNodeInfoWithEmptyResourceNameQualifier(), true, "nothing", nil},
+		{&v1.Pod{}, newNodeInfoWithPods(&v1.Pod{Spec: volState}), true, "one state", nil},
+		{&v1.Pod{Spec: volState}, newNodeInfoWithPods(&v1.Pod{Spec: volState}), false, "same state", errStatus},
+		{&v1.Pod{Spec: volState2}, newNodeInfoWithPods(&v1.Pod{Spec: volState}), true, "different state", nil},
 	}
 
 	for _, test := range tests {
@@ -158,10 +167,10 @@ func TestRBDDiskConflicts(t *testing.T) {
 		name       string
 		wantStatus *framework.Status
 	}{
-		{&v1.Pod{}, framework.NewNodeInfo(), true, "nothing", nil},
-		{&v1.Pod{}, framework.NewNodeInfo(&v1.Pod{Spec: volState}), true, "one state", nil},
-		{&v1.Pod{Spec: volState}, framework.NewNodeInfo(&v1.Pod{Spec: volState}), false, "same state", errStatus},
-		{&v1.Pod{Spec: volState2}, framework.NewNodeInfo(&v1.Pod{Spec: volState}), true, "different state", nil},
+		{&v1.Pod{}, fakeframework.NewNodeInfoWithEmptyResourceNameQualifier(), true, "nothing", nil},
+		{&v1.Pod{}, newNodeInfoWithPods(&v1.Pod{Spec: volState}), true, "one state", nil},
+		{&v1.Pod{Spec: volState}, newNodeInfoWithPods(&v1.Pod{Spec: volState}), false, "same state", errStatus},
+		{&v1.Pod{Spec: volState2}, newNodeInfoWithPods(&v1.Pod{Spec: volState}), true, "different state", nil},
 	}
 
 	for _, test := range tests {
@@ -212,10 +221,10 @@ func TestISCSIDiskConflicts(t *testing.T) {
 		name       string
 		wantStatus *framework.Status
 	}{
-		{&v1.Pod{}, framework.NewNodeInfo(), true, "nothing", nil},
-		{&v1.Pod{}, framework.NewNodeInfo(&v1.Pod{Spec: volState}), true, "one state", nil},
-		{&v1.Pod{Spec: volState}, framework.NewNodeInfo(&v1.Pod{Spec: volState}), false, "same state", errStatus},
-		{&v1.Pod{Spec: volState2}, framework.NewNodeInfo(&v1.Pod{Spec: volState}), true, "different state", nil},
+		{&v1.Pod{}, fakeframework.NewNodeInfoWithEmptyResourceNameQualifier(), true, "nothing", nil},
+		{&v1.Pod{}, newNodeInfoWithPods(&v1.Pod{Spec: volState}), true, "one state", nil},
+		{&v1.Pod{Spec: volState}, newNodeInfoWithPods(&v1.Pod{Spec: volState}), false, "same state", errStatus},
+		{&v1.Pod{Spec: volState2}, newNodeInfoWithPods(&v1.Pod{Spec: volState}), true, "different state", nil},
 	}
 
 	for _, test := range tests {

--- a/pkg/scheduler/framework/runtime/framework.go
+++ b/pkg/scheduler/framework/runtime/framework.go
@@ -104,6 +104,8 @@ type frameworkImpl struct {
 
 	parallelizer parallelize.Parallelizer
 
+	resourceNameQualifier framework.ResourceNameQualifier
+
 	// Indicates that RunFilterPlugins should accumulate all failed statuses and not return
 	// after the first failure.
 	runAllFilters bool
@@ -142,18 +144,19 @@ func (f *frameworkImpl) Extenders() []framework.Extender {
 }
 
 type frameworkOptions struct {
-	clientSet            clientset.Interface
-	kubeConfig           *restclient.Config
-	eventRecorder        events.EventRecorder
-	informerFactory      informers.SharedInformerFactory
-	snapshotSharedLister framework.SharedLister
-	metricsRecorder      *metricsRecorder
-	podNominator         framework.PodNominator
-	extenders            []framework.Extender
-	runAllFilters        bool
-	captureProfile       CaptureProfile
-	clusterEventMap      map[framework.ClusterEvent]sets.String
-	parallelizer         parallelize.Parallelizer
+	clientSet             clientset.Interface
+	kubeConfig            *restclient.Config
+	eventRecorder         events.EventRecorder
+	informerFactory       informers.SharedInformerFactory
+	snapshotSharedLister  framework.SharedLister
+	metricsRecorder       *metricsRecorder
+	podNominator          framework.PodNominator
+	extenders             []framework.Extender
+	runAllFilters         bool
+	captureProfile        CaptureProfile
+	clusterEventMap       map[framework.ClusterEvent]sets.String
+	parallelizer          parallelize.Parallelizer
+	resourceNameQualifier framework.ResourceNameQualifier
 }
 
 // Option for the frameworkImpl.
@@ -248,6 +251,13 @@ func WithClusterEventMap(m map[framework.ClusterEvent]sets.String) Option {
 	}
 }
 
+// WithResourceNameQualifier sets ResourceNameQualifier for qualifying resource names
+func WithResourceNameQualifier(rnq framework.ResourceNameQualifier) Option {
+	return func(o *frameworkOptions) {
+		o.resourceNameQualifier = rnq
+	}
+}
+
 var _ framework.Framework = &frameworkImpl{}
 
 // NewFramework initializes plugins given the configuration and the registry.
@@ -271,6 +281,7 @@ func NewFramework(r Registry, profile *config.KubeSchedulerProfile, opts ...Opti
 		extenders:             options.extenders,
 		PodNominator:          options.podNominator,
 		parallelizer:          options.parallelizer,
+		resourceNameQualifier: options.resourceNameQualifier,
 	}
 
 	if profile == nil {
@@ -1200,4 +1211,9 @@ func (f *frameworkImpl) ProfileName() string {
 // Parallelizer returns a parallelizer holding parallelism for scheduler.
 func (f *frameworkImpl) Parallelizer() parallelize.Parallelizer {
 	return f.parallelizer
+}
+
+// ResourceNameQualifier returns resource name qualifier for qualifying resource names
+func (f *frameworkImpl) ResourceNameQualifier() framework.ResourceNameQualifier {
+	return f.resourceNameQualifier
 }

--- a/pkg/scheduler/framework/runtime/framework_test.go
+++ b/pkg/scheduler/framework/runtime/framework_test.go
@@ -34,6 +34,7 @@ import (
 	"k8s.io/component-base/metrics/testutil"
 	"k8s.io/kubernetes/pkg/scheduler/apis/config"
 	"k8s.io/kubernetes/pkg/scheduler/framework"
+	fakeframework "k8s.io/kubernetes/pkg/scheduler/framework/fake"
 	internalqueue "k8s.io/kubernetes/pkg/scheduler/internal/queue"
 	"k8s.io/kubernetes/pkg/scheduler/metrics"
 )
@@ -1346,6 +1347,14 @@ func TestPostFilterPlugins(t *testing.T) {
 	}
 }
 
+func newNodeInfoWithPods(pods ...*v1.Pod) *framework.NodeInfo {
+	ni := fakeframework.NewNodeInfoWithEmptyResourceNameQualifier()
+	for _, pod := range pods {
+		ni.AddPod(pod)
+	}
+	return ni
+}
+
 func TestFilterPluginsWithNominatedPods(t *testing.T) {
 	tests := []struct {
 		name            string
@@ -1364,7 +1373,7 @@ func TestFilterPluginsWithNominatedPods(t *testing.T) {
 			pod:             lowPriorityPod,
 			nominatedPod:    nil,
 			node:            node,
-			nodeInfo:        framework.NewNodeInfo(pod),
+			nodeInfo:        newNodeInfoWithPods(pod),
 			wantStatus:      nil,
 		},
 		{
@@ -1384,7 +1393,7 @@ func TestFilterPluginsWithNominatedPods(t *testing.T) {
 			pod:          lowPriorityPod,
 			nominatedPod: highPriorityPod,
 			node:         node,
-			nodeInfo:     framework.NewNodeInfo(pod),
+			nodeInfo:     newNodeInfoWithPods(pod),
 			wantStatus:   nil,
 		},
 		{
@@ -1399,7 +1408,7 @@ func TestFilterPluginsWithNominatedPods(t *testing.T) {
 			pod:          lowPriorityPod,
 			nominatedPod: highPriorityPod,
 			node:         node,
-			nodeInfo:     framework.NewNodeInfo(pod),
+			nodeInfo:     newNodeInfoWithPods(pod),
 			wantStatus:   framework.AsStatus(fmt.Errorf(`running AddPod on PreFilter plugin "TestPlugin1": %w`, errInjectedStatus)),
 		},
 		{
@@ -1419,7 +1428,7 @@ func TestFilterPluginsWithNominatedPods(t *testing.T) {
 			pod:          lowPriorityPod,
 			nominatedPod: highPriorityPod,
 			node:         node,
-			nodeInfo:     framework.NewNodeInfo(pod),
+			nodeInfo:     newNodeInfoWithPods(pod),
 			wantStatus:   framework.AsStatus(fmt.Errorf(`running "TestPlugin2" filter plugin: %w`, errInjectedFilterStatus)).WithFailedPlugin("TestPlugin2"),
 		},
 		{
@@ -1439,7 +1448,7 @@ func TestFilterPluginsWithNominatedPods(t *testing.T) {
 			pod:          highPriorityPod,
 			nominatedPod: lowPriorityPod,
 			node:         node,
-			nodeInfo:     framework.NewNodeInfo(pod),
+			nodeInfo:     newNodeInfoWithPods(pod),
 			wantStatus:   nil,
 		},
 	}

--- a/pkg/scheduler/framework/types.go
+++ b/pkg/scheduler/framework/types.go
@@ -396,6 +396,8 @@ type NodeInfo struct {
 	// Whenever NodeInfo changes, generation is bumped.
 	// This is used to avoid cloning it if the object didn't change.
 	Generation int64
+
+	resourceNameQualifier ResourceNameQualifier
 }
 
 //initializeNodeTransientInfo initializes transient information pertaining to node.
@@ -461,14 +463,14 @@ type Resource struct {
 }
 
 // NewResource creates a Resource from ResourceList
-func NewResource(rl v1.ResourceList) *Resource {
+func NewResource(rl v1.ResourceList, rnq ResourceNameQualifier) *Resource {
 	r := &Resource{}
-	r.Add(rl)
+	r.Add(rl, rnq)
 	return r
 }
 
 // Add adds ResourceList into Resource.
-func (r *Resource) Add(rl v1.ResourceList) {
+func (r *Resource) Add(rl v1.ResourceList, rnq ResourceNameQualifier) {
 	if r == nil {
 		return
 	}
@@ -487,11 +489,15 @@ func (r *Resource) Add(rl v1.ResourceList) {
 				r.EphemeralStorage += rQuant.Value()
 			}
 		default:
-			if schedutil.IsScalarResourceName(rName) {
+			if r.isScalarResourceName(rName, rnq) {
 				r.AddScalar(rName, rQuant.Value())
 			}
 		}
 	}
+}
+
+func (r *Resource) isScalarResourceName(name v1.ResourceName, rnq ResourceNameQualifier) bool {
+	return rnq.IsExtended(name) || rnq.IsHugePage(name) || rnq.IsPrefixedNativeResource(name) || rnq.IsAttachableVolume(name)
 }
 
 // Clone returns a copy of this resource.
@@ -526,7 +532,7 @@ func (r *Resource) SetScalar(name v1.ResourceName, quantity int64) {
 }
 
 // SetMaxResource compares with ResourceList and takes max value for each Resource.
-func (r *Resource) SetMaxResource(rl v1.ResourceList) {
+func (r *Resource) SetMaxResource(rl v1.ResourceList, rnq ResourceNameQualifier) {
 	if r == nil {
 		return
 	}
@@ -542,7 +548,7 @@ func (r *Resource) SetMaxResource(rl v1.ResourceList) {
 				r.EphemeralStorage = max(r.EphemeralStorage, rQuantity.Value())
 			}
 		default:
-			if schedutil.IsScalarResourceName(rName) {
+			if r.isScalarResourceName(rName, rnq) {
 				r.SetScalar(rName, max(r.ScalarResources[rName], rQuantity.Value()))
 			}
 		}
@@ -550,22 +556,17 @@ func (r *Resource) SetMaxResource(rl v1.ResourceList) {
 }
 
 // NewNodeInfo returns a ready to use empty NodeInfo object.
-// If any pods are given in arguments, their information will be aggregated in
-// the returned object.
-func NewNodeInfo(pods ...*v1.Pod) *NodeInfo {
-	ni := &NodeInfo{
-		Requested:        &Resource{},
-		NonZeroRequested: &Resource{},
-		Allocatable:      &Resource{},
-		TransientInfo:    NewTransientSchedulerInfo(),
-		Generation:       nextGeneration(),
-		UsedPorts:        make(HostPortInfo),
-		ImageStates:      make(map[string]*ImageStateSummary),
+func NewNodeInfo(rnq ResourceNameQualifier) *NodeInfo {
+	return &NodeInfo{
+		Requested:             &Resource{},
+		NonZeroRequested:      &Resource{},
+		Allocatable:           &Resource{},
+		TransientInfo:         NewTransientSchedulerInfo(),
+		Generation:            nextGeneration(),
+		UsedPorts:             make(HostPortInfo),
+		ImageStates:           make(map[string]*ImageStateSummary),
+		resourceNameQualifier: rnq,
 	}
-	for _, pod := range pods {
-		ni.AddPod(pod)
-	}
-	return ni
 }
 
 // Node returns overall information about this node.
@@ -579,14 +580,15 @@ func (n *NodeInfo) Node() *v1.Node {
 // Clone returns a copy of this node.
 func (n *NodeInfo) Clone() *NodeInfo {
 	clone := &NodeInfo{
-		node:             n.node,
-		Requested:        n.Requested.Clone(),
-		NonZeroRequested: n.NonZeroRequested.Clone(),
-		Allocatable:      n.Allocatable.Clone(),
-		TransientInfo:    n.TransientInfo,
-		UsedPorts:        make(HostPortInfo),
-		ImageStates:      n.ImageStates,
-		Generation:       n.Generation,
+		node:                  n.node,
+		Requested:             n.Requested.Clone(),
+		NonZeroRequested:      n.NonZeroRequested.Clone(),
+		Allocatable:           n.Allocatable.Clone(),
+		TransientInfo:         n.TransientInfo,
+		UsedPorts:             make(HostPortInfo),
+		ImageStates:           n.ImageStates,
+		Generation:            n.Generation,
+		resourceNameQualifier: n.resourceNameQualifier,
 	}
 	if len(n.Pods) > 0 {
 		clone.Pods = append([]*PodInfo(nil), n.Pods...)
@@ -623,7 +625,7 @@ func (n *NodeInfo) String() string {
 // AddPodInfo adds pod information to this NodeInfo.
 // Consider using this instead of AddPod if a PodInfo is already computed.
 func (n *NodeInfo) AddPodInfo(podInfo *PodInfo) {
-	res, non0CPU, non0Mem := calculateResource(podInfo.Pod)
+	res, non0CPU, non0Mem := calculateResource(podInfo.Pod, n.resourceNameQualifier)
 	n.Requested.MilliCPU += res.MilliCPU
 	n.Requested.Memory += res.Memory
 	n.Requested.EphemeralStorage += res.EphemeralStorage
@@ -706,7 +708,7 @@ func (n *NodeInfo) RemovePod(pod *v1.Pod) error {
 			n.Pods[i] = n.Pods[len(n.Pods)-1]
 			n.Pods = n.Pods[:len(n.Pods)-1]
 			// reduce the resource data
-			res, non0CPU, non0Mem := calculateResource(pod)
+			res, non0CPU, non0Mem := calculateResource(pod, n.resourceNameQualifier)
 
 			n.Requested.MilliCPU -= res.MilliCPU
 			n.Requested.Memory -= res.Memory
@@ -752,10 +754,10 @@ func max(a, b int64) int64 {
 }
 
 // resourceRequest = max(sum(podSpec.Containers), podSpec.InitContainers) + overHead
-func calculateResource(pod *v1.Pod) (res Resource, non0CPU int64, non0Mem int64) {
+func calculateResource(pod *v1.Pod, rnq ResourceNameQualifier) (res Resource, non0CPU int64, non0Mem int64) {
 	resPtr := &res
 	for _, c := range pod.Spec.Containers {
-		resPtr.Add(c.Resources.Requests)
+		resPtr.Add(c.Resources.Requests, rnq)
 		non0CPUReq, non0MemReq := schedutil.GetNonzeroRequests(&c.Resources.Requests)
 		non0CPU += non0CPUReq
 		non0Mem += non0MemReq
@@ -763,7 +765,7 @@ func calculateResource(pod *v1.Pod) (res Resource, non0CPU int64, non0Mem int64)
 	}
 
 	for _, ic := range pod.Spec.InitContainers {
-		resPtr.SetMaxResource(ic.Resources.Requests)
+		resPtr.SetMaxResource(ic.Resources.Requests, rnq)
 		non0CPUReq, non0MemReq := schedutil.GetNonzeroRequests(&ic.Resources.Requests)
 		non0CPU = max(non0CPU, non0CPUReq)
 		non0Mem = max(non0Mem, non0MemReq)
@@ -771,7 +773,7 @@ func calculateResource(pod *v1.Pod) (res Resource, non0CPU int64, non0Mem int64)
 
 	// If Overhead is being utilized, add to the total requests for the pod
 	if pod.Spec.Overhead != nil && utilfeature.DefaultFeatureGate.Enabled(features.PodOverhead) {
-		resPtr.Add(pod.Spec.Overhead)
+		resPtr.Add(pod.Spec.Overhead, rnq)
 		if _, found := pod.Spec.Overhead[v1.ResourceCPU]; found {
 			non0CPU += pod.Spec.Overhead.Cpu().MilliValue()
 		}
@@ -802,7 +804,7 @@ func (n *NodeInfo) updateUsedPorts(pod *v1.Pod, add bool) {
 // SetNode sets the overall node information.
 func (n *NodeInfo) SetNode(node *v1.Node) {
 	n.node = node
-	n.Allocatable = NewResource(node.Status.Allocatable)
+	n.Allocatable = NewResource(node.Status.Allocatable, n.resourceNameQualifier)
 	n.TransientInfo = NewTransientSchedulerInfo()
 	n.Generation = nextGeneration()
 }

--- a/pkg/scheduler/internal/cache/cache_test.go
+++ b/pkg/scheduler/internal/cache/cache_test.go
@@ -32,8 +32,21 @@ import (
 	featuregatetesting "k8s.io/component-base/featuregate/testing"
 	"k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/pkg/scheduler/framework"
+	fakeframework "k8s.io/kubernetes/pkg/scheduler/framework/fake"
 	schedutil "k8s.io/kubernetes/pkg/scheduler/util"
 )
+
+func getFakeResourceNameQualifier() framework.ResourceNameQualifier {
+	return &fakeframework.ResourceNameQualifier{
+		ExtendedResourceNames: []v1.ResourceName{
+			"example.com/foo",
+		},
+	}
+}
+
+func newNodeInfoWithResourceNameQualifier() *framework.NodeInfo {
+	return framework.NewNodeInfo(getFakeResourceNameQualifier())
+}
 
 func deepEqualWithoutGeneration(actual *nodeInfoListItem, expected *framework.NodeInfo) error {
 	if (actual == nil) != (expected == nil) {
@@ -83,8 +96,12 @@ func newNodeInfo(requestedResource *framework.Resource,
 	pods []*v1.Pod,
 	usedPorts framework.HostPortInfo,
 	imageStates map[string]*framework.ImageStateSummary,
+	rnq framework.ResourceNameQualifier,
 ) *framework.NodeInfo {
-	nodeInfo := framework.NewNodeInfo(pods...)
+	nodeInfo := framework.NewNodeInfo(rnq)
+	for _, pod := range pods {
+		nodeInfo.AddPod(pod)
+	}
 	nodeInfo.Requested = requestedResource
 	nodeInfo.NonZeroRequested = nonzeroRequest
 	nodeInfo.UsedPorts = usedPorts
@@ -108,6 +125,8 @@ func TestAssumePodScheduled(t *testing.T) {
 		makeBasePod(t, nodeName, "test", "100m", "500", "random-invalid-extended-key:100", []v1.ContainerPort{{}}),
 	}
 
+	rnq := getFakeResourceNameQualifier()
+
 	tests := []struct {
 		pods []*v1.Pod
 
@@ -126,6 +145,7 @@ func TestAssumePodScheduled(t *testing.T) {
 			[]*v1.Pod{testPods[0]},
 			newHostPortInfoBuilder().add("TCP", "127.0.0.1", 80).build(),
 			make(map[string]*framework.ImageStateSummary),
+			rnq,
 		),
 	}, {
 		pods: []*v1.Pod{testPods[1], testPods[2]},
@@ -141,6 +161,7 @@ func TestAssumePodScheduled(t *testing.T) {
 			[]*v1.Pod{testPods[1], testPods[2]},
 			newHostPortInfoBuilder().add("TCP", "127.0.0.1", 80).add("TCP", "127.0.0.1", 8080).build(),
 			make(map[string]*framework.ImageStateSummary),
+			rnq,
 		),
 	}, { // test non-zero request
 		pods: []*v1.Pod{testPods[3]},
@@ -156,6 +177,7 @@ func TestAssumePodScheduled(t *testing.T) {
 			[]*v1.Pod{testPods[3]},
 			newHostPortInfoBuilder().add("TCP", "127.0.0.1", 80).build(),
 			make(map[string]*framework.ImageStateSummary),
+			rnq,
 		),
 	}, {
 		pods: []*v1.Pod{testPods[4]},
@@ -172,6 +194,7 @@ func TestAssumePodScheduled(t *testing.T) {
 			[]*v1.Pod{testPods[4]},
 			newHostPortInfoBuilder().add("TCP", "127.0.0.1", 80).build(),
 			make(map[string]*framework.ImageStateSummary),
+			rnq,
 		),
 	}, {
 		pods: []*v1.Pod{testPods[4], testPods[5]},
@@ -188,6 +211,7 @@ func TestAssumePodScheduled(t *testing.T) {
 			[]*v1.Pod{testPods[4], testPods[5]},
 			newHostPortInfoBuilder().add("TCP", "127.0.0.1", 80).add("TCP", "127.0.0.1", 8080).build(),
 			make(map[string]*framework.ImageStateSummary),
+			rnq,
 		),
 	}, {
 		pods: []*v1.Pod{testPods[6]},
@@ -203,13 +227,16 @@ func TestAssumePodScheduled(t *testing.T) {
 			[]*v1.Pod{testPods[6]},
 			newHostPortInfoBuilder().build(),
 			make(map[string]*framework.ImageStateSummary),
+			rnq,
 		),
 	},
 	}
 
 	for i, tt := range tests {
 		t.Run(fmt.Sprintf("case_%d", i), func(t *testing.T) {
-			cache := newSchedulerCache(time.Second, time.Second, nil)
+			cache := newSchedulerCache(time.Second, time.Second, nil, func() *framework.NodeInfo {
+				return framework.NewNodeInfo(rnq)
+			})
 			for _, pod := range tt.pods {
 				if err := cache.AssumePod(pod); err != nil {
 					t.Fatalf("AssumePod failed: %v", err)
@@ -258,6 +285,7 @@ func TestExpirePod(t *testing.T) {
 	}
 	now := time.Now()
 	ttl := 10 * time.Second
+	rnq := getFakeResourceNameQualifier()
 	tests := []struct {
 		pods        []*testExpirePodStruct
 		cleanupTime time.Time
@@ -289,12 +317,15 @@ func TestExpirePod(t *testing.T) {
 			[]*v1.Pod{testPods[2], testPods[1]},
 			newHostPortInfoBuilder().add("TCP", "127.0.0.1", 8080).build(),
 			make(map[string]*framework.ImageStateSummary),
+			rnq,
 		),
 	}}
 
 	for i, tt := range tests {
 		t.Run(fmt.Sprintf("case_%d", i), func(t *testing.T) {
-			cache := newSchedulerCache(ttl, time.Second, nil)
+			cache := newSchedulerCache(ttl, time.Second, nil, func() *framework.NodeInfo {
+				return framework.NewNodeInfo(rnq)
+			})
 
 			for _, pod := range tt.pods {
 				if err := cache.AssumePod(pod.pod); err != nil {
@@ -331,6 +362,7 @@ func TestAddPodWillConfirm(t *testing.T) {
 		makeBasePod(t, nodeName, "test-1", "100m", "500", "", []v1.ContainerPort{{HostIP: "127.0.0.1", HostPort: 80, Protocol: "TCP"}}),
 		makeBasePod(t, nodeName, "test-2", "200m", "1Ki", "", []v1.ContainerPort{{HostIP: "127.0.0.1", HostPort: 8080, Protocol: "TCP"}}),
 	}
+	rnq := getFakeResourceNameQualifier()
 	tests := []struct {
 		podsToAssume []*v1.Pod
 		podsToAdd    []*v1.Pod
@@ -351,12 +383,15 @@ func TestAddPodWillConfirm(t *testing.T) {
 			[]*v1.Pod{testPods[0]},
 			newHostPortInfoBuilder().add("TCP", "127.0.0.1", 80).build(),
 			make(map[string]*framework.ImageStateSummary),
+			rnq,
 		),
 	}}
 
 	for i, tt := range tests {
 		t.Run(fmt.Sprintf("case_%d", i), func(t *testing.T) {
-			cache := newSchedulerCache(ttl, time.Second, nil)
+			cache := newSchedulerCache(ttl, time.Second, nil, func() *framework.NodeInfo {
+				return framework.NewNodeInfo(rnq)
+			})
 			for _, podToAssume := range tt.podsToAssume {
 				if err := assumeAndFinishBinding(cache, podToAssume, now); err != nil {
 					t.Fatalf("assumePod failed: %v", err)
@@ -396,7 +431,7 @@ func TestDump(t *testing.T) {
 
 	for i, tt := range tests {
 		t.Run(fmt.Sprintf("case_%d", i), func(t *testing.T) {
-			cache := newSchedulerCache(ttl, time.Second, nil)
+			cache := newSchedulerCache(ttl, time.Second, nil, newNodeInfoWithResourceNameQualifier)
 			for _, podToAssume := range tt.podsToAssume {
 				if err := assumeAndFinishBinding(cache, podToAssume, now); err != nil {
 					t.Errorf("assumePod failed: %v", err)
@@ -433,6 +468,7 @@ func TestAddPodWillReplaceAssumed(t *testing.T) {
 	assumedPod := makeBasePod(t, "assumed-node-1", "test-1", "100m", "500", "", []v1.ContainerPort{{HostPort: 80}})
 	addedPod := makeBasePod(t, "actual-node", "test-1", "100m", "500", "", []v1.ContainerPort{{HostPort: 80}})
 	updatedPod := makeBasePod(t, "actual-node", "test-1", "200m", "500", "", []v1.ContainerPort{{HostPort: 90}})
+	rnq := getFakeResourceNameQualifier()
 
 	tests := []struct {
 		podsToAssume []*v1.Pod
@@ -458,13 +494,16 @@ func TestAddPodWillReplaceAssumed(t *testing.T) {
 				[]*v1.Pod{updatedPod.DeepCopy()},
 				newHostPortInfoBuilder().add("TCP", "0.0.0.0", 90).build(),
 				make(map[string]*framework.ImageStateSummary),
+				rnq,
 			),
 		},
 	}}
 
 	for i, tt := range tests {
 		t.Run(fmt.Sprintf("case_%d", i), func(t *testing.T) {
-			cache := newSchedulerCache(ttl, time.Second, nil)
+			cache := newSchedulerCache(ttl, time.Second, nil, func() *framework.NodeInfo {
+				return framework.NewNodeInfo(rnq)
+			})
 			for _, podToAssume := range tt.podsToAssume {
 				if err := assumeAndFinishBinding(cache, podToAssume, now); err != nil {
 					t.Fatalf("assumePod failed: %v", err)
@@ -497,6 +536,7 @@ func TestAddPodAfterExpiration(t *testing.T) {
 	nodeName := "node"
 	ttl := 10 * time.Second
 	basePod := makeBasePod(t, nodeName, "test", "100m", "500", "", []v1.ContainerPort{{HostIP: "127.0.0.1", HostPort: 80, Protocol: "TCP"}})
+	rnq := getFakeResourceNameQualifier()
 	tests := []struct {
 		pod *v1.Pod
 
@@ -515,13 +555,16 @@ func TestAddPodAfterExpiration(t *testing.T) {
 			[]*v1.Pod{basePod},
 			newHostPortInfoBuilder().add("TCP", "127.0.0.1", 80).build(),
 			make(map[string]*framework.ImageStateSummary),
+			rnq,
 		),
 	}}
 
 	for i, tt := range tests {
 		t.Run(fmt.Sprintf("case_%d", i), func(t *testing.T) {
 			now := time.Now()
-			cache := newSchedulerCache(ttl, time.Second, nil)
+			cache := newSchedulerCache(ttl, time.Second, nil, func() *framework.NodeInfo {
+				return framework.NewNodeInfo(rnq)
+			})
 			if err := assumeAndFinishBinding(cache, tt.pod, now); err != nil {
 				t.Fatalf("assumePod failed: %v", err)
 			}
@@ -552,6 +595,7 @@ func TestUpdatePod(t *testing.T) {
 		makeBasePod(t, nodeName, "test", "100m", "500", "", []v1.ContainerPort{{HostIP: "127.0.0.1", HostPort: 80, Protocol: "TCP"}}),
 		makeBasePod(t, nodeName, "test", "200m", "1Ki", "", []v1.ContainerPort{{HostIP: "127.0.0.1", HostPort: 8080, Protocol: "TCP"}}),
 	}
+	rnq := getFakeResourceNameQualifier()
 	tests := []struct {
 		podsToAdd    []*v1.Pod
 		podsToUpdate []*v1.Pod
@@ -572,6 +616,7 @@ func TestUpdatePod(t *testing.T) {
 			[]*v1.Pod{testPods[1]},
 			newHostPortInfoBuilder().add("TCP", "127.0.0.1", 8080).build(),
 			make(map[string]*framework.ImageStateSummary),
+			rnq,
 		), newNodeInfo(
 			&framework.Resource{
 				MilliCPU: 100,
@@ -584,12 +629,15 @@ func TestUpdatePod(t *testing.T) {
 			[]*v1.Pod{testPods[0]},
 			newHostPortInfoBuilder().add("TCP", "127.0.0.1", 80).build(),
 			make(map[string]*framework.ImageStateSummary),
+			rnq,
 		)},
 	}}
 
 	for i, tt := range tests {
 		t.Run(fmt.Sprintf("case_%d", i), func(t *testing.T) {
-			cache := newSchedulerCache(ttl, time.Second, nil)
+			cache := newSchedulerCache(ttl, time.Second, nil, func() *framework.NodeInfo {
+				return framework.NewNodeInfo(rnq)
+			})
 			for _, podToAdd := range tt.podsToAdd {
 				if err := cache.AddPod(podToAdd); err != nil {
 					t.Fatalf("AddPod failed: %v", err)
@@ -651,7 +699,7 @@ func TestUpdatePodAndGet(t *testing.T) {
 
 	for i, tt := range tests {
 		t.Run(fmt.Sprintf("case_%d", i), func(t *testing.T) {
-			cache := newSchedulerCache(ttl, time.Second, nil)
+			cache := newSchedulerCache(ttl, time.Second, nil, newNodeInfoWithResourceNameQualifier)
 
 			if err := tt.handler(cache, tt.pod); err != nil {
 				t.Fatalf("unexpected err: %v", err)
@@ -684,6 +732,7 @@ func TestExpireAddUpdatePod(t *testing.T) {
 		makeBasePod(t, nodeName, "test", "100m", "500", "", []v1.ContainerPort{{HostIP: "127.0.0.1", HostPort: 80, Protocol: "TCP"}}),
 		makeBasePod(t, nodeName, "test", "200m", "1Ki", "", []v1.ContainerPort{{HostIP: "127.0.0.1", HostPort: 8080, Protocol: "TCP"}}),
 	}
+	rnq := getFakeResourceNameQualifier()
 	tests := []struct {
 		podsToAssume []*v1.Pod
 		podsToAdd    []*v1.Pod
@@ -706,6 +755,7 @@ func TestExpireAddUpdatePod(t *testing.T) {
 			[]*v1.Pod{testPods[1]},
 			newHostPortInfoBuilder().add("TCP", "127.0.0.1", 8080).build(),
 			make(map[string]*framework.ImageStateSummary),
+			rnq,
 		), newNodeInfo(
 			&framework.Resource{
 				MilliCPU: 100,
@@ -718,13 +768,16 @@ func TestExpireAddUpdatePod(t *testing.T) {
 			[]*v1.Pod{testPods[0]},
 			newHostPortInfoBuilder().add("TCP", "127.0.0.1", 80).build(),
 			make(map[string]*framework.ImageStateSummary),
+			rnq,
 		)},
 	}}
 
 	for i, tt := range tests {
 		t.Run(fmt.Sprintf("case_%d", i), func(t *testing.T) {
 			now := time.Now()
-			cache := newSchedulerCache(ttl, time.Second, nil)
+			cache := newSchedulerCache(ttl, time.Second, nil, func() *framework.NodeInfo {
+				return framework.NewNodeInfo(rnq)
+			})
 			for _, podToAssume := range tt.podsToAssume {
 				if err := assumeAndFinishBinding(cache, podToAssume, now); err != nil {
 					t.Fatalf("assumePod failed: %v", err)
@@ -781,6 +834,7 @@ func TestEphemeralStorageResource(t *testing.T) {
 	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.BalanceAttachedNodeVolumes, true)()
 	nodeName := "node"
 	podE := makePodWithEphemeralStorage(nodeName, "500")
+	rnq := getFakeResourceNameQualifier()
 	tests := []struct {
 		pod       *v1.Pod
 		wNodeInfo *framework.NodeInfo
@@ -798,12 +852,15 @@ func TestEphemeralStorageResource(t *testing.T) {
 				[]*v1.Pod{podE},
 				framework.HostPortInfo{},
 				make(map[string]*framework.ImageStateSummary),
+				rnq,
 			),
 		},
 	}
 	for i, tt := range tests {
 		t.Run(fmt.Sprintf("case_%d", i), func(t *testing.T) {
-			cache := newSchedulerCache(time.Second, time.Second, nil)
+			cache := newSchedulerCache(time.Second, time.Second, nil, func() *framework.NodeInfo {
+				return framework.NewNodeInfo(rnq)
+			})
 			if err := cache.AddPod(tt.pod); err != nil {
 				t.Fatalf("AddPod failed: %v", err)
 			}
@@ -827,6 +884,7 @@ func TestRemovePod(t *testing.T) {
 	// Enable volumesOnNodeForBalancing to do balanced resource allocation
 	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.BalanceAttachedNodeVolumes, true)()
 	basePod := makeBasePod(t, "node-1", "test", "100m", "500", "", []v1.ContainerPort{{HostIP: "127.0.0.1", HostPort: 80, Protocol: "TCP"}})
+	rnq := getFakeResourceNameQualifier()
 	tests := []struct {
 		nodes     []*v1.Node
 		pod       *v1.Pod
@@ -853,13 +911,16 @@ func TestRemovePod(t *testing.T) {
 			[]*v1.Pod{basePod},
 			newHostPortInfoBuilder().add("TCP", "127.0.0.1", 80).build(),
 			make(map[string]*framework.ImageStateSummary),
+			rnq,
 		),
 	}}
 
 	for i, tt := range tests {
 		t.Run(fmt.Sprintf("case_%d", i), func(t *testing.T) {
 			nodeName := tt.pod.Spec.NodeName
-			cache := newSchedulerCache(time.Second, time.Second, nil)
+			cache := newSchedulerCache(time.Second, time.Second, nil, func() *framework.NodeInfo {
+				return framework.NewNodeInfo(rnq)
+			})
 			// Add pod succeeds even before adding the nodes.
 			if err := cache.AddPod(tt.pod); err != nil {
 				t.Fatalf("AddPod failed: %v", err)
@@ -895,7 +956,7 @@ func TestForgetPod(t *testing.T) {
 	now := time.Now()
 	ttl := 10 * time.Second
 
-	cache := newSchedulerCache(ttl, time.Second, nil)
+	cache := newSchedulerCache(ttl, time.Second, nil, newNodeInfoWithResourceNameQualifier)
 	for _, pod := range pods {
 		if err := assumeAndFinishBinding(cache, pod, now); err != nil {
 			t.Fatalf("assumePod failed: %v", err)
@@ -930,9 +991,9 @@ func TestForgetPod(t *testing.T) {
 
 // buildNodeInfo creates a NodeInfo by simulating node operations in cache.
 func buildNodeInfo(node *v1.Node, pods []*v1.Pod) *framework.NodeInfo {
-	expected := framework.NewNodeInfo()
+	expected := newNodeInfoWithResourceNameQualifier()
 	expected.SetNode(node)
-	expected.Allocatable = framework.NewResource(node.Status.Allocatable)
+	expected.Allocatable = framework.NewResource(node.Status.Allocatable, getFakeResourceNameQualifier())
 	expected.Generation++
 	for _, pod := range pods {
 		expected.AddPod(pod)
@@ -1077,7 +1138,7 @@ func TestNodeOperators(t *testing.T) {
 			expected := buildNodeInfo(test.node, test.pods)
 			node := test.node
 
-			cache := newSchedulerCache(time.Second, time.Second, nil)
+			cache := newSchedulerCache(time.Second, time.Second, nil, newNodeInfoWithResourceNameQualifier)
 			cache.AddNode(node)
 			for _, pod := range test.pods {
 				if err := cache.AddPod(pod); err != nil {
@@ -1462,7 +1523,7 @@ func TestSchedulerCache_UpdateSnapshot(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			cache = newSchedulerCache(time.Second, time.Second, nil)
+			cache = newSchedulerCache(time.Second, time.Second, nil, newNodeInfoWithResourceNameQualifier)
 			snapshot = NewEmptySnapshot()
 
 			for _, op := range test.operations {
@@ -1677,7 +1738,7 @@ func TestSchedulerCache_updateNodeInfoSnapshotList(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			cache = newSchedulerCache(time.Second, time.Second, nil)
+			cache = newSchedulerCache(time.Second, time.Second, nil, newNodeInfoWithResourceNameQualifier)
 			snapshot = NewEmptySnapshot()
 
 			test.operations(t)
@@ -1771,7 +1832,7 @@ func makeBasePod(t testingMode, nodeName, objName, cpu, mem, extended string, po
 }
 
 func setupCacheOf1kNodes30kPods(b *testing.B) Cache {
-	cache := newSchedulerCache(time.Second, time.Second, nil)
+	cache := newSchedulerCache(time.Second, time.Second, nil, newNodeInfoWithResourceNameQualifier)
 	for i := 0; i < 1000; i++ {
 		nodeName := fmt.Sprintf("node-%d", i)
 		for j := 0; j < 30; j++ {
@@ -1787,7 +1848,7 @@ func setupCacheOf1kNodes30kPods(b *testing.B) Cache {
 }
 
 func setupCacheWithAssumedPods(b *testing.B, podNum int, assumedTime time.Time) *schedulerCache {
-	cache := newSchedulerCache(time.Second, time.Second, nil)
+	cache := newSchedulerCache(time.Second, time.Second, nil, newNodeInfoWithResourceNameQualifier)
 	for i := 0; i < podNum; i++ {
 		nodeName := fmt.Sprintf("node-%d", i/10)
 		objName := fmt.Sprintf("%s-pod-%d", nodeName, i%10)

--- a/pkg/scheduler/internal/cache/debugger/comparer_test.go
+++ b/pkg/scheduler/internal/cache/debugger/comparer_test.go
@@ -20,9 +20,10 @@ import (
 	"reflect"
 	"testing"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/kubernetes/pkg/scheduler/framework"
+	fakeframework "k8s.io/kubernetes/pkg/scheduler/framework/fake"
 )
 
 func TestCompareNodes(t *testing.T) {
@@ -177,7 +178,8 @@ func testComparePods(actual, cached, queued, missing, redundant []string, t *tes
 		pod.Namespace = "ns"
 		pod.Name = uid
 
-		nodeInfo[uid] = framework.NewNodeInfo(pod)
+		nodeInfo[uid] = fakeframework.NewNodeInfoWithEmptyResourceNameQualifier()
+		nodeInfo[uid].AddPod(pod)
 	}
 
 	m, r := compare.ComparePods(pods, queuedPods, nodeInfo)

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -50,6 +50,7 @@ import (
 	schedulerapi "k8s.io/kubernetes/pkg/scheduler/apis/config"
 	"k8s.io/kubernetes/pkg/scheduler/core"
 	"k8s.io/kubernetes/pkg/scheduler/framework"
+	fakeframework "k8s.io/kubernetes/pkg/scheduler/framework/fake"
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/defaultbinder"
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/nodeports"
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/noderesources"
@@ -180,6 +181,7 @@ func TestSchedulerCreation(t *testing.T) {
 				client,
 				informerFactory,
 				profile.NewRecorderFactory(eventBroadcaster),
+				fakeframework.EmptyResourceNameQualifier(),
 				stopCh,
 				tc.opts...,
 			)
@@ -461,6 +463,7 @@ func TestSchedulerMultipleProfilesScheduling(t *testing.T) {
 		client,
 		informerFactory,
 		profile.NewRecorderFactory(broadcaster),
+		fakeframework.EmptyResourceNameQualifier(),
 		ctx.Done(),
 		WithProfiles(
 			schedulerapi.KubeSchedulerProfile{SchedulerName: "match-machine2",
@@ -548,7 +551,7 @@ func TestSchedulerNoPhantomPodAfterExpire(t *testing.T) {
 	stop := make(chan struct{})
 	defer close(stop)
 	queuedPodStore := clientcache.NewFIFO(clientcache.MetaNamespaceKeyFunc)
-	scache := internalcache.New(100*time.Millisecond, stop)
+	scache := internalcache.New(100*time.Millisecond, stop, fakeframework.NewNodeInfoWithEmptyResourceNameQualifier)
 	pod := podWithPort("pod.Name", "", 8080)
 	node := v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "machine1", UID: types.UID("machine1")}}
 	scache.AddNode(&node)
@@ -615,7 +618,7 @@ func TestSchedulerNoPhantomPodAfterDelete(t *testing.T) {
 	stop := make(chan struct{})
 	defer close(stop)
 	queuedPodStore := clientcache.NewFIFO(clientcache.MetaNamespaceKeyFunc)
-	scache := internalcache.New(10*time.Minute, stop)
+	scache := internalcache.New(10*time.Minute, stop, fakeframework.NewNodeInfoWithEmptyResourceNameQualifier)
 	firstPod := podWithPort("pod.Name", "", 8080)
 	node := v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "machine1", UID: types.UID("machine1")}}
 	scache.AddNode(&node)
@@ -719,7 +722,7 @@ func TestSchedulerFailedSchedulingReasons(t *testing.T) {
 	stop := make(chan struct{})
 	defer close(stop)
 	queuedPodStore := clientcache.NewFIFO(clientcache.MetaNamespaceKeyFunc)
-	scache := internalcache.New(10*time.Minute, stop)
+	scache := internalcache.New(10*time.Minute, stop, fakeframework.NewNodeInfoWithEmptyResourceNameQualifier)
 
 	// Design the baseline for the pods, and we will make nodes that don't fit it later.
 	var cpu = int64(4)
@@ -864,7 +867,7 @@ func setupTestSchedulerWithVolumeBinding(volumeBinder scheduling.SchedulerVolume
 	pod.Spec.Volumes = append(pod.Spec.Volumes, v1.Volume{Name: "testVol",
 		VolumeSource: v1.VolumeSource{PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{ClaimName: "testPVC"}}})
 	queuedPodStore.Add(pod)
-	scache := internalcache.New(10*time.Minute, stop)
+	scache := internalcache.New(10*time.Minute, stop, fakeframework.NewNodeInfoWithEmptyResourceNameQualifier)
 	scache.AddNode(&testNode)
 	testPVC := v1.PersistentVolumeClaim{ObjectMeta: metav1.ObjectMeta{Name: "testPVC", Namespace: pod.Namespace, UID: types.UID("testPVC")}}
 	client := clientsetfake.NewSimpleClientset(&testNode, &testPVC)
@@ -1176,7 +1179,7 @@ func TestSchedulerBinding(t *testing.T) {
 			}
 			stop := make(chan struct{})
 			defer close(stop)
-			scache := internalcache.New(100*time.Millisecond, stop)
+			scache := internalcache.New(100*time.Millisecond, stop, fakeframework.NewNodeInfoWithEmptyResourceNameQualifier)
 			algo := core.NewGenericScheduler(
 				scache,
 				nil,

--- a/pkg/scheduler/util/utils.go
+++ b/pkg/scheduler/util/utils.go
@@ -31,7 +31,6 @@ import (
 	corev1helpers "k8s.io/component-helpers/scheduling/corev1"
 	"k8s.io/klog/v2"
 	extenderv1 "k8s.io/kube-scheduler/extender/v1"
-	v1helper "k8s.io/kubernetes/pkg/apis/core/v1/helper"
 )
 
 // GetPodFullName returns a name that uniquely identifies a pod.
@@ -135,10 +134,4 @@ func ClearNominatedNodeName(cs kubernetes.Interface, pods ...*v1.Pod) utilerrors
 		}
 	}
 	return utilerrors.NewAggregate(errs)
-}
-
-// IsScalarResourceName validates the resource for Extended, Hugepages, Native and AttachableVolume resources
-func IsScalarResourceName(name v1.ResourceName) bool {
-	return v1helper.IsExtendedResourceName(name) || v1helper.IsHugePageResourceName(name) ||
-		v1helper.IsPrefixedNativeResource(name) || v1helper.IsAttachableVolumeResourceName(name)
 }

--- a/pkg/util/resources/resourcenamequantifier.go
+++ b/pkg/util/resources/resourcenamequantifier.go
@@ -1,0 +1,44 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resources
+
+import (
+	v1 "k8s.io/api/core/v1"
+	v1helper "k8s.io/kubernetes/pkg/apis/core/v1/helper"
+)
+
+func NewResourceNameQualifier() *resourceNameQualifier {
+	return &resourceNameQualifier{}
+}
+
+type resourceNameQualifier struct{}
+
+func (rnq *resourceNameQualifier) IsExtended(name v1.ResourceName) bool {
+	return v1helper.IsExtendedResourceName(name)
+}
+
+func (rnq *resourceNameQualifier) IsHugePage(name v1.ResourceName) bool {
+	return v1helper.IsHugePageResourceName(name)
+}
+
+func (rnq *resourceNameQualifier) IsAttachableVolume(name v1.ResourceName) bool {
+	return v1helper.IsAttachableVolumeResourceName(name)
+}
+
+func (rnq *resourceNameQualifier) IsPrefixedNativeResource(name v1.ResourceName) bool {
+	return v1helper.IsPrefixedNativeResource(name)
+}

--- a/test/e2e/framework/.import-restrictions
+++ b/test/e2e/framework/.import-restrictions
@@ -226,6 +226,7 @@ rules:
       - k8s.io/kubernetes/pkg/util/procfs
       - k8s.io/kubernetes/pkg/util/removeall
       - k8s.io/kubernetes/pkg/util/resizefs
+      - k8s.io/kubernetes/pkg/util/resources
       - k8s.io/kubernetes/pkg/util/rlimit
       - k8s.io/kubernetes/pkg/util/selinux
       - k8s.io/kubernetes/pkg/util/slice

--- a/test/integration/daemonset/daemonset_test.go
+++ b/test/integration/daemonset/daemonset_test.go
@@ -46,6 +46,7 @@ import (
 	"k8s.io/kubernetes/pkg/scheduler"
 	"k8s.io/kubernetes/pkg/scheduler/profile"
 	labelsutil "k8s.io/kubernetes/pkg/util/labels"
+	"k8s.io/kubernetes/pkg/util/resources"
 	"k8s.io/kubernetes/test/integration/framework"
 )
 
@@ -91,6 +92,7 @@ func setupScheduler(
 		cs,
 		informerFactory,
 		profile.NewRecorderFactory(eventBroadcaster),
+		resources.NewResourceNameQualifier(),
 		ctx.Done(),
 	)
 	if err != nil {

--- a/test/integration/scheduler/scheduler_test.go
+++ b/test/integration/scheduler/scheduler_test.go
@@ -40,6 +40,7 @@ import (
 	kubeschedulerconfig "k8s.io/kubernetes/pkg/scheduler/apis/config"
 	"k8s.io/kubernetes/pkg/scheduler/profile"
 	st "k8s.io/kubernetes/pkg/scheduler/testing"
+	"k8s.io/kubernetes/pkg/util/resources"
 	"k8s.io/kubernetes/test/integration/framework"
 	testutils "k8s.io/kubernetes/test/integration/util"
 )
@@ -281,6 +282,7 @@ priorities: []
 		sched, err := scheduler.New(clientSet,
 			informerFactory,
 			profile.NewRecorderFactory(eventBroadcaster),
+			resources.NewResourceNameQualifier(),
 			nil,
 			scheduler.WithAlgorithmSource(kubeschedulerconfig.SchedulerAlgorithmSource{
 				Policy: &kubeschedulerconfig.SchedulerPolicySource{
@@ -334,6 +336,7 @@ func TestSchedulerCreationFromNonExistentConfigMap(t *testing.T) {
 	_, err := scheduler.New(clientSet,
 		informerFactory,
 		profile.NewRecorderFactory(eventBroadcaster),
+		resources.NewResourceNameQualifier(),
 		nil,
 		scheduler.WithAlgorithmSource(kubeschedulerconfig.SchedulerAlgorithmSource{
 			Policy: &kubeschedulerconfig.SchedulerPolicySource{

--- a/test/integration/scheduler_perf/scheduler_perf_test.go
+++ b/test/integration/scheduler_perf/scheduler_perf_test.go
@@ -47,6 +47,7 @@ import (
 	"k8s.io/kubernetes/pkg/scheduler/apis/config"
 	"k8s.io/kubernetes/pkg/scheduler/apis/config/scheme"
 	"k8s.io/kubernetes/pkg/scheduler/apis/config/validation"
+	"k8s.io/kubernetes/pkg/util/resources"
 	"k8s.io/kubernetes/test/integration/framework"
 	testutils "k8s.io/kubernetes/test/utils"
 	"sigs.k8s.io/yaml"
@@ -528,7 +529,7 @@ func runWorkload(b *testing.B, tc *testCase, w *workload) []DataItem {
 		if err != nil {
 			b.Fatalf("error loading scheduler config file: %v", err)
 		}
-		if err = validation.ValidateKubeSchedulerConfiguration(cfg); err != nil {
+		if err = validation.ValidateKubeSchedulerConfiguration(cfg, resources.NewResourceNameQualifier()); err != nil {
 			b.Fatalf("validate scheduler config file failed: %v", err)
 		}
 	}

--- a/test/integration/util/util.go
+++ b/test/integration/util/util.go
@@ -47,6 +47,7 @@ import (
 	"k8s.io/kubernetes/pkg/scheduler/apis/config/scheme"
 	schedulerapiv1 "k8s.io/kubernetes/pkg/scheduler/apis/config/v1"
 	"k8s.io/kubernetes/pkg/scheduler/profile"
+	"k8s.io/kubernetes/pkg/util/resources"
 	taintutils "k8s.io/kubernetes/pkg/util/taints"
 	"k8s.io/kubernetes/test/integration/framework"
 )
@@ -88,6 +89,7 @@ func StartScheduler(clientSet clientset.Interface, kubeConfig *restclient.Config
 		clientSet,
 		informerFactory,
 		profile.NewRecorderFactory(evtBroadcaster),
+		resources.NewResourceNameQualifier(),
 		ctx.Done(),
 		scheduler.WithKubeConfig(kubeConfig),
 		scheduler.WithProfiles(cfg.Profiles...),
@@ -410,6 +412,7 @@ func InitTestSchedulerWithOptions(
 		testCtx.ClientSet,
 		testCtx.InformerFactory,
 		profile.NewRecorderFactory(eventBroadcaster),
+		resources.NewResourceNameQualifier(),
 		testCtx.Ctx.Done(),
 		opts...,
 	)

--- a/test/integration/volumescheduling/util.go
+++ b/test/integration/volumescheduling/util.go
@@ -39,6 +39,7 @@ import (
 	"k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/pkg/scheduler"
 	"k8s.io/kubernetes/pkg/scheduler/profile"
+	"k8s.io/kubernetes/pkg/util/resources"
 	"k8s.io/kubernetes/test/integration/framework"
 )
 
@@ -124,6 +125,7 @@ func initTestSchedulerWithOptions(
 		testCtx.clientSet,
 		testCtx.informerFactory,
 		profile.NewRecorderFactory(eventBroadcaster),
+		resources.NewResourceNameQualifier(),
 		testCtx.ctx.Done())
 
 	if err != nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Removes `k8s.io/kubernetes/pkg/apis/core/v1/helper` from pkg/scheduler code base.

TBD

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

Part of https://github.com/kubernetes/kubernetes/issues/91782 effort

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
