### PR TITLE
Fix zone calculation - consider only untainted nodes

### DIFF
--- a/test/e2e/framework/node/resource.go
+++ b/test/e2e/framework/node/resource.go
@@ -563,18 +563,15 @@ func GetClusterZones(c clientset.Interface) (sets.String, error) {
 
 // GetSchedulableClusterZones returns the values of zone label collected from all nodes which are schedulable.
 func GetSchedulableClusterZones(c clientset.Interface) (sets.String, error) {
-	nodes, err := c.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{})
+	// GetReadySchedulableNodes already filters our tainted and unschedulable nodes.
+	nodes, err := GetReadySchedulableNodes(c)
 	if err != nil {
-		return nil, fmt.Errorf("Error getting nodes while attempting to list cluster zones: %v", err)
+		return nil, fmt.Errorf("error getting nodes while attempting to list cluster zones: %v", err)
 	}
 
 	// collect values of zone label from all nodes
 	zones := sets.NewString()
 	for _, node := range nodes.Items {
-		// We should have at least 1 node in the zone which is schedulable.
-		if !IsNodeSchedulable(&node) {
-			continue
-		}
 		if zone, found := node.Labels[v1.LabelFailureDomainBetaZone]; found {
 			zones.Insert(zone)
 		}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind flake

#### What this PR does / why we need it:
Tests "Multi-AZ Cluster Volumes" should consider only nodes that are schedulable and *untainted* when computing AZ where to run the tests.

Let's reuse `GetReadySchedulableNodes()`, which already filters schedulable + untainted nodes.

#### Which issue(s) this PR fixes:
Fixes a flake when "Multi-AZ Cluster Volumes" tests were run on a cluster with tainted nodes in one AZ. Such zone should not be used for the test. Found in a downstream CI.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
