### PR TITLE
Simplify 'attach' command by decoupling flags from options

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/attach/attach.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/attach/attach.go
@@ -55,14 +55,6 @@ var (
 		# Get output from the first pod of a ReplicaSet named nginx
 		kubectl attach rs/nginx
 		`))
-
-	defaultAttachResourceBuilderFlags = genericclioptions.NewResourceBuilderFlags().
-						WithLabelSelector("").
-						WithFieldSelector("").
-						WithAll(false).
-						WithAllNamespaces(false).
-						WithLocal(false).
-						WithLatest()
 )
 
 const (
@@ -74,9 +66,8 @@ const (
 // flags. They will be converted to Options, which reflect the runtime
 // requirements for the command.
 type AttachFlags struct {
-	builder              func() *resource.Builder
-	resourceBuilderFlags *genericclioptions.ResourceBuilderFlags
-	restClientGetter     genericclioptions.RESTClientGetter
+	builder          func() *resource.Builder
+	restClientGetter genericclioptions.RESTClientGetter
 	exec.StreamOptions
 }
 
@@ -86,9 +77,8 @@ func NewAttachFlags(
 	streams genericclioptions.IOStreams) *AttachFlags {
 
 	return &AttachFlags{
-		builder:              f.NewBuilder,
-		resourceBuilderFlags: defaultAttachResourceBuilderFlags,
-		restClientGetter:     f,
+		builder:          f.NewBuilder,
+		restClientGetter: f,
 		StreamOptions: exec.StreamOptions{
 			IOStreams: streams,
 		},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

This PR refactors the `attach` command by decoupling its CLI flags from
commands. This change helps to reduce the amount of structs transformation and
makes unit testing easier.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Part of https://github.com/kubernetes/kubectl/issues/1046

#### Special notes for your reviewer:

The YAML used for testing can be found in this [gist](https://gist.github.com/ihcsim/94dbd79c4fda19d8983adf872ea2affa).

<details>
<summary>Some test results:</summary>

```sh
# attach to the default container with tty enabled
$ _output/bin/kubectl -n testcli attach echo-59c6fbdf7-8swdc -it       
Defaulted container "echo1" out of: echo1, echo2                                                                                                  
If you don't see a command prompt, try pressing enter.                                                                                            
test                                               
stdout: test
stderr: test
^CSession ended, resume using 'kubectl attach echo-59c6fbdf7-8swdc -c echo1 -i -t' command when the pod is running

# attach to the first container with tty enabled
$ _output/bin/kubectl -n testcli attach echo-59c6fbdf7-8swdc -c echo1 -it         
If you don't see a command prompt, try pressing enter.
test
stdout: test
stderr: test
^CSession ended, resume using 'kubectl attach echo-59c6fbdf7-8swdc -c echo1 -i -t' command when the pod is running

# attach to the 2nd container with tty enabled
$ _output/bin/kubectl -n testcli attach echo-59c6fbdf7-8swdc -c echo2 -it
If you don't see a command prompt, try pressing enter.
test
stdout: test
stderr: test
^CSession ended, resume using 'kubectl attach echo-59c6fbdf7-8swdc -c echo1 -i -t' command when the pod is running

# attach to the deployment resource with tty enabled
$ _output/bin/kubectl -n testcli attach deploy/echo -it                   
Defaulted container "echo1" out of: echo1, echo2
If you don't see a command prompt, try pressing enter.
test
stdout: test
stderr: test
^CSession ended, resume using 'kubectl attach echo-59c6fbdf7-8swdc -c echo1 -i -t' command when the pod is running

# attach to the 2nd container via the deployment resource
_output/bin/kubectl -n testcli attach deploy/echo -c echo2 -it            
If you don't see a command prompt, try pressing enter.
test
stdout: test
stderr: test
^[^[^CSession ended, resume using 'kubectl attach echo-59c6fbdf7-8swdc -c echo2 -i -t' command when the pod is running
```
</details>

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
