### PR TITLE
Promote Replicaset list and deleteCollection e2e test to Conformance +2 endpoints

### DIFF
--- a/test/conformance/testdata/conformance.yaml
+++ b/test/conformance/testdata/conformance.yaml
@@ -779,6 +779,14 @@
     owner references
   release: v1.13
   file: test/e2e/apps/replica_set.go
+- testname: ReplicaSet, list and delete a collection of ReplicaSets
+  codename: '[sig-apps] ReplicaSet should list and delete a collection of ReplicaSets
+    [Conformance]'
+  description: When a ReplicaSet is created it MUST succeed. It MUST succeed when
+    listing ReplicaSets via a label selector. It MUST succeed when deleting the ReplicaSet
+    via deleteCollection.
+  release: v1.22
+  file: test/e2e/apps/replica_set.go
 - testname: Replica Set, run basic image
   codename: '[sig-apps] ReplicaSet should serve a basic image on each replica with
     a public image  [Conformance]'

--- a/test/e2e/apps/replica_set.go
+++ b/test/e2e/apps/replica_set.go
@@ -153,7 +153,14 @@ var _ = SIGDescribe("ReplicaSet", func() {
 		testRSLifeCycle(f)
 	})
 
-	ginkgo.It("should list and delete a collection of ReplicaSets", func() {
+	/*
+		Release: v1.22
+		Testname: ReplicaSet, list and delete a collection of ReplicaSets
+		Description: When a ReplicaSet is created it MUST succeed. It
+		MUST succeed when listing ReplicaSets via a label selector. It
+		MUST succeed when deleting the ReplicaSet via deleteCollection.
+	*/
+	framework.ConformanceIt("should list and delete a collection of ReplicaSets", func() {
 		listRSDeleteCollection(f)
 
 	})


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it:**
This PR adds a test to test the following untested endpoints:
- listAppsV1ReplicaSetForAllNamespaces
- deleteAppsV1CollectionNamespacedReplicaSet

**Which issue(s) this PR fixes:**
Fixes #100546
**Testgrid Link:**
[Test](https://k8s-testgrid.appspot.com/sig-release-master-blocking#gce-cos-master-default&&width=5&include-filter-by-regex=delete.a.collection.of.ReplicaSets&graph-metrics=test-duration-minutes)


**Special notes for your reviewer:**
Adds +2 endpoint test coverage (good for conformance)

**Does this PR introduce a user-facing change?:**
```
NONE

```

**Release note:**
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:**
```
NONE

```

/sig testing
/sig architecture
/area conformance