### PR TITLE
Add missing case when guessing plural for kinds ending with "h"

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/api/meta/restmapper.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/meta/restmapper.go
@@ -138,7 +138,7 @@ func UnsafeGuessKindToResource(kind schema.GroupVersionKind) ( /*plural*/ schema
 	}
 
 	switch string(singularName[len(singularName)-1]) {
-	case "s":
+	case "s","h":
 		return kind.GroupVersion().WithResource(singularName + "es"), singular
 	case "y":
 		return kind.GroupVersion().WithResource(strings.TrimSuffix(singularName, "y") + "ies"), singular

--- a/staging/src/k8s.io/apimachinery/pkg/api/meta/restmapper_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/meta/restmapper_test.go
@@ -450,6 +450,8 @@ func TestKindToResource(t *testing.T) {
 		{Kind: "ImageRepository", Plural: "imagerepositories", Singular: "imagerepository"},
 		// Add "es" when ending with "s"
 		{Kind: "miss", Plural: "misses", Singular: "miss"},
+		// Add "es" when ending with "h"
+		{Kind: "cloth", Plural: "clothes", Singular: "cloth"},
 		// Add "s" otherwise
 		{Kind: "lowercase", Plural: "lowercases", Singular: "lowercase"},
 	}


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
This PR adds a missing case when guessing kind plural for kinds with a name ending with the letter "h".
Indeed, in most cases, the plural of english words ending with "h" will be "hes".
When using fake client in a custom controller to run some tests, I ran into a case where the plural was not correctly guessed (Elasticsearch -> Elasticsearchs) which resulted in tests failure.

#### Does this PR introduce a user-facing change?
NONE

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

