### PR TITLE
exec credential provider: handle wrapped exec errors

### DIFF
--- a/staging/src/k8s.io/client-go/plugin/pkg/client/auth/exec/testdata/not-executable.sh
+++ b/staging/src/k8s.io/client-go/plugin/pkg/client/auth/exec/testdata/not-executable.sh
@@ -1,0 +1,17 @@
+#!/bin/bash -e
+
+# Copyright 2021 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This file is not executable.

--- a/test/integration/client/exec_test.go
+++ b/test/integration/client/exec_test.go
@@ -380,7 +380,7 @@ func execPluginClientTests(t *testing.T, unauthorizedCert, unauthorizedKey []byt
 			clientConfigFunc: func(c *rest.Config) {
 				c.ExecProvider.Command = "does not exist"
 			},
-			wantGetCertificateErrorPrefix: "exec: executable does not exist not found",
+			wantGetCertificateErrorPrefix: "exec: binary does not exist not found",
 			wantClientErrorPrefix:         `Get "https`,
 			wantMetrics:                   &execPluginMetrics{calls: []execPluginCall{{exitCode: 1, callStatus: "plugin_not_found_error"}}},
 		},
@@ -389,7 +389,7 @@ func execPluginClientTests(t *testing.T, unauthorizedCert, unauthorizedKey []byt
 			clientConfigFunc: func(c *rest.Config) {
 				c.ExecProvider.Command = "./testdata/exec-plugin-not-executable.sh"
 			},
-			wantGetCertificateErrorPrefix: "exec: fork/exec ./testdata/exec-plugin-not-executable.sh: permission denied",
+			wantGetCertificateErrorPrefix: "exec: binary ./testdata/exec-plugin-not-executable.sh not executable",
 			wantClientErrorPrefix:         `Get "https`,
 			wantMetrics:                   &execPluginMetrics{calls: []execPluginCall{{exitCode: 1, callStatus: "plugin_not_found_error"}}},
 		},
@@ -403,7 +403,7 @@ func execPluginClientTests(t *testing.T, unauthorizedCert, unauthorizedKey []byt
 					},
 				}
 			},
-			wantGetCertificateErrorPrefix: "exec: executable testdata/exec-plugin.sh failed with exit code 10",
+			wantGetCertificateErrorPrefix: "exec: binary testdata/exec-plugin.sh failed with exit code 10",
 			wantClientErrorPrefix:         `Get "https`,
 			wantMetrics:                   &execPluginMetrics{calls: []execPluginCall{{exitCode: 10, callStatus: "plugin_execution_error"}}},
 		},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

- The updated code now handles cases where running an exec plugin fails with wrapped errors.

#### Which issue(s) this PR fixes:
 
None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

- KEP: https://github.com/kubernetes/enhancements/issues/541