### PR TITLE
Automated cherry pick of #103865: Add e2e testing manifest bundle to e2e_node test suite

### DIFF
--- a/test/e2e_node/e2e_node_suite_test.go
+++ b/test/e2e_node/e2e_node_suite_test.go
@@ -46,6 +46,7 @@ import (
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2econfig "k8s.io/kubernetes/test/e2e/framework/config"
 	e2etestfiles "k8s.io/kubernetes/test/e2e/framework/testfiles"
+	e2etestingmanifests "k8s.io/kubernetes/test/e2e/testing-manifests"
 	"k8s.io/kubernetes/test/e2e_node/services"
 	e2enodetestingmanifests "k8s.io/kubernetes/test/e2e_node/testing-manifests"
 	system "k8s.io/system-validators/validators"
@@ -93,6 +94,7 @@ func registerNodeFlags(flags *flag.FlagSet) {
 
 func init() {
 	// Enable embedded FS file lookup as fallback
+	e2etestfiles.AddFileSource(e2etestingmanifests.GetE2ETestingManifestsFS())
 	e2etestfiles.AddFileSource(e2enodetestingmanifests.GetE2ENodeTestingManifestsFS())
 }
 


### PR DESCRIPTION
Cherry pick of #103865 on release-1.22.

#103865: Add e2e testing manifest bundle to e2e_node test suite

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.