### PR TITLE
Add APF metrics about R(t)

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/queueset/queueset.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/queueset/queueset.go
@@ -709,7 +709,7 @@ func (qs *queueSet) selectQueueLocked() *queue {
 		if queue.requests.Length() != 0 {
 			sMin = math.Min(sMin, queue.virtualStart)
 			sMax = math.Max(sMax, queue.virtualStart)
-			estimatedWorkInProgress := qs.estimatedServiceTime * float64(queue.requestsExecuting)
+			estimatedWorkInProgress := qs.estimatedServiceTime * float64(queue.seatsInUse)
 			dsMin = math.Min(dsMin, queue.virtualStart-estimatedWorkInProgress)
 			dsMax = math.Max(dsMax, queue.virtualStart-estimatedWorkInProgress)
 			// the virtual finish time of the oldest request is:

--- a/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/queueset/queueset.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/queueset/queueset.go
@@ -408,6 +408,7 @@ func (qs *queueSet) syncTimeLocked() {
 	timeSinceLast := realNow.Sub(qs.lastRealTime).Seconds()
 	qs.lastRealTime = realNow
 	qs.virtualTime += timeSinceLast * qs.getVirtualTimeRatioLocked()
+	metrics.SetCurrentR(qs.qCfg.Name, qs.virtualTime)
 }
 
 // getVirtualTimeRatio calculates the rate at which virtual time has
@@ -576,6 +577,7 @@ func (qs *queueSet) dispatchAsMuchAsPossibleLocked() {
 }
 
 func (qs *queueSet) dispatchSansQueueLocked(ctx context.Context, width uint, flowDistinguisher, fsName string, descr1, descr2 interface{}) *request {
+	// does not call metrics.SetDispatchMetrics because there is no queuing and thus no interesting virtual world
 	now := qs.clock.Now()
 	req := &request{
 		qs:                qs,
@@ -694,6 +696,10 @@ func (qs *queueSet) canAccommodateSeatsLocked(seats int) bool {
 // the oldest waiting request is minimal.
 func (qs *queueSet) selectQueueLocked() *queue {
 	minVirtualFinish := math.Inf(1)
+	sMin := math.Inf(1)
+	dsMin := math.Inf(1)
+	sMax := math.Inf(-1)
+	dsMax := math.Inf(-1)
 	var minQueue *queue
 	var minIndex int
 	nq := len(qs.queues)
@@ -701,6 +707,11 @@ func (qs *queueSet) selectQueueLocked() *queue {
 		qs.robinIndex = (qs.robinIndex + 1) % nq
 		queue := qs.queues[qs.robinIndex]
 		if queue.requests.Length() != 0 {
+			sMin = math.Min(sMin, queue.virtualStart)
+			sMax = math.Max(sMax, queue.virtualStart)
+			estimatedWorkInProgress := qs.estimatedServiceTime * float64(queue.requestsExecuting)
+			dsMin = math.Min(dsMin, queue.virtualStart-estimatedWorkInProgress)
+			dsMax = math.Max(dsMax, queue.virtualStart-estimatedWorkInProgress)
 			// the virtual finish time of the oldest request is:
 			//   virtual start time + G
 			// we are not taking the width of the request into account when
@@ -760,6 +771,7 @@ func (qs *queueSet) selectQueueLocked() *queue {
 		// per-queue virtual time should not fall behind the global
 		minQueue.virtualStart = qs.virtualTime + previouslyEstimatedServiceTime
 	}
+	metrics.SetDispatchMetrics(qs.qCfg.Name, qs.virtualTime, minQueue.virtualStart, sMin, sMax, dsMin, dsMax)
 	return minQueue
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation

/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind feature

#### What this PR does / why we need it:
This PR adds metrics to API Priority and Fairness about the quantity currently known in the code as "virtual time" and in the write-up as "R(t)".  These metrics help understand the state of the implementation and evaluate whether there is significant divergence from max-min fairness.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->


#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Added new metrics about API Priority and Fairness.  Each one has a label `priority_level`.  The last two also have a label `bound` taking values `min` and `max.
- apiserver_flowcontrol_current_r: R(the time of the last change in state of the queues)
- apiserver_flowcontrol_dispatch_r: R(the time of the latest request dispatch)
- apiserver_flowcontrol_latest_s: S(the request last dispatched) = R(when that request starts executing in the virtual world)
- apiserver_flowcontrol_next_s_bounds: min and max next S among non-empty queues
- apiserver_flowcontrol_next_discounted_s_bounds: min and max next S - (sum [over requests executing] width * estimatedDuration) among non-empty queues
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->

