### PR TITLE
go-to-protobuf: small fixes to improve debuggability

### DIFF
--- a/staging/src/k8s.io/code-generator/cmd/go-to-protobuf/main.go
+++ b/staging/src/k8s.io/code-generator/cmd/go-to-protobuf/main.go
@@ -23,11 +23,13 @@ import (
 
 	flag "github.com/spf13/pflag"
 	"k8s.io/code-generator/cmd/go-to-protobuf/protobuf"
+	"k8s.io/klog/v2"
 )
 
 var g = protobuf.New()
 
 func init() {
+	klog.InitFlags(nil)
 	g.BindFlags(flag.CommandLine)
 	goflag.Set("logtostderr", "true")
 	flag.CommandLine.AddGoFlagSet(goflag.CommandLine)

--- a/staging/src/k8s.io/code-generator/cmd/go-to-protobuf/protobuf/cmd.go
+++ b/staging/src/k8s.io/code-generator/cmd/go-to-protobuf/protobuf/cmd.go
@@ -364,7 +364,12 @@ func Run(g *Generator) {
 func deps(c *generator.Context, pkgs []*protobufPackage) map[string][]string {
 	ret := map[string][]string{}
 	for _, p := range pkgs {
-		for _, d := range c.Universe[p.PackagePath].Imports {
+		pkg, ok := c.Universe[p.PackagePath]
+		if !ok {
+			log.Fatalf("Unrecognized package: %s", p.PackagePath)
+		}
+
+		for _, d := range pkg.Imports {
 			ret[p.PackagePath] = append(ret[p.PackagePath], d.Path)
 		}
 	}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Small fixes to make the go-to-protobuf tool easier to debug when it's failing:
- If a package isn't found, print the package name instead of segfaulting
- Init klog flags, like in other code-generator/cmd packages, to turn on verbose logging

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
