### PR TITLE
kubeadm: disallow the mixture of --cri-socket and --config

### DIFF
--- a/cmd/kubeadm/app/apis/kubeadm/validation/validation.go
+++ b/cmd/kubeadm/app/apis/kubeadm/validation/validation.go
@@ -559,17 +559,16 @@ func ValidateMixedArguments(flag *pflag.FlagSet) error {
 }
 
 func isAllowedFlag(flagName string) bool {
-	knownFlags := sets.NewString(kubeadmcmdoptions.CfgPath,
+	allowedFlags := sets.NewString(kubeadmcmdoptions.CfgPath,
 		kubeadmcmdoptions.IgnorePreflightErrors,
 		kubeadmcmdoptions.DryRun,
 		kubeadmcmdoptions.KubeconfigPath,
 		kubeadmcmdoptions.NodeName,
-		kubeadmcmdoptions.NodeCRISocket,
 		kubeadmcmdoptions.KubeconfigDir,
 		kubeadmcmdoptions.UploadCerts,
 		kubeadmcmdoptions.Patches,
 		"print-join-command", "rootfs", "v")
-	if knownFlags.Has(flagName) {
+	if allowedFlags.Has(flagName) {
 		return true
 	}
 	return strings.HasPrefix(flagName, "skip-")

--- a/cmd/kubeadm/app/cmd/init.go
+++ b/cmd/kubeadm/app/cmd/init.go
@@ -350,12 +350,9 @@ func newInitData(cmd *cobra.Command, args []string, options *initOptions, out io
 	// Also set the union of pre-flight errors to InitConfiguration, to provide a consistent view of the runtime configuration:
 	cfg.NodeRegistration.IgnorePreflightErrors = ignorePreflightErrorsSet.List()
 
-	// override node name and CRI socket from the command line options
+	// override node name from the command line option
 	if options.externalInitCfg.NodeRegistration.Name != "" {
 		cfg.NodeRegistration.Name = options.externalInitCfg.NodeRegistration.Name
-	}
-	if options.externalInitCfg.NodeRegistration.CRISocket != "" {
-		cfg.NodeRegistration.CRISocket = options.externalInitCfg.NodeRegistration.CRISocket
 	}
 
 	if err := configutil.VerifyAPIServerBindAddress(cfg.LocalAPIEndpoint.AdvertiseAddress); err != nil {

--- a/cmd/kubeadm/app/cmd/init_test.go
+++ b/cmd/kubeadm/app/cmd/init_test.go
@@ -102,15 +102,11 @@ func TestNewInitData(t *testing.T) {
 		{
 			name: "--cri-socket and --node-name flags override config from file",
 			flags: map[string]string{
-				options.CfgPath:       configFilePath,
-				options.NodeCRISocket: "/var/run/crio/crio.sock",
-				options.NodeName:      "anotherName",
+				options.CfgPath:  configFilePath,
+				options.NodeName: "anotherName",
 			},
 			validate: func(t *testing.T, data *initData) {
-				// validate that cri-socket and node-name are overwritten
-				if data.cfg.NodeRegistration.CRISocket != "/var/run/crio/crio.sock" {
-					t.Errorf("Invalid NodeRegistration.CRISocket")
-				}
+				// validate that node-name is overwritten
 				if data.cfg.NodeRegistration.Name != "anotherName" {
 					t.Errorf("Invalid NodeRegistration.Name")
 				}

--- a/cmd/kubeadm/app/cmd/join_test.go
+++ b/cmd/kubeadm/app/cmd/join_test.go
@@ -203,15 +203,11 @@ func TestNewJoinData(t *testing.T) {
 		{
 			name: "--cri-socket and --node-name flags override config from file",
 			flags: map[string]string{
-				options.CfgPath:       configFilePath,
-				options.NodeCRISocket: "/var/run/crio/crio.sock",
-				options.NodeName:      "anotherName",
+				options.CfgPath:  configFilePath,
+				options.NodeName: "anotherName",
 			},
 			validate: func(t *testing.T, data *joinData) {
-				// validate that cri-socket and node-name are overwritten
-				if data.cfg.NodeRegistration.CRISocket != "/var/run/crio/crio.sock" {
-					t.Errorf("Invalid NodeRegistration.CRISocket")
-				}
+				// validate that node-name is overwritten
 				if data.cfg.NodeRegistration.Name != "anotherName" {
 					t.Errorf("Invalid NodeRegistration.Name")
 				}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

If multiple container runtimes are available on the same node at the same time, for example, `Docker` and `CRI-O`, an error will be thrown when the following commands are executed:

```bash
$ ./_output/bin/kubeadm init --cri-socket=/var/run/dockershim.sock --config=/root/Documents/testdir/kubeadm-config-without-nodeRegistration.yaml --dry-run
Found multiple CRI sockets, please use --cri-socket to select one: /var/run/dockershim.sock, /var/run/crio/crio.sock
To see the stack trace of this error execute with --v=5 or higher
```

`kubeadm-config-without-nodeRegistration.yaml` does not contain the field `nodeRegistration`.

If the field `nodeRegistration` is added to `kubeadm-config-without-nodeRegistration.yaml`, it will be overridden by the `cri-socket` flag normally.

#### Which issue(s) this PR fixes:

Fixes #kubernetes/kubeadm#2039

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
ACTION REQUIRED: kubeadm: the flag --cri-socket is no longer allowed in a mixture with the flag --config. Please use the kubeadm configuration for setting the CRI socket for a node using {Init|Join}Configuration.nodeRegistration.criSocket.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
```