### PR TITLE
Update CSI mock volumes to use generic getVolumeAttachment

### DIFF
--- a/test/e2e/storage/testsuites/snapshottable.go
+++ b/test/e2e/storage/testsuites/snapshottable.go
@@ -198,6 +198,7 @@ func (s *snapshottableTestSuite) DefineTests(driver storageframework.TestDriver,
 				return true
 			})
 			framework.ExpectEqual(success, true)
+
 		}
 
 		cleanup := func() {


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
Creates a generic function to getVolumeAttachment. Separated from https://github.com/kubernetes/kubernetes/pull/102021 .

#### Which issue(s) this PR fixes:
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs

```
