### PR TITLE
Optimize scheduler res scorer on non-requested extended res

### DIFF
--- a/pkg/scheduler/framework/plugins/noderesources/least_allocated.go
+++ b/pkg/scheduler/framework/plugins/noderesources/least_allocated.go
@@ -95,7 +95,8 @@ func NewLeastAllocated(laArgs runtime.Object, h framework.Handle, fts feature.Fe
 func leastResourceScorer(resToWeightMap resourceToWeightMap) func(resourceToValueMap, resourceToValueMap) int64 {
 	return func(requested, allocable resourceToValueMap) int64 {
 		var nodeScore, weightSum int64
-		for resource, weight := range resToWeightMap {
+		for resource := range requested {
+			weight := resToWeightMap[resource]
 			resourceScore := leastRequestedScore(requested[resource], allocable[resource])
 			nodeScore += resourceScore * weight
 			weightSum += weight

--- a/pkg/scheduler/framework/plugins/noderesources/most_allocated.go
+++ b/pkg/scheduler/framework/plugins/noderesources/most_allocated.go
@@ -93,7 +93,8 @@ func NewMostAllocated(maArgs runtime.Object, h framework.Handle, fts feature.Fea
 func mostResourceScorer(resToWeightMap resourceToWeightMap) func(requested, allocable resourceToValueMap) int64 {
 	return func(requested, allocable resourceToValueMap) int64 {
 		var nodeScore, weightSum int64
-		for resource, weight := range resToWeightMap {
+		for resource := range requested {
+			weight := resToWeightMap[resource]
 			resourceScore := mostRequestedScore(requested[resource], allocable[resource])
 			nodeScore += resourceScore * weight
 			weightSum += weight
@@ -101,7 +102,7 @@ func mostResourceScorer(resToWeightMap resourceToWeightMap) func(requested, allo
 		if weightSum == 0 {
 			return 0
 		}
-		return (nodeScore / weightSum)
+		return nodeScore / weightSum
 	}
 }
 

--- a/pkg/scheduler/framework/plugins/noderesources/requested_to_capacity_ratio.go
+++ b/pkg/scheduler/framework/plugins/noderesources/requested_to_capacity_ratio.go
@@ -125,7 +125,8 @@ func buildRequestedToCapacityRatioScorerFunction(scoringFunctionShape helper.Fun
 	}
 	return func(requested, allocable resourceToValueMap) int64 {
 		var nodeScore, weightSum int64
-		for resource, weight := range resourceToWeightMap {
+		for resource := range requested {
+			weight := resourceToWeightMap[resource]
 			resourceScore := resourceScoringFunction(requested[resource], allocable[resource])
 			if resourceScore > 0 {
 				nodeScore += resourceScore * weight

--- a/pkg/scheduler/framework/plugins/noderesources/requested_to_capacity_ratio_test.go
+++ b/pkg/scheduler/framework/plugins/noderesources/requested_to_capacity_ratio_test.go
@@ -191,7 +191,6 @@ func TestResourceBinPackingSingleExtended(t *testing.T) {
 	extendedResource1 := map[string]int64{
 		"intel.com/foo": 4,
 	}
-
 	extendedResource2 := map[string]int64{
 		"intel.com/foo": 8,
 	}
@@ -231,27 +230,13 @@ func TestResourceBinPackingSingleExtended(t *testing.T) {
 		name         string
 	}{
 		{
-
-			//  Node1 scores (used resources) on 0-MaxNodeScore scale
-			//  Node1 Score:
-			//  rawScoringFunction(used + requested / available)
-			//  resourceScoringFunction((0+0),8)
-			//      = 0/8 * maxUtilization = 0 = rawScoringFunction(0)
-			//  Node1 Score: 0
-			//  Node2 scores (used resources) on 0-MaxNodeScore scale
-			//  rawScoringFunction(used + requested / available)
-			//  resourceScoringFunction((0+0),4)
-			//      = 0/4 * maxUtilization = 0 = rawScoringFunction(0)
-			//  Node2 Score: 0
-
+			//  Node1 Score = Node2 Score = 0 as the incoming Pod doesn't request extended resource.
 			pod:          &v1.Pod{Spec: noResources},
 			nodes:        []*v1.Node{makeNodeWithExtendedResource("machine1", 4000, 10000*1024*1024, extendedResource2), makeNodeWithExtendedResource("machine2", 4000, 10000*1024*1024, extendedResource1)},
 			expectedList: []framework.NodeScore{{Name: "machine1", Score: 0}, {Name: "machine2", Score: 0}},
 			name:         "nothing scheduled, nothing requested",
 		},
-
 		{
-
 			// Node1 scores (used resources) on 0-MaxNodeScore scale
 			// Node1 Score:
 			// rawScoringFunction(used + requested / available)
@@ -263,7 +248,6 @@ func TestResourceBinPackingSingleExtended(t *testing.T) {
 			// resourceScoringFunction((0+2),4)
 			//  = 2/4 * maxUtilization = 50 = rawScoringFunction(50)
 			// Node2 Score: 5
-
 			pod:          &v1.Pod{Spec: extendedResourcePod1},
 			nodes:        []*v1.Node{makeNodeWithExtendedResource("machine1", 4000, 10000*1024*1024, extendedResource2), makeNodeWithExtendedResource("machine2", 4000, 10000*1024*1024, extendedResource1)},
 			expectedList: []framework.NodeScore{{Name: "machine1", Score: 2}, {Name: "machine2", Score: 5}},
@@ -272,9 +256,7 @@ func TestResourceBinPackingSingleExtended(t *testing.T) {
 				{Spec: noResources},
 			},
 		},
-
 		{
-
 			// Node1 scores (used resources) on 0-MaxNodeScore scale
 			// Node1 Score:
 			// rawScoringFunction(used + requested / available)
@@ -286,7 +268,6 @@ func TestResourceBinPackingSingleExtended(t *testing.T) {
 			// resourceScoringFunction((2+2),4)
 			//  = 4/4 * maxUtilization = maxUtilization = rawScoringFunction(maxUtilization)
 			// Node2 Score: 10
-
 			pod:          &v1.Pod{Spec: extendedResourcePod1},
 			nodes:        []*v1.Node{makeNodeWithExtendedResource("machine1", 4000, 10000*1024*1024, extendedResource2), makeNodeWithExtendedResource("machine2", 4000, 10000*1024*1024, extendedResource1)},
 			expectedList: []framework.NodeScore{{Name: "machine1", Score: 2}, {Name: "machine2", Score: 10}},
@@ -295,9 +276,7 @@ func TestResourceBinPackingSingleExtended(t *testing.T) {
 				{Spec: machine2Pod},
 			},
 		},
-
 		{
-
 			// Node1 scores (used resources) on 0-MaxNodeScore scale
 			// Node1 Score:
 			// rawScoringFunction(used + requested / available)
@@ -309,7 +288,6 @@ func TestResourceBinPackingSingleExtended(t *testing.T) {
 			// resourceScoringFunction((0+4),4)
 			//  = 4/4 * maxUtilization = maxUtilization = rawScoringFunction(maxUtilization)
 			// Node2 Score: 10
-
 			pod:          &v1.Pod{Spec: extendedResourcePod2},
 			nodes:        []*v1.Node{makeNodeWithExtendedResource("machine1", 4000, 10000*1024*1024, extendedResource2), makeNodeWithExtendedResource("machine2", 4000, 10000*1024*1024, extendedResource1)},
 			expectedList: []framework.NodeScore{{Name: "machine1", Score: 5}, {Name: "machine2", Score: 10}},


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/sig scheduling

#### What this PR does / why we need it:

In a heterogeneous cluster, extended (scarce) resources may be defined in some nodes only. We know the best practice is to taint these "scarce" nodes so that only Pods with mapped toleration can be scheduled onto these nodes. However, this is not always the case, if taints are not managed well, some Pods without requesting scarce resource may be scheduled to the nodes with scarce resource, as revealed in #102154.

This PR introduced an enhancement on the resource scorer to bypass the extended resource usage smartly - which used to be calculated as a scoring factor at all times. So if a Pod doesn't request an extended resource, **all** nodes behave like they don't have that extended resource.

#### Which issue(s) this PR fixes:

Fixes #102154

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
Extended resources defined in LeastAllocated, MostAllocated and RequestedToCapacityRatio plugin argument are bypassed by the scheduler if the incoming Pod doesn't request them in the pod spec.
```