### PR TITLE
WIP: Restrict to running only one goroutine for a mirror pod

### DIFF
--- a/test/e2e_node/mirror_pod_grace_period_test.go
+++ b/test/e2e_node/mirror_pod_grace_period_test.go
@@ -26,8 +26,11 @@ import (
 	"github.com/onsi/gomega"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/uuid"
+	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/kubernetes/test/e2e/framework"
+	imageutils "k8s.io/kubernetes/test/utils/image"
 )
 
 var _ = SIGDescribe("MirrorPodWithGracePeriod", func() {
@@ -53,10 +56,9 @@ var _ = SIGDescribe("MirrorPodWithGracePeriod", func() {
 
 		ginkgo.It("mirror pod termination should satisfy grace period when static pod is deleted [NodeConformance]", func() {
 			ginkgo.By("get mirror pod uid")
-			_, err := f.ClientSet.CoreV1().Pods(ns).Get(context.TODO(), mirrorPodName, metav1.GetOptions{})
+			pod, err := f.ClientSet.CoreV1().Pods(ns).Get(context.TODO(), mirrorPodName, metav1.GetOptions{})
 			framework.ExpectNoError(err)
-
-			start := time.Now()
+			uid := pod.UID
 
 			ginkgo.By("delete the static pod")
 			file := staticPodPath(podPath, staticPodName, ns)
@@ -64,25 +66,51 @@ var _ = SIGDescribe("MirrorPodWithGracePeriod", func() {
 			err = os.Remove(file)
 			framework.ExpectNoError(err)
 
-			for {
-				if time.Now().Sub(start).Seconds() > 19 {
-					break
-				}
-				pod, err := f.ClientSet.CoreV1().Pods(ns).Get(context.TODO(), mirrorPodName, metav1.GetOptions{})
-				framework.ExpectNoError(err)
-				if pod.Status.Phase != v1.PodRunning {
-					framework.Failf("expected the mirror pod %q to be running, got %q", mirrorPodName, pod.Status.Phase)
-				}
-				// have some pause in between the API server queries to avoid throttling
-				time.Sleep(time.Duration(200) * time.Millisecond)
-			}
+			ginkgo.By("wait for the mirror pod to be running for grace period")
+			gomega.Consistently(func() error {
+				return checkMirrorPodRunningWithUID(f.ClientSet, mirrorPodName, ns, uid)
+			}, 19*time.Second, 200*time.Millisecond).Should(gomega.BeNil())
+		})
+
+		ginkgo.It("mirror pod termination should satisfy grace period when static pod is updated [NodeConformance]", func() {
+			ginkgo.By("get mirror pod uid")
+			pod, err := f.ClientSet.CoreV1().Pods(ns).Get(context.TODO(), mirrorPodName, metav1.GetOptions{})
+			framework.ExpectNoError(err)
+			uid := pod.UID
+
+			ginkgo.By("update the static pod container image")
+			image := imageutils.GetPauseImageName()
+			err = createStaticPod(podPath, staticPodName, ns, image, v1.RestartPolicyAlways)
+			framework.ExpectNoError(err)
+
+			ginkgo.By("wait for the mirror pod to be running for grace period")
+			gomega.Consistently(func() error {
+				return checkMirrorPodRunningWithUID(f.ClientSet, mirrorPodName, ns, uid)
+			}, 19*time.Second, 200*time.Millisecond).Should(gomega.BeNil())
+
+			ginkgo.By("wait for the mirror pod to be updated")
+			gomega.Eventually(func() error {
+				return checkMirrorPodRecreatedAndRunning(f.ClientSet, mirrorPodName, ns, uid)
+			}, 2*time.Minute, time.Second*4).Should(gomega.BeNil())
+
+			ginkgo.By("check the mirror pod container image is updated")
+			pod, err = f.ClientSet.CoreV1().Pods(ns).Get(context.TODO(), mirrorPodName, metav1.GetOptions{})
+			framework.ExpectNoError(err)
+			framework.ExpectEqual(len(pod.Spec.Containers), 1)
+			framework.ExpectEqual(pod.Spec.Containers[0].Image, image)
 		})
 
 		ginkgo.AfterEach(func() {
+			ginkgo.By("delete the static pod")
+			err := deleteStaticPod(podPath, staticPodName, ns)
+			if !os.IsNotExist(err) {
+				framework.ExpectNoError(err)
+			}
+
 			ginkgo.By("wait for the mirror pod to disappear")
 			gomega.Eventually(func() error {
 				return checkMirrorPodDisappear(f.ClientSet, mirrorPodName, ns)
-			}, time.Second*19, time.Second).Should(gomega.BeNil())
+			}, 2*time.Minute, time.Second*4).Should(gomega.BeNil())
 		})
 	})
 })
@@ -123,4 +151,18 @@ spec:
 	_, err = f.WriteString(podYaml)
 	framework.Logf("has written %v", file)
 	return err
+}
+
+func checkMirrorPodRunningWithUID(cl clientset.Interface, name, namespace string, oUID types.UID) error {
+	pod, err := cl.CoreV1().Pods(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+	if err != nil {
+		return fmt.Errorf("expected the mirror pod %q to appear: %v", name, err)
+	}
+	if pod.UID != oUID {
+		return fmt.Errorf("expected the uid of mirror pod %q to be same, got %q", name, pod.UID)
+	}
+	if pod.Status.Phase != v1.PodRunning {
+		return fmt.Errorf("expected the mirror pod %q to be running, got %q", name, pod.Status.Phase)
+	}
+	return nil
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

/cc @smarterclayton 
I think your refactoring is the right way to go. However, it seems that static pods are not considered much.

There can be more than two static pods with the same full name in podWorkers. It conceptually breaks the assumption that there should be only one goroutine responsible for a pod. (static pod's UID is the hash of its content, so there can be more than two static pods with the same name and different contents)

This PR restricts to running only one goroutine for a mirror pod that reflects the static pod.

I think we need to re-consider the current design of the static pods some days.
However, this PR may be enough to fix this inconsistency for now.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #97722 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Respect grace period when updating static pods.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

