### PR TITLE
Fix staticcheck in kubelet, util and apimachinery

### DIFF
--- a/hack/.staticcheck_failures
+++ b/hack/.staticcheck_failures
@@ -1,8 +1,3 @@
-pkg/kubelet/cm/cpuset
-pkg/util/flag
-test/e2e/apimachinery
-vendor/k8s.io/apimachinery/pkg/util/json
-vendor/k8s.io/apimachinery/pkg/util/strategicpatch
 vendor/k8s.io/apiserver/pkg/server/dynamiccertificates
 vendor/k8s.io/apiserver/pkg/server/filters
 vendor/k8s.io/apiserver/pkg/server/routes

--- a/pkg/kubelet/cm/cpuset/cpuset.go
+++ b/pkg/kubelet/cm/cpuset/cpuset.go
@@ -57,7 +57,7 @@ func (b Builder) Add(elems ...int) {
 
 // Result returns the result CPUSet containing all elements that were
 // previously added to this builder. Subsequent calls to Add have no effect.
-func (b Builder) Result() CPUSet {
+func (b *Builder) Result() CPUSet {
 	b.done = true
 	return b.result
 }

--- a/pkg/kubelet/cm/cpuset/cpuset_test.go
+++ b/pkg/kubelet/cm/cpuset/cpuset_test.go
@@ -36,6 +36,11 @@ func TestCPUSetBuilder(t *testing.T) {
 	if len(elems) != result.Size() {
 		t.Fatalf("expected cpuset %s to have the same size as %v", result, elems)
 	}
+
+	b.Add(6)
+	if len(elems) != result.Size() {
+		t.Error("expected call to Add after Result to have no effect")
+	}
 }
 
 func TestCPUSetSize(t *testing.T) {

--- a/pkg/util/flag/flags.go
+++ b/pkg/util/flag/flags.go
@@ -50,7 +50,6 @@ type IPVar struct {
 // Set sets the flag value
 func (v IPVar) Set(s string) error {
 	if len(s) == 0 {
-		v.Val = nil
 		return nil
 	}
 	if net.ParseIP(s) == nil {
@@ -85,7 +84,6 @@ type IPPortVar struct {
 // Set sets the flag value
 func (v IPPortVar) Set(s string) error {
 	if len(s) == 0 {
-		v.Val = nil
 		return nil
 	}
 

--- a/staging/src/k8s.io/apimachinery/pkg/util/json/json_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/json/json_test.go
@@ -121,7 +121,7 @@ func TestEvaluateTypes(t *testing.T) {
 		},
 		{
 			In:   `-0.0`,
-			Data: float64(-0.0),
+			Data: float64(0.0),
 			Out:  `-0`,
 		},
 		{

--- a/staging/src/k8s.io/apimachinery/pkg/util/strategicpatch/meta.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/strategicpatch/meta.go
@@ -38,7 +38,7 @@ func (pm PatchMeta) GetPatchStrategies() []string {
 	return pm.patchStrategies
 }
 
-func (pm PatchMeta) SetPatchStrategies(ps []string) {
+func (pm *PatchMeta) SetPatchStrategies(ps []string) {
 	pm.patchStrategies = ps
 }
 
@@ -46,7 +46,7 @@ func (pm PatchMeta) GetPatchMergeKey() string {
 	return pm.patchMergeKey
 }
 
-func (pm PatchMeta) SetPatchMergeKey(pmk string) {
+func (pm *PatchMeta) SetPatchMergeKey(pmk string) {
 	pm.patchMergeKey = pmk
 }
 

--- a/test/e2e/apimachinery/garbage_collector.go
+++ b/test/e2e/apimachinery/garbage_collector.go
@@ -66,8 +66,8 @@ func estimateMaximumPods(c clientset.Interface, min, max int32) int32 {
 		// one core.
 		availablePods += 10
 	}
-	//avoid creating exactly max pods
-	availablePods *= 8 / 10
+	// avoid creating exactly max pods
+	availablePods = availablePods * 8 / 10
 	// bound the top and bottom
 	if availablePods > max {
 		availablePods = max


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
PR fixes issues found by staticcheck in `pkg/kubelet/cm/cpuset`, `pkg/util/flag`, `test/e2e/apimachinery` and `vendor/k8s.io/apimachinery/`
```
pkg/kubelet/cm/cpuset/cpuset.go:61:2: ineffective assignment to field Builder.done (SA4005)
pkg/util/flag/flags.go:53:3: ineffective assignment to field IPVar.Val (SA4005)
pkg/util/flag/flags.go:88:3: ineffective assignment to field IPPortVar.Val (SA4005)
test/e2e/apimachinery/garbage_collector.go:70:19: the integer division '8 / 10' results in zero (SA4025)
vendor/k8s.io/apimachinery/pkg/util/json/json_test.go:124:18: in Go, the floating-point literal '-0.0' is the same as '0.0', it does not produce a negative zero (SA4026)
vendor/k8s.io/apimachinery/pkg/util/strategicpatch/meta.go:42:2: ineffective assignment to field PatchMeta.patchStrategies (SA4005)
vendor/k8s.io/apimachinery/pkg/util/strategicpatch/meta.go:50:2: ineffective assignment to field PatchMeta.patchMergeKey (SA4005)
```

#### Which issue(s) this PR fixes:
Part of #92402

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```