### PR TITLE
Update podCondition.lastTransitionTime on status change

### DIFF
--- a/pkg/kubelet/status/status_manager.go
+++ b/pkg/kubelet/status/status_manager.go
@@ -743,9 +743,15 @@ func mergePodStatus(oldPodStatus, newPodStatus v1.PodStatus) v1.PodStatus {
 		}
 	}
 
-	for _, c := range newPodStatus.Conditions {
-		if kubetypes.PodConditionByKubelet(c.Type) {
-			podConditions = append(podConditions, c)
+	for _, newCondition := range newPodStatus.Conditions {
+		if kubetypes.PodConditionByKubelet(newCondition.Type) {
+			for _, oldCondition := range oldPodStatus.Conditions {
+				// Update LastTransitionTime if status is different.
+				if oldCondition.Type == newCondition.Type && oldCondition.Status != newCondition.Status {
+					newCondition.LastTransitionTime = metav1.Now()
+				}
+			}
+			podConditions = append(podConditions, newCondition)
 		}
 	}
 	newPodStatus.Conditions = podConditions

--- a/pkg/kubelet/status/status_manager_test.go
+++ b/pkg/kubelet/status/status_manager_test.go
@@ -1034,8 +1034,9 @@ func TestMergePodStatus(t *testing.T) {
 				Phase: v1.PodRunning,
 				Conditions: []v1.PodCondition{
 					{
-						Type:   v1.PodReady,
-						Status: v1.ConditionFalse,
+						Type:               v1.PodReady,
+						Status:             v1.ConditionFalse,
+						LastTransitionTime: metav1.Now(),
 					},
 					{
 						Type:   v1.PodScheduled,
@@ -1172,8 +1173,8 @@ func conditionsEqual(left, right []v1.PodCondition) bool {
 				if l.Status != r.Status {
 					return false
 				}
-				// If r.LastTransitionTime is not zero, l.LastTransitionTime must not be either. But they aren't compared.
-				if !r.LastTransitionTime.IsZero() && l.LastTransitionTime.IsZero() {
+				// If r.LastTransitionTime is set, l.LastTransitionTime must be too. But they aren't compared.
+				if r.LastTransitionTime.IsZero() != l.LastTransitionTime.IsZero() {
 					return false
 				}
 			}

--- a/pkg/kubelet/status/status_manager_test.go
+++ b/pkg/kubelet/status/status_manager_test.go
@@ -1091,8 +1091,9 @@ func TestMergePodStatus(t *testing.T) {
 				Phase: v1.PodRunning,
 				Conditions: []v1.PodCondition{
 					{
-						Type:   v1.PodReady,
-						Status: v1.ConditionFalse,
+						Type:               v1.PodReady,
+						Status:             v1.ConditionFalse,
+						LastTransitionTime: metav1.Now(),
 					},
 					{
 						Type:   v1.PodScheduled,
@@ -1169,6 +1170,10 @@ func conditionsEqual(left, right []v1.PodCondition) bool {
 			if l.Type == r.Type {
 				found = true
 				if l.Status != r.Status {
+					return false
+				}
+				// If r.LastTransitionTime is not zero, l.LastTransitionTime must not be either. But they aren't compared.
+				if !r.LastTransitionTime.IsZero() && l.LastTransitionTime.IsZero() {
 					return false
 				}
 			}


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
Update lastTransitionTime of podCondition when condition.Status changes. See capture for detail:
<img width="480" alt="Screen Shot 2021-05-18 at 5 47 53 PM" src="https://user-images.githubusercontent.com/16291376/118740689-570ed500-b801-11eb-95af-02cf9dc6995c.png">

#### Which issue(s) this PR fixes:
Not a tracked issue.

#### Special notes for your reviewer:
This PR is a followup to #91282, which includes updated tests.

#### Does this PR introduce a user-facing change?
```release-note
Fixed a bug in which podCondition.lastTransitionTime was not updated whenever the status changed.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
