### PR TITLE
Prevent data race condition in vsphere unit tests

### DIFF
--- a/staging/src/k8s.io/legacy-cloud-providers/vsphere/vsphere_test.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/vsphere/vsphere_test.go
@@ -205,6 +205,95 @@ func configFromEnvOrSim() (VSphereConfig, func()) {
 	return configFromSim()
 }
 
+func TestSecretUpdated(t *testing.T) {
+	datacenter := "0.0.0.0"
+	secretName := "vccreds"
+	secretNamespace := "kube-system"
+	username := "test-username"
+	password := "test-password"
+	basicSecret := fakeSecret(secretName, secretNamespace, datacenter, username, password)
+
+	cfg, cleanup := configFromSim()
+	defer cleanup()
+
+	cfg.Global.User = username
+	cfg.Global.Password = password
+	cfg.Global.Datacenter = datacenter
+	cfg.Global.SecretName = secretName
+	cfg.Global.SecretNamespace = secretNamespace
+
+	vsphere, err := buildVSphereFromConfig(cfg)
+	if err != nil {
+		t.Fatalf("Should succeed when a valid config is provided: %s", err)
+	}
+	klog.Flush()
+
+	klog.InitFlags(nil)
+	flag.Set("logtostderr", "false")
+	flag.Set("alsologtostderr", "false")
+	flag.Set("v", "9")
+	flag.Parse()
+
+	testcases := []struct {
+		name            string
+		oldSecret       *v1.Secret
+		secret          *v1.Secret
+		expectOutput    bool
+		expectErrOutput bool
+	}{
+		{
+			name:         "Secrets are equal",
+			oldSecret:    basicSecret.DeepCopy(),
+			secret:       basicSecret.DeepCopy(),
+			expectOutput: false,
+		},
+		{
+			name:         "Secret with a different name",
+			oldSecret:    basicSecret.DeepCopy(),
+			secret:       fakeSecret("different", secretNamespace, datacenter, username, password),
+			expectOutput: false,
+		},
+		{
+			name:         "Secret with a different data",
+			oldSecret:    basicSecret.DeepCopy(),
+			secret:       fakeSecret(secretName, secretNamespace, datacenter, "...", "..."),
+			expectOutput: true,
+		},
+		{
+			name:            "Secret being nil",
+			oldSecret:       basicSecret.DeepCopy(),
+			secret:          nil,
+			expectOutput:    true,
+			expectErrOutput: true,
+		},
+	}
+
+	for _, testcase := range testcases {
+		t.Run(testcase.name, func(t *testing.T) {
+			buf := new(buffer)
+			errBuf := new(buffer)
+
+			klog.SetOutputBySeverity("INFO", buf)
+			klog.SetOutputBySeverity("WARNING", errBuf)
+
+			vsphere.SecretUpdated(testcase.oldSecret, testcase.secret)
+
+			klog.Flush()
+			if testcase.expectOutput && len(buf.String()) == 0 {
+				t.Fatalf("Expected log secret update for secrets:\nOld:\n\t%+v\nNew\n\t%+v", testcase.oldSecret, testcase.secret)
+			} else if !testcase.expectOutput && len(buf.String()) > 0 {
+				t.Fatalf("Unexpected log messages for secrets:\nOld:\n\t%+v\n\nNew:\n\t%+v\nMessage:%s", testcase.oldSecret, testcase.secret, buf.String())
+			}
+
+			if testcase.expectErrOutput && len(errBuf.String()) == 0 {
+				t.Fatalf("Expected log error output on secret update for secrets:\nOld:\n\t%+v\nNew\n\t%+v", testcase.oldSecret, testcase.secret)
+			} else if !testcase.expectErrOutput && len(errBuf.String()) > 0 {
+				t.Fatalf("Unexpected log error messages for secrets:\nOld:\n\t%+v\n\nNew:\n\t%+v\nMessage:%s", testcase.oldSecret, testcase.secret, errBuf.String())
+			}
+		})
+	}
+}
+
 func TestReadConfig(t *testing.T) {
 	_, err := readConfig(nil)
 	if err == nil {
@@ -1181,93 +1270,4 @@ func (b *buffer) Write(p []byte) (n int, err error) {
 	b.rw.Lock()
 	defer b.rw.Unlock()
 	return b.b.Write(p)
-}
-
-func TestSecretUpdated(t *testing.T) {
-	datacenter := "0.0.0.0"
-	secretName := "vccreds"
-	secretNamespace := "kube-system"
-	username := "test-username"
-	password := "test-password"
-	basicSecret := fakeSecret(secretName, secretNamespace, datacenter, username, password)
-
-	cfg, cleanup := configFromSim()
-	defer cleanup()
-
-	cfg.Global.User = username
-	cfg.Global.Password = password
-	cfg.Global.Datacenter = datacenter
-	cfg.Global.SecretName = secretName
-	cfg.Global.SecretNamespace = secretNamespace
-
-	vsphere, err := buildVSphereFromConfig(cfg)
-	if err != nil {
-		t.Fatalf("Should succeed when a valid config is provided: %s", err)
-	}
-	klog.Flush()
-
-	klog.InitFlags(nil)
-	flag.Set("logtostderr", "false")
-	flag.Set("alsologtostderr", "false")
-	flag.Set("v", "9")
-	flag.Parse()
-
-	testcases := []struct {
-		name            string
-		oldSecret       *v1.Secret
-		secret          *v1.Secret
-		expectOutput    bool
-		expectErrOutput bool
-	}{
-		{
-			name:         "Secrets are equal",
-			oldSecret:    basicSecret.DeepCopy(),
-			secret:       basicSecret.DeepCopy(),
-			expectOutput: false,
-		},
-		{
-			name:         "Secret with a different name",
-			oldSecret:    basicSecret.DeepCopy(),
-			secret:       fakeSecret("different", secretNamespace, datacenter, username, password),
-			expectOutput: false,
-		},
-		{
-			name:         "Secret with a different data",
-			oldSecret:    basicSecret.DeepCopy(),
-			secret:       fakeSecret(secretName, secretNamespace, datacenter, "...", "..."),
-			expectOutput: true,
-		},
-		{
-			name:            "Secret being nil",
-			oldSecret:       basicSecret.DeepCopy(),
-			secret:          nil,
-			expectOutput:    true,
-			expectErrOutput: true,
-		},
-	}
-
-	for _, testcase := range testcases {
-		t.Run(testcase.name, func(t *testing.T) {
-			buf := new(buffer)
-			errBuf := new(buffer)
-
-			klog.SetOutputBySeverity("INFO", buf)
-			klog.SetOutputBySeverity("WARNING", errBuf)
-
-			vsphere.SecretUpdated(testcase.oldSecret, testcase.secret)
-
-			klog.Flush()
-			if testcase.expectOutput && len(buf.String()) == 0 {
-				t.Fatalf("Expected log secret update for secrets:\nOld:\n\t%+v\nNew\n\t%+v", testcase.oldSecret, testcase.secret)
-			} else if !testcase.expectOutput && len(buf.String()) > 0 {
-				t.Fatalf("Unexpected log messages for secrets:\nOld:\n\t%+v\n\nNew:\n\t%+v\nMessage:%s", testcase.oldSecret, testcase.secret, buf.String())
-			}
-
-			if testcase.expectErrOutput && len(errBuf.String()) == 0 {
-				t.Fatalf("Expected log error output on secret update for secrets:\nOld:\n\t%+v\nNew\n\t%+v", testcase.oldSecret, testcase.secret)
-			} else if !testcase.expectErrOutput && len(errBuf.String()) > 0 {
-				t.Fatalf("Unexpected log error messages for secrets:\nOld:\n\t%+v\n\nNew:\n\t%+v\nMessage:%s", testcase.oldSecret, testcase.secret, errBuf.String())
-			}
-		})
-	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind failing-test

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Prevent data race condition in vsphere unit tests 
https://storage.googleapis.com/k8s-gubernator/triage/index.html?pr=1&text=RACE&test=TestSecretUpdated

In this vsphere unit tests file, The method TestSecretUpdated **does not call**  `NewControllerNode` .
TestSecretUpdated  call [klog.InitFlags(nil)](https://github.com/kubernetes/kubernetes/blob/f40b10e3aa0fab3a2b79cdb9a3b44e37286a3c01/staging/src/k8s.io/legacy-cloud-providers/vsphere/vsphere_test.go#L231) —> [logging.addDirHeader]()  to write value of  logging.addDirHeader.

the other test methods call [`NewControllerNode`](https://github.com/kubernetes/kubernetes/blob/f40b10e3aa0fab3a2b79cdb9a3b44e37286a3c01/staging/src/k8s.io/legacy-cloud-providers/vsphere/vsphere_test.go#L347) function which call [runtime.SetFinalizer(vs, logout)](https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/legacy-cloud-providers/vsphere/vsphere.go#L512).
the finalizer calls [logout](https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/legacy-cloud-providers/vsphere/vsphere.go#L559) —> kolg.Errof()—>logging.printf() —> l.header(s, 0) —> [l.addDirHeader](https://github.com/kubernetes/kubernetes/blob/master/vendor/k8s.io/klog/v2/klog.go#L605) to read value of logging.addDirHeader

Very occasionally, this test method  `TestSecretUpdated` is run at the same time as the finalizer `logout`.
Two goroutine simultaneously access a variable, and one of them is a write operation，resulting in the `DATA RACE`
Therefore,This method is moved to the position before the other function calls the finalizer to avoid `DATA RACE`

The root cause of  `data race` is that `Klog` global logging addDirHeader does not use atomic reads and writes and the Klog code needs to be modified . For now, fix the test failure problem in kubernetes test code.


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Part of  #101927

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
