### PR TITLE
Clean apply's prune and kube addons with batch/v1 CronJob

### DIFF
--- a/cluster/addons/addon-manager/kube-addons.sh
+++ b/cluster/addons/addon-manager/kube-addons.sh
@@ -46,7 +46,7 @@ if [ -z "${KUBECTL_PRUNE_WHITELIST_OVERRIDE:-}" ]; then
     core/v1/Secret
     core/v1/Service
     batch/v1/Job
-    batch/v1beta1/CronJob
+    batch/v1/CronJob
     apps/v1/DaemonSet
     apps/v1/Deployment
     apps/v1/ReplicaSet

--- a/staging/src/k8s.io/kubectl/pkg/cmd/apply/prune.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/apply/prune.go
@@ -184,7 +184,7 @@ func getRESTMappings(mapper meta.RESTMapper, pruneResources *[]pruneResource) (n
 			{"", "v1", "Secret", true},
 			{"", "v1", "Service", true},
 			{"batch", "v1", "Job", true},
-			{"batch", "v1beta1", "CronJob", true},
+			{"batch", "v1", "CronJob", true},
 			{"networking.k8s.io", "v1", "Ingress", true},
 			{"apps", "v1", "DaemonSet", true},
 			{"apps", "v1", "Deployment", true},


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
This is cleaning missing leftovers from CronJob GA-ing in 1.21. 

xref https://github.com/kubernetes/enhancements/issues/19

#### Special notes for your reviewer:
/assign @dims 
for cluster changes
/assign @ravisantoshgudimetla 
for cli changes


#### Does this PR introduce a user-facing change?
```release-note
NONE
```
