### PR TITLE
disable aufs module

### DIFF
--- a/cluster/gce/gci/configure-helper.sh
+++ b/cluster/gce/gci/configure-helper.sh
@@ -1489,6 +1489,13 @@ EOF
 	fi
 }
 
+function disable_aufs() {
+  # disable aufs module if aufs is loaded
+  if lsmod | grep "aufs" &> /dev/null ; then 
+    sudo modprobe -r aufs
+  fi
+}
+
 function set_docker_options_non_ubuntu() {
   # set docker options mtu and storage driver for non-ubuntu
   # as it is default for ubuntu
@@ -1547,7 +1554,8 @@ addockeropt "\"pidfile\": \"/var/run/docker.pid\",
   if [[ -n "${DOCKER_REGISTRY_MIRROR_URL:-}" ]]; then
       docker_opts+="--registry-mirror=${DOCKER_REGISTRY_MIRROR_URL} "
   fi
-
+  
+  disable_aufs
   set_docker_options_non_ubuntu
 
   echo "setting docker logging options"


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
This PR is to disable AUFS module which is no longer used by docker. 

AUFSUmountHung kernel error slows down the node and caused timeout for other processes.

We've confirmed that docker is using overlay2 and containerd is using overlay so it is safe to disable AUFS.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes # 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
None

```release-note
disable aufs module for gce clusters
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
