### PR TITLE
e2e storage: enable health-check controller in hostpath deployment

### DIFF
--- a/test/e2e/storage/drivers/csi.go
+++ b/test/e2e/storage/drivers/csi.go
@@ -241,18 +241,16 @@ func (h *hostpathCSIDriver) PrepareTest(f *framework.Framework) (*storageframewo
 			return err
 		}
 
-		// Remove csi-external-health-monitor-agent and
-		// csi-external-health-monitor-controller
-		// containers. They are not needed for any of the
-		// tests and may be causing too much overhead when
-		// running in a large cluster (see
-		// https://github.com/kubernetes/kubernetes/issues/102452#issuecomment-854452816).
+		// Remove csi-external-health-monitor-agent because it is
+		// obsolete and shouldn't have been deployed by csi-driver-host-path v1.7.2.
+		// This can be removed when updating to a newer driver that
+		// doesn't deploy the agent.
 		switch item := item.(type) {
 		case *appsv1.StatefulSet:
 			var containers []v1.Container
 			for _, container := range item.Spec.Template.Spec.Containers {
 				switch container.Name {
-				case "csi-external-health-monitor-agent", "csi-external-health-monitor-controller":
+				case "csi-external-health-monitor-agent":
 					// Remove these containers.
 				default:
 					// Keep the others.


### PR DESCRIPTION

#### What type of PR is this?

/kind cleanup
/kind failing-test

#### What this PR does / why we need it:

It was disabled together with the agent to avoid test failures in
gce-master-scale-correctness (https://github.com/kubernetes/kubernetes/issues/102452). That
solved the problem, but we still need to check whether the controller
alone works.

#### Which issue(s) this PR fixes:
Related-to: https://github.com/kubernetes/kubernetes/issues/102452

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

