### PR TITLE
sched: make CycleState's Read()/Write()/Delete() thread-safe

### DIFF
--- a/pkg/scheduler/framework/plugins/examples/multipoint/multipoint.go
+++ b/pkg/scheduler/framework/plugins/examples/multipoint/multipoint.go
@@ -56,9 +56,7 @@ func (mc CommunicatingPlugin) Reserve(ctx context.Context, state *framework.Cycl
 		return framework.NewStatus(framework.Error, "pod cannot be nil")
 	}
 	if pod.Name == "my-test-pod" {
-		state.Lock()
 		state.Write(framework.StateKey(pod.Name), &stateData{data: "never bind"})
-		state.Unlock()
 	}
 	return nil
 }
@@ -67,12 +65,10 @@ func (mc CommunicatingPlugin) Reserve(ctx context.Context, state *framework.Cycl
 // during "reserve" extension point or later.
 func (mc CommunicatingPlugin) Unreserve(ctx context.Context, state *framework.CycleState, pod *v1.Pod, nodeName string) {
 	if pod.Name == "my-test-pod" {
-		state.Lock()
 		// The pod is at the end of its lifecycle -- let's clean up the allocated
 		// resources. In this case, our clean up is simply deleting the key written
 		// in the Reserve operation.
 		state.Delete(framework.StateKey(pod.Name))
-		state.Unlock()
 	}
 }
 
@@ -81,8 +77,6 @@ func (mc CommunicatingPlugin) PreBind(ctx context.Context, state *framework.Cycl
 	if pod == nil {
 		return framework.NewStatus(framework.Error, "pod cannot be nil")
 	}
-	state.RLock()
-	defer state.RUnlock()
 	if v, e := state.Read(framework.StateKey(pod.Name)); e == nil {
 		if value, ok := v.(*stateData); ok && value.data == "never bind" {
 			return framework.NewStatus(framework.Unschedulable, "pod is not permitted")


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/sig scheduling

#### What this PR does / why we need it:

This is a followup of the TBD item in https://github.com/kubernetes/kubernetes/issues/95887#issuecomment-722187136.

Scheduler used and exposed a map called `CycleState` to store transient data within one scheduling cycle. This struct is usually keyed with a particular plugin name + phase (PreFilter or PreScore), and valued with the concrete data. Without this PR, this struct is:

1. written without locking in PreFilter / PreScore phases
2. read without locking in Filter / Score phases

Behavior 2 should be adjusted to acquire read lock before using it as we shouldn't make that assumption for out-of-tree plugins - which is how the racing condition occured in #95887. (although in-tree plugins don't write data to `CycleState`)

In terms of behavior 1, although in-tree plugins use Write() in sequential phase, and hence _can_ be lock-free. But again, to eventually remove misleading Lock()/Unlock() functions in CycleState, we decide to make no assumption which phase it can/should be used, in other words, add lock inside Write() as well.

Note that the racing pattern this PR solves is **multiple plugins run in parallel** to compete for `CycleSatate`. Another racing pattern is **the same plugin runs in parallel (on different nodes)**, which can be resolved by the plugin's implementation itself (check #96777 for more details).

#### Which issue(s) this PR fixes:

Fixes #95887

#### Special notes for your reviewer:

I didn't see an obvious performance downgrade according to the bench diff:

<details>
  <summary>SchedulingBasic/5000Nodes</summary>
  
  ```
  +--------------------------+---------------------------+----------+--------+---------+---------+---------+
  |          METRIC          |           GROUP           | QUANTILE |  UNIT  |   OLD   |   NEW   |  DIFF   |
  +--------------------------+---------------------------+----------+--------+---------+---------+---------+
  | SchedulingThroughput     | SchedulingBasic/5000Nodes | Average  | pods/s |  166.67 |  162.56 | -2.47%  |
  | SchedulingThroughput     | SchedulingBasic/5000Nodes | Perc50   | pods/s |  178.56 |  184.89 | +3.55%  |
  | SchedulingThroughput     | SchedulingBasic/5000Nodes | Perc90   | pods/s |  208.00 |  202.30 | -2.74%  |
  | SchedulingThroughput     | SchedulingBasic/5000Nodes | Perc99   | pods/s |  209.00 |  202.50 | -3.11%  |
  | scheduler_e2e_scheduling | SchedulingBasic/5000Nodes | Average  | ms     |   26.75 |   25.30 | -5.41%  |
  | scheduler_e2e_scheduling | SchedulingBasic/5000Nodes | Perc50   | ms     |   12.53 |   12.52 | -0.09%  |
  | scheduler_e2e_scheduling | SchedulingBasic/5000Nodes | Perc90   | ms     |   29.98 |   30.88 | +3.01%  |
  | scheduler_e2e_scheduling | SchedulingBasic/5000Nodes | Perc99   | ms     |  524.08 |  446.84 | -14.74% |
  | scheduler_pod_scheduling | SchedulingBasic/5000Nodes | Average  | ms     | 2382.24 | 2498.31 | +4.87%  |
  | scheduler_pod_scheduling | SchedulingBasic/5000Nodes | Perc50   | ms     | 2447.23 | 2604.43 | +6.42%  |
  | scheduler_pod_scheduling | SchedulingBasic/5000Nodes | Perc90   | ms     | 4565.14 | 4613.83 | +1.07%  |
  | scheduler_pod_scheduling | SchedulingBasic/5000Nodes | Perc99   | ms     | 5064.51 | 5069.38 | +0.10%  |
  +--------------------------+---------------------------+----------+--------+---------+---------+---------+
  ```
</details>

<details>
  <summary>Preemption/5000Nodes</summary>
  
  ```
  +--------------------------+----------------------+----------+--------+-----------+-----------+--------+
  |          METRIC          |        GROUP         | QUANTILE |  UNIT  |    OLD    |    NEW    |  DIFF  |
  +--------------------------+----------------------+----------+--------+-----------+-----------+--------+
  | SchedulingThroughput     | Preemption/5000Nodes | Average  | pods/s |      9.90 |      9.78 | -1.18% |
  | SchedulingThroughput     | Preemption/5000Nodes | Perc50   | pods/s |      0.00 |      0.00 | NaN%   |
  | SchedulingThroughput     | Preemption/5000Nodes | Perc90   | pods/s |     42.40 |     42.20 | -0.47% |
  | SchedulingThroughput     | Preemption/5000Nodes | Perc99   | pods/s |     67.40 |     66.62 | -1.15% |
  | scheduler_e2e_scheduling | Preemption/5000Nodes | Average  | ms     |     36.57 |     36.53 | -0.10% |
  | scheduler_e2e_scheduling | Preemption/5000Nodes | Perc50   | ms     |     26.96 |     27.08 | +0.44% |
  | scheduler_e2e_scheduling | Preemption/5000Nodes | Perc90   | ms     |     85.95 |     84.09 | -2.16% |
  | scheduler_e2e_scheduling | Preemption/5000Nodes | Perc99   | ms     |    194.85 |    189.65 | -2.67% |
  | scheduler_pod_scheduling | Preemption/5000Nodes | Average  | ms     | 456669.70 | 460623.34 | +0.87% |
  | scheduler_pod_scheduling | Preemption/5000Nodes | Perc50   | ms     | 490881.59 | 491069.79 | +0.04% |
  | scheduler_pod_scheduling | Preemption/5000Nodes | Perc90   | ms     | 622464.32 | 622501.96 | +0.01% |
  | scheduler_pod_scheduling | Preemption/5000Nodes | Perc99   | ms     | 652070.43 | 652074.20 | +0.00% |
  +--------------------------+----------------------+----------+--------+-----------+-----------+--------+
  ```
</details>

<details>
  <summary>SchedulingNodeAffinity/5000Nodes</summary>
  
  ```
  +--------------------------+----------------------------------+----------+--------+---------+---------+---------+
  |          METRIC          |              GROUP               | QUANTILE |  UNIT  |   OLD   |   NEW   |  DIFF   |
  +--------------------------+----------------------------------+----------+--------+---------+---------+---------+
  | SchedulingThroughput     | SchedulingNodeAffinity/5000Nodes | Average  | pods/s |  125.00 |  125.00 | +0.00%  |
  | SchedulingThroughput     | SchedulingNodeAffinity/5000Nodes | Perc50   | pods/s |  117.00 |  120.00 | +2.56%  |
  | SchedulingThroughput     | SchedulingNodeAffinity/5000Nodes | Perc90   | pods/s |  190.50 |  187.40 | -1.63%  |
  | SchedulingThroughput     | SchedulingNodeAffinity/5000Nodes | Perc99   | pods/s |  190.50 |  187.40 | -1.63%  |
  | scheduler_e2e_scheduling | SchedulingNodeAffinity/5000Nodes | Average  | ms     |   91.10 |   77.56 | -14.86% |
  | scheduler_e2e_scheduling | SchedulingNodeAffinity/5000Nodes | Perc50   | ms     |   15.11 |   15.00 | -0.73%  |
  | scheduler_e2e_scheduling | SchedulingNodeAffinity/5000Nodes | Perc90   | ms     |   67.56 |   57.52 | -14.86% |
  | scheduler_e2e_scheduling | SchedulingNodeAffinity/5000Nodes | Perc99   | ms     | 2483.95 | 1880.22 | -24.31% |
  | scheduler_pod_scheduling | SchedulingNodeAffinity/5000Nodes | Average  | ms     | 3058.69 | 3080.09 | +0.70%  |
  | scheduler_pod_scheduling | SchedulingNodeAffinity/5000Nodes | Perc50   | ms     | 3297.63 | 3227.48 | -2.13%  |
  | scheduler_pod_scheduling | SchedulingNodeAffinity/5000Nodes | Perc90   | ms     | 4762.16 | 4757.87 | -0.09%  |
  | scheduler_pod_scheduling | SchedulingNodeAffinity/5000Nodes | Perc99   | ms     | 6228.38 | 6765.56 | +8.62%  |
  +--------------------------+----------------------------------+----------+--------+---------+---------+---------+
  ```
</details>

<details>
  <summary>SchedulingPodAffinity/5000Nodes</summary>
  
  ```
  +--------------------------+---------------------------------+----------+--------+----------+----------+--------+
  |          METRIC          |              GROUP              | QUANTILE |  UNIT  |   OLD    |   NEW    |  DIFF  |
  +--------------------------+---------------------------------+----------+--------+----------+----------+--------+
  | SchedulingThroughput     | SchedulingPodAffinity/5000Nodes | Average  | pods/s |    33.65 |    33.23 | -1.25% |
  | SchedulingThroughput     | SchedulingPodAffinity/5000Nodes | Perc50   | pods/s |    34.10 |    33.22 | -2.57% |
  | SchedulingThroughput     | SchedulingPodAffinity/5000Nodes | Perc90   | pods/s |    42.90 |    42.50 | -0.93% |
  | SchedulingThroughput     | SchedulingPodAffinity/5000Nodes | Perc99   | pods/s |    46.60 |    45.10 | -3.22% |
  | scheduler_e2e_scheduling | SchedulingPodAffinity/5000Nodes | Average  | ms     |    45.07 |    45.56 | +1.09% |
  | scheduler_e2e_scheduling | SchedulingPodAffinity/5000Nodes | Perc50   | ms     |    39.93 |    39.74 | -0.48% |
  | scheduler_e2e_scheduling | SchedulingPodAffinity/5000Nodes | Perc90   | ms     |    92.52 |    90.29 | -2.40% |
  | scheduler_e2e_scheduling | SchedulingPodAffinity/5000Nodes | Perc99   | ms     |   206.22 |   205.90 | -0.16% |
  | scheduler_pod_scheduling | SchedulingPodAffinity/5000Nodes | Average  | ms     | 14263.98 | 14465.57 | +1.41% |
  | scheduler_pod_scheduling | SchedulingPodAffinity/5000Nodes | Perc50   | ms     | 14118.47 | 14445.44 | +2.32% |
  | scheduler_pod_scheduling | SchedulingPodAffinity/5000Nodes | Perc90   | ms     | 33113.01 | 33451.37 | +1.02% |
  | scheduler_pod_scheduling | SchedulingPodAffinity/5000Nodes | Perc99   | ms     | 40175.30 | 40209.14 | +0.08% |
  +--------------------------+---------------------------------+----------+--------+----------+----------+--------+
  ```
</details>

<details>
  <summary>SchedulingPodAntiAffinity/5000Nodes</summary>
  
  ```
  +--------------------------+-------------------------------------+----------+--------+---------+---------+---------+
  |          METRIC          |                GROUP                | QUANTILE |  UNIT  |   OLD   |   NEW   |  DIFF   |
  +--------------------------+-------------------------------------+----------+--------+---------+---------+---------+
  | SchedulingThroughput     | SchedulingPodAntiAffinity/5000Nodes | Average  | pods/s |  118.00 |  117.57 | -0.37%  |
  | SchedulingThroughput     | SchedulingPodAntiAffinity/5000Nodes | Perc50   | pods/s |  115.60 |  111.40 | -3.63%  |
  | SchedulingThroughput     | SchedulingPodAntiAffinity/5000Nodes | Perc90   | pods/s |  178.90 |  178.00 | -0.50%  |
  | SchedulingThroughput     | SchedulingPodAntiAffinity/5000Nodes | Perc99   | pods/s |  178.90 |  178.00 | -0.50%  |
  | scheduler_e2e_scheduling | SchedulingPodAntiAffinity/5000Nodes | Average  | ms     |   88.81 |  131.50 | +48.07% |
  | scheduler_e2e_scheduling | SchedulingPodAntiAffinity/5000Nodes | Perc50   | ms     |   13.04 |   13.54 | +3.83%  |
  | scheduler_e2e_scheduling | SchedulingPodAntiAffinity/5000Nodes | Perc90   | ms     |  119.43 |  152.76 | +27.91% |
  | scheduler_e2e_scheduling | SchedulingPodAntiAffinity/5000Nodes | Perc99   | ms     | 2038.12 | 2649.58 | +30.00% |
  | scheduler_pod_scheduling | SchedulingPodAntiAffinity/5000Nodes | Average  | ms     | 1028.14 | 1061.80 | +3.27%  |
  | scheduler_pod_scheduling | SchedulingPodAntiAffinity/5000Nodes | Perc50   | ms     | 1028.81 | 1064.57 | +3.48%  |
  | scheduler_pod_scheduling | SchedulingPodAntiAffinity/5000Nodes | Perc90   | ms     | 2225.85 | 2267.39 | +1.87%  |
  | scheduler_pod_scheduling | SchedulingPodAntiAffinity/5000Nodes | Perc99   | ms     | 3165.23 | 3599.39 | +13.72% |
  +--------------------------+-------------------------------------+----------+--------+---------+---------+---------+
  ```
</details>

<details>
  <summary>TopologySpreading/5000Nodes</summary>
  
  ```
  +--------------------------+-----------------------------+----------+--------+----------+----------+--------+
  |          METRIC          |            GROUP            | QUANTILE |  UNIT  |   OLD    |   NEW    |  DIFF  |
  +--------------------------+-----------------------------+----------+--------+----------+----------+--------+
  | SchedulingThroughput     | TopologySpreading/5000Nodes | Average  | pods/s |    64.75 |    63.56 | -1.84% |
  | SchedulingThroughput     | TopologySpreading/5000Nodes | Perc50   | pods/s |    69.50 |    67.60 | -2.73% |
  | SchedulingThroughput     | TopologySpreading/5000Nodes | Perc90   | pods/s |    80.90 |    79.90 | -1.24% |
  | SchedulingThroughput     | TopologySpreading/5000Nodes | Perc99   | pods/s |    86.80 |    85.50 | -1.50% |
  | scheduler_e2e_scheduling | TopologySpreading/5000Nodes | Average  | ms     |    26.64 |    27.61 | +3.64% |
  | scheduler_e2e_scheduling | TopologySpreading/5000Nodes | Perc50   | ms     |    18.13 |    19.30 | +6.45% |
  | scheduler_e2e_scheduling | TopologySpreading/5000Nodes | Perc90   | ms     |    46.88 |    47.63 | +1.60% |
  | scheduler_e2e_scheduling | TopologySpreading/5000Nodes | Perc99   | ms     |   149.39 |   153.74 | +2.91% |
  | scheduler_pod_scheduling | TopologySpreading/5000Nodes | Average  | ms     | 14399.95 | 14615.29 | +1.50% |
  | scheduler_pod_scheduling | TopologySpreading/5000Nodes | Perc50   | ms     | 14435.52 | 14594.17 | +1.10% |
  | scheduler_pod_scheduling | TopologySpreading/5000Nodes | Perc90   | ms     | 33046.80 | 33264.58 | +0.66% |
  | scheduler_pod_scheduling | TopologySpreading/5000Nodes | Perc99   | ms     | 40168.68 | 40190.46 | +0.05% |
  +--------------------------+-----------------------------+----------+--------+----------+----------+--------+
  ```
</details>

#### Does this PR introduce a user-facing change?

```release-note
Scheduler's CycleState now embeds internal read/write locking inside its Read() and Write() functions. Meanwhile, Lock() and Unlock() function are removed.

action required: scheduler plugin developers are now required to remove CycleState#Lock() and CycleState#Unlock(). Just simply use Read() and Write() as they're natively thread-safe now.
```