### PR TITLE
Deprecate azure and gcp in-tree auth plugins

### DIFF
--- a/staging/src/k8s.io/client-go/plugin/pkg/client/auth/azure/azure.go
+++ b/staging/src/k8s.io/client-go/plugin/pkg/client/auth/azure/azure.go
@@ -84,7 +84,16 @@ func (c *azureTokenCache) setToken(tokenKey string, token *azureToken) {
 	c.cache[tokenKey] = token
 }
 
+var warnOnce sync.Once
+
 func newAzureAuthProvider(_ string, cfg map[string]string, persister restclient.AuthProviderConfigPersister) (restclient.AuthProvider, error) {
+	// deprecated in v1.22, remove in v1.25
+	// this should be updated to use klog.Warningf in v1.24 to more actively warn consumers
+	warnOnce.Do(func() {
+		klog.V(1).Infof(`WARNING: the azure auth plugin is deprecated in v1.22+, unavailable in v1.25+; use https://github.com/Azure/kubelogin instead.
+To learn more, consult https://kubernetes.io/docs/reference/access-authn-authz/authentication/#client-go-credential-plugins`)
+	})
+
 	var (
 		ts          tokenSource
 		environment azure.Environment

--- a/staging/src/k8s.io/client-go/plugin/pkg/client/auth/gcp/gcp.go
+++ b/staging/src/k8s.io/client-go/plugin/pkg/client/auth/gcp/gcp.go
@@ -113,7 +113,16 @@ type gcpAuthProvider struct {
 	persister   restclient.AuthProviderConfigPersister
 }
 
+var warnOnce sync.Once
+
 func newGCPAuthProvider(_ string, gcpConfig map[string]string, persister restclient.AuthProviderConfigPersister) (restclient.AuthProvider, error) {
+	// deprecated in v1.22, remove in v1.25
+	// this should be updated to use klog.Warningf in v1.24 to more actively warn consumers
+	warnOnce.Do(func() {
+		klog.V(1).Infof(`WARNING: the gcp auth plugin is deprecated in v1.22+, unavailable in v1.25+; use gcloud instead.
+To learn more, consult https://kubernetes.io/docs/reference/access-authn-authz/authentication/#client-go-credential-plugins`)
+	})
+
 	ts, err := tokenSource(isCmdTokenSource(gcpConfig), gcpConfig)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
With the client-go credential plugin functionality going GA in 1.22,
it is now time to deprecate these legacy integrations.

Signed-off-by: Monis Khan <mok@vmware.com>

/kind cleanup
/kind deprecation
/sig auth
/priority important-soon
/triage accepted
/milestone v1.22
@kubernetes/sig-auth-pr-reviews
/assign @ritazh @mikedanese @cjcullen @ankeesler @liggitt 

```release-note
The in-tree azure and gcp auth plugins have been deprecated.  The https://github.com/Azure/kubelogin and gcloud commands serve as out-of-tree replacements via the kubectl/client-go credential plugin mechanism.
```

```docs
- [KEP]: https://github.com/kubernetes/enhancements/tree/master/keps/sig-auth/541-external-credential-providers
```