### PR TITLE
Revert "Use docker buildx for the build-image."

### DIFF
--- a/build/common.sh
+++ b/build/common.sh
@@ -397,11 +397,11 @@ function kube::build::docker_build() {
   local build_args
   IFS=" " read -r -a build_args <<< "$4"
   readonly build_args
-  local -ra build_cmd=("${DOCKER[@]}" buildx build --load -t "${image}" "--pull=${pull}" "${build_args[@]}" "${context_dir}")
+  local -ra build_cmd=("${DOCKER[@]}" build -t "${image}" "--pull=${pull}" "${build_args[@]}" "${context_dir}")
 
   kube::log::status "Building Docker image ${image}"
   local docker_output
-  docker_output=$(DOCKER_CLI_EXPERIMENTAL=enabled "${build_cmd[@]}" 2>&1) || {
+  docker_output=$("${build_cmd[@]}" 2>&1) || {
     cat <<EOF >&2
 +++ Docker build command failed for ${image}
 
@@ -409,7 +409,7 @@ ${docker_output}
 
 To retry manually, run:
 
-DOCKER_CLI_EXPERIMENTAL=enabled ${build_cmd[*]}
+${build_cmd[*]}
 
 EOF
     return 1


### PR DESCRIPTION
Reverts kubernetes/kubernetes#99080

Per https://github.com/kubernetes/kubernetes/issues/102822 I'd like to suggest we revert this change, or find some other way to ensure that `buildx` is consistently available. I haven't been able to run `make update` with a stock `docker.io` package install on Debian since this merged, so proposing the revert.

/cc @BenTheElder @vinayakankugoyal 
/sig release
/priority important-soon
/kind bug

```release-note
NONE
```