### PR TITLE
Make apimachineryvalidation.totalAnnotationSizeLimitB public

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/api/validation/objectmeta.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/validation/objectmeta.go
@@ -33,7 +33,7 @@ import (
 // FieldImmutableErrorMsg is a error message for field is immutable.
 const FieldImmutableErrorMsg string = `field is immutable`
 
-const totalAnnotationSizeLimitB int = 256 * (1 << 10) // 256 kB
+const TotalAnnotationSizeLimitB int = 256 * (1 << 10) // 256 kB
 
 // BannedOwners is a black list of object that are not allowed to be owners.
 var BannedOwners = map[schema.GroupVersionKind]struct{}{
@@ -53,8 +53,8 @@ func ValidateAnnotations(annotations map[string]string, fldPath *field.Path) fie
 		}
 		totalSize += (int64)(len(k)) + (int64)(len(v))
 	}
-	if totalSize > (int64)(totalAnnotationSizeLimitB) {
-		allErrs = append(allErrs, field.TooLong(fldPath, "", totalAnnotationSizeLimitB))
+	if totalSize > (int64)(TotalAnnotationSizeLimitB) {
+		allErrs = append(allErrs, field.TooLong(fldPath, "", TotalAnnotationSizeLimitB))
 	}
 	return allErrs
 }

--- a/staging/src/k8s.io/apimachinery/pkg/api/validation/objectmeta_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/validation/objectmeta_test.go
@@ -452,10 +452,10 @@ func TestValidateAnnotations(t *testing.T) {
 		{"1234/5678": "bar"},
 		{"1.2.3.4/5678": "bar"},
 		{"UpperCase123": "bar"},
-		{"a": strings.Repeat("b", totalAnnotationSizeLimitB-1)},
+		{"a": strings.Repeat("b", TotalAnnotationSizeLimitB-1)},
 		{
-			"a": strings.Repeat("b", totalAnnotationSizeLimitB/2-1),
-			"c": strings.Repeat("d", totalAnnotationSizeLimitB/2-1),
+			"a": strings.Repeat("b", TotalAnnotationSizeLimitB/2-1),
+			"c": strings.Repeat("d", TotalAnnotationSizeLimitB/2-1),
 		},
 	}
 	for i := range successCases {
@@ -485,10 +485,10 @@ func TestValidateAnnotations(t *testing.T) {
 		}
 	}
 	totalSizeErrorCases := []map[string]string{
-		{"a": strings.Repeat("b", totalAnnotationSizeLimitB)},
+		{"a": strings.Repeat("b", TotalAnnotationSizeLimitB)},
 		{
-			"a": strings.Repeat("b", totalAnnotationSizeLimitB/2),
-			"c": strings.Repeat("d", totalAnnotationSizeLimitB/2),
+			"a": strings.Repeat("b", TotalAnnotationSizeLimitB/2),
+			"c": strings.Repeat("d", TotalAnnotationSizeLimitB/2),
 		},
 	}
 	for i := range totalSizeErrorCases {

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/lastappliedupdater.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/lastappliedupdater.go
@@ -21,11 +21,10 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
+	apimachineryvalidation "k8s.io/apimachinery/pkg/api/validation"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 )
-
-const totalAnnotationSizeLimitB int64 = 256 * (1 << 10) // 256 kB
 
 type lastAppliedUpdater struct {
 	fieldManager Manager
@@ -126,8 +125,8 @@ func isAnnotationsValid(annotations map[string]string) error {
 	for k, v := range annotations {
 		totalSize += (int64)(len(k)) + (int64)(len(v))
 	}
-	if totalSize > (int64)(totalAnnotationSizeLimitB) {
-		return fmt.Errorf("annotations size %d is larger than limit %d", totalSize, totalAnnotationSizeLimitB)
+	if totalSize > (int64)(apimachineryvalidation.TotalAnnotationSizeLimitB) {
+		return fmt.Errorf("annotations size %d is larger than limit %d", totalSize, apimachineryvalidation.TotalAnnotationSizeLimitB)
 	}
 	return nil
 }

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/lastappliedupdater.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/lastappliedupdater.go
@@ -93,7 +93,7 @@ func setLastApplied(obj runtime.Object, value string) error {
 		annotations = map[string]string{}
 	}
 	annotations[corev1.LastAppliedConfigAnnotation] = value
-	if isAnnotationsValid(annotations) != nil {
+	if err := apimachineryvalidation.ValidateAnnotationsSize(annotations); err != nil {
 		delete(annotations, corev1.LastAppliedConfigAnnotation)
 	}
 	accessor.SetAnnotations(annotations)
@@ -118,15 +118,4 @@ func buildLastApplied(obj runtime.Object) (string, error) {
 		return "", fmt.Errorf("couldn't encode object into last applied annotation: %v", err)
 	}
 	return string(lastApplied), nil
-}
-
-func isAnnotationsValid(annotations map[string]string) error {
-	var totalSize int64
-	for k, v := range annotations {
-		totalSize += (int64)(len(k)) + (int64)(len(v))
-	}
-	if totalSize > (int64)(apimachineryvalidation.TotalAnnotationSizeLimitB) {
-		return fmt.Errorf("annotations size %d is larger than limit %d", totalSize, apimachineryvalidation.TotalAnnotationSizeLimitB)
-	}
-	return nil
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This change exposes apimachineryvalidation.totalAnnotationSizeLimitB and replaces the forked totalAnnotationSizeLimitB with apimachineryvalidation.TotalAnnotationSizeLimitB.

This value is useful for validating annotations outside of the validation package, such as in SSA: #102105.

Otherwise, size validation on annotations outside of the package would diverge and cause issues later.

#### Which issue(s) this PR fixes:
Fixes https://github.com/kubernetes/kubernetes/issues/102110

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

/wg api-expression
