### PR TITLE
kubeadm: use defer to unlock mutex in certs.go

### DIFF
--- a/cmd/kubeadm/app/phases/certs/certs.go
+++ b/cmd/kubeadm/app/phases/certs/certs.go
@@ -477,12 +477,11 @@ func validateCertificateWithConfig(cert *x509.Certificate, baseName string, cfg 
 // by keeping track with a cache.
 func CheckCertificatePeriodValidity(baseName string, cert *x509.Certificate) {
 	certPeriodValidationMutex.Lock()
+	defer certPeriodValidationMutex.Unlock()
 	if _, exists := certPeriodValidation[baseName]; exists {
-		certPeriodValidationMutex.Unlock()
 		return
 	}
 	certPeriodValidation[baseName] = struct{}{}
-	certPeriodValidationMutex.Unlock()
 
 	klog.V(5).Infof("validating certificate period for %s certificate", baseName)
 	if err := pkiutil.ValidateCertPeriod(cert, 0); err != nil {


### PR DESCRIPTION
Use defer feature for unlock

#### What type of PR is this?
kind cleanup

#### What this PR does / why we need it:
Use defer feature for unlock.

#### Which issue(s) this PR fixes:
N/A

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
No
