### PR TITLE
Remove -k from toCurl output

### DIFF
--- a/staging/src/k8s.io/client-go/transport/round_trippers.go
+++ b/staging/src/k8s.io/client-go/transport/round_trippers.go
@@ -346,7 +346,7 @@ func (r *requestInfo) toCurl() string {
 		}
 	}
 
-	return fmt.Sprintf("curl -k -v -X%s %s '%s'", r.RequestVerb, headers, r.RequestURL)
+	return fmt.Sprintf("curl -v -X%s %s '%s'", r.RequestVerb, headers, r.RequestURL)
 }
 
 // debuggingRoundTripper will display information about the requests passing

--- a/staging/src/k8s.io/client-go/transport/round_trippers_test.go
+++ b/staging/src/k8s.io/client-go/transport/round_trippers_test.go
@@ -480,7 +480,7 @@ func TestDebuggingRoundTripper(t *testing.T) {
 		},
 		{
 			levels:              []DebugLevel{DebugCurlCommand},
-			expectedOutputLines: []string{fmt.Sprintf("curl -k -v -X")},
+			expectedOutputLines: []string{fmt.Sprintf("curl -v -X")},
 		},
 	}
 


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
This removes the insecure `curl` argument of `-k` from certain debugging output in `client-go`.

```release-note
NONE
```