### PR TITLE
Fix SecretRef validation for PersistentVolumes

### DIFF
--- a/pkg/apis/core/validation/validation.go
+++ b/pkg/apis/core/validation/validation.go
@@ -309,7 +309,7 @@ func ValidateSecretReference(secretRef *core.SecretReference, fldPath *field.Pat
 func ValidateSecretObjectReference(secretRef *core.ObjectReference, fldPath *field.Path) field.ErrorList {
 	var allErrs field.ErrorList
 	if secretRef.Kind != "Secret" {
-		allErrs = append(allErrs, field.Invalid(fldPath.Child("kind"), secretRef.Kind, "kind should be a secret"))
+		allErrs = append(allErrs, field.Invalid(fldPath.Child("kind"), secretRef.Kind, "kind should be Secret"))
 	} else {
 		if len(secretRef.Name) == 0 {
 			allErrs = append(allErrs, field.Required(fldPath.Child("name"), ""))

--- a/pkg/apis/core/validation/validation.go
+++ b/pkg/apis/core/validation/validation.go
@@ -1540,7 +1540,7 @@ func validateStorageOSPersistentVolumeSource(storageos *core.StorageOSPersistent
 	}
 	if storageos.SecretRef != nil {
 		allErrs = append(allErrs, ValidateSecretReference(&core.SecretReference{
-			Name: storageos.SecretRef.Name,
+			Name:      storageos.SecretRef.Name,
 			Namespace: storageos.SecretRef.Namespace,
 		}, fldPath.Child("secretRef"))...)
 	}

--- a/pkg/apis/core/validation/validation.go
+++ b/pkg/apis/core/validation/validation.go
@@ -809,6 +809,15 @@ func validateISCSIPersistentVolumeSource(iscsi *core.ISCSIPersistentVolumeSource
 	if iscsi.SecretRef != nil {
 		if len(iscsi.SecretRef.Name) == 0 {
 			allErrs = append(allErrs, field.Required(fldPath.Child("secretRef", "name"), ""))
+		} else {
+			for _, msg := range ValidateSecretName(iscsi.SecretRef.Name, false) {
+				allErrs = append(allErrs, field.Invalid(fldPath.Child("secretRef", "name"), iscsi.SecretRef.Name, msg))
+			}
+		}
+		if len(iscsi.SecretRef.Namespace) == 0 {
+			allErrs = append(allErrs, field.Required(fldPath.Child("secretRef", "namespace"), ""))
+		} else {
+			allErrs = append(allErrs, ValidateDNS1123Label(iscsi.SecretRef.Namespace, fldPath.Child("secretRef", "namespace"))...)
 		}
 	}
 	if iscsi.InitiatorName != nil {
@@ -1262,6 +1271,21 @@ func validateRBDPersistentVolumeSource(rbd *core.RBDPersistentVolumeSource, fldP
 	if len(rbd.RBDImage) == 0 {
 		allErrs = append(allErrs, field.Required(fldPath.Child("image"), ""))
 	}
+	if rbd.SecretRef != nil {
+		if len(rbd.SecretRef.Name) == 0 {
+			allErrs = append(allErrs, field.Required(fldPath.Child("secretRef", "name"), ""))
+		} else {
+			for _, msg := range ValidateSecretName(rbd.SecretRef.Name, false) {
+				allErrs = append(allErrs, field.Invalid(fldPath.Child("secretRef", "name"), rbd.SecretRef.Name, msg))
+			}
+		}
+		if len(rbd.SecretRef.Namespace) == 0 {
+			allErrs = append(allErrs, field.Required(fldPath.Child("secretRef", "namespace"), ""))
+		} else {
+			allErrs = append(allErrs, ValidateDNS1123Label(rbd.SecretRef.Namespace, fldPath.Child("secretRef", "namespace"))...)
+		}
+	}
+
 	return allErrs
 }
 
@@ -1286,9 +1310,15 @@ func validateCinderPersistentVolumeSource(cd *core.CinderPersistentVolumeSource,
 	if cd.SecretRef != nil {
 		if len(cd.SecretRef.Name) == 0 {
 			allErrs = append(allErrs, field.Required(fldPath.Child("secretRef", "name"), ""))
+		} else {
+			for _, msg := range ValidateSecretName(cd.SecretRef.Name, false) {
+				allErrs = append(allErrs, field.Invalid(fldPath.Child("secretRef", "name"), cd.SecretRef.Name, msg))
+			}
 		}
 		if len(cd.SecretRef.Namespace) == 0 {
 			allErrs = append(allErrs, field.Required(fldPath.Child("secretRef", "namespace"), ""))
+		} else {
+			allErrs = append(allErrs, ValidateDNS1123Label(cd.SecretRef.Namespace, fldPath.Child("secretRef", "namespace"))...)
 		}
 	}
 	return allErrs
@@ -1306,6 +1336,21 @@ func validateCephFSPersistentVolumeSource(cephfs *core.CephFSPersistentVolumeSou
 	allErrs := field.ErrorList{}
 	if len(cephfs.Monitors) == 0 {
 		allErrs = append(allErrs, field.Required(fldPath.Child("monitors"), ""))
+	}
+
+	if cephfs.SecretRef != nil {
+		if len(cephfs.SecretRef.Name) == 0 {
+			allErrs = append(allErrs, field.Required(fldPath.Child("secretRef", "name"), ""))
+		} else {
+			for _, msg := range ValidateSecretName(cephfs.SecretRef.Name, false) {
+				allErrs = append(allErrs, field.Invalid(fldPath.Child("secretRef", "name"), cephfs.SecretRef.Name, msg))
+			}
+		}
+		if len(cephfs.SecretRef.Namespace) == 0 {
+			allErrs = append(allErrs, field.Required(fldPath.Child("secretRef", "namespace"), ""))
+		} else {
+			allErrs = append(allErrs, ValidateDNS1123Label(cephfs.SecretRef.Namespace, fldPath.Child("secretRef", "namespace"))...)
+		}
 	}
 	return allErrs
 }
@@ -1349,6 +1394,21 @@ func validateFlexPersistentVolumeSource(fv *core.FlexPersistentVolumeSource, fld
 		}
 	}
 
+	if fv.SecretRef != nil {
+		if len(fv.SecretRef.Name) == 0 {
+			allErrs = append(allErrs, field.Required(fldPath.Child("secretRef", "name"), ""))
+		} else {
+			for _, msg := range ValidateSecretName(fv.SecretRef.Name, false) {
+				allErrs = append(allErrs, field.Invalid(fldPath.Child("secretRef", "name"), fv.SecretRef.Name, msg))
+			}
+		}
+		if len(fv.SecretRef.Namespace) == 0 {
+			allErrs = append(allErrs, field.Required(fldPath.Child("secretRef", "namespace"), ""))
+		} else {
+			allErrs = append(allErrs, ValidateDNS1123Label(fv.SecretRef.Namespace, fldPath.Child("secretRef", "namespace"))...)
+		}
+	}
+
 	return allErrs
 }
 
@@ -1367,6 +1427,10 @@ func validateAzureFilePV(azure *core.AzureFilePersistentVolumeSource, fldPath *f
 	allErrs := field.ErrorList{}
 	if azure.SecretName == "" {
 		allErrs = append(allErrs, field.Required(fldPath.Child("secretName"), ""))
+	} else {
+		for _, msg := range ValidateSecretName(azure.SecretName, false) {
+			allErrs = append(allErrs, field.Invalid(fldPath.Child("secretName"), azure.SecretName, msg))
+		}
 	}
 	if azure.ShareName == "" {
 		allErrs = append(allErrs, field.Required(fldPath.Child("shareName"), ""))
@@ -1374,6 +1438,8 @@ func validateAzureFilePV(azure *core.AzureFilePersistentVolumeSource, fldPath *f
 	if azure.SecretNamespace != nil {
 		if len(*azure.SecretNamespace) == 0 {
 			allErrs = append(allErrs, field.Required(fldPath.Child("secretNamespace"), ""))
+		} else {
+			allErrs = append(allErrs, ValidateDNS1123Label(*azure.SecretNamespace, fldPath.Child("secretNamespace"))...)
 		}
 	}
 	return allErrs
@@ -1464,6 +1530,20 @@ func validateScaleIOPersistentVolumeSource(sio *core.ScaleIOPersistentVolumeSour
 	if sio.VolumeName == "" {
 		allErrs = append(allErrs, field.Required(fldPath.Child("volumeName"), ""))
 	}
+	if sio.SecretRef != nil {
+		if len(sio.SecretRef.Name) == 0 {
+			allErrs = append(allErrs, field.Required(fldPath.Child("secretRef", "name"), ""))
+		} else {
+			for _, msg := range ValidateSecretName(sio.SecretRef.Name, false) {
+				allErrs = append(allErrs, field.Invalid(fldPath.Child("secretRef", "name"), sio.SecretRef.Name, msg))
+			}
+		}
+		if len(sio.SecretRef.Namespace) == 0 {
+			allErrs = append(allErrs, field.Required(fldPath.Child("secretRef", "namespace"), ""))
+		} else {
+			allErrs = append(allErrs, ValidateDNS1123Label(sio.SecretRef.Namespace, fldPath.Child("secretRef", "namespace"))...)
+		}
+	}
 	return allErrs
 }
 
@@ -1509,9 +1589,15 @@ func validateStorageOSPersistentVolumeSource(storageos *core.StorageOSPersistent
 	if storageos.SecretRef != nil {
 		if len(storageos.SecretRef.Name) == 0 {
 			allErrs = append(allErrs, field.Required(fldPath.Child("secretRef", "name"), ""))
+		} else {
+			for _, msg := range ValidateSecretName(storageos.SecretRef.Name, false) {
+				allErrs = append(allErrs, field.Invalid(fldPath.Child("secretRef", "name"), storageos.SecretRef.Name, msg))
+			}
 		}
 		if len(storageos.SecretRef.Namespace) == 0 {
 			allErrs = append(allErrs, field.Required(fldPath.Child("secretRef", "namespace"), ""))
+		} else {
+			allErrs = append(allErrs, ValidateDNS1123Label(storageos.SecretRef.Namespace, fldPath.Child("secretRef", "namespace"))...)
 		}
 	}
 	return allErrs
@@ -1548,12 +1634,14 @@ func validateCSIPersistentVolumeSource(csi *core.CSIPersistentVolumeSource, fldP
 		if len(csi.ControllerPublishSecretRef.Name) == 0 {
 			allErrs = append(allErrs, field.Required(fldPath.Child("controllerPublishSecretRef", "name"), ""))
 		} else {
-			allErrs = append(allErrs, ValidateDNS1123Label(csi.ControllerPublishSecretRef.Name, fldPath.Child("name"))...)
+			for _, msg := range ValidateSecretName(csi.ControllerPublishSecretRef.Name, false) {
+				allErrs = append(allErrs, field.Invalid(fldPath.Child("controllerPublishSecretRef", "name"), csi.ControllerPublishSecretRef.Name, msg))
+			}
 		}
 		if len(csi.ControllerPublishSecretRef.Namespace) == 0 {
 			allErrs = append(allErrs, field.Required(fldPath.Child("controllerPublishSecretRef", "namespace"), ""))
 		} else {
-			allErrs = append(allErrs, ValidateDNS1123Label(csi.ControllerPublishSecretRef.Namespace, fldPath.Child("namespace"))...)
+			allErrs = append(allErrs, ValidateDNS1123Label(csi.ControllerPublishSecretRef.Namespace, fldPath.Child("controllerPublishSecretRef", "namespace"))...)
 		}
 	}
 
@@ -1561,12 +1649,14 @@ func validateCSIPersistentVolumeSource(csi *core.CSIPersistentVolumeSource, fldP
 		if len(csi.ControllerExpandSecretRef.Name) == 0 {
 			allErrs = append(allErrs, field.Required(fldPath.Child("controllerExpandSecretRef", "name"), ""))
 		} else {
-			allErrs = append(allErrs, ValidateDNS1123Label(csi.ControllerExpandSecretRef.Name, fldPath.Child("name"))...)
+			for _, msg := range ValidateSecretName(csi.ControllerExpandSecretRef.Name, false) {
+				allErrs = append(allErrs, field.Invalid(fldPath.Child("controllerExpandSecretRef", "name"), csi.ControllerExpandSecretRef.Name, msg))
+			}
 		}
 		if len(csi.ControllerExpandSecretRef.Namespace) == 0 {
 			allErrs = append(allErrs, field.Required(fldPath.Child("controllerExpandSecretRef", "namespace"), ""))
 		} else {
-			allErrs = append(allErrs, ValidateDNS1123Label(csi.ControllerExpandSecretRef.Namespace, fldPath.Child("namespace"))...)
+			allErrs = append(allErrs, ValidateDNS1123Label(csi.ControllerExpandSecretRef.Namespace, fldPath.Child("controllerExpandSecretRef", "namespace"))...)
 		}
 	}
 
@@ -1574,12 +1664,14 @@ func validateCSIPersistentVolumeSource(csi *core.CSIPersistentVolumeSource, fldP
 		if len(csi.NodePublishSecretRef.Name) == 0 {
 			allErrs = append(allErrs, field.Required(fldPath.Child("nodePublishSecretRef ", "name"), ""))
 		} else {
-			allErrs = append(allErrs, ValidateDNS1123Label(csi.NodePublishSecretRef.Name, fldPath.Child("name"))...)
+			for _, msg := range ValidateSecretName(csi.NodePublishSecretRef.Name, false) {
+				allErrs = append(allErrs, field.Invalid(fldPath.Child("nodePublishSecretRef", "name"), csi.NodePublishSecretRef.Name, msg))
+			}
 		}
 		if len(csi.NodePublishSecretRef.Namespace) == 0 {
 			allErrs = append(allErrs, field.Required(fldPath.Child("nodePublishSecretRef ", "namespace"), ""))
 		} else {
-			allErrs = append(allErrs, ValidateDNS1123Label(csi.NodePublishSecretRef.Namespace, fldPath.Child("namespace"))...)
+			allErrs = append(allErrs, ValidateDNS1123Label(csi.NodePublishSecretRef.Namespace, fldPath.Child("nodePublishSecretRef", "namespace"))...)
 		}
 	}
 

--- a/pkg/apis/core/validation/validation.go
+++ b/pkg/apis/core/validation/validation.go
@@ -286,6 +286,26 @@ var ValidateClassName = apimachineryvalidation.NameIsDNSSubdomain
 // class name is valid.
 var ValidatePriorityClassName = apimachineryvalidation.NameIsDNSSubdomain
 
+// ValidateSecretReference can be use to check whether provided SecretReference object is valid.
+// Secret name is provided and is valid
+// Secret namespace is provided and is valid
+func ValidateSecretReference(secretRef *core.SecretReference, fldPath *field.Path) field.ErrorList {
+	var allErrs field.ErrorList
+	if len(secretRef.Name) == 0 {
+		allErrs = append(allErrs, field.Required(fldPath.Child("name"), ""))
+	} else {
+		for _, msg := range ValidateSecretName(secretRef.Name, false) {
+			allErrs = append(allErrs, field.Invalid(fldPath.Child("name"), secretRef.Name, msg))
+		}
+	}
+	if len(secretRef.Namespace) == 0 {
+		allErrs = append(allErrs, field.Required(fldPath.Child("namespace"), ""))
+	} else {
+		allErrs = append(allErrs, ValidateDNS1123Label(secretRef.Namespace, fldPath.Child("namespace"))...)
+	}
+	return allErrs
+}
+
 // ValidateRuntimeClassName can be used to check whether the given RuntimeClass name is valid.
 // Prefix indicates this name will be used as part of generation, in which case
 // trailing dashes are allowed.
@@ -807,18 +827,7 @@ func validateISCSIPersistentVolumeSource(iscsi *core.ISCSIPersistentVolumeSource
 		allErrs = append(allErrs, field.Required(fldPath.Child("secretRef"), ""))
 	}
 	if iscsi.SecretRef != nil {
-		if len(iscsi.SecretRef.Name) == 0 {
-			allErrs = append(allErrs, field.Required(fldPath.Child("secretRef", "name"), ""))
-		} else {
-			for _, msg := range ValidateSecretName(iscsi.SecretRef.Name, false) {
-				allErrs = append(allErrs, field.Invalid(fldPath.Child("secretRef", "name"), iscsi.SecretRef.Name, msg))
-			}
-		}
-		if len(iscsi.SecretRef.Namespace) == 0 {
-			allErrs = append(allErrs, field.Required(fldPath.Child("secretRef", "namespace"), ""))
-		} else {
-			allErrs = append(allErrs, ValidateDNS1123Label(iscsi.SecretRef.Namespace, fldPath.Child("secretRef", "namespace"))...)
-		}
+		allErrs = append(allErrs, ValidateSecretReference(iscsi.SecretRef, fldPath.Child("secretRef"))...)
 	}
 	if iscsi.InitiatorName != nil {
 		initiator := *iscsi.InitiatorName
@@ -1272,20 +1281,8 @@ func validateRBDPersistentVolumeSource(rbd *core.RBDPersistentVolumeSource, fldP
 		allErrs = append(allErrs, field.Required(fldPath.Child("image"), ""))
 	}
 	if rbd.SecretRef != nil {
-		if len(rbd.SecretRef.Name) == 0 {
-			allErrs = append(allErrs, field.Required(fldPath.Child("secretRef", "name"), ""))
-		} else {
-			for _, msg := range ValidateSecretName(rbd.SecretRef.Name, false) {
-				allErrs = append(allErrs, field.Invalid(fldPath.Child("secretRef", "name"), rbd.SecretRef.Name, msg))
-			}
-		}
-		if len(rbd.SecretRef.Namespace) == 0 {
-			allErrs = append(allErrs, field.Required(fldPath.Child("secretRef", "namespace"), ""))
-		} else {
-			allErrs = append(allErrs, ValidateDNS1123Label(rbd.SecretRef.Namespace, fldPath.Child("secretRef", "namespace"))...)
-		}
+		allErrs = append(allErrs, ValidateSecretReference(rbd.SecretRef, fldPath.Child("secretRef"))...)
 	}
-
 	return allErrs
 }
 
@@ -1308,18 +1305,7 @@ func validateCinderPersistentVolumeSource(cd *core.CinderPersistentVolumeSource,
 		allErrs = append(allErrs, field.Required(fldPath.Child("volumeID"), ""))
 	}
 	if cd.SecretRef != nil {
-		if len(cd.SecretRef.Name) == 0 {
-			allErrs = append(allErrs, field.Required(fldPath.Child("secretRef", "name"), ""))
-		} else {
-			for _, msg := range ValidateSecretName(cd.SecretRef.Name, false) {
-				allErrs = append(allErrs, field.Invalid(fldPath.Child("secretRef", "name"), cd.SecretRef.Name, msg))
-			}
-		}
-		if len(cd.SecretRef.Namespace) == 0 {
-			allErrs = append(allErrs, field.Required(fldPath.Child("secretRef", "namespace"), ""))
-		} else {
-			allErrs = append(allErrs, ValidateDNS1123Label(cd.SecretRef.Namespace, fldPath.Child("secretRef", "namespace"))...)
-		}
+		allErrs = append(allErrs, ValidateSecretReference(cd.SecretRef, fldPath.Child("secretRef"))...)
 	}
 	return allErrs
 }
@@ -1337,20 +1323,8 @@ func validateCephFSPersistentVolumeSource(cephfs *core.CephFSPersistentVolumeSou
 	if len(cephfs.Monitors) == 0 {
 		allErrs = append(allErrs, field.Required(fldPath.Child("monitors"), ""))
 	}
-
 	if cephfs.SecretRef != nil {
-		if len(cephfs.SecretRef.Name) == 0 {
-			allErrs = append(allErrs, field.Required(fldPath.Child("secretRef", "name"), ""))
-		} else {
-			for _, msg := range ValidateSecretName(cephfs.SecretRef.Name, false) {
-				allErrs = append(allErrs, field.Invalid(fldPath.Child("secretRef", "name"), cephfs.SecretRef.Name, msg))
-			}
-		}
-		if len(cephfs.SecretRef.Namespace) == 0 {
-			allErrs = append(allErrs, field.Required(fldPath.Child("secretRef", "namespace"), ""))
-		} else {
-			allErrs = append(allErrs, ValidateDNS1123Label(cephfs.SecretRef.Namespace, fldPath.Child("secretRef", "namespace"))...)
-		}
+		allErrs = append(allErrs, ValidateSecretReference(cephfs.SecretRef, fldPath.Child("secretRef"))...)
 	}
 	return allErrs
 }
@@ -1395,18 +1369,7 @@ func validateFlexPersistentVolumeSource(fv *core.FlexPersistentVolumeSource, fld
 	}
 
 	if fv.SecretRef != nil {
-		if len(fv.SecretRef.Name) == 0 {
-			allErrs = append(allErrs, field.Required(fldPath.Child("secretRef", "name"), ""))
-		} else {
-			for _, msg := range ValidateSecretName(fv.SecretRef.Name, false) {
-				allErrs = append(allErrs, field.Invalid(fldPath.Child("secretRef", "name"), fv.SecretRef.Name, msg))
-			}
-		}
-		if len(fv.SecretRef.Namespace) == 0 {
-			allErrs = append(allErrs, field.Required(fldPath.Child("secretRef", "namespace"), ""))
-		} else {
-			allErrs = append(allErrs, ValidateDNS1123Label(fv.SecretRef.Namespace, fldPath.Child("secretRef", "namespace"))...)
-		}
+		allErrs = append(allErrs, ValidateSecretReference(fv.SecretRef, fldPath.Child("secretRef"))...)
 	}
 
 	return allErrs
@@ -1531,18 +1494,7 @@ func validateScaleIOPersistentVolumeSource(sio *core.ScaleIOPersistentVolumeSour
 		allErrs = append(allErrs, field.Required(fldPath.Child("volumeName"), ""))
 	}
 	if sio.SecretRef != nil {
-		if len(sio.SecretRef.Name) == 0 {
-			allErrs = append(allErrs, field.Required(fldPath.Child("secretRef", "name"), ""))
-		} else {
-			for _, msg := range ValidateSecretName(sio.SecretRef.Name, false) {
-				allErrs = append(allErrs, field.Invalid(fldPath.Child("secretRef", "name"), sio.SecretRef.Name, msg))
-			}
-		}
-		if len(sio.SecretRef.Namespace) == 0 {
-			allErrs = append(allErrs, field.Required(fldPath.Child("secretRef", "namespace"), ""))
-		} else {
-			allErrs = append(allErrs, ValidateDNS1123Label(sio.SecretRef.Namespace, fldPath.Child("secretRef", "namespace"))...)
-		}
+		allErrs = append(allErrs, ValidateSecretReference(sio.SecretRef, fldPath.Child("secretRed"))...)
 	}
 	return allErrs
 }
@@ -1587,18 +1539,10 @@ func validateStorageOSPersistentVolumeSource(storageos *core.StorageOSPersistent
 		allErrs = append(allErrs, ValidateDNS1123Label(storageos.VolumeNamespace, fldPath.Child("volumeNamespace"))...)
 	}
 	if storageos.SecretRef != nil {
-		if len(storageos.SecretRef.Name) == 0 {
-			allErrs = append(allErrs, field.Required(fldPath.Child("secretRef", "name"), ""))
-		} else {
-			for _, msg := range ValidateSecretName(storageos.SecretRef.Name, false) {
-				allErrs = append(allErrs, field.Invalid(fldPath.Child("secretRef", "name"), storageos.SecretRef.Name, msg))
-			}
-		}
-		if len(storageos.SecretRef.Namespace) == 0 {
-			allErrs = append(allErrs, field.Required(fldPath.Child("secretRef", "namespace"), ""))
-		} else {
-			allErrs = append(allErrs, ValidateDNS1123Label(storageos.SecretRef.Namespace, fldPath.Child("secretRef", "namespace"))...)
-		}
+		allErrs = append(allErrs, ValidateSecretReference(&core.SecretReference{
+			Name: storageos.SecretRef.Name,
+			Namespace: storageos.SecretRef.Namespace,
+		}, fldPath.Child("secretRef"))...)
 	}
 	return allErrs
 }
@@ -1629,52 +1573,18 @@ func validateCSIPersistentVolumeSource(csi *core.CSIPersistentVolumeSource, fldP
 	if len(csi.VolumeHandle) == 0 {
 		allErrs = append(allErrs, field.Required(fldPath.Child("volumeHandle"), ""))
 	}
-
 	if csi.ControllerPublishSecretRef != nil {
-		if len(csi.ControllerPublishSecretRef.Name) == 0 {
-			allErrs = append(allErrs, field.Required(fldPath.Child("controllerPublishSecretRef", "name"), ""))
-		} else {
-			for _, msg := range ValidateSecretName(csi.ControllerPublishSecretRef.Name, false) {
-				allErrs = append(allErrs, field.Invalid(fldPath.Child("controllerPublishSecretRef", "name"), csi.ControllerPublishSecretRef.Name, msg))
-			}
-		}
-		if len(csi.ControllerPublishSecretRef.Namespace) == 0 {
-			allErrs = append(allErrs, field.Required(fldPath.Child("controllerPublishSecretRef", "namespace"), ""))
-		} else {
-			allErrs = append(allErrs, ValidateDNS1123Label(csi.ControllerPublishSecretRef.Namespace, fldPath.Child("controllerPublishSecretRef", "namespace"))...)
-		}
+		allErrs = append(allErrs, ValidateSecretReference(csi.ControllerPublishSecretRef, fldPath.Child("controllerPublishSecretRef"))...)
 	}
-
 	if csi.ControllerExpandSecretRef != nil {
-		if len(csi.ControllerExpandSecretRef.Name) == 0 {
-			allErrs = append(allErrs, field.Required(fldPath.Child("controllerExpandSecretRef", "name"), ""))
-		} else {
-			for _, msg := range ValidateSecretName(csi.ControllerExpandSecretRef.Name, false) {
-				allErrs = append(allErrs, field.Invalid(fldPath.Child("controllerExpandSecretRef", "name"), csi.ControllerExpandSecretRef.Name, msg))
-			}
-		}
-		if len(csi.ControllerExpandSecretRef.Namespace) == 0 {
-			allErrs = append(allErrs, field.Required(fldPath.Child("controllerExpandSecretRef", "namespace"), ""))
-		} else {
-			allErrs = append(allErrs, ValidateDNS1123Label(csi.ControllerExpandSecretRef.Namespace, fldPath.Child("controllerExpandSecretRef", "namespace"))...)
-		}
+		allErrs = append(allErrs, ValidateSecretReference(csi.ControllerExpandSecretRef, fldPath.Child("controllerExpandSecretRef"))...)
 	}
-
 	if csi.NodePublishSecretRef != nil {
-		if len(csi.NodePublishSecretRef.Name) == 0 {
-			allErrs = append(allErrs, field.Required(fldPath.Child("nodePublishSecretRef ", "name"), ""))
-		} else {
-			for _, msg := range ValidateSecretName(csi.NodePublishSecretRef.Name, false) {
-				allErrs = append(allErrs, field.Invalid(fldPath.Child("nodePublishSecretRef", "name"), csi.NodePublishSecretRef.Name, msg))
-			}
-		}
-		if len(csi.NodePublishSecretRef.Namespace) == 0 {
-			allErrs = append(allErrs, field.Required(fldPath.Child("nodePublishSecretRef ", "namespace"), ""))
-		} else {
-			allErrs = append(allErrs, ValidateDNS1123Label(csi.NodePublishSecretRef.Namespace, fldPath.Child("nodePublishSecretRef", "namespace"))...)
-		}
+		allErrs = append(allErrs, ValidateSecretReference(csi.NodePublishSecretRef, fldPath.Child("nodePublishSecretRef"))...)
 	}
-
+	if csi.NodeStageSecretRef != nil {
+		allErrs = append(allErrs, ValidateSecretReference(csi.NodeStageSecretRef, fldPath.Child("nodeStageSecretRef"))...)
+	}
 	return allErrs
 }
 

--- a/pkg/apis/core/validation/validation.go
+++ b/pkg/apis/core/validation/validation.go
@@ -819,7 +819,7 @@ func validateISCSIVolumeSource(iscsi *core.ISCSIVolumeSource, fldPath *field.Pat
 	return allErrs
 }
 
-func validateISCSIPersistentVolumeSource(iscsi *core.ISCSIPersistentVolumeSource, pvName string, fldPath *field.Path) field.ErrorList {
+func validateISCSIPersistentVolumeSource(iscsi *core.ISCSIPersistentVolumeSource, oldPVSource *core.ISCSIPersistentVolumeSource, pvName string, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 	if len(iscsi.TargetPortal) == 0 {
 		allErrs = append(allErrs, field.Required(fldPath.Child("targetPortal"), ""))
@@ -847,7 +847,7 @@ func validateISCSIPersistentVolumeSource(iscsi *core.ISCSIPersistentVolumeSource
 	if (iscsi.DiscoveryCHAPAuth || iscsi.SessionCHAPAuth) && iscsi.SecretRef == nil {
 		allErrs = append(allErrs, field.Required(fldPath.Child("secretRef"), ""))
 	}
-	if iscsi.SecretRef != nil {
+	if (oldPVSource == nil || !apiequality.Semantic.DeepEqual(iscsi.SecretRef, oldPVSource.SecretRef)) && iscsi.SecretRef != nil {
 		allErrs = append(allErrs, ValidateSecretReference(iscsi.SecretRef, fldPath.Child("secretRef"))...)
 	}
 	if iscsi.InitiatorName != nil {
@@ -1293,7 +1293,7 @@ func validateRBDVolumeSource(rbd *core.RBDVolumeSource, fldPath *field.Path) fie
 	return allErrs
 }
 
-func validateRBDPersistentVolumeSource(rbd *core.RBDPersistentVolumeSource, fldPath *field.Path) field.ErrorList {
+func validateRBDPersistentVolumeSource(rbd *core.RBDPersistentVolumeSource, oldPVSource *core.RBDPersistentVolumeSource, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 	if len(rbd.CephMonitors) == 0 {
 		allErrs = append(allErrs, field.Required(fldPath.Child("monitors"), ""))
@@ -1301,7 +1301,7 @@ func validateRBDPersistentVolumeSource(rbd *core.RBDPersistentVolumeSource, fldP
 	if len(rbd.RBDImage) == 0 {
 		allErrs = append(allErrs, field.Required(fldPath.Child("image"), ""))
 	}
-	if rbd.SecretRef != nil {
+	if (oldPVSource == nil || !apiequality.Semantic.DeepEqual(rbd.SecretRef, oldPVSource.SecretRef)) && rbd.SecretRef != nil {
 		allErrs = append(allErrs, ValidateSecretReference(rbd.SecretRef, fldPath.Child("secretRef"))...)
 	}
 	return allErrs
@@ -1320,12 +1320,12 @@ func validateCinderVolumeSource(cd *core.CinderVolumeSource, fldPath *field.Path
 	return allErrs
 }
 
-func validateCinderPersistentVolumeSource(cd *core.CinderPersistentVolumeSource, fldPath *field.Path) field.ErrorList {
+func validateCinderPersistentVolumeSource(cd *core.CinderPersistentVolumeSource, oldPVSource *core.CinderPersistentVolumeSource, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 	if len(cd.VolumeID) == 0 {
 		allErrs = append(allErrs, field.Required(fldPath.Child("volumeID"), ""))
 	}
-	if cd.SecretRef != nil {
+	if (oldPVSource == nil || !apiequality.Semantic.DeepEqual(cd.SecretRef, oldPVSource.SecretRef)) && cd.SecretRef != nil {
 		allErrs = append(allErrs, ValidateSecretReference(cd.SecretRef, fldPath.Child("secretRef"))...)
 	}
 	return allErrs
@@ -1339,12 +1339,12 @@ func validateCephFSVolumeSource(cephfs *core.CephFSVolumeSource, fldPath *field.
 	return allErrs
 }
 
-func validateCephFSPersistentVolumeSource(cephfs *core.CephFSPersistentVolumeSource, fldPath *field.Path) field.ErrorList {
+func validateCephFSPersistentVolumeSource(cephfs *core.CephFSPersistentVolumeSource, oldPVSource *core.CephFSPersistentVolumeSource, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 	if len(cephfs.Monitors) == 0 {
 		allErrs = append(allErrs, field.Required(fldPath.Child("monitors"), ""))
 	}
-	if cephfs.SecretRef != nil {
+	if (oldPVSource == nil || !apiequality.Semantic.DeepEqual(cephfs.SecretRef, oldPVSource.SecretRef)) && cephfs.SecretRef != nil {
 		allErrs = append(allErrs, ValidateSecretReference(cephfs.SecretRef, fldPath.Child("secretRef"))...)
 	}
 	return allErrs
@@ -1371,7 +1371,7 @@ func validateFlexVolumeSource(fv *core.FlexVolumeSource, fldPath *field.Path) fi
 	return allErrs
 }
 
-func validateFlexPersistentVolumeSource(fv *core.FlexPersistentVolumeSource, fldPath *field.Path) field.ErrorList {
+func validateFlexPersistentVolumeSource(fv *core.FlexPersistentVolumeSource, oldPVSource *core.FlexPersistentVolumeSource, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 	if len(fv.Driver) == 0 {
 		allErrs = append(allErrs, field.Required(fldPath.Child("driver"), ""))
@@ -1389,7 +1389,7 @@ func validateFlexPersistentVolumeSource(fv *core.FlexPersistentVolumeSource, fld
 		}
 	}
 
-	if fv.SecretRef != nil {
+	if (oldPVSource == nil || !apiequality.Semantic.DeepEqual(fv.SecretRef, oldPVSource.SecretRef)) && fv.SecretRef != nil {
 		allErrs = append(allErrs, ValidateSecretReference(fv.SecretRef, fldPath.Child("secretRef"))...)
 	}
 
@@ -1407,11 +1407,11 @@ func validateAzureFile(azure *core.AzureFileVolumeSource, fldPath *field.Path) f
 	return allErrs
 }
 
-func validateAzureFilePV(azure *core.AzureFilePersistentVolumeSource, fldPath *field.Path) field.ErrorList {
+func validateAzureFilePV(azure *core.AzureFilePersistentVolumeSource, oldPVSource *core.AzureFilePersistentVolumeSource, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 	if azure.SecretName == "" {
 		allErrs = append(allErrs, field.Required(fldPath.Child("secretName"), ""))
-	} else {
+	} else if oldPVSource == nil || !apiequality.Semantic.DeepEqual(azure.SecretName, oldPVSource.SecretName) {
 		for _, msg := range ValidateSecretName(azure.SecretName, false) {
 			allErrs = append(allErrs, field.Invalid(fldPath.Child("secretName"), azure.SecretName, msg))
 		}
@@ -1422,7 +1422,7 @@ func validateAzureFilePV(azure *core.AzureFilePersistentVolumeSource, fldPath *f
 	if azure.SecretNamespace != nil {
 		if len(*azure.SecretNamespace) == 0 {
 			allErrs = append(allErrs, field.Required(fldPath.Child("secretNamespace"), ""))
-		} else {
+		} else if oldPVSource == nil || !apiequality.Semantic.DeepEqual(azure.SecretNamespace, oldPVSource.SecretNamespace) {
 			allErrs = append(allErrs, ValidateDNS1123Label(*azure.SecretNamespace, fldPath.Child("secretNamespace"))...)
 		}
 	}
@@ -1503,7 +1503,7 @@ func validateScaleIOVolumeSource(sio *core.ScaleIOVolumeSource, fldPath *field.P
 	return allErrs
 }
 
-func validateScaleIOPersistentVolumeSource(sio *core.ScaleIOPersistentVolumeSource, fldPath *field.Path) field.ErrorList {
+func validateScaleIOPersistentVolumeSource(sio *core.ScaleIOPersistentVolumeSource, oldPVSource *core.ScaleIOPersistentVolumeSource, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 	if sio.Gateway == "" {
 		allErrs = append(allErrs, field.Required(fldPath.Child("gateway"), ""))
@@ -1514,7 +1514,7 @@ func validateScaleIOPersistentVolumeSource(sio *core.ScaleIOPersistentVolumeSour
 	if sio.VolumeName == "" {
 		allErrs = append(allErrs, field.Required(fldPath.Child("volumeName"), ""))
 	}
-	if sio.SecretRef != nil {
+	if (oldPVSource == nil || !apiequality.Semantic.DeepEqual(sio.SecretRef, oldPVSource.SecretRef)) && sio.SecretRef != nil {
 		allErrs = append(allErrs, ValidateSecretReference(sio.SecretRef, fldPath.Child("secretRed"))...)
 	}
 	return allErrs
@@ -1549,7 +1549,7 @@ func validateStorageOSVolumeSource(storageos *core.StorageOSVolumeSource, fldPat
 	return allErrs
 }
 
-func validateStorageOSPersistentVolumeSource(storageos *core.StorageOSPersistentVolumeSource, fldPath *field.Path) field.ErrorList {
+func validateStorageOSPersistentVolumeSource(storageos *core.StorageOSPersistentVolumeSource, oldPVSource *core.StorageOSPersistentVolumeSource, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 	if len(storageos.VolumeName) == 0 {
 		allErrs = append(allErrs, field.Required(fldPath.Child("volumeName"), ""))
@@ -1559,7 +1559,7 @@ func validateStorageOSPersistentVolumeSource(storageos *core.StorageOSPersistent
 	if len(storageos.VolumeNamespace) > 0 {
 		allErrs = append(allErrs, ValidateDNS1123Label(storageos.VolumeNamespace, fldPath.Child("volumeNamespace"))...)
 	}
-	if storageos.SecretRef != nil {
+	if (oldPVSource == nil || !apiequality.Semantic.DeepEqual(storageos.SecretRef, oldPVSource.SecretRef)) && storageos.SecretRef != nil {
 		allErrs = append(allErrs, ValidateSecretObjectReference(storageos.SecretRef, fldPath.Child("secretRef"))...)
 	}
 	return allErrs
@@ -1583,7 +1583,7 @@ func ValidateCSIDriverName(driverName string, fldPath *field.Path) field.ErrorLi
 	return allErrs
 }
 
-func validateCSIPersistentVolumeSource(csi *core.CSIPersistentVolumeSource, fldPath *field.Path) field.ErrorList {
+func validateCSIPersistentVolumeSource(csi *core.CSIPersistentVolumeSource, oldPVSource *core.CSIPersistentVolumeSource, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
 	allErrs = append(allErrs, ValidateCSIDriverName(csi.Driver, fldPath.Child("driver"))...)
@@ -1591,16 +1591,16 @@ func validateCSIPersistentVolumeSource(csi *core.CSIPersistentVolumeSource, fldP
 	if len(csi.VolumeHandle) == 0 {
 		allErrs = append(allErrs, field.Required(fldPath.Child("volumeHandle"), ""))
 	}
-	if csi.ControllerPublishSecretRef != nil {
+	if (oldPVSource == nil || !apiequality.Semantic.DeepEqual(csi.ControllerPublishSecretRef, oldPVSource.ControllerPublishSecretRef)) && csi.ControllerPublishSecretRef != nil {
 		allErrs = append(allErrs, ValidateSecretReference(csi.ControllerPublishSecretRef, fldPath.Child("controllerPublishSecretRef"))...)
 	}
-	if csi.ControllerExpandSecretRef != nil {
+	if (oldPVSource == nil || !apiequality.Semantic.DeepEqual(csi.ControllerExpandSecretRef, oldPVSource.ControllerExpandSecretRef)) && csi.ControllerExpandSecretRef != nil {
 		allErrs = append(allErrs, ValidateSecretReference(csi.ControllerExpandSecretRef, fldPath.Child("controllerExpandSecretRef"))...)
 	}
-	if csi.NodePublishSecretRef != nil {
+	if (oldPVSource == nil || !apiequality.Semantic.DeepEqual(csi.NodePublishSecretRef, oldPVSource.NodePublishSecretRef)) && csi.NodePublishSecretRef != nil {
 		allErrs = append(allErrs, ValidateSecretReference(csi.NodePublishSecretRef, fldPath.Child("nodePublishSecretRef"))...)
 	}
-	if csi.NodeStageSecretRef != nil {
+	if (oldPVSource == nil || !apiequality.Semantic.DeepEqual(csi.NodeStageSecretRef, oldPVSource.NodeStageSecretRef)) && csi.NodeStageSecretRef != nil {
 		allErrs = append(allErrs, ValidateSecretReference(csi.NodeStageSecretRef, fldPath.Child("nodeStageSecretRef"))...)
 	}
 	return allErrs
@@ -1690,7 +1690,7 @@ func ValidationOptionsForPersistentVolume(pv, oldPv *core.PersistentVolume) Pers
 	return opts
 }
 
-func ValidatePersistentVolumeSpec(pvSpec *core.PersistentVolumeSpec, pvName string, validateInlinePersistentVolumeSpec bool, fldPath *field.Path, opts PersistentVolumeSpecValidationOptions) field.ErrorList {
+func ValidatePersistentVolumeSpec(pvSpec *core.PersistentVolumeSpec, oldPVSpec *core.PersistentVolumeSpec, pvName string, validateInlinePersistentVolumeSpec bool, fldPath *field.Path, opts PersistentVolumeSpecValidationOptions) field.ErrorList {
 	allErrs := field.ErrorList{}
 
 	if validateInlinePersistentVolumeSpec {
@@ -1821,7 +1821,11 @@ func ValidatePersistentVolumeSpec(pvSpec *core.PersistentVolumeSpec, pvName stri
 			allErrs = append(allErrs, field.Forbidden(fldPath.Child("rbd"), "may not specify more than 1 volume type"))
 		} else {
 			numVolumes++
-			allErrs = append(allErrs, validateRBDPersistentVolumeSource(pvSpec.RBD, fldPath.Child("rbd"))...)
+			var oldPVSource *core.RBDPersistentVolumeSource = nil
+			if oldPVSpec != nil {
+				oldPVSource = oldPVSpec.RBD
+			}
+			allErrs = append(allErrs, validateRBDPersistentVolumeSource(pvSpec.RBD, oldPVSource, fldPath.Child("rbd"))...)
 		}
 	}
 	if pvSpec.Quobyte != nil {
@@ -1837,7 +1841,11 @@ func ValidatePersistentVolumeSpec(pvSpec *core.PersistentVolumeSpec, pvName stri
 			allErrs = append(allErrs, field.Forbidden(fldPath.Child("cephFS"), "may not specify more than 1 volume type"))
 		} else {
 			numVolumes++
-			allErrs = append(allErrs, validateCephFSPersistentVolumeSource(pvSpec.CephFS, fldPath.Child("cephfs"))...)
+			var oldPVSource *core.CephFSPersistentVolumeSource = nil
+			if oldPVSpec != nil {
+				oldPVSource = oldPVSpec.CephFS
+			}
+			allErrs = append(allErrs, validateCephFSPersistentVolumeSource(pvSpec.CephFS, oldPVSource, fldPath.Child("cephfs"))...)
 		}
 	}
 	if pvSpec.ISCSI != nil {
@@ -1845,7 +1853,11 @@ func ValidatePersistentVolumeSpec(pvSpec *core.PersistentVolumeSpec, pvName stri
 			allErrs = append(allErrs, field.Forbidden(fldPath.Child("iscsi"), "may not specify more than 1 volume type"))
 		} else {
 			numVolumes++
-			allErrs = append(allErrs, validateISCSIPersistentVolumeSource(pvSpec.ISCSI, pvName, fldPath.Child("iscsi"))...)
+			var oldPVSource *core.ISCSIPersistentVolumeSource = nil
+			if oldPVSpec != nil {
+				oldPVSource = oldPVSpec.ISCSI
+			}
+			allErrs = append(allErrs, validateISCSIPersistentVolumeSource(pvSpec.ISCSI, oldPVSource, pvName, fldPath.Child("iscsi"))...)
 		}
 	}
 	if pvSpec.Cinder != nil {
@@ -1853,7 +1865,11 @@ func ValidatePersistentVolumeSpec(pvSpec *core.PersistentVolumeSpec, pvName stri
 			allErrs = append(allErrs, field.Forbidden(fldPath.Child("cinder"), "may not specify more than 1 volume type"))
 		} else {
 			numVolumes++
-			allErrs = append(allErrs, validateCinderPersistentVolumeSource(pvSpec.Cinder, fldPath.Child("cinder"))...)
+			var oldPVSoruce *core.CinderPersistentVolumeSource = nil
+			if oldPVSpec != nil {
+				oldPVSoruce = oldPVSpec.Cinder
+			}
+			allErrs = append(allErrs, validateCinderPersistentVolumeSource(pvSpec.Cinder, oldPVSoruce, fldPath.Child("cinder"))...)
 		}
 	}
 	if pvSpec.FC != nil {
@@ -1866,7 +1882,11 @@ func ValidatePersistentVolumeSpec(pvSpec *core.PersistentVolumeSpec, pvName stri
 	}
 	if pvSpec.FlexVolume != nil {
 		numVolumes++
-		allErrs = append(allErrs, validateFlexPersistentVolumeSource(pvSpec.FlexVolume, fldPath.Child("flexVolume"))...)
+		var oldPVSource *core.FlexPersistentVolumeSource = nil
+		if oldPVSpec != nil {
+			oldPVSource = oldPVSpec.FlexVolume
+		}
+		allErrs = append(allErrs, validateFlexPersistentVolumeSource(pvSpec.FlexVolume, oldPVSource, fldPath.Child("flexVolume"))...)
 	}
 	if pvSpec.AzureFile != nil {
 		if numVolumes > 0 {
@@ -1874,7 +1894,11 @@ func ValidatePersistentVolumeSpec(pvSpec *core.PersistentVolumeSpec, pvName stri
 
 		} else {
 			numVolumes++
-			allErrs = append(allErrs, validateAzureFilePV(pvSpec.AzureFile, fldPath.Child("azureFile"))...)
+			var oldPVSource *core.AzureFilePersistentVolumeSource = nil
+			if oldPVSpec != nil {
+				oldPVSource = oldPVSpec.AzureFile
+			}
+			allErrs = append(allErrs, validateAzureFilePV(pvSpec.AzureFile, oldPVSource, fldPath.Child("azureFile"))...)
 		}
 	}
 
@@ -1915,7 +1939,11 @@ func ValidatePersistentVolumeSpec(pvSpec *core.PersistentVolumeSpec, pvName stri
 			allErrs = append(allErrs, field.Forbidden(fldPath.Child("scaleIO"), "may not specify more than 1 volume type"))
 		} else {
 			numVolumes++
-			allErrs = append(allErrs, validateScaleIOPersistentVolumeSource(pvSpec.ScaleIO, fldPath.Child("scaleIO"))...)
+			var oldPVSource *core.ScaleIOPersistentVolumeSource = nil
+			if oldPVSpec != nil {
+				oldPVSource = oldPVSpec.ScaleIO
+			}
+			allErrs = append(allErrs, validateScaleIOPersistentVolumeSource(pvSpec.ScaleIO, oldPVSource, fldPath.Child("scaleIO"))...)
 		}
 	}
 	if pvSpec.Local != nil {
@@ -1935,7 +1963,11 @@ func ValidatePersistentVolumeSpec(pvSpec *core.PersistentVolumeSpec, pvName stri
 			allErrs = append(allErrs, field.Forbidden(fldPath.Child("storageos"), "may not specify more than 1 volume type"))
 		} else {
 			numVolumes++
-			allErrs = append(allErrs, validateStorageOSPersistentVolumeSource(pvSpec.StorageOS, fldPath.Child("storageos"))...)
+			var oldPVSource *core.StorageOSPersistentVolumeSource = nil
+			if oldPVSpec != nil {
+				oldPVSource = oldPVSpec.StorageOS
+			}
+			allErrs = append(allErrs, validateStorageOSPersistentVolumeSource(pvSpec.StorageOS, oldPVSource, fldPath.Child("storageos"))...)
 		}
 	}
 
@@ -1944,7 +1976,11 @@ func ValidatePersistentVolumeSpec(pvSpec *core.PersistentVolumeSpec, pvName stri
 			allErrs = append(allErrs, field.Forbidden(fldPath.Child("csi"), "may not specify more than 1 volume type"))
 		} else {
 			numVolumes++
-			allErrs = append(allErrs, validateCSIPersistentVolumeSource(pvSpec.CSI, fldPath.Child("csi"))...)
+			var oldPVSource *core.CSIPersistentVolumeSource = nil
+			if oldPVSpec != nil {
+				oldPVSource = oldPVSpec.CSI
+			}
+			allErrs = append(allErrs, validateCSIPersistentVolumeSource(pvSpec.CSI, oldPVSource, fldPath.Child("csi"))...)
 		}
 	}
 
@@ -1980,17 +2016,21 @@ func ValidatePersistentVolumeSpec(pvSpec *core.PersistentVolumeSpec, pvName stri
 	return allErrs
 }
 
-func ValidatePersistentVolume(pv *core.PersistentVolume, opts PersistentVolumeSpecValidationOptions) field.ErrorList {
+func ValidatePersistentVolume(pv *core.PersistentVolume, oldPv *core.PersistentVolume, opts PersistentVolumeSpecValidationOptions) field.ErrorList {
+	var oldPVSpec *core.PersistentVolumeSpec = nil
+	if oldPv != nil {
+		oldPVSpec = &oldPv.Spec
+	}
 	metaPath := field.NewPath("metadata")
 	allErrs := ValidateObjectMeta(&pv.ObjectMeta, false, ValidatePersistentVolumeName, metaPath)
-	allErrs = append(allErrs, ValidatePersistentVolumeSpec(&pv.Spec, pv.ObjectMeta.Name, false, field.NewPath("spec"), opts)...)
+	allErrs = append(allErrs, ValidatePersistentVolumeSpec(&pv.Spec, oldPVSpec, pv.ObjectMeta.Name, false, field.NewPath("spec"), opts)...)
 	return allErrs
 }
 
 // ValidatePersistentVolumeUpdate tests to see if the update is legal for an end user to make.
 // newPv is updated with fields that cannot be changed.
 func ValidatePersistentVolumeUpdate(newPv, oldPv *core.PersistentVolume, opts PersistentVolumeSpecValidationOptions) field.ErrorList {
-	allErrs := ValidatePersistentVolume(newPv, opts)
+	var allErrs field.ErrorList
 
 	// if oldPV does not have ControllerExpandSecretRef then allow it to be set
 	if (oldPv.Spec.CSI != nil && oldPv.Spec.CSI.ControllerExpandSecretRef == nil) &&
@@ -2010,6 +2050,7 @@ func ValidatePersistentVolumeUpdate(newPv, oldPv *core.PersistentVolume, opts Pe
 	if oldPv.Spec.NodeAffinity != nil {
 		allErrs = append(allErrs, ValidateImmutableField(newPv.Spec.NodeAffinity, oldPv.Spec.NodeAffinity, field.NewPath("nodeAffinity"))...)
 	}
+	allErrs = append(allErrs, ValidatePersistentVolume(newPv, oldPv, opts)...)
 
 	return allErrs
 }

--- a/pkg/apis/core/validation/validation_test.go
+++ b/pkg/apis/core/validation/validation_test.go
@@ -467,7 +467,7 @@ func TestValidatePersistentVolumes(t *testing.T) {
 			defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.ReadWriteOncePod, scenario.enableReadWriteOncePod)()
 
 			opts := ValidationOptionsForPersistentVolume(scenario.volume, nil)
-			errs := ValidatePersistentVolume(scenario.volume, opts)
+			errs := ValidatePersistentVolume(scenario.volume, nil, opts)
 			if len(errs) == 0 && scenario.isExpectedFailure {
 				t.Errorf("Unexpected success for scenario: %s", name)
 			}
@@ -611,7 +611,7 @@ func TestValidatePersistentVolumeSpec(t *testing.T) {
 	}
 	for name, scenario := range scenarios {
 		opts := PersistentVolumeSpecValidationOptions{}
-		errs := ValidatePersistentVolumeSpec(scenario.pvSpec, "", scenario.isInlineSpec, field.NewPath("field"), opts)
+		errs := ValidatePersistentVolumeSpec(scenario.pvSpec, nil, "", scenario.isInlineSpec, field.NewPath("field"), opts)
 		if len(errs) == 0 && scenario.isExpectedFailure {
 			t.Errorf("Unexpected success for scenario: %s", name)
 		}
@@ -863,7 +863,7 @@ func TestValidateLocalVolumes(t *testing.T) {
 
 	for name, scenario := range scenarios {
 		opts := ValidationOptionsForPersistentVolume(scenario.volume, nil)
-		errs := ValidatePersistentVolume(scenario.volume, opts)
+		errs := ValidatePersistentVolume(scenario.volume, nil, opts)
 		if len(errs) == 0 && scenario.isExpectedFailure {
 			t.Errorf("Unexpected success for scenario: %s", name)
 		}
@@ -2507,7 +2507,7 @@ func TestValidateCSIVolumeSource(t *testing.T) {
 	}
 
 	for i, tc := range testCases {
-		errs := validateCSIPersistentVolumeSource(tc.csi, field.NewPath("field"))
+		errs := validateCSIPersistentVolumeSource(tc.csi, nil, field.NewPath("field"))
 
 		if len(errs) > 0 && tc.errtype == "" {
 			t.Errorf("[%d: %q] unexpected error(s): %v", i, tc.name, errs)
@@ -4648,7 +4648,7 @@ func TestPVVolumeMode(t *testing.T) {
 	}
 	for k, v := range successCasesPV {
 		opts := ValidationOptionsForPersistentVolume(v, nil)
-		if errs := ValidatePersistentVolume(v, opts); len(errs) != 0 {
+		if errs := ValidatePersistentVolume(v, nil, opts); len(errs) != 0 {
 			t.Errorf("expected success for %s", k)
 		}
 	}
@@ -4660,7 +4660,7 @@ func TestPVVolumeMode(t *testing.T) {
 	}
 	for k, v := range errorCasesPV {
 		opts := ValidationOptionsForPersistentVolume(v, nil)
-		if errs := ValidatePersistentVolume(v, opts); len(errs) == 0 {
+		if errs := ValidatePersistentVolume(v, nil, opts); len(errs) == 0 {
 			t.Errorf("expected failure for %s", k)
 		}
 	}

--- a/pkg/apis/core/validation/validation_test.go
+++ b/pkg/apis/core/validation/validation_test.go
@@ -18514,3 +18514,85 @@ func TestValidateWindowsHostProcessPod(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateSecretReference(t *testing.T) {
+	path := field.NewPath("secretRef")
+	scenarios := []struct {
+		name      string
+		errorType []field.ErrorType
+		secretRef *core.SecretReference
+	}{
+		{
+			name: "Secret Name is Required",
+			errorType: []field.ErrorType{
+				field.ErrorTypeRequired,
+			},
+			secretRef: &core.SecretReference{
+				Name:      "",
+				Namespace: "default",
+			},
+		}, {
+			name: "Secret Namespace is Required",
+			errorType: []field.ErrorType{
+				field.ErrorTypeRequired,
+			},
+			secretRef: &core.SecretReference{
+				Name:      "my-secret",
+				Namespace: "",
+			},
+		}, {
+			name:      "SecretReference is Valid",
+			errorType: []field.ErrorType{},
+			secretRef: &core.SecretReference{
+				Name:      "my-secret",
+				Namespace: "default",
+			},
+		}, {
+			name: "Secret Name is Invalid",
+			errorType: []field.ErrorType{
+				field.ErrorTypeInvalid,
+			},
+			secretRef: &core.SecretReference{
+				Name:      "my-secret-",
+				Namespace: "default",
+			},
+		}, {
+			name: "Secret Namespace Value is Required",
+			errorType: []field.ErrorType{
+				field.ErrorTypeInvalid,
+			},
+			secretRef: &core.SecretReference{
+				Name:      "my-secret",
+				Namespace: "default-",
+			},
+		}, {
+			name: "Secret Name and Namespace value Required",
+			errorType: []field.ErrorType{
+				field.ErrorTypeRequired,
+			},
+			secretRef: &core.SecretReference{
+				Name:      "",
+				Namespace: "",
+			},
+		}, {
+			name: "Secret Name Invalid and Namespace is Required",
+			errorType: []field.ErrorType{
+				field.ErrorTypeRequired,
+				field.ErrorTypeInvalid,
+			},
+			secretRef: &core.SecretReference{
+				Name:      "my-secret-",
+				Namespace: "",
+			},
+		},
+	}
+
+	for _, testScenario := range scenarios {
+		t.Run(testScenario.name, func(t *testing.T) {
+			errs := ValidateSecretReference(testScenario.secretRef, path)
+			for _, err := range errs {
+				asserttestify.Contains(t, testScenario.errorType, err.Type)
+			}
+		})
+	}
+}

--- a/pkg/apis/core/validation/validation_test.go
+++ b/pkg/apis/core/validation/validation_test.go
@@ -18596,3 +18596,102 @@ func TestValidateSecretReference(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateSecretObjectReference(t *testing.T) {
+	path := field.NewPath("secretRef")
+	scenarios := []struct {
+		name      string
+		errorType []field.ErrorType
+		secretRef *core.ObjectReference
+	}{
+		{
+			name: "Kind should be Secret",
+			errorType: []field.ErrorType{
+				field.ErrorTypeInvalid,
+			},
+			secretRef: &core.ObjectReference{
+				Kind:      "Namespace",
+				Name:      "",
+				Namespace: "default",
+			},
+		}, {
+			name: "Secret Name is Required",
+			errorType: []field.ErrorType{
+				field.ErrorTypeRequired,
+			},
+			secretRef: &core.ObjectReference{
+				Kind:      "Secret",
+				Name:      "",
+				Namespace: "default",
+			},
+		}, {
+			name: "Secret Namespace is Required",
+			errorType: []field.ErrorType{
+				field.ErrorTypeRequired,
+			},
+			secretRef: &core.ObjectReference{
+				Kind:      "Secret",
+				Name:      "my-secret",
+				Namespace: "",
+			},
+		}, {
+			name:      "SecretReference is Valid",
+			errorType: []field.ErrorType{},
+			secretRef: &core.ObjectReference{
+				Kind:      "Secret",
+				Name:      "my-secret",
+				Namespace: "default",
+			},
+		}, {
+			name: "Secret Name is Invalid",
+			errorType: []field.ErrorType{
+				field.ErrorTypeInvalid,
+			},
+			secretRef: &core.ObjectReference{
+				Kind:      "Secret",
+				Name:      "my-secret-",
+				Namespace: "default",
+			},
+		}, {
+			name: "Secret Namespace Value is Required",
+			errorType: []field.ErrorType{
+				field.ErrorTypeInvalid,
+			},
+			secretRef: &core.ObjectReference{
+				Kind:      "Secret",
+				Name:      "my-secret",
+				Namespace: "default-",
+			},
+		}, {
+			name: "Secret Name and Namespace value Required",
+			errorType: []field.ErrorType{
+				field.ErrorTypeRequired,
+			},
+			secretRef: &core.ObjectReference{
+				Kind:      "Secret",
+				Name:      "",
+				Namespace: "",
+			},
+		}, {
+			name: "Secret Name Invalid and Namespace is Required",
+			errorType: []field.ErrorType{
+				field.ErrorTypeRequired,
+				field.ErrorTypeInvalid,
+			},
+			secretRef: &core.ObjectReference{
+				Kind:      "Secret",
+				Name:      "my-secret-",
+				Namespace: "",
+			},
+		},
+	}
+
+	for _, testScenario := range scenarios {
+		t.Run(testScenario.name, func(t *testing.T) {
+			errs := ValidateSecretObjectReference(testScenario.secretRef, path)
+			for _, err := range errs {
+				asserttestify.Contains(t, testScenario.errorType, err.Type)
+			}
+		})
+	}
+}

--- a/pkg/apis/storage/validation/validation.go
+++ b/pkg/apis/storage/validation/validation.go
@@ -193,7 +193,7 @@ func validateVolumeAttachmentSource(source *storage.VolumeAttachmentSource, fldP
 		}
 	case source.InlineVolumeSpec != nil:
 		opts := apivalidation.PersistentVolumeSpecValidationOptions{}
-		allErrs = append(allErrs, apivalidation.ValidatePersistentVolumeSpec(source.InlineVolumeSpec, nil,"", true, fldPath.Child("inlineVolumeSpec"), opts)...)
+		allErrs = append(allErrs, apivalidation.ValidatePersistentVolumeSpec(source.InlineVolumeSpec, nil, "", true, fldPath.Child("inlineVolumeSpec"), opts)...)
 	}
 	return allErrs
 }

--- a/pkg/apis/storage/validation/validation.go
+++ b/pkg/apis/storage/validation/validation.go
@@ -193,7 +193,7 @@ func validateVolumeAttachmentSource(source *storage.VolumeAttachmentSource, fldP
 		}
 	case source.InlineVolumeSpec != nil:
 		opts := apivalidation.PersistentVolumeSpecValidationOptions{}
-		allErrs = append(allErrs, apivalidation.ValidatePersistentVolumeSpec(source.InlineVolumeSpec, "", true, fldPath.Child("inlineVolumeSpec"), opts)...)
+		allErrs = append(allErrs, apivalidation.ValidatePersistentVolumeSpec(source.InlineVolumeSpec, nil,"", true, fldPath.Child("inlineVolumeSpec"), opts)...)
 	}
 	return allErrs
 }

--- a/pkg/registry/core/persistentvolume/strategy.go
+++ b/pkg/registry/core/persistentvolume/strategy.go
@@ -72,7 +72,7 @@ func (persistentvolumeStrategy) PrepareForCreate(ctx context.Context, obj runtim
 func (persistentvolumeStrategy) Validate(ctx context.Context, obj runtime.Object) field.ErrorList {
 	persistentvolume := obj.(*api.PersistentVolume)
 	opts := validation.ValidationOptionsForPersistentVolume(persistentvolume, nil)
-	errorList := validation.ValidatePersistentVolume(persistentvolume, opts)
+	errorList := validation.ValidatePersistentVolume(persistentvolume, nil, opts)
 	return append(errorList, volumevalidation.ValidatePersistentVolume(persistentvolume)...)
 }
 
@@ -102,8 +102,7 @@ func (persistentvolumeStrategy) ValidateUpdate(ctx context.Context, obj, old run
 	newPv := obj.(*api.PersistentVolume)
 	oldPv := old.(*api.PersistentVolume)
 	opts := validation.ValidationOptionsForPersistentVolume(newPv, oldPv)
-	errorList := validation.ValidatePersistentVolume(newPv, opts)
-	errorList = append(errorList, volumevalidation.ValidatePersistentVolume(newPv)...)
+	errorList := volumevalidation.ValidatePersistentVolume(newPv)
 	return append(errorList, validation.ValidatePersistentVolumeUpdate(newPv, oldPv, opts)...)
 }
 


### PR DESCRIPTION
- Add `SecretRef` validation for core.RBDPersistentVolumeSource
- Add `SecretRef` validation for core.CephFSPersistentVolumeSource
- Add `Name` and `Namespace` value validation for core.ISCSIPersistentVolumeSource.SecretRef
- Add `Name` and `Namespace` value validation for core.CinderPersistentVolumeSource.SecretRef
- Add `SecretRef` validation for core.FlexPersistentVolumeSource
- Add `SecretName` and `SecretNamespace` validation for core.AzureFilePersistentVolumeSource
- Add `SecretRef` validation for core.ScaleIOPersistentVolumeSource
- Add `Name` and `Namespace` value validation for core.StorageOSPersistentVolumeSource.SecretRef
- Add `Name` and `Namespace` value validation for core.CSIPersistentVolumeSource.SecretRef

Signed-off-by: Akshit Grover <akshit.grover2016@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Adds and fixes validation checks for SecretReferences in PersistentVolumes

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #102939

#### Special notes for your reviewer:
Adds SecretReference checks for PersistentVolumes wherever missing

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
