### PR TITLE
compare the func with .Pointer() in scheduler registry-test

### DIFF
--- a/pkg/scheduler/framework/runtime/registry_test.go
+++ b/pkg/scheduler/framework/runtime/registry_test.go
@@ -76,7 +76,7 @@ func TestDecodeInto(t *testing.T) {
 func isRegistryEqual(registryX, registryY Registry) bool {
 	for name, pluginFactory := range registryY {
 		if val, ok := registryX[name]; ok {
-			if reflect.ValueOf(pluginFactory) != reflect.ValueOf(val) {
+			if reflect.ValueOf(pluginFactory).Pointer() != reflect.ValueOf(val).Pointer() {
 				// pluginFactory functions are not the same.
 				return false
 			}


### PR DESCRIPTION
#### What type of PR is this?
/kind failing-test
fix a test failure on
> go version devel go1.17-5daefc5363 Thu Apr 22 01:40:02 2021 +0000 linux/ppc64le

#### What this PR does / why we need it:
some references
- https://stackoverflow.com/questions/34901307/how-to-compare-2-functions-in-go/34901626
- https://stackoverflow.com/questions/9643205/how-do-i-compare-two-functions-for-pointer-equality-in-the-latest-go-weekly

#### Which issue(s) this PR fixes:
Fixes #101657

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```