### PR TITLE
sysctl-test: use status reason check instead of events check

### DIFF
--- a/test/e2e/framework/pod/wait.go
+++ b/test/e2e/framework/pod/wait.go
@@ -547,3 +547,21 @@ func WaitForPodContainerToFail(c clientset.Interface, namespace, podName string,
 func WaitForPodContainerStarted(c clientset.Interface, namespace, podName string, containerIndex int, timeout time.Duration) error {
 	return wait.PollImmediate(poll, timeout, podContainerStarted(c, namespace, podName, containerIndex))
 }
+
+// WaitForPodFailedReason wait for pod failed reason in status, for example "SysctlForbidden".
+func WaitForPodFailedReason(c clientset.Interface, pod *v1.Pod, reason string, timeout time.Duration) error {
+	waitErr := wait.PollImmediate(poll, timeout, func() (bool, error) {
+		pod, err := c.CoreV1().Pods(pod.Namespace).Get(context.TODO(), pod.Name, metav1.GetOptions{})
+		if err != nil {
+			return false, err
+		}
+		if pod.Status.Reason == reason {
+			return true, nil
+		}
+		return false, nil
+	})
+	if waitErr != nil {
+		return fmt.Errorf("error waiting for pod SysctlForbidden status: %v", waitErr)
+	}
+	return nil
+}


### PR DESCRIPTION
/kind bug
/sig node
/cc ehashman @mmiranda96 SergeyKanzhelev

follow up of #101190
1. unsafe sysctl should not be conformance testing: this is done in #103827
2. unsafe sysctl test case is testing `safe sysctl` which is not correct and dup with the case below. So I remove it in this PR.
3. Currently `should forbid unsafe sysctls` is using event check, it should use pod/container status check instead.

```release-note
NONE
```