### PR TITLE
Automated cherry pick of #104142: Update debian-base image to buster-v1.9.0

### DIFF
--- a/build/common.sh
+++ b/build/common.sh
@@ -93,7 +93,7 @@ readonly KUBE_CONTAINER_RSYNC_PORT=8730
 #
 # $1 - server architecture
 kube::build::get_docker_wrapped_binaries() {
-  local debian_iptables_version=buster-v1.6.5
+  local debian_iptables_version=buster-v1.6.6
   local go_runner_version=v2.3.1-go1.15.15-buster.0
   ### If you change any of these lists, please also update DOCKERIZED_BINARIES
   ### in build/BUILD. And kube::golang::server_image_targets

--- a/build/dependencies.yaml
+++ b/build/dependencies.yaml
@@ -136,7 +136,7 @@ dependencies:
       match: BASEIMAGE\?\=k8s\.gcr\.io\/build-image\/debian-base-s390x:[a-zA-Z]+\-v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)
 
   - name: "k8s.gcr.io/debian-iptables: dependents"
-    version: buster-v1.6.5
+    version: buster-v1.6.6
     refPaths:
     - path: build/common.sh
       match: debian_iptables_version=

--- a/build/dependencies.yaml
+++ b/build/dependencies.yaml
@@ -120,7 +120,7 @@ dependencies:
 
   # Base images
   - name: "k8s.gcr.io/debian-base: dependents"
-    version: buster-v1.8.0
+    version: buster-v1.9.0
     refPaths:
     - path: build/workspace.bzl
       match: tag =

--- a/build/workspace.bzl
+++ b/build/workspace.bzl
@@ -74,15 +74,15 @@ def cri_tarballs():
 # Use skopeo to find these values: https://github.com/containers/skopeo
 #
 # Example
-# Manifest: skopeo inspect docker://k8s.gcr.io/build-image/debian-base:buster-v1.8.0
-# Arches: skopeo inspect --raw docker://k8s.gcr.io/build-image/debian-base:buster-v1.8.0
+# Manifest: skopeo inspect docker://k8s.gcr.io/build-image/debian-base:buster-v1.9.0
+# Arches: skopeo inspect --raw docker://k8s.gcr.io/build-image/debian-base:buster-v1.9.0
 _DEBIAN_BASE_DIGEST = {
-    "manifest": "sha256:22666783ee41fa619ad4d7ea40800bb40901d2e27d60c0ca3339a5851374763e",
-    "amd64": "sha256:45965a68454706b7318a36cb9252c0e3f37a61b9e34578a56e06ac7d7ddb4d5e",
-    "arm": "sha256:7e1ea4457b1a5969067d79b748d6e648834ef6523f153e0780213f21590ad3e8",
-    "arm64": "sha256:336a612ad49a58e2440aa111fa3fc10e04c607b805debe4544fd2db6384d6ab8",
-    "ppc64le": "sha256:046123ab9444d9c66132b179bed6954a8bd4e35c9ff0c2194c45979021f49655",
-    "s390x": "sha256:468fae3b4ca48f0ea9c608994c12e99b32c9a617500c89efe98f84832a0ab007",
+    "manifest": "sha256:1e76a235c477dfe46d707d2be80a835b44cdcf6f35675fb2189c7a28b6d09878",
+    "amd64": "sha256:44c43ab99226d896cdff9f12ae59beb972643f4a9dd235efe62eded808fdaccb",
+    "arm": "sha256:4003db9e8c5812c130d2f3da946ff4858e6419548376c5687cc498bbd575326c",
+    "arm64": "sha256:1f138689e3a8b629bad0bb06c586117d97055bcaf19cb49d129d67b6d2afebe3",
+    "ppc64le": "sha256:40404f102c2db420ebb8aef8bb8b84d02634826ecbb0373a76c16ddde015fce5",
+    "s390x": "sha256:c97ee2895d7519655ffad5c90dfa68b0aa94e6b90cdd6cdd9f596a396e3b93ab",
 }
 
 # Use skopeo to find these values: https://github.com/containers/skopeo
@@ -137,7 +137,7 @@ def image_dependencies():
             registry = "k8s.gcr.io/build-image",
             repository = "debian-base",
             # Ensure the digests above are updated to match a new tag
-            tag = "buster-v1.8.0",  # ignored, but kept here for documentation
+            tag = "buster-v1.9.0",  # ignored, but kept here for documentation
         )
 
         container_pull(

--- a/build/workspace.bzl
+++ b/build/workspace.bzl
@@ -88,15 +88,15 @@ _DEBIAN_BASE_DIGEST = {
 # Use skopeo to find these values: https://github.com/containers/skopeo
 #
 # Example
-# Manifest: skopeo inspect docker://gcr.io/k8s-staging-build-image/debian-iptables:buster-v1.6.5
-# Arches: skopeo inspect --raw docker://gcr.io/k8s-staging-build-image/debian-iptables:buster-v1.6.5
+# Manifest: skopeo inspect docker://gcr.io/k8s-staging-build-image/debian-iptables:buster-v1.6.6
+# Arches: skopeo inspect --raw docker://gcr.io/k8s-staging-build-image/debian-iptables:buster-v1.6.6
 _DEBIAN_IPTABLES_DIGEST = {
-    "manifest": "sha256:d226f3fd5f293ff513f53573a40c069b89d57d42338a1045b493bf702ac6b1f6",
-    "amd64": "sha256:200be0a96b436ac42d50f04f291d51384001c0fb68f65836db6d18a0f6eca866",
-    "arm": "sha256:4c705fd85f52162853df8cd5c38b445ae4090e02d9370257b45e104fb7dff070",
-    "arm64": "sha256:7db471e96a33d4d1fc1611082a45f434e81b82402a1a3cd4255c6b5b2b9a5186",
-    "ppc64le": "sha256:e83a0368cfe4e3b99f85b557e39bad55446ac9c14249337889998b59399905c9",
-    "s390x": "sha256:1cff7805d2eda46bab962acd48a3cd8d536507149333d7c4706e57aad61b58b8",
+    "manifest": "sha256:e7bcffb508aac58f0d350193da968b6f0351cea2f5c720e78aa44578b2075eba",
+    "amd64": "sha256:9c2c1a9ca2b631de2c9fc3afb19bcb4e76ca1a7ed135b64db9dbc8ad31f0d744",
+    "arm": "sha256:4a988687cff20ccf9213df8f156fc9f2d084c1e297ed4de25b101557ce9f32e5",
+    "arm64": "sha256:6911afa6d33eafbeadfca1e81760773204b6fd8001144e86bf4649a6108ea3a2",
+    "ppc64le": "sha256:ee844689f485df0f32775781a7eaabc32cd44f055cb597d6f8c2db935eac01c9",
+    "s390x": "sha256:47e6873c2cacfb3ac23eff0731317a7bb0d6c3230723c2a913663dcf66065169",
 }
 
 # Use skopeo to find these values: https://github.com/containers/skopeo
@@ -147,7 +147,7 @@ def image_dependencies():
             registry = "k8s.gcr.io/build-image",
             repository = "debian-iptables",
             # Ensure the digests above are updated to match a new tag
-            tag = "buster-v1.6.5",  # ignored, but kept here for documentation
+            tag = "buster-v1.6.6",  # ignored, but kept here for documentation
         )
 
 def etcd_tarballs():

--- a/cluster/images/etcd/Makefile
+++ b/cluster/images/etcd/Makefile
@@ -67,19 +67,19 @@ GOARM?=7
 TEMP_DIR:=$(shell mktemp -d)
 
 ifeq ($(ARCH),amd64)
-    BASEIMAGE?=k8s.gcr.io/build-image/debian-base:buster-v1.8.0
+    BASEIMAGE?=k8s.gcr.io/build-image/debian-base:buster-v1.9.0
 endif
 ifeq ($(ARCH),arm)
-    BASEIMAGE?=k8s.gcr.io/build-image/debian-base-arm:buster-v1.8.0
+    BASEIMAGE?=k8s.gcr.io/build-image/debian-base-arm:buster-v1.9.0
 endif
 ifeq ($(ARCH),arm64)
-    BASEIMAGE?=k8s.gcr.io/build-image/debian-base-arm64:buster-v1.8.0
+    BASEIMAGE?=k8s.gcr.io/build-image/debian-base-arm64:buster-v1.9.0
 endif
 ifeq ($(ARCH),ppc64le)
-    BASEIMAGE?=k8s.gcr.io/build-image/debian-base-ppc64le:buster-v1.8.0
+    BASEIMAGE?=k8s.gcr.io/build-image/debian-base-ppc64le:buster-v1.9.0
 endif
 ifeq ($(ARCH),s390x)
-    BASEIMAGE?=k8s.gcr.io/build-image/debian-base-s390x:buster-v1.8.0
+    BASEIMAGE?=k8s.gcr.io/build-image/debian-base-s390x:buster-v1.9.0
 endif
 
 RUNNERIMAGE?=gcr.io/distroless/static:latest

--- a/test/utils/image/manifest.go
+++ b/test/utils/image/manifest.go
@@ -212,7 +212,7 @@ func initImageConfigs() map[int]Config {
 	configs[CheckMetadataConcealment] = Config{promoterE2eRegistry, "metadata-concealment", "1.6"}
 	configs[CudaVectorAdd] = Config{e2eRegistry, "cuda-vector-add", "1.0"}
 	configs[CudaVectorAdd2] = Config{e2eRegistry, "cuda-vector-add", "2.0"}
-	configs[DebianIptables] = Config{buildImageRegistry, "debian-iptables", "buster-v1.6.5"}
+	configs[DebianIptables] = Config{buildImageRegistry, "debian-iptables", "buster-v1.6.6"}
 	configs[EchoServer] = Config{e2eRegistry, "echoserver", "2.2"}
 	configs[Etcd] = Config{gcRegistry, "etcd", "3.4.13-0"}
 	configs[GlusterDynamicProvisioner] = Config{dockerGluster, "glusterdynamic-provisioner", "v1.0"}


### PR DESCRIPTION
Cherry pick of #104142 on release-1.20.

#104142: Update debian-base image to buster-v1.9.0

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.