### PR TITLE
Fix potential panic for node resource plugin

### DIFF
--- a/pkg/scheduler/framework/plugins/noderesources/least_allocated.go
+++ b/pkg/scheduler/framework/plugins/noderesources/least_allocated.go
@@ -97,6 +97,9 @@ func leastResourceScorer(resToWeightMap resourceToWeightMap) func(resourceToValu
 			nodeScore += resourceScore * weight
 			weightSum += weight
 		}
+		if weightSum == 0 {
+			return 0
+		}
 		return nodeScore / weightSum
 	}
 }

--- a/pkg/scheduler/framework/plugins/noderesources/least_allocated_test.go
+++ b/pkg/scheduler/framework/plugins/noderesources/least_allocated_test.go
@@ -139,6 +139,13 @@ func TestNodeResourcesLeastAllocated(t *testing.T) {
 			name:         "nothing scheduled, resources requested, differently sized machines",
 		},
 		{
+			pod:          &v1.Pod{Spec: cpuAndMemory},
+			nodes:        []*v1.Node{makeNode("machine1", 4000, 10000), makeNode("machine2", 6000, 10000)},
+			args:         config.NodeResourcesLeastAllocatedArgs{Resources: []config.ResourceSpec{}},
+			expectedList: []framework.NodeScore{{Name: "machine1", Score: 0}, {Name: "machine2", Score: 0}},
+			name:         "Resources not set, nothing scheduled, resources requested, differently sized machines",
+		},
+		{
 			// Node1 scores on 0-MaxNodeScore scale
 			// CPU Score: ((4000 - 0) * MaxNodeScore) / 4000 = MaxNodeScore
 			// Memory Score: ((10000 - 0) * MaxNodeScore) / 10000 = MaxNodeScore

--- a/pkg/scheduler/framework/plugins/noderesources/most_allocated.go
+++ b/pkg/scheduler/framework/plugins/noderesources/most_allocated.go
@@ -95,6 +95,9 @@ func mostResourceScorer(resToWeightMap resourceToWeightMap) func(requested, allo
 			nodeScore += resourceScore * weight
 			weightSum += weight
 		}
+		if weightSum == 0 {
+			return 0
+		}
 		return (nodeScore / weightSum)
 	}
 }

--- a/pkg/scheduler/framework/plugins/noderesources/most_allocated_test.go
+++ b/pkg/scheduler/framework/plugins/noderesources/most_allocated_test.go
@@ -154,6 +154,13 @@ func TestNodeResourcesMostAllocated(t *testing.T) {
 			name:         "nothing scheduled, resources requested, differently sized machines",
 		},
 		{
+			pod:          &v1.Pod{Spec: cpuAndMemory},
+			nodes:        []*v1.Node{makeNode("machine1", 4000, 10000), makeNode("machine2", 6000, 10000)},
+			args:         config.NodeResourcesMostAllocatedArgs{Resources: []config.ResourceSpec{}},
+			expectedList: []framework.NodeScore{{Name: "machine1", Score: 0}, {Name: "machine2", Score: 0}},
+			name:         "Resources not set, nothing scheduled, resources requested, differently sized machines",
+		},
+		{
 			// Node1 scores on 0-MaxNodeScore scale
 			// CPU Score: (6000 * MaxNodeScore) / 10000 = 60
 			// Memory Score: (0 * MaxNodeScore) / 20000 = 0


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug

#### What this PR does / why we need it:
Fix potential panic for node resource plugin `NodeResourcesLeastAllocated` and `NodeResourcesMostAllocated`, as `RequestedToCapacityRatio` did here https://github.com/kubernetes/kubernetes/blob/c6e65079c70100edc647e3ccfdfa9ead1fe71818/pkg/scheduler/framework/plugins/noderesources/requested_to_capacity_ratio.go#L132-L131.
Now there is default args.resource for plugin, but other direct caller of `mostResourceScorer` or `leastResourceScorer` may have potential panic like this:
```
panic: runtime error: integer divide by zero
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

/sig scheduling
/triage accepted
/priority important-longterm