### PR TITLE
Promote to Conformance StatefulSet Patch, Read and Replace Status test +3

### DIFF
--- a/test/conformance/testdata/conformance.yaml
+++ b/test/conformance/testdata/conformance.yaml
@@ -910,6 +910,14 @@
     StorageClass or a dynamic provisioner.
   release: v1.9
   file: test/e2e/apps/statefulset.go
+- testname: StatefulSet, status sub-resource
+  codename: '[sig-apps] StatefulSet Basic StatefulSet functionality [StatefulSetBasic]
+    should validate Statefulset Status endpoints [Conformance]'
+  description: When a StatefulSet is created it MUST succeed. Attempt to read, update
+    and patch its status sub-resource; all mutating sub-resource operations MUST be
+    visible to subsequent reads.
+  release: v1.22
+  file: test/e2e/apps/statefulset.go
 - testname: CertificateSigningRequest API
   codename: '[sig-auth] Certificates API [Privileged:ClusterAdmin] should support
     CSR API operations [Conformance]'

--- a/test/e2e/apps/statefulset.go
+++ b/test/e2e/apps/statefulset.go
@@ -954,7 +954,14 @@ var _ = SIGDescribe("StatefulSet", func() {
 			framework.ExpectEqual(len(ssList.Items), 0, "filtered list should have no Statefulsets")
 		})
 
-		ginkgo.It("should validate Statefulset Status endpoints", func() {
+		/*
+			Release: v1.22
+			Testname: StatefulSet, status sub-resource
+			Description: When a StatefulSet is created it MUST succeed.
+			Attempt to read, update and patch its status sub-resource; all
+			mutating sub-resource operations MUST be visible to subsequent reads.
+		*/
+		framework.ConformanceIt("should validate Statefulset Status endpoints", func() {
 			ssClient := c.AppsV1().StatefulSets(ns)
 			labelSelector := "e2e=testing"
 


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it:**
This PR adds a test to test the following untested endpoints:
- replaceAppsV1NamespacedStatefulSetStatus
- readAppsV1NamespacedStatefulSetStatus
- patchAppsV1NamespacedStatefulSetStatus

**Which issue(s) this PR fixes:**
Fixes #102255
**Testgrid Link:**
[Testgrid](https://k8s-testgrid.appspot.com/sig-release-master-blocking#gce-cos-master-default&width=5&include-filter-by-regex=should%20validate%20Statefulset%20Status%20endpoints&graph-metrics=test-duration-minutes) 

**Special notes for your reviewer:**
Adds +3 endpoint test coverage (good for conformance)

**Does this PR introduce a user-facing change?:**
```
NONE

```

**Release note:**
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:**
```
NONE

```

/sig testing
/sig architecture
/area conformance