### PR TITLE
Automated cherry pick of #101950: Make watch order conformance test reliable

### DIFF
--- a/test/e2e/apimachinery/BUILD
+++ b/test/e2e/apimachinery/BUILD
@@ -81,6 +81,8 @@ go_library(
         "//staging/src/k8s.io/client-go/dynamic:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes:go_default_library",
         "//staging/src/k8s.io/client-go/rest:go_default_library",
+        "//staging/src/k8s.io/client-go/tools/cache:go_default_library",
+        "//staging/src/k8s.io/client-go/tools/watch:go_default_library",
         "//staging/src/k8s.io/client-go/util/cert:go_default_library",
         "//staging/src/k8s.io/client-go/util/flowcontrol:go_default_library",
         "//staging/src/k8s.io/client-go/util/keyutil:go_default_library",


### PR DESCRIPTION
Cherry pick of #101950 on release-1.20.

#101950: Make watch order conformance test reliable

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.