### PR TITLE
WIP - Ensure integration tests populate user info

### DIFF
--- a/test/integration/framework/controlplane_utils.go
+++ b/test/integration/framework/controlplane_utils.go
@@ -78,11 +78,12 @@ func (alwaysAllow) Authorize(ctx context.Context, requestAttributes authorizer.A
 	return authorizer.DecisionAllow, "always allow", nil
 }
 
-// alwaysEmpty simulates "no authentication" for old tests
-func alwaysEmpty(req *http.Request) (*authauthenticator.Response, bool, error) {
+// unsecuredUser simulates requests to the unsecured endpoint for old tests
+func unsecuredUser(req *http.Request) (*authauthenticator.Response, bool, error) {
 	return &authauthenticator.Response{
 		User: &user.DefaultInfo{
-			Name: "",
+			Name:   "system:unsecured",
+			Groups: []string{user.SystemPrivilegedGroup, user.AllAuthenticated},
 		},
 	}, true, nil
 }
@@ -174,7 +175,7 @@ func startAPIServerOrDie(controlPlaneConfig *controlplane.Config, incomingServer
 
 	tokenAuthenticator := authenticatorfactory.NewFromTokens(tokens, controlPlaneConfig.GenericConfig.Authentication.APIAudiences)
 	if controlPlaneConfig.GenericConfig.Authentication.Authenticator == nil {
-		controlPlaneConfig.GenericConfig.Authentication.Authenticator = authenticatorunion.New(tokenAuthenticator, authauthenticator.RequestFunc(alwaysEmpty))
+		controlPlaneConfig.GenericConfig.Authentication.Authenticator = authenticatorunion.New(tokenAuthenticator, authauthenticator.RequestFunc(unsecuredUser))
 	} else {
 		controlPlaneConfig.GenericConfig.Authentication.Authenticator = authenticatorunion.New(tokenAuthenticator, controlPlaneConfig.GenericConfig.Authentication.Authenticator)
 	}


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Populates user info in requests to the API server in integration tests

xref https://github.com/kubernetes/kubernetes/issues/96647

might help with https://github.com/kubernetes/kubernetes/issues/103512#issuecomment-876529966


```release-note
NONE
```