### PR TITLE
fix error variable name

### DIFF
--- a/cmd/cloud-controller-manager/nodeipamcontroller.go
+++ b/cmd/cloud-controller-manager/nodeipamcontroller.go
@@ -53,8 +53,8 @@ type nodeIPAMController struct {
 }
 
 func (nodeIpamController *nodeIPAMController) startNodeIpamControllerWrapper(completedConfig *cloudcontrollerconfig.CompletedConfig, cloud cloudprovider.Interface) app.InitFunc {
-	errors := nodeIpamController.nodeIPAMControllerOptions.Validate()
-	if len(errors) > 0 {
+	allErrors := nodeIpamController.nodeIPAMControllerOptions.Validate()
+	if len(allErrors) > 0 {
 		klog.Fatal("NodeIPAM controller values are not properly set.")
 	}
 	nodeIpamController.nodeIPAMControllerOptions.ApplyTo(&nodeIpamController.nodeIPAMControllerConfiguration)


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup


#### What this PR does / why we need it:
The `errors` variable name is the same as the standard go `errors` package name, which may cause unknown errors.
It is recommended to use `allErrors` instead.

Line 23 imports the `errors` package, but in line 56, the variable returned by `Validate()` is also named `errors`.

This will cause the `errors` package to not work properly after the variable `errors`  in the function.

Although the `errors` package can be used before the variable `errors`, it adds complexity.
```release-note
NONE
```