### PR TITLE
Delete all terminating pods attached to a not-ready node

### DIFF
--- a/api/api-rules/violation_exceptions.list
+++ b/api/api-rules/violation_exceptions.list
@@ -593,6 +593,7 @@ API rule violation: names_match,k8s.io/kube-controller-manager/config/v1alpha1,P
 API rule violation: names_match,k8s.io/kube-controller-manager/config/v1alpha1,PersistentVolumeRecyclerConfiguration,MinimumTimeoutNFS
 API rule violation: names_match,k8s.io/kube-controller-manager/config/v1alpha1,PersistentVolumeRecyclerConfiguration,PodTemplateFilePathHostPath
 API rule violation: names_match,k8s.io/kube-controller-manager/config/v1alpha1,PersistentVolumeRecyclerConfiguration,PodTemplateFilePathNFS
+API rule violation: names_match,k8s.io/kube-controller-manager/config/v1alpha1,PodGCControllerConfiguration,DeleteUnreachableTerminatingPods
 API rule violation: names_match,k8s.io/kube-controller-manager/config/v1alpha1,PodGCControllerConfiguration,TerminatedPodGCThreshold
 API rule violation: names_match,k8s.io/kube-controller-manager/config/v1alpha1,ReplicaSetControllerConfiguration,ConcurrentRSSyncs
 API rule violation: names_match,k8s.io/kube-controller-manager/config/v1alpha1,ReplicationControllerConfiguration,ConcurrentRCSyncs

--- a/cmd/kube-controller-manager/app/core.go
+++ b/cmd/kube-controller-manager/app/core.go
@@ -435,6 +435,7 @@ func startPodGCController(ctx ControllerContext) (http.Handler, bool, error) {
 		ctx.InformerFactory.Core().V1().Pods(),
 		ctx.InformerFactory.Core().V1().Nodes(),
 		int(ctx.ComponentConfig.PodGCController.TerminatedPodGCThreshold),
+		ctx.ComponentConfig.PodGCController.DeleteUnreachableTerminatingPods,
 	).Run(ctx.Stop)
 	return nil, true, nil
 }

--- a/cmd/kube-controller-manager/app/options/options_test.go
+++ b/cmd/kube-controller-manager/app/options/options_test.go
@@ -364,7 +364,8 @@ func TestAddFlags(t *testing.T) {
 		},
 		PodGCController: &PodGCControllerOptions{
 			&podgcconfig.PodGCControllerConfiguration{
-				TerminatedPodGCThreshold: 12000,
+				TerminatedPodGCThreshold:         12000,
+				DeleteUnreachableTerminatingPods: false,
 			},
 		},
 		ReplicaSetController: &ReplicaSetControllerOptions{
@@ -604,7 +605,8 @@ func TestApplyTo(t *testing.T) {
 				VolumeHostAllowLocalLoopback: false,
 			},
 			PodGCController: podgcconfig.PodGCControllerConfiguration{
-				TerminatedPodGCThreshold: 12000,
+				TerminatedPodGCThreshold:         12000,
+				DeleteUnreachableTerminatingPods: false,
 			},
 			ReplicaSetController: replicasetconfig.ReplicaSetControllerConfiguration{
 				ConcurrentRSSyncs: 10,

--- a/cmd/kube-controller-manager/app/options/podgccontroller.go
+++ b/cmd/kube-controller-manager/app/options/podgccontroller.go
@@ -34,6 +34,7 @@ func (o *PodGCControllerOptions) AddFlags(fs *pflag.FlagSet) {
 	}
 
 	fs.Int32Var(&o.TerminatedPodGCThreshold, "terminated-pod-gc-threshold", o.TerminatedPodGCThreshold, "Number of terminated pods that can exist before the terminated pod garbage collector starts deleting terminated pods. If <= 0, the terminated pod garbage collector is disabled.")
+	fs.BoolVar(&o.DeleteUnreachableTerminatingPods, "delete-unreachable-terminating-pods", o.DeleteUnreachableTerminatingPods, "When set to 'true', termimating pods attached to a not-ready node will be garbage collected without waiting for the node to come back. Use wisely.")
 }
 
 // ApplyTo fills up PodGCController config with options.
@@ -43,6 +44,7 @@ func (o *PodGCControllerOptions) ApplyTo(cfg *podgcconfig.PodGCControllerConfigu
 	}
 
 	cfg.TerminatedPodGCThreshold = o.TerminatedPodGCThreshold
+	cfg.DeleteUnreachableTerminatingPods = o.DeleteUnreachableTerminatingPods
 
 	return nil
 }

--- a/pkg/controller/podgc/config/types.go
+++ b/pkg/controller/podgc/config/types.go
@@ -22,4 +22,8 @@ type PodGCControllerConfiguration struct {
 	// before the terminated pod garbage collector starts deleting terminated pods.
 	// If <= 0, the terminated pod garbage collector is disabled.
 	TerminatedPodGCThreshold int32
+	// When set to 'true', all terminating pods attached to a node which is not ready
+	// are are garbage collected. With setting this flag, such pods would stay forever
+	// until dead node comes back in the game.
+	DeleteUnreachableTerminatingPods bool
 }

--- a/pkg/controller/podgc/config/v1alpha1/defaults.go
+++ b/pkg/controller/podgc/config/v1alpha1/defaults.go
@@ -18,6 +18,7 @@ package v1alpha1
 
 import (
 	kubectrlmgrconfigv1alpha1 "k8s.io/kube-controller-manager/config/v1alpha1"
+	utilpointer "k8s.io/utils/pointer"
 )
 
 // RecommendedDefaultPodGCControllerConfiguration defaults a pointer to a
@@ -32,5 +33,9 @@ import (
 func RecommendedDefaultPodGCControllerConfiguration(obj *kubectrlmgrconfigv1alpha1.PodGCControllerConfiguration) {
 	if obj.TerminatedPodGCThreshold == 0 {
 		obj.TerminatedPodGCThreshold = 12500
+	}
+
+	if obj.DeleteUnreachableTerminatingPods == nil {
+		obj.DeleteUnreachableTerminatingPods = utilpointer.BoolPtr(false)
 	}
 }

--- a/pkg/controller/testutil/test_utils.go
+++ b/pkg/controller/testutil/test_utils.go
@@ -472,6 +472,13 @@ func NewNode(name string) *v1.Node {
 	}
 }
 
+// NewNodeWithConditions is a helper function for creating Nodes for testing.
+func NewNodeWithConditions(name string, conditions []v1.NodeCondition) *v1.Node {
+	node := NewNode(name)
+	node.Status.Conditions = conditions
+	return node
+}
+
 // NewPod is a helper function for creating Pods for testing.
 func NewPod(name, host string) *v1.Pod {
 	pod := &v1.Pod{

--- a/staging/src/k8s.io/kube-controller-manager/config/v1alpha1/types.go
+++ b/staging/src/k8s.io/kube-controller-manager/config/v1alpha1/types.go
@@ -426,6 +426,10 @@ type PodGCControllerConfiguration struct {
 	// before the terminated pod garbage collector starts deleting terminated pods.
 	// If <= 0, the terminated pod garbage collector is disabled.
 	TerminatedPodGCThreshold int32
+	// When set to 'true', all terminating pods attached to a node which is not ready
+	// are are garbage collected. With setting this flag, such pods would stay forever
+	// until dead node comes back in the game.
+	DeleteUnreachableTerminatingPods *bool
 }
 
 // ReplicaSetControllerConfiguration contains elements describing ReplicaSetController.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

This PR allows to delete all terminating pods which are attached to not-ready nodes.
The main reason to introduce this change is that when a node dies, its pods remain in terminating state until it comes back. Should the node be dead and unrecoverable and some pods be attached to PV with ReadWriteOnce access mode, volume is stuck forever as well at its attached pod, thus preventing any other pod from handing over.

This option is probably more relevant in embedded environments, with no human interaction possible, to bring high availability no matter a node is dying or not.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
N/A

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
This PR introduces the new option --delete-unreachable-terminating-pods for kube-controller-manager, which, when enabled, deletes all terminatig pods running on a not-ready node. 
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
