### PR TITLE
Migrate test/apiserver to structured logging

### DIFF
--- a/test/integration/apiserver/apiserver_test.go
+++ b/test/integration/apiserver/apiserver_test.go
@@ -109,7 +109,7 @@ func verifyStatusCode(t *testing.T, verb, URL, body string, expectedStatusCode i
 		t.Fatalf("unexpected error: %v in sending req with verb: %s, URL: %s and body: %s", err, verb, URL, body)
 	}
 	transport := http.DefaultTransport
-	klog.Infof("Sending request: %v", req)
+	klog.InfoS("Sending request", "request", req)
 	resp, err := transport.RoundTrip(req)
 	if err != nil {
 		t.Fatalf("unexpected error: %v in req: %v", err, req)
@@ -2230,7 +2230,7 @@ func TestDedupOwnerReferences(t *testing.T) {
 				gvr:    tc.gvr,
 				kind:   tc.kind,
 			}
-			klog.Infof("creating dependent with duplicate owner references")
+			klog.InfoS("Creating dependent with duplicate owner references")
 			dependent := c.createDependentWithOwners([]metav1.OwnerReference{fakeRefA, fakeRefA})
 			assertManagedFields(t, dependent)
 			expectedWarning := fmt.Sprintf(handlers.DuplicateOwnerReferencesWarningFormat, fakeRefA.UID)
@@ -2238,14 +2238,14 @@ func TestDedupOwnerReferences(t *testing.T) {
 			assertWarningCount(t, warningWriter, previousWarningCount+1)
 			assertWarningMessage(t, b, expectedWarning)
 
-			klog.Infof("updating dependent with duplicate owner references")
+			klog.InfoS("Updating dependent with duplicate owner references")
 			dependent = c.updateDependentWithOwners(dependent, []metav1.OwnerReference{fakeRefA, fakeRefA})
 			assertManagedFields(t, dependent)
 			assertOwnerReferences(t, dependent, []metav1.OwnerReference{fakeRefA})
 			assertWarningCount(t, warningWriter, previousWarningCount+2)
 			assertWarningMessage(t, b, expectedWarning)
 
-			klog.Infof("patching dependent with duplicate owner reference")
+			klog.InfoS("Patching dependent with duplicate owner reference")
 			dependent = c.patchDependentWithOwner(dependent, fakeRefA)
 			// TODO: currently a patch request that duplicates owner references can still
 			// wipe out managed fields. Note that this happens to built-in resources but
@@ -2257,19 +2257,19 @@ func TestDedupOwnerReferences(t *testing.T) {
 			assertWarningCount(t, warningWriter, previousWarningCount+3)
 			assertWarningMessage(t, b, expectedPatchWarning)
 
-			klog.Infof("updating dependent with different owner references")
+			klog.InfoS("Updating dependent with different owner references")
 			dependent = c.updateDependentWithOwners(dependent, []metav1.OwnerReference{fakeRefA, fakeRefB})
 			assertOwnerReferences(t, dependent, []metav1.OwnerReference{fakeRefA, fakeRefB})
 			assertWarningCount(t, warningWriter, previousWarningCount+3)
 			assertWarningMessage(t, b, "")
 
-			klog.Infof("patching dependent with different owner references")
+			klog.InfoS("Patching dependent with different owner references")
 			dependent = c.patchDependentWithOwner(dependent, fakeRefC)
 			assertOwnerReferences(t, dependent, []metav1.OwnerReference{fakeRefA, fakeRefB, fakeRefC})
 			assertWarningCount(t, warningWriter, previousWarningCount+3)
 			assertWarningMessage(t, b, "")
 
-			klog.Infof("deleting dependent")
+			klog.InfoS("Deleting dependent")
 			c.deleteDependent()
 			assertWarningCount(t, warningWriter, previousWarningCount+3)
 			assertWarningMessage(t, b, "")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
