### PR TITLE
Automated cherry pick of #104040: e2e node server: fix crash in log line

### DIFF
--- a/test/e2e_node/services/server.go
+++ b/test/e2e_node/services/server.go
@@ -177,7 +177,7 @@ func (s *server) start() error {
 						s.startCommand.Wait() // Release resources if necessary.
 					}
 					// This should not happen, immediately stop the e2eService process.
-					klog.Fatalf("Restart loop readinessCheck failed for %s", s)
+					klog.Fatalf("Restart loop readinessCheck failed for %q", s.name)
 				} else {
 					klog.Infof("Initial health check passed for service %q", s.name)
 				}


### PR DESCRIPTION
Cherry pick of #104040 on release-1.22.

#104040: e2e node server: fix crash in log line

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.