### PR TITLE
Allow customizing spam filtering in event client library

### DIFF
--- a/staging/src/k8s.io/client-go/tools/record/event.go
+++ b/staging/src/k8s.io/client-go/tools/record/event.go
@@ -82,6 +82,9 @@ type CorrelatorOptions struct {
 	// The clock used by the EventAggregator to allow for testing
 	// If not specified (zero value), clock.RealClock{} will be used
 	Clock clock.Clock
+	// The func used by EventFilterFunc, which returns a key for given event, based on which filtering will take place
+	// If not specified (zero value), getSpamKey will be used
+	SpamKeyFunc EventSpamKeyFunc
 }
 
 // EventRecorder knows how to record events on behalf of an EventSource.

--- a/staging/src/k8s.io/client-go/tools/record/events_cache.go
+++ b/staging/src/k8s.io/client-go/tools/record/events_cache.go
@@ -81,6 +81,9 @@ func getSpamKey(event *v1.Event) string {
 		"")
 }
 
+// EventSpamKeyFunc is a function that returns unique key based on provided event
+type EventSpamKeyFunc func(event *v1.Event) string
+
 // EventFilterFunc is a function that returns true if the event should be skipped
 type EventFilterFunc func(event *v1.Event) bool
 
@@ -100,15 +103,19 @@ type EventSourceObjectSpamFilter struct {
 
 	// clock is used to allow for testing over a time interval
 	clock clock.Clock
+
+	// spamKeyFunc is a func used to create a key based on an event, which is later used to filter spam events.
+	spamKeyFunc EventSpamKeyFunc
 }
 
 // NewEventSourceObjectSpamFilter allows burst events from a source about an object with the specified qps refill.
-func NewEventSourceObjectSpamFilter(lruCacheSize, burst int, qps float32, clock clock.Clock) *EventSourceObjectSpamFilter {
+func NewEventSourceObjectSpamFilter(lruCacheSize, burst int, qps float32, clock clock.Clock, spamKeyFunc EventSpamKeyFunc) *EventSourceObjectSpamFilter {
 	return &EventSourceObjectSpamFilter{
-		cache: lru.New(lruCacheSize),
-		burst: burst,
-		qps:   qps,
-		clock: clock,
+		cache:       lru.New(lruCacheSize),
+		burst:       burst,
+		qps:         qps,
+		clock:       clock,
+		spamKeyFunc: spamKeyFunc,
 	}
 }
 
@@ -122,8 +129,8 @@ type spamRecord struct {
 func (f *EventSourceObjectSpamFilter) Filter(event *v1.Event) bool {
 	var record spamRecord
 
-	// controls our cached information about this event (source+object)
-	eventKey := getSpamKey(event)
+	// controls our cached information about this event
+	eventKey := f.spamKeyFunc(event)
 
 	// do we have a record of similar events in our cache?
 	f.Lock()
@@ -431,7 +438,7 @@ type EventCorrelateResult struct {
 //     per object of 1 event every 5 minutes to control long-tail of spam.
 func NewEventCorrelator(clock clock.Clock) *EventCorrelator {
 	cacheSize := maxLruCacheEntries
-	spamFilter := NewEventSourceObjectSpamFilter(cacheSize, defaultSpamBurst, defaultSpamQPS, clock)
+	spamFilter := NewEventSourceObjectSpamFilter(cacheSize, defaultSpamBurst, defaultSpamQPS, clock, getSpamKey)
 	return &EventCorrelator{
 		filterFunc: spamFilter.Filter,
 		aggregator: NewEventAggregator(
@@ -448,8 +455,12 @@ func NewEventCorrelator(clock clock.Clock) *EventCorrelator {
 
 func NewEventCorrelatorWithOptions(options CorrelatorOptions) *EventCorrelator {
 	optionsWithDefaults := populateDefaults(options)
-	spamFilter := NewEventSourceObjectSpamFilter(optionsWithDefaults.LRUCacheSize,
-		optionsWithDefaults.BurstSize, optionsWithDefaults.QPS, optionsWithDefaults.Clock)
+	spamFilter := NewEventSourceObjectSpamFilter(
+		optionsWithDefaults.LRUCacheSize,
+		optionsWithDefaults.BurstSize,
+		optionsWithDefaults.QPS,
+		optionsWithDefaults.Clock,
+		optionsWithDefaults.SpamKeyFunc)
 	return &EventCorrelator{
 		filterFunc: spamFilter.Filter,
 		aggregator: NewEventAggregator(
@@ -488,6 +499,9 @@ func populateDefaults(options CorrelatorOptions) CorrelatorOptions {
 	}
 	if options.Clock == nil {
 		options.Clock = clock.RealClock{}
+	}
+	if options.SpamKeyFunc == nil {
+		options.SpamKeyFunc = getSpamKey
 	}
 	return options
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature


#### What this PR does / why we need it:

**Current implementation**
Event client library has aggregation and spam filtering implemented. While aggregation can be fully customized,  spam filtering functionality doesn't allow overriding spamKey func - function that is responsible for creating a key (based on an event) which is used to detect "spam" events. Currently used `getSpamKey()` function takes into account `Source` and `InvolvedObject` of an event. Per each such key `BurstSize` events can be sent.

**Changes in PR**
Allow customizing spamKey func in `CorrelatorOptions` of `EventCorrelator`. 

**Why allow customizing spamKey func?**
For some use cases it can be useful to also include for example `Reason` field of an event in spamKey. For example, if we have `n` normal events for a specific Object with the same reason and `n+1`-th event is e.g warning with a different reason we would like to have it emitted, while filtering n-1 normal events. 

This PR does not change default behavior and doesn't introduce any breaking change. Current users of client library won't experience any change, unless they explicitly modify `CorrelatorOptions`.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
None

#### Does this PR introduce a user-facing change?
```release-note
Client-go event library allows customizing spam filtering function. 
It is now possible to override `SpamKeyFunc`, which is used by event filtering to detect spam in the events.
```

/cc @serathius @dashpole @logicalhan 
/sig instrumentation