### PR TITLE
kubectl: add `--subresource` flag

### DIFF
--- a/pkg/printers/internalversion/printers.go
+++ b/pkg/printers/internalversion/printers.go
@@ -27,6 +27,7 @@ import (
 
 	apiserverinternalv1alpha1 "k8s.io/api/apiserverinternal/v1alpha1"
 	appsv1beta1 "k8s.io/api/apps/v1beta1"
+	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	autoscalingv2beta1 "k8s.io/api/autoscaling/v2beta1"
 	batchv1 "k8s.io/api/batch/v1"
 	batchv1beta1 "k8s.io/api/batch/v1beta1"
@@ -588,6 +589,13 @@ func AddHandlers(h printers.PrintHandler) {
 	}
 	h.TableHandler(storageVersionColumnDefinitions, printStorageVersion)
 	h.TableHandler(storageVersionColumnDefinitions, printStorageVersionList)
+
+	scaleColumnDefinitions := []metav1.TableColumnDefinition{
+		{Name: "Name", Type: "string", Description: metav1.ObjectMeta{}.SwaggerDoc()["name"]},
+		{Name: "Desired", Type: "integer", Description: autoscalingv1.ScaleSpec{}.SwaggerDoc()["replicas"]},
+		{Name: "Available", Type: "integer", Description: autoscalingv1.ScaleStatus{}.SwaggerDoc()["replicas"]},
+	}
+	h.TableHandler(scaleColumnDefinitions, printScale)
 }
 
 // Pass ports=nil for all ports.
@@ -2619,6 +2627,14 @@ func printPriorityLevelConfigurationList(list *flowcontrol.PriorityLevelConfigur
 		rows = append(rows, r...)
 	}
 	return rows, nil
+}
+
+func printScale(obj *autoscaling.Scale, options printers.GenerateOptions) ([]metav1.TableRow, error) {
+	row := metav1.TableRow{
+		Object: runtime.RawExtension{Object: obj},
+	}
+	row.Cells = append(row.Cells, obj.Name, obj.Spec.Replicas, obj.Status.Replicas)
+	return []metav1.TableRow{row}, nil
 }
 
 func printBoolPtr(value *bool) string {

--- a/pkg/registry/apiserverinternal/storageversion/storage/storage.go
+++ b/pkg/registry/apiserverinternal/storageversion/storage/storage.go
@@ -89,3 +89,7 @@ func (r *StatusREST) Update(ctx context.Context, name string, objInfo rest.Updat
 func (r *StatusREST) GetResetFields() map[fieldpath.APIVersion]*fieldpath.Set {
 	return r.store.GetResetFields()
 }
+
+func (r *StatusREST) ConvertToTable(ctx context.Context, object runtime.Object, tableOptions runtime.Object) (*metav1.Table, error) {
+	return r.store.ConvertToTable(ctx, object, tableOptions)
+}

--- a/pkg/registry/apps/daemonset/storage/storage.go
+++ b/pkg/registry/apps/daemonset/storage/storage.go
@@ -111,3 +111,7 @@ func (r *StatusREST) Update(ctx context.Context, name string, objInfo rest.Updat
 func (r *StatusREST) GetResetFields() map[fieldpath.APIVersion]*fieldpath.Set {
 	return r.store.GetResetFields()
 }
+
+func (r *StatusREST) ConvertToTable(ctx context.Context, object runtime.Object, tableOptions runtime.Object) (*metav1.Table, error) {
+	return r.store.ConvertToTable(ctx, object, tableOptions)
+}

--- a/pkg/registry/apps/deployment/storage/storage.go
+++ b/pkg/registry/apps/deployment/storage/storage.go
@@ -164,6 +164,10 @@ func (r *StatusREST) GetResetFields() map[fieldpath.APIVersion]*fieldpath.Set {
 	return r.store.GetResetFields()
 }
 
+func (r *StatusREST) ConvertToTable(ctx context.Context, object runtime.Object, tableOptions runtime.Object) (*metav1.Table, error) {
+	return r.store.ConvertToTable(ctx, object, tableOptions)
+}
+
 // RollbackREST implements the REST endpoint for initiating the rollback of a deployment
 type RollbackREST struct {
 	store *genericregistry.Store
@@ -320,6 +324,10 @@ func (r *ScaleREST) Update(ctx context.Context, name string, objInfo rest.Update
 		return nil, false, errors.NewBadRequest(fmt.Sprintf("%v", err))
 	}
 	return newScale, false, nil
+}
+
+func (r *ScaleREST) ConvertToTable(ctx context.Context, object runtime.Object, tableOptions runtime.Object) (*metav1.Table, error) {
+	return r.store.ConvertToTable(ctx, object, tableOptions)
 }
 
 func toScaleCreateValidation(f rest.ValidateObjectFunc) rest.ValidateObjectFunc {

--- a/pkg/registry/apps/replicaset/storage/storage.go
+++ b/pkg/registry/apps/replicaset/storage/storage.go
@@ -160,6 +160,10 @@ func (r *StatusREST) GetResetFields() map[fieldpath.APIVersion]*fieldpath.Set {
 	return r.store.GetResetFields()
 }
 
+func (r *StatusREST) ConvertToTable(ctx context.Context, object runtime.Object, tableOptions runtime.Object) (*metav1.Table, error) {
+	return r.store.ConvertToTable(ctx, object, tableOptions)
+}
+
 // ScaleREST implements a Scale for ReplicaSet.
 type ScaleREST struct {
 	store *genericregistry.Store
@@ -222,6 +226,10 @@ func (r *ScaleREST) Update(ctx context.Context, name string, objInfo rest.Update
 		return nil, false, errors.NewBadRequest(fmt.Sprintf("%v", err))
 	}
 	return newScale, false, err
+}
+
+func (r *ScaleREST) ConvertToTable(ctx context.Context, object runtime.Object, tableOptions runtime.Object) (*metav1.Table, error) {
+	return r.store.ConvertToTable(ctx, object, tableOptions)
 }
 
 func toScaleCreateValidation(f rest.ValidateObjectFunc) rest.ValidateObjectFunc {

--- a/pkg/registry/apps/statefulset/storage/storage.go
+++ b/pkg/registry/apps/statefulset/storage/storage.go
@@ -141,6 +141,10 @@ func (r *StatusREST) GetResetFields() map[fieldpath.APIVersion]*fieldpath.Set {
 	return r.store.GetResetFields()
 }
 
+func (r *StatusREST) ConvertToTable(ctx context.Context, object runtime.Object, tableOptions runtime.Object) (*metav1.Table, error) {
+	return r.store.ConvertToTable(ctx, object, tableOptions)
+}
+
 // Implement ShortNamesProvider
 var _ rest.ShortNamesProvider = &REST{}
 
@@ -209,6 +213,10 @@ func (r *ScaleREST) Update(ctx context.Context, name string, objInfo rest.Update
 		return nil, false, errors.NewBadRequest(fmt.Sprintf("%v", err))
 	}
 	return newScale, false, err
+}
+
+func (r *ScaleREST) ConvertToTable(ctx context.Context, object runtime.Object, tableOptions runtime.Object) (*metav1.Table, error) {
+	return r.store.ConvertToTable(ctx, object, tableOptions)
 }
 
 func toScaleCreateValidation(f rest.ValidateObjectFunc) rest.ValidateObjectFunc {

--- a/pkg/registry/autoscaling/horizontalpodautoscaler/storage/storage.go
+++ b/pkg/registry/autoscaling/horizontalpodautoscaler/storage/storage.go
@@ -104,3 +104,7 @@ func (r *StatusREST) Update(ctx context.Context, name string, objInfo rest.Updat
 func (r *StatusREST) GetResetFields() map[fieldpath.APIVersion]*fieldpath.Set {
 	return r.store.GetResetFields()
 }
+
+func (r *StatusREST) ConvertToTable(ctx context.Context, object runtime.Object, tableOptions runtime.Object) (*metav1.Table, error) {
+	return r.store.ConvertToTable(ctx, object, tableOptions)
+}

--- a/pkg/registry/batch/cronjob/storage/storage.go
+++ b/pkg/registry/batch/cronjob/storage/storage.go
@@ -102,3 +102,7 @@ func (r *StatusREST) Update(ctx context.Context, name string, objInfo rest.Updat
 func (r *StatusREST) GetResetFields() map[fieldpath.APIVersion]*fieldpath.Set {
 	return r.store.GetResetFields()
 }
+
+func (r *StatusREST) ConvertToTable(ctx context.Context, object runtime.Object, tableOptions runtime.Object) (*metav1.Table, error) {
+	return r.store.ConvertToTable(ctx, object, tableOptions)
+}

--- a/pkg/registry/batch/job/storage/storage.go
+++ b/pkg/registry/batch/job/storage/storage.go
@@ -117,3 +117,7 @@ func (r *StatusREST) Update(ctx context.Context, name string, objInfo rest.Updat
 func (r *StatusREST) GetResetFields() map[fieldpath.APIVersion]*fieldpath.Set {
 	return r.store.GetResetFields()
 }
+
+func (r *StatusREST) ConvertToTable(ctx context.Context, object runtime.Object, tableOptions runtime.Object) (*metav1.Table, error) {
+	return r.store.ConvertToTable(ctx, object, tableOptions)
+}

--- a/pkg/registry/certificates/certificates/storage/storage.go
+++ b/pkg/registry/certificates/certificates/storage/storage.go
@@ -105,6 +105,10 @@ func (r *StatusREST) GetResetFields() map[fieldpath.APIVersion]*fieldpath.Set {
 	return r.store.GetResetFields()
 }
 
+func (r *StatusREST) ConvertToTable(ctx context.Context, object runtime.Object, tableOptions runtime.Object) (*metav1.Table, error) {
+	return r.store.ConvertToTable(ctx, object, tableOptions)
+}
+
 var _ = rest.Patcher(&StatusREST{})
 
 // ApprovalREST implements the REST endpoint for changing the approval state of a CSR.

--- a/pkg/registry/core/namespace/storage/storage.go
+++ b/pkg/registry/core/namespace/storage/storage.go
@@ -318,6 +318,11 @@ func (r *StatusREST) Update(ctx context.Context, name string, objInfo rest.Updat
 func (r *StatusREST) GetResetFields() map[fieldpath.APIVersion]*fieldpath.Set {
 	return r.store.GetResetFields()
 }
+
+func (r *StatusREST) ConvertToTable(ctx context.Context, object runtime.Object, tableOptions runtime.Object) (*metav1.Table, error) {
+	return r.store.ConvertToTable(ctx, object, tableOptions)
+}
+
 func (r *FinalizeREST) New() runtime.Object {
 	return r.store.New()
 }

--- a/pkg/registry/core/node/storage/storage.go
+++ b/pkg/registry/core/node/storage/storage.go
@@ -83,6 +83,10 @@ func (r *StatusREST) GetResetFields() map[fieldpath.APIVersion]*fieldpath.Set {
 	return r.store.GetResetFields()
 }
 
+func (r *StatusREST) ConvertToTable(ctx context.Context, object runtime.Object, tableOptions runtime.Object) (*metav1.Table, error) {
+	return r.store.ConvertToTable(ctx, object, tableOptions)
+}
+
 // NewStorage returns a NodeStorage object that will work against nodes.
 func NewStorage(optsGetter generic.RESTOptionsGetter, kubeletClientConfig client.KubeletClientConfig, proxyTransport http.RoundTripper) (*NodeStorage, error) {
 	store := &genericregistry.Store{

--- a/pkg/registry/core/persistentvolume/storage/storage.go
+++ b/pkg/registry/core/persistentvolume/storage/storage.go
@@ -99,3 +99,7 @@ func (r *StatusREST) Update(ctx context.Context, name string, objInfo rest.Updat
 func (r *StatusREST) GetResetFields() map[fieldpath.APIVersion]*fieldpath.Set {
 	return r.store.GetResetFields()
 }
+
+func (r *StatusREST) ConvertToTable(ctx context.Context, object runtime.Object, tableOptions runtime.Object) (*metav1.Table, error) {
+	return r.store.ConvertToTable(ctx, object, tableOptions)
+}

--- a/pkg/registry/core/persistentvolumeclaim/storage/storage.go
+++ b/pkg/registry/core/persistentvolumeclaim/storage/storage.go
@@ -99,3 +99,7 @@ func (r *StatusREST) Update(ctx context.Context, name string, objInfo rest.Updat
 func (r *StatusREST) GetResetFields() map[fieldpath.APIVersion]*fieldpath.Set {
 	return r.store.GetResetFields()
 }
+
+func (r *StatusREST) ConvertToTable(ctx context.Context, object runtime.Object, tableOptions runtime.Object) (*metav1.Table, error) {
+	return r.store.ConvertToTable(ctx, object, tableOptions)
+}

--- a/pkg/registry/core/pod/storage/storage.go
+++ b/pkg/registry/core/pod/storage/storage.go
@@ -286,6 +286,10 @@ func (r *StatusREST) GetResetFields() map[fieldpath.APIVersion]*fieldpath.Set {
 	return r.store.GetResetFields()
 }
 
+func (r *StatusREST) ConvertToTable(ctx context.Context, object runtime.Object, tableOptions runtime.Object) (*metav1.Table, error) {
+	return r.store.ConvertToTable(ctx, object, tableOptions)
+}
+
 // EphemeralContainersREST implements the REST endpoint for adding EphemeralContainers
 type EphemeralContainersREST struct {
 	store *genericregistry.Store

--- a/pkg/registry/core/replicationcontroller/storage/storage.go
+++ b/pkg/registry/core/replicationcontroller/storage/storage.go
@@ -148,6 +148,10 @@ func (r *StatusREST) GetResetFields() map[fieldpath.APIVersion]*fieldpath.Set {
 	return r.store.GetResetFields()
 }
 
+func (r *StatusREST) ConvertToTable(ctx context.Context, object runtime.Object, tableOptions runtime.Object) (*metav1.Table, error) {
+	return r.store.ConvertToTable(ctx, object, tableOptions)
+}
+
 type ScaleREST struct {
 	store *genericregistry.Store
 }
@@ -194,6 +198,10 @@ func (r *ScaleREST) Update(ctx context.Context, name string, objInfo rest.Update
 	}
 	rc := obj.(*api.ReplicationController)
 	return scaleFromRC(rc), false, nil
+}
+
+func (r *ScaleREST) ConvertToTable(ctx context.Context, object runtime.Object, tableOptions runtime.Object) (*metav1.Table, error) {
+	return r.store.ConvertToTable(ctx, object, tableOptions)
 }
 
 func toScaleCreateValidation(f rest.ValidateObjectFunc) rest.ValidateObjectFunc {

--- a/pkg/registry/core/resourcequota/storage/storage.go
+++ b/pkg/registry/core/resourcequota/storage/storage.go
@@ -98,3 +98,7 @@ func (r *StatusREST) Update(ctx context.Context, name string, objInfo rest.Updat
 func (r *StatusREST) GetResetFields() map[fieldpath.APIVersion]*fieldpath.Set {
 	return r.store.GetResetFields()
 }
+
+func (r *StatusREST) ConvertToTable(ctx context.Context, object runtime.Object, tableOptions runtime.Object) (*metav1.Table, error) {
+	return r.store.ConvertToTable(ctx, object, tableOptions)
+}

--- a/pkg/registry/core/service/storage/storage.go
+++ b/pkg/registry/core/service/storage/storage.go
@@ -134,6 +134,10 @@ func (r *StatusREST) GetResetFields() map[fieldpath.APIVersion]*fieldpath.Set {
 	return r.store.GetResetFields()
 }
 
+func (r *StatusREST) ConvertToTable(ctx context.Context, object runtime.Object, tableOptions runtime.Object) (*metav1.Table, error) {
+	return r.store.ConvertToTable(ctx, object, tableOptions)
+}
+
 // defaultOnRead sets interlinked fields that were not previously set on read.
 // We can't do this in the normal defaulting path because that same logic
 // applies on Get, Create, and Update, but we need to distinguish between them.

--- a/pkg/registry/flowcontrol/flowschema/storage/storage.go
+++ b/pkg/registry/flowcontrol/flowschema/storage/storage.go
@@ -97,3 +97,7 @@ func (r *StatusREST) Update(ctx context.Context, name string, objInfo rest.Updat
 func (r *StatusREST) GetResetFields() map[fieldpath.APIVersion]*fieldpath.Set {
 	return r.store.GetResetFields()
 }
+
+func (r *StatusREST) ConvertToTable(ctx context.Context, object runtime.Object, tableOptions runtime.Object) (*metav1.Table, error) {
+	return r.store.ConvertToTable(ctx, object, tableOptions)
+}

--- a/pkg/registry/flowcontrol/prioritylevelconfiguration/storage/storage.go
+++ b/pkg/registry/flowcontrol/prioritylevelconfiguration/storage/storage.go
@@ -97,3 +97,7 @@ func (r *StatusREST) Update(ctx context.Context, name string, objInfo rest.Updat
 func (r *StatusREST) GetResetFields() map[fieldpath.APIVersion]*fieldpath.Set {
 	return r.store.GetResetFields()
 }
+
+func (r *StatusREST) ConvertToTable(ctx context.Context, object runtime.Object, tableOptions runtime.Object) (*metav1.Table, error) {
+	return r.store.ConvertToTable(ctx, object, tableOptions)
+}

--- a/pkg/registry/networking/ingress/storage/storage.go
+++ b/pkg/registry/networking/ingress/storage/storage.go
@@ -96,3 +96,7 @@ func (r *StatusREST) Update(ctx context.Context, name string, objInfo rest.Updat
 func (r *StatusREST) GetResetFields() map[fieldpath.APIVersion]*fieldpath.Set {
 	return r.store.GetResetFields()
 }
+
+func (r *StatusREST) ConvertToTable(ctx context.Context, object runtime.Object, tableOptions runtime.Object) (*metav1.Table, error) {
+	return r.store.ConvertToTable(ctx, object, tableOptions)
+}

--- a/pkg/registry/policy/poddisruptionbudget/storage/storage.go
+++ b/pkg/registry/policy/poddisruptionbudget/storage/storage.go
@@ -93,3 +93,7 @@ func (r *StatusREST) Update(ctx context.Context, name string, objInfo rest.Updat
 func (r *StatusREST) GetResetFields() map[fieldpath.APIVersion]*fieldpath.Set {
 	return r.store.GetResetFields()
 }
+
+func (r *StatusREST) ConvertToTable(ctx context.Context, object runtime.Object, tableOptions runtime.Object) (*metav1.Table, error) {
+	return r.store.ConvertToTable(ctx, object, tableOptions)
+}

--- a/pkg/registry/storage/volumeattachment/storage/storage.go
+++ b/pkg/registry/storage/volumeattachment/storage/storage.go
@@ -101,3 +101,7 @@ func (r *StatusREST) Update(ctx context.Context, name string, objInfo rest.Updat
 func (r *StatusREST) GetResetFields() map[fieldpath.APIVersion]*fieldpath.Set {
 	return r.store.GetResetFields()
 }
+
+func (r *StatusREST) ConvertToTable(ctx context.Context, object runtime.Object, tableOptions runtime.Object) (*metav1.Table, error) {
+	return r.store.ConvertToTable(ctx, object, tableOptions)
+}

--- a/staging/src/k8s.io/cli-runtime/pkg/resource/builder.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/resource/builder.go
@@ -83,7 +83,8 @@ type Builder struct {
 	limitChunks       int64
 	requestTransforms []RequestTransform
 
-	resources []string
+	resources   []string
+	subresource string
 
 	namespace    string
 	allNamespace bool
@@ -555,6 +556,13 @@ func (b *Builder) TransformRequests(opts ...RequestTransform) *Builder {
 	return b
 }
 
+// Subresource instructs the builder to retrieve the object at the
+// subresource path instead of the main resource path.
+func (b *Builder) Subresource(subresource string) *Builder {
+	b.subresource = subresource
+	return b
+}
+
 // SelectEverythingParam
 func (b *Builder) SelectAllParam(selectAll bool) *Builder {
 	if selectAll && (b.labelSelector != nil || b.fieldSelector != nil) {
@@ -886,6 +894,10 @@ func (b *Builder) visitBySelector() *Result {
 	if len(b.resources) == 0 {
 		return result.withError(fmt.Errorf("at least one resource must be specified to use a selector"))
 	}
+	if len(b.subresource) != 0 {
+		return result.withError(fmt.Errorf("--subresource cannot be used when bulk resources are specified"))
+	}
+
 	mappings, err := b.resourceMappings()
 	if err != nil {
 		result.err = err
@@ -1007,10 +1019,11 @@ func (b *Builder) visitByResource() *Result {
 		}
 
 		info := &Info{
-			Client:    client,
-			Mapping:   mapping,
-			Namespace: selectorNamespace,
-			Name:      tuple.Name,
+			Client:      client,
+			Mapping:     mapping,
+			Namespace:   selectorNamespace,
+			Name:        tuple.Name,
+			Subresource: b.subresource,
 		}
 		items = append(items, info)
 	}
@@ -1071,10 +1084,11 @@ func (b *Builder) visitByName() *Result {
 	visitors := []Visitor{}
 	for _, name := range b.names {
 		info := &Info{
-			Client:    client,
-			Mapping:   mapping,
-			Namespace: selectorNamespace,
-			Name:      name,
+			Client:      client,
+			Mapping:     mapping,
+			Namespace:   selectorNamespace,
+			Name:        name,
+			Subresource: b.subresource,
 		}
 		visitors = append(visitors, info)
 	}

--- a/staging/src/k8s.io/cli-runtime/pkg/resource/builder_test.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/resource/builder_test.go
@@ -150,6 +150,14 @@ func streamTestData() (io.Reader, *v1.PodList, *v1.ServiceList) {
 	return r, pods, svc
 }
 
+func subresourceTestData(name string) *v1.Pod {
+	return &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "test", ResourceVersion: "10"},
+		Spec:       V1DeepEqualSafePodSpec(),
+		Status:     V1DeepEqualSafePodStatus(),
+	}
+}
+
 func JSONToYAMLOrDie(in []byte) []byte {
 	data, err := yaml.JSONToYAML(in)
 	if err != nil {
@@ -911,6 +919,37 @@ func TestResourceByName(t *testing.T) {
 		t.Errorf("unexpected resource mapping: %#v", mapping)
 	}
 }
+func TestSubresourceByName(t *testing.T) {
+	pod := subresourceTestData("foo")
+	b := newDefaultBuilderWith(fakeClientWith("", t, map[string]string{
+		"/namespaces/test/pods/foo/status": runtime.EncodeOrDie(corev1Codec, pod),
+	})).NamespaceParam("test")
+
+	test := &testVisitor{}
+	singleItemImplied := false
+
+	if b.Do().Err() == nil {
+		t.Errorf("unexpected non-error")
+	}
+
+	b.ResourceTypeOrNameArgs(true, "pods", "foo").Subresource("status")
+
+	err := b.Do().IntoSingleItemImplied(&singleItemImplied).Visit(test.Handle)
+	if err != nil || !singleItemImplied || len(test.Infos) != 1 {
+		t.Fatalf("unexpected response: %v %t %#v", err, singleItemImplied, test.Infos)
+	}
+	if !apiequality.Semantic.DeepEqual(pod, test.Objects()[0]) {
+		t.Errorf("unexpected object: %#v", test.Objects()[0])
+	}
+
+	mapping, err := b.Do().ResourceMapping()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if mapping.Resource != (schema.GroupVersionResource{Group: "", Version: "v1", Resource: "pods"}) {
+		t.Errorf("unexpected resource mapping: %#v", mapping)
+	}
+}
 
 func TestRestMappingErrors(t *testing.T) {
 	pods, _ := testData()
@@ -1256,8 +1295,9 @@ func TestResourceTuple(t *testing.T) {
 	expectNoErr := func(err error) bool { return err == nil }
 	expectErr := func(err error) bool { return err != nil }
 	testCases := map[string]struct {
-		args  []string
-		errFn func(error) bool
+		args        []string
+		subresource string
+		errFn       func(error) bool
 	}{
 		"valid": {
 			args:  []string{"pods/foo"},
@@ -1299,6 +1339,16 @@ func TestResourceTuple(t *testing.T) {
 			args:  []string{"bar/"},
 			errFn: expectErr,
 		},
+		"valid status subresource": {
+			args:        []string{"pods/foo"},
+			subresource: "status",
+			errFn:       expectNoErr,
+		},
+		"valid status subresource for multiple with name indirection": {
+			args:        []string{"pods/foo", "pod/bar"},
+			subresource: "status",
+			errFn:       expectNoErr,
+		},
 	}
 	for k, tt := range testCases {
 		t.Run("using default namespace", func(t *testing.T) {
@@ -1307,14 +1357,18 @@ func TestResourceTuple(t *testing.T) {
 				if requireObject {
 					pods, _ := testData()
 					expectedRequests = map[string]string{
-						"/namespaces/test/pods/foo": runtime.EncodeOrDie(corev1Codec, &pods.Items[0]),
-						"/namespaces/test/pods/bar": runtime.EncodeOrDie(corev1Codec, &pods.Items[0]),
-						"/nodes/foo":                runtime.EncodeOrDie(corev1Codec, &v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "foo"}}),
+						"/namespaces/test/pods/foo":        runtime.EncodeOrDie(corev1Codec, &pods.Items[0]),
+						"/namespaces/test/pods/bar":        runtime.EncodeOrDie(corev1Codec, &pods.Items[0]),
+						"/namespaces/test/pods/foo/status": runtime.EncodeOrDie(corev1Codec, subresourceTestData("foo")),
+						"/namespaces/test/pods/bar/status": runtime.EncodeOrDie(corev1Codec, subresourceTestData("bar")),
+						"/nodes/foo":                       runtime.EncodeOrDie(corev1Codec, &v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "foo"}}),
 					}
 				}
 				b := newDefaultBuilderWith(fakeClientWith(k, t, expectedRequests)).
 					NamespaceParam("test").DefaultNamespace().
-					ResourceTypeOrNameArgs(true, tt.args...).RequireObject(requireObject)
+					ResourceTypeOrNameArgs(true, tt.args...).
+					RequireObject(requireObject).
+					Subresource(tt.subresource)
 
 				r := b.Do()
 
@@ -1550,6 +1604,23 @@ func TestListObjectWithDifferentVersions(t *testing.T) {
 	// resource version differs between type lists, so it's not possible to get a single version.
 	if list.ResourceVersion != "" || len(list.Items) != 3 {
 		t.Errorf("unexpected list: %#v", list)
+	}
+}
+
+func TestListObjectSubresource(t *testing.T) {
+	pods, _ := testData()
+	labelKey := metav1.LabelSelectorQueryParam(corev1GV.String())
+	b := newDefaultBuilderWith(fakeClientWith("", t, map[string]string{
+		"/namespaces/test/pods?" + labelKey: runtime.EncodeOrDie(corev1Codec, pods),
+	})).
+		NamespaceParam("test").
+		ResourceTypeOrNameArgs(true, "pods").
+		Subresource("status").
+		Flatten()
+
+	_, err := b.Do().Object()
+	if err == nil || !strings.Contains(err.Error(), "--subresource cannot be used when bulk resources are specified") {
+		t.Fatalf("unexpected response: %v", err)
 	}
 }
 

--- a/staging/src/k8s.io/cli-runtime/pkg/resource/helper_test.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/resource/helper_test.go
@@ -68,6 +68,17 @@ func V1DeepEqualSafePodSpec() corev1.PodSpec {
 	}
 }
 
+func V1DeepEqualSafePodStatus() corev1.PodStatus {
+	return corev1.PodStatus{
+		Conditions: []corev1.PodCondition{
+			{
+				Status: corev1.ConditionTrue,
+				Type:   corev1.PodReady,
+			},
+		},
+	}
+}
+
 func TestHelperDelete(t *testing.T) {
 	tests := []struct {
 		name    string
@@ -257,11 +268,12 @@ func TestHelperCreate(t *testing.T) {
 
 func TestHelperGet(t *testing.T) {
 	tests := []struct {
-		name    string
-		Err     bool
-		Req     func(*http.Request) bool
-		Resp    *http.Response
-		HttpErr error
+		name        string
+		subresource string
+		Err         bool
+		Req         func(*http.Request) bool
+		Resp        *http.Response
+		HttpErr     error
 	}{
 		{
 			name:    "test1",
@@ -301,6 +313,35 @@ func TestHelperGet(t *testing.T) {
 				return true
 			},
 		},
+		{
+			name:        "test with subresource",
+			subresource: "status",
+			Resp: &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     header(),
+				Body:       objBody(&corev1.Pod{TypeMeta: metav1.TypeMeta{APIVersion: "v1", Kind: "Pod"}, ObjectMeta: metav1.ObjectMeta{Name: "foo"}}),
+			},
+			Req: func(req *http.Request) bool {
+				if req.Method != "GET" {
+					t.Errorf("unexpected method: %#v", req)
+					return false
+				}
+				parts := splitPath(req.URL.Path)
+				if parts[1] != "bar" {
+					t.Errorf("url doesn't contain namespace: %#v", req)
+					return false
+				}
+				if parts[2] != "foo" {
+					t.Errorf("url doesn't contain name: %#v", req)
+					return false
+				}
+				if parts[3] != "status" {
+					t.Errorf("url doesn't contain subresource: %#v", req)
+					return false
+				}
+				return true
+			},
+		},
 	}
 	for i, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -313,6 +354,7 @@ func TestHelperGet(t *testing.T) {
 			modifier := &Helper{
 				RESTClient:      client,
 				NamespaceScoped: true,
+				Subresource:     tt.subresource,
 			}
 			obj, err := modifier.Get("bar", "foo")
 
@@ -356,6 +398,34 @@ func TestHelperList(t *testing.T) {
 		},
 		{
 			name: "test3",
+			Resp: &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     header(),
+				Body: objBody(&corev1.PodList{
+					Items: []corev1.Pod{{
+						ObjectMeta: metav1.ObjectMeta{Name: "foo"},
+					},
+					},
+				}),
+			},
+			Req: func(req *http.Request) bool {
+				if req.Method != "GET" {
+					t.Errorf("unexpected method: %#v", req)
+					return false
+				}
+				if req.URL.Path != "/namespaces/bar" {
+					t.Errorf("url doesn't contain name: %#v", req.URL)
+					return false
+				}
+				if req.URL.Query().Get(metav1.LabelSelectorQueryParam(corev1GV.String())) != labels.SelectorFromSet(labels.Set{"foo": "baz"}).String() {
+					t.Errorf("url doesn't contain query parameters: %#v", req.URL)
+					return false
+				}
+				return true
+			},
+		},
+		{
+			name: "test with",
 			Resp: &http.Response{
 				StatusCode: http.StatusOK,
 				Header:     header(),
@@ -501,6 +571,7 @@ func TestHelperReplace(t *testing.T) {
 		Object          runtime.Object
 		Namespace       string
 		NamespaceScoped bool
+		Subresource     string
 
 		ExpectPath   string
 		ExpectObject runtime.Object
@@ -592,6 +663,29 @@ func TestHelperReplace(t *testing.T) {
 			Resp:            &http.Response{StatusCode: http.StatusOK, Header: header(), Body: objBody(&metav1.Status{Status: metav1.StatusSuccess})},
 			Req:             expectPut,
 		},
+		{
+			Name:            "test7 - with status subresource",
+			Namespace:       "bar",
+			NamespaceScoped: true,
+			Subresource:     "status",
+			Object: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "foo"},
+				Status:     V1DeepEqualSafePodStatus(),
+			},
+			ExpectPath: "/namespaces/bar/foo/status",
+			ExpectObject: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "foo", ResourceVersion: "10"},
+				Status:     V1DeepEqualSafePodStatus(),
+			},
+			Overwrite: true,
+			HTTPClient: fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
+				if req.Method == "PUT" {
+					return &http.Response{StatusCode: http.StatusOK, Header: header(), Body: objBody(&metav1.Status{Status: metav1.StatusSuccess})}, nil
+				}
+				return &http.Response{StatusCode: http.StatusOK, Header: header(), Body: objBody(&corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "foo", ResourceVersion: "10"}})}, nil
+			}),
+			Req: expectPut,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.Name, func(t *testing.T) {
@@ -605,6 +699,7 @@ func TestHelperReplace(t *testing.T) {
 			modifier := &Helper{
 				RESTClient:      client,
 				NamespaceScoped: tt.NamespaceScoped,
+				Subresource:     tt.Subresource,
 			}
 			_, err := modifier.Replace(tt.Namespace, "foo", tt.Overwrite, tt.Object)
 			if (err != nil) != tt.Err {

--- a/staging/src/k8s.io/cli-runtime/pkg/resource/visitor.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/resource/visitor.go
@@ -78,12 +78,16 @@ type Info struct {
 	// defined. If retrieved from the server, the Builder expects the mapping client to
 	// decide the final form. Use the AsVersioned, AsUnstructured, and AsInternal helpers
 	// to alter the object versions.
+	// If Subresource is specified, this will be the object for the subresource.
 	Object runtime.Object
 	// Optional, this is the most recent resource version the server knows about for
 	// this type of resource. It may not match the resource version of the object,
 	// but if set it should be equal to or newer than the resource version of the
 	// object (however the server defines resource version).
 	ResourceVersion string
+	// Optional, if specified, the object is the most recent value of the subresource
+	// returned by the server if available.
+	Subresource string
 }
 
 // Visit implements Visitor
@@ -93,7 +97,7 @@ func (i *Info) Visit(fn VisitorFunc) error {
 
 // Get retrieves the object from the Namespace and Name fields
 func (i *Info) Get() (err error) {
-	obj, err := NewHelper(i.Client, i.Mapping).Get(i.Namespace, i.Name)
+	obj, err := NewHelper(i.Client, i.Mapping).WithSubresource(i.Subresource).Get(i.Namespace, i.Name)
 	if err != nil {
 		if errors.IsNotFound(err) && len(i.Namespace) > 0 && i.Namespace != metav1.NamespaceDefault && i.Namespace != metav1.NamespaceAll {
 			err2 := i.Client.Get().AbsPath("api", "v1", "namespaces", i.Namespace).Do(context.TODO()).Error()

--- a/staging/src/k8s.io/kubectl/pkg/cmd/edit/edit.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/edit/edit.go
@@ -62,7 +62,10 @@ var (
 		kubectl edit job.v1.batch/myjob -o json
 
 		# Edit the deployment 'mydeployment' in YAML and save the modified config in its annotation:
-		kubectl edit deployment/mydeployment -o yaml --save-config`))
+		kubectl edit deployment/mydeployment -o yaml --save-config
+		
+		# Edit the deployment/mydeployment's status subresource:
+		kubectl patch deployment mydeployment --subresource='status'`))
 )
 
 // NewCmdEdit creates the `edit` command
@@ -78,6 +81,7 @@ func NewCmdEdit(f cmdutil.Factory, ioStreams genericclioptions.IOStreams) *cobra
 		Example:               editExample,
 		Run: func(cmd *cobra.Command, args []string) {
 			cmdutil.CheckErr(o.Complete(f, args, cmd))
+			cmdutil.CheckErr(o.Validate())
 			cmdutil.CheckErr(o.Run())
 		},
 	}
@@ -94,5 +98,6 @@ func NewCmdEdit(f cmdutil.Factory, ioStreams genericclioptions.IOStreams) *cobra
 		"Defaults to the line ending native to your platform.")
 	cmdutil.AddFieldManagerFlagVar(cmd, &o.FieldManager, "kubectl-edit")
 	cmdutil.AddApplyAnnotationVarFlags(cmd, &o.ApplyAnnotation)
+	cmdutil.AddSubresourceFlags(cmd, &o.Subresource, "This is an 'alpha' flag. If specified, edit will operate on the subresource of the requested object.", cmdutil.StatusOnlySubresourceTypes)
 	return cmd
 }

--- a/staging/src/k8s.io/kubectl/pkg/cmd/edit/edit_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/edit/edit_test.go
@@ -53,6 +53,7 @@ type EditTestCase struct {
 	Output           string   `yaml:"outputFormat"`
 	OutputPatch      string   `yaml:"outputPatch"`
 	SaveConfig       string   `yaml:"saveConfig"`
+	Subresource      string   `yaml:"subresource"`
 	Namespace        string   `yaml:"namespace"`
 	ExpectedStdout   []string `yaml:"expectedStdout"`
 	ExpectedStderr   []string `yaml:"expectedStderr"`
@@ -252,6 +253,9 @@ func TestEdit(t *testing.T) {
 			}
 			if len(testcase.SaveConfig) > 0 {
 				cmd.Flags().Set("save-config", testcase.SaveConfig)
+			}
+			if len(testcase.Subresource) > 0 {
+				cmd.Flags().Set("subresource", testcase.Subresource)
 			}
 
 			cmdutil.BehaviorOnFatal(func(str string, code int) {

--- a/staging/src/k8s.io/kubectl/pkg/cmd/edit/testdata/testcase-edit-subreource-status/0.response
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/edit/testdata/testcase-edit-subreource-status/0.response
@@ -1,0 +1,85 @@
+{
+    "apiVersion": "apps/v1",
+    "kind": "Deployment",
+    "metadata": {
+        "annotations": {
+            "deployment.kubernetes.io/revision": "1"
+        },
+        "creationTimestamp": "2021-06-23T17:01:10Z",
+        "generation": 5,
+        "labels": {
+            "app": "nginx"
+        },
+        "name": "nginx",
+        "namespace": "edit-test",
+        "resourceVersion": "121107",
+        "uid": "a598ee47-9635-482b-bacb-16c9e3ade05c"
+    },
+    "spec": {
+        "progressDeadlineSeconds": 600,
+        "replicas": 3,
+        "revisionHistoryLimit": 10,
+        "selector": {
+            "matchLabels": {
+                "app": "nginx"
+            }
+        },
+        "strategy": {
+            "rollingUpdate": {
+                "maxSurge": "25%",
+                "maxUnavailable": "25%"
+            },
+            "type": "RollingUpdate"
+        },
+        "template": {
+            "metadata": {
+                "creationTimestamp": null,
+                "labels": {
+                    "app": "nginx"
+                }
+            },
+            "spec": {
+                "containers": [
+                    {
+                        "image": "gcr.io/kakaraparthy-devel/nginx:latest",
+                        "imagePullPolicy": "Always",
+                        "name": "nginx",
+                        "resources": {},
+                        "terminationMessagePath": "/dev/termination-log",
+                        "terminationMessagePolicy": "File"
+                    }
+                ],
+                "dnsPolicy": "ClusterFirst",
+                "restartPolicy": "Always",
+                "schedulerName": "default-scheduler",
+                "securityContext": {},
+                "terminationGracePeriodSeconds": 30
+            }
+        }
+    },
+    "status": {
+        "availableReplicas": 3,
+        "conditions": [
+            {
+                "lastTransitionTime": "2021-06-23T17:01:10Z",
+                "lastUpdateTime": "2021-06-23T17:01:18Z",
+                "message": "ReplicaSet \"nginx-6f5fdbd667\" has successfully progressed.",
+                "reason": "NewReplicaSetAvailable",
+                "status": "True",
+                "type": "Progressing"
+            },
+            {
+                "lastTransitionTime": "2021-06-23T17:59:01Z",
+                "lastUpdateTime": "2021-06-23T17:59:01Z",
+                "message": "Deployment has minimum availability.",
+                "reason": "MinimumReplicasAvailable",
+                "status": "True",
+                "type": "Available"
+            }
+        ],
+        "observedGeneration": 5,
+        "readyReplicas": 3,
+        "replicas": 3,
+        "updatedReplicas": 3
+    }
+}

--- a/staging/src/k8s.io/kubectl/pkg/cmd/edit/testdata/testcase-edit-subreource-status/1.edited
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/edit/testdata/testcase-edit-subreource-status/1.edited
@@ -1,0 +1,66 @@
+# Please edit the object below. Lines beginning with a '#' will be ignored,
+# and an empty file will abort the edit. If an error occurs while saving this file will be
+# reopened with the relevant failures.
+#
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    deployment.kubernetes.io/revision: "1"
+  creationTimestamp: "2021-06-23T17:01:10Z"
+  generation: 5
+  labels:
+    app: nginx
+  name: nginx
+  namespace: edit-test
+  resourceVersion: "121107"
+  uid: a598ee47-9635-482b-bacb-16c9e3ade05c
+spec:
+  progressDeadlineSeconds: 600
+  replicas: 3
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app: nginx
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: nginx
+    spec:
+      containers:
+      - image: gcr.io/kakaraparthy-devel/nginx:latest
+        imagePullPolicy: Always
+        name: nginx
+        resources: {}
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext: {}
+      terminationGracePeriodSeconds: 30
+status:
+  availableReplicas: 3
+  conditions:
+  - lastTransitionTime: "2021-06-23T17:01:10Z"
+    lastUpdateTime: "2021-06-23T17:01:18Z"
+    message: ReplicaSet "nginx-6f5fdbd667" has successfully progressed.
+    reason: NewReplicaSetAvailable
+    status: "True"
+    type: Progressing
+  - lastTransitionTime: "2021-06-23T17:59:01Z"
+    lastUpdateTime: "2021-06-23T17:59:01Z"
+    message: Deployment has minimum availability.
+    reason: MinimumReplicasAvailable
+    status: "True"
+    type: Available
+  observedGeneration: 5
+  readyReplicas: 3
+  replicas: 4
+  updatedReplicas: 3

--- a/staging/src/k8s.io/kubectl/pkg/cmd/edit/testdata/testcase-edit-subreource-status/1.original
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/edit/testdata/testcase-edit-subreource-status/1.original
@@ -1,0 +1,66 @@
+# Please edit the object below. Lines beginning with a '#' will be ignored,
+# and an empty file will abort the edit. If an error occurs while saving this file will be
+# reopened with the relevant failures.
+#
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    deployment.kubernetes.io/revision: "1"
+  creationTimestamp: "2021-06-23T17:01:10Z"
+  generation: 5
+  labels:
+    app: nginx
+  name: nginx
+  namespace: edit-test
+  resourceVersion: "121107"
+  uid: a598ee47-9635-482b-bacb-16c9e3ade05c
+spec:
+  progressDeadlineSeconds: 600
+  replicas: 3
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app: nginx
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: nginx
+    spec:
+      containers:
+      - image: gcr.io/kakaraparthy-devel/nginx:latest
+        imagePullPolicy: Always
+        name: nginx
+        resources: {}
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext: {}
+      terminationGracePeriodSeconds: 30
+status:
+  availableReplicas: 3
+  conditions:
+  - lastTransitionTime: "2021-06-23T17:01:10Z"
+    lastUpdateTime: "2021-06-23T17:01:18Z"
+    message: ReplicaSet "nginx-6f5fdbd667" has successfully progressed.
+    reason: NewReplicaSetAvailable
+    status: "True"
+    type: Progressing
+  - lastTransitionTime: "2021-06-23T17:59:01Z"
+    lastUpdateTime: "2021-06-23T17:59:01Z"
+    message: Deployment has minimum availability.
+    reason: MinimumReplicasAvailable
+    status: "True"
+    type: Available
+  observedGeneration: 5
+  readyReplicas: 3
+  replicas: 3
+  updatedReplicas: 3

--- a/staging/src/k8s.io/kubectl/pkg/cmd/edit/testdata/testcase-edit-subreource-status/2.request
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/edit/testdata/testcase-edit-subreource-status/2.request
@@ -1,0 +1,5 @@
+{
+  "status": {
+    "replicas": 4
+  }
+}

--- a/staging/src/k8s.io/kubectl/pkg/cmd/edit/testdata/testcase-edit-subreource-status/2.response
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/edit/testdata/testcase-edit-subreource-status/2.response
@@ -1,0 +1,85 @@
+{
+    "apiVersion": "apps/v1",
+    "kind": "Deployment",
+    "metadata": {
+        "annotations": {
+            "deployment.kubernetes.io/revision": "1"
+        },
+        "creationTimestamp": "2021-06-23T17:01:10Z",
+        "generation": 5,
+        "labels": {
+            "app": "nginx"
+        },
+        "name": "nginx",
+        "namespace": "edit-test",
+        "resourceVersion": "121107",
+        "uid": "a598ee47-9635-482b-bacb-16c9e3ade05c"
+    },
+    "spec": {
+        "progressDeadlineSeconds": 600,
+        "replicas": 3,
+        "revisionHistoryLimit": 10,
+        "selector": {
+            "matchLabels": {
+                "app": "nginx"
+            }
+        },
+        "strategy": {
+            "rollingUpdate": {
+                "maxSurge": "25%",
+                "maxUnavailable": "25%"
+            },
+            "type": "RollingUpdate"
+        },
+        "template": {
+            "metadata": {
+                "creationTimestamp": null,
+                "labels": {
+                    "app": "nginx"
+                }
+            },
+            "spec": {
+                "containers": [
+                    {
+                        "image": "gcr.io/kakaraparthy-devel/nginx:latest",
+                        "imagePullPolicy": "Always",
+                        "name": "nginx",
+                        "resources": {},
+                        "terminationMessagePath": "/dev/termination-log",
+                        "terminationMessagePolicy": "File"
+                    }
+                ],
+                "dnsPolicy": "ClusterFirst",
+                "restartPolicy": "Always",
+                "schedulerName": "default-scheduler",
+                "securityContext": {},
+                "terminationGracePeriodSeconds": 30
+            }
+        }
+    },
+    "status": {
+        "availableReplicas": 3,
+        "conditions": [
+            {
+                "lastTransitionTime": "2021-06-23T17:01:10Z",
+                "lastUpdateTime": "2021-06-23T17:01:18Z",
+                "message": "ReplicaSet \"nginx-6f5fdbd667\" has successfully progressed.",
+                "reason": "NewReplicaSetAvailable",
+                "status": "True",
+                "type": "Progressing"
+            },
+            {
+                "lastTransitionTime": "2021-06-23T17:59:01Z",
+                "lastUpdateTime": "2021-06-23T17:59:01Z",
+                "message": "Deployment has minimum availability.",
+                "reason": "MinimumReplicasAvailable",
+                "status": "True",
+                "type": "Available"
+            }
+        ],
+        "observedGeneration": 5,
+        "readyReplicas": 3,
+        "replicas": 4,
+        "updatedReplicas": 3
+    }
+}

--- a/staging/src/k8s.io/kubectl/pkg/cmd/edit/testdata/testcase-edit-subreource-status/test.yaml
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/edit/testdata/testcase-edit-subreource-status/test.yaml
@@ -1,0 +1,27 @@
+description: edit the status subresource
+mode: edit
+args:
+  - deployment
+  - nginx
+namespace: edit-test
+subresource: status
+expectedStdOut:
+  - deployment.apps/nginx edited
+expectedExitCode: 0
+steps:
+  - type: request
+    expectedMethod: GET
+    expectedPath: /apis/extensions/v1beta1/namespaces/edit-test/deployments/nginx/status
+    expectedInput: 0.request
+    resultingStatusCode: 200
+    resultingOutput: 0.response
+  - type: edit
+    expectedInput: 1.original
+    resultingOutput: 1.edited
+  - type: request
+    expectedMethod: PATCH
+    expectedPath: /apis/apps/v1/namespaces/edit-test/deployments/nginx/status
+    expectedContentType: application/strategic-merge-patch+json
+    expectedInput: 2.request
+    resultingStatusCode: 200
+    resultingOutput: 2.response

--- a/staging/src/k8s.io/kubectl/pkg/cmd/get/get.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/get/get.go
@@ -187,7 +187,7 @@ func NewCmdGet(parent string, f cmdutil.Factory, streams genericclioptions.IOStr
 	addServerPrintColumnFlags(cmd, o)
 	cmdutil.AddFilenameOptionFlags(cmd, &o.FilenameOptions, "identifying the resource to get from a server.")
 	cmdutil.AddChunkSizeFlag(cmd, &o.ChunkSize)
-	cmdutil.AddSubresourceFlags(cmd, &o.subresource, "This is an 'alpha' flag. If specified, gets the subresource of the requested object.")
+	cmdutil.AddSubresourceFlags(cmd, &o.subresource, "This is an 'alpha' flag. If specified, gets the subresource of the requested object.", cmdutil.SubresourceTypes)
 	return cmd
 }
 
@@ -322,7 +322,7 @@ func (o *GetOptions) Validate(cmd *cobra.Command) error {
 	if o.OutputWatchEvents && !(o.Watch || o.WatchOnly) {
 		return cmdutil.UsageErrorf(cmd, "--output-watch-events option can only be used with --watch or --watch-only")
 	}
-	if err := cmdutil.IsValidSubresource(o.subresource); err != nil {
+	if err := cmdutil.IsValidSubresource("get", o.subresource); err != nil {
 		return err
 	}
 	return nil

--- a/staging/src/k8s.io/kubectl/pkg/cmd/get/get_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/get/get_test.go
@@ -243,6 +243,60 @@ foo    <unknown>
 	}
 }
 
+func TestGetObjectSubresourceStatus(t *testing.T) {
+	_, _, replicationcontrollers := cmdtesting.TestData()
+
+	tf := cmdtesting.NewTestFactory().WithNamespace("test")
+	defer tf.Cleanup()
+	codec := scheme.Codecs.LegacyCodec(scheme.Scheme.PrioritizedVersionsAllGroups()...)
+
+	tf.UnstructuredClient = &fake.RESTClient{
+		NegotiatedSerializer: resource.UnstructuredPlusDefaultContentConfig().NegotiatedSerializer,
+		Resp:                 &http.Response{StatusCode: http.StatusOK, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.ObjBody(codec, &replicationcontrollers.Items[0])},
+	}
+
+	streams, _, buf, _ := genericclioptions.NewTestIOStreams()
+	cmd := NewCmdGet("kubectl", tf, streams)
+	cmd.SetOutput(buf)
+	cmd.Flags().Set("subresource", "status")
+	cmd.Run(cmd, []string{"replicationcontrollers", "rc1"})
+
+	expected := `NAME   AGE
+rc1    <unknown>
+`
+
+	if e, a := expected, buf.String(); e != a {
+		t.Errorf("expected\n%v\ngot\n%v", e, a)
+	}
+}
+
+func TestGetObjectSubresourceScale(t *testing.T) {
+	_, _, replicationcontrollers := cmdtesting.TestData()
+
+	tf := cmdtesting.NewTestFactory().WithNamespace("test")
+	defer tf.Cleanup()
+	codec := scheme.Codecs.LegacyCodec(scheme.Scheme.PrioritizedVersionsAllGroups()...)
+
+	tf.UnstructuredClient = &fake.RESTClient{
+		NegotiatedSerializer: resource.UnstructuredPlusDefaultContentConfig().NegotiatedSerializer,
+		Resp:                 &http.Response{StatusCode: http.StatusOK, Header: cmdtesting.DefaultHeader(), Body: replicationControllersScaleSubresourceTableObjBody(codec, replicationcontrollers.Items[0])},
+	}
+
+	streams, _, buf, _ := genericclioptions.NewTestIOStreams()
+	cmd := NewCmdGet("kubectl", tf, streams)
+	cmd.SetOutput(buf)
+	cmd.Flags().Set("subresource", "scale")
+	cmd.Run(cmd, []string{"replicationcontrollers", "rc1"})
+
+	expected := `NAME   DESIRED   AVAILABLE
+rc1    1         0
+`
+
+	if e, a := expected, buf.String(); e != a {
+		t.Errorf("expected\n%v\ngot\n%v", e, a)
+	}
+}
+
 func TestGetTableObjects(t *testing.T) {
 	pods, _, _ := cmdtesting.TestData()
 
@@ -2903,6 +2957,26 @@ func componentStatusTableObjBody(codec runtime.Codec, componentStatuses ...corev
 func emptyTableObjBody(codec runtime.Codec) io.ReadCloser {
 	table := &metav1.Table{
 		ColumnDefinitions: podColumns,
+	}
+	return cmdtesting.ObjBody(codec, table)
+}
+
+func replicationControllersScaleSubresourceTableObjBody(codec runtime.Codec, replicationControllers ...corev1.ReplicationController) io.ReadCloser {
+	table := &metav1.Table{
+		ColumnDefinitions: []metav1.TableColumnDefinition{
+			{Name: "Name", Type: "string", Description: metav1.ObjectMeta{}.SwaggerDoc()["name"]},
+			{Name: "Desired", Type: "integer", Description: autoscalingv1.ScaleSpec{}.SwaggerDoc()["replicas"]},
+			{Name: "Available", Type: "integer", Description: autoscalingv1.ScaleStatus{}.SwaggerDoc()["replicas"]},
+		},
+	}
+
+	for i := range replicationControllers {
+		b := bytes.NewBuffer(nil)
+		codec.Encode(&replicationControllers[i], b)
+		table.Rows = append(table.Rows, metav1.TableRow{
+			Object: runtime.RawExtension{Raw: b.Bytes()},
+			Cells:  []interface{}{replicationControllers[i].Name, replicationControllers[i].Spec.Replicas, replicationControllers[i].Status.Replicas},
+		})
 	}
 	return cmdtesting.ObjBody(codec, table)
 }

--- a/staging/src/k8s.io/kubectl/pkg/cmd/patch/patch.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/patch/patch.go
@@ -135,7 +135,7 @@ func NewCmdPatch(f cmdutil.Factory, ioStreams genericclioptions.IOStreams) *cobr
 	cmdutil.AddFilenameOptionFlags(cmd, &o.FilenameOptions, "identifying the resource to update")
 	cmd.Flags().BoolVar(&o.Local, "local", o.Local, "If true, patch will operate on the content of the file, not the server-side resource.")
 	cmdutil.AddFieldManagerFlagVar(cmd, &o.fieldManager, "kubectl-patch")
-	cmdutil.AddSubresourceFlags(cmd, &o.subresource, "If specified, patch will operate on the subresource of the requested object.")
+	cmdutil.AddSubresourceFlags(cmd, &o.subresource, "If specified, patch will operate on the subresource of the requested object.", cmdutil.SubresourceTypes)
 
 	return cmd
 }
@@ -195,7 +195,7 @@ func (o *PatchOptions) Validate() error {
 			return fmt.Errorf("--type must be one of %v, not %q", sets.StringKeySet(patchTypes).List(), o.PatchType)
 		}
 	}
-	if err := cmdutil.IsValidSubresource(o.subresource); err != nil {
+	if err := cmdutil.IsValidSubresource("patch", o.subresource); err != nil {
 		return err
 	}
 	return nil

--- a/staging/src/k8s.io/kubectl/pkg/cmd/replace/replace.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/replace/replace.go
@@ -95,6 +95,7 @@ type ReplaceOptions struct {
 	genericclioptions.IOStreams
 
 	fieldManager string
+	subresource  string
 }
 
 func NewReplaceOptions(streams genericclioptions.IOStreams) *ReplaceOptions {
@@ -132,6 +133,7 @@ func NewCmdReplace(f cmdutil.Factory, streams genericclioptions.IOStreams) *cobr
 
 	cmd.Flags().StringVar(&o.Raw, "raw", o.Raw, "Raw URI to PUT to the server.  Uses the transport specified by the kubeconfig file.")
 	cmdutil.AddFieldManagerFlagVar(cmd, &o.fieldManager, "kubectl-replace")
+	cmdutil.AddSubresourceFlags(cmd, &o.subresource, "If specified, replace will operate on the subresource of the requested object.")
 
 	return cmd
 }
@@ -238,6 +240,10 @@ func (o *ReplaceOptions) Validate(cmd *cobra.Command) error {
 		}
 	}
 
+	if err := cmdutil.IsValidSubresource(o.subresource); err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -262,6 +268,7 @@ func (o *ReplaceOptions) Run(f cmdutil.Factory) error {
 		ContinueOnError().
 		NamespaceParam(o.Namespace).DefaultNamespace().
 		FilenameParam(o.EnforceNamespace, &o.DeleteOptions.FilenameOptions).
+		Subresource(o.subresource).
 		Flatten().
 		Do()
 	if err := r.Err(); err != nil {
@@ -295,6 +302,7 @@ func (o *ReplaceOptions) Run(f cmdutil.Factory) error {
 			NewHelper(info.Client, info.Mapping).
 			DryRun(o.DryRunStrategy == cmdutil.DryRunServer).
 			WithFieldManager(o.fieldManager).
+			WithSubresource(o.subresource).
 			Replace(info.Namespace, info.Name, true, info.Object)
 		if err != nil {
 			return cmdutil.AddSourceToErr("replacing", info.Source, err)
@@ -330,6 +338,7 @@ func (o *ReplaceOptions) forceReplace() error {
 		NamespaceParam(o.Namespace).DefaultNamespace().
 		ResourceTypeOrNameArgs(false, o.BuilderArgs...).RequireObject(false).
 		FilenameParam(o.EnforceNamespace, &o.DeleteOptions.FilenameOptions).
+		Subresource(o.subresource).
 		Flatten()
 	if stdinInUse {
 		b = b.StdinInUse()
@@ -369,6 +378,7 @@ func (o *ReplaceOptions) forceReplace() error {
 		ContinueOnError().
 		NamespaceParam(o.Namespace).DefaultNamespace().
 		FilenameParam(o.EnforceNamespace, &o.DeleteOptions.FilenameOptions).
+		Subresource(o.subresource).
 		Flatten()
 	if stdinInUse {
 		b = b.StdinInUse()

--- a/staging/src/k8s.io/kubectl/pkg/cmd/replace/replace.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/replace/replace.go
@@ -133,7 +133,7 @@ func NewCmdReplace(f cmdutil.Factory, streams genericclioptions.IOStreams) *cobr
 
 	cmd.Flags().StringVar(&o.Raw, "raw", o.Raw, "Raw URI to PUT to the server.  Uses the transport specified by the kubeconfig file.")
 	cmdutil.AddFieldManagerFlagVar(cmd, &o.fieldManager, "kubectl-replace")
-	cmdutil.AddSubresourceFlags(cmd, &o.subresource, "If specified, replace will operate on the subresource of the requested object.")
+	cmdutil.AddSubresourceFlags(cmd, &o.subresource, "If specified, replace will operate on the subresource of the requested object.", cmdutil.SubresourceTypes)
 
 	return cmd
 }
@@ -240,7 +240,7 @@ func (o *ReplaceOptions) Validate(cmd *cobra.Command) error {
 		}
 	}
 
-	if err := cmdutil.IsValidSubresource(o.subresource); err != nil {
+	if err := cmdutil.IsValidSubresource("replace", o.subresource); err != nil {
 		return err
 	}
 

--- a/staging/src/k8s.io/kubectl/pkg/cmd/testing/util.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/testing/util.go
@@ -150,6 +150,22 @@ func EmptyTestData() (*corev1.PodList, *corev1.ServiceList, *corev1.ReplicationC
 	return pods, svc, rc
 }
 
+func SubresourceTestData() *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "test", ResourceVersion: "10"},
+		Spec: corev1.PodSpec{
+			RestartPolicy:                 corev1.RestartPolicyAlways,
+			DNSPolicy:                     corev1.DNSClusterFirst,
+			TerminationGracePeriodSeconds: &grace,
+			SecurityContext:               &corev1.PodSecurityContext{},
+			EnableServiceLinks:            &enableServiceLinks,
+		},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodPending,
+		},
+	}
+}
+
 func GenResponseWithJsonEncodedBody(bodyStruct interface{}) (*http.Response, error) {
 	jsonBytes, err := json.Marshal(bodyStruct)
 	if err != nil {

--- a/staging/src/k8s.io/kubectl/pkg/cmd/util/editor/editoptions.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/util/editor/editoptions.go
@@ -83,6 +83,8 @@ type EditOptions struct {
 	updatedResultGetter func(data []byte) *resource.Result
 
 	FieldManager string
+
+	Subresource string
 }
 
 // NewEditOptions returns an initialized EditOptions instance
@@ -183,6 +185,7 @@ func (o *EditOptions) Complete(f cmdutil.Factory, args []string, cmd *cobra.Comm
 	}
 	r := b.NamespaceParam(cmdNamespace).DefaultNamespace().
 		FilenameParam(enforceNamespace, &o.FilenameOptions).
+		Subresource(o.Subresource).
 		ContinueOnError().
 		Flatten().
 		Do()
@@ -197,6 +200,7 @@ func (o *EditOptions) Complete(f cmdutil.Factory, args []string, cmd *cobra.Comm
 		return f.NewBuilder().
 			Unstructured().
 			Stream(bytes.NewReader(data), "edited-file").
+			Subresource(o.Subresource).
 			ContinueOnError().
 			Flatten().
 			Do()
@@ -215,6 +219,9 @@ func (o *EditOptions) Complete(f cmdutil.Factory, args []string, cmd *cobra.Comm
 
 // Validate checks the EditOptions to see if there is sufficient information to run the command.
 func (o *EditOptions) Validate() error {
+	if err := cmdutil.IsValidSubresource("edit", o.Subresource); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -560,7 +567,7 @@ func (o *EditOptions) annotationPatch(update *resource.Info) error {
 	if err != nil {
 		return err
 	}
-	helper := resource.NewHelper(client, mapping).WithFieldManager(o.FieldManager)
+	helper := resource.NewHelper(client, mapping).WithFieldManager(o.FieldManager).WithSubresource(o.Subresource)
 	_, err = helper.Patch(o.CmdNamespace, update.Name, patchType, patch, nil)
 	if err != nil {
 		return err
@@ -692,7 +699,7 @@ func (o *EditOptions) visitToPatch(originalInfos []*resource.Info, patchVisitor 
 		}
 
 		patched, err := resource.NewHelper(info.Client, info.Mapping).
-			WithFieldManager(o.FieldManager).
+			WithFieldManager(o.FieldManager).WithSubresource(o.Subresource).
 			Patch(info.Namespace, info.Name, patchType, patch, nil)
 		if err != nil {
 			fmt.Fprintln(o.ErrOut, results.addError(err, info))

--- a/staging/src/k8s.io/kubectl/pkg/cmd/util/helpers.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/util/helpers.go
@@ -461,6 +461,10 @@ func AddChunkSizeFlag(cmd *cobra.Command, value *int64) {
 		"Return large lists in chunks rather than all at once. Pass 0 to disable. This flag is beta and may change in the future.")
 }
 
+func AddSubresourceFlags(cmd *cobra.Command, subresource *string, usage string) {
+	cmd.Flags().StringVar(subresource, "subresource", "", usage+fmt.Sprintf(" Must be one of %v. This flag is alpha and may change in the future.", subresourceTypes.List()))
+}
+
 type ValidateOptions struct {
 	EnableValidation bool
 }
@@ -745,4 +749,16 @@ func Warning(cmdErr io.Writer, newGeneratorName, oldGeneratorName string) {
 		newGeneratorName,
 		oldGeneratorName,
 	)
+}
+
+var subresourceTypes = sets.NewString("status", "scale")
+
+func IsValidSubresource(subresource string) error {
+	if len(subresource) == 0 {
+		return nil
+	}
+	if !subresourceTypes.Has(subresource) {
+		return fmt.Errorf("invalid subresource value: %q. Must be one of %v", subresource, subresourceTypes.List())
+	}
+	return nil
 }

--- a/staging/src/k8s.io/kubectl/pkg/cmd/util/helpers.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/util/helpers.go
@@ -461,8 +461,8 @@ func AddChunkSizeFlag(cmd *cobra.Command, value *int64) {
 		"Return large lists in chunks rather than all at once. Pass 0 to disable. This flag is beta and may change in the future.")
 }
 
-func AddSubresourceFlags(cmd *cobra.Command, subresource *string, usage string) {
-	cmd.Flags().StringVar(subresource, "subresource", "", usage+fmt.Sprintf(" Must be one of %v. This flag is alpha and may change in the future.", subresourceTypes.List()))
+func AddSubresourceFlags(cmd *cobra.Command, subresource *string, usage string, allowedSubresoruces sets.String) {
+	cmd.Flags().StringVar(subresource, "subresource", "", usage+fmt.Sprintf(" Must be one of %v. This flag is alpha and may change in the future.", allowedSubresoruces.List()))
 }
 
 type ValidateOptions struct {
@@ -751,14 +751,24 @@ func Warning(cmdErr io.Writer, newGeneratorName, oldGeneratorName string) {
 	)
 }
 
-var subresourceTypes = sets.NewString("status", "scale")
+var SubresourceTypes = sets.NewString("status", "scale")
+var StatusOnlySubresourceTypes = sets.NewString("status")
 
-func IsValidSubresource(subresource string) error {
+func IsValidSubresource(cmd string, subresource string) error {
 	if len(subresource) == 0 {
 		return nil
 	}
-	if !subresourceTypes.Has(subresource) {
-		return fmt.Errorf("invalid subresource value: %q. Must be one of %v", subresource, subresourceTypes.List())
+	switch cmd {
+	case "get", "patch", "replace":
+		if !SubresourceTypes.Has(subresource) {
+			return fmt.Errorf("invalid subresource value: %q. Must be one of %v", subresource, SubresourceTypes.List())
+		}
+	case "edit":
+		if !StatusOnlySubresourceTypes.Has(subresource) {
+			return fmt.Errorf("invalid subresource value: %q. Must be one of %v", subresource, StatusOnlySubresourceTypes.List())
+		}
+	default:
+		return fmt.Errorf("subresource used with unsupported command '%v'", cmd)
 	}
 	return nil
 }

--- a/staging/src/k8s.io/kubectl/pkg/cmd/util/helpers_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/util/helpers_test.go
@@ -321,3 +321,40 @@ func TestDumpReaderToFile(t *testing.T) {
 		t.Fatalf("Wrong file content %s != %s", testString, stringData)
 	}
 }
+
+func TestIsValidSubresource(t *testing.T) {
+	tests := []struct {
+		name        string
+		subresource string
+		isValid     bool
+	}{
+		{
+			name:        "Empty subresource - valid",
+			subresource: "",
+			isValid:     true,
+		},
+		{
+			name:        "Scale subresource - valid",
+			subresource: "scale",
+			isValid:     true,
+		},
+		{
+			name:        "Status subresource - valid",
+			subresource: "status",
+			isValid:     true,
+		},
+		{
+			name:        "invalid subresource - invalid",
+			subresource: "invalid",
+			isValid:     false,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			actual := IsValidSubresource(test.subresource)
+			if (actual == nil) != test.isValid {
+				t.Errorf("expected subresoruce validity to be '%v', got '%v'", test.isValid, actual)
+			}
+		})
+	}
+}

--- a/staging/src/k8s.io/kubectl/pkg/cmd/util/helpers_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/util/helpers_test.go
@@ -325,23 +325,33 @@ func TestDumpReaderToFile(t *testing.T) {
 func TestIsValidSubresource(t *testing.T) {
 	tests := []struct {
 		name        string
+		command     string
 		subresource string
 		isValid     bool
 	}{
 		{
 			name:        "Empty subresource - valid",
+			command:     "get",
 			subresource: "",
 			isValid:     true,
 		},
 		{
-			name:        "Scale subresource - valid",
+			name:        "Scale subresource with get - valid",
+			command:     "get",
 			subresource: "scale",
 			isValid:     true,
 		},
 		{
-			name:        "Status subresource - valid",
+			name:        "Status subresource with get - valid",
+			command:     "get",
 			subresource: "status",
 			isValid:     true,
+		},
+		{
+			name:        "Scale subresource with edit - invalid",
+			command:     "edit",
+			subresource: "scale",
+			isValid:     false,
 		},
 		{
 			name:        "invalid subresource - invalid",
@@ -351,7 +361,7 @@ func TestIsValidSubresource(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			actual := IsValidSubresource(test.subresource)
+			actual := IsValidSubresource(test.command, test.subresource)
 			if (actual == nil) != test.isValid {
 				t.Errorf("expected subresoruce validity to be '%v', got '%v'", test.isValid, actual)
 			}

--- a/test/cmd/get.sh
+++ b/test/cmd/get.sh
@@ -175,6 +175,14 @@ run_kubectl_get_tests() {
   output_message=$(! kubectl get pod valid-pod --allow-missing-template-keys=false -o go-template='{{.missing}}' "${kube_flags[@]}")
   kube::test::if_has_string "${output_message}" 'map has no entry for key "missing"'
 
+  ## check --subresource=status works
+  output_message=$(kubectl get "${kube_flags[@]}" pod valid-pod --subresource=status)
+  kube::test::if_has_string "${output_message}" 'valid-pod:'
+
+   ## check --subresource=status returns an error for pods
+  output_message=$(kubectl get "${kube_flags[@]}" pod valid-pod --subresource=scale)
+  kube::test::if_has_string "${output_message}" 'the server could not find the requested resource'
+
   ### Test kubectl get watch
   output_message=$(kubectl get pods -w --request-timeout=1 "${kube_flags[@]}")
   kube::test::if_has_string "${output_message}" 'STATUS'    # headers


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Implementation of KEP: Implements the KEP - https://github.com/kubernetes/enhancements/tree/master/keps/sig-cli/2590-kubectl-subresource

This adds `--subresource` flag support to `get`, `patch`, `edit` and `replace` commands in kubectl.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
An alpha flag --subresource is added to get, patch and replace kubectl commands to fetch and update status and scale subresources.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- [KEP]: - [KEP]: https://github.com/kubernetes/enhancements/tree/master/keps/sig-cli/2590-kubectl-subresource
```
