### PR TITLE
Upgrade to latest COS M85 image.

### DIFF
--- a/cluster/gce/config-default.sh
+++ b/cluster/gce/config-default.sh
@@ -86,7 +86,7 @@ fi
 # you are updating the os image versions, update this variable.
 # Also please update corresponding image for node e2e at:
 # https://github.com/kubernetes/kubernetes/blob/master/test/e2e_node/jenkins/image-config.yaml
-GCI_VERSION=${KUBE_GCI_VERSION:-cos-85-13310-1041-9}
+GCI_VERSION=${KUBE_GCI_VERSION:-cos-85-13310-1308-1}
 export MASTER_IMAGE=${KUBE_GCE_MASTER_IMAGE:-}
 export MASTER_IMAGE_PROJECT=${KUBE_GCE_MASTER_PROJECT:-cos-cloud}
 export NODE_IMAGE=${KUBE_GCE_NODE_IMAGE:-${GCI_VERSION}}

--- a/cluster/gce/config-test.sh
+++ b/cluster/gce/config-test.sh
@@ -99,7 +99,7 @@ ALLOWED_NOTREADY_NODES=${ALLOWED_NOTREADY_NODES:-$(($(get-num-nodes) / 100))}
 # you are updating the os image versions, update this variable.
 # Also please update corresponding image for node e2e at:
 # https://github.com/kubernetes/kubernetes/blob/master/test/e2e_node/jenkins/image-config.yaml
-GCI_VERSION=${KUBE_GCI_VERSION:-cos-85-13310-1041-9}
+GCI_VERSION=${KUBE_GCI_VERSION:-cos-85-13310-1308-1}
 export MASTER_IMAGE=${KUBE_GCE_MASTER_IMAGE:-}
 export MASTER_IMAGE_PROJECT=${KUBE_GCE_MASTER_PROJECT:-cos-cloud}
 export NODE_IMAGE=${KUBE_GCE_NODE_IMAGE:-${GCI_VERSION}}


### PR DESCRIPTION


#### What type of PR is this?

/kind bug

Optionally add one or more of the following kinds if applicable:
/kind failing-test
/kind flake
-->

#### What this PR does / why we need it:

While debugging flakes at #102904, @jdnurme and I have found some associated (minion node) kernel panics that we suspect may be fixed after https://git.kernel.org/pub/scm/linux/kernel/git/cel/linux.git/commit/?id=681370f4b00af0fcc65bbfb9f82de526ab7ceb0a. This newer COS version should include that fix.

FYI, this looks like the same error seen at https://github.com/kubernetes/kubernetes/issues/91236#issuecomment-713619858

```
[  218.880101] LoadPin: kernel-module pinning-excluded obj="/lib/modules/5.4.49+/kernel/net/netfilter/xt_recent.ko" pid=4351 cmdline="/sbin/modprobe -q -- ipt_recent"
[  226.702965] LoadPin: kernel-module pinning-excluded obj="/lib/modules/5.4.49+/kernel/net/sunrpc/sunrpc.ko" pid=5263 cmdline="/sbin/modprobe -q -- fs-nfsd"
[  226.781107] RPC: Registered named UNIX socket transport module.
[  226.787195] RPC: Registered udp transport module.
[  226.792037] RPC: Registered tcp transport module.
[  226.796866] RPC: Registered tcp NFSv4.1 backchannel transport module.
[  226.806706] LoadPin: kernel-module pinning-excluded obj="/lib/modules/5.4.49+/kernel/fs/nfs_common/grace.ko" pid=5263 cmdline="/sbin/modprobe -q -- fs-nfsd"
[  226.824037] LoadPin: kernel-module pinning-excluded obj="/lib/modules/5.4.49+/kernel/fs/lockd/lockd.ko" pid=5263 cmdline="/sbin/modprobe -q -- fs-nfsd"
[  226.851098] LoadPin: kernel-module pinning-excluded obj="/lib/modules/5.4.49+/kernel/fs/nfs_common/nfs_acl.ko" pid=5263 cmdline="/sbin/modprobe -q -- fs-nfsd"
[  226.869955] LoadPin: kernel-module pinning-excluded obj="/lib/modules/5.4.49+/kernel/net/sunrpc/auth_gss/auth_rpcgss.ko" pid=5263 cmdline="/sbin/modprobe -q -- fs-nfsd"
[  226.897648] LoadPin: kernel-module pinning-excluded obj="/lib/modules/5.4.49+/kernel/fs/nfsd/nfsd.ko" pid=5263 cmdline="/sbin/modprobe -q -- fs-nfsd"
[  226.937925] Installing knfsd (copyright (C) 1996 okir@monad.swb.de).
[  228.080658] NFSD: attempt to initialize umh client tracking in a container ignored.
[  228.088562] NFSD: attempt to initialize legacy client tracking in a container ignored.
[  228.096631] NFSD: Unable to initialize client recovery tracking! (-22)
[  228.103290] NFSD: starting 10-second grace period (net f00002ca)
[  234.077308] blk_update_request: I/O error, dev loop0, sector 40832 op 0x9:(WRITE_ZEROES) flags 0x1000800 phys_seg 0 prio class 0
[  234.090173] blk_update_request: I/O error, dev loop0, sector 336 op 0x9:(WRITE_ZEROES) flags 0x1000800 phys_seg 0 prio class 0
[  234.103564] blk_update_request: I/O error, dev loop0, sector 1646 op 0x9:(WRITE_ZEROES) flags 0x1000800 phys_seg 0 prio class 0
[  234.118214] blk_update_request: I/O error, dev loop0, sector 16708 op 0x9:(WRITE_ZEROES) flags 0x1000800 phys_seg 0 prio class 0
[  234.151302] EXT4-fs (loop0): mounted filesystem with ordered data mode. Opts: (null)
[  234.159203] ext4 filesystem being mounted at /var/lib/kubelet/plugins/kubernetes.io/local-volume/mounts/local-tlrx7 supports timestamps until 2038 (0x7fffffff)
[  234.182241] ext4 filesystem being remounted at /var/lib/kubelet/pods/02a07172-958f-4d13-970e-502133aed03e/volumes/kubernetes.io~local-volume/local-tlrx7 supports timestamps until 2038 (0x7fffffff)
[  234.329743] IPv6: ADDRCONF(NETDEV_CHANGE): vethca9e7e8c: link becomes ready
[  234.336950] IPv6: ADDRCONF(NETDEV_CHANGE): eth0: link becomes ready
[  234.763843] ext4 filesystem being remounted at /var/lib/kubelet/pods/02a07172-958f-4d13-970e-502133aed03e/volume-subpaths/local-tlrx7/test-init-subpath-preprovisionedpv-2tc7/0 supports timestamps until 2038 (0x7fffffff)
[  235.771742] ext4 filesystem being remounted at /var/lib/kubelet/pods/02a07172-958f-4d13-970e-502133aed03e/volume-subpaths/local-tlrx7/test-container-subpath-preprovisionedpv-2tc7/0 supports timestamps until 2038 (0x7fffffff)
[  241.357520] IPv6: ADDRCONF(NETDEV_CHANGE): veth1f38c3ce: link becomes ready
[  241.364720] IPv6: ADDRCONF(NETDEV_CHANGE): eth0: link becomes ready
[  241.540497] IPv6: ADDRCONF(NETDEV_CHANGE): eth0: link becomes ready
[  248.334045] nfsd: last server has exited, flushing export cache
[  248.355203] BUG: Dentry 0000000058422478{i=23,n=5}  still in use (1) [unmount of nfsd nfsd]
[  248.363735] ------------[ cut here ]------------
[  248.368472] WARNING: CPU: 0 PID: 7965 at fs/dcache.c:1595 umount_check+0x69/0x70
[  248.375978] Modules linked in: nfsd auth_rpcgss nfs_acl lockd grace sunrpc xt_recent xt_statistic ip_vs_sh veth ip_vs_wrr ip_vs_rr ip_vs xt_mark xt_nat xt_MASQUERADE xt_addrtype iptable_nat nf_nat br_netfilter ip6table_filter ip6_tables aesni_intel glue_helper crypto_simd cryptd loadpin_trigger(O)
[  248.402458] CPU: 0 PID: 7965 Comm: umount Tainted: G           O      5.4.49+ #1
[  248.409960] Hardware name: Google Google Compute Engine/Google Compute Engine, BIOS Google 01/01/2011
[  248.419286] RIP: 0010:umount_check+0x69/0x70
[  248.423678] Code: 96 80 00 00 00 49 8b 42 28 4c 8b 08 49 81 c2 88 04 00 00 48 c7 c7 da d6 f9 b5 48 89 f1 31 c0 41 52 e8 fc 9c e2 ff 48 83 c4 08 <0f> 0b eb b7 00 00 90 0f 1f 44 00 00 55 48 89 e5 41 56 53 bf ff ff
[  248.442566] RSP: 0018:ffffbb0e0215fd80 EFLAGS: 00010292
[  248.447897] RAX: 000000000000004f RBX: ffff99826e10de58 RCX: de3c5ecea6a9c100
[  248.455149] RDX: ffff998358225f38 RSI: ffff9983582161a8 RDI: ffff9983582161a8
[  248.462396] RBP: ffffbb0e0215fd80 R08: 0000000000000000 R09: 0000008138c3f96e
[  248.469635] R10: 00000000000001f3 R11: ffffffffb55e8410 R12: ffff99826e10deb0
[  248.476874] R13: ffff9982e11b49f0 R14: ffff998284769af8 R15: ffff998284769bb0
[  248.484110] FS:  00007f5f0ebe4880(0000) GS:ffff998358200000(0000) knlGS:0000000000000000
[  248.492301] CS:  0010 DS: 0000 ES: 0000 CR0: 0000000080050033
[  248.498161] CR2: 000000000049e2a8 CR3: 000000012a9f4005 CR4: 00000000003606b0
[  248.505400] DR0: 0000000000000000 DR1: 0000000000000000 DR2: 0000000000000000
[  248.512635] DR3: 0000000000000000 DR6: 00000000fffe0ff0 DR7: 0000000000000400
[  248.519884] Call Trace:
[  248.522440]  d_walk+0x15f/0x270
[  248.525684]  ? __d_free+0x20/0x20
[  248.529101]  do_one_tree+0x26/0x70
[  248.532607]  shrink_dcache_for_umount+0x2d/0x80
[  248.537264]  generic_shutdown_super+0x22/0x120
[  248.541809]  kill_litter_super+0x2e/0x40
[  248.545842]  nfsd_umount+0x16/0x30 [nfsd]
[  248.549960]  deactivate_locked_super+0x44/0x90
[  248.554521]  cleanup_mnt+0x11a/0x170
[  248.558202]  task_work_run+0x9f/0xc0
[  248.561889]  exit_to_usermode_loop+0xca/0xe0
[  248.566270]  syscall_return_slowpath+0x7d/0xb0
[  248.570821]  entry_SYSCALL_64_after_hwframe+0x44/0xa9
[  248.575978] RIP: 0033:0x7f5f0de4fa07
[  248.579659] Code: 84 2c 00 f7 d8 64 89 01 48 83 c8 ff c3 66 0f 1f 44 00 00 31 f6 e9 09 00 00 00 66 0f 1f 84 00 00 00 00 00 b8 a6 00 00 00 0f 05 <48> 3d 01 f0 ff ff 73 01 c3 48 8b 0d 39 84 2c 00 f7 d8 64 89 01 48
[  248.598528] RSP: 002b:00007ffdb2be2c18 EFLAGS: 00000246 ORIG_RAX: 00000000000000a6
[  248.606200] RAX: 0000000000000000 RBX: 000055b3ae0b9060 RCX: 00007f5f0de4fa07
[  248.613445] RDX: 0000000000000001 RSI: 0000000000000000 RDI: 000055b3ae0b92b0
[  248.620687] RBP: 000055b3ae0b92b0 R08: 000055b3ae0be410 R09: 0000000000000000
[  248.627933] R10: 00007ffdb2be26a0 R11: 0000000000000246 R12: 00007f5f0e9cdd78
[  248.635173] R13: 0000000000000000 R14: 000055b3ae0b9160 R15: 000055b3ae0b9060
[  248.642415] ---[ end trace ef43c9dd032fe1c3 ]---
```

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
