### PR TITLE
Add missing locks for device-manager in 1.19

### DIFF
--- a/pkg/kubelet/cm/devicemanager/manager.go
+++ b/pkg/kubelet/cm/devicemanager/manager.go
@@ -1032,6 +1032,8 @@ func (m *ManagerImpl) sanitizeNodeAllocatable(node *schedulerframework.NodeInfo)
 }
 
 func (m *ManagerImpl) isDevicePluginResource(resource string) bool {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
 	_, registeredResource := m.healthyDevices[resource]
 	_, allocatedResource := m.allocatedDevices[resource]
 	// Return true if this is either an active device plugin resource or


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

This PR should address issue of missing locks in device manager already fixed in 1.20+

#### Which issue(s) this PR fixes:
Fixes #99370

#### Special notes for your reviewer:
I just took over the two additional locks from https://github.com/kubernetes/kubernetes/pull/93243/files and checked again through manager file that `m.healthyDevices` and `m.allocatedDevices` are always covered by locks. In consequence, i did not take over the removal of locks in `GetDevices` as i think they are still necessary and that is maybe worth another bug for 1.20+ ? Happy to discuss.

#### Does this PR introduce a user-facing change?
```release-note
Fixes a regression in 1.18+ with the TopologyManager feature causing a concurrent map write and kubelet panic
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
