### PR TITLE
Improve ToSelectableFields' performance for events

### DIFF
--- a/pkg/registry/core/event/strategy.go
+++ b/pkg/registry/core/event/strategy.go
@@ -121,7 +121,7 @@ func ToSelectableFields(event *api.Event) fields.Set {
 		"source":                         source,
 		"type":                           event.Type,
 	}
-	return generic.MergeFieldsSets(objectMetaFieldsSet, specificFieldsSet)
+	return generic.MergeFieldsSets(specificFieldsSet, objectMetaFieldsSet)
 }
 
 // requestGroupVersion returns the group/version associated with the given context, or a zero-value group/version.


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
Improve func ToSelectableFields' performance for event, by merging a map with two elements into a map with eleven.

Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
Improve func ToSelectableFields' performance for event
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs

```
