### PR TITLE
kubeadm: CoreDNS permissions for endpointslices

### DIFF
--- a/cmd/kubeadm/app/phases/addons/dns/manifests.go
+++ b/cmd/kubeadm/app/phases/addons/dns/manifests.go
@@ -197,6 +197,13 @@ rules:
   - nodes
   verbs:
   - get
+- apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - list
+  - watch
 `
 	// CoreDNSClusterRoleBinding is the CoreDNS Clusterrolebinding manifest
 	CoreDNSClusterRoleBinding = `


### PR DESCRIPTION
/kind bug
#### What this PR does / why we need it:


```release-note
kubeadm: CoreDNS 1.8.1+ supports Dual Stack, and needs permissions to watch EndpointSlices
```
https://coredns.io/2021/01/20/coredns-1.8.1-release/

Reported:
https://github.com/coredns/coredns/pull/4209#issuecomment-839947858
