### PR TITLE
cm: handle nil cpumanager avoiding segfault

### DIFF
--- a/pkg/kubelet/cm/container_manager_linux.go
+++ b/pkg/kubelet/cm/container_manager_linux.go
@@ -1073,11 +1073,17 @@ func (cm *containerManagerImpl) GetAllocatableDevices() []*podresourcesapi.Conta
 }
 
 func (cm *containerManagerImpl) GetCPUs(podUID, containerName string) []int64 {
-	return cm.cpuManager.GetCPUs(podUID, containerName).ToSliceNoSortInt64()
+	if cm.cpuManager != nil {
+		return cm.cpuManager.GetCPUs(podUID, containerName).ToSliceNoSortInt64()
+	}
+	return []int64{}
 }
 
 func (cm *containerManagerImpl) GetAllocatableCPUs() []int64 {
-	return cm.cpuManager.GetAllocatableCPUs().ToSliceNoSortInt64()
+	if cm.cpuManager != nil {
+		return cm.cpuManager.GetAllocatableCPUs().ToSliceNoSortInt64()
+	}
+	return []int64{}
 }
 
 func (cm *containerManagerImpl) ShouldResetExtendedResourceCapacity() bool {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:
If the cpumanager feature gate is disabled, the corresponsing field of the containerManager will be nil.
A couple functions don't check for this occurrence and happily deference the pointer unconditionally, leading to possible segfaults.


#### Which issue(s) this PR fixes:
Fixes #102780 

#### Special notes for your reviewer:
The relevant functions were introduced to support the podresources API, so to trigger this segfault all the following are needed:
- cpumanager feature gate has to be disabled explicitely
- any podresources API must be called

Worth pointing out that when the new functions were introduced (around kubernetes 1.20) the default feature gate for cpumanager was already set to true, hence this bug is expected to be triggered rarely.



#### Does this PR introduce a user-facing change?
```release-note
None
```
