### PR TITLE
Do not register Kubelet In tree credential provider if external provider is enabled

### DIFF
--- a/cmd/kubelet/app/options/globalflags.go
+++ b/cmd/kubelet/app/options/globalflags.go
@@ -28,10 +28,6 @@ import (
 	"k8s.io/component-base/logs"
 	"k8s.io/component-base/version/verflag"
 	"k8s.io/klog/v2"
-
-	// ensure libs have a chance to globally register their flags
-	_ "k8s.io/kubernetes/pkg/credentialprovider/azure"
-	_ "k8s.io/kubernetes/pkg/credentialprovider/gcp"
 )
 
 // AddGlobalFlags explicitly registers flags that libraries (glog, verflag, etc.) register

--- a/cmd/kubelet/app/plugins_providers.go
+++ b/cmd/kubelet/app/plugins_providers.go
@@ -20,9 +20,7 @@ package app
 
 import (
 	// Credential providers
-	_ "k8s.io/kubernetes/pkg/credentialprovider/aws"
-	_ "k8s.io/kubernetes/pkg/credentialprovider/azure"
-	_ "k8s.io/kubernetes/pkg/credentialprovider/gcp"
+	_ "k8s.io/kubernetes/pkg/credentialprovider/register"
 
 	"k8s.io/component-base/featuregate"
 	"k8s.io/csi-translation-lib/plugins"

--- a/pkg/credentialprovider/aws/aws_credentials.go
+++ b/pkg/credentialprovider/aws/aws_credentials.go
@@ -46,9 +46,9 @@ var (
 	isEC2      bool
 )
 
-// init registers a credential provider for each registryURLTemplate and creates
+// Register registers a credential provider for each registryURLTemplate and creates
 // an ECR token getter factory with a new cache to store token getters
-func init() {
+func Register() {
 	credentialprovider.RegisterCredentialProvider("amazon-ecr",
 		newECRProvider(&ecrTokenGetterFactory{cache: make(map[string]tokenGetter)},
 			ec2ValidationImpl,

--- a/pkg/credentialprovider/azure/azure_credentials.go
+++ b/pkg/credentialprovider/azure/azure_credentials.go
@@ -54,9 +54,9 @@ var (
 	acrRE                 = regexp.MustCompile(`.*\.azurecr\.io|.*\.azurecr\.cn|.*\.azurecr\.de|.*\.azurecr\.us`)
 )
 
-// init registers the various means by which credentials may
+// Register registers the various means by which credentials may
 // be resolved on Azure.
-func init() {
+func Register() {
 	credentialprovider.RegisterCredentialProvider(
 		"azure",
 		NewACRProvider(flagConfigFile),

--- a/pkg/credentialprovider/gcp/metadata.go
+++ b/pkg/credentialprovider/gcp/metadata.go
@@ -57,9 +57,9 @@ var metadataHeader = &http.Header{
 	"Metadata-Flavor": []string{"Google"},
 }
 
-// init registers the various means by which credentials may
+// Register registers the various means by which credentials may
 // be resolved on GCP.
-func init() {
+func Register() {
 	tr := utilnet.SetTransportDefaults(&http.Transport{})
 	metadataHTTPClientTimeout := time.Second * 10
 	httpClient := &http.Client{

--- a/pkg/credentialprovider/register/register.go
+++ b/pkg/credentialprovider/register/register.go
@@ -1,0 +1,37 @@
+// +build !providerless
+
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package register
+
+import (
+	"k8s.io/apiserver/pkg/util/feature"
+	"k8s.io/kubernetes/pkg/features"
+
+	credentials "k8s.io/kubernetes/pkg/credentialprovider/aws"
+	"k8s.io/kubernetes/pkg/credentialprovider/azure"
+	"k8s.io/kubernetes/pkg/credentialprovider/gcp"
+)
+
+func init() {
+	// Do not register intree credential provider if external credential providers are enabled.
+	if !feature.DefaultFeatureGate.Enabled(features.KubeletCredentialProviders) {
+		credentials.Register()
+		azure.Register()
+		gcp.Register()
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

<!--
Add one of the following kinds:



Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Kubelet registers credential provider while startup, This PR proposes to not register in-tree credential providers if feature flag for external credential provider is enabled. 
Secondly if both external and intree registered then on any error from external providers it falls back to in tree which makes it difficult to catch any errors from external providers.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
