### PR TITLE
Add `-o extra-columns` format option to kubectl get

### DIFF
--- a/staging/src/k8s.io/cli-runtime/pkg/printers/interface.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/printers/interface.go
@@ -46,6 +46,7 @@ type PrintOptions struct {
 	ShowLabels    bool
 	Kind          schema.GroupKind
 	ColumnLabels  []string
+	ExtraColumns  []string
 
 	SortBy string
 

--- a/staging/src/k8s.io/kubectl/pkg/cmd/config/get_contexts.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/config/get_contexts.go
@@ -101,7 +101,7 @@ func (o *GetContextsOptions) Complete(cmd *cobra.Command, args []string) error {
 
 // Validate ensures the of output format
 func (o *GetContextsOptions) Validate(cmd *cobra.Command) error {
-	validOutputTypes := sets.NewString("", "json", "yaml", "wide", "name", "custom-columns", "custom-columns-file", "go-template", "go-template-file", "jsonpath", "jsonpath-file")
+	validOutputTypes := sets.NewString("", "json", "yaml", "wide", "name", "custom-columns", "custom-columns-file", "extra-columns", "go-template", "go-template-file", "jsonpath", "jsonpath-file")
 	supportedOutputTypes := sets.NewString("", "name")
 	outputFormat := cmdutil.GetFlagString(cmd, "output")
 	if !validOutputTypes.Has(outputFormat) {

--- a/staging/src/k8s.io/kubectl/pkg/cmd/get/get.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/get/get.go
@@ -215,7 +215,7 @@ func (o *GetOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, args []stri
 	// TODO (soltysh): currently we don't support custom columns
 	// with server side print. So in these cases force the old behavior.
 	outputOption := cmd.Flags().Lookup("output").Value.String()
-	if strings.Contains(outputOption, "custom-columns") || outputOption == "yaml" || strings.Contains(outputOption, "json") {
+	if strings.Contains(outputOption, "custom-columns") || strings.Contains(outputOption, "extra-columns") || outputOption == "yaml" || strings.Contains(outputOption, "json") {
 		o.ServerPrint = false
 	}
 
@@ -225,7 +225,7 @@ func (o *GetOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, args []stri
 	}
 
 	// human readable printers have special conversion rules, so we determine if we're using one.
-	if (len(*o.PrintFlags.OutputFormat) == 0 && len(templateArg) == 0) || *o.PrintFlags.OutputFormat == "wide" {
+	if (len(*o.PrintFlags.OutputFormat) == 0 && len(templateArg) == 0) || *o.PrintFlags.OutputFormat == "wide" || strings.Contains(outputOption, "extra-columns") {
 		o.IsHumanReadablePrinter = true
 	}
 


### PR DESCRIPTION
Fixes https://github.com/kubernetes/kubernetes/issues/98368

Note to reviewers: This PR is in draft while I get more feedback on if this desired and/or find more time to clean it up. Before merge, I would expect to clean up the logic a bit (notable - remove lazy error handling panics), and add tests.

Examples:
```
$ ~/go/bin/kubectl get pod -o "extra-columns=NAME:.metadata.name,IP:.status.podIP,IMAGE:.spec.containers[*].image"
NAME                      AGE   NAME                      IP             IMAGE
noproxy-688f47dc9-vxpbw   74m   noproxy-688f47dc9-vxpbw   10.244.0.106   howardjohn/alpine-shell
shell-7854df9c5-dc6ml     74m   shell-7854df9c5-dc6ml     10.244.0.105   howardjohn/alpine-shell,gcr.io/istio-testing/proxyv2:latest
$ ~/go/bin/kubectl get svc -o "extra-columns=NAME:.spec.ports[*].name,PORT:.spec.ports[*].port,TARGET:.spec.ports[*].targetPort"
NAME         AGE     NAME    PORT   TARGET
awake        6h13m   http    80     80
kubernetes   6h13m   https   443    6443
shell        75m     http    9087   9087
sleep        6h13m   http    80     80
```

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Add `-o extra-columns` format option to kubectl get. This allows printing additional columns, while not needing to attempt to re-construct all of the original columns, which may either be a large burden or impossible (for example, I don't think its possible to replicate the output of `kubectl get pods`).

#### Which issue(s) this PR fixes:
Fixes #98368
Fixes #71612

This has been a long standing popular feature request since 2018.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
Kubectl: add a new `-o extra-columns` format option to add additional columns to table output.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:


```docs

```
