### PR TITLE
kubectl create job override cmd with one container

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_job_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_job_test.go
@@ -42,11 +42,6 @@ func TestCreateJobValidation(t *testing.T) {
 			from:     "cronjob/xyz",
 			expected: "--image or --from must be specified",
 		},
-		"from and command specified": {
-			from:     "cronjob/xyz",
-			command:  []string{"test", "command"},
-			expected: "cannot specify --from and command",
-		},
 	}
 
 	for name, tc := range tests {
@@ -58,6 +53,9 @@ func TestCreateJobValidation(t *testing.T) {
 			}
 
 			err := o.Validate()
+			if err == nil && len(tc.expected) != 0 {
+				t.Errorf("expected:\n%v\ngot:\n nil", tc.expected)
+			}
 			if err != nil && !strings.Contains(err.Error(), tc.expected) {
 				t.Errorf("unexpected error: %v", err)
 			}


### PR DESCRIPTION
If we are creating a job using --from and the job template has a single
container, allow the user to override that command.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature


#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Can now use kubectl create job --from=some-cronjob -- cmd --with-args
```

