### PR TITLE
deprecate and disable by default DynamicKubeletConfig feature flag

### DIFF
--- a/cluster/gce/util.sh
+++ b/cluster/gce/util.sh
@@ -762,9 +762,6 @@ function construct-linux-kubelet-flags {
   flags+=" --experimental-check-node-capabilities-before-mount=true"
   # Keep in sync with the mkdir command in configure-helper.sh (until the TODO is resolved)
   flags+=" --cert-dir=/var/lib/kubelet/pki/"
-  # Configure the directory that the Kubelet should use to store dynamic config checkpoints
-  flags+=" --dynamic-config-dir=/var/lib/kubelet/dynamic-config"
-
 
   if [[ "${node_type}" == "master" ]]; then
     flags+=" ${MASTER_KUBELET_TEST_ARGS:-}"

--- a/cmd/kubelet/app/options/options.go
+++ b/cmd/kubelet/app/options/options.go
@@ -341,7 +341,8 @@ func (f *KubeletFlags) AddFlags(mainfs *pflag.FlagSet) {
 
 	fs.StringVar(&f.RootDirectory, "root-dir", f.RootDirectory, "Directory path for managing kubelet files (volume mounts,etc).")
 
-	fs.Var(&f.DynamicConfigDir, "dynamic-config-dir", "The Kubelet will use this directory for checkpointing downloaded configurations and tracking configuration health. The Kubelet will create this directory if it does not already exist. The path may be absolute or relative; relative paths start at the Kubelet's current working directory. Providing this flag enables dynamic Kubelet configuration. The DynamicKubeletConfig feature gate must be enabled to pass this flag; this gate currently defaults to true because the feature is beta.")
+	fs.Var(&f.DynamicConfigDir, "dynamic-config-dir", "The Kubelet will use this directory for checkpointing downloaded configurations and tracking configuration health. The Kubelet will create this directory if it does not already exist. The path may be absolute or relative; relative paths start at the Kubelet's current working directory. Providing this flag enables dynamic Kubelet configuration. The DynamicKubeletConfig feature gate must be enabled to pass this flag.")
+	fs.MarkDeprecated("dynamic-config-dir", "Feature DynamicKubeletConfig is deprecated in 1.22 and will not move to GA. It is planned to be removed from Kubernetes in the version 1.23. Please use alternative ways to update kubelet configuration.")
 
 	fs.BoolVar(&f.RegisterNode, "register-node", f.RegisterNode, "Register the node with the apiserver. If --kubeconfig is not provided, this flag is irrelevant, as the Kubelet won't have an apiserver to register with.")
 	fs.Var(utiltaints.NewTaintsVar(&f.RegisterWithTaints), "register-with-taints", "Register the node with the given list of taints (comma separated \"<key>=<value>:<effect>\"). No-op if register-node is false.")

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -38,6 +38,7 @@ const (
 	// owner: @mtaufen
 	// alpha: v1.4
 	// beta: v1.11
+	// deprecated: 1.22
 	DynamicKubeletConfig featuregate.Feature = "DynamicKubeletConfig"
 
 	// owner: @pweil-
@@ -744,7 +745,7 @@ func init() {
 // available throughout Kubernetes binaries.
 var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
 	AppArmor:             {Default: true, PreRelease: featuregate.Beta},
-	DynamicKubeletConfig: {Default: true, PreRelease: featuregate.Beta},
+	DynamicKubeletConfig: {Default: false, PreRelease: featuregate.Deprecated}, // feature gate is deprecated in 1.22, remove no early than 1.23
 	ExperimentalHostUserNamespaceDefaultingGate: {Default: false, PreRelease: featuregate.Beta},
 	DevicePlugins:                                  {Default: true, PreRelease: featuregate.Beta},
 	RotateKubeletServerCertificate:                 {Default: true, PreRelease: featuregate.Beta},

--- a/pkg/kubelet/metrics/metrics.go
+++ b/pkg/kubelet/metrics/metrics.go
@@ -350,20 +350,22 @@ var (
 	// AssignedConfig is a Gauge that is set 1 if the Kubelet has a NodeConfig assigned.
 	AssignedConfig = metrics.NewGaugeVec(
 		&metrics.GaugeOpts{
-			Subsystem:      KubeletSubsystem,
-			Name:           AssignedConfigKey,
-			Help:           "The node's understanding of intended config. The count is always 1.",
-			StabilityLevel: metrics.ALPHA,
+			Subsystem:         KubeletSubsystem,
+			Name:              AssignedConfigKey,
+			Help:              "The node's understanding of intended config. The count is always 1.",
+			DeprecatedVersion: "1.22",
+			StabilityLevel:    metrics.ALPHA,
 		},
 		[]string{ConfigSourceLabelKey, ConfigUIDLabelKey, ConfigResourceVersionLabelKey, KubeletConfigKeyLabelKey},
 	)
 	// ActiveConfig is a Gauge that is set to 1 if the Kubelet has an active NodeConfig.
 	ActiveConfig = metrics.NewGaugeVec(
 		&metrics.GaugeOpts{
-			Subsystem:      KubeletSubsystem,
-			Name:           ActiveConfigKey,
-			Help:           "The config source the node is actively using. The count is always 1.",
-			StabilityLevel: metrics.ALPHA,
+			Subsystem:         KubeletSubsystem,
+			Name:              ActiveConfigKey,
+			Help:              "The config source the node is actively using. The count is always 1.",
+			DeprecatedVersion: "1.22",
+			StabilityLevel:    metrics.ALPHA,
 		},
 		[]string{ConfigSourceLabelKey, ConfigUIDLabelKey, ConfigResourceVersionLabelKey, KubeletConfigKeyLabelKey},
 	)
@@ -371,20 +373,22 @@ var (
 	// are certain errors.
 	LastKnownGoodConfig = metrics.NewGaugeVec(
 		&metrics.GaugeOpts{
-			Subsystem:      KubeletSubsystem,
-			Name:           LastKnownGoodConfigKey,
-			Help:           "The config source the node will fall back to when it encounters certain errors. The count is always 1.",
-			StabilityLevel: metrics.ALPHA,
+			Subsystem:         KubeletSubsystem,
+			Name:              LastKnownGoodConfigKey,
+			Help:              "The config source the node will fall back to when it encounters certain errors. The count is always 1.",
+			DeprecatedVersion: "1.22",
+			StabilityLevel:    metrics.ALPHA,
 		},
 		[]string{ConfigSourceLabelKey, ConfigUIDLabelKey, ConfigResourceVersionLabelKey, KubeletConfigKeyLabelKey},
 	)
 	// ConfigError is a Gauge that is set to 1 if the node is experiencing a configuration-related error.
 	ConfigError = metrics.NewGauge(
 		&metrics.GaugeOpts{
-			Subsystem:      KubeletSubsystem,
-			Name:           ConfigErrorKey,
-			Help:           "This metric is true (1) if the node is experiencing a configuration-related error, false (0) otherwise.",
-			StabilityLevel: metrics.ALPHA,
+			Subsystem:         KubeletSubsystem,
+			Name:              ConfigErrorKey,
+			Help:              "This metric is true (1) if the node is experiencing a configuration-related error, false (0) otherwise.",
+			DeprecatedVersion: "1.22",
+			StabilityLevel:    metrics.ALPHA,
 		},
 	)
 	// RunPodSandboxDuration is a Histogram that tracks the duration (in seconds) it takes to run Pod Sandbox operations.

--- a/pkg/registry/core/node/strategy.go
+++ b/pkg/registry/core/node/strategy.go
@@ -141,7 +141,9 @@ func (nodeStrategy) Validate(ctx context.Context, obj runtime.Object) field.Erro
 }
 
 // WarningsOnCreate returns warnings for the creation of the given object.
-func (nodeStrategy) WarningsOnCreate(ctx context.Context, obj runtime.Object) []string { return nil }
+func (nodeStrategy) WarningsOnCreate(ctx context.Context, obj runtime.Object) []string {
+	return dynamicKubeletConfigIsDeprecatedWarning(obj)
+}
 
 // Canonicalize normalizes the object after validation.
 func (nodeStrategy) Canonicalize(obj runtime.Object) {
@@ -155,7 +157,7 @@ func (nodeStrategy) ValidateUpdate(ctx context.Context, obj, old runtime.Object)
 
 // WarningsOnUpdate returns warnings for the given update.
 func (nodeStrategy) WarningsOnUpdate(ctx context.Context, obj, old runtime.Object) []string {
-	return nil
+	return dynamicKubeletConfigIsDeprecatedWarning(obj)
 }
 
 func (nodeStrategy) AllowUnconditionalUpdate() bool {
@@ -282,4 +284,15 @@ func ResourceLocation(getter ResourceGetter, connection client.ConnectionInfoGet
 
 	// Otherwise, return the requested scheme and port, and the proxy transport
 	return &url.URL{Scheme: schemeReq, Host: net.JoinHostPort(info.Hostname, portReq)}, proxyTransport, nil
+}
+
+func dynamicKubeletConfigIsDeprecatedWarning(obj runtime.Object) []string {
+	newNode := obj.(*api.Node)
+	if newNode.Spec.ConfigSource != nil {
+		var warnings []string
+		// KEP https://github.com/kubernetes/enhancements/issues/281
+		warnings = append(warnings, "spec.configSource: deprecated in v1.22, support removal is planned in v1.23")
+		return warnings
+	}
+	return nil
 }

--- a/staging/src/k8s.io/api/core/v1/generated.proto
+++ b/staging/src/k8s.io/api/core/v1/generated.proto
@@ -522,6 +522,7 @@ message ConfigMapList {
 }
 
 // ConfigMapNodeConfigSource contains the information to reference a ConfigMap as a config source for the Node.
+// This API is deprecated since 1.22: https://git.k8s.io/enhancements/keps/sig-node/281-dynamic-kubelet-configuration
 message ConfigMapNodeConfigSource {
   // Namespace is the metadata.namespace of the referenced ConfigMap.
   // This field is required in all cases.
@@ -2231,6 +2232,7 @@ message NodeCondition {
 }
 
 // NodeConfigSource specifies a source of node configuration. Exactly one subfield (excluding metadata) must be non-nil.
+// This API is deprecated since 1.22
 message NodeConfigSource {
   // ConfigMap is a reference to a Node's ConfigMap
   optional ConfigMapNodeConfigSource configMap = 2;
@@ -2386,8 +2388,9 @@ message NodeSpec {
   // +optional
   repeated Taint taints = 5;
 
-  // If specified, the source to get node configuration from
-  // The DynamicKubeletConfig feature gate must be enabled for the Kubelet to use this field
+  // Deprecated. If specified, the source of the node's configuration.
+  // The DynamicKubeletConfig feature gate must be enabled for the Kubelet to use this field.
+  // This field is deprecated as of 1.22: https://git.k8s.io/enhancements/keps/sig-node/281-dynamic-kubelet-configuration
   // +optional
   optional NodeConfigSource configSource = 6;
 

--- a/staging/src/k8s.io/api/core/v1/types.go
+++ b/staging/src/k8s.io/api/core/v1/types.go
@@ -4603,8 +4603,10 @@ type NodeSpec struct {
 	// If specified, the node's taints.
 	// +optional
 	Taints []Taint `json:"taints,omitempty" protobuf:"bytes,5,opt,name=taints"`
-	// If specified, the source to get node configuration from
-	// The DynamicKubeletConfig feature gate must be enabled for the Kubelet to use this field
+
+	// Deprecated. If specified, the source of the node's configuration.
+	// The DynamicKubeletConfig feature gate must be enabled for the Kubelet to use this field.
+	// This field is deprecated as of 1.22: https://git.k8s.io/enhancements/keps/sig-node/281-dynamic-kubelet-configuration
 	// +optional
 	ConfigSource *NodeConfigSource `json:"configSource,omitempty" protobuf:"bytes,6,opt,name=configSource"`
 
@@ -4615,6 +4617,7 @@ type NodeSpec struct {
 }
 
 // NodeConfigSource specifies a source of node configuration. Exactly one subfield (excluding metadata) must be non-nil.
+// This API is deprecated since 1.22
 type NodeConfigSource struct {
 	// For historical context, regarding the below kind, apiVersion, and configMapRef deprecation tags:
 	// 1. kind/apiVersion were used by the kubelet to persist this struct to disk (they had no protobuf tags)
@@ -4632,6 +4635,7 @@ type NodeConfigSource struct {
 }
 
 // ConfigMapNodeConfigSource contains the information to reference a ConfigMap as a config source for the Node.
+// This API is deprecated since 1.22: https://git.k8s.io/enhancements/keps/sig-node/281-dynamic-kubelet-configuration
 type ConfigMapNodeConfigSource struct {
 	// Namespace is the metadata.namespace of the referenced ConfigMap.
 	// This field is required in all cases.

--- a/staging/src/k8s.io/api/core/v1/types_swagger_doc_generated.go
+++ b/staging/src/k8s.io/api/core/v1/types_swagger_doc_generated.go
@@ -291,7 +291,7 @@ func (ConfigMapList) SwaggerDoc() map[string]string {
 }
 
 var map_ConfigMapNodeConfigSource = map[string]string{
-	"":                 "ConfigMapNodeConfigSource contains the information to reference a ConfigMap as a config source for the Node.",
+	"":                 "ConfigMapNodeConfigSource contains the information to reference a ConfigMap as a config source for the Node. This API is deprecated since 1.22: https://git.k8s.io/enhancements/keps/sig-node/281-dynamic-kubelet-configuration",
 	"namespace":        "Namespace is the metadata.namespace of the referenced ConfigMap. This field is required in all cases.",
 	"name":             "Name is the metadata.name of the referenced ConfigMap. This field is required in all cases.",
 	"uid":              "UID is the metadata.UID of the referenced ConfigMap. This field is forbidden in Node.Spec, and required in Node.Status.",
@@ -1085,7 +1085,7 @@ func (NodeCondition) SwaggerDoc() map[string]string {
 }
 
 var map_NodeConfigSource = map[string]string{
-	"":          "NodeConfigSource specifies a source of node configuration. Exactly one subfield (excluding metadata) must be non-nil.",
+	"":          "NodeConfigSource specifies a source of node configuration. Exactly one subfield (excluding metadata) must be non-nil. This API is deprecated since 1.22",
 	"configMap": "ConfigMap is a reference to a Node's ConfigMap",
 }
 
@@ -1179,7 +1179,7 @@ var map_NodeSpec = map[string]string{
 	"providerID":    "ID of the node assigned by the cloud provider in the format: <ProviderName>://<ProviderSpecificNodeID>",
 	"unschedulable": "Unschedulable controls node schedulability of new pods. By default, node is schedulable. More info: https://kubernetes.io/docs/concepts/nodes/node/#manual-node-administration",
 	"taints":        "If specified, the node's taints.",
-	"configSource":  "If specified, the source to get node configuration from The DynamicKubeletConfig feature gate must be enabled for the Kubelet to use this field",
+	"configSource":  "Deprecated. If specified, the source of the node's configuration. The DynamicKubeletConfig feature gate must be enabled for the Kubelet to use this field. This field is deprecated as of 1.22: https://git.k8s.io/enhancements/keps/sig-node/281-dynamic-kubelet-configuration",
 	"externalID":    "Deprecated. Not all kubelets will set this field. Remove field after 1.13. see: https://issues.k8s.io/61966",
 }
 

--- a/staging/src/k8s.io/kubelet/config/v1beta1/types.go
+++ b/staging/src/k8s.io/kubelet/config/v1beta1/types.go
@@ -90,13 +90,13 @@ type KubeletConfiguration struct {
 
 	// enableServer enables Kubelet's secured server.
 	// Note: Kubelet's insecure port is controlled by the readOnlyPort option.
-	// Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+	// Dynamic Kubelet Config (deprecated): If dynamically updating this field, consider that
 	// it may disrupt components that interact with the Kubelet server.
 	// Default: true
 	EnableServer *bool `json:"enableServer,omitempty"`
 	// staticPodPath is the path to the directory containing local (static) pods to
 	// run, or the path to a single static pod file.
-	// Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+	// Dynamic Kubelet Config (deprecated): If dynamically updating this field, consider that
 	// the set of static pods specified at the new path may be different than the
 	// ones the Kubelet initially started with, and this may disrupt your node.
 	// Default: ""
@@ -104,7 +104,7 @@ type KubeletConfiguration struct {
 	StaticPodPath string `json:"staticPodPath,omitempty"`
 	// syncFrequency is the max period between synchronizing running
 	// containers and config.
-	// Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+	// Dynamic Kubelet Config (deprecated): If dynamically updating this field, consider that
 	// shortening this duration may have a negative performance impact, especially
 	// as the number of Pods on the node increases. Alternatively, increasing this
 	// duration will result in longer refresh times for ConfigMaps and Secrets.
@@ -113,42 +113,42 @@ type KubeletConfiguration struct {
 	SyncFrequency metav1.Duration `json:"syncFrequency,omitempty"`
 	// fileCheckFrequency is the duration between checking config files for
 	// new data
-	// Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+	// Dynamic Kubelet Config (deprecated): If dynamically updating this field, consider that
 	// shortening the duration will cause the Kubelet to reload local Static Pod
 	// configurations more frequently, which may have a negative performance impact.
 	// Default: "20s"
 	// +optional
 	FileCheckFrequency metav1.Duration `json:"fileCheckFrequency,omitempty"`
 	// httpCheckFrequency is the duration between checking http for new data
-	// Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+	// Dynamic Kubelet Config (deprecated): If dynamically updating this field, consider that
 	// shortening the duration will cause the Kubelet to poll staticPodURL more
 	// frequently, which may have a negative performance impact.
 	// Default: "20s"
 	// +optional
 	HTTPCheckFrequency metav1.Duration `json:"httpCheckFrequency,omitempty"`
 	// staticPodURL is the URL for accessing static pods to run
-	// Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+	// Dynamic Kubelet Config (deprecated): If dynamically updating this field, consider that
 	// the set of static pods specified at the new URL may be different than the
 	// ones the Kubelet initially started with, and this may disrupt your node.
 	// Default: ""
 	// +optional
 	StaticPodURL string `json:"staticPodURL,omitempty"`
 	// staticPodURLHeader is a map of slices with HTTP headers to use when accessing the podURL
-	// Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+	// Dynamic Kubelet Config (deprecated): If dynamically updating this field, consider that
 	// it may disrupt the ability to read the latest set of static pods from StaticPodURL.
 	// Default: nil
 	// +optional
 	StaticPodURLHeader map[string][]string `json:"staticPodURLHeader,omitempty"`
 	// address is the IP address for the Kubelet to serve on (set to 0.0.0.0
 	// for all interfaces).
-	// Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+	// Dynamic Kubelet Config (deprecated): If dynamically updating this field, consider that
 	// it may disrupt components that interact with the Kubelet server.
 	// Default: "0.0.0.0"
 	// +optional
 	Address string `json:"address,omitempty"`
 	// port is the port for the Kubelet to serve on.
 	// The port number must be between 1 and 65535, inclusive.
-	// Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+	// Dynamic Kubelet Config (deprecated): If dynamically updating this field, consider that
 	// it may disrupt components that interact with the Kubelet server.
 	// Default: 10250
 	// +optional
@@ -157,7 +157,7 @@ type KubeletConfiguration struct {
 	// no authentication/authorization.
 	// The port number must be between 1 and 65535, inclusive.
 	// Setting this field to 0 disables the read-only service.
-	// Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+	// Dynamic Kubelet Config (deprecated): If dynamically updating this field, consider that
 	// it may disrupt components that interact with the Kubelet server.
 	// Default: 0 (disabled)
 	// +optional
@@ -167,27 +167,27 @@ type KubeletConfiguration struct {
 	// tlsPrivateKeyFile are not provided, a self-signed certificate
 	// and key are generated for the public address and saved to the directory
 	// passed to the Kubelet's --cert-dir flag.
-	// Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+	// Dynamic Kubelet Config (deprecated): If dynamically updating this field, consider that
 	// it may disrupt components that interact with the Kubelet server.
 	// Default: ""
 	// +optional
 	TLSCertFile string `json:"tlsCertFile,omitempty"`
 	// tlsPrivateKeyFile is the file containing x509 private key matching tlsCertFile
-	// Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+	// Dynamic Kubelet Config (deprecated): If dynamically updating this field, consider that
 	// it may disrupt components that interact with the Kubelet server.
 	// Default: ""
 	// +optional
 	TLSPrivateKeyFile string `json:"tlsPrivateKeyFile,omitempty"`
 	// tlsCipherSuites is the list of allowed cipher suites for the server.
 	// Values are from tls package constants (https://golang.org/pkg/crypto/tls/#pkg-constants).
-	// Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+	// Dynamic Kubelet Config (deprecated): If dynamically updating this field, consider that
 	// it may disrupt components that interact with the Kubelet server.
 	// Default: nil
 	// +optional
 	TLSCipherSuites []string `json:"tlsCipherSuites,omitempty"`
 	// tlsMinVersion is the minimum TLS version supported.
 	// Values are from tls package constants (https://golang.org/pkg/crypto/tls/#pkg-constants).
-	// Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+	// Dynamic Kubelet Config (deprecated): If dynamically updating this field, consider that
 	// it may disrupt components that interact with the Kubelet server.
 	// Default: ""
 	// +optional
@@ -195,7 +195,7 @@ type KubeletConfiguration struct {
 	// rotateCertificates enables client certificate rotation. The Kubelet will request a
 	// new certificate from the certificates.k8s.io API. This requires an approver to approve the
 	// certificate signing requests.
-	// Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+	// Dynamic Kubelet Config (deprecated): If dynamically updating this field, consider that
 	// disabling it may disrupt the Kubelet's ability to authenticate with the API server
 	// after the current certificate expires.
 	// Default: false
@@ -206,7 +206,7 @@ type KubeletConfiguration struct {
 	// the 'certificates.k8s.io' API. This requires an approver to approve the
 	// certificate signing requests (CSR). The RotateKubeletServerCertificate feature
 	// must be enabled when setting this field.
-	// Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+	// Dynamic Kubelet Config (deprecated): If dynamically updating this field, consider that
 	// disabling it will stop the renewal of Kubelet server certificates, which can
 	// disrupt components that interact with the Kubelet server in the long term,
 	// due to certificate expiration.
@@ -214,7 +214,7 @@ type KubeletConfiguration struct {
 	// +optional
 	ServerTLSBootstrap bool `json:"serverTLSBootstrap,omitempty"`
 	// authentication specifies how requests to the Kubelet's server are authenticated
-	// Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+	// Dynamic Kubelet Config (deprecated): If dynamically updating this field, consider that
 	// it may disrupt components that interact with the Kubelet server.
 	// Defaults:
 	//   anonymous:
@@ -225,7 +225,7 @@ type KubeletConfiguration struct {
 	// +optional
 	Authentication KubeletAuthentication `json:"authentication"`
 	// authorization specifies how requests to the Kubelet's server are authorized
-	// Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+	// Dynamic Kubelet Config (deprecated): If dynamically updating this field, consider that
 	// it may disrupt components that interact with the Kubelet server.
 	// Defaults:
 	//   mode: Webhook
@@ -237,7 +237,7 @@ type KubeletConfiguration struct {
 	// registryPullQPS is the limit of registry pulls per second.
 	// The value must not be a negative number.
 	// Setting it to 0 means no limit.
-	// Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+	// Dynamic Kubelet Config (deprecated): If dynamically updating this field, consider that
 	// it may impact scalability by changing the amount of traffic produced
 	// by image pulls.
 	// Default: 5
@@ -247,7 +247,7 @@ type KubeletConfiguration struct {
 	// pulls to burst to this number, while still not exceeding registryPullQPS.
 	// The value must not be a negative number.
 	// Only used if registryPullQPS is greater than 0.
-	// Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+	// Dynamic Kubelet Config (deprecated): If dynamically updating this field, consider that
 	// it may impact scalability by changing the amount of traffic produced
 	// by image pulls.
 	// Default: 10
@@ -255,7 +255,7 @@ type KubeletConfiguration struct {
 	RegistryBurst int32 `json:"registryBurst,omitempty"`
 	// eventRecordQPS is the maximum event creations per second. If 0, there
 	// is no limit enforced. The value cannot be a negative number.
-	// Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+	// Dynamic Kubelet Config (deprecated): If dynamically updating this field, consider that
 	// it may impact scalability by changing the amount of traffic produced by
 	// event creations.
 	// Default: 5
@@ -265,7 +265,7 @@ type KubeletConfiguration struct {
 	// allows event creations to burst to this number, while still not exceeding
 	// eventRecordQPS. This field canot be a negative number and it is only used
 	// when eventRecordQPS > 0.
-	// Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+	// Dynamic Kubelet Config (deprecated): If dynamically updating this field, consider that
 	// it may impact scalability by changing the amount of traffic produced by
 	// event creations.
 	// Default: 10
@@ -274,33 +274,33 @@ type KubeletConfiguration struct {
 	// enableDebuggingHandlers enables server endpoints for log access
 	// and local running of containers and commands, including the exec,
 	// attach, logs, and portforward features.
-	// Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+	// Dynamic Kubelet Config (deprecated): If dynamically updating this field, consider that
 	// disabling it may disrupt components that interact with the Kubelet server.
 	// Default: true
 	// +optional
 	EnableDebuggingHandlers *bool `json:"enableDebuggingHandlers,omitempty"`
 	// enableContentionProfiling enables lock contention profiling, if enableDebuggingHandlers is true.
-	// Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+	// Dynamic Kubelet Config (deprecated): If dynamically updating this field, consider that
 	// enabling it may carry a performance impact.
 	// Default: false
 	// +optional
 	EnableContentionProfiling bool `json:"enableContentionProfiling,omitempty"`
 	// healthzPort is the port of the localhost healthz endpoint (set to 0 to disable)
 	// A valid number is between 1 and 65535.
-	// Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+	// Dynamic Kubelet Config (deprecated): If dynamically updating this field, consider that
 	// it may disrupt components that monitor Kubelet health.
 	// Default: 10248
 	// +optional
 	HealthzPort *int32 `json:"healthzPort,omitempty"`
 	// healthzBindAddress is the IP address for the healthz server to serve on
-	// Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+	// Dynamic Kubelet Config (deprecated): If dynamically updating this field, consider that
 	// it may disrupt components that monitor Kubelet health.
 	// Default: "127.0.0.1"
 	// +optional
 	HealthzBindAddress string `json:"healthzBindAddress,omitempty"`
 	// oomScoreAdj is The oom-score-adj value for kubelet process. Values
 	// must be within the range [-1000, 1000].
-	// Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+	// Dynamic Kubelet Config (deprecated): If dynamically updating this field, consider that
 	// it may impact the stability of nodes under memory pressure.
 	// Default: -999
 	// +optional
@@ -308,7 +308,7 @@ type KubeletConfiguration struct {
 	// clusterDomain is the DNS domain for this cluster. If set, kubelet will
 	// configure all containers to search this domain in addition to the
 	// host's search domains.
-	// Dynamic Kubelet Config (beta): Dynamically updating this field is not recommended,
+	// Dynamic Kubelet Config (deprecated): Dynamically updating this field is not recommended,
 	// as it should be kept in sync with the rest of the cluster.
 	// Default: ""
 	// +optional
@@ -316,7 +316,7 @@ type KubeletConfiguration struct {
 	// clusterDNS is a list of IP addresses for the cluster DNS server. If set,
 	// kubelet will configure all containers to use this for DNS resolution
 	// instead of the host's DNS servers.
-	// Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+	// Dynamic Kubelet Config (deprecated): If dynamically updating this field, consider that
 	// changes will only take effect on Pods created after the update. Draining
 	// the node is recommended before changing this field.
 	// Default: nil
@@ -324,7 +324,7 @@ type KubeletConfiguration struct {
 	ClusterDNS []string `json:"clusterDNS,omitempty"`
 	// streamingConnectionIdleTimeout is the maximum time a streaming connection
 	// can be idle before the connection is automatically closed.
-	// Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+	// Dynamic Kubelet Config (deprecated): If dynamically updating this field, consider that
 	// it may impact components that rely on infrequent updates over streaming
 	// connections to the Kubelet server.
 	// Default: "4h"
@@ -335,7 +335,7 @@ type KubeletConfiguration struct {
 	// kubelet posts node status to master.
 	// Note: When node lease feature is not enabled, be cautious when changing the
 	// constant, it must work with nodeMonitorGracePeriod in nodecontroller.
-	// Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+	// Dynamic Kubelet Config (deprecated): If dynamically updating this field, consider that
 	// it may impact node scalability, and also that the node controller's
 	// nodeMonitorGracePeriod must be set to N*NodeStatusUpdateFrequency,
 	// where N is the number of retries before the node controller marks
@@ -361,7 +361,7 @@ type KubeletConfiguration struct {
 	// may be set based on the lease duration.
 	// The field value must be greater than 0.
 	// Requires the NodeLease feature gate to be enabled.
-	// Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+	// Dynamic Kubelet Config (deprecated): If dynamically updating this field, consider that
 	// decreasing the duration may reduce tolerance for issues that temporarily prevent
 	// the Kubelet from renewing the lease (e.g. a short-lived network issue).
 	// Default: 40
@@ -369,7 +369,7 @@ type KubeletConfiguration struct {
 	NodeLeaseDurationSeconds int32 `json:"nodeLeaseDurationSeconds,omitempty"`
 	// imageMinimumGCAge is the minimum age for an unused image before it is
 	// garbage collected.
-	// Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+	// Dynamic Kubelet Config (deprecated): If dynamically updating this field, consider that
 	// it may trigger or delay garbage collection, and may change the image overhead
 	// on the node.
 	// Default: "2m"
@@ -380,7 +380,7 @@ type KubeletConfiguration struct {
 	// dividing this field value by 100, so this field must be between 0 and
 	// 100, inclusive. When specified, the value must be greater than
 	// imageGCLowThresholdPercent.
-	// Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+	// Dynamic Kubelet Config (deprecated): If dynamically updating this field, consider that
 	// it may trigger or delay garbage collection, and may change the image overhead
 	// on the node.
 	// Default: 85
@@ -391,7 +391,7 @@ type KubeletConfiguration struct {
 	// collect to. The percent is calculated by dividing this field value by 100,
 	// so the field value must be between 0 and 100, inclusive. When specified, the
 	// value must be less than imageGCHighThresholdPercent.
-	// Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+	// Dynamic Kubelet Config (deprecated): If dynamically updating this field, consider that
 	// it may trigger or delay garbage collection, and may change the image overhead
 	// on the node.
 	// Default: 80
@@ -399,13 +399,13 @@ type KubeletConfiguration struct {
 	ImageGCLowThresholdPercent *int32 `json:"imageGCLowThresholdPercent,omitempty"`
 	// volumeStatsAggPeriod is the frequency for calculating and caching volume
 	// disk usage for all pods.
-	// Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+	// Dynamic Kubelet Config (deprecated): If dynamically updating this field, consider that
 	// shortening the period may carry a performance impact.
 	// Default: "1m"
 	// +optional
 	VolumeStatsAggPeriod metav1.Duration `json:"volumeStatsAggPeriod,omitempty"`
 	// kubeletCgroups is the absolute name of cgroups to isolate the kubelet in
-	// Dynamic Kubelet Config (beta): This field should not be updated without a full node
+	// Dynamic Kubelet Config (deprecated): This field should not be updated without a full node
 	// reboot. It is safest to keep this value the same as the local config.
 	// Default: ""
 	// +optional
@@ -414,14 +414,14 @@ type KubeletConfiguration struct {
 	// all non-kernel processes that are not already in a container. Empty
 	// for no container. Rolling back the flag requires a reboot.
 	// The cgroupRoot must be specified if this field is not empty.
-	// Dynamic Kubelet Config (beta): This field should not be updated without a full node
+	// Dynamic Kubelet Config (deprecated): This field should not be updated without a full node
 	// reboot. It is safest to keep this value the same as the local config.
 	// Default: ""
 	// +optional
 	SystemCgroups string `json:"systemCgroups,omitempty"`
 	// cgroupRoot is the root cgroup to use for pods. This is handled by the
 	// container runtime on a best effort basis.
-	// Dynamic Kubelet Config (beta): This field should not be updated without a full node
+	// Dynamic Kubelet Config (deprecated): This field should not be updated without a full node
 	// reboot. It is safest to keep this value the same as the local config.
 	// Default: ""
 	// +optional
@@ -429,35 +429,35 @@ type KubeletConfiguration struct {
 	// cgroupsPerQOS enable QoS based CGroup hierarchy: top level CGroups for QoS classes
 	// and all Burstable and BestEffort Pods are brought up under their specific top level
 	// QoS CGroup.
-	// Dynamic Kubelet Config (beta): This field should not be updated without a full node
+	// Dynamic Kubelet Config (deprecated): This field should not be updated without a full node
 	// reboot. It is safest to keep this value the same as the local config.
 	// Default: true
 	// +optional
 	CgroupsPerQOS *bool `json:"cgroupsPerQOS,omitempty"`
 	// cgroupDriver is the driver kubelet uses to manipulate CGroups on the host (cgroupfs
 	// or systemd).
-	// Dynamic Kubelet Config (beta): This field should not be updated without a full node
+	// Dynamic Kubelet Config (deprecated): This field should not be updated without a full node
 	// reboot. It is safest to keep this value the same as the local config.
 	// Default: "cgroupfs"
 	// +optional
 	CgroupDriver string `json:"cgroupDriver,omitempty"`
 	// cpuManagerPolicy is the name of the policy to use.
 	// Requires the CPUManager feature gate to be enabled.
-	// Dynamic Kubelet Config (beta): This field should not be updated without a full node
+	// Dynamic Kubelet Config (deprecated): This field should not be updated without a full node
 	// reboot. It is safest to keep this value the same as the local config.
 	// Default: "None"
 	// +optional
 	CPUManagerPolicy string `json:"cpuManagerPolicy,omitempty"`
 	// cpuManagerReconcilePeriod is the reconciliation period for the CPU Manager.
 	// Requires the CPUManager feature gate to be enabled.
-	// Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+	// Dynamic Kubelet Config (deprecated): If dynamically updating this field, consider that
 	// shortening the period may carry a performance impact.
 	// Default: "10s"
 	// +optional
 	CPUManagerReconcilePeriod metav1.Duration `json:"cpuManagerReconcilePeriod,omitempty"`
 	// memoryManagerPolicy is the name of the policy to use by memory manager.
 	// Requires the MemoryManager feature gate to be enabled.
-	// Dynamic Kubelet Config (beta): This field should not be updated without a full node
+	// Dynamic Kubelet Config (deprecated): This field should not be updated without a full node
 	// reboot. It is safest to keep this value the same as the local config.
 	// Default: "none"
 	// +optional
@@ -474,7 +474,7 @@ type KubeletConfiguration struct {
 	//   of CPU and device resources.
 	//
 	// Policies other than "none" require the TopologyManager feature gate to be enabled.
-	// Dynamic Kubelet Config (beta): This field should not be updated without a full node
+	// Dynamic Kubelet Config (deprecated): This field should not be updated without a full node
 	// reboot. It is safest to keep this value the same as the local config.
 	// Default: "none"
 	// +optional
@@ -494,14 +494,14 @@ type KubeletConfiguration struct {
 	// guaranteed QoS tier.
 	// Currently supported resources: "memory"
 	// Requires the QOSReserved feature gate to be enabled.
-	// Dynamic Kubelet Config (beta): This field should not be updated without a full node
+	// Dynamic Kubelet Config (deprecated): This field should not be updated without a full node
 	// reboot. It is safest to keep this value the same as the local config.
 	// Default: nil
 	// +optional
 	QOSReserved map[string]string `json:"qosReserved,omitempty"`
 	// runtimeRequestTimeout is the timeout for all runtime requests except long running
 	// requests - pull, logs, exec and attach.
-	// Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+	// Dynamic Kubelet Config (deprecated): If dynamically updating this field, consider that
 	// it may disrupt components that interact with the Kubelet server.
 	// Default: "2m"
 	// +optional
@@ -517,14 +517,14 @@ type KubeletConfiguration struct {
 	//
 	// Generally, one must set `--hairpin-mode=hairpin-veth to` achieve hairpin NAT,
 	// because promiscuous-bridge assumes the existence of a container bridge named cbr0.
-	// Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+	// Dynamic Kubelet Config (deprecated): If dynamically updating this field, consider that
 	// it may require a node reboot, depending on the network plugin.
 	// Default: "promiscuous-bridge"
 	// +optional
 	HairpinMode string `json:"hairpinMode,omitempty"`
 	// maxPods is the maximum number of Pods that can run on this Kubelet.
 	// The value must be a non-negative integer.
-	// Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+	// Dynamic Kubelet Config (deprecated): If dynamically updating this field, consider that
 	// changes may cause Pods to fail admission on Kubelet restart, and may change
 	// the value reported in Node.Status.Capacity[v1.ResourcePods], thus affecting
 	// future scheduling decisions. Increasing this value may also decrease performance,
@@ -534,20 +534,20 @@ type KubeletConfiguration struct {
 	MaxPods int32 `json:"maxPods,omitempty"`
 	// podCIDR is the CIDR to use for pod IP addresses, only used in standalone mode.
 	// In cluster mode, this is obtained from the control plane.
-	// Dynamic Kubelet Config (beta): This field should always be set to the empty default.
+	// Dynamic Kubelet Config (deprecated): This field should always be set to the empty default.
 	// It should only set for standalone Kubelets, which cannot use Dynamic Kubelet Config.
 	// Default: ""
 	// +optional
 	PodCIDR string `json:"podCIDR,omitempty"`
 	// podPidsLimit is the maximum number of PIDs in any pod.
-	// Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+	// Dynamic Kubelet Config (deprecated): If dynamically updating this field, consider that
 	// lowering it may prevent container processes from forking after the change.
 	// Default: -1
 	// +optional
 	PodPidsLimit *int64 `json:"podPidsLimit,omitempty"`
 	// resolvConf is the resolver configuration file used as the basis
 	// for the container DNS resolution configuration.
-	// Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+	// Dynamic Kubelet Config (deprecated): If dynamically updating this field, consider that
 	// changes will only take effect on Pods created after the update. Draining
 	// the node is recommended before changing this field.
 	// Default: "/etc/resolv.conf"
@@ -560,7 +560,7 @@ type KubeletConfiguration struct {
 	RunOnce bool `json:"runOnce,omitempty"`
 	// cpuCFSQuota enables CPU CFS quota enforcement for containers that
 	// specify CPU limits.
-	// Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+	// Dynamic Kubelet Config (deprecated): If dynamically updating this field, consider that
 	// disabling it may reduce node stability.
 	// Default: true
 	// +optional
@@ -568,7 +568,7 @@ type KubeletConfiguration struct {
 	// cpuCFSQuotaPeriod is the CPU CFS quota period value, `cpu.cfs_period_us`.
 	// The value must be between 1 us and 1 second, inclusive.
 	// Requires the CustomCPUCFSQuotaPeriod feature gate to be enabled.
-	// Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+	// Dynamic Kubelet Config (deprecated): If dynamically updating this field, consider that
 	// limits set for containers will result in different cpu.cfs_quota settings. This
 	// will trigger container restarts on the node being reconfigured.
 	// Default: "100ms"
@@ -577,20 +577,20 @@ type KubeletConfiguration struct {
 	// nodeStatusMaxImages caps the number of images reported in Node.status.images.
 	// The value must be greater than -2.
 	// Note: If -1 is specified, no cap will be applied. If 0 is specified, no image is returned.
-	// Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+	// Dynamic Kubelet Config (deprecated): If dynamically updating this field, consider that
 	// different values can be reported on node status.
 	// Default: 50
 	// +optional
 	NodeStatusMaxImages *int32 `json:"nodeStatusMaxImages,omitempty"`
 	// maxOpenFiles is Number of files that can be opened by Kubelet process.
 	// The value must be a non-negative number.
-	// Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+	// Dynamic Kubelet Config (deprecated): If dynamically updating this field, consider that
 	// it may impact the ability of the Kubelet to interact with the node's filesystem.
 	// Default: 1000000
 	// +optional
 	MaxOpenFiles int64 `json:"maxOpenFiles,omitempty"`
 	// contentType is contentType of requests sent to apiserver.
-	// Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+	// Dynamic Kubelet Config (deprecated): If dynamically updating this field, consider that
 	// it may impact the ability for the Kubelet to communicate with the API server.
 	// If the Kubelet loses contact with the API server due to a change to this field,
 	// the change cannot be reverted via dynamic Kubelet config.
@@ -598,7 +598,7 @@ type KubeletConfiguration struct {
 	// +optional
 	ContentType string `json:"contentType,omitempty"`
 	// kubeAPIQPS is the QPS to use while talking with kubernetes apiserver
-	// Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+	// Dynamic Kubelet Config (deprecated): If dynamically updating this field, consider that
 	// it may impact scalability by changing the amount of traffic the Kubelet
 	// sends to the API server.
 	// Default: 5
@@ -606,7 +606,7 @@ type KubeletConfiguration struct {
 	KubeAPIQPS *int32 `json:"kubeAPIQPS,omitempty"`
 	// kubeAPIBurst is the burst to allow while talking with kubernetes API server.
 	// This field cannot be a negative number.
-	// Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+	// Dynamic Kubelet Config (deprecated): If dynamically updating this field, consider that
 	// it may impact scalability by changing the amount of traffic the Kubelet
 	// sends to the API server.
 	// Default: 10
@@ -616,7 +616,7 @@ type KubeletConfiguration struct {
 	// at a time. We recommend *not* changing the default value on nodes that
 	// run docker daemon with version  < 1.9 or an Aufs storage backend.
 	// Issue #10959 has more details.
-	// Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+	// Dynamic Kubelet Config (deprecated): If dynamically updating this field, consider that
 	// it may impact the performance of image pulls.
 	// Default: true
 	// +optional
@@ -624,7 +624,7 @@ type KubeletConfiguration struct {
 	// evictionHard is a map of signal names to quantities that defines hard eviction
 	// thresholds. For example: `{"memory.available": "300Mi"}`.
 	// To explicitly disable, pass a 0% or 100% threshold on an arbitrary resource.
-	// Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+	// Dynamic Kubelet Config (deprecated): If dynamically updating this field, consider that
 	// it may trigger or delay Pod evictions.
 	// Default:
 	//   memory.available:  "100Mi"
@@ -635,7 +635,7 @@ type KubeletConfiguration struct {
 	EvictionHard map[string]string `json:"evictionHard,omitempty"`
 	// evictionSoft is a map of signal names to quantities that defines soft eviction thresholds.
 	// For example: `{"memory.available": "300Mi"}`.
-	// Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+	// Dynamic Kubelet Config (deprecated): If dynamically updating this field, consider that
 	// it may trigger or delay Pod evictions, and may change the allocatable reported
 	// by the node.
 	// Default: nil
@@ -643,14 +643,14 @@ type KubeletConfiguration struct {
 	EvictionSoft map[string]string `json:"evictionSoft,omitempty"`
 	// evictionSoftGracePeriod is a map of signal names to quantities that defines grace
 	// periods for each soft eviction signal. For example: `{"memory.available": "30s"}`.
-	// Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+	// Dynamic Kubelet Config (deprecated): If dynamically updating this field, consider that
 	// it may trigger or delay Pod evictions.
 	// Default: nil
 	// +optional
 	EvictionSoftGracePeriod map[string]string `json:"evictionSoftGracePeriod,omitempty"`
 	// evictionPressureTransitionPeriod is the duration for which the kubelet has to wait
 	// before transitioning out of an eviction pressure condition.
-	// Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+	// Dynamic Kubelet Config (deprecated): If dynamically updating this field, consider that
 	// lowering it may decrease the stability of the node when the node is overcommitted.
 	// Default: "5m"
 	// +optional
@@ -661,7 +661,7 @@ type KubeletConfiguration struct {
 	// Note: Due to issue #64530, the behavior has a bug where this value currently just
 	// overrides the grace period during soft eviction, which can increase the grace
 	// period from what is set on the Pod. This bug will be fixed in a future release.
-	// Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+	// Dynamic Kubelet Config (deprecated): If dynamically updating this field, consider that
 	// lowering it decreases the amount of time Pods will have to gracefully clean
 	// up before being killed during a soft eviction.
 	// Default: 0
@@ -671,7 +671,7 @@ type KubeletConfiguration struct {
 	// which describe the minimum amount of a given resource the kubelet will reclaim when
 	// performing a pod eviction while that resource is under pressure.
 	// For example: `{"imagefs.available": "2Gi"}`.
-	// Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+	// Dynamic Kubelet Config (deprecated): If dynamically updating this field, consider that
 	// it may change how well eviction can manage resource pressure.
 	// Default: nil
 	// +optional
@@ -679,7 +679,7 @@ type KubeletConfiguration struct {
 	// podsPerCore is the maximum number of pods per core. Cannot exceed maxPods.
 	// The value must be a non-negative integer.
 	// If 0, there is no limit on the number of Pods.
-	// Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+	// Dynamic Kubelet Config (deprecated): If dynamically updating this field, consider that
 	// changes may cause Pods to fail admission on Kubelet restart, and may change
 	// the value reported in `Node.status.capacity.pods`, thus affecting
 	// future scheduling decisions. Increasing this value may also decrease performance,
@@ -690,7 +690,7 @@ type KubeletConfiguration struct {
 	// enableControllerAttachDetach enables the Attach/Detach controller to
 	// manage attachment/detachment of volumes scheduled to this node, and
 	// disables kubelet from executing any attach/detach operations
-	// Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+	// Dynamic Kubelet Config (deprecated): If dynamically updating this field, consider that
 	// changing which component is responsible for volume management on a live node
 	// may result in volumes refusing to detach if the node is not drained prior to
 	// the update, and if Pods are scheduled to the node before the
@@ -702,7 +702,7 @@ type KubeletConfiguration struct {
 	// protectKernelDefaults, if true, causes the Kubelet to error if kernel
 	// flags are not as it expects. Otherwise the Kubelet will attempt to modify
 	// kernel flags to match its expectation.
-	// Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+	// Dynamic Kubelet Config (deprecated): If dynamically updating this field, consider that
 	// enabling it may cause the Kubelet to crash-loop if the Kernel is not configured as
 	// Kubelet expects.
 	// Default: false
@@ -712,7 +712,7 @@ type KubeletConfiguration struct {
 	// are present on host.
 	// These rules will serve as utility rules for various components, e.g. kube-proxy.
 	// The rules will be created based on iptablesMasqueradeBit and iptablesDropBit.
-	// Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+	// Dynamic Kubelet Config (deprecated): If dynamically updating this field, consider that
 	// disabling it will prevent the Kubelet from healing locally misconfigured iptables rules.
 	// Default: true
 	// +optional
@@ -721,7 +721,7 @@ type KubeletConfiguration struct {
 	// Values must be within the range [0, 31]. Must be different from other mark bits.
 	// Warning: Please match the value of the corresponding parameter in kube-proxy.
 	// TODO: clean up IPTablesMasqueradeBit in kube-proxy
-	// Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+	// Dynamic Kubelet Config (deprecated): If dynamically updating this field, consider that
 	// it needs to be coordinated with other components, like kube-proxy, and the update
 	// will only be effective if MakeIPTablesUtilChains is enabled.
 	// Default: 14
@@ -729,7 +729,7 @@ type KubeletConfiguration struct {
 	IPTablesMasqueradeBit *int32 `json:"iptablesMasqueradeBit,omitempty"`
 	// iptablesDropBit is the bit of the iptables fwmark space to mark for dropping packets.
 	// Values must be within the range [0, 31]. Must be different from other mark bits.
-	// Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+	// Dynamic Kubelet Config (deprecated): If dynamically updating this field, consider that
 	// it needs to be coordinated with other components, like kube-proxy, and the update
 	// will only be effective if MakeIPTablesUtilChains is enabled.
 	// Default: 15
@@ -738,7 +738,7 @@ type KubeletConfiguration struct {
 	// featureGates is a map of feature names to bools that enable or disable experimental
 	// features. This field modifies piecemeal the built-in default values from
 	// "k8s.io/kubernetes/pkg/features/kube_features.go".
-	// Dynamic Kubelet Config (beta): If dynamically updating this field, consider the
+	// Dynamic Kubelet Config (deprecated): If dynamically updating this field, consider the
 	// documentation for the features you are enabling or disabling. While we
 	// encourage feature developers to make it possible to dynamically enable
 	// and disable features, some changes may require node reboots, and some
@@ -747,21 +747,21 @@ type KubeletConfiguration struct {
 	// +optional
 	FeatureGates map[string]bool `json:"featureGates,omitempty"`
 	// failSwapOn tells the Kubelet to fail to start if swap is enabled on the node.
-	// Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+	// Dynamic Kubelet Config (deprecated): If dynamically updating this field, consider that
 	// setting it to true will cause the Kubelet to crash-loop if swap is enabled.
 	// Default: true
 	// +optional
 	FailSwapOn *bool `json:"failSwapOn,omitempty"`
 	// containerLogMaxSize is a quantity defining the maximum size of the container log
 	// file before it is rotated. For example: "5Mi" or "256Ki".
-	// Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+	// Dynamic Kubelet Config (deprecated): If dynamically updating this field, consider that
 	// it may trigger log rotation.
 	// Default: "10Mi"
 	// +optional
 	ContainerLogMaxSize string `json:"containerLogMaxSize,omitempty"`
 	// containerLogMaxFiles specifies the maximum number of container log files that can
 	// be present for a container.
-	// Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+	// Dynamic Kubelet Config (deprecated): If dynamically updating this field, consider that
 	// lowering it may cause log files to be deleted.
 	// Default: 5
 	// +optional
@@ -783,7 +783,7 @@ type KubeletConfiguration struct {
 	// pairs that describe resources reserved for non-kubernetes components.
 	// Currently only cpu and memory are supported.
 	// See http://kubernetes.io/docs/user-guide/compute-resources for more detail.
-	// Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+	// Dynamic Kubelet Config (deprecated): If dynamically updating this field, consider that
 	// it may not be possible to increase the reserved resources, because this
 	// requires resizing cgroups. Always look for a NodeAllocatableEnforced event
 	// after updating this field to ensure that the update was successful.
@@ -795,7 +795,7 @@ type KubeletConfiguration struct {
 	// Currently cpu, memory and local storage for root file system are supported.
 	// See https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
 	// for more details.
-	// Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+	// Dynamic Kubelet Config (deprecated): If dynamically updating this field, consider that
 	// it may not be possible to increase the reserved resources, because this
 	// requires resizing cgroups. Always look for a NodeAllocatableEnforced event
 	// after updating this field to ensure that the update was successful.
@@ -821,7 +821,7 @@ type KubeletConfiguration struct {
 	// to enforce `systemReserved` compute resource reservation for OS system daemons.
 	// Refer to [Node Allocatable](https://git.k8s.io/community/contributors/design-proposals/node/node-allocatable.md)
 	// doc for more information.
-	// Dynamic Kubelet Config (beta): This field should not be updated without a full node
+	// Dynamic Kubelet Config (deprecated): This field should not be updated without a full node
 	// reboot. It is safest to keep this value the same as the local config.
 	// Default: ""
 	// +optional
@@ -830,7 +830,7 @@ type KubeletConfiguration struct {
 	// to enforce `KubeReserved` compute resource reservation for Kubernetes node system daemons.
 	// Refer to [Node Allocatable](https://git.k8s.io/community/contributors/design-proposals/node/node-allocatable.md)
 	// doc for more information.
-	// Dynamic Kubelet Config (beta): This field should not be updated without a full node
+	// Dynamic Kubelet Config (deprecated): This field should not be updated without a full node
 	// reboot. It is safest to keep this value the same as the local config.
 	// Default: ""
 	// +optional
@@ -844,7 +844,7 @@ type KubeletConfiguration struct {
 	// This field is supported only when `cgroupsPerQOS` is set to true.
 	// Refer to [Node Allocatable](https://git.k8s.io/community/contributors/design-proposals/node/node-allocatable.md)
 	// for more information.
-	// Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+	// Dynamic Kubelet Config (deprecated): If dynamically updating this field, consider that
 	// removing enforcements may reduce the stability of the node. Alternatively, adding
 	// enforcements may reduce the stability of components which were using more than
 	// the reserved amount of resources; for example, enforcing kube-reserved may cause
@@ -861,14 +861,14 @@ type KubeletConfiguration struct {
 	AllowedUnsafeSysctls []string `json:"allowedUnsafeSysctls,omitempty"`
 	// volumePluginDir is the full path of the directory in which to search
 	// for additional third party volume plugins.
-	// Dynamic Kubelet Config (beta): If dynamically updating this field, consider that changing
+	// Dynamic Kubelet Config (deprecated): If dynamically updating this field, consider that changing
 	// the volumePluginDir may disrupt workloads relying on third party volume plugins.
 	// Default: "/usr/libexec/kubernetes/kubelet-plugins/volume/exec/"
 	// +optional
 	VolumePluginDir string `json:"volumePluginDir,omitempty"`
 	// providerID, if set, sets the unique ID of the instance that an external
 	// provider (i.e. cloudprovider) can use to identify a specific node.
-	// Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+	// Dynamic Kubelet Config (deprecated): If dynamically updating this field, consider that
 	// it may impact the ability of the Kubelet to interact with cloud providers.
 	// Default: ""
 	// +optional
@@ -876,7 +876,7 @@ type KubeletConfiguration struct {
 	// kernelMemcgNotification, if set, instructs the the kubelet to integrate with the
 	// kernel memcg notification for determining if memory eviction thresholds are
 	// exceeded rather than polling.
-	// Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+	// Dynamic Kubelet Config (deprecated): If dynamically updating this field, consider that
 	// it may impact the way Kubelet interacts with the kernel.
 	// Default: false
 	// +optional


### PR DESCRIPTION
#### What type of PR is this?

Deprecation messages for DynamicKubeletConfig (KEP: https://github.com/kubernetes/enhancements/issues/281).

/sig node
/kind cleanup
/kind documentation
/kind deprecation

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
Relates #100799

(actual issue will need more clean up work)

#### Special notes for your reviewer:
I ***think*** I understood the deprecation rules correctly: https://kubernetes.io/docs/reference/using-api/deprecation-policy/#deprecation and I can disable feature gate on deprecation announcement.

#### Does this PR introduce a user-facing change?
```release-note
The feature Dynamic Kubelet Configuration is deprecated and kubelet will report warning when the flag `--dynamic-config-dir` is used. Feature gate `DynamicKubeletConfig` is disabled out of the box and needs to be explicitly enabled.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

- KEP: https://github.com/kubernetes/enhancements/issues/281
