### PR TITLE
kubeadm: remove e2e test for ClusterStatus

### DIFF
--- a/test/e2e_kubeadm/kubeadm_config_test.go
+++ b/test/e2e_kubeadm/kubeadm_config_test.go
@@ -32,7 +32,6 @@ const (
 	kubeadmConfigRoleName                         = "kubeadm:nodes-kubeadm-config"
 	kubeadmConfigRoleBindingName                  = kubeadmConfigRoleName
 	kubeadmConfigClusterConfigurationConfigMapKey = "ClusterConfiguration"
-	kubeadmConfigClusterStatusConfigMapKey        = "ClusterStatus"
 )
 
 var (
@@ -60,23 +59,6 @@ var _ = Describe("kubeadm-config ConfigMap", func() {
 		cm := GetConfigMap(f.ClientSet, kubeSystemNamespace, kubeadmConfigName)
 
 		gomega.Expect(cm.Data).To(gomega.HaveKey(kubeadmConfigClusterConfigurationConfigMapKey))
-		gomega.Expect(cm.Data).To(gomega.HaveKey(kubeadmConfigClusterStatusConfigMapKey))
-
-		m := unmarshalYaml(cm.Data[kubeadmConfigClusterStatusConfigMapKey])
-		if _, ok := m["apiEndpoints"]; ok {
-			d := m["apiEndpoints"].(map[interface{}]interface{})
-			// get all control-plane nodes
-			controlPlanes := getControlPlaneNodes(f.ClientSet)
-
-			// checks that all the control-plane nodes are in the apiEndpoints list
-			for _, cp := range controlPlanes.Items {
-				if _, ok := d[cp.Name]; !ok {
-					framework.Failf("failed to get apiEndpoints for control-plane %s in %s", cp.Name, kubeadmConfigClusterStatusConfigMapKey)
-				}
-			}
-		} else {
-			framework.Failf("failed to get apiEndpoints from %s", kubeadmConfigClusterStatusConfigMapKey)
-		}
 	})
 
 	ginkgo.It("should have related Role and RoleBinding", func() {


### PR DESCRIPTION
#### What this PR does / why we need it:

Remove the e2e test for ClusterStatus in the kubeadm suite.
The object was deprecated in a previous release and is no longer
written by kubeadm v1.22 in the kubeadm-config config map.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes/kubeadm/issues/2480

#### Special notes for your reviewer:
NONE

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
