### PR TITLE
kubeadm: use git.k8s.io link in app/util/error.go

### DIFF
--- a/cmd/kubeadm/app/util/error.go
+++ b/cmd/kubeadm/app/util/error.go
@@ -76,7 +76,7 @@ func checkErr(err error, handleErr func(string, int)) {
 			// assume that the "v" flag contains a parseable Int32 as per klog's "Level" type alias,
 			// thus no error from ParseInt is handled here.
 			if v, e := strconv.ParseInt(f.Value.String(), 10, 32); e == nil {
-				// https://github.com/kubernetes/community/blob/master/contributors/devel/sig-instrumentation/logging.md
+				// https://git.k8s.io/community/contributors/devel/sig-instrumentation/logging.md
 				// klog.V(5) - Trace level verbosity
 				if v > 4 {
 					msg = fmt.Sprintf("%+v", err)


### PR DESCRIPTION
#### What this PR does / why we need it:
Adapt for the future transition of kubernetes/community to
have "main" as its development branch.

Use:
`https://git.k8s.io/community/...`

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
NONE

#### Special notes for your reviewer:
NONE

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
