### PR TITLE
[WIP][DO NOT REVIEW] fairness for requests with variable width

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/queueset/types.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/queueset/types.go
@@ -102,6 +102,29 @@ func (q *queue) Dequeue() (*request, bool) {
 	return request, ok
 }
 
+// GetNextFinish returns the expected virtual finish time of the
+// oldest request in the queue with estimated duration G
+func (q *queue) GetNextFinish(G float64) float64 {
+	// TODO: if we decide to generalize this function to return virtual finish time
+	//  for the Nth oldest request waiting in the queue, we need to carefully
+	//  evaluate and potentially improve the performance here.
+	var oldestReq *request
+	q.requests.Walk(func(r *request) bool {
+		oldestReq = r
+		return false
+	})
+	if oldestReq == nil {
+		// we should never be here, since the caller should ensure
+		// that this queue has request(s) waiting to be served before
+		// calling this function.
+		return 0
+	}
+
+	// the estimated service time of the oldest request is (G * request width)
+	estimatedServiceTime := float64(G) * float64(oldestReq.Seats())
+	return q.virtualStart + estimatedServiceTime
+}
+
 func (q *queue) dump(includeDetails bool) debug.QueueDump {
 	digest := make([]debug.RequestDump, q.requests.Length())
 	i := 0


### PR DESCRIPTION

#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
Just a thought experiment on fairness where we have requests with variable width, related to  https://github.com/kubernetes/enhancements/pull/2766/files#r667848342

- queueset estimated service time `G = 1` 
- when we pick a queue we choose the one with lowest number of seats (in use + requested)
- when we pick from a queue for dispatch we select the request with the smallest value of `queue.virtualStart + float64(G) * float64(oldestReq.Seats())`
- when we dequeue a request for dispatch `queue.vritualStart += G * width`
- when a request finishes execution we don't adjust the actual service time `S` with `G`



#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
