### PR TITLE
Fixes formatting and typos in client-go docs

### DIFF
--- a/staging/src/k8s.io/client-go/tools/cache/controller.go
+++ b/staging/src/k8s.io/client-go/tools/cache/controller.go
@@ -325,7 +325,7 @@ func NewInformer(
 	return clientState, newInformer(lw, objType, resyncPeriod, h, clientState)
 }
 
-// NewIndexerInformer returns a Indexer and a controller for populating the index
+// NewIndexerInformer returns an Indexer and a Controller for populating the index
 // while also providing event notifications. You should only used the returned
 // Index for Get/List operations; Add/Modify/Deletes will cause the event
 // notifications to be faulty.

--- a/staging/src/k8s.io/client-go/tools/cache/delta_fifo.go
+++ b/staging/src/k8s.io/client-go/tools/cache/delta_fifo.go
@@ -153,7 +153,7 @@ const (
 // change happened, and the object's state after* that change.
 //
 // [*] Unless the change is a deletion, and then you'll get the final
-//     state of the object before it was deleted.
+// state of the object before it was deleted.
 type Delta struct {
 	Type   DeltaType
 	Object interface{}
@@ -174,9 +174,10 @@ type Deltas []Delta
 // modifications.
 //
 // TODO: consider merging keyLister with this object, tracking a list of
-//       "known" keys when Pop() is called. Have to think about how that
-//       affects error retrying.
-// NOTE: It is possible to misuse this and cause a race when using an
+// "known" keys when Pop() is called. Have to think about how that
+// affects error retrying.
+//
+//       NOTE: It is possible to misuse this and cause a race when using an
 //       external known object source.
 //       Whether there is a potential race depends on how the consumer
 //       modifies knownObjects. In Pop(), process function is called under
@@ -185,8 +186,7 @@ type Deltas []Delta
 //
 //       Example:
 //       In case of sharedIndexInformer being a consumer
-//       (https://github.com/kubernetes/kubernetes/blob/0cdd940f/staging/
-//       src/k8s.io/client-go/tools/cache/shared_informer.go#L192),
+//       (https://github.com/kubernetes/kubernetes/blob/0cdd940f/staging/src/k8s.io/client-go/tools/cache/shared_informer.go#L192),
 //       there is no race as knownObjects (s.indexer) is modified safely
 //       under DeltaFIFO's lock. The only exceptions are GetStore() and
 //       GetIndexer() methods, which expose ways to modify the underlying


### PR DESCRIPTION
This PR fixes rendering of client-go/tools/cache documentation on pkg.go.dev and the likes.

Part of the documentation looks like this right now:

![image](https://user-images.githubusercontent.com/29277957/116304946-63c08000-a7a3-11eb-9afc-28ad8f139184.png)

With the PR applied it looks like this:

![image](https://user-images.githubusercontent.com/29277957/116305055-894d8980-a7a3-11eb-8edb-1133257e5e0b.png)


A few minor typos have also been adressed.

/kind documentation