### PR TITLE
Drop beta APIs from create command for PDBs and CronJobs

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_pdb.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_pdb.go
@@ -23,13 +23,13 @@ import (
 
 	"github.com/spf13/cobra"
 
-	policyv1beta1 "k8s.io/api/policy/v1beta1"
+	policyv1 "k8s.io/api/policy/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	resourcecli "k8s.io/cli-runtime/pkg/resource"
-	policyclient "k8s.io/client-go/kubernetes/typed/policy/v1beta1"
+	policyv1client "k8s.io/client-go/kubernetes/typed/policy/v1"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 	"k8s.io/kubectl/pkg/scheme"
 	"k8s.io/kubectl/pkg/util"
@@ -69,7 +69,7 @@ type PodDisruptionBudgetOpts struct {
 	Namespace        string
 	EnforceNamespace bool
 
-	Client         *policyclient.PolicyV1beta1Client
+	Client         *policyv1client.PolicyV1Client
 	DryRunStrategy cmdutil.DryRunStrategy
 	DryRunVerifier *resourcecli.DryRunVerifier
 
@@ -127,7 +127,7 @@ func (o *PodDisruptionBudgetOpts) Complete(f cmdutil.Factory, cmd *cobra.Command
 	if err != nil {
 		return err
 	}
-	o.Client, err = policyclient.NewForConfig(restConfig)
+	o.Client, err = policyv1client.NewForConfig(restConfig)
 	if err != nil {
 		return err
 	}
@@ -230,15 +230,15 @@ func (o *PodDisruptionBudgetOpts) Run() error {
 	return o.PrintObj(podDisruptionBudget)
 }
 
-func (o *PodDisruptionBudgetOpts) createPodDisruptionBudgets() (*policyv1beta1.PodDisruptionBudget, error) {
+func (o *PodDisruptionBudgetOpts) createPodDisruptionBudgets() (*policyv1.PodDisruptionBudget, error) {
 	namespace := ""
 	if o.EnforceNamespace {
 		namespace = o.Namespace
 	}
 
-	podDisruptionBudget := &policyv1beta1.PodDisruptionBudget{
+	podDisruptionBudget := &policyv1.PodDisruptionBudget{
 		TypeMeta: metav1.TypeMeta{
-			APIVersion: policyv1beta1.SchemeGroupVersion.String(),
+			APIVersion: policyv1.SchemeGroupVersion.String(),
 			Kind:       "PodDisruptionBudget",
 		},
 		ObjectMeta: metav1.ObjectMeta{

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_pdb_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_pdb_test.go
@@ -19,7 +19,7 @@ package create
 import (
 	"testing"
 
-	policyv1beta1 "k8s.io/api/policy/v1beta1"
+	policyv1 "k8s.io/api/policy/v1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -137,7 +137,7 @@ func TestCreatePdb(t *testing.T) {
 
 	tests := map[string]struct {
 		options  *PodDisruptionBudgetOpts
-		expected *policyv1beta1.PodDisruptionBudget
+		expected *policyv1.PodDisruptionBudget
 	}{
 		"test-valid-min-available-pods-number": {
 			options: &PodDisruptionBudgetOpts{
@@ -145,15 +145,15 @@ func TestCreatePdb(t *testing.T) {
 				Selector:     selectorOpts,
 				MinAvailable: podAmountNumber,
 			},
-			expected: &policyv1beta1.PodDisruptionBudget{
+			expected: &policyv1.PodDisruptionBudget{
 				TypeMeta: metav1.TypeMeta{
 					Kind:       "PodDisruptionBudget",
-					APIVersion: "policy/v1beta1",
+					APIVersion: "policy/v1",
 				},
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "my-pdb",
 				},
-				Spec: policyv1beta1.PodDisruptionBudgetSpec{
+				Spec: policyv1.PodDisruptionBudgetSpec{
 					Selector:     selector,
 					MinAvailable: &minAvailableNumber,
 				},
@@ -165,15 +165,15 @@ func TestCreatePdb(t *testing.T) {
 				Selector:     selectorOpts,
 				MinAvailable: podAmountPercent,
 			},
-			expected: &policyv1beta1.PodDisruptionBudget{
+			expected: &policyv1.PodDisruptionBudget{
 				TypeMeta: metav1.TypeMeta{
 					Kind:       "PodDisruptionBudget",
-					APIVersion: "policy/v1beta1",
+					APIVersion: "policy/v1",
 				},
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "my-pdb",
 				},
-				Spec: policyv1beta1.PodDisruptionBudgetSpec{
+				Spec: policyv1.PodDisruptionBudgetSpec{
 					Selector:     selector,
 					MinAvailable: &minAvailablePercent,
 				},
@@ -185,15 +185,15 @@ func TestCreatePdb(t *testing.T) {
 				Selector:     selectorOpts,
 				MinAvailable: podAmountNumber,
 			},
-			expected: &policyv1beta1.PodDisruptionBudget{
+			expected: &policyv1.PodDisruptionBudget{
 				TypeMeta: metav1.TypeMeta{
 					Kind:       "PodDisruptionBudget",
-					APIVersion: "policy/v1beta1",
+					APIVersion: "policy/v1",
 				},
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "my-pdb",
 				},
-				Spec: policyv1beta1.PodDisruptionBudgetSpec{
+				Spec: policyv1.PodDisruptionBudgetSpec{
 					Selector:     selector,
 					MinAvailable: &minUnavailableNumber,
 				},
@@ -205,15 +205,15 @@ func TestCreatePdb(t *testing.T) {
 				Selector:     selectorOpts,
 				MinAvailable: podAmountPercent,
 			},
-			expected: &policyv1beta1.PodDisruptionBudget{
+			expected: &policyv1.PodDisruptionBudget{
 				TypeMeta: metav1.TypeMeta{
 					Kind:       "PodDisruptionBudget",
-					APIVersion: "policy/v1beta1",
+					APIVersion: "policy/v1",
 				},
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "my-pdb",
 				},
-				Spec: policyv1beta1.PodDisruptionBudgetSpec{
+				Spec: policyv1.PodDisruptionBudgetSpec{
 					Selector:     selector,
 					MinAvailable: &minUnavailablePercent,
 				},


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup
/sig cli
/priority important-longterm

#### What this PR does / why we need it:
In 1.21 CronJobs and PDB were graduated to GA ie. v1, with the current +/- 1 skew policy we can safely switch `kubectl create` commands working with these resources to GA APIs.

#### Special notes for your reviewer:
/assign @mortent 

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
