### PR TITLE
Reuse the caculated node resource usage information

### DIFF
--- a/pkg/scheduler/framework/plugins/noderesources/balanced_allocation.go
+++ b/pkg/scheduler/framework/plugins/noderesources/balanced_allocation.go
@@ -58,7 +58,7 @@ func (ba *BalancedAllocation) Score(ctx context.Context, state *framework.CycleS
 	// Detail: score = (1 - variance(cpuFraction,memoryFraction,volumeFraction)) * MaxNodeScore. The algorithm is partly inspired by:
 	// "Wei Huang et al. An Energy Efficient Virtual Machine Placement Algorithm with Balanced
 	// Resource Utilization"
-	return ba.score(pod, nodeInfo)
+	return ba.score(pod, nodeInfo, state)
 }
 
 // ScoreExtensions of the Score plugin.

--- a/pkg/scheduler/framework/plugins/noderesources/balanced_allocation_test.go
+++ b/pkg/scheduler/framework/plugins/noderesources/balanced_allocation_test.go
@@ -394,7 +394,8 @@ func TestNodeResourcesBalancedAllocation(t *testing.T) {
 			p, _ := NewBalancedAllocation(nil, fh, feature.Features{EnablePodOverhead: true, EnableBalanceAttachedNodeVolumes: true})
 
 			for i := range test.nodes {
-				hostResult, err := p.(framework.ScorePlugin).Score(context.Background(), nil, test.pod, test.nodes[i].Name)
+				state := framework.NewCycleState()
+				hostResult, err := p.(framework.ScorePlugin).Score(context.Background(), state, test.pod, test.nodes[i].Name)
 				if err != nil {
 					t.Errorf("unexpected error: %v", err)
 				}

--- a/pkg/scheduler/framework/plugins/noderesources/least_allocated.go
+++ b/pkg/scheduler/framework/plugins/noderesources/least_allocated.go
@@ -58,7 +58,7 @@ func (la *LeastAllocated) Score(ctx context.Context, state *framework.CycleState
 	//
 	// Details:
 	// (cpu((capacity-sum(requested))*MaxNodeScore/capacity) + memory((capacity-sum(requested))*MaxNodeScore/capacity))/weightSum
-	return la.score(pod, nodeInfo)
+	return la.score(pod, nodeInfo, state)
 }
 
 // ScoreExtensions of the Score plugin.

--- a/pkg/scheduler/framework/plugins/noderesources/least_allocated_test.go
+++ b/pkg/scheduler/framework/plugins/noderesources/least_allocated_test.go
@@ -333,7 +333,8 @@ func TestNodeResourcesLeastAllocated(t *testing.T) {
 			}
 
 			for i := range test.nodes {
-				hostResult, err := p.(framework.ScorePlugin).Score(context.Background(), nil, test.pod, test.nodes[i].Name)
+				state := framework.NewCycleState()
+				hostResult, err := p.(framework.ScorePlugin).Score(context.Background(), state, test.pod, test.nodes[i].Name)
 				if err != nil {
 					t.Errorf("unexpected error: %v", err)
 				}

--- a/pkg/scheduler/framework/plugins/noderesources/most_allocated.go
+++ b/pkg/scheduler/framework/plugins/noderesources/most_allocated.go
@@ -56,7 +56,7 @@ func (ma *MostAllocated) Score(ctx context.Context, state *framework.CycleState,
 	// It calculates the percentage of memory and CPU requested by pods scheduled on the node, and prioritizes
 	// based on the maximum of the average of the fraction of requested to capacity.
 	// Details: (cpu(MaxNodeScore * sum(requested) / capacity) + memory(MaxNodeScore * sum(requested) / capacity)) / weightSum
-	return ma.score(pod, nodeInfo)
+	return ma.score(pod, nodeInfo, state)
 }
 
 // ScoreExtensions of the Score plugin.

--- a/pkg/scheduler/framework/plugins/noderesources/most_allocated_test.go
+++ b/pkg/scheduler/framework/plugins/noderesources/most_allocated_test.go
@@ -293,7 +293,8 @@ func TestNodeResourcesMostAllocated(t *testing.T) {
 			}
 
 			for i := range test.nodes {
-				hostResult, err := p.(framework.ScorePlugin).Score(context.Background(), nil, test.pod, test.nodes[i].Name)
+				state := framework.NewCycleState()
+				hostResult, err := p.(framework.ScorePlugin).Score(context.Background(), state, test.pod, test.nodes[i].Name)
 				if err != nil {
 					t.Errorf("unexpected error: %v", err)
 				}

--- a/pkg/scheduler/framework/plugins/noderesources/requested_to_capacity_ratio.go
+++ b/pkg/scheduler/framework/plugins/noderesources/requested_to_capacity_ratio.go
@@ -101,12 +101,12 @@ func (pl *RequestedToCapacityRatio) Name() string {
 }
 
 // Score invoked at the score extension point.
-func (pl *RequestedToCapacityRatio) Score(ctx context.Context, _ *framework.CycleState, pod *v1.Pod, nodeName string) (int64, *framework.Status) {
+func (pl *RequestedToCapacityRatio) Score(ctx context.Context, state *framework.CycleState, pod *v1.Pod, nodeName string) (int64, *framework.Status) {
 	nodeInfo, err := pl.handle.SnapshotSharedLister().NodeInfos().Get(nodeName)
 	if err != nil {
 		return 0, framework.AsStatus(fmt.Errorf("getting node %q from Snapshot: %w", nodeName, err))
 	}
-	return pl.score(pod, nodeInfo)
+	return pl.score(pod, nodeInfo, state)
 }
 
 // ScoreExtensions of the Score plugin.

--- a/pkg/scheduler/framework/plugins/selectorspread/selector_spread.go
+++ b/pkg/scheduler/framework/plugins/selectorspread/selector_spread.go
@@ -92,7 +92,7 @@ func (pl *SelectorSpread) Score(ctx context.Context, state *framework.CycleState
 
 	s, ok := c.(*preScoreState)
 	if !ok {
-		return 0, framework.AsStatus(fmt.Errorf("cannot convert saved state to tainttoleration.preScoreState"))
+		return 0, framework.AsStatus(fmt.Errorf("cannot convert saved state to SelectorSpread.preScoreState"))
 	}
 
 	nodeInfo, err := pl.sharedLister.NodeInfos().Get(nodeName)


### PR DESCRIPTION
Signed-off-by: Dave Chen <dave.chen@arm.com>


btw, this PR take the chance to cleanup a typo.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature



#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes/kubernetes/issues/102977

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
