### PR TITLE
apimachinery: remove unused ignoredConversions map in converter.

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/conversion/converter.go
+++ b/staging/src/k8s.io/apimachinery/pkg/conversion/converter.go
@@ -44,23 +44,16 @@ type Converter struct {
 	generatedConversionFuncs ConversionFuncs
 
 	// Set of conversions that should be treated as a no-op
-	ignoredConversions        map[typePair]struct{}
 	ignoredUntypedConversions map[typePair]struct{}
-
-	// nameFunc is called to retrieve the name of a type; this name is used for the
-	// purpose of deciding whether two types match or not (i.e., will we attempt to
-	// do a conversion). The default returns the go type name.
-	nameFunc func(t reflect.Type) string
 }
 
 // NewConverter creates a new Converter object.
-func NewConverter(nameFn NameFunc) *Converter {
+// Arg NameFunc is just for backward compatibility.
+func NewConverter(NameFunc) *Converter {
 	c := &Converter{
 		conversionFuncs:           NewConversionFuncs(),
 		generatedConversionFuncs:  NewConversionFuncs(),
-		ignoredConversions:        make(map[typePair]struct{}),
 		ignoredUntypedConversions: make(map[typePair]struct{}),
-		nameFunc:                  nameFn,
 	}
 	c.RegisterUntypedConversionFunc(
 		(*[]byte)(nil), (*[]byte)(nil),
@@ -192,7 +185,6 @@ func (c *Converter) RegisterIgnoredConversion(from, to interface{}) error {
 	if typeTo.Kind() != reflect.Ptr {
 		return fmt.Errorf("expected pointer arg for 'to' param 1, got: %v", typeTo)
 	}
-	c.ignoredConversions[typePair{typeFrom.Elem(), typeTo.Elem()}] = struct{}{}
 	c.ignoredUntypedConversions[typePair{typeFrom, typeTo}] = struct{}{}
 	return nil
 }

--- a/staging/src/k8s.io/apimachinery/pkg/conversion/converter_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/conversion/converter_test.go
@@ -24,7 +24,7 @@ import (
 )
 
 func TestConverter_byteSlice(t *testing.T) {
-	c := NewConverter(DefaultNameFunc)
+	c := NewConverter(nil)
 	src := []byte{1, 2, 3}
 	dest := []byte{}
 	err := c.Convert(&src, &dest, nil)
@@ -37,7 +37,7 @@ func TestConverter_byteSlice(t *testing.T) {
 }
 
 func TestConverter_MismatchedTypes(t *testing.T) {
-	c := NewConverter(DefaultNameFunc)
+	c := NewConverter(nil)
 
 	convertFn := func(in *[]string, out *int, s Scope) error {
 		if str, err := strconv.Atoi((*in)[0]); err != nil {
@@ -76,7 +76,7 @@ func TestConverter_CallsRegisteredFunctions(t *testing.T) {
 		Baz int
 	}
 	type C struct{}
-	c := NewConverter(DefaultNameFunc)
+	c := NewConverter(nil)
 	convertFn1 := func(in *A, out *B, s Scope) error {
 		out.Bar = in.Foo
 		out.Baz = in.Baz
@@ -151,7 +151,7 @@ func TestConverter_IgnoredConversion(t *testing.T) {
 	type B struct{}
 
 	count := 0
-	c := NewConverter(DefaultNameFunc)
+	c := NewConverter(nil)
 	convertFn := func(in *A, out *B, s Scope) error {
 		count++
 		return nil
@@ -180,7 +180,7 @@ func TestConverter_IgnoredConversion(t *testing.T) {
 func TestConverter_GeneratedConversionOverridden(t *testing.T) {
 	type A struct{}
 	type B struct{}
-	c := NewConverter(DefaultNameFunc)
+	c := NewConverter(nil)
 	convertFn1 := func(in *A, out *B, s Scope) error {
 		return nil
 	}
@@ -214,7 +214,7 @@ func TestConverter_GeneratedConversionOverridden(t *testing.T) {
 func TestConverter_WithConversionOverridden(t *testing.T) {
 	type A struct{}
 	type B struct{}
-	c := NewConverter(DefaultNameFunc)
+	c := NewConverter(nil)
 	convertFn1 := func(in *A, out *B, s Scope) error {
 		return fmt.Errorf("conversion function should be overridden")
 	}
@@ -260,7 +260,7 @@ func TestConverter_WithConversionOverridden(t *testing.T) {
 func TestConverter_meta(t *testing.T) {
 	type Foo struct{ A string }
 	type Bar struct{ A string }
-	c := NewConverter(DefaultNameFunc)
+	c := NewConverter(nil)
 	checks := 0
 	convertFn1 := func(in *Foo, out *Bar, s Scope) error {
 		if s.Meta() == nil {

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/scheme.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/scheme.go
@@ -99,34 +99,12 @@ func NewScheme() *Scheme {
 		versionPriority:           map[string][]string{},
 		schemeName:                naming.GetNameFromCallsite(internalPackages...),
 	}
-	s.converter = conversion.NewConverter(s.nameFunc)
+	s.converter = conversion.NewConverter(nil)
 
 	// Enable couple default conversions by default.
 	utilruntime.Must(RegisterEmbeddedConversions(s))
 	utilruntime.Must(RegisterStringConversions(s))
 	return s
-}
-
-// nameFunc returns the name of the type that we wish to use to determine when two types attempt
-// a conversion. Defaults to the go name of the type if the type is not registered.
-func (s *Scheme) nameFunc(t reflect.Type) string {
-	// find the preferred names for this type
-	gvks, ok := s.typeToGVK[t]
-	if !ok {
-		return t.Name()
-	}
-
-	for _, gvk := range gvks {
-		internalGV := gvk.GroupVersion()
-		internalGV.Version = APIVersionInternal // this is hacky and maybe should be passed in
-		internalGVK := internalGV.WithKind(gvk.Kind)
-
-		if internalType, exists := s.gvkToType[internalGVK]; exists {
-			return s.typeToGVK[internalType][0].Kind
-		}
-	}
-
-	return gvks[0].Kind
 }
 
 // Converter allows access to the converter for the scheme


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
After https://github.com/kubernetes/kubernetes/pull/94460 , ignoredConversions AND nameFunc is not used.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
