### PR TITLE
[1.22.x] Automated cherry pick of #103958: Set idle and readheader timeouts

### DIFF
--- a/pkg/kubelet/server/server.go
+++ b/pkg/kubelet/server/server.go
@@ -151,6 +151,7 @@ func ListenAndServeKubeletServer(
 	s := &http.Server{
 		Addr:           net.JoinHostPort(address.String(), strconv.FormatUint(uint64(port), 10)),
 		Handler:        &handler,
+		IdleTimeout:    90 * time.Second, // matches http.DefaultTransport keep-alive timeout
 		ReadTimeout:    4 * 60 * time.Minute,
 		WriteTimeout:   4 * 60 * time.Minute,
 		MaxHeaderBytes: 1 << 20,
@@ -178,6 +179,9 @@ func ListenAndServeKubeletReadOnlyServer(host HostInterface, resourceAnalyzer st
 	server := &http.Server{
 		Addr:           net.JoinHostPort(address.String(), strconv.FormatUint(uint64(port), 10)),
 		Handler:        &s,
+		IdleTimeout:    90 * time.Second, // matches http.DefaultTransport keep-alive timeout
+		ReadTimeout:    4 * 60 * time.Minute,
+		WriteTimeout:   4 * 60 * time.Minute,
 		MaxHeaderBytes: 1 << 20,
 	}
 

--- a/staging/src/k8s.io/apiserver/pkg/server/deprecated_insecure_serving.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/deprecated_insecure_serving.go
@@ -45,6 +45,9 @@ func (s *DeprecatedInsecureServingInfo) Serve(handler http.Handler, shutdownTime
 		Addr:           s.Listener.Addr().String(),
 		Handler:        handler,
 		MaxHeaderBytes: 1 << 20,
+
+		IdleTimeout:       90 * time.Second, // matches http.DefaultTransport keep-alive timeout
+		ReadHeaderTimeout: 32 * time.Second, // just shy of requestTimeoutUpperBound
 	}
 
 	if len(s.Name) > 0 {

--- a/staging/src/k8s.io/apiserver/pkg/server/secure_serving.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/secure_serving.go
@@ -157,6 +157,9 @@ func (s *SecureServingInfo) Serve(handler http.Handler, shutdownTimeout time.Dur
 		Handler:        handler,
 		MaxHeaderBytes: 1 << 20,
 		TLSConfig:      tlsConfig,
+
+		IdleTimeout:       90 * time.Second, // matches http.DefaultTransport keep-alive timeout
+		ReadHeaderTimeout: 32 * time.Second, // just shy of requestTimeoutUpperBound
 	}
 
 	// At least 99% of serialized resources in surveyed clusters were smaller than 256kb.
@@ -164,7 +167,9 @@ func (s *SecureServingInfo) Serve(handler http.Handler, shutdownTimeout time.Dur
 	// and small enough to allow a per connection buffer of this size multiplied by `MaxConcurrentStreams`.
 	const resourceBody99Percentile = 256 * 1024
 
-	http2Options := &http2.Server{}
+	http2Options := &http2.Server{
+		IdleTimeout: 90 * time.Second, // matches http.DefaultTransport keep-alive timeout
+	}
 
 	// shrink the per-stream buffer and max framesize from the 1MB default while still accommodating most API POST requests in a single frame
 	http2Options.MaxUploadBufferPerStream = resourceBody99Percentile
@@ -218,6 +223,9 @@ func (s *SecureServingInfo) ServeWithListenerStopped(handler http.Handler, shutd
 		Handler:        handler,
 		MaxHeaderBytes: 1 << 20,
 		TLSConfig:      tlsConfig,
+
+		IdleTimeout:       90 * time.Second, // matches http.DefaultTransport keep-alive timeout
+		ReadHeaderTimeout: 32 * time.Second, // just shy of requestTimeoutUpperBound
 	}
 
 	// At least 99% of serialized resources in surveyed clusters were smaller than 256kb.
@@ -225,7 +233,9 @@ func (s *SecureServingInfo) ServeWithListenerStopped(handler http.Handler, shutd
 	// and small enough to allow a per connection buffer of this size multiplied by `MaxConcurrentStreams`.
 	const resourceBody99Percentile = 256 * 1024
 
-	http2Options := &http2.Server{}
+	http2Options := &http2.Server{
+		IdleTimeout: 90 * time.Second, // matches http.DefaultTransport keep-alive timeout
+	}
 
 	// shrink the per-stream buffer and max framesize from the 1MB default while still accommodating most API POST requests in a single frame
 	http2Options.MaxUploadBufferPerStream = resourceBody99Percentile


### PR DESCRIPTION
Cherry pick of #103958 on release-1.22.

#103958: Set idle and readheader timeouts

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.