### PR TITLE
fix net-tiers e2e test

### DIFF
--- a/test/e2e/network/network_tiers.go
+++ b/test/e2e/network/network_tiers.go
@@ -93,7 +93,7 @@ var _ = common.SIGDescribe("Services [Slow]", func() {
 		// Test 2: re-create a LB of a different tier for the updated Service.
 		ginkgo.By("updating the Service to use the premium (default) tier")
 		svc, err = jig.UpdateService(func(svc *v1.Service) {
-			clearNetworkTier(svc)
+			setNetworkTier(svc, string(gcecloud.NetworkTierAnnotationPremium))
 		})
 		framework.ExpectNoError(err)
 		// Verify that service has been updated properly.
@@ -210,14 +210,6 @@ func setNetworkTier(svc *v1.Service, tier string) {
 		svc.ObjectMeta.Annotations = map[string]string{}
 	}
 	svc.ObjectMeta.Annotations[key] = tier
-}
-
-func clearNetworkTier(svc *v1.Service) {
-	key := gcecloud.NetworkTierAnnotationKey
-	if svc.ObjectMeta.Annotations == nil {
-		return
-	}
-	delete(svc.ObjectMeta.Annotations, key)
 }
 
 // TODO: add retries if this turns out to be flaky.


### PR DESCRIPTION
/kind failing-test

#### What this PR does / why we need it:
This bug adjust the net-tiers e2e test to match the new behavior. 

#### Which issue(s) this PR fixes:
Fixes #102649

#### Special notes for your reviewer:


#### Does this PR introduce a user-facing change?
No

```release-note
NONE
```
