### PR TITLE
e2e node server: fix crash in log line

### DIFF
--- a/test/e2e_node/services/server.go
+++ b/test/e2e_node/services/server.go
@@ -177,7 +177,7 @@ func (s *server) start() error {
 						s.startCommand.Wait() // Release resources if necessary.
 					}
 					// This should not happen, immediately stop the e2eService process.
-					klog.Fatalf("Restart loop readinessCheck failed for %s", s)
+					klog.Fatalf("Restart loop readinessCheck failed for %q", s.name)
 				} else {
 					klog.Infof("Initial health check passed for service %q", s.name)
 				}


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
Fixes a crash in the e2e serial test server trying to log a string when it is actually a structure.

```
W0730 16:58:44.605] goroutine 237 [running]:
W0730 16:58:44.605] k8s.io/kubernetes/vendor/k8s.io/klog/v2.stacks(0xc000122001, 0xc001104000, 0x507, 0x70f)
W0730 16:58:44.605] 	/go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/vendor/k8s.io/klog/v2/klog.go:1026 +0xb9
W0730 16:58:44.606] k8s.io/kubernetes/vendor/k8s.io/klog/v2.(*loggingT).output(0x8d387a0, 0xc000000003, 0x0, 0x0, 0xc0003ed490, 0x0, 0x74bf5bb, 0x9, 0xb4, 0x0)
W0730 16:58:44.606] 	/go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/vendor/k8s.io/klog/v2/klog.go:975 +0x1e5
W0730 16:58:44.606] k8s.io/kubernetes/vendor/k8s.io/klog/v2.(*loggingT).printf(0x8d387a0, 0xc000000003, 0x0, 0x0, 0x0, 0x0, 0x5a31b94, 0x29, 0xc001db7800, 0x1, ...)
W0730 16:58:44.606] 	/go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/vendor/k8s.io/klog/v2/klog.go:753 +0x19a
W0730 16:58:44.606] k8s.io/kubernetes/vendor/k8s.io/klog/v2.Fatalf(...)
W0730 16:58:44.606] 	/go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/vendor/k8s.io/klog/v2/klog.go:1514
W0730 16:58:44.606] k8s.io/kubernetes/test/e2e_node/services.(*server).start.func1(0xc000d41560, 0xc000f2fea0, 0xc000d415c0, 0xc000d41620)
W0730 16:58:44.606] 	/go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/test/e2e_node/services/server.go:180 +0xa75
W0730 16:58:44.607] created by k8s.io/kubernetes/test/e2e_node/services.(*server).start
```

#### Which issue(s) this PR fixes:
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs

```
