### PR TITLE
storage e2e: auto detect sector size

### DIFF
--- a/test/e2e/storage/utils/utils.go
+++ b/test/e2e/storage/utils/utils.go
@@ -24,6 +24,7 @@ import (
 	"math"
 	"math/rand"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 
@@ -569,6 +570,16 @@ func CheckWriteToPath(f *framework.Framework, pod *v1.Pod, volMode v1.Persistent
 
 	e2evolume.VerifyExecInPodSucceed(f, pod, fmt.Sprintf("echo %s | base64 -d | sha256sum", encoded))
 	e2evolume.VerifyExecInPodSucceed(f, pod, fmt.Sprintf("echo %s | base64 -d | dd of=%s %s bs=%d count=1", encoded, pathForVolMode, oflag, len))
+}
+
+// GetSectorSize returns the sector size of the device.
+func GetSectorSize(f *framework.Framework, pod *v1.Pod, device string) int {
+	stdout, _, err := e2evolume.PodExec(f, pod, fmt.Sprintf("blockdev --getss %s", device))
+	framework.ExpectNoError(err, "Failed to get sector size of %s", device)
+	ss, err := strconv.Atoi(stdout)
+	framework.ExpectNoError(err, "Sector size returned by blockdev command isn't integer value.")
+
+	return ss
 }
 
 // findMountPoints returns all mount points on given node under specified directory.


### PR DESCRIPTION
#### What type of PR is this?
/kind bug
/kind failing-test

#### What this PR does / why we need it:
Multi-volume test with block volume mode fails for a backend other than 512KB sector disk, for direct-I/O needs an access with the block size that is aligned to the sector size.  This PR add a feature to detect sector size for the test and use the block size detected.

#### Which issue(s) this PR fixes:
Fixes #101873

#### Special notes for your reviewer:
/sig storage
/cc @Jiawei0227 @msau42 @nixpanic @jsafrane 

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs

```
