### PR TITLE
Allow using HTTP proxy to connect to OIDC provider

### DIFF
--- a/pkg/kubeapiserver/authenticator/config.go
+++ b/pkg/kubeapiserver/authenticator/config.go
@@ -52,6 +52,7 @@ type Config struct {
 
 	TokenAuthFile               string
 	OIDCIssuerURL               string
+	OIDCIssuerHTTPProxy         string
 	OIDCClientID                string
 	OIDCCAFile                  string
 	OIDCUsernameClaim           string
@@ -162,6 +163,7 @@ func (config Config) New() (authenticator.Request, *spec.SecurityDefinitions, er
 
 		oidcAuth, err := newAuthenticatorFromOIDCIssuerURL(oidc.Options{
 			IssuerURL:            config.OIDCIssuerURL,
+			IssuerHTTPProxy:      config.OIDCIssuerHTTPProxy,
 			ClientID:             config.OIDCClientID,
 			CAContentProvider:    oidcCAContent,
 			UsernameClaim:        config.OIDCUsernameClaim,

--- a/pkg/kubeapiserver/options/authentication.go
+++ b/pkg/kubeapiserver/options/authentication.go
@@ -72,15 +72,16 @@ type BootstrapTokenAuthenticationOptions struct {
 
 // OIDCAuthenticationOptions contains OIDC authentication options for API Server
 type OIDCAuthenticationOptions struct {
-	CAFile         string
-	ClientID       string
-	IssuerURL      string
-	UsernameClaim  string
-	UsernamePrefix string
-	GroupsClaim    string
-	GroupsPrefix   string
-	SigningAlgs    []string
-	RequiredClaims map[string]string
+	CAFile          string
+	ClientID        string
+	IssuerURL       string
+	IssuerHTTPProxy string
+	UsernameClaim   string
+	UsernamePrefix  string
+	GroupsClaim     string
+	GroupsPrefix    string
+	SigningAlgs     []string
+	RequiredClaims  map[string]string
 }
 
 // ServiceAccountAuthenticationOptions contains service account authentication options for API Server
@@ -271,6 +272,9 @@ func (o *BuiltInAuthenticationOptions) AddFlags(fs *pflag.FlagSet) {
 			"The URL of the OpenID issuer, only HTTPS scheme will be accepted. "+
 			"If set, it will be used to verify the OIDC JSON Web Token (JWT).")
 
+		fs.StringVar(&o.OIDC.IssuerHTTPProxy, "oidc-issuer-proxy", o.OIDC.IssuerHTTPProxy, ""+
+			"If provided, the HTTP proxy server to be used to connect to the OpenID issuer URL.")
+
 		fs.StringVar(&o.OIDC.ClientID, "oidc-client-id", o.OIDC.ClientID,
 			"The client ID for the OpenID Connect client, must be set if oidc-issuer-url is set.")
 
@@ -407,6 +411,7 @@ func (o *BuiltInAuthenticationOptions) ToAuthenticationConfig() (kubeauthenticat
 		ret.OIDCGroupsClaim = o.OIDC.GroupsClaim
 		ret.OIDCGroupsPrefix = o.OIDC.GroupsPrefix
 		ret.OIDCIssuerURL = o.OIDC.IssuerURL
+		ret.OIDCIssuerHTTPProxy = o.OIDC.IssuerHTTPProxy
 		ret.OIDCUsernameClaim = o.OIDC.UsernameClaim
 		ret.OIDCUsernamePrefix = o.OIDC.UsernamePrefix
 		ret.OIDCSigningAlgs = o.OIDC.SigningAlgs

--- a/staging/src/k8s.io/apiserver/plugin/pkg/authenticator/token/oidc/oidc.go
+++ b/staging/src/k8s.io/apiserver/plugin/pkg/authenticator/token/oidc/oidc.go
@@ -70,6 +70,10 @@ type Options struct {
 	// See: https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderConfig
 	IssuerURL string
 
+	// IssuerHTTPProxy, if specified, is used to proxy connection when the provider
+	// can not be reached directly (for example, from a private network without access to the Internet).
+	IssuerHTTPProxy string
+
 	// Optional KeySet to allow for synchronous initlization instead of fetching from the remote issuer.
 	KeySet oidc.KeySet
 
@@ -279,6 +283,14 @@ func New(opts Options) (*Authenticator, error) {
 		// TLS uses the host's root CA set.
 		TLSClientConfig: &tls.Config{RootCAs: roots},
 	})
+
+	if opts.IssuerHTTPProxy != "" {
+		proxyUrl, err := url.Parse(opts.IssuerHTTPProxy)
+		if err != nil {
+			return nil, err
+		}
+		tr.Proxy = http.ProxyURL(proxyUrl)
+	}
 
 	client := &http.Client{Transport: tr, Timeout: 30 * time.Second}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:

The ability to use HTTP proxy for OIDC provider connections allows using public OAuth2 providers on Kubernetes clusters located in private networks without direct connection to the Internet (i.e. internet access is allowed only via proxy gateway).

When apiserver doesn't have direct access to the Internet, it is not possible to use public oauth2 providers, because apiserver tries to reach the provider for initial configuration and fails.
For example, for Azure Active Directory:
```
oidc.go:234] oidc authenticator: initializing plugin: Get "https://login.microsoftonline.com/TENANT-ID/v2.0/.well-known/openid-configuration": dial tcp 40.126.29.14:443: connect: connection refused
```
This problem can be solved by passing HTTP proxy to the HTTP client in oidc.go 

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Kube-apiserver: add the "--oidc-issuer-proxy" flag. If specified, tells apiserver to use the proxy to connect to the OpenID issuer URL.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
