### PR TITLE
e2e: Fix NFS options test for IPv6

### DIFF
--- a/test/e2e/storage/drivers/in_tree.go
+++ b/test/e2e/storage/drivers/in_tree.go
@@ -104,7 +104,7 @@ func InitNFSDriver() storageframework.TestDriver {
 			SupportedFsType: sets.NewString(
 				"", // Default fsType
 			),
-			SupportedMountOption: sets.NewString("proto=tcp", "relatime"),
+			SupportedMountOption: sets.NewString("relatime"),
 			RequiredMountOption:  sets.NewString("vers=4.1"),
 			Capabilities: map[storageframework.Capability]bool{
 				storageframework.CapPersistence: true,


### PR DESCRIPTION
#### What type of PR is this?
/kind bug
/kind failing-test

#### What this PR does / why we need it:
One of the e2e Storage test adds NFS option `proto=tcp` which causes the test to fail with IPv6. Removing the option sounds like the easiest way to fix this: NFS 4 doesn't need it and it chooses the right IP protocol version if no `proto=...` option specified.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
