### PR TITLE
Fix the ceph deploy for e2e testing for ARM64

### DIFF
--- a/test/images/volume/rbd/BASEIMAGE
+++ b/test/images/volume/rbd/BASEIMAGE
@@ -1,3 +1,3 @@
-linux/amd64=fedora:26
-linux/arm64=arm64v8/fedora:26
-linux/ppc64le=ppc64le/fedora:26
+linux/amd64=fedora:33
+linux/arm64=arm64v8/fedora:33
+linux/ppc64le=ppc64le/fedora:33

--- a/test/images/volume/rbd/Dockerfile
+++ b/test/images/volume/rbd/Dockerfile
@@ -21,7 +21,7 @@ FROM $BASEIMAGE
 CROSS_BUILD_COPY qemu-QEMUARCH-static /usr/bin/
 
 # Base Packages
-RUN yum install -y wget strace psmisc procps-ng ceph ceph-fuse && yum clean all
+RUN yum install -y wget strace psmisc procps-ng ceph ceph-fuse hostname && yum clean all
 
 # Get ports exposed
 EXPOSE 6789

--- a/test/images/volume/rbd/bootstrap.sh
+++ b/test/images/volume/rbd/bootstrap.sh
@@ -41,6 +41,15 @@ sh ./mds.sh
 # Prepare a RBD volume "foo" (only with layering feature, the others may
 # require newer clients).
 # NOTE: we need Ceph kernel modules on the host that runs the client!
+# As the default pool `rbd` might not be created on arm64 platform for ceph deployment,
+# should create it if it does not exist.
+arch=$(uname -m)
+if [[ ${arch} = 'aarch64' || ${arch} = 'arm64' ]]; then
+    if [[ $(ceph osd lspools) = "" ]]; then
+        ceph osd pool create rbd 8
+        rbd pool init rbd
+    fi
+fi
 rbd import --image-feature layering block foo
 
 # Prepare a cephfs volume


### PR DESCRIPTION
- ceph deploy on ARM64 depends on "libec_jerasure_neon.so" which is not included
in `ceph-base` package in fedora26 distro, updated the distro to fedora33 to
fix the issue

```
sh ./mon.sh "$(hostname -i)"
/usr/lib64/ceph/erasure-code/libec_jerasure_neon.so: cannot open shared object file
```

- default pool `rbd` is not created on arm64, need to created this pool manually.

```
rbd import --image-feature layering block foo
rbd: error opening default pool 'rbd'
Ensure that the default pool has been created or specify an alternate pool name.
[root@4c05206b81c2 /]# ceph osd lspools  (nothing output inside the container)
```

Signed-off-by: Dave Chen <dave.chen@arm.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug


#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes/kubernetes/issues/101967

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
