### PR TITLE
Promote to Conformance StatefulSet List, Patch & DeleteCollection Test +3

### DIFF
--- a/test/conformance/testdata/conformance.yaml
+++ b/test/conformance/testdata/conformance.yaml
@@ -889,6 +889,14 @@
     scale MUST be at two replicas.
   release: v1.16, v1.21
   file: test/e2e/apps/statefulset.go
+- testname: StatefulSet, list, patch and delete a collection of StatefulSets
+  codename: '[sig-apps] StatefulSet Basic StatefulSet functionality [StatefulSetBasic]
+    should list, patch and delete a collection of StatefulSets [Conformance]'
+  description: When a StatefulSet is created it MUST succeed. It MUST succeed when
+    listing StatefulSets via a label selector. It MUST succeed when patching a StatefulSet.
+    It MUST succeed when deleting the StatefulSet via deleteCollection.
+  release: v1.22
+  file: test/e2e/apps/statefulset.go
 - testname: StatefulSet, Rolling Update with Partition
   codename: '[sig-apps] StatefulSet Basic StatefulSet functionality [StatefulSetBasic]
     should perform canary updates and phased rolling updates of template modifications

--- a/test/e2e/apps/statefulset.go
+++ b/test/e2e/apps/statefulset.go
@@ -892,7 +892,15 @@ var _ = SIGDescribe("StatefulSet", func() {
 			framework.ExpectEqual(*(ss.Spec.Replicas), int32(4), "statefulset should have 4 replicas")
 		})
 
-		ginkgo.It("should list, patch and delete a collection of StatefulSets", func() {
+		/*
+			Release: v1.22
+			Testname: StatefulSet, list, patch and delete a collection of StatefulSets
+			Description: When a StatefulSet is created it MUST succeed. It
+			MUST succeed when listing StatefulSets via a label selector. It
+			MUST succeed when patching a StatefulSet. It MUST succeed when
+			deleting the StatefulSet via deleteCollection.
+		*/
+		framework.ConformanceIt("should list, patch and delete a collection of StatefulSets", func() {
 
 			ssPatchReplicas := int32(2)
 			ssPatchImage := imageutils.GetE2EImage(imageutils.Pause)


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it:**
This PR adds a test to test the following untested endpoints:
- patchAppsV1NamespacedStatefulSet
- listAppsV1StatefulSetForAllNamespaces
- deleteAppsV1CollectionNamespacedStatefulSet

**Which issue(s) this PR fixes:**
Fixes #100727
**Testgrid Link:**
[Testgrid](https://k8s-testgrid.appspot.com/sig-release-master-blocking#gce-cos-master-default&width=5&include-filter-by-regex=should%20list,%20patch%20and%20delete%20a%20collection%20of%20StatefulSets&graph-metrics=test-duration-minutes)


**Special notes for your reviewer:**
Adds +3 endpoint test coverage (good for conformance)

**Does this PR introduce a user-facing change?:**
```
NONE

```

**Release note:**
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:**
```
NONE

```
/sig apps
/sig testing
/sig architecture
/area conformance