### PR TITLE
Remove purell package usage from kubeadm

### DIFF
--- a/cmd/kubeadm/app/preflight/checks.go
+++ b/cmd/kubeadm/app/preflight/checks.go
@@ -51,7 +51,6 @@ import (
 	utilsexec "k8s.io/utils/exec"
 	utilsnet "k8s.io/utils/net"
 
-	"github.com/PuerkitoBio/purell"
 	"github.com/pkg/errors"
 )
 
@@ -714,7 +713,7 @@ func (evc ExternalEtcdVersionCheck) Check() (warnings, errorList []error) {
 		resp := etcdVersionResponse{}
 		var err error
 		versionURL := fmt.Sprintf("%s/%s", endpoint, "version")
-		if tmpVersionURL, err := purell.NormalizeURLString(versionURL, purell.FlagRemoveDuplicateSlashes); err != nil {
+		if tmpVersionURL, err := normalizeURLString(versionURL); err != nil {
 			errorList = append(errorList, errors.Wrapf(err, "failed to normalize external etcd version url %s", versionURL))
 			continue
 		} else {
@@ -1118,4 +1117,17 @@ func setHasItemOrAll(s sets.String, item string) bool {
 		return true
 	}
 	return false
+}
+
+// normalizeURLString returns the normalized string, or an error if it can't be parsed into an URL object.
+// It takes an URL string as input.
+func normalizeURLString(s string) (string, error) {
+	u, err := url.Parse(s)
+	if err != nil {
+		return "", err
+	}
+	if len(u.Path) > 0 {
+		u.Path = strings.ReplaceAll(u.Path, "//", "/")
+	}
+	return u.String(), nil
 }

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,6 @@ require (
 	github.com/JeffAshton/win_pdh v0.0.0-20161109143554-76bb4ee9f0ab
 	github.com/Microsoft/go-winio v0.4.15
 	github.com/Microsoft/hcsshim v0.8.10-0.20200715222032-5eafd1556990
-	github.com/PuerkitoBio/purell v1.1.1
 	github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e
 	github.com/auth0/go-jwt-middleware v1.0.1 // indirect
 	github.com/aws/aws-sdk-go v1.38.49

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -81,7 +81,6 @@ github.com/Microsoft/hcsshim/osversion
 # github.com/NYTimes/gziphandler v1.1.1 => github.com/NYTimes/gziphandler v1.1.1
 github.com/NYTimes/gziphandler
 # github.com/PuerkitoBio/purell v1.1.1 => github.com/PuerkitoBio/purell v1.1.1
-## explicit
 github.com/PuerkitoBio/purell
 # github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 => github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578
 github.com/PuerkitoBio/urlesc


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:

This PR removes the usage of the `purell` module from the kubeadm and introduces the localized function for normalizing the URL.

#### Which issue(s) this PR fixes:
Fixes https://github.com/kubernetes/kubernetes/issues/103068

#### Special notes for your reviewer:
This PR is to move away from the non-maintained module `purell` and create a localized function that does the normalization of the URL string.
Ref: https://github.com/PuerkitoBio/purell/issues/33


#### Does this PR introduce a user-facing change?

```release-note
kubeadm: external etcd endpoints passed in the ClusterConfiguration that have Unicode characters are no longer IDNA encoded (converted to Punycode). They are now just URL encoded as per Go's implementation of RFC-3986, have duplicate "/" removed from the URL paths, and passed like that directly to the kube-apiserver --etcd-servers flag. If you have etcd endpoints that have Unicode characters, it is advisable to encode them in advance with tooling that is fully IDNA compliant. If you don't do that, the Go standard library (used in k8s and etcd) would do it for you when making requests to the endpoints.
```

/cc

/sig cluster-lifecycle
/area kubeadm
/area code-organization
@neolit123