### PR TITLE
fix nil problem for volume stats check

### DIFF
--- a/pkg/kubelet/server/stats/volume_stat_calculator.go
+++ b/pkg/kubelet/server/stats/volume_stat_calculator.go
@@ -18,6 +18,7 @@ package stats
 
 import (
 	"fmt"
+	"reflect"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -112,7 +113,11 @@ func (s *volumeStatCalculator) calcAndStoreStats() {
 		for name, v := range blockVolumes {
 			// Only add the blockVolume if it implements the MetricsProvider interface
 			if _, ok := v.(volume.MetricsProvider); ok {
-				metricVolumes[name] = v
+				bv := reflect.ValueOf(v)
+				filed := bv.FieldByName("MetricsProvider")
+				if !filed.IsNil() {
+					metricVolumes[name] = v
+				}
 			}
 		}
 	}


### PR DESCRIPTION
#### What type of PR is this?
/kind bug
/sig storage node

#### What this PR does / why we need it:
A nil pointer problem after #97972 is merged.
/cc derekwaynecarr gnufied 
for #97972

I found this error in kubelet.log in https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-containerd-e2e-ubuntu-gce/1393978095261716480
```
E0516 17:38:37.820912    2881 runtime.go:78] Observed a panic: "invalid memory address or nil pointer dereference" (runtime error: invalid memory address or nil pointer dereference)
goroutine 63351 [running]:
k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/util/runtime.logPanic(0x4235a00, 0x7411320)
	/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:74 +0x95
k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/util/runtime.HandleCrash(0x0, 0x0, 0x0)
	/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:48 +0x86
panic(0x4235a00, 0x7411320)
	/usr/local/go/src/runtime/panic.go:965 +0x1b9
k8s.io/kubernetes/pkg/volume/local.(*localVolumeMapper).GetMetrics(0xc0026e95d0, 0xc002dd97d8, 0xc002dd9898, 0xc002448500)
	<autogenerated>:1 +0x32
k8s.io/kubernetes/pkg/kubelet/server/stats.(*volumeStatCalculator).calcAndStoreStats(0xc003330c60)
/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/pkg/kubelet/server/stats/volume_stat_calculator.go:130 +0x3f5
k8s.io/kubernetes/pkg/kubelet/server/stats.(*volumeStatCalculator).StartOnce.func1.1()	/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/pkg/kubelet/server/stats/volume_stat_calculator.go:70 +0x2a
k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1(0xc0029e9820)	/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:155 +0x5f
k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/util/wait.BackoffUntil(0xc0029e9820, 0x5200e40, 0xc001cfda40, 0xc00263f001, 0xc002a46060)	/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:156 +0x9b
k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/util/wait.JitterUntil(0xc0029e9820, 0xdf8475800, 0x3ff0000000000000, 0x1, 0xc002a46060)	/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:133 +0x98
created by k8s.io/kubernetes/pkg/kubelet/server/stats.(*volumeStatCalculator).StartOnce.func1
/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/pkg/kubelet/server/stats/volume_stat_calculator.go:69 +0x9d
```
#### Which issue(s) this PR fixes:
Fixes None

#### Special notes for your reviewer:

MetricsProvider is the attribute of type BlockVolume.

```
type BlockVolume interface {
	GetGlobalMapPath(spec *Spec) (string, error)
	GetPodDeviceMapPath() (string, string)
	MetricsProvider
}

type MetricsProvider interface {
	GetMetrics() (*Metrics, error)
}
```

Some testing code:
```
package main

import "fmt"

type Shape interface {
	Area() float64
}

type Object interface {
	Volume() float64
}

type Skin interface {
	Color() float64
}

type Cube struct {
	side float64
}

type Local struct {
	side float64
	Skin
}

func (c Cube) Color() float64 {
	return 6 * (c.side * c.side)
}

func (c Local) Area() float64 {
	return 6 * (c.side * c.side)
}

func (c Local) Volume() float64 {
	return c.side * c.side * c.side
}

func (c Cube) Area() float64 {
	return 6 * (c.side * c.side)
}

func (c Cube) Volume() float64 {
	return c.side * c.side * c.side
}

type LocalVolumeMapper struct {
	side float64
	*Local
	readOnly bool
}

func (c LocalVolumeMapper) Area() float64 {
	return 6
}

func (c LocalVolumeMapper) Volume() float64 {
	return c.side * c.side * c.side
}


func main() {
	var s Shape = Cube{3}
	value2, _ := s.(Skin)

	lvm := Local{side: 3, Skin: value2}
	value3, ok3 := lvm.Skin.(Skin)
	fmt.Printf("dynamic value of Local 's' with value %v implements interface Skin? %v\n", value3, ok3)
	fmt.Println(lvm.Color())

	l2 := Local{side: 3}
	value4, ok4 := l2.Skin.(Skin)
	fmt.Printf("dynamic value of Local 's' with value %v implements interface Skin? %v\n", value4, ok4)

 	var l Skin = Local{side: 3}
	value5, ok5 := l.(Skin)
	fmt.Printf("dynamic value of Local 's' with value %v implements interface Skin? %v\n", value5, ok5)

	fmt.Println(l2.Color())
}

```

Output
```
dynamic value of Local 's' with value {3} implements interface Skin? true
54
dynamic value of Local 's' with value <nil> implements interface Skin? false
**dynamic value of Local 's' with value {3 <nil>} implements interface Skin? true**
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x499767]

goroutine 1 [running]:
main.main()
	/tmp/sandbox616056645/prog.go:78 +0x3a7

```

#### Does this PR introduce a user-facing change?
```release-note
Fix nil pionter dereference in volume stat calculator for local volume.
```
