### PR TITLE
cherry pick of #100913: no watch endpointslice in userpace mode

### DIFF
--- a/cmd/kube-proxy/app/server_others.go
+++ b/cmd/kube-proxy/app/server_others.go
@@ -358,6 +358,12 @@ func newProxyServer(
 		}
 	}
 
+	useEndpointSlices := utilfeature.DefaultFeatureGate.Enabled(features.EndpointSliceProxying)
+	if proxyMode == proxyModeUserspace {
+		// userspace mode doesn't support endpointslice.
+		useEndpointSlices = false
+	}
+
 	return &ProxyServer{
 		Client:                 client,
 		EventClient:            eventClient,
@@ -377,7 +383,7 @@ func newProxyServer(
 		OOMScoreAdj:            config.OOMScoreAdj,
 		ConfigSyncPeriod:       config.ConfigSyncPeriod.Duration,
 		HealthzServer:          healthzServer,
-		UseEndpointSlices:      utilfeature.DefaultFeatureGate.Enabled(features.EndpointSliceProxying),
+		UseEndpointSlices:      useEndpointSlices,
 	}, nil
 }
 


### PR DESCRIPTION
/kind bug

Cherry pick of  https://github.com/kubernetes/kubernetes/pull/100913 on release-1.20.

Ref https://github.com/kubernetes/kubernetes/issues/100880#

```release-note
no support endpointslice in linux userpace mode 
```
