### PR TITLE
fix unsafe json construction for digestConfigObjects.

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/patch_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/patch_test.go
@@ -1,0 +1,88 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package flowcontrol
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	flowcontrol "k8s.io/api/flowcontrol/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func Test_configController_generatePatchBytes(t *testing.T) {
+	now := time.Now().UTC()
+	tests := []struct {
+		name      string
+		condition flowcontrol.FlowSchemaCondition
+		want      []byte
+	}{
+		{
+			name: "check if only condition is parsed",
+			condition: flowcontrol.FlowSchemaCondition{
+				Type:               flowcontrol.FlowSchemaConditionDangling,
+				Status:             flowcontrol.ConditionTrue,
+				Reason:             "test reason",
+				Message:            "test none",
+				LastTransitionTime: metav1.NewTime(now),
+			},
+			want: []byte(fmt.Sprintf(`{"status":{"conditions":[{"type":"Dangling","status":"True","lastTransitionTime":"%s","reason":"test reason","message":"test none"}]}}`, now.Format(time.RFC3339))),
+		},
+		{
+			name: "check when message has double quotes",
+			condition: flowcontrol.FlowSchemaCondition{
+				Type:               flowcontrol.FlowSchemaConditionDangling,
+				Status:             flowcontrol.ConditionTrue,
+				Reason:             "test reason",
+				Message:            `test ""none`,
+				LastTransitionTime: metav1.NewTime(now),
+			},
+			want: []byte(fmt.Sprintf(`{"status":{"conditions":[{"type":"Dangling","status":"True","lastTransitionTime":"%s","reason":"test reason","message":"test \"\"none"}]}}`, now.Format(time.RFC3339))),
+		},
+		{
+			name: "check when message has a whitespace character that can be escaped",
+			condition: flowcontrol.FlowSchemaCondition{
+				Type:   flowcontrol.FlowSchemaConditionDangling,
+				Status: flowcontrol.ConditionTrue,
+				Reason: "test reason",
+				Message: `test 		none`,
+				LastTransitionTime: metav1.NewTime(now),
+			},
+			want: []byte(fmt.Sprintf(`{"status":{"conditions":[{"type":"Dangling","status":"True","lastTransitionTime":"%s","reason":"test reason","message":"test \t\tnone"}]}}`, now.Format(time.RFC3339))),
+		},
+		{
+			name: "check when a few fields (message & lastTransitionTime) are missing",
+			condition: flowcontrol.FlowSchemaCondition{
+				Type:   flowcontrol.FlowSchemaConditionDangling,
+				Status: flowcontrol.ConditionTrue,
+				Reason: "test reason",
+			},
+			want: []byte(`{"status":{"conditions":[{"type":"Dangling","status":"True","lastTransitionTime":null,"reason":"test reason"}]}}`),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, _ := makeFlowSchemaConditionPatch(tt.condition)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("makeFlowSchemaConditionPatch() got = %s, want %s; diff is %s", got, tt.want, cmp.Diff(tt.want, got))
+			}
+		})
+	}
+}


### PR DESCRIPTION
fix unsafe json creation by creating intermediate objects
while creating patch bytes.


#### What type of PR is this?

/kind bug



#### What this PR does / why we need it:

From a security audit, it was found that the code base is creating 
unsafe json in several places; this is one of those places. 
In order to avoid creation of unsafe json, use typed structs and then
call json.Marshal to validate it.


#### Which issue(s) this PR fixes:

https://github.com/kubernetes/kubernetes/issues/81134

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
