### PR TITLE
upgrade staticcheck to v0.2.0 and update the static failure packages

### DIFF
--- a/hack/.staticcheck_failures
+++ b/hack/.staticcheck_failures
@@ -1,3 +1,8 @@
+pkg/kubelet/cm/cpuset
+pkg/util/flag
+test/e2e/apimachinery
+vendor/k8s.io/apimachinery/pkg/util/json
+vendor/k8s.io/apimachinery/pkg/util/strategicpatch
 vendor/k8s.io/apiserver/pkg/server/dynamiccertificates
 vendor/k8s.io/apiserver/pkg/server/filters
 vendor/k8s.io/apiserver/pkg/server/routes

--- a/hack/tools/go.mod
+++ b/hack/tools/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/google/go-flow-levee v0.1.5
 	gotest.tools v2.2.0+incompatible
 	gotest.tools/gotestsum v0.3.5
-	honnef.co/go/tools v0.0.1-2020.1.6
+	honnef.co/go/tools v0.2.0
 	k8s.io/klog/hack/tools v0.0.0-20210303110520-14dec3377f55
 	sigs.k8s.io/zeitgeist v0.2.0
 )

--- a/hack/tools/go.sum
+++ b/hack/tools/go.sum
@@ -907,8 +907,9 @@ honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWh
 honnef.co/go/tools v0.0.1-2019.2.3/go.mod h1:a3bituU0lyd329TUQxRnasdCoJDkEUEAqEt0JzvZhAg=
 honnef.co/go/tools v0.0.1-2020.1.3/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
 honnef.co/go/tools v0.0.1-2020.1.4/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
-honnef.co/go/tools v0.0.1-2020.1.6 h1:W18jzjh8mfPez+AwGLxmOImucz/IFjpNlrKVnaj2YVc=
 honnef.co/go/tools v0.0.1-2020.1.6/go.mod h1:pyyisuGw24ruLjrr1ddx39WE0y9OooInRzEYLhQB2YY=
+honnef.co/go/tools v0.2.0 h1:ws8AfbgTX3oIczLPNPCu5166oBg9ST2vNs0rcht+mDE=
+honnef.co/go/tools v0.2.0/go.mod h1:lPVVZ2BS5TfnjLyizF7o7hv7j9/L+8cZY2hLyjP9cGY=
 k8s.io/klog/hack/tools v0.0.0-20210303110520-14dec3377f55 h1:dLsq+jacIVLNk1Jmh5RFmlTiD5kIwjYN5hh8udCyeDc=
 k8s.io/klog/hack/tools v0.0.0-20210303110520-14dec3377f55/go.mod h1:peYvfmhJdUiWTjdEpxAPkauLKX+lwVMfcSIMynAWZ14=
 mvdan.cc/gofumpt v0.1.0 h1:hsVv+Y9UsZ/mFZTxJZuHVI6shSQCtzZ11h1JEFPAZLw=

--- a/hack/verify-staticcheck.sh
+++ b/hack/verify-staticcheck.sh
@@ -35,8 +35,9 @@ FOCUS="${FOCUS%/}" # Remove the ending "/"
 # See https://staticcheck.io/docs/checks
 CHECKS=(
   "all"
-  "-S1*"   # Omit code simplifications for now.
-  "-ST1*"  # Mostly stylistic, redundant w/ golint
+  "-S1*"    # Omit code simplifications for now.
+  "-ST1*"   # Mostly stylistic, redundant w/ golint
+  "-SA5011" # Possible nil pointer dereference
 )
 export IFS=','; checks="${CHECKS[*]}"; unset IFS
 


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
After upgrading staticcheck to v0.2.0, some packages failed.
- SA5011 is not a valid check failure in my opinion. (Some discussions here https://github.com/dominikh/go-tools/issues/656)
#### Which issue(s) this PR fixes:
xref #92402

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```