### PR TITLE
Start deprecation of --record flag

### DIFF
--- a/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/record_flags.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/record_flags.go
@@ -93,6 +93,7 @@ func (f *RecordFlags) AddFlags(cmd *cobra.Command) {
 
 	if f.Record != nil {
 		cmd.Flags().BoolVar(f.Record, "record", *f.Record, "Record current kubectl command in the resource annotation. If set to false, do not record the command. If set to true, record the command. If not set, default to updating the existing annotation value only if one already exists.")
+		cmd.Flags().MarkDeprecated("record", "--record will be removed in the future")
 	}
 }
 


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup
/kind deprecation
/sig cli
/priority backlog

#### What this PR does / why we need it:
This is a follow up from a discussion at [SIG-CLI](https://docs.google.com/document/d/1r0YElcXt6G5mOWxwZiXgGu_X6he3F--wKwg-9UBc29I/edit#heading=h.2zzbdmokauz2) some time ago and email send to [k/dev](https://groups.google.com/g/kubernetes-dev/c/g8pm9bg1-Lo). I haven't heard any complaints and with [new mechanism which sends commands through HTTP headers](https://github.com/kubernetes/enhancements/issues/859) entering beta and very rich auditing functionality available in kubernetes it's time to deprecate `--record` flag which wasn't used consistently across all commands and is rather confusing to a lot of users. 

#### Special notes for your reviewer:
/assign @eddiezane 

#### Does this PR introduce a user-facing change?
```release-note
Deprecate --record flag in kubectl. The --record flag is being replaced with the mechanism from https://github.com/kubernetes/enhancements/tree/master/keps/sig-cli/859-kubectl-headers which annotates HTTP requests with kubectl command details.

```

