### PR TITLE
Automated cherry pick of #96115: Get inodes and disk usage via pure go

### DIFF
--- a/pkg/volume/metrics_du.go
+++ b/pkg/volume/metrics_du.go
@@ -46,12 +46,7 @@ func (md *metricsDu) GetMetrics() (*Metrics, error) {
 		return metrics, NewNoPathDefinedError()
 	}
 
-	err := md.runDiskUsage(metrics)
-	if err != nil {
-		return metrics, err
-	}
-
-	err = md.runFind(metrics)
+	err := md.getDiskUsage(metrics)
 	if err != nil {
 		return metrics, err
 	}
@@ -64,23 +59,14 @@ func (md *metricsDu) GetMetrics() (*Metrics, error) {
 	return metrics, nil
 }
 
-// runDiskUsage gets disk usage of md.path and writes the results to metrics.Used
-func (md *metricsDu) runDiskUsage(metrics *Metrics) error {
-	used, err := fs.DiskUsage(md.path)
+// getDiskUsage writes metrics.Used and metric.InodesUsed from fs.DiskUsage
+func (md *metricsDu) getDiskUsage(metrics *Metrics) error {
+	usage, err := fs.DiskUsage(md.path)
 	if err != nil {
 		return err
 	}
-	metrics.Used = used
-	return nil
-}
-
-// runFind executes the "find" command and writes the results to metrics.InodesUsed
-func (md *metricsDu) runFind(metrics *Metrics) error {
-	inodesUsed, err := fs.Find(md.path)
-	if err != nil {
-		return err
-	}
-	metrics.InodesUsed = resource.NewQuantity(inodesUsed, resource.BinarySI)
+	metrics.Used = resource.NewQuantity(usage.Bytes, resource.BinarySI)
+	metrics.InodesUsed = resource.NewQuantity(usage.Inodes, resource.BinarySI)
 	return nil
 }
 

--- a/pkg/volume/metrics_du_test.go
+++ b/pkg/volume/metrics_du_test.go
@@ -81,6 +81,21 @@ func TestMetricsDuGetCapacity(t *testing.T) {
 	if e, a := (expectedEmptyDirUsage.Value() + getExpectedBlockSize(filepath.Join(tmpDir, "f1"))), actual.Used.Value(); e != a {
 		t.Errorf("Unexpected Used for directory with file.  Expected %v, got %d.", e, a)
 	}
+
+	// create a hardlink and expect inodes count to stay the same
+	previousInodes := actual.InodesUsed.Value()
+	err = os.Link(filepath.Join(tmpDir, "f1"), filepath.Join(tmpDir, "f2"))
+	if err != nil {
+		t.Errorf("Unexpected error when creating hard link %v", err)
+	}
+	actual, err = metrics.GetMetrics()
+	if err != nil {
+		t.Errorf("Unexpected error when calling GetMetrics %v", err)
+	}
+	if e, a := previousInodes, actual.InodesUsed.Value(); e != a {
+		t.Errorf("Unexpected Used for directory with file.  Expected %v, got %d.", e, a)
+	}
+
 }
 
 // TestMetricsDuRequireInit tests that if MetricsDu is not initialized with a path, GetMetrics

--- a/pkg/volume/util/fs/BUILD
+++ b/pkg/volume/util/fs/BUILD
@@ -10,58 +10,23 @@ go_library(
     importpath = "k8s.io/kubernetes/pkg/volume/util/fs",
     visibility = ["//visibility:public"],
     deps = select({
-        "@io_bazel_rules_go//go/platform:aix": [
-            "//staging/src/k8s.io/apimachinery/pkg/api/resource:go_default_library",
-        ],
         "@io_bazel_rules_go//go/platform:android": [
             "//pkg/volume/util/fsquota:go_default_library",
-            "//staging/src/k8s.io/apimachinery/pkg/api/resource:go_default_library",
             "//vendor/golang.org/x/sys/unix:go_default_library",
         ],
         "@io_bazel_rules_go//go/platform:darwin": [
             "//pkg/volume/util/fsquota:go_default_library",
-            "//staging/src/k8s.io/apimachinery/pkg/api/resource:go_default_library",
             "//vendor/golang.org/x/sys/unix:go_default_library",
-        ],
-        "@io_bazel_rules_go//go/platform:dragonfly": [
-            "//staging/src/k8s.io/apimachinery/pkg/api/resource:go_default_library",
-        ],
-        "@io_bazel_rules_go//go/platform:freebsd": [
-            "//staging/src/k8s.io/apimachinery/pkg/api/resource:go_default_library",
-        ],
-        "@io_bazel_rules_go//go/platform:illumos": [
-            "//staging/src/k8s.io/apimachinery/pkg/api/resource:go_default_library",
         ],
         "@io_bazel_rules_go//go/platform:ios": [
             "//pkg/volume/util/fsquota:go_default_library",
-            "//staging/src/k8s.io/apimachinery/pkg/api/resource:go_default_library",
             "//vendor/golang.org/x/sys/unix:go_default_library",
-        ],
-        "@io_bazel_rules_go//go/platform:js": [
-            "//staging/src/k8s.io/apimachinery/pkg/api/resource:go_default_library",
         ],
         "@io_bazel_rules_go//go/platform:linux": [
             "//pkg/volume/util/fsquota:go_default_library",
-            "//staging/src/k8s.io/apimachinery/pkg/api/resource:go_default_library",
             "//vendor/golang.org/x/sys/unix:go_default_library",
         ],
-        "@io_bazel_rules_go//go/platform:nacl": [
-            "//staging/src/k8s.io/apimachinery/pkg/api/resource:go_default_library",
-        ],
-        "@io_bazel_rules_go//go/platform:netbsd": [
-            "//staging/src/k8s.io/apimachinery/pkg/api/resource:go_default_library",
-        ],
-        "@io_bazel_rules_go//go/platform:openbsd": [
-            "//staging/src/k8s.io/apimachinery/pkg/api/resource:go_default_library",
-        ],
-        "@io_bazel_rules_go//go/platform:plan9": [
-            "//staging/src/k8s.io/apimachinery/pkg/api/resource:go_default_library",
-        ],
-        "@io_bazel_rules_go//go/platform:solaris": [
-            "//staging/src/k8s.io/apimachinery/pkg/api/resource:go_default_library",
-        ],
         "@io_bazel_rules_go//go/platform:windows": [
-            "//staging/src/k8s.io/apimachinery/pkg/api/resource:go_default_library",
             "//vendor/golang.org/x/sys/windows:go_default_library",
         ],
         "//conditions:default": [],

--- a/pkg/volume/util/fs/fs.go
+++ b/pkg/volume/util/fs/fs.go
@@ -19,16 +19,20 @@ limitations under the License.
 package fs
 
 import (
-	"bytes"
 	"fmt"
-	"os/exec"
-	"strings"
+	"os"
+	"path/filepath"
+	"syscall"
 
 	"golang.org/x/sys/unix"
 
-	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/kubernetes/pkg/volume/util/fsquota"
 )
+
+type UsageInfo struct {
+	Bytes  int64
+	Inodes int64
+}
 
 // FsInfo linux returns (available bytes, byte capacity, byte usage, total inodes, inodes free, inode usage, error)
 // for the filesystem that path resides upon.
@@ -55,63 +59,83 @@ func FsInfo(path string) (int64, int64, int64, int64, int64, int64, error) {
 	return available, capacity, usage, inodes, inodesFree, inodesUsed, nil
 }
 
-// DiskUsage gets disk usage of specified path.
-func DiskUsage(path string) (*resource.Quantity, error) {
-	// First check whether the quota system knows about this directory
-	// A nil quantity with no error means that the path does not support quotas
-	// and we should use other mechanisms.
-	data, err := fsquota.GetConsumption(path)
-	if data != nil {
-		return data, nil
-	} else if err != nil {
-		return nil, fmt.Errorf("unable to retrieve disk consumption via quota for %s: %v", path, err)
-	}
-	// Uses the same niceness level as cadvisor.fs does when running du
-	// Uses -B 1 to always scale to a blocksize of 1 byte
-	out, err := exec.Command("nice", "-n", "19", "du", "-x", "-s", "-B", "1", path).CombinedOutput()
-	if err != nil {
-		return nil, fmt.Errorf("failed command 'du' ($ nice -n 19 du -x -s -B 1) on path %s with error %v", path, err)
-	}
-	used, err := resource.ParseQuantity(strings.Fields(string(out))[0])
-	if err != nil {
-		return nil, fmt.Errorf("failed to parse 'du' output %s due to error %v", out, err)
-	}
-	used.Format = resource.BinarySI
-	return &used, nil
-}
+// DiskUsage calculates the number of inodes and disk usage for a given directory
+func DiskUsage(path string) (UsageInfo, error) {
+	var usage UsageInfo
 
-// Find uses the equivalent of the command `find <path> -dev -printf '.' | wc -c` to count files and directories.
-// While this is not an exact measure of inodes used, it is a very good approximation.
-func Find(path string) (int64, error) {
 	if path == "" {
-		return 0, fmt.Errorf("invalid directory")
+		return usage, fmt.Errorf("invalid directory")
 	}
+
 	// First check whether the quota system knows about this directory
-	// A nil quantity with no error means that the path does not support quotas
-	// and we should use other mechanisms.
-	inodes, err := fsquota.GetInodes(path)
+	// A nil quantity or error means that the path does not support quotas
+	// or xfs_quota tool is missing and we should use other mechanisms.
+	consumption, _ := fsquota.GetConsumption(path)
+	if consumption != nil {
+		usage.Bytes = consumption.Value()
+	}
+
+	inodes, _ := fsquota.GetInodes(path)
 	if inodes != nil {
-		return inodes.Value(), nil
-	} else if err != nil {
-		return 0, fmt.Errorf("unable to retrieve inode consumption via quota for %s: %v", path, err)
+		usage.Inodes = inodes.Value()
 	}
-	var counter byteCounter
-	var stderr bytes.Buffer
-	findCmd := exec.Command("find", path, "-xdev", "-printf", ".")
-	findCmd.Stdout, findCmd.Stderr = &counter, &stderr
-	if err := findCmd.Start(); err != nil {
-		return 0, fmt.Errorf("failed to exec cmd %v - %v; stderr: %v", findCmd.Args, err, stderr.String())
-	}
-	if err := findCmd.Wait(); err != nil {
-		return 0, fmt.Errorf("cmd %v failed. stderr: %s; err: %v", findCmd.Args, stderr.String(), err)
-	}
-	return counter.bytesWritten, nil
-}
 
-// Simple io.Writer implementation that counts how many bytes were written.
-type byteCounter struct{ bytesWritten int64 }
+	if inodes != nil && consumption != nil {
+		return usage, nil
+	}
 
-func (b *byteCounter) Write(p []byte) (int, error) {
-	b.bytesWritten += int64(len(p))
-	return len(p), nil
+	topLevelStat := &unix.Stat_t{}
+	err := unix.Stat(path, topLevelStat)
+	if err != nil {
+		return usage, err
+	}
+
+	// dedupedInode stores inodes that could be duplicates (nlink > 1)
+	dedupedInodes := make(map[uint64]struct{})
+
+	err = filepath.Walk(path, func(path string, info os.FileInfo, err error) error {
+		// ignore files that have been deleted after directory was read
+		if os.IsNotExist(err) {
+			return nil
+		}
+		if err != nil {
+			return fmt.Errorf("unable to count inodes for %s: %s", path, err)
+		}
+
+		// according to the docs, Sys can be nil
+		if info.Sys() == nil {
+			return fmt.Errorf("fileinfo Sys is nil")
+		}
+
+		s, ok := info.Sys().(*syscall.Stat_t)
+		if !ok {
+			return fmt.Errorf("unsupported fileinfo; could not convert to stat_t")
+		}
+
+		if s.Dev != topLevelStat.Dev {
+			// don't descend into directories on other devices
+			return filepath.SkipDir
+		}
+
+		// Dedupe hardlinks
+		if s.Nlink > 1 {
+			if _, ok := dedupedInodes[s.Ino]; !ok {
+				dedupedInodes[s.Ino] = struct{}{}
+			} else {
+				return nil
+			}
+		}
+
+		if consumption == nil {
+			usage.Bytes += int64(s.Blocks) * int64(512) // blocksize in bytes
+		}
+
+		if inodes == nil {
+			usage.Inodes++
+		}
+
+		return nil
+	})
+
+	return usage, err
 }

--- a/pkg/volume/util/fs/fs_unsupported.go
+++ b/pkg/volume/util/fs/fs_unsupported.go
@@ -20,9 +20,12 @@ package fs
 
 import (
 	"fmt"
-
-	"k8s.io/apimachinery/pkg/api/resource"
 )
+
+type UsageInfo struct {
+	Bytes  int64
+	Inodes int64
+}
 
 // FSInfo unsupported returns 0 values for available and capacity and an error.
 func FsInfo(path string) (int64, int64, int64, int64, int64, int64, error) {
@@ -30,10 +33,12 @@ func FsInfo(path string) (int64, int64, int64, int64, int64, int64, error) {
 }
 
 // DiskUsage gets disk usage of specified path.
-func DiskUsage(path string) (*resource.Quantity, error) {
-	return nil, fmt.Errorf("Du not supported for this build.")
+func DiskUsage(path string) (UsageInfo, error) {
+	var usage UsageInfo
+	return usage, fmt.Errorf("directory disk usage not supported for this build.")
 }
 
 func Find(path string) (int64, error) {
 	return 0, fmt.Errorf("Find not supported for this build.")
-}
+
+

--- a/pkg/volume/util/fs/fs_unsupported.go
+++ b/pkg/volume/util/fs/fs_unsupported.go
@@ -37,8 +37,3 @@ func DiskUsage(path string) (UsageInfo, error) {
 	var usage UsageInfo
 	return usage, fmt.Errorf("directory disk usage not supported for this build.")
 }
-
-func Find(path string) (int64, error) {
-	return 0, fmt.Errorf("Find not supported for this build.")
-
-

--- a/pkg/volume/util/fs/fs_windows.go
+++ b/pkg/volume/util/fs/fs_windows.go
@@ -37,7 +37,7 @@ type UsageInfo struct {
 	Inodes int64
 }
 
-// FsInfoInfo returns (available bytes, byte capacity, byte usage, total inodes, inodes free, inode usage, error)
+// FsInfo returns (available bytes, byte capacity, byte usage, total inodes, inodes free, inode usage, error)
 // for the filesystem that path resides upon.
 func FsInfo(path string) (int64, int64, int64, int64, int64, int64, error) {
 	var freeBytesAvailable, totalNumberOfBytes, totalNumberOfFreeBytes int64

--- a/pkg/volume/util/fs/fs_windows_test.go
+++ b/pkg/volume/util/fs/fs_windows_test.go
@@ -66,8 +66,7 @@ func TestDiskUsage(t *testing.T) {
 	}
 	total := dirInfo1.Size() + dirInfo2.Size() + fileInfo1.Size() + fileInfo2.Size()
 
-
-	usage, err := DiskUsage(dir1)
+	usage, err := DiskUsage(dir_1)
 	if err != nil {
 		t.Fatalf("TestDiskUsage failed: %s", err.Error())
 	}

--- a/pkg/volume/util/fs/fs_windows_test.go
+++ b/pkg/volume/util/fs/fs_windows_test.go
@@ -66,10 +66,16 @@ func TestDiskUsage(t *testing.T) {
 	}
 	total := dirInfo1.Size() + dirInfo2.Size() + fileInfo1.Size() + fileInfo2.Size()
 
-	size, err := DiskUsage(dir_1)
+
+	usage, err := DiskUsage(dir1)
 	if err != nil {
 		t.Fatalf("TestDiskUsage failed: %s", err.Error())
 	}
+	size, err := resource.ParseQuantity(fmt.Sprintf("%d", usage.Bytes))
+	if err != nil {
+		t.Fatalf("TestDiskUsage failed: %s", err.Error())
+	}
+
 	used, err := resource.ParseQuantity(fmt.Sprintf("%d", total))
 	if err != nil {
 		t.Fatalf("TestDiskUsage failed: %s", err.Error())


### PR DESCRIPTION
Cherry pick of #96115 on release-1.20.

#96115: Get inodes and disk usage via pure go

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.