### PR TITLE
Simplify kube-cross dependency handling

### DIFF
--- a/build/dependencies.yaml
+++ b/build/dependencies.yaml
@@ -127,8 +127,6 @@ dependencies:
     version: v1.16.4-2
     refPaths:
     - path: build/build-image/cross/VERSION
-    - path: test/images/sample-apiserver/Makefile
-      match: k8s\.gcr\.io\/build-image\/kube-cross:v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)
 
   # Base images
   - name: "k8s.gcr.io/debian-base: dependents"

--- a/test/images/sample-apiserver/Makefile
+++ b/test/images/sample-apiserver/Makefile
@@ -18,13 +18,14 @@ TARGET ?= $(CURDIR)
 GOARM = 7
 GOLANG_VERSION ?= latest
 SRC_DIR = $(notdir $(shell pwd))
+KUBE_CROSS_VERSION ?= $(shell cat ../../../build/build-image/cross/VERSION)
 export
 
 # Build v1.17.0 to ensure the current release supports a prior version of the sample apiserver
 # Get without building to populate module cache
 # Then, get with OS/ARCH-specific env to build
 bin:
-	docker run --rm -i -v "${TARGET}:${TARGET}:Z" k8s.gcr.io/build-image/kube-cross:v1.16.4-2 \
+	docker run --rm -i -v "${TARGET}:${TARGET}:Z" k8s.gcr.io/build-image/kube-cross:${KUBE_CROSS_VERSION} \
 		/bin/bash -c "\
 			mkdir -p /go/src /go/bin && \
 			GO111MODULE=on go get -d k8s.io/sample-apiserver@v0.17.0 && \


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:
We can indirectly retrieve the kube-cross version from the
`build/build-image/cross/VERSION` for the sample-apiserver. This allows
us to simplify the handling in `build/dependencies.yaml` as well as
the required approval (via `OWNERS`) if the kube-cross version changes.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Follow-up on https://github.com/kubernetes/kubernetes/pull/102364

#### Special notes for your reviewer:
/assign @dims @justaugustus 
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
None
```
