### PR TITLE
Automated cherry pick of #101857: fixed wrong warning in kube-proxy regarding topology aware

### DIFF
--- a/pkg/proxy/topology.go
+++ b/pkg/proxy/topology.go
@@ -81,12 +81,12 @@ func filterEndpointsWithHints(endpoints []Endpoint, hintsAnnotation string, node
 		}
 	}
 
-	if len(filteredEndpoints) > 0 {
+	if len(filteredEndpoints) == 0 {
 		klog.Warningf("Skipping topology aware endpoint filtering since no hints were provided for zone %s", zone)
-		return filteredEndpoints
+		return endpoints
 	}
 
-	return endpoints
+	return filteredEndpoints
 }
 
 // deprecatedTopologyFilter returns the appropriate endpoints based on the


### PR DESCRIPTION
Cherry pick of #101857 on release-1.21.

#101857: fixed wrong warning in kube-proxy regarding topology aware

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.