### PR TITLE
[PodSecurity] Aggregate identical warnings for multiple pods in a namespace

### DIFF
--- a/staging/src/k8s.io/pod-security-admission/admission/admission.go
+++ b/staging/src/k8s.io/pod-security-admission/admission/admission.go
@@ -428,7 +428,10 @@ func (a *Admission) EvaluatePodsInNamespace(ctx context.Context, namespace strin
 		return []string{"Failed to list pods"}
 	}
 
-	var warnings []string
+	var (
+		warnings        []string
+		warningsPodsMap = make(map[string][]string)
+	)
 	if len(pods) > namespaceMaxPodsToCheck {
 		warnings = append(warnings, fmt.Sprintf("Large namespace: only checking the first %d of %d pods", namespaceMaxPodsToCheck, len(pods)))
 		pods = pods[0:namespaceMaxPodsToCheck]
@@ -441,15 +444,34 @@ func (a *Admission) EvaluatePodsInNamespace(ctx context.Context, namespace strin
 		}
 		r := policy.AggregateCheckResults(a.Evaluator.EvaluatePod(enforce, &pod.ObjectMeta, &pod.Spec))
 		if !r.Allowed {
-			// TODO: consider aggregating results (e.g. multiple pods failed for the same reasons)
-			warnings = append(warnings, fmt.Sprintf("%s: %s", pod.Name, r.ForbiddenReason()))
+			warningsPodsMap[r.ForbiddenReason()] = append(warningsPodsMap[r.ForbiddenReason()], pod.Name)
 		}
 		if time.Now().After(deadline) {
+			warnings = aggregatePodsWarnings(warningsPodsMap, warnings)
 			return append(warnings, fmt.Sprintf("Timeout reached after checking %d pods", i+1))
 		}
 	}
 
-	return warnings
+	return aggregatePodsWarnings(warningsPodsMap, warnings)
+}
+
+// Convert unordered map to []string
+func aggregatePodsWarnings(podsWarings map[string][]string, warning []string) []string {
+	var aggregatePodsWarning []string
+	for reason, podNames := range podsWarings {
+		var aggregaterPods string
+		switch len(podNames) {
+		case 1:
+			aggregaterPods = podNames[0]
+		case 2:
+			aggregaterPods = fmt.Sprintf("%s (and 1 other pod)", podNames[0])
+		default:
+			aggregaterPods = fmt.Sprintf("%s (and %d other pods)", podNames[0], len(podNames)-1)
+		}
+		aggregatePodsWarning = append(aggregatePodsWarning, fmt.Sprintf("%s: %s", aggregaterPods, reason))
+	}
+
+	return append(warning, aggregatePodsWarning...)
 }
 
 func (a *Admission) PolicyToEvaluate(labels map[string]string) (api.Policy, error) {

--- a/staging/src/k8s.io/pod-security-admission/admission/admission_test.go
+++ b/staging/src/k8s.io/pod-security-admission/admission/admission_test.go
@@ -18,7 +18,6 @@ package admission
 
 import (
 	"context"
-	"reflect"
 	"strings"
 	"testing"
 
@@ -351,7 +350,7 @@ func TestValidateNamespace(t *testing.T) {
 			expectAllowed:  true,
 			expectListPods: true,
 			expectEvaluate: api.LevelVersion{Level: api.LevelRestricted, Version: api.LatestVersion()},
-			expectWarnings: []string{"noruntimeclasspod: message", "runtimeclass1pod: message", "runtimeclass2pod: message"},
+			expectWarnings: []string{"noruntimeclasspod (and 2 other pods): message", "runtimeclass3pod: message, message2"},
 		},
 		{
 			name:                 "update with runtimeclass exempt pods",
@@ -361,10 +360,9 @@ func TestValidateNamespace(t *testing.T) {
 			expectAllowed:        true,
 			expectListPods:       true,
 			expectEvaluate:       api.LevelVersion{Level: api.LevelRestricted, Version: api.LatestVersion()},
-			expectWarnings:       []string{"noruntimeclasspod: message", "runtimeclass2pod: message"},
+			expectWarnings:       []string{"noruntimeclasspod (and 1 other pod): message", "runtimeclass3pod: message, message2"},
 		},
 
-		// TODO: test for aggregating pods with identical warnings
 		// TODO: test for bounding evalution time with a warning
 		// TODO: test for bounding pod count with a warning
 		// TODO: test for prioritizing evaluating pods from unique controllers
@@ -423,6 +421,9 @@ func TestValidateNamespace(t *testing.T) {
 						ObjectMeta: metav1.ObjectMeta{Name: "runtimeclass2pod", Annotations: map[string]string{"error": "message"}},
 						Spec:       corev1.PodSpec{RuntimeClassName: pointer.String("runtimeclass2")},
 					},
+					{
+						ObjectMeta: metav1.ObjectMeta{Name: "runtimeclass3pod", Annotations: map[string]string{"error": "message, message2"}},
+					},
 				}
 			}
 			podLister := &testPodLister{pods: pods}
@@ -459,9 +460,7 @@ func TestValidateNamespace(t *testing.T) {
 			if evaluator.lv != tc.expectEvaluate {
 				t.Errorf("expected to evaluate %v, got %v", tc.expectEvaluate, evaluator.lv)
 			}
-			if !reflect.DeepEqual(result.Warnings, tc.expectWarnings) {
-				t.Errorf("expected warnings:\n%v\ngot\n%v", tc.expectWarnings, result.Warnings)
-			}
+			assertAggregatePodsWarnings(t, tc.expectWarnings, result.Warnings)
 		})
 	}
 }
@@ -639,4 +638,22 @@ func TestValidatePodController(t *testing.T) {
 			assert.Equal(t, tc.expectWarnings, result.Warnings, "unexpected Warnings")
 		})
 	}
+}
+
+func assertAggregatePodsWarnings(t *testing.T, expected, actual []string) {
+	e, a := make(map[string]string), make(map[string]string)
+	for _, warning := range expected {
+		warningSplit := strings.Split(warning, ": ")
+		podNames := warningSplit[0]
+		reasons := warningSplit[1]
+		e[podNames] = reasons
+	}
+	for _, warning := range actual {
+		warningSplit := strings.Split(warning, ": ")
+		podNames := warningSplit[0]
+		reasons := warningSplit[1]
+		a[podNames] = reasons
+	}
+
+	assert.Equal(t, e, a, "unexpected warnings")
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
part-4 of #103561
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #103213

#### Special notes for your reviewer:
1. Use `map[string][]string` to storage the podname of `the same reason`
2. Convert unordered  map `podsWarings` to []string `warnings`, the order of the checkers that `output` warnings each time is not guaranteed.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
https://github.com/kubernetes/enhancements/tree/master/keps/sig-auth/2579-psp-replacement
```

/sig auth security
