### PR TITLE
Update vSphere volume topology label to GA

### DIFF
--- a/pkg/volume/vsphere_volume/vsphere_volume.go
+++ b/pkg/volume/vsphere_volume/vsphere_volume.go
@@ -433,7 +433,7 @@ func (v *vsphereVolumeProvisioner) Provision(selectedNode *v1.Node, allowedTopol
 		for k, v := range labels {
 			pv.Labels[k] = v
 			var values []string
-			if k == v1.LabelFailureDomainBetaZone {
+			if k == v1.LabelTopologyZone || k == v1.LabelFailureDomainBetaZone {
 				values, err = volumehelpers.LabelZonesToList(v)
 				if err != nil {
 					return nil, fmt.Errorf("failed to convert label string for Zone: %s to a List: %v", v, err)

--- a/staging/src/k8s.io/csi-translation-lib/plugins/vsphere_volume_test.go
+++ b/staging/src/k8s.io/csi-translation-lib/plugins/vsphere_volume_test.go
@@ -30,6 +30,16 @@ func TestTranslatevSphereInTreeStorageClassToCSI(t *testing.T) {
 	translator := NewvSphereCSITranslator()
 	topologySelectorTerm := v1.TopologySelectorTerm{[]v1.TopologySelectorLabelRequirement{
 		{
+			Key:    v1.LabelTopologyZone,
+			Values: []string{"zone-a"},
+		},
+		{
+			Key:    v1.LabelTopologyRegion,
+			Values: []string{"region-a"},
+		},
+	}}
+	topologySelectorTermWithBetaLabels := v1.TopologySelectorTerm{[]v1.TopologySelectorLabelRequirement{
+		{
 			Key:    v1.LabelFailureDomainBetaZone,
 			Values: []string{"zone-a"},
 		},
@@ -84,6 +94,11 @@ func TestTranslatevSphereInTreeStorageClassToCSI(t *testing.T) {
 			name:  "translate with storagepolicyname and allowedTopology",
 			sc:    NewStorageClass(map[string]string{"storagepolicyname": "test-policy-name"}, []v1.TopologySelectorTerm{topologySelectorTerm}),
 			expSc: NewStorageClass(map[string]string{"storagepolicyname": "test-policy-name", paramcsiMigration: "true"}, []v1.TopologySelectorTerm{topologySelectorTerm}),
+		},
+		{
+			name:  "translate with storagepolicyname and allowedTopology beta labels",
+			sc:    NewStorageClass(map[string]string{"storagepolicyname": "test-policy-name"}, []v1.TopologySelectorTerm{topologySelectorTermWithBetaLabels}),
+			expSc: NewStorageClass(map[string]string{"storagepolicyname": "test-policy-name", paramcsiMigration: "true"}, []v1.TopologySelectorTerm{topologySelectorTermWithBetaLabels}),
 		},
 		{
 			name:  "translate with raw vSAN policy parameters, datastore and diskformat",

--- a/staging/src/k8s.io/legacy-cloud-providers/vsphere/nodemanager.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/vsphere/nodemanager.go
@@ -219,8 +219,8 @@ func (nm *NodeManager) DiscoverNode(node *v1.Node) error {
 						}
 					}
 					// Get the node zone information
-					nodeFd := node.ObjectMeta.Labels[v1.LabelFailureDomainBetaZone]
-					nodeRegion := node.ObjectMeta.Labels[v1.LabelFailureDomainBetaRegion]
+					nodeFd := node.ObjectMeta.Labels[v1.LabelTopologyZone]
+					nodeRegion := node.ObjectMeta.Labels[v1.LabelTopologyRegion]
 					nodeZone := &cloudprovider.Zone{FailureDomain: nodeFd, Region: nodeRegion}
 					nodeInfo := &NodeInfo{dataCenter: res.datacenter, vm: vm, vcServer: res.vc, vmUUID: nodeUUID, zone: nodeZone}
 					nm.addNodeInfo(node.ObjectMeta.Name, nodeInfo)

--- a/staging/src/k8s.io/legacy-cloud-providers/vsphere/vsphere.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/vsphere/vsphere.go
@@ -1776,8 +1776,8 @@ func (vs *VSphere) GetVolumeLabels(volumePath string) (map[string]string, error)
 	// FIXME: For now, pick the first zone of datastore as the zone of volume
 	labels := make(map[string]string)
 	if len(dsZones) > 0 {
-		labels[v1.LabelFailureDomainBetaRegion] = dsZones[0].Region
-		labels[v1.LabelFailureDomainBetaZone] = dsZones[0].FailureDomain
+		labels[v1.LabelTopologyRegion] = dsZones[0].Region
+		labels[v1.LabelTopologyZone] = dsZones[0].FailureDomain
 	}
 	return labels, nil
 }

--- a/test/e2e/storage/vsphere/vsphere_utils.go
+++ b/test/e2e/storage/vsphere/vsphere_utils.go
@@ -226,7 +226,7 @@ func getVSphereStorageClassSpec(name string, scParameters map[string]string, zon
 		term := v1.TopologySelectorTerm{
 			MatchLabelExpressions: []v1.TopologySelectorLabelRequirement{
 				{
-					Key:    v1.LabelFailureDomainBetaZone,
+					Key:    v1.LabelTopologyZone,
 					Values: zones,
 				},
 			},

--- a/test/e2e/storage/vsphere/vsphere_zone_support.go
+++ b/test/e2e/storage/vsphere/vsphere_zone_support.go
@@ -369,7 +369,7 @@ var _ = utils.SIGDescribe("Zone Support [Feature:vsphere]", func() {
 		zones = append(zones, zoneA)
 		nodeSelectorMap := map[string]string{
 			// nodeSelector set as zoneB
-			v1.LabelFailureDomainBetaZone: zoneB,
+			v1.LabelTopologyZone: zoneB,
 		}
 		verifyPodSchedulingFails(client, namespace, nodeSelectorMap, scParameters, zones, storagev1.VolumeBindingWaitForFirstConsumer)
 	})
@@ -518,7 +518,7 @@ func verifyPVZoneLabels(client clientset.Interface, timeouts *framework.TimeoutC
 	ginkgo.By("Verify zone information is present in the volume labels")
 	for _, pv := range persistentvolumes {
 		// Multiple zones are separated with "__"
-		pvZoneLabels := strings.Split(pv.ObjectMeta.Labels["failure-domain.beta.kubernetes.io/zone"], "__")
+		pvZoneLabels := strings.Split(pv.ObjectMeta.Labels[v1.LabelTopologyZone], "__")
 		for _, zone := range zones {
 			gomega.Expect(pvZoneLabels).Should(gomega.ContainElement(zone), "Incorrect or missing zone labels in pv.")
 		}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind/deprecation
/kind/bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
this PR replaces the deprecated topology labels in favor of the new GA ones for vSphere volume

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes/kubernetes/issues/98281

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
[ACTION REQUIRED] Newly provisioned PVs by vSphere in-tree plugin will no longer have the beta FailureDomain label. vSphere volume plugin will start to have GA topology label instead.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

/cc @Jiawei0227 @xing-yang 
