### PR TITLE
apf: introduce the concept of width for a request

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/debug/dump.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/debug/dump.go
@@ -24,9 +24,10 @@ import (
 
 // QueueSetDump is an instant dump of queue-set.
 type QueueSetDump struct {
-	Queues    []QueueDump
-	Waiting   int
-	Executing int
+	Queues     []QueueDump
+	Waiting    int
+	Executing  int
+	SeatsInUse int
 }
 
 // QueueDump is an instant dump of one queue in a queue-set.
@@ -34,6 +35,7 @@ type QueueDump struct {
 	Requests          []RequestDump
 	VirtualStart      float64
 	ExecutingRequests int
+	SeatsInUse        int
 }
 
 // RequestDump is an instant dump of one requests pending in the queue.

--- a/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/queueset/types.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/queueset/types.go
@@ -43,6 +43,9 @@ type request struct {
 	// startTime is the real time when the request began executing
 	startTime time.Time
 
+	// width of the request
+	width float64
+
 	// decision gets set to a `requestDecision` indicating what to do
 	// with this request.  It gets set exactly once, when the request
 	// is removed from its queue.  The value will be decisionReject,
@@ -80,6 +83,10 @@ type queue struct {
 
 	requestsExecuting int
 	index             int
+
+	// seatsInUse is the total number of "seats" currently occupied
+	// by all the requests that are currently executing in this queue.
+	seatsInUse int
 }
 
 // Enqueue enqueues a request into the queue and
@@ -129,5 +136,6 @@ func (q *queue) dump(includeDetails bool) debug.QueueDump {
 		VirtualStart:      q.virtualStart,
 		Requests:          digest,
 		ExecutingRequests: q.requestsExecuting,
+		SeatsInUse:        q.seatsInUse,
 	}
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:
Introduce the concept of `width` for a request. For now all requests have a `width` of `1` to maintain current behavior.

#### Which issue(s) this PR fixes:
Fixes #

#### Special notes for your reviewer:
- metric: currently `current_executing_requests` represents the number of requests currently executing in the API Priority and Fairness system. We don't have any metric that tracks the number of `seats` in use. This works for now since `width` = number of `seats` = 1 for all requests. 

- we don't deal with the scenario when number of `seats` required for a request exceeds the concurrency limit, for now it's not an issue since the number of `seats` for all requests is `1` and min(concurrency limit) = 1. 

We will address the above issues in a follow up PR.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
