### PR TITLE
[Pod Security]: HostNamespace baseline check

### DIFF
--- a/staging/src/k8s.io/pod-security-admission/policy/check_hostNamespaces.go
+++ b/staging/src/k8s.io/pod-security-admission/policy/check_hostNamespaces.go
@@ -1,0 +1,83 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package policy
+
+import (
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/pod-security-admission/api"
+)
+
+/*
+Sharing the host namespaces must be disallowed.
+
+**Restricted Fields:**
+
+spec.hostNetwork
+spec.hostPID
+spec.hostIPC
+
+**Allowed Values:** false
+*/
+
+func init() {
+	addCheck(CheckHostNamespaces)
+}
+
+// CheckHostNamespaces returns a baseline level check
+// that prohibits host namespaces in 1.0+
+func CheckHostNamespaces() Check {
+	return Check{
+		ID:    "hostNamespaces",
+		Level: api.LevelBaseline,
+		Versions: []VersionedCheck{
+			{
+				MinimumVersion: api.MajorMinorVersion(1, 0),
+				CheckPod:       hostNamespaces_1_0,
+			},
+		},
+	}
+}
+
+func hostNamespaces_1_0(podMetadata *metav1.ObjectMeta, podSpec *corev1.PodSpec) CheckResult {
+	hostNamespaces := sets.NewString()
+
+	if podSpec.HostNetwork {
+		hostNamespaces.Insert("hostNetwork")
+	}
+
+	if podSpec.HostPID {
+		hostNamespaces.Insert("hostPID")
+	}
+
+	if podSpec.HostIPC {
+		hostNamespaces.Insert("hostIPC")
+	}
+
+	if len(hostNamespaces) > 0 {
+		return CheckResult{
+			Allowed:         false,
+			ForbiddenReason: "host namespaces",
+			ForbiddenDetail: strings.Join(hostNamespaces.List(), ", "),
+		}
+	}
+
+	return CheckResult{Allowed: true}
+}

--- a/staging/src/k8s.io/pod-security-admission/test/fixtures_hostNamespaces.go
+++ b/staging/src/k8s.io/pod-security-admission/test/fixtures_hostNamespaces.go
@@ -1,0 +1,54 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package test
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/pod-security-admission/api"
+)
+
+/*
+TODO: include field paths in reflect-based unit test
+*/
+
+func init() {
+
+	fixtureData_1_0 := fixtureGenerator{
+		expectErrorSubstring: "host namespaces",
+		generatePass: func(p *corev1.Pod) []*corev1.Pod {
+			return []*corev1.Pod{p} // minimal valid pod
+		},
+		generateFail: func(p *corev1.Pod) []*corev1.Pod {
+			return []*corev1.Pod{
+				tweak(p, func(p *corev1.Pod) {
+					p.Spec.HostIPC = true
+				}),
+				tweak(p, func(p *corev1.Pod) {
+					p.Spec.HostNetwork = true
+				}),
+				tweak(p, func(p *corev1.Pod) {
+					p.Spec.HostPID = true
+				}),
+			}
+		},
+	}
+
+	registerFixtureGenerator(
+		fixtureKey{level: api.LevelBaseline, version: api.MajorMinorVersion(1, 0), check: "hostNamespaces"},
+		fixtureData_1_0,
+	)
+}

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.0/fail/hostnamespaces0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.0/fail/hostnamespaces0.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  hostIPC: true
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.0/fail/hostnamespaces1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.0/fail/hostnamespaces1.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  hostNetwork: true
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.0/fail/hostnamespaces2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.0/fail/hostnamespaces2.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces2
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  hostPID: true
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.0/pass/hostnamespaces0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.0/pass/hostnamespaces0.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.1/fail/hostnamespaces0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.1/fail/hostnamespaces0.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  hostIPC: true
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.1/fail/hostnamespaces1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.1/fail/hostnamespaces1.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  hostNetwork: true
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.1/fail/hostnamespaces2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.1/fail/hostnamespaces2.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces2
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  hostPID: true
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.1/pass/hostnamespaces0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.1/pass/hostnamespaces0.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.10/fail/hostnamespaces0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.10/fail/hostnamespaces0.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  hostIPC: true
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.10/fail/hostnamespaces1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.10/fail/hostnamespaces1.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  hostNetwork: true
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.10/fail/hostnamespaces2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.10/fail/hostnamespaces2.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces2
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  hostPID: true
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.10/pass/hostnamespaces0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.10/pass/hostnamespaces0.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.11/fail/hostnamespaces0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.11/fail/hostnamespaces0.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  hostIPC: true
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.11/fail/hostnamespaces1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.11/fail/hostnamespaces1.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  hostNetwork: true
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.11/fail/hostnamespaces2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.11/fail/hostnamespaces2.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces2
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  hostPID: true
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.11/pass/hostnamespaces0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.11/pass/hostnamespaces0.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.12/fail/hostnamespaces0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.12/fail/hostnamespaces0.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  hostIPC: true
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.12/fail/hostnamespaces1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.12/fail/hostnamespaces1.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  hostNetwork: true
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.12/fail/hostnamespaces2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.12/fail/hostnamespaces2.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces2
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  hostPID: true
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.12/pass/hostnamespaces0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.12/pass/hostnamespaces0.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.13/fail/hostnamespaces0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.13/fail/hostnamespaces0.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  hostIPC: true
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.13/fail/hostnamespaces1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.13/fail/hostnamespaces1.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  hostNetwork: true
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.13/fail/hostnamespaces2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.13/fail/hostnamespaces2.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces2
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  hostPID: true
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.13/pass/hostnamespaces0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.13/pass/hostnamespaces0.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.14/fail/hostnamespaces0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.14/fail/hostnamespaces0.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  hostIPC: true
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.14/fail/hostnamespaces1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.14/fail/hostnamespaces1.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  hostNetwork: true
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.14/fail/hostnamespaces2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.14/fail/hostnamespaces2.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces2
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  hostPID: true
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.14/pass/hostnamespaces0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.14/pass/hostnamespaces0.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.15/fail/hostnamespaces0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.15/fail/hostnamespaces0.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  hostIPC: true
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.15/fail/hostnamespaces1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.15/fail/hostnamespaces1.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  hostNetwork: true
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.15/fail/hostnamespaces2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.15/fail/hostnamespaces2.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces2
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  hostPID: true
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.15/pass/hostnamespaces0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.15/pass/hostnamespaces0.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.16/fail/hostnamespaces0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.16/fail/hostnamespaces0.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  hostIPC: true
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.16/fail/hostnamespaces1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.16/fail/hostnamespaces1.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  hostNetwork: true
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.16/fail/hostnamespaces2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.16/fail/hostnamespaces2.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces2
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  hostPID: true
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.16/pass/hostnamespaces0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.16/pass/hostnamespaces0.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.17/fail/hostnamespaces0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.17/fail/hostnamespaces0.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  hostIPC: true
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.17/fail/hostnamespaces1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.17/fail/hostnamespaces1.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  hostNetwork: true
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.17/fail/hostnamespaces2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.17/fail/hostnamespaces2.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces2
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  hostPID: true
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.17/pass/hostnamespaces0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.17/pass/hostnamespaces0.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.18/fail/hostnamespaces0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.18/fail/hostnamespaces0.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  hostIPC: true
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.18/fail/hostnamespaces1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.18/fail/hostnamespaces1.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  hostNetwork: true
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.18/fail/hostnamespaces2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.18/fail/hostnamespaces2.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces2
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  hostPID: true
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.18/pass/hostnamespaces0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.18/pass/hostnamespaces0.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.19/fail/hostnamespaces0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.19/fail/hostnamespaces0.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  hostIPC: true
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.19/fail/hostnamespaces1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.19/fail/hostnamespaces1.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  hostNetwork: true
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.19/fail/hostnamespaces2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.19/fail/hostnamespaces2.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces2
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  hostPID: true
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.19/pass/hostnamespaces0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.19/pass/hostnamespaces0.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.2/fail/hostnamespaces0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.2/fail/hostnamespaces0.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  hostIPC: true
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.2/fail/hostnamespaces1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.2/fail/hostnamespaces1.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  hostNetwork: true
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.2/fail/hostnamespaces2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.2/fail/hostnamespaces2.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces2
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  hostPID: true
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.2/pass/hostnamespaces0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.2/pass/hostnamespaces0.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.20/fail/hostnamespaces0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.20/fail/hostnamespaces0.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  hostIPC: true
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.20/fail/hostnamespaces1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.20/fail/hostnamespaces1.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  hostNetwork: true
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.20/fail/hostnamespaces2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.20/fail/hostnamespaces2.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces2
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  hostPID: true
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.20/pass/hostnamespaces0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.20/pass/hostnamespaces0.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.21/fail/hostnamespaces0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.21/fail/hostnamespaces0.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  hostIPC: true
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.21/fail/hostnamespaces1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.21/fail/hostnamespaces1.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  hostNetwork: true
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.21/fail/hostnamespaces2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.21/fail/hostnamespaces2.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces2
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  hostPID: true
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.21/pass/hostnamespaces0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.21/pass/hostnamespaces0.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.22/fail/hostnamespaces0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.22/fail/hostnamespaces0.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  hostIPC: true
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.22/fail/hostnamespaces1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.22/fail/hostnamespaces1.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  hostNetwork: true
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.22/fail/hostnamespaces2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.22/fail/hostnamespaces2.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces2
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  hostPID: true
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.22/pass/hostnamespaces0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.22/pass/hostnamespaces0.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.3/fail/hostnamespaces0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.3/fail/hostnamespaces0.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  hostIPC: true
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.3/fail/hostnamespaces1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.3/fail/hostnamespaces1.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  hostNetwork: true
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.3/fail/hostnamespaces2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.3/fail/hostnamespaces2.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces2
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  hostPID: true
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.3/pass/hostnamespaces0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.3/pass/hostnamespaces0.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.4/fail/hostnamespaces0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.4/fail/hostnamespaces0.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  hostIPC: true
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.4/fail/hostnamespaces1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.4/fail/hostnamespaces1.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  hostNetwork: true
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.4/fail/hostnamespaces2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.4/fail/hostnamespaces2.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces2
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  hostPID: true
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.4/pass/hostnamespaces0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.4/pass/hostnamespaces0.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.5/fail/hostnamespaces0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.5/fail/hostnamespaces0.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  hostIPC: true
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.5/fail/hostnamespaces1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.5/fail/hostnamespaces1.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  hostNetwork: true
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.5/fail/hostnamespaces2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.5/fail/hostnamespaces2.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces2
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  hostPID: true
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.5/pass/hostnamespaces0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.5/pass/hostnamespaces0.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.6/fail/hostnamespaces0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.6/fail/hostnamespaces0.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  hostIPC: true
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.6/fail/hostnamespaces1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.6/fail/hostnamespaces1.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  hostNetwork: true
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.6/fail/hostnamespaces2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.6/fail/hostnamespaces2.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces2
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  hostPID: true
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.6/pass/hostnamespaces0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.6/pass/hostnamespaces0.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.7/fail/hostnamespaces0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.7/fail/hostnamespaces0.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  hostIPC: true
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.7/fail/hostnamespaces1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.7/fail/hostnamespaces1.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  hostNetwork: true
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.7/fail/hostnamespaces2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.7/fail/hostnamespaces2.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces2
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  hostPID: true
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.7/pass/hostnamespaces0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.7/pass/hostnamespaces0.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.8/fail/hostnamespaces0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.8/fail/hostnamespaces0.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  hostIPC: true
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.8/fail/hostnamespaces1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.8/fail/hostnamespaces1.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  hostNetwork: true
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.8/fail/hostnamespaces2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.8/fail/hostnamespaces2.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces2
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  hostPID: true
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.8/pass/hostnamespaces0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.8/pass/hostnamespaces0.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.9/fail/hostnamespaces0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.9/fail/hostnamespaces0.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  hostIPC: true
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.9/fail/hostnamespaces1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.9/fail/hostnamespaces1.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  hostNetwork: true
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.9/fail/hostnamespaces2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.9/fail/hostnamespaces2.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces2
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  hostPID: true
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.9/pass/hostnamespaces0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.9/pass/hostnamespaces0.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.0/fail/hostnamespaces0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.0/fail/hostnamespaces0.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  hostIPC: true
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.0/fail/hostnamespaces1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.0/fail/hostnamespaces1.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  hostNetwork: true
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.0/fail/hostnamespaces2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.0/fail/hostnamespaces2.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces2
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  hostPID: true
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.0/pass/hostnamespaces0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.0/pass/hostnamespaces0.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.1/fail/hostnamespaces0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.1/fail/hostnamespaces0.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  hostIPC: true
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.1/fail/hostnamespaces1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.1/fail/hostnamespaces1.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  hostNetwork: true
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.1/fail/hostnamespaces2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.1/fail/hostnamespaces2.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces2
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  hostPID: true
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.1/pass/hostnamespaces0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.1/pass/hostnamespaces0.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.10/fail/hostnamespaces0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.10/fail/hostnamespaces0.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+  hostIPC: true
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.10/fail/hostnamespaces1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.10/fail/hostnamespaces1.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+  hostNetwork: true
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.10/fail/hostnamespaces2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.10/fail/hostnamespaces2.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces2
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+  hostPID: true
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.10/pass/hostnamespaces0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.10/pass/hostnamespaces0.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.11/fail/hostnamespaces0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.11/fail/hostnamespaces0.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+  hostIPC: true
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.11/fail/hostnamespaces1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.11/fail/hostnamespaces1.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+  hostNetwork: true
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.11/fail/hostnamespaces2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.11/fail/hostnamespaces2.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces2
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+  hostPID: true
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.11/pass/hostnamespaces0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.11/pass/hostnamespaces0.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.12/fail/hostnamespaces0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.12/fail/hostnamespaces0.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+  hostIPC: true
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.12/fail/hostnamespaces1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.12/fail/hostnamespaces1.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+  hostNetwork: true
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.12/fail/hostnamespaces2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.12/fail/hostnamespaces2.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces2
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+  hostPID: true
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.12/pass/hostnamespaces0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.12/pass/hostnamespaces0.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.13/fail/hostnamespaces0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.13/fail/hostnamespaces0.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+  hostIPC: true
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.13/fail/hostnamespaces1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.13/fail/hostnamespaces1.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+  hostNetwork: true
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.13/fail/hostnamespaces2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.13/fail/hostnamespaces2.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces2
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+  hostPID: true
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.13/pass/hostnamespaces0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.13/pass/hostnamespaces0.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.14/fail/hostnamespaces0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.14/fail/hostnamespaces0.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+  hostIPC: true
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.14/fail/hostnamespaces1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.14/fail/hostnamespaces1.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+  hostNetwork: true
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.14/fail/hostnamespaces2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.14/fail/hostnamespaces2.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces2
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+  hostPID: true
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.14/pass/hostnamespaces0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.14/pass/hostnamespaces0.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.15/fail/hostnamespaces0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.15/fail/hostnamespaces0.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+  hostIPC: true
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.15/fail/hostnamespaces1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.15/fail/hostnamespaces1.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+  hostNetwork: true
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.15/fail/hostnamespaces2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.15/fail/hostnamespaces2.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces2
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+  hostPID: true
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.15/pass/hostnamespaces0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.15/pass/hostnamespaces0.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.16/fail/hostnamespaces0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.16/fail/hostnamespaces0.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+  hostIPC: true
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.16/fail/hostnamespaces1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.16/fail/hostnamespaces1.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+  hostNetwork: true
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.16/fail/hostnamespaces2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.16/fail/hostnamespaces2.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces2
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+  hostPID: true
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.16/pass/hostnamespaces0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.16/pass/hostnamespaces0.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.17/fail/hostnamespaces0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.17/fail/hostnamespaces0.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+  hostIPC: true
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.17/fail/hostnamespaces1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.17/fail/hostnamespaces1.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+  hostNetwork: true
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.17/fail/hostnamespaces2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.17/fail/hostnamespaces2.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces2
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+  hostPID: true
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.17/pass/hostnamespaces0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.17/pass/hostnamespaces0.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.18/fail/hostnamespaces0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.18/fail/hostnamespaces0.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+  hostIPC: true
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.18/fail/hostnamespaces1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.18/fail/hostnamespaces1.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+  hostNetwork: true
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.18/fail/hostnamespaces2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.18/fail/hostnamespaces2.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces2
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+  hostPID: true
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.18/pass/hostnamespaces0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.18/pass/hostnamespaces0.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.19/fail/hostnamespaces0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.19/fail/hostnamespaces0.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+  hostIPC: true
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.19/fail/hostnamespaces1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.19/fail/hostnamespaces1.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+  hostNetwork: true
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.19/fail/hostnamespaces2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.19/fail/hostnamespaces2.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces2
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+  hostPID: true
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.19/pass/hostnamespaces0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.19/pass/hostnamespaces0.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.2/fail/hostnamespaces0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.2/fail/hostnamespaces0.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  hostIPC: true
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.2/fail/hostnamespaces1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.2/fail/hostnamespaces1.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  hostNetwork: true
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.2/fail/hostnamespaces2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.2/fail/hostnamespaces2.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces2
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  hostPID: true
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.2/pass/hostnamespaces0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.2/pass/hostnamespaces0.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.20/fail/hostnamespaces0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.20/fail/hostnamespaces0.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+  hostIPC: true
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.20/fail/hostnamespaces1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.20/fail/hostnamespaces1.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+  hostNetwork: true
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.20/fail/hostnamespaces2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.20/fail/hostnamespaces2.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces2
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+  hostPID: true
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.20/pass/hostnamespaces0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.20/pass/hostnamespaces0.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.21/fail/hostnamespaces0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.21/fail/hostnamespaces0.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+  hostIPC: true
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.21/fail/hostnamespaces1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.21/fail/hostnamespaces1.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+  hostNetwork: true
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.21/fail/hostnamespaces2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.21/fail/hostnamespaces2.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces2
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+  hostPID: true
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.21/pass/hostnamespaces0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.21/pass/hostnamespaces0.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.22/fail/hostnamespaces0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.22/fail/hostnamespaces0.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+  hostIPC: true
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.22/fail/hostnamespaces1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.22/fail/hostnamespaces1.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+  hostNetwork: true
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.22/fail/hostnamespaces2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.22/fail/hostnamespaces2.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces2
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+  hostPID: true
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.22/pass/hostnamespaces0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.22/pass/hostnamespaces0.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.3/fail/hostnamespaces0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.3/fail/hostnamespaces0.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  hostIPC: true
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.3/fail/hostnamespaces1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.3/fail/hostnamespaces1.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  hostNetwork: true
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.3/fail/hostnamespaces2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.3/fail/hostnamespaces2.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces2
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  hostPID: true
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.3/pass/hostnamespaces0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.3/pass/hostnamespaces0.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.4/fail/hostnamespaces0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.4/fail/hostnamespaces0.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  hostIPC: true
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.4/fail/hostnamespaces1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.4/fail/hostnamespaces1.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  hostNetwork: true
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.4/fail/hostnamespaces2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.4/fail/hostnamespaces2.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces2
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  hostPID: true
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.4/pass/hostnamespaces0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.4/pass/hostnamespaces0.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.5/fail/hostnamespaces0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.5/fail/hostnamespaces0.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  hostIPC: true
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.5/fail/hostnamespaces1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.5/fail/hostnamespaces1.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  hostNetwork: true
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.5/fail/hostnamespaces2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.5/fail/hostnamespaces2.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces2
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  hostPID: true
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.5/pass/hostnamespaces0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.5/pass/hostnamespaces0.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.6/fail/hostnamespaces0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.6/fail/hostnamespaces0.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  hostIPC: true
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.6/fail/hostnamespaces1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.6/fail/hostnamespaces1.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  hostNetwork: true
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.6/fail/hostnamespaces2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.6/fail/hostnamespaces2.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces2
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  hostPID: true
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.6/pass/hostnamespaces0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.6/pass/hostnamespaces0.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.7/fail/hostnamespaces0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.7/fail/hostnamespaces0.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  hostIPC: true
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.7/fail/hostnamespaces1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.7/fail/hostnamespaces1.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  hostNetwork: true
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.7/fail/hostnamespaces2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.7/fail/hostnamespaces2.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces2
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  hostPID: true
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.7/pass/hostnamespaces0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.7/pass/hostnamespaces0.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.8/fail/hostnamespaces0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.8/fail/hostnamespaces0.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+  hostIPC: true
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.8/fail/hostnamespaces1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.8/fail/hostnamespaces1.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+  hostNetwork: true
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.8/fail/hostnamespaces2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.8/fail/hostnamespaces2.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces2
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+  hostPID: true
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.8/pass/hostnamespaces0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.8/pass/hostnamespaces0.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.9/fail/hostnamespaces0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.9/fail/hostnamespaces0.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+  hostIPC: true
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.9/fail/hostnamespaces1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.9/fail/hostnamespaces1.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+  hostNetwork: true
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.9/fail/hostnamespaces2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.9/fail/hostnamespaces2.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces2
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+  hostPID: true
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.9/pass/hostnamespaces0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.9/pass/hostnamespaces0.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+  securityContext:
+    runAsNonRoot: true


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

This PR adds a baseline policy check for host namespaces.

#### Which issue(s) this PR fixes:

Fixes #103195

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
- [KEP]: https://git.k8s.io/enhancements/keps/sig-auth/2579-psp-replacement
```

/sig auth security