### PR TITLE
test/integration/client: add TestExecPluginRotationViaInformer

### DIFF
--- a/test/integration/client/testdata/exec-plugin.sh
+++ b/test/integration/client/testdata/exec-plugin.sh
@@ -18,4 +18,9 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
+if [[ -n "${EXEC_PLUGIN_OUTPUT_FILE-""}" ]]; then
+  cat "$EXEC_PLUGIN_OUTPUT_FILE"
+  exit
+fi
+
 echo "$EXEC_PLUGIN_OUTPUT"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

* This PR adds more integration tests for the client-go credential provider feature.
* We are taking the feature GA, and thus need to implement the test plan from the KEP.
* KEP: https://github.com/kubernetes/enhancements/blob/master/keps/sig-auth/541-external-credential-providers/README.md.

#### Which issue(s) this PR fixes:

* Feature set tracking issue: kubernetes/enhancements#541
* KEP: https://github.com/kubernetes/enhancements/blob/master/keps/sig-auth/541-external-credential-providers/README.md

#### Special notes for your reviewer:

* This integration test is a specific response to https://github.com/kubernetes/kubernetes/pull/99713#discussion_r607290915.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

/cc @enj @liggitt 