### PR TITLE
Promote Daemonset list and deleteCollection e2e test to Conformance +2 Endpoints

### DIFF
--- a/test/conformance/testdata/conformance.yaml
+++ b/test/conformance/testdata/conformance.yaml
@@ -613,6 +613,14 @@
     and deletecollection. CronJob/status MUST support get, update and patch.'
   release: v1.21
   file: test/e2e/apps/cronjob.go
+- testname: DaemonSet, list and delete a collection of DaemonSets
+  codename: '[sig-apps] Daemon set [Serial] should list and delete a collection of
+    DaemonSets [Conformance]'
+  description: When a DaemonSet is created it MUST succeed. It MUST succeed when listing
+    DaemonSets via a label selector. It MUST succeed when deleting the DaemonSet via
+    deleteCollection.
+  release: v1.22
+  file: test/e2e/apps/daemon_set.go
 - testname: DaemonSet-FailedPodCreation
   codename: '[sig-apps] Daemon set [Serial] should retry creating failed daemon pods
     [Conformance]'

--- a/test/e2e/apps/daemon_set.go
+++ b/test/e2e/apps/daemon_set.go
@@ -809,7 +809,14 @@ var _ = SIGDescribe("Daemon set [Serial]", func() {
 		checkDaemonSetPodsLabels(listDaemonPods(c, ns, label), hash)
 	})
 
-	ginkgo.It("should list and delete a collection of DaemonSets", func() {
+	/*
+		Release: v1.22
+		Testname: DaemonSet, list and delete a collection of DaemonSets
+		Description: When a DaemonSet is created it MUST succeed. It
+		MUST succeed when listing DaemonSets via a label selector. It
+		MUST succeed when deleting the DaemonSet via deleteCollection.
+	*/
+	framework.ConformanceIt("should list and delete a collection of DaemonSets", func() {
 		label := map[string]string{daemonsetNameLabel: dsName}
 		labelSelector := labels.SelectorFromSet(label).String()
 


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it:**
This PR adds a test to test the following untested endpoints:
- listAppsV1DaemonSetForAllNamespaces
- deleteAppsV1CollectionNamespacedDaemonSet

**Which issue(s) this PR fixes:**
Fixes #100547
**Testgrid Link:**
[Test](https://testgrid.k8s.io/sig-release-master-informing#gce-cos-master-serial&include-filter-by-regex=collection&width=5&graph-metrics=test-duration-minutes)

**Special notes for your reviewer:**
Adds +2 endpoint test coverage (good for conformance)

**Does this PR introduce a user-facing change?:**
```
NONE

```

**Release note:**
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:**
```
NONE

```
/sig apps
/sig testing
/sig architecture
/area conformance