### PR TITLE
Increase TerminationGracePeriodSeconds to 1 second

### DIFF
--- a/test/e2e/apps/deployment.go
+++ b/test/e2e/apps/deployment.go
@@ -177,7 +177,7 @@ var _ = SIGDescribe("Deployment", func() {
 		the Deployment.
 	*/
 	framework.ConformanceIt("should run the lifecycle of a Deployment", func() {
-		zero := int64(0)
+		one := int64(1)
 		deploymentResource := schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"}
 		testNamespaceName := f.Namespace.Name
 		testDeploymentName := "test-deployment"
@@ -215,7 +215,7 @@ var _ = SIGDescribe("Deployment", func() {
 						Labels: testDeploymentLabelSelectors.MatchLabels,
 					},
 					Spec: v1.PodSpec{
-						TerminationGracePeriodSeconds: &zero,
+						TerminationGracePeriodSeconds: &one,
 						Containers: []v1.Container{{
 							Name:  testDeploymentName,
 							Image: testDeploymentInitialImage,
@@ -272,7 +272,7 @@ var _ = SIGDescribe("Deployment", func() {
 				"replicas": testDeploymentMinimumReplicas,
 				"template": map[string]interface{}{
 					"spec": map[string]interface{}{
-						"TerminationGracePeriodSeconds": &zero,
+						"TerminationGracePeriodSeconds": &one,
 						"containers": [1]map[string]interface{}{{
 							"name":  testDeploymentName,
 							"image": testDeploymentPatchImage,
@@ -458,7 +458,7 @@ var _ = SIGDescribe("Deployment", func() {
 		framework.ExpectNoError(err, "failed to see replicas of %v in namespace %v scale to requested amount of %v", testDeployment.Name, testNamespaceName, testDeploymentDefaultReplicas)
 
 		ginkgo.By("deleting the Deployment")
-		err = f.ClientSet.AppsV1().Deployments(testNamespaceName).DeleteCollection(context.TODO(), metav1.DeleteOptions{GracePeriodSeconds: &zero}, metav1.ListOptions{LabelSelector: testDeploymentLabelsFlat})
+		err = f.ClientSet.AppsV1().Deployments(testNamespaceName).DeleteCollection(context.TODO(), metav1.DeleteOptions{GracePeriodSeconds: &one}, metav1.ListOptions{LabelSelector: testDeploymentLabelsFlat})
 		framework.ExpectNoError(err, "failed to delete Deployment via collection")
 
 		ctx, cancel = context.WithTimeout(context.Background(), 1*time.Minute)

--- a/test/e2e/common/node/pods.go
+++ b/test/e2e/common/node/pods.go
@@ -845,7 +845,7 @@ var _ = SIGDescribe("Pods", func() {
 	framework.ConformanceIt("should delete a collection of pods", func() {
 		podTestNames := []string{"test-pod-1", "test-pod-2", "test-pod-3"}
 
-		zero := int64(0)
+		one := int64(1)
 
 		ginkgo.By("Create set of pods")
 		// create a set of pods in test namespace
@@ -857,7 +857,7 @@ var _ = SIGDescribe("Pods", func() {
 						"type": "Testing"},
 				},
 				Spec: v1.PodSpec{
-					TerminationGracePeriodSeconds: &zero,
+					TerminationGracePeriodSeconds: &one,
 					Containers: []v1.Container{{
 						Image: imageutils.GetE2EImage(imageutils.Agnhost),
 						Name:  "token-test",
@@ -874,7 +874,7 @@ var _ = SIGDescribe("Pods", func() {
 		framework.ExpectNoError(err, "3 pods not found")
 
 		// delete Collection of pods with a label in the current namespace
-		err = f.ClientSet.CoreV1().Pods(f.Namespace.Name).DeleteCollection(context.TODO(), metav1.DeleteOptions{GracePeriodSeconds: &zero}, metav1.ListOptions{
+		err = f.ClientSet.CoreV1().Pods(f.Namespace.Name).DeleteCollection(context.TODO(), metav1.DeleteOptions{GracePeriodSeconds: &one}, metav1.ListOptions{
 			LabelSelector: "type=Testing"})
 		framework.ExpectNoError(err, "failed to delete collection of pods")
 
@@ -899,7 +899,7 @@ var _ = SIGDescribe("Pods", func() {
 		testPodImage2 := imageutils.GetE2EImage(imageutils.Httpd)
 		testPodLabels := map[string]string{"test-pod-static": "true"}
 		testPodLabelsFlat := "test-pod-static=true"
-		zero := int64(0)
+		one := int64(1)
 
 		w := &cache.ListWatch{
 			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
@@ -916,7 +916,7 @@ var _ = SIGDescribe("Pods", func() {
 				Labels: testPodLabels,
 			},
 			Spec: v1.PodSpec{
-				TerminationGracePeriodSeconds: &zero,
+				TerminationGracePeriodSeconds: &one,
 				Containers: []v1.Container{
 					{
 						Name:  testPodName,
@@ -956,7 +956,7 @@ var _ = SIGDescribe("Pods", func() {
 				Labels: map[string]string{"test-pod": "patched"},
 			},
 			Spec: v1.PodSpec{
-				TerminationGracePeriodSeconds: &zero,
+				TerminationGracePeriodSeconds: &one,
 				Containers: []v1.Container{{
 					Name:  testPodName,
 					Image: testPodImage2,
@@ -1023,7 +1023,7 @@ var _ = SIGDescribe("Pods", func() {
 		framework.ExpectEqual(podStatusFieldPatchCount, podStatusFieldPatchCountTotal, "failed to update PodStatus - field patch count doesn't match the total")
 
 		ginkgo.By("deleting the Pod via a Collection with a LabelSelector")
-		err = f.ClientSet.CoreV1().Pods(testNamespaceName).DeleteCollection(context.TODO(), metav1.DeleteOptions{GracePeriodSeconds: &zero}, metav1.ListOptions{LabelSelector: testPodLabelsFlat})
+		err = f.ClientSet.CoreV1().Pods(testNamespaceName).DeleteCollection(context.TODO(), metav1.DeleteOptions{GracePeriodSeconds: &one}, metav1.ListOptions{LabelSelector: testPodLabelsFlat})
 		framework.ExpectNoError(err, "failed to delete Pod by collection")
 
 		ginkgo.By("watching for the Pod to be deleted")


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Using `GracePeriodSeconds: 0` is abnormal behavior based on the feedback from @smarterclayton  and should be using `GracePeriodSeconds: 1` in conformance tests.

#### Which issue(s) this PR fixes:

Fixes #101930

#### Special notes for your reviewer:

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
NONE
```
