### PR TITLE
fix:hpaController set hpa DesiredReplicas=0  in corner case when can not compute or get metrics 

### DIFF
--- a/pkg/controller/podautoscaler/horizontal.go
+++ b/pkg/controller/podautoscaler/horizontal.go
@@ -652,7 +652,9 @@ func (a *HorizontalController) reconcileAutoscaler(hpav1Shared *autoscalingv1.Ho
 		var metricTimestamp time.Time
 		metricDesiredReplicas, metricName, metricStatuses, metricTimestamp, err = a.computeReplicasForMetrics(hpa, scale, hpa.Spec.Metrics)
 		if err != nil {
-			a.setCurrentReplicasInStatus(hpa, currentReplicas)
+			// set desiredReplicas to scale.Spec.Replicas when can't compute metrics
+			desiredReplicas = scale.Spec.Replicas
+			a.setStatus(hpa, currentReplicas, desiredReplicas, hpa.Status.CurrentMetrics, false)
 			if err := a.updateStatusIfNeeded(hpaStatusOriginal, hpa); err != nil {
 				utilruntime.HandleError(err)
 			}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/sig autoscaling


#### What this PR does / why we need it:
When `hpaController` failed compute metrics, and not in below situation 
1) scale.Spec.Replicas==0 && minReplicas!=0
2)currentReplicas > hpa.Spec.MaxReplicas
3)currentReplicas < minReplicas
`reconcileAutoscaler` will set desiredReplicas=0. for example: a hpa with Spec minReplicas=1,maxReplicas:4 and ref deployment with 1 pod, this situation `reconcileAutoscaler` will set desiredReplicas=0, it's  that has misleading . That PR is aim to Fix this.

#### Which issue(s) this PR fixes:
fixed #102405 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs

```
