### PR TITLE
Deflake tests that need to grab metrics from controller-manager or scheduler

### DIFF
--- a/test/e2e/framework/metrics/metrics_proxy.go
+++ b/test/e2e/framework/metrics/metrics_proxy.go
@@ -50,6 +50,9 @@ func SetupMetricsProxy(c clientset.Interface) error {
 		}
 		var foundComponents []componentInfo
 		for _, pod := range podList.Items {
+			if len(pod.Status.PodIP) == 0 {
+				continue
+			}
 			switch {
 			case strings.HasPrefix(pod.Name, "kube-scheduler-"):
 				foundComponents = append(foundComponents, componentInfo{


### PR DESCRIPTION

#### What type of PR is this?

/kind cleanup
/kind flake

#### What this PR does / why we need it:

According to the logs in this test https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/101960/pull-kubernetes-e2e-gce-ubuntu-containerd/1392808375145730048/:
```
I0513 12:14:41.521] I0513 12:14:37.277313   84013 metrics_proxy.go:150] [DEBUG] metrics-proxy nginx config: 
I0513 12:14:41.521] server {
I0513 12:14:41.521] 	listen 10257;
I0513 12:14:41.521] 	server_name _;
I0513 12:14:41.522] 	proxy_set_header Authorization "Bearer eyJhbGciOiJSUzI1NiIsImtpZCI6InZDZEkxeTZLbjNKUGswNk5QeWdwa3ROT0p3M244NnFfRjBza3lpQWdxVncifQ.eyJpc3MiOiJrdWJlcm5ldGVzL3NlcnZpY2VhY2NvdW50Iiwia3ViZXJuZXRlcy5pby9zZXJ2aWNlYWNjb3VudC9uYW1lc3BhY2UiOiJrdWJlLXN5c3RlbSIsImt1YmVybmV0ZXMuaW8vc2VydmljZWFjY291bnQvc2VjcmV0Lm5hbWUiOiJtZXRyaWNzLXByb3h5LXRva2VuLWd0cDZoIiwia3ViZXJuZXRlcy5pby9zZXJ2aWNlYWNjb3VudC9zZXJ2aWNlLWFjY291bnQubmFtZSI6Im1ldHJpY3MtcHJveHkiLCJrdWJlcm5ldGVzLmlvL3NlcnZpY2VhY2NvdW50L3NlcnZpY2UtYWNjb3VudC51aWQiOiIyZmE0NDA5Yy0zMGE2LTRlMWQtODJiMS1jMzhlMTFiZjM2MjUiLCJzdWIiOiJzeXN0ZW06c2VydmljZWFjY291bnQ6a3ViZS1zeXN0ZW06bWV0cmljcy1wcm94eSJ9.D28Lvn8lmqHH21r_vfWJMFSp0uRXDxhX0m-6mNA7RdX-2S202kL1GqU7RUIV7F3uqPJB_8de6yzLqDu3kaHmpNB1FN68LQcgTCsV5A-V8axwXWCwlaCzb-40ig0UvasyaxOx4wg2TMWK3HxnViSEDD3B2t0KOefbHugeexImbYdsmUJkp_6Nctj2DSK3EH67NwmONYR61Xphnyh9a_CCP3rI6qvmgGD3pbtCaGuiupoBcHW1QniwkM4SlvOoov_g5Sx8l8vLWfaFbLhjC71tRGmH2DEyoXjjvJxe8j4An7bHk5ByGyZAJ3w1kQJlRUU7N9rHUM3kag_Z8tfS4QBEjw";
I0513 12:14:41.522] 	proxy_ssl_verify off;
I0513 12:14:41.522] 	location /metrics {
I0513 12:14:41.523] 		proxy_pass https://10.40.0.2:10257;
I0513 12:14:41.523] 	}
I0513 12:14:41.523] }
I0513 12:14:41.523] 
I0513 12:14:41.523] I0513 12:14:41.473977   84013 metrics_proxy.go:198] Successfully setup metrics-proxy
...

I0513 12:19:27.432] [It] should grab all metrics from a Scheduler.
...

I0513 12:19:27.433] 
I0513 12:19:27.433] May 13 12:19:19.525: FAIL: Unexpected error:
I0513 12:19:27.433]     <*errors.StatusError | 0xc001a726e0>: {
I0513 12:19:27.434]         ErrStatus: {
I0513 12:19:27.434]             TypeMeta: {Kind: "", APIVersion: ""},
I0513 12:19:27.434]             ListMeta: {
I0513 12:19:27.434]                 SelfLink: "",
I0513 12:19:27.434]                 ResourceVersion: "",
I0513 12:19:27.434]                 Continue: "",
I0513 12:19:27.434]                 RemainingItemCount: nil,
I0513 12:19:27.434]             },
I0513 12:19:27.434]             Status: "Failure",
I0513 12:19:27.435]             Message: "the server is currently unable to handle the request (get pods metrics-proxy:10259)",
I0513 12:19:27.435]             Reason: "ServiceUnavailable",
I0513 12:19:27.435]             Details: {
I0513 12:19:27.435]                 Name: "metrics-proxy:10259",
I0513 12:19:27.435]                 Group: "",
I0513 12:19:27.435]                 Kind: "pods",
I0513 12:19:27.435]                 UID: "",
I0513 12:19:27.435]                 Causes: [
I0513 12:19:27.436]                     {
I0513 12:19:27.436]                         Type: "UnexpectedServerResponse",
I0513 12:19:27.436]                         Message: "unknown",
I0513 12:19:27.436]                         Field: "",
I0513 12:19:27.436]                     },
I0513 12:19:27.436]                 ],
I0513 12:19:27.436]                 RetryAfterSeconds: 0,
I0513 12:19:27.436]             },
I0513 12:19:27.436]             Code: 503,
I0513 12:19:27.437]         },
I0513 12:19:27.437]     }
I0513 12:19:27.437]     the server is currently unable to handle the request (get pods metrics-proxy:10259)
```

It seems that the [scheduler pod had not shown up](https://github.com/kubernetes/kubernetes/blob/09268c16853b233ebaedcd6a877eac23690b5190/test/e2e/framework/metrics/metrics_proxy.go#L43-L50) when we [setup e2e test suite](https://github.com/kubernetes/kubernetes/blob/master/test/e2e/e2e.go#L312), so the nginx config for the forwarder pod was incomplete.

This PR make `SetupMetricsProxy` function wait for desired component pods to show up first.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
