### PR TITLE
remove superfluous [Feature:SCTP] tag in some test names

### DIFF
--- a/test/e2e/network/service.go
+++ b/test/e2e/network/service.go
@@ -3208,7 +3208,7 @@ func restartComponent(cs clientset.Interface, cName, ns string, matchLabels map[
 	return err
 }
 
-var _ = common.SIGDescribe("SCTP [Feature:SCTP] [LinuxOnly]", func() {
+var _ = common.SIGDescribe("SCTP [LinuxOnly]", func() {
 	f := framework.NewDefaultFramework("sctp")
 
 	var cs clientset.Interface


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
This tag was supposed to have gone away when SCTP went GA. (I think it got screwed up due to a PR being mis-rebased after the SCTP GA merge.)

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

/sig network
/priority backlog
cc @aojea 