### PR TITLE
Disable k/k way of log dumping if test-infra way is enabled

### DIFF
--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -1185,7 +1185,7 @@ func EnsureLoadBalancerResourcesDeleted(ip, portRange string) error {
 // CoreDump SSHs to the master and all nodes and dumps their logs into dir.
 // It shells out to cluster/log-dump/log-dump.sh to accomplish this.
 func CoreDump(dir string) {
-	if TestContext.DisableLogDump {
+	if TestContext.DisableLogDump || os.Getenv("USE_TEST_INFRA_LOG_DUMPING") == "true" {
 		Logf("Skipping dumping logs from cluster")
 		return
 	}


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
Do not invoke k/k log dumping script if the test job already leverages the log dumping mechanism from test-infra repo.

#### Which issue(s) this PR fixes:
No issue is opened for that.

#### Special notes for your reviewer:
/assign @jkaniuk
/assign @marseel 

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```