### PR TITLE
Fix flake for GracefulNodeShutdown e2e

### DIFF
--- a/test/e2e_node/node_shutdown_linux_test.go
+++ b/test/e2e_node/node_shutdown_linux_test.go
@@ -59,6 +59,11 @@ var _ = SIGDescribe("GracefulNodeShutdown [Serial] [NodeAlphaFeature:GracefulNod
 			initialConfig.ShutdownGracePeriodCriticalPods = metav1.Duration{Duration: nodeShutdownGracePeriodCriticalPods}
 		})
 
+		ginkgo.BeforeEach(func() {
+			ginkgo.By("Wait for the node to be ready")
+			waitForNodeReady()
+		})
+
 		ginkgo.AfterEach(func() {
 			ginkgo.By("Emitting Shutdown false signal; cancelling the shutdown")
 			err := emitSignalPrepareForShutdown(false)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind flake
/sig node

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

https://testgrid.k8s.io/sig-node-kubelet#kubelet-serial-gce-e2e-graceful-node-shutdown
https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-kubernetes-node-kubelet-serial-graceful-node-shutdown/1387152775078481920

It is expected that the execution interval of these two cases is too close, and the Node state has not been restored, causing the next case to fail.

```
I0427 21:23:04.380] STEP: Verifying that all pods are shutdown

...

I0427 21:23:04.896] • Failure [25.418 seconds]
I0427 21:23:04.897] [sig-node] GracefulNodeShutdown [Serial] [NodeAlphaFeature:GracefulNodeShutdown]
I0427 21:23:04.897] _output/local/go/src/k8s.io/kubernetes/test/e2e_node/framework.go:23
I0427 21:23:04.897]   when gracefully shutting down
I0427 21:23:04.897]   _output/local/go/src/k8s.io/kubernetes/test/e2e_node/node_shutdown_linux_test.go:44
I0427 21:23:04.897]     should be able to handle a cancelled shutdown [It]
I0427 21:23:04.898]     _output/local/go/src/k8s.io/kubernetes/test/e2e_node/node_shutdown_linux_test.go:153
I0427 21:23:04.898] 
I0427 21:23:04.898]     Timed out after 10.000s.
I0427 21:23:04.898]     Expected
I0427 21:23:04.898]         <*errors.errorString | 0xc000e4a060>: {
I0427 21:23:04.898]             s: "node did not become shutdown as expected",
I0427 21:23:04.899]         }
I0427 21:23:04.899]     to be nil
I0427 21:23:04.899] 
I0427 21:23:04.899]     _output/local/go/src/k8s.io/kubernetes/test/e2e_node/node_shutdown_linux_test.go:163
```


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #101570

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
NONE
```
