### PR TITLE
WIP: e2e: cpumanager: make the assertions less fragile

### DIFF
--- a/test/e2e_node/topology_manager_test.go
+++ b/test/e2e_node/topology_manager_test.go
@@ -383,7 +383,7 @@ func runTopologyManagerPolicySuiteTests(f *framework.Framework) {
 	}
 
 	ginkgo.By("running a Gu pod requesting multiple CPUs")
-	runMultipleCPUGuPod(f)
+	runGuPodTest(f, 2)
 
 	ginkgo.By("running a Gu pod with multiple containers requesting integer CPUs")
 	runMultipleCPUContainersGuPod(f)


### PR DESCRIPTION
/kind cleanup

#### What this PR does / why we need it:
Improve the e2e cpumanager test to use less fragile assertions, reducing the chances of future breakages or flakes

#### Which issue(s) this PR fixes:
Fixes https://github.com/kubernetes/kubernetes/issues/100145

#### Special notes for your reviewer:
still WIP

#### Does this PR introduce a user-facing change?
```release-note
NONE
```