### PR TITLE
Remove etcd connection apiserver preflight check

### DIFF
--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1498,7 +1498,6 @@ k8s.io/apiserver/pkg/storage/cacher
 k8s.io/apiserver/pkg/storage/errors
 k8s.io/apiserver/pkg/storage/etcd3
 k8s.io/apiserver/pkg/storage/etcd3/metrics
-k8s.io/apiserver/pkg/storage/etcd3/preflight
 k8s.io/apiserver/pkg/storage/etcd3/testing
 k8s.io/apiserver/pkg/storage/etcd3/testing/testingcert
 k8s.io/apiserver/pkg/storage/names


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
continuation of https://github.com/kubernetes/kubernetes/pull/91202

This initial `CheckEtcdServers` added by https://github.com/kubernetes/kubernetes/pull/39821 never works as intended. It just validates that the first server you pass starts with a scheme, it never actually checks if etcd is connectable. Because:

- if the first server you pass starts with a scheme (for example `--etcd-servers="http://127.0.0.1:2379`)* then net.SplitHostPort errors with `too many colons in address` https://play.golang.org/p/vASJ58fL6qD https://golang.org/pkg/net/#SplitHostPort and apiserver never enters the if statement containing the `CheckEtcdServers`
- if the first server you pass does NOT start with a scheme (for example`--etcd-servers="127.0.0.1:2379"`) then apiserver enters the if statement containing the `CheckEtcdServers` but errors with `Error: error waiting for etcd connection: unable to parse etcd url: parse "127.0.0.1:2379": first path segment in URL cannot contain colon`

This PR removes the check and so  the informal/unintended validation that the first etcd server starts with a scheme. So behavior changes slightly because now it's possible to pass a URL without scheme and somewhere down the line, after precheck, apiserver will attempt to dial it. To be honest I am not sure the implications of passing schemless URL around so if we want to avoid it I can add explicit validation for etcd-server to preserve the current behavior.

Another option is to fix the check to work as intended and poll for 60s like https://github.com/kubernetes/kubernetes/pull/91202. But since basically nobody has noticed that the check doesn't work I'm not sure if it's valuable. If etcd is not connectable, apiserver crashes in 20s:
```
I0513 16:15:28.592938 1256170 endpoint.go:68] ccResolverWrapper: sending new addresses to cc: [{http://asdfwongma7:2379  <nil> 0 <nil>}]
W0513 16:15:28.658178 1256170 clientconn.go:1223] grpc: addrConn.createTransport failed to connect to {http://asdfwongma7:2379  <nil> 0 <nil>}. Err :connection error: desc = "transport: Error while dialing dial tcp: lookup asdfwongma7 on 127.0.1.1:53: no such host". Reconnecting...
...
W0513 16:15:46.415026 1256170 clientconn.go:1223] grpc: addrConn.createTransport failed to connect to {http://asdfwongma7:2379  <nil> 0 <nil>}. Err :connection error: desc = "transport: Error while dialing dial tcp: lookup asdfwongma7 on 127.0.1.1:53: no such host". Reconnecting...
Error: context deadline exceeded
```
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
