### PR TITLE
Pass unknown labels in allowedTopologies during CSI translation

### DIFF
--- a/staging/src/k8s.io/csi-translation-lib/plugins/in_tree_volume.go
+++ b/staging/src/k8s.io/csi-translation-lib/plugins/in_tree_volume.go
@@ -306,7 +306,7 @@ func translateTopologyFromCSIToInTree(pv *v1.PersistentVolume, csiTopologyKey st
 	return nil
 }
 
-// translateAllowedTopologies translates allowed topologies within storage class
+// translateAllowedTopologies translates allowed topologies within storage class or PV
 // from legacy failure domain to given CSI topology key
 func translateAllowedTopologies(terms []v1.TopologySelectorTerm, key string) ([]v1.TopologySelectorTerm, error) {
 	if terms == nil {
@@ -323,10 +323,9 @@ func translateAllowedTopologies(terms []v1.TopologySelectorTerm, key string) ([]
 					Key:    key,
 					Values: exp.Values,
 				}
-			} else if exp.Key == key {
-				newExp = exp
 			} else {
-				return nil, fmt.Errorf("unknown topology key: %v", exp.Key)
+				// Other topologies are passed through unchanged.
+				newExp = exp
 			}
 			newTerm.MatchLabelExpressions = append(newTerm.MatchLabelExpressions, newExp)
 		}

--- a/staging/src/k8s.io/csi-translation-lib/plugins/in_tree_volume_test.go
+++ b/staging/src/k8s.io/csi-translation-lib/plugins/in_tree_volume_test.go
@@ -582,7 +582,6 @@ func TestTranslateAllowedTopologies(t *testing.T) {
 		name            string
 		topology        []v1.TopologySelectorTerm
 		expectedToplogy []v1.TopologySelectorTerm
-		expErr          bool
 	}{
 		{
 			name:     "no translation",
@@ -664,18 +663,24 @@ func TestTranslateAllowedTopologies(t *testing.T) {
 					},
 				},
 			},
-			expErr: true,
+			expectedToplogy: []v1.TopologySelectorTerm{
+				{
+					MatchLabelExpressions: []v1.TopologySelectorLabelRequirement{
+						{
+							Key:    "test",
+							Values: []string{"foo", "bar"},
+						},
+					},
+				},
+			},
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Logf("Running test: %v", tc.name)
 		gotTop, err := translateAllowedTopologies(tc.topology, GCEPDTopologyKey)
-		if err != nil && !tc.expErr {
-			t.Errorf("Did not expect an error, got: %v", err)
-		}
-		if err == nil && tc.expErr {
-			t.Errorf("Expected an error but did not get one")
+		if err != nil {
+			t.Errorf("Unexpected error: %w", err)
 		}
 
 		if !reflect.DeepEqual(gotTop, tc.expectedToplogy) {


### PR DESCRIPTION
Ignore unknown labels while doing translation of allowed topologies.

Fixes #103749

/kind bug
```release-note
None
```

/sig storage
/assign @msau42 
/assign @Jiawei0227 