### PR TITLE
Remove deprecated scheduler CLI flags 

### DIFF
--- a/cmd/kube-scheduler/app/options/deprecated_test.go
+++ b/cmd/kube-scheduler/app/options/deprecated_test.go
@@ -38,17 +38,6 @@ func TestValidateDeprecatedKubeSchedulerConfiguration(t *testing.T) {
 				UseLegacyPolicyConfig: true,
 			},
 		},
-		"good affinity weight": {
-			config: &DeprecatedOptions{
-				HardPodAffinitySymmetricWeight: 50,
-			},
-		},
-		"bad affinity weight": {
-			expectedToFail: true,
-			config: &DeprecatedOptions{
-				HardPodAffinitySymmetricWeight: -1,
-			},
-		},
 	}
 
 	for name, scenario := range scenarios {

--- a/cmd/kube-scheduler/app/options/options.go
+++ b/cmd/kube-scheduler/app/options/options.go
@@ -23,7 +23,6 @@ import (
 	"strconv"
 	"time"
 
-	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/uuid"
 	apiserveroptions "k8s.io/apiserver/pkg/server/options"
@@ -99,10 +98,8 @@ func NewOptions() (*Options, error) {
 		Authentication: apiserveroptions.NewDelegatingAuthenticationOptions(),
 		Authorization:  apiserveroptions.NewDelegatingAuthorizationOptions(),
 		Deprecated: &DeprecatedOptions{
-			UseLegacyPolicyConfig:          false,
-			PolicyConfigMapNamespace:       metav1.NamespaceSystem,
-			SchedulerName:                  corev1.DefaultSchedulerName,
-			HardPodAffinitySymmetricWeight: 1,
+			UseLegacyPolicyConfig:    false,
+			PolicyConfigMapNamespace: metav1.NamespaceSystem,
 		},
 		Metrics: metrics.NewOptions(),
 		Logs:    logs.NewOptions(),
@@ -195,7 +192,7 @@ func (o *Options) ApplyTo(c *schedulerappconfig.Config) error {
 		c.ComponentConfig = *cfg
 
 		// apply any deprecated Policy flags, if applicable
-		o.Deprecated.ApplyPolicySourceTo(c)
+		o.Deprecated.ApplyTo(c)
 
 		// if the user has set CC profiles and is trying to use a Policy config, error out
 		// these configs are no longer merged and they should not be used simultaneously

--- a/cmd/kube-scheduler/app/options/options_test.go
+++ b/cmd/kube-scheduler/app/options/options_test.go
@@ -40,7 +40,6 @@ import (
 	"k8s.io/kube-scheduler/config/v1beta2"
 	kubeschedulerconfig "k8s.io/kubernetes/pkg/scheduler/apis/config"
 	"k8s.io/kubernetes/pkg/scheduler/apis/config/scheme"
-	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/interpodaffinity"
 )
 
 func newV1beta1DefaultComponentConfig() (*kubeschedulerconfig.KubeSchedulerConfiguration, error) {
@@ -946,117 +945,6 @@ profiles:
 				Logs: logs.NewOptions(),
 			},
 			expectedError: "no configuration has been provided",
-		},
-		{
-			name: "Deprecated HardPodAffinitySymmetricWeight",
-			options: &Options{
-				ComponentConfig: func() kubeschedulerconfig.KubeSchedulerConfiguration {
-					cfg, _ := newDefaultComponentConfig()
-					cfg.ClientConnection.Kubeconfig = flagKubeconfig
-					return *cfg
-				}(),
-				Deprecated: &DeprecatedOptions{
-					HardPodAffinitySymmetricWeight: 5,
-				},
-				Logs: logs.NewOptions(),
-			},
-			expectedUsername: "flag",
-			expectedConfig: kubeschedulerconfig.KubeSchedulerConfiguration{
-				TypeMeta: metav1.TypeMeta{
-					APIVersion: v1beta2.SchemeGroupVersion.String(),
-				},
-				Parallelism: 16,
-				DebuggingConfiguration: componentbaseconfig.DebuggingConfiguration{
-					EnableProfiling:           true,
-					EnableContentionProfiling: true,
-				},
-				LeaderElection: componentbaseconfig.LeaderElectionConfiguration{
-					LeaderElect:       true,
-					LeaseDuration:     metav1.Duration{Duration: 15 * time.Second},
-					RenewDeadline:     metav1.Duration{Duration: 10 * time.Second},
-					RetryPeriod:       metav1.Duration{Duration: 2 * time.Second},
-					ResourceLock:      "leases",
-					ResourceNamespace: "kube-system",
-					ResourceName:      "kube-scheduler",
-				},
-				ClientConnection: componentbaseconfig.ClientConnectionConfiguration{
-					Kubeconfig:  flagKubeconfig,
-					QPS:         50,
-					Burst:       100,
-					ContentType: "application/vnd.kubernetes.protobuf",
-				},
-				PercentageOfNodesToScore: defaultPercentageOfNodesToScore,
-				PodInitialBackoffSeconds: defaultPodInitialBackoffSeconds,
-				PodMaxBackoffSeconds:     defaultPodMaxBackoffSeconds,
-				Profiles: []kubeschedulerconfig.KubeSchedulerProfile{
-					{
-						SchedulerName: "default-scheduler",
-						PluginConfig: []kubeschedulerconfig.PluginConfig{
-							{
-								Name: "InterPodAffinity",
-								Args: &kubeschedulerconfig.InterPodAffinityArgs{HardPodAffinityWeight: 5},
-							},
-						},
-					},
-				},
-			},
-		},
-		{
-			name: "Deprecated SchedulerName flag",
-			options: &Options{
-				ComponentConfig: func() kubeschedulerconfig.KubeSchedulerConfiguration {
-					cfg, _ := newDefaultComponentConfig()
-					cfg.ClientConnection.Kubeconfig = flagKubeconfig
-					return *cfg
-				}(),
-				Deprecated: &DeprecatedOptions{
-					SchedulerName:                  "my-nice-scheduler",
-					HardPodAffinitySymmetricWeight: 1,
-				},
-				Logs: logs.NewOptions(),
-			},
-			expectedUsername: "flag",
-			expectedConfig: kubeschedulerconfig.KubeSchedulerConfiguration{
-				TypeMeta: metav1.TypeMeta{
-					APIVersion: v1beta2.SchemeGroupVersion.String(),
-				},
-				Parallelism: 16,
-				DebuggingConfiguration: componentbaseconfig.DebuggingConfiguration{
-					EnableProfiling:           true,
-					EnableContentionProfiling: true,
-				},
-				LeaderElection: componentbaseconfig.LeaderElectionConfiguration{
-					LeaderElect:       true,
-					LeaseDuration:     metav1.Duration{Duration: 15 * time.Second},
-					RenewDeadline:     metav1.Duration{Duration: 10 * time.Second},
-					RetryPeriod:       metav1.Duration{Duration: 2 * time.Second},
-					ResourceLock:      "leases",
-					ResourceNamespace: "kube-system",
-					ResourceName:      "kube-scheduler",
-				},
-				ClientConnection: componentbaseconfig.ClientConnectionConfiguration{
-					Kubeconfig:  flagKubeconfig,
-					QPS:         50,
-					Burst:       100,
-					ContentType: "application/vnd.kubernetes.protobuf",
-				},
-				PercentageOfNodesToScore: defaultPercentageOfNodesToScore,
-				PodInitialBackoffSeconds: defaultPodInitialBackoffSeconds,
-				PodMaxBackoffSeconds:     defaultPodMaxBackoffSeconds,
-				Profiles: []kubeschedulerconfig.KubeSchedulerProfile{
-					{
-						SchedulerName: "my-nice-scheduler",
-						PluginConfig: []kubeschedulerconfig.PluginConfig{
-							{
-								Name: interpodaffinity.Name,
-								Args: &kubeschedulerconfig.InterPodAffinityArgs{
-									HardPodAffinityWeight: 1,
-								},
-							},
-						},
-					},
-				},
-			},
 		},
 		{
 			name: "Attempting to set Component Config Profiles and Policy config",

--- a/cmd/kube-scheduler/app/server_test.go
+++ b/cmd/kube-scheduler/app/server_test.go
@@ -255,16 +255,6 @@ profiles:
 			},
 		},
 		{
-			name: "Deprecated SchedulerName flag",
-			flags: []string{
-				"--kubeconfig", configKubeconfig,
-				"--scheduler-name", "my-scheduler",
-			},
-			wantPlugins: map[string]map[string][]kubeschedulerconfig.Plugin{
-				"my-scheduler": defaultPlugins,
-			},
-		},
-		{
 			name: "default algorithm provider",
 			flags: []string{
 				"--kubeconfig", configKubeconfig,

--- a/pkg/scheduler/apis/config/validation/validation_pluginargs.go
+++ b/pkg/scheduler/apis/config/validation/validation_pluginargs.go
@@ -68,11 +68,11 @@ func validateMinCandidateNodesAbsolute(minCandidateNodesAbsolute int32, p *field
 
 // ValidateInterPodAffinityArgs validates that InterPodAffinityArgs are correct.
 func ValidateInterPodAffinityArgs(path *field.Path, args *config.InterPodAffinityArgs) error {
-	return ValidateHardPodAffinityWeight(path.Child("hardPodAffinityWeight"), args.HardPodAffinityWeight)
+	return validateHardPodAffinityWeight(path.Child("hardPodAffinityWeight"), args.HardPodAffinityWeight)
 }
 
-// ValidateHardPodAffinityWeight validates that weight is within allowed range.
-func ValidateHardPodAffinityWeight(path *field.Path, w int32) error {
+// validateHardPodAffinityWeight validates that weight is within allowed range.
+func validateHardPodAffinityWeight(path *field.Path, w int32) error {
 	const (
 		minHardPodAffinityWeight = 0
 		maxHardPodAffinityWeight = 100


### PR DESCRIPTION
#### What type of PR is this?

/kind deprecation

#### What this PR does / why we need it:
Deprecates scheduler CLI flags `hard-pod-affinity-symmetric-weight` and `scheduler-name`.

Deprecation policy for admin-facing CLI flags is "GA, admin-facing flag, longer of 6 months or 1 release". Verify deprecated since 1.18: https://github.com/kubernetes/kubernetes/blob/release-1.18/cmd/kube-scheduler/app/options/deprecated.go


#### Which issue(s) this PR fixes:
Fixes #102804

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
The deprecated flag --hard-pod-affinity-symmetric-weight and --scheduler-name have been removed from kube-scheduler. Use ComponentConfig instead to configure those parameters.

```

/assign @alculquicondor 