### PR TITLE
Add hint to fake topology manager.

### DIFF
--- a/pkg/kubelet/cm/devicemanager/manager_test.go
+++ b/pkg/kubelet/cm/devicemanager/manager_test.go
@@ -758,11 +758,6 @@ func TestFilterByAffinity(t *testing.T) {
 	}
 }
 
-type fakeTopologyManagerWithHint struct {
-	t    *testing.T
-	hint *topologymanager.TopologyHint
-}
-
 func TestPodContainerDeviceAllocation(t *testing.T) {
 	res1 := TestResource{
 		resourceName:     "domain1.com/resource1",

--- a/pkg/kubelet/cm/devicemanager/manager_test.go
+++ b/pkg/kubelet/cm/devicemanager/manager_test.go
@@ -44,7 +44,6 @@ import (
 	"k8s.io/kubernetes/pkg/kubelet/config"
 	"k8s.io/kubernetes/pkg/kubelet/lifecycle"
 	"k8s.io/kubernetes/pkg/kubelet/pluginmanager"
-	"k8s.io/kubernetes/pkg/kubelet/util/format"
 	schedulerframework "k8s.io/kubernetes/pkg/scheduler/framework"
 )
 
@@ -727,7 +726,7 @@ func TestFilterByAffinity(t *testing.T) {
 		Preferred:        true,
 	}
 	testManager := ManagerImpl{
-		topologyAffinityStore: NewFakeTopologyManagerWithHint(t, &fakeHint),
+		topologyAffinityStore: topologymanager.NewFakeManagerWithHint(&fakeHint),
 		allDevices:            allDevices,
 	}
 
@@ -762,39 +761,6 @@ func TestFilterByAffinity(t *testing.T) {
 type fakeTopologyManagerWithHint struct {
 	t    *testing.T
 	hint *topologymanager.TopologyHint
-}
-
-// NewFakeTopologyManagerWithHint returns an instance of fake topology manager with specified topology hints
-func NewFakeTopologyManagerWithHint(t *testing.T, hint *topologymanager.TopologyHint) topologymanager.Manager {
-	return &fakeTopologyManagerWithHint{
-		t:    t,
-		hint: hint,
-	}
-}
-
-func (m *fakeTopologyManagerWithHint) AddHintProvider(h topologymanager.HintProvider) {
-	m.t.Logf("[fake topologymanager] AddHintProvider HintProvider:  %v", h)
-}
-
-func (m *fakeTopologyManagerWithHint) AddContainer(pod *v1.Pod, container *v1.Container, containerID string) {
-	m.t.Logf("[fake topologymanager] AddContainer  pod: %v container name: %v container id:  %v", format.Pod(pod), container.Name, containerID)
-}
-
-func (m *fakeTopologyManagerWithHint) RemoveContainer(containerID string) error {
-	m.t.Logf("[fake topologymanager] RemoveContainer container id:  %v", containerID)
-	return nil
-}
-
-func (m *fakeTopologyManagerWithHint) Admit(attrs *lifecycle.PodAdmitAttributes) lifecycle.PodAdmitResult {
-	m.t.Logf("[fake topologymanager] Topology Admit Handler")
-	return lifecycle.PodAdmitResult{
-		Admit: true,
-	}
-}
-
-func (m *fakeTopologyManagerWithHint) GetAffinity(podUID string, containerName string) topologymanager.TopologyHint {
-	m.t.Logf("[fake topologymanager] GetAffinity podUID: %v container name:  %v", podUID, containerName)
-	return *m.hint
 }
 
 func TestPodContainerDeviceAllocation(t *testing.T) {

--- a/pkg/kubelet/cm/topologymanager/fake_topology_manager.go
+++ b/pkg/kubelet/cm/topologymanager/fake_topology_manager.go
@@ -17,7 +17,7 @@ limitations under the License.
 package topologymanager
 
 import (
-	v1 "k8s.io/api/core/v1"
+	"k8s.io/api/core/v1"
 	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/pkg/kubelet/lifecycle"
 )

--- a/pkg/kubelet/cm/topologymanager/fake_topology_manager.go
+++ b/pkg/kubelet/cm/topologymanager/fake_topology_manager.go
@@ -17,12 +17,14 @@ limitations under the License.
 package topologymanager
 
 import (
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/pkg/kubelet/lifecycle"
 )
 
-type fakeManager struct{}
+type fakeManager struct {
+	hint *TopologyHint
+}
 
 //NewFakeManager returns an instance of FakeManager
 func NewFakeManager() Manager {
@@ -30,9 +32,21 @@ func NewFakeManager() Manager {
 	return &fakeManager{}
 }
 
+// NewFakeManagerWithHint returns an instance of fake topology manager with specified topology hints
+func NewFakeManagerWithHint(hint *TopologyHint) Manager {
+	klog.InfoS("NewFakeManagerWithHint")
+	return &fakeManager{
+		hint: hint,
+	}
+}
+
 func (m *fakeManager) GetAffinity(podUID string, containerName string) TopologyHint {
 	klog.InfoS("GetAffinity", "podUID", podUID, "containerName", containerName)
-	return TopologyHint{}
+	if m.hint == nil {
+		return TopologyHint{}
+	}
+
+	return *m.hint
 }
 
 func (m *fakeManager) AddHintProvider(h HintProvider) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

This PR extend the fake topology manager to make it return a fake `TopologyHint` from `GetAffinity()`. This is useful for unit tests, for example in memorymanager and devicemanager, they both create their own fake topology manager with hint:

https://github.com/kubernetes/kubernetes/blob/916ed1d3ad9ecfc921a08f8c06fadad045561ef6/pkg/kubelet/cm/memorymanager/policy_static_test.go#L69-L106

https://github.com/kubernetes/kubernetes/blob/916ed1d3ad9ecfc921a08f8c06fadad045561ef6/pkg/kubelet/cm/devicemanager/manager_test.go#L762-L798

instead of reinventing the wheel, we wanna make this topology manager with hint available for other moudules thus reduce code redundance.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
