### PR TITLE
Promote kube-addon-manager to v9.1.5

### DIFF
--- a/cluster/gce/manifests/kube-addon-manager.yaml
+++ b/cluster/gce/manifests/kube-addon-manager.yaml
@@ -23,7 +23,7 @@ spec:
         - all
     # When updating version also bump it in:
     # - test/kubemark/resources/manifests/kube-addon-manager.yaml
-    image: k8s.gcr.io/addon-manager/kube-addon-manager:v9.1.4
+    image: k8s.gcr.io/addon-manager/kube-addon-manager:v9.1.5
     command:
     - /bin/bash
     - -c

--- a/test/kubemark/resources/manifests/kube-addon-manager.yaml
+++ b/test/kubemark/resources/manifests/kube-addon-manager.yaml
@@ -9,7 +9,7 @@ spec:
   hostNetwork: true
   containers:
   - name: kube-addon-manager
-    image: {{kube_docker_registry}}/addon-manager/kube-addon-manager:v9.1.4
+    image: {{kube_docker_registry}}/addon-manager/kube-addon-manager:v9.1.5
     command:
     - /bin/bash
     - -c


### PR DESCRIPTION
Promotes kube-addon-manager to 9.1.5. This change includes 

- a2157b36b7c4276a1b7b14852e03e9f012dd4dd5 - Replaces extensions/v1beta1 usage with networking.k8s.io/v1
- 530072a38fc2ae0c152da0e48206d7a9dbd3cb19 - a base image bump to resolve security vulnerabilities.

/kind bug
/assign MrHohn

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
