### PR TITLE
Bump version of Addon Resizer used by Metrics Server

### DIFF
--- a/cluster/addons/metrics-server/metrics-server-deployment.yaml
+++ b/cluster/addons/metrics-server/metrics-server-deployment.yaml
@@ -69,7 +69,7 @@ spec:
         - mountPath: /tmp
           name: tmp-dir
       - name: metrics-server-nanny
-        image: k8s.gcr.io/autoscaling/addon-resizer:1.8.13
+        image: k8s.gcr.io/autoscaling/addon-resizer:1.8.14
         resources:
           limits:
             cpu: 100m


### PR DESCRIPTION
To pull in two fixes it needs to continue working in 1.22:

- Updated dependencies,
- Using new metric for getting node count.

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

We need to bump Addon Manager version or it will stop working in 1.22

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
Metrics Server will use Addon Manager 1.8.3
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
