### PR TITLE
bump docker version for CI

### DIFF
--- a/cluster/gce/gci/configure.sh
+++ b/cluster/gce/gci/configure.sh
@@ -471,7 +471,7 @@ function install-docker {
 
   # Install Docker
   apt-get update && \
-    apt-get install -y --no-install-recommends "${GCI_DOCKER_VERSION:-"docker-ce=5:19.03.*"}"
+    apt-get install -y --no-install-recommends "${GCI_DOCKER_VERSION:-"docker-ce docker-ce-cli containerd.io"}"
   rm -rf /var/lib/apt/lists/*
 }
 


### PR DESCRIPTION
We have 2 jobs with the same regex, one is failing constantly 

https://testgrid.k8s.io/sig-release-master-informing#gce-ubuntu-master-default

the other is working

https://testgrid.k8s.io/sig-release-master-blocking#gce-ubuntu-master-containerd&width=20

The only difference I can see is the runtime
```
<   job: ci-kubernetes-e2e-ubuntu-gce-containerd
---
>   job: ci-kubernetes-e2e-ubuntu-gce
39,42d38
<       - --env=KUBE_CONTAINER_RUNTIME=containerd
<       - --env=KUBE_UBUNTU_INSTALL_CONTAINERD_VERSION=v1.5.2
<       - --env=KUBE_UBUNTU_INSTALL_RUNC_VERSION=v1.0.0-rc95
<       - --env=LOG_DUMP_SYSTEMD_SERVICES=containerd
44d39
<       - --env=CONTAINER_RUNTIME_TEST_HANDLER=true
50a46
>       - --env=KUBE_CONTAINER_RUNTIME=docker
```

docker version in the job is 
```
time="2021-05-24T13:06:08.193330586Z" level=info msg="Docker daemon" commit=99e3ed8919 graphdriver(s)=overlay2 version=19.03.15
```
/kind failing-test

Tentatively fixes: https://github.com/kubernetes/kubernetes/issues/102101