### PR TITLE
Migrate pkg/kubemark logs to structured logging

### DIFF
--- a/pkg/kubemark/controller.go
+++ b/pkg/kubemark/controller.go
@@ -251,7 +251,7 @@ func (kubemarkController *KubemarkController) RemoveNodeFromNodeGroup(nodeGroup 
 		err = kubemarkController.externalCluster.client.CoreV1().ReplicationControllers(namespaceKubemark).Delete(context.TODO(), pod.ObjectMeta.Labels["name"],
 			metav1.DeleteOptions{PropagationPolicy: &policy})
 		if err == nil {
-			klog.Infof("marking node %s for deletion", node)
+			klog.InfoS("marking node for deletion", "nodeName", node)
 			// Mark node for deletion from kubemark cluster.
 			// Once it becomes unready after replication controller
 			// deletion has been noticed, we will delete it explicitly.
@@ -339,7 +339,7 @@ func (kubemarkController *KubemarkController) runNodeCreation(stop <-chan struct
 			kubemarkController.nodeGroupQueueSizeLock.Lock()
 			err := kubemarkController.addNodeToNodeGroup(nodeGroup)
 			if err != nil {
-				klog.Errorf("failed to add node to node group %s: %v", nodeGroup, err)
+				klog.ErrorS(err, "failed to add node to node group", "nodeGroup", nodeGroup)
 			} else {
 				kubemarkController.nodeGroupQueueSize[nodeGroup]--
 			}
@@ -376,7 +376,7 @@ func (kubemarkCluster *kubemarkCluster) removeUnneededNodes(oldObj interface{}, 
 			if kubemarkCluster.nodesToDelete[node.Name] {
 				kubemarkCluster.nodesToDelete[node.Name] = false
 				if err := kubemarkCluster.client.CoreV1().Nodes().Delete(context.TODO(), node.Name, metav1.DeleteOptions{}); err != nil {
-					klog.Errorf("failed to delete node %s from kubemark cluster, err: %v", node.Name, err)
+					klog.ErrorS(err, "failed to delete node from kubemark cluster", "nodeName", node.Name)
 				}
 			}
 			return

--- a/pkg/kubemark/hollow_kubelet.go
+++ b/pkg/kubemark/hollow_kubelet.go
@@ -153,7 +153,7 @@ type HollowKubletOptions struct {
 func GetHollowKubeletConfig(opt *HollowKubletOptions) (*options.KubeletFlags, *kubeletconfig.KubeletConfiguration) {
 	testRootDir := utils.MakeTempDirOrDie("hollow-kubelet.", "")
 	podFilePath := utils.MakeTempDirOrDie("static-pods", testRootDir)
-	klog.Infof("Using %s as root dir for hollow-kubelet", testRootDir)
+	klog.Infof("Using testRootDir as root dir for hollow-kubelet", "testRootDir", testRootDir)
 
 	// Flags struct
 	f := options.NewKubeletFlags()


### PR DESCRIPTION
in pkg/kubemark/controller.go

- log event of 'marking node'
- log event of 'failed to add node to node group'
- log event of 'failed to delete node from kubemark cluster'

in pkg/kubemark/hollow_kubelet.go

- log event of 'Using testRootDir as root dir for hollow-kubelet'




**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it:**

Ref:

- [keps/sig-instrumentation/1602-structured-logging](https://github.com/kubernetes/enhancements/tree/master/keps/sig-instrumentation/1602-structured-logging)

- [Structured Logging migration instructions](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-instrumentation/migration-to-structured-logging.md)


**Does this PR introduce a user-facing change?:**

```release-note
Migrate some pkg/kubemark log messages to structured logging
```