### PR TITLE
Demote sysctl test from its conformance status

### DIFF
--- a/test/conformance/testdata/conformance.yaml
+++ b/test/conformance/testdata/conformance.yaml
@@ -2181,7 +2181,7 @@
   release: v1.15
   file: test/e2e/common/node/security_context.go
 - testname: Sysctls, reject invalid sysctls
-  codename: '[sig-node] Sysctls [LinuxOnly] [NodeFeature:Sysctls] should reject invalid
+  codename: '[sig-node] Sysctls [LinuxOnly] [NodeConformance] should reject invalid
     sysctls [MinimumKubeletVersion:1.21] [Conformance]'
   description: 'Pod is created with one valid and two invalid sysctls. Pod should
     not apply invalid sysctls. [LinuxOnly]: This test is marked as LinuxOnly since
@@ -2189,19 +2189,11 @@
   release: v1.21
   file: test/e2e/common/node/sysctl.go
 - testname: Sysctl, test sysctls
-  codename: '[sig-node] Sysctls [LinuxOnly] [NodeFeature:Sysctls] should support sysctls
+  codename: '[sig-node] Sysctls [LinuxOnly] [NodeConformance] should support sysctls
     [MinimumKubeletVersion:1.21] [Conformance]'
   description: 'Pod is created with kernel.shm_rmid_forced sysctl. Kernel.shm_rmid_forced
     must be set to 1 [LinuxOnly]: This test is marked as LinuxOnly since Windows does
     not support sysctls'
-  release: v1.21
-  file: test/e2e/common/node/sysctl.go
-- testname: Sysctl, allow specified unsafe sysctls
-  codename: '[sig-node] Sysctls [LinuxOnly] [NodeFeature:Sysctls] should support unsafe
-    sysctls which are actually allowed [MinimumKubeletVersion:1.21] [Conformance]'
-  description: 'Pod is created with kernel.shm_rmid_forced. Should allow unsafe sysctls
-    that are specified. [LinuxOnly]: This test is marked as LinuxOnly since Windows
-    does not support sysctls'
   release: v1.21
   file: test/e2e/common/node/sysctl.go
 - testname: Environment variables, expansion

--- a/test/e2e/common/node/sysctl.go
+++ b/test/e2e/common/node/sysctl.go
@@ -31,7 +31,7 @@ import (
 	"github.com/onsi/gomega"
 )
 
-var _ = SIGDescribe("Sysctls [LinuxOnly] [NodeFeature:Sysctls]", func() {
+var _ = SIGDescribe("Sysctls [LinuxOnly] [NodeConformance]", func() {
 
 	ginkgo.BeforeEach(func() {
 		// sysctl is not supported on Windows.
@@ -118,7 +118,7 @@ var _ = SIGDescribe("Sysctls [LinuxOnly] [NodeFeature:Sysctls]", func() {
 	  Description: Pod is created with kernel.shm_rmid_forced. Should allow unsafe sysctls that are specified.
 	  [LinuxOnly]: This test is marked as LinuxOnly since Windows does not support sysctls
 	*/
-	framework.ConformanceIt("should support unsafe sysctls which are actually allowed [MinimumKubeletVersion:1.21]", func() {
+	ginkgo.It("should support unsafe sysctls which are actually allowed [MinimumKubeletVersion:1.21]", func() {
 		pod := testPod()
 		pod.Spec.SecurityContext = &v1.PodSecurityContext{
 			Sysctls: []v1.Sysctl{


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup
/kind regression

#### What this PR does / why we need it:
This PR demotes test `sysctl` from its conformance status. According to the [conformance definition](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/conformance-tests.md#conformance-test-requirements), there are two requirements not met by this test:
- it tests only GA, non-optional features or APIs (sysctl is an optional feature)
- it works for all providers (doesn't run in Windows or other non-sysctl OS)

#### Which issue(s) this PR fixes:
No issues are addressed directly, but it unblocks https://github.com/kubernetes/kubernetes/pull/103674.

#### Special notes for your reviewer:
This is a followup/partial replacement of https://github.com/kubernetes/kubernetes/pull/101190, which focuses on only the conformance demoting.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
