### PR TITLE
bug(staging_api_apps_v1): add descriptions to apps/v1/types.go files

### DIFF
--- a/hack/.descriptions_failures
+++ b/hack/.descriptions_failures
@@ -1,4 +1,3 @@
-./staging/src/k8s.io/api/apps/v1/types.go
 ./staging/src/k8s.io/api/apps/v1beta1/types.go
 ./staging/src/k8s.io/api/apps/v1beta2/types.go
 ./staging/src/k8s.io/api/autoscaling/v2beta2/types.go

--- a/staging/src/k8s.io/api/apps/v1/generated.proto
+++ b/staging/src/k8s.io/api/apps/v1/generated.proto
@@ -219,7 +219,8 @@ message DaemonSetUpdateStrategy {
 
 // Deployment enables declarative updates for Pods and ReplicaSets.
 message Deployment {
-  // Standard object metadata.
+  // Standard object's metadata.
+  // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
   // +optional
   optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
@@ -366,7 +367,8 @@ message DeploymentStrategy {
 message ReplicaSet {
   // If the Labels of a ReplicaSet are empty, they are defaulted to
   // be the same as the Pod(s) that the ReplicaSet manages.
-  // Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+  // Standard object's metadata.
+  // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
   // +optional
   optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
@@ -562,6 +564,8 @@ message RollingUpdateStatefulSetStrategy {
 // The StatefulSet guarantees that a given network identity will always
 // map to the same storage identity.
 message StatefulSet {
+  // Standard object's metadata.
+  // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
   // +optional
   optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
@@ -598,9 +602,12 @@ message StatefulSetCondition {
 
 // StatefulSetList is a collection of StatefulSets.
 message StatefulSetList {
+  // Standard list's metadata.
+  // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
   // +optional
   optional k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
 
+  // Items is the list of stateful sets.
   repeated StatefulSet items = 2;
 }
 

--- a/staging/src/k8s.io/api/apps/v1/types.go
+++ b/staging/src/k8s.io/api/apps/v1/types.go
@@ -45,6 +45,8 @@ const (
 // map to the same storage identity.
 type StatefulSet struct {
 	metav1.TypeMeta `json:",inline"`
+	// Standard object's metadata.
+	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
 	// +optional
 	metav1.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
 
@@ -241,9 +243,13 @@ type StatefulSetCondition struct {
 // StatefulSetList is a collection of StatefulSets.
 type StatefulSetList struct {
 	metav1.TypeMeta `json:",inline"`
+	// Standard list's metadata.
+	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
 	// +optional
 	metav1.ListMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
-	Items           []StatefulSet `json:"items" protobuf:"bytes,2,rep,name=items"`
+
+	// Items is the list of stateful sets.
+	Items []StatefulSet `json:"items" protobuf:"bytes,2,rep,name=items"`
 }
 
 // +genclient
@@ -255,7 +261,8 @@ type StatefulSetList struct {
 // Deployment enables declarative updates for Pods and ReplicaSets.
 type Deployment struct {
 	metav1.TypeMeta `json:",inline"`
-	// Standard object metadata.
+	// Standard object's metadata.
+	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
 	// +optional
 	metav1.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
 
@@ -693,7 +700,8 @@ type ReplicaSet struct {
 
 	// If the Labels of a ReplicaSet are empty, they are defaulted to
 	// be the same as the Pod(s) that the ReplicaSet manages.
-	// Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+	// Standard object's metadata.
+	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
 	// +optional
 	metav1.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
 

--- a/staging/src/k8s.io/api/apps/v1/types_swagger_doc_generated.go
+++ b/staging/src/k8s.io/api/apps/v1/types_swagger_doc_generated.go
@@ -125,7 +125,7 @@ func (DaemonSetUpdateStrategy) SwaggerDoc() map[string]string {
 
 var map_Deployment = map[string]string{
 	"":         "Deployment enables declarative updates for Pods and ReplicaSets.",
-	"metadata": "Standard object metadata.",
+	"metadata": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
 	"spec":     "Specification of the desired behavior of the Deployment.",
 	"status":   "Most recently observed status of the Deployment.",
 }
@@ -290,9 +290,10 @@ func (RollingUpdateStatefulSetStrategy) SwaggerDoc() map[string]string {
 }
 
 var map_StatefulSet = map[string]string{
-	"":       "StatefulSet represents a set of pods with consistent identities. Identities are defined as:\n - Network: A single stable DNS and hostname.\n - Storage: As many VolumeClaims as requested.\nThe StatefulSet guarantees that a given network identity will always map to the same storage identity.",
-	"spec":   "Spec defines the desired identities of pods in this set.",
-	"status": "Status is the current status of Pods in this StatefulSet. This data may be out of date by some window of time.",
+	"":         "StatefulSet represents a set of pods with consistent identities. Identities are defined as:\n - Network: A single stable DNS and hostname.\n - Storage: As many VolumeClaims as requested.\nThe StatefulSet guarantees that a given network identity will always map to the same storage identity.",
+	"metadata": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
+	"spec":     "Spec defines the desired identities of pods in this set.",
+	"status":   "Status is the current status of Pods in this StatefulSet. This data may be out of date by some window of time.",
 }
 
 func (StatefulSet) SwaggerDoc() map[string]string {
@@ -313,7 +314,9 @@ func (StatefulSetCondition) SwaggerDoc() map[string]string {
 }
 
 var map_StatefulSetList = map[string]string{
-	"": "StatefulSetList is a collection of StatefulSets.",
+	"":         "StatefulSetList is a collection of StatefulSets.",
+	"metadata": "Standard list's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
+	"items":    "Items is the list of stateful sets.",
 }
 
 func (StatefulSetList) SwaggerDoc() map[string]string {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

This PR adds descriptions for the following:

1. Metadata and List fields of Struct `StatefulSetLists`
2. Metadata field of Struct `StatefulSet`

#### Which issue(s) this PR fixes:

Ref #99675

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:


```docs

```