### PR TITLE
WIP: test/e2e/storage: replace mock driver with hostpath driver

### DIFF
--- a/test/e2e/storage/drivers/csi.go
+++ b/test/e2e/storage/drivers/csi.go
@@ -575,10 +575,10 @@ func (m *mockCSIDriver) PrepareTest(f *framework.Framework) (*storageframework.P
 	} else {
 		// When using the mock driver inside the cluster it has to be reconfigured
 		// via command line parameters.
-		containerArgs = append(containerArgs, "--name=csi-mock-"+f.UniqueName)
+		containerArgs = append(containerArgs, "--drivername=csi-mock-"+f.UniqueName)
 
-		if !m.attachable {
-			containerArgs = append(containerArgs, "--disable-attach")
+		if m.attachable {
+			containerArgs = append(containerArgs, "--enable-attach")
 		}
 
 		if m.enableTopology {

--- a/test/e2e/testing-manifests/storage-csi/mock/csi-mock-driver.yaml
+++ b/test/e2e/testing-manifests/storage-csi/mock/csi-mock-driver.yaml
@@ -53,10 +53,17 @@ spec:
           - mountPath: /registration
             name: registration-dir
         - name: mock
-          image: k8s.gcr.io/sig-storage/mock-driver:v4.1.0
+          # FIXME: Move to release image once the hostpath-plugin release
+          # having below chagnes;
+          #  - https://github.com/kubernetes-csi/csi-driver-host-path/pull/269
+          #  - https://github.com/kubernetes-csi/csi-driver-host-path/pull/260          #
+          image: gcr.io/k8s-staging-sig-storage/hostpathplugin:canary
           args:
-            - "--name=mock.storage.k8s.io"
-            - "-v=3" # enabled the gRPC call logging
+            - "--drivername=mock.storage.k8s.io"
+            - "--nodeid=$(KUBE_NODE_NAME)"
+            - "--endpoint=/csi/csi.sock"
+            - "--statedir=/tmp/csi-hotpath-data"
+            - "-v=5" # enabled the gRPC call logging
           env:
             - name: CSI_ENDPOINT
               value: /csi/csi.sock
@@ -74,6 +81,8 @@ spec:
               name: kubelet-pods-dir
             - mountPath: /var/lib/kubelet/plugins/kubernetes.io/csi
               name: kubelet-csi-dir
+            - mountPath: /dev
+              name: dev-dir
       volumes:
         - hostPath:
             path: /var/lib/kubelet/plugins/csi-mock
@@ -93,3 +102,7 @@ spec:
             path: /var/lib/kubelet/plugins_registry
             type: Directory
           name: registration-dir
+        - hostPath:
+            path: /dev
+            type: Directory
+          name: dev-dir

--- a/test/e2e/testing-manifests/storage-csi/mock/csi-mock-proxy.yaml
+++ b/test/e2e/testing-manifests/storage-csi/mock/csi-mock-proxy.yaml
@@ -53,16 +53,24 @@ spec:
           - mountPath: /registration
             name: registration-dir
         - name: mock
-          image: k8s.gcr.io/sig-storage/mock-driver:v4.1.0
+          # FIXME: Move to release image once the hostpath-plugin release
+          # having below chagnes;
+          #  - https://github.com/kubernetes-csi/csi-driver-host-path/pull/269
+          #  - https://github.com/kubernetes-csi/csi-driver-host-path/pull/260          #
+          image: gcr.io/k8s-staging-sig-storage/hostpathplugin:canary
           args:
-            # -v3 shows when connections get established. Higher log levels print information about
-            # transferred bytes, but cannot print message content (no gRPC parsing), so this is usually
-            # not interesting.
-            - -v=3
+            - -v=5
+            - -nodeid=$(KUBE_NODE_NAME)
+            - -endpoint=/csi/csi.sock
             - -proxy-endpoint=tcp://:9000
           env:
             - name: CSI_ENDPOINT
               value: /csi/csi.sock
+            - name: KUBE_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: spec.nodeName
           ports:
             - containerPort: 9000
               name: socat

--- a/test/utils/image/manifest.go
+++ b/test/utils/image/manifest.go
@@ -30,18 +30,19 @@ import (
 
 // RegistryList holds public and private image registries
 type RegistryList struct {
-	GcAuthenticatedRegistry string `yaml:"gcAuthenticatedRegistry"`
-	E2eRegistry             string `yaml:"e2eRegistry"`
-	PromoterE2eRegistry     string `yaml:"promoterE2eRegistry"`
-	BuildImageRegistry      string `yaml:"buildImageRegistry"`
-	InvalidRegistry         string `yaml:"invalidRegistry"`
-	GcEtcdRegistry          string `yaml:"gcEtcdRegistry"`
-	GcRegistry              string `yaml:"gcRegistry"`
-	SigStorageRegistry      string `yaml:"sigStorageRegistry"`
-	GcrReleaseRegistry      string `yaml:"gcrReleaseRegistry"`
-	PrivateRegistry         string `yaml:"privateRegistry"`
-	SampleRegistry          string `yaml:"sampleRegistry"`
-	MicrosoftRegistry       string `yaml:"microsoftRegistry"`
+	GcAuthenticatedRegistry  string `yaml:"gcAuthenticatedRegistry"`
+	E2eRegistry              string `yaml:"e2eRegistry"`
+	PromoterE2eRegistry      string `yaml:"promoterE2eRegistry"`
+	BuildImageRegistry       string `yaml:"buildImageRegistry"`
+	InvalidRegistry          string `yaml:"invalidRegistry"`
+	GcEtcdRegistry           string `yaml:"gcEtcdRegistry"`
+	GcRegistry               string `yaml:"gcRegistry"`
+	SigStorageRegistry       string `yaml:"sigStorageRegistry"`
+	SigStorageCanaryRegistry string `yaml:"sigStorageCanaryRegistry"`
+	GcrReleaseRegistry       string `yaml:"gcrReleaseRegistry"`
+	PrivateRegistry          string `yaml:"privateRegistry"`
+	SampleRegistry           string `yaml:"sampleRegistry"`
+	MicrosoftRegistry        string `yaml:"microsoftRegistry"`
 }
 
 // Config holds an images registry, name, and version
@@ -68,18 +69,19 @@ func (i *Config) SetVersion(version string) {
 
 func initReg() RegistryList {
 	registry := RegistryList{
-		GcAuthenticatedRegistry: "gcr.io/authenticated-image-pulling",
-		E2eRegistry:             "gcr.io/kubernetes-e2e-test-images",
-		PromoterE2eRegistry:     "k8s.gcr.io/e2e-test-images",
-		BuildImageRegistry:      "k8s.gcr.io/build-image",
-		InvalidRegistry:         "invalid.com/invalid",
-		GcEtcdRegistry:          "k8s.gcr.io",
-		GcRegistry:              "k8s.gcr.io",
-		SigStorageRegistry:      "k8s.gcr.io/sig-storage",
-		PrivateRegistry:         "gcr.io/k8s-authenticated-test",
-		SampleRegistry:          "gcr.io/google-samples",
-		GcrReleaseRegistry:      "gcr.io/gke-release",
-		MicrosoftRegistry:       "mcr.microsoft.com",
+		GcAuthenticatedRegistry:  "gcr.io/authenticated-image-pulling",
+		E2eRegistry:              "gcr.io/kubernetes-e2e-test-images",
+		PromoterE2eRegistry:      "k8s.gcr.io/e2e-test-images",
+		BuildImageRegistry:       "k8s.gcr.io/build-image",
+		InvalidRegistry:          "invalid.com/invalid",
+		GcEtcdRegistry:           "k8s.gcr.io",
+		GcRegistry:               "k8s.gcr.io",
+		SigStorageRegistry:       "k8s.gcr.io/sig-storage",
+		SigStorageCanaryRegistry: "gcr.io/k8s-staging-sig-storage",
+		PrivateRegistry:          "gcr.io/k8s-authenticated-test",
+		SampleRegistry:           "gcr.io/google-samples",
+		GcrReleaseRegistry:       "gcr.io/gke-release",
+		MicrosoftRegistry:        "mcr.microsoft.com",
 	}
 	repoList := os.Getenv("KUBE_TEST_REPO_LIST")
 	if repoList == "" {
@@ -105,18 +107,19 @@ var (
 	PrivateRegistry = registry.PrivateRegistry
 
 	// Preconfigured image configs
-	dockerLibraryRegistry   = "docker.io/library"
-	e2eRegistry             = registry.E2eRegistry
-	promoterE2eRegistry     = registry.PromoterE2eRegistry
-	buildImageRegistry      = registry.BuildImageRegistry
-	gcAuthenticatedRegistry = registry.GcAuthenticatedRegistry
-	gcEtcdRegistry          = registry.GcEtcdRegistry
-	gcRegistry              = registry.GcRegistry
-	sigStorageRegistry      = registry.SigStorageRegistry
-	gcrReleaseRegistry      = registry.GcrReleaseRegistry
-	invalidRegistry         = registry.InvalidRegistry
-	sampleRegistry          = registry.SampleRegistry
-	microsoftRegistry       = registry.MicrosoftRegistry
+	dockerLibraryRegistry    = "docker.io/library"
+	e2eRegistry              = registry.E2eRegistry
+	promoterE2eRegistry      = registry.PromoterE2eRegistry
+	buildImageRegistry       = registry.BuildImageRegistry
+	gcAuthenticatedRegistry  = registry.GcAuthenticatedRegistry
+	gcEtcdRegistry           = registry.GcEtcdRegistry
+	gcRegistry               = registry.GcRegistry
+	sigStorageRegistry       = registry.SigStorageRegistry
+	sigStorageCanaryRegistry = registry.SigStorageCanaryRegistry
+	gcrReleaseRegistry       = registry.GcrReleaseRegistry
+	invalidRegistry          = registry.InvalidRegistry
+	sampleRegistry           = registry.SampleRegistry
+	microsoftRegistry        = registry.MicrosoftRegistry
 
 	imageConfigs, originalImageConfigs = initImageConfigs()
 )
@@ -393,6 +396,8 @@ func ReplaceRegistryInImageURL(imageURL string) (string, error) {
 		registryAndUser = gcRegistry
 	case "k8s.gcr.io/sig-storage":
 		registryAndUser = sigStorageRegistry
+	case "gcr.io/k8s-staging-sig-storage":
+		registryAndUser = sigStorageCanaryRegistry
 	case "gcr.io/k8s-authenticated-test":
 		registryAndUser = PrivateRegistry
 	case "gcr.io/google-samples":


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup


#### What this PR does / why we need it:
This is a first step towards removing the mock CSI driver completely from
e2e testing in favor of hostpath plugin. With the recent hostpath plugin
changes(PR #260, #269), it supports all the features supported by the mock
csi driver.

Using hostpath-plugin for testing also covers CSI persistent feature
usecases.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:
The PR is in WIP as it requires a hostpath-plugin release with the needed changes. Currently, it is using hostpath 'canary' images.

#### Does this PR introduce a user-facing change?
No
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
