### PR TITLE
A collection of Service REST cleanups

### DIFF
--- a/pkg/api/endpoints/testing/make.go
+++ b/pkg/api/endpoints/testing/make.go
@@ -1,0 +1,70 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testing
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	api "k8s.io/kubernetes/pkg/apis/core"
+)
+
+// Tweak is a function that modifies a Endpoints.
+type Tweak func(*api.Endpoints)
+
+// MakeEndpoints helps construct Endpoints objects (which pass API validation)
+// more legibly and tersely than a Go struct definition.
+func MakeEndpoints(name string, addrs []api.EndpointAddress, ports []api.EndpointPort, tweaks ...Tweak) *api.Endpoints {
+	// NOTE: Any field that would be populated by defaulting needs to be
+	// present and valid here.
+	eps := &api.Endpoints{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: metav1.NamespaceDefault,
+		},
+		Subsets: []api.EndpointSubset{{
+			Addresses: addrs,
+			Ports:     ports,
+		}},
+	}
+
+	for _, tweak := range tweaks {
+		tweak(eps)
+	}
+
+	return eps
+}
+
+// MakeEndpointAddress helps construct EndpointAddress objects which pass API
+// validation.
+func MakeEndpointAddress(ip string, pod string) api.EndpointAddress {
+	return api.EndpointAddress{
+		IP: ip,
+		TargetRef: &api.ObjectReference{
+			Name:      pod,
+			Namespace: metav1.NamespaceDefault,
+		},
+	}
+}
+
+// MakeEndpointPort helps construct EndpointPort objects which pass API
+// validation.
+func MakeEndpointPort(name string, port int) api.EndpointPort {
+	return api.EndpointPort{
+		Name: name,
+		Port: int32(port),
+	}
+}

--- a/pkg/api/service/testing/make.go
+++ b/pkg/api/service/testing/make.go
@@ -1,0 +1,141 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testing
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+
+	api "k8s.io/kubernetes/pkg/apis/core"
+)
+
+// Tweak is a function that modifies a Service.
+type Tweak func(*api.Service)
+
+// MakeService helps construct Service objects (which pass API validation) more
+// legibly and tersely than a Go struct definition.  By default this produces
+// a ClusterIP service with a single port and a trivial selector.  The caller
+// can pass any number of tweak functions to further modify the result.
+func MakeService(name string, tweaks ...Tweak) *api.Service {
+	// NOTE: Any field that would be populated by defaulting needs to be
+	// present and valid here.
+	svc := &api.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: metav1.NamespaceDefault,
+		},
+		Spec: api.ServiceSpec{
+			Selector:        map[string]string{"k": "v"},
+			SessionAffinity: api.ServiceAffinityNone,
+		},
+	}
+	// Default to ClusterIP
+	SetTypeClusterIP(svc)
+	// Default to 1 port
+	SetPorts(MakeServicePort("", 93, intstr.FromInt(76), api.ProtocolTCP))(svc)
+
+	for _, tweak := range tweaks {
+		tweak(svc)
+	}
+
+	return svc
+}
+
+// SetTypeClusterIP sets the service type to ClusterIP and clears other fields.
+func SetTypeClusterIP(svc *api.Service) {
+	svc.Spec.Type = api.ServiceTypeClusterIP
+	for i := range svc.Spec.Ports {
+		svc.Spec.Ports[i].NodePort = 0
+	}
+	svc.Spec.ExternalName = ""
+}
+
+// SetTypeNodePort sets the service type to NodePort and clears other fields.
+func SetTypeNodePort(svc *api.Service) {
+	svc.Spec.Type = api.ServiceTypeNodePort
+	svc.Spec.ExternalTrafficPolicy = api.ServiceExternalTrafficPolicyTypeCluster
+	svc.Spec.ExternalName = ""
+}
+
+// SetTypeLoadBalancer sets the service type to LoadBalancer and clears other fields.
+func SetTypeLoadBalancer(svc *api.Service) {
+	svc.Spec.Type = api.ServiceTypeLoadBalancer
+	svc.Spec.ExternalTrafficPolicy = api.ServiceExternalTrafficPolicyTypeCluster
+	svc.Spec.ExternalName = ""
+}
+
+// SetTypeExternalName sets the service type to ExternalName and clears other fields.
+func SetTypeExternalName(svc *api.Service) {
+	svc.Spec.Type = api.ServiceTypeExternalName
+	svc.Spec.ExternalName = "example.com"
+	svc.Spec.ExternalTrafficPolicy = ""
+	svc.Spec.ClusterIP = ""
+	svc.Spec.ClusterIPs = nil
+}
+
+// SetPorts sets the service ports list.
+func SetPorts(ports ...api.ServicePort) Tweak {
+	return func(svc *api.Service) {
+		svc.Spec.Ports = ports
+	}
+}
+
+// MakeServicePort helps construct ServicePort objects which pass API
+// validation.
+func MakeServicePort(name string, port int, tgtPort intstr.IntOrString, proto api.Protocol) api.ServicePort {
+	return api.ServicePort{
+		Name:       name,
+		Port:       int32(port),
+		TargetPort: tgtPort,
+		Protocol:   proto,
+	}
+}
+
+// SetClusterIPs sets the service ClusterIP and ClusterIPs fields.
+func SetClusterIPs(ips ...string) Tweak {
+	return func(svc *api.Service) {
+		svc.Spec.ClusterIP = ips[0]
+		svc.Spec.ClusterIPs = ips
+	}
+}
+
+// SetIPFamilies sets the service IPFamilies field.
+func SetIPFamilies(families ...api.IPFamily) Tweak {
+	return func(svc *api.Service) {
+		svc.Spec.IPFamilies = families
+	}
+}
+
+// SetIPFamilyPolicy sets the service IPFamilyPolicy field.
+func SetIPFamilyPolicy(policy api.IPFamilyPolicyType) Tweak {
+	return func(svc *api.Service) {
+		svc.Spec.IPFamilyPolicy = &policy
+	}
+}
+
+// SetNodePorts sets the values for each node port, in order.  If less values
+// are specified than there are ports, the rest are untouched.
+func SetNodePorts(values ...int) Tweak {
+	return func(svc *api.Service) {
+		for i := range svc.Spec.Ports {
+			if i >= len(values) {
+				break
+			}
+			svc.Spec.Ports[i].NodePort = int32(values[i])
+		}
+	}
+}

--- a/pkg/api/service/testing/make.go
+++ b/pkg/api/service/testing/make.go
@@ -62,6 +62,7 @@ func SetTypeClusterIP(svc *api.Service) {
 		svc.Spec.Ports[i].NodePort = 0
 	}
 	svc.Spec.ExternalName = ""
+	svc.Spec.ExternalTrafficPolicy = ""
 }
 
 // SetTypeNodePort sets the service type to NodePort and clears other fields.

--- a/pkg/registry/core/service/ipallocator/allocator.go
+++ b/pkg/registry/core/service/ipallocator/allocator.go
@@ -36,8 +36,6 @@ type Interface interface {
 	ForEach(func(net.IP))
 	CIDR() net.IPNet
 	IPFamily() api.IPFamily
-
-	// For testing
 	Has(ip net.IP) bool
 }
 

--- a/pkg/registry/core/service/ipallocator/allocator.go
+++ b/pkg/registry/core/service/ipallocator/allocator.go
@@ -35,6 +35,7 @@ type Interface interface {
 	Release(net.IP) error
 	ForEach(func(net.IP))
 	CIDR() net.IPNet
+	IPFamily() api.IPFamily
 
 	// For testing
 	Has(ip net.IP) bool
@@ -76,6 +77,8 @@ type Range struct {
 	base *big.Int
 	// max is the maximum size of the usable addresses in the range
 	max int
+	// family is the IP family of this range
+	family api.IPFamily
 
 	alloc allocator.Interface
 }
@@ -85,13 +88,16 @@ func NewAllocatorCIDRRange(cidr *net.IPNet, allocatorFactory allocator.Allocator
 	max := utilnet.RangeSize(cidr)
 	base := utilnet.BigForIP(cidr.IP)
 	rangeSpec := cidr.String()
+	var family api.IPFamily
 
 	if utilnet.IsIPv6CIDR(cidr) {
+		family = api.IPv6Protocol
 		// Limit the max size, since the allocator keeps a bitmap of that size.
 		if max > 65536 {
 			max = 65536
 		}
 	} else {
+		family = api.IPv4Protocol
 		// Don't use the IPv4 network's broadcast address.
 		max--
 	}
@@ -101,9 +107,10 @@ func NewAllocatorCIDRRange(cidr *net.IPNet, allocatorFactory allocator.Allocator
 	max--
 
 	r := Range{
-		net:  cidr,
-		base: base,
-		max:  maximum(0, int(max)),
+		net:    cidr,
+		base:   base,
+		max:    maximum(0, int(max)),
+		family: family,
 	}
 	var err error
 	r.alloc, err = allocatorFactory(r.max, rangeSpec)
@@ -217,6 +224,11 @@ func (r *Range) Has(ip net.IP) bool {
 	}
 
 	return r.alloc.Has(offset)
+}
+
+// IPFamily returns the IP family of this range.
+func (r *Range) IPFamily() api.IPFamily {
+	return r.family
 }
 
 // Snapshot saves the current state of the pool.

--- a/pkg/registry/core/service/ipallocator/allocator_test.go
+++ b/pkg/registry/core/service/ipallocator/allocator_test.go
@@ -28,6 +28,7 @@ func TestAllocate(t *testing.T) {
 	testCases := []struct {
 		name             string
 		cidr             string
+		family           api.IPFamily
 		free             int
 		released         string
 		outOfRange       []string
@@ -36,6 +37,7 @@ func TestAllocate(t *testing.T) {
 		{
 			name:     "IPv4",
 			cidr:     "192.168.1.0/24",
+			family:   api.IPv4Protocol,
 			free:     254,
 			released: "192.168.1.5",
 			outOfRange: []string{
@@ -49,6 +51,7 @@ func TestAllocate(t *testing.T) {
 		{
 			name:     "IPv6",
 			cidr:     "2001:db8:1::/48",
+			family:   api.IPv6Protocol,
 			free:     65535,
 			released: "2001:db8:1::5",
 			outOfRange: []string{
@@ -77,6 +80,10 @@ func TestAllocate(t *testing.T) {
 		rCIDR := r.CIDR()
 		if rCIDR.String() != tc.cidr {
 			t.Errorf("allocator returned a different cidr")
+		}
+
+		if r.IPFamily() != tc.family {
+			t.Errorf("allocator returned wrong IP family")
 		}
 
 		if f := r.Used(); f != 0 {

--- a/pkg/registry/core/service/portallocator/allocator.go
+++ b/pkg/registry/core/service/portallocator/allocator.go
@@ -34,8 +34,6 @@ type Interface interface {
 	AllocateNext() (int, error)
 	Release(int) error
 	ForEach(func(int))
-
-	// For testing
 	Has(int) bool
 }
 

--- a/pkg/registry/core/service/storage/rest.go
+++ b/pkg/registry/core/service/storage/rest.go
@@ -612,7 +612,7 @@ func (rs *REST) allocClusterIPs(service *api.Service, toAlloc map[api.IPFamily]s
 		} else {
 			parsedIP := net.ParseIP(ip)
 			if err := allocator.Allocate(parsedIP); err != nil {
-				el := field.ErrorList{field.Invalid(field.NewPath("spec", "clusterIPs"), service.Spec.ClusterIPs, fmt.Sprintf("failed to allocated ip:%v with error:%v", ip, err))}
+				el := field.ErrorList{field.Invalid(field.NewPath("spec", "clusterIPs"), service.Spec.ClusterIPs, fmt.Sprintf("failed to allocate IP %v: %v", ip, err))}
 				return allocated, errors.NewInvalid(api.Kind("Service"), service.Name, el)
 			}
 			allocated[family] = ip

--- a/pkg/registry/core/service/storage/rest_test.go
+++ b/pkg/registry/core/service/storage/rest_test.go
@@ -1169,26 +1169,6 @@ func TestAllocateLoadBalancerNodePorts(t *testing.T) {
 		expectError          bool
 	}{
 		{
-			name: "allocate nil, gate on",
-			svc: &api.Service{
-				ObjectMeta: metav1.ObjectMeta{Name: "alloc-nil"},
-				Spec: api.ServiceSpec{
-					AllocateLoadBalancerNodePorts: nil,
-					Selector:                      map[string]string{"bar": "baz"},
-					SessionAffinity:               api.ServiceAffinityNone,
-					Type:                          api.ServiceTypeLoadBalancer,
-					Ports: []api.ServicePort{{
-						Port:       6502,
-						Protocol:   api.ProtocolTCP,
-						TargetPort: intstr.FromInt(6502),
-					}},
-				},
-			},
-			expectNodePorts:      true,
-			allocateNodePortGate: true,
-			expectError:          true,
-		},
-		{
 			name: "allocate false, gate on",
 			svc: &api.Service{
 				ObjectMeta: metav1.ObjectMeta{Name: "alloc-false"},

--- a/pkg/registry/core/service/storage/rest_test.go
+++ b/pkg/registry/core/service/storage/rest_test.go
@@ -54,10 +54,6 @@ import (
 	"sigs.k8s.io/structured-merge-diff/v4/fieldpath"
 )
 
-var (
-	singleStackIPv4 = []api.IPFamily{api.IPv4Protocol}
-)
-
 // TODO(wojtek-t): Cleanup this file.
 // It is now testing mostly the same things as other resources but
 // in a completely different way. We should unify it.
@@ -417,7 +413,7 @@ func TestServiceRegistryCreateDryRun(t *testing.T) {
 }
 
 func TestDryRunNodePort(t *testing.T) {
-	storage, server := NewTestREST(t, singleStackIPv4)
+	storage, server := NewTestREST(t, []api.IPFamily{api.IPv4Protocol})
 	defer server.Terminate(t)
 
 	// Test dry run create request with a node port
@@ -496,7 +492,7 @@ func TestDryRunNodePort(t *testing.T) {
 }
 
 func TestServiceRegistryCreateMultiNodePortsService(t *testing.T) {
-	storage, server := NewTestREST(t, singleStackIPv4)
+	storage, server := NewTestREST(t, []api.IPFamily{api.IPv4Protocol})
 	defer server.Terminate(t)
 
 	testCases := []struct {
@@ -569,7 +565,7 @@ func TestServiceRegistryCreateMultiNodePortsService(t *testing.T) {
 }
 
 func TestServiceStorageValidatesCreate(t *testing.T) {
-	storage, server := NewTestREST(t, singleStackIPv4)
+	storage, server := NewTestREST(t, []api.IPFamily{api.IPv4Protocol})
 	defer server.Terminate(t)
 	failureCases := map[string]*api.Service{
 		"empty ID": svctest.MakeService(""),
@@ -627,7 +623,7 @@ func TestServiceRegistryUpdate(t *testing.T) {
 
 func TestServiceRegistryUpdateDryRun(t *testing.T) {
 	ctx := genericapirequest.NewDefaultContext()
-	storage, server := NewTestREST(t, singleStackIPv4)
+	storage, server := NewTestREST(t, []api.IPFamily{api.IPv4Protocol})
 	defer server.Terminate(t)
 
 	obj, err := storage.Create(ctx, svctest.MakeService("foo", svctest.SetTypeExternalName), rest.ValidateAllObjectFunc, &metav1.CreateOptions{})
@@ -711,7 +707,7 @@ func TestServiceRegistryUpdateDryRun(t *testing.T) {
 
 func TestServiceStorageValidatesUpdate(t *testing.T) {
 	ctx := genericapirequest.NewDefaultContext()
-	storage, server := NewTestREST(t, singleStackIPv4)
+	storage, server := NewTestREST(t, []api.IPFamily{api.IPv4Protocol})
 	defer server.Terminate(t)
 	_, err := storage.Create(ctx, svctest.MakeService("foo"), rest.ValidateAllObjectFunc, &metav1.CreateOptions{})
 	if err != nil {
@@ -736,7 +732,7 @@ func TestServiceStorageValidatesUpdate(t *testing.T) {
 
 func TestServiceRegistryExternalService(t *testing.T) {
 	ctx := genericapirequest.NewDefaultContext()
-	storage, server := NewTestREST(t, singleStackIPv4)
+	storage, server := NewTestREST(t, []api.IPFamily{api.IPv4Protocol})
 	defer server.Terminate(t)
 	svc := svctest.MakeService("foo", svctest.SetTypeLoadBalancer)
 	_, err := storage.Create(ctx, svc, rest.ValidateAllObjectFunc, &metav1.CreateOptions{})
@@ -805,7 +801,7 @@ func TestAllocateLoadBalancerNodePorts(t *testing.T) {
 			ctx := genericapirequest.NewDefaultContext()
 			defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.ServiceLBNodePortControl, tc.allocateNodePortGate)()
 
-			storage, server := NewTestREST(t, singleStackIPv4)
+			storage, server := NewTestREST(t, []api.IPFamily{api.IPv4Protocol})
 			defer server.Terminate(t)
 
 			_, err := storage.Create(ctx, tc.svc, rest.ValidateAllObjectFunc, &metav1.CreateOptions{})
@@ -838,7 +834,7 @@ func TestAllocateLoadBalancerNodePorts(t *testing.T) {
 
 func TestServiceRegistryDelete(t *testing.T) {
 	ctx := genericapirequest.NewDefaultContext()
-	storage, server := NewTestREST(t, singleStackIPv4)
+	storage, server := NewTestREST(t, []api.IPFamily{api.IPv4Protocol})
 	defer server.Terminate(t)
 	svc := svctest.MakeService("foo")
 	_, err := storage.Create(ctx, svc, rest.ValidateAllObjectFunc, &metav1.CreateOptions{})
@@ -853,7 +849,7 @@ func TestServiceRegistryDelete(t *testing.T) {
 
 func TestServiceRegistryDeleteDryRun(t *testing.T) {
 	ctx := genericapirequest.NewDefaultContext()
-	storage, server := NewTestREST(t, singleStackIPv4)
+	storage, server := NewTestREST(t, []api.IPFamily{api.IPv4Protocol})
 	defer server.Terminate(t)
 
 	// Test dry run delete request with cluster ip
@@ -933,7 +929,7 @@ func TestDualStackServiceRegistryDeleteDryRun(t *testing.T) {
 
 func TestServiceRegistryDeleteExternal(t *testing.T) {
 	ctx := genericapirequest.NewDefaultContext()
-	storage, server := NewTestREST(t, singleStackIPv4)
+	storage, server := NewTestREST(t, []api.IPFamily{api.IPv4Protocol})
 	defer server.Terminate(t)
 	svc := svctest.MakeService("foo", svctest.SetTypeExternalName)
 	_, err := storage.Create(ctx, svc, rest.ValidateAllObjectFunc, &metav1.CreateOptions{})
@@ -948,7 +944,7 @@ func TestServiceRegistryDeleteExternal(t *testing.T) {
 
 func TestServiceRegistryUpdateExternalService(t *testing.T) {
 	ctx := genericapirequest.NewDefaultContext()
-	storage, server := NewTestREST(t, singleStackIPv4)
+	storage, server := NewTestREST(t, []api.IPFamily{api.IPv4Protocol})
 	defer server.Terminate(t)
 
 	// Create non-external load balancer.
@@ -976,7 +972,7 @@ func TestServiceRegistryUpdateExternalService(t *testing.T) {
 
 func TestServiceRegistryUpdateMultiPortExternalService(t *testing.T) {
 	ctx := genericapirequest.NewDefaultContext()
-	storage, server := NewTestREST(t, singleStackIPv4)
+	storage, server := NewTestREST(t, []api.IPFamily{api.IPv4Protocol})
 	defer server.Terminate(t)
 
 	// Create external load balancer.
@@ -1001,7 +997,7 @@ func TestServiceRegistryUpdateMultiPortExternalService(t *testing.T) {
 
 func TestServiceRegistryGet(t *testing.T) {
 	ctx := genericapirequest.NewDefaultContext()
-	storage, server := NewTestREST(t, singleStackIPv4)
+	storage, server := NewTestREST(t, []api.IPFamily{api.IPv4Protocol})
 	defer server.Terminate(t)
 	_, err := storage.Create(ctx, svctest.MakeService("foo"), rest.ValidateAllObjectFunc, &metav1.CreateOptions{})
 	if err != nil {
@@ -1071,7 +1067,7 @@ func TestServiceRegistryResourceLocation(t *testing.T) {
 		epstest.MakeEndpoints("no-endpoints", nil, nil), // to prove this does not get chosen
 	}
 
-	storage, server := NewTestRESTWithPods(t, endpoints, pods, singleStackIPv4)
+	storage, server := NewTestRESTWithPods(t, endpoints, pods, []api.IPFamily{api.IPv4Protocol})
 	defer server.Terminate(t)
 
 	ctx := genericapirequest.NewDefaultContext()
@@ -1171,7 +1167,7 @@ func TestServiceRegistryResourceLocation(t *testing.T) {
 
 func TestServiceRegistryList(t *testing.T) {
 	ctx := genericapirequest.NewDefaultContext()
-	storage, server := NewTestREST(t, singleStackIPv4)
+	storage, server := NewTestREST(t, []api.IPFamily{api.IPv4Protocol})
 	defer server.Terminate(t)
 	_, err := storage.Create(ctx, svctest.MakeService("foo"), rest.ValidateAllObjectFunc, &metav1.CreateOptions{})
 	if err != nil {
@@ -1195,7 +1191,7 @@ func TestServiceRegistryList(t *testing.T) {
 }
 
 func TestServiceRegistryIPAllocation(t *testing.T) {
-	storage, server := NewTestREST(t, singleStackIPv4)
+	storage, server := NewTestREST(t, []api.IPFamily{api.IPv4Protocol})
 	defer server.Terminate(t)
 
 	svc1 := svctest.MakeService("foo")
@@ -1248,7 +1244,7 @@ func TestServiceRegistryIPAllocation(t *testing.T) {
 }
 
 func TestServiceRegistryIPReallocation(t *testing.T) {
-	storage, server := NewTestREST(t, singleStackIPv4)
+	storage, server := NewTestREST(t, []api.IPFamily{api.IPv4Protocol})
 	defer server.Terminate(t)
 
 	svc1 := svctest.MakeService("foo")
@@ -1286,7 +1282,7 @@ func TestServiceRegistryIPReallocation(t *testing.T) {
 }
 
 func TestServiceRegistryIPUpdate(t *testing.T) {
-	storage, server := NewTestREST(t, singleStackIPv4)
+	storage, server := NewTestREST(t, []api.IPFamily{api.IPv4Protocol})
 	defer server.Terminate(t)
 
 	svc := svctest.MakeService("foo")
@@ -1336,7 +1332,7 @@ func TestServiceRegistryIPUpdate(t *testing.T) {
 }
 
 func TestServiceRegistryIPLoadBalancer(t *testing.T) {
-	storage, server := NewTestREST(t, singleStackIPv4)
+	storage, server := NewTestREST(t, []api.IPFamily{api.IPv4Protocol})
 	defer server.Terminate(t)
 
 	svc := svctest.MakeService("foo", svctest.SetTypeLoadBalancer)
@@ -1367,7 +1363,7 @@ func TestServiceRegistryIPLoadBalancer(t *testing.T) {
 // and type is LoadBalancer.
 func TestServiceRegistryExternalTrafficHealthCheckNodePortAllocation(t *testing.T) {
 	ctx := genericapirequest.NewDefaultContext()
-	storage, server := NewTestREST(t, singleStackIPv4)
+	storage, server := NewTestREST(t, []api.IPFamily{api.IPv4Protocol})
 	defer server.Terminate(t)
 	svc := svctest.MakeService("external-lb-esipp", svctest.SetTypeLoadBalancer, func(s *api.Service) {
 		s.Spec.ExternalTrafficPolicy = api.ServiceExternalTrafficPolicyTypeLocal
@@ -1395,7 +1391,7 @@ func TestServiceRegistryExternalTrafficHealthCheckNodePortAllocation(t *testing.
 // and type is LoadBalancer.
 func TestServiceRegistryExternalTrafficHealthCheckNodePortUserAllocation(t *testing.T) {
 	ctx := genericapirequest.NewDefaultContext()
-	storage, server := NewTestREST(t, singleStackIPv4)
+	storage, server := NewTestREST(t, []api.IPFamily{api.IPv4Protocol})
 	defer server.Terminate(t)
 	svc := svctest.MakeService("external-lb-esipp", svctest.SetTypeLoadBalancer, func(s *api.Service) {
 		// hard-code NodePort to make sure it doesn't conflict with the healthport.
@@ -1430,7 +1426,7 @@ func TestServiceRegistryExternalTrafficHealthCheckNodePortUserAllocation(t *test
 // Validate that the service creation fails when the requested port number is -1.
 func TestServiceRegistryExternalTrafficHealthCheckNodePortNegative(t *testing.T) {
 	ctx := genericapirequest.NewDefaultContext()
-	storage, server := NewTestREST(t, singleStackIPv4)
+	storage, server := NewTestREST(t, []api.IPFamily{api.IPv4Protocol})
 	defer server.Terminate(t)
 	svc := svctest.MakeService("external-lb-esipp", svctest.SetTypeLoadBalancer, func(s *api.Service) {
 		s.Spec.ExternalTrafficPolicy = api.ServiceExternalTrafficPolicyTypeLocal
@@ -1446,7 +1442,7 @@ func TestServiceRegistryExternalTrafficHealthCheckNodePortNegative(t *testing.T)
 // Validate that the health check nodePort is not allocated when ExternalTrafficPolicy is set to Global.
 func TestServiceRegistryExternalTrafficGlobal(t *testing.T) {
 	ctx := genericapirequest.NewDefaultContext()
-	storage, server := NewTestREST(t, singleStackIPv4)
+	storage, server := NewTestREST(t, []api.IPFamily{api.IPv4Protocol})
 	defer server.Terminate(t)
 	svc := svctest.MakeService("external-lb-esipp", svctest.SetTypeLoadBalancer, func(s *api.Service) {
 		s.Spec.ExternalTrafficPolicy = api.ServiceExternalTrafficPolicyTypeCluster
@@ -1798,7 +1794,7 @@ func TestInitNodePorts(t *testing.T) {
 }
 
 func TestUpdateNodePorts(t *testing.T) {
-	storage, server := NewTestREST(t, singleStackIPv4)
+	storage, server := NewTestREST(t, []api.IPFamily{api.IPv4Protocol})
 	defer server.Terminate(t)
 	nodePortOp := portallocator.StartOperation(storage.serviceNodePorts, false)
 	defer nodePortOp.Finish()

--- a/pkg/registry/core/service/storage/rest_test.go
+++ b/pkg/registry/core/service/storage/rest_test.go
@@ -38,6 +38,7 @@ import (
 	"k8s.io/apiserver/pkg/util/dryrun"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	featuregatetesting "k8s.io/component-base/featuregate/testing"
+	epstest "k8s.io/kubernetes/pkg/api/endpoints/testing"
 	"k8s.io/kubernetes/pkg/api/service"
 	svctest "k8s.io/kubernetes/pkg/api/service/testing"
 	api "k8s.io/kubernetes/pkg/apis/core"
@@ -1019,36 +1020,7 @@ func TestServiceRegistryGet(t *testing.T) {
 	}
 }
 
-func makeEndpoints(name string, addrs []api.EndpointAddress, ports []api.EndpointPort) *api.Endpoints {
-	return &api.Endpoints{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: metav1.NamespaceDefault,
-		},
-		Subsets: []api.EndpointSubset{{
-			Addresses: addrs,
-			Ports:     ports,
-		}},
-	}
-}
-
-func makeEndpointAddress(ip string, pod string) api.EndpointAddress {
-	return api.EndpointAddress{
-		IP: ip,
-		TargetRef: &api.ObjectReference{
-			Name:      pod,
-			Namespace: metav1.NamespaceDefault,
-		},
-	}
-}
-
-func makeEndpointPort(name string, port int) api.EndpointPort {
-	return api.EndpointPort{
-		Name: name,
-		Port: int32(port),
-	}
-}
-
+// this is local because it's not fully fleshed out enough for general use.
 func makePod(name string, ips ...string) api.Pod {
 	p := api.Pod{
 		ObjectMeta: metav1.ObjectMeta{
@@ -1080,29 +1052,29 @@ func TestServiceRegistryResourceLocation(t *testing.T) {
 	}
 
 	endpoints := []*api.Endpoints{
-		makeEndpoints("unnamed",
+		epstest.MakeEndpoints("unnamed",
 			[]api.EndpointAddress{
-				makeEndpointAddress("1.2.3.4", "unnamed"),
+				epstest.MakeEndpointAddress("1.2.3.4", "unnamed"),
 			},
 			[]api.EndpointPort{
-				makeEndpointPort("", 80),
+				epstest.MakeEndpointPort("", 80),
 			}),
-		makeEndpoints("unnamed2",
+		epstest.MakeEndpoints("unnamed2",
 			[]api.EndpointAddress{
-				makeEndpointAddress("1.2.3.5", "unnamed"),
+				epstest.MakeEndpointAddress("1.2.3.5", "unnamed"),
 			},
 			[]api.EndpointPort{
-				makeEndpointPort("", 80),
+				epstest.MakeEndpointPort("", 80),
 			}),
-		makeEndpoints("named",
+		epstest.MakeEndpoints("named",
 			[]api.EndpointAddress{
-				makeEndpointAddress("1.2.3.6", "named"),
+				epstest.MakeEndpointAddress("1.2.3.6", "named"),
 			},
 			[]api.EndpointPort{
-				makeEndpointPort("p", 80),
-				makeEndpointPort("q", 81),
+				epstest.MakeEndpointPort("p", 80),
+				epstest.MakeEndpointPort("q", 81),
 			}),
-		makeEndpoints("no-endpoints", nil, nil), // to prove this does not get chosen
+		epstest.MakeEndpoints("no-endpoints", nil, nil), // to prove this does not get chosen
 	}
 
 	storage, _, server := NewTestRESTWithPods(t, endpoints, pods, singleStackIPv4)

--- a/pkg/registry/core/service/storage/rest_test.go
+++ b/pkg/registry/core/service/storage/rest_test.go
@@ -63,16 +63,12 @@ var (
 // in a completely different way. We should unify it.
 
 type serviceStorage struct {
-	GottenID           string
-	UpdatedID          string
-	CreatedID          string
-	DeletedID          string
-	Created            bool
-	DeletedImmediately bool
-	Service            *api.Service
-	OldService         *api.Service
-	ServiceList        *api.ServiceList
-	Err                error
+	GottenID    string
+	UpdatedID   string
+	CreatedID   string
+	DeletedID   string
+	Service     *api.Service
+	ServiceList *api.ServiceList
 }
 
 func (s *serviceStorage) NamespaceScoped() bool {
@@ -81,11 +77,11 @@ func (s *serviceStorage) NamespaceScoped() bool {
 
 func (s *serviceStorage) Get(ctx context.Context, name string, options *metav1.GetOptions) (runtime.Object, error) {
 	s.GottenID = name
-	return s.Service, s.Err
+	return s.Service, nil
 }
 
 func (s *serviceStorage) GetService(ctx context.Context, name string, options *metav1.GetOptions) (*api.Service, error) {
-	return s.Service, s.Err
+	return s.Service, nil
 }
 
 func (s *serviceStorage) NewList() runtime.Object {
@@ -110,7 +106,7 @@ func (s *serviceStorage) List(ctx context.Context, options *metainternalversion.
 		res.Items = append([]api.Service{}, s.ServiceList.Items...)
 	}
 
-	return res, s.Err
+	return res, nil
 }
 
 func (s *serviceStorage) New() runtime.Object {
@@ -119,7 +115,7 @@ func (s *serviceStorage) New() runtime.Object {
 
 func (s *serviceStorage) Create(ctx context.Context, obj runtime.Object, createValidation rest.ValidateObjectFunc, options *metav1.CreateOptions) (runtime.Object, error) {
 	if dryrun.IsDryRun(options.DryRun) {
-		return obj, s.Err
+		return obj, nil
 	}
 	svc := obj.(*api.Service)
 	s.CreatedID = obj.(metav1.Object).GetName()
@@ -130,11 +126,11 @@ func (s *serviceStorage) Create(ctx context.Context, obj runtime.Object, createV
 	}
 
 	s.ServiceList.Items = append(s.ServiceList.Items, *svc)
-	return svc, s.Err
+	return svc, nil
 }
 
 func (s *serviceStorage) Update(ctx context.Context, name string, objInfo rest.UpdatedObjectInfo, createValidation rest.ValidateObjectFunc, updateValidation rest.ValidateObjectUpdateFunc, forceAllowCreate bool, options *metav1.UpdateOptions) (runtime.Object, bool, error) {
-	obj, err := objInfo.UpdatedObject(ctx, s.OldService)
+	obj, err := objInfo.UpdatedObject(ctx, nil)
 	if err != nil {
 		return nil, false, err
 	}
@@ -142,14 +138,14 @@ func (s *serviceStorage) Update(ctx context.Context, name string, objInfo rest.U
 		s.UpdatedID = name
 		s.Service = obj.(*api.Service)
 	}
-	return obj, s.Created, s.Err
+	return obj, false, nil
 }
 
 func (s *serviceStorage) Delete(ctx context.Context, name string, deleteValidation rest.ValidateObjectFunc, options *metav1.DeleteOptions) (runtime.Object, bool, error) {
 	if !dryrun.IsDryRun(options.DryRun) {
 		s.DeletedID = name
 	}
-	return s.Service, s.DeletedImmediately, s.Err
+	return s.Service, false, nil
 }
 
 func (s *serviceStorage) DeleteCollection(ctx context.Context, deleteValidation rest.ValidateObjectFunc, options *metav1.DeleteOptions, listOptions *metainternalversion.ListOptions) (runtime.Object, error) {

--- a/pkg/registry/core/service/storage/rest_test.go
+++ b/pkg/registry/core/service/storage/rest_test.go
@@ -1069,7 +1069,7 @@ func TestServiceStorageValidatesUpdate(t *testing.T) {
 	ctx := genericapirequest.NewDefaultContext()
 	storage, registry, server := NewTestREST(t, nil, singleStackIPv4)
 	defer server.Terminate(t)
-	registry.Create(ctx, &api.Service{
+	_, err := registry.Create(ctx, &api.Service{
 		ObjectMeta: metav1.ObjectMeta{Name: "foo"},
 		Spec: api.ServiceSpec{
 			Selector: map[string]string{"bar": "baz"},
@@ -1079,6 +1079,9 @@ func TestServiceStorageValidatesUpdate(t *testing.T) {
 			}},
 		},
 	}, rest.ValidateAllObjectFunc, &metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("error creating service: %v", err)
+	}
 	failureCases := map[string]api.Service{
 		"empty ID": {
 			ObjectMeta: metav1.ObjectMeta{Name: ""},
@@ -1312,7 +1315,10 @@ func TestServiceRegistryDelete(t *testing.T) {
 			}},
 		},
 	}
-	registry.Create(ctx, svc, rest.ValidateAllObjectFunc, &metav1.CreateOptions{})
+	_, err := registry.Create(ctx, svc, rest.ValidateAllObjectFunc, &metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("error creating service: %v", err)
+	}
 	storage.Delete(ctx, svc.Name, rest.ValidateAllObjectFunc, &metav1.DeleteOptions{})
 	if e, a := "foo", registry.DeletedID; e != a {
 		t.Errorf("Expected %v, but got %v", e, a)
@@ -1451,7 +1457,10 @@ func TestServiceRegistryDeleteExternal(t *testing.T) {
 			}},
 		},
 	}
-	registry.Create(ctx, svc, rest.ValidateAllObjectFunc, &metav1.CreateOptions{})
+	_, err := registry.Create(ctx, svc, rest.ValidateAllObjectFunc, &metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("error creating service: %v", err)
+	}
 	storage.Delete(ctx, svc.Name, rest.ValidateAllObjectFunc, &metav1.DeleteOptions{})
 	if e, a := "foo", registry.DeletedID; e != a {
 		t.Errorf("Expected %v, but got %v", e, a)
@@ -1539,12 +1548,15 @@ func TestServiceRegistryGet(t *testing.T) {
 	ctx := genericapirequest.NewDefaultContext()
 	storage, registry, server := NewTestREST(t, nil, singleStackIPv4)
 	defer server.Terminate(t)
-	registry.Create(ctx, &api.Service{
+	_, err := registry.Create(ctx, &api.Service{
 		ObjectMeta: metav1.ObjectMeta{Name: "foo"},
 		Spec: api.ServiceSpec{
 			Selector: map[string]string{"bar": "baz"},
 		},
 	}, rest.ValidateAllObjectFunc, &metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("error creating service: %v", err)
+	}
 	storage.Get(ctx, "foo", &metav1.GetOptions{})
 	if e, a := "foo", registry.GottenID; e != a {
 		t.Errorf("Expected %v, but got %v", e, a)
@@ -1626,7 +1638,7 @@ func TestServiceRegistryResourceLocation(t *testing.T) {
 	storage, registry, server := NewTestRESTWithPods(t, endpoints, pods, singleStackIPv4)
 	defer server.Terminate(t)
 	for _, name := range []string{"foo", "bad"} {
-		registry.Create(ctx, &api.Service{
+		_, err := registry.Create(ctx, &api.Service{
 			ObjectMeta: metav1.ObjectMeta{Name: name},
 			Spec: api.ServiceSpec{
 				Selector: map[string]string{"bar": "baz"},
@@ -1640,6 +1652,9 @@ func TestServiceRegistryResourceLocation(t *testing.T) {
 				},
 			},
 		}, rest.ValidateAllObjectFunc, &metav1.CreateOptions{})
+		if err != nil {
+			t.Fatalf("error creating service: %v", err)
+		}
 	}
 	redirector := rest.Redirector(storage)
 
@@ -1791,18 +1806,24 @@ func TestServiceRegistryList(t *testing.T) {
 	ctx := genericapirequest.NewDefaultContext()
 	storage, registry, server := NewTestREST(t, nil, singleStackIPv4)
 	defer server.Terminate(t)
-	registry.Create(ctx, &api.Service{
+	_, err := registry.Create(ctx, &api.Service{
 		ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: metav1.NamespaceDefault},
 		Spec: api.ServiceSpec{
 			Selector: map[string]string{"bar": "baz"},
 		},
 	}, rest.ValidateAllObjectFunc, &metav1.CreateOptions{})
-	registry.Create(ctx, &api.Service{
+	if err != nil {
+		t.Fatalf("error creating service: %v", err)
+	}
+	_, err = registry.Create(ctx, &api.Service{
 		ObjectMeta: metav1.ObjectMeta{Name: "foo2", Namespace: metav1.NamespaceDefault},
 		Spec: api.ServiceSpec{
 			Selector: map[string]string{"bar2": "baz2"},
 		},
 	}, rest.ValidateAllObjectFunc, &metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("error creating service: %v", err)
+	}
 	registry.ServiceList.ResourceVersion = "1"
 	s, _ := storage.List(ctx, nil)
 	sl := s.(*api.ServiceList)
@@ -1838,7 +1859,10 @@ func TestServiceRegistryIPAllocation(t *testing.T) {
 		},
 	}
 	ctx := genericapirequest.NewDefaultContext()
-	createdSvc1, _ := storage.Create(ctx, svc1, rest.ValidateAllObjectFunc, &metav1.CreateOptions{})
+	createdSvc1, err := storage.Create(ctx, svc1, rest.ValidateAllObjectFunc, &metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("error creating service: %v", err)
+	}
 	createdService1 := createdSvc1.(*api.Service)
 	if createdService1.Name != "foo" {
 		t.Errorf("Expected foo, but got %v", createdService1.Name)
@@ -1860,7 +1884,10 @@ func TestServiceRegistryIPAllocation(t *testing.T) {
 			}},
 		}}
 	ctx = genericapirequest.NewDefaultContext()
-	createdSvc2, _ := storage.Create(ctx, svc2, rest.ValidateAllObjectFunc, &metav1.CreateOptions{})
+	createdSvc2, err := storage.Create(ctx, svc2, rest.ValidateAllObjectFunc, &metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("error creating service: %v", err)
+	}
 	createdService2 := createdSvc2.(*api.Service)
 	if createdService2.Name != "bar" {
 		t.Errorf("Expected bar, but got %v", createdService2.Name)
@@ -1922,7 +1949,10 @@ func TestServiceRegistryIPReallocation(t *testing.T) {
 		},
 	}
 	ctx := genericapirequest.NewDefaultContext()
-	createdSvc1, _ := storage.Create(ctx, svc1, rest.ValidateAllObjectFunc, &metav1.CreateOptions{})
+	createdSvc1, err := storage.Create(ctx, svc1, rest.ValidateAllObjectFunc, &metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("error creating service: %v", err)
+	}
 	createdService1 := createdSvc1.(*api.Service)
 	if createdService1.Name != "foo" {
 		t.Errorf("Expected foo, but got %v", createdService1.Name)
@@ -1931,7 +1961,7 @@ func TestServiceRegistryIPReallocation(t *testing.T) {
 		t.Errorf("Unexpected ClusterIP: %s", createdService1.Spec.ClusterIPs[0])
 	}
 
-	_, _, err := storage.Delete(ctx, createdService1.Name, rest.ValidateAllObjectFunc, &metav1.DeleteOptions{})
+	_, _, err = storage.Delete(ctx, createdService1.Name, rest.ValidateAllObjectFunc, &metav1.DeleteOptions{})
 	if err != nil {
 		t.Errorf("Unexpected error deleting service: %v", err)
 	}
@@ -1950,7 +1980,10 @@ func TestServiceRegistryIPReallocation(t *testing.T) {
 		},
 	}
 	ctx = genericapirequest.NewDefaultContext()
-	createdSvc2, _ := storage.Create(ctx, svc2, rest.ValidateAllObjectFunc, &metav1.CreateOptions{})
+	createdSvc2, err := storage.Create(ctx, svc2, rest.ValidateAllObjectFunc, &metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("error creating service: %v", err)
+	}
 	createdService2 := createdSvc2.(*api.Service)
 	if createdService2.Name != "bar" {
 		t.Errorf("Expected bar, but got %v", createdService2.Name)
@@ -1978,7 +2011,10 @@ func TestServiceRegistryIPUpdate(t *testing.T) {
 		},
 	}
 	ctx := genericapirequest.NewDefaultContext()
-	createdSvc, _ := storage.Create(ctx, svc, rest.ValidateAllObjectFunc, &metav1.CreateOptions{})
+	createdSvc, err := storage.Create(ctx, svc, rest.ValidateAllObjectFunc, &metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("error creating service: %v", err)
+	}
 	createdService := createdSvc.(*api.Service)
 	if createdService.Spec.Ports[0].Port != 6502 {
 		t.Errorf("Expected port 6502, but got %v", createdService.Spec.Ports[0].Port)
@@ -2013,7 +2049,7 @@ func TestServiceRegistryIPUpdate(t *testing.T) {
 	update.Spec.ClusterIP = testIP
 	update.Spec.ClusterIPs[0] = testIP
 
-	_, _, err := storage.Update(ctx, update.Name, rest.DefaultUpdatedObjectInfo(update), rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc, false, &metav1.UpdateOptions{})
+	_, _, err = storage.Update(ctx, update.Name, rest.DefaultUpdatedObjectInfo(update), rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc, false, &metav1.UpdateOptions{})
 	if err == nil || !errors.IsInvalid(err) {
 		t.Errorf("Unexpected error type: %v", err)
 	}

--- a/pkg/registry/core/service/storage/rest_test.go
+++ b/pkg/registry/core/service/storage/rest_test.go
@@ -752,7 +752,7 @@ func TestServiceStorageValidatesUpdate(t *testing.T) {
 	}
 }
 
-func TestServiceRegistryExternalService(t *testing.T) {
+func TestServiceRegistryLoadBalancerService(t *testing.T) {
 	ctx := genericapirequest.NewDefaultContext()
 	storage, server := NewTestREST(t, []api.IPFamily{api.IPv4Protocol})
 	defer server.Terminate(t)
@@ -949,7 +949,7 @@ func TestDualStackServiceRegistryDeleteDryRun(t *testing.T) {
 	}
 }
 
-func TestServiceRegistryDeleteExternal(t *testing.T) {
+func TestServiceRegistryDeleteExternalName(t *testing.T) {
 	ctx := genericapirequest.NewDefaultContext()
 	storage, server := NewTestREST(t, []api.IPFamily{api.IPv4Protocol})
 	defer server.Terminate(t)
@@ -964,19 +964,19 @@ func TestServiceRegistryDeleteExternal(t *testing.T) {
 	}
 }
 
-func TestServiceRegistryUpdateExternalService(t *testing.T) {
+func TestServiceRegistryUpdateLoadBalancerService(t *testing.T) {
 	ctx := genericapirequest.NewDefaultContext()
 	storage, server := NewTestREST(t, []api.IPFamily{api.IPv4Protocol})
 	defer server.Terminate(t)
 
-	// Create non-external load balancer.
+	// Create non-loadbalancer.
 	svc1 := svctest.MakeService("foo")
 	obj, err := storage.Create(ctx, svc1, rest.ValidateAllObjectFunc, &metav1.CreateOptions{})
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
 
-	// Modify load balancer to be external.
+	// Modify to be loadbalancer.
 	svc2 := obj.(*api.Service).DeepCopy()
 	svc2.Spec.Type = api.ServiceTypeLoadBalancer
 	if _, _, err := storage.Update(ctx, svc2.Name, rest.DefaultUpdatedObjectInfo(svc2), rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc, false, &metav1.UpdateOptions{}); err != nil {
@@ -992,12 +992,12 @@ func TestServiceRegistryUpdateExternalService(t *testing.T) {
 	}
 }
 
-func TestServiceRegistryUpdateMultiPortExternalService(t *testing.T) {
+func TestServiceRegistryUpdateMultiPortLoadBalancerService(t *testing.T) {
 	ctx := genericapirequest.NewDefaultContext()
 	storage, server := NewTestREST(t, []api.IPFamily{api.IPv4Protocol})
 	defer server.Terminate(t)
 
-	// Create external load balancer.
+	// Create load balancer.
 	svc1 := svctest.MakeService("foo",
 		svctest.SetTypeLoadBalancer,
 		svctest.SetPorts(

--- a/pkg/registry/core/service/storage/storage.go
+++ b/pkg/registry/core/service/storage/storage.go
@@ -45,7 +45,7 @@ type GenericREST struct {
 	secondaryFamily *api.IPFamily
 }
 
-// NewREST returns a RESTStorage object that will work against services.
+// NewGenericREST returns a RESTStorage object that will work against services.
 func NewGenericREST(optsGetter generic.RESTOptionsGetter, serviceCIDR net.IPNet, hasSecondary bool) (*GenericREST, *StatusREST, error) {
 	strategy, _ := registry.StrategyForServiceCIDRs(serviceCIDR, hasSecondary)
 


### PR DESCRIPTION
This is the first part of https://github.com/kubernetes/kubernetes/pull/96684, which should all be viable for commit without the rest of the delayering.

/kind cleanup

#### What this PR does / why we need it:

Simplifies and corrects multiple issues around Service REST, making the effort to de-layer that code easier.  Some of the tests were simply wrong, but were not being caught because of how they are written.

#### Special notes for your reviewer:

I have taken great pains to make each commit about as small as possible.  Please review them commit-by-commit for max comprehension.  You probably want to disable whitespace diffs, too.

```release-note
NONE
```
