### PR TITLE
Fix bug about "kubectl version" that --short not work when set --output option

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/generated/openapi/zz_generated.openapi.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/generated/openapi/zz_generated.openapi.go
@@ -103,6 +103,7 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 		"k8s.io/apimachinery/pkg/runtime.TypeMeta":                       schema_k8sio_apimachinery_pkg_runtime_TypeMeta(ref),
 		"k8s.io/apimachinery/pkg/runtime.Unknown":                        schema_k8sio_apimachinery_pkg_runtime_Unknown(ref),
 		"k8s.io/apimachinery/pkg/version.Info":                           schema_k8sio_apimachinery_pkg_version_Info(ref),
+		"k8s.io/apimachinery/pkg/version.ShortInfo":                      schema_k8sio_apimachinery_pkg_version_ShortInfo(ref),
 	}
 }
 
@@ -3442,6 +3443,27 @@ func schema_k8sio_apimachinery_pkg_version_Info(ref common.ReferenceCallback) co
 					},
 				},
 				Required: []string{"major", "minor", "gitVersion", "gitCommit", "gitTreeState", "buildDate", "goVersion", "compiler", "platform"},
+			},
+		},
+	}
+}
+
+func schema_k8sio_apimachinery_pkg_version_ShortInfo(ref common.ReferenceCallback) common.OpenAPIDefinition {
+	return common.OpenAPIDefinition{
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Description: "ShortInfo just contains gitVersion information.",
+				Type:        []string{"object"},
+				Properties: map[string]spec.Schema{
+					"gitVersion": {
+						SchemaProps: spec.SchemaProps{
+							Default: "",
+							Type:    []string{"string"},
+							Format:  "",
+						},
+					},
+				},
+				Required: []string{"gitVersion"},
 			},
 		},
 	}

--- a/staging/src/k8s.io/apimachinery/pkg/version/types.go
+++ b/staging/src/k8s.io/apimachinery/pkg/version/types.go
@@ -35,3 +35,13 @@ type Info struct {
 func (info Info) String() string {
 	return info.GitVersion
 }
+
+// ShortInfo just contains gitVersion information.
+type ShortInfo struct {
+	GitVersion string `json:"gitVersion"`
+}
+
+// String returns info as a human-friendly version string.
+func (si ShortInfo) String() string {
+	return si.GitVersion
+}

--- a/staging/src/k8s.io/kubectl/pkg/cmd/version/version.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/version/version.go
@@ -36,8 +36,8 @@ import (
 
 // Version is a struct for version information
 type Version struct {
-	ClientVersion *apimachineryversion.Info `json:"clientVersion,omitempty" yaml:"clientVersion,omitempty"`
-	ServerVersion *apimachineryversion.Info `json:"serverVersion,omitempty" yaml:"serverVersion,omitempty"`
+	ClientVersion interface{} `json:"clientVersion,omitempty" yaml:"clientVersion,omitempty"`
+	ServerVersion interface{} `json:"serverVersion,omitempty" yaml:"serverVersion,omitempty"`
 }
 
 var (
@@ -127,18 +127,20 @@ func (o *Options) Run() error {
 		versionInfo.ServerVersion = serverVersion
 	}
 
+	if o.Short {
+		shortClientVersion := &apimachineryversion.ShortInfo{GitVersion: clientVersion.GitVersion}
+		versionInfo.ClientVersion = shortClientVersion
+		if serverVersion != nil {
+			shortServerVersion := &apimachineryversion.ShortInfo{GitVersion: serverVersion.GitVersion}
+			versionInfo.ServerVersion = shortServerVersion
+		}
+	}
+
 	switch o.Output {
 	case "":
-		if o.Short {
-			fmt.Fprintf(o.Out, "Client Version: %s\n", clientVersion.GitVersion)
-			if serverVersion != nil {
-				fmt.Fprintf(o.Out, "Server Version: %s\n", serverVersion.GitVersion)
-			}
-		} else {
-			fmt.Fprintf(o.Out, "Client Version: %s\n", fmt.Sprintf("%#v", clientVersion))
-			if serverVersion != nil {
-				fmt.Fprintf(o.Out, "Server Version: %s\n", fmt.Sprintf("%#v", *serverVersion))
-			}
+		fmt.Fprintf(o.Out, "Client Version: %s\n", fmt.Sprintf("%#v", versionInfo.ClientVersion))
+		if serverVersion != nil {
+			fmt.Fprintf(o.Out, "Server Version: %s\n", fmt.Sprintf("%#v", versionInfo.ServerVersion))
 		}
 	case "yaml":
 		marshalled, err := yaml.Marshal(&versionInfo)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
There is a problem about kubectl. The help information about `kubectl version`:
```
Options:
      --client=false: If true, shows client version only (no server required).
  -o, --output='': One of 'yaml' or 'json'.
      --short=false: If true, print just the version number.
``` 
But when I use `--short` and `--output` together. I found that `--short` not work. It still outputs all the information.
```
# kubectl version --short=true --output=json
{
  "clientVersion": {
    "major": "1",
    "minor": "20",
    "gitVersion": "v1.20.0",
    "gitCommit": "af46c47ce925f4c4ad5cc8d1fca46c7b77d13b38",
    "gitTreeState": "clean",
    "buildDate": "2020-12-08T17:59:43Z",
    "goVersion": "go1.15.5",
    "compiler": "gc",
    "platform": "linux/amd64"
  },
  "serverVersion": {
    "major": "1",
    "minor": "21",
    "gitVersion": "v1.21.0",
    "gitCommit": "cb303e613a121a29364f75cc67d3d580833a7479",
    "gitTreeState": "clean",
    "buildDate": "2021-04-08T16:25:06Z",
    "goVersion": "go1.16.1",
    "compiler": "gc",
    "platform": "linux/amd64"
  }
}
```
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
When use `--short` and `--output` together that `--short` can work properly. Just print the version number.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
