### PR TITLE
Add short names "vwh" and "mwh" for webhooks

### DIFF
--- a/pkg/registry/admissionregistration/mutatingwebhookconfiguration/storage/storage.go
+++ b/pkg/registry/admissionregistration/mutatingwebhookconfiguration/storage/storage.go
@@ -63,3 +63,11 @@ var _ rest.CategoriesProvider = &REST{}
 func (r *REST) Categories() []string {
 	return []string{"api-extensions"}
 }
+
+// Implement ShortNamesProvider
+var _ rest.ShortNamesProvider = &REST{}
+
+// ShortNames implements the ShortNamesProvider interface. Returns a list of short names for a resource.
+func (r *REST) ShortNames() []string {
+	return []string{"mwh"}
+}

--- a/pkg/registry/admissionregistration/validatingwebhookconfiguration/storage/storage.go
+++ b/pkg/registry/admissionregistration/validatingwebhookconfiguration/storage/storage.go
@@ -63,3 +63,11 @@ var _ rest.CategoriesProvider = &REST{}
 func (r *REST) Categories() []string {
 	return []string{"api-extensions"}
 }
+
+// Implement ShortNamesProvider
+var _ rest.ShortNamesProvider = &REST{}
+
+// ShortNames implements the ShortNamesProvider interface. Returns a list of short names for a resource.
+func (r *REST) ShortNames() []string {
+	return []string{"vwh"}
+}


### PR DESCRIPTION


#### What type of PR is this?

/kind feature

/kind api-change

#### What this PR does / why we need it:
This adds two new short names to the webhook types. This makes using the
extremely long `mutatingwebhookconfigurations` and
`validatingwebhookconfigurations` types a bit easier to manage.

#### Which issue(s) this PR fixes:

I couldn't find an issue, but I recall seeing a few people ask for it in the past as well. Maybe it was on slack or something rather than github.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Added a new short name for `validatingwebhookconfigurations`, `vwh`.
Added a new short name for `mutatingwebhookconfigurations`, `mwh`.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
NONE
```
