### PR TITLE
Do not try to "create" stdout "file".

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/server/options/audit.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/audit.go
@@ -511,21 +511,21 @@ func (o *AuditLogOptions) getWriter() (io.Writer, error) {
 		return nil, nil
 	}
 
-	if err := o.ensureLogFile(); err != nil {
-		return nil, err
+	if o.Path == "-" {
+		return os.Stdout, nil
 	}
 
-	var w io.Writer = os.Stdout
-	if o.Path != "-" {
-		w = &lumberjack.Logger{
-			Filename:   o.Path,
-			MaxAge:     o.MaxAge,
-			MaxBackups: o.MaxBackups,
-			MaxSize:    o.MaxSize,
-			Compress:   o.Compress,
-		}
+	if err := o.ensureLogFile(); err != nil {
+		return nil, fmt.Errorf("ensureLogFile: %w", err)
 	}
-	return w, nil
+
+	return &lumberjack.Logger{
+		Filename:   o.Path,
+		MaxAge:     o.MaxAge,
+		MaxBackups: o.MaxBackups,
+		MaxSize:    o.MaxSize,
+		Compress:   o.Compress,
+	}, nil
 }
 
 func (o *AuditLogOptions) ensureLogFile() error {


### PR DESCRIPTION
That PR fixes `--audit-log-path=-` support.

Additionally, it wraps a returned error to make logged error message easier to track.

Refs #95387.
Fixes #103845.
