### PR TITLE
Mark net.ipv4.ip_unprivileged_port_start as a safe sysctl

### DIFF
--- a/pkg/security/podsecuritypolicy/sysctl/mustmatchpatterns.go
+++ b/pkg/security/podsecuritypolicy/sysctl/mustmatchpatterns.go
@@ -35,6 +35,7 @@ func SafeSysctlWhitelist() []string {
 		"net.ipv4.ip_local_port_range",
 		"net.ipv4.tcp_syncookies",
 		"net.ipv4.ping_group_range",
+		"net.ipv4.ip_unprivileged_port_start",
 	}
 }
 

--- a/staging/src/k8s.io/pod-security-admission/policy/check_sysctls.go
+++ b/staging/src/k8s.io/pod-security-admission/policy/check_sysctls.go
@@ -50,6 +50,7 @@ var (
 		"net.ipv4.ip_local_port_range",
 		"net.ipv4.tcp_syncookies",
 		"net.ipv4.ping_group_range",
+		"net.ipv4.ip_unprivileged_port_start",
 	)
 )
 

--- a/staging/src/k8s.io/pod-security-admission/test/fixtures_sysctls.go
+++ b/staging/src/k8s.io/pod-security-admission/test/fixtures_sysctls.go
@@ -40,13 +40,15 @@ func init() {
 				// security context with no sysctls
 				tweak(p, func(p *corev1.Pod) { p.Spec.SecurityContext.Sysctls = nil }),
 				// sysctls with name="kernel.shm_rmid_forced" ,"net.ipv4.ip_local_port_range"
-				// "net.ipv4.tcp_syncookies", "net.ipv4.ping_group_range"
+				// "net.ipv4.tcp_syncookies", "net.ipv4.ping_group_range",
+				// "net.ipv4.ip_unprivileged_port_start"
 				tweak(p, func(p *corev1.Pod) {
 					p.Spec.SecurityContext.Sysctls = []corev1.Sysctl{
 						{Name: "kernel.shm_rmid_forced", Value: "0"},
 						{Name: "net.ipv4.ip_local_port_range", Value: "1024 65535"},
 						{Name: "net.ipv4.tcp_syncookies", Value: "0"},
 						{Name: "net.ipv4.ping_group_range", Value: "1 0"},
+						{Name: "net.ipv4.ip_unprivileged_port_start", Value: "1024"},
 					}
 				}),
 			}

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.0/pass/sysctls1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.0/pass/sysctls1.yaml
@@ -19,3 +19,5 @@ spec:
       value: "0"
     - name: net.ipv4.ping_group_range
       value: 1 0
+    - name: net.ipv4.ip_unprivileged_port_start
+      value: "1024"

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.1/pass/sysctls1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.1/pass/sysctls1.yaml
@@ -19,3 +19,5 @@ spec:
       value: "0"
     - name: net.ipv4.ping_group_range
       value: 1 0
+    - name: net.ipv4.ip_unprivileged_port_start
+      value: "1024"

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.10/pass/sysctls1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.10/pass/sysctls1.yaml
@@ -19,3 +19,5 @@ spec:
       value: "0"
     - name: net.ipv4.ping_group_range
       value: 1 0
+    - name: net.ipv4.ip_unprivileged_port_start
+      value: "1024"

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.11/pass/sysctls1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.11/pass/sysctls1.yaml
@@ -19,3 +19,5 @@ spec:
       value: "0"
     - name: net.ipv4.ping_group_range
       value: 1 0
+    - name: net.ipv4.ip_unprivileged_port_start
+      value: "1024"

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.12/pass/sysctls1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.12/pass/sysctls1.yaml
@@ -19,3 +19,5 @@ spec:
       value: "0"
     - name: net.ipv4.ping_group_range
       value: 1 0
+    - name: net.ipv4.ip_unprivileged_port_start
+      value: "1024"

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.13/pass/sysctls1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.13/pass/sysctls1.yaml
@@ -19,3 +19,5 @@ spec:
       value: "0"
     - name: net.ipv4.ping_group_range
       value: 1 0
+    - name: net.ipv4.ip_unprivileged_port_start
+      value: "1024"

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.14/pass/sysctls1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.14/pass/sysctls1.yaml
@@ -19,3 +19,5 @@ spec:
       value: "0"
     - name: net.ipv4.ping_group_range
       value: 1 0
+    - name: net.ipv4.ip_unprivileged_port_start
+      value: "1024"

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.15/pass/sysctls1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.15/pass/sysctls1.yaml
@@ -19,3 +19,5 @@ spec:
       value: "0"
     - name: net.ipv4.ping_group_range
       value: 1 0
+    - name: net.ipv4.ip_unprivileged_port_start
+      value: "1024"

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.16/pass/sysctls1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.16/pass/sysctls1.yaml
@@ -19,3 +19,5 @@ spec:
       value: "0"
     - name: net.ipv4.ping_group_range
       value: 1 0
+    - name: net.ipv4.ip_unprivileged_port_start
+      value: "1024"

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.17/pass/sysctls1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.17/pass/sysctls1.yaml
@@ -19,3 +19,5 @@ spec:
       value: "0"
     - name: net.ipv4.ping_group_range
       value: 1 0
+    - name: net.ipv4.ip_unprivileged_port_start
+      value: "1024"

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.18/pass/sysctls1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.18/pass/sysctls1.yaml
@@ -19,3 +19,5 @@ spec:
       value: "0"
     - name: net.ipv4.ping_group_range
       value: 1 0
+    - name: net.ipv4.ip_unprivileged_port_start
+      value: "1024"

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.19/pass/sysctls1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.19/pass/sysctls1.yaml
@@ -19,3 +19,5 @@ spec:
       value: "0"
     - name: net.ipv4.ping_group_range
       value: 1 0
+    - name: net.ipv4.ip_unprivileged_port_start
+      value: "1024"

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.2/pass/sysctls1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.2/pass/sysctls1.yaml
@@ -19,3 +19,5 @@ spec:
       value: "0"
     - name: net.ipv4.ping_group_range
       value: 1 0
+    - name: net.ipv4.ip_unprivileged_port_start
+      value: "1024"

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.20/pass/sysctls1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.20/pass/sysctls1.yaml
@@ -19,3 +19,5 @@ spec:
       value: "0"
     - name: net.ipv4.ping_group_range
       value: 1 0
+    - name: net.ipv4.ip_unprivileged_port_start
+      value: "1024"

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.21/pass/sysctls1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.21/pass/sysctls1.yaml
@@ -19,3 +19,5 @@ spec:
       value: "0"
     - name: net.ipv4.ping_group_range
       value: 1 0
+    - name: net.ipv4.ip_unprivileged_port_start
+      value: "1024"

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.22/pass/sysctls1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.22/pass/sysctls1.yaml
@@ -19,3 +19,5 @@ spec:
       value: "0"
     - name: net.ipv4.ping_group_range
       value: 1 0
+    - name: net.ipv4.ip_unprivileged_port_start
+      value: "1024"

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.3/pass/sysctls1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.3/pass/sysctls1.yaml
@@ -19,3 +19,5 @@ spec:
       value: "0"
     - name: net.ipv4.ping_group_range
       value: 1 0
+    - name: net.ipv4.ip_unprivileged_port_start
+      value: "1024"

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.4/pass/sysctls1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.4/pass/sysctls1.yaml
@@ -19,3 +19,5 @@ spec:
       value: "0"
     - name: net.ipv4.ping_group_range
       value: 1 0
+    - name: net.ipv4.ip_unprivileged_port_start
+      value: "1024"

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.5/pass/sysctls1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.5/pass/sysctls1.yaml
@@ -19,3 +19,5 @@ spec:
       value: "0"
     - name: net.ipv4.ping_group_range
       value: 1 0
+    - name: net.ipv4.ip_unprivileged_port_start
+      value: "1024"

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.6/pass/sysctls1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.6/pass/sysctls1.yaml
@@ -19,3 +19,5 @@ spec:
       value: "0"
     - name: net.ipv4.ping_group_range
       value: 1 0
+    - name: net.ipv4.ip_unprivileged_port_start
+      value: "1024"

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.7/pass/sysctls1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.7/pass/sysctls1.yaml
@@ -19,3 +19,5 @@ spec:
       value: "0"
     - name: net.ipv4.ping_group_range
       value: 1 0
+    - name: net.ipv4.ip_unprivileged_port_start
+      value: "1024"

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.8/pass/sysctls1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.8/pass/sysctls1.yaml
@@ -19,3 +19,5 @@ spec:
       value: "0"
     - name: net.ipv4.ping_group_range
       value: 1 0
+    - name: net.ipv4.ip_unprivileged_port_start
+      value: "1024"

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.9/pass/sysctls1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.9/pass/sysctls1.yaml
@@ -19,3 +19,5 @@ spec:
       value: "0"
     - name: net.ipv4.ping_group_range
       value: 1 0
+    - name: net.ipv4.ip_unprivileged_port_start
+      value: "1024"

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.0/pass/sysctls1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.0/pass/sysctls1.yaml
@@ -20,3 +20,5 @@ spec:
       value: "0"
     - name: net.ipv4.ping_group_range
       value: 1 0
+    - name: net.ipv4.ip_unprivileged_port_start
+      value: "1024"

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.1/pass/sysctls1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.1/pass/sysctls1.yaml
@@ -20,3 +20,5 @@ spec:
       value: "0"
     - name: net.ipv4.ping_group_range
       value: 1 0
+    - name: net.ipv4.ip_unprivileged_port_start
+      value: "1024"

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.10/pass/sysctls1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.10/pass/sysctls1.yaml
@@ -24,3 +24,5 @@ spec:
       value: "0"
     - name: net.ipv4.ping_group_range
       value: 1 0
+    - name: net.ipv4.ip_unprivileged_port_start
+      value: "1024"

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.11/pass/sysctls1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.11/pass/sysctls1.yaml
@@ -24,3 +24,5 @@ spec:
       value: "0"
     - name: net.ipv4.ping_group_range
       value: 1 0
+    - name: net.ipv4.ip_unprivileged_port_start
+      value: "1024"

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.12/pass/sysctls1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.12/pass/sysctls1.yaml
@@ -24,3 +24,5 @@ spec:
       value: "0"
     - name: net.ipv4.ping_group_range
       value: 1 0
+    - name: net.ipv4.ip_unprivileged_port_start
+      value: "1024"

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.13/pass/sysctls1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.13/pass/sysctls1.yaml
@@ -24,3 +24,5 @@ spec:
       value: "0"
     - name: net.ipv4.ping_group_range
       value: 1 0
+    - name: net.ipv4.ip_unprivileged_port_start
+      value: "1024"

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.14/pass/sysctls1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.14/pass/sysctls1.yaml
@@ -24,3 +24,5 @@ spec:
       value: "0"
     - name: net.ipv4.ping_group_range
       value: 1 0
+    - name: net.ipv4.ip_unprivileged_port_start
+      value: "1024"

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.15/pass/sysctls1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.15/pass/sysctls1.yaml
@@ -24,3 +24,5 @@ spec:
       value: "0"
     - name: net.ipv4.ping_group_range
       value: 1 0
+    - name: net.ipv4.ip_unprivileged_port_start
+      value: "1024"

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.16/pass/sysctls1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.16/pass/sysctls1.yaml
@@ -24,3 +24,5 @@ spec:
       value: "0"
     - name: net.ipv4.ping_group_range
       value: 1 0
+    - name: net.ipv4.ip_unprivileged_port_start
+      value: "1024"

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.17/pass/sysctls1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.17/pass/sysctls1.yaml
@@ -24,3 +24,5 @@ spec:
       value: "0"
     - name: net.ipv4.ping_group_range
       value: 1 0
+    - name: net.ipv4.ip_unprivileged_port_start
+      value: "1024"

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.18/pass/sysctls1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.18/pass/sysctls1.yaml
@@ -24,3 +24,5 @@ spec:
       value: "0"
     - name: net.ipv4.ping_group_range
       value: 1 0
+    - name: net.ipv4.ip_unprivileged_port_start
+      value: "1024"

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.19/pass/sysctls1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.19/pass/sysctls1.yaml
@@ -24,3 +24,5 @@ spec:
       value: "0"
     - name: net.ipv4.ping_group_range
       value: 1 0
+    - name: net.ipv4.ip_unprivileged_port_start
+      value: "1024"

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.2/pass/sysctls1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.2/pass/sysctls1.yaml
@@ -20,3 +20,5 @@ spec:
       value: "0"
     - name: net.ipv4.ping_group_range
       value: 1 0
+    - name: net.ipv4.ip_unprivileged_port_start
+      value: "1024"

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.20/pass/sysctls1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.20/pass/sysctls1.yaml
@@ -24,3 +24,5 @@ spec:
       value: "0"
     - name: net.ipv4.ping_group_range
       value: 1 0
+    - name: net.ipv4.ip_unprivileged_port_start
+      value: "1024"

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.21/pass/sysctls1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.21/pass/sysctls1.yaml
@@ -24,3 +24,5 @@ spec:
       value: "0"
     - name: net.ipv4.ping_group_range
       value: 1 0
+    - name: net.ipv4.ip_unprivileged_port_start
+      value: "1024"

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.22/pass/sysctls1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.22/pass/sysctls1.yaml
@@ -24,3 +24,5 @@ spec:
       value: "0"
     - name: net.ipv4.ping_group_range
       value: 1 0
+    - name: net.ipv4.ip_unprivileged_port_start
+      value: "1024"

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.3/pass/sysctls1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.3/pass/sysctls1.yaml
@@ -20,3 +20,5 @@ spec:
       value: "0"
     - name: net.ipv4.ping_group_range
       value: 1 0
+    - name: net.ipv4.ip_unprivileged_port_start
+      value: "1024"

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.4/pass/sysctls1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.4/pass/sysctls1.yaml
@@ -20,3 +20,5 @@ spec:
       value: "0"
     - name: net.ipv4.ping_group_range
       value: 1 0
+    - name: net.ipv4.ip_unprivileged_port_start
+      value: "1024"

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.5/pass/sysctls1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.5/pass/sysctls1.yaml
@@ -20,3 +20,5 @@ spec:
       value: "0"
     - name: net.ipv4.ping_group_range
       value: 1 0
+    - name: net.ipv4.ip_unprivileged_port_start
+      value: "1024"

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.6/pass/sysctls1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.6/pass/sysctls1.yaml
@@ -20,3 +20,5 @@ spec:
       value: "0"
     - name: net.ipv4.ping_group_range
       value: 1 0
+    - name: net.ipv4.ip_unprivileged_port_start
+      value: "1024"

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.7/pass/sysctls1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.7/pass/sysctls1.yaml
@@ -20,3 +20,5 @@ spec:
       value: "0"
     - name: net.ipv4.ping_group_range
       value: 1 0
+    - name: net.ipv4.ip_unprivileged_port_start
+      value: "1024"

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.8/pass/sysctls1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.8/pass/sysctls1.yaml
@@ -24,3 +24,5 @@ spec:
       value: "0"
     - name: net.ipv4.ping_group_range
       value: 1 0
+    - name: net.ipv4.ip_unprivileged_port_start
+      value: "1024"

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.9/pass/sysctls1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.9/pass/sysctls1.yaml
@@ -24,3 +24,5 @@ spec:
       value: "0"
     - name: net.ipv4.ping_group_range
       value: 1 0
+    - name: net.ipv4.ip_unprivileged_port_start
+      value: "1024"


### PR DESCRIPTION
#### What type of PR is this?
/kind feature
/sig node

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
Fixes #103298

#### Special notes for your reviewer:

- [x] add net.ipv4.ip_unprivileged_port_start in safe sysctl list
- [x] permit in PodSecurity baseline profile

#### Does this PR introduce a user-facing change?
```release-note
Mark net.ipv4.ip_unprivileged_port_start as safe sysctl
```
