### PR TITLE
Remove directxman12 from OWNERS

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -328,12 +328,13 @@ aliases:
     - dashpole
     - ehashman
     - s-urbaniak
-    - DirectXMan12
     - andyxning
     - coffeepac
     - logicalhan
     - RainbowMango
     - serathius
+  # emeritus
+  # - directxman12
 
   api-approvers:
     - erictune


### PR DESCRIPTION
As per
https://groups.google.com/g/kubebuilder/c/-5hOFa_adr4/m/Sp_Zb755AwAJ,
directxman12 is stepping down.

#### What type of PR is this?

/kind cleanup

```release-note
NONE
```

```docs

```
