### PR TITLE
Remove pkg/utils/slice dependeny in kube-proxy

### DIFF
--- a/pkg/proxy/winuserspace/roundrobin.go
+++ b/pkg/proxy/winuserspace/roundrobin.go
@@ -20,7 +20,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
-	"reflect"
+	"sort"
 	"sync"
 	"time"
 
@@ -29,7 +29,7 @@ import (
 	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/pkg/proxy"
 	"k8s.io/kubernetes/pkg/proxy/util"
-	"k8s.io/kubernetes/pkg/util/slice"
+	stringslices "k8s.io/utils/strings/slices"
 )
 
 var (
@@ -256,7 +256,7 @@ func (lb *LoadBalancerRR) OnEndpointsUpdate(oldEndpoints, endpoints *v1.Endpoint
 			curEndpoints = state.endpoints
 		}
 
-		if !exists || state == nil || len(curEndpoints) != len(newEndpoints) || !slicesEquiv(slice.CopyStrings(curEndpoints), newEndpoints) {
+		if !exists || state == nil || len(curEndpoints) != len(newEndpoints) || !slicesEquiv(stringslices.Clone(curEndpoints), newEndpoints) {
 			klog.V(1).Infof("LoadBalancerRR: Setting endpoints for %s to %+v", svcPort, newEndpoints)
 			lb.updateAffinityMap(svcPort, newEndpoints)
 			// OnEndpointsUpdate can be called without NewService being called externally.
@@ -311,10 +311,9 @@ func slicesEquiv(lhs, rhs []string) bool {
 	if len(lhs) != len(rhs) {
 		return false
 	}
-	if reflect.DeepEqual(slice.SortStrings(lhs), slice.SortStrings(rhs)) {
-		return true
-	}
-	return false
+	sort.Strings(lhs)
+	sort.Strings(rhs)
+	return stringslices.Equal(lhs, rhs)
 }
 
 func (lb *LoadBalancerRR) CleanupStaleStickySessions(svcPort proxy.ServicePortName) {

--- a/vendor/k8s.io/utils/strings/slices/slices.go
+++ b/vendor/k8s.io/utils/strings/slices/slices.go
@@ -1,0 +1,82 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package slices defines various functions useful with slices of string type.
+// The goal is to be as close as possible to
+// https://github.com/golang/go/issues/45955. Ideal would be if we can just
+// replace "stringslices" if the "slices" package becomes standard.
+package slices
+
+// Equal reports whether two slices are equal: the same length and all
+// elements equal. If the lengths are different, Equal returns false.
+// Otherwise, the elements are compared in index order, and the
+// comparison stops at the first unequal pair.
+func Equal(s1, s2 []string) bool {
+	if len(s1) != len(s2) {
+		return false
+	}
+	for i, n := range s1 {
+		if n != s2[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// Filter appends to d each element e of s for which keep(e) returns true.
+// It returns the modified d. d may be s[:0], in which case the kept
+// elements will be stored in the same slice.
+// if the slices overlap in some other way, the results are unspecified.
+// To create a new slice with the filtered results, pass nil for d.
+func Filter(d, s []string, keep func(string) bool) []string {
+	for _, n := range s {
+		if keep(n) {
+			d = append(d, n)
+		}
+	}
+	return d
+}
+
+// Contains reports whether v is present in s.
+func Contains(s []string, v string) bool {
+	return Index(s, v) >= 0
+}
+
+// Index returns the index of the first occurrence of v in s, or -1 if
+// not present.
+func Index(s []string, v string) int {
+	// "Contains" may be replaced with "Index(s, v) >= 0":
+	// https://github.com/golang/go/issues/45955#issuecomment-873377947
+	for i, n := range s {
+		if n == v {
+			return i
+		}
+	}
+	return -1
+}
+
+// Functions below are not in https://github.com/golang/go/issues/45955
+
+// Clone returns a new clone of s.
+func Clone(s []string) []string {
+	// https://github.com/go101/go101/wiki/There-is-not-a-perfect-way-to-clone-slices-in-Go
+	if s == nil {
+		return nil
+	}
+	c := make([]string, len(s))
+	copy(c, s)
+	return c
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -2289,6 +2289,7 @@ k8s.io/utils/nsenter
 k8s.io/utils/path
 k8s.io/utils/pointer
 k8s.io/utils/strings
+k8s.io/utils/strings/slices
 k8s.io/utils/trace
 # sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.22 => sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.22
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client/pkg/client


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

As a step towards move pkg/proxy to k8s.io/kube-proxy the `pkg/utils/slice` package is replaced with `k8s.io/utils/strings/slices`, see https://github.com/kubernetes/utils/pull/208.

The `k8s.io/utils/strings/slices` is in turn intended to be replaced with the standard "slices" package proposed in https://github.com/golang/go/issues/45955.

#### Which issue(s) this PR fixes:

Part of https://github.com/kubernetes/kubernetes/issues/92369

#### Special notes for your reviewer:

The update of the `k8s.io/utils` version should probably not be done in this PR but in some more controlled way. I am not familiar with the procedure but the update is kept in it's own commit (which should not be reviewed).

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

N/A