### PR TITLE
graduate IngressClassNamespacedParams to beta

### DIFF
--- a/pkg/api/testing/defaulting_test.go
+++ b/pkg/api/testing/defaulting_test.go
@@ -151,6 +151,8 @@ func TestDefaulting(t *testing.T) {
 		{Group: "networking.k8s.io", Version: "v1", Kind: "NetworkPolicyList"}:                                  {},
 		{Group: "networking.k8s.io", Version: "v1beta1", Kind: "Ingress"}:                                       {},
 		{Group: "networking.k8s.io", Version: "v1beta1", Kind: "IngressList"}:                                   {},
+		{Group: "networking.k8s.io", Version: "v1", Kind: "IngressClass"}:                                       {},
+		{Group: "networking.k8s.io", Version: "v1", Kind: "IngressClassList"}:                                   {},
 		{Group: "storage.k8s.io", Version: "v1beta1", Kind: "StorageClass"}:                                     {},
 		{Group: "storage.k8s.io", Version: "v1beta1", Kind: "StorageClassList"}:                                 {},
 		{Group: "storage.k8s.io", Version: "v1beta1", Kind: "CSIDriver"}:                                        {},

--- a/pkg/apis/networking/fuzzer/fuzzer.go
+++ b/pkg/apis/networking/fuzzer/fuzzer.go
@@ -20,6 +20,7 @@ import (
 	fuzz "github.com/google/gofuzz"
 	runtimeserializer "k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/kubernetes/pkg/apis/networking"
+	utilpointer "k8s.io/utils/pointer"
 )
 
 // Funcs returns the fuzzer functions for the networking api group.
@@ -61,6 +62,15 @@ var Funcs = func(codecs runtimeserializer.CodecFactory) []interface{} {
 				p.Number = 0
 				if p.Name == "" {
 					p.Name = "portname"
+				}
+			}
+		},
+		func(p *networking.IngressClass, c fuzz.Continue) {
+			c.FuzzNoCustom(p) // fuzz self without calling this function again
+			// default Parameters to Cluster
+			if p.Spec.Parameters == nil || p.Spec.Parameters.Scope == nil {
+				p.Spec.Parameters = &networking.IngressClassParametersReference{
+					Scope: utilpointer.StringPtr(networking.IngressClassParametersReferenceScopeCluster),
 				}
 			}
 		},

--- a/pkg/apis/networking/validation/validation_test.go
+++ b/pkg/apis/networking/validation/validation_test.go
@@ -1884,9 +1884,11 @@ func TestValidateIngressClassUpdate(t *testing.T) {
 				Spec: networking.IngressClassSpec{
 					Controller: "foo.co/bar",
 					Parameters: &networking.IngressClassParametersReference{
-						APIGroup: utilpointer.StringPtr("v1"),
-						Kind:     "ConfigMap",
-						Name:     "foo",
+						APIGroup:  utilpointer.StringPtr("v1"),
+						Scope:     utilpointer.StringPtr("Namespace"),
+						Kind:      "ConfigMap",
+						Name:      "foo",
+						Namespace: utilpointer.StringPtr("bar"),
 					},
 				},
 			},

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -692,6 +692,7 @@ const (
 
 	// owner: @hbagdi
 	// alpha: v1.21
+	// beta: v1.22
 	//
 	// Enable Scope and Namespace fields on IngressClassParametersReference.
 	IngressClassNamespacedParams featuregate.Feature = "IngressClassNamespacedParams"
@@ -830,7 +831,7 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
 	PodAffinityNamespaceSelector:                   {Default: false, PreRelease: featuregate.Alpha},
 	ServiceLoadBalancerClass:                       {Default: false, PreRelease: featuregate.Alpha},
 	LogarithmicScaleDown:                           {Default: false, PreRelease: featuregate.Alpha},
-	IngressClassNamespacedParams:                   {Default: false, PreRelease: featuregate.Alpha},
+	IngressClassNamespacedParams:                   {Default: true, PreRelease: featuregate.Beta},
 	ServiceInternalTrafficPolicy:                   {Default: false, PreRelease: featuregate.Alpha},
 	SuspendJob:                                     {Default: false, PreRelease: featuregate.Alpha},
 	KubeletPodResourcesGetAllocatable:              {Default: false, PreRelease: featuregate.Alpha},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind feature
#### What this PR does / why we need it:

Graduates IngressClassNamespacedParams feature gate to beta and enabling it by default.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
IngressClassNamespacedParams feature gate has graduated to beta and is enabled by default. This means IngressClass resource will now have two new fields - `spec.paramters.namespace` and `spec.parameters.scope`.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: https://github.com/kubernetes/enhancements/tree/master/keps/sig-network/2365-ingressclass-namespaced-params
- [Usage]: <link>
- [Other doc]: <link>
-->

KEP: https://github.com/kubernetes/enhancements/tree/master/keps/sig-network/2365-ingressclass-namespaced-params
Enhancement issue: https://github.com/kubernetes/enhancements/issues/2365

/sig network
/priority important-soon
/assign @robscott