### PR TITLE
Fix staticcheck in cluster & k8s.io/{apimachinery,apiserver}

### DIFF
--- a/cluster/images/etcd/migrate/versions.go
+++ b/cluster/images/etcd/migrate/versions.go
@@ -126,6 +126,7 @@ func ParseEtcdVersionPair(s string) (*EtcdVersionPair, error) {
 
 // MustParseEtcdVersionPair parses a "<version>/<storage-version>" string to an EtcdVersionPair
 // or panics if the parse fails.
+//lint:ignore U1000 Keep unused but exported MustParseEtcdVersionPair until deprecated package is being removed
 func MustParseEtcdVersionPair(s string) *EtcdVersionPair {
 	pair, err := ParseEtcdVersionPair(s)
 	if err != nil {
@@ -188,6 +189,7 @@ func ParseSupportedVersions(list []string) (SupportedVersions, error) {
 }
 
 // MustParseSupportedVersions parses a comma separated list of etcd versions or panics if the parse fails.
+//lint:ignore U1000 Keep unused but exported MustParseSupportedVersions until deprecated package is being removed
 func MustParseSupportedVersions(list []string) SupportedVersions {
 	versions, err := ParseSupportedVersions(list)
 	if err != nil {

--- a/hack/.staticcheck_failures
+++ b/hack/.staticcheck_failures
@@ -1,8 +1,3 @@
-cluster/images/etcd/migrate
-vendor/k8s.io/apimachinery/pkg/api/apitesting/roundtrip
-vendor/k8s.io/apimachinery/pkg/apis/meta/v1/validation
-vendor/k8s.io/apiserver/pkg/endpoints/filters
-vendor/k8s.io/apiserver/pkg/endpoints/metrics
 vendor/k8s.io/apiserver/pkg/server/dynamiccertificates
 vendor/k8s.io/apiserver/pkg/server/filters
 vendor/k8s.io/apiserver/pkg/server/routes

--- a/staging/src/k8s.io/apimachinery/pkg/api/apitesting/roundtrip/roundtrip.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/apitesting/roundtrip/roundtrip.go
@@ -25,6 +25,7 @@ import (
 	"testing"
 
 	"github.com/davecgh/go-spew/spew"
+	//lint:ignore SA1019 Keep using deprecated module; it still seems to be maintained and the api of the recommended replacement differs
 	"github.com/golang/protobuf/proto"
 	fuzz "github.com/google/gofuzz"
 	flag "github.com/spf13/pflag"

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/validation/validation.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/validation/validation.go
@@ -81,6 +81,7 @@ func ValidateLabels(labels map[string]string, fldPath *field.Path) field.ErrorLi
 
 func ValidateDeleteOptions(options *metav1.DeleteOptions) field.ErrorList {
 	allErrs := field.ErrorList{}
+	//lint:file-ignore SA1019 Keep validation for deprecated OrphanDependents option until it's being removed
 	if options.OrphanDependents != nil && options.PropagationPolicy != nil {
 		allErrs = append(allErrs, field.Invalid(field.NewPath("propagationPolicy"), options.PropagationPolicy, "orphanDependents and deletionPropagation cannot be both set"))
 	}

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/filters/audit.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/filters/audit.go
@@ -173,6 +173,7 @@ func decorateResponseWriter(ctx context.Context, responseWriter http.ResponseWri
 
 	// check if the ResponseWriter we're wrapping is the fancy one we need
 	// or if the basic is sufficient
+	//lint:file-ignore SA1019 Keep supporting deprecated http.CloseNotifier
 	_, cn := responseWriter.(http.CloseNotifier)
 	_, fl := responseWriter.(http.Flusher)
 	_, hj := responseWriter.(http.Hijacker)

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/metrics/metrics.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/metrics/metrics.go
@@ -469,6 +469,7 @@ func InstrumentRouteFunc(verb, group, version, resource, subresource, scope, com
 
 		delegate := &ResponseWriterDelegator{ResponseWriter: response.ResponseWriter}
 
+		//lint:file-ignore SA1019 Keep supporting deprecated http.CloseNotifier
 		_, cn := response.ResponseWriter.(http.CloseNotifier)
 		_, fl := response.ResponseWriter.(http.Flusher)
 		_, hj := response.ResponseWriter.(http.Hijacker)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
PR fixes issue found by staticcheck in `cluster/images/etcd`, `k8s.io/apimachinery`, and  `k8s.io/apiserver`
```
cluster/images/etcd/migrate/versions.go:129:6: func MustParseEtcdVersionPair is unused (U1000)
cluster/images/etcd/migrate/versions.go:191:6: func MustParseSupportedVersions is unused (U1000)
vendor/k8s.io/apimachinery/pkg/api/apitesting/roundtrip/roundtrip.go:28:2: package github.com/golang/protobuf/proto is deprecated: Use the "google.golang.org/protobuf/proto" package instead.  (SA1019)
vendor/k8s.io/apimachinery/pkg/apis/meta/v1/validation/validation.go:84:5: options.OrphanDependents is deprecated: please use the PropagationPolicy, this field will be deprecated in 1.7. Should the dependent objects be orphaned. If true/false, the "orphan" finalizer will be added to/removed from the object's finalizers list. Either this field or PropagationPolicy may be set, but not both. +optional  (SA1019)
vendor/k8s.io/apiserver/pkg/endpoints/filters/audit.go:176:27: http.CloseNotifier is deprecated: the CloseNotifier interface predates Go's context package. New code should use Request.Context instead.  (SA1019)
vendor/k8s.io/apiserver/pkg/endpoints/filters/audit.go:231:27: http.CloseNotifier is deprecated: the CloseNotifier interface predates Go's context package. New code should use Request.Context instead.  (SA1019)
vendor/k8s.io/apiserver/pkg/endpoints/filters/audit.go:245:7: http.CloseNotifier is deprecated: the CloseNotifier interface predates Go's context package. New code should use Request.Context instead.  (SA1019)
vendor/k8s.io/apiserver/pkg/endpoints/metrics/metrics.go:472:37: http.CloseNotifier is deprecated: the CloseNotifier interface predates Go's context package. New code should use Request.Context instead.  (SA1019)
vendor/k8s.io/apiserver/pkg/endpoints/metrics/metrics.go:499:15: http.CloseNotifier is deprecated: the CloseNotifier interface predates Go's context package. New code should use Request.Context instead.  (SA1019)
vendor/k8s.io/apiserver/pkg/endpoints/metrics/metrics.go:617:27: http.CloseNotifier is deprecated: the CloseNotifier interface predates Go's context package. New code should use Request.Context instead.  (SA1019)
```

#### Which issue(s) this PR fixes:
Part of #92402

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```