### PR TITLE
ResourceConfigForPod: check initContainers as other QoS func

### DIFF
--- a/pkg/kubelet/cm/helpers_linux.go
+++ b/pkg/kubelet/cm/helpers_linux.go
@@ -158,6 +158,21 @@ func ResourceConfigForPod(pod *v1.Pod, enforceCPULimits bool, cpuPeriod uint64) 
 		}
 	}
 
+	for _, container := range pod.Spec.InitContainers {
+		if container.Resources.Limits.Cpu().IsZero() {
+			cpuLimitsDeclared = false
+		}
+		if container.Resources.Limits.Memory().IsZero() {
+			memoryLimitsDeclared = false
+		}
+		containerHugePageLimits := HugePageLimits(container.Resources.Requests)
+		for k, v := range containerHugePageLimits {
+			if value, exists := hugePageLimits[k]; !exists || v > value {
+				hugePageLimits[k] = v
+			}
+		}
+	}
+
 	// quota is not capped when cfs quota is disabled
 	if !enforceCPULimits {
 		cpuQuota = int64(-1)

--- a/pkg/kubelet/cm/helpers_linux_test.go
+++ b/pkg/kubelet/cm/helpers_linux_test.go
@@ -248,6 +248,31 @@ func TestResourceConfigForPod(t *testing.T) {
 			quotaPeriod:      tunedQuotaPeriod,
 			expected:         &ResourceConfig{CpuShares: &guaranteedShares, CpuQuota: &cpuNoLimit, CpuPeriod: &tunedQuotaPeriod, Memory: &guaranteedMemory},
 		},
+		"burstable-partial-limits-with-init-containers": {
+			pod: &v1.Pod{
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						{
+							Resources: getResourceRequirements(getResourceList("100m", "100m"), getResourceList("100m", "100Mi")),
+						},
+						{
+							Resources: getResourceRequirements(getResourceList("100m", "100m"), getResourceList("", "")),
+						},
+					},
+					InitContainers: []v1.Container{
+						{
+							Resources: getResourceRequirements(getResourceList("100m", "100m"), getResourceList("100m", "100Mi")),
+						},
+						{
+							Resources: getResourceRequirements(getResourceList("100m", "100m"), getResourceList("", "")),
+						},
+					},
+				},
+			},
+			enforceCPULimits: true,
+			quotaPeriod:      tunedQuotaPeriod,
+			expected:         &ResourceConfig{CpuShares: &burstablePartialShares},
+		},
 	}
 
 	for testName, testCase := range testCases {
@@ -255,16 +280,16 @@ func TestResourceConfigForPod(t *testing.T) {
 		actual := ResourceConfigForPod(testCase.pod, testCase.enforceCPULimits, testCase.quotaPeriod)
 
 		if !reflect.DeepEqual(actual.CpuPeriod, testCase.expected.CpuPeriod) {
-			t.Errorf("unexpected result, test: %v, cpu period not as expected", testName)
+			t.Errorf("unexpected result, test: %v, cpu period not as expected. Expected: %v, Actual:%v", testName, *testCase.expected.CpuPeriod, *actual.CpuPeriod)
 		}
 		if !reflect.DeepEqual(actual.CpuQuota, testCase.expected.CpuQuota) {
-			t.Errorf("unexpected result, test: %v, cpu quota not as expected", testName)
+			t.Errorf("unexpected result, test: %v, cpu quota not as expected. Expected: %v, Actual:%v", testName, *testCase.expected.CpuQuota, *actual.CpuQuota)
 		}
 		if !reflect.DeepEqual(actual.CpuShares, testCase.expected.CpuShares) {
-			t.Errorf("unexpected result, test: %v, cpu shares not as expected", testName)
+			t.Errorf("unexpected result, test: %v, cpu shares not as expected. Expected: %v, Actual:%v", testName, *testCase.expected.CpuShares, &actual.CpuShares)
 		}
 		if !reflect.DeepEqual(actual.Memory, testCase.expected.Memory) {
-			t.Errorf("unexpected result, test: %v, memory not as expected", testName)
+			t.Errorf("unexpected result, test: %v, memory not as expected. Expected: %v, Actual:%v", testName, *testCase.expected.Memory, *actual.Memory)
 		}
 	}
 }


### PR DESCRIPTION
#### What type of PR is this?
/kind bug


#### What this PR does / why we need it:
According to [the website doc](https://kubernetes.io/docs/tasks/configure-pod-container/quality-service-pod/#create-a-pod-that-gets-assigned-a-qos-class-of-guaranteed).
> These restrictions apply to init containers and app containers equally.

> The methods called by ResourceConfigForPod (PodRequestsAndLimits and GetPodQOS) do check initContainers, but it looks like cpuLimitsDeclared and memoryLimitsDeclared can be true for burstable pods even when some of the initContainers do not declare cpu/memory limits.


#### Which issue(s) this PR fixes:
Fixes #93300

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
/release-note-none