### PR TITLE
Automated cherry pick of #101443: Add missing clientset to EBS storage e2e test

### DIFF
--- a/test/e2e/storage/volume_provisioning.go
+++ b/test/e2e/storage/volume_provisioning.go
@@ -825,6 +825,7 @@ var _ = utils.SIGDescribe("Dynamic Provisioning", func() {
 		ginkgo.It("should report an error and create no PV", func() {
 			e2eskipper.SkipUnlessProviderIs("aws")
 			test := testsuites.StorageClassTest{
+				Client:      c,
 				Name:        "AWS EBS with invalid KMS key",
 				Provisioner: "kubernetes.io/aws-ebs",
 				Timeouts:    f.Timeouts,


### PR DESCRIPTION
/kind cleanup
/kind failing-test

Cherry pick of #101443 on release-1.21.

#101443: Add missing clientset to EBS storage e2e test

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.


#### Does this PR introduce a user-facing change?

```release-note
NONE
```