### PR TITLE
exec credential provider: don't run exec plugin with basic auth

### DIFF
--- a/staging/src/k8s.io/client-go/plugin/pkg/client/auth/exec/exec.go
+++ b/staging/src/k8s.io/client-go/plugin/pkg/client/auth/exec/exec.go
@@ -263,8 +263,9 @@ func (a *Authenticator) UpdateTransportConfig(c *transport.Config) error {
 	// setting up the transport, as that triggers the exec action if the server is
 	// also configured to allow client certificates for authentication. For requests
 	// like "kubectl get --token (token) pods" we should assume the intention is to
-	// use the provided token for authentication.
-	if c.HasTokenAuth() {
+	// use the provided token for authentication. The same can be said for when the
+	// user specifies basic auth.
+	if c.HasTokenAuth() || c.HasBasicAuth() {
 		return nil
 	}
 

--- a/test/integration/client/exec_test.go
+++ b/test/integration/client/exec_test.go
@@ -329,12 +329,8 @@ func TestExecPluginViaClient(t *testing.T) {
 				c.Password = "unauthorized"
 			},
 			wantAuthorizationHeaderValues: [][]string{{"Basic " + basicAuthHeaderValue("unauthorized", "unauthorized")}},
-			wantCertificate:               &tls.Certificate{},
 			wantClientErrorPrefix:         "Unauthorized",
-			// I don't think we should be calling the exec plugin here. We don't call the exec
-			// plugin in the case where bearer tokens are already present, and this case is
-			// similar. See https://github.com/kubernetes/kubernetes/pull/102175.
-			wantMetrics: &execPluginMetrics{calls: []execPluginCall{{exitCode: 0, callStatus: "no_error"}}},
+			wantMetrics:                   &execPluginMetrics{},
 		},
 		{
 			name: "good token with static auth bearer token favors static auth bearer token",


### PR DESCRIPTION
If a user specifies basic auth, then apply the same short circuit logic
that we do for bearer tokens (see comment).

Signed-off-by: Andrew Keesler <akeesler@vmware.com>

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

* When a user has specified that they want to use basic auth, client-go should not call any exec plugins.
* See https://github.com/kubernetes/kubernetes/pull/91745 for more rationalization.

#### Which issue(s) this PR fixes:

None.

#### Special notes for your reviewer:

* This showed up when writing an integration test for exec plugin metrics: https://github.com/kubernetes/kubernetes/pull/102152
* This is related to taking exec plugins, which we are trying to take GA in 1.22
* Exec plugins feature set tracking issue: kubernetes/enhancements#541
* Exec plugins KEP: https://github.com/kubernetes/enhancements/blob/master/keps/sig-auth/541-external-credential-providers/README.md

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

/sig auth