### PR TITLE
remove CSIMigrationvSphereComplete flag

### DIFF
--- a/cmd/kube-controller-manager/app/plugins_providers.go
+++ b/cmd/kube-controller-manager/app/plugins_providers.go
@@ -39,8 +39,7 @@ func appendPluginBasedOnFeatureFlags(plugins []volume.VolumePlugin, inTreePlugin
 	// Skip appending the in-tree plugin to the list of plugins to be probed/initialized
 	// if the CSIMigration feature flag and plugin specific feature flag indicating
 	// CSI migration is complete
-	migrationComplete, err := csimigration.CheckMigrationFeatureFlags(featureGate, pluginInfo.pluginMigrationFeature,
-		pluginInfo.pluginMigrationCompleteFeature, pluginInfo.pluginUnregisterFeature)
+	migrationComplete, err := csimigration.CheckMigrationFeatureFlags(featureGate, pluginInfo.pluginMigrationFeature, pluginInfo.pluginUnregisterFeature)
 	if err != nil {
 		klog.Warningf("Unexpected CSI Migration Feature Flags combination detected: %v. CSI Migration may not take effect", err)
 		// TODO: fail and return here once alpha only tests can set the feature flags for a plugin correctly
@@ -60,8 +59,6 @@ func appendPluginBasedOnFeatureFlags(plugins []volume.VolumePlugin, inTreePlugin
 
 type pluginInfo struct {
 	pluginMigrationFeature featuregate.Feature
-	// deprecated, only to keep here for vSphere
-	pluginMigrationCompleteFeature featuregate.Feature
 	pluginUnregisterFeature        featuregate.Feature
 	pluginProbeFunction            probeFn
 }
@@ -72,7 +69,7 @@ func appendAttachableLegacyProviderVolumes(allPlugins []volume.VolumePlugin, fea
 	pluginMigrationStatus[plugins.GCEPDInTreePluginName] = pluginInfo{pluginMigrationFeature: features.CSIMigrationGCE, pluginUnregisterFeature: features.InTreePluginGCEUnregister, pluginProbeFunction: gcepd.ProbeVolumePlugins}
 	pluginMigrationStatus[plugins.CinderInTreePluginName] = pluginInfo{pluginMigrationFeature: features.CSIMigrationOpenStack, pluginUnregisterFeature: features.InTreePluginOpenStackUnregister, pluginProbeFunction: cinder.ProbeVolumePlugins}
 	pluginMigrationStatus[plugins.AzureDiskInTreePluginName] = pluginInfo{pluginMigrationFeature: features.CSIMigrationAzureDisk, pluginUnregisterFeature: features.InTreePluginAzureDiskUnregister, pluginProbeFunction: azuredd.ProbeVolumePlugins}
-	pluginMigrationStatus[plugins.VSphereInTreePluginName] = pluginInfo{pluginMigrationFeature: features.CSIMigrationvSphere, pluginMigrationCompleteFeature: features.CSIMigrationvSphereComplete, pluginUnregisterFeature: features.InTreePluginvSphereUnregister, pluginProbeFunction: vsphere_volume.ProbeVolumePlugins}
+	pluginMigrationStatus[plugins.VSphereInTreePluginName] = pluginInfo{pluginMigrationFeature: features.CSIMigrationvSphere, pluginUnregisterFeature: features.InTreePluginvSphereUnregister, pluginProbeFunction: vsphere_volume.ProbeVolumePlugins}
 
 	var err error
 	for pluginName, pluginInfo := range pluginMigrationStatus {

--- a/cmd/kubelet/app/plugins_providers.go
+++ b/cmd/kubelet/app/plugins_providers.go
@@ -46,7 +46,7 @@ func appendPluginBasedOnFeatureFlags(plugins []volume.VolumePlugin, inTreePlugin
 	// if the CSIMigration feature flag and plugin specific feature flag indicating
 	// CSI migration is complete
 	migrationComplete, err := csimigration.CheckMigrationFeatureFlags(featureGate, pluginInfo.pluginMigrationFeature,
-		pluginInfo.pluginMigrationCompleteFeature, pluginInfo.pluginUnregisterFeature)
+		pluginInfo.pluginUnregisterFeature)
 	if err != nil {
 		klog.InfoS("Unexpected CSI Migration Feature Flags combination detected, CSI Migration may not take effect", "err", err)
 		// TODO: fail and return here once alpha only tests can set the feature flags for a plugin correctly
@@ -67,8 +67,6 @@ func appendPluginBasedOnFeatureFlags(plugins []volume.VolumePlugin, inTreePlugin
 
 type pluginInfo struct {
 	pluginMigrationFeature featuregate.Feature
-	// deprecated, only to keep here for vSphere
-	pluginMigrationCompleteFeature featuregate.Feature
 	pluginUnregisterFeature        featuregate.Feature
 	pluginProbeFunction            probeFn
 }
@@ -80,7 +78,7 @@ func appendLegacyProviderVolumes(allPlugins []volume.VolumePlugin, featureGate f
 	pluginMigrationStatus[plugins.CinderInTreePluginName] = pluginInfo{pluginMigrationFeature: features.CSIMigrationOpenStack, pluginUnregisterFeature: features.InTreePluginOpenStackUnregister, pluginProbeFunction: cinder.ProbeVolumePlugins}
 	pluginMigrationStatus[plugins.AzureDiskInTreePluginName] = pluginInfo{pluginMigrationFeature: features.CSIMigrationAzureDisk, pluginUnregisterFeature: features.InTreePluginAzureDiskUnregister, pluginProbeFunction: azuredd.ProbeVolumePlugins}
 	pluginMigrationStatus[plugins.AzureFileInTreePluginName] = pluginInfo{pluginMigrationFeature: features.CSIMigrationAzureFile, pluginUnregisterFeature: features.InTreePluginAzureFileUnregister, pluginProbeFunction: azure_file.ProbeVolumePlugins}
-	pluginMigrationStatus[plugins.VSphereInTreePluginName] = pluginInfo{pluginMigrationFeature: features.CSIMigrationvSphere, pluginMigrationCompleteFeature: features.CSIMigrationvSphereComplete, pluginUnregisterFeature: features.InTreePluginvSphereUnregister, pluginProbeFunction: vsphere_volume.ProbeVolumePlugins}
+	pluginMigrationStatus[plugins.VSphereInTreePluginName] = pluginInfo{pluginMigrationFeature: features.CSIMigrationvSphere, pluginUnregisterFeature: features.InTreePluginvSphereUnregister, pluginProbeFunction: vsphere_volume.ProbeVolumePlugins}
 
 	var err error
 	for pluginName, pluginInfo := range pluginMigrationStatus {

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -770,7 +770,6 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
 	CSIMigrationAzureFile:                          {Default: false, PreRelease: featuregate.Beta}, // Off by default (requires Azure File CSI driver)
 	InTreePluginAzureFileUnregister:                {Default: false, PreRelease: featuregate.Alpha},
 	CSIMigrationvSphere:                            {Default: false, PreRelease: featuregate.Beta}, // Off by default (requires vSphere CSI driver)
-	CSIMigrationvSphereComplete:                    {Default: false, PreRelease: featuregate.Beta}, // remove in 1.22
 	InTreePluginvSphereUnregister:                  {Default: false, PreRelease: featuregate.Alpha},
 	CSIMigrationOpenStack:                          {Default: true, PreRelease: featuregate.Beta},
 	InTreePluginOpenStackUnregister:                {Default: false, PreRelease: featuregate.Alpha},

--- a/pkg/volume/csimigration/plugin_manager.go
+++ b/pkg/volume/csimigration/plugin_manager.go
@@ -71,7 +71,7 @@ func (pm PluginManager) IsMigrationCompleteForPlugin(pluginName string) bool {
 	case csilibplugins.CinderInTreePluginName:
 		return pm.featureGate.Enabled(features.InTreePluginOpenStackUnregister)
 	case csilibplugins.VSphereInTreePluginName:
-		return pm.featureGate.Enabled(features.CSIMigrationvSphereComplete) || pm.featureGate.Enabled(features.InTreePluginvSphereUnregister)
+		return pm.featureGate.Enabled(features.InTreePluginvSphereUnregister)
 	default:
 		return false
 	}
@@ -153,19 +153,9 @@ func TranslateInTreeSpecToCSI(spec *volume.Spec, podNamespace string, translator
 // CheckMigrationFeatureFlags checks the configuration of feature flags related
 // to CSI Migration is valid. It will return whether the migration is complete
 // by looking up the pluginMigrationComplete and pluginUnregister flag
-func CheckMigrationFeatureFlags(f featuregate.FeatureGate, pluginMigration,
-	pluginMigrationComplete, pluginUnregister featuregate.Feature) (migrationComplete bool, err error) {
+func CheckMigrationFeatureFlags(f featuregate.FeatureGate, pluginMigration, pluginUnregister featuregate.Feature) (migrationComplete bool, err error) {
 	if f.Enabled(pluginMigration) && !f.Enabled(features.CSIMigration) {
 		return false, fmt.Errorf("enabling %q requires CSIMigration to be enabled", pluginMigration)
-	}
-	// TODO: Remove the following two checks once the CSIMigrationXXComplete flag is removed
-	if pluginMigrationComplete != "" && f.Enabled(pluginMigrationComplete) && !f.Enabled(pluginMigration) {
-		return false, fmt.Errorf("enabling %q requires %q to be enabled", pluginMigrationComplete, pluginMigration)
-	}
-	// This is only needed for vSphere since we will deprecate the CSIMigrationvSphereComplete flag soon
-	if pluginMigrationComplete != "" && f.Enabled(features.CSIMigration) &&
-		f.Enabled(pluginMigration) && f.Enabled(pluginMigrationComplete) {
-		return true, nil
 	}
 	// This is for other in-tree plugin that get migration finished
 	if f.Enabled(pluginMigration) && f.Enabled(pluginUnregister) {

--- a/pkg/volume/csimigration/plugin_manager_test.go
+++ b/pkg/volume/csimigration/plugin_manager_test.go
@@ -146,60 +146,20 @@ func TestCheckMigrationFeatureFlags(t *testing.T) {
 		pluginFeature                featuregate.Feature
 		pluginFeatureEnabled         bool
 		csiMigrationEnabled          bool
-		pluginFeatureComplete        featuregate.Feature
-		pluginFeatureCompleteEnabled bool
 		pluginUnregsiterFeature      featuregate.Feature
 		pluginUnregsiterEnabled      bool
 		expectMigrationComplete      bool
 		expectErr                    bool
 	}{
 		{
-			name:                         "plugin specific feature flag enabled with migration flag disabled",
-			pluginFeature:                features.CSIMigrationvSphere,
-			pluginFeatureEnabled:         true,
-			csiMigrationEnabled:          false,
-			pluginFeatureComplete:        features.CSIMigrationvSphereComplete,
-			pluginFeatureCompleteEnabled: false,
-			pluginUnregsiterFeature:      features.InTreePluginvSphereUnregister,
-			pluginUnregsiterEnabled:      false,
-			expectMigrationComplete:      false,
-			expectErr:                    false,
-		},
-		{
-			name:                         "plugin specific complete flag enabled but plugin specific feature flag disabled",
-			pluginFeature:                features.CSIMigrationvSphere,
-			pluginFeatureEnabled:         false,
-			csiMigrationEnabled:          true,
-			pluginFeatureComplete:        features.CSIMigrationvSphereComplete,
-			pluginFeatureCompleteEnabled: true,
-			pluginUnregsiterFeature:      features.InTreePluginvSphereUnregister,
-			pluginUnregsiterEnabled:      false,
-			expectMigrationComplete:      false,
-			expectErr:                    false,
-		},
-		{
-			name:                         "plugin specific complete feature disabled but plugin specific migration feature and CSI migration flag enabled",
-			pluginFeature:                features.CSIMigrationvSphere,
-			pluginFeatureEnabled:         true,
-			csiMigrationEnabled:          true,
-			pluginFeatureComplete:        features.CSIMigrationvSphereComplete,
-			pluginFeatureCompleteEnabled: false,
-			pluginUnregsiterFeature:      features.InTreePluginvSphereUnregister,
-			pluginUnregsiterEnabled:      false,
-			expectMigrationComplete:      false,
-			expectErr:                    true,
-		},
-		{
-			name:                         "all features enabled",
-			pluginFeature:                features.CSIMigrationvSphere,
-			pluginFeatureEnabled:         true,
-			csiMigrationEnabled:          true,
-			pluginFeatureComplete:        features.CSIMigrationvSphereComplete,
-			pluginFeatureCompleteEnabled: true,
-			pluginUnregsiterFeature:      features.InTreePluginvSphereUnregister,
-			pluginUnregsiterEnabled:      true,
-			expectMigrationComplete:      true,
-			expectErr:                    true,
+			name:                    "no plugin feature complete set",
+			pluginFeature:           features.CSIMigrationvSphere,
+			pluginFeatureEnabled:    true,
+			csiMigrationEnabled:     true,
+			pluginUnregsiterFeature: features.InTreePluginvSphereUnregister,
+			pluginUnregsiterEnabled: true,
+			expectMigrationComplete: true,
+			expectErr:               true,
 		},
 		{
 			name:                    "no plugin feature complete set",
@@ -217,10 +177,8 @@ func TestCheckMigrationFeatureFlags(t *testing.T) {
 			defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.CSIMigration, test.csiMigrationEnabled)()
 			defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, test.pluginFeature, test.pluginFeatureEnabled)()
 			defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, test.pluginUnregsiterFeature, test.pluginUnregsiterEnabled)()
-			if test.pluginFeatureComplete != "" {
-				defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, test.pluginFeatureComplete, test.pluginFeatureCompleteEnabled)()
-			}
-			migrationComplete, err := CheckMigrationFeatureFlags(utilfeature.DefaultFeatureGate, test.pluginFeature, test.pluginFeatureComplete, test.pluginUnregsiterFeature)
+
+			migrationComplete, err := CheckMigrationFeatureFlags(utilfeature.DefaultFeatureGate, test.pluginFeature, test.pluginUnregsiterFeature)
 			if err != nil && test.expectErr == true {
 				t.Errorf("Unexpected error: %v", err)
 			}
@@ -330,6 +288,50 @@ func TestMigrationFeatureFlagStatus(t *testing.T) {
 			pluginFeatureEnabled:          true,
 			csiMigrationEnabled:           true,
 			inTreePluginUnregister:        features.InTreePluginAWSUnregister,
+			inTreePluginUnregisterEnabled: true,
+			csiMigrationResult:            true,
+			csiMigrationCompleteResult:    true,
+		},
+		{
+			name:                          "vsphere-volume migration flag disabled and migration-complete flag disabled with CSI migration flag disabled",
+			pluginName:                    "kubernetes.io/vsphere-volume",
+			pluginFeature:                 features.CSIMigrationvSphere,
+			pluginFeatureEnabled:          false,
+			csiMigrationEnabled:           false,
+			inTreePluginUnregister:        features.InTreePluginvSphereUnregister,
+			inTreePluginUnregisterEnabled: false,
+			csiMigrationResult:            false,
+			csiMigrationCompleteResult:    false,
+		},
+		{
+			name:                          "vsphere-volume migration flag disabled and migration-complete flag disabled with CSI migration flag enabled",
+			pluginName:                    "kubernetes.io/vsphere-volume",
+			pluginFeature:                 features.CSIMigrationvSphere,
+			pluginFeatureEnabled:          false,
+			csiMigrationEnabled:           true,
+			inTreePluginUnregister:        features.InTreePluginvSphereUnregister,
+			inTreePluginUnregisterEnabled: false,
+			csiMigrationResult:            false,
+			csiMigrationCompleteResult:    false,
+		},
+		{
+			name:                          "vsphere-volume migration flag enabled and migration-complete flag disabled with CSI migration flag enabled",
+			pluginName:                    "kubernetes.io/vsphere-volume",
+			pluginFeature:                 features.CSIMigrationvSphere,
+			pluginFeatureEnabled:          true,
+			csiMigrationEnabled:           true,
+			inTreePluginUnregister:        features.InTreePluginvSphereUnregister,
+			inTreePluginUnregisterEnabled: false,
+			csiMigrationResult:            true,
+			csiMigrationCompleteResult:    false,
+		},
+		{
+			name:                          "vsphere-volume migration flag enabled and migration-complete flag enabled with CSI migration flag enabled",
+			pluginName:                    "kubernetes.io/vsphere-volume",
+			pluginFeature:                 features.CSIMigrationvSphere,
+			pluginFeatureEnabled:          true,
+			csiMigrationEnabled:           true,
+			inTreePluginUnregister:        features.InTreePluginvSphereUnregister,
 			inTreePluginUnregisterEnabled: true,
 			csiMigrationResult:            true,
 			csiMigrationCompleteResult:    true,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
This is follow-up PR after https://github.com/kubernetes/kubernetes/pull/98243 to remove deprecated flag`CSIMigrationvSphereComplete`.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #96730

#### Special notes for your reviewer:
Testing is in progress

#### Does this PR introduce a user-facing change?
NONE
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
remove CSIMigrationvSphereComplete flag 
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

/sig storage
/assign @msau42 @Jiawei0227 

