### PR TITLE
Renamed variable within wait_test containing master to control plane

### DIFF
--- a/test/e2e/framework/node/wait_test.go
+++ b/test/e2e/framework/node/wait_test.go
@@ -31,7 +31,7 @@ import (
 // since single node checks are in TestReadyForTests.
 func TestCheckReadyForTests(t *testing.T) {
 	// This is a duplicate definition of the constant in pkg/controller/service/controller.go
-	labelNodeRoleControlPlane := "node-role.kubernetes.io/controlPlane"
+	labelNodeRoleControlPlane := "node-role.kubernetes.io/control-plane"
 
 	fromVanillaNode := func(f func(*v1.Node)) v1.Node {
 		vanillaNode := &v1.Node{
@@ -63,7 +63,7 @@ func TestCheckReadyForTests(t *testing.T) {
 			expected: true,
 		}, {
 			desc:              "Default value for nonblocking taints tolerates control plane taint",
-			nonblockingTaints: `node-role.kubernetes.io/controlPlane`,
+			nonblockingTaints: `node-role.kubernetes.io/control-plane`,
 			nodes: []v1.Node{
 				fromVanillaNode(func(n *v1.Node) {
 					n.Spec.Taints = []v1.Taint{{Key: labelNodeRoleControlPlane, Effect: v1.TaintEffectNoSchedule}}

--- a/test/e2e/framework/node/wait_test.go
+++ b/test/e2e/framework/node/wait_test.go
@@ -31,7 +31,7 @@ import (
 // since single node checks are in TestReadyForTests.
 func TestCheckReadyForTests(t *testing.T) {
 	// This is a duplicate definition of the constant in pkg/controller/service/controller.go
-	labelNodeRoleMaster := "node-role.kubernetes.io/master"
+	labelNodeRoleControlPlane := "node-role.kubernetes.io/controlPlane"
 
 	fromVanillaNode := func(f func(*v1.Node)) v1.Node {
 		vanillaNode := &v1.Node{
@@ -62,11 +62,11 @@ func TestCheckReadyForTests(t *testing.T) {
 			},
 			expected: true,
 		}, {
-			desc:              "Default value for nonblocking taints tolerates master taint",
-			nonblockingTaints: `node-role.kubernetes.io/master`,
+			desc:              "Default value for nonblocking taints tolerates control plane taint",
+			nonblockingTaints: `node-role.kubernetes.io/controlPlane`,
 			nodes: []v1.Node{
 				fromVanillaNode(func(n *v1.Node) {
-					n.Spec.Taints = []v1.Taint{{Key: labelNodeRoleMaster, Effect: v1.TaintEffectNoSchedule}}
+					n.Spec.Taints = []v1.Taint{{Key: labelNodeRoleControlPlane, Effect: v1.TaintEffectNoSchedule}}
 				}),
 			},
 			expected: true,


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/wg naming
/sig testing
/area test

#### What this PR does / why we need it:

Refactors variables containing "master" to "controlplane".

#### Which issue(s) this PR fixes:
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs

```