### PR TITLE
Use CSI driver to determine unique name for migrated in-tree plugins

### DIFF
--- a/pkg/controller/volume/attachdetach/attach_detach_controller.go
+++ b/pkg/controller/volume/attachdetach/attach_detach_controller.go
@@ -57,6 +57,7 @@ import (
 	"k8s.io/kubernetes/pkg/features"
 	proxyutil "k8s.io/kubernetes/pkg/proxy/util"
 	"k8s.io/kubernetes/pkg/volume"
+	"k8s.io/kubernetes/pkg/volume/csi"
 	"k8s.io/kubernetes/pkg/volume/csimigration"
 	volumeutil "k8s.io/kubernetes/pkg/volume/util"
 	"k8s.io/kubernetes/pkg/volume/util/operationexecutor"
@@ -724,6 +725,22 @@ func (adc *attachDetachController) processVolumeAttachments() error {
 				nodeName,
 				err)
 			continue
+		}
+		pluginName := plugin.GetPluginName()
+		if adc.csiMigratedPluginManager.IsMigrationEnabledForPlugin(pluginName) {
+			plugin, _ = adc.volumePluginMgr.FindAttachablePluginByName(csi.CSIPluginName)
+			// podNamespace is not needed here for Azurefile as the volumeName generated will be the same with or without podNamespace
+			volumeSpec, err = csimigration.TranslateInTreeSpecToCSI(volumeSpec, "" /* podNamespace */, adc.intreeToCSITranslator)
+			if err != nil {
+				klog.Errorf(
+					"Failed to translate intree volumeSpec to CSI volumeSpec for volume:%q, va.Name:%q, nodeName:%q: %v",
+					*pvName,
+					va.Name,
+					nodeName,
+					pluginName,
+					err)
+				continue
+			}
 		}
 		volumeName, err := volumeutil.GetUniqueVolumeNameFromSpec(plugin, volumeSpec)
 		if err != nil {

--- a/pkg/controller/volume/attachdetach/testing/testvolumespec.go
+++ b/pkg/controller/volume/attachdetach/testing/testvolumespec.go
@@ -158,6 +158,16 @@ func CreateTestClient() *fake.Clientset {
 		}
 		attachVolumeToNode("lostVolumeName", nodeName)
 	}
+	fakeClient.AddReactor("update", "nodes", func(action core.Action) (handled bool, ret runtime.Object, err error) {
+		updateAction := action.(core.UpdateAction)
+		node := updateAction.GetObject().(*v1.Node)
+		for index, n := range nodes.Items {
+			if n.Name == node.Name {
+				nodes.Items[index] = *node
+			}
+		}
+		return true, updateAction.GetObject(), nil
+	})
 	fakeClient.AddReactor("list", "nodes", func(action core.Action) (handled bool, ret runtime.Object, err error) {
 		obj := &v1.NodeList{}
 		obj.Items = append(obj.Items, nodes.Items...)


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
This is a forked PR from https://github.com/kubernetes/kubernetes/pull/101423
Credit to @codablock for reporting and sending the fix. This PR tries to add a unit test for it. It turns out that writing an integrated test using `Test_ADC_VolumeAttachmentRecovery` is non-trivial as the test is using a special plugin called `TestPlugin` which does not exist in csi migration. To enable it for CSI migration requires more code refactors. The unit test added in this PR tries to capture the main logic exist in the fix to verify the functionality.


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fixed false-positive uncertain volume attachments, which led to unexpected detachment of CSI migrated volumes
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

/sig storage
/assign @gnufied 
/cc @msau42 @codablock 