### PR TITLE
apf: always create missing bootstrap configuration object

### DIFF
--- a/pkg/registry/flowcontrol/ensurer/flowschema.go
+++ b/pkg/registry/flowcontrol/ensurer/flowschema.go
@@ -46,13 +46,12 @@ type FlowSchemaRemover interface {
 
 // NewSuggestedFlowSchemaEnsurer returns a FlowSchemaEnsurer instance that
 // can be used to ensure a set of suggested FlowSchema configuration objects.
-// shouldCreate indicates whether a missing 'suggested' FlowSchema object should be recreated.
-func NewSuggestedFlowSchemaEnsurer(client flowcontrolclient.FlowSchemaInterface, shouldCreate bool) FlowSchemaEnsurer {
+func NewSuggestedFlowSchemaEnsurer(client flowcontrolclient.FlowSchemaInterface) FlowSchemaEnsurer {
 	wrapper := &flowSchemaWrapper{
 		client: client,
 	}
 	return &fsEnsurer{
-		strategy: newSuggestedEnsureStrategy(wrapper, shouldCreate),
+		strategy: newSuggestedEnsureStrategy(wrapper),
 		wrapper:  wrapper,
 	}
 }

--- a/pkg/registry/flowcontrol/ensurer/flowschema_test.go
+++ b/pkg/registry/flowcontrol/ensurer/flowschema_test.go
@@ -43,27 +43,18 @@ func TestEnsureFlowSchema(t *testing.T) {
 	}{
 		// for suggested configurations
 		{
-			name: "suggested flow schema does not exist and we should ensure - the object should be created",
+			name: "suggested flow schema does not exist - the object should always be re-created",
 			strategy: func(client flowcontrolclient.FlowSchemaInterface) FlowSchemaEnsurer {
-				return NewSuggestedFlowSchemaEnsurer(client, true)
+				return NewSuggestedFlowSchemaEnsurer(client)
 			},
 			bootstrap: newFlowSchema("fs1", "pl1", 100).Object(),
 			current:   nil,
 			expected:  newFlowSchema("fs1", "pl1", 100).Object(),
 		},
 		{
-			name: "suggested flow schema does not exist and we should not ensure - the object should not be created",
-			strategy: func(client flowcontrolclient.FlowSchemaInterface) FlowSchemaEnsurer {
-				return NewSuggestedFlowSchemaEnsurer(client, false)
-			},
-			bootstrap: newFlowSchema("fs1", "pl1", 100).Object(),
-			current:   nil,
-			expected:  nil,
-		},
-		{
 			name: "suggested flow schema exists, auto update is enabled, spec does not match - current object should be updated",
 			strategy: func(client flowcontrolclient.FlowSchemaInterface) FlowSchemaEnsurer {
-				return NewSuggestedFlowSchemaEnsurer(client, true)
+				return NewSuggestedFlowSchemaEnsurer(client)
 			},
 			bootstrap: newFlowSchema("fs1", "pl1", 100).Object(),
 			current:   newFlowSchema("fs1", "pl1", 200).WithAutoUpdateAnnotation("true").Object(),
@@ -72,7 +63,7 @@ func TestEnsureFlowSchema(t *testing.T) {
 		{
 			name: "suggested flow schema exists, auto update is disabled, spec does not match - current object should not be updated",
 			strategy: func(client flowcontrolclient.FlowSchemaInterface) FlowSchemaEnsurer {
-				return NewSuggestedFlowSchemaEnsurer(client, true)
+				return NewSuggestedFlowSchemaEnsurer(client)
 			},
 			bootstrap: newFlowSchema("fs1", "pl1", 100).Object(),
 			current:   newFlowSchema("fs1", "pl1", 200).WithAutoUpdateAnnotation("false").Object(),
@@ -223,7 +214,7 @@ func TestSuggestedFSEnsureStrategy_ShouldUpdate(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			strategy := newSuggestedEnsureStrategy(&flowSchemaWrapper{}, false)
+			strategy := newSuggestedEnsureStrategy(&flowSchemaWrapper{})
 			newObjectGot, updateGot, err := strategy.ShouldUpdate(test.current, test.bootstrap)
 			if err != nil {
 				t.Errorf("Expected no error, but got: %v", err)

--- a/pkg/registry/flowcontrol/ensurer/prioritylevelconfiguration.go
+++ b/pkg/registry/flowcontrol/ensurer/prioritylevelconfiguration.go
@@ -46,13 +46,12 @@ type PriorityLevelRemover interface {
 
 // NewSuggestedPriorityLevelEnsurerEnsurer returns a PriorityLevelEnsurer instance that
 // can be used to ensure a set of suggested PriorityLevelConfiguration configuration objects.
-// shouldCreate indicates whether a missing 'suggested' PriorityLevelConfiguration object should be recreated.
-func NewSuggestedPriorityLevelEnsurerEnsurer(client flowcontrolclient.PriorityLevelConfigurationInterface, shouldCreate bool) PriorityLevelEnsurer {
+func NewSuggestedPriorityLevelEnsurerEnsurer(client flowcontrolclient.PriorityLevelConfigurationInterface) PriorityLevelEnsurer {
 	wrapper := &priorityLevelConfigurationWrapper{
 		client: client,
 	}
 	return &plEnsurer{
-		strategy: newSuggestedEnsureStrategy(wrapper, shouldCreate),
+		strategy: newSuggestedEnsureStrategy(wrapper),
 		wrapper:  wrapper,
 	}
 }

--- a/pkg/registry/flowcontrol/ensurer/prioritylevelconfiguration_test.go
+++ b/pkg/registry/flowcontrol/ensurer/prioritylevelconfiguration_test.go
@@ -43,27 +43,18 @@ func TestEnsurePriorityLevel(t *testing.T) {
 	}{
 		// for suggested configurations
 		{
-			name: "suggested priority level configuration does not exist and we should ensure - new object should be created",
+			name: "suggested priority level configuration does not exist - the object should always be re-created",
 			strategy: func(client flowcontrolclient.PriorityLevelConfigurationInterface) PriorityLevelEnsurer {
-				return NewSuggestedPriorityLevelEnsurerEnsurer(client, true)
+				return NewSuggestedPriorityLevelEnsurerEnsurer(client)
 			},
 			bootstrap: newPLConfiguration("pl1").WithLimited(10).Object(),
 			current:   nil,
 			expected:  newPLConfiguration("pl1").WithLimited(10).Object(),
 		},
 		{
-			name: "suggested priority level configuration does not exist and we should not ensure - new object should not be created",
-			strategy: func(client flowcontrolclient.PriorityLevelConfigurationInterface) PriorityLevelEnsurer {
-				return NewSuggestedPriorityLevelEnsurerEnsurer(client, false)
-			},
-			bootstrap: newPLConfiguration("pl1").WithLimited(10).Object(),
-			current:   nil,
-			expected:  nil,
-		},
-		{
 			name: "suggested priority level configuration exists, auto update is enabled, spec does not match - current object should be updated",
 			strategy: func(client flowcontrolclient.PriorityLevelConfigurationInterface) PriorityLevelEnsurer {
-				return NewSuggestedPriorityLevelEnsurerEnsurer(client, true)
+				return NewSuggestedPriorityLevelEnsurerEnsurer(client)
 			}, bootstrap: newPLConfiguration("pl1").WithLimited(20).Object(),
 			current:  newPLConfiguration("pl1").WithAutoUpdateAnnotation("true").WithLimited(10).Object(),
 			expected: newPLConfiguration("pl1").WithAutoUpdateAnnotation("true").WithLimited(20).Object(),
@@ -71,7 +62,7 @@ func TestEnsurePriorityLevel(t *testing.T) {
 		{
 			name: "suggested priority level configuration exists, auto update is disabled, spec does not match - current object should not be updated",
 			strategy: func(client flowcontrolclient.PriorityLevelConfigurationInterface) PriorityLevelEnsurer {
-				return NewSuggestedPriorityLevelEnsurerEnsurer(client, true)
+				return NewSuggestedPriorityLevelEnsurerEnsurer(client)
 			},
 			bootstrap: newPLConfiguration("pl1").WithLimited(20).Object(),
 			current:   newPLConfiguration("pl1").WithAutoUpdateAnnotation("false").WithLimited(10).Object(),
@@ -223,7 +214,7 @@ func TestSuggestedPLEnsureStrategy_ShouldUpdate(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			strategy := newSuggestedEnsureStrategy(&priorityLevelConfigurationWrapper{}, false)
+			strategy := newSuggestedEnsureStrategy(&priorityLevelConfigurationWrapper{})
 			newObjectGot, updateGot, err := strategy.ShouldUpdate(test.current, test.bootstrap)
 			if err != nil {
 				t.Errorf("Expected no error, but got: %v", err)

--- a/pkg/registry/flowcontrol/rest/storage_flowcontrol_test.go
+++ b/pkg/registry/flowcontrol/rest/storage_flowcontrol_test.go
@@ -20,44 +20,7 @@ import (
 	"context"
 	"testing"
 	"time"
-
-	"github.com/stretchr/testify/assert"
-	flowcontrolv1beta1 "k8s.io/api/flowcontrol/v1beta1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apiserver/pkg/apis/flowcontrol/bootstrap"
-	"k8s.io/client-go/kubernetes/fake"
 )
-
-func TestShouldEnsurePredefinedSettings(t *testing.T) {
-	testCases := []struct {
-		name                  string
-		existingPriorityLevel *flowcontrolv1beta1.PriorityLevelConfiguration
-		expected              bool
-	}{
-		{
-			name:                  "should ensure if exempt priority-level is absent",
-			existingPriorityLevel: nil,
-			expected:              true,
-		},
-		{
-			name:                  "should not ensure if exempt priority-level is present",
-			existingPriorityLevel: bootstrap.MandatoryPriorityLevelConfigurationExempt,
-			expected:              false,
-		},
-	}
-
-	for _, testCase := range testCases {
-		t.Run(testCase.name, func(t *testing.T) {
-			c := fake.NewSimpleClientset()
-			if testCase.existingPriorityLevel != nil {
-				c.FlowcontrolV1beta1().PriorityLevelConfigurations().Create(context.TODO(), testCase.existingPriorityLevel, metav1.CreateOptions{})
-			}
-			should, err := shouldCreateSuggested(c.FlowcontrolV1beta1())
-			assert.NoError(t, err)
-			assert.Equal(t, testCase.expected, should)
-		})
-	}
-}
 
 func TestContextFromChannelAndMaxWaitDurationWithChannelClosed(t *testing.T) {
 	stopCh := make(chan struct{})


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:
Always create missing apf bootstrap configuration object(s).

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
We no longer allow the cluster operator to delete any "suggested" priority & fairness bootstrap configuration object, 
If a cluster operator removes a suggested configuration, it will be restored by the apiserver. 
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
