### PR TITLE
Automated cherry pick of #104047: Log e2e-node kubelet output directly to file

### DIFF
--- a/test/e2e_node/services/kubelet.go
+++ b/test/e2e_node/services/kubelet.go
@@ -194,6 +194,7 @@ func (e *E2EServices) startKubelet() (*server, error) {
 		cmdArgs = append(cmdArgs,
 			systemdRun,
 			"-p", "Delegate=true",
+			"-p", "StandardError=file:"+framework.TestContext.ReportDir+"/kubelet.log",
 			"--unit="+unitName,
 			"--slice=runtime.slice",
 			"--remain-after-exit",
@@ -201,10 +202,6 @@ func (e *E2EServices) startKubelet() (*server, error) {
 
 		killCommand = exec.Command("systemctl", "kill", unitName)
 		restartCommand = exec.Command("systemctl", "restart", unitName)
-		e.logs["kubelet.log"] = LogFileData{
-			Name:              "kubelet.log",
-			JournalctlCommand: []string{"-u", unitName},
-		}
 
 		kc.KubeletCgroups = "/kubelet.slice"
 		kubeletConfigFlags = append(kubeletConfigFlags, "kubelet-cgroups")


### PR DESCRIPTION
Cherry pick of #104047 on release-1.22.

#104047: Log e2e-node kubelet output directly to file

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
NONE
```