### PR TITLE
Add backwards compatibility for ephemeral containers in kubectl debug

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/debug/debug.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/debug/debug.go
@@ -124,7 +124,7 @@ type DebugOptions struct {
 	attachChanged         bool
 	shareProcessedChanged bool
 
-	podClient corev1client.PodsGetter
+	podClient corev1client.CoreV1Interface
 
 	genericclioptions.IOStreams
 }
@@ -413,10 +413,52 @@ func (o *DebugOptions) debugByEphemeralContainer(ctx context.Context, pod *corev
 		if serr, ok := err.(*errors.StatusError); ok && serr.Status().Reason == metav1.StatusReasonNotFound && serr.ErrStatus.Details.Name == "" {
 			return nil, "", fmt.Errorf("ephemeral containers are disabled for this cluster (error from server: %q).", err)
 		}
+
+		// The Kind used for the /ephemeralcontainers subresource changed in 1.22. When presented with an unexpected
+		// Kind the api server will respond with a not-registered error. When this happens we can optimistically try
+		// using the old API.
+		if runtime.IsNotRegisteredError(err) {
+			klog.V(1).Infof("Falling back to legacy API because server returned error: %v", err)
+			return o.debugByEphemeralContainerLegacy(ctx, pod, debugContainer)
+		}
+
 		return nil, "", err
 	}
 
 	return result, debugContainer.Name, nil
+}
+
+// debugByEphemeralContainerLegacy adds debugContainer as an ephemeral container using the pre-1.22 /ephemeralcontainers API
+// This may be removed when we no longer wish to support releases prior to 1.22.
+func (o *DebugOptions) debugByEphemeralContainerLegacy(ctx context.Context, pod *corev1.Pod, debugContainer *corev1.EphemeralContainer) (*corev1.Pod, string, error) {
+	// We no longer have the v1.EphemeralContainers Kind since it was removed in 1.22, but
+	// we can present a JSON 6902 patch that the api server will apply.
+	patch, err := json.Marshal([]map[string]interface{}{{
+		"op":    "add",
+		"path":  "/ephemeralContainers/-",
+		"value": debugContainer,
+	}})
+	if err != nil {
+		return nil, "", fmt.Errorf("error creating JSON 6902 patch for old /ephemeralcontainers API: %s", err)
+	}
+
+	result := o.podClient.RESTClient().Patch(types.JSONPatchType).
+		Namespace(pod.Namespace).
+		Resource("pods").
+		Name(pod.Name).
+		SubResource("ephemeralcontainers").
+		Body(patch).
+		Do(ctx)
+	if err := result.Error(); err != nil {
+		return nil, "", err
+	}
+
+	newPod, err := o.podClient.Pods(pod.Namespace).Get(ctx, pod.Name, metav1.GetOptions{})
+	if err != nil {
+		return nil, "", err
+	}
+
+	return newPod, debugContainer.Name, nil
 }
 
 // debugByCopy runs a copy of the target Pod with a debug container added or an original container modified


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
The ephemeral containers API changed in 1.22. As a result, kubectl debug (currently) cannot create ephemeral containers in clusters prior to 1.22.

This change causes kubectl to retry the request using the old API when it receives a specific error message from the server.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #102008

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
`kubectl debug` is able to create ephemeral containers in pre-1.22 clusters with the `EphemeralContainers` feature enabled. Note that versions of kubectl prior to 1.22 are unable to create ephemeral containers in clusters version 1.22 and greater due to an API change.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
