### PR TITLE
staging/publishing: remove 1.17 and 1.18 rules

### DIFF
--- a/staging/publishing/rules.yaml
+++ b/staging/publishing/rules.yaml
@@ -16,16 +16,6 @@ rules:
       dir: staging/src/k8s.io/code-generator
     name: master
   - source:
-      branch: release-1.17
-      dir: staging/src/k8s.io/code-generator
-    name: release-1.17
-    go: 1.13.15
-  - source:
-      branch: release-1.18
-      dir: staging/src/k8s.io/code-generator
-    name: release-1.18
-    go: 1.13.15
-  - source:
       branch: release-1.19
       dir: staging/src/k8s.io/code-generator
     name: release-1.19
@@ -47,16 +37,6 @@ rules:
       branch: master
       dir: staging/src/k8s.io/apimachinery
     name: master
-  - source:
-      branch: release-1.17
-      dir: staging/src/k8s.io/apimachinery
-    name: release-1.17
-    go: 1.13.15
-  - source:
-      branch: release-1.18
-      dir: staging/src/k8s.io/apimachinery
-    name: release-1.18
-    go: 1.13.15
   - source:
       branch: release-1.19
       dir: staging/src/k8s.io/apimachinery
@@ -82,22 +62,6 @@ rules:
     dependencies:
     - repository: apimachinery
       branch: master
-  - source:
-      branch: release-1.17
-      dir: staging/src/k8s.io/api
-    name: release-1.17
-    go: 1.13.15
-    dependencies:
-      - repository: apimachinery
-        branch: release-1.17
-  - source:
-      branch: release-1.18
-      dir: staging/src/k8s.io/api
-    name: release-1.18
-    go: 1.13.15
-    dependencies:
-      - repository: apimachinery
-        branch: release-1.18
   - source:
       branch: release-1.19
       dir: staging/src/k8s.io/api
@@ -138,34 +102,6 @@ rules:
       # assumes GO111MODULE=on
       go build -mod=mod ./...
       go test -mod=mod ./...
-  - source:
-      branch: release-1.17
-      dir: staging/src/k8s.io/client-go
-    name: release-14.0
-    go: 1.13.15
-    dependencies:
-      - repository: apimachinery
-        branch: release-1.17
-      - repository: api
-        branch: release-1.17
-    smoke-test: |
-      # assumes GO111MODULE=on
-      go build ./...
-      go test ./...
-  - source:
-      branch: release-1.18
-      dir: staging/src/k8s.io/client-go
-    name: release-1.18
-    go: 1.13.15
-    dependencies:
-      - repository: apimachinery
-        branch: release-1.18
-      - repository: api
-        branch: release-1.18
-    smoke-test: |
-      # assumes GO111MODULE=on
-      go build ./...
-      go test ./...
   - source:
       branch: release-1.19
       dir: staging/src/k8s.io/client-go
@@ -222,30 +158,6 @@ rules:
       branch: master
     - repository: client-go
       branch: master
-  - source:
-      branch: release-1.17
-      dir: staging/src/k8s.io/component-base
-    name: release-1.17
-    go: 1.13.15
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.17
-    - repository: api
-      branch: release-1.17
-    - repository: client-go
-      branch: release-14.0
-  - source:
-      branch: release-1.18
-      dir: staging/src/k8s.io/component-base
-    name: release-1.18
-    go: 1.13.15
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.18
-    - repository: api
-      branch: release-1.18
-    - repository: client-go
-      branch: release-1.18
   - source:
       branch: release-1.19
       dir: staging/src/k8s.io/component-base
@@ -337,34 +249,6 @@ rules:
     - repository: component-base
       branch: master
   - source:
-      branch: release-1.17
-      dir: staging/src/k8s.io/apiserver
-    name: release-1.17
-    go: 1.13.15
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.17
-    - repository: api
-      branch: release-1.17
-    - repository: client-go
-      branch: release-14.0
-    - repository: component-base
-      branch: release-1.17
-  - source:
-      branch: release-1.18
-      dir: staging/src/k8s.io/apiserver
-    name: release-1.18
-    go: 1.13.15
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.18
-    - repository: api
-      branch: release-1.18
-    - repository: client-go
-      branch: release-1.18
-    - repository: component-base
-      branch: release-1.18
-  - source:
       branch: release-1.19
       dir: staging/src/k8s.io/apiserver
     name: release-1.19
@@ -425,42 +309,6 @@ rules:
       branch: master
     - repository: code-generator
       branch: master
-  - source:
-      branch: release-1.17
-      dir: staging/src/k8s.io/kube-aggregator
-    name: release-1.17
-    go: 1.13.15
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.17
-    - repository: api
-      branch: release-1.17
-    - repository: client-go
-      branch: release-14.0
-    - repository: apiserver
-      branch: release-1.17
-    - repository: component-base
-      branch: release-1.17
-    - repository: code-generator
-      branch: release-1.17
-  - source:
-      branch: release-1.18
-      dir: staging/src/k8s.io/kube-aggregator
-    name: release-1.18
-    go: 1.13.15
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.18
-    - repository: api
-      branch: release-1.18
-    - repository: client-go
-      branch: release-1.18
-    - repository: apiserver
-      branch: release-1.18
-    - repository: component-base
-      branch: release-1.18
-    - repository: code-generator
-      branch: release-1.18
   - source:
       branch: release-1.19
       dir: staging/src/k8s.io/kube-aggregator
@@ -539,52 +387,6 @@ rules:
     smoke-test: |
       # assumes GO111MODULE=on
       go build -mod=mod .
-  - source:
-      branch: release-1.17
-      dir: staging/src/k8s.io/sample-apiserver
-    name: release-1.17
-    go: 1.13.15
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.17
-    - repository: api
-      branch: release-1.17
-    - repository: client-go
-      branch: release-14.0
-    - repository: apiserver
-      branch: release-1.17
-    - repository: code-generator
-      branch: release-1.17
-    - repository: component-base
-      branch: release-1.17
-    required-packages:
-    - k8s.io/code-generator
-    smoke-test: |
-      # assumes GO111MODULE=on
-      go build .
-  - source:
-      branch: release-1.18
-      dir: staging/src/k8s.io/sample-apiserver
-    name: release-1.18
-    go: 1.13.15
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.18
-    - repository: api
-      branch: release-1.18
-    - repository: client-go
-      branch: release-1.18
-    - repository: apiserver
-      branch: release-1.18
-    - repository: code-generator
-      branch: release-1.18
-    - repository: component-base
-      branch: release-1.18
-    required-packages:
-    - k8s.io/code-generator
-    smoke-test: |
-      # assumes GO111MODULE=on
-      go build .
   - source:
       branch: release-1.19
       dir: staging/src/k8s.io/sample-apiserver
@@ -675,44 +477,6 @@ rules:
       # assumes GO111MODULE=on
       go build -mod=mod .
   - source:
-      branch: release-1.17
-      dir: staging/src/k8s.io/sample-controller
-    name: release-1.17
-    go: 1.13.15
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.17
-    - repository: api
-      branch: release-1.17
-    - repository: client-go
-      branch: release-14.0
-    - repository: code-generator
-      branch: release-1.17
-    required-packages:
-    - k8s.io/code-generator
-    smoke-test: |
-      # assumes GO111MODULE=on
-      go build .
-  - source:
-      branch: release-1.18
-      dir: staging/src/k8s.io/sample-controller
-    name: release-1.18
-    go: 1.13.15
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.18
-    - repository: api
-      branch: release-1.18
-    - repository: client-go
-      branch: release-1.18
-    - repository: code-generator
-      branch: release-1.18
-    required-packages:
-    - k8s.io/code-generator
-    smoke-test: |
-      # assumes GO111MODULE=on
-      go build .
-  - source:
       branch: release-1.19
       dir: staging/src/k8s.io/sample-controller
     name: release-1.19
@@ -788,46 +552,6 @@ rules:
       branch: master
     - repository: component-base
       branch: master
-    required-packages:
-    - k8s.io/code-generator
-  - source:
-      branch: release-1.17
-      dir: staging/src/k8s.io/apiextensions-apiserver
-    name: release-1.17
-    go: 1.13.15
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.17
-    - repository: api
-      branch: release-1.17
-    - repository: client-go
-      branch: release-14.0
-    - repository: apiserver
-      branch: release-1.17
-    - repository: code-generator
-      branch: release-1.17
-    - repository: component-base
-      branch: release-1.17
-    required-packages:
-    - k8s.io/code-generator
-  - source:
-      branch: release-1.18
-      dir: staging/src/k8s.io/apiextensions-apiserver
-    name: release-1.18
-    go: 1.13.15
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.18
-    - repository: api
-      branch: release-1.18
-    - repository: client-go
-      branch: release-1.18
-    - repository: apiserver
-      branch: release-1.18
-    - repository: code-generator
-      branch: release-1.18
-    - repository: component-base
-      branch: release-1.18
     required-packages:
     - k8s.io/code-generator
   - source:
@@ -907,34 +631,6 @@ rules:
     - repository: code-generator
       branch: master
   - source:
-      branch: release-1.17
-      dir: staging/src/k8s.io/metrics
-    name: release-1.17
-    go: 1.13.15
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.17
-    - repository: api
-      branch: release-1.17
-    - repository: client-go
-      branch: release-14.0
-    - repository: code-generator
-      branch: release-1.17
-  - source:
-      branch: release-1.18
-      dir: staging/src/k8s.io/metrics
-    name: release-1.18
-    go: 1.13.15
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.18
-    - repository: api
-      branch: release-1.18
-    - repository: client-go
-      branch: release-1.18
-    - repository: code-generator
-      branch: release-1.18
-  - source:
       branch: release-1.19
       dir: staging/src/k8s.io/metrics
     name: release-1.19
@@ -991,30 +687,6 @@ rules:
     - repository: client-go
       branch: master
   - source:
-      branch: release-1.17
-      dir: staging/src/k8s.io/cli-runtime
-    name: release-1.17
-    go: 1.13.15
-    dependencies:
-    - repository: api
-      branch: release-1.17
-    - repository: apimachinery
-      branch: release-1.17
-    - repository: client-go
-      branch: release-14.0
-  - source:
-      branch: release-1.18
-      dir: staging/src/k8s.io/cli-runtime
-    name: release-1.18
-    go: 1.13.15
-    dependencies:
-    - repository: api
-      branch: release-1.18
-    - repository: apimachinery
-      branch: release-1.18
-    - repository: client-go
-      branch: release-1.18
-  - source:
       branch: release-1.19
       dir: staging/src/k8s.io/cli-runtime
     name: release-1.19
@@ -1066,34 +738,6 @@ rules:
       branch: master
     - repository: client-go
       branch: master
-  - source:
-      branch: release-1.17
-      dir: staging/src/k8s.io/sample-cli-plugin
-    name: release-1.17
-    go: 1.13.15
-    dependencies:
-    - repository: api
-      branch: release-1.17
-    - repository: apimachinery
-      branch: release-1.17
-    - repository: cli-runtime
-      branch: release-1.17
-    - repository: client-go
-      branch: release-14.0
-  - source:
-      branch: release-1.18
-      dir: staging/src/k8s.io/sample-cli-plugin
-    name: release-1.18
-    go: 1.13.15
-    dependencies:
-    - repository: api
-      branch: release-1.18
-    - repository: apimachinery
-      branch: release-1.18
-    - repository: cli-runtime
-      branch: release-1.18
-    - repository: client-go
-      branch: release-1.18
   - source:
       branch: release-1.19
       dir: staging/src/k8s.io/sample-cli-plugin
@@ -1153,34 +797,6 @@ rules:
     - repository: client-go
       branch: master
   - source:
-      branch: release-1.17
-      dir: staging/src/k8s.io/kube-proxy
-    name: release-1.17
-    go: 1.13.15
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.17
-    - repository: component-base
-      branch: release-1.17
-    - repository: api
-      branch: release-1.17
-    - repository: client-go
-      branch: release-14.0
-  - source:
-      branch: release-1.18
-      dir: staging/src/k8s.io/kube-proxy
-    name: release-1.18
-    go: 1.13.15
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.18
-    - repository: component-base
-      branch: release-1.18
-    - repository: api
-      branch: release-1.18
-    - repository: client-go
-      branch: release-1.18
-  - source:
       branch: release-1.19
       dir: staging/src/k8s.io/kube-proxy
     name: release-1.19
@@ -1239,26 +855,6 @@ rules:
     - repository: component-base
       branch: master
   - source:
-      branch: release-1.17
-      dir: staging/src/k8s.io/kubelet
-    name: release-1.17
-    go: 1.13.15
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.17
-    - repository: api
-      branch: release-1.17
-  - source:
-      branch: release-1.18
-      dir: staging/src/k8s.io/kubelet
-    name: release-1.18
-    go: 1.13.15
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.18
-    - repository: api
-      branch: release-1.18
-  - source:
       branch: release-1.19
       dir: staging/src/k8s.io/kubelet
     name: release-1.19
@@ -1316,34 +912,6 @@ rules:
       branch: master
     - repository: client-go
       branch: master
-  - source:
-      branch: release-1.17
-      dir: staging/src/k8s.io/kube-scheduler
-    name: release-1.17
-    go: 1.13.15
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.17
-    - repository: component-base
-      branch: release-1.17
-    - repository: api
-      branch: release-1.17
-    - repository: client-go
-      branch: release-14.0
-  - source:
-      branch: release-1.18
-      dir: staging/src/k8s.io/kube-scheduler
-    name: release-1.18
-    go: 1.13.15
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.18
-    - repository: component-base
-      branch: release-1.18
-    - repository: api
-      branch: release-1.18
-    - repository: client-go
-      branch: release-1.18
   - source:
       branch: release-1.19
       dir: staging/src/k8s.io/kube-scheduler
@@ -1462,30 +1030,6 @@ rules:
     - repository: controller-manager
       branch: master
   - source:
-      branch: release-1.17
-      dir: staging/src/k8s.io/cloud-provider
-    name: release-1.17
-    go: 1.13.15
-    dependencies:
-    - repository: api
-      branch: release-1.17
-    - repository: apimachinery
-      branch: release-1.17
-    - repository: client-go
-      branch: release-14.0
-  - source:
-      branch: release-1.18
-      dir: staging/src/k8s.io/cloud-provider
-    name: release-1.18
-    go: 1.13.15
-    dependencies:
-    - repository: api
-      branch: release-1.18
-    - repository: apimachinery
-      branch: release-1.18
-    - repository: client-go
-      branch: release-1.18
-  - source:
       branch: release-1.19
       dir: staging/src/k8s.io/cloud-provider
     name: release-1.19
@@ -1558,34 +1102,6 @@ rules:
     - repository: cloud-provider
       branch: master
   - source:
-      branch: release-1.17
-      dir: staging/src/k8s.io/kube-controller-manager
-    name: release-1.17
-    go: 1.13.15
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.17
-    - repository: component-base
-      branch: release-1.17
-    - repository: api
-      branch: release-1.17
-    - repository: client-go
-      branch: release-14.0
-  - source:
-      branch: release-1.18
-      dir: staging/src/k8s.io/kube-controller-manager
-    name: release-1.18
-    go: 1.13.15
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.18
-    - repository: component-base
-      branch: release-1.18
-    - repository: api
-      branch: release-1.18
-    - repository: client-go
-      branch: release-1.18
-  - source:
       branch: release-1.19
       dir: staging/src/k8s.io/kube-controller-manager
     name: release-1.19
@@ -1652,26 +1168,6 @@ rules:
     - repository: api
       branch: master
   - source:
-      branch: release-1.17
-      dir: staging/src/k8s.io/cluster-bootstrap
-    name: release-1.17
-    go: 1.13.15
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.17
-    - repository: api
-      branch: release-1.17
-  - source:
-      branch: release-1.18
-      dir: staging/src/k8s.io/cluster-bootstrap
-    name: release-1.18
-    go: 1.13.15
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.18
-    - repository: api
-      branch: release-1.18
-  - source:
       branch: release-1.19
       dir: staging/src/k8s.io/cluster-bootstrap
     name: release-1.19
@@ -1713,34 +1209,6 @@ rules:
       branch: master
     - repository: apimachinery
       branch: master
-  - source:
-      branch: release-1.17
-      dir: staging/src/k8s.io/csi-translation-lib
-    name: release-1.17
-    go: 1.13.15
-    dependencies:
-    - repository: api
-      branch: release-1.17
-    - repository: apimachinery
-      branch: release-1.17
-    - repository: client-go
-      branch: release-14.0
-    - repository: cloud-provider
-      branch: release-1.17
-  - source:
-      branch: release-1.18
-      dir: staging/src/k8s.io/csi-translation-lib
-    name: release-1.18
-    go: 1.13.15
-    dependencies:
-    - repository: api
-      branch: release-1.18
-    - repository: apimachinery
-      branch: release-1.18
-    - repository: client-go
-      branch: release-1.18
-    - repository: cloud-provider
-      branch: release-1.18
   - source:
       branch: release-1.19
       dir: staging/src/k8s.io/csi-translation-lib
@@ -1802,46 +1270,6 @@ rules:
     - repository: controller-manager
       branch: master
   - source:
-      branch: release-1.17
-      dir: staging/src/k8s.io/legacy-cloud-providers
-    name: release-1.17
-    go: 1.13.15
-    dependencies:
-    - repository: api
-      branch: release-1.17
-    - repository: apimachinery
-      branch: release-1.17
-    - repository: client-go
-      branch: release-14.0
-    - repository: cloud-provider
-      branch: release-1.17
-    - repository: csi-translation-lib
-      branch: release-1.17
-    - repository: apiserver
-      branch: release-1.17
-    - repository: component-base
-      branch: release-1.17
-  - source:
-      branch: release-1.18
-      dir: staging/src/k8s.io/legacy-cloud-providers
-    name: release-1.18
-    go: 1.13.15
-    dependencies:
-    - repository: api
-      branch: release-1.18
-    - repository: apimachinery
-      branch: release-1.18
-    - repository: client-go
-      branch: release-1.18
-    - repository: cloud-provider
-      branch: release-1.18
-    - repository: csi-translation-lib
-      branch: release-1.18
-    - repository: apiserver
-      branch: release-1.18
-    - repository: component-base
-      branch: release-1.18
-  - source:
       branch: release-1.19
       dir: staging/src/k8s.io/legacy-cloud-providers
     name: release-1.19
@@ -1905,24 +1333,6 @@ rules:
     - repository: controller-manager
       branch: release-1.21
 
-- destination: node-api
-  library: true
-  branches:
-  - source:
-      branch: release-1.17
-      dir: staging/src/k8s.io/node-api
-    name: release-1.17
-    go: 1.13.15
-    dependencies:
-    - repository: api
-      branch: release-1.17
-    - repository: apimachinery
-      branch: release-1.17
-    - repository: client-go
-      branch: release-14.0
-    - repository: code-generator
-      branch: release-1.17
-
 - destination: cri-api
   library: true
   branches:
@@ -1930,16 +1340,6 @@ rules:
       branch: master
       dir: staging/src/k8s.io/cri-api
     name: master
-  - source:
-      branch: release-1.17
-      dir: staging/src/k8s.io/cri-api
-    name: release-1.17
-    go: 1.13.15
-  - source:
-      branch: release-1.18
-      dir: staging/src/k8s.io/cri-api
-    name: release-1.18
-    go: 1.13.15
   - source:
       branch: release-1.19
       dir: staging/src/k8s.io/cri-api
@@ -1979,46 +1379,6 @@ rules:
       branch: master
     - repository: metrics
       branch: master
-  - source:
-      branch: release-1.17
-      dir: staging/src/k8s.io/kubectl
-    name: release-1.17
-    go: 1.13.15
-    dependencies:
-    - repository: api
-      branch: release-1.17
-    - repository: apimachinery
-      branch: release-1.17
-    - repository: cli-runtime
-      branch: release-1.17
-    - repository: client-go
-      branch: release-14.0
-    - repository: code-generator
-      branch: release-1.17
-    - repository: component-base
-      branch: release-1.17
-    - repository: metrics
-      branch: release-1.17
-  - source:
-      branch: release-1.18
-      dir: staging/src/k8s.io/kubectl
-    name: release-1.18
-    go: 1.13.15
-    dependencies:
-    - repository: api
-      branch: release-1.18
-    - repository: apimachinery
-      branch: release-1.18
-    - repository: cli-runtime
-      branch: release-1.18
-    - repository: client-go
-      branch: release-1.18
-    - repository: code-generator
-      branch: release-1.18
-    - repository: component-base
-      branch: release-1.18
-    - repository: metrics
-      branch: release-1.18
   - source:
       branch: release-1.19
       dir: staging/src/k8s.io/kubectl


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Cleanups rules for branches that have reached end of life and are not supported anymore.

#### Special notes for your reviewer:

/hold
This should merge _after_ the publishing-bot is fixed and the [last patch release](https://github.com/kubernetes/sig-release/blob/master/releases/patch-releases.md#118) of 1.18  (`v1.18.19`) has been published.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

/assign @dims @xmudrii 