### PR TITLE
Don't set sysctl net.ipv4.vs.conn_reuse_mode for kernels >=5.9

### DIFF
--- a/pkg/proxy/ipvs/proxier.go
+++ b/pkg/proxy/ipvs/proxier.go
@@ -91,6 +91,9 @@ const (
 	DefaultDummyDevice = "kube-ipvs0"
 
 	connReuseMinSupportedKernelVersion = "4.1"
+
+	// https://github.com/torvalds/linux/commit/35dfb013149f74c2be1ff9c78f14e6a3cd1539d1
+	connReuseFixedKernelVersion = "5.9"
 )
 
 // iptablesJumpChain is tables of iptables chains that ipvs proxier used to install iptables or cleanup iptables.
@@ -376,6 +379,9 @@ func NewProxier(ipt utiliptables.Interface,
 	}
 	if kernelVersion.LessThan(version.MustParseGeneric(connReuseMinSupportedKernelVersion)) {
 		klog.ErrorS(nil, fmt.Sprintf("can't set sysctl %s, kernel version must be at least %s", sysctlConnReuse, connReuseMinSupportedKernelVersion))
+	} else if kernelVersion.AtLeast(version.MustParseGeneric(connReuseFixedKernelVersion)) {
+		// https://github.com/kubernetes/kubernetes/issues/93297
+		klog.V(2).InfoS("Left as-is", "sysctl", sysctlConnReuse)
 	} else {
 		// Set the connection reuse mode
 		if err := utilproxy.EnsureSysctl(sysctl, sysctlConnReuse, 0); err != nil {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

The `net.ipv4.vs.conn_reuse_mode=0` is probably responsible for the problems in #81775 and #99162.

#### Which issue(s) this PR fixes:

Fixes #93297

#### Special notes for your reviewer:

The sysctl net.ipv4.vs.conn_reuse_mode is left as-is for kernels >=5.9 rather that explicitly set to 1 as proposed in https://github.com/kubernetes/kubernetes/issues/93297#issuecomment-662295497.

Tested manually for;
* 5.8.1 - net.ipv4.vs.conn_reuse_mode set to 0
* 5.9.1 - net.ipv4.vs.conn_reuse_mode left as-is
* 5.12.1 - net.ipv4.vs.conn_reuse_mode left as-is

The version string "5.9" will not be changed and is intentionally used as a string literal rather than a constant as `connReuseMinSupportedKernelVersion` (which decrease readability IMHO. I had to search for it and it will never change).

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

N/A

