### PR TITLE
Automated cherry pick of #100944: Ensure service deleted when the Azure resource group has been deleted

### DIFF
--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_backoff.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_backoff.go
@@ -275,6 +275,9 @@ func (az *Cloud) ListLB(service *v1.Service) ([]network.LoadBalancer, error) {
 	rgName := az.getLoadBalancerResourceGroup()
 	allLBs, rerr := az.LoadBalancerClient.List(ctx, rgName)
 	if rerr != nil {
+		if rerr.IsNotFound() {
+			return nil, nil
+		}
 		az.Event(service, v1.EventTypeWarning, "ListLoadBalancers", rerr.Error().Error())
 		klog.Errorf("LoadBalancerClient.List(%v) failure with err=%v", rgName, rerr)
 		return nil, rerr.Error()
@@ -290,6 +293,9 @@ func (az *Cloud) ListPIP(service *v1.Service, pipResourceGroup string) ([]networ
 
 	allPIPs, rerr := az.PublicIPAddressesClient.List(ctx, pipResourceGroup)
 	if rerr != nil {
+		if rerr.IsNotFound() {
+			return nil, nil
+		}
 		az.Event(service, v1.EventTypeWarning, "ListPublicIPs", rerr.Error().Error())
 		klog.Errorf("PublicIPAddressesClient.List(%v) failure with err=%v", pipResourceGroup, rerr)
 		return nil, rerr.Error()

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_backoff_test.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_backoff_test.go
@@ -294,26 +294,57 @@ func TestListLB(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
-	az := GetTestCloud(ctrl)
-	mockLBClient := az.LoadBalancerClient.(*mockloadbalancerclient.MockInterface)
-	mockLBClient.EXPECT().List(gomock.Any(), az.ResourceGroup).Return(nil, &retry.Error{HTTPStatusCode: http.StatusInternalServerError})
+	tests := []struct {
+		clientErr   *retry.Error
+		expectedErr error
+	}{
+		{
+			clientErr:   &retry.Error{HTTPStatusCode: http.StatusInternalServerError},
+			expectedErr: fmt.Errorf("Retriable: false, RetryAfter: 0s, HTTPStatusCode: 500, RawError: <nil>"),
+		},
+		{
+			clientErr:   &retry.Error{HTTPStatusCode: http.StatusNotFound},
+			expectedErr: nil,
+		},
+	}
+	for _, test := range tests {
+		az := GetTestCloud(ctrl)
+		mockLBClient := az.LoadBalancerClient.(*mockloadbalancerclient.MockInterface)
+		mockLBClient.EXPECT().List(gomock.Any(), az.ResourceGroup).Return(nil, test.clientErr)
 
-	pips, err := az.ListLB(&v1.Service{})
-	assert.Equal(t, fmt.Errorf("Retriable: false, RetryAfter: 0s, HTTPStatusCode: 500, RawError: <nil>"), err)
-	assert.Empty(t, pips)
+		pips, err := az.ListLB(&v1.Service{})
+		assert.Equal(t, test.expectedErr, err)
+		assert.Empty(t, pips)
+	}
+
 }
 
 func TestListPIP(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
-	az := GetTestCloud(ctrl)
-	mockPIPClient := az.PublicIPAddressesClient.(*mockpublicipclient.MockInterface)
-	mockPIPClient.EXPECT().List(gomock.Any(), az.ResourceGroup).Return(nil, &retry.Error{HTTPStatusCode: http.StatusInternalServerError})
+	tests := []struct {
+		clientErr   *retry.Error
+		expectedErr error
+	}{
+		{
+			clientErr:   &retry.Error{HTTPStatusCode: http.StatusInternalServerError},
+			expectedErr: fmt.Errorf("Retriable: false, RetryAfter: 0s, HTTPStatusCode: 500, RawError: <nil>"),
+		},
+		{
+			clientErr:   &retry.Error{HTTPStatusCode: http.StatusNotFound},
+			expectedErr: nil,
+		},
+	}
+	for _, test := range tests {
+		az := GetTestCloud(ctrl)
+		mockPIPClient := az.PublicIPAddressesClient.(*mockpublicipclient.MockInterface)
+		mockPIPClient.EXPECT().List(gomock.Any(), az.ResourceGroup).Return(nil, test.clientErr)
 
-	pips, err := az.ListPIP(&v1.Service{}, az.ResourceGroup)
-	assert.Equal(t, fmt.Errorf("Retriable: false, RetryAfter: 0s, HTTPStatusCode: 500, RawError: <nil>"), err)
-	assert.Empty(t, pips)
+		pips, err := az.ListPIP(&v1.Service{}, az.ResourceGroup)
+		assert.Equal(t, test.expectedErr, err)
+		assert.Empty(t, pips)
+	}
 }
 
 func TestCreateOrUpdatePIP(t *testing.T) {


### PR DESCRIPTION
Cherry pick of #100944 on release-1.20.

#100944: Ensure service deleted when the Azure resource group has been deleted

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.