### PR TITLE
Restore the ability to print long strings, but still cut newlines

### DIFF
--- a/staging/src/k8s.io/cli-runtime/pkg/printers/tableprinter.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/printers/tableprinter.go
@@ -32,8 +32,6 @@ import (
 	"k8s.io/apimachinery/pkg/watch"
 )
 
-const maxStringLength = 100
-
 var _ ResourcePrinter = &HumanReadablePrinter{}
 
 type printHandler struct {
@@ -214,12 +212,6 @@ func printTable(table *metav1.Table, output io.Writer, options PrintOptions) err
 				case string:
 					print := val
 					more := 0
-					// cut to maxStringLength
-					if len(val) > maxStringLength {
-						more = len(print) - maxStringLength
-						print = print[:maxStringLength]
-					}
-					// and also check for newlines
 					newline := strings.Index(print, "\n")
 					if newline >= 0 {
 						more = more + len(print) - newline

--- a/staging/src/k8s.io/cli-runtime/pkg/printers/tableprinter_test.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/printers/tableprinter_test.go
@@ -743,34 +743,6 @@ func TestStringPrinting(t *testing.T) {
 test1   20h   This is first line + 56 more...
 `,
 		},
-		// lengthy string
-		{
-			columns: []metav1.TableColumnDefinition{
-				{Name: "Name", Type: "string"},
-				{Name: "Age", Type: "string"},
-				{Name: "Description", Type: "string"},
-			},
-			rows: []metav1.TableRow{
-				{Cells: []interface{}{"test1", "20h", "This is first line which is long and goes for on and on and on an on and on and on and on and on and on and on and on and on and on and on"}},
-			},
-			expected: `NAME    AGE   DESCRIPTION
-test1   20h   This is first line which is long and goes for on and on and on an on and on and on and on and on and + 38 more...
-`,
-		},
-		// lengthy string + newline
-		{
-			columns: []metav1.TableColumnDefinition{
-				{Name: "Name", Type: "string"},
-				{Name: "Age", Type: "string"},
-				{Name: "Description", Type: "string"},
-			},
-			rows: []metav1.TableRow{
-				{Cells: []interface{}{"test1", "20h", "This is first\n line which is long and goes for on and on and on an on and on and on and on and on and on and on and on and on and on and on"}},
-			},
-			expected: `NAME    AGE   DESCRIPTION
-test1   20h   This is first + 126 more...
-`,
-		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
Alternative to #103574

This drops only the long line support from #103514, but still keeps cutting newlines from the output. 

#### Special notes for your reviewer:
/assign @liggitt 

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
