### PR TITLE
use uid first for MetaNamespaceKeyFunc

### DIFF
--- a/staging/src/k8s.io/client-go/tools/cache/store.go
+++ b/staging/src/k8s.io/client-go/tools/cache/store.go
@@ -109,6 +109,11 @@ func MetaNamespaceKeyFunc(obj interface{}) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("object has no meta: %v", err)
 	}
+	// When statefulset pods update, the old pod shares the same name with new one
+	// We should use UID to distinguish them.
+	if len(meta.GetUID()) > 0 {
+		return string(meta.GetUID()), nil
+	}
 	if len(meta.GetNamespace()) > 0 {
 		return meta.GetNamespace() + "/" + meta.GetName(), nil
 	}


### PR DESCRIPTION
#### What type of PR is this?
/kind bug


#### What this PR does / why we need it:

 #ref https://github.com/kubernetes/kubernetes/issues/102718

When `Reflector.Watch` failed after `List`, `Reflector` will start a new `List` function.

If a statefulset pod is deleted and then created between two `Reflector.List`,  `MetaNamespaceKeyFunc` will regard the two pod with same name as one pod update

1. statefulset-pod1 (uid xxxxx1) is created
2. Reflector.List          ->         get statefulset-pod1 (uid xxxxx1)  add 
3. Reflector.Watch failed
4.  statefulset-pod1 (uid xxxxx1) deleted, and a new pod statefulset-pod1 (uid xxxxx2) is created
5. another Reflector.List   -> get statefulset-pod1   update (uid xxxxx1) - (uid xxxxx2) 

 This change will involve many test case. If it can be accepted, I will fix the test case


#### Which issue(s) this PR fixes:

Fixes #https://github.com/kubernetes/kubernetes/pull/91126

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
/sig cli