### PR TITLE
kubectl: update set command description to include cronjob resource

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/set/set_env.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/set/set_env.go
@@ -45,7 +45,7 @@ import (
 var (
 	validEnvNameRegexp = regexp.MustCompile("[^a-zA-Z0-9_]")
 	envResources       = `
-  	pod (po), replicationcontroller (rc), deployment (deploy), daemonset (ds), statefulset (sts), job, cronjob (cj), replicaset (rs)`
+  	pod (po), replicationcontroller (rc), deployment (deploy), daemonset (ds), statefulset (sts), cronjob (cj), replicaset (rs)`
 
 	envLong = templates.LongDesc(i18n.T(`
 		Update environment variables on a pod template.

--- a/staging/src/k8s.io/kubectl/pkg/cmd/set/set_env.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/set/set_env.go
@@ -45,7 +45,7 @@ import (
 var (
 	validEnvNameRegexp = regexp.MustCompile("[^a-zA-Z0-9_]")
 	envResources       = `
-  	pod (po), replicationcontroller (rc), deployment (deploy), daemonset (ds), job, replicaset (rs)`
+  	pod (po), replicationcontroller (rc), deployment (deploy), daemonset (ds), job, cronjob (cj), replicaset (rs)`
 
 	envLong = templates.LongDesc(i18n.T(`
 		Update environment variables on a pod template.

--- a/staging/src/k8s.io/kubectl/pkg/cmd/set/set_env.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/set/set_env.go
@@ -45,7 +45,7 @@ import (
 var (
 	validEnvNameRegexp = regexp.MustCompile("[^a-zA-Z0-9_]")
 	envResources       = `
-  	pod (po), replicationcontroller (rc), deployment (deploy), daemonset (ds), job, cronjob (cj), replicaset (rs)`
+  	pod (po), replicationcontroller (rc), deployment (deploy), daemonset (ds), statefulset (sts), job, cronjob (cj), replicaset (rs)`
 
 	envLong = templates.LongDesc(i18n.T(`
 		Update environment variables on a pod template.

--- a/staging/src/k8s.io/kubectl/pkg/cmd/set/set_env_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/set/set_env_test.go
@@ -439,8 +439,8 @@ func TestSetEnvRemote(t *testing.T) {
 			object: &batchv1.CronJob{
 				ObjectMeta: metav1.ObjectMeta{Name: "nginx"},
 				Spec: batchv1.CronJobSpec{
-					JobTemplate: batchv1.JobTemplateSpec {
-						Spec: batchv1.JobSpec {
+					JobTemplate: batchv1.JobTemplateSpec{
+						Spec: batchv1.JobSpec{
 							Template: corev1.PodTemplateSpec{
 								Spec: corev1.PodSpec{
 									Containers: []corev1.Container{

--- a/staging/src/k8s.io/kubectl/pkg/cmd/set/set_env_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/set/set_env_test.go
@@ -435,16 +435,20 @@ func TestSetEnvRemote(t *testing.T) {
 			args:         []string{"statefulset", "nginx", "env=prod"},
 		},
 		{
-			name: "test batchv1 Job",
-			object: &batchv1.Job{
+			name: "set image batchv1 CronJob",
+			object: &batchv1.CronJob{
 				ObjectMeta: metav1.ObjectMeta{Name: "nginx"},
-				Spec: batchv1.JobSpec{
-					Template: corev1.PodTemplateSpec{
-						Spec: corev1.PodSpec{
-							Containers: []corev1.Container{
-								{
-									Name:  "nginx",
-									Image: "nginx",
+				Spec: batchv1.CronJobSpec{
+					JobTemplate: batchv1.JobTemplateSpec {
+						Spec: batchv1.JobSpec {
+							Template: corev1.PodTemplateSpec{
+								Spec: corev1.PodSpec{
+									Containers: []corev1.Container{
+										{
+											Name:  "nginx",
+											Image: "nginx",
+										},
+									},
 								},
 							},
 						},
@@ -452,8 +456,8 @@ func TestSetEnvRemote(t *testing.T) {
 				},
 			},
 			groupVersion: batchv1.SchemeGroupVersion,
-			path:         "/namespaces/test/jobs/nginx",
-			args:         []string{"job", "nginx", "env=prod"},
+			path:         "/namespaces/test/cronjobs/nginx",
+			args:         []string{"cronjob", "nginx", "env=prod"},
 		},
 		{
 			name: "test corev1 replication controller",

--- a/staging/src/k8s.io/kubectl/pkg/cmd/set/set_image.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/set/set_image.go
@@ -66,7 +66,7 @@ type SetImageOptions struct {
 
 var (
 	imageResources = i18n.T(`
-  	pod (po), replicationcontroller (rc), deployment (deploy), daemonset (ds), replicaset (rs)`)
+  	pod (po), replicationcontroller (rc), deployment (deploy), daemonset (ds), cronjob (cj), replicaset (rs)`)
 
 	imageLong = templates.LongDesc(i18n.T(`
 		Update existing container image(s) of resources.

--- a/staging/src/k8s.io/kubectl/pkg/cmd/set/set_image.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/set/set_image.go
@@ -66,7 +66,7 @@ type SetImageOptions struct {
 
 var (
 	imageResources = i18n.T(`
-  	pod (po), replicationcontroller (rc), deployment (deploy), daemonset (ds), cronjob (cj), replicaset (rs)`)
+  	pod (po), replicationcontroller (rc), deployment (deploy), daemonset (ds), statefulset (sts), cronjob (cj), replicaset (rs)`)
 
 	imageLong = templates.LongDesc(i18n.T(`
 		Update existing container image(s) of resources.

--- a/staging/src/k8s.io/kubectl/pkg/cmd/set/set_image_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/set/set_image_test.go
@@ -563,8 +563,8 @@ func TestSetImageRemote(t *testing.T) {
 			object: &batchv1.CronJob{
 				ObjectMeta: metav1.ObjectMeta{Name: "nginx"},
 				Spec: batchv1.CronJobSpec{
-					JobTemplate: batchv1.JobTemplateSpec {
-						Spec: batchv1.JobSpec {
+					JobTemplate: batchv1.JobTemplateSpec{
+						Spec: batchv1.JobSpec{
 							Template: corev1.PodTemplateSpec{
 								Spec: corev1.PodSpec{
 									Containers: []corev1.Container{

--- a/staging/src/k8s.io/kubectl/pkg/cmd/set/set_image_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/set/set_image_test.go
@@ -559,22 +559,26 @@ func TestSetImageRemote(t *testing.T) {
 			args:         []string{"statefulset", "nginx", "*=thingy"},
 		},
 		{
-			name: "set image batchv1 Job",
-			object: &batchv1.Job{
+			name: "set image batchv1 CronJob",
+			object: &batchv1.CronJob{
 				ObjectMeta: metav1.ObjectMeta{Name: "nginx"},
-				Spec: batchv1.JobSpec{
-					Template: corev1.PodTemplateSpec{
-						Spec: corev1.PodSpec{
-							Containers: []corev1.Container{
-								{
-									Name:  "nginx",
-									Image: "nginx",
-								},
-							},
-							InitContainers: []corev1.Container{
-								{
-									Name:  "busybox",
-									Image: "busybox",
+				Spec: batchv1.CronJobSpec{
+					JobTemplate: batchv1.JobTemplateSpec {
+						Spec: batchv1.JobSpec {
+							Template: corev1.PodTemplateSpec{
+								Spec: corev1.PodSpec{
+									Containers: []corev1.Container{
+										{
+											Name:  "nginx",
+											Image: "nginx",
+										},
+									},
+									InitContainers: []corev1.Container{
+										{
+											Name:  "busybox",
+											Image: "busybox",
+										},
+									},
 								},
 							},
 						},
@@ -582,8 +586,8 @@ func TestSetImageRemote(t *testing.T) {
 				},
 			},
 			groupVersion: batchv1.SchemeGroupVersion,
-			path:         "/namespaces/test/jobs/nginx",
-			args:         []string{"job", "nginx", "*=thingy"},
+			path:         "/namespaces/test/cronjobs/nginx",
+			args:         []string{"cronjob", "nginx", "*=thingy"},
 		},
 		{
 			name: "set image corev1.ReplicationController",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind documentation
/kind cleanup


#### What this PR does / why we need it:
1. Updated set command description.
- Since kubectl set env/image support cronjob and statefulset, update the command description to include cronjob resource.
  - Related PR: https://github.com/kubernetes/kubernetes/pull/57742
  - Related code (set_env_test): https://github.com/kubernetes/kubernetes/blob/52eea971c57580c6b1b74f0a12bf9cc6083a4d6b/staging/src/k8s.io/kubectl/pkg/cmd/set/set_env_test.go#L375-L436
  - Related code (set_image_test): https://github.com/kubernetes/kubernetes/blob/52eea971c57580c6b1b74f0a12bf9cc6083a4d6b/staging/src/k8s.io/kubectl/pkg/cmd/set/set_image_test.go#L480-L587
 2. Similar to `set image`, remove job resource from `set env` command.
   - Related issue: https://github.com/kubernetes/kubernetes/issues/48388
   - Related PR: https://github.com/kubernetes/kubernetes/pull/52164
 3. Update set image/env test accordingly (remove job from tests and add cronjob)

#### Special notes for your reviewer:
This PR was initially re-visiting this PR: https://github.com/kubernetes/kubernetes/pull/57957, which is closed by the author's inactivity.
With [this feedback](https://github.com/kubernetes/kubernetes/pull/102503#pullrequestreview-674544124), I added more updates to make descriptions more accurate.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```