### PR TITLE
enable race detector by default in make test

### DIFF
--- a/hack/jenkins/test-dockerized.sh
+++ b/hack/jenkins/test-dockerized.sh
@@ -19,17 +19,6 @@ set -o nounset
 set -o pipefail
 set -o xtrace
 
-retry() {
-  for i in {1..5}; do
-    if "$@"; then
-      return 0
-    else
-      sleep "${i}"
-    fi
-  done
-  "$@"
-}
-
 # Runs the unit and integration tests, producing JUnit-style XML test
 # reports in ${WORKSPACE}/artifacts. This script is intended to be run from
 # kubekins-test container with a kubernetes repo mapped in. See
@@ -47,14 +36,10 @@ pushd "./hack/tools" >/dev/null
   GO111MODULE=on go install gotest.tools/gotestsum
 popd >/dev/null
 
-# Enable the Go race detector.
-export KUBE_RACE=-race
 # Disable coverage report
 export KUBE_COVER="n"
 # Set artifacts directory
 export ARTIFACTS=${ARTIFACTS:-"${WORKSPACE}/artifacts"}
-# Produce a JUnit-style XML test report
-export KUBE_JUNIT_REPORT_DIR="${ARTIFACTS}"
 # Save the verbose stdout as well.
 export KUBE_KEEP_VERBOSE_TEST_OUTPUT=y
 export KUBE_INTEGRATION_TEST_MAX_CONCURRENCY=4

--- a/hack/make-rules/test-cmd.sh
+++ b/hack/make-rules/test-cmd.sh
@@ -170,7 +170,8 @@ if [[ ${WHAT} == "" || ${WHAT} =~ .*kubeadm.* ]] ; then
   # invoke the tests
   make -C "${KUBE_ROOT}" test \
     WHAT=k8s.io/kubernetes/cmd/kubeadm/test/cmd \
-    KUBE_TIMEOUT=--timeout=240s
+    KUBE_TIMEOUT=--timeout=240s \
+    KUBE_RACE=""
 
   # if we ONLY want to run kubeadm, then exit here.
   if [[ ${WHAT} == "kubeadm" ]]; then

--- a/hack/make-rules/test-integration.sh
+++ b/hack/make-rules/test-integration.sh
@@ -66,16 +66,12 @@ runTests() {
   kube::etcd::start
   kube::log::status "Running integration test cases"
 
-  # export KUBE_RACE
-  #
-  # Enable the Go race detector.
-  export KUBE_RACE="-race"
   make -C "${KUBE_ROOT}" test \
       WHAT="${WHAT:-$(kube::test::find_integration_test_dirs | paste -sd' ' -)}" \
       GOFLAGS="${GOFLAGS:-}" \
       KUBE_TEST_ARGS="--alsologtostderr=true ${KUBE_TEST_ARGS:-} ${SHORT:--short=true} --vmodule=${KUBE_TEST_VMODULE}" \
-      KUBE_RACE="" \
-      KUBE_TIMEOUT="${KUBE_TIMEOUT}"
+      KUBE_TIMEOUT="${KUBE_TIMEOUT}" \
+      KUBE_RACE=""
 
   cleanup
 }

--- a/hack/make-rules/test.sh
+++ b/hack/make-rules/test.sh
@@ -253,7 +253,7 @@ runTests() {
   # If we're not collecting coverage, run all requested tests with one 'go test'
   # command, which is much faster.
   if [[ ! ${KUBE_COVER} =~ ^[yY]$ ]]; then
-    kube::log::status "Running tests without code coverage"
+    kube::log::status "Running tests without code coverage ${KUBE_RACE:+"and with ${KUBE_RACE}"}"
     go test "${goflags[@]:+${goflags[@]}}" \
      "${KUBE_TIMEOUT}" "${@}" \
      "${testargs[@]:+${testargs[@]}}" \
@@ -262,6 +262,8 @@ runTests() {
     produceJUnitXMLReport "${junit_filename_prefix}"
     return ${rc}
   fi
+
+  kube::log::status "Running tests with code coverage ${KUBE_RACE:+"and with ${KUBE_RACE}"}"
 
   # Create coverage report directories.
   if [[ -z "${KUBE_COVER_REPORT_DIR}" ]]; then

--- a/hack/make-rules/test.sh
+++ b/hack/make-rules/test.sh
@@ -71,7 +71,10 @@ KUBE_COVER_REPORT_DIR="${KUBE_COVER_REPORT_DIR:-}"
 # How many 'go test' instances to run simultaneously when running tests in
 # coverage mode.
 KUBE_COVERPROCS=${KUBE_COVERPROCS:-4}
-KUBE_RACE=${KUBE_RACE:-}   # use KUBE_RACE="-race" to enable race testing
+# use KUBE_RACE="" to disable the race detector
+# this is defaulted to "-race" in make test as well
+# NOTE: DO NOT ADD A COLON HERE. KUBE_RACE="" is meaningful!
+KUBE_RACE=${KUBE_RACE-"-race"}
 # Set to the goveralls binary path to report coverage results to Coveralls.io.
 KUBE_GOVERALLS_BIN=${KUBE_GOVERALLS_BIN:-}
 # once we have multiple group supports


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

enables the golang race detector by default when running unit tests
see: https://github.com/kubernetes/kubernetes/issues/102607

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

with this change we'll be able to change CI to actually run `make test` with no parameters, bringing it closer to trivially reproducing CI locally ™️ 

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
/sig testing
/triage accepted
/priority important-longterm
