### PR TITLE
kubeadm: fix wrong check for keys/certs during "download-certs"

### DIFF
--- a/cmd/kubeadm/app/phases/copycerts/copycerts.go
+++ b/cmd/kubeadm/app/phases/copycerts/copycerts.go
@@ -251,9 +251,9 @@ func DownloadCerts(client clientset.Interface, cfg *kubeadmapi.InitConfiguration
 }
 
 func writeCertOrKey(certOrKeyPath string, certOrKeyData []byte) error {
-	if _, err := keyutil.ParsePublicKeysPEM(certOrKeyData); err == nil {
+	if _, err := keyutil.ParsePrivateKeyPEM(certOrKeyData); err == nil {
 		return keyutil.WriteKey(certOrKeyPath, certOrKeyData)
-	} else if _, err := certutil.ParseCertsPEM(certOrKeyData); err == nil {
+	} else if _, err := keyutil.ParsePublicKeysPEM(certOrKeyData); err == nil {
 		return certutil.WriteCert(certOrKeyPath, certOrKeyData)
 	}
 	return errors.New("unknown data found in Secret entry")

--- a/cmd/kubeadm/app/phases/copycerts/copycerts_test.go
+++ b/cmd/kubeadm/app/phases/copycerts/copycerts_test.go
@@ -29,7 +29,6 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	fakeclient "k8s.io/client-go/kubernetes/fake"
-	certutil "k8s.io/client-go/util/cert"
 	keyutil "k8s.io/client-go/util/keyutil"
 	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
 	kubeadmconstants "k8s.io/kubernetes/cmd/kubeadm/app/constants"
@@ -240,7 +239,7 @@ func TestDownloadCerts(t *testing.T) {
 		}
 		// Check that the written files are either certificates or keys, and that they have
 		// the expected permissions
-		if _, err := keyutil.ParsePublicKeysPEM(diskCertData); err == nil {
+		if _, err := keyutil.ParsePrivateKeyPEM(diskCertData); err == nil {
 			if stat, err := os.Stat(certPath); err == nil {
 				if stat.Mode() != keyFileMode {
 					t.Errorf("key %q should have mode %#o, has %#o", certName, keyFileMode, stat.Mode())
@@ -248,7 +247,7 @@ func TestDownloadCerts(t *testing.T) {
 			} else {
 				t.Errorf("could not stat key %q: %v", certName, err)
 			}
-		} else if _, err := certutil.ParseCertsPEM(diskCertData); err == nil {
+		} else if _, err := keyutil.ParsePublicKeysPEM(diskCertData); err == nil {
 			if stat, err := os.Stat(certPath); err == nil {
 				if stat.Mode() != certFileMode {
 					t.Errorf("cert %q should have mode %#o, has %#o", certName, certFileMode, stat.Mode())


### PR DESCRIPTION
#### What this PR does / why we need it:

During "join" of new control plane machines, kubeadm would
download shared certificates and keys from the cluster stored
in a Secret. Based on the contents of an entry in the Secret,
it would use helper functions from client-go to either write
it as public key, cert (mode 644) or as a private key (mode 600).

The existing logic is always writing both keys and certs with mode 600.
Allow detecting public readable data properly and writing some files
with mode 644.

First check the data with ParsePrivateKeyPEM(); if this passes
there must be at least one private key and the file should be written
with mode 600 as private. If that fails, validate if the data contains
public keys with ParsePublicKeysPEM() and write the file as public
(mode 644).

As a result of this new logic, and given the current set of managed
kubeadm files, .key files will end up with 600, while .crt and .pub
files will end up with 644.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Blocker for graduating https://github.com/kubernetes/kubeadm/issues/2473 to Alpha

#### Special notes for your reviewer:
NONE

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
kubeadm: fix a bug where "kubeadm join" for control plane nodes would download certificates and keys from the cluster, but would not write publicly readable certificates and public keys with mode 0644 and instead use mode 0600.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
