### PR TITLE
Fix "should not mistakenly treat 'protocol: SCTP' as 'protocol: TCP', even if the plugin doesn't support SCTP" test

### DIFF
--- a/test/e2e/network/netpol/network_policy.go
+++ b/test/e2e/network/netpol/network_policy.go
@@ -1064,8 +1064,8 @@ var _ = common.SIGDescribe("Netpol", func() {
 		// traffic that is supposed to be blocked.
 		ginkgo.It("should not mistakenly treat 'protocol: SCTP' as 'protocol: TCP', even if the plugin doesn't support SCTP [Feature:NetworkPolicy]", func() {
 			nsX, _, _, model, k8s := getK8SModel(f)
-
 			ginkgo.By("Creating a default-deny ingress policy.")
+			// Empty podSelector blocks the entire namespace
 			policy := GenNetworkPolicyWithNameAndPodSelector("deny-ingress", metav1.LabelSelector{}, SetSpecIngressRules())
 			CreatePolicy(k8s, policy, nsX)
 
@@ -1077,7 +1077,7 @@ var _ = common.SIGDescribe("Netpol", func() {
 
 			ginkgo.By("Trying to connect to TCP port 81, which should be blocked by the deny-ingress policy.")
 			reachability := NewReachability(model.AllPods(), true)
-			reachability.ExpectAllIngress(NewPodString(nsX, "a"), false)
+			reachability.ExpectPeer(&Peer{}, &Peer{Namespace: nsX}, false)
 			ValidateOrFail(k8s, model, &TestCase{ToPort: 81, Protocol: v1.ProtocolTCP, Reachability: reachability})
 		})
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind failing-test

Optionally add one or more of the following kinds if applicable:

/kind failing-test

-->

#### What this PR does / why we need it:
To fix this failing test "should not mistakenly treat 'protocol: SCTP' as 'protocol: TCP', even if the plugin doesn't support SCTP" in https://github.com/kubernetes/kubernetes/blob/master/test/e2e/network/netpol/network_policy.go
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
To reproduce the test failure I did the following:
```
Get a kind cluster up with calico as cni from https://github.com/jayunit100/k8sprototypes/blob/master/kind/kind-local-up.sh
Run `make WHAT=test/e2e/e2e.test && ./_output/local/bin/linux/amd64/e2e.test --provider=local --kubeconfig=/home/rajas/.kube/config --ginkgo.focus="should not mistakenly treat"`
```
This test fails because it tries to apply a deny-ingress rule to all the pods of the namespace and then add only one of them in the reachability matrix

I couldn't find a job which runs this test
#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
