### PR TITLE
Migrate pkg/routes logs to structured logging

### DIFF
--- a/pkg/routes/openidmetadata.go
+++ b/pkg/routes/openidmetadata.go
@@ -98,7 +98,7 @@ func (s *OpenIDMetadataServer) serveConfiguration(w http.ResponseWriter, req *ht
 	w.Header().Set(restful.HEADER_ContentType, restful.MIME_JSON)
 	w.Header().Set(headerCacheControl, cacheControl)
 	if _, err := w.Write(s.configJSON); err != nil {
-		klog.Errorf("failed to write service account issuer metadata response: %v", err)
+		klog.ErrorS(err, "failed to write service account issuer metadata response")
 		return
 	}
 }
@@ -108,7 +108,7 @@ func (s *OpenIDMetadataServer) serveKeys(w http.ResponseWriter, req *http.Reques
 	w.Header().Set(restful.HEADER_ContentType, mimeJWKS)
 	w.Header().Set(headerCacheControl, cacheControl)
 	if _, err := w.Write(s.keysetJSON); err != nil {
-		klog.Errorf("failed to write service account issuer JWKS response: %v", err)
+		klog.ErrorS(err, "failed to write service account issuer JWKS response")
 		return
 	}
 }


### PR DESCRIPTION
in pkg/routes/openidmetadata.go

- log event of 'failed to write service account issuer metadata response'
- log event of 'failed to write service account issuer JWKS response'





**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it:**

Ref:

- [keps/sig-instrumentation/1602-structured-logging](https://github.com/kubernetes/enhancements/tree/master/keps/sig-instrumentation/1602-structured-logging)

- [Structured Logging migration instructions](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-instrumentation/migration-to-structured-logging.md)


**Does this PR introduce a user-facing change?:**

```release-note
Migrate some pkg/routes log messages to structured logging
```