### PR TITLE
E2E test for kubelet exit-on-lock-contention

### DIFF
--- a/test/e2e_node/lock_contention_test.go
+++ b/test/e2e_node/lock_contention_test.go
@@ -1,0 +1,81 @@
+// +build linux
+
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2enode
+
+import (
+	"time"
+
+	"golang.org/x/sys/unix"
+
+	"github.com/onsi/ginkgo"
+	"github.com/onsi/gomega"
+	"k8s.io/kubernetes/test/e2e/framework"
+)
+
+const contentionLockFile = "/var/run/kubelet.lock"
+
+var _ = SIGDescribe("Lock contention [Slow] [Disruptive] [NodeFeature:LockContention]", func() {
+
+	ginkgo.It("Kubelet should stop when the test acquires the lock on lock file and restart once the lock is released", func() {
+
+		ginkgo.By("perform kubelet health check to check if kubelet is healthy and running.")
+		// Precautionary check that kubelet is healthy before running the test.
+		gomega.Expect(kubeletHealthCheck(kubeletHealthCheckURL)).To(gomega.BeTrue())
+
+		ginkgo.By("acquiring the lock on lock file i.e /var/run/kubelet.lock")
+		// Open the file with the intention to acquire the lock, this would imitate the behaviour
+		// of the another kubelet(self-hosted) trying to start. When this lock contention happens
+		// it is expected that the running kubelet must terminate and wait until the lock on the
+		// lock file is released.
+		// Kubelet uses the same approach to acquire the lock on lock file as shown here:
+		// https://github.com/kubernetes/kubernetes/blob/master/cmd/kubelet/app/server.go#L530-#L546
+		// and the function definition of Acquire is here:
+		// https://github.com/kubernetes/kubernetes/blob/master/pkg/util/flock/flock_unix.go#L25
+		fd, err := unix.Open(contentionLockFile, unix.O_CREAT|unix.O_RDWR|unix.O_CLOEXEC, 0600)
+		framework.ExpectNoError(err)
+		// Defer the lock release in case test fails and we don't reach the step of the release
+		// lock. This ensures that we release the lock for sure.
+		defer func() {
+			err = unix.Flock(fd, unix.LOCK_UN)
+			framework.ExpectNoError(err)
+		}()
+		// Acquire lock.
+		err = unix.Flock(fd, unix.LOCK_EX)
+		framework.ExpectNoError(err)
+
+		ginkgo.By("verifying the kubelet is not healthy as there was a lock contention.")
+		// Once the lock is acquired, check if the kubelet is in healthy state or not.
+		// It should not be.
+		gomega.Eventually(func() bool {
+			return kubeletHealthCheck(kubeletHealthCheckURL)
+		}, 10*time.Second, time.Second).Should(gomega.BeFalse())
+
+		ginkgo.By("releasing the lock on lock file i.e /var/run/kubelet.lock")
+		// Release the lock.
+		err = unix.Flock(fd, unix.LOCK_UN)
+		framework.ExpectNoError(err)
+
+		ginkgo.By("verifying the kubelet is healthy again after the lock was released.")
+		// Releasing the lock triggers kubelet to re-acquire the lock and restart.
+		// Hence the kubelet should report healthy state.
+		gomega.Eventually(func() bool {
+			return kubeletHealthCheck(kubeletHealthCheckURL)
+		}, 10*time.Second, time.Second).Should(gomega.BeTrue())
+	})
+})


### PR DESCRIPTION
#### What type of PR is this?

/sig node
/kind feature

#### What this PR does / why we need it:

This PR adds an e2e test for the kubelet flags `--lock-file` and `exit-on-lock-contention`.  Eventually we would like to move them to the kubelet configuration file rather than flags. Having an E2E test helps us move forward with confidence.

This PR is created to supersede #96775.

Requesting the author of the original PR #96775 to acknowledge the same and provide further steps on the original PR. Can #96775 be closed in favor of this ? 

#### Which issue(s) this PR fixes:

Fixes #96766

#### Special notes for your reviewer:

This PR is created to supersede #96775.

Requesting the reviewers of the original PR @ike-ma @tallclair @dchen1107 to please provide your reviews. 

To test this PR locally:
```
make test-e2e-node REMOTE=false TEST_ARGS="--kubelet-flags=\"--lock-file=/var/run/kubelet.lock --exit-on-lock-contention --v 4\"" FOCUS="\[NodeFeature:LockContention\]" SKIP="\[Flaky\]|\[Serial\]"
```

This PR takes a different approach than the original PR :

1. It doesn't need the e2e test suite flag `--restart-kubelet` which was merged in the PR #97028,  I presume in preparation of  #96775. In fact if the sole purposet of `--restart-kubelet` flag was for #96775 then I believe we can remove `--restart-kubelet` flag on the e2e test suite.

2. To check whether the kubelet is running or not, this PR takes the approach of kubelet health check instead of performing a regex on the systemctl output checking if there is any `kubelet-*` service in running state. The downside of that approach  is that it binds the test to an environment where init system is
`systemd`

Instead, this test is based on the premise that whenever there is a lock contention of the lock file (e.g. /var/run/kubelet.lock), the running kubelet must terminate and wait for the lock on the lock file to be released before starting again.

In this test we simulate that behaviour of a lock file contention. The test would try to acquire the lock on the lock file.

Success of the test is determined by kubelet health check which fails when the lock is acquired by the test and passes when the lock on the lock file is released.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```

/cc @rata @knabben 

