### PR TITLE
Define in-tree scheduler plugin names in separate pkg

### DIFF
--- a/pkg/scheduler/framework/plugins/defaultbinder/default_binder.go
+++ b/pkg/scheduler/framework/plugins/defaultbinder/default_binder.go
@@ -24,10 +24,11 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/pkg/scheduler/framework"
+	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/names"
 )
 
 // Name of the plugin used in the plugin registry and configurations.
-const Name = "DefaultBinder"
+const Name = names.DefaultBinder
 
 // DefaultBinder binds pods to nodes using a k8s client.
 type DefaultBinder struct {

--- a/pkg/scheduler/framework/plugins/defaultpreemption/default_preemption.go
+++ b/pkg/scheduler/framework/plugins/defaultpreemption/default_preemption.go
@@ -43,13 +43,14 @@ import (
 	"k8s.io/kubernetes/pkg/scheduler/apis/config/validation"
 	"k8s.io/kubernetes/pkg/scheduler/framework"
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/feature"
+	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/names"
 	"k8s.io/kubernetes/pkg/scheduler/metrics"
 	"k8s.io/kubernetes/pkg/scheduler/util"
 )
 
 const (
 	// Name of the plugin used in the plugin registry and configurations.
-	Name = "DefaultPreemption"
+	Name = names.DefaultPreemption
 )
 
 // DefaultPreemption is a PostFilter plugin implements the preemption logic.

--- a/pkg/scheduler/framework/plugins/imagelocality/image_locality.go
+++ b/pkg/scheduler/framework/plugins/imagelocality/image_locality.go
@@ -24,6 +24,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/kubernetes/pkg/scheduler/framework"
+	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/names"
 )
 
 // The two thresholds are used as bounds for the image score range. They correspond to a reasonable size range for
@@ -42,7 +43,7 @@ type ImageLocality struct {
 var _ framework.ScorePlugin = &ImageLocality{}
 
 // Name is the name of the plugin used in the plugin registry and configurations.
-const Name = "ImageLocality"
+const Name = names.ImageLocality
 
 // Name returns name of the plugin. It is used in logs, etc.
 func (pl *ImageLocality) Name() string {

--- a/pkg/scheduler/framework/plugins/interpodaffinity/plugin.go
+++ b/pkg/scheduler/framework/plugins/interpodaffinity/plugin.go
@@ -27,12 +27,13 @@ import (
 	"k8s.io/kubernetes/pkg/scheduler/apis/config/validation"
 	"k8s.io/kubernetes/pkg/scheduler/framework"
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/feature"
+	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/names"
 	"k8s.io/kubernetes/pkg/scheduler/internal/parallelize"
 )
 
 const (
 	// Name is the name of the plugin used in the plugin registry and configurations.
-	Name = "InterPodAffinity"
+	Name = names.InterPodAffinity
 )
 
 var _ framework.PreFilterPlugin = &InterPodAffinity{}

--- a/pkg/scheduler/framework/plugins/names/names.go
+++ b/pkg/scheduler/framework/plugins/names/names.go
@@ -1,0 +1,48 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package names
+
+const (
+	PrioritySort                    = "PrioritySort"
+	DefaultBinder                   = "DefaultBinder"
+	DefaultPreemption               = "DefaultPreemption"
+	ImageLocality                   = "ImageLocality"
+	InterPodAffinity                = "InterPodAffinity"
+	NodeAffinity                    = "NodeAffinity"
+	NodeLabel                       = "NodeLabel"
+	NodeName                        = "NodeName"
+	NodePorts                       = "NodePorts"
+	NodePreferAvoidPods             = "NodePreferAvoidPods"
+	NodeResourcesBalancedAllocation = "NodeResourcesBalancedAllocation"
+	NodeResourcesFit                = "NodeResourcesFit"
+	NodeResourcesLeastAllocated     = "NodeResourcesLeastAllocated"
+	NodeResourcesMostAllocated      = "NodeResourcesMostAllocated"
+	RequestedToCapacityRatio        = "RequestedToCapacityRatio"
+	NodeUnschedulable               = "NodeUnschedulable"
+	NodeVolumeLimits                = "NodeVolumeLimits"
+	AzureDiskLimits                 = "AzureDiskLimits"
+	CinderLimits                    = "CinderLimits"
+	EBSLimits                       = "EBSLimits"
+	GCEPDLimits                     = "GCEPDLimits"
+	PodTopologySpread               = "PodTopologySpread"
+	SelectorSpread                  = "SelectorSpread"
+	ServiceAffinity                 = "ServiceAffinity"
+	TaintToleration                 = "TaintToleration"
+	VolumeBinding                   = "VolumeBinding"
+	VolumeRestrictions              = "VolumeRestrictions"
+	VolumeZone                      = "VolumeZone"
+)

--- a/pkg/scheduler/framework/plugins/nodeaffinity/node_affinity.go
+++ b/pkg/scheduler/framework/plugins/nodeaffinity/node_affinity.go
@@ -26,7 +26,8 @@ import (
 	"k8s.io/kubernetes/pkg/scheduler/apis/config"
 	"k8s.io/kubernetes/pkg/scheduler/apis/config/validation"
 	"k8s.io/kubernetes/pkg/scheduler/framework"
-	pluginhelper "k8s.io/kubernetes/pkg/scheduler/framework/plugins/helper"
+	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/helper"
+	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/names"
 )
 
 // NodeAffinity is a plugin that checks if a pod node selector matches the node label.
@@ -44,7 +45,7 @@ var _ framework.EnqueueExtensions = &NodeAffinity{}
 
 const (
 	// Name is the name of the plugin used in the plugin registry and configurations.
-	Name = "NodeAffinity"
+	Name = names.NodeAffinity
 
 	// preScoreStateKey is the key in CycleState to NodeAffinity pre-computed data for Scoring.
 	preScoreStateKey = "PreScore" + Name
@@ -187,7 +188,7 @@ func (pl *NodeAffinity) Score(ctx context.Context, state *framework.CycleState, 
 
 // NormalizeScore invoked after scoring all nodes.
 func (pl *NodeAffinity) NormalizeScore(ctx context.Context, state *framework.CycleState, pod *v1.Pod, scores framework.NodeScoreList) *framework.Status {
-	return pluginhelper.DefaultNormalizeScore(framework.MaxNodeScore, false, scores)
+	return helper.DefaultNormalizeScore(framework.MaxNodeScore, false, scores)
 }
 
 // ScoreExtensions of the Score plugin.

--- a/pkg/scheduler/framework/plugins/nodelabel/node_label.go
+++ b/pkg/scheduler/framework/plugins/nodelabel/node_label.go
@@ -30,10 +30,11 @@ import (
 	"k8s.io/kubernetes/pkg/scheduler/apis/config"
 	"k8s.io/kubernetes/pkg/scheduler/apis/config/validation"
 	"k8s.io/kubernetes/pkg/scheduler/framework"
+	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/names"
 )
 
 // Name of this plugin.
-const Name = "NodeLabel"
+const Name = names.NodeLabel
 
 const (
 	// ErrReasonPresenceViolated is used for CheckNodeLabelPresence predicate error.

--- a/pkg/scheduler/framework/plugins/nodename/node_name.go
+++ b/pkg/scheduler/framework/plugins/nodename/node_name.go
@@ -22,6 +22,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/kubernetes/pkg/scheduler/framework"
+	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/names"
 )
 
 // NodeName is a plugin that checks if a pod spec node name matches the current node.
@@ -32,7 +33,7 @@ var _ framework.EnqueueExtensions = &NodeName{}
 
 const (
 	// Name is the name of the plugin used in the plugin registry and configurations.
-	Name = "NodeName"
+	Name = names.NodeName
 
 	// ErrReason returned when node name doesn't match.
 	ErrReason = "node(s) didn't match the requested node name"

--- a/pkg/scheduler/framework/plugins/nodeports/node_ports.go
+++ b/pkg/scheduler/framework/plugins/nodeports/node_ports.go
@@ -23,6 +23,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/kubernetes/pkg/scheduler/framework"
+	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/names"
 )
 
 // NodePorts is a plugin that checks if a node has free ports for the requested pod ports.
@@ -34,7 +35,7 @@ var _ framework.EnqueueExtensions = &NodePorts{}
 
 const (
 	// Name is the name of the plugin used in the plugin registry and configurations.
-	Name = "NodePorts"
+	Name = names.NodePorts
 
 	// preFilterStateKey is the key in CycleState to NodePorts pre-computed data.
 	// Using the name of the plugin will likely help us avoid collisions with other plugins.

--- a/pkg/scheduler/framework/plugins/nodepreferavoidpods/node_prefer_avoid_pods.go
+++ b/pkg/scheduler/framework/plugins/nodepreferavoidpods/node_prefer_avoid_pods.go
@@ -29,6 +29,7 @@ import (
 	v1helper "k8s.io/component-helpers/scheduling/corev1"
 	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/pkg/scheduler/framework"
+	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/names"
 )
 
 // NodePreferAvoidPods is a plugin that priorities nodes according to the node annotation
@@ -40,7 +41,7 @@ type NodePreferAvoidPods struct {
 var _ framework.ScorePlugin = &NodePreferAvoidPods{}
 
 // Name is the name of the plugin used in the plugin registry and configurations.
-const Name = "NodePreferAvoidPods"
+const Name = names.NodePreferAvoidPods
 
 // Name returns name of the plugin. It is used in logs, etc.
 func (pl *NodePreferAvoidPods) Name() string {

--- a/pkg/scheduler/framework/plugins/noderesources/balanced_allocation.go
+++ b/pkg/scheduler/framework/plugins/noderesources/balanced_allocation.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/kubernetes/pkg/scheduler/framework"
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/feature"
+	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/names"
 )
 
 // BalancedAllocation is a score plugin that calculates the difference between the cpu and memory fraction
@@ -37,7 +38,7 @@ type BalancedAllocation struct {
 var _ = framework.ScorePlugin(&BalancedAllocation{})
 
 // BalancedAllocationName is the name of the plugin used in the plugin registry and configurations.
-const BalancedAllocationName = "NodeResourcesBalancedAllocation"
+const BalancedAllocationName = names.NodeResourcesBalancedAllocation
 
 // Name returns name of the plugin. It is used in logs, etc.
 func (ba *BalancedAllocation) Name() string {

--- a/pkg/scheduler/framework/plugins/noderesources/fit.go
+++ b/pkg/scheduler/framework/plugins/noderesources/fit.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/kubernetes/pkg/scheduler/apis/config/validation"
 	"k8s.io/kubernetes/pkg/scheduler/framework"
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/feature"
+	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/names"
 )
 
 var _ framework.PreFilterPlugin = &Fit{}
@@ -37,7 +38,7 @@ var _ framework.EnqueueExtensions = &Fit{}
 
 const (
 	// FitName is the name of the plugin used in the plugin registry and configurations.
-	FitName = "NodeResourcesFit"
+	FitName = names.NodeResourcesFit
 
 	// preFilterStateKey is the key in CycleState to NodeResourcesFit pre-computed data.
 	// Using the name of the plugin will likely help us avoid collisions with other plugins.

--- a/pkg/scheduler/framework/plugins/noderesources/least_allocated.go
+++ b/pkg/scheduler/framework/plugins/noderesources/least_allocated.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/kubernetes/pkg/scheduler/apis/config/validation"
 	"k8s.io/kubernetes/pkg/scheduler/framework"
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/feature"
+	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/names"
 )
 
 // LeastAllocated is a score plugin that favors nodes with fewer allocation requested resources based on requested resources.
@@ -37,7 +38,7 @@ type LeastAllocated struct {
 var _ = framework.ScorePlugin(&LeastAllocated{})
 
 // LeastAllocatedName is the name of the plugin used in the plugin registry and configurations.
-const LeastAllocatedName = "NodeResourcesLeastAllocated"
+const LeastAllocatedName = names.NodeResourcesLeastAllocated
 
 // Name returns name of the plugin. It is used in logs, etc.
 func (la *LeastAllocated) Name() string {

--- a/pkg/scheduler/framework/plugins/noderesources/most_allocated.go
+++ b/pkg/scheduler/framework/plugins/noderesources/most_allocated.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/kubernetes/pkg/scheduler/apis/config/validation"
 	"k8s.io/kubernetes/pkg/scheduler/framework"
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/feature"
+	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/names"
 )
 
 // MostAllocated is a score plugin that favors nodes with high allocation based on requested resources.
@@ -37,7 +38,7 @@ type MostAllocated struct {
 var _ = framework.ScorePlugin(&MostAllocated{})
 
 // MostAllocatedName is the name of the plugin used in the plugin registry and configurations.
-const MostAllocatedName = "NodeResourcesMostAllocated"
+const MostAllocatedName = names.NodeResourcesMostAllocated
 
 // Name returns name of the plugin. It is used in logs, etc.
 func (ma *MostAllocated) Name() string {

--- a/pkg/scheduler/framework/plugins/noderesources/requested_to_capacity_ratio.go
+++ b/pkg/scheduler/framework/plugins/noderesources/requested_to_capacity_ratio.go
@@ -28,11 +28,12 @@ import (
 	"k8s.io/kubernetes/pkg/scheduler/framework"
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/feature"
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/helper"
+	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/names"
 )
 
 const (
 	// RequestedToCapacityRatioName is the name of this plugin.
-	RequestedToCapacityRatioName = "RequestedToCapacityRatio"
+	RequestedToCapacityRatioName = names.RequestedToCapacityRatio
 	maxUtilization               = 100
 )
 

--- a/pkg/scheduler/framework/plugins/nodeunschedulable/node_unschedulable.go
+++ b/pkg/scheduler/framework/plugins/nodeunschedulable/node_unschedulable.go
@@ -23,6 +23,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	v1helper "k8s.io/component-helpers/scheduling/corev1"
 	"k8s.io/kubernetes/pkg/scheduler/framework"
+	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/names"
 )
 
 // NodeUnschedulable plugin filters nodes that set node.Spec.Unschedulable=true unless
@@ -34,7 +35,7 @@ var _ framework.FilterPlugin = &NodeUnschedulable{}
 var _ framework.EnqueueExtensions = &NodeUnschedulable{}
 
 // Name is the name of the plugin used in the plugin registry and configurations.
-const Name = "NodeUnschedulable"
+const Name = names.NodeUnschedulable
 
 const (
 	// ErrReasonUnknownCondition is used for NodeUnknownCondition predicate error.

--- a/pkg/scheduler/framework/plugins/nodevolumelimits/csi.go
+++ b/pkg/scheduler/framework/plugins/nodevolumelimits/csi.go
@@ -28,10 +28,10 @@ import (
 	storagelisters "k8s.io/client-go/listers/storage/v1"
 	storagehelpers "k8s.io/component-helpers/storage/volume"
 	csitrans "k8s.io/csi-translation-lib"
-	"k8s.io/kubernetes/pkg/scheduler/framework"
-	volumeutil "k8s.io/kubernetes/pkg/volume/util"
-
 	"k8s.io/klog/v2"
+	"k8s.io/kubernetes/pkg/scheduler/framework"
+	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/names"
+	volumeutil "k8s.io/kubernetes/pkg/volume/util"
 )
 
 // InTreeToCSITranslator contains methods required to check migratable status
@@ -60,7 +60,7 @@ var _ framework.FilterPlugin = &CSILimits{}
 var _ framework.EnqueueExtensions = &CSILimits{}
 
 // CSIName is the name of the plugin used in the plugin registry and configurations.
-const CSIName = "NodeVolumeLimits"
+const CSIName = names.NodeVolumeLimits
 
 // Name returns name of the plugin. It is used in logs, etc.
 func (pl *CSILimits) Name() string {

--- a/pkg/scheduler/framework/plugins/nodevolumelimits/non_csi.go
+++ b/pkg/scheduler/framework/plugins/nodevolumelimits/non_csi.go
@@ -37,6 +37,7 @@ import (
 	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/pkg/scheduler/framework"
+	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/names"
 	volumeutil "k8s.io/kubernetes/pkg/volume/util"
 )
 
@@ -66,7 +67,7 @@ const (
 )
 
 // AzureDiskName is the name of the plugin used in the plugin registry and configurations.
-const AzureDiskName = "AzureDiskLimits"
+const AzureDiskName = names.AzureDiskLimits
 
 // NewAzureDisk returns function that initializes a new plugin and returns it.
 func NewAzureDisk(_ runtime.Object, handle framework.Handle) (framework.Plugin, error) {
@@ -75,7 +76,7 @@ func NewAzureDisk(_ runtime.Object, handle framework.Handle) (framework.Plugin, 
 }
 
 // CinderName is the name of the plugin used in the plugin registry and configurations.
-const CinderName = "CinderLimits"
+const CinderName = names.CinderLimits
 
 // NewCinder returns function that initializes a new plugin and returns it.
 func NewCinder(_ runtime.Object, handle framework.Handle) (framework.Plugin, error) {
@@ -84,7 +85,7 @@ func NewCinder(_ runtime.Object, handle framework.Handle) (framework.Plugin, err
 }
 
 // EBSName is the name of the plugin used in the plugin registry and configurations.
-const EBSName = "EBSLimits"
+const EBSName = names.EBSLimits
 
 // NewEBS returns function that initializes a new plugin and returns it.
 func NewEBS(_ runtime.Object, handle framework.Handle) (framework.Plugin, error) {
@@ -93,7 +94,7 @@ func NewEBS(_ runtime.Object, handle framework.Handle) (framework.Plugin, error)
 }
 
 // GCEPDName is the name of the plugin used in the plugin registry and configurations.
-const GCEPDName = "GCEPDLimits"
+const GCEPDName = names.GCEPDLimits
 
 // NewGCEPD returns function that initializes a new plugin and returns it.
 func NewGCEPD(_ runtime.Object, handle framework.Handle) (framework.Plugin, error) {

--- a/pkg/scheduler/framework/plugins/podtopologyspread/plugin.go
+++ b/pkg/scheduler/framework/plugins/podtopologyspread/plugin.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/kubernetes/pkg/scheduler/apis/config"
 	"k8s.io/kubernetes/pkg/scheduler/apis/config/validation"
 	"k8s.io/kubernetes/pkg/scheduler/framework"
+	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/names"
 	"k8s.io/kubernetes/pkg/scheduler/internal/parallelize"
 )
 
@@ -69,7 +70,7 @@ var _ framework.EnqueueExtensions = &PodTopologySpread{}
 
 const (
 	// Name is the name of the plugin used in the plugin registry and configurations.
-	Name = "PodTopologySpread"
+	Name = names.PodTopologySpread
 )
 
 // Name returns name of the plugin. It is used in logs, etc.

--- a/pkg/scheduler/framework/plugins/queuesort/priority_sort.go
+++ b/pkg/scheduler/framework/plugins/queuesort/priority_sort.go
@@ -20,10 +20,11 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	corev1helpers "k8s.io/component-helpers/scheduling/corev1"
 	"k8s.io/kubernetes/pkg/scheduler/framework"
+	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/names"
 )
 
 // Name is the name of the plugin used in the plugin registry and configurations.
-const Name = "PrioritySort"
+const Name = names.PrioritySort
 
 // PrioritySort is a plugin that implements Priority based sorting.
 type PrioritySort struct{}

--- a/pkg/scheduler/framework/plugins/selectorspread/selector_spread.go
+++ b/pkg/scheduler/framework/plugins/selectorspread/selector_spread.go
@@ -28,6 +28,7 @@ import (
 	utilnode "k8s.io/component-helpers/node/topology"
 	"k8s.io/kubernetes/pkg/scheduler/framework"
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/helper"
+	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/names"
 )
 
 // SelectorSpread is a plugin that calculates selector spread priority.
@@ -44,7 +45,7 @@ var _ framework.ScorePlugin = &SelectorSpread{}
 
 const (
 	// Name is the name of the plugin used in the plugin registry and configurations.
-	Name = "SelectorSpread"
+	Name = names.SelectorSpread
 	// preScoreStateKey is the key in CycleState to SelectorSpread pre-computed data for Scoring.
 	preScoreStateKey = "PreScore" + Name
 

--- a/pkg/scheduler/framework/plugins/serviceaffinity/service_affinity.go
+++ b/pkg/scheduler/framework/plugins/serviceaffinity/service_affinity.go
@@ -31,11 +31,12 @@ import (
 	"k8s.io/kubernetes/pkg/scheduler/apis/config"
 	"k8s.io/kubernetes/pkg/scheduler/framework"
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/helper"
+	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/names"
 )
 
 const (
 	// Name is the name of the plugin used in the plugin registry and configurations.
-	Name = "ServiceAffinity"
+	Name = names.ServiceAffinity
 
 	// preFilterStateKey is the key in CycleState to ServiceAffinity pre-computed data.
 	// Using the name of the plugin will likely help us avoid collisions with other plugins.

--- a/pkg/scheduler/framework/plugins/tainttoleration/taint_toleration.go
+++ b/pkg/scheduler/framework/plugins/tainttoleration/taint_toleration.go
@@ -24,7 +24,8 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	v1helper "k8s.io/component-helpers/scheduling/corev1"
 	"k8s.io/kubernetes/pkg/scheduler/framework"
-	pluginhelper "k8s.io/kubernetes/pkg/scheduler/framework/plugins/helper"
+	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/helper"
+	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/names"
 )
 
 // TaintToleration is a plugin that checks if a pod tolerates a node's taints.
@@ -39,7 +40,7 @@ var _ framework.EnqueueExtensions = &TaintToleration{}
 
 const (
 	// Name is the name of the plugin used in the plugin registry and configurations.
-	Name = "TaintToleration"
+	Name = names.TaintToleration
 	// preScoreStateKey is the key in CycleState to TaintToleration pre-computed data for Scoring.
 	preScoreStateKey = "PreScore" + Name
 	// ErrReasonNotMatch is the Filter reason status when not matching.
@@ -162,7 +163,7 @@ func (pl *TaintToleration) Score(ctx context.Context, state *framework.CycleStat
 
 // NormalizeScore invoked after scoring all nodes.
 func (pl *TaintToleration) NormalizeScore(ctx context.Context, _ *framework.CycleState, pod *v1.Pod, scores framework.NodeScoreList) *framework.Status {
-	return pluginhelper.DefaultNormalizeScore(framework.MaxNodeScore, true, scores)
+	return helper.DefaultNormalizeScore(framework.MaxNodeScore, true, scores)
 }
 
 // ScoreExtensions of the Score plugin.

--- a/pkg/scheduler/framework/plugins/volumebinding/volume_binding.go
+++ b/pkg/scheduler/framework/plugins/volumebinding/volume_binding.go
@@ -35,6 +35,7 @@ import (
 	"k8s.io/kubernetes/pkg/scheduler/apis/config/validation"
 	"k8s.io/kubernetes/pkg/scheduler/framework"
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/helper"
+	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/names"
 )
 
 const (
@@ -82,7 +83,7 @@ var _ framework.PreBindPlugin = &VolumeBinding{}
 var _ framework.ScorePlugin = &VolumeBinding{}
 
 // Name is the name of the plugin used in Registry and configurations.
-const Name = "VolumeBinding"
+const Name = names.VolumeBinding
 
 // Name returns name of the plugin. It is used in logs, etc.
 func (pl *VolumeBinding) Name() string {

--- a/pkg/scheduler/framework/plugins/volumerestrictions/volume_restrictions.go
+++ b/pkg/scheduler/framework/plugins/volumerestrictions/volume_restrictions.go
@@ -23,6 +23,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/kubernetes/pkg/scheduler/framework"
+	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/names"
 )
 
 // VolumeRestrictions is a plugin that checks volume restrictions.
@@ -32,7 +33,7 @@ var _ framework.FilterPlugin = &VolumeRestrictions{}
 var _ framework.EnqueueExtensions = &VolumeRestrictions{}
 
 // Name is the name of the plugin used in the plugin registry and configurations.
-const Name = "VolumeRestrictions"
+const Name = names.VolumeRestrictions
 
 const (
 	// ErrReasonDiskConflict is used for NoDiskConflict predicate error.

--- a/pkg/scheduler/framework/plugins/volumezone/volume_zone.go
+++ b/pkg/scheduler/framework/plugins/volumezone/volume_zone.go
@@ -31,6 +31,7 @@ import (
 	storagehelpers "k8s.io/component-helpers/storage/volume"
 	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/pkg/scheduler/framework"
+	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/names"
 )
 
 // VolumeZone is a plugin that checks volume zone.
@@ -45,7 +46,7 @@ var _ framework.EnqueueExtensions = &VolumeZone{}
 
 const (
 	// Name is the name of the plugin used in the plugin registry and configurations.
-	Name = "VolumeZone"
+	Name = names.VolumeZone
 
 	// ErrReasonConflict is used for NoVolumeZoneConflict predicate error.
 	ErrReasonConflict = "node(s) had no available volume zone"


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:
Defines in-tree plugin names in a separate pkg to break a cyclic dependency when moving plugin defaulting to CC.

#### Which issue(s) this PR fixes:
Part of #102211

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

