### PR TITLE
Speed up unit tests in -race detection mode

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/api/apitesting/roundtrip/fuzz_norace.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/apitesting/roundtrip/fuzz_norace.go
@@ -1,0 +1,22 @@
+// +build !race
+
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package roundtrip
+
+// in non-race-detection mode, a higher number of iterations is reasonable
+const defaultFuzzIters = 20

--- a/staging/src/k8s.io/apimachinery/pkg/api/apitesting/roundtrip/fuzz_race.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/apitesting/roundtrip/fuzz_race.go
@@ -1,0 +1,22 @@
+// +build race
+
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package roundtrip
+
+// in race-detection mode, lower the number of iterations to keep reasonable runtimes in CI
+const defaultFuzzIters = 5

--- a/staging/src/k8s.io/apimachinery/pkg/api/apitesting/roundtrip/roundtrip.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/apitesting/roundtrip/roundtrip.go
@@ -85,7 +85,7 @@ func RoundTripProtobufTestForScheme(t *testing.T, scheme *runtime.Scheme, fuzzin
 	RoundTripTypes(t, scheme, codecFactory, fuzzer, nil)
 }
 
-var FuzzIters = flag.Int("fuzz-iters", 20, "How many fuzzing iterations to do.")
+var FuzzIters = flag.Int("fuzz-iters", defaultFuzzIters, "How many fuzzing iterations to do.")
 
 // globalNonRoundTrippableTypes are kinds that are effectively reserved across all GroupVersions
 // They don't roundtrip


### PR DESCRIPTION
#### What type of PR is this?

/kind flake

#### What this PR does / why we need it:

Lowers the number of fuzz iterations when testing in race detection mode... these tests take longer than 3 minutes in CI currently and time out.


```release-note
NONE
```

cc @BenTheElder 