### PR TITLE
Fixes flaky GKE kubectl test

### DIFF
--- a/test/e2e/kubectl/kubectl.go
+++ b/test/e2e/kubectl/kubectl.go
@@ -644,6 +644,11 @@ var _ = SIGDescribe("Kubectl client", func() {
 		})
 
 		ginkgo.It("should handle in-cluster config", func() {
+			// This test does not work for dynamically linked kubectl binaries; only statically linked ones. The
+			// problem happens when the kubectl binary is copied to a pod in the cluster. For dynamically linked
+			// binaries, the necessary libraries are not also copied. For this reason, the test can not be
+			// guaranteed to work with GKE, which sometimes run tests using a dynamically linked kubectl.
+			e2eskipper.SkipIfProviderIs("gke")
 			// TODO: Find a way to download and copy the appropriate kubectl binary, or maybe a multi-arch kubectl image
 			// for now this only works on amd64
 			e2eskipper.SkipUnlessNodeOSArchIs("amd64")


### PR DESCRIPTION
* Fixes flaky `kubectl` e2e test case by skipping if provider `GKE`. This test case copies the `kubectl` binary into a pod in the cluster, but it assumes the `kubectl` is statically linked. Sometimes this test, however, is run with a dynamically linked `kubectl`, causing the test to fail.

/sig cli
/triage accepted
/priority important-soon
/kind flake

```release-note
NONE
```