### PR TITLE
remove unnecessary function after PR #88885 merged

### DIFF
--- a/staging/src/k8s.io/cli-runtime/pkg/resource/visitor.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/resource/visitor.go
@@ -693,16 +693,6 @@ func RetrieveLazy(info *Info, err error) error {
 	return nil
 }
 
-// CreateAndRefresh creates an object from input info and refreshes info with that object
-func CreateAndRefresh(info *Info) error {
-	obj, err := NewHelper(info.Client, info.Mapping).Create(info.Namespace, true, info.Object)
-	if err != nil {
-		return err
-	}
-	info.Refresh(obj, true)
-	return nil
-}
-
 type FilterFunc func(info *Info, err error) (bool, error)
 
 type FilteredVisitor struct {


### PR DESCRIPTION
What type of PR is this?
/kind cleanup

What this PR does / why we need it:
Ref: #88885
The function `CreateAndRefresh()` definition is unnecessary after this PR merged.

![image](https://user-images.githubusercontent.com/47560998/125217237-c16c5f00-e2f2-11eb-9fc8-f5791ac06b69.png)


Which issue(s) this PR fixes:


Does this PR introduce a user-facing change?:
```release-notes
NONE
```

Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```release-notes
NONE
```