### PR TITLE
test/integration: Rename master to controlplane

### DIFF
--- a/test/integration/apiserver/apiserver_test.go
+++ b/test/integration/apiserver/apiserver_test.go
@@ -75,15 +75,15 @@ func setup(t *testing.T, groupVersions ...schema.GroupVersion) (*httptest.Server
 	return setupWithResources(t, groupVersions, nil)
 }
 
-func setupWithOptions(t *testing.T, opts *framework.MasterConfigOptions, groupVersions ...schema.GroupVersion) (*httptest.Server, clientset.Interface, framework.CloseFunc) {
+func setupWithOptions(t *testing.T, opts *framework.ControlPlaneConfigOptions, groupVersions ...schema.GroupVersion) (*httptest.Server, clientset.Interface, framework.CloseFunc) {
 	return setupWithResourcesWithOptions(t, opts, groupVersions, nil)
 }
 
 func setupWithResources(t *testing.T, groupVersions []schema.GroupVersion, resources []schema.GroupVersionResource) (*httptest.Server, clientset.Interface, framework.CloseFunc) {
-	return setupWithResourcesWithOptions(t, &framework.MasterConfigOptions{}, groupVersions, resources)
+	return setupWithResourcesWithOptions(t, &framework.ControlPlaneConfigOptions{}, groupVersions, resources)
 }
 
-func setupWithResourcesWithOptions(t *testing.T, opts *framework.MasterConfigOptions, groupVersions []schema.GroupVersion, resources []schema.GroupVersionResource) (*httptest.Server, clientset.Interface, framework.CloseFunc) {
+func setupWithResourcesWithOptions(t *testing.T, opts *framework.ControlPlaneConfigOptions, groupVersions []schema.GroupVersion, resources []schema.GroupVersionResource) (*httptest.Server, clientset.Interface, framework.CloseFunc) {
 	controlPlaneConfig := framework.NewIntegrationTestControlPlaneConfigWithOptions(opts)
 	if len(groupVersions) > 0 || len(resources) > 0 {
 		resourceConfig := controlplane.DefaultAPIResourceConfigSource()
@@ -224,7 +224,7 @@ func Test4xxStatusCodeInvalidPatch(t *testing.T) {
 }
 
 func TestCacheControl(t *testing.T) {
-	controlPlaneConfig := framework.NewIntegrationTestControlPlaneConfigWithOptions(&framework.MasterConfigOptions{})
+	controlPlaneConfig := framework.NewIntegrationTestControlPlaneConfigWithOptions(&framework.ControlPlaneConfigOptions{})
 	controlPlaneConfig.GenericConfig.OpenAPIConfig = framework.DefaultOpenAPIConfig()
 	master, _, closeFn := framework.RunAnAPIServer(controlPlaneConfig)
 	defer closeFn()
@@ -331,7 +331,7 @@ func TestListOptions(t *testing.T) {
 			defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.APIListChunking, true)()
 			etcdOptions := framework.DefaultEtcdOptions()
 			etcdOptions.EnableWatchCache = watchCacheEnabled
-			s, clientSet, closeFn := setupWithOptions(t, &framework.MasterConfigOptions{EtcdOptions: etcdOptions})
+			s, clientSet, closeFn := setupWithOptions(t, &framework.ControlPlaneConfigOptions{EtcdOptions: etcdOptions})
 			defer closeFn()
 
 			ns := framework.CreateTestingNamespace("list-options", s, t)
@@ -563,7 +563,7 @@ func TestListResourceVersion0(t *testing.T) {
 			defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.APIListChunking, true)()
 			etcdOptions := framework.DefaultEtcdOptions()
 			etcdOptions.EnableWatchCache = tc.watchCacheEnabled
-			s, clientSet, closeFn := setupWithOptions(t, &framework.MasterConfigOptions{EtcdOptions: etcdOptions})
+			s, clientSet, closeFn := setupWithOptions(t, &framework.ControlPlaneConfigOptions{EtcdOptions: etcdOptions})
 			defer closeFn()
 
 			ns := framework.CreateTestingNamespace("list-paging", s, t)

--- a/test/integration/apiserver/apiserver_test.go
+++ b/test/integration/apiserver/apiserver_test.go
@@ -226,10 +226,10 @@ func Test4xxStatusCodeInvalidPatch(t *testing.T) {
 func TestCacheControl(t *testing.T) {
 	controlPlaneConfig := framework.NewIntegrationTestControlPlaneConfigWithOptions(&framework.ControlPlaneConfigOptions{})
 	controlPlaneConfig.GenericConfig.OpenAPIConfig = framework.DefaultOpenAPIConfig()
-	master, _, closeFn := framework.RunAnAPIServer(controlPlaneConfig)
+	instanceConfig, _, closeFn := framework.RunAnAPIServer(controlPlaneConfig)
 	defer closeFn()
 
-	rt, err := restclient.TransportFor(master.GenericAPIServer.LoopbackClientConfig)
+	rt, err := restclient.TransportFor(instanceConfig.GenericAPIServer.LoopbackClientConfig)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -253,7 +253,7 @@ func TestCacheControl(t *testing.T) {
 	}
 	for _, path := range paths {
 		t.Run(path, func(t *testing.T) {
-			req, err := http.NewRequest("GET", master.GenericAPIServer.LoopbackClientConfig.Host+path, nil)
+			req, err := http.NewRequest("GET", instanceConfig.GenericAPIServer.LoopbackClientConfig.Host+path, nil)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/test/integration/apiserver/apply/apply_test.go
+++ b/test/integration/apiserver/apply/apply_test.go
@@ -50,7 +50,7 @@ import (
 )
 
 func setup(t testing.TB, groupVersions ...schema.GroupVersion) (*httptest.Server, clientset.Interface, framework.CloseFunc) {
-	opts := framework.MasterConfigOptions{EtcdOptions: framework.DefaultEtcdOptions()}
+	opts := framework.ControlPlaneConfigOptions{EtcdOptions: framework.DefaultEtcdOptions()}
 	opts.EtcdOptions.DefaultStorageMediaType = "application/vnd.kubernetes.protobuf"
 	controlPlaneConfig := framework.NewIntegrationTestControlPlaneConfigWithOptions(&opts)
 	if len(groupVersions) > 0 {
@@ -2819,7 +2819,7 @@ spec:
 
 func TestStopTrackingManagedFieldsOnFeatureDisabled(t *testing.T) {
 	sharedEtcd := framework.DefaultEtcdOptions()
-	controlPlaneConfig := framework.NewIntegrationTestControlPlaneConfigWithOptions(&framework.MasterConfigOptions{
+	controlPlaneConfig := framework.NewIntegrationTestControlPlaneConfigWithOptions(&framework.ControlPlaneConfigOptions{
 		EtcdOptions: sharedEtcd,
 	})
 	controlPlaneConfig.GenericConfig.OpenAPIConfig = framework.DefaultOpenAPIConfig()

--- a/test/integration/apiserver/apply/apply_test.go
+++ b/test/integration/apiserver/apply/apply_test.go
@@ -2825,8 +2825,8 @@ func TestStopTrackingManagedFieldsOnFeatureDisabled(t *testing.T) {
 	controlPlaneConfig.GenericConfig.OpenAPIConfig = framework.DefaultOpenAPIConfig()
 
 	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, genericfeatures.ServerSideApply, true)()
-	_, master, closeFn := framework.RunAnAPIServer(controlPlaneConfig)
-	client, err := clientset.NewForConfig(&restclient.Config{Host: master.URL, QPS: -1})
+	_, instanceConfig, closeFn := framework.RunAnAPIServer(controlPlaneConfig)
+	client, err := clientset.NewForConfig(&restclient.Config{Host: instanceConfig.URL, QPS: -1})
 	if err != nil {
 		t.Fatalf("Error in create clientset: %v", err)
 	}
@@ -2878,8 +2878,8 @@ spec:
 	// Restart server with server-side apply disabled
 	closeFn()
 	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, genericfeatures.ServerSideApply, false)()
-	_, master, closeFn = framework.RunAnAPIServer(controlPlaneConfig)
-	client, err = clientset.NewForConfig(&restclient.Config{Host: master.URL, QPS: -1})
+	_, instanceConfig, closeFn = framework.RunAnAPIServer(controlPlaneConfig)
+	client, err = clientset.NewForConfig(&restclient.Config{Host: instanceConfig.URL, QPS: -1})
 	if err != nil {
 		t.Fatalf("Error in create clientset: %v", err)
 	}

--- a/test/integration/apiserver/flowcontrol/concurrency_test.go
+++ b/test/integration/apiserver/flowcontrol/concurrency_test.go
@@ -50,7 +50,7 @@ const (
 )
 
 func setup(t testing.TB, maxReadonlyRequestsInFlight, MaxMutatingRequestsInFlight int) (*httptest.Server, *rest.Config, framework.CloseFunc) {
-	opts := framework.MasterConfigOptions{EtcdOptions: framework.DefaultEtcdOptions()}
+	opts := framework.ControlPlaneConfigOptions{EtcdOptions: framework.DefaultEtcdOptions()}
 	opts.EtcdOptions.DefaultStorageMediaType = "application/vnd.kubernetes.protobuf"
 	controlPlaneConfig := framework.NewIntegrationTestControlPlaneConfigWithOptions(&opts)
 	resourceConfig := controlplane.DefaultAPIResourceConfigSource()

--- a/test/integration/apiserver/watchcache_test.go
+++ b/test/integration/apiserver/watchcache_test.go
@@ -54,7 +54,7 @@ func multiEtcdSetup(t testing.TB) (clientset.Interface, framework.CloseFunc) {
 	etcdOptions.EtcdServersOverrides = []string{fmt.Sprintf("/events#%s", etcd1URL)}
 	etcdOptions.EnableWatchCache = true
 
-	opts := framework.MasterConfigOptions{EtcdOptions: etcdOptions}
+	opts := framework.ControlPlaneConfigOptions{EtcdOptions: etcdOptions}
 	controlPlaneConfig := framework.NewIntegrationTestControlPlaneConfigWithOptions(&opts)
 	// Switch off endpoints reconciler to avoid unnecessary operations.
 	controlPlaneConfig.ExtraConfig.EndpointReconcilerType = reconcilers.NoneEndpointReconcilerType

--- a/test/integration/auth/svcaccttoken_test.go
+++ b/test/integration/auth/svcaccttoken_test.go
@@ -119,16 +119,16 @@ func TestServiceAccountTokenCreate(t *testing.T) {
 	controlPlaneConfig.ExtraConfig.ServiceAccountJWKSURI = ""
 	controlPlaneConfig.ExtraConfig.ServiceAccountPublicKeys = []interface{}{&pk}
 
-	master, _, closeFn := framework.RunAnAPIServer(controlPlaneConfig)
+	instanceConfig, _, closeFn := framework.RunAnAPIServer(controlPlaneConfig)
 	defer closeFn()
 
-	cs, err := clientset.NewForConfig(master.GenericAPIServer.LoopbackClientConfig)
+	cs, err := clientset.NewForConfig(instanceConfig.GenericAPIServer.LoopbackClientConfig)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
 	*gcs = *cs
 
-	rc, err := rest.UnversionedRESTClientFor(master.GenericAPIServer.LoopbackClientConfig)
+	rc, err := rest.UnversionedRESTClientFor(instanceConfig.GenericAPIServer.LoopbackClientConfig)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/test/integration/framework/master_utils.go
+++ b/test/integration/framework/master_utils.go
@@ -59,10 +59,10 @@ import (
 	kubeletclient "k8s.io/kubernetes/pkg/kubelet/client"
 )
 
-// Config is a struct of configuration directives for NewMasterComponents.
+// Config is a struct of configuration directives for NewControlPlaneComponents.
 type Config struct {
 	// If nil, a default is used, partially filled configs will not get populated.
-	MasterConfig            *controlplane.Config
+	InstanceConfig          *controlplane.Config
 	StartReplicationManager bool
 	// Client throttling qps
 	QPS float32

--- a/test/integration/framework/master_utils.go
+++ b/test/integration/framework/master_utils.go
@@ -253,12 +253,12 @@ func startAPIServerOrDie(controlPlaneConfig *controlplane.Config, incomingServer
 
 // NewIntegrationTestControlPlaneConfig returns the master config appropriate for most integration tests.
 func NewIntegrationTestControlPlaneConfig() *controlplane.Config {
-	return NewIntegrationTestControlPlaneConfigWithOptions(&MasterConfigOptions{})
+	return NewIntegrationTestControlPlaneConfigWithOptions(&ControlPlaneConfigOptions{})
 }
 
 // NewIntegrationTestControlPlaneConfigWithOptions returns the control plane config appropriate for most integration tests
 // configured with the provided options.
-func NewIntegrationTestControlPlaneConfigWithOptions(opts *MasterConfigOptions) *controlplane.Config {
+func NewIntegrationTestControlPlaneConfigWithOptions(opts *ControlPlaneConfigOptions) *controlplane.Config {
 	controlPlaneConfig := NewControlPlaneConfigWithOptions(opts)
 	controlPlaneConfig.GenericConfig.PublicAddress = net.ParseIP("192.168.10.4")
 	controlPlaneConfig.ExtraConfig.APIResourceConfigSource = controlplane.DefaultAPIResourceConfigSource()
@@ -269,8 +269,8 @@ func NewIntegrationTestControlPlaneConfigWithOptions(opts *MasterConfigOptions) 
 	return controlPlaneConfig
 }
 
-// MasterConfigOptions are the configurable options for a new integration test master config.
-type MasterConfigOptions struct {
+// ControlPlaneConfigOptions are the configurable options for a new integration test master config.
+type ControlPlaneConfigOptions struct {
 	EtcdOptions *options.EtcdOptions
 }
 
@@ -286,11 +286,11 @@ func DefaultEtcdOptions() *options.EtcdOptions {
 
 // NewControlPlaneConfig returns a basic control plane config.
 func NewControlPlaneConfig() *controlplane.Config {
-	return NewControlPlaneConfigWithOptions(&MasterConfigOptions{})
+	return NewControlPlaneConfigWithOptions(&ControlPlaneConfigOptions{})
 }
 
 // NewControlPlaneConfigWithOptions returns a basic control plane config configured with the provided options.
-func NewControlPlaneConfigWithOptions(opts *MasterConfigOptions) *controlplane.Config {
+func NewControlPlaneConfigWithOptions(opts *ControlPlaneConfigOptions) *controlplane.Config {
 	etcdOptions := DefaultEtcdOptions()
 	if opts.EtcdOptions != nil {
 		etcdOptions = opts.EtcdOptions

--- a/test/integration/framework/master_utils.go
+++ b/test/integration/framework/master_utils.go
@@ -123,7 +123,7 @@ func DefaultOpenAPIConfig() *openapicommon.Config {
 	return openAPIConfig
 }
 
-// startAPIServerOrDie starts a kubernetes master and an httpserver to handle api requests
+// startAPIServerOrDie starts a kubernetes API server and an httpserver to handle api requests
 func startAPIServerOrDie(controlPlaneConfig *controlplane.Config, incomingServer *httptest.Server, apiServerReceiver APIServerReceiver) (*controlplane.Instance, *httptest.Server, CloseFunc) {
 	var m *controlplane.Instance
 	var s *httptest.Server
@@ -210,9 +210,9 @@ func startAPIServerOrDie(controlPlaneConfig *controlplane.Config, incomingServer
 	m, err = controlPlaneConfig.Complete().New(genericapiserver.NewEmptyDelegate())
 	if err != nil {
 		// We log the error first so that even if closeFn crashes, the error is shown
-		klog.Errorf("error in bringing up the master: %v", err)
+		klog.Errorf("error in bringing up the apiserver: %v", err)
 		closeFn()
-		klog.Fatalf("error in bringing up the master: %v", err)
+		klog.Fatalf("error in bringing up the apiserver: %v", err)
 	}
 	if apiServerReceiver != nil {
 		apiServerReceiver.SetAPIServer(m)
@@ -251,7 +251,7 @@ func startAPIServerOrDie(controlPlaneConfig *controlplane.Config, incomingServer
 	return m, s, closeFn
 }
 
-// NewIntegrationTestControlPlaneConfig returns the master config appropriate for most integration tests.
+// NewIntegrationTestControlPlaneConfig returns the control plane config appropriate for most integration tests.
 func NewIntegrationTestControlPlaneConfig() *controlplane.Config {
 	return NewIntegrationTestControlPlaneConfigWithOptions(&ControlPlaneConfigOptions{})
 }
@@ -269,7 +269,7 @@ func NewIntegrationTestControlPlaneConfigWithOptions(opts *ControlPlaneConfigOpt
 	return controlPlaneConfig
 }
 
-// ControlPlaneConfigOptions are the configurable options for a new integration test master config.
+// ControlPlaneConfigOptions are the configurable options for a new integration test control plane config.
 type ControlPlaneConfigOptions struct {
 	EtcdOptions *options.EtcdOptions
 }
@@ -338,7 +338,7 @@ func NewControlPlaneConfigWithOptions(opts *ControlPlaneConfigOptions) *controlp
 	}
 }
 
-// CloseFunc can be called to cleanup the master
+// CloseFunc can be called to cleanup the API server
 type CloseFunc func()
 
 // RunAnAPIServer starts a API server with the provided config.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
/wg naming
/area test

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

xref #94407
As https://github.com/kubernetes/kubernetes/pull/100181#issuecomment-805017091 commented, this PR change codes less than 50 lines at a time. It would be friendly to review.
As https://github.com/kubernetes/kubernetes/pull/100181#discussion_r594825941 Name the API Server-related master method  `APIServer` instead of the `ControlPlane`.
Rename master:
-  MasterConfigOptions -> ControlPlaneConfigOptions
- master - > instanceConfig  and MasterConfig  -> InstanceConfig
  + Refer to https://github.com/kubernetes/kubernetes/pull/100181#discussion_r594525229
- master -> controlplane or apiserver （ According to specific use）

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Part of #94900

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
