### PR TITLE
Cleanup: re-order the imports in kubeadm

### DIFF
--- a/cmd/kubeadm/app/apis/kubeadm/fuzzer/fuzzer.go
+++ b/cmd/kubeadm/app/apis/kubeadm/fuzzer/fuzzer.go
@@ -17,12 +17,14 @@ limitations under the License.
 package fuzzer
 
 import (
-	fuzz "github.com/google/gofuzz"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	runtimeserializer "k8s.io/apimachinery/pkg/runtime/serializer"
 	bootstraptokenv1 "k8s.io/kubernetes/cmd/kubeadm/app/apis/bootstraptoken/v1"
 	"k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
 	"k8s.io/kubernetes/cmd/kubeadm/app/constants"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	runtimeserializer "k8s.io/apimachinery/pkg/runtime/serializer"
+
+	fuzz "github.com/google/gofuzz"
 )
 
 // Funcs returns the fuzzer functions for the kubeadm apis.

--- a/cmd/kubeadm/app/apis/kubeadm/fuzzer/fuzzer_test.go
+++ b/cmd/kubeadm/app/apis/kubeadm/fuzzer/fuzzer_test.go
@@ -19,8 +19,9 @@ package fuzzer
 import (
 	"testing"
 
-	"k8s.io/apimachinery/pkg/api/apitesting/roundtrip"
 	"k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/scheme"
+
+	"k8s.io/apimachinery/pkg/api/apitesting/roundtrip"
 )
 
 func TestRoundTripTypes(t *testing.T) {

--- a/cmd/kubeadm/app/apis/kubeadm/scheme/scheme.go
+++ b/cmd/kubeadm/app/apis/kubeadm/scheme/scheme.go
@@ -17,14 +17,15 @@ limitations under the License.
 package scheme
 
 import (
+	"k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
+	"k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1beta2"
+	"k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1beta3"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
-	"k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
-	"k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1beta2"
-	"k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1beta3"
 )
 
 // Scheme is the runtime.Scheme to which all kubeadm api types are registered.

--- a/cmd/kubeadm/app/apis/kubeadm/types.go
+++ b/cmd/kubeadm/app/apis/kubeadm/types.go
@@ -19,11 +19,12 @@ package kubeadm
 import (
 	"crypto/x509"
 
+	"k8s.io/kubernetes/cmd/kubeadm/app/features"
+
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	bootstraptokenv1 "k8s.io/kubernetes/cmd/kubeadm/app/apis/bootstraptoken/v1"
-	"k8s.io/kubernetes/cmd/kubeadm/app/features"
 )
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/cmd/kubeadm/app/apis/kubeadm/v1beta2/bootstraptokenstring.go
+++ b/cmd/kubeadm/app/apis/kubeadm/v1beta2/bootstraptokenstring.go
@@ -20,10 +20,10 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/pkg/errors"
-
 	bootstrapapi "k8s.io/cluster-bootstrap/token/api"
 	bootstraputil "k8s.io/cluster-bootstrap/token/util"
+
+	"github.com/pkg/errors"
 )
 
 // BootstrapTokenString is a token of the format abcdef.abcdef0123456789 that is used

--- a/cmd/kubeadm/app/apis/kubeadm/v1beta2/conversion.go
+++ b/cmd/kubeadm/app/apis/kubeadm/v1beta2/conversion.go
@@ -17,8 +17,9 @@ limitations under the License.
 package v1beta2
 
 import (
-	conversion "k8s.io/apimachinery/pkg/conversion"
 	kubeadm "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
+
+	conversion "k8s.io/apimachinery/pkg/conversion"
 )
 
 func Convert_kubeadm_InitConfiguration_To_v1beta2_InitConfiguration(in *kubeadm.InitConfiguration, out *InitConfiguration, s conversion.Scope) error {

--- a/cmd/kubeadm/app/apis/kubeadm/v1beta2/defaults.go
+++ b/cmd/kubeadm/app/apis/kubeadm/v1beta2/defaults.go
@@ -20,9 +20,10 @@ import (
 	"net/url"
 	"time"
 
+	"k8s.io/kubernetes/cmd/kubeadm/app/constants"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/kubernetes/cmd/kubeadm/app/constants"
 )
 
 const (

--- a/cmd/kubeadm/app/apis/kubeadm/v1beta3/conversion.go
+++ b/cmd/kubeadm/app/apis/kubeadm/v1beta3/conversion.go
@@ -17,8 +17,9 @@ limitations under the License.
 package v1beta3
 
 import (
-	conversion "k8s.io/apimachinery/pkg/conversion"
 	kubeadm "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
+
+	conversion "k8s.io/apimachinery/pkg/conversion"
 )
 
 func Convert_kubeadm_InitConfiguration_To_v1beta3_InitConfiguration(in *kubeadm.InitConfiguration, out *InitConfiguration, s conversion.Scope) error {

--- a/cmd/kubeadm/app/apis/kubeadm/v1beta3/defaults.go
+++ b/cmd/kubeadm/app/apis/kubeadm/v1beta3/defaults.go
@@ -20,10 +20,11 @@ import (
 	"net/url"
 	"time"
 
+	"k8s.io/kubernetes/cmd/kubeadm/app/constants"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	bootstraptokenv1 "k8s.io/kubernetes/cmd/kubeadm/app/apis/bootstraptoken/v1"
-	"k8s.io/kubernetes/cmd/kubeadm/app/constants"
 )
 
 const (

--- a/cmd/kubeadm/app/apis/kubeadm/validation/validation.go
+++ b/cmd/kubeadm/app/apis/kubeadm/validation/validation.go
@@ -25,14 +25,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/pkg/errors"
-	"github.com/spf13/pflag"
-	"k8s.io/apimachinery/pkg/util/sets"
-	"k8s.io/apimachinery/pkg/util/validation"
-	"k8s.io/apimachinery/pkg/util/validation/field"
-	bootstrapapi "k8s.io/cluster-bootstrap/token/api"
-	bootstraputil "k8s.io/cluster-bootstrap/token/util"
-	"k8s.io/klog/v2"
 	bootstraptokenv1 "k8s.io/kubernetes/cmd/kubeadm/app/apis/bootstraptoken/v1"
 	"k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
 	kubeadmapiv1 "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1beta3"
@@ -41,7 +33,17 @@ import (
 	"k8s.io/kubernetes/cmd/kubeadm/app/constants"
 	"k8s.io/kubernetes/cmd/kubeadm/app/features"
 	kubeadmutil "k8s.io/kubernetes/cmd/kubeadm/app/util"
+
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/validation"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	bootstrapapi "k8s.io/cluster-bootstrap/token/api"
+	bootstraputil "k8s.io/cluster-bootstrap/token/util"
+	"k8s.io/klog/v2"
 	utilnet "k8s.io/utils/net"
+
+	"github.com/pkg/errors"
+	"github.com/spf13/pflag"
 )
 
 // ValidateInitConfiguration validates an InitConfiguration object and collects all encountered errors

--- a/cmd/kubeadm/app/apis/kubeadm/validation/validation_test.go
+++ b/cmd/kubeadm/app/apis/kubeadm/validation/validation_test.go
@@ -21,12 +21,14 @@ import (
 	"os"
 	"testing"
 
-	"github.com/spf13/pflag"
-	"k8s.io/apimachinery/pkg/util/sets"
-	"k8s.io/apimachinery/pkg/util/validation/field"
 	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
 	kubeadmapiv1 "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1beta3"
 	"k8s.io/kubernetes/cmd/kubeadm/app/features"
+
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+
+	"github.com/spf13/pflag"
 )
 
 func TestValidateToken(t *testing.T) {

--- a/cmd/kubeadm/app/apis/output/fuzzer/fuzzer.go
+++ b/cmd/kubeadm/app/apis/output/fuzzer/fuzzer.go
@@ -19,11 +19,13 @@ package fuzzer
 import (
 	"time"
 
-	fuzz "github.com/google/gofuzz"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	runtimeserializer "k8s.io/apimachinery/pkg/runtime/serializer"
 	kubeadmapiv1beta2 "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1beta2"
 	"k8s.io/kubernetes/cmd/kubeadm/app/apis/output"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	runtimeserializer "k8s.io/apimachinery/pkg/runtime/serializer"
+
+	fuzz "github.com/google/gofuzz"
 )
 
 // Funcs returns the fuzzer functions for the kubeadm apis.

--- a/cmd/kubeadm/app/apis/output/fuzzer/fuzzer_test.go
+++ b/cmd/kubeadm/app/apis/output/fuzzer/fuzzer_test.go
@@ -19,8 +19,9 @@ package fuzzer
 import (
 	"testing"
 
-	"k8s.io/apimachinery/pkg/api/apitesting/roundtrip"
 	"k8s.io/kubernetes/cmd/kubeadm/app/apis/output/scheme"
+
+	"k8s.io/apimachinery/pkg/api/apitesting/roundtrip"
 )
 
 func TestRoundTripTypes(t *testing.T) {

--- a/cmd/kubeadm/app/apis/output/scheme/scheme.go
+++ b/cmd/kubeadm/app/apis/output/scheme/scheme.go
@@ -17,13 +17,14 @@ limitations under the License.
 package scheme
 
 import (
+	"k8s.io/kubernetes/cmd/kubeadm/app/apis/output"
+	"k8s.io/kubernetes/cmd/kubeadm/app/apis/output/v1alpha1"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
-	"k8s.io/kubernetes/cmd/kubeadm/app/apis/output"
-	"k8s.io/kubernetes/cmd/kubeadm/app/apis/output/v1alpha1"
 )
 
 // Scheme is the runtime.Scheme to which all kubeadm api types are registered.

--- a/cmd/kubeadm/app/apis/output/types.go
+++ b/cmd/kubeadm/app/apis/output/types.go
@@ -17,8 +17,9 @@ limitations under the License.
 package output
 
 import (
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kubeadmapiv1beta2 "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1beta2"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/cmd/kubeadm/app/apis/output/v1alpha1/types.go
+++ b/cmd/kubeadm/app/apis/output/v1alpha1/types.go
@@ -17,8 +17,9 @@ limitations under the License.
 package v1alpha1
 
 import (
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kubeadmapiv1beta2 "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1beta2"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/cmd/kubeadm/app/cmd/certs.go
+++ b/cmd/kubeadm/app/cmd/certs.go
@@ -21,13 +21,6 @@ import (
 	"io"
 	"text/tabwriter"
 
-	"github.com/lithammer/dedent"
-	"github.com/pkg/errors"
-	"github.com/spf13/cobra"
-	"github.com/spf13/pflag"
-
-	"k8s.io/apimachinery/pkg/util/duration"
-
 	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
 	kubeadmscheme "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/scheme"
 	kubeadmapiv1 "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1beta3"
@@ -40,6 +33,13 @@ import (
 	kubeconfigphase "k8s.io/kubernetes/cmd/kubeadm/app/phases/kubeconfig"
 	configutil "k8s.io/kubernetes/cmd/kubeadm/app/util/config"
 	kubeconfigutil "k8s.io/kubernetes/cmd/kubeadm/app/util/kubeconfig"
+
+	"k8s.io/apimachinery/pkg/util/duration"
+
+	"github.com/lithammer/dedent"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 )
 
 var (

--- a/cmd/kubeadm/app/cmd/certs_test.go
+++ b/cmd/kubeadm/app/cmd/certs_test.go
@@ -26,13 +26,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/spf13/cobra"
-	"github.com/spf13/pflag"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-
-	"k8s.io/client-go/tools/clientcmd"
-
 	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
 	kubeadmapiv1 "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1beta3"
 	kubeadmconstants "k8s.io/kubernetes/cmd/kubeadm/app/constants"
@@ -41,6 +34,13 @@ import (
 	"k8s.io/kubernetes/cmd/kubeadm/app/util/pkiutil"
 	testutil "k8s.io/kubernetes/cmd/kubeadm/test"
 	cmdtestutil "k8s.io/kubernetes/cmd/kubeadm/test/cmd"
+
+	"k8s.io/client-go/tools/clientcmd"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestCommandsGenerated(t *testing.T) {

--- a/cmd/kubeadm/app/cmd/cmd.go
+++ b/cmd/kubeadm/app/cmd/cmd.go
@@ -19,15 +19,15 @@ package cmd
 import (
 	"io"
 
-	"github.com/lithammer/dedent"
-	"github.com/spf13/cobra"
-
 	"k8s.io/kubernetes/cmd/kubeadm/app/cmd/alpha"
 	"k8s.io/kubernetes/cmd/kubeadm/app/cmd/options"
 	"k8s.io/kubernetes/cmd/kubeadm/app/cmd/upgrade"
 	kubeadmutil "k8s.io/kubernetes/cmd/kubeadm/app/util"
 	// Register the kubeadm configuration types because CLI flag generation
 	// depends on the generated defaults.
+
+	"github.com/lithammer/dedent"
+	"github.com/spf13/cobra"
 )
 
 // NewKubeadmCommand returns cobra.Command to run kubeadm command

--- a/cmd/kubeadm/app/cmd/completion.go
+++ b/cmd/kubeadm/app/cmd/completion.go
@@ -20,10 +20,11 @@ import (
 	"bytes"
 	"io"
 
+	"k8s.io/klog/v2"
+
 	"github.com/lithammer/dedent"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
-	"k8s.io/klog/v2"
 )
 
 const defaultBoilerPlate = `

--- a/cmd/kubeadm/app/cmd/config.go
+++ b/cmd/kubeadm/app/cmd/config.go
@@ -24,14 +24,6 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/lithammer/dedent"
-	"github.com/pkg/errors"
-	"github.com/spf13/cobra"
-	flag "github.com/spf13/pflag"
-
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/cli-runtime/pkg/genericclioptions"
 	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
 	kubeadmscheme "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/scheme"
 	kubeadmapiv1 "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1beta3"
@@ -46,7 +38,16 @@ import (
 	configutil "k8s.io/kubernetes/cmd/kubeadm/app/util/config"
 	"k8s.io/kubernetes/cmd/kubeadm/app/util/output"
 	utilruntime "k8s.io/kubernetes/cmd/kubeadm/app/util/runtime"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
 	utilsexec "k8s.io/utils/exec"
+
+	"github.com/lithammer/dedent"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+	flag "github.com/spf13/pflag"
 )
 
 // newCmdConfig returns cobra.Command for "kubeadm config" command

--- a/cmd/kubeadm/app/cmd/config_test.go
+++ b/cmd/kubeadm/app/cmd/config_test.go
@@ -29,8 +29,6 @@ import (
 	"testing"
 	"text/template"
 
-	"github.com/lithammer/dedent"
-	"github.com/spf13/cobra"
 	kubeadmapiv1old "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1beta2"
 	kubeadmapiv1 "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1beta3"
 	outputapischeme "k8s.io/kubernetes/cmd/kubeadm/app/apis/output/scheme"
@@ -39,8 +37,12 @@ import (
 	configutil "k8s.io/kubernetes/cmd/kubeadm/app/util/config"
 	"k8s.io/kubernetes/cmd/kubeadm/app/util/output"
 	utilruntime "k8s.io/kubernetes/cmd/kubeadm/app/util/runtime"
+
 	"k8s.io/utils/exec"
 	fakeexec "k8s.io/utils/exec/testing"
+
+	"github.com/lithammer/dedent"
+	"github.com/spf13/cobra"
 )
 
 const (

--- a/cmd/kubeadm/app/cmd/init.go
+++ b/cmd/kubeadm/app/cmd/init.go
@@ -23,12 +23,6 @@ import (
 	"path/filepath"
 	"text/template"
 
-	"github.com/lithammer/dedent"
-	"github.com/pkg/errors"
-	"github.com/spf13/cobra"
-	flag "github.com/spf13/pflag"
-	"k8s.io/apimachinery/pkg/util/sets"
-	clientset "k8s.io/client-go/kubernetes"
 	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
 	kubeadmscheme "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/scheme"
 	kubeadmapiv1 "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1beta3"
@@ -44,6 +38,14 @@ import (
 	"k8s.io/kubernetes/cmd/kubeadm/app/util/apiclient"
 	configutil "k8s.io/kubernetes/cmd/kubeadm/app/util/config"
 	kubeconfigutil "k8s.io/kubernetes/cmd/kubeadm/app/util/kubeconfig"
+
+	"k8s.io/apimachinery/pkg/util/sets"
+	clientset "k8s.io/client-go/kubernetes"
+
+	"github.com/lithammer/dedent"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+	flag "github.com/spf13/pflag"
 )
 
 var (

--- a/cmd/kubeadm/app/cmd/init_test.go
+++ b/cmd/kubeadm/app/cmd/init_test.go
@@ -23,9 +23,10 @@ import (
 	"path/filepath"
 	"testing"
 
-	"k8s.io/apimachinery/pkg/util/sets"
 	kubeadmapiv1 "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1beta3"
 	"k8s.io/kubernetes/cmd/kubeadm/app/cmd/options"
+
+	"k8s.io/apimachinery/pkg/util/sets"
 )
 
 var testInitConfig = fmt.Sprintf(`---

--- a/cmd/kubeadm/app/cmd/join.go
+++ b/cmd/kubeadm/app/cmd/join.go
@@ -23,15 +23,6 @@ import (
 	"strings"
 	"text/template"
 
-	"github.com/lithammer/dedent"
-	"github.com/pkg/errors"
-	"github.com/spf13/cobra"
-	flag "github.com/spf13/pflag"
-	"k8s.io/apimachinery/pkg/util/sets"
-	clientset "k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/tools/clientcmd"
-	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
-	"k8s.io/klog/v2"
 	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
 	kubeadmscheme "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/scheme"
 	kubeadmapiv1 "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1beta3"
@@ -44,6 +35,17 @@ import (
 	"k8s.io/kubernetes/cmd/kubeadm/app/discovery"
 	configutil "k8s.io/kubernetes/cmd/kubeadm/app/util/config"
 	kubeconfigutil "k8s.io/kubernetes/cmd/kubeadm/app/util/kubeconfig"
+
+	"k8s.io/apimachinery/pkg/util/sets"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/clientcmd"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+	"k8s.io/klog/v2"
+
+	"github.com/lithammer/dedent"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+	flag "github.com/spf13/pflag"
 )
 
 var (

--- a/cmd/kubeadm/app/cmd/join_test.go
+++ b/cmd/kubeadm/app/cmd/join_test.go
@@ -23,10 +23,11 @@ import (
 	"path/filepath"
 	"testing"
 
-	"k8s.io/apimachinery/pkg/util/sets"
 	kubeadmapiv1 "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1beta3"
 	"k8s.io/kubernetes/cmd/kubeadm/app/cmd/options"
 	kubeconfigutil "k8s.io/kubernetes/cmd/kubeadm/app/util/kubeconfig"
+
+	"k8s.io/apimachinery/pkg/util/sets"
 )
 
 var testJoinConfig = fmt.Sprintf(`apiVersion: %s

--- a/cmd/kubeadm/app/cmd/kubeconfig.go
+++ b/cmd/kubeadm/app/cmd/kubeconfig.go
@@ -20,15 +20,16 @@ import (
 	"io"
 	"time"
 
-	"github.com/spf13/cobra"
-	"k8s.io/klog/v2"
-
 	kubeadmapiv1 "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1beta3"
 	"k8s.io/kubernetes/cmd/kubeadm/app/cmd/options"
 	cmdutil "k8s.io/kubernetes/cmd/kubeadm/app/cmd/util"
 	kubeadmconstants "k8s.io/kubernetes/cmd/kubeadm/app/constants"
 	kubeconfigphase "k8s.io/kubernetes/cmd/kubeadm/app/phases/kubeconfig"
 	configutil "k8s.io/kubernetes/cmd/kubeadm/app/util/config"
+
+	"k8s.io/klog/v2"
+
+	"github.com/spf13/cobra"
 )
 
 var (

--- a/cmd/kubeadm/app/cmd/kubeconfig_test.go
+++ b/cmd/kubeadm/app/cmd/kubeconfig_test.go
@@ -24,15 +24,15 @@ import (
 	"path/filepath"
 	"testing"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/tools/clientcmd"
-	"sigs.k8s.io/yaml"
-
 	kubeadmapiv1 "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1beta3"
 	kubeadmconstants "k8s.io/kubernetes/cmd/kubeadm/app/constants"
 	"k8s.io/kubernetes/cmd/kubeadm/app/util/pkiutil"
 	testutil "k8s.io/kubernetes/cmd/kubeadm/test"
 	kubeconfigtestutil "k8s.io/kubernetes/cmd/kubeadm/test/kubeconfig"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/clientcmd"
+	"sigs.k8s.io/yaml"
 )
 
 func generateTestKubeadmConfig(dir, id, certDir, clusterName string) (string, error) {

--- a/cmd/kubeadm/app/cmd/main_test.go
+++ b/cmd/kubeadm/app/cmd/main_test.go
@@ -17,8 +17,9 @@ limitations under the License.
 package cmd
 
 import (
-	pkiutiltesting "k8s.io/kubernetes/cmd/kubeadm/app/util/pkiutil/testing"
 	"testing"
+
+	pkiutiltesting "k8s.io/kubernetes/cmd/kubeadm/app/util/pkiutil/testing"
 )
 
 func TestMain(m *testing.M) {

--- a/cmd/kubeadm/app/cmd/options/generic.go
+++ b/cmd/kubeadm/app/cmd/options/generic.go
@@ -19,10 +19,12 @@ package options
 import (
 	"strings"
 
-	"github.com/spf13/pflag"
-	cliflag "k8s.io/component-base/cli/flag"
 	"k8s.io/kubernetes/cmd/kubeadm/app/constants"
 	"k8s.io/kubernetes/cmd/kubeadm/app/features"
+
+	cliflag "k8s.io/component-base/cli/flag"
+
+	"github.com/spf13/pflag"
 )
 
 // AddKubeConfigFlag adds the --kubeconfig flag to the given flagset

--- a/cmd/kubeadm/app/cmd/options/token.go
+++ b/cmd/kubeadm/app/cmd/options/token.go
@@ -20,12 +20,13 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/spf13/pflag"
-
-	bootstrapapi "k8s.io/cluster-bootstrap/token/api"
 	bootstraptokenv1 "k8s.io/kubernetes/cmd/kubeadm/app/apis/bootstraptoken/v1"
 	kubeadmapiv1 "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1beta3"
 	kubeadmconstants "k8s.io/kubernetes/cmd/kubeadm/app/constants"
+
+	bootstrapapi "k8s.io/cluster-bootstrap/token/api"
+
+	"github.com/spf13/pflag"
 )
 
 // NewBootstrapTokenOptions creates a new BootstrapTokenOptions object with the default values

--- a/cmd/kubeadm/app/cmd/phases/init/addons.go
+++ b/cmd/kubeadm/app/cmd/phases/init/addons.go
@@ -17,15 +17,16 @@ limitations under the License.
 package phases
 
 import (
-	"github.com/pkg/errors"
-
-	clientset "k8s.io/client-go/kubernetes"
 	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
 	"k8s.io/kubernetes/cmd/kubeadm/app/cmd/options"
 	"k8s.io/kubernetes/cmd/kubeadm/app/cmd/phases/workflow"
 	cmdutil "k8s.io/kubernetes/cmd/kubeadm/app/cmd/util"
 	dnsaddon "k8s.io/kubernetes/cmd/kubeadm/app/phases/addons/dns"
 	proxyaddon "k8s.io/kubernetes/cmd/kubeadm/app/phases/addons/proxy"
+
+	clientset "k8s.io/client-go/kubernetes"
+
+	"github.com/pkg/errors"
 )
 
 var (

--- a/cmd/kubeadm/app/cmd/phases/init/bootstraptoken.go
+++ b/cmd/kubeadm/app/cmd/phases/init/bootstraptoken.go
@@ -19,13 +19,13 @@ package phases
 import (
 	"fmt"
 
-	"github.com/pkg/errors"
-
 	"k8s.io/kubernetes/cmd/kubeadm/app/cmd/options"
 	"k8s.io/kubernetes/cmd/kubeadm/app/cmd/phases/workflow"
 	cmdutil "k8s.io/kubernetes/cmd/kubeadm/app/cmd/util"
 	clusterinfophase "k8s.io/kubernetes/cmd/kubeadm/app/phases/bootstraptoken/clusterinfo"
 	nodebootstraptokenphase "k8s.io/kubernetes/cmd/kubeadm/app/phases/bootstraptoken/node"
+
+	"github.com/pkg/errors"
 )
 
 var (

--- a/cmd/kubeadm/app/cmd/phases/init/certs.go
+++ b/cmd/kubeadm/app/cmd/phases/init/certs.go
@@ -22,8 +22,6 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/pkg/errors"
-
 	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
 	kubeadmscheme "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/scheme"
 	kubeadmapiv1 "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1beta3"
@@ -33,6 +31,8 @@ import (
 	kubeadmconstants "k8s.io/kubernetes/cmd/kubeadm/app/constants"
 	certsphase "k8s.io/kubernetes/cmd/kubeadm/app/phases/certs"
 	"k8s.io/kubernetes/cmd/kubeadm/app/util/pkiutil"
+
+	"github.com/pkg/errors"
 )
 
 var (

--- a/cmd/kubeadm/app/cmd/phases/init/certs_test.go
+++ b/cmd/kubeadm/app/cmd/phases/init/certs_test.go
@@ -20,12 +20,13 @@ import (
 	"os"
 	"testing"
 
-	"github.com/spf13/cobra"
 	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
 	"k8s.io/kubernetes/cmd/kubeadm/app/cmd/phases/workflow"
 	certstestutil "k8s.io/kubernetes/cmd/kubeadm/app/util/certs"
 	pkiutiltesting "k8s.io/kubernetes/cmd/kubeadm/app/util/pkiutil/testing"
 	testutil "k8s.io/kubernetes/cmd/kubeadm/test"
+
+	"github.com/spf13/cobra"
 )
 
 type testCertsData struct {

--- a/cmd/kubeadm/app/cmd/phases/init/controlplane.go
+++ b/cmd/kubeadm/app/cmd/phases/init/controlplane.go
@@ -19,13 +19,13 @@ package phases
 import (
 	"fmt"
 
-	"github.com/pkg/errors"
-
 	"k8s.io/kubernetes/cmd/kubeadm/app/cmd/options"
 	"k8s.io/kubernetes/cmd/kubeadm/app/cmd/phases/workflow"
 	cmdutil "k8s.io/kubernetes/cmd/kubeadm/app/cmd/util"
 	kubeadmconstants "k8s.io/kubernetes/cmd/kubeadm/app/constants"
 	"k8s.io/kubernetes/cmd/kubeadm/app/phases/controlplane"
+
+	"github.com/pkg/errors"
 )
 
 var (

--- a/cmd/kubeadm/app/cmd/phases/init/data.go
+++ b/cmd/kubeadm/app/cmd/phases/init/data.go
@@ -19,9 +19,10 @@ package phases
 import (
 	"io"
 
+	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
+
 	"k8s.io/apimachinery/pkg/util/sets"
 	clientset "k8s.io/client-go/kubernetes"
-	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
 )
 
 // InitData is the interface to use for init phases.

--- a/cmd/kubeadm/app/cmd/phases/init/data_test.go
+++ b/cmd/kubeadm/app/cmd/phases/init/data_test.go
@@ -19,9 +19,10 @@ package phases
 import (
 	"io"
 
+	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
+
 	"k8s.io/apimachinery/pkg/util/sets"
 	clientset "k8s.io/client-go/kubernetes"
-	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
 )
 
 // a package local type for testing purposes.

--- a/cmd/kubeadm/app/cmd/phases/init/etcd.go
+++ b/cmd/kubeadm/app/cmd/phases/init/etcd.go
@@ -19,13 +19,15 @@ package phases
 import (
 	"fmt"
 
-	"github.com/pkg/errors"
-	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/cmd/kubeadm/app/cmd/options"
 	"k8s.io/kubernetes/cmd/kubeadm/app/cmd/phases/workflow"
 	cmdutil "k8s.io/kubernetes/cmd/kubeadm/app/cmd/util"
 	etcdphase "k8s.io/kubernetes/cmd/kubeadm/app/phases/etcd"
 	etcdutil "k8s.io/kubernetes/cmd/kubeadm/app/util/etcd"
+
+	"k8s.io/klog/v2"
+
+	"github.com/pkg/errors"
 )
 
 var (

--- a/cmd/kubeadm/app/cmd/phases/init/kubeconfig.go
+++ b/cmd/kubeadm/app/cmd/phases/init/kubeconfig.go
@@ -21,12 +21,13 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/pkg/errors"
 	"k8s.io/kubernetes/cmd/kubeadm/app/cmd/options"
 	"k8s.io/kubernetes/cmd/kubeadm/app/cmd/phases/workflow"
 	cmdutil "k8s.io/kubernetes/cmd/kubeadm/app/cmd/util"
 	kubeadmconstants "k8s.io/kubernetes/cmd/kubeadm/app/constants"
 	kubeconfigphase "k8s.io/kubernetes/cmd/kubeadm/app/phases/kubeconfig"
+
+	"github.com/pkg/errors"
 )
 
 var (

--- a/cmd/kubeadm/app/cmd/phases/init/kubelet.go
+++ b/cmd/kubeadm/app/cmd/phases/init/kubelet.go
@@ -19,12 +19,14 @@ package phases
 import (
 	"fmt"
 
-	"github.com/pkg/errors"
-	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/cmd/kubeadm/app/cmd/options"
 	"k8s.io/kubernetes/cmd/kubeadm/app/cmd/phases/workflow"
 	cmdutil "k8s.io/kubernetes/cmd/kubeadm/app/cmd/util"
 	kubeletphase "k8s.io/kubernetes/cmd/kubeadm/app/phases/kubelet"
+
+	"k8s.io/klog/v2"
+
+	"github.com/pkg/errors"
 )
 
 var (

--- a/cmd/kubeadm/app/cmd/phases/init/kubeletfinalize.go
+++ b/cmd/kubeadm/app/cmd/phases/init/kubeletfinalize.go
@@ -21,14 +21,16 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/pkg/errors"
-	clientcmd "k8s.io/client-go/tools/clientcmd"
-	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/cmd/kubeadm/app/cmd/options"
 	"k8s.io/kubernetes/cmd/kubeadm/app/cmd/phases/workflow"
 	cmdutil "k8s.io/kubernetes/cmd/kubeadm/app/cmd/util"
 	kubeadmconstants "k8s.io/kubernetes/cmd/kubeadm/app/constants"
 	kubeletphase "k8s.io/kubernetes/cmd/kubeadm/app/phases/kubelet"
+
+	clientcmd "k8s.io/client-go/tools/clientcmd"
+	"k8s.io/klog/v2"
+
+	"github.com/pkg/errors"
 )
 
 var (

--- a/cmd/kubeadm/app/cmd/phases/init/main_test.go
+++ b/cmd/kubeadm/app/cmd/phases/init/main_test.go
@@ -17,8 +17,9 @@ limitations under the License.
 package phases
 
 import (
-	pkiutiltesting "k8s.io/kubernetes/cmd/kubeadm/app/util/pkiutil/testing"
 	"testing"
+
+	pkiutiltesting "k8s.io/kubernetes/cmd/kubeadm/app/util/pkiutil/testing"
 )
 
 func TestMain(m *testing.M) {

--- a/cmd/kubeadm/app/cmd/phases/init/markcontrolplane.go
+++ b/cmd/kubeadm/app/cmd/phases/init/markcontrolplane.go
@@ -17,11 +17,12 @@ limitations under the License.
 package phases
 
 import (
-	"github.com/pkg/errors"
 	"k8s.io/kubernetes/cmd/kubeadm/app/cmd/options"
 	"k8s.io/kubernetes/cmd/kubeadm/app/cmd/phases/workflow"
 	cmdutil "k8s.io/kubernetes/cmd/kubeadm/app/cmd/util"
 	markcontrolplanephase "k8s.io/kubernetes/cmd/kubeadm/app/phases/markcontrolplane"
+
+	"github.com/pkg/errors"
 )
 
 var (

--- a/cmd/kubeadm/app/cmd/phases/init/preflight.go
+++ b/cmd/kubeadm/app/cmd/phases/init/preflight.go
@@ -19,12 +19,14 @@ package phases
 import (
 	"fmt"
 
-	"github.com/pkg/errors"
 	"k8s.io/kubernetes/cmd/kubeadm/app/cmd/options"
 	"k8s.io/kubernetes/cmd/kubeadm/app/cmd/phases/workflow"
 	cmdutil "k8s.io/kubernetes/cmd/kubeadm/app/cmd/util"
 	"k8s.io/kubernetes/cmd/kubeadm/app/preflight"
+
 	utilsexec "k8s.io/utils/exec"
+
+	"github.com/pkg/errors"
 )
 
 var (

--- a/cmd/kubeadm/app/cmd/phases/init/uploadcerts.go
+++ b/cmd/kubeadm/app/cmd/phases/init/uploadcerts.go
@@ -19,13 +19,13 @@ package phases
 import (
 	"fmt"
 
-	"github.com/pkg/errors"
-
 	"k8s.io/kubernetes/cmd/kubeadm/app/cmd/options"
 	"k8s.io/kubernetes/cmd/kubeadm/app/cmd/phases/workflow"
 	cmdutil "k8s.io/kubernetes/cmd/kubeadm/app/cmd/util"
 	kubeadmconstants "k8s.io/kubernetes/cmd/kubeadm/app/constants"
 	"k8s.io/kubernetes/cmd/kubeadm/app/phases/copycerts"
+
+	"github.com/pkg/errors"
 )
 
 // NewUploadCertsPhase returns the uploadCerts phase

--- a/cmd/kubeadm/app/cmd/phases/init/uploadconfig.go
+++ b/cmd/kubeadm/app/cmd/phases/init/uploadconfig.go
@@ -19,10 +19,6 @@ package phases
 import (
 	"fmt"
 
-	"github.com/pkg/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	clientset "k8s.io/client-go/kubernetes"
-	"k8s.io/klog/v2"
 	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
 	"k8s.io/kubernetes/cmd/kubeadm/app/cmd/options"
 	"k8s.io/kubernetes/cmd/kubeadm/app/cmd/phases/workflow"
@@ -31,6 +27,12 @@ import (
 	kubeletphase "k8s.io/kubernetes/cmd/kubeadm/app/phases/kubelet"
 	patchnodephase "k8s.io/kubernetes/cmd/kubeadm/app/phases/patchnode"
 	"k8s.io/kubernetes/cmd/kubeadm/app/phases/uploadconfig"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/klog/v2"
+
+	"github.com/pkg/errors"
 )
 
 var (

--- a/cmd/kubeadm/app/cmd/phases/init/waitcontrolplane.go
+++ b/cmd/kubeadm/app/cmd/phases/init/waitcontrolplane.go
@@ -23,14 +23,16 @@ import (
 	"text/template"
 	"time"
 
-	"github.com/lithammer/dedent"
-	"github.com/pkg/errors"
-	clientset "k8s.io/client-go/kubernetes"
-	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/cmd/kubeadm/app/cmd/phases/workflow"
 	kubeadmconstants "k8s.io/kubernetes/cmd/kubeadm/app/constants"
 	"k8s.io/kubernetes/cmd/kubeadm/app/util/apiclient"
 	dryrunutil "k8s.io/kubernetes/cmd/kubeadm/app/util/dryrun"
+
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/klog/v2"
+
+	"github.com/lithammer/dedent"
+	"github.com/pkg/errors"
 )
 
 var (

--- a/cmd/kubeadm/app/cmd/phases/join/checketcd.go
+++ b/cmd/kubeadm/app/cmd/phases/join/checketcd.go
@@ -19,9 +19,10 @@ package phases
 import (
 	"fmt"
 
-	"github.com/pkg/errors"
 	"k8s.io/kubernetes/cmd/kubeadm/app/cmd/phases/workflow"
 	etcdphase "k8s.io/kubernetes/cmd/kubeadm/app/phases/etcd"
+
+	"github.com/pkg/errors"
 )
 
 // NewCheckEtcdPhase is a hidden phase that runs after the control-plane-prepare and

--- a/cmd/kubeadm/app/cmd/phases/join/controlplanejoin.go
+++ b/cmd/kubeadm/app/cmd/phases/join/controlplanejoin.go
@@ -19,9 +19,6 @@ package phases
 import (
 	"fmt"
 
-	"github.com/pkg/errors"
-	"github.com/spf13/cobra"
-
 	"k8s.io/kubernetes/cmd/kubeadm/app/cmd/options"
 	"k8s.io/kubernetes/cmd/kubeadm/app/cmd/phases/workflow"
 	cmdutil "k8s.io/kubernetes/cmd/kubeadm/app/cmd/util"
@@ -29,6 +26,9 @@ import (
 	etcdphase "k8s.io/kubernetes/cmd/kubeadm/app/phases/etcd"
 	markcontrolplanephase "k8s.io/kubernetes/cmd/kubeadm/app/phases/markcontrolplane"
 	etcdutil "k8s.io/kubernetes/cmd/kubeadm/app/util/etcd"
+
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
 )
 
 var controlPlaneJoinExample = cmdutil.Examples(`

--- a/cmd/kubeadm/app/cmd/phases/join/controlplaneprepare.go
+++ b/cmd/kubeadm/app/cmd/phases/join/controlplaneprepare.go
@@ -19,11 +19,6 @@ package phases
 import (
 	"fmt"
 
-	"github.com/pkg/errors"
-	"github.com/spf13/cobra"
-
-	clientset "k8s.io/client-go/kubernetes"
-	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/cmd/kubeadm/app/cmd/options"
 	"k8s.io/kubernetes/cmd/kubeadm/app/cmd/phases/workflow"
 	cmdutil "k8s.io/kubernetes/cmd/kubeadm/app/cmd/util"
@@ -33,6 +28,12 @@ import (
 	"k8s.io/kubernetes/cmd/kubeadm/app/phases/copycerts"
 	kubeconfigphase "k8s.io/kubernetes/cmd/kubeadm/app/phases/kubeconfig"
 	kubeconfigutil "k8s.io/kubernetes/cmd/kubeadm/app/util/kubeconfig"
+
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/klog/v2"
+
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
 )
 
 var controlPlanePrepareExample = cmdutil.Examples(`

--- a/cmd/kubeadm/app/cmd/phases/join/data.go
+++ b/cmd/kubeadm/app/cmd/phases/join/data.go
@@ -19,10 +19,11 @@ package phases
 import (
 	"io"
 
+	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
+
 	"k8s.io/apimachinery/pkg/util/sets"
 	clientset "k8s.io/client-go/kubernetes"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
-	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
 )
 
 // JoinData is the interface to use for join phases.

--- a/cmd/kubeadm/app/cmd/phases/join/data_test.go
+++ b/cmd/kubeadm/app/cmd/phases/join/data_test.go
@@ -19,10 +19,11 @@ package phases
 import (
 	"io"
 
+	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
+
 	"k8s.io/apimachinery/pkg/util/sets"
 	clientset "k8s.io/client-go/kubernetes"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
-	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
 )
 
 // a package local type for testing purposes.

--- a/cmd/kubeadm/app/cmd/phases/join/kubelet.go
+++ b/cmd/kubeadm/app/cmd/phases/join/kubelet.go
@@ -21,15 +21,6 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/lithammer/dedent"
-	"github.com/pkg/errors"
-	v1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/wait"
-	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
-	certutil "k8s.io/client-go/util/cert"
-	"k8s.io/klog/v2"
 	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
 	"k8s.io/kubernetes/cmd/kubeadm/app/cmd/options"
 	"k8s.io/kubernetes/cmd/kubeadm/app/cmd/phases/workflow"
@@ -38,6 +29,17 @@ import (
 	patchnodephase "k8s.io/kubernetes/cmd/kubeadm/app/phases/patchnode"
 	"k8s.io/kubernetes/cmd/kubeadm/app/util/apiclient"
 	kubeconfigutil "k8s.io/kubernetes/cmd/kubeadm/app/util/kubeconfig"
+
+	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+	certutil "k8s.io/client-go/util/cert"
+	"k8s.io/klog/v2"
+
+	"github.com/lithammer/dedent"
+	"github.com/pkg/errors"
 )
 
 var (

--- a/cmd/kubeadm/app/cmd/phases/join/preflight.go
+++ b/cmd/kubeadm/app/cmd/phases/join/preflight.go
@@ -21,16 +21,18 @@ import (
 	"fmt"
 	"text/template"
 
-	"github.com/lithammer/dedent"
-	"github.com/pkg/errors"
-	"k8s.io/klog/v2"
 	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
 	"k8s.io/kubernetes/cmd/kubeadm/app/cmd/options"
 	"k8s.io/kubernetes/cmd/kubeadm/app/cmd/phases/workflow"
 	cmdutil "k8s.io/kubernetes/cmd/kubeadm/app/cmd/util"
 	"k8s.io/kubernetes/cmd/kubeadm/app/phases/certs"
 	"k8s.io/kubernetes/cmd/kubeadm/app/preflight"
+
+	"k8s.io/klog/v2"
 	utilsexec "k8s.io/utils/exec"
+
+	"github.com/lithammer/dedent"
+	"github.com/pkg/errors"
 )
 
 var (

--- a/cmd/kubeadm/app/cmd/phases/reset/cleanupnode.go
+++ b/cmd/kubeadm/app/cmd/phases/reset/cleanupnode.go
@@ -22,7 +22,6 @@ import (
 	"os"
 	"path/filepath"
 
-	"k8s.io/klog/v2"
 	kubeadmapiv1 "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1beta3"
 	"k8s.io/kubernetes/cmd/kubeadm/app/cmd/options"
 	"k8s.io/kubernetes/cmd/kubeadm/app/cmd/phases/workflow"
@@ -31,6 +30,8 @@ import (
 	"k8s.io/kubernetes/cmd/kubeadm/app/util/initsystem"
 	utilruntime "k8s.io/kubernetes/cmd/kubeadm/app/util/runtime"
 	"k8s.io/kubernetes/cmd/kubeadm/app/util/users"
+
+	"k8s.io/klog/v2"
 	utilsexec "k8s.io/utils/exec"
 )
 

--- a/cmd/kubeadm/app/cmd/phases/reset/cleanupnode_test.go
+++ b/cmd/kubeadm/app/cmd/phases/reset/cleanupnode_test.go
@@ -24,6 +24,7 @@ import (
 
 	kubeadmconstants "k8s.io/kubernetes/cmd/kubeadm/app/constants"
 	"k8s.io/kubernetes/cmd/kubeadm/app/preflight"
+
 	"k8s.io/utils/exec"
 	fakeexec "k8s.io/utils/exec/testing"
 )

--- a/cmd/kubeadm/app/cmd/phases/reset/data.go
+++ b/cmd/kubeadm/app/cmd/phases/reset/data.go
@@ -19,9 +19,10 @@ package phases
 import (
 	"io"
 
+	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
+
 	"k8s.io/apimachinery/pkg/util/sets"
 	clientset "k8s.io/client-go/kubernetes"
-	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
 )
 
 // resetData is the interface to use for reset phases.

--- a/cmd/kubeadm/app/cmd/phases/reset/removeetcdmember.go
+++ b/cmd/kubeadm/app/cmd/phases/reset/removeetcdmember.go
@@ -21,13 +21,14 @@ import (
 	"fmt"
 	"path/filepath"
 
-	"k8s.io/klog/v2"
 	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
 	"k8s.io/kubernetes/cmd/kubeadm/app/cmd/options"
 	"k8s.io/kubernetes/cmd/kubeadm/app/cmd/phases/workflow"
 	kubeadmconstants "k8s.io/kubernetes/cmd/kubeadm/app/constants"
 	etcdphase "k8s.io/kubernetes/cmd/kubeadm/app/phases/etcd"
 	utilstaticpod "k8s.io/kubernetes/cmd/kubeadm/app/util/staticpod"
+
+	"k8s.io/klog/v2"
 )
 
 // NewRemoveETCDMemberPhase creates a kubeadm workflow phase for remove-etcd-member

--- a/cmd/kubeadm/app/cmd/phases/reset/removeetcdmember_test.go
+++ b/cmd/kubeadm/app/cmd/phases/reset/removeetcdmember_test.go
@@ -22,9 +22,10 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/lithammer/dedent"
 	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
 	testutil "k8s.io/kubernetes/cmd/kubeadm/test"
+
+	"github.com/lithammer/dedent"
 )
 
 const (

--- a/cmd/kubeadm/app/cmd/phases/upgrade/node/controlplane.go
+++ b/cmd/kubeadm/app/cmd/phases/upgrade/node/controlplane.go
@@ -20,12 +20,12 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/pkg/errors"
-
 	"k8s.io/kubernetes/cmd/kubeadm/app/cmd/options"
 	"k8s.io/kubernetes/cmd/kubeadm/app/cmd/phases/workflow"
 	"k8s.io/kubernetes/cmd/kubeadm/app/phases/upgrade"
 	"k8s.io/kubernetes/cmd/kubeadm/app/util/apiclient"
+
+	"github.com/pkg/errors"
 )
 
 // NewControlPlane creates a kubeadm workflow phase that implements handling of control-plane upgrade.

--- a/cmd/kubeadm/app/cmd/phases/upgrade/node/data.go
+++ b/cmd/kubeadm/app/cmd/phases/upgrade/node/data.go
@@ -17,9 +17,10 @@ limitations under the License.
 package node
 
 import (
+	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
+
 	"k8s.io/apimachinery/pkg/util/sets"
 	clientset "k8s.io/client-go/kubernetes"
-	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
 )
 
 // Data is the interface to use for kubeadm upgrade node phases.

--- a/cmd/kubeadm/app/cmd/phases/upgrade/node/kubeletconfig.go
+++ b/cmd/kubeadm/app/cmd/phases/upgrade/node/kubeletconfig.go
@@ -21,8 +21,6 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/pkg/errors"
-
 	"k8s.io/kubernetes/cmd/kubeadm/app/cmd/options"
 	"k8s.io/kubernetes/cmd/kubeadm/app/cmd/phases/workflow"
 	cmdutil "k8s.io/kubernetes/cmd/kubeadm/app/cmd/util"
@@ -30,6 +28,8 @@ import (
 	kubeletphase "k8s.io/kubernetes/cmd/kubeadm/app/phases/kubelet"
 	"k8s.io/kubernetes/cmd/kubeadm/app/phases/upgrade"
 	dryrunutil "k8s.io/kubernetes/cmd/kubeadm/app/util/dryrun"
+
+	"github.com/pkg/errors"
 )
 
 var (

--- a/cmd/kubeadm/app/cmd/phases/upgrade/node/preflight.go
+++ b/cmd/kubeadm/app/cmd/phases/upgrade/node/preflight.go
@@ -19,11 +19,13 @@ package node
 import (
 	"fmt"
 
-	"github.com/pkg/errors"
 	"k8s.io/kubernetes/cmd/kubeadm/app/cmd/options"
 	"k8s.io/kubernetes/cmd/kubeadm/app/cmd/phases/workflow"
 	"k8s.io/kubernetes/cmd/kubeadm/app/preflight"
+
 	utilsexec "k8s.io/utils/exec"
+
+	"github.com/pkg/errors"
 )
 
 // NewPreflightPhase creates a kubeadm workflow phase that implements preflight checks for a new node join

--- a/cmd/kubeadm/app/cmd/phases/util.go
+++ b/cmd/kubeadm/app/cmd/phases/util.go
@@ -17,8 +17,9 @@ limitations under the License.
 package phases
 
 import (
-	"k8s.io/component-base/version"
 	kubeadmapiv1 "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1beta3"
+
+	"k8s.io/component-base/version"
 )
 
 // SetKubernetesVersion gets the current Kubeadm version and sets it as KubeadmVersion in the config,

--- a/cmd/kubeadm/app/cmd/phases/util_test.go
+++ b/cmd/kubeadm/app/cmd/phases/util_test.go
@@ -19,8 +19,9 @@ package phases
 import (
 	"testing"
 
-	"k8s.io/component-base/version"
 	kubeadmapiv1 "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1beta3"
+
+	"k8s.io/component-base/version"
 )
 
 func TestSetKubernetesVersion(t *testing.T) {

--- a/cmd/kubeadm/app/cmd/reset.go
+++ b/cmd/kubeadm/app/cmd/reset.go
@@ -20,12 +20,6 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/lithammer/dedent"
-	"github.com/spf13/cobra"
-	flag "github.com/spf13/pflag"
-	"k8s.io/apimachinery/pkg/util/sets"
-	clientset "k8s.io/client-go/kubernetes"
-	"k8s.io/klog/v2"
 	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
 	kubeadmapiv1 "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1beta3"
 	"k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/validation"
@@ -36,6 +30,14 @@ import (
 	kubeadmconstants "k8s.io/kubernetes/cmd/kubeadm/app/constants"
 	configutil "k8s.io/kubernetes/cmd/kubeadm/app/util/config"
 	utilruntime "k8s.io/kubernetes/cmd/kubeadm/app/util/runtime"
+
+	"k8s.io/apimachinery/pkg/util/sets"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/klog/v2"
+
+	"github.com/lithammer/dedent"
+	"github.com/spf13/cobra"
+	flag "github.com/spf13/pflag"
 )
 
 var (

--- a/cmd/kubeadm/app/cmd/token.go
+++ b/cmd/kubeadm/app/cmd/token.go
@@ -25,19 +25,6 @@ import (
 	"text/tabwriter"
 	"time"
 
-	"github.com/lithammer/dedent"
-	"github.com/pkg/errors"
-	"github.com/spf13/cobra"
-
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/fields"
-	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/util/duration"
-	"k8s.io/cli-runtime/pkg/genericclioptions"
-	clientset "k8s.io/client-go/kubernetes"
-	bootstrapapi "k8s.io/cluster-bootstrap/token/api"
-	bootstraputil "k8s.io/cluster-bootstrap/token/util"
-	"k8s.io/klog/v2"
 	bootstraptokenv1 "k8s.io/kubernetes/cmd/kubeadm/app/apis/bootstraptoken/v1"
 	kubeadmscheme "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/scheme"
 	kubeadmapiv1beta2 "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1beta2"
@@ -53,6 +40,20 @@ import (
 	configutil "k8s.io/kubernetes/cmd/kubeadm/app/util/config"
 	kubeconfigutil "k8s.io/kubernetes/cmd/kubeadm/app/util/kubeconfig"
 	"k8s.io/kubernetes/cmd/kubeadm/app/util/output"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/duration"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	clientset "k8s.io/client-go/kubernetes"
+	bootstrapapi "k8s.io/cluster-bootstrap/token/api"
+	bootstraputil "k8s.io/cluster-bootstrap/token/util"
+	"k8s.io/klog/v2"
+
+	"github.com/lithammer/dedent"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
 )
 
 // newCmdToken returns cobra.Command for token management

--- a/cmd/kubeadm/app/cmd/token_test.go
+++ b/cmd/kubeadm/app/cmd/token_test.go
@@ -24,6 +24,13 @@ import (
 	"regexp"
 	"testing"
 
+	bootstraptokenv1 "k8s.io/kubernetes/cmd/kubeadm/app/apis/bootstraptoken/v1"
+	kubeadmapiv1beta2 "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1beta2"
+	kubeadmapiv1 "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1beta3"
+	outputapischeme "k8s.io/kubernetes/cmd/kubeadm/app/apis/output/scheme"
+	outputapiv1alpha1 "k8s.io/kubernetes/cmd/kubeadm/app/apis/output/v1alpha1"
+	"k8s.io/kubernetes/cmd/kubeadm/app/util/output"
+
 	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -31,12 +38,6 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 	core "k8s.io/client-go/testing"
 	"k8s.io/client-go/tools/clientcmd"
-	bootstraptokenv1 "k8s.io/kubernetes/cmd/kubeadm/app/apis/bootstraptoken/v1"
-	kubeadmapiv1beta2 "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1beta2"
-	kubeadmapiv1 "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1beta3"
-	outputapischeme "k8s.io/kubernetes/cmd/kubeadm/app/apis/output/scheme"
-	outputapiv1alpha1 "k8s.io/kubernetes/cmd/kubeadm/app/apis/output/v1alpha1"
-	"k8s.io/kubernetes/cmd/kubeadm/app/util/output"
 )
 
 const (

--- a/cmd/kubeadm/app/cmd/upgrade/apply.go
+++ b/cmd/kubeadm/app/cmd/upgrade/apply.go
@@ -19,12 +19,6 @@ package upgrade
 import (
 	"fmt"
 
-	"github.com/pkg/errors"
-	"github.com/spf13/cobra"
-	"k8s.io/apimachinery/pkg/util/sets"
-	"k8s.io/apimachinery/pkg/util/version"
-	clientset "k8s.io/client-go/kubernetes"
-	"k8s.io/klog/v2"
 	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
 	"k8s.io/kubernetes/cmd/kubeadm/app/cmd/options"
 	kubeadmconstants "k8s.io/kubernetes/cmd/kubeadm/app/constants"
@@ -34,7 +28,15 @@ import (
 	kubeadmutil "k8s.io/kubernetes/cmd/kubeadm/app/util"
 	"k8s.io/kubernetes/cmd/kubeadm/app/util/apiclient"
 	configutil "k8s.io/kubernetes/cmd/kubeadm/app/util/config"
+
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/version"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/klog/v2"
 	utilsexec "k8s.io/utils/exec"
+
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
 )
 
 // applyFlags holds the information about the flags that can be passed to apply

--- a/cmd/kubeadm/app/cmd/upgrade/common.go
+++ b/cmd/kubeadm/app/cmd/upgrade/common.go
@@ -26,14 +26,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/pkg/errors"
-
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/sets"
-	fakediscovery "k8s.io/client-go/discovery/fake"
-	clientset "k8s.io/client-go/kubernetes"
-	"k8s.io/klog/v2"
 	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
 	"k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/validation"
 	cmdutil "k8s.io/kubernetes/cmd/kubeadm/app/cmd/util"
@@ -47,6 +39,15 @@ import (
 	configutil "k8s.io/kubernetes/cmd/kubeadm/app/util/config"
 	dryrunutil "k8s.io/kubernetes/cmd/kubeadm/app/util/dryrun"
 	kubeconfigutil "k8s.io/kubernetes/cmd/kubeadm/app/util/kubeconfig"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+	fakediscovery "k8s.io/client-go/discovery/fake"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/klog/v2"
+
+	"github.com/pkg/errors"
 )
 
 // isKubeadmConfigPresent checks if a kubeadm config type is found in the provided document map

--- a/cmd/kubeadm/app/cmd/upgrade/diff.go
+++ b/cmd/kubeadm/app/cmd/upgrade/diff.go
@@ -21,13 +21,6 @@ import (
 	"io/ioutil"
 	"os"
 
-	"github.com/pkg/errors"
-	"github.com/pmezard/go-difflib/difflib"
-	"github.com/spf13/cobra"
-	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/util/version"
-	client "k8s.io/client-go/kubernetes"
-	"k8s.io/klog/v2"
 	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
 	"k8s.io/kubernetes/cmd/kubeadm/app/cmd/options"
 	cmdutil "k8s.io/kubernetes/cmd/kubeadm/app/cmd/util"
@@ -36,6 +29,15 @@ import (
 	kubeadmutil "k8s.io/kubernetes/cmd/kubeadm/app/util"
 	configutil "k8s.io/kubernetes/cmd/kubeadm/app/util/config"
 	kubeconfigutil "k8s.io/kubernetes/cmd/kubeadm/app/util/kubeconfig"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/version"
+	client "k8s.io/client-go/kubernetes"
+	"k8s.io/klog/v2"
+
+	"github.com/pkg/errors"
+	"github.com/pmezard/go-difflib/difflib"
+	"github.com/spf13/cobra"
 )
 
 type diffFlags struct {

--- a/cmd/kubeadm/app/cmd/upgrade/diff_test.go
+++ b/cmd/kubeadm/app/cmd/upgrade/diff_test.go
@@ -22,9 +22,10 @@ import (
 	"os"
 	"testing"
 
-	"github.com/pkg/errors"
 	kubeadmapiv1 "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1beta3"
 	"k8s.io/kubernetes/cmd/kubeadm/app/constants"
+
+	"github.com/pkg/errors"
 )
 
 func createTestRunDiffFile(contents []byte) (string, error) {

--- a/cmd/kubeadm/app/cmd/upgrade/node.go
+++ b/cmd/kubeadm/app/cmd/upgrade/node.go
@@ -19,12 +19,6 @@ package upgrade
 import (
 	"os"
 
-	"github.com/pkg/errors"
-	"github.com/spf13/cobra"
-	flag "github.com/spf13/pflag"
-
-	"k8s.io/apimachinery/pkg/util/sets"
-	clientset "k8s.io/client-go/kubernetes"
 	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
 	"k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/validation"
 	"k8s.io/kubernetes/cmd/kubeadm/app/cmd/options"
@@ -32,6 +26,13 @@ import (
 	"k8s.io/kubernetes/cmd/kubeadm/app/cmd/phases/workflow"
 	"k8s.io/kubernetes/cmd/kubeadm/app/constants"
 	configutil "k8s.io/kubernetes/cmd/kubeadm/app/util/config"
+
+	"k8s.io/apimachinery/pkg/util/sets"
+	clientset "k8s.io/client-go/kubernetes"
+
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+	flag "github.com/spf13/pflag"
 )
 
 // nodeOptions defines all the options exposed via flags by kubeadm upgrade node.

--- a/cmd/kubeadm/app/cmd/upgrade/plan.go
+++ b/cmd/kubeadm/app/cmd/upgrade/plan.go
@@ -25,19 +25,20 @@ import (
 	"strings"
 	"text/tabwriter"
 
-	"github.com/lithammer/dedent"
-	"github.com/pkg/errors"
-	"github.com/spf13/cobra"
-
-	"k8s.io/apimachinery/pkg/util/version"
-	clientset "k8s.io/client-go/kubernetes"
-	"k8s.io/klog/v2"
 	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
 	outputapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/output"
 	"k8s.io/kubernetes/cmd/kubeadm/app/componentconfigs"
 	"k8s.io/kubernetes/cmd/kubeadm/app/constants"
 	"k8s.io/kubernetes/cmd/kubeadm/app/phases/upgrade"
 	kubeadmutil "k8s.io/kubernetes/cmd/kubeadm/app/util"
+
+	"k8s.io/apimachinery/pkg/util/version"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/klog/v2"
+
+	"github.com/lithammer/dedent"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
 )
 
 type planFlags struct {

--- a/cmd/kubeadm/app/cmd/upgrade/upgrade.go
+++ b/cmd/kubeadm/app/cmd/upgrade/upgrade.go
@@ -19,12 +19,12 @@ package upgrade
 import (
 	"io"
 
-	"github.com/spf13/cobra"
-	"github.com/spf13/pflag"
-
 	"k8s.io/kubernetes/cmd/kubeadm/app/cmd/options"
 	cmdutil "k8s.io/kubernetes/cmd/kubeadm/app/cmd/util"
 	kubeadmconstants "k8s.io/kubernetes/cmd/kubeadm/app/constants"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 )
 
 // applyPlanFlags holds the values for the common flags in `kubeadm upgrade apply` and `kubeadm upgrade plan`

--- a/cmd/kubeadm/app/cmd/util/cmdutil.go
+++ b/cmd/kubeadm/app/cmd/util/cmdutil.go
@@ -17,15 +17,16 @@ limitations under the License.
 package util
 
 import (
-	"github.com/pkg/errors"
-	"github.com/spf13/cobra"
-	"github.com/spf13/pflag"
-
-	"k8s.io/client-go/tools/clientcmd"
-	"k8s.io/klog/v2"
 	kubeadmapiv1 "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1beta3"
 	"k8s.io/kubernetes/cmd/kubeadm/app/cmd/options"
 	kubeadmconstants "k8s.io/kubernetes/cmd/kubeadm/app/constants"
+
+	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/klog/v2"
+
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 )
 
 // SubCmdRunE returns a function that handles a case where a subcommand must be specified

--- a/cmd/kubeadm/app/cmd/util/join.go
+++ b/cmd/kubeadm/app/cmd/util/join.go
@@ -22,11 +22,13 @@ import (
 	"html/template"
 	"strings"
 
-	"github.com/pkg/errors"
-	"k8s.io/client-go/tools/clientcmd"
-	clientcertutil "k8s.io/client-go/util/cert"
 	kubeconfigutil "k8s.io/kubernetes/cmd/kubeadm/app/util/kubeconfig"
 	"k8s.io/kubernetes/cmd/kubeadm/app/util/pubkeypin"
+
+	"k8s.io/client-go/tools/clientcmd"
+	clientcertutil "k8s.io/client-go/util/cert"
+
+	"github.com/pkg/errors"
 )
 
 var joinCommandTemplate = template.Must(template.New("join").Parse(`` +

--- a/cmd/kubeadm/app/cmd/version.go
+++ b/cmd/kubeadm/app/cmd/version.go
@@ -21,13 +21,13 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/pkg/errors"
-	"github.com/spf13/cobra"
+	apimachineryversion "k8s.io/apimachinery/pkg/version"
+	"k8s.io/component-base/version"
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/yaml"
 
-	apimachineryversion "k8s.io/apimachinery/pkg/version"
-	"k8s.io/component-base/version"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
 )
 
 // Version provides the version information of kubeadm.

--- a/cmd/kubeadm/app/cmd/version_test.go
+++ b/cmd/kubeadm/app/cmd/version_test.go
@@ -19,9 +19,11 @@ package cmd
 import (
 	"bytes"
 	"encoding/json"
-	"github.com/pkg/errors"
-	"sigs.k8s.io/yaml"
 	"testing"
+
+	"sigs.k8s.io/yaml"
+
+	"github.com/pkg/errors"
 )
 
 func TestNewCmdVersion(t *testing.T) {

--- a/cmd/kubeadm/app/componentconfigs/checksums.go
+++ b/cmd/kubeadm/app/componentconfigs/checksums.go
@@ -21,8 +21,9 @@ import (
 	"fmt"
 	"sort"
 
-	v1 "k8s.io/api/core/v1"
 	"k8s.io/kubernetes/cmd/kubeadm/app/constants"
+
+	v1 "k8s.io/api/core/v1"
 )
 
 // ChecksumForConfigMap calculates a checksum for the supplied config map. The exact algorithm depends on hash and prefix parameters

--- a/cmd/kubeadm/app/componentconfigs/checksums_test.go
+++ b/cmd/kubeadm/app/componentconfigs/checksums_test.go
@@ -19,9 +19,10 @@ package componentconfigs
 import (
 	"testing"
 
+	"k8s.io/kubernetes/cmd/kubeadm/app/constants"
+
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/kubernetes/cmd/kubeadm/app/constants"
 )
 
 var checksumTestCases = []struct {

--- a/cmd/kubeadm/app/componentconfigs/configset.go
+++ b/cmd/kubeadm/app/componentconfigs/configset.go
@@ -17,7 +17,10 @@ limitations under the License.
 package componentconfigs
 
 import (
-	"github.com/pkg/errors"
+	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
+	"k8s.io/kubernetes/cmd/kubeadm/app/apis/output"
+	kubeadmutil "k8s.io/kubernetes/cmd/kubeadm/app/util"
+	"k8s.io/kubernetes/cmd/kubeadm/app/util/apiclient"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -27,10 +30,7 @@ import (
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/klog/v2"
 
-	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
-	"k8s.io/kubernetes/cmd/kubeadm/app/apis/output"
-	kubeadmutil "k8s.io/kubernetes/cmd/kubeadm/app/util"
-	"k8s.io/kubernetes/cmd/kubeadm/app/util/apiclient"
+	"github.com/pkg/errors"
 )
 
 // handler is a package internal type that handles component config factory and common functionality.

--- a/cmd/kubeadm/app/componentconfigs/configset_test.go
+++ b/cmd/kubeadm/app/componentconfigs/configset_test.go
@@ -19,14 +19,14 @@ package componentconfigs
 import (
 	"testing"
 
-	"github.com/lithammer/dedent"
+	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
+	"k8s.io/kubernetes/cmd/kubeadm/app/constants"
+	kubeadmutil "k8s.io/kubernetes/cmd/kubeadm/app/util"
 
 	"k8s.io/apimachinery/pkg/runtime"
 	clientsetfake "k8s.io/client-go/kubernetes/fake"
 
-	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
-	"k8s.io/kubernetes/cmd/kubeadm/app/constants"
-	kubeadmutil "k8s.io/kubernetes/cmd/kubeadm/app/util"
+	"github.com/lithammer/dedent"
 )
 
 func testClusterCfg() *kubeadmapi.ClusterConfiguration {

--- a/cmd/kubeadm/app/componentconfigs/fakeconfig_test.go
+++ b/cmd/kubeadm/app/componentconfigs/fakeconfig_test.go
@@ -24,19 +24,20 @@ import (
 	"testing"
 	"time"
 
-	"github.com/lithammer/dedent"
-
-	v1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
-	clientset "k8s.io/client-go/kubernetes"
-	clientsetfake "k8s.io/client-go/kubernetes/fake"
 	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
 	kubeadmscheme "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/scheme"
 	kubeadmapiv1 "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1beta3"
 	outputapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/output"
 	"k8s.io/kubernetes/cmd/kubeadm/app/constants"
 	kubeadmutil "k8s.io/kubernetes/cmd/kubeadm/app/util"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	clientset "k8s.io/client-go/kubernetes"
+	clientsetfake "k8s.io/client-go/kubernetes/fake"
+
+	"github.com/lithammer/dedent"
 )
 
 // All tests in this file use an alternative set of `known` component configs.

--- a/cmd/kubeadm/app/componentconfigs/kubelet.go
+++ b/cmd/kubeadm/app/componentconfigs/kubelet.go
@@ -19,17 +19,17 @@ package componentconfigs
 import (
 	"path/filepath"
 
-	"k8s.io/apimachinery/pkg/util/version"
-	clientset "k8s.io/client-go/kubernetes"
-	"k8s.io/klog/v2"
-	kubeletconfig "k8s.io/kubelet/config/v1beta1"
-	"k8s.io/kubernetes/cmd/kubeadm/app/util/initsystem"
-	utilpointer "k8s.io/utils/pointer"
-
 	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
 	kubeadmapiv1 "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1beta3"
 	"k8s.io/kubernetes/cmd/kubeadm/app/constants"
 	"k8s.io/kubernetes/cmd/kubeadm/app/features"
+	"k8s.io/kubernetes/cmd/kubeadm/app/util/initsystem"
+
+	"k8s.io/apimachinery/pkg/util/version"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/klog/v2"
+	kubeletconfig "k8s.io/kubelet/config/v1beta1"
+	utilpointer "k8s.io/utils/pointer"
 )
 
 const (

--- a/cmd/kubeadm/app/componentconfigs/kubelet_test.go
+++ b/cmd/kubeadm/app/componentconfigs/kubelet_test.go
@@ -22,7 +22,10 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/lithammer/dedent"
+	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
+	kubeadmapiv1 "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1beta3"
+	"k8s.io/kubernetes/cmd/kubeadm/app/constants"
+	"k8s.io/kubernetes/cmd/kubeadm/app/features"
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -31,10 +34,7 @@ import (
 	kubeletconfig "k8s.io/kubelet/config/v1beta1"
 	utilpointer "k8s.io/utils/pointer"
 
-	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
-	kubeadmapiv1 "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1beta3"
-	"k8s.io/kubernetes/cmd/kubeadm/app/constants"
-	"k8s.io/kubernetes/cmd/kubeadm/app/features"
+	"github.com/lithammer/dedent"
 )
 
 func testKubeletConfigMap(contents string) *v1.ConfigMap {

--- a/cmd/kubeadm/app/componentconfigs/kubeproxy.go
+++ b/cmd/kubeadm/app/componentconfigs/kubeproxy.go
@@ -19,13 +19,13 @@ package componentconfigs
 import (
 	"net"
 
-	clientset "k8s.io/client-go/kubernetes"
-	kubeproxyconfig "k8s.io/kube-proxy/config/v1alpha1"
-
 	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
 	kubeadmapiv1 "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1beta3"
 	kubeadmconstants "k8s.io/kubernetes/cmd/kubeadm/app/constants"
 	"k8s.io/kubernetes/cmd/kubeadm/app/features"
+
+	clientset "k8s.io/client-go/kubernetes"
+	kubeproxyconfig "k8s.io/kube-proxy/config/v1alpha1"
 )
 
 const (

--- a/cmd/kubeadm/app/componentconfigs/kubeproxy_test.go
+++ b/cmd/kubeadm/app/componentconfigs/kubeproxy_test.go
@@ -21,19 +21,19 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/lithammer/dedent"
-
-	v1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	clientsetfake "k8s.io/client-go/kubernetes/fake"
-	componentbaseconfig "k8s.io/component-base/config/v1alpha1"
-	kubeproxyconfig "k8s.io/kube-proxy/config/v1alpha1"
-
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
 	kubeadmapiv1 "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1beta3"
 	"k8s.io/kubernetes/cmd/kubeadm/app/constants"
 	"k8s.io/kubernetes/cmd/kubeadm/app/features"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	clientsetfake "k8s.io/client-go/kubernetes/fake"
+	componentbaseconfig "k8s.io/component-base/config/v1alpha1"
+	kubeproxyconfig "k8s.io/kube-proxy/config/v1alpha1"
+
+	"github.com/lithammer/dedent"
 )
 
 func testKubeProxyConfigMap(contents string) *v1.ConfigMap {

--- a/cmd/kubeadm/app/constants/constants.go
+++ b/cmd/kubeadm/app/constants/constants.go
@@ -26,13 +26,13 @@ import (
 	"strings"
 	"time"
 
-	"github.com/pkg/errors"
-
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/version"
 	"k8s.io/apimachinery/pkg/util/wait"
 	bootstrapapi "k8s.io/cluster-bootstrap/token/api"
 	utilnet "k8s.io/utils/net"
+
+	"github.com/pkg/errors"
 )
 
 const (

--- a/cmd/kubeadm/app/discovery/discovery.go
+++ b/cmd/kubeadm/app/discovery/discovery.go
@@ -19,16 +19,17 @@ package discovery
 import (
 	"net/url"
 
-	"github.com/pkg/errors"
-
-	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
-	"k8s.io/klog/v2"
 	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
 	kubeadmapiv1 "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1beta3"
 	"k8s.io/kubernetes/cmd/kubeadm/app/discovery/file"
 	"k8s.io/kubernetes/cmd/kubeadm/app/discovery/https"
 	"k8s.io/kubernetes/cmd/kubeadm/app/discovery/token"
 	kubeconfigutil "k8s.io/kubernetes/cmd/kubeadm/app/util/kubeconfig"
+
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+	"k8s.io/klog/v2"
+
+	"github.com/pkg/errors"
 )
 
 // TokenUser defines token user

--- a/cmd/kubeadm/app/discovery/discovery_test.go
+++ b/cmd/kubeadm/app/discovery/discovery_test.go
@@ -20,8 +20,9 @@ import (
 	"testing"
 	"time"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestFor(t *testing.T) {

--- a/cmd/kubeadm/app/discovery/file/file.go
+++ b/cmd/kubeadm/app/discovery/file/file.go
@@ -20,7 +20,8 @@ import (
 	"context"
 	"time"
 
-	"github.com/pkg/errors"
+	"k8s.io/kubernetes/cmd/kubeadm/app/constants"
+	kubeconfigutil "k8s.io/kubernetes/cmd/kubeadm/app/util/kubeconfig"
 
 	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -30,8 +31,8 @@ import (
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 	bootstrapapi "k8s.io/cluster-bootstrap/token/api"
 	"k8s.io/klog/v2"
-	"k8s.io/kubernetes/cmd/kubeadm/app/constants"
-	kubeconfigutil "k8s.io/kubernetes/cmd/kubeadm/app/util/kubeconfig"
+
+	"github.com/pkg/errors"
 )
 
 // RetrieveValidatedConfigInfo connects to the API Server and makes sure it can talk

--- a/cmd/kubeadm/app/discovery/https/https.go
+++ b/cmd/kubeadm/app/discovery/https/https.go
@@ -21,10 +21,11 @@ import (
 	"net/http"
 	"time"
 
+	"k8s.io/kubernetes/cmd/kubeadm/app/discovery/file"
+
 	netutil "k8s.io/apimachinery/pkg/util/net"
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
-	"k8s.io/kubernetes/cmd/kubeadm/app/discovery/file"
 )
 
 // RetrieveValidatedConfigInfo connects to the API Server and makes sure it can talk

--- a/cmd/kubeadm/app/discovery/token/token.go
+++ b/cmd/kubeadm/app/discovery/token/token.go
@@ -22,7 +22,12 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/pkg/errors"
+	bootstraptokenv1 "k8s.io/kubernetes/cmd/kubeadm/app/apis/bootstraptoken/v1"
+	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
+	kubeadmapiv1 "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1beta3"
+	"k8s.io/kubernetes/cmd/kubeadm/app/constants"
+	kubeconfigutil "k8s.io/kubernetes/cmd/kubeadm/app/util/kubeconfig"
+	"k8s.io/kubernetes/cmd/kubeadm/app/util/pubkeypin"
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -34,12 +39,8 @@ import (
 	bootstrapapi "k8s.io/cluster-bootstrap/token/api"
 	bootstrap "k8s.io/cluster-bootstrap/token/jws"
 	"k8s.io/klog/v2"
-	bootstraptokenv1 "k8s.io/kubernetes/cmd/kubeadm/app/apis/bootstraptoken/v1"
-	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
-	kubeadmapiv1 "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1beta3"
-	"k8s.io/kubernetes/cmd/kubeadm/app/constants"
-	kubeconfigutil "k8s.io/kubernetes/cmd/kubeadm/app/util/kubeconfig"
-	"k8s.io/kubernetes/cmd/kubeadm/app/util/pubkeypin"
+
+	"github.com/pkg/errors"
 )
 
 // BootstrapUser defines bootstrap user name

--- a/cmd/kubeadm/app/discovery/token/token_test.go
+++ b/cmd/kubeadm/app/discovery/token/token_test.go
@@ -20,6 +20,9 @@ import (
 	"testing"
 	"time"
 
+	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
+	"k8s.io/kubernetes/cmd/kubeadm/app/util/apiclient"
+
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clientset "k8s.io/client-go/kubernetes"
@@ -27,8 +30,6 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 	bootstrapapi "k8s.io/cluster-bootstrap/token/api"
 	tokenjws "k8s.io/cluster-bootstrap/token/jws"
-	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
-	"k8s.io/kubernetes/cmd/kubeadm/app/util/apiclient"
 
 	"github.com/pmezard/go-difflib/difflib"
 )

--- a/cmd/kubeadm/app/features/features.go
+++ b/cmd/kubeadm/app/features/features.go
@@ -22,9 +22,10 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/util/version"
 	"k8s.io/component-base/featuregate"
+
+	"github.com/pkg/errors"
 )
 
 const (

--- a/cmd/kubeadm/app/images/images.go
+++ b/cmd/kubeadm/app/images/images.go
@@ -19,11 +19,12 @@ package images
 import (
 	"fmt"
 
-	"k8s.io/klog/v2"
 	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
 	kubeadmapiv1beta2 "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1beta2"
 	"k8s.io/kubernetes/cmd/kubeadm/app/constants"
 	kubeadmutil "k8s.io/kubernetes/cmd/kubeadm/app/util"
+
+	"k8s.io/klog/v2"
 )
 
 // GetGenericImage generates and returns a platform agnostic image (backed by manifest list)

--- a/cmd/kubeadm/app/kubeadm.go
+++ b/cmd/kubeadm/app/kubeadm.go
@@ -20,12 +20,12 @@ import (
 	"flag"
 	"os"
 
-	"github.com/spf13/pflag"
-
-	"k8s.io/klog/v2"
+	"k8s.io/kubernetes/cmd/kubeadm/app/cmd"
 
 	cliflag "k8s.io/component-base/cli/flag"
-	"k8s.io/kubernetes/cmd/kubeadm/app/cmd"
+	"k8s.io/klog/v2"
+
+	"github.com/spf13/pflag"
 )
 
 // Run creates and executes new kubeadm command

--- a/cmd/kubeadm/app/phases/addons/dns/dns.go
+++ b/cmd/kubeadm/app/phases/addons/dns/dns.go
@@ -21,8 +21,13 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/coredns/corefile-migration/migration"
-	"github.com/pkg/errors"
+	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
+	kubeadmconstants "k8s.io/kubernetes/cmd/kubeadm/app/constants"
+	"k8s.io/kubernetes/cmd/kubeadm/app/features"
+	"k8s.io/kubernetes/cmd/kubeadm/app/images"
+	kubeadmutil "k8s.io/kubernetes/cmd/kubeadm/app/util"
+	"k8s.io/kubernetes/cmd/kubeadm/app/util/apiclient"
+
 	apps "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	rbac "k8s.io/api/rbac/v1"
@@ -33,12 +38,9 @@ import (
 	clientset "k8s.io/client-go/kubernetes"
 	clientsetscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/klog/v2"
-	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
-	kubeadmconstants "k8s.io/kubernetes/cmd/kubeadm/app/constants"
-	"k8s.io/kubernetes/cmd/kubeadm/app/features"
-	"k8s.io/kubernetes/cmd/kubeadm/app/images"
-	kubeadmutil "k8s.io/kubernetes/cmd/kubeadm/app/util"
-	"k8s.io/kubernetes/cmd/kubeadm/app/util/apiclient"
+
+	"github.com/coredns/corefile-migration/migration"
+	"github.com/pkg/errors"
 )
 
 const (

--- a/cmd/kubeadm/app/phases/addons/dns/dns_test.go
+++ b/cmd/kubeadm/app/phases/addons/dns/dns_test.go
@@ -21,14 +21,15 @@ import (
 	"strings"
 	"testing"
 
+	kubeadmconstants "k8s.io/kubernetes/cmd/kubeadm/app/constants"
+	kubeadmutil "k8s.io/kubernetes/cmd/kubeadm/app/util"
+
 	apps "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	clientsetfake "k8s.io/client-go/kubernetes/fake"
 	clientsetscheme "k8s.io/client-go/kubernetes/scheme"
-	kubeadmconstants "k8s.io/kubernetes/cmd/kubeadm/app/constants"
-	kubeadmutil "k8s.io/kubernetes/cmd/kubeadm/app/util"
 )
 
 func TestCompileManifests(t *testing.T) {

--- a/cmd/kubeadm/app/phases/addons/proxy/proxy.go
+++ b/cmd/kubeadm/app/phases/addons/proxy/proxy.go
@@ -20,7 +20,13 @@ import (
 	"bytes"
 	"fmt"
 
-	"github.com/pkg/errors"
+	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
+	"k8s.io/kubernetes/cmd/kubeadm/app/componentconfigs"
+	"k8s.io/kubernetes/cmd/kubeadm/app/constants"
+	"k8s.io/kubernetes/cmd/kubeadm/app/images"
+	kubeadmutil "k8s.io/kubernetes/cmd/kubeadm/app/util"
+	"k8s.io/kubernetes/cmd/kubeadm/app/util/apiclient"
+
 	apps "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	rbac "k8s.io/api/rbac/v1"
@@ -28,12 +34,8 @@ import (
 	kuberuntime "k8s.io/apimachinery/pkg/runtime"
 	clientset "k8s.io/client-go/kubernetes"
 	clientsetscheme "k8s.io/client-go/kubernetes/scheme"
-	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
-	"k8s.io/kubernetes/cmd/kubeadm/app/componentconfigs"
-	"k8s.io/kubernetes/cmd/kubeadm/app/constants"
-	"k8s.io/kubernetes/cmd/kubeadm/app/images"
-	kubeadmutil "k8s.io/kubernetes/cmd/kubeadm/app/util"
-	"k8s.io/kubernetes/cmd/kubeadm/app/util/apiclient"
+
+	"github.com/pkg/errors"
 )
 
 const (

--- a/cmd/kubeadm/app/phases/addons/proxy/proxy_test.go
+++ b/cmd/kubeadm/app/phases/addons/proxy/proxy_test.go
@@ -20,6 +20,10 @@ import (
 	"strings"
 	"testing"
 
+	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
+	kubeadmutil "k8s.io/kubernetes/cmd/kubeadm/app/util"
+	configutil "k8s.io/kubernetes/cmd/kubeadm/app/util/config"
+
 	apps "k8s.io/api/apps/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -27,9 +31,6 @@ import (
 	clientsetfake "k8s.io/client-go/kubernetes/fake"
 	clientsetscheme "k8s.io/client-go/kubernetes/scheme"
 	core "k8s.io/client-go/testing"
-	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
-	kubeadmutil "k8s.io/kubernetes/cmd/kubeadm/app/util"
-	configutil "k8s.io/kubernetes/cmd/kubeadm/app/util/config"
 )
 
 func TestCreateServiceAccount(t *testing.T) {

--- a/cmd/kubeadm/app/phases/bootstraptoken/clusterinfo/clusterinfo.go
+++ b/cmd/kubeadm/app/phases/bootstraptoken/clusterinfo/clusterinfo.go
@@ -19,7 +19,8 @@ package clusterinfo
 import (
 	"fmt"
 
-	"github.com/pkg/errors"
+	"k8s.io/kubernetes/cmd/kubeadm/app/util/apiclient"
+
 	"k8s.io/api/core/v1"
 	rbac "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -29,7 +30,8 @@ import (
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 	bootstrapapi "k8s.io/cluster-bootstrap/token/api"
 	"k8s.io/klog/v2"
-	"k8s.io/kubernetes/cmd/kubeadm/app/util/apiclient"
+
+	"github.com/pkg/errors"
 )
 
 const (

--- a/cmd/kubeadm/app/phases/bootstraptoken/node/tlsbootstrap.go
+++ b/cmd/kubeadm/app/phases/bootstraptoken/node/tlsbootstrap.go
@@ -19,11 +19,12 @@ package node
 import (
 	"fmt"
 
+	"k8s.io/kubernetes/cmd/kubeadm/app/constants"
+	"k8s.io/kubernetes/cmd/kubeadm/app/util/apiclient"
+
 	rbac "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clientset "k8s.io/client-go/kubernetes"
-	"k8s.io/kubernetes/cmd/kubeadm/app/constants"
-	"k8s.io/kubernetes/cmd/kubeadm/app/util/apiclient"
 )
 
 const (

--- a/cmd/kubeadm/app/phases/bootstraptoken/node/token.go
+++ b/cmd/kubeadm/app/phases/bootstraptoken/node/token.go
@@ -19,13 +19,14 @@ package node
 import (
 	"context"
 
-	"github.com/pkg/errors"
+	bootstraptokenv1 "k8s.io/kubernetes/cmd/kubeadm/app/apis/bootstraptoken/v1"
+	"k8s.io/kubernetes/cmd/kubeadm/app/util/apiclient"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clientset "k8s.io/client-go/kubernetes"
 	bootstraputil "k8s.io/cluster-bootstrap/token/util"
-	bootstraptokenv1 "k8s.io/kubernetes/cmd/kubeadm/app/apis/bootstraptoken/v1"
-	"k8s.io/kubernetes/cmd/kubeadm/app/util/apiclient"
+
+	"github.com/pkg/errors"
 )
 
 // CreateNewTokens tries to create a token and fails if one with the same ID already exists

--- a/cmd/kubeadm/app/phases/certs/certlist.go
+++ b/cmd/kubeadm/app/phases/certs/certlist.go
@@ -22,12 +22,13 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/pkg/errors"
-
-	certutil "k8s.io/client-go/util/cert"
 	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
 	kubeadmconstants "k8s.io/kubernetes/cmd/kubeadm/app/constants"
 	"k8s.io/kubernetes/cmd/kubeadm/app/util/pkiutil"
+
+	certutil "k8s.io/client-go/util/cert"
+
+	"github.com/pkg/errors"
 )
 
 const (

--- a/cmd/kubeadm/app/phases/certs/certlist_test.go
+++ b/cmd/kubeadm/app/phases/certs/certlist_test.go
@@ -25,9 +25,10 @@ import (
 	"path"
 	"testing"
 
-	certutil "k8s.io/client-go/util/cert"
 	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
 	"k8s.io/kubernetes/cmd/kubeadm/app/util/pkiutil"
+
+	certutil "k8s.io/client-go/util/cert"
 )
 
 func TestCertListOrder(t *testing.T) {

--- a/cmd/kubeadm/app/phases/certs/certs.go
+++ b/cmd/kubeadm/app/phases/certs/certs.go
@@ -24,13 +24,14 @@ import (
 	"path/filepath"
 	"sync"
 
-	"github.com/pkg/errors"
-	"k8s.io/client-go/util/keyutil"
-	"k8s.io/klog/v2"
 	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
+	kubeadmconstants "k8s.io/kubernetes/cmd/kubeadm/app/constants"
 	pkiutil "k8s.io/kubernetes/cmd/kubeadm/app/util/pkiutil"
 
-	kubeadmconstants "k8s.io/kubernetes/cmd/kubeadm/app/constants"
+	"k8s.io/client-go/util/keyutil"
+	"k8s.io/klog/v2"
+
+	"github.com/pkg/errors"
 )
 
 var (

--- a/cmd/kubeadm/app/phases/certs/certs_test.go
+++ b/cmd/kubeadm/app/phases/certs/certs_test.go
@@ -28,17 +28,18 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/pkg/errors"
-	"github.com/stretchr/testify/assert"
-
-	certutil "k8s.io/client-go/util/cert"
-	"k8s.io/client-go/util/keyutil"
 	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
 	kubeadmconstants "k8s.io/kubernetes/cmd/kubeadm/app/constants"
 	certstestutil "k8s.io/kubernetes/cmd/kubeadm/app/util/certs"
 	"k8s.io/kubernetes/cmd/kubeadm/app/util/pkiutil"
 	pkiutiltesting "k8s.io/kubernetes/cmd/kubeadm/app/util/pkiutil/testing"
 	testutil "k8s.io/kubernetes/cmd/kubeadm/test"
+
+	certutil "k8s.io/client-go/util/cert"
+	"k8s.io/client-go/util/keyutil"
+
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
 )
 
 func createTestCSR(t *testing.T) (*x509.CertificateRequest, crypto.Signer) {

--- a/cmd/kubeadm/app/phases/certs/main_test.go
+++ b/cmd/kubeadm/app/phases/certs/main_test.go
@@ -17,8 +17,9 @@ limitations under the License.
 package certs
 
 import (
-	pkiutiltesting "k8s.io/kubernetes/cmd/kubeadm/app/util/pkiutil/testing"
 	"testing"
+
+	pkiutiltesting "k8s.io/kubernetes/cmd/kubeadm/app/util/pkiutil/testing"
 )
 
 func TestMain(m *testing.M) {

--- a/cmd/kubeadm/app/phases/certs/renewal/filerenewer_test.go
+++ b/cmd/kubeadm/app/phases/certs/renewal/filerenewer_test.go
@@ -20,8 +20,9 @@ import (
 	"crypto/x509"
 	"testing"
 
-	certutil "k8s.io/client-go/util/cert"
 	pkiutil "k8s.io/kubernetes/cmd/kubeadm/app/util/pkiutil"
+
+	certutil "k8s.io/client-go/util/cert"
 )
 
 func TestFileRenewer(t *testing.T) {

--- a/cmd/kubeadm/app/phases/certs/renewal/main_test.go
+++ b/cmd/kubeadm/app/phases/certs/renewal/main_test.go
@@ -17,8 +17,9 @@ limitations under the License.
 package renewal
 
 import (
-	pkiutiltesting "k8s.io/kubernetes/cmd/kubeadm/app/util/pkiutil/testing"
 	"testing"
+
+	pkiutiltesting "k8s.io/kubernetes/cmd/kubeadm/app/util/pkiutil/testing"
 )
 
 func TestMain(m *testing.M) {

--- a/cmd/kubeadm/app/phases/certs/renewal/manager.go
+++ b/cmd/kubeadm/app/phases/certs/renewal/manager.go
@@ -20,12 +20,14 @@ import (
 	"crypto/x509"
 	"sort"
 
-	"github.com/pkg/errors"
-	certutil "k8s.io/client-go/util/cert"
 	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
 	kubeadmconstants "k8s.io/kubernetes/cmd/kubeadm/app/constants"
 	certsphase "k8s.io/kubernetes/cmd/kubeadm/app/phases/certs"
 	"k8s.io/kubernetes/cmd/kubeadm/app/util/pkiutil"
+
+	certutil "k8s.io/client-go/util/cert"
+
+	"github.com/pkg/errors"
 )
 
 // Manager can be used to coordinate certificate renewal and related processes,

--- a/cmd/kubeadm/app/phases/certs/renewal/manager_test.go
+++ b/cmd/kubeadm/app/phases/certs/renewal/manager_test.go
@@ -26,11 +26,12 @@ import (
 	"testing"
 	"time"
 
-	certutil "k8s.io/client-go/util/cert"
 	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
 	certtestutil "k8s.io/kubernetes/cmd/kubeadm/app/util/certs"
 	"k8s.io/kubernetes/cmd/kubeadm/app/util/pkiutil"
 	testutil "k8s.io/kubernetes/cmd/kubeadm/test"
+
+	certutil "k8s.io/client-go/util/cert"
 )
 
 var (

--- a/cmd/kubeadm/app/phases/certs/renewal/readwriter.go
+++ b/cmd/kubeadm/app/phases/certs/renewal/readwriter.go
@@ -22,14 +22,15 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/pkg/errors"
+	certsphase "k8s.io/kubernetes/cmd/kubeadm/app/phases/certs"
+	pkiutil "k8s.io/kubernetes/cmd/kubeadm/app/util/pkiutil"
 
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 	certutil "k8s.io/client-go/util/cert"
 	"k8s.io/client-go/util/keyutil"
-	certsphase "k8s.io/kubernetes/cmd/kubeadm/app/phases/certs"
-	pkiutil "k8s.io/kubernetes/cmd/kubeadm/app/util/pkiutil"
+
+	"github.com/pkg/errors"
 )
 
 // certificateReadWriter defines the behavior of a component that

--- a/cmd/kubeadm/app/phases/certs/renewal/readwriter_test.go
+++ b/cmd/kubeadm/app/phases/certs/renewal/readwriter_test.go
@@ -24,13 +24,14 @@ import (
 	"path/filepath"
 	"testing"
 
-	"k8s.io/client-go/tools/clientcmd"
-	certutil "k8s.io/client-go/util/cert"
-	"k8s.io/client-go/util/keyutil"
 	kubeadmconstants "k8s.io/kubernetes/cmd/kubeadm/app/constants"
 	kubeconfigutil "k8s.io/kubernetes/cmd/kubeadm/app/util/kubeconfig"
 	pkiutil "k8s.io/kubernetes/cmd/kubeadm/app/util/pkiutil"
 	testutil "k8s.io/kubernetes/cmd/kubeadm/test"
+
+	"k8s.io/client-go/tools/clientcmd"
+	certutil "k8s.io/client-go/util/cert"
+	"k8s.io/client-go/util/keyutil"
 )
 
 func TestPKICertificateReadWriter(t *testing.T) {

--- a/cmd/kubeadm/app/phases/controlplane/main_test.go
+++ b/cmd/kubeadm/app/phases/controlplane/main_test.go
@@ -17,8 +17,9 @@ limitations under the License.
 package controlplane
 
 import (
-	pkiutiltesting "k8s.io/kubernetes/cmd/kubeadm/app/util/pkiutil/testing"
 	"testing"
+
+	pkiutiltesting "k8s.io/kubernetes/cmd/kubeadm/app/util/pkiutil/testing"
 )
 
 func TestMain(m *testing.M) {

--- a/cmd/kubeadm/app/phases/controlplane/manifests.go
+++ b/cmd/kubeadm/app/phases/controlplane/manifests.go
@@ -24,9 +24,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/pkg/errors"
-	v1 "k8s.io/api/core/v1"
-	"k8s.io/klog/v2"
 	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
 	kubeadmconstants "k8s.io/kubernetes/cmd/kubeadm/app/constants"
 	"k8s.io/kubernetes/cmd/kubeadm/app/features"
@@ -35,7 +32,12 @@ import (
 	kubeadmutil "k8s.io/kubernetes/cmd/kubeadm/app/util"
 	staticpodutil "k8s.io/kubernetes/cmd/kubeadm/app/util/staticpod"
 	"k8s.io/kubernetes/cmd/kubeadm/app/util/users"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/klog/v2"
 	utilsnet "k8s.io/utils/net"
+
+	"github.com/pkg/errors"
 )
 
 // CreateInitStaticPodManifestFiles will write all static pod manifest files needed to bring up the control plane.

--- a/cmd/kubeadm/app/phases/controlplane/manifests_test.go
+++ b/cmd/kubeadm/app/phases/controlplane/manifests_test.go
@@ -26,9 +26,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/lithammer/dedent"
-
-	"k8s.io/apimachinery/pkg/util/sets"
 	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
 	kubeadmconstants "k8s.io/kubernetes/cmd/kubeadm/app/constants"
 	"k8s.io/kubernetes/cmd/kubeadm/app/features"
@@ -36,6 +33,10 @@ import (
 	pkiutiltesting "k8s.io/kubernetes/cmd/kubeadm/app/util/pkiutil/testing"
 	staticpodutil "k8s.io/kubernetes/cmd/kubeadm/app/util/staticpod"
 	testutil "k8s.io/kubernetes/cmd/kubeadm/test"
+
+	"k8s.io/apimachinery/pkg/util/sets"
+
+	"github.com/lithammer/dedent"
 )
 
 const (

--- a/cmd/kubeadm/app/phases/controlplane/volumes.go
+++ b/cmd/kubeadm/app/phases/controlplane/volumes.go
@@ -22,11 +22,12 @@ import (
 	"path/filepath"
 	"strings"
 
-	v1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/util/sets"
 	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
 	kubeadmconstants "k8s.io/kubernetes/cmd/kubeadm/app/constants"
 	staticpodutil "k8s.io/kubernetes/cmd/kubeadm/app/util/staticpod"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
 )
 
 const (

--- a/cmd/kubeadm/app/phases/controlplane/volumes_test.go
+++ b/cmd/kubeadm/app/phases/controlplane/volumes_test.go
@@ -23,9 +23,10 @@ import (
 	"reflect"
 	"testing"
 
-	"k8s.io/api/core/v1"
 	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
 	kubeadmconstants "k8s.io/kubernetes/cmd/kubeadm/app/constants"
+
+	"k8s.io/api/core/v1"
 )
 
 func TestGetEtcdCertVolumes(t *testing.T) {

--- a/cmd/kubeadm/app/phases/copycerts/copycerts.go
+++ b/cmd/kubeadm/app/phases/copycerts/copycerts.go
@@ -25,7 +25,12 @@ import (
 	"path"
 	"strings"
 
-	"github.com/pkg/errors"
+	bootstraptokenv1 "k8s.io/kubernetes/cmd/kubeadm/app/apis/bootstraptoken/v1"
+	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
+	kubeadmconstants "k8s.io/kubernetes/cmd/kubeadm/app/constants"
+	nodebootstraptokenphase "k8s.io/kubernetes/cmd/kubeadm/app/phases/bootstraptoken/node"
+	"k8s.io/kubernetes/cmd/kubeadm/app/util/apiclient"
+	cryptoutil "k8s.io/kubernetes/cmd/kubeadm/app/util/crypto"
 
 	v1 "k8s.io/api/core/v1"
 	rbac "k8s.io/api/rbac/v1"
@@ -37,12 +42,8 @@ import (
 	keyutil "k8s.io/client-go/util/keyutil"
 	bootstraputil "k8s.io/cluster-bootstrap/token/util"
 	"k8s.io/klog/v2"
-	bootstraptokenv1 "k8s.io/kubernetes/cmd/kubeadm/app/apis/bootstraptoken/v1"
-	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
-	kubeadmconstants "k8s.io/kubernetes/cmd/kubeadm/app/constants"
-	nodebootstraptokenphase "k8s.io/kubernetes/cmd/kubeadm/app/phases/bootstraptoken/node"
-	"k8s.io/kubernetes/cmd/kubeadm/app/util/apiclient"
-	cryptoutil "k8s.io/kubernetes/cmd/kubeadm/app/util/crypto"
+
+	"github.com/pkg/errors"
 )
 
 const (

--- a/cmd/kubeadm/app/phases/copycerts/copycerts_test.go
+++ b/cmd/kubeadm/app/phases/copycerts/copycerts_test.go
@@ -25,16 +25,18 @@ import (
 	"regexp"
 	"testing"
 
-	"github.com/lithammer/dedent"
-	v1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	fakeclient "k8s.io/client-go/kubernetes/fake"
-	keyutil "k8s.io/client-go/util/keyutil"
 	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
 	kubeadmconstants "k8s.io/kubernetes/cmd/kubeadm/app/constants"
 	"k8s.io/kubernetes/cmd/kubeadm/app/phases/certs"
 	cryptoutil "k8s.io/kubernetes/cmd/kubeadm/app/util/crypto"
 	testutil "k8s.io/kubernetes/cmd/kubeadm/test"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	fakeclient "k8s.io/client-go/kubernetes/fake"
+	keyutil "k8s.io/client-go/util/keyutil"
+
+	"github.com/lithammer/dedent"
 )
 
 func TestGetDataFromInitConfig(t *testing.T) {

--- a/cmd/kubeadm/app/phases/copycerts/main_test.go
+++ b/cmd/kubeadm/app/phases/copycerts/main_test.go
@@ -17,8 +17,9 @@ limitations under the License.
 package copycerts
 
 import (
-	pkiutiltesting "k8s.io/kubernetes/cmd/kubeadm/app/util/pkiutil/testing"
 	"testing"
+
+	pkiutiltesting "k8s.io/kubernetes/cmd/kubeadm/app/util/pkiutil/testing"
 )
 
 func TestMain(m *testing.M) {

--- a/cmd/kubeadm/app/phases/etcd/local.go
+++ b/cmd/kubeadm/app/phases/etcd/local.go
@@ -25,13 +25,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/pkg/errors"
-	v1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/resource"
-	clientset "k8s.io/client-go/kubernetes"
-	"k8s.io/klog/v2"
-	utilsnet "k8s.io/utils/net"
-
 	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
 	kubeadmconstants "k8s.io/kubernetes/cmd/kubeadm/app/constants"
 	"k8s.io/kubernetes/cmd/kubeadm/app/features"
@@ -40,6 +33,14 @@ import (
 	etcdutil "k8s.io/kubernetes/cmd/kubeadm/app/util/etcd"
 	staticpodutil "k8s.io/kubernetes/cmd/kubeadm/app/util/staticpod"
 	"k8s.io/kubernetes/cmd/kubeadm/app/util/users"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/klog/v2"
+	utilsnet "k8s.io/utils/net"
+
+	"github.com/pkg/errors"
 )
 
 const (

--- a/cmd/kubeadm/app/phases/etcd/local_test.go
+++ b/cmd/kubeadm/app/phases/etcd/local_test.go
@@ -25,13 +25,13 @@ import (
 	"sort"
 	"testing"
 
-	"github.com/lithammer/dedent"
-
 	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
 	kubeadmconstants "k8s.io/kubernetes/cmd/kubeadm/app/constants"
 	etcdutil "k8s.io/kubernetes/cmd/kubeadm/app/util/etcd"
 	staticpodutil "k8s.io/kubernetes/cmd/kubeadm/app/util/staticpod"
 	testutil "k8s.io/kubernetes/cmd/kubeadm/test"
+
+	"github.com/lithammer/dedent"
 )
 
 func TestGetEtcdPodSpec(t *testing.T) {

--- a/cmd/kubeadm/app/phases/kubeconfig/kubeconfig.go
+++ b/cmd/kubeadm/app/phases/kubeconfig/kubeconfig.go
@@ -26,19 +26,20 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/pkg/errors"
-
-	"k8s.io/client-go/tools/clientcmd"
-	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
-	certutil "k8s.io/client-go/util/cert"
-	"k8s.io/client-go/util/keyutil"
-	"k8s.io/klog/v2"
 	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
 	kubeadmconstants "k8s.io/kubernetes/cmd/kubeadm/app/constants"
 	certsphase "k8s.io/kubernetes/cmd/kubeadm/app/phases/certs"
 	kubeadmutil "k8s.io/kubernetes/cmd/kubeadm/app/util"
 	kubeconfigutil "k8s.io/kubernetes/cmd/kubeadm/app/util/kubeconfig"
 	pkiutil "k8s.io/kubernetes/cmd/kubeadm/app/util/pkiutil"
+
+	"k8s.io/client-go/tools/clientcmd"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+	certutil "k8s.io/client-go/util/cert"
+	"k8s.io/client-go/util/keyutil"
+	"k8s.io/klog/v2"
+
+	"github.com/pkg/errors"
 )
 
 const (

--- a/cmd/kubeadm/app/phases/kubeconfig/kubeconfig_test.go
+++ b/cmd/kubeadm/app/phases/kubeconfig/kubeconfig_test.go
@@ -27,10 +27,6 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/lithammer/dedent"
-
-	"k8s.io/client-go/tools/clientcmd"
-	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
 	kubeadmconstants "k8s.io/kubernetes/cmd/kubeadm/app/constants"
 	kubeadmutil "k8s.io/kubernetes/cmd/kubeadm/app/util"
@@ -38,6 +34,11 @@ import (
 	pkiutil "k8s.io/kubernetes/cmd/kubeadm/app/util/pkiutil"
 	testutil "k8s.io/kubernetes/cmd/kubeadm/test"
 	kubeconfigtestutil "k8s.io/kubernetes/cmd/kubeadm/test/kubeconfig"
+
+	"k8s.io/client-go/tools/clientcmd"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+
+	"github.com/lithammer/dedent"
 )
 
 func TestGetKubeConfigSpecsFailsIfCADoesntExists(t *testing.T) {

--- a/cmd/kubeadm/app/phases/kubeconfig/main_test.go
+++ b/cmd/kubeadm/app/phases/kubeconfig/main_test.go
@@ -17,8 +17,9 @@ limitations under the License.
 package kubeconfig
 
 import (
-	pkiutiltesting "k8s.io/kubernetes/cmd/kubeadm/app/util/pkiutil/testing"
 	"testing"
+
+	pkiutiltesting "k8s.io/kubernetes/cmd/kubeadm/app/util/pkiutil/testing"
 )
 
 func TestMain(m *testing.M) {

--- a/cmd/kubeadm/app/phases/kubelet/config.go
+++ b/cmd/kubeadm/app/phases/kubelet/config.go
@@ -22,17 +22,18 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/pkg/errors"
+	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
+	"k8s.io/kubernetes/cmd/kubeadm/app/componentconfigs"
+	kubeadmconstants "k8s.io/kubernetes/cmd/kubeadm/app/constants"
+	"k8s.io/kubernetes/cmd/kubeadm/app/util/apiclient"
 
 	v1 "k8s.io/api/core/v1"
 	rbac "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/version"
 	clientset "k8s.io/client-go/kubernetes"
-	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
-	"k8s.io/kubernetes/cmd/kubeadm/app/componentconfigs"
-	kubeadmconstants "k8s.io/kubernetes/cmd/kubeadm/app/constants"
-	"k8s.io/kubernetes/cmd/kubeadm/app/util/apiclient"
+
+	"github.com/pkg/errors"
 )
 
 // WriteConfigToDisk writes the kubelet config object down to a file

--- a/cmd/kubeadm/app/phases/kubelet/config_test.go
+++ b/cmd/kubeadm/app/phases/kubelet/config_test.go
@@ -19,13 +19,14 @@ package kubelet
 import (
 	"testing"
 
+	configutil "k8s.io/kubernetes/cmd/kubeadm/app/util/config"
+
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/version"
 	"k8s.io/client-go/kubernetes/fake"
 	core "k8s.io/client-go/testing"
-	configutil "k8s.io/kubernetes/cmd/kubeadm/app/util/config"
 )
 
 func TestCreateConfigMap(t *testing.T) {

--- a/cmd/kubeadm/app/phases/kubelet/flags.go
+++ b/cmd/kubeadm/app/phases/kubelet/flags.go
@@ -23,13 +23,14 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/pkg/errors"
-
-	"k8s.io/klog/v2"
 	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
 	"k8s.io/kubernetes/cmd/kubeadm/app/constants"
 	"k8s.io/kubernetes/cmd/kubeadm/app/images"
 	kubeadmutil "k8s.io/kubernetes/cmd/kubeadm/app/util"
+
+	"k8s.io/klog/v2"
+
+	"github.com/pkg/errors"
 )
 
 type kubeletFlagsOpts struct {

--- a/cmd/kubeadm/app/phases/kubelet/flags_test.go
+++ b/cmd/kubeadm/app/phases/kubelet/flags_test.go
@@ -20,8 +20,9 @@ import (
 	"reflect"
 	"testing"
 
-	v1 "k8s.io/api/core/v1"
 	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
+
+	v1 "k8s.io/api/core/v1"
 )
 
 func TestBuildKubeletArgMap(t *testing.T) {

--- a/cmd/kubeadm/app/phases/markcontrolplane/markcontrolplane.go
+++ b/cmd/kubeadm/app/phases/markcontrolplane/markcontrolplane.go
@@ -19,10 +19,11 @@ package markcontrolplane
 import (
 	"fmt"
 
-	"k8s.io/api/core/v1"
-	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/kubernetes/cmd/kubeadm/app/constants"
 	"k8s.io/kubernetes/cmd/kubeadm/app/util/apiclient"
+
+	"k8s.io/api/core/v1"
+	clientset "k8s.io/client-go/kubernetes"
 )
 
 var labelsToAdd = []string{

--- a/cmd/kubeadm/app/phases/markcontrolplane/markcontrolplane_test.go
+++ b/cmd/kubeadm/app/phases/markcontrolplane/markcontrolplane_test.go
@@ -23,11 +23,12 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	kubeadmconstants "k8s.io/kubernetes/cmd/kubeadm/app/constants"
+
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clientset "k8s.io/client-go/kubernetes"
 	restclient "k8s.io/client-go/rest"
-	kubeadmconstants "k8s.io/kubernetes/cmd/kubeadm/app/constants"
 )
 
 func TestMarkControlPlane(t *testing.T) {

--- a/cmd/kubeadm/app/phases/patchnode/patchnode.go
+++ b/cmd/kubeadm/app/phases/patchnode/patchnode.go
@@ -17,11 +17,12 @@ limitations under the License.
 package patchnode
 
 import (
+	"k8s.io/kubernetes/cmd/kubeadm/app/constants"
+	"k8s.io/kubernetes/cmd/kubeadm/app/util/apiclient"
+
 	"k8s.io/api/core/v1"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/klog/v2"
-	"k8s.io/kubernetes/cmd/kubeadm/app/constants"
-	"k8s.io/kubernetes/cmd/kubeadm/app/util/apiclient"
 )
 
 // AnnotateCRISocket annotates the node with the given crisocket

--- a/cmd/kubeadm/app/phases/patchnode/patchnode_test.go
+++ b/cmd/kubeadm/app/phases/patchnode/patchnode_test.go
@@ -23,11 +23,12 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	kubeadmconstants "k8s.io/kubernetes/cmd/kubeadm/app/constants"
+
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clientset "k8s.io/client-go/kubernetes"
 	restclient "k8s.io/client-go/rest"
-	kubeadmconstants "k8s.io/kubernetes/cmd/kubeadm/app/constants"
 )
 
 func TestAnnotateCRISocket(t *testing.T) {

--- a/cmd/kubeadm/app/phases/upgrade/compute.go
+++ b/cmd/kubeadm/app/phases/upgrade/compute.go
@@ -20,11 +20,12 @@ import (
 	"fmt"
 	"strings"
 
+	kubeadmconstants "k8s.io/kubernetes/cmd/kubeadm/app/constants"
+	"k8s.io/kubernetes/cmd/kubeadm/app/phases/addons/dns"
+
 	versionutil "k8s.io/apimachinery/pkg/util/version"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/klog/v2"
-	kubeadmconstants "k8s.io/kubernetes/cmd/kubeadm/app/constants"
-	"k8s.io/kubernetes/cmd/kubeadm/app/phases/addons/dns"
 )
 
 // Upgrade defines an upgrade possibility to upgrade from a current version to a new one

--- a/cmd/kubeadm/app/phases/upgrade/compute_test.go
+++ b/cmd/kubeadm/app/phases/upgrade/compute_test.go
@@ -24,12 +24,13 @@ import (
 	"strings"
 	"testing"
 
+	"k8s.io/kubernetes/cmd/kubeadm/app/constants"
+
 	apps "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	versionutil "k8s.io/apimachinery/pkg/util/version"
 	clientsetfake "k8s.io/client-go/kubernetes/fake"
-	"k8s.io/kubernetes/cmd/kubeadm/app/constants"
 )
 
 type fakeVersionGetter struct {

--- a/cmd/kubeadm/app/phases/upgrade/health.go
+++ b/cmd/kubeadm/app/phases/upgrade/health.go
@@ -22,7 +22,10 @@ import (
 	"os"
 	"time"
 
-	"github.com/pkg/errors"
+	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
+	"k8s.io/kubernetes/cmd/kubeadm/app/constants"
+	"k8s.io/kubernetes/cmd/kubeadm/app/images"
+	"k8s.io/kubernetes/cmd/kubeadm/app/preflight"
 
 	batchv1 "k8s.io/api/batch/v1"
 	v1 "k8s.io/api/core/v1"
@@ -34,10 +37,7 @@ import (
 	"k8s.io/klog/v2"
 	utilpointer "k8s.io/utils/pointer"
 
-	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
-	"k8s.io/kubernetes/cmd/kubeadm/app/constants"
-	"k8s.io/kubernetes/cmd/kubeadm/app/images"
-	"k8s.io/kubernetes/cmd/kubeadm/app/preflight"
+	"github.com/pkg/errors"
 )
 
 // healthCheck is a helper struct for easily performing healthchecks against the cluster and printing the output

--- a/cmd/kubeadm/app/phases/upgrade/main_test.go
+++ b/cmd/kubeadm/app/phases/upgrade/main_test.go
@@ -17,8 +17,9 @@ limitations under the License.
 package upgrade
 
 import (
-	pkiutiltesting "k8s.io/kubernetes/cmd/kubeadm/app/util/pkiutil/testing"
 	"testing"
+
+	pkiutiltesting "k8s.io/kubernetes/cmd/kubeadm/app/util/pkiutil/testing"
 )
 
 func TestMain(m *testing.M) {

--- a/cmd/kubeadm/app/phases/upgrade/policy.go
+++ b/cmd/kubeadm/app/phases/upgrade/policy.go
@@ -20,10 +20,11 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/pkg/errors"
+	"k8s.io/kubernetes/cmd/kubeadm/app/constants"
 
 	"k8s.io/apimachinery/pkg/util/version"
-	"k8s.io/kubernetes/cmd/kubeadm/app/constants"
+
+	"github.com/pkg/errors"
 )
 
 const (

--- a/cmd/kubeadm/app/phases/upgrade/policy_test.go
+++ b/cmd/kubeadm/app/phases/upgrade/policy_test.go
@@ -19,8 +19,9 @@ package upgrade
 import (
 	"testing"
 
-	"k8s.io/apimachinery/pkg/util/version"
 	"k8s.io/kubernetes/cmd/kubeadm/app/constants"
+
+	"k8s.io/apimachinery/pkg/util/version"
 )
 
 func TestEnforceVersionPolicies(t *testing.T) {

--- a/cmd/kubeadm/app/phases/upgrade/postupgrade.go
+++ b/cmd/kubeadm/app/phases/upgrade/postupgrade.go
@@ -20,15 +20,6 @@ import (
 	"context"
 	"os"
 
-	"github.com/pkg/errors"
-
-	v1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
-	errorsutil "k8s.io/apimachinery/pkg/util/errors"
-	clientset "k8s.io/client-go/kubernetes"
-	"k8s.io/klog/v2"
 	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
 	kubeadmconstants "k8s.io/kubernetes/cmd/kubeadm/app/constants"
 	"k8s.io/kubernetes/cmd/kubeadm/app/phases/addons/dns"
@@ -40,6 +31,16 @@ import (
 	"k8s.io/kubernetes/cmd/kubeadm/app/phases/uploadconfig"
 	"k8s.io/kubernetes/cmd/kubeadm/app/util/apiclient"
 	dryrunutil "k8s.io/kubernetes/cmd/kubeadm/app/util/dryrun"
+
+	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	errorsutil "k8s.io/apimachinery/pkg/util/errors"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/klog/v2"
+
+	"github.com/pkg/errors"
 )
 
 // PerformPostUpgradeTasks runs nearly the same functions as 'kubeadm init' would do

--- a/cmd/kubeadm/app/phases/upgrade/postupgrade_test.go
+++ b/cmd/kubeadm/app/phases/upgrade/postupgrade_test.go
@@ -22,10 +22,10 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/pkg/errors"
-
 	"k8s.io/kubernetes/cmd/kubeadm/app/constants"
 	testutil "k8s.io/kubernetes/cmd/kubeadm/test"
+
+	"github.com/pkg/errors"
 )
 
 func TestMoveFiles(t *testing.T) {

--- a/cmd/kubeadm/app/phases/upgrade/preflight.go
+++ b/cmd/kubeadm/app/phases/upgrade/preflight.go
@@ -21,15 +21,16 @@ import (
 	"os"
 	"strings"
 
-	"github.com/coredns/corefile-migration/migration"
-	"github.com/pkg/errors"
+	kubeadmconstants "k8s.io/kubernetes/cmd/kubeadm/app/constants"
+	"k8s.io/kubernetes/cmd/kubeadm/app/phases/addons/dns"
+	"k8s.io/kubernetes/cmd/kubeadm/app/preflight"
 
 	"k8s.io/apimachinery/pkg/util/sets"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/klog/v2"
-	kubeadmconstants "k8s.io/kubernetes/cmd/kubeadm/app/constants"
-	"k8s.io/kubernetes/cmd/kubeadm/app/phases/addons/dns"
-	"k8s.io/kubernetes/cmd/kubeadm/app/preflight"
+
+	"github.com/coredns/corefile-migration/migration"
+	"github.com/pkg/errors"
 )
 
 // CoreDNSCheck validates installed kubelet version

--- a/cmd/kubeadm/app/phases/upgrade/staticpods.go
+++ b/cmd/kubeadm/app/phases/upgrade/staticpods.go
@@ -23,12 +23,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/pkg/errors"
-
-	utilerrors "k8s.io/apimachinery/pkg/util/errors"
-	"k8s.io/apimachinery/pkg/util/version"
-	clientset "k8s.io/client-go/kubernetes"
-	"k8s.io/klog/v2"
 	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
 	"k8s.io/kubernetes/cmd/kubeadm/app/constants"
 	certsphase "k8s.io/kubernetes/cmd/kubeadm/app/phases/certs"
@@ -41,6 +35,13 @@ import (
 	etcdutil "k8s.io/kubernetes/cmd/kubeadm/app/util/etcd"
 	"k8s.io/kubernetes/cmd/kubeadm/app/util/image"
 	"k8s.io/kubernetes/cmd/kubeadm/app/util/staticpod"
+
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/apimachinery/pkg/util/version"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/klog/v2"
+
+	"github.com/pkg/errors"
 )
 
 const (

--- a/cmd/kubeadm/app/phases/upgrade/staticpods_test.go
+++ b/cmd/kubeadm/app/phases/upgrade/staticpods_test.go
@@ -28,11 +28,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/pkg/errors"
-	"go.etcd.io/etcd/client/pkg/v3/transport"
-
-	"k8s.io/client-go/tools/clientcmd"
-	certutil "k8s.io/client-go/util/cert"
 	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
 	kubeadmapiv1 "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1beta3"
 	"k8s.io/kubernetes/cmd/kubeadm/app/constants"
@@ -48,6 +43,12 @@ import (
 	"k8s.io/kubernetes/cmd/kubeadm/app/util/pkiutil"
 	pkiutiltesting "k8s.io/kubernetes/cmd/kubeadm/app/util/pkiutil/testing"
 	testutil "k8s.io/kubernetes/cmd/kubeadm/test"
+
+	"k8s.io/client-go/tools/clientcmd"
+	certutil "k8s.io/client-go/util/cert"
+
+	"github.com/pkg/errors"
+	"go.etcd.io/etcd/client/pkg/v3/transport"
 )
 
 const (

--- a/cmd/kubeadm/app/phases/upgrade/versiongetter.go
+++ b/cmd/kubeadm/app/phases/upgrade/versiongetter.go
@@ -18,14 +18,16 @@ package upgrade
 
 import (
 	"context"
-	"github.com/pkg/errors"
+
+	kubeadmutil "k8s.io/kubernetes/cmd/kubeadm/app/util"
 
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	versionutil "k8s.io/apimachinery/pkg/util/version"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/component-base/version"
-	kubeadmutil "k8s.io/kubernetes/cmd/kubeadm/app/util"
+
+	"github.com/pkg/errors"
 )
 
 // VersionGetter defines an interface for fetching different versions.

--- a/cmd/kubeadm/app/phases/uploadconfig/uploadconfig.go
+++ b/cmd/kubeadm/app/phases/uploadconfig/uploadconfig.go
@@ -19,14 +19,15 @@ package uploadconfig
 import (
 	"fmt"
 
-	v1 "k8s.io/api/core/v1"
-	rbac "k8s.io/api/rbac/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	clientset "k8s.io/client-go/kubernetes"
 	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
 	kubeadmconstants "k8s.io/kubernetes/cmd/kubeadm/app/constants"
 	"k8s.io/kubernetes/cmd/kubeadm/app/util/apiclient"
 	configutil "k8s.io/kubernetes/cmd/kubeadm/app/util/config"
+
+	v1 "k8s.io/api/core/v1"
+	rbac "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clientset "k8s.io/client-go/kubernetes"
 )
 
 const (

--- a/cmd/kubeadm/app/phases/uploadconfig/uploadconfig_test.go
+++ b/cmd/kubeadm/app/phases/uploadconfig/uploadconfig_test.go
@@ -21,13 +21,14 @@ import (
 	"reflect"
 	"testing"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
-	clientsetfake "k8s.io/client-go/kubernetes/fake"
 	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
 	kubeadmscheme "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/scheme"
 	kubeadmconstants "k8s.io/kubernetes/cmd/kubeadm/app/constants"
 	configutil "k8s.io/kubernetes/cmd/kubeadm/app/util/config"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	clientsetfake "k8s.io/client-go/kubernetes/fake"
 )
 
 func TestUploadConfiguration(t *testing.T) {

--- a/cmd/kubeadm/app/preflight/checks.go
+++ b/cmd/kubeadm/app/preflight/checks.go
@@ -34,8 +34,12 @@ import (
 	"strings"
 	"time"
 
-	"github.com/PuerkitoBio/purell"
-	"github.com/pkg/errors"
+	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
+	kubeadmconstants "k8s.io/kubernetes/cmd/kubeadm/app/constants"
+	"k8s.io/kubernetes/cmd/kubeadm/app/images"
+	"k8s.io/kubernetes/cmd/kubeadm/app/util/initsystem"
+	utilruntime "k8s.io/kubernetes/cmd/kubeadm/app/util/runtime"
+
 	v1 "k8s.io/api/core/v1"
 	netutil "k8s.io/apimachinery/pkg/util/net"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -43,14 +47,12 @@ import (
 	versionutil "k8s.io/apimachinery/pkg/util/version"
 	kubeadmversion "k8s.io/component-base/version"
 	"k8s.io/klog/v2"
-	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
-	kubeadmconstants "k8s.io/kubernetes/cmd/kubeadm/app/constants"
-	"k8s.io/kubernetes/cmd/kubeadm/app/images"
-	"k8s.io/kubernetes/cmd/kubeadm/app/util/initsystem"
-	utilruntime "k8s.io/kubernetes/cmd/kubeadm/app/util/runtime"
 	system "k8s.io/system-validators/validators"
 	utilsexec "k8s.io/utils/exec"
 	utilsnet "k8s.io/utils/net"
+
+	"github.com/PuerkitoBio/purell"
+	"github.com/pkg/errors"
 )
 
 const (

--- a/cmd/kubeadm/app/preflight/checks_test.go
+++ b/cmd/kubeadm/app/preflight/checks_test.go
@@ -21,22 +21,22 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net"
+	"net/http"
+	"os"
 	"runtime"
 	"strings"
 	"testing"
 
-	"github.com/lithammer/dedent"
-	"github.com/pkg/errors"
-
-	"net/http"
-	"os"
-
-	"k8s.io/apimachinery/pkg/util/sets"
 	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
 	"k8s.io/kubernetes/cmd/kubeadm/app/constants"
 	utilruntime "k8s.io/kubernetes/cmd/kubeadm/app/util/runtime"
+
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/utils/exec"
 	fakeexec "k8s.io/utils/exec/testing"
+
+	"github.com/lithammer/dedent"
+	"github.com/pkg/errors"
 )
 
 var (

--- a/cmd/kubeadm/app/preflight/utils.go
+++ b/cmd/kubeadm/app/preflight/utils.go
@@ -20,10 +20,10 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/pkg/errors"
-
 	"k8s.io/apimachinery/pkg/util/version"
 	utilsexec "k8s.io/utils/exec"
+
+	"github.com/pkg/errors"
 )
 
 // GetKubeletVersion is helper function that returns version of kubelet available in $PATH

--- a/cmd/kubeadm/app/preflight/utils_test.go
+++ b/cmd/kubeadm/app/preflight/utils_test.go
@@ -19,10 +19,10 @@ package preflight
 import (
 	"testing"
 
-	"github.com/pkg/errors"
-
 	utilsexec "k8s.io/utils/exec"
 	fakeexec "k8s.io/utils/exec/testing"
+
+	"github.com/pkg/errors"
 )
 
 func TestGetKubeletVersion(t *testing.T) {

--- a/cmd/kubeadm/app/util/apiclient/clientbacked_dryrun.go
+++ b/cmd/kubeadm/app/util/apiclient/clientbacked_dryrun.go
@@ -21,8 +21,6 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/pkg/errors"
-
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -32,6 +30,8 @@ import (
 	"k8s.io/client-go/rest"
 	core "k8s.io/client-go/testing"
 	"k8s.io/client-go/tools/clientcmd"
+
+	"github.com/pkg/errors"
 )
 
 // ClientBackedDryRunGetter implements the DryRunGetter interface for use in NewDryRunClient() and proxies all GET and LIST requests to the backing API server reachable via rest.Config

--- a/cmd/kubeadm/app/util/apiclient/dryrunclient.go
+++ b/cmd/kubeadm/app/util/apiclient/dryrunclient.go
@@ -23,13 +23,15 @@ import (
 	"io"
 	"strings"
 
-	"github.com/pkg/errors"
+	kubeadmutil "k8s.io/kubernetes/cmd/kubeadm/app/util"
+
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	clientset "k8s.io/client-go/kubernetes"
 	fakeclientset "k8s.io/client-go/kubernetes/fake"
 	core "k8s.io/client-go/testing"
-	kubeadmutil "k8s.io/kubernetes/cmd/kubeadm/app/util"
+
+	"github.com/pkg/errors"
 )
 
 // DryRunGetter is an interface that must be supplied to the NewDryRunClient function in order to construct a fully functional fake dryrun clientset

--- a/cmd/kubeadm/app/util/apiclient/idempotency.go
+++ b/cmd/kubeadm/app/util/apiclient/idempotency.go
@@ -21,7 +21,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/pkg/errors"
+	"k8s.io/kubernetes/cmd/kubeadm/app/constants"
 
 	apps "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
@@ -33,7 +33,8 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	clientset "k8s.io/client-go/kubernetes"
 	clientsetretry "k8s.io/client-go/util/retry"
-	"k8s.io/kubernetes/cmd/kubeadm/app/constants"
+
+	"github.com/pkg/errors"
 )
 
 // ConfigMapMutator is a function that mutates the given ConfigMap and optionally returns an error

--- a/cmd/kubeadm/app/util/apiclient/idempotency_test.go
+++ b/cmd/kubeadm/app/util/apiclient/idempotency_test.go
@@ -20,13 +20,14 @@ import (
 	"context"
 	"testing"
 
-	"github.com/pkg/errors"
 	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/fake"
 	core "k8s.io/client-go/testing"
+
+	"github.com/pkg/errors"
 )
 
 const configMapName = "configmap"

--- a/cmd/kubeadm/app/util/apiclient/init_dryrun.go
+++ b/cmd/kubeadm/app/util/apiclient/init_dryrun.go
@@ -20,7 +20,7 @@ import (
 	"net"
 	"strings"
 
-	"github.com/pkg/errors"
+	"k8s.io/kubernetes/cmd/kubeadm/app/constants"
 
 	"k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -28,8 +28,9 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	core "k8s.io/client-go/testing"
-	"k8s.io/kubernetes/cmd/kubeadm/app/constants"
 	utilnet "k8s.io/utils/net"
+
+	"github.com/pkg/errors"
 )
 
 // InitDryRunGetter implements the DryRunGetter interface and can be used to GET/LIST values in the dryrun fake clientset

--- a/cmd/kubeadm/app/util/apiclient/wait.go
+++ b/cmd/kubeadm/app/util/apiclient/wait.go
@@ -23,7 +23,7 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/pkg/errors"
+	kubeadmconstants "k8s.io/kubernetes/cmd/kubeadm/app/constants"
 
 	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -31,7 +31,8 @@ import (
 	netutil "k8s.io/apimachinery/pkg/util/net"
 	"k8s.io/apimachinery/pkg/util/wait"
 	clientset "k8s.io/client-go/kubernetes"
-	kubeadmconstants "k8s.io/kubernetes/cmd/kubeadm/app/constants"
+
+	"github.com/pkg/errors"
 )
 
 // Waiter is an interface for waiting for criteria in Kubernetes to happen

--- a/cmd/kubeadm/app/util/certs/util.go
+++ b/cmd/kubeadm/app/util/certs/util.go
@@ -24,9 +24,10 @@ import (
 	"path"
 	"testing"
 
+	pkiutil "k8s.io/kubernetes/cmd/kubeadm/app/util/pkiutil"
+
 	certutil "k8s.io/client-go/util/cert"
 	"k8s.io/client-go/util/keyutil"
-	pkiutil "k8s.io/kubernetes/cmd/kubeadm/app/util/pkiutil"
 )
 
 // SetupCertificateAuthority is a utility function for kubeadm testing that creates a

--- a/cmd/kubeadm/app/util/chroot_unix.go
+++ b/cmd/kubeadm/app/util/chroot_unix.go
@@ -19,10 +19,11 @@ limitations under the License.
 package util
 
 import (
-	"github.com/pkg/errors"
 	"os"
 	"path/filepath"
 	"syscall"
+
+	"github.com/pkg/errors"
 )
 
 // Chroot chroot()s to the new path.

--- a/cmd/kubeadm/app/util/config/cluster.go
+++ b/cmd/kubeadm/app/util/config/cluster.go
@@ -24,7 +24,11 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/pkg/errors"
+	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
+	kubeadmscheme "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/scheme"
+	"k8s.io/kubernetes/cmd/kubeadm/app/componentconfigs"
+	"k8s.io/kubernetes/cmd/kubeadm/app/constants"
+	"k8s.io/kubernetes/cmd/kubeadm/app/util/apiclient"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -33,11 +37,8 @@ import (
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
 	certutil "k8s.io/client-go/util/cert"
-	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
-	kubeadmscheme "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/scheme"
-	"k8s.io/kubernetes/cmd/kubeadm/app/componentconfigs"
-	"k8s.io/kubernetes/cmd/kubeadm/app/constants"
-	"k8s.io/kubernetes/cmd/kubeadm/app/util/apiclient"
+
+	"github.com/pkg/errors"
 )
 
 // FetchInitConfigurationFromCluster fetches configuration from a ConfigMap in the cluster

--- a/cmd/kubeadm/app/util/config/cluster_test.go
+++ b/cmd/kubeadm/app/util/config/cluster_test.go
@@ -27,7 +27,12 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/pkg/errors"
+	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
+	kubeadmapiv1old "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1beta2"
+	kubeadmapiv1 "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1beta3"
+	"k8s.io/kubernetes/cmd/kubeadm/app/componentconfigs"
+	kubeadmconstants "k8s.io/kubernetes/cmd/kubeadm/app/constants"
+	testresources "k8s.io/kubernetes/cmd/kubeadm/test/resources"
 
 	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -37,12 +42,8 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	clientsetfake "k8s.io/client-go/kubernetes/fake"
 	clienttesting "k8s.io/client-go/testing"
-	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
-	kubeadmapiv1old "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1beta2"
-	kubeadmapiv1 "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1beta3"
-	"k8s.io/kubernetes/cmd/kubeadm/app/componentconfigs"
-	kubeadmconstants "k8s.io/kubernetes/cmd/kubeadm/app/constants"
-	testresources "k8s.io/kubernetes/cmd/kubeadm/test/resources"
+
+	"github.com/pkg/errors"
 )
 
 var k8sVersionString = kubeadmconstants.MinimumControlPlaneVersion.String()

--- a/cmd/kubeadm/app/util/config/common.go
+++ b/cmd/kubeadm/app/util/config/common.go
@@ -22,18 +22,19 @@ import (
 	"reflect"
 	"strings"
 
-	"github.com/pkg/errors"
-	"k8s.io/klog/v2"
-
-	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/schema"
-	netutil "k8s.io/apimachinery/pkg/util/net"
-	"k8s.io/apimachinery/pkg/util/version"
 	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
 	kubeadmscheme "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/scheme"
 	kubeadmapiv1 "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1beta3"
 	"k8s.io/kubernetes/cmd/kubeadm/app/constants"
 	kubeadmutil "k8s.io/kubernetes/cmd/kubeadm/app/util"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	netutil "k8s.io/apimachinery/pkg/util/net"
+	"k8s.io/apimachinery/pkg/util/version"
+	"k8s.io/klog/v2"
+
+	"github.com/pkg/errors"
 )
 
 // MarshalKubeadmConfigObject marshals an Object registered in the kubeadm scheme. If the object is a InitConfiguration or ClusterConfiguration, some extra logic is run

--- a/cmd/kubeadm/app/util/config/common_test.go
+++ b/cmd/kubeadm/app/util/config/common_test.go
@@ -20,13 +20,14 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/lithammer/dedent"
-
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	kubeadmapiv1old "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1beta2"
 	kubeadmapiv1 "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1beta3"
 	"k8s.io/kubernetes/cmd/kubeadm/app/constants"
 	kubeadmutil "k8s.io/kubernetes/cmd/kubeadm/app/util"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/lithammer/dedent"
 )
 
 const KubeadmGroupName = "kubeadm.k8s.io"

--- a/cmd/kubeadm/app/util/config/initconfiguration.go
+++ b/cmd/kubeadm/app/util/config/initconfiguration.go
@@ -23,14 +23,6 @@ import (
 	"net"
 	"strconv"
 
-	"github.com/pkg/errors"
-	"k8s.io/klog/v2"
-
-	v1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/schema"
-	netutil "k8s.io/apimachinery/pkg/util/net"
-	bootstraputil "k8s.io/cluster-bootstrap/token/util"
 	bootstraptokenv1 "k8s.io/kubernetes/cmd/kubeadm/app/apis/bootstraptoken/v1"
 	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
 	kubeadmscheme "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/scheme"
@@ -41,6 +33,15 @@ import (
 	kubeadmutil "k8s.io/kubernetes/cmd/kubeadm/app/util"
 	"k8s.io/kubernetes/cmd/kubeadm/app/util/config/strict"
 	kubeadmruntime "k8s.io/kubernetes/cmd/kubeadm/app/util/runtime"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	netutil "k8s.io/apimachinery/pkg/util/net"
+	bootstraputil "k8s.io/cluster-bootstrap/token/util"
+	"k8s.io/klog/v2"
+
+	"github.com/pkg/errors"
 )
 
 var (

--- a/cmd/kubeadm/app/util/config/initconfiguration_test.go
+++ b/cmd/kubeadm/app/util/config/initconfiguration_test.go
@@ -23,10 +23,11 @@ import (
 	"path/filepath"
 	"testing"
 
-	v1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kubeadmapiv1 "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1beta3"
 	"k8s.io/kubernetes/cmd/kubeadm/app/constants"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/yaml"
 )
 

--- a/cmd/kubeadm/app/util/config/joinconfiguration.go
+++ b/cmd/kubeadm/app/util/config/joinconfiguration.go
@@ -19,9 +19,6 @@ package config
 import (
 	"io/ioutil"
 
-	"github.com/pkg/errors"
-	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/klog/v2"
 	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
 	kubeadmscheme "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/scheme"
 	kubeadmapiv1 "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1beta3"
@@ -29,6 +26,11 @@ import (
 	"k8s.io/kubernetes/cmd/kubeadm/app/constants"
 	kubeadmutil "k8s.io/kubernetes/cmd/kubeadm/app/util"
 	"k8s.io/kubernetes/cmd/kubeadm/app/util/config/strict"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/klog/v2"
+
+	"github.com/pkg/errors"
 )
 
 // SetJoinDynamicDefaults checks and sets configuration values for the JoinConfiguration object

--- a/cmd/kubeadm/app/util/config/joinconfiguration_test.go
+++ b/cmd/kubeadm/app/util/config/joinconfiguration_test.go
@@ -23,8 +23,9 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/lithammer/dedent"
 	kubeadmapiv1old "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1beta2"
+
+	"github.com/lithammer/dedent"
 )
 
 func TestLoadJoinConfigurationFromFile(t *testing.T) {

--- a/cmd/kubeadm/app/util/config/strict/strict.go
+++ b/cmd/kubeadm/app/util/config/strict/strict.go
@@ -17,13 +17,14 @@ limitations under the License.
 package strict
 
 import (
-	"github.com/pkg/errors"
+	"k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/scheme"
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/klog/v2"
-	"k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/scheme"
 	"k8s.io/kubernetes/cmd/kubeadm/app/componentconfigs"
 	"sigs.k8s.io/yaml"
+
+	"github.com/pkg/errors"
 )
 
 // VerifyUnmarshalStrict takes a YAML byte slice and a GroupVersionKind and verifies if the YAML

--- a/cmd/kubeadm/app/util/config/strict/strict_test.go
+++ b/cmd/kubeadm/app/util/config/strict/strict_test.go
@@ -21,11 +21,12 @@ import (
 	"path/filepath"
 	"testing"
 
+	kubeadmapiv1 "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1beta3"
+	"k8s.io/kubernetes/cmd/kubeadm/app/constants"
+
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	kubeproxyconfigv1alpha1 "k8s.io/kube-proxy/config/v1alpha1"
 	kubeletconfigv1beta1 "k8s.io/kubelet/config/v1beta1"
-	kubeadmapiv1 "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1beta3"
-	"k8s.io/kubernetes/cmd/kubeadm/app/constants"
 )
 
 func TestVerifyUnmarshalStrict(t *testing.T) {

--- a/cmd/kubeadm/app/util/crypto/crypto.go
+++ b/cmd/kubeadm/app/util/crypto/crypto.go
@@ -17,11 +17,11 @@ limitations under the License.
 package crypto
 
 import (
-	"github.com/pkg/errors"
-
 	"crypto/aes"
 	"crypto/cipher"
 	"crypto/rand"
+
+	"github.com/pkg/errors"
 )
 
 // CreateRandBytes returns a cryptographically secure slice of random bytes with a given size

--- a/cmd/kubeadm/app/util/crypto/crypto_test.go
+++ b/cmd/kubeadm/app/util/crypto/crypto_test.go
@@ -19,9 +19,9 @@ package crypto
 import (
 	"testing"
 
-	"github.com/lithammer/dedent"
-
 	kubeadmconstants "k8s.io/kubernetes/cmd/kubeadm/app/constants"
+
+	"github.com/lithammer/dedent"
 )
 
 func TestEncryptAndDecryptData(t *testing.T) {

--- a/cmd/kubeadm/app/util/dryrun/dryrun.go
+++ b/cmd/kubeadm/app/util/dryrun/dryrun.go
@@ -23,10 +23,11 @@ import (
 	"path/filepath"
 	"time"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	errorsutil "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/kubernetes/cmd/kubeadm/app/constants"
 	"k8s.io/kubernetes/cmd/kubeadm/app/util/apiclient"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	errorsutil "k8s.io/apimachinery/pkg/util/errors"
 )
 
 // FileToPrint represents a temporary file on disk that might want to be aliased when printing

--- a/cmd/kubeadm/app/util/endpoint.go
+++ b/cmd/kubeadm/app/util/endpoint.go
@@ -22,11 +22,12 @@ import (
 	"net/url"
 	"strconv"
 
-	"github.com/pkg/errors"
+	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
 
 	"k8s.io/apimachinery/pkg/util/validation"
-	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
 	utilsnet "k8s.io/utils/net"
+
+	"github.com/pkg/errors"
 )
 
 // GetControlPlaneEndpoint returns a properly formatted endpoint for the control plane built according following rules:

--- a/cmd/kubeadm/app/util/error_test.go
+++ b/cmd/kubeadm/app/util/error_test.go
@@ -17,8 +17,9 @@ limitations under the License.
 package util
 
 import (
-	"github.com/pkg/errors"
 	"testing"
+
+	"github.com/pkg/errors"
 )
 
 type pferror struct{}

--- a/cmd/kubeadm/app/util/etcd/etcd.go
+++ b/cmd/kubeadm/app/util/etcd/etcd.go
@@ -27,16 +27,18 @@ import (
 	"strings"
 	"time"
 
-	"github.com/pkg/errors"
-	"go.etcd.io/etcd/client/pkg/v3/transport"
-	clientv3 "go.etcd.io/etcd/client/v3"
-	"google.golang.org/grpc"
+	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
+	"k8s.io/kubernetes/cmd/kubeadm/app/constants"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/klog/v2"
-	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
-	"k8s.io/kubernetes/cmd/kubeadm/app/constants"
+
+	"github.com/pkg/errors"
+	"go.etcd.io/etcd/client/pkg/v3/transport"
+	clientv3 "go.etcd.io/etcd/client/v3"
+	"google.golang.org/grpc"
 )
 
 const etcdTimeout = 2 * time.Second

--- a/cmd/kubeadm/app/util/etcd/etcd_test.go
+++ b/cmd/kubeadm/app/util/etcd/etcd_test.go
@@ -22,15 +22,17 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/pkg/errors"
+	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
+	"k8s.io/kubernetes/cmd/kubeadm/app/constants"
+	testresources "k8s.io/kubernetes/cmd/kubeadm/test/resources"
+
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
 	clientsetfake "k8s.io/client-go/kubernetes/fake"
 	clienttesting "k8s.io/client-go/testing"
-	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
-	"k8s.io/kubernetes/cmd/kubeadm/app/constants"
-	testresources "k8s.io/kubernetes/cmd/kubeadm/test/resources"
+
+	"github.com/pkg/errors"
 )
 
 func testGetURL(t *testing.T, getURLFunc func(*kubeadmapi.APIEndpoint) string, port int) {

--- a/cmd/kubeadm/app/util/marshal.go
+++ b/cmd/kubeadm/app/util/marshal.go
@@ -21,7 +21,8 @@ import (
 	"bytes"
 	"io"
 
-	"github.com/pkg/errors"
+	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
+	"k8s.io/kubernetes/cmd/kubeadm/app/constants"
 
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -30,8 +31,8 @@ import (
 	errorsutil "k8s.io/apimachinery/pkg/util/errors"
 	utilyaml "k8s.io/apimachinery/pkg/util/yaml"
 	clientsetscheme "k8s.io/client-go/kubernetes/scheme"
-	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
-	"k8s.io/kubernetes/cmd/kubeadm/app/constants"
+
+	"github.com/pkg/errors"
 )
 
 // MarshalToYaml marshals an object into yaml.

--- a/cmd/kubeadm/app/util/marshal_test.go
+++ b/cmd/kubeadm/app/util/marshal_test.go
@@ -22,15 +22,16 @@ import (
 	"sort"
 	"testing"
 
+	bootstraptokenv1 "k8s.io/kubernetes/cmd/kubeadm/app/apis/bootstraptoken/v1"
+	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
+	kubeadmapiv1 "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1beta3"
+	"k8s.io/kubernetes/cmd/kubeadm/app/constants"
+
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
-	bootstraptokenv1 "k8s.io/kubernetes/cmd/kubeadm/app/apis/bootstraptoken/v1"
-	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
-	kubeadmapiv1 "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1beta3"
-	"k8s.io/kubernetes/cmd/kubeadm/app/constants"
 )
 
 var files = map[string][]byte{

--- a/cmd/kubeadm/app/util/output/output.go
+++ b/cmd/kubeadm/app/util/output/output.go
@@ -21,10 +21,11 @@ import (
 	"io"
 	"strings"
 
-	"github.com/spf13/cobra"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/cli-runtime/pkg/printers"
+
+	"github.com/spf13/cobra"
 )
 
 // TextOutput describes the plain text output

--- a/cmd/kubeadm/app/util/patches/patches.go
+++ b/cmd/kubeadm/app/util/patches/patches.go
@@ -28,12 +28,13 @@ import (
 	"strings"
 	"sync"
 
-	jsonpatch "github.com/evanphx/json-patch"
-	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/strategicpatch"
 	utilyaml "k8s.io/apimachinery/pkg/util/yaml"
 	"sigs.k8s.io/yaml"
+
+	jsonpatch "github.com/evanphx/json-patch"
+	"github.com/pkg/errors"
 )
 
 // PatchTarget defines a target to be patched, such as a control-plane static Pod.

--- a/cmd/kubeadm/app/util/patches/patches_test.go
+++ b/cmd/kubeadm/app/util/patches/patches_test.go
@@ -24,9 +24,10 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/pkg/errors"
 	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/pkg/errors"
 )
 
 var testKnownTargets = []string{

--- a/cmd/kubeadm/app/util/pkiutil/pki_helpers.go
+++ b/cmd/kubeadm/app/util/pkiutil/pki_helpers.go
@@ -35,16 +35,17 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/pkg/errors"
+	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
+	kubeadmconstants "k8s.io/kubernetes/cmd/kubeadm/app/constants"
+	"k8s.io/kubernetes/cmd/kubeadm/app/features"
+	kubeadmutil "k8s.io/kubernetes/cmd/kubeadm/app/util"
 
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/validation"
 	certutil "k8s.io/client-go/util/cert"
 	"k8s.io/client-go/util/keyutil"
-	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
-	kubeadmconstants "k8s.io/kubernetes/cmd/kubeadm/app/constants"
-	"k8s.io/kubernetes/cmd/kubeadm/app/features"
-	kubeadmutil "k8s.io/kubernetes/cmd/kubeadm/app/util"
+
+	"github.com/pkg/errors"
 )
 
 const (

--- a/cmd/kubeadm/app/util/pkiutil/pki_helpers_test.go
+++ b/cmd/kubeadm/app/util/pkiutil/pki_helpers_test.go
@@ -29,8 +29,9 @@ import (
 	"reflect"
 	"testing"
 
-	certutil "k8s.io/client-go/util/cert"
 	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
+
+	certutil "k8s.io/client-go/util/cert"
 )
 
 var (

--- a/cmd/kubeadm/app/util/runtime/runtime.go
+++ b/cmd/kubeadm/app/util/runtime/runtime.go
@@ -21,11 +21,12 @@ import (
 	goruntime "runtime"
 	"strings"
 
-	"github.com/pkg/errors"
+	"k8s.io/kubernetes/cmd/kubeadm/app/constants"
 
 	errorsutil "k8s.io/apimachinery/pkg/util/errors"
-	"k8s.io/kubernetes/cmd/kubeadm/app/constants"
 	utilsexec "k8s.io/utils/exec"
+
+	"github.com/pkg/errors"
 )
 
 // ContainerRuntime is an interface for working with container runtimes

--- a/cmd/kubeadm/app/util/runtime/runtime_test.go
+++ b/cmd/kubeadm/app/util/runtime/runtime_test.go
@@ -24,11 +24,12 @@ import (
 	"runtime"
 	"testing"
 
-	"github.com/pkg/errors"
-
 	"k8s.io/kubernetes/cmd/kubeadm/app/constants"
+
 	"k8s.io/utils/exec"
 	fakeexec "k8s.io/utils/exec/testing"
+
+	"github.com/pkg/errors"
 )
 
 func TestNewContainerRuntime(t *testing.T) {

--- a/cmd/kubeadm/app/util/staticpod/utils.go
+++ b/cmd/kubeadm/app/util/staticpod/utils.go
@@ -28,17 +28,18 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/pkg/errors"
-
-	v1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/resource"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/intstr"
 	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
 	kubeadmconstants "k8s.io/kubernetes/cmd/kubeadm/app/constants"
 	kubeadmutil "k8s.io/kubernetes/cmd/kubeadm/app/util"
 	"k8s.io/kubernetes/cmd/kubeadm/app/util/patches"
 	"k8s.io/kubernetes/cmd/kubeadm/app/util/users"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+
+	"github.com/pkg/errors"
 )
 
 const (

--- a/cmd/kubeadm/app/util/staticpod/utils_linux.go
+++ b/cmd/kubeadm/app/util/staticpod/utils_linux.go
@@ -22,13 +22,15 @@ import (
 	"fmt"
 	"path/filepath"
 
-	"github.com/pkg/errors"
-	v1 "k8s.io/api/core/v1"
 	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
 	kubeadmconstants "k8s.io/kubernetes/cmd/kubeadm/app/constants"
 	certphase "k8s.io/kubernetes/cmd/kubeadm/app/phases/certs"
 	"k8s.io/kubernetes/cmd/kubeadm/app/util/users"
+
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/utils/pointer"
+
+	"github.com/pkg/errors"
 )
 
 type pathOwnerAndPermissionsUpdaterFunc func(path string, uid, gid int64, perms uint32) error

--- a/cmd/kubeadm/app/util/staticpod/utils_linux_test.go
+++ b/cmd/kubeadm/app/util/staticpod/utils_linux_test.go
@@ -23,9 +23,10 @@ import (
 	"reflect"
 	"testing"
 
-	v1 "k8s.io/api/core/v1"
 	"k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
 	kubeadmconstants "k8s.io/kubernetes/cmd/kubeadm/app/constants"
+
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/utils/pointer"
 )
 

--- a/cmd/kubeadm/app/util/staticpod/utils_others.go
+++ b/cmd/kubeadm/app/util/staticpod/utils_others.go
@@ -19,9 +19,10 @@ limitations under the License.
 package staticpod
 
 import (
-	v1 "k8s.io/api/core/v1"
 	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
 	"k8s.io/kubernetes/cmd/kubeadm/app/util/users"
+
+	v1 "k8s.io/api/core/v1"
 )
 
 // RunComponentAsNonRoot is a NO-OP on non linux.

--- a/cmd/kubeadm/app/util/staticpod/utils_test.go
+++ b/cmd/kubeadm/app/util/staticpod/utils_test.go
@@ -25,11 +25,12 @@ import (
 	"strconv"
 	"testing"
 
-	v1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
 	kubeadmconstants "k8s.io/kubernetes/cmd/kubeadm/app/constants"
 	testutil "k8s.io/kubernetes/cmd/kubeadm/test"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestComponentResources(t *testing.T) {

--- a/cmd/kubeadm/app/util/users/users_linux.go
+++ b/cmd/kubeadm/app/util/users/users_linux.go
@@ -30,10 +30,11 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/pkg/errors"
+	"k8s.io/kubernetes/cmd/kubeadm/app/constants"
 
 	"k8s.io/klog/v2"
-	"k8s.io/kubernetes/cmd/kubeadm/app/constants"
+
+	"github.com/pkg/errors"
 )
 
 // EntryMap holds a map of user or group entries.

--- a/cmd/kubeadm/app/util/version.go
+++ b/cmd/kubeadm/app/util/version.go
@@ -24,13 +24,14 @@ import (
 	"strings"
 	"time"
 
-	"github.com/pkg/errors"
+	"k8s.io/kubernetes/cmd/kubeadm/app/constants"
 
 	netutil "k8s.io/apimachinery/pkg/util/net"
 	versionutil "k8s.io/apimachinery/pkg/util/version"
 	pkgversion "k8s.io/component-base/version"
 	"k8s.io/klog/v2"
-	"k8s.io/kubernetes/cmd/kubeadm/app/constants"
+
+	"github.com/pkg/errors"
 )
 
 const (

--- a/cmd/kubeadm/test/cmd/init_test.go
+++ b/cmd/kubeadm/test/cmd/init_test.go
@@ -21,8 +21,9 @@ import (
 	"os"
 	"testing"
 
-	"github.com/lithammer/dedent"
 	"k8s.io/kubernetes/cmd/kubeadm/app/constants"
+
+	"github.com/lithammer/dedent"
 )
 
 func runKubeadmInit(args ...string) (string, string, int, error) {

--- a/cmd/kubeadm/test/cmd/util.go
+++ b/cmd/kubeadm/test/cmd/util.go
@@ -23,7 +23,6 @@ import (
 	"testing"
 
 	"github.com/pkg/errors"
-
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/kubeadm/test/kubeconfig/util.go
+++ b/cmd/kubeadm/test/kubeconfig/util.go
@@ -21,8 +21,9 @@ import (
 	"encoding/pem"
 	"testing"
 
-	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 	certstestutil "k8s.io/kubernetes/cmd/kubeadm/app/util/certs"
+
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 )
 
 // AssertKubeConfigCurrentCluster is a utility function for kubeadm testing that asserts if the CurrentCluster in

--- a/cmd/kubeadm/test/resources/configmap.go
+++ b/cmd/kubeadm/test/resources/configmap.go
@@ -17,10 +17,11 @@ limitations under the License.
 package resources
 
 import (
+	"k8s.io/kubernetes/cmd/kubeadm/app/util/apiclient"
+
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clientset "k8s.io/client-go/kubernetes"
-	"k8s.io/kubernetes/cmd/kubeadm/app/util/apiclient"
 )
 
 // FakeConfigMap represents a fake config map

--- a/cmd/kubeadm/test/resources/pods.go
+++ b/cmd/kubeadm/test/resources/pods.go
@@ -20,10 +20,11 @@ import (
 	"context"
 	"fmt"
 
+	staticpodutil "k8s.io/kubernetes/cmd/kubeadm/app/util/staticpod"
+
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clientset "k8s.io/client-go/kubernetes"
-	staticpodutil "k8s.io/kubernetes/cmd/kubeadm/app/util/staticpod"
 )
 
 // FakeStaticPod represents a fake static pod


### PR DESCRIPTION
Signed-off-by: XinYang <xinydev@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

the kubeadm code base under kubernetes/kubernetes/cmd/kubeadm has inconsistent Go imports in source code files.



#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes/kubeadm/issues/2515

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
NONE
```


