### PR TITLE
cluster: fix metrics-server deployment on CI jobs

### DIFF
--- a/cluster/addons/metrics-server/metrics-server-deployment.yaml
+++ b/cluster/addons/metrics-server/metrics-server-deployment.yaml
@@ -23,23 +23,23 @@ data:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: metrics-server-v0.4.4
+  name: metrics-server-v0.5.0
   namespace: kube-system
   labels:
     k8s-app: metrics-server
     addonmanager.kubernetes.io/mode: Reconcile
-    version: v0.4.4
+    version: v0.5.0
 spec:
   selector:
     matchLabels:
       k8s-app: metrics-server
-      version: v0.4.4
+      version: v0.5.0
   template:
     metadata:
       name: metrics-server
       labels:
         k8s-app: metrics-server
-        version: v0.4.4
+        version: v0.5.0
     spec:
       securityContext:
         seccompProfile:
@@ -50,7 +50,7 @@ spec:
         kubernetes.io/os: linux
       containers:
       - name: metrics-server
-        image: k8s.gcr.io/metrics-server/metrics-server:v0.4.4
+        image: k8s.gcr.io/metrics-server/metrics-server:v0.5.0
         command:
         - /metrics-server
         - --metric-resolution=30s
@@ -109,7 +109,7 @@ spec:
           - --memory={{ base_metrics_server_memory }}
           - --extra-memory={{ metrics_server_memory_per_node }}Mi
           - --threshold=5
-          - --deployment=metrics-server-v0.4.4
+          - --deployment=metrics-server-v0.5.0
           - --container=metrics-server
           - --poll-period=30000
           - --estimator=exponential

--- a/cluster/addons/metrics-server/metrics-server-deployment.yaml
+++ b/cluster/addons/metrics-server/metrics-server-deployment.yaml
@@ -54,10 +54,8 @@ spec:
         command:
         - /metrics-server
         - --metric-resolution=30s
-        # These are needed for GKE, which doesn't support secure communication yet.
-        # Remove these lines for non-GKE clusters, and when GKE supports token-based auth.
-        - --kubelet-port=10255
-        - --deprecated-kubelet-completely-insecure=true
+        - --kubelet-use-node-status-port
+        - --kubelet-insecure-tls
         - --kubelet-preferred-address-types=InternalIP,Hostname,InternalDNS,ExternalDNS,ExternalIP
         - --cert-dir=/tmp
         - --secure-port=443
@@ -65,6 +63,20 @@ spec:
         - containerPort: 443
           name: https
           protocol: TCP
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: https
+            scheme: HTTPS
+          periodSeconds: 10
+          failureThreshold: 3
+        livenessProbe:
+          httpGet:
+            path: /livez
+            port: https
+            scheme: HTTPS
+          periodSeconds: 10
+          failureThreshold: 3
         volumeMounts:
         - mountPath: /tmp
           name: tmp-dir


### PR DESCRIPTION
/kind failing-test
/kind flake
Fixes #103708



```release-note
NONE
```

The metrics-server deployed wasn't working correctly due to the recent changes in kubernetes.
Surprisingly, the metrics-server was constantly crash looping but the tests were passing.

This PR fixes the metrics-server deployment:
- adds liveness and readiness probes so if the metrics-server fails, the job fails
- metrics-server listen on an unprivileged port (4443)
- allow to use the kubelet secure port (the insecure port was deprecated IIRC)