### PR TITLE
Promote Read, Patch & Replace ReplicaSet Status +3 endpoints

### DIFF
--- a/test/conformance/testdata/conformance.yaml
+++ b/test/conformance/testdata/conformance.yaml
@@ -786,6 +786,13 @@
     the Pod is running. Pod SHOULD send a valid response when queried.
   release: v1.9
   file: test/e2e/apps/replica_set.go
+- testname: ReplicaSet, status sub-resource
+  codename: '[sig-apps] ReplicaSet should validate Replicaset Status endpoints [Conformance]'
+  description: Create a ReplicaSet resource which MUST succeed. Attempt to read, update
+    and patch its status sub-resource; all mutating sub-resource operations MUST be
+    visible to subsequent reads.
+  release: v1.22
+  file: test/e2e/apps/replica_set.go
 - testname: Replication Controller, adopt matching pods
   codename: '[sig-apps] ReplicationController should adopt matching pods on creation
     [Conformance]'

--- a/test/e2e/apps/replica_set.go
+++ b/test/e2e/apps/replica_set.go
@@ -158,7 +158,13 @@ var _ = SIGDescribe("ReplicaSet", func() {
 
 	})
 
-	ginkgo.It("should validate Replicaset Status endpoints", func() {
+	/*	Release: v1.22
+		Testname: ReplicaSet, status sub-resource
+		Description: Create a ReplicaSet resource which MUST succeed.
+		Attempt to read, update and patch its status sub-resource; all
+		mutating sub-resource operations MUST be visible to subsequent reads.
+	*/
+	framework.ConformanceIt("should validate Replicaset Status endpoints", func() {
 		testRSStatus(f)
 	})
 })


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it:**
This PR adds a test to test the following untested endpoints:
- replaceAppsV1NamespacedReplicaSetStatus
- readAppsV1NamespacedReplicaSetStatus
- patchAppsV1NamespacedReplicaSetStatus

**Which issue(s) this PR fixes:**
Fixes #100863
**Testgrid Link:**
[Test](https://k8s-testgrid.appspot.com/sig-release-master-blocking#gce-cos-master-default&&width=5&include-filter-by-regex=should%20validate%20Replicaset%20Status%20endpoints&graph-metrics=test-duration-minutes)

**Special notes for your reviewer:**
Adds +3 endpoint test coverage (good for conformance)

**Does this PR introduce a user-facing change?:**
```
NONE

```

**Release note:**
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:**
```
NONE

```

/sig testing
/sig architecture
/area conformance