### PR TITLE
Update etcd in kubeadm to run as non-root.

### DIFF
--- a/cmd/kubeadm/app/cmd/phases/join/controlplanejoin.go
+++ b/cmd/kubeadm/app/cmd/phases/join/controlplanejoin.go
@@ -145,7 +145,8 @@ func runEtcdPhase(c workflow.RunData) error {
 	// because it needs two members as majority to agree on the consensus. You will only see this behavior between the time
 	// etcdctl member add informs the cluster about the new member and the new member successfully establishing a connection to the
 	// existing one."
-	if err := etcdphase.CreateStackedEtcdStaticPodManifestFile(client, kubeadmconstants.GetStaticPodDirectory(), data.PatchesDir(), cfg.NodeRegistration.Name, &cfg.ClusterConfiguration, &cfg.LocalAPIEndpoint); err != nil {
+	// TODO: add support for join dry-run: https://github.com/kubernetes/kubeadm/issues/2505
+	if err := etcdphase.CreateStackedEtcdStaticPodManifestFile(client, kubeadmconstants.GetStaticPodDirectory(), data.PatchesDir(), cfg.NodeRegistration.Name, &cfg.ClusterConfiguration, &cfg.LocalAPIEndpoint, false /* isDryRun */); err != nil {
 		return errors.Wrap(err, "error creating local etcd static pod manifest file")
 	}
 

--- a/cmd/kubeadm/app/util/staticpod/utils_linux_test.go
+++ b/cmd/kubeadm/app/util/staticpod/utils_linux_test.go
@@ -133,3 +133,34 @@ func TestRunKubeSchedulerAsNonRoot(t *testing.T) {
 	}
 	verifyFilePermissions(t, updatedFiles, wantUpdateFiles)
 }
+
+func TestRunEtcdAsNonRoot(t *testing.T) {
+	cfg := &kubeadm.ClusterConfiguration{
+		Etcd: kubeadm.Etcd{
+			Local: &kubeadm.LocalEtcd{
+				DataDir: "/var/lib/etcd/data",
+			},
+		},
+	}
+	pod := ComponentPod(v1.Container{Name: "etcd"}, nil, nil)
+	var runAsUser, runAsGroup int64 = 1000, 1001
+	updatedFiles := map[string]ownerAndPermissions{}
+	if err := runEtcdAsNonRoot(&pod, &runAsUser, &runAsGroup, func(path string, uid, gid int64, perms uint32) error {
+		updatedFiles[path] = ownerAndPermissions{uid: uid, gid: gid, permissions: perms}
+		return nil
+	},
+		func(path string, uid, gid int64) error {
+			updatedFiles[path] = ownerAndPermissions{uid: uid, gid: gid, permissions: 0700}
+			return nil
+		}, cfg); err != nil {
+		t.Fatal(err)
+	}
+	verifyPodSecurityContext(t, &pod, runAsUser, runAsGroup, nil)
+	verifyContainerSecurityContext(t, pod.Spec.Containers[0], nil, []v1.Capability{"ALL"}, pointer.Bool(false))
+	wantUpdateFiles := map[string]ownerAndPermissions{
+		cfg.Etcd.Local.DataDir: {uid: runAsUser, gid: runAsGroup, permissions: 0700},
+		filepath.Join(cfg.CertificatesDir, kubeadmconstants.EtcdServerKeyName): {uid: runAsUser, gid: runAsGroup, permissions: 0600},
+		filepath.Join(cfg.CertificatesDir, kubeadmconstants.EtcdPeerKeyName):   {uid: runAsUser, gid: runAsGroup, permissions: 0600},
+	}
+	verifyFilePermissions(t, updatedFiles, wantUpdateFiles)
+}

--- a/cmd/kubeadm/app/util/users/users_other.go
+++ b/cmd/kubeadm/app/util/users/users_other.go
@@ -48,3 +48,8 @@ func RemoveUsersAndGroups() error {
 func UpdatePathOwnerAndPermissions(path string, uid, gid int64, perms uint32) error {
 	return nil
 }
+
+// UpdatePathOwner is a NO-OP on non-Linux.
+func UpdatePathOwner(dirPath string, uid, gid int64) error {
+	return nil
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

This PR introduces the code changes to run etcd in kubeadm  as non-root when the feature-gate RootlessControlPlane is enabled.

In a follow-up PR I will add e2e tests that will enable the feature-gate RootlessControlPlane.

To opt-in before upgrade you must patch the ClusterConfiguration object in the "kube-system/kubeadm-config" ConfigMap to include "- RootlessControlPlane: true" under "featureGates".

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
xref kubernetes/kubeadm#2473
xref kubernetes/enhancements#2568
#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- [KEP]: https://github.com/kubernetes/enhancements/issues/2568
```
