### PR TITLE
Fix staticcheck in k8s.io/{apiserver/pkg/storage,client-go/rest/watch}

### DIFF
--- a/hack/.staticcheck_failures
+++ b/hack/.staticcheck_failures
@@ -1,9 +1,6 @@
 vendor/k8s.io/apiserver/pkg/server/dynamiccertificates
 vendor/k8s.io/apiserver/pkg/server/filters
 vendor/k8s.io/apiserver/pkg/server/routes
-vendor/k8s.io/apiserver/pkg/storage/cacher
-vendor/k8s.io/apiserver/pkg/storage/tests
 vendor/k8s.io/apiserver/pkg/storage/value/encrypt/envelope
 vendor/k8s.io/apiserver/pkg/util/wsstream
 vendor/k8s.io/client-go/rest
-vendor/k8s.io/client-go/rest/watch

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher_whitebox_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher_whitebox_test.go
@@ -18,6 +18,7 @@ package cacher
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"reflect"
 	goruntime "runtime"
@@ -649,6 +650,7 @@ func TestCacherNoLeakWithMultipleWatchers(t *testing.T) {
 
 	// run the collision test for 3 seconds to let ~2 buckets expire
 	stopCh := make(chan struct{})
+	var watchErr error
 	time.AfterFunc(3*time.Second, func() { close(stopCh) })
 
 	wg := &sync.WaitGroup{}
@@ -664,7 +666,8 @@ func TestCacherNoLeakWithMultipleWatchers(t *testing.T) {
 				ctx, _ := context.WithTimeout(context.Background(), 3*time.Second)
 				w, err := cacher.Watch(ctx, "pods/ns", storage.ListOptions{ResourceVersion: "0", Predicate: pred})
 				if err != nil {
-					t.Fatalf("Failed to create watch: %v", err)
+					watchErr = fmt.Errorf("Failed to create watch: %v", err)
+					return
 				}
 				w.Stop()
 			}
@@ -686,6 +689,10 @@ func TestCacherNoLeakWithMultipleWatchers(t *testing.T) {
 
 	// wait for adding/removing watchers to end
 	wg.Wait()
+
+	if watchErr != nil {
+		t.Fatal(watchErr)
+	}
 
 	// wait out the expiration period and pop expired watchers
 	time.Sleep(2 * time.Second)
@@ -742,6 +749,7 @@ func testCacherSendBookmarkEvents(t *testing.T, allowWatchBookmarks, expectedBoo
 	}
 
 	resourceVersion := uint64(1000)
+	errc := make(chan error, 1)
 	go func() {
 		deadline := time.Now().Add(time.Second)
 		for i := 0; time.Now().Before(deadline); i++ {
@@ -752,7 +760,8 @@ func testCacherSendBookmarkEvents(t *testing.T, allowWatchBookmarks, expectedBoo
 					ResourceVersion: fmt.Sprintf("%v", resourceVersion+uint64(i)),
 				}})
 			if err != nil {
-				t.Fatalf("failed to add a pod: %v", err)
+				errc <- fmt.Errorf("failed to add a pod: %v", err)
+				return
 			}
 			time.Sleep(100 * time.Millisecond)
 		}
@@ -762,6 +771,9 @@ func testCacherSendBookmarkEvents(t *testing.T, allowWatchBookmarks, expectedBoo
 	lastObservedRV := uint64(0)
 	for {
 		select {
+		case err := <-errc:
+			t.Fatal(err)
+			return
 		case event, ok := <-w.ResultChan():
 			if !ok {
 				t.Fatal("Unexpected closed")
@@ -945,7 +957,6 @@ func TestDispatchingBookmarkEventsWithConcurrentStop(t *testing.T) {
 
 		select {
 		case <-done:
-			break
 		case <-time.After(time.Second):
 			t.Fatal("receive result timeout")
 		}
@@ -994,6 +1005,8 @@ func TestBookmarksOnResourceVersionUpdates(t *testing.T) {
 
 	expectedRV := 2000
 
+	var rcErr error
+
 	wg := sync.WaitGroup{}
 	wg.Add(1)
 	go func() {
@@ -1001,7 +1014,8 @@ func TestBookmarksOnResourceVersionUpdates(t *testing.T) {
 		for {
 			event, ok := <-w.ResultChan()
 			if !ok {
-				t.Fatalf("Unexpected closed channel")
+				rcErr = errors.New("Unexpected closed channel")
+				return
 			}
 			rv, err := cacher.versioner.ObjectResourceVersion(event.Object)
 			if err != nil {
@@ -1017,6 +1031,9 @@ func TestBookmarksOnResourceVersionUpdates(t *testing.T) {
 	cacher.watchCache.UpdateResourceVersion(strconv.Itoa(expectedRV))
 
 	wg.Wait()
+	if rcErr != nil {
+		t.Fatal(rcErr)
+	}
 }
 
 type fakeTimeBudget struct{}

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/caching_object_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/caching_object_test.go
@@ -149,7 +149,8 @@ func TestCachingObjectRaces(t *testing.T) {
 			}
 			accessor, err := meta.Accessor(object.GetObject())
 			if err != nil {
-				t.Fatalf("failed to get accessor: %v", err)
+				t.Errorf("failed to get accessor: %v", err)
+				return
 			}
 			if selfLink := accessor.GetSelfLink(); selfLink != "selfLink" {
 				t.Errorf("unexpected selfLink: %s", selfLink)

--- a/staging/src/k8s.io/apiserver/pkg/storage/value/encrypt/envelope/grpc_service_unix_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/value/encrypt/envelope/grpc_service_unix_test.go
@@ -185,12 +185,13 @@ func TestTimeouts(t *testing.T) {
 func TestIntermittentConnectionLoss(t *testing.T) {
 	t.Parallel()
 	var (
-		wg1      sync.WaitGroup
-		wg2      sync.WaitGroup
-		timeout  = 30 * time.Second
-		blackOut = 1 * time.Second
-		data     = []byte("test data")
-		endpoint = newEndpoint()
+		wg1        sync.WaitGroup
+		wg2        sync.WaitGroup
+		timeout    = 30 * time.Second
+		blackOut   = 1 * time.Second
+		data       = []byte("test data")
+		endpoint   = newEndpoint()
+		encryptErr error
 	)
 	// Start KMS Plugin
 	f, err := mock.NewBase64Plugin(endpoint.path)
@@ -228,7 +229,7 @@ func TestIntermittentConnectionLoss(t *testing.T) {
 		wg1.Done()
 		_, err := service.Encrypt(data)
 		if err != nil {
-			t.Fatalf("failed when executing encrypt, error: %v", err)
+			encryptErr = fmt.Errorf("failed when executing encrypt, error: %v", err)
 		}
 	}()
 
@@ -246,6 +247,10 @@ func TestIntermittentConnectionLoss(t *testing.T) {
 	t.Log("Restarted KMS Plugin")
 
 	wg2.Wait()
+
+	if encryptErr != nil {
+		t.Error(encryptErr)
+	}
 }
 
 func TestUnsupportedVersion(t *testing.T) {

--- a/staging/src/k8s.io/client-go/rest/watch/decoder_test.go
+++ b/staging/src/k8s.io/client-go/rest/watch/decoder_test.go
@@ -18,6 +18,7 @@ package versioned_test
 
 import (
 	"encoding/json"
+	"fmt"
 	"io"
 	"testing"
 	"time"
@@ -51,10 +52,13 @@ func TestDecoder(t *testing.T) {
 		expect := &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "foo"}}
 		encoder := json.NewEncoder(in)
 		eType := eventType
+		errc := make(chan error)
+
 		go func() {
 			data, err := runtime.Encode(scheme.Codecs.LegacyCodec(v1.SchemeGroupVersion), expect)
 			if err != nil {
-				t.Fatalf("Unexpected error %v", err)
+				errc <- fmt.Errorf("Unexpected error %v", err)
+				return
 			}
 			event := metav1.WatchEvent{
 				Type:   string(eType),
@@ -70,7 +74,8 @@ func TestDecoder(t *testing.T) {
 		go func() {
 			action, got, err := decoder.Decode()
 			if err != nil {
-				t.Fatalf("Unexpected error %v", err)
+				errc <- fmt.Errorf("Unexpected error %v", err)
+				return
 			}
 			if e, a := eType, action; e != a {
 				t.Errorf("Expected %v, got %v", e, a)
@@ -81,7 +86,11 @@ func TestDecoder(t *testing.T) {
 			t.Logf("Exited read")
 			close(done)
 		}()
-		<-done
+		select {
+		case err := <-errc:
+			t.Fatal(err)
+		case <-done:
+		}
 
 		done = make(chan struct{})
 		go func() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
PR fixes issues found by staticcheck in `k8s.io/apiserver/pkg/storage/` and `k8s.io/client-go/rest/watch`:
```
vendor/k8s.io/apiserver/pkg/storage/cacher/cacher_whitebox_test.go:657:2: the goroutine calls T.Fatalf, which must be called in the same goroutine as the test (SA2002)
vendor/k8s.io/apiserver/pkg/storage/cacher/cacher_whitebox_test.go:667:6: call to T.Fatalf
vendor/k8s.io/apiserver/pkg/storage/cacher/cacher_whitebox_test.go:745:2: the goroutine calls T.Fatalf, which must be called in the same goroutine as the test (SA2002)
vendor/k8s.io/apiserver/pkg/storage/cacher/cacher_whitebox_test.go:755:5: call to T.Fatalf
vendor/k8s.io/apiserver/pkg/storage/cacher/cacher_whitebox_test.go:948:4: ineffective break statement. Did you mean to break out of the outer loop? (SA4011)
vendor/k8s.io/apiserver/pkg/storage/cacher/cacher_whitebox_test.go:999:2: the goroutine calls T.Fatalf, which must be called in the same goroutine as the test (SA2002)
vendor/k8s.io/apiserver/pkg/storage/cacher/cacher_whitebox_test.go:1004:5: call to T.Fatalf
vendor/k8s.io/apiserver/pkg/storage/cacher/caching_object_test.go:137:3: the goroutine calls T.Fatalf, which must be called in the same goroutine as the test (SA2002)
vendor/k8s.io/apiserver/pkg/storage/cacher/caching_object_test.go:152:5: call to T.Fatalf
vendor/k8s.io/apiserver/pkg/storage/tests/cacher_test.go:894:2: the goroutine calls T.Fatalf, which must be called in the same goroutine as the test (SA2002)
vendor/k8s.io/apiserver/pkg/storage/tests/cacher_test.go:904:6: call to T.Fatalf
vendor/k8s.io/apiserver/pkg/storage/value/encrypt/envelope/grpc_service_unix_test.go:135:4: the goroutine calls T.Fatalf, which must be called in the same goroutine as the test (SA2002)
vendor/k8s.io/apiserver/pkg/storage/value/encrypt/envelope/grpc_service_unix_test.go:141:6: call to T.Fatalf
vendor/k8s.io/apiserver/pkg/storage/value/encrypt/envelope/grpc_service_unix_test.go:150:4: the goroutine calls T.Fatalf, which must be called in the same goroutine as the test (SA2002)
vendor/k8s.io/apiserver/pkg/storage/value/encrypt/envelope/grpc_service_unix_test.go:159:6: call to T.Fatalf
vendor/k8s.io/apiserver/pkg/storage/value/encrypt/envelope/grpc_service_unix_test.go:224:2: the goroutine calls T.Fatalf, which must be called in the same goroutine as the test (SA2002)
vendor/k8s.io/apiserver/pkg/storage/value/encrypt/envelope/grpc_service_unix_test.go:231:4: call to T.Fatalf
vendor/k8s.io/client-go/rest/watch/decoder_test.go:54:3: the goroutine calls T.Fatalf, which must be called in the same goroutine as the test (SA2002)
vendor/k8s.io/client-go/rest/watch/decoder_test.go:57:5: call to T.Fatalf
vendor/k8s.io/client-go/rest/watch/decoder_test.go:70:3: the goroutine calls T.Fatalf, which must be called in the same goroutine as the test (SA2002)
vendor/k8s.io/client-go/rest/watch/decoder_test.go:73:5: call to T.Fatalf
```

#### Which issue(s) this PR fixes:
Part of #92402

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
