### PR TITLE
Leader election support network partitions

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/api/errors/errors.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/errors/errors.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net"
 	"net/http"
 	"reflect"
 	"strings"
@@ -622,6 +623,15 @@ func IsUnexpectedServerError(err error) bool {
 func IsUnexpectedObjectError(err error) bool {
 	uoe := &UnexpectedObjectError{}
 	return err != nil && errors.As(err, &uoe)
+}
+
+// IsNetworkError determines if err is due to a network connectivity problem.
+func IsNetworkError(err error) bool {
+	if err == nil {
+		return false
+	}
+	_, ok := err.(net.Error)
+	return ok
 }
 
 // SuggestsClientDelay returns true if this error suggests a client delay as well as the


### PR DESCRIPTION
/kind feature
/kind design


#### What this PR does / why we need it:

Add a new TolerateNetworkPartition option, so the leader doesn't stop leading if is not able
to renew the lock because of network problems. Most likely, the consumer
of the library should not be able to reach the apiserver too, so it should
handle the network problems, but in this case, it will not be affected by
the OnStoppedLeadingcallback.
On the connection is restored, it can happen that there are multiple leaders
until the new election happens again.


```release-note
client-go leaderelection: add new option to tolerate network failures. If the leader is isolated due to network problems, it assumes it is still the leader, and doesn't execute the OnStopLeading callback
```

