### PR TITLE
websocket: migrate to gorilla/websocket

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -51,6 +51,7 @@ require (
 	github.com/google/gofuzz v1.1.0
 	github.com/google/uuid v1.1.2
 	github.com/googleapis/gnostic v0.5.5
+	github.com/gorilla/websocket v1.4.2
 	github.com/heketi/heketi v10.3.0+incompatible
 	github.com/heketi/tests v0.0.0-20151005000721-f3775cbcefd6 // indirect
 	github.com/ishidawataru/sctp v0.0.0-20190723014705-7c296d48a2b5

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -459,6 +459,7 @@ github.com/gophercloud/gophercloud/openstack/networking/v2/ports
 github.com/gophercloud/gophercloud/openstack/utils
 github.com/gophercloud/gophercloud/pagination
 # github.com/gorilla/websocket v1.4.2 => github.com/gorilla/websocket v1.4.2
+## explicit
 github.com/gorilla/websocket
 # github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7 => github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7
 github.com/gregjones/httpcache


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This change migrates away from golang.org/x/net/websocket, in favor
of github.com/gorilla/websocket. The main motivation for this change
is I would like to run the e2e tests through a squid proxy to reach
the remote cluster. Largely this just works, however the
golang.org/x/net/websocket package does not support this and these
tests fail for me when going through a proxy.

The [docs for net/websocket](https://pkg.go.dev/golang.org/x/net/websocket)
even point out that gorilla/websocket is more actively maintained and
supports more features.

gorilla/websocket is already available as well, so we're not introducing
any additional dependencies.

#### Which issue(s) this PR fixes:

N/A

#### Special notes for your reviewer:

N/A

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

I'm using this squid configuration:

```
http_access allow all
http_port 3128
debug_options ALL,1 33,2 28,9
dns_v4_first on
coredump_dir /var/spool/squid
```
Launched as:

```
  sudo podman run -d --rm \
     --net host \
     --volume $PWD/squid.conf:/etc/squid/squid.conf \
     --name squid \
     docker.io/sameersbn/squid:3.5.27-2
```


When using a proxy with golang.org/x/net/websocket, the tests fail:

```bash
export HTTP_PROXY=http://10.N.N.N:3128
export HTTPS_PROXY=http://10.N.N.N:3128
```

```
$ ./_output/bin/ginkgo -p -focus ".*websocket.*"  ./test/e2e
[...]
Summarizing 4 Failures:

[Fail] [sig-node] Pods [It] should support remote command execution over websockets [NodeConformance] [Conformance] 
/home/stbenjam/go/src/github.com/kubernetes/kubernetes/vendor/github.com/onsi/ginkgo/internal/leafnodes/runner.go:113

[Fail] [sig-node] Pods [It] should support retrieving logs from the container over websockets [NodeConformance] [Conformance] 
/home/stbenjam/go/src/github.com/kubernetes/kubernetes/vendor/github.com/onsi/ginkgo/internal/leafnodes/runner.go:113

[Fail] [sig-cli] Kubectl Port forwarding With a server listening on 0.0.0.0 [It] should support forwarding over websockets 
/home/stbenjam/go/src/github.com/kubernetes/kubernetes/test/e2e/kubectl/portforward.go:469

[Fail] [sig-cli] Kubectl Port forwarding With a server listening on localhost [It] should support forwarding over websockets 
/home/stbenjam/go/src/github.com/kubernetes/kubernetes/test/e2e/kubectl/portforward.go:491

Ran 4 of 6433 Specs in 16.684 seconds
FAIL! -- 0 Passed | 4 Failed | 0 Pending | 6429 Skipped


Ginkgo ran 1 suite in 35.950365959s
Test Suite Failed
```


With this PR:

```
$ ./_output/bin/ginkgo -p -focus ".*websocket.*"  ./test/e2e
[...]
Ran 4 of 6433 Specs in 16.594 seconds
SUCCESS! -- 4 Passed | 0 Failed | 0 Pending | 6429 Skipped


Ginkgo ran 1 suite in 39.173493889s
Test Suite Passed
```