### PR TITLE
Introduce event clocks based on k8s.io/utils/clock, 2nd attempt

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/clock/event_clock_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/clock/event_clock_test.go
@@ -1,0 +1,185 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package clock
+
+import (
+	"math/rand"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"k8s.io/utils/clock"
+)
+
+type TestableEventClock interface {
+	EventClock
+	SetTime(time.Time)
+	Run(*time.Time)
+}
+
+func exerciseTestableEventClock(t *testing.T, ec TestableEventClock, fuzz time.Duration) {
+	exercisePassiveClock(t, ec)
+	var numDone int32
+	now := ec.Now()
+	strictable := true
+	const batchSize = 100
+	times := make(chan time.Time, batchSize+1)
+	try := func(abs, strict bool, d time.Duration) {
+		f := func(u time.Time) {
+			realD := ec.Since(now)
+			atomic.AddInt32(&numDone, 1)
+			times <- u
+			if realD < d || strict && strictable && realD > d+fuzz {
+				t.Errorf("Asked for %v, got %v", d, realD)
+			}
+		}
+		if abs {
+			ec.EventAfterTime(f, now.Add(d))
+		} else {
+			ec.EventAfterDuration(f, d)
+		}
+	}
+	try(true, true, time.Minute)
+	for i := 0; i < batchSize; i++ {
+		d := time.Duration(rand.Intn(30)-3) * time.Second
+		try(i%2 == 0, d >= 0, d)
+	}
+	ec.Run(nil)
+	if numDone != batchSize+1 {
+		t.Errorf("Got only %v events", numDone)
+	}
+	lastTime := now.Add(-3 * time.Second)
+	for i := 0; i <= batchSize; i++ {
+		nextTime := <-times
+		if nextTime.Before(lastTime) {
+			t.Errorf("Got %s after %s", nextTime, lastTime)
+		}
+	}
+	endTime := ec.Now()
+	dx := endTime.Sub(now)
+	if dx > time.Minute+fuzz {
+		t.Errorf("Run started at %#+v, ended at %#+v, dx=%d", now, endTime, dx)
+	}
+	now = endTime
+	var shouldRun int32
+	strictable = false
+	for i := 0; i < batchSize; i++ {
+		d := time.Duration(rand.Intn(30)-3) * time.Second
+		try(i%2 == 0, d >= 0, d)
+		if d <= 12*time.Second {
+			shouldRun++
+		}
+	}
+	ec.SetTime(now.Add(13*time.Second - 1))
+	if numDone != batchSize+1+shouldRun {
+		t.Errorf("Expected %v, but %v ran", shouldRun, numDone-batchSize-1)
+	}
+	lastTime = now.Add(-3 * time.Second)
+	for i := int32(0); i < shouldRun; i++ {
+		nextTime := <-times
+		if nextTime.Before(lastTime) {
+			t.Errorf("Got %s after %s", nextTime, lastTime)
+		}
+		lastTime = nextTime
+	}
+}
+
+// copied from baseclocktest, because apparently
+// test files can not define public symbols.
+type SettablePassiveClock interface {
+	clock.PassiveClock
+	SetTime(time.Time)
+}
+
+// copied from baseclocktest, because it is not public
+func exercisePassiveClock(t *testing.T, pc SettablePassiveClock) {
+	t1 := time.Now()
+	t2 := t1.Add(time.Hour)
+	pc.SetTime(t1)
+	tx := pc.Now()
+	if tx != t1 {
+		t.Errorf("SetTime(%#+v); Now() => %#+v", t1, tx)
+	}
+	dx := pc.Since(t1)
+	if dx != 0 {
+		t.Errorf("Since() => %v", dx)
+	}
+	pc.SetTime(t2)
+	dx = pc.Since(t1)
+	if dx != time.Hour {
+		t.Errorf("Since() => %v", dx)
+	}
+	tx = pc.Now()
+	if tx != t2 {
+		t.Errorf("Now() => %#+v", tx)
+	}
+}
+
+func TestFakeEventClock(t *testing.T) {
+	startTime := time.Now()
+	fec, _ := NewFakeEventClock(startTime, 0, nil)
+	exerciseTestableEventClock(t, fec, 0)
+	fec, _ = NewFakeEventClock(startTime, time.Second, nil)
+	exerciseTestableEventClock(t, fec, time.Second)
+}
+
+func exerciseEventClock(t *testing.T, ec EventClock, relax func(time.Duration)) {
+	var numDone int32
+	now := ec.Now()
+	const batchSize = 100
+	times := make(chan time.Time, batchSize+1)
+	try := func(abs bool, d time.Duration) {
+		f := func(u time.Time) {
+			realD := ec.Since(now)
+			atomic.AddInt32(&numDone, 1)
+			times <- u
+			if realD < d {
+				t.Errorf("Asked for %v, got %v", d, realD)
+			}
+		}
+		if abs {
+			ec.EventAfterTime(f, now.Add(d))
+		} else {
+			ec.EventAfterDuration(f, d)
+		}
+	}
+	try(true, time.Millisecond*3300)
+	for i := 0; i < batchSize; i++ {
+		d := time.Duration(rand.Intn(30)-3) * time.Millisecond * 100
+		try(i%2 == 0, d)
+	}
+	relax(time.Second * 4)
+	if atomic.LoadInt32(&numDone) != batchSize+1 {
+		t.Errorf("Got only %v events", numDone)
+	}
+	lastTime := now
+	for i := 0; i <= batchSize; i++ {
+		nextTime := <-times
+		if nextTime.Before(now) {
+			continue
+		}
+		dt := nextTime.Sub(lastTime) / (50 * time.Millisecond)
+		if dt < 0 {
+			t.Errorf("Got %s after %s", nextTime, lastTime)
+		}
+		lastTime = nextTime
+	}
+}
+
+func TestRealEventClock(t *testing.T) {
+	exerciseEventClock(t, RealEventClock{}, func(d time.Duration) { time.Sleep(d) })
+}

--- a/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/clock/fake.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/clock/fake.go
@@ -1,0 +1,211 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package clock
+
+import (
+	"container/heap"
+	"math/rand"
+	"runtime"
+	"strings"
+	"sync"
+	"time"
+
+	"k8s.io/apiserver/pkg/util/flowcontrol/counter"
+	"k8s.io/klog/v2"
+	baseclocktest "k8s.io/utils/clock/testing"
+)
+
+// waitGroupCounter is a wait group used for a GoRoutine Counter.  This private
+// type is used to disallow direct waitGroup access
+type waitGroupCounter struct {
+	wg sync.WaitGroup
+}
+
+// compile time assertion that waitGroupCounter meets requirements
+//  of GoRoutineCounter
+var _ counter.GoRoutineCounter = (*waitGroupCounter)(nil)
+
+func (wgc *waitGroupCounter) Add(delta int) {
+	if klog.V(7).Enabled() {
+		var pcs [5]uintptr
+		nCallers := runtime.Callers(2, pcs[:])
+		frames := runtime.CallersFrames(pcs[:nCallers])
+		frame1, more1 := frames.Next()
+		fileParts1 := strings.Split(frame1.File, "/")
+		tail2 := "(none)"
+		line2 := 0
+		if more1 {
+			frame2, _ := frames.Next()
+			fileParts2 := strings.Split(frame2.File, "/")
+			tail2 = fileParts2[len(fileParts2)-1]
+			line2 = frame2.Line
+		}
+		klog.Infof("GRC(%p).Add(%d) from %s:%d from %s:%d", wgc, delta, fileParts1[len(fileParts1)-1], frame1.Line, tail2, line2)
+	}
+	wgc.wg.Add(delta)
+}
+
+func (wgc *waitGroupCounter) Wait() {
+	wgc.wg.Wait()
+}
+
+// FakeEventClock is one whose time does not pass implicitly but
+// rather is explicitly set by invocations of its SetTime method
+type FakeEventClock struct {
+	baseclocktest.FakePassiveClock
+
+	// waiters is a heap of waiting work, sorted by time
+	waiters     eventWaiterHeap
+	waitersLock sync.RWMutex
+
+	// clientWG may be nil and if not supplies constraints on time
+	// passing in Run.  The Run method will not pick a new time until
+	// this is nil or its counter is zero.
+	clientWG *waitGroupCounter
+
+	// fuzz is the amount of noise to add to scheduling.  An event
+	// requested to run at time T will run at some time chosen
+	// uniformly at random from the interval [T, T+fuzz]; the upper
+	// bound is exclusive iff fuzz is non-zero.
+	fuzz time.Duration
+
+	// rand is the random number generator to use in fuzzing
+	rand *rand.Rand
+}
+
+type eventWaiterHeap []eventWaiter
+
+var _ heap.Interface = (*eventWaiterHeap)(nil)
+
+type eventWaiter struct {
+	targetTime time.Time
+	f          EventFunc
+}
+
+// NewFakeEventClock constructor.  The given `r *rand.Rand` must
+// henceforth not be used for any other purpose.  If `r` is nil then a
+// fresh one will be constructed, seeded with the current real time.
+// The clientWG can be `nil` and if not is used to let Run know about
+// additional work that has to complete before time can advance.
+func NewFakeEventClock(t time.Time, fuzz time.Duration, r *rand.Rand) (*FakeEventClock, counter.GoRoutineCounter) {
+	grc := &waitGroupCounter{}
+
+	if r == nil {
+		r = rand.New(rand.NewSource(time.Now().UnixNano()))
+		r.Uint64()
+		r.Uint64()
+		r.Uint64()
+	}
+	return &FakeEventClock{
+		FakePassiveClock: *baseclocktest.NewFakePassiveClock(t),
+		clientWG:         grc,
+		fuzz:             fuzz,
+		rand:             r,
+	}, grc
+}
+
+// GetNextTime returns the next time at which there is work scheduled,
+// and a bool indicating whether there is any such time
+func (fec *FakeEventClock) GetNextTime() (time.Time, bool) {
+	fec.waitersLock.RLock()
+	defer fec.waitersLock.RUnlock()
+	if len(fec.waiters) > 0 {
+		return fec.waiters[0].targetTime, true
+	}
+	return time.Time{}, false
+}
+
+// Run runs all the events scheduled, and all the events they
+// schedule, and so on, until there are none scheduled or the limit is not
+// nil and the next time would exceed the limit.  The clientWG given in
+// the constructor gates each advance of time.
+func (fec *FakeEventClock) Run(limit *time.Time) {
+	for {
+		fec.clientWG.Wait()
+		t, ok := fec.GetNextTime()
+		if !ok || limit != nil && t.After(*limit) {
+			break
+		}
+		fec.SetTime(t)
+	}
+}
+
+// SetTime sets the time and runs to completion all events that should
+// be started by the given time --- including any further events they
+// schedule
+func (fec *FakeEventClock) SetTime(t time.Time) {
+	fec.FakePassiveClock.SetTime(t)
+	for {
+		foundSome := false
+		func() {
+			fec.waitersLock.Lock()
+			defer fec.waitersLock.Unlock()
+			// This loop is because events run at a given time may schedule more
+			// events to run at that or an earlier time.
+			// Events should not advance the clock.  But just in case they do...
+			now := fec.Now()
+			var wg sync.WaitGroup
+			for len(fec.waiters) > 0 && !now.Before(fec.waiters[0].targetTime) {
+				ew := heap.Pop(&fec.waiters).(eventWaiter)
+				wg.Add(1)
+				go func(f EventFunc) { f(now); wg.Done() }(ew.f)
+				foundSome = true
+			}
+			wg.Wait()
+		}()
+		if !foundSome {
+			break
+		}
+	}
+}
+
+// EventAfterDuration schedules the given function to be invoked once
+// the given duration has passed.
+func (fec *FakeEventClock) EventAfterDuration(f EventFunc, d time.Duration) {
+	fec.waitersLock.Lock()
+	defer fec.waitersLock.Unlock()
+	now := fec.Now()
+	fd := time.Duration(float32(fec.fuzz) * fec.rand.Float32())
+	heap.Push(&fec.waiters, eventWaiter{targetTime: now.Add(d + fd), f: f})
+}
+
+// EventAfterTime schedules the given function to be invoked once
+// the given time has arrived.
+func (fec *FakeEventClock) EventAfterTime(f EventFunc, t time.Time) {
+	fec.waitersLock.Lock()
+	defer fec.waitersLock.Unlock()
+	fd := time.Duration(float32(fec.fuzz) * fec.rand.Float32())
+	heap.Push(&fec.waiters, eventWaiter{targetTime: t.Add(fd), f: f})
+}
+
+func (ewh eventWaiterHeap) Len() int { return len(ewh) }
+
+func (ewh eventWaiterHeap) Less(i, j int) bool { return ewh[i].targetTime.Before(ewh[j].targetTime) }
+
+func (ewh eventWaiterHeap) Swap(i, j int) { ewh[i], ewh[j] = ewh[j], ewh[i] }
+
+func (ewh *eventWaiterHeap) Push(x interface{}) {
+	*ewh = append(*ewh, x.(eventWaiter))
+}
+
+func (ewh *eventWaiterHeap) Pop() interface{} {
+	old := *ewh
+	n := len(old)
+	x := old[n-1]
+	*ewh = old[:n-1]
+	return x
+}

--- a/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/clock/interface.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/clock/interface.go
@@ -1,0 +1,36 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package clock
+
+import (
+	"time"
+
+	baseclock "k8s.io/utils/clock"
+)
+
+// EventFunc does some work that needs to be done at or after the
+// given time. After this function returns, associated work may continue
+//  on other goroutines only if they are counted by the GoRoutineCounter
+// of the FakeEventClock handling this EventFunc.
+type EventFunc func(time.Time)
+
+// EventClock fires event on time
+type EventClock interface {
+	baseclock.PassiveClock
+	EventAfterDuration(f EventFunc, d time.Duration)
+	EventAfterTime(f EventFunc, t time.Time)
+}

--- a/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/clock/real.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/clock/real.go
@@ -1,0 +1,48 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package clock
+
+import (
+	"time"
+
+	"k8s.io/utils/clock"
+)
+
+// RealEventClock fires event on real world time
+type RealEventClock struct {
+	clock.RealClock
+}
+
+// EventAfterDuration schedules an EventFunc
+func (RealEventClock) EventAfterDuration(f EventFunc, d time.Duration) {
+	ch := time.After(d)
+	go func() {
+		t := <-ch
+		f(t)
+	}()
+}
+
+// EventAfterTime schedules an EventFunc
+func (r RealEventClock) EventAfterTime(f EventFunc, t time.Time) {
+	now := time.Now()
+	d := t.Sub(now)
+	if d <= 0 {
+		go f(now)
+	} else {
+		r.EventAfterDuration(f, d)
+	}
+}

--- a/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/queueset/queueset.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/queueset/queueset.go
@@ -23,7 +23,8 @@ import (
 	"sync"
 	"time"
 
-	"k8s.io/apimachinery/pkg/util/clock"
+	"k8s.io/utils/clock"
+
 	"k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apiserver/pkg/util/flowcontrol/counter"
 	"k8s.io/apiserver/pkg/util/flowcontrol/debug"

--- a/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/queueset/queueset_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/queueset/queueset_test.go
@@ -27,11 +27,12 @@ import (
 	"testing"
 	"time"
 
-	"k8s.io/apimachinery/pkg/util/clock"
+	"k8s.io/utils/clock"
+
 	"k8s.io/apiserver/pkg/util/flowcontrol/counter"
 	fq "k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing"
+	testclock "k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/clock"
 	test "k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/testing"
-	testclock "k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/testing/clock"
 	"k8s.io/apiserver/pkg/util/flowcontrol/metrics"
 	fcrequest "k8s.io/apiserver/pkg/util/flowcontrol/request"
 	"k8s.io/klog/v2"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug

/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind cleanup

#### What this PR does / why we need it:
This PR makes an alternate version of the event clock stuff from `staging/src/k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/testing/clock` that is better in two ways:
1. it is based on k8s.io/utils/clock rather than the apimachinery clock package, and
2. it exports the EventClock interface and implementations.

The latter is helpful so that we can make the queueset implementation take an action after a time (for duration padding).

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:
This is an alternative to #103830.  The two commits here are cherry-picks of two of the three there; the one updating the vendor modules.txt is absent here, demonstrating that that is not the source of the mysterious problem.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
