### PR TITLE
fix empty imagePullSecret merge error in scheduler

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/util/strategicpatch/patch.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/strategicpatch/patch.go
@@ -1434,6 +1434,10 @@ func mergeSlice(original, patch []interface{}, schema LookupPatchMeta, mergeKey 
 		if mergeKey == "" {
 			return nil, fmt.Errorf("cannot merge lists without merge key for %s", schema.Name())
 		}
+		// if original array is `[{}]`, clear the array to `[]` as it should have a merge key
+		if len(original) == 1 && len(original[0].(map[string]interface{})) == 0 {
+			original = nil
+		}
 
 		original, patch, err = mergeSliceWithSpecialElements(original, patch, mergeKey)
 		if err != nil {

--- a/staging/src/k8s.io/apimachinery/pkg/util/strategicpatch/patch_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/strategicpatch/patch_test.go
@@ -669,6 +669,25 @@ mergingList:
 			ExpectedError: "does not contain declared merge key",
 		},
 	},
+	{
+		Description: "merge a list to an empty map",
+		StrategicMergePatchRawTestCaseData: StrategicMergePatchRawTestCaseData{
+			Original: []byte(`
+mergingList:
+  - {}
+`),
+			TwoWay: []byte(`
+mergingList:
+  - name: 1
+    value: a
+`),
+			Modified: []byte(`
+mergingList:
+  - name: 1
+    value: a
+`),
+		},
+	},
 }
 
 func TestCustomStrategicMergePatch(t *testing.T) {


### PR DESCRIPTION
#### What type of PR is this?
/kind bug
/sig scheduling

#### What this PR does / why we need it:
Fix empty imagePullSecret pod problem and add a UT.

#### Which issue(s) this PR fixes:
Fixes #101697

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
fix scheduler error when handling pod with empty imagePullSecret
```
