### PR TITLE
test: fix potential blocking problems in unit tests

### DIFF
--- a/cmd/kube-proxy/app/server_test.go
+++ b/cmd/kube-proxy/app/server_test.go
@@ -501,6 +501,10 @@ udpIdleTimeout: 250ms`)
 		errCh := make(chan error, 1)
 		go func() {
 			errCh <- opt.runLoop()
+			select {
+			case <-opt.errCh:
+			case <-time.After(10 * time.Second):
+			}
 		}()
 
 		if tc.append {

--- a/pkg/controller/nodeipam/ipam/cloud_cidr_allocator_test.go
+++ b/pkg/controller/nodeipam/ipam/cloud_cidr_allocator_test.go
@@ -42,6 +42,7 @@ func TestBoundedRetries(t *testing.T) {
 	clientSet := fake.NewSimpleClientset()
 	updateChan := make(chan string, 1) // need to buffer as we are using only on go routine
 	stopChan := make(chan struct{})
+	defer close(stopChan)
 	sharedInfomer := informers.NewSharedInformerFactory(clientSet, 1*time.Hour)
 	ca := &cloudCIDRAllocator{
 		client:            clientSet,

--- a/pkg/controller/nodeipam/ipam/sync/sync_test.go
+++ b/pkg/controller/nodeipam/ipam/sync/sync_test.go
@@ -235,7 +235,10 @@ func TestNodeSyncResync(t *testing.T) {
 	close(sync.opChan)
 	// Unblock loop().
 	go func() {
-		<-fake.reportChan
+		select {
+		case <-fake.reportChan:
+		case <-doneChan:
+		}
 	}()
 	<-doneChan
 	fake.dumpTrace()

--- a/pkg/kubelet/config/file_linux_test.go
+++ b/pkg/kubelet/config/file_linux_test.go
@@ -51,7 +51,7 @@ func TestExtractFromNonExistentFile(t *testing.T) {
 }
 
 func TestUpdateOnNonExistentFile(t *testing.T) {
-	ch := make(chan interface{})
+	ch := make(chan interface{}, 1)
 	NewSourceFile("random_non_existent_path", "localhost", time.Millisecond, ch)
 	select {
 	case got := <-ch:

--- a/pkg/kubelet/nodeshutdown/systemd/inhibit_linux_test.go
+++ b/pkg/kubelet/nodeshutdown/systemd/inhibit_linux_test.go
@@ -184,6 +184,7 @@ func TestMonitorShutdown(t *testing.T) {
 			signal := &dbus.Signal{Body: []interface{}{tc.shutdownActive}}
 			fakeSystemBus.signalChannel <- signal
 			<-done
+			close(fakeSystemBus.signalChannel)
 		})
 	}
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind failing-test

#### What this PR does / why we need it:

This PR fixes several potential blocking problems in unit tests. The fixes are explained as following:

**(1) server_test.go**
During the second testcase "fake error", channel `opt.errCh` will be sent a non-nil error (server.go:329) and a nil error (server.go:269).
However, its receive will only be executed once because the loop will be broken after the first non-nil error, as shown below:
https://github.com/kubernetes/kubernetes/blob/234d7311822aecb8c5f4115107007b8420d9316b/cmd/kube-proxy/app/server.go#L332-L337
This PR adds a select that can receive the second error.

**(2) cloud_cidr_allocator_test.go**
The goroutine running `go ca.worker(stopChan)` will never be stopped because `stopChan` is never closed.
This PR adds the close to this channel.

**(3) sync_test.go**
This unit test will only send one message to `fake.reportChan`, which is at sync.go:148. However, it has two receive operations for this channel.
This PR puts the second receive operation into a select that can unblock together with the unit test goroutine, so it won't be blocked.

**(4) file_linux_test.go**
`ch` in this unit test is alias to `s.updates` below:
https://github.com/kubernetes/kubernetes/blob/234d7311822aecb8c5f4115107007b8420d9316b/pkg/kubelet/config/file.go#L124-L131
It will be blocked if the unit test calls `t.Fatalf()` and doesn't receive from `ch`.
This PR adds 1 buffer to `ch` to make the send operation non blocking.

**(5) inhibit_linux_test.go**
`fakeSystemBus.signalChannel` is alias to `busChan` below:
https://github.com/kubernetes/kubernetes/blob/234d7311822aecb8c5f4115107007b8420d9316b/pkg/kubelet/nodeshutdown/systemd/inhibit_linux.go#L145-L156
Note that the goroutine created above can stop only when `busChan` is closed, which never happens.
This PR adds the close operation of it.


#### Special notes for your reviewer:

Sorry that these problems may be somewhat trivial and can only waste some memory during testing. We found them by our fuzzer that just report any blocking in the program.

For the `worker()` mentioned in  cloud_cidr_allocator_test.go, we also noticed that there are six places using `wait.NeverStop` when calling several worker functions, which also result in never stopped workers. 
Wondering if there is any way to avoid such behavior.
These places are: pkg/kubelet/cm/devicemanager/manager_test.go:275; pkg/kubelet/kubelet.go:1438; pkg/controller/nodeipam/ipam/range_allocator_test.go:554 & 652 & 794


#### Does this PR introduce a user-facing change?
```release-note
NONE
```
