### PR TITLE
bug(staging_api_apps_v1beta1): add descriptions to staging/src/k8s.io/api/apps/v1beta1/types.go

### DIFF
--- a/hack/.descriptions_failures
+++ b/hack/.descriptions_failures
@@ -1,5 +1,3 @@
-./staging/src/k8s.io/api/apps/v1beta1/types.go
-./staging/src/k8s.io/api/apps/v1beta2/types.go
 ./staging/src/k8s.io/api/autoscaling/v2beta2/types.go
 ./staging/src/k8s.io/api/certificates/v1/types.go
 ./staging/src/k8s.io/api/certificates/v1beta1/types.go

--- a/staging/src/k8s.io/api/apps/v1beta1/generated.proto
+++ b/staging/src/k8s.io/api/apps/v1beta1/generated.proto
@@ -68,7 +68,8 @@ message ControllerRevisionList {
 // more information.
 // Deployment enables declarative updates for Pods and ReplicaSets.
 message Deployment {
-  // Standard object metadata.
+  // Standard object's metadata.
+  // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
   // +optional
   optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
@@ -277,7 +278,8 @@ message RollingUpdateStatefulSetStrategy {
 
 // Scale represents a scaling request for a resource.
 message Scale {
-  // Standard object metadata; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata.
+  // Standard object's metadata.
+  // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
   // +optional
   optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
@@ -325,6 +327,8 @@ message ScaleStatus {
 // The StatefulSet guarantees that a given network identity will always
 // map to the same storage identity.
 message StatefulSet {
+  // Standard object's metadata.
+  // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
   // +optional
   optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
@@ -361,9 +365,12 @@ message StatefulSetCondition {
 
 // StatefulSetList is a collection of StatefulSets.
 message StatefulSetList {
+  // Standard list's metadata.
+  // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
   // +optional
   optional k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
 
+  // Items is the list of Stateful sets.
   repeated StatefulSet items = 2;
 }
 

--- a/staging/src/k8s.io/api/apps/v1beta1/types.go
+++ b/staging/src/k8s.io/api/apps/v1beta1/types.go
@@ -64,7 +64,8 @@ type ScaleStatus struct {
 // Scale represents a scaling request for a resource.
 type Scale struct {
 	metav1.TypeMeta `json:",inline"`
-	// Standard object metadata; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata.
+	// Standard object's metadata.
+	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
 	// +optional
 	metav1.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
 
@@ -94,6 +95,8 @@ type Scale struct {
 // map to the same storage identity.
 type StatefulSet struct {
 	metav1.TypeMeta `json:",inline"`
+	// Standard object's metadata.
+	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
 	// +optional
 	metav1.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
 
@@ -290,9 +293,13 @@ type StatefulSetCondition struct {
 // StatefulSetList is a collection of StatefulSets.
 type StatefulSetList struct {
 	metav1.TypeMeta `json:",inline"`
+	// Standard list's metadata.
+	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
 	// +optional
 	metav1.ListMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
-	Items           []StatefulSet `json:"items" protobuf:"bytes,2,rep,name=items"`
+
+	// Items is the list of Stateful sets.
+	Items []StatefulSet `json:"items" protobuf:"bytes,2,rep,name=items"`
 }
 
 // +genclient
@@ -307,7 +314,8 @@ type StatefulSetList struct {
 // Deployment enables declarative updates for Pods and ReplicaSets.
 type Deployment struct {
 	metav1.TypeMeta `json:",inline"`
-	// Standard object metadata.
+	// Standard object's metadata.
+	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
 	// +optional
 	metav1.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
 

--- a/staging/src/k8s.io/api/apps/v1beta1/types_swagger_doc_generated.go
+++ b/staging/src/k8s.io/api/apps/v1beta1/types_swagger_doc_generated.go
@@ -50,7 +50,7 @@ func (ControllerRevisionList) SwaggerDoc() map[string]string {
 
 var map_Deployment = map[string]string{
 	"":         "DEPRECATED - This group version of Deployment is deprecated by apps/v1beta2/Deployment. See the release notes for more information. Deployment enables declarative updates for Pods and ReplicaSets.",
-	"metadata": "Standard object metadata.",
+	"metadata": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
 	"spec":     "Specification of the desired behavior of the Deployment.",
 	"status":   "Most recently observed status of the Deployment.",
 }
@@ -167,7 +167,7 @@ func (RollingUpdateStatefulSetStrategy) SwaggerDoc() map[string]string {
 
 var map_Scale = map[string]string{
 	"":         "Scale represents a scaling request for a resource.",
-	"metadata": "Standard object metadata; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata.",
+	"metadata": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
 	"spec":     "defines the behavior of the scale. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status.",
 	"status":   "current status of the scale. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status. Read-only.",
 }
@@ -197,9 +197,10 @@ func (ScaleStatus) SwaggerDoc() map[string]string {
 }
 
 var map_StatefulSet = map[string]string{
-	"":       "DEPRECATED - This group version of StatefulSet is deprecated by apps/v1beta2/StatefulSet. See the release notes for more information. StatefulSet represents a set of pods with consistent identities. Identities are defined as:\n - Network: A single stable DNS and hostname.\n - Storage: As many VolumeClaims as requested.\nThe StatefulSet guarantees that a given network identity will always map to the same storage identity.",
-	"spec":   "Spec defines the desired identities of pods in this set.",
-	"status": "Status is the current status of Pods in this StatefulSet. This data may be out of date by some window of time.",
+	"":         "DEPRECATED - This group version of StatefulSet is deprecated by apps/v1beta2/StatefulSet. See the release notes for more information. StatefulSet represents a set of pods with consistent identities. Identities are defined as:\n - Network: A single stable DNS and hostname.\n - Storage: As many VolumeClaims as requested.\nThe StatefulSet guarantees that a given network identity will always map to the same storage identity.",
+	"metadata": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
+	"spec":     "Spec defines the desired identities of pods in this set.",
+	"status":   "Status is the current status of Pods in this StatefulSet. This data may be out of date by some window of time.",
 }
 
 func (StatefulSet) SwaggerDoc() map[string]string {
@@ -220,7 +221,9 @@ func (StatefulSetCondition) SwaggerDoc() map[string]string {
 }
 
 var map_StatefulSetList = map[string]string{
-	"": "StatefulSetList is a collection of StatefulSets.",
+	"":         "StatefulSetList is a collection of StatefulSets.",
+	"metadata": "Standard list's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
+	"items":    "Items is the list of Stateful sets.",
 }
 
 func (StatefulSetList) SwaggerDoc() map[string]string {

--- a/staging/src/k8s.io/api/apps/v1beta2/generated.proto
+++ b/staging/src/k8s.io/api/apps/v1beta2/generated.proto
@@ -614,6 +614,8 @@ message ScaleStatus {
 // The StatefulSet guarantees that a given network identity will always
 // map to the same storage identity.
 message StatefulSet {
+  // Standard object's metadata.
+  // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
   // +optional
   optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
@@ -650,9 +652,12 @@ message StatefulSetCondition {
 
 // StatefulSetList is a collection of StatefulSets.
 message StatefulSetList {
+  // Standard list's metadata.
+  // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
   // +optional
   optional k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
 
+  // Items is the list of Stateful sets.
   repeated StatefulSet items = 2;
 }
 

--- a/staging/src/k8s.io/api/apps/v1beta2/types.go
+++ b/staging/src/k8s.io/api/apps/v1beta2/types.go
@@ -100,6 +100,8 @@ type Scale struct {
 // map to the same storage identity.
 type StatefulSet struct {
 	metav1.TypeMeta `json:",inline"`
+	// Standard object's metadata.
+	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
 	// +optional
 	metav1.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
 
@@ -300,9 +302,13 @@ type StatefulSetCondition struct {
 // StatefulSetList is a collection of StatefulSets.
 type StatefulSetList struct {
 	metav1.TypeMeta `json:",inline"`
+	// Standard list's metadata.
+	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
 	// +optional
 	metav1.ListMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
-	Items           []StatefulSet `json:"items" protobuf:"bytes,2,rep,name=items"`
+
+	// Items is the list of Stateful sets.
+	Items []StatefulSet `json:"items" protobuf:"bytes,2,rep,name=items"`
 }
 
 // +genclient

--- a/staging/src/k8s.io/api/apps/v1beta2/types_swagger_doc_generated.go
+++ b/staging/src/k8s.io/api/apps/v1beta2/types_swagger_doc_generated.go
@@ -321,9 +321,10 @@ func (ScaleStatus) SwaggerDoc() map[string]string {
 }
 
 var map_StatefulSet = map[string]string{
-	"":       "DEPRECATED - This group version of StatefulSet is deprecated by apps/v1/StatefulSet. See the release notes for more information. StatefulSet represents a set of pods with consistent identities. Identities are defined as:\n - Network: A single stable DNS and hostname.\n - Storage: As many VolumeClaims as requested.\nThe StatefulSet guarantees that a given network identity will always map to the same storage identity.",
-	"spec":   "Spec defines the desired identities of pods in this set.",
-	"status": "Status is the current status of Pods in this StatefulSet. This data may be out of date by some window of time.",
+	"":         "DEPRECATED - This group version of StatefulSet is deprecated by apps/v1/StatefulSet. See the release notes for more information. StatefulSet represents a set of pods with consistent identities. Identities are defined as:\n - Network: A single stable DNS and hostname.\n - Storage: As many VolumeClaims as requested.\nThe StatefulSet guarantees that a given network identity will always map to the same storage identity.",
+	"metadata": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
+	"spec":     "Spec defines the desired identities of pods in this set.",
+	"status":   "Status is the current status of Pods in this StatefulSet. This data may be out of date by some window of time.",
 }
 
 func (StatefulSet) SwaggerDoc() map[string]string {
@@ -344,7 +345,9 @@ func (StatefulSetCondition) SwaggerDoc() map[string]string {
 }
 
 var map_StatefulSetList = map[string]string{
-	"": "StatefulSetList is a collection of StatefulSets.",
+	"":         "StatefulSetList is a collection of StatefulSets.",
+	"metadata": "Standard list's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
+	"items":    "Items is the list of Stateful sets.",
 }
 
 func (StatefulSetList) SwaggerDoc() map[string]string {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

This PR adds descriptions for the following in the files staging/src/k8s.io/api/apps/v1beta1/types.go and 
staging/src/k8s.io/api/apps/v1beta2/types.go:

1. Metadata and List fields of Struct `StatefulSetLists`
2. Metadata field of Struct `StatefulSet`

#### Which issue(s) this PR fixes:

Ref #99675

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```