### PR TITLE
Automated cherry pick of #103937: Fix disruptive subPath test failures

### DIFF
--- a/test/e2e/storage/drivers/csi.go
+++ b/test/e2e/storage/drivers/csi.go
@@ -235,9 +235,9 @@ func (h *hostpathCSIDriver) PrepareTest(f *framework.Framework) (*storageframewo
 			// testsuites/volumelimits.go `should support volume limits`
 			// test.
 			"--maxvolumespernode=10",
-			// Enable volume lifecycle checks, to report failure if
-			// the volume is not unpublished / unstaged correctly.
-			"--check-volume-lifecycle=true",
+			// Disable volume lifecycle checks due to issue #103651
+			// TODO: enable this check once issue is resolved for csi-host-path driver.
+			"--check-volume-lifecycle=false",
 		},
 		ProvisionerContainerName: "csi-provisioner",
 		SnapshotterContainerName: "csi-snapshotter",

--- a/test/e2e/storage/testsuites/subpath.go
+++ b/test/e2e/storage/testsuites/subpath.go
@@ -342,6 +342,11 @@ func (s *subPathTestSuite) DefineTests(driver storageframework.TestDriver, patte
 		init()
 		defer cleanup()
 
+		if strings.HasPrefix(driverName, "hostPath") {
+			// TODO: This skip should be removed once #61446 is fixed
+			e2eskipper.Skipf("Driver %s does not support reconstruction, skipping", driverName)
+		}
+
 		testSubpathReconstruction(f, l.hostExec, l.pod, false)
 	})
 


### PR DESCRIPTION
Cherry pick of #103937 on release-1.22.

#103937: Fix disruptive subPath test failures

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
NONE
```