### PR TITLE
apf: fix bootstrap ensurer log message

### DIFF
--- a/pkg/registry/flowcontrol/rest/storage_flowcontrol.go
+++ b/pkg/registry/flowcontrol/rest/storage_flowcontrol.go
@@ -129,7 +129,7 @@ func ensureAPFBootstrapConfiguration(hookContext genericapiserver.PostStartHookC
 	// we have successfully initialized the bootstrap configuration, now we
 	// spin up a goroutine which reconciles the bootstrap configuration periodically.
 	go func() {
-		err := wait.PollImmediateUntil(
+		wait.PollImmediateUntil(
 			time.Minute,
 			func() (bool, error) {
 				if err := ensure(clientset); err != nil {
@@ -138,9 +138,7 @@ func ensureAPFBootstrapConfiguration(hookContext genericapiserver.PostStartHookC
 				// always auto update both suggested and mandatory configuration
 				return false, nil
 			}, hookContext.StopCh)
-		if err != nil {
-			klog.ErrorS(err, "APF bootstrap ensurer is exiting")
-		}
+		klog.Info("APF bootstrap ensurer is exiting")
 	}()
 
 	return nil


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:
when the server shuts down the apf bootstrap ensurer should not print its exit message as an error.

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
