### PR TITLE
Automated cherry pick of #102502: use subpath for coredns only for default repository

### DIFF
--- a/cmd/kubeadm/app/constants/constants.go
+++ b/cmd/kubeadm/app/constants/constants.go
@@ -328,7 +328,7 @@ const (
 	CoreDNSDeploymentName = "coredns"
 
 	// CoreDNSImageName specifies the name of the image for CoreDNS add-on
-	CoreDNSImageName = "coredns/coredns"
+	CoreDNSImageName = "coredns"
 
 	// CoreDNSVersion is the version of CoreDNS to be deployed if it is used
 	CoreDNSVersion = "v1.8.0"

--- a/cmd/kubeadm/app/images/images.go
+++ b/cmd/kubeadm/app/images/images.go
@@ -21,6 +21,7 @@ import (
 
 	"k8s.io/klog/v2"
 	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
+	kubeadmapiv1beta2 "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1beta2"
 	"k8s.io/kubernetes/cmd/kubeadm/app/constants"
 	kubeadmutil "k8s.io/kubernetes/cmd/kubeadm/app/util"
 )
@@ -51,6 +52,10 @@ func GetDNSImage(cfg *kubeadmapi.ClusterConfiguration) string {
 	// unless an override is specified
 	if cfg.DNS.ImageRepository != "" {
 		dnsImageRepository = cfg.DNS.ImageRepository
+	}
+	// Handle the renaming of the official image from "k8s.gcr.io/coredns" to "k8s.gcr.io/coredns/coredns
+	if dnsImageRepository == kubeadmapiv1beta2.DefaultImageRepository {
+		dnsImageRepository = fmt.Sprintf("%s/coredns", dnsImageRepository)
 	}
 	// DNS uses an imageTag that corresponds to the DNS version matching the Kubernetes version
 	dnsImageTag := constants.GetDNSVersion(cfg.DNS.Type)

--- a/cmd/kubeadm/app/images/images_test.go
+++ b/cmd/kubeadm/app/images/images_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
+	kubeadmapiv1beta2 "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1beta2"
 	"k8s.io/kubernetes/cmd/kubeadm/app/constants"
 )
 
@@ -235,5 +236,54 @@ func TestGetAllImages(t *testing.T) {
 			}
 			t.Fatalf("did not find %q in %q", tc.expect, imgs)
 		})
+	}
+}
+
+func TestGetDNSImage(t *testing.T) {
+	var tests = []struct {
+		expected string
+		cfg      *kubeadmapi.ClusterConfiguration
+	}{
+		{
+			expected: "foo.io/coredns:v1.8.0",
+			cfg: &kubeadmapi.ClusterConfiguration{
+				ImageRepository: "foo.io",
+				DNS: kubeadmapi.DNS{
+					Type: kubeadmapi.CoreDNS,
+				},
+			},
+		},
+		{
+			expected: kubeadmapiv1beta2.DefaultImageRepository + "/coredns/coredns:v1.8.0",
+			cfg: &kubeadmapi.ClusterConfiguration{
+				ImageRepository: kubeadmapiv1beta2.DefaultImageRepository,
+				DNS: kubeadmapi.DNS{
+					Type: kubeadmapi.CoreDNS,
+				},
+			},
+		},
+		{
+			expected: "foo.io/coredns/coredns:v1.8.0",
+			cfg: &kubeadmapi.ClusterConfiguration{
+				ImageRepository: "foo.io",
+				DNS: kubeadmapi.DNS{
+					Type: kubeadmapi.CoreDNS,
+					ImageMeta: kubeadmapi.ImageMeta{
+						ImageRepository: "foo.io/coredns",
+					},
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		actual := GetDNSImage(test.cfg)
+		if actual != test.expected {
+			t.Errorf(
+				"failed to GetDNSImage:\n\texpected: %s\n\t actual: %s",
+				test.expected,
+				actual,
+			)
+		}
 	}
 }


### PR DESCRIPTION
Cherry pick of #102502 on release-1.21.

#102502: use subpath for coredns only for default repository

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
Fixes a regression in 1.21: ACTION REQUIRED: kubeadm: when using a custom image repository for CoreDNS kubeadm now will append the "coredns"  image name instead of  "coredns/coredns", thus restoring the behaviour existing before the v1.21 release. Users who rely on nested folder for the coredns image should set the "clusterConfiguration.dns.imageRepository" value including the nested path name (e.g using "registry.company.xyz/coredns" will force kubeadm to use "registry.company.xyz/coredns/coredns" image). No action is needed if using the default registry (k8s.gcr.io).
```