### PR TITLE
Azure auth forwarding adal refresh error to azureTokenSource

### DIFF
--- a/staging/src/k8s.io/client-go/plugin/pkg/client/auth/azure/azure.go
+++ b/staging/src/k8s.io/client-go/plugin/pkg/client/auth/azure/azure.go
@@ -354,7 +354,6 @@ func (ts *azureTokenSource) Refresh(token *azureToken) (*azureToken, error) {
 }
 
 // refresh outdated token with adal.
-// adal.RefreshTokenError will be returned if error occur during refreshing.
 func (ts *azureTokenSourceDeviceCode) Refresh(token *azureToken) (*azureToken, error) {
 	env, err := azure.EnvironmentFromName(token.environment)
 	if err != nil {
@@ -388,7 +387,8 @@ func (ts *azureTokenSourceDeviceCode) Refresh(token *azureToken) (*azureToken, e
 	}
 
 	if err := spt.Refresh(); err != nil {
-		return nil, fmt.Errorf("refreshing token: %v", err)
+		// Caller expects IsTokenRefreshError(err) to trigger prompt.
+		return nil, fmt.Errorf("refreshing token: %w", err)
 	}
 
 	return &azureToken{

--- a/staging/src/k8s.io/client-go/plugin/pkg/client/auth/azure/azure_test.go
+++ b/staging/src/k8s.io/client-go/plugin/pkg/client/auth/azure/azure_test.go
@@ -331,6 +331,16 @@ func TestAzureTokenSourceScenarios(t *testing.T) {
 			persistCalls: 1,
 		},
 		{
+			name:         "extend failure with fmt.Errorf nested tokenRefreshError",
+			configToken:  expiredToken,
+			refreshErr:   fmt.Errorf("refreshing token: %w", fakeTokenRefreshError{message: "nested FakeError happened when refreshing"}),
+			sourceToken:  fakeToken,
+			expectToken:  fakeToken,
+			refreshCalls: 1,
+			tokenCalls:   1,
+			persistCalls: 1,
+		},
+		{
 			name:         "unexpected error when extend",
 			configToken:  expiredToken,
 			refreshErr:   errors.New("unexpected refresh error"),


### PR DESCRIPTION
Signed-off-by: Ping He <tdihp@hotmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes/client-go/issues/931

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fixed an issue blocking azure auth to prompt to device code authentication flow when refresh token expires.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
