### PR TITLE
Clarify and split up the "not actually SCTP" SCTP NetworkPolicy test

### DIFF
--- a/test/e2e/network/netpol/network_legacy.go
+++ b/test/e2e/network/netpol/network_legacy.go
@@ -1682,7 +1682,7 @@ var _ = common.SIGDescribe("NetworkPolicy [LinuxOnly]", func() {
 			})
 			cleanupServerPodAndService(f, podA, serviceA)
 		})
-		ginkgo.It("should not allow access by TCP when a policy specifies only SCTP [Feature:NetworkPolicy] [Feature:SCTP]", func() {
+		ginkgo.It("should not allow access by TCP when a policy specifies only SCTP [Feature:NetworkPolicy]", func() {
 			ginkgo.By("getting the state of the sctp module on nodes")
 			nodes, err := e2enode.GetReadySchedulableNodes(f.ClientSet)
 			framework.ExpectNoError(err)

--- a/test/e2e/network/netpol/network_policy.go
+++ b/test/e2e/network/netpol/network_policy.go
@@ -1059,16 +1059,40 @@ var _ = common.SIGDescribe("Netpol", func() {
 			ValidateOrFail(k8s, model, &TestCase{ToPort: 80, Protocol: v1.ProtocolTCP, Reachability: denyIngressToXReachability})
 		})
 
-		ginkgo.It("should not allow access by TCP when a policy specifies only SCTP [Feature:NetworkPolicy]", func() {
-			ingressRule := networkingv1.NetworkPolicyIngressRule{}
-			ingressRule.Ports = append(ingressRule.Ports, networkingv1.NetworkPolicyPort{Port: &intstr.IntOrString{IntVal: 81}, Protocol: &protocolSCTP})
-			policy := GenNetworkPolicyWithNameAndPodMatchLabel("allow-only-sctp-ingress-on-port-81", map[string]string{"pod": "a"}, SetSpecIngressRules(ingressRule))
+		// This test *does* apply to plugins that do not implement SCTP. It is a
+		// security hole if you fail this test, because you are allowing TCP
+		// traffic that is supposed to be blocked.
+		ginkgo.It("should not mistakenly treat 'protocol: SCTP' as 'protocol: TCP', even if the plugin doesn't support SCTP [Feature:NetworkPolicy]", func() {
 			nsX, _, _, model, k8s := getK8SModel(f)
+
+			ginkgo.By("Creating a default-deny ingress policy.")
+			policy := GenNetworkPolicyWithNameAndPodSelector("deny-ingress", metav1.LabelSelector{}, SetSpecIngressRules())
 			CreatePolicy(k8s, policy, nsX)
 
 			ginkgo.By("Creating a network policy for the server which allows traffic only via SCTP on port 81.")
+			ingressRule := networkingv1.NetworkPolicyIngressRule{}
+			ingressRule.Ports = append(ingressRule.Ports, networkingv1.NetworkPolicyPort{Port: &intstr.IntOrString{IntVal: 81}, Protocol: &protocolSCTP})
+			policy = GenNetworkPolicyWithNameAndPodMatchLabel("allow-only-sctp-ingress-on-port-81", map[string]string{"pod": "a"}, SetSpecIngressRules(ingressRule))
+			CreatePolicy(k8s, policy, nsX)
 
-			// Probing with TCP, so all traffic should be dropped.
+			ginkgo.By("Trying to connect to TCP port 81, which should be blocked by the deny-ingress policy.")
+			reachability := NewReachability(model.AllPods(), true)
+			reachability.ExpectAllIngress(NewPodString(nsX, "a"), false)
+			ValidateOrFail(k8s, model, &TestCase{ToPort: 81, Protocol: v1.ProtocolTCP, Reachability: reachability})
+		})
+
+		// This test *does* apply to plugins that do not implement SCTP. It is a
+		// security hole if you fail this test, because you are allowing TCP
+		// traffic that is supposed to be blocked.
+		ginkgo.It("should properly isolate pods that are selected by a policy allowing SCTP, even if the plugin doesn't support SCTP [Feature:NetworkPolicy]", func() {
+			ginkgo.By("Creating a network policy for the server which allows traffic only via SCTP on port 80.")
+			ingressRule := networkingv1.NetworkPolicyIngressRule{}
+			ingressRule.Ports = append(ingressRule.Ports, networkingv1.NetworkPolicyPort{Port: &intstr.IntOrString{IntVal: 80}, Protocol: &protocolSCTP})
+			policy := GenNetworkPolicyWithNameAndPodMatchLabel("allow-only-sctp-ingress-on-port-80", map[string]string{"pod": "a"}, SetSpecIngressRules(ingressRule))
+			nsX, _, _, model, k8s := getK8SModel(f)
+			CreatePolicy(k8s, policy, nsX)
+
+			ginkgo.By("Trying to connect to TCP port 81, which should be blocked by implicit isolation.")
 			reachability := NewReachability(model.AllPods(), true)
 			reachability.ExpectAllIngress(NewPodString(nsX, "a"), false)
 			ValidateOrFail(k8s, model, &TestCase{ToPort: 81, Protocol: v1.ProtocolTCP, Reachability: reachability})

--- a/test/e2e/network/netpol/network_policy.go
+++ b/test/e2e/network/netpol/network_policy.go
@@ -1059,7 +1059,7 @@ var _ = common.SIGDescribe("Netpol", func() {
 			ValidateOrFail(k8s, model, &TestCase{ToPort: 80, Protocol: v1.ProtocolTCP, Reachability: denyIngressToXReachability})
 		})
 
-		ginkgo.It("should not allow access by TCP when a policy specifies only SCTP [Feature:NetworkPolicy] [Feature:SCTP]", func() {
+		ginkgo.It("should not allow access by TCP when a policy specifies only SCTP [Feature:NetworkPolicy]", func() {
 			ingressRule := networkingv1.NetworkPolicyIngressRule{}
 			ingressRule.Ports = append(ingressRule.Ports, networkingv1.NetworkPolicyPort{Port: &intstr.IntOrString{IntVal: 81}, Protocol: &protocolSCTP})
 			policy := GenNetworkPolicyWithNameAndPodMatchLabel("allow-only-sctp-ingress-on-port-81", map[string]string{"pod": "a"}, SetSpecIngressRules(ingressRule))
@@ -1074,7 +1074,7 @@ var _ = common.SIGDescribe("Netpol", func() {
 			ValidateOrFail(k8s, model, &TestCase{ToPort: 81, Protocol: v1.ProtocolTCP, Reachability: reachability})
 		})
 
-		ginkgo.It("should not allow access by TCP when a policy specifies only UDP [Feature:NetworkPolicy] [Feature:UDP]", func() {
+		ginkgo.It("should not allow access by TCP when a policy specifies only UDP [Feature:NetworkPolicy]", func() {
 			ingressRule := networkingv1.NetworkPolicyIngressRule{}
 			ingressRule.Ports = append(ingressRule.Ports, networkingv1.NetworkPolicyPort{Port: &intstr.IntOrString{IntVal: 81}, Protocol: &protocolUDP})
 			policy := GenNetworkPolicyWithNameAndPodMatchLabel("allow-only-udp-ingress-on-port-81", map[string]string{"pod": "a"}, SetSpecIngressRules(ingressRule))
@@ -1091,7 +1091,7 @@ var _ = common.SIGDescribe("Netpol", func() {
 	})
 })
 
-var _ = common.SIGDescribe("Netpol [Feature:UDPConnectivity][LinuxOnly]", func() {
+var _ = common.SIGDescribe("Netpol [LinuxOnly]", func() {
 	f := framework.NewDefaultFramework("udp-network-policy")
 
 	ginkgo.BeforeEach(func() {


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
The e2e suite has a test to make sure that plugins that don't implement SCTP nonetheless still behave in a sane way in the presence of NetworkPolices that mention SCTP. Unfortunately, people keep misunderstanding the point of the test and assuming that they can ignore it because they don't implement SCTP. (This has come up twice now with vendors certifying network plugins against OpenShift.)

Additionally, the existing test ("`should not allow access by TCP when a policy specifies only SCTP`") could fail for two different reasons, so I've now split it into two separate tests, with hopefully clearer descriptions:

* "`should not mistakenly treat 'protocol: SCTP' as 'protocol: TCP', even if the plugin doesn't support SCTP`"
  This tests that given a "deny all" policy and an "allow to SCTP port 81" policy, that the plugin does not allow traffic to *TCP* port 81. This is because some people seem to have implemented the "the default value for `protocol` is `TCP`" rule themselves, incorrectly, and end up treating everything that isn't `UDP` as `TCP`.
* "`should properly isolate pods that are selected by a policy allowing SCTP, even if the plugin doesn't support SCTP`"
  This tests that given _just_ an "allow to SCTP port 80" policy, that the plugin does not allow traffic to TCP port 81. That is, it tests that plugins still implement the "any pod selected by a NetworkPolicy is isolated" rule, even when the pod is selected by a NetworkPolicy they don't know how to implement.

I have three arguments for the latter test (beyond "this has always been part of the e2e suite so you always should have been passing this"):

1. NetworkPolicy is a security mechanism, so if you can't implement a policy _correctly_, then the user will probably be happier if you do something too restrictive than if you do something too permissive.
2. Except, you _can_ implement the policy correctly; if your plugin doesn't allow SCTP traffic between pods anyway, then you can implement a policy that says "don't allow anything except SCTP port 80" by just not allowing anything.
3. Based on NetworkPolicy semantics, users can expect that, eg, this pair of policies:

        kind: NetworkPolicy
        metadata:
          name: policy-tcp
        spec:
          ingress:
            - ports:
                - protocol: TCP
                  port: 80
        
        kind: NetworkPolicy
        metadata:
          name: policy-sctp
        spec:
          ingress:
            - ports:
                - protocol: SCTP
                  port: 80

    could correctly be squashed into a single policy:

        kind: NetworkPolicy
        metadata:
          name: policy-combined
        spec:
          ingress:
            - ports:
                - protocol: TCP
                  port: 80
            - ports:
                - protocol: SCTP
                  port: 80

    Any plugin that does not allow and deny exactly the same traffic given the combined policy as it would given the two separate policies is behaving inconsistently with the definition of NetworkPolicy.

#### Which issue(s) this PR fixes:
None

#### Does this PR introduce a user-facing change?
```release-note
Clarified the description of a test in the e2e suite that mentions "SCTP" but is
actually intended to be testing the behavior of network plugins that *don't*
implement SCTP.
```

/sig network
/priority important-longterm
