### PR TITLE
kubelet: do not cleanup volumes if pod is being killed

### DIFF
--- a/pkg/kubelet/kubelet_test.go
+++ b/pkg/kubelet/kubelet_test.go
@@ -119,7 +119,9 @@ type TestKubelet struct {
 
 func (tk *TestKubelet) Cleanup() {
 	if tk.kubelet != nil {
+		tk.kubelet.podKiller.Close()
 		os.RemoveAll(tk.kubelet.rootDirectory)
+		tk.kubelet = nil
 	}
 }
 
@@ -292,6 +294,7 @@ func newTestKubeletWithImageList(
 	kubelet.backOff = flowcontrol.NewBackOff(time.Second, time.Minute)
 	kubelet.backOff.Clock = fakeClock
 	kubelet.podKiller = NewPodKiller(kubelet)
+	go kubelet.podKiller.PerformPodKillingWork()
 	kubelet.resyncInterval = 10 * time.Second
 	kubelet.workQueue = queue.NewBasicWorkQueue(fakeClock)
 	// Relist period does not affect the tests.
@@ -420,9 +423,7 @@ func TestSyncPodsStartPod(t *testing.T) {
 
 func TestHandlePodCleanupsPerQOS(t *testing.T) {
 	testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled */)
-	go testKubelet.kubelet.podKiller.PerformPodKillingWork()
 	defer testKubelet.Cleanup()
-	defer testKubelet.kubelet.podKiller.Close()
 
 	pod := &kubecontainer.Pod{
 		ID:        "12345678",
@@ -612,9 +613,7 @@ func TestDispatchWorkOfActivePod(t *testing.T) {
 
 func TestHandlePodCleanups(t *testing.T) {
 	testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled */)
-	go testKubelet.kubelet.podKiller.PerformPodKillingWork()
 	defer testKubelet.Cleanup()
-	defer testKubelet.kubelet.podKiller.Close()
 
 	pod := &kubecontainer.Pod{
 		ID:        "12345678",
@@ -643,8 +642,6 @@ func TestHandlePodRemovesWhenSourcesAreReady(t *testing.T) {
 
 	testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled */)
 	defer testKubelet.Cleanup()
-	go testKubelet.kubelet.podKiller.PerformPodKillingWork()
-	defer testKubelet.kubelet.podKiller.Close()
 
 	fakePod := &kubecontainer.Pod{
 		ID:        "1",
@@ -683,8 +680,6 @@ func TestHandlePodRemovesWhenSourcesAreReady(t *testing.T) {
 func TestKillPodFollwedByIsPodPendingTermination(t *testing.T) {
 	testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled */)
 	defer testKubelet.Cleanup()
-	defer testKubelet.kubelet.podKiller.Close()
-	go testKubelet.kubelet.podKiller.PerformPodKillingWork()
 
 	pod := &kubecontainer.Pod{
 		ID:        "12345678",

--- a/pkg/kubelet/kubelet_test.go
+++ b/pkg/kubelet/kubelet_test.go
@@ -1596,6 +1596,12 @@ func syncAndVerifyPodDir(t *testing.T, testKubelet *TestKubelet, pods []*v1.Pod,
 	kl.podManager.SetPods(pods)
 	kl.HandlePodSyncs(pods)
 	kl.HandlePodCleanups()
+	// The first time HandlePodCleanups() is run the pod is placed into the
+	// podKiller, and bypasses the pod directory cleanup. The pod is
+	// already killed in the second run to HandlePodCleanups() and will
+	// cleanup the directories.
+	time.Sleep(2 * time.Second)
+	kl.HandlePodCleanups()
 	for i, pod := range podsToCheck {
 		exist := dirExists(kl.getPodDir(pod.UID))
 		assert.Equal(t, shouldExist, exist, "directory of pod %d", i)

--- a/pkg/kubelet/kubelet_volumes.go
+++ b/pkg/kubelet/kubelet_volumes.go
@@ -133,6 +133,11 @@ func (kl *Kubelet) cleanupOrphanedPodDirs(pods []*v1.Pod, runningPods []*kubecon
 		if allPods.Has(string(uid)) {
 			continue
 		}
+		// if the pod is within termination grace period, we shouldn't cleanup the underlying volumes
+		if kl.podKiller.IsPodPendingTerminationByUID(uid) {
+			klog.V(3).InfoS("Pod is pending termination", "podUID", uid)
+			continue
+		}
 		// If volumes have not been unmounted/detached, do not delete directory.
 		// Doing so may result in corruption of data.
 		// TODO: getMountedVolumePathListFromDisk() call may be redundant with


### PR DESCRIPTION
#### What type of PR is this?
/kind bug
/sig node

#### What this PR does / why we need it:
This PR fixes another race in HandlePodCleanups on Volume mounts. This PR superscedes my prior PR https://github.com/kubernetes/kubernetes/pull/101376 since HandlePodCleanups is not supposed to block due to running in the main Kubelet loop.

The change here adds onto https://github.com/kubernetes/kubernetes/pull/98424 which added a check into cleanupOrphanedPodCgroups if the pod was being killed. Volumes can begin to be torn down while the pod is within the podkiller causing pod shutdown issues (never restarting, extremely slow restarts - tens of minutes).

This PR also cleans up the podkiller in the main TestKubelet Cleanup() function.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
