### PR TITLE
Automated cherry pick of #104142: Update debian-base image to buster-v1.9.0

### DIFF
--- a/build/common.sh
+++ b/build/common.sh
@@ -86,7 +86,7 @@ readonly KUBE_RSYNC_PORT="${KUBE_RSYNC_PORT:-}"
 readonly KUBE_CONTAINER_RSYNC_PORT=8730
 
 # These are the default versions (image tags) for their respective base images.
-readonly __default_debian_iptables_version=buster-v1.6.5
+readonly __default_debian_iptables_version=buster-v1.6.6
 readonly __default_go_runner_version=v2.3.1-go1.16.7-buster.0
 readonly __default_setcap_version=buster-v2.0.3
 

--- a/build/common.sh
+++ b/build/common.sh
@@ -88,7 +88,7 @@ readonly KUBE_CONTAINER_RSYNC_PORT=8730
 # These are the default versions (image tags) for their respective base images.
 readonly __default_debian_iptables_version=buster-v1.6.6
 readonly __default_go_runner_version=v2.3.1-go1.16.7-buster.0
-readonly __default_setcap_version=buster-v2.0.3
+readonly __default_setcap_version=buster-v2.0.4
 
 # These are the base images for the Docker-wrapped binaries.
 readonly KUBE_GORUNNER_IMAGE="${KUBE_GORUNNER_IMAGE:-$KUBE_BASE_IMAGE_REGISTRY/go-runner:$__default_go_runner_version}"

--- a/build/dependencies.yaml
+++ b/build/dependencies.yaml
@@ -216,7 +216,7 @@ dependencies:
       match: configs\[Pause\] = Config{list\.GcRegistry, "pause", "\d+\.\d+(.\d+)?"}
 
   - name: "k8s.gcr.io/setcap: dependents"
-    version: buster-v2.0.3
+    version: buster-v2.0.4
     refPaths:
     - path: build/common.sh
       match: __default_setcap_version=

--- a/build/dependencies.yaml
+++ b/build/dependencies.yaml
@@ -130,7 +130,7 @@ dependencies:
 
   # Base images
   - name: "k8s.gcr.io/debian-base: dependents"
-    version: buster-v1.8.0
+    version: buster-v1.9.0
     refPaths:
     - path: cluster/images/etcd/Makefile
       match: BASEIMAGE\?\=k8s\.gcr\.io\/build-image\/debian-base:[a-zA-Z]+\-v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)

--- a/build/dependencies.yaml
+++ b/build/dependencies.yaml
@@ -144,7 +144,7 @@ dependencies:
       match: BASEIMAGE\?\=k8s\.gcr\.io\/build-image\/debian-base-s390x:[a-zA-Z]+\-v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)
 
   - name: "k8s.gcr.io/debian-iptables: dependents"
-    version: buster-v1.6.5
+    version: buster-v1.6.6
     refPaths:
     - path: build/common.sh
       match: __default_debian_iptables_version=

--- a/cluster/images/etcd/Makefile
+++ b/cluster/images/etcd/Makefile
@@ -67,19 +67,19 @@ GOARM?=7
 TEMP_DIR:=$(shell mktemp -d)
 
 ifeq ($(ARCH),amd64)
-    BASEIMAGE?=k8s.gcr.io/build-image/debian-base:buster-v1.8.0
+    BASEIMAGE?=k8s.gcr.io/build-image/debian-base:buster-v1.9.0
 endif
 ifeq ($(ARCH),arm)
-    BASEIMAGE?=k8s.gcr.io/build-image/debian-base-arm:buster-v1.8.0
+    BASEIMAGE?=k8s.gcr.io/build-image/debian-base-arm:buster-v1.9.0
 endif
 ifeq ($(ARCH),arm64)
-    BASEIMAGE?=k8s.gcr.io/build-image/debian-base-arm64:buster-v1.8.0
+    BASEIMAGE?=k8s.gcr.io/build-image/debian-base-arm64:buster-v1.9.0
 endif
 ifeq ($(ARCH),ppc64le)
-    BASEIMAGE?=k8s.gcr.io/build-image/debian-base-ppc64le:buster-v1.8.0
+    BASEIMAGE?=k8s.gcr.io/build-image/debian-base-ppc64le:buster-v1.9.0
 endif
 ifeq ($(ARCH),s390x)
-    BASEIMAGE?=k8s.gcr.io/build-image/debian-base-s390x:buster-v1.8.0
+    BASEIMAGE?=k8s.gcr.io/build-image/debian-base-s390x:buster-v1.9.0
 endif
 
 RUNNERIMAGE?=gcr.io/distroless/static:latest

--- a/test/utils/image/manifest.go
+++ b/test/utils/image/manifest.go
@@ -214,7 +214,7 @@ func initImageConfigs(list RegistryList) (map[int]Config, map[int]Config) {
 	configs[CheckMetadataConcealment] = Config{list.PromoterE2eRegistry, "metadata-concealment", "1.6"}
 	configs[CudaVectorAdd] = Config{list.PromoterE2eRegistry, "cuda-vector-add", "1.0"}
 	configs[CudaVectorAdd2] = Config{list.PromoterE2eRegistry, "cuda-vector-add", "2.2"}
-	configs[DebianIptables] = Config{list.BuildImageRegistry, "debian-iptables", "buster-v1.6.5"}
+	configs[DebianIptables] = Config{list.BuildImageRegistry, "debian-iptables", "buster-v1.6.6"}
 	configs[EchoServer] = Config{list.PromoterE2eRegistry, "echoserver", "2.3"}
 	configs[Etcd] = Config{list.GcEtcdRegistry, "etcd", "3.4.13-0"}
 	configs[GlusterDynamicProvisioner] = Config{list.PromoterE2eRegistry, "glusterdynamic-provisioner", "v1.0"}


### PR DESCRIPTION
Cherry pick of #104142 on release-1.22.

#104142: Update debian-base image to buster-v1.9.0

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.