### PR TITLE
e2e: node: fix the critical pod test

### DIFF
--- a/test/e2e_node/critical_pod_test.go
+++ b/test/e2e_node/critical_pod_test.go
@@ -102,7 +102,7 @@ var _ = SIGDescribe("CriticalPod [Serial] [Disruptive] [NodeFeature:CriticalPod]
 			f.PodClient().DeleteSync(guaranteedPodName, metav1.DeleteOptions{}, framework.DefaultPodDeletionTimeout)
 			f.PodClient().DeleteSync(burstablePodName, metav1.DeleteOptions{}, framework.DefaultPodDeletionTimeout)
 			f.PodClient().DeleteSync(bestEffortPodName, metav1.DeleteOptions{}, framework.DefaultPodDeletionTimeout)
-			f.PodClientNS(kubeapi.NamespaceSystem).DeleteSync(criticalPodName, metav1.DeleteOptions{}, framework.DefaultPodDeletionTimeout)
+			f.PodClientNS(kubeapi.NamespaceSystem).DeleteSyncOnNamespace(kubeapi.NamespaceSystem, criticalPodName, metav1.DeleteOptions{}, framework.DefaultPodDeletionTimeout)
 			// Log Events
 			logPodEvents(f)
 			logNodeEvents(f)


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind failing-test

#### What this PR does / why we need it:
The Critical Pod test test was constantly failing lately.
Turns out the main reason was the test was looking for the pod in the wrong (inconsistent) namespace.
Fix this by always using the same namespace for create/get/delete, and add minor improvements along the way to make the test easier to troubleshoot next time.

#### Which issue(s) this PR fixes:
see below

#### Special notes for your reviewer:
This is an alternate take on https://github.com/kubernetes/kubernetes/pull/103408: here we try to fix the framework instead of inline the functions in the affected test. However changing `CreateSync` has far-reaching implications I'm not really sure about.

**PARTIALLY** Fixes https://github.com/kubernetes/kubernetes/issues/102148 - Other failure in the serial lane will be addressed by other PRs.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```