### PR TITLE
Run volume cloning tests in the same topology segment

### DIFF
--- a/test/e2e/storage/testsuites/provisioning.go
+++ b/test/e2e/storage/testsuites/provisioning.go
@@ -60,6 +60,7 @@ type StorageClassTest struct {
 	PvCheck              func(claim *v1.PersistentVolumeClaim)
 	VolumeMode           v1.PersistentVolumeMode
 	AllowVolumeExpansion bool
+	NodeSelection        e2epod.NodeSelection
 }
 
 type provisioningTestSuite struct {
@@ -242,12 +243,20 @@ func (p *provisioningTestSuite) DefineTests(driver storageframework.TestDriver, 
 		init()
 		defer cleanup()
 
+		if l.config.ClientNodeSelection.Name == "" {
+			// Schedule all pods to the same topology segment (e.g. a cloud availability zone), some
+			// drivers don't support cloning across them.
+			if err := ensureTopologyRequirements(&l.config.ClientNodeSelection, l.cs, dInfo, 1); err != nil {
+				framework.Failf("Error setting topology requirements: %v", err)
+			}
+		}
 		testConfig := storageframework.ConvertTestConfig(l.config)
 		expectedContent := fmt.Sprintf("Hello from namespace %s", f.Namespace.Name)
 		dataSource, dataSourceCleanup := preparePVCDataSourceForProvisioning(f, testConfig, l.cs, l.sourcePVC, l.sc, pattern.VolMode, expectedContent)
 		defer dataSourceCleanup()
 
 		l.pvc.Spec.DataSource = dataSource
+		l.testCase.NodeSelection = testConfig.ClientNodeSelection
 		l.testCase.PvCheck = func(claim *v1.PersistentVolumeClaim) {
 			ginkgo.By("checking whether the created volume has the pre-populated data")
 			tests := []e2evolume.Test{
@@ -275,6 +284,13 @@ func (p *provisioningTestSuite) DefineTests(driver storageframework.TestDriver, 
 		init()
 		defer cleanup()
 
+		if l.config.ClientNodeSelection.Name == "" {
+			// Schedule all pods to the same topology segment (e.g. a cloud availability zone), some
+			// drivers don't support cloning across them.
+			if err := ensureTopologyRequirements(&l.config.ClientNodeSelection, l.cs, dInfo, 1); err != nil {
+				framework.Failf("Error setting topology requirements: %v", err)
+			}
+		}
 		testConfig := storageframework.ConvertTestConfig(l.config)
 		expectedContent := fmt.Sprintf("Hello from namespace %s", f.Namespace.Name)
 		dataSource, dataSourceCleanup := preparePVCDataSourceForProvisioning(f, testConfig, l.cs, l.sourcePVC, l.sc, pattern.VolMode, expectedContent)
@@ -293,6 +309,7 @@ func (p *provisioningTestSuite) DefineTests(driver storageframework.TestDriver, 
 				myTestConfig.Prefix = fmt.Sprintf("%s-%d", myTestConfig.Prefix, i)
 
 				t := *l.testCase
+				t.NodeSelection = testConfig.ClientNodeSelection
 				t.PvCheck = func(claim *v1.PersistentVolumeClaim) {
 					ginkgo.By(fmt.Sprintf("checking whether the created volume %d has the pre-populated data", i))
 					tests := []e2evolume.Test{
@@ -390,8 +407,9 @@ func (t StorageClassTest) TestDynamicProvisioning() *v1.PersistentVolume {
 	if *class.VolumeBindingMode == storagev1.VolumeBindingWaitForFirstConsumer {
 		ginkgo.By(fmt.Sprintf("creating a pod referring to the class=%+v claim=%+v", class, claim))
 		var podConfig *e2epod.Config = &e2epod.Config{
-			NS:   claim.Namespace,
-			PVCs: []*v1.PersistentVolumeClaim{claim},
+			NS:            claim.Namespace,
+			PVCs:          []*v1.PersistentVolumeClaim{claim},
+			NodeSelection: t.NodeSelection,
 		}
 
 		var pod *v1.Pod


### PR DESCRIPTION
#### What type of PR is this?
/kind bug
(?)

#### What this PR does / why we need it:
Some CSI drivers can't clone a volume into another topology segment (e.g. a cloud availability zone). The scheduler does not know about these restrictions and schedules pods with PVCs that clone a volume mostly randomly.
    
Run all volume cloning tests in the same topology segment, if such segment is available and has at least one schedulable node.

When at it, I refactored `ensureTopologyRequirements` to contain all common code that was copied around all tests that used it to avoid copying it to cloning tests.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
