### PR TITLE
Change known-modules.json as it expects to be absolute path.

### DIFF
--- a/cluster/gce/gci/configure-helper.sh
+++ b/cluster/gce/gci/configure-helper.sh
@@ -1634,6 +1634,10 @@ function start-node-problem-detector {
     local -r sm_config="${KUBE_HOME}/node-problem-detector/config/systemd-monitor.json"
     local -r ssm_config="${KUBE_HOME}/node-problem-detector/config/system-stats-monitor.json"
 
+    # TODO(vteratipally): Remove this when updating the NPD version as with PR kubernetes/node-problem-detector#557, the config path can accept relative path.
+    # replace the known-modules.json file path in system-stats-monitor.json with the absolute path
+    sed -i "s|config/guestosconfig/known-modules.json|${KUBE_HOME}/node-problem-detector/config/guestosconfig/known-modules.json|g" "${KUBE_HOME}/node-problem-detector/config/system-stats-monitor.json"
+
     local -r custom_km_config="${KUBE_HOME}/node-problem-detector/config/kernel-monitor-counter.json"
     local -r custom_sm_config="${KUBE_HOME}/node-problem-detector/config/systemd-monitor-counter.json"
 


### PR DESCRIPTION


#### What type of PR is this?

/kind bug


#### What this PR does / why we need it:

With the latest version of the NPD, in order to track the out of tree modules it expects a file known as known-modules.json and 
it is needed to be an absolute path. As the path in the system-stats-monitor.json is default related to npd the npd service is throwing error messages which are harmful, but to avoid this, changing the path to absolute. 

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
