### PR TITLE
Promote `ingressclass.kubernetes.io/is-default-class` annotation to networking/v1

### DIFF
--- a/plugin/pkg/admission/network/defaultingressclass/admission.go
+++ b/plugin/pkg/admission/network/defaultingressclass/admission.go
@@ -133,7 +133,7 @@ func getDefaultClass(lister networkingv1listers.IngressClassLister) (*networking
 
 	defaultClasses := []*networkingv1.IngressClass{}
 	for _, class := range list {
-		if class.Annotations[networkingv1beta1.AnnotationIsDefaultIngressClass] == "true" {
+		if class.Annotations[networkingv1.AnnotationIsDefaultIngressClass] == "true" {
 			defaultClasses = append(defaultClasses, class)
 		}
 	}

--- a/plugin/pkg/admission/network/defaultingressclass/admission_test.go
+++ b/plugin/pkg/admission/network/defaultingressclass/admission_test.go
@@ -43,7 +43,7 @@ func TestAdmission(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "default1",
 			Annotations: map[string]string{
-				networkingv1beta1.AnnotationIsDefaultIngressClass: "true",
+				networkingv1.AnnotationIsDefaultIngressClass: "true",
 			},
 		},
 	}
@@ -51,7 +51,7 @@ func TestAdmission(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "default2",
 			Annotations: map[string]string{
-				networkingv1beta1.AnnotationIsDefaultIngressClass: "true",
+				networkingv1.AnnotationIsDefaultIngressClass: "true",
 			},
 		},
 	}
@@ -63,7 +63,7 @@ func TestAdmission(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "nondefault1",
 			Annotations: map[string]string{
-				networkingv1beta1.AnnotationIsDefaultIngressClass: "false",
+				networkingv1.AnnotationIsDefaultIngressClass: "false",
 			},
 		},
 	}
@@ -84,7 +84,7 @@ func TestAdmission(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "nondefault2",
 			Annotations: map[string]string{
-				networkingv1beta1.AnnotationIsDefaultIngressClass: "",
+				networkingv1.AnnotationIsDefaultIngressClass: "",
 			},
 		},
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
According to KEP, this annotation  `ingressclass.kubernetes.io/is-default-class` should have been updated to `networking/v1` in version 1.20.

Ref https://github.com/kubernetes/enhancements/issues/1453
Ref #43214
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->


#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- https://github.com/kubernetes/enhancements/tree/master/keps/sig-network/1453-ingress-api
```
