### PR TITLE
Fix error handling for kubectl create configmap

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_configmap.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_configmap.go
@@ -215,7 +215,7 @@ func (o *ConfigMapOptions) Validate() error {
 func (o *ConfigMapOptions) Run() error {
 	configMap, err := o.createConfigMap()
 	if err != nil {
-		return nil
+		return err
 	}
 	if err := util.CreateOrUpdateAnnotation(o.CreateAnnotation, configMap, scheme.DefaultJSONEncoder()); err != nil {
 		return err


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

`kubectl create cm` prints no error message with zero exit code even with invalid command option. e.g. `--from-file=<non-existing-path>`. This patch fixes it.

#### Which issue(s) this PR fixes:

Fixes https://github.com/kubernetes/kubernetes/issues/101779

#### Does this PR introduce a user-facing change?

```release-note
Fixed a bug that `kubectl create configmap` always returns zero exit code when failed.
```