### PR TITLE
Remove tallclair for gce owners

### DIFF
--- a/cluster/gce/manifests/OWNERS
+++ b/cluster/gce/manifests/OWNERS
@@ -1,10 +1,8 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 reviewers:
-- tallclair
 - MrHohn
 approvers:
-- tallclair
 - MrHohn
 labels:
 - area/provider/gcp


### PR DESCRIPTION
I'm no longer at Google, so I shouldn't be approving GCE manifests.

Google folks - I'd suggest consolidating all the sub-directory OWNERS files into the `cluster/gce` OWNERS.

```release-note
NONE
```