### PR TITLE
 rootcacertpublisher: drop the namespace label from metrics to reduce its cardinality

### DIFF
--- a/pkg/controller/certificates/rootcacertpublisher/metrics.go
+++ b/pkg/controller/certificates/rootcacertpublisher/metrics.go
@@ -37,7 +37,7 @@ var (
 			Help:           "Number of namespace syncs happened in root ca cert publisher.",
 			StabilityLevel: metrics.ALPHA,
 		},
-		[]string{"namespace", "code"},
+		[]string{"code"},
 	)
 	syncLatency = metrics.NewHistogramVec(
 		&metrics.HistogramOpts{
@@ -47,19 +47,19 @@ var (
 			Buckets:        metrics.ExponentialBuckets(0.001, 2, 15),
 			StabilityLevel: metrics.ALPHA,
 		},
-		[]string{"namespace", "code"},
+		[]string{"code"},
 	)
 )
 
-func recordMetrics(start time.Time, ns string, err error) {
+func recordMetrics(start time.Time, err error) {
 	code := "500"
 	if err == nil {
 		code = "200"
 	} else if se, ok := err.(*apierrors.StatusError); ok && se.Status().Code != 0 {
 		code = strconv.Itoa(int(se.Status().Code))
 	}
-	syncLatency.WithLabelValues(ns, code).Observe(time.Since(start).Seconds())
-	syncCounter.WithLabelValues(ns, code).Inc()
+	syncLatency.WithLabelValues(code).Observe(time.Since(start).Seconds())
+	syncCounter.WithLabelValues(code).Inc()
 }
 
 var once sync.Once

--- a/pkg/controller/certificates/rootcacertpublisher/metrics_test.go
+++ b/pkg/controller/certificates/rootcacertpublisher/metrics_test.go
@@ -44,7 +44,7 @@ func TestSyncCounter(t *testing.T) {
 			want: `
 # HELP root_ca_cert_publisher_sync_total [ALPHA] Number of namespace syncs happened in root ca cert publisher.
 # TYPE root_ca_cert_publisher_sync_total counter
-root_ca_cert_publisher_sync_total{code="200",namespace="test-ns"} 1
+root_ca_cert_publisher_sync_total{code="200"} 1
 				`,
 		},
 		{
@@ -56,7 +56,7 @@ root_ca_cert_publisher_sync_total{code="200",namespace="test-ns"} 1
 			want: `
 # HELP root_ca_cert_publisher_sync_total [ALPHA] Number of namespace syncs happened in root ca cert publisher.
 # TYPE root_ca_cert_publisher_sync_total counter
-root_ca_cert_publisher_sync_total{code="404",namespace="test-ns"} 1
+root_ca_cert_publisher_sync_total{code="404"} 1
 				`,
 		},
 		{
@@ -68,7 +68,7 @@ root_ca_cert_publisher_sync_total{code="404",namespace="test-ns"} 1
 			want: `
 # HELP root_ca_cert_publisher_sync_total [ALPHA] Number of namespace syncs happened in root ca cert publisher.
 # TYPE root_ca_cert_publisher_sync_total counter
-root_ca_cert_publisher_sync_total{code="500",namespace="test-ns"} 1
+root_ca_cert_publisher_sync_total{code="500"} 1
 				`,
 		},
 		{
@@ -80,14 +80,14 @@ root_ca_cert_publisher_sync_total{code="500",namespace="test-ns"} 1
 			want: `
 # HELP root_ca_cert_publisher_sync_total [ALPHA] Number of namespace syncs happened in root ca cert publisher.
 # TYPE root_ca_cert_publisher_sync_total counter
-root_ca_cert_publisher_sync_total{code="500",namespace="test-ns"} 1
+root_ca_cert_publisher_sync_total{code="500"} 1
 				`,
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
-			recordMetrics(time.Now(), "test-ns", tc.err)
+			recordMetrics(time.Now(), tc.err)
 			defer syncCounter.Reset()
 			if err := testutil.GatherAndCompare(legacyregistry.DefaultGatherer, strings.NewReader(tc.want), tc.metrics...); err != nil {
 				t.Fatal(err)

--- a/pkg/controller/certificates/rootcacertpublisher/publisher.go
+++ b/pkg/controller/certificates/rootcacertpublisher/publisher.go
@@ -182,7 +182,7 @@ func (c *Publisher) processNextWorkItem() bool {
 func (c *Publisher) syncNamespace(ns string) (err error) {
 	startTime := time.Now()
 	defer func() {
-		recordMetrics(startTime, ns, err)
+		recordMetrics(startTime, err)
 		klog.V(4).Infof("Finished syncing namespace %q (%v)", ns, time.Since(startTime))
 	}()
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
The PR modifies the RootCA Publisher Controller metrics so that it does not include namespace as a label.

#### Which issue(s) this PR fixes:
The `root_ca_cert_publisher_sync_duration_seconds` metric tracks the sync duration in the root CA cert publisher per code and namespace. In clusters with a high namespace turnover (like CI clusters), this may cause the kube-controller-manager to expose over 100k series to Prometheus, which may cause degradation of that service.

Drop the `namespace` label to remove the metrics' cardinality, tracking this metric by namespace does not justify the impact of keeping it.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
The `root_ca_cert_publisher_sync_duration_seconds` and `root_ca_cert_publisher_sync_total` metrics only track the response codes encountered but the namespace label was dropped.
 ```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.: