### PR TITLE
bump ingress e2e tests  to v1

### DIFF
--- a/staging/src/k8s.io/api/networking/v1/well_known_annotations.go
+++ b/staging/src/k8s.io/api/networking/v1/well_known_annotations.go
@@ -1,0 +1,25 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1
+
+const (
+	// AnnotationIsDefaultIngressClass can be used to indicate that an
+	// IngressClass should be considered default. When a single IngressClass
+	// resource has this annotation set to true, new Ingress resources without a
+	// class specified will be assigned this default class.
+	AnnotationIsDefaultIngressClass = "ingressclass.kubernetes.io/is-default-class"
+)

--- a/test/e2e/framework/ingress/ingress_utils.go
+++ b/test/e2e/framework/ingress/ingress_utils.go
@@ -41,7 +41,7 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
-	networkingv1beta1 "k8s.io/api/networking/v1beta1"
+	networkingv1 "k8s.io/api/networking/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
@@ -220,6 +220,7 @@ func CreateIngressComformanceTests(jig *TestJig, ns string, annotations map[stri
 	updatedTLSHost := "foobar.com"
 	updateURLMapHost := "bar.baz.com"
 	updateURLMapPath := "/testurl"
+	prefixPathType := networkingv1.PathTypePrefix
 	// Platform agnostic list of tests that must be satisfied by all controllers
 	tests := []ConformanceTests{
 		{
@@ -236,8 +237,8 @@ func CreateIngressComformanceTests(jig *TestJig, ns string, annotations map[stri
 			fmt.Sprintf("should update url map for host %v to expose a single url: %v", updateURLMapHost, updateURLMapPath),
 			func() {
 				var pathToFail string
-				jig.Update(func(ing *networkingv1beta1.Ingress) {
-					newRules := []networkingv1beta1.IngressRule{}
+				jig.Update(func(ing *networkingv1.Ingress) {
+					newRules := []networkingv1.IngressRule{}
 					for _, rule := range ing.Spec.Rules {
 						if rule.Host != updateURLMapHost {
 							newRules = append(newRules, rule)
@@ -245,14 +246,15 @@ func CreateIngressComformanceTests(jig *TestJig, ns string, annotations map[stri
 						}
 						existingPath := rule.IngressRuleValue.HTTP.Paths[0]
 						pathToFail = existingPath.Path
-						newRules = append(newRules, networkingv1beta1.IngressRule{
+						newRules = append(newRules, networkingv1.IngressRule{
 							Host: updateURLMapHost,
-							IngressRuleValue: networkingv1beta1.IngressRuleValue{
-								HTTP: &networkingv1beta1.HTTPIngressRuleValue{
-									Paths: []networkingv1beta1.HTTPIngressPath{
+							IngressRuleValue: networkingv1.IngressRuleValue{
+								HTTP: &networkingv1.HTTPIngressRuleValue{
+									Paths: []networkingv1.HTTPIngressPath{
 										{
-											Path:    updateURLMapPath,
-											Backend: existingPath.Backend,
+											Path:     updateURLMapPath,
+											PathType: &prefixPathType,
+											Backend:  existingPath.Backend,
 										},
 									},
 								},
@@ -273,14 +275,14 @@ func CreateIngressComformanceTests(jig *TestJig, ns string, annotations map[stri
 		tests = append(tests, ConformanceTests{
 			fmt.Sprintf("should update SSL certificate with modified hostname %v", updatedTLSHost),
 			func() {
-				jig.Update(func(ing *networkingv1beta1.Ingress) {
-					newRules := []networkingv1beta1.IngressRule{}
+				jig.Update(func(ing *networkingv1.Ingress) {
+					newRules := []networkingv1.IngressRule{}
 					for _, rule := range ing.Spec.Rules {
 						if rule.Host != tlsHost {
 							newRules = append(newRules, rule)
 							continue
 						}
-						newRules = append(newRules, networkingv1beta1.IngressRule{
+						newRules = append(newRules, networkingv1.IngressRule{
 							Host:             updatedTLSHost,
 							IngressRuleValue: rule.IngressRuleValue,
 						})
@@ -417,7 +419,7 @@ type TestJig struct {
 
 	RootCAs map[string][]byte
 	Address string
-	Ingress *networkingv1beta1.Ingress
+	Ingress *networkingv1.Ingress
 	// class is the value of the annotation keyed under
 	// `kubernetes.io/ingress.class`. It's added to all ingresses created by
 	// this jig.
@@ -483,10 +485,7 @@ func (j *TestJig) CreateIngress(manifestPath, ns string, ingAnnotations map[stri
 	j.Ingress, err = ingressFromManifest(filepath.Join(manifestPath, "ing.yaml"))
 	framework.ExpectNoError(err)
 	j.Ingress.Namespace = ns
-	j.Ingress.Annotations = map[string]string{IngressClassKey: j.Class}
-	for k, v := range ingAnnotations {
-		j.Ingress.Annotations[k] = v
-	}
+	j.Ingress.Spec.IngressClassName = &j.Class
 	j.Logger.Infof("creating %v ingress", j.Ingress.Name)
 	j.Ingress, err = j.runCreate(j.Ingress)
 	framework.ExpectNoError(err)
@@ -505,8 +504,8 @@ func marshalToYaml(obj runtime.Object, gv schema.GroupVersion) ([]byte, error) {
 }
 
 // ingressFromManifest reads a .json/yaml file and returns the ingress in it.
-func ingressFromManifest(fileName string) (*networkingv1beta1.Ingress, error) {
-	var ing networkingv1beta1.Ingress
+func ingressFromManifest(fileName string) (*networkingv1.Ingress, error) {
+	var ing networkingv1.Ingress
 	data, err := e2etestfiles.Read(fileName)
 	if err != nil {
 		return nil, err
@@ -524,8 +523,8 @@ func ingressFromManifest(fileName string) (*networkingv1beta1.Ingress, error) {
 
 // ingressToManifest generates a yaml file in the given path with the given ingress.
 // Assumes that a directory exists at the given path.
-func ingressToManifest(ing *networkingv1beta1.Ingress, path string) error {
-	serialized, err := marshalToYaml(ing, networkingv1beta1.SchemeGroupVersion)
+func ingressToManifest(ing *networkingv1.Ingress, path string) error {
+	serialized, err := marshalToYaml(ing, networkingv1.SchemeGroupVersion)
 	if err != nil {
 		return fmt.Errorf("failed to marshal ingress %v to YAML: %v", ing, err)
 	}
@@ -537,9 +536,9 @@ func ingressToManifest(ing *networkingv1beta1.Ingress, path string) error {
 }
 
 // runCreate runs the required command to create the given ingress.
-func (j *TestJig) runCreate(ing *networkingv1beta1.Ingress) (*networkingv1beta1.Ingress, error) {
+func (j *TestJig) runCreate(ing *networkingv1.Ingress) (*networkingv1.Ingress, error) {
 	if j.Class != MulticlusterIngressClassValue {
-		return j.Client.NetworkingV1beta1().Ingresses(ing.Namespace).Create(context.TODO(), ing, metav1.CreateOptions{})
+		return j.Client.NetworkingV1().Ingresses(ing.Namespace).Create(context.TODO(), ing, metav1.CreateOptions{})
 	}
 	// Use kubemci to create a multicluster ingress.
 	filePath := framework.TestContext.OutputDir + "/mci.yaml"
@@ -551,9 +550,9 @@ func (j *TestJig) runCreate(ing *networkingv1beta1.Ingress) (*networkingv1beta1.
 }
 
 // runUpdate runs the required command to update the given ingress.
-func (j *TestJig) runUpdate(ing *networkingv1beta1.Ingress) (*networkingv1beta1.Ingress, error) {
+func (j *TestJig) runUpdate(ing *networkingv1.Ingress) (*networkingv1.Ingress, error) {
 	if j.Class != MulticlusterIngressClassValue {
-		return j.Client.NetworkingV1beta1().Ingresses(ing.Namespace).Update(context.TODO(), ing, metav1.UpdateOptions{})
+		return j.Client.NetworkingV1().Ingresses(ing.Namespace).Update(context.TODO(), ing, metav1.UpdateOptions{})
 	}
 	// Use kubemci to update a multicluster ingress.
 	// kubemci does not have an update command. We use "create --force" to update an existing ingress.
@@ -574,11 +573,11 @@ func DescribeIng(ns string) {
 }
 
 // Update retrieves the ingress, performs the passed function, and then updates it.
-func (j *TestJig) Update(update func(ing *networkingv1beta1.Ingress)) {
+func (j *TestJig) Update(update func(ing *networkingv1.Ingress)) {
 	var err error
 	ns, name := j.Ingress.Namespace, j.Ingress.Name
 	for i := 0; i < 3; i++ {
-		j.Ingress, err = j.Client.NetworkingV1beta1().Ingresses(ns).Get(context.TODO(), name, metav1.GetOptions{})
+		j.Ingress, err = j.Client.NetworkingV1().Ingresses(ns).Get(context.TODO(), name, metav1.GetOptions{})
 		if err != nil {
 			framework.Failf("failed to get ingress %s/%s: %v", ns, name, err)
 		}
@@ -602,8 +601,8 @@ func (j *TestJig) AddHTTPS(secretName string, hosts ...string) {
 	_, cert, _, err := createTLSSecret(j.Client, j.Ingress.Namespace, secretName, hosts...)
 	framework.ExpectNoError(err)
 	j.Logger.Infof("Updating ingress %v to also use secret %v for TLS termination", j.Ingress.Name, secretName)
-	j.Update(func(ing *networkingv1beta1.Ingress) {
-		ing.Spec.TLS = append(ing.Spec.TLS, networkingv1beta1.IngressTLS{Hosts: hosts, SecretName: secretName})
+	j.Update(func(ing *networkingv1.Ingress) {
+		ing.Spec.TLS = append(ing.Spec.TLS, networkingv1.IngressTLS{Hosts: hosts, SecretName: secretName})
 	})
 	j.RootCAs[secretName] = cert
 }
@@ -613,8 +612,8 @@ func (j *TestJig) SetHTTPS(secretName string, hosts ...string) {
 	_, cert, _, err := createTLSSecret(j.Client, j.Ingress.Namespace, secretName, hosts...)
 	framework.ExpectNoError(err)
 	j.Logger.Infof("Updating ingress %v to only use secret %v for TLS termination", j.Ingress.Name, secretName)
-	j.Update(func(ing *networkingv1beta1.Ingress) {
-		ing.Spec.TLS = []networkingv1beta1.IngressTLS{{Hosts: hosts, SecretName: secretName}}
+	j.Update(func(ing *networkingv1.Ingress) {
+		ing.Spec.TLS = []networkingv1.IngressTLS{{Hosts: hosts, SecretName: secretName}}
 	})
 	j.RootCAs = map[string][]byte{secretName: cert}
 }
@@ -622,14 +621,14 @@ func (j *TestJig) SetHTTPS(secretName string, hosts ...string) {
 // RemoveHTTPS updates the ingress to not use this secret for TLS.
 // Note: Does not delete the secret.
 func (j *TestJig) RemoveHTTPS(secretName string) {
-	newTLS := []networkingv1beta1.IngressTLS{}
+	newTLS := []networkingv1.IngressTLS{}
 	for _, ingressTLS := range j.Ingress.Spec.TLS {
 		if secretName != ingressTLS.SecretName {
 			newTLS = append(newTLS, ingressTLS)
 		}
 	}
 	j.Logger.Infof("Updating ingress %v to not use secret %v for TLS termination", j.Ingress.Name, secretName)
-	j.Update(func(ing *networkingv1beta1.Ingress) {
+	j.Update(func(ing *networkingv1.Ingress) {
 		ing.Spec.TLS = newTLS
 	})
 	delete(j.RootCAs, secretName)
@@ -660,16 +659,16 @@ func (j *TestJig) TryDeleteIngress() {
 	j.tryDeleteGivenIngress(j.Ingress)
 }
 
-func (j *TestJig) tryDeleteGivenIngress(ing *networkingv1beta1.Ingress) {
+func (j *TestJig) tryDeleteGivenIngress(ing *networkingv1.Ingress) {
 	if err := j.runDelete(ing); err != nil {
 		j.Logger.Infof("Error while deleting the ingress %v/%v with class %s: %v", ing.Namespace, ing.Name, j.Class, err)
 	}
 }
 
 // runDelete runs the required command to delete the given ingress.
-func (j *TestJig) runDelete(ing *networkingv1beta1.Ingress) error {
+func (j *TestJig) runDelete(ing *networkingv1.Ingress) error {
 	if j.Class != MulticlusterIngressClassValue {
-		return j.Client.NetworkingV1beta1().Ingresses(ing.Namespace).Delete(context.TODO(), ing.Name, metav1.DeleteOptions{})
+		return j.Client.NetworkingV1().Ingresses(ing.Namespace).Delete(context.TODO(), ing.Name, metav1.DeleteOptions{})
 	}
 	// Use kubemci to delete a multicluster ingress.
 	filePath := framework.TestContext.OutputDir + "/mci.yaml"
@@ -709,7 +708,7 @@ func getIngressAddress(client clientset.Interface, ns, name, class string) ([]st
 	if class == MulticlusterIngressClassValue {
 		return getIngressAddressFromKubemci(name)
 	}
-	ing, err := client.NetworkingV1beta1().Ingresses(ns).Get(context.TODO(), name, metav1.GetOptions{})
+	ing, err := client.NetworkingV1().Ingresses(ns).Get(context.TODO(), name, metav1.GetOptions{})
 	if err != nil {
 		return nil, err
 	}
@@ -741,7 +740,7 @@ func (j *TestJig) WaitForIngressAddress(c clientset.Interface, ns, ingName strin
 	return address, err
 }
 
-func (j *TestJig) pollIngressWithCert(ing *networkingv1beta1.Ingress, address string, knownHosts []string, cert []byte, waitForNodePort bool, timeout time.Duration) error {
+func (j *TestJig) pollIngressWithCert(ing *networkingv1.Ingress, address string, knownHosts []string, cert []byte, waitForNodePort bool, timeout time.Duration) error {
 	// Check that all rules respond to a simple GET.
 	knownHostsSet := sets.NewString(knownHosts...)
 	for _, rules := range ing.Spec.Rules {
@@ -758,9 +757,9 @@ func (j *TestJig) pollIngressWithCert(ing *networkingv1beta1.Ingress, address st
 		}
 		for _, p := range rules.IngressRuleValue.HTTP.Paths {
 			if waitForNodePort {
-				nodePort := int(p.Backend.ServicePort.IntVal)
-				if err := j.pollServiceNodePort(ing.Namespace, p.Backend.ServiceName, nodePort); err != nil {
-					j.Logger.Infof("Error in waiting for nodeport %d on service %v/%v: %s", nodePort, ing.Namespace, p.Backend.ServiceName, err)
+				nodePort := int(p.Backend.Service.Port.Number)
+				if err := j.pollServiceNodePort(ing.Namespace, p.Backend.Service.Name, nodePort); err != nil {
+					j.Logger.Infof("Error in waiting for nodeport %d on service %v/%v: %s", nodePort, ing.Namespace, p.Backend.Service.Name, err)
 					return err
 				}
 			}
@@ -801,7 +800,7 @@ func (j *TestJig) WaitForIngressToStable() {
 // http or https). If waitForNodePort is true, the NodePort of the Service
 // is verified before verifying the Ingress. NodePort is currently a
 // requirement for cloudprovider Ingress.
-func (j *TestJig) WaitForGivenIngressWithTimeout(ing *networkingv1beta1.Ingress, waitForNodePort bool, timeout time.Duration) error {
+func (j *TestJig) WaitForGivenIngressWithTimeout(ing *networkingv1.Ingress, waitForNodePort bool, timeout time.Duration) error {
 	// Wait for the loadbalancer IP.
 	address, err := j.WaitForIngressAddress(j.Client, ing.Namespace, ing.Name, timeout)
 	if err != nil {
@@ -935,12 +934,12 @@ func (j *TestJig) GetServicePorts(includeDefaultBackend bool) map[string]v1.Serv
 	}
 
 	backendSvcs := []string{}
-	if j.Ingress.Spec.Backend != nil {
-		backendSvcs = append(backendSvcs, j.Ingress.Spec.Backend.ServiceName)
+	if j.Ingress.Spec.DefaultBackend != nil {
+		backendSvcs = append(backendSvcs, j.Ingress.Spec.DefaultBackend.Service.Name)
 	}
 	for _, rule := range j.Ingress.Spec.Rules {
 		for _, ingPath := range rule.HTTP.Paths {
-			backendSvcs = append(backendSvcs, ingPath.Backend.ServiceName)
+			backendSvcs = append(backendSvcs, ingPath.Backend.Service.Name)
 		}
 	}
 	for _, svcName := range backendSvcs {
@@ -1055,19 +1054,20 @@ func (cont *NginxIngressController) TearDown() {
 	e2eservice.WaitForServiceDeletedWithFinalizer(cont.Client, cont.Ns, cont.lbSvc.Name)
 }
 
-func generateBacksideHTTPSIngressSpec(ns string) *networkingv1beta1.Ingress {
-	return &networkingv1beta1.Ingress{
+func generateBacksideHTTPSIngressSpec(ns string) *networkingv1.Ingress {
+	return &networkingv1.Ingress{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "echoheaders-https",
 			Namespace: ns,
 		},
-		Spec: networkingv1beta1.IngressSpec{
+		Spec: networkingv1.IngressSpec{
 			// Note kubemci requires a default backend.
-			Backend: &networkingv1beta1.IngressBackend{
-				ServiceName: "echoheaders-https",
-				ServicePort: intstr.IntOrString{
-					Type:   intstr.Int,
-					IntVal: 443,
+			DefaultBackend: &networkingv1.IngressBackend{
+				Service: &networkingv1.IngressServiceBackend{
+					Name: "echoheaders-https",
+					Port: networkingv1.ServiceBackendPort{
+						Number: 443,
+					},
 				},
 			},
 		},
@@ -1130,7 +1130,7 @@ func generateBacksideHTTPSDeploymentSpec() *appsv1.Deployment {
 }
 
 // SetUpBacksideHTTPSIngress sets up deployment, service and ingress with backside HTTPS configured.
-func (j *TestJig) SetUpBacksideHTTPSIngress(cs clientset.Interface, namespace string, staticIPName string) (*appsv1.Deployment, *v1.Service, *networkingv1beta1.Ingress, error) {
+func (j *TestJig) SetUpBacksideHTTPSIngress(cs clientset.Interface, namespace string, staticIPName string) (*appsv1.Deployment, *v1.Service, *networkingv1.Ingress, error) {
 	deployCreated, err := cs.AppsV1().Deployments(namespace).Create(context.TODO(), generateBacksideHTTPSDeploymentSpec(), metav1.CreateOptions{})
 	if err != nil {
 		return nil, nil, nil, err
@@ -1154,7 +1154,7 @@ func (j *TestJig) SetUpBacksideHTTPSIngress(cs clientset.Interface, namespace st
 }
 
 // DeleteTestResource deletes given deployment, service and ingress.
-func (j *TestJig) DeleteTestResource(cs clientset.Interface, deploy *appsv1.Deployment, svc *v1.Service, ing *networkingv1beta1.Ingress) []error {
+func (j *TestJig) DeleteTestResource(cs clientset.Interface, deploy *appsv1.Deployment, svc *v1.Service, ing *networkingv1.Ingress) []error {
 	var errs []error
 	if ing != nil {
 		if err := j.runDelete(ing); err != nil {

--- a/test/e2e/framework/ingress/ingress_utils.go
+++ b/test/e2e/framework/ingress/ingress_utils.go
@@ -420,9 +420,9 @@ type TestJig struct {
 	RootCAs map[string][]byte
 	Address string
 	Ingress *networkingv1.Ingress
-	// class is the value of the annotation keyed under
-	// `kubernetes.io/ingress.class`. It's added to all ingresses created by
-	// this jig.
+	// class was the value of the annotation keyed under `kubernetes.io/ingress.class`.
+	// A new ingressClassName field has been added that is used to reference the IngressClass.
+	// It's added to all ingresses created by this jig.
 	Class string
 
 	// The interval used to poll urls
@@ -485,7 +485,9 @@ func (j *TestJig) CreateIngress(manifestPath, ns string, ingAnnotations map[stri
 	j.Ingress, err = ingressFromManifest(filepath.Join(manifestPath, "ing.yaml"))
 	framework.ExpectNoError(err)
 	j.Ingress.Namespace = ns
-	j.Ingress.Spec.IngressClassName = &j.Class
+	if j.Class != "" {
+		j.Ingress.Spec.IngressClassName = &j.Class
+	}
 	j.Logger.Infof("creating %v ingress", j.Ingress.Name)
 	j.Ingress, err = j.runCreate(j.Ingress)
 	framework.ExpectNoError(err)

--- a/test/e2e/framework/ingress/ingress_utils.go
+++ b/test/e2e/framework/ingress/ingress_utils.go
@@ -220,7 +220,7 @@ func CreateIngressComformanceTests(jig *TestJig, ns string, annotations map[stri
 	updatedTLSHost := "foobar.com"
 	updateURLMapHost := "bar.baz.com"
 	updateURLMapPath := "/testurl"
-	prefixPathType := networkingv1.PathTypePrefix
+	prefixPathType := networkingv1.PathTypeImplementationSpecific
 	// Platform agnostic list of tests that must be satisfied by all controllers
 	tests := []ConformanceTests{
 		{

--- a/test/e2e/framework/ingress/ingress_utils_test.go
+++ b/test/e2e/framework/ingress/ingress_utils_test.go
@@ -22,11 +22,11 @@ import (
 	"path/filepath"
 	"testing"
 
-	networkingv1beta1 "k8s.io/api/networking/v1beta1"
+	networkingv1 "k8s.io/api/networking/v1"
 )
 
 func TestIngressToManifest(t *testing.T) {
-	ing := &networkingv1beta1.Ingress{}
+	ing := &networkingv1.Ingress{}
 	// Create a temp dir.
 	tmpDir, err := ioutil.TempDir("", "kubemci")
 	if err != nil {

--- a/test/e2e/network/ingress.go
+++ b/test/e2e/network/ingress.go
@@ -685,6 +685,11 @@ var _ = common.SIGDescribe("Loadbalancing: L7", func() {
 		var nginxController *e2eingress.NginxIngressController
 
 		ginkgo.BeforeEach(func() {
+			// Skip until nginx-ingress controller works against kubernetes 1.22+
+			// Those versions no longer server ingress v1beta1
+			// xref: https://github.com/kubernetes/ingress-nginx/issues/7145
+			e2eskipper.Skipf("Skipping because nginx-controller requires ingress/v1beta1 API")
+
 			e2eskipper.SkipUnlessProviderIs("gce", "gke")
 			ginkgo.By("Initializing nginx controller")
 			jig.Class = "nginx"

--- a/test/e2e/network/ingress.go
+++ b/test/e2e/network/ingress.go
@@ -29,7 +29,6 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
-	networkingv1beta1 "k8s.io/api/networking/v1beta1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -141,7 +140,7 @@ var _ = common.SIGDescribe("Loadbalancing: L7", func() {
 			ginkgo.By(fmt.Sprintf("waiting for Ingress %s to get instance group annotation", name))
 			propagationTimeout := e2eservice.GetServiceLoadBalancerPropagationTimeout(f.ClientSet)
 			pollErr := wait.Poll(2*time.Second, propagationTimeout, func() (bool, error) {
-				ing, err := f.ClientSet.NetworkingV1beta1().Ingresses(ns).Get(context.TODO(), name, metav1.GetOptions{})
+				ing, err := f.ClientSet.NetworkingV1().Ingresses(ns).Get(context.TODO(), name, metav1.GetOptions{})
 				framework.ExpectNoError(err)
 				annotations := ing.Annotations
 				if annotations == nil || annotations[instanceGroupAnnotation] == "" {
@@ -162,7 +161,7 @@ var _ = common.SIGDescribe("Loadbalancing: L7", func() {
 			scKey := e2eingress.StatusPrefix + "/ssl-cert"
 			beKey := e2eingress.StatusPrefix + "/backends"
 			wait.Poll(2*time.Second, time.Minute, func() (bool, error) {
-				ing, err := f.ClientSet.NetworkingV1beta1().Ingresses(ns).Get(context.TODO(), name, metav1.GetOptions{})
+				ing, err := f.ClientSet.NetworkingV1().Ingresses(ns).Get(context.TODO(), name, metav1.GetOptions{})
 				framework.ExpectNoError(err)
 				annotations := ing.Annotations
 				if annotations != nil && (annotations[umKey] != "" || annotations[fwKey] != "" ||
@@ -972,7 +971,7 @@ var _ = common.SIGDescribe("Ingress API", func() {
 			framework.ExpectNoError(err)
 			found := false
 			for _, group := range discoveryGroups.Groups {
-				if group.Name == networkingv1beta1.GroupName {
+				if group.Name == networkingv1.GroupName {
 					for _, version := range group.Versions {
 						if version.Version == ingVersion {
 							found = true

--- a/test/e2e/network/ingress.go
+++ b/test/e2e/network/ingress.go
@@ -131,11 +131,10 @@ var _ = common.SIGDescribe("Loadbalancing: L7", func() {
 			}
 		})
 
-		ginkgo.It("multicluster ingress should get instance group annotation", func() {
+		ginkgo.It("multicluster ingress should get instance group annotation [Feature:kubemci]", func() {
 			name := "echomap"
-			jig.CreateIngress(filepath.Join(e2eingress.IngressManifestPath, "http"), ns, map[string]string{
-				e2eingress.IngressClassKey: e2eingress.MulticlusterIngressClassValue,
-			}, map[string]string{})
+			jig.Class = e2eingress.MulticlusterIngressClassValue
+			jig.CreateIngress(filepath.Join(e2eingress.IngressManifestPath, "http"), ns, map[string]string{}, map[string]string{})
 
 			ginkgo.By(fmt.Sprintf("waiting for Ingress %s to get instance group annotation", name))
 			propagationTimeout := e2eservice.GetServiceLoadBalancerPropagationTimeout(f.ClientSet)

--- a/test/e2e/network/ingress.go
+++ b/test/e2e/network/ingress.go
@@ -926,7 +926,7 @@ var _ = common.SIGDescribe("Ingress API", func() {
 		ingVersion := "v1"
 		ingClient := f.ClientSet.NetworkingV1().Ingresses(ns)
 
-		prefixPathType := networkingv1.PathTypePrefix
+		prefixPathType := networkingv1.PathTypeImplementationSpecific
 		serviceBackend := &networkingv1.IngressServiceBackend{
 			Name: "default-backend",
 			Port: networkingv1.ServiceBackendPort{

--- a/test/e2e/network/ingressclass.go
+++ b/test/e2e/network/ingressclass.go
@@ -23,7 +23,6 @@ import (
 	"time"
 
 	networkingv1 "k8s.io/api/networking/v1"
-	networkingv1beta1 "k8s.io/api/networking/v1beta1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
@@ -114,7 +113,7 @@ func createIngressClass(cs clientset.Interface, name string, isDefault bool, uni
 	}
 
 	if isDefault {
-		ingressClass.Annotations = map[string]string{networkingv1beta1.AnnotationIsDefaultIngressClass: "true"}
+		ingressClass.Annotations = map[string]string{networkingv1.AnnotationIsDefaultIngressClass: "true"}
 	}
 
 	return cs.NetworkingV1().IngressClasses().Create(context.TODO(), ingressClass, metav1.CreateOptions{})

--- a/test/e2e/network/loadbalancer.go
+++ b/test/e2e/network/loadbalancer.go
@@ -689,7 +689,7 @@ var _ = common.SIGDescribe("LoadBalancers", func() {
 	// This test creates a load balancer, make sure its health check interval
 	// equals to gceHcCheckIntervalSeconds. Then the interval is manipulated
 	// to be something else, see if the interval will be reconciled.
-	ginkgo.It("should reconcile LB health check interval [Slow][Serial]", func() {
+	ginkgo.It("should reconcile LB health check interval [Slow][Serial][Disruptive]", func() {
 		const gceHcCheckIntervalSeconds = int64(8)
 		// This test is for clusters on GCE.
 		// (It restarts kube-controller-manager, which we don't support on GKE)

--- a/test/e2e/network/scale/ingress.go
+++ b/test/e2e/network/scale/ingress.go
@@ -383,6 +383,7 @@ func (f *IngressScaleFramework) createScaleTestServiceIngress(suffix string, ena
 }
 
 func generateScaleTestIngressSpec(suffix string, enableTLS bool) *networkingv1.Ingress {
+	prefixPathType := networkingv1.PathTypePrefix
 	ing := &networkingv1.Ingress{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: fmt.Sprintf("%s-%s", scaleTestIngressNamePrefix, suffix),
@@ -398,7 +399,8 @@ func generateScaleTestIngressSpec(suffix string, enableTLS bool) *networkingv1.I
 						HTTP: &networkingv1.HTTPIngressRuleValue{
 							Paths: []networkingv1.HTTPIngressPath{
 								{
-									Path: "/scale",
+									Path:     "/scale",
+									PathType: &prefixPathType,
 									Backend: networkingv1.IngressBackend{
 										Service: &networkingv1.IngressServiceBackend{
 											Name: fmt.Sprintf("%s-%s", scaleTestBackendName, suffix),

--- a/test/e2e/network/scale/ingress.go
+++ b/test/e2e/network/scale/ingress.go
@@ -25,7 +25,7 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
-	networkingv1beta1 "k8s.io/api/networking/v1beta1"
+	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	clientset "k8s.io/client-go/kubernetes"
@@ -76,7 +76,7 @@ type IngressScaleFramework struct {
 
 	ScaleTestDeploy *appsv1.Deployment
 	ScaleTestSvcs   []*v1.Service
-	ScaleTestIngs   []*networkingv1beta1.Ingress
+	ScaleTestIngs   []*networkingv1.Ingress
 
 	// BatchCreateLatencies stores all ingress creation latencies, in different
 	// batches.
@@ -123,7 +123,7 @@ func (f *IngressScaleFramework) PrepareScaleTest() error {
 	}
 
 	f.ScaleTestSvcs = []*v1.Service{}
-	f.ScaleTestIngs = []*networkingv1beta1.Ingress{}
+	f.ScaleTestIngs = []*networkingv1.Ingress{}
 
 	return nil
 }
@@ -135,7 +135,7 @@ func (f *IngressScaleFramework) CleanupScaleTest() []error {
 	f.Logger.Infof("Cleaning up ingresses...")
 	for _, ing := range f.ScaleTestIngs {
 		if ing != nil {
-			if err := f.Clientset.NetworkingV1beta1().Ingresses(ing.Namespace).Delete(context.TODO(), ing.Name, metav1.DeleteOptions{}); err != nil {
+			if err := f.Clientset.NetworkingV1().Ingresses(ing.Namespace).Delete(context.TODO(), ing.Name, metav1.DeleteOptions{}); err != nil {
 				errs = append(errs, fmt.Errorf("error while deleting ingress %s/%s: %v", ing.Namespace, ing.Name, err))
 			}
 		}
@@ -192,7 +192,7 @@ func (f *IngressScaleFramework) RunScaleTest() []error {
 		numIngsToCreate := numIngsNeeded - numIngsCreated
 		ingWg.Add(numIngsToCreate)
 		svcQueue := make(chan *v1.Service, numIngsToCreate)
-		ingQueue := make(chan *networkingv1beta1.Ingress, numIngsToCreate)
+		ingQueue := make(chan *networkingv1.Ingress, numIngsToCreate)
 		errQueue := make(chan error, numIngsToCreate)
 		latencyQueue := make(chan time.Duration, numIngsToCreate)
 		start := time.Now()
@@ -272,14 +272,14 @@ func (f *IngressScaleFramework) RunScaleTest() []error {
 		f.StepCreateLatencies = append(f.StepCreateLatencies, elapsed)
 
 		f.Logger.Infof("Updating ingress and wait for change to take effect")
-		ingToUpdate, err := f.Clientset.NetworkingV1beta1().Ingresses(f.Namespace).Get(context.TODO(), ingCreated.Name, metav1.GetOptions{})
+		ingToUpdate, err := f.Clientset.NetworkingV1().Ingresses(f.Namespace).Get(context.TODO(), ingCreated.Name, metav1.GetOptions{})
 		if err != nil {
 			errs = append(errs, err)
 			return
 		}
 		addTestPathToIngress(ingToUpdate)
 		start = time.Now()
-		ingToUpdate, err = f.Clientset.NetworkingV1beta1().Ingresses(f.Namespace).Update(context.TODO(), ingToUpdate, metav1.UpdateOptions{})
+		ingToUpdate, err = f.Clientset.NetworkingV1().Ingresses(f.Namespace).Update(context.TODO(), ingToUpdate, metav1.UpdateOptions{})
 		if err != nil {
 			errs = append(errs, err)
 			return
@@ -359,49 +359,52 @@ func (f *IngressScaleFramework) GetFormattedLatencies() string {
 	return res
 }
 
-func addTestPathToIngress(ing *networkingv1beta1.Ingress) {
+func addTestPathToIngress(ing *networkingv1.Ingress) {
+	prefixPathType := networkingv1.PathTypePrefix
 	ing.Spec.Rules[0].IngressRuleValue.HTTP.Paths = append(
 		ing.Spec.Rules[0].IngressRuleValue.HTTP.Paths,
-		networkingv1beta1.HTTPIngressPath{
-			Path:    "/test",
-			Backend: ing.Spec.Rules[0].IngressRuleValue.HTTP.Paths[0].Backend,
+		networkingv1.HTTPIngressPath{
+			Path:     "/test",
+			PathType: &prefixPathType,
+			Backend:  ing.Spec.Rules[0].IngressRuleValue.HTTP.Paths[0].Backend,
 		})
 }
 
-func (f *IngressScaleFramework) createScaleTestServiceIngress(suffix string, enableTLS bool) (*v1.Service, *networkingv1beta1.Ingress, error) {
+func (f *IngressScaleFramework) createScaleTestServiceIngress(suffix string, enableTLS bool) (*v1.Service, *networkingv1.Ingress, error) {
 	svcCreated, err := f.Clientset.CoreV1().Services(f.Namespace).Create(context.TODO(), generateScaleTestServiceSpec(suffix), metav1.CreateOptions{})
 	if err != nil {
 		return nil, nil, err
 	}
-	ingCreated, err := f.Clientset.NetworkingV1beta1().Ingresses(f.Namespace).Create(context.TODO(), generateScaleTestIngressSpec(suffix, enableTLS), metav1.CreateOptions{})
+	ingCreated, err := f.Clientset.NetworkingV1().Ingresses(f.Namespace).Create(context.TODO(), generateScaleTestIngressSpec(suffix, enableTLS), metav1.CreateOptions{})
 	if err != nil {
 		return nil, nil, err
 	}
 	return svcCreated, ingCreated, nil
 }
 
-func generateScaleTestIngressSpec(suffix string, enableTLS bool) *networkingv1beta1.Ingress {
-	ing := &networkingv1beta1.Ingress{
+func generateScaleTestIngressSpec(suffix string, enableTLS bool) *networkingv1.Ingress {
+	ing := &networkingv1.Ingress{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: fmt.Sprintf("%s-%s", scaleTestIngressNamePrefix, suffix),
 		},
-		Spec: networkingv1beta1.IngressSpec{
-			TLS: []networkingv1beta1.IngressTLS{
+		Spec: networkingv1.IngressSpec{
+			TLS: []networkingv1.IngressTLS{
 				{SecretName: scaleTestSecretName},
 			},
-			Rules: []networkingv1beta1.IngressRule{
+			Rules: []networkingv1.IngressRule{
 				{
 					Host: scaleTestHostname,
-					IngressRuleValue: networkingv1beta1.IngressRuleValue{
-						HTTP: &networkingv1beta1.HTTPIngressRuleValue{
-							Paths: []networkingv1beta1.HTTPIngressPath{
+					IngressRuleValue: networkingv1.IngressRuleValue{
+						HTTP: &networkingv1.HTTPIngressRuleValue{
+							Paths: []networkingv1.HTTPIngressPath{
 								{
 									Path: "/scale",
-									Backend: networkingv1beta1.IngressBackend{
-										ServiceName: fmt.Sprintf("%s-%s", scaleTestBackendName, suffix),
-										ServicePort: intstr.IntOrString{
-											Type:   intstr.Int,
-											IntVal: 80,
+									Backend: networkingv1.IngressBackend{
+										Service: &networkingv1.IngressServiceBackend{
+											Name: fmt.Sprintf("%s-%s", scaleTestBackendName, suffix),
+											Port: networkingv1.ServiceBackendPort{
+												Number: 80,
+											},
 										},
 									},
 								},
@@ -413,7 +416,7 @@ func generateScaleTestIngressSpec(suffix string, enableTLS bool) *networkingv1be
 		},
 	}
 	if enableTLS {
-		ing.Spec.TLS = []networkingv1beta1.IngressTLS{
+		ing.Spec.TLS = []networkingv1.IngressTLS{
 			{SecretName: scaleTestSecretName},
 		}
 	}

--- a/test/e2e/network/scale/ingress.go
+++ b/test/e2e/network/scale/ingress.go
@@ -360,7 +360,7 @@ func (f *IngressScaleFramework) GetFormattedLatencies() string {
 }
 
 func addTestPathToIngress(ing *networkingv1.Ingress) {
-	prefixPathType := networkingv1.PathTypePrefix
+	prefixPathType := networkingv1.PathTypeImplementationSpecific
 	ing.Spec.Rules[0].IngressRuleValue.HTTP.Paths = append(
 		ing.Spec.Rules[0].IngressRuleValue.HTTP.Paths,
 		networkingv1.HTTPIngressPath{
@@ -383,7 +383,7 @@ func (f *IngressScaleFramework) createScaleTestServiceIngress(suffix string, ena
 }
 
 func generateScaleTestIngressSpec(suffix string, enableTLS bool) *networkingv1.Ingress {
-	prefixPathType := networkingv1.PathTypePrefix
+	prefixPathType := networkingv1.PathTypeImplementationSpecific
 	ing := &networkingv1.Ingress{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: fmt.Sprintf("%s-%s", scaleTestIngressNamePrefix, suffix),

--- a/test/e2e/testing-manifests/ingress/gce/static-ip-2/ing.yaml
+++ b/test/e2e/testing-manifests/ingress/gce/static-ip-2/ing.yaml
@@ -1,4 +1,4 @@
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: static-ip
@@ -11,6 +11,9 @@ spec:
     http:
       paths:
       - path: /foo
+        pathType: "Prefix"
         backend:
-          serviceName: echoheaders-https
-          servicePort: 80
+          service:
+            name: echoheaders-https
+            port:
+              number: 80

--- a/test/e2e/testing-manifests/ingress/gce/static-ip-2/ing.yaml
+++ b/test/e2e/testing-manifests/ingress/gce/static-ip-2/ing.yaml
@@ -11,7 +11,7 @@ spec:
     http:
       paths:
       - path: /foo
-        pathType: "Prefix"
+        pathType: "ImplementationSpecific"
         backend:
           service:
             name: echoheaders-https

--- a/test/e2e/testing-manifests/ingress/http/ing.yaml
+++ b/test/e2e/testing-manifests/ingress/http/ing.yaml
@@ -1,28 +1,40 @@
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: echomap
 spec:
   # kubemci requires a default backend.
-  backend:
-    serviceName: echoheadersx
-    servicePort: 80
+  defaultBackend:
+    service:
+      name: echoheadersx
+      port:
+        number: 80
   rules:
   - host: foo.bar.com
     http:
       paths:
       - path: /foo
+        pathType: "Prefix"
         backend:
-          serviceName: echoheadersx
-          servicePort: 80
+          service:
+            name: echoheadersx
+            port:
+              number: 80
   - host: bar.baz.com
     http:
       paths:
       - path: /bar
+        pathType: "Prefix"
         backend:
-          serviceName: echoheadersy
-          servicePort: 80
+          service:
+            name: echoheadersy
+            port:
+              number: 80
       - path: /foo
+        pathType: "Prefix"
         backend:
-          serviceName: echoheadersx
-          servicePort: 80
+          service:
+            name: echoheadersx
+            port:
+              number: 80
+

--- a/test/e2e/testing-manifests/ingress/http/ing.yaml
+++ b/test/e2e/testing-manifests/ingress/http/ing.yaml
@@ -14,7 +14,7 @@ spec:
     http:
       paths:
       - path: /foo
-        pathType: "Prefix"
+        pathType: "ImplementationSpecific"
         backend:
           service:
             name: echoheadersx
@@ -24,14 +24,14 @@ spec:
     http:
       paths:
       - path: /bar
-        pathType: "Prefix"
+        pathType: "ImplementationSpecific"
         backend:
           service:
             name: echoheadersy
             port:
               number: 80
       - path: /foo
-        pathType: "Prefix"
+        pathType: "ImplementationSpecific"
         backend:
           service:
             name: echoheadersx

--- a/test/e2e/testing-manifests/ingress/http2/ing.yaml
+++ b/test/e2e/testing-manifests/ingress/http2/ing.yaml
@@ -1,9 +1,12 @@
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: echomap
 spec:
   # kubemci requires a default backend.
-  backend:
-    serviceName: echoheaders
-    servicePort: 443
+  defaultBackend:
+    service:
+      name: echoheaders
+      port:
+        number: 443
+

--- a/test/e2e/testing-manifests/ingress/multiple-certs/ing.yaml
+++ b/test/e2e/testing-manifests/ingress/multiple-certs/ing.yaml
@@ -1,4 +1,4 @@
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: multiple-certs
@@ -8,27 +8,39 @@ spec:
     http:
       paths:
       - path: /test
+        pathType: "Prefix"
         backend:
-          serviceName: echoheaders-https
-          servicePort: 80
+          service:
+            name: echoheaders-https
+            port:
+              number: 80
   - host: test2.ingress.com
     http:
       paths:
       - path: /test
+        pathType: "Prefix"
         backend:
-          serviceName: echoheaders-https
-          servicePort: 80
+          service:
+            name: echoheaders-https
+            port:
+              number: 80
   - host: test3.ingress.com
     http:
       paths:
       - path: /test
+        pathType: "Prefix"
         backend:
-          serviceName: echoheaders-https
-          servicePort: 80
+          service:
+            name: echoheaders-https
+            port:
+              number: 80
   - host: test4.ingress.com
     http:
       paths:
       - path: /test
+        pathType: "Prefix"
         backend:
-          serviceName: echoheaders-https
-          servicePort: 80
+          service:
+            name: echoheaders-https
+            port:
+              number: 80

--- a/test/e2e/testing-manifests/ingress/multiple-certs/ing.yaml
+++ b/test/e2e/testing-manifests/ingress/multiple-certs/ing.yaml
@@ -8,7 +8,7 @@ spec:
     http:
       paths:
       - path: /test
-        pathType: "Prefix"
+        pathType: "ImplementationSpecific"
         backend:
           service:
             name: echoheaders-https
@@ -18,7 +18,7 @@ spec:
     http:
       paths:
       - path: /test
-        pathType: "Prefix"
+        pathType: "ImplementationSpecific"
         backend:
           service:
             name: echoheaders-https
@@ -28,7 +28,7 @@ spec:
     http:
       paths:
       - path: /test
-        pathType: "Prefix"
+        pathType: "ImplementationSpecific"
         backend:
           service:
             name: echoheaders-https
@@ -38,7 +38,7 @@ spec:
     http:
       paths:
       - path: /test
-        pathType: "Prefix"
+        pathType: "ImplementationSpecific"
         backend:
           service:
             name: echoheaders-https

--- a/test/e2e/testing-manifests/ingress/neg-clusterip/ing.yaml
+++ b/test/e2e/testing-manifests/ingress/neg-clusterip/ing.yaml
@@ -1,8 +1,10 @@
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: hostname
 spec:
-  backend:
-    serviceName: hostname
-    servicePort: 80
+  defaultBackend:
+    service:
+      name: hostname
+      port:
+        number: 80

--- a/test/e2e/testing-manifests/ingress/neg-exposed/ing.yaml
+++ b/test/e2e/testing-manifests/ingress/neg-exposed/ing.yaml
@@ -1,8 +1,10 @@
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: hostname
 spec:
-  backend:
-    serviceName: hostname
-    servicePort: 80
+  defaultBackend:
+    service:
+      name: hostname
+      port:
+        number: 80

--- a/test/e2e/testing-manifests/ingress/neg/ing.yaml
+++ b/test/e2e/testing-manifests/ingress/neg/ing.yaml
@@ -1,8 +1,10 @@
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: hostname
 spec:
-  backend:
-    serviceName: hostname
-    servicePort: 80
+  defaultBackend:
+    service:
+      name: hostname
+      port:
+        number: 80

--- a/test/e2e/testing-manifests/ingress/nginx/rc.yaml
+++ b/test/e2e/testing-manifests/ingress/nginx/rc.yaml
@@ -17,7 +17,19 @@ spec:
     spec:
       terminationGracePeriodSeconds: 0
       containers:
-      - image: k8s.gcr.io/nginx-ingress-controller:0.9.0-beta.1
+      - image: k8s.gcr.io/ingress-nginx/controller:v0.46.0
+        args:
+        - /nginx-ingress-controller
+        - --election-id=ingress-controller-leader
+        - --ingress-class=nginx
+        securityContext:
+          capabilities:
+              drop:
+              - ALL
+              add:
+              - NET_BIND_SERVICE
+          runAsUser: 101
+          allowPrivilegeEscalation: true
         livenessProbe:
           httpGet:
             path: /healthz
@@ -41,11 +53,3 @@ spec:
           hostPort: 80
         - containerPort: 443
           hostPort: 443
-        # we expose 18080 to access nginx stats in url /nginx-status
-        # this is optional
-        - containerPort: 18080
-          hostPort: 18080
-        args:
-        - /nginx-ingress-controller
-        - --default-backend-service=kube-system/default-http-backend
-        - --publish-service=$(POD_NAMESPACE)/nginx-ingress-lb

--- a/test/e2e/testing-manifests/ingress/pre-shared-cert/ing.yaml
+++ b/test/e2e/testing-manifests/ingress/pre-shared-cert/ing.yaml
@@ -1,4 +1,4 @@
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: pre-shared-cert
@@ -7,14 +7,20 @@ metadata:
   #  ingress.gcp.kubernetes.io/pre-shared-cert: "test-pre-shared-cert"
 spec:
   # kubemci requires a default backend.
-  backend:
-    serviceName: echoheaders-https
-    servicePort: 80
+  defaultBackend:
+    service:
+      name: echoheaders-https
+      port:
+        number: 80
   rules:
   - host: test.ingress.com
     http:
       paths:
       - path: /test
+        pathType: "Prefix"
         backend:
-          serviceName: echoheaders-https
-          servicePort: 80
+          service:
+            name: echoheaders-https
+            port:
+              number: 80
+

--- a/test/e2e/testing-manifests/ingress/pre-shared-cert/ing.yaml
+++ b/test/e2e/testing-manifests/ingress/pre-shared-cert/ing.yaml
@@ -17,7 +17,7 @@ spec:
     http:
       paths:
       - path: /test
-        pathType: "Prefix"
+        pathType: "ImplementationSpecific"
         backend:
           service:
             name: echoheaders-https

--- a/test/e2e/testing-manifests/ingress/static-ip/ing.yaml
+++ b/test/e2e/testing-manifests/ingress/static-ip/ing.yaml
@@ -1,4 +1,4 @@
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: static-ip
@@ -10,6 +10,8 @@ spec:
   # This assumes tls-secret exists.
   # To generate it run the make in this directory.
   - secretName: tls-secret
-  backend:
-    serviceName: echoheaders-https
-    servicePort: 80
+  defaultBackend:
+    service:
+      name: echoheaders-https
+      port:
+        number: 80

--- a/test/fixtures/pkg/kubectl/cmd/convert/v1beta1ingress.yaml
+++ b/test/fixtures/pkg/kubectl/cmd/convert/v1beta1ingress.yaml
@@ -3,9 +3,11 @@ kind: Ingress
 metadata:
   name: example
 spec:
-  backend:
-    serviceName: default-backend
-    servicePort: 80
+  defaultBackend:
+    service:
+      name: default-backend
+      port:
+        number: 80
   rules:
   - http:
       paths:


### PR DESCRIPTION
/kind cleanup
/kind deprecation
/kind failing-test

#### What this PR does / why we need it:

Bump ingress tests from v1beta1 to v1



#### Which issue(s) this PR fixes:
Fixes #95309, #102006
xref: https://github.com/kubernetes/kubernetes/issues/43214

```release-note
ingress v1beta1 has been deprecated
```
