### PR TITLE
Update local-cluster-up.sh to auto-detect darwin and skip kubelet and kube-proxy

### DIFF
--- a/hack/local-up-cluster.sh
+++ b/hack/local-up-cluster.sh
@@ -1188,9 +1188,22 @@ fi
 
 if [[ "${START_MODE}" != "kubeletonly" ]]; then
   if [[ "${START_MODE}" != "nokubeproxy" ]]; then
-    start_kubeproxy
+    ## TODO remove this check if/when kubelet is supported on darwin
+    # Detect the OS name/arch and display appropriate error.
+    case "$(uname -s)" in
+      Darwin)
+        print_color "kubelet is not currently supported in darwin, kube-proxy aborted."
+        ;;
+      Linux)
+        start_kubeproxy
+        ;;
+      *)
+        print_color "Unsupported host OS.  Must be Linux or Mac OS X, kube-proxy aborted."
+        ;;
+    esac
   fi
 fi
+
 if [[ -n "${PSP_ADMISSION}" && "${AUTHORIZATION_MODE}" = *RBAC* ]]; then
   create_psp_policy
 fi


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

When we run `hack/local-up-cluster.sh` on MacOS, Kubelet is not supported. When kube-proxy tries to get spun up, it waits for kubelet to become ready, which won't ever be ready because it's not supported. Hence, it is better to skip kubelet and kube-proxy on Mac. This PR tries to achieve the same. Also this PR tries to resurrect the [PR #94172](https://github.com/kubernetes/kubernetes/pull/94172)


Release Notes: 
```release-note
NONE
```

/sig testing