### PR TITLE
Update version of go-flow-levee for verify-govet-levee check.

### DIFF
--- a/cmd/kubeadm/app/apis/kubeadm/v1beta3/bootstraptokenstring.go
+++ b/cmd/kubeadm/app/apis/kubeadm/v1beta3/bootstraptokenstring.go
@@ -31,7 +31,7 @@ import (
 // of view and as an authentication method for the node in the bootstrap phase of
 // "kubeadm join". This token is and should be short-lived
 type BootstrapTokenString struct {
-	ID     string `json:"-" datapolicy:"token"`
+	ID     string `json:"-"`
 	Secret string `json:"-" datapolicy:"token"`
 }
 

--- a/hack/testdata/levee/levee-config.yaml
+++ b/hack/testdata/levee/levee-config.yaml
@@ -25,11 +25,11 @@
 # These field tags were introduced by KEP-1753 to indicate fields which may contain credentials
 FieldTags:
   - Key: "datapolicy"
-    Val: "security-key"
+    Value: "security-key"
   - Key: "datapolicy"
-    Val: "token"
+    Value: "token"
   - Key: "datapolicy"
-    Val: "password"
+    Value: "password"
 
 # This preliminary collection of source types should be removed once
 # KEP-1753 adds tags to the relevant fields.
@@ -147,15 +147,6 @@ Sanitizers:
 # Exclude reporting within a given function by specifying it similar to Sinks, i.e.,
 # PackageRE | ReceiverRE | MethodRE regexp
 Exclude:
-# Corrected in #97000
 - PackageRE: "k8s.io/kubernetes/cmd/kubelet/app"
   # Regexp matches anonymized inner function
-  MethodRE: "initConfigz|NewKubeletCommand|run"
-# Corrected by go-flow-levee version update in #96999
-- PackageRE: "pkg/credentialprovider"
-  ReceiverRE: "BasicDockerKeyring"
-  MethodRE: "Add"
-# Corrected in #96576.
-- PackageRE: "k8s.io/kubernetes/pkg/credentialprovider/gcp"
-  ReceiverRE: "containerRegistryProvider"
-  MethodRE: "Provide"
+  MethodRE: "NewKubeletCommand"

--- a/hack/tools/go.mod
+++ b/hack/tools/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/cespare/prettybench v0.0.0-20150116022406-03b8cfe5406c
 	github.com/client9/misspell v0.3.4
 	github.com/golangci/golangci-lint v1.36.0
-	github.com/google/go-flow-levee v0.1.4-0.20201102181719-72c65d71b1d3
+	github.com/google/go-flow-levee v0.1.5-0.20210422150831-99e72693f5c8
 	gotest.tools v2.2.0+incompatible
 	gotest.tools/gotestsum v0.3.5
 	honnef.co/go/tools v0.0.1-2020.1.6

--- a/hack/tools/go.sum
+++ b/hack/tools/go.sum
@@ -228,8 +228,8 @@ github.com/google/go-cmp v0.5.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.4 h1:L8R9j+yAqZuZjsqh/z+F1NCffTKKLShY6zXTItVIZ8M=
 github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
-github.com/google/go-flow-levee v0.1.4-0.20201102181719-72c65d71b1d3 h1:yyMdeOKc/LqowWbSC/8KnGm++FWbwVeZw1aQaj9F3zQ=
-github.com/google/go-flow-levee v0.1.4-0.20201102181719-72c65d71b1d3/go.mod h1:Uiz/03u4gZX0ldjN5Tj5+fyZN1v6VK22uKRcpQCDsyE=
+github.com/google/go-flow-levee v0.1.5-0.20210422150831-99e72693f5c8 h1:D1Se3y8Tj9y30iIKlbGcGHyeyn/Hc3G/iOhXJFWLZVA=
+github.com/google/go-flow-levee v0.1.5-0.20210422150831-99e72693f5c8/go.mod h1:Uiz/03u4gZX0ldjN5Tj5+fyZN1v6VK22uKRcpQCDsyE=
 github.com/google/go-github/v33 v33.0.0 h1:qAf9yP0qc54ufQxzwv+u9H0tiVOnPJxo0lI/JXqw3ZM=
 github.com/google/go-github/v33 v33.0.0/go.mod h1:GMdDnVZY/2TsWgp/lkYnpSAh6TrzhANBBwm6k6TTEXg=
 github.com/google/go-querystring v1.0.0 h1:Xkwi/a1rcvNg1PPYe5vI8GbeBY/jrVuDX5ASuANWTrk=


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This PR bumps the version of the `go-flow-levee` analyzer used in the `verify-govet-levee.sh` check. Bumping the version of the analyzer allows improvements we've made recently to be applied. Related to this version bump, it also:
- Removes analysis exclusions which are no longer needed
- Removes a datapolicy tag which is causing a the analyzer to produce a finding and appears to be erroneous

#### Special notes for your reviewer:

@SataQiu: in #102174 you added a `datapolicy:"token"` tag to the `ID` field of `kubeadm`'s `BootstrapTokenString`. I would like to double check that this `ID` is indeed sensitive data that shouldn't be logged, because it is currently causing the analyzer to produce a finding.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
