### PR TITLE
Update component-base owners to include SIG-Architecture

### DIFF
--- a/staging/src/k8s.io/component-base/OWNERS
+++ b/staging/src/k8s.io/component-base/OWNERS
@@ -1,20 +1,21 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
-- mtaufen
-- stealthybox
-- luxas
-- sttts
-- lavalamp
+- sig-architecture-approvers
 reviewers:
-- luxas
-- sttts
-- stewart-yu
-- dims
-- dixudx
-- rosti
+- sig-architecture-approvers
 emeritus_approvers:
 - jbeda
+- lavalamp
+- luxas
+- mtaufen
+- stealthybox
+- sttts
+emeritus_reviewers:
+- dixudx
+- rosti
+- stewart-yu
 labels:
+- sig/architecture
 - sig/cluster-lifecycle
 - sig/api-machinery

--- a/staging/src/k8s.io/component-base/cli/OWNERS
+++ b/staging/src/k8s.io/component-base/cli/OWNERS
@@ -1,0 +1,12 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+# Currently assigned cli to sig-cli since:
+# (a) its literally named "cli"
+# (b) flags are the bread-and-butter of cli tools.
+
+approvers:
+- sig-cli-maintainers
+reviewers:
+- sig-cli
+labels:
+- sig/cli

--- a/staging/src/k8s.io/component-base/codec/OWNERS
+++ b/staging/src/k8s.io/component-base/codec/OWNERS
@@ -1,0 +1,11 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+# Currently assigned codec to sig-api-machinery since its used for encoding/
+# decoding KRM style manifests.
+
+approvers:
+- sig-api-machinery-api-approvers
+reviewers:
+- sig-api-machinery-api-reviewers
+labels:
+- sig/api-machinery

--- a/staging/src/k8s.io/component-base/configz/OWNERS
+++ b/staging/src/k8s.io/component-base/configz/OWNERS
@@ -1,5 +1,9 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
+# For lack of a better idea, assigned configz to api-approvers because
+# configz is an API that has been around for a long time, even if we don't
+# guarantee its stability.
+
 # Disable inheritance as this is an api owners file
 options:
   no_parent_owners: true
@@ -7,11 +11,7 @@ approvers:
 - api-approvers
 reviewers:
 - api-reviewers
-emeritus_reviewers:
-- luxas
-- mtaufen
-- sttts
+
 labels:
 - kind/api-change
-- sig/api-machinery
-- sig/scheduling
+- sig/cluster-lifecycle

--- a/staging/src/k8s.io/component-base/featuregate/OWNERS
+++ b/staging/src/k8s.io/component-base/featuregate/OWNERS
@@ -1,5 +1,8 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
+# Currently assigned to api-approvers since feature gates are the API
+# for enabling/disabling other APIs.
+
 # Disable inheritance as this is an api owners file
 options:
   no_parent_owners: true
@@ -7,11 +10,8 @@ approvers:
 - api-approvers
 reviewers:
 - api-reviewers
-emeritus_reviewers:
-- luxas
-- mtaufen
-- sttts
+
 labels:
 - kind/api-change
 - sig/api-machinery
-- sig/scheduling
+- sig/cluster-lifecycle

--- a/staging/src/k8s.io/component-base/term/OWNERS
+++ b/staging/src/k8s.io/component-base/term/OWNERS
@@ -1,0 +1,12 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+# Currently assigned this directory to sig-cli since the main use of
+# term seems to be for getting terminal size when printing help text.
+
+approvers:
+- sig-cli-maintainers
+reviewers:
+- sig-cli
+
+labels:
+- sig/cli

--- a/staging/src/k8s.io/component-base/version/OWNERS
+++ b/staging/src/k8s.io/component-base/version/OWNERS
@@ -1,0 +1,17 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+# Currently assigned this directory to sig-api-machinery since this is
+# an interface to the version definition in "k8s.io/apimachinery/pkg/version",
+# and also to sig-release since this version information is set up for
+# each release.
+
+approvers:
+- sig-api-machinery-api-approvers
+- release-engineering-approvers
+reviewers:
+- sig-api-machinery-api-reviewers
+- release-engineering-reviewers
+
+labels:
+- sig/api-machinery
+- sig/release


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Update component-base owners to include SIG-Architecture, as a stakeholder SIG of the (soon-to-be-dissolved) WG Component Standard, and as the owners of code organization projects.

#### Special notes for your reviewer:

@neolit123 suggested that SIG-Cluster-Lifecycle doesn't have much of a stake in component-base, maybe we remove the sig/cluster-lifecycle label in this PR also?

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs

```

SIG-Architecture approvers:
/assign @derekwaynecarr @dims @johnbelamaric 
