### PR TITLE
Add tracing to apiserver authentication and authorization requests

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/server/options/authentication.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/authentication.go
@@ -229,8 +229,9 @@ func (s *DelegatingAuthenticationOptions) WithRequestTimeout(timeout time.Durati
 }
 
 // WithCustomRoundTripper allows for specifying a middleware function for custom HTTP behaviour for the authentication webhook client.
+// Multiple calls to wrappers causes wrappers to be called in the order they were added with WithCustomRoundTripper.
 func (s *DelegatingAuthenticationOptions) WithCustomRoundTripper(rt transport.WrapperFunc) {
-	s.CustomRoundTripperFn = rt
+	s.CustomRoundTripperFn = transport.Wrappers(s.CustomRoundTripperFn, rt)
 }
 
 func (s *DelegatingAuthenticationOptions) Validate() []error {

--- a/staging/src/k8s.io/apiserver/pkg/server/options/authorization.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/authorization.go
@@ -116,8 +116,9 @@ func (s *DelegatingAuthorizationOptions) WithCustomRetryBackoff(backoff wait.Bac
 }
 
 // WithCustomRoundTripper allows for specifying a middleware function for custom HTTP behaviour for the authorization webhook client.
+// Multiple calls to wrappers causes wrappers to be called in the order they were added with WithCustomRoundTripper.
 func (s *DelegatingAuthorizationOptions) WithCustomRoundTripper(rt transport.WrapperFunc) {
-	s.CustomRoundTripperFn = rt
+	s.CustomRoundTripperFn = transport.Wrappers(s.CustomRoundTripperFn, rt)
 }
 
 func (s *DelegatingAuthorizationOptions) Validate() []error {

--- a/staging/src/k8s.io/apiserver/pkg/server/options/recommended.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/recommended.go
@@ -30,6 +30,7 @@ import (
 	utilflowcontrol "k8s.io/apiserver/pkg/util/flowcontrol"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/component-base/featuregate"
+	"k8s.io/component-base/traces"
 	"k8s.io/klog/v2"
 )
 
@@ -111,6 +112,9 @@ func (o *RecommendedOptions) ApplyTo(config *server.RecommendedConfig) error {
 		if err := o.Traces.ApplyTo(config.Config.EgressSelector, &config.Config); err != nil {
 			return err
 		}
+		wrapper := traces.WrapperFor(config.TracerProvider)
+		o.Authentication.WithCustomRoundTripper(wrapper)
+		o.Authorization.WithCustomRoundTripper(wrapper)
 	}
 	if err := o.SecureServing.ApplyTo(&config.Config.SecureServing, &config.Config.LoopbackClientConfig); err != nil {
 		return err


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Follow-up to #103218.  This adds tracing for authentication and authorization client-go requests, which will help debug reentrant api calls, even if they are not part of the same trace (#103186).

Part of enhancement: kubernetes/enhancements#647

#### Does this PR introduce a user-facing change?

```release-note
API Server tracing can now trace authentication and authorization API requests.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
- [KEP]: https://github.com/kubernetes/enhancements/blob/master/keps/sig-instrumentation/0034-distributed-tracing-kep.md
```

/assign @logicalhan @liggitt 