### PR TITLE
Fix wrong comments

### DIFF
--- a/pkg/registry/core/pod/rest/subresources.go
+++ b/pkg/registry/core/pod/rest/subresources.go
@@ -93,7 +93,7 @@ func (r *AttachREST) New() runtime.Object {
 	return &api.PodAttachOptions{}
 }
 
-// Connect returns a handler for the pod exec proxy
+// Connect returns a handler for the pod attach proxy
 func (r *AttachREST) Connect(ctx context.Context, name string, opts runtime.Object, responder rest.Responder) (http.Handler, error) {
 	attachOpts, ok := opts.(*api.PodAttachOptions)
 	if !ok {
@@ -106,12 +106,12 @@ func (r *AttachREST) Connect(ctx context.Context, name string, opts runtime.Obje
 	return newThrottledUpgradeAwareProxyHandler(location, transport, false, true, true, responder), nil
 }
 
-// NewConnectOptions returns the versioned object that represents exec parameters
+// NewConnectOptions returns the versioned object that represents attach parameters
 func (r *AttachREST) NewConnectOptions() (runtime.Object, bool, string) {
 	return &api.PodAttachOptions{}, false, ""
 }
 
-// ConnectMethods returns the methods supported by exec
+// ConnectMethods returns the methods supported by attach
 func (r *AttachREST) ConnectMethods() []string {
 	return upgradeableMethods
 }

--- a/staging/src/k8s.io/apimachinery/pkg/util/proxy/upgradeaware.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/proxy/upgradeaware.go
@@ -58,7 +58,7 @@ type UpgradeAwareHandler struct {
 	// UpgradeRequired will reject non-upgrade connections if true.
 	UpgradeRequired bool
 	// Location is the location of the upstream proxy. It is used as the location to Dial on the upstream server
-	// for upgrade requests unless UseRequestLocationOnUpgrade is true.
+	// for upgrade requests unless UseRequestLocation is true.
 	Location *url.URL
 	// Transport provides an optional round tripper to use to proxy. If nil, the default proxy transport is used
 	Transport http.RoundTripper


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
Fixes some mistakes in comments I noticed:
* wrong field name:  There is no field called `UseRequestLocationOnUpgrade` field, it should be `UseRequestLocation`.
* copy/paste mistakes:  Looks like attach code was copied from exec, but comments were not changed

#### Which issue(s) this PR fixes:
None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs

```
