### PR TITLE
Changed flag name underscore warning to prevent duplicate warnings and avoid recommending invalid flag name

### DIFF
--- a/staging/src/k8s.io/component-base/cli/flag/flags.go
+++ b/staging/src/k8s.io/component-base/cli/flag/flags.go
@@ -24,6 +24,8 @@ import (
 	"k8s.io/klog/v2"
 )
 
+var underscoreWarnings = make(map[string]bool)
+
 // WordSepNormalizeFunc changes all flags that contain "_" separators
 func WordSepNormalizeFunc(f *pflag.FlagSet, name string) pflag.NormalizedName {
 	if strings.Contains(name, "_") {
@@ -36,7 +38,10 @@ func WordSepNormalizeFunc(f *pflag.FlagSet, name string) pflag.NormalizedName {
 func WarnWordSepNormalizeFunc(f *pflag.FlagSet, name string) pflag.NormalizedName {
 	if strings.Contains(name, "_") {
 		nname := strings.Replace(name, "_", "-", -1)
-		klog.Warningf("%s is DEPRECATED and will be removed in a future version. Use %s instead.", name, nname)
+		if _, alreadyWarned := underscoreWarnings[name]; !alreadyWarned {
+			klog.Warningf("using an underscore in a flag name is not supported. %s has been converted to %s.", name, nname)
+			underscoreWarnings[name] = true
+		}
 
 		return pflag.NormalizedName(nname)
 	}

--- a/staging/src/k8s.io/component-base/cli/flag/flags_test.go
+++ b/staging/src/k8s.io/component-base/cli/flag/flags_test.go
@@ -1,0 +1,107 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package flag
+
+import (
+	"bytes"
+	"github.com/go-logr/logr"
+	"github.com/spf13/pflag"
+	"github.com/stretchr/testify/assert"
+	"k8s.io/klog/v2"
+	"testing"
+)
+
+type FakeLogger struct {
+	logr.Logger
+	infoBuffer  bytes.Buffer
+	errorBuffer bytes.Buffer
+}
+
+func (logger *FakeLogger) Enabled() bool { return true }
+func (logger *FakeLogger) Info(msg string, keysAndValues ...interface{}) {
+	logger.infoBuffer.WriteString(msg)
+}
+func (logger *FakeLogger) Error(err error, msg string, keysAndValues ...interface{}) {
+	logger.errorBuffer.WriteString(msg)
+}
+func (logger *FakeLogger) V(level int) logr.Logger                             { return logger }
+func (logger *FakeLogger) WithValues(keysAndValues ...interface{}) logr.Logger { return logger }
+func (logger *FakeLogger) WithName(name string) logr.Logger                    { return logger }
+
+func TestWordSepNormalizeFunc(t *testing.T) {
+	cases := []struct {
+		flagName         string
+		expectedFlagName string
+	}{
+		{
+			flagName:         "foo",
+			expectedFlagName: "foo",
+		},
+		{
+			flagName:         "foo-bar",
+			expectedFlagName: "foo-bar",
+		},
+		{
+			flagName:         "foo_bar",
+			expectedFlagName: "foo-bar",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.flagName, func(t *testing.T) {
+			fakeLogger := &FakeLogger{}
+			klog.SetLogger(fakeLogger)
+			result := WordSepNormalizeFunc(nil, tc.flagName)
+			assert.Equal(t, pflag.NormalizedName(tc.expectedFlagName), result)
+			assert.Equal(t, "", fakeLogger.infoBuffer.String())
+			assert.Equal(t, "", fakeLogger.errorBuffer.String())
+		})
+	}
+}
+
+func TestWarnWordSepNormalizeFunc(t *testing.T) {
+	cases := []struct {
+		flagName         string
+		expectedFlagName string
+		expectedWarning  string
+	}{
+		{
+			flagName:         "foo",
+			expectedFlagName: "foo",
+			expectedWarning:  "",
+		},
+		{
+			flagName:         "foo-bar",
+			expectedFlagName: "foo-bar",
+			expectedWarning:  "",
+		},
+		{
+			flagName:         "foo_bar",
+			expectedFlagName: "foo-bar",
+			expectedWarning:  "using an underscore in a flag name is not supported. foo_bar has been converted to foo-bar.\n",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.flagName, func(t *testing.T) {
+			fakeLogger := &FakeLogger{}
+			klog.SetLogger(fakeLogger)
+			result := WarnWordSepNormalizeFunc(nil, tc.flagName)
+			assert.Equal(t, pflag.NormalizedName(tc.expectedFlagName), result)
+			assert.Equal(t, tc.expectedWarning, fakeLogger.infoBuffer.String())
+			assert.Equal(t, "", fakeLogger.errorBuffer.String())
+		})
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
If you use kubectl with a flag name that has underscores as a word separator, but is an invalid flag name, kubectl recommends you use the invalid flag name with - as word separator.  It also writes the same warning out numerous times.

Example below tells me `foo_bar` is deprecated (not true, it is an invalid flag) and to use a flag called `foo-bar` even though that obviously is not a valid flag.
```
$ kubectl run nginx --image=nginx --foo_bar
W0722 12:20:18.905885  381541 flags.go:39] foo_bar is DEPRECATED and will be removed in a future version. Use foo-bar instead.
W0722 12:20:18.906154  381541 flags.go:39] foo_bar is DEPRECATED and will be removed in a future version. Use foo-bar instead.
W0722 12:20:18.906204  381541 flags.go:39] foo_bar is DEPRECATED and will be removed in a future version. Use foo-bar instead.
W0722 12:20:18.906408  381541 flags.go:39] foo_bar is DEPRECATED and will be removed in a future version. Use foo-bar instead.
W0722 12:20:18.906478  381541 flags.go:39] foo_bar is DEPRECATED and will be removed in a future version. Use foo-bar instead.
W0722 12:20:18.906522  381541 flags.go:39] foo_bar is DEPRECATED and will be removed in a future version. Use foo-bar instead.
W0722 12:20:18.906579  381541 flags.go:39] foo_bar is DEPRECATED and will be removed in a future version. Use foo-bar instead.
W0722 12:20:18.906612  381541 flags.go:39] foo_bar is DEPRECATED and will be removed in a future version. Use foo-bar instead.
W0722 12:20:18.906645  381541 flags.go:39] foo_bar is DEPRECATED and will be removed in a future version. Use foo-bar instead.
W0722 12:20:18.906699  381541 flags.go:39] foo_bar is DEPRECATED and will be removed in a future version. Use foo-bar instead.
Error: unknown flag: --foo_bar
See 'kubectl run --help' for usage.
```

The message saying that all flags containing an underscore is deprecated is 5+ years old.  However we don't really want to break someone who happens to be using a flag named this way.  

The approach discussed during the 7/21 sig-cli bug scrub meeting is to allow the conversion to remain, but change the warning message to not say anything about deprecation and not make any recommendation about the flag name because we don't know at this point in the code execution whether the flag is valid or invalid.  

The conversion between _ and - will still occur as it has to preserve compatibility.

This PR also prevents writing the same flag name warning out multiple times.

New output after this PR:
```
$ kubectl run nginx --image=nginx --foo_bar
W0722 12:38:42.412943  386533 flags.go:42] using an underscore in a flag name is not supported. foo_bar has been converted to foo-bar.
Error: unknown flag: --foo_bar
See 'kubectl run --help' for usage.
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes/kubectl/issues/1078

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
Fixed bug where kubectl would emit duplicate warning messages for flag names that contain an underscore and recommend using a nonexistent flag in some cases
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
