### PR TITLE
Update generic_scheduler.go

### DIFF
--- a/pkg/scheduler/core/generic_scheduler.go
+++ b/pkg/scheduler/core/generic_scheduler.go
@@ -546,8 +546,7 @@ func (g *genericScheduler) findNodesThatFit(pluginContext *framework.PluginConte
 						extender, err)
 					continue
 				}
-
-				return []*v1.Node{}, FailedPredicateMap{}, framework.NodeToStatusMap{}, err
+	                        return filtered, failedPredicateMap, filteredNodesStatuses, nil
 			}
 
 			for failedNodeName, failedMsg := range failedMap {


### PR DESCRIPTION
What type of PR is this?

/kind bug
/sig scheduling

What this PR does / why we need it:

An exception occurs when the filter is used to extend the service, and the entire scheduling process fails.

I think this design is not reasonable.

So I think if the schedule filter expansion fails, the default filter nodes should be returned.
