### PR TITLE
aws: fallback to user intent set by kubernetes.io/role/elb tag when finding public subnets for ELB

### DIFF
--- a/staging/src/k8s.io/legacy-cloud-providers/aws/aws_test.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/aws/aws_test.go
@@ -834,12 +834,6 @@ func Test_findELBSubnets(t *testing.T) {
 	subnetA0000002 := &ec2.Subnet{
 		AvailabilityZone: aws.String("us-west-2a"),
 		SubnetId:         aws.String("subnet-a0000002"),
-		Tags: []*ec2.Tag{
-			{
-				Key:   aws.String(TagNameSubnetPublicELB),
-				Value: aws.String("1"),
-			},
-		},
 	}
 	subnetA0000003 := &ec2.Subnet{
 		AvailabilityZone: aws.String("us-west-2a"),
@@ -946,6 +940,26 @@ func Test_findELBSubnets(t *testing.T) {
 				"subnet-a0000002": false,
 			},
 			want: nil,
+		},
+		{
+			name: "public subnet using route table",
+			subnets: []*ec2.Subnet{
+				subnetA0000001,
+			},
+			routeTables: map[string]bool{
+				"subnet-a0000002": true,
+			},
+			want: []string{"subnet-a0000001"},
+		},
+		{
+			name: "public subnet using the elb tag",
+			subnets: []*ec2.Subnet{
+				subnetA0000001,
+			},
+			routeTables: map[string]bool{
+				"subnet-a0000002": false,
+			},
+			want: []string{"subnet-a0000001"},
 		},
 		{
 			name: "prefer role over cluster tag",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

Currently the discovery codepath only decides whether a subnet is public
by using the routetables. Only when there are more than one such
subnets, the codepath picks a subnet with PublicSubnetTagName.

There are many network deployments which do not directly attach an igw
to the public subnet, but usage of these subnets is clearly defined by
the user by tagging these subnets with PublicSubnetTagName.
So instead of having the users of SLB define the subnets everytime, it
would be beneficial if the discovery codepath respect the indication on
the public subnets set by the admins of the cluster.

Similarly the aws-load-balancer-controller [1] now solely depends on
PublicSubnetTagName to discover the public subnets for ELB.

In this change, we update the isSubnetPublic function such that when it
fails to decide that a subnet is public using route table rules, if
checks if the subnet has the PublicSubnetTagName, and if the tag exists
and equal to empty("") and "1" value [2] it returns true. So the main check is
still route tables based, and the tag based becomes a fallback.

[1]:
https://github.com/kubernetes-sigs/aws-load-balancer-controller/blob/main/pkg/networking/subnet_resolver.go#L114
[2]:
https://docs.aws.amazon.com/eks/latest/userguide/network-load-balancing.html


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
aws: fallback to user intent set by kubernetes.io/role/elb tag when finding public subnets for ELB
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
