### PR TITLE
Use "Capacity" instead of "Allocatable" for an accurate node memory total size

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/top/top_node.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/top/top_node.go
@@ -43,6 +43,7 @@ type TopNodeOptions struct {
 	SortBy             string
 	NoHeaders          bool
 	UseProtocolBuffers bool
+	ShowCapacity       bool
 
 	NodeClient      corev1client.CoreV1Interface
 	Printer         *metricsutil.TopCmdPrinter
@@ -91,6 +92,7 @@ func NewCmdTopNode(f cmdutil.Factory, o *TopNodeOptions, streams genericclioptio
 	cmd.Flags().StringVar(&o.SortBy, "sort-by", o.SortBy, "If non-empty, sort nodes list using specified field. The field can be either 'cpu' or 'memory'.")
 	cmd.Flags().BoolVar(&o.NoHeaders, "no-headers", o.NoHeaders, "If present, print output without headers")
 	cmd.Flags().BoolVar(&o.UseProtocolBuffers, "use-protocol-buffers", o.UseProtocolBuffers, "Enables using protocol-buffers to access Metrics API.")
+	cmd.Flags().BoolVar(&o.ShowCapacity, "show-capacity", o.ShowCapacity, "Print node resources based on Capacity instead of Allocatable(default) of the nodes.")
 
 	return cmd
 }
@@ -186,13 +188,17 @@ func (o TopNodeOptions) RunTopNode() error {
 		nodes = append(nodes, nodeList.Items...)
 	}
 
-	allocatable := make(map[string]v1.ResourceList)
+	availableResources := make(map[string]v1.ResourceList)
 
 	for _, n := range nodes {
-		allocatable[n.Name] = n.Status.Allocatable
+		if !o.ShowCapacity {
+			availableResources[n.Name] = n.Status.Allocatable
+		} else {
+			availableResources[n.Name] = n.Status.Capacity
+		}
 	}
 
-	return o.Printer.PrintNodeMetrics(metrics.Items, allocatable, o.NoHeaders, o.SortBy)
+	return o.Printer.PrintNodeMetrics(metrics.Items, availableResources, o.NoHeaders, o.SortBy)
 }
 
 func getNodeMetricsFromMetricsAPI(metricsClient metricsclientset.Interface, resourceName string, selector labels.Selector) (*metricsapi.NodeMetricsList, error) {


### PR DESCRIPTION
**What type of PR is this?**

/kind bug
/sig cli

**What this PR does / why we need it:**

  "Allocatable" is just a logical total memory size based on `[Allocatable] = [Node Capacity] - [system-reserved] - [Hard-Eviction-Thresholds]`.
  In contrast, the node memory usage collected by Metrics API(metrics.k8s.io) is based on real usage constantly on the node host. So if `system-reserved` or `hard-eviction` threshold is configured bigger, the `MEMORY%` can be overflow than `100%`.
  
  We focus the "Allocatable" value is useful to schedule pods to a node, at that time scheduler consider the pod memory requests size based on logical value. All values and calculation is under logical assumption.

  But the real node total memory usage that is "MEMORY%" of "kubectl top node" column value is different.
  It should be based on the actual hard threshold size `(MemTotal in /proc/meminfo)`, because the collected metrics usage is also based on real usage on the node host.
  We should not mix the logical and real values to calculate some value accurately, so we should replace "Allocatable" with "Capacity" which is the same with the `MemTotal` in "MEMORY%" calculation for accurate total node memory usage.

  ```
  (before) [MEMORY%] =  [node memory usage of the Metrics API] / [node Allocatable] * 100
  (after ) [MEMORY%] =  [node memory usage of the Metrics API] / [node Capacity]    * 100
  ```

**Which issue(s) this PR fixes:**

Fixes https://github.com/kubernetes/kubernetes/issues/86499

**Special notes for your reviewer:**

**Does this PR introduce a user-facing change?**
```release-note
Added show-capacity option to `kubectl top node` to show `Capacity` resource usage
```