### PR TITLE
Cache rest mapper and discovery client

### DIFF
--- a/staging/src/k8s.io/cli-runtime/pkg/resource/builder.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/resource/builder.go
@@ -212,7 +212,7 @@ func NewBuilder(restClientGetter RESTClientGetter) *Builder {
 
 	return newBuilder(
 		restClientGetter.ToRESTConfig,
-		(&cachingRESTMapperFunc{delegate: restClientGetter.ToRESTMapper}).ToRESTMapper,
+		restClientGetter.ToRESTMapper,
 		(&cachingCategoryExpanderFunc{delegate: categoryExpanderFn}).ToCategoryExpander,
 	)
 }
@@ -1185,28 +1185,6 @@ func HasNames(args []string) (bool, error) {
 		return false, err
 	}
 	return hasCombinedTypes || len(args) > 1, nil
-}
-
-type cachingRESTMapperFunc struct {
-	delegate RESTMapperFunc
-
-	lock   sync.Mutex
-	cached meta.RESTMapper
-}
-
-func (c *cachingRESTMapperFunc) ToRESTMapper() (meta.RESTMapper, error) {
-	c.lock.Lock()
-	defer c.lock.Unlock()
-	if c.cached != nil {
-		return c.cached, nil
-	}
-
-	ret, err := c.delegate()
-	if err != nil {
-		return nil, err
-	}
-	c.cached = ret
-	return c.cached, nil
 }
 
 type cachingCategoryExpanderFunc struct {

--- a/staging/src/k8s.io/client-go/restmapper/discovery.go
+++ b/staging/src/k8s.io/client-go/restmapper/discovery.go
@@ -205,7 +205,7 @@ func (d *DeferredDiscoveryRESTMapper) getDelegate() (meta.RESTMapper, error) {
 	}
 
 	d.delegate = NewDiscoveryRESTMapper(groupResources)
-	return d.delegate, err
+	return d.delegate, nil
 }
 
 // Reset resets the internally cached Discovery information and will


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/sig cli
/sig api-machinery

#### What this PR does / why we need it:

Rest mapper and discovery client are both stateful so it is beneficial for performance to cache them:
- One place where rest mapper is cached is being removed in this PR, another example is in [`cli-utils`](https://github.com/kubernetes-sigs/cli-utils/blob/8ccd6e63e141f1a24025cb453d51644c6d31ecce/pkg/util/factory/clientgetter.go#L16-L46). Makes sense to just cache it for all library code users. Rest mapper contains prepared mappings it got from discovery client. No need to re-prepare the mappings, can just share the mapper.
- Discovery client [tracks which files were created by this process](https://github.com/kubernetes/kubernetes/blob/47e1df8f4e86af1904ec9b3ecf427e1f1178be6e/staging/src/k8s.io/client-go/discovery/cached/disk/cached_discovery.go#L54). Makes sense to have a single instance for the whole process. Also, invalidation/freshness state.

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

I was trying to understand why `kubectl` makes 125 API calls for a simple `get pods` command. Turned out the directory was not writable and cache for discovery info was not working. Discovery retrieves the data 3 times hence so many calls (i.e. should be a third). Do we want to cache discovery in memory in addition to caching on disk for situations like this (container with read-only fs in my case)?

I wasn't able to reduce the number of API calls with this change, but I think this PR makes sense anyway. I can send a follow up with in-memory caching.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
