### PR TITLE
Update glbc image to v1.12.0

### DIFF
--- a/cluster/gce/manifests/glbc.manifest
+++ b/cluster/gce/manifests/glbc.manifest
@@ -17,7 +17,7 @@ spec:
   terminationGracePeriodSeconds: 600
   hostNetwork: true
   containers:
-  - image: gcr.io/k8s-ingress-image-push/ingress-gce-glbc-amd64:v1.11.0
+  - image: gcr.io/k8s-ingress-image-push/ingress-gce-glbc-amd64:v1.12.0
     livenessProbe:
       httpGet:
         path: /healthz


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:
This PR updates the GLBC image so that networking.k8s.io/v1beta1 APIs are not longer required. This is necessary for E2E tests to pass once v1beta1 Ingress is removed.

#### Which issue(s) this PR fixes:
fixes #100560
Unblocks #99840

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

/sig-network
/cc @aojea @robscott @prameshj 
/assign @liggitt @freehan 