### PR TITLE
Add prioritized leader election

### DIFF
--- a/staging/src/k8s.io/client-go/tools/leaderelection/healthzadaptor_test.go
+++ b/staging/src/k8s.io/client-go/tools/leaderelection/healthzadaptor_test.go
@@ -30,6 +30,7 @@ import (
 
 type fakeLock struct {
 	identity string
+	key      string
 }
 
 // Get is a dummy to allow us to have a fakeLock for testing.
@@ -53,6 +54,11 @@ func (fl *fakeLock) RecordEvent(string) {}
 // Identity is a dummy to allow us to have a fakeLock for testing.
 func (fl *fakeLock) Identity() string {
 	return fl.identity
+}
+
+// Key is a dummy to allow us to have a fakeLock for testing.
+func (fl *fakeLock) Key() string {
+	return fl.key
 }
 
 // Describe is a dummy to allow us to have a fakeLock for testing.

--- a/staging/src/k8s.io/client-go/tools/leaderelection/resourcelock/configmaplock.go
+++ b/staging/src/k8s.io/client-go/tools/leaderelection/resourcelock/configmaplock.go
@@ -120,3 +120,8 @@ func (cml *ConfigMapLock) Describe() string {
 func (cml *ConfigMapLock) Identity() string {
 	return cml.LockConfig.Identity
 }
+
+// Identity returns the Identity of the lock
+func (cml *ConfigMapLock) Key() string {
+	return cml.LockConfig.Key
+}

--- a/staging/src/k8s.io/client-go/tools/leaderelection/resourcelock/endpointslock.go
+++ b/staging/src/k8s.io/client-go/tools/leaderelection/resourcelock/endpointslock.go
@@ -115,3 +115,8 @@ func (el *EndpointsLock) Describe() string {
 func (el *EndpointsLock) Identity() string {
 	return el.LockConfig.Identity
 }
+
+// Key returns the Key of the lock
+func (el *EndpointsLock) Key() string {
+	return el.LockConfig.Key
+}

--- a/staging/src/k8s.io/client-go/tools/leaderelection/resourcelock/interface.go
+++ b/staging/src/k8s.io/client-go/tools/leaderelection/resourcelock/interface.go
@@ -48,7 +48,9 @@ type LeaderElectionRecord struct {
 	// attempt to acquire leases with empty identities and will wait for the full lease
 	// interval to expire before attempting to reacquire. This value is set to empty when
 	// a client voluntarily steps down.
-	HolderIdentity       string      `json:"holderIdentity"`
+	HolderIdentity string `json:"holderIdentity"`
+	// HolderKey is the Key of the lease owner. This may be empty if a key is not set.
+	HolderKey            string      `json:"holderKey"`
 	LeaseDurationSeconds int         `json:"leaseDurationSeconds"`
 	AcquireTime          metav1.Time `json:"acquireTime"`
 	RenewTime            metav1.Time `json:"renewTime"`
@@ -66,6 +68,10 @@ type ResourceLockConfig struct {
 	// Identity is the unique string identifying a lease holder across
 	// all participants in an election.
 	Identity string
+	// Key is a user-defined value used to indicate how high priority this lock
+	// have. Other locks may steal the lock from us if they believe their key
+	// has a higher priority.
+	Key string
 	// EventRecorder is optional.
 	EventRecorder EventRecorder
 }
@@ -90,6 +96,8 @@ type Interface interface {
 
 	// Identity will return the locks Identity
 	Identity() string
+
+	Key() string
 
 	// Describe is used to convert details on current resource lock
 	// into a string

--- a/staging/src/k8s.io/client-go/tools/leaderelection/resourcelock/leaselock.go
+++ b/staging/src/k8s.io/client-go/tools/leaderelection/resourcelock/leaselock.go
@@ -101,6 +101,11 @@ func (ll *LeaseLock) Identity() string {
 	return ll.LockConfig.Identity
 }
 
+// Key returns the Key of the lock
+func (ll *LeaseLock) Key() string {
+	return ll.LockConfig.Key
+}
+
 func LeaseSpecToLeaderElectionRecord(spec *coordinationv1.LeaseSpec) *LeaderElectionRecord {
 	var r LeaderElectionRecord
 	if spec.HolderIdentity != nil {

--- a/staging/src/k8s.io/client-go/tools/leaderelection/resourcelock/multilock.go
+++ b/staging/src/k8s.io/client-go/tools/leaderelection/resourcelock/multilock.go
@@ -99,6 +99,11 @@ func (ml *MultiLock) Identity() string {
 	return ml.Primary.Identity()
 }
 
+// Key returns the Key of the lock
+func (ml *MultiLock) Key() string {
+	return ml.Primary.Key()
+}
+
 func ConcatRawRecord(primaryRaw, secondaryRaw []byte) []byte {
 	return bytes.Join([][]byte{primaryRaw, secondaryRaw}, []byte(","))
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:
This introduces a new concept to the `leaderelection` package, allowing
participants to declare a precedence order between certain clients.

Example use cases:
* I have multiple versions of an application running concurrently in the
cluster; I want the newest one to become the leader (cc @monkeyanator)
* I have multiple replicas with different resources. I want the largest
replica to be the leader
* I am implementing a cross-region controller (think multicluster
service discovery) and the geographically closest region to be the
leader (to avoid something like a US controller acting on a cluster in
Asia, when I have a controller replica already running in Asia) (cc @JeremyOT)

Library users can define an arbitrary key to indicate whatever metadata
they choose. They may also choose to implement a KeyComparison function.
If present, this function will be used to determine if our key is higher
priority than the existing leader; if it is, we will acquire the lock
even though its already held by another.

Version skew compatibility: old clients will not set a key, nor will
they implement a KeyComparison function. If they see a lock with a key
set, they will gracefully ignore it, which is not an issue - this just
means they will never steal a lock. Because the key is empty, a
KeyComparison function must account for `""` as a key value, but they
would need to do that regardless as the field is optional. As a result,
I do not expect any version skew issues.


#### Which issue(s) this PR fixes:


#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Added a new `KeyComparison` feature to the client-go leaderelection package to allow prioritized leader elections.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
```
