### PR TITLE
fix code comment ambiguities

### DIFF
--- a/pkg/scheduler/internal/queue/scheduling_queue.go
+++ b/pkg/scheduler/internal/queue/scheduling_queue.go
@@ -302,7 +302,7 @@ func (p *PriorityQueue) Add(pod *v1.Pod) error {
 }
 
 // isPodBackingoff returns true if a pod is still waiting for its backoff timer.
-// If this returns true, the pod should not be re-tried.
+// If this returns true, the pod should be re-tried.
 func (p *PriorityQueue) isPodBackingoff(podInfo *framework.QueuedPodInfo) bool {
 	boTime := p.getBackoffTime(podInfo)
 	return boTime.After(p.clock.Now())


### PR DESCRIPTION
Signed-off-by: algebra2k <jackson.cloudnative@gmail.com>


#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:

the `isPodBackingoff` returns true which seems to be a retry of pod, but the function comment descries that it should not be re-tried.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```


