### PR TITLE
Migrate pkg/probe logs to structured logging

### DIFF
--- a/pkg/probe/exec/exec.go
+++ b/pkg/probe/exec/exec.go
@@ -59,7 +59,7 @@ func (pr execProber) Probe(e exec.Cmd) (probe.Result, string, error) {
 	}
 	data := dataBuffer.Bytes()
 
-	klog.V(4).Infof("Exec probe response: %q", string(data))
+	klog.V(4).InfoS("Exec probe response", "probeResponse", string(data))
 	if err != nil {
 		exit, ok := err.(exec.ExitError)
 		if ok {

--- a/pkg/probe/http/http.go
+++ b/pkg/probe/http/http.go
@@ -120,7 +120,7 @@ func DoHTTPProbe(url *url.URL, headers http.Header, client GetHTTPInterface) (pr
 	b, err := utilio.ReadAtMost(res.Body, maxRespBodyLength)
 	if err != nil {
 		if err == utilio.ErrLimitReached {
-			klog.V(4).Infof("Non fatal body truncation for %s, Response: %v", url.String(), *res)
+			klog.V(4).InfoS("Non fatal body truncation", "url", url.String(), "response", *res)
 		} else {
 			return probe.Failure, "", err
 		}
@@ -128,13 +128,13 @@ func DoHTTPProbe(url *url.URL, headers http.Header, client GetHTTPInterface) (pr
 	body := string(b)
 	if res.StatusCode >= http.StatusOK && res.StatusCode < http.StatusBadRequest {
 		if res.StatusCode >= http.StatusMultipleChoices { // Redirect
-			klog.V(4).Infof("Probe terminated redirects for %s, Response: %v", url.String(), *res)
+			klog.V(4).InfoS("Probe terminated redirects", "url", url.String(), "response", *res)
 			return probe.Warning, body, nil
 		}
-		klog.V(4).Infof("Probe succeeded for %s, Response: %v", url.String(), *res)
+		klog.V(4).InfoS("Probe succeeded", "url", url.String(), "response", *res)
 		return probe.Success, body, nil
 	}
-	klog.V(4).Infof("Probe failed for %s with request headers %v, response body: %v", url.String(), headers, body)
+	klog.V(4).InfoS("Probe failed", "requestUrl", url.String(), "requestHeader", headers, "responseBody", body)
 	return probe.Failure, fmt.Sprintf("HTTP probe failed with statuscode: %d", res.StatusCode), nil
 }
 


### PR DESCRIPTION
in pkg/probe/exec/exec.go

- log event of 'Exec probe response'

in pkg/probe/http/http.go

- log event of 'Exec probe response'
- log event of 'Exec probe response'
- log event of 'Exec probe response'
- log event of 'Exec probe response'




**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it:**

Ref:

- [keps/sig-instrumentation/1602-structured-logging](https://github.com/kubernetes/enhancements/tree/master/keps/sig-instrumentation/1602-structured-logging)

- [Structured Logging migration instructions](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-instrumentation/migration-to-structured-logging.md)


**Does this PR introduce a user-facing change?:**

```release-note
Migrate some pkg/probe log messages to structured logging
```