### PR TITLE
use PermitWithoutStream=true for etcd: send pings even without active stream

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/storagebackend/factory/etcd3.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/storagebackend/factory/etcd3.go
@@ -149,6 +149,7 @@ func newETCD3Client(c storagebackend.TransportConfig) (*clientv3.Client, error) 
 		DialTimeout:          dialTimeout,
 		DialKeepAliveTime:    keepaliveTime,
 		DialKeepAliveTimeout: keepaliveTimeout,
+		PermitWithoutStream:  true,
 		DialOptions:          dialOptions,
 		Endpoints:            c.ServerList,
 		TLS:                  tlsConfig,


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
During reading https://grafana.com/blog/2020/04/07/how-a-production-outage-in-grafana-clouds-hosted-prometheus-service-was-caused-by-a-bad-etcd-client-setup/, the conclusion suggests using 

```
cli, err := clientv3.New(clientv3.Config{
	Endpoints:   cfg.Endpoints,
	DialTimeout: cfg.DialTimeout,
+	DialKeepAliveTime:    10 * time.Second, // already configured
+	DialKeepAliveTimeout: 2 * cfg.DialTimeout, // already configured
+	PermitWithoutStream:  true,  // apiserver doesn't have this config
})
```

It may avoid some `“context deadline exceeded”` during upgrading or one of the etcd server failed(I think).

#### Which issue(s) this PR fixes:

Fixes None

#### Special notes for your reviewer:
Refer to a presentation from kubecon eurepean https://events.linuxfoundation.org/kubecon-cloudnativecon-europe/program/schedule/ some examples: https://github.com/cortexproject/cortex/pull/2278.

I also checked some other projects are using it   
https://grep.app/search?current=4&q=PermitWithoutStream&filter[path][0]=pkg/

#### Does this PR introduce a user-facing change?
```release-note
NONE
```