### PR TITLE
add a keepalive time to the konnectivity server

### DIFF
--- a/cluster/gce/gci/configure-helper.sh
+++ b/cluster/gce/gci/configure-helper.sh
@@ -1944,6 +1944,8 @@ function prepare-konnectivity-server-manifest {
   params+=("--authentication-audience=system:konnectivity-server")
   params+=("--kubeconfig-qps=75")
   params+=("--kubeconfig-burst=150")
+  params+=("--keepalive-time=60s")
+  params+=("--frontend-keepalive-time=60s")
   konnectivity_args=""
   for param in "${params[@]}"; do
     konnectivity_args+=", \"${param}\""


### PR DESCRIPTION
/kind bug
/assign @cheftako @jkh52 

This is the [`keepalive` interval](https://github.com/kubernetes-sigs/apiserver-network-proxy/blob/master/cmd/server/app/options/options.go#L41) that the proxy server checks if the proxy agent is still healthy. This helps the proxy server to detect an unhealthy proxy agent early and avoid sending traffic to the unhealthy agent.

The default value is [1 hour](https://github.com/kubernetes-sigs/apiserver-network-proxy/blob/master/cmd/server/app/options/options.go#L280), changing it to 60s should significantly reduce the chance that the proxy server picks an unhealthy proxy agent as the backend.