### PR TITLE
remove storageOperationErrorMetric and storageOperationStatusMetric in release 1.21

### DIFF
--- a/pkg/volume/util/operationexecutor/operation_generator_test.go
+++ b/pkg/volume/util/operationexecutor/operation_generator_test.go
@@ -84,28 +84,29 @@ func TestOperationGenerator_GenerateUnmapVolumeFunc_PluginName(t *testing.T) {
 			t.Fatalf("Error occurred while generating unmapVolumeFunc: %v", e)
 		}
 
-		metricFamilyName := "storage_operation_status_count"
+		metricFamilyName := "storage_operation_duration_seconds"
 		labelFilter := map[string]string{
+			"migrated":       "false",
 			"status":         "success",
 			"operation_name": "unmap_volume",
 			"volume_plugin":  expectedPluginName,
 		}
 		// compare the relative change of the metric because of the global state of the prometheus.DefaultGatherer.Gather()
-		storageOperationStatusCountMetricBefore := findMetricWithNameAndLabels(metricFamilyName, labelFilter)
+		storageOperationDurationSecondsMetricBefore := findMetricWithNameAndLabels(metricFamilyName, labelFilter)
 
 		var ee error
 		unmapVolumeFunc.CompleteFunc(volumetypes.CompleteFuncParam{Err: &ee})
 
-		storageOperationStatusCountMetricAfter := findMetricWithNameAndLabels(metricFamilyName, labelFilter)
-		if storageOperationStatusCountMetricAfter == nil {
+		storageOperationDurationSecondsMetricAfter := findMetricWithNameAndLabels(metricFamilyName, labelFilter)
+		if storageOperationDurationSecondsMetricAfter == nil {
 			t.Fatalf("Couldn't find the metric with name(%s) and labels(%v)", metricFamilyName, labelFilter)
 		}
 
-		if storageOperationStatusCountMetricBefore == nil {
-			assert.Equal(t, float64(1), *storageOperationStatusCountMetricAfter.Counter.Value, tc.name)
+		if storageOperationDurationSecondsMetricBefore == nil {
+			assert.Equal(t, uint64(1), *storageOperationDurationSecondsMetricAfter.Histogram.SampleCount, tc.name)
 		} else {
-			metricValueDiff := *storageOperationStatusCountMetricAfter.Counter.Value - *storageOperationStatusCountMetricBefore.Counter.Value
-			assert.Equal(t, float64(1), metricValueDiff, tc.name)
+			metricValueDiff := *storageOperationDurationSecondsMetricAfter.Histogram.SampleCount - *storageOperationDurationSecondsMetricBefore.Histogram.SampleCount
+			assert.Equal(t, uint64(1), metricValueDiff, tc.name)
 		}
 	}
 }


### PR DESCRIPTION
What type of PR is this?

/kind cleanup

What this PR does / why we need it:
Ref: #99045

Does this PR introduce a user-facing change?:
```release-note
ACTION REQUIRED: Both storage metrics `storage_operation_errors_total` and `storage_operation_status_count`  are removed.
```
Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```release-note
NONE
```