### PR TITLE
set AllowLongNodeID to true by default since 1.23

### DIFF
--- a/pkg/registry/storage/csinode/strategy.go
+++ b/pkg/registry/storage/csinode/strategy.go
@@ -47,11 +47,8 @@ func (csiNodeStrategy) PrepareForCreate(ctx context.Context, obj runtime.Object)
 
 func (csiNodeStrategy) Validate(ctx context.Context, obj runtime.Object) field.ErrorList {
 	csiNode := obj.(*storage.CSINode)
-
-	// in 1.22, on create, set AllowLongNodeID=false
-	// in 1.23, on create, set AllowLongNodeID=true
 	validateOptions := validation.CSINodeValidationOptions{
-		AllowLongNodeID: false,
+		AllowLongNodeID: true,
 	}
 
 	errs := validation.ValidateCSINode(csiNode, validateOptions)
@@ -77,16 +74,8 @@ func (csiNodeStrategy) PrepareForUpdate(ctx context.Context, obj, old runtime.Ob
 func (csiNodeStrategy) ValidateUpdate(ctx context.Context, obj, old runtime.Object) field.ErrorList {
 	newCSINodeObj := obj.(*storage.CSINode)
 	oldCSINodeObj := old.(*storage.CSINode)
-	// in 1.22 on update, set AllowLongNodeID to true only if the old object already has a long node ID
-	// in 1.23 on update, set AllowLongNodeID=true
-	allowLongNodeID := false
-	for _, nodeDriver := range oldCSINodeObj.Spec.Drivers {
-		if validation.CSINodeLongerID(nodeDriver.NodeID) {
-			allowLongNodeID = true
-		}
-	}
 	validateOptions := validation.CSINodeValidationOptions{
-		AllowLongNodeID: allowLongNodeID,
+		AllowLongNodeID: true,
 	}
 
 	errorList := validation.ValidateCSINode(newCSINodeObj, validateOptions)


### PR DESCRIPTION
#### What type of PR is this?
follow up of #98753 to fix #99981

/kind cleanup
/sig storage
/assign @Jiawei0227

```release-note
The maximum length of the CSINode id field has increased to 256 bytes to match the CSI spec
```