### PR TITLE
Hide long and multiline strings when printing

### DIFF
--- a/staging/src/k8s.io/cli-runtime/pkg/printers/tableprinter_test.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/printers/tableprinter_test.go
@@ -722,3 +722,70 @@ func TestUnknownTypePrinting(t *testing.T) {
 		t.Errorf("An error was expected from printing unknown type")
 	}
 }
+
+func TestStringPrinting(t *testing.T) {
+	tests := []struct {
+		columns  []metav1.TableColumnDefinition
+		rows     []metav1.TableRow
+		expected string
+	}{
+		// multiline string
+		{
+			columns: []metav1.TableColumnDefinition{
+				{Name: "Name", Type: "string"},
+				{Name: "Age", Type: "string"},
+				{Name: "Description", Type: "string"},
+			},
+			rows: []metav1.TableRow{
+				{Cells: []interface{}{"test1", "20h", "This is first line\nThis is second line\nThis is third line\nand another one\n"}},
+			},
+			expected: `NAME    AGE   DESCRIPTION
+test1   20h   This is first line + 56 more...
+`,
+		},
+		// lengthy string
+		{
+			columns: []metav1.TableColumnDefinition{
+				{Name: "Name", Type: "string"},
+				{Name: "Age", Type: "string"},
+				{Name: "Description", Type: "string"},
+			},
+			rows: []metav1.TableRow{
+				{Cells: []interface{}{"test1", "20h", "This is first line which is long and goes for on and on and on an on and on and on and on and on and on and on and on and on and on and on"}},
+			},
+			expected: `NAME    AGE   DESCRIPTION
+test1   20h   This is first line which is long and goes for on and on and on an on and on and on and on and on and + 38 more...
+`,
+		},
+		// lengthy string + newline
+		{
+			columns: []metav1.TableColumnDefinition{
+				{Name: "Name", Type: "string"},
+				{Name: "Age", Type: "string"},
+				{Name: "Description", Type: "string"},
+			},
+			rows: []metav1.TableRow{
+				{Cells: []interface{}{"test1", "20h", "This is first\n line which is long and goes for on and on and on an on and on and on and on and on and on and on and on and on and on and on"}},
+			},
+			expected: `NAME    AGE   DESCRIPTION
+test1   20h   This is first + 126 more...
+`,
+		},
+	}
+
+	for _, test := range tests {
+		// Create the table from the columns and rows.
+		table := &metav1.Table{
+			ColumnDefinitions: test.columns,
+			Rows:              test.rows,
+		}
+		// Print the table
+		out := bytes.NewBuffer([]byte{})
+		printer := NewTablePrinter(PrintOptions{})
+		printer.PrintObj(table, out)
+
+		if test.expected != out.String() {
+			t.Errorf("Table printing error: expected \n(%s), got \n(%s)", test.expected, out.String())
+		}
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?
/kind bug
/kind cleanup
/sig cli

#### What this PR does / why we need it:
Currently both long strings and multi-line strings can potentially "break" printing. Example:
```
insights    4.9.0-0.ci-2021-07-05-195740    3h8m    This is first line
This is second line
This is third line
and another one
```
I'm adding extra formatting to ensure we cut strings either at newline or at 100 chars with information that more information
is available. With the fix:
```
insights    4.9.0-0.ci-2021-07-05-195740    3h8m    This is first line + 56 more...
```
#### Special notes for your reviewer:
/assign @sttts

#### Does this PR introduce a user-facing change?
```release-note
`kubectl get` now truncates multi-line strings to avoid breaking printing
```

