### PR TITLE
kube-apiserver: use --api-audiences as --service-account-api-audiences is deprecated

### DIFF
--- a/cluster/gce/gci/configure-kubeapiserver.sh
+++ b/cluster/gce/gci/configure-kubeapiserver.sh
@@ -146,7 +146,7 @@ function start-kube-apiserver {
     params+=" --service-cluster-ip-range=${SERVICE_CLUSTER_IP_RANGE}"
   fi
   params+=" --service-account-issuer=${SERVICEACCOUNT_ISSUER}"
-  params+=" --service-account-api-audiences=${SERVICEACCOUNT_ISSUER}"
+  params+=" --api-audiences=${SERVICEACCOUNT_ISSUER}"
   params+=" --service-account-signing-key-file=${SERVICEACCOUNT_KEY_PATH}"
 
   local audit_policy_config_mount=""


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### Which issue(s) this PR fixes:

https://github.com/kubernetes/kubernetes/blob/4f50f99cc65ae6b0f2cca21fdf448229c5b22cdf/pkg/kubeapiserver/options/authentication.go#L344-L348
It is deprecated since 1.13.

Fixes none
```
Flag --service-account-api-audiences has been deprecated, Use --api-audiences
```

#### Special notes for your reviewer:

```release-note
NONE
```