### PR TITLE
bump calico to v3.19.1

### DIFF
--- a/cluster/addons/calico-policy-controller/calico-node-daemonset.yaml
+++ b/cluster/addons/calico-policy-controller/calico-node-daemonset.yaml
@@ -27,7 +27,7 @@ spec:
       terminationGracePeriodSeconds: 0
       initContainers:
         - name: install-cni
-          image: gcr.io/projectcalico-org/cni:v3.16.2
+          image: gcr.io/projectcalico-org/cni:v3.19.1
           command: ["/opt/cni/bin/install"]
           env:
             - name: CNI_CONF_NAME
@@ -78,7 +78,7 @@ spec:
         # container programs network policy and routes on each
         # host.
         - name: calico-node
-          image: gcr.io/projectcalico-org/node:v3.16.2
+          image: gcr.io/projectcalico-org/node:v3.19.1
           env:
             - name: CALICO_MANAGE_CNI
               value: "true"

--- a/cluster/addons/calico-policy-controller/typha-deployment.yaml
+++ b/cluster/addons/calico-policy-controller/typha-deployment.yaml
@@ -23,7 +23,7 @@ spec:
       hostNetwork: true
       serviceAccountName: calico
       containers:
-      - image: gcr.io/projectcalico-org/typha:v3.16.2
+      - image: gcr.io/projectcalico-org/typha:v3.19.1
         name: calico-typha
         ports:
         - containerPort: 5473


### PR DESCRIPTION
/kind cleanup

to run endport feature (https://github.com/kubernetes/kubernetes/pull/100291) e2e test case, we need >v3.19 Calico

```release-note
update Calico to v3.19.1
```
