### PR TITLE
scheduler_perf: allow users to specify default pod and node specs

### DIFF
--- a/test/integration/scheduler_perf/config/performance-config.yaml
+++ b/test/integration/scheduler_perf/config/performance-config.yaml
@@ -1,13 +1,12 @@
 - name: SchedulingBasic
+  defaultPodTemplatePath: config/pod-default.yaml
   workloadTemplate:
   - opcode: createNodes
     countParam: $initNodes
   - opcode: createPods
     countParam: $initPods
-    podTemplatePath: config/pod-default.yaml
   - opcode: createPods
     countParam: $measurePods
-    podTemplatePath: config/pod-default.yaml
     collectMetrics: true
   workloads:
   - name: 500Nodes
@@ -22,6 +21,7 @@
       measurePods: 1000
 
 - name: SchedulingPodAntiAffinity
+  defaultPodTemplatePath: config/pod-with-pod-anti-affinity.yaml
   workloadTemplate:
   - opcode: createNodes
     countParam: $initNodes
@@ -32,11 +32,9 @@
     count: 2
   - opcode: createPods
     countParam: $initPods
-    podTemplatePath: config/pod-with-pod-anti-affinity.yaml
     namespace: sched-0
   - opcode: createPods
     countParam: $measurePods
-    podTemplatePath: config/pod-with-pod-anti-affinity.yaml
     collectMetrics: true
     namespace: sched-1
   workloads:
@@ -52,15 +50,14 @@
       measurePods: 1000
 
 - name: SchedulingSecrets
+  defaultPodTemplatePath: config/pod-with-secret-volume.yaml
   workloadTemplate:
   - opcode: createNodes
     countParam: $initNodes
   - opcode: createPods
     countParam: $initPods
-    podTemplatePath: config/pod-with-secret-volume.yaml
   - opcode: createPods
     countParam: $measurePods
-    podTemplatePath: config/pod-with-secret-volume.yaml
     collectMetrics: true
   workloads:
   - name: 500Nodes
@@ -169,6 +166,7 @@
       measurePods: 1000
 
 - name: SchedulingPodAffinity
+  defaultPodTemplatePath: config/pod-with-pod-affinity.yaml
   workloadTemplate:
   - opcode: createNodes
     countParam: $initNodes
@@ -181,11 +179,9 @@
     count: 2
   - opcode: createPods
     countParam: $initPods
-    podTemplatePath: config/pod-with-pod-affinity.yaml
     namespace: sched-0
   - opcode: createPods
     countParam: $measurePods
-    podTemplatePath: config/pod-with-pod-affinity.yaml
     namespace: sched-1
     collectMetrics: true
   workloads:
@@ -201,6 +197,7 @@
       measurePods: 1000
 
 - name: SchedulingPreferredPodAffinity
+  defaultPodTemplatePath: config/pod-with-preferred-pod-affinity.yaml
   workloadTemplate:
   - opcode: createNodes
     countParam: $initNodes
@@ -211,11 +208,9 @@
     count: 2
   - opcode: createPods
     countParam: $initPods
-    podTemplatePath: config/pod-with-preferred-pod-affinity.yaml
     namespace: sched-0
   - opcode: createPods
     countParam: $measurePods
-    podTemplatePath: config/pod-with-preferred-pod-affinity.yaml
     namespace: sched-1
     collectMetrics: true
   workloads:
@@ -231,6 +226,7 @@
       measurePods: 1000
 
 - name: SchedulingPreferredPodAntiAffinity
+  defaultPodTemplatePath: config/pod-with-preferred-pod-affinity.yaml
   workloadTemplate:
   - opcode: createNodes
     countParam: $initNodes
@@ -241,11 +237,9 @@
     count: 2
   - opcode: createPods
     countParam: $initPods
-    podTemplatePath: config/pod-with-preferred-pod-anti-affinity.yaml
     namespace: sched-0
   - opcode: createPods
     countParam: $measurePods
-    podTemplatePath: config/pod-with-preferred-pod-anti-affinity.yaml
     namespace: sched-1
     collectMetrics: true
   workloads:
@@ -261,6 +255,7 @@
       measurePods: 1000
 
 - name: SchedulingNodeAffinity
+  defaultPodTemplatePath: config/pod-with-node-affinity.yaml
   workloadTemplate:
   - opcode: createNodes
     countParam: $initNodes
@@ -270,10 +265,8 @@
       labelValues: ["zone1"]
   - opcode: createPods
     countParam: $initPods
-    podTemplatePath: config/pod-with-node-affinity.yaml
   - opcode: createPods
     countParam: $measurePods
-    podTemplatePath: config/pod-with-node-affinity.yaml
     collectMetrics: true
   workloads:
   - name: 500Nodes
@@ -342,6 +335,7 @@
       measurePods: 2000
 
 - name: MixedSchedulingBasePod
+  defaultPodTemplatePath: config/pod-default.yaml
   workloadTemplate:
   - opcode: createNodes
     countParam: $initNodes
@@ -354,7 +348,6 @@
     count: 1
   - opcode: createPods
     countParam: $initPods
-    podTemplatePath: config/pod-default.yaml
     namespace: sched-0
   - opcode: createPods
     countParam: $initPods
@@ -374,7 +367,6 @@
     namespace: sched-0
   - opcode: createPods
     countParam: $measurePods
-    podTemplatePath: config/pod-default.yaml
     collectMetrics: true
   workloads:
   - name: 500Nodes
@@ -498,6 +490,7 @@
       measurePods: 2000
 
 - name: SchedulingRequiredPodAntiAffinityWithNSSelector
+  defaultPodTemplatePath: config/pod-anti-affinity-ns-selector.yaml
   featureGates:
     PodAffinityNamespaceSelector: true
   workloadTemplate:
@@ -519,10 +512,8 @@
     createPodsOp:
       opcode: createPods
       countParam: $initPodsPerNamespace
-      podTemplatePath: config/pod-anti-affinity-ns-selector.yaml
   - opcode: createPods
     countParam: $measurePods
-    podTemplatePath: config/pod-anti-affinity-ns-selector.yaml
     collectMetrics: true
     namespace: measure-ns-0
   workloads:
@@ -534,6 +525,7 @@
       measurePods: 1000
 
 - name: SchedulingPreferredAntiAffinityWithNSSelector
+  defaultPodTemplatePath: config/pod-preferred-anti-affinity-ns-selector.yaml
   featureGates:
     PodAffinityNamespaceSelector: true
   workloadTemplate:
@@ -555,10 +547,8 @@
     createPodsOp:
       opcode: createPods
       countParam: $initPodsPerNamespace
-      podTemplatePath: config/pod-preferred-anti-affinity-ns-selector.yaml
   - opcode: createPods
     countParam: $measurePods
-    podTemplatePath: config/pod-preferred-anti-affinity-ns-selector.yaml
     collectMetrics: true
     namespace: measure-ns-0
   workloads:
@@ -570,6 +560,7 @@
       measurePods: 1000
 
 - name: SchedulingRequiredPodAffinityWithNSSelector
+  defaultPodTemplatePath: config/pod-affinity-ns-selector.yaml
   featureGates:
     PodAffinityNamespaceSelector: true
   workloadTemplate:
@@ -592,10 +583,8 @@
     createPodsOp:
       opcode: createPods
       countParam: $initPodsPerNamespace
-      podTemplatePath: config/pod-affinity-ns-selector.yaml
   - opcode: createPods
     countParam: $measurePods
-    podTemplatePath: config/pod-affinity-ns-selector.yaml
     collectMetrics: true
     namespace: measure-ns-0
   workloads:
@@ -607,6 +596,7 @@
       measurePods: 1000
 
 - name: SchedulingPreferredAffinityWithNSSelector
+  defaultPodTemplatePath: config/pod-preferred-affinity-ns-selector.yaml
   featureGates:
     PodAffinityNamespaceSelector: true
   workloadTemplate:
@@ -628,10 +618,8 @@
     createPodsOp:
       opcode: createPods
       countParam: $initPodsPerNamespace
-      podTemplatePath: config/pod-preferred-affinity-ns-selector.yaml
   - opcode: createPods
     countParam: $measurePods
-    podTemplatePath: config/pod-preferred-affinity-ns-selector.yaml
     collectMetrics: true
     namespace: measure-ns-0
   workloads:

--- a/test/integration/scheduler_perf/scheduler_perf_test.go
+++ b/test/integration/scheduler_perf/scheduler_perf_test.go
@@ -106,9 +106,6 @@ type testCase struct {
 	// Default path to spec file describing the pods to create. Optional.
 	// This path can be overridden in createPodsOp by setting PodTemplatePath .
 	DefaultPodTemplatePath *string
-	// Default path to spec file describing the nodes to create. Optional.
-	// This path can be overridden in createNodesOp by setting NodeTemplatePath .
-	DefaultNodeTemplatePath *string
 }
 
 func (tc *testCase) collectsMetrics() bool {
@@ -261,7 +258,6 @@ type createNodesOp struct {
 	// Template parameter for Count.
 	CountParam string
 	// Path to spec file describing the nodes to create. Optional.
-	// If nil, DefaultNodeTemplatePath will be used.
 	NodeTemplatePath *string
 	// At most one of the following strategies can be defined. Optional, defaults
 	// to TrivialNodePrepareStrategy if unspecified.
@@ -668,9 +664,6 @@ func runWorkload(b *testing.B, tc *testCase, w *workload) []DataItem {
 		}
 		switch concreteOp := realOp.(type) {
 		case *createNodesOp:
-			if concreteOp.NodeTemplatePath == nil {
-				concreteOp.NodeTemplatePath = tc.DefaultNodeTemplatePath
-			}
 			nodePreparer, err := getNodePreparer(fmt.Sprintf("node-%d-", opIndex), concreteOp, client)
 			if err != nil {
 				b.Fatalf("op %d: %v", opIndex, err)


### PR DESCRIPTION
Hi team!

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #93792

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
