### PR TITLE
kubeadm: fix nil pointer in  Cfg() feature gate checking

### DIFF
--- a/cmd/kubeadm/app/cmd/phases/reset/cleanupnode.go
+++ b/cmd/kubeadm/app/cmd/phases/reset/cleanupnode.go
@@ -92,7 +92,7 @@ func runCleanupNode(c workflow.RunData) error {
 	}
 	resetConfigDir(kubeadmconstants.KubernetesDir, certsDir)
 
-	if features.Enabled(r.Cfg().FeatureGates, features.RootlessControlPlane) {
+	if r.Cfg() != nil && features.Enabled(r.Cfg().FeatureGates, features.RootlessControlPlane) {
 		klog.V(1).Infoln("[reset] Removing users and groups created for rootless control-plane")
 		if err := users.RemoveUsersAndGroups(); err != nil {
 			klog.Warningf("[reset] Failed to remove users and groups: %v\n", err)


### PR DESCRIPTION
/cc vinayakankugoyal  neolit123

#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
https://testgrid.k8s.io/sig-cluster-lifecycle-kubeadm#kubeadm-kinder-latest
CI failed since #101988 was merged
/release-note-none

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x188 pc=0x1a03181]
goroutine 1 [running]:
k8s.io/kubernetes/cmd/kubeadm/app/cmd/phases/reset.runCleanupNode(0x1d10820, 0xc00055b780, 0x1e6f4fd, 0xc)
	/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/cmd/kubeadm/app/cmd/phases/reset/cleanupnode.go:95 +0x701
k8s.io/kubernetes/cmd/kubeadm/app/cmd/phases/workflow.(*Runner).Run.func1(0xc0002f7400, 0x0, 0x0)
	/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/cmd/kubeadm/app/cmd/phases/workflow/runner.go:234 +0x1ac
k8s.io/kubernetes/cmd/kubeadm/app/cmd/phases/workflow.(*Runner).visitAll(0xc00065c6c0, 0xc00069fcc0, 0x0, 0x2)
	/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/cmd/kubeadm/app/cmd/phases/workflow/runner.go:421 +0x6e
```

```release-note
NONE
```