### PR TITLE
Create node_e2e test for ephemeral containers

### DIFF
--- a/test/e2e/framework/pod/wait.go
+++ b/test/e2e/framework/pod/wait.go
@@ -565,3 +565,8 @@ func WaitForPodFailedReason(c clientset.Interface, pod *v1.Pod, reason string, t
 	}
 	return nil
 }
+
+// WaitForContainerRunning waits for the given Pod container to have a state of running
+func WaitForContainerRunning(c clientset.Interface, namespace, podName, containerName string, timeout time.Duration) error {
+	return wait.PollImmediate(poll, timeout, isContainerRunning(c, namespace, podName, containerName))
+}

--- a/test/e2e/framework/pods.go
+++ b/test/e2e/framework/pods.go
@@ -40,6 +40,7 @@ import (
 	"github.com/onsi/gomega"
 
 	// TODO: Remove the following imports (ref: https://github.com/kubernetes/kubernetes/issues/81245)
+	"k8s.io/kubernetes/pkg/kubelet/util/format"
 	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
 )
 
@@ -154,18 +155,18 @@ func (c *PodClient) AddEphemeralContainerSync(pod *v1.Pod, ec *v1.EphemeralConta
 	namespace := c.f.Namespace.Name
 
 	podJS, err := json.Marshal(pod)
-	ExpectNoError(err, "error creating JSON for pod: %v", err)
+	ExpectNoError(err, "error creating JSON for pod %q", format.Pod(pod))
 
 	ecPod := pod.DeepCopy()
 	ecPod.Spec.EphemeralContainers = append(ecPod.Spec.EphemeralContainers, *ec)
 	ecJS, err := json.Marshal(ecPod)
-	ExpectNoError(err, "error creating JSON for pod with ephemeral container: %v", err)
+	ExpectNoError(err, "error creating JSON for pod with ephemeral container %q", format.Pod(pod))
 
 	patch, err := strategicpatch.CreateTwoWayMergePatch(podJS, ecJS, pod)
-	ExpectNoError(err, "error creating patch to add ephemeral container: %v", err)
+	ExpectNoError(err, "error creating patch to add ephemeral container %q", format.Pod(pod))
 
 	_, err = c.Patch(context.TODO(), pod.Name, types.StrategicMergePatchType, patch, metav1.PatchOptions{}, "ephemeralcontainers")
-	ExpectNoError(err, "Failed to patch ephemeral containers in pod %q: %v", pod.Name, err)
+	ExpectNoError(err, "Failed to patch ephemeral containers in pod %q", format.Pod(pod))
 
 	ExpectNoError(e2epod.WaitForContainerRunning(c.f.ClientSet, namespace, pod.Name, ec.Name, timeout))
 }

--- a/test/e2e_node/ephemeral_containers_test.go
+++ b/test/e2e_node/ephemeral_containers_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2017 The Kubernetes Authors.
+Copyright 2021 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/test/e2e_node/ephemeral_containers_test.go
+++ b/test/e2e_node/ephemeral_containers_test.go
@@ -1,0 +1,69 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2enode
+
+import (
+	"time"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/kubernetes/test/e2e/framework"
+	imageutils "k8s.io/kubernetes/test/utils/image"
+
+	"github.com/onsi/ginkgo"
+)
+
+var _ = SIGDescribe("Ephemeral Containers [Feature:EphemeralContainers][NodeAlphaFeature:EphemeralContainers]", func() {
+	f := framework.NewDefaultFramework("ephemeral-containers-test")
+	var podClient *framework.PodClient
+	ginkgo.BeforeEach(func() {
+		podClient = f.PodClient()
+	})
+
+	ginkgo.It("will start an ephemeral container in an existing pod", func() {
+		ginkgo.By("creating a target pod")
+		pod := podClient.CreateSync(&v1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Name: "ephemeral-containers-target-pod"},
+			Spec: v1.PodSpec{
+				Containers: []v1.Container{
+					{
+						Name:    "test-container-1",
+						Image:   imageutils.GetE2EImage(imageutils.BusyBox),
+						Command: []string{"/bin/sleep"},
+						Args:    []string{"10000"},
+					},
+				},
+			},
+		})
+
+		ginkgo.By("adding an ephemeral container")
+		ec := &v1.EphemeralContainer{
+			EphemeralContainerCommon: v1.EphemeralContainerCommon{
+				Name:    "debugger",
+				Image:   imageutils.GetE2EImage(imageutils.BusyBox),
+				Command: []string{"/bin/sh"},
+				Stdin:   true,
+				TTY:     true,
+			},
+		}
+		podClient.AddEphemeralContainerSync(pod, ec, time.Minute)
+
+		ginkgo.By("confirm that the container is really running")
+		marco := f.ExecCommandInContainer(pod.Name, "debugger", "/bin/echo", "polo")
+		framework.ExpectEqual(marco, "polo")
+	})
+})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature
/sig node

#### What this PR does / why we need it:

This adds an node e2e test for creating ephemeral containers.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #85545

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- [KEP]: http://kep.k8s.io/277
```
