### PR TITLE
Add e2e test for a volume + its clone used on the same node

### DIFF
--- a/test/e2e/storage/framework/testpattern.go
+++ b/test/e2e/storage/framework/testpattern.go
@@ -179,9 +179,11 @@ var (
 	}
 	// Ext4DynamicPV is TestPattern for "Dynamic PV (ext4)"
 	Ext4DynamicPV = TestPattern{
-		Name:    "Dynamic PV (ext4)",
-		VolType: DynamicPV,
-		FsType:  "ext4",
+		Name:                   "Dynamic PV (ext4)",
+		VolType:                DynamicPV,
+		FsType:                 "ext4",
+		SnapshotType:           DynamicCreatedSnapshot,
+		SnapshotDeletionPolicy: DeleteSnapshot,
 	}
 
 	// Definitions for xfs
@@ -216,10 +218,12 @@ var (
 	}
 	// XfsDynamicPV is TestPattern for "Dynamic PV (xfs)"
 	XfsDynamicPV = TestPattern{
-		Name:       "Dynamic PV (xfs)",
-		VolType:    DynamicPV,
-		FsType:     "xfs",
-		FeatureTag: "[Slow]",
+		Name:                   "Dynamic PV (xfs)",
+		VolType:                DynamicPV,
+		FsType:                 "xfs",
+		FeatureTag:             "[Slow]",
+		SnapshotType:           DynamicCreatedSnapshot,
+		SnapshotDeletionPolicy: DeleteSnapshot,
 	}
 
 	// Definitions for ntfs


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
CSI driver need to pass special mount opts to XFS filesystem to be able to mount a volume + its clone or its restored snapshot on the same node. See https://github.com/container-storage-interface/spec/issues/482.

Add a test to exhibit this behavior. As consequence, some ext4 + xfs tests were made "snapshottable" (i.e. set `SnapshotType` for them).

The test is optional for now, behind `[Feature:VolumeSourceXFS]`, giving CSI drivers option to skip it until they fix their XFS mounting. The feature tag will be removed in a future releases.

#### Which issue(s) this PR fixes:
Related to https://github.com/container-storage-interface/spec/issues/482.

#### Special notes for your reviewer:
Running the test with AWS EBS CSI driver: https://github.com/kubernetes-sigs/aws-ebs-csi-driver/pull/913

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
