### PR TITLE
Automated cherry pick of #103827: Remove conformance status from a sysctl test and relabel

### DIFF
--- a/test/conformance/testdata/conformance.yaml
+++ b/test/conformance/testdata/conformance.yaml
@@ -2181,7 +2181,7 @@
   release: v1.15
   file: test/e2e/common/node/security_context.go
 - testname: Sysctls, reject invalid sysctls
-  codename: '[sig-node] Sysctls [LinuxOnly] [NodeFeature:Sysctls] should reject invalid
+  codename: '[sig-node] Sysctls [LinuxOnly] [NodeConformance] should reject invalid
     sysctls [MinimumKubeletVersion:1.21] [Conformance]'
   description: 'Pod is created with one valid and two invalid sysctls. Pod should
     not apply invalid sysctls. [LinuxOnly]: This test is marked as LinuxOnly since
@@ -2189,19 +2189,11 @@
   release: v1.21
   file: test/e2e/common/node/sysctl.go
 - testname: Sysctl, test sysctls
-  codename: '[sig-node] Sysctls [LinuxOnly] [NodeFeature:Sysctls] should support sysctls
+  codename: '[sig-node] Sysctls [LinuxOnly] [NodeConformance] should support sysctls
     [MinimumKubeletVersion:1.21] [Conformance]'
   description: 'Pod is created with kernel.shm_rmid_forced sysctl. Kernel.shm_rmid_forced
     must be set to 1 [LinuxOnly]: This test is marked as LinuxOnly since Windows does
     not support sysctls'
-  release: v1.21
-  file: test/e2e/common/node/sysctl.go
-- testname: Sysctl, allow specified unsafe sysctls
-  codename: '[sig-node] Sysctls [LinuxOnly] [NodeFeature:Sysctls] should support unsafe
-    sysctls which are actually allowed [MinimumKubeletVersion:1.21] [Conformance]'
-  description: 'Pod is created with kernel.shm_rmid_forced. Should allow unsafe sysctls
-    that are specified. [LinuxOnly]: This test is marked as LinuxOnly since Windows
-    does not support sysctls'
   release: v1.21
   file: test/e2e/common/node/sysctl.go
 - testname: Environment variables, expansion

--- a/test/e2e/common/node/sysctl.go
+++ b/test/e2e/common/node/sysctl.go
@@ -31,7 +31,7 @@ import (
 	"github.com/onsi/gomega"
 )
 
-var _ = SIGDescribe("Sysctls [LinuxOnly] [NodeFeature:Sysctls]", func() {
+var _ = SIGDescribe("Sysctls [LinuxOnly] [NodeConformance]", func() {
 
 	ginkgo.BeforeEach(func() {
 		// sysctl is not supported on Windows.
@@ -118,7 +118,7 @@ var _ = SIGDescribe("Sysctls [LinuxOnly] [NodeFeature:Sysctls]", func() {
 	  Description: Pod is created with kernel.shm_rmid_forced. Should allow unsafe sysctls that are specified.
 	  [LinuxOnly]: This test is marked as LinuxOnly since Windows does not support sysctls
 	*/
-	framework.ConformanceIt("should support unsafe sysctls which are actually allowed [MinimumKubeletVersion:1.21]", func() {
+	ginkgo.It("should support unsafe sysctls which are actually allowed [MinimumKubeletVersion:1.21]", func() {
 		pod := testPod()
 		pod.Spec.SecurityContext = &v1.PodSecurityContext{
 			Sysctls: []v1.Sysctl{


### PR DESCRIPTION
Cherry pick of #103827 on release-1.22.

#103827: Remove conformance status from a sysctl test and relabel

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.