### PR TITLE
Update the containerd runtime binary - GCE Windows

### DIFF
--- a/cluster/gce/windows/k8s-node-setup.psm1
+++ b/cluster/gce/windows/k8s-node-setup.psm1
@@ -1584,9 +1584,10 @@ function Install_Containerd {
   $tmp_dir = 'C:\containerd_tmp'
   New-Item $tmp_dir -ItemType 'directory' -Force | Out-Null
 
-  # TODO(ibrahimab) Change this to a gcs bucket with CI maintained and accessible by community.
-  $version = '1.4.4'
-  $tar_url = ("https://github.com/containerd/containerd/releases/download/v${version}/" +
+  # TODO(ibrahimab) Change this to pick from a CI maintained and accessible by community.
+  # Current (1.5.2) version on the gke-release bucket is patched with PR pull/5411 on containerd repo.
+  $version = '1.5.2'
+  $tar_url = ("https://storage.googleapis.com/gke-release/winnode/containerd/${version}/" +
               "cri-containerd-cni-${version}-windows-amd64.tar.gz")
   $sha_url = $tar_url + ".sha256sum"
   MustDownload-File -URLs $sha_url -OutFile $tmp_dir\sha256sum


### PR DESCRIPTION

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Update the Containerd binaries to latest (1.5.2) version. The latest binary includes the fix for csi driver handling (#5411).

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

No

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
