### PR TITLE
Automated cherry pick of #102892: Do not throw error when we can't get canonical path

### DIFF
--- a/staging/src/k8s.io/legacy-cloud-providers/vsphere/vsphere.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/vsphere/vsphere.go
@@ -933,11 +933,10 @@ func (vs *VSphere) AttachDisk(vmDiskPath string, storagePolicyName string, nodeN
 			return "", err
 		}
 
-		// try and get canonical path for disk and if we can't throw error
-		vmDiskPath, err = getcanonicalVolumePath(ctx, vm.Datacenter, vmDiskPath)
-		if err != nil {
-			klog.Errorf("failed to get canonical path for %s on node %s: %v", vmDiskPath, convertToString(nodeName), err)
-			return "", err
+		// try and get canonical path for disk and if we can't use provided vmDiskPath
+		canonicalPath, pathFetchErr := getcanonicalVolumePath(ctx, vm.Datacenter, vmDiskPath)
+		if canonicalPath != "" && pathFetchErr == nil {
+			vmDiskPath = canonicalPath
 		}
 
 		diskUUID, err = vm.AttachDisk(ctx, vmDiskPath, &vclib.VolumeOptions{SCSIControllerType: vclib.PVSCSIControllerType, StoragePolicyName: storagePolicyName})


### PR DESCRIPTION
Cherry pick of #102892 on release-1.20.

#102892: Do not throw error when we can't get canonical path

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.


```release-note
vSphere: Fix regression in 1.20+ during attach disk if datastore is within a storage folder or datastore cluster.
```
