### PR TITLE
test/e2e: metric proxy setup is blocking tests on HA control plane

### DIFF
--- a/test/e2e/framework/metrics/metrics_proxy.go
+++ b/test/e2e/framework/metrics/metrics_proxy.go
@@ -68,8 +68,8 @@ func SetupMetricsProxy(c clientset.Interface) error {
 				})
 			}
 		}
-		if len(foundComponents) != 2 {
-			klog.Infof("Only %d components found. Will retry.", len(foundComponents))
+		if len(foundComponents) < 2 {
+			klog.Infof("Only %d components found, at least 2 expected. Will retry.", len(foundComponents))
 			klog.Infof("Found components: %v", foundComponents)
 			return false, nil
 		}


### PR DESCRIPTION
Signed-off-by: Andrew Sy Kim <kim.andrewsy@gmail.com>

#### What type of PR is this?
/kind bug


#### What this PR does / why we need it:
The metrics proxy setup code is  assuming there is exactly two pods that start with `kube-controller-mangaer-` and `kube-scheduler-`. This assumption is true when there is only 1 control plane and one instance of each of these components. However, if the cluster is running an HA control plane with 3 instances of each, this check will block forever. 

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
