### PR TITLE
Fix kubectl version unit test

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/version/version_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/version/version_test.go
@@ -23,11 +23,12 @@ import (
 	"github.com/spf13/cobra"
 
 	"k8s.io/cli-runtime/pkg/genericclioptions"
-	cmdutil "k8s.io/kubectl/pkg/cmd/util"
+	cmdtesting "k8s.io/kubectl/pkg/cmd/testing"
 )
 
-func TestNewCmdVersionWithoutConfigFile(t *testing.T) {
-	tf := cmdutil.NewFactory(&genericclioptions.ConfigFlags{})
+func TestNewCmdVersionClientVersion(t *testing.T) {
+	tf := cmdtesting.NewTestFactory().WithNamespace("test")
+	defer tf.Cleanup()
 	streams, _, buf, _ := genericclioptions.NewTestIOStreams()
 	o := NewOptions(streams)
 	if err := o.Complete(tf, &cobra.Command{}); err != nil {
@@ -36,10 +37,7 @@ func TestNewCmdVersionWithoutConfigFile(t *testing.T) {
 	if err := o.Validate(); err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
-	// FIXME soltysh:
-	// since we have defaulting to localhost:8080 in staging/src/k8s.io/client-go/tools/clientcmd/client_config.go#getDefaultServer
-	// we need to ignore the localhost:8080 server, when above gets removed this should be dropped too
-	if err := o.Run(); err != nil && !strings.Contains(err.Error(), "localhost:8080") {
+	if err := o.Run(); err != nil {
 		t.Errorf("Cannot execute version command: %v", err)
 	}
 	if !strings.Contains(buf.String(), "Client Version") {


### PR DESCRIPTION
#### What type of PR is this?

/kind failing-test

#### What this PR does / why we need it:

The `TestNewCmdVersionWithoutConfigFile` unit test currently relies on an API server. This causes the test to fail for developers that don't have a cluster configured.

This PR swaps out the cmd factory for a testing one that does not provide a discovery client. This causes the external request bits to be skipped.

https://github.com/kubernetes/kubernetes/blob/d92b788faa2521a937acc5fdcb66bfdb960dbd48/staging/src/k8s.io/kubectl/pkg/cmd/version/version.go#L123-L128

The external testing is currently accounted for in [e2e tests](https://github.com/kubernetes/kubernetes/blob/d92b788faa2521a937acc5fdcb66bfdb960dbd48/test/e2e/kubectl/kubectl.go#L1503).

#### Which issue(s) this PR fixes:

Fixes: #102754

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
