### PR TITLE
make MicroTime parser more lenient

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/micro_time.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/micro_time.go
@@ -21,7 +21,8 @@ import (
 	"time"
 )
 
-const RFC3339Micro = "2006-01-02T15:04:05.000000Z07:00"
+const RFC3339MicroLenient = "2006-01-02T15:04:05.999999Z07:00"
+const RFC3339MicroFixed = "2006-01-02T15:04:05.000000Z07:00"
 
 // MicroTime is version of Time with microsecond level precision.
 //
@@ -120,7 +121,7 @@ func (t *MicroTime) UnmarshalJSON(b []byte) error {
 		return err
 	}
 
-	pt, err := time.Parse(RFC3339Micro, str)
+	pt, err := time.Parse(RFC3339MicroLenient, str)
 	if err != nil {
 		return err
 	}
@@ -141,7 +142,7 @@ func (t *MicroTime) UnmarshalQueryParameter(str string) error {
 		return nil
 	}
 
-	pt, err := time.Parse(RFC3339Micro, str)
+	pt, err := time.Parse(RFC3339MicroLenient, str)
 	if err != nil {
 		return err
 	}
@@ -157,7 +158,7 @@ func (t MicroTime) MarshalJSON() ([]byte, error) {
 		return []byte("null"), nil
 	}
 
-	return json.Marshal(t.UTC().Format(RFC3339Micro))
+	return json.Marshal(t.UTC().Format(RFC3339MicroFixed))
 }
 
 // OpenAPISchemaType is used by the kube-openapi generator when constructing
@@ -177,5 +178,5 @@ func (t MicroTime) MarshalQueryParameter() (string, error) {
 		return "", nil
 	}
 
-	return t.UTC().Format(RFC3339Micro), nil
+	return t.UTC().Format(RFC3339MicroFixed), nil
 }

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/micro_time_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/micro_time_test.go
@@ -36,6 +36,8 @@ func TestMicroTimeMarshalYAML(t *testing.T) {
 	}{
 		{MicroTime{}, "t: null\n"},
 		{DateMicro(1998, time.May, 5, 1, 5, 5, 50, time.FixedZone("test", -4*60*60)), "t: \"1998-05-05T05:05:05.000000Z\"\n"},
+		{DateMicro(1998, time.May, 5, 5, 5, 5, 123000000, time.UTC), "t: \"1998-05-05T05:05:05.123000Z\"\n"},
+		{DateMicro(1998, time.May, 5, 5, 5, 5, 123456000, time.UTC), "t: \"1998-05-05T05:05:05.123456Z\"\n"},
 		{DateMicro(1998, time.May, 5, 5, 5, 5, 0, time.UTC), "t: \"1998-05-05T05:05:05.000000Z\"\n"},
 	}
 
@@ -57,6 +59,9 @@ func TestMicroTimeUnmarshalYAML(t *testing.T) {
 		result MicroTime
 	}{
 		{"t: null\n", MicroTime{}},
+		{"t: 1998-05-05T05:05:05Z\n", MicroTime{Date(1998, time.May, 5, 5, 5, 5, 0, time.UTC).Local()}},
+		{"t: 1998-05-05T05:05:05.123Z\n", MicroTime{Date(1998, time.May, 5, 5, 5, 5, 123000000, time.UTC).Local()}},
+		{"t: 1998-05-05T05:05:05.123456Z\n", MicroTime{Date(1998, time.May, 5, 5, 5, 5, 123456000, time.UTC).Local()}},
 		{"t: 1998-05-05T05:05:05.000000Z\n", MicroTime{Date(1998, time.May, 5, 5, 5, 5, 0, time.UTC).Local()}},
 	}
 
@@ -78,6 +83,8 @@ func TestMicroTimeMarshalJSON(t *testing.T) {
 	}{
 		{MicroTime{}, "{\"t\":null}"},
 		{DateMicro(1998, time.May, 5, 5, 5, 5, 50, time.UTC), "{\"t\":\"1998-05-05T05:05:05.000000Z\"}"},
+		{DateMicro(1998, time.May, 5, 5, 5, 5, 123000000, time.UTC), "{\"t\":\"1998-05-05T05:05:05.123000Z\"}"},
+		{DateMicro(1998, time.May, 5, 5, 5, 5, 123456000, time.UTC), "{\"t\":\"1998-05-05T05:05:05.123456Z\"}"},
 		{DateMicro(1998, time.May, 5, 5, 5, 5, 0, time.UTC), "{\"t\":\"1998-05-05T05:05:05.000000Z\"}"},
 	}
 
@@ -99,6 +106,9 @@ func TestMicroTimeUnmarshalJSON(t *testing.T) {
 		result MicroTime
 	}{
 		{"{\"t\":null}", MicroTime{}},
+		{"{\"t\":\"1998-05-05T05:05:05Z\"}", MicroTime{Date(1998, time.May, 5, 5, 5, 5, 0, time.UTC).Local()}},
+		{"{\"t\":\"1998-05-05T05:05:05.123Z\"}", MicroTime{Date(1998, time.May, 5, 5, 5, 5, 123000000, time.UTC).Local()}},
+		{"{\"t\":\"1998-05-05T05:05:05.123456Z\"}", MicroTime{Date(1998, time.May, 5, 5, 5, 5, 123456000, time.UTC).Local()}},
 		{"{\"t\":\"1998-05-05T05:05:05.000000Z\"}", MicroTime{Date(1998, time.May, 5, 5, 5, 5, 0, time.UTC).Local()}},
 	}
 
@@ -119,6 +129,8 @@ func TestMicroTimeProto(t *testing.T) {
 	}{
 		{MicroTime{}},
 		{DateMicro(1998, time.May, 5, 1, 5, 5, 50, time.Local)},
+		{DateMicro(1998, time.May, 5, 5, 5, 5, 123000000, time.Local)},
+		{DateMicro(1998, time.May, 5, 5, 5, 5, 123456000, time.Local)},
 		{DateMicro(1998, time.May, 5, 5, 5, 5, 0, time.Local)},
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

`MicroTime` is parsed too strictly when receiving a requests. Requests from the JavaScript client that contain a `MicroTime` fail for a parsing error, since the JavaScript client only has precision up to the millisecond, but `MicroTime` requires precision to the microsecond even for input. This PR follows the suggestion in https://github.com/kubernetes/kubernetes/issues/89156#issuecomment-629884397.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #89156

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

