### PR TITLE
test: e2e: HPA ContainerResource

### DIFF
--- a/test/e2e/autoscaling/autoscaling_timer.go
+++ b/test/e2e/autoscaling/autoscaling_timer.go
@@ -21,7 +21,7 @@ import (
 	"strings"
 	"time"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2eautoscaling "k8s.io/kubernetes/test/e2e/framework/autoscaling"
@@ -96,7 +96,7 @@ var _ = SIGDescribe("[Feature:ClusterSizeAutoscalingScaleUp] [Slow] Autoscaling"
 				nodeMemoryMB := (&nodeMemoryBytes).Value() / 1024 / 1024
 				memRequestMB := nodeMemoryMB / 10 // Ensure each pod takes not more than 10% of node's allocatable memory.
 				replicas := 1
-				resourceConsumer := e2eautoscaling.NewDynamicResourceConsumer("resource-consumer", f.Namespace.Name, e2eautoscaling.KindDeployment, replicas, 0, 0, 0, cpuRequestMillis, memRequestMB, f.ClientSet, f.ScalesGetter)
+				resourceConsumer := e2eautoscaling.NewDynamicResourceConsumer("resource-consumer", f.Namespace.Name, e2eautoscaling.KindDeployment, replicas, 0, 0, 0, cpuRequestMillis, memRequestMB, f.ClientSet, f.ScalesGetter, e2eautoscaling.Disable, e2eautoscaling.Idle)
 				defer resourceConsumer.CleanUp()
 				resourceConsumer.WaitForReplicas(replicas, 1*time.Minute) // Should finish ~immediately, so 1 minute is more than enough.
 

--- a/test/e2e/autoscaling/horizontal_pod_autoscaling.go
+++ b/test/e2e/autoscaling/horizontal_pod_autoscaling.go
@@ -91,6 +91,18 @@ var _ = SIGDescribe("[Feature:HPA] Horizontal pod autoscaling (scale resource: C
 			scaleTest.run("rc-light", e2eautoscaling.KindRC, f)
 		})
 	})
+
+	ginkgo.Describe("[Serial] [Slow] ReplicaSet with idle sidecar (ContainerResource use case)", func() {
+		// ContainerResource CPU autoscaling on idle sidecar
+		ginkgo.It(titleUp+" on a busy application with an idle sidecar container", func() {
+			scaleOnIdleSideCar("rs", e2eautoscaling.KindReplicaSet, false, f)
+		})
+
+		// ContainerResource CPU autoscaling on busy sidecar
+		ginkgo.It("Should not scale up on a busy sidecar with an idle application", func() {
+			doNotScaleOnBusySidecar("rs", e2eautoscaling.KindReplicaSet, true, f)
+		})
+	})
 })
 
 // HPAScaleTest struct is used by the scale(...) function.
@@ -114,7 +126,7 @@ type HPAScaleTest struct {
 // TODO The use of 3 states is arbitrary, we could eventually make this test handle "n" states once this test stabilizes.
 func (scaleTest *HPAScaleTest) run(name string, kind schema.GroupVersionKind, f *framework.Framework) {
 	const timeToWait = 15 * time.Minute
-	rc := e2eautoscaling.NewDynamicResourceConsumer(name, f.Namespace.Name, kind, scaleTest.initPods, scaleTest.totalInitialCPUUsage, 0, 0, scaleTest.perPodCPURequest, 200, f.ClientSet, f.ScalesGetter)
+	rc := e2eautoscaling.NewDynamicResourceConsumer(name, f.Namespace.Name, kind, scaleTest.initPods, scaleTest.totalInitialCPUUsage, 0, 0, scaleTest.perPodCPURequest, 200, f.ClientSet, f.ScalesGetter, e2eautoscaling.Disable, e2eautoscaling.Idle)
 	defer rc.CleanUp()
 	hpa := e2eautoscaling.CreateCPUHorizontalPodAutoscaler(rc, scaleTest.targetCPUUtilizationPercent, scaleTest.minPods, scaleTest.maxPods)
 	defer e2eautoscaling.DeleteHorizontalPodAutoscaler(rc, hpa.Name)
@@ -165,6 +177,91 @@ func scaleDown(name string, kind schema.GroupVersionKind, checkStability bool, f
 		firstScaleStasis:            stasis,
 		cpuBurst:                    10,
 		secondScale:                 1,
+	}
+	scaleTest.run(name, kind, f)
+}
+
+type HPAContainerResourceScaleTest struct {
+	initPods                    int
+	totalInitialCPUUsage        int
+	perContainerCPURequest      int64
+	targetCPUUtilizationPercent int32
+	minPods                     int32
+	maxPods                     int32
+	noScale                     bool
+	noScaleStasis               time.Duration
+	firstScale                  int
+	firstScaleStasis            time.Duration
+	cpuBurst                    int
+	secondScale                 int32
+	sidecarStatus               e2eautoscaling.SidecarStatusType
+	sidecarType                 e2eautoscaling.SidecarWorkloadType
+}
+
+func (scaleTest *HPAContainerResourceScaleTest) run(name string, kind schema.GroupVersionKind, f *framework.Framework) {
+	const timeToWait = 15 * time.Minute
+	rc := e2eautoscaling.NewDynamicResourceConsumer(name, f.Namespace.Name, kind, scaleTest.initPods, scaleTest.totalInitialCPUUsage, 0, 0, scaleTest.perContainerCPURequest, 200, f.ClientSet, f.ScalesGetter, scaleTest.sidecarStatus, scaleTest.sidecarType)
+	defer rc.CleanUp()
+	hpa := e2eautoscaling.CreateContainerResourceCPUHorizontalPodAutoscaler(rc, scaleTest.targetCPUUtilizationPercent, scaleTest.minPods, scaleTest.maxPods)
+	defer e2eautoscaling.DeleteContainerResourceHPA(rc, hpa.Name)
+
+	if scaleTest.noScale {
+		if scaleTest.noScaleStasis > 0 {
+			rc.EnsureDesiredReplicasInRange(scaleTest.initPods, scaleTest.initPods, scaleTest.noScaleStasis, hpa.Name)
+		}
+	} else {
+		rc.WaitForReplicas(scaleTest.firstScale, timeToWait)
+		if scaleTest.firstScaleStasis > 0 {
+			rc.EnsureDesiredReplicasInRange(scaleTest.firstScale, scaleTest.firstScale+1, scaleTest.firstScaleStasis, hpa.Name)
+		}
+		if scaleTest.cpuBurst > 0 && scaleTest.secondScale > 0 {
+			rc.ConsumeCPU(scaleTest.cpuBurst)
+			rc.WaitForReplicas(int(scaleTest.secondScale), timeToWait)
+		}
+	}
+}
+
+func scaleOnIdleSideCar(name string, kind schema.GroupVersionKind, checkStability bool, f *framework.Framework) {
+	// Scale up on a busy application with an idle sidecar container
+	stasis := 0 * time.Minute
+	if checkStability {
+		stasis = 10 * time.Minute
+	}
+	scaleTest := &HPAContainerResourceScaleTest{
+		initPods:                    1,
+		totalInitialCPUUsage:        250,
+		perContainerCPURequest:      500,
+		targetCPUUtilizationPercent: 20,
+		minPods:                     1,
+		maxPods:                     5,
+		firstScale:                  3,
+		firstScaleStasis:            stasis,
+		cpuBurst:                    700,
+		secondScale:                 5,
+		sidecarStatus:               e2eautoscaling.Enable,
+		sidecarType:                 e2eautoscaling.Idle,
+	}
+	scaleTest.run(name, kind, f)
+}
+
+func doNotScaleOnBusySidecar(name string, kind schema.GroupVersionKind, checkStability bool, f *framework.Framework) {
+	// Do not scale up on a busy sidecar with an idle application
+	stasis := 0 * time.Minute
+	if checkStability {
+		stasis = 1 * time.Minute
+	}
+	scaleTest := &HPAContainerResourceScaleTest{
+		initPods:                    1,
+		totalInitialCPUUsage:        250,
+		perContainerCPURequest:      500,
+		targetCPUUtilizationPercent: 20,
+		minPods:                     1,
+		maxPods:                     5,
+		cpuBurst:                    700,
+		sidecarStatus:               e2eautoscaling.Enable,
+		sidecarType:                 e2eautoscaling.Busy,
+		noScale:                     true,
+		noScaleStasis:               stasis,
 	}
 	scaleTest.run(name, kind, f)
 }

--- a/test/e2e/instrumentation/monitoring/stackdriver.go
+++ b/test/e2e/instrumentation/monitoring/stackdriver.go
@@ -103,7 +103,7 @@ func testStackdriverMonitoring(f *framework.Framework, pods, allPodsCPU int, per
 
 	framework.ExpectNoError(err)
 
-	rc := e2eautoscaling.NewDynamicResourceConsumer(rcName, f.Namespace.Name, e2eautoscaling.KindDeployment, pods, allPodsCPU, memoryUsed, 0, perPodCPU, memoryLimit, f.ClientSet, f.ScalesGetter)
+	rc := e2eautoscaling.NewDynamicResourceConsumer(rcName, f.Namespace.Name, e2eautoscaling.KindDeployment, pods, allPodsCPU, memoryUsed, 0, perPodCPU, memoryLimit, f.ClientSet, f.ScalesGetter, e2eautoscaling.Disable, e2eautoscaling.Idle)
 	defer rc.CleanUp()
 
 	rc.WaitForReplicas(pods, 15*time.Minute)

--- a/test/e2e/upgrades/autoscaling/horizontal_pod_autoscalers.go
+++ b/test/e2e/upgrades/autoscaling/horizontal_pod_autoscalers.go
@@ -50,7 +50,9 @@ func (t *HPAUpgradeTest) Setup(f *framework.Framework) {
 		500, /* cpuLimit */
 		200, /* memLimit */
 		f.ClientSet,
-		f.ScalesGetter)
+		f.ScalesGetter,
+		e2eautoscaling.Disable,
+		e2eautoscaling.Idle)
 	t.hpa = e2eautoscaling.CreateCPUHorizontalPodAutoscaler(
 		t.rc,
 		20, /* targetCPUUtilizationPercent */

--- a/test/utils/runners.go
+++ b/test/utils/runners.go
@@ -181,6 +181,9 @@ type RCConfig struct {
 	ConfigMapNames []string
 
 	ServiceAccountTokenProjections int
+
+	//Additional containers to run in the pod
+	AdditionalContainers []v1.Container
 }
 
 func (rc *RCConfig) RCConfigLog(fmt string, args ...interface{}) {
@@ -343,6 +346,10 @@ func (config *DeploymentConfig) create() error {
 		},
 	}
 
+	if len(config.AdditionalContainers) > 0 {
+		deployment.Spec.Template.Spec.Containers = append(deployment.Spec.Template.Spec.Containers, config.AdditionalContainers...)
+	}
+
 	if len(config.SecretNames) > 0 {
 		attachSecrets(&deployment.Spec.Template, config.SecretNames)
 	}
@@ -423,6 +430,10 @@ func (config *ReplicaSetConfig) create() error {
 				},
 			},
 		},
+	}
+
+	if len(config.AdditionalContainers) > 0 {
+		rs.Spec.Template.Spec.Containers = append(rs.Spec.Template.Spec.Containers, config.AdditionalContainers...)
 	}
 
 	if len(config.SecretNames) > 0 {
@@ -616,6 +627,10 @@ func (config *RCConfig) create() error {
 				},
 			},
 		},
+	}
+
+	if len(config.AdditionalContainers) > 0 {
+		rc.Spec.Template.Spec.Containers = append(rc.Spec.Template.Spec.Containers, config.AdditionalContainers...)
 	}
 
 	if len(config.SecretNames) > 0 {


### PR DESCRIPTION
This add e2e test for HPA ContainerResource metrics. This add test to cover two scenarios
1. Scale up on a busy application with an idle sidecar container
2. Do not scale up on a busy sidecar with an idle application.

Signed-off-by: Vivek Singh <svivekkumar@vmware.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

This PR add e2e testing for testing ContainerResource feature of HPA. This is required for HPA v2beat2 graduation to stable.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes: #102374

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
