### PR TITLE
Cleanup sig scheduling maintainers and reviewers

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -171,28 +171,27 @@ aliases:
 
   sig-scheduling-maintainers:
     - alculquicondor
-    - k82cn
-    - wojtek-t
-    - ravisantoshgudimetla
     - Huang-Wei
     - ahg-g
     - damemi
   # emeritus:
   # - bsalamat
+  # - k82cn
+  # - ravisantoshgudimetla
+  # - wojtek-t  
   sig-scheduling:
-    - k82cn
-    - resouer
-    - ravisantoshgudimetla
-    - Huang-Wei
-    - wgliang
+    - Huang-Wei    
     - ahg-g
-    - draveness
-    - hex108
     - alculquicondor
-    - liu-cong
     - damemi
     - chendave
     - adtac
+  # emeritus:
+  # - liu-cong
+  # - draveness
+  # - hex108
+  # - resouer
+  # - wgliang
 
   sig-cli-maintainers:
     - deads2k


### PR DESCRIPTION
#### What type of PR is this?
/kind documentation

#### What this PR does / why we need it:
Move inactive members of sig scheduling to emeritus

#### Which issue(s) this PR fixes:
This is a follow up to a comment on the annual report: https://github.com/kubernetes/community/pull/5557/files#r606606704

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```


/cc @k82cn @wgliang @liu-cong @ravisantoshgudimetla @resouer @draveness 