### PR TITLE
make sure to split NPD hashes by architecture when upgrading to 0.8.9

### DIFF
--- a/cluster/gce/gci/configure.sh
+++ b/cluster/gce/gci/configure.sh
@@ -27,7 +27,9 @@ set -o pipefail
 DEFAULT_CNI_VERSION='v0.9.1'
 DEFAULT_CNI_HASH='b5a59660053a5f1a33b5dd5624d9ed61864482d9dc8e5b79c9b3afc3d6f62c9830e1c30f9ccba6ee76f5fb1ff0504e58984420cc0680b26cb643f1cb07afbd1c'
 DEFAULT_NPD_VERSION='v0.8.8'
-DEFAULT_NPD_HASH='ba8315a29368bfc33bdc602eb02d325b0b80e295c8739da35616de5b562c372bd297a2553f3ccd4daaecd67698b659b2c7068a2d2a0b9418ad29233fb75ff3f2'
+DEFAULT_NPD_HASH_AMD64='ba8315a29368bfc33bdc602eb02d325b0b80e295c8739da35616de5b562c372bd297a2553f3ccd4daaecd67698b659b2c7068a2d2a0b9418ad29233fb75ff3f2'
+# TODO (SergeyKanzhelev): fill up for npd 0.8.9+
+DEFAULT_NPD_HASH_ARM64='N/A'
 DEFAULT_CRICTL_VERSION='v1.21.0'
 DEFAULT_CRICTL_HASH='e4fb9822cb5f71ab8f85021c66170613aae972f4b32030e42868fb36a3bc3ea8642613df8542bf716fad903ed4d7528021ecb28b20c6330448cd2bd2b76bd776'
 DEFAULT_MOUNTER_TAR_SHA='7956fd42523de6b3107ddc3ce0e75233d2fcb78436ff07a1389b6eaac91fb2b1b72a08f7a219eaf96ba1ca4da8d45271002e0d60e0644e796c665f99bb356516'
@@ -238,6 +240,18 @@ function install-gci-mounter-tools {
 
 # Install node problem detector binary.
 function install-node-problem-detector {
+  if [[ "${HOST_ARCH}" == "amd64" ]]; then
+    DEFAULT_NPD_HASH=${DEFAULT_NPD_HASH_AMD64}
+  elif [[ "${HOST_ARCH}" == "arm64" ]]; then
+    DEFAULT_NPD_HASH=${DEFAULT_NPD_HASH_ARM64}
+  else
+    # no other architectures are supported currently.
+    # Assumption is that this script only runs on linux,
+    # see cluster/gce/windows/k8s-node-setup.psm1 for windows
+    # https://github.com/kubernetes/node-problem-detector/releases/
+    DEFAULT_NPD_HASH='N/A'
+  fi
+
   if [[ -n "${NODE_PROBLEM_DETECTOR_VERSION:-}" ]]; then
       local -r npd_version="${NODE_PROBLEM_DETECTOR_VERSION}"
       local -r npd_hash="${NODE_PROBLEM_DETECTOR_TAR_HASH}"


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Follow up for the https://github.com/kubernetes/kubernetes/pull/103104#discussion_r661838790

#### Special notes for your reviewer:

NPD 0.8.8 doesn't compile arm64 package. With the update we will need to update the hash though.

Note, this PR doesn't make situation worse for arm64 as it was attempting to use an image built for amd64 before. Now it will fail faster by not finding the NPD binary.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
