### PR TITLE
Fixes to wire in context to Single Use Tunnel.

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/server/egressselector/egress_selector_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/egressselector/egress_selector_test.go
@@ -176,7 +176,7 @@ type fakeProxyServerConnector struct {
 	proxierErr   bool
 }
 
-func (f *fakeProxyServerConnector) connect() (proxier, error) {
+func (f *fakeProxyServerConnector) connect(ctx context.Context) (proxier, error) {
 	if f.connectorErr {
 		return nil, fmt.Errorf("fake error")
 	}


### PR DESCRIPTION
Ensures we actually wire the context passed through
to connect, into the single use tunnnel.
Also fixed some of the error reporting.

#### What type of PR is this?

/kind feature
/kind failing-test

#### What this PR does / why we need it:
to connect, into the single use tunnnel.
Also fixed some of the error reporting.

#### Which issue(s) this PR fixes:
Fixes #102904

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs
NONE
```
