### PR TITLE
Automated cherry pick of #93250: Handle int -> float conversion in FromUnstructured

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/runtime/converter.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/converter.go
@@ -186,6 +186,9 @@ func fromUnstructured(sv, dv reflect.Value) error {
 					reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
 					dv.Set(sv.Convert(dt))
 					return nil
+				case reflect.Float32, reflect.Float64:
+					dv.Set(sv.Convert(dt))
+					return nil
 				}
 			case reflect.Float32, reflect.Float64:
 				switch dt.Kind() {

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/converter_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/converter_test.go
@@ -544,6 +544,28 @@ func TestFloatIntConversion(t *testing.T) {
 	}
 }
 
+func TestIntFloatConversion(t *testing.T) {
+	unstr := map[string]interface{}{"ch": int64(3)}
+
+	var obj C
+	if err := runtime.NewTestUnstructuredConverter(simpleEquality).FromUnstructured(unstr, &obj); err != nil {
+		t.Errorf("Unexpected error in FromUnstructured: %v", err)
+	}
+
+	data, err := json.Marshal(unstr)
+	if err != nil {
+		t.Fatalf("Error when marshaling unstructured: %v", err)
+	}
+	var unmarshalled C
+	if err := json.Unmarshal(data, &unmarshalled); err != nil {
+		t.Fatalf("Error when unmarshaling to object: %v", err)
+	}
+
+	if !reflect.DeepEqual(obj, unmarshalled) {
+		t.Errorf("Incorrect conversion, diff: %v", diff.ObjectReflectDiff(obj, unmarshalled))
+	}
+}
+
 func TestCustomToUnstructured(t *testing.T) {
 	testcases := []struct {
 		Data     string


### PR DESCRIPTION
Cherry pick of #93250 on release-1.19.

#93250: Handle int -> float conversion in FromUnstructured

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

The backport of https://github.com/kubernetes/kubernetes/pull/95836 to release-1.19 in https://github.com/kubernetes/kubernetes/pull/100713 without this fix introduced a type mismatch that can break server-side apply of CRDs in 1.19.10+

```release-note
Fixes a regression in 1.19.10 where a `cannot convert int64 to float64` error is seen using server-side apply with certain CRDs
```