### PR TITLE
Add utils to set file/directory owners and permissions.

### DIFF
--- a/cmd/kubeadm/app/util/users/users_linux.go
+++ b/cmd/kubeadm/app/util/users/users_linux.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"sort"
 	"strconv"
 	"strings"
@@ -628,4 +629,22 @@ func writeFile(f *os.File, str string) error {
 		return err
 	}
 	return nil
+}
+
+// UpdatePathOwnerAndPermissions updates the owner and permissions of the given path.
+// If the path is a directory it updates its contents recursively.
+func UpdatePathOwnerAndPermissions(dirPath string, uid, gid int64, perms uint32) error {
+	err := filepath.WalkDir(dirPath, func(path string, d os.DirEntry, err error) error {
+		if err := os.Chown(path, int(uid), int(gid)); err != nil {
+			return errors.Wrapf(err, "failed to update owner of %q to uid: %d and gid: %d", path, uid, gid)
+		}
+
+		fm := os.FileMode(perms)
+		if err := os.Chmod(path, fm); err != nil {
+			return errors.Wrapf(err, "failed to update permissions of %q to %s", path, fm.String())
+		}
+		return nil
+	})
+
+	return err
 }

--- a/cmd/kubeadm/app/util/users/users_other.go
+++ b/cmd/kubeadm/app/util/users/users_other.go
@@ -43,3 +43,8 @@ func AddUsersAndGroups() (*UsersAndGroups, error) {
 func RemoveUsersAndGroups() error {
 	return nil
 }
+
+// UpdatePathOwnerAndPermissions is a NO-OP on non-Linux.
+func UpdatePathOwnerAndPermissions(path string, uid, gid int64, perms uint32) error {
+	return nil
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
Adds some utils that will be used to update the file permissions of the host volumes that the rootless control-plane components will mount.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
xref https://github.com/kubernetes/kubeadm/issues/2473
xref https://github.com/kubernetes/enhancements/issues/2568

#### Special notes for your reviewer:
Per discussion in #99881 we cannot add unit tests, because they require running as root.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- [KEP]: https://github.com/kubernetes/enhancements/issues/2568
```
