### PR TITLE
PodSecurity: make failure integration tests feature-aware

### DIFF
--- a/staging/publishing/import-restrictions.yaml
+++ b/staging/publishing/import-restrictions.yaml
@@ -271,4 +271,5 @@
   - k8s.io/client-go
   - k8s.io/klog
   - k8s.io/pod-security-admission
+  - k8s.io/component-base/featuregate
   - k8s.io/utils

--- a/staging/src/k8s.io/component-base/featuregate/feature_gate.go
+++ b/staging/src/k8s.io/component-base/featuregate/feature_gate.go
@@ -109,6 +109,8 @@ type MutableFeatureGate interface {
 	SetFromMap(m map[string]bool) error
 	// Add adds features to the featureGate.
 	Add(features map[Feature]FeatureSpec) error
+	// GetAll returns a copy of the map of known feature names to feature specs.
+	GetAll() map[Feature]FeatureSpec
 }
 
 // featureGate implements FeatureGate as well as pflag.Value for flag parsing.
@@ -288,6 +290,15 @@ func (f *featureGate) Add(features map[Feature]FeatureSpec) error {
 	f.known.Store(known)
 
 	return nil
+}
+
+// GetAll returns a copy of the map of known feature names to feature specs.
+func (f *featureGate) GetAll() map[Feature]FeatureSpec {
+	retval := map[Feature]FeatureSpec{}
+	for k, v := range f.known.Load().(map[Feature]FeatureSpec) {
+		retval[k] = v
+	}
+	return retval
 }
 
 // Enabled returns true if the key is enabled.  If the key is not known, this call will panic.

--- a/staging/src/k8s.io/pod-security-admission/go.mod
+++ b/staging/src/k8s.io/pod-security-admission/go.mod
@@ -11,6 +11,7 @@ require (
 	k8s.io/apimachinery v0.0.0
 	k8s.io/apiserver v0.0.0
 	k8s.io/client-go v0.0.0
+	k8s.io/component-base v0.0.0
 	k8s.io/klog/v2 v2.9.0
 	k8s.io/utils v0.0.0-20210521133846-da695404a2bc
 	sigs.k8s.io/yaml v1.2.0

--- a/staging/src/k8s.io/pod-security-admission/test/fixtures.go
+++ b/staging/src/k8s.io/pod-security-admission/test/fixtures.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/component-base/featuregate"
 	"k8s.io/pod-security-admission/api"
 	"k8s.io/pod-security-admission/policy"
 	"k8s.io/utils/pointer"
@@ -90,6 +91,13 @@ type fixtureGenerator struct {
 	// expectErrorSubstring is a substring to expect in the error message for failed pods.
 	// if empty, the check ID is used.
 	expectErrorSubstring string
+
+	// failRequiresFeatures lists feature gates that must all be enabled for failure cases to fail properly.
+	// This allows failure cases depending on rejecting data populated in alpha or beta fields to be skipped when those features are not enabled.
+	// If empty, failure test cases are always run.
+	// Pass cases are not allowed to be feature-gated (pass cases must only depend on data existing in GA fields).
+	failRequiresFeatures []featuregate.Feature
+
 	// generatePass transforms a minimum valid pod into one or more valid pods.
 	// pods do not need to populate metadata.name.
 	generatePass func(*corev1.Pod) []*corev1.Pod
@@ -101,6 +109,12 @@ type fixtureGenerator struct {
 // fixtureData holds valid and invalid pod fixtures.
 type fixtureData struct {
 	expectErrorSubstring string
+
+	// failRequiresFeatures lists feature gates that must all be enabled for failure cases to fail properly.
+	// This allows failure cases depending on rejecting data populated in alpha or beta fields to be skipped when those features are not enabled.
+	// If empty, failure test cases are always run.
+	// Pass cases are not allowed to be feature-gated (pass cases must only depend on data existing in GA fields).
+	failRequiresFeatures []featuregate.Feature
 
 	pass []*corev1.Pod
 	fail []*corev1.Pod
@@ -148,6 +162,7 @@ func getFixtures(key fixtureKey) (fixtureData, error) {
 		if generator, exists := fixtureGenerators[key]; exists {
 			data := fixtureData{
 				expectErrorSubstring: generator.expectErrorSubstring,
+				failRequiresFeatures: generator.failRequiresFeatures,
 
 				pass: generator.generatePass(validPodForLevel.DeepCopy()),
 				fail: generator.generateFail(validPodForLevel.DeepCopy()),

--- a/test/integration/auth/podsecurity_test.go
+++ b/test/integration/auth/podsecurity_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	"k8s.io/component-base/featuregate"
 	featuregatetesting "k8s.io/component-base/featuregate/testing"
 	kubeapiservertesting "k8s.io/kubernetes/cmd/kube-apiserver/app/testing"
 	"k8s.io/kubernetes/pkg/capabilities"
@@ -29,20 +30,16 @@ import (
 )
 
 func TestPodSecurity(t *testing.T) {
+	// Enable all feature gates needed to allow all fields to be exercised
+	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.ProcMountType, true)()
+	// Ensure the PodSecurity feature is enabled
 	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.PodSecurity, true)()
-	server := kubeapiservertesting.StartTestServerOrDie(t, kubeapiservertesting.NewDefaultTestServerOptions(), []string{
-		"--anonymous-auth=false",
-		"--enable-admission-plugins=PodSecurity",
-		"--allow-privileged=true",
-		// TODO: "--admission-control-config-file=" + admissionConfigFile.Name(),
-	}, framework.SharedEtcd())
-	defer server.TearDownFn()
-
-	// ensure the global is set to allow privileged containers
-	capabilities.SetForTests(capabilities.Capabilities{AllowPrivileged: true})
-
+	// Start server
+	server := startPodSecurityServer(t)
 	opts := podsecuritytest.Options{
 		ClientConfig: server.ClientConfig,
+
+		// Don't pass in feature-gate info, so all testcases run
 
 		// TODO
 		ExemptClient:         nil,
@@ -50,4 +47,39 @@ func TestPodSecurity(t *testing.T) {
 		ExemptRuntimeClasses: []string{},
 	}
 	podsecuritytest.Run(t, opts)
+}
+
+// TestPodSecurityGAOnly ensures policies pass with only GA features enabled
+func TestPodSecurityGAOnly(t *testing.T) {
+	// Disable all alpha and beta features
+	for k, v := range utilfeature.DefaultFeatureGate.DeepCopy().GetAll() {
+		if v.PreRelease == featuregate.Alpha || v.PreRelease == featuregate.Beta {
+			defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, k, false)()
+		}
+	}
+	// Ensure PodSecurity feature is enabled
+	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.PodSecurity, true)()
+	// Start server
+	server := startPodSecurityServer(t)
+
+	opts := podsecuritytest.Options{
+		ClientConfig: server.ClientConfig,
+		// Pass in feature gate info so negative test cases depending on alpha or beta features can be skipped
+		Features: utilfeature.DefaultFeatureGate,
+	}
+	podsecuritytest.Run(t, opts)
+}
+
+func startPodSecurityServer(t *testing.T) *kubeapiservertesting.TestServer {
+	// ensure the global is set to allow privileged containers
+	capabilities.SetForTests(capabilities.Capabilities{AllowPrivileged: true})
+
+	server := kubeapiservertesting.StartTestServerOrDie(t, kubeapiservertesting.NewDefaultTestServerOptions(), []string{
+		"--anonymous-auth=false",
+		"--enable-admission-plugins=PodSecurity",
+		"--allow-privileged=true",
+		// TODO: "--admission-control-config-file=" + admissionConfigFile.Name(),
+	}, framework.SharedEtcd())
+	t.Cleanup(server.TearDownFn)
+	return server
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/kind test

#### What this PR does / why we need it:

Enables the failure testcases for podsecurity tests to indicate features they depend on (for example, features which must be enabled for data to be persisted in the fields the negative testcase expects to reject).

It also runs the integration tests with only GA features to ensure passing testcases only depend on GA features.

This unblocks adding testcases for procMount (xref https://github.com/kubernetes/kubernetes/pull/103340#discussion_r661497825)

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

/assign @tallclair 