### PR TITLE
Add e2e testing manifest bundle to e2e_node test suite

### DIFF
--- a/test/e2e_node/e2e_node_suite_test.go
+++ b/test/e2e_node/e2e_node_suite_test.go
@@ -46,6 +46,7 @@ import (
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2econfig "k8s.io/kubernetes/test/e2e/framework/config"
 	e2etestfiles "k8s.io/kubernetes/test/e2e/framework/testfiles"
+	e2etestingmanifests "k8s.io/kubernetes/test/e2e/testing-manifests"
 	"k8s.io/kubernetes/test/e2e_node/services"
 	e2enodetestingmanifests "k8s.io/kubernetes/test/e2e_node/testing-manifests"
 	system "k8s.io/system-validators/validators"
@@ -93,6 +94,7 @@ func registerNodeFlags(flags *flag.FlagSet) {
 
 func init() {
 	// Enable embedded FS file lookup as fallback
+	e2etestfiles.AddFileSource(e2etestingmanifests.GetE2ETestingManifestsFS())
 	e2etestfiles.AddFileSource(e2enodetestingmanifests.GetE2ENodeTestingManifestsFS())
 }
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind failing-test

#### What this PR does / why we need it:

The test `pull-kubernetes-node-kubelet-serial` is failing (https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/103743/pull-kubernetes-node-kubelet-serial/1417899241208025088/) because a test manifest cannot be found. 

https://github.com/kubernetes/kubernetes/pull/103743 is blocked on this.

Ref: https://kubernetes.slack.com/archives/C0BP8PW9G/p1627003199187100?thread_ts=1626988113.184100&cid=C0BP8PW9G

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

None

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

None