### PR TITLE
Eviction: account for PDB failsafe mode

### DIFF
--- a/pkg/registry/core/pod/storage/eviction.go
+++ b/pkg/registry/core/pod/storage/eviction.go
@@ -25,6 +25,7 @@ import (
 	policyv1 "k8s.io/api/policy/v1"
 	policyv1beta1 "k8s.io/api/policy/v1beta1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -220,7 +221,7 @@ func (r *EvictionREST) Create(ctx context.Context, name string, obj runtime.Obje
 		pdbName = pdb.Name
 
 		// If the pod is not ready, it doesn't count towards healthy and we should not decrement
-		if !podutil.IsPodReady(pod) && pdb.Status.CurrentHealthy >= pdb.Status.DesiredHealthy && pdb.Status.DesiredHealthy > 0 {
+		if !podutil.IsPodReady(pod) && enoughHealthyReplicas(pdb) {
 			updateDeletionOptions = true
 			return nil
 		}
@@ -301,6 +302,26 @@ func canIgnorePDB(pod *api.Pod) bool {
 		return true
 	}
 	return false
+}
+
+// enoughHealthyReplicas checks to determine there are enough healthy replicas
+// available to allow already disrupted pods to be evicted.  We also ensure the
+// PDB is not in failSafe mode so we don't use stale data.
+func enoughHealthyReplicas(pdb *policyv1.PodDisruptionBudget) bool {
+	// We only consider if the conditions is not nil and if we're in failSafe mode represented by
+	// condition.Reason == policyv1.SyncFailedReason
+	disruptionAllowed := apimeta.FindStatusCondition(pdb.Status.Conditions, policyv1.DisruptionAllowedCondition)
+
+	// we only allow disruptions for PDBs that have synced at least once
+	if disruptionAllowed == nil {
+		return false
+	}
+	// if the sync failed, PDB was unable to calculate accurate DesiredHealthy
+	if disruptionAllowed.Status == metav1.ConditionFalse && disruptionAllowed.Reason == policyv1.SyncFailedReason {
+		return false
+	}
+
+	return pdb.Status.CurrentHealthy >= pdb.Status.DesiredHealthy && pdb.Status.DesiredHealthy > 0
 }
 
 func shouldEnforceResourceVersion(pod *api.Pod) bool {

--- a/pkg/registry/core/pod/storage/eviction_test.go
+++ b/pkg/registry/core/pod/storage/eviction_test.go
@@ -337,12 +337,105 @@ func TestEvictionIngorePDB(t *testing.T) {
 					DisruptionsAllowed: 0,
 					CurrentHealthy:     2,
 					DesiredHealthy:     2,
+					Conditions: []metav1.Condition{
+						{
+							Type:    policyv1.DisruptionAllowedCondition,
+							Status:  metav1.ConditionTrue,
+							Reason:  "none",
+							Message: "none",
+						},
+					},
 				},
 			}},
 			eviction:            &policy.Eviction{ObjectMeta: metav1.ObjectMeta{Name: "t8", Namespace: "default"}, DeleteOptions: metav1.NewDeleteOptions(0)},
 			expectError:         false,
 			podName:             "t8",
 			expectedDeleteCount: 1,
+			podTerminating:      false,
+			podPhase:            api.PodRunning,
+			prc: &api.PodCondition{
+				Type:   api.PodReady,
+				Status: api.ConditionFalse,
+			},
+		},
+		{
+			name: "matching pdbs with no disruptions allowed, pod running, pod unhealthy, unhealthy pod ours, nil conditions",
+			pdbs: []runtime.Object{&policyv1.PodDisruptionBudget{
+				ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "default"},
+				Spec:       policyv1.PodDisruptionBudgetSpec{Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"a": "true"}}},
+				Status: policyv1.PodDisruptionBudgetStatus{
+					// This simulates 3 pods desired, our pod unhealthy
+					DisruptionsAllowed: 0,
+					CurrentHealthy:     2,
+					DesiredHealthy:     2,
+				},
+			}},
+			eviction:            &policy.Eviction{ObjectMeta: metav1.ObjectMeta{Name: "t8", Namespace: "default"}, DeleteOptions: metav1.NewDeleteOptions(0)},
+			expectError:         true,
+			podName:             "t8",
+			expectedDeleteCount: 0,
+			podTerminating:      false,
+			podPhase:            api.PodRunning,
+			prc: &api.PodCondition{
+				Type:   api.PodReady,
+				Status: api.ConditionFalse,
+			},
+		},
+		{
+			name: "matching pdbs with no disruptions allowed, pod running, pod unhealthy, unhealthy pod ours, conditions.disruptionAllowed==False, conditions.reason=other",
+			pdbs: []runtime.Object{&policyv1.PodDisruptionBudget{
+				ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "default"},
+				Spec:       policyv1.PodDisruptionBudgetSpec{Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"a": "true"}}},
+				Status: policyv1.PodDisruptionBudgetStatus{
+					// This simulates 3 pods desired, our pod unhealthy
+					DisruptionsAllowed: 0,
+					CurrentHealthy:     2,
+					DesiredHealthy:     2,
+					Conditions: []metav1.Condition{
+						{
+							Type:    policyv1.DisruptionAllowedCondition,
+							Status:  metav1.ConditionFalse,
+							Reason:  "other",
+							Message: "none",
+						},
+					},
+				},
+			}},
+			eviction:            &policy.Eviction{ObjectMeta: metav1.ObjectMeta{Name: "t8", Namespace: "default"}, DeleteOptions: metav1.NewDeleteOptions(0)},
+			expectError:         false,
+			podName:             "t8",
+			expectedDeleteCount: 1,
+			podTerminating:      false,
+			podPhase:            api.PodRunning,
+			prc: &api.PodCondition{
+				Type:   api.PodReady,
+				Status: api.ConditionFalse,
+			},
+		},
+		{
+			name: "matching pdbs with no disruptions allowed, pod running, pod unhealthy, unhealthy pod ours, conditions.disruptionAllowed==False, conditions.reason=policyv1.SyncFailedReason",
+			pdbs: []runtime.Object{&policyv1.PodDisruptionBudget{
+				ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "default"},
+				Spec:       policyv1.PodDisruptionBudgetSpec{Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"a": "true"}}},
+				Status: policyv1.PodDisruptionBudgetStatus{
+					// This simulates 3 pods desired, our pod unhealthy
+					DisruptionsAllowed: 0,
+					CurrentHealthy:     2,
+					DesiredHealthy:     2,
+					Conditions: []metav1.Condition{
+						{
+							Type:    policyv1.DisruptionAllowedCondition,
+							Status:  metav1.ConditionFalse,
+							Reason:  policyv1.SyncFailedReason,
+							Message: "none",
+						},
+					},
+				},
+			}},
+			eviction:            &policy.Eviction{ObjectMeta: metav1.ObjectMeta{Name: "t8", Namespace: "default"}, DeleteOptions: metav1.NewDeleteOptions(0)},
+			expectError:         true,
+			podName:             "t8",
+			expectedDeleteCount: 0,
 			podTerminating:      false,
 			podPhase:            api.PodRunning,
 			prc: &api.PodCondition{
@@ -361,6 +454,14 @@ func TestEvictionIngorePDB(t *testing.T) {
 					DisruptionsAllowed: 0,
 					CurrentHealthy:     2,
 					DesiredHealthy:     2,
+					Conditions: []metav1.Condition{
+						{
+							Type:    policyv1.DisruptionAllowedCondition,
+							Status:  metav1.ConditionTrue,
+							Reason:  "none",
+							Message: "none",
+						},
+					},
 				},
 			}},
 			eviction:            &policy.Eviction{ObjectMeta: metav1.ObjectMeta{Name: "t9", Namespace: "default"}, DeleteOptions: metav1.NewDeleteOptions(0)},
@@ -385,6 +486,14 @@ func TestEvictionIngorePDB(t *testing.T) {
 					DisruptionsAllowed: 0,
 					CurrentHealthy:     2,
 					DesiredHealthy:     2,
+					Conditions: []metav1.Condition{
+						{
+							Type:    policyv1.DisruptionAllowedCondition,
+							Status:  metav1.ConditionTrue,
+							Reason:  "none",
+							Message: "none",
+						},
+					},
 				},
 			}},
 			eviction:            &policy.Eviction{ObjectMeta: metav1.ObjectMeta{Name: "t10", Namespace: "default"}, DeleteOptions: metav1.NewDeleteOptions(0)},


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:
If PDB controller experiences a failure, it may set a status condition
to represent a failsafe mode.  Currently, the eviction API will allow
deletion of unready pods without considering PDB failsafe condition.
The eviction API should respect this failsafe and disallow evictions
of unready pods.

#### Which issue(s) this PR fixes:

Fixes #99598

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
To protect against unwanted disruption, evictions will be disallowed for unready pods when a related PDB is in failsafe mode.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
