### PR TITLE
Promote Read, Patch & Replace DaemonSet Status e2e test to Conformance +3 endpoints

### DIFF
--- a/test/conformance/testdata/conformance.yaml
+++ b/test/conformance/testdata/conformance.yaml
@@ -646,6 +646,14 @@
   description: A conformant Kubernetes distribution MUST support DaemonSet RollingUpdates.
   release: v1.10
   file: test/e2e/apps/daemon_set.go
+- testname: DaemonSet, status sub-resource
+  codename: '[sig-apps] Daemon set [Serial] should verify changes to a daemon set
+    status [Conformance]'
+  description: When a DaemonSet is created it MUST succeed. Attempt to read, update
+    and patch its status sub-resource; all mutating sub-resource operations MUST be
+    visible to subsequent reads.
+  release: v1.22
+  file: test/e2e/apps/daemon_set.go
 - testname: Deployment, completes the scaling of a Deployment subresource
   codename: '[sig-apps] Deployment Deployment should have a working scale subresource
     [Conformance]'

--- a/test/e2e/apps/daemon_set.go
+++ b/test/e2e/apps/daemon_set.go
@@ -842,7 +842,13 @@ var _ = SIGDescribe("Daemon set [Serial]", func() {
 		framework.ExpectEqual(len(dsList.Items), 0, "filtered list should have no daemonset")
 	})
 
-	ginkgo.It("should verify changes to a daemon set status", func() {
+	/*	Release: v1.22
+		Testname: DaemonSet, status sub-resource
+		Description: When a DaemonSet is created it MUST succeed.
+		Attempt to read, update and patch its status sub-resource; all
+		mutating sub-resource operations MUST be visible to subsequent reads.
+	*/
+	framework.ConformanceIt("should verify changes to a daemon set status", func() {
 		label := map[string]string{daemonsetNameLabel: dsName}
 		labelSelector := labels.SelectorFromSet(label).String()
 


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it:**
This PR adds a test to test the following untested endpoints:
- replaceAppsV1NamespacedDaemonSetStatus
- readAppsV1NamespacedDaemonSetStatus
- patchAppsV1NamespacedDaemonSetStatus  

**Which issue(s) this PR fixes:**
Fixes #100437
**Testgrid Link:**
[Testgrid Link](https://testgrid.k8s.io/sig-release-master-informing#gce-cos-master-serial&include-filter-by-regex=should%20verify%20changes%20to%20a%20daemon%20set%20status&graph-metrics=test-duration-minutes&width=5)

**Special notes for your reviewer:**
Adds +3 endpoint test coverage (good for conformance)

**Does this PR introduce a user-facing change?:**
```
NONE

```

**Release note:**
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:**
```
NONE

```

/sig testing
/sig architecture
/area conformance