### PR TITLE
kubeadm: fix the bug that kubeadm only uses the first hash in caCertHashes to verify the root CA

### DIFF
--- a/cmd/kubeadm/app/util/pubkeypin/pubkeypin.go
+++ b/cmd/kubeadm/app/util/pubkeypin/pubkeypin.go
@@ -59,7 +59,9 @@ func (s *Set) Allow(pubKeyHashes ...string) error {
 
 		switch strings.ToLower(format) {
 		case "sha256":
-			return s.allowSHA256(value)
+			if err := s.allowSHA256(value); err != nil {
+				return errors.Errorf("invalid hash %q, %v", pubKeyHash, err)
+			}
 		default:
 			return errors.Errorf("unknown hash format %q. Known format(s) are: %s", format, supportedFormats)
 		}

--- a/cmd/kubeadm/app/util/pubkeypin/pubkeypin_test.go
+++ b/cmd/kubeadm/app/util/pubkeypin/pubkeypin_test.go
@@ -143,6 +143,17 @@ func TestSet(t *testing.T) {
 		t.Error("expected the second test cert to be disallowed")
 		return
 	}
+
+	s = NewSet() // keep set empty
+	hashes := []string{
+		`sha256:0000000000000000000000000000000000000000000000000000000000000000`,
+		`sha256:0000000000000000000000000000000000000000000000000000000000000001`,
+	}
+	err = s.Allow(hashes...)
+	if err != nil || len(s.sha256Hashes) != 2 {
+		t.Error("expected allowing multiple hashes to succeed")
+		return
+	}
 }
 
 func TestHash(t *testing.T) {


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
kubeadm: fix the bug that kubeadm only uses the first hash in caCertHashes to verify the root CA

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes kubernetes/kubeadm#2471

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
kubeadm: fix the bug that kubeadm only uses the first hash in caCertHashes to verify the root CA
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
