### PR TITLE
e2e: node: fix the device plugin test

### DIFF
--- a/test/e2e_node/image_list.go
+++ b/test/e2e_node/image_list.go
@@ -65,6 +65,8 @@ var NodePrePullImageList = sets.NewString(
 	imageutils.GetE2EImage(imageutils.NodePerfTfWideDeep),
 )
 
+type getDevicePluginImageFunc func() (string, error)
+
 // updateImageAllowList updates the framework.ImagePrePullList with
 // 1. the hard coded lists
 // 2. the ones passed in from framework.TestContext.ExtraEnvs
@@ -74,15 +76,17 @@ func updateImageAllowList() {
 	framework.ImagePrePullList = NodePrePullImageList.Union(commontest.PrePulledImages)
 	// Images from extra envs
 	framework.ImagePrePullList.Insert(getNodeProblemDetectorImage())
-	if sriovDevicePluginImage, err := getSRIOVDevicePluginImage(); err != nil {
-		klog.Errorln(err)
-	} else {
-		framework.ImagePrePullList.Insert(sriovDevicePluginImage)
-	}
-	if gpuDevicePluginImage, err := getGPUDevicePluginImage(); err != nil {
-		klog.Errorln(err)
-	} else {
-		framework.ImagePrePullList.Insert(gpuDevicePluginImage)
+
+	for _, getImage := range []getDevicePluginImageFunc{
+		getSRIOVDevicePluginImage,
+		getGPUDevicePluginImage,
+		getSampleDevicePluginImage,
+	} {
+		if devicePluginImage, err := getImage(); err != nil {
+			klog.Errorln(err)
+		} else {
+			framework.ImagePrePullList.Insert(devicePluginImage)
+		}
 	}
 }
 
@@ -239,6 +243,25 @@ func getGPUDevicePluginImage() (string, error) {
 // getSRIOVDevicePluginImage returns the image of SRIOV device plugin.
 func getSRIOVDevicePluginImage() (string, error) {
 	data, err := e2etestfiles.Read(SRIOVDevicePluginDSYAML)
+	if err != nil {
+		return "", fmt.Errorf("failed to read the device plugin manifest: %w", err)
+	}
+	ds, err := e2emanifest.DaemonSetFromData(data)
+	if err != nil {
+		return "", fmt.Errorf("failed to parse the device plugin image: %w", err)
+	}
+	if ds == nil {
+		return "", fmt.Errorf("failed to parse the device plugin image: the extracted DaemonSet is nil")
+	}
+	if len(ds.Spec.Template.Spec.Containers) < 1 {
+		return "", fmt.Errorf("failed to parse the device plugin image: cannot extract the container from YAML")
+	}
+	return ds.Spec.Template.Spec.Containers[0].Image, nil
+}
+
+// getSampleDevicePluginImage returns the image of the sample device plugin.
+func getSampleDevicePluginImage() (string, error) {
+	data, err := e2etestfiles.Read(SampleDevicePluginDSYAML)
 	if err != nil {
 		return "", fmt.Errorf("failed to read the device plugin manifest: %w", err)
 	}

--- a/test/e2e_node/util_sample_device.go
+++ b/test/e2e_node/util_sample_device.go
@@ -1,0 +1,26 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2enode
+
+const (
+	// SampleResourceName is the name of the example resource which is used in the e2e test
+	SampleResourceName = "example.com/resource"
+	// SampleDevicePluginDSYAML is the path of the daemonset template of the sample device plugin. // TODO: Parametrize it by making it a feature in TestFramework.
+	SampleDevicePluginDSYAML = "test/e2e/testing-manifests/sample-device-plugin.yaml"
+	// SampleDevicePluginName is the name of the device plugin pod
+	SampleDevicePluginName = "sample-device-plugin"
+)


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind failing-test

#### What this PR does / why we need it:
The DevicePluginProbe test was constantly failing lately.
One of the key reasons was that the testing pod was restarting too often.
In general this test suffered a bit of bit rot, but we postpone larger cleanups until the kubelet-node-serial lane is reliable again.

#### Which issue(s) this PR fixes:
https://github.com/kubernetes/kubernetes/issues/103691

#### Special notes for your reviewer:
**PARTIALLY** Fixes https://github.com/kubernetes/kubernetes/issues/102148 - Other failure in the serial lane will be addressed by other PRs.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```