### PR TITLE
apf: calculation of dR/dt should use seats in use

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/queueset/queueset.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/queueset/queueset.go
@@ -414,9 +414,9 @@ func (qs *queueSet) syncTimeLocked() {
 // been advancing, according to the logic in `doc.go`.
 func (qs *queueSet) getVirtualTimeRatioLocked() float64 {
 	activeQueues := 0
-	reqs := 0
+	seatsInUse := 0
 	for _, queue := range qs.queues {
-		reqs += queue.requestsExecuting
+		seatsInUse += queue.seatsInUse
 		if queue.requests.Length() > 0 || queue.requestsExecuting > 0 {
 			activeQueues++
 		}
@@ -424,7 +424,7 @@ func (qs *queueSet) getVirtualTimeRatioLocked() float64 {
 	if activeQueues == 0 {
 		return 0
 	}
-	return math.Min(float64(reqs), float64(qs.dCfg.ConcurrencyLimit)) / float64(activeQueues)
+	return math.Min(float64(seatsInUse), float64(qs.dCfg.ConcurrencyLimit)) / float64(activeQueues)
 }
 
 // timeoutOldRequestsAndRejectOrEnqueueLocked encapsulates the logic required


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:
calculation of `dR/dt` should use number of seats in use, as opposed to number of currently executing requests.

#### Which issue(s) this PR fixes:

Fixes #102973 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
