### PR TITLE
podIPs order match node IP family preference (Downward API)

### DIFF
--- a/pkg/kubelet/kubelet_pods_test.go
+++ b/pkg/kubelet/kubelet_pods_test.go
@@ -461,6 +461,7 @@ func TestMakeEnvironmentVariables(t *testing.T) {
 		unsyncedServices   bool                   // whether the services should NOT be synced
 		configMap          *v1.ConfigMap          // an optional ConfigMap to pull from
 		secret             *v1.Secret             // an optional Secret to pull from
+		podIPs             []string               // the pod IPs
 		expectedEnvs       []kubecontainer.EnvVar // a set of expected environment vars
 		expectedError      bool                   // does the test fail
 		expectedEvent      string                 // does the test emit an event
@@ -766,6 +767,7 @@ func TestMakeEnvironmentVariables(t *testing.T) {
 					},
 				},
 			},
+			podIPs:          []string{"1.2.3.4", "fd00::6"},
 			masterServiceNs: "nothing",
 			nilLister:       true,
 			expectedEnvs: []kubecontainer.EnvVar{
@@ -773,6 +775,94 @@ func TestMakeEnvironmentVariables(t *testing.T) {
 				{Name: "POD_NAMESPACE", Value: "downward-api"},
 				{Name: "POD_NODE_NAME", Value: "node-name"},
 				{Name: "POD_SERVICE_ACCOUNT_NAME", Value: "special"},
+				{Name: "POD_IP", Value: "1.2.3.4"},
+				{Name: "POD_IPS", Value: "1.2.3.4,fd00::6"},
+				{Name: "HOST_IP", Value: testKubeletHostIP},
+			},
+		},
+		{
+			name:               "downward api pod ips reverse order",
+			ns:                 "downward-api",
+			enableServiceLinks: &falseValue,
+			container: &v1.Container{
+				Env: []v1.EnvVar{
+					{
+						Name: "POD_IP",
+						ValueFrom: &v1.EnvVarSource{
+							FieldRef: &v1.ObjectFieldSelector{
+								APIVersion: "v1",
+								FieldPath:  "status.podIP",
+							},
+						},
+					},
+					{
+						Name: "POD_IPS",
+						ValueFrom: &v1.EnvVarSource{
+							FieldRef: &v1.ObjectFieldSelector{
+								APIVersion: "v1",
+								FieldPath:  "status.podIPs",
+							},
+						},
+					},
+					{
+						Name: "HOST_IP",
+						ValueFrom: &v1.EnvVarSource{
+							FieldRef: &v1.ObjectFieldSelector{
+								APIVersion: "v1",
+								FieldPath:  "status.hostIP",
+							},
+						},
+					},
+				},
+			},
+			podIPs:          []string{"fd00::6", "1.2.3.4"},
+			masterServiceNs: "nothing",
+			nilLister:       true,
+			expectedEnvs: []kubecontainer.EnvVar{
+				{Name: "POD_IP", Value: "1.2.3.4"},
+				{Name: "POD_IPS", Value: "1.2.3.4,fd00::6"},
+				{Name: "HOST_IP", Value: testKubeletHostIP},
+			},
+		},
+		{
+			name:               "downward api pod ips multiple ips",
+			ns:                 "downward-api",
+			enableServiceLinks: &falseValue,
+			container: &v1.Container{
+				Env: []v1.EnvVar{
+					{
+						Name: "POD_IP",
+						ValueFrom: &v1.EnvVarSource{
+							FieldRef: &v1.ObjectFieldSelector{
+								APIVersion: "v1",
+								FieldPath:  "status.podIP",
+							},
+						},
+					},
+					{
+						Name: "POD_IPS",
+						ValueFrom: &v1.EnvVarSource{
+							FieldRef: &v1.ObjectFieldSelector{
+								APIVersion: "v1",
+								FieldPath:  "status.podIPs",
+							},
+						},
+					},
+					{
+						Name: "HOST_IP",
+						ValueFrom: &v1.EnvVarSource{
+							FieldRef: &v1.ObjectFieldSelector{
+								APIVersion: "v1",
+								FieldPath:  "status.hostIP",
+							},
+						},
+					},
+				},
+			},
+			podIPs:          []string{"1.2.3.4", "192.168.1.1.", "fd00::6"},
+			masterServiceNs: "nothing",
+			nilLister:       true,
+			expectedEnvs: []kubecontainer.EnvVar{
 				{Name: "POD_IP", Value: "1.2.3.4"},
 				{Name: "POD_IPS", Value: "1.2.3.4,fd00::6"},
 				{Name: "HOST_IP", Value: testKubeletHostIP},
@@ -1685,13 +1775,15 @@ func TestMakeEnvironmentVariables(t *testing.T) {
 					EnableServiceLinks: tc.enableServiceLinks,
 				},
 			}
-			podIP := "1.2.3.4"
-			podIPs := []string{"1.2.3.4,fd00::6"}
+			podIP := ""
+			if len(tc.podIPs) > 0 {
+				podIP = tc.podIPs[0]
+			}
 			if tc.staticPod {
 				testPod.Annotations[kubetypes.ConfigSourceAnnotationKey] = "file"
 			}
 
-			result, err := kl.makeEnvironmentVariables(testPod, tc.container, podIP, podIPs)
+			result, err := kl.makeEnvironmentVariables(testPod, tc.container, podIP, tc.podIPs)
 			select {
 			case e := <-fakeRecorder.Events:
 				assert.Equal(t, tc.expectedEvent, e)
@@ -2837,6 +2929,33 @@ func TestGenerateAPIPodStatusHostNetworkPodIPs(t *testing.T) {
 				{IP: "192.168.0.1"},
 			},
 		},
+		{
+			name: "CRI dual-stack PodIPs override NodeAddresses",
+			nodeAddresses: []v1.NodeAddress{
+				{Type: v1.NodeInternalIP, Address: "10.0.0.1"},
+				{Type: v1.NodeInternalIP, Address: "fd01::1234"},
+			},
+			dualStack: true,
+			criPodIPs: []string{"192.168.0.1", "2001:db8::2"},
+			podIPs: []v1.PodIP{
+				{IP: "192.168.0.1"},
+				{IP: "2001:db8::2"},
+			},
+		},
+		{
+			// by default the cluster prefers IPv4
+			name: "CRI dual-stack PodIPs override NodeAddresses prefer IPv4",
+			nodeAddresses: []v1.NodeAddress{
+				{Type: v1.NodeInternalIP, Address: "10.0.0.1"},
+				{Type: v1.NodeInternalIP, Address: "fd01::1234"},
+			},
+			dualStack: true,
+			criPodIPs: []string{"2001:db8::2", "192.168.0.1"},
+			podIPs: []v1.PodIP{
+				{IP: "192.168.0.1"},
+				{IP: "2001:db8::2"},
+			},
+		},
 	}
 
 	for _, tc := range testcases {
@@ -3005,6 +3124,98 @@ func TestGenerateAPIPodStatusPodIPs(t *testing.T) {
 			}
 			if status.PodIP != status.PodIPs[0].IP {
 				t.Fatalf("Expected PodIP %q to equal PodIPs[0].IP %q", status.PodIP, status.PodIPs[0].IP)
+			}
+		})
+	}
+}
+
+func TestSortPodIPs(t *testing.T) {
+	testcases := []struct {
+		name        string
+		nodeIP      string
+		podIPs      []string
+		expectedIPs []string
+	}{
+		{
+			name:        "Simple",
+			nodeIP:      "",
+			podIPs:      []string{"10.0.0.1"},
+			expectedIPs: []string{"10.0.0.1"},
+		},
+		{
+			name:        "Dual-stack",
+			nodeIP:      "",
+			podIPs:      []string{"10.0.0.1", "fd01::1234"},
+			expectedIPs: []string{"10.0.0.1", "fd01::1234"},
+		},
+		{
+			name:        "Dual-stack with explicit node IP",
+			nodeIP:      "192.168.1.1",
+			podIPs:      []string{"10.0.0.1", "fd01::1234"},
+			expectedIPs: []string{"10.0.0.1", "fd01::1234"},
+		},
+		{
+			name:        "Dual-stack with CRI returning wrong family first",
+			nodeIP:      "",
+			podIPs:      []string{"fd01::1234", "10.0.0.1"},
+			expectedIPs: []string{"10.0.0.1", "fd01::1234"},
+		},
+		{
+			name:        "Dual-stack with explicit node IP with CRI returning wrong family first",
+			nodeIP:      "192.168.1.1",
+			podIPs:      []string{"fd01::1234", "10.0.0.1"},
+			expectedIPs: []string{"10.0.0.1", "fd01::1234"},
+		},
+		{
+			name:        "Dual-stack with IPv6 node IP",
+			nodeIP:      "fd00::5678",
+			podIPs:      []string{"10.0.0.1", "fd01::1234"},
+			expectedIPs: []string{"fd01::1234", "10.0.0.1"},
+		},
+		{
+			name:        "Dual-stack with IPv6 node IP, other CRI order",
+			nodeIP:      "fd00::5678",
+			podIPs:      []string{"fd01::1234", "10.0.0.1"},
+			expectedIPs: []string{"fd01::1234", "10.0.0.1"},
+		},
+		{
+			name:        "No Pod IP matching Node IP",
+			nodeIP:      "fd00::5678",
+			podIPs:      []string{"10.0.0.1"},
+			expectedIPs: []string{"10.0.0.1"},
+		},
+		{
+			name:        "No Pod IP matching (unspecified) Node IP",
+			nodeIP:      "",
+			podIPs:      []string{"fd01::1234"},
+			expectedIPs: []string{"fd01::1234"},
+		},
+		{
+			name:        "Multiple IPv4 IPs",
+			nodeIP:      "",
+			podIPs:      []string{"10.0.0.1", "10.0.0.2", "10.0.0.3"},
+			expectedIPs: []string{"10.0.0.1"},
+		},
+		{
+			name:        "Multiple Dual-Stack IPs",
+			nodeIP:      "",
+			podIPs:      []string{"10.0.0.1", "10.0.0.2", "fd01::1234", "10.0.0.3", "fd01::5678"},
+			expectedIPs: []string{"10.0.0.1", "fd01::1234"},
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled */)
+			defer testKubelet.Cleanup()
+			kl := testKubelet.kubelet
+			if tc.nodeIP != "" {
+				kl.nodeIPs = []net.IP{net.ParseIP(tc.nodeIP)}
+			}
+
+			podIPs := kl.sortPodIPs(tc.podIPs)
+			if !reflect.DeepEqual(podIPs, tc.expectedIPs) {
+				t.Fatalf("Expected PodIPs %#v, got %#v", tc.expectedIPs, podIPs)
 			}
 		})
 	}


### PR DESCRIPTION
Following up on https://github.com/kubernetes/kubernetes/pull/97979,
we should implement the same logic for the exposed PodIPs in the downward API, so
both values are identical.

In addition, it also fixes a bug that causes panic in the kubelet, because the podIPs object was mutated meanwhile the code was parsing the IP addresses.

xref: https://github.com/kubernetes/kubernetes/pull/102817

#### Additional information

I've tried different approaches, also to filter directly the podIPs in 
https://github.com/kubernetes/kubernetes/blob/5f8f5ab3268b41d45481d2d865716fa04c026aab/pkg/kubelet/kuberuntime/kuberuntime_sandbox.go#L231

but I've discarded that approach because it has to add a dependeny to the runtimeManager on the kubelet nodeIPs.

Another alternative that I started and stopped because  it is toooo disruptive, is to refactor all code to stop plumbing `podIP` and `podIPs` 

#### What type of PR is this?

/kind bug
Fixes #103263, #102806

```release-note
kubelet: the returned value for PodIPs is the same in the Downward API and in the pod.status.PodIPs field
```
