### PR TITLE
custom-metrics: do cleanup even if the creation is not full succeed

### DIFF
--- a/test/e2e/autoscaling/custom_metrics_stackdriver_autoscaling.go
+++ b/test/e2e/autoscaling/custom_metrics_stackdriver_autoscaling.go
@@ -264,10 +264,10 @@ func (tc *CustomMetricTestCase) Run() {
 	defer monitoring.CleanupDescriptors(gcmService, projectID)
 
 	err = monitoring.CreateAdapter(monitoring.AdapterDefault)
+	defer monitoring.CleanupAdapter(monitoring.AdapterDefault)
 	if err != nil {
 		framework.Failf("Failed to set up: %v", err)
 	}
-	defer monitoring.CleanupAdapter(monitoring.AdapterDefault)
 
 	// Run application that exports the metric
 	err = createDeploymentToScale(tc.framework, tc.kubeClient, tc.deployment, tc.pod)


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup
/kind flake

#### What this PR does / why we need it:
https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-kubernetes-e2e-gci-gce-autoscaling-migs-hpa/1409378458580029440
```
stderr:
error: failed to create clusterrolebinding: clusterrolebindings.rbac.authorization.k8s.io "e2e-test-cluster-admin-binding" already exists
```
After a test case started to fail for https://github.com/GoogleCloudPlatform/k8s-stackdriver/pull/426, other test case failed for `"e2e-test-cluster-admin-binding" already exists`.

This is due to a cleanup that is not triaged. 
`CreateAdapter` is a function that has 2 steps:
- create clusterrolebindings
- create a bunch of things: `kubectl create -f`
When it failed, it may already created the crb and some data.
So we should do cleanup even the creation failed.

#### Special notes for your reviewer:
For other functions like single instance creation, you can skip the cleanup if the creation failed. 
For batch creation,  we should always do cleanup even the creation failed.


#### Does this PR introduce a user-facing change?
```release-note
NONE
```