### PR TITLE
Improve slice allocation in LabelSelectorAsSelector

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/helpers_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/helpers_test.go
@@ -93,6 +93,26 @@ func TestLabelSelectorAsSelector(t *testing.T) {
 	}
 }
 
+func BenchmarkLabelSelectorAsSelector(b *testing.B) {
+	selector := &LabelSelector{
+		MatchLabels: map[string]string{
+			"foo": "foo",
+			"bar": "bar",
+		},
+		MatchExpressions: []LabelSelectorRequirement{{
+			Key:      "baz",
+			Operator: LabelSelectorOpExists,
+		}},
+	}
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := LabelSelectorAsSelector(selector)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
 func TestLabelSelectorAsMap(t *testing.T) {
 	matchLabels := map[string]string{"foo": "bar"}
 	matchExpressions := func(operator LabelSelectorOperator, values []string) []LabelSelectorRequirement {

--- a/staging/src/k8s.io/apimachinery/pkg/labels/selector.go
+++ b/staging/src/k8s.io/apimachinery/pkg/labels/selector.go
@@ -367,13 +367,9 @@ func safeSort(in []string) []string {
 
 // Add adds requirements to the selector. It copies the current selector returning a new one
 func (s internalSelector) Add(reqs ...Requirement) Selector {
-	var ret internalSelector
-	for ix := range s {
-		ret = append(ret, s[ix])
-	}
-	for _, r := range reqs {
-		ret = append(ret, r)
-	}
+	ret := make(internalSelector, 0, len(s)+len(reqs))
+	ret = append(ret, s...)
+	ret = append(ret, reqs...)
 	sort.Sort(ByKey(ret))
 	return ret
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Improves the running time of LabelSelectorAsSelector by creating at most 2 slices.

The original implementation creates one slice for each label and expression.

#### Which issue(s) this PR fixes:

Ref #102179

#### Special notes for your reviewer:

For the given benchmark, it improves the runtime by roughly 10%.

#### Does this PR introduce a user-facing change?

```release-note
Improved parsing of label selectors
```