### PR TITLE
fix e2e test predicates conflict hostip

### DIFF
--- a/hack/local-up-cluster.sh
+++ b/hack/local-up-cluster.sh
@@ -16,7 +16,10 @@
 
 KUBE_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
 
-# This script builds and runs a local kubernetes cluster. You may need to run
+#get the default gateway
+DEFAULT_GATEWAY=$(ip route get 1.1.1.1 | grep -Po '(?<=(src )).*(?= uid)')
+DEFAULT_HOSTNAME=${DEFAULT_GATEWAY:-"127.0.0.1"}
+
 # this as root to allow kubelet to open docker's socket, and to write the test
 # CA in /var/run/kubernetes.
 # Usage: `hack/local-up-cluster.sh`.
@@ -76,7 +79,7 @@ KUBECTL=${KUBECTL:-"${KUBE_ROOT}/cluster/kubectl.sh"}
 WAIT_FOR_URL_API_SERVER=${WAIT_FOR_URL_API_SERVER:-60}
 MAX_TIME_FOR_URL_API_SERVER=${MAX_TIME_FOR_URL_API_SERVER:-1}
 ENABLE_DAEMON=${ENABLE_DAEMON:-false}
-HOSTNAME_OVERRIDE=${HOSTNAME_OVERRIDE:-"127.0.0.1"}
+HOSTNAME_OVERRIDE=${HOSTNAME_OVERRIDE:-$DEFAULT_HOSTNAME}
 EXTERNAL_CLOUD_PROVIDER=${EXTERNAL_CLOUD_PROVIDER:-false}
 EXTERNAL_CLOUD_PROVIDER_BINARY=${EXTERNAL_CLOUD_PROVIDER_BINARY:-""}
 EXTERNAL_CLOUD_VOLUME_PLUGIN=${EXTERNAL_CLOUD_VOLUME_PLUGIN:-""}
@@ -220,7 +223,7 @@ NODE_PORT_RANGE=${NODE_PORT_RANGE:-""}
 API_BIND_ADDR=${API_BIND_ADDR:-"0.0.0.0"}
 EXTERNAL_HOSTNAME=${EXTERNAL_HOSTNAME:-localhost}
 
-KUBELET_HOST=${KUBELET_HOST:-"127.0.0.1"}
+KUBELET_HOST=${KUBELET_HOST:-$DEFAULT_HOSTNAME}
 # By default only allow CORS for requests on localhost
 API_CORS_ALLOWED_ORIGINS=${API_CORS_ALLOWED_ORIGINS:-/127.0.0.1(:[0-9]+)?$,/localhost(:[0-9]+)?$}
 KUBELET_PORT=${KUBELET_PORT:-10250}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
/kind failing-test
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
In some scenarios, for example, when using local-up-cluster.sh to build a kubernetes cluster, the InternalIP of node is 127.0.0.1, and it is same as ”localhost”, which will causes the execution of the use case to fail.

```
[2021-05-28 16:26:25]  [sig-scheduling] SchedulerPredicates [Serial] 
[2021-05-28 16:26:25]    validates that there is no conflict between pods with same hostPort but different hostIP and protocol
[2021-05-28 16:26:25]    /usr1/k8s/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/test/e2e/scheduling/predicates.go:654
[2021-05-28 16:26:25]  [BeforeEach] [sig-scheduling] SchedulerPredicates [Serial]
[2021-05-28 16:26:25]    /usr1/k8s/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:185
[2021-05-28 16:26:25]  STEP: Creating a kubernetes client
[2021-05-28 16:26:25]  May 28 16:26:25.690: INFO: >>> kubeConfig: /var/run/kubernetes/admin.kubeconfig
[2021-05-28 16:26:25]  STEP: Building a namespace api object, basename sched-pred
[2021-05-28 16:26:25]  STEP: Waiting for a default service account to be provisioned in namespace
[2021-05-28 16:26:25]  [BeforeEach] [sig-scheduling] SchedulerPredicates [Serial]
[2021-05-28 16:26:25]    /usr1/k8s/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/test/e2e/scheduling/predicates.go:90
[2021-05-28 16:26:25]  May 28 16:26:25.744: INFO: Waiting up to 1m0s for all (but 0) nodes to be ready
[2021-05-28 16:26:25]  May 28 16:26:25.748: INFO: Waiting for terminating namespaces to be deleted...
[2021-05-28 16:26:25]  May 28 16:26:25.752: INFO: 
[2021-05-28 16:26:25]  Logging pods the apiserver thinks is on node 127.0.0.1 before test
[2021-05-28 16:26:25]  May 28 16:26:25.755: INFO: pod1 from hostport-9800 started at 2021-05-28 16:26:11 +0800 CST (1 container statuses recorded)
[2021-05-28 16:26:25]  May 28 16:26:25.755: INFO: 	Container agnhost ready: true, restart count 0
[2021-05-28 16:26:25]  May 28 16:26:25.755: INFO: pod2 from hostport-9800 started at 2021-05-28 16:26:23 +0800 CST (0 container statuses recorded)
[2021-05-28 16:26:25]  May 28 16:26:25.755: INFO: coredns-755cd654d4-dpph7 from kube-system started at 2021-05-28 16:16:19 +0800 CST (1 container statuses recorded)
[2021-05-28 16:26:25]  May 28 16:26:25.755: INFO: 	Container coredns ready: true, restart count 0
[2021-05-28 16:26:25]  [It] validates that there is no conflict between pods with same hostPort but different hostIP and protocol
[2021-05-28 16:26:25]    /usr1/k8s/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/test/e2e/scheduling/predicates.go:654
[2021-05-28 16:26:25]  STEP: Trying to launch a pod without a label to get a node which can launch it.
[2021-05-28 16:26:29]  STEP: Explicitly delete pod here to free the resource it takes.
[2021-05-28 16:26:29]  STEP: Trying to apply a random label on the found node.
[2021-05-28 16:26:29]  STEP: verifying the node has the label kubernetes.io/e2e-59cc176a-94b9-4c89-8931-b47d444cda1d 90
[2021-05-28 16:26:29]  STEP: Trying to create a pod(pod1) with hostport 54321 and hostIP 127.0.0.1 and expect scheduled
[2021-05-28 16:26:33]  STEP: Trying to create another pod(pod2) with hostport 54321 but hostIP 127.0.0.1 on the node which pod1 resides and expect scheduled
[2021-05-28 16:31:33]  May 28 16:31:33.865: FAIL: Unexpected error:
[2021-05-28 16:31:33]      <*errors.errorString | 0xc000246250>: {
[2021-05-28 16:31:33]          s: "timed out waiting for the condition",
[2021-05-28 16:31:33]      }
[2021-05-28 16:31:33]      timed out waiting for the condition
[2021-05-28 16:31:33]  occurred
[2021-05-28 16:31:33]  
[2021-05-28 16:31:33]  Full Stack Trace
[2021-05-28 16:31:33]  k8s.io/kubernetes/test/e2e/scheduling.createHostPortPodOnNode(0xc000e6d080, 0x6e8b0ee, 0x4, 0xc00439a1b0, 0xf, 0xc00439a7e0, 0x9, 0xd431, 0x6e89d64, 0x3, ...)
[2021-05-28 16:31:33]  	/usr1/k8s/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/test/e2e/scheduling/predicates.go:1068 +0x5bc
[2021-05-28 16:31:33]  k8s.io/kubernetes/test/e2e/scheduling.glob..func4.12()
[2021-05-28 16:31:33]  	/usr1/k8s/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/test/e2e/scheduling/predicates.go:680 +0x66a
[2021-05-28 16:31:33]  k8s.io/kubernetes/test/e2e.RunE2ETests(0xc003c64d80)
[2021-05-28 16:31:33]  	_output/local/go/src/k8s.io/kubernetes/test/e2e/e2e.go:130 +0x36c
[2021-05-28 16:31:33]  k8s.io/kubernetes/test/e2e.TestE2E(0xc003c64d80)
[2021-05-28 16:31:33]  	_output/local/go/src/k8s.io/kubernetes/test/e2e/e2e_test.go:144 +0x2b
[2021-05-28 16:31:33]  testing.tRunner(0xc003c64d80, 0x70a78c8)
[2021-05-28 16:31:33]  	/usr1/go/src/testing/testing.go:1194 +0xef
[2021-05-28 16:31:33]  created by testing.(*T).Run
[2021-05-28 16:31:33]  	/usr1/go/src/testing/testing.go:1239 +0x2b3
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
