### PR TITLE
retrywatcher: info log if watch fail for canceled error

### DIFF
--- a/staging/src/k8s.io/client-go/tools/watch/retrywatcher.go
+++ b/staging/src/k8s.io/client-go/tools/watch/retrywatcher.go
@@ -126,6 +126,11 @@ func (rw *RetryWatcher) doReceive() (bool, time.Duration) {
 			// Retry
 			return false, 0
 		}
+		if errors.Is(err, context.DeadlineExceeded) {
+			klog.V(5).InfoS("Watch is stopped", "err", err)
+			// Retry
+			return false, 0
+		}
 
 		klog.ErrorS(err, msg)
 		// Retry


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
#99177 asks to remove this log when it is canceled error.
> Watch failed: 
>  Get \"https://xxx/api/v1/services?allowWatchBookmarks=1&resourceVersion=x&watch=1\": context canceled
> Watch failed: Get \"https://xxx/api/v1/services?allowWatchBookmarks=1&resourceVersion=x&watch=1\": context canceled
 
#### Which issue(s) this PR fixes:
Fixes #99177

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```