### PR TITLE
Added unit tests for ExpandPathsToFileVisitors

### DIFF
--- a/staging/src/k8s.io/cli-runtime/pkg/resource/visitor_test.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/resource/visitor_test.go
@@ -21,7 +21,10 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"io/ioutil"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -195,5 +198,161 @@ func TestFlattenListVisitorWithVisitorError(t *testing.T) {
 	}
 	if len(test.Infos) != 6 {
 		t.Fatal(spew.Sdump(test.Infos))
+	}
+}
+
+func TestExpandPathsToFileVisitors(t *testing.T) {
+	// Define a directory structure that will be used for testing and create empty files
+	testDir := t.TempDir()
+	filePaths := []string{
+		filepath.Join(testDir, "0", "10.yaml"),
+		filepath.Join(testDir, "0", "a", "10.yaml"),
+		filepath.Join(testDir, "02.yaml"),
+		filepath.Join(testDir, "10.yaml"),
+		filepath.Join(testDir, "2.yaml"),
+		filepath.Join(testDir, "AB.yaml"),
+		filepath.Join(testDir, "a", "a.yaml"),
+		filepath.Join(testDir, "a", "b.json"),
+		filepath.Join(testDir, "a.yaml"),
+		filepath.Join(testDir, "aa.yaml"),
+		filepath.Join(testDir, "b.yml"),
+	}
+	for _, fp := range filePaths {
+		if err := os.MkdirAll(filepath.Dir(fp), 0700); err != nil {
+			t.Fatal(err)
+		}
+		func() {
+			f, err := os.Create(fp)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer f.Close()
+		}()
+	}
+
+	// Define and execute test cases
+	tests := []struct {
+		name            string
+		path            string
+		recursive       bool
+		fileExtensions  []string
+		expectedPaths   []string
+		expectPathError bool
+	}{
+		{
+			name:           "Recursive with default file extensions",
+			path:           testDir,
+			recursive:      true,
+			fileExtensions: FileExtensions,
+			expectedPaths: []string{
+				filepath.Join(testDir, "0", "10.yaml"),
+				filepath.Join(testDir, "0", "a", "10.yaml"),
+				filepath.Join(testDir, "02.yaml"),
+				filepath.Join(testDir, "10.yaml"),
+				filepath.Join(testDir, "2.yaml"),
+				filepath.Join(testDir, "AB.yaml"),
+				filepath.Join(testDir, "a", "a.yaml"),
+				filepath.Join(testDir, "a", "b.json"),
+				filepath.Join(testDir, "a.yaml"),
+				filepath.Join(testDir, "aa.yaml"),
+				filepath.Join(testDir, "b.yml"),
+			},
+		},
+		{
+			name:           "Non-recursive with default file extensions",
+			path:           testDir,
+			fileExtensions: FileExtensions,
+			expectedPaths: []string{
+				filepath.Join(testDir, "02.yaml"),
+				filepath.Join(testDir, "10.yaml"),
+				filepath.Join(testDir, "2.yaml"),
+				filepath.Join(testDir, "AB.yaml"),
+				filepath.Join(testDir, "a.yaml"),
+				filepath.Join(testDir, "aa.yaml"),
+				filepath.Join(testDir, "b.yml"),
+			},
+		},
+		{
+			name:           "Recursive with yaml file extension",
+			path:           testDir,
+			recursive:      true,
+			fileExtensions: []string{".yaml"},
+			expectedPaths: []string{
+				filepath.Join(testDir, "0", "10.yaml"),
+				filepath.Join(testDir, "0", "a", "10.yaml"),
+				filepath.Join(testDir, "02.yaml"),
+				filepath.Join(testDir, "10.yaml"),
+				filepath.Join(testDir, "2.yaml"),
+				filepath.Join(testDir, "AB.yaml"),
+				filepath.Join(testDir, "a", "a.yaml"),
+				filepath.Join(testDir, "a.yaml"),
+				filepath.Join(testDir, "aa.yaml"),
+			},
+		},
+		{
+			name:           "Recursive with json and yml file extensions",
+			path:           testDir,
+			recursive:      true,
+			fileExtensions: []string{".json", ".yml"},
+			expectedPaths: []string{
+				filepath.Join(testDir, "a", "b.json"),
+				filepath.Join(testDir, "b.yml"),
+			},
+		},
+		{
+			name:           "Non-recursive with json and yml file extensions",
+			path:           testDir,
+			fileExtensions: []string{".json", ".yml"},
+			expectedPaths: []string{
+				filepath.Join(testDir, "b.yml"),
+			},
+		},
+		{
+			name:           "Non-existent file extensions should return nothing",
+			path:           testDir,
+			recursive:      true,
+			fileExtensions: []string{".foo"},
+			expectedPaths:  []string{},
+		},
+		{
+			name:            "Non-existent path should return file not found error",
+			path:            filepath.Join(testDir, "does", "not", "exist"),
+			recursive:       true,
+			fileExtensions:  []string{".foo"},
+			expectedPaths:   []string{},
+			expectPathError: true,
+		},
+		{
+			name:           "Visitor for single file is returned even if extension does not match",
+			path:           filepath.Join(testDir, "a.yaml"),
+			recursive:      true,
+			fileExtensions: []string{"foo"},
+			expectedPaths: []string{
+				filepath.Join(testDir, "a.yaml"),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			visitors, err := ExpandPathsToFileVisitors(nil, tt.path, tt.recursive, tt.fileExtensions, nil)
+			if err != nil {
+				switch e := err.(type) {
+				case *fs.PathError:
+					if tt.expectPathError {
+						// The other details of PathError are os-specific, so only assert that the error has the path
+						assert.Equal(t, tt.path, e.Path)
+						return
+					}
+				}
+				t.Fatal(err)
+			}
+
+			actualPaths := []string{}
+			for _, v := range visitors {
+				actualPaths = append(actualPaths, v.(*FileVisitor).Path)
+			}
+			assert.Equal(t, tt.expectedPaths, actualPaths)
+		})
 	}
 }


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
[ExpandPathsToFileVisitors](https://github.com/kubernetes/kubernetes/blob/6c9460f0b405630ebd21cd432b8b8ffede6d7554/staging/src/k8s.io/cli-runtime/pkg/resource/visitor.go#L466-L497) is missing unit tests.

[A question was posed in slack](https://kubernetes.slack.com/archives/C2GL57FJ4/p1625145162084000) whether the a potential future change to the order in which files are processed by `kubectl apply -f` is considered a breaking change or not.

This PR adds unit tests to cover the order in which files are visited in recursive and non-recursive scenarios as well as filtering based on file extension.

#### Which issue(s) this PR fixes:
n/a

#### Special notes for your reviewer:
I wasn't sure if there is a better way to test this without creating the file structure in artifacts.  I'm open to suggestions if there is a way to mock this.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
n/a