### PR TITLE
When set gcc.terminatedPodThreshold = 0, we should delete all terminated pods, not disable pod garbage collector

### DIFF
--- a/cmd/kube-controller-manager/app/options/podgccontroller.go
+++ b/cmd/kube-controller-manager/app/options/podgccontroller.go
@@ -33,7 +33,7 @@ func (o *PodGCControllerOptions) AddFlags(fs *pflag.FlagSet) {
 		return
 	}
 
-	fs.Int32Var(&o.TerminatedPodGCThreshold, "terminated-pod-gc-threshold", o.TerminatedPodGCThreshold, "Number of terminated pods that can exist before the terminated pod garbage collector starts deleting terminated pods. If <= 0, the terminated pod garbage collector is disabled.")
+	fs.Int32Var(&o.TerminatedPodGCThreshold, "terminated-pod-gc-threshold", o.TerminatedPodGCThreshold, "Number of terminated pods that can exist after the terminated pod garbage collector starts deleting terminated pods. If < 0, the terminated pod garbage collector is disabled.Defaults to 12500.")
 }
 
 // ApplyTo fills up PodGCController config with options.

--- a/pkg/controller/podgc/config/types.go
+++ b/pkg/controller/podgc/config/types.go
@@ -19,7 +19,7 @@ package config
 // PodGCControllerConfiguration contains elements describing PodGCController.
 type PodGCControllerConfiguration struct {
 	// terminatedPodGCThreshold is the number of terminated pods that can exist
-	// before the terminated pod garbage collector starts deleting terminated pods.
-	// If <= 0, the terminated pod garbage collector is disabled.
+	// after the terminated pod garbage collector starts deleting terminated pods.
+	// If < 0, the terminated pod garbage collector is disabled.
 	TerminatedPodGCThreshold int32
 }

--- a/pkg/controller/podgc/gc_controller.go
+++ b/pkg/controller/podgc/gc_controller.go
@@ -110,7 +110,7 @@ func (gcc *PodGCController) gc() {
 		klog.Errorf("Error while listing all nodes: %v", err)
 		return
 	}
-	if gcc.terminatedPodThreshold > 0 {
+	if gcc.terminatedPodThreshold >= 0 {
 		gcc.gcTerminated(pods)
 	}
 	gcc.gcOrphaned(pods, nodes)

--- a/pkg/controller/podgc/gc_controller_test.go
+++ b/pkg/controller/podgc/gc_controller_test.go
@@ -73,15 +73,24 @@ func TestGCTerminated(t *testing.T) {
 		deletedPodNames sets.String
 	}{
 		{
-			name: "threshold = 0, disables terminated pod deletion",
+			name: "threshold < 0, disables terminated pod deletion",
 			pods: []nameToPhase{
 				{name: "a", phase: v1.PodFailed},
 				{name: "b", phase: v1.PodSucceeded},
 			},
-			threshold: 0,
-			// threshold = 0 disables terminated pod deletion
+			threshold:       -1,
+			// threshold < 0, disables terminated pod deletion
 			deletedPodNames: sets.NewString(),
 		},
+		 {
+                        name: "threshold = 0, delete pod a which is PodFailed and pod b which is PodSucceeded",
+                        pods: []nameToPhase{
+                                {name: "a", phase: v1.PodFailed},
+                                {name: "b", phase: v1.PodSucceeded},
+                        },
+                        threshold:       0,
+                        deletedPodNames: sets.NewString("a", "b"),
+                },
 		{
 			name: "threshold = 1, delete pod a which is PodFailed and pod b which is PodSucceeded",
 			pods: []nameToPhase{

--- a/staging/src/k8s.io/kube-controller-manager/config/v1alpha1/types.go
+++ b/staging/src/k8s.io/kube-controller-manager/config/v1alpha1/types.go
@@ -423,8 +423,8 @@ type PersistentVolumeBinderControllerConfiguration struct {
 // PodGCControllerConfiguration contains elements describing PodGCController.
 type PodGCControllerConfiguration struct {
 	// terminatedPodGCThreshold is the number of terminated pods that can exist
-	// before the terminated pod garbage collector starts deleting terminated pods.
-	// If <= 0, the terminated pod garbage collector is disabled.
+	// after the terminated pod garbage collector starts deleting terminated pods.
+	// If < 0, the terminated pod garbage collector is disabled.
 	TerminatedPodGCThreshold int32
 }
 


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
In  production environment, users do not want to leave any terminated pods, so why not to  when gcc.terminatedPodThreshold = 0, we  delete all terminated pods.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #103330

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
when set gcc.terminatedPodThreshold = 0, delete all terminated pods.
when set gcc.terminatedPodThreshold < 0, disable pod garbage collector.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
