### PR TITLE
run_remote: improve error reporting

### DIFF
--- a/test/e2e_node/runner/remote/run_remote.go
+++ b/test/e2e_node/runner/remote/run_remote.go
@@ -557,7 +557,7 @@ func testImage(imageConfig *internalGCEImage, junitFilePrefix string) *TestResul
 func createInstance(imageConfig *internalGCEImage) (string, error) {
 	p, err := computeService.Projects.Get(*project).Do()
 	if err != nil {
-		return "", fmt.Errorf("failed to get project info %q", *project)
+		return "", fmt.Errorf("failed to get project info %q: %v", *project, err)
 	}
 	// Use default service account
 	serviceAccount := p.DefaultServiceAccount


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This PR is a result of my own experience of debugging node e2e test failure. I've got an error: "unable to create gce instance with running docker daemon for image ubuntu-gke-2004-1-20-v20210401.  failed to get project info "<project name>". This didn't help much to understand what's going on.

After this change the error message became much more informative and helped to fix the issue:
"unable to create gce instance with running docker daemon for image ubuntu-gke-2004-1-20-v20210401.  failed to get project info "<project name>": Get "https://compute.googleapis.com/compute/beta/projects/<project name>?alt=json&prettyPrint=false": Post "https://oauth2.googleapis.com/token": read tcp <addr>:<port>-><proxy addr>:<port>: read: connection reset by peer."

#### Does this PR introduce a user-facing change?
```release-note
NONE
```