### PR TITLE
Add feature gate to disable in-tree credential providers

### DIFF
--- a/pkg/credentialprovider/aws/aws_credentials.go
+++ b/pkg/credentialprovider/aws/aws_credentials.go
@@ -159,9 +159,17 @@ func (p *ecrProvider) Provide(image string) credentialprovider.DockerConfig {
 	// (see https://github.com/kubernetes/kubernetes/issues/92162)
 	once.Do(func() {
 		isEC2 = p.isEC2()
+
+		if isEC2 && credentialprovider.AreLegacyCloudCredentialProvidersDisabled() {
+			klog.V(4).Infof("AWS credential provider is now disabled. Please refer to sig-cloud-provider for guidance on external credential provider integration for AWS")
+		}
 	})
 
 	if !isEC2 {
+		return credentialprovider.DockerConfig{}
+	}
+
+	if credentialprovider.AreLegacyCloudCredentialProvidersDisabled() {
 		return credentialprovider.DockerConfig{}
 	}
 

--- a/pkg/credentialprovider/azure/azure_credentials.go
+++ b/pkg/credentialprovider/azure/azure_credentials.go
@@ -26,6 +26,7 @@ import (
 	"os"
 	"regexp"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/services/containerregistry/mgmt/2019-05-01/containerregistry"
@@ -52,6 +53,7 @@ const (
 var (
 	containerRegistryUrls = []string{"*.azurecr.io", "*.azurecr.cn", "*.azurecr.de", "*.azurecr.us"}
 	acrRE                 = regexp.MustCompile(`.*\.azurecr\.io|.*\.azurecr\.cn|.*\.azurecr\.de|.*\.azurecr\.us`)
+	warnOnce              sync.Once
 )
 
 // init registers the various means by which credentials may
@@ -183,6 +185,13 @@ func (a *acrProvider) Enabled() bool {
 		return false
 	}
 
+	if credentialprovider.AreLegacyCloudCredentialProvidersDisabled() {
+		warnOnce.Do(func() {
+			klog.V(4).Infof("Azure credential provider is now disabled. Please refer to sig-cloud-provider for guidance on external credential provider integration for Azure")
+		})
+		return false
+	}
+
 	f, err := os.Open(*a.file)
 	if err != nil {
 		klog.Errorf("Failed to load config from file: %s", *a.file)
@@ -203,6 +212,7 @@ func (a *acrProvider) Enabled() bool {
 	}
 
 	a.registryClient = newAzRegistriesClient(a.config.SubscriptionID, a.environment.ResourceManagerEndpoint, a.servicePrincipalToken)
+
 	return true
 }
 

--- a/pkg/credentialprovider/plugins.go
+++ b/pkg/credentialprovider/plugins.go
@@ -21,7 +21,9 @@ import (
 	"sort"
 	"sync"
 
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/klog/v2"
+	"k8s.io/kubernetes/pkg/features"
 )
 
 // All registered credential providers.
@@ -42,6 +44,12 @@ func RegisterCredentialProvider(name string, provider DockerConfigProvider) {
 	}
 	klog.V(4).Infof("Registered credential provider %q", name)
 	providers[name] = provider
+}
+
+// AreLegacyCloudCredentialProvidersDisabled checks if the legacy in-tree cloud
+// credential providers have been disabled.
+func AreLegacyCloudCredentialProvidersDisabled() bool {
+	return utilfeature.DefaultFeatureGate.Enabled(features.DisableKubeletCloudCredentialProviders)
 }
 
 // NewDockerKeyring creates a DockerKeyring to use for resolving credentials,

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -595,6 +595,12 @@ const (
 	// Disable any functionality in kube-apiserver, kube-controller-manager and kubelet related to the `--cloud-provider` component flag.
 	DisableCloudProviders featuregate.Feature = "DisableCloudProviders"
 
+	// owner: @andrewsykim
+	// alpha: v1.22
+	//
+	// Disable in-tree functionality in kubelet to authenticate to cloud provider container registries for image pull credentials.
+	DisableKubeletCloudCredentialProviders featuregate.Feature = "DisableKubeletCloudCredentialProviders"
+
 	// owner: @zshihang
 	// alpha: v1.20
 	// beta: v1.21
@@ -895,6 +901,7 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
 	CSIVolumeHealth:                                {Default: false, PreRelease: featuregate.Alpha},
 	WindowsHostProcessContainers:                   {Default: false, PreRelease: featuregate.Alpha},
 	DisableCloudProviders:                          {Default: false, PreRelease: featuregate.Alpha},
+	DisableKubeletCloudCredentialProviders:         {Default: false, PreRelease: featuregate.Alpha},
 	StatefulSetMinReadySeconds:                     {Default: false, PreRelease: featuregate.Alpha},
 	ExpandedDNSConfig:                              {Default: false, PreRelease: featuregate.Alpha},
 	SeccompDefault:                                 {Default: false, PreRelease: featuregate.Alpha},


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Implementing DisableKubeletCloudCredentialProviders FG according to proposal kubernetes/enhancements#2443

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Introduce a feature gate DisableKubeletCloudCredentialProviders which allows disabling the in-tree kubelet credential providers.

The DisableKubeletCloudCredentialProviders FeatureGate is currently in Alpha, which means is currently disabled by default. Once the FeatureGate moves to beta, in-tree credential providers will be disabled by default, and users will need to migrate to using external credential providers.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
- [KEP]: https://github.com/kubernetes/enhancements/pull/2443
- [KEP]: https://github.com/kubernetes/enhancements/tree/1a66671cf0e01ceb19f56bfb563100909cb67867/keps/sig-cloud-provider/2133-out-of-tree-credential-provider
```
