### PR TITLE
Services tests for NodePorts must match the Node Address and Service IP family

### DIFF
--- a/test/e2e/network/conntrack.go
+++ b/test/e2e/network/conntrack.go
@@ -105,11 +105,9 @@ var _ = common.SIGDescribe("Conntrack", func() {
 				len(nodes.Items))
 		}
 
-		var family v1.IPFamily
+		family := v1.IPv4Protocol
 		if framework.TestContext.ClusterIsIPv6() {
 			family = v1.IPv6Protocol
-		} else {
-			family = v1.IPv4Protocol
 		}
 
 		ips := e2enode.GetAddressesByTypeAndFamily(&nodes.Items[0], v1.NodeInternalIP, family)


### PR DESCRIPTION

/kind bug
/kind failing-test

```release-note
NONE
```

Services affinity test wasn't taking into account the Service IP family for testing the NodePort services.
This causes the Affinity test that have single-stack services in a dual-stack cluster to fail, because an IPv6 Service only, will not work in an IPv4 node address, we don't translate IP families :smile: 