### PR TITLE
kube-proxy: Fix EndpointSliceCache::getEndpointsMap for different endpoints with same IP

### DIFF
--- a/pkg/proxy/endpointslicecache_test.go
+++ b/pkg/proxy/endpointslicecache_test.go
@@ -183,6 +183,23 @@ func TestEndpointsMapFromESC(t *testing.T) {
 			},
 			expectedMap: map[ServicePortName][]*BaseEndpointInfo{},
 		},
+		// Make sure that different endpoints with duplicate IPs are returned correctly.
+		"Different endpoints with duplicate IPs should not be filtered": {
+			namespacedName: types.NamespacedName{Name: "svc1", Namespace: "ns1"},
+			hostname:       "host1",
+			endpointSlices: []*discovery.EndpointSlice{
+				generateEndpointSliceWithOffset("svc1", "ns1", 1, 1, 2, 999, 999, []string{"host1", "host2"}, []*int32{utilpointer.Int32Ptr(80)}),
+				generateEndpointSliceWithOffset("svc1", "ns1", 2, 1, 2, 999, 999, []string{"host1", "host2"}, []*int32{utilpointer.Int32Ptr(8080)}),
+			},
+			expectedMap: map[ServicePortName][]*BaseEndpointInfo{
+				makeServicePortName("ns1", "svc1", "port-0", v1.ProtocolTCP): {
+					&BaseEndpointInfo{Endpoint: "10.0.1.1:80", IsLocal: false, Ready: true, Serving: true, Terminating: false},
+					&BaseEndpointInfo{Endpoint: "10.0.1.1:8080", IsLocal: false, Ready: true, Serving: true, Terminating: false},
+					&BaseEndpointInfo{Endpoint: "10.0.1.2:80", IsLocal: true, Ready: true, Serving: true, Terminating: false},
+					&BaseEndpointInfo{Endpoint: "10.0.1.2:8080", IsLocal: true, Ready: true, Serving: true, Terminating: false},
+				},
+			},
+		},
 	}
 
 	for name, tc := range testCases {
@@ -215,7 +232,7 @@ func TestEndpointInfoByServicePort(t *testing.T) {
 			},
 			expectedMap: spToEndpointMap{
 				makeServicePortName("ns1", "svc1", "port-0", v1.ProtocolTCP): {
-					"10.0.1.1": &BaseEndpointInfo{
+					"10.0.1.1:80": &BaseEndpointInfo{
 						Endpoint:    "10.0.1.1:80",
 						IsLocal:     false,
 						Topology:    map[string]string{"kubernetes.io/hostname": "host2"},
@@ -223,7 +240,7 @@ func TestEndpointInfoByServicePort(t *testing.T) {
 						Serving:     true,
 						Terminating: false,
 					},
-					"10.0.1.2": &BaseEndpointInfo{
+					"10.0.1.2:80": &BaseEndpointInfo{
 						Endpoint:    "10.0.1.2:80",
 						IsLocal:     true,
 						Topology:    map[string]string{"kubernetes.io/hostname": "host1"},
@@ -231,10 +248,54 @@ func TestEndpointInfoByServicePort(t *testing.T) {
 						Serving:     true,
 						Terminating: false,
 					},
-					"10.0.1.3": &BaseEndpointInfo{
+					"10.0.1.3:80": &BaseEndpointInfo{
 						Endpoint:    "10.0.1.3:80",
 						IsLocal:     false,
 						Topology:    map[string]string{"kubernetes.io/hostname": "host2"},
+						Ready:       true,
+						Serving:     true,
+						Terminating: false,
+					},
+				},
+			},
+		},
+		"4 different slices with duplicate IPs": {
+			namespacedName: types.NamespacedName{Name: "svc1", Namespace: "ns1"},
+			hostname:       "host1",
+			endpointSlices: []*discovery.EndpointSlice{
+				generateEndpointSliceWithOffset("svc1", "ns1", 1, 1, 2, 999, 999, []string{"host1", "host2"}, []*int32{utilpointer.Int32Ptr(80)}),
+				generateEndpointSliceWithOffset("svc1", "ns1", 2, 1, 2, 999, 999, []string{"host1", "host2"}, []*int32{utilpointer.Int32Ptr(8080)}),
+			},
+			expectedMap: spToEndpointMap{
+				makeServicePortName("ns1", "svc1", "port-0", v1.ProtocolTCP): {
+					"10.0.1.1:80": &BaseEndpointInfo{
+						Endpoint:    "10.0.1.1:80",
+						IsLocal:     false,
+						Topology:    map[string]string{"kubernetes.io/hostname": "host2"},
+						Ready:       true,
+						Serving:     true,
+						Terminating: false,
+					},
+					"10.0.1.2:80": &BaseEndpointInfo{
+						Endpoint:    "10.0.1.2:80",
+						IsLocal:     true,
+						Topology:    map[string]string{"kubernetes.io/hostname": "host1"},
+						Ready:       true,
+						Serving:     true,
+						Terminating: false,
+					},
+					"10.0.1.1:8080": &BaseEndpointInfo{
+						Endpoint:    "10.0.1.1:8080",
+						IsLocal:     false,
+						Topology:    map[string]string{"kubernetes.io/hostname": "host2"},
+						Ready:       true,
+						Serving:     true,
+						Terminating: false,
+					},
+					"10.0.1.2:8080": &BaseEndpointInfo{
+						Endpoint:    "10.0.1.2:8080",
+						IsLocal:     true,
+						Topology:    map[string]string{"kubernetes.io/hostname": "host1"},
 						Ready:       true,
 						Serving:     true,
 						Terminating: false,


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind bug

#### What this PR does / why we need it:

While using Kubernetes in our tests, I've found that a Service which has two unique endpoints with the same IP isn't been synced properly.

```
Svc1     -> Endpoint 10.0.1.1:8080 (hostnetwork)
         -> Endpoint 10.0.1.1:8081 (hostnetwork)
```

In the example above, only one of the endpoint with same IP is synced.

The root cause is found in EndpointSliceCache::getEndpointsMap which incorrectly deduplicates endpoints by IP. This PR fixes the issue by using Endpoint::String() in the format of "IP:port" instead of IP to build the map.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
None
```