### PR TITLE
Format multiple pods to a string like single ones

### DIFF
--- a/pkg/kubelet/util/format/pod.go
+++ b/pkg/kubelet/util/format/pod.go
@@ -55,12 +55,12 @@ func PodWithDeletionTimestamp(pod *v1.Pod) string {
 	return Pod(pod) + deletionTimestamp
 }
 
-// Pods returns a list of pods as ObjectRef
-func Pods(pods []*v1.Pod) []klog.ObjectRef {
-	podKObjs := make([]klog.ObjectRef, 0, len(pods))
+// Pods returns a list of pods as strings of the form $ns/$name
+func Pods(pods []*v1.Pod) []string {
+	podKObjs := make([]string, 0, len(pods))
 	for _, p := range pods {
 		if p != nil {
-			podKObjs = append(podKObjs, klog.KObj(p))
+			podKObjs = append(podKObjs, klog.KObj(p).String())
 		}
 	}
 	return podKObjs


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This might not actually be correct and I'm happy to bin this:

This makes the behavior of multiple pods (i.e. using the `"pods"` field with the `format.Pods` helper) behave the same as single pods do, especially in JSON formatted logging.

Currently, a line with multiple pods would be logged like this

```
{"ts":1628007538403.2212,"caller":"kubelet/kubelet.go:1941","msg":"SyncLoop ADD","v":2,"source":"api","pods":[{"namespace":"default","name":"basic-30fb5d6a-7063-411d-a21e-432ece8bdede"}]}
```

(note the object inside the array)

A single pod however, is logged like this:

```
{"ts":1628001511209.806,"caller":"config/config.go:383","msg":"Receiving a new pod","v":4,"pod":"default/basic-b7ab1b87-c31d-42f4-94aa-750c5f7f3f5d"}
```

(note that it's not an object but a string)

That feels inconsistent, so this changes the `format.Pod` function to force-output a string as well. With this change, the log line above becomes

```
{"ts":1628007538403.2212,"caller":"kubelet/kubelet.go:1941","msg":"SyncLoop ADD","v":2,"source":"api","pods":["default/basic-30fb5d6a-7063-411d-a21e-432ece8bdede"]}
```

#### Special notes for your reviewer:

As mentioned, this might be misled and there might be a setting for the log output that I haven't found that'd achieve the same. I'm happy to bin this if there's a better way.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
