### PR TITLE
test/e2e: minor netpol test improvements

### DIFF
--- a/test/e2e/framework/pod/utils.go
+++ b/test/e2e/framework/pod/utils.go
@@ -17,24 +17,10 @@ limitations under the License.
 package pod
 
 import (
-	"flag"
-
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/kubernetes/test/e2e/framework"
 	imageutils "k8s.io/kubernetes/test/utils/image"
 )
-
-// NodeOSDistroIs returns true if the distro is the same as `--node-os-distro`
-// the package framework/pod can't import the framework package (see #81245)
-// we need to check if the --node-os-distro=windows is set and the framework package
-// is the one that's parsing the flags, as a workaround this method is looking for the same flag again
-// TODO: replace with `framework.NodeOSDistroIs` when #81245 is complete
-func NodeOSDistroIs(distro string) bool {
-	var nodeOsDistro *flag.Flag = flag.Lookup("node-os-distro")
-	if nodeOsDistro != nil && nodeOsDistro.Value.String() == distro {
-		return true
-	}
-	return false
-}
 
 // GenerateScriptCmd generates the corresponding command lines to execute a command.
 // Depending on the Node OS is Windows or linux, the command will use powershell or /bin/sh
@@ -43,7 +29,7 @@ func GenerateScriptCmd(command string) []string {
 	if command == "" {
 		return commands
 	}
-	if !NodeOSDistroIs("windows") {
+	if !framework.NodeOSDistroIs("windows") {
 		commands = []string{"/bin/sh", "-c", command}
 	} else {
 		commands = []string{"powershell", "/c", command}
@@ -71,7 +57,7 @@ func GetDefaultTestImageID() int {
 // If the Node OS is windows, currently we return Agnhost image for Windows node
 // due to the issue of #https://github.com/kubernetes-sigs/windows-testing/pull/35.
 func GetTestImage(id int) string {
-	if NodeOSDistroIs("windows") {
+	if framework.NodeOSDistroIs("windows") {
 		return imageutils.GetE2EImage(imageutils.Agnhost)
 	}
 	return imageutils.GetE2EImage(id)
@@ -81,7 +67,7 @@ func GetTestImage(id int) string {
 // If the Node OS is windows, currently we return Agnhost image for Windows node
 // due to the issue of #https://github.com/kubernetes-sigs/windows-testing/pull/35.
 func GetTestImageID(id int) int {
-	if NodeOSDistroIs("windows") {
+	if framework.NodeOSDistroIs("windows") {
 		return imageutils.Agnhost
 	}
 	return id
@@ -91,7 +77,7 @@ func GetTestImageID(id int) int {
 // If the Node OS is windows, currently we will ignore the inputs and return nil.
 // TODO: Will modify it after windows has its own security context
 func GeneratePodSecurityContext(fsGroup *int64, seLinuxOptions *v1.SELinuxOptions) *v1.PodSecurityContext {
-	if NodeOSDistroIs("windows") {
+	if framework.NodeOSDistroIs("windows") {
 		return nil
 	}
 	return &v1.PodSecurityContext{
@@ -104,7 +90,7 @@ func GeneratePodSecurityContext(fsGroup *int64, seLinuxOptions *v1.SELinuxOption
 // If the Node OS is windows, currently we will ignore the inputs and return nil.
 // TODO: Will modify it after windows has its own security context
 func GenerateContainerSecurityContext(privileged bool) *v1.SecurityContext {
-	if NodeOSDistroIs("windows") {
+	if framework.NodeOSDistroIs("windows") {
 		return nil
 	}
 	return &v1.SecurityContext{
@@ -115,7 +101,7 @@ func GenerateContainerSecurityContext(privileged bool) *v1.SecurityContext {
 // GetLinuxLabel returns the default SELinuxLabel based on OS.
 // If the node OS is windows, it will return nil
 func GetLinuxLabel() *v1.SELinuxOptions {
-	if NodeOSDistroIs("windows") {
+	if framework.NodeOSDistroIs("windows") {
 		return nil
 	}
 	return &v1.SELinuxOptions{

--- a/test/e2e/network/netpol/probe.go
+++ b/test/e2e/network/netpol/probe.go
@@ -86,8 +86,15 @@ func ProbePodToPodConnectivity(k8s *kubeManager, model *Model, testCase *TestCas
 func probeWorker(k8s *kubeManager, jobs <-chan *ProbeJob, results chan<- *ProbeJobResults, timeoutSeconds int) {
 	defer ginkgo.GinkgoRecover()
 	for job := range jobs {
-		podFrom := job.PodFrom
-		connected, command, err := k8s.probeConnectivity(podFrom.Namespace, podFrom.Name, podFrom.Containers[0].Name(), job.PodTo.QualifiedServiceAddress(job.ToPodDNSDomain), job.Protocol, job.ToPort, timeoutSeconds)
+		connected, command, err := k8s.probeConnectivity(&probeConnArgs{
+			nsFrom:         job.PodFrom.Namespace,
+			podFrom:        job.PodFrom.Name,
+			containerFrom:  job.PodFrom.Containers[0].Name(),
+			addrTo:         job.PodTo.QualifiedServiceAddress(job.ToPodDNSDomain),
+			protocol:       job.Protocol,
+			toPort:         job.ToPort,
+			timeoutSeconds: timeoutSeconds,
+		})
 		result := &ProbeJobResults{
 			Job:         job,
 			IsConnected: connected,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->


/kind cleanup

#### Which issue(s) this PR fixes:
Fixes #102334

#### Special notes for your reviewer:

Referring to the list from the original issue:
2. From what I understand, it's `agnhost` which is handling the flag parsing so doesn't it make more sense to make the relevant changes there? (I'm not entirely sure how this works rn, so please correct me If I'm wrong). Also, the flag could not be a native Go timestamp passed as a string since it would be highly inconvenient imo, right?. What do you think?
3. Do we want to have `newWindowsFramework`? and if yes, is this just being prudent? because the way `framework.NodeOSDistroIs` is used right now doesn't seem to warrant it or am I missing something?
4. I do agree with having two separate structs. The syscall package does something similar. 
