### PR TITLE
Update rest strategy BeforeCreate to allow failing a request

### DIFF
--- a/pkg/registry/admissionregistration/mutatingwebhookconfiguration/strategy.go
+++ b/pkg/registry/admissionregistration/mutatingwebhookconfiguration/strategy.go
@@ -45,9 +45,10 @@ func (mutatingWebhookConfigurationStrategy) NamespaceScoped() bool {
 }
 
 // PrepareForCreate clears the status of an mutatingWebhookConfiguration before creation.
-func (mutatingWebhookConfigurationStrategy) PrepareForCreate(ctx context.Context, obj runtime.Object) {
+func (mutatingWebhookConfigurationStrategy) PrepareForCreate(ctx context.Context, obj runtime.Object) field.ErrorList {
 	ic := obj.(*admissionregistration.MutatingWebhookConfiguration)
 	ic.Generation = 1
+	return nil
 }
 
 // PrepareForUpdate clears fields that are not allowed to be set by end users on update.

--- a/pkg/registry/admissionregistration/validatingwebhookconfiguration/strategy.go
+++ b/pkg/registry/admissionregistration/validatingwebhookconfiguration/strategy.go
@@ -45,9 +45,10 @@ func (validatingWebhookConfigurationStrategy) NamespaceScoped() bool {
 }
 
 // PrepareForCreate clears the status of an validatingWebhookConfiguration before creation.
-func (validatingWebhookConfigurationStrategy) PrepareForCreate(ctx context.Context, obj runtime.Object) {
+func (validatingWebhookConfigurationStrategy) PrepareForCreate(ctx context.Context, obj runtime.Object) field.ErrorList {
 	ic := obj.(*admissionregistration.ValidatingWebhookConfiguration)
 	ic.Generation = 1
+	return nil
 }
 
 // PrepareForUpdate clears fields that are not allowed to be set by end users on update.

--- a/pkg/registry/apiserverinternal/storageversion/strategy.go
+++ b/pkg/registry/apiserverinternal/storageversion/strategy.go
@@ -56,9 +56,10 @@ func (storageVersionStrategy) GetResetFields() map[fieldpath.APIVersion]*fieldpa
 }
 
 // PrepareForCreate clears the status of an StorageVersion before creation.
-func (storageVersionStrategy) PrepareForCreate(ctx context.Context, obj runtime.Object) {
+func (storageVersionStrategy) PrepareForCreate(ctx context.Context, obj runtime.Object) field.ErrorList {
 	sv := obj.(*apiserverinternal.StorageVersion)
 	sv.Status = apiserverinternal.StorageVersionStatus{}
+	return nil
 }
 
 // PrepareForUpdate clears fields that are not allowed to be set by end users on update.

--- a/pkg/registry/apps/controllerrevision/strategy.go
+++ b/pkg/registry/apps/controllerrevision/strategy.go
@@ -55,8 +55,9 @@ func (strategy) AllowCreateOnUpdate() bool {
 	return false
 }
 
-func (strategy) PrepareForCreate(ctx context.Context, obj runtime.Object) {
+func (strategy) PrepareForCreate(ctx context.Context, obj runtime.Object) field.ErrorList {
 	_ = obj.(*apps.ControllerRevision)
+	return nil
 }
 
 func (strategy) Validate(ctx context.Context, obj runtime.Object) field.ErrorList {

--- a/pkg/registry/apps/daemonset/strategy.go
+++ b/pkg/registry/apps/daemonset/strategy.go
@@ -82,7 +82,7 @@ func (daemonSetStrategy) GetResetFields() map[fieldpath.APIVersion]*fieldpath.Se
 }
 
 // PrepareForCreate clears the status of a daemon set before creation.
-func (daemonSetStrategy) PrepareForCreate(ctx context.Context, obj runtime.Object) {
+func (daemonSetStrategy) PrepareForCreate(ctx context.Context, obj runtime.Object) field.ErrorList {
 	daemonSet := obj.(*apps.DaemonSet)
 	daemonSet.Status = apps.DaemonSetStatus{}
 
@@ -93,6 +93,8 @@ func (daemonSetStrategy) PrepareForCreate(ctx context.Context, obj runtime.Objec
 
 	dropDaemonSetDisabledFields(daemonSet, nil)
 	pod.DropDisabledTemplateFields(&daemonSet.Spec.Template, nil)
+
+	return nil
 }
 
 // PrepareForUpdate clears fields that are not allowed to be set by end users on update.

--- a/pkg/registry/apps/deployment/strategy.go
+++ b/pkg/registry/apps/deployment/strategy.go
@@ -81,12 +81,13 @@ func (deploymentStrategy) GetResetFields() map[fieldpath.APIVersion]*fieldpath.S
 }
 
 // PrepareForCreate clears fields that are not allowed to be set by end users on creation.
-func (deploymentStrategy) PrepareForCreate(ctx context.Context, obj runtime.Object) {
+func (deploymentStrategy) PrepareForCreate(ctx context.Context, obj runtime.Object) field.ErrorList {
 	deployment := obj.(*apps.Deployment)
 	deployment.Status = apps.DeploymentStatus{}
 	deployment.Generation = 1
 
 	pod.DropDisabledTemplateFields(&deployment.Spec.Template, nil)
+	return nil
 }
 
 // Validate validates a new deployment.

--- a/pkg/registry/apps/replicaset/strategy.go
+++ b/pkg/registry/apps/replicaset/strategy.go
@@ -87,13 +87,14 @@ func (rsStrategy) GetResetFields() map[fieldpath.APIVersion]*fieldpath.Set {
 }
 
 // PrepareForCreate clears the status of a ReplicaSet before creation.
-func (rsStrategy) PrepareForCreate(ctx context.Context, obj runtime.Object) {
+func (rsStrategy) PrepareForCreate(ctx context.Context, obj runtime.Object) field.ErrorList {
 	rs := obj.(*apps.ReplicaSet)
 	rs.Status = apps.ReplicaSetStatus{}
 
 	rs.Generation = 1
 
 	pod.DropDisabledTemplateFields(&rs.Spec.Template, nil)
+	return nil
 }
 
 // PrepareForUpdate clears fields that are not allowed to be set by end users on update.

--- a/pkg/registry/apps/statefulset/strategy.go
+++ b/pkg/registry/apps/statefulset/strategy.go
@@ -78,7 +78,7 @@ func (statefulSetStrategy) GetResetFields() map[fieldpath.APIVersion]*fieldpath.
 }
 
 // PrepareForCreate clears the status of an StatefulSet before creation.
-func (statefulSetStrategy) PrepareForCreate(ctx context.Context, obj runtime.Object) {
+func (statefulSetStrategy) PrepareForCreate(ctx context.Context, obj runtime.Object) field.ErrorList {
 	statefulSet := obj.(*apps.StatefulSet)
 	// create cannot set status
 	statefulSet.Status = apps.StatefulSetStatus{}
@@ -86,6 +86,7 @@ func (statefulSetStrategy) PrepareForCreate(ctx context.Context, obj runtime.Obj
 	statefulSet.Generation = 1
 
 	pod.DropDisabledTemplateFields(&statefulSet.Spec.Template, nil)
+	return nil
 }
 
 // PrepareForUpdate clears fields that are not allowed to be set by end users on update.

--- a/pkg/registry/autoscaling/horizontalpodautoscaler/strategy.go
+++ b/pkg/registry/autoscaling/horizontalpodautoscaler/strategy.go
@@ -64,7 +64,7 @@ func (autoscalerStrategy) GetResetFields() map[fieldpath.APIVersion]*fieldpath.S
 }
 
 // PrepareForCreate clears fields that are not allowed to be set by end users on creation.
-func (autoscalerStrategy) PrepareForCreate(ctx context.Context, obj runtime.Object) {
+func (autoscalerStrategy) PrepareForCreate(ctx context.Context, obj runtime.Object) field.ErrorList {
 	newHPA := obj.(*autoscaling.HorizontalPodAutoscaler)
 
 	// create cannot set status
@@ -73,6 +73,7 @@ func (autoscalerStrategy) PrepareForCreate(ctx context.Context, obj runtime.Obje
 	if !utilfeature.DefaultFeatureGate.Enabled(features.HPAContainerMetrics) {
 		dropContainerMetricSources(newHPA.Spec.Metrics)
 	}
+	return nil
 }
 
 // Validate validates a new autoscaler.

--- a/pkg/registry/batch/cronjob/strategy.go
+++ b/pkg/registry/batch/cronjob/strategy.go
@@ -79,11 +79,13 @@ func (cronJobStrategy) GetResetFields() map[fieldpath.APIVersion]*fieldpath.Set 
 }
 
 // PrepareForCreate clears the status of a scheduled job before creation.
-func (cronJobStrategy) PrepareForCreate(ctx context.Context, obj runtime.Object) {
+func (cronJobStrategy) PrepareForCreate(ctx context.Context, obj runtime.Object) field.ErrorList {
 	cronJob := obj.(*batch.CronJob)
 	cronJob.Status = batch.CronJobStatus{}
 
 	pod.DropDisabledTemplateFields(&cronJob.Spec.JobTemplate.Spec.Template, nil)
+
+	return nil
 }
 
 // PrepareForUpdate clears fields that are not allowed to be set by end users on update.

--- a/pkg/registry/batch/job/strategy.go
+++ b/pkg/registry/batch/job/strategy.go
@@ -85,7 +85,7 @@ func (jobStrategy) GetResetFields() map[fieldpath.APIVersion]*fieldpath.Set {
 }
 
 // PrepareForCreate clears the status of a job before creation.
-func (jobStrategy) PrepareForCreate(ctx context.Context, obj runtime.Object) {
+func (jobStrategy) PrepareForCreate(ctx context.Context, obj runtime.Object) field.ErrorList {
 	job := obj.(*batch.Job)
 	job.Status = batch.JobStatus{}
 
@@ -102,6 +102,7 @@ func (jobStrategy) PrepareForCreate(ctx context.Context, obj runtime.Object) {
 	}
 
 	pod.DropDisabledTemplateFields(&job.Spec.Template, nil)
+	return nil
 }
 
 // PrepareForUpdate clears fields that are not allowed to be set by end users on update.

--- a/pkg/registry/certificates/certificates/strategy.go
+++ b/pkg/registry/certificates/certificates/strategy.go
@@ -75,7 +75,7 @@ func (csrStrategy) AllowCreateOnUpdate() bool {
 
 // PrepareForCreate clears fields that are not allowed to be set by end users
 // on creation.
-func (csrStrategy) PrepareForCreate(ctx context.Context, obj runtime.Object) {
+func (csrStrategy) PrepareForCreate(ctx context.Context, obj runtime.Object) field.ErrorList {
 	csr := obj.(*certificates.CertificateSigningRequest)
 
 	// Clear any user-specified info
@@ -99,6 +99,7 @@ func (csrStrategy) PrepareForCreate(ctx context.Context, obj runtime.Object) {
 	// Be explicit that users cannot create pre-approved certificate requests.
 	csr.Status = certificates.CertificateSigningRequestStatus{}
 	csr.Status.Conditions = []certificates.CertificateSigningRequestCondition{}
+	return nil
 }
 
 // PrepareForUpdate clears fields that are not allowed to be set by end users

--- a/pkg/registry/coordination/lease/strategy.go
+++ b/pkg/registry/coordination/lease/strategy.go
@@ -42,7 +42,8 @@ func (leaseStrategy) NamespaceScoped() bool {
 }
 
 // PrepareForCreate prepares Lease for creation.
-func (leaseStrategy) PrepareForCreate(ctx context.Context, obj runtime.Object) {
+func (leaseStrategy) PrepareForCreate(ctx context.Context, obj runtime.Object) field.ErrorList {
+	return nil
 }
 
 // PrepareForUpdate clears fields that are not allowed to be set by end users on update.

--- a/pkg/registry/core/configmap/strategy.go
+++ b/pkg/registry/core/configmap/strategy.go
@@ -53,9 +53,10 @@ func (strategy) NamespaceScoped() bool {
 	return true
 }
 
-func (strategy) PrepareForCreate(ctx context.Context, obj runtime.Object) {
+func (strategy) PrepareForCreate(ctx context.Context, obj runtime.Object) field.ErrorList {
 	configMap := obj.(*api.ConfigMap)
 	dropDisabledFields(configMap, nil)
+	return nil
 }
 
 func (strategy) Validate(ctx context.Context, obj runtime.Object) field.ErrorList {

--- a/pkg/registry/core/endpoint/strategy.go
+++ b/pkg/registry/core/endpoint/strategy.go
@@ -43,7 +43,8 @@ func (endpointsStrategy) NamespaceScoped() bool {
 }
 
 // PrepareForCreate clears fields that are not allowed to be set by end users on creation.
-func (endpointsStrategy) PrepareForCreate(ctx context.Context, obj runtime.Object) {
+func (endpointsStrategy) PrepareForCreate(ctx context.Context, obj runtime.Object) field.ErrorList {
+	return nil
 }
 
 // PrepareForUpdate clears fields that are not allowed to be set by end users on update.

--- a/pkg/registry/core/event/strategy.go
+++ b/pkg/registry/core/event/strategy.go
@@ -52,7 +52,8 @@ func (eventStrategy) NamespaceScoped() bool {
 	return true
 }
 
-func (eventStrategy) PrepareForCreate(ctx context.Context, obj runtime.Object) {
+func (eventStrategy) PrepareForCreate(ctx context.Context, obj runtime.Object) field.ErrorList {
+	return nil
 }
 
 func (eventStrategy) PrepareForUpdate(ctx context.Context, obj, old runtime.Object) {

--- a/pkg/registry/core/limitrange/strategy.go
+++ b/pkg/registry/core/limitrange/strategy.go
@@ -41,11 +41,12 @@ func (limitrangeStrategy) NamespaceScoped() bool {
 	return true
 }
 
-func (limitrangeStrategy) PrepareForCreate(ctx context.Context, obj runtime.Object) {
+func (limitrangeStrategy) PrepareForCreate(ctx context.Context, obj runtime.Object) field.ErrorList {
 	limitRange := obj.(*api.LimitRange)
 	if len(limitRange.Name) == 0 {
 		limitRange.Name = string(uuid.NewUUID())
 	}
+	return nil
 }
 
 func (limitrangeStrategy) PrepareForUpdate(ctx context.Context, obj, old runtime.Object) {

--- a/pkg/registry/core/namespace/strategy.go
+++ b/pkg/registry/core/namespace/strategy.go
@@ -62,7 +62,7 @@ func (namespaceStrategy) GetResetFields() map[fieldpath.APIVersion]*fieldpath.Se
 }
 
 // PrepareForCreate clears fields that are not allowed to be set by end users on creation.
-func (namespaceStrategy) PrepareForCreate(ctx context.Context, obj runtime.Object) {
+func (namespaceStrategy) PrepareForCreate(ctx context.Context, obj runtime.Object) field.ErrorList {
 	// on create, status is active
 	namespace := obj.(*api.Namespace)
 	namespace.Status = api.NamespaceStatus{
@@ -84,6 +84,7 @@ func (namespaceStrategy) PrepareForCreate(ctx context.Context, obj runtime.Objec
 			namespace.Spec.Finalizers = append(namespace.Spec.Finalizers, api.FinalizerKubernetes)
 		}
 	}
+	return nil
 }
 
 // PrepareForUpdate clears fields that are not allowed to be set by end users on update.

--- a/pkg/registry/core/node/strategy.go
+++ b/pkg/registry/core/node/strategy.go
@@ -77,9 +77,10 @@ func (nodeStrategy) AllowCreateOnUpdate() bool {
 }
 
 // PrepareForCreate clears fields that are not allowed to be set by end users on creation.
-func (nodeStrategy) PrepareForCreate(ctx context.Context, obj runtime.Object) {
+func (nodeStrategy) PrepareForCreate(ctx context.Context, obj runtime.Object) field.ErrorList {
 	node := obj.(*api.Node)
 	dropDisabledFields(node, nil)
+	return nil
 }
 
 // PrepareForUpdate clears fields that are not allowed to be set by end users on update.

--- a/pkg/registry/core/persistentvolume/strategy.go
+++ b/pkg/registry/core/persistentvolume/strategy.go
@@ -62,11 +62,12 @@ func (persistentvolumeStrategy) GetResetFields() map[fieldpath.APIVersion]*field
 }
 
 // ResetBeforeCreate clears the Status field which is not allowed to be set by end users on creation.
-func (persistentvolumeStrategy) PrepareForCreate(ctx context.Context, obj runtime.Object) {
+func (persistentvolumeStrategy) PrepareForCreate(ctx context.Context, obj runtime.Object) field.ErrorList {
 	pv := obj.(*api.PersistentVolume)
 	pv.Status = api.PersistentVolumeStatus{}
 
 	pvutil.DropDisabledFields(&pv.Spec, nil)
+	return nil
 }
 
 func (persistentvolumeStrategy) Validate(ctx context.Context, obj runtime.Object) field.ErrorList {

--- a/pkg/registry/core/persistentvolumeclaim/strategy.go
+++ b/pkg/registry/core/persistentvolumeclaim/strategy.go
@@ -63,11 +63,12 @@ func (persistentvolumeclaimStrategy) GetResetFields() map[fieldpath.APIVersion]*
 }
 
 // PrepareForCreate clears the Status field which is not allowed to be set by end users on creation.
-func (persistentvolumeclaimStrategy) PrepareForCreate(ctx context.Context, obj runtime.Object) {
+func (persistentvolumeclaimStrategy) PrepareForCreate(ctx context.Context, obj runtime.Object) field.ErrorList {
 	pvc := obj.(*api.PersistentVolumeClaim)
 	pvc.Status = api.PersistentVolumeClaimStatus{}
 
 	pvcutil.DropDisabledFields(&pvc.Spec, nil)
+	return nil
 }
 
 func (persistentvolumeclaimStrategy) Validate(ctx context.Context, obj runtime.Object) field.ErrorList {

--- a/pkg/registry/core/pod/strategy.go
+++ b/pkg/registry/core/pod/strategy.go
@@ -79,7 +79,7 @@ func (podStrategy) GetResetFields() map[fieldpath.APIVersion]*fieldpath.Set {
 }
 
 // PrepareForCreate clears fields that are not allowed to be set by end users on creation.
-func (podStrategy) PrepareForCreate(ctx context.Context, obj runtime.Object) {
+func (podStrategy) PrepareForCreate(ctx context.Context, obj runtime.Object) field.ErrorList {
 	pod := obj.(*api.Pod)
 	pod.Status = api.PodStatus{
 		Phase:    api.PodPending,
@@ -89,6 +89,7 @@ func (podStrategy) PrepareForCreate(ctx context.Context, obj runtime.Object) {
 	podutil.DropDisabledPodFields(pod, nil)
 
 	applySeccompVersionSkew(pod)
+	return nil
 }
 
 // PrepareForUpdate clears fields that are not allowed to be set by end users on update.

--- a/pkg/registry/core/podtemplate/strategy.go
+++ b/pkg/registry/core/podtemplate/strategy.go
@@ -44,10 +44,11 @@ func (podTemplateStrategy) NamespaceScoped() bool {
 }
 
 // PrepareForCreate clears fields that are not allowed to be set by end users on creation.
-func (podTemplateStrategy) PrepareForCreate(ctx context.Context, obj runtime.Object) {
+func (podTemplateStrategy) PrepareForCreate(ctx context.Context, obj runtime.Object) field.ErrorList {
 	template := obj.(*api.PodTemplate)
 
 	pod.DropDisabledTemplateFields(&template.Template, nil)
+	return nil
 }
 
 // Validate validates a new pod template.

--- a/pkg/registry/core/replicationcontroller/strategy.go
+++ b/pkg/registry/core/replicationcontroller/strategy.go
@@ -87,13 +87,14 @@ func (rcStrategy) GetResetFields() map[fieldpath.APIVersion]*fieldpath.Set {
 }
 
 // PrepareForCreate clears the status of a replication controller before creation.
-func (rcStrategy) PrepareForCreate(ctx context.Context, obj runtime.Object) {
+func (rcStrategy) PrepareForCreate(ctx context.Context, obj runtime.Object) field.ErrorList {
 	controller := obj.(*api.ReplicationController)
 	controller.Status = api.ReplicationControllerStatus{}
 
 	controller.Generation = 1
 
 	pod.DropDisabledTemplateFields(controller.Spec.Template, nil)
+	return nil
 }
 
 // PrepareForUpdate clears fields that are not allowed to be set by end users on update.

--- a/pkg/registry/core/resourcequota/strategy.go
+++ b/pkg/registry/core/resourcequota/strategy.go
@@ -58,9 +58,10 @@ func (resourcequotaStrategy) GetResetFields() map[fieldpath.APIVersion]*fieldpat
 }
 
 // PrepareForCreate clears fields that are not allowed to be set by end users on creation.
-func (resourcequotaStrategy) PrepareForCreate(ctx context.Context, obj runtime.Object) {
+func (resourcequotaStrategy) PrepareForCreate(ctx context.Context, obj runtime.Object) field.ErrorList {
 	resourcequota := obj.(*api.ResourceQuota)
 	resourcequota.Status = api.ResourceQuotaStatus{}
+	return nil
 }
 
 // PrepareForUpdate clears fields that are not allowed to be set by end users on update.

--- a/pkg/registry/core/secret/strategy.go
+++ b/pkg/registry/core/secret/strategy.go
@@ -51,9 +51,10 @@ func (strategy) NamespaceScoped() bool {
 	return true
 }
 
-func (strategy) PrepareForCreate(ctx context.Context, obj runtime.Object) {
+func (strategy) PrepareForCreate(ctx context.Context, obj runtime.Object) field.ErrorList {
 	secret := obj.(*api.Secret)
 	dropDisabledFields(secret, nil)
+	return nil
 }
 
 func (strategy) Validate(ctx context.Context, obj runtime.Object) field.ErrorList {

--- a/pkg/registry/core/service/strategy.go
+++ b/pkg/registry/core/service/strategy.go
@@ -105,12 +105,13 @@ func (svcStrategy) GetResetFields() map[fieldpath.APIVersion]*fieldpath.Set {
 }
 
 // PrepareForCreate sets contextual defaults and clears fields that are not allowed to be set by end users on creation.
-func (strategy svcStrategy) PrepareForCreate(ctx context.Context, obj runtime.Object) {
+func (strategy svcStrategy) PrepareForCreate(ctx context.Context, obj runtime.Object) field.ErrorList {
 	service := obj.(*api.Service)
 	service.Status = api.ServiceStatus{}
 
 	NormalizeClusterIPs(nil, service)
 	dropServiceDisabledFields(service, nil)
+	return nil
 }
 
 // PrepareForUpdate sets contextual defaults and clears fields that are not allowed to be set by end users on update.

--- a/pkg/registry/core/serviceaccount/strategy.go
+++ b/pkg/registry/core/serviceaccount/strategy.go
@@ -41,8 +41,9 @@ func (strategy) NamespaceScoped() bool {
 	return true
 }
 
-func (strategy) PrepareForCreate(ctx context.Context, obj runtime.Object) {
+func (strategy) PrepareForCreate(ctx context.Context, obj runtime.Object) field.ErrorList {
 	cleanSecretReferences(obj.(*api.ServiceAccount))
+	return nil
 }
 
 func (strategy) Validate(ctx context.Context, obj runtime.Object) field.ErrorList {

--- a/pkg/registry/discovery/endpointslice/strategy.go
+++ b/pkg/registry/discovery/endpointslice/strategy.go
@@ -49,12 +49,14 @@ func (endpointSliceStrategy) NamespaceScoped() bool {
 }
 
 // PrepareForCreate clears the status of an EndpointSlice before creation.
-func (endpointSliceStrategy) PrepareForCreate(ctx context.Context, obj runtime.Object) {
+func (endpointSliceStrategy) PrepareForCreate(ctx context.Context, obj runtime.Object) field.ErrorList {
 	endpointSlice := obj.(*discovery.EndpointSlice)
 	endpointSlice.Generation = 1
 
 	dropDisabledFieldsOnCreate(endpointSlice)
 	dropTopologyOnV1(ctx, nil, endpointSlice)
+
+	return nil
 }
 
 // PrepareForUpdate clears fields that are not allowed to be set by end users on update.

--- a/pkg/registry/flowcontrol/flowschema/strategy.go
+++ b/pkg/registry/flowcontrol/flowschema/strategy.go
@@ -59,10 +59,11 @@ func (flowSchemaStrategy) GetResetFields() map[fieldpath.APIVersion]*fieldpath.S
 }
 
 // PrepareForCreate clears the status of a flow-schema before creation.
-func (flowSchemaStrategy) PrepareForCreate(ctx context.Context, obj runtime.Object) {
+func (flowSchemaStrategy) PrepareForCreate(ctx context.Context, obj runtime.Object) field.ErrorList {
 	fl := obj.(*flowcontrol.FlowSchema)
 	fl.Status = flowcontrol.FlowSchemaStatus{}
 	fl.Generation = 1
+	return nil
 }
 
 // PrepareForUpdate clears fields that are not allowed to be set by end users on update.

--- a/pkg/registry/flowcontrol/prioritylevelconfiguration/strategy.go
+++ b/pkg/registry/flowcontrol/prioritylevelconfiguration/strategy.go
@@ -59,10 +59,11 @@ func (priorityLevelConfigurationStrategy) GetResetFields() map[fieldpath.APIVers
 }
 
 // PrepareForCreate clears the status of a priority-level-configuration before creation.
-func (priorityLevelConfigurationStrategy) PrepareForCreate(ctx context.Context, obj runtime.Object) {
+func (priorityLevelConfigurationStrategy) PrepareForCreate(ctx context.Context, obj runtime.Object) field.ErrorList {
 	pl := obj.(*flowcontrol.PriorityLevelConfiguration)
 	pl.Status = flowcontrol.PriorityLevelConfigurationStatus{}
 	pl.Generation = 1
+	return nil
 }
 
 // PrepareForUpdate clears fields that are not allowed to be set by end users on update.

--- a/pkg/registry/networking/ingress/strategy.go
+++ b/pkg/registry/networking/ingress/strategy.go
@@ -64,12 +64,13 @@ func (ingressStrategy) GetResetFields() map[fieldpath.APIVersion]*fieldpath.Set 
 }
 
 // PrepareForCreate clears the status of an Ingress before creation.
-func (ingressStrategy) PrepareForCreate(ctx context.Context, obj runtime.Object) {
+func (ingressStrategy) PrepareForCreate(ctx context.Context, obj runtime.Object) field.ErrorList {
 	ingress := obj.(*networking.Ingress)
 	// create cannot set status
 	ingress.Status = networking.IngressStatus{}
 
 	ingress.Generation = 1
+	return nil
 }
 
 // PrepareForUpdate clears fields that are not allowed to be set by end users on update.

--- a/pkg/registry/networking/ingressclass/strategy.go
+++ b/pkg/registry/networking/ingressclass/strategy.go
@@ -48,13 +48,14 @@ func (ingressClassStrategy) NamespaceScoped() bool {
 }
 
 // PrepareForCreate prepares an IngressClass for creation.
-func (ingressClassStrategy) PrepareForCreate(ctx context.Context, obj runtime.Object) {
+func (ingressClassStrategy) PrepareForCreate(ctx context.Context, obj runtime.Object) field.ErrorList {
 	ingressClass := obj.(*networking.IngressClass)
 	ingressClass.Generation = 1
 
 	if !utilfeature.DefaultFeatureGate.Enabled(features.IngressClassNamespacedParams) {
 		dropIngressClassParametersReferenceScope(ingressClass)
 	}
+	return nil
 }
 
 // PrepareForUpdate clears fields that are not allowed to be set by end users on

--- a/pkg/registry/networking/networkpolicy/strategy.go
+++ b/pkg/registry/networking/networkpolicy/strategy.go
@@ -45,13 +45,14 @@ func (networkPolicyStrategy) NamespaceScoped() bool {
 }
 
 // PrepareForCreate clears the status of a NetworkPolicy before creation.
-func (networkPolicyStrategy) PrepareForCreate(ctx context.Context, obj runtime.Object) {
+func (networkPolicyStrategy) PrepareForCreate(ctx context.Context, obj runtime.Object) field.ErrorList {
 	networkPolicy := obj.(*networking.NetworkPolicy)
 	networkPolicy.Generation = 1
 
 	if !utilfeature.DefaultFeatureGate.Enabled(features.NetworkPolicyEndPort) {
 		dropNetworkPolicyEndPort(networkPolicy)
 	}
+	return nil
 }
 
 // PrepareForUpdate clears fields that are not allowed to be set by end users on update.

--- a/pkg/registry/node/runtimeclass/strategy.go
+++ b/pkg/registry/node/runtimeclass/strategy.go
@@ -57,13 +57,14 @@ func (strategy) AllowCreateOnUpdate() bool {
 
 // PrepareForCreate clears fields that are not allowed to be set by end users
 // on creation.
-func (strategy) PrepareForCreate(ctx context.Context, obj runtime.Object) {
+func (strategy) PrepareForCreate(ctx context.Context, obj runtime.Object) field.ErrorList {
 	rc := obj.(*node.RuntimeClass)
 
 	if !utilfeature.DefaultFeatureGate.Enabled(features.PodOverhead) && rc != nil {
 		// Set Overhead to nil only if the feature is disabled and it is not used
 		rc.Overhead = nil
 	}
+	return nil
 }
 
 // PrepareForUpdate clears fields that are not allowed to be set by end users on update.

--- a/pkg/registry/policy/poddisruptionbudget/strategy.go
+++ b/pkg/registry/policy/poddisruptionbudget/strategy.go
@@ -61,12 +61,13 @@ func (podDisruptionBudgetStrategy) GetResetFields() map[fieldpath.APIVersion]*fi
 }
 
 // PrepareForCreate clears the status of an PodDisruptionBudget before creation.
-func (podDisruptionBudgetStrategy) PrepareForCreate(ctx context.Context, obj runtime.Object) {
+func (podDisruptionBudgetStrategy) PrepareForCreate(ctx context.Context, obj runtime.Object) field.ErrorList {
 	podDisruptionBudget := obj.(*policy.PodDisruptionBudget)
 	// create cannot set status
 	podDisruptionBudget.Status = policy.PodDisruptionBudgetStatus{}
 
 	podDisruptionBudget.Generation = 1
+	return nil
 }
 
 // PrepareForUpdate clears fields that are not allowed to be set by end users on update.

--- a/pkg/registry/policy/podsecuritypolicy/strategy.go
+++ b/pkg/registry/policy/podsecuritypolicy/strategy.go
@@ -57,10 +57,11 @@ func (strategy) AllowUnconditionalUpdate() bool {
 	return true
 }
 
-func (strategy) PrepareForCreate(ctx context.Context, obj runtime.Object) {
+func (strategy) PrepareForCreate(ctx context.Context, obj runtime.Object) field.ErrorList {
 	psp := obj.(*policy.PodSecurityPolicy)
 
 	psputil.DropDisabledFields(&psp.Spec, nil)
+	return nil
 }
 
 func (strategy) PrepareForUpdate(ctx context.Context, obj, old runtime.Object) {

--- a/pkg/registry/rbac/clusterrole/strategy.go
+++ b/pkg/registry/rbac/clusterrole/strategy.go
@@ -56,8 +56,9 @@ func (strategy) AllowCreateOnUpdate() bool {
 
 // PrepareForCreate clears fields that are not allowed to be set by end users
 // on creation.
-func (strategy) PrepareForCreate(ctx context.Context, obj runtime.Object) {
+func (strategy) PrepareForCreate(ctx context.Context, obj runtime.Object) field.ErrorList {
 	_ = obj.(*rbac.ClusterRole)
+	return nil
 }
 
 // PrepareForUpdate clears fields that are not allowed to be set by end users on update.

--- a/pkg/registry/rbac/clusterrolebinding/strategy.go
+++ b/pkg/registry/rbac/clusterrolebinding/strategy.go
@@ -56,8 +56,9 @@ func (strategy) AllowCreateOnUpdate() bool {
 
 // PrepareForCreate clears fields that are not allowed to be set by end users
 // on creation.
-func (strategy) PrepareForCreate(ctx context.Context, obj runtime.Object) {
+func (strategy) PrepareForCreate(ctx context.Context, obj runtime.Object) field.ErrorList {
 	_ = obj.(*rbac.ClusterRoleBinding)
+	return nil
 }
 
 // PrepareForUpdate clears fields that are not allowed to be set by end users on update.

--- a/pkg/registry/rbac/role/strategy.go
+++ b/pkg/registry/rbac/role/strategy.go
@@ -56,8 +56,9 @@ func (strategy) AllowCreateOnUpdate() bool {
 
 // PrepareForCreate clears fields that are not allowed to be set by end users
 // on creation.
-func (strategy) PrepareForCreate(ctx context.Context, obj runtime.Object) {
+func (strategy) PrepareForCreate(ctx context.Context, obj runtime.Object) field.ErrorList {
 	_ = obj.(*rbac.Role)
+	return nil
 }
 
 // PrepareForUpdate clears fields that are not allowed to be set by end users on update.

--- a/pkg/registry/rbac/rolebinding/strategy.go
+++ b/pkg/registry/rbac/rolebinding/strategy.go
@@ -56,8 +56,9 @@ func (strategy) AllowCreateOnUpdate() bool {
 
 // PrepareForCreate clears fields that are not allowed to be set by end users
 // on creation.
-func (strategy) PrepareForCreate(ctx context.Context, obj runtime.Object) {
+func (strategy) PrepareForCreate(ctx context.Context, obj runtime.Object) field.ErrorList {
 	_ = obj.(*rbac.RoleBinding)
+	return nil
 }
 
 // PrepareForUpdate clears fields that are not allowed to be set by end users on update.

--- a/pkg/registry/scheduling/priorityclass/strategy.go
+++ b/pkg/registry/scheduling/priorityclass/strategy.go
@@ -43,10 +43,11 @@ func (priorityClassStrategy) NamespaceScoped() bool {
 }
 
 // PrepareForCreate clears the status of a PriorityClass before creation.
-func (priorityClassStrategy) PrepareForCreate(ctx context.Context, obj runtime.Object) {
+func (priorityClassStrategy) PrepareForCreate(ctx context.Context, obj runtime.Object) field.ErrorList {
 	pc := obj.(*scheduling.PriorityClass)
 	pc.Generation = 1
 	schedulingutil.DropDisabledFields(pc, nil)
+	return nil
 }
 
 // PrepareForUpdate clears fields that are not allowed to be set by end users on update.

--- a/pkg/registry/storage/csidriver/strategy.go
+++ b/pkg/registry/storage/csidriver/strategy.go
@@ -45,7 +45,7 @@ func (csiDriverStrategy) NamespaceScoped() bool {
 }
 
 // PrepareForCreate clears the fields for which the corresponding feature is disabled.
-func (csiDriverStrategy) PrepareForCreate(ctx context.Context, obj runtime.Object) {
+func (csiDriverStrategy) PrepareForCreate(ctx context.Context, obj runtime.Object) field.ErrorList {
 	csiDriver := obj.(*storage.CSIDriver)
 	if !utilfeature.DefaultFeatureGate.Enabled(features.CSIStorageCapacity) {
 		csiDriver.Spec.StorageCapacity = nil
@@ -60,6 +60,7 @@ func (csiDriverStrategy) PrepareForCreate(ctx context.Context, obj runtime.Objec
 		csiDriver.Spec.TokenRequests = nil
 		csiDriver.Spec.RequiresRepublish = nil
 	}
+	return nil
 }
 
 func (csiDriverStrategy) Validate(ctx context.Context, obj runtime.Object) field.ErrorList {

--- a/pkg/registry/storage/csinode/strategy.go
+++ b/pkg/registry/storage/csinode/strategy.go
@@ -42,7 +42,8 @@ func (csiNodeStrategy) NamespaceScoped() bool {
 }
 
 // PrepareForCreate clears fields that are not allowed to be set on creation.
-func (csiNodeStrategy) PrepareForCreate(ctx context.Context, obj runtime.Object) {
+func (csiNodeStrategy) PrepareForCreate(ctx context.Context, obj runtime.Object) field.ErrorList {
+	return nil
 }
 
 func (csiNodeStrategy) Validate(ctx context.Context, obj runtime.Object) field.ErrorList {

--- a/pkg/registry/storage/csistoragecapacity/strategy.go
+++ b/pkg/registry/storage/csistoragecapacity/strategy.go
@@ -42,7 +42,8 @@ func (csiStorageCapacityStrategy) NamespaceScoped() bool {
 }
 
 // PrepareForCreate is currently a NOP.
-func (csiStorageCapacityStrategy) PrepareForCreate(ctx context.Context, obj runtime.Object) {
+func (csiStorageCapacityStrategy) PrepareForCreate(ctx context.Context, obj runtime.Object) field.ErrorList {
+	return nil
 }
 
 func (csiStorageCapacityStrategy) Validate(ctx context.Context, obj runtime.Object) field.ErrorList {

--- a/pkg/registry/storage/storageclass/strategy.go
+++ b/pkg/registry/storage/storageclass/strategy.go
@@ -43,10 +43,11 @@ func (storageClassStrategy) NamespaceScoped() bool {
 }
 
 // ResetBeforeCreate clears the Status field which is not allowed to be set by end users on creation.
-func (storageClassStrategy) PrepareForCreate(ctx context.Context, obj runtime.Object) {
+func (storageClassStrategy) PrepareForCreate(ctx context.Context, obj runtime.Object) field.ErrorList {
 	class := obj.(*storage.StorageClass)
 
 	storageutil.DropDisabledFields(class, nil)
+	return nil
 }
 
 func (storageClassStrategy) Validate(ctx context.Context, obj runtime.Object) field.ErrorList {

--- a/pkg/registry/storage/volumeattachment/strategy.go
+++ b/pkg/registry/storage/volumeattachment/strategy.go
@@ -61,7 +61,7 @@ func (volumeAttachmentStrategy) GetResetFields() map[fieldpath.APIVersion]*field
 }
 
 // ResetBeforeCreate clears the Status field which is not allowed to be set by end users on creation.
-func (volumeAttachmentStrategy) PrepareForCreate(ctx context.Context, obj runtime.Object) {
+func (volumeAttachmentStrategy) PrepareForCreate(ctx context.Context, obj runtime.Object) field.ErrorList {
 	var groupVersion schema.GroupVersion
 
 	if requestInfo, found := genericapirequest.RequestInfoFrom(ctx); found {
@@ -81,6 +81,7 @@ func (volumeAttachmentStrategy) PrepareForCreate(ctx context.Context, obj runtim
 		volumeAttachment.Spec.Source.InlineVolumeSpec = nil
 	}
 
+	return nil
 }
 
 func (volumeAttachmentStrategy) Validate(ctx context.Context, obj runtime.Object) field.ErrorList {

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/registry/customresource/strategy.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/registry/customresource/strategy.go
@@ -89,7 +89,7 @@ func (a customResourceStrategy) GetResetFields() map[fieldpath.APIVersion]*field
 }
 
 // PrepareForCreate clears the status of a CustomResource before creation.
-func (a customResourceStrategy) PrepareForCreate(ctx context.Context, obj runtime.Object) {
+func (a customResourceStrategy) PrepareForCreate(ctx context.Context, obj runtime.Object) field.ErrorList {
 	if a.status != nil {
 		customResourceObject := obj.(*unstructured.Unstructured)
 		customResource := customResourceObject.UnstructuredContent()
@@ -100,6 +100,8 @@ func (a customResourceStrategy) PrepareForCreate(ctx context.Context, obj runtim
 
 	accessor, _ := meta.Accessor(obj)
 	accessor.SetGeneration(1)
+
+	return nil
 }
 
 // PrepareForUpdate clears fields that are not allowed to be set by end users on update.

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/registry/customresourcedefinition/strategy.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/registry/customresourcedefinition/strategy.go
@@ -66,7 +66,7 @@ func (strategy) GetResetFields() map[fieldpath.APIVersion]*fieldpath.Set {
 }
 
 // PrepareForCreate clears the status of a CustomResourceDefinition before creation.
-func (strategy) PrepareForCreate(ctx context.Context, obj runtime.Object) {
+func (strategy) PrepareForCreate(ctx context.Context, obj runtime.Object) field.ErrorList {
 	crd := obj.(*apiextensions.CustomResourceDefinition)
 	crd.Status = apiextensions.CustomResourceDefinitionStatus{}
 	crd.Generation = 1
@@ -79,6 +79,7 @@ func (strategy) PrepareForCreate(ctx context.Context, obj runtime.Object) {
 			break
 		}
 	}
+	return nil
 }
 
 // PrepareForUpdate clears fields that are not allowed to be set by end users on update.

--- a/staging/src/k8s.io/kube-aggregator/pkg/registry/apiservice/strategy.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/registry/apiservice/strategy.go
@@ -65,7 +65,7 @@ func (apiServerStrategy) GetResetFields() map[fieldpath.APIVersion]*fieldpath.Se
 	return fields
 }
 
-func (apiServerStrategy) PrepareForCreate(ctx context.Context, obj runtime.Object) {
+func (apiServerStrategy) PrepareForCreate(ctx context.Context, obj runtime.Object) field.ErrorList {
 	apiservice := obj.(*apiregistration.APIService)
 	apiservice.Status = apiregistration.APIServiceStatus{}
 
@@ -73,6 +73,8 @@ func (apiServerStrategy) PrepareForCreate(ctx context.Context, obj runtime.Objec
 	if apiservice.Spec.Service == nil {
 		apiregistration.SetAPIServiceCondition(apiservice, apiregistration.NewLocalAvailableAPIServiceCondition())
 	}
+
+	return nil
 }
 
 func (apiServerStrategy) PrepareForUpdate(ctx context.Context, obj, old runtime.Object) {

--- a/staging/src/k8s.io/sample-apiserver/pkg/registry/wardle/fischer/strategy.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/registry/wardle/fischer/strategy.go
@@ -69,7 +69,8 @@ func (fischerStrategy) NamespaceScoped() bool {
 	return false
 }
 
-func (fischerStrategy) PrepareForCreate(ctx context.Context, obj runtime.Object) {
+func (fischerStrategy) PrepareForCreate(ctx context.Context, obj runtime.Object) field.ErrorList {
+	return nil
 }
 
 func (fischerStrategy) PrepareForUpdate(ctx context.Context, obj, old runtime.Object) {

--- a/staging/src/k8s.io/sample-apiserver/pkg/registry/wardle/flunder/strategy.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/registry/wardle/flunder/strategy.go
@@ -70,7 +70,8 @@ func (flunderStrategy) NamespaceScoped() bool {
 	return true
 }
 
-func (flunderStrategy) PrepareForCreate(ctx context.Context, obj runtime.Object) {
+func (flunderStrategy) PrepareForCreate(ctx context.Context, obj runtime.Object) field.ErrorList {
+	return nil
 }
 
 func (flunderStrategy) PrepareForUpdate(ctx context.Context, obj, old runtime.Object) {


### PR DESCRIPTION
Currently, when a conditional field is specified, but not honored (an alpha field on a GA API for instance), the client does not get any immediate feedback that their intent is not honored. This leads to unexpected behavior.

Today the, best practice is to strip fields in `BeforeCreate`. While this is compatible with servers that aren't aware of the field, the code could return an error an fail the request instead so that a caller that is trying to specify a field (usually for some purpose) will know that intent is not fulfilled.  The code will live in the same spot and we will not change the behavior of existing fields, but we the opportunity to make future features easier for clients to use predictably when they are in alpha and beta states.

/kind cleanup
/priority important-soon (may as well decide)
@kubernetes/sig-api-machinery-misc 

```release-note
NONE
```