### PR TITLE
Appended OS's environment variables to the ones configured in Credent…

### DIFF
--- a/pkg/credentialprovider/plugin/plugin.go
+++ b/pkg/credentialprovider/plugin/plugin.go
@@ -135,6 +135,7 @@ func newPluginProvider(pluginBinDir string, provider kubeletconfig.CredentialPro
 			pluginBinDir: pluginBinDir,
 			args:         provider.Args,
 			envVars:      provider.Env,
+			environ:      os.Environ,
 		},
 	}, nil
 }
@@ -354,6 +355,7 @@ type execPlugin struct {
 	args         []string
 	envVars      []kubeletconfig.ExecEnvVar
 	pluginBinDir string
+	environ      func() []string
 }
 
 // ExecPlugin executes the plugin binary with arguments and environment variables specified in CredentialProviderConfig:
@@ -385,10 +387,16 @@ func (e *execPlugin) ExecPlugin(ctx context.Context, image string) (*credentialp
 	cmd := exec.CommandContext(ctx, filepath.Join(e.pluginBinDir, e.name), e.args...)
 	cmd.Stdout, cmd.Stderr, cmd.Stdin = stdout, stderr, stdin
 
-	cmd.Env = []string{}
-	for _, envVar := range e.envVars {
-		cmd.Env = append(cmd.Env, fmt.Sprintf("%s=%s", envVar.Name, envVar.Value))
+	var configEnvVars []string
+	for _, v := range e.envVars {
+		configEnvVars = append(configEnvVars, fmt.Sprintf("%s=%s", v.Name, v.Value))
 	}
+
+	// Append current system environment variables, to the ones configured in the
+	// credential provider file. Failing to do so may result in unsuccessful execution
+	// of the provider binary, see https://github.com/kubernetes/kubernetes/issues/102750
+	// also, this behaviour is inline with Credential Provider Config spec
+	cmd.Env = mergeEnvVars(e.environ(), configEnvVars)
 
 	err = cmd.Run()
 	if ctx.Err() != nil {
@@ -456,4 +464,15 @@ func (e *execPlugin) decodeResponse(data []byte) (*credentialproviderapi.Credent
 func parseRegistry(image string) string {
 	imageParts := strings.Split(image, "/")
 	return imageParts[0]
+}
+
+// mergedEnvVars overlays system defined env vars with credential provider env vars,
+// it gives priority to the credential provider vars allowing user to override system
+// env vars
+func mergeEnvVars(sysEnvVars, credProviderVars []string) []string {
+	mergedEnvVars := sysEnvVars
+	for _, credProviderVar := range credProviderVars {
+		mergedEnvVars = append(mergedEnvVars, credProviderVar)
+	}
+	return mergedEnvVars
 }

--- a/pkg/credentialprovider/plugin/plugin_test.go
+++ b/pkg/credentialprovider/plugin/plugin_test.go
@@ -18,7 +18,9 @@ package plugin
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	kubeletconfig "k8s.io/kubernetes/pkg/kubelet/apis/config"
 	"reflect"
 	"sync"
 	"testing"
@@ -712,4 +714,111 @@ func Test_NoCacheResponse(t *testing.T) {
 		t.Logf("expected cache keys: %v", expectedCacheKeys)
 		t.Error("unexpected cache keys")
 	}
+}
+
+func Test_ExecPluginEnvVars(t *testing.T) {
+	testcases := []struct {
+		name            string
+		systemEnvVars   []string
+		execPlugin      *execPlugin
+		expectedEnvVars []string
+	}{
+		{
+			name:          "positive append system env vars",
+			systemEnvVars: []string{"HOME=/home/foo", "PATH=/usr/bin"},
+			execPlugin: &execPlugin{
+				envVars: []kubeletconfig.ExecEnvVar{
+					{
+						Name:  "SUPER_SECRET_STRONG_ACCESS_KEY",
+						Value: "123456789",
+					},
+				},
+			},
+			expectedEnvVars: []string{
+				"HOME=/home/foo",
+				"PATH=/usr/bin",
+				"SUPER_SECRET_STRONG_ACCESS_KEY=123456789",
+			},
+		},
+		{
+			name:          "positive no env vars provided in plugin",
+			systemEnvVars: []string{"HOME=/home/foo", "PATH=/usr/bin"},
+			execPlugin:    &execPlugin{},
+			expectedEnvVars: []string{
+				"HOME=/home/foo",
+				"PATH=/usr/bin",
+			},
+		},
+		{
+			name: "positive no system env vars but env vars are provided in plugin",
+			execPlugin: &execPlugin{
+				envVars: []kubeletconfig.ExecEnvVar{
+					{
+						Name:  "SUPER_SECRET_STRONG_ACCESS_KEY",
+						Value: "123456789",
+					},
+				},
+			},
+			expectedEnvVars: []string{
+				"SUPER_SECRET_STRONG_ACCESS_KEY=123456789",
+			},
+		},
+		{
+			name:            "positive no system or plugin provided env vars",
+			execPlugin:      &execPlugin{},
+			expectedEnvVars: nil,
+		},
+		{
+			name:          "positive plugin provided vars takes priority",
+			systemEnvVars: []string{"HOME=/home/foo", "PATH=/usr/bin", "SUPER_SECRET_STRONG_ACCESS_KEY=1111"},
+			execPlugin: &execPlugin{
+				envVars: []kubeletconfig.ExecEnvVar{
+					{
+						Name:  "SUPER_SECRET_STRONG_ACCESS_KEY",
+						Value: "123456789",
+					},
+				},
+			},
+			expectedEnvVars: []string{
+				"HOME=/home/foo",
+				"PATH=/usr/bin",
+				"SUPER_SECRET_STRONG_ACCESS_KEY=1111",
+				"SUPER_SECRET_STRONG_ACCESS_KEY=123456789",
+			},
+		},
+	}
+
+	for _, testcase := range testcases {
+		t.Run(testcase.name, func(t *testing.T) {
+			testcase.execPlugin.environ = func() []string {
+				return testcase.systemEnvVars
+			}
+
+			var configVars []string
+			for _, envVar := range testcase.execPlugin.envVars {
+				configVars = append(configVars, fmt.Sprintf("%s=%s", envVar.Name, envVar.Value))
+			}
+			merged := mergeEnvVars(testcase.systemEnvVars, configVars)
+
+			err := validate(testcase.expectedEnvVars, merged)
+			if err != nil {
+				t.Logf("unexpecged error %v", err)
+			}
+		})
+	}
+}
+
+func validate(expected, actual []string) error {
+	if len(actual) != len(expected) {
+		return errors.New(fmt.Sprintf("actual env var length [%d] and expected env var length [%d] don't match",
+			len(actual), len(expected)))
+	}
+
+	for i := range actual {
+		if actual[i] != expected[i] {
+			return fmt.Errorf("mismatch in expected env var %s and actual env var %s", actual[i], expected[i])
+		}
+	}
+
+	return nil
 }


### PR DESCRIPTION
1. Appended OS's environment variables with the ones provided in the Credential Provider Config file
2. Wrote UnitTest cases to validate the above behaviour
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
According to the behaviour described in the `kubelete-credential-provider` [documentation](https://kubernetes.io/docs/tasks/kubelet-credential-provider/kubelet-credential-provider/#configure-a-kubelet-credential-provider), the environment variables provided in the config file should be appended with the OS env vars.

However, this seems to be a missed out case and credential providers may fail to execute if `$PATH` and `$HOME` are missing.

This bug was verified for `ecr-credential-provider`

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes/kubernetes/issues/102750

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fixed an issue which didn't append OS's environment variables with the one provided in Credential Provider Config file, which may lead to failed execution of external credential provider binary. 
See https://github.com/kubernetes/kubernetes/issues/102750
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
