### PR TITLE
Use docker buildx for etcd image

### DIFF
--- a/cluster/images/etcd/Makefile
+++ b/cluster/images/etcd/Makefile
@@ -34,7 +34,7 @@ LATEST_ETCD_VERSION?=3.5.0
 # REVISION provides a version number for this image and all it's bundled
 # artifacts. It should start at zero for each LATEST_ETCD_VERSION and increment
 # for each revision of this image at that etcd version.
-REVISION?=0
+REVISION?=1
 
 # IMAGE_TAG Uniquely identifies k8s.gcr.io/etcd docker image with a tag of the form "<etcd-version>-<revision>".
 IMAGE_TAG=$(LATEST_ETCD_VERSION)-$(REVISION)
@@ -83,6 +83,8 @@ ifeq ($(ARCH),s390x)
 endif
 
 RUNNERIMAGE?=gcr.io/distroless/static:latest
+
+QEMUVERSION?=5.2.0-2
 
 build:
 	# Explicitly copy files to the temp directory
@@ -143,13 +145,20 @@ else
 	cd $(TEMP_DIR) && echo "ENV ETCD_UNSUPPORTED_ARCH=$(ARCH)" >> Dockerfile
 endif
 
+	docker run --rm --privileged multiarch/qemu-user-static:$(QEMUVERSION) --reset -p yes
+	docker buildx version
+	BUILDER=$(shell docker buildx create --use)
+
 	# And build the image
-	docker build \
+	docker buildx build \
 		--pull \
+		--load \
+		--platform linux/$(ARCH) \
 		-t $(REGISTRY)/etcd-$(ARCH):$(IMAGE_TAG) \
 		--build-arg BASEIMAGE=$(BASEIMAGE) \
 		--build-arg RUNNERIMAGE=$(RUNNERIMAGE) \
 		$(TEMP_DIR)
+	docker buildx rm $$BUILDER
 
 push: build
 	docker tag $(REGISTRY)/etcd-$(ARCH):$(IMAGE_TAG) $(MANIFEST_IMAGE)-$(ARCH):$(IMAGE_TAG)


### PR DESCRIPTION
#### What type of PR is this?

/kind bug


#### What this PR does / why we need it:
This allows to choose the correct architecture in the image manifest,
which defaulted to the host system before applying this patch.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Refers to https://github.com/kubernetes/kubernetes/issues/104085

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fixed architecture within manifest for non `amd64` etcd images.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
None
```
