### PR TITLE
Some cleanup of the package for event clocks

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/apf_filter.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/apf_filter.go
@@ -24,12 +24,12 @@ import (
 	"k8s.io/apiserver/pkg/server/mux"
 	"k8s.io/apiserver/pkg/util/flowcontrol/counter"
 	fq "k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing"
-	fairqueuingclock "k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/clock"
+	"k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/eventclock"
 	fqs "k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/queueset"
 	"k8s.io/apiserver/pkg/util/flowcontrol/metrics"
 	kubeinformers "k8s.io/client-go/informers"
 	"k8s.io/klog/v2"
-	utilclock "k8s.io/utils/clock"
+	"k8s.io/utils/clock"
 
 	flowcontrol "k8s.io/api/flowcontrol/v1beta1"
 	flowcontrolclient "k8s.io/client-go/kubernetes/typed/flowcontrol/v1beta1"
@@ -84,7 +84,7 @@ func New(
 	requestWaitLimit time.Duration,
 ) Interface {
 	grc := counter.NoOp{}
-	clk := fairqueuingclock.RealEventClock{}
+	clk := eventclock.Real{}
 	return NewTestable(TestableConfig{
 		Name:                   "Controller",
 		Clock:                  clk,
@@ -105,7 +105,7 @@ type TestableConfig struct {
 	Name string
 
 	// Clock to use in timing deliberate delays
-	Clock utilclock.PassiveClock
+	Clock clock.PassiveClock
 
 	// AsFieldManager is the string to use in the metadata for
 	// server-side apply.  Normally this is

--- a/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/eventclock/interface.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/eventclock/interface.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package clock
+package eventclock
 
 import (
 	"time"
@@ -31,7 +31,7 @@ type EventFunc func(time.Time)
 // advanced.  The timing paradigm is invoking EventFuncs rather than
 // synchronizing through channels, so that the fake clock has a handle
 // on when associated activity is done.
-type EventClock interface {
+type Interface interface {
 	baseclock.PassiveClock
 
 	// Sleep returns after the given duration (or more).

--- a/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/eventclock/real.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/eventclock/real.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package clock
+package eventclock
 
 import (
 	"time"
@@ -23,12 +23,14 @@ import (
 )
 
 // RealEventClock fires event on real world time
-type RealEventClock struct {
+type Real struct {
 	clock.RealClock
 }
 
+var _ Interface = Real{}
+
 // EventAfterDuration schedules an EventFunc
-func (RealEventClock) EventAfterDuration(f EventFunc, d time.Duration) {
+func (Real) EventAfterDuration(f EventFunc, d time.Duration) {
 	ch := time.After(d)
 	go func() {
 		t := <-ch
@@ -37,6 +39,6 @@ func (RealEventClock) EventAfterDuration(f EventFunc, d time.Duration) {
 }
 
 // EventAfterTime schedules an EventFunc
-func (r RealEventClock) EventAfterTime(f EventFunc, t time.Time) {
+func (r Real) EventAfterTime(f EventFunc, t time.Time) {
 	r.EventAfterDuration(f, time.Until(t))
 }

--- a/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/eventclock/real_event_clock_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/eventclock/real_event_clock_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package clock
+package eventclock
 
 import (
 	"math/rand"
@@ -24,7 +24,7 @@ import (
 )
 
 func TestRealEventClock(t *testing.T) {
-	ec := RealEventClock{}
+	ec := Real{}
 	var numDone int32
 	now := ec.Now()
 	const batchSize = 100

--- a/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/promise/promise_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/promise/promise_test.go
@@ -22,12 +22,12 @@ import (
 	"testing"
 	"time"
 
-	testclock "k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/clock/testing"
+	testclock "k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/testing/eventclock"
 )
 
 func TestLockingWriteOnce(t *testing.T) {
 	now := time.Now()
-	clock, counter := testclock.NewFakeEventClock(now, 0, nil)
+	clock, counter := testclock.NewFake(now, 0, nil)
 	var lock sync.Mutex
 	wr := NewWriteOnce(&lock, counter)
 	var gots int32

--- a/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/testing/eventclock/fake_event_clock_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/testing/eventclock/fake_event_clock_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package testing
+package eventclock
 
 import (
 	"math/rand"
@@ -22,11 +22,11 @@ import (
 	"testing"
 	"time"
 
-	"k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/clock"
+	"k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/eventclock"
 )
 
 type TestableEventClock interface {
-	clock.EventClock
+	eventclock.Interface
 	SetTime(time.Time)
 	Run(*time.Time)
 }
@@ -122,10 +122,10 @@ func exerciseSettablePassiveClock(t *testing.T, pc TestableEventClock) {
 	}
 }
 
-func TestFakeEventClock(t *testing.T) {
+func TestFake(t *testing.T) {
 	startTime := time.Now()
-	fec, _ := NewFakeEventClock(startTime, 0, nil)
+	fec, _ := NewFake(startTime, 0, nil)
 	exerciseTestableEventClock(t, fec, 0)
-	fec, _ = NewFakeEventClock(startTime, time.Second, nil)
+	fec, _ = NewFake(startTime, time.Second, nil)
 	exerciseTestableEventClock(t, fec, time.Second)
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1548,7 +1548,7 @@ k8s.io/apiserver/pkg/util/flowcontrol
 k8s.io/apiserver/pkg/util/flowcontrol/counter
 k8s.io/apiserver/pkg/util/flowcontrol/debug
 k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing
-k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/clock
+k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/eventclock
 k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/promise
 k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/queueset
 k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/testing


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind cleanup

#### What this PR does / why we need it:
Rename fairqueuing package `clock` to `eventclock` because it is a specific extension of the existing clock abstraction package rather than a replacement.

Simplify by removing the prohibition on an EventFunc waiting on time advancing.

Remove "EventClock" from names to avoid stuttering.

Start to consolidate test code under fairqueuing/testing/, because that was requested in https://github.com/kubernetes/kubernetes/pull/104002#discussion_r684007905

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:
This is a (hopefully better) alternative to #104189 .

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
