### PR TITLE
Sets to loopback (127.0.0.1) etcd-peer listening port in a single-master clusters.

### DIFF
--- a/cluster/gce/gci/configure-helper.sh
+++ b/cluster/gce/gci/configure-helper.sh
@@ -1795,8 +1795,14 @@ def resolve(host):
       continue
 
 '
+  if [[ -n "${MULTIMASTER:-}" ]]; then
+    # Multi-master should expose the peer server on the host level.
+    local -r host_ip=$(python3 -c "${resolve_host_script_py}"$'\n'"resolve(\"${host_name}\")")
+  else
+    # Single-master should expose the peer connection on the host level.
+    local -r host_ip=127.0.0.1
+  fi
 
-  local -r host_ip=$(python3 -c "${resolve_host_script_py}"$'\n'"resolve(\"${host_name}\")")
   local etcd_cluster=""
   local cluster_state="new"
   local etcd_protocol="http"


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Sets to loopback (127.0.0.1) etcd-peer listening port in  a single-master clusters. This limits port exposure on the host-level network.

During cluster configuration, the hostname is getting resolved to IP, as etcd requires IP address as listening address
for peer-etcd configuration. The configuration happens only for MULTIMASTER configurations. 
The exposure of the port in case of single-master setups can be additional (potential) attack vector. 

The PR was discussed in:  https://github.com/kubernetes/kubernetes/pull/101781
and is to be applied on top of the https://github.com/kubernetes/kubernetes/pull/101781.

#### Which issue(s) this PR fixes:

NONE

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

NONE

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

