### PR TITLE
apf: add additional latency into work estimate

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/request/width.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/request/width.go
@@ -19,6 +19,7 @@ package request
 import (
 	"fmt"
 	"net/http"
+	"time"
 
 	apirequest "k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/klog/v2"
@@ -35,6 +36,12 @@ const (
 type WorkEstimate struct {
 	// Seats represents the number of seats associated with this request
 	Seats uint
+
+	// AdditionalLatency specifies the additional duration the seats allocated
+	// to this request must be reserved after the given request had finished.
+	// AdditionalLatency should not have any impact on the user experience, the
+	// caller must not experience this additional latency.
+	AdditionalLatency time.Duration
 }
 
 // objectCountGetterFunc represents a function that gets the total


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:
add additional latency into `width` for a request 

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
