### PR TITLE
Revert counting deleted pods as failures for Job

### DIFF
--- a/pkg/controller/job/job_controller_test.go
+++ b/pkg/controller/job/job_controller_test.go
@@ -1066,6 +1066,16 @@ func TestGetStatus(t *testing.T) {
 			wantFailed:    4,
 		},
 		"deleted pods": {
+			pods: []*v1.Pod{
+				buildPod().uid("a").phase(v1.PodSucceeded).deletionTimestamp().Pod,
+				buildPod().uid("b").phase(v1.PodFailed).deletionTimestamp().Pod,
+				buildPod().uid("c").phase(v1.PodRunning).deletionTimestamp().Pod,
+				buildPod().uid("d").phase(v1.PodPending).deletionTimestamp().Pod,
+			},
+			wantSucceeded: 1,
+			wantFailed:    1,
+		},
+		"deleted pods, tracking with finalizers": {
 			job: batch.Job{
 				Status: batch.JobStatus{
 					Succeeded:               1,


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Revert counting deleted pods as failures for Job when JobTrackingWithFinalizers is disabled, in order to preserve existing behavior.

This was reproduced by scalability tests https://k8s-testgrid.appspot.com/sig-scalability-gce#gce-master-scale-performance
The root cause is that this tests does scale downs. The controller was treating those removals as failures, causing the Job to fail due to hitting the backoff limit.

#### Which issue(s) this PR fixes:

Fixes #103682

#### Special notes for your reviewer:

Verified by scalability tests

#### Does this PR introduce a user-facing change?

```release-note
NONE
```