### PR TITLE
Make khenidak a sig-net approver

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -275,6 +275,7 @@ aliases:
     - dcbw
     - freehan
     - johnbelamaric
+    - khenidak
     - mrhohn
     - thockin
   sig-network-reviewers:
@@ -287,6 +288,7 @@ aliases:
     - dcbw
     - freehan
     - johnbelamaric
+    - khenidak
     - m1093782566
     - mrhohn
     - rramkumar1


### PR DESCRIPTION
/kind cleanup
/sig network

Following the community guidelines, I'd like to nominate @khenidak as sig-network approver

He meets all the requirements https://github.com/kubernetes/community/blob/master/community-membership.md#reviewer 

- [x]  Member for at least 3 months
- [x] Primary reviewer for at least 5 PRs to the codebase
- [x]  Reviewed or merged at least 20 substantial PRs to the codebase https://github.com/kubernetes/kubernetes/pulls?q=is%3Apr+author%3Akhenidak+is%3Aclosed
- [x] Knowledgeable about the codebase
- [x] Sponsored by a subproject approver

```release-note
NONE
```