### PR TITLE
Remove ReallyCrashForTesting and cleaned up some references to Handle…

### DIFF
--- a/cmd/kubelet/app/options/options.go
+++ b/cmd/kubelet/app/options/options.go
@@ -54,9 +54,6 @@ type KubeletFlags struct {
 	KubeConfig          string
 	BootstrapKubeconfig string
 
-	// Crash immediately, rather than eating panics.
-	ReallyCrashForTesting bool
-
 	// HostnameOverride is the hostname used to identify the kubelet instead
 	// of the actual hostname.
 	HostnameOverride string
@@ -352,8 +349,6 @@ func (f *KubeletFlags) AddFlags(mainfs *pflag.FlagSet) {
 	fs.MarkDeprecated("non-masquerade-cidr", "will be removed in a future version")
 	fs.BoolVar(&f.KeepTerminatedPodVolumes, "keep-terminated-pod-volumes", f.KeepTerminatedPodVolumes, "Keep terminated pod volumes mounted to the node after the pod terminates.  Can be useful for debugging volume related issues.")
 	fs.MarkDeprecated("keep-terminated-pod-volumes", "will be removed in a future version")
-	fs.BoolVar(&f.ReallyCrashForTesting, "really-crash-for-testing", f.ReallyCrashForTesting, "If true, when panics occur crash. Intended for testing.")
-	fs.MarkDeprecated("really-crash-for-testing", "will be removed in a future version.")
 	fs.StringVar(&f.ExperimentalMounterPath, "experimental-mounter-path", f.ExperimentalMounterPath, "[Experimental] Path of mounter binary. Leave empty to use the default mount.")
 	fs.MarkDeprecated("experimental-mounter-path", "will be removed in 1.23. in favor of using CSI.")
 	fs.BoolVar(&f.ExperimentalCheckNodeCapabilitiesBeforeMount, "experimental-check-node-capabilities-before-mount", f.ExperimentalCheckNodeCapabilitiesBeforeMount, "[Experimental] if set true, the kubelet will check the underlying node for required components (binaries, etc.) before performing the mount")

--- a/cmd/kubelet/app/server.go
+++ b/cmd/kubelet/app/server.go
@@ -45,7 +45,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	utilnet "k8s.io/apimachinery/pkg/util/net"
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
 	genericapiserver "k8s.io/apiserver/pkg/server"
@@ -790,8 +789,6 @@ func run(ctx context.Context, s *options.KubeletServer, kubeDeps *kubelet.Depend
 			return err
 		}
 	}
-
-	utilruntime.ReallyCrash = s.ReallyCrashForTesting
 
 	// TODO(vmarmol): Do this through container config.
 	oomAdjuster := kubeDeps.OOMAdjuster

--- a/pkg/kubelet/kubelet_test.go
+++ b/pkg/kubelet/kubelet_test.go
@@ -39,7 +39,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes/fake"
@@ -87,7 +86,6 @@ import (
 )
 
 func init() {
-	utilruntime.ReallyCrash = true
 }
 
 const (

--- a/pkg/kubelet/prober/prober_manager_test.go
+++ b/pkg/kubelet/prober/prober_manager_test.go
@@ -25,7 +25,6 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
@@ -34,7 +33,6 @@ import (
 )
 
 func init() {
-	runtime.ReallyCrash = true
 }
 
 var defaultProbe = &v1.Probe{

--- a/pkg/proxy/userspace/proxier_test.go
+++ b/pkg/proxy/userspace/proxier_test.go
@@ -33,7 +33,6 @@ import (
 	discovery "k8s.io/api/discovery/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/kubernetes/pkg/proxy"
 	ipttest "k8s.io/kubernetes/pkg/util/iptables/testing"
@@ -186,9 +185,6 @@ var tcpServerPort int32
 var udpServerPort int32
 
 func TestMain(m *testing.M) {
-	// Don't handle panics
-	runtime.ReallyCrash = true
-
 	// TCP setup.
 	tcp := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)

--- a/pkg/proxy/winuserspace/proxier_test.go
+++ b/pkg/proxy/winuserspace/proxier_test.go
@@ -33,7 +33,6 @@ import (
 	discovery "k8s.io/api/discovery/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/kubernetes/pkg/proxy"
 	netshtest "k8s.io/kubernetes/pkg/util/netsh/testing"
 	netutils "k8s.io/utils/net"
@@ -115,9 +114,6 @@ var tcpServerPort int32
 var udpServerPort int32
 
 func TestMain(m *testing.M) {
-	// Don't handle panics
-	runtime.ReallyCrash = true
-
 	// TCP setup.
 	tcp := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)

--- a/staging/src/k8s.io/apimachinery/pkg/util/runtime/runtime.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/runtime/runtime.go
@@ -27,9 +27,10 @@ import (
 )
 
 var (
-	// ReallyCrash controls the behavior of HandleCrash and now defaults
-	// true. It's still exposed so components can optionally set to false
-	// to restore prior behavior.
+	// ReallyCrash controls the behavior of HandleCrash and defaults to
+	// true. It's exposed so components can optionally set to false
+	// to restore prior behavior. This flag is mostly used for tests to validate
+	// crash conditions.
 	ReallyCrash = true
 )
 

--- a/staging/src/k8s.io/apiserver/pkg/server/filters/wrap.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/filters/wrap.go
@@ -41,8 +41,7 @@ func WithPanicRecovery(handler http.Handler, resolver request.RequestInfoResolve
 			// the client sees an interrupted response but the server doesn't log
 			// an error, panic with the value ErrAbortHandler.
 			//
-			// Note that the ReallyCrash variable controls the behaviour of the HandleCrash function
-			// So it might actually crash, after calling the handlers
+			// Note that HandleCrash function is actually crashing, after calling the handlers
 			if info, err := resolver.NewRequestInfo(req); err != nil {
 				metrics.RecordRequestAbort(req, nil)
 			} else {

--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -39,7 +39,6 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	runtimeutils "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/component-base/logs"
 	"k8s.io/component-base/version"
@@ -98,7 +97,6 @@ var _ = ginkgo.SynchronizedAfterSuite(func() {
 // generated in this directory, and cluster logs will also be saved.
 // This function is called on each Ginkgo node in parallel mode.
 func RunE2ETests(t *testing.T) {
-	runtimeutils.ReallyCrash = true
 	logs.InitLogs()
 	defer logs.FlushLogs()
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind cleanup

/sig node
/priority important-longterm

#### What this PR does / why we need it:

The flag `--really-crash-for-testing` was deprecated for over a year: https://github.com/kubernetes/kubernetes/pull/90499 And at that time it was already never set.

This error https://github.com/kubernetes/kubernetes/pull/101012 wasn't caught as the default for tests was not to panic.

#### Does this PR introduce a user-facing change?
```release-note
The deprecated flag `--really-crash-for-testing` is removed.
```