### PR TITLE
Set EC2 instance cache max age to 10 mins

### DIFF
--- a/staging/src/k8s.io/legacy-cloud-providers/aws/aws_loadbalancer.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/aws/aws_loadbalancer.go
@@ -26,6 +26,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
@@ -52,6 +53,9 @@ const (
 	lbAttrAccessLogsS3Enabled           = "access_logs.s3.enabled"
 	lbAttrAccessLogsS3Bucket            = "access_logs.s3.bucket"
 	lbAttrAccessLogsS3Prefix            = "access_logs.s3.prefix"
+
+	// defaultEC2InstanceCacheMaxAge is the max age for the EC2 instance cache
+	defaultEC2InstanceCacheMaxAge = 10 * time.Minute
 )
 
 var (
@@ -1606,7 +1610,7 @@ func (c *Cloud) findInstancesForELB(nodes []*v1.Node, annotations map[string]str
 	instanceIDs := mapToAWSInstanceIDsTolerant(targetNodes)
 
 	cacheCriteria := cacheCriteria{
-		// MaxAge not required, because we only care about security groups, which should not change
+		MaxAge:       defaultEC2InstanceCacheMaxAge,
 		HasInstances: instanceIDs, // Refresh if any of the instance ids are missing
 	}
 	snapshot, err := c.instanceCache.describeAllInstancesCached(cacheCriteria)

--- a/staging/src/k8s.io/legacy-cloud-providers/aws/aws_loadbalancer_test.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/aws/aws_loadbalancer_test.go
@@ -19,15 +19,20 @@ limitations under the License.
 package aws
 
 import (
-	"k8s.io/apimachinery/pkg/types"
+	"fmt"
+	"reflect"
 	"testing"
+	"time"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/elb"
 	"github.com/aws/aws-sdk-go/service/elbv2"
 	"github.com/stretchr/testify/assert"
-
-	"k8s.io/api/core/v1"
 )
 
 func TestElbProtocolsAreEqual(t *testing.T) {
@@ -540,6 +545,86 @@ func TestFilterTargetNodes(t *testing.T) {
 			}
 		})
 	}
+}
+
+func makeNodeInstancePair(offset int) (*v1.Node, *ec2.Instance) {
+	instanceID := fmt.Sprintf("i-%x", int64(0x03bcc3496da09f78e)+int64(offset))
+	instance := &ec2.Instance{
+		InstanceId: aws.String(instanceID),
+		Placement: &ec2.Placement{
+			AvailabilityZone: aws.String("us-east-1b"),
+		},
+		PrivateDnsName:   aws.String(fmt.Sprintf("ip-192-168-32-%d.ec2.internal", 101+offset)),
+		PrivateIpAddress: aws.String(fmt.Sprintf("192.168.32.%d", 101+offset)),
+		PublicIpAddress:  aws.String(fmt.Sprintf("1.2.3.%d", 1+offset)),
+	}
+
+	var tag ec2.Tag
+	tag.Key = aws.String(fmt.Sprintf("%s%s", TagNameKubernetesClusterPrefix, TestClusterID))
+	tag.Value = aws.String("owned")
+	instance.Tags = []*ec2.Tag{&tag}
+
+	node := &v1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: fmt.Sprintf("ip-192-168-0-%d.ec2.internal", 101+offset),
+		},
+		Spec: v1.NodeSpec{
+			ProviderID: fmt.Sprintf("aws:///us-east-1b/%s", instanceID),
+		},
+	}
+	return node, instance
+}
+
+func TestCloud_findInstancesForELB(t *testing.T) {
+	defaultNode := &v1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "ip-172-20-0-100.ec2.internal",
+		},
+		Spec: v1.NodeSpec{
+			ProviderID: "aws:///us-east-1a/i-self",
+		},
+	}
+	newNode, newInstance := makeNodeInstancePair(1)
+	awsServices := NewFakeAWSServices(TestClusterID)
+	c, err := newAWSCloud(CloudConfig{}, awsServices)
+	if err != nil {
+		t.Errorf("Error building aws cloud: %v", err)
+		return
+	}
+
+	want := map[InstanceID]*ec2.Instance{
+		"i-self": awsServices.selfInstance,
+	}
+	got, err := c.findInstancesForELB([]*v1.Node{defaultNode}, nil)
+	assert.NoError(t, err)
+	assert.True(t, reflect.DeepEqual(want, got))
+
+	// Add a new EC2 instance
+	awsServices.instances = append(awsServices.instances, newInstance)
+	want = map[InstanceID]*ec2.Instance{
+		"i-self": awsServices.selfInstance,
+		InstanceID(aws.StringValue(newInstance.InstanceId)): newInstance,
+	}
+	got, err = c.findInstancesForELB([]*v1.Node{defaultNode, newNode}, nil)
+	assert.NoError(t, err)
+	assert.True(t, reflect.DeepEqual(want, got))
+
+	// Verify existing instance cache gets used
+	cacheExpiryOld := c.instanceCache.snapshot.timestamp
+	got, err = c.findInstancesForELB([]*v1.Node{defaultNode, newNode}, nil)
+	assert.NoError(t, err)
+	assert.True(t, reflect.DeepEqual(want, got))
+	cacheExpiryNew := c.instanceCache.snapshot.timestamp
+	assert.Equal(t, cacheExpiryOld, cacheExpiryNew)
+
+	// Force cache expiry and verify cache gets updated with new timestamp
+	cacheExpiryOld = c.instanceCache.snapshot.timestamp
+	c.instanceCache.snapshot.timestamp = c.instanceCache.snapshot.timestamp.Add(-(defaultEC2InstanceCacheMaxAge + 1*time.Second))
+	got, err = c.findInstancesForELB([]*v1.Node{defaultNode, newNode}, nil)
+	assert.NoError(t, err)
+	assert.True(t, reflect.DeepEqual(want, got))
+	cacheExpiryNew = c.instanceCache.snapshot.timestamp
+	assert.True(t, cacheExpiryNew.After(cacheExpiryOld))
 }
 
 func TestCloud_chunkTargetDescriptions(t *testing.T) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
The AWS in-tree controller caches the EC2 instance information indefinitely unless the nodes get scaled up. In case the EC2 instances have multiple security groups attached, this caching strategy leads to inconsistency between the actual EC2 instance configuration in AWS and the controller's view of the EC2 instance information. This PR sets the maximum age of 10 minutes to the EC2 instance cache.

Once the security group requirements are satisfied, controller will be able to fetch the new EC2 information, and get past the following errors without scaling up the nodes - 
- Multiple tagged security groups found for instance i-xxxx ...
- Multiple untagged security groups found for instance i-xxx ...

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:
Testing
- First setup an EC2 instance with at least 2 security groups, none of them contain the cluster tag. As expected, the in-tree controller fails to provision the load balancer. Attach a cluster tagged security group to the EC2 instances, and verify after the cache expiry controller is able to fetch the updated information without having to scale up the k8s worker nodes.
- Update the EC2 instance security groups configuration, and verify the the controller is able to update the correct security group after the cache expiry.
 
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
NONE
```
