### PR TITLE
Fix HPA bug about unintentional scale out during updating deployment

### DIFF
--- a/pkg/controller/podautoscaler/replica_calculator.go
+++ b/pkg/controller/podautoscaler/replica_calculator.go
@@ -233,9 +233,15 @@ func (c *ReplicaCalculator) calcPlainMetricReplicas(metrics metricsclient.PodMet
 		return currentReplicas, utilization, nil
 	}
 
+	newReplicas := int32(math.Ceil(newUsageRatio * float64(len(metrics))))
+	if (newUsageRatio < 1.0 && newReplicas > currentReplicas) || (newUsageRatio > 1.0 && newReplicas < currentReplicas) {
+		// return the current replicas if the change of metrics length would cause a change in scale direction
+		return currentReplicas, utilization, nil
+	}
+
 	// return the result, where the number of replicas considered is
 	// however many replicas factored into our calculation
-	return int32(math.Ceil(newUsageRatio * float64(len(metrics)))), utilization, nil
+	return newReplicas, utilization, nil
 }
 
 // GetObjectMetricReplicas calculates the desired replica count based on a target metric utilization (as a milli-value)

--- a/pkg/controller/podautoscaler/replica_calculator_test.go
+++ b/pkg/controller/podautoscaler/replica_calculator_test.go
@@ -1265,6 +1265,22 @@ func TestReplicaCalcDuringRollingUpdateWithMaxSurge(t *testing.T) {
 	tc.runTest(t)
 }
 
+func TestReplicaCalcDuringRollingUpdateWithMaxSurgeCM(t *testing.T) {
+	tc := replicaCalcTestCase{
+		currentReplicas:  2,
+		expectedReplicas: 2,
+		podPhase:         []v1.PodPhase{v1.PodRunning, v1.PodRunning, v1.PodRunning},
+		metric: &metricInfo{
+			name:                "qps",
+			levels:              []int64{10000, 10000},
+			targetUtilization:   17000,
+			expectedUtilization: 10000,
+			metricType:          podMetric,
+		},
+	}
+	tc.runTest(t)
+}
+
 // TestComputedToleranceAlgImplementation is a regression test which
 // back-calculates a minimal percentage for downscaling based on a small percentage
 // increase in pod utilization which is calibrated against the tolerance value.

--- a/pkg/scheduler/core/generic_scheduler.go
+++ b/pkg/scheduler/core/generic_scheduler.go
@@ -196,7 +196,7 @@ func (g *genericScheduler) Schedule(pod *v1.Pod, pluginContext *framework.Plugin
 
 	// Run "prefilter" plugins.
 	preFilterStatus := g.framework.RunPreFilterPlugins(pluginContext, pod)
-	if !preFilterStatus.IsSuccess() {
+	if preFilterStatus == nil || !preFilterStatus.IsSuccess() {
 		return result, preFilterStatus.AsError()
 	}
 
@@ -218,7 +218,7 @@ func (g *genericScheduler) Schedule(pod *v1.Pod, pluginContext *framework.Plugin
 
 	// Run "postfilter" plugins.
 	postfilterStatus := g.framework.RunPostFilterPlugins(pluginContext, pod, filteredNodes, filteredNodesStatuses)
-	if !postfilterStatus.IsSuccess() {
+	if postfilterStatus == nil || !postfilterStatus.IsSuccess() {
 		return result, postfilterStatus.AsError()
 	}
 

--- a/pkg/scheduler/core/generic_scheduler.go
+++ b/pkg/scheduler/core/generic_scheduler.go
@@ -547,7 +547,7 @@ func (g *genericScheduler) findNodesThatFit(pluginContext *framework.PluginConte
 					continue
 				}
 
-				return []*v1.Node{}, FailedPredicateMap{}, framework.NodeToStatusMap{}, err
+				return filtered, failedPredicateMap, filteredNodesStatuses, nil
 			}
 
 			for failedNodeName, failedMsg := range failedMap {


### PR DESCRIPTION
What type of PR is this?

/kind bug


[First commit](https://github.com/kubernetes/kubernetes/pull/102914/commits/760613a5e01d86e43ec2b22e923e79f2b30dacd1)

What this PR does / why we need it:

During rolling update with maxSurge: 1 and maxUnavailable: 0, len(metrics) may be greater than currentReplcas and it may cause unintentional scale out in spite of usageRatio and newUsageRatio are less than 1.0. This PR fix that bug.

More detail scenario description and the way to reproduce bug is described in #84142 . Please see it.

Which issue(s) this PR fixes:

Fixes [#84142](https://github.com/kubernetes/kubernetes/issues/84142)

[Second commit]
(https://github.com/kubernetes/kubernetes/pull/102914/commits/f89f6f5f5cc486705c7ecb0c618e0685c4fe7a4b)

What this PR does / why we need it:

framework.RunPostFilterPlugins or framework.RunPreFilterPlugins may return nil,so add the assertion of nil
