### PR TITLE
e2e: add log for running which cleanup action

### DIFF
--- a/test/e2e/framework/cleanup.go
+++ b/test/e2e/framework/cleanup.go
@@ -17,6 +17,9 @@ limitations under the License.
 package framework
 
 import (
+	e2elog "k8s.io/kubernetes/test/e2e/framework/log"
+	"reflect"
+	"runtime"
 	"sync"
 )
 
@@ -70,6 +73,7 @@ func RunCleanupActions() {
 	}()
 	// Run unlocked.
 	for _, fn := range list {
+		e2elog.Logf("Running Cleanup Action: %v", runtime.FuncForPC(reflect.ValueOf(fn).Pointer()).Name())
 		fn()
 	}
 }


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup
/sig testing

#### What this PR does / why we need it:
> CleanupActions would
> 
> - self describe the current state, i.e. 'deleting all namespaces ' or whatever
> - not silently hang, i.e., be subject to timeouts or periodic updates at least to the logger
> 

This PR only tries to add some log for cleanup actions.
/cc jayunit100
is this enough? 

#### Which issue(s) this PR fixes:
xref #101870

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
