### PR TITLE
Promote endPort field in netpolicies to beta

### DIFF
--- a/pkg/apis/networking/types.go
+++ b/pkg/apis/networking/types.go
@@ -149,8 +149,8 @@ type NetworkPolicyPort struct {
 	// should be allowed by the policy. This field cannot be defined if the port field
 	// is not defined or if the port field is defined as a named (string) port.
 	// The endPort must be equal or greater than port.
-	// This feature is in Alpha state and should be enabled using the Feature Gate
-	// "NetworkPolicyEndPort".
+	// This feature is in Beta state and is enabled by default.
+	// It can be disabled using the Feature Gate "NetworkPolicyEndPort".
 	// +optional
 	EndPort *int32
 }

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -254,6 +254,7 @@ const (
 	// owner: @rikatz
 	// kep: http://kep.k8s.io/2079
 	// alpha: v1.21
+	// beta:  v1.22
 	//
 	// Enables the endPort field in NetworkPolicy to enable a Port Range behavior in Network Policies.
 	NetworkPolicyEndPort featuregate.Feature = "NetworkPolicyEndPort"
@@ -781,7 +782,7 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
 	CSIVolumeFSGroupPolicy:                         {Default: true, PreRelease: featuregate.Beta},
 	RuntimeClass:                                   {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.23
 	NodeLease:                                      {Default: true, PreRelease: featuregate.GA, LockToDefault: true},
-	NetworkPolicyEndPort:                           {Default: false, PreRelease: featuregate.Alpha},
+	NetworkPolicyEndPort:                           {Default: true, PreRelease: featuregate.Beta},
 	ProcMountType:                                  {Default: false, PreRelease: featuregate.Alpha},
 	TTLAfterFinished:                               {Default: true, PreRelease: featuregate.Beta},
 	IndexedJob:                                     {Default: true, PreRelease: featuregate.Beta},

--- a/staging/src/k8s.io/api/extensions/v1beta1/generated.proto
+++ b/staging/src/k8s.io/api/extensions/v1beta1/generated.proto
@@ -764,8 +764,8 @@ message NetworkPolicyPort {
   // should be allowed by the policy. This field cannot be defined if the port field
   // is not defined or if the port field is defined as a named (string) port.
   // The endPort must be equal or greater than port.
-  // This feature is in Alpha state and should be enabled using the Feature Gate
-  // "NetworkPolicyEndPort".
+  // This feature is in Beta state and is enabled by default.
+  // It can be disabled using the Feature Gate "NetworkPolicyEndPort".
   // +optional
   optional int32 endPort = 3;
 }

--- a/staging/src/k8s.io/api/extensions/v1beta1/types.go
+++ b/staging/src/k8s.io/api/extensions/v1beta1/types.go
@@ -1493,8 +1493,8 @@ type NetworkPolicyPort struct {
 	// should be allowed by the policy. This field cannot be defined if the port field
 	// is not defined or if the port field is defined as a named (string) port.
 	// The endPort must be equal or greater than port.
-	// This feature is in Alpha state and should be enabled using the Feature Gate
-	// "NetworkPolicyEndPort".
+	// This feature is in Beta state and is enabled by default.
+	// It can be disabled using the Feature Gate "NetworkPolicyEndPort".
 	// +optional
 	EndPort *int32 `json:"endPort,omitempty" protobuf:"bytes,3,opt,name=endPort"`
 }

--- a/staging/src/k8s.io/api/extensions/v1beta1/types_swagger_doc_generated.go
+++ b/staging/src/k8s.io/api/extensions/v1beta1/types_swagger_doc_generated.go
@@ -416,7 +416,7 @@ var map_NetworkPolicyPort = map[string]string{
 	"":         "DEPRECATED 1.9 - This group version of NetworkPolicyPort is deprecated by networking/v1/NetworkPolicyPort.",
 	"protocol": "Optional.  The protocol (TCP, UDP, or SCTP) which traffic must match. If not specified, this field defaults to TCP.",
 	"port":     "The port on the given protocol. This can either be a numerical or named port on a pod. If this field is not provided, this matches all port names and numbers. If present, only traffic on the specified protocol AND port will be matched.",
-	"endPort":  "If set, indicates that the range of ports from port to endPort, inclusive, should be allowed by the policy. This field cannot be defined if the port field is not defined or if the port field is defined as a named (string) port. The endPort must be equal or greater than port. This feature is in Alpha state and should be enabled using the Feature Gate \"NetworkPolicyEndPort\".",
+	"endPort":  "If set, indicates that the range of ports from port to endPort, inclusive, should be allowed by the policy. This field cannot be defined if the port field is not defined or if the port field is defined as a named (string) port. The endPort must be equal or greater than port. This feature is in Beta state and is enabled by default. It can be disabled using the Feature Gate \"NetworkPolicyEndPort\".",
 }
 
 func (NetworkPolicyPort) SwaggerDoc() map[string]string {

--- a/staging/src/k8s.io/api/networking/v1/generated.proto
+++ b/staging/src/k8s.io/api/networking/v1/generated.proto
@@ -439,8 +439,8 @@ message NetworkPolicyPort {
   // should be allowed by the policy. This field cannot be defined if the port field
   // is not defined or if the port field is defined as a named (string) port.
   // The endPort must be equal or greater than port.
-  // This feature is in Alpha state and should be enabled using the Feature Gate
-  // "NetworkPolicyEndPort".
+  // This feature is in Beta state and is enabled by default.
+  // It can be disabled using the Feature Gate "NetworkPolicyEndPort".
   // +optional
   optional int32 endPort = 3;
 }

--- a/staging/src/k8s.io/api/networking/v1/types.go
+++ b/staging/src/k8s.io/api/networking/v1/types.go
@@ -152,8 +152,8 @@ type NetworkPolicyPort struct {
 	// should be allowed by the policy. This field cannot be defined if the port field
 	// is not defined or if the port field is defined as a named (string) port.
 	// The endPort must be equal or greater than port.
-	// This feature is in Alpha state and should be enabled using the Feature Gate
-	// "NetworkPolicyEndPort".
+	// This feature is in Beta state and is enabled by default. 
+	// It can be disabled using the Feature Gate "NetworkPolicyEndPort".
 	// +optional
 	EndPort *int32 `json:"endPort,omitempty" protobuf:"bytes,3,opt,name=endPort"`
 }

--- a/staging/src/k8s.io/api/networking/v1/types.go
+++ b/staging/src/k8s.io/api/networking/v1/types.go
@@ -152,7 +152,7 @@ type NetworkPolicyPort struct {
 	// should be allowed by the policy. This field cannot be defined if the port field
 	// is not defined or if the port field is defined as a named (string) port.
 	// The endPort must be equal or greater than port.
-	// This feature is in Beta state and is enabled by default. 
+	// This feature is in Beta state and is enabled by default.
 	// It can be disabled using the Feature Gate "NetworkPolicyEndPort".
 	// +optional
 	EndPort *int32 `json:"endPort,omitempty" protobuf:"bytes,3,opt,name=endPort"`

--- a/staging/src/k8s.io/api/networking/v1/types_swagger_doc_generated.go
+++ b/staging/src/k8s.io/api/networking/v1/types_swagger_doc_generated.go
@@ -244,7 +244,7 @@ var map_NetworkPolicyPort = map[string]string{
 	"":         "NetworkPolicyPort describes a port to allow traffic on",
 	"protocol": "The protocol (TCP, UDP, or SCTP) which traffic must match. If not specified, this field defaults to TCP.",
 	"port":     "The port on the given protocol. This can either be a numerical or named port on a pod. If this field is not provided, this matches all port names and numbers. If present, only traffic on the specified protocol AND port will be matched.",
-	"endPort":  "If set, indicates that the range of ports from port to endPort, inclusive, should be allowed by the policy. This field cannot be defined if the port field is not defined or if the port field is defined as a named (string) port. The endPort must be equal or greater than port. This feature is in Alpha state and should be enabled using the Feature Gate \"NetworkPolicyEndPort\".",
+	"endPort":  "If set, indicates that the range of ports from port to endPort, inclusive, should be allowed by the policy. This field cannot be defined if the port field is not defined or if the port field is defined as a named (string) port. The endPort must be equal or greater than port. This feature is in Beta state and is enabled by default. It can be disabled using the Feature Gate \"NetworkPolicyEndPort\".",
 }
 
 func (NetworkPolicyPort) SwaggerDoc() map[string]string {


### PR DESCRIPTION
Signed-off-by: Ricardo Pchevuzinske Katz <ricardo.katz@gmail.com>


#### What type of PR is this?

/kind feature
/kind api-change

#### What this PR does / why we need it:
Promote the endPort field in Network Policies to Beta

#### Which issue(s) this PR fixes:
Part of https://github.com/kubernetes/enhancements/issues/2079 

#### Special notes for your reviewer:
As per graduation criteria, we now have 2 CNIs supporting EndPort and one on its way to support:

* Calico, per PR https://github.com/projectcalico/libcalico-go/pull/1357
* Antrea, per PR https://github.com/antrea-io/antrea/pull/2190
* Kube-router (ongoing) per PR https://github.com/cloudnativelabs/kube-router/pull/1080

About other CNIs:
* Cilium seems to need some change on its dataplane layer, which was already part of conversation with them and it's on roadmap.
* Openshift-sdn does not gets any new feature
* ovn-kubernetes just implements when a feature is GA

#### Does this PR introduce a user-facing change?
```release-note
Network Policy EndPort is graduated to beta and is enabled by default
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
- [KEP]: https://github.com/kubernetes/enhancements/tree/d0b04580b6e3cd9287185cfc379efad151f966b2/keps/sig-network/2079-network-policy-port-range
```
