### PR TITLE
Automated cherry pick of #103823: Make CSR cleaner tolerate objects with invalid

### DIFF
--- a/pkg/controller/certificates/cleaner/cleaner_test.go
+++ b/pkg/controller/certificates/cleaner/cleaner_test.go
@@ -194,6 +194,18 @@ func TestCleanerWithApprovedExpiredCSR(t *testing.T) {
 			},
 			[]string{"delete"},
 		},
+		{
+			"delete approved passed deadline unparseable",
+			metav1.NewTime(time.Now().Add(-1 * time.Minute)),
+			[]byte(`garbage`),
+			[]capi.CertificateSigningRequestCondition{
+				{
+					Type:           capi.CertificateApproved,
+					LastUpdateTime: metav1.NewTime(time.Now().Add(-2 * time.Hour)),
+				},
+			},
+			[]string{"delete"},
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
Cherry pick of #103823 on release-1.22.

#103823: Make CSR cleaner tolerate objects with invalid

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
Fixes an issue cleaning up CertificateSigningRequest objects with an unparseable `status.certificate` field
```
