### PR TITLE
add NoExecute toleration for konnectivity agent

### DIFF
--- a/cluster/gce/addons/konnectivity-agent/konnectivity-agent-ds.yaml
+++ b/cluster/gce/addons/konnectivity-agent/konnectivity-agent-ds.yaml
@@ -22,6 +22,10 @@ spec:
       tolerations:
         - key: "CriticalAddonsOnly"
           operator: "Exists"
+        - operator: "Exists"
+          effect: "NoExecute"
+        - operator: "Exists"
+          effect: "NoSchedule"
       nodeSelector:
         kubernetes.io/os: linux
       containers:


### PR DESCRIPTION
#### What type of PR is this?
/kind bug


#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
Fixes #102582

#### Special notes for your reviewer:
Following node-local-dns and kube-proxy:

https://github.com/kubernetes/kubernetes/blob/646acf096e61dcda9cc20c9acbbe2969741e07c3/cluster/gce/addons/konnectivity-agent/konnectivity-agent-ds.yaml#L21-L24

https://github.com/kubernetes/kubernetes/blob/ea0764452222146c47ec826977f49d7001b0ea8c/cluster/addons/dns/nodelocaldns/nodelocaldns.yaml#L132-L138


#### Does this PR introduce a user-facing change?
```release-note
NONE
```
