### PR TITLE
publishing: Use go1.15.13 for 1.20 and 1.19 release branches

### DIFF
--- a/staging/publishing/rules.yaml
+++ b/staging/publishing/rules.yaml
@@ -19,12 +19,12 @@ rules:
       branch: release-1.19
       dir: staging/src/k8s.io/code-generator
     name: release-1.19
-    go: 1.15.12
+    go: 1.15.13
   - source:
       branch: release-1.20
       dir: staging/src/k8s.io/code-generator
     name: release-1.20
-    go: 1.15.12
+    go: 1.15.13
   - source:
       branch: release-1.21
       dir: staging/src/k8s.io/code-generator
@@ -41,12 +41,12 @@ rules:
       branch: release-1.19
       dir: staging/src/k8s.io/apimachinery
     name: release-1.19
-    go: 1.15.12
+    go: 1.15.13
   - source:
       branch: release-1.20
       dir: staging/src/k8s.io/apimachinery
     name: release-1.20
-    go: 1.15.12
+    go: 1.15.13
   - source:
       branch: release-1.21
       dir: staging/src/k8s.io/apimachinery
@@ -66,7 +66,7 @@ rules:
       branch: release-1.19
       dir: staging/src/k8s.io/api
     name: release-1.19
-    go: 1.15.12
+    go: 1.15.13
     dependencies:
       - repository: apimachinery
         branch: release-1.19
@@ -74,7 +74,7 @@ rules:
       branch: release-1.20
       dir: staging/src/k8s.io/api
     name: release-1.20
-    go: 1.15.12
+    go: 1.15.13
     dependencies:
       - repository: apimachinery
         branch: release-1.20
@@ -106,7 +106,7 @@ rules:
       branch: release-1.19
       dir: staging/src/k8s.io/client-go
     name: release-1.19
-    go: 1.15.12
+    go: 1.15.13
     dependencies:
       - repository: apimachinery
         branch: release-1.19
@@ -120,7 +120,7 @@ rules:
       branch: release-1.20
       dir: staging/src/k8s.io/client-go
     name: release-1.20
-    go: 1.15.12
+    go: 1.15.13
     dependencies:
       - repository: apimachinery
         branch: release-1.20
@@ -162,7 +162,7 @@ rules:
       branch: release-1.19
       dir: staging/src/k8s.io/component-base
     name: release-1.19
-    go: 1.15.12
+    go: 1.15.13
     dependencies:
     - repository: apimachinery
       branch: release-1.19
@@ -174,7 +174,7 @@ rules:
       branch: release-1.20
       dir: staging/src/k8s.io/component-base
     name: release-1.20
-    go: 1.15.12
+    go: 1.15.13
     dependencies:
     - repository: apimachinery
       branch: release-1.20
@@ -212,7 +212,7 @@ rules:
       branch: release-1.20
       dir: staging/src/k8s.io/component-helpers
     name: release-1.20
-    go: 1.15.12
+    go: 1.15.13
     dependencies:
     - repository: apimachinery
       branch: release-1.20
@@ -252,7 +252,7 @@ rules:
       branch: release-1.19
       dir: staging/src/k8s.io/apiserver
     name: release-1.19
-    go: 1.15.12
+    go: 1.15.13
     dependencies:
     - repository: apimachinery
       branch: release-1.19
@@ -266,7 +266,7 @@ rules:
       branch: release-1.20
       dir: staging/src/k8s.io/apiserver
     name: release-1.20
-    go: 1.15.12
+    go: 1.15.13
     dependencies:
     - repository: apimachinery
       branch: release-1.20
@@ -313,7 +313,7 @@ rules:
       branch: release-1.19
       dir: staging/src/k8s.io/kube-aggregator
     name: release-1.19
-    go: 1.15.12
+    go: 1.15.13
     dependencies:
     - repository: apimachinery
       branch: release-1.19
@@ -331,7 +331,7 @@ rules:
       branch: release-1.20
       dir: staging/src/k8s.io/kube-aggregator
     name: release-1.20
-    go: 1.15.12
+    go: 1.15.13
     dependencies:
     - repository: apimachinery
       branch: release-1.20
@@ -391,7 +391,7 @@ rules:
       branch: release-1.19
       dir: staging/src/k8s.io/sample-apiserver
     name: release-1.19
-    go: 1.15.12
+    go: 1.15.13
     dependencies:
     - repository: apimachinery
       branch: release-1.19
@@ -414,7 +414,7 @@ rules:
       branch: release-1.20
       dir: staging/src/k8s.io/sample-apiserver
     name: release-1.20
-    go: 1.15.12
+    go: 1.15.13
     dependencies:
     - repository: apimachinery
       branch: release-1.20
@@ -480,7 +480,7 @@ rules:
       branch: release-1.19
       dir: staging/src/k8s.io/sample-controller
     name: release-1.19
-    go: 1.15.12
+    go: 1.15.13
     dependencies:
     - repository: apimachinery
       branch: release-1.19
@@ -499,7 +499,7 @@ rules:
       branch: release-1.20
       dir: staging/src/k8s.io/sample-controller
     name: release-1.20
-    go: 1.15.12
+    go: 1.15.13
     dependencies:
     - repository: apimachinery
       branch: release-1.20
@@ -558,7 +558,7 @@ rules:
       branch: release-1.19
       dir: staging/src/k8s.io/apiextensions-apiserver
     name: release-1.19
-    go: 1.15.12
+    go: 1.15.13
     dependencies:
     - repository: apimachinery
       branch: release-1.19
@@ -578,7 +578,7 @@ rules:
       branch: release-1.20
       dir: staging/src/k8s.io/apiextensions-apiserver
     name: release-1.20
-    go: 1.15.12
+    go: 1.15.13
     dependencies:
     - repository: apimachinery
       branch: release-1.20
@@ -634,7 +634,7 @@ rules:
       branch: release-1.19
       dir: staging/src/k8s.io/metrics
     name: release-1.19
-    go: 1.15.12
+    go: 1.15.13
     dependencies:
     - repository: apimachinery
       branch: release-1.19
@@ -648,7 +648,7 @@ rules:
       branch: release-1.20
       dir: staging/src/k8s.io/metrics
     name: release-1.20
-    go: 1.15.12
+    go: 1.15.13
     dependencies:
     - repository: apimachinery
       branch: release-1.20
@@ -690,7 +690,7 @@ rules:
       branch: release-1.19
       dir: staging/src/k8s.io/cli-runtime
     name: release-1.19
-    go: 1.15.12
+    go: 1.15.13
     dependencies:
     - repository: api
       branch: release-1.19
@@ -702,7 +702,7 @@ rules:
       branch: release-1.20
       dir: staging/src/k8s.io/cli-runtime
     name: release-1.20
-    go: 1.15.12
+    go: 1.15.13
     dependencies:
     - repository: api
       branch: release-1.20
@@ -742,7 +742,7 @@ rules:
       branch: release-1.19
       dir: staging/src/k8s.io/sample-cli-plugin
     name: release-1.19
-    go: 1.15.12
+    go: 1.15.13
     dependencies:
     - repository: api
       branch: release-1.19
@@ -756,7 +756,7 @@ rules:
       branch: release-1.20
       dir: staging/src/k8s.io/sample-cli-plugin
     name: release-1.20
-    go: 1.15.12
+    go: 1.15.13
     dependencies:
     - repository: api
       branch: release-1.20
@@ -800,7 +800,7 @@ rules:
       branch: release-1.19
       dir: staging/src/k8s.io/kube-proxy
     name: release-1.19
-    go: 1.15.12
+    go: 1.15.13
     dependencies:
     - repository: apimachinery
       branch: release-1.19
@@ -814,7 +814,7 @@ rules:
       branch: release-1.20
       dir: staging/src/k8s.io/kube-proxy
     name: release-1.20
-    go: 1.15.12
+    go: 1.15.13
     dependencies:
     - repository: apimachinery
       branch: release-1.20
@@ -858,7 +858,7 @@ rules:
       branch: release-1.19
       dir: staging/src/k8s.io/kubelet
     name: release-1.19
-    go: 1.15.12
+    go: 1.15.13
     dependencies:
     - repository: apimachinery
       branch: release-1.19
@@ -872,7 +872,7 @@ rules:
       branch: release-1.20
       dir: staging/src/k8s.io/kubelet
     name: release-1.20
-    go: 1.15.12
+    go: 1.15.13
     dependencies:
     - repository: apimachinery
       branch: release-1.20
@@ -916,7 +916,7 @@ rules:
       branch: release-1.19
       dir: staging/src/k8s.io/kube-scheduler
     name: release-1.19
-    go: 1.15.12
+    go: 1.15.13
     dependencies:
     - repository: apimachinery
       branch: release-1.19
@@ -930,7 +930,7 @@ rules:
       branch: release-1.20
       dir: staging/src/k8s.io/kube-scheduler
     name: release-1.20
-    go: 1.15.12
+    go: 1.15.13
     dependencies:
     - repository: apimachinery
       branch: release-1.20
@@ -976,12 +976,12 @@ rules:
       branch: release-1.19
       dir: staging/src/k8s.io/controller-manager
     name: release-1.19
-    go: 1.15.12
+    go: 1.15.13
   - source:
       branch: release-1.20
       dir: staging/src/k8s.io/controller-manager
     name: release-1.20
-    go: 1.15.12
+    go: 1.15.13
     dependencies:
     - repository: api
       branch: release-1.20
@@ -1033,7 +1033,7 @@ rules:
       branch: release-1.19
       dir: staging/src/k8s.io/cloud-provider
     name: release-1.19
-    go: 1.15.12
+    go: 1.15.13
     dependencies:
     - repository: api
       branch: release-1.19
@@ -1047,7 +1047,7 @@ rules:
       branch: release-1.20
       dir: staging/src/k8s.io/cloud-provider
     name: release-1.20
-    go: 1.15.12
+    go: 1.15.13
     dependencies:
     - repository: api
       branch: release-1.20
@@ -1105,7 +1105,7 @@ rules:
       branch: release-1.19
       dir: staging/src/k8s.io/kube-controller-manager
     name: release-1.19
-    go: 1.15.12
+    go: 1.15.13
     dependencies:
     - repository: apimachinery
       branch: release-1.19
@@ -1119,7 +1119,7 @@ rules:
       branch: release-1.20
       dir: staging/src/k8s.io/kube-controller-manager
     name: release-1.20
-    go: 1.15.12
+    go: 1.15.13
     dependencies:
     - repository: apimachinery
       branch: release-1.20
@@ -1171,7 +1171,7 @@ rules:
       branch: release-1.19
       dir: staging/src/k8s.io/cluster-bootstrap
     name: release-1.19
-    go: 1.15.12
+    go: 1.15.13
     dependencies:
     - repository: apimachinery
       branch: release-1.19
@@ -1181,7 +1181,7 @@ rules:
       branch: release-1.20
       dir: staging/src/k8s.io/cluster-bootstrap
     name: release-1.20
-    go: 1.15.12
+    go: 1.15.13
     dependencies:
     - repository: apimachinery
       branch: release-1.20
@@ -1213,7 +1213,7 @@ rules:
       branch: release-1.19
       dir: staging/src/k8s.io/csi-translation-lib
     name: release-1.19
-    go: 1.15.12
+    go: 1.15.13
     dependencies:
     - repository: api
       branch: release-1.19
@@ -1229,7 +1229,7 @@ rules:
       branch: release-1.20
       dir: staging/src/k8s.io/csi-translation-lib
     name: release-1.20
-    go: 1.15.12
+    go: 1.15.13
     dependencies:
     - repository: api
       branch: release-1.20
@@ -1256,7 +1256,7 @@ rules:
       branch: release-1.20
       dir: staging/src/k8s.io/mount-utils
     name: release-1.20
-    go: 1.15.12
+    go: 1.15.13
   - source:
       branch: release-1.21
       dir: staging/src/k8s.io/mount-utils
@@ -1292,7 +1292,7 @@ rules:
       branch: release-1.19
       dir: staging/src/k8s.io/legacy-cloud-providers
     name: release-1.19
-    go: 1.15.12
+    go: 1.15.13
     dependencies:
     - repository: api
       branch: release-1.19
@@ -1312,7 +1312,7 @@ rules:
       branch: release-1.20
       dir: staging/src/k8s.io/legacy-cloud-providers
     name: release-1.20
-    go: 1.15.12
+    go: 1.15.13
     dependencies:
     - repository: api
       branch: release-1.20
@@ -1363,12 +1363,12 @@ rules:
       branch: release-1.19
       dir: staging/src/k8s.io/cri-api
     name: release-1.19
-    go: 1.15.12
+    go: 1.15.13
   - source:
       branch: release-1.20
       dir: staging/src/k8s.io/cri-api
     name: release-1.20
-    go: 1.15.12
+    go: 1.15.13
   - source:
       branch: release-1.21
       dir: staging/src/k8s.io/cri-api
@@ -1402,7 +1402,7 @@ rules:
       branch: release-1.19
       dir: staging/src/k8s.io/kubectl
     name: release-1.19
-    go: 1.15.12
+    go: 1.15.13
     dependencies:
     - repository: api
       branch: release-1.19
@@ -1422,7 +1422,7 @@ rules:
       branch: release-1.20
       dir: staging/src/k8s.io/kubectl
     name: release-1.20
-    go: 1.15.12
+    go: 1.15.13
     dependencies:
     - repository: api
       branch: release-1.20


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/area dependency

#### What this PR does / why we need it:
Go updates for release 1.19 and 1.20 branches

Tracking issue: https://github.com/kubernetes/release/issues/2107


/hold wait for 
 - https://github.com/kubernetes/kubernetes/pull/102809
 - https://github.com/kubernetes/kubernetes/pull/102786


/assign @nikhita @dims 
cc: @kubernetes/release-engineering 

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
