### PR TITLE
Do not try to create an audit log file named "-"

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/server/options/audit.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/audit.go
@@ -511,21 +511,21 @@ func (o *AuditLogOptions) getWriter() (io.Writer, error) {
 		return nil, nil
 	}
 
-	if err := o.ensureLogFile(); err != nil {
-		return nil, err
+	if o.Path == "-" {
+		return os.Stdout, nil
 	}
 
-	var w io.Writer = os.Stdout
-	if o.Path != "-" {
-		w = &lumberjack.Logger{
-			Filename:   o.Path,
-			MaxAge:     o.MaxAge,
-			MaxBackups: o.MaxBackups,
-			MaxSize:    o.MaxSize,
-			Compress:   o.Compress,
-		}
+	if err := o.ensureLogFile(); err != nil {
+		return nil, fmt.Errorf("ensureLogFile: %w", err)
 	}
-	return w, nil
+
+	return &lumberjack.Logger{
+		Filename:   o.Path,
+		MaxAge:     o.MaxAge,
+		MaxBackups: o.MaxBackups,
+		MaxSize:    o.MaxSize,
+		Compress:   o.Compress,
+	}, nil
 }
 
 func (o *AuditLogOptions) ensureLogFile() error {


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind bug

#### What this PR does / why we need it:

Fixes --audit-log-path=- support.
It now logs to stdout as in 1.21.

This PR should be accredited to @AlekSi. I am merely creating the PR for him since there is an issue with his CLA.

```release-note
Fixes a regression setting --audit-log-path=- to log to stdout in 1.22 pre-release builds
```