### PR TITLE
kubeadm: remove deprecated "--csr*" flags in "init phase certs"

### DIFF
--- a/cmd/kubeadm/app/cmd/certs.go
+++ b/cmd/kubeadm/app/cmd/certs.go
@@ -301,8 +301,14 @@ func addRenewFlags(cmd *cobra.Command, flags *renewFlags) {
 	options.AddConfigFlag(cmd.Flags(), &flags.cfgPath)
 	options.AddCertificateDirFlag(cmd.Flags(), &flags.cfg.CertificatesDir)
 	options.AddKubeConfigFlag(cmd.Flags(), &flags.kubeconfigPath)
+
+	// TODO: remove these flags in a future version:
+	// https://github.com/kubernetes/kubeadm/issues/2163
+	const deprecationMessage = "This flag will be removed in a future version. Please use 'kubeadm certs generate-csr' instead."
 	options.AddCSRFlag(cmd.Flags(), &flags.csrOnly)
+	cmd.Flags().MarkDeprecated(options.CSROnly, deprecationMessage)
 	options.AddCSRDirFlag(cmd.Flags(), &flags.csrPath)
+	cmd.Flags().MarkDeprecated(options.CSRDir, deprecationMessage)
 }
 
 func renewCert(flags *renewFlags, kdir string, internalcfg *kubeadmapi.InitConfiguration, handler *renewal.CertificateRenewHandler) error {

--- a/cmd/kubeadm/app/cmd/phases/init/certs.go
+++ b/cmd/kubeadm/app/cmd/phases/init/certs.go
@@ -21,7 +21,6 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
-	"github.com/spf13/pflag"
 
 	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
 	kubeadmscheme "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/scheme"
@@ -48,11 +47,6 @@ var (
 		` + cmdutil.AlphaDisclaimer)
 )
 
-var (
-	csrOnly bool
-	csrDir  string
-)
-
 // NewCertsPhase returns the phase for the certs
 func NewCertsPhase() workflow.Phase {
 	return workflow.Phase{
@@ -62,15 +56,6 @@ func NewCertsPhase() workflow.Phase {
 		Run:    runCerts,
 		Long:   cmdutil.MacroCommandLongDescription,
 	}
-}
-
-func localFlags() *pflag.FlagSet {
-	set := pflag.NewFlagSet("csr", pflag.ExitOnError)
-	options.AddCSRFlag(set, &csrOnly)
-	set.MarkDeprecated(options.CSROnly, "This flag will be removed in a future version. Please use kubeadm alpha certs generate-csr instead.")
-	options.AddCSRDirFlag(set, &csrDir)
-	set.MarkDeprecated(options.CSRDir, "This flag will be removed in a future version. Please use kubeadm alpha certs generate-csr instead.")
-	return set
 }
 
 // newCertSubPhases returns sub phases for certs phase
@@ -97,7 +82,6 @@ func newCertSubPhases() []workflow.Phase {
 			lastCACert = cert
 		} else {
 			phase = newCertSubPhase(cert, runCertPhase(cert, lastCACert))
-			phase.LocalFlags = localFlags()
 		}
 		subPhases = append(subPhases, phase)
 	}
@@ -279,15 +263,6 @@ func runCertPhase(cert *certsphase.KubeadmCert, caCert *certsphase.KubeadmCert) 
 
 			fmt.Printf("[certs] Using existing %s certificate and key on disk\n", cert.BaseName)
 			return nil
-		}
-
-		if csrOnly {
-			fmt.Printf("[certs] Generating CSR for %s instead of certificate\n", cert.BaseName)
-			if csrDir == "" {
-				csrDir = data.CertificateWriteDir()
-			}
-
-			return certsphase.CreateCSR(cert, data.Cfg(), csrDir)
 		}
 
 		// if dryrunning, write certificates to a temporary folder (and defer restore to the path originally specified by the user)

--- a/cmd/kubeadm/app/cmd/phases/init/certs_test.go
+++ b/cmd/kubeadm/app/cmd/phases/init/certs_test.go
@@ -23,9 +23,7 @@ import (
 	"github.com/spf13/cobra"
 	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
 	"k8s.io/kubernetes/cmd/kubeadm/app/cmd/phases/workflow"
-	"k8s.io/kubernetes/cmd/kubeadm/app/phases/certs"
 	certstestutil "k8s.io/kubernetes/cmd/kubeadm/app/util/certs"
-	"k8s.io/kubernetes/cmd/kubeadm/app/util/pkiutil"
 	pkiutiltesting "k8s.io/kubernetes/cmd/kubeadm/app/util/pkiutil/testing"
 	testutil "k8s.io/kubernetes/cmd/kubeadm/test"
 )
@@ -39,52 +37,6 @@ func (t *testCertsData) Cfg() *kubeadmapi.InitConfiguration { return t.cfg }
 func (t *testCertsData) ExternalCA() bool                   { return false }
 func (t *testCertsData) CertificateDir() string             { return t.cfg.CertificatesDir }
 func (t *testCertsData) CertificateWriteDir() string        { return t.cfg.CertificatesDir }
-
-func TestCertsWithCSRs(t *testing.T) {
-	// restore global variables
-	defer func() {
-		csrOnly = false
-		csrDir = ""
-	}()
-
-	csrDir := testutil.SetupTempDir(t)
-	defer os.RemoveAll(csrDir)
-	certDir := testutil.SetupTempDir(t)
-	defer os.RemoveAll(certDir)
-	cert := certs.KubeadmCertAPIServer()
-
-	certsData := &testCertsData{
-		cfg: testutil.GetDefaultInternalConfig(t),
-	}
-	certsData.cfg.CertificatesDir = certDir
-
-	// set global vars for the test
-	csrOnly = true
-	csrDir = certDir
-
-	phase := NewCertsPhase()
-	// find the api cert phase
-	var apiServerPhase *workflow.Phase
-	for _, phase := range phase.Phases {
-		if phase.Name == cert.Name {
-			apiServerPhase = &phase
-			break
-		}
-	}
-
-	if apiServerPhase == nil {
-		t.Fatalf("couldn't find apiserver phase")
-	}
-
-	err := apiServerPhase.Run(certsData)
-	if err != nil {
-		t.Fatalf("couldn't run API server phase: %v", err)
-	}
-
-	if _, _, err := pkiutil.TryLoadCSRAndKeyFromDisk(csrDir, cert.BaseName); err != nil {
-		t.Fatalf("couldn't load certificate %q: %v", cert.BaseName, err)
-	}
-}
 
 func TestCreateSparseCerts(t *testing.T) {
 	for _, test := range certstestutil.GetSparseCertTestCases(t) {

--- a/cmd/kubeadm/test/cmd/init_test.go
+++ b/cmd/kubeadm/test/cmd/init_test.go
@@ -19,16 +19,10 @@ package kubeadm
 import (
 	"fmt"
 	"os"
-	"os/exec"
-	"strings"
 	"testing"
 
 	"github.com/lithammer/dedent"
-	"github.com/pkg/errors"
 	"k8s.io/kubernetes/cmd/kubeadm/app/constants"
-	"k8s.io/kubernetes/cmd/kubeadm/app/phases/certs"
-	"k8s.io/kubernetes/cmd/kubeadm/app/util/pkiutil"
-	testutil "k8s.io/kubernetes/cmd/kubeadm/test"
 )
 
 func runKubeadmInit(args ...string) (string, string, int, error) {
@@ -189,66 +183,6 @@ func TestCmdInitConfig(t *testing.T) {
 					rt.expected,
 					(err == nil),
 				)
-			}
-		})
-	}
-}
-
-func TestCmdInitCertPhaseCSR(t *testing.T) {
-	tests := []struct {
-		name          string
-		baseName      string
-		expectedError string
-	}{
-		{
-			name:     "generate CSR",
-			baseName: certs.KubeadmCertKubeletClient().BaseName,
-		},
-		{
-			name:          "fails on CSR",
-			baseName:      certs.KubeadmCertRootCA().BaseName,
-			expectedError: "unknown flag: --csr-only",
-		},
-		{
-			name:          "fails on all",
-			baseName:      "all",
-			expectedError: "unknown flag: --csr-only",
-		},
-	}
-
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			csrDir := testutil.SetupTempDir(t)
-			cert := certs.KubeadmCertKubeletClient()
-			kubeadmPath := getKubeadmPath()
-			_, stderr, _, err := RunCmd(kubeadmPath,
-				"init",
-				"phase",
-				"certs",
-				test.baseName,
-				"--csr-only",
-				"--csr-dir="+csrDir,
-			)
-
-			if test.expectedError != "" {
-				cause := errors.Cause(err)
-				_, ok := cause.(*exec.ExitError)
-				if !ok {
-					t.Fatalf("expected exitErr: got %T (%v)", cause, err)
-				}
-
-				if !strings.Contains(stderr, test.expectedError) {
-					t.Errorf("expected %q to contain %q", stderr, test.expectedError)
-				}
-				return
-			}
-
-			if err != nil {
-				t.Fatalf("couldn't run kubeadm: %v", err)
-			}
-
-			if _, _, err := pkiutil.TryLoadCSRAndKeyFromDisk(csrDir, cert.BaseName); err != nil {
-				t.Fatalf("couldn't load certificate %q: %v", cert.BaseName, err)
 			}
 		})
 	}


### PR DESCRIPTION
#### What this PR does / why we need it:

- Remove the deprecated --csr* flags "init phase certs"
- Deprecate the same flags for "certs renew".

For both cases users should be using "certs generate-csr".

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
xref https://github.com/kubernetes/kubeadm/issues/2163

#### Special notes for your reviewer:
NONE

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
kubead: remove the deprecated "--csr-only" and "--csr-dir" flags from "kubeadm init phase certs". Deprecate the same flags under "kubeadm certs renew". In both cases the command "kubeadm certs generate-csr" should be used instead.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
