### PR TITLE
test: fix leaked goroutines in unit tests

### DIFF
--- a/pkg/kubelet/pluginmanager/operationexecutor/operation_executor_test.go
+++ b/pkg/kubelet/pluginmanager/operationexecutor/operation_executor_test.go
@@ -170,6 +170,10 @@ func setup() (chan interface{}, chan interface{}, OperationExecutor) {
 // This function starts by writing to ch and blocks on the quit channel
 // until it is closed by the currently running test
 func startOperationAndBlock(ch chan<- interface{}, quit <-chan interface{}) {
-	ch <- nil
-	<-quit
+	select {
+	case ch <- nil:
+		<-quit
+	case <-quit:
+		return
+	}
 }

--- a/pkg/util/goroutinemap/goroutinemap_test.go
+++ b/pkg/util/goroutinemap/goroutinemap_test.go
@@ -221,6 +221,7 @@ func Test_NewGoRoutineMap_Negative_SecondOpBeforeFirstCompletes(t *testing.T) {
 	grm := NewGoRoutineMap(false /* exponentialBackOffOnError */)
 	operationName := "operation-name"
 	operation1DoneCh := make(chan interface{}, 0 /* bufferSize */)
+	defer close(operation1DoneCh)
 	operation1 := generateWaitFunc(operation1DoneCh)
 	err1 := grm.Run(operationName, operation1)
 	if err1 != nil {
@@ -245,6 +246,7 @@ func Test_NewGoRoutineMap_Negative_SecondOpBeforeFirstCompletesWithExpBackoff(t 
 	grm := NewGoRoutineMap(true /* exponentialBackOffOnError */)
 	operationName := "operation-name"
 	operation1DoneCh := make(chan interface{}, 0 /* bufferSize */)
+	defer close(operation1DoneCh)
 	operation1 := generateWaitFunc(operation1DoneCh)
 	err1 := grm.Run(operationName, operation1)
 	if err1 != nil {
@@ -269,6 +271,7 @@ func Test_NewGoRoutineMap_Positive_ThirdOpAfterFirstCompletes(t *testing.T) {
 	grm := NewGoRoutineMap(false /* exponentialBackOffOnError */)
 	operationName := "operation-name"
 	operation1DoneCh := make(chan interface{}, 0 /* bufferSize */)
+	defer close(operation1DoneCh)
 	operation1 := generateWaitFunc(operation1DoneCh)
 	err1 := grm.Run(operationName, operation1)
 	if err1 != nil {
@@ -313,6 +316,7 @@ func Test_NewGoRoutineMap_Positive_ThirdOpAfterFirstCompletesWithExpBackoff(t *t
 	grm := NewGoRoutineMap(true /* exponentialBackOffOnError */)
 	operationName := "operation-name"
 	operation1DoneCh := make(chan interface{}, 0 /* bufferSize */)
+	defer close(operation1DoneCh)
 	operation1 := generateWaitFunc(operation1DoneCh)
 	err1 := grm.Run(operationName, operation1)
 	if err1 != nil {
@@ -396,6 +400,7 @@ func Test_NewGoRoutineMap_Positive_Wait(t *testing.T) {
 	grm := NewGoRoutineMap(false /* exponentialBackOffOnError */)
 	operationName := "operation-name"
 	operation1DoneCh := make(chan interface{}, 0 /* bufferSize */)
+	defer close(operation1DoneCh)
 	operation1 := generateWaitFunc(operation1DoneCh)
 	err := grm.Run(operationName, operation1)
 	if err != nil {
@@ -425,6 +430,7 @@ func Test_NewGoRoutineMap_Positive_WaitWithExpBackoff(t *testing.T) {
 	grm := NewGoRoutineMap(true /* exponentialBackOffOnError */)
 	operationName := "operation-name"
 	operation1DoneCh := make(chan interface{}, 0 /* bufferSize */)
+	defer close(operation1DoneCh)
 	operation1 := generateWaitFunc(operation1DoneCh)
 	err := grm.Run(operationName, operation1)
 	if err != nil {

--- a/pkg/volume/util/operationexecutor/operation_executor_test.go
+++ b/pkg/volume/util/operationexecutor/operation_executor_test.go
@@ -840,6 +840,10 @@ func setup() (chan interface{}, chan interface{}, OperationExecutor) {
 // This function starts by writing to ch and blocks on the quit channel
 // until it is closed by the currently running test
 func startOperationAndBlock(ch chan<- interface{}, quit <-chan interface{}) {
-	ch <- nil
-	<-quit
+	select {
+	case ch <- nil:
+		<-quit
+	case <-quit:
+		return
+	}
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

This PR fixes two potential leaked goroutine problems in unit tests.

***Problem in goroutinemap_test.go***
There are 6 unit tests in this file that create a child goroutine, which will be blocked at `<-operation1DoneCh`.
However, `<-operation1DoneCh` is not guaranteed to be unblocked, so the child goroutine may be blocked forever.
In 2 unit tests, `operation1DoneCh` never has send or close operation, and the child will always be blocked.
In 4 unit tests, `operation1DoneCh` has one send operation, but it may not be executed due to `t.Fatal()` branch before the send.

***Fix in goroutinemap_test.go***
This PR adds a `defer close(operation1DoneCh)` in the 6 unit tests. So no matter what happens, the child goroutine can be unblocked when the unit test passes or fails.

***Problem in pkg/kubelet/.../operation_executor_test.go and pkg/volume/.../operation_executor_test.go***
The two `startOperationAndBlock()` functions might cause similar problems in unit tests using them.
These unit tests create a child goroutine running `startOperationAndBlock()` that will be blocked at `ch <- nil`, and in the main goroutine, `<-ch` is in a select case and not guaranteed to execute. So the child goroutine may be leaked.

***Fix in pkg/kubelet/.../operation_executor_test.go and pkg/volume/.../operation_executor_test.go***
This PR replaces the `ch <- nil` with a select that can also unblock after `close(quit)`, which is guaranteed to happen in main goroutine.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
