### PR TITLE
Automated cherry pick of #103019: Fix frameworkImpl.extenders being not set

### DIFF
--- a/pkg/scheduler/factory.go
+++ b/pkg/scheduler/factory.go
@@ -139,6 +139,7 @@ func (c *Configurator) create() (*Scheduler, error) {
 		frameworkruntime.WithRunAllFilters(c.alwaysCheckAllPredicates),
 		frameworkruntime.WithPodNominator(nominator),
 		frameworkruntime.WithCaptureProfile(frameworkruntime.CaptureProfile(c.frameworkCapturer)),
+		frameworkruntime.WithExtenders(extenders),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("initializing profiles: %v", err)


### PR DESCRIPTION
Cherry pick of #103019 on release-1.20.

#103019: Fix frameworkImpl.extenders being not set

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
Fixed a regression in 1.20+ scheduler extender setup that scheduler extenders are not called on preemptions
```
