### PR TITLE
Get Content-Length from http header to avoid unnecessary I/O operation

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/rest.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/rest.go
@@ -24,6 +24,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/url"
+	"strconv"
 	"strings"
 	"time"
 
@@ -435,6 +436,14 @@ func summarizeData(data []byte, maxLength int) string {
 
 func limitedReadBody(req *http.Request, limit int64) ([]byte, error) {
 	defer req.Body.Close()
+
+	// Get Content-Length from header to avoid unnecessary I/O operation
+	if contentLength, err := strconv.Atoi(req.Header.Get("Content-Length")); err == nil {
+		if int64(contentLength) > limit {
+			return nil, errors.NewRequestEntityTooLargeError(fmt.Sprintf("limit is %d", limit))
+		}
+	}
+
 	if limit <= 0 {
 		return ioutil.ReadAll(req.Body)
 	}


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
ioutil.ReadAll(lr) could take up to 2 seconds during our performance tests when the cluster is under heavy load.
Get Content-Length from http header and compare it to the limit can save us one heavy ReadAll operation.

Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
Get Content-Length from header in limitedReadBody to avoid unnecessary I/O operation
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs

```
