### PR TITLE
Disable deprecated volume limits test when CSI migration enabled and replace with CSI-specific test

### DIFF
--- a/test/e2e/framework/skipper/skipper.go
+++ b/test/e2e/framework/skipper/skipper.go
@@ -49,6 +49,7 @@ var localStorageCapacityIsolation featuregate.Feature = "LocalStorageCapacityIso
 var (
 	downwardAPIHugePages featuregate.Feature = "DownwardAPIHugePages"
 	execProbeTimeout     featuregate.Feature = "ExecProbeTimeout"
+	csiMigration         featuregate.Feature = "CSIMigration"
 )
 
 func skipInternalf(caller int, format string, args ...interface{}) {
@@ -151,6 +152,12 @@ func SkipUnlessDownwardAPIHugePagesEnabled() {
 func SkipUnlessExecProbeTimeoutEnabled() {
 	if !utilfeature.DefaultFeatureGate.Enabled(execProbeTimeout) {
 		skipInternalf(1, "Only supported when %v feature is enabled", execProbeTimeout)
+	}
+}
+
+func SkipIfCSIMigrationEnabled() {
+	if utilfeature.DefaultFeatureGate.Enabled(csiMigration) {
+		skipInternalf(1, "Only supported when %v feature is disabled", csiMigration)
 	}
 }
 

--- a/test/e2e/storage/volume_limits.go
+++ b/test/e2e/storage/volume_limits.go
@@ -34,6 +34,8 @@ var _ = utils.SIGDescribe("Volume limits", func() {
 	f := framework.NewDefaultFramework("volume-limits-on-node")
 	ginkgo.BeforeEach(func() {
 		e2eskipper.SkipUnlessProviderIs("aws", "gce", "gke")
+		// If CSIMigration is enabled, then the limits should be on CSINodes, not Nodes, and another test checks this
+		e2eskipper.SkipIfCSIMigrationEnabled()
 		c = f.ClientSet
 		framework.ExpectNoError(framework.WaitForAllNodesSchedulable(c, framework.TestContext.NodeSchedulableTimeout))
 	})


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

- `should support volume limits [Serial]` is too slow to run as part of presubmit CI
- `should verify that all nodes have volume limits` is not applicable to CSIMigration. If CSIMigration is enabled, then it's expected that nodes have empty volume limits because instead csinodes will have nonempty volume limits . https://github.com/kubernetes-sigs/aws-ebs-csi-driver/issues/915

So I add this test  `should verify that all csinodes have volume limits` as a substitute for  `should verify that all nodes have volume limits`.

```
$ ./_output/bin/e2e.test --ginkgo.focus "aws.*should.verify.that.all.csinodes.have.volume.limits" --provider aws --storage.testdriver ~/go/src/github.com/kubernetes-sigs/aws-ebs-csi-driver/tests/e2e-kubernetes/manifests.yaml --kubeconfig ~/.kube/config
...
Ran 1 of 6002 Specs in 0.566 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 6001 Skipped
PASS
...
$ ./_output/bin/e2e.test --ginkgo.focus "should.verify.that.all.nodes.have.volume.limits" --provider aws --storage.testdriver ~/go/src/github.com/kubernetes-sigs/aws-ebs-csi-driver/tests/e2e-kubernetes/manifests.yaml --kubeconfig ~/.kube/config
...
  Only supported when CSIMigration feature is disabled
...
```
#### Which issue(s) this PR fixes:
Fixes https://github.com/kubernetes/kubernetes/issues/79660

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
