### PR TITLE
scheduler_perf: create `deleteNodes` op

### DIFF
--- a/test/integration/scheduler_perf/scheduler_perf_legacy_test.go
+++ b/test/integration/scheduler_perf/scheduler_perf_legacy_test.go
@@ -444,7 +444,7 @@ func benchmarkScheduling(numExistingPods, minPods int,
 	finalFunc, podInformer, clientset, _ := mustSetupScheduler(nil)
 	defer finalFunc()
 
-	nodePreparer := framework.NewIntegrationTestNodePreparer(
+	nodePreparer := framework.NewIntegrationTestNodeManager(
 		clientset,
 		nodeStrategies,
 		"scheduler-perf-")

--- a/test/integration/scheduler_perf/scheduler_perf_test.go
+++ b/test/integration/scheduler_perf/scheduler_perf_test.go
@@ -321,9 +321,10 @@ func (dno *deleteNodesOp) collectsMetrics() bool {
 
 func (dno deleteNodesOp) patchParams(w *workload) (realOp, error) {
 	if dno.CountParam != "" {
-		var ok bool
-		if dno.Count, ok = w.Params[dno.CountParam[1:]]; !ok {
-			return nil, fmt.Errorf("parameter %s is undefined", dno.CountParam)
+		var err error
+		dno.Count, err = w.Params.get(dno.CountParam[1:])
+		if err != nil {
+			return nil, err
 		}
 	}
 	return &dno, (&dno).isValid(false)

--- a/test/utils/runners.go
+++ b/test/utils/runners.go
@@ -945,8 +945,11 @@ type CountToStrategy struct {
 	Strategy PrepareNodeStrategy
 }
 
-type TestNodePreparer interface {
+type TestNodeManager interface {
 	PrepareNodes(nextNodeIndex int) error
+	// DeleteNodes deletes a specified number of Nodes created by this TestNodeManager.
+	// If the specified number is more than the number of existing Nodes, all Nodes will be deleted.
+	DeleteNodes(count int) error
 	CleanupNodes() error
 }
 


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

Hi team. 

#### What type of PR is this?

/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

**1. create `deleteNodes` op**

Now we can delete nodes with `deleteNodes` op like below.
In this example, delete 2 Nodes from the 5 Nodes created with the name of `nodeA`
As you can see, I added a field named `name` to createNodes for use in the `deleteNodes` op.

```
- name: SchedulingBasic
  workloadTemplate:
  - opcode: createNodes
    countParam: $initNodes
    name: nodesA
  - opcode: deleteNodes
    countParam: $deleteNodes
    name: nodesA
  - opcode: createPods
    countParam: $initPods
    podTemplatePath: config/pod-default.yaml
  - opcode: createPods
    countParam: $measurePods
    podTemplatePath: config/pod-default.yaml
    collectMetrics: true
  workloads:
  - name: 500Nodes
    params:
      initNodes: 5
      deleteNodes: 2
      initPods: 5
      measurePods: 10
```

**2. rename `TestNodePreparer` to `TestNodeManager`**

since it now also has the role of deleting nodes.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #94601

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
