### PR TITLE
Add an option to specify an authorization webhook timeout

### DIFF
--- a/cmd/kube-apiserver/app/options/options_test.go
+++ b/cmd/kube-apiserver/app/options/options_test.go
@@ -91,6 +91,7 @@ func TestAddFlags(t *testing.T) {
 		"--authorization-webhook-cache-authorized-ttl=3m",
 		"--authorization-webhook-cache-unauthorized-ttl=1m",
 		"--authorization-webhook-config-file=/webhook-config",
+		"--authorization-webhook-request-timeout=10m",
 		"--bind-address=192.168.10.20",
 		"--client-ca-file=/client-ca",
 		"--cloud-config=/cloud-config",
@@ -294,6 +295,7 @@ func TestAddFlags(t *testing.T) {
 			WebhookCacheUnauthorizedTTL: 60000000000,
 			WebhookVersion:              "v1beta1",
 			WebhookRetryBackoff:         apiserveroptions.DefaultAuthWebhookRetryBackoff(),
+			WebhookRequestTimeout:       10 * time.Minute,
 		},
 		CloudProvider: &kubeoptions.CloudProviderOptions{
 			CloudConfigFile: "/cloud-config",

--- a/pkg/kubeapiserver/authorizer/config.go
+++ b/pkg/kubeapiserver/authorizer/config.go
@@ -51,6 +51,8 @@ type Config struct {
 	WebhookConfigFile string
 	// API version of subject access reviews to send to the webhook (e.g. "v1", "v1beta1")
 	WebhookVersion string
+	// Request time out for the request to the webhook server.
+	WebhookRequestTimeout time.Duration
 	// TTL for caching of authorized responses from the webhook server.
 	WebhookCacheAuthorizedTTL time.Duration
 	// TTL for caching of unauthorized responses from the webhook server.
@@ -119,7 +121,8 @@ func (config Config) New() (authorizer.Authorizer, authorizer.RuleResolver, erro
 				config.WebhookCacheAuthorizedTTL,
 				config.WebhookCacheUnauthorizedTTL,
 				*config.WebhookRetryBackoff,
-				config.CustomDial)
+				config.CustomDial,
+				config.WebhookRequestTimeout)
 			if err != nil {
 				return nil, nil, err
 			}

--- a/pkg/kubeapiserver/options/authorization.go
+++ b/pkg/kubeapiserver/options/authorization.go
@@ -36,6 +36,7 @@ type BuiltInAuthorizationOptions struct {
 	Modes                       []string
 	PolicyFile                  string
 	WebhookConfigFile           string
+	WebhookRequestTimeout       time.Duration
 	WebhookVersion              string
 	WebhookCacheAuthorizedTTL   time.Duration
 	WebhookCacheUnauthorizedTTL time.Duration
@@ -112,6 +113,10 @@ func (o *BuiltInAuthorizationOptions) AddFlags(fs *pflag.FlagSet) {
 		"File with webhook configuration in kubeconfig format, used with --authorization-mode=Webhook. "+
 		"The API server will query the remote service to determine access on the API server's secure port.")
 
+	fs.DurationVar(&o.WebhookRequestTimeout,
+		"authorization-webhook-request-timeout", o.WebhookRequestTimeout,
+		"The timeout duration set on the webhook authorizer request.")
+
 	fs.StringVar(&o.WebhookVersion, "authorization-webhook-version", o.WebhookVersion, ""+
 		"The API version of the authorization.k8s.io SubjectAccessReview to send to and expect from the webhook.")
 
@@ -135,5 +140,6 @@ func (o *BuiltInAuthorizationOptions) ToAuthorizationConfig(versionedInformerFac
 		WebhookCacheUnauthorizedTTL: o.WebhookCacheUnauthorizedTTL,
 		VersionedInformerFactory:    versionedInformerFactory,
 		WebhookRetryBackoff:         o.WebhookRetryBackoff,
+		WebhookRequestTimeout:       o.WebhookRequestTimeout,
 	}
 }

--- a/staging/src/k8s.io/apiserver/plugin/pkg/authorizer/webhook/webhook_v1_test.go
+++ b/staging/src/k8s.io/apiserver/plugin/pkg/authorizer/webhook/webhook_v1_test.go
@@ -198,7 +198,7 @@ current-context: default
 			if err != nil {
 				return fmt.Errorf("error building sar client: %v", err)
 			}
-			_, err = newWithBackoff(sarClient, 0, 0, testRetryBackoff, noopAuthorizerMetrics())
+			_, err = newWithBackoff(sarClient, 0, 0, testRetryBackoff, noopAuthorizerMetrics(), 0)
 			return err
 		}()
 		if err != nil && !tt.wantErr {
@@ -337,7 +337,7 @@ func newV1Authorizer(callbackURL string, clientCert, clientKey, ca []byte, cache
 	if err != nil {
 		return nil, fmt.Errorf("error building sar client: %v", err)
 	}
-	return newWithBackoff(sarClient, cacheTime, cacheTime, testRetryBackoff, metrics)
+	return newWithBackoff(sarClient, cacheTime, cacheTime, testRetryBackoff, metrics, 0)
 }
 
 func TestV1TLSConfig(t *testing.T) {

--- a/staging/src/k8s.io/apiserver/plugin/pkg/authorizer/webhook/webhook_v1beta1_test.go
+++ b/staging/src/k8s.io/apiserver/plugin/pkg/authorizer/webhook/webhook_v1beta1_test.go
@@ -190,7 +190,7 @@ current-context: default
 			if err != nil {
 				return fmt.Errorf("error building sar client: %v", err)
 			}
-			_, err = newWithBackoff(sarClient, 0, 0, testRetryBackoff, noopAuthorizerMetrics())
+			_, err = newWithBackoff(sarClient, 0, 0, testRetryBackoff, noopAuthorizerMetrics(), 0)
 			return err
 		}()
 		if err != nil && !tt.wantErr {
@@ -329,7 +329,7 @@ func newV1beta1Authorizer(callbackURL string, clientCert, clientKey, ca []byte, 
 	if err != nil {
 		return nil, fmt.Errorf("error building sar client: %v", err)
 	}
-	return newWithBackoff(sarClient, cacheTime, cacheTime, testRetryBackoff, noopAuthorizerMetrics())
+	return newWithBackoff(sarClient, cacheTime, cacheTime, testRetryBackoff, noopAuthorizerMetrics(), 0)
 }
 
 func TestV1beta1TLSConfig(t *testing.T) {


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
Adds an option to specify a authorizer webhook request timeout in the built-in authenticator options

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs

```
