### PR TITLE
[scheduler] avoid comparing function pointers in unit tests

### DIFF
--- a/pkg/scheduler/framework/runtime/registry_test.go
+++ b/pkg/scheduler/framework/runtime/registry_test.go
@@ -20,6 +20,8 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/google/uuid"
+
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/kubernetes/pkg/scheduler/framework"
 )
@@ -76,7 +78,9 @@ func TestDecodeInto(t *testing.T) {
 func isRegistryEqual(registryX, registryY Registry) bool {
 	for name, pluginFactory := range registryY {
 		if val, ok := registryX[name]; ok {
-			if reflect.ValueOf(pluginFactory).Pointer() != reflect.ValueOf(val).Pointer() {
+			p1, _ := pluginFactory(nil, nil)
+			p2, _ := val(nil, nil)
+			if p1.Name() != p2.Name() {
 				// pluginFactory functions are not the same.
 				return false
 			}
@@ -96,19 +100,24 @@ func isRegistryEqual(registryX, registryY Registry) bool {
 	return true
 }
 
-type mockNoopPlugin struct{}
+type mockNoopPlugin struct {
+	uuid string
+}
 
 func (p *mockNoopPlugin) Name() string {
-	return "MockNoop"
+	return p.uuid
 }
 
 func NewMockNoopPluginFactory() PluginFactory {
+	uuid := uuid.New().String()
 	return func(_ runtime.Object, _ framework.Handle) (framework.Plugin, error) {
-		return &mockNoopPlugin{}, nil
+		return &mockNoopPlugin{uuid}, nil
 	}
 }
 
 func TestMerge(t *testing.T) {
+	m1 := NewMockNoopPluginFactory()
+	m2 := NewMockNoopPluginFactory()
 	tests := []struct {
 		name            string
 		primaryRegistry Registry
@@ -119,27 +128,27 @@ func TestMerge(t *testing.T) {
 		{
 			name: "valid Merge",
 			primaryRegistry: Registry{
-				"pluginFactory1": NewMockNoopPluginFactory(),
+				"pluginFactory1": m1,
 			},
 			registryToMerge: Registry{
-				"pluginFactory2": NewMockNoopPluginFactory(),
+				"pluginFactory2": m2,
 			},
 			expected: Registry{
-				"pluginFactory1": NewMockNoopPluginFactory(),
-				"pluginFactory2": NewMockNoopPluginFactory(),
+				"pluginFactory1": m1,
+				"pluginFactory2": m2,
 			},
 			shouldError: false,
 		},
 		{
 			name: "Merge duplicate factories",
 			primaryRegistry: Registry{
-				"pluginFactory1": NewMockNoopPluginFactory(),
+				"pluginFactory1": m1,
 			},
 			registryToMerge: Registry{
-				"pluginFactory1": NewMockNoopPluginFactory(),
+				"pluginFactory1": m2,
 			},
 			expected: Registry{
-				"pluginFactory1": NewMockNoopPluginFactory(),
+				"pluginFactory1": m1,
 			},
 			shouldError: true,
 		},
@@ -162,6 +171,8 @@ func TestMerge(t *testing.T) {
 }
 
 func TestRegister(t *testing.T) {
+	m1 := NewMockNoopPluginFactory()
+	m2 := NewMockNoopPluginFactory()
 	tests := []struct {
 		name              string
 		registry          Registry
@@ -174,21 +185,21 @@ func TestRegister(t *testing.T) {
 			name:              "valid Register",
 			registry:          Registry{},
 			nameToRegister:    "pluginFactory1",
-			factoryToRegister: NewMockNoopPluginFactory(),
+			factoryToRegister: m1,
 			expected: Registry{
-				"pluginFactory1": NewMockNoopPluginFactory(),
+				"pluginFactory1": m1,
 			},
 			shouldError: false,
 		},
 		{
 			name: "Register duplicate factories",
 			registry: Registry{
-				"pluginFactory1": NewMockNoopPluginFactory(),
+				"pluginFactory1": m1,
 			},
 			nameToRegister:    "pluginFactory1",
-			factoryToRegister: NewMockNoopPluginFactory(),
+			factoryToRegister: m2,
 			expected: Registry{
-				"pluginFactory1": NewMockNoopPluginFactory(),
+				"pluginFactory1": m1,
 			},
 			shouldError: true,
 		},
@@ -211,6 +222,8 @@ func TestRegister(t *testing.T) {
 }
 
 func TestUnregister(t *testing.T) {
+	m1 := NewMockNoopPluginFactory()
+	m2 := NewMockNoopPluginFactory()
 	tests := []struct {
 		name             string
 		registry         Registry
@@ -221,12 +234,12 @@ func TestUnregister(t *testing.T) {
 		{
 			name: "valid Unregister",
 			registry: Registry{
-				"pluginFactory1": NewMockNoopPluginFactory(),
-				"pluginFactory2": NewMockNoopPluginFactory(),
+				"pluginFactory1": m1,
+				"pluginFactory2": m2,
 			},
 			nameToUnregister: "pluginFactory1",
 			expected: Registry{
-				"pluginFactory2": NewMockNoopPluginFactory(),
+				"pluginFactory2": m2,
 			},
 			shouldError: false,
 		},


### PR DESCRIPTION
PluginFactory is a function that returns a plugin. We have been
comparing these functions in unit tests and it has worked so far, but
starts to fail in gotip/master.

Note from the golang team:
```
Func values are incomparable. It is true that you could get the PC
through reflection but it is still not expected to be compared. PCs
can change due to inlining, wrappers, etc., depending on the
compiler's details, which is subject to change.
```

Signed-off-by: Davanum Srinivas <davanum@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug
<!--
Add one of the following kinds:
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes/kubernetes/issues/101657

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
