### PR TITLE
kubeadm: fix godoc formatting for v1beta3

### DIFF
--- a/cmd/kubeadm/app/apis/kubeadm/v1beta3/doc.go
+++ b/cmd/kubeadm/app/apis/kubeadm/v1beta3/doc.go
@@ -23,26 +23,26 @@ limitations under the License.
 // This version improves on the v1beta2 format by fixing some minor issues and adding a few new fields.
 //
 // A list of changes since v1beta2:
-// - The deprecated "ClusterConfiguration.useHyperKubeImage" field has been removed.
-// Kubeadm no longer supports the hyperkube image.
-// - The "ClusterConfiguration.DNS.Type" field has been removed since CoreDNS is the only supported
-// DNS server type by kubeadm.
-// - Include "datapolicy" tags on the fields that hold secrets.
-// This would result in the field values to be omitted when API structures are printed with klog.
-// - Add "InitConfiguration.SkipPhases", "JoinConfiguration.SkipPhases" to allow skipping
-// a list of phases during kubeadm init/join command execution.
-// - Add "InitConfiguration.NodeRegistration.ImagePullPolicy" and "JoinConfiguration.NodeRegistration.ImagePullPolicy"
-// to allow specifying the images pull policy during kubeadm "init" and "join". The value must be one of "Always", "Never" or
-// "IfNotPresent". "IfNotPresent" is the default, which has been the existing behavior prior to this addition.
-// - Add "InitConfiguration.Patches.Directory", "JoinConfiguration.Patches.Directory" to allow
-// the user to configure a directory from which to take patches for components deployed by kubeadm.
-// - Move the BootstrapToken* API and related utilities out of the "kubeadm" API group to a new group
-// "bootstraptoken". The kubeadm API version v1beta3 no longer contains the BootstrapToken* structures.
+//	- The deprecated "ClusterConfiguration.useHyperKubeImage" field has been removed.
+//	Kubeadm no longer supports the hyperkube image.
+//	- The "ClusterConfiguration.DNS.Type" field has been removed since CoreDNS is the only supported
+//	DNS server type by kubeadm.
+//	- Include "datapolicy" tags on the fields that hold secrets.
+//	This would result in the field values to be omitted when API structures are printed with klog.
+//	- Add "InitConfiguration.SkipPhases", "JoinConfiguration.SkipPhases" to allow skipping
+//	a list of phases during kubeadm init/join command execution.
+//	- Add "InitConfiguration.NodeRegistration.ImagePullPolicy" and "JoinConfiguration.NodeRegistration.ImagePullPolicy"
+//	to allow specifying the images pull policy during kubeadm "init" and "join". The value must be one of "Always", "Never" or
+//	"IfNotPresent". "IfNotPresent" is the default, which has been the existing behavior prior to this addition.
+//	- Add "InitConfiguration.Patches.Directory", "JoinConfiguration.Patches.Directory" to allow
+//	the user to configure a directory from which to take patches for components deployed by kubeadm.
+//	- Move the BootstrapToken* API and related utilities out of the "kubeadm" API group to a new group
+//	"bootstraptoken". The kubeadm API version v1beta3 no longer contains the BootstrapToken* structures.
 //
 // Migration from old kubeadm config versions
 //
-// - kubeadm v1.15.x and newer can be used to migrate from the v1beta1 to v1beta2.
-// - kubeadm v1.22.x no longer supports v1beta1 and older APIs, but can be used to migrate v1beta2 to v1beta3.
+//	- kubeadm v1.15.x and newer can be used to migrate from v1beta1 to v1beta2.
+//	- kubeadm v1.22.x and newer no longer support v1beta1 and older APIs, but can be used to migrate v1beta2 to v1beta3.
 //
 // Basics
 //


### PR DESCRIPTION
#### What this PR does / why we need it:

Fix indentation of entries in the changelog and the migration steps.
fixes formatting at https://pkg.go.dev/k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1beta3

v1beta2 has similar indentation:
https://github.com/kubernetes/kubernetes/blob/master/cmd/kubeadm/app/apis/kubeadm/v1beta2/doc.go#L25-L37

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
