### PR TITLE
fix CleanScope so we can resolve correct verb for apiserver_request_terminations_total

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/endpoints/metrics/metrics.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/metrics/metrics.go
@@ -514,11 +514,11 @@ func InstrumentHandlerFunc(verb, group, version, resource, subresource, scope, c
 
 // CleanScope returns the scope of the request.
 func CleanScope(requestInfo *request.RequestInfo) string {
-	if requestInfo.Namespace != "" {
-		return "namespace"
-	}
 	if requestInfo.Name != "" {
 		return "resource"
+	}
+	if requestInfo.Namespace != "" {
+		return "namespace"
 	}
 	if requestInfo.IsResourceRequest {
 		return "cluster"


### PR DESCRIPTION
This pr fixes #103563 by returning correct scope of requests with namespace and name


#### What type of PR is this?

/kind bug 

#### What this PR does / why we need it:
This pr fixes #103563 by returning correct scope of requests with namespace and name, so we can end up with correct verb for metrics such as `apiserver_longrunning_gauge`, `apiserver_request_terminations_total `

#### Which issue(s) this PR fixes:
Fixes #103563

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
Fix "verb" and "scope" tag in apiserver_longrunning_gauge and apiserver_request_terminations_total  such that a GET namespaced object by name call will have verb "GET" instead of "LIST", and scope "resource" instead of "namespace"
```

/sig api-machinery
/cc @wojtek-t 
