### PR TITLE
Fix index out of range if multiple default plugins are overridden

### DIFF
--- a/cmd/kube-scheduler/app/options/configfile.go
+++ b/cmd/kube-scheduler/app/options/configfile.go
@@ -87,30 +87,6 @@ func LogOrWriteConfig(fileName string, cfg *config.KubeSchedulerConfiguration, c
 	}
 	cfg.Profiles = completedProfiles
 
-	if len(fileName) > 0 {
-		// Since the default component config lists all the default plugins as enabled
-		// without disabling them, we must explicitly disable all the plugins for each
-		// extension point using the "*" expression to ensure that the generated config
-		// file is usable
-		disabledPlugins := []config.Plugin{{Name: "*"}}
-		for i := range cfg.Profiles {
-			if cfg.Profiles[i].Plugins == nil {
-				continue
-			}
-			cfg.Profiles[i].Plugins.QueueSort.Disabled = disabledPlugins
-			cfg.Profiles[i].Plugins.PreFilter.Disabled = disabledPlugins
-			cfg.Profiles[i].Plugins.Filter.Disabled = disabledPlugins
-			cfg.Profiles[i].Plugins.PostFilter.Disabled = disabledPlugins
-			cfg.Profiles[i].Plugins.PreScore.Disabled = disabledPlugins
-			cfg.Profiles[i].Plugins.Score.Disabled = disabledPlugins
-			cfg.Profiles[i].Plugins.Reserve.Disabled = disabledPlugins
-			cfg.Profiles[i].Plugins.Permit.Disabled = disabledPlugins
-			cfg.Profiles[i].Plugins.PreBind.Disabled = disabledPlugins
-			cfg.Profiles[i].Plugins.Bind.Disabled = disabledPlugins
-			cfg.Profiles[i].Plugins.PostBind.Disabled = disabledPlugins
-		}
-	}
-
 	buf, err := encodeConfig(cfg)
 	if err != nil {
 		return err

--- a/pkg/scheduler/apis/config/v1beta2/default_plugins_test.go
+++ b/pkg/scheduler/apis/config/v1beta2/default_plugins_test.go
@@ -367,6 +367,7 @@ func TestMergePlugins(t *testing.T) {
 				Filter: v1beta2.PluginSet{
 					Enabled: []v1beta2.Plugin{
 						{Name: "Plugin1", Weight: pointer.Int32Ptr(2)},
+						{Name: "Plugin3", Weight: pointer.Int32Ptr(3)},
 					},
 				},
 			},
@@ -374,6 +375,8 @@ func TestMergePlugins(t *testing.T) {
 				Filter: v1beta2.PluginSet{
 					Enabled: []v1beta2.Plugin{
 						{Name: "Plugin1"},
+						{Name: "Plugin2"},
+						{Name: "Plugin3"},
 					},
 				},
 			},
@@ -381,6 +384,8 @@ func TestMergePlugins(t *testing.T) {
 				Filter: v1beta2.PluginSet{
 					Enabled: []v1beta2.Plugin{
 						{Name: "Plugin1", Weight: pointer.Int32Ptr(2)},
+						{Name: "Plugin2"},
+						{Name: "Plugin3", Weight: pointer.Int32Ptr(3)},
 					},
 				},
 			},
@@ -391,6 +396,38 @@ func TestMergePlugins(t *testing.T) {
 				Filter: v1beta2.PluginSet{
 					Enabled: []v1beta2.Plugin{
 						{Name: "Plugin2", Weight: pointer.Int32Ptr(2)},
+						{Name: "Plugin1", Weight: pointer.Int32Ptr(1)},
+					},
+				},
+			},
+			defaultPlugins: &v1beta2.Plugins{
+				Filter: v1beta2.PluginSet{
+					Enabled: []v1beta2.Plugin{
+						{Name: "Plugin1"},
+						{Name: "Plugin2"},
+						{Name: "Plugin3"},
+					},
+				},
+			},
+			expectedPlugins: &v1beta2.Plugins{
+				Filter: v1beta2.PluginSet{
+					Enabled: []v1beta2.Plugin{
+						{Name: "Plugin1", Weight: pointer.Int32Ptr(1)},
+						{Name: "Plugin2", Weight: pointer.Int32Ptr(2)},
+						{Name: "Plugin3"},
+					},
+				},
+			},
+		},
+		{
+			name: "RepeatedCustomPlugin",
+			customPlugins: &v1beta2.Plugins{
+				Filter: v1beta2.PluginSet{
+					Enabled: []v1beta2.Plugin{
+						{Name: "Plugin1"},
+						{Name: "Plugin2", Weight: pointer.Int32Ptr(2)},
+						{Name: "Plugin3"},
+						{Name: "Plugin2", Weight: pointer.Int32Ptr(4)},
 					},
 				},
 			},
@@ -407,8 +444,9 @@ func TestMergePlugins(t *testing.T) {
 				Filter: v1beta2.PluginSet{
 					Enabled: []v1beta2.Plugin{
 						{Name: "Plugin1"},
-						{Name: "Plugin2", Weight: pointer.Int32Ptr(2)},
+						{Name: "Plugin2", Weight: pointer.Int32Ptr(4)},
 						{Name: "Plugin3"},
+						{Name: "Plugin2", Weight: pointer.Int32Ptr(2)},
 					},
 				},
 			},


### PR DESCRIPTION
Commit1: Fix index out of range if multiple default plugins are overridden - https://github.com/kubernetes/kubernetes/issues/103572
Commit2: Revert https://github.com/kubernetes/kubernetes/pull/103327 


Signed-off-by: Dave Chen <dave.chen@arm.com>


/kind bug


#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes/kubernetes/issues/103572

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
