### PR TITLE
quota controller and admission: set consistent unit format in quota used

### DIFF
--- a/test/conformance/testdata/conformance.yaml
+++ b/test/conformance/testdata/conformance.yaml
@@ -434,7 +434,7 @@
     fail as the request exceeds ResourceQuota limits. Update the successfully created
     pod's resource requests. Updation MUST fail as a Pod can not dynamically update
     its resource requirements. Delete the successfully created Pod. Pod Deletion MUST
-    be scuccessful and it MUST release the allocated resource counts from ResourceQuotaStatus
+    be successful and it MUST release the allocated resource counts from ResourceQuotaStatus
     of the ResourceQuota.
   release: v1.16
   file: test/e2e/apimachinery/resource_quota.go


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Unit format is chosen in a non deterministic manner; ie it chooses a unit format according to a resource that gets counted first. And so it is  not computed consistently from a similar set of pods (values + units). Since we cannot automatically and consistently choose the right unit format for the user (BinarySI vs DecimalSI), it is better to at least default to the one defined in hard limits.

This can be also fixed on CLI side: https://github.com/kubernetes/kubernetes/pull/102177

#### Which issue(s) this PR fixes:
Unit format would change on reordering containers when having just one deployment (first container having 400M and the second 400Mi). This issue also arises with multiple deployments/pods.

|                 | container-1 | container-2 | Quota used
|----|---|---|---
|scenario A | 400M | 400Mi | 819430400
|scenario B | 400Mi | 400M | 800225Ki

#### Special notes for your reviewer:

Since the status can get updated in two places it requires both changes to quota controller and to the admission plugin.
I added the unit tests to the quota controller, but not to the admission plugin. Please let me know if I should include the tests there as well.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
ResourceQuota status.used has the same unit format as hard 
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
NONE
```
