### PR TITLE
Bump `distroless/base` image to latest version

### DIFF
--- a/cluster/images/kubemark/Dockerfile
+++ b/cluster/images/kubemark/Dockerfile
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM gcr.io/distroless/base:latest
+# The line below points to distroless/base as of 2021-06-29. The SHA should be
+# kept in sycn with distroless_base definition in the WORKSPACE file.
+FROM gcr.io/distroless/base@sha256:5e3fac1733c75e0e879a9770724e3960610a5cfbbfb5366559fbc334fe86c249
 
 COPY kubemark /kubemark

--- a/cluster/images/kubemark/Dockerfile
+++ b/cluster/images/kubemark/Dockerfile
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# The line below points to distroless/base as of 2019-11-15. The SHA should be
-# kept in sycn with distroless_base definition in the WORKSPACE file.
-FROM gcr.io/distroless/base@sha256:7fa7445dfbebae4f4b7ab0e6ef99276e96075ae42584af6286ba080750d6dfe5
+FROM gcr.io/distroless/base:latest
 
 COPY kubemark /kubemark


### PR DESCRIPTION
`distroless/base:latest` is a multi-arched image now, this will help the `kubemark` works properly
on the platforms other than `amd64`


verified on ARM64, 

```
docker image inspect gcr.io/distroless/base:latest | grep Architecture
"Architecture": "arm64",
```

```
docker image inspect gcr.io/distroless/base@sha256:7fa7445dfbebae4f4b7ab0e6ef99276e96075ae42584af6286ba080750d6dfe5 | grep Architecture

"Architecture": "amd64",
```



Signed-off-by: Dave Chen <dave.chen@arm.com>


/kind bug



#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Ref https://github.com/kubernetes/kubernetes/pull/88513
Ref: https://github.com/GoogleContainerTools/distroless/blob/main/base/distro.bzl

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
