### PR TITLE
kubeadm: update coredns to 1.8.4

### DIFF
--- a/build/dependencies.yaml
+++ b/build/dependencies.yaml
@@ -55,7 +55,7 @@ dependencies:
       match: k8s.gcr.io/coredns
 
   - name: "coredns-kubeadm"
-    version: 1.8.0
+    version: 1.8.4
     refPaths:
     - path: cmd/kubeadm/app/constants/constants.go
       match: CoreDNSVersion =

--- a/cmd/kubeadm/app/constants/constants.go
+++ b/cmd/kubeadm/app/constants/constants.go
@@ -325,7 +325,7 @@ const (
 	CoreDNSImageName = "coredns"
 
 	// CoreDNSVersion is the version of CoreDNS to be deployed if it is used
-	CoreDNSVersion = "v1.8.0"
+	CoreDNSVersion = "v1.8.4"
 
 	// ClusterConfigurationKind is the string kind value for the ClusterConfiguration struct
 	ClusterConfigurationKind = "ClusterConfiguration"

--- a/cmd/kubeadm/app/images/images_test.go
+++ b/cmd/kubeadm/app/images/images_test.go
@@ -233,7 +233,7 @@ func TestGetDNSImage(t *testing.T) {
 		cfg      *kubeadmapi.ClusterConfiguration
 	}{
 		{
-			expected: "foo.io/coredns:v1.8.0",
+			expected: "foo.io/coredns:v1.8.4",
 			cfg: &kubeadmapi.ClusterConfiguration{
 				ImageRepository: "foo.io",
 				DNS: kubeadmapi.DNS{
@@ -242,7 +242,7 @@ func TestGetDNSImage(t *testing.T) {
 			},
 		},
 		{
-			expected: kubeadmapiv1beta2.DefaultImageRepository + "/coredns/coredns:v1.8.0",
+			expected: kubeadmapiv1beta2.DefaultImageRepository + "/coredns/coredns:v1.8.4",
 			cfg: &kubeadmapi.ClusterConfiguration{
 				ImageRepository: kubeadmapiv1beta2.DefaultImageRepository,
 				DNS: kubeadmapi.DNS{
@@ -251,7 +251,7 @@ func TestGetDNSImage(t *testing.T) {
 			},
 		},
 		{
-			expected: "foo.io/coredns/coredns:v1.8.0",
+			expected: "foo.io/coredns/coredns:v1.8.4",
 			cfg: &kubeadmapi.ClusterConfiguration{
 				ImageRepository: "foo.io",
 				DNS: kubeadmapi.DNS{

--- a/cmd/kubeadm/app/phases/addons/dns/manifests.go
+++ b/cmd/kubeadm/app/phases/addons/dns/manifests.go
@@ -197,6 +197,13 @@ rules:
   - nodes
   verbs:
   - get
+- apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - list
+  - watch
 `
 	// CoreDNSClusterRoleBinding is the CoreDNS Clusterrolebinding manifest
 	CoreDNSClusterRoleBinding = `


### PR DESCRIPTION
#### What type of PR is this?
/kind feature
/kind cleanup

#### What this PR does / why we need it:

- [x] wait for promoting coredns image 1.8.4: https://github.com/kubernetes/k8s.io/pull/2118
- [x] wait for  corefile-migration release for 1.8.4.  As corefile-migration  is not released, I would update it later after https://github.com/coredns/corefile-migration/pull/60 is merged. #102830 upgraded it

#### Which issue(s) this PR fixes:
xref #99751

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
kubeadm: update CoreDNS to 1.8.4. Grant CoreDNS permissions to "list" and "watch" EndpointSlice objects to accommodate dual-stack support.
```
