### PR TITLE
Automated cherry pick of #102105: Respect annotation size limit for SSA last-applied.

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/lastappliedupdater_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/lastappliedupdater_test.go
@@ -17,9 +17,13 @@ limitations under the License.
 package fieldmanager_test
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager"
@@ -87,5 +91,135 @@ spec:
 		!strings.Contains(lastApplied, "my-app") ||
 		!strings.Contains(lastApplied, "my-image") {
 		t.Errorf("expected last applied annotation to be updated, but got: %q", lastApplied)
+	}
+}
+
+func TestLargeLastApplied(t *testing.T) {
+	tests := []struct {
+		name      string
+		oldObject *corev1.ConfigMap
+		newObject *corev1.ConfigMap
+	}{
+		{
+			name: "old object + new object last-applied annotation is too big",
+			oldObject: &corev1.ConfigMap{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "v1",
+					Kind:       "ConfigMap",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "large-update-test-cm",
+					Namespace: "default",
+					Annotations: map[string]string{
+						corev1.LastAppliedConfigAnnotation: "nonempty",
+					},
+				},
+				Data: map[string]string{"k": "v"},
+			},
+			newObject: func() *corev1.ConfigMap {
+				cfg := &corev1.ConfigMap{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "v1",
+						Kind:       "ConfigMap",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "large-update-test-cm",
+						Namespace: "default",
+						Annotations: map[string]string{
+							corev1.LastAppliedConfigAnnotation: "nonempty",
+						},
+					},
+					Data: map[string]string{"k": "v"},
+				}
+				for i := 0; i < 9999; i++ {
+					unique := fmt.Sprintf("this-key-is-very-long-so-as-to-create-a-very-large-serialized-fieldset-%v", i)
+					cfg.Data[unique] = "A"
+				}
+				return cfg
+			}(),
+		},
+		{
+			name: "old object + new object annotations + new object last-applied annotation is too big",
+			oldObject: func() *corev1.ConfigMap {
+				cfg := &corev1.ConfigMap{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "v1",
+						Kind:       "ConfigMap",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "large-update-test-cm",
+						Namespace: "default",
+						Annotations: map[string]string{
+							corev1.LastAppliedConfigAnnotation: "nonempty",
+						},
+					},
+					Data: map[string]string{"k": "v"},
+				}
+				for i := 0; i < 2000; i++ {
+					unique := fmt.Sprintf("this-key-is-very-long-so-as-to-create-a-very-large-serialized-fieldset-%v", i)
+					cfg.Data[unique] = "A"
+				}
+				return cfg
+			}(),
+			newObject: func() *corev1.ConfigMap {
+				cfg := &corev1.ConfigMap{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "v1",
+						Kind:       "ConfigMap",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "large-update-test-cm",
+						Namespace: "default",
+						Annotations: map[string]string{
+							corev1.LastAppliedConfigAnnotation: "nonempty",
+						},
+					},
+					Data: map[string]string{"k": "v"},
+				}
+				for i := 0; i < 2000; i++ {
+					unique := fmt.Sprintf("this-key-is-very-long-so-as-to-create-a-very-large-serialized-fieldset-%v", i)
+					cfg.Data[unique] = "A"
+					cfg.ObjectMeta.Annotations[unique] = "A"
+				}
+				return cfg
+			}(),
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			f := NewTestFieldManager(schema.FromAPIVersionAndKind("v1", "ConfigMap"),
+				func(m fieldmanager.Manager) fieldmanager.Manager {
+					return fieldmanager.NewLastAppliedUpdater(m)
+				})
+
+			if err := f.Apply(test.oldObject, "kubectl", false); err != nil {
+				t.Errorf("Error applying object: %v", err)
+			}
+
+			lastApplied, err := getLastApplied(f.liveObj)
+			if err != nil {
+				t.Errorf("Failed to access last applied annotation: %v", err)
+			}
+			if len(lastApplied) == 0 || lastApplied == "nonempty" {
+				t.Errorf("Expected an updated last-applied annotation, but got: %q", lastApplied)
+			}
+
+			if err := f.Apply(test.newObject, "kubectl", false); err != nil {
+				t.Errorf("Error applying object: %v", err)
+			}
+
+			accessor := meta.NewAccessor()
+			annotations, err := accessor.Annotations(f.liveObj)
+			if err != nil {
+				t.Errorf("Failed to access annotations: %v", err)
+			}
+			if annotations == nil {
+				t.Errorf("No annotations on obj: %v", f.liveObj)
+			}
+			lastApplied, ok := annotations[corev1.LastAppliedConfigAnnotation]
+			if ok || len(lastApplied) > 0 {
+				t.Errorf("Expected no last applied annotation, but got last applied with length: %d", len(lastApplied))
+			}
+		})
 	}
 }


### PR DESCRIPTION
Cherry pick of #102105 on release-1.19.

#102105: Respect annotation size limit for SSA last-applied.

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
Fixes a regression in 1.19 to respect annotation size limit for server-side apply updates to the client-side apply annotation. Also, fix opt-out of this behavior by setting the client-side apply annotation to the empty string.
```
