### PR TITLE
Update e2e test images url

### DIFF
--- a/hack/testdata/pod-with-large-name.yaml
+++ b/hack/testdata/pod-with-large-name.yaml
@@ -8,4 +8,5 @@ metadata:
 spec:
   containers:
   - name: kubernetes-serve-hostname
-    image: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.1
+    image: k8s.gcr.io/e2e-test-images/agnhost:2.32
+    command: ["/agnhost", "serve-hostname"]

--- a/staging/src/k8s.io/sample-apiserver/artifacts/example/deployment.yaml
+++ b/staging/src/k8s.io/sample-apiserver/artifacts/example/deployment.yaml
@@ -20,8 +20,8 @@ spec:
       - name: wardle-server
         # build from staging/src/k8s.io/sample-apiserver/artifacts/simple-image/Dockerfile
         # or
-        # docker pull gcr.io/kubernetes-e2e-test-images/sample-apiserver:1.17
-        # docker tag gcr.io/kubernetes-e2e-test-images/sample-apiserver:1.17 kube-sample-apiserver:latest
+        # docker pull k8s.gcr.io/e2e-test-images/sample-apiserver:1.17.4
+        # docker tag k8s.gcr.io/e2e-test-images/sample-apiserver:1.17.4 kube-sample-apiserver:latest
         image: kube-sample-apiserver:latest
         imagePullPolicy: Never
         args: [ "--etcd-servers=http://localhost:2379" ]

--- a/test/e2e/testing-manifests/ingress/gce/static-ip-2/rc.yaml
+++ b/test/e2e/testing-manifests/ingress/gce/static-ip-2/rc.yaml
@@ -11,6 +11,6 @@ spec:
     spec:
       containers:
       - name: echoheaders-https
-        image: gcr.io/kubernetes-e2e-test-images/echoserver:2.2
+        image: k8s.gcr.io/e2e-test-images/echoserver:2.3
         ports:
         - containerPort: 8080

--- a/test/e2e/testing-manifests/ingress/http/rc.yaml
+++ b/test/e2e/testing-manifests/ingress/http/rc.yaml
@@ -11,7 +11,7 @@ spec:
     spec:
       containers:
       - name: echoheaders
-        image: gcr.io/kubernetes-e2e-test-images/echoserver:2.2
+        image: k8s.gcr.io/e2e-test-images/echoserver:2.3
         ports:
         - containerPort: 8080
         readinessProbe:

--- a/test/e2e/testing-manifests/ingress/http2/rc.yaml
+++ b/test/e2e/testing-manifests/ingress/http2/rc.yaml
@@ -14,6 +14,6 @@ spec:
     spec:
       containers:
       - name: echoheaders
-        image: gcr.io/kubernetes-e2e-test-images/echoserver:2.2
+        image: k8s.gcr.io/e2e-test-images/echoserver:2.3
         ports:
         - containerPort: 8443

--- a/test/e2e/testing-manifests/ingress/multiple-certs/rc.yaml
+++ b/test/e2e/testing-manifests/ingress/multiple-certs/rc.yaml
@@ -11,6 +11,6 @@ spec:
     spec:
       containers:
       - name: echoheaders-https
-        image: gcr.io/kubernetes-e2e-test-images/echoserver:2.2
+        image: k8s.gcr.io/e2e-test-images/echoserver:2.3
         ports:
         - containerPort: 8080

--- a/test/e2e/testing-manifests/ingress/neg-clusterip/rc.yaml
+++ b/test/e2e/testing-manifests/ingress/neg-clusterip/rc.yaml
@@ -15,7 +15,8 @@ spec:
         run: hostname
     spec:
       containers:
-      - image: gcr.io/kubernetes-e2e-test-images/serve-hostname:1.1
+      - image: k8s.gcr.io/e2e-test-images/agnhost:2.32
+        command: ["/agnhost", "serve-hostname"]
         imagePullPolicy: IfNotPresent
         name: hostname
       terminationGracePeriodSeconds: 120

--- a/test/e2e/testing-manifests/ingress/neg-exposed/rc.yaml
+++ b/test/e2e/testing-manifests/ingress/neg-exposed/rc.yaml
@@ -14,21 +14,15 @@ spec:
         run: hostname
     spec:
       containers:
-      - image: gcr.io/kubernetes-e2e-test-images/serve-hostname:1.1
+      - image: k8s.gcr.io/e2e-test-images/agnhost:2.32
         name: host1
-        command:
-        - /bin/sh
-        - -c
-        - /serve_hostname -http=true -udp=false -port=8000
+        args: ["serve-hostname", "--http=true", "--udp=false", "--port=8000"]
         ports:
         - protocol: TCP
           containerPort: 8000
-      - image: gcr.io/kubernetes-e2e-test-images/serve-hostname:1.1
+      - image: k8s.gcr.io/e2e-test-images/agnhost:2.32
         name: host2
-        command:
-        - /bin/sh
-        - -c
-        - /serve_hostname -http=true -udp=false -port=8080
+        args: ["serve-hostname", "--http=true", "--udp=false", "--port=8080"]
         ports:
         - protocol: TCP
           containerPort: 8080

--- a/test/e2e/testing-manifests/ingress/neg/rc.yaml
+++ b/test/e2e/testing-manifests/ingress/neg/rc.yaml
@@ -15,7 +15,8 @@ spec:
         run: hostname
     spec:
       containers:
-      - image: gcr.io/kubernetes-e2e-test-images/serve-hostname:1.1
+      - image: k8s.gcr.io/e2e-test-images/agnhost:2.32
+        command: ["/agnhost", "serve-hostname"]
         imagePullPolicy: IfNotPresent
         name: hostname
       terminationGracePeriodSeconds: 120

--- a/test/e2e/testing-manifests/ingress/pre-shared-cert/rc.yaml
+++ b/test/e2e/testing-manifests/ingress/pre-shared-cert/rc.yaml
@@ -11,6 +11,6 @@ spec:
     spec:
       containers:
       - name: echoheaders-https
-        image: gcr.io/kubernetes-e2e-test-images/echoserver:2.2
+        image: k8s.gcr.io/e2e-test-images/echoserver:2.3
         ports:
         - containerPort: 8080

--- a/test/e2e/testing-manifests/ingress/static-ip/rc.yaml
+++ b/test/e2e/testing-manifests/ingress/static-ip/rc.yaml
@@ -11,6 +11,6 @@ spec:
     spec:
       containers:
       - name: echoheaders-https
-        image: gcr.io/kubernetes-e2e-test-images/echoserver:2.2
+        image: k8s.gcr.io/e2e-test-images/echoserver:2.3
         ports:
         - containerPort: 8080

--- a/test/e2e/testing-manifests/kubectl/agnhost-primary-pod.yaml
+++ b/test/e2e/testing-manifests/kubectl/agnhost-primary-pod.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   containers:
     - name: primary
-      image: gcr.io/kubernetes-e2e-test-images/agnhost:1.0
+      image: k8s.gcr.io/e2e-test-images/agnhost:2.32
       env:
         - name: PRIMARY
           value: "true"
@@ -21,7 +21,7 @@ spec:
         - mountPath: /agnhost-primary-data
           name: data
     - name: sentinel
-      image: gcr.io/kubernetes-e2e-test-images/agnhost:1.0
+      image: k8s.gcr.io/e2e-test-images/agnhost:2.32
       env:
         - name: SENTINEL
           value: "true"

--- a/test/e2e/testing-manifests/serviceloadbalancer/netexecrc.yaml
+++ b/test/e2e/testing-manifests/serviceloadbalancer/netexecrc.yaml
@@ -12,7 +12,8 @@ spec:
     spec:
       containers:
       - name: netexec
-        image: gcr.io/kubernetes-e2e-test-images/netexec:1.0
+        image: k8s.gcr.io/e2e-test-images/agnhost:2.32
+        command: ["/agnhost", "netexec"]
         ports:
         - containerPort: 8080
           # This is to force these pods to land on different hosts.

--- a/test/fixtures/doc-yaml/user-guide/multi-pod.yaml
+++ b/test/fixtures/doc-yaml/user-guide/multi-pod.yaml
@@ -10,7 +10,7 @@ metadata:
 spec:
   containers:
     - name: master
-      image: gcr.io/kubernetes-e2e-test-images/redis:1.0
+      image: k8s.gcr.io/e2e-test-images/redis:5.0.5-alpine
       env:
         - name: MASTER
           value: "true"
@@ -23,7 +23,7 @@ spec:
         - mountPath: /redis-master-data
           name: data
     - name: sentinel
-      image: gcr.io/kubernetes-e2e-test-images/redis:1.0
+      image: k8s.gcr.io/e2e-test-images/redis:5.0.5-alpine
       env:
         - name: SENTINEL
           value: "true"
@@ -42,7 +42,8 @@ metadata:
 spec:
   containers:
   - name: kubernetes-serve-hostname
-    image: gcr.io/kubernetes-e2e-test-images/serve-hostname:1.0
+    image: k8s.gcr.io/e2e-test-images/agnhost:2.32
+    command: ["/agnhost", "serve-hostname"]
     resources:
       limits:
         cpu: "1"

--- a/test/fixtures/pkg/kubectl/cmd/auth/rbac-resource-plus.yaml
+++ b/test/fixtures/pkg/kubectl/cmd/auth/rbac-resource-plus.yaml
@@ -30,7 +30,8 @@ items:
   spec:
     containers:
     - name: kubernetes-serve-hostname
-      image: gcr.io/kubernetes-e2e-test-images/serve-hostname:1.1
+      image: k8s.gcr.io/e2e-test-images/agnhost:2.32
+      command: ["/agnhost", "serve-hostname"]
       resources:
         limits:
           cpu: "1"

--- a/test/images/Makefile
+++ b/test/images/Makefile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-REGISTRY ?= gcr.io/kubernetes-e2e-test-images
+REGISTRY ?= k8s.gcr.io/e2e-test-images
 GOARM ?= 7
 DOCKER_CERT_BASE_PATH ?=
 QEMUVERSION=v5.1.0-2

--- a/test/images/README.md
+++ b/test/images/README.md
@@ -131,7 +131,7 @@ To build AND push an image, the following command can be used:
 make all-push WHAT=agnhost
 ```
 
-By default, the images will be tagged and pushed under the `gcr.io/kubernetes-e2e-test-images`
+By default, the images will be tagged and pushed under the `k8s.gcr.io/e2e-test-images`
 registry. That can changed by running this command instead:
 
 ```bash
@@ -142,7 +142,7 @@ REGISTRY=foo_registry make all-push WHAT=agnhost
 require the `agnhost` image to be published in an authenticated repo as well:
 
 ```bash
-REGISTRY=gcr.io/kubernetes-e2e-test-images make all-push WHAT=agnhost
+REGISTRY=k8s.gcr.io/e2e-test-images make all-push WHAT=agnhost
 REGISTRY=gcr.io/k8s-authenticated-test make all-push WHAT=agnhost
 ```
 
@@ -164,7 +164,6 @@ export KUBE_TEST_REPO_LIST=/path/to/repo_list.yaml
 to pull the images from. Sample file:
 
 ```yaml
-e2eRegistry: your-awesome-registry
 promoterE2eRegistry: your-awesome-registry
 gcRegistry: your-awesome-registry
 sampleRegistry: your-awesome-registry

--- a/test/images/windows/Makefile
+++ b/test/images/windows/Makefile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-REGISTRY ?= gcr.io/kubernetes-e2e-test-images
+REGISTRY ?= k8s.gcr.io/e2e-test-images
 REMOTE_DOCKER_URL ?=
 DOCKER_CERT_PATH ?= "$(HOME)/.docker"
 export

--- a/test/utils/image/manifest.go
+++ b/test/utils/image/manifest.go
@@ -31,7 +31,6 @@ import (
 // RegistryList holds public and private image registries
 type RegistryList struct {
 	GcAuthenticatedRegistry  string `yaml:"gcAuthenticatedRegistry"`
-	E2eRegistry              string `yaml:"e2eRegistry"`
 	PromoterE2eRegistry      string `yaml:"promoterE2eRegistry"`
 	BuildImageRegistry       string `yaml:"buildImageRegistry"`
 	InvalidRegistry          string `yaml:"invalidRegistry"`
@@ -91,7 +90,6 @@ func initReg() RegistryList {
 var (
 	initRegistry = RegistryList{
 		GcAuthenticatedRegistry:  "gcr.io/authenticated-image-pulling",
-		E2eRegistry:              "gcr.io/kubernetes-e2e-test-images",
 		PromoterE2eRegistry:      "k8s.gcr.io/e2e-test-images",
 		BuildImageRegistry:       "k8s.gcr.io/build-image",
 		InvalidRegistry:          "invalid.com/invalid",
@@ -212,7 +210,7 @@ func initImageConfigs(list RegistryList) (map[int]Config, map[int]Config) {
 	configs[AppArmorLoader] = Config{list.PromoterE2eRegistry, "apparmor-loader", "1.3"}
 	configs[BusyBox] = Config{list.PromoterE2eRegistry, "busybox", "1.29-1"}
 	configs[CheckMetadataConcealment] = Config{list.PromoterE2eRegistry, "metadata-concealment", "1.6"}
-	configs[CudaVectorAdd] = Config{list.E2eRegistry, "cuda-vector-add", "1.0"}
+	configs[CudaVectorAdd] = Config{list.PromoterE2eRegistry, "cuda-vector-add", "1.0"}
 	configs[CudaVectorAdd2] = Config{list.PromoterE2eRegistry, "cuda-vector-add", "2.2"}
 	configs[DebianIptables] = Config{list.BuildImageRegistry, "debian-iptables", "buster-v1.6.5"}
 	configs[EchoServer] = Config{list.PromoterE2eRegistry, "echoserver", "2.3"}
@@ -383,8 +381,6 @@ func replaceRegistryInImageURLWithList(imageURL string, reg RegistryList) (strin
 	}
 
 	switch registryAndUser {
-	case initRegistry.E2eRegistry:
-		registryAndUser = reg.E2eRegistry
 	case initRegistry.GcRegistry:
 		registryAndUser = reg.GcRegistry
 	case initRegistry.SigStorageRegistry:

--- a/test/utils/image/manifest_test.go
+++ b/test/utils/image/manifest_test.go
@@ -41,9 +41,6 @@ func TestReplaceRegistryInImageURL(t *testing.T) {
 			in:  "test",
 			out: "test.io/library/test",
 		}, {
-			in:  "gcr.io/kubernetes-e2e-test-images/test:123",
-			out: "test.io/kubernetes-e2e-test-images/test:123",
-		}, {
 			in:  "k8s.gcr.io/test:123",
 			out: "test.io/test:123",
 		}, {
@@ -82,7 +79,6 @@ func TestReplaceRegistryInImageURL(t *testing.T) {
 	// Set custom registries
 	reg := RegistryList{
 		DockerLibraryRegistry:   "test.io/library",
-		E2eRegistry:             "test.io/kubernetes-e2e-test-images",
 		GcRegistry:              "test.io",
 		GcrReleaseRegistry:      "test.io/gke-release",
 		PrivateRegistry:         "test.io/k8s-authenticated-test",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind cleanup

/sig testing
/priority important-soon

#### What this PR does / why we need it:

Removes any reference from the registry ``gcr.io/kubernetes-e2e-test-images`` in kubernetes/kubernetes, replacing them with ``k8s.gcr.io/kubernetes-e2e-test-images``. In some cases, the images had to be updated since a few things have changed since
their original implementation, most notably being the fact that some of the images have been centralized into the agnhost image.

Co-Authored-By: Claudiu Belu <cbelu@cloudbasesolutions.com>

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #96770

#### Special notes for your reviewer:

Cherry-picked from: #100470

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
``gcr.io/kubernetes-e2e-test-images`` will no longer be used in E2E / CI testing, ``k8s.gcr.io/e2e-test-images`` will be used instead.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
