### PR TITLE
Automated cherry pick of #103019: Fix frameworkImpl.extenders being not set

### DIFF
--- a/pkg/scheduler/factory.go
+++ b/pkg/scheduler/factory.go
@@ -144,6 +144,7 @@ func (c *Configurator) create() (*Scheduler, error) {
 		frameworkruntime.WithCaptureProfile(frameworkruntime.CaptureProfile(c.frameworkCapturer)),
 		frameworkruntime.WithClusterEventMap(clusterEventMap),
 		frameworkruntime.WithParallelism(int(c.parallellism)),
+		frameworkruntime.WithExtenders(extenders),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("initializing profiles: %v", err)

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -128,10 +128,11 @@ func TestSchedulerCreation(t *testing.T) {
 		"Foo": defaultbinder.New,
 	}
 	cases := []struct {
-		name         string
-		opts         []Option
-		wantErr      string
-		wantProfiles []string
+		name          string
+		opts          []Option
+		wantErr       string
+		wantProfiles  []string
+		wantExtenders []string
 	}{
 		{
 			name:         "default scheduler",
@@ -165,6 +166,18 @@ func TestSchedulerCreation(t *testing.T) {
 			)},
 			wantErr: "duplicate profile with scheduler name \"foo\"",
 		},
+		{
+			name: "With extenders",
+			opts: []Option{
+				WithExtenders(
+					schedulerapi.Extender{
+						URLPrefix: "http://extender.kube-system/",
+					},
+				),
+			},
+			wantProfiles:  []string{"default-scheduler"},
+			wantExtenders: []string{"http://extender.kube-system/"},
+		},
 	}
 
 	for _, tc := range cases {
@@ -183,6 +196,7 @@ func TestSchedulerCreation(t *testing.T) {
 				tc.opts...,
 			)
 
+			// Errors
 			if len(tc.wantErr) != 0 {
 				if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
 					t.Errorf("got error %q, want %q", err, tc.wantErr)
@@ -192,6 +206,8 @@ func TestSchedulerCreation(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Failed to create scheduler: %v", err)
 			}
+
+			// Profiles
 			profiles := make([]string, 0, len(s.Profiles))
 			for name := range s.Profiles {
 				profiles = append(profiles, name)
@@ -199,6 +215,29 @@ func TestSchedulerCreation(t *testing.T) {
 			sort.Strings(profiles)
 			if diff := cmp.Diff(tc.wantProfiles, profiles); diff != "" {
 				t.Errorf("unexpected profiles (-want, +got):\n%s", diff)
+			}
+
+			// Extenders
+			if len(tc.wantExtenders) != 0 {
+				// Scheduler.Extenders
+				extenders := make([]string, 0, len(s.Algorithm.Extenders()))
+				for _, e := range s.Algorithm.Extenders() {
+					extenders = append(extenders, e.Name())
+				}
+				if diff := cmp.Diff(tc.wantExtenders, extenders); diff != "" {
+					t.Errorf("unexpected extenders (-want, +got):\n%s", diff)
+				}
+
+				// framework.Handle.Extenders()
+				for _, p := range s.Profiles {
+					extenders := make([]string, 0, len(p.Extenders()))
+					for _, e := range p.Extenders() {
+						extenders = append(extenders, e.Name())
+					}
+					if diff := cmp.Diff(tc.wantExtenders, extenders); diff != "" {
+						t.Errorf("unexpected extenders (-want, +got):\n%s", diff)
+					}
+				}
 			}
 		})
 	}


### PR DESCRIPTION
Cherry pick of #103019 on release-1.21.

#103019: Fix frameworkImpl.extenders being not set

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
Fixed a regression in 1.20+ scheduler extender setup that scheduler extenders are not called on preemptions
```
