### PR TITLE
Revert "use PermitWithoutStream=true for etcd: send pings even without active stream"

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/storagebackend/factory/etcd3.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/storagebackend/factory/etcd3.go
@@ -171,7 +171,6 @@ func newETCD3Client(c storagebackend.TransportConfig) (*clientv3.Client, error) 
 		DialTimeout:          dialTimeout,
 		DialKeepAliveTime:    keepaliveTime,
 		DialKeepAliveTimeout: keepaliveTimeout,
-		PermitWithoutStream:  true,
 		DialOptions:          dialOptions,
 		Endpoints:            c.ServerList,
 		TLS:                  tlsConfig,


### PR DESCRIPTION
Reverts kubernetes/kubernetes#101604

To avoid the "too many pings" issue in https://github.com/kubernetes/kubernetes/issues/103512

See https://github.com/kubernetes/kubernetes/issues/103512#issuecomment-878085936

> I thought it is only a client configuration. But it seems that configuration in server-side is also needed.
> The --grpc-keepalive-min-time of etcd should be configured if we set PermitWithoutStream to true
> 
> https://github.com/etcd-io/etcd/blob/184b0e5d4964f1115590acec50fa5e584a2f7770/server/embed/etcd.go#L716-L722
> if --grpc-keepalive-min-time > 0 , PermitWithoutStream is false on server side.

As etcd `--grpc-keepalive-min-time ` is default 5s, we cannot set `PermitWithoutStream=true` here.