### PR TITLE
Automated cherry pick of #98510: Ignore transient errors when gather stats

### DIFF
--- a/pkg/kubelet/dockershim/docker_stats_windows.go
+++ b/pkg/kubelet/dockershim/docker_stats_windows.go
@@ -20,6 +20,7 @@ package dockershim
 
 import (
 	"context"
+	"strings"
 	"time"
 
 	"github.com/Microsoft/hcsshim"
@@ -39,7 +40,7 @@ func (ds *dockerService) getContainerStats(containerID string) (*runtimeapi.Cont
 		// That will typically happen with init-containers in Exited state. Docker still knows about them but the HCS does not.
 		// As we don't want to block stats retrieval for other containers, we only log errors.
 		if !hcsshim.IsNotExist(err) && !hcsshim.IsAlreadyStopped(err) {
-			klog.Errorf("Error opening container (stats will be missing) '%s': %v", containerID, err)
+			klog.V(4).Infof("Error opening container (stats will be missing) '%s': %v", containerID, err)
 		}
 		return nil, nil
 	}
@@ -52,6 +53,16 @@ func (ds *dockerService) getContainerStats(containerID string) (*runtimeapi.Cont
 
 	stats, err := hcsshim_container.Statistics()
 	if err != nil {
+		if strings.Contains(err.Error(), "0x5") || strings.Contains(err.Error(), "0xc0370105") {
+			// When the container is just created, querying for stats causes access errors because it hasn't started yet
+			// This is transient; skip container for now
+			//
+			// These hcs errors do not have helpers exposed in public package so need to query for the known codes
+			// https://github.com/microsoft/hcsshim/blob/master/internal/hcs/errors.go
+			// PR to expose helpers in hcsshim: https://github.com/microsoft/hcsshim/pull/933
+			klog.V(4).Infof("Container is not in a state that stats can be accessed '%s': %v. This occurs when the container is created but not started.", containerID, err)
+			return nil, nil
+		}
 		return nil, err
 	}
 


### PR DESCRIPTION
Cherry pick of #98510 on release-1.19.

#98510: Ignore transient errors when gather stats

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.