### PR TITLE
Automated cherry pick of #103937: Fix disruptive subPath test failures

### DIFF
--- a/test/e2e/storage/testsuites/subpath.go
+++ b/test/e2e/storage/testsuites/subpath.go
@@ -346,6 +346,11 @@ func (s *subPathTestSuite) DefineTests(driver storageframework.TestDriver, patte
 		init()
 		defer cleanup()
 
+		if strings.HasPrefix(driverName, "hostPath") {
+			// TODO: This skip should be removed once #61446 is fixed
+			e2eskipper.Skipf("Driver %s does not support reconstruction, skipping", driverName)
+		}
+
 		testSubpathReconstruction(f, l.hostExec, l.pod, false)
 	})
 


### PR DESCRIPTION
Cherry pick of #103937 on release-1.21.

#103937: Fix disruptive subPath test failures

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.