### PR TITLE
fix: 81134: display conflicted taint without a json representation

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/taint/taint.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/taint/taint.go
@@ -248,7 +248,7 @@ func (o TaintOptions) Validate() error {
 				continue
 			}
 			if len(taintRemove.Effect) == 0 || taintAdd.Effect == taintRemove.Effect {
-				conflictTaint := fmt.Sprintf("{\"%s\":\"%s\"}", taintRemove.Key, taintRemove.Effect)
+				conflictTaint := fmt.Sprintf("%s=%s", taintRemove.Key, taintRemove.Effect)
 				conflictTaints = append(conflictTaints, conflictTaint)
 			}
 		}

--- a/staging/src/k8s.io/kubectl/pkg/cmd/taint/taint_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/taint/taint_test.go
@@ -217,6 +217,12 @@ func TestTaint(t *testing.T) {
 			expectTaint: false,
 		},
 		{
+			description: "add and remove taint with same key and effect should be rejected",
+			args:        []string{"node", "node-name", "foo=:NoExcute", "foo=:NoExcute-"},
+			expectFatal: true,
+			expectTaint: false,
+		},
+		{
 			description: "can't update existing taint on the node, since 'overwrite' flag is not set",
 			oldTaints: []corev1.Taint{{
 				Key:    "foo",


### PR DESCRIPTION
From
https://github.com/kubernetes/kubernetes/issues/81134#issuecomment-540800845

1. string is formatted as unsafe json. Since this is created on the fly;
TaintKey and Effect are formatted as a 'key=effect' instead of '{key=effect}'
eliminating unsafe json representation.

2. Adds a fail test case for the case where a taint with same key and effect is added
and removed together.

Manual Testing

```
▶ ./_output/bin/kubectl taint nodes kind-control-plane key1=:NoSchedule key1=:NoSchedule-
error: can not both modify and remove the following taint(s) in the same command: key1=NoSchedule
```

Also, ran unit tests 

```
▶ make test WHAT=./staging/src/k8s.io/kubectl/pkg/cmd/taint
+++ [0729 16:32:27] Running tests without code coverage and with -race
ok  	k8s.io/kubernetes/staging/src/k8s.io/kubectl/pkg/cmd/taint	0.278s
```

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Earlier the string that was constructed was an unsafe json. 
As recommended in https://github.com/kubernetes/kubernetes/issues/81134 I am adding an in-depth check
to not create a json as araw string.

#### Which issue(s) this PR fixes:
https://github.com/kubernetes/kubernetes/issues/81134

#### Special notes for your reviewer:
Please see Manual Testing to see that the user output did not change.

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
1. Changes json representation for a conflicted taint to Key=Effect when a conflicted taint occurs in kubectl taint.
```

