### PR TITLE
Additional cases for reconcileState testing

### DIFF
--- a/pkg/kubelet/cm/cpumanager/cpu_manager_test.go
+++ b/pkg/kubelet/cm/cpumanager/cpu_manager_test.go
@@ -705,19 +705,46 @@ func TestCPUManagerRemove(t *testing.T) {
 }
 
 func TestReconcileState(t *testing.T) {
+	testPolicy, _ := NewStaticPolicy(
+		&topology.CPUTopology{
+			NumCPUs:    8,
+			NumSockets: 2,
+			NumCores:   4,
+			CPUDetails: map[int]topology.CPUInfo{
+				0: {CoreID: 0, SocketID: 0},
+				1: {CoreID: 1, SocketID: 0},
+				2: {CoreID: 2, SocketID: 0},
+				3: {CoreID: 3, SocketID: 0},
+				4: {CoreID: 0, SocketID: 1},
+				5: {CoreID: 1, SocketID: 1},
+				6: {CoreID: 2, SocketID: 1},
+				7: {CoreID: 3, SocketID: 1},
+			},
+		},
+		0,
+		cpuset.NewCPUSet(),
+		topologymanager.NewFakeManager(),
+		nil)
+
 	testCases := []struct {
 		description                  string
+		policy                       Policy
 		activePods                   []*v1.Pod
 		pspPS                        v1.PodStatus
 		pspFound                     bool
+		updateErr                    error
 		stAssignments                state.ContainerCPUAssignments
 		stDefaultCPUSet              cpuset.CPUSet
-		updateErr                    error
+		lastUpdateStAssignments      state.ContainerCPUAssignments
+		lastUpdateStDefaultCPUSet    cpuset.CPUSet
+		expectStAssignments          state.ContainerCPUAssignments
+		expectStDefaultCPUSet        cpuset.CPUSet
 		expectSucceededContainerName string
 		expectFailedContainerName    string
 	}{
 		{
-			description: "cpu manager reconclie - no error",
+			description: "cpu manager reconcile - no error",
+			policy:      testPolicy,
 			activePods: []*v1.Pod{
 				{
 					ObjectMeta: metav1.ObjectMeta{
@@ -744,19 +771,28 @@ func TestReconcileState(t *testing.T) {
 					},
 				},
 			},
-			pspFound: true,
+			pspFound:  true,
+			updateErr: nil,
 			stAssignments: state.ContainerCPUAssignments{
 				"fakePodUID": map[string]cpuset.CPUSet{
 					"fakeContainerName": cpuset.NewCPUSet(1, 2),
 				},
 			},
-			stDefaultCPUSet:              cpuset.NewCPUSet(3, 4, 5, 6, 7),
-			updateErr:                    nil,
+			stDefaultCPUSet:           cpuset.NewCPUSet(3, 4, 5, 6, 7),
+			lastUpdateStAssignments:   state.ContainerCPUAssignments{},
+			lastUpdateStDefaultCPUSet: cpuset.NewCPUSet(),
+			expectStAssignments: state.ContainerCPUAssignments{
+				"fakePodUID": map[string]cpuset.CPUSet{
+					"fakeContainerName": cpuset.NewCPUSet(1, 2),
+				},
+			},
+			expectStDefaultCPUSet:        cpuset.NewCPUSet(3, 4, 5, 6, 7),
 			expectSucceededContainerName: "fakeContainerName",
 			expectFailedContainerName:    "",
 		},
 		{
 			description: "cpu manager reconcile init container - no error",
+			policy:      testPolicy,
 			activePods: []*v1.Pod{
 				{
 					ObjectMeta: metav1.ObjectMeta{
@@ -783,19 +819,28 @@ func TestReconcileState(t *testing.T) {
 					},
 				},
 			},
-			pspFound: true,
+			pspFound:  true,
+			updateErr: nil,
 			stAssignments: state.ContainerCPUAssignments{
 				"fakePodUID": map[string]cpuset.CPUSet{
 					"fakeContainerName": cpuset.NewCPUSet(1, 2),
 				},
 			},
-			stDefaultCPUSet:              cpuset.NewCPUSet(3, 4, 5, 6, 7),
-			updateErr:                    nil,
+			stDefaultCPUSet:           cpuset.NewCPUSet(3, 4, 5, 6, 7),
+			lastUpdateStAssignments:   state.ContainerCPUAssignments{},
+			lastUpdateStDefaultCPUSet: cpuset.NewCPUSet(),
+			expectStAssignments: state.ContainerCPUAssignments{
+				"fakePodUID": map[string]cpuset.CPUSet{
+					"fakeContainerName": cpuset.NewCPUSet(1, 2),
+				},
+			},
+			expectStDefaultCPUSet:        cpuset.NewCPUSet(3, 4, 5, 6, 7),
 			expectSucceededContainerName: "fakeContainerName",
 			expectFailedContainerName:    "",
 		},
 		{
 			description: "cpu manager reconcile - pod status not found",
+			policy:      testPolicy,
 			activePods: []*v1.Pod{
 				{
 					ObjectMeta: metav1.ObjectMeta{
@@ -813,14 +858,19 @@ func TestReconcileState(t *testing.T) {
 			},
 			pspPS:                        v1.PodStatus{},
 			pspFound:                     false,
+			updateErr:                    nil,
 			stAssignments:                state.ContainerCPUAssignments{},
 			stDefaultCPUSet:              cpuset.NewCPUSet(),
-			updateErr:                    nil,
+			lastUpdateStAssignments:      state.ContainerCPUAssignments{},
+			lastUpdateStDefaultCPUSet:    cpuset.NewCPUSet(),
+			expectStAssignments:          state.ContainerCPUAssignments{},
+			expectStDefaultCPUSet:        cpuset.NewCPUSet(),
 			expectSucceededContainerName: "",
 			expectFailedContainerName:    "",
 		},
 		{
 			description: "cpu manager reconcile - container state not found",
+			policy:      testPolicy,
 			activePods: []*v1.Pod{
 				{
 					ObjectMeta: metav1.ObjectMeta{
@@ -845,14 +895,19 @@ func TestReconcileState(t *testing.T) {
 				},
 			},
 			pspFound:                     true,
+			updateErr:                    nil,
 			stAssignments:                state.ContainerCPUAssignments{},
 			stDefaultCPUSet:              cpuset.NewCPUSet(),
-			updateErr:                    nil,
+			lastUpdateStAssignments:      state.ContainerCPUAssignments{},
+			lastUpdateStDefaultCPUSet:    cpuset.NewCPUSet(),
+			expectStAssignments:          state.ContainerCPUAssignments{},
+			expectStDefaultCPUSet:        cpuset.NewCPUSet(),
 			expectSucceededContainerName: "",
 			expectFailedContainerName:    "fakeContainerName",
 		},
 		{
 			description: "cpu manager reconclie - cpuset is empty",
+			policy:      testPolicy,
 			activePods: []*v1.Pod{
 				{
 					ObjectMeta: metav1.ObjectMeta{
@@ -879,19 +934,28 @@ func TestReconcileState(t *testing.T) {
 					},
 				},
 			},
-			pspFound: true,
+			pspFound:  true,
+			updateErr: nil,
 			stAssignments: state.ContainerCPUAssignments{
 				"fakePodUID": map[string]cpuset.CPUSet{
 					"fakeContainerName": cpuset.NewCPUSet(),
 				},
 			},
-			stDefaultCPUSet:              cpuset.NewCPUSet(1, 2, 3, 4, 5, 6, 7),
-			updateErr:                    nil,
+			stDefaultCPUSet:           cpuset.NewCPUSet(1, 2, 3, 4, 5, 6, 7),
+			lastUpdateStAssignments:   state.ContainerCPUAssignments{},
+			lastUpdateStDefaultCPUSet: cpuset.NewCPUSet(),
+			expectStAssignments: state.ContainerCPUAssignments{
+				"fakePodUID": map[string]cpuset.CPUSet{
+					"fakeContainerName": cpuset.NewCPUSet(),
+				},
+			},
+			expectStDefaultCPUSet:        cpuset.NewCPUSet(1, 2, 3, 4, 5, 6, 7),
 			expectSucceededContainerName: "",
 			expectFailedContainerName:    "fakeContainerName",
 		},
 		{
 			description: "cpu manager reconclie - container update error",
+			policy:      testPolicy,
 			activePods: []*v1.Pod{
 				{
 					ObjectMeta: metav1.ObjectMeta{
@@ -918,24 +982,185 @@ func TestReconcileState(t *testing.T) {
 					},
 				},
 			},
-			pspFound: true,
+			pspFound:  true,
+			updateErr: fmt.Errorf("fake container update error"),
 			stAssignments: state.ContainerCPUAssignments{
 				"fakePodUID": map[string]cpuset.CPUSet{
 					"fakeContainerName": cpuset.NewCPUSet(1, 2),
 				},
 			},
-			stDefaultCPUSet:              cpuset.NewCPUSet(3, 4, 5, 6, 7),
-			updateErr:                    fmt.Errorf("fake container update error"),
+			stDefaultCPUSet:           cpuset.NewCPUSet(3, 4, 5, 6, 7),
+			lastUpdateStAssignments:   state.ContainerCPUAssignments{},
+			lastUpdateStDefaultCPUSet: cpuset.NewCPUSet(),
+			expectStAssignments: state.ContainerCPUAssignments{
+				"fakePodUID": map[string]cpuset.CPUSet{
+					"fakeContainerName": cpuset.NewCPUSet(1, 2),
+				},
+			},
+			expectStDefaultCPUSet:        cpuset.NewCPUSet(3, 4, 5, 6, 7),
 			expectSucceededContainerName: "",
 			expectFailedContainerName:    "fakeContainerName",
+		},
+		{
+			description: "cpu manager reconcile - state has inactive container",
+			policy:      testPolicy,
+			activePods: []*v1.Pod{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "fakePodName",
+						UID:  "fakePodUID",
+					},
+					Spec: v1.PodSpec{
+						Containers: []v1.Container{
+							{
+								Name: "fakeContainerName",
+							},
+						},
+					},
+				},
+			},
+			pspPS: v1.PodStatus{
+				ContainerStatuses: []v1.ContainerStatus{
+					{
+						Name:        "fakeContainerName",
+						ContainerID: "docker://fakeContainerID",
+						State: v1.ContainerState{
+							Running: &v1.ContainerStateRunning{},
+						},
+					},
+				},
+			},
+			pspFound:  true,
+			updateErr: nil,
+			stAssignments: state.ContainerCPUAssignments{
+				"fakePodUID": map[string]cpuset.CPUSet{
+					"fakeContainerName": cpuset.NewCPUSet(1, 2),
+				},
+				"secondfakePodUID": map[string]cpuset.CPUSet{
+					"secondfakeContainerName": cpuset.NewCPUSet(3, 4),
+				},
+			},
+			stDefaultCPUSet:           cpuset.NewCPUSet(5, 6, 7),
+			lastUpdateStAssignments:   state.ContainerCPUAssignments{},
+			lastUpdateStDefaultCPUSet: cpuset.NewCPUSet(),
+			expectStAssignments: state.ContainerCPUAssignments{
+				"fakePodUID": map[string]cpuset.CPUSet{
+					"fakeContainerName": cpuset.NewCPUSet(1, 2),
+				},
+			},
+			expectStDefaultCPUSet:        cpuset.NewCPUSet(3, 4, 5, 6, 7),
+			expectSucceededContainerName: "fakeContainerName",
+			expectFailedContainerName:    "",
+		},
+		{
+			description: "cpu manager reconcile - last update state is current",
+			policy:      testPolicy,
+			activePods: []*v1.Pod{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "fakePodName",
+						UID:  "fakePodUID",
+					},
+					Spec: v1.PodSpec{
+						Containers: []v1.Container{
+							{
+								Name: "fakeContainerName",
+							},
+						},
+					},
+				},
+			},
+			pspPS: v1.PodStatus{
+				ContainerStatuses: []v1.ContainerStatus{
+					{
+						Name:        "fakeContainerName",
+						ContainerID: "docker://fakeContainerID",
+						State: v1.ContainerState{
+							Running: &v1.ContainerStateRunning{},
+						},
+					},
+				},
+			},
+			pspFound:  true,
+			updateErr: nil,
+			stAssignments: state.ContainerCPUAssignments{
+				"fakePodUID": map[string]cpuset.CPUSet{
+					"fakeContainerName": cpuset.NewCPUSet(1, 2),
+				},
+			},
+			stDefaultCPUSet: cpuset.NewCPUSet(5, 6, 7),
+			lastUpdateStAssignments: state.ContainerCPUAssignments{
+				"fakePodUID": map[string]cpuset.CPUSet{
+					"fakeContainerName": cpuset.NewCPUSet(1, 2),
+				},
+			},
+			lastUpdateStDefaultCPUSet: cpuset.NewCPUSet(5, 6, 7),
+			expectStAssignments: state.ContainerCPUAssignments{
+				"fakePodUID": map[string]cpuset.CPUSet{
+					"fakeContainerName": cpuset.NewCPUSet(1, 2),
+				},
+			},
+			expectStDefaultCPUSet:        cpuset.NewCPUSet(5, 6, 7),
+			expectSucceededContainerName: "fakeContainerName",
+			expectFailedContainerName:    "",
+		},
+		{
+			description: "cpu manager reconcile - last update state is not current",
+			policy:      testPolicy,
+			activePods: []*v1.Pod{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "fakePodName",
+						UID:  "fakePodUID",
+					},
+					Spec: v1.PodSpec{
+						Containers: []v1.Container{
+							{
+								Name: "fakeContainerName",
+							},
+						},
+					},
+				},
+			},
+			pspPS: v1.PodStatus{
+				ContainerStatuses: []v1.ContainerStatus{
+					{
+						Name:        "fakeContainerName",
+						ContainerID: "docker://fakeContainerID",
+						State: v1.ContainerState{
+							Running: &v1.ContainerStateRunning{},
+						},
+					},
+				},
+			},
+			pspFound:  true,
+			updateErr: nil,
+			stAssignments: state.ContainerCPUAssignments{
+				"fakePodUID": map[string]cpuset.CPUSet{
+					"fakeContainerName": cpuset.NewCPUSet(1, 2),
+				},
+			},
+			stDefaultCPUSet: cpuset.NewCPUSet(3, 4, 5, 6, 7),
+			lastUpdateStAssignments: state.ContainerCPUAssignments{
+				"fakePodUID": map[string]cpuset.CPUSet{
+					"fakeContainerName": cpuset.NewCPUSet(3, 4),
+				},
+			},
+			lastUpdateStDefaultCPUSet: cpuset.NewCPUSet(1, 2, 5, 6, 7),
+			expectStAssignments: state.ContainerCPUAssignments{
+				"fakePodUID": map[string]cpuset.CPUSet{
+					"fakeContainerName": cpuset.NewCPUSet(1, 2),
+				},
+			},
+			expectStDefaultCPUSet:        cpuset.NewCPUSet(3, 4, 5, 6, 7),
+			expectSucceededContainerName: "fakeContainerName",
+			expectFailedContainerName:    "",
 		},
 	}
 
 	for _, testCase := range testCases {
 		mgr := &manager{
-			policy: &mockPolicy{
-				err: nil,
-			},
+			policy: testCase.policy,
 			state: &mockState{
 				assignments:   testCase.stAssignments,
 				defaultCPUSet: testCase.stDefaultCPUSet,
@@ -955,6 +1180,18 @@ func TestReconcileState(t *testing.T) {
 		}
 		mgr.sourcesReady = &sourcesReadyStub{}
 		success, failure := mgr.reconcileState()
+
+		if !reflect.DeepEqual(testCase.expectStAssignments, mgr.state.GetCPUAssignments()) {
+			t.Errorf("%v", testCase.description)
+			t.Errorf("Expected state container cpu assignments: %v, actual: %v", testCase.expectStAssignments, mgr.state.GetCPUAssignments())
+
+		}
+
+		if !reflect.DeepEqual(testCase.expectStDefaultCPUSet, mgr.state.GetDefaultCPUSet()) {
+			t.Errorf("%v", testCase.description)
+			t.Errorf("Expected state default cpuset: %v, actual: %v", testCase.expectStDefaultCPUSet, mgr.state.GetDefaultCPUSet())
+
+		}
 
 		if testCase.expectSucceededContainerName != "" {
 			// Search succeeded reconciled containers for the supplied name.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Additional test cases to exercise new logic in `reconcileState` introduced by #101771.

Previously, test cases were given an empty `lastUpdateState` so existing test cases were utilized and passed. This PR adds two new cases with different `lastUpdateState` data - one requires update, the other does not.
 
One case also added to test `policyRemoveContainerByRef` which was previously untested.

Checks also added to test itself to compare actual `state` vs expected `state`.

Existing test cases are unchanged.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
