### PR TITLE
Fix static checks failures for apiserver

### DIFF
--- a/hack/.staticcheck_failures
+++ b/hack/.staticcheck_failures
@@ -3,9 +3,6 @@ pkg/util/flag
 test/e2e/apimachinery
 vendor/k8s.io/apimachinery/pkg/util/json
 vendor/k8s.io/apimachinery/pkg/util/strategicpatch
-vendor/k8s.io/apiserver/pkg/server/dynamiccertificates
-vendor/k8s.io/apiserver/pkg/server/filters
-vendor/k8s.io/apiserver/pkg/server/routes
 vendor/k8s.io/apiserver/pkg/storage/cacher
 vendor/k8s.io/apiserver/pkg/storage/tests
 vendor/k8s.io/apiserver/pkg/storage/value/encrypt/envelope

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/filters/audit.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/filters/audit.go
@@ -228,6 +228,8 @@ type fancyResponseWriterDelegator struct {
 	*auditResponseWriter
 }
 
+// CloseNotify implements http.CloseNotifier.
+// Deprecated: use Request.Context instead
 func (f *fancyResponseWriterDelegator) CloseNotify() <-chan bool {
 	return f.ResponseWriter.(http.CloseNotifier).CloseNotify()
 }
@@ -243,6 +245,7 @@ func (f *fancyResponseWriterDelegator) Hijack() (net.Conn, *bufio.ReadWriter, er
 	return f.ResponseWriter.(http.Hijacker).Hijack()
 }
 
+//lint:ignore SA1019 backwards compatibility
 var _ http.CloseNotifier = &fancyResponseWriterDelegator{}
 var _ http.Flusher = &fancyResponseWriterDelegator{}
 var _ http.Hijacker = &fancyResponseWriterDelegator{}

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/metrics/metrics.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/metrics/metrics.go
@@ -497,6 +497,7 @@ func InstrumentHandlerFunc(verb, group, version, resource, subresource, scope, c
 
 		delegate := &ResponseWriterDelegator{ResponseWriter: w}
 
+		//lint:ignore SA1019 backwards compatibility
 		_, cn := w.(http.CloseNotifier)
 		_, fl := w.(http.Flusher)
 		_, hj := w.(http.Hijacker)
@@ -624,6 +625,8 @@ type fancyResponseWriterDelegator struct {
 	*ResponseWriterDelegator
 }
 
+// CloseNotify implements http.CloseNotifier.
+// Deprecated: use Request.Context instead
 func (f *fancyResponseWriterDelegator) CloseNotify() <-chan bool {
 	return f.ResponseWriter.(http.CloseNotifier).CloseNotify()
 }

--- a/staging/src/k8s.io/apiserver/pkg/server/dynamiccertificates/tlsconfig.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/dynamiccertificates/tlsconfig.go
@@ -108,11 +108,13 @@ func (c *DynamicServingCertificateController) GetConfigForClient(clientHello *tl
 		return tlsConfigCopy, nil
 	}
 
+	//lint:ignore SA1019 backward compatibility
 	ipCert, ok := tlsConfigCopy.NameToCertificate[host]
 	if !ok {
 		return tlsConfigCopy, nil
 	}
 	tlsConfigCopy.Certificates = []tls.Certificate{*ipCert}
+	//lint:ignore SA1019 setting to nil as documented
 	tlsConfigCopy.NameToCertificate = nil
 
 	return tlsConfigCopy, nil
@@ -206,6 +208,7 @@ func (c *DynamicServingCertificateController) syncCerts() error {
 	}
 
 	if len(newContent.sniCerts) > 0 {
+		//lint:ignore SA1019 backwards compatibility
 		newTLSConfigCopy.NameToCertificate, err = c.BuildNamedCertificates(newContent.sniCerts)
 		if err != nil {
 			return fmt.Errorf("unable to build named certificate map: %v", err)
@@ -215,6 +218,7 @@ func (c *DynamicServingCertificateController) syncCerts() error {
 		// is necessary because there is only one cert anyway.
 		// Moreover, if servingCert is not set, the first SNI
 		// cert will become the default cert. That's what we expect anyway.
+		//lint:ignore SA1019 copying certificates to proper field
 		for _, sniCert := range newTLSConfigCopy.NameToCertificate {
 			newTLSConfigCopy.Certificates = append(newTLSConfigCopy.Certificates, *sniCert)
 		}

--- a/staging/src/k8s.io/apiserver/pkg/server/filters/goaway_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/filters/goaway_test.go
@@ -105,10 +105,6 @@ var (
 	// for watch request, test GOAWAY server push 1 byte in every second.
 	responseBody = []byte("hello")
 
-	// responseBodySize is the size of response body which test GOAWAY server sent for watch request,
-	// used to check if watch request was broken by GOAWAY frame.
-	responseBodySize = len(responseBody)
-
 	// requestPostBody is the request body which client must send to test GOAWAY server for POST method,
 	// otherwise, test GOAWAY server will respond 400 HTTP status code.
 	requestPostBody = responseBody

--- a/staging/src/k8s.io/apiserver/pkg/server/filters/timeout.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/filters/timeout.go
@@ -149,6 +149,7 @@ type timeoutWriter interface {
 func newTimeoutWriter(w http.ResponseWriter) timeoutWriter {
 	base := &baseTimeoutWriter{w: w}
 
+	//lint:ignore SA1019 backward compatibility
 	_, notifiable := w.(http.CloseNotifier)
 	_, hijackable := w.(http.Hijacker)
 
@@ -269,6 +270,7 @@ func (tw *baseTimeoutWriter) closeNotify() <-chan bool {
 		return done
 	}
 
+	//lint:ignore SA1019 backward compatibility
 	return tw.w.(http.CloseNotifier).CloseNotify()
 }
 

--- a/staging/src/k8s.io/apiserver/pkg/server/httplog/httplog.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/httplog/httplog.go
@@ -126,11 +126,6 @@ func newLoggedWithStartTime(req *http.Request, w http.ResponseWriter, startTime 
 	}
 }
 
-// newLogged turns a normal response writer into a logged response writer.
-func newLogged(req *http.Request, w http.ResponseWriter) *respLogger {
-	return newLoggedWithStartTime(req, w, time.Now())
-}
-
 // LogOf returns the logger hiding in w. If there is not an existing logger
 // then a passthroughLogger will be created which will log to stdout immediately
 // when Addf is called.

--- a/staging/src/k8s.io/apiserver/pkg/server/httplog/httplog_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/httplog/httplog_test.go
@@ -21,6 +21,7 @@ import (
 	"net/http/httptest"
 	"reflect"
 	"testing"
+	"time"
 )
 
 func TestDefaultStacktracePred(t *testing.T) {
@@ -132,6 +133,11 @@ type testResponseWriter struct{}
 func (*testResponseWriter) Header() http.Header       { return nil }
 func (*testResponseWriter) Write([]byte) (int, error) { return 0, nil }
 func (*testResponseWriter) WriteHeader(int)           {}
+
+// newLogged turns a normal response writer into a logged response writer.
+func newLogged(req *http.Request, w http.ResponseWriter) *respLogger {
+	return newLoggedWithStartTime(req, w, time.Now())
+}
 
 func TestLoggedStatus(t *testing.T) {
 	req, err := http.NewRequest("GET", "http://example.com", nil)

--- a/staging/src/k8s.io/apiserver/pkg/server/routes/metrics.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/routes/metrics.go
@@ -30,6 +30,7 @@ type DefaultMetrics struct{}
 // Install adds the DefaultMetrics handler
 func (m DefaultMetrics) Install(c *mux.PathRecorderMux) {
 	register()
+	//lint:ignore SA1019 backwards compatibility
 	c.Handle("/metrics", legacyregistry.Handler())
 }
 

--- a/staging/src/k8s.io/component-base/metrics/testutil/metrics.go
+++ b/staging/src/k8s.io/component-base/metrics/testutil/metrics.go
@@ -211,10 +211,6 @@ func GetHistogramFromGatherer(gatherer metrics.Gatherer, metricName string) (His
 	}, nil
 }
 
-func uint64Ptr(u uint64) *uint64 {
-	return &u
-}
-
 // Bucket of a histogram
 type bucket struct {
 	upperBound float64

--- a/staging/src/k8s.io/component-base/metrics/testutil/metrics_test.go
+++ b/staging/src/k8s.io/component-base/metrics/testutil/metrics_test.go
@@ -26,6 +26,10 @@ import (
 	dto "github.com/prometheus/client_model/go"
 )
 
+func uint64Ptr(u uint64) *uint64 {
+	return &u
+}
+
 func samples2Histogram(samples []float64, upperBounds []float64) Histogram {
 	histogram := dto.Histogram{
 		SampleCount: uint64Ptr(0),


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
Address static check failures in the following directories:
- `staging/k8s.io/apiserver/pkg/endpoints`
- `staging/k8s.io/apiserver/pkg/server`

#### Which issue(s) this PR fixes:
Partially addresses #92402

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

