### PR TITLE
kubeadm: disallow the mixture of --config and --patches & remove deprecated --experimental-patches

### DIFF
--- a/cmd/kubeadm/app/apis/kubeadm/validation/validation.go
+++ b/cmd/kubeadm/app/apis/kubeadm/validation/validation.go
@@ -571,8 +571,6 @@ func isAllowedFlag(flagName string) bool {
 		kubeadmcmdoptions.KubeconfigDir,
 		kubeadmcmdoptions.UploadCerts,
 		kubeadmcmdoptions.Patches,
-		// TODO: https://github.com/kubernetes/kubeadm/issues/2046 remove in 1.23
-		kubeadmcmdoptions.ExperimentalPatches,
 		"print-join-command", "rootfs", "v", "log-file")
 	if allowedFlags.Has(flagName) {
 		return true

--- a/cmd/kubeadm/app/apis/kubeadm/validation/validation.go
+++ b/cmd/kubeadm/app/apis/kubeadm/validation/validation.go
@@ -570,7 +570,6 @@ func isAllowedFlag(flagName string) bool {
 		kubeadmcmdoptions.NodeName,
 		kubeadmcmdoptions.KubeconfigDir,
 		kubeadmcmdoptions.UploadCerts,
-		kubeadmcmdoptions.Patches,
 		"print-join-command", "rootfs", "v", "log-file")
 	if allowedFlags.Has(flagName) {
 		return true

--- a/cmd/kubeadm/app/cmd/options/constant.go
+++ b/cmd/kubeadm/app/cmd/options/constant.go
@@ -145,8 +145,4 @@ const (
 
 	// Patches flag sets the folder where kubeadm component patches are stored
 	Patches = "patches"
-
-	// ExperimentalPatches (DEPRECATED) is the same as Patches
-	// TODO: https://github.com/kubernetes/kubeadm/issues/2046 remove in 1.23
-	ExperimentalPatches = "experimental-patches"
 )

--- a/cmd/kubeadm/app/cmd/options/generic.go
+++ b/cmd/kubeadm/app/cmd/options/generic.go
@@ -102,7 +102,4 @@ func AddPatchesFlag(fs *pflag.FlagSet, patchesDir *string) {
 		`"json" or "yaml". "suffix" is an optional string that can be used to determine ` +
 		`which patches are applied first alpha-numerically.`
 	fs.StringVar(patchesDir, Patches, *patchesDir, usage)
-	// TODO: https://github.com/kubernetes/kubeadm/issues/2046 remove in 1.23
-	fs.StringVar(patchesDir, ExperimentalPatches, *patchesDir, usage)
-	fs.MarkDeprecated(ExperimentalPatches, "This flag will be removed in a future version. Please use '--patches' instead.")
 }

--- a/cmd/kubeadm/app/cmd/phases/init/controlplane.go
+++ b/cmd/kubeadm/app/cmd/phases/init/controlplane.go
@@ -101,8 +101,6 @@ func getControlPlanePhaseFlags(name string) []string {
 		options.KubernetesVersion,
 		options.ImageRepository,
 		options.Patches,
-		// TODO: https://github.com/kubernetes/kubeadm/issues/2046 remove in 1.23
-		options.ExperimentalPatches,
 		options.DryRun,
 	}
 	if name == "all" || name == kubeadmconstants.KubeAPIServer {

--- a/cmd/kubeadm/app/cmd/phases/join/controlplanejoin.go
+++ b/cmd/kubeadm/app/cmd/phases/join/controlplanejoin.go
@@ -44,8 +44,6 @@ func getControlPlaneJoinPhaseFlags(name string) []string {
 	}
 	if name == "etcd" || name == "all" {
 		flags = append(flags, options.Patches)
-		// TODO: https://github.com/kubernetes/kubeadm/issues/2046 remove in 1.23
-		flags = append(flags, options.ExperimentalPatches)
 	}
 	if name != "mark-control-plane" {
 		flags = append(flags, options.APIServerAdvertiseAddress)

--- a/cmd/kubeadm/app/cmd/phases/join/controlplaneprepare.go
+++ b/cmd/kubeadm/app/cmd/phases/join/controlplaneprepare.go
@@ -80,8 +80,6 @@ func getControlPlanePreparePhaseFlags(name string) []string {
 			options.TokenStr,
 			options.CertificateKey,
 			options.Patches,
-			// TODO: https://github.com/kubernetes/kubeadm/issues/2046 remove in 1.23
-			options.ExperimentalPatches,
 		}
 	case "download-certs":
 		flags = []string{
@@ -127,8 +125,6 @@ func getControlPlanePreparePhaseFlags(name string) []string {
 			options.CfgPath,
 			options.ControlPlane,
 			options.Patches,
-			// TODO: https://github.com/kubernetes/kubeadm/issues/2046 remove in 1.23
-			options.ExperimentalPatches,
 		}
 	default:
 		flags = []string{}

--- a/cmd/kubeadm/app/cmd/phases/upgrade/node/controlplane.go
+++ b/cmd/kubeadm/app/cmd/phases/upgrade/node/controlplane.go
@@ -40,8 +40,6 @@ func NewControlPlane() workflow.Phase {
 			options.CertificateRenewal,
 			options.EtcdUpgrade,
 			options.Patches,
-			// TODO: https://github.com/kubernetes/kubeadm/issues/2046 remove in 1.23
-			options.ExperimentalPatches,
 		},
 	}
 	return phase


### PR DESCRIPTION
#### What type of PR is this?
/kind feature
/area kubeadm
/sig cluster-lifecycle
milestone 1.23

- [x]  https://github.com/kubernetes/kubeadm/pull/2537 

#### Which issue(s) this PR fixes:
follow up of #103063 
part of https://github.com/kubernetes/kubeadm/issues/2046

#### Does this PR introduce a user-facing change?
```release-note
ACTION REQUIRED: kubeadm: remove the deprecated flag --experimental-patches for the init|join|upgrade commands. The flag --patches is no longer allowed in a mixture with the flag --config. Please use the kubeadm configuration for setting patches for a node using {Init|Join}Configuration.patches.
```

```docs
- [KEP]: https://github.com/kubernetes/enhancements/tree/master/keps/sig-cluster-lifecycle/kubeadm/1739-customization-with-patches
```
