### PR TITLE
staging/publishing: add release-1.22 rules

### DIFF
--- a/staging/publishing/rules.yaml
+++ b/staging/publishing/rules.yaml
@@ -29,6 +29,10 @@ rules:
       branch: release-1.21
       dir: staging/src/k8s.io/code-generator
     name: release-1.21
+  - source:
+      branch: release-1.22
+      dir: staging/src/k8s.io/code-generator
+    name: release-1.22
 
 - destination: apimachinery
   library: true
@@ -51,6 +55,10 @@ rules:
       branch: release-1.21
       dir: staging/src/k8s.io/apimachinery
     name: release-1.21
+  - source:
+      branch: release-1.22
+      dir: staging/src/k8s.io/apimachinery
+    name: release-1.22
 
 - destination: api
   library: true
@@ -85,6 +93,13 @@ rules:
     dependencies:
       - repository: apimachinery
         branch: release-1.21
+  - source:
+      branch: release-1.22
+      dir: staging/src/k8s.io/api
+    name: release-1.22
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.22
 
 - destination: client-go
   library: true
@@ -143,6 +158,19 @@ rules:
       # assumes GO111MODULE=on
       go build -mod=mod ./...
       go test -mod=mod ./...
+  - source:
+      branch: release-1.22
+      dir: staging/src/k8s.io/client-go
+    name: release-1.22
+    dependencies:
+      - repository: apimachinery
+        branch: release-1.22
+      - repository: api
+        branch: release-1.22
+    smoke-test: |
+      # assumes GO111MODULE=on
+      go build -mod=mod ./...
+      go test -mod=mod ./...
 
 - destination: component-base
   library: true
@@ -193,6 +221,17 @@ rules:
       branch: release-1.21
     - repository: client-go
       branch: release-1.21
+  - source:
+      branch: release-1.22
+      dir: staging/src/k8s.io/component-base
+    name: release-1.22
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.22
+    - repository: api
+      branch: release-1.22
+    - repository: client-go
+      branch: release-1.22
 
 - destination: component-helpers
   library: true
@@ -231,6 +270,17 @@ rules:
       branch: release-1.21
     - repository: client-go
       branch: release-1.21
+  - source:
+      branch: release-1.22
+      dir: staging/src/k8s.io/component-helpers
+    name: release-1.22
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.22
+    - repository: api
+      branch: release-1.22
+    - repository: client-go
+      branch: release-1.22
 
 - destination: apiserver
   library: true
@@ -289,6 +339,19 @@ rules:
       branch: release-1.21
     - repository: component-base
       branch: release-1.21
+  - source:
+      branch: release-1.22
+      dir: staging/src/k8s.io/apiserver
+    name: release-1.22
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.22
+    - repository: api
+      branch: release-1.22
+    - repository: client-go
+      branch: release-1.22
+    - repository: component-base
+      branch: release-1.22
 
 - destination: kube-aggregator
   branches:
@@ -362,6 +425,23 @@ rules:
       branch: release-1.21
     - repository: code-generator
       branch: release-1.21
+  - source:
+      branch: release-1.22
+      dir: staging/src/k8s.io/kube-aggregator
+    name: release-1.22
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.22
+    - repository: api
+      branch: release-1.22
+    - repository: client-go
+      branch: release-1.22
+    - repository: apiserver
+      branch: release-1.22
+    - repository: component-base
+      branch: release-1.22
+    - repository: code-generator
+      branch: release-1.22
 
 - destination: sample-apiserver
   branches:
@@ -455,6 +535,28 @@ rules:
     smoke-test: |
       # assumes GO111MODULE=on
       go build -mod=mod .
+  - source:
+      branch: release-1.22
+      dir: staging/src/k8s.io/sample-apiserver
+    name: release-1.22
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.22
+    - repository: api
+      branch: release-1.22
+    - repository: client-go
+      branch: release-1.22
+    - repository: apiserver
+      branch: release-1.22
+    - repository: code-generator
+      branch: release-1.22
+    - repository: component-base
+      branch: release-1.22
+    required-packages:
+    - k8s.io/code-generator
+    smoke-test: |
+      # assumes GO111MODULE=on
+      go build -mod=mod .
 
 - destination: sample-controller
   branches:
@@ -527,6 +629,24 @@ rules:
       branch: release-1.21
     - repository: code-generator
       branch: release-1.21
+    required-packages:
+    - k8s.io/code-generator
+    smoke-test: |
+      # assumes GO111MODULE=on
+      go build -mod=mod .
+  - source:
+      branch: release-1.22
+      dir: staging/src/k8s.io/sample-controller
+    name: release-1.22
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.22
+    - repository: api
+      branch: release-1.22
+    - repository: client-go
+      branch: release-1.22
+    - repository: code-generator
+      branch: release-1.22
     required-packages:
     - k8s.io/code-generator
     smoke-test: |
@@ -613,6 +733,25 @@ rules:
       branch: release-1.21
     required-packages:
     - k8s.io/code-generator
+  - source:
+      branch: release-1.22
+      dir: staging/src/k8s.io/apiextensions-apiserver
+    name: release-1.22
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.22
+    - repository: api
+      branch: release-1.22
+    - repository: client-go
+      branch: release-1.22
+    - repository: apiserver
+      branch: release-1.22
+    - repository: code-generator
+      branch: release-1.22
+    - repository: component-base
+      branch: release-1.22
+    required-packages:
+    - k8s.io/code-generator
 
 - destination: metrics
   library: true
@@ -671,6 +810,19 @@ rules:
       branch: release-1.21
     - repository: code-generator
       branch: release-1.21
+  - source:
+      branch: release-1.22
+      dir: staging/src/k8s.io/metrics
+    name: release-1.22
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.22
+    - repository: api
+      branch: release-1.22
+    - repository: client-go
+      branch: release-1.22
+    - repository: code-generator
+      branch: release-1.22
 
 - destination: cli-runtime
   library: true
@@ -721,6 +873,17 @@ rules:
       branch: release-1.21
     - repository: client-go
       branch: release-1.21
+  - source:
+      branch: release-1.22
+      dir: staging/src/k8s.io/cli-runtime
+    name: release-1.22
+    dependencies:
+    - repository: api
+      branch: release-1.22
+    - repository: apimachinery
+      branch: release-1.22
+    - repository: client-go
+      branch: release-1.22
 
 - destination: sample-cli-plugin
   library: false
@@ -779,6 +942,19 @@ rules:
       branch: release-1.21
     - repository: client-go
       branch: release-1.21
+  - source:
+      branch: release-1.22
+      dir: staging/src/k8s.io/sample-cli-plugin
+    name: release-1.22
+    dependencies:
+    - repository: api
+      branch: release-1.22
+    - repository: apimachinery
+      branch: release-1.22
+    - repository: cli-runtime
+      branch: release-1.22
+    - repository: client-go
+      branch: release-1.22
 
 - destination: kube-proxy
   library: true
@@ -837,6 +1013,19 @@ rules:
       branch: release-1.21
     - repository: client-go
       branch: release-1.21
+  - source:
+      branch: release-1.22
+      dir: staging/src/k8s.io/kube-proxy
+    name: release-1.22
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.22
+    - repository: component-base
+      branch: release-1.22
+    - repository: api
+      branch: release-1.22
+    - repository: client-go
+      branch: release-1.22
 
 - destination: kubelet
   library: true
@@ -895,6 +1084,19 @@ rules:
       branch: release-1.21
     - repository: component-base
       branch: release-1.21
+  - source:
+      branch: release-1.22
+      dir: staging/src/k8s.io/kubelet
+    name: release-1.22
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.22
+    - repository: api
+      branch: release-1.22
+    - repository: client-go
+      branch: release-1.22
+    - repository: component-base
+      branch: release-1.22
 
 - destination: kube-scheduler
   library: true
@@ -953,6 +1155,19 @@ rules:
       branch: release-1.21
     - repository: client-go
       branch: release-1.21
+  - source:
+      branch: release-1.22
+      dir: staging/src/k8s.io/kube-scheduler
+    name: release-1.22
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.22
+    - repository: component-base
+      branch: release-1.22
+    - repository: api
+      branch: release-1.22
+    - repository: client-go
+      branch: release-1.22
 
 - destination: controller-manager
   library: true
@@ -1008,6 +1223,21 @@ rules:
       branch: release-1.21
     - repository: apiserver
       branch: release-1.21
+  - source:
+      branch: release-1.22
+      dir: staging/src/k8s.io/controller-manager
+    name: release-1.22
+    dependencies:
+    - repository: api
+      branch: release-1.22
+    - repository: apimachinery
+      branch: release-1.22
+    - repository: client-go
+      branch: release-1.22
+    - repository: component-base
+      branch: release-1.22
+    - repository: apiserver
+      branch: release-1.22
 
 - destination: cloud-provider
   library: true
@@ -1078,6 +1308,23 @@ rules:
       branch: release-1.21
     - repository: controller-manager
       branch: release-1.21
+  - source:
+      branch: release-1.22
+      dir: staging/src/k8s.io/cloud-provider
+    name: release-1.22
+    dependencies:
+    - repository: api
+      branch: release-1.22
+    - repository: apimachinery
+      branch: release-1.22
+    - repository: apiserver
+      branch: release-1.22
+    - repository: client-go
+      branch: release-1.22
+    - repository: component-base
+      branch: release-1.22
+    - repository: controller-manager
+      branch: release-1.22
 
 - destination: kube-controller-manager
   library: true
@@ -1154,6 +1401,25 @@ rules:
       branch: release-1.21
     - repository: cloud-provider
       branch: release-1.21
+  - source:
+      branch: release-1.22
+      dir: staging/src/k8s.io/kube-controller-manager
+    name: release-1.22
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.22
+    - repository: apiserver
+      branch: release-1.22
+    - repository: component-base
+      branch: release-1.22
+    - repository: api
+      branch: release-1.22
+    - repository: client-go
+      branch: release-1.22
+    - repository: controller-manager
+      branch: release-1.22
+    - repository: cloud-provider
+      branch: release-1.22
 
 - destination: cluster-bootstrap
   library: true
@@ -1196,6 +1462,15 @@ rules:
       branch: release-1.21
     - repository: api
       branch: release-1.21
+  - source:
+      branch: release-1.22
+      dir: staging/src/k8s.io/cluster-bootstrap
+    name: release-1.22
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.22
+    - repository: api
+      branch: release-1.22
 
 - destination: csi-translation-lib
   library: true
@@ -1244,6 +1519,15 @@ rules:
       branch: release-1.21
     - repository: apimachinery
       branch: release-1.21
+  - source:
+      branch: release-1.22
+      dir: staging/src/k8s.io/csi-translation-lib
+    name: release-1.22
+    dependencies:
+    - repository: api
+      branch: release-1.22
+    - repository: apimachinery
+      branch: release-1.22
 
 - destination: mount-utils
   library: true
@@ -1261,6 +1545,10 @@ rules:
       branch: release-1.21
       dir: staging/src/k8s.io/mount-utils
     name: release-1.21
+  - source:
+      branch: release-1.22
+      dir: staging/src/k8s.io/mount-utils
+    name: release-1.22
 
 - destination: legacy-cloud-providers
   library: true
@@ -1351,6 +1639,28 @@ rules:
       branch: release-1.21
     - repository: controller-manager
       branch: release-1.21
+  - source:
+      branch: release-1.22
+      dir: staging/src/k8s.io/legacy-cloud-providers
+    name: release-1.22
+    dependencies:
+    - repository: api
+      branch: release-1.22
+    - repository: apimachinery
+      branch: release-1.22
+    - repository: client-go
+      branch: release-1.22
+    - repository: cloud-provider
+      branch: release-1.22
+    - repository: csi-translation-lib
+      branch: release-1.22
+    - repository: apiserver
+      branch: release-1.22
+    - repository: component-base
+      branch: release-1.22
+    - repository: controller-manager
+      branch: release-1.22
+
 
 - destination: cri-api
   library: true
@@ -1373,6 +1683,10 @@ rules:
       branch: release-1.21
       dir: staging/src/k8s.io/cri-api
     name: release-1.21
+  - source:
+      branch: release-1.22
+      dir: staging/src/k8s.io/cri-api
+    name: release-1.22
 
 - destination: kubectl
   library: true
@@ -1461,6 +1775,27 @@ rules:
       branch: release-1.21
     - repository: metrics
       branch: release-1.21
+  - source:
+      branch: release-1.22
+      dir: staging/src/k8s.io/kubectl
+    name: release-1.22
+    dependencies:
+    - repository: api
+      branch: release-1.22
+    - repository: apimachinery
+      branch: release-1.22
+    - repository: cli-runtime
+      branch: release-1.22
+    - repository: client-go
+      branch: release-1.22
+    - repository: code-generator
+      branch: release-1.22
+    - repository: component-base
+      branch: release-1.22
+    - repository: component-helpers
+      branch: release-1.22
+    - repository: metrics
+      branch: release-1.22
 
 - destination: pod-security-admission
   library: true
@@ -1480,3 +1815,18 @@ rules:
       branch: master
     - repository: component-base
       branch: master
+  - source:
+      branch: release-1.22
+      dir: staging/src/k8s.io/pod-security-admission
+    name: release-1.22
+    dependencies:
+    - repository: api
+      branch: release-1.22
+    - repository: apimachinery
+      branch: release-1.22
+    - repository: apiserver
+      branch: release-1.22
+    - repository: client-go
+      branch: release-1.22
+    - repository: component-base
+      branch: release-1.22


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Adds publishing bot rules for `release-1.22`

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

None

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

None

/assign @puerco (for releng approval) 
/assign @nikhita (for publishing rules approval)
/cc @kubernetes/release-managers 

/priority critical-urgent

This would also need to be milestoned to v1.22.