### PR TITLE
instantiates scheduler ComponentConfig after parsing feature gates

### DIFF
--- a/cmd/kube-scheduler/app/options/deprecated.go
+++ b/cmd/kube-scheduler/app/options/deprecated.go
@@ -69,7 +69,7 @@ func (o *DeprecatedOptions) Validate() []error {
 	return errs
 }
 
-// ApplyPolicySourceTo sets cfg.PolicySource from flags passed on the command line in the following precedence order:
+// ApplyTo sets cfg.PolicySource from flags passed on the command line in the following precedence order:
 //
 // 1. --use-legacy-policy-config to use a policy file.
 // 2. --policy-configmap to use a policy config map value.

--- a/cmd/kube-scheduler/app/server.go
+++ b/cmd/kube-scheduler/app/server.go
@@ -68,6 +68,7 @@ func NewSchedulerCommand(registryOptions ...Option) *cobra.Command {
 		klog.Fatalf("unable to initialize command options: %v", err)
 	}
 
+	namedFlagSets := opts.Flags()
 	cmd := &cobra.Command{
 		Use: "kube-scheduler",
 		Long: `The Kubernetes scheduler is a control plane process which assigns
@@ -79,6 +80,10 @@ kube-scheduler is the reference implementation.
 See [scheduling](https://kubernetes.io/docs/concepts/scheduling-eviction/)
 for more information about scheduling and the kube-scheduler component.`,
 		Run: func(cmd *cobra.Command, args []string) {
+			if err := opts.Complete(&namedFlagSets); err != nil {
+				fmt.Fprintf(os.Stderr, "%v\n", err)
+				os.Exit(1)
+			}
 			if err := runCommand(cmd, opts, registryOptions...); err != nil {
 				fmt.Fprintf(os.Stderr, "%v\n", err)
 				os.Exit(1)
@@ -94,7 +99,6 @@ for more information about scheduling and the kube-scheduler component.`,
 		},
 	}
 	fs := cmd.Flags()
-	namedFlagSets := opts.Flags()
 	verflag.AddFlags(namedFlagSets.FlagSet("global"))
 	globalflag.AddGlobalFlags(namedFlagSets.FlagSet("global"), cmd.Name())
 	for _, f := range namedFlagSets.FlagSets {

--- a/cmd/kube-scheduler/app/server_test.go
+++ b/cmd/kube-scheduler/app/server_test.go
@@ -249,6 +249,18 @@ profiles:
 				t.Fatal(err)
 			}
 
+			nfs := opts.Flags()
+			for _, f := range nfs.FlagSets {
+				fs.AddFlagSet(f)
+			}
+			if err := fs.Parse(tc.flags); err != nil {
+				t.Fatal(err)
+			}
+
+			if err := opts.Complete(&nfs); err != nil {
+				t.Fatal(err)
+			}
+
 			// use listeners instead of static ports so parallel test runs don't conflict
 			opts.SecureServing.Listener = makeListener(t)
 			defer opts.SecureServing.Listener.Close()
@@ -256,13 +268,6 @@ profiles:
 			defer opts.CombinedInsecureServing.Metrics.Listener.Close()
 			opts.CombinedInsecureServing.Healthz.Listener = makeListener(t)
 			defer opts.CombinedInsecureServing.Healthz.Listener.Close()
-
-			for _, f := range opts.Flags().FlagSets {
-				fs.AddFlagSet(f)
-			}
-			if err := fs.Parse(tc.flags); err != nil {
-				t.Fatal(err)
-			}
 
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()

--- a/cmd/kube-scheduler/app/testing/testserver.go
+++ b/cmd/kube-scheduler/app/testing/testserver.go
@@ -86,12 +86,16 @@ func StartTestServer(t Logger, customFlags []string) (result TestServer, err err
 	if err != nil {
 		return TestServer{}, err
 	}
+
 	namedFlagSets := opts.Flags()
 	for _, f := range namedFlagSets.FlagSets {
 		fs.AddFlagSet(f)
 	}
-
 	fs.Parse(customFlags)
+
+	if err := opts.Complete(&namedFlagSets); err != nil {
+		return TestServer{}, err
+	}
 
 	if opts.SecureServing.BindPort != 0 {
 		opts.SecureServing.Listener, opts.SecureServing.BindPort, err = createListenerOnFreePort()

--- a/pkg/scheduler/apis/config/latest/latest.go
+++ b/pkg/scheduler/apis/config/latest/latest.go
@@ -23,7 +23,7 @@ import (
 	"k8s.io/kubernetes/pkg/scheduler/apis/config/scheme"
 )
 
-// Default creates a default configuration of the latset versioned type.
+// Default creates a default configuration of the latest versioned type.
 // This function needs to be updated whenever we bump the scheduler's component config version.
 func Default() (*config.KubeSchedulerConfiguration, error) {
 	versionedCfg := v1beta2.KubeSchedulerConfiguration{}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/sig scheduling

#### What this PR does / why we need it:

Now scheduler instantiates the ComponentConfig obj before feature gates get parsed. This may leads to undesirable defaults when non-default feature gates are passed in (e.g., an alpha feature sets to true, or beta feature sets to false), and quit due to validation error.

We can simply reproduce this by running: `FEATURE_GATES=VolumeCapacityPriority=true hack/local-up-cluster.sh` - scheduler aborts with the error:

```
profiles[0].pluginConfig[5].args.shape: Required value: at least one point must be specified
```

This PR delays scheduler's ComponentConfig to ensure feature gates get parsed first.

#### Which issue(s) this PR fixes:

Fixes #103440

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```