### PR TITLE
Automated cherry pick of #102576: kubelet: do not call RemoveAll on volumes directory for

### DIFF
--- a/pkg/kubelet/kubelet_volumes_linux_test.go
+++ b/pkg/kubelet/kubelet_volumes_linux_test.go
@@ -104,6 +104,16 @@ func TestCleanupOrphanedPodDirs(t *testing.T) {
 				return validateDirNotExists(podDir)
 			},
 		},
+		"pod-doesnot-exist-with-volume-subdir": {
+			prepareFunc: func(kubelet *Kubelet) error {
+				podDir := kubelet.getPodDir("pod1uid")
+				return os.MkdirAll(filepath.Join(podDir, "volumes/plugin/name/subdir"), 0750)
+			},
+			validateFunc: func(kubelet *Kubelet) error {
+				podDir := kubelet.getPodDir("pod1uid")
+				return validateDirNotExists(filepath.Join(podDir, "volumes"))
+			},
+		},
 		"pod-doesnot-exist-with-subpath": {
 			prepareFunc: func(kubelet *Kubelet) error {
 				podDir := kubelet.getPodDir("pod1uid")

--- a/pkg/util/removeall/OWNERS
+++ b/pkg/util/removeall/OWNERS
@@ -1,0 +1,8 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+- sig-storage-approvers
+reviewers:
+- sig-storage-reviewers
+labels:
+- sig/storage

--- a/pkg/util/removeall/removeall.go
+++ b/pkg/util/removeall/removeall.go
@@ -109,15 +109,20 @@ func RemoveAllOneFilesystemCommon(mounter mount.Interface, path string, remove f
 
 // RemoveAllOneFilesystem removes the path and any children it contains, using
 // the os.Remove function. It makes sure it does not cross mount boundaries,
-// i.e. it does *not* remove files from another filesystem.
+// i.e. it returns an error rather than remove files from another filesystem.
+// It removes everything it can but returns the first error it encounters.
+// If the path does not exist, it returns nil (no error).
 func RemoveAllOneFilesystem(mounter mount.Interface, path string) error {
 	return RemoveAllOneFilesystemCommon(mounter, path, os.Remove)
 }
 
 // RemoveDirsOneFilesystem removes the path and any empty subdirectories it
 // contains, using the syscall.Rmdir function. Unlike RemoveAllOneFilesystem,
-// RemoveDirsOneFilesystem will remove only directories and fails if it
-// encounters any files in the directory tree.
+// RemoveDirsOneFilesystem will remove only directories and returns an error if
+// it encounters any files in the directory tree. It makes sure it does not
+// cross mount boundaries, i.e. it returns an error rather than remove dirs
+// from another filesystem. It removes everything it can but returns the first
+// error it encounters. If the path does not exist, it returns nil (no error).
 func RemoveDirsOneFilesystem(mounter mount.Interface, path string) error {
 	return RemoveAllOneFilesystemCommon(mounter, path, syscall.Rmdir)
 }

--- a/pkg/util/removeall/removeall.go
+++ b/pkg/util/removeall/removeall.go
@@ -25,16 +25,16 @@ import (
 	"k8s.io/utils/mount"
 )
 
-// RemoveAllOneFilesystem removes path and any children it contains.
-// It removes everything it can but returns the first error
-// it encounters. If the path does not exist, RemoveAll
+// RemoveAllOneFilesystemCommon removes the path and any children it contains,
+// using the provided remove function. It removes everything it can but returns
+// the first error it encounters. If the path does not exist, RemoveAll
 // returns nil (no error).
 // It makes sure it does not cross mount boundary, i.e. it does *not* remove
 // files from another filesystems. Like 'rm -rf --one-file-system'.
 // It is copied from RemoveAll() sources, with IsLikelyNotMountPoint
-func RemoveAllOneFilesystem(mounter mount.Interface, path string) error {
+func RemoveAllOneFilesystemCommon(mounter mount.Interface, path string, remove func(string) error) error {
 	// Simple case: if Remove works, we're done.
-	err := os.Remove(path)
+	err := remove(path)
 	if err == nil || os.IsNotExist(err) {
 		return nil
 	}
@@ -48,7 +48,7 @@ func RemoveAllOneFilesystem(mounter mount.Interface, path string) error {
 		return serr
 	}
 	if !dir.IsDir() {
-		// Not a directory; return the error from Remove.
+		// Not a directory; return the error from remove.
 		return err
 	}
 
@@ -76,7 +76,7 @@ func RemoveAllOneFilesystem(mounter mount.Interface, path string) error {
 	for {
 		names, err1 := fd.Readdirnames(100)
 		for _, name := range names {
-			err1 := RemoveAllOneFilesystem(mounter, path+string(os.PathSeparator)+name)
+			err1 := RemoveAllOneFilesystemCommon(mounter, path+string(os.PathSeparator)+name, remove)
 			if err == nil {
 				err = err1
 			}
@@ -97,7 +97,7 @@ func RemoveAllOneFilesystem(mounter mount.Interface, path string) error {
 	fd.Close()
 
 	// Remove directory.
-	err1 := os.Remove(path)
+	err1 := remove(path)
 	if err1 == nil || os.IsNotExist(err1) {
 		return nil
 	}
@@ -105,4 +105,19 @@ func RemoveAllOneFilesystem(mounter mount.Interface, path string) error {
 		err = err1
 	}
 	return err
+}
+
+// RemoveAllOneFilesystem removes the path and any children it contains, using
+// the os.Remove function. It makes sure it does not cross mount boundaries,
+// i.e. it does *not* remove files from another filesystem.
+func RemoveAllOneFilesystem(mounter mount.Interface, path string) error {
+	return RemoveAllOneFilesystemCommon(mounter, path, os.Remove)
+}
+
+// RemoveDirsOneFilesystem removes the path and any empty subdirectories it
+// contains, using the syscall.Rmdir function. Unlike RemoveAllOneFilesystem,
+// RemoveDirsOneFilesystem will remove only directories and fails if it
+// encounters any files in the directory tree.
+func RemoveDirsOneFilesystem(mounter mount.Interface, path string) error {
+	return RemoveAllOneFilesystemCommon(mounter, path, syscall.Rmdir)
 }

--- a/pkg/util/removeall/removeall_test.go
+++ b/pkg/util/removeall/removeall_test.go
@@ -138,3 +138,123 @@ func TestRemoveAllOneFilesystem(t *testing.T) {
 		}
 	}
 }
+
+func TestRemoveDirsOneFilesystem(t *testing.T) {
+	tests := []struct {
+		name string
+		// Items of the test directory. Directories end with "/".
+		// Directories starting with "mount" are considered to be mount points.
+		// Directories starting with "err" will cause an error in
+		// IsLikelyNotMountPoint.
+		items       []string
+		expectError bool
+	}{
+		{
+			"empty dir",
+			[]string{},
+			false,
+		},
+		{
+			"non-mount-no-files",
+			[]string{
+				"dir/",
+				"dir/subdir1/",
+				"dir2/",
+				"dir2/subdir2/",
+				"dir2/subdir2/subdir3/",
+				"dir3/",
+			},
+			false,
+		},
+		{
+			"non-mount-with-files",
+			[]string{
+				"dir/",
+				"dir/file",
+				"dir2/",
+				"file2",
+			},
+			true,
+		},
+		{
+			"mount-no-files",
+			[]string{
+				"dir/",
+				"dir/subdir1/",
+				"dir2/",
+				"dir2/subdir2/",
+				"dir2/subdir2/subdir3/",
+				"mount/",
+				"mount/dir3/",
+			},
+			true,
+		},
+		{
+			"mount-with-files",
+			[]string{
+				"dir/",
+				"dir/file",
+				"dir2/",
+				"file2",
+				"mount/",
+				"mount/file3",
+			},
+			true,
+		},
+		{
+			"innermount",
+			[]string{
+				"dir/",
+				"dir/subdir1/",
+				"dir/dir2/",
+				"dir/dir2/subdir2/",
+				"dir/dir2/mount/",
+				"dir/dir2/mount/subdir3/",
+			},
+			true,
+		},
+		{
+			"error",
+			[]string{
+				"dir/",
+				"dir/subdir1/",
+				"dir2/",
+				"err/",
+				"err/subdir3/",
+			},
+			true,
+		},
+	}
+
+	for _, test := range tests {
+		tmpDir, err := utiltesting.MkTmpdir("removeall-" + test.name + "-")
+		if err != nil {
+			t.Fatalf("Can't make a tmp dir: %v", err)
+		}
+		defer os.RemoveAll(tmpDir)
+		// Create the directory structure
+		for _, item := range test.items {
+			if strings.HasSuffix(item, "/") {
+				item = strings.TrimRight(item, "/")
+				if err = os.Mkdir(path.Join(tmpDir, item), 0777); err != nil {
+					t.Fatalf("error creating %s: %v", item, err)
+				}
+			} else {
+				f, err := os.Create(path.Join(tmpDir, item))
+				if err != nil {
+					t.Fatalf("error creating %s: %v", item, err)
+				}
+				f.Close()
+			}
+		}
+
+		mounter := &fakeMounter{}
+		err = RemoveDirsOneFilesystem(mounter, tmpDir)
+		if err == nil && test.expectError {
+			t.Errorf("test %q failed: expected error and got none", test.name)
+		}
+		if err != nil && !test.expectError {
+			t.Errorf("test %q failed: unexpected error: %v", test.name, err)
+		}
+	}
+}


### PR DESCRIPTION
Cherry pick of #102576 on release-1.19.

#102576: kubelet: do not call RemoveAll on volumes directory for

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.