### PR TITLE
Readable error message on the plugin configs of the removed plugins

### DIFF
--- a/pkg/scheduler/apis/config/validation/validation.go
+++ b/pkg/scheduler/apis/config/validation/validation.go
@@ -201,31 +201,6 @@ func validatePluginConfig(path *field.Path, apiVersion string, profile *config.K
 		"VolumeBinding":               ValidateVolumeBindingArgs,
 	}
 
-	seenPluginConfig := make(sets.String)
-	for i := range profile.PluginConfig {
-		pluginConfigPath := path.Child("pluginConfig").Index(i)
-		name := profile.PluginConfig[i].Name
-		args := profile.PluginConfig[i].Args
-		if seenPluginConfig.Has(name) {
-			errs = append(errs, field.Duplicate(pluginConfigPath, name))
-		} else {
-			seenPluginConfig.Insert(name)
-		}
-		if validateFunc, ok := m[name]; ok {
-			// type mismatch, no need to validate the `args`.
-			if reflect.TypeOf(args) != reflect.ValueOf(validateFunc).Type().In(1) {
-				errs = append(errs, field.Invalid(pluginConfigPath.Child("args"), args, "has to match plugin args"))
-				return errs
-			}
-			in := []reflect.Value{reflect.ValueOf(pluginConfigPath.Child("args")), reflect.ValueOf(args)}
-			res := reflect.ValueOf(validateFunc).Call(in)
-			// It's possible that validation function return a Aggregate, just append here and it will be flattened at the end of CC validation.
-			if res[0].Interface() != nil {
-				errs = append(errs, res[0].Interface().(error))
-			}
-		}
-	}
-
 	if profile.Plugins != nil {
 		stagesToPluginSet := map[string]config.PluginSet{
 			"queueSort":  profile.Plugins.QueueSort,
@@ -248,6 +223,36 @@ func validatePluginConfig(path *field.Path, apiVersion string, profile *config.K
 		}
 		errs = append(errs, validateScorePluginSetForConflictPlugins(
 			pluginsPath.Child("score"), apiVersion, profile)...)
+	}
+
+	seenPluginConfig := make(sets.String)
+
+	// validate plugin config at the end because we will return the aggregated errors early if type of args doesn't match.
+	// validate plugin config at the end will will help to collect as much as misconfiguration as possible.
+	for i := range profile.PluginConfig {
+		pluginConfigPath := path.Child("pluginConfig").Index(i)
+		name := profile.PluginConfig[i].Name
+		args := profile.PluginConfig[i].Args
+		if seenPluginConfig.Has(name) {
+			errs = append(errs, field.Duplicate(pluginConfigPath, name))
+		} else {
+			seenPluginConfig.Insert(name)
+		}
+		if removed, removedVersion := isPluginRemoved(apiVersion, name); removed {
+			errs = append(errs, field.Invalid(pluginConfigPath, name, fmt.Sprintf("was removed in version %q (KubeSchedulerConfiguration is version %q)", removedVersion, apiVersion)))
+		} else if validateFunc, ok := m[name]; ok {
+			// type mismatch, no need to validate the `args`.
+			if reflect.TypeOf(args) != reflect.ValueOf(validateFunc).Type().In(1) {
+				errs = append(errs, field.Invalid(pluginConfigPath.Child("args"), args, "has to match plugin args"))
+				return errs
+			}
+			in := []reflect.Value{reflect.ValueOf(pluginConfigPath.Child("args")), reflect.ValueOf(args)}
+			res := reflect.ValueOf(validateFunc).Call(in)
+			// It's possible that validation function return a Aggregate, just append here and it will be flattened at the end of CC validation.
+			if res[0].Interface() != nil {
+				errs = append(errs, res[0].Interface().(error))
+			}
+		}
 	}
 	return errs
 }

--- a/pkg/scheduler/apis/config/validation/validation_test.go
+++ b/pkg/scheduler/apis/config/validation/validation_test.go
@@ -254,8 +254,8 @@ func TestValidateKubeSchedulerConfiguration(t *testing.T) {
 	goodConflictPlugins2.Profiles[0].Plugins.Score.Enabled = append(goodConflictPlugins2.Profiles[0].Plugins.Score.Enabled, config.Plugin{Name: "NodeResourcesMostAllocated", Weight: 2})
 	goodConflictPlugins2.Profiles[0].Plugins.Score.Enabled = append(goodConflictPlugins2.Profiles[0].Plugins.Score.Enabled, config.Plugin{Name: "RequestedToCapacityRatio", Weight: 2})
 
-	badPluginsConfig := validConfig.DeepCopy()
-	badPluginsConfig.Profiles[0].PluginConfig = append(badPluginsConfig.Profiles[0].PluginConfig, config.PluginConfig{
+	deprecatedPluginsConfig := validConfig.DeepCopy()
+	deprecatedPluginsConfig.Profiles[0].PluginConfig = append(deprecatedPluginsConfig.Profiles[0].PluginConfig, config.PluginConfig{
 		Name: "NodeResourcesLeastAllocated",
 		Args: &config.NodeResourcesLeastAllocatedArgs{},
 	})
@@ -392,7 +392,7 @@ func TestValidateKubeSchedulerConfiguration(t *testing.T) {
 		},
 		"bad-plugins-config": {
 			expectedToFail: true,
-			config:         badPluginsConfig,
+			config:         deprecatedPluginsConfig,
 			errorString:    "profiles[0].pluginConfig[1]: Invalid value: \"NodeResourcesLeastAllocated\": was removed in version \"kubescheduler.config.k8s.io/v1beta2\" (KubeSchedulerConfiguration is version \"kubescheduler.config.k8s.io/v1beta2\")",
 		},
 	}

--- a/pkg/scheduler/apis/config/validation/validation_test.go
+++ b/pkg/scheduler/apis/config/validation/validation_test.go
@@ -254,6 +254,12 @@ func TestValidateKubeSchedulerConfiguration(t *testing.T) {
 	goodConflictPlugins2.Profiles[0].Plugins.Score.Enabled = append(goodConflictPlugins2.Profiles[0].Plugins.Score.Enabled, config.Plugin{Name: "NodeResourcesMostAllocated", Weight: 2})
 	goodConflictPlugins2.Profiles[0].Plugins.Score.Enabled = append(goodConflictPlugins2.Profiles[0].Plugins.Score.Enabled, config.Plugin{Name: "RequestedToCapacityRatio", Weight: 2})
 
+	badPluginsConfig := validConfig.DeepCopy()
+	badPluginsConfig.Profiles[0].PluginConfig = append(badPluginsConfig.Profiles[0].PluginConfig, config.PluginConfig{
+		Name: "NodeResourcesLeastAllocated",
+		Args: &config.NodeResourcesLeastAllocatedArgs{},
+	})
+
 	scenarios := map[string]struct {
 		expectedToFail bool
 		config         *config.KubeSchedulerConfiguration
@@ -383,6 +389,11 @@ func TestValidateKubeSchedulerConfiguration(t *testing.T) {
 		"good-conflict-plugins-2": {
 			expectedToFail: false,
 			config:         goodConflictPlugins2,
+		},
+		"bad-plugins-config": {
+			expectedToFail: true,
+			config:         badPluginsConfig,
+			errorString:    "profiles[0].pluginConfig[1]: Invalid value: \"NodeResourcesLeastAllocated\": was removed in version \"kubescheduler.config.k8s.io/v1beta2\" (KubeSchedulerConfiguration is version \"kubescheduler.config.k8s.io/v1beta2\")",
 		},
 	}
 


### PR DESCRIPTION
Several plugins are removed in the v1beta2, but the legacy scheduler
config would still have the plugin configs of those removed plugins.

It was throwing raw byte data when those plugin configs are still in
place which will hard to read and understand.

Fix it by checking the removed plugin config before the validation of
the plugin args.

Signed-off-by: Dave Chen <dave.chen@arm.com>

/kind bug


#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes/kubernetes/issues/103478

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```


/sig scheduling