### PR TITLE
Make volume unmount max duration customizable

### DIFF
--- a/api/api-rules/violation_exceptions.list
+++ b/api/api-rules/violation_exceptions.list
@@ -503,6 +503,7 @@ API rule violation: names_match,k8s.io/controller-manager/config/v1alpha1,Generi
 API rule violation: names_match,k8s.io/controller-manager/config/v1alpha1,GenericControllerManagerConfiguration,MinResyncPeriod
 API rule violation: names_match,k8s.io/controller-manager/config/v1alpha1,GenericControllerManagerConfiguration,Port
 API rule violation: names_match,k8s.io/kube-controller-manager/config/v1alpha1,AttachDetachControllerConfiguration,DisableAttachDetachReconcilerSync
+API rule violation: names_match,k8s.io/kube-controller-manager/config/v1alpha1,AttachDetachControllerConfiguration,ReconcilerMaxWaitForUnmountDuration
 API rule violation: names_match,k8s.io/kube-controller-manager/config/v1alpha1,AttachDetachControllerConfiguration,ReconcilerSyncLoopPeriod
 API rule violation: names_match,k8s.io/kube-controller-manager/config/v1alpha1,CSRSigningConfiguration,CertFile
 API rule violation: names_match,k8s.io/kube-controller-manager/config/v1alpha1,CSRSigningConfiguration,KeyFile

--- a/cmd/kube-controller-manager/app/core.go
+++ b/cmd/kube-controller-manager/app/core.go
@@ -349,7 +349,7 @@ func startAttachDetachController(ctx ControllerContext) (http.Handler, bool, err
 			GetDynamicPluginProber(ctx.ComponentConfig.PersistentVolumeBinderController.VolumeConfiguration),
 			ctx.ComponentConfig.AttachDetachController.DisableAttachDetachReconcilerSync,
 			ctx.ComponentConfig.AttachDetachController.ReconcilerSyncLoopPeriod.Duration,
-			attachdetach.DefaultTimerConfig,
+			attachdetach.NewAttachDetachTimerConfig(ctx.ComponentConfig.AttachDetachController.ReconcilerMaxWaitForUnmountDuration.Duration),
 			filteredDialOptions,
 		)
 	if attachDetachControllerErr != nil {

--- a/cmd/kube-controller-manager/app/options/attachdetachcontroller.go
+++ b/cmd/kube-controller-manager/app/options/attachdetachcontroller.go
@@ -19,6 +19,7 @@ package options
 import (
 	"github.com/spf13/pflag"
 
+	"k8s.io/kubernetes/pkg/controller/volume/attachdetach"
 	attachdetachconfig "k8s.io/kubernetes/pkg/controller/volume/attachdetach/config"
 )
 
@@ -35,6 +36,7 @@ func (o *AttachDetachControllerOptions) AddFlags(fs *pflag.FlagSet) {
 
 	fs.BoolVar(&o.DisableAttachDetachReconcilerSync, "disable-attach-detach-reconcile-sync", false, "Disable volume attach detach reconciler sync. Disabling this may cause volumes to be mismatched with pods. Use wisely.")
 	fs.DurationVar(&o.ReconcilerSyncLoopPeriod.Duration, "attach-detach-reconcile-sync-period", o.ReconcilerSyncLoopPeriod.Duration, "The reconciler sync wait time between volume attach detach. This duration must be larger than one second, and increasing this value from the default may allow for volumes to be mismatched with pods.")
+	fs.DurationVar(&o.ReconcilerMaxWaitForUnmountDuration.Duration, "attach-detach-reconcile-max-wait-for-unmount-duration", attachdetach.DefaultTimerConfig.ReconcilerMaxWaitForUnmountDuration, "The maximum amount of time the attach detach controller will wait for the volume to be safely unmounted from its node. Once this time has expired, the controller will assume the node or kubelet are unresponsive and will detach the volume anyway. Use wisely.")
 }
 
 // ApplyTo fills up AttachDetachController config with options.
@@ -45,6 +47,7 @@ func (o *AttachDetachControllerOptions) ApplyTo(cfg *attachdetachconfig.AttachDe
 
 	cfg.DisableAttachDetachReconcilerSync = o.DisableAttachDetachReconcilerSync
 	cfg.ReconcilerSyncLoopPeriod = o.ReconcilerSyncLoopPeriod
+	cfg.ReconcilerMaxWaitForUnmountDuration = o.ReconcilerMaxWaitForUnmountDuration
 
 	return nil
 }

--- a/cmd/kube-controller-manager/app/options/options_test.go
+++ b/cmd/kube-controller-manager/app/options/options_test.go
@@ -223,6 +223,7 @@ func TestAddFlags(t *testing.T) {
 		AttachDetachController: &AttachDetachControllerOptions{
 			&attachdetachconfig.AttachDetachControllerConfiguration{
 				ReconcilerSyncLoopPeriod:          metav1.Duration{Duration: 30 * time.Second},
+				ReconcilerMaxWaitForUnmountDuration: metav1.Duration{Duration: 6 * time.Minute},
 				DisableAttachDetachReconcilerSync: true,
 			},
 		},
@@ -497,6 +498,7 @@ func TestApplyTo(t *testing.T) {
 			},
 			AttachDetachController: attachdetachconfig.AttachDetachControllerConfiguration{
 				ReconcilerSyncLoopPeriod:          metav1.Duration{Duration: 30 * time.Second},
+				ReconcilerMaxWaitForUnmountDuration: metav1.Duration{Duration: 6 * time.Minute},
 				DisableAttachDetachReconcilerSync: true,
 			},
 			CSRSigningController: csrsigningconfig.CSRSigningControllerConfiguration{

--- a/pkg/controller/volume/attachdetach/attach_detach_controller.go
+++ b/pkg/controller/volume/attachdetach/attach_detach_controller.go
@@ -98,6 +98,14 @@ var DefaultTimerConfig TimerConfig = TimerConfig{
 	DesiredStateOfWorldPopulatorListPodsRetryDuration: 3 * time.Minute,
 }
 
+// NewAttachDetachTimerConfig returns a new instance of TimerConfig where max wait
+// for umount duration is overriden with the desired value.
+func NewAttachDetachTimerConfig(reconcilerMaxWaitForUnmountDuration time.Duration) TimerConfig {
+	timerConfig := DefaultTimerConfig
+	timerConfig.ReconcilerMaxWaitForUnmountDuration = reconcilerMaxWaitForUnmountDuration
+	return timerConfig
+}
+
 // AttachDetachController defines the operations supported by this controller.
 type AttachDetachController interface {
 	Run(stopCh <-chan struct{})

--- a/pkg/controller/volume/attachdetach/attach_detach_controller_test.go
+++ b/pkg/controller/volume/attachdetach/attach_detach_controller_test.go
@@ -166,7 +166,6 @@ func Test_AttachDetachControllerRecovery(t *testing.T) {
 func attachDetachRecoveryTestCase(t *testing.T, extraPods1 []*v1.Pod, extraPods2 []*v1.Pod) {
 	fakeKubeClient := controllervolumetesting.CreateTestClient()
 	informerFactory := informers.NewSharedInformerFactory(fakeKubeClient, time.Second*1)
-	//informerFactory := informers.NewSharedInformerFactory(fakeKubeClient, time.Second*1)
 	plugins := controllervolumetesting.CreateTestPlugin()
 	var prober volume.DynamicPluginProber = nil // TODO (#51147) inject mock
 	nodeInformer := informerFactory.Core().V1().Nodes().Informer()

--- a/pkg/controller/volume/attachdetach/config/types.go
+++ b/pkg/controller/volume/attachdetach/config/types.go
@@ -29,4 +29,10 @@ type AttachDetachControllerConfiguration struct {
 	// ReconcilerSyncLoopPeriod is the amount of time the reconciler sync states loop
 	// wait between successive executions. Is set to 5 sec by default.
 	ReconcilerSyncLoopPeriod metav1.Duration
+	// ReconcilerMaxWaitForUnmountDuration is the maximum amount of time the
+	// attach detach controller will wait for a volume to be safely unmounted
+	// from its node. Once this time has expired, the controller will assume the
+	// node or kubelet are unresponsive and will detach the volume anyway.
+	// Is set to 6 minutes by default.
+	ReconcilerMaxWaitForUnmountDuration metav1.Duration
 }

--- a/pkg/controller/volume/attachdetach/config/v1alpha1/zz_generated.conversion.go
+++ b/pkg/controller/volume/attachdetach/config/v1alpha1/zz_generated.conversion.go
@@ -61,12 +61,14 @@ func RegisterConversions(s *runtime.Scheme) error {
 func autoConvert_v1alpha1_AttachDetachControllerConfiguration_To_config_AttachDetachControllerConfiguration(in *v1alpha1.AttachDetachControllerConfiguration, out *config.AttachDetachControllerConfiguration, s conversion.Scope) error {
 	out.DisableAttachDetachReconcilerSync = in.DisableAttachDetachReconcilerSync
 	out.ReconcilerSyncLoopPeriod = in.ReconcilerSyncLoopPeriod
+	out.ReconcilerMaxWaitForUnmountDuration = in.ReconcilerMaxWaitForUnmountDuration
 	return nil
 }
 
 func autoConvert_config_AttachDetachControllerConfiguration_To_v1alpha1_AttachDetachControllerConfiguration(in *config.AttachDetachControllerConfiguration, out *v1alpha1.AttachDetachControllerConfiguration, s conversion.Scope) error {
 	out.DisableAttachDetachReconcilerSync = in.DisableAttachDetachReconcilerSync
 	out.ReconcilerSyncLoopPeriod = in.ReconcilerSyncLoopPeriod
+	out.ReconcilerMaxWaitForUnmountDuration = in.ReconcilerMaxWaitForUnmountDuration
 	return nil
 }
 

--- a/pkg/controller/volume/attachdetach/config/zz_generated.deepcopy.go
+++ b/pkg/controller/volume/attachdetach/config/zz_generated.deepcopy.go
@@ -24,6 +24,7 @@ package config
 func (in *AttachDetachControllerConfiguration) DeepCopyInto(out *AttachDetachControllerConfiguration) {
 	*out = *in
 	out.ReconcilerSyncLoopPeriod = in.ReconcilerSyncLoopPeriod
+	out.ReconcilerMaxWaitForUnmountDuration = in.ReconcilerMaxWaitForUnmountDuration
 	return
 }
 

--- a/staging/src/k8s.io/kube-controller-manager/config/v1alpha1/types.go
+++ b/staging/src/k8s.io/kube-controller-manager/config/v1alpha1/types.go
@@ -173,6 +173,12 @@ type AttachDetachControllerConfiguration struct {
 	// ReconcilerSyncLoopPeriod is the amount of time the reconciler sync states loop
 	// wait between successive executions. Is set to 5 sec by default.
 	ReconcilerSyncLoopPeriod metav1.Duration
+	// ReconcilerMaxWaitForUnmountDuration is the maximum amount of time the
+	// attach detach controller will wait for a volume to be safely unmounted
+	// from its node. Once this time has expired, the controller will assume the
+	// node or kubelet are unresponsive and will detach the volume anyway.
+	// Is set to 6 minutes by default.
+	ReconcilerMaxWaitForUnmountDuration metav1.Duration
 }
 
 // CSRSigningControllerConfiguration contains elements describing CSRSigningController.

--- a/staging/src/k8s.io/kube-controller-manager/config/v1alpha1/zz_generated.deepcopy.go
+++ b/staging/src/k8s.io/kube-controller-manager/config/v1alpha1/zz_generated.deepcopy.go
@@ -28,6 +28,7 @@ import (
 func (in *AttachDetachControllerConfiguration) DeepCopyInto(out *AttachDetachControllerConfiguration) {
 	*out = *in
 	out.ReconcilerSyncLoopPeriod = in.ReconcilerSyncLoopPeriod
+	out.ReconcilerMaxWaitForUnmountDuration = in.ReconcilerMaxWaitForUnmountDuration
 	return
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind feature

#### What this PR does / why we need it:

Some of our pods are attached RBD volumes. When a node goes down and such volume attached pod is evicted and then terminated, it's impossible for another pod to handover until the 6 minutes delay expires.
We are running in an embedded environment where nodes are never shutdown gracefully. It makes sense for us to reduce the 6 minutes delay to the value we want.
This PR adds the flag --attach-detach-reconcile-max-wait-for-unmount-duration to kube-controller-manager while keeping its default value, making it a seamless change for user who don't care.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #66603

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Added flag --attach-detach-reconcile-max-wait-for-unmount-duration to kube-controller-manager. Default value of 6 minutes is left unchanged.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
