### PR TITLE
Update setcap to buster-v2.0.1 and add setcap to dependencies.yaml

### DIFF
--- a/build/common.sh
+++ b/build/common.sh
@@ -88,6 +88,7 @@ readonly KUBE_CONTAINER_RSYNC_PORT=8730
 # These are the default versions (image tags) for their respective base images.
 readonly __default_debian_iptables_version=buster-v1.6.1
 readonly __default_go_runner_version=v2.3.1-go1.16.4-buster.0
+readonly __default_setcap_version=buster-v2.0.1
 
 # These are the base images for the Docker-wrapped binaries.
 readonly KUBE_GORUNNER_IMAGE="${KUBE_GORUNNER_IMAGE:-$KUBE_BASE_IMAGE_REGISTRY/go-runner:$__default_go_runner_version}"
@@ -97,7 +98,7 @@ readonly KUBE_SCHEDULER_BASE_IMAGE="${KUBE_SCHEDULER_BASE_IMAGE:-$KUBE_GORUNNER_
 readonly KUBE_PROXY_BASE_IMAGE="${KUBE_PROXY_BASE_IMAGE:-$KUBE_BASE_IMAGE_REGISTRY/debian-iptables:$__default_debian_iptables_version}"
 
 # This is the image used in a multi-stage build to apply capabilities to Docker-wrapped binaries.
-readonly KUBE_BUILD_SETCAP_IMAGE="${KUBE_BUILD_SETCAP_IMAGE:-$KUBE_BASE_IMAGE_REGISTRY/setcap:buster-v1.4.0}"
+readonly KUBE_BUILD_SETCAP_IMAGE="${KUBE_BUILD_SETCAP_IMAGE:-$KUBE_BASE_IMAGE_REGISTRY/setcap:$__default_setcap_version}"
 
 # Get the set of master binaries that run in Docker (on Linux)
 # Entry format is "<binary-name>,<base-image>".

--- a/build/dependencies.yaml
+++ b/build/dependencies.yaml
@@ -215,6 +215,12 @@ dependencies:
     - path: test/utils/image/manifest.go
       match: configs\[Pause\] = Config{list\.GcRegistry, "pause", "\d+\.\d+(.\d+)?"}
 
+  - name: "k8s.gcr.io/setcap: dependents"
+    version: buster-v2.0.1
+    refPaths:
+    - path: build/common.sh
+      match: __default_setcap_version=
+
   # metadata-concealment: bump this one first
   - name: "metadata-concealment"
     version: "1.6"


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

This PR updates the `setcap` image to `buster-v2.0.1` to pick up the CVE-2021-3520 fix in the base image. This PR also adds `setcap` to the `dependencies.yaml` file.

#### Which issue(s) this PR fixes:
xref #102215

#### Does this PR introduce a user-facing change?
```release-note
Update the setcap image to buster-v2.0.1
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```

/assign @justaugustus @puerco 