### PR TITLE
Revert "Revert "cluster: Use python3 everywhere""

### DIFF
--- a/cluster/gce/gci/configure-helper.sh
+++ b/cluster/gce/gci/configure-helper.sh
@@ -1781,7 +1781,7 @@ function start-kube-proxy {
 # $5: pod name, which should be either etcd or etcd-events
 function prepare-etcd-manifest {
   local host_name=${ETCD_HOSTNAME:-$(hostname -s)}
-  local -r host_ip=$(${PYTHON} -c "import socket;print(socket.gethostbyname(\"${host_name}\"))")
+  local -r host_ip=$(python3 -c "import socket;print(socket.gethostbyname(\"${host_name}\"))")
   local etcd_cluster=""
   local cluster_state="new"
   local etcd_protocol="http"
@@ -3287,24 +3287,6 @@ function main() {
   KUBE_BIN=${KUBE_HOME}/bin
   CONTAINERIZED_MOUNTER_HOME="${KUBE_HOME}/containerized_mounter"
   PV_RECYCLER_OVERRIDE_TEMPLATE="${KUBE_HOME}/kube-manifests/kubernetes/pv-recycler-template.yaml"
-
-  log-start 'SetPythonVersion'
-  if [[ "$(python -V 2>&1)" =~ "Python 2" ]]; then
-    # found python2, just use that
-    PYTHON="python"
-  elif [[ -f "/usr/bin/python2.7" ]]; then
-    # System python not defaulted to python 2 but using 2.7 during migration
-    PYTHON="/usr/bin/python2.7"
-  else
-    # No python2 either by default, let's see if we can find python3
-    PYTHON="python3"
-    if ! command -v ${PYTHON} >/dev/null 2>&1; then
-      echo "ERROR Python not found. Aborting."
-      exit 2
-    fi
-  fi
-  echo "Version :  $(${PYTHON} -V 2>&1)"
-  log-end 'SetPythonVersion'
 
   log-start 'SourceKubeEnv'
   if [[ ! -e "${KUBE_HOME}/kube-env" ]]; then

--- a/cluster/gce/gci/configure.sh
+++ b/cluster/gce/gci/configure.sh
@@ -87,13 +87,9 @@ function download-kube-env {
       -o "${tmp_kube_env}" \
       http://metadata.google.internal/computeMetadata/v1/instance/attributes/kube-env
     # Convert the yaml format file into a shell-style file.
-    eval "$(${PYTHON} -c '''
+    eval "$(python3 -c '''
 import pipes,sys,yaml
-# check version of python and call methods appropriate for that version
-if sys.version_info[0] < 3:
-    items = yaml.load(sys.stdin).iteritems()
-else:
-    items = yaml.load(sys.stdin, Loader=yaml.BaseLoader).items()
+items = yaml.load(sys.stdin, Loader=yaml.BaseLoader).items()
 for k, v in items:
     print("readonly {var}={value}".format(var=k, value=pipes.quote(str(v))))
 ''' < "${tmp_kube_env}" > "${KUBE_HOME}/kube-env")"
@@ -131,13 +127,9 @@ function download-kube-master-certs {
       -o "${tmp_kube_master_certs}" \
       http://metadata.google.internal/computeMetadata/v1/instance/attributes/kube-master-certs
     # Convert the yaml format file into a shell-style file.
-    eval "$(${PYTHON} -c '''
+    eval "$(python3 -c '''
 import pipes,sys,yaml
-# check version of python and call methods appropriate for that version
-if sys.version_info[0] < 3:
-    items = yaml.load(sys.stdin).iteritems()
-else:
-    items = yaml.load(sys.stdin, Loader=yaml.BaseLoader).items()
+items = yaml.load(sys.stdin, Loader=yaml.BaseLoader).items()
 for k, v in items:
     print("readonly {var}={value}".format(var=k, value=pipes.quote(str(v))))
 ''' < "${tmp_kube_master_certs}" > "${KUBE_HOME}/kube-master-certs")"
@@ -160,7 +152,7 @@ function validate-hash {
 # Get default service account credentials of the VM.
 GCE_METADATA_INTERNAL="http://metadata.google.internal/computeMetadata/v1/instance"
 function get-credentials {
-  curl --fail --retry 5 --retry-delay 3 --retry-connrefused --silent --show-error "${GCE_METADATA_INTERNAL}/service-accounts/default/token" -H "Metadata-Flavor: Google" -s | ${PYTHON} -c \
+  curl --fail --retry 5 --retry-delay 3 --retry-connrefused --silent --show-error "${GCE_METADATA_INTERNAL}/service-accounts/default/token" -H "Metadata-Flavor: Google" -s | python3 -c \
     'import sys; import json; print(json.loads(sys.stdin.read())["access_token"])'
 }
 
@@ -861,25 +853,6 @@ log-wrap 'SetBrokenMotd' set-broken-motd
 
 KUBE_HOME="/home/kubernetes"
 KUBE_BIN="${KUBE_HOME}/bin"
-PYTHON="python"
-
-log-start 'SetPythonVersion'
-if [[ "$(python -V 2>&1)" =~ "Python 2" ]]; then
-  # found python2, just use that
-  PYTHON="python"
-elif [[ -f "/usr/bin/python2.7" ]]; then
-  # System python not defaulted to python 2 but using 2.7 during migration
-  PYTHON="/usr/bin/python2.7"
-else
-  # No python2 either by default, let's see if we can find python3
-  PYTHON="python3"
-  if ! command -v ${PYTHON} >/dev/null 2>&1; then
-    echo "ERROR Python not found. Aborting."
-    exit 2
-  fi
-fi
-echo "Version :  $(${PYTHON} -V 2>&1)"
-log-end 'SetPythonVersion'
 
 # download and source kube-env
 log-wrap 'DownloadKubeEnv' retry-forever 30 download-kube-env


### PR DESCRIPTION
This reverts commit 7038338e0fc5a6b8f8996403730ac9087f595f72.



<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind cleanup
#### What this PR does / why we need it:

Followup to https://github.com/kubernetes/kubernetes/pull/101437 which was reverted in https://github.com/kubernetes/kubernetes/pull/101473 due to failing test (issue https://github.com/kubernetes/kubernetes/issues/101471)

The original PR was reverted due the gpu device plugin test failing due to using a very old image which does not support python3. I updated the image used in https://github.com/kubernetes/kubernetes/issues/101558 to COS-85 (which has full python3 support), so we should be able to make this change again.


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
