### PR TITLE
lock feature-gate execProbeTimeout and remove relevant code

### DIFF
--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -835,7 +835,7 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
 	HPAContainerMetrics:                            {Default: false, PreRelease: featuregate.Alpha},
 	RootCAConfigMap:                                {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.22
 	SizeMemoryBackedVolumes:                        {Default: true, PreRelease: featuregate.Beta},
-	ExecProbeTimeout:                               {Default: true, PreRelease: featuregate.GA}, // lock to default and remove after v1.22 based on KEP #1972 update
+	ExecProbeTimeout:                               {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // lock to default and remove after v1.22 based on KEP #1972 update
 	KubeletCredentialProviders:                     {Default: false, PreRelease: featuregate.Alpha},
 	GracefulNodeShutdown:                           {Default: true, PreRelease: featuregate.Beta},
 	ServiceLBNodePortControl:                       {Default: false, PreRelease: featuregate.Alpha},

--- a/pkg/kubelet/dockershim/exec.go
+++ b/pkg/kubelet/dockershim/exec.go
@@ -26,7 +26,6 @@ import (
 
 	dockertypes "github.com/docker/docker/api/types"
 
-	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/client-go/tools/remotecommand"
 	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/pkg/features"
@@ -108,7 +107,7 @@ func (*NativeExecHandler) ExecInContainer(ctx context.Context, client libdocker.
 		ExecStarted:  execStarted,
 	}
 
-	if timeout > 0 && utilfeature.DefaultFeatureGate.Enabled(features.ExecProbeTimeout) {
+	if timeout > 0 {
 		var cancel context.CancelFunc
 		ctx, cancel = context.WithTimeout(ctx, timeout)
 		defer cancel()

--- a/pkg/kubelet/dockershim/exec_test.go
+++ b/pkg/kubelet/dockershim/exec_test.go
@@ -29,10 +29,7 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 
-	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/client-go/tools/remotecommand"
-	featuregatetesting "k8s.io/component-base/featuregate/testing"
-	"k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/pkg/kubelet/dockershim/libdocker"
 	mockclient "k8s.io/kubernetes/pkg/kubelet/dockershim/libdocker/testing"
 )
@@ -111,7 +108,7 @@ func TestExecInContainer(t *testing.T) {
 		execProbeTimeout:   true,
 		expectError:        context.DeadlineExceeded,
 	}, {
-		description:        "[ExecProbeTimeout=true] StartExec that takes longer than the probe timeout returns context.DeadlineExceeded",
+		description:        "StartExec that takes longer than the probe timeout returns context.DeadlineExceeded",
 		timeout:            1 * time.Second,
 		returnCreateExec1:  &dockertypes.IDResponse{ID: "12345678"},
 		returnCreateExec2:  nil,
@@ -121,17 +118,6 @@ func TestExecInContainer(t *testing.T) {
 		returnInspectExec2: nil,
 		execProbeTimeout:   true,
 		expectError:        context.DeadlineExceeded,
-	}, {
-		description:        "[ExecProbeTimeout=false] StartExec that takes longer than the probe timeout returns a error",
-		timeout:            1 * time.Second,
-		returnCreateExec1:  &dockertypes.IDResponse{ID: "12345678"},
-		returnCreateExec2:  nil,
-		startExecDelay:     5 * time.Second,
-		returnStartExec:    fmt.Errorf("error in StartExec()"),
-		returnInspectExec1: nil,
-		returnInspectExec2: nil,
-		execProbeTimeout:   false,
-		expectError:        fmt.Errorf("error in StartExec()"),
 	}}
 
 	eh := &NativeExecHandler{}
@@ -146,7 +132,6 @@ func TestExecInContainer(t *testing.T) {
 		// these tests cannot be run in parallel due to the fact that they are feature gate dependent
 		tc := tc
 		t.Run(tc.description, func(t *testing.T) {
-			defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.ExecProbeTimeout, tc.execProbeTimeout)()
 
 			mockClient := mockclient.NewMockInterface(ctrl)
 			mockClient.EXPECT().CreateExec(gomock.Any(), gomock.Any()).Return(

--- a/pkg/probe/exec/exec.go
+++ b/pkg/probe/exec/exec.go
@@ -19,8 +19,6 @@ package exec
 import (
 	"bytes"
 
-	utilfeature "k8s.io/apiserver/pkg/util/feature"
-	"k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/pkg/kubelet/util/ioutils"
 	"k8s.io/kubernetes/pkg/probe"
 
@@ -71,11 +69,7 @@ func (pr execProber) Probe(e exec.Cmd) (probe.Result, string, error) {
 
 		timeoutErr, ok := err.(*TimeoutError)
 		if ok {
-			if utilfeature.DefaultFeatureGate.Enabled(features.ExecProbeTimeout) {
-				return probe.Failure, string(data), nil
-			}
-
-			klog.Warningf("Exec probe timed out after %s but ExecProbeTimeout feature gate was disabled", timeoutErr.Timeout())
+			return probe.Failure, string(data), nil
 		}
 
 		return probe.Unknown, "", err

--- a/test/e2e/common/node/container_probe.go
+++ b/test/e2e/common/node/container_probe.go
@@ -32,7 +32,6 @@ import (
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2eevents "k8s.io/kubernetes/test/e2e/framework/events"
 	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
-	e2eskipper "k8s.io/kubernetes/test/e2e/framework/skipper"
 	testutils "k8s.io/kubernetes/test/utils"
 
 	"github.com/onsi/ginkgo"
@@ -215,9 +214,6 @@ var _ = SIGDescribe("Probing container", func() {
 		Description: A Pod is created with liveness probe with a Exec action on the Pod. If the liveness probe call does not return within the timeout specified, liveness probe MUST restart the Pod.
 	*/
 	ginkgo.It("should be restarted with an exec liveness probe with timeout [MinimumKubeletVersion:1.20] [NodeConformance]", func() {
-		// The ExecProbeTimeout feature gate exists to allow backwards-compatibility with pre-1.20 cluster behaviors, where livenessProbe timeouts were ignored
-		// If ExecProbeTimeout feature gate is disabled, timeout enforcement for exec livenessProbes is disabled, so we should skip this test
-		e2eskipper.SkipUnlessExecProbeTimeoutEnabled()
 		cmd := []string{"/bin/sh", "-c", "sleep 600"}
 		livenessProbe := &v1.Probe{
 			Handler:             execHandler([]string{"/bin/sh", "-c", "sleep 10"}),
@@ -249,12 +245,9 @@ var _ = SIGDescribe("Probing container", func() {
 	/*
 		Release: v1.21
 		Testname: Pod liveness probe, container exec timeout, restart
-		Description: A Pod is created with liveness probe with a Exec action on the Pod. If the liveness probe call does not return within the timeout specified, liveness probe MUST restart the Pod. When ExecProbeTimeout feature gate is disabled and cluster is using dockershim, the timeout is ignored BUT a failing liveness probe MUST restart the Pod.
+		Description: A Pod is created with liveness probe with a Exec action on the Pod. If the liveness probe call does not return within the timeout specified, liveness probe MUST restart the Pod. 
 	*/
 	ginkgo.It("should be restarted with a failing exec liveness probe that took longer than the timeout", func() {
-		// The ExecProbeTimeout feature gate exists to allow backwards-compatibility with pre-1.20 cluster behaviors using dockershim, where livenessProbe timeouts were ignored
-		// If ExecProbeTimeout feature gate is disabled on a dockershim cluster, timeout enforcement for exec livenessProbes is disabled, but a failing liveness probe MUST still trigger a restart
-		// Note ExecProbeTimeout=false is not recommended for non-dockershim clusters (e.g., containerd), and this test will fail if run against such a configuration
 		cmd := []string{"/bin/sh", "-c", "sleep 600"}
 		livenessProbe := &v1.Probe{
 			Handler:             execHandler([]string{"/bin/sh", "-c", "sleep 10 & exit 1"}),

--- a/test/e2e/framework/skipper/skipper.go
+++ b/test/e2e/framework/skipper/skipper.go
@@ -48,7 +48,6 @@ var localStorageCapacityIsolation featuregate.Feature = "LocalStorageCapacityIso
 
 var (
 	downwardAPIHugePages featuregate.Feature = "DownwardAPIHugePages"
-	execProbeTimeout     featuregate.Feature = "ExecProbeTimeout"
 )
 
 func skipInternalf(caller int, format string, args ...interface{}) {
@@ -145,12 +144,6 @@ func SkipUnlessLocalEphemeralStorageEnabled() {
 func SkipUnlessDownwardAPIHugePagesEnabled() {
 	if !utilfeature.DefaultFeatureGate.Enabled(downwardAPIHugePages) {
 		skipInternalf(1, "Only supported when %v feature is enabled", downwardAPIHugePages)
-	}
-}
-
-func SkipUnlessExecProbeTimeoutEnabled() {
-	if !utilfeature.DefaultFeatureGate.Enabled(execProbeTimeout) {
-		skipInternalf(1, "Only supported when %v feature is enabled", execProbeTimeout)
 	}
 }
 


### PR DESCRIPTION
Signed-off-by: wangyysde <net_use@bzhy.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
The feature gate execProbeTimeout  had been added in v1.20. Now,lock feature gate execProbeTimeout to default and remove relevant code.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
ref #94115

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Now the feature gate execProbeTimeout  is locked to default.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- [KEP]: https://github.com/kubernetes/enhancements/pull/1973
```
