### PR TITLE
Suppress 100+% overflow at the memory total usage ratio

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/metricsutil/metrics_printer.go
+++ b/staging/src/k8s.io/kubectl/pkg/metricsutil/metrics_printer.go
@@ -297,6 +297,10 @@ func printAllResourceUsages(out io.Writer, metrics *ResourceMetricsInfo) {
 		fmt.Fprint(out, "\t")
 		if available, found := metrics.Available[res]; found {
 			fraction := float64(quantity.MilliValue()) / float64(available.MilliValue()) * 100
+			// Set 100% if overflow
+			if fraction > 100.0 {
+				fraction = 100.0
+			}
 			fmt.Fprintf(out, "%d%%\t", int64(fraction))
 		}
 	}


### PR DESCRIPTION
#### What type of PR is this?
/kind bug
/kind design
/sig cli

#### What this PR does / why we need it:
Suppress wrong 100+% node memory total usage percent by "kubectl top node".

#### Which issue(s) this PR fixes:

Fixes #https://github.com/kubernetes/kubernetes/issues/86499

```console
// BEFORE
# kubectl top node
NAME                       CPU(cores)   CPU%   MEMORY(bytes)   MEMORY%   
:
k8s-s2xs4-worker-0-wj68h   282m         3%     8374Mi          230%      

// AFTER
# kubectl top node
NAME                       CPU(cores)   CPU%   MEMORY(bytes)   MEMORY%   
:
k8s-s2xs4-worker-0-wj68h   350m         4%     8375Mi          100%   
```
#### Special notes for your reviewer:

* This fix is also concerned the following PRs:
https://github.com/kubernetes/kubernetes/pull/100222
https://github.com/kubernetes/kubernetes/pull/102917

#### Does this PR introduce a user-facing change?
N/A

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
N/A
