### PR TITLE
Avoid overwriting podStatus ContainerStatuses in convertToAPIContainerStatuses - lock implementation

### DIFF
--- a/pkg/kubelet/container/helpers.go
+++ b/pkg/kubelet/container/helpers.go
@@ -236,6 +236,7 @@ func ConvertPodStatusToRunningPod(runtimeName string, podStatus *PodStatus) Pod 
 		Name:      podStatus.Name,
 		Namespace: podStatus.Namespace,
 	}
+	podStatus.ContainerStatusesLock.RLock()
 	for _, containerStatus := range podStatus.ContainerStatuses {
 		if containerStatus.State != ContainerStateRunning {
 			continue
@@ -250,6 +251,7 @@ func ConvertPodStatusToRunningPod(runtimeName string, podStatus *PodStatus) Pod 
 		}
 		runningPod.Containers = append(runningPod.Containers, container)
 	}
+	podStatus.ContainerStatusesLock.RUnlock()
 
 	// Populate sandboxes in kubecontainer.Pod
 	for _, sandbox := range podStatus.SandboxStatuses {

--- a/pkg/kubelet/container/testing/fake_runtime.go
+++ b/pkg/kubelet/container/testing/fake_runtime.go
@@ -285,7 +285,14 @@ func (f *FakeRuntime) GetPodStatus(uid types.UID, name, namespace string) (*kube
 	defer f.Unlock()
 
 	f.CalledFunctions = append(f.CalledFunctions, "GetPodStatus")
-	status := f.PodStatus
+	status := kubecontainer.PodStatus{
+		ID:                f.PodStatus.ID,
+		Name:              f.PodStatus.Name,
+		Namespace:         f.PodStatus.Namespace,
+		IPs:               f.PodStatus.IPs,
+		ContainerStatuses: f.PodStatus.ContainerStatuses,
+		SandboxStatuses:   f.PodStatus.SandboxStatuses,
+	}
 	return &status, f.Err
 }
 

--- a/pkg/kubelet/kuberuntime/kuberuntime_container.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_container.go
@@ -769,6 +769,7 @@ func (m *kubeGenericRuntimeManager) pruneInitContainersBeforeStart(pod *v1.Pod, 
 	}
 	for name := range initContainerNames {
 		count := 0
+		podStatus.ContainerStatusesLock.RLock()
 		for _, status := range podStatus.ContainerStatuses {
 			if status.Name != name ||
 				(status.State != kubecontainer.ContainerStateExited &&
@@ -790,6 +791,7 @@ func (m *kubeGenericRuntimeManager) pruneInitContainersBeforeStart(pod *v1.Pod, 
 				continue
 			}
 		}
+		podStatus.ContainerStatusesLock.RUnlock()
 	}
 }
 
@@ -803,6 +805,7 @@ func (m *kubeGenericRuntimeManager) purgeInitContainers(pod *v1.Pod, podStatus *
 	}
 	for name := range initContainerNames {
 		count := 0
+		podStatus.ContainerStatusesLock.RLock()
 		for _, status := range podStatus.ContainerStatuses {
 			if status.Name != name {
 				continue
@@ -815,6 +818,7 @@ func (m *kubeGenericRuntimeManager) purgeInitContainers(pod *v1.Pod, podStatus *
 				continue
 			}
 		}
+		podStatus.ContainerStatusesLock.RUnlock()
 	}
 }
 

--- a/pkg/kubelet/pleg/generic.go
+++ b/pkg/kubelet/pleg/generic.go
@@ -286,9 +286,11 @@ func (g *GenericPLEG) relist() {
 					// Get updated podStatus
 					status, err := g.cache.Get(pod.ID)
 					if err == nil {
+						status.ContainerStatusesLock.RLock()
 						for _, containerStatus := range status.ContainerStatuses {
 							containerExitCode[containerStatus.ID.ID] = containerStatus.ExitCode
 						}
+						status.ContainerStatusesLock.RUnlock()
 					}
 				}
 				if containerID, ok := events[i].Data.(string); ok {

--- a/pkg/kubelet/pleg/generic_test.go
+++ b/pkg/kubelet/pleg/generic_test.go
@@ -641,7 +641,14 @@ func TestRelistIPChange(t *testing.T) {
 		actualStatus, actualErr = pleg.cache.Get(pod.ID)
 		// Must copy status to compare since its pointer gets passed through all
 		// the way to the event
-		statusCopy := *status
+		statusCopy := kubecontainer.PodStatus{
+			ID:                status.ID,
+			Name:              status.Name,
+			Namespace:         status.Namespace,
+			IPs:               status.IPs,
+			ContainerStatuses: status.ContainerStatuses,
+			SandboxStatuses:   status.SandboxStatuses,
+		}
 		statusCopy.IPs = tc.podIPs
 		assert.Equal(t, &statusCopy, actualStatus, tc.name)
 		assert.Nil(t, actualErr, tc.name)

--- a/pkg/kubelet/pod_container_deletor.go
+++ b/pkg/kubelet/pod_container_deletor.go
@@ -67,6 +67,8 @@ func getContainersToDeleteInPod(filterContainerID string, podStatus *kubecontain
 		if filterContainerId == "" {
 			return nil
 		}
+		podStatus.ContainerStatusesLock.RLock()
+		defer podStatus.ContainerStatusesLock.RUnlock()
 		for _, containerStatus := range podStatus.ContainerStatuses {
 			if containerStatus.ID.ID == filterContainerId {
 				return containerStatus
@@ -82,6 +84,7 @@ func getContainersToDeleteInPod(filterContainerID string, podStatus *kubecontain
 
 	// Find the exited containers whose name matches the name of the container with id being filterContainerId
 	var candidates containerStatusbyCreatedList
+	podStatus.ContainerStatusesLock.RLock()
 	for _, containerStatus := range podStatus.ContainerStatuses {
 		if containerStatus.State != kubecontainer.ContainerStateExited {
 			continue
@@ -90,6 +93,7 @@ func getContainersToDeleteInPod(filterContainerID string, podStatus *kubecontain
 			candidates = append(candidates, containerStatus)
 		}
 	}
+	podStatus.ContainerStatusesLock.RUnlock()
 
 	if len(candidates) <= containersToKeep {
 		return containerStatusbyCreatedList{}

--- a/pkg/kubelet/runonce.go
+++ b/pkg/kubelet/runonce.go
@@ -168,10 +168,12 @@ func (kl *Kubelet) getFailedContainers(pod *v1.Pod) ([]string, error) {
 		return nil, fmt.Errorf("unable to get status for pod %q: %v", format.Pod(pod), err)
 	}
 	var containerNames []string
+	status.ContainerStatusesLock.RLock()
 	for _, cs := range status.ContainerStatuses {
 		if cs.State != kubecontainer.ContainerStateRunning && cs.ExitCode != 0 {
 			containerNames = append(containerNames, cs.Name)
 		}
 	}
+	status.ContainerStatusesLock.RUnlock()
 	return containerNames, nil
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

⚠️  This PR is an alternative implementation of https://github.com/kubernetes/kubernetes/pull/90216 using a lock on `ContainerStatuses` instead of copying the object on sort.

(The section below is copied from the PR above)
There is a race condition between the kubelet SyncLoop when the PLEG issues a ContainerDied event and the pod worker syncPod call.

This race condition is triggered by :

- In the SyncLoop, the call to cleanUpContainersInPod which in turn calls generateAPIPodStatus on a podStatus pointer fetched from the pod cache https://github.com/kubernetes/kubernetes/blob/7d176851f2c433f4301a64dfeb3b2626ca9c2f60/pkg/kubelet/kubelet.go#L2278-L2289
- In the pod workers, the call to syncPod which in turn also calls generateAPIPodStatus on a podStatus pointer fetched from the pod cache https://github.com/kubernetes/kubernetes/blob/7d176851f2c433f4301a64dfeb3b2626ca9c2f60/pkg/kubelet/kubelet.go#L1545-L1546
generateAPIPodStatus would eventually call convertToAPIContainerStatuses that sorts podStatus.ContainerStatuses in place. This is not a thread-safe operation, and when called concurrently, leads to the resulting podStatus.ContainerStatuses missing some entries and having some entries as duplicates.

At this point, the pod cache is containing a podStatus that is missing some containers statuses, thus computePodActions https://github.com/kubernetes/kubernetes/blob/7d176851f2c433f4301a64dfeb3b2626ca9c2f60/pkg/kubelet/kuberuntime/kuberuntime_manager.go#L516 will try creating the missing containers.

However, as those containers may already be running, this leads the pod to be in CreateContainerError that does not recover until either the kubelet is restarted or another mechanism causes a refresh of the runtime state and a Set to the podCache.

#### Which issue(s) this PR fixes:

Fixes #94557

#### Special notes for your reviewer:

As mentioned above, this PR is an alternative implementation of https://github.com/kubernetes/kubernetes/pull/90216 using a lock on `ContainerStatuses` instead of copying the object on sort.

We managed to track down and reproduce the issue as we were seeing CreateContainerError on pods containing multiple containers that were happening after Kubelet restarts. On a test cluster, we deployed the same setup, and forced a kubelet restart at least once every 20min until a CreateContainerError is encountered. All pods would eventually get stuck in CreateContainerError until the kubelet is restarted on the fleet.

We traced this down to duplicate and missing entries in podStatus.ContainerStatuses.

With the proposed patch, we didn't encounter CreateContainerError on restarting the kubelet anymore.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs

```
