### PR TITLE
cherry-pick #100353: strip prefix 'v' in coredns version if exists

### DIFF
--- a/cluster/gce/upgrade.sh
+++ b/cluster/gce/upgrade.sh
@@ -480,7 +480,7 @@ function update-coredns-config() {
   fi
 
   echo "== Fetching the latest installed CoreDNS version =="
-  NEW_COREDNS_VERSION=$("${KUBE_ROOT}"/cluster/kubectl.sh -n kube-system get deployment coredns -o=jsonpath='{$.spec.template.spec.containers[:1].image}' | cut -d ":" -f 2)
+  NEW_COREDNS_VERSION=$("${KUBE_ROOT}"/cluster/kubectl.sh -n kube-system get deployment coredns -o=jsonpath='{$.spec.template.spec.containers[:1].image}' | sed -r 's/.+:v?(.+)/\1/')
 
   case "$(uname -m)" in
       x86_64*)
@@ -552,7 +552,7 @@ function update-coredns-config() {
 }
 
 echo "Fetching the previously installed CoreDNS version"
-CURRENT_COREDNS_VERSION=$("${KUBE_ROOT}/cluster/kubectl.sh" -n kube-system get deployment coredns -o=jsonpath='{$.spec.template.spec.containers[:1].image}' | cut -d ":" -f 2)
+CURRENT_COREDNS_VERSION=$("${KUBE_ROOT}/cluster/kubectl.sh" -n kube-system get deployment coredns -o=jsonpath='{$.spec.template.spec.containers[:1].image}' | sed -r 's/.+:v?(.+)/\1/')
 COREDNS_DEPLOY_RESOURCE_VERSION=$("${KUBE_ROOT}/cluster/kubectl.sh" -n kube-system get deployment coredns -o=jsonpath='{$.metadata.resourceVersion}')
 
 master_upgrade=true


### PR DESCRIPTION
/kind bug
/kind failing-test
cherry-pick #100353 to 1.21 to fix the test failure

fix coredns failure in ci-kubernetes-e2e-gce-stable1-beta-upgrade-cluster-new-parallel

https://storage.googleapis.com/k8s-gubernator/triage/index.html?job=gce-stable#8da0c0e98cf68c6146d2
```
Error: error while migration: cannot migrate up to 'v1.8.0' from '1.7.0
```
failure example: https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-stable1-beta-upgrade-cluster-new-parallel/1404770969326718976

/cc zshihang liggitt
/triage accepted
/priority important-soon

```release-note
NONE
```


https://github.com/kubernetes/test-infra/blob/a5528997fea7e64a44a3335ad95c4d3df6514ed7/config/jobs/kubernetes/sig-cloud-provider/gcp/upgrade-gce.yaml#L113