### PR TITLE
Update addon resizer to 1.8.13

### DIFF
--- a/cluster/addons/metrics-server/metrics-server-deployment.yaml
+++ b/cluster/addons/metrics-server/metrics-server-deployment.yaml
@@ -69,7 +69,7 @@ spec:
         - mountPath: /tmp
           name: tmp-dir
       - name: metrics-server-nanny
-        image: k8s.gcr.io/addon-resizer:1.8.11
+        image: k8s.gcr.io/autoscaling/addon-resizer:1.8.13
         resources:
           limits:
             cpu: 100m

--- a/cluster/addons/metrics-server/resource-reader.yaml
+++ b/cluster/addons/metrics-server/resource-reader.yaml
@@ -25,6 +25,7 @@ rules:
   - list
   - update
   - watch
+  - patch
 - nonResourceURLs:
   - /metrics
   verbs:


### PR DESCRIPTION
/kind bug

#### What this PR does / why we need it:

Fixes the issue where addon resizer drops newer deployment fields. Fix consists of only patching deployment's pod requests instead of updating the entire object.

#### Which issue(s) this PR fixes:

Fixes https://github.com/kubernetes/autoscaler/issues/3567

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

