### PR TITLE
Extract columnPrinter interface for printing the values behind additional columns

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/registry/customresource/tableconvertor/tableconvertor.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/registry/customresource/tableconvertor/tableconvertor.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"reflect"
 
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
@@ -69,9 +70,14 @@ func New(crdColumns []apiextensionsv1.CustomResourceColumnDefinition) (rest.Tabl
 	return c, nil
 }
 
+type columnPrinter interface {
+	FindResults(data interface{}) ([][]reflect.Value, error)
+	PrintResults(w io.Writer, results []reflect.Value) error
+}
+
 type convertor struct {
 	headers           []metav1.TableColumnDefinition
-	additionalColumns []*jsonpath.JSONPath
+	additionalColumns []columnPrinter
 }
 
 func (c *convertor) ConvertToTable(ctx context.Context, obj runtime.Object, tableOptions runtime.Object) (*metav1.Table, error) {

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/registry/customresource/tableconvertor/tableconvertor_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/registry/customresource/tableconvertor/tableconvertor_test.go
@@ -78,7 +78,7 @@ func Test_cellForJSONValue(t *testing.T) {
 func Test_convertor_ConvertToTable(t *testing.T) {
 	type fields struct {
 		headers           []metav1.TableColumnDefinition
-		additionalColumns []*jsonpath.JSONPath
+		additionalColumns []columnPrinter
 	}
 	type args struct {
 		ctx          context.Context
@@ -212,7 +212,7 @@ func Test_convertor_ConvertToTable(t *testing.T) {
 					{Name: "single2", Type: "string"},
 					{Name: "multi", Type: "string"},
 				},
-				additionalColumns: []*jsonpath.JSONPath{
+				additionalColumns: []columnPrinter{
 					newJSONPath("valueOnly", "{.spec.servers[0].hosts[0]}"),
 					newJSONPath("single1", "{.spec.servers[0].hosts}"),
 					newJSONPath("single2", "{.spec.servers[1].hosts}"),
@@ -285,7 +285,7 @@ func Test_convertor_ConvertToTable(t *testing.T) {
 					{Name: "single2", Type: "string"},
 					{Name: "multi", Type: "string"},
 				},
-				additionalColumns: []*jsonpath.JSONPath{
+				additionalColumns: []columnPrinter{
 					newJSONPath("valueOnly", "{.spec.foo[0].bar[0]}"),
 					newJSONPath("single1", "{.spec.foo[0].bar}"),
 					newJSONPath("single2", "{.spec.foo[1].bar}"),
@@ -358,7 +358,7 @@ func Test_convertor_ConvertToTable(t *testing.T) {
 					{Name: "single2", Type: "integer"},
 					{Name: "multi", Type: "integer"},
 				},
-				additionalColumns: []*jsonpath.JSONPath{
+				additionalColumns: []columnPrinter{
 					newJSONPath("valueOnly", "{.spec.foo[0].bar[0]}"),
 					newJSONPath("single1", "{.spec.foo[0].bar}"),
 					newJSONPath("single2", "{.spec.foo[1].bar}"),
@@ -440,7 +440,7 @@ func Test_convertor_ConvertToTable(t *testing.T) {
 	}
 }
 
-func newJSONPath(name string, jsonPathExpression string) *jsonpath.JSONPath {
+func newJSONPath(name string, jsonPathExpression string) columnPrinter {
 	jp := jsonpath.New(name)
 	_ = jp.Parse(jsonPathExpression)
 	return jp


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup
/sig api-machinery

#### What this PR does / why we need it:
Currently we rely on the JSONPath when printing CRD's `additionalColumns`, this PR extracts method used for finding value and printing into a re-usable interface. 

#### Special notes for your reviewer:
/assign @sttts 

```release-note
NONE
```
