### PR TITLE
kubeadm: allow imageName to be specified in kubeadm configuration

### DIFF
--- a/cmd/kubeadm/app/apis/kubeadm/types.go
+++ b/cmd/kubeadm/app/apis/kubeadm/types.go
@@ -181,7 +181,9 @@ type ImageMeta struct {
 	// In case this value is set, kubeadm does not change automatically the version of the above components during upgrades.
 	ImageTag string
 
-	//TODO: evaluate if we need also a ImageName based on user feedbacks
+	// ImageName allows to specify an exact name of the image.
+	// if not set, the ImageName defined in a constants.go will be used instead.
+	ImageName string
 }
 
 // APIEndpoint struct contains elements of API server instance deployed on a node.

--- a/cmd/kubeadm/app/apis/kubeadm/v1beta2/doc.go
+++ b/cmd/kubeadm/app/apis/kubeadm/v1beta2/doc.go
@@ -188,6 +188,7 @@ limitations under the License.
 // 	  local:
 // 	    imageRepository: "k8s.gcr.io"
 // 	    imageTag: "3.2.24"
+//	    imageName: "etcd"
 // 	    dataDir: "/var/lib/etcd"
 // 	    extraArgs:
 // 	      listen-client-urls: "http://10.100.0.1:2379"

--- a/cmd/kubeadm/app/apis/kubeadm/v1beta2/types.go
+++ b/cmd/kubeadm/app/apis/kubeadm/v1beta2/types.go
@@ -163,7 +163,9 @@ type ImageMeta struct {
 	// In case this value is set, kubeadm does not change automatically the version of the above components during upgrades.
 	ImageTag string `json:"imageTag,omitempty"`
 
-	//TODO: evaluate if we need also a ImageName based on user feedbacks
+	// ImageName allows to specify an exact name of the image.
+	// if not set, the ImageName defined in a constants.go will be used instead.
+	ImageName string `json:"imageName,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/cmd/kubeadm/app/apis/kubeadm/v1beta2/zz_generated.conversion.go
+++ b/cmd/kubeadm/app/apis/kubeadm/v1beta2/zz_generated.conversion.go
@@ -605,6 +605,7 @@ func Convert_kubeadm_HostPathMount_To_v1beta2_HostPathMount(in *kubeadm.HostPath
 func autoConvert_v1beta2_ImageMeta_To_kubeadm_ImageMeta(in *ImageMeta, out *kubeadm.ImageMeta, s conversion.Scope) error {
 	out.ImageRepository = in.ImageRepository
 	out.ImageTag = in.ImageTag
+	out.ImageName = in.ImageName
 	return nil
 }
 
@@ -616,6 +617,7 @@ func Convert_v1beta2_ImageMeta_To_kubeadm_ImageMeta(in *ImageMeta, out *kubeadm.
 func autoConvert_kubeadm_ImageMeta_To_v1beta2_ImageMeta(in *kubeadm.ImageMeta, out *ImageMeta, s conversion.Scope) error {
 	out.ImageRepository = in.ImageRepository
 	out.ImageTag = in.ImageTag
+	out.ImageName = in.ImageName
 	return nil
 }
 

--- a/cmd/kubeadm/app/apis/kubeadm/v1beta3/doc.go
+++ b/cmd/kubeadm/app/apis/kubeadm/v1beta3/doc.go
@@ -189,6 +189,7 @@ limitations under the License.
 // 	  local:
 // 	    imageRepository: "k8s.gcr.io"
 // 	    imageTag: "3.2.24"
+//	    imageName: "etcd"
 // 	    dataDir: "/var/lib/etcd"
 // 	    extraArgs:
 // 	      listen-client-urls: "http://10.100.0.1:2379"

--- a/cmd/kubeadm/app/apis/kubeadm/v1beta3/types.go
+++ b/cmd/kubeadm/app/apis/kubeadm/v1beta3/types.go
@@ -178,7 +178,9 @@ type ImageMeta struct {
 	// +optional
 	ImageTag string `json:"imageTag,omitempty"`
 
-	//TODO: evaluate if we need also a ImageName based on user feedbacks
+	// ImageName allows to specify an exact name of the image.
+	// if not set, the ImageName defined in a constants.go will be used instead.
+	ImageName string `json:"imageName,omitempty"`
 }
 
 // APIEndpoint struct contains elements of API server instance deployed on a node.

--- a/cmd/kubeadm/app/apis/kubeadm/v1beta3/zz_generated.conversion.go
+++ b/cmd/kubeadm/app/apis/kubeadm/v1beta3/zz_generated.conversion.go
@@ -598,6 +598,7 @@ func Convert_kubeadm_HostPathMount_To_v1beta3_HostPathMount(in *kubeadm.HostPath
 func autoConvert_v1beta3_ImageMeta_To_kubeadm_ImageMeta(in *ImageMeta, out *kubeadm.ImageMeta, s conversion.Scope) error {
 	out.ImageRepository = in.ImageRepository
 	out.ImageTag = in.ImageTag
+	out.ImageName = in.ImageName
 	return nil
 }
 
@@ -609,6 +610,7 @@ func Convert_v1beta3_ImageMeta_To_kubeadm_ImageMeta(in *ImageMeta, out *kubeadm.
 func autoConvert_kubeadm_ImageMeta_To_v1beta3_ImageMeta(in *kubeadm.ImageMeta, out *ImageMeta, s conversion.Scope) error {
 	out.ImageRepository = in.ImageRepository
 	out.ImageTag = in.ImageTag
+	out.ImageName = in.ImageName
 	return nil
 }
 

--- a/cmd/kubeadm/app/images/images.go
+++ b/cmd/kubeadm/app/images/images.go
@@ -58,7 +58,14 @@ func GetDNSImage(cfg *kubeadmapi.ClusterConfiguration) string {
 	if cfg.DNS.ImageTag != "" {
 		dnsImageTag = cfg.DNS.ImageTag
 	}
-	return GetGenericImage(dnsImageRepository, constants.CoreDNSImageName, dnsImageTag)
+
+	// DNS uses default image name by default
+	dnsImageName := constants.CoreDNSImageName
+	if cfg.DNS.ImageName != "" {
+		dnsImageName = cfg.DNS.ImageName
+	}
+
+	return GetGenericImage(dnsImageRepository, dnsImageName, dnsImageTag)
 }
 
 // GetEtcdImage generates and returns the image for etcd
@@ -82,7 +89,14 @@ func GetEtcdImage(cfg *kubeadmapi.ClusterConfiguration) string {
 	if cfg.Etcd.Local != nil && cfg.Etcd.Local.ImageTag != "" {
 		etcdImageTag = cfg.Etcd.Local.ImageTag
 	}
-	return GetGenericImage(etcdImageRepository, constants.Etcd, etcdImageTag)
+
+	// Etcd uses default image name by default
+	etcdImageName := constants.Etcd
+	if cfg.Etcd.Local != nil && cfg.Etcd.Local.ImageName != "" {
+		etcdImageName = cfg.Etcd.Local.ImageName
+	}
+
+	return GetGenericImage(etcdImageRepository, etcdImageName, etcdImageTag)
 }
 
 // GetControlPlaneImages returns a list of container images kubeadm expects to use on a control plane node

--- a/cmd/kubeadm/app/images/images_test.go
+++ b/cmd/kubeadm/app/images/images_test.go
@@ -132,6 +132,20 @@ func TestGetEtcdImage(t *testing.T) {
 			expected: "override/etcd:3.3.17-0",
 		},
 		{
+			cfg: &kubeadmapi.ClusterConfiguration{
+				ImageRepository:   "real.repo",
+				KubernetesVersion: "1.16.0",
+				Etcd: kubeadmapi.Etcd{
+					Local: &kubeadmapi.LocalEtcd{
+						ImageMeta: kubeadmapi.ImageMeta{
+							ImageName: "override",
+						},
+					},
+				},
+			},
+			expected: "real.repo/override:3.3.17-0",
+		},
+		{
 			expected: GetGenericImage(gcrPrefix, "etcd", constants.DefaultEtcdVersion),
 			cfg: &kubeadmapi.ClusterConfiguration{
 				ImageRepository:   gcrPrefix,


### PR DESCRIPTION
The ability to specify a specific image name to be used for kubeadm config
is useful in case other components that kubeadm depended on decided to
rename its image.

Signed-off-by: Thomas Tanaka <thomas.tanaka@oracle.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
/kind regression

<!--
Add one of the following kinds:
/kind feature
/kind regression

-->

#### What this PR does / why we need it:
The ability to specify an image name will be useful as other components
that kubeadm do not have a direct control of might decided to change its
image name, e.g in k8s 1.21.1 coredns image is named as "coredns/coredns".

#### Does this PR introduce a user-facing change?
```
release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```
docs

```
