### PR TITLE
test images: Adds image labels by default

### DIFF
--- a/test/images/busybox/Dockerfile
+++ b/test/images/busybox/Dockerfile
@@ -15,5 +15,3 @@
 # NOTE(claudiub): Noop. We're just mirroring the image to staging.
 ARG BASEIMAGE
 FROM $BASEIMAGE
-
-LABEL image_version="1.29-1"

--- a/test/images/busybox/Dockerfile_windows
+++ b/test/images/busybox/Dockerfile_windows
@@ -92,5 +92,4 @@ ENV PATH="C:\dig\;C:\bin;C:\curl;C:\Windows\System32;C:\Windows;C:\Program Files
     # Persist %PSCORE% ENV variable for user convenience
     PSCORE="C:\Program Files\PowerShell\pwsh.exe"
 
-LABEL image_version="1.29-1"
 ENTRYPOINT ["cmd.exe", "/s", "/c"]

--- a/test/images/glusterdynamic-provisioner/Dockerfile
+++ b/test/images/glusterdynamic-provisioner/Dockerfile
@@ -15,5 +15,3 @@
 # NOTE(claudiub): Noop. We're just mirroring the image to staging.
 ARG BASEIMAGE
 FROM $BASEIMAGE
-
-LABEL image_version="v1.0"

--- a/test/images/httpd-new/Dockerfile
+++ b/test/images/httpd-new/Dockerfile
@@ -15,5 +15,3 @@
 # NOTE(claudiub): Noop. We're just mirroring the image to staging.
 ARG BASEIMAGE
 FROM $BASEIMAGE
-
-LABEL image_version="2.4.39-1"

--- a/test/images/httpd-new/Dockerfile_windows
+++ b/test/images/httpd-new/Dockerfile_windows
@@ -43,5 +43,4 @@ ENV PATH="C:\dig;C:\bin;C:\curl;C:\Windows\System32;C:\Windows;C:\Program Files\
 
 USER ContainerAdministrator
 EXPOSE 80
-LABEL image_version="2.4.39-1"
 ENTRYPOINT ["C:/usr/local/apache2/bin/httpd.exe"]

--- a/test/images/httpd/Dockerfile
+++ b/test/images/httpd/Dockerfile
@@ -15,5 +15,3 @@
 # NOTE(claudiub): Noop. We're just mirroring the image to staging.
 ARG BASEIMAGE
 FROM $BASEIMAGE
-
-LABEL image_version="2.4.38-1"

--- a/test/images/httpd/Dockerfile_windows
+++ b/test/images/httpd/Dockerfile_windows
@@ -43,5 +43,4 @@ ENV PATH="C:\dig;C:\bin;C:\curl;C:\Windows\System32;C:\Windows;C:\Program Files\
 
 USER ContainerAdministrator
 EXPOSE 80
-LABEL image_version="2.4.39-1"
 ENTRYPOINT ["C:/usr/local/apache2/bin/httpd.exe"]

--- a/test/images/image-util.sh
+++ b/test/images/image-util.sh
@@ -36,6 +36,7 @@ source "${KUBE_ROOT}/hack/lib/util.sh"
 # Mapping of go ARCH to actual architectures shipped part of multiarch/qemu-user-static project
 declare -A QEMUARCHS=( ["amd64"]="x86_64" ["arm"]="arm" ["arm64"]="aarch64" ["ppc64le"]="ppc64le" ["s390x"]="s390x" )
 
+GIT_COMMIT_ID=$(git log -1 --format=%h)
 windows_os_versions=(1809 1903 1909 2004 20H2)
 declare -A WINDOWS_OS_VERSIONS_MAP
 
@@ -182,7 +183,9 @@ build() {
 
     docker buildx build --progress=plain --no-cache --pull --output=type="${output_type}" --platform "${os_name}/${arch}" \
         --build-arg BASEIMAGE="${base_image}" --build-arg REGISTRY="${REGISTRY}" --build-arg OS_VERSION="${os_version}" \
-        -t "${REGISTRY}/${image}:${TAG}-${suffix}" -f "${dockerfile_name}" .
+        -t "${REGISTRY}/${image}:${TAG}-${suffix}" -f "${dockerfile_name}" \
+	--label "image_version=${TAG}" --label "commit_id=${GIT_COMMIT_ID}" \
+	--label "git_url=https://github.com/kubernetes/kubernetes/tree/${GIT_COMMIT_ID}/test/images/${img_folder}" .
 
     popd
   done

--- a/test/images/nginx-new/Dockerfile
+++ b/test/images/nginx-new/Dockerfile
@@ -15,5 +15,3 @@
 # NOTE(claudiub): Noop. We're just mirroring the image to staging.
 ARG BASEIMAGE
 FROM $BASEIMAGE
-
-LABEL image_version="1.15-1"

--- a/test/images/nginx-new/Dockerfile_windows
+++ b/test/images/nginx-new/Dockerfile_windows
@@ -24,5 +24,4 @@ COPY --from=nginx-source /nginx /usr/share/nginx
 
 USER ContainerAdministrator
 EXPOSE 80
-LABEL image_version="1.15-1"
 ENTRYPOINT ["/bin/sh", "-c", " cd /usr/share/nginx && ./nginx.exe"]

--- a/test/images/nginx/Dockerfile
+++ b/test/images/nginx/Dockerfile
@@ -15,5 +15,3 @@
 # NOTE(claudiub): Noop. We're just mirroring the image to staging.
 ARG BASEIMAGE
 FROM $BASEIMAGE
-
-LABEL image_version="1.14-1"

--- a/test/images/nginx/Dockerfile_windows
+++ b/test/images/nginx/Dockerfile_windows
@@ -24,5 +24,4 @@ COPY --from=nginx-source /nginx /usr/share/nginx
 
 USER ContainerAdministrator
 EXPOSE 80
-LABEL image_version="1.14-1"
 ENTRYPOINT ["/bin/sh", "-c", " cd /usr/share/nginx && ./nginx.exe"]

--- a/test/images/perl/Dockerfile
+++ b/test/images/perl/Dockerfile
@@ -15,5 +15,3 @@
 # NOTE(claudiub): Noop. We're just mirroring the image to staging.
 ARG BASEIMAGE
 FROM $BASEIMAGE
-
-LABEL image_version="5.26"

--- a/test/images/windows-nanoserver/Dockerfile
+++ b/test/images/windows-nanoserver/Dockerfile
@@ -15,5 +15,3 @@
 # NOTE(claudiub): Noop. We're just mirroring the image to staging.
 ARG BASEIMAGE
 FROM $BASEIMAGE
-
-LABEL image_version="v1"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind cleanup

/sig testing

#### What this PR does / why we need it:

Adds the "image_version" and "commit_id" to the image labels.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #99648

#### Special notes for your reviewer:

Image build with this PR:

```
docker inspect claudiubelu/busybox:1.29-1
[
    {
        "Id": "sha256:25cb596ea358107320b19aa0735da2359a6bbb3be612511b18ab18825a2a3bd2",
        "RepoTags": [
            "claudiubelu/busybox:1.29-1"
        ],
        "RepoDigests": [
            "claudiubelu/busybox@sha256:a6506eba8d8fe4651c10c0d55cab601fe22900784badd395325c834123922ceb"
        ],
        "Parent": "",
        "Comment": "",
        "Created": "2018-12-26T08:20:42.831353376Z",
        "Container": "",
        "ContainerConfig": {
            "Hostname": "",
            "Domainname": "",
            "User": "",
            "AttachStdin": false,
            "AttachStdout": false,
            "AttachStderr": false,
            "Tty": false,
            "OpenStdin": false,
            "StdinOnce": false,
            "Env": null,
            "Cmd": null,
            "Image": "",
            "Volumes": null,
            "WorkingDir": "",
            "Entrypoint": null,
            "OnBuild": null,
            "Labels": null
        },
        "DockerVersion": "",
        "Author": "",
        "Config": {
            "Hostname": "",
            "Domainname": "",
            "User": "",
            "AttachStdin": false,
            "AttachStdout": false,
            "AttachStderr": false,
            "Tty": false,
            "OpenStdin": false,
            "StdinOnce": false,
            "Env": [
                "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
            ],
            "Cmd": [
                "sh"
            ],
            "ArgsEscaped": true,
            "Image": "",
            "Volumes": null,
            "WorkingDir": "",
            "Entrypoint": null,
            "OnBuild": null,
            "Labels": {
                "commit_id": "f8cdcc10562",
                "image_version": "1.29-1"
            }
        },
        "Architecture": "amd64",
        "Os": "linux",
        "Size": 1154361,
        "VirtualSize": 1154361,
        "GraphDriver": {
            "Data": {
                "MergedDir": "/var/lib/docker/overlay2/474b4adbbd584a3b568cf74e7c18f778fc56168d61b3179aea8960179eb24512/merged",
                "UpperDir": "/var/lib/docker/overlay2/474b4adbbd584a3b568cf74e7c18f778fc56168d61b3179aea8960179eb24512/diff",
                "WorkDir": "/var/lib/docker/overlay2/474b4adbbd584a3b568cf74e7c18f778fc56168d61b3179aea8960179eb24512/work"
            },
            "Name": "overlay2"
        },
        "RootFS": {
            "Type": "layers",
            "Layers": [
                "sha256:23bc2b70b2014dec0ac22f27bb93e9babd08cdd6f1115d0c955b9ff22b382f5a"
            ]
        },
        "Metadata": {
            "LastTagTime": "0001-01-01T00:00:00Z"
        }
    }
]
```

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
