### PR TITLE
Default GCE testing to using konnectivity

### DIFF
--- a/cluster/gce/config-test.sh
+++ b/cluster/gce/config-test.sh
@@ -42,6 +42,9 @@ NODE_LOCAL_SSDS=${NODE_LOCAL_SSDS:-0}
 NODE_LABELS=${KUBE_NODE_LABELS:-}
 WINDOWS_NODE_LABELS=${WINDOWS_NODE_LABELS:-}
 NODE_LOCAL_SSDS_EPHEMERAL=${NODE_LOCAL_SSDS_EPHEMERAL:-}
+# Turning GRPC based Konnectivity testing on id advance of
+# removing the SSHTunnel code.
+export KUBE_ENABLE_EGRESS_VIA_KONNECTIVITY_SERVICE=true
 
 # KUBE_CREATE_NODES can be used to avoid creating nodes, while master will be sized for NUM_NODES nodes.
 # Firewalls and node templates are still created.


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
Turning GRPC based Konnectivity testing on id advance of
removing the SSHTunnel code.
https://testgrid.k8s.io/sig-api-machinery-network-proxy#ci-kubernetes-e2e-gci-gce-network-proxy-grpc&width=25
shows the feature to be stable and it should remain that way.


#### Which issue(s) this PR fixes:
Fixes #

#### Special notes for your reviewer:
Desirable to get this in before #102297 lands.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs
NONE
```
