### PR TITLE
[release-1.19] Allow deletion of unhealthy pods if enough healthy

### DIFF
--- a/pkg/registry/core/pod/storage/BUILD
+++ b/pkg/registry/core/pod/storage/BUILD
@@ -14,6 +14,7 @@ go_test(
     ],
     embed = [":go_default_library"],
     deps = [
+        "//pkg/api/pod:go_default_library",
         "//pkg/apis/core:go_default_library",
         "//pkg/apis/policy:go_default_library",
         "//pkg/registry/registrytest:go_default_library",


### PR DESCRIPTION
#### What type of PR is this?
backport of https://github.com/kubernetes/kubernetes/pull/94381

/kind bug

#### Which issue(s) this PR fixes:
Fixes #103970

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Unhealthy pods covered by PDBs can be successfully evicted if enough healthy pods are available.
```
