### PR TITLE
remove gcr.io/gke-release it is deprecated and not used

### DIFF
--- a/test/utils/image/manifest.go
+++ b/test/utils/image/manifest.go
@@ -100,7 +100,6 @@ var (
 		SigStorageRegistry:       "k8s.gcr.io/sig-storage",
 		PrivateRegistry:          "gcr.io/k8s-authenticated-test",
 		SampleRegistry:           "gcr.io/google-samples",
-		GcrReleaseRegistry:       "gcr.io/gke-release",
 		MicrosoftRegistry:        "mcr.microsoft.com",
 		DockerLibraryRegistry:    "docker.io/library",
 		CloudProviderGcpRegistry: "k8s.gcr.io/cloud-provider-gcp",
@@ -393,8 +392,6 @@ func replaceRegistryInImageURLWithList(imageURL string, reg RegistryList) (strin
 		registryAndUser = reg.PrivateRegistry
 	case initRegistry.SampleRegistry:
 		registryAndUser = reg.SampleRegistry
-	case initRegistry.GcrReleaseRegistry:
-		registryAndUser = reg.GcrReleaseRegistry
 	case initRegistry.InvalidRegistry:
 		registryAndUser = reg.InvalidRegistry
 	case initRegistry.MicrosoftRegistry:

--- a/test/utils/image/manifest_test.go
+++ b/test/utils/image/manifest_test.go
@@ -53,9 +53,6 @@ func TestReplaceRegistryInImageURL(t *testing.T) {
 			in:  "gcr.io/google-samples/test:latest",
 			out: "test.io/google-samples/test:latest",
 		}, {
-			in:  "gcr.io/gke-release/test:latest",
-			out: "test.io/gke-release/test:latest",
-		}, {
 			in:  "k8s.gcr.io/sig-storage/test:latest",
 			out: "test.io/sig-storage/test:latest",
 		}, {
@@ -84,7 +81,6 @@ func TestReplaceRegistryInImageURL(t *testing.T) {
 		DockerLibraryRegistry:   "test.io/library",
 		E2eRegistry:             "test.io/kubernetes-e2e-test-images",
 		GcRegistry:              "test.io",
-		GcrReleaseRegistry:      "test.io/gke-release",
 		PrivateRegistry:         "test.io/k8s-authenticated-test",
 		SampleRegistry:          "test.io/google-samples",
 		SigStorageRegistry:      "test.io/sig-storage",


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:
As part of the efforts described in this Issue https://github.com/kubernetes/k8s.io/issues/1525

k/k is not using `gcr.io/gke-release` registry anymore so cleaning the references all related images were moved  to `k8s.gcr.io` community registry

/assign @spiffxp 

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
