### PR TITLE
Simplify construction of the fake dynamic client

### DIFF
--- a/staging/src/k8s.io/client-go/dynamic/fake/simple_test.go
+++ b/staging/src/k8s.io/client-go/dynamic/fake/simple_test.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -303,3 +304,166 @@ func TestPatch(t *testing.T) {
 		t.Run(tc.name, tc.runner)
 	}
 }
+
+// This test ensures list works when the fake dynamic client is seeded with a typed scheme and
+// unstructured type fixtures
+func TestListWithUnstructuredObjectsAndTypedScheme(t *testing.T) {
+	gvr := schema.GroupVersionResource{Group: testGroup, Version: testVersion, Resource: testResource}
+	gvk := gvr.GroupVersion().WithKind(testKind)
+
+	listGVK := gvk
+	listGVK.Kind += "List"
+
+	u := unstructured.Unstructured{}
+	u.SetGroupVersionKind(gvk)
+	u.SetName("name")
+	u.SetNamespace("namespace")
+
+	typedScheme := runtime.NewScheme()
+	typedScheme.AddKnownTypeWithName(gvk, &mockResource{})
+	typedScheme.AddKnownTypeWithName(listGVK, &mockResourceList{})
+
+	client := NewSimpleDynamicClient(typedScheme, &u)
+	list, err := client.Resource(gvr).Namespace("namespace").List(context.Background(), metav1.ListOptions{})
+
+	if err != nil {
+		t.Error("error listing", err)
+	}
+
+	expectedList := &unstructured.UnstructuredList{}
+	expectedList.SetGroupVersionKind(listGVK)
+	expectedList.SetResourceVersion("") // by product of the fake setting resource version
+	expectedList.Items = append(expectedList.Items, u)
+
+	if diff := cmp.Diff(expectedList, list); diff != "" {
+		t.Fatal("unexpected diff (-want, +got): ", diff)
+	}
+}
+
+func TestListWithNoFixturesAndTypedScheme(t *testing.T) {
+	gvr := schema.GroupVersionResource{Group: testGroup, Version: testVersion, Resource: testResource}
+	gvk := gvr.GroupVersion().WithKind(testKind)
+
+	listGVK := gvk
+	listGVK.Kind += "List"
+
+	typedScheme := runtime.NewScheme()
+	typedScheme.AddKnownTypeWithName(gvk, &mockResource{})
+	typedScheme.AddKnownTypeWithName(listGVK, &mockResourceList{})
+
+	client := NewSimpleDynamicClient(typedScheme)
+	list, err := client.Resource(gvr).Namespace("namespace").List(context.Background(), metav1.ListOptions{})
+
+	if err != nil {
+		t.Error("error listing", err)
+	}
+
+	expectedList := &unstructured.UnstructuredList{}
+	expectedList.SetGroupVersionKind(listGVK)
+	expectedList.SetResourceVersion("") // by product of the fake setting resource version
+
+	if diff := cmp.Diff(expectedList, list); diff != "" {
+		t.Fatal("unexpected diff (-want, +got): ", diff)
+	}
+}
+
+// This test ensures list works when the dynamic client is seeded with an empty scheme and
+// unstructured typed fixtures
+func TestListWithNoScheme(t *testing.T) {
+	gvr := schema.GroupVersionResource{Group: testGroup, Version: testVersion, Resource: testResource}
+	gvk := gvr.GroupVersion().WithKind(testKind)
+
+	listGVK := gvk
+	listGVK.Kind += "List"
+
+	u := unstructured.Unstructured{}
+	u.SetGroupVersionKind(gvk)
+	u.SetName("name")
+	u.SetNamespace("namespace")
+
+	emptyScheme := runtime.NewScheme()
+
+	client := NewSimpleDynamicClient(emptyScheme, &u)
+	list, err := client.Resource(gvr).Namespace("namespace").List(context.Background(), metav1.ListOptions{})
+
+	if err != nil {
+		t.Error("error listing", err)
+	}
+
+	expectedList := &unstructured.UnstructuredList{}
+	expectedList.SetGroupVersionKind(listGVK)
+	expectedList.SetResourceVersion("") // by product of the fake setting resource version
+	expectedList.Items = append(expectedList.Items, u)
+
+	if diff := cmp.Diff(expectedList, list); diff != "" {
+		t.Fatal("unexpected diff (-want, +got): ", diff)
+	}
+}
+
+// This test ensures list works when the dynamic client is seeded with an empty scheme and
+// unstructured typed fixtures
+func TestListWithTypedFixtures(t *testing.T) {
+	gvr := schema.GroupVersionResource{Group: testGroup, Version: testVersion, Resource: testResource}
+	gvk := gvr.GroupVersion().WithKind(testKind)
+
+	listGVK := gvk
+	listGVK.Kind += "List"
+
+	r := mockResource{}
+	r.SetGroupVersionKind(gvk)
+	r.SetName("name")
+	r.SetNamespace("namespace")
+
+	u := unstructured.Unstructured{}
+	u.SetGroupVersionKind(r.GetObjectKind().GroupVersionKind())
+	u.SetName(r.GetName())
+	u.SetNamespace(r.GetNamespace())
+	// Needed see: https://github.com/kubernetes/kubernetes/issues/67610
+	unstructured.SetNestedField(u.Object, nil, "metadata", "creationTimestamp")
+
+	typedScheme := runtime.NewScheme()
+	typedScheme.AddKnownTypeWithName(gvk, &mockResource{})
+	typedScheme.AddKnownTypeWithName(listGVK, &mockResourceList{})
+
+	client := NewSimpleDynamicClient(typedScheme, &r)
+	list, err := client.Resource(gvr).Namespace("namespace").List(context.Background(), metav1.ListOptions{})
+
+	if err != nil {
+		t.Error("error listing", err)
+	}
+
+	expectedList := &unstructured.UnstructuredList{}
+	expectedList.SetGroupVersionKind(listGVK)
+	expectedList.SetResourceVersion("") // by product of the fake setting resource version
+	expectedList.Items = []unstructured.Unstructured{u}
+
+	if diff := cmp.Diff(expectedList, list); diff != "" {
+		t.Fatal("unexpected diff (-want, +got): ", diff)
+	}
+}
+
+type (
+	mockResource struct {
+		metav1.TypeMeta   `json:",inline"`
+		metav1.ObjectMeta `json:"metadata"`
+	}
+	mockResourceList struct {
+		metav1.TypeMeta `json:",inline"`
+		metav1.ListMeta `json:"metadata"`
+
+		Items []mockResource
+	}
+)
+
+func (l *mockResourceList) DeepCopyObject() runtime.Object {
+	o := *l
+	return &o
+}
+
+func (r *mockResource) DeepCopyObject() runtime.Object {
+	o := *r
+	return &o
+}
+
+var _ runtime.Object = (*mockResource)(nil)
+var _ runtime.Object = (*mockResourceList)(nil)


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind cleanup

#### What this PR does / why we need it:
With the introduction of GVK to the fake dynamic client it made using
the fake much more cumbersome.

Specifically:
- requires manual registration of list types
- mismatch between scheme types and passed in fixtures would result in errors

The PR changes the constructor method NewSimpleDynamicClient to do the following:
- rewire the schemes to unstructured types
- typed fixtures are converted to unstructured types
- automatically register fixture gvks with the scheme

This should make the dynamic client 'flexible' with it's inputs like it was
before

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes N/A

#### Special notes for your reviewer:
Thanks!

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
NONE
```
