### PR TITLE
scheduler: fix non-compatible change in default topology spread constraints

### DIFF
--- a/pkg/scheduler/framework/plugins/podtopologyspread/plugin.go
+++ b/pkg/scheduler/framework/plugins/podtopologyspread/plugin.go
@@ -54,6 +54,7 @@ var systemDefaultConstraints = []v1.TopologySpreadConstraint{
 type PodTopologySpread struct {
 	parallelizer       parallelize.Parallelizer
 	defaultConstraints []v1.TopologySpreadConstraint
+	defaultingType     config.PodTopologySpreadConstraintsDefaulting
 	sharedLister       framework.SharedLister
 	services           corelisters.ServiceLister
 	replicationCtrls   corelisters.ReplicationControllerLister
@@ -93,6 +94,7 @@ func New(plArgs runtime.Object, h framework.Handle) (framework.Plugin, error) {
 		parallelizer:       h.Parallelizer(),
 		sharedLister:       h.SnapshotSharedLister(),
 		defaultConstraints: args.DefaultConstraints,
+		defaultingType:     args.DefaultingType,
 	}
 	if args.DefaultingType == config.SystemDefaulting {
 		pl.defaultConstraints = systemDefaultConstraints


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #102136

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```



/sig scheduling
@alculquicondor 