### PR TITLE
Automated cherry pick of #101542: sched: make CycleState's Read()/Write()/Delete() thread-safe

### DIFF
--- a/pkg/scheduler/framework/plugins/examples/multipoint/multipoint.go
+++ b/pkg/scheduler/framework/plugins/examples/multipoint/multipoint.go
@@ -56,9 +56,7 @@ func (mc CommunicatingPlugin) Reserve(ctx context.Context, state *framework.Cycl
 		return framework.NewStatus(framework.Error, "pod cannot be nil")
 	}
 	if pod.Name == "my-test-pod" {
-		state.Lock()
 		state.Write(framework.StateKey(pod.Name), &stateData{data: "never bind"})
-		state.Unlock()
 	}
 	return nil
 }
@@ -67,12 +65,10 @@ func (mc CommunicatingPlugin) Reserve(ctx context.Context, state *framework.Cycl
 // during "reserve" extension point or later.
 func (mc CommunicatingPlugin) Unreserve(ctx context.Context, state *framework.CycleState, pod *v1.Pod, nodeName string) {
 	if pod.Name == "my-test-pod" {
-		state.Lock()
 		// The pod is at the end of its lifecycle -- let's clean up the allocated
 		// resources. In this case, our clean up is simply deleting the key written
 		// in the Reserve operation.
 		state.Delete(framework.StateKey(pod.Name))
-		state.Unlock()
 	}
 }
 
@@ -81,8 +77,6 @@ func (mc CommunicatingPlugin) PreBind(ctx context.Context, state *framework.Cycl
 	if pod == nil {
 		return framework.NewStatus(framework.Error, "pod cannot be nil")
 	}
-	state.RLock()
-	defer state.RUnlock()
 	if v, e := state.Read(framework.StateKey(pod.Name)); e == nil {
 		if value, ok := v.(*stateData); ok && value.data == "never bind" {
 			return framework.NewStatus(framework.Unschedulable, "pod is not permitted")


### PR DESCRIPTION
Cherry pick of #101542 on release-1.20.

#101542: sched: make CycleState's Read()/Write()/Delete() thread-safe

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.