### PR TITLE
Add validation for names like '-'

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/api/validation/generic.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/validation/generic.go
@@ -68,9 +68,11 @@ var ValidateNamespaceName = NameIsDNSLabel
 var ValidateServiceAccountName = NameIsDNSSubdomain
 
 // maskTrailingDash replaces the final character of a string with a subdomain safe
-// value if is a dash.
+// value if it is a dash and if the length of this string is greater than 1. Note that
+// this is used when a value could be appended to the string, see ValidateNameFunc
+// for more info.
 func maskTrailingDash(name string) string {
-	if strings.HasSuffix(name, "-") {
+	if len(name) > 1 && strings.HasSuffix(name, "-") {
 		return name[:len(name)-2] + "a"
 	}
 	return name

--- a/staging/src/k8s.io/apimachinery/pkg/api/validation/generic_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/validation/generic_test.go
@@ -1,0 +1,65 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package validation
+
+import "testing"
+
+func TestMaskTrailingDash(t *testing.T) {
+	testCases := []struct {
+		beforeMasking        string
+		expectedAfterMasking string
+		description          string
+	}{
+		{
+			beforeMasking:        "",
+			expectedAfterMasking: "",
+			description:          "empty string",
+		},
+		{
+			beforeMasking:        "-",
+			expectedAfterMasking: "-",
+			description:          "only a single dash",
+		},
+		{
+			beforeMasking:        "-foo",
+			expectedAfterMasking: "-foo",
+			description:          "has leading dash",
+		},
+		{
+			beforeMasking:        "-foo-",
+			expectedAfterMasking: "-foa",
+			description:          "has both leading and trailing dashes",
+		},
+		{
+			beforeMasking:        "b-",
+			expectedAfterMasking: "a",
+			description:          "has trailing dash",
+		},
+		{
+			beforeMasking:        "ab",
+			expectedAfterMasking: "ab",
+			description:          "has neither leading nor trailing dashes",
+		},
+	}
+
+	for _, tc := range testCases {
+		afterMasking := maskTrailingDash(tc.beforeMasking)
+		if afterMasking != tc.expectedAfterMasking {
+			t.Errorf("error in test case: %s. expected: %s, actual: %s", tc.description, tc.expectedAfterMasking, afterMasking)
+		}
+	}
+}


### PR DESCRIPTION
Signed-off-by: Madhav Jivrajani <madhav.jiv@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

- Handles the case where the subdomain is something like `-` and `prefix` is set to true in validation. 

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #101623

#### Special notes for your reviewer:
- The fix returns `-` as is and then the calling function handles passing of appropriate error message, but the function is meant to mask trailing dashes. I was a little unsure if It should return `"a"` if the name is something like `-`, i.e. a complete replacement happens and since the intent of `prefix` is to have something appended to a name, I thought this might be the right way to do it, any feedback would be great, thank you!

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
