### PR TITLE
Add Node IP IPv6 formatting in NodeAuthenticator tests

### DIFF
--- a/test/e2e/auth/node_authn.go
+++ b/test/e2e/auth/node_authn.go
@@ -19,7 +19,8 @@ package auth
 import (
 	"context"
 	"fmt"
-	netutil "k8s.io/utils/net"
+	"net"
+	"strconv"
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -61,8 +62,8 @@ var _ = SIGDescribe("[Feature:NodeAuthenticator]", func() {
 		pod := createNodeAuthTestPod(f)
 		for _, nodeIP := range nodeIPs {
 			// Anonymous authentication is disabled by default
-			nodeIP = getFormattedNodeIP(nodeIP)
-			result := framework.RunHostCmdOrDie(ns, pod.Name, fmt.Sprintf("curl -sIk -o /dev/null -w '%s' https://%s:%v/metrics", "%{http_code}", nodeIP, ports.KubeletPort))
+			host := net.JoinHostPort(nodeIP, strconv.Itoa(ports.KubeletPort))
+			result := framework.RunHostCmdOrDie(ns, pod.Name, fmt.Sprintf("curl -sIk -o /dev/null -w '%s' https://%s/metrics", "%{http_code}", host))
 			gomega.Expect(result).To(gomega.Or(gomega.Equal("401"), gomega.Equal("403")), "the kubelet's main port 10250 should reject requests with no credentials")
 		}
 	})
@@ -83,24 +84,17 @@ var _ = SIGDescribe("[Feature:NodeAuthenticator]", func() {
 		pod := createNodeAuthTestPod(f)
 
 		for _, nodeIP := range nodeIPs {
-			nodeIP = getFormattedNodeIP(nodeIP)
+			host := net.JoinHostPort(nodeIP, strconv.Itoa(ports.KubeletPort))
 			result := framework.RunHostCmdOrDie(ns,
 				pod.Name,
-				fmt.Sprintf("curl -sIk -o /dev/null -w '%s' --header \"Authorization: Bearer `%s`\" https://%s:%v/metrics",
+				fmt.Sprintf("curl -sIk -o /dev/null -w '%s' --header \"Authorization: Bearer `%s`\" https://%s/metrics",
 					"%{http_code}",
 					"cat /var/run/secrets/kubernetes.io/serviceaccount/token",
-					nodeIP, ports.KubeletPort))
+					host))
 			gomega.Expect(result).To(gomega.Or(gomega.Equal("401"), gomega.Equal("403")), "the kubelet can delegate ServiceAccount tokens to the API server")
 		}
 	})
 })
-
-func getFormattedNodeIP(nodeIP string) string {
-	if netutil.IsIPv6String(nodeIP) {
-		return fmt.Sprintf("[%s]", nodeIP)
-	}
-	return nodeIP
-}
 
 func createNodeAuthTestPod(f *framework.Framework) *v1.Pod {
 	pod := e2epod.NewAgnhostPod(f.Namespace.Name, "agnhost-pod", nil, nil, nil)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Enable `[Feature:Feature:NodeAuthenticator]` tests for IPv6 configuration.

#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for your reviewer:

Enclose node ip within `[]` when it is IPv6 for `[Feature:NodeAuthenticator]` tests. 

```release-notes
NONE
```