### PR TITLE
Automated cherry pick of #101398: fix: set "host is down" as corrupted mount

### DIFF
--- a/staging/src/k8s.io/mount-utils/mount_helper_unix.go
+++ b/staging/src/k8s.io/mount-utils/mount_helper_unix.go
@@ -52,7 +52,7 @@ func IsCorruptedMnt(err error) bool {
 		underlyingError = pe.Err
 	}
 
-	return underlyingError == syscall.ENOTCONN || underlyingError == syscall.ESTALE || underlyingError == syscall.EIO || underlyingError == syscall.EACCES
+	return underlyingError == syscall.ENOTCONN || underlyingError == syscall.ESTALE || underlyingError == syscall.EIO || underlyingError == syscall.EACCES || underlyingError == syscall.EHOSTDOWN
 }
 
 // MountInfo represents a single line in /proc/<pid>/mountinfo.

--- a/staging/src/k8s.io/mount-utils/mount_helper_windows.go
+++ b/staging/src/k8s.io/mount-utils/mount_helper_windows.go
@@ -38,7 +38,8 @@ import (
 // ERROR_BAD_NET_NAME                = 67
 // ERROR_SESSION_CREDENTIAL_CONFLICT = 1219
 // ERROR_LOGON_FAILURE               = 1326
-var errorNoList = [...]int{53, 54, 59, 64, 65, 66, 67, 1219, 1326}
+// WSAEHOSTDOWN                      = 10064
+var errorNoList = [...]int{53, 54, 59, 64, 65, 66, 67, 1219, 1326, 10064}
 
 // IsCorruptedMnt return true if err is about corrupted mount point
 func IsCorruptedMnt(err error) bool {


### PR DESCRIPTION
Cherry pick of #101398 on release-1.20.

#101398: fix: set "host is down" as corrupted mount

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.