### PR TITLE
Introduce event clocks based on k8s.io/utils/clock

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/clock/interface.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/clock/interface.go
@@ -1,0 +1,47 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package clock
+
+import (
+	"time"
+
+	baseclock "k8s.io/utils/clock"
+)
+
+// EventFunc does some work that needs to be done at or after the
+// given time.
+type EventFunc func(time.Time)
+
+// EventClock is an active clock abstraction for use in code that is
+// testable with a fake clock that itself determines how time may be
+// advanced.  The timing paradigm is invoking EventFuncs rather than
+// synchronizing through channels, so that the fake clock has a handle
+// on when associated activity is done.
+type EventClock interface {
+	baseclock.PassiveClock
+
+	// Sleep returns after the given duration (or more).
+	Sleep(d time.Duration)
+
+	// EventAfterDuration invokes the given EventFunc after the given duration (or more),
+	// passing the time when the invocation was launched.
+	EventAfterDuration(f EventFunc, d time.Duration)
+
+	// EventAfterTime invokes the given EventFunc at the given time or later,
+	// passing the time when the invocation was launched.
+	EventAfterTime(f EventFunc, t time.Time)
+}

--- a/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/clock/real.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/clock/real.go
@@ -1,0 +1,42 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package clock
+
+import (
+	"time"
+
+	"k8s.io/utils/clock"
+)
+
+// RealEventClock fires event on real world time
+type RealEventClock struct {
+	clock.RealClock
+}
+
+// EventAfterDuration schedules an EventFunc
+func (RealEventClock) EventAfterDuration(f EventFunc, d time.Duration) {
+	ch := time.After(d)
+	go func() {
+		t := <-ch
+		f(t)
+	}()
+}
+
+// EventAfterTime schedules an EventFunc
+func (r RealEventClock) EventAfterTime(f EventFunc, t time.Time) {
+	r.EventAfterDuration(f, time.Until(t))
+}

--- a/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/clock/real_event_clock_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/clock/real_event_clock_test.go
@@ -1,0 +1,68 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package clock
+
+import (
+	"math/rand"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestRealEventClock(t *testing.T) {
+	ec := RealEventClock{}
+	var numDone int32
+	now := ec.Now()
+	const batchSize = 100
+	times := make(chan time.Time, batchSize+1)
+	try := func(abs bool, d time.Duration) {
+		f := func(u time.Time) {
+			realD := ec.Since(now)
+			atomic.AddInt32(&numDone, 1)
+			times <- u
+			if realD < d {
+				t.Errorf("Asked for %v, got %v", d, realD)
+			}
+		}
+		if abs {
+			ec.EventAfterTime(f, now.Add(d))
+		} else {
+			ec.EventAfterDuration(f, d)
+		}
+	}
+	try(true, time.Millisecond*3300)
+	for i := 0; i < batchSize; i++ {
+		d := time.Duration(rand.Intn(30)-3) * time.Millisecond * 100
+		try(i%2 == 0, d)
+	}
+	time.Sleep(time.Second * 4)
+	if atomic.LoadInt32(&numDone) != batchSize+1 {
+		t.Errorf("Got only %v events", numDone)
+	}
+	lastTime := now
+	for i := 0; i <= batchSize; i++ {
+		nextTime := <-times
+		if nextTime.Before(now) {
+			continue
+		}
+		dt := nextTime.Sub(lastTime) / (50 * time.Millisecond)
+		if dt < 0 {
+			t.Errorf("Got %s after %s", nextTime, lastTime)
+		}
+		lastTime = nextTime
+	}
+}

--- a/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/clock/testing/fake_event_clock_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/clock/testing/fake_event_clock_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 The Kubernetes Authors.
+Copyright 2021 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package clock
+package testing
 
 import (
 	"math/rand"
@@ -22,23 +22,17 @@ import (
 	"testing"
 	"time"
 
-	"k8s.io/apimachinery/pkg/util/clock"
+	"k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/clock"
 )
 
 type TestableEventClock interface {
-	EventClock
+	clock.EventClock
 	SetTime(time.Time)
 	Run(*time.Time)
 }
 
-// settablePassiveClock allows setting current time of a passive clock
-type settablePassiveClock interface {
-	clock.PassiveClock
-	SetTime(time.Time)
-}
-
 func exerciseTestableEventClock(t *testing.T, ec TestableEventClock, fuzz time.Duration) {
-	exercisePassiveClock(t, ec)
+	exerciseSettablePassiveClock(t, ec)
 	var numDone int32
 	now := ec.Now()
 	strictable := true
@@ -104,7 +98,8 @@ func exerciseTestableEventClock(t *testing.T, ec TestableEventClock, fuzz time.D
 	}
 }
 
-func exercisePassiveClock(t *testing.T, pc settablePassiveClock) {
+// copied from baseclocktest, because it is not public
+func exerciseSettablePassiveClock(t *testing.T, pc TestableEventClock) {
 	t1 := time.Now()
 	t2 := t1.Add(time.Hour)
 	pc.SetTime(t1)
@@ -133,51 +128,4 @@ func TestFakeEventClock(t *testing.T) {
 	exerciseTestableEventClock(t, fec, 0)
 	fec, _ = NewFakeEventClock(startTime, time.Second, nil)
 	exerciseTestableEventClock(t, fec, time.Second)
-}
-
-func exerciseEventClock(t *testing.T, ec EventClock, relax func(time.Duration)) {
-	var numDone int32
-	now := ec.Now()
-	const batchSize = 100
-	times := make(chan time.Time, batchSize+1)
-	try := func(abs bool, d time.Duration) {
-		f := func(u time.Time) {
-			realD := ec.Since(now)
-			atomic.AddInt32(&numDone, 1)
-			times <- u
-			if realD < d {
-				t.Errorf("Asked for %v, got %v", d, realD)
-			}
-		}
-		if abs {
-			ec.EventAfterTime(f, now.Add(d))
-		} else {
-			ec.EventAfterDuration(f, d)
-		}
-	}
-	try(true, time.Millisecond*3300)
-	for i := 0; i < batchSize; i++ {
-		d := time.Duration(rand.Intn(30)-3) * time.Millisecond * 100
-		try(i%2 == 0, d)
-	}
-	relax(time.Second * 4)
-	if atomic.LoadInt32(&numDone) != batchSize+1 {
-		t.Errorf("Got only %v events", numDone)
-	}
-	lastTime := now
-	for i := 0; i <= batchSize; i++ {
-		nextTime := <-times
-		if nextTime.Before(now) {
-			continue
-		}
-		dt := nextTime.Sub(lastTime) / (50 * time.Millisecond)
-		if dt < 0 {
-			t.Errorf("Got %s after %s", nextTime, lastTime)
-		}
-		lastTime = nextTime
-	}
-}
-
-func TestRealEventClock(t *testing.T) {
-	exerciseEventClock(t, RealEventClock{}, func(d time.Duration) { time.Sleep(d) })
 }

--- a/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/promise/promise_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/promise/promise_test.go
@@ -22,12 +22,12 @@ import (
 	"testing"
 	"time"
 
-	"k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/testing/clock"
+	testclock "k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/clock/testing"
 )
 
 func TestLockingWriteOnce(t *testing.T) {
 	now := time.Now()
-	clock, counter := clock.NewFakeEventClock(now, 0, nil)
+	clock, counter := testclock.NewFakeEventClock(now, 0, nil)
 	var lock sync.Mutex
 	wr := NewWriteOnce(&lock, counter)
 	var gots int32

--- a/vendor/k8s.io/utils/clock/testing/fake_clock.go
+++ b/vendor/k8s.io/utils/clock/testing/fake_clock.go
@@ -1,0 +1,294 @@
+/*
+Copyright 2014 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testing
+
+import (
+	"sync"
+	"time"
+
+	"k8s.io/utils/clock"
+)
+
+var (
+	_ = clock.PassiveClock(&FakePassiveClock{})
+	_ = clock.Clock(&FakeClock{})
+	_ = clock.Clock(&IntervalClock{})
+)
+
+// FakePassiveClock implements PassiveClock, but returns an arbitrary time.
+type FakePassiveClock struct {
+	lock sync.RWMutex
+	time time.Time
+}
+
+// FakeClock implements clock.Clock, but returns an arbitrary time.
+type FakeClock struct {
+	FakePassiveClock
+
+	// waiters are waiting for the fake time to pass their specified time
+	waiters []*fakeClockWaiter
+}
+
+type fakeClockWaiter struct {
+	targetTime    time.Time
+	stepInterval  time.Duration
+	skipIfBlocked bool
+	destChan      chan time.Time
+	fired         bool
+}
+
+// NewFakePassiveClock returns a new FakePassiveClock.
+func NewFakePassiveClock(t time.Time) *FakePassiveClock {
+	return &FakePassiveClock{
+		time: t,
+	}
+}
+
+// NewFakeClock constructs a fake clock set to the provided time.
+func NewFakeClock(t time.Time) *FakeClock {
+	return &FakeClock{
+		FakePassiveClock: *NewFakePassiveClock(t),
+	}
+}
+
+// Now returns f's time.
+func (f *FakePassiveClock) Now() time.Time {
+	f.lock.RLock()
+	defer f.lock.RUnlock()
+	return f.time
+}
+
+// Since returns time since the time in f.
+func (f *FakePassiveClock) Since(ts time.Time) time.Duration {
+	f.lock.RLock()
+	defer f.lock.RUnlock()
+	return f.time.Sub(ts)
+}
+
+// SetTime sets the time on the FakePassiveClock.
+func (f *FakePassiveClock) SetTime(t time.Time) {
+	f.lock.Lock()
+	defer f.lock.Unlock()
+	f.time = t
+}
+
+// After is the fake version of time.After(d).
+func (f *FakeClock) After(d time.Duration) <-chan time.Time {
+	f.lock.Lock()
+	defer f.lock.Unlock()
+	stopTime := f.time.Add(d)
+	ch := make(chan time.Time, 1) // Don't block!
+	f.waiters = append(f.waiters, &fakeClockWaiter{
+		targetTime: stopTime,
+		destChan:   ch,
+	})
+	return ch
+}
+
+// NewTimer constructs a fake timer, akin to time.NewTimer(d).
+func (f *FakeClock) NewTimer(d time.Duration) clock.Timer {
+	f.lock.Lock()
+	defer f.lock.Unlock()
+	stopTime := f.time.Add(d)
+	ch := make(chan time.Time, 1) // Don't block!
+	timer := &fakeTimer{
+		fakeClock: f,
+		waiter: fakeClockWaiter{
+			targetTime: stopTime,
+			destChan:   ch,
+		},
+	}
+	f.waiters = append(f.waiters, &timer.waiter)
+	return timer
+}
+
+// Tick constructs a fake ticker, akin to time.Tick
+func (f *FakeClock) Tick(d time.Duration) <-chan time.Time {
+	if d <= 0 {
+		return nil
+	}
+	f.lock.Lock()
+	defer f.lock.Unlock()
+	tickTime := f.time.Add(d)
+	ch := make(chan time.Time, 1) // hold one tick
+	f.waiters = append(f.waiters, &fakeClockWaiter{
+		targetTime:    tickTime,
+		stepInterval:  d,
+		skipIfBlocked: true,
+		destChan:      ch,
+	})
+
+	return ch
+}
+
+// Step moves the clock by Duration and notifies anyone that's called After,
+// Tick, or NewTimer.
+func (f *FakeClock) Step(d time.Duration) {
+	f.lock.Lock()
+	defer f.lock.Unlock()
+	f.setTimeLocked(f.time.Add(d))
+}
+
+// SetTime sets the time.
+func (f *FakeClock) SetTime(t time.Time) {
+	f.lock.Lock()
+	defer f.lock.Unlock()
+	f.setTimeLocked(t)
+}
+
+// Actually changes the time and checks any waiters. f must be write-locked.
+func (f *FakeClock) setTimeLocked(t time.Time) {
+	f.time = t
+	newWaiters := make([]*fakeClockWaiter, 0, len(f.waiters))
+	for i := range f.waiters {
+		w := f.waiters[i]
+		if !w.targetTime.After(t) {
+
+			if w.skipIfBlocked {
+				select {
+				case w.destChan <- t:
+					w.fired = true
+				default:
+				}
+			} else {
+				w.destChan <- t
+				w.fired = true
+			}
+
+			if w.stepInterval > 0 {
+				for !w.targetTime.After(t) {
+					w.targetTime = w.targetTime.Add(w.stepInterval)
+				}
+				newWaiters = append(newWaiters, w)
+			}
+
+		} else {
+			newWaiters = append(newWaiters, f.waiters[i])
+		}
+	}
+	f.waiters = newWaiters
+}
+
+// HasWaiters returns true if After has been called on f but not yet satisfied (so you can
+// write race-free tests).
+func (f *FakeClock) HasWaiters() bool {
+	f.lock.RLock()
+	defer f.lock.RUnlock()
+	return len(f.waiters) > 0
+}
+
+// Sleep is akin to time.Sleep
+func (f *FakeClock) Sleep(d time.Duration) {
+	f.Step(d)
+}
+
+// IntervalClock implements clock.Clock, but each invocation of Now steps the clock forward the specified duration
+type IntervalClock struct {
+	Time     time.Time
+	Duration time.Duration
+}
+
+// Now returns i's time.
+func (i *IntervalClock) Now() time.Time {
+	i.Time = i.Time.Add(i.Duration)
+	return i.Time
+}
+
+// Since returns time since the time in i.
+func (i *IntervalClock) Since(ts time.Time) time.Duration {
+	return i.Time.Sub(ts)
+}
+
+// After is unimplemented, will panic.
+// TODO: make interval clock use FakeClock so this can be implemented.
+func (*IntervalClock) After(d time.Duration) <-chan time.Time {
+	panic("IntervalClock doesn't implement After")
+}
+
+// NewTimer is unimplemented, will panic.
+// TODO: make interval clock use FakeClock so this can be implemented.
+func (*IntervalClock) NewTimer(d time.Duration) clock.Timer {
+	panic("IntervalClock doesn't implement NewTimer")
+}
+
+// Tick is unimplemented, will panic.
+// TODO: make interval clock use FakeClock so this can be implemented.
+func (*IntervalClock) Tick(d time.Duration) <-chan time.Time {
+	panic("IntervalClock doesn't implement Tick")
+}
+
+// Sleep is unimplemented, will panic.
+func (*IntervalClock) Sleep(d time.Duration) {
+	panic("IntervalClock doesn't implement Sleep")
+}
+
+var _ = clock.Timer(&fakeTimer{})
+
+// fakeTimer implements clock.Timer based on a FakeClock.
+type fakeTimer struct {
+	fakeClock *FakeClock
+	waiter    fakeClockWaiter
+}
+
+// C returns the channel that notifies when this timer has fired.
+func (f *fakeTimer) C() <-chan time.Time {
+	return f.waiter.destChan
+}
+
+// Stop stops the timer and returns true if the timer has not yet fired, or false otherwise.
+func (f *fakeTimer) Stop() bool {
+	f.fakeClock.lock.Lock()
+	defer f.fakeClock.lock.Unlock()
+
+	newWaiters := make([]*fakeClockWaiter, 0, len(f.fakeClock.waiters))
+	for i := range f.fakeClock.waiters {
+		w := f.fakeClock.waiters[i]
+		if w != &f.waiter {
+			newWaiters = append(newWaiters, w)
+		}
+	}
+
+	f.fakeClock.waiters = newWaiters
+
+	return !f.waiter.fired
+}
+
+// Reset resets the timer to the fake clock's "now" + d. It returns true if the timer has not yet
+// fired, or false otherwise.
+func (f *fakeTimer) Reset(d time.Duration) bool {
+	f.fakeClock.lock.Lock()
+	defer f.fakeClock.lock.Unlock()
+
+	active := !f.waiter.fired
+
+	f.waiter.fired = false
+	f.waiter.targetTime = f.fakeClock.time.Add(d)
+
+	var isWaiting bool
+	for i := range f.fakeClock.waiters {
+		w := f.fakeClock.waiters[i]
+		if w == &f.waiter {
+			isWaiting = true
+			break
+		}
+	}
+	if !isWaiting {
+		f.fakeClock.waiters = append(f.fakeClock.waiters, &f.waiter)
+	}
+
+	return active
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -2270,6 +2270,7 @@ k8s.io/system-validators/validators
 ## explicit
 k8s.io/utils/buffer
 k8s.io/utils/clock
+k8s.io/utils/clock/testing
 k8s.io/utils/exec
 k8s.io/utils/exec/testing
 k8s.io/utils/inotify


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind cleanup

#### What this PR does / why we need it:
This PR makes an alternate version of the event clock stuff from `staging/src/k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/testing/clock` that is better in two ways:
1. it is based on k8s.io/utils/clock rather than the apimachinery clock package, and
2. it exports the EventClock interface and implementations.

The latter is helpful so that we can make the queueset implementation take an action after a time (for duration padding).

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
