### PR TITLE
Feature: Add StrictCPUReservation option in static cpu policy

### DIFF
--- a/api/api-rules/violation_exceptions.list
+++ b/api/api-rules/violation_exceptions.list
@@ -612,5 +612,6 @@ API rule violation: names_match,k8s.io/kube-scheduler/config/v1,LegacyExtender,E
 API rule violation: names_match,k8s.io/kubelet/config/v1beta1,KubeletConfiguration,IPTablesDropBit
 API rule violation: names_match,k8s.io/kubelet/config/v1beta1,KubeletConfiguration,IPTablesMasqueradeBit
 API rule violation: names_match,k8s.io/kubelet/config/v1beta1,KubeletConfiguration,ResolverConfig
+API rule violation: names_match,k8s.io/kubelet/config/v1beta1,KubeletConfiguration,StrictCPUReservation
 API rule violation: names_match,k8s.io/metrics/pkg/apis/custom_metrics/v1beta1,MetricValue,WindowSeconds
 API rule violation: names_match,k8s.io/metrics/pkg/apis/external_metrics/v1beta1,ExternalMetricValue,WindowSeconds

--- a/cmd/kubelet/app/server.go
+++ b/cmd/kubelet/app/server.go
@@ -762,6 +762,7 @@ func run(ctx context.Context, s *options.KubeletServer, kubeDeps *kubelet.Depend
 					KubeReserved:             kubeReserved,
 					SystemReserved:           systemReserved,
 					ReservedSystemCPUs:       reservedSystemCPUs,
+					StrictCPUReservation:	  s.StrictCPUReservation,
 					HardEvictionThresholds:   hardEvictionThresholds,
 				},
 				QOSReserved:                             *experimentalQOSReserved,

--- a/pkg/kubelet/apis/config/helpers_test.go
+++ b/pkg/kubelet/apis/config/helpers_test.go
@@ -234,6 +234,7 @@ var (
 		"ReservedMemory[*].Limits[*].s",
 		"ReservedMemory[*].NumaNode",
 		"ReservedSystemCPUs",
+		"StrictCPUReservation",
 		"RuntimeRequestTimeout.Duration",
 		"RunOnce",
 		"SeccompDefault",

--- a/pkg/kubelet/apis/config/types.go
+++ b/pkg/kubelet/apis/config/types.go
@@ -375,6 +375,9 @@ type KubeletConfiguration struct {
 	// This provide a "static" CPU list rather than the "dynamic" list by system-reserved and kube-reserved.
 	// This option overwrites CPUs provided by system-reserved and kube-reserved.
 	ReservedSystemCPUs string
+	// This flag enabled option of strict cpu reservation of pods.
+	// When enabled cpuset list removes ReservedSystemCPUs cpus from topology for non-guaranteed pods.
+	StrictCPUReservation bool
 	// The previous version for which you want to show hidden metrics.
 	// Only the previous minor version is meaningful, other values will not be allowed.
 	// The format is <major>.<minor>, e.g.: '1.16'.

--- a/pkg/kubelet/apis/config/v1beta1/zz_generated.conversion.go
+++ b/pkg/kubelet/apis/config/v1beta1/zz_generated.conversion.go
@@ -362,6 +362,7 @@ func autoConvert_v1beta1_KubeletConfiguration_To_config_KubeletConfiguration(in 
 	out.SystemReserved = *(*map[string]string)(unsafe.Pointer(&in.SystemReserved))
 	out.KubeReserved = *(*map[string]string)(unsafe.Pointer(&in.KubeReserved))
 	out.ReservedSystemCPUs = in.ReservedSystemCPUs
+	out.StrictCPUReservation = in.StrictCPUReservation
 	out.ShowHiddenMetricsForVersion = in.ShowHiddenMetricsForVersion
 	out.SystemReservedCgroup = in.SystemReservedCgroup
 	out.KubeReservedCgroup = in.KubeReservedCgroup
@@ -538,6 +539,7 @@ func autoConvert_config_KubeletConfiguration_To_v1beta1_KubeletConfiguration(in 
 	out.KubeReservedCgroup = in.KubeReservedCgroup
 	out.EnforceNodeAllocatable = *(*[]string)(unsafe.Pointer(&in.EnforceNodeAllocatable))
 	out.ReservedSystemCPUs = in.ReservedSystemCPUs
+	out.StrictCPUReservation = in.StrictCPUReservation
 	out.ShowHiddenMetricsForVersion = in.ShowHiddenMetricsForVersion
 	if err := v1alpha1.Convert_config_LoggingConfiguration_To_v1alpha1_LoggingConfiguration(&in.Logging, &out.Logging, s); err != nil {
 		return err

--- a/pkg/kubelet/cm/container_manager.go
+++ b/pkg/kubelet/cm/container_manager.go
@@ -149,6 +149,7 @@ type NodeAllocatableConfig struct {
 	KubeReservedCgroupName   string
 	SystemReservedCgroupName string
 	ReservedSystemCPUs       cpuset.CPUSet
+	StrictCPUReservation	 bool
 	EnforceNodeAllocatable   sets.String
 	KubeReserved             v1.ResourceList
 	SystemReserved           v1.ResourceList

--- a/pkg/kubelet/cm/container_manager_linux.go
+++ b/pkg/kubelet/cm/container_manager_linux.go
@@ -339,6 +339,7 @@ func NewContainerManager(mountUtil mount.Interface, cadvisorInterface cadvisor.I
 			cm.GetNodeAllocatableReservation(),
 			nodeConfig.KubeletRootDir,
 			cm.topologyManager,
+			nodeConfig.NodeAllocatableConfig.StrictCPUReservation,
 		)
 		if err != nil {
 			klog.ErrorS(err, "Failed to initialize cpu manager")

--- a/staging/src/k8s.io/kubelet/config/v1beta1/types.go
+++ b/staging/src/k8s.io/kubelet/config/v1beta1/types.go
@@ -886,6 +886,11 @@ type KubeletConfiguration struct {
 	// CPU list rather than the "dynamic" list by systemReserved and kubeReserved.
 	// This option does not support systemReservedCgroup or kubeReservedCgroup.
 	ReservedSystemCPUs string `json:"reservedSystemCPUs,omitempty"`
+	// This flag enabled option of strict cpu reservation of pods. When enabled
+	// cpuset list removes ReservedSystemCPUs cpus from topology for non-guaranteed pods.
+	// Default: false
+	// +optional
+	StrictCPUReservation bool `json:"strictCPUReservation,omitempty"`
 	// showHiddenMetricsForVersion is the previous version for which you want to show
 	// hidden metrics.
 	// Only the previous minor version is meaningful, other values will not be allowed.


### PR DESCRIPTION
#### What type of PR is this?
/kind feature
/kind api-change

#### What this PR does / why we need it:
In some situations, a static CPU policy is used to reduce latency or improve performance. If you want to move system daemons or interrupt processing to dedicated cores, the oblivious way is use ReservedSystemCPUs option. But in current implementation of cpu policies this isolation is impossible. In static policy this option taken into account only for guaranteed pods.
In case of policy none we can set cpuset.cpus option for whole kubelet cgroup by third-party methods, but static policy uses topology as DefaultCPUSet var. When we try set cpuset option in root kubelet cgroup, with static policy we receive error on container creating, like this:
`Warning  Failed     12s (x2 over 13s)  kubelet            Error: failed to create containerd task: OCI runtime create failed: container_linux.go:370: starting container process caused: process_linux.go:326: applying cgroup configuration for process caused: failed to write "0-7,9,11,13,15,17,19,21,23,25,27,29,31,33,35,37-55,57,59,61,63,65,67,69,71,73,75,77,79,81,83,85-95" to "/sys/fs/cgroup/cpuset/kubepods/burstable/pod83aefcf5-4e06-45b5-9ba1-95d6557f0823/file-d/cpuset.cpus": write /sys/fs/cgroup/cpuset/kubepods/burstable/pod83aefcf5-4e06-45b5-9ba1-95d6557f0823/file-d/cpuset.cpus: permission denied: unknown`

This PR introduces **strictCPUReservation** flag in kubelet config. It is used with static CPU policy and explicitly configured ReservedSystemCPUs option, and removes reserved cores from the list of all available cores at the stage of calculation DefaultCPUSet. As a result, Burstable and BestEffort containers are launched with a cpuset in which reserved cores are excluded.

#### Which issue(s) this PR fixes:
Fixes #104147

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
Added strict CPU reservation option in static CPU policy.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs

```
