### PR TITLE
Automated cherry pick of #99680: fix error of setting  negative value for containerLogMaxSize

### DIFF
--- a/pkg/kubelet/logs/container_log_manager.go
+++ b/pkg/kubelet/logs/container_log_manager.go
@@ -138,9 +138,6 @@ func parseMaxSize(size string) (int64, error) {
 	if !ok {
 		return 0, fmt.Errorf("invalid max log size")
 	}
-	if maxSize < 0 {
-		return 0, fmt.Errorf("negative max log size %d", maxSize)
-	}
 	return maxSize, nil
 }
 
@@ -160,6 +157,10 @@ func NewContainerLogManager(runtimeService internalapi.RuntimeService, osInterfa
 	parsedMaxSize, err := parseMaxSize(maxSize)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse container log max size %q: %v", maxSize, err)
+	}
+	// Negative number means to disable container log rotation
+	if parsedMaxSize < 0 {
+		return NewStubContainerLogManager(), nil
 	}
 	// policy LogRotatePolicy
 	return &containerLogManager{


### PR DESCRIPTION
Cherry pick of #99680 on release-1.20.

#99680: fix error of setting  negative value for containerLogMaxSize

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
NONE
```