### PR TITLE
e2e: test SSH port on NodeSSHHosts

### DIFF
--- a/test/e2e/node/crictl.go
+++ b/test/e2e/node/crictl.go
@@ -44,6 +44,7 @@ var _ = SIGDescribe("crictl", func() {
 		if err != nil {
 			framework.Failf("Error getting node hostnames: %v", err)
 		}
+		e2eskipper.SkipUnlessAtLeast(len(hosts), 1, "Skipping test because found no SSH'able node")
 
 		testCases := []struct {
 			cmd string
@@ -53,22 +54,22 @@ var _ = SIGDescribe("crictl", func() {
 		}
 
 		for _, testCase := range testCases {
-			// Choose an arbitrary node to test.
-			host := hosts[0]
-			ginkgo.By(fmt.Sprintf("SSH'ing to node %q to run %q", host, testCase.cmd))
+			for _, host := range hosts {
+				ginkgo.By(fmt.Sprintf("SSH'ing to node %q to run %q", host, testCase.cmd))
 
-			result, err := e2essh.SSH(testCase.cmd, host, framework.TestContext.Provider)
-			stdout, stderr := strings.TrimSpace(result.Stdout), strings.TrimSpace(result.Stderr)
-			if err != nil {
-				framework.Failf("Ran %q on %q, got error %v", testCase.cmd, host, err)
-			}
-			// Log the stdout/stderr output.
-			// TODO: Verify the output.
-			if len(stdout) > 0 {
-				framework.Logf("Got stdout from %q:\n %s\n", host, strings.TrimSpace(stdout))
-			}
-			if len(stderr) > 0 {
-				framework.Logf("Got stderr from %q:\n %s\n", host, strings.TrimSpace(stderr))
+				result, err := e2essh.SSH(testCase.cmd, host, framework.TestContext.Provider)
+				stdout, stderr := strings.TrimSpace(result.Stdout), strings.TrimSpace(result.Stderr)
+				if err != nil {
+					framework.Failf("Ran %q on %q, got error %v", testCase.cmd, host, err)
+				}
+				// Log the stdout/stderr output.
+				// TODO: Verify the output.
+				if len(stdout) > 0 {
+					framework.Logf("Got stdout from %q:\n %s\n", host, strings.TrimSpace(stdout))
+				}
+				if len(stderr) > 0 {
+					framework.Logf("Got stderr from %q:\n %s\n", host, strings.TrimSpace(stderr))
+				}
 			}
 		}
 	})


### PR DESCRIPTION
#### What type of PR is this?

/kind failing-test

#### What this PR does / why we need it:
Before assuming that a certain host runs an SSH server, we now test its
`SSHPort` for connectivity. This means that the test `should be able to
run crictl on the node` can be now more failure proof by checking only
hosts where SSH actually runs. Beside that, we can also test all hosts
and not only the first one.
#### Which issue(s) this PR fixes:
The test failed on GCE Kubernetes instances where the nodes do not run SSH at all.

#### Special notes for your reviewer:
The `NodeSSHHosts` function is used in multiple places:

##### test/e2e/framework/log_size_monitoring.go
https://github.com/kubernetes/kubernetes/blob/27af788a1765dec279086be18fa9ba4a057ef427/test/e2e/framework/log_size_monitoring.go#L160-L161

##### test/e2e/network/networking.go
https://github.com/kubernetes/kubernetes/blob/27af788a1765dec279086be18fa9ba4a057ef427/test/e2e/network/networking.go#L556-L560

##### test/e2e/node/ssh.go
https://github.com/kubernetes/kubernetes/blob/27af788a1765dec279086be18fa9ba4a057ef427/test/e2e/node/ssh.go#L48-L51

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
None
```
