### PR TITLE
Restore ability to print long strings

### DIFF
--- a/staging/src/k8s.io/cli-runtime/pkg/printers/tableprinter.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/printers/tableprinter.go
@@ -32,8 +32,6 @@ import (
 	"k8s.io/apimachinery/pkg/watch"
 )
 
-const maxStringLength = 100
-
 var _ ResourcePrinter = &HumanReadablePrinter{}
 
 type printHandler struct {
@@ -213,21 +211,16 @@ func printTable(table *metav1.Table, output io.Writer, options PrintOptions) err
 				switch val := cell.(type) {
 				case string:
 					print := val
-					more := 0
-					// cut to maxStringLength
-					if len(val) > maxStringLength {
-						more = len(print) - maxStringLength
-						print = print[:maxStringLength]
-					}
-					// and also check for newlines
+					truncated := false
+					// truncate at newlines
 					newline := strings.Index(print, "\n")
 					if newline >= 0 {
-						more = more + len(print) - newline
+						truncated = true
 						print = print[:newline]
 					}
 					fmt.Fprint(output, print)
-					if more > 0 {
-						fmt.Fprintf(output, " + %d more...", more)
+					if truncated {
+						fmt.Fprint(output, "...")
 					}
 				default:
 					fmt.Fprint(output, val)

--- a/staging/src/k8s.io/cli-runtime/pkg/printers/tableprinter_test.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/printers/tableprinter_test.go
@@ -740,7 +740,7 @@ func TestStringPrinting(t *testing.T) {
 				{Cells: []interface{}{"test1", "20h", "This is first line\nThis is second line\nThis is third line\nand another one\n"}},
 			},
 			expected: `NAME    AGE   DESCRIPTION
-test1   20h   This is first line + 56 more...
+test1   20h   This is first line...
 `,
 		},
 		// lengthy string
@@ -754,7 +754,7 @@ test1   20h   This is first line + 56 more...
 				{Cells: []interface{}{"test1", "20h", "This is first line which is long and goes for on and on and on an on and on and on and on and on and on and on and on and on and on and on"}},
 			},
 			expected: `NAME    AGE   DESCRIPTION
-test1   20h   This is first line which is long and goes for on and on and on an on and on and on and on and on and + 38 more...
+test1   20h   This is first line which is long and goes for on and on and on an on and on and on and on and on and on and on and on and on and on and on
 `,
 		},
 		// lengthy string + newline
@@ -768,7 +768,7 @@ test1   20h   This is first line which is long and goes for on and on and on an 
 				{Cells: []interface{}{"test1", "20h", "This is first\n line which is long and goes for on and on and on an on and on and on and on and on and on and on and on and on and on and on"}},
 			},
 			expected: `NAME    AGE   DESCRIPTION
-test1   20h   This is first + 126 more...
+test1   20h   This is first...
 `,
 		},
 	}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Reverts the long string truncation added in https://github.com/kubernetes/kubernetes/pull/103514 until it can be done in a less invasive or more adaptive way. Kept the multi-line truncation.

```release-note
NONE
```

/assign @soltysh 
/sig cli