### PR TITLE
Konnectivity: tune flags for larger clusters (5k nodes).

### DIFF
--- a/cluster/gce/addons/konnectivity-agent/konnectivity-agent-ds.yaml
+++ b/cluster/gce/addons/konnectivity-agent/konnectivity-agent-ds.yaml
@@ -33,6 +33,9 @@ spec:
                   "--ca-cert=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt",
                   "--proxy-server-host=__APISERVER_IP__",
                   "--proxy-server-port=8132",
+                  "--sync-interval=5s",
+                  "--sync-interval-cap=30s",
+                  "--probe-interval=5s",
                   "--service-account-token-path=/var/run/secrets/tokens/konnectivity-agent-token"
                   ]
           env:

--- a/cluster/gce/gci/configure-helper.sh
+++ b/cluster/gce/gci/configure-helper.sh
@@ -1932,6 +1932,8 @@ function prepare-konnectivity-server-manifest {
   params+=("--agent-service-account=konnectivity-agent")
   params+=("--kubeconfig=/etc/srv/kubernetes/konnectivity-server/kubeconfig")
   params+=("--authentication-audience=system:konnectivity-server")
+  params+=("--kubeconfig-qps=75")
+  params+=("--kubeconfig-burst=150")
   konnectivity_args=""
   for param in "${params[@]}"; do
     konnectivity_args+=", \"${param}\""


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

Optionally add one or more of the following kinds if applicable:
/kind failing-test
/kind flake
-->

#### What this PR does / why we need it:

When there are enough proxy-agent (pod count), proxy-server can become overloaded and (auth requests to kube-apiserver become client-throttled).

Use the flags introduced at https://github.com/kubernetes-sigs/apiserver-network-proxy/pull/192 to mitigate.

#### Which issue(s) this PR fixes:
Fixes #102784

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
```
