### PR TITLE
Change tracing service from kube-apiserver to apiserver

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/server/options/tracing.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/tracing.go
@@ -35,7 +35,7 @@ import (
 	"k8s.io/utils/path"
 )
 
-const apiserverService = "kube-apiserver"
+const apiserverService = "apiserver"
 
 // TracingOptions contain configuration options for tracing
 // exporters


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:
Address feedback from the initial tracing PR: https://github.com/kubernetes/kubernetes/pull/94942#pullrequestreview-692774419
The library can be used by things other than the kube-apiserver, so this renames it to apiserver.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
- [KEP]: https://github.com/kubernetes/enhancements/blob/master/keps/sig-instrumentation/0034-distributed-tracing-kep.md
```

/assign @liggitt 