### PR TITLE
kubeadm: fix image pull policy integration

### DIFF
--- a/cmd/kubeadm/app/preflight/checks_test.go
+++ b/cmd/kubeadm/app/preflight/checks_test.go
@@ -31,7 +31,6 @@ import (
 	"net/http"
 	"os"
 
-	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
 	"k8s.io/kubernetes/cmd/kubeadm/app/constants"
@@ -924,7 +923,7 @@ func TestImagePullCheck(t *testing.T) {
 	check := ImagePullCheck{
 		runtime:         containerRuntime,
 		imageList:       []string{"img1", "img2", "img3"},
-		imagePullPolicy: v1.PullIfNotPresent,
+		imagePullPolicy: "", // should be defaulted to v1.PullIfNotPresent
 	}
 	warnings, errors := check.Check()
 	if len(warnings) != 0 {


### PR DESCRIPTION
#### What this PR does / why we need it:

If the user has not specified a pull policy we must assume a default of
v1.PullIfNotPresent.

Add some extra verbose output to help users monitor what policy is
used and what images are skipped / pulled.

Use "fallthrough" and case handle "v1.PullAlways".

Update unit test.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes/kubernetes/issues/103101

#### Special notes for your reviewer:

NONE

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
