### PR TITLE
Implement support for watch initialization in P&F

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/server/filters/maxinflight.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/filters/maxinflight.go
@@ -47,7 +47,10 @@ const (
 	observationMaintenancePeriod = 10 * time.Second
 )
 
-var nonMutatingRequestVerbs = sets.NewString("get", "list", "watch")
+var (
+	nonMutatingRequestVerbs = sets.NewString("get", "list", "watch")
+	watchVerbs              = sets.NewString("watch")
+)
 
 func handleError(w http.ResponseWriter, r *http.Request, err error) {
 	errorMsg := fmt.Sprintf("Internal Server Error: %#v", r.RequestURI)

--- a/staging/src/k8s.io/apiserver/pkg/server/filters/priority-and-fairness.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/filters/priority-and-fairness.go
@@ -17,23 +17,20 @@ limitations under the License.
 package filters
 
 import (
-	"context"
 	"fmt"
 	"net/http"
+	"sync"
 	"sync/atomic"
 
 	flowcontrol "k8s.io/api/flowcontrol/v1beta1"
 	apitypes "k8s.io/apimachinery/pkg/types"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	epmetrics "k8s.io/apiserver/pkg/endpoints/metrics"
 	apirequest "k8s.io/apiserver/pkg/endpoints/request"
 	utilflowcontrol "k8s.io/apiserver/pkg/util/flowcontrol"
 	fcmetrics "k8s.io/apiserver/pkg/util/flowcontrol/metrics"
 	"k8s.io/klog/v2"
 )
-
-type priorityAndFairnessKeyType int
-
-const priorityAndFairnessKey priorityAndFairnessKeyType = iota
 
 // PriorityAndFairnessClassification identifies the results of
 // classification for API Priority and Fairness
@@ -42,12 +39,6 @@ type PriorityAndFairnessClassification struct {
 	FlowSchemaUID     apitypes.UID
 	PriorityLevelName string
 	PriorityLevelUID  apitypes.UID
-}
-
-// GetClassification returns the classification associated with the
-// given context, if any, otherwise nil
-func GetClassification(ctx context.Context) *PriorityAndFairnessClassification {
-	return ctx.Value(priorityAndFairnessKey).(*PriorityAndFairnessClassification)
 }
 
 // waitingMark tracks requests waiting rather than being executed
@@ -59,6 +50,9 @@ var waitingMark = &requestWatermark{
 
 var atomicMutatingExecuting, atomicReadOnlyExecuting int32
 var atomicMutatingWaiting, atomicReadOnlyWaiting int32
+
+// newInitializationSignal is defined for testing purposes.
+var newInitializationSignal = utilflowcontrol.NewInitializationSignal
 
 // WithPriorityAndFairness limits the number of in-flight
 // requests in a fine-grained way.
@@ -84,8 +78,10 @@ func WithPriorityAndFairness(
 			return
 		}
 
-		// Skip tracking long running requests.
-		if longRunningRequestCheck != nil && longRunningRequestCheck(r, requestInfo) {
+		isWatchRequest := watchVerbs.Has(requestInfo.Verb)
+
+		// Skip tracking long running non-watch requests.
+		if longRunningRequestCheck != nil && longRunningRequestCheck(r, requestInfo) && !isWatchRequest {
 			klog.V(6).Infof("Serving RequestInfo=%#+v, user.Info=%#+v as longrunning\n", requestInfo, user)
 			handler.ServeHTTP(w, r)
 			return
@@ -116,15 +112,40 @@ func WithPriorityAndFairness(
 				waitingMark.recordReadOnly(int(atomic.AddInt32(&atomicReadOnlyWaiting, delta)))
 			}
 		}
+		wg := sync.WaitGroup{}
 		execute := func() {
 			noteExecutingDelta(1)
 			defer noteExecutingDelta(-1)
 			served = true
-			innerCtx := context.WithValue(ctx, priorityAndFairnessKey, classification)
-			innerReq := r.Clone(innerCtx)
+
+			innerCtx := ctx
+			innerReq := r
+
+			var watchInitializationSignal utilflowcontrol.InitializationSignal
+			if isWatchRequest {
+				watchInitializationSignal = newInitializationSignal()
+				innerCtx = utilflowcontrol.WithInitializationSignal(ctx, watchInitializationSignal)
+				innerReq = r.Clone(innerCtx)
+			}
 			setResponseHeaders(classification, w)
 
-			handler.ServeHTTP(w, innerReq)
+			if isWatchRequest {
+				wg.Add(1)
+				go func() {
+					defer utilruntime.HandleCrash()
+
+					defer wg.Done()
+					// Protect from the situations when request will not reach storage layer
+					// and the initialization signal will not be send.
+					defer watchInitializationSignal.Signal()
+
+					handler.ServeHTTP(w, innerReq)
+				}()
+
+				watchInitializationSignal.Wait()
+			} else {
+				handler.ServeHTTP(w, innerReq)
+			}
 		}
 		digest := utilflowcontrol.RequestDigest{RequestInfo: requestInfo, User: user}
 		fcIfc.Handle(ctx, digest, note, func(inQueue bool) {
@@ -143,9 +164,13 @@ func WithPriorityAndFairness(
 				epmetrics.DroppedRequests.WithContext(ctx).WithLabelValues(epmetrics.ReadOnlyKind).Inc()
 			}
 			epmetrics.RecordRequestTermination(r, requestInfo, epmetrics.APIServerComponent, http.StatusTooManyRequests)
+			if isWatchRequest {
+				wg.Done()
+			}
 			tooManyRequests(r, w)
 		}
-
+		// In case of watch, from P&F POV it already finished, but we need to wait until the request itself finishes.
+		wg.Wait()
 	})
 }
 

--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/watcher.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/watcher.go
@@ -32,6 +32,7 @@ import (
 	"k8s.io/apiserver/pkg/storage"
 	"k8s.io/apiserver/pkg/storage/etcd3/metrics"
 	"k8s.io/apiserver/pkg/storage/value"
+	utilflowcontrol "k8s.io/apiserver/pkg/util/flowcontrol"
 
 	"go.etcd.io/etcd/clientv3"
 	"k8s.io/klog/v2"
@@ -120,6 +121,14 @@ func (w *watcher) Watch(ctx context.Context, key string, rev int64, recursive, p
 	}
 	wc := w.createWatchChan(ctx, key, rev, recursive, progressNotify, pred)
 	go wc.run()
+
+	// For etcd watch we don't have an easy way to answer whether the watch
+	// has already caught up. So in the initial version (given that watchcache
+	// is by default enabled for all resources but Events), we just deliver
+	// the initialization signal immediately. Improving this will be explored
+	// in the future.
+	utilflowcontrol.WatchInitialized(ctx)
+
 	return wc, nil
 }
 

--- a/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/apf_context.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/apf_context.go
@@ -1,0 +1,82 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package flowcontrol
+
+import (
+	"context"
+	"sync"
+)
+
+type priorityAndFairnessKeyType int
+
+const (
+	// priorityAndFairnessInitializationSignalKey is a key under which
+	// initialization signal function for watch requests is stored
+	// in the context.
+	priorityAndFairnessInitializationSignalKey priorityAndFairnessKeyType = iota
+)
+
+// WithInitializationSignal creates a copy of parent context with
+// priority and fairness initialization signal value.
+func WithInitializationSignal(ctx context.Context, signal InitializationSignal) context.Context {
+	return context.WithValue(ctx, priorityAndFairnessInitializationSignalKey, signal)
+}
+
+// initializationSignalFrom returns an initialization signal function
+// which when called signals that watch initialization has already finished
+// to priority and fairness dispatcher.
+func initializationSignalFrom(ctx context.Context) (InitializationSignal, bool) {
+	signal, ok := ctx.Value(priorityAndFairnessInitializationSignalKey).(InitializationSignal)
+	return signal, ok && signal != nil
+}
+
+// WatchInitialized sends a signal to priority and fairness dispatcher
+// that a given watch request has already been initialized.
+func WatchInitialized(ctx context.Context) {
+	if signal, ok := initializationSignalFrom(ctx); ok {
+		signal.Signal()
+	}
+}
+
+// InitializationSignal is an interface that allows sending and handling
+// initialization signals.
+type InitializationSignal interface {
+	// Signal notifies the dispatcher about finished initialization.
+	Signal()
+	// Wait waits for the initialization signal.
+	Wait()
+}
+
+type initializationSignal struct {
+	once sync.Once
+	done chan struct{}
+}
+
+func NewInitializationSignal() InitializationSignal {
+	return &initializationSignal{
+		once: sync.Once{},
+		done: make(chan struct{}),
+	}
+}
+
+func (i *initializationSignal) Signal() {
+	i.once.Do(func() { close(i.done) })
+}
+
+func (i *initializationSignal) Wait() {
+	<-i.done
+}


### PR DESCRIPTION
Ref https://github.com/kubernetes/enhancements/issues/1040

/kind feature
/priority important-longterm

```release-note
Watch requests are now handled throttled by priority and fairness filter in kube-apiserver
```

/assign @deads2k @tkashem 
/cc @lavalamp @MikeSpreitzer 