### PR TITLE
Improve netpol validation retry

### DIFF
--- a/test/e2e/network/netpol/network_policy.go
+++ b/test/e2e/network/netpol/network_policy.go
@@ -19,7 +19,6 @@ package netpol
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -909,7 +908,6 @@ var _ = common.SIGDescribe("Netpol", func() {
 			ValidateOrFail(k8s, model, &TestCase{ToPort: 80, Protocol: v1.ProtocolTCP, Reachability: reachability})
 
 			err := k8s.cleanNetworkPolicies(model.NamespaceNames)
-			time.Sleep(3 * time.Second) // TODO we can remove this eventually, its just a hack to keep CI stable.
 			framework.ExpectNoError(err, "unable to clean network policies")
 
 			// Now the policy is deleted, we expect all connectivity to work again.


### PR DESCRIPTION

#### What type of PR is this?

/kind cleanup
/kind flake

#### What this PR does / why we need it:

ValidateOrFail only retries twice, and assumes that the time it took to
test the first time, was enough to wait to try again.  This refactors
the function to poll instead.

This also removes a now unnecessary 3 second wait in the policy
deletion test.

We're seeing in OpenShift OVN, the test that we should stop enforcing
policies after they are deleted fails occasionally as the implicit wait in
ValidateOrFail isn't long enough to ensure the policies are actually
deleted.


#### Which issue(s) this PR fixes:

Test: `[sig-network] Netpol [LinuxOnly] NetworkPolicy between server and client should stop enforcing policies after they are deleted`

https://testgrid.k8s.io/redhat-openshift-ocp-release-4.9-informing#periodic-ci-openshift-release-master-nightly-4.9-e2e-metal-ipi-ovn-dualstack

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

/sig network
