### PR TITLE
e2e storage: disable health-monitor controller in hostpath deployment

### DIFF
--- a/test/e2e/storage/drivers/csi.go
+++ b/test/e2e/storage/drivers/csi.go
@@ -242,16 +242,19 @@ func (h *hostpathCSIDriver) PrepareTest(f *framework.Framework) (*storageframewo
 			return err
 		}
 
-		// Remove csi-external-health-monitor-agent because it is
-		// obsolete and shouldn't have been deployed by csi-driver-host-path v1.7.2.
-		// This can be removed when updating to a newer driver that
-		// doesn't deploy the agent.
+		// Remove csi-external-health-monitor-agent and
+		// csi-external-health-monitor-controller
+		// containers. The agent is obsolete.
+		// The controller is not needed for any of the
+		// tests and is causing too much overhead when
+		// running in a large cluster (see
+		// https://github.com/kubernetes/kubernetes/issues/102452#issuecomment-856991009).
 		switch item := item.(type) {
 		case *appsv1.StatefulSet:
 			var containers []v1.Container
 			for _, container := range item.Spec.Template.Spec.Containers {
 				switch container.Name {
-				case "csi-external-health-monitor-agent":
+				case "csi-external-health-monitor-agent", "csi-external-health-monitor-controller":
 					// Remove these containers.
 				default:
 					// Keep the others.


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/kind failing-test

#### What this PR does / why we need it:

This reverts commit
c15fd76ee9052b257dc16e275078a354695141e7. Most (all?) of the hostpath
tests and several other tests started to fail again in
gce-scale-master-correctness after re-enabling the controller. This
shows that it was not just the obsolete agent which causes scalability
problems, but also the controller.

It has to be disabled until the scalability problems are addressed.

#### Which issue(s) this PR fixes:
Related-to: https://github.com/kubernetes/kubernetes/issues/102452

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

