### PR TITLE
e2e: node: remove obsolete AlphaFeature tag

### DIFF
--- a/test/e2e_node/cpu_manager_test.go
+++ b/test/e2e_node/cpu_manager_test.go
@@ -666,7 +666,7 @@ func runCPUManagerTests(f *framework.Framework) {
 }
 
 // Serial because the test updates kubelet configuration.
-var _ = SIGDescribe("CPU Manager [Serial] [Feature:CPUManager][NodeAlphaFeature:CPUManager]", func() {
+var _ = SIGDescribe("CPU Manager [Serial] [Feature:CPUManager]", func() {
 	f := framework.NewDefaultFramework("cpu-manager-test")
 
 	ginkgo.Context("With kubeconfig updated with static CPU Manager policy run the CPU Manager tests", func() {


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:
CPUManager graduated to beta from quite some time, yet its e2e tests are still tagged as `AlphaFeature`, so the tests are not run by default on the serial lanes. Let's get rid of the obsolete tag.

#### Which issue(s) this PR fixes:
Fixes: N/A

#### Special notes for your reviewer:
No actual code change, just fixing the ginkgo tags :)

#### Does this PR introduce a user-facing change?
```release-note
NONE
```