### PR TITLE
Automated cherry pick of #102302: Update debian-iptables to buster-v1.6.1

### DIFF
--- a/build/common.sh
+++ b/build/common.sh
@@ -86,7 +86,7 @@ readonly KUBE_RSYNC_PORT="${KUBE_RSYNC_PORT:-}"
 readonly KUBE_CONTAINER_RSYNC_PORT=8730
 
 # These are the default versions (image tags) for their respective base images.
-readonly __default_debian_iptables_version=buster-v1.6.0
+readonly __default_debian_iptables_version=buster-v1.6.1
 readonly __default_go_runner_version=v2.3.1-go1.16.4-buster.0
 
 # These are the base images for the Docker-wrapped binaries.

--- a/build/dependencies.yaml
+++ b/build/dependencies.yaml
@@ -146,7 +146,7 @@ dependencies:
       match: BASEIMAGE\?\=k8s\.gcr\.io\/build-image\/debian-base-s390x:[a-zA-Z]+\-v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)
 
   - name: "k8s.gcr.io/debian-iptables: dependents"
-    version: buster-v1.6.0
+    version: buster-v1.6.1
     refPaths:
     - path: build/common.sh
       match: __default_debian_iptables_version=

--- a/build/dependencies.yaml
+++ b/build/dependencies.yaml
@@ -132,7 +132,7 @@ dependencies:
 
   # Base images
   - name: "k8s.gcr.io/debian-base: dependents"
-    version: buster-v1.6.0
+    version: buster-v1.7.0
     refPaths:
     - path: cluster/images/etcd/Makefile
       match: BASEIMAGE\?\=k8s\.gcr\.io\/build-image\/debian-base:[a-zA-Z]+\-v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)

--- a/cluster/images/etcd/Makefile
+++ b/cluster/images/etcd/Makefile
@@ -67,19 +67,19 @@ GOARM?=7
 TEMP_DIR:=$(shell mktemp -d)
 
 ifeq ($(ARCH),amd64)
-    BASEIMAGE?=k8s.gcr.io/build-image/debian-base:buster-v1.6.0
+    BASEIMAGE?=k8s.gcr.io/build-image/debian-base:buster-v1.7.0
 endif
 ifeq ($(ARCH),arm)
-    BASEIMAGE?=k8s.gcr.io/build-image/debian-base-arm:buster-v1.6.0
+    BASEIMAGE?=k8s.gcr.io/build-image/debian-base-arm:buster-v1.7.0
 endif
 ifeq ($(ARCH),arm64)
-    BASEIMAGE?=k8s.gcr.io/build-image/debian-base-arm64:buster-v1.6.0
+    BASEIMAGE?=k8s.gcr.io/build-image/debian-base-arm64:buster-v1.7.0
 endif
 ifeq ($(ARCH),ppc64le)
-    BASEIMAGE?=k8s.gcr.io/build-image/debian-base-ppc64le:buster-v1.6.0
+    BASEIMAGE?=k8s.gcr.io/build-image/debian-base-ppc64le:buster-v1.7.0
 endif
 ifeq ($(ARCH),s390x)
-    BASEIMAGE?=k8s.gcr.io/build-image/debian-base-s390x:buster-v1.6.0
+    BASEIMAGE?=k8s.gcr.io/build-image/debian-base-s390x:buster-v1.7.0
 endif
 
 RUNNERIMAGE?=gcr.io/distroless/static:latest

--- a/cluster/images/etcd/Makefile
+++ b/cluster/images/etcd/Makefile
@@ -31,7 +31,7 @@ BUNDLED_ETCD_VERSIONS?=3.0.17 3.1.12 3.2.24 3.3.17 3.4.13
 # LATEST_ETCD_VERSION identifies the most recent etcd version available.
 LATEST_ETCD_VERSION?=3.4.13
 
-# REVISION provides a version number fo this image and all it's bundled
+# REVISION provides a version number for this image and all it's bundled
 # artifacts. It should start at zero for each LATEST_ETCD_VERSION and increment
 # for each revision of this image at that etcd version.
 REVISION?=4

--- a/test/utils/image/manifest.go
+++ b/test/utils/image/manifest.go
@@ -223,7 +223,7 @@ func initImageConfigs() (map[int]Config, map[int]Config) {
 	configs[CheckMetadataConcealment] = Config{promoterE2eRegistry, "metadata-concealment", "1.6"}
 	configs[CudaVectorAdd] = Config{e2eRegistry, "cuda-vector-add", "1.0"}
 	configs[CudaVectorAdd2] = Config{promoterE2eRegistry, "cuda-vector-add", "2.2"}
-	configs[DebianIptables] = Config{buildImageRegistry, "debian-iptables", "buster-v1.6.0"}
+	configs[DebianIptables] = Config{buildImageRegistry, "debian-iptables", "buster-v1.6.1"}
 	configs[EchoServer] = Config{promoterE2eRegistry, "echoserver", "2.3"}
 	configs[Etcd] = Config{gcEtcdRegistry, "etcd", "3.4.13-0"}
 	configs[GlusterDynamicProvisioner] = Config{promoterE2eRegistry, "glusterdynamic-provisioner", "v1.0"}


### PR DESCRIPTION
Cherry pick of #102302 on release-1.21.

#102302: Update debian-iptables to buster-v1.6.1

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

---

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Update the Debian images to pick up CVE fixes in the base images:

* Update the `debian-base` image to v1.7.0
* Update the `debian-iptables` image to v1.6.1

#### Which issue(s) this PR fixes:

Related to https://github.com/kubernetes/kubernetes/issues/102215

#### Does this PR introduce a user-facing change?
```release-note
Update the Debian images to pick up CVE fixes in the base images:
- Update the `debian-base` image to v1.7.0
- Update the `debian-iptables` image to v1.6.1
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```

/assign @justaugustus @dims
/sig release
/area release-eng