### PR TITLE
MOD:fix kubectl drain daemonSetFilter with other APIVersion

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/drain/filters.go
+++ b/staging/src/k8s.io/kubectl/pkg/drain/filters.go
@@ -179,7 +179,7 @@ func (d *Helper) daemonSetFilter(pod corev1.Pod) PodDeleteStatus {
 	// management resource - including DaemonSet - is not found).
 	// Such pods will be deleted if --force is used.
 	controllerRef := metav1.GetControllerOf(&pod)
-	if controllerRef == nil || controllerRef.Kind != appsv1.SchemeGroupVersion.WithKind("DaemonSet").Kind {
+	if controllerRef == nil || !isControllerRefDaemonSet(controllerRef) {
 		return MakePodDeleteStatusOkay()
 	}
 	// Any finished pod can be removed.
@@ -255,4 +255,10 @@ func (d *Helper) skipDeletedFilter(pod corev1.Pod) PodDeleteStatus {
 		return MakePodDeleteStatusSkip()
 	}
 	return MakePodDeleteStatusOkay()
+}
+
+func isControllerRefDaemonSet(workloadRef *metav1.OwnerReference) bool {
+	// find if workloadRef is daemonSet
+	daemonSetAPIVersion, daemonSetKind := appsv1.SchemeGroupVersion.WithKind("DaemonSet").ToAPIVersionAndKind()
+	return workloadRef.Kind == daemonSetKind && workloadRef.APIVersion == daemonSetAPIVersion
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
[screenShots](http://www.calmkart.com/wp-content/uploads/2021/04/1-5.png)

When using the drain command of kubectl, all DaemonSets will be filtered. But the way to judge that workloadRef is DaemonSet in Filter only considers the Kind of workloadRef and ignores the APIVersion of workloadRef. 

https://github.com/kubernetes/kubernetes/blob/f631c0e520774494cb37dca709943adaf63b2951/staging/src/k8s.io/kubectl/pkg/drain/filters.go#L182

However, the logic that follows immediately obtains all apps/v1 DaemonSet, which will cause if there is a crd with the same name as Kind (Kind=DaemonSet), it will be regarded as a native DaemonSet, but in fact, the original DaemonSet cannot obtain this CRD and thus DrainNode The problem of failure.

https://github.com/kubernetes/kubernetes/blob/f631c0e520774494cb37dca709943adaf63b2951/staging/src/k8s.io/kubectl/pkg/drain/filters.go#L190-L196

Example:
there is a crd [kruise-daemonSet](https://openkruise.io/en-us/docs/advanced_daemonset.html)
```
apiVersion: apps.kruise.io/v1alpha1
kind: DaemonSet
metadata:
  annotations:
```

When we DrainNode, it mistakenly regards it as a native DaemonSet, but the native DaemonSet cannot be obtained and an error is reported

So I added detailed judgments here to find if the workload is native DaemonSet or not.


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #101557 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
