### PR TITLE
Fix regression for timed-out stream cleanups

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/util/httpstream/spdy/connection.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/httpstream/spdy/connection.go
@@ -123,7 +123,10 @@ func (c *connection) Close() error {
 func (c *connection) RemoveStreams(streams ...httpstream.Stream) {
 	c.streamLock.Lock()
 	for _, stream := range streams {
-		delete(c.streams, stream.Identifier())
+		// It may be possible that the provided stream is nil if timed out.
+		if stream != nil {
+			delete(c.streams, stream.Identifier())
+		}
 	}
 	c.streamLock.Unlock()
 }

--- a/staging/src/k8s.io/apimachinery/pkg/util/httpstream/spdy/connection_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/httpstream/spdy/connection_test.go
@@ -323,6 +323,9 @@ func TestConnectionRemoveStreams(t *testing.T) {
 	// remove all existing
 	c.RemoveStreams(stream0, stream1)
 
+	// remove nil stream should not crash
+	c.RemoveStreams(nil)
+
 	if len(c.streams) != 0 {
 		t.Fatalf("should not have any streams, has %d", len(c.streams))
 	}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind regression
#### What this PR does / why we need it:
If a stream is already timed-out, then either the data or error stream
may be `nil`. This would cause a segmentation fault, which is now
covered with this patch.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes/kubernetes/issues/102480

#### Special notes for your reviewer:
Has to be backported since the original PR got backported, too. :-/
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fixed a regression that can make kubelet runtime panic for timed-out portforward streams.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
None
```
