### PR TITLE
[DNM] Add latency using EventClock

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/apf_filter.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/apf_filter.go
@@ -21,10 +21,12 @@ import (
 	"strconv"
 	"time"
 
-	"k8s.io/apimachinery/pkg/util/clock"
+	"k8s.io/utils/clock"
+
 	"k8s.io/apiserver/pkg/server/mux"
 	"k8s.io/apiserver/pkg/util/flowcontrol/counter"
 	fq "k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing"
+	fqclock "k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/clock"
 	fqs "k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/queueset"
 	"k8s.io/apiserver/pkg/util/flowcontrol/metrics"
 	kubeinformers "k8s.io/client-go/informers"
@@ -83,7 +85,7 @@ func New(
 	requestWaitLimit time.Duration,
 ) Interface {
 	grc := counter.NoOp{}
-	clk := clock.RealClock{}
+	clk := fqclock.RealEventClock{}
 	return NewTestable(TestableConfig{
 		Name:                   "Controller",
 		Clock:                  clk,

--- a/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/clock/event_clock_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/clock/event_clock_test.go
@@ -1,0 +1,185 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package clock
+
+import (
+	"math/rand"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"k8s.io/utils/clock"
+)
+
+type TestableEventClock interface {
+	EventClock
+	SetTime(time.Time)
+	Run(*time.Time)
+}
+
+func exerciseTestableEventClock(t *testing.T, ec TestableEventClock, fuzz time.Duration) {
+	exercisePassiveClock(t, ec)
+	var numDone int32
+	now := ec.Now()
+	strictable := true
+	const batchSize = 100
+	times := make(chan time.Time, batchSize+1)
+	try := func(abs, strict bool, d time.Duration) {
+		f := func(u time.Time) {
+			realD := ec.Since(now)
+			atomic.AddInt32(&numDone, 1)
+			times <- u
+			if realD < d || strict && strictable && realD > d+fuzz {
+				t.Errorf("Asked for %v, got %v", d, realD)
+			}
+		}
+		if abs {
+			ec.EventAfterTime(f, now.Add(d))
+		} else {
+			ec.EventAfterDuration(f, d)
+		}
+	}
+	try(true, true, time.Minute)
+	for i := 0; i < batchSize; i++ {
+		d := time.Duration(rand.Intn(30)-3) * time.Second
+		try(i%2 == 0, d >= 0, d)
+	}
+	ec.Run(nil)
+	if numDone != batchSize+1 {
+		t.Errorf("Got only %v events", numDone)
+	}
+	lastTime := now.Add(-3 * time.Second)
+	for i := 0; i <= batchSize; i++ {
+		nextTime := <-times
+		if nextTime.Before(lastTime) {
+			t.Errorf("Got %s after %s", nextTime, lastTime)
+		}
+	}
+	endTime := ec.Now()
+	dx := endTime.Sub(now)
+	if dx > time.Minute+fuzz {
+		t.Errorf("Run started at %#+v, ended at %#+v, dx=%d", now, endTime, dx)
+	}
+	now = endTime
+	var shouldRun int32
+	strictable = false
+	for i := 0; i < batchSize; i++ {
+		d := time.Duration(rand.Intn(30)-3) * time.Second
+		try(i%2 == 0, d >= 0, d)
+		if d <= 12*time.Second {
+			shouldRun++
+		}
+	}
+	ec.SetTime(now.Add(13*time.Second - 1))
+	if numDone != batchSize+1+shouldRun {
+		t.Errorf("Expected %v, but %v ran", shouldRun, numDone-batchSize-1)
+	}
+	lastTime = now.Add(-3 * time.Second)
+	for i := int32(0); i < shouldRun; i++ {
+		nextTime := <-times
+		if nextTime.Before(lastTime) {
+			t.Errorf("Got %s after %s", nextTime, lastTime)
+		}
+		lastTime = nextTime
+	}
+}
+
+// copied from baseclocktest, because apparently
+// test files can not define public symbols.
+type SettablePassiveClock interface {
+	clock.PassiveClock
+	SetTime(time.Time)
+}
+
+// copied from baseclocktest, because it is not public
+func exercisePassiveClock(t *testing.T, pc SettablePassiveClock) {
+	t1 := time.Now()
+	t2 := t1.Add(time.Hour)
+	pc.SetTime(t1)
+	tx := pc.Now()
+	if tx != t1 {
+		t.Errorf("SetTime(%#+v); Now() => %#+v", t1, tx)
+	}
+	dx := pc.Since(t1)
+	if dx != 0 {
+		t.Errorf("Since() => %v", dx)
+	}
+	pc.SetTime(t2)
+	dx = pc.Since(t1)
+	if dx != time.Hour {
+		t.Errorf("Since() => %v", dx)
+	}
+	tx = pc.Now()
+	if tx != t2 {
+		t.Errorf("Now() => %#+v", tx)
+	}
+}
+
+func TestFakeEventClock(t *testing.T) {
+	startTime := time.Now()
+	fec, _ := NewFakeEventClock(startTime, 0, nil)
+	exerciseTestableEventClock(t, fec, 0)
+	fec, _ = NewFakeEventClock(startTime, time.Second, nil)
+	exerciseTestableEventClock(t, fec, time.Second)
+}
+
+func exerciseEventClock(t *testing.T, ec EventClock, relax func(time.Duration)) {
+	var numDone int32
+	now := ec.Now()
+	const batchSize = 100
+	times := make(chan time.Time, batchSize+1)
+	try := func(abs bool, d time.Duration) {
+		f := func(u time.Time) {
+			realD := ec.Since(now)
+			atomic.AddInt32(&numDone, 1)
+			times <- u
+			if realD < d {
+				t.Errorf("Asked for %v, got %v", d, realD)
+			}
+		}
+		if abs {
+			ec.EventAfterTime(f, now.Add(d))
+		} else {
+			ec.EventAfterDuration(f, d)
+		}
+	}
+	try(true, time.Millisecond*3300)
+	for i := 0; i < batchSize; i++ {
+		d := time.Duration(rand.Intn(30)-3) * time.Millisecond * 100
+		try(i%2 == 0, d)
+	}
+	relax(time.Second * 4)
+	if atomic.LoadInt32(&numDone) != batchSize+1 {
+		t.Errorf("Got only %v events", numDone)
+	}
+	lastTime := now
+	for i := 0; i <= batchSize; i++ {
+		nextTime := <-times
+		if nextTime.Before(now) {
+			continue
+		}
+		dt := nextTime.Sub(lastTime) / (50 * time.Millisecond)
+		if dt < 0 {
+			t.Errorf("Got %s after %s", nextTime, lastTime)
+		}
+		lastTime = nextTime
+	}
+}
+
+func TestRealEventClock(t *testing.T) {
+	exerciseEventClock(t, RealEventClock{}, func(d time.Duration) { time.Sleep(d) })
+}

--- a/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/clock/fake.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/clock/fake.go
@@ -1,0 +1,211 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package clock
+
+import (
+	"container/heap"
+	"math/rand"
+	"runtime"
+	"strings"
+	"sync"
+	"time"
+
+	"k8s.io/apiserver/pkg/util/flowcontrol/counter"
+	"k8s.io/klog/v2"
+	baseclocktest "k8s.io/utils/clock/testing"
+)
+
+// waitGroupCounter is a wait group used for a GoRoutine Counter.  This private
+// type is used to disallow direct waitGroup access
+type waitGroupCounter struct {
+	wg sync.WaitGroup
+}
+
+// compile time assertion that waitGroupCounter meets requirements
+//  of GoRoutineCounter
+var _ counter.GoRoutineCounter = (*waitGroupCounter)(nil)
+
+func (wgc *waitGroupCounter) Add(delta int) {
+	if klog.V(7).Enabled() {
+		var pcs [5]uintptr
+		nCallers := runtime.Callers(2, pcs[:])
+		frames := runtime.CallersFrames(pcs[:nCallers])
+		frame1, more1 := frames.Next()
+		fileParts1 := strings.Split(frame1.File, "/")
+		tail2 := "(none)"
+		line2 := 0
+		if more1 {
+			frame2, _ := frames.Next()
+			fileParts2 := strings.Split(frame2.File, "/")
+			tail2 = fileParts2[len(fileParts2)-1]
+			line2 = frame2.Line
+		}
+		klog.Infof("GRC(%p).Add(%d) from %s:%d from %s:%d", wgc, delta, fileParts1[len(fileParts1)-1], frame1.Line, tail2, line2)
+	}
+	wgc.wg.Add(delta)
+}
+
+func (wgc *waitGroupCounter) Wait() {
+	wgc.wg.Wait()
+}
+
+// FakeEventClock is one whose time does not pass implicitly but
+// rather is explicitly set by invocations of its SetTime method
+type FakeEventClock struct {
+	baseclocktest.FakePassiveClock
+
+	// waiters is a heap of waiting work, sorted by time
+	waiters     eventWaiterHeap
+	waitersLock sync.RWMutex
+
+	// clientWG may be nil and if not supplies constraints on time
+	// passing in Run.  The Run method will not pick a new time until
+	// this is nil or its counter is zero.
+	clientWG *waitGroupCounter
+
+	// fuzz is the amount of noise to add to scheduling.  An event
+	// requested to run at time T will run at some time chosen
+	// uniformly at random from the interval [T, T+fuzz]; the upper
+	// bound is exclusive iff fuzz is non-zero.
+	fuzz time.Duration
+
+	// rand is the random number generator to use in fuzzing
+	rand *rand.Rand
+}
+
+type eventWaiterHeap []eventWaiter
+
+var _ heap.Interface = (*eventWaiterHeap)(nil)
+
+type eventWaiter struct {
+	targetTime time.Time
+	f          EventFunc
+}
+
+// NewFakeEventClock constructor.  The given `r *rand.Rand` must
+// henceforth not be used for any other purpose.  If `r` is nil then a
+// fresh one will be constructed, seeded with the current real time.
+// The clientWG can be `nil` and if not is used to let Run know about
+// additional work that has to complete before time can advance.
+func NewFakeEventClock(t time.Time, fuzz time.Duration, r *rand.Rand) (*FakeEventClock, counter.GoRoutineCounter) {
+	grc := &waitGroupCounter{}
+
+	if r == nil {
+		r = rand.New(rand.NewSource(time.Now().UnixNano()))
+		r.Uint64()
+		r.Uint64()
+		r.Uint64()
+	}
+	return &FakeEventClock{
+		FakePassiveClock: *baseclocktest.NewFakePassiveClock(t),
+		clientWG:         grc,
+		fuzz:             fuzz,
+		rand:             r,
+	}, grc
+}
+
+// GetNextTime returns the next time at which there is work scheduled,
+// and a bool indicating whether there is any such time
+func (fec *FakeEventClock) GetNextTime() (time.Time, bool) {
+	fec.waitersLock.RLock()
+	defer fec.waitersLock.RUnlock()
+	if len(fec.waiters) > 0 {
+		return fec.waiters[0].targetTime, true
+	}
+	return time.Time{}, false
+}
+
+// Run runs all the events scheduled, and all the events they
+// schedule, and so on, until there are none scheduled or the limit is not
+// nil and the next time would exceed the limit.  The clientWG given in
+// the constructor gates each advance of time.
+func (fec *FakeEventClock) Run(limit *time.Time) {
+	for {
+		fec.clientWG.Wait()
+		t, ok := fec.GetNextTime()
+		if !ok || limit != nil && t.After(*limit) {
+			break
+		}
+		fec.SetTime(t)
+	}
+}
+
+// SetTime sets the time and runs to completion all events that should
+// be started by the given time --- including any further events they
+// schedule
+func (fec *FakeEventClock) SetTime(t time.Time) {
+	fec.FakePassiveClock.SetTime(t)
+	for {
+		foundSome := false
+		func() {
+			fec.waitersLock.Lock()
+			defer fec.waitersLock.Unlock()
+			// This loop is because events run at a given time may schedule more
+			// events to run at that or an earlier time.
+			// Events should not advance the clock.  But just in case they do...
+			now := fec.Now()
+			var wg sync.WaitGroup
+			for len(fec.waiters) > 0 && !now.Before(fec.waiters[0].targetTime) {
+				ew := heap.Pop(&fec.waiters).(eventWaiter)
+				wg.Add(1)
+				go func(f EventFunc) { f(now); wg.Done() }(ew.f)
+				foundSome = true
+			}
+			wg.Wait()
+		}()
+		if !foundSome {
+			break
+		}
+	}
+}
+
+// EventAfterDuration schedules the given function to be invoked once
+// the given duration has passed.
+func (fec *FakeEventClock) EventAfterDuration(f EventFunc, d time.Duration) {
+	fec.waitersLock.Lock()
+	defer fec.waitersLock.Unlock()
+	now := fec.Now()
+	fd := time.Duration(float32(fec.fuzz) * fec.rand.Float32())
+	heap.Push(&fec.waiters, eventWaiter{targetTime: now.Add(d + fd), f: f})
+}
+
+// EventAfterTime schedules the given function to be invoked once
+// the given time has arrived.
+func (fec *FakeEventClock) EventAfterTime(f EventFunc, t time.Time) {
+	fec.waitersLock.Lock()
+	defer fec.waitersLock.Unlock()
+	fd := time.Duration(float32(fec.fuzz) * fec.rand.Float32())
+	heap.Push(&fec.waiters, eventWaiter{targetTime: t.Add(fd), f: f})
+}
+
+func (ewh eventWaiterHeap) Len() int { return len(ewh) }
+
+func (ewh eventWaiterHeap) Less(i, j int) bool { return ewh[i].targetTime.Before(ewh[j].targetTime) }
+
+func (ewh eventWaiterHeap) Swap(i, j int) { ewh[i], ewh[j] = ewh[j], ewh[i] }
+
+func (ewh *eventWaiterHeap) Push(x interface{}) {
+	*ewh = append(*ewh, x.(eventWaiter))
+}
+
+func (ewh *eventWaiterHeap) Pop() interface{} {
+	old := *ewh
+	n := len(old)
+	x := old[n-1]
+	*ewh = old[:n-1]
+	return x
+}

--- a/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/clock/interface.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/clock/interface.go
@@ -1,0 +1,36 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package clock
+
+import (
+	"time"
+
+	baseclock "k8s.io/utils/clock"
+)
+
+// EventFunc does some work that needs to be done at or after the
+// given time. After this function returns, associated work may continue
+//  on other goroutines only if they are counted by the GoRoutineCounter
+// of the FakeEventClock handling this EventFunc.
+type EventFunc func(time.Time)
+
+// EventClock fires event on time
+type EventClock interface {
+	baseclock.PassiveClock
+	EventAfterDuration(f EventFunc, d time.Duration)
+	EventAfterTime(f EventFunc, t time.Time)
+}

--- a/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/clock/real.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/clock/real.go
@@ -1,0 +1,48 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package clock
+
+import (
+	"time"
+
+	"k8s.io/utils/clock"
+)
+
+// RealEventClock fires event on real world time
+type RealEventClock struct {
+	clock.RealClock
+}
+
+// EventAfterDuration schedules an EventFunc
+func (RealEventClock) EventAfterDuration(f EventFunc, d time.Duration) {
+	ch := time.After(d)
+	go func() {
+		t := <-ch
+		f(t)
+	}()
+}
+
+// EventAfterTime schedules an EventFunc
+func (r RealEventClock) EventAfterTime(f EventFunc, t time.Time) {
+	now := time.Now()
+	d := t.Sub(now)
+	if d <= 0 {
+		go f(now)
+	} else {
+		r.EventAfterDuration(f, d)
+	}
+}

--- a/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/queueset/queueset.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/queueset/queueset.go
@@ -23,7 +23,8 @@ import (
 	"sync"
 	"time"
 
-	"k8s.io/apimachinery/pkg/util/clock"
+	"k8s.io/utils/clock"
+
 	"k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apiserver/pkg/util/flowcontrol/counter"
 	"k8s.io/apiserver/pkg/util/flowcontrol/debug"

--- a/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/queueset/queueset.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/queueset/queueset.go
@@ -34,6 +34,12 @@ import (
 	fqrequest "k8s.io/apiserver/pkg/util/flowcontrol/request"
 	"k8s.io/apiserver/pkg/util/shufflesharding"
 	"k8s.io/klog/v2"
+
+	// The following hack is needed to work around a tooling deficiency.
+	// Packages imported only for test code are not included in vendor.
+	// See https://kubernetes.slack.com/archives/C0EG7JC6T/p1626985671458800?thread_ts=1626983387.450800&cid=C0EG7JC6T
+	// The need for this hack will be removed when we make queueset use an EventClock rather than a PassiveClock.
+	_ "k8s.io/utils/clock/testing"
 )
 
 const nsTimeFmt = "2006-01-02 15:04:05.000000000"

--- a/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/queueset/queueset_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/queueset/queueset_test.go
@@ -27,11 +27,12 @@ import (
 	"testing"
 	"time"
 
-	"k8s.io/apimachinery/pkg/util/clock"
+	"k8s.io/utils/clock"
+
 	"k8s.io/apiserver/pkg/util/flowcontrol/counter"
 	fq "k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing"
+	testclock "k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/clock"
 	test "k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/testing"
-	testclock "k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/testing/clock"
 	"k8s.io/apiserver/pkg/util/flowcontrol/metrics"
 	fcrequest "k8s.io/apiserver/pkg/util/flowcontrol/request"
 	"k8s.io/klog/v2"

--- a/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/queueset/queueset_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/queueset/queueset_test.go
@@ -31,7 +31,7 @@ import (
 
 	"k8s.io/apiserver/pkg/util/flowcontrol/counter"
 	fq "k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing"
-	testclock "k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/clock"
+	fqclock "k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/clock"
 	test "k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/testing"
 	"k8s.io/apiserver/pkg/util/flowcontrol/metrics"
 	fcrequest "k8s.io/apiserver/pkg/util/flowcontrol/request"
@@ -133,7 +133,7 @@ type uniformScenario struct {
 	expectAllRequests                        bool
 	evalInqueueMetrics, evalExecutingMetrics bool
 	rejectReason                             string
-	clk                                      *testclock.FakeEventClock
+	clk                                      *fqclock.FakeEventClock
 	counter                                  counter.GoRoutineCounter
 }
 
@@ -359,7 +359,7 @@ func (uss *uniformScenarioState) finalReview() {
 	}
 }
 
-func ClockWait(clk *testclock.FakeEventClock, counter counter.GoRoutineCounter, duration time.Duration) {
+func ClockWait(clk *fqclock.FakeEventClock, counter counter.GoRoutineCounter, duration time.Duration) {
 	dunch := make(chan struct{})
 	clk.EventAfterDuration(func(time.Time) {
 		counter.Add(1)
@@ -377,7 +377,7 @@ func init() {
 func TestNoRestraint(t *testing.T) {
 	metrics.Register()
 	now := time.Now()
-	clk, counter := testclock.NewFakeEventClock(now, 0, nil)
+	clk, counter := fqclock.NewFakeEventClock(now, 0, nil)
 	nrc, err := test.NewNoRestraintFactory().BeginConstruction(fq.QueuingConfig{}, newObserverPair(clk))
 	if err != nil {
 		t.Fatal(err)
@@ -403,7 +403,7 @@ func TestUniformFlowsHandSize1(t *testing.T) {
 	metrics.Register()
 	now := time.Now()
 
-	clk, counter := testclock.NewFakeEventClock(now, 0, nil)
+	clk, counter := fqclock.NewFakeEventClock(now, 0, nil)
 	qsf := NewQueueSetFactory(clk, counter)
 	qCfg := fq.QueuingConfig{
 		Name:             "TestUniformFlowsHandSize1",
@@ -440,7 +440,7 @@ func TestUniformFlowsHandSize3(t *testing.T) {
 	metrics.Register()
 	now := time.Now()
 
-	clk, counter := testclock.NewFakeEventClock(now, 0, nil)
+	clk, counter := fqclock.NewFakeEventClock(now, 0, nil)
 	qsf := NewQueueSetFactory(clk, counter)
 	qCfg := fq.QueuingConfig{
 		Name:             "TestUniformFlowsHandSize3",
@@ -476,7 +476,7 @@ func TestDifferentFlowsExpectEqual(t *testing.T) {
 	metrics.Register()
 	now := time.Now()
 
-	clk, counter := testclock.NewFakeEventClock(now, 0, nil)
+	clk, counter := fqclock.NewFakeEventClock(now, 0, nil)
 	qsf := NewQueueSetFactory(clk, counter)
 	qCfg := fq.QueuingConfig{
 		Name:             "DiffFlowsExpectEqual",
@@ -513,7 +513,7 @@ func TestDifferentFlowsExpectUnequal(t *testing.T) {
 	metrics.Register()
 	now := time.Now()
 
-	clk, counter := testclock.NewFakeEventClock(now, 0, nil)
+	clk, counter := fqclock.NewFakeEventClock(now, 0, nil)
 	qsf := NewQueueSetFactory(clk, counter)
 	qCfg := fq.QueuingConfig{
 		Name:             "DiffFlowsExpectUnequal",
@@ -550,7 +550,7 @@ func TestWindup(t *testing.T) {
 	metrics.Register()
 	now := time.Now()
 
-	clk, counter := testclock.NewFakeEventClock(now, 0, nil)
+	clk, counter := fqclock.NewFakeEventClock(now, 0, nil)
 	qsf := NewQueueSetFactory(clk, counter)
 	qCfg := fq.QueuingConfig{
 		Name:             "TestWindup",
@@ -586,7 +586,7 @@ func TestDifferentFlowsWithoutQueuing(t *testing.T) {
 	metrics.Register()
 	now := time.Now()
 
-	clk, counter := testclock.NewFakeEventClock(now, 0, nil)
+	clk, counter := fqclock.NewFakeEventClock(now, 0, nil)
 	qsf := NewQueueSetFactory(clk, counter)
 	qCfg := fq.QueuingConfig{
 		Name:             "TestDifferentFlowsWithoutQueuing",
@@ -619,7 +619,7 @@ func TestTimeout(t *testing.T) {
 	metrics.Register()
 	now := time.Now()
 
-	clk, counter := testclock.NewFakeEventClock(now, 0, nil)
+	clk, counter := fqclock.NewFakeEventClock(now, 0, nil)
 	qsf := NewQueueSetFactory(clk, counter)
 	qCfg := fq.QueuingConfig{
 		Name:             "TestTimeout",
@@ -655,7 +655,7 @@ func TestContextCancel(t *testing.T) {
 	metrics.Register()
 	metrics.Reset()
 	now := time.Now()
-	clk, counter := testclock.NewFakeEventClock(now, 0, nil)
+	clk, counter := fqclock.NewFakeEventClock(now, 0, nil)
 	qsf := NewQueueSetFactory(clk, counter)
 	qCfg := fq.QueuingConfig{
 		Name:             "TestContextCancel",
@@ -734,7 +734,7 @@ func TestTotalRequestsExecutingWithPanic(t *testing.T) {
 	metrics.Register()
 	metrics.Reset()
 	now := time.Now()
-	clk, counter := testclock.NewFakeEventClock(now, 0, nil)
+	clk, counter := fqclock.NewFakeEventClock(now, 0, nil)
 	qsf := NewQueueSetFactory(clk, counter)
 	qCfg := fq.QueuingConfig{
 		Name:             "TestTotalRequestsExecutingWithPanic",

--- a/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/request/width.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/request/width.go
@@ -18,11 +18,18 @@ package request
 
 import (
 	"net/http"
+	"time"
 )
 
 type Width struct {
 	// Seats represents the number of seats associated with this request
 	Seats uint
+
+	// AdditionalLatency specifies the additional duration the seats allocated
+	// to this request must be reserved after the given request had finished.
+	// AdditionalLatency should not have any impact on the user experience, the
+	// caller must not experience this additional latency.
+	AdditionalLatency time.Duration
 }
 
 // DefaultWidthEstimator returns returns '1' as the "width"

--- a/vendor/k8s.io/utils/clock/testing/fake_clock.go
+++ b/vendor/k8s.io/utils/clock/testing/fake_clock.go
@@ -1,0 +1,294 @@
+/*
+Copyright 2014 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testing
+
+import (
+	"sync"
+	"time"
+
+	"k8s.io/utils/clock"
+)
+
+var (
+	_ = clock.PassiveClock(&FakePassiveClock{})
+	_ = clock.Clock(&FakeClock{})
+	_ = clock.Clock(&IntervalClock{})
+)
+
+// FakePassiveClock implements PassiveClock, but returns an arbitrary time.
+type FakePassiveClock struct {
+	lock sync.RWMutex
+	time time.Time
+}
+
+// FakeClock implements clock.Clock, but returns an arbitrary time.
+type FakeClock struct {
+	FakePassiveClock
+
+	// waiters are waiting for the fake time to pass their specified time
+	waiters []*fakeClockWaiter
+}
+
+type fakeClockWaiter struct {
+	targetTime    time.Time
+	stepInterval  time.Duration
+	skipIfBlocked bool
+	destChan      chan time.Time
+	fired         bool
+}
+
+// NewFakePassiveClock returns a new FakePassiveClock.
+func NewFakePassiveClock(t time.Time) *FakePassiveClock {
+	return &FakePassiveClock{
+		time: t,
+	}
+}
+
+// NewFakeClock constructs a fake clock set to the provided time.
+func NewFakeClock(t time.Time) *FakeClock {
+	return &FakeClock{
+		FakePassiveClock: *NewFakePassiveClock(t),
+	}
+}
+
+// Now returns f's time.
+func (f *FakePassiveClock) Now() time.Time {
+	f.lock.RLock()
+	defer f.lock.RUnlock()
+	return f.time
+}
+
+// Since returns time since the time in f.
+func (f *FakePassiveClock) Since(ts time.Time) time.Duration {
+	f.lock.RLock()
+	defer f.lock.RUnlock()
+	return f.time.Sub(ts)
+}
+
+// SetTime sets the time on the FakePassiveClock.
+func (f *FakePassiveClock) SetTime(t time.Time) {
+	f.lock.Lock()
+	defer f.lock.Unlock()
+	f.time = t
+}
+
+// After is the fake version of time.After(d).
+func (f *FakeClock) After(d time.Duration) <-chan time.Time {
+	f.lock.Lock()
+	defer f.lock.Unlock()
+	stopTime := f.time.Add(d)
+	ch := make(chan time.Time, 1) // Don't block!
+	f.waiters = append(f.waiters, &fakeClockWaiter{
+		targetTime: stopTime,
+		destChan:   ch,
+	})
+	return ch
+}
+
+// NewTimer constructs a fake timer, akin to time.NewTimer(d).
+func (f *FakeClock) NewTimer(d time.Duration) clock.Timer {
+	f.lock.Lock()
+	defer f.lock.Unlock()
+	stopTime := f.time.Add(d)
+	ch := make(chan time.Time, 1) // Don't block!
+	timer := &fakeTimer{
+		fakeClock: f,
+		waiter: fakeClockWaiter{
+			targetTime: stopTime,
+			destChan:   ch,
+		},
+	}
+	f.waiters = append(f.waiters, &timer.waiter)
+	return timer
+}
+
+// Tick constructs a fake ticker, akin to time.Tick
+func (f *FakeClock) Tick(d time.Duration) <-chan time.Time {
+	if d <= 0 {
+		return nil
+	}
+	f.lock.Lock()
+	defer f.lock.Unlock()
+	tickTime := f.time.Add(d)
+	ch := make(chan time.Time, 1) // hold one tick
+	f.waiters = append(f.waiters, &fakeClockWaiter{
+		targetTime:    tickTime,
+		stepInterval:  d,
+		skipIfBlocked: true,
+		destChan:      ch,
+	})
+
+	return ch
+}
+
+// Step moves the clock by Duration and notifies anyone that's called After,
+// Tick, or NewTimer.
+func (f *FakeClock) Step(d time.Duration) {
+	f.lock.Lock()
+	defer f.lock.Unlock()
+	f.setTimeLocked(f.time.Add(d))
+}
+
+// SetTime sets the time.
+func (f *FakeClock) SetTime(t time.Time) {
+	f.lock.Lock()
+	defer f.lock.Unlock()
+	f.setTimeLocked(t)
+}
+
+// Actually changes the time and checks any waiters. f must be write-locked.
+func (f *FakeClock) setTimeLocked(t time.Time) {
+	f.time = t
+	newWaiters := make([]*fakeClockWaiter, 0, len(f.waiters))
+	for i := range f.waiters {
+		w := f.waiters[i]
+		if !w.targetTime.After(t) {
+
+			if w.skipIfBlocked {
+				select {
+				case w.destChan <- t:
+					w.fired = true
+				default:
+				}
+			} else {
+				w.destChan <- t
+				w.fired = true
+			}
+
+			if w.stepInterval > 0 {
+				for !w.targetTime.After(t) {
+					w.targetTime = w.targetTime.Add(w.stepInterval)
+				}
+				newWaiters = append(newWaiters, w)
+			}
+
+		} else {
+			newWaiters = append(newWaiters, f.waiters[i])
+		}
+	}
+	f.waiters = newWaiters
+}
+
+// HasWaiters returns true if After has been called on f but not yet satisfied (so you can
+// write race-free tests).
+func (f *FakeClock) HasWaiters() bool {
+	f.lock.RLock()
+	defer f.lock.RUnlock()
+	return len(f.waiters) > 0
+}
+
+// Sleep is akin to time.Sleep
+func (f *FakeClock) Sleep(d time.Duration) {
+	f.Step(d)
+}
+
+// IntervalClock implements clock.Clock, but each invocation of Now steps the clock forward the specified duration
+type IntervalClock struct {
+	Time     time.Time
+	Duration time.Duration
+}
+
+// Now returns i's time.
+func (i *IntervalClock) Now() time.Time {
+	i.Time = i.Time.Add(i.Duration)
+	return i.Time
+}
+
+// Since returns time since the time in i.
+func (i *IntervalClock) Since(ts time.Time) time.Duration {
+	return i.Time.Sub(ts)
+}
+
+// After is unimplemented, will panic.
+// TODO: make interval clock use FakeClock so this can be implemented.
+func (*IntervalClock) After(d time.Duration) <-chan time.Time {
+	panic("IntervalClock doesn't implement After")
+}
+
+// NewTimer is unimplemented, will panic.
+// TODO: make interval clock use FakeClock so this can be implemented.
+func (*IntervalClock) NewTimer(d time.Duration) clock.Timer {
+	panic("IntervalClock doesn't implement NewTimer")
+}
+
+// Tick is unimplemented, will panic.
+// TODO: make interval clock use FakeClock so this can be implemented.
+func (*IntervalClock) Tick(d time.Duration) <-chan time.Time {
+	panic("IntervalClock doesn't implement Tick")
+}
+
+// Sleep is unimplemented, will panic.
+func (*IntervalClock) Sleep(d time.Duration) {
+	panic("IntervalClock doesn't implement Sleep")
+}
+
+var _ = clock.Timer(&fakeTimer{})
+
+// fakeTimer implements clock.Timer based on a FakeClock.
+type fakeTimer struct {
+	fakeClock *FakeClock
+	waiter    fakeClockWaiter
+}
+
+// C returns the channel that notifies when this timer has fired.
+func (f *fakeTimer) C() <-chan time.Time {
+	return f.waiter.destChan
+}
+
+// Stop stops the timer and returns true if the timer has not yet fired, or false otherwise.
+func (f *fakeTimer) Stop() bool {
+	f.fakeClock.lock.Lock()
+	defer f.fakeClock.lock.Unlock()
+
+	newWaiters := make([]*fakeClockWaiter, 0, len(f.fakeClock.waiters))
+	for i := range f.fakeClock.waiters {
+		w := f.fakeClock.waiters[i]
+		if w != &f.waiter {
+			newWaiters = append(newWaiters, w)
+		}
+	}
+
+	f.fakeClock.waiters = newWaiters
+
+	return !f.waiter.fired
+}
+
+// Reset resets the timer to the fake clock's "now" + d. It returns true if the timer has not yet
+// fired, or false otherwise.
+func (f *fakeTimer) Reset(d time.Duration) bool {
+	f.fakeClock.lock.Lock()
+	defer f.fakeClock.lock.Unlock()
+
+	active := !f.waiter.fired
+
+	f.waiter.fired = false
+	f.waiter.targetTime = f.fakeClock.time.Add(d)
+
+	var isWaiting bool
+	for i := range f.fakeClock.waiters {
+		w := f.fakeClock.waiters[i]
+		if w == &f.waiter {
+			isWaiting = true
+			break
+		}
+	}
+	if !isWaiting {
+		f.fakeClock.waiters = append(f.fakeClock.waiters, &f.waiter)
+	}
+
+	return active
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -2271,6 +2271,7 @@ k8s.io/system-validators/validators
 ## explicit
 k8s.io/utils/buffer
 k8s.io/utils/clock
+k8s.io/utils/clock/testing
 k8s.io/utils/exec
 k8s.io/utils/exec/testing
 k8s.io/utils/inotify


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind feature

#### What this PR does / why we need it:
This is an alternate version of #103240 that uses EventClock (introduced in #103830) so that queueset remains testable with a fake clock.  The penultimate commit here is a copy of the only commit in #103240 .  The final commit is the switch to the new clock.  The earlier commits are #103830 (which I have to copy her now because that has not merged yet).

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:
This is not a real PR, just a demo of how to use the new clock code.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
NONE
```
