### PR TITLE
Automated cherry pick of #100326: Fix watchForLockfileContention memory leak

### DIFF
--- a/cmd/kubelet/app/server_linux.go
+++ b/cmd/kubelet/app/server_linux.go
@@ -29,6 +29,7 @@ func watchForLockfileContention(path string, done chan struct{}) error {
 	}
 	if err = watcher.AddWatch(path, inotify.InOpen|inotify.InDeleteSelf); err != nil {
 		klog.ErrorS(err, "Unable to watch lockfile")
+		watcher.Close()
 		return err
 	}
 	go func() {
@@ -39,6 +40,7 @@ func watchForLockfileContention(path string, done chan struct{}) error {
 			klog.ErrorS(err, "inotify watcher error")
 		}
 		close(done)
+		watcher.Close()
 	}()
 	return nil
 }


### PR DESCRIPTION
Cherry pick of #100326 on release-1.21.

#100326: Fix watchForLockfileContention memory leak

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.