### PR TITLE
deprecate unused option deployment-controller-sync-period for deploym…

### DIFF
--- a/cmd/kube-controller-manager/app/options/deploymentcontroller.go
+++ b/cmd/kube-controller-manager/app/options/deploymentcontroller.go
@@ -35,6 +35,7 @@ func (o *DeploymentControllerOptions) AddFlags(fs *pflag.FlagSet) {
 
 	fs.Int32Var(&o.ConcurrentDeploymentSyncs, "concurrent-deployment-syncs", o.ConcurrentDeploymentSyncs, "The number of deployment objects that are allowed to sync concurrently. Larger number = more responsive deployments, but more CPU (and network) load")
 	fs.DurationVar(&o.DeploymentControllerSyncPeriod.Duration, "deployment-controller-sync-period", o.DeploymentControllerSyncPeriod.Duration, "Period for syncing the deployments.")
+	fs.MarkDeprecated("deployment-controller-sync-period", "This flag is currently no-op and will be removed in v1.24.")
 }
 
 // ApplyTo fills up DeploymentController config with options.


### PR DESCRIPTION
…ent controller

#### What type of PR is this?
/kind cleanup


#### What this PR does / why we need it:
`deployment-controller-sync-period` option is unused in code, deprecate it.
```shell
grep -r 'DeploymentControllerSyncPeriod'
cmd/kube-controller-manager/app/options/options_test.go:				DeploymentControllerSyncPeriod: metav1.Duration{Duration: 45 * time.Second},
cmd/kube-controller-manager/app/options/options_test.go:				DeploymentControllerSyncPeriod: metav1.Duration{Duration: 45 * time.Second},
cmd/kube-controller-manager/app/options/deploymentcontroller.go:	fs.DurationVar(&o.DeploymentControllerSyncPeriod.Duration, "deployment-controller-sync-period", o.DeploymentControllerSyncPeriod.Duration, "Period for syncing the deployments.")
cmd/kube-controller-manager/app/options/deploymentcontroller.go:	cfg.DeploymentControllerSyncPeriod = o.DeploymentControllerSyncPeriod
_output/KUBE_violations.report:API rule violation: names_match,k8s.io/kube-controller-manager/config/v1alpha1,DeploymentControllerConfiguration,DeploymentControllerSyncPeriod
staging/src/k8s.io/kube-controller-manager/config/v1alpha1/zz_generated.deepcopy.go:	out.DeploymentControllerSyncPeriod = in.DeploymentControllerSyncPeriod
staging/src/k8s.io/kube-controller-manager/config/v1alpha1/types.go:	DeploymentControllerSyncPeriod metav1.Duration
pkg/controller/deployment/config/zz_generated.deepcopy.go:	out.DeploymentControllerSyncPeriod = in.DeploymentControllerSyncPeriod
pkg/controller/deployment/config/types.go:	DeploymentControllerSyncPeriod metav1.Duration
pkg/controller/deployment/config/v1alpha1/zz_generated.conversion.go:	out.DeploymentControllerSyncPeriod = in.DeploymentControllerSyncPeriod
pkg/controller/deployment/config/v1alpha1/zz_generated.conversion.go:	out.DeploymentControllerSyncPeriod = in.DeploymentControllerSyncPeriod
pkg/controller/deployment/config/v1alpha1/defaults.go:	if obj.DeploymentControllerSyncPeriod == zero {
pkg/controller/deployment/config/v1alpha1/defaults.go:		obj.DeploymentControllerSyncPeriod = metav1.Duration{Duration: 30 * time.Second}
pkg/generated/openapi/zz_generated.openapi.go:					"DeploymentControllerSyncPeriod": {
pkg/generated/openapi/zz_generated.openapi.go:				Required: []string{"ConcurrentDeploymentSyncs", "DeploymentControllerSyncPeriod"},
api/api-rules/violation_exceptions.list:API rule violation: names_match,k8s.io/kube-controller-manager/config/v1alpha1,DeploymentControllerConfiguration,DeploymentControllerSyncPeriod

```
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
the flag `--deployment-controller-sync-period` has no effect now, deprecate it and will be removed in v1.24.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
