### PR TITLE
Promote to Conformance Patch, Read and Replace DeploymentStatus test +1

### DIFF
--- a/test/conformance/testdata/conformance.yaml
+++ b/test/conformance/testdata/conformance.yaml
@@ -714,6 +714,13 @@
     MUST succeed. It MUST succeed when deleting the Deployment.
   release: v1.20
   file: test/e2e/apps/deployment.go
+- testname: Deployment, status sub-resource
+  codename: '[sig-apps] Deployment should validate Deployment Status endpoints [Conformance]'
+  description: When a Deployment is created it MUST succeed. Attempt to read, update
+    and patch its status sub-resource; all mutating sub-resource operations MUST be
+    visible to subsequent reads.
+  release: v1.22
+  file: test/e2e/apps/deployment.go
 - testname: 'PodDisruptionBudget: list and delete collection'
   codename: '[sig-apps] DisruptionController Listing PodDisruptionBudgets for all
     namespaces should list and delete a collection of PodDisruptionBudgets [Conformance]'

--- a/test/e2e/apps/deployment.go
+++ b/test/e2e/apps/deployment.go
@@ -485,7 +485,14 @@ var _ = SIGDescribe("Deployment", func() {
 		framework.ExpectNoError(err, "failed to see %v event", watch.Deleted)
 	})
 
-	ginkgo.It("should validate Deployment Status endpoints", func() {
+	/*
+		Release: v1.22
+		Testname: Deployment, status sub-resource
+		Description: When a Deployment is created it MUST succeed.
+		Attempt to read, update and patch its status sub-resource; all
+		mutating sub-resource operations MUST be visible to subsequent reads.
+	*/
+	framework.ConformanceIt("should validate Deployment Status endpoints", func() {
 		dClient := c.AppsV1().Deployments(ns)
 		dName := "test-deployment-" + utilrand.String(5)
 		labelSelector := "e2e=testing"


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it:**
This PR adds a test to test the following untested endpoints:
- replaceAppsV1NamespacedDeploymentStatus

**Which issue(s) this PR fixes:**
Fixes #102258

**Testgrid Link:**
[Testgrid](https://k8s-testgrid.appspot.com/sig-release-master-blocking#gce-cos-master-default&width=5&include-filter-by-regex=should.validate.Deployment.Status.endpoints&graph-metrics=test-duration-minutes)


**Special notes for your reviewer:**
Adds +1 endpoint test coverage (good for conformance)

**Does this PR introduce a user-facing change?:**
```
NONE

```

**Release note:**
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:**
```
NONE

```

/sig testing
/sig architecture
/area conformance