### PR TITLE
Propagate server version correctly to apiextensions-apiserver, stop serving v1beta1 CRDs

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/apiserver.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/apiserver.go
@@ -116,9 +116,11 @@ func (cfg *Config) Complete() CompletedConfig {
 	}
 
 	c.GenericConfig.EnableDiscovery = false
-	c.GenericConfig.Version = &version.Info{
-		Major: "0",
-		Minor: "1",
+	if c.GenericConfig.Version == nil {
+		c.GenericConfig.Version = &version.Info{
+			Major: "0",
+			Minor: "1",
+		}
 	}
 
 	return CompletedConfig{&c}


### PR DESCRIPTION
/kind bug

#### What this PR does / why we need it:

Fixes version propagation internally, makes APILifecycle effective for CRDs

Follow up to https://github.com/kubernetes/kubernetes/pull/99840

```release-note
NONE
```

/assign @deads2k 