### PR TITLE
clean up algorithmprovider pkg and remove scheduler deprecated algorithm-provider flag

### DIFF
--- a/cluster/gce/gci/configure-helper.sh
+++ b/cluster/gce/gci/configure-helper.sh
@@ -2203,9 +2203,6 @@ function start-kube-scheduler {
     params+=("--config=/etc/srv/kubernetes/kube-scheduler/config")
   else
     params+=("--kubeconfig=/etc/srv/kubernetes/kube-scheduler/kubeconfig")
-    if [[ -n "${SCHEDULING_ALGORITHM_PROVIDER:-}"  ]]; then
-      params+=("--algorithm-provider=${SCHEDULING_ALGORITHM_PROVIDER}")
-    fi
     if [[ -n "${SCHEDULER_POLICY_CONFIG:-}" ]]; then
       create-kubescheduler-policy-config
       params+=("--use-legacy-policy-config")

--- a/cmd/kube-scheduler/app/options/deprecated.go
+++ b/cmd/kube-scheduler/app/options/deprecated.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/spf13/pflag"
 	"k8s.io/apimachinery/pkg/util/validation/field"
-	"k8s.io/kubernetes/pkg/scheduler/algorithmprovider"
 	kubeschedulerconfig "k8s.io/kubernetes/pkg/scheduler/apis/config"
 	"k8s.io/kubernetes/pkg/scheduler/apis/config/validation"
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/interpodaffinity"
@@ -36,7 +35,6 @@ type DeprecatedOptions struct {
 	PolicyConfigMapName            string
 	PolicyConfigMapNamespace       string
 	UseLegacyPolicyConfig          bool
-	AlgorithmProvider              string
 	HardPodAffinitySymmetricWeight int32
 	SchedulerName                  string
 }
@@ -47,7 +45,6 @@ func (o *DeprecatedOptions) AddFlags(fs *pflag.FlagSet, cfg *kubeschedulerconfig
 		return
 	}
 
-	fs.StringVar(&o.AlgorithmProvider, "algorithm-provider", o.AlgorithmProvider, "DEPRECATED: the scheduling algorithm provider to use, this sets the default plugins for component config profiles. Choose one of: "+algorithmprovider.ListAlgorithmProviders())
 	fs.StringVar(&o.PolicyConfigFile, "policy-config-file", o.PolicyConfigFile, "DEPRECATED: file with scheduler policy configuration. This file is used if policy ConfigMap is not provided or --use-legacy-policy-config=true. Note: The scheduler will fail if this is combined with Plugin configs")
 	usage := fmt.Sprintf("DEPRECATED: name of the ConfigMap object that contains scheduler's policy configuration. It must exist in the system namespace before scheduler initialization if --use-legacy-policy-config=false. The config must be provided as the value of an element in 'Data' map with the key='%v'. Note: The scheduler will fail if this is combined with Plugin configs", kubeschedulerconfig.SchedulerPolicyConfigMapKey)
 	fs.StringVar(&o.PolicyConfigMapName, "policy-configmap", o.PolicyConfigMapName, usage)
@@ -91,7 +88,6 @@ func (o *DeprecatedOptions) Validate() []error {
 //
 // 1. --use-legacy-policy-config to use a policy file.
 // 2. --policy-configmap to use a policy config map value.
-// 3. --algorithm-provider to use a named algorithm provider.
 func (o *DeprecatedOptions) ApplyAlgorithmSourceTo(cfg *kubeschedulerconfig.KubeSchedulerConfiguration) {
 	if o == nil {
 		return
@@ -114,10 +110,6 @@ func (o *DeprecatedOptions) ApplyAlgorithmSourceTo(cfg *kubeschedulerconfig.Kube
 					Namespace: o.PolicyConfigMapNamespace,
 				},
 			},
-		}
-	case len(o.AlgorithmProvider) > 0:
-		cfg.AlgorithmSource = kubeschedulerconfig.SchedulerAlgorithmSource{
-			Provider: &o.AlgorithmProvider,
 		}
 	}
 }

--- a/cmd/kube-scheduler/app/options/deprecated_test.go
+++ b/cmd/kube-scheduler/app/options/deprecated_test.go
@@ -29,7 +29,6 @@ func TestValidateDeprecatedKubeSchedulerConfiguration(t *testing.T) {
 			config: &DeprecatedOptions{
 				PolicyConfigFile:      "/some/file",
 				UseLegacyPolicyConfig: true,
-				AlgorithmProvider:     "",
 			},
 		},
 		"bad-policy-config-file-null": {
@@ -37,7 +36,6 @@ func TestValidateDeprecatedKubeSchedulerConfiguration(t *testing.T) {
 			config: &DeprecatedOptions{
 				PolicyConfigFile:      "",
 				UseLegacyPolicyConfig: true,
-				AlgorithmProvider:     "",
 			},
 		},
 		"good affinity weight": {

--- a/cmd/kube-scheduler/app/options/options.go
+++ b/cmd/kube-scheduler/app/options/options.go
@@ -148,7 +148,6 @@ func newDefaultComponentConfig() (*kubeschedulerconfig.KubeSchedulerConfiguratio
 func (o *Options) Flags() (nfs cliflag.NamedFlagSets) {
 	fs := nfs.FlagSet("misc")
 	fs.StringVar(&o.ConfigFile, "config", o.ConfigFile, `The path to the configuration file. The following flags can overwrite fields in this file:
-  --algorithm-provider
   --policy-config-file
   --policy-configmap
   --policy-configmap-namespace`)

--- a/cmd/kube-scheduler/app/server_test.go
+++ b/cmd/kube-scheduler/app/server_test.go
@@ -268,71 +268,9 @@ profiles:
 			name: "default algorithm provider",
 			flags: []string{
 				"--kubeconfig", configKubeconfig,
-				"--algorithm-provider", "DefaultProvider",
 			},
 			wantPlugins: map[string]map[string][]kubeschedulerconfig.Plugin{
 				"default-scheduler": defaultPlugins,
-			},
-		},
-		{
-			name: "cluster autoscaler provider",
-			flags: []string{
-				"--kubeconfig", configKubeconfig,
-				"--algorithm-provider", "ClusterAutoscalerProvider",
-			},
-			wantPlugins: map[string]map[string][]kubeschedulerconfig.Plugin{
-				"default-scheduler": {
-					"QueueSortPlugin": {
-						{Name: "PrioritySort"},
-					},
-					"PreFilterPlugin": {
-						{Name: "NodeResourcesFit"},
-						{Name: "NodePorts"},
-						{Name: "PodTopologySpread"},
-						{Name: "InterPodAffinity"},
-						{Name: "VolumeBinding"},
-						{Name: "NodeAffinity"},
-					},
-					"FilterPlugin": {
-						{Name: "NodeUnschedulable"},
-						{Name: "NodeName"},
-						{Name: "TaintToleration"},
-						{Name: "NodeAffinity"},
-						{Name: "NodePorts"},
-						{Name: "NodeResourcesFit"},
-						{Name: "VolumeRestrictions"},
-						{Name: "EBSLimits"},
-						{Name: "GCEPDLimits"},
-						{Name: "NodeVolumeLimits"},
-						{Name: "AzureDiskLimits"},
-						{Name: "VolumeBinding"},
-						{Name: "VolumeZone"},
-						{Name: "PodTopologySpread"},
-						{Name: "InterPodAffinity"},
-					},
-					"PostFilterPlugin": {
-						{Name: "DefaultPreemption"},
-					},
-					"PreScorePlugin": {
-						{Name: "InterPodAffinity"},
-						{Name: "PodTopologySpread"},
-						{Name: "TaintToleration"},
-						{Name: "NodeAffinity"},
-					},
-					"ScorePlugin": {
-						{Name: "NodeResourcesBalancedAllocation", Weight: 1},
-						{Name: "ImageLocality", Weight: 1},
-						{Name: "InterPodAffinity", Weight: 1},
-						{Name: "NodeResourcesMostAllocated", Weight: 1},
-						{Name: "NodeAffinity", Weight: 1},
-						{Name: "NodePreferAvoidPods", Weight: 10000},
-						{Name: "PodTopologySpread", Weight: 2},
-						{Name: "TaintToleration", Weight: 1},
-					},
-					"BindPlugin":    {{Name: "DefaultBinder"}},
-					"ReservePlugin": {{Name: "VolumeBinding"}},
-					"PreBindPlugin": {{Name: "VolumeBinding"}},
-				},
 			},
 		},
 		{

--- a/pkg/scheduler/algorithmprovider/registry_test.go
+++ b/pkg/scheduler/algorithmprovider/registry_test.go
@@ -45,91 +45,6 @@ import (
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/volumezone"
 )
 
-func TestClusterAutoscalerProvider(t *testing.T) {
-	wantConfig := &schedulerapi.Plugins{
-		QueueSort: schedulerapi.PluginSet{
-			Enabled: []schedulerapi.Plugin{
-				{Name: queuesort.Name},
-			},
-		},
-		PreFilter: schedulerapi.PluginSet{
-			Enabled: []schedulerapi.Plugin{
-				{Name: noderesources.FitName},
-				{Name: nodeports.Name},
-				{Name: podtopologyspread.Name},
-				{Name: interpodaffinity.Name},
-				{Name: volumebinding.Name},
-				{Name: nodeaffinity.Name},
-			},
-		},
-		Filter: schedulerapi.PluginSet{
-			Enabled: []schedulerapi.Plugin{
-				{Name: nodeunschedulable.Name},
-				{Name: nodename.Name},
-				{Name: tainttoleration.Name},
-				{Name: nodeaffinity.Name},
-				{Name: nodeports.Name},
-				{Name: noderesources.FitName},
-				{Name: volumerestrictions.Name},
-				{Name: nodevolumelimits.EBSName},
-				{Name: nodevolumelimits.GCEPDName},
-				{Name: nodevolumelimits.CSIName},
-				{Name: nodevolumelimits.AzureDiskName},
-				{Name: volumebinding.Name},
-				{Name: volumezone.Name},
-				{Name: podtopologyspread.Name},
-				{Name: interpodaffinity.Name},
-			},
-		},
-		PostFilter: schedulerapi.PluginSet{
-			Enabled: []schedulerapi.Plugin{
-				{Name: defaultpreemption.Name},
-			},
-		},
-		PreScore: schedulerapi.PluginSet{
-			Enabled: []schedulerapi.Plugin{
-				{Name: interpodaffinity.Name},
-				{Name: podtopologyspread.Name},
-				{Name: tainttoleration.Name},
-				{Name: nodeaffinity.Name},
-			},
-		},
-		Score: schedulerapi.PluginSet{
-			Enabled: []schedulerapi.Plugin{
-				{Name: noderesources.BalancedAllocationName, Weight: 1},
-				{Name: imagelocality.Name, Weight: 1},
-				{Name: interpodaffinity.Name, Weight: 1},
-				{Name: noderesources.MostAllocatedName, Weight: 1},
-				{Name: nodeaffinity.Name, Weight: 1},
-				{Name: nodepreferavoidpods.Name, Weight: 10000},
-				{Name: podtopologyspread.Name, Weight: 2},
-				{Name: tainttoleration.Name, Weight: 1},
-			},
-		},
-		Reserve: schedulerapi.PluginSet{
-			Enabled: []schedulerapi.Plugin{
-				{Name: volumebinding.Name},
-			},
-		},
-		PreBind: schedulerapi.PluginSet{
-			Enabled: []schedulerapi.Plugin{
-				{Name: volumebinding.Name},
-			},
-		},
-		Bind: schedulerapi.PluginSet{
-			Enabled: []schedulerapi.Plugin{
-				{Name: defaultbinder.Name},
-			},
-		},
-	}
-
-	r := NewRegistry()
-	gotConfig := r[ClusterAutoscalerProvider]
-	if diff := cmp.Diff(wantConfig, gotConfig); diff != "" {
-		t.Errorf("unexpected config diff (-want, +got): %s", diff)
-	}
-}
-
 func TestApplyFeatureGates(t *testing.T) {
 	tests := []struct {
 		name       string
@@ -307,8 +222,8 @@ func TestApplyFeatureGates(t *testing.T) {
 				defer featuregatetesting.SetFeatureGateDuringTest(t, feature.DefaultFeatureGate, k, v)()
 			}
 
-			r := NewRegistry()
-			gotConfig := r[schedulerapi.SchedulerDefaultProviderName]
+			gotConfig := GetDefaultConfig()
+
 			if diff := cmp.Diff(test.wantConfig, gotConfig); diff != "" {
 				t.Errorf("unexpected config diff (-want, +got): %s", diff)
 			}

--- a/pkg/scheduler/apis/config/testing/compatibility_test.go
+++ b/pkg/scheduler/apis/config/testing/compatibility_test.go
@@ -32,7 +32,6 @@ import (
 	featuregatetesting "k8s.io/component-base/featuregate/testing"
 	_ "k8s.io/kubernetes/pkg/apis/core/install"
 	"k8s.io/kubernetes/pkg/scheduler"
-	"k8s.io/kubernetes/pkg/scheduler/algorithmprovider"
 	"k8s.io/kubernetes/pkg/scheduler/apis/config"
 	"k8s.io/kubernetes/pkg/scheduler/core"
 )
@@ -1481,62 +1480,6 @@ func TestAlgorithmProviderCompatibility(t *testing.T) {
 			name:        "DefaultProvider",
 			provider:    config.SchedulerDefaultProviderName,
 			wantPlugins: defaultPlugins,
-		},
-		{
-			name:     "ClusterAutoscalerProvider",
-			provider: algorithmprovider.ClusterAutoscalerProvider,
-			wantPlugins: map[string][]config.Plugin{
-				"QueueSortPlugin": {
-					{Name: "PrioritySort"},
-				},
-				"PreFilterPlugin": {
-					{Name: "NodeResourcesFit"},
-					{Name: "NodePorts"},
-					{Name: "PodTopologySpread"},
-					{Name: "InterPodAffinity"},
-					{Name: "VolumeBinding"},
-					{Name: "NodeAffinity"},
-				},
-				"FilterPlugin": {
-					{Name: "NodeUnschedulable"},
-					{Name: "NodeName"},
-					{Name: "TaintToleration"},
-					{Name: "NodeAffinity"},
-					{Name: "NodePorts"},
-					{Name: "NodeResourcesFit"},
-					{Name: "VolumeRestrictions"},
-					{Name: "EBSLimits"},
-					{Name: "GCEPDLimits"},
-					{Name: "NodeVolumeLimits"},
-					{Name: "AzureDiskLimits"},
-					{Name: "VolumeBinding"},
-					{Name: "VolumeZone"},
-					{Name: "PodTopologySpread"},
-					{Name: "InterPodAffinity"},
-				},
-				"PostFilterPlugin": {
-					{Name: "DefaultPreemption"},
-				},
-				"PreScorePlugin": {
-					{Name: "InterPodAffinity"},
-					{Name: "PodTopologySpread"},
-					{Name: "TaintToleration"},
-					{Name: "NodeAffinity"},
-				},
-				"ScorePlugin": {
-					{Name: "NodeResourcesBalancedAllocation", Weight: 1},
-					{Name: "ImageLocality", Weight: 1},
-					{Name: "InterPodAffinity", Weight: 1},
-					{Name: "NodeResourcesMostAllocated", Weight: 1},
-					{Name: "NodeAffinity", Weight: 1},
-					{Name: "NodePreferAvoidPods", Weight: 10000},
-					{Name: "PodTopologySpread", Weight: 2},
-					{Name: "TaintToleration", Weight: 1},
-				},
-				"ReservePlugin": {{Name: "VolumeBinding"}},
-				"PreBindPlugin": {{Name: "VolumeBinding"}},
-				"BindPlugin":    {{Name: "DefaultBinder"}},
-			},
 		},
 	}
 	for _, tc := range testcases {

--- a/pkg/scheduler/factory.go
+++ b/pkg/scheduler/factory.go
@@ -195,11 +195,8 @@ func (c *Configurator) create() (*Scheduler, error) {
 // createFromProvider creates a scheduler from the name of a registered algorithm provider.
 func (c *Configurator) createFromProvider(providerName string) (*Scheduler, error) {
 	klog.V(2).InfoS("Creating scheduler from algorithm provider", "algorithmProvider", providerName)
-	r := algorithmprovider.NewRegistry()
-	defaultPlugins, exist := r[providerName]
-	if !exist {
-		return nil, fmt.Errorf("algorithm provider %q is not registered", providerName)
-	}
+
+	defaultPlugins := algorithmprovider.GetDefaultConfig()
 
 	for i := range c.profiles {
 		prof := &c.profiles[i]


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
1. Remove AlgorithmProvider flag in scheduler. This flag was marked as deprecated since v1.17.
2. clean up algorithmprovider pkg,  only preserve default plugin setting

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes/kubernetes/issues/102151

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
The deprecated flag --algorithm-provider has been removed from kube-scheduler. Use instead ComponentConfig to configure the set of enabled plugins
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
