### PR TITLE
WIP: Update API versions in GC's dependency graph.

### DIFF
--- a/pkg/controller/garbagecollector/graph_builder.go
+++ b/pkg/controller/garbagecollector/graph_builder.go
@@ -683,6 +683,8 @@ func (gb *GraphBuilder) processGraphChanges() bool {
 			gb.addUnblockedOwnersToDeleteQueue(removed, changed)
 			// update the node itself
 			existingNode.owners = accessor.GetOwnerReferences()
+			// Make sure the API version stored in memory is up to date.
+			existingNode.identity.APIVersion = event.gvk.GroupVersion().String()
 			// Add the node to its new owners' dependent lists.
 			gb.addDependentToOwners(existingNode, added)
 			// remove the node from the dependent list of node that are no longer in


### PR DESCRIPTION






<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug



#### What this PR does / why we need it:

This PR fixes a bug where after a custom resource version is no longer served an owned resource created at this version is not garbage collected. We now update API versions of owned resources in GC's
in-memory dependency graph.

#### Which issue(s) this PR fixes: 
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #102641 

#### Special notes for your reviewer:

I have manually tested that with this the resources now get garbage collected correctly in the scenario described in https://github.com/kubernetes/kubernetes/issues/102641#issuecomment-857809490 .

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fixes a bug where owned CRs were not garbage collected after a CR version removal.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
Signed-off-by: irbekrm <irbekrm@gmail.com>
