### PR TITLE
add support for volume type gp3 for aws cloud provider

### DIFF
--- a/staging/src/k8s.io/legacy-cloud-providers/aws/aws.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/aws/aws.go
@@ -451,6 +451,8 @@ const (
 	VolumeTypeIO1 = "io1"
 	// General Purpose SSD
 	VolumeTypeGP2 = "gp2"
+	// General Purpose SSD
+	VolumeTypeGP3 = "gp3"
 	// Cold HDD (sc1)
 	VolumeTypeSC1 = "sc1"
 	// Throughput Optimized HDD
@@ -2532,7 +2534,7 @@ func (c *Cloud) CreateDisk(volumeOptions *VolumeOptions) (KubernetesVolumeID, er
 	var createType string
 	var iops int64
 	switch volumeOptions.VolumeType {
-	case VolumeTypeGP2, VolumeTypeSC1, VolumeTypeST1:
+	case VolumeTypeGP2, VolumeTypeGP3, VolumeTypeSC1, VolumeTypeST1:
 		createType = volumeOptions.VolumeType
 
 	case VolumeTypeIO1:


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
The main difference between gp2 and gp3 is `Max throughput per volume`.
- gp3: 1,000 MiB/s
- gp2: 250 MiB/s

**Which issue(s) this PR fixes**:

Fixes #102707

**Special notes for your reviewer**:
https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ebs-volume-types.html

>  If you need higher performance or performance consistency than previous-generation volumes can provide, we recommend that you consider using General Purpose SSD (gp2 and **gp3**) or other current volume types.


**Does this PR introduce a user-facing change?**:
```release-note
aws cloud provider: add support for SSD volumes GP3
```
