### PR TITLE
taint based eviction: allow lengthening eviction schedule

### DIFF
--- a/pkg/controller/nodelifecycle/scheduler/taint_manager.go
+++ b/pkg/controller/nodelifecycle/scheduler/taint_manager.go
@@ -368,7 +368,8 @@ func (tc *NoExecuteTaintManager) processPodOnNode(
 	scheduledEviction := tc.taintEvictionQueue.GetWorkerUnsafe(podNamespacedName.String())
 	if scheduledEviction != nil {
 		startTime = scheduledEviction.CreatedAt
-		if startTime.Add(minTolerationTime).Before(triggerTime) {
+		deltaScheduleSeconds:= math.Abs(startTime.Add(minTolerationTime).Sub(scheduledEviction.FireAt).Seconds())
+		if deltaScheduleSeconds< 10.0 { // schedule differ by less than 10s, no need to reschedule
 			return
 		}
 		tc.cancelWorkWithEvent(podNamespacedName)

--- a/pkg/controller/nodelifecycle/scheduler/taint_manager.go
+++ b/pkg/controller/nodelifecycle/scheduler/taint_manager.go
@@ -368,8 +368,8 @@ func (tc *NoExecuteTaintManager) processPodOnNode(
 	scheduledEviction := tc.taintEvictionQueue.GetWorkerUnsafe(podNamespacedName.String())
 	if scheduledEviction != nil {
 		startTime = scheduledEviction.CreatedAt
-		deltaScheduleSeconds:= math.Abs(startTime.Add(minTolerationTime).Sub(scheduledEviction.FireAt).Seconds())
-		if deltaScheduleSeconds< 10.0 { // schedule differ by less than 10s, no need to reschedule
+		deltaScheduleSeconds := math.Abs(startTime.Add(minTolerationTime).Sub(scheduledEviction.FireAt).Seconds())
+		if deltaScheduleSeconds < 10.0 { // schedule differ by less than 10s, no need to reschedule
 			return
 		}
 		tc.cancelWorkWithEvent(podNamespacedName)

--- a/pkg/controller/nodelifecycle/scheduler/taint_manager_test.go
+++ b/pkg/controller/nodelifecycle/scheduler/taint_manager_test.go
@@ -292,13 +292,13 @@ func TestUpdatePod(t *testing.T) {
 			expectDelete: true,
 		},
 		{
-			description: "lengthening toleration shouldn't work",
+			description: "allow lengthening toleration",
 			prevPod:     addToleration(testutil.NewPod("pod1", "node1"), 1, 1),
 			newPod:      addToleration(testutil.NewPod("pod1", "node1"), 1, 100),
 			taintedNodes: map[string][]v1.Taint{
 				"node1": {createNoExecuteTaint(1)},
 			},
-			expectDelete:    true,
+			expectDelete:    false,
 			additionalSleep: 1500 * time.Millisecond,
 		},
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:
The `tolerationSeconds` modification is not respected if an eviction schedule already exists and is planned earlier than what the new schedule would be.

This leads to inconsistent/unpredictable behavior for users as described in the issue #102993

Lengthening tolerationSeconds should be a valid usecase even if an eviction schedule exists: it is a user request to gain time against the taint based eviction. This time extension might be required to act on the cluster (or nodes) and apply some remediations before the taint based eviction starts deleting pods.

Having taint based eviction removing pod slowly and fixing the system is nice when we are talking about some units here and there. But if we have a massive or concentrated (defined subset of nodes) problem on nodes, giving an opportunity to users (operators) to push back the eviction schedule is a must have functionality. Current implementation does not allow it. The proposition to act on eviction rate (primary and secondary) does not make sense or does not even work in several cases.

#### Which issue(s) this PR fixes:

Fixes #102993.

#### Special notes for your reviewer:

I could not find any valid reason in the code nor in the documentation about the motivation to prevent eviction schedule extension.
I started a discussion on #sig-node to ask for motivations on such behavior but I got no answer.

#### Does this PR introduce a user-facing change?
```release-note
behavioral change: extending eviction schedule would now be possible.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
I could not find any documentation about modification of exist schedule for taint-based-eviction. If this PR is accepted we should maybe add few words about it in the following sections:

https://kubernetes.io/docs/concepts/scheduling-eviction/_print/#pg-ede4960b56a3529ee0bfe7c8fe2d09a5

https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/#taint-based-evictions
