### PR TITLE
Remove default JSON logging format registration from k8s.io/component-base/logs package

### DIFF
--- a/pkg/kubelet/apis/config/validation/validation_test.go
+++ b/pkg/kubelet/apis/config/validation/validation_test.go
@@ -150,7 +150,7 @@ func TestValidateKubeletConfiguration(t *testing.T) {
 			"GracefulNodeShutdown":    true,
 		},
 		Logging: componentbaseconfig.LoggingConfiguration{
-			Format: "json",
+			Format: "text",
 		},
 	}
 	if allErrors := ValidateKubeletConfiguration(successCase3); allErrors != nil {

--- a/staging/src/k8s.io/component-base/logs/config.go
+++ b/staging/src/k8s.io/component-base/logs/config.go
@@ -22,10 +22,9 @@ import (
 	"strings"
 
 	"github.com/spf13/pflag"
-	"k8s.io/klog/v2"
 
 	"k8s.io/component-base/config"
-	json "k8s.io/component-base/logs/json"
+	"k8s.io/klog/v2"
 )
 
 // Supported klog formats
@@ -40,7 +39,6 @@ var LogRegistry = NewLogFormatRegistry()
 func init() {
 	// Text format is default klog format
 	LogRegistry.Register(DefaultLogFormat, nil)
-	LogRegistry.Register(JSONLogFormat, json.JSONLogger)
 }
 
 // List of logs (k8s.io/klog + k8s.io/component-base/logs) flags supported by all logging formats


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Currently importing k8s.io/component-base/logs results both text and json logging format available by default. As Json format is not yet GAed, it is undesired to force it on component authors that use the library. Instead it should be optional.

As this change requires high level approvals in cmd directories it's recommended to do the change in multiple PRs，the PR only modifies the `kube-apiserver` JSON log format registration.

- [x] Create a new module ./staging/src/k8s.io/component-base/logs/json/register  #102644
- Add import _ "k8s.io/component-base/logs/json/register" to system components
  - [x]  kubelet #102716
  - [x]  kube-scheduler #102752 
  - [x]  kube-apiserver  (the PR for it)
  - [x] kube-controller-manager #102756
- **Remove JSON register call (the PR for it)**
  -  Add JSON logging format registration importing in kubelet config validation
      https://github.com/kubernetes/kubernetes/blob/8ac5d4d6a92d59bba70844fbd6e5de2383a08c96/pkg/kubelet/apis/config/validation/validation_test.go#L147
  -  Add JSON format registration and rename test package names to avoid circular import
  - Remove default JSON logging format registration from k8s.io/component-base/logs package
 https://github.com/kubernetes/kubernetes/blob/8ac5d4d6a92d59bba70844fbd6e5de2383a08c96/staging/src/k8s.io/component-base/logs/config.go#L42


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Part of #102632

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
JSON logging format is no longer available by default in non-core Kubernetes Components and require owners to opt in.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
