### PR TITLE
Update NPD release version and include windows defender config

### DIFF
--- a/cluster/gce/windows/k8s-node-setup.psm1
+++ b/cluster/gce/windows/k8s-node-setup.psm1
@@ -1673,9 +1673,9 @@ function Install-Pigz {
 
 # Node Problem Detector Resources
 $NPD_SERVICE = "node-problem-detector"
-$DEFAULT_NPD_VERSION = '0.8.8'
+$DEFAULT_NPD_VERSION = '0.8.9'
 $DEFAULT_NPD_RELEASE_PATH = 'https://storage.googleapis.com/kubernetes-release'
-$DEFAULT_NPD_HASH = 'ff264e727fecf7114f00afb9b63755b47b62fc85bffb4a39062d4bbe105186d13cbd111431ae01e49cae3b6940c42934cac0fbbbcae2395df7a73507dc44bc80'
+$DEFAULT_NPD_HASH = 'f87a01d344e16d16511c5160d7d0f3b8a694e00452f50ffbb550deb10460a1ffa7e170233401ae11df5d58cf070e746feea3bd0407af95ba00d6362630da620c'
 
 # Install Node Problem Detector (NPD).
 # NPD analyzes the host for problems that can disrupt workloads.
@@ -1754,6 +1754,7 @@ function Configure-NodeProblemDetector {
         # Custom Plugin Monitors
         $custom_plugin_monitors += @("${npd_dir}\config\windows-health-checker-kubelet.json")
         $custom_plugin_monitors += @("${npd_dir}\config\windows-health-checker-kubeproxy.json")
+        $custom_plugin_monitors += @("${npd_dir}\config\windows-defender-monitor.json")
 
         # System Stats Monitors
         $system_stats_monitors += @("${npd_dir}\config\windows-system-stats-monitor.json")


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
This PR will pull in the latest version of Node problem detector project that has some fixes to an issue in windows. This also includes a windows defender custom plugin problem detector to be monitored. 
Without this update, NPD cannot be enabled on Windows running containerd without causing the node to become unhealthy.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
NONE
