### PR TITLE
fix slice sort algorithm in freeCores/freeCPUS

### DIFF
--- a/pkg/kubelet/cm/cpumanager/cpu_assignment.go
+++ b/pkg/kubelet/cm/cpumanager/cpu_assignment.go
@@ -74,7 +74,10 @@ func (a *cpuAccumulator) freeCores() []int {
 		func(i, j int) bool {
 			iCores := a.details.CoresInSockets(socketIDs[i]).Filter(a.isCoreFree)
 			jCores := a.details.CoresInSockets(socketIDs[j]).Filter(a.isCoreFree)
-			return iCores.Size() < jCores.Size() || socketIDs[i] < socketIDs[j]
+			if iCores.Size() != jCores.Size() {
+				return iCores.Size() < jCores.Size()
+			}
+			return socketIDs[i] < socketIDs[j]
 		})
 
 	coreIDs := []int{}
@@ -120,11 +123,19 @@ func (a *cpuAccumulator) freeCPUs() []int {
 			iCoreFreeScore := a.details.CPUsInCores(iCore).Size()
 			jCoreFreeScore := a.details.CPUsInCores(jCore).Size()
 
-			return iSocketColoScore > jSocketColoScore ||
-				iSocketFreeScore < jSocketFreeScore ||
-				iCoreFreeScore < jCoreFreeScore ||
-				iSocket < jSocket ||
-				iCore < jCore
+			if iSocketColoScore != jSocketColoScore {
+				return iSocketColoScore > jSocketColoScore
+			}
+			if iSocketFreeScore != jSocketFreeScore {
+				return iSocketFreeScore < jSocketFreeScore
+			}
+			if iCoreFreeScore != jCoreFreeScore {
+				return iCoreFreeScore < jCoreFreeScore
+			}
+			if iSocket != jSocket {
+				return iSocket < jSocket
+			}
+			return iCore < jCore
 		})
 
 	// For each core, append sorted CPU IDs to result.

--- a/pkg/kubelet/cm/cpumanager/cpu_assignment_test.go
+++ b/pkg/kubelet/cm/cpumanager/cpu_assignment_test.go
@@ -175,6 +175,12 @@ func TestCPUAccumulatorFreeCPUs(t *testing.T) {
 			cpuset.NewCPUSet(1, 2, 3, 4, 5, 7, 8, 9, 10, 11),
 			[]int{2, 8, 4, 10, 1, 7, 3, 9, 5, 11},
 		},
+		{
+			"triple socket HT, 12 cpus free",
+			topoTripleSocketHT,
+			cpuset.NewCPUSet(0, 1, 2, 3, 6, 7, 8, 9, 10, 11, 12, 13),
+			[]int{12, 13, 0, 1, 2, 3, 6, 7, 8, 9, 10, 11},
+		},
 	}
 
 	for _, tc := range testCases {

--- a/pkg/kubelet/cm/cpumanager/policy_test.go
+++ b/pkg/kubelet/cm/cpumanager/policy_test.go
@@ -57,6 +57,33 @@ var (
 		},
 	}
 
+	// fake topology for testing purposes only
+	topoTripleSocketHT = &topology.CPUTopology{
+		NumCPUs:    18,
+		NumSockets: 3,
+		NumCores:   9,
+		CPUDetails: map[int]topology.CPUInfo{
+			0:  {CoreID: 0, SocketID: 1},
+			1:  {CoreID: 0, SocketID: 1},
+			2:  {CoreID: 1, SocketID: 1},
+			3:  {CoreID: 1, SocketID: 1},
+			4:  {CoreID: 2, SocketID: 1},
+			5:  {CoreID: 2, SocketID: 1},
+			6:  {CoreID: 3, SocketID: 0},
+			7:  {CoreID: 3, SocketID: 0},
+			8:  {CoreID: 4, SocketID: 0},
+			9:  {CoreID: 4, SocketID: 0},
+			10: {CoreID: 5, SocketID: 0},
+			11: {CoreID: 5, SocketID: 0},
+			12: {CoreID: 6, SocketID: 2},
+			13: {CoreID: 6, SocketID: 2},
+			14: {CoreID: 7, SocketID: 2},
+			15: {CoreID: 7, SocketID: 2},
+			16: {CoreID: 8, SocketID: 2},
+			17: {CoreID: 8, SocketID: 2},
+		},
+	}
+
 	topoDualSocketNoHT = &topology.CPUTopology{
 		NumCPUs:    8,
 		NumSockets: 2,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:
Take freeCores now for example(https://github.com/kubernetes/kubernetes/blob/master/pkg/kubelet/cm/cpumanager/cpu_assignment.go#L82): 
```go
func (a *cpuAccumulator) freeCores() []int {
...
	sort.Slice(socketIDs,
		func(i, j int) bool {
			iCores := a.details.CoresInSockets(socketIDs[i]).Filter(a.isCoreFree)
			jCores := a.details.CoresInSockets(socketIDs[j]).Filter(a.isCoreFree)
			return iCores.Size() < jCores.Size() || socketIDs[i] < socketIDs[j]
		})
...
```
Currently, when `iCores.Size() > jCores.Size() ` socketIDs will sort by result of `socketIDs[i] < socketIDs[j]`. In my opinion, it should act like below. 
```
1. iCores.Size() < jCores.Size(), return true.
2. iCores.Size() > jCores.Size(), return false.
3. iCores.Size() == jCores.Size(), try to compare if socketIDs[i] < socketIDs[j]
```
Problems the same in freeCPUs. 
The fix could make allocations more socket/core affiniate.
Testcases now is hard to get a error, so i add a test.