### PR TITLE
[WIP] Add e2e for container restart backoff

### DIFF
--- a/test/conformance/testdata/conformance.yaml
+++ b/test/conformance/testdata/conformance.yaml
@@ -1740,6 +1740,12 @@
     accordingly.
   release: v1.13
   file: test/e2e/common/node/runtime.go
+- testname: Kubelet, Container, Restart, Backoff
+  codename: '[sig-node] ContainerRestartBackoff when a container restart Should be
+    restarted the container with an exponential backoff [NodeConformance] [Conformance]'
+  description: Restarted the container with an exponential backoff.
+  release: v1.23
+  file: test/e2e/common/node/container_restart_backoff.go
 - testname: Containers, with arguments
   codename: '[sig-node] Containers should be able to override the image''s default
     arguments (container cmd) [NodeConformance] [Conformance]'

--- a/test/e2e/common/node/container_restart_backoff.go
+++ b/test/e2e/common/node/container_restart_backoff.go
@@ -78,6 +78,7 @@ var _ = SIGDescribe("ContainerRestartBackoff", func() {
 				300, // Maximum duration of retreat backoff from pkg/kubelet.MaxContainerBackOff
 				300,
 				300,
+				300,
 			}
 
 			ginkgo.By("watch container restart")

--- a/test/e2e/common/node/container_restart_backoff.go
+++ b/test/e2e/common/node/container_restart_backoff.go
@@ -1,0 +1,131 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package node
+
+import (
+	"context"
+	"time"
+
+	"github.com/onsi/ginkgo"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/kubernetes/test/e2e/framework"
+)
+
+var _ = SIGDescribe("ContainerRestartBackoff", func() {
+	f := framework.NewDefaultFramework("container-restart-backoff-test")
+	ginkgo.Context("when a container restart", func() {
+
+		/*
+		  Release: v1.23
+		  Testname: Kubelet, Container, Restart, Backoff
+		  Description: Restarted the container with an exponential backoff.
+		*/
+		framework.ConformanceIt("Should be restarted the container with an exponential backoff [NodeConformance]", func() {
+			ginkgo.By("create container")
+			name := "test-container-restart-backoff"
+			pod := &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: name,
+				},
+				Spec: v1.PodSpec{
+					RestartPolicy: v1.RestartPolicyAlways,
+					Containers: []v1.Container{
+						{
+							Name:  "c",
+							Image: framework.BusyBoxImage,
+							Command: []string{
+								"false",
+							},
+						},
+					},
+				},
+			}
+			f.PodClient().Create(pod)
+			defer f.PodClient().Delete(context.Background(), pod.Name, metav1.DeleteOptions{})
+
+			watcher, err := f.PodClient().Watch(context.Background(), metav1.ListOptions{
+				FieldSelector: fields.OneTermEqualSelector("metadata.name", pod.Name).String(),
+			})
+			framework.ExpectNoError(err, "watch pod")
+			defer watcher.Stop()
+
+			backOffPeriod := 10 // pkg/kubelet.backOffPeriod
+			expectRestartBackoffSecond := []int{
+				0,
+				10, // Period duration of retreat backoff from pkg/kubelet.backOffPeriod
+				10,
+				10, // Initial duration of retreat backoff from pkg/kubelet.backOffPeriod
+				20,
+				40,
+				80,
+				160,
+				300, // Maximum duration of retreat backoff from pkg/kubelet.MaxContainerBackOff
+				300,
+				300,
+			}
+
+			ginkgo.By("watch container restart")
+			var count int32
+			var lastAt time.Time
+			for result := range watcher.ResultChan() {
+				pod := result.Object.(*v1.Pod)
+				if pod.Name != name {
+					continue
+				}
+				if len(pod.Status.ContainerStatuses) == 0 {
+					continue
+				}
+				status := pod.Status.ContainerStatuses[0]
+				terminated := status.LastTerminationState.Terminated
+				if terminated == nil {
+					continue
+				}
+				if status.RestartCount <= count {
+					continue
+				}
+				if lastAt.IsZero() && pod.Status.StartTime != nil {
+					lastAt = pod.Status.StartTime.Time
+				}
+
+				count = status.RestartCount
+				if int(count) >= len(expectRestartBackoffSecond) {
+					break
+				}
+
+				// Get actual tolerance
+				gotIntervalSecond := int(terminated.StartedAt.Sub(lastAt) / time.Second)
+				wantIntervalSecond := expectRestartBackoffSecond[count]
+				gotTolerance := gotIntervalSecond - wantIntervalSecond
+				if gotTolerance < 0 {
+					gotTolerance = -gotTolerance
+				}
+
+				framework.Logf("container restart backoff: count:%d interval:%ds startdAt:%s", count, gotIntervalSecond, terminated.StartedAt)
+
+				// Theoretically, the maximum tolerance is backOffPeriod, but in order to avoid the flakes from increasing the tolerance
+				tolerance := backOffPeriod * 2
+				if tolerance < gotTolerance {
+					framework.Failf("container restart backoff does not meet expectations tolerance, want:%ds got:%ds", tolerance, gotTolerance)
+				}
+
+				lastAt = terminated.StartedAt.Time
+			}
+		})
+	})
+})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
xref #103257

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
NONE
```
