### PR TITLE
Clean up the master term in test/integration comments

### DIFF
--- a/test/integration/auth/accessreview_test.go
+++ b/test/integration/auth/accessreview_test.go
@@ -34,7 +34,7 @@ import (
 	"k8s.io/kubernetes/test/integration/framework"
 )
 
-// Inject into master an authorizer that uses user info.
+// Inject into control plane an authorizer that uses user info.
 // TODO(etune): remove this test once a more comprehensive built-in authorizer is implemented.
 type sarAuthorizer struct{}
 

--- a/test/integration/auth/auth_test.go
+++ b/test/integration/auth/auth_test.go
@@ -16,7 +16,7 @@ limitations under the License.
 
 package auth
 
-// This file tests authentication and (soon) authorization of HTTP requests to a master object.
+// This file tests authentication and (soon) authorization of HTTP requests to an API server object.
 // It does not use the client in pkg/client/... because authentication and authorization needs
 // to work for any client of the HTTP interface.
 
@@ -569,7 +569,7 @@ func TestAuthModeAlwaysDeny(t *testing.T) {
 	}
 }
 
-// Inject into master an authorizer that uses user info.
+// Inject into control plane an authorizer that uses user info.
 // TODO(etune): remove this test once a more comprehensive built-in authorizer is implemented.
 type allowAliceAuthorizer struct{}
 
@@ -1203,7 +1203,7 @@ func TestReadOnlyAuthorization(t *testing.T) {
 	}
 }
 
-// TestWebhookTokenAuthenticator tests that a master can use the webhook token
+// TestWebhookTokenAuthenticator tests that a control plane can use the webhook token
 // authenticator to call out to a remote web server for authentication
 // decisions.
 func TestWebhookTokenAuthenticator(t *testing.T) {

--- a/test/integration/deployment/util.go
+++ b/test/integration/deployment/util.go
@@ -101,7 +101,7 @@ func newDeployment(name, ns string, replicas int32) *apps.Deployment {
 	}
 }
 
-// dcSetup sets up necessities for Deployment integration test, including master, apiserver, informers, and clientset
+// dcSetup sets up necessities for Deployment integration test, including control plane, apiserver, informers, and clientset
 func dcSetup(t *testing.T) (*httptest.Server, framework.CloseFunc, *replicaset.ReplicaSetController, *deployment.DeploymentController, informers.SharedInformerFactory, clientset.Interface) {
 	controlPlaneConfig := framework.NewIntegrationTestControlPlaneConfig()
 	_, s, closeFn := framework.RunAnAPIServer(controlPlaneConfig)
@@ -132,7 +132,7 @@ func dcSetup(t *testing.T) (*httptest.Server, framework.CloseFunc, *replicaset.R
 	return s, closeFn, rm, dc, informers, clientSet
 }
 
-// dcSimpleSetup sets up necessities for Deployment integration test, including master, apiserver,
+// dcSimpleSetup sets up necessities for Deployment integration test, including control plane, apiserver,
 // and clientset, but not controllers and informers
 func dcSimpleSetup(t *testing.T) (*httptest.Server, framework.CloseFunc, clientset.Interface) {
 	controlPlaneConfig := framework.NewIntegrationTestControlPlaneConfig()

--- a/test/integration/master/synthetic_master_test.go
+++ b/test/integration/master/synthetic_master_test.go
@@ -709,7 +709,7 @@ func TestServiceAlloc(t *testing.T) {
 }
 
 // TestUpdateNodeObjects represents a simple version of the behavior of node checkins at steady
-// state. This test allows for easy profiling of a realistic master scenario for baseline CPU
+// state. This test allows for easy profiling of a realistic primary scenario for baseline CPU
 // in very large clusters. It is disabled by default - start a kube-apiserver and pass
 // UPDATE_NODE_APISERVER as the host value.
 func TestUpdateNodeObjects(t *testing.T) {

--- a/test/integration/scheduler/util.go
+++ b/test/integration/scheduler/util.go
@@ -80,7 +80,7 @@ func initDisruptionController(t *testing.T, testCtx *testutils.TestContext) *dis
 	return dc
 }
 
-// initTest initializes a test environment and creates master and scheduler with default
+// initTest initializes a test environment and creates API server and scheduler with default
 // configuration.
 func initTest(t *testing.T, nsPrefix string, opts ...scheduler.Option) *testutils.TestContext {
 	testCtx := testutils.InitTestSchedulerWithOptions(t, testutils.InitTestAPIServer(t, nsPrefix, nil), nil, opts...)
@@ -89,7 +89,7 @@ func initTest(t *testing.T, nsPrefix string, opts ...scheduler.Option) *testutil
 	return testCtx
 }
 
-// initTestDisablePreemption initializes a test environment and creates master and scheduler with default
+// initTestDisablePreemption initializes a test environment and creates API server and scheduler with default
 // configuration but with pod preemption disabled.
 func initTestDisablePreemption(t *testing.T, nsPrefix string) *testutils.TestContext {
 	cfg := configtesting.V1beta2ToInternalWithDefaults(t, v1beta2.KubeSchedulerConfiguration{

--- a/test/integration/scheduler_perf/util.go
+++ b/test/integration/scheduler_perf/util.go
@@ -67,7 +67,7 @@ func newDefaultComponentConfig() (*config.KubeSchedulerConfiguration, error) {
 }
 
 // mustSetupScheduler starts the following components:
-// - k8s api server (a.k.a. master)
+// - k8s api server
 // - scheduler
 // It returns regular and dynamic clients, and destroyFunc which should be used to
 // remove resources after finished.

--- a/test/integration/serviceaccount/service_account_test.go
+++ b/test/integration/serviceaccount/service_account_test.go
@@ -16,7 +16,7 @@ limitations under the License.
 
 package serviceaccount
 
-// This file tests authentication and (soon) authorization of HTTP requests to a master object.
+// This file tests authentication and (soon) authorization of HTTP requests to an API server object.
 // It does not use the client in pkg/client/... because authentication and authorization needs
 // to work for any client of the HTTP interface.
 

--- a/test/integration/statefulset/util.go
+++ b/test/integration/statefulset/util.go
@@ -157,7 +157,7 @@ func newStatefulSetPVC(name string) v1.PersistentVolumeClaim {
 	}
 }
 
-// scSetup sets up necessities for Statefulset integration test, including master, apiserver, informers, and clientset
+// scSetup sets up necessities for Statefulset integration test, including control plane, apiserver, informers, and clientset
 func scSetup(t *testing.T) (*httptest.Server, framework.CloseFunc, *statefulset.StatefulSetController, informers.SharedInformerFactory, clientset.Interface) {
 	controlPlaneConfig := framework.NewIntegrationTestControlPlaneConfig()
 	_, s, closeFn := framework.RunAnAPIServer(controlPlaneConfig)

--- a/test/integration/utils.go
+++ b/test/integration/utils.go
@@ -41,7 +41,7 @@ func DeletePodOrErrorf(t *testing.T, c clientset.Interface, ns, name string) {
 }
 
 // Requests to try.  Each one should be forbidden or not forbidden
-// depending on the authentication and authorization setup of the master.
+// depending on the authentication and authorization setup of the API server.
 var (
 	Code200 = map[int]bool{200: true}
 	Code201 = map[int]bool{201: true}

--- a/test/integration/volumescheduling/util.go
+++ b/test/integration/volumescheduling/util.go
@@ -54,7 +54,7 @@ type testContext struct {
 	cancelFn context.CancelFunc
 }
 
-// initTestAPIServer initializes a test environment and creates a master with default
+// initTestAPIServer initializes a test environment and creates an API server with default
 // configuration. Alpha resources are enabled automatically if the corresponding feature
 // is enabled.
 func initTestAPIServer(t *testing.T, nsPrefix string, admission admission.Interface) *testContext {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
/wg naming
/area test

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

xref #94407
As https://github.com/kubernetes/kubernetes/pull/100181#issuecomment-805017091 commented, this PR change codes less than 50 lines at a time. It would be friendly to review.
As https://github.com/kubernetes/kubernetes/pull/100181#discussion_r594825941 Name the API Server-related master method  `APIServer` instead of the `ControlPlane`.

According to specific use, rename master to control plane, API server or primary.


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Part of #94900

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
