### PR TITLE
Use aliases in sig apps and scheduling APIs OWNERS

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -452,6 +452,7 @@ aliases:
     - janetkuo
     - kow3ns
     - soltysh
+    - alculquicondor
 
   sig-auth-api-reviewers:
     - enj
@@ -500,9 +501,8 @@ aliases:
     - mm4tt
     - wojtek-t
 
-  # sig-scheduling-api-reviewers:
-  #   -
-  #   -
+  sig-scheduling-api-reviewers:
+    - alculquicondor
 
   sig-storage-api-reviewers:
     - deads2k

--- a/pkg/apis/apps/OWNERS
+++ b/pkg/apis/apps/OWNERS
@@ -1,18 +1,8 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
+# approval on api packages bubbles to api-approvers
 reviewers:
-- thockin
-- lavalamp
-- smarterclayton
-- deads2k
-- caesarxuchao
-- pmorie
-- sttts
-- saad-ali
-- ncdc
-- dims
-- errordeveloper
-- m1093782566
-- kevin-wangzefeng
+- sig-apps-api-reviewers
+- sig-apps-api-approvers
 labels:
 - sig/apps

--- a/pkg/apis/batch/OWNERS
+++ b/pkg/apis/batch/OWNERS
@@ -1,17 +1,8 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
+# approval on api packages bubbles to api-approvers
 reviewers:
-- thockin
-- lavalamp
-- smarterclayton
-- wojtek-t
-- deads2k
-- caesarxuchao
-- sttts
-- saad-ali
-- ncdc
-- soltysh
-- dims
-- errordeveloper
+- sig-apps-api-reviewers
+- sig-apps-api-approvers
 labels:
 - sig/apps

--- a/pkg/apis/policy/OWNERS
+++ b/pkg/apis/policy/OWNERS
@@ -2,6 +2,7 @@
 
 # approval on api packages bubbles to api-approvers
 reviewers:
+- sig-apps-api-reviewers
 - sig-apps-api-approvers
 - sig-auth-policy-approvers
 - sig-auth-policy-reviewers

--- a/pkg/controller/apis/config/OWNERS
+++ b/pkg/controller/apis/config/OWNERS
@@ -1,5 +1,8 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
+# Disable inheritance as this is an api owners file
+options:
+  no_parent_owners: true
 approvers:
 - api-approvers
 - deads2k

--- a/pkg/scheduler/apis/config/OWNERS
+++ b/pkg/scheduler/apis/config/OWNERS
@@ -1,13 +1,14 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
+# Disable inheritance as this is an api owners file
+options:
+  no_parent_owners: true
 approvers:
 - api-approvers
-- sig-scheduling-maintainers
-- sttts
-- luxas
 reviewers:
-- sig-scheduling
 - api-reviewers
-- dixudx
-- luxas
-- sttts
+- sig-scheduling-api-reviewers
+- sig-scheduling-api-approvers
+labels:
+- kind/api-change
+- sig/scheduling

--- a/staging/src/k8s.io/api/apps/OWNERS
+++ b/staging/src/k8s.io/api/apps/OWNERS
@@ -1,16 +1,8 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
+# approval on api packages bubbles to api-approvers
 reviewers:
-- thockin
-- lavalamp
-- smarterclayton
-- deads2k
-- caesarxuchao
-- pmorie
-- sttts
-- saad-ali
-- ncdc
-- dims
-- errordeveloper
-- m1093782566
-- kevin-wangzefeng
+- sig-apps-api-reviewers
+- sig-apps-api-approvers
+labels:
+- sig/apps

--- a/staging/src/k8s.io/api/batch/OWNERS
+++ b/staging/src/k8s.io/api/batch/OWNERS
@@ -1,15 +1,8 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
+# approval on api packages bubbles to api-approvers
 reviewers:
-- thockin
-- lavalamp
-- smarterclayton
-- wojtek-t
-- deads2k
-- caesarxuchao
-- sttts
-- saad-ali
-- ncdc
-- soltysh
-- dims
-- errordeveloper
+- sig-apps-api-reviewers
+- sig-apps-api-approvers
+labels:
+- sig/apps

--- a/staging/src/k8s.io/kube-scheduler/config/OWNERS
+++ b/staging/src/k8s.io/kube-scheduler/config/OWNERS
@@ -7,6 +7,7 @@ approvers:
 - api-approvers
 reviewers:
 - api-reviewers
-- sig-scheduling
+- sig-scheduling-api-reviewers
+- sig-scheduling-api-approvers
 labels:
 - kind/api-change


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Use aliases exclusively in SIG apps and SIG Scheduling APIs OWNERS to simplify management.

Add alculquicondor to sig-scheduling-api-reviewers and sig-apps-api-reviewers.

/sig apps
/sig scheduling

#### Special notes for your reviewer:

My past API reviews:

apps:
#98727
#82162
#99378 
#99490

scheduling:
#99597
#92200
#91603
#91625
#88585

#### Does this PR introduce a user-facing change?
```release-note
NONE
```