### PR TITLE
Fix: kubectl create -f and kubectl delete -f are not glob friendly

### DIFF
--- a/staging/src/k8s.io/cli-runtime/artifacts/oddly-named-file[x].yaml
+++ b/staging/src/k8s.io/cli-runtime/artifacts/oddly-named-file[x].yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: busybox
+  labels:
+    name: busybox
+spec:
+  containers:
+    - name: busybox
+      image: busybox
+      ports:
+        - containerPort: 80

--- a/staging/src/k8s.io/cli-runtime/go.mod
+++ b/staging/src/k8s.io/cli-runtime/go.mod
@@ -20,6 +20,7 @@ require (
 	k8s.io/api v0.0.0
 	k8s.io/apimachinery v0.0.0
 	k8s.io/client-go v0.0.0
+	k8s.io/klog/v2 v2.40.1
 	k8s.io/kube-openapi v0.0.0-20211115234752-e816edb12b65
 	sigs.k8s.io/kustomize/api v0.10.1
 	sigs.k8s.io/kustomize/kyaml v0.13.0

--- a/staging/src/k8s.io/cli-runtime/go.mod
+++ b/staging/src/k8s.io/cli-runtime/go.mod
@@ -20,7 +20,6 @@ require (
 	k8s.io/api v0.0.0
 	k8s.io/apimachinery v0.0.0
 	k8s.io/client-go v0.0.0
-	k8s.io/klog/v2 v2.40.1
 	k8s.io/kube-openapi v0.0.0-20211115234752-e816edb12b65
 	sigs.k8s.io/kustomize/api v0.10.1
 	sigs.k8s.io/kustomize/kyaml v0.13.0

--- a/staging/src/k8s.io/cli-runtime/pkg/resource/builder.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/resource/builder.go
@@ -1205,28 +1205,6 @@ func expandIfFilePattern(pattern string) ([]string, error) {
 	return matches, err
 }
 
-type cachingRESTMapperFunc struct {
-	delegate RESTMapperFunc
-
-	lock   sync.Mutex
-	cached meta.RESTMapper
-}
-
-func (c *cachingRESTMapperFunc) ToRESTMapper() (meta.RESTMapper, error) {
-	c.lock.Lock()
-	defer c.lock.Unlock()
-	if c.cached != nil {
-		return c.cached, nil
-	}
-
-	ret, err := c.delegate()
-	if err != nil {
-		return nil, err
-	}
-	c.cached = ret
-	return c.cached, nil
-}
-
 type cachingCategoryExpanderFunc struct {
 	delegate CategoryExpanderFunc
 

--- a/staging/src/k8s.io/cli-runtime/pkg/resource/builder.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/resource/builder.go
@@ -39,7 +39,8 @@ import (
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/restmapper"
-	"sigs.k8s.io/kustomize/kyaml/filesys"
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/kustomize/api/filesys"
 )
 
 var FileExtensions = []string{".json", ".yaml", ".yml"}
@@ -261,6 +262,7 @@ func (b *Builder) FilenameParam(enforceNamespace bool, filenameOptions *Filename
 				b.errs = append(b.errs, fmt.Errorf("file pattern %v is not valid: %v", s, err))
 				continue
 			}
+			klog.V(4).Infof("Processing path %q, matched with %q", s, matches)
 			if !recursive && len(matches) == 1 {
 				b.singleItemImplied = true
 			}

--- a/staging/src/k8s.io/cli-runtime/pkg/resource/builder.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/resource/builder.go
@@ -40,7 +40,7 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/restmapper"
 	"k8s.io/klog/v2"
-	"sigs.k8s.io/kustomize/api/filesys"
+	"sigs.k8s.io/kustomize/kyaml/filesys"
 )
 
 var FileExtensions = []string{".json", ".yaml", ".yml"}

--- a/staging/src/k8s.io/cli-runtime/pkg/resource/builder.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/resource/builder.go
@@ -259,7 +259,7 @@ func (b *Builder) FilenameParam(enforceNamespace bool, filenameOptions *Filename
 		default:
 			matches, err := expandIfFilePattern(s)
 			if err != nil {
-				b.errs = append(b.errs, fmt.Errorf("file pattern %v is not valid: %v", s, err))
+				b.errs = append(b.errs, fmt.Errorf("pattern %q is not valid: %v", s, err))
 				continue
 			}
 			klog.V(4).Infof("Processing path %q, matched with %q", s, matches)
@@ -1200,7 +1200,7 @@ func HasNames(args []string) (bool, error) {
 func expandIfFilePattern(pattern string) ([]string, error) {
 	matches, err := filepath.Glob(pattern)
 	if err == nil && len(matches) == 0 {
-		return nil, fmt.Errorf("pattern did not yield any results")
+		return nil, fmt.Errorf("no match")
 	}
 	return matches, err
 }

--- a/staging/src/k8s.io/cli-runtime/pkg/resource/builder_test.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/resource/builder_test.go
@@ -631,7 +631,7 @@ func TestFilePatternBuilder(t *testing.T) {
 	}
 
 	for _, info := range test.Infos {
-		if strings.Index(info.Name, "redis-") != 0{
+		if strings.Index(info.Name, "redis-") != 0 {
 			t.Errorf("unexpected response: %#v", info.Name)
 		}
 	}

--- a/staging/src/k8s.io/cli-runtime/pkg/resource/builder_test.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/resource/builder_test.go
@@ -617,6 +617,26 @@ func TestDirectoryBuilder(t *testing.T) {
 	}
 }
 
+func TestFilePatternBuilder(t *testing.T) {
+	b := newDefaultBuilder().
+		FilenameParam(false, &FilenameOptions{Recursive: false, Filenames: []string{"../../artifacts/guestbook/redis-*.yaml"}}).
+		NamespaceParam("test").DefaultNamespace()
+
+	test := &testVisitor{}
+	singleItemImplied := false
+
+	err := b.Do().IntoSingleItemImplied(&singleItemImplied).Visit(test.Handle)
+	if err != nil || singleItemImplied || len(test.Infos) < 3 {
+		t.Fatalf("unexpected response: %v %t %#v", err, singleItemImplied, test.Infos)
+	}
+
+	for _, info := range test.Infos {
+		if strings.Index(info.Name, "redis-") != 0{
+			t.Errorf("unexpected response: %#v", info.Name)
+		}
+	}
+}
+
 func setupKustomizeDirectory() (string, error) {
 	path, err := ioutil.TempDir("/tmp", "")
 	if err != nil {

--- a/staging/src/k8s.io/cli-runtime/pkg/resource/builder_test.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/resource/builder_test.go
@@ -617,6 +617,28 @@ func TestDirectoryBuilder(t *testing.T) {
 	}
 }
 
+func TestFilePatternBuilderWhenPatternYieldsNoResult(t *testing.T) {
+	const pathPattern = "../../artifacts/_does_not_exist_/*.yaml"
+	b := newDefaultBuilder().
+		FilenameParam(false, &FilenameOptions{Recursive: false, Filenames: []string{pathPattern}}).
+		NamespaceParam("test").DefaultNamespace()
+
+	test := &testVisitor{}
+	singleItemImplied := false
+
+	err := b.Do().IntoSingleItemImplied(&singleItemImplied).Visit(test.Handle)
+	if err == nil {
+		t.Fatalf("unexpected response: error is nil")
+	}
+	const expectedErrorMsg = "pattern did not yield any results"
+	if !strings.Contains(err.Error(), expectedErrorMsg) {
+		t.Fatalf("expected %s but got %s", expectedErrorMsg, err.Error())
+	}
+	if !strings.Contains(err.Error(), pathPattern) {
+		t.Fatalf("expected %s but got %s", pathPattern, err.Error())
+	}
+}
+
 func TestFilePatternBuilder(t *testing.T) {
 	b := newDefaultBuilder().
 		FilenameParam(false, &FilenameOptions{Recursive: false, Filenames: []string{"../../artifacts/guestbook/redis-*.yaml"}}).

--- a/staging/src/k8s.io/cli-runtime/pkg/resource/builder_test.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/resource/builder_test.go
@@ -630,7 +630,7 @@ func TestFilePatternBuilderWhenPatternYieldsNoResult(t *testing.T) {
 	if err == nil {
 		t.Fatalf("unexpected response: error is nil")
 	}
-	const expectedErrorMsg = "pattern did not yield any results"
+	const expectedErrorMsg = "no match"
 	if !strings.Contains(err.Error(), expectedErrorMsg) {
 		t.Fatalf("expected %s but got %s", expectedErrorMsg, err.Error())
 	}

--- a/staging/src/k8s.io/cli-runtime/pkg/resource/builder_test.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/resource/builder_test.go
@@ -639,6 +639,46 @@ func TestFilePatternBuilderWhenPatternYieldsNoResult(t *testing.T) {
 	}
 }
 
+func TestFilePatternBuilderWhenFileLiteralExists(t *testing.T) {
+	const pathPattern = "../../artifacts/oddly-named-file[x].yaml"
+	b := newDefaultBuilder().
+		FilenameParam(false, &FilenameOptions{Recursive: false, Filenames: []string{pathPattern}}).
+		NamespaceParam("test").DefaultNamespace()
+
+	test := &testVisitor{}
+	singleItemImplied := false
+
+	err := b.Do().IntoSingleItemImplied(&singleItemImplied).Visit(test.Handle)
+	if err != nil || !singleItemImplied || len(test.Infos) != 1 {
+		t.Fatalf("unexpected result: %v %t %#v", err, singleItemImplied, test.Infos)
+	}
+	if !strings.Contains(test.Infos[0].Source, "oddly-named-file[x]") {
+		t.Errorf("unexpected file name: %#v", test.Infos[0].Source)
+	}
+}
+
+func TestFilePatternBuilderWhenBadPatternUsesRawInput(t *testing.T) {
+	const pathPattern = "../../artifacts/[a-z*.yaml" // missing closing bracket, "[a-z]*.yaml"
+	b := newDefaultBuilder().
+		FilenameParam(false, &FilenameOptions{Recursive: false, Filenames: []string{pathPattern}}).
+		NamespaceParam("test").DefaultNamespace()
+
+	test := &testVisitor{}
+	singleItemImplied := false
+
+	err := b.Do().IntoSingleItemImplied(&singleItemImplied).Visit(test.Handle)
+	if err == nil {
+		t.Fatalf("unexpected response: error is nil")
+	}
+	const expectedErrorMsg = "does not exist"
+	if !strings.Contains(err.Error(), expectedErrorMsg) {
+		t.Fatalf("expected %s but got %s", expectedErrorMsg, err.Error())
+	}
+	if !strings.Contains(err.Error(), pathPattern) {
+		t.Fatalf("expected %s but got %s", pathPattern, err.Error())
+	}
+}
+
 func TestFilePatternBuilder(t *testing.T) {
 	b := newDefaultBuilder().
 		FilenameParam(false, &FilenameOptions{Recursive: false, Filenames: []string{"../../artifacts/guestbook/redis-*.yaml"}}).

--- a/staging/src/k8s.io/kubectl/pkg/cmd/apply/apply.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/apply/apply.go
@@ -149,6 +149,9 @@ var (
 		# Apply the JSON passed into stdin to a pod
 		cat pod.json | kubectl apply -f -
 
+		# Apply the configuration from all files that end with '.json' - i.e. expand wildcard characters in file names
+		kubectl apply -f '*.json'
+
 		# Note: --prune is still in Alpha
 		# Apply the configuration in manifest.yaml that matches label app=nginx and delete all other resources that are not in the file and match label app=nginx
 		kubectl apply --prune -f manifest.yaml -l app=nginx

--- a/staging/src/k8s.io/kubectl/pkg/cmd/delete/delete.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/delete/delete.go
@@ -82,6 +82,9 @@ var (
 		# Delete resources from a directory containing kustomization.yaml - e.g. dir/kustomization.yaml
 		kubectl delete -k dir
 
+		# Delete resources from all files that end with '.json' - i.e. expand wildcard characters in file names
+		kubectl apply -f '*.json'
+
 		# Delete a pod based on the type and name in the JSON passed into stdin
 		cat pod.json | kubectl delete -f -
 


### PR DESCRIPTION

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
Fixes #12123, a way to skip shell expanding special characters like * or ? and thus preventing multiple files to be fed

#### Special notes for your reviewer:

`filepath.Glob` sorts filenames so multiple runs should process files in the same order

#### Does this PR introduce a user-facing change?

```release-note
allow kubectl to manage resources by filename patterns without the shell expanding it first
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:


```docs
- Usage: 
  kubectl delete -f '*.go'
```
/sig-cli