### PR TITLE
Automated cherry pick of #103051: Fix race in attachdetach tests

### DIFF
--- a/pkg/controller/volume/attachdetach/testing/testvolumespec.go
+++ b/pkg/controller/volume/attachdetach/testing/testvolumespec.go
@@ -59,12 +59,12 @@ func GetTestVolumeSpec(volumeName string, diskName v1.UniqueVolumeName) *volume.
 	}
 }
 
-var extraPods *v1.PodList
-var volumeAttachments *storagev1.VolumeAttachmentList
-var pvs *v1.PersistentVolumeList
-var nodes *v1.NodeList
-
 func CreateTestClient() *fake.Clientset {
+	var extraPods *v1.PodList
+	var volumeAttachments *storagev1.VolumeAttachmentList
+	var pvs *v1.PersistentVolumeList
+	var nodes *v1.NodeList
+
 	fakeClient := &fake.Clientset{}
 
 	extraPods = &v1.PodList{}
@@ -156,7 +156,7 @@ func CreateTestClient() *fake.Clientset {
 			// We want also the "mynode" node since all the testing pods live there
 			nodeName = nodeNamePrefix
 		}
-		attachVolumeToNode("lostVolumeName", nodeName)
+		attachVolumeToNode(nodes, "lostVolumeName", nodeName)
 	}
 	fakeClient.AddReactor("update", "nodes", func(action core.Action) (handled bool, ret runtime.Object, err error) {
 		updateAction := action.(core.UpdateAction)
@@ -296,7 +296,7 @@ func NewPV(pvName, volumeName string) *v1.PersistentVolume {
 	}
 }
 
-func attachVolumeToNode(volumeName, nodeName string) {
+func attachVolumeToNode(nodes *v1.NodeList, volumeName, nodeName string) {
 	// if nodeName exists, get the object.. if not create node object
 	var node *v1.Node
 	found := false


### PR DESCRIPTION
Cherry pick of #103051 on release-1.19.

#103051: Fix race in attachdetach tests

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.