### PR TITLE
Add YAML separator validation and avoid silent ignoration

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/util/yaml/decoder.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/yaml/decoder.go
@@ -291,14 +291,18 @@ func (r *YAMLReader) Read() ([]byte, error) {
 		if i := bytes.Index(line, []byte(separator)); i == 0 {
 			// We have a potential document terminator
 			i += sep
-			after := line[i:]
-			if len(strings.TrimRightFunc(string(after), unicode.IsSpace)) == 0 {
-				if buffer.Len() != 0 {
-					return buffer.Bytes(), nil
+			trimmed := strings.TrimSpace(string(line[i:]))
+			// We only allow comments and spaces following the yaml doc separator, otherwise we'll return an error
+			if len(trimmed) > 0 && string(trimmed[0]) != "#" {
+				return nil, YAMLSyntaxError{
+					err: fmt.Errorf("invalid Yaml document separator: %s", trimmed),
 				}
-				if err == io.EOF {
-					return nil, err
-				}
+			}
+			if buffer.Len() != 0 {
+				return buffer.Bytes(), nil
+			}
+			if err == io.EOF {
+				return nil, err
 			}
 		}
 		if err == io.EOF {

--- a/staging/src/k8s.io/apimachinery/pkg/util/yaml/decoder_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/yaml/decoder_test.go
@@ -211,6 +211,40 @@ stuff: 1
 	}
 }
 
+func TestDecodeYAMLSeparatorValidation(t *testing.T) {
+	s := NewYAMLToJSONDecoder(bytes.NewReader([]byte(`---
+stuff: 1
+---    # Make sure termination happen with inline comment
+stuff: 2
+---
+stuff: 3
+--- Make sure uncommented content results YAMLSyntaxError
+
+ `)))
+	obj := generic{}
+	if err := s.Decode(&obj); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if fmt.Sprintf("%#v", obj) != `yaml.generic{"stuff":1}` {
+		t.Errorf("unexpected object: %#v", obj)
+	}
+	obj = generic{}
+	if err := s.Decode(&obj); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if fmt.Sprintf("%#v", obj) != `yaml.generic{"stuff":2}` {
+		t.Errorf("unexpected object: %#v", obj)
+	}
+	obj = generic{}
+	err := s.Decode(&obj)
+	if err == nil {
+		t.Fatalf("expected YamlSyntaxError, got nil instead")
+	}
+	if _, ok := err.(YAMLSyntaxError); !ok {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 func TestDecodeBrokenYAML(t *testing.T) {
 	s := NewYAMLOrJSONDecoder(bytes.NewReader([]byte(`---
 stuff: 1
@@ -279,6 +313,10 @@ func TestYAMLOrJSONDecoder(t *testing.T) {
 		}},
 		{"", 1, false, false, []generic{}},
 		{"foo: bar\n---\nbaz: biz", 100, false, false, []generic{
+			{"foo": "bar"},
+			{"baz": "biz"},
+		}},
+		{"---\nfoo: bar\n--- # with Comment\nbaz: biz", 100, false, false, []generic{
 			{"foo": "bar"},
 			{"baz": "biz"},
 		}},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:
 This PR fixes silent ignoration of Yaml separators when followed by any other content than spaces, as described in [https://github.com/kubernetes/kubernetes/issues/103185](https://github.com/kubernetes/kubernetes/issues/103185)

#### Which issue(s) this PR fixes:

Fixes #103185

#### Special notes for your reviewer:

Please have a look at the issue page to see discussion around the final solution

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
YAML documents separators ("---") can now be followed by whitespace and comments ("# ....") on the same line. This fixes a bug where documents starting with a comment after the separator were ignored. Other types of content on the same line will result in an error.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
