### PR TITLE
Fix incorrect user and group for kube-scheduler when it is running as non-root.

### DIFF
--- a/cmd/kubeadm/app/util/staticpod/utils_linux.go
+++ b/cmd/kubeadm/app/util/staticpod/utils_linux.go
@@ -58,8 +58,8 @@ func RunComponentAsNonRoot(componentName string, pod *v1.Pod, usersAndGroups *us
 	case kubeadmconstants.KubeScheduler:
 		return runKubeSchedulerAsNonRoot(
 			pod,
-			usersAndGroups.Users.ID(kubeadmconstants.KubeControllerManagerUserName),
-			usersAndGroups.Groups.ID(kubeadmconstants.KubeControllerManagerUserName),
+			usersAndGroups.Users.ID(kubeadmconstants.KubeSchedulerUserName),
+			usersAndGroups.Groups.ID(kubeadmconstants.KubeSchedulerUserName),
 			users.UpdatePathOwnerAndPermissions,
 		)
 	case kubeadmconstants.Etcd:


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
We were setting the incorrect uid,gid for kube-scheduler container in kubeadm when the RootlessControlPlane feature-gate is enabled. This caused kube-scheduler to run with the same id as kube-controller-manager. This bug was caught in e2e tests that we added for this scenario.  [Failure log](https://storage.googleapis.com/kubernetes-jenkins/logs/ci-kubernetes-e2e-kubeadm-kinder-rootless-latest/1410281288924925952/build-log.txt)

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
