### PR TITLE
WIP: Troubleshooting E2E GCE slow test timeouts

### DIFF
--- a/test/e2e/framework/exec_util.go
+++ b/test/e2e/framework/exec_util.go
@@ -19,9 +19,11 @@ package framework
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"io"
 	"net/url"
 	"strings"
+	"time"
 
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -55,6 +57,9 @@ func (f *Framework) ExecWithOptions(options ExecOptions) (string, string, error)
 	}
 	config, err := LoadConfig()
 	ExpectNoError(err, "failed to load restclient config")
+
+	fmt.Printf("README: %+v\n", config)
+	config.Timeout = time.Minute
 
 	const tty = false
 


### PR DESCRIPTION
#### What type of PR is this?
/kind flake

#### What this PR does / why we need it:
Checks the default timeout for REST API calls made in E2E tests. Also doubles the timeout (it appears to be default 30s) to see if this fixes current flaky tests.

#### Which issue(s) this PR fixes:
Fixes #102794

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs

```

@msau42 
@Jiawei0227 