### PR TITLE
kubeadm: dynamically populate the current/minimum k8s versions

### DIFF
--- a/cmd/kubeadm/app/cmd/config_test.go
+++ b/cmd/kubeadm/app/cmd/config_test.go
@@ -208,8 +208,8 @@ func TestConfigImagesListRunWithoutPath(t *testing.T) {
 
 func TestConfigImagesListOutput(t *testing.T) {
 
-	etcdVersion, ok := constants.SupportedEtcdVersion[uint8(dummyKubernetesVersion.Minor())]
-	if !ok {
+	etcdVersion, _, err := constants.EtcdSupportedVersion(constants.SupportedEtcdVersion, dummyKubernetesVersionStr)
+	if err != nil {
 		t.Fatalf("cannot determine etcd version for Kubernetes version %s", dummyKubernetesVersionStr)
 	}
 	versionMapping := struct {
@@ -218,7 +218,7 @@ func TestConfigImagesListOutput(t *testing.T) {
 		PauseVersion   string
 		CoreDNSVersion string
 	}{
-		EtcdVersion:    etcdVersion,
+		EtcdVersion:    etcdVersion.String(),
 		KubeVersion:    "v" + dummyKubernetesVersionStr,
 		PauseVersion:   constants.PauseVersion,
 		CoreDNSVersion: constants.CoreDNSVersion,

--- a/cmd/kubeadm/app/phases/upgrade/compute_test.go
+++ b/cmd/kubeadm/app/phases/upgrade/compute_test.go
@@ -85,7 +85,8 @@ spec:
     image: k8s.gcr.io/etcd:` + fakeCurrentEtcdVersion
 
 func getEtcdVersion(v *versionutil.Version) string {
-	return constants.SupportedEtcdVersion[uint8(v.Minor())]
+	etcdVer, _, _ := constants.EtcdSupportedVersion(constants.SupportedEtcdVersion, v.String())
+	return etcdVer.String()
 }
 
 const fakeCurrentCoreDNSVersion = "1.0.6"

--- a/cmd/kubeadm/app/phases/upgrade/policy_test.go
+++ b/cmd/kubeadm/app/phases/upgrade/policy_test.go
@@ -76,7 +76,7 @@ func TestEnforceVersionPolicies(t *testing.T) {
 				kubeletVersion: "v1.12.3",
 				kubeadmVersion: "v1.12.3",
 			},
-			newK8sVersion:         "v1.11.10",
+			newK8sVersion:         "v1.10.10",
 			expectedMandatoryErrs: 1, // version must be higher than v1.12.0
 			expectedSkippableErrs: 1, // can't upgrade old k8s with newer kubeadm
 		},
@@ -85,9 +85,9 @@ func TestEnforceVersionPolicies(t *testing.T) {
 			vg: &fakeVersionGetter{
 				clusterVersion: "v1.11.3",
 				kubeletVersion: "v1.11.3",
-				kubeadmVersion: constants.CurrentKubernetesVersion.String(),
+				kubeadmVersion: "v1.13.0",
 			},
-			newK8sVersion:         constants.CurrentKubernetesVersion.String(),
+			newK8sVersion:         "v1.13.0",
 			expectedMandatoryErrs: 1, // can't upgrade two minor versions
 			expectedSkippableErrs: 1, // kubelet <-> apiserver skew too large
 		},
@@ -124,11 +124,11 @@ func TestEnforceVersionPolicies(t *testing.T) {
 		{
 			name: "the maximum skew between the cluster version and the kubelet versions should be one minor version. This may be forced through though.",
 			vg: &fakeVersionGetter{
-				clusterVersion: constants.MinimumControlPlaneVersion.WithPatch(3).String(),
-				kubeletVersion: "v1.12.8",
-				kubeadmVersion: constants.CurrentKubernetesVersion.String(),
+				clusterVersion: "v1.12.0",
+				kubeletVersion: "v1.10.8",
+				kubeadmVersion: "v1.12.0",
 			},
-			newK8sVersion:         constants.CurrentKubernetesVersion.String(),
+			newK8sVersion:         "v1.12.0",
 			expectedSkippableErrs: 1,
 		},
 		{

--- a/cmd/kubeadm/app/preflight/checks_test.go
+++ b/cmd/kubeadm/app/preflight/checks_test.go
@@ -793,7 +793,7 @@ func TestKubeletVersionCheck(t *testing.T) {
 		expectWarnings bool
 	}{
 		{"v" + constants.CurrentKubernetesVersion.WithPatch(2).String(), "", false, false},                                                                     // check minimally supported version when there is no information about control plane
-		{"v1.11.3", "v1.11.8", true, false},                                                                                                                    // too old kubelet (older than kubeadmconstants.MinimumKubeletVersion), should fail.
+		{"v1.1.0", "v1.11.8", true, false},                                                                                                                     // too old kubelet, should fail.
 		{"v" + constants.MinimumKubeletVersion.String(), constants.MinimumControlPlaneVersion.WithPatch(5).String(), false, false},                             // kubelet within same major.minor as control plane
 		{"v" + constants.MinimumKubeletVersion.WithPatch(5).String(), constants.MinimumControlPlaneVersion.WithPatch(1).String(), false, false},                // kubelet is newer, but still within same major.minor as control plane
 		{"v" + constants.MinimumKubeletVersion.String(), constants.CurrentKubernetesVersion.WithPatch(1).String(), false, false},                               // kubelet is lower than control plane, but newer than minimally supported

--- a/cmd/kubeadm/app/util/config/common.go
+++ b/cmd/kubeadm/app/util/config/common.go
@@ -32,6 +32,8 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	netutil "k8s.io/apimachinery/pkg/util/net"
 	"k8s.io/apimachinery/pkg/util/version"
+	apimachineryversion "k8s.io/apimachinery/pkg/version"
+	componentversion "k8s.io/component-base/version"
 	"k8s.io/klog/v2"
 
 	"github.com/pkg/errors"
@@ -102,8 +104,23 @@ func NormalizeKubernetesVersion(cfg *kubeadmapi.ClusterConfiguration) error {
 	if err != nil {
 		return errors.Wrapf(err, "couldn't parse Kubernetes version %q", cfg.KubernetesVersion)
 	}
-	if k8sVersion.LessThan(constants.MinimumControlPlaneVersion) {
-		return errors.Errorf("this version of kubeadm only supports deploying clusters with the control plane version >= %s. Current version: %s", constants.MinimumControlPlaneVersion.String(), cfg.KubernetesVersion)
+
+	// During the k8s release process, a kubeadm version in the main branch could be 1.23.0-pre,
+	// while the 1.22.0 version is not released yet. The MinimumControlPlaneVersion validation
+	// in such a case will not pass, since the value of MinimumControlPlaneVersion would be
+	// calculated as kubeadm version - 1 (1.22) and k8sVersion would still be at 1.21.x
+	// (fetched from the 'stable' marker). Handle this case by only showing a warning.
+	mcpVersion := constants.MinimumControlPlaneVersion
+	versionInfo := componentversion.Get()
+	if isKubeadmPrereleaseVersion(&versionInfo, k8sVersion, mcpVersion) {
+		klog.V(1).Infof("WARNING: tolerating control plane version %s, assuming that k8s version %s is not released yet",
+			cfg.KubernetesVersion, mcpVersion)
+		return nil
+	}
+	// If not a pre-release version, handle the validation normally.
+	if k8sVersion.LessThan(mcpVersion) {
+		return errors.Errorf("this version of kubeadm only supports deploying clusters with the control plane version >= %s. Current version: %s",
+			mcpVersion, cfg.KubernetesVersion)
 	}
 	return nil
 }
@@ -203,4 +220,21 @@ func MigrateOldConfig(oldConfig []byte) ([]byte, error) {
 	}
 
 	return bytes.Join(newConfig, []byte(constants.YAMLDocumentSeparator)), nil
+}
+
+// isKubeadmPrereleaseVersion returns true if the kubeadm version is a pre-release version and
+// the minimum control plane version is N+2 MINOR version of the given k8sVersion.
+func isKubeadmPrereleaseVersion(versionInfo *apimachineryversion.Info, k8sVersion, mcpVersion *version.Version) bool {
+	if len(versionInfo.Major) != 0 { // Make sure the component version is populated
+		kubeadmVersion := version.MustParseSemantic(versionInfo.String())
+		if len(kubeadmVersion.PreRelease()) != 0 { // Only handle this if the kubeadm binary is a pre-release
+			// After incrementing the k8s MINOR version by one, if this version is equal or greater than the
+			// MCP version, return true.
+			v := k8sVersion.WithMinor(k8sVersion.Minor() + 1)
+			if comp, _ := v.Compare(mcpVersion.String()); comp != -1 {
+				return true
+			}
+		}
+	}
+	return false
 }

--- a/cmd/kubeadm/app/util/config/common_test.go
+++ b/cmd/kubeadm/app/util/config/common_test.go
@@ -26,6 +26,8 @@ import (
 	kubeadmutil "k8s.io/kubernetes/cmd/kubeadm/app/util"
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/version"
+	apimachineryversion "k8s.io/apimachinery/pkg/version"
 
 	"github.com/lithammer/dedent"
 )
@@ -393,6 +395,58 @@ func TestMigrateOldConfigFromFile(t *testing.T) {
 						t.Fatalf("migration failed to produce config kind: %s", expectedKind)
 					}
 				}
+			}
+		})
+	}
+}
+
+func TestIsKubeadmPrereleaseVersion(t *testing.T) {
+	validVersionInfo := &apimachineryversion.Info{Major: "1", GitVersion: "v1.23.0-alpha.1"}
+	tests := []struct {
+		name           string
+		versionInfo    *apimachineryversion.Info
+		k8sVersion     *version.Version
+		mcpVersion     *version.Version
+		expectedResult bool
+	}{
+		{
+			name:           "invalid versionInfo",
+			versionInfo:    &apimachineryversion.Info{},
+			expectedResult: false,
+		},
+		{
+			name:           "kubeadm is not a prerelease version",
+			versionInfo:    &apimachineryversion.Info{Major: "1", GitVersion: "v1.23.0"},
+			expectedResult: false,
+		},
+		{
+			name:           "mcpVersion is equal to k8sVersion",
+			versionInfo:    validVersionInfo,
+			k8sVersion:     version.MustParseSemantic("v1.21.0"),
+			mcpVersion:     version.MustParseSemantic("v1.21.0"),
+			expectedResult: true,
+		},
+		{
+			name:           "k8sVersion is 1 MINOR version older than mcpVersion",
+			versionInfo:    validVersionInfo,
+			k8sVersion:     version.MustParseSemantic("v1.21.0"),
+			mcpVersion:     version.MustParseSemantic("v1.22.0"),
+			expectedResult: true,
+		},
+		{
+			name:           "k8sVersion is 2 MINOR versions older than mcpVersion",
+			versionInfo:    validVersionInfo,
+			k8sVersion:     version.MustParseSemantic("v1.21.0"),
+			mcpVersion:     version.MustParseSemantic("v1.23.0"),
+			expectedResult: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result := isKubeadmPrereleaseVersion(tc.versionInfo, tc.k8sVersion, tc.mcpVersion)
+			if result != tc.expectedResult {
+				t.Errorf("expected result: %v, got %v", tc.expectedResult, result)
 			}
 		})
 	}

--- a/cmd/kubeadm/test/cmd/init_test.go
+++ b/cmd/kubeadm/test/cmd/init_test.go
@@ -19,9 +19,10 @@ package kubeadm
 import (
 	"fmt"
 	"os"
+	"strings"
 	"testing"
 
-	"k8s.io/kubernetes/cmd/kubeadm/app/constants"
+	"k8s.io/apimachinery/pkg/util/version"
 
 	"github.com/lithammer/dedent"
 )
@@ -35,6 +36,16 @@ func runKubeadmInit(args ...string) (string, string, int, error) {
 	kubeadmArgs := []string{"init", "--dry-run", "--ignore-preflight-errors=all"}
 	kubeadmArgs = append(kubeadmArgs, args...)
 	return RunCmd(kubeadmPath, kubeadmArgs...)
+}
+
+func getKubeadmVersion() *version.Version {
+	kubeadmPath := getKubeadmPath()
+	kubeadmArgs := []string{"version", "-o=short"}
+	out, _, _, err := RunCmd(kubeadmPath, kubeadmArgs...)
+	if err != nil {
+		panic(fmt.Sprintf("could not run 'kubeadm version -o=short': %v", err))
+	}
+	return version.MustParseSemantic(strings.TrimSpace(out))
 }
 
 func TestCmdInitToken(t *testing.T) {
@@ -94,7 +105,7 @@ func TestCmdInitKubernetesVersion(t *testing.T) {
 		},
 		{
 			name:     "valid version is accepted",
-			args:     "--kubernetes-version=" + constants.CurrentKubernetesVersion.String(),
+			args:     "--kubernetes-version=" + getKubeadmVersion().String(),
 			expected: true,
 		},
 	}


### PR DESCRIPTION
#### What this PR does / why we need it:

Kubeadm requires manual version updates of its current supported k8s
control plane version and minimally supported k8s control plane and
kubelet versions every release cycle.

To avoid that, in constants.go:
- Add the helper function getSkewedKubernetesVersion() that can be
used to retrieve a MAJOR.(MINOR+n).0 version of k8s. It currently
uses the kubeadm version populated in "component-base/version" during
the kubeadm build process.
- Use the function to set existing version constants (variables).

Update util/config/common.go#NormalizeKubernetesVersion() to
tolerate the case where a k8s version in the ClusterConfiguration
is too old for the kubeadm binary to use during code freeze.

Include unit tests for the new utilities.

Update existing unit tests to tolerate the new dynamic versions.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes/kubeadm/issues/1714
xref https://github.com/kubernetes/kubeadm/issues/2440

#### Special notes for your reviewer:

**NOTE:** better to review one commit at a time.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
