### PR TITLE
Fix panic in master upgrade tests

### DIFF
--- a/test/e2e/cloud/gcp/cluster_upgrade.go
+++ b/test/e2e/cloud/gcp/cluster_upgrade.go
@@ -64,7 +64,7 @@ var _ = SIGDescribe("Upgrade [Feature:Upgrade]", func() {
 				Name:      "[sig-cloud-provider-gcp] master-upgrade",
 				Classname: "upgrade_tests",
 			}
-			testSuite.TestCases = append(testSuite.TestCases, masterUpgradeTest, nil)
+			testSuite.TestCases = append(testSuite.TestCases, masterUpgradeTest)
 
 			upgradeFunc := common.ControlPlaneUpgradeFunc(f, upgCtx, masterUpgradeTest, nil)
 			upgrades.RunUpgradeSuite(upgCtx, upgradeTests, testFrameworks, testSuite, upgrades.MasterUpgrade, upgradeFunc)


### PR DESCRIPTION
Ref https://github.com/kubernetes/kubernetes/issues/103697

```release-note
NONE
```

/kind bug
/priority critical-urgent
/sig cloud-provider

/assign @liggitt @spiffxp 