### PR TITLE
Changes headers to remove "X-" prefix (IETF deprecation)

### DIFF
--- a/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/command_headers.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/command_headers.go
@@ -25,8 +25,8 @@ import (
 )
 
 const (
-	kubectlCommandHeader = "X-Kubectl-Command"
-	kubectlSessionHeader = "X-Kubectl-Session"
+	kubectlCommandHeader = "Kubectl-Command"
+	kubectlSessionHeader = "Kubectl-Session"
 )
 
 // CommandHeaderRoundTripper adds a layer around the standard


### PR DESCRIPTION
* Changes kubectl header keys by removing `X-` prefix. This conforms with [IETF recommendations](https://datatracker.ietf.org/doc/html/rfc6648).
* [KEP](https://github.com/kubernetes/enhancements/tree/master/keps/sig-cli/859-kubectl-headers)

Example:
```
X-Kubectl-Command -> Kubectl-Command
```

/sig cli
/kind feature
/priority important-soon

```release-note
NONE
```