### PR TITLE
devicemanager: skip unhealthy devices in GetAllocatable

### DIFF
--- a/pkg/kubelet/cm/devicemanager/manager.go
+++ b/pkg/kubelet/cm/devicemanager/manager.go
@@ -1103,12 +1103,12 @@ func (m *ManagerImpl) isDevicePluginResource(resource string) bool {
 	return false
 }
 
-// GetAllocatableDevices returns information about all the devices known to the manager
+// GetAllocatableDevices returns information about all the healthy devices known to the manager
 func (m *ManagerImpl) GetAllocatableDevices() ResourceDeviceInstances {
 	m.mutex.Lock()
-	resp := m.allDevices.Clone()
-	m.mutex.Unlock()
-	klog.V(4).InfoS("Known devices", "numDevices", len(resp))
+	defer m.mutex.Unlock()
+	resp := m.allDevices.Filter(m.healthyDevices)
+	klog.V(4).InfoS("GetAllocatableDevices", "known", len(m.allDevices), "allocatable", len(resp))
 	return resp
 }
 

--- a/pkg/kubelet/cm/devicemanager/manager_test.go
+++ b/pkg/kubelet/cm/devicemanager/manager_test.go
@@ -434,6 +434,100 @@ func TestUpdateCapacityAllocatable(t *testing.T) {
 	as.True(testManager.isDevicePluginResource(resourceName2))
 }
 
+func TestGetAllocatableDevicesMultipleResources(t *testing.T) {
+	socketDir, socketName, _, err := tmpSocketDir()
+	topologyStore := topologymanager.NewFakeManager()
+	require.NoError(t, err)
+	defer os.RemoveAll(socketDir)
+	testManager, err := newManagerImpl(socketName, nil, topologyStore)
+	as := assert.New(t)
+	as.NotNil(testManager)
+	as.Nil(err)
+
+	resource1Devs := []pluginapi.Device{
+		{ID: "R1Device1", Health: pluginapi.Healthy},
+		{ID: "R1Device2", Health: pluginapi.Healthy},
+		{ID: "R1Device3", Health: pluginapi.Unhealthy},
+	}
+	resourceName1 := "domain1.com/resource1"
+	e1 := &endpointImpl{}
+	testManager.endpoints[resourceName1] = endpointInfo{e: e1, opts: nil}
+	testManager.genericDeviceUpdateCallback(resourceName1, resource1Devs)
+
+	resource2Devs := []pluginapi.Device{
+		{ID: "R2Device1", Health: pluginapi.Healthy},
+	}
+	resourceName2 := "other.domain2.org/resource2"
+	e2 := &endpointImpl{}
+	testManager.endpoints[resourceName2] = endpointInfo{e: e2, opts: nil}
+	testManager.genericDeviceUpdateCallback(resourceName2, resource2Devs)
+
+	allocatableDevs := testManager.GetAllocatableDevices()
+	as.Equal(2, len(allocatableDevs))
+
+	devInstances1, ok := allocatableDevs[resourceName1]
+	as.True(ok)
+	checkAllocatableDevicesConsistsOf(as, devInstances1, []string{"R1Device1", "R1Device2"})
+
+	devInstances2, ok := allocatableDevs[resourceName2]
+	as.True(ok)
+	checkAllocatableDevicesConsistsOf(as, devInstances2, []string{"R2Device1"})
+
+}
+
+func TestGetAllocatableDevicesHealthTransition(t *testing.T) {
+	socketDir, socketName, _, err := tmpSocketDir()
+	topologyStore := topologymanager.NewFakeManager()
+	require.NoError(t, err)
+	defer os.RemoveAll(socketDir)
+	testManager, err := newManagerImpl(socketName, nil, topologyStore)
+	as := assert.New(t)
+	as.NotNil(testManager)
+	as.Nil(err)
+
+	resource1Devs := []pluginapi.Device{
+		{ID: "R1Device1", Health: pluginapi.Healthy},
+		{ID: "R1Device2", Health: pluginapi.Healthy},
+		{ID: "R1Device3", Health: pluginapi.Unhealthy},
+	}
+
+	// Adds three devices for resource1, two healthy and one unhealthy.
+	// Expects allocatable devices for resource1 to be 2.
+	resourceName1 := "domain1.com/resource1"
+	e1 := &endpointImpl{}
+	testManager.endpoints[resourceName1] = endpointInfo{e: e1, opts: nil}
+
+	testManager.genericDeviceUpdateCallback(resourceName1, resource1Devs)
+
+	allocatableDevs := testManager.GetAllocatableDevices()
+	as.Equal(1, len(allocatableDevs))
+	devInstances, ok := allocatableDevs[resourceName1]
+	as.True(ok)
+	checkAllocatableDevicesConsistsOf(as, devInstances, []string{"R1Device1", "R1Device2"})
+
+	// Unhealthy device becomes healthy
+	resource1Devs = []pluginapi.Device{
+		{ID: "R1Device1", Health: pluginapi.Healthy},
+		{ID: "R1Device2", Health: pluginapi.Healthy},
+		{ID: "R1Device3", Health: pluginapi.Healthy},
+	}
+	testManager.genericDeviceUpdateCallback(resourceName1, resource1Devs)
+
+	allocatableDevs = testManager.GetAllocatableDevices()
+	as.Equal(1, len(allocatableDevs))
+	devInstances, ok = allocatableDevs[resourceName1]
+	as.True(ok)
+	checkAllocatableDevicesConsistsOf(as, devInstances, []string{"R1Device1", "R1Device2", "R1Device3"})
+}
+
+func checkAllocatableDevicesConsistsOf(as *assert.Assertions, devInstances DeviceInstances, expectedDevs []string) {
+	as.Equal(len(expectedDevs), len(devInstances))
+	for _, deviceID := range expectedDevs {
+		_, ok := devInstances[deviceID]
+		as.True(ok)
+	}
+}
+
 func constructDevices(devices []string) checkpoint.DevicesPerNUMA {
 	ret := checkpoint.DevicesPerNUMA{}
 	for _, dev := range devices {

--- a/pkg/kubelet/cm/devicemanager/pod_devices.go
+++ b/pkg/kubelet/cm/devicemanager/pod_devices.go
@@ -384,3 +384,21 @@ func (rdev ResourceDeviceInstances) Clone() ResourceDeviceInstances {
 	}
 	return clone
 }
+
+// Filter takes a condition set expressed as map[string]sets.String and returns a new
+// ResourceDeviceInstances with only the devices matching the condition set.
+func (rdev ResourceDeviceInstances) Filter(cond map[string]sets.String) ResourceDeviceInstances {
+	filtered := NewResourceDeviceInstances()
+	for resourceName, filterIDs := range cond {
+		if _, exists := rdev[resourceName]; !exists {
+			continue
+		}
+		filtered[resourceName] = DeviceInstances{}
+		for instanceID, instance := range rdev[resourceName] {
+			if filterIDs.Has(instanceID) {
+				filtered[resourceName][instanceID] = instance
+			}
+		}
+	}
+	return filtered
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:
The `GetAllocatableDevices` function, needed to support the podresources API, doesn't take into account the device health when computing its output.
    
In this PR we address this gap and add unit tests along the way to prevent regressions.
This gives us a good initial coverage, E2E tests to cover this case are much harder to write, because we would need to inject faults to trigger the unhealthy status. We will evaluate if adding these tests into later PRs.


#### Which issue(s) this PR fixes:
Fixes #104122

#### Special notes for your reviewer:
This ONLY affects the podresources API - the core device manager functionality is not affected.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
