### PR TITLE
Fix delete nil pointer panic

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/registry/rest/delete.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/rest/delete.go
@@ -57,6 +57,8 @@ type GarbageCollectionDeleteStrategy interface {
 type RESTGracefulDeleteStrategy interface {
 	// CheckGracefulDelete should return true if the object can be gracefully deleted and set
 	// any default values on the DeleteOptions.
+	// NOTE: if return true, `options.GracePeriodSeconds` must be non-nil (nil will fail),
+	// that's what tells the deletion how "graceful" to be.
 	CheckGracefulDelete(ctx context.Context, obj runtime.Object, options *metav1.DeleteOptions) bool
 }
 
@@ -126,9 +128,15 @@ func BeforeDelete(strategy RESTDeleteStrategy, ctx context.Context, obj runtime.
 		return false, true, nil
 	}
 
+	// `CheckGracefulDelete` will be implemented by specific strategy
 	if !gracefulStrategy.CheckGracefulDelete(ctx, obj, options) {
 		return false, false, nil
 	}
+
+	if options.GracePeriodSeconds == nil {
+		return false, false, errors.NewInternalError(fmt.Errorf("options.GracePeriodSeconds should not be nil"))
+	}
+
 	now := metav1.NewTime(metav1.Now().Add(time.Second * time.Duration(*options.GracePeriodSeconds)))
 	objectMeta.SetDeletionTimestamp(&now)
 	objectMeta.SetDeletionGracePeriodSeconds(options.GracePeriodSeconds)
@@ -139,6 +147,7 @@ func BeforeDelete(strategy RESTDeleteStrategy, ctx context.Context, obj runtime.
 	if objectMeta.GetGeneration() > 0 {
 		objectMeta.SetGeneration(objectMeta.GetGeneration() + 1)
 	}
+
 	return true, false, nil
 }
 


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
check if `options.GracePeriodSeconds` is nil to avoid delete panic

#### Which issue(s) this PR fixes:
Fixes #103228

#### Special notes for your reviewer:
Use apiserver extension(APIService) strategy, impl this function below will lead to panic:
```go
// just impl this method and return true, then will lead to delete resource panic
func (s Strategy) CheckGracefulDelete(ctx context.Context, obj runtime.Object, options *metav1.DeleteOptions) bool {
	return true
}
```

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### SIG labels
- sig apiserver
- sig api-machinery
