### PR TITLE
Automated cherry pick of #101652: Add jitter to lease controller

### DIFF
--- a/staging/src/k8s.io/component-helpers/apimachinery/lease/controller.go
+++ b/staging/src/k8s.io/component-helpers/apimachinery/lease/controller.go
@@ -95,7 +95,7 @@ func (c *controller) Run(stopCh <-chan struct{}) {
 		klog.Infof("lease controller has nil lease client, will not claim or renew leases")
 		return
 	}
-	wait.Until(c.sync, c.renewInterval, stopCh)
+	wait.JitterUntil(c.sync, c.renewInterval, 0.04, true, stopCh)
 }
 
 func (c *controller) sync() {


### PR DESCRIPTION
Cherry pick of #101652 on release-1.21.

#101652: Add jitter to lease controller

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.