### PR TITLE
terminate long-running requests on termination

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/server/config.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/config.go
@@ -770,6 +770,7 @@ func DefaultBuildHandlerChain(apiHandler http.Handler, c *Config) http.Handler {
 	handler = filterlatency.TrackStarted(handler, "authentication")
 
 	handler = genericfilters.WithCORS(handler, c.CorsAllowedOriginList, nil, nil, nil, "true")
+	handler = genericfilters.WithLongRunningRequestTermination(handler, c.LongRunningFunc, c.lifecycleSignals.AfterShutdownDelayDuration.Signaled(), c.lifecycleSignals.InFlightRequestsDrained.Signaled())
 
 	// WithTimeoutForNonLongRunningRequests will call the rest of the request handling in a go-routine with the
 	// context with deadline. The go-routine can keep running, while the timeout logic will return a timeout to the client.

--- a/staging/src/k8s.io/apiserver/pkg/server/config_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/config_test.go
@@ -298,6 +298,7 @@ func TestAuthenticationAuditAnnotationsDefaultChain(t *testing.T) {
 		RequestInfoResolver:   &request.RequestInfoFactory{},
 		RequestTimeout:        10 * time.Second,
 		LongRunningFunc:       func(_ *http.Request, _ *request.RequestInfo) bool { return false },
+		lifecycleSignals:      newLifecycleSignals(),
 	}
 
 	h := DefaultBuildHandlerChain(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/staging/src/k8s.io/apiserver/pkg/server/filters/longrunning_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/filters/longrunning_test.go
@@ -1,0 +1,376 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package filters
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+
+	"golang.org/x/net/http2"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	kjson "k8s.io/apimachinery/pkg/runtime/serializer/json"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/apiserver/pkg/endpoints/handlers"
+	apirequest "k8s.io/apiserver/pkg/endpoints/request"
+	apitesting "k8s.io/apiserver/pkg/endpoints/testing"
+)
+
+// TestWatchRequestTerminationPanic checks if WithLongRunningRequestTermination handler catches and propagates a panic from an inner handler
+func TestWatchRequestTerminationPanic(t *testing.T) {
+	// setup: prepare general test data
+	terminationStartCh := make(chan struct{})
+	inFlightRequestsFinished := make(chan struct{})
+	shouldPanic := false
+	alwaysSatisfiedLongRunningCheckFn := func(r *http.Request, requestInfo *apirequest.RequestInfo) bool { return true }
+
+	panicHandler := http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		if shouldPanic {
+			panic("i was told to panic")
+		}
+		w.Write([]byte("hello from the server"))
+	})
+
+	var gotPanic interface{}
+	panicCatcher := func(delegate http.Handler) http.HandlerFunc {
+		return func(w http.ResponseWriter, req *http.Request) {
+			defer func() {
+				err := recover()
+				if err != nil {
+					gotPanic = err
+					panic(err)
+				}
+			}()
+			delegate.ServeHTTP(w, req)
+		}
+	}
+
+	// setup: create the backend server
+	//        wire a fake handler for populating RequestInfo required by WithLongRunningRequestTermination
+	//        wire WithLongRunningRequestTermination handler that wraps the panicHandler
+	backendServer := createServer(panicCatcher(withFakeRequestInfo(WithLongRunningRequestTermination(panicHandler, alwaysSatisfiedLongRunningCheckFn, terminationStartCh, inFlightRequestsFinished))), t)
+	backendServer.StartTLS()
+	defer backendServer.Close()
+
+	// setup: create the client
+	client := createClient(backendServer.URL)
+
+	// act: send a request to the server
+	//      just to see if the wiring is in place
+	dest, _ := url.Parse(backendServer.URL)
+	req, _ := http.NewRequest("GET", dest.String(), nil)
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	rspFromServer, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(rspFromServer) != "hello from the server" {
+		t.Fatalf("unexpected rsp from the server: %q", string(rspFromServer))
+	}
+	resp.Body.Close()
+
+	// act: instruct panicCatcher handler to panic and verify if it was
+	//      caught by WithLongRunningRequestTermination filter and passed up the stack to the next handler
+	shouldPanic = true
+	resp, err = client.Do(req.Clone(context.TODO()))
+	if err == nil {
+		t.Errorf("expected to get an error")
+	}
+	if gotPanic == nil {
+		t.Errorf("expected to get panic")
+	}
+	if fmt.Sprintf("%v", gotPanic) != "i was told to panic" {
+		t.Errorf("unexpected panic msg = %q, exptected  = %q", gotPanic, "i was told to panic")
+	}
+}
+
+// TestWatchRequestTerminationUngraceful checks if the handler receives the termination signal (after closing terminationStartCh) and will be eventually forcefully killed when inFlightRequestsFinished is closed
+func TestWatchRequestTerminationUngraceful(t *testing.T) {
+	// setup: prepare general test data
+	terminationStartCh := make(chan struct{})
+	inFlightRequestsFinished := make(chan struct{})
+	ctxCancelled := false
+	holdRequestAndInitTerminationCh := make(chan struct{})
+	alwaysSatisfiedLongRunningCheckFn := func(r *http.Request, requestInfo *apirequest.RequestInfo) bool { return true }
+
+	initTerminationHandler := http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		select {
+		case <-holdRequestAndInitTerminationCh:
+			close(terminationStartCh)
+
+			time.Sleep(1 * time.Second)
+			select {
+			case <-req.Context().Done():
+				ctxCancelled = true
+				close(inFlightRequestsFinished)
+			default:
+				// ctxCancelled set to false - the test will fail
+				return
+			}
+
+			time.Sleep(100 * time.Hour)
+			return
+		default:
+		}
+		w.Write([]byte("hello from the server"))
+	})
+
+	// setup: create the backend server
+	//        wire a fake handler for populating RequestInfo required by WithLongRunningRequestTermination
+	//        wire WithLongRunningRequestTermination handler that wraps the initTerminationHandler
+	backendServer := createServer(withFakeRequestInfo(WithLongRunningRequestTermination(initTerminationHandler, alwaysSatisfiedLongRunningCheckFn, terminationStartCh, inFlightRequestsFinished)), t)
+	backendServer.StartTLS()
+	defer backendServer.Close()
+
+	// setup: create the client
+	client := createClient(backendServer.URL)
+
+	// act: send a request to the server
+	//      just to see if the wiring is in place
+	dest, _ := url.Parse(backendServer.URL)
+	req, _ := http.NewRequest("GET", dest.String(), nil)
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	rspFromServer, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(rspFromServer) != "hello from the server" {
+		t.Fatalf("unexpected rsp from the server: %q", string(rspFromServer))
+	}
+	resp.Body.Close()
+
+	// act: send a signal to the handler to hold up the requests and then send an HTTP req
+	//      note that initTerminationHandler will close terminationStartCh
+	close(holdRequestAndInitTerminationCh)
+	resp, err = client.Do(req.Clone(context.TODO()))
+	if err == nil {
+		t.Errorf("expected to get an error")
+	}
+	if !ctxCancelled {
+		t.Errorf("the cancellaciton signal wasn't propagated to the handler")
+	}
+}
+
+// TestWatchRequestTermination examines WithLongRunningRequestTermination handler.
+// It makes sure that the new handler will propagate the termination signal to the watch server
+// which in turn propagates the signal to the client.
+func TestWatchRequestTermination(t *testing.T) {
+	// setup: prepare general test data
+	encoder := testEncoder{}
+	terminationStartCh := make(chan struct{})
+	inFlightRequestsFinished := make(chan struct{})
+	alwaysSatisfiedLongRunningCheckFn := func(r *http.Request, requestInfo *apirequest.RequestInfo) bool { return true }
+
+	// setup: create a new watch server
+	watcher := watch.NewFake()
+	watchServer := &handlers.WatchServer{
+		Scope:    &handlers.RequestScope{},
+		Watching: watcher,
+
+		Framer:          kjson.Framer,
+		Encoder:         encoder,
+		EmbeddedEncoder: encoder,
+
+		Fixup:          func(obj runtime.Object) runtime.Object { return obj },
+		TimeoutFactory: &fakeTimeoutFactory{make(chan time.Time), make(chan struct{})},
+	}
+
+	// setup: create the backend server
+	//        wire a fake handler for populating RequestInfo required by WithLongRunningRequestTermination
+	//        wire WithLongRunningRequestTermination handler that wraps the watchServer
+	backendServer := createServer(withFakeRequestInfo(WithLongRunningRequestTermination(watchServer, alwaysSatisfiedLongRunningCheckFn, terminationStartCh, inFlightRequestsFinished)), t)
+	backendServer.StartTLS()
+	defer backendServer.Close()
+
+	// setup: create the client
+	client := createClient(backendServer.URL)
+
+	// act: establish a WATCH request to the server
+	resp, err := client.Do(createWatchRequest(backendServer.URL))
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	defer resp.Body.Close()
+
+	// act: fake an event the server would get from etcd
+	watcher.Add(&apitesting.Simple{})
+
+	// act: read a watch event from the server
+	decoder := json.NewDecoder(resp.Body)
+	var got watchRsp
+	err = decoder.Decode(&got)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	if got.Type != watch.Added {
+		t.Fatalf("Unexpected watch event: %q, expected %q", got.Type, watch.Added)
+	}
+
+	// act: initiate the server shutdown and read from the server.
+	//      the signal will be propagated to the watch server
+	//      which will close the connection with the test client
+	close(terminationStartCh)
+	err = decoder.Decode(&got)
+
+	// validate: we expect to get EOF from the server,
+	//           EOF is the error returned by Read when no more input is available.
+	//           it is a signal of a graceful end of input.
+	if err != io.EOF {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+}
+
+func createServer(handler http.Handler, t *testing.T) *httptest.Server {
+	backendServer := httptest.NewUnstartedServer(handler)
+	backendServer.EnableHTTP2 = true
+	backendCert, err := tls.X509KeyPair(backendCrt, backendKey)
+	if err != nil {
+		t.Fatalf("backend: invalid x509/key pair: %v", err)
+	}
+	backendServer.TLS = &tls.Config{
+		Certificates: []tls.Certificate{backendCert},
+		NextProtos:   []string{http2.NextProtoTLS},
+	}
+	return backendServer
+}
+
+func createClient(server string) http.Client {
+	clientCACertPool := x509.NewCertPool()
+	clientCACertPool.AppendCertsFromPEM(backendCrt)
+	clientTLSConfig := &tls.Config{
+		RootCAs:    clientCACertPool,
+		NextProtos: []string{http2.NextProtoTLS},
+	}
+	client := http.Client{}
+	client.Transport = &http2.Transport{
+		TLSClientConfig: clientTLSConfig,
+	}
+	return client
+}
+
+func createWatchRequest(server string) *http.Request {
+	dest, _ := url.Parse(server)
+	dest.RawQuery = "watch=true"
+	req, _ := http.NewRequest("GET", dest.String(), nil)
+	return req
+}
+
+type testEncoder struct{}
+
+func (e testEncoder) Encode(obj runtime.Object, w io.Writer) error {
+	objRaw, err := json.Marshal(obj)
+	if err != nil {
+		return err
+	}
+	_, err = w.Write(objRaw)
+	return err
+}
+
+func (e testEncoder) Identifier() runtime.Identifier {
+	return runtime.Identifier("testEncoder")
+}
+
+type watchRsp struct {
+	Type   watch.EventType `json:"type,omitempty"`
+	Object json.RawMessage `json:"object,omitempty"`
+}
+
+func withFakeRequestInfo(handler http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		ctx := req.Context()
+		req = req.WithContext(apirequest.WithRequestInfo(ctx, &apirequest.RequestInfo{}))
+		handler.ServeHTTP(w, req)
+	})
+}
+
+type fakeTimeoutFactory struct {
+	timeoutCh chan time.Time
+	done      chan struct{}
+}
+
+func (t *fakeTimeoutFactory) TimeoutCh() (<-chan time.Time, func() bool) {
+	return t.timeoutCh, func() bool {
+		defer close(t.done)
+		return true
+	}
+}
+
+var backendCrt = []byte(`-----BEGIN CERTIFICATE-----
+MIIDTjCCAjagAwIBAgIJANYWBFaLyBC/MA0GCSqGSIb3DQEBCwUAMFAxCzAJBgNV
+BAYTAlBMMQ8wDQYDVQQIDAZQb2xhbmQxDzANBgNVBAcMBkdkYW5zazELMAkGA1UE
+CgwCU0sxEjAQBgNVBAMMCTEyNy4wLjAuMTAeFw0yMDEyMTExMDI0MzBaFw0zMDEy
+MDkxMDI0MzBaMFAxCzAJBgNVBAYTAlBMMQ8wDQYDVQQIDAZQb2xhbmQxDzANBgNV
+BAcMBkdkYW5zazELMAkGA1UECgwCU0sxEjAQBgNVBAMMCTEyNy4wLjAuMTCCASIw
+DQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAMYax2q/m/N237UFMFKZsox4EyKq
+De+mbaRGeKqnI7Gi9Ai3b7BPCIa7RFJ2ntpGUd5GyL+HCQHG8/f6DjsbUuhZnmn7
+F7ZJeih2DP2acKkODdGbXA52kABCMdDs2DMYhR2UwECY2t+DLpxqJqE2ab8pI9Xd
+BZ3pCNodS03yHXzfeJV44lCjxoDOi9ynXLjd3w3+FowomHMEBunTepiqnbgoYtnn
+RW9tQyQQK5g6+/j/O1M8o71s/0loBT3vKSqNSrdlMOEGrj4yyL/Cw1NmQf1V1sGf
+w1QAW5xk7Br5oh8h1D+oflGWV3Y3zluuZQnA9D+vFpjL0969oFedsgr4UU8CAwEA
+AaMrMCkwCQYDVR0TBAIwADALBgNVHQ8EBAMCBaAwDwYDVR0RBAgwBocEfwAAATAN
+BgkqhkiG9w0BAQsFAAOCAQEAWbOF7TOfGiC59S50okfcS7M4gwz2kcbqOftWzcA1
+lT1qX6TWj7A4bVIOMAFK2tWNd4Omk6bnIAxTJdHB7b1hrBjkpt2krEGH1S8xeRRz
+Gs62KQwehM3fMhLvYSEqOQMETZn9AjEigYm6ohCO5obG9Gkfz7uvuv9rbIetbAmm
+YE9HdDv6qhCqtynpP2yad3v53idlrDnCIe9e4eKUD5uR/MIp9mEFgnMXR1m43/ya
+DnmddSsjtzamVvI/+2Cqjb8qT8dMHZrCBK64UwSaJsUKzSeF6yNvZKQ1yfA/NrfV
+P6gNULDOqtPgXFP4j+Z402gjYox1bGHjeDHh1OVSnr9jVw==
+-----END CERTIFICATE-----`)
+
+var backendKey = []byte(`-----BEGIN PRIVATE KEY-----
+MIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQDGGsdqv5vzdt+1
+BTBSmbKMeBMiqg3vpm2kRniqpyOxovQIt2+wTwiGu0RSdp7aRlHeRsi/hwkBxvP3
++g47G1LoWZ5p+xe2SXoodgz9mnCpDg3Rm1wOdpAAQjHQ7NgzGIUdlMBAmNrfgy6c
+aiahNmm/KSPV3QWd6QjaHUtN8h1833iVeOJQo8aAzovcp1y43d8N/haMKJhzBAbp
+03qYqp24KGLZ50VvbUMkECuYOvv4/ztTPKO9bP9JaAU97ykqjUq3ZTDhBq4+Msi/
+wsNTZkH9VdbBn8NUAFucZOwa+aIfIdQ/qH5Rlld2N85brmUJwPQ/rxaYy9PevaBX
+nbIK+FFPAgMBAAECggEAKmdZABR7gSWUxN6TdVrIySB6mBTmXsG0/lDHS1/zV/aV
+XbhGA+sm3BABk9UoM3iR1Y45MiXpW6QGXLH9kdFLccidC/pfHPmlWDvMlAwWyVjk
+xFUI41+leyiwGRRZQrag57ALZshRMT6XH4vpMODAydY4gXKJ3T8gUe+rSsfkX/Hl
+Ce59c8pDsV3NDy4WKy00lYZfTqBqHu10qy9W8/eVYf+RUt53nrygCesnFfmJx/P8
+GnHnN06QbZdpgVgbU49u+BujkjFgKH/60Ct9A19o34upXvkPOaKbABZ4dL1lUrbo
+e3L3vnSdgXh1oOsy/JyICmDG5M2b68h33YNa+qUEgQKBgQDs1rf1+hw75o7iDlnx
+E46CPC+9DkDuisWLgbUyW5KHPgropPl80uqnRxmaWpYGU/Fgyml08orpduHIWxtU
+0tMRKm2HoFRM010fAp3xWc/B4pt2pdRMMSjMle//4FmoNlcJ8+owmD+2eook9Qjm
+qN1UsQllkSoH4zx4iI+HhDJnHwKBgQDWIdGmlZqaYGhsndkco9yK+gve6W80ik4J
+qnjnv9ux28SBrlORn2zzfGcu5LkJw8Dp9yjZzVUiFT8VFsWVNNuJyFba227Qxrwz
+Hb/qvd5l2DfXHk4poyMZThzg7cxkxlVaWUIBMoGynDxQZIOypc6WmTeEG5+9W4+w
+NCuTKt6/0QKBgQCOgALftUUXpXmC+i+TpbixE5WFovXekRCbB8gGLKLVTLczk0+p
+kx4s19LH1Ik/9XHeUutwuh5qqmTfMDIZr1/fjC+q0wTl1KbK6cAuX2NpvPbdRJmf
+3lQ2BGELC+nmFAv6qQ/XfUOYf9JuuiBI6IGDW6HTwqwPYuIXg9MYLqpE8QKBgA/2
+2YCH6szTnzVp10PxW4Ho/nWSBb5vCT5jPTxZ63EpJ09bxdM3hZHplm/CkaEOvRU0
+XhFO46f02Y0i83waQrvU+dS7Q1nBV0qgTyybFzeUlSUulzk3dmhukGycjf59YuOn
+f+pC77R3PW/o7oClJ+/GYIMy5AfkCaRjX1RLf+vhAoGBANJBi0ARkhwOWbnD2urA
+0tPMURSYIZ+JW7ghMspbm1XV1NTreCB/llLNqUGQ7zLAmH+KyqJK8O37/oh3VHrV
+6jp9pqrqmibtGEIpQi4D9IM8Zo9mc8GexCf0x+11mamC+ZXjT+bvLQzbcJGnG5CL
+W+S7SneWTL09leh5ATNhog6s
+-----END PRIVATE KEY-----`)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it: 

It turns out that closing the server always takes `ShutdownTimeout`. In our case, it is always 60 seconds. 

However, it wasn’t always like that. Back in the old days the http server didn’t wait for in-flight requests at all and close them ungracefully. The issue was fixed in go 1.16. Now it waits until all pending requests are finished. It turns out that’s exactly what holds the server for `ShutdownTimeout`. The long-running requests like for example the `WATCH` requests which are not hijacked must be torn down by the server.

It also turns out that closing the long-running requests is not that easy. They might be blocked on various things like `io.Read`. So, instead of trying to identify all current and future issues, we provide a filter that ensures termination of long-running requests.

The new filter runs two additional goroutines. One for running the request and the second one for intercepting the termination signal and propagating it to the requests. If the request is not terminated within 5 seconds it will be forcefully killed.

Before:
![termination-always-60s](https://user-images.githubusercontent.com/21304151/121369522-36d3c100-c93c-11eb-8bc0-9e4b3986ff4b.png)

After:
![Screenshot 2021-06-10 at 09 55 21](https://user-images.githubusercontent.com/21304151/121490864-b8c3f880-c9d5-11eb-9d58-8c4f1fda5519.png)

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fix kube-apiserver not to wait for watches to end before gracefully termination can finish.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
