### PR TITLE
Automated cherry pick of #101047: Only use dualstack if the node and config supports it

### DIFF
--- a/pkg/proxy/winkernel/proxier_test.go
+++ b/pkg/proxy/winkernel/proxier_test.go
@@ -20,6 +20,7 @@ package winkernel
 
 import (
 	"fmt"
+	"github.com/Microsoft/hcsshim/hcn"
 	"k8s.io/api/core/v1"
 	discovery "k8s.io/api/discovery/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -936,4 +937,55 @@ func makeTestEndpoints(namespace, name string, eptFunc func(*v1.Endpoints)) *v1.
 	}
 	eptFunc(ept)
 	return ept
+}
+
+func Test_kernelSupportsDualstack(t *testing.T) {
+	tests := []struct {
+		currentVersion hcn.Version
+		name           string
+		want           bool
+	}{
+		{
+			hcn.Version{Major: 10, Minor: 10},
+			"Less than minimal should not be supported",
+			false,
+		},
+		{
+			hcn.Version{Major: 9, Minor: 11},
+			"Less than minimal should not be supported",
+			false,
+		},
+		{
+			hcn.Version{Major: 11, Minor: 1},
+			"Less than minimal should not be supported",
+			false,
+		},
+		{
+			hcn.Version{Major: 11, Minor: 10},
+			"Current version should be supported",
+			true,
+		},
+		{
+			hcn.Version{Major: 11, Minor: 11},
+			"Greater than minimal version should be supported",
+			true,
+		},
+		{
+			hcn.Version{Major: 12, Minor: 1},
+			"Greater than minimal version should be supported",
+			true,
+		},
+		{
+			hcn.Version{Major: 12, Minor: 12},
+			"Greater than minimal should be supported",
+			true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := kernelSupportsDualstack(tt.currentVersion); got != tt.want {
+				t.Errorf("kernelSupportsDualstack on version %v: got %v, want %v", tt.currentVersion, got, tt.want)
+			}
+		})
+	}
 }


### PR DESCRIPTION
Cherry pick of #101047 on release-1.21.

#101047: Only use dualstack if the node and config supports it

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.