### PR TITLE
Add ExemptPathsRequestsInFlight flag for skip paths from rate limit

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/server/filters/maxinflight.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/filters/maxinflight.go
@@ -124,6 +124,7 @@ func WithMaxInFlightLimit(
 	nonMutatingLimit int,
 	mutatingLimit int,
 	longRunningRequestCheck apirequest.LongRunningRequestCheck,
+	exemptPathsRequestsInFlight []string,
 ) http.Handler {
 	if nonMutatingLimit == 0 && mutatingLimit == 0 {
 		return handler
@@ -151,6 +152,14 @@ func WithMaxInFlightLimit(
 		if longRunningRequestCheck != nil && longRunningRequestCheck(r, requestInfo) {
 			handler.ServeHTTP(w, r)
 			return
+		}
+
+		// Skip exempt paths
+		for _, exemptPath := range exemptPathsRequestsInFlight {
+			if exemptPath == requestInfo.Path {
+				handler.ServeHTTP(w, r)
+				return
+			}
 		}
 
 		var c chan bool


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:
The PR adds the `ExemptPathsRequestsInFlight` flag for providing a list of paths exempt from the inFlight requests rate limiter.
The current implementation (before APIPriorityAndFairness) is limiting all the requests to the API server which results to situations of heavy load when API Server also blocks telemetry and health endpoints (`/readyz`, `/healthz`, `/metrics` e.t.c) as it suggested in https://kubernetes.io/docs/concepts/cluster-administration/flow-control/#health-check-concurrency-exemption, but in terms of old in-flight requests rate limiter.

It could be unnecessary after https://kubernetes.io/docs/concepts/cluster-administration/flow-control/, while the switch to APIPriorityAndFairness could be more difficult and slow, rather than adding such flag, which is already needed now.

#### Does this PR introduce a user-facing change?
```release-note
Added optional flag --exempt-paths-requests-inflight for ignoring some URLs from rate limiting
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

