### PR TITLE
Fix validation for basic-auth secrets and error messaging

### DIFF
--- a/pkg/apis/core/validation/validation.go
+++ b/pkg/apis/core/validation/validation.go
@@ -5303,21 +5303,17 @@ func ValidateSecret(secret *core.Secret) field.ErrorList {
 			allErrs = append(allErrs, field.Invalid(dataPath.Key(core.DockerConfigJSONKey), "<secret contents redacted>", err.Error()))
 		}
 	case core.SecretTypeBasicAuth:
-		_, usernameFieldExists := secret.Data[core.BasicAuthUsernameKey]
-		_, passwordFieldExists := secret.Data[core.BasicAuthPasswordKey]
-
-		// username or password might be empty, but the field must be present
-		if !usernameFieldExists && !passwordFieldExists {
-			allErrs = append(allErrs, field.Required(field.NewPath("data[%s]").Key(core.BasicAuthUsernameKey), ""))
-			allErrs = append(allErrs, field.Required(field.NewPath("data[%s]").Key(core.BasicAuthPasswordKey), ""))
-			break
+		// username or password might be empty, but the fields must be present
+		if _, exists := secret.Data[core.BasicAuthUsernameKey]; !exists {
+			allErrs = append(allErrs, field.Required(dataPath.Key(core.BasicAuthUsernameKey), ""))
+		}
+		if _, exists := secret.Data[core.BasicAuthPasswordKey]; !exists {
+			allErrs = append(allErrs, field.Required(dataPath.Key(core.BasicAuthPasswordKey), ""))
 		}
 	case core.SecretTypeSSHAuth:
 		if len(secret.Data[core.SSHAuthPrivateKey]) == 0 {
-			allErrs = append(allErrs, field.Required(field.NewPath("data[%s]").Key(core.SSHAuthPrivateKey), ""))
-			break
+			allErrs = append(allErrs, field.Required(dataPath.Key(core.SSHAuthPrivateKey), ""))
 		}
-
 	case core.SecretTypeTLS:
 		if _, exists := secret.Data[core.TLSCertKey]; !exists {
 			allErrs = append(allErrs, field.Required(dataPath.Key(core.TLSCertKey), ""))


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
This PR attempts to fix an issue with validation for secrets of type `kubernetes.io/basic-auth`. 

The documentation for this type of secret mentions [here](kubernetes.io/basic-auth) the following:
```
When using this Secret type, the data field of the Secret must contain the following two keys:

username: the user name for authentication;
password: the password or token for authentication.
```

However, an error is only thrown for these fields if both keys aren't present. The error also looks like the following, which shouldn't include the `[%s]` formatting as shown below:
```
The Secret "secret-basic-auth" is invalid: 
* data[%s][username]: Required value
* data[%s][password]: Required value
```
Looking at the validation of a secret of similar type, `kubernetes.io/tls`, this is how the error looks if either or both keys aren't present:

One field isn't present:
```
The Secret "secret-tls" is invalid: data[tls.key]: Required value
```

Both fields aren't present:
```
The Secret "secret-tls" is invalid: 
* data[tls.crt]: Required value
* data[tls.key]: Required value
```

With this PR, the error for basic auth type should look similar to what it shows for tls, like below:
```
The Secret "secret-basic-auth" is invalid: 
* data[username]: Required value
* data[password]: Required value
```

This PR also fixes the formatting for the error message of ssh auth secret type.

#### Which issue(s) this PR fixes:
N/A

#### Special notes for your reviewer:
This is my first PR in this project so would love to get any feedback on what I can change in terms of my commit messages, code, description of this PR, and whether I can do any other type of testing on my local machine apart from what is tested through Prow.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Add additional validation to secrets of type `kubernetes.io/basic-auth` to ensure that required fields are present.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
