### PR TITLE
Refactor create commands to split flags from options

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create.go
@@ -104,12 +104,6 @@ func (flags *CreateFlags) ToOptions(f cmdutil.Factory, cmd *cobra.Command, args 
 		return nil, err
 	}
 	cmdutil.PrintFlagsWithDryRunStrategy(flags.PrintFlags, dryRunStrategy)
-	dynamicClient, err := f.DynamicClient()
-	if err != nil {
-		return nil, err
-	}
-	dryRunVerifier := resource.NewQueryParamVerifier(dynamicClient, f.OpenAPIGetter(), resource.QueryParamDryRun)
-	fieldValidationVerifier := resource.NewQueryParamVerifier(dynamicClient, f.OpenAPIGetter(), resource.QueryParamFieldValidation)
 
 	validationDirective, err := cmdutil.GetValidationDirective(cmd)
 	if err != nil {
@@ -152,10 +146,7 @@ func (flags *CreateFlags) ToOptions(f cmdutil.Factory, cmd *cobra.Command, args 
 		PrintFlags:  flags.PrintFlags,
 		RecordFlags: flags.RecordFlags,
 
-		DryRunStrategy:          dryRunStrategy,
-		DryRunVerifier:          dryRunVerifier,
-		FieldValidationVerifier: fieldValidationVerifier,
-
+		DryRunStrategy:      dryRunStrategy,
 		ValidationDirective: validationDirective,
 
 		fieldManager:     flags.fieldManager,

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create.go
@@ -25,7 +25,6 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
-	"k8s.io/klog/v2"
 
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -36,6 +35,7 @@ import (
 	"k8s.io/cli-runtime/pkg/printers"
 	"k8s.io/cli-runtime/pkg/resource"
 	"k8s.io/client-go/dynamic"
+	"k8s.io/klog/v2"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 	"k8s.io/kubectl/pkg/cmd/util/editor"
 	"k8s.io/kubectl/pkg/generate"

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_test.go
@@ -20,11 +20,13 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/spf13/cobra"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/cli-runtime/pkg/resource"
 	"k8s.io/client-go/rest/fake"
 	cmdtesting "k8s.io/kubectl/pkg/cmd/testing"
+	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 	"k8s.io/kubectl/pkg/scheme"
 )
 
@@ -35,11 +37,16 @@ func TestExtraArgsFail(t *testing.T) {
 	defer f.Cleanup()
 
 	c := NewCmdCreate(f, genericclioptions.NewTestIOStreamsDiscard())
-	ioStreams, _, _, _ := genericclioptions.NewTestIOStreams()
-	options := NewCreateOptions(ioStreams)
-	if options.Complete(f, c, []string{"rc"}) == nil {
+	if validateCreateArgs(c, []string{"rc"}) == nil {
 		t.Errorf("unexpected non-error")
 	}
+}
+
+func validateCreateArgs(cmd *cobra.Command, args []string) error {
+	if len(args) != 0 {
+		return cmdutil.UsageErrorf(cmd, "Unexpected args: %v", args)
+	}
+	return nil
 }
 
 func TestCreateObject(t *testing.T) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup


#### What this PR does / why we need it:
Refactor commands to split flags from options

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Ref https://github.com/kubernetes/kubectl/issues/1046

#### Special notes for your reviewer:
1) I tried to add the `ResourceBuilder` flag to it but the `builder_flags.go` doesn't have the `Builder().Schema()` . Moreover, the filename flags in `builder_flags.go` clashed with [this Filename Flag](https://github.com/kubernetes/kubernetes/blob/aa450787bff54c96b4588e7ddbfdf9bda89a882a/staging/src/k8s.io/kubectl/pkg/cmd/create/create.go#L59) so I couldn't add it to it.
2) Couldn't remove [`PrintFlags`](https://github.com/kubernetes/kubernetes/blob/aa450787bff54c96b4588e7ddbfdf9bda89a882a/staging/src/k8s.io/kubectl/pkg/cmd/create/create.go#L51) and [`RecordFlags`](https://github.com/kubernetes/kubernetes/blob/aa450787bff54c96b4588e7ddbfdf9bda89a882a/staging/src/k8s.io/kubectl/pkg/cmd/create/create.go#L52) because it will be used [here](https://github.com/kubernetes/kubernetes/blob/aa450787bff54c96b4588e7ddbfdf9bda89a882a/staging/src/k8s.io/kubectl/pkg/cmd/create/create.go#L236) 
3) Removed the `TestExtraArgsFail` because `ToOptions` is combined with `Complete` and `Validate` now, so it will panic

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
