### PR TITLE
Update etcd makefile to build v3.5.0-beta.3 image

### DIFF
--- a/build/dependencies.yaml
+++ b/build/dependencies.yaml
@@ -93,7 +93,7 @@ dependencies:
       match: const etcdImage
 
   - name: "etcd-image"
-    version: 3.4.13
+    version: 3.5.0-beta.3
     refPaths:
     - path: cluster/images/etcd/Makefile
       match: BUNDLED_ETCD_VERSIONS\?|LATEST_ETCD_VERSION\?

--- a/cluster/images/etcd/Makefile
+++ b/cluster/images/etcd/Makefile
@@ -15,7 +15,7 @@
 # Build the etcd image
 #
 # Usage:
-# 	[BUNDLED_ETCD_VERSIONS=3.0.17 3.1.12 3.2.24 3.3.17 3.4.13] [REGISTRY=k8s.gcr.io] [ARCH=amd64] [BASEIMAGE=busybox] make (build|push)
+# 	[BUNDLED_ETCD_VERSIONS=3.0.17 3.1.12 3.2.24 3.3.17 3.4.13 3.5.0-beta.3] [REGISTRY=k8s.gcr.io] [ARCH=amd64] [BASEIMAGE=busybox] make (build|push)
 #
 # The image contains different etcd versions to simplify
 # upgrades. Thus be careful when removing any versions from here.
@@ -26,15 +26,15 @@
 # Except from etcd-$(version) and etcdctl-$(version) binaries, we also
 # need etcd and etcdctl binaries for backward compatibility reasons.
 # That binary will be set to the last version from $(BUNDLED_ETCD_VERSIONS).
-BUNDLED_ETCD_VERSIONS?=3.0.17 3.1.12 3.2.24 3.3.17 3.4.13
+BUNDLED_ETCD_VERSIONS?=3.0.17 3.1.12 3.2.24 3.3.17 3.4.13 3.5.0-beta.3
 
 # LATEST_ETCD_VERSION identifies the most recent etcd version available.
-LATEST_ETCD_VERSION?=3.4.13
+LATEST_ETCD_VERSION?=3.5.0-beta.3
 
 # REVISION provides a version number fo this image and all it's bundled
 # artifacts. It should start at zero for each LATEST_ETCD_VERSION and increment
 # for each revision of this image at that etcd version.
-REVISION?=4
+REVISION?=0
 
 # IMAGE_TAG Uniquely identifies k8s.gcr.io/etcd docker image with a tag of the form "<etcd-version>-<revision>".
 IMAGE_TAG=$(LATEST_ETCD_VERSION)-$(REVISION)

--- a/cluster/images/etcd/migrate/options.go
+++ b/cluster/images/etcd/migrate/options.go
@@ -28,7 +28,7 @@ import (
 )
 
 var (
-	supportedEtcdVersions = []string{"3.0.17", "3.1.12", "3.2.24", "3.3.17", "3.4.13"}
+	supportedEtcdVersions = []string{"3.0.17", "3.1.12", "3.2.24", "3.3.17", "3.4.13", "3.5.0-beta.3"}
 )
 
 const (


### PR DESCRIPTION
/kind feature

#### Special notes for your reviewer:
We are planning an to upgrade etcd to v3.5.0 for 1.22. As so are updating etcd client in https://github.com/kubernetes/kubernetes/pull/100488 and will bump the etcd server after this PR is merged and image built.

By merging server upgrade for v3.5.0-beta.3 before full release we increase qualification time and reduce the chance of regression. 
To validate Etcd 3.5.0-beta.3 performance I have created a separate PR https://github.com/kubernetes/kubernetes/pull/102062 that uses a self build image and collaborated with SIG Scalability to conduct a full 5k node test. The results were positive, got green light for upgrade from @mborsz 

After this PR is merged I will update https://github.com/kubernetes/kubernetes/pull/102062 to use it and work on merging it.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```


