### PR TITLE
test/e2e/network: remove dependency to google.com for in-cluster networking tests

### DIFF
--- a/test/e2e/network/networking.go
+++ b/test/e2e/network/networking.go
@@ -19,7 +19,6 @@ package network
 import (
 	"context"
 	"fmt"
-	"net/http"
 	"strconv"
 	"strings"
 
@@ -81,20 +80,6 @@ var _ = common.SIGDescribe("Networking", func() {
 	var svcname = "nettest"
 	f := framework.NewDefaultFramework(svcname)
 
-	ginkgo.BeforeEach(func() {
-		// Assert basic external connectivity.
-		// Since this is not really a test of kubernetes in any way, we
-		// leave it as a pre-test assertion, rather than a Ginko test.
-		ginkgo.By("Executing a successful http request from the external internet")
-		resp, err := http.Get("http://google.com")
-		if err != nil {
-			framework.Failf("Unable to connect/talk to the internet: %v", err)
-		}
-		if resp.StatusCode != http.StatusOK {
-			framework.Failf("Unexpected error code, expected 200, got, %v (%v)", resp.StatusCode, resp)
-		}
-	})
-
 	ginkgo.It("should provide Internet connection for containers [Feature:Networking-IPv4]", func() {
 		ginkgo.By("Running container which tries to connect to 8.8.8.8")
 		framework.ExpectNoError(
@@ -107,6 +92,12 @@ var _ = common.SIGDescribe("Networking", func() {
 		ginkgo.By("Running container which tries to connect to 2001:4860:4860::8888")
 		framework.ExpectNoError(
 			checkConnectivityToHost(f, "", "connectivity-test", "2001:4860:4860::8888", 53, 30))
+	})
+
+	ginkgo.It("should provider Internet connection for containers using DNS [Feature:Networking-DNS]", func() {
+		ginkgo.By("Running container which tries to connect to google.com")
+		framework.ExpectNoError(
+			checkConnectivityToHost(f, "", "connectivity-test", "google.com", 80, 30))
 	})
 
 	// First test because it has no dependencies on variables created later on.


### PR DESCRIPTION
Signed-off-by: Andrew Sy Kim <kim.andrewsy@gmail.com>

#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
Many tests in test/e2e/network/networking.go are really in-cluster only tests, but there's a BeforeEach ginkgo hook that does a "pre-check" against google.com. For environments where there's no external access or if google.com is specifically not allowed, this causes all the valid in-cluster tests to also fail.

This PR moves the google.com preflight check into the `should provide Internet connection for containers` test and removes the google.com check in BeforeEach. 

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
