### PR TITLE
refactor(kubeadm): remove alpha command

### DIFF
--- a/cmd/kubeadm/app/cmd/alpha/alpha.go
+++ b/cmd/kubeadm/app/cmd/alpha/alpha.go
@@ -29,19 +29,5 @@ func NewCmdAlpha(in io.Reader, out io.Writer) *cobra.Command {
 		Short: "Kubeadm experimental sub-commands",
 	}
 
-	kubeconfigCmd := NewCmdKubeConfigUtility(out)
-	deprecateCommand(`please use the same command under "kubeadm kubeconfig"`, kubeconfigCmd)
-	cmd.AddCommand(kubeconfigCmd)
-
 	return cmd
-}
-
-func deprecateCommand(msg string, cmds ...*cobra.Command) {
-	for _, cmd := range cmds {
-		cmd.Deprecated = msg
-		childCmds := cmd.Commands()
-		if len(childCmds) > 0 {
-			deprecateCommand(msg, childCmds...)
-		}
-	}
 }

--- a/cmd/kubeadm/app/cmd/cmd.go
+++ b/cmd/kubeadm/app/cmd/cmd.go
@@ -93,9 +93,7 @@ func NewKubeadmCommand(in io.Reader, out, err io.Writer) *cobra.Command {
 	cmds.AddCommand(upgrade.NewCmdUpgrade(out))
 	cmds.AddCommand(alpha.NewCmdAlpha(in, out))
 	options.AddKubeadmOtherFlags(cmds.PersistentFlags(), &rootfsPath)
-	// TODO: remove "kubeconfig" from "alpha"
-	// https://github.com/kubernetes/kubeadm/issues/2292
-	cmds.AddCommand(alpha.NewCmdKubeConfigUtility(out))
+	cmds.AddCommand(newCmdKubeConfigUtility(out))
 
 	return cmds
 }

--- a/cmd/kubeadm/app/cmd/kubeconfig.go
+++ b/cmd/kubeadm/app/cmd/kubeconfig.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package alpha
+package cmd
 
 import (
 	"io"
@@ -34,20 +34,20 @@ import (
 var (
 	kubeconfigLongDesc = cmdutil.LongDesc(`
 	Kubeconfig file utilities.
-	` + cmdutil.AlphaDisclaimer)
+	`)
 
 	userKubeconfigLongDesc = cmdutil.LongDesc(`
 	Output a kubeconfig file for an additional user.
-	` + cmdutil.AlphaDisclaimer)
+	`)
 
 	userKubeconfigExample = cmdutil.Examples(`
 	# Output a kubeconfig file for an additional user named foo using a kubeadm config file bar
-	kubeadm alpha kubeconfig user --client-name=foo --config=bar
+	kubeadm kubeconfig user --client-name=foo --config=bar
 	`)
 )
 
-// NewCmdKubeConfigUtility returns main command for kubeconfig phase
-func NewCmdKubeConfigUtility(out io.Writer) *cobra.Command {
+// newCmdKubeConfigUtility returns main command for kubeconfig phase
+func newCmdKubeConfigUtility(out io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "kubeconfig",
 		Short: "Kubeconfig file utilities",

--- a/cmd/kubeadm/app/cmd/kubeconfig_test.go
+++ b/cmd/kubeadm/app/cmd/kubeconfig_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package alpha
+package cmd
 
 import (
 	"bytes"


### PR DESCRIPTION
Signed-off-by: Jian Zeng <zengjian.zj@bytedance.com>


#### What type of PR is this?

/kind cleanup
/kind deprecation

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes/kubeadm/issues/2292

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
kubeadm: remove the deprecated command "kubeadm alpha kubeconfig". Please use "kubeadm kubeconfig" instead.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
