### PR TITLE
[PodSecurity] baseline - apparmor

### DIFF
--- a/staging/src/k8s.io/pod-security-admission/policy/check_apparmor.go
+++ b/staging/src/k8s.io/pod-security-admission/policy/check_apparmor.go
@@ -1,0 +1,88 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package policy
+
+import (
+	"fmt"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/pod-security-admission/api"
+)
+
+/*
+On supported hosts, the 'runtime/default' AppArmor profile is applied by default.
+The baseline policy should prevent overriding or disabling the default AppArmor
+profile, or restrict overrides to an allowed set of profiles.
+
+**Restricted Fields:**
+metadata.annotations['container.apparmor.security.beta.kubernetes.io/*']
+
+**Allowed Values:** 'runtime/default', undefined
+*/
+func init() {
+	addCheck(CheckAppArmorProfile)
+}
+
+// CheckAppArmorProfile returns a baseline level check
+// that limits the value of AppArmor profiles in 1.0+
+func CheckAppArmorProfile() Check {
+	return Check{
+		ID:    "appArmorProfile",
+		Level: api.LevelBaseline,
+		Versions: []VersionedCheck{
+			{
+				MinimumVersion: api.MajorMinorVersion(1, 0),
+				CheckPod:       appArmorProfile_1_0,
+			},
+		},
+	}
+}
+
+func allowedProfile(profile string) bool {
+	return profile == corev1.AppArmorBetaProfileRuntimeDefault ||
+		strings.HasPrefix(profile, corev1.AppArmorBetaProfileNamePrefix)
+}
+
+func appArmorProfile_1_0(podMetadata *metav1.ObjectMeta, podSpec *corev1.PodSpec) CheckResult {
+	forbiddenValues := sets.NewString()
+
+	// undefined is an allowed value for 'container.apparmor.security.beta.kubernetes.io/*'
+	if len(podMetadata.Annotations) == 0 {
+		return CheckResult{Allowed: true}
+	}
+
+	for k, v := range podMetadata.Annotations {
+		if strings.HasPrefix(k, corev1.AppArmorBetaContainerAnnotationKeyPrefix) && !allowedProfile(v) {
+			forbiddenValues.Insert(fmt.Sprintf("%s:%s", k, v))
+		}
+	}
+
+	if len(forbiddenValues) > 0 {
+		return CheckResult{
+			Allowed:         false,
+			ForbiddenReason: "forbidden AppArmor profile",
+			ForbiddenDetail: fmt.Sprintf("forbidden AppArmor annotations %q",
+				forbiddenValues,
+			),
+		}
+	}
+
+	return CheckResult{Allowed: true}
+}

--- a/staging/src/k8s.io/pod-security-admission/policy/check_apparmor_test.go
+++ b/staging/src/k8s.io/pod-security-admission/policy/check_apparmor_test.go
@@ -1,0 +1,80 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package policy
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestCheckAppArmor(t *testing.T) {
+
+	testCases := []struct {
+		name           string
+		metaData       *metav1.ObjectMeta
+		podSpec        *corev1.PodSpec
+		expectedResult *CheckResult
+	}{
+		{
+			name: "container with default AppArmor + extra annotations",
+			metaData: &metav1.ObjectMeta{Annotations: map[string]string{
+				corev1.AppArmorBetaProfileNamePrefix + "test": "runtime/default",
+				"env": "prod",
+			},
+			},
+			podSpec:        &corev1.PodSpec{},
+			expectedResult: &CheckResult{Allowed: true},
+		},
+		{
+			name: "container with local AppArmor + extra annotations",
+			metaData: &metav1.ObjectMeta{Annotations: map[string]string{
+				corev1.AppArmorBetaProfileNamePrefix + "test": "localhost/sec-profile01",
+				"env": "dev",
+			},
+			},
+			podSpec:        &corev1.PodSpec{},
+			expectedResult: &CheckResult{Allowed: true},
+		},
+		{
+			name: "container with no AppArmor annotations",
+			metaData: &metav1.ObjectMeta{Annotations: map[string]string{
+				"env": "dev",
+			},
+			},
+			podSpec:        &corev1.PodSpec{},
+			expectedResult: &CheckResult{Allowed: true},
+		},
+		{
+			name:           "container with no annotations",
+			metaData:       &metav1.ObjectMeta{},
+			podSpec:        &corev1.PodSpec{},
+			expectedResult: &CheckResult{Allowed: true},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			result := appArmorProfile_1_0(testCase.metaData, nil)
+			if result.Allowed != testCase.expectedResult.Allowed {
+				t.Errorf("Expected result was Allowed=%v for annotations %v",
+					testCase.expectedResult.Allowed, testCase.metaData.Annotations)
+			}
+		})
+	}
+}

--- a/staging/src/k8s.io/pod-security-admission/test/fixtures_apparmor.go
+++ b/staging/src/k8s.io/pod-security-admission/test/fixtures_apparmor.go
@@ -1,0 +1,65 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package test
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/component-base/featuregate"
+	"k8s.io/pod-security-admission/api"
+)
+
+func init() {
+	appArmorFixture_1_0 := fixtureGenerator{
+		expectErrorSubstring: "forbidden AppArmor profile",
+		generatePass: func(pod *corev1.Pod) []*corev1.Pod {
+			pod = ensureAnnotation(pod)
+			return []*corev1.Pod{
+				// container with runtime/default annotation
+				// container with localhost/foo annotation
+				tweak(pod, func(copy *corev1.Pod) {
+					containerName := copy.Spec.Containers[0].Name
+					copy.Annotations[corev1.AppArmorBetaContainerAnnotationKeyPrefix+containerName] = "runtime/default"
+
+					initContainerName := copy.Spec.Containers[0].Name
+					copy.Annotations[corev1.AppArmorBetaContainerAnnotationKeyPrefix+initContainerName] = "localhost/foo"
+				}),
+			}
+		},
+		generateFail: func(pod *corev1.Pod) []*corev1.Pod {
+			pod = ensureAnnotation(pod)
+			return []*corev1.Pod{
+				// container with unconfined annotation
+				tweak(pod, func(copy *corev1.Pod) {
+					name := copy.Spec.Containers[0].Name
+					copy.Annotations[corev1.AppArmorBetaContainerAnnotationKeyPrefix+name] = "unconfined"
+				}),
+
+				// initContainer with unconfined annotation
+				tweak(pod, func(copy *corev1.Pod) {
+					name := copy.Spec.InitContainers[0].Name
+					copy.Annotations[corev1.AppArmorBetaContainerAnnotationKeyPrefix+name] = "unconfined"
+				}),
+			}
+		},
+		failRequiresFeatures: []featuregate.Feature{"AppArmor"},
+	}
+
+	registerFixtureGenerator(
+		fixtureKey{level: api.LevelBaseline, version: api.MajorMinorVersion(1, 0), check: "appArmorProfile"},
+		appArmorFixture_1_0,
+	)
+}

--- a/staging/src/k8s.io/pod-security-admission/test/helpers.go
+++ b/staging/src/k8s.io/pod-security-admission/test/helpers.go
@@ -65,3 +65,11 @@ func ensureSELinuxOptions(p *corev1.Pod) *corev1.Pod {
 	}
 	return p
 }
+
+// ensureAnnotation makes sure that pod.Annotations is never nil
+func ensureAnnotation(pod *corev1.Pod) *corev1.Pod {
+	if pod.Annotations == nil {
+		pod.Annotations = map[string]string{}
+	}
+	return pod
+}

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.0/fail/apparmorprofile0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.0/fail/apparmorprofile0.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    container.apparmor.security.beta.kubernetes.io/container1: unconfined
+  name: apparmorprofile0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.0/fail/apparmorprofile1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.0/fail/apparmorprofile1.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    container.apparmor.security.beta.kubernetes.io/initcontainer1: unconfined
+  name: apparmorprofile1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.0/pass/apparmorprofile0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.0/pass/apparmorprofile0.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    container.apparmor.security.beta.kubernetes.io/container1: localhost/foo
+  name: apparmorprofile0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.1/fail/apparmorprofile0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.1/fail/apparmorprofile0.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    container.apparmor.security.beta.kubernetes.io/container1: unconfined
+  name: apparmorprofile0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.1/fail/apparmorprofile1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.1/fail/apparmorprofile1.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    container.apparmor.security.beta.kubernetes.io/initcontainer1: unconfined
+  name: apparmorprofile1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.1/pass/apparmorprofile0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.1/pass/apparmorprofile0.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    container.apparmor.security.beta.kubernetes.io/container1: localhost/foo
+  name: apparmorprofile0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.10/fail/apparmorprofile0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.10/fail/apparmorprofile0.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    container.apparmor.security.beta.kubernetes.io/container1: unconfined
+  name: apparmorprofile0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.10/fail/apparmorprofile1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.10/fail/apparmorprofile1.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    container.apparmor.security.beta.kubernetes.io/initcontainer1: unconfined
+  name: apparmorprofile1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.10/pass/apparmorprofile0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.10/pass/apparmorprofile0.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    container.apparmor.security.beta.kubernetes.io/container1: localhost/foo
+  name: apparmorprofile0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.11/fail/apparmorprofile0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.11/fail/apparmorprofile0.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    container.apparmor.security.beta.kubernetes.io/container1: unconfined
+  name: apparmorprofile0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.11/fail/apparmorprofile1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.11/fail/apparmorprofile1.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    container.apparmor.security.beta.kubernetes.io/initcontainer1: unconfined
+  name: apparmorprofile1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.11/pass/apparmorprofile0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.11/pass/apparmorprofile0.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    container.apparmor.security.beta.kubernetes.io/container1: localhost/foo
+  name: apparmorprofile0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.12/fail/apparmorprofile0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.12/fail/apparmorprofile0.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    container.apparmor.security.beta.kubernetes.io/container1: unconfined
+  name: apparmorprofile0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.12/fail/apparmorprofile1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.12/fail/apparmorprofile1.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    container.apparmor.security.beta.kubernetes.io/initcontainer1: unconfined
+  name: apparmorprofile1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.12/pass/apparmorprofile0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.12/pass/apparmorprofile0.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    container.apparmor.security.beta.kubernetes.io/container1: localhost/foo
+  name: apparmorprofile0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.13/fail/apparmorprofile0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.13/fail/apparmorprofile0.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    container.apparmor.security.beta.kubernetes.io/container1: unconfined
+  name: apparmorprofile0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.13/fail/apparmorprofile1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.13/fail/apparmorprofile1.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    container.apparmor.security.beta.kubernetes.io/initcontainer1: unconfined
+  name: apparmorprofile1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.13/pass/apparmorprofile0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.13/pass/apparmorprofile0.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    container.apparmor.security.beta.kubernetes.io/container1: localhost/foo
+  name: apparmorprofile0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.14/fail/apparmorprofile0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.14/fail/apparmorprofile0.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    container.apparmor.security.beta.kubernetes.io/container1: unconfined
+  name: apparmorprofile0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.14/fail/apparmorprofile1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.14/fail/apparmorprofile1.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    container.apparmor.security.beta.kubernetes.io/initcontainer1: unconfined
+  name: apparmorprofile1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.14/pass/apparmorprofile0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.14/pass/apparmorprofile0.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    container.apparmor.security.beta.kubernetes.io/container1: localhost/foo
+  name: apparmorprofile0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.15/fail/apparmorprofile0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.15/fail/apparmorprofile0.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    container.apparmor.security.beta.kubernetes.io/container1: unconfined
+  name: apparmorprofile0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.15/fail/apparmorprofile1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.15/fail/apparmorprofile1.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    container.apparmor.security.beta.kubernetes.io/initcontainer1: unconfined
+  name: apparmorprofile1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.15/pass/apparmorprofile0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.15/pass/apparmorprofile0.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    container.apparmor.security.beta.kubernetes.io/container1: localhost/foo
+  name: apparmorprofile0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.16/fail/apparmorprofile0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.16/fail/apparmorprofile0.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    container.apparmor.security.beta.kubernetes.io/container1: unconfined
+  name: apparmorprofile0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.16/fail/apparmorprofile1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.16/fail/apparmorprofile1.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    container.apparmor.security.beta.kubernetes.io/initcontainer1: unconfined
+  name: apparmorprofile1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.16/pass/apparmorprofile0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.16/pass/apparmorprofile0.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    container.apparmor.security.beta.kubernetes.io/container1: localhost/foo
+  name: apparmorprofile0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.17/fail/apparmorprofile0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.17/fail/apparmorprofile0.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    container.apparmor.security.beta.kubernetes.io/container1: unconfined
+  name: apparmorprofile0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.17/fail/apparmorprofile1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.17/fail/apparmorprofile1.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    container.apparmor.security.beta.kubernetes.io/initcontainer1: unconfined
+  name: apparmorprofile1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.17/pass/apparmorprofile0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.17/pass/apparmorprofile0.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    container.apparmor.security.beta.kubernetes.io/container1: localhost/foo
+  name: apparmorprofile0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.18/fail/apparmorprofile0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.18/fail/apparmorprofile0.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    container.apparmor.security.beta.kubernetes.io/container1: unconfined
+  name: apparmorprofile0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.18/fail/apparmorprofile1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.18/fail/apparmorprofile1.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    container.apparmor.security.beta.kubernetes.io/initcontainer1: unconfined
+  name: apparmorprofile1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.18/pass/apparmorprofile0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.18/pass/apparmorprofile0.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    container.apparmor.security.beta.kubernetes.io/container1: localhost/foo
+  name: apparmorprofile0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.19/fail/apparmorprofile0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.19/fail/apparmorprofile0.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    container.apparmor.security.beta.kubernetes.io/container1: unconfined
+  name: apparmorprofile0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.19/fail/apparmorprofile1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.19/fail/apparmorprofile1.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    container.apparmor.security.beta.kubernetes.io/initcontainer1: unconfined
+  name: apparmorprofile1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.19/pass/apparmorprofile0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.19/pass/apparmorprofile0.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    container.apparmor.security.beta.kubernetes.io/container1: localhost/foo
+  name: apparmorprofile0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.2/fail/apparmorprofile0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.2/fail/apparmorprofile0.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    container.apparmor.security.beta.kubernetes.io/container1: unconfined
+  name: apparmorprofile0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.2/fail/apparmorprofile1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.2/fail/apparmorprofile1.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    container.apparmor.security.beta.kubernetes.io/initcontainer1: unconfined
+  name: apparmorprofile1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.2/pass/apparmorprofile0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.2/pass/apparmorprofile0.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    container.apparmor.security.beta.kubernetes.io/container1: localhost/foo
+  name: apparmorprofile0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.20/fail/apparmorprofile0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.20/fail/apparmorprofile0.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    container.apparmor.security.beta.kubernetes.io/container1: unconfined
+  name: apparmorprofile0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.20/fail/apparmorprofile1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.20/fail/apparmorprofile1.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    container.apparmor.security.beta.kubernetes.io/initcontainer1: unconfined
+  name: apparmorprofile1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.20/pass/apparmorprofile0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.20/pass/apparmorprofile0.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    container.apparmor.security.beta.kubernetes.io/container1: localhost/foo
+  name: apparmorprofile0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.21/fail/apparmorprofile0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.21/fail/apparmorprofile0.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    container.apparmor.security.beta.kubernetes.io/container1: unconfined
+  name: apparmorprofile0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.21/fail/apparmorprofile1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.21/fail/apparmorprofile1.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    container.apparmor.security.beta.kubernetes.io/initcontainer1: unconfined
+  name: apparmorprofile1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.21/pass/apparmorprofile0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.21/pass/apparmorprofile0.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    container.apparmor.security.beta.kubernetes.io/container1: localhost/foo
+  name: apparmorprofile0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.22/fail/apparmorprofile0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.22/fail/apparmorprofile0.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    container.apparmor.security.beta.kubernetes.io/container1: unconfined
+  name: apparmorprofile0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.22/fail/apparmorprofile1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.22/fail/apparmorprofile1.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    container.apparmor.security.beta.kubernetes.io/initcontainer1: unconfined
+  name: apparmorprofile1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.22/pass/apparmorprofile0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.22/pass/apparmorprofile0.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    container.apparmor.security.beta.kubernetes.io/container1: localhost/foo
+  name: apparmorprofile0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.3/fail/apparmorprofile0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.3/fail/apparmorprofile0.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    container.apparmor.security.beta.kubernetes.io/container1: unconfined
+  name: apparmorprofile0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.3/fail/apparmorprofile1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.3/fail/apparmorprofile1.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    container.apparmor.security.beta.kubernetes.io/initcontainer1: unconfined
+  name: apparmorprofile1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.3/pass/apparmorprofile0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.3/pass/apparmorprofile0.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    container.apparmor.security.beta.kubernetes.io/container1: localhost/foo
+  name: apparmorprofile0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.4/fail/apparmorprofile0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.4/fail/apparmorprofile0.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    container.apparmor.security.beta.kubernetes.io/container1: unconfined
+  name: apparmorprofile0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.4/fail/apparmorprofile1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.4/fail/apparmorprofile1.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    container.apparmor.security.beta.kubernetes.io/initcontainer1: unconfined
+  name: apparmorprofile1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.4/pass/apparmorprofile0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.4/pass/apparmorprofile0.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    container.apparmor.security.beta.kubernetes.io/container1: localhost/foo
+  name: apparmorprofile0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.5/fail/apparmorprofile0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.5/fail/apparmorprofile0.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    container.apparmor.security.beta.kubernetes.io/container1: unconfined
+  name: apparmorprofile0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.5/fail/apparmorprofile1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.5/fail/apparmorprofile1.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    container.apparmor.security.beta.kubernetes.io/initcontainer1: unconfined
+  name: apparmorprofile1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.5/pass/apparmorprofile0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.5/pass/apparmorprofile0.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    container.apparmor.security.beta.kubernetes.io/container1: localhost/foo
+  name: apparmorprofile0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.6/fail/apparmorprofile0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.6/fail/apparmorprofile0.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    container.apparmor.security.beta.kubernetes.io/container1: unconfined
+  name: apparmorprofile0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.6/fail/apparmorprofile1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.6/fail/apparmorprofile1.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    container.apparmor.security.beta.kubernetes.io/initcontainer1: unconfined
+  name: apparmorprofile1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.6/pass/apparmorprofile0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.6/pass/apparmorprofile0.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    container.apparmor.security.beta.kubernetes.io/container1: localhost/foo
+  name: apparmorprofile0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.7/fail/apparmorprofile0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.7/fail/apparmorprofile0.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    container.apparmor.security.beta.kubernetes.io/container1: unconfined
+  name: apparmorprofile0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.7/fail/apparmorprofile1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.7/fail/apparmorprofile1.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    container.apparmor.security.beta.kubernetes.io/initcontainer1: unconfined
+  name: apparmorprofile1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.7/pass/apparmorprofile0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.7/pass/apparmorprofile0.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    container.apparmor.security.beta.kubernetes.io/container1: localhost/foo
+  name: apparmorprofile0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.8/fail/apparmorprofile0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.8/fail/apparmorprofile0.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    container.apparmor.security.beta.kubernetes.io/container1: unconfined
+  name: apparmorprofile0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.8/fail/apparmorprofile1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.8/fail/apparmorprofile1.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    container.apparmor.security.beta.kubernetes.io/initcontainer1: unconfined
+  name: apparmorprofile1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.8/pass/apparmorprofile0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.8/pass/apparmorprofile0.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    container.apparmor.security.beta.kubernetes.io/container1: localhost/foo
+  name: apparmorprofile0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.9/fail/apparmorprofile0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.9/fail/apparmorprofile0.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    container.apparmor.security.beta.kubernetes.io/container1: unconfined
+  name: apparmorprofile0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.9/fail/apparmorprofile1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.9/fail/apparmorprofile1.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    container.apparmor.security.beta.kubernetes.io/initcontainer1: unconfined
+  name: apparmorprofile1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.9/pass/apparmorprofile0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.9/pass/apparmorprofile0.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    container.apparmor.security.beta.kubernetes.io/container1: localhost/foo
+  name: apparmorprofile0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.0/fail/apparmorprofile0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.0/fail/apparmorprofile0.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    container.apparmor.security.beta.kubernetes.io/container1: unconfined
+  name: apparmorprofile0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.0/fail/apparmorprofile1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.0/fail/apparmorprofile1.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    container.apparmor.security.beta.kubernetes.io/initcontainer1: unconfined
+  name: apparmorprofile1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.0/pass/apparmorprofile0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.0/pass/apparmorprofile0.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    container.apparmor.security.beta.kubernetes.io/container1: localhost/foo
+  name: apparmorprofile0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.1/fail/apparmorprofile0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.1/fail/apparmorprofile0.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    container.apparmor.security.beta.kubernetes.io/container1: unconfined
+  name: apparmorprofile0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.1/fail/apparmorprofile1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.1/fail/apparmorprofile1.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    container.apparmor.security.beta.kubernetes.io/initcontainer1: unconfined
+  name: apparmorprofile1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.1/pass/apparmorprofile0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.1/pass/apparmorprofile0.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    container.apparmor.security.beta.kubernetes.io/container1: localhost/foo
+  name: apparmorprofile0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.10/fail/apparmorprofile0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.10/fail/apparmorprofile0.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    container.apparmor.security.beta.kubernetes.io/container1: unconfined
+  name: apparmorprofile0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.10/fail/apparmorprofile1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.10/fail/apparmorprofile1.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    container.apparmor.security.beta.kubernetes.io/initcontainer1: unconfined
+  name: apparmorprofile1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.10/pass/apparmorprofile0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.10/pass/apparmorprofile0.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    container.apparmor.security.beta.kubernetes.io/container1: localhost/foo
+  name: apparmorprofile0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.11/fail/apparmorprofile0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.11/fail/apparmorprofile0.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    container.apparmor.security.beta.kubernetes.io/container1: unconfined
+  name: apparmorprofile0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.11/fail/apparmorprofile1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.11/fail/apparmorprofile1.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    container.apparmor.security.beta.kubernetes.io/initcontainer1: unconfined
+  name: apparmorprofile1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.11/pass/apparmorprofile0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.11/pass/apparmorprofile0.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    container.apparmor.security.beta.kubernetes.io/container1: localhost/foo
+  name: apparmorprofile0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.12/fail/apparmorprofile0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.12/fail/apparmorprofile0.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    container.apparmor.security.beta.kubernetes.io/container1: unconfined
+  name: apparmorprofile0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.12/fail/apparmorprofile1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.12/fail/apparmorprofile1.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    container.apparmor.security.beta.kubernetes.io/initcontainer1: unconfined
+  name: apparmorprofile1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.12/pass/apparmorprofile0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.12/pass/apparmorprofile0.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    container.apparmor.security.beta.kubernetes.io/container1: localhost/foo
+  name: apparmorprofile0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.13/fail/apparmorprofile0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.13/fail/apparmorprofile0.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    container.apparmor.security.beta.kubernetes.io/container1: unconfined
+  name: apparmorprofile0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.13/fail/apparmorprofile1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.13/fail/apparmorprofile1.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    container.apparmor.security.beta.kubernetes.io/initcontainer1: unconfined
+  name: apparmorprofile1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.13/pass/apparmorprofile0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.13/pass/apparmorprofile0.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    container.apparmor.security.beta.kubernetes.io/container1: localhost/foo
+  name: apparmorprofile0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.14/fail/apparmorprofile0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.14/fail/apparmorprofile0.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    container.apparmor.security.beta.kubernetes.io/container1: unconfined
+  name: apparmorprofile0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.14/fail/apparmorprofile1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.14/fail/apparmorprofile1.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    container.apparmor.security.beta.kubernetes.io/initcontainer1: unconfined
+  name: apparmorprofile1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.14/pass/apparmorprofile0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.14/pass/apparmorprofile0.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    container.apparmor.security.beta.kubernetes.io/container1: localhost/foo
+  name: apparmorprofile0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.15/fail/apparmorprofile0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.15/fail/apparmorprofile0.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    container.apparmor.security.beta.kubernetes.io/container1: unconfined
+  name: apparmorprofile0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.15/fail/apparmorprofile1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.15/fail/apparmorprofile1.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    container.apparmor.security.beta.kubernetes.io/initcontainer1: unconfined
+  name: apparmorprofile1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.15/pass/apparmorprofile0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.15/pass/apparmorprofile0.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    container.apparmor.security.beta.kubernetes.io/container1: localhost/foo
+  name: apparmorprofile0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.16/fail/apparmorprofile0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.16/fail/apparmorprofile0.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    container.apparmor.security.beta.kubernetes.io/container1: unconfined
+  name: apparmorprofile0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.16/fail/apparmorprofile1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.16/fail/apparmorprofile1.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    container.apparmor.security.beta.kubernetes.io/initcontainer1: unconfined
+  name: apparmorprofile1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.16/pass/apparmorprofile0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.16/pass/apparmorprofile0.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    container.apparmor.security.beta.kubernetes.io/container1: localhost/foo
+  name: apparmorprofile0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.17/fail/apparmorprofile0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.17/fail/apparmorprofile0.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    container.apparmor.security.beta.kubernetes.io/container1: unconfined
+  name: apparmorprofile0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.17/fail/apparmorprofile1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.17/fail/apparmorprofile1.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    container.apparmor.security.beta.kubernetes.io/initcontainer1: unconfined
+  name: apparmorprofile1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.17/pass/apparmorprofile0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.17/pass/apparmorprofile0.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    container.apparmor.security.beta.kubernetes.io/container1: localhost/foo
+  name: apparmorprofile0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.18/fail/apparmorprofile0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.18/fail/apparmorprofile0.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    container.apparmor.security.beta.kubernetes.io/container1: unconfined
+  name: apparmorprofile0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.18/fail/apparmorprofile1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.18/fail/apparmorprofile1.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    container.apparmor.security.beta.kubernetes.io/initcontainer1: unconfined
+  name: apparmorprofile1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.18/pass/apparmorprofile0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.18/pass/apparmorprofile0.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    container.apparmor.security.beta.kubernetes.io/container1: localhost/foo
+  name: apparmorprofile0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.19/fail/apparmorprofile0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.19/fail/apparmorprofile0.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    container.apparmor.security.beta.kubernetes.io/container1: unconfined
+  name: apparmorprofile0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.19/fail/apparmorprofile1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.19/fail/apparmorprofile1.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    container.apparmor.security.beta.kubernetes.io/initcontainer1: unconfined
+  name: apparmorprofile1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.19/pass/apparmorprofile0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.19/pass/apparmorprofile0.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    container.apparmor.security.beta.kubernetes.io/container1: localhost/foo
+  name: apparmorprofile0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.2/fail/apparmorprofile0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.2/fail/apparmorprofile0.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    container.apparmor.security.beta.kubernetes.io/container1: unconfined
+  name: apparmorprofile0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.2/fail/apparmorprofile1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.2/fail/apparmorprofile1.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    container.apparmor.security.beta.kubernetes.io/initcontainer1: unconfined
+  name: apparmorprofile1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.2/pass/apparmorprofile0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.2/pass/apparmorprofile0.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    container.apparmor.security.beta.kubernetes.io/container1: localhost/foo
+  name: apparmorprofile0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.20/fail/apparmorprofile0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.20/fail/apparmorprofile0.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    container.apparmor.security.beta.kubernetes.io/container1: unconfined
+  name: apparmorprofile0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.20/fail/apparmorprofile1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.20/fail/apparmorprofile1.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    container.apparmor.security.beta.kubernetes.io/initcontainer1: unconfined
+  name: apparmorprofile1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.20/pass/apparmorprofile0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.20/pass/apparmorprofile0.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    container.apparmor.security.beta.kubernetes.io/container1: localhost/foo
+  name: apparmorprofile0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.21/fail/apparmorprofile0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.21/fail/apparmorprofile0.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    container.apparmor.security.beta.kubernetes.io/container1: unconfined
+  name: apparmorprofile0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.21/fail/apparmorprofile1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.21/fail/apparmorprofile1.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    container.apparmor.security.beta.kubernetes.io/initcontainer1: unconfined
+  name: apparmorprofile1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.21/pass/apparmorprofile0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.21/pass/apparmorprofile0.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    container.apparmor.security.beta.kubernetes.io/container1: localhost/foo
+  name: apparmorprofile0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.22/fail/apparmorprofile0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.22/fail/apparmorprofile0.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    container.apparmor.security.beta.kubernetes.io/container1: unconfined
+  name: apparmorprofile0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.22/fail/apparmorprofile1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.22/fail/apparmorprofile1.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    container.apparmor.security.beta.kubernetes.io/initcontainer1: unconfined
+  name: apparmorprofile1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.22/pass/apparmorprofile0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.22/pass/apparmorprofile0.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    container.apparmor.security.beta.kubernetes.io/container1: localhost/foo
+  name: apparmorprofile0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.3/fail/apparmorprofile0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.3/fail/apparmorprofile0.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    container.apparmor.security.beta.kubernetes.io/container1: unconfined
+  name: apparmorprofile0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.3/fail/apparmorprofile1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.3/fail/apparmorprofile1.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    container.apparmor.security.beta.kubernetes.io/initcontainer1: unconfined
+  name: apparmorprofile1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.3/pass/apparmorprofile0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.3/pass/apparmorprofile0.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    container.apparmor.security.beta.kubernetes.io/container1: localhost/foo
+  name: apparmorprofile0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.4/fail/apparmorprofile0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.4/fail/apparmorprofile0.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    container.apparmor.security.beta.kubernetes.io/container1: unconfined
+  name: apparmorprofile0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.4/fail/apparmorprofile1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.4/fail/apparmorprofile1.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    container.apparmor.security.beta.kubernetes.io/initcontainer1: unconfined
+  name: apparmorprofile1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.4/pass/apparmorprofile0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.4/pass/apparmorprofile0.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    container.apparmor.security.beta.kubernetes.io/container1: localhost/foo
+  name: apparmorprofile0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.5/fail/apparmorprofile0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.5/fail/apparmorprofile0.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    container.apparmor.security.beta.kubernetes.io/container1: unconfined
+  name: apparmorprofile0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.5/fail/apparmorprofile1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.5/fail/apparmorprofile1.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    container.apparmor.security.beta.kubernetes.io/initcontainer1: unconfined
+  name: apparmorprofile1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.5/pass/apparmorprofile0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.5/pass/apparmorprofile0.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    container.apparmor.security.beta.kubernetes.io/container1: localhost/foo
+  name: apparmorprofile0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.6/fail/apparmorprofile0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.6/fail/apparmorprofile0.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    container.apparmor.security.beta.kubernetes.io/container1: unconfined
+  name: apparmorprofile0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.6/fail/apparmorprofile1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.6/fail/apparmorprofile1.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    container.apparmor.security.beta.kubernetes.io/initcontainer1: unconfined
+  name: apparmorprofile1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.6/pass/apparmorprofile0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.6/pass/apparmorprofile0.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    container.apparmor.security.beta.kubernetes.io/container1: localhost/foo
+  name: apparmorprofile0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.7/fail/apparmorprofile0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.7/fail/apparmorprofile0.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    container.apparmor.security.beta.kubernetes.io/container1: unconfined
+  name: apparmorprofile0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.7/fail/apparmorprofile1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.7/fail/apparmorprofile1.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    container.apparmor.security.beta.kubernetes.io/initcontainer1: unconfined
+  name: apparmorprofile1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.7/pass/apparmorprofile0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.7/pass/apparmorprofile0.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    container.apparmor.security.beta.kubernetes.io/container1: localhost/foo
+  name: apparmorprofile0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.8/fail/apparmorprofile0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.8/fail/apparmorprofile0.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    container.apparmor.security.beta.kubernetes.io/container1: unconfined
+  name: apparmorprofile0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.8/fail/apparmorprofile1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.8/fail/apparmorprofile1.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    container.apparmor.security.beta.kubernetes.io/initcontainer1: unconfined
+  name: apparmorprofile1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.8/pass/apparmorprofile0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.8/pass/apparmorprofile0.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    container.apparmor.security.beta.kubernetes.io/container1: localhost/foo
+  name: apparmorprofile0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.9/fail/apparmorprofile0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.9/fail/apparmorprofile0.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    container.apparmor.security.beta.kubernetes.io/container1: unconfined
+  name: apparmorprofile0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.9/fail/apparmorprofile1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.9/fail/apparmorprofile1.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    container.apparmor.security.beta.kubernetes.io/initcontainer1: unconfined
+  name: apparmorprofile1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.9/pass/apparmorprofile0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.9/pass/apparmorprofile0.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    container.apparmor.security.beta.kubernetes.io/container1: localhost/foo
+  name: apparmorprofile0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+  securityContext:
+    runAsNonRoot: true


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Implement the "AppArmor" check from https://kubernetes.io/docs/concepts/security/pod-security-standards/#baseline
- Disallows `containers` and `initContainers` with `uncofined` AppArmor annotation

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes/kubernetes/issues/103200

#### Special notes for your reviewer:
NONE
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- [KEP]: https://github.com/kubernetes/enhancements/tree/master/keps/sig-auth/2579-psp-replacement
```
