### PR TITLE
Add scalability label to kubemark OWNERS

### DIFF
--- a/pkg/kubemark/OWNERS
+++ b/pkg/kubemark/OWNERS
@@ -11,3 +11,6 @@ approvers:
 
 emeritus_approvers:
 - gmarek
+
+labels:
+  - sig/scalability


### PR DESCRIPTION

#### What type of PR is this?

/kind cleanup
/sig scalability
/assign @wojtek-t @mm4tt @shyamjvs

#### What this PR does / why we need it:

Auto-apply SIG scalability label to pkg/kubemark PRs. It's on other code but not here for some reason:

```
ehashman@fedora:~/src/k8s$ git grep 'sig/scalability'
cluster/images/kubemark/OWNERS:- sig/scalability
cluster/kubemark/OWNERS:- sig/scalability
cluster/log-dump/OWNERS:- sig/scalability
cluster/pre-existing/OWNERS:- sig/scalability
test/kubemark/OWNERS:  - sig/scalability
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
