### PR TITLE
kubeadm: use subpath for coredns only for default repository

### DIFF
--- a/cmd/kubeadm/app/constants/constants.go
+++ b/cmd/kubeadm/app/constants/constants.go
@@ -326,7 +326,7 @@ const (
 	CoreDNSDeploymentName = "coredns"
 
 	// CoreDNSImageName specifies the name of the image for CoreDNS add-on
-	CoreDNSImageName = "coredns/coredns"
+	CoreDNSImageName = "coredns"
 
 	// CoreDNSVersion is the version of CoreDNS to be deployed if it is used
 	CoreDNSVersion = "v1.8.0"

--- a/cmd/kubeadm/app/images/images.go
+++ b/cmd/kubeadm/app/images/images.go
@@ -21,6 +21,7 @@ import (
 
 	"k8s.io/klog/v2"
 	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
+	kubeadmapiv1beta2 "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1beta2"
 	"k8s.io/kubernetes/cmd/kubeadm/app/constants"
 	kubeadmutil "k8s.io/kubernetes/cmd/kubeadm/app/util"
 )
@@ -45,6 +46,10 @@ func GetDNSImage(cfg *kubeadmapi.ClusterConfiguration) string {
 	// unless an override is specified
 	if cfg.DNS.ImageRepository != "" {
 		dnsImageRepository = cfg.DNS.ImageRepository
+	}
+	// Handle the renaming of the official image from "k8s.gcr.io/coredns" to "k8s.gcr.io/coredns/coredns
+	if dnsImageRepository == kubeadmapiv1beta2.DefaultImageRepository {
+		dnsImageRepository = fmt.Sprintf("%s/coredns", dnsImageRepository)
 	}
 	// DNS uses an imageTag that corresponds to the DNS version matching the Kubernetes version
 	dnsImageTag := constants.GetDNSVersion(cfg.DNS.Type)

--- a/cmd/kubeadm/app/images/images_test.go
+++ b/cmd/kubeadm/app/images/images_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
+	kubeadmapiv1beta2 "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1beta2"
 	"k8s.io/kubernetes/cmd/kubeadm/app/constants"
 )
 
@@ -227,5 +228,54 @@ func TestGetAllImages(t *testing.T) {
 			}
 			t.Fatalf("did not find %q in %q", tc.expect, imgs)
 		})
+	}
+}
+
+func TestGetDNSImage(t *testing.T) {
+	var tests = []struct {
+		expected string
+		cfg      *kubeadmapi.ClusterConfiguration
+	}{
+		{
+			expected: "foo.io/coredns:v1.8.0",
+			cfg: &kubeadmapi.ClusterConfiguration{
+				ImageRepository: "foo.io",
+				DNS: kubeadmapi.DNS{
+					Type: kubeadmapi.CoreDNS,
+				},
+			},
+		},
+		{
+			expected: kubeadmapiv1beta2.DefaultImageRepository + "/coredns/coredns:v1.8.0",
+			cfg: &kubeadmapi.ClusterConfiguration{
+				ImageRepository: kubeadmapiv1beta2.DefaultImageRepository,
+				DNS: kubeadmapi.DNS{
+					Type: kubeadmapi.CoreDNS,
+				},
+			},
+		},
+		{
+			expected: "foo.io/coredns/coredns:v1.8.0",
+			cfg: &kubeadmapi.ClusterConfiguration{
+				ImageRepository: "foo.io",
+				DNS: kubeadmapi.DNS{
+					Type: kubeadmapi.CoreDNS,
+					ImageMeta: kubeadmapi.ImageMeta{
+						ImageRepository: "foo.io/coredns",
+					},
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		actual := GetDNSImage(test.cfg)
+		if actual != test.expected {
+			t.Errorf(
+				"failed to GetDNSImage:\n\texpected: %s\n\t actual: %s",
+				test.expected,
+				actual,
+			)
+		}
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
/kind regression
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This PR changes the default coredns image name back to `coredns` from `coredns/coredns`. In kubeadm if the registry used is the default registry, change dns image registry to `<default-registry>/coredns`.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:
This PR is a breaking change to users that now have clusterconfiguration.dns.imageRepository to workaround the original "coredns/coredns" change.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fixes a regression in 1.21: ACTION REQUIRED: kubeadm: when using a custom image repository for CoreDNS kubeadm now will append the "coredns"  image name instead of  "coredns/coredns", thus restoring the behaviour existing before the v1.21 release. Users who rely on nested folder for the coredns image should set the "clusterConfiguration.dns.imageRepository" value including the nested path name (e.g using "registry.company.xyz/coredns" will force kubeadm to use "registry.company.xyz/coredns/coredns" image). No action is needed if using the default registry (k8s.gcr.io).
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
