### PR TITLE
Fix panic in pkg/volume/csi tests

### DIFF
--- a/pkg/volume/csi/csi_attacher_test.go
+++ b/pkg/volume/csi/csi_attacher_test.go
@@ -1187,9 +1187,13 @@ func TestAttacherMountDevice(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		user, _ := user.Current()
-		if tc.populateDeviceMountPath && user.Uid == "0" {
-			t.Skipf("Skipping intentional failure on existing data when running as root.")
+		user, err := user.Current()
+		if err != nil {
+			t.Logf("Current user could not be determined, assuming non-root: %v", err)
+		} else {
+			if tc.populateDeviceMountPath && user.Uid == "0" {
+				t.Skipf("Skipping intentional failure on existing data when running as root.")
+			}
 		}
 		t.Run(tc.testName, func(t *testing.T) {
 			t.Logf("Running test case: %s", tc.testName)


### PR DESCRIPTION
When run as non-root user, TestAttacherMountDevice fails, because of missing
nil check that induces a panic. Fixed by doing `err != nil` check

/kind cleanup

/kind failing-test

#### What this PR does / why we need it:

xRef #99881 

/sig security
/sig testing