### PR TITLE
kube-apiserver: allow mutation of PersistentVolumeSource in PersistentVolume

### DIFF
--- a/cmd/kube-apiserver/app/options/options.go
+++ b/cmd/kube-apiserver/app/options/options.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/component-base/metrics"
 
 	api "k8s.io/kubernetes/pkg/apis/core"
+	"k8s.io/kubernetes/pkg/apis/core/validation"
 	"k8s.io/kubernetes/pkg/cluster/ports"
 	"k8s.io/kubernetes/pkg/controlplane/reconcilers"
 	_ "k8s.io/kubernetes/pkg/features" // add the kubernetes feature gates
@@ -270,6 +271,9 @@ func (s *ServerRunOptions) Flags() (fss cliflag.NamedFlagSets) {
 
 	fs.StringVar(&s.ServiceAccountSigningKeyFile, "service-account-signing-key-file", s.ServiceAccountSigningKeyFile, ""+
 		"Path to the file that contains the current private key of the service account token issuer. The issuer will sign issued ID tokens with this private key.")
+
+	// allow mutation of persistent volumes sources
+	fs.BoolVar(&validation.MutablePersistentVolumeSource, "mutable-persistent-volume-source", false, "allow mutation of PersistentVolumeSource in PersistentVolume")
 
 	return fss
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/kind api-change

#### What this PR does / why we need it:

Adds a flag to allow mutation of PersistentVolumeSource in PersistentVolume. Just a flag so it's only a temporary activation while doing an "expert fix".

#### Which issue(s) this PR fixes:

Fixes #70047 and probably others.

```release-note
kube-apiserver: add a flag to allow mutation of PersistentVolumeSource in PersistentVolume
```