### PR TITLE
apiextension: fix typo and test case in conversion integration test

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/conversion/conversion_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/conversion/conversion_test.go
@@ -677,7 +677,13 @@ func expectConversionFailureMessage(id, message string) func(t *testing.T, ctc *
 		if err != nil {
 			t.Fatal(err)
 		}
-		for _, verb := range []string{"get", "list", "create", "udpate", "patch", "delete", "deletecollection"} {
+
+		// manually convert
+		objv1beta2 := newConversionMultiVersionFixture(ns, id, "v1beta2")
+		meta, _, _ := unstructured.NestedFieldCopy(obj.Object, "metadata")
+		unstructured.SetNestedField(objv1beta2.Object, meta, "metadata")
+
+		for _, verb := range []string{"get", "list", "create", "update", "patch", "delete", "deletecollection"} {
 			t.Run(verb, func(t *testing.T) {
 				switch verb {
 				case "get":
@@ -687,13 +693,15 @@ func expectConversionFailureMessage(id, message string) func(t *testing.T, ctc *
 				case "create":
 					_, err = clients["v1beta2"].Create(context.TODO(), newConversionMultiVersionFixture(ns, id, "v1beta2"), metav1.CreateOptions{})
 				case "update":
-					_, err = clients["v1beta2"].Update(context.TODO(), obj, metav1.UpdateOptions{})
+					_, err = clients["v1beta2"].Update(context.TODO(), objv1beta2, metav1.UpdateOptions{})
 				case "patch":
 					_, err = clients["v1beta2"].Patch(context.TODO(), obj.GetName(), types.MergePatchType, []byte(`{"metadata":{"annotations":{"patch":"true"}}}`), metav1.PatchOptions{})
 				case "delete":
 					err = clients["v1beta2"].Delete(context.TODO(), obj.GetName(), metav1.DeleteOptions{})
 				case "deletecollection":
 					err = clients["v1beta2"].DeleteCollection(context.TODO(), metav1.DeleteOptions{}, metav1.ListOptions{})
+				default:
+					t.Errorf("unknown verb %q", verb)
 				}
 
 				if err == nil {
@@ -704,15 +712,32 @@ func expectConversionFailureMessage(id, message string) func(t *testing.T, ctc *
 			})
 		}
 		for _, subresource := range []string{"status", "scale"} {
-			for _, verb := range []string{"get", "udpate", "patch"} {
+			for _, verb := range []string{"get", "update", "patch"} {
 				t.Run(fmt.Sprintf("%s-%s", subresource, verb), func(t *testing.T) {
 					switch verb {
-					case "create":
-						_, err = clients["v1beta2"].Create(context.TODO(), newConversionMultiVersionFixture(ns, id, "v1beta2"), metav1.CreateOptions{}, subresource)
+					case "get":
+						_, err = clients["v1beta2"].Get(context.TODO(), obj.GetName(), metav1.GetOptions{}, subresource)
 					case "update":
-						_, err = clients["v1beta2"].Update(context.TODO(), obj, metav1.UpdateOptions{}, subresource)
+						o := objv1beta2
+						if subresource == "scale" {
+							o = &unstructured.Unstructured{
+								Object: map[string]interface{}{
+									"apiVersion": "autoscaling/v1",
+									"kind":       "Scale",
+									"metadata": map[string]interface{}{
+										"name": obj.GetName(),
+									},
+									"spec": map[string]interface{}{
+										"replicas": 42,
+									},
+								},
+							}
+						}
+						_, err = clients["v1beta2"].Update(context.TODO(), o, metav1.UpdateOptions{}, subresource)
 					case "patch":
 						_, err = clients["v1beta2"].Patch(context.TODO(), obj.GetName(), types.MergePatchType, []byte(`{"metadata":{"annotations":{"patch":"true"}}}`), metav1.PatchOptions{}, subresource)
+					default:
+						t.Errorf("unknown subresource verb %q", verb)
 					}
 
 					if err == nil {


### PR DESCRIPTION
Replaces #96967.

/kind bug
/kind failing-test

```release-note
NONE
```