### PR TITLE
Automated cherry pick of #104129: job controller: don't mutate shared cache object

### DIFF
--- a/pkg/controller/job/job_controller.go
+++ b/pkg/controller/job/job_controller.go
@@ -460,7 +460,8 @@ func (jm *Controller) syncJob(key string) (bool, error) {
 		}
 		return false, err
 	}
-	job := *sharedJob
+	// make a copy so we don't mutate the shared cache
+	job := *sharedJob.DeepCopy()
 
 	// if job was finished previously, we don't want to redo the termination
 	if IsJobFinished(&job) {


### PR DESCRIPTION
Cherry pick of #104129 on release-1.19.

#104129: job controller: don't mutate shared cache object

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

Release note:

```release-note
Fixed a bug in the job controller to not mutate the shared cache
```