### PR TITLE
test images: Adds sync.exe to Windows agnhost images

### DIFF
--- a/test/images/agnhost/Dockerfile_windows
+++ b/test/images/agnhost/Dockerfile_windows
@@ -21,12 +21,15 @@ FROM --platform=linux/amd64 alpine:3.6 as prep
 
 ADD https://github.com/coredns/coredns/releases/download/v1.5.0/coredns_1.5.0_windows_amd64.tgz /coredns.tgz
 ADD https://iperf.fr/download/windows/iperf-2.0.9-win64.zip /iperf.zip
+ADD http://download.savannah.nongnu.org/releases/coreutils/windows-64bit-unsupported/coreutils-8.31-28-windows-64bit.zip /coreutils.zip
 
 # we're also creating an empty /uploads folder, which we're copying over to Windows  because
 # we can't RUN commands on a Windows image.
 RUN tar -xzvf /coredns.tgz &&\
     unzip iperf.zip &&\
     mv iperf-2.0.9-win64 iperf &&\
+    unzip coreutils.zip &&\
+    mv coreutils-8.31-28-windows-64bit wincoreutils &&\
     mkdir /uploads
 
 FROM --platform=linux/amd64 $REGISTRY/windows-servercore-cache:1.0-linux-amd64-$OS_VERSION as servercore-helper
@@ -44,6 +47,7 @@ FROM $BASEIMAGE
 COPY --from=servercore-helper /Windows/System32/netapi32.dll /Windows/System32/netapi32.dll
 COPY --from=prep /coredns.exe /coredns.exe
 COPY --from=prep /iperf /iperf
+COPY --from=prep /wincoreutils/sync.exe /bin/sync.exe
 
 # NOTE(claudiub): docker buildx sets the PATH env variable to a Linux-like PATH, which is not desirable.
 ENV PATH="C:\dig\;C:\bin\;C:\curl\;C:\Windows\system32;C:\Windows;C:\Program Files\PowerShell;"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind feature

/sig windows
/sig testing

/priority important-soon

#### What this PR does / why we need it:

We can get sync.exe from coreutils.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #101172

#### Special notes for your reviewer:

Built ``claudiubelu/agnhost:2.33`` with this PR:

```
docker run --rm --entrypoint sync.exe claudiubelu/agnhost:2.33 --help
Unable to find image 'claudiubelu/agnhost:2.33' locally
2.33: Pulling from claudiubelu/agnhost
ba17af31b927: Pull complete
...
7f46c3c5afe7: Pull complete
Digest: sha256:0e5869ae59ad8609b96d1e750205be6cb190fc59ee4ee648635f27d8dbd808fd
Status: Downloaded newer image for claudiubelu/agnhost:2.33
Usage: sync.exe [OPTION] [FILE]...
Synchronize cached writes to persistent storage

If one or more files are specified, sync only them,
or their containing file systems.

  -d, --data             sync only file data, no unneeded metadata
  -f, --file-system      sync the file systems that contain the files
      --help     display this help and exit
      --version  output version information and exit

GNU coreutils online help: <https://www.gnu.org/software/coreutils/>
Full documentation <https://www.gnu.org/software/coreutils/sync>
or available locally via: info '(coreutils) sync invocation'

This is an UNSUPPORTED, UNTESTED, EXPERIMENTAL build of GNU coreutils.
USE AT YOUR OWN RISK.
```


#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
