### PR TITLE
Fix Trace format

### DIFF
--- a/vendor/k8s.io/utils/trace/trace.go
+++ b/vendor/k8s.io/utils/trace/trace.go
@@ -56,7 +56,7 @@ func writeTraceItemSummary(b *bytes.Buffer, msg string, totalTime time.Duration,
 		b.WriteString(" ")
 	}
 
-	b.WriteString(fmt.Sprintf("%vms (%v)", durationToMilliseconds(totalTime), startTime.Format("15:04:00.000")))
+	b.WriteString(fmt.Sprintf("%vms (%v)", durationToMilliseconds(totalTime), startTime.Format("15:04:05.000")))
 }
 
 func durationToMilliseconds(timeDuration time.Duration) int64 {


### PR DESCRIPTION
We should use format matching https://golang.org/pkg/time/#Time.Format, otherwise we are losing seconds in our Trace logs

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:
It fixes format used by trace utility. Currently, traces has steps with zeroed seconds. Example:

```
10450262 I0521 18:17:55.322083      12 trace.go:205] Trace[497877834]: "Update" url:/apis/coordination.k8s.io/v1/namespaces/kube-node-lease/leases/gce-scale-cluster-minion-group-3-bfc3,user-agent:kubelet/v1.22.0 (linux/amd64) kubernetes/e5bee02,audit-id:         62de2fd0-d266-4b63-b868-47d957a3e779,client:10.40.31.195,accept:application/vnd.kubernetes.protobuf,application/json,protocol:HTTP/2.0 (21-May-2021 18:17:49.322) (total time: 5999ms):                                                              
10450263 Trace[497877834]: ---"Object stored in database" 5997ms (18:17:00.321)                                                                                                                                                                               
10450264 Trace[497877834]: [5.999560182s] [5.999560182s] END
```

`(18:17:00.321) ` should be something like `(18:17:55.321)`

Example from `gs://kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-scale-performance/1395786764303470592/build-log.txt`

####

/cc @wojtek-t 