### PR TITLE
Fix staticcheck failures in pkg/util/flag

### DIFF
--- a/hack/.staticcheck_failures
+++ b/hack/.staticcheck_failures
@@ -1,4 +1,3 @@
-pkg/util/flag
 test/e2e/apimachinery
 vendor/k8s.io/apimachinery/pkg/util/json
 vendor/k8s.io/apimachinery/pkg/util/strategicpatch

--- a/pkg/util/flag/flags_test.go
+++ b/pkg/util/flag/flags_test.go
@@ -46,6 +46,10 @@ func TestIPVar(t *testing.T) {
 			expectErr: true,
 			expectVal: defaultIP,
 		},
+		{
+			argc:      "blah --ip=",
+			expectVal: "",
+		},
 	}
 	for _, tc := range testCases {
 		fs := pflag.NewFlagSet("blah", pflag.PanicOnError)
@@ -94,6 +98,11 @@ func TestIPPortVar(t *testing.T) {
 			desc:      "valid ipv4 2",
 			argc:      "blah --ipport=127.0.0.1",
 			expectVal: "127.0.0.1",
+		},
+		{
+			desc:      "valid empty string",
+			argc:      "blah --ipport=",
+			expectVal: "",
 		},
 
 		{
@@ -222,6 +231,11 @@ func TestReservedMemoryVar(t *testing.T) {
 					},
 				},
 			},
+		},
+		{
+			desc:      "valid empty input",
+			argc:      "blah --reserved-memory=",
+			expectVal: []kubeletconfig.MemoryReservation{},
 		},
 		{
 			desc:      "invalid input",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
PR fixes issues found by staticcheck in `pkg/util/flag`
```
pkg/util/flag/flags.go:53:3: ineffective assignment to field IPVar.Val (SA4005)
pkg/util/flag/flags.go:88:3: ineffective assignment to field IPPortVar.Val (SA4005)
```

#### Which issue(s) this PR fixes:
Part of #92402
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->


#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
