### PR TITLE
Add a function that returns default scheduler configuration

### DIFF
--- a/cmd/kube-scheduler/app/options/options.go
+++ b/cmd/kube-scheduler/app/options/options.go
@@ -38,14 +38,12 @@ import (
 	cliflag "k8s.io/component-base/cli/flag"
 	componentbaseconfig "k8s.io/component-base/config"
 	"k8s.io/component-base/config/options"
-	configv1alpha1 "k8s.io/component-base/config/v1alpha1"
 	"k8s.io/component-base/logs"
 	"k8s.io/component-base/metrics"
-	configv1beta2 "k8s.io/kube-scheduler/config/v1beta2"
 	schedulerappconfig "k8s.io/kubernetes/cmd/kube-scheduler/app/config"
 	"k8s.io/kubernetes/pkg/scheduler"
 	kubeschedulerconfig "k8s.io/kubernetes/pkg/scheduler/apis/config"
-	kubeschedulerscheme "k8s.io/kubernetes/pkg/scheduler/apis/config/scheme"
+	"k8s.io/kubernetes/pkg/scheduler/apis/config/latest"
 	"k8s.io/kubernetes/pkg/scheduler/apis/config/validation"
 )
 
@@ -73,7 +71,7 @@ type Options struct {
 
 // NewOptions returns default scheduler app options.
 func NewOptions() (*Options, error) {
-	cfg, err := newDefaultComponentConfig()
+	cfg, err := latest.Default()
 	if err != nil {
 		return nil, err
 	}
@@ -128,23 +126,6 @@ func splitHostIntPort(s string) (string, int, error) {
 		return "", 0, err
 	}
 	return host, portInt, err
-}
-
-func newDefaultComponentConfig() (*kubeschedulerconfig.KubeSchedulerConfiguration, error) {
-	versionedCfg := configv1beta2.KubeSchedulerConfiguration{}
-	versionedCfg.DebuggingConfiguration = *configv1alpha1.NewRecommendedDebuggingConfiguration()
-
-	kubeschedulerscheme.Scheme.Default(&versionedCfg)
-	cfg := kubeschedulerconfig.KubeSchedulerConfiguration{}
-	if err := kubeschedulerscheme.Scheme.Convert(&versionedCfg, &cfg, nil); err != nil {
-		return nil, err
-	}
-	// We don't set this field in pkg/scheduler/apis/config/{version}/conversion.go
-	// because the field will be cleared later by API machinery during
-	// conversion. See KubeSchedulerConfiguration internal type definition for
-	// more details.
-	cfg.TypeMeta.APIVersion = configv1beta2.SchemeGroupVersion.String()
-	return &cfg, nil
 }
 
 // Flags returns flags for a specific scheduler by section name

--- a/cmd/kube-scheduler/app/options/options_test.go
+++ b/cmd/kube-scheduler/app/options/options_test.go
@@ -38,6 +38,7 @@ import (
 	"k8s.io/kube-scheduler/config/v1beta1"
 	"k8s.io/kube-scheduler/config/v1beta2"
 	kubeschedulerconfig "k8s.io/kubernetes/pkg/scheduler/apis/config"
+	"k8s.io/kubernetes/pkg/scheduler/apis/config/latest"
 	configtesting "k8s.io/kubernetes/pkg/scheduler/apis/config/testing"
 	"k8s.io/kubernetes/pkg/scheduler/apis/config/testing/defaults"
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/names"
@@ -341,7 +342,7 @@ profiles:
 			options: &Options{
 				ConfigFile: configFile,
 				ComponentConfig: func() kubeschedulerconfig.KubeSchedulerConfiguration {
-					cfg, err := newDefaultComponentConfig()
+					cfg, err := latest.Default()
 					if err != nil {
 						t.Fatal(err)
 					}
@@ -490,7 +491,7 @@ profiles:
 			options: &Options{
 				ConfigFile: oldConfigFile,
 				ComponentConfig: func() kubeschedulerconfig.KubeSchedulerConfiguration {
-					cfg, err := newDefaultComponentConfig()
+					cfg, err := latest.Default()
 					if err != nil {
 						t.Fatal(err)
 					}
@@ -520,7 +521,7 @@ profiles:
 			name: "kubeconfig flag",
 			options: &Options{
 				ComponentConfig: func() kubeschedulerconfig.KubeSchedulerConfiguration {
-					cfg, _ := newDefaultComponentConfig()
+					cfg, _ := latest.Default()
 					cfg.ClientConnection.Kubeconfig = flagKubeconfig
 					return *cfg
 				}(),
@@ -593,7 +594,7 @@ profiles:
 			name: "overridden master",
 			options: &Options{
 				ComponentConfig: func() kubeschedulerconfig.KubeSchedulerConfiguration {
-					cfg, _ := newDefaultComponentConfig()
+					cfg, _ := latest.Default()
 					cfg.ClientConnection.Kubeconfig = flagKubeconfig
 					return *cfg
 				}(),

--- a/pkg/scheduler/apis/config/latest/latest.go
+++ b/pkg/scheduler/apis/config/latest/latest.go
@@ -1,0 +1,43 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package latest
+
+import (
+	"k8s.io/component-base/config/v1alpha1"
+	"k8s.io/kube-scheduler/config/v1beta2"
+	"k8s.io/kubernetes/pkg/scheduler/apis/config"
+	"k8s.io/kubernetes/pkg/scheduler/apis/config/scheme"
+)
+
+// Default creates a default configuration of the latset versioned type.
+// This function needs to be updated whenever we bump the scheduler's component config version.
+func Default() (*config.KubeSchedulerConfiguration, error) {
+	versionedCfg := v1beta2.KubeSchedulerConfiguration{}
+	versionedCfg.DebuggingConfiguration = *v1alpha1.NewRecommendedDebuggingConfiguration()
+
+	scheme.Scheme.Default(&versionedCfg)
+	cfg := config.KubeSchedulerConfiguration{}
+	if err := scheme.Scheme.Convert(&versionedCfg, &cfg, nil); err != nil {
+		return nil, err
+	}
+	// We don't set this field in pkg/scheduler/apis/config/{version}/conversion.go
+	// because the field will be cleared later by API machinery during
+	// conversion. See KubeSchedulerConfiguration internal type definition for
+	// more details.
+	cfg.TypeMeta.APIVersion = v1beta2.SchemeGroupVersion.String()
+	return &cfg, nil
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Adds a function that returns the default scheduler configuration. This is needed to simplify cluster autoscaler importing of the default set of filters required when simulating pod scheduler in CA.

#### Which issue(s) this PR fixes:
Part of # https://github.com/kubernetes/autoscaler/issues/4160

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

