### PR TITLE
[PodSecurity] Implement host ports check

### DIFF
--- a/staging/src/k8s.io/pod-security-admission/policy/check_hostPorts.go
+++ b/staging/src/k8s.io/pod-security-admission/policy/check_hostPorts.go
@@ -1,0 +1,72 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package policy
+
+import (
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/pod-security-admission/api"
+)
+
+func init() {
+	addCheck(CheckHostPorts)
+}
+
+// CheckHostPorts returns a baseline level check
+// that forbids any host ports in 1.0+
+func CheckHostPorts() Check {
+	return Check{
+		ID:    "hostPorts",
+		Level: api.LevelBaseline,
+		Versions: []VersionedCheck{
+			{
+				MinimumVersion: api.MajorMinorVersion(1, 0),
+				CheckPod:       hostPorts_1_0,
+			},
+		},
+	}
+}
+
+func hostPorts_1_0(podMetadata *metav1.ObjectMeta, podSpec *corev1.PodSpec) CheckResult {
+	forbiddenContainers := sets.NewString()
+	forbiddenHostPorts := sets.NewInt32()
+	visitContainersWithPath(podSpec, field.NewPath("spec"), func(container *corev1.Container, path *field.Path) {
+		for _, c := range container.Ports {
+			if c.HostPort != 0 {
+				forbiddenContainers.Insert(container.Name)
+				forbiddenHostPorts.Insert(c.HostPort)
+			}
+		}
+	})
+
+	if len(forbiddenHostPorts) > 0 {
+		return CheckResult{
+			Allowed:         false,
+			ForbiddenReason: "forbidden host ports",
+			ForbiddenDetail: fmt.Sprintf(
+				"containers %q use these host ports %d",
+				forbiddenContainers.List(),
+				forbiddenHostPorts.List(),
+			),
+		}
+	}
+	return CheckResult{Allowed: true}
+}

--- a/staging/src/k8s.io/pod-security-admission/test/fixtures_hostPorts.go
+++ b/staging/src/k8s.io/pod-security-admission/test/fixtures_hostPorts.go
@@ -1,0 +1,100 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package test
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/pod-security-admission/api"
+)
+
+/*
+TODO: include field paths in reflect-based unit test
+
+containerFields: []string{
+	`securityContext.capabilities.add`,
+},
+*/
+
+func init() {
+	fixtureData_1_0 := fixtureGenerator{
+		expectErrorSubstring: "forbidden host ports",
+		generatePass: func(p *corev1.Pod) []*corev1.Pod {
+			return []*corev1.Pod{
+				// no host ports
+				tweak(p, func(p *corev1.Pod) {
+					p.Spec.Containers[0].Ports = []corev1.ContainerPort{
+						{
+							ContainerPort: 12345,
+						},
+					}
+					p.Spec.InitContainers[0].Ports = []corev1.ContainerPort{
+						{
+							ContainerPort: 12346,
+						},
+					}
+				}),
+			}
+		},
+		generateFail: func(p *corev1.Pod) []*corev1.Pod {
+			return []*corev1.Pod{
+				// Host Port present
+				tweak(p, func(p *corev1.Pod) {
+					p.Spec.Containers[0].Ports = []corev1.ContainerPort{
+						{
+							ContainerPort: 12345,
+							HostPort:      12345,
+						},
+					}
+				}),
+				tweak(p, func(p *corev1.Pod) {
+					p.Spec.InitContainers[0].Ports = []corev1.ContainerPort{
+						{
+							ContainerPort: 12346,
+							HostPort:      12346,
+						},
+					}
+				}),
+				// both init-container and app container use host ports and regular ports
+				tweak(p, func(p *corev1.Pod) {
+					p.Spec.Containers[0].Ports = []corev1.ContainerPort{
+						{
+							ContainerPort: 12345,
+							HostPort:      12345,
+						},
+						{
+							ContainerPort: 12347,
+						},
+					}
+					p.Spec.InitContainers[0].Ports = []corev1.ContainerPort{
+						{
+							ContainerPort: 12346,
+							HostPort:      12346,
+						},
+						{
+							ContainerPort: 12348,
+						},
+					}
+				}),
+			}
+		},
+	}
+
+	registerFixtureGenerator(
+		fixtureKey{level: api.LevelBaseline, version: api.MajorMinorVersion(1, 0), check: "hostPorts"},
+		fixtureData_1_0,
+	)
+}

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.0/fail/hostports0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.0/fail/hostports0.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    ports:
+    - containerPort: 12345
+      hostPort: 12345
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.0/fail/hostports1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.0/fail/hostports1.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    ports:
+    - containerPort: 12346
+      hostPort: 12346

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.0/fail/hostports2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.0/fail/hostports2.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports2
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    ports:
+    - containerPort: 12345
+      hostPort: 12345
+    - containerPort: 12347
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    ports:
+    - containerPort: 12346
+      hostPort: 12346
+    - containerPort: 12348

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.0/pass/hostports0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.0/pass/hostports0.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    ports:
+    - containerPort: 12345
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    ports:
+    - containerPort: 12346

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.1/fail/hostports0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.1/fail/hostports0.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    ports:
+    - containerPort: 12345
+      hostPort: 12345
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.1/fail/hostports1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.1/fail/hostports1.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    ports:
+    - containerPort: 12346
+      hostPort: 12346

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.1/fail/hostports2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.1/fail/hostports2.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports2
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    ports:
+    - containerPort: 12345
+      hostPort: 12345
+    - containerPort: 12347
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    ports:
+    - containerPort: 12346
+      hostPort: 12346
+    - containerPort: 12348

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.1/pass/hostports0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.1/pass/hostports0.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    ports:
+    - containerPort: 12345
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    ports:
+    - containerPort: 12346

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.10/fail/hostports0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.10/fail/hostports0.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    ports:
+    - containerPort: 12345
+      hostPort: 12345
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.10/fail/hostports1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.10/fail/hostports1.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    ports:
+    - containerPort: 12346
+      hostPort: 12346

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.10/fail/hostports2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.10/fail/hostports2.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports2
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    ports:
+    - containerPort: 12345
+      hostPort: 12345
+    - containerPort: 12347
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    ports:
+    - containerPort: 12346
+      hostPort: 12346
+    - containerPort: 12348

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.10/pass/hostports0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.10/pass/hostports0.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    ports:
+    - containerPort: 12345
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    ports:
+    - containerPort: 12346

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.11/fail/hostports0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.11/fail/hostports0.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    ports:
+    - containerPort: 12345
+      hostPort: 12345
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.11/fail/hostports1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.11/fail/hostports1.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    ports:
+    - containerPort: 12346
+      hostPort: 12346

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.11/fail/hostports2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.11/fail/hostports2.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports2
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    ports:
+    - containerPort: 12345
+      hostPort: 12345
+    - containerPort: 12347
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    ports:
+    - containerPort: 12346
+      hostPort: 12346
+    - containerPort: 12348

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.11/pass/hostports0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.11/pass/hostports0.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    ports:
+    - containerPort: 12345
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    ports:
+    - containerPort: 12346

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.12/fail/hostports0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.12/fail/hostports0.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    ports:
+    - containerPort: 12345
+      hostPort: 12345
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.12/fail/hostports1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.12/fail/hostports1.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    ports:
+    - containerPort: 12346
+      hostPort: 12346

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.12/fail/hostports2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.12/fail/hostports2.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports2
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    ports:
+    - containerPort: 12345
+      hostPort: 12345
+    - containerPort: 12347
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    ports:
+    - containerPort: 12346
+      hostPort: 12346
+    - containerPort: 12348

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.12/pass/hostports0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.12/pass/hostports0.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    ports:
+    - containerPort: 12345
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    ports:
+    - containerPort: 12346

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.13/fail/hostports0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.13/fail/hostports0.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    ports:
+    - containerPort: 12345
+      hostPort: 12345
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.13/fail/hostports1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.13/fail/hostports1.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    ports:
+    - containerPort: 12346
+      hostPort: 12346

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.13/fail/hostports2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.13/fail/hostports2.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports2
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    ports:
+    - containerPort: 12345
+      hostPort: 12345
+    - containerPort: 12347
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    ports:
+    - containerPort: 12346
+      hostPort: 12346
+    - containerPort: 12348

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.13/pass/hostports0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.13/pass/hostports0.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    ports:
+    - containerPort: 12345
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    ports:
+    - containerPort: 12346

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.14/fail/hostports0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.14/fail/hostports0.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    ports:
+    - containerPort: 12345
+      hostPort: 12345
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.14/fail/hostports1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.14/fail/hostports1.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    ports:
+    - containerPort: 12346
+      hostPort: 12346

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.14/fail/hostports2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.14/fail/hostports2.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports2
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    ports:
+    - containerPort: 12345
+      hostPort: 12345
+    - containerPort: 12347
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    ports:
+    - containerPort: 12346
+      hostPort: 12346
+    - containerPort: 12348

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.14/pass/hostports0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.14/pass/hostports0.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    ports:
+    - containerPort: 12345
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    ports:
+    - containerPort: 12346

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.15/fail/hostports0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.15/fail/hostports0.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    ports:
+    - containerPort: 12345
+      hostPort: 12345
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.15/fail/hostports1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.15/fail/hostports1.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    ports:
+    - containerPort: 12346
+      hostPort: 12346

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.15/fail/hostports2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.15/fail/hostports2.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports2
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    ports:
+    - containerPort: 12345
+      hostPort: 12345
+    - containerPort: 12347
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    ports:
+    - containerPort: 12346
+      hostPort: 12346
+    - containerPort: 12348

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.15/pass/hostports0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.15/pass/hostports0.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    ports:
+    - containerPort: 12345
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    ports:
+    - containerPort: 12346

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.16/fail/hostports0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.16/fail/hostports0.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    ports:
+    - containerPort: 12345
+      hostPort: 12345
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.16/fail/hostports1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.16/fail/hostports1.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    ports:
+    - containerPort: 12346
+      hostPort: 12346

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.16/fail/hostports2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.16/fail/hostports2.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports2
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    ports:
+    - containerPort: 12345
+      hostPort: 12345
+    - containerPort: 12347
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    ports:
+    - containerPort: 12346
+      hostPort: 12346
+    - containerPort: 12348

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.16/pass/hostports0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.16/pass/hostports0.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    ports:
+    - containerPort: 12345
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    ports:
+    - containerPort: 12346

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.17/fail/hostports0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.17/fail/hostports0.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    ports:
+    - containerPort: 12345
+      hostPort: 12345
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.17/fail/hostports1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.17/fail/hostports1.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    ports:
+    - containerPort: 12346
+      hostPort: 12346

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.17/fail/hostports2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.17/fail/hostports2.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports2
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    ports:
+    - containerPort: 12345
+      hostPort: 12345
+    - containerPort: 12347
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    ports:
+    - containerPort: 12346
+      hostPort: 12346
+    - containerPort: 12348

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.17/pass/hostports0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.17/pass/hostports0.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    ports:
+    - containerPort: 12345
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    ports:
+    - containerPort: 12346

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.18/fail/hostports0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.18/fail/hostports0.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    ports:
+    - containerPort: 12345
+      hostPort: 12345
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.18/fail/hostports1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.18/fail/hostports1.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    ports:
+    - containerPort: 12346
+      hostPort: 12346

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.18/fail/hostports2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.18/fail/hostports2.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports2
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    ports:
+    - containerPort: 12345
+      hostPort: 12345
+    - containerPort: 12347
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    ports:
+    - containerPort: 12346
+      hostPort: 12346
+    - containerPort: 12348

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.18/pass/hostports0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.18/pass/hostports0.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    ports:
+    - containerPort: 12345
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    ports:
+    - containerPort: 12346

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.19/fail/hostports0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.19/fail/hostports0.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    ports:
+    - containerPort: 12345
+      hostPort: 12345
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.19/fail/hostports1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.19/fail/hostports1.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    ports:
+    - containerPort: 12346
+      hostPort: 12346

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.19/fail/hostports2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.19/fail/hostports2.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports2
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    ports:
+    - containerPort: 12345
+      hostPort: 12345
+    - containerPort: 12347
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    ports:
+    - containerPort: 12346
+      hostPort: 12346
+    - containerPort: 12348

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.19/pass/hostports0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.19/pass/hostports0.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    ports:
+    - containerPort: 12345
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    ports:
+    - containerPort: 12346

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.2/fail/hostports0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.2/fail/hostports0.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    ports:
+    - containerPort: 12345
+      hostPort: 12345
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.2/fail/hostports1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.2/fail/hostports1.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    ports:
+    - containerPort: 12346
+      hostPort: 12346

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.2/fail/hostports2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.2/fail/hostports2.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports2
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    ports:
+    - containerPort: 12345
+      hostPort: 12345
+    - containerPort: 12347
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    ports:
+    - containerPort: 12346
+      hostPort: 12346
+    - containerPort: 12348

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.2/pass/hostports0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.2/pass/hostports0.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    ports:
+    - containerPort: 12345
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    ports:
+    - containerPort: 12346

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.20/fail/hostports0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.20/fail/hostports0.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    ports:
+    - containerPort: 12345
+      hostPort: 12345
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.20/fail/hostports1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.20/fail/hostports1.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    ports:
+    - containerPort: 12346
+      hostPort: 12346

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.20/fail/hostports2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.20/fail/hostports2.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports2
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    ports:
+    - containerPort: 12345
+      hostPort: 12345
+    - containerPort: 12347
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    ports:
+    - containerPort: 12346
+      hostPort: 12346
+    - containerPort: 12348

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.20/pass/hostports0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.20/pass/hostports0.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    ports:
+    - containerPort: 12345
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    ports:
+    - containerPort: 12346

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.21/fail/hostports0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.21/fail/hostports0.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    ports:
+    - containerPort: 12345
+      hostPort: 12345
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.21/fail/hostports1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.21/fail/hostports1.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    ports:
+    - containerPort: 12346
+      hostPort: 12346

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.21/fail/hostports2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.21/fail/hostports2.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports2
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    ports:
+    - containerPort: 12345
+      hostPort: 12345
+    - containerPort: 12347
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    ports:
+    - containerPort: 12346
+      hostPort: 12346
+    - containerPort: 12348

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.21/pass/hostports0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.21/pass/hostports0.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    ports:
+    - containerPort: 12345
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    ports:
+    - containerPort: 12346

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.22/fail/hostports0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.22/fail/hostports0.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    ports:
+    - containerPort: 12345
+      hostPort: 12345
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.22/fail/hostports1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.22/fail/hostports1.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    ports:
+    - containerPort: 12346
+      hostPort: 12346

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.22/fail/hostports2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.22/fail/hostports2.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports2
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    ports:
+    - containerPort: 12345
+      hostPort: 12345
+    - containerPort: 12347
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    ports:
+    - containerPort: 12346
+      hostPort: 12346
+    - containerPort: 12348

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.22/pass/hostports0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.22/pass/hostports0.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    ports:
+    - containerPort: 12345
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    ports:
+    - containerPort: 12346

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.3/fail/hostports0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.3/fail/hostports0.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    ports:
+    - containerPort: 12345
+      hostPort: 12345
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.3/fail/hostports1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.3/fail/hostports1.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    ports:
+    - containerPort: 12346
+      hostPort: 12346

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.3/fail/hostports2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.3/fail/hostports2.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports2
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    ports:
+    - containerPort: 12345
+      hostPort: 12345
+    - containerPort: 12347
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    ports:
+    - containerPort: 12346
+      hostPort: 12346
+    - containerPort: 12348

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.3/pass/hostports0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.3/pass/hostports0.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    ports:
+    - containerPort: 12345
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    ports:
+    - containerPort: 12346

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.4/fail/hostports0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.4/fail/hostports0.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    ports:
+    - containerPort: 12345
+      hostPort: 12345
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.4/fail/hostports1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.4/fail/hostports1.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    ports:
+    - containerPort: 12346
+      hostPort: 12346

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.4/fail/hostports2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.4/fail/hostports2.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports2
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    ports:
+    - containerPort: 12345
+      hostPort: 12345
+    - containerPort: 12347
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    ports:
+    - containerPort: 12346
+      hostPort: 12346
+    - containerPort: 12348

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.4/pass/hostports0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.4/pass/hostports0.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    ports:
+    - containerPort: 12345
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    ports:
+    - containerPort: 12346

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.5/fail/hostports0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.5/fail/hostports0.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    ports:
+    - containerPort: 12345
+      hostPort: 12345
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.5/fail/hostports1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.5/fail/hostports1.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    ports:
+    - containerPort: 12346
+      hostPort: 12346

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.5/fail/hostports2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.5/fail/hostports2.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports2
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    ports:
+    - containerPort: 12345
+      hostPort: 12345
+    - containerPort: 12347
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    ports:
+    - containerPort: 12346
+      hostPort: 12346
+    - containerPort: 12348

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.5/pass/hostports0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.5/pass/hostports0.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    ports:
+    - containerPort: 12345
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    ports:
+    - containerPort: 12346

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.6/fail/hostports0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.6/fail/hostports0.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    ports:
+    - containerPort: 12345
+      hostPort: 12345
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.6/fail/hostports1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.6/fail/hostports1.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    ports:
+    - containerPort: 12346
+      hostPort: 12346

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.6/fail/hostports2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.6/fail/hostports2.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports2
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    ports:
+    - containerPort: 12345
+      hostPort: 12345
+    - containerPort: 12347
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    ports:
+    - containerPort: 12346
+      hostPort: 12346
+    - containerPort: 12348

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.6/pass/hostports0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.6/pass/hostports0.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    ports:
+    - containerPort: 12345
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    ports:
+    - containerPort: 12346

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.7/fail/hostports0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.7/fail/hostports0.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    ports:
+    - containerPort: 12345
+      hostPort: 12345
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.7/fail/hostports1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.7/fail/hostports1.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    ports:
+    - containerPort: 12346
+      hostPort: 12346

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.7/fail/hostports2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.7/fail/hostports2.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports2
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    ports:
+    - containerPort: 12345
+      hostPort: 12345
+    - containerPort: 12347
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    ports:
+    - containerPort: 12346
+      hostPort: 12346
+    - containerPort: 12348

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.7/pass/hostports0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.7/pass/hostports0.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    ports:
+    - containerPort: 12345
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    ports:
+    - containerPort: 12346

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.8/fail/hostports0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.8/fail/hostports0.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    ports:
+    - containerPort: 12345
+      hostPort: 12345
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.8/fail/hostports1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.8/fail/hostports1.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    ports:
+    - containerPort: 12346
+      hostPort: 12346

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.8/fail/hostports2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.8/fail/hostports2.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports2
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    ports:
+    - containerPort: 12345
+      hostPort: 12345
+    - containerPort: 12347
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    ports:
+    - containerPort: 12346
+      hostPort: 12346
+    - containerPort: 12348

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.8/pass/hostports0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.8/pass/hostports0.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    ports:
+    - containerPort: 12345
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    ports:
+    - containerPort: 12346

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.9/fail/hostports0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.9/fail/hostports0.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    ports:
+    - containerPort: 12345
+      hostPort: 12345
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.9/fail/hostports1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.9/fail/hostports1.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    ports:
+    - containerPort: 12346
+      hostPort: 12346

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.9/fail/hostports2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.9/fail/hostports2.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports2
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    ports:
+    - containerPort: 12345
+      hostPort: 12345
+    - containerPort: 12347
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    ports:
+    - containerPort: 12346
+      hostPort: 12346
+    - containerPort: 12348

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.9/pass/hostports0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.9/pass/hostports0.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    ports:
+    - containerPort: 12345
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    ports:
+    - containerPort: 12346

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.0/fail/hostports0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.0/fail/hostports0.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    ports:
+    - containerPort: 12345
+      hostPort: 12345
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.0/fail/hostports1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.0/fail/hostports1.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    ports:
+    - containerPort: 12346
+      hostPort: 12346
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.0/fail/hostports2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.0/fail/hostports2.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports2
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    ports:
+    - containerPort: 12345
+      hostPort: 12345
+    - containerPort: 12347
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    ports:
+    - containerPort: 12346
+      hostPort: 12346
+    - containerPort: 12348
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.0/pass/hostports0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.0/pass/hostports0.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    ports:
+    - containerPort: 12345
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    ports:
+    - containerPort: 12346
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.1/fail/hostports0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.1/fail/hostports0.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    ports:
+    - containerPort: 12345
+      hostPort: 12345
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.1/fail/hostports1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.1/fail/hostports1.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    ports:
+    - containerPort: 12346
+      hostPort: 12346
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.1/fail/hostports2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.1/fail/hostports2.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports2
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    ports:
+    - containerPort: 12345
+      hostPort: 12345
+    - containerPort: 12347
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    ports:
+    - containerPort: 12346
+      hostPort: 12346
+    - containerPort: 12348
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.1/pass/hostports0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.1/pass/hostports0.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    ports:
+    - containerPort: 12345
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    ports:
+    - containerPort: 12346
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.10/fail/hostports0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.10/fail/hostports0.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    ports:
+    - containerPort: 12345
+      hostPort: 12345
+    securityContext:
+      allowPrivilegeEscalation: false
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.10/fail/hostports1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.10/fail/hostports1.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    ports:
+    - containerPort: 12346
+      hostPort: 12346
+    securityContext:
+      allowPrivilegeEscalation: false
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.10/fail/hostports2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.10/fail/hostports2.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports2
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    ports:
+    - containerPort: 12345
+      hostPort: 12345
+    - containerPort: 12347
+    securityContext:
+      allowPrivilegeEscalation: false
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    ports:
+    - containerPort: 12346
+      hostPort: 12346
+    - containerPort: 12348
+    securityContext:
+      allowPrivilegeEscalation: false
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.10/pass/hostports0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.10/pass/hostports0.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    ports:
+    - containerPort: 12345
+    securityContext:
+      allowPrivilegeEscalation: false
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    ports:
+    - containerPort: 12346
+    securityContext:
+      allowPrivilegeEscalation: false
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.11/fail/hostports0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.11/fail/hostports0.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    ports:
+    - containerPort: 12345
+      hostPort: 12345
+    securityContext:
+      allowPrivilegeEscalation: false
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.11/fail/hostports1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.11/fail/hostports1.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    ports:
+    - containerPort: 12346
+      hostPort: 12346
+    securityContext:
+      allowPrivilegeEscalation: false
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.11/fail/hostports2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.11/fail/hostports2.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports2
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    ports:
+    - containerPort: 12345
+      hostPort: 12345
+    - containerPort: 12347
+    securityContext:
+      allowPrivilegeEscalation: false
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    ports:
+    - containerPort: 12346
+      hostPort: 12346
+    - containerPort: 12348
+    securityContext:
+      allowPrivilegeEscalation: false
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.11/pass/hostports0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.11/pass/hostports0.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    ports:
+    - containerPort: 12345
+    securityContext:
+      allowPrivilegeEscalation: false
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    ports:
+    - containerPort: 12346
+    securityContext:
+      allowPrivilegeEscalation: false
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.12/fail/hostports0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.12/fail/hostports0.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    ports:
+    - containerPort: 12345
+      hostPort: 12345
+    securityContext:
+      allowPrivilegeEscalation: false
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.12/fail/hostports1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.12/fail/hostports1.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    ports:
+    - containerPort: 12346
+      hostPort: 12346
+    securityContext:
+      allowPrivilegeEscalation: false
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.12/fail/hostports2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.12/fail/hostports2.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports2
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    ports:
+    - containerPort: 12345
+      hostPort: 12345
+    - containerPort: 12347
+    securityContext:
+      allowPrivilegeEscalation: false
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    ports:
+    - containerPort: 12346
+      hostPort: 12346
+    - containerPort: 12348
+    securityContext:
+      allowPrivilegeEscalation: false
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.12/pass/hostports0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.12/pass/hostports0.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    ports:
+    - containerPort: 12345
+    securityContext:
+      allowPrivilegeEscalation: false
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    ports:
+    - containerPort: 12346
+    securityContext:
+      allowPrivilegeEscalation: false
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.13/fail/hostports0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.13/fail/hostports0.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    ports:
+    - containerPort: 12345
+      hostPort: 12345
+    securityContext:
+      allowPrivilegeEscalation: false
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.13/fail/hostports1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.13/fail/hostports1.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    ports:
+    - containerPort: 12346
+      hostPort: 12346
+    securityContext:
+      allowPrivilegeEscalation: false
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.13/fail/hostports2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.13/fail/hostports2.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports2
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    ports:
+    - containerPort: 12345
+      hostPort: 12345
+    - containerPort: 12347
+    securityContext:
+      allowPrivilegeEscalation: false
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    ports:
+    - containerPort: 12346
+      hostPort: 12346
+    - containerPort: 12348
+    securityContext:
+      allowPrivilegeEscalation: false
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.13/pass/hostports0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.13/pass/hostports0.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    ports:
+    - containerPort: 12345
+    securityContext:
+      allowPrivilegeEscalation: false
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    ports:
+    - containerPort: 12346
+    securityContext:
+      allowPrivilegeEscalation: false
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.14/fail/hostports0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.14/fail/hostports0.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    ports:
+    - containerPort: 12345
+      hostPort: 12345
+    securityContext:
+      allowPrivilegeEscalation: false
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.14/fail/hostports1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.14/fail/hostports1.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    ports:
+    - containerPort: 12346
+      hostPort: 12346
+    securityContext:
+      allowPrivilegeEscalation: false
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.14/fail/hostports2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.14/fail/hostports2.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports2
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    ports:
+    - containerPort: 12345
+      hostPort: 12345
+    - containerPort: 12347
+    securityContext:
+      allowPrivilegeEscalation: false
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    ports:
+    - containerPort: 12346
+      hostPort: 12346
+    - containerPort: 12348
+    securityContext:
+      allowPrivilegeEscalation: false
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.14/pass/hostports0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.14/pass/hostports0.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    ports:
+    - containerPort: 12345
+    securityContext:
+      allowPrivilegeEscalation: false
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    ports:
+    - containerPort: 12346
+    securityContext:
+      allowPrivilegeEscalation: false
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.15/fail/hostports0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.15/fail/hostports0.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    ports:
+    - containerPort: 12345
+      hostPort: 12345
+    securityContext:
+      allowPrivilegeEscalation: false
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.15/fail/hostports1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.15/fail/hostports1.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    ports:
+    - containerPort: 12346
+      hostPort: 12346
+    securityContext:
+      allowPrivilegeEscalation: false
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.15/fail/hostports2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.15/fail/hostports2.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports2
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    ports:
+    - containerPort: 12345
+      hostPort: 12345
+    - containerPort: 12347
+    securityContext:
+      allowPrivilegeEscalation: false
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    ports:
+    - containerPort: 12346
+      hostPort: 12346
+    - containerPort: 12348
+    securityContext:
+      allowPrivilegeEscalation: false
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.15/pass/hostports0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.15/pass/hostports0.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    ports:
+    - containerPort: 12345
+    securityContext:
+      allowPrivilegeEscalation: false
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    ports:
+    - containerPort: 12346
+    securityContext:
+      allowPrivilegeEscalation: false
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.16/fail/hostports0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.16/fail/hostports0.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    ports:
+    - containerPort: 12345
+      hostPort: 12345
+    securityContext:
+      allowPrivilegeEscalation: false
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.16/fail/hostports1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.16/fail/hostports1.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    ports:
+    - containerPort: 12346
+      hostPort: 12346
+    securityContext:
+      allowPrivilegeEscalation: false
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.16/fail/hostports2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.16/fail/hostports2.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports2
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    ports:
+    - containerPort: 12345
+      hostPort: 12345
+    - containerPort: 12347
+    securityContext:
+      allowPrivilegeEscalation: false
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    ports:
+    - containerPort: 12346
+      hostPort: 12346
+    - containerPort: 12348
+    securityContext:
+      allowPrivilegeEscalation: false
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.16/pass/hostports0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.16/pass/hostports0.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    ports:
+    - containerPort: 12345
+    securityContext:
+      allowPrivilegeEscalation: false
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    ports:
+    - containerPort: 12346
+    securityContext:
+      allowPrivilegeEscalation: false
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.17/fail/hostports0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.17/fail/hostports0.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    ports:
+    - containerPort: 12345
+      hostPort: 12345
+    securityContext:
+      allowPrivilegeEscalation: false
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.17/fail/hostports1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.17/fail/hostports1.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    ports:
+    - containerPort: 12346
+      hostPort: 12346
+    securityContext:
+      allowPrivilegeEscalation: false
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.17/fail/hostports2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.17/fail/hostports2.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports2
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    ports:
+    - containerPort: 12345
+      hostPort: 12345
+    - containerPort: 12347
+    securityContext:
+      allowPrivilegeEscalation: false
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    ports:
+    - containerPort: 12346
+      hostPort: 12346
+    - containerPort: 12348
+    securityContext:
+      allowPrivilegeEscalation: false
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.17/pass/hostports0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.17/pass/hostports0.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    ports:
+    - containerPort: 12345
+    securityContext:
+      allowPrivilegeEscalation: false
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    ports:
+    - containerPort: 12346
+    securityContext:
+      allowPrivilegeEscalation: false
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.18/fail/hostports0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.18/fail/hostports0.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    ports:
+    - containerPort: 12345
+      hostPort: 12345
+    securityContext:
+      allowPrivilegeEscalation: false
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.18/fail/hostports1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.18/fail/hostports1.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    ports:
+    - containerPort: 12346
+      hostPort: 12346
+    securityContext:
+      allowPrivilegeEscalation: false
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.18/fail/hostports2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.18/fail/hostports2.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports2
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    ports:
+    - containerPort: 12345
+      hostPort: 12345
+    - containerPort: 12347
+    securityContext:
+      allowPrivilegeEscalation: false
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    ports:
+    - containerPort: 12346
+      hostPort: 12346
+    - containerPort: 12348
+    securityContext:
+      allowPrivilegeEscalation: false
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.18/pass/hostports0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.18/pass/hostports0.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    ports:
+    - containerPort: 12345
+    securityContext:
+      allowPrivilegeEscalation: false
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    ports:
+    - containerPort: 12346
+    securityContext:
+      allowPrivilegeEscalation: false
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.19/fail/hostports0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.19/fail/hostports0.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    ports:
+    - containerPort: 12345
+      hostPort: 12345
+    securityContext:
+      allowPrivilegeEscalation: false
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.19/fail/hostports1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.19/fail/hostports1.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    ports:
+    - containerPort: 12346
+      hostPort: 12346
+    securityContext:
+      allowPrivilegeEscalation: false
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.19/fail/hostports2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.19/fail/hostports2.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports2
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    ports:
+    - containerPort: 12345
+      hostPort: 12345
+    - containerPort: 12347
+    securityContext:
+      allowPrivilegeEscalation: false
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    ports:
+    - containerPort: 12346
+      hostPort: 12346
+    - containerPort: 12348
+    securityContext:
+      allowPrivilegeEscalation: false
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.19/pass/hostports0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.19/pass/hostports0.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    ports:
+    - containerPort: 12345
+    securityContext:
+      allowPrivilegeEscalation: false
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    ports:
+    - containerPort: 12346
+    securityContext:
+      allowPrivilegeEscalation: false
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.2/fail/hostports0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.2/fail/hostports0.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    ports:
+    - containerPort: 12345
+      hostPort: 12345
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.2/fail/hostports1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.2/fail/hostports1.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    ports:
+    - containerPort: 12346
+      hostPort: 12346
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.2/fail/hostports2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.2/fail/hostports2.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports2
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    ports:
+    - containerPort: 12345
+      hostPort: 12345
+    - containerPort: 12347
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    ports:
+    - containerPort: 12346
+      hostPort: 12346
+    - containerPort: 12348
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.2/pass/hostports0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.2/pass/hostports0.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    ports:
+    - containerPort: 12345
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    ports:
+    - containerPort: 12346
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.20/fail/hostports0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.20/fail/hostports0.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    ports:
+    - containerPort: 12345
+      hostPort: 12345
+    securityContext:
+      allowPrivilegeEscalation: false
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.20/fail/hostports1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.20/fail/hostports1.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    ports:
+    - containerPort: 12346
+      hostPort: 12346
+    securityContext:
+      allowPrivilegeEscalation: false
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.20/fail/hostports2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.20/fail/hostports2.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports2
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    ports:
+    - containerPort: 12345
+      hostPort: 12345
+    - containerPort: 12347
+    securityContext:
+      allowPrivilegeEscalation: false
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    ports:
+    - containerPort: 12346
+      hostPort: 12346
+    - containerPort: 12348
+    securityContext:
+      allowPrivilegeEscalation: false
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.20/pass/hostports0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.20/pass/hostports0.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    ports:
+    - containerPort: 12345
+    securityContext:
+      allowPrivilegeEscalation: false
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    ports:
+    - containerPort: 12346
+    securityContext:
+      allowPrivilegeEscalation: false
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.21/fail/hostports0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.21/fail/hostports0.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    ports:
+    - containerPort: 12345
+      hostPort: 12345
+    securityContext:
+      allowPrivilegeEscalation: false
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.21/fail/hostports1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.21/fail/hostports1.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    ports:
+    - containerPort: 12346
+      hostPort: 12346
+    securityContext:
+      allowPrivilegeEscalation: false
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.21/fail/hostports2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.21/fail/hostports2.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports2
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    ports:
+    - containerPort: 12345
+      hostPort: 12345
+    - containerPort: 12347
+    securityContext:
+      allowPrivilegeEscalation: false
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    ports:
+    - containerPort: 12346
+      hostPort: 12346
+    - containerPort: 12348
+    securityContext:
+      allowPrivilegeEscalation: false
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.21/pass/hostports0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.21/pass/hostports0.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    ports:
+    - containerPort: 12345
+    securityContext:
+      allowPrivilegeEscalation: false
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    ports:
+    - containerPort: 12346
+    securityContext:
+      allowPrivilegeEscalation: false
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.22/fail/hostports0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.22/fail/hostports0.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    ports:
+    - containerPort: 12345
+      hostPort: 12345
+    securityContext:
+      allowPrivilegeEscalation: false
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.22/fail/hostports1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.22/fail/hostports1.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    ports:
+    - containerPort: 12346
+      hostPort: 12346
+    securityContext:
+      allowPrivilegeEscalation: false
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.22/fail/hostports2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.22/fail/hostports2.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports2
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    ports:
+    - containerPort: 12345
+      hostPort: 12345
+    - containerPort: 12347
+    securityContext:
+      allowPrivilegeEscalation: false
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    ports:
+    - containerPort: 12346
+      hostPort: 12346
+    - containerPort: 12348
+    securityContext:
+      allowPrivilegeEscalation: false
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.22/pass/hostports0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.22/pass/hostports0.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    ports:
+    - containerPort: 12345
+    securityContext:
+      allowPrivilegeEscalation: false
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    ports:
+    - containerPort: 12346
+    securityContext:
+      allowPrivilegeEscalation: false
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.3/fail/hostports0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.3/fail/hostports0.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    ports:
+    - containerPort: 12345
+      hostPort: 12345
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.3/fail/hostports1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.3/fail/hostports1.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    ports:
+    - containerPort: 12346
+      hostPort: 12346
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.3/fail/hostports2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.3/fail/hostports2.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports2
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    ports:
+    - containerPort: 12345
+      hostPort: 12345
+    - containerPort: 12347
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    ports:
+    - containerPort: 12346
+      hostPort: 12346
+    - containerPort: 12348
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.3/pass/hostports0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.3/pass/hostports0.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    ports:
+    - containerPort: 12345
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    ports:
+    - containerPort: 12346
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.4/fail/hostports0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.4/fail/hostports0.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    ports:
+    - containerPort: 12345
+      hostPort: 12345
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.4/fail/hostports1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.4/fail/hostports1.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    ports:
+    - containerPort: 12346
+      hostPort: 12346
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.4/fail/hostports2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.4/fail/hostports2.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports2
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    ports:
+    - containerPort: 12345
+      hostPort: 12345
+    - containerPort: 12347
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    ports:
+    - containerPort: 12346
+      hostPort: 12346
+    - containerPort: 12348
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.4/pass/hostports0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.4/pass/hostports0.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    ports:
+    - containerPort: 12345
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    ports:
+    - containerPort: 12346
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.5/fail/hostports0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.5/fail/hostports0.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    ports:
+    - containerPort: 12345
+      hostPort: 12345
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.5/fail/hostports1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.5/fail/hostports1.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    ports:
+    - containerPort: 12346
+      hostPort: 12346
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.5/fail/hostports2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.5/fail/hostports2.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports2
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    ports:
+    - containerPort: 12345
+      hostPort: 12345
+    - containerPort: 12347
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    ports:
+    - containerPort: 12346
+      hostPort: 12346
+    - containerPort: 12348
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.5/pass/hostports0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.5/pass/hostports0.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    ports:
+    - containerPort: 12345
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    ports:
+    - containerPort: 12346
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.6/fail/hostports0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.6/fail/hostports0.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    ports:
+    - containerPort: 12345
+      hostPort: 12345
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.6/fail/hostports1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.6/fail/hostports1.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    ports:
+    - containerPort: 12346
+      hostPort: 12346
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.6/fail/hostports2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.6/fail/hostports2.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports2
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    ports:
+    - containerPort: 12345
+      hostPort: 12345
+    - containerPort: 12347
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    ports:
+    - containerPort: 12346
+      hostPort: 12346
+    - containerPort: 12348
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.6/pass/hostports0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.6/pass/hostports0.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    ports:
+    - containerPort: 12345
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    ports:
+    - containerPort: 12346
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.7/fail/hostports0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.7/fail/hostports0.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    ports:
+    - containerPort: 12345
+      hostPort: 12345
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.7/fail/hostports1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.7/fail/hostports1.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    ports:
+    - containerPort: 12346
+      hostPort: 12346
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.7/fail/hostports2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.7/fail/hostports2.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports2
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    ports:
+    - containerPort: 12345
+      hostPort: 12345
+    - containerPort: 12347
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    ports:
+    - containerPort: 12346
+      hostPort: 12346
+    - containerPort: 12348
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.7/pass/hostports0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.7/pass/hostports0.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    ports:
+    - containerPort: 12345
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    ports:
+    - containerPort: 12346
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.8/fail/hostports0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.8/fail/hostports0.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    ports:
+    - containerPort: 12345
+      hostPort: 12345
+    securityContext:
+      allowPrivilegeEscalation: false
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.8/fail/hostports1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.8/fail/hostports1.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    ports:
+    - containerPort: 12346
+      hostPort: 12346
+    securityContext:
+      allowPrivilegeEscalation: false
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.8/fail/hostports2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.8/fail/hostports2.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports2
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    ports:
+    - containerPort: 12345
+      hostPort: 12345
+    - containerPort: 12347
+    securityContext:
+      allowPrivilegeEscalation: false
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    ports:
+    - containerPort: 12346
+      hostPort: 12346
+    - containerPort: 12348
+    securityContext:
+      allowPrivilegeEscalation: false
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.8/pass/hostports0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.8/pass/hostports0.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    ports:
+    - containerPort: 12345
+    securityContext:
+      allowPrivilegeEscalation: false
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    ports:
+    - containerPort: 12346
+    securityContext:
+      allowPrivilegeEscalation: false
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.9/fail/hostports0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.9/fail/hostports0.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    ports:
+    - containerPort: 12345
+      hostPort: 12345
+    securityContext:
+      allowPrivilegeEscalation: false
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.9/fail/hostports1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.9/fail/hostports1.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    ports:
+    - containerPort: 12346
+      hostPort: 12346
+    securityContext:
+      allowPrivilegeEscalation: false
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.9/fail/hostports2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.9/fail/hostports2.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports2
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    ports:
+    - containerPort: 12345
+      hostPort: 12345
+    - containerPort: 12347
+    securityContext:
+      allowPrivilegeEscalation: false
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    ports:
+    - containerPort: 12346
+      hostPort: 12346
+    - containerPort: 12348
+    securityContext:
+      allowPrivilegeEscalation: false
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.9/pass/hostports0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.9/pass/hostports0.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    ports:
+    - containerPort: 12345
+    securityContext:
+      allowPrivilegeEscalation: false
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    ports:
+    - containerPort: 12346
+    securityContext:
+      allowPrivilegeEscalation: false
+  securityContext:
+    runAsNonRoot: true


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
Applies to baseline policy. Since host ports is a niche feature, usage of any host ports is forbidden for either app container or init container

#### Which issue(s) this PR fixes:
Fixes #103199  

#### Special notes for your reviewer:
```release-note
NONE
```


#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
- [KEP]: https://git.k8s.io/enhancements/keps/sig-auth/2579-psp-replacement
```
/sig auth security