### PR TITLE
deflake TestClientReceivedGOAWAY test

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/server/filters/goaway_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/filters/goaway_test.go
@@ -190,38 +190,6 @@ type watchResponse struct {
 	err error
 }
 
-// newGOAWAYClient return a configured http client which used to request test GOAWAY server, a dial may specified
-// to encounter the TCP connection.
-func newGOAWAYClient(dial func(network, addr string, cfg *tls.Config) (net.Conn, error)) (*http.Client, error) {
-	tlsConfig := &tls.Config{
-		InsecureSkipVerify: true,
-		NextProtos:         []string{http2.NextProtoTLS},
-	}
-
-	tr := &http.Transport{
-		Proxy:               http.ProxyFromEnvironment,
-		TLSHandshakeTimeout: 10 * time.Second,
-		TLSClientConfig:     tlsConfig,
-		MaxIdleConnsPerHost: 25,
-		DialTLSContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
-			if dial != nil {
-				return dial(network, addr, tlsConfig)
-			}
-
-			return tls.Dial(network, addr, tlsConfig)
-		},
-	}
-	if err := http2.ConfigureTransport(tr); err != nil {
-		return nil, err
-	}
-
-	client := &http.Client{
-		Transport: tr,
-	}
-
-	return client, nil
-}
-
 // requestGOAWAYServer request test GOAWAY server using specified method and data according to the given url.
 // A non-nil channel will be returned if the request is watch, and a watchResponse can be got from the channel when watch done.
 func requestGOAWAYServer(client *http.Client, serverBaseURL, url string) (<-chan watchResponse, error) {
@@ -299,8 +267,6 @@ func requestGOAWAYServer(client *http.Client, serverBaseURL, url string) (<-chan
 // TestClientReceivedGOAWAY tests the in-flight watch requests will not be affected and new requests use a new
 // connection after client received GOAWAY.
 func TestClientReceivedGOAWAY(t *testing.T) {
-	t.Skip("disabled because of https://github.com/kubernetes/kubernetes/issues/94622")
-
 	s, err := newTestGOAWAYServer()
 	if err != nil {
 		t.Fatalf("failed to set-up test GOAWAY http server, err: %v", err)
@@ -344,23 +310,39 @@ func TestClientReceivedGOAWAY(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			var mu sync.Mutex
 			// localAddr indicates how many TCP connection set up
 			localAddr := make([]string, 0)
 
-			client, err := newGOAWAYClient(func(network, addr string, cfg *tls.Config) (conn net.Conn, err error) {
+			// create the http client
+			dialFn := func(network, addr string, cfg *tls.Config) (conn net.Conn, err error) {
 				conn, err = tls.Dial(network, addr, cfg)
 				if err != nil {
 					t.Fatalf("unexpect connection err: %v", err)
 				}
 
-				mu.Lock()
 				localAddr = append(localAddr, conn.LocalAddr().String())
-				mu.Unlock()
 				return
-			})
-			if err != nil {
-				t.Fatalf("failed to set-up client, err: %v", err)
+			}
+			tlsConfig := &tls.Config{
+				InsecureSkipVerify: true,
+				NextProtos:         []string{http2.NextProtoTLS},
+			}
+			tr := &http.Transport{
+				TLSHandshakeTimeout: 10 * time.Second,
+				TLSClientConfig:     tlsConfig,
+				// Disable connection pooling to avoid additional connections
+				// that cause the test to flake
+				MaxIdleConnsPerHost: -1,
+				DialTLSContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
+					return dialFn(network, addr, tlsConfig)
+				},
+			}
+			if err := http2.ConfigureTransport(tr); err != nil {
+				t.Fatalf("failed to configure http transport, err: %v", err)
+			}
+
+			client := &http.Client{
+				Transport: tr,
 			}
 
 			watchChs := make([]<-chan watchResponse, 0)
@@ -447,7 +429,23 @@ func TestGOAWAYConcurrency(t *testing.T) {
 	s.StartTLS()
 	defer s.Close()
 
-	client, err := newGOAWAYClient(nil)
+	// create the http client
+	tlsConfig := &tls.Config{
+		InsecureSkipVerify: true,
+		NextProtos:         []string{http2.NextProtoTLS},
+	}
+	tr := &http.Transport{
+		TLSHandshakeTimeout: 10 * time.Second,
+		TLSClientConfig:     tlsConfig,
+		MaxIdleConnsPerHost: 25,
+	}
+	if err := http2.ConfigureTransport(tr); err != nil {
+		t.Fatalf("failed to configure http transport, err: %v", err)
+	}
+
+	client := &http.Client{
+		Transport: tr,
+	}
 	if err != nil {
 		t.Fatalf("failed to set-up client, err: %v", err)
 	}


### PR DESCRIPTION
The test was flaking because the test was creating more connections
than expected.

Disabling connection pooling removes the flakes.

The flake is easy to reproduce, without this patch:

```
go test -run ^TestClientReceivedGOAWAY$ k8s.io/apiserver/pkg/server/filters -race -c
stress -p 50 ./filters.test -test.run ^TestClientReceivedGOAWAY$ 
...
ERROR: exit status 1

3m20s: 452 runs so far, 3 failures (0.66%)
3m25s: 500 runs so far, 3 failures (0.60%)
```

with this patch
```
stress -p 50 ./filters.test -test.run ^TestClientReceivedGOAWAY$ 
...
6m40s: 950 runs so far, 0 failures
6m45s: 950 runs so far, 0 failures
6m50s: 1000 runs so far, 0 failures
```


/kind flake
Fixes #94622

#### Special notes for your reviewer:


```release-note
NONE
```
