### PR TITLE
Return StatusError 404 in fake client when resource is not found

### DIFF
--- a/staging/src/k8s.io/client-go/discovery/fake/discovery.go
+++ b/staging/src/k8s.io/client-go/discovery/fake/discovery.go
@@ -18,9 +18,11 @@ package fake
 
 import (
 	"fmt"
+	"net/http"
 
 	openapi_v2 "github.com/googleapis/gnostic/openapiv2"
 
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/version"
@@ -49,7 +51,13 @@ func (c *FakeDiscovery) ServerResourcesForGroupVersion(groupVersion string) (*me
 			return resourceList, nil
 		}
 	}
-	return nil, fmt.Errorf("GroupVersion %q not found", groupVersion)
+	return nil, &errors.StatusError{
+		ErrStatus: metav1.Status{
+			Status:  metav1.StatusFailure,
+			Code:    http.StatusNotFound,
+			Reason:  metav1.StatusReasonNotFound,
+			Message: fmt.Sprintf("the server could not find the requested resource, GroupVersion %q not found", groupVersion),
+		}}
 }
 
 // ServerResources returns the supported resources for all groups and versions.


### PR DESCRIPTION
#### What this PR does / why we need it:

When a resource is not found the fake client returns a custom error created using `ftm.Error`, while the API server would return an `errors.StatusError` with a `http.StatusNotFound` code. It makes it difficult to unit test situations where it is expected for a resource to not be found, for example:

```golang
// Detect if V1 is available
_, err := clientset.Discovery().ServerResourcesForGroupVersion(v1.SchemeGroupVersion.String())
if errors.IsNotFound(err) { // Here
     // resource does not exist, but it's fine, we can try something else
 }
if err != nil {
    return nil, err
}
```

/kind bug

```release-note
NONE
```