### PR TITLE
WIP Tcp conntrack

### DIFF
--- a/pkg/proxy/service.go
+++ b/pkg/proxy/service.go
@@ -309,15 +309,15 @@ type UpdateServiceMapResult struct {
 	// HCServiceNodePorts is a map of Service names to node port numbers which indicate the health of that Service on this Node.
 	// The value(uint16) of HCServices map is the service health check node port.
 	HCServiceNodePorts map[types.NamespacedName]uint16
-	// UDPStaleClusterIP holds stale (no longer assigned to a Service) Service IPs that had UDP ports.
+	// StaleClusterIP holds stale (no longer assigned to a Service) Service IPs that had UDP ports.
 	// Callers can use this to abort timeout-waits or clear connection-tracking information.
-	UDPStaleClusterIP sets.String
+	StaleClusterIP map[string]v1.Protocol
 }
 
 // Update updates ServiceMap base on the given changes.
 func (sm ServiceMap) Update(changes *ServiceChangeTracker) (result UpdateServiceMapResult) {
-	result.UDPStaleClusterIP = sets.NewString()
-	sm.apply(changes, result.UDPStaleClusterIP)
+	result.StaleClusterIP = map[string]v1.Protocol{}
+	sm.apply(changes, result.StaleClusterIP)
 
 	// TODO: If this will appear to be computationally expensive, consider
 	// computing this incrementally similarly to serviceMap.
@@ -366,10 +366,10 @@ func (sct *ServiceChangeTracker) serviceToServiceMap(service *v1.Service) Servic
 	return serviceMap
 }
 
-// apply the changes to ServiceMap and update the stale udp cluster IP set. The UDPStaleClusterIP argument is passed in to store the
+// apply the changes to ServiceMap and update the stale udp cluster IP set. The StaleClusterIP argument is passed in to store the
 // udp protocol service cluster ip when service is deleted from the ServiceMap.
 // apply triggers processServiceMapChange on every change.
-func (sm *ServiceMap) apply(changes *ServiceChangeTracker, UDPStaleClusterIP sets.String) {
+func (sm *ServiceMap) apply(changes *ServiceChangeTracker, StaleClusterIP map[string]v1.Protocol) {
 	changes.lock.Lock()
 	defer changes.lock.Unlock()
 	for _, change := range changes.items {
@@ -380,7 +380,7 @@ func (sm *ServiceMap) apply(changes *ServiceChangeTracker, UDPStaleClusterIP set
 		// filter out the Update event of current changes from previous changes before calling unmerge() so that can
 		// skip deleting the Update events.
 		change.previous.filter(change.current)
-		sm.unmerge(change.previous, UDPStaleClusterIP)
+		sm.unmerge(change.previous, StaleClusterIP)
 	}
 	// clear changes after applying them to ServiceMap.
 	changes.items = make(map[types.NamespacedName]*serviceChange)
@@ -432,16 +432,14 @@ func (sm *ServiceMap) filter(other ServiceMap) {
 	}
 }
 
-// unmerge deletes all other ServiceMap's elements from current ServiceMap.  We pass in the UDPStaleClusterIP strings sets
-// for storing the stale udp service cluster IPs. We will clear stale udp connection base on UDPStaleClusterIP later
-func (sm *ServiceMap) unmerge(other ServiceMap, UDPStaleClusterIP sets.String) {
+// unmerge deletes all other ServiceMap's elements from current ServiceMap.  We pass in the StaleClusterIP strings sets
+// for storing the stale udp service cluster IPs. We will clear stale udp connection base on StaleClusterIP later
+func (sm *ServiceMap) unmerge(other ServiceMap, StaleClusterIP map[string]v1.Protocol) {
 	for svcPortName := range other {
 		info, exists := (*sm)[svcPortName]
 		if exists {
 			klog.V(1).Infof("Removing service port %q", svcPortName)
-			if info.Protocol() == v1.ProtocolUDP {
-				UDPStaleClusterIP.Insert(info.ClusterIP().String())
-			}
+			StaleClusterIP[info.ClusterIP().String()] = info.Protocol()
 			delete(*sm, svcPortName)
 		} else {
 			klog.Errorf("Service port %q doesn't exists", svcPortName)


### PR DESCRIPTION
/kind bug

kube-proxy was always deleting stale conntrack entries for stateless protocols, like UDP and SCTP, since TCP clients retries with different source ports and eventually the stale entries timeout.
However, on TCP clients with a low number of source ports, the stale entries can also blackhole connections, so we need to delete them too.

However, we should be careful deleting conntrack entries, since it can break TCP graceful shutdown, i.e. pods are still using the connection despite the endpoint is no longer present in kube-proxy. To avoid that, we delete only conntrack entries with the SYN_SENT status.


Fixes #101607

```release-note
kube-proxy was deleting stale conntrack entries for stateless protocols, like UDP and SCTP. However, on TCP clients with a low number of source ports, the stale entries can also blackhole connections, so we delete them too.
```