### PR TITLE
Fix broken KEP link for issue #101008

### DIFF
--- a/CHANGELOG/CHANGELOG-1.14.md
+++ b/CHANGELOG/CHANGELOG-1.14.md
@@ -940,7 +940,7 @@ Kubeadm: Expose the `kubeadm join` workflow as phases
 
 - The `kubeadm join` command can now be used in phases. Similar to the work that was done for `kubeadm init` in 1.13, in 1.14 the `join` phases can be now executed step-by-step/selectively using the `kubeadm join phase` sub-command. This makes it possible to further customize the workflow of joining nodes to the cluster.
 kubernetes/kubeadm: [#1204](https://github.com/kubernetes/kubeadm/issues/1204)
-kubernetes/enhancements: [kep](https://github.com/kubernetes/enhancements/blob/master/keps/sig-cluster-lifecycle/kubeadm/0029-20180918-kubeadm-phases-beta.md)
+kubernetes/enhancements: [kep](https://github.com/kubernetes/enhancements/blob/master/keps/sig-cluster-lifecycle/kubeadm/2501-kubeadm-phases-to-beta/README.md)
 
 ## Known Issues
 

--- a/CHANGELOG/CHANGELOG-1.8.md
+++ b/CHANGELOG/CHANGELOG-1.8.md
@@ -1431,7 +1431,7 @@ Service Level Indicators (SLIs) and Service Level Objectives (SLOs) for the syst
 Here's the release [scalability validation report].
 
 [SIG Scalability]: https://github.com/kubernetes/community/tree/master/sig-scalability
-[scalability validation report]: https://github.com/kubernetes/enhancements/tree/master/release-1.8/scalability_validation_report.md
+[scalability validation report]: https://github.com/kubernetes/sig-release/blob/master/releases/release-1.8/scalability_validation_report.md
 
 ### SIG Scheduling
 


### PR DESCRIPTION
## What type of PR is this?
/kind documentation

## What this PR does / why we need it:
This PR fixes following broken links from `[Umbrella] Fix KEP link #101008` :
- CHANGELOG/CHANGELOG-1.8.md:1434:[scalability validation report]
- CHANGELOG/CHANGELOG-1.14.md:943:kubernetes/enhancements: kep

## Which issue(s) this PR fixes:
x-ref #101008

## Special notes for your reviewer:
Does this PR introduce a user-facing change?
`NONE`
Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
`NONE`

Release Notes needed:
```release-note
NONE
```