### PR TITLE
sched: provide an option for plugin developers to move pods to activeQ

### DIFF
--- a/pkg/scheduler/framework/interface.go
+++ b/pkg/scheduler/framework/interface.go
@@ -23,6 +23,7 @@ import (
 	"errors"
 	"math"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/google/go-cmp/cmp"
@@ -104,6 +105,30 @@ const (
 	// MaxTotalScore is the maximum total score.
 	MaxTotalScore int64 = math.MaxInt64
 )
+
+// PodsToActivateKey is a reserved state key for stashing pods.
+// If the stashed pods are present in unschedulableQ or backoffQ，they will be
+// activated (i.e., moved to activeQ) in two phases:
+// - end of a scheduling cycle if it succeeds (will be cleared from `PodsToActivate` if activated)
+// - end of a binding cycle if it succeeds
+var PodsToActivateKey StateKey = "kubernetes.io/pods-to-activate"
+
+// PodsToActivate stores pods to be activated.
+type PodsToActivate struct {
+	sync.Mutex
+	// Map is keyed with namespaced pod name, and valued with the pod.
+	Map map[string]*v1.Pod
+}
+
+// Clone just returns the same state.
+func (s *PodsToActivate) Clone() StateData {
+	return s
+}
+
+// NewPodsToActivate instantiates a PodsToActivate object.
+func NewPodsToActivate() *PodsToActivate {
+	return &PodsToActivate{Map: make(map[string]*v1.Pod)}
+}
 
 // Status indicates the result of running a plugin. It consists of a code, a
 // message, (optionally) an error and an plugin name it fails by. When the status

--- a/pkg/scheduler/internal/queue/events.go
+++ b/pkg/scheduler/internal/queue/events.go
@@ -27,6 +27,9 @@ const (
 	ScheduleAttemptFailure = "ScheduleAttemptFailure"
 	// BackoffComplete is the event when a pod finishes backoff.
 	BackoffComplete = "BackoffComplete"
+	// ForceActivate is the event when a pod is moved from unschedulableQ/backoffQ
+	// to activeQ. Usually it's triggered by plugin implementations.
+	ForceActivate = "ForceActivate"
 )
 
 var (


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/sig scheduling

#### What this PR does / why we need it:

In the ML/Batch fields, a series of Pods are usually considered as a unit that requires to be co-scheduled, or scheduled in a particular order (e.g., a spark job requires the driver to be running prior to executors). The current scheduling mechanics can make them work, but sometimes not efficient enough as different pods of a unit may be present in different internal queues and backoff-ed in different paces, and hence needs extra scheduling cycles to be scheduled. (see more explanation in the design doc)

This PR introduces a reserved CycleState (both key and data struct) and plumbs it into the scheduling cycle, so plugin developers can choose to move particular pods based on their requirements, proactively. The queued-up Pods will be moved to activeQ at the end of a successful scheduling cycle and binding cycle, in a best-efforts manner.

#### Which issue(s) this PR fixes:

Part of #100347.

#### Special notes for your reviewer:

In addition to the integration test, I also apply this patch to scheduler-plugins, and verified the integration performance of coscheduling plugin. The time reduced sharply from 400s~600s to ~17s:

Original test:

```
root@wei-dev:~/go/src/sigs.k8s.io/scheduler-plugins# for i in {1..20}; do go test -timeout 20m ./test/integration/... -run ^TestCoschedulingPlugin -count=1; done
ok      sigs.k8s.io/scheduler-plugins/test/integration  456.129s
ok      sigs.k8s.io/scheduler-plugins/test/integration  456.756s
ok      sigs.k8s.io/scheduler-plugins/test/integration  456.668s
ok      sigs.k8s.io/scheduler-plugins/test/integration  547.129s
ok      sigs.k8s.io/scheduler-plugins/test/integration  456.216s
ok      sigs.k8s.io/scheduler-plugins/test/integration  456.751s
ok      sigs.k8s.io/scheduler-plugins/test/integration  456.487s
ok      sigs.k8s.io/scheduler-plugins/test/integration  457.138s
ok      sigs.k8s.io/scheduler-plugins/test/integration  456.431s
ok      sigs.k8s.io/scheduler-plugins/test/integration  457.470s
...
```

With this PR and proactive moving pods logic:

```
root@wei-dev:~/go/src/sigs.k8s.io/scheduler-plugins# for i in {1..20}; do go test -timeout 20m ./test/integration/... -run ^TestCoschedulingPlugin -count=1; done
ok      sigs.k8s.io/scheduler-plugins/test/integration  16.867s
ok      sigs.k8s.io/scheduler-plugins/test/integration  16.367s
ok      sigs.k8s.io/scheduler-plugins/test/integration  16.836s
ok      sigs.k8s.io/scheduler-plugins/test/integration  16.842s
ok      sigs.k8s.io/scheduler-plugins/test/integration  16.363s
ok      sigs.k8s.io/scheduler-plugins/test/integration  16.441s
ok      sigs.k8s.io/scheduler-plugins/test/integration  16.506s
ok      sigs.k8s.io/scheduler-plugins/test/integration  16.970s
ok      sigs.k8s.io/scheduler-plugins/test/integration  17.014s
ok      sigs.k8s.io/scheduler-plugins/test/integration  16.739s
...
```

#### Does this PR introduce a user-facing change?

```release-note
Scheduler nows provides an option for plugin developers to move Pods to activeQ proactively.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
- [Design doc]: https://docs.google.com/document/d/1mdOJN9ceICMTh4sbSZezK5WuzH9OM8ou6IVuyN3CY0U/view
```
