### PR TITLE
Fix verify staticcheck flake in cluster/images/etcd/migrate

### DIFF
--- a/cluster/images/etcd/migrate/integration_test.go
+++ b/cluster/images/etcd/migrate/integration_test.go
@@ -42,7 +42,7 @@ import (
 )
 
 var (
-	testSupportedVersions = MustParseSupportedVersions([]string{"3.0.17", "3.1.12"})
+	testSupportedVersions = mustParseSupportedVersions([]string{"3.0.17", "3.1.12"})
 	testVersionPrevious   = &EtcdVersion{semver.MustParse("3.0.17")}
 	testVersionLatest     = &EtcdVersion{semver.MustParse("3.1.12")}
 )
@@ -79,8 +79,8 @@ func TestMigrate(t *testing.T) {
 
 	for _, m := range migrations {
 		t.Run(m.title, func(t *testing.T) {
-			start := MustParseEtcdVersionPair(m.startVersion)
-			end := MustParseEtcdVersionPair(m.endVersion)
+			start := mustParseEtcdVersionPair(m.startVersion)
+			end := mustParseEtcdVersionPair(m.endVersion)
 
 			testCfgs := clusterConfig(t, m.title, m.memberCount, m.protocol, m.clientListenUrls)
 
@@ -362,4 +362,23 @@ func generateSelfSignedCertKey(host string, alternateIPs []net.IP, alternateDNS 
 	}
 
 	return certBuffer.Bytes(), keyBuffer.Bytes(), nil
+}
+
+// mustParseEtcdVersionPair parses a "<version>/<storage-version>" string to an EtcdVersionPair
+// or panics if the parse fails.
+func mustParseEtcdVersionPair(s string) *EtcdVersionPair {
+	pair, err := ParseEtcdVersionPair(s)
+	if err != nil {
+		panic(err)
+	}
+	return pair
+}
+
+// mustParseSupportedVersions parses a comma separated list of etcd versions or panics if the parse fails.
+func mustParseSupportedVersions(list []string) SupportedVersions {
+	versions, err := ParseSupportedVersions(list)
+	if err != nil {
+		panic(err)
+	}
+	return versions
 }

--- a/cluster/images/etcd/migrate/versions.go
+++ b/cluster/images/etcd/migrate/versions.go
@@ -124,17 +124,6 @@ func ParseEtcdVersionPair(s string) (*EtcdVersionPair, error) {
 	return &EtcdVersionPair{version, storageVersion}, nil
 }
 
-// MustParseEtcdVersionPair parses a "<version>/<storage-version>" string to an EtcdVersionPair
-// or panics if the parse fails.
-//lint:ignore U1000 Keep unused but exported MustParseEtcdVersionPair until deprecated package is being removed
-func MustParseEtcdVersionPair(s string) *EtcdVersionPair {
-	pair, err := ParseEtcdVersionPair(s)
-	if err != nil {
-		panic(err)
-	}
-	return pair
-}
-
 // String returns "<version>/<storage-version>" string of the EtcdVersionPair.
 func (vp *EtcdVersionPair) String() string {
 	return fmt.Sprintf("%s/%s", vp.version, vp.storageVersion)
@@ -186,14 +175,4 @@ func ParseSupportedVersions(list []string) (SupportedVersions, error) {
 		}
 	}
 	return versions, nil
-}
-
-// MustParseSupportedVersions parses a comma separated list of etcd versions or panics if the parse fails.
-//lint:ignore U1000 Keep unused but exported MustParseSupportedVersions until deprecated package is being removed
-func MustParseSupportedVersions(list []string) SupportedVersions {
-	versions, err := ParseSupportedVersions(list)
-	if err != nil {
-		panic(err)
-	}
-	return versions
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
/kind flake

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
PR fixes a verify staticcheck flake which has been introduced by #102629:
```
Errors from staticcheck:
cluster/images/etcd/migrate/versions.go:129:1: this linter directive didn't match anything; should it be removed? ()
cluster/images/etcd/migrate/versions.go:192:1: this linter directive didn't match anything; should it be removed? ()
```
Examples of verify staticcheck failures: [#102913](https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/102913/pull-kubernetes-verify/1406813972832718848) and [#103038](https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/103038/pull-kubernetes-verify/1406899926289354752).

<!--
#### Which issue(s) this PR fixes:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*

Fixes #

#### Special notes for your reviewer:
`MustParseEtcdVersionPair` and  `MustParseSupportedVersions` seem to be used in the package's integration test only.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
<!--
#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>

```docs

```
-->