### PR TITLE
Cleanup redundant failure reason in InterPodAffinity plugin

### DIFF
--- a/pkg/scheduler/framework/plugins/defaultpreemption/default_preemption_test.go
+++ b/pkg/scheduler/framework/plugins/defaultpreemption/default_preemption_test.go
@@ -1344,27 +1344,19 @@ func TestNodesWherePreemptionMightHelp(t *testing.T) {
 			expected: sets.NewString(),
 		},
 		{
-			name: "ErrReasonAffinityNotMatch should be tried as it indicates that the pod is unschedulable due to inter-pod affinity or anti-affinity",
+			name: "ErrReasonAntiAffinityRulesNotMatch should be tried as it indicates that the pod is unschedulable due to inter-pod anti-affinity",
 			nodesStatuses: framework.NodeToStatusMap{
-				"node1": framework.NewStatus(framework.Unschedulable, interpodaffinity.ErrReasonAffinityNotMatch),
+				"node1": framework.NewStatus(framework.Unschedulable, interpodaffinity.ErrReasonAntiAffinityRulesNotMatch),
 				"node2": framework.NewStatus(framework.UnschedulableAndUnresolvable, nodename.ErrReason),
 				"node3": framework.NewStatus(framework.UnschedulableAndUnresolvable, nodeunschedulable.ErrReasonUnschedulable),
 			},
 			expected: sets.NewString("node1", "node4"),
 		},
 		{
-			name: "pod with both pod affinity and anti-affinity should be tried",
-			nodesStatuses: framework.NodeToStatusMap{
-				"node1": framework.NewStatus(framework.Unschedulable, interpodaffinity.ErrReasonAffinityNotMatch),
-				"node2": framework.NewStatus(framework.UnschedulableAndUnresolvable, nodename.ErrReason),
-			},
-			expected: sets.NewString("node1", "node3", "node4"),
-		},
-		{
-			name: "ErrReasonAffinityRulesNotMatch should not be tried as it indicates that the pod is unschedulable due to inter-pod affinity, but ErrReasonAffinityNotMatch should be tried as it indicates that the pod is unschedulable due to inter-pod affinity or anti-affinity",
+			name: "ErrReasonAffinityRulesNotMatch should not be tried as it indicates that the pod is unschedulable due to inter-pod affinity, but ErrReasonAntiAffinityRulesNotMatch should be tried as it indicates that the pod is unschedulable due to inter-pod anti-affinity",
 			nodesStatuses: framework.NodeToStatusMap{
 				"node1": framework.NewStatus(framework.UnschedulableAndUnresolvable, interpodaffinity.ErrReasonAffinityRulesNotMatch),
-				"node2": framework.NewStatus(framework.Unschedulable, interpodaffinity.ErrReasonAffinityNotMatch),
+				"node2": framework.NewStatus(framework.Unschedulable, interpodaffinity.ErrReasonAntiAffinityRulesNotMatch),
 			},
 			expected: sets.NewString("node2", "node3", "node4"),
 		},

--- a/pkg/scheduler/framework/plugins/interpodaffinity/filtering.go
+++ b/pkg/scheduler/framework/plugins/interpodaffinity/filtering.go
@@ -21,7 +21,7 @@ import (
 	"fmt"
 	"sync/atomic"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/pkg/scheduler/framework"
@@ -34,8 +34,6 @@ const (
 
 	// ErrReasonExistingAntiAffinityRulesNotMatch is used for ExistingPodsAntiAffinityRulesNotMatch predicate error.
 	ErrReasonExistingAntiAffinityRulesNotMatch = "node(s) didn't satisfy existing pods anti-affinity rules"
-	// ErrReasonAffinityNotMatch is used for MatchInterPodAffinity predicate error.
-	ErrReasonAffinityNotMatch = "node(s) didn't match pod affinity/anti-affinity rules"
 	// ErrReasonAffinityRulesNotMatch is used for PodAffinityRulesNotMatch predicate error.
 	ErrReasonAffinityRulesNotMatch = "node(s) didn't match pod affinity rules"
 	// ErrReasonAntiAffinityRulesNotMatch is used for PodAntiAffinityRulesNotMatch predicate error.
@@ -384,15 +382,15 @@ func (pl *InterPodAffinity) Filter(ctx context.Context, cycleState *framework.Cy
 	}
 
 	if !satisfyPodAffinity(state, nodeInfo) {
-		return framework.NewStatus(framework.UnschedulableAndUnresolvable, ErrReasonAffinityNotMatch, ErrReasonAffinityRulesNotMatch)
+		return framework.NewStatus(framework.UnschedulableAndUnresolvable, ErrReasonAffinityRulesNotMatch)
 	}
 
 	if !satisfyPodAntiAffinity(state, nodeInfo) {
-		return framework.NewStatus(framework.Unschedulable, ErrReasonAffinityNotMatch, ErrReasonAntiAffinityRulesNotMatch)
+		return framework.NewStatus(framework.Unschedulable, ErrReasonAntiAffinityRulesNotMatch)
 	}
 
 	if !satisfyExistingPodsAntiAffinity(state, nodeInfo) {
-		return framework.NewStatus(framework.Unschedulable, ErrReasonAffinityNotMatch, ErrReasonExistingAntiAffinityRulesNotMatch)
+		return framework.NewStatus(framework.Unschedulable, ErrReasonExistingAntiAffinityRulesNotMatch)
 	}
 
 	return nil

--- a/pkg/scheduler/framework/plugins/interpodaffinity/filtering_test.go
+++ b/pkg/scheduler/framework/plugins/interpodaffinity/filtering_test.go
@@ -23,7 +23,7 @@ import (
 	"strings"
 	"testing"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/kubernetes/pkg/scheduler/apis/config"
@@ -140,7 +140,6 @@ func TestRequiredAffinitySingleNode(t *testing.T) {
 			node: &node1,
 			wantStatus: framework.NewStatus(
 				framework.UnschedulableAndUnresolvable,
-				ErrReasonAffinityNotMatch,
 				ErrReasonAffinityRulesNotMatch,
 			),
 		},
@@ -164,7 +163,6 @@ func TestRequiredAffinitySingleNode(t *testing.T) {
 			node: &node1,
 			wantStatus: framework.NewStatus(
 				framework.UnschedulableAndUnresolvable,
-				ErrReasonAffinityNotMatch,
 				ErrReasonAffinityRulesNotMatch,
 			),
 		},
@@ -243,7 +241,6 @@ func TestRequiredAffinitySingleNode(t *testing.T) {
 			node: &node1,
 			wantStatus: framework.NewStatus(
 				framework.UnschedulableAndUnresolvable,
-				ErrReasonAffinityNotMatch,
 				ErrReasonAffinityRulesNotMatch,
 			),
 		},
@@ -366,7 +363,6 @@ func TestRequiredAffinitySingleNode(t *testing.T) {
 			node: &node1,
 			wantStatus: framework.NewStatus(
 				framework.Unschedulable,
-				ErrReasonAffinityNotMatch,
 				ErrReasonAntiAffinityRulesNotMatch,
 			),
 		},
@@ -421,7 +417,6 @@ func TestRequiredAffinitySingleNode(t *testing.T) {
 			node: &node1,
 			wantStatus: framework.NewStatus(
 				framework.Unschedulable,
-				ErrReasonAffinityNotMatch,
 				ErrReasonExistingAntiAffinityRulesNotMatch,
 			),
 		},
@@ -446,7 +441,6 @@ func TestRequiredAffinitySingleNode(t *testing.T) {
 			node: &node1,
 			wantStatus: framework.NewStatus(
 				framework.UnschedulableAndUnresolvable,
-				ErrReasonAffinityNotMatch,
 				ErrReasonAffinityRulesNotMatch,
 			),
 		},
@@ -477,7 +471,6 @@ func TestRequiredAffinitySingleNode(t *testing.T) {
 			node: &node1,
 			wantStatus: framework.NewStatus(
 				framework.Unschedulable,
-				ErrReasonAffinityNotMatch,
 				ErrReasonExistingAntiAffinityRulesNotMatch,
 			),
 		},
@@ -553,7 +546,6 @@ func TestRequiredAffinitySingleNode(t *testing.T) {
 			node: &node1,
 			wantStatus: framework.NewStatus(
 				framework.Unschedulable,
-				ErrReasonAffinityNotMatch,
 				ErrReasonAntiAffinityRulesNotMatch,
 			),
 		},
@@ -603,7 +595,6 @@ func TestRequiredAffinitySingleNode(t *testing.T) {
 			node: &node1,
 			wantStatus: framework.NewStatus(
 				framework.Unschedulable,
-				ErrReasonAffinityNotMatch,
 				ErrReasonAntiAffinityRulesNotMatch,
 			),
 		},
@@ -653,7 +644,6 @@ func TestRequiredAffinitySingleNode(t *testing.T) {
 			node: &node1,
 			wantStatus: framework.NewStatus(
 				framework.Unschedulable,
-				ErrReasonAffinityNotMatch,
 				ErrReasonExistingAntiAffinityRulesNotMatch,
 			),
 		},
@@ -714,7 +704,6 @@ func TestRequiredAffinitySingleNode(t *testing.T) {
 			node: &node1,
 			wantStatus: framework.NewStatus(
 				framework.Unschedulable,
-				ErrReasonAffinityNotMatch,
 				ErrReasonAntiAffinityRulesNotMatch,
 			),
 		},
@@ -775,7 +764,6 @@ func TestRequiredAffinitySingleNode(t *testing.T) {
 			node: &node1,
 			wantStatus: framework.NewStatus(
 				framework.Unschedulable,
-				ErrReasonAffinityNotMatch,
 				ErrReasonAntiAffinityRulesNotMatch,
 			),
 		},
@@ -912,7 +900,6 @@ func TestRequiredAffinitySingleNode(t *testing.T) {
 			node: &node1,
 			wantStatus: framework.NewStatus(
 				framework.UnschedulableAndUnresolvable,
-				ErrReasonAffinityNotMatch,
 				ErrReasonAffinityRulesNotMatch,
 			),
 		},
@@ -946,7 +933,6 @@ func TestRequiredAffinitySingleNode(t *testing.T) {
 			node: &node1,
 			wantStatus: framework.NewStatus(
 				framework.Unschedulable,
-				ErrReasonAffinityNotMatch,
 				ErrReasonAntiAffinityRulesNotMatch,
 			),
 		},
@@ -972,7 +958,6 @@ func TestRequiredAffinitySingleNode(t *testing.T) {
 			node: &node1,
 			wantStatus: framework.NewStatus(
 				framework.Unschedulable,
-				ErrReasonAffinityNotMatch,
 				ErrReasonAntiAffinityRulesNotMatch,
 			),
 		},
@@ -1085,7 +1070,6 @@ func TestRequiredAffinityMultipleNodes(t *testing.T) {
 				nil,
 				framework.NewStatus(
 					framework.UnschedulableAndUnresolvable,
-					ErrReasonAffinityNotMatch,
 					ErrReasonAffinityRulesNotMatch,
 				),
 			},
@@ -1164,12 +1148,10 @@ func TestRequiredAffinityMultipleNodes(t *testing.T) {
 			wantStatuses: []*framework.Status{
 				framework.NewStatus(
 					framework.UnschedulableAndUnresolvable,
-					ErrReasonAffinityNotMatch,
 					ErrReasonAffinityRulesNotMatch,
 				),
 				framework.NewStatus(
 					framework.UnschedulableAndUnresolvable,
-					ErrReasonAffinityNotMatch,
 					ErrReasonAffinityRulesNotMatch,
 				),
 			},
@@ -1201,12 +1183,10 @@ func TestRequiredAffinityMultipleNodes(t *testing.T) {
 			wantStatuses: []*framework.Status{
 				framework.NewStatus(
 					framework.Unschedulable,
-					ErrReasonAffinityNotMatch,
 					ErrReasonAntiAffinityRulesNotMatch,
 				),
 				framework.NewStatus(
 					framework.Unschedulable,
-					ErrReasonAffinityNotMatch,
 					ErrReasonAntiAffinityRulesNotMatch,
 				),
 			},
@@ -1250,12 +1230,10 @@ func TestRequiredAffinityMultipleNodes(t *testing.T) {
 			wantStatuses: []*framework.Status{
 				framework.NewStatus(
 					framework.Unschedulable,
-					ErrReasonAffinityNotMatch,
 					ErrReasonAntiAffinityRulesNotMatch,
 				),
 				framework.NewStatus(
 					framework.Unschedulable,
-					ErrReasonAffinityNotMatch,
 					ErrReasonAntiAffinityRulesNotMatch,
 				),
 			},
@@ -1288,12 +1266,10 @@ func TestRequiredAffinityMultipleNodes(t *testing.T) {
 			wantStatuses: []*framework.Status{
 				framework.NewStatus(
 					framework.Unschedulable,
-					ErrReasonAffinityNotMatch,
 					ErrReasonAntiAffinityRulesNotMatch,
 				),
 				framework.NewStatus(
 					framework.Unschedulable,
-					ErrReasonAffinityNotMatch,
 					ErrReasonAntiAffinityRulesNotMatch,
 				),
 				nil,
@@ -1348,12 +1324,10 @@ func TestRequiredAffinityMultipleNodes(t *testing.T) {
 			wantStatuses: []*framework.Status{
 				framework.NewStatus(
 					framework.Unschedulable,
-					ErrReasonAffinityNotMatch,
 					ErrReasonAntiAffinityRulesNotMatch,
 				),
 				framework.NewStatus(
 					framework.Unschedulable,
-					ErrReasonAffinityNotMatch,
 					ErrReasonAntiAffinityRulesNotMatch,
 				),
 				nil,
@@ -1458,12 +1432,10 @@ func TestRequiredAffinityMultipleNodes(t *testing.T) {
 			wantStatuses: []*framework.Status{
 				framework.NewStatus(
 					framework.Unschedulable,
-					ErrReasonAffinityNotMatch,
 					ErrReasonExistingAntiAffinityRulesNotMatch,
 				),
 				framework.NewStatus(
 					framework.Unschedulable,
-					ErrReasonAffinityNotMatch,
 					ErrReasonExistingAntiAffinityRulesNotMatch,
 				),
 			},
@@ -1516,12 +1488,10 @@ func TestRequiredAffinityMultipleNodes(t *testing.T) {
 			wantStatuses: []*framework.Status{
 				framework.NewStatus(
 					framework.Unschedulable,
-					ErrReasonAffinityNotMatch,
 					ErrReasonAntiAffinityRulesNotMatch,
 				),
 				framework.NewStatus(
 					framework.Unschedulable,
-					ErrReasonAffinityNotMatch,
 					ErrReasonAntiAffinityRulesNotMatch,
 				),
 			},
@@ -1565,7 +1535,6 @@ func TestRequiredAffinityMultipleNodes(t *testing.T) {
 			wantStatuses: []*framework.Status{
 				framework.NewStatus(
 					framework.Unschedulable,
-					ErrReasonAffinityNotMatch,
 					ErrReasonExistingAntiAffinityRulesNotMatch,
 				),
 				nil,
@@ -1616,7 +1585,6 @@ func TestRequiredAffinityMultipleNodes(t *testing.T) {
 			wantStatuses: []*framework.Status{
 				framework.NewStatus(
 					framework.Unschedulable,
-					ErrReasonAffinityNotMatch,
 					ErrReasonAntiAffinityRulesNotMatch,
 				),
 				nil,
@@ -1661,12 +1629,10 @@ func TestRequiredAffinityMultipleNodes(t *testing.T) {
 			wantStatuses: []*framework.Status{
 				framework.NewStatus(
 					framework.Unschedulable,
-					ErrReasonAffinityNotMatch,
 					ErrReasonExistingAntiAffinityRulesNotMatch,
 				),
 				framework.NewStatus(
 					framework.Unschedulable,
-					ErrReasonAffinityNotMatch,
 					ErrReasonExistingAntiAffinityRulesNotMatch,
 				),
 			},
@@ -1713,12 +1679,10 @@ func TestRequiredAffinityMultipleNodes(t *testing.T) {
 			wantStatuses: []*framework.Status{
 				framework.NewStatus(
 					framework.Unschedulable,
-					ErrReasonAffinityNotMatch,
 					ErrReasonAntiAffinityRulesNotMatch,
 				),
 				framework.NewStatus(
 					framework.Unschedulable,
-					ErrReasonAffinityNotMatch,
 					ErrReasonAntiAffinityRulesNotMatch,
 				),
 			},
@@ -1788,12 +1752,10 @@ func TestRequiredAffinityMultipleNodes(t *testing.T) {
 			wantStatuses: []*framework.Status{
 				framework.NewStatus(
 					framework.Unschedulable,
-					ErrReasonAffinityNotMatch,
 					ErrReasonExistingAntiAffinityRulesNotMatch,
 				),
 				framework.NewStatus(
 					framework.Unschedulable,
-					ErrReasonAffinityNotMatch,
 					ErrReasonExistingAntiAffinityRulesNotMatch,
 				),
 				nil,
@@ -1888,12 +1850,10 @@ func TestRequiredAffinityMultipleNodes(t *testing.T) {
 			wantStatuses: []*framework.Status{
 				framework.NewStatus(
 					framework.UnschedulableAndUnresolvable,
-					ErrReasonAffinityNotMatch,
 					ErrReasonAffinityRulesNotMatch,
 				),
 				framework.NewStatus(
 					framework.UnschedulableAndUnresolvable,
-					ErrReasonAffinityNotMatch,
 					ErrReasonAffinityRulesNotMatch,
 				),
 			},


### PR DESCRIPTION
Both `ErrReasonAffinityRulesNotMatch` and `ErrReasonAntiAffinityRulesNotMatch` are
more precise than `ErrReasonAffinityNotMatch`.

Signed-off-by: Dave Chen <dave.chen@arm.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup




#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
