### PR TITLE
Cleanup SCTP tests addressing #96717 part 2

### DIFF
--- a/test/e2e/network/service.go
+++ b/test/e2e/network/service.go
@@ -3170,203 +3170,29 @@ var _ = common.SIGDescribe("SCTP [LinuxOnly]", func() {
 		cs = f.ClientSet
 	})
 
-	/* testing new test
-	ginkgo.It("should allow creating a basic SCTP service with pod and endpoints", func() {
-		serviceName := "sctp-endpoint-test"
-		ns := f.Namespace.Name
-		jig := e2eservice.NewTestJig(cs, ns, serviceName)
-
-		ginkgo.By("getting the state of the sctp module on nodes")
-		nodes, err := e2enode.GetBoundedReadySchedulableNodes(cs, 2)
-		framework.ExpectNoError(err)
-		sctpLoadedAtStart := CheckSCTPModuleLoadedOnNodes(f, nodes)
-
-		ginkgo.By("creating service " + serviceName + " in namespace " + ns)
-		_, err = jig.CreateSCTPServiceWithPort(nil, 5060)
-		framework.ExpectNoError(err)
-		defer func() {
-			err := cs.CoreV1().Services(ns).Delete(context.TODO(), serviceName, metav1.DeleteOptions{})
-			framework.ExpectNoError(err, "failed to delete service: %s in namespace: %s", serviceName, ns)
-		}()
-
-		err = e2enetwork.WaitForService(f.ClientSet, ns, serviceName, true, 5*time.Second, e2eservice.TestTimeout)
-		framework.ExpectNoError(err, fmt.Sprintf("error while waiting for service:%s err: %v", serviceName, err))
-
-		ginkgo.By("validating endpoints do not exist yet")
-		validateEndpointsPortsOrFail(cs, ns, serviceName, portsByPodName{})
-
-		ginkgo.By("creating a pod for the service")
-		names := map[string]bool{}
-
-		name1 := "pod1"
-
-		createPodOrFail(f, ns, name1, jig.Labels, []v1.ContainerPort{{ContainerPort: 5060, Protocol: v1.ProtocolSCTP}})
-		names[name1] = true
-		defer func() {
-			for name := range names {
-				err := cs.CoreV1().Pods(ns).Delete(context.TODO(), name, metav1.DeleteOptions{})
-				framework.ExpectNoError(err, "failed to delete pod: %s in namespace: %s", name, ns)
-			}
-		}()
-
-		ginkgo.By("validating endpoints exists")
-		validateEndpointsPortsOrFail(cs, ns, serviceName, portsByPodName{name1: {5060}})
-
-		ginkgo.By("deleting the pod")
-		e2epod.DeletePodOrFail(cs, ns, name1)
-		delete(names, name1)
-		ginkgo.By("validating endpoints do not exist anymore")
-		validateEndpointsPortsOrFail(cs, ns, serviceName, portsByPodName{})
-
-		ginkgo.By("validating sctp module is still not loaded")
-		sctpLoadedAtEnd := CheckSCTPModuleLoadedOnNodes(f, nodes)
-		if !sctpLoadedAtStart && sctpLoadedAtEnd {
-			framework.Failf("The state of the sctp module has changed due to the test case")
-		}
-	})
-
-	ginkgo.It("should create a Pod with SCTP HostPort", func() {
-		node, err := e2enode.GetRandomReadySchedulableNode(cs)
-		framework.ExpectNoError(err)
-		hostExec := utils.NewHostExec(f)
-		defer hostExec.Cleanup()
-
-		ginkgo.By("getting the state of the sctp module on the selected node")
-		nodes := &v1.NodeList{}
-		nodes.Items = append(nodes.Items, *node)
-		sctpLoadedAtStart := CheckSCTPModuleLoadedOnNodes(f, nodes)
-
-		ginkgo.By("creating a pod with hostport on the selected node")
-		podName := "hostport"
-		ports := []v1.ContainerPort{{Protocol: v1.ProtocolSCTP, ContainerPort: 5060, HostPort: 5060}}
-		podSpec := e2epod.NewAgnhostPod(f.Namespace.Name, podName, nil, nil, ports)
-		nodeSelection := e2epod.NodeSelection{Name: node.Name}
-		e2epod.SetNodeSelection(&podSpec.Spec, nodeSelection)
-
-		ginkgo.By(fmt.Sprintf("Launching the pod on node %v", node.Name))
-		f.PodClient().CreateSync(podSpec)
-		defer func() {
-			err := cs.CoreV1().Pods(f.Namespace.Name).Delete(context.TODO(), podName, metav1.DeleteOptions{})
-			framework.ExpectNoError(err, "failed to delete pod: %s in namespace: %s", podName, f.Namespace.Name)
-		}()
-		// wait until host port manager syncs rules
-		cmd := "iptables-save"
-		if framework.TestContext.ClusterIsIPv6() {
-			cmd = "ip6tables-save"
-		}
-		err = wait.PollImmediate(framework.Poll, framework.PollShortTimeout, func() (bool, error) {
-			framework.Logf("Executing cmd %q on node %v", cmd, node.Name)
-			result, err := hostExec.IssueCommandWithResult(cmd, node)
-			if err != nil {
-				framework.Logf("Interrogation of iptables rules failed on node %v", node.Name)
-				return false, nil
-			}
-
-			for _, line := range strings.Split(result, "\n") {
-				if strings.Contains(line, "-p sctp") && strings.Contains(line, "--dport 5060") {
-					return true, nil
-				}
-			}
-			framework.Logf("retrying ... not hostport sctp iptables rules found on node %v", node.Name)
-			return false, nil
-		})
-		if err != nil {
-			framework.Failf("iptables rules are not set for a pod with sctp hostport")
-		}
-		ginkgo.By("validating sctp module is still not loaded")
-		sctpLoadedAtEnd := CheckSCTPModuleLoadedOnNodes(f, nodes)
-		if !sctpLoadedAtStart && sctpLoadedAtEnd {
-			framework.Failf("The state of the sctp module has changed due to the test case")
-		}
-	})
-	ginkgo.It("should create a ClusterIP Service with SCTP ports", func() {
-		ginkgo.By("checking that kube-proxy is in iptables mode")
-		if proxyMode, err := proxyMode(f); err != nil {
-			e2eskipper.Skipf("Couldn't detect KubeProxy mode - skip, %v", err)
-		} else if proxyMode != "iptables" {
-			e2eskipper.Skipf("The test doesn't work if kube-proxy is not in iptables mode")
-		}
-
-		serviceName := "sctp-clusterip"
-		ns := f.Namespace.Name
-		jig := e2eservice.NewTestJig(cs, ns, serviceName)
-
-		ginkgo.By("getting the state of the sctp module on nodes")
-		nodes, err := e2enode.GetBoundedReadySchedulableNodes(cs, 2)
-		framework.ExpectNoError(err)
-		sctpLoadedAtStart := CheckSCTPModuleLoadedOnNodes(f, nodes)
-
-		ginkgo.By("creating service " + serviceName + " in namespace " + ns)
-		_, err = jig.CreateSCTPServiceWithPort(func(svc *v1.Service) {
-			svc.Spec.Type = v1.ServiceTypeClusterIP
-			svc.Spec.Ports = []v1.ServicePort{{Protocol: v1.ProtocolSCTP, Port: 5060}}
-		}, 5060)
-		framework.ExpectNoError(err)
-		defer func() {
-			err := cs.CoreV1().Services(ns).Delete(context.TODO(), serviceName, metav1.DeleteOptions{})
-			framework.ExpectNoError(err, "failed to delete service: %s in namespace: %s", serviceName, ns)
-		}()
-
-		err = e2enetwork.WaitForService(f.ClientSet, ns, serviceName, true, 5*time.Second, e2eservice.TestTimeout)
-		framework.ExpectNoError(err, fmt.Sprintf("error while waiting for service:%s err: %v", serviceName, err))
-		hostExec := utils.NewHostExec(f)
-		defer hostExec.Cleanup()
-		node := &nodes.Items[0]
-		cmd := "iptables-save"
-		if framework.TestContext.ClusterIsIPv6() {
-			cmd = "ip6tables-save"
-		}
-		err = wait.PollImmediate(framework.Poll, e2eservice.KubeProxyLagTimeout, func() (bool, error) {
-			framework.Logf("Executing cmd %q on node %v", cmd, node.Name)
-			result, err := hostExec.IssueCommandWithResult(cmd, node)
-			if err != nil {
-				framework.Logf("Interrogation of iptables rules failed on node %v", node.Name)
-				return false, nil
-			}
-
-			for _, line := range strings.Split(result, "\n") {
-				if strings.Contains(line, "-A KUBE-SERVICES") && strings.Contains(line, "-p sctp") {
-					return true, nil
-				}
-			}
-			framework.Logf("retrying ... no iptables rules found for service with sctp ports on node %v", node.Name)
-			return false, nil
-		})
-		if err != nil {
-			framework.Failf("iptables rules are not set for a clusterip service with sctp ports")
-		}
-		ginkgo.By("validating sctp module is still not loaded")
-		sctpLoadedAtEnd := CheckSCTPModuleLoadedOnNodes(f, nodes)
-		if !sctpLoadedAtStart && sctpLoadedAtEnd {
-			framework.Failf("The state of the sctp module has changed due to the test case")
-		}
-	})
-	End testing
-	*/
-
 	ginkgo.It("should allow creating Pods, Services and NetworkPolicies with SCTP ports", func() {
-		endpointserviceName := "sctp-endpoint-test"
+		endpointServiceName := "sctp-endpoint-test"
 		ns := f.Namespace.Name
-		jig := e2eservice.NewTestJig(cs, ns, serviceName)
+		jig := e2eservice.NewTestJig(cs, ns, endpointServiceName)
 
 		ginkgo.By("getting the state of the sctp module on nodes")
 		nodes, err := e2enode.GetReadySchedulableNodes(cs)
 		framework.ExpectNoError(err)
 		sctpLoadedAtStart := CheckSCTPModuleLoadedOnNodes(f, nodes)
 
-		ginkgo.By("creating service " + endpointserviceName + " in namespace " + ns)
+		ginkgo.By("creating service " + endpointServiceName + " in namespace " + ns)
 		_, err = jig.CreateSCTPServiceWithPort(nil, 5060)
 		framework.ExpectNoError(err)
 		defer func() {
-			err := cs.CoreV1().Services(ns).Delete(context.TODO(), endpointserviceName, metav1.DeleteOptions{})
-			framework.ExpectNoError(err, "failed to delete service: %s in namespace: %s", serviceName, ns)
+			err := cs.CoreV1().Services(ns).Delete(context.TODO(), endpointServiceName, metav1.DeleteOptions{})
+			framework.ExpectNoError(err, "failed to delete service: %s in namespace: %s", endpointServiceName, ns)
 		}()
 
-		err = e2enetwork.WaitForService(f.ClientSet, ns, serviceName, true, 5*time.Second, e2eservice.TestTimeout)
-		framework.ExpectNoError(err, fmt.Sprintf("error while waiting for service:%s err: %v", serviceName, err))
+		err = e2enetwork.WaitForService(f.ClientSet, ns, endpointServiceName, true, 5*time.Second, e2eservice.TestTimeout)
+		framework.ExpectNoError(err, fmt.Sprintf("error while waiting for service:%s err: %v", endpointServiceName, err))
 
 		ginkgo.By("validating endpoints do not exist yet")
-		validateEndpointsPortsOrFail(cs, ns, serviceName, portsByPodName{})
+		validateEndpointsPortsOrFail(cs, ns, endpointServiceName, portsByPodName{})
 
 		ginkgo.By("creating a pod for the service")
 		names := map[string]bool{}
@@ -3383,13 +3209,13 @@ var _ = common.SIGDescribe("SCTP [LinuxOnly]", func() {
 		}()
 
 		ginkgo.By("validating endpoints exists")
-		validateEndpointsPortsOrFail(cs, ns, serviceName, portsByPodName{name1: {5060}})
+		validateEndpointsPortsOrFail(cs, ns, endpointServiceName, portsByPodName{name1: {5060}})
 
 		ginkgo.By("deleting the pod")
 		e2epod.DeletePodOrFail(cs, ns, name1)
 		delete(names, name1)
 		ginkgo.By("validating endpoints do not exist anymore")
-		validateEndpointsPortsOrFail(cs, ns, serviceName, portsByPodName{})
+		validateEndpointsPortsOrFail(cs, ns, endpointServiceName, portsByPodName{})
 
 		ginkgo.By("creating a pod with hostport on the selected node")
 		// Pick the first node from all schedulable nodes
@@ -3407,25 +3233,25 @@ var _ = common.SIGDescribe("SCTP [LinuxOnly]", func() {
 			framework.ExpectNoError(err, "failed to delete pod: %s in namespace: %s", podName, f.Namespace.Name)
 		}()
 
-		clusterIPserviceName := "sctp-clusterip"
+		clusterIPServiceName := "sctp-clusterip"
+		jig = e2eservice.NewTestJig(cs, ns, clusterIPServiceName)
 
-		//ginkgo.By("getting the state of the sctp module on nodes")
 		nodes, err = e2enode.GetReadySchedulableNodes(cs)
 		framework.ExpectNoError(err)
 
-		ginkgo.By("creating service " + clusterIPserviceName + " in namespace " + ns)
+		ginkgo.By("creating service " + clusterIPServiceName + " in namespace " + ns)
 		_, err = jig.CreateSCTPServiceWithPort(func(svc *v1.Service) {
 			svc.Spec.Type = v1.ServiceTypeClusterIP
 			svc.Spec.Ports = []v1.ServicePort{{Protocol: v1.ProtocolSCTP, Port: 5060}}
 		}, 5060)
 		framework.ExpectNoError(err)
 		defer func() {
-			err := cs.CoreV1().Services(ns).Delete(context.TODO(), clusterIPserviceName, metav1.DeleteOptions{})
-			framework.ExpectNoError(err, "failed to delete service: %s in namespace: %s", serviceName, ns)
+			err := cs.CoreV1().Services(ns).Delete(context.TODO(), clusterIPServiceName, metav1.DeleteOptions{})
+			framework.ExpectNoError(err, "failed to delete service: %s in namespace: %s", clusterIPServiceName, ns)
 		}()
 
-		err = e2enetwork.WaitForService(f.ClientSet, ns, serviceName, true, 5*time.Second, e2eservice.TestTimeout)
-		framework.ExpectNoError(err, fmt.Sprintf("error while waiting for service:%s err: %v", serviceName, err))
+		err = e2enetwork.WaitForService(f.ClientSet, ns, clusterIPServiceName, true, 5*time.Second, e2eservice.TestTimeout)
+		framework.ExpectNoError(err, fmt.Sprintf("error while waiting for service:%s err: %v", clusterIPServiceName, err))
 
 		ginkgo.By("validating sctp module is still not loaded")
 		sctpLoadedAtEnd := CheckSCTPModuleLoadedOnNodes(f, nodes)

--- a/test/e2e/network/service.go
+++ b/test/e2e/network/service.go
@@ -3170,7 +3170,7 @@ var _ = common.SIGDescribe("SCTP [LinuxOnly]", func() {
 		cs = f.ClientSet
 	})
 
-	ginkgo.It("should allow creating Pods, Services and NetworkPolicies with SCTP ports", func() {
+	ginkgo.It("should allow creating Pods and Services with SCTP ports", func() {
 		endpointServiceName := "sctp-endpoint-test"
 		ns := f.Namespace.Name
 		jig := e2eservice.NewTestJig(cs, ns, endpointServiceName)
@@ -3232,26 +3232,6 @@ var _ = common.SIGDescribe("SCTP [LinuxOnly]", func() {
 			err := cs.CoreV1().Pods(f.Namespace.Name).Delete(context.TODO(), podName, metav1.DeleteOptions{})
 			framework.ExpectNoError(err, "failed to delete pod: %s in namespace: %s", podName, f.Namespace.Name)
 		}()
-
-		clusterIPServiceName := "sctp-clusterip"
-		jig = e2eservice.NewTestJig(cs, ns, clusterIPServiceName)
-
-		nodes, err = e2enode.GetReadySchedulableNodes(cs)
-		framework.ExpectNoError(err)
-
-		ginkgo.By("creating service " + clusterIPServiceName + " in namespace " + ns)
-		_, err = jig.CreateSCTPServiceWithPort(func(svc *v1.Service) {
-			svc.Spec.Type = v1.ServiceTypeClusterIP
-			svc.Spec.Ports = []v1.ServicePort{{Protocol: v1.ProtocolSCTP, Port: 5060}}
-		}, 5060)
-		framework.ExpectNoError(err)
-		defer func() {
-			err := cs.CoreV1().Services(ns).Delete(context.TODO(), clusterIPServiceName, metav1.DeleteOptions{})
-			framework.ExpectNoError(err, "failed to delete service: %s in namespace: %s", clusterIPServiceName, ns)
-		}()
-
-		err = e2enetwork.WaitForService(f.ClientSet, ns, clusterIPServiceName, true, 5*time.Second, e2eservice.TestTimeout)
-		framework.ExpectNoError(err, fmt.Sprintf("error while waiting for service:%s err: %v", clusterIPServiceName, err))
 
 		ginkgo.By("validating sctp module is still not loaded")
 		sctpLoadedAtEnd := CheckSCTPModuleLoadedOnNodes(f, nodes)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This PR addresses bullet **II** as mentioned in issue #96717 and cleans up the test in `test/e2e/network/service.go` with regards to the `Feature:SCTP` test.

#### Which issue(s) this PR fixes:

Fixes part of #96717

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
