### PR TITLE
Modify API server validation error message misses ^ and $ in regexp format

### DIFF
--- a/pkg/apis/apiserverinternal/validation/validation.go
+++ b/pkg/apis/apiserverinternal/validation/validation.go
@@ -159,7 +159,7 @@ func validateStorageVersionCondition(conditions []apiserverinternal.StorageVersi
 	return allErrs
 }
 
-const dns1035LabelFmt string = "[a-z]([-a-z0-9]*[a-z0-9])?"
+const dns1035LabelFmt string = "^[a-z]([-a-z0-9]*[a-z0-9])?$"
 const dns1035LabelErrMsg string = "a DNS-1035 label, which must consist of lower case alphanumeric characters or '-', start with an alphabetic character, and end with an alphanumeric character"
 
 // isValidAPIVersion tests whether the value passed is a valid apiVersion. A

--- a/pkg/apis/apiserverinternal/validation/validation.go
+++ b/pkg/apis/apiserverinternal/validation/validation.go
@@ -159,7 +159,7 @@ func validateStorageVersionCondition(conditions []apiserverinternal.StorageVersi
 	return allErrs
 }
 
-const dns1035LabelFmt string = "^[a-z]([-a-z0-9]*[a-z0-9])?$"
+const dns1035LabelFmt string = "[a-z]([-a-z0-9]*[a-z0-9])?"
 const dns1035LabelErrMsg string = "a DNS-1035 label, which must consist of lower case alphanumeric characters or '-', start with an alphabetic character, and end with an alphanumeric character"
 
 // isValidAPIVersion tests whether the value passed is a valid apiVersion. A
@@ -183,7 +183,7 @@ func isValidAPIVersion(apiVersion string) []string {
 			errs = append(errs, prefixEach(msgs, "group part: ")...)
 		}
 	default:
-		return append(errs, "an apiVersion is "+utilvalidation.RegexError(dns1035LabelErrMsg, dns1035LabelFmt, "my-name", "abc-123")+
+		return append(errs, "an apiVersion is "+utilvalidation.RegexError(dns1035LabelErrMsg, "^"+dns1035LabelFmt+"$", "my-name", "abc-123")+
 			" with an optional DNS subdomain prefix and '/' (e.g. 'example.com/MyVersion')")
 	}
 

--- a/pkg/apis/apiserverinternal/validation/validation_test.go
+++ b/pkg/apis/apiserverinternal/validation/validation_test.go
@@ -99,7 +99,7 @@ func TestValidateServerStorageVersion(t *testing.T) {
 				EncodingVersion:   "v1",
 				DecodableVersions: []string{"v1", "mygroup_com/v2"},
 			},
-			expectedErr: `[].decodableVersions[1]: Invalid value: "mygroup_com/v2": group part: a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')`,
+			expectedErr: `[].decodableVersions[1]: Invalid value: "mygroup_com/v2": group part: a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$')`,
 		},
 		{
 			ssv: apiserverinternal.ServerStorageVersion{
@@ -107,7 +107,7 @@ func TestValidateServerStorageVersion(t *testing.T) {
 				EncodingVersion:   "v1",
 				DecodableVersions: []string{"v1", "mygroup.com/v2_"},
 			},
-			expectedErr: `[].decodableVersions[1]: Invalid value: "mygroup.com/v2_": version part: a DNS-1035 label must consist of lower case alphanumeric characters or '-', start with an alphabetic character, and end with an alphanumeric character (e.g. 'my-name',  or 'abc-123', regex used for validation is '[a-z]([-a-z0-9]*[a-z0-9])?')`,
+			expectedErr: `[].decodableVersions[1]: Invalid value: "mygroup.com/v2_": version part: a DNS-1035 label must consist of lower case alphanumeric characters or '-', start with an alphabetic character, and end with an alphanumeric character (e.g. 'my-name',  or 'abc-123', regex used for validation is '^[a-z]([-a-z0-9]*[a-z0-9])?$')`,
 		},
 		{
 			ssv: apiserverinternal.ServerStorageVersion{
@@ -115,7 +115,7 @@ func TestValidateServerStorageVersion(t *testing.T) {
 				EncodingVersion:   "v1",
 				DecodableVersions: []string{"v1", "mygroup.com/v2/myresource"},
 			},
-			expectedErr: `[].decodableVersions[1]: Invalid value: "mygroup.com/v2/myresource": an apiVersion is a DNS-1035 label, which must consist of lower case alphanumeric characters or '-', start with an alphabetic character, and end with an alphanumeric character (e.g. 'my-name',  or 'abc-123', regex used for validation is '[a-z]([-a-z0-9]*[a-z0-9])?') with an optional DNS subdomain prefix and '/' (e.g. 'example.com/MyVersion')`,
+			expectedErr: `[].decodableVersions[1]: Invalid value: "mygroup.com/v2/myresource": an apiVersion is a DNS-1035 label, which must consist of lower case alphanumeric characters or '-', start with an alphabetic character, and end with an alphanumeric character (e.g. 'my-name',  or 'abc-123', regex used for validation is '^[a-z]([-a-z0-9]*[a-z0-9])?$') with an optional DNS subdomain prefix and '/' (e.g. 'example.com/MyVersion')`,
 		},
 	}
 

--- a/pkg/apis/certificates/validation/validation_test.go
+++ b/pkg/apis/certificates/validation/validation_test.go
@@ -152,7 +152,7 @@ func TestValidateCertificateSigningRequestCreate(t *testing.T) {
 				},
 			},
 			errs: field.ErrorList{
-				field.Invalid(specPath.Child("signerName"), "", `validating label "": a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')`),
+				field.Invalid(specPath.Child("signerName"), "", `validating label "": a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$')`),
 			},
 		},
 		"signerName path component ends with a symbol": {
@@ -165,7 +165,7 @@ func TestValidateCertificateSigningRequestCreate(t *testing.T) {
 				},
 			},
 			errs: field.ErrorList{
-				field.Invalid(specPath.Child("signerName"), "something-", `validating label "something-": a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')`),
+				field.Invalid(specPath.Child("signerName"), "something-", `validating label "something-": a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$')`),
 			},
 		},
 		"signerName path component is a symbol": {
@@ -178,7 +178,7 @@ func TestValidateCertificateSigningRequestCreate(t *testing.T) {
 				},
 			},
 			errs: field.ErrorList{
-				field.Invalid(specPath.Child("signerName"), "-", `validating label "-": a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')`),
+				field.Invalid(specPath.Child("signerName"), "-", `validating label "-": a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$')`),
 			},
 		},
 		"signerName path component contains no '.' but is valid": {

--- a/pkg/apis/flowcontrol/validation/validation_test.go
+++ b/pkg/apis/flowcontrol/validation/validation_test.go
@@ -614,7 +614,7 @@ func TestFlowSchemaValidation(t *testing.T) {
 				},
 			},
 			expectedErrors: field.ErrorList{
-				field.Invalid(field.NewPath("spec").Child("priorityLevelConfiguration").Child("name"), "system+++$$", `a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')`),
+				field.Invalid(field.NewPath("spec").Child("priorityLevelConfiguration").Child("name"), "system+++$$", `a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$')`),
 			},
 		},
 		{
@@ -857,7 +857,7 @@ func TestFlowSchemaValidation(t *testing.T) {
 				},
 			},
 			expectedErrors: field.ErrorList{
-				field.Invalid(field.NewPath("spec").Child("rules").Index(0).Child("resourceRules").Index(0).Child("namespaces").Index(0), "-foo", nsErrIntro+`a lowercase RFC 1123 label must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?')`),
+				field.Invalid(field.NewPath("spec").Child("rules").Index(0).Child("resourceRules").Index(0).Child("namespaces").Index(0), "-foo", nsErrIntro+`a lowercase RFC 1123 label must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc', regex used for validation is '^[a-z0-9]([-a-z0-9]*[a-z0-9])?$')`),
 			},
 		},
 		{

--- a/pkg/apis/networking/validation/validation_test.go
+++ b/pkg/apis/networking/validation/validation_test.go
@@ -961,7 +961,7 @@ func TestValidateIngressCreate(t *testing.T) {
 			tweakIngress: func(ingress *networking.Ingress) {
 				ingress.Spec.TLS = []networking.IngressTLS{{SecretName: "invalid name"}}
 			},
-			expectedErrs: field.ErrorList{field.Invalid(field.NewPath("spec").Child("tls").Index(0).Child("secretName"), "invalid name", `a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')`)},
+			expectedErrs: field.ErrorList{field.Invalid(field.NewPath("spec").Child("tls").Index(0).Child("secretName"), "invalid name", `a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$')`)},
 		},
 		"v1beta1: valid secret": {
 			groupVersion: &networkingv1beta1.SchemeGroupVersion,
@@ -1391,7 +1391,7 @@ func TestValidateIngressUpdate(t *testing.T) {
 				oldIngress.Spec.TLS = []networking.IngressTLS{{SecretName: "valid"}}
 				newIngress.Spec.TLS = []networking.IngressTLS{{SecretName: "invalid name"}}
 			},
-			expectedErrs: field.ErrorList{field.Invalid(field.NewPath("spec").Child("tls").Index(0).Child("secretName"), "invalid name", `a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')`)},
+			expectedErrs: field.ErrorList{field.Invalid(field.NewPath("spec").Child("tls").Index(0).Child("secretName"), "invalid name", `a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$')`)},
 		},
 		"v1: change invalid secret -> invalid secret": {
 			gv: networkingv1.SchemeGroupVersion,
@@ -1588,7 +1588,7 @@ func TestValidateIngressClass(t *testing.T) {
 					Controller: "foo.co/bar",
 				},
 			},
-			expectedErrs: field.ErrorList{field.Invalid(field.NewPath("metadata.name"), "test*123", "a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')")},
+			expectedErrs: field.ErrorList{field.Invalid(field.NewPath("metadata.name"), "test*123", "a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$')")},
 		},
 		"valid name, empty controller": {
 			ingressClass: networking.IngressClass{
@@ -1718,7 +1718,7 @@ func TestValidateIngressClass(t *testing.T) {
 			expectedErrs: field.ErrorList{field.Invalid(field.NewPath("spec.parameters.namespace"), "foo_ns",
 				"a lowercase RFC 1123 label must consist of lower case alphanumeric characters or '-',"+
 					" and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc', "+
-					"regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?')")},
+					"regex used for validation is '^[a-z0-9]([-a-z0-9]*[a-z0-9])?$')")},
 		},
 		"valid name, valid controller, valid Cluster scope": {
 			ingressClass: networking.IngressClass{

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/validation/validation_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/validation/validation_test.go
@@ -337,7 +337,7 @@ func TestValidateConditions(t *testing.T) {
 				Message:            "",
 			}},
 			validateErrs: func(t *testing.T, errs field.ErrorList) {
-				needle := `status.conditions[0].type: Invalid value: ":invalid": name part must consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyName',  or 'my.name',  or '123-abc', regex used for validation is '([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]')`
+				needle := `status.conditions[0].type: Invalid value: ":invalid": name part must consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyName',  or 'my.name',  or '123-abc', regex used for validation is '^([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$')`
 				if !hasError(errs, needle) {
 					t.Errorf("missing %q in\n%v", needle, errorsAsString(errs))
 				}

--- a/staging/src/k8s.io/apimachinery/pkg/util/validation/validation.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/validation/validation.go
@@ -55,7 +55,7 @@ func IsQualifiedName(value string) []string {
 			errs = append(errs, prefixEach(msgs, "prefix part ")...)
 		}
 	default:
-		return append(errs, "a qualified name "+RegexError(qualifiedNameErrMsg, qualifiedNameFmt, "MyName", "my.name", "123-abc")+
+		return append(errs, "a qualified name "+RegexError(qualifiedNameErrMsg, "^" + qualifiedNameFmt + "$", "MyName", "my.name", "123-abc")+
 			" with an optional DNS subdomain prefix and '/' (e.g. 'example.com/MyName')")
 	}
 
@@ -65,7 +65,7 @@ func IsQualifiedName(value string) []string {
 		errs = append(errs, "name part "+MaxLenError(qualifiedNameMaxLength))
 	}
 	if !qualifiedNameRegexp.MatchString(name) {
-		errs = append(errs, "name part "+RegexError(qualifiedNameErrMsg, qualifiedNameFmt, "MyName", "my.name", "123-abc"))
+		errs = append(errs, "name part "+RegexError(qualifiedNameErrMsg, "^" + qualifiedNameFmt + "$", "MyName", "my.name", "123-abc"))
 	}
 	return errs
 }
@@ -169,7 +169,7 @@ func IsValidLabelValue(value string) []string {
 		errs = append(errs, MaxLenError(LabelValueMaxLength))
 	}
 	if !labelValueRegexp.MatchString(value) {
-		errs = append(errs, RegexError(labelValueErrMsg, labelValueFmt, "MyValue", "my_value", "12345"))
+		errs = append(errs, RegexError(labelValueErrMsg, "^" + labelValueFmt + "$", "MyValue", "my_value", "12345"))
 	}
 	return errs
 }
@@ -190,7 +190,7 @@ func IsDNS1123Label(value string) []string {
 		errs = append(errs, MaxLenError(DNS1123LabelMaxLength))
 	}
 	if !dns1123LabelRegexp.MatchString(value) {
-		errs = append(errs, RegexError(dns1123LabelErrMsg, dns1123LabelFmt, "my-name", "123-abc"))
+		errs = append(errs, RegexError(dns1123LabelErrMsg, "^" + dns1123LabelFmt + "$", "my-name", "123-abc"))
 	}
 	return errs
 }
@@ -211,18 +211,18 @@ func IsDNS1123Subdomain(value string) []string {
 		errs = append(errs, MaxLenError(DNS1123SubdomainMaxLength))
 	}
 	if !dns1123SubdomainRegexp.MatchString(value) {
-		errs = append(errs, RegexError(dns1123SubdomainErrorMsg, dns1123SubdomainFmt, "example.com"))
+		errs = append(errs, RegexError(dns1123SubdomainErrorMsg, "^" + dns1123SubdomainFmt + "$", "example.com"))
 	}
 	return errs
 }
 
-const dns1035LabelFmt string = "[a-z]([-a-z0-9]*[a-z0-9])?"
+const dns1035LabelFmt string = "^[a-z]([-a-z0-9]*[a-z0-9])?$"
 const dns1035LabelErrMsg string = "a DNS-1035 label must consist of lower case alphanumeric characters or '-', start with an alphabetic character, and end with an alphanumeric character"
 
 // DNS1035LabelMaxLength is a label's max length in DNS (RFC 1035)
 const DNS1035LabelMaxLength int = 63
 
-var dns1035LabelRegexp = regexp.MustCompile("^" + dns1035LabelFmt + "$")
+var dns1035LabelRegexp = regexp.MustCompile(dns1035LabelFmt)
 
 // IsDNS1035Label tests for a string that conforms to the definition of a label in
 // DNS (RFC 1035).
@@ -254,7 +254,7 @@ func IsWildcardDNS1123Subdomain(value string) []string {
 		errs = append(errs, MaxLenError(DNS1123SubdomainMaxLength))
 	}
 	if !wildcardDNS1123SubdomainRegexp.MatchString(value) {
-		errs = append(errs, RegexError(wildcardDNS1123SubdomainErrMsg, wildcardDNS1123SubdomainFmt, "*.example.com"))
+		errs = append(errs, RegexError(wildcardDNS1123SubdomainErrMsg, "^" + wildcardDNS1123SubdomainFmt + "$", "*.example.com"))
 	}
 	return errs
 }

--- a/staging/src/k8s.io/apimachinery/pkg/util/validation/validation.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/validation/validation.go
@@ -55,7 +55,7 @@ func IsQualifiedName(value string) []string {
 			errs = append(errs, prefixEach(msgs, "prefix part ")...)
 		}
 	default:
-		return append(errs, "a qualified name "+RegexError(qualifiedNameErrMsg, "^" + qualifiedNameFmt + "$", "MyName", "my.name", "123-abc")+
+		return append(errs, "a qualified name "+RegexError(qualifiedNameErrMsg, "^"+qualifiedNameFmt+"$", "MyName", "my.name", "123-abc")+
 			" with an optional DNS subdomain prefix and '/' (e.g. 'example.com/MyName')")
 	}
 
@@ -65,7 +65,7 @@ func IsQualifiedName(value string) []string {
 		errs = append(errs, "name part "+MaxLenError(qualifiedNameMaxLength))
 	}
 	if !qualifiedNameRegexp.MatchString(name) {
-		errs = append(errs, "name part "+RegexError(qualifiedNameErrMsg, "^" + qualifiedNameFmt + "$", "MyName", "my.name", "123-abc"))
+		errs = append(errs, "name part "+RegexError(qualifiedNameErrMsg, "^"+qualifiedNameFmt+"$", "MyName", "my.name", "123-abc"))
 	}
 	return errs
 }
@@ -169,7 +169,7 @@ func IsValidLabelValue(value string) []string {
 		errs = append(errs, MaxLenError(LabelValueMaxLength))
 	}
 	if !labelValueRegexp.MatchString(value) {
-		errs = append(errs, RegexError(labelValueErrMsg, "^" + labelValueFmt + "$", "MyValue", "my_value", "12345"))
+		errs = append(errs, RegexError(labelValueErrMsg, "^"+labelValueFmt+"$", "MyValue", "my_value", "12345"))
 	}
 	return errs
 }
@@ -190,7 +190,7 @@ func IsDNS1123Label(value string) []string {
 		errs = append(errs, MaxLenError(DNS1123LabelMaxLength))
 	}
 	if !dns1123LabelRegexp.MatchString(value) {
-		errs = append(errs, RegexError(dns1123LabelErrMsg, "^" + dns1123LabelFmt + "$", "my-name", "123-abc"))
+		errs = append(errs, RegexError(dns1123LabelErrMsg, "^"+dns1123LabelFmt+"$", "my-name", "123-abc"))
 	}
 	return errs
 }
@@ -211,18 +211,18 @@ func IsDNS1123Subdomain(value string) []string {
 		errs = append(errs, MaxLenError(DNS1123SubdomainMaxLength))
 	}
 	if !dns1123SubdomainRegexp.MatchString(value) {
-		errs = append(errs, RegexError(dns1123SubdomainErrorMsg, "^" + dns1123SubdomainFmt + "$", "example.com"))
+		errs = append(errs, RegexError(dns1123SubdomainErrorMsg, "^"+dns1123SubdomainFmt+"$", "example.com"))
 	}
 	return errs
 }
 
-const dns1035LabelFmt string = "^[a-z]([-a-z0-9]*[a-z0-9])?$"
+const dns1035LabelFmt string = "[a-z]([-a-z0-9]*[a-z0-9])?"
 const dns1035LabelErrMsg string = "a DNS-1035 label must consist of lower case alphanumeric characters or '-', start with an alphabetic character, and end with an alphanumeric character"
 
 // DNS1035LabelMaxLength is a label's max length in DNS (RFC 1035)
 const DNS1035LabelMaxLength int = 63
 
-var dns1035LabelRegexp = regexp.MustCompile(dns1035LabelFmt)
+var dns1035LabelRegexp = regexp.MustCompile("^" + dns1035LabelFmt + "$")
 
 // IsDNS1035Label tests for a string that conforms to the definition of a label in
 // DNS (RFC 1035).
@@ -232,7 +232,7 @@ func IsDNS1035Label(value string) []string {
 		errs = append(errs, MaxLenError(DNS1035LabelMaxLength))
 	}
 	if !dns1035LabelRegexp.MatchString(value) {
-		errs = append(errs, RegexError(dns1035LabelErrMsg, dns1035LabelFmt, "my-name", "abc-123"))
+		errs = append(errs, RegexError(dns1035LabelErrMsg, "^"+dns1035LabelFmt+"$", "my-name", "abc-123"))
 	}
 	return errs
 }
@@ -254,7 +254,7 @@ func IsWildcardDNS1123Subdomain(value string) []string {
 		errs = append(errs, MaxLenError(DNS1123SubdomainMaxLength))
 	}
 	if !wildcardDNS1123SubdomainRegexp.MatchString(value) {
-		errs = append(errs, RegexError(wildcardDNS1123SubdomainErrMsg, "^" + wildcardDNS1123SubdomainFmt + "$", "*.example.com"))
+		errs = append(errs, RegexError(wildcardDNS1123SubdomainErrMsg, "^"+wildcardDNS1123SubdomainFmt+"$", "*.example.com"))
 	}
 	return errs
 }

--- a/staging/src/k8s.io/component-helpers/scheduling/corev1/nodeaffinity/nodeaffinity_test.go
+++ b/staging/src/k8s.io/component-helpers/scheduling/corev1/nodeaffinity/nodeaffinity_test.go
@@ -83,7 +83,7 @@ func TestNodeSelectorMatch(t *testing.T) {
 				&field.Error{
 					Type:   field.ErrorTypeInvalid,
 					Field:  "nodeSelectorTerms[2].matchExpressions[0].key",
-					Detail: `name part must consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyName',  or 'my.name',  or '123-abc', regex used for validation is '([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]')`,
+					Detail: `name part must consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyName',  or 'my.name',  or '123-abc', regex used for validation is '^([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$')`,
 				},
 			}.ToAggregate(),
 		},
@@ -219,7 +219,7 @@ func TestPreferredSchedulingTermsScore(t *testing.T) {
 				&field.Error{
 					Type:   field.ErrorTypeInvalid,
 					Field:  "[2].matchExpressions[0].key",
-					Detail: `name part must consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyName',  or 'my.name',  or '123-abc', regex used for validation is '([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]')`,
+					Detail: `name part must consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyName',  or 'my.name',  or '123-abc', regex used for validation is '^([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$')`,
 				},
 			}.ToAggregate(),
 		},


### PR DESCRIPTION
#### What type of PR is this?
/kind bug
/kind cleanup

#### What this PR does / why we need it:

Now the RegexErr msg like: **** regex used for validation is
`'[a-z0-9]([-a-z0-9]*[a-z0-9])?'`

But the regex is: `^[a-z]([-a-z0-9]*[a-z0-9])?$`

#### Which issue(s) this PR fixes:
Fixes #101942

#### Special notes for your reviewer:
#### Does this PR introduce a user-facing change?
None
#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
None

