### PR TITLE
Remove feature label from Indexed Job E2E test

### DIFF
--- a/test/e2e/apps/job.go
+++ b/test/e2e/apps/job.go
@@ -153,7 +153,7 @@ var _ = SIGDescribe("Job", func() {
 		Testcase: Ensure Pods of an Indexed Job get a unique index.
 		Description: Create an Indexed Job, wait for completion, capture the output of the pods and verify that they contain the completion index.
 	*/
-	ginkgo.It("[Feature:IndexedJob] should create pods for an Indexed job with completion indexes and specified hostname", func() {
+	ginkgo.It("should create pods for an Indexed job with completion indexes and specified hostname", func() {
 		ginkgo.By("Creating Indexed job")
 		job := e2ejob.NewTestJob("succeed", "indexed-job", v1.RestartPolicyNever, parallelism, completions, nil, backoffLimit)
 		mode := batchv1.IndexedCompletion


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

To allow the test to run during presubmit and other suites.
IndexedJob is graduating to beta in this release.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```