### PR TITLE
Automated cherry pick of #103815: Fix SIG Node SSH e2e test

### DIFF
--- a/test/e2e/framework/ssh/ssh.go
+++ b/test/e2e/framework/ssh/ssh.go
@@ -49,6 +49,9 @@ const (
 	// singleCallTimeout is how long to try single API calls (like 'get' or 'list'). Used to prevent
 	// transient failures from failing tests.
 	singleCallTimeout = 5 * time.Minute
+
+	// sshBastionEnvKey is the environment variable key for running SSH commands via bastion.
+	sshBastionEnvKey = "KUBE_SSH_BASTION"
 )
 
 // GetSigner returns an ssh.Signer for the provider ("gce", etc.) that can be
@@ -160,9 +163,13 @@ func NodeSSHHosts(c clientset.Interface) ([]string, error) {
 
 // canConnect returns true if a network connection is possible to the SSHPort.
 func canConnect(host string) bool {
+	if _, ok := os.LookupEnv(sshBastionEnvKey); ok {
+		return true
+	}
 	hostPort := net.JoinHostPort(host, SSHPort)
 	conn, err := net.DialTimeout("tcp", hostPort, 3*time.Second)
 	if err != nil {
+		e2elog.Logf("cannot dial %s: %v", hostPort, err)
 		return false
 	}
 	conn.Close()
@@ -205,7 +212,7 @@ func SSH(cmd, host, provider string) (Result, error) {
 		result.User = os.Getenv("USER")
 	}
 
-	if bastion := os.Getenv("KUBE_SSH_BASTION"); len(bastion) > 0 {
+	if bastion := os.Getenv(sshBastionEnvKey); len(bastion) > 0 {
 		stdout, stderr, code, err := runSSHCommandViaBastion(cmd, result.User, bastion, host, signer)
 		result.Stdout = stdout
 		result.Stderr = stderr

--- a/test/e2e/node/ssh.go
+++ b/test/e2e/node/ssh.go
@@ -49,6 +49,7 @@ var _ = SIGDescribe("SSH", func() {
 		if err != nil {
 			framework.Failf("Error getting node hostnames: %v", err)
 		}
+		ginkgo.By(fmt.Sprintf("Found %d SSH'able hosts", len(hosts)))
 
 		testCases := []struct {
 			cmd            string
@@ -79,6 +80,8 @@ var _ = SIGDescribe("SSH", func() {
 			ginkgo.By(fmt.Sprintf("SSH'ing to %d nodes and running %s", len(testhosts), testCase.cmd))
 
 			for _, host := range testhosts {
+				ginkgo.By(fmt.Sprintf("SSH'ing host %s", host))
+
 				result, err := e2essh.SSH(testCase.cmd, host, framework.TestContext.Provider)
 				stdout, stderr := strings.TrimSpace(result.Stdout), strings.TrimSpace(result.Stderr)
 				if err != testCase.expectedError {


### PR DESCRIPTION
Cherry pick of #103815 on release-1.22.

#103815: Fix SIG Node SSH e2e test

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.