### PR TITLE
kubelet log patchBytes as string

### DIFF
--- a/pkg/kubelet/status/status_manager.go
+++ b/pkg/kubelet/status/status_manager.go
@@ -583,7 +583,7 @@ func (m *manager) syncPod(uid types.UID, status versionedPodStatus) {
 
 	oldStatus := pod.Status.DeepCopy()
 	newPod, patchBytes, unchanged, err := statusutil.PatchPodStatus(m.kubeClient, pod.Namespace, pod.Name, pod.UID, *oldStatus, mergePodStatus(*oldStatus, status.status))
-	klog.V(3).InfoS("Patch status for pod", "pod", klog.KObj(pod), "patchBytes", patchBytes)
+	klog.V(3).InfoS("Patch status for pod", "pod", klog.KObj(pod), "patchBytes", string(patchBytes))
 
 	if err != nil {
 		klog.InfoS("Failed to update status for pod", "pod", klog.KObj(pod), "err", err)


### PR DESCRIPTION

/kind cleanup
```release-note
NONE
```

Kubelet was logging the pod status patch as a slice of bytes instead of a string, so logs were "hard" to read :)

current logs
> 
I0525 18:02:58.942075   11127 status_manager.go:586] "Patch status for pod" pod="e2e-kubelet-etc-hosts-3312/test-host-network-pod" patchBytes=[123 34 109 101 116 97 100 97 116 97 34 58 123 34 117 105 100 34 58 34 55 56 57 53 48 56 54 102 45 53 97 52 50 45 52 55 54 52 45 57 100 55 56 45 53 49 54 53 52 49 50 101 102 55 48 53 34 125 44 34 115 116 97 116 117 115 34 58 123 34 36 115 101 116 69 108 101 109 101 110 116 79 114 100 101 114 47 99 111 110 100 105 116 105 111 110 115 34 58 91 123 34 116 121 112 101 34 58 34 73 110 105 116 105 97 108 105 122 101 100 34 125 44 123 34 116 121 112 101 34 58 34 82 101 97 100 121 34 125 44 123 34 116 121 112 101 34 58 34 67 111 110 116 97 105 110 101 114 115 82 101 97 100 121 34 125 44 123 34 116 121 112 101 34 58 34 80 111 100 83 99 104 101 100 117 108 101 100 34 125 93 44 34 99 111 110 100 105 116 105 111 110 115 34 58 91 123 34 108 97 115 116 84 114 97 110 115 105 116 105 111 110 84 105 109 101 34 58 34 50 48 50 49 45 48 53 45 50 53 84 49 56 58 48 50 58 53 56 90 34 44 34 109 101 115 115 97 103 101 34 58 34 99 111 110 116 97 105 110 101 114 115 32 119 105 116 104 32 117 110 114 101 97 100 121 32 115 116 97 116 117 115 58 32 91 98 117 115 121 98 111 120 45 49 32 98 117 115 121 98 111 120 45 50 93 34 44 34 114 101 97 115 111 110 34 58 34 67 111 110 116 97 105 110 101 114 115 78 111 116 82 101 97 100 121 34 44 34 115 116 97 116 117 115 34 58 34 70 97 108 115 101 34 44 34 116 121 112 101 34 58 34 82 101 97 100 121 34 125 44 123 34 108 97 115 116 84 114 97 110 115 105 116 105 111 110 84 105 109 101 34 58 34 50 48 50 49 45 48 53 45 50 53 84 49 56 58 48 50 58 53 56 90 34 44 34 109 101 115 115 97 103 101 34 58 34 99 111 110 116 97 105 110 101 114 115 32 119 105 116 104 32 117 110 114 101 97 100 121 32 115 116 97 116 117 115 58 32 91 98 117 115 121 98 111 120 45 49 32 98 117 115 121 98 111 120 45 50 93 34 44 34 114 101 97 115 111 110 34 58 34 67 111 110 116 97 105 110 101 114 115 78 111 116 82 101 97 100 121 34 44 34 115 116 97 116 117 115 34 58 34 70 97 108 115 101 34 44 34 116 121 112 101 34 58 34 67 111 110 116 97 105 110 101 114 115 82 101 97 100 121 34 125 93 44 34 99 111 110 116 97 105 110 101 114 83 116 97 116 117 115 101 115 34 58 91 123 34 99 111 110 116 97 105 110 101 114 73 68 34 58 34 100 111 99 107 101 114 58 47 47 97 48 102 53 102 50 48 53 48 52 97 100 48 55 52 48 54 101 100 53 53 53 102 97 98 51 99 98 55 49 48 97 97 56 56 56 55 49 102 50 100 102 98 100 49 54 56 99 55 52 49 56 102 49 98 53 53 49 97 55 52 55 56 102 34 44 34 105 109 97 103 101 34 58 34 107 56 115 46 103 99 114 46 105 111 47 101 50 101 45 116 101 115 116 45 105 109 97 103 101 115 47 97 103 110 104 111 115 116 58 50 46 51 50 34 44 34 105 109 97 103 101 73 68 34 58 34 100 111 99 107 101 114 45 112 117 108 108 97 98 108 101 58 47 47 107 56 115 46 103 99 114 46 105 111 47 101 50 101 45 116 101 115 116 45 105 109 97 103 101 115 47 97 103 110 104 111 115 116 64 115 104 97 50 53 54 58 55 53 56 100 98 54 54 54 97 99 55 48 50 56 53 51 52 100 98 97 55 50 101 55 101 57 98 98 49 101 53 55 98 98 56 49 98 56 49 57 54 102 57 55 54 102 55 97 53 99 99 51 53 49 101 102 56 98 51 53 50 57 101 49 34 44 34 108 97 115 116 83 116 97 116 101 34 58 123 125 44 34 110 97 109 101 34 58 34 98 117 115 121 98 111 120 45 49 34 44 34 114 101 97 100 121 34 58 102 97 108 115 101 44 34 114 101 115 116 97 114 116 67 111 117 110 116 34 58 48 44 34 115 116 97 114 116 101 100 34 58 102 97 108 115 101 44 34 115 116 97 116 101 34 58 123 34 116 101 114 109 105 110 97 116 101 100 34 58 123 34 99 111 110 116 97 105 110 101 114 73 68 34 58 34 100 111 99 107 101 114 58 47 47 97 48 102 53 102 50 48 53 48 52 97 100 48 55 52 48 54 101 100 53 53 53 102 97 98 51 99 98 55 49 48 97 97 56 56 56 55 49 102 50 100 102 98 100 49 54 56 99 55 52 49 56 102 49 98 53 53 49 97 55 52 55 56 102 34 44 34 101 120 105 116 67 111 100 101 34 58 50 44 34 102 105 110 105 115 104 101 100 65 116 34 58 34 50 48 50 49 45 48 53 45 50 53 84 49 56 58 48 50 58 53 55 90 34 44 34 114 101 97 115 111 110 34 58 34 69 114 114 111 114 34 44 34 115 116 97 114 116 101 100 65 116 34 58 34 50 48 50 49 45 48 53 45 50 53 84 49 55 58 53 49 58 52 48 90 34 125 125 125 44 123 34 99 111 110 116 97 105 110 101 114 73 68 34 58 34 100 111 99 107 101 114 58 47 47 100 54 53 55 50 100 48 54 100 49 52 48 100 56 53 99 57 99 57 57 98 57 54 102 49 50 57 56 98 49 54 55 98 57 57 48 100 57 101 102 48 51 100 56 54 56 98 99 99 52 57 101 57 98 55 97 53 54 98 98 99 48 48 49 34 44 34 105 109 97 103 101 34 58 34 107 56 115 46 103 99 114 46 105 111 47 101 50 101 45 116 101 115 116 45 105 109 97 103 101 115 47 97 103 110 104 111 115 116 58 50 46 51 50 34 44 34 105 109 97 103 101 73 68 34 58 34 100 111 99 107 101 114 45 112 117 108 108 97 98 108 101 58 47 47 107 56 115 46 103 99 114 46 105 111 47 101 50 101 45 116 101 115 116 45 105 109 97 103 101 115 47 97 103 110 104 111 115 116 64 115 104 97 50 53 54 58 55 53 56 100 98 54 54 54 97 99 55 48 50 56 53 51 52 100 98 97 55 50 101 55 101 57 98 98 49 101 53 55 98 98 56 49 98 56 49 57 54 102 57 55 54 102 55 97 53 99 99 51 53 49 101 102 56 98 51 53 50 57 101 49 34 44 34 108 97 115 116 83 116 97 116 101 34 58 123 125 44 34 110 97 109 101 34 58 34 98 117 115 121 98 111 120 45 50 34 44 34 114 101 97 100 121 34 58 102 97 108 115 101 44 34 114 101 115 116 97 114 116 67 111 117 110 116 34 58 48 44 34 115 116 97 114 116 101 100 34 58 102 97 108 115 101 44 34 115 116 97 116 101 34 58 123 34 116 101 114 109 105 110 97 116 101 100 34 58 123 34 99 111 110 116 97 105 110 101 114 73 68 34 58 34 100 111 99 107 101 114 58 47 47 100 54 53 55 50 100 48 54 100 49 52 48 100 56 53 99 57 99 57 57 98 57 54 102 49 50 57 56 98 49 54 55 98 57 57 48 100 57 101 102 48 51 100 56 54 56 98 99 99 52 57 101 57 98 55 97 53 54 98 98 99 48 48 49 34 44 34 101 120 105 116 67 111 100 101 34 58 50 44 34 102 105 110 105 115 104 101 100 65 116 34 58 34 50 48 50 49 45 48 53 45 50 53 84 49 56 58 48 50 58 53 55 90 34 44 34 114 101 97 115 111 110 34 58 34 69 114 114 111 114 34 44 34 115 116 97 114 116 101 100 65 116 34 58 34 50 48 50 49 45 48 53 45 50 53 84 49 55 58 53 49 58 52 48 90 34 125 125 125 93 125 125]

new logs

> 
I0525 18:02:58.942075   11127 status_manager.go:586] "Patch status for pod" pod="e2e-kubelet-etc-hosts-3312/test-host-network-pod" patchBytes={"metadata":{"uid":"18e4eaa7-d9bf-4363-84ac-d0040150ad25"},"status":{"containerStatuses":[{"containerID":"docker://8c56606e6baa3cc19856725fdea9d6aee95a7ca61e4c710035f5232c5f2a9698","image":"k8s.gcr.io/sig-storage/csi-external-health-monitor-agent:v0.2.0","imageID":"docker-pullable://k8s.gcr.io/sig-storage/csi-external-health-monitor-agent@sha256:c20d4a4772599e68944452edfcecc944a1df28c19e94b942d526ca25a522ea02","lastState":{"terminated":{"containerID":"docker://732a58e0293dfe60c33ebae48d9985614df04610e2d0bef7378cfb0d3455f2bd","exitCode":1,"finishedAt":"2021-05-25T17:40:35Z","reason":"Error","startedAt":"2021-05-25T17:40:35Z"}},"name":"csi-external-health-monitor-agent","ready":false,"restartCount":5,"started":false,"state":{"terminated":{"containerID":"docker://8c56606e6baa3cc19856725fdea9d6aee95a7ca61e4c710035f5232c5f2a9698","exitCode":1,"finishedAt":"2021-05-25T17:42:00Z","reason":"Error","startedAt":"2021-05-25T17:42:00Z"}}},{"containerID":"docker://088520d447d591d73b0b83a483089245f3c1faf410e5bc9c19ff07b81dd6b6f4","image":"k8s.gcr.io/sig-storage/csi-external-health-monitor-controller:v0.2.0","imageID":"docker-pullable://k8s.gcr.io/sig-storage/csi-external-health-monitor-controller@sha256:14988b598a180cc0282f3f4bc982371baf9a9c9b80878fb385f8ae8bd04ecf16","lastState":{"terminated":{"containerID":"docker://6fc6a98f3945f0a88174fb7fce57d570b9890d8d7b8d1f0cf6bd72656960680a","exitCode":1,"finishedAt":"2021-05-25T17:40:37Z","reason":"Error","startedAt":"2021-05-25T17:40:37Z"}},"name":"csi-external-health-monitor-controller","ready":false,"restartCount":5,"started":false,"state":{"terminated":{"containerID":"docker://088520d447d591d73b0b83a483089245f3c1faf410e5bc9c19ff07b81dd6b6f4","exitCode":1,"finishedAt":"2021-05-25T17:42:01Z","reason":"Error","startedAt":"2021-05-25T17:42:01Z"}}},{"containerID":"docker://32b9faa996e51808cc9059f6c858ae1101ece8f5902eef001d314d2996200952","image":"k8s.gcr.io/sig-storage/hostpathplugin:v1.4.0","imageID":"docker-pullable://k8s.gcr.io/sig-storage/hostpathplugin@sha256:d2b357bb02430fee9eaa43b16083981463d260419fe3acb2f560ede5c129f6f5","lastState":{},"name":"hostpath","ready":true,"restartCount":0,"started":true,"state":{"running":{"startedAt":"2021-05-25T17:39:11Z"}}},{"containerID":"docker://4b0712c8e53c29ce04a2ee9cfb9518635a39ad207cb46af12097c256d54b4694","image":"k8s.gcr.io/sig-storage/livenessprobe:v2.2.0","imageID":"docker-pullable://k8s.gcr.io/sig-storage/livenessprobe@sha256:48da0e4ed7238ad461ea05f68c25921783c37b315f21a5c5a2780157a6460994","lastState":{},"name":"liveness-probe","ready":true,"restartCount":0,"started":true,"state":{"running":{"startedAt":"2021-05-25T17:39:11Z"}}},{"containerID":"docker://5e22e329fcd4abb40710b0cc715614fc4383510359ddc6481b530c5996fbee7c","image":"k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.0.1","imageID":"docker-pullable://k8s.gcr.io/sig-storage/csi-node-driver-registrar@sha256:e07f914c32f0505e4c470a62a40ee43f84cbf8dc46ff861f31b14457ccbad108","lastState":{},"name":"node-driver-registrar","ready":true,"restartCount":0,"started":true,"state":{"running":{"startedAt":"2021-05-25T17:39:10Z"}}}]}}
