### PR TITLE
Fix staticcheck failures in apimachinery

### DIFF
--- a/hack/.staticcheck_failures
+++ b/hack/.staticcheck_failures
@@ -1,7 +1,4 @@
 pkg/util/flag
-test/e2e/apimachinery
-vendor/k8s.io/apimachinery/pkg/util/json
-vendor/k8s.io/apimachinery/pkg/util/strategicpatch
 vendor/k8s.io/apiserver/pkg/server/dynamiccertificates
 vendor/k8s.io/apiserver/pkg/server/filters
 vendor/k8s.io/apiserver/pkg/server/routes

--- a/test/e2e/apimachinery/garbage_collector.go
+++ b/test/e2e/apimachinery/garbage_collector.go
@@ -67,8 +67,8 @@ func estimateMaximumPods(c clientset.Interface, min, max int32) int32 {
 		// one core.
 		availablePods += 10
 	}
-	//avoid creating exactly max pods
-	availablePods = int32(float32(availablePods) * 0.8)
+	// avoid creating exactly max pods
+	availablePods = availablePods * 8 / 10
 	// bound the top and bottom
 	if availablePods > max {
 		availablePods = max


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
PR fixes issues found by staticcheck in `test/e2e/apimachinery` and `vendor/k8s.io/apimachinery`
```
test/e2e/apimachinery/garbage_collector.go:70:19: the integer division '8 / 10' results in zero (SA4025)
vendor/k8s.io/apimachinery/pkg/util/json/json_test.go:124:18: in Go, the floating-point literal '-0.0' is the same as '0.0', it does not produce a negative zero (SA4026)
vendor/k8s.io/apimachinery/pkg/util/strategicpatch/meta.go:42:2: ineffective assignment to field PatchMeta.patchStrategies (SA4005)
vendor/k8s.io/apimachinery/pkg/util/strategicpatch/meta.go:50:2: ineffective assignment to field PatchMeta.patchMergeKey (SA4005)
```

#### Which issue(s) this PR fixes:
Part of #92402
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```