### PR TITLE
[WIP] test pull-kubernetes-integration timeouts

### DIFF
--- a/hack/jenkins/test-dockerized.sh
+++ b/hack/jenkins/test-dockerized.sh
@@ -45,6 +45,10 @@ export KUBE_KEEP_VERBOSE_TEST_OUTPUT=y
 export KUBE_INTEGRATION_TEST_MAX_CONCURRENCY=4
 export LOG_LEVEL=4
 
+# Increase ephemeral port range
+sysctl -w net.ipv4.ip_local_port_range="20000 60999"
+sysctl -w net.ipv4.tcp_fin_timeout=30
+
 cd "${GOPATH}/src/k8s.io/kubernetes"
 
 make generated_files

--- a/hack/lib/etcd.sh
+++ b/hack/lib/etcd.sh
@@ -82,8 +82,8 @@ kube::etcd::start() {
   else
     ETCD_LOGFILE=${ETCD_LOGFILE:-"/dev/null"}
   fi
-  kube::log::info "etcd --advertise-client-urls ${KUBE_INTEGRATION_ETCD_URL} --data-dir ${ETCD_DIR} --listen-client-urls http://${ETCD_HOST}:${ETCD_PORT} --log-level=debug > \"${ETCD_LOGFILE}\" 2>/dev/null"
-  etcd --advertise-client-urls "${KUBE_INTEGRATION_ETCD_URL}" --data-dir "${ETCD_DIR}" --listen-client-urls "${KUBE_INTEGRATION_ETCD_URL}" --log-level=debug 2> "${ETCD_LOGFILE}" >/dev/null &
+  kube::log::info "etcd --advertise-client-urls ${KUBE_INTEGRATION_ETCD_URL} --data-dir ${ETCD_DIR} --listen-client-urls http://${ETCD_HOST}:${ETCD_PORT} --unsafe-no-fsync --log-level=debug > \"${ETCD_LOGFILE}\" 2>/dev/null"
+  etcd --advertise-client-urls "${KUBE_INTEGRATION_ETCD_URL}" --data-dir "${ETCD_DIR}" --listen-client-urls "${KUBE_INTEGRATION_ETCD_URL}" --unsafe-no-fsync --log-level=debug 2> "${ETCD_LOGFILE}" >/dev/null &
   ETCD_PID=$!
 
   echo "Waiting for etcd to come up."

--- a/staging/src/k8s.io/pod-security-admission/test/run.go
+++ b/staging/src/k8s.io/pod-security-admission/test/run.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"sort"
 	"strings"
 	"sync"
 	"testing"
@@ -83,59 +82,22 @@ func checksForLevelAndVersion(checks []policy.Check, level api.Level, version ap
 	return retval, nil
 }
 
-// computeVersionsToTest returns all the versions that have distinct checks defined,
-// all the versions that have distinct minimal valid pod fixtures defined, and
-// any hard-coded versions that should always be tested.
-//
-// This lets us sparsely test all versions with distinct fixture or policy changes
-// without needing to exercise every intermediate version that had no changes.
-func computeVersionsToTest(t *testing.T, checks []policy.Check) []api.Version {
-	seenVersions := map[api.Version]bool{}
-
-	// include all versions we have registered distinct checks for
+// maxMinorVersionToTest returns the maximum minor version to exercise for a given set of checks.
+// checks are assumed to be well-formed and valid to pass to policy.NewEvaluator().
+func maxMinorVersionToTest(checks []policy.Check) (int, error) {
+	// start with the release under development (1.22 at time of writing).
+	// this can be incremented to the current version whenever is convenient.
+	maxTestMinor := 22
 	for _, check := range checks {
-		for _, checkVersion := range check.Versions {
-			if checkVersion.MinimumVersion.Major() != 1 {
-				t.Fatalf("expected major version 1, got %d", checkVersion.MinimumVersion.Major())
-			}
-			seenVersions[checkVersion.MinimumVersion] = true
+		lastCheckVersion := check.Versions[len(check.Versions)-1].MinimumVersion
+		if lastCheckVersion.Major() != 1 {
+			return 0, fmt.Errorf("expected major version 1, got %d", lastCheckVersion.Major())
+		}
+		if lastCheckVersion.Minor() > maxTestMinor {
+			maxTestMinor = lastCheckVersion.Minor()
 		}
 	}
-	if len(seenVersions) == 0 {
-		t.Fatal("no versions defined for checks")
-	}
-
-	// include all versions we have registered distinct fixtures for
-	for _, versionsForLevel := range minimalValidPods {
-		for version := range versionsForLevel {
-			if version.Major() != 1 {
-				t.Fatalf("expected major version 1, got %d", version.Major())
-			}
-			seenVersions[version] = true
-		}
-	}
-
-	alwaysIncludeVersions := []api.Version{
-		// include the oldest version by default
-		api.MajorMinorVersion(1, 0),
-		// include the release under development (1.22 at time of writing).
-		// this can be incremented to the current version whenever is convenient.
-		// TODO: find a way to use api.LatestVersion() here
-		api.MajorMinorVersion(1, 22),
-	}
-	for _, version := range alwaysIncludeVersions {
-		seenVersions[version] = true
-	}
-
-	versions := []api.Version{}
-	for version := range seenVersions {
-		versions = append(versions, version)
-	}
-	sort.Slice(versions, func(i, j int) bool { return versions[i].Older(versions[j]) })
-
-	// TODO: consider exposing an option to test all versions instead of sparse ones
-
-	return versions
+	return maxTestMinor, nil
 }
 
 type testWarningHandler struct {
@@ -178,12 +140,15 @@ func Run(t *testing.T, opts Options) {
 	if err != nil {
 		t.Fatalf("invalid checks: %v", err)
 	}
-
-	versionsToTest := computeVersionsToTest(t, opts.Checks)
+	maxMinor, err := maxMinorVersionToTest(opts.Checks)
+	if err != nil {
+		t.Fatalf("invalid checks: %v", err)
+	}
 
 	for _, level := range []api.Level{api.LevelBaseline, api.LevelRestricted} {
-		for _, version := range versionsToTest {
-			minor := version.Minor()
+		for minor := 0; minor <= maxMinor; minor++ {
+			version := api.MajorMinorVersion(1, minor)
+
 			// create test name
 			ns := fmt.Sprintf("podsecurity-%s-1-%d", level, minor)
 

--- a/test/integration/auth/rbac_test.go
+++ b/test/integration/auth/rbac_test.go
@@ -518,124 +518,125 @@ func TestRBAC(t *testing.T) {
 	}
 
 	for i, tc := range tests {
-		// Create an API Server.
-		controlPlaneConfig := framework.NewIntegrationTestControlPlaneConfig()
-		controlPlaneConfig.GenericConfig.Authorization.Authorizer = newRBACAuthorizer(t, controlPlaneConfig)
-		controlPlaneConfig.GenericConfig.Authentication.Authenticator = bearertoken.New(tokenfile.New(map[string]*user.DefaultInfo{
-			superUser:                          {Name: "admin", Groups: []string{"system:masters"}},
-			"any-rolebinding-writer":           {Name: "any-rolebinding-writer"},
-			"any-rolebinding-writer-namespace": {Name: "any-rolebinding-writer-namespace"},
-			"bob":                              {Name: "bob"},
-			"job-writer":                       {Name: "job-writer"},
-			"job-writer-namespace":             {Name: "job-writer-namespace"},
-			"nonescalating-rolebinding-writer": {Name: "nonescalating-rolebinding-writer"},
-			"pod-reader":                       {Name: "pod-reader"},
-			"limitrange-updater":               {Name: "limitrange-updater"},
-			"limitrange-patcher":               {Name: "limitrange-patcher"},
-			"user-with-no-permissions":         {Name: "user-with-no-permissions"},
-		}))
-		controlPlaneConfig.GenericConfig.OpenAPIConfig = framework.DefaultOpenAPIConfig()
-		_, s, closeFn := framework.RunAnAPIServer(controlPlaneConfig)
-		defer closeFn()
+		t.Run(fmt.Sprintf("TestRBAC_%d", i), func(t *testing.T) {
+			// Create an API Server.
+			controlPlaneConfig := framework.NewIntegrationTestControlPlaneConfig()
+			controlPlaneConfig.GenericConfig.Authorization.Authorizer = newRBACAuthorizer(t, controlPlaneConfig)
+			controlPlaneConfig.GenericConfig.Authentication.Authenticator = bearertoken.New(tokenfile.New(map[string]*user.DefaultInfo{
+				superUser:                          {Name: "admin", Groups: []string{"system:masters"}},
+				"any-rolebinding-writer":           {Name: "any-rolebinding-writer"},
+				"any-rolebinding-writer-namespace": {Name: "any-rolebinding-writer-namespace"},
+				"bob":                              {Name: "bob"},
+				"job-writer":                       {Name: "job-writer"},
+				"job-writer-namespace":             {Name: "job-writer-namespace"},
+				"nonescalating-rolebinding-writer": {Name: "nonescalating-rolebinding-writer"},
+				"pod-reader":                       {Name: "pod-reader"},
+				"limitrange-updater":               {Name: "limitrange-updater"},
+				"limitrange-patcher":               {Name: "limitrange-patcher"},
+				"user-with-no-permissions":         {Name: "user-with-no-permissions"},
+			}))
+			controlPlaneConfig.GenericConfig.OpenAPIConfig = framework.DefaultOpenAPIConfig()
+			_, s, closeFn := framework.RunAnAPIServer(controlPlaneConfig)
+			defer closeFn()
 
-		clientConfig := &restclient.Config{Host: s.URL, ContentConfig: restclient.ContentConfig{NegotiatedSerializer: legacyscheme.Codecs}}
+			clientConfig := &restclient.Config{Host: s.URL, ContentConfig: restclient.ContentConfig{NegotiatedSerializer: legacyscheme.Codecs}}
 
-		// Bootstrap the API Server with the test case's initial roles.
-		superuserClient, _ := clientsetForToken(superUser, clientConfig)
-		if err := tc.bootstrapRoles.bootstrap(superuserClient); err != nil {
-			t.Errorf("case %d: failed to apply initial roles: %v", i, err)
-			continue
-		}
-		previousResourceVersion := make(map[string]float64)
+			// Bootstrap the API Server with the test case's initial roles.
+			superuserClient, _ := clientsetForToken(superUser, clientConfig)
+			if err := tc.bootstrapRoles.bootstrap(superuserClient); err != nil {
+				t.Fatalf("case %d: failed to apply initial roles: %v", i, err)
+			}
+			previousResourceVersion := make(map[string]float64)
 
-		for j, r := range tc.requests {
-			path := "/"
-			if r.apiGroup == "" {
-				path = gopath.Join(path, "api/v1")
-			} else {
-				path = gopath.Join(path, "apis", r.apiGroup, "v1")
-			}
-			if r.namespace != "" {
-				path = gopath.Join(path, "namespaces", r.namespace)
-			}
-			if r.resource != "" {
-				path = gopath.Join(path, r.resource)
-			}
-			if r.name != "" {
-				path = gopath.Join(path, r.name)
-			}
+			for j, r := range tc.requests {
+				path := "/"
+				if r.apiGroup == "" {
+					path = gopath.Join(path, "api/v1")
+				} else {
+					path = gopath.Join(path, "apis", r.apiGroup, "v1")
+				}
+				if r.namespace != "" {
+					path = gopath.Join(path, "namespaces", r.namespace)
+				}
+				if r.resource != "" {
+					path = gopath.Join(path, r.resource)
+				}
+				if r.name != "" {
+					path = gopath.Join(path, r.name)
+				}
 
-			var body io.Reader
-			if r.body != "" {
-				sub := ""
-				if r.verb == "PUT" {
-					// For update operations, insert previous resource version
-					if resVersion := previousResourceVersion[getPreviousResourceVersionKey(path, "")]; resVersion != 0 {
-						sub += fmt.Sprintf(",\"resourceVersion\": \"%v\"", resVersion)
+				var body io.Reader
+				if r.body != "" {
+					sub := ""
+					if r.verb == "PUT" {
+						// For update operations, insert previous resource version
+						if resVersion := previousResourceVersion[getPreviousResourceVersionKey(path, "")]; resVersion != 0 {
+							sub += fmt.Sprintf(",\"resourceVersion\": \"%v\"", resVersion)
+						}
 					}
+					body = strings.NewReader(fmt.Sprintf(r.body, sub))
 				}
-				body = strings.NewReader(fmt.Sprintf(r.body, sub))
-			}
 
-			req, err := http.NewRequest(r.verb, s.URL+path, body)
-			if r.verb == "PATCH" {
-				// For patch operations, use the apply content type
-				req.Header.Add("Content-Type", string(types.ApplyPatchType))
-				q := req.URL.Query()
-				q.Add("fieldManager", "rbac_test")
-				req.URL.RawQuery = q.Encode()
-			}
+				req, err := http.NewRequest(r.verb, s.URL+path, body)
+				if r.verb == "PATCH" {
+					// For patch operations, use the apply content type
+					req.Header.Add("Content-Type", string(types.ApplyPatchType))
+					q := req.URL.Query()
+					q.Add("fieldManager", "rbac_test")
+					req.URL.RawQuery = q.Encode()
+				}
 
-			if err != nil {
-				t.Fatalf("failed to create request: %v", err)
-			}
-
-			func() {
-				reqDump, err := httputil.DumpRequest(req, true)
 				if err != nil {
-					t.Fatalf("failed to dump request: %v", err)
-					return
+					t.Fatalf("failed to create request: %v", err)
 				}
 
-				resp, err := clientForToken(r.token).Do(req)
-				if err != nil {
-					t.Errorf("case %d, req %d: failed to make request: %v", i, j, err)
-					return
-				}
-				defer resp.Body.Close()
-
-				respDump, err := httputil.DumpResponse(resp, true)
-				if err != nil {
-					t.Fatalf("failed to dump response: %v", err)
-					return
-				}
-
-				if resp.StatusCode != r.expectedStatus {
-					// When debugging is on, dump the entire request and response. Very helpful for
-					// debugging malformed test cases.
-					//
-					// To turn on debugging, use the '-args' flag.
-					//
-					//    go test -v -tags integration -run RBAC -args -v 10
-					//
-					klog.V(8).Infof("case %d, req %d: %s\n%s\n", i, j, reqDump, respDump)
-					t.Errorf("case %d, req %d: %s expected %q got %q", i, j, r, statusCode(r.expectedStatus), statusCode(resp.StatusCode))
-				}
-
-				b, _ := ioutil.ReadAll(resp.Body)
-
-				if r.verb == "POST" && (resp.StatusCode/100) == 2 {
-					// For successful create operations, extract resourceVersion
-					id, currentResourceVersion, err := parseResourceVersion(b)
-					if err == nil {
-						key := getPreviousResourceVersionKey(path, id)
-						previousResourceVersion[key] = currentResourceVersion
-					} else {
-						t.Logf("error in trying to extract resource version: %s", err)
+				func() {
+					reqDump, err := httputil.DumpRequest(req, true)
+					if err != nil {
+						t.Fatalf("failed to dump request: %v", err)
+						return
 					}
-				}
-			}()
-		}
+
+					resp, err := clientForToken(r.token).Do(req)
+					if err != nil {
+						t.Errorf("case %d, req %d: failed to make request: %v", i, j, err)
+						return
+					}
+					defer resp.Body.Close()
+
+					respDump, err := httputil.DumpResponse(resp, true)
+					if err != nil {
+						t.Fatalf("failed to dump response: %v", err)
+						return
+					}
+
+					if resp.StatusCode != r.expectedStatus {
+						// When debugging is on, dump the entire request and response. Very helpful for
+						// debugging malformed test cases.
+						//
+						// To turn on debugging, use the '-args' flag.
+						//
+						//    go test -v -tags integration -run RBAC -args -v 10
+						//
+						klog.V(8).Infof("case %d, req %d: %s\n%s\n", i, j, reqDump, respDump)
+						t.Errorf("case %d, req %d: %s expected %q got %q", i, j, r, statusCode(r.expectedStatus), statusCode(resp.StatusCode))
+					}
+
+					b, _ := ioutil.ReadAll(resp.Body)
+
+					if r.verb == "POST" && (resp.StatusCode/100) == 2 {
+						// For successful create operations, extract resourceVersion
+						id, currentResourceVersion, err := parseResourceVersion(b)
+						if err == nil {
+							key := getPreviousResourceVersionKey(path, id)
+							previousResourceVersion[key] = currentResourceVersion
+						} else {
+							t.Logf("error in trying to extract resource version: %s", err)
+						}
+					}
+				}()
+			}
+		})
 	}
 }
 


### PR DESCRIPTION

there is something odd with the TCP connections errors

From the logs in https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/103635/pull-kubernetes-integration/1414506047057432576 , the ones with `failed to read frame` , we can see that the test iterates over all the ephemeral ports (these are the port assigned by the OS as source, they are taking from a pool defined in the kernel incrementally)

```sh
$ cat  /proc/sys/net/ipv4/ip_local_port_range                                                                                                                                                                                                                           32768	60999
$ grep "failed to read frame" etcd.6f2a034c-e2ed-11eb-88c2-06073436da28.root.log.DEBUG.20210712-0* | cut -d\> -f 2 | cut -d\:  -f2 | sort -u | head -n2
33432
33476
$ grep "failed to read frame" etcd.6f2a034c-e2ed-11eb-88c2-06073436da28.root.log.DEBUG.20210712-0* | cut -d\> -f 2 | cut -d\:  -f2 | sort -u | tail -n2
60878
60960
$ grep "failed to read frame" etcd.6f2a034c-e2ed-11eb-88c2-06073436da28.root.log.DEBUG.20210712-0* | cut -d\> -f 2 | cut -d\:  -f2 | wc
    653     653    3918
```

ref https://github.com/kubernetes/kubernetes/issues/103512