### PR TITLE
Clean up tempDir after fsstore_test.go is executed

### DIFF
--- a/pkg/kubelet/kubeletconfig/checkpoint/store/fsstore_test.go
+++ b/pkg/kubelet/kubeletconfig/checkpoint/store/fsstore_test.go
@@ -18,7 +18,6 @@ package store
 
 import (
 	"fmt"
-	"io/ioutil"
 	"path/filepath"
 	"reflect"
 	"testing"
@@ -39,31 +38,25 @@ import (
 	utilfs "k8s.io/kubernetes/pkg/util/filesystem"
 )
 
-var testdir string
-
-func init() {
-	tmp, err := ioutil.TempDir("", "fsstore-test")
-	if err != nil {
-		panic(err)
-	}
-	testdir = tmp
-}
-
 func newInitializedFakeFsStore() (*fsStore, error) {
 	// Test with the default filesystem, the fake filesystem has an issue caused by afero: https://github.com/spf13/afero/issues/141
 	// The default filesystem also behaves more like production, so we should probably not mock the filesystem for unit tests.
 	fs := utilfs.DefaultFs{}
 
-	tmpdir, err := fs.TempDir(testdir, "store-")
+	tmpDir, err := fs.TempDir("", "fsstore-test-")
 	if err != nil {
 		return nil, err
 	}
 
-	store := NewFsStore(fs, tmpdir)
+	store := NewFsStore(fs, tmpDir)
 	if err := store.Initialize(); err != nil {
 		return nil, err
 	}
 	return store.(*fsStore), nil
+}
+
+func cleanupFakeFsStore(store *fsStore) {
+	_ = store.fs.RemoveAll(store.dir)
 }
 
 func TestFsStoreInitialize(t *testing.T) {
@@ -71,6 +64,7 @@ func TestFsStoreInitialize(t *testing.T) {
 	if err != nil {
 		t.Fatalf("fsStore.Initialize() failed with error: %v", err)
 	}
+	defer cleanupFakeFsStore(store)
 
 	// check that store.dir exists
 	if _, err := store.fs.Stat(store.dir); err != nil {
@@ -103,6 +97,7 @@ func TestFsStoreExists(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error constructing store: %v", err)
 	}
+	defer cleanupFakeFsStore(store)
 
 	// checkpoint a payload
 	const (
@@ -160,6 +155,7 @@ func TestFsStoreSave(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error constructing store: %v", err)
 	}
+	defer cleanupFakeFsStore(store)
 
 	nameTooLong := func() string {
 		s := ""
@@ -224,6 +220,8 @@ func TestFsStoreLoad(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error constructing store: %v", err)
 	}
+	defer cleanupFakeFsStore(store)
+
 	// encode a kubelet configuration that has all defaults set
 	expect, err := newKubeletConfiguration()
 	if err != nil {
@@ -295,6 +293,7 @@ func TestFsStoreAssignedModified(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error constructing store: %v", err)
 	}
+	defer cleanupFakeFsStore(store)
 
 	// create an empty assigned file, this is good enough for testing
 	saveTestSourceFile(t, store, assignedFile, nil)
@@ -321,6 +320,7 @@ func TestFsStoreAssigned(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error constructing store: %v", err)
 	}
+	defer cleanupFakeFsStore(store)
 
 	source, _, err := checkpoint.NewRemoteConfigSource(&apiv1.NodeConfigSource{
 		ConfigMap: &apiv1.ConfigMapNodeConfigSource{
@@ -364,6 +364,7 @@ func TestFsStoreLastKnownGood(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error constructing store: %v", err)
 	}
+	defer cleanupFakeFsStore(store)
 
 	source, _, err := checkpoint.NewRemoteConfigSource(&apiv1.NodeConfigSource{
 		ConfigMap: &apiv1.ConfigMapNodeConfigSource{
@@ -407,6 +408,7 @@ func TestFsStoreSetAssigned(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error constructing store: %v", err)
 	}
+	defer cleanupFakeFsStore(store)
 
 	cases := []struct {
 		desc   string
@@ -490,6 +492,7 @@ func TestFsStoreSetLastKnownGood(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error constructing store: %v", err)
 	}
+	defer cleanupFakeFsStore(store)
 
 	cases := []struct {
 		desc   string
@@ -573,6 +576,7 @@ func TestFsStoreReset(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error constructing store: %v", err)
 	}
+	defer cleanupFakeFsStore(store)
 
 	source, _, err := checkpoint.NewRemoteConfigSource(&apiv1.NodeConfigSource{ConfigMap: &apiv1.ConfigMapNodeConfigSource{
 		Name:             "name",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
