### PR TITLE
Automated cherry pick of #102665: Add explicit capability for online volume expansion

### DIFF
--- a/test/e2e/storage/drivers/csi.go
+++ b/test/e2e/storage/drivers/csi.go
@@ -118,8 +118,14 @@ func InitHostPathCSIDriver() testsuites.TestDriver {
 		testsuites.CapBlock:               true,
 		testsuites.CapPVCDataSource:       true,
 		testsuites.CapControllerExpansion: true,
+		testsuites.CapOnlineExpansion:     true,
 		testsuites.CapSingleNodeVolume:    true,
-		testsuites.CapVolumeLimits:        true,
+
+		// This is needed for the
+		// testsuites/volumelimits.go `should support volume limits`
+		// test. --maxvolumespernode=10 gets
+		// added when patching the deployment.
+		testsuites.CapVolumeLimits: true,
 	}
 	return initHostPathCSIDriver("csi-hostpath",
 		capabilities,
@@ -518,6 +524,7 @@ func InitGcePDCSIDriver() testsuites.TestDriver {
 				testsuites.CapVolumeLimits:        false,
 				testsuites.CapTopology:            true,
 				testsuites.CapControllerExpansion: true,
+				testsuites.CapOnlineExpansion:     true,
 				testsuites.CapNodeExpansion:       true,
 				testsuites.CapSnapshotDataSource:  true,
 			},

--- a/test/e2e/storage/drivers/in_tree.go
+++ b/test/e2e/storage/drivers/in_tree.go
@@ -1255,6 +1255,7 @@ func InitGcePdDriver() testsuites.TestDriver {
 				testsuites.CapMultiPODs:           true,
 				testsuites.CapControllerExpansion: true,
 				testsuites.CapNodeExpansion:       true,
+				testsuites.CapOnlineExpansion:     true,
 				// GCE supports volume limits, but the test creates large
 				// number of volumes and times out test suites.
 				testsuites.CapVolumeLimits: false,
@@ -1697,6 +1698,7 @@ func InitAwsDriver() testsuites.TestDriver {
 				testsuites.CapMultiPODs:           true,
 				testsuites.CapControllerExpansion: true,
 				testsuites.CapNodeExpansion:       true,
+				testsuites.CapOnlineExpansion:     true,
 				// AWS supports volume limits, but the test creates large
 				// number of volumes and times out test suites.
 				testsuites.CapVolumeLimits: false,

--- a/test/e2e/storage/external/external.go
+++ b/test/e2e/storage/external/external.go
@@ -197,6 +197,14 @@ func loadDriverDefinition(filename string) (*driverDefinition, error) {
 	if err := runtime.DecodeInto(scheme.Codecs.UniversalDecoder(), data, driver); err != nil {
 		return nil, errors.Wrap(err, filename)
 	}
+
+	// to ensure backward compatibility if controller expansion is enabled then set online expansion to true
+	if _, ok := driver.GetDriverInfo().Capabilities[testsuites.CapOnlineExpansion]; !ok &&
+		driver.GetDriverInfo().Capabilities[testsuites.CapControllerExpansion] {
+		caps := driver.DriverInfo.Capabilities
+		caps[testsuites.CapOnlineExpansion] = true
+		driver.DriverInfo.Capabilities = caps
+	}
 	return driver, nil
 }
 

--- a/test/e2e/storage/testsuites/testdriver.go
+++ b/test/e2e/storage/testsuites/testdriver.go
@@ -151,6 +151,7 @@ const (
 	CapRWX                 Capability = "RWX"                 // support ReadWriteMany access modes
 	CapControllerExpansion Capability = "controllerExpansion" // support volume expansion for controller
 	CapNodeExpansion       Capability = "nodeExpansion"       // support volume expansion for node
+	CapOnlineExpansion     Capability = "onlineExpansion"     // supports online volume expansion
 	CapVolumeLimits        Capability = "volumeLimits"        // support volume limits (can be *very* slow)
 	CapSingleNodeVolume    Capability = "singleNodeVolume"    // support volume that can run on single node (like hostpath)
 	CapTopology            Capability = "topology"            // support topology

--- a/test/e2e/storage/testsuites/volume_expand.go
+++ b/test/e2e/storage/testsuites/volume_expand.go
@@ -242,6 +242,10 @@ func (v *volumeExpandTestSuite) DefineTests(driver TestDriver, pattern testpatte
 			init()
 			defer cleanup()
 
+			if !driver.GetDriverInfo().Capabilities[CapOnlineExpansion] {
+				e2eskipper.Skipf("Driver %q does not support online volume expansion - skipping", driver.GetDriverInfo().Name)
+			}
+
 			var err error
 			ginkgo.By("Creating a pod with dynamically provisioned volume")
 			podConfig := e2epod.Config{


### PR DESCRIPTION
Cherry pick of #102665 on release-1.20.

#102665: Add explicit capability for online volume expansion

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.