### PR TITLE
Increases the log level showing the static pod update.

### DIFF
--- a/pkg/kubelet/kubelet_getters.go
+++ b/pkg/kubelet/kubelet_getters.go
@@ -173,7 +173,7 @@ func (kl *Kubelet) GetPods() []*v1.Pod {
 	for _, p := range pods {
 		if kubelettypes.IsStaticPod(p) {
 			if status, ok := kl.statusManager.GetPodStatus(p.UID); ok {
-				klog.V(2).InfoS("Pod status updated", "pod", klog.KObj(p), "status", status.Phase)
+				klog.V(3).InfoS("Pod status updated", "pod", klog.KObj(p), "status", status.Phase)
 				p.Status = status
 			}
 		}


### PR DESCRIPTION

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

In some cases, the level log 2 to show static pod updates are to low.
Causing a flood of messages in the logs with irrelevant messages.

#### Which issue(s) this PR fixes:

Fixes #98422 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
NONE


```release-note
Increase the log level for the static pod status update
```