### PR TITLE
client-go exec: fix metrics related to plugin not found

### DIFF
--- a/staging/src/k8s.io/client-go/plugin/pkg/client/auth/exec/metrics_test.go
+++ b/staging/src/k8s.io/client-go/plugin/pkg/client/auth/exec/metrics_test.go
@@ -18,6 +18,7 @@ package exec
 
 import (
 	"fmt"
+	"io"
 	"testing"
 	"time"
 
@@ -147,6 +148,7 @@ func TestCallsMetric(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
+		a.stderr = io.Discard
 
 		// Run refresh creds twice so that our test validates that the metrics are set correctly twice
 		// in a row with the same authenticator.
@@ -172,7 +174,7 @@ func TestCallsMetric(t *testing.T) {
 	// metric values.
 	refreshCreds := func(command string) {
 		c := api.ExecConfig{
-			Command:         "does not exist",
+			Command:         command,
 			APIVersion:      "client.authentication.k8s.io/v1beta1",
 			InteractiveMode: api.IfAvailableExecInteractiveMode,
 		}
@@ -180,6 +182,7 @@ func TestCallsMetric(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
+		a.stderr = io.Discard
 		if err := a.refreshCredsLocked(&clientauthentication.Response{}); err == nil {
 			t.Fatal("expected the authenticator to fail because the plugin does not exist")
 		}

--- a/test/integration/client/exec_test.go
+++ b/test/integration/client/exec_test.go
@@ -391,7 +391,7 @@ func execPluginClientTests(t *testing.T, unauthorizedCert, unauthorizedKey []byt
 			},
 			wantGetCertificateErrorPrefix: "exec: fork/exec ./testdata/exec-plugin-not-executable.sh: permission denied",
 			wantClientErrorPrefix:         `Get "https`,
-			wantMetrics:                   &execPluginMetrics{calls: []execPluginCall{{exitCode: 1, callStatus: "client_internal_error"}}},
+			wantMetrics:                   &execPluginMetrics{calls: []execPluginCall{{exitCode: 1, callStatus: "plugin_not_found_error"}}},
 		},
 		{
 			name: "binary fails",


### PR DESCRIPTION
These were missed because our tests did not pass in the correct test data input (the command to execute).

Signed-off-by: Monis Khan <mok@vmware.com>

/kind bug
/sig auth
/milestone v1.22

```release-note
NONE
```