### PR TITLE
[WIP] Always allow evicting unready Pods

### DIFF
--- a/pkg/registry/core/pod/storage/eviction.go
+++ b/pkg/registry/core/pod/storage/eviction.go
@@ -297,7 +297,9 @@ func setPreconditionsResourceVersion(deleteOptions *metav1.DeleteOptions, resour
 // without checking PDBs.
 func canIgnorePDB(pod *api.Pod) bool {
 	if pod.Status.Phase == api.PodSucceeded || pod.Status.Phase == api.PodFailed ||
-		pod.Status.Phase == api.PodPending || !pod.ObjectMeta.DeletionTimestamp.IsZero() {
+		pod.Status.Phase == api.PodPending || !pod.ObjectMeta.DeletionTimestamp.IsZero() ||
+		// Unready pods are not accounted in the PDB, so they have to be freely evictable.
+		!podutil.IsPodReady(pod) {
 		return true
 	}
 	return false


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
We should always allow to evict unready pods as they are not accounted in the PDB and their deletion won't change the PDB state.

#### Which issue(s) this PR fixes:
Fixes #103970 

#### Does this PR introduce a user-facing change?
```release-note
PodDisruptionBudget now allows always evicting unready Pods.
```