### PR TITLE
Automated cherry pick of #101025: Fix EndpointSlice describe panic when an Endpoint doesn't

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/describe/describe.go
+++ b/staging/src/k8s.io/kubectl/pkg/describe/describe.go
@@ -3055,7 +3055,7 @@ func describeEndpointSliceV1(eps *discoveryv1.EndpointSlice, events *corev1.Even
 				w.Write(LEVEL_2, "NodeName:\t%s\n", nodeNameText)
 
 				zoneText := "<unset>"
-				if endpoint.NodeName != nil {
+				if endpoint.Zone != nil {
 					zoneText = *endpoint.Zone
 				}
 				w.Write(LEVEL_2, "Zone:\t%s\n", zoneText)

--- a/staging/src/k8s.io/kubectl/pkg/describe/describe_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/describe/describe_test.go
@@ -4874,6 +4874,7 @@ Events:         <none>` + "\n",
 						Addresses:  []string{"1.2.3.6", "1.2.3.7"},
 						Conditions: discoveryv1.EndpointConditions{Ready: utilpointer.BoolPtr(true)},
 						TargetRef:  &corev1.ObjectReference{Kind: "Pod", Name: "test-124"},
+						NodeName:   utilpointer.StringPtr("node-2"),
 					},
 				},
 				Ports: []discoveryv1.EndpointPort{
@@ -4906,7 +4907,7 @@ Endpoints:
       Ready:    true
     Hostname:   <unset>
     TargetRef:  Pod/test-124
-    NodeName:   <unset>
+    NodeName:   node-2
     Zone:       <unset>
 Events:         <none>` + "\n",
 		},


### PR DESCRIPTION
Cherry pick of #101025 on release-1.21.

#101025: Fix EndpointSlice describe panic when an Endpoint doesn't

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
Fix regression in 1.21 where kubectl EndpointSlice describe panic when an Endpoint doesn't have zone
```
