### PR TITLE
set grabber metrics helper only once and when needed

### DIFF
--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -46,7 +46,6 @@ import (
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2ekubectl "k8s.io/kubernetes/test/e2e/framework/kubectl"
 	e2emanifest "k8s.io/kubernetes/test/e2e/framework/manifest"
-	"k8s.io/kubernetes/test/e2e/framework/metrics"
 	e2enode "k8s.io/kubernetes/test/e2e/framework/node"
 	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
 	e2ereporters "k8s.io/kubernetes/test/e2e/reporters"
@@ -309,10 +308,6 @@ func setupSuite() {
 		go nodeKiller.Run(framework.TestContext.NodeKiller.NodeKillerStopCh)
 	}
 
-	err = metrics.SetupMetricsProxy(c)
-	if err != nil {
-		framework.Logf("Fail to setup metrics proxy: %v", err)
-	}
 }
 
 // logClusterImageSources writes out cluster image sources.

--- a/test/e2e/framework/metrics/metrics_grabber.go
+++ b/test/e2e/framework/metrics/metrics_grabber.go
@@ -76,6 +76,7 @@ func NewMetricsGrabber(c clientset.Interface, ec clientset.Interface, kubelets b
 	kubeScheduler := ""
 	kubeControllerManager := ""
 	snapshotControllerManager := ""
+	components := []string{}
 
 	regKubeScheduler := regexp.MustCompile("kube-scheduler-.*")
 	regKubeControllerManager := regexp.MustCompile("kube-controller-manager-.*")
@@ -116,6 +117,17 @@ func NewMetricsGrabber(c clientset.Interface, ec clientset.Interface, kubelets b
 	}
 	if ec == nil {
 		klog.Warningf("Did not receive an external client interface. Grabbing metrics from ClusterAutoscaler is disabled.")
+	}
+
+	if !scheduler {
+		components = append(components, "kube-scheduler")
+	}
+	if !controllers {
+		components = append(components, "kube-controller-manager")
+	}
+	err = setupMetricsProxy(c, components)
+	if err != nil {
+		return &Grabber{}, err
 	}
 
 	return &Grabber{


### PR DESCRIPTION
/kind cleanup
```release-note
NONE
```

Since the core components that exposed metrics deprecated the insecure handlers, we have to provide a mechanism to being able to gathers the metrics.
Current solution creates a service account with the right permissions, and deploys a pod proxy that is able to gather the metrics.

The problem is that we were creating this pod once the e2e framework runs, but:
- metrics tests are optional and doesn't belong to conformance
- the proxy assumes components are deployed as pods, that is not mandatory, hence clusters can be blocked during 5 mins until the metrics-proxy creation gives up

We can move the logic to the NewMetricsGather() method, so only test that need it set up the proxy pod. Also, the proxy pod checks if it was already set up, so it only needs to be configured once