### PR TITLE
client-go/workqueue: Drain work queue on shutdown

### DIFF
--- a/pkg/controller/garbagecollector/garbagecollector_test.go
+++ b/pkg/controller/garbagecollector/garbagecollector_test.go
@@ -2767,6 +2767,9 @@ func (t *trackingWorkqueue) Len() int {
 func (t *trackingWorkqueue) ShutDown() {
 	t.limiter.ShutDown()
 }
+func (t *trackingWorkqueue) ShutDownWithDrain() {
+	t.limiter.ShutDownWithDrain()
+}
 func (t *trackingWorkqueue) ShuttingDown() bool {
 	return t.limiter.ShuttingDown()
 }

--- a/staging/src/k8s.io/client-go/util/workqueue/queue.go
+++ b/staging/src/k8s.io/client-go/util/workqueue/queue.go
@@ -29,6 +29,7 @@ type Interface interface {
 	Get() (item interface{}, shutdown bool)
 	Done(item interface{})
 	ShutDown()
+	ShutDownWithDrain()
 	ShuttingDown() bool
 }
 
@@ -86,6 +87,7 @@ type Type struct {
 	cond *sync.Cond
 
 	shuttingDown bool
+	drain        bool
 
 	metrics queueMetrics
 
@@ -108,6 +110,10 @@ func (s set) insert(item t) {
 
 func (s set) delete(item t) {
 	delete(s, item)
+}
+
+func (s set) len() int {
+	return len(s)
 }
 
 // Add marks item as needing processing.
@@ -178,13 +184,71 @@ func (q *Type) Done(item interface{}) {
 	if q.dirty.has(item) {
 		q.queue = append(q.queue, item)
 		q.cond.Signal()
+	} else if q.processing.len() == 0 {
+		q.cond.Signal()
 	}
 }
 
-// ShutDown will cause q to ignore all new items added to it. As soon as the
-// worker goroutines have drained the existing items in the queue, they will be
-// instructed to exit.
+// ShutDown will cause q to ignore all new items added to it and
+// immediately instruct the worker goroutines to exit.
 func (q *Type) ShutDown() {
+	q.setDrain(false)
+	q.shutdown()
+}
+
+// ShutDownWithDrain will cause q to ignore all new items added to it. As soon
+// as the worker goroutines have "drained", i.e: finished processing and called
+// Done on all existing items in the queue; they will be instructed to exit and
+// ShutDownWithDrain will return. Hence: a strict requirement for using this is;
+// your workers must ensure that Done is called on all items in the queue once
+// the shut down has been initiated, if that is not the case: this will block
+// indefinitely. It is, however, safe to call ShutDown after having called
+// ShutDownWithDrain, as to force the queue shut down to terminate immediately
+// without waiting for the drainage.
+func (q *Type) ShutDownWithDrain() {
+	q.setDrain(true)
+	q.shutdown()
+	for q.isProcessing() && q.shouldDrain() {
+		q.waitForProcessing()
+	}
+}
+
+// isProcessing indicates if there are still items on the work queue being
+// processed. It's used to drain the work queue on an eventual shutdown.
+func (q *Type) isProcessing() bool {
+	q.cond.L.Lock()
+	defer q.cond.L.Unlock()
+	return q.processing.len() != 0
+}
+
+// waitForProcessing waits for the worker goroutines to finish processing items
+// and call Done on them.
+func (q *Type) waitForProcessing() {
+	q.cond.L.Lock()
+	defer q.cond.L.Unlock()
+	// Ensure that we do not wait on a queue which is already empty, as that
+	// could result in waiting for Done to be called on items in an empty queue
+	// which has already been shut down, which will result in waiting
+	// indefinitely.
+	if q.processing.len() == 0 {
+		return
+	}
+	q.cond.Wait()
+}
+
+func (q *Type) setDrain(shouldDrain bool) {
+	q.cond.L.Lock()
+	defer q.cond.L.Unlock()
+	q.drain = shouldDrain
+}
+
+func (q *Type) shouldDrain() bool {
+	q.cond.L.Lock()
+	defer q.cond.L.Unlock()
+	return q.drain
+}
+
+func (q *Type) shutdown() {
 	q.cond.L.Lock()
 	defer q.cond.L.Unlock()
 	q.shuttingDown = true

--- a/staging/src/k8s.io/client-go/util/workqueue/queue_test.go
+++ b/staging/src/k8s.io/client-go/util/workqueue/queue_test.go
@@ -25,93 +25,127 @@ import (
 )
 
 func TestBasic(t *testing.T) {
-	// If something is seriously wrong this test will never complete.
-	q := workqueue.New()
-
-	// Start producers
-	const producers = 50
-	producerWG := sync.WaitGroup{}
-	producerWG.Add(producers)
-	for i := 0; i < producers; i++ {
-		go func(i int) {
-			defer producerWG.Done()
-			for j := 0; j < 50; j++ {
-				q.Add(i)
-				time.Sleep(time.Millisecond)
-			}
-		}(i)
+	tests := []struct {
+		queue         *workqueue.Type
+		queueShutDown func(workqueue.Interface)
+	}{
+		{
+			queue:         workqueue.New(),
+			queueShutDown: workqueue.Interface.ShutDown,
+		},
+		{
+			queue:         workqueue.New(),
+			queueShutDown: workqueue.Interface.ShutDownWithDrain,
+		},
 	}
+	for _, test := range tests {
+		// If something is seriously wrong this test will never complete.
 
-	// Start consumers
-	const consumers = 10
-	consumerWG := sync.WaitGroup{}
-	consumerWG.Add(consumers)
-	for i := 0; i < consumers; i++ {
-		go func(i int) {
-			defer consumerWG.Done()
-			for {
-				item, quit := q.Get()
-				if item == "added after shutdown!" {
-					t.Errorf("Got an item added after shutdown.")
+		// Start producers
+		const producers = 50
+		producerWG := sync.WaitGroup{}
+		producerWG.Add(producers)
+		for i := 0; i < producers; i++ {
+			go func(i int) {
+				defer producerWG.Done()
+				for j := 0; j < 50; j++ {
+					test.queue.Add(i)
+					time.Sleep(time.Millisecond)
 				}
-				if quit {
-					return
+			}(i)
+		}
+
+		// Start consumers
+		const consumers = 10
+		consumerWG := sync.WaitGroup{}
+		consumerWG.Add(consumers)
+		for i := 0; i < consumers; i++ {
+			go func(i int) {
+				defer consumerWG.Done()
+				for {
+					item, quit := test.queue.Get()
+					if item == "added after shutdown!" {
+						t.Errorf("Got an item added after shutdown.")
+					}
+					if quit {
+						return
+					}
+					t.Logf("Worker %v: begin processing %v", i, item)
+					time.Sleep(3 * time.Millisecond)
+					t.Logf("Worker %v: done processing %v", i, item)
+					test.queue.Done(item)
 				}
-				t.Logf("Worker %v: begin processing %v", i, item)
-				time.Sleep(3 * time.Millisecond)
-				t.Logf("Worker %v: done processing %v", i, item)
-				q.Done(item)
-			}
-		}(i)
+			}(i)
+		}
+
+		producerWG.Wait()
+		test.queueShutDown(test.queue)
+		test.queue.Add("added after shutdown!")
+		consumerWG.Wait()
+		if test.queue.Len() != 0 {
+			t.Errorf("Expected the queue to be empty, had: %v items", test.queue.Len())
+		}
 	}
-
-	producerWG.Wait()
-	q.ShutDown()
-	q.Add("added after shutdown!")
-	consumerWG.Wait()
 }
 
 func TestAddWhileProcessing(t *testing.T) {
-	q := workqueue.New()
-
-	// Start producers
-	const producers = 50
-	producerWG := sync.WaitGroup{}
-	producerWG.Add(producers)
-	for i := 0; i < producers; i++ {
-		go func(i int) {
-			defer producerWG.Done()
-			q.Add(i)
-		}(i)
+	tests := []struct {
+		queue         *workqueue.Type
+		queueShutDown func(workqueue.Interface)
+	}{
+		{
+			queue:         workqueue.New(),
+			queueShutDown: workqueue.Interface.ShutDown,
+		},
+		{
+			queue:         workqueue.New(),
+			queueShutDown: workqueue.Interface.ShutDownWithDrain,
+		},
 	}
+	for _, test := range tests {
 
-	// Start consumers
-	const consumers = 10
-	consumerWG := sync.WaitGroup{}
-	consumerWG.Add(consumers)
-	for i := 0; i < consumers; i++ {
-		go func(i int) {
-			defer consumerWG.Done()
-			// Every worker will re-add every item up to two times.
-			// This tests the dirty-while-processing case.
-			counters := map[interface{}]int{}
-			for {
-				item, quit := q.Get()
-				if quit {
-					return
+		// Start producers
+		const producers = 50
+		producerWG := sync.WaitGroup{}
+		producerWG.Add(producers)
+		for i := 0; i < producers; i++ {
+			go func(i int) {
+				defer producerWG.Done()
+				test.queue.Add(i)
+			}(i)
+		}
+
+		// Start consumers
+		const consumers = 10
+		consumerWG := sync.WaitGroup{}
+		consumerWG.Add(consumers)
+		for i := 0; i < consumers; i++ {
+			go func(i int) {
+				defer consumerWG.Done()
+				// Every worker will re-add every item up to two times.
+				// This tests the dirty-while-processing case.
+				counters := map[interface{}]int{}
+				for {
+					item, quit := test.queue.Get()
+					if quit {
+						return
+					}
+					counters[item]++
+					if counters[item] < 2 {
+						test.queue.Add(item)
+					}
+					test.queue.Done(item)
 				}
-				counters[item]++
-				if counters[item] < 2 {
-					q.Add(item)
-				}
-				q.Done(item)
-			}
-		}(i)
+			}(i)
+		}
+
+		producerWG.Wait()
+		test.queueShutDown(test.queue)
+		consumerWG.Wait()
+		if test.queue.Len() != 0 {
+			t.Errorf("Expected the queue to be empty, had: %v items", test.queue.Len())
+		}
 	}
-
-	producerWG.Wait()
-	q.ShutDown()
-	consumerWG.Wait()
 }
 
 func TestLen(t *testing.T) {
@@ -158,4 +192,132 @@ func TestReinsert(t *testing.T) {
 	if a := q.Len(); a != 0 {
 		t.Errorf("Expected queue to be empty. Has %v items", a)
 	}
+}
+
+func TestQueueDrainageUsingShutDownWithDrain(t *testing.T) {
+
+	q := workqueue.New()
+
+	q.Add("foo")
+	q.Add("bar")
+
+	firstItem, _ := q.Get()
+	secondItem, _ := q.Get()
+
+	finishedWG := sync.WaitGroup{}
+	finishedWG.Add(1)
+	go func() {
+		defer finishedWG.Done()
+		q.ShutDownWithDrain()
+	}()
+
+	// This is done as to simulate a sequence of events where ShutDownWithDrain
+	// is called before we start marking all items as done - thus simulating a
+	// drain where we wait for all items to finish processing.
+	shuttingDown := false
+	for !shuttingDown {
+		_, shuttingDown = q.Get()
+	}
+
+	// Mark the first two items as done, as to finish up
+	q.Done(firstItem)
+	q.Done(secondItem)
+
+	finishedWG.Wait()
+}
+
+func TestNoQueueDrainageUsingShutDown(t *testing.T) {
+
+	q := workqueue.New()
+
+	q.Add("foo")
+	q.Add("bar")
+
+	q.Get()
+	q.Get()
+
+	finishedWG := sync.WaitGroup{}
+	finishedWG.Add(1)
+	go func() {
+		defer finishedWG.Done()
+		// Invoke ShutDown: suspending the execution immediately.
+		q.ShutDown()
+	}()
+
+	// We can now do this and not have the test timeout because we didn't call
+	// Done on the first two items before arriving here.
+	finishedWG.Wait()
+}
+
+func TestForceQueueShutdownUsingShutDown(t *testing.T) {
+
+	q := workqueue.New()
+
+	q.Add("foo")
+	q.Add("bar")
+
+	q.Get()
+	q.Get()
+
+	finishedWG := sync.WaitGroup{}
+	finishedWG.Add(1)
+	go func() {
+		defer finishedWG.Done()
+		q.ShutDownWithDrain()
+	}()
+
+	// This is done as to simulate a sequence of events where ShutDownWithDrain
+	// is called before ShutDown
+	shuttingDown := false
+	for !shuttingDown {
+		_, shuttingDown = q.Get()
+	}
+
+	// Use ShutDown to force the queue to shut down (simulating a caller
+	// which can invoke this function on a second SIGTERM/SIGINT)
+	q.ShutDown()
+
+	// We can now do this and not have the test timeout because we didn't call
+	// done on any of the items before arriving here.
+	finishedWG.Wait()
+}
+
+func TestQueueDrainageUsingShutDownWithDrainWithDirtyItem(t *testing.T) {
+	q := workqueue.New()
+
+	q.Add("foo")
+	gotten, _ := q.Get()
+	q.Add("foo")
+
+	finishedWG := sync.WaitGroup{}
+	finishedWG.Add(1)
+	go func() {
+		defer finishedWG.Done()
+		q.ShutDownWithDrain()
+	}()
+
+	// Ensure that ShutDownWithDrain has started and is blocked.
+	shuttingDown := false
+	for !shuttingDown {
+		_, shuttingDown = q.Get()
+	}
+
+	// Finish "working".
+	q.Done(gotten)
+
+	// `shuttingDown` becomes false because Done caused an item to go back into
+	// the queue.
+	again, shuttingDown := q.Get()
+	if shuttingDown {
+		t.Fatalf("should not have been done")
+	}
+	q.Done(again)
+
+	// Now we are really done.
+	_, shuttingDown = q.Get()
+	if !shuttingDown {
+		t.Fatalf("should have been done")
+	}
+
+	finishedWG.Wait()
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind api-change

#### What this PR does / why we need it:

This PR implements a drained shutdown of the workqueue, in line with what the doc bloc mention for `Shutdown` in both `delaying_queue.go` and `queue.go`. This drained shutdown was not the case today (i.e: the doc bloc were wrong). The underlying functional reason for this PR is that it would be better if controllers finished executing their `syncHandler` before shutting down completely, some controllers might depend (or are at least better off) being able to terminate that sync term, processing the result and updating whatever data store they depend on, before terminating completely.

This PR assumes that whatever is put on the queue will also terminate at one point (I am not sure if this is a valid assumption), i.e: that no `syncHandler` will indefinitely execute. It thus does not implement a timeout when verifying if the queue is still processing. 

Moreover, this introduces an API change to the client-go's workqueue library. I am thus not sure if this requires additional work besides this PR?

Assigning to the people whom - it seems - have most frequently come in contact with the workqueue. 

/assign @deads2k @lavalamp 

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Added a `Processing` condition for the workqueue API
Changed `Shutdown` for the workqueue API to wait until the work queue finishes processing all in-flight items.  
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
