### PR TITLE
fix SetStatusCondition() for nil conditions

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/api/meta/conditions.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/meta/conditions.go
@@ -28,7 +28,7 @@ import (
 //    newCondition, LastTransitionTime is set to now if the new status differs from the old status)
 // 2. if a condition of the specified type does not exist (LastTransitionTime is set to now() if unset, and newCondition is appended)
 func SetStatusCondition(conditions *[]metav1.Condition, newCondition metav1.Condition) {
-	if conditions == nil {
+	if *conditions == nil {
 		return
 	}
 	existingCondition := FindStatusCondition(*conditions, newCondition.Type)
@@ -57,7 +57,7 @@ func SetStatusCondition(conditions *[]metav1.Condition, newCondition metav1.Cond
 // RemoveStatusCondition removes the corresponding conditionType from conditions.
 // conditions must be non-nil.
 func RemoveStatusCondition(conditions *[]metav1.Condition, conditionType string) {
-	if conditions == nil || len(*conditions) == 0 {
+	if len(*conditions) == 0 {
 		return
 	}
 	newConditions := make([]metav1.Condition, 0, len(*conditions)-1)

--- a/staging/src/k8s.io/apimachinery/pkg/api/meta/conditions_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/meta/conditions_test.go
@@ -75,6 +75,12 @@ func TestSetStatusCondition(t *testing.T) {
 				{Type: "third"},
 			},
 		},
+		{
+			name:       "should-not-add-for-nil-conditions",
+			conditions: nil,
+			toAdd:      metav1.Condition{Type: "second", Status: metav1.ConditionTrue, LastTransitionTime: metav1.Time{Time: oneHourBefore}, Reason: "reason", Message: "message"},
+			expected:   nil,
+		},
 	}
 
 	for _, test := range tests {
@@ -126,6 +132,12 @@ func TestRemoveStatusCondition(t *testing.T) {
 			conditions:    []metav1.Condition{},
 			conditionType: "Foo",
 			expected:      []metav1.Condition{},
+		},
+		{
+			name:          "nil-conditions",
+			conditions:    nil,
+			conditionType: "nil",
+			expected:      nil,
 		},
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind cleanup

#### What this PR does / why we need it:
setting status for nil conditions fixed

- pointer to type conditions could never be nil

There could be 2 ways of using SetStatusCondition() based on declaring empty conditions slices
If one use var a []metav1.Condition, the variable needs an allocation.
```
var a []metav1.Condition
a = make([]metav1.Condition, 0)
```

Else if b := []metav1.Condition{} is used, nothing changes.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
For whom to use conditions in custom resource operator's Status, they need to allocate memory for the CustomResource.Status.Conditions.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
