### PR TITLE
Add logic to only call CPUManager Update() if state different than last Update()

### DIFF
--- a/pkg/kubelet/cm/cpumanager/cpu_manager_test.go
+++ b/pkg/kubelet/cm/cpumanager/cpu_manager_test.go
@@ -265,6 +265,7 @@ func TestCPUManagerAdd(t *testing.T) {
 				assignments:   state.ContainerCPUAssignments{},
 				defaultCPUSet: cpuset.NewCPUSet(1, 2, 3, 4),
 			},
+			lastUpdateState: state.NewMemoryState(),
 			containerRuntime: mockRuntimeService{
 				err: testCase.updateErr,
 			},
@@ -488,6 +489,7 @@ func TestCPUManagerAddWithInitContainers(t *testing.T) {
 		mgr := &manager{
 			policy:            policy,
 			state:             mockState,
+			lastUpdateState:   state.NewMemoryState(),
 			containerRuntime:  mockRuntimeService{},
 			containerMap:      containermap.NewContainerMap(),
 			podStatusProvider: mockPodStatusProvider{},
@@ -670,6 +672,7 @@ func TestCPUManagerRemove(t *testing.T) {
 			assignments:   state.ContainerCPUAssignments{},
 			defaultCPUSet: cpuset.NewCPUSet(),
 		},
+		lastUpdateState:   state.NewMemoryState(),
 		containerRuntime:  mockRuntimeService{},
 		containerMap:      containerMap,
 		activePods:        func() []*v1.Pod { return nil },
@@ -936,6 +939,7 @@ func TestReconcileState(t *testing.T) {
 				assignments:   testCase.stAssignments,
 				defaultCPUSet: testCase.stDefaultCPUSet,
 			},
+			lastUpdateState: state.NewMemoryState(),
 			containerRuntime: mockRuntimeService{
 				err: testCase.updateErr,
 			},
@@ -1026,6 +1030,7 @@ func TestCPUManagerAddWithResvList(t *testing.T) {
 				assignments:   state.ContainerCPUAssignments{},
 				defaultCPUSet: cpuset.NewCPUSet(0, 1, 2, 3),
 			},
+			lastUpdateState: state.NewMemoryState(),
 			containerRuntime: mockRuntimeService{
 				err: testCase.updateErr,
 			},


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:
Currently, the CPUManager will call `Update()` into the container runtime  to update its `cset` on *every* container from *every* pod every 10 seconds (or whatever the `reconcilePeriod` is set to, which is 10s by default). This patch updates this logic to only call `Update()` if the container's `cset` has changed since (1) it was first started, or (2) the last time `Update()` was called on it.

This PR also has the side effect of mitigating issues caused by the following since calls to `Update()` trigger all cgroups to be updated (and not just the `cset` cgroup):
https://github.com/opencontainers/runc/issues/2366#issue-609480075

#### Which issue(s) this PR fixes:
Fixes #100906

#### Does this PR introduce a user-facing change?
```release-note
NONE
```