### PR TITLE
Build non-static binaries with PIE buildmode

### DIFF
--- a/hack/lib/golang.sh
+++ b/hack/lib/golang.sh
@@ -412,6 +412,10 @@ kube::golang::set_platform_envs() {
         export CGO_ENABLED=1
         export CC=${KUBE_LINUX_AMD64_CC:-x86_64-linux-gnu-gcc}
         ;;
+      "linux/386")
+        export CGO_ENABLED=1
+        export CC=${KUBE_LINUX_386_CC:-i686-linux-gnu-gcc}
+        ;;
       "linux/arm")
         export CGO_ENABLED=1
         export CC=${KUBE_LINUX_ARM_CC:-arm-linux-gnueabihf-gcc}
@@ -721,6 +725,7 @@ kube::golang::build_binaries_for_platform() {
       -gcflags "${gogcflags:-}"
       -asmflags "${goasmflags:-}"
       -ldflags "${goldflags:-}"
+      -buildmode pie
       -tags "${gotags:-}"
     )
     kube::golang::build_some_binaries "${nonstatics[@]}"


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

We now add the `-buildmode pie` flag when building non-static binaries, which enables the ASLR security mechanism.

#### Which issue(s) this PR fixes:

Fixes #90311

#### Special notes for your reviewer:

Supersedes #94448

For example, we now build the `kubelet` as `LSB pie executable`:
```
> make WHAT=cmd/kubelet
> file _output/bin/kubelet
_output/bin/kubelet: ELF 64-bit LSB pie executable, x86-64, version 1 (SYSV), dynamically linked, interpreter /nix/store/vaf92wc23m067q9aig6zjkcnjvrg768n-glibc-2.32-46/lib/ld-linux-x86-64.so.2, for GNU/Linux 2.6.32, Go BuildID=2XJTWqoOSzrJFsezWtNV/Ljlb-W11uIqFXSJ5PWOt/4aLSZPegz6V8zUDouB74/B8q7ucGO132SbpmNnZMA, stripped
```

We do not apply the change to statically linked binaries, because if we add the `pie` buildmode to them we would result in gaining a dynamically linked binary without choosing an external linker. Ref: https://github.com/golang/go/issues/40719

#### Does this PR introduce a user-facing change?

```release-note
Changed buildmode of non static Kubernetes binaries to produce position independent executables (PIE).
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
None
```

/area release-eng
/sig release
/priority important-soon
/cc @kubernetes/release-managers @abhay-krishna