### PR TITLE
[WIP] use embed etcd for integration tests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -83,6 +83,7 @@ require (
 	github.com/vmware/govmomi v0.20.3
 	go.etcd.io/etcd/client/pkg/v3 v3.5.0
 	go.etcd.io/etcd/client/v3 v3.5.0
+	go.etcd.io/etcd/server/v3 v3.5.0
 	go.opentelemetry.io/otel/sdk v0.20.0
 	go.opentelemetry.io/otel/trace v0.20.0
 	go.opentelemetry.io/proto/otlp v0.7.0

--- a/hack/make-rules/test-integration.sh
+++ b/hack/make-rules/test-integration.sh
@@ -49,21 +49,7 @@ kube::test::find_integration_test_dirs() {
   )
 }
 
-CLEANUP_REQUIRED=
-cleanup() {
-  if [[ -z "${CLEANUP_REQUIRED}" ]]; then
-    return
-  fi
-  kube::log::status "Cleaning up etcd"
-  kube::etcd::cleanup
-  CLEANUP_REQUIRED=
-  kube::log::status "Integration test cleanup complete"
-}
-
 runTests() {
-  kube::log::status "Starting etcd instance"
-  CLEANUP_REQUIRED=1
-  kube::etcd::start
   kube::log::status "Running integration test cases"
 
   make -C "${KUBE_ROOT}" test \
@@ -72,22 +58,6 @@ runTests() {
       KUBE_TEST_ARGS="--alsologtostderr=true ${KUBE_TEST_ARGS:-} ${SHORT:--short=true} --vmodule=${KUBE_TEST_VMODULE}" \
       KUBE_TIMEOUT="${KUBE_TIMEOUT}" \
       KUBE_RACE=""
-
-  cleanup
 }
-
-checkEtcdOnPath() {
-  kube::log::status "Checking etcd is on PATH"
-  which etcd && return
-  kube::log::status "Cannot find etcd, cannot run integration tests."
-  kube::log::status "Please see https://git.k8s.io/community/contributors/devel/sig-testing/integration-tests.md#install-etcd-dependency for instructions."
-  kube::log::usage "You can use 'hack/install-etcd.sh' to install a copy in third_party/."
-  return 1
-}
-
-checkEtcdOnPath
-
-# Run cleanup to stop etcd on interrupt or other kill signal.
-trap cleanup EXIT
 
 runTests

--- a/staging/src/k8s.io/pod-security-admission/test/run.go
+++ b/staging/src/k8s.io/pod-security-admission/test/run.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"sort"
 	"strings"
 	"sync"
 	"testing"
@@ -83,59 +82,22 @@ func checksForLevelAndVersion(checks []policy.Check, level api.Level, version ap
 	return retval, nil
 }
 
-// computeVersionsToTest returns all the versions that have distinct checks defined,
-// all the versions that have distinct minimal valid pod fixtures defined, and
-// any hard-coded versions that should always be tested.
-//
-// This lets us sparsely test all versions with distinct fixture or policy changes
-// without needing to exercise every intermediate version that had no changes.
-func computeVersionsToTest(t *testing.T, checks []policy.Check) []api.Version {
-	seenVersions := map[api.Version]bool{}
-
-	// include all versions we have registered distinct checks for
+// maxMinorVersionToTest returns the maximum minor version to exercise for a given set of checks.
+// checks are assumed to be well-formed and valid to pass to policy.NewEvaluator().
+func maxMinorVersionToTest(checks []policy.Check) (int, error) {
+	// start with the release under development (1.22 at time of writing).
+	// this can be incremented to the current version whenever is convenient.
+	maxTestMinor := 22
 	for _, check := range checks {
-		for _, checkVersion := range check.Versions {
-			if checkVersion.MinimumVersion.Major() != 1 {
-				t.Fatalf("expected major version 1, got %d", checkVersion.MinimumVersion.Major())
-			}
-			seenVersions[checkVersion.MinimumVersion] = true
+		lastCheckVersion := check.Versions[len(check.Versions)-1].MinimumVersion
+		if lastCheckVersion.Major() != 1 {
+			return 0, fmt.Errorf("expected major version 1, got %d", lastCheckVersion.Major())
+		}
+		if lastCheckVersion.Minor() > maxTestMinor {
+			maxTestMinor = lastCheckVersion.Minor()
 		}
 	}
-	if len(seenVersions) == 0 {
-		t.Fatal("no versions defined for checks")
-	}
-
-	// include all versions we have registered distinct fixtures for
-	for _, versionsForLevel := range minimalValidPods {
-		for version := range versionsForLevel {
-			if version.Major() != 1 {
-				t.Fatalf("expected major version 1, got %d", version.Major())
-			}
-			seenVersions[version] = true
-		}
-	}
-
-	alwaysIncludeVersions := []api.Version{
-		// include the oldest version by default
-		api.MajorMinorVersion(1, 0),
-		// include the release under development (1.22 at time of writing).
-		// this can be incremented to the current version whenever is convenient.
-		// TODO: find a way to use api.LatestVersion() here
-		api.MajorMinorVersion(1, 22),
-	}
-	for _, version := range alwaysIncludeVersions {
-		seenVersions[version] = true
-	}
-
-	versions := []api.Version{}
-	for version := range seenVersions {
-		versions = append(versions, version)
-	}
-	sort.Slice(versions, func(i, j int) bool { return versions[i].Older(versions[j]) })
-
-	// TODO: consider exposing an option to test all versions instead of sparse ones
-
-	return versions
+	return maxTestMinor, nil
 }
 
 type testWarningHandler struct {
@@ -178,12 +140,15 @@ func Run(t *testing.T, opts Options) {
 	if err != nil {
 		t.Fatalf("invalid checks: %v", err)
 	}
-
-	versionsToTest := computeVersionsToTest(t, opts.Checks)
+	maxMinor, err := maxMinorVersionToTest(opts.Checks)
+	if err != nil {
+		t.Fatalf("invalid checks: %v", err)
+	}
 
 	for _, level := range []api.Level{api.LevelBaseline, api.LevelRestricted} {
-		for _, version := range versionsToTest {
-			minor := version.Minor()
+		for minor := 0; minor <= maxMinor; minor++ {
+			version := api.MajorMinorVersion(1, minor)
+
 			// create test name
 			ns := fmt.Sprintf("podsecurity-%s-1-%d", level, minor)
 

--- a/test/integration/framework/etcd.go
+++ b/test/integration/framework/etcd.go
@@ -161,3 +161,7 @@ func EtcdMain(tests func() int) {
 func GetEtcdURL() string {
 	return etcdURL
 }
+
+func RunCustomEtcd(dataDir string, customFlags []string) (url string, stopFn func(), err error) {
+	return "", nil, fmt.Errorf("not implemented")
+}

--- a/test/integration/framework/etcd.go
+++ b/test/integration/framework/etcd.go
@@ -23,14 +23,21 @@ import (
 	"net/url"
 	"os"
 	"strconv"
+	"strings"
 	"time"
 
 	"go.etcd.io/etcd/client/pkg/v3/transport"
 	"go.etcd.io/etcd/server/v3/embed"
 	"k8s.io/klog/v2"
+	"k8s.io/kubernetes/pkg/util/env"
+
+	"github.com/docker/docker/pkg/reexec"
 )
 
-var etcdURL = ""
+var (
+	etcdURL = ""
+	ports   = []int{2379, 2380}
+)
 
 // getAvailablePort returns a TCP port that is available for binding.
 func getAvailablePorts(count int) ([]int, error) {
@@ -47,12 +54,20 @@ func getAvailablePorts(count int) ([]int, error) {
 	return ports, nil
 }
 
+func init() {
+	klog.Infof("init start, os.Args = %+v\n", os.Args)
+	reexec.Register("startEtcd", startEtcd)
+	if reexec.Init() {
+		os.Exit(0)
+	}
+}
+
 // startEtcd executes an embedded etcd instance.
-func startEtcd() (func(), error) {
+func startEtcd() {
 	dataDir := "integration_test_etcd_data"
 	etcdDir, err := ioutil.TempDir(os.TempDir(), dataDir)
 	if err != nil {
-		return nil, fmt.Errorf("unable to make temp etcd data dir %s: %v", dataDir, err)
+		klog.Fatalf("unable to make temp etcd data dir %s: %v", dataDir, err)
 	}
 	klog.Infof("storing etcd data in: %v", etcdDir)
 	os.Chmod(etcdDir, 0700)
@@ -60,20 +75,9 @@ func startEtcd() (func(), error) {
 	cfg := embed.NewConfig()
 	cfg.Dir = etcdDir
 	cfg.Name = "etcd-integration"
-
 	cfg.UnsafeNoFsync = true
 
-	// use standard ports if they are free
-	ports := []int{2379, 2380}
-	conn, err := net.Dial("tcp", "127.0.0.1:2379")
-	if err == nil {
-		klog.Infof("etcd ports are not free at 127.0.0.1:2379")
-		conn.Close()
-		ports, err = getAvailablePorts(2)
-		if err != nil {
-			return nil, err
-		}
-	}
+	// create the etcd instance
 	clientURL := url.URL{Scheme: "http", Host: net.JoinHostPort("127.0.0.1", strconv.Itoa(ports[0]))}
 	etcdURL = clientURL.String()
 	peerURL := url.URL{Scheme: "http", Host: net.JoinHostPort("127.0.0.1", strconv.Itoa(ports[1]))}
@@ -92,34 +96,64 @@ func startEtcd() (func(), error) {
 
 	e, err := embed.StartEtcd(cfg)
 	if err != nil {
-		return nil, err
+		klog.Fatalf("Can not start etcd: %v", err)
 	}
-	stop := func() {
+	defer func() {
 		e.Close()
 		err = os.RemoveAll(etcdDir)
 		if err != nil {
 			klog.Warningf("error during etcd cleanup: %v", err)
 		}
-	}
+	}()
 
 	select {
 	case <-e.Server.ReadyNotify():
 	case <-time.After(60 * time.Second):
 		e.Server.Stop() // trigger a shutdown
-		return nil, err
+		klog.Fatalf("Timeout waiting for etcd to start: %v", err)
 	}
 
-	return stop, nil
+	os.Setenv("KUBE_INTEGRATION_ETCD_URL", etcdURL)
+	// block until we are done
+	<-e.Err()
 }
 
 // EtcdMain starts an etcd instance before running tests.
 func EtcdMain(tests func() int) {
-	stop, err := startEtcd()
-	if err != nil {
+	// start an etcd process if it is not running
+	// the process keeps running, caller should kill it
+	// once the tests finish.
+	etcdURL = env.GetEnvAsStringOrFallback("KUBE_INTEGRATION_ETCD_URL", "http://127.0.0.1:2379")
+	conn, err := net.Dial("tcp", strings.TrimPrefix(etcdURL, "http://"))
+	if err == nil {
+		klog.Infof("etcd already running at %s", etcdURL)
+		conn.Close()
+		result := tests()
+		os.Exit(result)
+	}
+
+	klog.V(1).Infof("could not connect to etcd: %v", err)
+	// use standard ports if they are free
+	ports = []int{2379, 2380}
+	conn, err = net.Dial("tcp", "127.0.0.1:2379")
+	if err == nil {
+		klog.Infof("etcd ports are not free at 127.0.0.1:2379")
+		conn.Close()
+		ports, err = getAvailablePorts(2)
+		if err != nil {
+			klog.Fatalf("Can not get free ports to run etcd: %v", err)
+		}
+	}
+
+	cmd := reexec.Command("startEtcd")
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Start(); err != nil {
 		klog.Fatalf("cannot run integration tests: unable to start etcd: %v", err)
 	}
+
 	result := tests()
-	stop() // Don't defer this. See os.Exit documentation.
 	os.Exit(result)
 }
 

--- a/vendor/github.com/docker/docker/pkg/reexec/README.md
+++ b/vendor/github.com/docker/docker/pkg/reexec/README.md
@@ -1,0 +1,5 @@
+# reexec
+
+The `reexec` package facilitates the busybox style reexec of the docker binary that we require because 
+of the forking limitations of using Go.  Handlers can be registered with a name and the argv 0 of 
+the exec of the binary will be used to find and execute custom init paths.

--- a/vendor/github.com/docker/docker/pkg/reexec/command_linux.go
+++ b/vendor/github.com/docker/docker/pkg/reexec/command_linux.go
@@ -1,0 +1,28 @@
+package reexec // import "github.com/docker/docker/pkg/reexec"
+
+import (
+	"os/exec"
+	"syscall"
+
+	"golang.org/x/sys/unix"
+)
+
+// Self returns the path to the current process's binary.
+// Returns "/proc/self/exe".
+func Self() string {
+	return "/proc/self/exe"
+}
+
+// Command returns *exec.Cmd which has Path as current binary. Also it setting
+// SysProcAttr.Pdeathsig to SIGTERM.
+// This will use the in-memory version (/proc/self/exe) of the current binary,
+// it is thus safe to delete or replace the on-disk binary (os.Args[0]).
+func Command(args ...string) *exec.Cmd {
+	return &exec.Cmd{
+		Path: Self(),
+		Args: args,
+		SysProcAttr: &syscall.SysProcAttr{
+			Pdeathsig: unix.SIGTERM,
+		},
+	}
+}

--- a/vendor/github.com/docker/docker/pkg/reexec/command_unix.go
+++ b/vendor/github.com/docker/docker/pkg/reexec/command_unix.go
@@ -1,0 +1,23 @@
+// +build freebsd darwin
+
+package reexec // import "github.com/docker/docker/pkg/reexec"
+
+import (
+	"os/exec"
+)
+
+// Self returns the path to the current process's binary.
+// Uses os.Args[0].
+func Self() string {
+	return naiveSelf()
+}
+
+// Command returns *exec.Cmd which has Path as current binary.
+// For example if current binary is "docker" at "/usr/bin/", then cmd.Path will
+// be set to "/usr/bin/docker".
+func Command(args ...string) *exec.Cmd {
+	return &exec.Cmd{
+		Path: Self(),
+		Args: args,
+	}
+}

--- a/vendor/github.com/docker/docker/pkg/reexec/command_unsupported.go
+++ b/vendor/github.com/docker/docker/pkg/reexec/command_unsupported.go
@@ -1,0 +1,16 @@
+// +build !linux,!windows,!freebsd,!darwin
+
+package reexec // import "github.com/docker/docker/pkg/reexec"
+
+import (
+	"os/exec"
+)
+
+func Self() string {
+	return ""
+}
+
+// Command is unsupported on operating systems apart from Linux, Windows, and Darwin.
+func Command(args ...string) *exec.Cmd {
+	return nil
+}

--- a/vendor/github.com/docker/docker/pkg/reexec/command_windows.go
+++ b/vendor/github.com/docker/docker/pkg/reexec/command_windows.go
@@ -1,0 +1,21 @@
+package reexec // import "github.com/docker/docker/pkg/reexec"
+
+import (
+	"os/exec"
+)
+
+// Self returns the path to the current process's binary.
+// Uses os.Args[0].
+func Self() string {
+	return naiveSelf()
+}
+
+// Command returns *exec.Cmd which has Path as current binary.
+// For example if current binary is "docker.exe" at "C:\", then cmd.Path will
+// be set to "C:\docker.exe".
+func Command(args ...string) *exec.Cmd {
+	return &exec.Cmd{
+		Path: Self(),
+		Args: args,
+	}
+}

--- a/vendor/github.com/docker/docker/pkg/reexec/reexec.go
+++ b/vendor/github.com/docker/docker/pkg/reexec/reexec.go
@@ -1,0 +1,47 @@
+package reexec // import "github.com/docker/docker/pkg/reexec"
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+)
+
+var registeredInitializers = make(map[string]func())
+
+// Register adds an initialization func under the specified name
+func Register(name string, initializer func()) {
+	if _, exists := registeredInitializers[name]; exists {
+		panic(fmt.Sprintf("reexec func already registered under name %q", name))
+	}
+
+	registeredInitializers[name] = initializer
+}
+
+// Init is called as the first part of the exec process and returns true if an
+// initialization function was called.
+func Init() bool {
+	initializer, exists := registeredInitializers[os.Args[0]]
+	if exists {
+		initializer()
+
+		return true
+	}
+	return false
+}
+
+func naiveSelf() string {
+	name := os.Args[0]
+	if filepath.Base(name) == name {
+		if lp, err := exec.LookPath(name); err == nil {
+			return lp
+		}
+	}
+	// handle conversion of relative paths to absolute
+	if absName, err := filepath.Abs(name); err == nil {
+		return absName
+	}
+	// if we couldn't get absolute name, return original
+	// (NOTE: Go only errors on Abs() if os.Getwd fails)
+	return name
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -255,6 +255,7 @@ github.com/docker/docker/api/types/volume
 github.com/docker/docker/client
 github.com/docker/docker/errdefs
 github.com/docker/docker/pkg/jsonmessage
+github.com/docker/docker/pkg/reexec
 github.com/docker/docker/pkg/stdcopy
 # github.com/docker/go-connections v0.4.0 => github.com/docker/go-connections v0.4.0
 ## explicit
@@ -822,6 +823,7 @@ go.etcd.io/etcd/raft/v3/quorum
 go.etcd.io/etcd/raft/v3/raftpb
 go.etcd.io/etcd/raft/v3/tracker
 # go.etcd.io/etcd/server/v3 v3.5.0 => go.etcd.io/etcd/server/v3 v3.5.0
+## explicit
 go.etcd.io/etcd/server/v3/auth
 go.etcd.io/etcd/server/v3/config
 go.etcd.io/etcd/server/v3/datadir


### PR DESCRIPTION
Instead of using the same etcd process for the whole suite, spawn a new embed etcd server per test.

This removes the dependency on the etcd binary and gives more control to the integration framwork.

TODO
- improve logging? or do we want to keep everything logging to the output instead to separate files? it is more verbose but you can trace the problems
- understand the problem with client tls for the 
```	
testServer := kastesting.StartTestServerOrDie(t, &kastesting.TestServerInstanceOptions{EnableCertAuth: true}, nil, framework.SharedEtcd())
```

ref #103512

