### PR TITLE
limitrange: skip default limit setting if container's request is larger

### DIFF
--- a/plugin/pkg/admission/limitranger/admission.go
+++ b/plugin/pkg/admission/limitranger/admission.go
@@ -558,7 +558,10 @@ func PodValidateLimitFunc(limitRange *corev1.LimitRange, pod *api.Pod) error {
 					}
 				}
 			}
-		} else if limitType == corev1.LimitTypePod { // enforce pod limits on init containers
+		}
+
+		// enforce pod limits on init containers
+		if limitType == corev1.LimitTypePod {
 			containerRequests, containerLimits := []api.ResourceList{}, []api.ResourceList{}
 			for j := range pod.Spec.Containers {
 				container := &pod.Spec.Containers[j]

--- a/plugin/pkg/admission/limitranger/admission_test.go
+++ b/plugin/pkg/admission/limitranger/admission_test.go
@@ -227,7 +227,9 @@ func TestMergePodResourceRequirements(t *testing.T) {
 			api.ResourceCPU:    defaultRequirements.Requests[api.ResourceCPU],
 			api.ResourceMemory: resource.MustParse("512Mi"),
 		},
-		Limits: defaultRequirements.Limits,
+		Limits: api.ResourceList{
+			api.ResourceCPU: defaultRequirements.Limits[api.ResourceCPU],
+		},
 	}
 	mergePodResourceRequirements(&pod, &defaultRequirements)
 	for i := range pod.Spec.Containers {
@@ -242,7 +244,7 @@ func TestMergePodResourceRequirements(t *testing.T) {
 			t.Errorf("pod %v, expected != actual; %v != %v", pod.Name, expected, actual)
 		}
 	}
-	verifyAnnotation(t, &pod, "LimitRanger plugin set: cpu request for container foo-0; cpu, memory limit for container foo-0")
+	verifyAnnotation(t, &pod, "LimitRanger plugin set: cpu request for container foo-0; cpu limit for container foo-0")
 
 	// pod with all resources enumerated should not merge anything
 	input = getResourceRequirements(getComputeResourceList("100m", "512Mi"), getComputeResourceList("200m", "1G"))


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
for mistakenly closing  #98295
**What this PR does / why we need it**:
default limit sometimes acts as max limit #51430

**Which issue(s) this PR fixes**:
Fixes #51430 

**Special notes for your reviewer**:
Default settings is not enforced as max or min.

The quota in the namespace is by default 500MB limit.
So if a user wants to create a pod with a memory request of 1GB, it should not fail.

- Current Behavior: pod failed with the default 500MB limit, as it is not larger than the requested 1GB.
- Expected: no limit for this pod.
- 

**Does this PR introduce a user-facing change?**:
```release-note
ignore default limit if container's request is larger
```

/priority important-longterm
/triage accepted
/cc  @ehashman 
/assign @deads2k @derekwaynecarr
