### PR TITLE
capture PodIPs variable to avoid it is dereferenced

### DIFF
--- a/pkg/kubelet/kubelet_pods.go
+++ b/pkg/kubelet/kubelet_pods.go
@@ -1587,13 +1587,16 @@ func (kl *Kubelet) convertStatusToAPIStatus(pod *v1.Pod, podStatus *kubecontaine
 		validPrimaryIP = utilnet.IsIPv6String
 		validSecondaryIP = utilnet.IsIPv4String
 	}
-	for _, ip := range podStatus.IPs {
+	// clone podStatus.IPs to avoid a panic if it is mutated meanwhile it is being parsed
+	podStatusIPsCopy := make([]string, len(podStatus.IPs))
+	copy(podStatusIPsCopy, podStatus.IPs)
+	for _, ip := range podStatusIPsCopy {
 		if validPrimaryIP(ip) {
 			podIPs = append(podIPs, v1.PodIP{IP: ip})
 			break
 		}
 	}
-	for _, ip := range podStatus.IPs {
+	for _, ip := range podStatusIPsCopy {
 		if validSecondaryIP(ip) {
 			podIPs = append(podIPs, v1.PodIP{IP: ip})
 			break


### PR DESCRIPTION
/kind bug

```release-note
NONE
```
If the PodIPs is changed meanwhile the code is parsing it, it can cause a panic

Fixes: #102806

```go
package main

import (
	"fmt"
	"net"
	"time"
)

func main() {
	quit := make(chan bool)
	var podIPs []string
	validIP := net.ParseIP

	go func() {
		for {
			for _, ip := range podIPs {
				validIP(ip)
			}

			select {
			case <-quit:
				fmt.Println("stopping")
				return
			default:
			}

		}
	}()

	time.Sleep(1 * time.Second)
	podIPs = []string{"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}
	podIPs = []string{"x"}
	time.Sleep(1 * time.Second)
	close(quit)

	time.Sleep(1 * time.Second)
}

```
```
[aojea@aojea-laptop tmp]$ stress  ./main

/tmp/go-stress-20210611T223438-759254165
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x49f5ee]

goroutine 19 [running]:
main.main.func1(0xc00012a030, 0x4cd038, 0xc0001100c0)
	/home/aojea/tmp/main.go:16 +0x4e
created by main.main
	/home/aojea/tmp/main.go:14 +0x91


ERROR: exit status 2
```