### PR TITLE
Fix prometheus-to-sd image for fluentbit

### DIFF
--- a/cluster/addons/fluentd-gcp/fluentd-gcp-ds.yaml
+++ b/cluster/addons/fluentd-gcp/fluentd-gcp-ds.yaml
@@ -79,7 +79,7 @@ spec:
               fi;
       # BEGIN_PROMETHEUS_TO_SD
       - name: prometheus-to-sd-exporter
-        image: k8s.gcr.io/prometheus-to-sd:v0.11.1
+        image: gke.gcr.io/prometheus-to-sd:v0.11.1-gke.1
         command:
           - /monitor
           - --stackdriver-prefix={{ prometheus_to_sd_prefix }}/addons


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

I missed an image while updating the prometheus-to-sd images here: https://github.com/kubernetes/kubernetes/pull/101486/files#r640134779

```release-note
NONE
```

/sig instrumentation
/priority important-soon