### PR TITLE
Cherrypick: Update tests to use agnhost 2.32

### DIFF
--- a/build/dependencies.yaml
+++ b/build/dependencies.yaml
@@ -27,7 +27,7 @@ dependencies:
 
   # then after merge and successful postsubmit image push / promotion, bump this
   - name: "agnhost: dependents"
-    version: "2.31"
+    version: "2.32"
     refPaths:
     - path: test/utils/image/manifest.go
       match: configs\[Agnhost\] = Config{promoterE2eRegistry, "agnhost", "\d+\.\d+"}

--- a/test/e2e/auth/service_accounts.go
+++ b/test/e2e/auth/service_accounts.go
@@ -735,7 +735,6 @@ var _ = SIGDescribe("ServiceAccounts", func() {
 					Image: imageutils.GetE2EImage(imageutils.Agnhost),
 					Args: []string{
 						"test-service-account-issuer-discovery",
-						"--in-cluster-discovery",
 						"--token-path", path.Join(tokenPath, tokenName),
 						"--audience", audience,
 					},

--- a/test/utils/image/manifest.go
+++ b/test/utils/image/manifest.go
@@ -213,7 +213,7 @@ const (
 
 func initImageConfigs() (map[int]Config, map[int]Config) {
 	configs := map[int]Config{}
-	configs[Agnhost] = Config{promoterE2eRegistry, "agnhost", "2.31"}
+	configs[Agnhost] = Config{promoterE2eRegistry, "agnhost", "2.32"}
 	configs[AgnhostPrivate] = Config{PrivateRegistry, "agnhost", "2.6"}
 	configs[AuthenticatedAlpine] = Config{gcAuthenticatedRegistry, "alpine", "3.7"}
 	configs[AuthenticatedWindowsNanoServer] = Config{gcAuthenticatedRegistry, "windows-nanoserver", "v1"}


### PR DESCRIPTION
Updates e2e tests to use agnhost 2.32, which fixes an issue with the
conformance tests for ServiceAccountIssuerDiscovery.

Original fix: https://github.com/kubernetes/kubernetes/pull/101589

Image promotion: https://github.com/kubernetes/k8s.io/pull/1994

#### What type of PR is this?

/kind bug
/kind failing-test

#### What this PR does / why we need it:

Cherry pick #101713 to 1.21.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Resolves an issue with the "ServiceAccountIssuerDiscovery should support OIDC discovery" conformance test failing on clusters which are configured with issuers outside the cluster
```

/assign @liggitt 