### PR TITLE
Cherry pick of #101595: Update cos-gpu-installer image

### DIFF
--- a/test/e2e/testing-manifests/scheduling/nvidia-driver-installer.yaml
+++ b/test/e2e/testing-manifests/scheduling/nvidia-driver-installer.yaml
@@ -48,7 +48,12 @@ spec:
         hostPath:
           path: /
       initContainers:
-      - image: gcr.io/cos-cloud/cos-gpu-installer:v20200701
+        # The COS GPU installer image version may be dependent on the version of COS being used.
+        # Refer to details about the installer in https://cos.googlesource.com/cos/tools/+/refs/heads/master/src/cmd/cos_gpu_installer/
+        # and the COS release notes (https://cloud.google.com/container-optimized-os/docs/release-notes) to determine version COS GPU installer for a given version of COS.
+
+        # Maps to gcr.io/cos-cloud/cos-gpu-installer:v2.0.3 - suitable for COS M85 as per https://cloud.google.com/container-optimized-os/docs/release-notes#cos-85-13310-1209-3
+      - image: gcr.io/cos-cloud/cos-gpu-installer@sha256:1cf2701dc2c3944a93fd06cb6c9eedfabf323425483ba3af294510621bb37d0e
         name: nvidia-driver-installer
         resources:
           requests:


### PR DESCRIPTION
This installer image should be compatible with COS-M85 images,
specifically `cos-85-13310-1041-9`

#### What type of PR is this?
/kind failing-test

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
per https://github.com/kubernetes/kubernetes/pull/101833#issuecomment-837279295

> This is the old GPU installer (prior to #101595). So I suspect the issue here is that we upgraded the COS image to COS-m85 which requires updated COS GPU installer (#101595), but the update to COS gpu installer only happened in master branch (not on 1.21).

/cc bobbypage

#### Special notes for your reviewer:


#### Does this PR introduce a user-facing change?

```release-note
NONE
```
