### PR TITLE
staging/publishing: fix rules for legacy-cloud-providers for 1.22

### DIFF
--- a/staging/publishing/rules.yaml
+++ b/staging/publishing/rules.yaml
@@ -1660,7 +1660,8 @@ rules:
       branch: release-1.22
     - repository: controller-manager
       branch: release-1.22
-
+    - repository: mount-utils
+      branch: release-1.22
 
 - destination: cri-api
   library: true


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

The mount-utils repo is a [dependency](https://github.com/kubernetes/kubernetes/blob/release-1.22/staging/src/k8s.io/legacy-cloud-providers/go.mod#L56) for legacy-cloud-providers but got missed from the rules.

#### Which issue(s) this PR fixes:

This PR fixes the currently broken publishing bot - https://github.com/kubernetes/kubernetes/issues/56876#issuecomment-887259900

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

/assign @palnabarun 