### PR TITLE
Automated cherry pick of #94693: test/e2e: Busybox image is not being templatized

### DIFF
--- a/test/e2e/kubectl/kubectl.go
+++ b/test/e2e/kubectl/kubectl.go
@@ -1185,7 +1185,7 @@ metadata:
 
 		ginkgo.It("should check if kubectl describe prints relevant information for cronjob", func() {
 			ginkgo.By("creating a cronjob")
-			cronjobYaml := commonutils.SubstituteImageName(string(readTestFileOrDie("busybox-cronjob.yaml")))
+			cronjobYaml := commonutils.SubstituteImageName(string(readTestFileOrDie("busybox-cronjob.yaml.in")))
 			framework.RunKubectlOrDieInput(ns, cronjobYaml, "create", "-f", "-")
 
 			ginkgo.By("waiting for cronjob to start.")
@@ -1345,7 +1345,7 @@ metadata:
 		var podYaml string
 		ginkgo.BeforeEach(func() {
 			ginkgo.By("creating the pod")
-			podYaml = commonutils.SubstituteImageName(string(readTestFileOrDie("busybox-pod.yaml")))
+			podYaml = commonutils.SubstituteImageName(string(readTestFileOrDie("busybox-pod.yaml.in")))
 			framework.RunKubectlOrDieInput(ns, podYaml, "create", "-f", "-")
 			framework.ExpectEqual(e2epod.CheckPodsRunningReady(c, ns, []string{busyboxPodName}, framework.PodStartTimeout), true)
 		})

--- a/test/e2e/testing-manifests/kubectl/busybox-cronjob.yaml.in
+++ b/test/e2e/testing-manifests/kubectl/busybox-cronjob.yaml.in
@@ -15,7 +15,7 @@ spec:
         spec:
           containers:
           - name: test
-            image: busybox
+            image: {{.BusyBoxImage}}
             args:
             - "/bin/true"
           restartPolicy: OnFailure

--- a/test/e2e/testing-manifests/kubectl/busybox-pod.yaml.in
+++ b/test/e2e/testing-manifests/kubectl/busybox-pod.yaml.in
@@ -6,7 +6,7 @@ metadata:
     app: busybox1
 spec:
   containers:
-  - image: busybox
+  - image: {{.BusyBoxImage}}
     command: ["/bin/sh", "-c", "mkdir -p /root/foo/bar && echo 'foobar' > /root/foo/bar/foo.bar && sleep 3600"]
     imagePullPolicy: IfNotPresent
     name: busybox


### PR DESCRIPTION
Cherry pick of #94693 on release-1.19.

#94693: test/e2e: Busybox image is not being templatized

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.