### PR TITLE
hotfix(staging_apiserver_pkg_httplog): restore depth to log calls

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/server/httplog/httplog.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/httplog/httplog.go
@@ -97,7 +97,7 @@ func WithLogging(handler http.Handler, pred StacktracePred) http.Handler {
 		req = req.WithContext(context.WithValue(ctx, respLoggerContextKey, rl))
 
 		if klog.V(3).Enabled() {
-			defer func() { klog.InfoS("HTTP", rl.LogArgs()...) }()
+			defer rl.Log()
 		}
 		handler.ServeHTTP(rl, req)
 	})
@@ -180,38 +180,33 @@ func AddInfof(ctx context.Context, format string, data ...interface{}) {
 	}
 }
 
-func (rl *respLogger) LogArgs() []interface{} {
+// Log is intended to be called once at the end of your request handler, via defer
+func (rl *respLogger) Log() {
 	latency := time.Since(rl.startTime)
 	auditID := request.GetAuditIDTruncated(rl.req)
-	if rl.hijacked {
-		return []interface{}{
-			"verb", rl.req.Method,
-			"URI", rl.req.RequestURI,
-			"latency", latency,
-			"userAgent", rl.req.UserAgent(),
-			"audit-ID", auditID,
-			"srcIP", rl.req.RemoteAddr,
-			"hijacked", true,
-		}
-	}
-	args := []interface{}{
+	keysAndValues := []interface{}{
 		"verb", rl.req.Method,
 		"URI", rl.req.RequestURI,
 		"latency", latency,
 		"userAgent", rl.req.UserAgent(),
 		"audit-ID", auditID,
 		"srcIP", rl.req.RemoteAddr,
-		"resp", rl.status,
-	}
-	if len(rl.statusStack) > 0 {
-		args = append(args, "statusStack", rl.statusStack)
 	}
 
-	info := rl.addedInfo.String()
-	if len(info) > 0 {
-		args = append(args, "addedInfo", info)
+	if rl.hijacked {
+		keysAndValues = append(keysAndValues, "hijacked", true)
+	} else {
+		keysAndValues = append(keysAndValues, "resp", rl.status)
+		if len(rl.statusStack) > 0 {
+			keysAndValues = append(keysAndValues, "statusStack", rl.statusStack)
+		}
+		info := rl.addedInfo.String()
+		if len(info) > 0 {
+			keysAndValues = append(keysAndValues, "addedInfo", info)
+		}
 	}
-	return args
+
+	klog.InfoSDepth(1, "HTTP", keysAndValues...)
 }
 
 // Header implements http.ResponseWriter.


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

This PR adds depth to logging which was removed when migrating to structured logging.

#### Which issue(s) this PR fixes:

Ref #102353

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```