### PR TITLE
Improve terminated pod message when node is shutting down

### DIFF
--- a/pkg/kubelet/nodeshutdown/nodeshutdown_manager_linux.go
+++ b/pkg/kubelet/nodeshutdown/nodeshutdown_manager_linux.go
@@ -36,10 +36,11 @@ import (
 )
 
 const (
-	nodeShutdownReason          = "Shutdown"
-	nodeShutdownMessage         = "Node is shutting, evicting pods"
-	nodeShutdownNotAdmitMessage = "Node is in progress of shutting down, not admitting any new pods"
-	dbusReconnectPeriod         = 1 * time.Second
+	nodeShutdownReason             = "Terminated"
+	nodeShutdownMessage            = "Pod was terminated in response to imminent node shutdown."
+	nodeShutdownNotAdmittedReason  = "NodeShutdown"
+	nodeShutdownNotAdmittedMessage = "Pod was rejected as the node is shutting down."
+	dbusReconnectPeriod            = 1 * time.Second
 )
 
 var systemDbus = func() (dbusInhibiter, error) {
@@ -93,8 +94,8 @@ func (m *Manager) Admit(attrs *lifecycle.PodAdmitAttributes) lifecycle.PodAdmitR
 	if nodeShuttingDown {
 		return lifecycle.PodAdmitResult{
 			Admit:   false,
-			Reason:  nodeShutdownReason,
-			Message: nodeShutdownNotAdmitMessage,
+			Reason:  nodeShutdownNotAdmittedReason,
+			Message: nodeShutdownNotAdmittedMessage,
 		}
 	}
 	return lifecycle.PodAdmitResult{Admit: true}
@@ -270,8 +271,8 @@ func (m *Manager) processShutdownEvent() error {
 
 			status := v1.PodStatus{
 				Phase:   v1.PodFailed,
-				Message: nodeShutdownMessage,
 				Reason:  nodeShutdownReason,
+				Message: nodeShutdownMessage,
 			}
 
 			err := m.killPod(pod, status, &gracePeriodOverride)


### PR DESCRIPTION
Signed-off-by: Guillaume Le Biller <glebiller@Traveldoo.com>

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
Fixes #102820  
Also relates to #99986

#### Special notes for your reviewer:
In addition to changing the Pod Status reason and message being terminated when a node is shutting down, I also changed the Pod Admission Status reason and message on rejection when the node is shutting down.

```
Pod Terminated
* Reason: Shutdown ----------------------------> Terminated
* Message: Node is shutting, evicting pods ----> Pod was terminated in response to node shutdown.

Pod Rejected
* Reason: Terminated -----------------------------------------------------------> NodeShutdown
* Message: Node is in progress of shutting down, not admitting any new pods ----> Pod was rejected as node is shutting down.
```
#### Does this PR introduce a user-facing change?

```release-note
Changed the Graceful Node Shutdown Pod termination reason and message.
Changed the Graceful Node Shutdown Pod rejection reason and message.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
KEP: kubernetes/enhancements#2000
/sig node
```
