### PR TITLE
Automated cherry pick of #100731: Normalize share name to not include capital letters

### DIFF
--- a/pkg/volume/azure_file/azure_provision.go
+++ b/pkg/volume/azure_file/azure_provision.go
@@ -200,8 +200,9 @@ func (a *azureFileProvisioner) Provision(selectedNode *v1.Node, allowedTopologie
 	if shareName == "" {
 		// File share name has a length limit of 63, it cannot contain two consecutive '-'s, and all letters must be lower case.
 		name := util.GenerateVolumeName(a.options.ClusterName, a.options.PVName, 63)
-		shareName = strings.ToLower(strings.Replace(name, "--", "-", -1))
-}
+		shareName = strings.Replace(name, "--", "-", -1)
+		shareName = strings.ToLower(shareName)
+	}
 
 	if resourceGroup == "" {
 		resourceGroup = a.options.PVC.ObjectMeta.Annotations[resourceGroupAnnotation]

--- a/pkg/volume/azure_file/azure_provision.go
+++ b/pkg/volume/azure_file/azure_provision.go
@@ -198,10 +198,10 @@ func (a *azureFileProvisioner) Provision(selectedNode *v1.Node, allowedTopologie
 	}
 
 	if shareName == "" {
-		// File share name has a length limit of 63, and it cannot contain two consecutive '-'s.
+		// File share name has a length limit of 63, it cannot contain two consecutive '-'s, and all letters must be lower case.
 		name := util.GenerateVolumeName(a.options.ClusterName, a.options.PVName, 63)
-		shareName = strings.Replace(name, "--", "-", -1)
-	}
+		shareName = strings.ToLower(strings.Replace(name, "--", "-", -1))
+}
 
 	if resourceGroup == "" {
 		resourceGroup = a.options.PVC.ObjectMeta.Annotations[resourceGroupAnnotation]


### PR DESCRIPTION
Cherry pick of #100731 on release-1.21.

#100731: Normalize share name to not include capital letters

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.