### PR TITLE
Scheduler: remove pkg/features dependency from DefaultPreemption plugin

### DIFF
--- a/pkg/scheduler/framework/plugins/defaultpreemption/default_preemption_test.go
+++ b/pkg/scheduler/framework/plugins/defaultpreemption/default_preemption_test.go
@@ -291,7 +291,7 @@ func TestPostFilter(t *testing.T) {
 			p := DefaultPreemption{
 				fh:        f,
 				podLister: informerFactory.Core().V1().Pods().Lister(),
-				pdbLister: getPDBLister(informerFactory),
+				pdbLister: getPDBLister(informerFactory, true),
 				args:      *getDefaultDefaultPreemptionArgs(),
 			}
 
@@ -1670,7 +1670,7 @@ func TestPreempt(t *testing.T) {
 			pl := DefaultPreemption{
 				fh:        fwk,
 				podLister: informerFactory.Core().V1().Pods().Lister(),
-				pdbLister: getPDBLister(informerFactory),
+				pdbLister: getPDBLister(informerFactory, true),
 				args:      *getDefaultDefaultPreemptionArgs(),
 			}
 			node, status := pl.preempt(context.Background(), state, test.pod, make(framework.NodeToStatusMap))

--- a/pkg/scheduler/framework/plugins/feature/feature.go
+++ b/pkg/scheduler/framework/plugins/feature/feature.go
@@ -21,4 +21,5 @@ package feature
 // the internal k8s features pkg.
 type Features struct {
 	EnablePodAffinityNamespaceSelector bool
+	EnablePodDisruptionBudget          bool
 }

--- a/pkg/scheduler/framework/plugins/registry.go
+++ b/pkg/scheduler/framework/plugins/registry.go
@@ -51,6 +51,7 @@ import (
 func NewInTreeRegistry() runtime.Registry {
 	fts := plfeature.Features{
 		EnablePodAffinityNamespaceSelector: utilfeature.DefaultFeatureGate.Enabled(features.PodAffinityNamespaceSelector),
+		EnablePodDisruptionBudget:          utilfeature.DefaultFeatureGate.Enabled(features.PodDisruptionBudget),
 	}
 
 	return runtime.Registry{
@@ -79,10 +80,12 @@ func NewInTreeRegistry() runtime.Registry {
 		interpodaffinity.Name: func(plArgs apiruntime.Object, fh framework.Handle) (framework.Plugin, error) {
 			return interpodaffinity.New(plArgs, fh, fts)
 		},
-		nodelabel.Name:         nodelabel.New,
-		serviceaffinity.Name:   serviceaffinity.New,
-		queuesort.Name:         queuesort.New,
-		defaultbinder.Name:     defaultbinder.New,
-		defaultpreemption.Name: defaultpreemption.New,
+		nodelabel.Name:       nodelabel.New,
+		serviceaffinity.Name: serviceaffinity.New,
+		queuesort.Name:       queuesort.New,
+		defaultbinder.Name:   defaultbinder.New,
+		defaultpreemption.Name: func(plArgs apiruntime.Object, fh framework.Handle) (framework.Plugin, error) {
+			return defaultpreemption.New(plArgs, fh, fts)
+		},
 	}
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This PR is a part of #89930. It removes `pkg/features` from the `DefaultPreemption` plugin.

#### Which issue(s) this PR fixes:

Refs #89930, #98583

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
