### PR TITLE
[1.19] backport vendor: bump runc to 1.0.1 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,107 +10,323 @@ go 1.15
 
 require (
 	bitbucket.org/bertimus9/systemstat v0.0.0-20180207000608-0eeff89b0690
+	cloud.google.com/go v0.51.0
+	cloud.google.com/go/bigquery v1.0.1
+	cloud.google.com/go/datastore v1.0.0
+	cloud.google.com/go/pubsub v1.0.1
+	cloud.google.com/go/storage v1.0.0
+	dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9
 	github.com/Azure/azure-sdk-for-go v43.0.0+incompatible
+	github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78
 	github.com/Azure/go-autorest/autorest v0.9.6
 	github.com/Azure/go-autorest/autorest/adal v0.8.2
+	github.com/Azure/go-autorest/autorest/date v0.2.0
+	github.com/Azure/go-autorest/autorest/mocks v0.3.0
 	github.com/Azure/go-autorest/autorest/to v0.2.0
+	github.com/Azure/go-autorest/autorest/validation v0.1.0
+	github.com/Azure/go-autorest/logger v0.1.0
+	github.com/Azure/go-autorest/tracing v0.5.0
+	github.com/BurntSushi/toml v0.3.1
+	github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802
 	github.com/GoogleCloudPlatform/k8s-cloud-provider v0.0.0-20200415212048-7901bc822317
 	github.com/JeffAshton/win_pdh v0.0.0-20161109143554-76bb4ee9f0ab
+	github.com/MakeNowJust/heredoc v0.0.0-20170808103936-bb23615498cd
 	github.com/Microsoft/go-winio v0.4.15-0.20190919025122-fc70bd9a86b5
 	github.com/Microsoft/hcsshim v0.8.10-0.20200715222032-5eafd1556990
+	github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46
 	github.com/PuerkitoBio/purell v1.1.1
+	github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578
+	github.com/agnivade/levenshtein v1.0.1
+	github.com/ajstarks/svgo v0.0.0-20180226025133-644b8db467af
+	github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751
+	github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4
+	github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883
 	github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e
+	github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6
+	github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a
 	github.com/auth0/go-jwt-middleware v0.0.0-20170425171159-5493cabe49f7 // indirect
 	github.com/aws/aws-sdk-go v1.28.2
+	github.com/beorn7/perks v1.0.1
+	github.com/bgentry/speakeasy v0.1.0
+	github.com/bifurcation/mint v0.0.0-20180715133206-93c51c6ce115
+	github.com/bits-and-blooms/bitset v1.2.0
 	github.com/blang/semver v3.5.0+incompatible
 	github.com/boltdb/bolt v1.3.1 // indirect
 	github.com/caddyserver/caddy v1.0.3
+	github.com/cenkalti/backoff v2.1.1+incompatible
+	github.com/census-instrumentation/opencensus-proto v0.2.1
+	github.com/cespare/xxhash/v2 v2.1.1
+	github.com/chai2010/gettext-go v0.0.0-20160711120539-c6fed771bfd5
+	github.com/checkpoint-restore/go-criu/v4 v4.0.2
+	github.com/checkpoint-restore/go-criu/v5 v5.0.0
+	github.com/cheekybits/genny v0.0.0-20170328200008-9127e812e1e9
+	github.com/chzyer/logex v1.1.10
+	github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e
+	github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1
+	github.com/cilium/ebpf v0.6.2
 	github.com/clusterhq/flocker-go v0.0.0-20160920122132-2b8b7259d313
+	github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa
 	github.com/codegangsta/negroni v1.0.0 // indirect
 	github.com/container-storage-interface/spec v1.2.0
+	github.com/containerd/cgroups v0.0.0-20200531161412-0dbf7f05ba59
+	github.com/containerd/console v1.0.2
+	github.com/containerd/containerd v1.3.3
+	github.com/containerd/continuity v0.0.0-20190426062206-aaeac12a7ffc
+	github.com/containerd/fifo v0.0.0-20190226154929-a9fb20d87448
+	github.com/containerd/go-runc v0.0.0-20180907222934-5a6d9f37cfa3
+	github.com/containerd/ttrpc v1.0.0
+	github.com/containerd/typeurl v1.0.0
 	github.com/containernetworking/cni v0.8.0
 	github.com/coredns/corefile-migration v1.0.10
+	github.com/coreos/bbolt v1.3.2
+	github.com/coreos/etcd v3.3.10+incompatible
 	github.com/coreos/go-oidc v2.1.0+incompatible
+	github.com/coreos/go-semver v0.3.0
 	github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e
+	github.com/coreos/go-systemd/v22 v22.3.2
 	github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f
 	github.com/cpuguy83/go-md2man/v2 v2.0.0
+	github.com/creack/pty v1.1.7
+	github.com/cyphar/filepath-securejoin v0.2.2
 	github.com/davecgh/go-spew v1.1.1
+	github.com/daviddengcn/go-colortext v0.0.0-20160507010035-511bcaf42ccd
+	github.com/dgrijalva/jwt-go v3.2.0+incompatible
+	github.com/dnaeon/go-vcr v1.0.1
 	github.com/docker/distribution v2.7.1+incompatible
 	github.com/docker/docker v1.4.2-0.20200309214505-aa6a9891b09c
 	github.com/docker/go-connections v0.4.0
 	github.com/docker/go-units v0.4.0
+	github.com/docker/spdystream v0.0.0-20160310174837-449fdfce4d96
+	github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815
+	github.com/dustin/go-humanize v1.0.0
 	github.com/elazarl/goproxy v0.0.0-20180725130230-947c36da3153
 	github.com/emicklei/go-restful v2.9.5+incompatible
+	github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473
+	github.com/envoyproxy/protoc-gen-validate v0.1.0
+	github.com/euank/go-kmsg-parser v2.0.0+incompatible
 	github.com/evanphx/json-patch v4.9.0+incompatible
+	github.com/exponent-io/jsonpath v0.0.0-20151013193312-d6023ce2651d
+	github.com/fatih/camelcase v1.0.0
+	github.com/fatih/color v1.7.0
+	github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568
+	github.com/fogleman/gg v1.2.1-0.20190220221249-0403632d5b90
 	github.com/fsnotify/fsnotify v1.4.9
+	github.com/ghodss/yaml v1.0.0
+	github.com/go-acme/lego v2.5.0+incompatible
 	github.com/go-bindata/go-bindata v3.1.1+incompatible
+	github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72
+	github.com/go-ini/ini v1.9.0
+	github.com/go-kit/kit v0.9.0
+	github.com/go-logfmt/logfmt v0.4.0
+	github.com/go-logr/logr v0.2.0
 	github.com/go-openapi/analysis v0.19.5
+	github.com/go-openapi/errors v0.19.2
+	github.com/go-openapi/jsonpointer v0.19.3
+	github.com/go-openapi/jsonreference v0.19.3
 	github.com/go-openapi/loads v0.19.4
+	github.com/go-openapi/runtime v0.19.4
 	github.com/go-openapi/spec v0.19.3
 	github.com/go-openapi/strfmt v0.19.3
+	github.com/go-openapi/swag v0.19.5
 	github.com/go-openapi/validate v0.19.5
 	github.com/go-ozzo/ozzo-validation v3.5.0+incompatible // indirect
+	github.com/go-stack/stack v1.8.0
+	github.com/godbus/dbus/v5 v5.0.4
 	github.com/gogo/protobuf v1.3.2
+	github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0
+	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
 	github.com/golang/groupcache v0.0.0-20191227052852-215e87163ea7
 	github.com/golang/mock v1.3.1
+	github.com/golang/protobuf v1.4.3
+	github.com/golangplus/bytes v0.0.0-20160111154220-45c989fe5450
+	github.com/golangplus/fmt v0.0.0-20150411045040-2a5d6d7d2995
+	github.com/golangplus/testing v0.0.0-20180327235837-af21d9c3145e
+	github.com/google/btree v1.0.0
 	github.com/google/cadvisor v0.37.5
 	github.com/google/go-cmp v0.4.0
 	github.com/google/gofuzz v1.1.0
+	github.com/google/martian v2.1.0+incompatible
+	github.com/google/pprof v0.0.0-20191218002539-d4f498aebedc
+	github.com/google/renameio v0.1.0
 	github.com/google/uuid v1.1.1
+	github.com/googleapis/gax-go/v2 v2.0.5
 	github.com/googleapis/gnostic v0.4.1
+	github.com/gophercloud/gophercloud v0.1.0
+	github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1
 	github.com/gorilla/context v1.1.1 // indirect
+	github.com/gorilla/mux v1.7.3
+	github.com/gorilla/websocket v1.4.0
+	github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7
+	github.com/grpc-ecosystem/go-grpc-middleware v1.0.1-0.20190118093823-f849b5445de4
+	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0
+	github.com/grpc-ecosystem/grpc-gateway v1.9.5
+	github.com/hashicorp/go-syslog v1.0.0
 	github.com/hashicorp/golang-lru v0.5.1
+	github.com/hashicorp/hcl v1.0.0
 	github.com/heketi/heketi v9.0.1-0.20190917153846-c2e2a4ab7ab9+incompatible
 	github.com/heketi/tests v0.0.0-20151005000721-f3775cbcefd6 // indirect
+	github.com/hpcloud/tail v1.0.0
+	github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6
+	github.com/imdario/mergo v0.3.5
+	github.com/inconshreveable/mousetrap v1.0.0
 	github.com/ishidawataru/sctp v0.0.0-20190723014705-7c296d48a2b5
+	github.com/jimstudt/http-authentication v0.0.0-20140401203705-3eca13d6893a
+	github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af
+	github.com/jonboulle/clockwork v0.1.0
 	github.com/json-iterator/go v1.1.10
+	github.com/jstemmer/go-junit-report v0.9.1
+	github.com/jtolds/gls v4.20.0+incompatible
+	github.com/julienschmidt/httprouter v1.2.0
+	github.com/jung-kurt/gofpdf v1.0.3-0.20190309125859-24315acbbda5
+	github.com/karrick/godirwalk v1.7.5
+	github.com/kisielk/errcheck v1.5.0
+	github.com/kisielk/gotool v1.0.0
+	github.com/klauspost/cpuid v1.2.0
+	github.com/konsorten/go-windows-terminal-sequences v1.0.3
+	github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515
+	github.com/kr/pretty v0.2.0
+	github.com/kr/pty v1.1.5
+	github.com/kr/text v0.1.0
+	github.com/kylelemons/godebug v0.0.0-20170820004349-d65d576e9348
 	github.com/libopenstorage/openstorage v1.0.0
+	github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de
 	github.com/lithammer/dedent v1.1.0
 	github.com/lpabon/godbc v0.1.1 // indirect
+	github.com/lucas-clemente/aes12 v0.0.0-20171027163421-cd47fb39b79f
+	github.com/lucas-clemente/quic-clients v0.1.0
+	github.com/lucas-clemente/quic-go v0.10.2
+	github.com/lucas-clemente/quic-go-certificates v0.0.0-20160823095156-d2f86524cced
 	github.com/magiconair/properties v1.8.1 // indirect
+	github.com/mailru/easyjson v0.7.0
+	github.com/marten-seemann/qtls v0.2.3
+	github.com/mattn/go-colorable v0.0.9
+	github.com/mattn/go-isatty v0.0.4
+	github.com/mattn/go-runewidth v0.0.2
+	github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369
+	github.com/mholt/certmagic v0.6.2-0.20190624175158-6a42ef9fe8c2
 	github.com/miekg/dns v1.1.4
+	github.com/mindprince/gonvml v0.0.0-20190828220739-9ebdce4bb989
+	github.com/mistifyio/go-zfs v2.1.2-0.20190413222219-f784269be439+incompatible
+	github.com/mitchellh/go-homedir v1.1.0
+	github.com/mitchellh/go-wordwrap v1.0.0
+	github.com/mitchellh/mapstructure v1.1.2
 	github.com/moby/ipvs v1.0.1
+	github.com/moby/sys/mountinfo v0.4.1
+	github.com/moby/term v0.0.0-20200312100748-672ec06f55cd
+	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd
+	github.com/modern-go/reflect2 v1.0.1
 	github.com/mohae/deepcopy v0.0.0-20170603005431-491d3605edfb // indirect
-	github.com/mrunalp/fileutils v0.0.0-20200520151820-abd8a0e76976
+	github.com/morikuni/aec v1.0.0
+	github.com/mrunalp/fileutils v0.5.0
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822
 	github.com/mvdan/xurls v1.1.0
+	github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223
+	github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f
+	github.com/naoina/go-stringutil v0.1.0
+	github.com/naoina/toml v0.1.1
+	github.com/olekukonko/tablewriter v0.0.0-20170122224234-a0225b3f23b5
 	github.com/onsi/ginkgo v1.11.0
 	github.com/onsi/gomega v1.7.0
 	github.com/opencontainers/go-digest v1.0.0-rc1
-	github.com/opencontainers/runc v1.0.0-rc91.0.20200707015106-819fcc687efb
-	github.com/opencontainers/selinux v1.5.2
+	github.com/opencontainers/image-spec v1.0.1
+	github.com/opencontainers/runc v1.0.1
+	github.com/opencontainers/runtime-spec v1.0.3-0.20210326190908-1c3f411f0417
+	github.com/opencontainers/selinux v1.8.2
+	github.com/pelletier/go-toml v1.2.0
+	github.com/peterbourgon/diskv v2.0.1+incompatible
 	github.com/pkg/errors v0.9.1
 	github.com/pmezard/go-difflib v1.0.0
+	github.com/pquerna/cachecontrol v0.0.0-20171018203845-0dec1b30a021
 	github.com/prometheus/client_golang v1.7.1
 	github.com/prometheus/client_model v0.2.0
 	github.com/prometheus/common v0.10.0
+	github.com/prometheus/procfs v0.1.3
 	github.com/quobyte/api v0.1.2
+	github.com/remyoudompheng/bigfft v0.0.0-20170806203942-52369c62f446
 	github.com/robfig/cron v1.1.0
+	github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af
+	github.com/rogpeppe/go-internal v1.3.0
+	github.com/rubiojr/go-vhd v0.0.0-20200706105327-02e210299021
+	github.com/russross/blackfriday v1.5.2
+	github.com/russross/blackfriday/v2 v2.0.1
+	github.com/satori/go.uuid v1.2.0
+	github.com/seccomp/libseccomp-golang v0.9.1
+	github.com/sergi/go-diff v1.0.0
+	github.com/shurcooL/sanitized_anchor_name v1.0.0
+	github.com/sirupsen/logrus v1.8.1
+	github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d
+	github.com/smartystreets/goconvey v1.6.4
+	github.com/soheilhy/cmux v0.1.4
 	github.com/spf13/afero v1.2.2
+	github.com/spf13/cast v1.3.0
 	github.com/spf13/cobra v1.0.0
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.4.0
 	github.com/storageos/go-api v0.0.0-20180912212459-343b3eff91fc
+	github.com/stretchr/objx v0.2.0
 	github.com/stretchr/testify v1.4.0
+	github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635
 	github.com/thecodeteam/goscaleio v0.1.0
+	github.com/tidwall/pretty v1.0.0
+	github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5
+	github.com/ugorji/go v1.1.4
+	github.com/urfave/cli v1.22.2
 	github.com/urfave/negroni v1.0.0 // indirect
+	github.com/vektah/gqlparser v1.1.2
 	github.com/vishvananda/netlink v1.1.0
+	github.com/vishvananda/netns v0.0.0-20200520041808-52d707b772fe
 	github.com/vmware/govmomi v0.20.3
+	github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2
+	github.com/xlab/handysort v0.0.0-20150421192137-fb3537ed64a1
+	github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77
+	github.com/yuin/goldmark v1.2.1
+	go.etcd.io/bbolt v1.3.5
 	go.etcd.io/etcd v0.5.0-alpha.5.0.20200819165624-17cef6e3e9d5
+	go.mongodb.org/mongo-driver v1.1.2
+	go.opencensus.io v0.22.2
+	go.uber.org/atomic v1.4.0
+	go.uber.org/multierr v1.1.0
+	go.uber.org/zap v1.10.0
 	golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9
-	golang.org/x/net v0.0.0-20201110031124-69a78807bb2b
+	golang.org/x/exp v0.0.0-20191227195350-da58074b4299
+	golang.org/x/image v0.0.0-20190802002840-cff245a6509b
+	golang.org/x/lint v0.0.0-20191125180803-fdd1cda4f05f
+	golang.org/x/mobile v0.0.0-20190719004257-d2bd2a29d028
+	golang.org/x/mod v0.3.0
+	golang.org/x/net v0.0.0-20201224014010-6772e930b67b
 	golang.org/x/oauth2 v0.0.0-20191202225959-858c2ad4c8b6
-	golang.org/x/sys v0.0.0-20201112073958-5cba982894dd
+	golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9
+	golang.org/x/sys v0.0.0-20210426230700-d19ff857e887
+	golang.org/x/text v0.3.3
 	golang.org/x/time v0.0.0-20191024005414-555d28b269f0
 	golang.org/x/tools v0.0.0-20210106214847-113979e3529a
+	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1
 	gonum.org/v1/gonum v0.6.2
 	gonum.org/v1/netlib v0.0.0-20190331212654-76723241ea4e // indirect
+	gonum.org/v1/plot v0.0.0-20190515093506-e2840ee46a6b
 	google.golang.org/api v0.15.1
+	google.golang.org/appengine v1.6.5
+	google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013
 	google.golang.org/grpc v1.27.0
+	google.golang.org/protobuf v1.26.0
+	gopkg.in/alecthomas/kingpin.v2 v2.2.6
+	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15
+	gopkg.in/cheggaaa/pb.v1 v1.0.25
+	gopkg.in/errgo.v2 v2.1.0
+	gopkg.in/fsnotify.v1 v1.4.7
 	gopkg.in/gcfg.v1 v1.2.0
+	gopkg.in/inf.v0 v0.9.1
+	gopkg.in/mcuadros/go-syslog.v2 v2.2.1
+	gopkg.in/natefinch/lumberjack.v2 v2.0.0
+	gopkg.in/resty.v1 v1.12.0
 	gopkg.in/square/go-jose.v2 v2.2.2
+	gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7
+	gopkg.in/warnings.v0 v0.1.1
 	gopkg.in/yaml.v2 v2.2.8
+	gotest.tools v2.2.0+incompatible
+	gotest.tools/v3 v3.0.2
+	honnef.co/go/tools v0.0.1-2019.2.3
 	k8s.io/api v0.0.0
 	k8s.io/apiextensions-apiserver v0.0.0
 	k8s.io/apimachinery v0.0.0
@@ -121,6 +337,7 @@ require (
 	k8s.io/cluster-bootstrap v0.0.0
 	k8s.io/code-generator v0.0.0
 	k8s.io/component-base v0.0.0
+	k8s.io/controller-manager v0.0.0
 	k8s.io/cri-api v0.0.0
 	k8s.io/csi-translation-lib v0.0.0
 	k8s.io/gengo v0.0.0-20200428234225-8167cfdcfc14
@@ -136,10 +353,21 @@ require (
 	k8s.io/legacy-cloud-providers v0.0.0
 	k8s.io/metrics v0.0.0
 	k8s.io/sample-apiserver v0.0.0
+	k8s.io/sample-cli-plugin v0.0.0
+	k8s.io/sample-controller v0.0.0
 	k8s.io/system-validators v1.1.2
 	k8s.io/utils v0.0.0-20200729134348-d5654de09c73
+	modernc.org/cc v1.0.0
+	modernc.org/golex v1.0.0
+	modernc.org/mathutil v1.0.0
+	modernc.org/strutil v1.0.0
+	modernc.org/xc v1.0.0
+	rsc.io/pdf v0.1.1
+	sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.15
 	sigs.k8s.io/kustomize v2.0.3+incompatible
+	sigs.k8s.io/structured-merge-diff/v4 v4.1.2
 	sigs.k8s.io/yaml v1.2.0
+	vbom.ml/util v0.0.0-20160121211510-db5cfe13f5cc
 )
 
 replace (
@@ -361,7 +589,7 @@ replace (
 	github.com/onsi/gomega => github.com/onsi/gomega v1.7.0
 	github.com/opencontainers/go-digest => github.com/opencontainers/go-digest v1.0.0-rc1
 	github.com/opencontainers/image-spec => github.com/opencontainers/image-spec v1.0.1
-	github.com/opencontainers/runc => github.com/opencontainers/runc v1.0.0-rc91.0.20200707015106-819fcc687efb
+	github.com/opencontainers/runc => github.com/opencontainers/runc v1.0.1
 	github.com/opencontainers/runtime-spec => github.com/opencontainers/runtime-spec v1.0.3-0.20200520003142-237cc4f519e2
 	github.com/opencontainers/selinux => github.com/opencontainers/selinux v1.5.2
 	github.com/pelletier/go-toml => github.com/pelletier/go-toml v1.2.0
@@ -459,34 +687,10 @@ replace (
 	gotest.tools => gotest.tools v2.2.0+incompatible
 	gotest.tools/v3 => gotest.tools/v3 v3.0.2
 	honnef.co/go/tools => honnef.co/go/tools v0.0.1-2019.2.3
-	k8s.io/api => ./staging/src/k8s.io/api
-	k8s.io/apiextensions-apiserver => ./staging/src/k8s.io/apiextensions-apiserver
-	k8s.io/apimachinery => ./staging/src/k8s.io/apimachinery
-	k8s.io/apiserver => ./staging/src/k8s.io/apiserver
-	k8s.io/cli-runtime => ./staging/src/k8s.io/cli-runtime
-	k8s.io/client-go => ./staging/src/k8s.io/client-go
-	k8s.io/cloud-provider => ./staging/src/k8s.io/cloud-provider
-	k8s.io/cluster-bootstrap => ./staging/src/k8s.io/cluster-bootstrap
-	k8s.io/code-generator => ./staging/src/k8s.io/code-generator
-	k8s.io/component-base => ./staging/src/k8s.io/component-base
-	k8s.io/controller-manager => ./staging/src/k8s.io/controller-manager
-	k8s.io/cri-api => ./staging/src/k8s.io/cri-api
-	k8s.io/csi-translation-lib => ./staging/src/k8s.io/csi-translation-lib
 	k8s.io/gengo => k8s.io/gengo v0.0.0-20200428234225-8167cfdcfc14
 	k8s.io/heapster => k8s.io/heapster v1.2.0-beta.1
 	k8s.io/klog/v2 => k8s.io/klog/v2 v2.2.0
-	k8s.io/kube-aggregator => ./staging/src/k8s.io/kube-aggregator
-	k8s.io/kube-controller-manager => ./staging/src/k8s.io/kube-controller-manager
 	k8s.io/kube-openapi => k8s.io/kube-openapi v0.0.0-20200805222855-6aeccd4b50c6
-	k8s.io/kube-proxy => ./staging/src/k8s.io/kube-proxy
-	k8s.io/kube-scheduler => ./staging/src/k8s.io/kube-scheduler
-	k8s.io/kubectl => ./staging/src/k8s.io/kubectl
-	k8s.io/kubelet => ./staging/src/k8s.io/kubelet
-	k8s.io/legacy-cloud-providers => ./staging/src/k8s.io/legacy-cloud-providers
-	k8s.io/metrics => ./staging/src/k8s.io/metrics
-	k8s.io/sample-apiserver => ./staging/src/k8s.io/sample-apiserver
-	k8s.io/sample-cli-plugin => ./staging/src/k8s.io/sample-cli-plugin
-	k8s.io/sample-controller => ./staging/src/k8s.io/sample-controller
 	k8s.io/system-validators => k8s.io/system-validators v1.1.2
 	k8s.io/utils => k8s.io/utils v0.0.0-20200729134348-d5654de09c73
 	modernc.org/cc => modernc.org/cc v1.0.0
@@ -501,3 +705,55 @@ replace (
 	sigs.k8s.io/yaml => sigs.k8s.io/yaml v1.2.0
 	vbom.ml/util => vbom.ml/util v0.0.0-20160121211510-db5cfe13f5cc
 )
+
+replace k8s.io/api => ./staging/src/k8s.io/api
+
+replace k8s.io/apiextensions-apiserver => ./staging/src/k8s.io/apiextensions-apiserver
+
+replace k8s.io/apimachinery => ./staging/src/k8s.io/apimachinery
+
+replace k8s.io/apiserver => ./staging/src/k8s.io/apiserver
+
+replace k8s.io/cli-runtime => ./staging/src/k8s.io/cli-runtime
+
+replace k8s.io/client-go => ./staging/src/k8s.io/client-go
+
+replace k8s.io/cloud-provider => ./staging/src/k8s.io/cloud-provider
+
+replace k8s.io/cluster-bootstrap => ./staging/src/k8s.io/cluster-bootstrap
+
+replace k8s.io/code-generator => ./staging/src/k8s.io/code-generator
+
+replace k8s.io/component-base => ./staging/src/k8s.io/component-base
+
+replace k8s.io/controller-manager => ./staging/src/k8s.io/controller-manager
+
+replace k8s.io/cri-api => ./staging/src/k8s.io/cri-api
+
+replace k8s.io/csi-translation-lib => ./staging/src/k8s.io/csi-translation-lib
+
+replace k8s.io/kube-aggregator => ./staging/src/k8s.io/kube-aggregator
+
+replace k8s.io/kube-controller-manager => ./staging/src/k8s.io/kube-controller-manager
+
+replace k8s.io/kube-proxy => ./staging/src/k8s.io/kube-proxy
+
+replace k8s.io/kube-scheduler => ./staging/src/k8s.io/kube-scheduler
+
+replace k8s.io/kubectl => ./staging/src/k8s.io/kubectl
+
+replace k8s.io/kubelet => ./staging/src/k8s.io/kubelet
+
+replace k8s.io/legacy-cloud-providers => ./staging/src/k8s.io/legacy-cloud-providers
+
+replace k8s.io/metrics => ./staging/src/k8s.io/metrics
+
+replace k8s.io/sample-apiserver => ./staging/src/k8s.io/sample-apiserver
+
+replace k8s.io/sample-cli-plugin => ./staging/src/k8s.io/sample-cli-plugin
+
+replace k8s.io/sample-controller => ./staging/src/k8s.io/sample-controller
+
+replace github.com/bits-and-blooms/bitset => github.com/bits-and-blooms/bitset v1.2.0
+
+replace github.com/checkpoint-restore/go-criu/v5 => github.com/checkpoint-restore/go-criu/v5 v5.0.0

--- a/go.sum
+++ b/go.sum
@@ -64,6 +64,7 @@ github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
 github.com/bifurcation/mint v0.0.0-20180715133206-93c51c6ce115/go.mod h1:zVt7zX3K/aDCk9Tj+VM7YymsX66ERvzCJzw8rFCX2JU=
+github.com/bits-and-blooms/bitset v1.2.0/go.mod h1:gIdJ4wp64HaoK2YrL1Q5/N7Y16edYb8uY+O0FJTyyDA=
 github.com/blang/semver v3.5.0+incompatible h1:CGxCgetQ64DKk7rdZ++Vfnb1+ogGNnB17OJKJXD2Cfs=
 github.com/blang/semver v3.5.0+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
 github.com/boltdb/bolt v1.3.1 h1:JQmyP4ZBrce+ZQu0dY660FMfatumYDLun9hBCUVIkF4=
@@ -78,6 +79,7 @@ github.com/chai2010/gettext-go v0.0.0-20160711120539-c6fed771bfd5 h1:7aWHqerlJ41
 github.com/chai2010/gettext-go v0.0.0-20160711120539-c6fed771bfd5/go.mod h1:/iP1qXHoty45bqomnu2LM+VVyAEdWN+vtSHGlQgyxbw=
 github.com/checkpoint-restore/go-criu/v4 v4.0.2 h1:jt+rnBIhFtPw0fhtpYGcUOilh4aO9Hj7r+YLEtf30uA=
 github.com/checkpoint-restore/go-criu/v4 v4.0.2/go.mod h1:xUQBLp4RLc5zJtWY++yjOoMoB5lihDt7fai+75m+rGw=
+github.com/checkpoint-restore/go-criu/v5 v5.0.0/go.mod h1:cfwC0EG7HMUenopBsUf9d89JlCLQIfgVcNsNN0t6T2M=
 github.com/cheekybits/genny v0.0.0-20170328200008-9127e812e1e9/go.mod h1:+tQajlRqAUrPI7DOSpB0XAqZYtQakVtB7wXkRAgjxjQ=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
@@ -369,6 +371,7 @@ github.com/opencontainers/image-spec v1.0.1 h1:JMemWkRwHx4Zj+fVxWoMCFm/8sYGGrUVo
 github.com/opencontainers/image-spec v1.0.1/go.mod h1:BtxoFyWECRxE4U/7sNtV5W15zMzWCbyJoFRP3s7yZA0=
 github.com/opencontainers/runc v1.0.0-rc91.0.20200707015106-819fcc687efb h1:LcPVE5u4oaqw8ffPbJew0lUxZC7faM5t52PgU4px1xY=
 github.com/opencontainers/runc v1.0.0-rc91.0.20200707015106-819fcc687efb/go.mod h1:ZuXhqlr4EiRYgDrBDNfSbE4+n9JX4+V107NwAmF7sZA=
+github.com/opencontainers/runc v1.0.1/go.mod h1:aTaHFFwQXuA71CiyxOdFFIorAoemI04suvGRQFzWTD0=
 github.com/opencontainers/runtime-spec v1.0.3-0.20200520003142-237cc4f519e2 h1:9mv9SC7GWmRWE0J/+oD8w3GsN2KYGKtg6uwLN7hfP5E=
 github.com/opencontainers/runtime-spec v1.0.3-0.20200520003142-237cc4f519e2/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
 github.com/opencontainers/selinux v1.5.2 h1:F6DgIsjgBIcDksLW4D5RG9bXok6oqZ3nvMwj4ZoFu/Q=
@@ -446,6 +449,7 @@ github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhV
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5 h1:LnC5Kc/wtumK+WB441p7ynQJzVuNRJiqddSIE3IlSEQ=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
+github.com/urfave/cli v1.22.2 h1:gsqYFH8bb9ekPA12kRo0hfjngWQjkJPlN9R0N78BoUo=
 github.com/urfave/cli v1.22.2/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
 github.com/urfave/negroni v1.0.0 h1:kIimOitoypq34K7TG7DUaJ9kq/N4Ofuwi1sjz0KipXc=
 github.com/urfave/negroni v1.0.0/go.mod h1:Meg73S6kFm/4PpbYdq35yYWoCZ9mS/YSx+lKnmiohz4=

--- a/staging/src/k8s.io/api/go.mod
+++ b/staging/src/k8s.io/api/go.mod
@@ -5,12 +5,786 @@ module k8s.io/api
 go 1.15
 
 require (
+	bitbucket.org/bertimus9/systemstat v0.0.0-20180207000608-0eeff89b0690
+	github.com/Azure/azure-sdk-for-go v43.0.0+incompatible
+	github.com/Azure/go-autorest/autorest v0.9.6
+	github.com/Azure/go-autorest/autorest/adal v0.8.2
+	github.com/Azure/go-autorest/autorest/to v0.2.0
+	github.com/GoogleCloudPlatform/k8s-cloud-provider v0.0.0-20200415212048-7901bc822317
+	github.com/JeffAshton/win_pdh v0.0.0-20161109143554-76bb4ee9f0ab
+	github.com/Microsoft/go-winio v0.4.15-0.20190919025122-fc70bd9a86b5
+	github.com/Microsoft/hcsshim v0.8.10-0.20200715222032-5eafd1556990
+	github.com/PuerkitoBio/purell v1.1.1
+	github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e
+	github.com/auth0/go-jwt-middleware v0.0.0-20170425171159-5493cabe49f7
+	github.com/aws/aws-sdk-go v1.28.2
+	github.com/blang/semver v3.5.0+incompatible
+	github.com/boltdb/bolt v1.3.1
+	github.com/caddyserver/caddy v1.0.3
+	github.com/clusterhq/flocker-go v0.0.0-20160920122132-2b8b7259d313
+	github.com/codegangsta/negroni v1.0.0
+	github.com/container-storage-interface/spec v1.2.0
+	github.com/containernetworking/cni v0.8.0
+	github.com/coredns/corefile-migration v1.0.10
+	github.com/coreos/go-oidc v2.1.0+incompatible
+	github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e
+	github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f
+	github.com/cpuguy83/go-md2man/v2 v2.0.0
+	github.com/davecgh/go-spew v1.1.1
+	github.com/docker/distribution v2.7.1+incompatible
+	github.com/docker/docker v1.4.2-0.20200309214505-aa6a9891b09c
+	github.com/docker/go-connections v0.4.0
+	github.com/docker/go-units v0.4.0
+	github.com/elazarl/goproxy v0.0.0-20180725130230-947c36da3153
+	github.com/emicklei/go-restful v2.9.5+incompatible
+	github.com/evanphx/json-patch v4.9.0+incompatible
+	github.com/fsnotify/fsnotify v1.4.9
+	github.com/go-bindata/go-bindata v3.1.1+incompatible
+	github.com/go-openapi/analysis v0.19.5
+	github.com/go-openapi/loads v0.19.4
+	github.com/go-openapi/spec v0.19.3
+	github.com/go-openapi/strfmt v0.19.3
+	github.com/go-openapi/validate v0.19.5
+	github.com/go-ozzo/ozzo-validation v3.5.0+incompatible
 	github.com/gogo/protobuf v1.3.2
+	github.com/golang/groupcache v0.0.0-20191227052852-215e87163ea7
+	github.com/golang/mock v1.3.1
+	github.com/google/cadvisor v0.37.5
+	github.com/google/go-cmp v0.4.0
+	github.com/google/gofuzz v1.1.0
+	github.com/google/uuid v1.1.1
+	github.com/googleapis/gnostic v0.4.1
+	github.com/gorilla/context v1.1.1
+	github.com/hashicorp/golang-lru v0.5.1
+	github.com/heketi/heketi v9.0.1-0.20190917153846-c2e2a4ab7ab9+incompatible
+	github.com/heketi/tests v0.0.0-20151005000721-f3775cbcefd6
+	github.com/ishidawataru/sctp v0.0.0-20190723014705-7c296d48a2b5
+	github.com/json-iterator/go v1.1.10
+	github.com/libopenstorage/openstorage v1.0.0
+	github.com/lithammer/dedent v1.1.0
+	github.com/lpabon/godbc v0.1.1
+	github.com/magiconair/properties v1.8.1
+	github.com/miekg/dns v1.1.4
+	github.com/moby/ipvs v1.0.1
+	github.com/mohae/deepcopy v0.0.0-20170603005431-491d3605edfb
+	github.com/mrunalp/fileutils v0.0.0-20200520151820-abd8a0e76976
+	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822
+	github.com/mvdan/xurls v1.1.0
+	github.com/onsi/ginkgo v1.11.0
+	github.com/onsi/gomega v1.7.0
+	github.com/opencontainers/go-digest v1.0.0-rc1
+	github.com/opencontainers/runc v1.0.1
+	github.com/opencontainers/selinux v1.5.2
+	github.com/pkg/errors v0.9.1
+	github.com/pmezard/go-difflib v1.0.0
+	github.com/prometheus/client_golang v1.7.1
+	github.com/prometheus/client_model v0.2.0
+	github.com/prometheus/common v0.10.0
+	github.com/quobyte/api v0.1.2
+	github.com/robfig/cron v1.1.0
+	github.com/spf13/afero v1.2.2
+	github.com/spf13/cobra v1.0.0
+	github.com/spf13/jwalterweatherman v1.1.0
+	github.com/spf13/pflag v1.0.5
+	github.com/spf13/viper v1.4.0
+	github.com/storageos/go-api v0.0.0-20180912212459-343b3eff91fc
 	github.com/stretchr/testify v1.4.0
+	github.com/thecodeteam/goscaleio v0.1.0
+	github.com/urfave/negroni v1.0.0
+	github.com/vishvananda/netlink v1.1.0
+	github.com/vmware/govmomi v0.20.3
+	go.etcd.io/etcd v0.5.0-alpha.5.0.20200819165624-17cef6e3e9d5
+	golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9
+	golang.org/x/net v0.0.0-20201110031124-69a78807bb2b
+	golang.org/x/oauth2 v0.0.0-20191202225959-858c2ad4c8b6
+	golang.org/x/sys v0.0.0-20201112073958-5cba982894dd
+	golang.org/x/time v0.0.0-20191024005414-555d28b269f0
+	golang.org/x/tools v0.0.0-20210106214847-113979e3529a
+	gonum.org/v1/gonum v0.6.2
+	gonum.org/v1/netlib v0.0.0-20190331212654-76723241ea4e
+	google.golang.org/api v0.15.1
+	google.golang.org/grpc v1.27.0
+	gopkg.in/gcfg.v1 v1.2.0
+	gopkg.in/square/go-jose.v2 v2.2.2
+	gopkg.in/yaml.v2 v2.2.8
 	k8s.io/apimachinery v0.0.0
+	k8s.io/gengo v0.0.0-20200428234225-8167cfdcfc14
+	k8s.io/heapster v1.2.0-beta.1
+	k8s.io/klog/v2 v2.2.0
+	k8s.io/kube-openapi v0.0.0-20200805222855-6aeccd4b50c6
+	k8s.io/system-validators v1.1.2
+	k8s.io/utils v0.0.0-20200729134348-d5654de09c73
+	sigs.k8s.io/kustomize v2.0.3+incompatible
+	sigs.k8s.io/yaml v1.2.0
 )
 
 replace (
 	k8s.io/api => ../api
 	k8s.io/apimachinery => ../apimachinery
 )
+
+replace github.com/auth0/go-jwt-middleware => github.com/auth0/go-jwt-middleware v0.0.0-20170425171159-5493cabe49f7
+
+replace github.com/boltdb/bolt => github.com/boltdb/bolt v1.3.1
+
+replace github.com/codegangsta/negroni => github.com/codegangsta/negroni v1.0.0
+
+replace github.com/go-ozzo/ozzo-validation => github.com/go-ozzo/ozzo-validation v3.5.0+incompatible
+
+replace github.com/gorilla/context => github.com/gorilla/context v1.1.1
+
+replace github.com/heketi/tests => github.com/heketi/tests v0.0.0-20151005000721-f3775cbcefd6
+
+replace github.com/lpabon/godbc => github.com/lpabon/godbc v0.1.1
+
+replace github.com/magiconair/properties => github.com/magiconair/properties v1.8.1
+
+replace github.com/mohae/deepcopy => github.com/mohae/deepcopy v0.0.0-20170603005431-491d3605edfb
+
+replace github.com/spf13/jwalterweatherman => github.com/spf13/jwalterweatherman v1.1.0
+
+replace github.com/urfave/negroni => github.com/urfave/negroni v1.0.0
+
+replace gonum.org/v1/netlib => gonum.org/v1/netlib v0.0.0-20190331212654-76723241ea4e
+
+replace bitbucket.org/bertimus9/systemstat => bitbucket.org/bertimus9/systemstat v0.0.0-20180207000608-0eeff89b0690
+
+replace github.com/Azure/azure-sdk-for-go => github.com/Azure/azure-sdk-for-go v43.0.0+incompatible
+
+replace github.com/Azure/go-autorest/autorest => github.com/Azure/go-autorest/autorest v0.9.6
+
+replace github.com/Azure/go-autorest/autorest/adal => github.com/Azure/go-autorest/autorest/adal v0.8.2
+
+replace github.com/Azure/go-autorest/autorest/to => github.com/Azure/go-autorest/autorest/to v0.2.0
+
+replace github.com/GoogleCloudPlatform/k8s-cloud-provider => github.com/GoogleCloudPlatform/k8s-cloud-provider v0.0.0-20200415212048-7901bc822317
+
+replace github.com/JeffAshton/win_pdh => github.com/JeffAshton/win_pdh v0.0.0-20161109143554-76bb4ee9f0ab
+
+replace github.com/Microsoft/go-winio => github.com/Microsoft/go-winio v0.4.15-0.20190919025122-fc70bd9a86b5
+
+replace github.com/Microsoft/hcsshim => github.com/Microsoft/hcsshim v0.8.10-0.20200715222032-5eafd1556990
+
+replace github.com/PuerkitoBio/purell => github.com/PuerkitoBio/purell v1.1.1
+
+replace github.com/armon/circbuf => github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e
+
+replace github.com/aws/aws-sdk-go => github.com/aws/aws-sdk-go v1.28.2
+
+replace github.com/blang/semver => github.com/blang/semver v3.5.0+incompatible
+
+replace github.com/caddyserver/caddy => github.com/caddyserver/caddy v1.0.3
+
+replace github.com/clusterhq/flocker-go => github.com/clusterhq/flocker-go v0.0.0-20160920122132-2b8b7259d313
+
+replace github.com/container-storage-interface/spec => github.com/container-storage-interface/spec v1.2.0
+
+replace github.com/containernetworking/cni => github.com/containernetworking/cni v0.8.0
+
+replace github.com/coredns/corefile-migration => github.com/coredns/corefile-migration v1.0.10
+
+replace github.com/coreos/go-oidc => github.com/coreos/go-oidc v2.1.0+incompatible
+
+replace github.com/coreos/go-systemd => github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e
+
+replace github.com/coreos/pkg => github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f
+
+replace github.com/cpuguy83/go-md2man/v2 => github.com/cpuguy83/go-md2man/v2 v2.0.0
+
+replace github.com/davecgh/go-spew => github.com/davecgh/go-spew v1.1.1
+
+replace github.com/docker/distribution => github.com/docker/distribution v2.7.1+incompatible
+
+replace github.com/docker/docker => github.com/docker/docker v1.4.2-0.20200309214505-aa6a9891b09c
+
+replace github.com/docker/go-connections => github.com/docker/go-connections v0.4.0
+
+replace github.com/docker/go-units => github.com/docker/go-units v0.4.0
+
+replace github.com/elazarl/goproxy => github.com/elazarl/goproxy v0.0.0-20180725130230-947c36da3153
+
+replace github.com/emicklei/go-restful => github.com/emicklei/go-restful v2.9.5+incompatible
+
+replace github.com/evanphx/json-patch => github.com/evanphx/json-patch v4.9.0+incompatible
+
+replace github.com/fsnotify/fsnotify => github.com/fsnotify/fsnotify v1.4.9
+
+replace github.com/go-bindata/go-bindata => github.com/go-bindata/go-bindata v3.1.1+incompatible
+
+replace github.com/go-openapi/analysis => github.com/go-openapi/analysis v0.19.5
+
+replace github.com/go-openapi/loads => github.com/go-openapi/loads v0.19.4
+
+replace github.com/go-openapi/spec => github.com/go-openapi/spec v0.19.3
+
+replace github.com/go-openapi/strfmt => github.com/go-openapi/strfmt v0.19.3
+
+replace github.com/go-openapi/validate => github.com/go-openapi/validate v0.19.5
+
+replace github.com/gogo/protobuf => github.com/gogo/protobuf v1.3.2
+
+replace github.com/golang/groupcache => github.com/golang/groupcache v0.0.0-20191227052852-215e87163ea7
+
+replace github.com/golang/mock => github.com/golang/mock v1.3.1
+
+replace github.com/google/cadvisor => github.com/google/cadvisor v0.37.5
+
+replace github.com/google/go-cmp => github.com/google/go-cmp v0.4.0
+
+replace github.com/google/gofuzz => github.com/google/gofuzz v1.1.0
+
+replace github.com/google/uuid => github.com/google/uuid v1.1.1
+
+replace github.com/googleapis/gnostic => github.com/googleapis/gnostic v0.4.1
+
+replace github.com/hashicorp/golang-lru => github.com/hashicorp/golang-lru v0.5.1
+
+replace github.com/heketi/heketi => github.com/heketi/heketi v9.0.1-0.20190917153846-c2e2a4ab7ab9+incompatible
+
+replace github.com/ishidawataru/sctp => github.com/ishidawataru/sctp v0.0.0-20190723014705-7c296d48a2b5
+
+replace github.com/json-iterator/go => github.com/json-iterator/go v1.1.10
+
+replace github.com/libopenstorage/openstorage => github.com/libopenstorage/openstorage v1.0.0
+
+replace github.com/lithammer/dedent => github.com/lithammer/dedent v1.1.0
+
+replace github.com/miekg/dns => github.com/miekg/dns v1.1.4
+
+replace github.com/moby/ipvs => github.com/moby/ipvs v1.0.1
+
+replace github.com/mrunalp/fileutils => github.com/mrunalp/fileutils v0.0.0-20200520151820-abd8a0e76976
+
+replace github.com/munnerz/goautoneg => github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822
+
+replace github.com/mvdan/xurls => github.com/mvdan/xurls v1.1.0
+
+replace github.com/onsi/ginkgo => github.com/onsi/ginkgo v1.11.0
+
+replace github.com/onsi/gomega => github.com/onsi/gomega v1.7.0
+
+replace github.com/opencontainers/go-digest => github.com/opencontainers/go-digest v1.0.0-rc1
+
+replace github.com/opencontainers/runc => github.com/opencontainers/runc v1.0.1
+
+replace github.com/opencontainers/selinux => github.com/opencontainers/selinux v1.5.2
+
+replace github.com/pkg/errors => github.com/pkg/errors v0.9.1
+
+replace github.com/pmezard/go-difflib => github.com/pmezard/go-difflib v1.0.0
+
+replace github.com/prometheus/client_golang => github.com/prometheus/client_golang v1.7.1
+
+replace github.com/prometheus/client_model => github.com/prometheus/client_model v0.2.0
+
+replace github.com/prometheus/common => github.com/prometheus/common v0.10.0
+
+replace github.com/quobyte/api => github.com/quobyte/api v0.1.2
+
+replace github.com/robfig/cron => github.com/robfig/cron v1.1.0
+
+replace github.com/spf13/afero => github.com/spf13/afero v1.2.2
+
+replace github.com/spf13/cobra => github.com/spf13/cobra v1.0.0
+
+replace github.com/spf13/pflag => github.com/spf13/pflag v1.0.5
+
+replace github.com/spf13/viper => github.com/spf13/viper v1.4.0
+
+replace github.com/storageos/go-api => github.com/storageos/go-api v0.0.0-20180912212459-343b3eff91fc
+
+replace github.com/stretchr/testify => github.com/stretchr/testify v1.4.0
+
+replace github.com/thecodeteam/goscaleio => github.com/thecodeteam/goscaleio v0.1.0
+
+replace github.com/vishvananda/netlink => github.com/vishvananda/netlink v1.1.0
+
+replace github.com/vmware/govmomi => github.com/vmware/govmomi v0.20.3
+
+replace go.etcd.io/etcd => go.etcd.io/etcd v0.5.0-alpha.5.0.20200819165624-17cef6e3e9d5
+
+replace golang.org/x/crypto => golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9
+
+replace golang.org/x/net => golang.org/x/net v0.0.0-20201110031124-69a78807bb2b
+
+replace golang.org/x/oauth2 => golang.org/x/oauth2 v0.0.0-20191202225959-858c2ad4c8b6
+
+replace golang.org/x/sys => golang.org/x/sys v0.0.0-20201112073958-5cba982894dd
+
+replace golang.org/x/time => golang.org/x/time v0.0.0-20191024005414-555d28b269f0
+
+replace golang.org/x/tools => golang.org/x/tools v0.0.0-20210106214847-113979e3529a
+
+replace gonum.org/v1/gonum => gonum.org/v1/gonum v0.6.2
+
+replace google.golang.org/api => google.golang.org/api v0.15.1
+
+replace google.golang.org/grpc => google.golang.org/grpc v1.27.0
+
+replace gopkg.in/gcfg.v1 => gopkg.in/gcfg.v1 v1.2.0
+
+replace gopkg.in/square/go-jose.v2 => gopkg.in/square/go-jose.v2 v2.2.2
+
+replace gopkg.in/yaml.v2 => gopkg.in/yaml.v2 v2.2.8
+
+replace k8s.io/gengo => k8s.io/gengo v0.0.0-20200428234225-8167cfdcfc14
+
+replace k8s.io/heapster => k8s.io/heapster v1.2.0-beta.1
+
+replace k8s.io/klog/v2 => k8s.io/klog/v2 v2.2.0
+
+replace k8s.io/kube-openapi => k8s.io/kube-openapi v0.0.0-20200805222855-6aeccd4b50c6
+
+replace k8s.io/system-validators => k8s.io/system-validators v1.1.2
+
+replace k8s.io/utils => k8s.io/utils v0.0.0-20200729134348-d5654de09c73
+
+replace sigs.k8s.io/kustomize => sigs.k8s.io/kustomize v2.0.3+incompatible
+
+replace sigs.k8s.io/yaml => sigs.k8s.io/yaml v1.2.0
+
+replace cloud.google.com/go => cloud.google.com/go v0.51.0
+
+replace cloud.google.com/go/bigquery => cloud.google.com/go/bigquery v1.0.1
+
+replace cloud.google.com/go/datastore => cloud.google.com/go/datastore v1.0.0
+
+replace cloud.google.com/go/pubsub => cloud.google.com/go/pubsub v1.0.1
+
+replace cloud.google.com/go/storage => cloud.google.com/go/storage v1.0.0
+
+replace dmitri.shuralyov.com/gpu/mtl => dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9
+
+replace github.com/Azure/go-ansiterm => github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78
+
+replace github.com/Azure/go-autorest/autorest/date => github.com/Azure/go-autorest/autorest/date v0.2.0
+
+replace github.com/Azure/go-autorest/autorest/mocks => github.com/Azure/go-autorest/autorest/mocks v0.3.0
+
+replace github.com/Azure/go-autorest/autorest/validation => github.com/Azure/go-autorest/autorest/validation v0.1.0
+
+replace github.com/Azure/go-autorest/logger => github.com/Azure/go-autorest/logger v0.1.0
+
+replace github.com/Azure/go-autorest/tracing => github.com/Azure/go-autorest/tracing v0.5.0
+
+replace github.com/BurntSushi/toml => github.com/BurntSushi/toml v0.3.1
+
+replace github.com/BurntSushi/xgb => github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802
+
+replace github.com/MakeNowJust/heredoc => github.com/MakeNowJust/heredoc v0.0.0-20170808103936-bb23615498cd
+
+replace github.com/NYTimes/gziphandler => github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46
+
+replace github.com/PuerkitoBio/urlesc => github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578
+
+replace github.com/agnivade/levenshtein => github.com/agnivade/levenshtein v1.0.1
+
+replace github.com/ajstarks/svgo => github.com/ajstarks/svgo v0.0.0-20180226025133-644b8db467af
+
+replace github.com/alecthomas/template => github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751
+
+replace github.com/alecthomas/units => github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4
+
+replace github.com/andreyvit/diff => github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883
+
+replace github.com/armon/consul-api => github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6
+
+replace github.com/asaskevich/govalidator => github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a
+
+replace github.com/beorn7/perks => github.com/beorn7/perks v1.0.1
+
+replace github.com/bgentry/speakeasy => github.com/bgentry/speakeasy v0.1.0
+
+replace github.com/bifurcation/mint => github.com/bifurcation/mint v0.0.0-20180715133206-93c51c6ce115
+
+replace github.com/cenkalti/backoff => github.com/cenkalti/backoff v2.1.1+incompatible
+
+replace github.com/census-instrumentation/opencensus-proto => github.com/census-instrumentation/opencensus-proto v0.2.1
+
+replace github.com/cespare/xxhash/v2 => github.com/cespare/xxhash/v2 v2.1.1
+
+replace github.com/chai2010/gettext-go => github.com/chai2010/gettext-go v0.0.0-20160711120539-c6fed771bfd5
+
+replace github.com/checkpoint-restore/go-criu/v4 => github.com/checkpoint-restore/go-criu/v4 v4.0.2
+
+replace github.com/cheekybits/genny => github.com/cheekybits/genny v0.0.0-20170328200008-9127e812e1e9
+
+replace github.com/chzyer/logex => github.com/chzyer/logex v1.1.10
+
+replace github.com/chzyer/readline => github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e
+
+replace github.com/chzyer/test => github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1
+
+replace github.com/cilium/ebpf => github.com/cilium/ebpf v0.0.0-20200702112145-1c8d4c9ef775
+
+replace github.com/cockroachdb/datadriven => github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa
+
+replace github.com/containerd/cgroups => github.com/containerd/cgroups v0.0.0-20200531161412-0dbf7f05ba59
+
+replace github.com/containerd/console => github.com/containerd/console v1.0.0
+
+replace github.com/containerd/containerd => github.com/containerd/containerd v1.3.3
+
+replace github.com/containerd/continuity => github.com/containerd/continuity v0.0.0-20190426062206-aaeac12a7ffc
+
+replace github.com/containerd/fifo => github.com/containerd/fifo v0.0.0-20190226154929-a9fb20d87448
+
+replace github.com/containerd/go-runc => github.com/containerd/go-runc v0.0.0-20180907222934-5a6d9f37cfa3
+
+replace github.com/containerd/ttrpc => github.com/containerd/ttrpc v1.0.0
+
+replace github.com/containerd/typeurl => github.com/containerd/typeurl v1.0.0
+
+replace github.com/coreos/bbolt => github.com/coreos/bbolt v1.3.2
+
+replace github.com/coreos/etcd => github.com/coreos/etcd v3.3.10+incompatible
+
+replace github.com/coreos/go-semver => github.com/coreos/go-semver v0.3.0
+
+replace github.com/coreos/go-systemd/v22 => github.com/coreos/go-systemd/v22 v22.1.0
+
+replace github.com/creack/pty => github.com/creack/pty v1.1.7
+
+replace github.com/cyphar/filepath-securejoin => github.com/cyphar/filepath-securejoin v0.2.2
+
+replace github.com/daviddengcn/go-colortext => github.com/daviddengcn/go-colortext v0.0.0-20160507010035-511bcaf42ccd
+
+replace github.com/dgrijalva/jwt-go => github.com/dgrijalva/jwt-go v3.2.0+incompatible
+
+replace github.com/dnaeon/go-vcr => github.com/dnaeon/go-vcr v1.0.1
+
+replace github.com/docker/spdystream => github.com/docker/spdystream v0.0.0-20160310174837-449fdfce4d96
+
+replace github.com/docopt/docopt-go => github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815
+
+replace github.com/dustin/go-humanize => github.com/dustin/go-humanize v1.0.0
+
+replace github.com/envoyproxy/go-control-plane => github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473
+
+replace github.com/envoyproxy/protoc-gen-validate => github.com/envoyproxy/protoc-gen-validate v0.1.0
+
+replace github.com/euank/go-kmsg-parser => github.com/euank/go-kmsg-parser v2.0.0+incompatible
+
+replace github.com/exponent-io/jsonpath => github.com/exponent-io/jsonpath v0.0.0-20151013193312-d6023ce2651d
+
+replace github.com/fatih/camelcase => github.com/fatih/camelcase v1.0.0
+
+replace github.com/fatih/color => github.com/fatih/color v1.7.0
+
+replace github.com/flynn/go-shlex => github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568
+
+replace github.com/fogleman/gg => github.com/fogleman/gg v1.2.1-0.20190220221249-0403632d5b90
+
+replace github.com/ghodss/yaml => github.com/ghodss/yaml v1.0.0
+
+replace github.com/go-acme/lego => github.com/go-acme/lego v2.5.0+incompatible
+
+replace github.com/go-gl/glfw/v3.3/glfw => github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72
+
+replace github.com/go-ini/ini => github.com/go-ini/ini v1.9.0
+
+replace github.com/go-kit/kit => github.com/go-kit/kit v0.9.0
+
+replace github.com/go-logfmt/logfmt => github.com/go-logfmt/logfmt v0.4.0
+
+replace github.com/go-logr/logr => github.com/go-logr/logr v0.2.0
+
+replace github.com/go-openapi/errors => github.com/go-openapi/errors v0.19.2
+
+replace github.com/go-openapi/jsonpointer => github.com/go-openapi/jsonpointer v0.19.3
+
+replace github.com/go-openapi/jsonreference => github.com/go-openapi/jsonreference v0.19.3
+
+replace github.com/go-openapi/runtime => github.com/go-openapi/runtime v0.19.4
+
+replace github.com/go-openapi/swag => github.com/go-openapi/swag v0.19.5
+
+replace github.com/go-stack/stack => github.com/go-stack/stack v1.8.0
+
+replace github.com/godbus/dbus/v5 => github.com/godbus/dbus/v5 v5.0.3
+
+replace github.com/golang/freetype => github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0
+
+replace github.com/golang/glog => github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
+
+replace github.com/golang/protobuf => github.com/golang/protobuf v1.4.2
+
+replace github.com/golangplus/bytes => github.com/golangplus/bytes v0.0.0-20160111154220-45c989fe5450
+
+replace github.com/golangplus/fmt => github.com/golangplus/fmt v0.0.0-20150411045040-2a5d6d7d2995
+
+replace github.com/golangplus/testing => github.com/golangplus/testing v0.0.0-20180327235837-af21d9c3145e
+
+replace github.com/google/btree => github.com/google/btree v1.0.0
+
+replace github.com/google/martian => github.com/google/martian v2.1.0+incompatible
+
+replace github.com/google/pprof => github.com/google/pprof v0.0.0-20191218002539-d4f498aebedc
+
+replace github.com/google/renameio => github.com/google/renameio v0.1.0
+
+replace github.com/googleapis/gax-go/v2 => github.com/googleapis/gax-go/v2 v2.0.5
+
+replace github.com/gophercloud/gophercloud => github.com/gophercloud/gophercloud v0.1.0
+
+replace github.com/gopherjs/gopherjs => github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1
+
+replace github.com/gorilla/mux => github.com/gorilla/mux v1.7.3
+
+replace github.com/gorilla/websocket => github.com/gorilla/websocket v1.4.0
+
+replace github.com/gregjones/httpcache => github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7
+
+replace github.com/grpc-ecosystem/go-grpc-middleware => github.com/grpc-ecosystem/go-grpc-middleware v1.0.1-0.20190118093823-f849b5445de4
+
+replace github.com/grpc-ecosystem/go-grpc-prometheus => github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0
+
+replace github.com/grpc-ecosystem/grpc-gateway => github.com/grpc-ecosystem/grpc-gateway v1.9.5
+
+replace github.com/hashicorp/go-syslog => github.com/hashicorp/go-syslog v1.0.0
+
+replace github.com/hashicorp/hcl => github.com/hashicorp/hcl v1.0.0
+
+replace github.com/hpcloud/tail => github.com/hpcloud/tail v1.0.0
+
+replace github.com/ianlancetaylor/demangle => github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6
+
+replace github.com/imdario/mergo => github.com/imdario/mergo v0.3.5
+
+replace github.com/inconshreveable/mousetrap => github.com/inconshreveable/mousetrap v1.0.0
+
+replace github.com/jimstudt/http-authentication => github.com/jimstudt/http-authentication v0.0.0-20140401203705-3eca13d6893a
+
+replace github.com/jmespath/go-jmespath => github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af
+
+replace github.com/jonboulle/clockwork => github.com/jonboulle/clockwork v0.1.0
+
+replace github.com/jstemmer/go-junit-report => github.com/jstemmer/go-junit-report v0.9.1
+
+replace github.com/jtolds/gls => github.com/jtolds/gls v4.20.0+incompatible
+
+replace github.com/julienschmidt/httprouter => github.com/julienschmidt/httprouter v1.2.0
+
+replace github.com/jung-kurt/gofpdf => github.com/jung-kurt/gofpdf v1.0.3-0.20190309125859-24315acbbda5
+
+replace github.com/karrick/godirwalk => github.com/karrick/godirwalk v1.7.5
+
+replace github.com/kisielk/errcheck => github.com/kisielk/errcheck v1.5.0
+
+replace github.com/kisielk/gotool => github.com/kisielk/gotool v1.0.0
+
+replace github.com/klauspost/cpuid => github.com/klauspost/cpuid v1.2.0
+
+replace github.com/konsorten/go-windows-terminal-sequences => github.com/konsorten/go-windows-terminal-sequences v1.0.3
+
+replace github.com/kr/logfmt => github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515
+
+replace github.com/kr/pretty => github.com/kr/pretty v0.2.0
+
+replace github.com/kr/pty => github.com/kr/pty v1.1.5
+
+replace github.com/kr/text => github.com/kr/text v0.1.0
+
+replace github.com/kylelemons/godebug => github.com/kylelemons/godebug v0.0.0-20170820004349-d65d576e9348
+
+replace github.com/liggitt/tabwriter => github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de
+
+replace github.com/lucas-clemente/aes12 => github.com/lucas-clemente/aes12 v0.0.0-20171027163421-cd47fb39b79f
+
+replace github.com/lucas-clemente/quic-clients => github.com/lucas-clemente/quic-clients v0.1.0
+
+replace github.com/lucas-clemente/quic-go => github.com/lucas-clemente/quic-go v0.10.2
+
+replace github.com/lucas-clemente/quic-go-certificates => github.com/lucas-clemente/quic-go-certificates v0.0.0-20160823095156-d2f86524cced
+
+replace github.com/mailru/easyjson => github.com/mailru/easyjson v0.7.0
+
+replace github.com/marten-seemann/qtls => github.com/marten-seemann/qtls v0.2.3
+
+replace github.com/mattn/go-colorable => github.com/mattn/go-colorable v0.0.9
+
+replace github.com/mattn/go-isatty => github.com/mattn/go-isatty v0.0.4
+
+replace github.com/mattn/go-runewidth => github.com/mattn/go-runewidth v0.0.2
+
+replace github.com/matttproud/golang_protobuf_extensions => github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369
+
+replace github.com/mholt/certmagic => github.com/mholt/certmagic v0.6.2-0.20190624175158-6a42ef9fe8c2
+
+replace github.com/mindprince/gonvml => github.com/mindprince/gonvml v0.0.0-20190828220739-9ebdce4bb989
+
+replace github.com/mistifyio/go-zfs => github.com/mistifyio/go-zfs v2.1.2-0.20190413222219-f784269be439+incompatible
+
+replace github.com/mitchellh/go-homedir => github.com/mitchellh/go-homedir v1.1.0
+
+replace github.com/mitchellh/go-wordwrap => github.com/mitchellh/go-wordwrap v1.0.0
+
+replace github.com/mitchellh/mapstructure => github.com/mitchellh/mapstructure v1.1.2
+
+replace github.com/moby/sys/mountinfo => github.com/moby/sys/mountinfo v0.1.3
+
+replace github.com/moby/term => github.com/moby/term v0.0.0-20200312100748-672ec06f55cd
+
+replace github.com/modern-go/concurrent => github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd
+
+replace github.com/modern-go/reflect2 => github.com/modern-go/reflect2 v1.0.1
+
+replace github.com/morikuni/aec => github.com/morikuni/aec v1.0.0
+
+replace github.com/mwitkow/go-conntrack => github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223
+
+replace github.com/mxk/go-flowrate => github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f
+
+replace github.com/naoina/go-stringutil => github.com/naoina/go-stringutil v0.1.0
+
+replace github.com/naoina/toml => github.com/naoina/toml v0.1.1
+
+replace github.com/olekukonko/tablewriter => github.com/olekukonko/tablewriter v0.0.0-20170122224234-a0225b3f23b5
+
+replace github.com/opencontainers/image-spec => github.com/opencontainers/image-spec v1.0.1
+
+replace github.com/opencontainers/runtime-spec => github.com/opencontainers/runtime-spec v1.0.3-0.20200520003142-237cc4f519e2
+
+replace github.com/pelletier/go-toml => github.com/pelletier/go-toml v1.2.0
+
+replace github.com/peterbourgon/diskv => github.com/peterbourgon/diskv v2.0.1+incompatible
+
+replace github.com/pquerna/cachecontrol => github.com/pquerna/cachecontrol v0.0.0-20171018203845-0dec1b30a021
+
+replace github.com/prometheus/procfs => github.com/prometheus/procfs v0.1.3
+
+replace github.com/remyoudompheng/bigfft => github.com/remyoudompheng/bigfft v0.0.0-20170806203942-52369c62f446
+
+replace github.com/rogpeppe/fastuuid => github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af
+
+replace github.com/rogpeppe/go-internal => github.com/rogpeppe/go-internal v1.3.0
+
+replace github.com/rubiojr/go-vhd => github.com/rubiojr/go-vhd v0.0.0-20200706105327-02e210299021
+
+replace github.com/russross/blackfriday => github.com/russross/blackfriday v1.5.2
+
+replace github.com/russross/blackfriday/v2 => github.com/russross/blackfriday/v2 v2.0.1
+
+replace github.com/satori/go.uuid => github.com/satori/go.uuid v1.2.0
+
+replace github.com/seccomp/libseccomp-golang => github.com/seccomp/libseccomp-golang v0.9.1
+
+replace github.com/sergi/go-diff => github.com/sergi/go-diff v1.0.0
+
+replace github.com/shurcooL/sanitized_anchor_name => github.com/shurcooL/sanitized_anchor_name v1.0.0
+
+replace github.com/sirupsen/logrus => github.com/sirupsen/logrus v1.6.0
+
+replace github.com/smartystreets/assertions => github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d
+
+replace github.com/smartystreets/goconvey => github.com/smartystreets/goconvey v1.6.4
+
+replace github.com/soheilhy/cmux => github.com/soheilhy/cmux v0.1.4
+
+replace github.com/spf13/cast => github.com/spf13/cast v1.3.0
+
+replace github.com/stretchr/objx => github.com/stretchr/objx v0.2.0
+
+replace github.com/syndtr/gocapability => github.com/syndtr/gocapability v0.0.0-20180916011248-d98352740cb2
+
+replace github.com/tidwall/pretty => github.com/tidwall/pretty v1.0.0
+
+replace github.com/tmc/grpc-websocket-proxy => github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5
+
+replace github.com/ugorji/go => github.com/ugorji/go v1.1.4
+
+replace github.com/urfave/cli => github.com/urfave/cli v1.22.2
+
+replace github.com/vektah/gqlparser => github.com/vektah/gqlparser v1.1.2
+
+replace github.com/vishvananda/netns => github.com/vishvananda/netns v0.0.0-20200520041808-52d707b772fe
+
+replace github.com/xiang90/probing => github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2
+
+replace github.com/xlab/handysort => github.com/xlab/handysort v0.0.0-20150421192137-fb3537ed64a1
+
+replace github.com/xordataexchange/crypt => github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77
+
+replace github.com/yuin/goldmark => github.com/yuin/goldmark v1.2.1
+
+replace go.etcd.io/bbolt => go.etcd.io/bbolt v1.3.5
+
+replace go.mongodb.org/mongo-driver => go.mongodb.org/mongo-driver v1.1.2
+
+replace go.opencensus.io => go.opencensus.io v0.22.2
+
+replace go.uber.org/atomic => go.uber.org/atomic v1.4.0
+
+replace go.uber.org/multierr => go.uber.org/multierr v1.1.0
+
+replace go.uber.org/zap => go.uber.org/zap v1.10.0
+
+replace golang.org/x/exp => golang.org/x/exp v0.0.0-20191227195350-da58074b4299
+
+replace golang.org/x/image => golang.org/x/image v0.0.0-20190802002840-cff245a6509b
+
+replace golang.org/x/lint => golang.org/x/lint v0.0.0-20191125180803-fdd1cda4f05f
+
+replace golang.org/x/mobile => golang.org/x/mobile v0.0.0-20190719004257-d2bd2a29d028
+
+replace golang.org/x/mod => golang.org/x/mod v0.3.0
+
+replace golang.org/x/sync => golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9
+
+replace golang.org/x/text => golang.org/x/text v0.3.3
+
+replace golang.org/x/xerrors => golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1
+
+replace gonum.org/v1/plot => gonum.org/v1/plot v0.0.0-20190515093506-e2840ee46a6b
+
+replace google.golang.org/appengine => google.golang.org/appengine v1.6.5
+
+replace google.golang.org/genproto => google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013
+
+replace google.golang.org/protobuf => google.golang.org/protobuf v1.24.0
+
+replace gopkg.in/alecthomas/kingpin.v2 => gopkg.in/alecthomas/kingpin.v2 v2.2.6
+
+replace gopkg.in/check.v1 => gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15
+
+replace gopkg.in/cheggaaa/pb.v1 => gopkg.in/cheggaaa/pb.v1 v1.0.25
+
+replace gopkg.in/errgo.v2 => gopkg.in/errgo.v2 v2.1.0
+
+replace gopkg.in/fsnotify.v1 => gopkg.in/fsnotify.v1 v1.4.7
+
+replace gopkg.in/inf.v0 => gopkg.in/inf.v0 v0.9.1
+
+replace gopkg.in/mcuadros/go-syslog.v2 => gopkg.in/mcuadros/go-syslog.v2 v2.2.1
+
+replace gopkg.in/natefinch/lumberjack.v2 => gopkg.in/natefinch/lumberjack.v2 v2.0.0
+
+replace gopkg.in/resty.v1 => gopkg.in/resty.v1 v1.12.0
+
+replace gopkg.in/tomb.v1 => gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7
+
+replace gopkg.in/warnings.v0 => gopkg.in/warnings.v0 v0.1.1
+
+replace gotest.tools => gotest.tools v2.2.0+incompatible
+
+replace gotest.tools/v3 => gotest.tools/v3 v3.0.2
+
+replace honnef.co/go/tools => honnef.co/go/tools v0.0.1-2019.2.3
+
+replace modernc.org/cc => modernc.org/cc v1.0.0
+
+replace modernc.org/golex => modernc.org/golex v1.0.0
+
+replace modernc.org/mathutil => modernc.org/mathutil v1.0.0
+
+replace modernc.org/strutil => modernc.org/strutil v1.0.0
+
+replace modernc.org/xc => modernc.org/xc v1.0.0
+
+replace rsc.io/pdf => rsc.io/pdf v0.1.1
+
+replace sigs.k8s.io/apiserver-network-proxy/konnectivity-client => sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.15
+
+replace sigs.k8s.io/structured-merge-diff/v4 => sigs.k8s.io/structured-merge-diff/v4 v4.1.2
+
+replace vbom.ml/util => vbom.ml/util v0.0.0-20160121211510-db5cfe13f5cc

--- a/staging/src/k8s.io/apiextensions-apiserver/go.mod
+++ b/staging/src/k8s.io/apiextensions-apiserver/go.mod
@@ -5,21 +5,108 @@ module k8s.io/apiextensions-apiserver
 go 1.15
 
 require (
+	bitbucket.org/bertimus9/systemstat v0.0.0-20180207000608-0eeff89b0690
+	github.com/Azure/azure-sdk-for-go v43.0.0+incompatible
+	github.com/Azure/go-autorest/autorest v0.9.6
+	github.com/Azure/go-autorest/autorest/adal v0.8.2
+	github.com/Azure/go-autorest/autorest/to v0.2.0
+	github.com/GoogleCloudPlatform/k8s-cloud-provider v0.0.0-20200415212048-7901bc822317
+	github.com/JeffAshton/win_pdh v0.0.0-20161109143554-76bb4ee9f0ab
+	github.com/Microsoft/go-winio v0.4.15-0.20190919025122-fc70bd9a86b5
+	github.com/Microsoft/hcsshim v0.8.10-0.20200715222032-5eafd1556990
+	github.com/PuerkitoBio/purell v1.1.1
+	github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e
+	github.com/auth0/go-jwt-middleware v0.0.0-20170425171159-5493cabe49f7
+	github.com/aws/aws-sdk-go v1.28.2
+	github.com/blang/semver v3.5.0+incompatible
+	github.com/boltdb/bolt v1.3.1
+	github.com/caddyserver/caddy v1.0.3
+	github.com/clusterhq/flocker-go v0.0.0-20160920122132-2b8b7259d313
+	github.com/codegangsta/negroni v1.0.0
+	github.com/container-storage-interface/spec v1.2.0
+	github.com/containernetworking/cni v0.8.0
+	github.com/coredns/corefile-migration v1.0.10
+	github.com/coreos/go-oidc v2.1.0+incompatible
+	github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e
+	github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f
+	github.com/cpuguy83/go-md2man/v2 v2.0.0
+	github.com/davecgh/go-spew v1.1.1
+	github.com/docker/distribution v2.7.1+incompatible
+	github.com/docker/docker v1.4.2-0.20200309214505-aa6a9891b09c
+	github.com/docker/go-connections v0.4.0
+	github.com/docker/go-units v0.4.0
+	github.com/elazarl/goproxy v0.0.0-20180725130230-947c36da3153
 	github.com/emicklei/go-restful v2.9.5+incompatible
+	github.com/evanphx/json-patch v4.9.0+incompatible
+	github.com/fsnotify/fsnotify v1.4.9
+	github.com/go-bindata/go-bindata v3.1.1+incompatible
+	github.com/go-openapi/analysis v0.19.5
 	github.com/go-openapi/errors v0.19.2
+	github.com/go-openapi/loads v0.19.4
 	github.com/go-openapi/spec v0.19.3
 	github.com/go-openapi/strfmt v0.19.3
 	github.com/go-openapi/validate v0.19.5
+	github.com/go-ozzo/ozzo-validation v3.5.0+incompatible
 	github.com/gogo/protobuf v1.3.2
+	github.com/golang/groupcache v0.0.0-20191227052852-215e87163ea7
+	github.com/golang/mock v1.3.1
+	github.com/google/cadvisor v0.37.5
 	github.com/google/go-cmp v0.4.0
 	github.com/google/gofuzz v1.1.0
 	github.com/google/uuid v1.1.1
 	github.com/googleapis/gnostic v0.4.1
+	github.com/gorilla/context v1.1.1
+	github.com/hashicorp/golang-lru v0.5.1
+	github.com/heketi/heketi v9.0.1-0.20190917153846-c2e2a4ab7ab9+incompatible
+	github.com/heketi/tests v0.0.0-20151005000721-f3775cbcefd6
+	github.com/ishidawataru/sctp v0.0.0-20190723014705-7c296d48a2b5
+	github.com/json-iterator/go v1.1.10
+	github.com/libopenstorage/openstorage v1.0.0
+	github.com/lithammer/dedent v1.1.0
+	github.com/lpabon/godbc v0.1.1
+	github.com/magiconair/properties v1.8.1
+	github.com/miekg/dns v1.1.4
+	github.com/moby/ipvs v1.0.1
+	github.com/mohae/deepcopy v0.0.0-20170603005431-491d3605edfb
+	github.com/mrunalp/fileutils v0.0.0-20200520151820-abd8a0e76976
+	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822
+	github.com/mvdan/xurls v1.1.0
+	github.com/onsi/ginkgo v1.11.0
+	github.com/onsi/gomega v1.7.0
+	github.com/opencontainers/go-digest v1.0.0-rc1
+	github.com/opencontainers/runc v1.0.1
+	github.com/opencontainers/selinux v1.5.2
+	github.com/pkg/errors v0.9.1
+	github.com/pmezard/go-difflib v1.0.0
+	github.com/prometheus/client_golang v1.7.1
+	github.com/prometheus/client_model v0.2.0
+	github.com/prometheus/common v0.10.0
+	github.com/quobyte/api v0.1.2
+	github.com/robfig/cron v1.1.0
+	github.com/spf13/afero v1.2.2
 	github.com/spf13/cobra v1.0.0
+	github.com/spf13/jwalterweatherman v1.1.0
 	github.com/spf13/pflag v1.0.5
+	github.com/spf13/viper v1.4.0
+	github.com/storageos/go-api v0.0.0-20180912212459-343b3eff91fc
 	github.com/stretchr/testify v1.4.0
+	github.com/thecodeteam/goscaleio v0.1.0
+	github.com/urfave/negroni v1.0.0
+	github.com/vishvananda/netlink v1.1.0
+	github.com/vmware/govmomi v0.20.3
 	go.etcd.io/etcd v0.5.0-alpha.5.0.20200819165624-17cef6e3e9d5
+	golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9
+	golang.org/x/net v0.0.0-20201110031124-69a78807bb2b
+	golang.org/x/oauth2 v0.0.0-20191202225959-858c2ad4c8b6
+	golang.org/x/sys v0.0.0-20201112073958-5cba982894dd
+	golang.org/x/time v0.0.0-20191024005414-555d28b269f0
+	golang.org/x/tools v0.0.0-20210106214847-113979e3529a
+	gonum.org/v1/gonum v0.6.2
+	gonum.org/v1/netlib v0.0.0-20190331212654-76723241ea4e
+	google.golang.org/api v0.15.1
 	google.golang.org/grpc v1.27.0
+	gopkg.in/gcfg.v1 v1.2.0
+	gopkg.in/square/go-jose.v2 v2.2.2
 	gopkg.in/yaml.v2 v2.2.8
 	k8s.io/api v0.0.0
 	k8s.io/apimachinery v0.0.0
@@ -27,9 +114,13 @@ require (
 	k8s.io/client-go v0.0.0
 	k8s.io/code-generator v0.0.0
 	k8s.io/component-base v0.0.0
+	k8s.io/gengo v0.0.0-20200428234225-8167cfdcfc14
+	k8s.io/heapster v1.2.0-beta.1
 	k8s.io/klog/v2 v2.2.0
 	k8s.io/kube-openapi v0.0.0-20200805222855-6aeccd4b50c6
+	k8s.io/system-validators v1.1.2
 	k8s.io/utils v0.0.0-20200729134348-d5654de09c73
+	sigs.k8s.io/kustomize v2.0.3+incompatible
 	sigs.k8s.io/yaml v1.2.0
 )
 
@@ -42,3 +133,669 @@ replace (
 	k8s.io/code-generator => ../code-generator
 	k8s.io/component-base => ../component-base
 )
+
+replace github.com/auth0/go-jwt-middleware => github.com/auth0/go-jwt-middleware v0.0.0-20170425171159-5493cabe49f7
+
+replace github.com/boltdb/bolt => github.com/boltdb/bolt v1.3.1
+
+replace github.com/codegangsta/negroni => github.com/codegangsta/negroni v1.0.0
+
+replace github.com/go-ozzo/ozzo-validation => github.com/go-ozzo/ozzo-validation v3.5.0+incompatible
+
+replace github.com/gorilla/context => github.com/gorilla/context v1.1.1
+
+replace github.com/heketi/tests => github.com/heketi/tests v0.0.0-20151005000721-f3775cbcefd6
+
+replace github.com/lpabon/godbc => github.com/lpabon/godbc v0.1.1
+
+replace github.com/magiconair/properties => github.com/magiconair/properties v1.8.1
+
+replace github.com/mohae/deepcopy => github.com/mohae/deepcopy v0.0.0-20170603005431-491d3605edfb
+
+replace github.com/spf13/jwalterweatherman => github.com/spf13/jwalterweatherman v1.1.0
+
+replace github.com/urfave/negroni => github.com/urfave/negroni v1.0.0
+
+replace gonum.org/v1/netlib => gonum.org/v1/netlib v0.0.0-20190331212654-76723241ea4e
+
+replace bitbucket.org/bertimus9/systemstat => bitbucket.org/bertimus9/systemstat v0.0.0-20180207000608-0eeff89b0690
+
+replace github.com/Azure/azure-sdk-for-go => github.com/Azure/azure-sdk-for-go v43.0.0+incompatible
+
+replace github.com/Azure/go-autorest/autorest => github.com/Azure/go-autorest/autorest v0.9.6
+
+replace github.com/Azure/go-autorest/autorest/adal => github.com/Azure/go-autorest/autorest/adal v0.8.2
+
+replace github.com/Azure/go-autorest/autorest/to => github.com/Azure/go-autorest/autorest/to v0.2.0
+
+replace github.com/GoogleCloudPlatform/k8s-cloud-provider => github.com/GoogleCloudPlatform/k8s-cloud-provider v0.0.0-20200415212048-7901bc822317
+
+replace github.com/JeffAshton/win_pdh => github.com/JeffAshton/win_pdh v0.0.0-20161109143554-76bb4ee9f0ab
+
+replace github.com/Microsoft/go-winio => github.com/Microsoft/go-winio v0.4.15-0.20190919025122-fc70bd9a86b5
+
+replace github.com/Microsoft/hcsshim => github.com/Microsoft/hcsshim v0.8.10-0.20200715222032-5eafd1556990
+
+replace github.com/PuerkitoBio/purell => github.com/PuerkitoBio/purell v1.1.1
+
+replace github.com/armon/circbuf => github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e
+
+replace github.com/aws/aws-sdk-go => github.com/aws/aws-sdk-go v1.28.2
+
+replace github.com/blang/semver => github.com/blang/semver v3.5.0+incompatible
+
+replace github.com/caddyserver/caddy => github.com/caddyserver/caddy v1.0.3
+
+replace github.com/clusterhq/flocker-go => github.com/clusterhq/flocker-go v0.0.0-20160920122132-2b8b7259d313
+
+replace github.com/container-storage-interface/spec => github.com/container-storage-interface/spec v1.2.0
+
+replace github.com/containernetworking/cni => github.com/containernetworking/cni v0.8.0
+
+replace github.com/coredns/corefile-migration => github.com/coredns/corefile-migration v1.0.10
+
+replace github.com/coreos/go-oidc => github.com/coreos/go-oidc v2.1.0+incompatible
+
+replace github.com/coreos/go-systemd => github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e
+
+replace github.com/coreos/pkg => github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f
+
+replace github.com/cpuguy83/go-md2man/v2 => github.com/cpuguy83/go-md2man/v2 v2.0.0
+
+replace github.com/davecgh/go-spew => github.com/davecgh/go-spew v1.1.1
+
+replace github.com/docker/distribution => github.com/docker/distribution v2.7.1+incompatible
+
+replace github.com/docker/docker => github.com/docker/docker v1.4.2-0.20200309214505-aa6a9891b09c
+
+replace github.com/docker/go-connections => github.com/docker/go-connections v0.4.0
+
+replace github.com/docker/go-units => github.com/docker/go-units v0.4.0
+
+replace github.com/elazarl/goproxy => github.com/elazarl/goproxy v0.0.0-20180725130230-947c36da3153
+
+replace github.com/emicklei/go-restful => github.com/emicklei/go-restful v2.9.5+incompatible
+
+replace github.com/evanphx/json-patch => github.com/evanphx/json-patch v4.9.0+incompatible
+
+replace github.com/fsnotify/fsnotify => github.com/fsnotify/fsnotify v1.4.9
+
+replace github.com/go-bindata/go-bindata => github.com/go-bindata/go-bindata v3.1.1+incompatible
+
+replace github.com/go-openapi/analysis => github.com/go-openapi/analysis v0.19.5
+
+replace github.com/go-openapi/loads => github.com/go-openapi/loads v0.19.4
+
+replace github.com/go-openapi/spec => github.com/go-openapi/spec v0.19.3
+
+replace github.com/go-openapi/strfmt => github.com/go-openapi/strfmt v0.19.3
+
+replace github.com/go-openapi/validate => github.com/go-openapi/validate v0.19.5
+
+replace github.com/gogo/protobuf => github.com/gogo/protobuf v1.3.2
+
+replace github.com/golang/groupcache => github.com/golang/groupcache v0.0.0-20191227052852-215e87163ea7
+
+replace github.com/golang/mock => github.com/golang/mock v1.3.1
+
+replace github.com/google/cadvisor => github.com/google/cadvisor v0.37.5
+
+replace github.com/google/go-cmp => github.com/google/go-cmp v0.4.0
+
+replace github.com/google/gofuzz => github.com/google/gofuzz v1.1.0
+
+replace github.com/google/uuid => github.com/google/uuid v1.1.1
+
+replace github.com/googleapis/gnostic => github.com/googleapis/gnostic v0.4.1
+
+replace github.com/hashicorp/golang-lru => github.com/hashicorp/golang-lru v0.5.1
+
+replace github.com/heketi/heketi => github.com/heketi/heketi v9.0.1-0.20190917153846-c2e2a4ab7ab9+incompatible
+
+replace github.com/ishidawataru/sctp => github.com/ishidawataru/sctp v0.0.0-20190723014705-7c296d48a2b5
+
+replace github.com/json-iterator/go => github.com/json-iterator/go v1.1.10
+
+replace github.com/libopenstorage/openstorage => github.com/libopenstorage/openstorage v1.0.0
+
+replace github.com/lithammer/dedent => github.com/lithammer/dedent v1.1.0
+
+replace github.com/miekg/dns => github.com/miekg/dns v1.1.4
+
+replace github.com/moby/ipvs => github.com/moby/ipvs v1.0.1
+
+replace github.com/mrunalp/fileutils => github.com/mrunalp/fileutils v0.0.0-20200520151820-abd8a0e76976
+
+replace github.com/munnerz/goautoneg => github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822
+
+replace github.com/mvdan/xurls => github.com/mvdan/xurls v1.1.0
+
+replace github.com/onsi/ginkgo => github.com/onsi/ginkgo v1.11.0
+
+replace github.com/onsi/gomega => github.com/onsi/gomega v1.7.0
+
+replace github.com/opencontainers/go-digest => github.com/opencontainers/go-digest v1.0.0-rc1
+
+replace github.com/opencontainers/runc => github.com/opencontainers/runc v1.0.1
+
+replace github.com/opencontainers/selinux => github.com/opencontainers/selinux v1.5.2
+
+replace github.com/pkg/errors => github.com/pkg/errors v0.9.1
+
+replace github.com/pmezard/go-difflib => github.com/pmezard/go-difflib v1.0.0
+
+replace github.com/prometheus/client_golang => github.com/prometheus/client_golang v1.7.1
+
+replace github.com/prometheus/client_model => github.com/prometheus/client_model v0.2.0
+
+replace github.com/prometheus/common => github.com/prometheus/common v0.10.0
+
+replace github.com/quobyte/api => github.com/quobyte/api v0.1.2
+
+replace github.com/robfig/cron => github.com/robfig/cron v1.1.0
+
+replace github.com/spf13/afero => github.com/spf13/afero v1.2.2
+
+replace github.com/spf13/cobra => github.com/spf13/cobra v1.0.0
+
+replace github.com/spf13/pflag => github.com/spf13/pflag v1.0.5
+
+replace github.com/spf13/viper => github.com/spf13/viper v1.4.0
+
+replace github.com/storageos/go-api => github.com/storageos/go-api v0.0.0-20180912212459-343b3eff91fc
+
+replace github.com/stretchr/testify => github.com/stretchr/testify v1.4.0
+
+replace github.com/thecodeteam/goscaleio => github.com/thecodeteam/goscaleio v0.1.0
+
+replace github.com/vishvananda/netlink => github.com/vishvananda/netlink v1.1.0
+
+replace github.com/vmware/govmomi => github.com/vmware/govmomi v0.20.3
+
+replace go.etcd.io/etcd => go.etcd.io/etcd v0.5.0-alpha.5.0.20200819165624-17cef6e3e9d5
+
+replace golang.org/x/crypto => golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9
+
+replace golang.org/x/net => golang.org/x/net v0.0.0-20201110031124-69a78807bb2b
+
+replace golang.org/x/oauth2 => golang.org/x/oauth2 v0.0.0-20191202225959-858c2ad4c8b6
+
+replace golang.org/x/sys => golang.org/x/sys v0.0.0-20201112073958-5cba982894dd
+
+replace golang.org/x/time => golang.org/x/time v0.0.0-20191024005414-555d28b269f0
+
+replace golang.org/x/tools => golang.org/x/tools v0.0.0-20210106214847-113979e3529a
+
+replace gonum.org/v1/gonum => gonum.org/v1/gonum v0.6.2
+
+replace google.golang.org/api => google.golang.org/api v0.15.1
+
+replace google.golang.org/grpc => google.golang.org/grpc v1.27.0
+
+replace gopkg.in/gcfg.v1 => gopkg.in/gcfg.v1 v1.2.0
+
+replace gopkg.in/square/go-jose.v2 => gopkg.in/square/go-jose.v2 v2.2.2
+
+replace gopkg.in/yaml.v2 => gopkg.in/yaml.v2 v2.2.8
+
+replace k8s.io/gengo => k8s.io/gengo v0.0.0-20200428234225-8167cfdcfc14
+
+replace k8s.io/heapster => k8s.io/heapster v1.2.0-beta.1
+
+replace k8s.io/klog/v2 => k8s.io/klog/v2 v2.2.0
+
+replace k8s.io/kube-openapi => k8s.io/kube-openapi v0.0.0-20200805222855-6aeccd4b50c6
+
+replace k8s.io/system-validators => k8s.io/system-validators v1.1.2
+
+replace k8s.io/utils => k8s.io/utils v0.0.0-20200729134348-d5654de09c73
+
+replace sigs.k8s.io/kustomize => sigs.k8s.io/kustomize v2.0.3+incompatible
+
+replace sigs.k8s.io/yaml => sigs.k8s.io/yaml v1.2.0
+
+replace cloud.google.com/go => cloud.google.com/go v0.51.0
+
+replace cloud.google.com/go/bigquery => cloud.google.com/go/bigquery v1.0.1
+
+replace cloud.google.com/go/datastore => cloud.google.com/go/datastore v1.0.0
+
+replace cloud.google.com/go/pubsub => cloud.google.com/go/pubsub v1.0.1
+
+replace cloud.google.com/go/storage => cloud.google.com/go/storage v1.0.0
+
+replace dmitri.shuralyov.com/gpu/mtl => dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9
+
+replace github.com/Azure/go-ansiterm => github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78
+
+replace github.com/Azure/go-autorest/autorest/date => github.com/Azure/go-autorest/autorest/date v0.2.0
+
+replace github.com/Azure/go-autorest/autorest/mocks => github.com/Azure/go-autorest/autorest/mocks v0.3.0
+
+replace github.com/Azure/go-autorest/autorest/validation => github.com/Azure/go-autorest/autorest/validation v0.1.0
+
+replace github.com/Azure/go-autorest/logger => github.com/Azure/go-autorest/logger v0.1.0
+
+replace github.com/Azure/go-autorest/tracing => github.com/Azure/go-autorest/tracing v0.5.0
+
+replace github.com/BurntSushi/toml => github.com/BurntSushi/toml v0.3.1
+
+replace github.com/BurntSushi/xgb => github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802
+
+replace github.com/MakeNowJust/heredoc => github.com/MakeNowJust/heredoc v0.0.0-20170808103936-bb23615498cd
+
+replace github.com/NYTimes/gziphandler => github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46
+
+replace github.com/PuerkitoBio/urlesc => github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578
+
+replace github.com/agnivade/levenshtein => github.com/agnivade/levenshtein v1.0.1
+
+replace github.com/ajstarks/svgo => github.com/ajstarks/svgo v0.0.0-20180226025133-644b8db467af
+
+replace github.com/alecthomas/template => github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751
+
+replace github.com/alecthomas/units => github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4
+
+replace github.com/andreyvit/diff => github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883
+
+replace github.com/armon/consul-api => github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6
+
+replace github.com/asaskevich/govalidator => github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a
+
+replace github.com/beorn7/perks => github.com/beorn7/perks v1.0.1
+
+replace github.com/bgentry/speakeasy => github.com/bgentry/speakeasy v0.1.0
+
+replace github.com/bifurcation/mint => github.com/bifurcation/mint v0.0.0-20180715133206-93c51c6ce115
+
+replace github.com/cenkalti/backoff => github.com/cenkalti/backoff v2.1.1+incompatible
+
+replace github.com/census-instrumentation/opencensus-proto => github.com/census-instrumentation/opencensus-proto v0.2.1
+
+replace github.com/cespare/xxhash/v2 => github.com/cespare/xxhash/v2 v2.1.1
+
+replace github.com/chai2010/gettext-go => github.com/chai2010/gettext-go v0.0.0-20160711120539-c6fed771bfd5
+
+replace github.com/checkpoint-restore/go-criu/v4 => github.com/checkpoint-restore/go-criu/v4 v4.0.2
+
+replace github.com/cheekybits/genny => github.com/cheekybits/genny v0.0.0-20170328200008-9127e812e1e9
+
+replace github.com/chzyer/logex => github.com/chzyer/logex v1.1.10
+
+replace github.com/chzyer/readline => github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e
+
+replace github.com/chzyer/test => github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1
+
+replace github.com/cilium/ebpf => github.com/cilium/ebpf v0.0.0-20200702112145-1c8d4c9ef775
+
+replace github.com/cockroachdb/datadriven => github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa
+
+replace github.com/containerd/cgroups => github.com/containerd/cgroups v0.0.0-20200531161412-0dbf7f05ba59
+
+replace github.com/containerd/console => github.com/containerd/console v1.0.0
+
+replace github.com/containerd/containerd => github.com/containerd/containerd v1.3.3
+
+replace github.com/containerd/continuity => github.com/containerd/continuity v0.0.0-20190426062206-aaeac12a7ffc
+
+replace github.com/containerd/fifo => github.com/containerd/fifo v0.0.0-20190226154929-a9fb20d87448
+
+replace github.com/containerd/go-runc => github.com/containerd/go-runc v0.0.0-20180907222934-5a6d9f37cfa3
+
+replace github.com/containerd/ttrpc => github.com/containerd/ttrpc v1.0.0
+
+replace github.com/containerd/typeurl => github.com/containerd/typeurl v1.0.0
+
+replace github.com/coreos/bbolt => github.com/coreos/bbolt v1.3.2
+
+replace github.com/coreos/etcd => github.com/coreos/etcd v3.3.10+incompatible
+
+replace github.com/coreos/go-semver => github.com/coreos/go-semver v0.3.0
+
+replace github.com/coreos/go-systemd/v22 => github.com/coreos/go-systemd/v22 v22.1.0
+
+replace github.com/creack/pty => github.com/creack/pty v1.1.7
+
+replace github.com/cyphar/filepath-securejoin => github.com/cyphar/filepath-securejoin v0.2.2
+
+replace github.com/daviddengcn/go-colortext => github.com/daviddengcn/go-colortext v0.0.0-20160507010035-511bcaf42ccd
+
+replace github.com/dgrijalva/jwt-go => github.com/dgrijalva/jwt-go v3.2.0+incompatible
+
+replace github.com/dnaeon/go-vcr => github.com/dnaeon/go-vcr v1.0.1
+
+replace github.com/docker/spdystream => github.com/docker/spdystream v0.0.0-20160310174837-449fdfce4d96
+
+replace github.com/docopt/docopt-go => github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815
+
+replace github.com/dustin/go-humanize => github.com/dustin/go-humanize v1.0.0
+
+replace github.com/envoyproxy/go-control-plane => github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473
+
+replace github.com/envoyproxy/protoc-gen-validate => github.com/envoyproxy/protoc-gen-validate v0.1.0
+
+replace github.com/euank/go-kmsg-parser => github.com/euank/go-kmsg-parser v2.0.0+incompatible
+
+replace github.com/exponent-io/jsonpath => github.com/exponent-io/jsonpath v0.0.0-20151013193312-d6023ce2651d
+
+replace github.com/fatih/camelcase => github.com/fatih/camelcase v1.0.0
+
+replace github.com/fatih/color => github.com/fatih/color v1.7.0
+
+replace github.com/flynn/go-shlex => github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568
+
+replace github.com/fogleman/gg => github.com/fogleman/gg v1.2.1-0.20190220221249-0403632d5b90
+
+replace github.com/ghodss/yaml => github.com/ghodss/yaml v1.0.0
+
+replace github.com/go-acme/lego => github.com/go-acme/lego v2.5.0+incompatible
+
+replace github.com/go-gl/glfw/v3.3/glfw => github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72
+
+replace github.com/go-ini/ini => github.com/go-ini/ini v1.9.0
+
+replace github.com/go-kit/kit => github.com/go-kit/kit v0.9.0
+
+replace github.com/go-logfmt/logfmt => github.com/go-logfmt/logfmt v0.4.0
+
+replace github.com/go-logr/logr => github.com/go-logr/logr v0.2.0
+
+replace github.com/go-openapi/errors => github.com/go-openapi/errors v0.19.2
+
+replace github.com/go-openapi/jsonpointer => github.com/go-openapi/jsonpointer v0.19.3
+
+replace github.com/go-openapi/jsonreference => github.com/go-openapi/jsonreference v0.19.3
+
+replace github.com/go-openapi/runtime => github.com/go-openapi/runtime v0.19.4
+
+replace github.com/go-openapi/swag => github.com/go-openapi/swag v0.19.5
+
+replace github.com/go-stack/stack => github.com/go-stack/stack v1.8.0
+
+replace github.com/godbus/dbus/v5 => github.com/godbus/dbus/v5 v5.0.3
+
+replace github.com/golang/freetype => github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0
+
+replace github.com/golang/glog => github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
+
+replace github.com/golang/protobuf => github.com/golang/protobuf v1.4.2
+
+replace github.com/golangplus/bytes => github.com/golangplus/bytes v0.0.0-20160111154220-45c989fe5450
+
+replace github.com/golangplus/fmt => github.com/golangplus/fmt v0.0.0-20150411045040-2a5d6d7d2995
+
+replace github.com/golangplus/testing => github.com/golangplus/testing v0.0.0-20180327235837-af21d9c3145e
+
+replace github.com/google/btree => github.com/google/btree v1.0.0
+
+replace github.com/google/martian => github.com/google/martian v2.1.0+incompatible
+
+replace github.com/google/pprof => github.com/google/pprof v0.0.0-20191218002539-d4f498aebedc
+
+replace github.com/google/renameio => github.com/google/renameio v0.1.0
+
+replace github.com/googleapis/gax-go/v2 => github.com/googleapis/gax-go/v2 v2.0.5
+
+replace github.com/gophercloud/gophercloud => github.com/gophercloud/gophercloud v0.1.0
+
+replace github.com/gopherjs/gopherjs => github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1
+
+replace github.com/gorilla/mux => github.com/gorilla/mux v1.7.3
+
+replace github.com/gorilla/websocket => github.com/gorilla/websocket v1.4.0
+
+replace github.com/gregjones/httpcache => github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7
+
+replace github.com/grpc-ecosystem/go-grpc-middleware => github.com/grpc-ecosystem/go-grpc-middleware v1.0.1-0.20190118093823-f849b5445de4
+
+replace github.com/grpc-ecosystem/go-grpc-prometheus => github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0
+
+replace github.com/grpc-ecosystem/grpc-gateway => github.com/grpc-ecosystem/grpc-gateway v1.9.5
+
+replace github.com/hashicorp/go-syslog => github.com/hashicorp/go-syslog v1.0.0
+
+replace github.com/hashicorp/hcl => github.com/hashicorp/hcl v1.0.0
+
+replace github.com/hpcloud/tail => github.com/hpcloud/tail v1.0.0
+
+replace github.com/ianlancetaylor/demangle => github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6
+
+replace github.com/imdario/mergo => github.com/imdario/mergo v0.3.5
+
+replace github.com/inconshreveable/mousetrap => github.com/inconshreveable/mousetrap v1.0.0
+
+replace github.com/jimstudt/http-authentication => github.com/jimstudt/http-authentication v0.0.0-20140401203705-3eca13d6893a
+
+replace github.com/jmespath/go-jmespath => github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af
+
+replace github.com/jonboulle/clockwork => github.com/jonboulle/clockwork v0.1.0
+
+replace github.com/jstemmer/go-junit-report => github.com/jstemmer/go-junit-report v0.9.1
+
+replace github.com/jtolds/gls => github.com/jtolds/gls v4.20.0+incompatible
+
+replace github.com/julienschmidt/httprouter => github.com/julienschmidt/httprouter v1.2.0
+
+replace github.com/jung-kurt/gofpdf => github.com/jung-kurt/gofpdf v1.0.3-0.20190309125859-24315acbbda5
+
+replace github.com/karrick/godirwalk => github.com/karrick/godirwalk v1.7.5
+
+replace github.com/kisielk/errcheck => github.com/kisielk/errcheck v1.5.0
+
+replace github.com/kisielk/gotool => github.com/kisielk/gotool v1.0.0
+
+replace github.com/klauspost/cpuid => github.com/klauspost/cpuid v1.2.0
+
+replace github.com/konsorten/go-windows-terminal-sequences => github.com/konsorten/go-windows-terminal-sequences v1.0.3
+
+replace github.com/kr/logfmt => github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515
+
+replace github.com/kr/pretty => github.com/kr/pretty v0.2.0
+
+replace github.com/kr/pty => github.com/kr/pty v1.1.5
+
+replace github.com/kr/text => github.com/kr/text v0.1.0
+
+replace github.com/kylelemons/godebug => github.com/kylelemons/godebug v0.0.0-20170820004349-d65d576e9348
+
+replace github.com/liggitt/tabwriter => github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de
+
+replace github.com/lucas-clemente/aes12 => github.com/lucas-clemente/aes12 v0.0.0-20171027163421-cd47fb39b79f
+
+replace github.com/lucas-clemente/quic-clients => github.com/lucas-clemente/quic-clients v0.1.0
+
+replace github.com/lucas-clemente/quic-go => github.com/lucas-clemente/quic-go v0.10.2
+
+replace github.com/lucas-clemente/quic-go-certificates => github.com/lucas-clemente/quic-go-certificates v0.0.0-20160823095156-d2f86524cced
+
+replace github.com/mailru/easyjson => github.com/mailru/easyjson v0.7.0
+
+replace github.com/marten-seemann/qtls => github.com/marten-seemann/qtls v0.2.3
+
+replace github.com/mattn/go-colorable => github.com/mattn/go-colorable v0.0.9
+
+replace github.com/mattn/go-isatty => github.com/mattn/go-isatty v0.0.4
+
+replace github.com/mattn/go-runewidth => github.com/mattn/go-runewidth v0.0.2
+
+replace github.com/matttproud/golang_protobuf_extensions => github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369
+
+replace github.com/mholt/certmagic => github.com/mholt/certmagic v0.6.2-0.20190624175158-6a42ef9fe8c2
+
+replace github.com/mindprince/gonvml => github.com/mindprince/gonvml v0.0.0-20190828220739-9ebdce4bb989
+
+replace github.com/mistifyio/go-zfs => github.com/mistifyio/go-zfs v2.1.2-0.20190413222219-f784269be439+incompatible
+
+replace github.com/mitchellh/go-homedir => github.com/mitchellh/go-homedir v1.1.0
+
+replace github.com/mitchellh/go-wordwrap => github.com/mitchellh/go-wordwrap v1.0.0
+
+replace github.com/mitchellh/mapstructure => github.com/mitchellh/mapstructure v1.1.2
+
+replace github.com/moby/sys/mountinfo => github.com/moby/sys/mountinfo v0.1.3
+
+replace github.com/moby/term => github.com/moby/term v0.0.0-20200312100748-672ec06f55cd
+
+replace github.com/modern-go/concurrent => github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd
+
+replace github.com/modern-go/reflect2 => github.com/modern-go/reflect2 v1.0.1
+
+replace github.com/morikuni/aec => github.com/morikuni/aec v1.0.0
+
+replace github.com/mwitkow/go-conntrack => github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223
+
+replace github.com/mxk/go-flowrate => github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f
+
+replace github.com/naoina/go-stringutil => github.com/naoina/go-stringutil v0.1.0
+
+replace github.com/naoina/toml => github.com/naoina/toml v0.1.1
+
+replace github.com/olekukonko/tablewriter => github.com/olekukonko/tablewriter v0.0.0-20170122224234-a0225b3f23b5
+
+replace github.com/opencontainers/image-spec => github.com/opencontainers/image-spec v1.0.1
+
+replace github.com/opencontainers/runtime-spec => github.com/opencontainers/runtime-spec v1.0.3-0.20200520003142-237cc4f519e2
+
+replace github.com/pelletier/go-toml => github.com/pelletier/go-toml v1.2.0
+
+replace github.com/peterbourgon/diskv => github.com/peterbourgon/diskv v2.0.1+incompatible
+
+replace github.com/pquerna/cachecontrol => github.com/pquerna/cachecontrol v0.0.0-20171018203845-0dec1b30a021
+
+replace github.com/prometheus/procfs => github.com/prometheus/procfs v0.1.3
+
+replace github.com/remyoudompheng/bigfft => github.com/remyoudompheng/bigfft v0.0.0-20170806203942-52369c62f446
+
+replace github.com/rogpeppe/fastuuid => github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af
+
+replace github.com/rogpeppe/go-internal => github.com/rogpeppe/go-internal v1.3.0
+
+replace github.com/rubiojr/go-vhd => github.com/rubiojr/go-vhd v0.0.0-20200706105327-02e210299021
+
+replace github.com/russross/blackfriday => github.com/russross/blackfriday v1.5.2
+
+replace github.com/russross/blackfriday/v2 => github.com/russross/blackfriday/v2 v2.0.1
+
+replace github.com/satori/go.uuid => github.com/satori/go.uuid v1.2.0
+
+replace github.com/seccomp/libseccomp-golang => github.com/seccomp/libseccomp-golang v0.9.1
+
+replace github.com/sergi/go-diff => github.com/sergi/go-diff v1.0.0
+
+replace github.com/shurcooL/sanitized_anchor_name => github.com/shurcooL/sanitized_anchor_name v1.0.0
+
+replace github.com/sirupsen/logrus => github.com/sirupsen/logrus v1.6.0
+
+replace github.com/smartystreets/assertions => github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d
+
+replace github.com/smartystreets/goconvey => github.com/smartystreets/goconvey v1.6.4
+
+replace github.com/soheilhy/cmux => github.com/soheilhy/cmux v0.1.4
+
+replace github.com/spf13/cast => github.com/spf13/cast v1.3.0
+
+replace github.com/stretchr/objx => github.com/stretchr/objx v0.2.0
+
+replace github.com/syndtr/gocapability => github.com/syndtr/gocapability v0.0.0-20180916011248-d98352740cb2
+
+replace github.com/tidwall/pretty => github.com/tidwall/pretty v1.0.0
+
+replace github.com/tmc/grpc-websocket-proxy => github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5
+
+replace github.com/ugorji/go => github.com/ugorji/go v1.1.4
+
+replace github.com/urfave/cli => github.com/urfave/cli v1.22.2
+
+replace github.com/vektah/gqlparser => github.com/vektah/gqlparser v1.1.2
+
+replace github.com/vishvananda/netns => github.com/vishvananda/netns v0.0.0-20200520041808-52d707b772fe
+
+replace github.com/xiang90/probing => github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2
+
+replace github.com/xlab/handysort => github.com/xlab/handysort v0.0.0-20150421192137-fb3537ed64a1
+
+replace github.com/xordataexchange/crypt => github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77
+
+replace github.com/yuin/goldmark => github.com/yuin/goldmark v1.2.1
+
+replace go.etcd.io/bbolt => go.etcd.io/bbolt v1.3.5
+
+replace go.mongodb.org/mongo-driver => go.mongodb.org/mongo-driver v1.1.2
+
+replace go.opencensus.io => go.opencensus.io v0.22.2
+
+replace go.uber.org/atomic => go.uber.org/atomic v1.4.0
+
+replace go.uber.org/multierr => go.uber.org/multierr v1.1.0
+
+replace go.uber.org/zap => go.uber.org/zap v1.10.0
+
+replace golang.org/x/exp => golang.org/x/exp v0.0.0-20191227195350-da58074b4299
+
+replace golang.org/x/image => golang.org/x/image v0.0.0-20190802002840-cff245a6509b
+
+replace golang.org/x/lint => golang.org/x/lint v0.0.0-20191125180803-fdd1cda4f05f
+
+replace golang.org/x/mobile => golang.org/x/mobile v0.0.0-20190719004257-d2bd2a29d028
+
+replace golang.org/x/mod => golang.org/x/mod v0.3.0
+
+replace golang.org/x/sync => golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9
+
+replace golang.org/x/text => golang.org/x/text v0.3.3
+
+replace golang.org/x/xerrors => golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1
+
+replace gonum.org/v1/plot => gonum.org/v1/plot v0.0.0-20190515093506-e2840ee46a6b
+
+replace google.golang.org/appengine => google.golang.org/appengine v1.6.5
+
+replace google.golang.org/genproto => google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013
+
+replace google.golang.org/protobuf => google.golang.org/protobuf v1.24.0
+
+replace gopkg.in/alecthomas/kingpin.v2 => gopkg.in/alecthomas/kingpin.v2 v2.2.6
+
+replace gopkg.in/check.v1 => gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15
+
+replace gopkg.in/cheggaaa/pb.v1 => gopkg.in/cheggaaa/pb.v1 v1.0.25
+
+replace gopkg.in/errgo.v2 => gopkg.in/errgo.v2 v2.1.0
+
+replace gopkg.in/fsnotify.v1 => gopkg.in/fsnotify.v1 v1.4.7
+
+replace gopkg.in/inf.v0 => gopkg.in/inf.v0 v0.9.1
+
+replace gopkg.in/mcuadros/go-syslog.v2 => gopkg.in/mcuadros/go-syslog.v2 v2.2.1
+
+replace gopkg.in/natefinch/lumberjack.v2 => gopkg.in/natefinch/lumberjack.v2 v2.0.0
+
+replace gopkg.in/resty.v1 => gopkg.in/resty.v1 v1.12.0
+
+replace gopkg.in/tomb.v1 => gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7
+
+replace gopkg.in/warnings.v0 => gopkg.in/warnings.v0 v0.1.1
+
+replace gotest.tools => gotest.tools v2.2.0+incompatible
+
+replace gotest.tools/v3 => gotest.tools/v3 v3.0.2
+
+replace honnef.co/go/tools => honnef.co/go/tools v0.0.1-2019.2.3
+
+replace modernc.org/cc => modernc.org/cc v1.0.0
+
+replace modernc.org/golex => modernc.org/golex v1.0.0
+
+replace modernc.org/mathutil => modernc.org/mathutil v1.0.0
+
+replace modernc.org/strutil => modernc.org/strutil v1.0.0
+
+replace modernc.org/xc => modernc.org/xc v1.0.0
+
+replace rsc.io/pdf => rsc.io/pdf v0.1.1
+
+replace sigs.k8s.io/apiserver-network-proxy/konnectivity-client => sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.15
+
+replace sigs.k8s.io/structured-merge-diff/v4 => sigs.k8s.io/structured-merge-diff/v4 v4.1.2
+
+replace vbom.ml/util => vbom.ml/util v0.0.0-20160121211510-db5cfe13f5cc

--- a/staging/src/k8s.io/apimachinery/go.mod
+++ b/staging/src/k8s.io/apimachinery/go.mod
@@ -5,36 +5,789 @@ module k8s.io/apimachinery
 go 1.15
 
 require (
+	bitbucket.org/bertimus9/systemstat v0.0.0-20180207000608-0eeff89b0690
+	github.com/Azure/azure-sdk-for-go v43.0.0+incompatible
+	github.com/Azure/go-autorest/autorest v0.9.6
+	github.com/Azure/go-autorest/autorest/adal v0.8.2
+	github.com/Azure/go-autorest/autorest/to v0.2.0
+	github.com/GoogleCloudPlatform/k8s-cloud-provider v0.0.0-20200415212048-7901bc822317
+	github.com/JeffAshton/win_pdh v0.0.0-20161109143554-76bb4ee9f0ab
+	github.com/Microsoft/go-winio v0.4.15-0.20190919025122-fc70bd9a86b5
+	github.com/Microsoft/hcsshim v0.8.10-0.20200715222032-5eafd1556990
+	github.com/PuerkitoBio/purell v1.1.1
+	github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e
+	github.com/auth0/go-jwt-middleware v0.0.0-20170425171159-5493cabe49f7
+	github.com/aws/aws-sdk-go v1.28.2
+	github.com/blang/semver v3.5.0+incompatible
+	github.com/boltdb/bolt v1.3.1
+	github.com/caddyserver/caddy v1.0.3
+	github.com/clusterhq/flocker-go v0.0.0-20160920122132-2b8b7259d313
+	github.com/codegangsta/negroni v1.0.0
+	github.com/container-storage-interface/spec v1.2.0
+	github.com/containernetworking/cni v0.8.0
+	github.com/coredns/corefile-migration v1.0.10
+	github.com/coreos/go-oidc v2.1.0+incompatible
+	github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e
+	github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f
+	github.com/cpuguy83/go-md2man/v2 v2.0.0
 	github.com/davecgh/go-spew v1.1.1
+	github.com/docker/distribution v2.7.1+incompatible
+	github.com/docker/docker v1.4.2-0.20200309214505-aa6a9891b09c
+	github.com/docker/go-connections v0.4.0
+	github.com/docker/go-units v0.4.0
 	github.com/docker/spdystream v0.0.0-20160310174837-449fdfce4d96
 	github.com/elazarl/goproxy v0.0.0-20180725130230-947c36da3153
+	github.com/emicklei/go-restful v2.9.5+incompatible
 	github.com/evanphx/json-patch v4.9.0+incompatible
 	github.com/fsnotify/fsnotify v1.4.9 // indirect
+	github.com/go-bindata/go-bindata v3.1.1+incompatible
+	github.com/go-openapi/analysis v0.19.5
+	github.com/go-openapi/loads v0.19.4
+	github.com/go-openapi/spec v0.19.3
+	github.com/go-openapi/strfmt v0.19.3
+	github.com/go-openapi/validate v0.19.5
+	github.com/go-ozzo/ozzo-validation v3.5.0+incompatible
 	github.com/gogo/protobuf v1.3.2
 	github.com/golang/groupcache v0.0.0-20191227052852-215e87163ea7
+	github.com/golang/mock v1.3.1
 	github.com/golang/protobuf v1.4.2
+	github.com/google/cadvisor v0.37.5
 	github.com/google/go-cmp v0.4.0
 	github.com/google/gofuzz v1.1.0
 	github.com/google/uuid v1.1.1
 	github.com/googleapis/gnostic v0.4.1
+	github.com/gorilla/context v1.1.1
 	github.com/hashicorp/golang-lru v0.5.1
+	github.com/heketi/heketi v9.0.1-0.20190917153846-c2e2a4ab7ab9+incompatible
+	github.com/heketi/tests v0.0.0-20151005000721-f3775cbcefd6
+	github.com/ishidawataru/sctp v0.0.0-20190723014705-7c296d48a2b5
 	github.com/json-iterator/go v1.1.10
+	github.com/libopenstorage/openstorage v1.0.0
+	github.com/lithammer/dedent v1.1.0
+	github.com/lpabon/godbc v0.1.1
+	github.com/magiconair/properties v1.8.1
+	github.com/miekg/dns v1.1.4
+	github.com/moby/ipvs v1.0.1
 	github.com/modern-go/reflect2 v1.0.1
+	github.com/mohae/deepcopy v0.0.0-20170603005431-491d3605edfb
+	github.com/mrunalp/fileutils v0.0.0-20200520151820-abd8a0e76976
+	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822
+	github.com/mvdan/xurls v1.1.0
 	github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f
 	github.com/onsi/ginkgo v1.11.0 // indirect
 	github.com/onsi/gomega v1.7.0 // indirect
+	github.com/opencontainers/go-digest v1.0.0-rc1
+	github.com/opencontainers/runc v1.0.1
+	github.com/opencontainers/selinux v1.5.2
 	github.com/pkg/errors v0.9.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0
+	github.com/prometheus/client_golang v1.7.1
+	github.com/prometheus/client_model v0.2.0
+	github.com/prometheus/common v0.10.0
+	github.com/quobyte/api v0.1.2
+	github.com/robfig/cron v1.1.0
+	github.com/spf13/afero v1.2.2
+	github.com/spf13/cobra v1.0.0
+	github.com/spf13/jwalterweatherman v1.1.0
 	github.com/spf13/pflag v1.0.5
+	github.com/spf13/viper v1.4.0
+	github.com/storageos/go-api v0.0.0-20180912212459-343b3eff91fc
 	github.com/stretchr/testify v1.4.0
+	github.com/thecodeteam/goscaleio v0.1.0
+	github.com/urfave/negroni v1.0.0
+	github.com/vishvananda/netlink v1.1.0
+	github.com/vmware/govmomi v0.20.3
+	go.etcd.io/etcd v0.5.0-alpha.5.0.20200819165624-17cef6e3e9d5
+	golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9
 	golang.org/x/net v0.0.0-20201110031124-69a78807bb2b
+	golang.org/x/oauth2 v0.0.0-20191202225959-858c2ad4c8b6
 	golang.org/x/sys v0.0.0-20201112073958-5cba982894dd // indirect
+	golang.org/x/time v0.0.0-20191024005414-555d28b269f0
+	golang.org/x/tools v0.0.0-20210106214847-113979e3529a
+	gonum.org/v1/gonum v0.6.2
+	gonum.org/v1/netlib v0.0.0-20190331212654-76723241ea4e
+	google.golang.org/api v0.15.1
+	google.golang.org/grpc v1.27.0
 	google.golang.org/protobuf v1.24.0 // indirect
+	gopkg.in/gcfg.v1 v1.2.0
 	gopkg.in/inf.v0 v0.9.1
+	gopkg.in/square/go-jose.v2 v2.2.2
 	gopkg.in/yaml.v2 v2.2.8
+	k8s.io/gengo v0.0.0-20200428234225-8167cfdcfc14
+	k8s.io/heapster v1.2.0-beta.1
 	k8s.io/klog/v2 v2.2.0
 	k8s.io/kube-openapi v0.0.0-20200805222855-6aeccd4b50c6
+	k8s.io/system-validators v1.1.2
+	k8s.io/utils v0.0.0-20200729134348-d5654de09c73
+	sigs.k8s.io/kustomize v2.0.3+incompatible
 	sigs.k8s.io/structured-merge-diff/v4 v4.1.2
 	sigs.k8s.io/yaml v1.2.0
 )
 
 replace k8s.io/apimachinery => ../apimachinery
+
+replace github.com/auth0/go-jwt-middleware => github.com/auth0/go-jwt-middleware v0.0.0-20170425171159-5493cabe49f7
+
+replace github.com/boltdb/bolt => github.com/boltdb/bolt v1.3.1
+
+replace github.com/codegangsta/negroni => github.com/codegangsta/negroni v1.0.0
+
+replace github.com/go-ozzo/ozzo-validation => github.com/go-ozzo/ozzo-validation v3.5.0+incompatible
+
+replace github.com/gorilla/context => github.com/gorilla/context v1.1.1
+
+replace github.com/heketi/tests => github.com/heketi/tests v0.0.0-20151005000721-f3775cbcefd6
+
+replace github.com/lpabon/godbc => github.com/lpabon/godbc v0.1.1
+
+replace github.com/magiconair/properties => github.com/magiconair/properties v1.8.1
+
+replace github.com/mohae/deepcopy => github.com/mohae/deepcopy v0.0.0-20170603005431-491d3605edfb
+
+replace github.com/spf13/jwalterweatherman => github.com/spf13/jwalterweatherman v1.1.0
+
+replace github.com/urfave/negroni => github.com/urfave/negroni v1.0.0
+
+replace gonum.org/v1/netlib => gonum.org/v1/netlib v0.0.0-20190331212654-76723241ea4e
+
+replace bitbucket.org/bertimus9/systemstat => bitbucket.org/bertimus9/systemstat v0.0.0-20180207000608-0eeff89b0690
+
+replace github.com/Azure/azure-sdk-for-go => github.com/Azure/azure-sdk-for-go v43.0.0+incompatible
+
+replace github.com/Azure/go-autorest/autorest => github.com/Azure/go-autorest/autorest v0.9.6
+
+replace github.com/Azure/go-autorest/autorest/adal => github.com/Azure/go-autorest/autorest/adal v0.8.2
+
+replace github.com/Azure/go-autorest/autorest/to => github.com/Azure/go-autorest/autorest/to v0.2.0
+
+replace github.com/GoogleCloudPlatform/k8s-cloud-provider => github.com/GoogleCloudPlatform/k8s-cloud-provider v0.0.0-20200415212048-7901bc822317
+
+replace github.com/JeffAshton/win_pdh => github.com/JeffAshton/win_pdh v0.0.0-20161109143554-76bb4ee9f0ab
+
+replace github.com/Microsoft/go-winio => github.com/Microsoft/go-winio v0.4.15-0.20190919025122-fc70bd9a86b5
+
+replace github.com/Microsoft/hcsshim => github.com/Microsoft/hcsshim v0.8.10-0.20200715222032-5eafd1556990
+
+replace github.com/PuerkitoBio/purell => github.com/PuerkitoBio/purell v1.1.1
+
+replace github.com/armon/circbuf => github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e
+
+replace github.com/aws/aws-sdk-go => github.com/aws/aws-sdk-go v1.28.2
+
+replace github.com/blang/semver => github.com/blang/semver v3.5.0+incompatible
+
+replace github.com/caddyserver/caddy => github.com/caddyserver/caddy v1.0.3
+
+replace github.com/clusterhq/flocker-go => github.com/clusterhq/flocker-go v0.0.0-20160920122132-2b8b7259d313
+
+replace github.com/container-storage-interface/spec => github.com/container-storage-interface/spec v1.2.0
+
+replace github.com/containernetworking/cni => github.com/containernetworking/cni v0.8.0
+
+replace github.com/coredns/corefile-migration => github.com/coredns/corefile-migration v1.0.10
+
+replace github.com/coreos/go-oidc => github.com/coreos/go-oidc v2.1.0+incompatible
+
+replace github.com/coreos/go-systemd => github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e
+
+replace github.com/coreos/pkg => github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f
+
+replace github.com/cpuguy83/go-md2man/v2 => github.com/cpuguy83/go-md2man/v2 v2.0.0
+
+replace github.com/davecgh/go-spew => github.com/davecgh/go-spew v1.1.1
+
+replace github.com/docker/distribution => github.com/docker/distribution v2.7.1+incompatible
+
+replace github.com/docker/docker => github.com/docker/docker v1.4.2-0.20200309214505-aa6a9891b09c
+
+replace github.com/docker/go-connections => github.com/docker/go-connections v0.4.0
+
+replace github.com/docker/go-units => github.com/docker/go-units v0.4.0
+
+replace github.com/elazarl/goproxy => github.com/elazarl/goproxy v0.0.0-20180725130230-947c36da3153
+
+replace github.com/emicklei/go-restful => github.com/emicklei/go-restful v2.9.5+incompatible
+
+replace github.com/evanphx/json-patch => github.com/evanphx/json-patch v4.9.0+incompatible
+
+replace github.com/fsnotify/fsnotify => github.com/fsnotify/fsnotify v1.4.9
+
+replace github.com/go-bindata/go-bindata => github.com/go-bindata/go-bindata v3.1.1+incompatible
+
+replace github.com/go-openapi/analysis => github.com/go-openapi/analysis v0.19.5
+
+replace github.com/go-openapi/loads => github.com/go-openapi/loads v0.19.4
+
+replace github.com/go-openapi/spec => github.com/go-openapi/spec v0.19.3
+
+replace github.com/go-openapi/strfmt => github.com/go-openapi/strfmt v0.19.3
+
+replace github.com/go-openapi/validate => github.com/go-openapi/validate v0.19.5
+
+replace github.com/gogo/protobuf => github.com/gogo/protobuf v1.3.2
+
+replace github.com/golang/groupcache => github.com/golang/groupcache v0.0.0-20191227052852-215e87163ea7
+
+replace github.com/golang/mock => github.com/golang/mock v1.3.1
+
+replace github.com/google/cadvisor => github.com/google/cadvisor v0.37.5
+
+replace github.com/google/go-cmp => github.com/google/go-cmp v0.4.0
+
+replace github.com/google/gofuzz => github.com/google/gofuzz v1.1.0
+
+replace github.com/google/uuid => github.com/google/uuid v1.1.1
+
+replace github.com/googleapis/gnostic => github.com/googleapis/gnostic v0.4.1
+
+replace github.com/hashicorp/golang-lru => github.com/hashicorp/golang-lru v0.5.1
+
+replace github.com/heketi/heketi => github.com/heketi/heketi v9.0.1-0.20190917153846-c2e2a4ab7ab9+incompatible
+
+replace github.com/ishidawataru/sctp => github.com/ishidawataru/sctp v0.0.0-20190723014705-7c296d48a2b5
+
+replace github.com/json-iterator/go => github.com/json-iterator/go v1.1.10
+
+replace github.com/libopenstorage/openstorage => github.com/libopenstorage/openstorage v1.0.0
+
+replace github.com/lithammer/dedent => github.com/lithammer/dedent v1.1.0
+
+replace github.com/miekg/dns => github.com/miekg/dns v1.1.4
+
+replace github.com/moby/ipvs => github.com/moby/ipvs v1.0.1
+
+replace github.com/mrunalp/fileutils => github.com/mrunalp/fileutils v0.0.0-20200520151820-abd8a0e76976
+
+replace github.com/munnerz/goautoneg => github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822
+
+replace github.com/mvdan/xurls => github.com/mvdan/xurls v1.1.0
+
+replace github.com/onsi/ginkgo => github.com/onsi/ginkgo v1.11.0
+
+replace github.com/onsi/gomega => github.com/onsi/gomega v1.7.0
+
+replace github.com/opencontainers/go-digest => github.com/opencontainers/go-digest v1.0.0-rc1
+
+replace github.com/opencontainers/runc => github.com/opencontainers/runc v1.0.1
+
+replace github.com/opencontainers/selinux => github.com/opencontainers/selinux v1.5.2
+
+replace github.com/pkg/errors => github.com/pkg/errors v0.9.1
+
+replace github.com/pmezard/go-difflib => github.com/pmezard/go-difflib v1.0.0
+
+replace github.com/prometheus/client_golang => github.com/prometheus/client_golang v1.7.1
+
+replace github.com/prometheus/client_model => github.com/prometheus/client_model v0.2.0
+
+replace github.com/prometheus/common => github.com/prometheus/common v0.10.0
+
+replace github.com/quobyte/api => github.com/quobyte/api v0.1.2
+
+replace github.com/robfig/cron => github.com/robfig/cron v1.1.0
+
+replace github.com/spf13/afero => github.com/spf13/afero v1.2.2
+
+replace github.com/spf13/cobra => github.com/spf13/cobra v1.0.0
+
+replace github.com/spf13/pflag => github.com/spf13/pflag v1.0.5
+
+replace github.com/spf13/viper => github.com/spf13/viper v1.4.0
+
+replace github.com/storageos/go-api => github.com/storageos/go-api v0.0.0-20180912212459-343b3eff91fc
+
+replace github.com/stretchr/testify => github.com/stretchr/testify v1.4.0
+
+replace github.com/thecodeteam/goscaleio => github.com/thecodeteam/goscaleio v0.1.0
+
+replace github.com/vishvananda/netlink => github.com/vishvananda/netlink v1.1.0
+
+replace github.com/vmware/govmomi => github.com/vmware/govmomi v0.20.3
+
+replace go.etcd.io/etcd => go.etcd.io/etcd v0.5.0-alpha.5.0.20200819165624-17cef6e3e9d5
+
+replace golang.org/x/crypto => golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9
+
+replace golang.org/x/net => golang.org/x/net v0.0.0-20201110031124-69a78807bb2b
+
+replace golang.org/x/oauth2 => golang.org/x/oauth2 v0.0.0-20191202225959-858c2ad4c8b6
+
+replace golang.org/x/sys => golang.org/x/sys v0.0.0-20201112073958-5cba982894dd
+
+replace golang.org/x/time => golang.org/x/time v0.0.0-20191024005414-555d28b269f0
+
+replace golang.org/x/tools => golang.org/x/tools v0.0.0-20210106214847-113979e3529a
+
+replace gonum.org/v1/gonum => gonum.org/v1/gonum v0.6.2
+
+replace google.golang.org/api => google.golang.org/api v0.15.1
+
+replace google.golang.org/grpc => google.golang.org/grpc v1.27.0
+
+replace gopkg.in/gcfg.v1 => gopkg.in/gcfg.v1 v1.2.0
+
+replace gopkg.in/square/go-jose.v2 => gopkg.in/square/go-jose.v2 v2.2.2
+
+replace gopkg.in/yaml.v2 => gopkg.in/yaml.v2 v2.2.8
+
+replace k8s.io/gengo => k8s.io/gengo v0.0.0-20200428234225-8167cfdcfc14
+
+replace k8s.io/heapster => k8s.io/heapster v1.2.0-beta.1
+
+replace k8s.io/klog/v2 => k8s.io/klog/v2 v2.2.0
+
+replace k8s.io/kube-openapi => k8s.io/kube-openapi v0.0.0-20200805222855-6aeccd4b50c6
+
+replace k8s.io/system-validators => k8s.io/system-validators v1.1.2
+
+replace k8s.io/utils => k8s.io/utils v0.0.0-20200729134348-d5654de09c73
+
+replace sigs.k8s.io/kustomize => sigs.k8s.io/kustomize v2.0.3+incompatible
+
+replace sigs.k8s.io/yaml => sigs.k8s.io/yaml v1.2.0
+
+replace cloud.google.com/go => cloud.google.com/go v0.51.0
+
+replace cloud.google.com/go/bigquery => cloud.google.com/go/bigquery v1.0.1
+
+replace cloud.google.com/go/datastore => cloud.google.com/go/datastore v1.0.0
+
+replace cloud.google.com/go/pubsub => cloud.google.com/go/pubsub v1.0.1
+
+replace cloud.google.com/go/storage => cloud.google.com/go/storage v1.0.0
+
+replace dmitri.shuralyov.com/gpu/mtl => dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9
+
+replace github.com/Azure/go-ansiterm => github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78
+
+replace github.com/Azure/go-autorest/autorest/date => github.com/Azure/go-autorest/autorest/date v0.2.0
+
+replace github.com/Azure/go-autorest/autorest/mocks => github.com/Azure/go-autorest/autorest/mocks v0.3.0
+
+replace github.com/Azure/go-autorest/autorest/validation => github.com/Azure/go-autorest/autorest/validation v0.1.0
+
+replace github.com/Azure/go-autorest/logger => github.com/Azure/go-autorest/logger v0.1.0
+
+replace github.com/Azure/go-autorest/tracing => github.com/Azure/go-autorest/tracing v0.5.0
+
+replace github.com/BurntSushi/toml => github.com/BurntSushi/toml v0.3.1
+
+replace github.com/BurntSushi/xgb => github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802
+
+replace github.com/MakeNowJust/heredoc => github.com/MakeNowJust/heredoc v0.0.0-20170808103936-bb23615498cd
+
+replace github.com/NYTimes/gziphandler => github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46
+
+replace github.com/PuerkitoBio/urlesc => github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578
+
+replace github.com/agnivade/levenshtein => github.com/agnivade/levenshtein v1.0.1
+
+replace github.com/ajstarks/svgo => github.com/ajstarks/svgo v0.0.0-20180226025133-644b8db467af
+
+replace github.com/alecthomas/template => github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751
+
+replace github.com/alecthomas/units => github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4
+
+replace github.com/andreyvit/diff => github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883
+
+replace github.com/armon/consul-api => github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6
+
+replace github.com/asaskevich/govalidator => github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a
+
+replace github.com/beorn7/perks => github.com/beorn7/perks v1.0.1
+
+replace github.com/bgentry/speakeasy => github.com/bgentry/speakeasy v0.1.0
+
+replace github.com/bifurcation/mint => github.com/bifurcation/mint v0.0.0-20180715133206-93c51c6ce115
+
+replace github.com/cenkalti/backoff => github.com/cenkalti/backoff v2.1.1+incompatible
+
+replace github.com/census-instrumentation/opencensus-proto => github.com/census-instrumentation/opencensus-proto v0.2.1
+
+replace github.com/cespare/xxhash/v2 => github.com/cespare/xxhash/v2 v2.1.1
+
+replace github.com/chai2010/gettext-go => github.com/chai2010/gettext-go v0.0.0-20160711120539-c6fed771bfd5
+
+replace github.com/checkpoint-restore/go-criu/v4 => github.com/checkpoint-restore/go-criu/v4 v4.0.2
+
+replace github.com/cheekybits/genny => github.com/cheekybits/genny v0.0.0-20170328200008-9127e812e1e9
+
+replace github.com/chzyer/logex => github.com/chzyer/logex v1.1.10
+
+replace github.com/chzyer/readline => github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e
+
+replace github.com/chzyer/test => github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1
+
+replace github.com/cilium/ebpf => github.com/cilium/ebpf v0.0.0-20200702112145-1c8d4c9ef775
+
+replace github.com/cockroachdb/datadriven => github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa
+
+replace github.com/containerd/cgroups => github.com/containerd/cgroups v0.0.0-20200531161412-0dbf7f05ba59
+
+replace github.com/containerd/console => github.com/containerd/console v1.0.0
+
+replace github.com/containerd/containerd => github.com/containerd/containerd v1.3.3
+
+replace github.com/containerd/continuity => github.com/containerd/continuity v0.0.0-20190426062206-aaeac12a7ffc
+
+replace github.com/containerd/fifo => github.com/containerd/fifo v0.0.0-20190226154929-a9fb20d87448
+
+replace github.com/containerd/go-runc => github.com/containerd/go-runc v0.0.0-20180907222934-5a6d9f37cfa3
+
+replace github.com/containerd/ttrpc => github.com/containerd/ttrpc v1.0.0
+
+replace github.com/containerd/typeurl => github.com/containerd/typeurl v1.0.0
+
+replace github.com/coreos/bbolt => github.com/coreos/bbolt v1.3.2
+
+replace github.com/coreos/etcd => github.com/coreos/etcd v3.3.10+incompatible
+
+replace github.com/coreos/go-semver => github.com/coreos/go-semver v0.3.0
+
+replace github.com/coreos/go-systemd/v22 => github.com/coreos/go-systemd/v22 v22.1.0
+
+replace github.com/creack/pty => github.com/creack/pty v1.1.7
+
+replace github.com/cyphar/filepath-securejoin => github.com/cyphar/filepath-securejoin v0.2.2
+
+replace github.com/daviddengcn/go-colortext => github.com/daviddengcn/go-colortext v0.0.0-20160507010035-511bcaf42ccd
+
+replace github.com/dgrijalva/jwt-go => github.com/dgrijalva/jwt-go v3.2.0+incompatible
+
+replace github.com/dnaeon/go-vcr => github.com/dnaeon/go-vcr v1.0.1
+
+replace github.com/docker/spdystream => github.com/docker/spdystream v0.0.0-20160310174837-449fdfce4d96
+
+replace github.com/docopt/docopt-go => github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815
+
+replace github.com/dustin/go-humanize => github.com/dustin/go-humanize v1.0.0
+
+replace github.com/envoyproxy/go-control-plane => github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473
+
+replace github.com/envoyproxy/protoc-gen-validate => github.com/envoyproxy/protoc-gen-validate v0.1.0
+
+replace github.com/euank/go-kmsg-parser => github.com/euank/go-kmsg-parser v2.0.0+incompatible
+
+replace github.com/exponent-io/jsonpath => github.com/exponent-io/jsonpath v0.0.0-20151013193312-d6023ce2651d
+
+replace github.com/fatih/camelcase => github.com/fatih/camelcase v1.0.0
+
+replace github.com/fatih/color => github.com/fatih/color v1.7.0
+
+replace github.com/flynn/go-shlex => github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568
+
+replace github.com/fogleman/gg => github.com/fogleman/gg v1.2.1-0.20190220221249-0403632d5b90
+
+replace github.com/ghodss/yaml => github.com/ghodss/yaml v1.0.0
+
+replace github.com/go-acme/lego => github.com/go-acme/lego v2.5.0+incompatible
+
+replace github.com/go-gl/glfw/v3.3/glfw => github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72
+
+replace github.com/go-ini/ini => github.com/go-ini/ini v1.9.0
+
+replace github.com/go-kit/kit => github.com/go-kit/kit v0.9.0
+
+replace github.com/go-logfmt/logfmt => github.com/go-logfmt/logfmt v0.4.0
+
+replace github.com/go-logr/logr => github.com/go-logr/logr v0.2.0
+
+replace github.com/go-openapi/errors => github.com/go-openapi/errors v0.19.2
+
+replace github.com/go-openapi/jsonpointer => github.com/go-openapi/jsonpointer v0.19.3
+
+replace github.com/go-openapi/jsonreference => github.com/go-openapi/jsonreference v0.19.3
+
+replace github.com/go-openapi/runtime => github.com/go-openapi/runtime v0.19.4
+
+replace github.com/go-openapi/swag => github.com/go-openapi/swag v0.19.5
+
+replace github.com/go-stack/stack => github.com/go-stack/stack v1.8.0
+
+replace github.com/godbus/dbus/v5 => github.com/godbus/dbus/v5 v5.0.3
+
+replace github.com/golang/freetype => github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0
+
+replace github.com/golang/glog => github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
+
+replace github.com/golang/protobuf => github.com/golang/protobuf v1.4.2
+
+replace github.com/golangplus/bytes => github.com/golangplus/bytes v0.0.0-20160111154220-45c989fe5450
+
+replace github.com/golangplus/fmt => github.com/golangplus/fmt v0.0.0-20150411045040-2a5d6d7d2995
+
+replace github.com/golangplus/testing => github.com/golangplus/testing v0.0.0-20180327235837-af21d9c3145e
+
+replace github.com/google/btree => github.com/google/btree v1.0.0
+
+replace github.com/google/martian => github.com/google/martian v2.1.0+incompatible
+
+replace github.com/google/pprof => github.com/google/pprof v0.0.0-20191218002539-d4f498aebedc
+
+replace github.com/google/renameio => github.com/google/renameio v0.1.0
+
+replace github.com/googleapis/gax-go/v2 => github.com/googleapis/gax-go/v2 v2.0.5
+
+replace github.com/gophercloud/gophercloud => github.com/gophercloud/gophercloud v0.1.0
+
+replace github.com/gopherjs/gopherjs => github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1
+
+replace github.com/gorilla/mux => github.com/gorilla/mux v1.7.3
+
+replace github.com/gorilla/websocket => github.com/gorilla/websocket v1.4.0
+
+replace github.com/gregjones/httpcache => github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7
+
+replace github.com/grpc-ecosystem/go-grpc-middleware => github.com/grpc-ecosystem/go-grpc-middleware v1.0.1-0.20190118093823-f849b5445de4
+
+replace github.com/grpc-ecosystem/go-grpc-prometheus => github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0
+
+replace github.com/grpc-ecosystem/grpc-gateway => github.com/grpc-ecosystem/grpc-gateway v1.9.5
+
+replace github.com/hashicorp/go-syslog => github.com/hashicorp/go-syslog v1.0.0
+
+replace github.com/hashicorp/hcl => github.com/hashicorp/hcl v1.0.0
+
+replace github.com/hpcloud/tail => github.com/hpcloud/tail v1.0.0
+
+replace github.com/ianlancetaylor/demangle => github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6
+
+replace github.com/imdario/mergo => github.com/imdario/mergo v0.3.5
+
+replace github.com/inconshreveable/mousetrap => github.com/inconshreveable/mousetrap v1.0.0
+
+replace github.com/jimstudt/http-authentication => github.com/jimstudt/http-authentication v0.0.0-20140401203705-3eca13d6893a
+
+replace github.com/jmespath/go-jmespath => github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af
+
+replace github.com/jonboulle/clockwork => github.com/jonboulle/clockwork v0.1.0
+
+replace github.com/jstemmer/go-junit-report => github.com/jstemmer/go-junit-report v0.9.1
+
+replace github.com/jtolds/gls => github.com/jtolds/gls v4.20.0+incompatible
+
+replace github.com/julienschmidt/httprouter => github.com/julienschmidt/httprouter v1.2.0
+
+replace github.com/jung-kurt/gofpdf => github.com/jung-kurt/gofpdf v1.0.3-0.20190309125859-24315acbbda5
+
+replace github.com/karrick/godirwalk => github.com/karrick/godirwalk v1.7.5
+
+replace github.com/kisielk/errcheck => github.com/kisielk/errcheck v1.5.0
+
+replace github.com/kisielk/gotool => github.com/kisielk/gotool v1.0.0
+
+replace github.com/klauspost/cpuid => github.com/klauspost/cpuid v1.2.0
+
+replace github.com/konsorten/go-windows-terminal-sequences => github.com/konsorten/go-windows-terminal-sequences v1.0.3
+
+replace github.com/kr/logfmt => github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515
+
+replace github.com/kr/pretty => github.com/kr/pretty v0.2.0
+
+replace github.com/kr/pty => github.com/kr/pty v1.1.5
+
+replace github.com/kr/text => github.com/kr/text v0.1.0
+
+replace github.com/kylelemons/godebug => github.com/kylelemons/godebug v0.0.0-20170820004349-d65d576e9348
+
+replace github.com/liggitt/tabwriter => github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de
+
+replace github.com/lucas-clemente/aes12 => github.com/lucas-clemente/aes12 v0.0.0-20171027163421-cd47fb39b79f
+
+replace github.com/lucas-clemente/quic-clients => github.com/lucas-clemente/quic-clients v0.1.0
+
+replace github.com/lucas-clemente/quic-go => github.com/lucas-clemente/quic-go v0.10.2
+
+replace github.com/lucas-clemente/quic-go-certificates => github.com/lucas-clemente/quic-go-certificates v0.0.0-20160823095156-d2f86524cced
+
+replace github.com/mailru/easyjson => github.com/mailru/easyjson v0.7.0
+
+replace github.com/marten-seemann/qtls => github.com/marten-seemann/qtls v0.2.3
+
+replace github.com/mattn/go-colorable => github.com/mattn/go-colorable v0.0.9
+
+replace github.com/mattn/go-isatty => github.com/mattn/go-isatty v0.0.4
+
+replace github.com/mattn/go-runewidth => github.com/mattn/go-runewidth v0.0.2
+
+replace github.com/matttproud/golang_protobuf_extensions => github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369
+
+replace github.com/mholt/certmagic => github.com/mholt/certmagic v0.6.2-0.20190624175158-6a42ef9fe8c2
+
+replace github.com/mindprince/gonvml => github.com/mindprince/gonvml v0.0.0-20190828220739-9ebdce4bb989
+
+replace github.com/mistifyio/go-zfs => github.com/mistifyio/go-zfs v2.1.2-0.20190413222219-f784269be439+incompatible
+
+replace github.com/mitchellh/go-homedir => github.com/mitchellh/go-homedir v1.1.0
+
+replace github.com/mitchellh/go-wordwrap => github.com/mitchellh/go-wordwrap v1.0.0
+
+replace github.com/mitchellh/mapstructure => github.com/mitchellh/mapstructure v1.1.2
+
+replace github.com/moby/sys/mountinfo => github.com/moby/sys/mountinfo v0.1.3
+
+replace github.com/moby/term => github.com/moby/term v0.0.0-20200312100748-672ec06f55cd
+
+replace github.com/modern-go/concurrent => github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd
+
+replace github.com/modern-go/reflect2 => github.com/modern-go/reflect2 v1.0.1
+
+replace github.com/morikuni/aec => github.com/morikuni/aec v1.0.0
+
+replace github.com/mwitkow/go-conntrack => github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223
+
+replace github.com/mxk/go-flowrate => github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f
+
+replace github.com/naoina/go-stringutil => github.com/naoina/go-stringutil v0.1.0
+
+replace github.com/naoina/toml => github.com/naoina/toml v0.1.1
+
+replace github.com/olekukonko/tablewriter => github.com/olekukonko/tablewriter v0.0.0-20170122224234-a0225b3f23b5
+
+replace github.com/opencontainers/image-spec => github.com/opencontainers/image-spec v1.0.1
+
+replace github.com/opencontainers/runtime-spec => github.com/opencontainers/runtime-spec v1.0.3-0.20200520003142-237cc4f519e2
+
+replace github.com/pelletier/go-toml => github.com/pelletier/go-toml v1.2.0
+
+replace github.com/peterbourgon/diskv => github.com/peterbourgon/diskv v2.0.1+incompatible
+
+replace github.com/pquerna/cachecontrol => github.com/pquerna/cachecontrol v0.0.0-20171018203845-0dec1b30a021
+
+replace github.com/prometheus/procfs => github.com/prometheus/procfs v0.1.3
+
+replace github.com/remyoudompheng/bigfft => github.com/remyoudompheng/bigfft v0.0.0-20170806203942-52369c62f446
+
+replace github.com/rogpeppe/fastuuid => github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af
+
+replace github.com/rogpeppe/go-internal => github.com/rogpeppe/go-internal v1.3.0
+
+replace github.com/rubiojr/go-vhd => github.com/rubiojr/go-vhd v0.0.0-20200706105327-02e210299021
+
+replace github.com/russross/blackfriday => github.com/russross/blackfriday v1.5.2
+
+replace github.com/russross/blackfriday/v2 => github.com/russross/blackfriday/v2 v2.0.1
+
+replace github.com/satori/go.uuid => github.com/satori/go.uuid v1.2.0
+
+replace github.com/seccomp/libseccomp-golang => github.com/seccomp/libseccomp-golang v0.9.1
+
+replace github.com/sergi/go-diff => github.com/sergi/go-diff v1.0.0
+
+replace github.com/shurcooL/sanitized_anchor_name => github.com/shurcooL/sanitized_anchor_name v1.0.0
+
+replace github.com/sirupsen/logrus => github.com/sirupsen/logrus v1.6.0
+
+replace github.com/smartystreets/assertions => github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d
+
+replace github.com/smartystreets/goconvey => github.com/smartystreets/goconvey v1.6.4
+
+replace github.com/soheilhy/cmux => github.com/soheilhy/cmux v0.1.4
+
+replace github.com/spf13/cast => github.com/spf13/cast v1.3.0
+
+replace github.com/stretchr/objx => github.com/stretchr/objx v0.2.0
+
+replace github.com/syndtr/gocapability => github.com/syndtr/gocapability v0.0.0-20180916011248-d98352740cb2
+
+replace github.com/tidwall/pretty => github.com/tidwall/pretty v1.0.0
+
+replace github.com/tmc/grpc-websocket-proxy => github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5
+
+replace github.com/ugorji/go => github.com/ugorji/go v1.1.4
+
+replace github.com/urfave/cli => github.com/urfave/cli v1.22.2
+
+replace github.com/vektah/gqlparser => github.com/vektah/gqlparser v1.1.2
+
+replace github.com/vishvananda/netns => github.com/vishvananda/netns v0.0.0-20200520041808-52d707b772fe
+
+replace github.com/xiang90/probing => github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2
+
+replace github.com/xlab/handysort => github.com/xlab/handysort v0.0.0-20150421192137-fb3537ed64a1
+
+replace github.com/xordataexchange/crypt => github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77
+
+replace github.com/yuin/goldmark => github.com/yuin/goldmark v1.2.1
+
+replace go.etcd.io/bbolt => go.etcd.io/bbolt v1.3.5
+
+replace go.mongodb.org/mongo-driver => go.mongodb.org/mongo-driver v1.1.2
+
+replace go.opencensus.io => go.opencensus.io v0.22.2
+
+replace go.uber.org/atomic => go.uber.org/atomic v1.4.0
+
+replace go.uber.org/multierr => go.uber.org/multierr v1.1.0
+
+replace go.uber.org/zap => go.uber.org/zap v1.10.0
+
+replace golang.org/x/exp => golang.org/x/exp v0.0.0-20191227195350-da58074b4299
+
+replace golang.org/x/image => golang.org/x/image v0.0.0-20190802002840-cff245a6509b
+
+replace golang.org/x/lint => golang.org/x/lint v0.0.0-20191125180803-fdd1cda4f05f
+
+replace golang.org/x/mobile => golang.org/x/mobile v0.0.0-20190719004257-d2bd2a29d028
+
+replace golang.org/x/mod => golang.org/x/mod v0.3.0
+
+replace golang.org/x/sync => golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9
+
+replace golang.org/x/text => golang.org/x/text v0.3.3
+
+replace golang.org/x/xerrors => golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1
+
+replace gonum.org/v1/plot => gonum.org/v1/plot v0.0.0-20190515093506-e2840ee46a6b
+
+replace google.golang.org/appengine => google.golang.org/appengine v1.6.5
+
+replace google.golang.org/genproto => google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013
+
+replace google.golang.org/protobuf => google.golang.org/protobuf v1.24.0
+
+replace gopkg.in/alecthomas/kingpin.v2 => gopkg.in/alecthomas/kingpin.v2 v2.2.6
+
+replace gopkg.in/check.v1 => gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15
+
+replace gopkg.in/cheggaaa/pb.v1 => gopkg.in/cheggaaa/pb.v1 v1.0.25
+
+replace gopkg.in/errgo.v2 => gopkg.in/errgo.v2 v2.1.0
+
+replace gopkg.in/fsnotify.v1 => gopkg.in/fsnotify.v1 v1.4.7
+
+replace gopkg.in/inf.v0 => gopkg.in/inf.v0 v0.9.1
+
+replace gopkg.in/mcuadros/go-syslog.v2 => gopkg.in/mcuadros/go-syslog.v2 v2.2.1
+
+replace gopkg.in/natefinch/lumberjack.v2 => gopkg.in/natefinch/lumberjack.v2 v2.0.0
+
+replace gopkg.in/resty.v1 => gopkg.in/resty.v1 v1.12.0
+
+replace gopkg.in/tomb.v1 => gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7
+
+replace gopkg.in/warnings.v0 => gopkg.in/warnings.v0 v0.1.1
+
+replace gotest.tools => gotest.tools v2.2.0+incompatible
+
+replace gotest.tools/v3 => gotest.tools/v3 v3.0.2
+
+replace honnef.co/go/tools => honnef.co/go/tools v0.0.1-2019.2.3
+
+replace modernc.org/cc => modernc.org/cc v1.0.0
+
+replace modernc.org/golex => modernc.org/golex v1.0.0
+
+replace modernc.org/mathutil => modernc.org/mathutil v1.0.0
+
+replace modernc.org/strutil => modernc.org/strutil v1.0.0
+
+replace modernc.org/xc => modernc.org/xc v1.0.0
+
+replace rsc.io/pdf => rsc.io/pdf v0.1.1
+
+replace sigs.k8s.io/apiserver-network-proxy/konnectivity-client => sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.15
+
+replace sigs.k8s.io/structured-merge-diff/v4 => sigs.k8s.io/structured-merge-diff/v4 v4.1.2
+
+replace vbom.ml/util => vbom.ml/util v0.0.0-20160121211510-db5cfe13f5cc

--- a/staging/src/k8s.io/apiserver/go.mod
+++ b/staging/src/k8s.io/apiserver/go.mod
@@ -5,39 +5,117 @@ module k8s.io/apiserver
 go 1.15
 
 require (
+	bitbucket.org/bertimus9/systemstat v0.0.0-20180207000608-0eeff89b0690
+	github.com/Azure/azure-sdk-for-go v43.0.0+incompatible
+	github.com/Azure/go-autorest/autorest v0.9.6
+	github.com/Azure/go-autorest/autorest/adal v0.8.2
+	github.com/Azure/go-autorest/autorest/to v0.2.0
+	github.com/GoogleCloudPlatform/k8s-cloud-provider v0.0.0-20200415212048-7901bc822317
+	github.com/JeffAshton/win_pdh v0.0.0-20161109143554-76bb4ee9f0ab
+	github.com/Microsoft/go-winio v0.4.15-0.20190919025122-fc70bd9a86b5
+	github.com/Microsoft/hcsshim v0.8.10-0.20200715222032-5eafd1556990
+	github.com/PuerkitoBio/purell v1.1.1
+	github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e
+	github.com/auth0/go-jwt-middleware v0.0.0-20170425171159-5493cabe49f7
+	github.com/aws/aws-sdk-go v1.28.2
+	github.com/blang/semver v3.5.0+incompatible
+	github.com/boltdb/bolt v1.3.1
+	github.com/caddyserver/caddy v1.0.3
+	github.com/clusterhq/flocker-go v0.0.0-20160920122132-2b8b7259d313
+	github.com/codegangsta/negroni v1.0.0
+	github.com/container-storage-interface/spec v1.2.0
+	github.com/containernetworking/cni v0.8.0
+	github.com/coredns/corefile-migration v1.0.10
 	github.com/coreos/go-oidc v2.1.0+incompatible
 	github.com/coreos/go-semver v0.3.0 // indirect
 	github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e
 	github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f
+	github.com/cpuguy83/go-md2man/v2 v2.0.0
 	github.com/davecgh/go-spew v1.1.1
+	github.com/docker/distribution v2.7.1+incompatible
+	github.com/docker/docker v1.4.2-0.20200309214505-aa6a9891b09c
+	github.com/docker/go-connections v0.4.0
+	github.com/docker/go-units v0.4.0
 	github.com/dustin/go-humanize v1.0.0 // indirect
+	github.com/elazarl/goproxy v0.0.0-20180725130230-947c36da3153
 	github.com/emicklei/go-restful v2.9.5+incompatible
 	github.com/evanphx/json-patch v4.9.0+incompatible
+	github.com/fsnotify/fsnotify v1.4.9
+	github.com/go-bindata/go-bindata v3.1.1+incompatible
+	github.com/go-openapi/analysis v0.19.5
 	github.com/go-openapi/jsonreference v0.19.3 // indirect
+	github.com/go-openapi/loads v0.19.4
 	github.com/go-openapi/spec v0.19.3
+	github.com/go-openapi/strfmt v0.19.3
+	github.com/go-openapi/validate v0.19.5
+	github.com/go-ozzo/ozzo-validation v3.5.0+incompatible
 	github.com/gogo/protobuf v1.3.2
+	github.com/golang/groupcache v0.0.0-20191227052852-215e87163ea7
+	github.com/golang/mock v1.3.1
+	github.com/google/cadvisor v0.37.5
 	github.com/google/go-cmp v0.4.0
 	github.com/google/gofuzz v1.1.0
 	github.com/google/uuid v1.1.1
 	github.com/googleapis/gnostic v0.4.1
+	github.com/gorilla/context v1.1.1
 	github.com/gorilla/websocket v1.4.0 // indirect
 	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0
 	github.com/hashicorp/golang-lru v0.5.1
+	github.com/heketi/heketi v9.0.1-0.20190917153846-c2e2a4ab7ab9+incompatible
+	github.com/heketi/tests v0.0.0-20151005000721-f3775cbcefd6
+	github.com/ishidawataru/sctp v0.0.0-20190723014705-7c296d48a2b5
+	github.com/json-iterator/go v1.1.10
+	github.com/libopenstorage/openstorage v1.0.0
+	github.com/lithammer/dedent v1.1.0
+	github.com/lpabon/godbc v0.1.1
+	github.com/magiconair/properties v1.8.1
 	github.com/mailru/easyjson v0.7.0 // indirect
+	github.com/miekg/dns v1.1.4
+	github.com/moby/ipvs v1.0.1
+	github.com/mohae/deepcopy v0.0.0-20170603005431-491d3605edfb
+	github.com/mrunalp/fileutils v0.0.0-20200520151820-abd8a0e76976
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822
+	github.com/mvdan/xurls v1.1.0
+	github.com/onsi/ginkgo v1.11.0
+	github.com/onsi/gomega v1.7.0
+	github.com/opencontainers/go-digest v1.0.0-rc1
+	github.com/opencontainers/runc v1.0.1
+	github.com/opencontainers/selinux v1.5.2
 	github.com/pkg/errors v0.9.1
+	github.com/pmezard/go-difflib v1.0.0
 	github.com/pquerna/cachecontrol v0.0.0-20171018203845-0dec1b30a021 // indirect
+	github.com/prometheus/client_golang v1.7.1
+	github.com/prometheus/client_model v0.2.0
+	github.com/prometheus/common v0.10.0
+	github.com/quobyte/api v0.1.2
+	github.com/robfig/cron v1.1.0
+	github.com/spf13/afero v1.2.2
+	github.com/spf13/cobra v1.0.0
+	github.com/spf13/jwalterweatherman v1.1.0
 	github.com/spf13/pflag v1.0.5
+	github.com/spf13/viper v1.4.0
+	github.com/storageos/go-api v0.0.0-20180912212459-343b3eff91fc
 	github.com/stretchr/testify v1.4.0
+	github.com/thecodeteam/goscaleio v0.1.0
 	github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5 // indirect
+	github.com/urfave/negroni v1.0.0
+	github.com/vishvananda/netlink v1.1.0
+	github.com/vmware/govmomi v0.20.3
 	go.etcd.io/bbolt v1.3.5 // indirect
 	go.etcd.io/etcd v0.5.0-alpha.5.0.20200819165624-17cef6e3e9d5
 	go.uber.org/zap v1.10.0
 	golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9
 	golang.org/x/net v0.0.0-20201110031124-69a78807bb2b
+	golang.org/x/oauth2 v0.0.0-20191202225959-858c2ad4c8b6
 	golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9
 	golang.org/x/sys v0.0.0-20201112073958-5cba982894dd
+	golang.org/x/time v0.0.0-20191024005414-555d28b269f0
+	golang.org/x/tools v0.0.0-20210106214847-113979e3529a
+	gonum.org/v1/gonum v0.6.2
+	gonum.org/v1/netlib v0.0.0-20190331212654-76723241ea4e
+	google.golang.org/api v0.15.1
 	google.golang.org/grpc v1.27.0
+	gopkg.in/gcfg.v1 v1.2.0
 	gopkg.in/natefinch/lumberjack.v2 v2.0.0
 	gopkg.in/square/go-jose.v2 v2.2.2
 	gopkg.in/yaml.v2 v2.2.8
@@ -45,10 +123,14 @@ require (
 	k8s.io/apimachinery v0.0.0
 	k8s.io/client-go v0.0.0
 	k8s.io/component-base v0.0.0
+	k8s.io/gengo v0.0.0-20200428234225-8167cfdcfc14
+	k8s.io/heapster v1.2.0-beta.1
 	k8s.io/klog/v2 v2.2.0
 	k8s.io/kube-openapi v0.0.0-20200805222855-6aeccd4b50c6
+	k8s.io/system-validators v1.1.2
 	k8s.io/utils v0.0.0-20200729134348-d5654de09c73
 	sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.15
+	sigs.k8s.io/kustomize v2.0.3+incompatible
 	sigs.k8s.io/structured-merge-diff/v4 v4.1.2
 	sigs.k8s.io/yaml v1.2.0
 )
@@ -60,3 +142,669 @@ replace (
 	k8s.io/client-go => ../client-go
 	k8s.io/component-base => ../component-base
 )
+
+replace github.com/auth0/go-jwt-middleware => github.com/auth0/go-jwt-middleware v0.0.0-20170425171159-5493cabe49f7
+
+replace github.com/boltdb/bolt => github.com/boltdb/bolt v1.3.1
+
+replace github.com/codegangsta/negroni => github.com/codegangsta/negroni v1.0.0
+
+replace github.com/go-ozzo/ozzo-validation => github.com/go-ozzo/ozzo-validation v3.5.0+incompatible
+
+replace github.com/gorilla/context => github.com/gorilla/context v1.1.1
+
+replace github.com/heketi/tests => github.com/heketi/tests v0.0.0-20151005000721-f3775cbcefd6
+
+replace github.com/lpabon/godbc => github.com/lpabon/godbc v0.1.1
+
+replace github.com/magiconair/properties => github.com/magiconair/properties v1.8.1
+
+replace github.com/mohae/deepcopy => github.com/mohae/deepcopy v0.0.0-20170603005431-491d3605edfb
+
+replace github.com/spf13/jwalterweatherman => github.com/spf13/jwalterweatherman v1.1.0
+
+replace github.com/urfave/negroni => github.com/urfave/negroni v1.0.0
+
+replace gonum.org/v1/netlib => gonum.org/v1/netlib v0.0.0-20190331212654-76723241ea4e
+
+replace bitbucket.org/bertimus9/systemstat => bitbucket.org/bertimus9/systemstat v0.0.0-20180207000608-0eeff89b0690
+
+replace github.com/Azure/azure-sdk-for-go => github.com/Azure/azure-sdk-for-go v43.0.0+incompatible
+
+replace github.com/Azure/go-autorest/autorest => github.com/Azure/go-autorest/autorest v0.9.6
+
+replace github.com/Azure/go-autorest/autorest/adal => github.com/Azure/go-autorest/autorest/adal v0.8.2
+
+replace github.com/Azure/go-autorest/autorest/to => github.com/Azure/go-autorest/autorest/to v0.2.0
+
+replace github.com/GoogleCloudPlatform/k8s-cloud-provider => github.com/GoogleCloudPlatform/k8s-cloud-provider v0.0.0-20200415212048-7901bc822317
+
+replace github.com/JeffAshton/win_pdh => github.com/JeffAshton/win_pdh v0.0.0-20161109143554-76bb4ee9f0ab
+
+replace github.com/Microsoft/go-winio => github.com/Microsoft/go-winio v0.4.15-0.20190919025122-fc70bd9a86b5
+
+replace github.com/Microsoft/hcsshim => github.com/Microsoft/hcsshim v0.8.10-0.20200715222032-5eafd1556990
+
+replace github.com/PuerkitoBio/purell => github.com/PuerkitoBio/purell v1.1.1
+
+replace github.com/armon/circbuf => github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e
+
+replace github.com/aws/aws-sdk-go => github.com/aws/aws-sdk-go v1.28.2
+
+replace github.com/blang/semver => github.com/blang/semver v3.5.0+incompatible
+
+replace github.com/caddyserver/caddy => github.com/caddyserver/caddy v1.0.3
+
+replace github.com/clusterhq/flocker-go => github.com/clusterhq/flocker-go v0.0.0-20160920122132-2b8b7259d313
+
+replace github.com/container-storage-interface/spec => github.com/container-storage-interface/spec v1.2.0
+
+replace github.com/containernetworking/cni => github.com/containernetworking/cni v0.8.0
+
+replace github.com/coredns/corefile-migration => github.com/coredns/corefile-migration v1.0.10
+
+replace github.com/coreos/go-oidc => github.com/coreos/go-oidc v2.1.0+incompatible
+
+replace github.com/coreos/go-systemd => github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e
+
+replace github.com/coreos/pkg => github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f
+
+replace github.com/cpuguy83/go-md2man/v2 => github.com/cpuguy83/go-md2man/v2 v2.0.0
+
+replace github.com/davecgh/go-spew => github.com/davecgh/go-spew v1.1.1
+
+replace github.com/docker/distribution => github.com/docker/distribution v2.7.1+incompatible
+
+replace github.com/docker/docker => github.com/docker/docker v1.4.2-0.20200309214505-aa6a9891b09c
+
+replace github.com/docker/go-connections => github.com/docker/go-connections v0.4.0
+
+replace github.com/docker/go-units => github.com/docker/go-units v0.4.0
+
+replace github.com/elazarl/goproxy => github.com/elazarl/goproxy v0.0.0-20180725130230-947c36da3153
+
+replace github.com/emicklei/go-restful => github.com/emicklei/go-restful v2.9.5+incompatible
+
+replace github.com/evanphx/json-patch => github.com/evanphx/json-patch v4.9.0+incompatible
+
+replace github.com/fsnotify/fsnotify => github.com/fsnotify/fsnotify v1.4.9
+
+replace github.com/go-bindata/go-bindata => github.com/go-bindata/go-bindata v3.1.1+incompatible
+
+replace github.com/go-openapi/analysis => github.com/go-openapi/analysis v0.19.5
+
+replace github.com/go-openapi/loads => github.com/go-openapi/loads v0.19.4
+
+replace github.com/go-openapi/spec => github.com/go-openapi/spec v0.19.3
+
+replace github.com/go-openapi/strfmt => github.com/go-openapi/strfmt v0.19.3
+
+replace github.com/go-openapi/validate => github.com/go-openapi/validate v0.19.5
+
+replace github.com/gogo/protobuf => github.com/gogo/protobuf v1.3.2
+
+replace github.com/golang/groupcache => github.com/golang/groupcache v0.0.0-20191227052852-215e87163ea7
+
+replace github.com/golang/mock => github.com/golang/mock v1.3.1
+
+replace github.com/google/cadvisor => github.com/google/cadvisor v0.37.5
+
+replace github.com/google/go-cmp => github.com/google/go-cmp v0.4.0
+
+replace github.com/google/gofuzz => github.com/google/gofuzz v1.1.0
+
+replace github.com/google/uuid => github.com/google/uuid v1.1.1
+
+replace github.com/googleapis/gnostic => github.com/googleapis/gnostic v0.4.1
+
+replace github.com/hashicorp/golang-lru => github.com/hashicorp/golang-lru v0.5.1
+
+replace github.com/heketi/heketi => github.com/heketi/heketi v9.0.1-0.20190917153846-c2e2a4ab7ab9+incompatible
+
+replace github.com/ishidawataru/sctp => github.com/ishidawataru/sctp v0.0.0-20190723014705-7c296d48a2b5
+
+replace github.com/json-iterator/go => github.com/json-iterator/go v1.1.10
+
+replace github.com/libopenstorage/openstorage => github.com/libopenstorage/openstorage v1.0.0
+
+replace github.com/lithammer/dedent => github.com/lithammer/dedent v1.1.0
+
+replace github.com/miekg/dns => github.com/miekg/dns v1.1.4
+
+replace github.com/moby/ipvs => github.com/moby/ipvs v1.0.1
+
+replace github.com/mrunalp/fileutils => github.com/mrunalp/fileutils v0.0.0-20200520151820-abd8a0e76976
+
+replace github.com/munnerz/goautoneg => github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822
+
+replace github.com/mvdan/xurls => github.com/mvdan/xurls v1.1.0
+
+replace github.com/onsi/ginkgo => github.com/onsi/ginkgo v1.11.0
+
+replace github.com/onsi/gomega => github.com/onsi/gomega v1.7.0
+
+replace github.com/opencontainers/go-digest => github.com/opencontainers/go-digest v1.0.0-rc1
+
+replace github.com/opencontainers/runc => github.com/opencontainers/runc v1.0.1
+
+replace github.com/opencontainers/selinux => github.com/opencontainers/selinux v1.5.2
+
+replace github.com/pkg/errors => github.com/pkg/errors v0.9.1
+
+replace github.com/pmezard/go-difflib => github.com/pmezard/go-difflib v1.0.0
+
+replace github.com/prometheus/client_golang => github.com/prometheus/client_golang v1.7.1
+
+replace github.com/prometheus/client_model => github.com/prometheus/client_model v0.2.0
+
+replace github.com/prometheus/common => github.com/prometheus/common v0.10.0
+
+replace github.com/quobyte/api => github.com/quobyte/api v0.1.2
+
+replace github.com/robfig/cron => github.com/robfig/cron v1.1.0
+
+replace github.com/spf13/afero => github.com/spf13/afero v1.2.2
+
+replace github.com/spf13/cobra => github.com/spf13/cobra v1.0.0
+
+replace github.com/spf13/pflag => github.com/spf13/pflag v1.0.5
+
+replace github.com/spf13/viper => github.com/spf13/viper v1.4.0
+
+replace github.com/storageos/go-api => github.com/storageos/go-api v0.0.0-20180912212459-343b3eff91fc
+
+replace github.com/stretchr/testify => github.com/stretchr/testify v1.4.0
+
+replace github.com/thecodeteam/goscaleio => github.com/thecodeteam/goscaleio v0.1.0
+
+replace github.com/vishvananda/netlink => github.com/vishvananda/netlink v1.1.0
+
+replace github.com/vmware/govmomi => github.com/vmware/govmomi v0.20.3
+
+replace go.etcd.io/etcd => go.etcd.io/etcd v0.5.0-alpha.5.0.20200819165624-17cef6e3e9d5
+
+replace golang.org/x/crypto => golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9
+
+replace golang.org/x/net => golang.org/x/net v0.0.0-20201110031124-69a78807bb2b
+
+replace golang.org/x/oauth2 => golang.org/x/oauth2 v0.0.0-20191202225959-858c2ad4c8b6
+
+replace golang.org/x/sys => golang.org/x/sys v0.0.0-20201112073958-5cba982894dd
+
+replace golang.org/x/time => golang.org/x/time v0.0.0-20191024005414-555d28b269f0
+
+replace golang.org/x/tools => golang.org/x/tools v0.0.0-20210106214847-113979e3529a
+
+replace gonum.org/v1/gonum => gonum.org/v1/gonum v0.6.2
+
+replace google.golang.org/api => google.golang.org/api v0.15.1
+
+replace google.golang.org/grpc => google.golang.org/grpc v1.27.0
+
+replace gopkg.in/gcfg.v1 => gopkg.in/gcfg.v1 v1.2.0
+
+replace gopkg.in/square/go-jose.v2 => gopkg.in/square/go-jose.v2 v2.2.2
+
+replace gopkg.in/yaml.v2 => gopkg.in/yaml.v2 v2.2.8
+
+replace k8s.io/gengo => k8s.io/gengo v0.0.0-20200428234225-8167cfdcfc14
+
+replace k8s.io/heapster => k8s.io/heapster v1.2.0-beta.1
+
+replace k8s.io/klog/v2 => k8s.io/klog/v2 v2.2.0
+
+replace k8s.io/kube-openapi => k8s.io/kube-openapi v0.0.0-20200805222855-6aeccd4b50c6
+
+replace k8s.io/system-validators => k8s.io/system-validators v1.1.2
+
+replace k8s.io/utils => k8s.io/utils v0.0.0-20200729134348-d5654de09c73
+
+replace sigs.k8s.io/kustomize => sigs.k8s.io/kustomize v2.0.3+incompatible
+
+replace sigs.k8s.io/yaml => sigs.k8s.io/yaml v1.2.0
+
+replace cloud.google.com/go => cloud.google.com/go v0.51.0
+
+replace cloud.google.com/go/bigquery => cloud.google.com/go/bigquery v1.0.1
+
+replace cloud.google.com/go/datastore => cloud.google.com/go/datastore v1.0.0
+
+replace cloud.google.com/go/pubsub => cloud.google.com/go/pubsub v1.0.1
+
+replace cloud.google.com/go/storage => cloud.google.com/go/storage v1.0.0
+
+replace dmitri.shuralyov.com/gpu/mtl => dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9
+
+replace github.com/Azure/go-ansiterm => github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78
+
+replace github.com/Azure/go-autorest/autorest/date => github.com/Azure/go-autorest/autorest/date v0.2.0
+
+replace github.com/Azure/go-autorest/autorest/mocks => github.com/Azure/go-autorest/autorest/mocks v0.3.0
+
+replace github.com/Azure/go-autorest/autorest/validation => github.com/Azure/go-autorest/autorest/validation v0.1.0
+
+replace github.com/Azure/go-autorest/logger => github.com/Azure/go-autorest/logger v0.1.0
+
+replace github.com/Azure/go-autorest/tracing => github.com/Azure/go-autorest/tracing v0.5.0
+
+replace github.com/BurntSushi/toml => github.com/BurntSushi/toml v0.3.1
+
+replace github.com/BurntSushi/xgb => github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802
+
+replace github.com/MakeNowJust/heredoc => github.com/MakeNowJust/heredoc v0.0.0-20170808103936-bb23615498cd
+
+replace github.com/NYTimes/gziphandler => github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46
+
+replace github.com/PuerkitoBio/urlesc => github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578
+
+replace github.com/agnivade/levenshtein => github.com/agnivade/levenshtein v1.0.1
+
+replace github.com/ajstarks/svgo => github.com/ajstarks/svgo v0.0.0-20180226025133-644b8db467af
+
+replace github.com/alecthomas/template => github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751
+
+replace github.com/alecthomas/units => github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4
+
+replace github.com/andreyvit/diff => github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883
+
+replace github.com/armon/consul-api => github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6
+
+replace github.com/asaskevich/govalidator => github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a
+
+replace github.com/beorn7/perks => github.com/beorn7/perks v1.0.1
+
+replace github.com/bgentry/speakeasy => github.com/bgentry/speakeasy v0.1.0
+
+replace github.com/bifurcation/mint => github.com/bifurcation/mint v0.0.0-20180715133206-93c51c6ce115
+
+replace github.com/cenkalti/backoff => github.com/cenkalti/backoff v2.1.1+incompatible
+
+replace github.com/census-instrumentation/opencensus-proto => github.com/census-instrumentation/opencensus-proto v0.2.1
+
+replace github.com/cespare/xxhash/v2 => github.com/cespare/xxhash/v2 v2.1.1
+
+replace github.com/chai2010/gettext-go => github.com/chai2010/gettext-go v0.0.0-20160711120539-c6fed771bfd5
+
+replace github.com/checkpoint-restore/go-criu/v4 => github.com/checkpoint-restore/go-criu/v4 v4.0.2
+
+replace github.com/cheekybits/genny => github.com/cheekybits/genny v0.0.0-20170328200008-9127e812e1e9
+
+replace github.com/chzyer/logex => github.com/chzyer/logex v1.1.10
+
+replace github.com/chzyer/readline => github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e
+
+replace github.com/chzyer/test => github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1
+
+replace github.com/cilium/ebpf => github.com/cilium/ebpf v0.0.0-20200702112145-1c8d4c9ef775
+
+replace github.com/cockroachdb/datadriven => github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa
+
+replace github.com/containerd/cgroups => github.com/containerd/cgroups v0.0.0-20200531161412-0dbf7f05ba59
+
+replace github.com/containerd/console => github.com/containerd/console v1.0.0
+
+replace github.com/containerd/containerd => github.com/containerd/containerd v1.3.3
+
+replace github.com/containerd/continuity => github.com/containerd/continuity v0.0.0-20190426062206-aaeac12a7ffc
+
+replace github.com/containerd/fifo => github.com/containerd/fifo v0.0.0-20190226154929-a9fb20d87448
+
+replace github.com/containerd/go-runc => github.com/containerd/go-runc v0.0.0-20180907222934-5a6d9f37cfa3
+
+replace github.com/containerd/ttrpc => github.com/containerd/ttrpc v1.0.0
+
+replace github.com/containerd/typeurl => github.com/containerd/typeurl v1.0.0
+
+replace github.com/coreos/bbolt => github.com/coreos/bbolt v1.3.2
+
+replace github.com/coreos/etcd => github.com/coreos/etcd v3.3.10+incompatible
+
+replace github.com/coreos/go-semver => github.com/coreos/go-semver v0.3.0
+
+replace github.com/coreos/go-systemd/v22 => github.com/coreos/go-systemd/v22 v22.1.0
+
+replace github.com/creack/pty => github.com/creack/pty v1.1.7
+
+replace github.com/cyphar/filepath-securejoin => github.com/cyphar/filepath-securejoin v0.2.2
+
+replace github.com/daviddengcn/go-colortext => github.com/daviddengcn/go-colortext v0.0.0-20160507010035-511bcaf42ccd
+
+replace github.com/dgrijalva/jwt-go => github.com/dgrijalva/jwt-go v3.2.0+incompatible
+
+replace github.com/dnaeon/go-vcr => github.com/dnaeon/go-vcr v1.0.1
+
+replace github.com/docker/spdystream => github.com/docker/spdystream v0.0.0-20160310174837-449fdfce4d96
+
+replace github.com/docopt/docopt-go => github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815
+
+replace github.com/dustin/go-humanize => github.com/dustin/go-humanize v1.0.0
+
+replace github.com/envoyproxy/go-control-plane => github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473
+
+replace github.com/envoyproxy/protoc-gen-validate => github.com/envoyproxy/protoc-gen-validate v0.1.0
+
+replace github.com/euank/go-kmsg-parser => github.com/euank/go-kmsg-parser v2.0.0+incompatible
+
+replace github.com/exponent-io/jsonpath => github.com/exponent-io/jsonpath v0.0.0-20151013193312-d6023ce2651d
+
+replace github.com/fatih/camelcase => github.com/fatih/camelcase v1.0.0
+
+replace github.com/fatih/color => github.com/fatih/color v1.7.0
+
+replace github.com/flynn/go-shlex => github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568
+
+replace github.com/fogleman/gg => github.com/fogleman/gg v1.2.1-0.20190220221249-0403632d5b90
+
+replace github.com/ghodss/yaml => github.com/ghodss/yaml v1.0.0
+
+replace github.com/go-acme/lego => github.com/go-acme/lego v2.5.0+incompatible
+
+replace github.com/go-gl/glfw/v3.3/glfw => github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72
+
+replace github.com/go-ini/ini => github.com/go-ini/ini v1.9.0
+
+replace github.com/go-kit/kit => github.com/go-kit/kit v0.9.0
+
+replace github.com/go-logfmt/logfmt => github.com/go-logfmt/logfmt v0.4.0
+
+replace github.com/go-logr/logr => github.com/go-logr/logr v0.2.0
+
+replace github.com/go-openapi/errors => github.com/go-openapi/errors v0.19.2
+
+replace github.com/go-openapi/jsonpointer => github.com/go-openapi/jsonpointer v0.19.3
+
+replace github.com/go-openapi/jsonreference => github.com/go-openapi/jsonreference v0.19.3
+
+replace github.com/go-openapi/runtime => github.com/go-openapi/runtime v0.19.4
+
+replace github.com/go-openapi/swag => github.com/go-openapi/swag v0.19.5
+
+replace github.com/go-stack/stack => github.com/go-stack/stack v1.8.0
+
+replace github.com/godbus/dbus/v5 => github.com/godbus/dbus/v5 v5.0.3
+
+replace github.com/golang/freetype => github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0
+
+replace github.com/golang/glog => github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
+
+replace github.com/golang/protobuf => github.com/golang/protobuf v1.4.2
+
+replace github.com/golangplus/bytes => github.com/golangplus/bytes v0.0.0-20160111154220-45c989fe5450
+
+replace github.com/golangplus/fmt => github.com/golangplus/fmt v0.0.0-20150411045040-2a5d6d7d2995
+
+replace github.com/golangplus/testing => github.com/golangplus/testing v0.0.0-20180327235837-af21d9c3145e
+
+replace github.com/google/btree => github.com/google/btree v1.0.0
+
+replace github.com/google/martian => github.com/google/martian v2.1.0+incompatible
+
+replace github.com/google/pprof => github.com/google/pprof v0.0.0-20191218002539-d4f498aebedc
+
+replace github.com/google/renameio => github.com/google/renameio v0.1.0
+
+replace github.com/googleapis/gax-go/v2 => github.com/googleapis/gax-go/v2 v2.0.5
+
+replace github.com/gophercloud/gophercloud => github.com/gophercloud/gophercloud v0.1.0
+
+replace github.com/gopherjs/gopherjs => github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1
+
+replace github.com/gorilla/mux => github.com/gorilla/mux v1.7.3
+
+replace github.com/gorilla/websocket => github.com/gorilla/websocket v1.4.0
+
+replace github.com/gregjones/httpcache => github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7
+
+replace github.com/grpc-ecosystem/go-grpc-middleware => github.com/grpc-ecosystem/go-grpc-middleware v1.0.1-0.20190118093823-f849b5445de4
+
+replace github.com/grpc-ecosystem/go-grpc-prometheus => github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0
+
+replace github.com/grpc-ecosystem/grpc-gateway => github.com/grpc-ecosystem/grpc-gateway v1.9.5
+
+replace github.com/hashicorp/go-syslog => github.com/hashicorp/go-syslog v1.0.0
+
+replace github.com/hashicorp/hcl => github.com/hashicorp/hcl v1.0.0
+
+replace github.com/hpcloud/tail => github.com/hpcloud/tail v1.0.0
+
+replace github.com/ianlancetaylor/demangle => github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6
+
+replace github.com/imdario/mergo => github.com/imdario/mergo v0.3.5
+
+replace github.com/inconshreveable/mousetrap => github.com/inconshreveable/mousetrap v1.0.0
+
+replace github.com/jimstudt/http-authentication => github.com/jimstudt/http-authentication v0.0.0-20140401203705-3eca13d6893a
+
+replace github.com/jmespath/go-jmespath => github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af
+
+replace github.com/jonboulle/clockwork => github.com/jonboulle/clockwork v0.1.0
+
+replace github.com/jstemmer/go-junit-report => github.com/jstemmer/go-junit-report v0.9.1
+
+replace github.com/jtolds/gls => github.com/jtolds/gls v4.20.0+incompatible
+
+replace github.com/julienschmidt/httprouter => github.com/julienschmidt/httprouter v1.2.0
+
+replace github.com/jung-kurt/gofpdf => github.com/jung-kurt/gofpdf v1.0.3-0.20190309125859-24315acbbda5
+
+replace github.com/karrick/godirwalk => github.com/karrick/godirwalk v1.7.5
+
+replace github.com/kisielk/errcheck => github.com/kisielk/errcheck v1.5.0
+
+replace github.com/kisielk/gotool => github.com/kisielk/gotool v1.0.0
+
+replace github.com/klauspost/cpuid => github.com/klauspost/cpuid v1.2.0
+
+replace github.com/konsorten/go-windows-terminal-sequences => github.com/konsorten/go-windows-terminal-sequences v1.0.3
+
+replace github.com/kr/logfmt => github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515
+
+replace github.com/kr/pretty => github.com/kr/pretty v0.2.0
+
+replace github.com/kr/pty => github.com/kr/pty v1.1.5
+
+replace github.com/kr/text => github.com/kr/text v0.1.0
+
+replace github.com/kylelemons/godebug => github.com/kylelemons/godebug v0.0.0-20170820004349-d65d576e9348
+
+replace github.com/liggitt/tabwriter => github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de
+
+replace github.com/lucas-clemente/aes12 => github.com/lucas-clemente/aes12 v0.0.0-20171027163421-cd47fb39b79f
+
+replace github.com/lucas-clemente/quic-clients => github.com/lucas-clemente/quic-clients v0.1.0
+
+replace github.com/lucas-clemente/quic-go => github.com/lucas-clemente/quic-go v0.10.2
+
+replace github.com/lucas-clemente/quic-go-certificates => github.com/lucas-clemente/quic-go-certificates v0.0.0-20160823095156-d2f86524cced
+
+replace github.com/mailru/easyjson => github.com/mailru/easyjson v0.7.0
+
+replace github.com/marten-seemann/qtls => github.com/marten-seemann/qtls v0.2.3
+
+replace github.com/mattn/go-colorable => github.com/mattn/go-colorable v0.0.9
+
+replace github.com/mattn/go-isatty => github.com/mattn/go-isatty v0.0.4
+
+replace github.com/mattn/go-runewidth => github.com/mattn/go-runewidth v0.0.2
+
+replace github.com/matttproud/golang_protobuf_extensions => github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369
+
+replace github.com/mholt/certmagic => github.com/mholt/certmagic v0.6.2-0.20190624175158-6a42ef9fe8c2
+
+replace github.com/mindprince/gonvml => github.com/mindprince/gonvml v0.0.0-20190828220739-9ebdce4bb989
+
+replace github.com/mistifyio/go-zfs => github.com/mistifyio/go-zfs v2.1.2-0.20190413222219-f784269be439+incompatible
+
+replace github.com/mitchellh/go-homedir => github.com/mitchellh/go-homedir v1.1.0
+
+replace github.com/mitchellh/go-wordwrap => github.com/mitchellh/go-wordwrap v1.0.0
+
+replace github.com/mitchellh/mapstructure => github.com/mitchellh/mapstructure v1.1.2
+
+replace github.com/moby/sys/mountinfo => github.com/moby/sys/mountinfo v0.1.3
+
+replace github.com/moby/term => github.com/moby/term v0.0.0-20200312100748-672ec06f55cd
+
+replace github.com/modern-go/concurrent => github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd
+
+replace github.com/modern-go/reflect2 => github.com/modern-go/reflect2 v1.0.1
+
+replace github.com/morikuni/aec => github.com/morikuni/aec v1.0.0
+
+replace github.com/mwitkow/go-conntrack => github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223
+
+replace github.com/mxk/go-flowrate => github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f
+
+replace github.com/naoina/go-stringutil => github.com/naoina/go-stringutil v0.1.0
+
+replace github.com/naoina/toml => github.com/naoina/toml v0.1.1
+
+replace github.com/olekukonko/tablewriter => github.com/olekukonko/tablewriter v0.0.0-20170122224234-a0225b3f23b5
+
+replace github.com/opencontainers/image-spec => github.com/opencontainers/image-spec v1.0.1
+
+replace github.com/opencontainers/runtime-spec => github.com/opencontainers/runtime-spec v1.0.3-0.20200520003142-237cc4f519e2
+
+replace github.com/pelletier/go-toml => github.com/pelletier/go-toml v1.2.0
+
+replace github.com/peterbourgon/diskv => github.com/peterbourgon/diskv v2.0.1+incompatible
+
+replace github.com/pquerna/cachecontrol => github.com/pquerna/cachecontrol v0.0.0-20171018203845-0dec1b30a021
+
+replace github.com/prometheus/procfs => github.com/prometheus/procfs v0.1.3
+
+replace github.com/remyoudompheng/bigfft => github.com/remyoudompheng/bigfft v0.0.0-20170806203942-52369c62f446
+
+replace github.com/rogpeppe/fastuuid => github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af
+
+replace github.com/rogpeppe/go-internal => github.com/rogpeppe/go-internal v1.3.0
+
+replace github.com/rubiojr/go-vhd => github.com/rubiojr/go-vhd v0.0.0-20200706105327-02e210299021
+
+replace github.com/russross/blackfriday => github.com/russross/blackfriday v1.5.2
+
+replace github.com/russross/blackfriday/v2 => github.com/russross/blackfriday/v2 v2.0.1
+
+replace github.com/satori/go.uuid => github.com/satori/go.uuid v1.2.0
+
+replace github.com/seccomp/libseccomp-golang => github.com/seccomp/libseccomp-golang v0.9.1
+
+replace github.com/sergi/go-diff => github.com/sergi/go-diff v1.0.0
+
+replace github.com/shurcooL/sanitized_anchor_name => github.com/shurcooL/sanitized_anchor_name v1.0.0
+
+replace github.com/sirupsen/logrus => github.com/sirupsen/logrus v1.6.0
+
+replace github.com/smartystreets/assertions => github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d
+
+replace github.com/smartystreets/goconvey => github.com/smartystreets/goconvey v1.6.4
+
+replace github.com/soheilhy/cmux => github.com/soheilhy/cmux v0.1.4
+
+replace github.com/spf13/cast => github.com/spf13/cast v1.3.0
+
+replace github.com/stretchr/objx => github.com/stretchr/objx v0.2.0
+
+replace github.com/syndtr/gocapability => github.com/syndtr/gocapability v0.0.0-20180916011248-d98352740cb2
+
+replace github.com/tidwall/pretty => github.com/tidwall/pretty v1.0.0
+
+replace github.com/tmc/grpc-websocket-proxy => github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5
+
+replace github.com/ugorji/go => github.com/ugorji/go v1.1.4
+
+replace github.com/urfave/cli => github.com/urfave/cli v1.22.2
+
+replace github.com/vektah/gqlparser => github.com/vektah/gqlparser v1.1.2
+
+replace github.com/vishvananda/netns => github.com/vishvananda/netns v0.0.0-20200520041808-52d707b772fe
+
+replace github.com/xiang90/probing => github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2
+
+replace github.com/xlab/handysort => github.com/xlab/handysort v0.0.0-20150421192137-fb3537ed64a1
+
+replace github.com/xordataexchange/crypt => github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77
+
+replace github.com/yuin/goldmark => github.com/yuin/goldmark v1.2.1
+
+replace go.etcd.io/bbolt => go.etcd.io/bbolt v1.3.5
+
+replace go.mongodb.org/mongo-driver => go.mongodb.org/mongo-driver v1.1.2
+
+replace go.opencensus.io => go.opencensus.io v0.22.2
+
+replace go.uber.org/atomic => go.uber.org/atomic v1.4.0
+
+replace go.uber.org/multierr => go.uber.org/multierr v1.1.0
+
+replace go.uber.org/zap => go.uber.org/zap v1.10.0
+
+replace golang.org/x/exp => golang.org/x/exp v0.0.0-20191227195350-da58074b4299
+
+replace golang.org/x/image => golang.org/x/image v0.0.0-20190802002840-cff245a6509b
+
+replace golang.org/x/lint => golang.org/x/lint v0.0.0-20191125180803-fdd1cda4f05f
+
+replace golang.org/x/mobile => golang.org/x/mobile v0.0.0-20190719004257-d2bd2a29d028
+
+replace golang.org/x/mod => golang.org/x/mod v0.3.0
+
+replace golang.org/x/sync => golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9
+
+replace golang.org/x/text => golang.org/x/text v0.3.3
+
+replace golang.org/x/xerrors => golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1
+
+replace gonum.org/v1/plot => gonum.org/v1/plot v0.0.0-20190515093506-e2840ee46a6b
+
+replace google.golang.org/appengine => google.golang.org/appengine v1.6.5
+
+replace google.golang.org/genproto => google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013
+
+replace google.golang.org/protobuf => google.golang.org/protobuf v1.24.0
+
+replace gopkg.in/alecthomas/kingpin.v2 => gopkg.in/alecthomas/kingpin.v2 v2.2.6
+
+replace gopkg.in/check.v1 => gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15
+
+replace gopkg.in/cheggaaa/pb.v1 => gopkg.in/cheggaaa/pb.v1 v1.0.25
+
+replace gopkg.in/errgo.v2 => gopkg.in/errgo.v2 v2.1.0
+
+replace gopkg.in/fsnotify.v1 => gopkg.in/fsnotify.v1 v1.4.7
+
+replace gopkg.in/inf.v0 => gopkg.in/inf.v0 v0.9.1
+
+replace gopkg.in/mcuadros/go-syslog.v2 => gopkg.in/mcuadros/go-syslog.v2 v2.2.1
+
+replace gopkg.in/natefinch/lumberjack.v2 => gopkg.in/natefinch/lumberjack.v2 v2.0.0
+
+replace gopkg.in/resty.v1 => gopkg.in/resty.v1 v1.12.0
+
+replace gopkg.in/tomb.v1 => gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7
+
+replace gopkg.in/warnings.v0 => gopkg.in/warnings.v0 v0.1.1
+
+replace gotest.tools => gotest.tools v2.2.0+incompatible
+
+replace gotest.tools/v3 => gotest.tools/v3 v3.0.2
+
+replace honnef.co/go/tools => honnef.co/go/tools v0.0.1-2019.2.3
+
+replace modernc.org/cc => modernc.org/cc v1.0.0
+
+replace modernc.org/golex => modernc.org/golex v1.0.0
+
+replace modernc.org/mathutil => modernc.org/mathutil v1.0.0
+
+replace modernc.org/strutil => modernc.org/strutil v1.0.0
+
+replace modernc.org/xc => modernc.org/xc v1.0.0
+
+replace rsc.io/pdf => rsc.io/pdf v0.1.1
+
+replace sigs.k8s.io/apiserver-network-proxy/konnectivity-client => sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.15
+
+replace sigs.k8s.io/structured-merge-diff/v4 => sigs.k8s.io/structured-merge-diff/v4 v4.1.2
+
+replace vbom.ml/util => vbom.ml/util v0.0.0-20160121211510-db5cfe13f5cc

--- a/staging/src/k8s.io/cli-runtime/go.mod
+++ b/staging/src/k8s.io/cli-runtime/go.mod
@@ -5,24 +5,121 @@ module k8s.io/cli-runtime
 go 1.15
 
 require (
+	bitbucket.org/bertimus9/systemstat v0.0.0-20180207000608-0eeff89b0690
+	github.com/Azure/azure-sdk-for-go v43.0.0+incompatible
+	github.com/Azure/go-autorest/autorest v0.9.6
+	github.com/Azure/go-autorest/autorest/adal v0.8.2
+	github.com/Azure/go-autorest/autorest/to v0.2.0
+	github.com/GoogleCloudPlatform/k8s-cloud-provider v0.0.0-20200415212048-7901bc822317
+	github.com/JeffAshton/win_pdh v0.0.0-20161109143554-76bb4ee9f0ab
+	github.com/Microsoft/go-winio v0.4.15-0.20190919025122-fc70bd9a86b5
+	github.com/Microsoft/hcsshim v0.8.10-0.20200715222032-5eafd1556990
+	github.com/PuerkitoBio/purell v1.1.1
+	github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e
+	github.com/auth0/go-jwt-middleware v0.0.0-20170425171159-5493cabe49f7
+	github.com/aws/aws-sdk-go v1.28.2
+	github.com/blang/semver v3.5.0+incompatible
+	github.com/boltdb/bolt v1.3.1
+	github.com/caddyserver/caddy v1.0.3
+	github.com/clusterhq/flocker-go v0.0.0-20160920122132-2b8b7259d313
+	github.com/codegangsta/negroni v1.0.0
+	github.com/container-storage-interface/spec v1.2.0
+	github.com/containernetworking/cni v0.8.0
+	github.com/coredns/corefile-migration v1.0.10
+	github.com/coreos/go-oidc v2.1.0+incompatible
+	github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e
+	github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f
+	github.com/cpuguy83/go-md2man/v2 v2.0.0
 	github.com/davecgh/go-spew v1.1.1
+	github.com/docker/distribution v2.7.1+incompatible
+	github.com/docker/docker v1.4.2-0.20200309214505-aa6a9891b09c
+	github.com/docker/go-connections v0.4.0
+	github.com/docker/go-units v0.4.0
+	github.com/elazarl/goproxy v0.0.0-20180725130230-947c36da3153
 	github.com/emicklei/go-restful v2.9.5+incompatible // indirect
 	github.com/evanphx/json-patch v4.9.0+incompatible
+	github.com/fsnotify/fsnotify v1.4.9
+	github.com/go-bindata/go-bindata v3.1.1+incompatible
+	github.com/go-openapi/analysis v0.19.5
 	github.com/go-openapi/jsonreference v0.19.3 // indirect
+	github.com/go-openapi/loads v0.19.4
 	github.com/go-openapi/spec v0.19.3 // indirect
+	github.com/go-openapi/strfmt v0.19.3
+	github.com/go-openapi/validate v0.19.5
+	github.com/go-ozzo/ozzo-validation v3.5.0+incompatible
+	github.com/gogo/protobuf v1.3.2
+	github.com/golang/groupcache v0.0.0-20191227052852-215e87163ea7
+	github.com/golang/mock v1.3.1
+	github.com/google/cadvisor v0.37.5
+	github.com/google/go-cmp v0.4.0
+	github.com/google/gofuzz v1.1.0
+	github.com/google/uuid v1.1.1
 	github.com/googleapis/gnostic v0.4.1
+	github.com/gorilla/context v1.1.1
+	github.com/hashicorp/golang-lru v0.5.1
+	github.com/heketi/heketi v9.0.1-0.20190917153846-c2e2a4ab7ab9+incompatible
+	github.com/heketi/tests v0.0.0-20151005000721-f3775cbcefd6
+	github.com/ishidawataru/sctp v0.0.0-20190723014705-7c296d48a2b5
+	github.com/json-iterator/go v1.1.10
+	github.com/libopenstorage/openstorage v1.0.0
 	github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de
+	github.com/lithammer/dedent v1.1.0
+	github.com/lpabon/godbc v0.1.1
+	github.com/magiconair/properties v1.8.1
 	github.com/mailru/easyjson v0.7.0 // indirect
+	github.com/miekg/dns v1.1.4
+	github.com/moby/ipvs v1.0.1
+	github.com/mohae/deepcopy v0.0.0-20170603005431-491d3605edfb
+	github.com/mrunalp/fileutils v0.0.0-20200520151820-abd8a0e76976
+	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822
+	github.com/mvdan/xurls v1.1.0
+	github.com/onsi/ginkgo v1.11.0
+	github.com/onsi/gomega v1.7.0
+	github.com/opencontainers/go-digest v1.0.0-rc1
+	github.com/opencontainers/runc v1.0.1
+	github.com/opencontainers/selinux v1.5.2
 	github.com/pkg/errors v0.9.1
+	github.com/pmezard/go-difflib v1.0.0
+	github.com/prometheus/client_golang v1.7.1
+	github.com/prometheus/client_model v0.2.0
+	github.com/prometheus/common v0.10.0
+	github.com/quobyte/api v0.1.2
+	github.com/robfig/cron v1.1.0
+	github.com/spf13/afero v1.2.2
 	github.com/spf13/cobra v1.0.0
+	github.com/spf13/jwalterweatherman v1.1.0
 	github.com/spf13/pflag v1.0.5
+	github.com/spf13/viper v1.4.0
+	github.com/storageos/go-api v0.0.0-20180912212459-343b3eff91fc
 	github.com/stretchr/testify v1.4.0
+	github.com/thecodeteam/goscaleio v0.1.0
+	github.com/urfave/negroni v1.0.0
+	github.com/vishvananda/netlink v1.1.0
+	github.com/vmware/govmomi v0.20.3
+	go.etcd.io/etcd v0.5.0-alpha.5.0.20200819165624-17cef6e3e9d5
+	golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9
+	golang.org/x/net v0.0.0-20201110031124-69a78807bb2b
+	golang.org/x/oauth2 v0.0.0-20191202225959-858c2ad4c8b6
+	golang.org/x/sys v0.0.0-20201112073958-5cba982894dd
 	golang.org/x/text v0.3.3
+	golang.org/x/time v0.0.0-20191024005414-555d28b269f0
+	golang.org/x/tools v0.0.0-20210106214847-113979e3529a
+	gonum.org/v1/gonum v0.6.2
+	gonum.org/v1/netlib v0.0.0-20190331212654-76723241ea4e
+	google.golang.org/api v0.15.1
+	google.golang.org/grpc v1.27.0
+	gopkg.in/gcfg.v1 v1.2.0
+	gopkg.in/square/go-jose.v2 v2.2.2
 	gopkg.in/yaml.v2 v2.2.8
 	k8s.io/api v0.0.0
 	k8s.io/apimachinery v0.0.0
 	k8s.io/client-go v0.0.0
+	k8s.io/gengo v0.0.0-20200428234225-8167cfdcfc14
+	k8s.io/heapster v1.2.0-beta.1
+	k8s.io/klog/v2 v2.2.0
 	k8s.io/kube-openapi v0.0.0-20200805222855-6aeccd4b50c6
+	k8s.io/system-validators v1.1.2
+	k8s.io/utils v0.0.0-20200729134348-d5654de09c73
 	sigs.k8s.io/kustomize v2.0.3+incompatible
 	sigs.k8s.io/yaml v1.2.0
 )
@@ -33,3 +130,669 @@ replace (
 	k8s.io/cli-runtime => ../cli-runtime
 	k8s.io/client-go => ../client-go
 )
+
+replace github.com/auth0/go-jwt-middleware => github.com/auth0/go-jwt-middleware v0.0.0-20170425171159-5493cabe49f7
+
+replace github.com/boltdb/bolt => github.com/boltdb/bolt v1.3.1
+
+replace github.com/codegangsta/negroni => github.com/codegangsta/negroni v1.0.0
+
+replace github.com/go-ozzo/ozzo-validation => github.com/go-ozzo/ozzo-validation v3.5.0+incompatible
+
+replace github.com/gorilla/context => github.com/gorilla/context v1.1.1
+
+replace github.com/heketi/tests => github.com/heketi/tests v0.0.0-20151005000721-f3775cbcefd6
+
+replace github.com/lpabon/godbc => github.com/lpabon/godbc v0.1.1
+
+replace github.com/magiconair/properties => github.com/magiconair/properties v1.8.1
+
+replace github.com/mohae/deepcopy => github.com/mohae/deepcopy v0.0.0-20170603005431-491d3605edfb
+
+replace github.com/spf13/jwalterweatherman => github.com/spf13/jwalterweatherman v1.1.0
+
+replace github.com/urfave/negroni => github.com/urfave/negroni v1.0.0
+
+replace gonum.org/v1/netlib => gonum.org/v1/netlib v0.0.0-20190331212654-76723241ea4e
+
+replace bitbucket.org/bertimus9/systemstat => bitbucket.org/bertimus9/systemstat v0.0.0-20180207000608-0eeff89b0690
+
+replace github.com/Azure/azure-sdk-for-go => github.com/Azure/azure-sdk-for-go v43.0.0+incompatible
+
+replace github.com/Azure/go-autorest/autorest => github.com/Azure/go-autorest/autorest v0.9.6
+
+replace github.com/Azure/go-autorest/autorest/adal => github.com/Azure/go-autorest/autorest/adal v0.8.2
+
+replace github.com/Azure/go-autorest/autorest/to => github.com/Azure/go-autorest/autorest/to v0.2.0
+
+replace github.com/GoogleCloudPlatform/k8s-cloud-provider => github.com/GoogleCloudPlatform/k8s-cloud-provider v0.0.0-20200415212048-7901bc822317
+
+replace github.com/JeffAshton/win_pdh => github.com/JeffAshton/win_pdh v0.0.0-20161109143554-76bb4ee9f0ab
+
+replace github.com/Microsoft/go-winio => github.com/Microsoft/go-winio v0.4.15-0.20190919025122-fc70bd9a86b5
+
+replace github.com/Microsoft/hcsshim => github.com/Microsoft/hcsshim v0.8.10-0.20200715222032-5eafd1556990
+
+replace github.com/PuerkitoBio/purell => github.com/PuerkitoBio/purell v1.1.1
+
+replace github.com/armon/circbuf => github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e
+
+replace github.com/aws/aws-sdk-go => github.com/aws/aws-sdk-go v1.28.2
+
+replace github.com/blang/semver => github.com/blang/semver v3.5.0+incompatible
+
+replace github.com/caddyserver/caddy => github.com/caddyserver/caddy v1.0.3
+
+replace github.com/clusterhq/flocker-go => github.com/clusterhq/flocker-go v0.0.0-20160920122132-2b8b7259d313
+
+replace github.com/container-storage-interface/spec => github.com/container-storage-interface/spec v1.2.0
+
+replace github.com/containernetworking/cni => github.com/containernetworking/cni v0.8.0
+
+replace github.com/coredns/corefile-migration => github.com/coredns/corefile-migration v1.0.10
+
+replace github.com/coreos/go-oidc => github.com/coreos/go-oidc v2.1.0+incompatible
+
+replace github.com/coreos/go-systemd => github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e
+
+replace github.com/coreos/pkg => github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f
+
+replace github.com/cpuguy83/go-md2man/v2 => github.com/cpuguy83/go-md2man/v2 v2.0.0
+
+replace github.com/davecgh/go-spew => github.com/davecgh/go-spew v1.1.1
+
+replace github.com/docker/distribution => github.com/docker/distribution v2.7.1+incompatible
+
+replace github.com/docker/docker => github.com/docker/docker v1.4.2-0.20200309214505-aa6a9891b09c
+
+replace github.com/docker/go-connections => github.com/docker/go-connections v0.4.0
+
+replace github.com/docker/go-units => github.com/docker/go-units v0.4.0
+
+replace github.com/elazarl/goproxy => github.com/elazarl/goproxy v0.0.0-20180725130230-947c36da3153
+
+replace github.com/emicklei/go-restful => github.com/emicklei/go-restful v2.9.5+incompatible
+
+replace github.com/evanphx/json-patch => github.com/evanphx/json-patch v4.9.0+incompatible
+
+replace github.com/fsnotify/fsnotify => github.com/fsnotify/fsnotify v1.4.9
+
+replace github.com/go-bindata/go-bindata => github.com/go-bindata/go-bindata v3.1.1+incompatible
+
+replace github.com/go-openapi/analysis => github.com/go-openapi/analysis v0.19.5
+
+replace github.com/go-openapi/loads => github.com/go-openapi/loads v0.19.4
+
+replace github.com/go-openapi/spec => github.com/go-openapi/spec v0.19.3
+
+replace github.com/go-openapi/strfmt => github.com/go-openapi/strfmt v0.19.3
+
+replace github.com/go-openapi/validate => github.com/go-openapi/validate v0.19.5
+
+replace github.com/gogo/protobuf => github.com/gogo/protobuf v1.3.2
+
+replace github.com/golang/groupcache => github.com/golang/groupcache v0.0.0-20191227052852-215e87163ea7
+
+replace github.com/golang/mock => github.com/golang/mock v1.3.1
+
+replace github.com/google/cadvisor => github.com/google/cadvisor v0.37.5
+
+replace github.com/google/go-cmp => github.com/google/go-cmp v0.4.0
+
+replace github.com/google/gofuzz => github.com/google/gofuzz v1.1.0
+
+replace github.com/google/uuid => github.com/google/uuid v1.1.1
+
+replace github.com/googleapis/gnostic => github.com/googleapis/gnostic v0.4.1
+
+replace github.com/hashicorp/golang-lru => github.com/hashicorp/golang-lru v0.5.1
+
+replace github.com/heketi/heketi => github.com/heketi/heketi v9.0.1-0.20190917153846-c2e2a4ab7ab9+incompatible
+
+replace github.com/ishidawataru/sctp => github.com/ishidawataru/sctp v0.0.0-20190723014705-7c296d48a2b5
+
+replace github.com/json-iterator/go => github.com/json-iterator/go v1.1.10
+
+replace github.com/libopenstorage/openstorage => github.com/libopenstorage/openstorage v1.0.0
+
+replace github.com/lithammer/dedent => github.com/lithammer/dedent v1.1.0
+
+replace github.com/miekg/dns => github.com/miekg/dns v1.1.4
+
+replace github.com/moby/ipvs => github.com/moby/ipvs v1.0.1
+
+replace github.com/mrunalp/fileutils => github.com/mrunalp/fileutils v0.0.0-20200520151820-abd8a0e76976
+
+replace github.com/munnerz/goautoneg => github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822
+
+replace github.com/mvdan/xurls => github.com/mvdan/xurls v1.1.0
+
+replace github.com/onsi/ginkgo => github.com/onsi/ginkgo v1.11.0
+
+replace github.com/onsi/gomega => github.com/onsi/gomega v1.7.0
+
+replace github.com/opencontainers/go-digest => github.com/opencontainers/go-digest v1.0.0-rc1
+
+replace github.com/opencontainers/runc => github.com/opencontainers/runc v1.0.1
+
+replace github.com/opencontainers/selinux => github.com/opencontainers/selinux v1.5.2
+
+replace github.com/pkg/errors => github.com/pkg/errors v0.9.1
+
+replace github.com/pmezard/go-difflib => github.com/pmezard/go-difflib v1.0.0
+
+replace github.com/prometheus/client_golang => github.com/prometheus/client_golang v1.7.1
+
+replace github.com/prometheus/client_model => github.com/prometheus/client_model v0.2.0
+
+replace github.com/prometheus/common => github.com/prometheus/common v0.10.0
+
+replace github.com/quobyte/api => github.com/quobyte/api v0.1.2
+
+replace github.com/robfig/cron => github.com/robfig/cron v1.1.0
+
+replace github.com/spf13/afero => github.com/spf13/afero v1.2.2
+
+replace github.com/spf13/cobra => github.com/spf13/cobra v1.0.0
+
+replace github.com/spf13/pflag => github.com/spf13/pflag v1.0.5
+
+replace github.com/spf13/viper => github.com/spf13/viper v1.4.0
+
+replace github.com/storageos/go-api => github.com/storageos/go-api v0.0.0-20180912212459-343b3eff91fc
+
+replace github.com/stretchr/testify => github.com/stretchr/testify v1.4.0
+
+replace github.com/thecodeteam/goscaleio => github.com/thecodeteam/goscaleio v0.1.0
+
+replace github.com/vishvananda/netlink => github.com/vishvananda/netlink v1.1.0
+
+replace github.com/vmware/govmomi => github.com/vmware/govmomi v0.20.3
+
+replace go.etcd.io/etcd => go.etcd.io/etcd v0.5.0-alpha.5.0.20200819165624-17cef6e3e9d5
+
+replace golang.org/x/crypto => golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9
+
+replace golang.org/x/net => golang.org/x/net v0.0.0-20201110031124-69a78807bb2b
+
+replace golang.org/x/oauth2 => golang.org/x/oauth2 v0.0.0-20191202225959-858c2ad4c8b6
+
+replace golang.org/x/sys => golang.org/x/sys v0.0.0-20201112073958-5cba982894dd
+
+replace golang.org/x/time => golang.org/x/time v0.0.0-20191024005414-555d28b269f0
+
+replace golang.org/x/tools => golang.org/x/tools v0.0.0-20210106214847-113979e3529a
+
+replace gonum.org/v1/gonum => gonum.org/v1/gonum v0.6.2
+
+replace google.golang.org/api => google.golang.org/api v0.15.1
+
+replace google.golang.org/grpc => google.golang.org/grpc v1.27.0
+
+replace gopkg.in/gcfg.v1 => gopkg.in/gcfg.v1 v1.2.0
+
+replace gopkg.in/square/go-jose.v2 => gopkg.in/square/go-jose.v2 v2.2.2
+
+replace gopkg.in/yaml.v2 => gopkg.in/yaml.v2 v2.2.8
+
+replace k8s.io/gengo => k8s.io/gengo v0.0.0-20200428234225-8167cfdcfc14
+
+replace k8s.io/heapster => k8s.io/heapster v1.2.0-beta.1
+
+replace k8s.io/klog/v2 => k8s.io/klog/v2 v2.2.0
+
+replace k8s.io/kube-openapi => k8s.io/kube-openapi v0.0.0-20200805222855-6aeccd4b50c6
+
+replace k8s.io/system-validators => k8s.io/system-validators v1.1.2
+
+replace k8s.io/utils => k8s.io/utils v0.0.0-20200729134348-d5654de09c73
+
+replace sigs.k8s.io/kustomize => sigs.k8s.io/kustomize v2.0.3+incompatible
+
+replace sigs.k8s.io/yaml => sigs.k8s.io/yaml v1.2.0
+
+replace cloud.google.com/go => cloud.google.com/go v0.51.0
+
+replace cloud.google.com/go/bigquery => cloud.google.com/go/bigquery v1.0.1
+
+replace cloud.google.com/go/datastore => cloud.google.com/go/datastore v1.0.0
+
+replace cloud.google.com/go/pubsub => cloud.google.com/go/pubsub v1.0.1
+
+replace cloud.google.com/go/storage => cloud.google.com/go/storage v1.0.0
+
+replace dmitri.shuralyov.com/gpu/mtl => dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9
+
+replace github.com/Azure/go-ansiterm => github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78
+
+replace github.com/Azure/go-autorest/autorest/date => github.com/Azure/go-autorest/autorest/date v0.2.0
+
+replace github.com/Azure/go-autorest/autorest/mocks => github.com/Azure/go-autorest/autorest/mocks v0.3.0
+
+replace github.com/Azure/go-autorest/autorest/validation => github.com/Azure/go-autorest/autorest/validation v0.1.0
+
+replace github.com/Azure/go-autorest/logger => github.com/Azure/go-autorest/logger v0.1.0
+
+replace github.com/Azure/go-autorest/tracing => github.com/Azure/go-autorest/tracing v0.5.0
+
+replace github.com/BurntSushi/toml => github.com/BurntSushi/toml v0.3.1
+
+replace github.com/BurntSushi/xgb => github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802
+
+replace github.com/MakeNowJust/heredoc => github.com/MakeNowJust/heredoc v0.0.0-20170808103936-bb23615498cd
+
+replace github.com/NYTimes/gziphandler => github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46
+
+replace github.com/PuerkitoBio/urlesc => github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578
+
+replace github.com/agnivade/levenshtein => github.com/agnivade/levenshtein v1.0.1
+
+replace github.com/ajstarks/svgo => github.com/ajstarks/svgo v0.0.0-20180226025133-644b8db467af
+
+replace github.com/alecthomas/template => github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751
+
+replace github.com/alecthomas/units => github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4
+
+replace github.com/andreyvit/diff => github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883
+
+replace github.com/armon/consul-api => github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6
+
+replace github.com/asaskevich/govalidator => github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a
+
+replace github.com/beorn7/perks => github.com/beorn7/perks v1.0.1
+
+replace github.com/bgentry/speakeasy => github.com/bgentry/speakeasy v0.1.0
+
+replace github.com/bifurcation/mint => github.com/bifurcation/mint v0.0.0-20180715133206-93c51c6ce115
+
+replace github.com/cenkalti/backoff => github.com/cenkalti/backoff v2.1.1+incompatible
+
+replace github.com/census-instrumentation/opencensus-proto => github.com/census-instrumentation/opencensus-proto v0.2.1
+
+replace github.com/cespare/xxhash/v2 => github.com/cespare/xxhash/v2 v2.1.1
+
+replace github.com/chai2010/gettext-go => github.com/chai2010/gettext-go v0.0.0-20160711120539-c6fed771bfd5
+
+replace github.com/checkpoint-restore/go-criu/v4 => github.com/checkpoint-restore/go-criu/v4 v4.0.2
+
+replace github.com/cheekybits/genny => github.com/cheekybits/genny v0.0.0-20170328200008-9127e812e1e9
+
+replace github.com/chzyer/logex => github.com/chzyer/logex v1.1.10
+
+replace github.com/chzyer/readline => github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e
+
+replace github.com/chzyer/test => github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1
+
+replace github.com/cilium/ebpf => github.com/cilium/ebpf v0.0.0-20200702112145-1c8d4c9ef775
+
+replace github.com/cockroachdb/datadriven => github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa
+
+replace github.com/containerd/cgroups => github.com/containerd/cgroups v0.0.0-20200531161412-0dbf7f05ba59
+
+replace github.com/containerd/console => github.com/containerd/console v1.0.0
+
+replace github.com/containerd/containerd => github.com/containerd/containerd v1.3.3
+
+replace github.com/containerd/continuity => github.com/containerd/continuity v0.0.0-20190426062206-aaeac12a7ffc
+
+replace github.com/containerd/fifo => github.com/containerd/fifo v0.0.0-20190226154929-a9fb20d87448
+
+replace github.com/containerd/go-runc => github.com/containerd/go-runc v0.0.0-20180907222934-5a6d9f37cfa3
+
+replace github.com/containerd/ttrpc => github.com/containerd/ttrpc v1.0.0
+
+replace github.com/containerd/typeurl => github.com/containerd/typeurl v1.0.0
+
+replace github.com/coreos/bbolt => github.com/coreos/bbolt v1.3.2
+
+replace github.com/coreos/etcd => github.com/coreos/etcd v3.3.10+incompatible
+
+replace github.com/coreos/go-semver => github.com/coreos/go-semver v0.3.0
+
+replace github.com/coreos/go-systemd/v22 => github.com/coreos/go-systemd/v22 v22.1.0
+
+replace github.com/creack/pty => github.com/creack/pty v1.1.7
+
+replace github.com/cyphar/filepath-securejoin => github.com/cyphar/filepath-securejoin v0.2.2
+
+replace github.com/daviddengcn/go-colortext => github.com/daviddengcn/go-colortext v0.0.0-20160507010035-511bcaf42ccd
+
+replace github.com/dgrijalva/jwt-go => github.com/dgrijalva/jwt-go v3.2.0+incompatible
+
+replace github.com/dnaeon/go-vcr => github.com/dnaeon/go-vcr v1.0.1
+
+replace github.com/docker/spdystream => github.com/docker/spdystream v0.0.0-20160310174837-449fdfce4d96
+
+replace github.com/docopt/docopt-go => github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815
+
+replace github.com/dustin/go-humanize => github.com/dustin/go-humanize v1.0.0
+
+replace github.com/envoyproxy/go-control-plane => github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473
+
+replace github.com/envoyproxy/protoc-gen-validate => github.com/envoyproxy/protoc-gen-validate v0.1.0
+
+replace github.com/euank/go-kmsg-parser => github.com/euank/go-kmsg-parser v2.0.0+incompatible
+
+replace github.com/exponent-io/jsonpath => github.com/exponent-io/jsonpath v0.0.0-20151013193312-d6023ce2651d
+
+replace github.com/fatih/camelcase => github.com/fatih/camelcase v1.0.0
+
+replace github.com/fatih/color => github.com/fatih/color v1.7.0
+
+replace github.com/flynn/go-shlex => github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568
+
+replace github.com/fogleman/gg => github.com/fogleman/gg v1.2.1-0.20190220221249-0403632d5b90
+
+replace github.com/ghodss/yaml => github.com/ghodss/yaml v1.0.0
+
+replace github.com/go-acme/lego => github.com/go-acme/lego v2.5.0+incompatible
+
+replace github.com/go-gl/glfw/v3.3/glfw => github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72
+
+replace github.com/go-ini/ini => github.com/go-ini/ini v1.9.0
+
+replace github.com/go-kit/kit => github.com/go-kit/kit v0.9.0
+
+replace github.com/go-logfmt/logfmt => github.com/go-logfmt/logfmt v0.4.0
+
+replace github.com/go-logr/logr => github.com/go-logr/logr v0.2.0
+
+replace github.com/go-openapi/errors => github.com/go-openapi/errors v0.19.2
+
+replace github.com/go-openapi/jsonpointer => github.com/go-openapi/jsonpointer v0.19.3
+
+replace github.com/go-openapi/jsonreference => github.com/go-openapi/jsonreference v0.19.3
+
+replace github.com/go-openapi/runtime => github.com/go-openapi/runtime v0.19.4
+
+replace github.com/go-openapi/swag => github.com/go-openapi/swag v0.19.5
+
+replace github.com/go-stack/stack => github.com/go-stack/stack v1.8.0
+
+replace github.com/godbus/dbus/v5 => github.com/godbus/dbus/v5 v5.0.3
+
+replace github.com/golang/freetype => github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0
+
+replace github.com/golang/glog => github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
+
+replace github.com/golang/protobuf => github.com/golang/protobuf v1.4.2
+
+replace github.com/golangplus/bytes => github.com/golangplus/bytes v0.0.0-20160111154220-45c989fe5450
+
+replace github.com/golangplus/fmt => github.com/golangplus/fmt v0.0.0-20150411045040-2a5d6d7d2995
+
+replace github.com/golangplus/testing => github.com/golangplus/testing v0.0.0-20180327235837-af21d9c3145e
+
+replace github.com/google/btree => github.com/google/btree v1.0.0
+
+replace github.com/google/martian => github.com/google/martian v2.1.0+incompatible
+
+replace github.com/google/pprof => github.com/google/pprof v0.0.0-20191218002539-d4f498aebedc
+
+replace github.com/google/renameio => github.com/google/renameio v0.1.0
+
+replace github.com/googleapis/gax-go/v2 => github.com/googleapis/gax-go/v2 v2.0.5
+
+replace github.com/gophercloud/gophercloud => github.com/gophercloud/gophercloud v0.1.0
+
+replace github.com/gopherjs/gopherjs => github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1
+
+replace github.com/gorilla/mux => github.com/gorilla/mux v1.7.3
+
+replace github.com/gorilla/websocket => github.com/gorilla/websocket v1.4.0
+
+replace github.com/gregjones/httpcache => github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7
+
+replace github.com/grpc-ecosystem/go-grpc-middleware => github.com/grpc-ecosystem/go-grpc-middleware v1.0.1-0.20190118093823-f849b5445de4
+
+replace github.com/grpc-ecosystem/go-grpc-prometheus => github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0
+
+replace github.com/grpc-ecosystem/grpc-gateway => github.com/grpc-ecosystem/grpc-gateway v1.9.5
+
+replace github.com/hashicorp/go-syslog => github.com/hashicorp/go-syslog v1.0.0
+
+replace github.com/hashicorp/hcl => github.com/hashicorp/hcl v1.0.0
+
+replace github.com/hpcloud/tail => github.com/hpcloud/tail v1.0.0
+
+replace github.com/ianlancetaylor/demangle => github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6
+
+replace github.com/imdario/mergo => github.com/imdario/mergo v0.3.5
+
+replace github.com/inconshreveable/mousetrap => github.com/inconshreveable/mousetrap v1.0.0
+
+replace github.com/jimstudt/http-authentication => github.com/jimstudt/http-authentication v0.0.0-20140401203705-3eca13d6893a
+
+replace github.com/jmespath/go-jmespath => github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af
+
+replace github.com/jonboulle/clockwork => github.com/jonboulle/clockwork v0.1.0
+
+replace github.com/jstemmer/go-junit-report => github.com/jstemmer/go-junit-report v0.9.1
+
+replace github.com/jtolds/gls => github.com/jtolds/gls v4.20.0+incompatible
+
+replace github.com/julienschmidt/httprouter => github.com/julienschmidt/httprouter v1.2.0
+
+replace github.com/jung-kurt/gofpdf => github.com/jung-kurt/gofpdf v1.0.3-0.20190309125859-24315acbbda5
+
+replace github.com/karrick/godirwalk => github.com/karrick/godirwalk v1.7.5
+
+replace github.com/kisielk/errcheck => github.com/kisielk/errcheck v1.5.0
+
+replace github.com/kisielk/gotool => github.com/kisielk/gotool v1.0.0
+
+replace github.com/klauspost/cpuid => github.com/klauspost/cpuid v1.2.0
+
+replace github.com/konsorten/go-windows-terminal-sequences => github.com/konsorten/go-windows-terminal-sequences v1.0.3
+
+replace github.com/kr/logfmt => github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515
+
+replace github.com/kr/pretty => github.com/kr/pretty v0.2.0
+
+replace github.com/kr/pty => github.com/kr/pty v1.1.5
+
+replace github.com/kr/text => github.com/kr/text v0.1.0
+
+replace github.com/kylelemons/godebug => github.com/kylelemons/godebug v0.0.0-20170820004349-d65d576e9348
+
+replace github.com/liggitt/tabwriter => github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de
+
+replace github.com/lucas-clemente/aes12 => github.com/lucas-clemente/aes12 v0.0.0-20171027163421-cd47fb39b79f
+
+replace github.com/lucas-clemente/quic-clients => github.com/lucas-clemente/quic-clients v0.1.0
+
+replace github.com/lucas-clemente/quic-go => github.com/lucas-clemente/quic-go v0.10.2
+
+replace github.com/lucas-clemente/quic-go-certificates => github.com/lucas-clemente/quic-go-certificates v0.0.0-20160823095156-d2f86524cced
+
+replace github.com/mailru/easyjson => github.com/mailru/easyjson v0.7.0
+
+replace github.com/marten-seemann/qtls => github.com/marten-seemann/qtls v0.2.3
+
+replace github.com/mattn/go-colorable => github.com/mattn/go-colorable v0.0.9
+
+replace github.com/mattn/go-isatty => github.com/mattn/go-isatty v0.0.4
+
+replace github.com/mattn/go-runewidth => github.com/mattn/go-runewidth v0.0.2
+
+replace github.com/matttproud/golang_protobuf_extensions => github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369
+
+replace github.com/mholt/certmagic => github.com/mholt/certmagic v0.6.2-0.20190624175158-6a42ef9fe8c2
+
+replace github.com/mindprince/gonvml => github.com/mindprince/gonvml v0.0.0-20190828220739-9ebdce4bb989
+
+replace github.com/mistifyio/go-zfs => github.com/mistifyio/go-zfs v2.1.2-0.20190413222219-f784269be439+incompatible
+
+replace github.com/mitchellh/go-homedir => github.com/mitchellh/go-homedir v1.1.0
+
+replace github.com/mitchellh/go-wordwrap => github.com/mitchellh/go-wordwrap v1.0.0
+
+replace github.com/mitchellh/mapstructure => github.com/mitchellh/mapstructure v1.1.2
+
+replace github.com/moby/sys/mountinfo => github.com/moby/sys/mountinfo v0.1.3
+
+replace github.com/moby/term => github.com/moby/term v0.0.0-20200312100748-672ec06f55cd
+
+replace github.com/modern-go/concurrent => github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd
+
+replace github.com/modern-go/reflect2 => github.com/modern-go/reflect2 v1.0.1
+
+replace github.com/morikuni/aec => github.com/morikuni/aec v1.0.0
+
+replace github.com/mwitkow/go-conntrack => github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223
+
+replace github.com/mxk/go-flowrate => github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f
+
+replace github.com/naoina/go-stringutil => github.com/naoina/go-stringutil v0.1.0
+
+replace github.com/naoina/toml => github.com/naoina/toml v0.1.1
+
+replace github.com/olekukonko/tablewriter => github.com/olekukonko/tablewriter v0.0.0-20170122224234-a0225b3f23b5
+
+replace github.com/opencontainers/image-spec => github.com/opencontainers/image-spec v1.0.1
+
+replace github.com/opencontainers/runtime-spec => github.com/opencontainers/runtime-spec v1.0.3-0.20200520003142-237cc4f519e2
+
+replace github.com/pelletier/go-toml => github.com/pelletier/go-toml v1.2.0
+
+replace github.com/peterbourgon/diskv => github.com/peterbourgon/diskv v2.0.1+incompatible
+
+replace github.com/pquerna/cachecontrol => github.com/pquerna/cachecontrol v0.0.0-20171018203845-0dec1b30a021
+
+replace github.com/prometheus/procfs => github.com/prometheus/procfs v0.1.3
+
+replace github.com/remyoudompheng/bigfft => github.com/remyoudompheng/bigfft v0.0.0-20170806203942-52369c62f446
+
+replace github.com/rogpeppe/fastuuid => github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af
+
+replace github.com/rogpeppe/go-internal => github.com/rogpeppe/go-internal v1.3.0
+
+replace github.com/rubiojr/go-vhd => github.com/rubiojr/go-vhd v0.0.0-20200706105327-02e210299021
+
+replace github.com/russross/blackfriday => github.com/russross/blackfriday v1.5.2
+
+replace github.com/russross/blackfriday/v2 => github.com/russross/blackfriday/v2 v2.0.1
+
+replace github.com/satori/go.uuid => github.com/satori/go.uuid v1.2.0
+
+replace github.com/seccomp/libseccomp-golang => github.com/seccomp/libseccomp-golang v0.9.1
+
+replace github.com/sergi/go-diff => github.com/sergi/go-diff v1.0.0
+
+replace github.com/shurcooL/sanitized_anchor_name => github.com/shurcooL/sanitized_anchor_name v1.0.0
+
+replace github.com/sirupsen/logrus => github.com/sirupsen/logrus v1.6.0
+
+replace github.com/smartystreets/assertions => github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d
+
+replace github.com/smartystreets/goconvey => github.com/smartystreets/goconvey v1.6.4
+
+replace github.com/soheilhy/cmux => github.com/soheilhy/cmux v0.1.4
+
+replace github.com/spf13/cast => github.com/spf13/cast v1.3.0
+
+replace github.com/stretchr/objx => github.com/stretchr/objx v0.2.0
+
+replace github.com/syndtr/gocapability => github.com/syndtr/gocapability v0.0.0-20180916011248-d98352740cb2
+
+replace github.com/tidwall/pretty => github.com/tidwall/pretty v1.0.0
+
+replace github.com/tmc/grpc-websocket-proxy => github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5
+
+replace github.com/ugorji/go => github.com/ugorji/go v1.1.4
+
+replace github.com/urfave/cli => github.com/urfave/cli v1.22.2
+
+replace github.com/vektah/gqlparser => github.com/vektah/gqlparser v1.1.2
+
+replace github.com/vishvananda/netns => github.com/vishvananda/netns v0.0.0-20200520041808-52d707b772fe
+
+replace github.com/xiang90/probing => github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2
+
+replace github.com/xlab/handysort => github.com/xlab/handysort v0.0.0-20150421192137-fb3537ed64a1
+
+replace github.com/xordataexchange/crypt => github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77
+
+replace github.com/yuin/goldmark => github.com/yuin/goldmark v1.2.1
+
+replace go.etcd.io/bbolt => go.etcd.io/bbolt v1.3.5
+
+replace go.mongodb.org/mongo-driver => go.mongodb.org/mongo-driver v1.1.2
+
+replace go.opencensus.io => go.opencensus.io v0.22.2
+
+replace go.uber.org/atomic => go.uber.org/atomic v1.4.0
+
+replace go.uber.org/multierr => go.uber.org/multierr v1.1.0
+
+replace go.uber.org/zap => go.uber.org/zap v1.10.0
+
+replace golang.org/x/exp => golang.org/x/exp v0.0.0-20191227195350-da58074b4299
+
+replace golang.org/x/image => golang.org/x/image v0.0.0-20190802002840-cff245a6509b
+
+replace golang.org/x/lint => golang.org/x/lint v0.0.0-20191125180803-fdd1cda4f05f
+
+replace golang.org/x/mobile => golang.org/x/mobile v0.0.0-20190719004257-d2bd2a29d028
+
+replace golang.org/x/mod => golang.org/x/mod v0.3.0
+
+replace golang.org/x/sync => golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9
+
+replace golang.org/x/text => golang.org/x/text v0.3.3
+
+replace golang.org/x/xerrors => golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1
+
+replace gonum.org/v1/plot => gonum.org/v1/plot v0.0.0-20190515093506-e2840ee46a6b
+
+replace google.golang.org/appengine => google.golang.org/appengine v1.6.5
+
+replace google.golang.org/genproto => google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013
+
+replace google.golang.org/protobuf => google.golang.org/protobuf v1.24.0
+
+replace gopkg.in/alecthomas/kingpin.v2 => gopkg.in/alecthomas/kingpin.v2 v2.2.6
+
+replace gopkg.in/check.v1 => gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15
+
+replace gopkg.in/cheggaaa/pb.v1 => gopkg.in/cheggaaa/pb.v1 v1.0.25
+
+replace gopkg.in/errgo.v2 => gopkg.in/errgo.v2 v2.1.0
+
+replace gopkg.in/fsnotify.v1 => gopkg.in/fsnotify.v1 v1.4.7
+
+replace gopkg.in/inf.v0 => gopkg.in/inf.v0 v0.9.1
+
+replace gopkg.in/mcuadros/go-syslog.v2 => gopkg.in/mcuadros/go-syslog.v2 v2.2.1
+
+replace gopkg.in/natefinch/lumberjack.v2 => gopkg.in/natefinch/lumberjack.v2 v2.0.0
+
+replace gopkg.in/resty.v1 => gopkg.in/resty.v1 v1.12.0
+
+replace gopkg.in/tomb.v1 => gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7
+
+replace gopkg.in/warnings.v0 => gopkg.in/warnings.v0 v0.1.1
+
+replace gotest.tools => gotest.tools v2.2.0+incompatible
+
+replace gotest.tools/v3 => gotest.tools/v3 v3.0.2
+
+replace honnef.co/go/tools => honnef.co/go/tools v0.0.1-2019.2.3
+
+replace modernc.org/cc => modernc.org/cc v1.0.0
+
+replace modernc.org/golex => modernc.org/golex v1.0.0
+
+replace modernc.org/mathutil => modernc.org/mathutil v1.0.0
+
+replace modernc.org/strutil => modernc.org/strutil v1.0.0
+
+replace modernc.org/xc => modernc.org/xc v1.0.0
+
+replace rsc.io/pdf => rsc.io/pdf v0.1.1
+
+replace sigs.k8s.io/apiserver-network-proxy/konnectivity-client => sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.15
+
+replace sigs.k8s.io/structured-merge-diff/v4 => sigs.k8s.io/structured-merge-diff/v4 v4.1.2
+
+replace vbom.ml/util => vbom.ml/util v0.0.0-20160121211510-db5cfe13f5cc

--- a/staging/src/k8s.io/client-go/go.mod
+++ b/staging/src/k8s.io/client-go/go.mod
@@ -5,31 +5,122 @@ module k8s.io/client-go
 go 1.15
 
 require (
+	bitbucket.org/bertimus9/systemstat v0.0.0-20180207000608-0eeff89b0690
 	cloud.google.com/go v0.51.0 // indirect
+	github.com/Azure/azure-sdk-for-go v43.0.0+incompatible
 	github.com/Azure/go-autorest/autorest v0.9.6
 	github.com/Azure/go-autorest/autorest/adal v0.8.2
+	github.com/Azure/go-autorest/autorest/to v0.2.0
+	github.com/GoogleCloudPlatform/k8s-cloud-provider v0.0.0-20200415212048-7901bc822317
+	github.com/JeffAshton/win_pdh v0.0.0-20161109143554-76bb4ee9f0ab
+	github.com/Microsoft/go-winio v0.4.15-0.20190919025122-fc70bd9a86b5
+	github.com/Microsoft/hcsshim v0.8.10-0.20200715222032-5eafd1556990
+	github.com/PuerkitoBio/purell v1.1.1
+	github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e
+	github.com/auth0/go-jwt-middleware v0.0.0-20170425171159-5493cabe49f7
+	github.com/aws/aws-sdk-go v1.28.2
+	github.com/blang/semver v3.5.0+incompatible
+	github.com/boltdb/bolt v1.3.1
+	github.com/caddyserver/caddy v1.0.3
+	github.com/clusterhq/flocker-go v0.0.0-20160920122132-2b8b7259d313
+	github.com/codegangsta/negroni v1.0.0
+	github.com/container-storage-interface/spec v1.2.0
+	github.com/containernetworking/cni v0.8.0
+	github.com/coredns/corefile-migration v1.0.10
+	github.com/coreos/go-oidc v2.1.0+incompatible
+	github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e
+	github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f
+	github.com/cpuguy83/go-md2man/v2 v2.0.0
 	github.com/davecgh/go-spew v1.1.1
+	github.com/docker/distribution v2.7.1+incompatible
+	github.com/docker/docker v1.4.2-0.20200309214505-aa6a9891b09c
+	github.com/docker/go-connections v0.4.0
+	github.com/docker/go-units v0.4.0
+	github.com/elazarl/goproxy v0.0.0-20180725130230-947c36da3153
+	github.com/emicklei/go-restful v2.9.5+incompatible
 	github.com/evanphx/json-patch v4.9.0+incompatible
+	github.com/fsnotify/fsnotify v1.4.9
+	github.com/go-bindata/go-bindata v3.1.1+incompatible
+	github.com/go-openapi/analysis v0.19.5
+	github.com/go-openapi/loads v0.19.4
+	github.com/go-openapi/spec v0.19.3
+	github.com/go-openapi/strfmt v0.19.3
+	github.com/go-openapi/validate v0.19.5
+	github.com/go-ozzo/ozzo-validation v3.5.0+incompatible
 	github.com/gogo/protobuf v1.3.2
 	github.com/golang/groupcache v0.0.0-20191227052852-215e87163ea7
+	github.com/golang/mock v1.3.1
 	github.com/golang/protobuf v1.4.2
+	github.com/google/cadvisor v0.37.5
 	github.com/google/go-cmp v0.4.0
 	github.com/google/gofuzz v1.1.0
 	github.com/google/uuid v1.1.1
 	github.com/googleapis/gnostic v0.4.1
+	github.com/gorilla/context v1.1.1
 	github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7
+	github.com/hashicorp/golang-lru v0.5.1
+	github.com/heketi/heketi v9.0.1-0.20190917153846-c2e2a4ab7ab9+incompatible
+	github.com/heketi/tests v0.0.0-20151005000721-f3775cbcefd6
 	github.com/imdario/mergo v0.3.5
+	github.com/ishidawataru/sctp v0.0.0-20190723014705-7c296d48a2b5
+	github.com/json-iterator/go v1.1.10
+	github.com/libopenstorage/openstorage v1.0.0
+	github.com/lithammer/dedent v1.1.0
+	github.com/lpabon/godbc v0.1.1
+	github.com/magiconair/properties v1.8.1
+	github.com/miekg/dns v1.1.4
+	github.com/moby/ipvs v1.0.1
+	github.com/mohae/deepcopy v0.0.0-20170603005431-491d3605edfb
+	github.com/mrunalp/fileutils v0.0.0-20200520151820-abd8a0e76976
+	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822
+	github.com/mvdan/xurls v1.1.0
+	github.com/onsi/ginkgo v1.11.0
+	github.com/onsi/gomega v1.7.0
+	github.com/opencontainers/go-digest v1.0.0-rc1
+	github.com/opencontainers/runc v1.0.1
+	github.com/opencontainers/selinux v1.5.2
 	github.com/peterbourgon/diskv v2.0.1+incompatible
+	github.com/pkg/errors v0.9.1
+	github.com/pmezard/go-difflib v1.0.0
+	github.com/prometheus/client_golang v1.7.1
+	github.com/prometheus/client_model v0.2.0
+	github.com/prometheus/common v0.10.0
+	github.com/quobyte/api v0.1.2
+	github.com/robfig/cron v1.1.0
+	github.com/spf13/afero v1.2.2
+	github.com/spf13/cobra v1.0.0
+	github.com/spf13/jwalterweatherman v1.1.0
 	github.com/spf13/pflag v1.0.5
+	github.com/spf13/viper v1.4.0
+	github.com/storageos/go-api v0.0.0-20180912212459-343b3eff91fc
 	github.com/stretchr/testify v1.4.0
+	github.com/thecodeteam/goscaleio v0.1.0
+	github.com/urfave/negroni v1.0.0
+	github.com/vishvananda/netlink v1.1.0
+	github.com/vmware/govmomi v0.20.3
+	go.etcd.io/etcd v0.5.0-alpha.5.0.20200819165624-17cef6e3e9d5
 	golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9
 	golang.org/x/net v0.0.0-20201110031124-69a78807bb2b
 	golang.org/x/oauth2 v0.0.0-20191202225959-858c2ad4c8b6
+	golang.org/x/sys v0.0.0-20201112073958-5cba982894dd
 	golang.org/x/time v0.0.0-20191024005414-555d28b269f0
+	golang.org/x/tools v0.0.0-20210106214847-113979e3529a
+	gonum.org/v1/gonum v0.6.2
+	gonum.org/v1/netlib v0.0.0-20190331212654-76723241ea4e
+	google.golang.org/api v0.15.1
+	google.golang.org/grpc v1.27.0
+	gopkg.in/gcfg.v1 v1.2.0
+	gopkg.in/square/go-jose.v2 v2.2.2
+	gopkg.in/yaml.v2 v2.2.8
 	k8s.io/api v0.0.0
 	k8s.io/apimachinery v0.0.0
+	k8s.io/gengo v0.0.0-20200428234225-8167cfdcfc14
+	k8s.io/heapster v1.2.0-beta.1
 	k8s.io/klog/v2 v2.2.0
+	k8s.io/kube-openapi v0.0.0-20200805222855-6aeccd4b50c6
+	k8s.io/system-validators v1.1.2
 	k8s.io/utils v0.0.0-20200729134348-d5654de09c73
+	sigs.k8s.io/kustomize v2.0.3+incompatible
 	sigs.k8s.io/yaml v1.2.0
 )
 
@@ -38,3 +129,669 @@ replace (
 	k8s.io/apimachinery => ../apimachinery
 	k8s.io/client-go => ../client-go
 )
+
+replace github.com/auth0/go-jwt-middleware => github.com/auth0/go-jwt-middleware v0.0.0-20170425171159-5493cabe49f7
+
+replace github.com/boltdb/bolt => github.com/boltdb/bolt v1.3.1
+
+replace github.com/codegangsta/negroni => github.com/codegangsta/negroni v1.0.0
+
+replace github.com/go-ozzo/ozzo-validation => github.com/go-ozzo/ozzo-validation v3.5.0+incompatible
+
+replace github.com/gorilla/context => github.com/gorilla/context v1.1.1
+
+replace github.com/heketi/tests => github.com/heketi/tests v0.0.0-20151005000721-f3775cbcefd6
+
+replace github.com/lpabon/godbc => github.com/lpabon/godbc v0.1.1
+
+replace github.com/magiconair/properties => github.com/magiconair/properties v1.8.1
+
+replace github.com/mohae/deepcopy => github.com/mohae/deepcopy v0.0.0-20170603005431-491d3605edfb
+
+replace github.com/spf13/jwalterweatherman => github.com/spf13/jwalterweatherman v1.1.0
+
+replace github.com/urfave/negroni => github.com/urfave/negroni v1.0.0
+
+replace gonum.org/v1/netlib => gonum.org/v1/netlib v0.0.0-20190331212654-76723241ea4e
+
+replace bitbucket.org/bertimus9/systemstat => bitbucket.org/bertimus9/systemstat v0.0.0-20180207000608-0eeff89b0690
+
+replace github.com/Azure/azure-sdk-for-go => github.com/Azure/azure-sdk-for-go v43.0.0+incompatible
+
+replace github.com/Azure/go-autorest/autorest => github.com/Azure/go-autorest/autorest v0.9.6
+
+replace github.com/Azure/go-autorest/autorest/adal => github.com/Azure/go-autorest/autorest/adal v0.8.2
+
+replace github.com/Azure/go-autorest/autorest/to => github.com/Azure/go-autorest/autorest/to v0.2.0
+
+replace github.com/GoogleCloudPlatform/k8s-cloud-provider => github.com/GoogleCloudPlatform/k8s-cloud-provider v0.0.0-20200415212048-7901bc822317
+
+replace github.com/JeffAshton/win_pdh => github.com/JeffAshton/win_pdh v0.0.0-20161109143554-76bb4ee9f0ab
+
+replace github.com/Microsoft/go-winio => github.com/Microsoft/go-winio v0.4.15-0.20190919025122-fc70bd9a86b5
+
+replace github.com/Microsoft/hcsshim => github.com/Microsoft/hcsshim v0.8.10-0.20200715222032-5eafd1556990
+
+replace github.com/PuerkitoBio/purell => github.com/PuerkitoBio/purell v1.1.1
+
+replace github.com/armon/circbuf => github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e
+
+replace github.com/aws/aws-sdk-go => github.com/aws/aws-sdk-go v1.28.2
+
+replace github.com/blang/semver => github.com/blang/semver v3.5.0+incompatible
+
+replace github.com/caddyserver/caddy => github.com/caddyserver/caddy v1.0.3
+
+replace github.com/clusterhq/flocker-go => github.com/clusterhq/flocker-go v0.0.0-20160920122132-2b8b7259d313
+
+replace github.com/container-storage-interface/spec => github.com/container-storage-interface/spec v1.2.0
+
+replace github.com/containernetworking/cni => github.com/containernetworking/cni v0.8.0
+
+replace github.com/coredns/corefile-migration => github.com/coredns/corefile-migration v1.0.10
+
+replace github.com/coreos/go-oidc => github.com/coreos/go-oidc v2.1.0+incompatible
+
+replace github.com/coreos/go-systemd => github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e
+
+replace github.com/coreos/pkg => github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f
+
+replace github.com/cpuguy83/go-md2man/v2 => github.com/cpuguy83/go-md2man/v2 v2.0.0
+
+replace github.com/davecgh/go-spew => github.com/davecgh/go-spew v1.1.1
+
+replace github.com/docker/distribution => github.com/docker/distribution v2.7.1+incompatible
+
+replace github.com/docker/docker => github.com/docker/docker v1.4.2-0.20200309214505-aa6a9891b09c
+
+replace github.com/docker/go-connections => github.com/docker/go-connections v0.4.0
+
+replace github.com/docker/go-units => github.com/docker/go-units v0.4.0
+
+replace github.com/elazarl/goproxy => github.com/elazarl/goproxy v0.0.0-20180725130230-947c36da3153
+
+replace github.com/emicklei/go-restful => github.com/emicklei/go-restful v2.9.5+incompatible
+
+replace github.com/evanphx/json-patch => github.com/evanphx/json-patch v4.9.0+incompatible
+
+replace github.com/fsnotify/fsnotify => github.com/fsnotify/fsnotify v1.4.9
+
+replace github.com/go-bindata/go-bindata => github.com/go-bindata/go-bindata v3.1.1+incompatible
+
+replace github.com/go-openapi/analysis => github.com/go-openapi/analysis v0.19.5
+
+replace github.com/go-openapi/loads => github.com/go-openapi/loads v0.19.4
+
+replace github.com/go-openapi/spec => github.com/go-openapi/spec v0.19.3
+
+replace github.com/go-openapi/strfmt => github.com/go-openapi/strfmt v0.19.3
+
+replace github.com/go-openapi/validate => github.com/go-openapi/validate v0.19.5
+
+replace github.com/gogo/protobuf => github.com/gogo/protobuf v1.3.2
+
+replace github.com/golang/groupcache => github.com/golang/groupcache v0.0.0-20191227052852-215e87163ea7
+
+replace github.com/golang/mock => github.com/golang/mock v1.3.1
+
+replace github.com/google/cadvisor => github.com/google/cadvisor v0.37.5
+
+replace github.com/google/go-cmp => github.com/google/go-cmp v0.4.0
+
+replace github.com/google/gofuzz => github.com/google/gofuzz v1.1.0
+
+replace github.com/google/uuid => github.com/google/uuid v1.1.1
+
+replace github.com/googleapis/gnostic => github.com/googleapis/gnostic v0.4.1
+
+replace github.com/hashicorp/golang-lru => github.com/hashicorp/golang-lru v0.5.1
+
+replace github.com/heketi/heketi => github.com/heketi/heketi v9.0.1-0.20190917153846-c2e2a4ab7ab9+incompatible
+
+replace github.com/ishidawataru/sctp => github.com/ishidawataru/sctp v0.0.0-20190723014705-7c296d48a2b5
+
+replace github.com/json-iterator/go => github.com/json-iterator/go v1.1.10
+
+replace github.com/libopenstorage/openstorage => github.com/libopenstorage/openstorage v1.0.0
+
+replace github.com/lithammer/dedent => github.com/lithammer/dedent v1.1.0
+
+replace github.com/miekg/dns => github.com/miekg/dns v1.1.4
+
+replace github.com/moby/ipvs => github.com/moby/ipvs v1.0.1
+
+replace github.com/mrunalp/fileutils => github.com/mrunalp/fileutils v0.0.0-20200520151820-abd8a0e76976
+
+replace github.com/munnerz/goautoneg => github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822
+
+replace github.com/mvdan/xurls => github.com/mvdan/xurls v1.1.0
+
+replace github.com/onsi/ginkgo => github.com/onsi/ginkgo v1.11.0
+
+replace github.com/onsi/gomega => github.com/onsi/gomega v1.7.0
+
+replace github.com/opencontainers/go-digest => github.com/opencontainers/go-digest v1.0.0-rc1
+
+replace github.com/opencontainers/runc => github.com/opencontainers/runc v1.0.1
+
+replace github.com/opencontainers/selinux => github.com/opencontainers/selinux v1.5.2
+
+replace github.com/pkg/errors => github.com/pkg/errors v0.9.1
+
+replace github.com/pmezard/go-difflib => github.com/pmezard/go-difflib v1.0.0
+
+replace github.com/prometheus/client_golang => github.com/prometheus/client_golang v1.7.1
+
+replace github.com/prometheus/client_model => github.com/prometheus/client_model v0.2.0
+
+replace github.com/prometheus/common => github.com/prometheus/common v0.10.0
+
+replace github.com/quobyte/api => github.com/quobyte/api v0.1.2
+
+replace github.com/robfig/cron => github.com/robfig/cron v1.1.0
+
+replace github.com/spf13/afero => github.com/spf13/afero v1.2.2
+
+replace github.com/spf13/cobra => github.com/spf13/cobra v1.0.0
+
+replace github.com/spf13/pflag => github.com/spf13/pflag v1.0.5
+
+replace github.com/spf13/viper => github.com/spf13/viper v1.4.0
+
+replace github.com/storageos/go-api => github.com/storageos/go-api v0.0.0-20180912212459-343b3eff91fc
+
+replace github.com/stretchr/testify => github.com/stretchr/testify v1.4.0
+
+replace github.com/thecodeteam/goscaleio => github.com/thecodeteam/goscaleio v0.1.0
+
+replace github.com/vishvananda/netlink => github.com/vishvananda/netlink v1.1.0
+
+replace github.com/vmware/govmomi => github.com/vmware/govmomi v0.20.3
+
+replace go.etcd.io/etcd => go.etcd.io/etcd v0.5.0-alpha.5.0.20200819165624-17cef6e3e9d5
+
+replace golang.org/x/crypto => golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9
+
+replace golang.org/x/net => golang.org/x/net v0.0.0-20201110031124-69a78807bb2b
+
+replace golang.org/x/oauth2 => golang.org/x/oauth2 v0.0.0-20191202225959-858c2ad4c8b6
+
+replace golang.org/x/sys => golang.org/x/sys v0.0.0-20201112073958-5cba982894dd
+
+replace golang.org/x/time => golang.org/x/time v0.0.0-20191024005414-555d28b269f0
+
+replace golang.org/x/tools => golang.org/x/tools v0.0.0-20210106214847-113979e3529a
+
+replace gonum.org/v1/gonum => gonum.org/v1/gonum v0.6.2
+
+replace google.golang.org/api => google.golang.org/api v0.15.1
+
+replace google.golang.org/grpc => google.golang.org/grpc v1.27.0
+
+replace gopkg.in/gcfg.v1 => gopkg.in/gcfg.v1 v1.2.0
+
+replace gopkg.in/square/go-jose.v2 => gopkg.in/square/go-jose.v2 v2.2.2
+
+replace gopkg.in/yaml.v2 => gopkg.in/yaml.v2 v2.2.8
+
+replace k8s.io/gengo => k8s.io/gengo v0.0.0-20200428234225-8167cfdcfc14
+
+replace k8s.io/heapster => k8s.io/heapster v1.2.0-beta.1
+
+replace k8s.io/klog/v2 => k8s.io/klog/v2 v2.2.0
+
+replace k8s.io/kube-openapi => k8s.io/kube-openapi v0.0.0-20200805222855-6aeccd4b50c6
+
+replace k8s.io/system-validators => k8s.io/system-validators v1.1.2
+
+replace k8s.io/utils => k8s.io/utils v0.0.0-20200729134348-d5654de09c73
+
+replace sigs.k8s.io/kustomize => sigs.k8s.io/kustomize v2.0.3+incompatible
+
+replace sigs.k8s.io/yaml => sigs.k8s.io/yaml v1.2.0
+
+replace cloud.google.com/go => cloud.google.com/go v0.51.0
+
+replace cloud.google.com/go/bigquery => cloud.google.com/go/bigquery v1.0.1
+
+replace cloud.google.com/go/datastore => cloud.google.com/go/datastore v1.0.0
+
+replace cloud.google.com/go/pubsub => cloud.google.com/go/pubsub v1.0.1
+
+replace cloud.google.com/go/storage => cloud.google.com/go/storage v1.0.0
+
+replace dmitri.shuralyov.com/gpu/mtl => dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9
+
+replace github.com/Azure/go-ansiterm => github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78
+
+replace github.com/Azure/go-autorest/autorest/date => github.com/Azure/go-autorest/autorest/date v0.2.0
+
+replace github.com/Azure/go-autorest/autorest/mocks => github.com/Azure/go-autorest/autorest/mocks v0.3.0
+
+replace github.com/Azure/go-autorest/autorest/validation => github.com/Azure/go-autorest/autorest/validation v0.1.0
+
+replace github.com/Azure/go-autorest/logger => github.com/Azure/go-autorest/logger v0.1.0
+
+replace github.com/Azure/go-autorest/tracing => github.com/Azure/go-autorest/tracing v0.5.0
+
+replace github.com/BurntSushi/toml => github.com/BurntSushi/toml v0.3.1
+
+replace github.com/BurntSushi/xgb => github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802
+
+replace github.com/MakeNowJust/heredoc => github.com/MakeNowJust/heredoc v0.0.0-20170808103936-bb23615498cd
+
+replace github.com/NYTimes/gziphandler => github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46
+
+replace github.com/PuerkitoBio/urlesc => github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578
+
+replace github.com/agnivade/levenshtein => github.com/agnivade/levenshtein v1.0.1
+
+replace github.com/ajstarks/svgo => github.com/ajstarks/svgo v0.0.0-20180226025133-644b8db467af
+
+replace github.com/alecthomas/template => github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751
+
+replace github.com/alecthomas/units => github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4
+
+replace github.com/andreyvit/diff => github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883
+
+replace github.com/armon/consul-api => github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6
+
+replace github.com/asaskevich/govalidator => github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a
+
+replace github.com/beorn7/perks => github.com/beorn7/perks v1.0.1
+
+replace github.com/bgentry/speakeasy => github.com/bgentry/speakeasy v0.1.0
+
+replace github.com/bifurcation/mint => github.com/bifurcation/mint v0.0.0-20180715133206-93c51c6ce115
+
+replace github.com/cenkalti/backoff => github.com/cenkalti/backoff v2.1.1+incompatible
+
+replace github.com/census-instrumentation/opencensus-proto => github.com/census-instrumentation/opencensus-proto v0.2.1
+
+replace github.com/cespare/xxhash/v2 => github.com/cespare/xxhash/v2 v2.1.1
+
+replace github.com/chai2010/gettext-go => github.com/chai2010/gettext-go v0.0.0-20160711120539-c6fed771bfd5
+
+replace github.com/checkpoint-restore/go-criu/v4 => github.com/checkpoint-restore/go-criu/v4 v4.0.2
+
+replace github.com/cheekybits/genny => github.com/cheekybits/genny v0.0.0-20170328200008-9127e812e1e9
+
+replace github.com/chzyer/logex => github.com/chzyer/logex v1.1.10
+
+replace github.com/chzyer/readline => github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e
+
+replace github.com/chzyer/test => github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1
+
+replace github.com/cilium/ebpf => github.com/cilium/ebpf v0.0.0-20200702112145-1c8d4c9ef775
+
+replace github.com/cockroachdb/datadriven => github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa
+
+replace github.com/containerd/cgroups => github.com/containerd/cgroups v0.0.0-20200531161412-0dbf7f05ba59
+
+replace github.com/containerd/console => github.com/containerd/console v1.0.0
+
+replace github.com/containerd/containerd => github.com/containerd/containerd v1.3.3
+
+replace github.com/containerd/continuity => github.com/containerd/continuity v0.0.0-20190426062206-aaeac12a7ffc
+
+replace github.com/containerd/fifo => github.com/containerd/fifo v0.0.0-20190226154929-a9fb20d87448
+
+replace github.com/containerd/go-runc => github.com/containerd/go-runc v0.0.0-20180907222934-5a6d9f37cfa3
+
+replace github.com/containerd/ttrpc => github.com/containerd/ttrpc v1.0.0
+
+replace github.com/containerd/typeurl => github.com/containerd/typeurl v1.0.0
+
+replace github.com/coreos/bbolt => github.com/coreos/bbolt v1.3.2
+
+replace github.com/coreos/etcd => github.com/coreos/etcd v3.3.10+incompatible
+
+replace github.com/coreos/go-semver => github.com/coreos/go-semver v0.3.0
+
+replace github.com/coreos/go-systemd/v22 => github.com/coreos/go-systemd/v22 v22.1.0
+
+replace github.com/creack/pty => github.com/creack/pty v1.1.7
+
+replace github.com/cyphar/filepath-securejoin => github.com/cyphar/filepath-securejoin v0.2.2
+
+replace github.com/daviddengcn/go-colortext => github.com/daviddengcn/go-colortext v0.0.0-20160507010035-511bcaf42ccd
+
+replace github.com/dgrijalva/jwt-go => github.com/dgrijalva/jwt-go v3.2.0+incompatible
+
+replace github.com/dnaeon/go-vcr => github.com/dnaeon/go-vcr v1.0.1
+
+replace github.com/docker/spdystream => github.com/docker/spdystream v0.0.0-20160310174837-449fdfce4d96
+
+replace github.com/docopt/docopt-go => github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815
+
+replace github.com/dustin/go-humanize => github.com/dustin/go-humanize v1.0.0
+
+replace github.com/envoyproxy/go-control-plane => github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473
+
+replace github.com/envoyproxy/protoc-gen-validate => github.com/envoyproxy/protoc-gen-validate v0.1.0
+
+replace github.com/euank/go-kmsg-parser => github.com/euank/go-kmsg-parser v2.0.0+incompatible
+
+replace github.com/exponent-io/jsonpath => github.com/exponent-io/jsonpath v0.0.0-20151013193312-d6023ce2651d
+
+replace github.com/fatih/camelcase => github.com/fatih/camelcase v1.0.0
+
+replace github.com/fatih/color => github.com/fatih/color v1.7.0
+
+replace github.com/flynn/go-shlex => github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568
+
+replace github.com/fogleman/gg => github.com/fogleman/gg v1.2.1-0.20190220221249-0403632d5b90
+
+replace github.com/ghodss/yaml => github.com/ghodss/yaml v1.0.0
+
+replace github.com/go-acme/lego => github.com/go-acme/lego v2.5.0+incompatible
+
+replace github.com/go-gl/glfw/v3.3/glfw => github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72
+
+replace github.com/go-ini/ini => github.com/go-ini/ini v1.9.0
+
+replace github.com/go-kit/kit => github.com/go-kit/kit v0.9.0
+
+replace github.com/go-logfmt/logfmt => github.com/go-logfmt/logfmt v0.4.0
+
+replace github.com/go-logr/logr => github.com/go-logr/logr v0.2.0
+
+replace github.com/go-openapi/errors => github.com/go-openapi/errors v0.19.2
+
+replace github.com/go-openapi/jsonpointer => github.com/go-openapi/jsonpointer v0.19.3
+
+replace github.com/go-openapi/jsonreference => github.com/go-openapi/jsonreference v0.19.3
+
+replace github.com/go-openapi/runtime => github.com/go-openapi/runtime v0.19.4
+
+replace github.com/go-openapi/swag => github.com/go-openapi/swag v0.19.5
+
+replace github.com/go-stack/stack => github.com/go-stack/stack v1.8.0
+
+replace github.com/godbus/dbus/v5 => github.com/godbus/dbus/v5 v5.0.3
+
+replace github.com/golang/freetype => github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0
+
+replace github.com/golang/glog => github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
+
+replace github.com/golang/protobuf => github.com/golang/protobuf v1.4.2
+
+replace github.com/golangplus/bytes => github.com/golangplus/bytes v0.0.0-20160111154220-45c989fe5450
+
+replace github.com/golangplus/fmt => github.com/golangplus/fmt v0.0.0-20150411045040-2a5d6d7d2995
+
+replace github.com/golangplus/testing => github.com/golangplus/testing v0.0.0-20180327235837-af21d9c3145e
+
+replace github.com/google/btree => github.com/google/btree v1.0.0
+
+replace github.com/google/martian => github.com/google/martian v2.1.0+incompatible
+
+replace github.com/google/pprof => github.com/google/pprof v0.0.0-20191218002539-d4f498aebedc
+
+replace github.com/google/renameio => github.com/google/renameio v0.1.0
+
+replace github.com/googleapis/gax-go/v2 => github.com/googleapis/gax-go/v2 v2.0.5
+
+replace github.com/gophercloud/gophercloud => github.com/gophercloud/gophercloud v0.1.0
+
+replace github.com/gopherjs/gopherjs => github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1
+
+replace github.com/gorilla/mux => github.com/gorilla/mux v1.7.3
+
+replace github.com/gorilla/websocket => github.com/gorilla/websocket v1.4.0
+
+replace github.com/gregjones/httpcache => github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7
+
+replace github.com/grpc-ecosystem/go-grpc-middleware => github.com/grpc-ecosystem/go-grpc-middleware v1.0.1-0.20190118093823-f849b5445de4
+
+replace github.com/grpc-ecosystem/go-grpc-prometheus => github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0
+
+replace github.com/grpc-ecosystem/grpc-gateway => github.com/grpc-ecosystem/grpc-gateway v1.9.5
+
+replace github.com/hashicorp/go-syslog => github.com/hashicorp/go-syslog v1.0.0
+
+replace github.com/hashicorp/hcl => github.com/hashicorp/hcl v1.0.0
+
+replace github.com/hpcloud/tail => github.com/hpcloud/tail v1.0.0
+
+replace github.com/ianlancetaylor/demangle => github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6
+
+replace github.com/imdario/mergo => github.com/imdario/mergo v0.3.5
+
+replace github.com/inconshreveable/mousetrap => github.com/inconshreveable/mousetrap v1.0.0
+
+replace github.com/jimstudt/http-authentication => github.com/jimstudt/http-authentication v0.0.0-20140401203705-3eca13d6893a
+
+replace github.com/jmespath/go-jmespath => github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af
+
+replace github.com/jonboulle/clockwork => github.com/jonboulle/clockwork v0.1.0
+
+replace github.com/jstemmer/go-junit-report => github.com/jstemmer/go-junit-report v0.9.1
+
+replace github.com/jtolds/gls => github.com/jtolds/gls v4.20.0+incompatible
+
+replace github.com/julienschmidt/httprouter => github.com/julienschmidt/httprouter v1.2.0
+
+replace github.com/jung-kurt/gofpdf => github.com/jung-kurt/gofpdf v1.0.3-0.20190309125859-24315acbbda5
+
+replace github.com/karrick/godirwalk => github.com/karrick/godirwalk v1.7.5
+
+replace github.com/kisielk/errcheck => github.com/kisielk/errcheck v1.5.0
+
+replace github.com/kisielk/gotool => github.com/kisielk/gotool v1.0.0
+
+replace github.com/klauspost/cpuid => github.com/klauspost/cpuid v1.2.0
+
+replace github.com/konsorten/go-windows-terminal-sequences => github.com/konsorten/go-windows-terminal-sequences v1.0.3
+
+replace github.com/kr/logfmt => github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515
+
+replace github.com/kr/pretty => github.com/kr/pretty v0.2.0
+
+replace github.com/kr/pty => github.com/kr/pty v1.1.5
+
+replace github.com/kr/text => github.com/kr/text v0.1.0
+
+replace github.com/kylelemons/godebug => github.com/kylelemons/godebug v0.0.0-20170820004349-d65d576e9348
+
+replace github.com/liggitt/tabwriter => github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de
+
+replace github.com/lucas-clemente/aes12 => github.com/lucas-clemente/aes12 v0.0.0-20171027163421-cd47fb39b79f
+
+replace github.com/lucas-clemente/quic-clients => github.com/lucas-clemente/quic-clients v0.1.0
+
+replace github.com/lucas-clemente/quic-go => github.com/lucas-clemente/quic-go v0.10.2
+
+replace github.com/lucas-clemente/quic-go-certificates => github.com/lucas-clemente/quic-go-certificates v0.0.0-20160823095156-d2f86524cced
+
+replace github.com/mailru/easyjson => github.com/mailru/easyjson v0.7.0
+
+replace github.com/marten-seemann/qtls => github.com/marten-seemann/qtls v0.2.3
+
+replace github.com/mattn/go-colorable => github.com/mattn/go-colorable v0.0.9
+
+replace github.com/mattn/go-isatty => github.com/mattn/go-isatty v0.0.4
+
+replace github.com/mattn/go-runewidth => github.com/mattn/go-runewidth v0.0.2
+
+replace github.com/matttproud/golang_protobuf_extensions => github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369
+
+replace github.com/mholt/certmagic => github.com/mholt/certmagic v0.6.2-0.20190624175158-6a42ef9fe8c2
+
+replace github.com/mindprince/gonvml => github.com/mindprince/gonvml v0.0.0-20190828220739-9ebdce4bb989
+
+replace github.com/mistifyio/go-zfs => github.com/mistifyio/go-zfs v2.1.2-0.20190413222219-f784269be439+incompatible
+
+replace github.com/mitchellh/go-homedir => github.com/mitchellh/go-homedir v1.1.0
+
+replace github.com/mitchellh/go-wordwrap => github.com/mitchellh/go-wordwrap v1.0.0
+
+replace github.com/mitchellh/mapstructure => github.com/mitchellh/mapstructure v1.1.2
+
+replace github.com/moby/sys/mountinfo => github.com/moby/sys/mountinfo v0.1.3
+
+replace github.com/moby/term => github.com/moby/term v0.0.0-20200312100748-672ec06f55cd
+
+replace github.com/modern-go/concurrent => github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd
+
+replace github.com/modern-go/reflect2 => github.com/modern-go/reflect2 v1.0.1
+
+replace github.com/morikuni/aec => github.com/morikuni/aec v1.0.0
+
+replace github.com/mwitkow/go-conntrack => github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223
+
+replace github.com/mxk/go-flowrate => github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f
+
+replace github.com/naoina/go-stringutil => github.com/naoina/go-stringutil v0.1.0
+
+replace github.com/naoina/toml => github.com/naoina/toml v0.1.1
+
+replace github.com/olekukonko/tablewriter => github.com/olekukonko/tablewriter v0.0.0-20170122224234-a0225b3f23b5
+
+replace github.com/opencontainers/image-spec => github.com/opencontainers/image-spec v1.0.1
+
+replace github.com/opencontainers/runtime-spec => github.com/opencontainers/runtime-spec v1.0.3-0.20200520003142-237cc4f519e2
+
+replace github.com/pelletier/go-toml => github.com/pelletier/go-toml v1.2.0
+
+replace github.com/peterbourgon/diskv => github.com/peterbourgon/diskv v2.0.1+incompatible
+
+replace github.com/pquerna/cachecontrol => github.com/pquerna/cachecontrol v0.0.0-20171018203845-0dec1b30a021
+
+replace github.com/prometheus/procfs => github.com/prometheus/procfs v0.1.3
+
+replace github.com/remyoudompheng/bigfft => github.com/remyoudompheng/bigfft v0.0.0-20170806203942-52369c62f446
+
+replace github.com/rogpeppe/fastuuid => github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af
+
+replace github.com/rogpeppe/go-internal => github.com/rogpeppe/go-internal v1.3.0
+
+replace github.com/rubiojr/go-vhd => github.com/rubiojr/go-vhd v0.0.0-20200706105327-02e210299021
+
+replace github.com/russross/blackfriday => github.com/russross/blackfriday v1.5.2
+
+replace github.com/russross/blackfriday/v2 => github.com/russross/blackfriday/v2 v2.0.1
+
+replace github.com/satori/go.uuid => github.com/satori/go.uuid v1.2.0
+
+replace github.com/seccomp/libseccomp-golang => github.com/seccomp/libseccomp-golang v0.9.1
+
+replace github.com/sergi/go-diff => github.com/sergi/go-diff v1.0.0
+
+replace github.com/shurcooL/sanitized_anchor_name => github.com/shurcooL/sanitized_anchor_name v1.0.0
+
+replace github.com/sirupsen/logrus => github.com/sirupsen/logrus v1.6.0
+
+replace github.com/smartystreets/assertions => github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d
+
+replace github.com/smartystreets/goconvey => github.com/smartystreets/goconvey v1.6.4
+
+replace github.com/soheilhy/cmux => github.com/soheilhy/cmux v0.1.4
+
+replace github.com/spf13/cast => github.com/spf13/cast v1.3.0
+
+replace github.com/stretchr/objx => github.com/stretchr/objx v0.2.0
+
+replace github.com/syndtr/gocapability => github.com/syndtr/gocapability v0.0.0-20180916011248-d98352740cb2
+
+replace github.com/tidwall/pretty => github.com/tidwall/pretty v1.0.0
+
+replace github.com/tmc/grpc-websocket-proxy => github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5
+
+replace github.com/ugorji/go => github.com/ugorji/go v1.1.4
+
+replace github.com/urfave/cli => github.com/urfave/cli v1.22.2
+
+replace github.com/vektah/gqlparser => github.com/vektah/gqlparser v1.1.2
+
+replace github.com/vishvananda/netns => github.com/vishvananda/netns v0.0.0-20200520041808-52d707b772fe
+
+replace github.com/xiang90/probing => github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2
+
+replace github.com/xlab/handysort => github.com/xlab/handysort v0.0.0-20150421192137-fb3537ed64a1
+
+replace github.com/xordataexchange/crypt => github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77
+
+replace github.com/yuin/goldmark => github.com/yuin/goldmark v1.2.1
+
+replace go.etcd.io/bbolt => go.etcd.io/bbolt v1.3.5
+
+replace go.mongodb.org/mongo-driver => go.mongodb.org/mongo-driver v1.1.2
+
+replace go.opencensus.io => go.opencensus.io v0.22.2
+
+replace go.uber.org/atomic => go.uber.org/atomic v1.4.0
+
+replace go.uber.org/multierr => go.uber.org/multierr v1.1.0
+
+replace go.uber.org/zap => go.uber.org/zap v1.10.0
+
+replace golang.org/x/exp => golang.org/x/exp v0.0.0-20191227195350-da58074b4299
+
+replace golang.org/x/image => golang.org/x/image v0.0.0-20190802002840-cff245a6509b
+
+replace golang.org/x/lint => golang.org/x/lint v0.0.0-20191125180803-fdd1cda4f05f
+
+replace golang.org/x/mobile => golang.org/x/mobile v0.0.0-20190719004257-d2bd2a29d028
+
+replace golang.org/x/mod => golang.org/x/mod v0.3.0
+
+replace golang.org/x/sync => golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9
+
+replace golang.org/x/text => golang.org/x/text v0.3.3
+
+replace golang.org/x/xerrors => golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1
+
+replace gonum.org/v1/plot => gonum.org/v1/plot v0.0.0-20190515093506-e2840ee46a6b
+
+replace google.golang.org/appengine => google.golang.org/appengine v1.6.5
+
+replace google.golang.org/genproto => google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013
+
+replace google.golang.org/protobuf => google.golang.org/protobuf v1.24.0
+
+replace gopkg.in/alecthomas/kingpin.v2 => gopkg.in/alecthomas/kingpin.v2 v2.2.6
+
+replace gopkg.in/check.v1 => gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15
+
+replace gopkg.in/cheggaaa/pb.v1 => gopkg.in/cheggaaa/pb.v1 v1.0.25
+
+replace gopkg.in/errgo.v2 => gopkg.in/errgo.v2 v2.1.0
+
+replace gopkg.in/fsnotify.v1 => gopkg.in/fsnotify.v1 v1.4.7
+
+replace gopkg.in/inf.v0 => gopkg.in/inf.v0 v0.9.1
+
+replace gopkg.in/mcuadros/go-syslog.v2 => gopkg.in/mcuadros/go-syslog.v2 v2.2.1
+
+replace gopkg.in/natefinch/lumberjack.v2 => gopkg.in/natefinch/lumberjack.v2 v2.0.0
+
+replace gopkg.in/resty.v1 => gopkg.in/resty.v1 v1.12.0
+
+replace gopkg.in/tomb.v1 => gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7
+
+replace gopkg.in/warnings.v0 => gopkg.in/warnings.v0 v0.1.1
+
+replace gotest.tools => gotest.tools v2.2.0+incompatible
+
+replace gotest.tools/v3 => gotest.tools/v3 v3.0.2
+
+replace honnef.co/go/tools => honnef.co/go/tools v0.0.1-2019.2.3
+
+replace modernc.org/cc => modernc.org/cc v1.0.0
+
+replace modernc.org/golex => modernc.org/golex v1.0.0
+
+replace modernc.org/mathutil => modernc.org/mathutil v1.0.0
+
+replace modernc.org/strutil => modernc.org/strutil v1.0.0
+
+replace modernc.org/xc => modernc.org/xc v1.0.0
+
+replace rsc.io/pdf => rsc.io/pdf v0.1.1
+
+replace sigs.k8s.io/apiserver-network-proxy/konnectivity-client => sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.15
+
+replace sigs.k8s.io/structured-merge-diff/v4 => sigs.k8s.io/structured-merge-diff/v4 v4.1.2
+
+replace vbom.ml/util => vbom.ml/util v0.0.0-20160121211510-db5cfe13f5cc

--- a/staging/src/k8s.io/cloud-provider/go.mod
+++ b/staging/src/k8s.io/cloud-provider/go.mod
@@ -5,14 +5,120 @@ module k8s.io/cloud-provider
 go 1.15
 
 require (
+	bitbucket.org/bertimus9/systemstat v0.0.0-20180207000608-0eeff89b0690
+	github.com/Azure/azure-sdk-for-go v43.0.0+incompatible
+	github.com/Azure/go-autorest/autorest v0.9.6
+	github.com/Azure/go-autorest/autorest/adal v0.8.2
+	github.com/Azure/go-autorest/autorest/to v0.2.0
+	github.com/GoogleCloudPlatform/k8s-cloud-provider v0.0.0-20200415212048-7901bc822317
+	github.com/JeffAshton/win_pdh v0.0.0-20161109143554-76bb4ee9f0ab
+	github.com/Microsoft/go-winio v0.4.15-0.20190919025122-fc70bd9a86b5
+	github.com/Microsoft/hcsshim v0.8.10-0.20200715222032-5eafd1556990
+	github.com/PuerkitoBio/purell v1.1.1
+	github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e
+	github.com/auth0/go-jwt-middleware v0.0.0-20170425171159-5493cabe49f7
+	github.com/aws/aws-sdk-go v1.28.2
+	github.com/blang/semver v3.5.0+incompatible
+	github.com/boltdb/bolt v1.3.1
+	github.com/caddyserver/caddy v1.0.3
+	github.com/clusterhq/flocker-go v0.0.0-20160920122132-2b8b7259d313
+	github.com/codegangsta/negroni v1.0.0
+	github.com/container-storage-interface/spec v1.2.0
+	github.com/containernetworking/cni v0.8.0
+	github.com/coredns/corefile-migration v1.0.10
+	github.com/coreos/go-oidc v2.1.0+incompatible
+	github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e
+	github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f
+	github.com/cpuguy83/go-md2man/v2 v2.0.0
+	github.com/davecgh/go-spew v1.1.1
+	github.com/docker/distribution v2.7.1+incompatible
+	github.com/docker/docker v1.4.2-0.20200309214505-aa6a9891b09c
+	github.com/docker/go-connections v0.4.0
+	github.com/docker/go-units v0.4.0
+	github.com/elazarl/goproxy v0.0.0-20180725130230-947c36da3153
+	github.com/emicklei/go-restful v2.9.5+incompatible
+	github.com/evanphx/json-patch v4.9.0+incompatible
+	github.com/fsnotify/fsnotify v1.4.9
+	github.com/go-bindata/go-bindata v3.1.1+incompatible
+	github.com/go-openapi/analysis v0.19.5
+	github.com/go-openapi/loads v0.19.4
+	github.com/go-openapi/spec v0.19.3
+	github.com/go-openapi/strfmt v0.19.3
+	github.com/go-openapi/validate v0.19.5
+	github.com/go-ozzo/ozzo-validation v3.5.0+incompatible
+	github.com/gogo/protobuf v1.3.2
+	github.com/golang/groupcache v0.0.0-20191227052852-215e87163ea7
+	github.com/golang/mock v1.3.1
+	github.com/google/cadvisor v0.37.5
 	github.com/google/go-cmp v0.4.0
+	github.com/google/gofuzz v1.1.0
+	github.com/google/uuid v1.1.1
+	github.com/googleapis/gnostic v0.4.1
+	github.com/gorilla/context v1.1.1
+	github.com/hashicorp/golang-lru v0.5.1
+	github.com/heketi/heketi v9.0.1-0.20190917153846-c2e2a4ab7ab9+incompatible
+	github.com/heketi/tests v0.0.0-20151005000721-f3775cbcefd6
+	github.com/ishidawataru/sctp v0.0.0-20190723014705-7c296d48a2b5
+	github.com/json-iterator/go v1.1.10
+	github.com/libopenstorage/openstorage v1.0.0
+	github.com/lithammer/dedent v1.1.0
+	github.com/lpabon/godbc v0.1.1
+	github.com/magiconair/properties v1.8.1
+	github.com/miekg/dns v1.1.4
+	github.com/moby/ipvs v1.0.1
+	github.com/mohae/deepcopy v0.0.0-20170603005431-491d3605edfb
+	github.com/mrunalp/fileutils v0.0.0-20200520151820-abd8a0e76976
+	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822
+	github.com/mvdan/xurls v1.1.0
+	github.com/onsi/ginkgo v1.11.0
+	github.com/onsi/gomega v1.7.0
+	github.com/opencontainers/go-digest v1.0.0-rc1
+	github.com/opencontainers/runc v1.0.1
+	github.com/opencontainers/selinux v1.5.2
+	github.com/pkg/errors v0.9.1
+	github.com/pmezard/go-difflib v1.0.0
+	github.com/prometheus/client_golang v1.7.1
+	github.com/prometheus/client_model v0.2.0
+	github.com/prometheus/common v0.10.0
+	github.com/quobyte/api v0.1.2
+	github.com/robfig/cron v1.1.0
+	github.com/spf13/afero v1.2.2
+	github.com/spf13/cobra v1.0.0
+	github.com/spf13/jwalterweatherman v1.1.0
+	github.com/spf13/pflag v1.0.5
+	github.com/spf13/viper v1.4.0
+	github.com/storageos/go-api v0.0.0-20180912212459-343b3eff91fc
 	github.com/stretchr/testify v1.4.0
+	github.com/thecodeteam/goscaleio v0.1.0
+	github.com/urfave/negroni v1.0.0
+	github.com/vishvananda/netlink v1.1.0
+	github.com/vmware/govmomi v0.20.3
+	go.etcd.io/etcd v0.5.0-alpha.5.0.20200819165624-17cef6e3e9d5
+	golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9
+	golang.org/x/net v0.0.0-20201110031124-69a78807bb2b
+	golang.org/x/oauth2 v0.0.0-20191202225959-858c2ad4c8b6
+	golang.org/x/sys v0.0.0-20201112073958-5cba982894dd
+	golang.org/x/time v0.0.0-20191024005414-555d28b269f0
+	golang.org/x/tools v0.0.0-20210106214847-113979e3529a
+	gonum.org/v1/gonum v0.6.2
+	gonum.org/v1/netlib v0.0.0-20190331212654-76723241ea4e
+	google.golang.org/api v0.15.1
+	google.golang.org/grpc v1.27.0
+	gopkg.in/gcfg.v1 v1.2.0
+	gopkg.in/square/go-jose.v2 v2.2.2
+	gopkg.in/yaml.v2 v2.2.8
 	k8s.io/api v0.0.0
 	k8s.io/apimachinery v0.0.0
 	k8s.io/client-go v0.0.0
 	k8s.io/component-base v0.0.0
+	k8s.io/gengo v0.0.0-20200428234225-8167cfdcfc14
+	k8s.io/heapster v1.2.0-beta.1
 	k8s.io/klog/v2 v2.2.0
+	k8s.io/kube-openapi v0.0.0-20200805222855-6aeccd4b50c6
+	k8s.io/system-validators v1.1.2
 	k8s.io/utils v0.0.0-20200729134348-d5654de09c73
+	sigs.k8s.io/kustomize v2.0.3+incompatible
+	sigs.k8s.io/yaml v1.2.0
 )
 
 replace (
@@ -22,3 +128,669 @@ replace (
 	k8s.io/cloud-provider => ../cloud-provider
 	k8s.io/component-base => ../component-base
 )
+
+replace github.com/auth0/go-jwt-middleware => github.com/auth0/go-jwt-middleware v0.0.0-20170425171159-5493cabe49f7
+
+replace github.com/boltdb/bolt => github.com/boltdb/bolt v1.3.1
+
+replace github.com/codegangsta/negroni => github.com/codegangsta/negroni v1.0.0
+
+replace github.com/go-ozzo/ozzo-validation => github.com/go-ozzo/ozzo-validation v3.5.0+incompatible
+
+replace github.com/gorilla/context => github.com/gorilla/context v1.1.1
+
+replace github.com/heketi/tests => github.com/heketi/tests v0.0.0-20151005000721-f3775cbcefd6
+
+replace github.com/lpabon/godbc => github.com/lpabon/godbc v0.1.1
+
+replace github.com/magiconair/properties => github.com/magiconair/properties v1.8.1
+
+replace github.com/mohae/deepcopy => github.com/mohae/deepcopy v0.0.0-20170603005431-491d3605edfb
+
+replace github.com/spf13/jwalterweatherman => github.com/spf13/jwalterweatherman v1.1.0
+
+replace github.com/urfave/negroni => github.com/urfave/negroni v1.0.0
+
+replace gonum.org/v1/netlib => gonum.org/v1/netlib v0.0.0-20190331212654-76723241ea4e
+
+replace bitbucket.org/bertimus9/systemstat => bitbucket.org/bertimus9/systemstat v0.0.0-20180207000608-0eeff89b0690
+
+replace github.com/Azure/azure-sdk-for-go => github.com/Azure/azure-sdk-for-go v43.0.0+incompatible
+
+replace github.com/Azure/go-autorest/autorest => github.com/Azure/go-autorest/autorest v0.9.6
+
+replace github.com/Azure/go-autorest/autorest/adal => github.com/Azure/go-autorest/autorest/adal v0.8.2
+
+replace github.com/Azure/go-autorest/autorest/to => github.com/Azure/go-autorest/autorest/to v0.2.0
+
+replace github.com/GoogleCloudPlatform/k8s-cloud-provider => github.com/GoogleCloudPlatform/k8s-cloud-provider v0.0.0-20200415212048-7901bc822317
+
+replace github.com/JeffAshton/win_pdh => github.com/JeffAshton/win_pdh v0.0.0-20161109143554-76bb4ee9f0ab
+
+replace github.com/Microsoft/go-winio => github.com/Microsoft/go-winio v0.4.15-0.20190919025122-fc70bd9a86b5
+
+replace github.com/Microsoft/hcsshim => github.com/Microsoft/hcsshim v0.8.10-0.20200715222032-5eafd1556990
+
+replace github.com/PuerkitoBio/purell => github.com/PuerkitoBio/purell v1.1.1
+
+replace github.com/armon/circbuf => github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e
+
+replace github.com/aws/aws-sdk-go => github.com/aws/aws-sdk-go v1.28.2
+
+replace github.com/blang/semver => github.com/blang/semver v3.5.0+incompatible
+
+replace github.com/caddyserver/caddy => github.com/caddyserver/caddy v1.0.3
+
+replace github.com/clusterhq/flocker-go => github.com/clusterhq/flocker-go v0.0.0-20160920122132-2b8b7259d313
+
+replace github.com/container-storage-interface/spec => github.com/container-storage-interface/spec v1.2.0
+
+replace github.com/containernetworking/cni => github.com/containernetworking/cni v0.8.0
+
+replace github.com/coredns/corefile-migration => github.com/coredns/corefile-migration v1.0.10
+
+replace github.com/coreos/go-oidc => github.com/coreos/go-oidc v2.1.0+incompatible
+
+replace github.com/coreos/go-systemd => github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e
+
+replace github.com/coreos/pkg => github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f
+
+replace github.com/cpuguy83/go-md2man/v2 => github.com/cpuguy83/go-md2man/v2 v2.0.0
+
+replace github.com/davecgh/go-spew => github.com/davecgh/go-spew v1.1.1
+
+replace github.com/docker/distribution => github.com/docker/distribution v2.7.1+incompatible
+
+replace github.com/docker/docker => github.com/docker/docker v1.4.2-0.20200309214505-aa6a9891b09c
+
+replace github.com/docker/go-connections => github.com/docker/go-connections v0.4.0
+
+replace github.com/docker/go-units => github.com/docker/go-units v0.4.0
+
+replace github.com/elazarl/goproxy => github.com/elazarl/goproxy v0.0.0-20180725130230-947c36da3153
+
+replace github.com/emicklei/go-restful => github.com/emicklei/go-restful v2.9.5+incompatible
+
+replace github.com/evanphx/json-patch => github.com/evanphx/json-patch v4.9.0+incompatible
+
+replace github.com/fsnotify/fsnotify => github.com/fsnotify/fsnotify v1.4.9
+
+replace github.com/go-bindata/go-bindata => github.com/go-bindata/go-bindata v3.1.1+incompatible
+
+replace github.com/go-openapi/analysis => github.com/go-openapi/analysis v0.19.5
+
+replace github.com/go-openapi/loads => github.com/go-openapi/loads v0.19.4
+
+replace github.com/go-openapi/spec => github.com/go-openapi/spec v0.19.3
+
+replace github.com/go-openapi/strfmt => github.com/go-openapi/strfmt v0.19.3
+
+replace github.com/go-openapi/validate => github.com/go-openapi/validate v0.19.5
+
+replace github.com/gogo/protobuf => github.com/gogo/protobuf v1.3.2
+
+replace github.com/golang/groupcache => github.com/golang/groupcache v0.0.0-20191227052852-215e87163ea7
+
+replace github.com/golang/mock => github.com/golang/mock v1.3.1
+
+replace github.com/google/cadvisor => github.com/google/cadvisor v0.37.5
+
+replace github.com/google/go-cmp => github.com/google/go-cmp v0.4.0
+
+replace github.com/google/gofuzz => github.com/google/gofuzz v1.1.0
+
+replace github.com/google/uuid => github.com/google/uuid v1.1.1
+
+replace github.com/googleapis/gnostic => github.com/googleapis/gnostic v0.4.1
+
+replace github.com/hashicorp/golang-lru => github.com/hashicorp/golang-lru v0.5.1
+
+replace github.com/heketi/heketi => github.com/heketi/heketi v9.0.1-0.20190917153846-c2e2a4ab7ab9+incompatible
+
+replace github.com/ishidawataru/sctp => github.com/ishidawataru/sctp v0.0.0-20190723014705-7c296d48a2b5
+
+replace github.com/json-iterator/go => github.com/json-iterator/go v1.1.10
+
+replace github.com/libopenstorage/openstorage => github.com/libopenstorage/openstorage v1.0.0
+
+replace github.com/lithammer/dedent => github.com/lithammer/dedent v1.1.0
+
+replace github.com/miekg/dns => github.com/miekg/dns v1.1.4
+
+replace github.com/moby/ipvs => github.com/moby/ipvs v1.0.1
+
+replace github.com/mrunalp/fileutils => github.com/mrunalp/fileutils v0.0.0-20200520151820-abd8a0e76976
+
+replace github.com/munnerz/goautoneg => github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822
+
+replace github.com/mvdan/xurls => github.com/mvdan/xurls v1.1.0
+
+replace github.com/onsi/ginkgo => github.com/onsi/ginkgo v1.11.0
+
+replace github.com/onsi/gomega => github.com/onsi/gomega v1.7.0
+
+replace github.com/opencontainers/go-digest => github.com/opencontainers/go-digest v1.0.0-rc1
+
+replace github.com/opencontainers/runc => github.com/opencontainers/runc v1.0.1
+
+replace github.com/opencontainers/selinux => github.com/opencontainers/selinux v1.5.2
+
+replace github.com/pkg/errors => github.com/pkg/errors v0.9.1
+
+replace github.com/pmezard/go-difflib => github.com/pmezard/go-difflib v1.0.0
+
+replace github.com/prometheus/client_golang => github.com/prometheus/client_golang v1.7.1
+
+replace github.com/prometheus/client_model => github.com/prometheus/client_model v0.2.0
+
+replace github.com/prometheus/common => github.com/prometheus/common v0.10.0
+
+replace github.com/quobyte/api => github.com/quobyte/api v0.1.2
+
+replace github.com/robfig/cron => github.com/robfig/cron v1.1.0
+
+replace github.com/spf13/afero => github.com/spf13/afero v1.2.2
+
+replace github.com/spf13/cobra => github.com/spf13/cobra v1.0.0
+
+replace github.com/spf13/pflag => github.com/spf13/pflag v1.0.5
+
+replace github.com/spf13/viper => github.com/spf13/viper v1.4.0
+
+replace github.com/storageos/go-api => github.com/storageos/go-api v0.0.0-20180912212459-343b3eff91fc
+
+replace github.com/stretchr/testify => github.com/stretchr/testify v1.4.0
+
+replace github.com/thecodeteam/goscaleio => github.com/thecodeteam/goscaleio v0.1.0
+
+replace github.com/vishvananda/netlink => github.com/vishvananda/netlink v1.1.0
+
+replace github.com/vmware/govmomi => github.com/vmware/govmomi v0.20.3
+
+replace go.etcd.io/etcd => go.etcd.io/etcd v0.5.0-alpha.5.0.20200819165624-17cef6e3e9d5
+
+replace golang.org/x/crypto => golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9
+
+replace golang.org/x/net => golang.org/x/net v0.0.0-20201110031124-69a78807bb2b
+
+replace golang.org/x/oauth2 => golang.org/x/oauth2 v0.0.0-20191202225959-858c2ad4c8b6
+
+replace golang.org/x/sys => golang.org/x/sys v0.0.0-20201112073958-5cba982894dd
+
+replace golang.org/x/time => golang.org/x/time v0.0.0-20191024005414-555d28b269f0
+
+replace golang.org/x/tools => golang.org/x/tools v0.0.0-20210106214847-113979e3529a
+
+replace gonum.org/v1/gonum => gonum.org/v1/gonum v0.6.2
+
+replace google.golang.org/api => google.golang.org/api v0.15.1
+
+replace google.golang.org/grpc => google.golang.org/grpc v1.27.0
+
+replace gopkg.in/gcfg.v1 => gopkg.in/gcfg.v1 v1.2.0
+
+replace gopkg.in/square/go-jose.v2 => gopkg.in/square/go-jose.v2 v2.2.2
+
+replace gopkg.in/yaml.v2 => gopkg.in/yaml.v2 v2.2.8
+
+replace k8s.io/gengo => k8s.io/gengo v0.0.0-20200428234225-8167cfdcfc14
+
+replace k8s.io/heapster => k8s.io/heapster v1.2.0-beta.1
+
+replace k8s.io/klog/v2 => k8s.io/klog/v2 v2.2.0
+
+replace k8s.io/kube-openapi => k8s.io/kube-openapi v0.0.0-20200805222855-6aeccd4b50c6
+
+replace k8s.io/system-validators => k8s.io/system-validators v1.1.2
+
+replace k8s.io/utils => k8s.io/utils v0.0.0-20200729134348-d5654de09c73
+
+replace sigs.k8s.io/kustomize => sigs.k8s.io/kustomize v2.0.3+incompatible
+
+replace sigs.k8s.io/yaml => sigs.k8s.io/yaml v1.2.0
+
+replace cloud.google.com/go => cloud.google.com/go v0.51.0
+
+replace cloud.google.com/go/bigquery => cloud.google.com/go/bigquery v1.0.1
+
+replace cloud.google.com/go/datastore => cloud.google.com/go/datastore v1.0.0
+
+replace cloud.google.com/go/pubsub => cloud.google.com/go/pubsub v1.0.1
+
+replace cloud.google.com/go/storage => cloud.google.com/go/storage v1.0.0
+
+replace dmitri.shuralyov.com/gpu/mtl => dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9
+
+replace github.com/Azure/go-ansiterm => github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78
+
+replace github.com/Azure/go-autorest/autorest/date => github.com/Azure/go-autorest/autorest/date v0.2.0
+
+replace github.com/Azure/go-autorest/autorest/mocks => github.com/Azure/go-autorest/autorest/mocks v0.3.0
+
+replace github.com/Azure/go-autorest/autorest/validation => github.com/Azure/go-autorest/autorest/validation v0.1.0
+
+replace github.com/Azure/go-autorest/logger => github.com/Azure/go-autorest/logger v0.1.0
+
+replace github.com/Azure/go-autorest/tracing => github.com/Azure/go-autorest/tracing v0.5.0
+
+replace github.com/BurntSushi/toml => github.com/BurntSushi/toml v0.3.1
+
+replace github.com/BurntSushi/xgb => github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802
+
+replace github.com/MakeNowJust/heredoc => github.com/MakeNowJust/heredoc v0.0.0-20170808103936-bb23615498cd
+
+replace github.com/NYTimes/gziphandler => github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46
+
+replace github.com/PuerkitoBio/urlesc => github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578
+
+replace github.com/agnivade/levenshtein => github.com/agnivade/levenshtein v1.0.1
+
+replace github.com/ajstarks/svgo => github.com/ajstarks/svgo v0.0.0-20180226025133-644b8db467af
+
+replace github.com/alecthomas/template => github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751
+
+replace github.com/alecthomas/units => github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4
+
+replace github.com/andreyvit/diff => github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883
+
+replace github.com/armon/consul-api => github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6
+
+replace github.com/asaskevich/govalidator => github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a
+
+replace github.com/beorn7/perks => github.com/beorn7/perks v1.0.1
+
+replace github.com/bgentry/speakeasy => github.com/bgentry/speakeasy v0.1.0
+
+replace github.com/bifurcation/mint => github.com/bifurcation/mint v0.0.0-20180715133206-93c51c6ce115
+
+replace github.com/cenkalti/backoff => github.com/cenkalti/backoff v2.1.1+incompatible
+
+replace github.com/census-instrumentation/opencensus-proto => github.com/census-instrumentation/opencensus-proto v0.2.1
+
+replace github.com/cespare/xxhash/v2 => github.com/cespare/xxhash/v2 v2.1.1
+
+replace github.com/chai2010/gettext-go => github.com/chai2010/gettext-go v0.0.0-20160711120539-c6fed771bfd5
+
+replace github.com/checkpoint-restore/go-criu/v4 => github.com/checkpoint-restore/go-criu/v4 v4.0.2
+
+replace github.com/cheekybits/genny => github.com/cheekybits/genny v0.0.0-20170328200008-9127e812e1e9
+
+replace github.com/chzyer/logex => github.com/chzyer/logex v1.1.10
+
+replace github.com/chzyer/readline => github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e
+
+replace github.com/chzyer/test => github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1
+
+replace github.com/cilium/ebpf => github.com/cilium/ebpf v0.0.0-20200702112145-1c8d4c9ef775
+
+replace github.com/cockroachdb/datadriven => github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa
+
+replace github.com/containerd/cgroups => github.com/containerd/cgroups v0.0.0-20200531161412-0dbf7f05ba59
+
+replace github.com/containerd/console => github.com/containerd/console v1.0.0
+
+replace github.com/containerd/containerd => github.com/containerd/containerd v1.3.3
+
+replace github.com/containerd/continuity => github.com/containerd/continuity v0.0.0-20190426062206-aaeac12a7ffc
+
+replace github.com/containerd/fifo => github.com/containerd/fifo v0.0.0-20190226154929-a9fb20d87448
+
+replace github.com/containerd/go-runc => github.com/containerd/go-runc v0.0.0-20180907222934-5a6d9f37cfa3
+
+replace github.com/containerd/ttrpc => github.com/containerd/ttrpc v1.0.0
+
+replace github.com/containerd/typeurl => github.com/containerd/typeurl v1.0.0
+
+replace github.com/coreos/bbolt => github.com/coreos/bbolt v1.3.2
+
+replace github.com/coreos/etcd => github.com/coreos/etcd v3.3.10+incompatible
+
+replace github.com/coreos/go-semver => github.com/coreos/go-semver v0.3.0
+
+replace github.com/coreos/go-systemd/v22 => github.com/coreos/go-systemd/v22 v22.1.0
+
+replace github.com/creack/pty => github.com/creack/pty v1.1.7
+
+replace github.com/cyphar/filepath-securejoin => github.com/cyphar/filepath-securejoin v0.2.2
+
+replace github.com/daviddengcn/go-colortext => github.com/daviddengcn/go-colortext v0.0.0-20160507010035-511bcaf42ccd
+
+replace github.com/dgrijalva/jwt-go => github.com/dgrijalva/jwt-go v3.2.0+incompatible
+
+replace github.com/dnaeon/go-vcr => github.com/dnaeon/go-vcr v1.0.1
+
+replace github.com/docker/spdystream => github.com/docker/spdystream v0.0.0-20160310174837-449fdfce4d96
+
+replace github.com/docopt/docopt-go => github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815
+
+replace github.com/dustin/go-humanize => github.com/dustin/go-humanize v1.0.0
+
+replace github.com/envoyproxy/go-control-plane => github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473
+
+replace github.com/envoyproxy/protoc-gen-validate => github.com/envoyproxy/protoc-gen-validate v0.1.0
+
+replace github.com/euank/go-kmsg-parser => github.com/euank/go-kmsg-parser v2.0.0+incompatible
+
+replace github.com/exponent-io/jsonpath => github.com/exponent-io/jsonpath v0.0.0-20151013193312-d6023ce2651d
+
+replace github.com/fatih/camelcase => github.com/fatih/camelcase v1.0.0
+
+replace github.com/fatih/color => github.com/fatih/color v1.7.0
+
+replace github.com/flynn/go-shlex => github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568
+
+replace github.com/fogleman/gg => github.com/fogleman/gg v1.2.1-0.20190220221249-0403632d5b90
+
+replace github.com/ghodss/yaml => github.com/ghodss/yaml v1.0.0
+
+replace github.com/go-acme/lego => github.com/go-acme/lego v2.5.0+incompatible
+
+replace github.com/go-gl/glfw/v3.3/glfw => github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72
+
+replace github.com/go-ini/ini => github.com/go-ini/ini v1.9.0
+
+replace github.com/go-kit/kit => github.com/go-kit/kit v0.9.0
+
+replace github.com/go-logfmt/logfmt => github.com/go-logfmt/logfmt v0.4.0
+
+replace github.com/go-logr/logr => github.com/go-logr/logr v0.2.0
+
+replace github.com/go-openapi/errors => github.com/go-openapi/errors v0.19.2
+
+replace github.com/go-openapi/jsonpointer => github.com/go-openapi/jsonpointer v0.19.3
+
+replace github.com/go-openapi/jsonreference => github.com/go-openapi/jsonreference v0.19.3
+
+replace github.com/go-openapi/runtime => github.com/go-openapi/runtime v0.19.4
+
+replace github.com/go-openapi/swag => github.com/go-openapi/swag v0.19.5
+
+replace github.com/go-stack/stack => github.com/go-stack/stack v1.8.0
+
+replace github.com/godbus/dbus/v5 => github.com/godbus/dbus/v5 v5.0.3
+
+replace github.com/golang/freetype => github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0
+
+replace github.com/golang/glog => github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
+
+replace github.com/golang/protobuf => github.com/golang/protobuf v1.4.2
+
+replace github.com/golangplus/bytes => github.com/golangplus/bytes v0.0.0-20160111154220-45c989fe5450
+
+replace github.com/golangplus/fmt => github.com/golangplus/fmt v0.0.0-20150411045040-2a5d6d7d2995
+
+replace github.com/golangplus/testing => github.com/golangplus/testing v0.0.0-20180327235837-af21d9c3145e
+
+replace github.com/google/btree => github.com/google/btree v1.0.0
+
+replace github.com/google/martian => github.com/google/martian v2.1.0+incompatible
+
+replace github.com/google/pprof => github.com/google/pprof v0.0.0-20191218002539-d4f498aebedc
+
+replace github.com/google/renameio => github.com/google/renameio v0.1.0
+
+replace github.com/googleapis/gax-go/v2 => github.com/googleapis/gax-go/v2 v2.0.5
+
+replace github.com/gophercloud/gophercloud => github.com/gophercloud/gophercloud v0.1.0
+
+replace github.com/gopherjs/gopherjs => github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1
+
+replace github.com/gorilla/mux => github.com/gorilla/mux v1.7.3
+
+replace github.com/gorilla/websocket => github.com/gorilla/websocket v1.4.0
+
+replace github.com/gregjones/httpcache => github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7
+
+replace github.com/grpc-ecosystem/go-grpc-middleware => github.com/grpc-ecosystem/go-grpc-middleware v1.0.1-0.20190118093823-f849b5445de4
+
+replace github.com/grpc-ecosystem/go-grpc-prometheus => github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0
+
+replace github.com/grpc-ecosystem/grpc-gateway => github.com/grpc-ecosystem/grpc-gateway v1.9.5
+
+replace github.com/hashicorp/go-syslog => github.com/hashicorp/go-syslog v1.0.0
+
+replace github.com/hashicorp/hcl => github.com/hashicorp/hcl v1.0.0
+
+replace github.com/hpcloud/tail => github.com/hpcloud/tail v1.0.0
+
+replace github.com/ianlancetaylor/demangle => github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6
+
+replace github.com/imdario/mergo => github.com/imdario/mergo v0.3.5
+
+replace github.com/inconshreveable/mousetrap => github.com/inconshreveable/mousetrap v1.0.0
+
+replace github.com/jimstudt/http-authentication => github.com/jimstudt/http-authentication v0.0.0-20140401203705-3eca13d6893a
+
+replace github.com/jmespath/go-jmespath => github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af
+
+replace github.com/jonboulle/clockwork => github.com/jonboulle/clockwork v0.1.0
+
+replace github.com/jstemmer/go-junit-report => github.com/jstemmer/go-junit-report v0.9.1
+
+replace github.com/jtolds/gls => github.com/jtolds/gls v4.20.0+incompatible
+
+replace github.com/julienschmidt/httprouter => github.com/julienschmidt/httprouter v1.2.0
+
+replace github.com/jung-kurt/gofpdf => github.com/jung-kurt/gofpdf v1.0.3-0.20190309125859-24315acbbda5
+
+replace github.com/karrick/godirwalk => github.com/karrick/godirwalk v1.7.5
+
+replace github.com/kisielk/errcheck => github.com/kisielk/errcheck v1.5.0
+
+replace github.com/kisielk/gotool => github.com/kisielk/gotool v1.0.0
+
+replace github.com/klauspost/cpuid => github.com/klauspost/cpuid v1.2.0
+
+replace github.com/konsorten/go-windows-terminal-sequences => github.com/konsorten/go-windows-terminal-sequences v1.0.3
+
+replace github.com/kr/logfmt => github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515
+
+replace github.com/kr/pretty => github.com/kr/pretty v0.2.0
+
+replace github.com/kr/pty => github.com/kr/pty v1.1.5
+
+replace github.com/kr/text => github.com/kr/text v0.1.0
+
+replace github.com/kylelemons/godebug => github.com/kylelemons/godebug v0.0.0-20170820004349-d65d576e9348
+
+replace github.com/liggitt/tabwriter => github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de
+
+replace github.com/lucas-clemente/aes12 => github.com/lucas-clemente/aes12 v0.0.0-20171027163421-cd47fb39b79f
+
+replace github.com/lucas-clemente/quic-clients => github.com/lucas-clemente/quic-clients v0.1.0
+
+replace github.com/lucas-clemente/quic-go => github.com/lucas-clemente/quic-go v0.10.2
+
+replace github.com/lucas-clemente/quic-go-certificates => github.com/lucas-clemente/quic-go-certificates v0.0.0-20160823095156-d2f86524cced
+
+replace github.com/mailru/easyjson => github.com/mailru/easyjson v0.7.0
+
+replace github.com/marten-seemann/qtls => github.com/marten-seemann/qtls v0.2.3
+
+replace github.com/mattn/go-colorable => github.com/mattn/go-colorable v0.0.9
+
+replace github.com/mattn/go-isatty => github.com/mattn/go-isatty v0.0.4
+
+replace github.com/mattn/go-runewidth => github.com/mattn/go-runewidth v0.0.2
+
+replace github.com/matttproud/golang_protobuf_extensions => github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369
+
+replace github.com/mholt/certmagic => github.com/mholt/certmagic v0.6.2-0.20190624175158-6a42ef9fe8c2
+
+replace github.com/mindprince/gonvml => github.com/mindprince/gonvml v0.0.0-20190828220739-9ebdce4bb989
+
+replace github.com/mistifyio/go-zfs => github.com/mistifyio/go-zfs v2.1.2-0.20190413222219-f784269be439+incompatible
+
+replace github.com/mitchellh/go-homedir => github.com/mitchellh/go-homedir v1.1.0
+
+replace github.com/mitchellh/go-wordwrap => github.com/mitchellh/go-wordwrap v1.0.0
+
+replace github.com/mitchellh/mapstructure => github.com/mitchellh/mapstructure v1.1.2
+
+replace github.com/moby/sys/mountinfo => github.com/moby/sys/mountinfo v0.1.3
+
+replace github.com/moby/term => github.com/moby/term v0.0.0-20200312100748-672ec06f55cd
+
+replace github.com/modern-go/concurrent => github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd
+
+replace github.com/modern-go/reflect2 => github.com/modern-go/reflect2 v1.0.1
+
+replace github.com/morikuni/aec => github.com/morikuni/aec v1.0.0
+
+replace github.com/mwitkow/go-conntrack => github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223
+
+replace github.com/mxk/go-flowrate => github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f
+
+replace github.com/naoina/go-stringutil => github.com/naoina/go-stringutil v0.1.0
+
+replace github.com/naoina/toml => github.com/naoina/toml v0.1.1
+
+replace github.com/olekukonko/tablewriter => github.com/olekukonko/tablewriter v0.0.0-20170122224234-a0225b3f23b5
+
+replace github.com/opencontainers/image-spec => github.com/opencontainers/image-spec v1.0.1
+
+replace github.com/opencontainers/runtime-spec => github.com/opencontainers/runtime-spec v1.0.3-0.20200520003142-237cc4f519e2
+
+replace github.com/pelletier/go-toml => github.com/pelletier/go-toml v1.2.0
+
+replace github.com/peterbourgon/diskv => github.com/peterbourgon/diskv v2.0.1+incompatible
+
+replace github.com/pquerna/cachecontrol => github.com/pquerna/cachecontrol v0.0.0-20171018203845-0dec1b30a021
+
+replace github.com/prometheus/procfs => github.com/prometheus/procfs v0.1.3
+
+replace github.com/remyoudompheng/bigfft => github.com/remyoudompheng/bigfft v0.0.0-20170806203942-52369c62f446
+
+replace github.com/rogpeppe/fastuuid => github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af
+
+replace github.com/rogpeppe/go-internal => github.com/rogpeppe/go-internal v1.3.0
+
+replace github.com/rubiojr/go-vhd => github.com/rubiojr/go-vhd v0.0.0-20200706105327-02e210299021
+
+replace github.com/russross/blackfriday => github.com/russross/blackfriday v1.5.2
+
+replace github.com/russross/blackfriday/v2 => github.com/russross/blackfriday/v2 v2.0.1
+
+replace github.com/satori/go.uuid => github.com/satori/go.uuid v1.2.0
+
+replace github.com/seccomp/libseccomp-golang => github.com/seccomp/libseccomp-golang v0.9.1
+
+replace github.com/sergi/go-diff => github.com/sergi/go-diff v1.0.0
+
+replace github.com/shurcooL/sanitized_anchor_name => github.com/shurcooL/sanitized_anchor_name v1.0.0
+
+replace github.com/sirupsen/logrus => github.com/sirupsen/logrus v1.6.0
+
+replace github.com/smartystreets/assertions => github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d
+
+replace github.com/smartystreets/goconvey => github.com/smartystreets/goconvey v1.6.4
+
+replace github.com/soheilhy/cmux => github.com/soheilhy/cmux v0.1.4
+
+replace github.com/spf13/cast => github.com/spf13/cast v1.3.0
+
+replace github.com/stretchr/objx => github.com/stretchr/objx v0.2.0
+
+replace github.com/syndtr/gocapability => github.com/syndtr/gocapability v0.0.0-20180916011248-d98352740cb2
+
+replace github.com/tidwall/pretty => github.com/tidwall/pretty v1.0.0
+
+replace github.com/tmc/grpc-websocket-proxy => github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5
+
+replace github.com/ugorji/go => github.com/ugorji/go v1.1.4
+
+replace github.com/urfave/cli => github.com/urfave/cli v1.22.2
+
+replace github.com/vektah/gqlparser => github.com/vektah/gqlparser v1.1.2
+
+replace github.com/vishvananda/netns => github.com/vishvananda/netns v0.0.0-20200520041808-52d707b772fe
+
+replace github.com/xiang90/probing => github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2
+
+replace github.com/xlab/handysort => github.com/xlab/handysort v0.0.0-20150421192137-fb3537ed64a1
+
+replace github.com/xordataexchange/crypt => github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77
+
+replace github.com/yuin/goldmark => github.com/yuin/goldmark v1.2.1
+
+replace go.etcd.io/bbolt => go.etcd.io/bbolt v1.3.5
+
+replace go.mongodb.org/mongo-driver => go.mongodb.org/mongo-driver v1.1.2
+
+replace go.opencensus.io => go.opencensus.io v0.22.2
+
+replace go.uber.org/atomic => go.uber.org/atomic v1.4.0
+
+replace go.uber.org/multierr => go.uber.org/multierr v1.1.0
+
+replace go.uber.org/zap => go.uber.org/zap v1.10.0
+
+replace golang.org/x/exp => golang.org/x/exp v0.0.0-20191227195350-da58074b4299
+
+replace golang.org/x/image => golang.org/x/image v0.0.0-20190802002840-cff245a6509b
+
+replace golang.org/x/lint => golang.org/x/lint v0.0.0-20191125180803-fdd1cda4f05f
+
+replace golang.org/x/mobile => golang.org/x/mobile v0.0.0-20190719004257-d2bd2a29d028
+
+replace golang.org/x/mod => golang.org/x/mod v0.3.0
+
+replace golang.org/x/sync => golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9
+
+replace golang.org/x/text => golang.org/x/text v0.3.3
+
+replace golang.org/x/xerrors => golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1
+
+replace gonum.org/v1/plot => gonum.org/v1/plot v0.0.0-20190515093506-e2840ee46a6b
+
+replace google.golang.org/appengine => google.golang.org/appengine v1.6.5
+
+replace google.golang.org/genproto => google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013
+
+replace google.golang.org/protobuf => google.golang.org/protobuf v1.24.0
+
+replace gopkg.in/alecthomas/kingpin.v2 => gopkg.in/alecthomas/kingpin.v2 v2.2.6
+
+replace gopkg.in/check.v1 => gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15
+
+replace gopkg.in/cheggaaa/pb.v1 => gopkg.in/cheggaaa/pb.v1 v1.0.25
+
+replace gopkg.in/errgo.v2 => gopkg.in/errgo.v2 v2.1.0
+
+replace gopkg.in/fsnotify.v1 => gopkg.in/fsnotify.v1 v1.4.7
+
+replace gopkg.in/inf.v0 => gopkg.in/inf.v0 v0.9.1
+
+replace gopkg.in/mcuadros/go-syslog.v2 => gopkg.in/mcuadros/go-syslog.v2 v2.2.1
+
+replace gopkg.in/natefinch/lumberjack.v2 => gopkg.in/natefinch/lumberjack.v2 v2.0.0
+
+replace gopkg.in/resty.v1 => gopkg.in/resty.v1 v1.12.0
+
+replace gopkg.in/tomb.v1 => gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7
+
+replace gopkg.in/warnings.v0 => gopkg.in/warnings.v0 v0.1.1
+
+replace gotest.tools => gotest.tools v2.2.0+incompatible
+
+replace gotest.tools/v3 => gotest.tools/v3 v3.0.2
+
+replace honnef.co/go/tools => honnef.co/go/tools v0.0.1-2019.2.3
+
+replace modernc.org/cc => modernc.org/cc v1.0.0
+
+replace modernc.org/golex => modernc.org/golex v1.0.0
+
+replace modernc.org/mathutil => modernc.org/mathutil v1.0.0
+
+replace modernc.org/strutil => modernc.org/strutil v1.0.0
+
+replace modernc.org/xc => modernc.org/xc v1.0.0
+
+replace rsc.io/pdf => rsc.io/pdf v0.1.1
+
+replace sigs.k8s.io/apiserver-network-proxy/konnectivity-client => sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.15
+
+replace sigs.k8s.io/structured-merge-diff/v4 => sigs.k8s.io/structured-merge-diff/v4 v4.1.2
+
+replace vbom.ml/util => vbom.ml/util v0.0.0-20160121211510-db5cfe13f5cc

--- a/staging/src/k8s.io/cluster-bootstrap/go.mod
+++ b/staging/src/k8s.io/cluster-bootstrap/go.mod
@@ -5,11 +5,118 @@ module k8s.io/cluster-bootstrap
 go 1.15
 
 require (
+	bitbucket.org/bertimus9/systemstat v0.0.0-20180207000608-0eeff89b0690
+	github.com/Azure/azure-sdk-for-go v43.0.0+incompatible
+	github.com/Azure/go-autorest/autorest v0.9.6
+	github.com/Azure/go-autorest/autorest/adal v0.8.2
+	github.com/Azure/go-autorest/autorest/to v0.2.0
+	github.com/GoogleCloudPlatform/k8s-cloud-provider v0.0.0-20200415212048-7901bc822317
+	github.com/JeffAshton/win_pdh v0.0.0-20161109143554-76bb4ee9f0ab
+	github.com/Microsoft/go-winio v0.4.15-0.20190919025122-fc70bd9a86b5
+	github.com/Microsoft/hcsshim v0.8.10-0.20200715222032-5eafd1556990
+	github.com/PuerkitoBio/purell v1.1.1
+	github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e
+	github.com/auth0/go-jwt-middleware v0.0.0-20170425171159-5493cabe49f7
+	github.com/aws/aws-sdk-go v1.28.2
+	github.com/blang/semver v3.5.0+incompatible
+	github.com/boltdb/bolt v1.3.1
+	github.com/caddyserver/caddy v1.0.3
+	github.com/clusterhq/flocker-go v0.0.0-20160920122132-2b8b7259d313
+	github.com/codegangsta/negroni v1.0.0
+	github.com/container-storage-interface/spec v1.2.0
+	github.com/containernetworking/cni v0.8.0
+	github.com/coredns/corefile-migration v1.0.10
+	github.com/coreos/go-oidc v2.1.0+incompatible
+	github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e
+	github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f
+	github.com/cpuguy83/go-md2man/v2 v2.0.0
+	github.com/davecgh/go-spew v1.1.1
+	github.com/docker/distribution v2.7.1+incompatible
+	github.com/docker/docker v1.4.2-0.20200309214505-aa6a9891b09c
+	github.com/docker/go-connections v0.4.0
+	github.com/docker/go-units v0.4.0
+	github.com/elazarl/goproxy v0.0.0-20180725130230-947c36da3153
+	github.com/emicklei/go-restful v2.9.5+incompatible
+	github.com/evanphx/json-patch v4.9.0+incompatible
+	github.com/fsnotify/fsnotify v1.4.9
+	github.com/go-bindata/go-bindata v3.1.1+incompatible
+	github.com/go-openapi/analysis v0.19.5
+	github.com/go-openapi/loads v0.19.4
+	github.com/go-openapi/spec v0.19.3
+	github.com/go-openapi/strfmt v0.19.3
+	github.com/go-openapi/validate v0.19.5
+	github.com/go-ozzo/ozzo-validation v3.5.0+incompatible
+	github.com/gogo/protobuf v1.3.2
+	github.com/golang/groupcache v0.0.0-20191227052852-215e87163ea7
+	github.com/golang/mock v1.3.1
+	github.com/google/cadvisor v0.37.5
+	github.com/google/go-cmp v0.4.0
+	github.com/google/gofuzz v1.1.0
+	github.com/google/uuid v1.1.1
+	github.com/googleapis/gnostic v0.4.1
+	github.com/gorilla/context v1.1.1
+	github.com/hashicorp/golang-lru v0.5.1
+	github.com/heketi/heketi v9.0.1-0.20190917153846-c2e2a4ab7ab9+incompatible
+	github.com/heketi/tests v0.0.0-20151005000721-f3775cbcefd6
+	github.com/ishidawataru/sctp v0.0.0-20190723014705-7c296d48a2b5
+	github.com/json-iterator/go v1.1.10
+	github.com/libopenstorage/openstorage v1.0.0
+	github.com/lithammer/dedent v1.1.0
+	github.com/lpabon/godbc v0.1.1
+	github.com/magiconair/properties v1.8.1
+	github.com/miekg/dns v1.1.4
+	github.com/moby/ipvs v1.0.1
+	github.com/mohae/deepcopy v0.0.0-20170603005431-491d3605edfb
+	github.com/mrunalp/fileutils v0.0.0-20200520151820-abd8a0e76976
+	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822
+	github.com/mvdan/xurls v1.1.0
+	github.com/onsi/ginkgo v1.11.0
+	github.com/onsi/gomega v1.7.0
+	github.com/opencontainers/go-digest v1.0.0-rc1
+	github.com/opencontainers/runc v1.0.1
+	github.com/opencontainers/selinux v1.5.2
+	github.com/pkg/errors v0.9.1
+	github.com/pmezard/go-difflib v1.0.0
+	github.com/prometheus/client_golang v1.7.1
+	github.com/prometheus/client_model v0.2.0
+	github.com/prometheus/common v0.10.0
+	github.com/quobyte/api v0.1.2
+	github.com/robfig/cron v1.1.0
+	github.com/spf13/afero v1.2.2
+	github.com/spf13/cobra v1.0.0
+	github.com/spf13/jwalterweatherman v1.1.0
+	github.com/spf13/pflag v1.0.5
+	github.com/spf13/viper v1.4.0
+	github.com/storageos/go-api v0.0.0-20180912212459-343b3eff91fc
 	github.com/stretchr/testify v1.4.0
+	github.com/thecodeteam/goscaleio v0.1.0
+	github.com/urfave/negroni v1.0.0
+	github.com/vishvananda/netlink v1.1.0
+	github.com/vmware/govmomi v0.20.3
+	go.etcd.io/etcd v0.5.0-alpha.5.0.20200819165624-17cef6e3e9d5
+	golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9
+	golang.org/x/net v0.0.0-20201110031124-69a78807bb2b
+	golang.org/x/oauth2 v0.0.0-20191202225959-858c2ad4c8b6
+	golang.org/x/sys v0.0.0-20201112073958-5cba982894dd
+	golang.org/x/time v0.0.0-20191024005414-555d28b269f0
+	golang.org/x/tools v0.0.0-20210106214847-113979e3529a
+	gonum.org/v1/gonum v0.6.2
+	gonum.org/v1/netlib v0.0.0-20190331212654-76723241ea4e
+	google.golang.org/api v0.15.1
+	google.golang.org/grpc v1.27.0
+	gopkg.in/gcfg.v1 v1.2.0
 	gopkg.in/square/go-jose.v2 v2.2.2
+	gopkg.in/yaml.v2 v2.2.8
 	k8s.io/api v0.0.0
 	k8s.io/apimachinery v0.0.0
+	k8s.io/gengo v0.0.0-20200428234225-8167cfdcfc14
+	k8s.io/heapster v1.2.0-beta.1
 	k8s.io/klog/v2 v2.2.0
+	k8s.io/kube-openapi v0.0.0-20200805222855-6aeccd4b50c6
+	k8s.io/system-validators v1.1.2
+	k8s.io/utils v0.0.0-20200729134348-d5654de09c73
+	sigs.k8s.io/kustomize v2.0.3+incompatible
+	sigs.k8s.io/yaml v1.2.0
 )
 
 replace (
@@ -17,3 +124,669 @@ replace (
 	k8s.io/apimachinery => ../apimachinery
 	k8s.io/cluster-bootstrap => ../cluster-bootstrap
 )
+
+replace github.com/auth0/go-jwt-middleware => github.com/auth0/go-jwt-middleware v0.0.0-20170425171159-5493cabe49f7
+
+replace github.com/boltdb/bolt => github.com/boltdb/bolt v1.3.1
+
+replace github.com/codegangsta/negroni => github.com/codegangsta/negroni v1.0.0
+
+replace github.com/go-ozzo/ozzo-validation => github.com/go-ozzo/ozzo-validation v3.5.0+incompatible
+
+replace github.com/gorilla/context => github.com/gorilla/context v1.1.1
+
+replace github.com/heketi/tests => github.com/heketi/tests v0.0.0-20151005000721-f3775cbcefd6
+
+replace github.com/lpabon/godbc => github.com/lpabon/godbc v0.1.1
+
+replace github.com/magiconair/properties => github.com/magiconair/properties v1.8.1
+
+replace github.com/mohae/deepcopy => github.com/mohae/deepcopy v0.0.0-20170603005431-491d3605edfb
+
+replace github.com/spf13/jwalterweatherman => github.com/spf13/jwalterweatherman v1.1.0
+
+replace github.com/urfave/negroni => github.com/urfave/negroni v1.0.0
+
+replace gonum.org/v1/netlib => gonum.org/v1/netlib v0.0.0-20190331212654-76723241ea4e
+
+replace bitbucket.org/bertimus9/systemstat => bitbucket.org/bertimus9/systemstat v0.0.0-20180207000608-0eeff89b0690
+
+replace github.com/Azure/azure-sdk-for-go => github.com/Azure/azure-sdk-for-go v43.0.0+incompatible
+
+replace github.com/Azure/go-autorest/autorest => github.com/Azure/go-autorest/autorest v0.9.6
+
+replace github.com/Azure/go-autorest/autorest/adal => github.com/Azure/go-autorest/autorest/adal v0.8.2
+
+replace github.com/Azure/go-autorest/autorest/to => github.com/Azure/go-autorest/autorest/to v0.2.0
+
+replace github.com/GoogleCloudPlatform/k8s-cloud-provider => github.com/GoogleCloudPlatform/k8s-cloud-provider v0.0.0-20200415212048-7901bc822317
+
+replace github.com/JeffAshton/win_pdh => github.com/JeffAshton/win_pdh v0.0.0-20161109143554-76bb4ee9f0ab
+
+replace github.com/Microsoft/go-winio => github.com/Microsoft/go-winio v0.4.15-0.20190919025122-fc70bd9a86b5
+
+replace github.com/Microsoft/hcsshim => github.com/Microsoft/hcsshim v0.8.10-0.20200715222032-5eafd1556990
+
+replace github.com/PuerkitoBio/purell => github.com/PuerkitoBio/purell v1.1.1
+
+replace github.com/armon/circbuf => github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e
+
+replace github.com/aws/aws-sdk-go => github.com/aws/aws-sdk-go v1.28.2
+
+replace github.com/blang/semver => github.com/blang/semver v3.5.0+incompatible
+
+replace github.com/caddyserver/caddy => github.com/caddyserver/caddy v1.0.3
+
+replace github.com/clusterhq/flocker-go => github.com/clusterhq/flocker-go v0.0.0-20160920122132-2b8b7259d313
+
+replace github.com/container-storage-interface/spec => github.com/container-storage-interface/spec v1.2.0
+
+replace github.com/containernetworking/cni => github.com/containernetworking/cni v0.8.0
+
+replace github.com/coredns/corefile-migration => github.com/coredns/corefile-migration v1.0.10
+
+replace github.com/coreos/go-oidc => github.com/coreos/go-oidc v2.1.0+incompatible
+
+replace github.com/coreos/go-systemd => github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e
+
+replace github.com/coreos/pkg => github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f
+
+replace github.com/cpuguy83/go-md2man/v2 => github.com/cpuguy83/go-md2man/v2 v2.0.0
+
+replace github.com/davecgh/go-spew => github.com/davecgh/go-spew v1.1.1
+
+replace github.com/docker/distribution => github.com/docker/distribution v2.7.1+incompatible
+
+replace github.com/docker/docker => github.com/docker/docker v1.4.2-0.20200309214505-aa6a9891b09c
+
+replace github.com/docker/go-connections => github.com/docker/go-connections v0.4.0
+
+replace github.com/docker/go-units => github.com/docker/go-units v0.4.0
+
+replace github.com/elazarl/goproxy => github.com/elazarl/goproxy v0.0.0-20180725130230-947c36da3153
+
+replace github.com/emicklei/go-restful => github.com/emicklei/go-restful v2.9.5+incompatible
+
+replace github.com/evanphx/json-patch => github.com/evanphx/json-patch v4.9.0+incompatible
+
+replace github.com/fsnotify/fsnotify => github.com/fsnotify/fsnotify v1.4.9
+
+replace github.com/go-bindata/go-bindata => github.com/go-bindata/go-bindata v3.1.1+incompatible
+
+replace github.com/go-openapi/analysis => github.com/go-openapi/analysis v0.19.5
+
+replace github.com/go-openapi/loads => github.com/go-openapi/loads v0.19.4
+
+replace github.com/go-openapi/spec => github.com/go-openapi/spec v0.19.3
+
+replace github.com/go-openapi/strfmt => github.com/go-openapi/strfmt v0.19.3
+
+replace github.com/go-openapi/validate => github.com/go-openapi/validate v0.19.5
+
+replace github.com/gogo/protobuf => github.com/gogo/protobuf v1.3.2
+
+replace github.com/golang/groupcache => github.com/golang/groupcache v0.0.0-20191227052852-215e87163ea7
+
+replace github.com/golang/mock => github.com/golang/mock v1.3.1
+
+replace github.com/google/cadvisor => github.com/google/cadvisor v0.37.5
+
+replace github.com/google/go-cmp => github.com/google/go-cmp v0.4.0
+
+replace github.com/google/gofuzz => github.com/google/gofuzz v1.1.0
+
+replace github.com/google/uuid => github.com/google/uuid v1.1.1
+
+replace github.com/googleapis/gnostic => github.com/googleapis/gnostic v0.4.1
+
+replace github.com/hashicorp/golang-lru => github.com/hashicorp/golang-lru v0.5.1
+
+replace github.com/heketi/heketi => github.com/heketi/heketi v9.0.1-0.20190917153846-c2e2a4ab7ab9+incompatible
+
+replace github.com/ishidawataru/sctp => github.com/ishidawataru/sctp v0.0.0-20190723014705-7c296d48a2b5
+
+replace github.com/json-iterator/go => github.com/json-iterator/go v1.1.10
+
+replace github.com/libopenstorage/openstorage => github.com/libopenstorage/openstorage v1.0.0
+
+replace github.com/lithammer/dedent => github.com/lithammer/dedent v1.1.0
+
+replace github.com/miekg/dns => github.com/miekg/dns v1.1.4
+
+replace github.com/moby/ipvs => github.com/moby/ipvs v1.0.1
+
+replace github.com/mrunalp/fileutils => github.com/mrunalp/fileutils v0.0.0-20200520151820-abd8a0e76976
+
+replace github.com/munnerz/goautoneg => github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822
+
+replace github.com/mvdan/xurls => github.com/mvdan/xurls v1.1.0
+
+replace github.com/onsi/ginkgo => github.com/onsi/ginkgo v1.11.0
+
+replace github.com/onsi/gomega => github.com/onsi/gomega v1.7.0
+
+replace github.com/opencontainers/go-digest => github.com/opencontainers/go-digest v1.0.0-rc1
+
+replace github.com/opencontainers/runc => github.com/opencontainers/runc v1.0.1
+
+replace github.com/opencontainers/selinux => github.com/opencontainers/selinux v1.5.2
+
+replace github.com/pkg/errors => github.com/pkg/errors v0.9.1
+
+replace github.com/pmezard/go-difflib => github.com/pmezard/go-difflib v1.0.0
+
+replace github.com/prometheus/client_golang => github.com/prometheus/client_golang v1.7.1
+
+replace github.com/prometheus/client_model => github.com/prometheus/client_model v0.2.0
+
+replace github.com/prometheus/common => github.com/prometheus/common v0.10.0
+
+replace github.com/quobyte/api => github.com/quobyte/api v0.1.2
+
+replace github.com/robfig/cron => github.com/robfig/cron v1.1.0
+
+replace github.com/spf13/afero => github.com/spf13/afero v1.2.2
+
+replace github.com/spf13/cobra => github.com/spf13/cobra v1.0.0
+
+replace github.com/spf13/pflag => github.com/spf13/pflag v1.0.5
+
+replace github.com/spf13/viper => github.com/spf13/viper v1.4.0
+
+replace github.com/storageos/go-api => github.com/storageos/go-api v0.0.0-20180912212459-343b3eff91fc
+
+replace github.com/stretchr/testify => github.com/stretchr/testify v1.4.0
+
+replace github.com/thecodeteam/goscaleio => github.com/thecodeteam/goscaleio v0.1.0
+
+replace github.com/vishvananda/netlink => github.com/vishvananda/netlink v1.1.0
+
+replace github.com/vmware/govmomi => github.com/vmware/govmomi v0.20.3
+
+replace go.etcd.io/etcd => go.etcd.io/etcd v0.5.0-alpha.5.0.20200819165624-17cef6e3e9d5
+
+replace golang.org/x/crypto => golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9
+
+replace golang.org/x/net => golang.org/x/net v0.0.0-20201110031124-69a78807bb2b
+
+replace golang.org/x/oauth2 => golang.org/x/oauth2 v0.0.0-20191202225959-858c2ad4c8b6
+
+replace golang.org/x/sys => golang.org/x/sys v0.0.0-20201112073958-5cba982894dd
+
+replace golang.org/x/time => golang.org/x/time v0.0.0-20191024005414-555d28b269f0
+
+replace golang.org/x/tools => golang.org/x/tools v0.0.0-20210106214847-113979e3529a
+
+replace gonum.org/v1/gonum => gonum.org/v1/gonum v0.6.2
+
+replace google.golang.org/api => google.golang.org/api v0.15.1
+
+replace google.golang.org/grpc => google.golang.org/grpc v1.27.0
+
+replace gopkg.in/gcfg.v1 => gopkg.in/gcfg.v1 v1.2.0
+
+replace gopkg.in/square/go-jose.v2 => gopkg.in/square/go-jose.v2 v2.2.2
+
+replace gopkg.in/yaml.v2 => gopkg.in/yaml.v2 v2.2.8
+
+replace k8s.io/gengo => k8s.io/gengo v0.0.0-20200428234225-8167cfdcfc14
+
+replace k8s.io/heapster => k8s.io/heapster v1.2.0-beta.1
+
+replace k8s.io/klog/v2 => k8s.io/klog/v2 v2.2.0
+
+replace k8s.io/kube-openapi => k8s.io/kube-openapi v0.0.0-20200805222855-6aeccd4b50c6
+
+replace k8s.io/system-validators => k8s.io/system-validators v1.1.2
+
+replace k8s.io/utils => k8s.io/utils v0.0.0-20200729134348-d5654de09c73
+
+replace sigs.k8s.io/kustomize => sigs.k8s.io/kustomize v2.0.3+incompatible
+
+replace sigs.k8s.io/yaml => sigs.k8s.io/yaml v1.2.0
+
+replace cloud.google.com/go => cloud.google.com/go v0.51.0
+
+replace cloud.google.com/go/bigquery => cloud.google.com/go/bigquery v1.0.1
+
+replace cloud.google.com/go/datastore => cloud.google.com/go/datastore v1.0.0
+
+replace cloud.google.com/go/pubsub => cloud.google.com/go/pubsub v1.0.1
+
+replace cloud.google.com/go/storage => cloud.google.com/go/storage v1.0.0
+
+replace dmitri.shuralyov.com/gpu/mtl => dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9
+
+replace github.com/Azure/go-ansiterm => github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78
+
+replace github.com/Azure/go-autorest/autorest/date => github.com/Azure/go-autorest/autorest/date v0.2.0
+
+replace github.com/Azure/go-autorest/autorest/mocks => github.com/Azure/go-autorest/autorest/mocks v0.3.0
+
+replace github.com/Azure/go-autorest/autorest/validation => github.com/Azure/go-autorest/autorest/validation v0.1.0
+
+replace github.com/Azure/go-autorest/logger => github.com/Azure/go-autorest/logger v0.1.0
+
+replace github.com/Azure/go-autorest/tracing => github.com/Azure/go-autorest/tracing v0.5.0
+
+replace github.com/BurntSushi/toml => github.com/BurntSushi/toml v0.3.1
+
+replace github.com/BurntSushi/xgb => github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802
+
+replace github.com/MakeNowJust/heredoc => github.com/MakeNowJust/heredoc v0.0.0-20170808103936-bb23615498cd
+
+replace github.com/NYTimes/gziphandler => github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46
+
+replace github.com/PuerkitoBio/urlesc => github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578
+
+replace github.com/agnivade/levenshtein => github.com/agnivade/levenshtein v1.0.1
+
+replace github.com/ajstarks/svgo => github.com/ajstarks/svgo v0.0.0-20180226025133-644b8db467af
+
+replace github.com/alecthomas/template => github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751
+
+replace github.com/alecthomas/units => github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4
+
+replace github.com/andreyvit/diff => github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883
+
+replace github.com/armon/consul-api => github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6
+
+replace github.com/asaskevich/govalidator => github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a
+
+replace github.com/beorn7/perks => github.com/beorn7/perks v1.0.1
+
+replace github.com/bgentry/speakeasy => github.com/bgentry/speakeasy v0.1.0
+
+replace github.com/bifurcation/mint => github.com/bifurcation/mint v0.0.0-20180715133206-93c51c6ce115
+
+replace github.com/cenkalti/backoff => github.com/cenkalti/backoff v2.1.1+incompatible
+
+replace github.com/census-instrumentation/opencensus-proto => github.com/census-instrumentation/opencensus-proto v0.2.1
+
+replace github.com/cespare/xxhash/v2 => github.com/cespare/xxhash/v2 v2.1.1
+
+replace github.com/chai2010/gettext-go => github.com/chai2010/gettext-go v0.0.0-20160711120539-c6fed771bfd5
+
+replace github.com/checkpoint-restore/go-criu/v4 => github.com/checkpoint-restore/go-criu/v4 v4.0.2
+
+replace github.com/cheekybits/genny => github.com/cheekybits/genny v0.0.0-20170328200008-9127e812e1e9
+
+replace github.com/chzyer/logex => github.com/chzyer/logex v1.1.10
+
+replace github.com/chzyer/readline => github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e
+
+replace github.com/chzyer/test => github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1
+
+replace github.com/cilium/ebpf => github.com/cilium/ebpf v0.0.0-20200702112145-1c8d4c9ef775
+
+replace github.com/cockroachdb/datadriven => github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa
+
+replace github.com/containerd/cgroups => github.com/containerd/cgroups v0.0.0-20200531161412-0dbf7f05ba59
+
+replace github.com/containerd/console => github.com/containerd/console v1.0.0
+
+replace github.com/containerd/containerd => github.com/containerd/containerd v1.3.3
+
+replace github.com/containerd/continuity => github.com/containerd/continuity v0.0.0-20190426062206-aaeac12a7ffc
+
+replace github.com/containerd/fifo => github.com/containerd/fifo v0.0.0-20190226154929-a9fb20d87448
+
+replace github.com/containerd/go-runc => github.com/containerd/go-runc v0.0.0-20180907222934-5a6d9f37cfa3
+
+replace github.com/containerd/ttrpc => github.com/containerd/ttrpc v1.0.0
+
+replace github.com/containerd/typeurl => github.com/containerd/typeurl v1.0.0
+
+replace github.com/coreos/bbolt => github.com/coreos/bbolt v1.3.2
+
+replace github.com/coreos/etcd => github.com/coreos/etcd v3.3.10+incompatible
+
+replace github.com/coreos/go-semver => github.com/coreos/go-semver v0.3.0
+
+replace github.com/coreos/go-systemd/v22 => github.com/coreos/go-systemd/v22 v22.1.0
+
+replace github.com/creack/pty => github.com/creack/pty v1.1.7
+
+replace github.com/cyphar/filepath-securejoin => github.com/cyphar/filepath-securejoin v0.2.2
+
+replace github.com/daviddengcn/go-colortext => github.com/daviddengcn/go-colortext v0.0.0-20160507010035-511bcaf42ccd
+
+replace github.com/dgrijalva/jwt-go => github.com/dgrijalva/jwt-go v3.2.0+incompatible
+
+replace github.com/dnaeon/go-vcr => github.com/dnaeon/go-vcr v1.0.1
+
+replace github.com/docker/spdystream => github.com/docker/spdystream v0.0.0-20160310174837-449fdfce4d96
+
+replace github.com/docopt/docopt-go => github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815
+
+replace github.com/dustin/go-humanize => github.com/dustin/go-humanize v1.0.0
+
+replace github.com/envoyproxy/go-control-plane => github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473
+
+replace github.com/envoyproxy/protoc-gen-validate => github.com/envoyproxy/protoc-gen-validate v0.1.0
+
+replace github.com/euank/go-kmsg-parser => github.com/euank/go-kmsg-parser v2.0.0+incompatible
+
+replace github.com/exponent-io/jsonpath => github.com/exponent-io/jsonpath v0.0.0-20151013193312-d6023ce2651d
+
+replace github.com/fatih/camelcase => github.com/fatih/camelcase v1.0.0
+
+replace github.com/fatih/color => github.com/fatih/color v1.7.0
+
+replace github.com/flynn/go-shlex => github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568
+
+replace github.com/fogleman/gg => github.com/fogleman/gg v1.2.1-0.20190220221249-0403632d5b90
+
+replace github.com/ghodss/yaml => github.com/ghodss/yaml v1.0.0
+
+replace github.com/go-acme/lego => github.com/go-acme/lego v2.5.0+incompatible
+
+replace github.com/go-gl/glfw/v3.3/glfw => github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72
+
+replace github.com/go-ini/ini => github.com/go-ini/ini v1.9.0
+
+replace github.com/go-kit/kit => github.com/go-kit/kit v0.9.0
+
+replace github.com/go-logfmt/logfmt => github.com/go-logfmt/logfmt v0.4.0
+
+replace github.com/go-logr/logr => github.com/go-logr/logr v0.2.0
+
+replace github.com/go-openapi/errors => github.com/go-openapi/errors v0.19.2
+
+replace github.com/go-openapi/jsonpointer => github.com/go-openapi/jsonpointer v0.19.3
+
+replace github.com/go-openapi/jsonreference => github.com/go-openapi/jsonreference v0.19.3
+
+replace github.com/go-openapi/runtime => github.com/go-openapi/runtime v0.19.4
+
+replace github.com/go-openapi/swag => github.com/go-openapi/swag v0.19.5
+
+replace github.com/go-stack/stack => github.com/go-stack/stack v1.8.0
+
+replace github.com/godbus/dbus/v5 => github.com/godbus/dbus/v5 v5.0.3
+
+replace github.com/golang/freetype => github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0
+
+replace github.com/golang/glog => github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
+
+replace github.com/golang/protobuf => github.com/golang/protobuf v1.4.2
+
+replace github.com/golangplus/bytes => github.com/golangplus/bytes v0.0.0-20160111154220-45c989fe5450
+
+replace github.com/golangplus/fmt => github.com/golangplus/fmt v0.0.0-20150411045040-2a5d6d7d2995
+
+replace github.com/golangplus/testing => github.com/golangplus/testing v0.0.0-20180327235837-af21d9c3145e
+
+replace github.com/google/btree => github.com/google/btree v1.0.0
+
+replace github.com/google/martian => github.com/google/martian v2.1.0+incompatible
+
+replace github.com/google/pprof => github.com/google/pprof v0.0.0-20191218002539-d4f498aebedc
+
+replace github.com/google/renameio => github.com/google/renameio v0.1.0
+
+replace github.com/googleapis/gax-go/v2 => github.com/googleapis/gax-go/v2 v2.0.5
+
+replace github.com/gophercloud/gophercloud => github.com/gophercloud/gophercloud v0.1.0
+
+replace github.com/gopherjs/gopherjs => github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1
+
+replace github.com/gorilla/mux => github.com/gorilla/mux v1.7.3
+
+replace github.com/gorilla/websocket => github.com/gorilla/websocket v1.4.0
+
+replace github.com/gregjones/httpcache => github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7
+
+replace github.com/grpc-ecosystem/go-grpc-middleware => github.com/grpc-ecosystem/go-grpc-middleware v1.0.1-0.20190118093823-f849b5445de4
+
+replace github.com/grpc-ecosystem/go-grpc-prometheus => github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0
+
+replace github.com/grpc-ecosystem/grpc-gateway => github.com/grpc-ecosystem/grpc-gateway v1.9.5
+
+replace github.com/hashicorp/go-syslog => github.com/hashicorp/go-syslog v1.0.0
+
+replace github.com/hashicorp/hcl => github.com/hashicorp/hcl v1.0.0
+
+replace github.com/hpcloud/tail => github.com/hpcloud/tail v1.0.0
+
+replace github.com/ianlancetaylor/demangle => github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6
+
+replace github.com/imdario/mergo => github.com/imdario/mergo v0.3.5
+
+replace github.com/inconshreveable/mousetrap => github.com/inconshreveable/mousetrap v1.0.0
+
+replace github.com/jimstudt/http-authentication => github.com/jimstudt/http-authentication v0.0.0-20140401203705-3eca13d6893a
+
+replace github.com/jmespath/go-jmespath => github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af
+
+replace github.com/jonboulle/clockwork => github.com/jonboulle/clockwork v0.1.0
+
+replace github.com/jstemmer/go-junit-report => github.com/jstemmer/go-junit-report v0.9.1
+
+replace github.com/jtolds/gls => github.com/jtolds/gls v4.20.0+incompatible
+
+replace github.com/julienschmidt/httprouter => github.com/julienschmidt/httprouter v1.2.0
+
+replace github.com/jung-kurt/gofpdf => github.com/jung-kurt/gofpdf v1.0.3-0.20190309125859-24315acbbda5
+
+replace github.com/karrick/godirwalk => github.com/karrick/godirwalk v1.7.5
+
+replace github.com/kisielk/errcheck => github.com/kisielk/errcheck v1.5.0
+
+replace github.com/kisielk/gotool => github.com/kisielk/gotool v1.0.0
+
+replace github.com/klauspost/cpuid => github.com/klauspost/cpuid v1.2.0
+
+replace github.com/konsorten/go-windows-terminal-sequences => github.com/konsorten/go-windows-terminal-sequences v1.0.3
+
+replace github.com/kr/logfmt => github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515
+
+replace github.com/kr/pretty => github.com/kr/pretty v0.2.0
+
+replace github.com/kr/pty => github.com/kr/pty v1.1.5
+
+replace github.com/kr/text => github.com/kr/text v0.1.0
+
+replace github.com/kylelemons/godebug => github.com/kylelemons/godebug v0.0.0-20170820004349-d65d576e9348
+
+replace github.com/liggitt/tabwriter => github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de
+
+replace github.com/lucas-clemente/aes12 => github.com/lucas-clemente/aes12 v0.0.0-20171027163421-cd47fb39b79f
+
+replace github.com/lucas-clemente/quic-clients => github.com/lucas-clemente/quic-clients v0.1.0
+
+replace github.com/lucas-clemente/quic-go => github.com/lucas-clemente/quic-go v0.10.2
+
+replace github.com/lucas-clemente/quic-go-certificates => github.com/lucas-clemente/quic-go-certificates v0.0.0-20160823095156-d2f86524cced
+
+replace github.com/mailru/easyjson => github.com/mailru/easyjson v0.7.0
+
+replace github.com/marten-seemann/qtls => github.com/marten-seemann/qtls v0.2.3
+
+replace github.com/mattn/go-colorable => github.com/mattn/go-colorable v0.0.9
+
+replace github.com/mattn/go-isatty => github.com/mattn/go-isatty v0.0.4
+
+replace github.com/mattn/go-runewidth => github.com/mattn/go-runewidth v0.0.2
+
+replace github.com/matttproud/golang_protobuf_extensions => github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369
+
+replace github.com/mholt/certmagic => github.com/mholt/certmagic v0.6.2-0.20190624175158-6a42ef9fe8c2
+
+replace github.com/mindprince/gonvml => github.com/mindprince/gonvml v0.0.0-20190828220739-9ebdce4bb989
+
+replace github.com/mistifyio/go-zfs => github.com/mistifyio/go-zfs v2.1.2-0.20190413222219-f784269be439+incompatible
+
+replace github.com/mitchellh/go-homedir => github.com/mitchellh/go-homedir v1.1.0
+
+replace github.com/mitchellh/go-wordwrap => github.com/mitchellh/go-wordwrap v1.0.0
+
+replace github.com/mitchellh/mapstructure => github.com/mitchellh/mapstructure v1.1.2
+
+replace github.com/moby/sys/mountinfo => github.com/moby/sys/mountinfo v0.1.3
+
+replace github.com/moby/term => github.com/moby/term v0.0.0-20200312100748-672ec06f55cd
+
+replace github.com/modern-go/concurrent => github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd
+
+replace github.com/modern-go/reflect2 => github.com/modern-go/reflect2 v1.0.1
+
+replace github.com/morikuni/aec => github.com/morikuni/aec v1.0.0
+
+replace github.com/mwitkow/go-conntrack => github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223
+
+replace github.com/mxk/go-flowrate => github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f
+
+replace github.com/naoina/go-stringutil => github.com/naoina/go-stringutil v0.1.0
+
+replace github.com/naoina/toml => github.com/naoina/toml v0.1.1
+
+replace github.com/olekukonko/tablewriter => github.com/olekukonko/tablewriter v0.0.0-20170122224234-a0225b3f23b5
+
+replace github.com/opencontainers/image-spec => github.com/opencontainers/image-spec v1.0.1
+
+replace github.com/opencontainers/runtime-spec => github.com/opencontainers/runtime-spec v1.0.3-0.20200520003142-237cc4f519e2
+
+replace github.com/pelletier/go-toml => github.com/pelletier/go-toml v1.2.0
+
+replace github.com/peterbourgon/diskv => github.com/peterbourgon/diskv v2.0.1+incompatible
+
+replace github.com/pquerna/cachecontrol => github.com/pquerna/cachecontrol v0.0.0-20171018203845-0dec1b30a021
+
+replace github.com/prometheus/procfs => github.com/prometheus/procfs v0.1.3
+
+replace github.com/remyoudompheng/bigfft => github.com/remyoudompheng/bigfft v0.0.0-20170806203942-52369c62f446
+
+replace github.com/rogpeppe/fastuuid => github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af
+
+replace github.com/rogpeppe/go-internal => github.com/rogpeppe/go-internal v1.3.0
+
+replace github.com/rubiojr/go-vhd => github.com/rubiojr/go-vhd v0.0.0-20200706105327-02e210299021
+
+replace github.com/russross/blackfriday => github.com/russross/blackfriday v1.5.2
+
+replace github.com/russross/blackfriday/v2 => github.com/russross/blackfriday/v2 v2.0.1
+
+replace github.com/satori/go.uuid => github.com/satori/go.uuid v1.2.0
+
+replace github.com/seccomp/libseccomp-golang => github.com/seccomp/libseccomp-golang v0.9.1
+
+replace github.com/sergi/go-diff => github.com/sergi/go-diff v1.0.0
+
+replace github.com/shurcooL/sanitized_anchor_name => github.com/shurcooL/sanitized_anchor_name v1.0.0
+
+replace github.com/sirupsen/logrus => github.com/sirupsen/logrus v1.6.0
+
+replace github.com/smartystreets/assertions => github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d
+
+replace github.com/smartystreets/goconvey => github.com/smartystreets/goconvey v1.6.4
+
+replace github.com/soheilhy/cmux => github.com/soheilhy/cmux v0.1.4
+
+replace github.com/spf13/cast => github.com/spf13/cast v1.3.0
+
+replace github.com/stretchr/objx => github.com/stretchr/objx v0.2.0
+
+replace github.com/syndtr/gocapability => github.com/syndtr/gocapability v0.0.0-20180916011248-d98352740cb2
+
+replace github.com/tidwall/pretty => github.com/tidwall/pretty v1.0.0
+
+replace github.com/tmc/grpc-websocket-proxy => github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5
+
+replace github.com/ugorji/go => github.com/ugorji/go v1.1.4
+
+replace github.com/urfave/cli => github.com/urfave/cli v1.22.2
+
+replace github.com/vektah/gqlparser => github.com/vektah/gqlparser v1.1.2
+
+replace github.com/vishvananda/netns => github.com/vishvananda/netns v0.0.0-20200520041808-52d707b772fe
+
+replace github.com/xiang90/probing => github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2
+
+replace github.com/xlab/handysort => github.com/xlab/handysort v0.0.0-20150421192137-fb3537ed64a1
+
+replace github.com/xordataexchange/crypt => github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77
+
+replace github.com/yuin/goldmark => github.com/yuin/goldmark v1.2.1
+
+replace go.etcd.io/bbolt => go.etcd.io/bbolt v1.3.5
+
+replace go.mongodb.org/mongo-driver => go.mongodb.org/mongo-driver v1.1.2
+
+replace go.opencensus.io => go.opencensus.io v0.22.2
+
+replace go.uber.org/atomic => go.uber.org/atomic v1.4.0
+
+replace go.uber.org/multierr => go.uber.org/multierr v1.1.0
+
+replace go.uber.org/zap => go.uber.org/zap v1.10.0
+
+replace golang.org/x/exp => golang.org/x/exp v0.0.0-20191227195350-da58074b4299
+
+replace golang.org/x/image => golang.org/x/image v0.0.0-20190802002840-cff245a6509b
+
+replace golang.org/x/lint => golang.org/x/lint v0.0.0-20191125180803-fdd1cda4f05f
+
+replace golang.org/x/mobile => golang.org/x/mobile v0.0.0-20190719004257-d2bd2a29d028
+
+replace golang.org/x/mod => golang.org/x/mod v0.3.0
+
+replace golang.org/x/sync => golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9
+
+replace golang.org/x/text => golang.org/x/text v0.3.3
+
+replace golang.org/x/xerrors => golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1
+
+replace gonum.org/v1/plot => gonum.org/v1/plot v0.0.0-20190515093506-e2840ee46a6b
+
+replace google.golang.org/appengine => google.golang.org/appengine v1.6.5
+
+replace google.golang.org/genproto => google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013
+
+replace google.golang.org/protobuf => google.golang.org/protobuf v1.24.0
+
+replace gopkg.in/alecthomas/kingpin.v2 => gopkg.in/alecthomas/kingpin.v2 v2.2.6
+
+replace gopkg.in/check.v1 => gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15
+
+replace gopkg.in/cheggaaa/pb.v1 => gopkg.in/cheggaaa/pb.v1 v1.0.25
+
+replace gopkg.in/errgo.v2 => gopkg.in/errgo.v2 v2.1.0
+
+replace gopkg.in/fsnotify.v1 => gopkg.in/fsnotify.v1 v1.4.7
+
+replace gopkg.in/inf.v0 => gopkg.in/inf.v0 v0.9.1
+
+replace gopkg.in/mcuadros/go-syslog.v2 => gopkg.in/mcuadros/go-syslog.v2 v2.2.1
+
+replace gopkg.in/natefinch/lumberjack.v2 => gopkg.in/natefinch/lumberjack.v2 v2.0.0
+
+replace gopkg.in/resty.v1 => gopkg.in/resty.v1 v1.12.0
+
+replace gopkg.in/tomb.v1 => gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7
+
+replace gopkg.in/warnings.v0 => gopkg.in/warnings.v0 v0.1.1
+
+replace gotest.tools => gotest.tools v2.2.0+incompatible
+
+replace gotest.tools/v3 => gotest.tools/v3 v3.0.2
+
+replace honnef.co/go/tools => honnef.co/go/tools v0.0.1-2019.2.3
+
+replace modernc.org/cc => modernc.org/cc v1.0.0
+
+replace modernc.org/golex => modernc.org/golex v1.0.0
+
+replace modernc.org/mathutil => modernc.org/mathutil v1.0.0
+
+replace modernc.org/strutil => modernc.org/strutil v1.0.0
+
+replace modernc.org/xc => modernc.org/xc v1.0.0
+
+replace rsc.io/pdf => rsc.io/pdf v0.1.1
+
+replace sigs.k8s.io/apiserver-network-proxy/konnectivity-client => sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.15
+
+replace sigs.k8s.io/structured-merge-diff/v4 => sigs.k8s.io/structured-merge-diff/v4 v4.1.2
+
+replace vbom.ml/util => vbom.ml/util v0.0.0-20160121211510-db5cfe13f5cc

--- a/staging/src/k8s.io/code-generator/go.mod
+++ b/staging/src/k8s.io/code-generator/go.mod
@@ -5,19 +5,784 @@ module k8s.io/code-generator
 go 1.15
 
 require (
+	bitbucket.org/bertimus9/systemstat v0.0.0-20180207000608-0eeff89b0690
+	github.com/Azure/azure-sdk-for-go v43.0.0+incompatible
+	github.com/Azure/go-autorest/autorest v0.9.6
+	github.com/Azure/go-autorest/autorest/adal v0.8.2
+	github.com/Azure/go-autorest/autorest/to v0.2.0
+	github.com/GoogleCloudPlatform/k8s-cloud-provider v0.0.0-20200415212048-7901bc822317
+	github.com/JeffAshton/win_pdh v0.0.0-20161109143554-76bb4ee9f0ab
+	github.com/Microsoft/go-winio v0.4.15-0.20190919025122-fc70bd9a86b5
+	github.com/Microsoft/hcsshim v0.8.10-0.20200715222032-5eafd1556990
+	github.com/PuerkitoBio/purell v1.1.1
+	github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e
+	github.com/auth0/go-jwt-middleware v0.0.0-20170425171159-5493cabe49f7
+	github.com/aws/aws-sdk-go v1.28.2
+	github.com/blang/semver v3.5.0+incompatible
+	github.com/boltdb/bolt v1.3.1
+	github.com/caddyserver/caddy v1.0.3
+	github.com/clusterhq/flocker-go v0.0.0-20160920122132-2b8b7259d313
+	github.com/codegangsta/negroni v1.0.0
+	github.com/container-storage-interface/spec v1.2.0
+	github.com/containernetworking/cni v0.8.0
+	github.com/coredns/corefile-migration v1.0.10
+	github.com/coreos/go-oidc v2.1.0+incompatible
+	github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e
+	github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f
+	github.com/cpuguy83/go-md2man/v2 v2.0.0
+	github.com/davecgh/go-spew v1.1.1
+	github.com/docker/distribution v2.7.1+incompatible
+	github.com/docker/docker v1.4.2-0.20200309214505-aa6a9891b09c
+	github.com/docker/go-connections v0.4.0
+	github.com/docker/go-units v0.4.0
+	github.com/elazarl/goproxy v0.0.0-20180725130230-947c36da3153
 	github.com/emicklei/go-restful v2.9.5+incompatible // indirect
+	github.com/evanphx/json-patch v4.9.0+incompatible
+	github.com/fsnotify/fsnotify v1.4.9
+	github.com/go-bindata/go-bindata v3.1.1+incompatible
+	github.com/go-openapi/analysis v0.19.5
 	github.com/go-openapi/jsonreference v0.19.3 // indirect
+	github.com/go-openapi/loads v0.19.4
 	github.com/go-openapi/spec v0.19.3 // indirect
+	github.com/go-openapi/strfmt v0.19.3
+	github.com/go-openapi/validate v0.19.5
+	github.com/go-ozzo/ozzo-validation v3.5.0+incompatible
 	github.com/gogo/protobuf v1.3.2
+	github.com/golang/groupcache v0.0.0-20191227052852-215e87163ea7
+	github.com/golang/mock v1.3.1
+	github.com/google/cadvisor v0.37.5
+	github.com/google/go-cmp v0.4.0
+	github.com/google/gofuzz v1.1.0
+	github.com/google/uuid v1.1.1
+	github.com/googleapis/gnostic v0.4.1
+	github.com/gorilla/context v1.1.1
+	github.com/hashicorp/golang-lru v0.5.1
+	github.com/heketi/heketi v9.0.1-0.20190917153846-c2e2a4ab7ab9+incompatible
+	github.com/heketi/tests v0.0.0-20151005000721-f3775cbcefd6
+	github.com/ishidawataru/sctp v0.0.0-20190723014705-7c296d48a2b5
 	github.com/json-iterator/go v1.1.10 // indirect
+	github.com/libopenstorage/openstorage v1.0.0
+	github.com/lithammer/dedent v1.1.0
+	github.com/lpabon/godbc v0.1.1
+	github.com/magiconair/properties v1.8.1
 	github.com/mailru/easyjson v0.7.0 // indirect
+	github.com/miekg/dns v1.1.4
+	github.com/moby/ipvs v1.0.1
+	github.com/mohae/deepcopy v0.0.0-20170603005431-491d3605edfb
+	github.com/mrunalp/fileutils v0.0.0-20200520151820-abd8a0e76976
+	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822
+	github.com/mvdan/xurls v1.1.0
+	github.com/onsi/ginkgo v1.11.0
+	github.com/onsi/gomega v1.7.0
+	github.com/opencontainers/go-digest v1.0.0-rc1
+	github.com/opencontainers/runc v1.0.1
+	github.com/opencontainers/selinux v1.5.2
+	github.com/pkg/errors v0.9.1
+	github.com/pmezard/go-difflib v1.0.0
+	github.com/prometheus/client_golang v1.7.1
+	github.com/prometheus/client_model v0.2.0
+	github.com/prometheus/common v0.10.0
+	github.com/quobyte/api v0.1.2
+	github.com/robfig/cron v1.1.0
+	github.com/spf13/afero v1.2.2
+	github.com/spf13/cobra v1.0.0
+	github.com/spf13/jwalterweatherman v1.1.0
 	github.com/spf13/pflag v1.0.5
+	github.com/spf13/viper v1.4.0
+	github.com/storageos/go-api v0.0.0-20180912212459-343b3eff91fc
 	github.com/stretchr/testify v1.4.0 // indirect
+	github.com/thecodeteam/goscaleio v0.1.0
+	github.com/urfave/negroni v1.0.0
+	github.com/vishvananda/netlink v1.1.0
+	github.com/vmware/govmomi v0.20.3
+	go.etcd.io/etcd v0.5.0-alpha.5.0.20200819165624-17cef6e3e9d5
+	golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9
 	golang.org/x/net v0.0.0-20201110031124-69a78807bb2b // indirect
+	golang.org/x/oauth2 v0.0.0-20191202225959-858c2ad4c8b6
+	golang.org/x/sys v0.0.0-20201112073958-5cba982894dd
+	golang.org/x/time v0.0.0-20191024005414-555d28b269f0
+	golang.org/x/tools v0.0.0-20210106214847-113979e3529a
+	gonum.org/v1/gonum v0.6.2
+	gonum.org/v1/netlib v0.0.0-20190331212654-76723241ea4e
+	google.golang.org/api v0.15.1
+	google.golang.org/grpc v1.27.0
+	gopkg.in/gcfg.v1 v1.2.0
+	gopkg.in/square/go-jose.v2 v2.2.2
+	gopkg.in/yaml.v2 v2.2.8
 	k8s.io/gengo v0.0.0-20200428234225-8167cfdcfc14
+	k8s.io/heapster v1.2.0-beta.1
 	k8s.io/klog/v2 v2.2.0
 	k8s.io/kube-openapi v0.0.0-20200805222855-6aeccd4b50c6
+	k8s.io/system-validators v1.1.2
+	k8s.io/utils v0.0.0-20200729134348-d5654de09c73
+	sigs.k8s.io/kustomize v2.0.3+incompatible
 	sigs.k8s.io/yaml v1.2.0 // indirect
 )
 
 replace k8s.io/code-generator => ../code-generator
+
+replace github.com/auth0/go-jwt-middleware => github.com/auth0/go-jwt-middleware v0.0.0-20170425171159-5493cabe49f7
+
+replace github.com/boltdb/bolt => github.com/boltdb/bolt v1.3.1
+
+replace github.com/codegangsta/negroni => github.com/codegangsta/negroni v1.0.0
+
+replace github.com/go-ozzo/ozzo-validation => github.com/go-ozzo/ozzo-validation v3.5.0+incompatible
+
+replace github.com/gorilla/context => github.com/gorilla/context v1.1.1
+
+replace github.com/heketi/tests => github.com/heketi/tests v0.0.0-20151005000721-f3775cbcefd6
+
+replace github.com/lpabon/godbc => github.com/lpabon/godbc v0.1.1
+
+replace github.com/magiconair/properties => github.com/magiconair/properties v1.8.1
+
+replace github.com/mohae/deepcopy => github.com/mohae/deepcopy v0.0.0-20170603005431-491d3605edfb
+
+replace github.com/spf13/jwalterweatherman => github.com/spf13/jwalterweatherman v1.1.0
+
+replace github.com/urfave/negroni => github.com/urfave/negroni v1.0.0
+
+replace gonum.org/v1/netlib => gonum.org/v1/netlib v0.0.0-20190331212654-76723241ea4e
+
+replace bitbucket.org/bertimus9/systemstat => bitbucket.org/bertimus9/systemstat v0.0.0-20180207000608-0eeff89b0690
+
+replace github.com/Azure/azure-sdk-for-go => github.com/Azure/azure-sdk-for-go v43.0.0+incompatible
+
+replace github.com/Azure/go-autorest/autorest => github.com/Azure/go-autorest/autorest v0.9.6
+
+replace github.com/Azure/go-autorest/autorest/adal => github.com/Azure/go-autorest/autorest/adal v0.8.2
+
+replace github.com/Azure/go-autorest/autorest/to => github.com/Azure/go-autorest/autorest/to v0.2.0
+
+replace github.com/GoogleCloudPlatform/k8s-cloud-provider => github.com/GoogleCloudPlatform/k8s-cloud-provider v0.0.0-20200415212048-7901bc822317
+
+replace github.com/JeffAshton/win_pdh => github.com/JeffAshton/win_pdh v0.0.0-20161109143554-76bb4ee9f0ab
+
+replace github.com/Microsoft/go-winio => github.com/Microsoft/go-winio v0.4.15-0.20190919025122-fc70bd9a86b5
+
+replace github.com/Microsoft/hcsshim => github.com/Microsoft/hcsshim v0.8.10-0.20200715222032-5eafd1556990
+
+replace github.com/PuerkitoBio/purell => github.com/PuerkitoBio/purell v1.1.1
+
+replace github.com/armon/circbuf => github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e
+
+replace github.com/aws/aws-sdk-go => github.com/aws/aws-sdk-go v1.28.2
+
+replace github.com/blang/semver => github.com/blang/semver v3.5.0+incompatible
+
+replace github.com/caddyserver/caddy => github.com/caddyserver/caddy v1.0.3
+
+replace github.com/clusterhq/flocker-go => github.com/clusterhq/flocker-go v0.0.0-20160920122132-2b8b7259d313
+
+replace github.com/container-storage-interface/spec => github.com/container-storage-interface/spec v1.2.0
+
+replace github.com/containernetworking/cni => github.com/containernetworking/cni v0.8.0
+
+replace github.com/coredns/corefile-migration => github.com/coredns/corefile-migration v1.0.10
+
+replace github.com/coreos/go-oidc => github.com/coreos/go-oidc v2.1.0+incompatible
+
+replace github.com/coreos/go-systemd => github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e
+
+replace github.com/coreos/pkg => github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f
+
+replace github.com/cpuguy83/go-md2man/v2 => github.com/cpuguy83/go-md2man/v2 v2.0.0
+
+replace github.com/davecgh/go-spew => github.com/davecgh/go-spew v1.1.1
+
+replace github.com/docker/distribution => github.com/docker/distribution v2.7.1+incompatible
+
+replace github.com/docker/docker => github.com/docker/docker v1.4.2-0.20200309214505-aa6a9891b09c
+
+replace github.com/docker/go-connections => github.com/docker/go-connections v0.4.0
+
+replace github.com/docker/go-units => github.com/docker/go-units v0.4.0
+
+replace github.com/elazarl/goproxy => github.com/elazarl/goproxy v0.0.0-20180725130230-947c36da3153
+
+replace github.com/emicklei/go-restful => github.com/emicklei/go-restful v2.9.5+incompatible
+
+replace github.com/evanphx/json-patch => github.com/evanphx/json-patch v4.9.0+incompatible
+
+replace github.com/fsnotify/fsnotify => github.com/fsnotify/fsnotify v1.4.9
+
+replace github.com/go-bindata/go-bindata => github.com/go-bindata/go-bindata v3.1.1+incompatible
+
+replace github.com/go-openapi/analysis => github.com/go-openapi/analysis v0.19.5
+
+replace github.com/go-openapi/loads => github.com/go-openapi/loads v0.19.4
+
+replace github.com/go-openapi/spec => github.com/go-openapi/spec v0.19.3
+
+replace github.com/go-openapi/strfmt => github.com/go-openapi/strfmt v0.19.3
+
+replace github.com/go-openapi/validate => github.com/go-openapi/validate v0.19.5
+
+replace github.com/gogo/protobuf => github.com/gogo/protobuf v1.3.2
+
+replace github.com/golang/groupcache => github.com/golang/groupcache v0.0.0-20191227052852-215e87163ea7
+
+replace github.com/golang/mock => github.com/golang/mock v1.3.1
+
+replace github.com/google/cadvisor => github.com/google/cadvisor v0.37.5
+
+replace github.com/google/go-cmp => github.com/google/go-cmp v0.4.0
+
+replace github.com/google/gofuzz => github.com/google/gofuzz v1.1.0
+
+replace github.com/google/uuid => github.com/google/uuid v1.1.1
+
+replace github.com/googleapis/gnostic => github.com/googleapis/gnostic v0.4.1
+
+replace github.com/hashicorp/golang-lru => github.com/hashicorp/golang-lru v0.5.1
+
+replace github.com/heketi/heketi => github.com/heketi/heketi v9.0.1-0.20190917153846-c2e2a4ab7ab9+incompatible
+
+replace github.com/ishidawataru/sctp => github.com/ishidawataru/sctp v0.0.0-20190723014705-7c296d48a2b5
+
+replace github.com/json-iterator/go => github.com/json-iterator/go v1.1.10
+
+replace github.com/libopenstorage/openstorage => github.com/libopenstorage/openstorage v1.0.0
+
+replace github.com/lithammer/dedent => github.com/lithammer/dedent v1.1.0
+
+replace github.com/miekg/dns => github.com/miekg/dns v1.1.4
+
+replace github.com/moby/ipvs => github.com/moby/ipvs v1.0.1
+
+replace github.com/mrunalp/fileutils => github.com/mrunalp/fileutils v0.0.0-20200520151820-abd8a0e76976
+
+replace github.com/munnerz/goautoneg => github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822
+
+replace github.com/mvdan/xurls => github.com/mvdan/xurls v1.1.0
+
+replace github.com/onsi/ginkgo => github.com/onsi/ginkgo v1.11.0
+
+replace github.com/onsi/gomega => github.com/onsi/gomega v1.7.0
+
+replace github.com/opencontainers/go-digest => github.com/opencontainers/go-digest v1.0.0-rc1
+
+replace github.com/opencontainers/runc => github.com/opencontainers/runc v1.0.1
+
+replace github.com/opencontainers/selinux => github.com/opencontainers/selinux v1.5.2
+
+replace github.com/pkg/errors => github.com/pkg/errors v0.9.1
+
+replace github.com/pmezard/go-difflib => github.com/pmezard/go-difflib v1.0.0
+
+replace github.com/prometheus/client_golang => github.com/prometheus/client_golang v1.7.1
+
+replace github.com/prometheus/client_model => github.com/prometheus/client_model v0.2.0
+
+replace github.com/prometheus/common => github.com/prometheus/common v0.10.0
+
+replace github.com/quobyte/api => github.com/quobyte/api v0.1.2
+
+replace github.com/robfig/cron => github.com/robfig/cron v1.1.0
+
+replace github.com/spf13/afero => github.com/spf13/afero v1.2.2
+
+replace github.com/spf13/cobra => github.com/spf13/cobra v1.0.0
+
+replace github.com/spf13/pflag => github.com/spf13/pflag v1.0.5
+
+replace github.com/spf13/viper => github.com/spf13/viper v1.4.0
+
+replace github.com/storageos/go-api => github.com/storageos/go-api v0.0.0-20180912212459-343b3eff91fc
+
+replace github.com/stretchr/testify => github.com/stretchr/testify v1.4.0
+
+replace github.com/thecodeteam/goscaleio => github.com/thecodeteam/goscaleio v0.1.0
+
+replace github.com/vishvananda/netlink => github.com/vishvananda/netlink v1.1.0
+
+replace github.com/vmware/govmomi => github.com/vmware/govmomi v0.20.3
+
+replace go.etcd.io/etcd => go.etcd.io/etcd v0.5.0-alpha.5.0.20200819165624-17cef6e3e9d5
+
+replace golang.org/x/crypto => golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9
+
+replace golang.org/x/net => golang.org/x/net v0.0.0-20201110031124-69a78807bb2b
+
+replace golang.org/x/oauth2 => golang.org/x/oauth2 v0.0.0-20191202225959-858c2ad4c8b6
+
+replace golang.org/x/sys => golang.org/x/sys v0.0.0-20201112073958-5cba982894dd
+
+replace golang.org/x/time => golang.org/x/time v0.0.0-20191024005414-555d28b269f0
+
+replace golang.org/x/tools => golang.org/x/tools v0.0.0-20210106214847-113979e3529a
+
+replace gonum.org/v1/gonum => gonum.org/v1/gonum v0.6.2
+
+replace google.golang.org/api => google.golang.org/api v0.15.1
+
+replace google.golang.org/grpc => google.golang.org/grpc v1.27.0
+
+replace gopkg.in/gcfg.v1 => gopkg.in/gcfg.v1 v1.2.0
+
+replace gopkg.in/square/go-jose.v2 => gopkg.in/square/go-jose.v2 v2.2.2
+
+replace gopkg.in/yaml.v2 => gopkg.in/yaml.v2 v2.2.8
+
+replace k8s.io/gengo => k8s.io/gengo v0.0.0-20200428234225-8167cfdcfc14
+
+replace k8s.io/heapster => k8s.io/heapster v1.2.0-beta.1
+
+replace k8s.io/klog/v2 => k8s.io/klog/v2 v2.2.0
+
+replace k8s.io/kube-openapi => k8s.io/kube-openapi v0.0.0-20200805222855-6aeccd4b50c6
+
+replace k8s.io/system-validators => k8s.io/system-validators v1.1.2
+
+replace k8s.io/utils => k8s.io/utils v0.0.0-20200729134348-d5654de09c73
+
+replace sigs.k8s.io/kustomize => sigs.k8s.io/kustomize v2.0.3+incompatible
+
+replace sigs.k8s.io/yaml => sigs.k8s.io/yaml v1.2.0
+
+replace cloud.google.com/go => cloud.google.com/go v0.51.0
+
+replace cloud.google.com/go/bigquery => cloud.google.com/go/bigquery v1.0.1
+
+replace cloud.google.com/go/datastore => cloud.google.com/go/datastore v1.0.0
+
+replace cloud.google.com/go/pubsub => cloud.google.com/go/pubsub v1.0.1
+
+replace cloud.google.com/go/storage => cloud.google.com/go/storage v1.0.0
+
+replace dmitri.shuralyov.com/gpu/mtl => dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9
+
+replace github.com/Azure/go-ansiterm => github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78
+
+replace github.com/Azure/go-autorest/autorest/date => github.com/Azure/go-autorest/autorest/date v0.2.0
+
+replace github.com/Azure/go-autorest/autorest/mocks => github.com/Azure/go-autorest/autorest/mocks v0.3.0
+
+replace github.com/Azure/go-autorest/autorest/validation => github.com/Azure/go-autorest/autorest/validation v0.1.0
+
+replace github.com/Azure/go-autorest/logger => github.com/Azure/go-autorest/logger v0.1.0
+
+replace github.com/Azure/go-autorest/tracing => github.com/Azure/go-autorest/tracing v0.5.0
+
+replace github.com/BurntSushi/toml => github.com/BurntSushi/toml v0.3.1
+
+replace github.com/BurntSushi/xgb => github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802
+
+replace github.com/MakeNowJust/heredoc => github.com/MakeNowJust/heredoc v0.0.0-20170808103936-bb23615498cd
+
+replace github.com/NYTimes/gziphandler => github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46
+
+replace github.com/PuerkitoBio/urlesc => github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578
+
+replace github.com/agnivade/levenshtein => github.com/agnivade/levenshtein v1.0.1
+
+replace github.com/ajstarks/svgo => github.com/ajstarks/svgo v0.0.0-20180226025133-644b8db467af
+
+replace github.com/alecthomas/template => github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751
+
+replace github.com/alecthomas/units => github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4
+
+replace github.com/andreyvit/diff => github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883
+
+replace github.com/armon/consul-api => github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6
+
+replace github.com/asaskevich/govalidator => github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a
+
+replace github.com/beorn7/perks => github.com/beorn7/perks v1.0.1
+
+replace github.com/bgentry/speakeasy => github.com/bgentry/speakeasy v0.1.0
+
+replace github.com/bifurcation/mint => github.com/bifurcation/mint v0.0.0-20180715133206-93c51c6ce115
+
+replace github.com/cenkalti/backoff => github.com/cenkalti/backoff v2.1.1+incompatible
+
+replace github.com/census-instrumentation/opencensus-proto => github.com/census-instrumentation/opencensus-proto v0.2.1
+
+replace github.com/cespare/xxhash/v2 => github.com/cespare/xxhash/v2 v2.1.1
+
+replace github.com/chai2010/gettext-go => github.com/chai2010/gettext-go v0.0.0-20160711120539-c6fed771bfd5
+
+replace github.com/checkpoint-restore/go-criu/v4 => github.com/checkpoint-restore/go-criu/v4 v4.0.2
+
+replace github.com/cheekybits/genny => github.com/cheekybits/genny v0.0.0-20170328200008-9127e812e1e9
+
+replace github.com/chzyer/logex => github.com/chzyer/logex v1.1.10
+
+replace github.com/chzyer/readline => github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e
+
+replace github.com/chzyer/test => github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1
+
+replace github.com/cilium/ebpf => github.com/cilium/ebpf v0.0.0-20200702112145-1c8d4c9ef775
+
+replace github.com/cockroachdb/datadriven => github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa
+
+replace github.com/containerd/cgroups => github.com/containerd/cgroups v0.0.0-20200531161412-0dbf7f05ba59
+
+replace github.com/containerd/console => github.com/containerd/console v1.0.0
+
+replace github.com/containerd/containerd => github.com/containerd/containerd v1.3.3
+
+replace github.com/containerd/continuity => github.com/containerd/continuity v0.0.0-20190426062206-aaeac12a7ffc
+
+replace github.com/containerd/fifo => github.com/containerd/fifo v0.0.0-20190226154929-a9fb20d87448
+
+replace github.com/containerd/go-runc => github.com/containerd/go-runc v0.0.0-20180907222934-5a6d9f37cfa3
+
+replace github.com/containerd/ttrpc => github.com/containerd/ttrpc v1.0.0
+
+replace github.com/containerd/typeurl => github.com/containerd/typeurl v1.0.0
+
+replace github.com/coreos/bbolt => github.com/coreos/bbolt v1.3.2
+
+replace github.com/coreos/etcd => github.com/coreos/etcd v3.3.10+incompatible
+
+replace github.com/coreos/go-semver => github.com/coreos/go-semver v0.3.0
+
+replace github.com/coreos/go-systemd/v22 => github.com/coreos/go-systemd/v22 v22.1.0
+
+replace github.com/creack/pty => github.com/creack/pty v1.1.7
+
+replace github.com/cyphar/filepath-securejoin => github.com/cyphar/filepath-securejoin v0.2.2
+
+replace github.com/daviddengcn/go-colortext => github.com/daviddengcn/go-colortext v0.0.0-20160507010035-511bcaf42ccd
+
+replace github.com/dgrijalva/jwt-go => github.com/dgrijalva/jwt-go v3.2.0+incompatible
+
+replace github.com/dnaeon/go-vcr => github.com/dnaeon/go-vcr v1.0.1
+
+replace github.com/docker/spdystream => github.com/docker/spdystream v0.0.0-20160310174837-449fdfce4d96
+
+replace github.com/docopt/docopt-go => github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815
+
+replace github.com/dustin/go-humanize => github.com/dustin/go-humanize v1.0.0
+
+replace github.com/envoyproxy/go-control-plane => github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473
+
+replace github.com/envoyproxy/protoc-gen-validate => github.com/envoyproxy/protoc-gen-validate v0.1.0
+
+replace github.com/euank/go-kmsg-parser => github.com/euank/go-kmsg-parser v2.0.0+incompatible
+
+replace github.com/exponent-io/jsonpath => github.com/exponent-io/jsonpath v0.0.0-20151013193312-d6023ce2651d
+
+replace github.com/fatih/camelcase => github.com/fatih/camelcase v1.0.0
+
+replace github.com/fatih/color => github.com/fatih/color v1.7.0
+
+replace github.com/flynn/go-shlex => github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568
+
+replace github.com/fogleman/gg => github.com/fogleman/gg v1.2.1-0.20190220221249-0403632d5b90
+
+replace github.com/ghodss/yaml => github.com/ghodss/yaml v1.0.0
+
+replace github.com/go-acme/lego => github.com/go-acme/lego v2.5.0+incompatible
+
+replace github.com/go-gl/glfw/v3.3/glfw => github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72
+
+replace github.com/go-ini/ini => github.com/go-ini/ini v1.9.0
+
+replace github.com/go-kit/kit => github.com/go-kit/kit v0.9.0
+
+replace github.com/go-logfmt/logfmt => github.com/go-logfmt/logfmt v0.4.0
+
+replace github.com/go-logr/logr => github.com/go-logr/logr v0.2.0
+
+replace github.com/go-openapi/errors => github.com/go-openapi/errors v0.19.2
+
+replace github.com/go-openapi/jsonpointer => github.com/go-openapi/jsonpointer v0.19.3
+
+replace github.com/go-openapi/jsonreference => github.com/go-openapi/jsonreference v0.19.3
+
+replace github.com/go-openapi/runtime => github.com/go-openapi/runtime v0.19.4
+
+replace github.com/go-openapi/swag => github.com/go-openapi/swag v0.19.5
+
+replace github.com/go-stack/stack => github.com/go-stack/stack v1.8.0
+
+replace github.com/godbus/dbus/v5 => github.com/godbus/dbus/v5 v5.0.3
+
+replace github.com/golang/freetype => github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0
+
+replace github.com/golang/glog => github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
+
+replace github.com/golang/protobuf => github.com/golang/protobuf v1.4.2
+
+replace github.com/golangplus/bytes => github.com/golangplus/bytes v0.0.0-20160111154220-45c989fe5450
+
+replace github.com/golangplus/fmt => github.com/golangplus/fmt v0.0.0-20150411045040-2a5d6d7d2995
+
+replace github.com/golangplus/testing => github.com/golangplus/testing v0.0.0-20180327235837-af21d9c3145e
+
+replace github.com/google/btree => github.com/google/btree v1.0.0
+
+replace github.com/google/martian => github.com/google/martian v2.1.0+incompatible
+
+replace github.com/google/pprof => github.com/google/pprof v0.0.0-20191218002539-d4f498aebedc
+
+replace github.com/google/renameio => github.com/google/renameio v0.1.0
+
+replace github.com/googleapis/gax-go/v2 => github.com/googleapis/gax-go/v2 v2.0.5
+
+replace github.com/gophercloud/gophercloud => github.com/gophercloud/gophercloud v0.1.0
+
+replace github.com/gopherjs/gopherjs => github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1
+
+replace github.com/gorilla/mux => github.com/gorilla/mux v1.7.3
+
+replace github.com/gorilla/websocket => github.com/gorilla/websocket v1.4.0
+
+replace github.com/gregjones/httpcache => github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7
+
+replace github.com/grpc-ecosystem/go-grpc-middleware => github.com/grpc-ecosystem/go-grpc-middleware v1.0.1-0.20190118093823-f849b5445de4
+
+replace github.com/grpc-ecosystem/go-grpc-prometheus => github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0
+
+replace github.com/grpc-ecosystem/grpc-gateway => github.com/grpc-ecosystem/grpc-gateway v1.9.5
+
+replace github.com/hashicorp/go-syslog => github.com/hashicorp/go-syslog v1.0.0
+
+replace github.com/hashicorp/hcl => github.com/hashicorp/hcl v1.0.0
+
+replace github.com/hpcloud/tail => github.com/hpcloud/tail v1.0.0
+
+replace github.com/ianlancetaylor/demangle => github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6
+
+replace github.com/imdario/mergo => github.com/imdario/mergo v0.3.5
+
+replace github.com/inconshreveable/mousetrap => github.com/inconshreveable/mousetrap v1.0.0
+
+replace github.com/jimstudt/http-authentication => github.com/jimstudt/http-authentication v0.0.0-20140401203705-3eca13d6893a
+
+replace github.com/jmespath/go-jmespath => github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af
+
+replace github.com/jonboulle/clockwork => github.com/jonboulle/clockwork v0.1.0
+
+replace github.com/jstemmer/go-junit-report => github.com/jstemmer/go-junit-report v0.9.1
+
+replace github.com/jtolds/gls => github.com/jtolds/gls v4.20.0+incompatible
+
+replace github.com/julienschmidt/httprouter => github.com/julienschmidt/httprouter v1.2.0
+
+replace github.com/jung-kurt/gofpdf => github.com/jung-kurt/gofpdf v1.0.3-0.20190309125859-24315acbbda5
+
+replace github.com/karrick/godirwalk => github.com/karrick/godirwalk v1.7.5
+
+replace github.com/kisielk/errcheck => github.com/kisielk/errcheck v1.5.0
+
+replace github.com/kisielk/gotool => github.com/kisielk/gotool v1.0.0
+
+replace github.com/klauspost/cpuid => github.com/klauspost/cpuid v1.2.0
+
+replace github.com/konsorten/go-windows-terminal-sequences => github.com/konsorten/go-windows-terminal-sequences v1.0.3
+
+replace github.com/kr/logfmt => github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515
+
+replace github.com/kr/pretty => github.com/kr/pretty v0.2.0
+
+replace github.com/kr/pty => github.com/kr/pty v1.1.5
+
+replace github.com/kr/text => github.com/kr/text v0.1.0
+
+replace github.com/kylelemons/godebug => github.com/kylelemons/godebug v0.0.0-20170820004349-d65d576e9348
+
+replace github.com/liggitt/tabwriter => github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de
+
+replace github.com/lucas-clemente/aes12 => github.com/lucas-clemente/aes12 v0.0.0-20171027163421-cd47fb39b79f
+
+replace github.com/lucas-clemente/quic-clients => github.com/lucas-clemente/quic-clients v0.1.0
+
+replace github.com/lucas-clemente/quic-go => github.com/lucas-clemente/quic-go v0.10.2
+
+replace github.com/lucas-clemente/quic-go-certificates => github.com/lucas-clemente/quic-go-certificates v0.0.0-20160823095156-d2f86524cced
+
+replace github.com/mailru/easyjson => github.com/mailru/easyjson v0.7.0
+
+replace github.com/marten-seemann/qtls => github.com/marten-seemann/qtls v0.2.3
+
+replace github.com/mattn/go-colorable => github.com/mattn/go-colorable v0.0.9
+
+replace github.com/mattn/go-isatty => github.com/mattn/go-isatty v0.0.4
+
+replace github.com/mattn/go-runewidth => github.com/mattn/go-runewidth v0.0.2
+
+replace github.com/matttproud/golang_protobuf_extensions => github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369
+
+replace github.com/mholt/certmagic => github.com/mholt/certmagic v0.6.2-0.20190624175158-6a42ef9fe8c2
+
+replace github.com/mindprince/gonvml => github.com/mindprince/gonvml v0.0.0-20190828220739-9ebdce4bb989
+
+replace github.com/mistifyio/go-zfs => github.com/mistifyio/go-zfs v2.1.2-0.20190413222219-f784269be439+incompatible
+
+replace github.com/mitchellh/go-homedir => github.com/mitchellh/go-homedir v1.1.0
+
+replace github.com/mitchellh/go-wordwrap => github.com/mitchellh/go-wordwrap v1.0.0
+
+replace github.com/mitchellh/mapstructure => github.com/mitchellh/mapstructure v1.1.2
+
+replace github.com/moby/sys/mountinfo => github.com/moby/sys/mountinfo v0.1.3
+
+replace github.com/moby/term => github.com/moby/term v0.0.0-20200312100748-672ec06f55cd
+
+replace github.com/modern-go/concurrent => github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd
+
+replace github.com/modern-go/reflect2 => github.com/modern-go/reflect2 v1.0.1
+
+replace github.com/morikuni/aec => github.com/morikuni/aec v1.0.0
+
+replace github.com/mwitkow/go-conntrack => github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223
+
+replace github.com/mxk/go-flowrate => github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f
+
+replace github.com/naoina/go-stringutil => github.com/naoina/go-stringutil v0.1.0
+
+replace github.com/naoina/toml => github.com/naoina/toml v0.1.1
+
+replace github.com/olekukonko/tablewriter => github.com/olekukonko/tablewriter v0.0.0-20170122224234-a0225b3f23b5
+
+replace github.com/opencontainers/image-spec => github.com/opencontainers/image-spec v1.0.1
+
+replace github.com/opencontainers/runtime-spec => github.com/opencontainers/runtime-spec v1.0.3-0.20200520003142-237cc4f519e2
+
+replace github.com/pelletier/go-toml => github.com/pelletier/go-toml v1.2.0
+
+replace github.com/peterbourgon/diskv => github.com/peterbourgon/diskv v2.0.1+incompatible
+
+replace github.com/pquerna/cachecontrol => github.com/pquerna/cachecontrol v0.0.0-20171018203845-0dec1b30a021
+
+replace github.com/prometheus/procfs => github.com/prometheus/procfs v0.1.3
+
+replace github.com/remyoudompheng/bigfft => github.com/remyoudompheng/bigfft v0.0.0-20170806203942-52369c62f446
+
+replace github.com/rogpeppe/fastuuid => github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af
+
+replace github.com/rogpeppe/go-internal => github.com/rogpeppe/go-internal v1.3.0
+
+replace github.com/rubiojr/go-vhd => github.com/rubiojr/go-vhd v0.0.0-20200706105327-02e210299021
+
+replace github.com/russross/blackfriday => github.com/russross/blackfriday v1.5.2
+
+replace github.com/russross/blackfriday/v2 => github.com/russross/blackfriday/v2 v2.0.1
+
+replace github.com/satori/go.uuid => github.com/satori/go.uuid v1.2.0
+
+replace github.com/seccomp/libseccomp-golang => github.com/seccomp/libseccomp-golang v0.9.1
+
+replace github.com/sergi/go-diff => github.com/sergi/go-diff v1.0.0
+
+replace github.com/shurcooL/sanitized_anchor_name => github.com/shurcooL/sanitized_anchor_name v1.0.0
+
+replace github.com/sirupsen/logrus => github.com/sirupsen/logrus v1.6.0
+
+replace github.com/smartystreets/assertions => github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d
+
+replace github.com/smartystreets/goconvey => github.com/smartystreets/goconvey v1.6.4
+
+replace github.com/soheilhy/cmux => github.com/soheilhy/cmux v0.1.4
+
+replace github.com/spf13/cast => github.com/spf13/cast v1.3.0
+
+replace github.com/stretchr/objx => github.com/stretchr/objx v0.2.0
+
+replace github.com/syndtr/gocapability => github.com/syndtr/gocapability v0.0.0-20180916011248-d98352740cb2
+
+replace github.com/tidwall/pretty => github.com/tidwall/pretty v1.0.0
+
+replace github.com/tmc/grpc-websocket-proxy => github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5
+
+replace github.com/ugorji/go => github.com/ugorji/go v1.1.4
+
+replace github.com/urfave/cli => github.com/urfave/cli v1.22.2
+
+replace github.com/vektah/gqlparser => github.com/vektah/gqlparser v1.1.2
+
+replace github.com/vishvananda/netns => github.com/vishvananda/netns v0.0.0-20200520041808-52d707b772fe
+
+replace github.com/xiang90/probing => github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2
+
+replace github.com/xlab/handysort => github.com/xlab/handysort v0.0.0-20150421192137-fb3537ed64a1
+
+replace github.com/xordataexchange/crypt => github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77
+
+replace github.com/yuin/goldmark => github.com/yuin/goldmark v1.2.1
+
+replace go.etcd.io/bbolt => go.etcd.io/bbolt v1.3.5
+
+replace go.mongodb.org/mongo-driver => go.mongodb.org/mongo-driver v1.1.2
+
+replace go.opencensus.io => go.opencensus.io v0.22.2
+
+replace go.uber.org/atomic => go.uber.org/atomic v1.4.0
+
+replace go.uber.org/multierr => go.uber.org/multierr v1.1.0
+
+replace go.uber.org/zap => go.uber.org/zap v1.10.0
+
+replace golang.org/x/exp => golang.org/x/exp v0.0.0-20191227195350-da58074b4299
+
+replace golang.org/x/image => golang.org/x/image v0.0.0-20190802002840-cff245a6509b
+
+replace golang.org/x/lint => golang.org/x/lint v0.0.0-20191125180803-fdd1cda4f05f
+
+replace golang.org/x/mobile => golang.org/x/mobile v0.0.0-20190719004257-d2bd2a29d028
+
+replace golang.org/x/mod => golang.org/x/mod v0.3.0
+
+replace golang.org/x/sync => golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9
+
+replace golang.org/x/text => golang.org/x/text v0.3.3
+
+replace golang.org/x/xerrors => golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1
+
+replace gonum.org/v1/plot => gonum.org/v1/plot v0.0.0-20190515093506-e2840ee46a6b
+
+replace google.golang.org/appengine => google.golang.org/appengine v1.6.5
+
+replace google.golang.org/genproto => google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013
+
+replace google.golang.org/protobuf => google.golang.org/protobuf v1.24.0
+
+replace gopkg.in/alecthomas/kingpin.v2 => gopkg.in/alecthomas/kingpin.v2 v2.2.6
+
+replace gopkg.in/check.v1 => gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15
+
+replace gopkg.in/cheggaaa/pb.v1 => gopkg.in/cheggaaa/pb.v1 v1.0.25
+
+replace gopkg.in/errgo.v2 => gopkg.in/errgo.v2 v2.1.0
+
+replace gopkg.in/fsnotify.v1 => gopkg.in/fsnotify.v1 v1.4.7
+
+replace gopkg.in/inf.v0 => gopkg.in/inf.v0 v0.9.1
+
+replace gopkg.in/mcuadros/go-syslog.v2 => gopkg.in/mcuadros/go-syslog.v2 v2.2.1
+
+replace gopkg.in/natefinch/lumberjack.v2 => gopkg.in/natefinch/lumberjack.v2 v2.0.0
+
+replace gopkg.in/resty.v1 => gopkg.in/resty.v1 v1.12.0
+
+replace gopkg.in/tomb.v1 => gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7
+
+replace gopkg.in/warnings.v0 => gopkg.in/warnings.v0 v0.1.1
+
+replace gotest.tools => gotest.tools v2.2.0+incompatible
+
+replace gotest.tools/v3 => gotest.tools/v3 v3.0.2
+
+replace honnef.co/go/tools => honnef.co/go/tools v0.0.1-2019.2.3
+
+replace modernc.org/cc => modernc.org/cc v1.0.0
+
+replace modernc.org/golex => modernc.org/golex v1.0.0
+
+replace modernc.org/mathutil => modernc.org/mathutil v1.0.0
+
+replace modernc.org/strutil => modernc.org/strutil v1.0.0
+
+replace modernc.org/xc => modernc.org/xc v1.0.0
+
+replace rsc.io/pdf => rsc.io/pdf v0.1.1
+
+replace sigs.k8s.io/apiserver-network-proxy/konnectivity-client => sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.15
+
+replace sigs.k8s.io/structured-merge-diff/v4 => sigs.k8s.io/structured-merge-diff/v4 v4.1.2
+
+replace vbom.ml/util => vbom.ml/util v0.0.0-20160121211510-db5cfe13f5cc

--- a/staging/src/k8s.io/component-base/go.mod
+++ b/staging/src/k8s.io/component-base/go.mod
@@ -5,25 +5,126 @@ module k8s.io/component-base
 go 1.15
 
 require (
+	bitbucket.org/bertimus9/systemstat v0.0.0-20180207000608-0eeff89b0690
+	github.com/Azure/azure-sdk-for-go v43.0.0+incompatible
+	github.com/Azure/go-autorest/autorest v0.9.6
+	github.com/Azure/go-autorest/autorest/adal v0.8.2
+	github.com/Azure/go-autorest/autorest/to v0.2.0
+	github.com/GoogleCloudPlatform/k8s-cloud-provider v0.0.0-20200415212048-7901bc822317
+	github.com/JeffAshton/win_pdh v0.0.0-20161109143554-76bb4ee9f0ab
+	github.com/Microsoft/go-winio v0.4.15-0.20190919025122-fc70bd9a86b5
+	github.com/Microsoft/hcsshim v0.8.10-0.20200715222032-5eafd1556990
+	github.com/PuerkitoBio/purell v1.1.1
+	github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e
+	github.com/auth0/go-jwt-middleware v0.0.0-20170425171159-5493cabe49f7
+	github.com/aws/aws-sdk-go v1.28.2
 	github.com/blang/semver v3.5.0+incompatible
+	github.com/boltdb/bolt v1.3.1
+	github.com/caddyserver/caddy v1.0.3
+	github.com/clusterhq/flocker-go v0.0.0-20160920122132-2b8b7259d313
+	github.com/codegangsta/negroni v1.0.0
+	github.com/container-storage-interface/spec v1.2.0
+	github.com/containernetworking/cni v0.8.0
+	github.com/coredns/corefile-migration v1.0.10
+	github.com/coreos/go-oidc v2.1.0+incompatible
+	github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e
+	github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f
+	github.com/cpuguy83/go-md2man/v2 v2.0.0
+	github.com/davecgh/go-spew v1.1.1
+	github.com/docker/distribution v2.7.1+incompatible
+	github.com/docker/docker v1.4.2-0.20200309214505-aa6a9891b09c
+	github.com/docker/go-connections v0.4.0
+	github.com/docker/go-units v0.4.0
+	github.com/elazarl/goproxy v0.0.0-20180725130230-947c36da3153
+	github.com/emicklei/go-restful v2.9.5+incompatible
+	github.com/evanphx/json-patch v4.9.0+incompatible
+	github.com/fsnotify/fsnotify v1.4.9
+	github.com/go-bindata/go-bindata v3.1.1+incompatible
 	github.com/go-logr/logr v0.2.0
+	github.com/go-openapi/analysis v0.19.5
+	github.com/go-openapi/loads v0.19.4
+	github.com/go-openapi/spec v0.19.3
+	github.com/go-openapi/strfmt v0.19.3
+	github.com/go-openapi/validate v0.19.5
+	github.com/go-ozzo/ozzo-validation v3.5.0+incompatible
+	github.com/gogo/protobuf v1.3.2
+	github.com/golang/groupcache v0.0.0-20191227052852-215e87163ea7
+	github.com/golang/mock v1.3.1
+	github.com/google/cadvisor v0.37.5
 	github.com/google/go-cmp v0.4.0
+	github.com/google/gofuzz v1.1.0
+	github.com/google/uuid v1.1.1
+	github.com/googleapis/gnostic v0.4.1
+	github.com/gorilla/context v1.1.1
+	github.com/hashicorp/golang-lru v0.5.1
+	github.com/heketi/heketi v9.0.1-0.20190917153846-c2e2a4ab7ab9+incompatible
+	github.com/heketi/tests v0.0.0-20151005000721-f3775cbcefd6
+	github.com/ishidawataru/sctp v0.0.0-20190723014705-7c296d48a2b5
+	github.com/json-iterator/go v1.1.10
+	github.com/libopenstorage/openstorage v1.0.0
+	github.com/lithammer/dedent v1.1.0
+	github.com/lpabon/godbc v0.1.1
+	github.com/magiconair/properties v1.8.1
 	github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369 // indirect
+	github.com/miekg/dns v1.1.4
+	github.com/moby/ipvs v1.0.1
 	github.com/moby/term v0.0.0-20200312100748-672ec06f55cd
+	github.com/mohae/deepcopy v0.0.0-20170603005431-491d3605edfb
+	github.com/mrunalp/fileutils v0.0.0-20200520151820-abd8a0e76976
+	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822
+	github.com/mvdan/xurls v1.1.0
+	github.com/onsi/ginkgo v1.11.0
+	github.com/onsi/gomega v1.7.0
+	github.com/opencontainers/go-digest v1.0.0-rc1
+	github.com/opencontainers/runc v1.0.1
+	github.com/opencontainers/selinux v1.5.2
+	github.com/pkg/errors v0.9.1
+	github.com/pmezard/go-difflib v1.0.0
 	github.com/prometheus/client_golang v1.7.1
 	github.com/prometheus/client_model v0.2.0
 	github.com/prometheus/common v0.10.0
 	github.com/prometheus/procfs v0.1.3
+	github.com/quobyte/api v0.1.2
+	github.com/robfig/cron v1.1.0
 	github.com/sirupsen/logrus v1.6.0 // indirect
+	github.com/spf13/afero v1.2.2
+	github.com/spf13/cobra v1.0.0
+	github.com/spf13/jwalterweatherman v1.1.0
 	github.com/spf13/pflag v1.0.5
+	github.com/spf13/viper v1.4.0
+	github.com/storageos/go-api v0.0.0-20180912212459-343b3eff91fc
 	github.com/stretchr/testify v1.4.0
+	github.com/thecodeteam/goscaleio v0.1.0
+	github.com/urfave/negroni v1.0.0
+	github.com/vishvananda/netlink v1.1.0
+	github.com/vmware/govmomi v0.20.3
+	go.etcd.io/etcd v0.5.0-alpha.5.0.20200819165624-17cef6e3e9d5
 	go.uber.org/atomic v1.4.0 // indirect
 	go.uber.org/multierr v1.1.0 // indirect
 	go.uber.org/zap v1.10.0
+	golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9
+	golang.org/x/net v0.0.0-20201110031124-69a78807bb2b
+	golang.org/x/oauth2 v0.0.0-20191202225959-858c2ad4c8b6
+	golang.org/x/sys v0.0.0-20201112073958-5cba982894dd
+	golang.org/x/time v0.0.0-20191024005414-555d28b269f0
+	golang.org/x/tools v0.0.0-20210106214847-113979e3529a
+	gonum.org/v1/gonum v0.6.2
+	gonum.org/v1/netlib v0.0.0-20190331212654-76723241ea4e
+	google.golang.org/api v0.15.1
+	google.golang.org/grpc v1.27.0
+	gopkg.in/gcfg.v1 v1.2.0
+	gopkg.in/square/go-jose.v2 v2.2.2
+	gopkg.in/yaml.v2 v2.2.8
 	k8s.io/apimachinery v0.0.0
 	k8s.io/client-go v0.0.0
+	k8s.io/gengo v0.0.0-20200428234225-8167cfdcfc14
+	k8s.io/heapster v1.2.0-beta.1
 	k8s.io/klog/v2 v2.2.0
+	k8s.io/kube-openapi v0.0.0-20200805222855-6aeccd4b50c6
+	k8s.io/system-validators v1.1.2
 	k8s.io/utils v0.0.0-20200729134348-d5654de09c73
+	sigs.k8s.io/kustomize v2.0.3+incompatible
+	sigs.k8s.io/yaml v1.2.0
 )
 
 replace (
@@ -32,3 +133,669 @@ replace (
 	k8s.io/client-go => ../client-go
 	k8s.io/component-base => ../component-base
 )
+
+replace github.com/auth0/go-jwt-middleware => github.com/auth0/go-jwt-middleware v0.0.0-20170425171159-5493cabe49f7
+
+replace github.com/boltdb/bolt => github.com/boltdb/bolt v1.3.1
+
+replace github.com/codegangsta/negroni => github.com/codegangsta/negroni v1.0.0
+
+replace github.com/go-ozzo/ozzo-validation => github.com/go-ozzo/ozzo-validation v3.5.0+incompatible
+
+replace github.com/gorilla/context => github.com/gorilla/context v1.1.1
+
+replace github.com/heketi/tests => github.com/heketi/tests v0.0.0-20151005000721-f3775cbcefd6
+
+replace github.com/lpabon/godbc => github.com/lpabon/godbc v0.1.1
+
+replace github.com/magiconair/properties => github.com/magiconair/properties v1.8.1
+
+replace github.com/mohae/deepcopy => github.com/mohae/deepcopy v0.0.0-20170603005431-491d3605edfb
+
+replace github.com/spf13/jwalterweatherman => github.com/spf13/jwalterweatherman v1.1.0
+
+replace github.com/urfave/negroni => github.com/urfave/negroni v1.0.0
+
+replace gonum.org/v1/netlib => gonum.org/v1/netlib v0.0.0-20190331212654-76723241ea4e
+
+replace bitbucket.org/bertimus9/systemstat => bitbucket.org/bertimus9/systemstat v0.0.0-20180207000608-0eeff89b0690
+
+replace github.com/Azure/azure-sdk-for-go => github.com/Azure/azure-sdk-for-go v43.0.0+incompatible
+
+replace github.com/Azure/go-autorest/autorest => github.com/Azure/go-autorest/autorest v0.9.6
+
+replace github.com/Azure/go-autorest/autorest/adal => github.com/Azure/go-autorest/autorest/adal v0.8.2
+
+replace github.com/Azure/go-autorest/autorest/to => github.com/Azure/go-autorest/autorest/to v0.2.0
+
+replace github.com/GoogleCloudPlatform/k8s-cloud-provider => github.com/GoogleCloudPlatform/k8s-cloud-provider v0.0.0-20200415212048-7901bc822317
+
+replace github.com/JeffAshton/win_pdh => github.com/JeffAshton/win_pdh v0.0.0-20161109143554-76bb4ee9f0ab
+
+replace github.com/Microsoft/go-winio => github.com/Microsoft/go-winio v0.4.15-0.20190919025122-fc70bd9a86b5
+
+replace github.com/Microsoft/hcsshim => github.com/Microsoft/hcsshim v0.8.10-0.20200715222032-5eafd1556990
+
+replace github.com/PuerkitoBio/purell => github.com/PuerkitoBio/purell v1.1.1
+
+replace github.com/armon/circbuf => github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e
+
+replace github.com/aws/aws-sdk-go => github.com/aws/aws-sdk-go v1.28.2
+
+replace github.com/blang/semver => github.com/blang/semver v3.5.0+incompatible
+
+replace github.com/caddyserver/caddy => github.com/caddyserver/caddy v1.0.3
+
+replace github.com/clusterhq/flocker-go => github.com/clusterhq/flocker-go v0.0.0-20160920122132-2b8b7259d313
+
+replace github.com/container-storage-interface/spec => github.com/container-storage-interface/spec v1.2.0
+
+replace github.com/containernetworking/cni => github.com/containernetworking/cni v0.8.0
+
+replace github.com/coredns/corefile-migration => github.com/coredns/corefile-migration v1.0.10
+
+replace github.com/coreos/go-oidc => github.com/coreos/go-oidc v2.1.0+incompatible
+
+replace github.com/coreos/go-systemd => github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e
+
+replace github.com/coreos/pkg => github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f
+
+replace github.com/cpuguy83/go-md2man/v2 => github.com/cpuguy83/go-md2man/v2 v2.0.0
+
+replace github.com/davecgh/go-spew => github.com/davecgh/go-spew v1.1.1
+
+replace github.com/docker/distribution => github.com/docker/distribution v2.7.1+incompatible
+
+replace github.com/docker/docker => github.com/docker/docker v1.4.2-0.20200309214505-aa6a9891b09c
+
+replace github.com/docker/go-connections => github.com/docker/go-connections v0.4.0
+
+replace github.com/docker/go-units => github.com/docker/go-units v0.4.0
+
+replace github.com/elazarl/goproxy => github.com/elazarl/goproxy v0.0.0-20180725130230-947c36da3153
+
+replace github.com/emicklei/go-restful => github.com/emicklei/go-restful v2.9.5+incompatible
+
+replace github.com/evanphx/json-patch => github.com/evanphx/json-patch v4.9.0+incompatible
+
+replace github.com/fsnotify/fsnotify => github.com/fsnotify/fsnotify v1.4.9
+
+replace github.com/go-bindata/go-bindata => github.com/go-bindata/go-bindata v3.1.1+incompatible
+
+replace github.com/go-openapi/analysis => github.com/go-openapi/analysis v0.19.5
+
+replace github.com/go-openapi/loads => github.com/go-openapi/loads v0.19.4
+
+replace github.com/go-openapi/spec => github.com/go-openapi/spec v0.19.3
+
+replace github.com/go-openapi/strfmt => github.com/go-openapi/strfmt v0.19.3
+
+replace github.com/go-openapi/validate => github.com/go-openapi/validate v0.19.5
+
+replace github.com/gogo/protobuf => github.com/gogo/protobuf v1.3.2
+
+replace github.com/golang/groupcache => github.com/golang/groupcache v0.0.0-20191227052852-215e87163ea7
+
+replace github.com/golang/mock => github.com/golang/mock v1.3.1
+
+replace github.com/google/cadvisor => github.com/google/cadvisor v0.37.5
+
+replace github.com/google/go-cmp => github.com/google/go-cmp v0.4.0
+
+replace github.com/google/gofuzz => github.com/google/gofuzz v1.1.0
+
+replace github.com/google/uuid => github.com/google/uuid v1.1.1
+
+replace github.com/googleapis/gnostic => github.com/googleapis/gnostic v0.4.1
+
+replace github.com/hashicorp/golang-lru => github.com/hashicorp/golang-lru v0.5.1
+
+replace github.com/heketi/heketi => github.com/heketi/heketi v9.0.1-0.20190917153846-c2e2a4ab7ab9+incompatible
+
+replace github.com/ishidawataru/sctp => github.com/ishidawataru/sctp v0.0.0-20190723014705-7c296d48a2b5
+
+replace github.com/json-iterator/go => github.com/json-iterator/go v1.1.10
+
+replace github.com/libopenstorage/openstorage => github.com/libopenstorage/openstorage v1.0.0
+
+replace github.com/lithammer/dedent => github.com/lithammer/dedent v1.1.0
+
+replace github.com/miekg/dns => github.com/miekg/dns v1.1.4
+
+replace github.com/moby/ipvs => github.com/moby/ipvs v1.0.1
+
+replace github.com/mrunalp/fileutils => github.com/mrunalp/fileutils v0.0.0-20200520151820-abd8a0e76976
+
+replace github.com/munnerz/goautoneg => github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822
+
+replace github.com/mvdan/xurls => github.com/mvdan/xurls v1.1.0
+
+replace github.com/onsi/ginkgo => github.com/onsi/ginkgo v1.11.0
+
+replace github.com/onsi/gomega => github.com/onsi/gomega v1.7.0
+
+replace github.com/opencontainers/go-digest => github.com/opencontainers/go-digest v1.0.0-rc1
+
+replace github.com/opencontainers/runc => github.com/opencontainers/runc v1.0.1
+
+replace github.com/opencontainers/selinux => github.com/opencontainers/selinux v1.5.2
+
+replace github.com/pkg/errors => github.com/pkg/errors v0.9.1
+
+replace github.com/pmezard/go-difflib => github.com/pmezard/go-difflib v1.0.0
+
+replace github.com/prometheus/client_golang => github.com/prometheus/client_golang v1.7.1
+
+replace github.com/prometheus/client_model => github.com/prometheus/client_model v0.2.0
+
+replace github.com/prometheus/common => github.com/prometheus/common v0.10.0
+
+replace github.com/quobyte/api => github.com/quobyte/api v0.1.2
+
+replace github.com/robfig/cron => github.com/robfig/cron v1.1.0
+
+replace github.com/spf13/afero => github.com/spf13/afero v1.2.2
+
+replace github.com/spf13/cobra => github.com/spf13/cobra v1.0.0
+
+replace github.com/spf13/pflag => github.com/spf13/pflag v1.0.5
+
+replace github.com/spf13/viper => github.com/spf13/viper v1.4.0
+
+replace github.com/storageos/go-api => github.com/storageos/go-api v0.0.0-20180912212459-343b3eff91fc
+
+replace github.com/stretchr/testify => github.com/stretchr/testify v1.4.0
+
+replace github.com/thecodeteam/goscaleio => github.com/thecodeteam/goscaleio v0.1.0
+
+replace github.com/vishvananda/netlink => github.com/vishvananda/netlink v1.1.0
+
+replace github.com/vmware/govmomi => github.com/vmware/govmomi v0.20.3
+
+replace go.etcd.io/etcd => go.etcd.io/etcd v0.5.0-alpha.5.0.20200819165624-17cef6e3e9d5
+
+replace golang.org/x/crypto => golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9
+
+replace golang.org/x/net => golang.org/x/net v0.0.0-20201110031124-69a78807bb2b
+
+replace golang.org/x/oauth2 => golang.org/x/oauth2 v0.0.0-20191202225959-858c2ad4c8b6
+
+replace golang.org/x/sys => golang.org/x/sys v0.0.0-20201112073958-5cba982894dd
+
+replace golang.org/x/time => golang.org/x/time v0.0.0-20191024005414-555d28b269f0
+
+replace golang.org/x/tools => golang.org/x/tools v0.0.0-20210106214847-113979e3529a
+
+replace gonum.org/v1/gonum => gonum.org/v1/gonum v0.6.2
+
+replace google.golang.org/api => google.golang.org/api v0.15.1
+
+replace google.golang.org/grpc => google.golang.org/grpc v1.27.0
+
+replace gopkg.in/gcfg.v1 => gopkg.in/gcfg.v1 v1.2.0
+
+replace gopkg.in/square/go-jose.v2 => gopkg.in/square/go-jose.v2 v2.2.2
+
+replace gopkg.in/yaml.v2 => gopkg.in/yaml.v2 v2.2.8
+
+replace k8s.io/gengo => k8s.io/gengo v0.0.0-20200428234225-8167cfdcfc14
+
+replace k8s.io/heapster => k8s.io/heapster v1.2.0-beta.1
+
+replace k8s.io/klog/v2 => k8s.io/klog/v2 v2.2.0
+
+replace k8s.io/kube-openapi => k8s.io/kube-openapi v0.0.0-20200805222855-6aeccd4b50c6
+
+replace k8s.io/system-validators => k8s.io/system-validators v1.1.2
+
+replace k8s.io/utils => k8s.io/utils v0.0.0-20200729134348-d5654de09c73
+
+replace sigs.k8s.io/kustomize => sigs.k8s.io/kustomize v2.0.3+incompatible
+
+replace sigs.k8s.io/yaml => sigs.k8s.io/yaml v1.2.0
+
+replace cloud.google.com/go => cloud.google.com/go v0.51.0
+
+replace cloud.google.com/go/bigquery => cloud.google.com/go/bigquery v1.0.1
+
+replace cloud.google.com/go/datastore => cloud.google.com/go/datastore v1.0.0
+
+replace cloud.google.com/go/pubsub => cloud.google.com/go/pubsub v1.0.1
+
+replace cloud.google.com/go/storage => cloud.google.com/go/storage v1.0.0
+
+replace dmitri.shuralyov.com/gpu/mtl => dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9
+
+replace github.com/Azure/go-ansiterm => github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78
+
+replace github.com/Azure/go-autorest/autorest/date => github.com/Azure/go-autorest/autorest/date v0.2.0
+
+replace github.com/Azure/go-autorest/autorest/mocks => github.com/Azure/go-autorest/autorest/mocks v0.3.0
+
+replace github.com/Azure/go-autorest/autorest/validation => github.com/Azure/go-autorest/autorest/validation v0.1.0
+
+replace github.com/Azure/go-autorest/logger => github.com/Azure/go-autorest/logger v0.1.0
+
+replace github.com/Azure/go-autorest/tracing => github.com/Azure/go-autorest/tracing v0.5.0
+
+replace github.com/BurntSushi/toml => github.com/BurntSushi/toml v0.3.1
+
+replace github.com/BurntSushi/xgb => github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802
+
+replace github.com/MakeNowJust/heredoc => github.com/MakeNowJust/heredoc v0.0.0-20170808103936-bb23615498cd
+
+replace github.com/NYTimes/gziphandler => github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46
+
+replace github.com/PuerkitoBio/urlesc => github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578
+
+replace github.com/agnivade/levenshtein => github.com/agnivade/levenshtein v1.0.1
+
+replace github.com/ajstarks/svgo => github.com/ajstarks/svgo v0.0.0-20180226025133-644b8db467af
+
+replace github.com/alecthomas/template => github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751
+
+replace github.com/alecthomas/units => github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4
+
+replace github.com/andreyvit/diff => github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883
+
+replace github.com/armon/consul-api => github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6
+
+replace github.com/asaskevich/govalidator => github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a
+
+replace github.com/beorn7/perks => github.com/beorn7/perks v1.0.1
+
+replace github.com/bgentry/speakeasy => github.com/bgentry/speakeasy v0.1.0
+
+replace github.com/bifurcation/mint => github.com/bifurcation/mint v0.0.0-20180715133206-93c51c6ce115
+
+replace github.com/cenkalti/backoff => github.com/cenkalti/backoff v2.1.1+incompatible
+
+replace github.com/census-instrumentation/opencensus-proto => github.com/census-instrumentation/opencensus-proto v0.2.1
+
+replace github.com/cespare/xxhash/v2 => github.com/cespare/xxhash/v2 v2.1.1
+
+replace github.com/chai2010/gettext-go => github.com/chai2010/gettext-go v0.0.0-20160711120539-c6fed771bfd5
+
+replace github.com/checkpoint-restore/go-criu/v4 => github.com/checkpoint-restore/go-criu/v4 v4.0.2
+
+replace github.com/cheekybits/genny => github.com/cheekybits/genny v0.0.0-20170328200008-9127e812e1e9
+
+replace github.com/chzyer/logex => github.com/chzyer/logex v1.1.10
+
+replace github.com/chzyer/readline => github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e
+
+replace github.com/chzyer/test => github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1
+
+replace github.com/cilium/ebpf => github.com/cilium/ebpf v0.0.0-20200702112145-1c8d4c9ef775
+
+replace github.com/cockroachdb/datadriven => github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa
+
+replace github.com/containerd/cgroups => github.com/containerd/cgroups v0.0.0-20200531161412-0dbf7f05ba59
+
+replace github.com/containerd/console => github.com/containerd/console v1.0.0
+
+replace github.com/containerd/containerd => github.com/containerd/containerd v1.3.3
+
+replace github.com/containerd/continuity => github.com/containerd/continuity v0.0.0-20190426062206-aaeac12a7ffc
+
+replace github.com/containerd/fifo => github.com/containerd/fifo v0.0.0-20190226154929-a9fb20d87448
+
+replace github.com/containerd/go-runc => github.com/containerd/go-runc v0.0.0-20180907222934-5a6d9f37cfa3
+
+replace github.com/containerd/ttrpc => github.com/containerd/ttrpc v1.0.0
+
+replace github.com/containerd/typeurl => github.com/containerd/typeurl v1.0.0
+
+replace github.com/coreos/bbolt => github.com/coreos/bbolt v1.3.2
+
+replace github.com/coreos/etcd => github.com/coreos/etcd v3.3.10+incompatible
+
+replace github.com/coreos/go-semver => github.com/coreos/go-semver v0.3.0
+
+replace github.com/coreos/go-systemd/v22 => github.com/coreos/go-systemd/v22 v22.1.0
+
+replace github.com/creack/pty => github.com/creack/pty v1.1.7
+
+replace github.com/cyphar/filepath-securejoin => github.com/cyphar/filepath-securejoin v0.2.2
+
+replace github.com/daviddengcn/go-colortext => github.com/daviddengcn/go-colortext v0.0.0-20160507010035-511bcaf42ccd
+
+replace github.com/dgrijalva/jwt-go => github.com/dgrijalva/jwt-go v3.2.0+incompatible
+
+replace github.com/dnaeon/go-vcr => github.com/dnaeon/go-vcr v1.0.1
+
+replace github.com/docker/spdystream => github.com/docker/spdystream v0.0.0-20160310174837-449fdfce4d96
+
+replace github.com/docopt/docopt-go => github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815
+
+replace github.com/dustin/go-humanize => github.com/dustin/go-humanize v1.0.0
+
+replace github.com/envoyproxy/go-control-plane => github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473
+
+replace github.com/envoyproxy/protoc-gen-validate => github.com/envoyproxy/protoc-gen-validate v0.1.0
+
+replace github.com/euank/go-kmsg-parser => github.com/euank/go-kmsg-parser v2.0.0+incompatible
+
+replace github.com/exponent-io/jsonpath => github.com/exponent-io/jsonpath v0.0.0-20151013193312-d6023ce2651d
+
+replace github.com/fatih/camelcase => github.com/fatih/camelcase v1.0.0
+
+replace github.com/fatih/color => github.com/fatih/color v1.7.0
+
+replace github.com/flynn/go-shlex => github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568
+
+replace github.com/fogleman/gg => github.com/fogleman/gg v1.2.1-0.20190220221249-0403632d5b90
+
+replace github.com/ghodss/yaml => github.com/ghodss/yaml v1.0.0
+
+replace github.com/go-acme/lego => github.com/go-acme/lego v2.5.0+incompatible
+
+replace github.com/go-gl/glfw/v3.3/glfw => github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72
+
+replace github.com/go-ini/ini => github.com/go-ini/ini v1.9.0
+
+replace github.com/go-kit/kit => github.com/go-kit/kit v0.9.0
+
+replace github.com/go-logfmt/logfmt => github.com/go-logfmt/logfmt v0.4.0
+
+replace github.com/go-logr/logr => github.com/go-logr/logr v0.2.0
+
+replace github.com/go-openapi/errors => github.com/go-openapi/errors v0.19.2
+
+replace github.com/go-openapi/jsonpointer => github.com/go-openapi/jsonpointer v0.19.3
+
+replace github.com/go-openapi/jsonreference => github.com/go-openapi/jsonreference v0.19.3
+
+replace github.com/go-openapi/runtime => github.com/go-openapi/runtime v0.19.4
+
+replace github.com/go-openapi/swag => github.com/go-openapi/swag v0.19.5
+
+replace github.com/go-stack/stack => github.com/go-stack/stack v1.8.0
+
+replace github.com/godbus/dbus/v5 => github.com/godbus/dbus/v5 v5.0.3
+
+replace github.com/golang/freetype => github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0
+
+replace github.com/golang/glog => github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
+
+replace github.com/golang/protobuf => github.com/golang/protobuf v1.4.2
+
+replace github.com/golangplus/bytes => github.com/golangplus/bytes v0.0.0-20160111154220-45c989fe5450
+
+replace github.com/golangplus/fmt => github.com/golangplus/fmt v0.0.0-20150411045040-2a5d6d7d2995
+
+replace github.com/golangplus/testing => github.com/golangplus/testing v0.0.0-20180327235837-af21d9c3145e
+
+replace github.com/google/btree => github.com/google/btree v1.0.0
+
+replace github.com/google/martian => github.com/google/martian v2.1.0+incompatible
+
+replace github.com/google/pprof => github.com/google/pprof v0.0.0-20191218002539-d4f498aebedc
+
+replace github.com/google/renameio => github.com/google/renameio v0.1.0
+
+replace github.com/googleapis/gax-go/v2 => github.com/googleapis/gax-go/v2 v2.0.5
+
+replace github.com/gophercloud/gophercloud => github.com/gophercloud/gophercloud v0.1.0
+
+replace github.com/gopherjs/gopherjs => github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1
+
+replace github.com/gorilla/mux => github.com/gorilla/mux v1.7.3
+
+replace github.com/gorilla/websocket => github.com/gorilla/websocket v1.4.0
+
+replace github.com/gregjones/httpcache => github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7
+
+replace github.com/grpc-ecosystem/go-grpc-middleware => github.com/grpc-ecosystem/go-grpc-middleware v1.0.1-0.20190118093823-f849b5445de4
+
+replace github.com/grpc-ecosystem/go-grpc-prometheus => github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0
+
+replace github.com/grpc-ecosystem/grpc-gateway => github.com/grpc-ecosystem/grpc-gateway v1.9.5
+
+replace github.com/hashicorp/go-syslog => github.com/hashicorp/go-syslog v1.0.0
+
+replace github.com/hashicorp/hcl => github.com/hashicorp/hcl v1.0.0
+
+replace github.com/hpcloud/tail => github.com/hpcloud/tail v1.0.0
+
+replace github.com/ianlancetaylor/demangle => github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6
+
+replace github.com/imdario/mergo => github.com/imdario/mergo v0.3.5
+
+replace github.com/inconshreveable/mousetrap => github.com/inconshreveable/mousetrap v1.0.0
+
+replace github.com/jimstudt/http-authentication => github.com/jimstudt/http-authentication v0.0.0-20140401203705-3eca13d6893a
+
+replace github.com/jmespath/go-jmespath => github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af
+
+replace github.com/jonboulle/clockwork => github.com/jonboulle/clockwork v0.1.0
+
+replace github.com/jstemmer/go-junit-report => github.com/jstemmer/go-junit-report v0.9.1
+
+replace github.com/jtolds/gls => github.com/jtolds/gls v4.20.0+incompatible
+
+replace github.com/julienschmidt/httprouter => github.com/julienschmidt/httprouter v1.2.0
+
+replace github.com/jung-kurt/gofpdf => github.com/jung-kurt/gofpdf v1.0.3-0.20190309125859-24315acbbda5
+
+replace github.com/karrick/godirwalk => github.com/karrick/godirwalk v1.7.5
+
+replace github.com/kisielk/errcheck => github.com/kisielk/errcheck v1.5.0
+
+replace github.com/kisielk/gotool => github.com/kisielk/gotool v1.0.0
+
+replace github.com/klauspost/cpuid => github.com/klauspost/cpuid v1.2.0
+
+replace github.com/konsorten/go-windows-terminal-sequences => github.com/konsorten/go-windows-terminal-sequences v1.0.3
+
+replace github.com/kr/logfmt => github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515
+
+replace github.com/kr/pretty => github.com/kr/pretty v0.2.0
+
+replace github.com/kr/pty => github.com/kr/pty v1.1.5
+
+replace github.com/kr/text => github.com/kr/text v0.1.0
+
+replace github.com/kylelemons/godebug => github.com/kylelemons/godebug v0.0.0-20170820004349-d65d576e9348
+
+replace github.com/liggitt/tabwriter => github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de
+
+replace github.com/lucas-clemente/aes12 => github.com/lucas-clemente/aes12 v0.0.0-20171027163421-cd47fb39b79f
+
+replace github.com/lucas-clemente/quic-clients => github.com/lucas-clemente/quic-clients v0.1.0
+
+replace github.com/lucas-clemente/quic-go => github.com/lucas-clemente/quic-go v0.10.2
+
+replace github.com/lucas-clemente/quic-go-certificates => github.com/lucas-clemente/quic-go-certificates v0.0.0-20160823095156-d2f86524cced
+
+replace github.com/mailru/easyjson => github.com/mailru/easyjson v0.7.0
+
+replace github.com/marten-seemann/qtls => github.com/marten-seemann/qtls v0.2.3
+
+replace github.com/mattn/go-colorable => github.com/mattn/go-colorable v0.0.9
+
+replace github.com/mattn/go-isatty => github.com/mattn/go-isatty v0.0.4
+
+replace github.com/mattn/go-runewidth => github.com/mattn/go-runewidth v0.0.2
+
+replace github.com/matttproud/golang_protobuf_extensions => github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369
+
+replace github.com/mholt/certmagic => github.com/mholt/certmagic v0.6.2-0.20190624175158-6a42ef9fe8c2
+
+replace github.com/mindprince/gonvml => github.com/mindprince/gonvml v0.0.0-20190828220739-9ebdce4bb989
+
+replace github.com/mistifyio/go-zfs => github.com/mistifyio/go-zfs v2.1.2-0.20190413222219-f784269be439+incompatible
+
+replace github.com/mitchellh/go-homedir => github.com/mitchellh/go-homedir v1.1.0
+
+replace github.com/mitchellh/go-wordwrap => github.com/mitchellh/go-wordwrap v1.0.0
+
+replace github.com/mitchellh/mapstructure => github.com/mitchellh/mapstructure v1.1.2
+
+replace github.com/moby/sys/mountinfo => github.com/moby/sys/mountinfo v0.1.3
+
+replace github.com/moby/term => github.com/moby/term v0.0.0-20200312100748-672ec06f55cd
+
+replace github.com/modern-go/concurrent => github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd
+
+replace github.com/modern-go/reflect2 => github.com/modern-go/reflect2 v1.0.1
+
+replace github.com/morikuni/aec => github.com/morikuni/aec v1.0.0
+
+replace github.com/mwitkow/go-conntrack => github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223
+
+replace github.com/mxk/go-flowrate => github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f
+
+replace github.com/naoina/go-stringutil => github.com/naoina/go-stringutil v0.1.0
+
+replace github.com/naoina/toml => github.com/naoina/toml v0.1.1
+
+replace github.com/olekukonko/tablewriter => github.com/olekukonko/tablewriter v0.0.0-20170122224234-a0225b3f23b5
+
+replace github.com/opencontainers/image-spec => github.com/opencontainers/image-spec v1.0.1
+
+replace github.com/opencontainers/runtime-spec => github.com/opencontainers/runtime-spec v1.0.3-0.20200520003142-237cc4f519e2
+
+replace github.com/pelletier/go-toml => github.com/pelletier/go-toml v1.2.0
+
+replace github.com/peterbourgon/diskv => github.com/peterbourgon/diskv v2.0.1+incompatible
+
+replace github.com/pquerna/cachecontrol => github.com/pquerna/cachecontrol v0.0.0-20171018203845-0dec1b30a021
+
+replace github.com/prometheus/procfs => github.com/prometheus/procfs v0.1.3
+
+replace github.com/remyoudompheng/bigfft => github.com/remyoudompheng/bigfft v0.0.0-20170806203942-52369c62f446
+
+replace github.com/rogpeppe/fastuuid => github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af
+
+replace github.com/rogpeppe/go-internal => github.com/rogpeppe/go-internal v1.3.0
+
+replace github.com/rubiojr/go-vhd => github.com/rubiojr/go-vhd v0.0.0-20200706105327-02e210299021
+
+replace github.com/russross/blackfriday => github.com/russross/blackfriday v1.5.2
+
+replace github.com/russross/blackfriday/v2 => github.com/russross/blackfriday/v2 v2.0.1
+
+replace github.com/satori/go.uuid => github.com/satori/go.uuid v1.2.0
+
+replace github.com/seccomp/libseccomp-golang => github.com/seccomp/libseccomp-golang v0.9.1
+
+replace github.com/sergi/go-diff => github.com/sergi/go-diff v1.0.0
+
+replace github.com/shurcooL/sanitized_anchor_name => github.com/shurcooL/sanitized_anchor_name v1.0.0
+
+replace github.com/sirupsen/logrus => github.com/sirupsen/logrus v1.6.0
+
+replace github.com/smartystreets/assertions => github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d
+
+replace github.com/smartystreets/goconvey => github.com/smartystreets/goconvey v1.6.4
+
+replace github.com/soheilhy/cmux => github.com/soheilhy/cmux v0.1.4
+
+replace github.com/spf13/cast => github.com/spf13/cast v1.3.0
+
+replace github.com/stretchr/objx => github.com/stretchr/objx v0.2.0
+
+replace github.com/syndtr/gocapability => github.com/syndtr/gocapability v0.0.0-20180916011248-d98352740cb2
+
+replace github.com/tidwall/pretty => github.com/tidwall/pretty v1.0.0
+
+replace github.com/tmc/grpc-websocket-proxy => github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5
+
+replace github.com/ugorji/go => github.com/ugorji/go v1.1.4
+
+replace github.com/urfave/cli => github.com/urfave/cli v1.22.2
+
+replace github.com/vektah/gqlparser => github.com/vektah/gqlparser v1.1.2
+
+replace github.com/vishvananda/netns => github.com/vishvananda/netns v0.0.0-20200520041808-52d707b772fe
+
+replace github.com/xiang90/probing => github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2
+
+replace github.com/xlab/handysort => github.com/xlab/handysort v0.0.0-20150421192137-fb3537ed64a1
+
+replace github.com/xordataexchange/crypt => github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77
+
+replace github.com/yuin/goldmark => github.com/yuin/goldmark v1.2.1
+
+replace go.etcd.io/bbolt => go.etcd.io/bbolt v1.3.5
+
+replace go.mongodb.org/mongo-driver => go.mongodb.org/mongo-driver v1.1.2
+
+replace go.opencensus.io => go.opencensus.io v0.22.2
+
+replace go.uber.org/atomic => go.uber.org/atomic v1.4.0
+
+replace go.uber.org/multierr => go.uber.org/multierr v1.1.0
+
+replace go.uber.org/zap => go.uber.org/zap v1.10.0
+
+replace golang.org/x/exp => golang.org/x/exp v0.0.0-20191227195350-da58074b4299
+
+replace golang.org/x/image => golang.org/x/image v0.0.0-20190802002840-cff245a6509b
+
+replace golang.org/x/lint => golang.org/x/lint v0.0.0-20191125180803-fdd1cda4f05f
+
+replace golang.org/x/mobile => golang.org/x/mobile v0.0.0-20190719004257-d2bd2a29d028
+
+replace golang.org/x/mod => golang.org/x/mod v0.3.0
+
+replace golang.org/x/sync => golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9
+
+replace golang.org/x/text => golang.org/x/text v0.3.3
+
+replace golang.org/x/xerrors => golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1
+
+replace gonum.org/v1/plot => gonum.org/v1/plot v0.0.0-20190515093506-e2840ee46a6b
+
+replace google.golang.org/appengine => google.golang.org/appengine v1.6.5
+
+replace google.golang.org/genproto => google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013
+
+replace google.golang.org/protobuf => google.golang.org/protobuf v1.24.0
+
+replace gopkg.in/alecthomas/kingpin.v2 => gopkg.in/alecthomas/kingpin.v2 v2.2.6
+
+replace gopkg.in/check.v1 => gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15
+
+replace gopkg.in/cheggaaa/pb.v1 => gopkg.in/cheggaaa/pb.v1 v1.0.25
+
+replace gopkg.in/errgo.v2 => gopkg.in/errgo.v2 v2.1.0
+
+replace gopkg.in/fsnotify.v1 => gopkg.in/fsnotify.v1 v1.4.7
+
+replace gopkg.in/inf.v0 => gopkg.in/inf.v0 v0.9.1
+
+replace gopkg.in/mcuadros/go-syslog.v2 => gopkg.in/mcuadros/go-syslog.v2 v2.2.1
+
+replace gopkg.in/natefinch/lumberjack.v2 => gopkg.in/natefinch/lumberjack.v2 v2.0.0
+
+replace gopkg.in/resty.v1 => gopkg.in/resty.v1 v1.12.0
+
+replace gopkg.in/tomb.v1 => gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7
+
+replace gopkg.in/warnings.v0 => gopkg.in/warnings.v0 v0.1.1
+
+replace gotest.tools => gotest.tools v2.2.0+incompatible
+
+replace gotest.tools/v3 => gotest.tools/v3 v3.0.2
+
+replace honnef.co/go/tools => honnef.co/go/tools v0.0.1-2019.2.3
+
+replace modernc.org/cc => modernc.org/cc v1.0.0
+
+replace modernc.org/golex => modernc.org/golex v1.0.0
+
+replace modernc.org/mathutil => modernc.org/mathutil v1.0.0
+
+replace modernc.org/strutil => modernc.org/strutil v1.0.0
+
+replace modernc.org/xc => modernc.org/xc v1.0.0
+
+replace rsc.io/pdf => rsc.io/pdf v0.1.1
+
+replace sigs.k8s.io/apiserver-network-proxy/konnectivity-client => sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.15
+
+replace sigs.k8s.io/structured-merge-diff/v4 => sigs.k8s.io/structured-merge-diff/v4 v4.1.2
+
+replace vbom.ml/util => vbom.ml/util v0.0.0-20160121211510-db5cfe13f5cc

--- a/staging/src/k8s.io/controller-manager/go.mod
+++ b/staging/src/k8s.io/controller-manager/go.mod
@@ -5,3 +5,782 @@ module k8s.io/controller-manager
 go 1.15
 
 replace k8s.io/controller-manager => ../controller-manager
+
+require (
+	bitbucket.org/bertimus9/systemstat v0.0.0-20180207000608-0eeff89b0690
+	github.com/Azure/azure-sdk-for-go v43.0.0+incompatible
+	github.com/Azure/go-autorest/autorest v0.9.6
+	github.com/Azure/go-autorest/autorest/adal v0.8.2
+	github.com/Azure/go-autorest/autorest/to v0.2.0
+	github.com/GoogleCloudPlatform/k8s-cloud-provider v0.0.0-20200415212048-7901bc822317
+	github.com/JeffAshton/win_pdh v0.0.0-20161109143554-76bb4ee9f0ab
+	github.com/Microsoft/go-winio v0.4.15-0.20190919025122-fc70bd9a86b5
+	github.com/Microsoft/hcsshim v0.8.10-0.20200715222032-5eafd1556990
+	github.com/PuerkitoBio/purell v1.1.1
+	github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e
+	github.com/auth0/go-jwt-middleware v0.0.0-20170425171159-5493cabe49f7
+	github.com/aws/aws-sdk-go v1.28.2
+	github.com/blang/semver v3.5.0+incompatible
+	github.com/boltdb/bolt v1.3.1
+	github.com/caddyserver/caddy v1.0.3
+	github.com/clusterhq/flocker-go v0.0.0-20160920122132-2b8b7259d313
+	github.com/codegangsta/negroni v1.0.0
+	github.com/container-storage-interface/spec v1.2.0
+	github.com/containernetworking/cni v0.8.0
+	github.com/coredns/corefile-migration v1.0.10
+	github.com/coreos/go-oidc v2.1.0+incompatible
+	github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e
+	github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f
+	github.com/cpuguy83/go-md2man/v2 v2.0.0
+	github.com/davecgh/go-spew v1.1.1
+	github.com/docker/distribution v2.7.1+incompatible
+	github.com/docker/docker v1.4.2-0.20200309214505-aa6a9891b09c
+	github.com/docker/go-connections v0.4.0
+	github.com/docker/go-units v0.4.0
+	github.com/elazarl/goproxy v0.0.0-20180725130230-947c36da3153
+	github.com/emicklei/go-restful v2.9.5+incompatible
+	github.com/evanphx/json-patch v4.9.0+incompatible
+	github.com/fsnotify/fsnotify v1.4.9
+	github.com/go-bindata/go-bindata v3.1.1+incompatible
+	github.com/go-openapi/analysis v0.19.5
+	github.com/go-openapi/loads v0.19.4
+	github.com/go-openapi/spec v0.19.3
+	github.com/go-openapi/strfmt v0.19.3
+	github.com/go-openapi/validate v0.19.5
+	github.com/go-ozzo/ozzo-validation v3.5.0+incompatible
+	github.com/gogo/protobuf v1.3.2
+	github.com/golang/groupcache v0.0.0-20191227052852-215e87163ea7
+	github.com/golang/mock v1.3.1
+	github.com/google/cadvisor v0.37.5
+	github.com/google/go-cmp v0.4.0
+	github.com/google/gofuzz v1.1.0
+	github.com/google/uuid v1.1.1
+	github.com/googleapis/gnostic v0.4.1
+	github.com/gorilla/context v1.1.1
+	github.com/hashicorp/golang-lru v0.5.1
+	github.com/heketi/heketi v9.0.1-0.20190917153846-c2e2a4ab7ab9+incompatible
+	github.com/heketi/tests v0.0.0-20151005000721-f3775cbcefd6
+	github.com/ishidawataru/sctp v0.0.0-20190723014705-7c296d48a2b5
+	github.com/json-iterator/go v1.1.10
+	github.com/libopenstorage/openstorage v1.0.0
+	github.com/lithammer/dedent v1.1.0
+	github.com/lpabon/godbc v0.1.1
+	github.com/magiconair/properties v1.8.1
+	github.com/miekg/dns v1.1.4
+	github.com/moby/ipvs v1.0.1
+	github.com/mohae/deepcopy v0.0.0-20170603005431-491d3605edfb
+	github.com/mrunalp/fileutils v0.0.0-20200520151820-abd8a0e76976
+	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822
+	github.com/mvdan/xurls v1.1.0
+	github.com/onsi/ginkgo v1.11.0
+	github.com/onsi/gomega v1.7.0
+	github.com/opencontainers/go-digest v1.0.0-rc1
+	github.com/opencontainers/runc v1.0.1
+	github.com/opencontainers/selinux v1.5.2
+	github.com/pkg/errors v0.9.1
+	github.com/pmezard/go-difflib v1.0.0
+	github.com/prometheus/client_golang v1.7.1
+	github.com/prometheus/client_model v0.2.0
+	github.com/prometheus/common v0.10.0
+	github.com/quobyte/api v0.1.2
+	github.com/robfig/cron v1.1.0
+	github.com/spf13/afero v1.2.2
+	github.com/spf13/cobra v1.0.0
+	github.com/spf13/jwalterweatherman v1.1.0
+	github.com/spf13/pflag v1.0.5
+	github.com/spf13/viper v1.4.0
+	github.com/storageos/go-api v0.0.0-20180912212459-343b3eff91fc
+	github.com/stretchr/testify v1.4.0
+	github.com/thecodeteam/goscaleio v0.1.0
+	github.com/urfave/negroni v1.0.0
+	github.com/vishvananda/netlink v1.1.0
+	github.com/vmware/govmomi v0.20.3
+	go.etcd.io/etcd v0.5.0-alpha.5.0.20200819165624-17cef6e3e9d5
+	golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9
+	golang.org/x/net v0.0.0-20201110031124-69a78807bb2b
+	golang.org/x/oauth2 v0.0.0-20191202225959-858c2ad4c8b6
+	golang.org/x/sys v0.0.0-20201112073958-5cba982894dd
+	golang.org/x/time v0.0.0-20191024005414-555d28b269f0
+	golang.org/x/tools v0.0.0-20210106214847-113979e3529a
+	gonum.org/v1/gonum v0.6.2
+	gonum.org/v1/netlib v0.0.0-20190331212654-76723241ea4e
+	google.golang.org/api v0.15.1
+	google.golang.org/grpc v1.27.0
+	gopkg.in/gcfg.v1 v1.2.0
+	gopkg.in/square/go-jose.v2 v2.2.2
+	gopkg.in/yaml.v2 v2.2.8
+	k8s.io/gengo v0.0.0-20200428234225-8167cfdcfc14
+	k8s.io/heapster v1.2.0-beta.1
+	k8s.io/klog/v2 v2.2.0
+	k8s.io/kube-openapi v0.0.0-20200805222855-6aeccd4b50c6
+	k8s.io/system-validators v1.1.2
+	k8s.io/utils v0.0.0-20200729134348-d5654de09c73
+	sigs.k8s.io/kustomize v2.0.3+incompatible
+	sigs.k8s.io/yaml v1.2.0
+)
+
+replace github.com/auth0/go-jwt-middleware => github.com/auth0/go-jwt-middleware v0.0.0-20170425171159-5493cabe49f7
+
+replace github.com/boltdb/bolt => github.com/boltdb/bolt v1.3.1
+
+replace github.com/codegangsta/negroni => github.com/codegangsta/negroni v1.0.0
+
+replace github.com/go-ozzo/ozzo-validation => github.com/go-ozzo/ozzo-validation v3.5.0+incompatible
+
+replace github.com/gorilla/context => github.com/gorilla/context v1.1.1
+
+replace github.com/heketi/tests => github.com/heketi/tests v0.0.0-20151005000721-f3775cbcefd6
+
+replace github.com/lpabon/godbc => github.com/lpabon/godbc v0.1.1
+
+replace github.com/magiconair/properties => github.com/magiconair/properties v1.8.1
+
+replace github.com/mohae/deepcopy => github.com/mohae/deepcopy v0.0.0-20170603005431-491d3605edfb
+
+replace github.com/spf13/jwalterweatherman => github.com/spf13/jwalterweatherman v1.1.0
+
+replace github.com/urfave/negroni => github.com/urfave/negroni v1.0.0
+
+replace gonum.org/v1/netlib => gonum.org/v1/netlib v0.0.0-20190331212654-76723241ea4e
+
+replace bitbucket.org/bertimus9/systemstat => bitbucket.org/bertimus9/systemstat v0.0.0-20180207000608-0eeff89b0690
+
+replace github.com/Azure/azure-sdk-for-go => github.com/Azure/azure-sdk-for-go v43.0.0+incompatible
+
+replace github.com/Azure/go-autorest/autorest => github.com/Azure/go-autorest/autorest v0.9.6
+
+replace github.com/Azure/go-autorest/autorest/adal => github.com/Azure/go-autorest/autorest/adal v0.8.2
+
+replace github.com/Azure/go-autorest/autorest/to => github.com/Azure/go-autorest/autorest/to v0.2.0
+
+replace github.com/GoogleCloudPlatform/k8s-cloud-provider => github.com/GoogleCloudPlatform/k8s-cloud-provider v0.0.0-20200415212048-7901bc822317
+
+replace github.com/JeffAshton/win_pdh => github.com/JeffAshton/win_pdh v0.0.0-20161109143554-76bb4ee9f0ab
+
+replace github.com/Microsoft/go-winio => github.com/Microsoft/go-winio v0.4.15-0.20190919025122-fc70bd9a86b5
+
+replace github.com/Microsoft/hcsshim => github.com/Microsoft/hcsshim v0.8.10-0.20200715222032-5eafd1556990
+
+replace github.com/PuerkitoBio/purell => github.com/PuerkitoBio/purell v1.1.1
+
+replace github.com/armon/circbuf => github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e
+
+replace github.com/aws/aws-sdk-go => github.com/aws/aws-sdk-go v1.28.2
+
+replace github.com/blang/semver => github.com/blang/semver v3.5.0+incompatible
+
+replace github.com/caddyserver/caddy => github.com/caddyserver/caddy v1.0.3
+
+replace github.com/clusterhq/flocker-go => github.com/clusterhq/flocker-go v0.0.0-20160920122132-2b8b7259d313
+
+replace github.com/container-storage-interface/spec => github.com/container-storage-interface/spec v1.2.0
+
+replace github.com/containernetworking/cni => github.com/containernetworking/cni v0.8.0
+
+replace github.com/coredns/corefile-migration => github.com/coredns/corefile-migration v1.0.10
+
+replace github.com/coreos/go-oidc => github.com/coreos/go-oidc v2.1.0+incompatible
+
+replace github.com/coreos/go-systemd => github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e
+
+replace github.com/coreos/pkg => github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f
+
+replace github.com/cpuguy83/go-md2man/v2 => github.com/cpuguy83/go-md2man/v2 v2.0.0
+
+replace github.com/davecgh/go-spew => github.com/davecgh/go-spew v1.1.1
+
+replace github.com/docker/distribution => github.com/docker/distribution v2.7.1+incompatible
+
+replace github.com/docker/docker => github.com/docker/docker v1.4.2-0.20200309214505-aa6a9891b09c
+
+replace github.com/docker/go-connections => github.com/docker/go-connections v0.4.0
+
+replace github.com/docker/go-units => github.com/docker/go-units v0.4.0
+
+replace github.com/elazarl/goproxy => github.com/elazarl/goproxy v0.0.0-20180725130230-947c36da3153
+
+replace github.com/emicklei/go-restful => github.com/emicklei/go-restful v2.9.5+incompatible
+
+replace github.com/evanphx/json-patch => github.com/evanphx/json-patch v4.9.0+incompatible
+
+replace github.com/fsnotify/fsnotify => github.com/fsnotify/fsnotify v1.4.9
+
+replace github.com/go-bindata/go-bindata => github.com/go-bindata/go-bindata v3.1.1+incompatible
+
+replace github.com/go-openapi/analysis => github.com/go-openapi/analysis v0.19.5
+
+replace github.com/go-openapi/loads => github.com/go-openapi/loads v0.19.4
+
+replace github.com/go-openapi/spec => github.com/go-openapi/spec v0.19.3
+
+replace github.com/go-openapi/strfmt => github.com/go-openapi/strfmt v0.19.3
+
+replace github.com/go-openapi/validate => github.com/go-openapi/validate v0.19.5
+
+replace github.com/gogo/protobuf => github.com/gogo/protobuf v1.3.2
+
+replace github.com/golang/groupcache => github.com/golang/groupcache v0.0.0-20191227052852-215e87163ea7
+
+replace github.com/golang/mock => github.com/golang/mock v1.3.1
+
+replace github.com/google/cadvisor => github.com/google/cadvisor v0.37.5
+
+replace github.com/google/go-cmp => github.com/google/go-cmp v0.4.0
+
+replace github.com/google/gofuzz => github.com/google/gofuzz v1.1.0
+
+replace github.com/google/uuid => github.com/google/uuid v1.1.1
+
+replace github.com/googleapis/gnostic => github.com/googleapis/gnostic v0.4.1
+
+replace github.com/hashicorp/golang-lru => github.com/hashicorp/golang-lru v0.5.1
+
+replace github.com/heketi/heketi => github.com/heketi/heketi v9.0.1-0.20190917153846-c2e2a4ab7ab9+incompatible
+
+replace github.com/ishidawataru/sctp => github.com/ishidawataru/sctp v0.0.0-20190723014705-7c296d48a2b5
+
+replace github.com/json-iterator/go => github.com/json-iterator/go v1.1.10
+
+replace github.com/libopenstorage/openstorage => github.com/libopenstorage/openstorage v1.0.0
+
+replace github.com/lithammer/dedent => github.com/lithammer/dedent v1.1.0
+
+replace github.com/miekg/dns => github.com/miekg/dns v1.1.4
+
+replace github.com/moby/ipvs => github.com/moby/ipvs v1.0.1
+
+replace github.com/mrunalp/fileutils => github.com/mrunalp/fileutils v0.0.0-20200520151820-abd8a0e76976
+
+replace github.com/munnerz/goautoneg => github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822
+
+replace github.com/mvdan/xurls => github.com/mvdan/xurls v1.1.0
+
+replace github.com/onsi/ginkgo => github.com/onsi/ginkgo v1.11.0
+
+replace github.com/onsi/gomega => github.com/onsi/gomega v1.7.0
+
+replace github.com/opencontainers/go-digest => github.com/opencontainers/go-digest v1.0.0-rc1
+
+replace github.com/opencontainers/runc => github.com/opencontainers/runc v1.0.1
+
+replace github.com/opencontainers/selinux => github.com/opencontainers/selinux v1.5.2
+
+replace github.com/pkg/errors => github.com/pkg/errors v0.9.1
+
+replace github.com/pmezard/go-difflib => github.com/pmezard/go-difflib v1.0.0
+
+replace github.com/prometheus/client_golang => github.com/prometheus/client_golang v1.7.1
+
+replace github.com/prometheus/client_model => github.com/prometheus/client_model v0.2.0
+
+replace github.com/prometheus/common => github.com/prometheus/common v0.10.0
+
+replace github.com/quobyte/api => github.com/quobyte/api v0.1.2
+
+replace github.com/robfig/cron => github.com/robfig/cron v1.1.0
+
+replace github.com/spf13/afero => github.com/spf13/afero v1.2.2
+
+replace github.com/spf13/cobra => github.com/spf13/cobra v1.0.0
+
+replace github.com/spf13/pflag => github.com/spf13/pflag v1.0.5
+
+replace github.com/spf13/viper => github.com/spf13/viper v1.4.0
+
+replace github.com/storageos/go-api => github.com/storageos/go-api v0.0.0-20180912212459-343b3eff91fc
+
+replace github.com/stretchr/testify => github.com/stretchr/testify v1.4.0
+
+replace github.com/thecodeteam/goscaleio => github.com/thecodeteam/goscaleio v0.1.0
+
+replace github.com/vishvananda/netlink => github.com/vishvananda/netlink v1.1.0
+
+replace github.com/vmware/govmomi => github.com/vmware/govmomi v0.20.3
+
+replace go.etcd.io/etcd => go.etcd.io/etcd v0.5.0-alpha.5.0.20200819165624-17cef6e3e9d5
+
+replace golang.org/x/crypto => golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9
+
+replace golang.org/x/net => golang.org/x/net v0.0.0-20201110031124-69a78807bb2b
+
+replace golang.org/x/oauth2 => golang.org/x/oauth2 v0.0.0-20191202225959-858c2ad4c8b6
+
+replace golang.org/x/sys => golang.org/x/sys v0.0.0-20201112073958-5cba982894dd
+
+replace golang.org/x/time => golang.org/x/time v0.0.0-20191024005414-555d28b269f0
+
+replace golang.org/x/tools => golang.org/x/tools v0.0.0-20210106214847-113979e3529a
+
+replace gonum.org/v1/gonum => gonum.org/v1/gonum v0.6.2
+
+replace google.golang.org/api => google.golang.org/api v0.15.1
+
+replace google.golang.org/grpc => google.golang.org/grpc v1.27.0
+
+replace gopkg.in/gcfg.v1 => gopkg.in/gcfg.v1 v1.2.0
+
+replace gopkg.in/square/go-jose.v2 => gopkg.in/square/go-jose.v2 v2.2.2
+
+replace gopkg.in/yaml.v2 => gopkg.in/yaml.v2 v2.2.8
+
+replace k8s.io/gengo => k8s.io/gengo v0.0.0-20200428234225-8167cfdcfc14
+
+replace k8s.io/heapster => k8s.io/heapster v1.2.0-beta.1
+
+replace k8s.io/klog/v2 => k8s.io/klog/v2 v2.2.0
+
+replace k8s.io/kube-openapi => k8s.io/kube-openapi v0.0.0-20200805222855-6aeccd4b50c6
+
+replace k8s.io/system-validators => k8s.io/system-validators v1.1.2
+
+replace k8s.io/utils => k8s.io/utils v0.0.0-20200729134348-d5654de09c73
+
+replace sigs.k8s.io/kustomize => sigs.k8s.io/kustomize v2.0.3+incompatible
+
+replace sigs.k8s.io/yaml => sigs.k8s.io/yaml v1.2.0
+
+replace cloud.google.com/go => cloud.google.com/go v0.51.0
+
+replace cloud.google.com/go/bigquery => cloud.google.com/go/bigquery v1.0.1
+
+replace cloud.google.com/go/datastore => cloud.google.com/go/datastore v1.0.0
+
+replace cloud.google.com/go/pubsub => cloud.google.com/go/pubsub v1.0.1
+
+replace cloud.google.com/go/storage => cloud.google.com/go/storage v1.0.0
+
+replace dmitri.shuralyov.com/gpu/mtl => dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9
+
+replace github.com/Azure/go-ansiterm => github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78
+
+replace github.com/Azure/go-autorest/autorest/date => github.com/Azure/go-autorest/autorest/date v0.2.0
+
+replace github.com/Azure/go-autorest/autorest/mocks => github.com/Azure/go-autorest/autorest/mocks v0.3.0
+
+replace github.com/Azure/go-autorest/autorest/validation => github.com/Azure/go-autorest/autorest/validation v0.1.0
+
+replace github.com/Azure/go-autorest/logger => github.com/Azure/go-autorest/logger v0.1.0
+
+replace github.com/Azure/go-autorest/tracing => github.com/Azure/go-autorest/tracing v0.5.0
+
+replace github.com/BurntSushi/toml => github.com/BurntSushi/toml v0.3.1
+
+replace github.com/BurntSushi/xgb => github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802
+
+replace github.com/MakeNowJust/heredoc => github.com/MakeNowJust/heredoc v0.0.0-20170808103936-bb23615498cd
+
+replace github.com/NYTimes/gziphandler => github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46
+
+replace github.com/PuerkitoBio/urlesc => github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578
+
+replace github.com/agnivade/levenshtein => github.com/agnivade/levenshtein v1.0.1
+
+replace github.com/ajstarks/svgo => github.com/ajstarks/svgo v0.0.0-20180226025133-644b8db467af
+
+replace github.com/alecthomas/template => github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751
+
+replace github.com/alecthomas/units => github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4
+
+replace github.com/andreyvit/diff => github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883
+
+replace github.com/armon/consul-api => github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6
+
+replace github.com/asaskevich/govalidator => github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a
+
+replace github.com/beorn7/perks => github.com/beorn7/perks v1.0.1
+
+replace github.com/bgentry/speakeasy => github.com/bgentry/speakeasy v0.1.0
+
+replace github.com/bifurcation/mint => github.com/bifurcation/mint v0.0.0-20180715133206-93c51c6ce115
+
+replace github.com/cenkalti/backoff => github.com/cenkalti/backoff v2.1.1+incompatible
+
+replace github.com/census-instrumentation/opencensus-proto => github.com/census-instrumentation/opencensus-proto v0.2.1
+
+replace github.com/cespare/xxhash/v2 => github.com/cespare/xxhash/v2 v2.1.1
+
+replace github.com/chai2010/gettext-go => github.com/chai2010/gettext-go v0.0.0-20160711120539-c6fed771bfd5
+
+replace github.com/checkpoint-restore/go-criu/v4 => github.com/checkpoint-restore/go-criu/v4 v4.0.2
+
+replace github.com/cheekybits/genny => github.com/cheekybits/genny v0.0.0-20170328200008-9127e812e1e9
+
+replace github.com/chzyer/logex => github.com/chzyer/logex v1.1.10
+
+replace github.com/chzyer/readline => github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e
+
+replace github.com/chzyer/test => github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1
+
+replace github.com/cilium/ebpf => github.com/cilium/ebpf v0.0.0-20200702112145-1c8d4c9ef775
+
+replace github.com/cockroachdb/datadriven => github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa
+
+replace github.com/containerd/cgroups => github.com/containerd/cgroups v0.0.0-20200531161412-0dbf7f05ba59
+
+replace github.com/containerd/console => github.com/containerd/console v1.0.0
+
+replace github.com/containerd/containerd => github.com/containerd/containerd v1.3.3
+
+replace github.com/containerd/continuity => github.com/containerd/continuity v0.0.0-20190426062206-aaeac12a7ffc
+
+replace github.com/containerd/fifo => github.com/containerd/fifo v0.0.0-20190226154929-a9fb20d87448
+
+replace github.com/containerd/go-runc => github.com/containerd/go-runc v0.0.0-20180907222934-5a6d9f37cfa3
+
+replace github.com/containerd/ttrpc => github.com/containerd/ttrpc v1.0.0
+
+replace github.com/containerd/typeurl => github.com/containerd/typeurl v1.0.0
+
+replace github.com/coreos/bbolt => github.com/coreos/bbolt v1.3.2
+
+replace github.com/coreos/etcd => github.com/coreos/etcd v3.3.10+incompatible
+
+replace github.com/coreos/go-semver => github.com/coreos/go-semver v0.3.0
+
+replace github.com/coreos/go-systemd/v22 => github.com/coreos/go-systemd/v22 v22.1.0
+
+replace github.com/creack/pty => github.com/creack/pty v1.1.7
+
+replace github.com/cyphar/filepath-securejoin => github.com/cyphar/filepath-securejoin v0.2.2
+
+replace github.com/daviddengcn/go-colortext => github.com/daviddengcn/go-colortext v0.0.0-20160507010035-511bcaf42ccd
+
+replace github.com/dgrijalva/jwt-go => github.com/dgrijalva/jwt-go v3.2.0+incompatible
+
+replace github.com/dnaeon/go-vcr => github.com/dnaeon/go-vcr v1.0.1
+
+replace github.com/docker/spdystream => github.com/docker/spdystream v0.0.0-20160310174837-449fdfce4d96
+
+replace github.com/docopt/docopt-go => github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815
+
+replace github.com/dustin/go-humanize => github.com/dustin/go-humanize v1.0.0
+
+replace github.com/envoyproxy/go-control-plane => github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473
+
+replace github.com/envoyproxy/protoc-gen-validate => github.com/envoyproxy/protoc-gen-validate v0.1.0
+
+replace github.com/euank/go-kmsg-parser => github.com/euank/go-kmsg-parser v2.0.0+incompatible
+
+replace github.com/exponent-io/jsonpath => github.com/exponent-io/jsonpath v0.0.0-20151013193312-d6023ce2651d
+
+replace github.com/fatih/camelcase => github.com/fatih/camelcase v1.0.0
+
+replace github.com/fatih/color => github.com/fatih/color v1.7.0
+
+replace github.com/flynn/go-shlex => github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568
+
+replace github.com/fogleman/gg => github.com/fogleman/gg v1.2.1-0.20190220221249-0403632d5b90
+
+replace github.com/ghodss/yaml => github.com/ghodss/yaml v1.0.0
+
+replace github.com/go-acme/lego => github.com/go-acme/lego v2.5.0+incompatible
+
+replace github.com/go-gl/glfw/v3.3/glfw => github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72
+
+replace github.com/go-ini/ini => github.com/go-ini/ini v1.9.0
+
+replace github.com/go-kit/kit => github.com/go-kit/kit v0.9.0
+
+replace github.com/go-logfmt/logfmt => github.com/go-logfmt/logfmt v0.4.0
+
+replace github.com/go-logr/logr => github.com/go-logr/logr v0.2.0
+
+replace github.com/go-openapi/errors => github.com/go-openapi/errors v0.19.2
+
+replace github.com/go-openapi/jsonpointer => github.com/go-openapi/jsonpointer v0.19.3
+
+replace github.com/go-openapi/jsonreference => github.com/go-openapi/jsonreference v0.19.3
+
+replace github.com/go-openapi/runtime => github.com/go-openapi/runtime v0.19.4
+
+replace github.com/go-openapi/swag => github.com/go-openapi/swag v0.19.5
+
+replace github.com/go-stack/stack => github.com/go-stack/stack v1.8.0
+
+replace github.com/godbus/dbus/v5 => github.com/godbus/dbus/v5 v5.0.3
+
+replace github.com/golang/freetype => github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0
+
+replace github.com/golang/glog => github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
+
+replace github.com/golang/protobuf => github.com/golang/protobuf v1.4.2
+
+replace github.com/golangplus/bytes => github.com/golangplus/bytes v0.0.0-20160111154220-45c989fe5450
+
+replace github.com/golangplus/fmt => github.com/golangplus/fmt v0.0.0-20150411045040-2a5d6d7d2995
+
+replace github.com/golangplus/testing => github.com/golangplus/testing v0.0.0-20180327235837-af21d9c3145e
+
+replace github.com/google/btree => github.com/google/btree v1.0.0
+
+replace github.com/google/martian => github.com/google/martian v2.1.0+incompatible
+
+replace github.com/google/pprof => github.com/google/pprof v0.0.0-20191218002539-d4f498aebedc
+
+replace github.com/google/renameio => github.com/google/renameio v0.1.0
+
+replace github.com/googleapis/gax-go/v2 => github.com/googleapis/gax-go/v2 v2.0.5
+
+replace github.com/gophercloud/gophercloud => github.com/gophercloud/gophercloud v0.1.0
+
+replace github.com/gopherjs/gopherjs => github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1
+
+replace github.com/gorilla/mux => github.com/gorilla/mux v1.7.3
+
+replace github.com/gorilla/websocket => github.com/gorilla/websocket v1.4.0
+
+replace github.com/gregjones/httpcache => github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7
+
+replace github.com/grpc-ecosystem/go-grpc-middleware => github.com/grpc-ecosystem/go-grpc-middleware v1.0.1-0.20190118093823-f849b5445de4
+
+replace github.com/grpc-ecosystem/go-grpc-prometheus => github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0
+
+replace github.com/grpc-ecosystem/grpc-gateway => github.com/grpc-ecosystem/grpc-gateway v1.9.5
+
+replace github.com/hashicorp/go-syslog => github.com/hashicorp/go-syslog v1.0.0
+
+replace github.com/hashicorp/hcl => github.com/hashicorp/hcl v1.0.0
+
+replace github.com/hpcloud/tail => github.com/hpcloud/tail v1.0.0
+
+replace github.com/ianlancetaylor/demangle => github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6
+
+replace github.com/imdario/mergo => github.com/imdario/mergo v0.3.5
+
+replace github.com/inconshreveable/mousetrap => github.com/inconshreveable/mousetrap v1.0.0
+
+replace github.com/jimstudt/http-authentication => github.com/jimstudt/http-authentication v0.0.0-20140401203705-3eca13d6893a
+
+replace github.com/jmespath/go-jmespath => github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af
+
+replace github.com/jonboulle/clockwork => github.com/jonboulle/clockwork v0.1.0
+
+replace github.com/jstemmer/go-junit-report => github.com/jstemmer/go-junit-report v0.9.1
+
+replace github.com/jtolds/gls => github.com/jtolds/gls v4.20.0+incompatible
+
+replace github.com/julienschmidt/httprouter => github.com/julienschmidt/httprouter v1.2.0
+
+replace github.com/jung-kurt/gofpdf => github.com/jung-kurt/gofpdf v1.0.3-0.20190309125859-24315acbbda5
+
+replace github.com/karrick/godirwalk => github.com/karrick/godirwalk v1.7.5
+
+replace github.com/kisielk/errcheck => github.com/kisielk/errcheck v1.5.0
+
+replace github.com/kisielk/gotool => github.com/kisielk/gotool v1.0.0
+
+replace github.com/klauspost/cpuid => github.com/klauspost/cpuid v1.2.0
+
+replace github.com/konsorten/go-windows-terminal-sequences => github.com/konsorten/go-windows-terminal-sequences v1.0.3
+
+replace github.com/kr/logfmt => github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515
+
+replace github.com/kr/pretty => github.com/kr/pretty v0.2.0
+
+replace github.com/kr/pty => github.com/kr/pty v1.1.5
+
+replace github.com/kr/text => github.com/kr/text v0.1.0
+
+replace github.com/kylelemons/godebug => github.com/kylelemons/godebug v0.0.0-20170820004349-d65d576e9348
+
+replace github.com/liggitt/tabwriter => github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de
+
+replace github.com/lucas-clemente/aes12 => github.com/lucas-clemente/aes12 v0.0.0-20171027163421-cd47fb39b79f
+
+replace github.com/lucas-clemente/quic-clients => github.com/lucas-clemente/quic-clients v0.1.0
+
+replace github.com/lucas-clemente/quic-go => github.com/lucas-clemente/quic-go v0.10.2
+
+replace github.com/lucas-clemente/quic-go-certificates => github.com/lucas-clemente/quic-go-certificates v0.0.0-20160823095156-d2f86524cced
+
+replace github.com/mailru/easyjson => github.com/mailru/easyjson v0.7.0
+
+replace github.com/marten-seemann/qtls => github.com/marten-seemann/qtls v0.2.3
+
+replace github.com/mattn/go-colorable => github.com/mattn/go-colorable v0.0.9
+
+replace github.com/mattn/go-isatty => github.com/mattn/go-isatty v0.0.4
+
+replace github.com/mattn/go-runewidth => github.com/mattn/go-runewidth v0.0.2
+
+replace github.com/matttproud/golang_protobuf_extensions => github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369
+
+replace github.com/mholt/certmagic => github.com/mholt/certmagic v0.6.2-0.20190624175158-6a42ef9fe8c2
+
+replace github.com/mindprince/gonvml => github.com/mindprince/gonvml v0.0.0-20190828220739-9ebdce4bb989
+
+replace github.com/mistifyio/go-zfs => github.com/mistifyio/go-zfs v2.1.2-0.20190413222219-f784269be439+incompatible
+
+replace github.com/mitchellh/go-homedir => github.com/mitchellh/go-homedir v1.1.0
+
+replace github.com/mitchellh/go-wordwrap => github.com/mitchellh/go-wordwrap v1.0.0
+
+replace github.com/mitchellh/mapstructure => github.com/mitchellh/mapstructure v1.1.2
+
+replace github.com/moby/sys/mountinfo => github.com/moby/sys/mountinfo v0.1.3
+
+replace github.com/moby/term => github.com/moby/term v0.0.0-20200312100748-672ec06f55cd
+
+replace github.com/modern-go/concurrent => github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd
+
+replace github.com/modern-go/reflect2 => github.com/modern-go/reflect2 v1.0.1
+
+replace github.com/morikuni/aec => github.com/morikuni/aec v1.0.0
+
+replace github.com/mwitkow/go-conntrack => github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223
+
+replace github.com/mxk/go-flowrate => github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f
+
+replace github.com/naoina/go-stringutil => github.com/naoina/go-stringutil v0.1.0
+
+replace github.com/naoina/toml => github.com/naoina/toml v0.1.1
+
+replace github.com/olekukonko/tablewriter => github.com/olekukonko/tablewriter v0.0.0-20170122224234-a0225b3f23b5
+
+replace github.com/opencontainers/image-spec => github.com/opencontainers/image-spec v1.0.1
+
+replace github.com/opencontainers/runtime-spec => github.com/opencontainers/runtime-spec v1.0.3-0.20200520003142-237cc4f519e2
+
+replace github.com/pelletier/go-toml => github.com/pelletier/go-toml v1.2.0
+
+replace github.com/peterbourgon/diskv => github.com/peterbourgon/diskv v2.0.1+incompatible
+
+replace github.com/pquerna/cachecontrol => github.com/pquerna/cachecontrol v0.0.0-20171018203845-0dec1b30a021
+
+replace github.com/prometheus/procfs => github.com/prometheus/procfs v0.1.3
+
+replace github.com/remyoudompheng/bigfft => github.com/remyoudompheng/bigfft v0.0.0-20170806203942-52369c62f446
+
+replace github.com/rogpeppe/fastuuid => github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af
+
+replace github.com/rogpeppe/go-internal => github.com/rogpeppe/go-internal v1.3.0
+
+replace github.com/rubiojr/go-vhd => github.com/rubiojr/go-vhd v0.0.0-20200706105327-02e210299021
+
+replace github.com/russross/blackfriday => github.com/russross/blackfriday v1.5.2
+
+replace github.com/russross/blackfriday/v2 => github.com/russross/blackfriday/v2 v2.0.1
+
+replace github.com/satori/go.uuid => github.com/satori/go.uuid v1.2.0
+
+replace github.com/seccomp/libseccomp-golang => github.com/seccomp/libseccomp-golang v0.9.1
+
+replace github.com/sergi/go-diff => github.com/sergi/go-diff v1.0.0
+
+replace github.com/shurcooL/sanitized_anchor_name => github.com/shurcooL/sanitized_anchor_name v1.0.0
+
+replace github.com/sirupsen/logrus => github.com/sirupsen/logrus v1.6.0
+
+replace github.com/smartystreets/assertions => github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d
+
+replace github.com/smartystreets/goconvey => github.com/smartystreets/goconvey v1.6.4
+
+replace github.com/soheilhy/cmux => github.com/soheilhy/cmux v0.1.4
+
+replace github.com/spf13/cast => github.com/spf13/cast v1.3.0
+
+replace github.com/stretchr/objx => github.com/stretchr/objx v0.2.0
+
+replace github.com/syndtr/gocapability => github.com/syndtr/gocapability v0.0.0-20180916011248-d98352740cb2
+
+replace github.com/tidwall/pretty => github.com/tidwall/pretty v1.0.0
+
+replace github.com/tmc/grpc-websocket-proxy => github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5
+
+replace github.com/ugorji/go => github.com/ugorji/go v1.1.4
+
+replace github.com/urfave/cli => github.com/urfave/cli v1.22.2
+
+replace github.com/vektah/gqlparser => github.com/vektah/gqlparser v1.1.2
+
+replace github.com/vishvananda/netns => github.com/vishvananda/netns v0.0.0-20200520041808-52d707b772fe
+
+replace github.com/xiang90/probing => github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2
+
+replace github.com/xlab/handysort => github.com/xlab/handysort v0.0.0-20150421192137-fb3537ed64a1
+
+replace github.com/xordataexchange/crypt => github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77
+
+replace github.com/yuin/goldmark => github.com/yuin/goldmark v1.2.1
+
+replace go.etcd.io/bbolt => go.etcd.io/bbolt v1.3.5
+
+replace go.mongodb.org/mongo-driver => go.mongodb.org/mongo-driver v1.1.2
+
+replace go.opencensus.io => go.opencensus.io v0.22.2
+
+replace go.uber.org/atomic => go.uber.org/atomic v1.4.0
+
+replace go.uber.org/multierr => go.uber.org/multierr v1.1.0
+
+replace go.uber.org/zap => go.uber.org/zap v1.10.0
+
+replace golang.org/x/exp => golang.org/x/exp v0.0.0-20191227195350-da58074b4299
+
+replace golang.org/x/image => golang.org/x/image v0.0.0-20190802002840-cff245a6509b
+
+replace golang.org/x/lint => golang.org/x/lint v0.0.0-20191125180803-fdd1cda4f05f
+
+replace golang.org/x/mobile => golang.org/x/mobile v0.0.0-20190719004257-d2bd2a29d028
+
+replace golang.org/x/mod => golang.org/x/mod v0.3.0
+
+replace golang.org/x/sync => golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9
+
+replace golang.org/x/text => golang.org/x/text v0.3.3
+
+replace golang.org/x/xerrors => golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1
+
+replace gonum.org/v1/plot => gonum.org/v1/plot v0.0.0-20190515093506-e2840ee46a6b
+
+replace google.golang.org/appengine => google.golang.org/appengine v1.6.5
+
+replace google.golang.org/genproto => google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013
+
+replace google.golang.org/protobuf => google.golang.org/protobuf v1.24.0
+
+replace gopkg.in/alecthomas/kingpin.v2 => gopkg.in/alecthomas/kingpin.v2 v2.2.6
+
+replace gopkg.in/check.v1 => gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15
+
+replace gopkg.in/cheggaaa/pb.v1 => gopkg.in/cheggaaa/pb.v1 v1.0.25
+
+replace gopkg.in/errgo.v2 => gopkg.in/errgo.v2 v2.1.0
+
+replace gopkg.in/fsnotify.v1 => gopkg.in/fsnotify.v1 v1.4.7
+
+replace gopkg.in/inf.v0 => gopkg.in/inf.v0 v0.9.1
+
+replace gopkg.in/mcuadros/go-syslog.v2 => gopkg.in/mcuadros/go-syslog.v2 v2.2.1
+
+replace gopkg.in/natefinch/lumberjack.v2 => gopkg.in/natefinch/lumberjack.v2 v2.0.0
+
+replace gopkg.in/resty.v1 => gopkg.in/resty.v1 v1.12.0
+
+replace gopkg.in/tomb.v1 => gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7
+
+replace gopkg.in/warnings.v0 => gopkg.in/warnings.v0 v0.1.1
+
+replace gotest.tools => gotest.tools v2.2.0+incompatible
+
+replace gotest.tools/v3 => gotest.tools/v3 v3.0.2
+
+replace honnef.co/go/tools => honnef.co/go/tools v0.0.1-2019.2.3
+
+replace modernc.org/cc => modernc.org/cc v1.0.0
+
+replace modernc.org/golex => modernc.org/golex v1.0.0
+
+replace modernc.org/mathutil => modernc.org/mathutil v1.0.0
+
+replace modernc.org/strutil => modernc.org/strutil v1.0.0
+
+replace modernc.org/xc => modernc.org/xc v1.0.0
+
+replace rsc.io/pdf => rsc.io/pdf v0.1.1
+
+replace sigs.k8s.io/apiserver-network-proxy/konnectivity-client => sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.15
+
+replace sigs.k8s.io/structured-merge-diff/v4 => sigs.k8s.io/structured-merge-diff/v4 v4.1.2
+
+replace vbom.ml/util => vbom.ml/util v0.0.0-20160121211510-db5cfe13f5cc

--- a/staging/src/k8s.io/cri-api/go.mod
+++ b/staging/src/k8s.io/cri-api/go.mod
@@ -5,17 +5,786 @@ module k8s.io/cri-api
 go 1.15
 
 require (
+	bitbucket.org/bertimus9/systemstat v0.0.0-20180207000608-0eeff89b0690
+	github.com/Azure/azure-sdk-for-go v43.0.0+incompatible
+	github.com/Azure/go-autorest/autorest v0.9.6
+	github.com/Azure/go-autorest/autorest/adal v0.8.2
+	github.com/Azure/go-autorest/autorest/to v0.2.0
+	github.com/GoogleCloudPlatform/k8s-cloud-provider v0.0.0-20200415212048-7901bc822317
+	github.com/JeffAshton/win_pdh v0.0.0-20161109143554-76bb4ee9f0ab
+	github.com/Microsoft/go-winio v0.4.15-0.20190919025122-fc70bd9a86b5
+	github.com/Microsoft/hcsshim v0.8.10-0.20200715222032-5eafd1556990
+	github.com/PuerkitoBio/purell v1.1.1
+	github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e
+	github.com/auth0/go-jwt-middleware v0.0.0-20170425171159-5493cabe49f7
+	github.com/aws/aws-sdk-go v1.28.2
+	github.com/blang/semver v3.5.0+incompatible
+	github.com/boltdb/bolt v1.3.1
+	github.com/caddyserver/caddy v1.0.3
+	github.com/clusterhq/flocker-go v0.0.0-20160920122132-2b8b7259d313
+	github.com/codegangsta/negroni v1.0.0
+	github.com/container-storage-interface/spec v1.2.0
+	github.com/containernetworking/cni v0.8.0
+	github.com/coredns/corefile-migration v1.0.10
+	github.com/coreos/go-oidc v2.1.0+incompatible
+	github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e
+	github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f
+	github.com/cpuguy83/go-md2man/v2 v2.0.0
 	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/docker/distribution v2.7.1+incompatible
+	github.com/docker/docker v1.4.2-0.20200309214505-aa6a9891b09c
+	github.com/docker/go-connections v0.4.0
+	github.com/docker/go-units v0.4.0
+	github.com/elazarl/goproxy v0.0.0-20180725130230-947c36da3153
+	github.com/emicklei/go-restful v2.9.5+incompatible
+	github.com/evanphx/json-patch v4.9.0+incompatible
+	github.com/fsnotify/fsnotify v1.4.9
+	github.com/go-bindata/go-bindata v3.1.1+incompatible
+	github.com/go-openapi/analysis v0.19.5
+	github.com/go-openapi/loads v0.19.4
+	github.com/go-openapi/spec v0.19.3
+	github.com/go-openapi/strfmt v0.19.3
+	github.com/go-openapi/validate v0.19.5
+	github.com/go-ozzo/ozzo-validation v3.5.0+incompatible
 	github.com/gogo/protobuf v1.3.2
+	github.com/golang/groupcache v0.0.0-20191227052852-215e87163ea7
+	github.com/golang/mock v1.3.1
 	github.com/golang/protobuf v1.4.2 // indirect
+	github.com/google/cadvisor v0.37.5
+	github.com/google/go-cmp v0.4.0
+	github.com/google/gofuzz v1.1.0
+	github.com/google/uuid v1.1.1
+	github.com/googleapis/gnostic v0.4.1
+	github.com/gorilla/context v1.1.1
+	github.com/hashicorp/golang-lru v0.5.1
+	github.com/heketi/heketi v9.0.1-0.20190917153846-c2e2a4ab7ab9+incompatible
+	github.com/heketi/tests v0.0.0-20151005000721-f3775cbcefd6
+	github.com/ishidawataru/sctp v0.0.0-20190723014705-7c296d48a2b5
+	github.com/json-iterator/go v1.1.10
 	github.com/kr/pretty v0.2.0 // indirect
+	github.com/libopenstorage/openstorage v1.0.0
+	github.com/lithammer/dedent v1.1.0
+	github.com/lpabon/godbc v0.1.1
+	github.com/magiconair/properties v1.8.1
+	github.com/miekg/dns v1.1.4
+	github.com/moby/ipvs v1.0.1
+	github.com/mohae/deepcopy v0.0.0-20170603005431-491d3605edfb
+	github.com/mrunalp/fileutils v0.0.0-20200520151820-abd8a0e76976
+	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822
+	github.com/mvdan/xurls v1.1.0
+	github.com/onsi/ginkgo v1.11.0
+	github.com/onsi/gomega v1.7.0
+	github.com/opencontainers/go-digest v1.0.0-rc1
+	github.com/opencontainers/runc v1.0.1
+	github.com/opencontainers/selinux v1.5.2
+	github.com/pkg/errors v0.9.1
+	github.com/pmezard/go-difflib v1.0.0
+	github.com/prometheus/client_golang v1.7.1
+	github.com/prometheus/client_model v0.2.0
+	github.com/prometheus/common v0.10.0
+	github.com/quobyte/api v0.1.2
+	github.com/robfig/cron v1.1.0
+	github.com/spf13/afero v1.2.2
+	github.com/spf13/cobra v1.0.0
+	github.com/spf13/jwalterweatherman v1.1.0
+	github.com/spf13/pflag v1.0.5
+	github.com/spf13/viper v1.4.0
+	github.com/storageos/go-api v0.0.0-20180912212459-343b3eff91fc
 	github.com/stretchr/testify v1.4.0
+	github.com/thecodeteam/goscaleio v0.1.0
+	github.com/urfave/negroni v1.0.0
+	github.com/vishvananda/netlink v1.1.0
+	github.com/vmware/govmomi v0.20.3
+	go.etcd.io/etcd v0.5.0-alpha.5.0.20200819165624-17cef6e3e9d5
+	golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9
 	golang.org/x/net v0.0.0-20201110031124-69a78807bb2b // indirect
+	golang.org/x/oauth2 v0.0.0-20191202225959-858c2ad4c8b6
 	golang.org/x/sys v0.0.0-20201112073958-5cba982894dd // indirect
+	golang.org/x/time v0.0.0-20191024005414-555d28b269f0
+	golang.org/x/tools v0.0.0-20210106214847-113979e3529a
+	gonum.org/v1/gonum v0.6.2
+	gonum.org/v1/netlib v0.0.0-20190331212654-76723241ea4e
+	google.golang.org/api v0.15.1
 	google.golang.org/grpc v1.27.0
 	google.golang.org/protobuf v1.24.0 // indirect
 	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect
+	gopkg.in/gcfg.v1 v1.2.0
+	gopkg.in/square/go-jose.v2 v2.2.2
 	gopkg.in/yaml.v2 v2.2.8 // indirect
+	k8s.io/gengo v0.0.0-20200428234225-8167cfdcfc14
+	k8s.io/heapster v1.2.0-beta.1
+	k8s.io/klog/v2 v2.2.0
+	k8s.io/kube-openapi v0.0.0-20200805222855-6aeccd4b50c6
+	k8s.io/system-validators v1.1.2
+	k8s.io/utils v0.0.0-20200729134348-d5654de09c73
+	sigs.k8s.io/kustomize v2.0.3+incompatible
+	sigs.k8s.io/yaml v1.2.0
 )
 
 replace k8s.io/cri-api => ../cri-api
+
+replace github.com/auth0/go-jwt-middleware => github.com/auth0/go-jwt-middleware v0.0.0-20170425171159-5493cabe49f7
+
+replace github.com/boltdb/bolt => github.com/boltdb/bolt v1.3.1
+
+replace github.com/codegangsta/negroni => github.com/codegangsta/negroni v1.0.0
+
+replace github.com/go-ozzo/ozzo-validation => github.com/go-ozzo/ozzo-validation v3.5.0+incompatible
+
+replace github.com/gorilla/context => github.com/gorilla/context v1.1.1
+
+replace github.com/heketi/tests => github.com/heketi/tests v0.0.0-20151005000721-f3775cbcefd6
+
+replace github.com/lpabon/godbc => github.com/lpabon/godbc v0.1.1
+
+replace github.com/magiconair/properties => github.com/magiconair/properties v1.8.1
+
+replace github.com/mohae/deepcopy => github.com/mohae/deepcopy v0.0.0-20170603005431-491d3605edfb
+
+replace github.com/spf13/jwalterweatherman => github.com/spf13/jwalterweatherman v1.1.0
+
+replace github.com/urfave/negroni => github.com/urfave/negroni v1.0.0
+
+replace gonum.org/v1/netlib => gonum.org/v1/netlib v0.0.0-20190331212654-76723241ea4e
+
+replace bitbucket.org/bertimus9/systemstat => bitbucket.org/bertimus9/systemstat v0.0.0-20180207000608-0eeff89b0690
+
+replace github.com/Azure/azure-sdk-for-go => github.com/Azure/azure-sdk-for-go v43.0.0+incompatible
+
+replace github.com/Azure/go-autorest/autorest => github.com/Azure/go-autorest/autorest v0.9.6
+
+replace github.com/Azure/go-autorest/autorest/adal => github.com/Azure/go-autorest/autorest/adal v0.8.2
+
+replace github.com/Azure/go-autorest/autorest/to => github.com/Azure/go-autorest/autorest/to v0.2.0
+
+replace github.com/GoogleCloudPlatform/k8s-cloud-provider => github.com/GoogleCloudPlatform/k8s-cloud-provider v0.0.0-20200415212048-7901bc822317
+
+replace github.com/JeffAshton/win_pdh => github.com/JeffAshton/win_pdh v0.0.0-20161109143554-76bb4ee9f0ab
+
+replace github.com/Microsoft/go-winio => github.com/Microsoft/go-winio v0.4.15-0.20190919025122-fc70bd9a86b5
+
+replace github.com/Microsoft/hcsshim => github.com/Microsoft/hcsshim v0.8.10-0.20200715222032-5eafd1556990
+
+replace github.com/PuerkitoBio/purell => github.com/PuerkitoBio/purell v1.1.1
+
+replace github.com/armon/circbuf => github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e
+
+replace github.com/aws/aws-sdk-go => github.com/aws/aws-sdk-go v1.28.2
+
+replace github.com/blang/semver => github.com/blang/semver v3.5.0+incompatible
+
+replace github.com/caddyserver/caddy => github.com/caddyserver/caddy v1.0.3
+
+replace github.com/clusterhq/flocker-go => github.com/clusterhq/flocker-go v0.0.0-20160920122132-2b8b7259d313
+
+replace github.com/container-storage-interface/spec => github.com/container-storage-interface/spec v1.2.0
+
+replace github.com/containernetworking/cni => github.com/containernetworking/cni v0.8.0
+
+replace github.com/coredns/corefile-migration => github.com/coredns/corefile-migration v1.0.10
+
+replace github.com/coreos/go-oidc => github.com/coreos/go-oidc v2.1.0+incompatible
+
+replace github.com/coreos/go-systemd => github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e
+
+replace github.com/coreos/pkg => github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f
+
+replace github.com/cpuguy83/go-md2man/v2 => github.com/cpuguy83/go-md2man/v2 v2.0.0
+
+replace github.com/davecgh/go-spew => github.com/davecgh/go-spew v1.1.1
+
+replace github.com/docker/distribution => github.com/docker/distribution v2.7.1+incompatible
+
+replace github.com/docker/docker => github.com/docker/docker v1.4.2-0.20200309214505-aa6a9891b09c
+
+replace github.com/docker/go-connections => github.com/docker/go-connections v0.4.0
+
+replace github.com/docker/go-units => github.com/docker/go-units v0.4.0
+
+replace github.com/elazarl/goproxy => github.com/elazarl/goproxy v0.0.0-20180725130230-947c36da3153
+
+replace github.com/emicklei/go-restful => github.com/emicklei/go-restful v2.9.5+incompatible
+
+replace github.com/evanphx/json-patch => github.com/evanphx/json-patch v4.9.0+incompatible
+
+replace github.com/fsnotify/fsnotify => github.com/fsnotify/fsnotify v1.4.9
+
+replace github.com/go-bindata/go-bindata => github.com/go-bindata/go-bindata v3.1.1+incompatible
+
+replace github.com/go-openapi/analysis => github.com/go-openapi/analysis v0.19.5
+
+replace github.com/go-openapi/loads => github.com/go-openapi/loads v0.19.4
+
+replace github.com/go-openapi/spec => github.com/go-openapi/spec v0.19.3
+
+replace github.com/go-openapi/strfmt => github.com/go-openapi/strfmt v0.19.3
+
+replace github.com/go-openapi/validate => github.com/go-openapi/validate v0.19.5
+
+replace github.com/gogo/protobuf => github.com/gogo/protobuf v1.3.2
+
+replace github.com/golang/groupcache => github.com/golang/groupcache v0.0.0-20191227052852-215e87163ea7
+
+replace github.com/golang/mock => github.com/golang/mock v1.3.1
+
+replace github.com/google/cadvisor => github.com/google/cadvisor v0.37.5
+
+replace github.com/google/go-cmp => github.com/google/go-cmp v0.4.0
+
+replace github.com/google/gofuzz => github.com/google/gofuzz v1.1.0
+
+replace github.com/google/uuid => github.com/google/uuid v1.1.1
+
+replace github.com/googleapis/gnostic => github.com/googleapis/gnostic v0.4.1
+
+replace github.com/hashicorp/golang-lru => github.com/hashicorp/golang-lru v0.5.1
+
+replace github.com/heketi/heketi => github.com/heketi/heketi v9.0.1-0.20190917153846-c2e2a4ab7ab9+incompatible
+
+replace github.com/ishidawataru/sctp => github.com/ishidawataru/sctp v0.0.0-20190723014705-7c296d48a2b5
+
+replace github.com/json-iterator/go => github.com/json-iterator/go v1.1.10
+
+replace github.com/libopenstorage/openstorage => github.com/libopenstorage/openstorage v1.0.0
+
+replace github.com/lithammer/dedent => github.com/lithammer/dedent v1.1.0
+
+replace github.com/miekg/dns => github.com/miekg/dns v1.1.4
+
+replace github.com/moby/ipvs => github.com/moby/ipvs v1.0.1
+
+replace github.com/mrunalp/fileutils => github.com/mrunalp/fileutils v0.0.0-20200520151820-abd8a0e76976
+
+replace github.com/munnerz/goautoneg => github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822
+
+replace github.com/mvdan/xurls => github.com/mvdan/xurls v1.1.0
+
+replace github.com/onsi/ginkgo => github.com/onsi/ginkgo v1.11.0
+
+replace github.com/onsi/gomega => github.com/onsi/gomega v1.7.0
+
+replace github.com/opencontainers/go-digest => github.com/opencontainers/go-digest v1.0.0-rc1
+
+replace github.com/opencontainers/runc => github.com/opencontainers/runc v1.0.1
+
+replace github.com/opencontainers/selinux => github.com/opencontainers/selinux v1.5.2
+
+replace github.com/pkg/errors => github.com/pkg/errors v0.9.1
+
+replace github.com/pmezard/go-difflib => github.com/pmezard/go-difflib v1.0.0
+
+replace github.com/prometheus/client_golang => github.com/prometheus/client_golang v1.7.1
+
+replace github.com/prometheus/client_model => github.com/prometheus/client_model v0.2.0
+
+replace github.com/prometheus/common => github.com/prometheus/common v0.10.0
+
+replace github.com/quobyte/api => github.com/quobyte/api v0.1.2
+
+replace github.com/robfig/cron => github.com/robfig/cron v1.1.0
+
+replace github.com/spf13/afero => github.com/spf13/afero v1.2.2
+
+replace github.com/spf13/cobra => github.com/spf13/cobra v1.0.0
+
+replace github.com/spf13/pflag => github.com/spf13/pflag v1.0.5
+
+replace github.com/spf13/viper => github.com/spf13/viper v1.4.0
+
+replace github.com/storageos/go-api => github.com/storageos/go-api v0.0.0-20180912212459-343b3eff91fc
+
+replace github.com/stretchr/testify => github.com/stretchr/testify v1.4.0
+
+replace github.com/thecodeteam/goscaleio => github.com/thecodeteam/goscaleio v0.1.0
+
+replace github.com/vishvananda/netlink => github.com/vishvananda/netlink v1.1.0
+
+replace github.com/vmware/govmomi => github.com/vmware/govmomi v0.20.3
+
+replace go.etcd.io/etcd => go.etcd.io/etcd v0.5.0-alpha.5.0.20200819165624-17cef6e3e9d5
+
+replace golang.org/x/crypto => golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9
+
+replace golang.org/x/net => golang.org/x/net v0.0.0-20201110031124-69a78807bb2b
+
+replace golang.org/x/oauth2 => golang.org/x/oauth2 v0.0.0-20191202225959-858c2ad4c8b6
+
+replace golang.org/x/sys => golang.org/x/sys v0.0.0-20201112073958-5cba982894dd
+
+replace golang.org/x/time => golang.org/x/time v0.0.0-20191024005414-555d28b269f0
+
+replace golang.org/x/tools => golang.org/x/tools v0.0.0-20210106214847-113979e3529a
+
+replace gonum.org/v1/gonum => gonum.org/v1/gonum v0.6.2
+
+replace google.golang.org/api => google.golang.org/api v0.15.1
+
+replace google.golang.org/grpc => google.golang.org/grpc v1.27.0
+
+replace gopkg.in/gcfg.v1 => gopkg.in/gcfg.v1 v1.2.0
+
+replace gopkg.in/square/go-jose.v2 => gopkg.in/square/go-jose.v2 v2.2.2
+
+replace gopkg.in/yaml.v2 => gopkg.in/yaml.v2 v2.2.8
+
+replace k8s.io/gengo => k8s.io/gengo v0.0.0-20200428234225-8167cfdcfc14
+
+replace k8s.io/heapster => k8s.io/heapster v1.2.0-beta.1
+
+replace k8s.io/klog/v2 => k8s.io/klog/v2 v2.2.0
+
+replace k8s.io/kube-openapi => k8s.io/kube-openapi v0.0.0-20200805222855-6aeccd4b50c6
+
+replace k8s.io/system-validators => k8s.io/system-validators v1.1.2
+
+replace k8s.io/utils => k8s.io/utils v0.0.0-20200729134348-d5654de09c73
+
+replace sigs.k8s.io/kustomize => sigs.k8s.io/kustomize v2.0.3+incompatible
+
+replace sigs.k8s.io/yaml => sigs.k8s.io/yaml v1.2.0
+
+replace cloud.google.com/go => cloud.google.com/go v0.51.0
+
+replace cloud.google.com/go/bigquery => cloud.google.com/go/bigquery v1.0.1
+
+replace cloud.google.com/go/datastore => cloud.google.com/go/datastore v1.0.0
+
+replace cloud.google.com/go/pubsub => cloud.google.com/go/pubsub v1.0.1
+
+replace cloud.google.com/go/storage => cloud.google.com/go/storage v1.0.0
+
+replace dmitri.shuralyov.com/gpu/mtl => dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9
+
+replace github.com/Azure/go-ansiterm => github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78
+
+replace github.com/Azure/go-autorest/autorest/date => github.com/Azure/go-autorest/autorest/date v0.2.0
+
+replace github.com/Azure/go-autorest/autorest/mocks => github.com/Azure/go-autorest/autorest/mocks v0.3.0
+
+replace github.com/Azure/go-autorest/autorest/validation => github.com/Azure/go-autorest/autorest/validation v0.1.0
+
+replace github.com/Azure/go-autorest/logger => github.com/Azure/go-autorest/logger v0.1.0
+
+replace github.com/Azure/go-autorest/tracing => github.com/Azure/go-autorest/tracing v0.5.0
+
+replace github.com/BurntSushi/toml => github.com/BurntSushi/toml v0.3.1
+
+replace github.com/BurntSushi/xgb => github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802
+
+replace github.com/MakeNowJust/heredoc => github.com/MakeNowJust/heredoc v0.0.0-20170808103936-bb23615498cd
+
+replace github.com/NYTimes/gziphandler => github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46
+
+replace github.com/PuerkitoBio/urlesc => github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578
+
+replace github.com/agnivade/levenshtein => github.com/agnivade/levenshtein v1.0.1
+
+replace github.com/ajstarks/svgo => github.com/ajstarks/svgo v0.0.0-20180226025133-644b8db467af
+
+replace github.com/alecthomas/template => github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751
+
+replace github.com/alecthomas/units => github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4
+
+replace github.com/andreyvit/diff => github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883
+
+replace github.com/armon/consul-api => github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6
+
+replace github.com/asaskevich/govalidator => github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a
+
+replace github.com/beorn7/perks => github.com/beorn7/perks v1.0.1
+
+replace github.com/bgentry/speakeasy => github.com/bgentry/speakeasy v0.1.0
+
+replace github.com/bifurcation/mint => github.com/bifurcation/mint v0.0.0-20180715133206-93c51c6ce115
+
+replace github.com/cenkalti/backoff => github.com/cenkalti/backoff v2.1.1+incompatible
+
+replace github.com/census-instrumentation/opencensus-proto => github.com/census-instrumentation/opencensus-proto v0.2.1
+
+replace github.com/cespare/xxhash/v2 => github.com/cespare/xxhash/v2 v2.1.1
+
+replace github.com/chai2010/gettext-go => github.com/chai2010/gettext-go v0.0.0-20160711120539-c6fed771bfd5
+
+replace github.com/checkpoint-restore/go-criu/v4 => github.com/checkpoint-restore/go-criu/v4 v4.0.2
+
+replace github.com/cheekybits/genny => github.com/cheekybits/genny v0.0.0-20170328200008-9127e812e1e9
+
+replace github.com/chzyer/logex => github.com/chzyer/logex v1.1.10
+
+replace github.com/chzyer/readline => github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e
+
+replace github.com/chzyer/test => github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1
+
+replace github.com/cilium/ebpf => github.com/cilium/ebpf v0.0.0-20200702112145-1c8d4c9ef775
+
+replace github.com/cockroachdb/datadriven => github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa
+
+replace github.com/containerd/cgroups => github.com/containerd/cgroups v0.0.0-20200531161412-0dbf7f05ba59
+
+replace github.com/containerd/console => github.com/containerd/console v1.0.0
+
+replace github.com/containerd/containerd => github.com/containerd/containerd v1.3.3
+
+replace github.com/containerd/continuity => github.com/containerd/continuity v0.0.0-20190426062206-aaeac12a7ffc
+
+replace github.com/containerd/fifo => github.com/containerd/fifo v0.0.0-20190226154929-a9fb20d87448
+
+replace github.com/containerd/go-runc => github.com/containerd/go-runc v0.0.0-20180907222934-5a6d9f37cfa3
+
+replace github.com/containerd/ttrpc => github.com/containerd/ttrpc v1.0.0
+
+replace github.com/containerd/typeurl => github.com/containerd/typeurl v1.0.0
+
+replace github.com/coreos/bbolt => github.com/coreos/bbolt v1.3.2
+
+replace github.com/coreos/etcd => github.com/coreos/etcd v3.3.10+incompatible
+
+replace github.com/coreos/go-semver => github.com/coreos/go-semver v0.3.0
+
+replace github.com/coreos/go-systemd/v22 => github.com/coreos/go-systemd/v22 v22.1.0
+
+replace github.com/creack/pty => github.com/creack/pty v1.1.7
+
+replace github.com/cyphar/filepath-securejoin => github.com/cyphar/filepath-securejoin v0.2.2
+
+replace github.com/daviddengcn/go-colortext => github.com/daviddengcn/go-colortext v0.0.0-20160507010035-511bcaf42ccd
+
+replace github.com/dgrijalva/jwt-go => github.com/dgrijalva/jwt-go v3.2.0+incompatible
+
+replace github.com/dnaeon/go-vcr => github.com/dnaeon/go-vcr v1.0.1
+
+replace github.com/docker/spdystream => github.com/docker/spdystream v0.0.0-20160310174837-449fdfce4d96
+
+replace github.com/docopt/docopt-go => github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815
+
+replace github.com/dustin/go-humanize => github.com/dustin/go-humanize v1.0.0
+
+replace github.com/envoyproxy/go-control-plane => github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473
+
+replace github.com/envoyproxy/protoc-gen-validate => github.com/envoyproxy/protoc-gen-validate v0.1.0
+
+replace github.com/euank/go-kmsg-parser => github.com/euank/go-kmsg-parser v2.0.0+incompatible
+
+replace github.com/exponent-io/jsonpath => github.com/exponent-io/jsonpath v0.0.0-20151013193312-d6023ce2651d
+
+replace github.com/fatih/camelcase => github.com/fatih/camelcase v1.0.0
+
+replace github.com/fatih/color => github.com/fatih/color v1.7.0
+
+replace github.com/flynn/go-shlex => github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568
+
+replace github.com/fogleman/gg => github.com/fogleman/gg v1.2.1-0.20190220221249-0403632d5b90
+
+replace github.com/ghodss/yaml => github.com/ghodss/yaml v1.0.0
+
+replace github.com/go-acme/lego => github.com/go-acme/lego v2.5.0+incompatible
+
+replace github.com/go-gl/glfw/v3.3/glfw => github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72
+
+replace github.com/go-ini/ini => github.com/go-ini/ini v1.9.0
+
+replace github.com/go-kit/kit => github.com/go-kit/kit v0.9.0
+
+replace github.com/go-logfmt/logfmt => github.com/go-logfmt/logfmt v0.4.0
+
+replace github.com/go-logr/logr => github.com/go-logr/logr v0.2.0
+
+replace github.com/go-openapi/errors => github.com/go-openapi/errors v0.19.2
+
+replace github.com/go-openapi/jsonpointer => github.com/go-openapi/jsonpointer v0.19.3
+
+replace github.com/go-openapi/jsonreference => github.com/go-openapi/jsonreference v0.19.3
+
+replace github.com/go-openapi/runtime => github.com/go-openapi/runtime v0.19.4
+
+replace github.com/go-openapi/swag => github.com/go-openapi/swag v0.19.5
+
+replace github.com/go-stack/stack => github.com/go-stack/stack v1.8.0
+
+replace github.com/godbus/dbus/v5 => github.com/godbus/dbus/v5 v5.0.3
+
+replace github.com/golang/freetype => github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0
+
+replace github.com/golang/glog => github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
+
+replace github.com/golang/protobuf => github.com/golang/protobuf v1.4.2
+
+replace github.com/golangplus/bytes => github.com/golangplus/bytes v0.0.0-20160111154220-45c989fe5450
+
+replace github.com/golangplus/fmt => github.com/golangplus/fmt v0.0.0-20150411045040-2a5d6d7d2995
+
+replace github.com/golangplus/testing => github.com/golangplus/testing v0.0.0-20180327235837-af21d9c3145e
+
+replace github.com/google/btree => github.com/google/btree v1.0.0
+
+replace github.com/google/martian => github.com/google/martian v2.1.0+incompatible
+
+replace github.com/google/pprof => github.com/google/pprof v0.0.0-20191218002539-d4f498aebedc
+
+replace github.com/google/renameio => github.com/google/renameio v0.1.0
+
+replace github.com/googleapis/gax-go/v2 => github.com/googleapis/gax-go/v2 v2.0.5
+
+replace github.com/gophercloud/gophercloud => github.com/gophercloud/gophercloud v0.1.0
+
+replace github.com/gopherjs/gopherjs => github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1
+
+replace github.com/gorilla/mux => github.com/gorilla/mux v1.7.3
+
+replace github.com/gorilla/websocket => github.com/gorilla/websocket v1.4.0
+
+replace github.com/gregjones/httpcache => github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7
+
+replace github.com/grpc-ecosystem/go-grpc-middleware => github.com/grpc-ecosystem/go-grpc-middleware v1.0.1-0.20190118093823-f849b5445de4
+
+replace github.com/grpc-ecosystem/go-grpc-prometheus => github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0
+
+replace github.com/grpc-ecosystem/grpc-gateway => github.com/grpc-ecosystem/grpc-gateway v1.9.5
+
+replace github.com/hashicorp/go-syslog => github.com/hashicorp/go-syslog v1.0.0
+
+replace github.com/hashicorp/hcl => github.com/hashicorp/hcl v1.0.0
+
+replace github.com/hpcloud/tail => github.com/hpcloud/tail v1.0.0
+
+replace github.com/ianlancetaylor/demangle => github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6
+
+replace github.com/imdario/mergo => github.com/imdario/mergo v0.3.5
+
+replace github.com/inconshreveable/mousetrap => github.com/inconshreveable/mousetrap v1.0.0
+
+replace github.com/jimstudt/http-authentication => github.com/jimstudt/http-authentication v0.0.0-20140401203705-3eca13d6893a
+
+replace github.com/jmespath/go-jmespath => github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af
+
+replace github.com/jonboulle/clockwork => github.com/jonboulle/clockwork v0.1.0
+
+replace github.com/jstemmer/go-junit-report => github.com/jstemmer/go-junit-report v0.9.1
+
+replace github.com/jtolds/gls => github.com/jtolds/gls v4.20.0+incompatible
+
+replace github.com/julienschmidt/httprouter => github.com/julienschmidt/httprouter v1.2.0
+
+replace github.com/jung-kurt/gofpdf => github.com/jung-kurt/gofpdf v1.0.3-0.20190309125859-24315acbbda5
+
+replace github.com/karrick/godirwalk => github.com/karrick/godirwalk v1.7.5
+
+replace github.com/kisielk/errcheck => github.com/kisielk/errcheck v1.5.0
+
+replace github.com/kisielk/gotool => github.com/kisielk/gotool v1.0.0
+
+replace github.com/klauspost/cpuid => github.com/klauspost/cpuid v1.2.0
+
+replace github.com/konsorten/go-windows-terminal-sequences => github.com/konsorten/go-windows-terminal-sequences v1.0.3
+
+replace github.com/kr/logfmt => github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515
+
+replace github.com/kr/pretty => github.com/kr/pretty v0.2.0
+
+replace github.com/kr/pty => github.com/kr/pty v1.1.5
+
+replace github.com/kr/text => github.com/kr/text v0.1.0
+
+replace github.com/kylelemons/godebug => github.com/kylelemons/godebug v0.0.0-20170820004349-d65d576e9348
+
+replace github.com/liggitt/tabwriter => github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de
+
+replace github.com/lucas-clemente/aes12 => github.com/lucas-clemente/aes12 v0.0.0-20171027163421-cd47fb39b79f
+
+replace github.com/lucas-clemente/quic-clients => github.com/lucas-clemente/quic-clients v0.1.0
+
+replace github.com/lucas-clemente/quic-go => github.com/lucas-clemente/quic-go v0.10.2
+
+replace github.com/lucas-clemente/quic-go-certificates => github.com/lucas-clemente/quic-go-certificates v0.0.0-20160823095156-d2f86524cced
+
+replace github.com/mailru/easyjson => github.com/mailru/easyjson v0.7.0
+
+replace github.com/marten-seemann/qtls => github.com/marten-seemann/qtls v0.2.3
+
+replace github.com/mattn/go-colorable => github.com/mattn/go-colorable v0.0.9
+
+replace github.com/mattn/go-isatty => github.com/mattn/go-isatty v0.0.4
+
+replace github.com/mattn/go-runewidth => github.com/mattn/go-runewidth v0.0.2
+
+replace github.com/matttproud/golang_protobuf_extensions => github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369
+
+replace github.com/mholt/certmagic => github.com/mholt/certmagic v0.6.2-0.20190624175158-6a42ef9fe8c2
+
+replace github.com/mindprince/gonvml => github.com/mindprince/gonvml v0.0.0-20190828220739-9ebdce4bb989
+
+replace github.com/mistifyio/go-zfs => github.com/mistifyio/go-zfs v2.1.2-0.20190413222219-f784269be439+incompatible
+
+replace github.com/mitchellh/go-homedir => github.com/mitchellh/go-homedir v1.1.0
+
+replace github.com/mitchellh/go-wordwrap => github.com/mitchellh/go-wordwrap v1.0.0
+
+replace github.com/mitchellh/mapstructure => github.com/mitchellh/mapstructure v1.1.2
+
+replace github.com/moby/sys/mountinfo => github.com/moby/sys/mountinfo v0.1.3
+
+replace github.com/moby/term => github.com/moby/term v0.0.0-20200312100748-672ec06f55cd
+
+replace github.com/modern-go/concurrent => github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd
+
+replace github.com/modern-go/reflect2 => github.com/modern-go/reflect2 v1.0.1
+
+replace github.com/morikuni/aec => github.com/morikuni/aec v1.0.0
+
+replace github.com/mwitkow/go-conntrack => github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223
+
+replace github.com/mxk/go-flowrate => github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f
+
+replace github.com/naoina/go-stringutil => github.com/naoina/go-stringutil v0.1.0
+
+replace github.com/naoina/toml => github.com/naoina/toml v0.1.1
+
+replace github.com/olekukonko/tablewriter => github.com/olekukonko/tablewriter v0.0.0-20170122224234-a0225b3f23b5
+
+replace github.com/opencontainers/image-spec => github.com/opencontainers/image-spec v1.0.1
+
+replace github.com/opencontainers/runtime-spec => github.com/opencontainers/runtime-spec v1.0.3-0.20200520003142-237cc4f519e2
+
+replace github.com/pelletier/go-toml => github.com/pelletier/go-toml v1.2.0
+
+replace github.com/peterbourgon/diskv => github.com/peterbourgon/diskv v2.0.1+incompatible
+
+replace github.com/pquerna/cachecontrol => github.com/pquerna/cachecontrol v0.0.0-20171018203845-0dec1b30a021
+
+replace github.com/prometheus/procfs => github.com/prometheus/procfs v0.1.3
+
+replace github.com/remyoudompheng/bigfft => github.com/remyoudompheng/bigfft v0.0.0-20170806203942-52369c62f446
+
+replace github.com/rogpeppe/fastuuid => github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af
+
+replace github.com/rogpeppe/go-internal => github.com/rogpeppe/go-internal v1.3.0
+
+replace github.com/rubiojr/go-vhd => github.com/rubiojr/go-vhd v0.0.0-20200706105327-02e210299021
+
+replace github.com/russross/blackfriday => github.com/russross/blackfriday v1.5.2
+
+replace github.com/russross/blackfriday/v2 => github.com/russross/blackfriday/v2 v2.0.1
+
+replace github.com/satori/go.uuid => github.com/satori/go.uuid v1.2.0
+
+replace github.com/seccomp/libseccomp-golang => github.com/seccomp/libseccomp-golang v0.9.1
+
+replace github.com/sergi/go-diff => github.com/sergi/go-diff v1.0.0
+
+replace github.com/shurcooL/sanitized_anchor_name => github.com/shurcooL/sanitized_anchor_name v1.0.0
+
+replace github.com/sirupsen/logrus => github.com/sirupsen/logrus v1.6.0
+
+replace github.com/smartystreets/assertions => github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d
+
+replace github.com/smartystreets/goconvey => github.com/smartystreets/goconvey v1.6.4
+
+replace github.com/soheilhy/cmux => github.com/soheilhy/cmux v0.1.4
+
+replace github.com/spf13/cast => github.com/spf13/cast v1.3.0
+
+replace github.com/stretchr/objx => github.com/stretchr/objx v0.2.0
+
+replace github.com/syndtr/gocapability => github.com/syndtr/gocapability v0.0.0-20180916011248-d98352740cb2
+
+replace github.com/tidwall/pretty => github.com/tidwall/pretty v1.0.0
+
+replace github.com/tmc/grpc-websocket-proxy => github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5
+
+replace github.com/ugorji/go => github.com/ugorji/go v1.1.4
+
+replace github.com/urfave/cli => github.com/urfave/cli v1.22.2
+
+replace github.com/vektah/gqlparser => github.com/vektah/gqlparser v1.1.2
+
+replace github.com/vishvananda/netns => github.com/vishvananda/netns v0.0.0-20200520041808-52d707b772fe
+
+replace github.com/xiang90/probing => github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2
+
+replace github.com/xlab/handysort => github.com/xlab/handysort v0.0.0-20150421192137-fb3537ed64a1
+
+replace github.com/xordataexchange/crypt => github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77
+
+replace github.com/yuin/goldmark => github.com/yuin/goldmark v1.2.1
+
+replace go.etcd.io/bbolt => go.etcd.io/bbolt v1.3.5
+
+replace go.mongodb.org/mongo-driver => go.mongodb.org/mongo-driver v1.1.2
+
+replace go.opencensus.io => go.opencensus.io v0.22.2
+
+replace go.uber.org/atomic => go.uber.org/atomic v1.4.0
+
+replace go.uber.org/multierr => go.uber.org/multierr v1.1.0
+
+replace go.uber.org/zap => go.uber.org/zap v1.10.0
+
+replace golang.org/x/exp => golang.org/x/exp v0.0.0-20191227195350-da58074b4299
+
+replace golang.org/x/image => golang.org/x/image v0.0.0-20190802002840-cff245a6509b
+
+replace golang.org/x/lint => golang.org/x/lint v0.0.0-20191125180803-fdd1cda4f05f
+
+replace golang.org/x/mobile => golang.org/x/mobile v0.0.0-20190719004257-d2bd2a29d028
+
+replace golang.org/x/mod => golang.org/x/mod v0.3.0
+
+replace golang.org/x/sync => golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9
+
+replace golang.org/x/text => golang.org/x/text v0.3.3
+
+replace golang.org/x/xerrors => golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1
+
+replace gonum.org/v1/plot => gonum.org/v1/plot v0.0.0-20190515093506-e2840ee46a6b
+
+replace google.golang.org/appengine => google.golang.org/appengine v1.6.5
+
+replace google.golang.org/genproto => google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013
+
+replace google.golang.org/protobuf => google.golang.org/protobuf v1.24.0
+
+replace gopkg.in/alecthomas/kingpin.v2 => gopkg.in/alecthomas/kingpin.v2 v2.2.6
+
+replace gopkg.in/check.v1 => gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15
+
+replace gopkg.in/cheggaaa/pb.v1 => gopkg.in/cheggaaa/pb.v1 v1.0.25
+
+replace gopkg.in/errgo.v2 => gopkg.in/errgo.v2 v2.1.0
+
+replace gopkg.in/fsnotify.v1 => gopkg.in/fsnotify.v1 v1.4.7
+
+replace gopkg.in/inf.v0 => gopkg.in/inf.v0 v0.9.1
+
+replace gopkg.in/mcuadros/go-syslog.v2 => gopkg.in/mcuadros/go-syslog.v2 v2.2.1
+
+replace gopkg.in/natefinch/lumberjack.v2 => gopkg.in/natefinch/lumberjack.v2 v2.0.0
+
+replace gopkg.in/resty.v1 => gopkg.in/resty.v1 v1.12.0
+
+replace gopkg.in/tomb.v1 => gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7
+
+replace gopkg.in/warnings.v0 => gopkg.in/warnings.v0 v0.1.1
+
+replace gotest.tools => gotest.tools v2.2.0+incompatible
+
+replace gotest.tools/v3 => gotest.tools/v3 v3.0.2
+
+replace honnef.co/go/tools => honnef.co/go/tools v0.0.1-2019.2.3
+
+replace modernc.org/cc => modernc.org/cc v1.0.0
+
+replace modernc.org/golex => modernc.org/golex v1.0.0
+
+replace modernc.org/mathutil => modernc.org/mathutil v1.0.0
+
+replace modernc.org/strutil => modernc.org/strutil v1.0.0
+
+replace modernc.org/xc => modernc.org/xc v1.0.0
+
+replace rsc.io/pdf => rsc.io/pdf v0.1.1
+
+replace sigs.k8s.io/apiserver-network-proxy/konnectivity-client => sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.15
+
+replace sigs.k8s.io/structured-merge-diff/v4 => sigs.k8s.io/structured-merge-diff/v4 v4.1.2
+
+replace vbom.ml/util => vbom.ml/util v0.0.0-20160121211510-db5cfe13f5cc

--- a/staging/src/k8s.io/csi-translation-lib/go.mod
+++ b/staging/src/k8s.io/csi-translation-lib/go.mod
@@ -5,11 +5,119 @@ module k8s.io/csi-translation-lib
 go 1.15
 
 require (
+	bitbucket.org/bertimus9/systemstat v0.0.0-20180207000608-0eeff89b0690
+	github.com/Azure/azure-sdk-for-go v43.0.0+incompatible
+	github.com/Azure/go-autorest/autorest v0.9.6
+	github.com/Azure/go-autorest/autorest/adal v0.8.2
+	github.com/Azure/go-autorest/autorest/to v0.2.0
+	github.com/GoogleCloudPlatform/k8s-cloud-provider v0.0.0-20200415212048-7901bc822317
+	github.com/JeffAshton/win_pdh v0.0.0-20161109143554-76bb4ee9f0ab
+	github.com/Microsoft/go-winio v0.4.15-0.20190919025122-fc70bd9a86b5
+	github.com/Microsoft/hcsshim v0.8.10-0.20200715222032-5eafd1556990
+	github.com/PuerkitoBio/purell v1.1.1
+	github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e
+	github.com/auth0/go-jwt-middleware v0.0.0-20170425171159-5493cabe49f7
+	github.com/aws/aws-sdk-go v1.28.2
+	github.com/blang/semver v3.5.0+incompatible
+	github.com/boltdb/bolt v1.3.1
+	github.com/caddyserver/caddy v1.0.3
+	github.com/clusterhq/flocker-go v0.0.0-20160920122132-2b8b7259d313
+	github.com/codegangsta/negroni v1.0.0
+	github.com/container-storage-interface/spec v1.2.0
+	github.com/containernetworking/cni v0.8.0
+	github.com/coredns/corefile-migration v1.0.10
+	github.com/coreos/go-oidc v2.1.0+incompatible
+	github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e
+	github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f
+	github.com/cpuguy83/go-md2man/v2 v2.0.0
+	github.com/davecgh/go-spew v1.1.1
+	github.com/docker/distribution v2.7.1+incompatible
+	github.com/docker/docker v1.4.2-0.20200309214505-aa6a9891b09c
+	github.com/docker/go-connections v0.4.0
+	github.com/docker/go-units v0.4.0
+	github.com/elazarl/goproxy v0.0.0-20180725130230-947c36da3153
+	github.com/emicklei/go-restful v2.9.5+incompatible
+	github.com/evanphx/json-patch v4.9.0+incompatible
+	github.com/fsnotify/fsnotify v1.4.9
+	github.com/go-bindata/go-bindata v3.1.1+incompatible
+	github.com/go-openapi/analysis v0.19.5
+	github.com/go-openapi/loads v0.19.4
+	github.com/go-openapi/spec v0.19.3
+	github.com/go-openapi/strfmt v0.19.3
+	github.com/go-openapi/validate v0.19.5
+	github.com/go-ozzo/ozzo-validation v3.5.0+incompatible
+	github.com/gogo/protobuf v1.3.2
+	github.com/golang/groupcache v0.0.0-20191227052852-215e87163ea7
+	github.com/golang/mock v1.3.1
+	github.com/google/cadvisor v0.37.5
+	github.com/google/go-cmp v0.4.0
+	github.com/google/gofuzz v1.1.0
+	github.com/google/uuid v1.1.1
+	github.com/googleapis/gnostic v0.4.1
+	github.com/gorilla/context v1.1.1
+	github.com/hashicorp/golang-lru v0.5.1
+	github.com/heketi/heketi v9.0.1-0.20190917153846-c2e2a4ab7ab9+incompatible
+	github.com/heketi/tests v0.0.0-20151005000721-f3775cbcefd6
+	github.com/ishidawataru/sctp v0.0.0-20190723014705-7c296d48a2b5
+	github.com/json-iterator/go v1.1.10
+	github.com/libopenstorage/openstorage v1.0.0
+	github.com/lithammer/dedent v1.1.0
+	github.com/lpabon/godbc v0.1.1
+	github.com/magiconair/properties v1.8.1
+	github.com/miekg/dns v1.1.4
+	github.com/moby/ipvs v1.0.1
+	github.com/mohae/deepcopy v0.0.0-20170603005431-491d3605edfb
+	github.com/mrunalp/fileutils v0.0.0-20200520151820-abd8a0e76976
+	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822
+	github.com/mvdan/xurls v1.1.0
+	github.com/onsi/ginkgo v1.11.0
+	github.com/onsi/gomega v1.7.0
+	github.com/opencontainers/go-digest v1.0.0-rc1
+	github.com/opencontainers/runc v1.0.1
+	github.com/opencontainers/selinux v1.5.2
+	github.com/pkg/errors v0.9.1
+	github.com/pmezard/go-difflib v1.0.0
+	github.com/prometheus/client_golang v1.7.1
+	github.com/prometheus/client_model v0.2.0
+	github.com/prometheus/common v0.10.0
+	github.com/quobyte/api v0.1.2
+	github.com/robfig/cron v1.1.0
+	github.com/spf13/afero v1.2.2
+	github.com/spf13/cobra v1.0.0
+	github.com/spf13/jwalterweatherman v1.1.0
+	github.com/spf13/pflag v1.0.5
+	github.com/spf13/viper v1.4.0
+	github.com/storageos/go-api v0.0.0-20180912212459-343b3eff91fc
 	github.com/stretchr/testify v1.4.0
+	github.com/thecodeteam/goscaleio v0.1.0
+	github.com/urfave/negroni v1.0.0
+	github.com/vishvananda/netlink v1.1.0
+	github.com/vmware/govmomi v0.20.3
+	go.etcd.io/etcd v0.5.0-alpha.5.0.20200819165624-17cef6e3e9d5
+	golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9
+	golang.org/x/net v0.0.0-20201110031124-69a78807bb2b
+	golang.org/x/oauth2 v0.0.0-20191202225959-858c2ad4c8b6
+	golang.org/x/sys v0.0.0-20201112073958-5cba982894dd
+	golang.org/x/time v0.0.0-20191024005414-555d28b269f0
+	golang.org/x/tools v0.0.0-20210106214847-113979e3529a
+	gonum.org/v1/gonum v0.6.2
+	gonum.org/v1/netlib v0.0.0-20190331212654-76723241ea4e
+	google.golang.org/api v0.15.1
+	google.golang.org/grpc v1.27.0
+	gopkg.in/gcfg.v1 v1.2.0
+	gopkg.in/square/go-jose.v2 v2.2.2
+	gopkg.in/yaml.v2 v2.2.8
 	k8s.io/api v0.0.0
 	k8s.io/apimachinery v0.0.0
 	k8s.io/cloud-provider v0.0.0
+	k8s.io/gengo v0.0.0-20200428234225-8167cfdcfc14
+	k8s.io/heapster v1.2.0-beta.1
 	k8s.io/klog/v2 v2.2.0
+	k8s.io/kube-openapi v0.0.0-20200805222855-6aeccd4b50c6
+	k8s.io/system-validators v1.1.2
+	k8s.io/utils v0.0.0-20200729134348-d5654de09c73
+	sigs.k8s.io/kustomize v2.0.3+incompatible
+	sigs.k8s.io/yaml v1.2.0
 )
 
 replace (
@@ -20,3 +128,669 @@ replace (
 	k8s.io/component-base => ../component-base
 	k8s.io/csi-translation-lib => ../csi-translation-lib
 )
+
+replace github.com/auth0/go-jwt-middleware => github.com/auth0/go-jwt-middleware v0.0.0-20170425171159-5493cabe49f7
+
+replace github.com/boltdb/bolt => github.com/boltdb/bolt v1.3.1
+
+replace github.com/codegangsta/negroni => github.com/codegangsta/negroni v1.0.0
+
+replace github.com/go-ozzo/ozzo-validation => github.com/go-ozzo/ozzo-validation v3.5.0+incompatible
+
+replace github.com/gorilla/context => github.com/gorilla/context v1.1.1
+
+replace github.com/heketi/tests => github.com/heketi/tests v0.0.0-20151005000721-f3775cbcefd6
+
+replace github.com/lpabon/godbc => github.com/lpabon/godbc v0.1.1
+
+replace github.com/magiconair/properties => github.com/magiconair/properties v1.8.1
+
+replace github.com/mohae/deepcopy => github.com/mohae/deepcopy v0.0.0-20170603005431-491d3605edfb
+
+replace github.com/spf13/jwalterweatherman => github.com/spf13/jwalterweatherman v1.1.0
+
+replace github.com/urfave/negroni => github.com/urfave/negroni v1.0.0
+
+replace gonum.org/v1/netlib => gonum.org/v1/netlib v0.0.0-20190331212654-76723241ea4e
+
+replace bitbucket.org/bertimus9/systemstat => bitbucket.org/bertimus9/systemstat v0.0.0-20180207000608-0eeff89b0690
+
+replace github.com/Azure/azure-sdk-for-go => github.com/Azure/azure-sdk-for-go v43.0.0+incompatible
+
+replace github.com/Azure/go-autorest/autorest => github.com/Azure/go-autorest/autorest v0.9.6
+
+replace github.com/Azure/go-autorest/autorest/adal => github.com/Azure/go-autorest/autorest/adal v0.8.2
+
+replace github.com/Azure/go-autorest/autorest/to => github.com/Azure/go-autorest/autorest/to v0.2.0
+
+replace github.com/GoogleCloudPlatform/k8s-cloud-provider => github.com/GoogleCloudPlatform/k8s-cloud-provider v0.0.0-20200415212048-7901bc822317
+
+replace github.com/JeffAshton/win_pdh => github.com/JeffAshton/win_pdh v0.0.0-20161109143554-76bb4ee9f0ab
+
+replace github.com/Microsoft/go-winio => github.com/Microsoft/go-winio v0.4.15-0.20190919025122-fc70bd9a86b5
+
+replace github.com/Microsoft/hcsshim => github.com/Microsoft/hcsshim v0.8.10-0.20200715222032-5eafd1556990
+
+replace github.com/PuerkitoBio/purell => github.com/PuerkitoBio/purell v1.1.1
+
+replace github.com/armon/circbuf => github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e
+
+replace github.com/aws/aws-sdk-go => github.com/aws/aws-sdk-go v1.28.2
+
+replace github.com/blang/semver => github.com/blang/semver v3.5.0+incompatible
+
+replace github.com/caddyserver/caddy => github.com/caddyserver/caddy v1.0.3
+
+replace github.com/clusterhq/flocker-go => github.com/clusterhq/flocker-go v0.0.0-20160920122132-2b8b7259d313
+
+replace github.com/container-storage-interface/spec => github.com/container-storage-interface/spec v1.2.0
+
+replace github.com/containernetworking/cni => github.com/containernetworking/cni v0.8.0
+
+replace github.com/coredns/corefile-migration => github.com/coredns/corefile-migration v1.0.10
+
+replace github.com/coreos/go-oidc => github.com/coreos/go-oidc v2.1.0+incompatible
+
+replace github.com/coreos/go-systemd => github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e
+
+replace github.com/coreos/pkg => github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f
+
+replace github.com/cpuguy83/go-md2man/v2 => github.com/cpuguy83/go-md2man/v2 v2.0.0
+
+replace github.com/davecgh/go-spew => github.com/davecgh/go-spew v1.1.1
+
+replace github.com/docker/distribution => github.com/docker/distribution v2.7.1+incompatible
+
+replace github.com/docker/docker => github.com/docker/docker v1.4.2-0.20200309214505-aa6a9891b09c
+
+replace github.com/docker/go-connections => github.com/docker/go-connections v0.4.0
+
+replace github.com/docker/go-units => github.com/docker/go-units v0.4.0
+
+replace github.com/elazarl/goproxy => github.com/elazarl/goproxy v0.0.0-20180725130230-947c36da3153
+
+replace github.com/emicklei/go-restful => github.com/emicklei/go-restful v2.9.5+incompatible
+
+replace github.com/evanphx/json-patch => github.com/evanphx/json-patch v4.9.0+incompatible
+
+replace github.com/fsnotify/fsnotify => github.com/fsnotify/fsnotify v1.4.9
+
+replace github.com/go-bindata/go-bindata => github.com/go-bindata/go-bindata v3.1.1+incompatible
+
+replace github.com/go-openapi/analysis => github.com/go-openapi/analysis v0.19.5
+
+replace github.com/go-openapi/loads => github.com/go-openapi/loads v0.19.4
+
+replace github.com/go-openapi/spec => github.com/go-openapi/spec v0.19.3
+
+replace github.com/go-openapi/strfmt => github.com/go-openapi/strfmt v0.19.3
+
+replace github.com/go-openapi/validate => github.com/go-openapi/validate v0.19.5
+
+replace github.com/gogo/protobuf => github.com/gogo/protobuf v1.3.2
+
+replace github.com/golang/groupcache => github.com/golang/groupcache v0.0.0-20191227052852-215e87163ea7
+
+replace github.com/golang/mock => github.com/golang/mock v1.3.1
+
+replace github.com/google/cadvisor => github.com/google/cadvisor v0.37.5
+
+replace github.com/google/go-cmp => github.com/google/go-cmp v0.4.0
+
+replace github.com/google/gofuzz => github.com/google/gofuzz v1.1.0
+
+replace github.com/google/uuid => github.com/google/uuid v1.1.1
+
+replace github.com/googleapis/gnostic => github.com/googleapis/gnostic v0.4.1
+
+replace github.com/hashicorp/golang-lru => github.com/hashicorp/golang-lru v0.5.1
+
+replace github.com/heketi/heketi => github.com/heketi/heketi v9.0.1-0.20190917153846-c2e2a4ab7ab9+incompatible
+
+replace github.com/ishidawataru/sctp => github.com/ishidawataru/sctp v0.0.0-20190723014705-7c296d48a2b5
+
+replace github.com/json-iterator/go => github.com/json-iterator/go v1.1.10
+
+replace github.com/libopenstorage/openstorage => github.com/libopenstorage/openstorage v1.0.0
+
+replace github.com/lithammer/dedent => github.com/lithammer/dedent v1.1.0
+
+replace github.com/miekg/dns => github.com/miekg/dns v1.1.4
+
+replace github.com/moby/ipvs => github.com/moby/ipvs v1.0.1
+
+replace github.com/mrunalp/fileutils => github.com/mrunalp/fileutils v0.0.0-20200520151820-abd8a0e76976
+
+replace github.com/munnerz/goautoneg => github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822
+
+replace github.com/mvdan/xurls => github.com/mvdan/xurls v1.1.0
+
+replace github.com/onsi/ginkgo => github.com/onsi/ginkgo v1.11.0
+
+replace github.com/onsi/gomega => github.com/onsi/gomega v1.7.0
+
+replace github.com/opencontainers/go-digest => github.com/opencontainers/go-digest v1.0.0-rc1
+
+replace github.com/opencontainers/runc => github.com/opencontainers/runc v1.0.1
+
+replace github.com/opencontainers/selinux => github.com/opencontainers/selinux v1.5.2
+
+replace github.com/pkg/errors => github.com/pkg/errors v0.9.1
+
+replace github.com/pmezard/go-difflib => github.com/pmezard/go-difflib v1.0.0
+
+replace github.com/prometheus/client_golang => github.com/prometheus/client_golang v1.7.1
+
+replace github.com/prometheus/client_model => github.com/prometheus/client_model v0.2.0
+
+replace github.com/prometheus/common => github.com/prometheus/common v0.10.0
+
+replace github.com/quobyte/api => github.com/quobyte/api v0.1.2
+
+replace github.com/robfig/cron => github.com/robfig/cron v1.1.0
+
+replace github.com/spf13/afero => github.com/spf13/afero v1.2.2
+
+replace github.com/spf13/cobra => github.com/spf13/cobra v1.0.0
+
+replace github.com/spf13/pflag => github.com/spf13/pflag v1.0.5
+
+replace github.com/spf13/viper => github.com/spf13/viper v1.4.0
+
+replace github.com/storageos/go-api => github.com/storageos/go-api v0.0.0-20180912212459-343b3eff91fc
+
+replace github.com/stretchr/testify => github.com/stretchr/testify v1.4.0
+
+replace github.com/thecodeteam/goscaleio => github.com/thecodeteam/goscaleio v0.1.0
+
+replace github.com/vishvananda/netlink => github.com/vishvananda/netlink v1.1.0
+
+replace github.com/vmware/govmomi => github.com/vmware/govmomi v0.20.3
+
+replace go.etcd.io/etcd => go.etcd.io/etcd v0.5.0-alpha.5.0.20200819165624-17cef6e3e9d5
+
+replace golang.org/x/crypto => golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9
+
+replace golang.org/x/net => golang.org/x/net v0.0.0-20201110031124-69a78807bb2b
+
+replace golang.org/x/oauth2 => golang.org/x/oauth2 v0.0.0-20191202225959-858c2ad4c8b6
+
+replace golang.org/x/sys => golang.org/x/sys v0.0.0-20201112073958-5cba982894dd
+
+replace golang.org/x/time => golang.org/x/time v0.0.0-20191024005414-555d28b269f0
+
+replace golang.org/x/tools => golang.org/x/tools v0.0.0-20210106214847-113979e3529a
+
+replace gonum.org/v1/gonum => gonum.org/v1/gonum v0.6.2
+
+replace google.golang.org/api => google.golang.org/api v0.15.1
+
+replace google.golang.org/grpc => google.golang.org/grpc v1.27.0
+
+replace gopkg.in/gcfg.v1 => gopkg.in/gcfg.v1 v1.2.0
+
+replace gopkg.in/square/go-jose.v2 => gopkg.in/square/go-jose.v2 v2.2.2
+
+replace gopkg.in/yaml.v2 => gopkg.in/yaml.v2 v2.2.8
+
+replace k8s.io/gengo => k8s.io/gengo v0.0.0-20200428234225-8167cfdcfc14
+
+replace k8s.io/heapster => k8s.io/heapster v1.2.0-beta.1
+
+replace k8s.io/klog/v2 => k8s.io/klog/v2 v2.2.0
+
+replace k8s.io/kube-openapi => k8s.io/kube-openapi v0.0.0-20200805222855-6aeccd4b50c6
+
+replace k8s.io/system-validators => k8s.io/system-validators v1.1.2
+
+replace k8s.io/utils => k8s.io/utils v0.0.0-20200729134348-d5654de09c73
+
+replace sigs.k8s.io/kustomize => sigs.k8s.io/kustomize v2.0.3+incompatible
+
+replace sigs.k8s.io/yaml => sigs.k8s.io/yaml v1.2.0
+
+replace cloud.google.com/go => cloud.google.com/go v0.51.0
+
+replace cloud.google.com/go/bigquery => cloud.google.com/go/bigquery v1.0.1
+
+replace cloud.google.com/go/datastore => cloud.google.com/go/datastore v1.0.0
+
+replace cloud.google.com/go/pubsub => cloud.google.com/go/pubsub v1.0.1
+
+replace cloud.google.com/go/storage => cloud.google.com/go/storage v1.0.0
+
+replace dmitri.shuralyov.com/gpu/mtl => dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9
+
+replace github.com/Azure/go-ansiterm => github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78
+
+replace github.com/Azure/go-autorest/autorest/date => github.com/Azure/go-autorest/autorest/date v0.2.0
+
+replace github.com/Azure/go-autorest/autorest/mocks => github.com/Azure/go-autorest/autorest/mocks v0.3.0
+
+replace github.com/Azure/go-autorest/autorest/validation => github.com/Azure/go-autorest/autorest/validation v0.1.0
+
+replace github.com/Azure/go-autorest/logger => github.com/Azure/go-autorest/logger v0.1.0
+
+replace github.com/Azure/go-autorest/tracing => github.com/Azure/go-autorest/tracing v0.5.0
+
+replace github.com/BurntSushi/toml => github.com/BurntSushi/toml v0.3.1
+
+replace github.com/BurntSushi/xgb => github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802
+
+replace github.com/MakeNowJust/heredoc => github.com/MakeNowJust/heredoc v0.0.0-20170808103936-bb23615498cd
+
+replace github.com/NYTimes/gziphandler => github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46
+
+replace github.com/PuerkitoBio/urlesc => github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578
+
+replace github.com/agnivade/levenshtein => github.com/agnivade/levenshtein v1.0.1
+
+replace github.com/ajstarks/svgo => github.com/ajstarks/svgo v0.0.0-20180226025133-644b8db467af
+
+replace github.com/alecthomas/template => github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751
+
+replace github.com/alecthomas/units => github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4
+
+replace github.com/andreyvit/diff => github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883
+
+replace github.com/armon/consul-api => github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6
+
+replace github.com/asaskevich/govalidator => github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a
+
+replace github.com/beorn7/perks => github.com/beorn7/perks v1.0.1
+
+replace github.com/bgentry/speakeasy => github.com/bgentry/speakeasy v0.1.0
+
+replace github.com/bifurcation/mint => github.com/bifurcation/mint v0.0.0-20180715133206-93c51c6ce115
+
+replace github.com/cenkalti/backoff => github.com/cenkalti/backoff v2.1.1+incompatible
+
+replace github.com/census-instrumentation/opencensus-proto => github.com/census-instrumentation/opencensus-proto v0.2.1
+
+replace github.com/cespare/xxhash/v2 => github.com/cespare/xxhash/v2 v2.1.1
+
+replace github.com/chai2010/gettext-go => github.com/chai2010/gettext-go v0.0.0-20160711120539-c6fed771bfd5
+
+replace github.com/checkpoint-restore/go-criu/v4 => github.com/checkpoint-restore/go-criu/v4 v4.0.2
+
+replace github.com/cheekybits/genny => github.com/cheekybits/genny v0.0.0-20170328200008-9127e812e1e9
+
+replace github.com/chzyer/logex => github.com/chzyer/logex v1.1.10
+
+replace github.com/chzyer/readline => github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e
+
+replace github.com/chzyer/test => github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1
+
+replace github.com/cilium/ebpf => github.com/cilium/ebpf v0.0.0-20200702112145-1c8d4c9ef775
+
+replace github.com/cockroachdb/datadriven => github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa
+
+replace github.com/containerd/cgroups => github.com/containerd/cgroups v0.0.0-20200531161412-0dbf7f05ba59
+
+replace github.com/containerd/console => github.com/containerd/console v1.0.0
+
+replace github.com/containerd/containerd => github.com/containerd/containerd v1.3.3
+
+replace github.com/containerd/continuity => github.com/containerd/continuity v0.0.0-20190426062206-aaeac12a7ffc
+
+replace github.com/containerd/fifo => github.com/containerd/fifo v0.0.0-20190226154929-a9fb20d87448
+
+replace github.com/containerd/go-runc => github.com/containerd/go-runc v0.0.0-20180907222934-5a6d9f37cfa3
+
+replace github.com/containerd/ttrpc => github.com/containerd/ttrpc v1.0.0
+
+replace github.com/containerd/typeurl => github.com/containerd/typeurl v1.0.0
+
+replace github.com/coreos/bbolt => github.com/coreos/bbolt v1.3.2
+
+replace github.com/coreos/etcd => github.com/coreos/etcd v3.3.10+incompatible
+
+replace github.com/coreos/go-semver => github.com/coreos/go-semver v0.3.0
+
+replace github.com/coreos/go-systemd/v22 => github.com/coreos/go-systemd/v22 v22.1.0
+
+replace github.com/creack/pty => github.com/creack/pty v1.1.7
+
+replace github.com/cyphar/filepath-securejoin => github.com/cyphar/filepath-securejoin v0.2.2
+
+replace github.com/daviddengcn/go-colortext => github.com/daviddengcn/go-colortext v0.0.0-20160507010035-511bcaf42ccd
+
+replace github.com/dgrijalva/jwt-go => github.com/dgrijalva/jwt-go v3.2.0+incompatible
+
+replace github.com/dnaeon/go-vcr => github.com/dnaeon/go-vcr v1.0.1
+
+replace github.com/docker/spdystream => github.com/docker/spdystream v0.0.0-20160310174837-449fdfce4d96
+
+replace github.com/docopt/docopt-go => github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815
+
+replace github.com/dustin/go-humanize => github.com/dustin/go-humanize v1.0.0
+
+replace github.com/envoyproxy/go-control-plane => github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473
+
+replace github.com/envoyproxy/protoc-gen-validate => github.com/envoyproxy/protoc-gen-validate v0.1.0
+
+replace github.com/euank/go-kmsg-parser => github.com/euank/go-kmsg-parser v2.0.0+incompatible
+
+replace github.com/exponent-io/jsonpath => github.com/exponent-io/jsonpath v0.0.0-20151013193312-d6023ce2651d
+
+replace github.com/fatih/camelcase => github.com/fatih/camelcase v1.0.0
+
+replace github.com/fatih/color => github.com/fatih/color v1.7.0
+
+replace github.com/flynn/go-shlex => github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568
+
+replace github.com/fogleman/gg => github.com/fogleman/gg v1.2.1-0.20190220221249-0403632d5b90
+
+replace github.com/ghodss/yaml => github.com/ghodss/yaml v1.0.0
+
+replace github.com/go-acme/lego => github.com/go-acme/lego v2.5.0+incompatible
+
+replace github.com/go-gl/glfw/v3.3/glfw => github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72
+
+replace github.com/go-ini/ini => github.com/go-ini/ini v1.9.0
+
+replace github.com/go-kit/kit => github.com/go-kit/kit v0.9.0
+
+replace github.com/go-logfmt/logfmt => github.com/go-logfmt/logfmt v0.4.0
+
+replace github.com/go-logr/logr => github.com/go-logr/logr v0.2.0
+
+replace github.com/go-openapi/errors => github.com/go-openapi/errors v0.19.2
+
+replace github.com/go-openapi/jsonpointer => github.com/go-openapi/jsonpointer v0.19.3
+
+replace github.com/go-openapi/jsonreference => github.com/go-openapi/jsonreference v0.19.3
+
+replace github.com/go-openapi/runtime => github.com/go-openapi/runtime v0.19.4
+
+replace github.com/go-openapi/swag => github.com/go-openapi/swag v0.19.5
+
+replace github.com/go-stack/stack => github.com/go-stack/stack v1.8.0
+
+replace github.com/godbus/dbus/v5 => github.com/godbus/dbus/v5 v5.0.3
+
+replace github.com/golang/freetype => github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0
+
+replace github.com/golang/glog => github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
+
+replace github.com/golang/protobuf => github.com/golang/protobuf v1.4.2
+
+replace github.com/golangplus/bytes => github.com/golangplus/bytes v0.0.0-20160111154220-45c989fe5450
+
+replace github.com/golangplus/fmt => github.com/golangplus/fmt v0.0.0-20150411045040-2a5d6d7d2995
+
+replace github.com/golangplus/testing => github.com/golangplus/testing v0.0.0-20180327235837-af21d9c3145e
+
+replace github.com/google/btree => github.com/google/btree v1.0.0
+
+replace github.com/google/martian => github.com/google/martian v2.1.0+incompatible
+
+replace github.com/google/pprof => github.com/google/pprof v0.0.0-20191218002539-d4f498aebedc
+
+replace github.com/google/renameio => github.com/google/renameio v0.1.0
+
+replace github.com/googleapis/gax-go/v2 => github.com/googleapis/gax-go/v2 v2.0.5
+
+replace github.com/gophercloud/gophercloud => github.com/gophercloud/gophercloud v0.1.0
+
+replace github.com/gopherjs/gopherjs => github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1
+
+replace github.com/gorilla/mux => github.com/gorilla/mux v1.7.3
+
+replace github.com/gorilla/websocket => github.com/gorilla/websocket v1.4.0
+
+replace github.com/gregjones/httpcache => github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7
+
+replace github.com/grpc-ecosystem/go-grpc-middleware => github.com/grpc-ecosystem/go-grpc-middleware v1.0.1-0.20190118093823-f849b5445de4
+
+replace github.com/grpc-ecosystem/go-grpc-prometheus => github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0
+
+replace github.com/grpc-ecosystem/grpc-gateway => github.com/grpc-ecosystem/grpc-gateway v1.9.5
+
+replace github.com/hashicorp/go-syslog => github.com/hashicorp/go-syslog v1.0.0
+
+replace github.com/hashicorp/hcl => github.com/hashicorp/hcl v1.0.0
+
+replace github.com/hpcloud/tail => github.com/hpcloud/tail v1.0.0
+
+replace github.com/ianlancetaylor/demangle => github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6
+
+replace github.com/imdario/mergo => github.com/imdario/mergo v0.3.5
+
+replace github.com/inconshreveable/mousetrap => github.com/inconshreveable/mousetrap v1.0.0
+
+replace github.com/jimstudt/http-authentication => github.com/jimstudt/http-authentication v0.0.0-20140401203705-3eca13d6893a
+
+replace github.com/jmespath/go-jmespath => github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af
+
+replace github.com/jonboulle/clockwork => github.com/jonboulle/clockwork v0.1.0
+
+replace github.com/jstemmer/go-junit-report => github.com/jstemmer/go-junit-report v0.9.1
+
+replace github.com/jtolds/gls => github.com/jtolds/gls v4.20.0+incompatible
+
+replace github.com/julienschmidt/httprouter => github.com/julienschmidt/httprouter v1.2.0
+
+replace github.com/jung-kurt/gofpdf => github.com/jung-kurt/gofpdf v1.0.3-0.20190309125859-24315acbbda5
+
+replace github.com/karrick/godirwalk => github.com/karrick/godirwalk v1.7.5
+
+replace github.com/kisielk/errcheck => github.com/kisielk/errcheck v1.5.0
+
+replace github.com/kisielk/gotool => github.com/kisielk/gotool v1.0.0
+
+replace github.com/klauspost/cpuid => github.com/klauspost/cpuid v1.2.0
+
+replace github.com/konsorten/go-windows-terminal-sequences => github.com/konsorten/go-windows-terminal-sequences v1.0.3
+
+replace github.com/kr/logfmt => github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515
+
+replace github.com/kr/pretty => github.com/kr/pretty v0.2.0
+
+replace github.com/kr/pty => github.com/kr/pty v1.1.5
+
+replace github.com/kr/text => github.com/kr/text v0.1.0
+
+replace github.com/kylelemons/godebug => github.com/kylelemons/godebug v0.0.0-20170820004349-d65d576e9348
+
+replace github.com/liggitt/tabwriter => github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de
+
+replace github.com/lucas-clemente/aes12 => github.com/lucas-clemente/aes12 v0.0.0-20171027163421-cd47fb39b79f
+
+replace github.com/lucas-clemente/quic-clients => github.com/lucas-clemente/quic-clients v0.1.0
+
+replace github.com/lucas-clemente/quic-go => github.com/lucas-clemente/quic-go v0.10.2
+
+replace github.com/lucas-clemente/quic-go-certificates => github.com/lucas-clemente/quic-go-certificates v0.0.0-20160823095156-d2f86524cced
+
+replace github.com/mailru/easyjson => github.com/mailru/easyjson v0.7.0
+
+replace github.com/marten-seemann/qtls => github.com/marten-seemann/qtls v0.2.3
+
+replace github.com/mattn/go-colorable => github.com/mattn/go-colorable v0.0.9
+
+replace github.com/mattn/go-isatty => github.com/mattn/go-isatty v0.0.4
+
+replace github.com/mattn/go-runewidth => github.com/mattn/go-runewidth v0.0.2
+
+replace github.com/matttproud/golang_protobuf_extensions => github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369
+
+replace github.com/mholt/certmagic => github.com/mholt/certmagic v0.6.2-0.20190624175158-6a42ef9fe8c2
+
+replace github.com/mindprince/gonvml => github.com/mindprince/gonvml v0.0.0-20190828220739-9ebdce4bb989
+
+replace github.com/mistifyio/go-zfs => github.com/mistifyio/go-zfs v2.1.2-0.20190413222219-f784269be439+incompatible
+
+replace github.com/mitchellh/go-homedir => github.com/mitchellh/go-homedir v1.1.0
+
+replace github.com/mitchellh/go-wordwrap => github.com/mitchellh/go-wordwrap v1.0.0
+
+replace github.com/mitchellh/mapstructure => github.com/mitchellh/mapstructure v1.1.2
+
+replace github.com/moby/sys/mountinfo => github.com/moby/sys/mountinfo v0.1.3
+
+replace github.com/moby/term => github.com/moby/term v0.0.0-20200312100748-672ec06f55cd
+
+replace github.com/modern-go/concurrent => github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd
+
+replace github.com/modern-go/reflect2 => github.com/modern-go/reflect2 v1.0.1
+
+replace github.com/morikuni/aec => github.com/morikuni/aec v1.0.0
+
+replace github.com/mwitkow/go-conntrack => github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223
+
+replace github.com/mxk/go-flowrate => github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f
+
+replace github.com/naoina/go-stringutil => github.com/naoina/go-stringutil v0.1.0
+
+replace github.com/naoina/toml => github.com/naoina/toml v0.1.1
+
+replace github.com/olekukonko/tablewriter => github.com/olekukonko/tablewriter v0.0.0-20170122224234-a0225b3f23b5
+
+replace github.com/opencontainers/image-spec => github.com/opencontainers/image-spec v1.0.1
+
+replace github.com/opencontainers/runtime-spec => github.com/opencontainers/runtime-spec v1.0.3-0.20200520003142-237cc4f519e2
+
+replace github.com/pelletier/go-toml => github.com/pelletier/go-toml v1.2.0
+
+replace github.com/peterbourgon/diskv => github.com/peterbourgon/diskv v2.0.1+incompatible
+
+replace github.com/pquerna/cachecontrol => github.com/pquerna/cachecontrol v0.0.0-20171018203845-0dec1b30a021
+
+replace github.com/prometheus/procfs => github.com/prometheus/procfs v0.1.3
+
+replace github.com/remyoudompheng/bigfft => github.com/remyoudompheng/bigfft v0.0.0-20170806203942-52369c62f446
+
+replace github.com/rogpeppe/fastuuid => github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af
+
+replace github.com/rogpeppe/go-internal => github.com/rogpeppe/go-internal v1.3.0
+
+replace github.com/rubiojr/go-vhd => github.com/rubiojr/go-vhd v0.0.0-20200706105327-02e210299021
+
+replace github.com/russross/blackfriday => github.com/russross/blackfriday v1.5.2
+
+replace github.com/russross/blackfriday/v2 => github.com/russross/blackfriday/v2 v2.0.1
+
+replace github.com/satori/go.uuid => github.com/satori/go.uuid v1.2.0
+
+replace github.com/seccomp/libseccomp-golang => github.com/seccomp/libseccomp-golang v0.9.1
+
+replace github.com/sergi/go-diff => github.com/sergi/go-diff v1.0.0
+
+replace github.com/shurcooL/sanitized_anchor_name => github.com/shurcooL/sanitized_anchor_name v1.0.0
+
+replace github.com/sirupsen/logrus => github.com/sirupsen/logrus v1.6.0
+
+replace github.com/smartystreets/assertions => github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d
+
+replace github.com/smartystreets/goconvey => github.com/smartystreets/goconvey v1.6.4
+
+replace github.com/soheilhy/cmux => github.com/soheilhy/cmux v0.1.4
+
+replace github.com/spf13/cast => github.com/spf13/cast v1.3.0
+
+replace github.com/stretchr/objx => github.com/stretchr/objx v0.2.0
+
+replace github.com/syndtr/gocapability => github.com/syndtr/gocapability v0.0.0-20180916011248-d98352740cb2
+
+replace github.com/tidwall/pretty => github.com/tidwall/pretty v1.0.0
+
+replace github.com/tmc/grpc-websocket-proxy => github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5
+
+replace github.com/ugorji/go => github.com/ugorji/go v1.1.4
+
+replace github.com/urfave/cli => github.com/urfave/cli v1.22.2
+
+replace github.com/vektah/gqlparser => github.com/vektah/gqlparser v1.1.2
+
+replace github.com/vishvananda/netns => github.com/vishvananda/netns v0.0.0-20200520041808-52d707b772fe
+
+replace github.com/xiang90/probing => github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2
+
+replace github.com/xlab/handysort => github.com/xlab/handysort v0.0.0-20150421192137-fb3537ed64a1
+
+replace github.com/xordataexchange/crypt => github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77
+
+replace github.com/yuin/goldmark => github.com/yuin/goldmark v1.2.1
+
+replace go.etcd.io/bbolt => go.etcd.io/bbolt v1.3.5
+
+replace go.mongodb.org/mongo-driver => go.mongodb.org/mongo-driver v1.1.2
+
+replace go.opencensus.io => go.opencensus.io v0.22.2
+
+replace go.uber.org/atomic => go.uber.org/atomic v1.4.0
+
+replace go.uber.org/multierr => go.uber.org/multierr v1.1.0
+
+replace go.uber.org/zap => go.uber.org/zap v1.10.0
+
+replace golang.org/x/exp => golang.org/x/exp v0.0.0-20191227195350-da58074b4299
+
+replace golang.org/x/image => golang.org/x/image v0.0.0-20190802002840-cff245a6509b
+
+replace golang.org/x/lint => golang.org/x/lint v0.0.0-20191125180803-fdd1cda4f05f
+
+replace golang.org/x/mobile => golang.org/x/mobile v0.0.0-20190719004257-d2bd2a29d028
+
+replace golang.org/x/mod => golang.org/x/mod v0.3.0
+
+replace golang.org/x/sync => golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9
+
+replace golang.org/x/text => golang.org/x/text v0.3.3
+
+replace golang.org/x/xerrors => golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1
+
+replace gonum.org/v1/plot => gonum.org/v1/plot v0.0.0-20190515093506-e2840ee46a6b
+
+replace google.golang.org/appengine => google.golang.org/appengine v1.6.5
+
+replace google.golang.org/genproto => google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013
+
+replace google.golang.org/protobuf => google.golang.org/protobuf v1.24.0
+
+replace gopkg.in/alecthomas/kingpin.v2 => gopkg.in/alecthomas/kingpin.v2 v2.2.6
+
+replace gopkg.in/check.v1 => gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15
+
+replace gopkg.in/cheggaaa/pb.v1 => gopkg.in/cheggaaa/pb.v1 v1.0.25
+
+replace gopkg.in/errgo.v2 => gopkg.in/errgo.v2 v2.1.0
+
+replace gopkg.in/fsnotify.v1 => gopkg.in/fsnotify.v1 v1.4.7
+
+replace gopkg.in/inf.v0 => gopkg.in/inf.v0 v0.9.1
+
+replace gopkg.in/mcuadros/go-syslog.v2 => gopkg.in/mcuadros/go-syslog.v2 v2.2.1
+
+replace gopkg.in/natefinch/lumberjack.v2 => gopkg.in/natefinch/lumberjack.v2 v2.0.0
+
+replace gopkg.in/resty.v1 => gopkg.in/resty.v1 v1.12.0
+
+replace gopkg.in/tomb.v1 => gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7
+
+replace gopkg.in/warnings.v0 => gopkg.in/warnings.v0 v0.1.1
+
+replace gotest.tools => gotest.tools v2.2.0+incompatible
+
+replace gotest.tools/v3 => gotest.tools/v3 v3.0.2
+
+replace honnef.co/go/tools => honnef.co/go/tools v0.0.1-2019.2.3
+
+replace modernc.org/cc => modernc.org/cc v1.0.0
+
+replace modernc.org/golex => modernc.org/golex v1.0.0
+
+replace modernc.org/mathutil => modernc.org/mathutil v1.0.0
+
+replace modernc.org/strutil => modernc.org/strutil v1.0.0
+
+replace modernc.org/xc => modernc.org/xc v1.0.0
+
+replace rsc.io/pdf => rsc.io/pdf v0.1.1
+
+replace sigs.k8s.io/apiserver-network-proxy/konnectivity-client => sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.15
+
+replace sigs.k8s.io/structured-merge-diff/v4 => sigs.k8s.io/structured-merge-diff/v4 v4.1.2
+
+replace vbom.ml/util => vbom.ml/util v0.0.0-20160121211510-db5cfe13f5cc

--- a/staging/src/k8s.io/kube-aggregator/go.mod
+++ b/staging/src/k8s.io/kube-aggregator/go.mod
@@ -5,24 +5,122 @@ module k8s.io/kube-aggregator
 go 1.15
 
 require (
+	bitbucket.org/bertimus9/systemstat v0.0.0-20180207000608-0eeff89b0690
+	github.com/Azure/azure-sdk-for-go v43.0.0+incompatible
+	github.com/Azure/go-autorest/autorest v0.9.6
+	github.com/Azure/go-autorest/autorest/adal v0.8.2
+	github.com/Azure/go-autorest/autorest/to v0.2.0
+	github.com/GoogleCloudPlatform/k8s-cloud-provider v0.0.0-20200415212048-7901bc822317
+	github.com/JeffAshton/win_pdh v0.0.0-20161109143554-76bb4ee9f0ab
+	github.com/Microsoft/go-winio v0.4.15-0.20190919025122-fc70bd9a86b5
+	github.com/Microsoft/hcsshim v0.8.10-0.20200715222032-5eafd1556990
+	github.com/PuerkitoBio/purell v1.1.1
+	github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e
+	github.com/auth0/go-jwt-middleware v0.0.0-20170425171159-5493cabe49f7
+	github.com/aws/aws-sdk-go v1.28.2
+	github.com/blang/semver v3.5.0+incompatible
+	github.com/boltdb/bolt v1.3.1
+	github.com/caddyserver/caddy v1.0.3
+	github.com/clusterhq/flocker-go v0.0.0-20160920122132-2b8b7259d313
+	github.com/codegangsta/negroni v1.0.0
+	github.com/container-storage-interface/spec v1.2.0
+	github.com/containernetworking/cni v0.8.0
+	github.com/coredns/corefile-migration v1.0.10
+	github.com/coreos/go-oidc v2.1.0+incompatible
+	github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e
+	github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f
+	github.com/cpuguy83/go-md2man/v2 v2.0.0
 	github.com/davecgh/go-spew v1.1.1
+	github.com/docker/distribution v2.7.1+incompatible
+	github.com/docker/docker v1.4.2-0.20200309214505-aa6a9891b09c
+	github.com/docker/go-connections v0.4.0
+	github.com/docker/go-units v0.4.0
+	github.com/elazarl/goproxy v0.0.0-20180725130230-947c36da3153
 	github.com/emicklei/go-restful v2.9.5+incompatible
+	github.com/evanphx/json-patch v4.9.0+incompatible
+	github.com/fsnotify/fsnotify v1.4.9
+	github.com/go-bindata/go-bindata v3.1.1+incompatible
+	github.com/go-openapi/analysis v0.19.5
+	github.com/go-openapi/loads v0.19.4
 	github.com/go-openapi/spec v0.19.3
+	github.com/go-openapi/strfmt v0.19.3
+	github.com/go-openapi/validate v0.19.5
+	github.com/go-ozzo/ozzo-validation v3.5.0+incompatible
 	github.com/gogo/protobuf v1.3.2
+	github.com/golang/groupcache v0.0.0-20191227052852-215e87163ea7
+	github.com/golang/mock v1.3.1
+	github.com/google/cadvisor v0.37.5
+	github.com/google/go-cmp v0.4.0
+	github.com/google/gofuzz v1.1.0
+	github.com/google/uuid v1.1.1
+	github.com/googleapis/gnostic v0.4.1
+	github.com/gorilla/context v1.1.1
+	github.com/hashicorp/golang-lru v0.5.1
+	github.com/heketi/heketi v9.0.1-0.20190917153846-c2e2a4ab7ab9+incompatible
+	github.com/heketi/tests v0.0.0-20151005000721-f3775cbcefd6
+	github.com/ishidawataru/sctp v0.0.0-20190723014705-7c296d48a2b5
 	github.com/json-iterator/go v1.1.10
+	github.com/libopenstorage/openstorage v1.0.0
+	github.com/lithammer/dedent v1.1.0
+	github.com/lpabon/godbc v0.1.1
+	github.com/magiconair/properties v1.8.1
+	github.com/miekg/dns v1.1.4
+	github.com/moby/ipvs v1.0.1
+	github.com/mohae/deepcopy v0.0.0-20170603005431-491d3605edfb
+	github.com/mrunalp/fileutils v0.0.0-20200520151820-abd8a0e76976
+	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822
+	github.com/mvdan/xurls v1.1.0
+	github.com/onsi/ginkgo v1.11.0
+	github.com/onsi/gomega v1.7.0
+	github.com/opencontainers/go-digest v1.0.0-rc1
+	github.com/opencontainers/runc v1.0.1
+	github.com/opencontainers/selinux v1.5.2
+	github.com/pkg/errors v0.9.1
+	github.com/pmezard/go-difflib v1.0.0
+	github.com/prometheus/client_golang v1.7.1
+	github.com/prometheus/client_model v0.2.0
+	github.com/prometheus/common v0.10.0
+	github.com/quobyte/api v0.1.2
+	github.com/robfig/cron v1.1.0
+	github.com/spf13/afero v1.2.2
 	github.com/spf13/cobra v1.0.0
+	github.com/spf13/jwalterweatherman v1.1.0
 	github.com/spf13/pflag v1.0.5
+	github.com/spf13/viper v1.4.0
+	github.com/storageos/go-api v0.0.0-20180912212459-343b3eff91fc
 	github.com/stretchr/testify v1.4.0
+	github.com/thecodeteam/goscaleio v0.1.0
+	github.com/urfave/negroni v1.0.0
+	github.com/vishvananda/netlink v1.1.0
+	github.com/vmware/govmomi v0.20.3
+	go.etcd.io/etcd v0.5.0-alpha.5.0.20200819165624-17cef6e3e9d5
+	golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9
 	golang.org/x/net v0.0.0-20201110031124-69a78807bb2b
+	golang.org/x/oauth2 v0.0.0-20191202225959-858c2ad4c8b6
+	golang.org/x/sys v0.0.0-20201112073958-5cba982894dd
+	golang.org/x/time v0.0.0-20191024005414-555d28b269f0
+	golang.org/x/tools v0.0.0-20210106214847-113979e3529a
+	gonum.org/v1/gonum v0.6.2
+	gonum.org/v1/netlib v0.0.0-20190331212654-76723241ea4e
+	google.golang.org/api v0.15.1
+	google.golang.org/grpc v1.27.0
+	gopkg.in/gcfg.v1 v1.2.0
+	gopkg.in/square/go-jose.v2 v2.2.2
+	gopkg.in/yaml.v2 v2.2.8
 	k8s.io/api v0.0.0
 	k8s.io/apimachinery v0.0.0
 	k8s.io/apiserver v0.0.0
 	k8s.io/client-go v0.0.0
 	k8s.io/code-generator v0.0.0
 	k8s.io/component-base v0.0.0
+	k8s.io/gengo v0.0.0-20200428234225-8167cfdcfc14
+	k8s.io/heapster v1.2.0-beta.1
 	k8s.io/klog/v2 v2.2.0
 	k8s.io/kube-openapi v0.0.0-20200805222855-6aeccd4b50c6
+	k8s.io/system-validators v1.1.2
 	k8s.io/utils v0.0.0-20200729134348-d5654de09c73
+	sigs.k8s.io/kustomize v2.0.3+incompatible
+	sigs.k8s.io/yaml v1.2.0
 )
 
 replace (
@@ -34,3 +132,669 @@ replace (
 	k8s.io/component-base => ../component-base
 	k8s.io/kube-aggregator => ../kube-aggregator
 )
+
+replace github.com/auth0/go-jwt-middleware => github.com/auth0/go-jwt-middleware v0.0.0-20170425171159-5493cabe49f7
+
+replace github.com/boltdb/bolt => github.com/boltdb/bolt v1.3.1
+
+replace github.com/codegangsta/negroni => github.com/codegangsta/negroni v1.0.0
+
+replace github.com/go-ozzo/ozzo-validation => github.com/go-ozzo/ozzo-validation v3.5.0+incompatible
+
+replace github.com/gorilla/context => github.com/gorilla/context v1.1.1
+
+replace github.com/heketi/tests => github.com/heketi/tests v0.0.0-20151005000721-f3775cbcefd6
+
+replace github.com/lpabon/godbc => github.com/lpabon/godbc v0.1.1
+
+replace github.com/magiconair/properties => github.com/magiconair/properties v1.8.1
+
+replace github.com/mohae/deepcopy => github.com/mohae/deepcopy v0.0.0-20170603005431-491d3605edfb
+
+replace github.com/spf13/jwalterweatherman => github.com/spf13/jwalterweatherman v1.1.0
+
+replace github.com/urfave/negroni => github.com/urfave/negroni v1.0.0
+
+replace gonum.org/v1/netlib => gonum.org/v1/netlib v0.0.0-20190331212654-76723241ea4e
+
+replace bitbucket.org/bertimus9/systemstat => bitbucket.org/bertimus9/systemstat v0.0.0-20180207000608-0eeff89b0690
+
+replace github.com/Azure/azure-sdk-for-go => github.com/Azure/azure-sdk-for-go v43.0.0+incompatible
+
+replace github.com/Azure/go-autorest/autorest => github.com/Azure/go-autorest/autorest v0.9.6
+
+replace github.com/Azure/go-autorest/autorest/adal => github.com/Azure/go-autorest/autorest/adal v0.8.2
+
+replace github.com/Azure/go-autorest/autorest/to => github.com/Azure/go-autorest/autorest/to v0.2.0
+
+replace github.com/GoogleCloudPlatform/k8s-cloud-provider => github.com/GoogleCloudPlatform/k8s-cloud-provider v0.0.0-20200415212048-7901bc822317
+
+replace github.com/JeffAshton/win_pdh => github.com/JeffAshton/win_pdh v0.0.0-20161109143554-76bb4ee9f0ab
+
+replace github.com/Microsoft/go-winio => github.com/Microsoft/go-winio v0.4.15-0.20190919025122-fc70bd9a86b5
+
+replace github.com/Microsoft/hcsshim => github.com/Microsoft/hcsshim v0.8.10-0.20200715222032-5eafd1556990
+
+replace github.com/PuerkitoBio/purell => github.com/PuerkitoBio/purell v1.1.1
+
+replace github.com/armon/circbuf => github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e
+
+replace github.com/aws/aws-sdk-go => github.com/aws/aws-sdk-go v1.28.2
+
+replace github.com/blang/semver => github.com/blang/semver v3.5.0+incompatible
+
+replace github.com/caddyserver/caddy => github.com/caddyserver/caddy v1.0.3
+
+replace github.com/clusterhq/flocker-go => github.com/clusterhq/flocker-go v0.0.0-20160920122132-2b8b7259d313
+
+replace github.com/container-storage-interface/spec => github.com/container-storage-interface/spec v1.2.0
+
+replace github.com/containernetworking/cni => github.com/containernetworking/cni v0.8.0
+
+replace github.com/coredns/corefile-migration => github.com/coredns/corefile-migration v1.0.10
+
+replace github.com/coreos/go-oidc => github.com/coreos/go-oidc v2.1.0+incompatible
+
+replace github.com/coreos/go-systemd => github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e
+
+replace github.com/coreos/pkg => github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f
+
+replace github.com/cpuguy83/go-md2man/v2 => github.com/cpuguy83/go-md2man/v2 v2.0.0
+
+replace github.com/davecgh/go-spew => github.com/davecgh/go-spew v1.1.1
+
+replace github.com/docker/distribution => github.com/docker/distribution v2.7.1+incompatible
+
+replace github.com/docker/docker => github.com/docker/docker v1.4.2-0.20200309214505-aa6a9891b09c
+
+replace github.com/docker/go-connections => github.com/docker/go-connections v0.4.0
+
+replace github.com/docker/go-units => github.com/docker/go-units v0.4.0
+
+replace github.com/elazarl/goproxy => github.com/elazarl/goproxy v0.0.0-20180725130230-947c36da3153
+
+replace github.com/emicklei/go-restful => github.com/emicklei/go-restful v2.9.5+incompatible
+
+replace github.com/evanphx/json-patch => github.com/evanphx/json-patch v4.9.0+incompatible
+
+replace github.com/fsnotify/fsnotify => github.com/fsnotify/fsnotify v1.4.9
+
+replace github.com/go-bindata/go-bindata => github.com/go-bindata/go-bindata v3.1.1+incompatible
+
+replace github.com/go-openapi/analysis => github.com/go-openapi/analysis v0.19.5
+
+replace github.com/go-openapi/loads => github.com/go-openapi/loads v0.19.4
+
+replace github.com/go-openapi/spec => github.com/go-openapi/spec v0.19.3
+
+replace github.com/go-openapi/strfmt => github.com/go-openapi/strfmt v0.19.3
+
+replace github.com/go-openapi/validate => github.com/go-openapi/validate v0.19.5
+
+replace github.com/gogo/protobuf => github.com/gogo/protobuf v1.3.2
+
+replace github.com/golang/groupcache => github.com/golang/groupcache v0.0.0-20191227052852-215e87163ea7
+
+replace github.com/golang/mock => github.com/golang/mock v1.3.1
+
+replace github.com/google/cadvisor => github.com/google/cadvisor v0.37.5
+
+replace github.com/google/go-cmp => github.com/google/go-cmp v0.4.0
+
+replace github.com/google/gofuzz => github.com/google/gofuzz v1.1.0
+
+replace github.com/google/uuid => github.com/google/uuid v1.1.1
+
+replace github.com/googleapis/gnostic => github.com/googleapis/gnostic v0.4.1
+
+replace github.com/hashicorp/golang-lru => github.com/hashicorp/golang-lru v0.5.1
+
+replace github.com/heketi/heketi => github.com/heketi/heketi v9.0.1-0.20190917153846-c2e2a4ab7ab9+incompatible
+
+replace github.com/ishidawataru/sctp => github.com/ishidawataru/sctp v0.0.0-20190723014705-7c296d48a2b5
+
+replace github.com/json-iterator/go => github.com/json-iterator/go v1.1.10
+
+replace github.com/libopenstorage/openstorage => github.com/libopenstorage/openstorage v1.0.0
+
+replace github.com/lithammer/dedent => github.com/lithammer/dedent v1.1.0
+
+replace github.com/miekg/dns => github.com/miekg/dns v1.1.4
+
+replace github.com/moby/ipvs => github.com/moby/ipvs v1.0.1
+
+replace github.com/mrunalp/fileutils => github.com/mrunalp/fileutils v0.0.0-20200520151820-abd8a0e76976
+
+replace github.com/munnerz/goautoneg => github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822
+
+replace github.com/mvdan/xurls => github.com/mvdan/xurls v1.1.0
+
+replace github.com/onsi/ginkgo => github.com/onsi/ginkgo v1.11.0
+
+replace github.com/onsi/gomega => github.com/onsi/gomega v1.7.0
+
+replace github.com/opencontainers/go-digest => github.com/opencontainers/go-digest v1.0.0-rc1
+
+replace github.com/opencontainers/runc => github.com/opencontainers/runc v1.0.1
+
+replace github.com/opencontainers/selinux => github.com/opencontainers/selinux v1.5.2
+
+replace github.com/pkg/errors => github.com/pkg/errors v0.9.1
+
+replace github.com/pmezard/go-difflib => github.com/pmezard/go-difflib v1.0.0
+
+replace github.com/prometheus/client_golang => github.com/prometheus/client_golang v1.7.1
+
+replace github.com/prometheus/client_model => github.com/prometheus/client_model v0.2.0
+
+replace github.com/prometheus/common => github.com/prometheus/common v0.10.0
+
+replace github.com/quobyte/api => github.com/quobyte/api v0.1.2
+
+replace github.com/robfig/cron => github.com/robfig/cron v1.1.0
+
+replace github.com/spf13/afero => github.com/spf13/afero v1.2.2
+
+replace github.com/spf13/cobra => github.com/spf13/cobra v1.0.0
+
+replace github.com/spf13/pflag => github.com/spf13/pflag v1.0.5
+
+replace github.com/spf13/viper => github.com/spf13/viper v1.4.0
+
+replace github.com/storageos/go-api => github.com/storageos/go-api v0.0.0-20180912212459-343b3eff91fc
+
+replace github.com/stretchr/testify => github.com/stretchr/testify v1.4.0
+
+replace github.com/thecodeteam/goscaleio => github.com/thecodeteam/goscaleio v0.1.0
+
+replace github.com/vishvananda/netlink => github.com/vishvananda/netlink v1.1.0
+
+replace github.com/vmware/govmomi => github.com/vmware/govmomi v0.20.3
+
+replace go.etcd.io/etcd => go.etcd.io/etcd v0.5.0-alpha.5.0.20200819165624-17cef6e3e9d5
+
+replace golang.org/x/crypto => golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9
+
+replace golang.org/x/net => golang.org/x/net v0.0.0-20201110031124-69a78807bb2b
+
+replace golang.org/x/oauth2 => golang.org/x/oauth2 v0.0.0-20191202225959-858c2ad4c8b6
+
+replace golang.org/x/sys => golang.org/x/sys v0.0.0-20201112073958-5cba982894dd
+
+replace golang.org/x/time => golang.org/x/time v0.0.0-20191024005414-555d28b269f0
+
+replace golang.org/x/tools => golang.org/x/tools v0.0.0-20210106214847-113979e3529a
+
+replace gonum.org/v1/gonum => gonum.org/v1/gonum v0.6.2
+
+replace google.golang.org/api => google.golang.org/api v0.15.1
+
+replace google.golang.org/grpc => google.golang.org/grpc v1.27.0
+
+replace gopkg.in/gcfg.v1 => gopkg.in/gcfg.v1 v1.2.0
+
+replace gopkg.in/square/go-jose.v2 => gopkg.in/square/go-jose.v2 v2.2.2
+
+replace gopkg.in/yaml.v2 => gopkg.in/yaml.v2 v2.2.8
+
+replace k8s.io/gengo => k8s.io/gengo v0.0.0-20200428234225-8167cfdcfc14
+
+replace k8s.io/heapster => k8s.io/heapster v1.2.0-beta.1
+
+replace k8s.io/klog/v2 => k8s.io/klog/v2 v2.2.0
+
+replace k8s.io/kube-openapi => k8s.io/kube-openapi v0.0.0-20200805222855-6aeccd4b50c6
+
+replace k8s.io/system-validators => k8s.io/system-validators v1.1.2
+
+replace k8s.io/utils => k8s.io/utils v0.0.0-20200729134348-d5654de09c73
+
+replace sigs.k8s.io/kustomize => sigs.k8s.io/kustomize v2.0.3+incompatible
+
+replace sigs.k8s.io/yaml => sigs.k8s.io/yaml v1.2.0
+
+replace cloud.google.com/go => cloud.google.com/go v0.51.0
+
+replace cloud.google.com/go/bigquery => cloud.google.com/go/bigquery v1.0.1
+
+replace cloud.google.com/go/datastore => cloud.google.com/go/datastore v1.0.0
+
+replace cloud.google.com/go/pubsub => cloud.google.com/go/pubsub v1.0.1
+
+replace cloud.google.com/go/storage => cloud.google.com/go/storage v1.0.0
+
+replace dmitri.shuralyov.com/gpu/mtl => dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9
+
+replace github.com/Azure/go-ansiterm => github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78
+
+replace github.com/Azure/go-autorest/autorest/date => github.com/Azure/go-autorest/autorest/date v0.2.0
+
+replace github.com/Azure/go-autorest/autorest/mocks => github.com/Azure/go-autorest/autorest/mocks v0.3.0
+
+replace github.com/Azure/go-autorest/autorest/validation => github.com/Azure/go-autorest/autorest/validation v0.1.0
+
+replace github.com/Azure/go-autorest/logger => github.com/Azure/go-autorest/logger v0.1.0
+
+replace github.com/Azure/go-autorest/tracing => github.com/Azure/go-autorest/tracing v0.5.0
+
+replace github.com/BurntSushi/toml => github.com/BurntSushi/toml v0.3.1
+
+replace github.com/BurntSushi/xgb => github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802
+
+replace github.com/MakeNowJust/heredoc => github.com/MakeNowJust/heredoc v0.0.0-20170808103936-bb23615498cd
+
+replace github.com/NYTimes/gziphandler => github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46
+
+replace github.com/PuerkitoBio/urlesc => github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578
+
+replace github.com/agnivade/levenshtein => github.com/agnivade/levenshtein v1.0.1
+
+replace github.com/ajstarks/svgo => github.com/ajstarks/svgo v0.0.0-20180226025133-644b8db467af
+
+replace github.com/alecthomas/template => github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751
+
+replace github.com/alecthomas/units => github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4
+
+replace github.com/andreyvit/diff => github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883
+
+replace github.com/armon/consul-api => github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6
+
+replace github.com/asaskevich/govalidator => github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a
+
+replace github.com/beorn7/perks => github.com/beorn7/perks v1.0.1
+
+replace github.com/bgentry/speakeasy => github.com/bgentry/speakeasy v0.1.0
+
+replace github.com/bifurcation/mint => github.com/bifurcation/mint v0.0.0-20180715133206-93c51c6ce115
+
+replace github.com/cenkalti/backoff => github.com/cenkalti/backoff v2.1.1+incompatible
+
+replace github.com/census-instrumentation/opencensus-proto => github.com/census-instrumentation/opencensus-proto v0.2.1
+
+replace github.com/cespare/xxhash/v2 => github.com/cespare/xxhash/v2 v2.1.1
+
+replace github.com/chai2010/gettext-go => github.com/chai2010/gettext-go v0.0.0-20160711120539-c6fed771bfd5
+
+replace github.com/checkpoint-restore/go-criu/v4 => github.com/checkpoint-restore/go-criu/v4 v4.0.2
+
+replace github.com/cheekybits/genny => github.com/cheekybits/genny v0.0.0-20170328200008-9127e812e1e9
+
+replace github.com/chzyer/logex => github.com/chzyer/logex v1.1.10
+
+replace github.com/chzyer/readline => github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e
+
+replace github.com/chzyer/test => github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1
+
+replace github.com/cilium/ebpf => github.com/cilium/ebpf v0.0.0-20200702112145-1c8d4c9ef775
+
+replace github.com/cockroachdb/datadriven => github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa
+
+replace github.com/containerd/cgroups => github.com/containerd/cgroups v0.0.0-20200531161412-0dbf7f05ba59
+
+replace github.com/containerd/console => github.com/containerd/console v1.0.0
+
+replace github.com/containerd/containerd => github.com/containerd/containerd v1.3.3
+
+replace github.com/containerd/continuity => github.com/containerd/continuity v0.0.0-20190426062206-aaeac12a7ffc
+
+replace github.com/containerd/fifo => github.com/containerd/fifo v0.0.0-20190226154929-a9fb20d87448
+
+replace github.com/containerd/go-runc => github.com/containerd/go-runc v0.0.0-20180907222934-5a6d9f37cfa3
+
+replace github.com/containerd/ttrpc => github.com/containerd/ttrpc v1.0.0
+
+replace github.com/containerd/typeurl => github.com/containerd/typeurl v1.0.0
+
+replace github.com/coreos/bbolt => github.com/coreos/bbolt v1.3.2
+
+replace github.com/coreos/etcd => github.com/coreos/etcd v3.3.10+incompatible
+
+replace github.com/coreos/go-semver => github.com/coreos/go-semver v0.3.0
+
+replace github.com/coreos/go-systemd/v22 => github.com/coreos/go-systemd/v22 v22.1.0
+
+replace github.com/creack/pty => github.com/creack/pty v1.1.7
+
+replace github.com/cyphar/filepath-securejoin => github.com/cyphar/filepath-securejoin v0.2.2
+
+replace github.com/daviddengcn/go-colortext => github.com/daviddengcn/go-colortext v0.0.0-20160507010035-511bcaf42ccd
+
+replace github.com/dgrijalva/jwt-go => github.com/dgrijalva/jwt-go v3.2.0+incompatible
+
+replace github.com/dnaeon/go-vcr => github.com/dnaeon/go-vcr v1.0.1
+
+replace github.com/docker/spdystream => github.com/docker/spdystream v0.0.0-20160310174837-449fdfce4d96
+
+replace github.com/docopt/docopt-go => github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815
+
+replace github.com/dustin/go-humanize => github.com/dustin/go-humanize v1.0.0
+
+replace github.com/envoyproxy/go-control-plane => github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473
+
+replace github.com/envoyproxy/protoc-gen-validate => github.com/envoyproxy/protoc-gen-validate v0.1.0
+
+replace github.com/euank/go-kmsg-parser => github.com/euank/go-kmsg-parser v2.0.0+incompatible
+
+replace github.com/exponent-io/jsonpath => github.com/exponent-io/jsonpath v0.0.0-20151013193312-d6023ce2651d
+
+replace github.com/fatih/camelcase => github.com/fatih/camelcase v1.0.0
+
+replace github.com/fatih/color => github.com/fatih/color v1.7.0
+
+replace github.com/flynn/go-shlex => github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568
+
+replace github.com/fogleman/gg => github.com/fogleman/gg v1.2.1-0.20190220221249-0403632d5b90
+
+replace github.com/ghodss/yaml => github.com/ghodss/yaml v1.0.0
+
+replace github.com/go-acme/lego => github.com/go-acme/lego v2.5.0+incompatible
+
+replace github.com/go-gl/glfw/v3.3/glfw => github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72
+
+replace github.com/go-ini/ini => github.com/go-ini/ini v1.9.0
+
+replace github.com/go-kit/kit => github.com/go-kit/kit v0.9.0
+
+replace github.com/go-logfmt/logfmt => github.com/go-logfmt/logfmt v0.4.0
+
+replace github.com/go-logr/logr => github.com/go-logr/logr v0.2.0
+
+replace github.com/go-openapi/errors => github.com/go-openapi/errors v0.19.2
+
+replace github.com/go-openapi/jsonpointer => github.com/go-openapi/jsonpointer v0.19.3
+
+replace github.com/go-openapi/jsonreference => github.com/go-openapi/jsonreference v0.19.3
+
+replace github.com/go-openapi/runtime => github.com/go-openapi/runtime v0.19.4
+
+replace github.com/go-openapi/swag => github.com/go-openapi/swag v0.19.5
+
+replace github.com/go-stack/stack => github.com/go-stack/stack v1.8.0
+
+replace github.com/godbus/dbus/v5 => github.com/godbus/dbus/v5 v5.0.3
+
+replace github.com/golang/freetype => github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0
+
+replace github.com/golang/glog => github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
+
+replace github.com/golang/protobuf => github.com/golang/protobuf v1.4.2
+
+replace github.com/golangplus/bytes => github.com/golangplus/bytes v0.0.0-20160111154220-45c989fe5450
+
+replace github.com/golangplus/fmt => github.com/golangplus/fmt v0.0.0-20150411045040-2a5d6d7d2995
+
+replace github.com/golangplus/testing => github.com/golangplus/testing v0.0.0-20180327235837-af21d9c3145e
+
+replace github.com/google/btree => github.com/google/btree v1.0.0
+
+replace github.com/google/martian => github.com/google/martian v2.1.0+incompatible
+
+replace github.com/google/pprof => github.com/google/pprof v0.0.0-20191218002539-d4f498aebedc
+
+replace github.com/google/renameio => github.com/google/renameio v0.1.0
+
+replace github.com/googleapis/gax-go/v2 => github.com/googleapis/gax-go/v2 v2.0.5
+
+replace github.com/gophercloud/gophercloud => github.com/gophercloud/gophercloud v0.1.0
+
+replace github.com/gopherjs/gopherjs => github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1
+
+replace github.com/gorilla/mux => github.com/gorilla/mux v1.7.3
+
+replace github.com/gorilla/websocket => github.com/gorilla/websocket v1.4.0
+
+replace github.com/gregjones/httpcache => github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7
+
+replace github.com/grpc-ecosystem/go-grpc-middleware => github.com/grpc-ecosystem/go-grpc-middleware v1.0.1-0.20190118093823-f849b5445de4
+
+replace github.com/grpc-ecosystem/go-grpc-prometheus => github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0
+
+replace github.com/grpc-ecosystem/grpc-gateway => github.com/grpc-ecosystem/grpc-gateway v1.9.5
+
+replace github.com/hashicorp/go-syslog => github.com/hashicorp/go-syslog v1.0.0
+
+replace github.com/hashicorp/hcl => github.com/hashicorp/hcl v1.0.0
+
+replace github.com/hpcloud/tail => github.com/hpcloud/tail v1.0.0
+
+replace github.com/ianlancetaylor/demangle => github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6
+
+replace github.com/imdario/mergo => github.com/imdario/mergo v0.3.5
+
+replace github.com/inconshreveable/mousetrap => github.com/inconshreveable/mousetrap v1.0.0
+
+replace github.com/jimstudt/http-authentication => github.com/jimstudt/http-authentication v0.0.0-20140401203705-3eca13d6893a
+
+replace github.com/jmespath/go-jmespath => github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af
+
+replace github.com/jonboulle/clockwork => github.com/jonboulle/clockwork v0.1.0
+
+replace github.com/jstemmer/go-junit-report => github.com/jstemmer/go-junit-report v0.9.1
+
+replace github.com/jtolds/gls => github.com/jtolds/gls v4.20.0+incompatible
+
+replace github.com/julienschmidt/httprouter => github.com/julienschmidt/httprouter v1.2.0
+
+replace github.com/jung-kurt/gofpdf => github.com/jung-kurt/gofpdf v1.0.3-0.20190309125859-24315acbbda5
+
+replace github.com/karrick/godirwalk => github.com/karrick/godirwalk v1.7.5
+
+replace github.com/kisielk/errcheck => github.com/kisielk/errcheck v1.5.0
+
+replace github.com/kisielk/gotool => github.com/kisielk/gotool v1.0.0
+
+replace github.com/klauspost/cpuid => github.com/klauspost/cpuid v1.2.0
+
+replace github.com/konsorten/go-windows-terminal-sequences => github.com/konsorten/go-windows-terminal-sequences v1.0.3
+
+replace github.com/kr/logfmt => github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515
+
+replace github.com/kr/pretty => github.com/kr/pretty v0.2.0
+
+replace github.com/kr/pty => github.com/kr/pty v1.1.5
+
+replace github.com/kr/text => github.com/kr/text v0.1.0
+
+replace github.com/kylelemons/godebug => github.com/kylelemons/godebug v0.0.0-20170820004349-d65d576e9348
+
+replace github.com/liggitt/tabwriter => github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de
+
+replace github.com/lucas-clemente/aes12 => github.com/lucas-clemente/aes12 v0.0.0-20171027163421-cd47fb39b79f
+
+replace github.com/lucas-clemente/quic-clients => github.com/lucas-clemente/quic-clients v0.1.0
+
+replace github.com/lucas-clemente/quic-go => github.com/lucas-clemente/quic-go v0.10.2
+
+replace github.com/lucas-clemente/quic-go-certificates => github.com/lucas-clemente/quic-go-certificates v0.0.0-20160823095156-d2f86524cced
+
+replace github.com/mailru/easyjson => github.com/mailru/easyjson v0.7.0
+
+replace github.com/marten-seemann/qtls => github.com/marten-seemann/qtls v0.2.3
+
+replace github.com/mattn/go-colorable => github.com/mattn/go-colorable v0.0.9
+
+replace github.com/mattn/go-isatty => github.com/mattn/go-isatty v0.0.4
+
+replace github.com/mattn/go-runewidth => github.com/mattn/go-runewidth v0.0.2
+
+replace github.com/matttproud/golang_protobuf_extensions => github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369
+
+replace github.com/mholt/certmagic => github.com/mholt/certmagic v0.6.2-0.20190624175158-6a42ef9fe8c2
+
+replace github.com/mindprince/gonvml => github.com/mindprince/gonvml v0.0.0-20190828220739-9ebdce4bb989
+
+replace github.com/mistifyio/go-zfs => github.com/mistifyio/go-zfs v2.1.2-0.20190413222219-f784269be439+incompatible
+
+replace github.com/mitchellh/go-homedir => github.com/mitchellh/go-homedir v1.1.0
+
+replace github.com/mitchellh/go-wordwrap => github.com/mitchellh/go-wordwrap v1.0.0
+
+replace github.com/mitchellh/mapstructure => github.com/mitchellh/mapstructure v1.1.2
+
+replace github.com/moby/sys/mountinfo => github.com/moby/sys/mountinfo v0.1.3
+
+replace github.com/moby/term => github.com/moby/term v0.0.0-20200312100748-672ec06f55cd
+
+replace github.com/modern-go/concurrent => github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd
+
+replace github.com/modern-go/reflect2 => github.com/modern-go/reflect2 v1.0.1
+
+replace github.com/morikuni/aec => github.com/morikuni/aec v1.0.0
+
+replace github.com/mwitkow/go-conntrack => github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223
+
+replace github.com/mxk/go-flowrate => github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f
+
+replace github.com/naoina/go-stringutil => github.com/naoina/go-stringutil v0.1.0
+
+replace github.com/naoina/toml => github.com/naoina/toml v0.1.1
+
+replace github.com/olekukonko/tablewriter => github.com/olekukonko/tablewriter v0.0.0-20170122224234-a0225b3f23b5
+
+replace github.com/opencontainers/image-spec => github.com/opencontainers/image-spec v1.0.1
+
+replace github.com/opencontainers/runtime-spec => github.com/opencontainers/runtime-spec v1.0.3-0.20200520003142-237cc4f519e2
+
+replace github.com/pelletier/go-toml => github.com/pelletier/go-toml v1.2.0
+
+replace github.com/peterbourgon/diskv => github.com/peterbourgon/diskv v2.0.1+incompatible
+
+replace github.com/pquerna/cachecontrol => github.com/pquerna/cachecontrol v0.0.0-20171018203845-0dec1b30a021
+
+replace github.com/prometheus/procfs => github.com/prometheus/procfs v0.1.3
+
+replace github.com/remyoudompheng/bigfft => github.com/remyoudompheng/bigfft v0.0.0-20170806203942-52369c62f446
+
+replace github.com/rogpeppe/fastuuid => github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af
+
+replace github.com/rogpeppe/go-internal => github.com/rogpeppe/go-internal v1.3.0
+
+replace github.com/rubiojr/go-vhd => github.com/rubiojr/go-vhd v0.0.0-20200706105327-02e210299021
+
+replace github.com/russross/blackfriday => github.com/russross/blackfriday v1.5.2
+
+replace github.com/russross/blackfriday/v2 => github.com/russross/blackfriday/v2 v2.0.1
+
+replace github.com/satori/go.uuid => github.com/satori/go.uuid v1.2.0
+
+replace github.com/seccomp/libseccomp-golang => github.com/seccomp/libseccomp-golang v0.9.1
+
+replace github.com/sergi/go-diff => github.com/sergi/go-diff v1.0.0
+
+replace github.com/shurcooL/sanitized_anchor_name => github.com/shurcooL/sanitized_anchor_name v1.0.0
+
+replace github.com/sirupsen/logrus => github.com/sirupsen/logrus v1.6.0
+
+replace github.com/smartystreets/assertions => github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d
+
+replace github.com/smartystreets/goconvey => github.com/smartystreets/goconvey v1.6.4
+
+replace github.com/soheilhy/cmux => github.com/soheilhy/cmux v0.1.4
+
+replace github.com/spf13/cast => github.com/spf13/cast v1.3.0
+
+replace github.com/stretchr/objx => github.com/stretchr/objx v0.2.0
+
+replace github.com/syndtr/gocapability => github.com/syndtr/gocapability v0.0.0-20180916011248-d98352740cb2
+
+replace github.com/tidwall/pretty => github.com/tidwall/pretty v1.0.0
+
+replace github.com/tmc/grpc-websocket-proxy => github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5
+
+replace github.com/ugorji/go => github.com/ugorji/go v1.1.4
+
+replace github.com/urfave/cli => github.com/urfave/cli v1.22.2
+
+replace github.com/vektah/gqlparser => github.com/vektah/gqlparser v1.1.2
+
+replace github.com/vishvananda/netns => github.com/vishvananda/netns v0.0.0-20200520041808-52d707b772fe
+
+replace github.com/xiang90/probing => github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2
+
+replace github.com/xlab/handysort => github.com/xlab/handysort v0.0.0-20150421192137-fb3537ed64a1
+
+replace github.com/xordataexchange/crypt => github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77
+
+replace github.com/yuin/goldmark => github.com/yuin/goldmark v1.2.1
+
+replace go.etcd.io/bbolt => go.etcd.io/bbolt v1.3.5
+
+replace go.mongodb.org/mongo-driver => go.mongodb.org/mongo-driver v1.1.2
+
+replace go.opencensus.io => go.opencensus.io v0.22.2
+
+replace go.uber.org/atomic => go.uber.org/atomic v1.4.0
+
+replace go.uber.org/multierr => go.uber.org/multierr v1.1.0
+
+replace go.uber.org/zap => go.uber.org/zap v1.10.0
+
+replace golang.org/x/exp => golang.org/x/exp v0.0.0-20191227195350-da58074b4299
+
+replace golang.org/x/image => golang.org/x/image v0.0.0-20190802002840-cff245a6509b
+
+replace golang.org/x/lint => golang.org/x/lint v0.0.0-20191125180803-fdd1cda4f05f
+
+replace golang.org/x/mobile => golang.org/x/mobile v0.0.0-20190719004257-d2bd2a29d028
+
+replace golang.org/x/mod => golang.org/x/mod v0.3.0
+
+replace golang.org/x/sync => golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9
+
+replace golang.org/x/text => golang.org/x/text v0.3.3
+
+replace golang.org/x/xerrors => golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1
+
+replace gonum.org/v1/plot => gonum.org/v1/plot v0.0.0-20190515093506-e2840ee46a6b
+
+replace google.golang.org/appengine => google.golang.org/appengine v1.6.5
+
+replace google.golang.org/genproto => google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013
+
+replace google.golang.org/protobuf => google.golang.org/protobuf v1.24.0
+
+replace gopkg.in/alecthomas/kingpin.v2 => gopkg.in/alecthomas/kingpin.v2 v2.2.6
+
+replace gopkg.in/check.v1 => gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15
+
+replace gopkg.in/cheggaaa/pb.v1 => gopkg.in/cheggaaa/pb.v1 v1.0.25
+
+replace gopkg.in/errgo.v2 => gopkg.in/errgo.v2 v2.1.0
+
+replace gopkg.in/fsnotify.v1 => gopkg.in/fsnotify.v1 v1.4.7
+
+replace gopkg.in/inf.v0 => gopkg.in/inf.v0 v0.9.1
+
+replace gopkg.in/mcuadros/go-syslog.v2 => gopkg.in/mcuadros/go-syslog.v2 v2.2.1
+
+replace gopkg.in/natefinch/lumberjack.v2 => gopkg.in/natefinch/lumberjack.v2 v2.0.0
+
+replace gopkg.in/resty.v1 => gopkg.in/resty.v1 v1.12.0
+
+replace gopkg.in/tomb.v1 => gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7
+
+replace gopkg.in/warnings.v0 => gopkg.in/warnings.v0 v0.1.1
+
+replace gotest.tools => gotest.tools v2.2.0+incompatible
+
+replace gotest.tools/v3 => gotest.tools/v3 v3.0.2
+
+replace honnef.co/go/tools => honnef.co/go/tools v0.0.1-2019.2.3
+
+replace modernc.org/cc => modernc.org/cc v1.0.0
+
+replace modernc.org/golex => modernc.org/golex v1.0.0
+
+replace modernc.org/mathutil => modernc.org/mathutil v1.0.0
+
+replace modernc.org/strutil => modernc.org/strutil v1.0.0
+
+replace modernc.org/xc => modernc.org/xc v1.0.0
+
+replace rsc.io/pdf => rsc.io/pdf v0.1.1
+
+replace sigs.k8s.io/apiserver-network-proxy/konnectivity-client => sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.15
+
+replace sigs.k8s.io/structured-merge-diff/v4 => sigs.k8s.io/structured-merge-diff/v4 v4.1.2
+
+replace vbom.ml/util => vbom.ml/util v0.0.0-20160121211510-db5cfe13f5cc

--- a/staging/src/k8s.io/kube-controller-manager/go.mod
+++ b/staging/src/k8s.io/kube-controller-manager/go.mod
@@ -5,8 +5,118 @@ module k8s.io/kube-controller-manager
 go 1.15
 
 require (
+	bitbucket.org/bertimus9/systemstat v0.0.0-20180207000608-0eeff89b0690
+	github.com/Azure/azure-sdk-for-go v43.0.0+incompatible
+	github.com/Azure/go-autorest/autorest v0.9.6
+	github.com/Azure/go-autorest/autorest/adal v0.8.2
+	github.com/Azure/go-autorest/autorest/to v0.2.0
+	github.com/GoogleCloudPlatform/k8s-cloud-provider v0.0.0-20200415212048-7901bc822317
+	github.com/JeffAshton/win_pdh v0.0.0-20161109143554-76bb4ee9f0ab
+	github.com/Microsoft/go-winio v0.4.15-0.20190919025122-fc70bd9a86b5
+	github.com/Microsoft/hcsshim v0.8.10-0.20200715222032-5eafd1556990
+	github.com/PuerkitoBio/purell v1.1.1
+	github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e
+	github.com/auth0/go-jwt-middleware v0.0.0-20170425171159-5493cabe49f7
+	github.com/aws/aws-sdk-go v1.28.2
+	github.com/blang/semver v3.5.0+incompatible
+	github.com/boltdb/bolt v1.3.1
+	github.com/caddyserver/caddy v1.0.3
+	github.com/clusterhq/flocker-go v0.0.0-20160920122132-2b8b7259d313
+	github.com/codegangsta/negroni v1.0.0
+	github.com/container-storage-interface/spec v1.2.0
+	github.com/containernetworking/cni v0.8.0
+	github.com/coredns/corefile-migration v1.0.10
+	github.com/coreos/go-oidc v2.1.0+incompatible
+	github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e
+	github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f
+	github.com/cpuguy83/go-md2man/v2 v2.0.0
+	github.com/davecgh/go-spew v1.1.1
+	github.com/docker/distribution v2.7.1+incompatible
+	github.com/docker/docker v1.4.2-0.20200309214505-aa6a9891b09c
+	github.com/docker/go-connections v0.4.0
+	github.com/docker/go-units v0.4.0
+	github.com/elazarl/goproxy v0.0.0-20180725130230-947c36da3153
+	github.com/emicklei/go-restful v2.9.5+incompatible
+	github.com/evanphx/json-patch v4.9.0+incompatible
+	github.com/fsnotify/fsnotify v1.4.9
+	github.com/go-bindata/go-bindata v3.1.1+incompatible
+	github.com/go-openapi/analysis v0.19.5
+	github.com/go-openapi/loads v0.19.4
+	github.com/go-openapi/spec v0.19.3
+	github.com/go-openapi/strfmt v0.19.3
+	github.com/go-openapi/validate v0.19.5
+	github.com/go-ozzo/ozzo-validation v3.5.0+incompatible
+	github.com/gogo/protobuf v1.3.2
+	github.com/golang/groupcache v0.0.0-20191227052852-215e87163ea7
+	github.com/golang/mock v1.3.1
+	github.com/google/cadvisor v0.37.5
+	github.com/google/go-cmp v0.4.0
+	github.com/google/gofuzz v1.1.0
+	github.com/google/uuid v1.1.1
+	github.com/googleapis/gnostic v0.4.1
+	github.com/gorilla/context v1.1.1
+	github.com/hashicorp/golang-lru v0.5.1
+	github.com/heketi/heketi v9.0.1-0.20190917153846-c2e2a4ab7ab9+incompatible
+	github.com/heketi/tests v0.0.0-20151005000721-f3775cbcefd6
+	github.com/ishidawataru/sctp v0.0.0-20190723014705-7c296d48a2b5
+	github.com/json-iterator/go v1.1.10
+	github.com/libopenstorage/openstorage v1.0.0
+	github.com/lithammer/dedent v1.1.0
+	github.com/lpabon/godbc v0.1.1
+	github.com/magiconair/properties v1.8.1
+	github.com/miekg/dns v1.1.4
+	github.com/moby/ipvs v1.0.1
+	github.com/mohae/deepcopy v0.0.0-20170603005431-491d3605edfb
+	github.com/mrunalp/fileutils v0.0.0-20200520151820-abd8a0e76976
+	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822
+	github.com/mvdan/xurls v1.1.0
+	github.com/onsi/ginkgo v1.11.0
+	github.com/onsi/gomega v1.7.0
+	github.com/opencontainers/go-digest v1.0.0-rc1
+	github.com/opencontainers/runc v1.0.1
+	github.com/opencontainers/selinux v1.5.2
+	github.com/pkg/errors v0.9.1
+	github.com/pmezard/go-difflib v1.0.0
+	github.com/prometheus/client_golang v1.7.1
+	github.com/prometheus/client_model v0.2.0
+	github.com/prometheus/common v0.10.0
+	github.com/quobyte/api v0.1.2
+	github.com/robfig/cron v1.1.0
+	github.com/spf13/afero v1.2.2
+	github.com/spf13/cobra v1.0.0
+	github.com/spf13/jwalterweatherman v1.1.0
+	github.com/spf13/pflag v1.0.5
+	github.com/spf13/viper v1.4.0
+	github.com/storageos/go-api v0.0.0-20180912212459-343b3eff91fc
+	github.com/stretchr/testify v1.4.0
+	github.com/thecodeteam/goscaleio v0.1.0
+	github.com/urfave/negroni v1.0.0
+	github.com/vishvananda/netlink v1.1.0
+	github.com/vmware/govmomi v0.20.3
+	go.etcd.io/etcd v0.5.0-alpha.5.0.20200819165624-17cef6e3e9d5
+	golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9
+	golang.org/x/net v0.0.0-20201110031124-69a78807bb2b
+	golang.org/x/oauth2 v0.0.0-20191202225959-858c2ad4c8b6
+	golang.org/x/sys v0.0.0-20201112073958-5cba982894dd
+	golang.org/x/time v0.0.0-20191024005414-555d28b269f0
+	golang.org/x/tools v0.0.0-20210106214847-113979e3529a
+	gonum.org/v1/gonum v0.6.2
+	gonum.org/v1/netlib v0.0.0-20190331212654-76723241ea4e
+	google.golang.org/api v0.15.1
+	google.golang.org/grpc v1.27.0
+	gopkg.in/gcfg.v1 v1.2.0
+	gopkg.in/square/go-jose.v2 v2.2.2
+	gopkg.in/yaml.v2 v2.2.8
 	k8s.io/apimachinery v0.0.0
 	k8s.io/component-base v0.0.0
+	k8s.io/gengo v0.0.0-20200428234225-8167cfdcfc14
+	k8s.io/heapster v1.2.0-beta.1
+	k8s.io/klog/v2 v2.2.0
+	k8s.io/kube-openapi v0.0.0-20200805222855-6aeccd4b50c6
+	k8s.io/system-validators v1.1.2
+	k8s.io/utils v0.0.0-20200729134348-d5654de09c73
+	sigs.k8s.io/kustomize v2.0.3+incompatible
+	sigs.k8s.io/yaml v1.2.0
 )
 
 replace (
@@ -16,3 +126,669 @@ replace (
 	k8s.io/component-base => ../component-base
 	k8s.io/kube-controller-manager => ../kube-controller-manager
 )
+
+replace github.com/auth0/go-jwt-middleware => github.com/auth0/go-jwt-middleware v0.0.0-20170425171159-5493cabe49f7
+
+replace github.com/boltdb/bolt => github.com/boltdb/bolt v1.3.1
+
+replace github.com/codegangsta/negroni => github.com/codegangsta/negroni v1.0.0
+
+replace github.com/go-ozzo/ozzo-validation => github.com/go-ozzo/ozzo-validation v3.5.0+incompatible
+
+replace github.com/gorilla/context => github.com/gorilla/context v1.1.1
+
+replace github.com/heketi/tests => github.com/heketi/tests v0.0.0-20151005000721-f3775cbcefd6
+
+replace github.com/lpabon/godbc => github.com/lpabon/godbc v0.1.1
+
+replace github.com/magiconair/properties => github.com/magiconair/properties v1.8.1
+
+replace github.com/mohae/deepcopy => github.com/mohae/deepcopy v0.0.0-20170603005431-491d3605edfb
+
+replace github.com/spf13/jwalterweatherman => github.com/spf13/jwalterweatherman v1.1.0
+
+replace github.com/urfave/negroni => github.com/urfave/negroni v1.0.0
+
+replace gonum.org/v1/netlib => gonum.org/v1/netlib v0.0.0-20190331212654-76723241ea4e
+
+replace bitbucket.org/bertimus9/systemstat => bitbucket.org/bertimus9/systemstat v0.0.0-20180207000608-0eeff89b0690
+
+replace github.com/Azure/azure-sdk-for-go => github.com/Azure/azure-sdk-for-go v43.0.0+incompatible
+
+replace github.com/Azure/go-autorest/autorest => github.com/Azure/go-autorest/autorest v0.9.6
+
+replace github.com/Azure/go-autorest/autorest/adal => github.com/Azure/go-autorest/autorest/adal v0.8.2
+
+replace github.com/Azure/go-autorest/autorest/to => github.com/Azure/go-autorest/autorest/to v0.2.0
+
+replace github.com/GoogleCloudPlatform/k8s-cloud-provider => github.com/GoogleCloudPlatform/k8s-cloud-provider v0.0.0-20200415212048-7901bc822317
+
+replace github.com/JeffAshton/win_pdh => github.com/JeffAshton/win_pdh v0.0.0-20161109143554-76bb4ee9f0ab
+
+replace github.com/Microsoft/go-winio => github.com/Microsoft/go-winio v0.4.15-0.20190919025122-fc70bd9a86b5
+
+replace github.com/Microsoft/hcsshim => github.com/Microsoft/hcsshim v0.8.10-0.20200715222032-5eafd1556990
+
+replace github.com/PuerkitoBio/purell => github.com/PuerkitoBio/purell v1.1.1
+
+replace github.com/armon/circbuf => github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e
+
+replace github.com/aws/aws-sdk-go => github.com/aws/aws-sdk-go v1.28.2
+
+replace github.com/blang/semver => github.com/blang/semver v3.5.0+incompatible
+
+replace github.com/caddyserver/caddy => github.com/caddyserver/caddy v1.0.3
+
+replace github.com/clusterhq/flocker-go => github.com/clusterhq/flocker-go v0.0.0-20160920122132-2b8b7259d313
+
+replace github.com/container-storage-interface/spec => github.com/container-storage-interface/spec v1.2.0
+
+replace github.com/containernetworking/cni => github.com/containernetworking/cni v0.8.0
+
+replace github.com/coredns/corefile-migration => github.com/coredns/corefile-migration v1.0.10
+
+replace github.com/coreos/go-oidc => github.com/coreos/go-oidc v2.1.0+incompatible
+
+replace github.com/coreos/go-systemd => github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e
+
+replace github.com/coreos/pkg => github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f
+
+replace github.com/cpuguy83/go-md2man/v2 => github.com/cpuguy83/go-md2man/v2 v2.0.0
+
+replace github.com/davecgh/go-spew => github.com/davecgh/go-spew v1.1.1
+
+replace github.com/docker/distribution => github.com/docker/distribution v2.7.1+incompatible
+
+replace github.com/docker/docker => github.com/docker/docker v1.4.2-0.20200309214505-aa6a9891b09c
+
+replace github.com/docker/go-connections => github.com/docker/go-connections v0.4.0
+
+replace github.com/docker/go-units => github.com/docker/go-units v0.4.0
+
+replace github.com/elazarl/goproxy => github.com/elazarl/goproxy v0.0.0-20180725130230-947c36da3153
+
+replace github.com/emicklei/go-restful => github.com/emicklei/go-restful v2.9.5+incompatible
+
+replace github.com/evanphx/json-patch => github.com/evanphx/json-patch v4.9.0+incompatible
+
+replace github.com/fsnotify/fsnotify => github.com/fsnotify/fsnotify v1.4.9
+
+replace github.com/go-bindata/go-bindata => github.com/go-bindata/go-bindata v3.1.1+incompatible
+
+replace github.com/go-openapi/analysis => github.com/go-openapi/analysis v0.19.5
+
+replace github.com/go-openapi/loads => github.com/go-openapi/loads v0.19.4
+
+replace github.com/go-openapi/spec => github.com/go-openapi/spec v0.19.3
+
+replace github.com/go-openapi/strfmt => github.com/go-openapi/strfmt v0.19.3
+
+replace github.com/go-openapi/validate => github.com/go-openapi/validate v0.19.5
+
+replace github.com/gogo/protobuf => github.com/gogo/protobuf v1.3.2
+
+replace github.com/golang/groupcache => github.com/golang/groupcache v0.0.0-20191227052852-215e87163ea7
+
+replace github.com/golang/mock => github.com/golang/mock v1.3.1
+
+replace github.com/google/cadvisor => github.com/google/cadvisor v0.37.5
+
+replace github.com/google/go-cmp => github.com/google/go-cmp v0.4.0
+
+replace github.com/google/gofuzz => github.com/google/gofuzz v1.1.0
+
+replace github.com/google/uuid => github.com/google/uuid v1.1.1
+
+replace github.com/googleapis/gnostic => github.com/googleapis/gnostic v0.4.1
+
+replace github.com/hashicorp/golang-lru => github.com/hashicorp/golang-lru v0.5.1
+
+replace github.com/heketi/heketi => github.com/heketi/heketi v9.0.1-0.20190917153846-c2e2a4ab7ab9+incompatible
+
+replace github.com/ishidawataru/sctp => github.com/ishidawataru/sctp v0.0.0-20190723014705-7c296d48a2b5
+
+replace github.com/json-iterator/go => github.com/json-iterator/go v1.1.10
+
+replace github.com/libopenstorage/openstorage => github.com/libopenstorage/openstorage v1.0.0
+
+replace github.com/lithammer/dedent => github.com/lithammer/dedent v1.1.0
+
+replace github.com/miekg/dns => github.com/miekg/dns v1.1.4
+
+replace github.com/moby/ipvs => github.com/moby/ipvs v1.0.1
+
+replace github.com/mrunalp/fileutils => github.com/mrunalp/fileutils v0.0.0-20200520151820-abd8a0e76976
+
+replace github.com/munnerz/goautoneg => github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822
+
+replace github.com/mvdan/xurls => github.com/mvdan/xurls v1.1.0
+
+replace github.com/onsi/ginkgo => github.com/onsi/ginkgo v1.11.0
+
+replace github.com/onsi/gomega => github.com/onsi/gomega v1.7.0
+
+replace github.com/opencontainers/go-digest => github.com/opencontainers/go-digest v1.0.0-rc1
+
+replace github.com/opencontainers/runc => github.com/opencontainers/runc v1.0.1
+
+replace github.com/opencontainers/selinux => github.com/opencontainers/selinux v1.5.2
+
+replace github.com/pkg/errors => github.com/pkg/errors v0.9.1
+
+replace github.com/pmezard/go-difflib => github.com/pmezard/go-difflib v1.0.0
+
+replace github.com/prometheus/client_golang => github.com/prometheus/client_golang v1.7.1
+
+replace github.com/prometheus/client_model => github.com/prometheus/client_model v0.2.0
+
+replace github.com/prometheus/common => github.com/prometheus/common v0.10.0
+
+replace github.com/quobyte/api => github.com/quobyte/api v0.1.2
+
+replace github.com/robfig/cron => github.com/robfig/cron v1.1.0
+
+replace github.com/spf13/afero => github.com/spf13/afero v1.2.2
+
+replace github.com/spf13/cobra => github.com/spf13/cobra v1.0.0
+
+replace github.com/spf13/pflag => github.com/spf13/pflag v1.0.5
+
+replace github.com/spf13/viper => github.com/spf13/viper v1.4.0
+
+replace github.com/storageos/go-api => github.com/storageos/go-api v0.0.0-20180912212459-343b3eff91fc
+
+replace github.com/stretchr/testify => github.com/stretchr/testify v1.4.0
+
+replace github.com/thecodeteam/goscaleio => github.com/thecodeteam/goscaleio v0.1.0
+
+replace github.com/vishvananda/netlink => github.com/vishvananda/netlink v1.1.0
+
+replace github.com/vmware/govmomi => github.com/vmware/govmomi v0.20.3
+
+replace go.etcd.io/etcd => go.etcd.io/etcd v0.5.0-alpha.5.0.20200819165624-17cef6e3e9d5
+
+replace golang.org/x/crypto => golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9
+
+replace golang.org/x/net => golang.org/x/net v0.0.0-20201110031124-69a78807bb2b
+
+replace golang.org/x/oauth2 => golang.org/x/oauth2 v0.0.0-20191202225959-858c2ad4c8b6
+
+replace golang.org/x/sys => golang.org/x/sys v0.0.0-20201112073958-5cba982894dd
+
+replace golang.org/x/time => golang.org/x/time v0.0.0-20191024005414-555d28b269f0
+
+replace golang.org/x/tools => golang.org/x/tools v0.0.0-20210106214847-113979e3529a
+
+replace gonum.org/v1/gonum => gonum.org/v1/gonum v0.6.2
+
+replace google.golang.org/api => google.golang.org/api v0.15.1
+
+replace google.golang.org/grpc => google.golang.org/grpc v1.27.0
+
+replace gopkg.in/gcfg.v1 => gopkg.in/gcfg.v1 v1.2.0
+
+replace gopkg.in/square/go-jose.v2 => gopkg.in/square/go-jose.v2 v2.2.2
+
+replace gopkg.in/yaml.v2 => gopkg.in/yaml.v2 v2.2.8
+
+replace k8s.io/gengo => k8s.io/gengo v0.0.0-20200428234225-8167cfdcfc14
+
+replace k8s.io/heapster => k8s.io/heapster v1.2.0-beta.1
+
+replace k8s.io/klog/v2 => k8s.io/klog/v2 v2.2.0
+
+replace k8s.io/kube-openapi => k8s.io/kube-openapi v0.0.0-20200805222855-6aeccd4b50c6
+
+replace k8s.io/system-validators => k8s.io/system-validators v1.1.2
+
+replace k8s.io/utils => k8s.io/utils v0.0.0-20200729134348-d5654de09c73
+
+replace sigs.k8s.io/kustomize => sigs.k8s.io/kustomize v2.0.3+incompatible
+
+replace sigs.k8s.io/yaml => sigs.k8s.io/yaml v1.2.0
+
+replace cloud.google.com/go => cloud.google.com/go v0.51.0
+
+replace cloud.google.com/go/bigquery => cloud.google.com/go/bigquery v1.0.1
+
+replace cloud.google.com/go/datastore => cloud.google.com/go/datastore v1.0.0
+
+replace cloud.google.com/go/pubsub => cloud.google.com/go/pubsub v1.0.1
+
+replace cloud.google.com/go/storage => cloud.google.com/go/storage v1.0.0
+
+replace dmitri.shuralyov.com/gpu/mtl => dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9
+
+replace github.com/Azure/go-ansiterm => github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78
+
+replace github.com/Azure/go-autorest/autorest/date => github.com/Azure/go-autorest/autorest/date v0.2.0
+
+replace github.com/Azure/go-autorest/autorest/mocks => github.com/Azure/go-autorest/autorest/mocks v0.3.0
+
+replace github.com/Azure/go-autorest/autorest/validation => github.com/Azure/go-autorest/autorest/validation v0.1.0
+
+replace github.com/Azure/go-autorest/logger => github.com/Azure/go-autorest/logger v0.1.0
+
+replace github.com/Azure/go-autorest/tracing => github.com/Azure/go-autorest/tracing v0.5.0
+
+replace github.com/BurntSushi/toml => github.com/BurntSushi/toml v0.3.1
+
+replace github.com/BurntSushi/xgb => github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802
+
+replace github.com/MakeNowJust/heredoc => github.com/MakeNowJust/heredoc v0.0.0-20170808103936-bb23615498cd
+
+replace github.com/NYTimes/gziphandler => github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46
+
+replace github.com/PuerkitoBio/urlesc => github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578
+
+replace github.com/agnivade/levenshtein => github.com/agnivade/levenshtein v1.0.1
+
+replace github.com/ajstarks/svgo => github.com/ajstarks/svgo v0.0.0-20180226025133-644b8db467af
+
+replace github.com/alecthomas/template => github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751
+
+replace github.com/alecthomas/units => github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4
+
+replace github.com/andreyvit/diff => github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883
+
+replace github.com/armon/consul-api => github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6
+
+replace github.com/asaskevich/govalidator => github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a
+
+replace github.com/beorn7/perks => github.com/beorn7/perks v1.0.1
+
+replace github.com/bgentry/speakeasy => github.com/bgentry/speakeasy v0.1.0
+
+replace github.com/bifurcation/mint => github.com/bifurcation/mint v0.0.0-20180715133206-93c51c6ce115
+
+replace github.com/cenkalti/backoff => github.com/cenkalti/backoff v2.1.1+incompatible
+
+replace github.com/census-instrumentation/opencensus-proto => github.com/census-instrumentation/opencensus-proto v0.2.1
+
+replace github.com/cespare/xxhash/v2 => github.com/cespare/xxhash/v2 v2.1.1
+
+replace github.com/chai2010/gettext-go => github.com/chai2010/gettext-go v0.0.0-20160711120539-c6fed771bfd5
+
+replace github.com/checkpoint-restore/go-criu/v4 => github.com/checkpoint-restore/go-criu/v4 v4.0.2
+
+replace github.com/cheekybits/genny => github.com/cheekybits/genny v0.0.0-20170328200008-9127e812e1e9
+
+replace github.com/chzyer/logex => github.com/chzyer/logex v1.1.10
+
+replace github.com/chzyer/readline => github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e
+
+replace github.com/chzyer/test => github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1
+
+replace github.com/cilium/ebpf => github.com/cilium/ebpf v0.0.0-20200702112145-1c8d4c9ef775
+
+replace github.com/cockroachdb/datadriven => github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa
+
+replace github.com/containerd/cgroups => github.com/containerd/cgroups v0.0.0-20200531161412-0dbf7f05ba59
+
+replace github.com/containerd/console => github.com/containerd/console v1.0.0
+
+replace github.com/containerd/containerd => github.com/containerd/containerd v1.3.3
+
+replace github.com/containerd/continuity => github.com/containerd/continuity v0.0.0-20190426062206-aaeac12a7ffc
+
+replace github.com/containerd/fifo => github.com/containerd/fifo v0.0.0-20190226154929-a9fb20d87448
+
+replace github.com/containerd/go-runc => github.com/containerd/go-runc v0.0.0-20180907222934-5a6d9f37cfa3
+
+replace github.com/containerd/ttrpc => github.com/containerd/ttrpc v1.0.0
+
+replace github.com/containerd/typeurl => github.com/containerd/typeurl v1.0.0
+
+replace github.com/coreos/bbolt => github.com/coreos/bbolt v1.3.2
+
+replace github.com/coreos/etcd => github.com/coreos/etcd v3.3.10+incompatible
+
+replace github.com/coreos/go-semver => github.com/coreos/go-semver v0.3.0
+
+replace github.com/coreos/go-systemd/v22 => github.com/coreos/go-systemd/v22 v22.1.0
+
+replace github.com/creack/pty => github.com/creack/pty v1.1.7
+
+replace github.com/cyphar/filepath-securejoin => github.com/cyphar/filepath-securejoin v0.2.2
+
+replace github.com/daviddengcn/go-colortext => github.com/daviddengcn/go-colortext v0.0.0-20160507010035-511bcaf42ccd
+
+replace github.com/dgrijalva/jwt-go => github.com/dgrijalva/jwt-go v3.2.0+incompatible
+
+replace github.com/dnaeon/go-vcr => github.com/dnaeon/go-vcr v1.0.1
+
+replace github.com/docker/spdystream => github.com/docker/spdystream v0.0.0-20160310174837-449fdfce4d96
+
+replace github.com/docopt/docopt-go => github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815
+
+replace github.com/dustin/go-humanize => github.com/dustin/go-humanize v1.0.0
+
+replace github.com/envoyproxy/go-control-plane => github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473
+
+replace github.com/envoyproxy/protoc-gen-validate => github.com/envoyproxy/protoc-gen-validate v0.1.0
+
+replace github.com/euank/go-kmsg-parser => github.com/euank/go-kmsg-parser v2.0.0+incompatible
+
+replace github.com/exponent-io/jsonpath => github.com/exponent-io/jsonpath v0.0.0-20151013193312-d6023ce2651d
+
+replace github.com/fatih/camelcase => github.com/fatih/camelcase v1.0.0
+
+replace github.com/fatih/color => github.com/fatih/color v1.7.0
+
+replace github.com/flynn/go-shlex => github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568
+
+replace github.com/fogleman/gg => github.com/fogleman/gg v1.2.1-0.20190220221249-0403632d5b90
+
+replace github.com/ghodss/yaml => github.com/ghodss/yaml v1.0.0
+
+replace github.com/go-acme/lego => github.com/go-acme/lego v2.5.0+incompatible
+
+replace github.com/go-gl/glfw/v3.3/glfw => github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72
+
+replace github.com/go-ini/ini => github.com/go-ini/ini v1.9.0
+
+replace github.com/go-kit/kit => github.com/go-kit/kit v0.9.0
+
+replace github.com/go-logfmt/logfmt => github.com/go-logfmt/logfmt v0.4.0
+
+replace github.com/go-logr/logr => github.com/go-logr/logr v0.2.0
+
+replace github.com/go-openapi/errors => github.com/go-openapi/errors v0.19.2
+
+replace github.com/go-openapi/jsonpointer => github.com/go-openapi/jsonpointer v0.19.3
+
+replace github.com/go-openapi/jsonreference => github.com/go-openapi/jsonreference v0.19.3
+
+replace github.com/go-openapi/runtime => github.com/go-openapi/runtime v0.19.4
+
+replace github.com/go-openapi/swag => github.com/go-openapi/swag v0.19.5
+
+replace github.com/go-stack/stack => github.com/go-stack/stack v1.8.0
+
+replace github.com/godbus/dbus/v5 => github.com/godbus/dbus/v5 v5.0.3
+
+replace github.com/golang/freetype => github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0
+
+replace github.com/golang/glog => github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
+
+replace github.com/golang/protobuf => github.com/golang/protobuf v1.4.2
+
+replace github.com/golangplus/bytes => github.com/golangplus/bytes v0.0.0-20160111154220-45c989fe5450
+
+replace github.com/golangplus/fmt => github.com/golangplus/fmt v0.0.0-20150411045040-2a5d6d7d2995
+
+replace github.com/golangplus/testing => github.com/golangplus/testing v0.0.0-20180327235837-af21d9c3145e
+
+replace github.com/google/btree => github.com/google/btree v1.0.0
+
+replace github.com/google/martian => github.com/google/martian v2.1.0+incompatible
+
+replace github.com/google/pprof => github.com/google/pprof v0.0.0-20191218002539-d4f498aebedc
+
+replace github.com/google/renameio => github.com/google/renameio v0.1.0
+
+replace github.com/googleapis/gax-go/v2 => github.com/googleapis/gax-go/v2 v2.0.5
+
+replace github.com/gophercloud/gophercloud => github.com/gophercloud/gophercloud v0.1.0
+
+replace github.com/gopherjs/gopherjs => github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1
+
+replace github.com/gorilla/mux => github.com/gorilla/mux v1.7.3
+
+replace github.com/gorilla/websocket => github.com/gorilla/websocket v1.4.0
+
+replace github.com/gregjones/httpcache => github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7
+
+replace github.com/grpc-ecosystem/go-grpc-middleware => github.com/grpc-ecosystem/go-grpc-middleware v1.0.1-0.20190118093823-f849b5445de4
+
+replace github.com/grpc-ecosystem/go-grpc-prometheus => github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0
+
+replace github.com/grpc-ecosystem/grpc-gateway => github.com/grpc-ecosystem/grpc-gateway v1.9.5
+
+replace github.com/hashicorp/go-syslog => github.com/hashicorp/go-syslog v1.0.0
+
+replace github.com/hashicorp/hcl => github.com/hashicorp/hcl v1.0.0
+
+replace github.com/hpcloud/tail => github.com/hpcloud/tail v1.0.0
+
+replace github.com/ianlancetaylor/demangle => github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6
+
+replace github.com/imdario/mergo => github.com/imdario/mergo v0.3.5
+
+replace github.com/inconshreveable/mousetrap => github.com/inconshreveable/mousetrap v1.0.0
+
+replace github.com/jimstudt/http-authentication => github.com/jimstudt/http-authentication v0.0.0-20140401203705-3eca13d6893a
+
+replace github.com/jmespath/go-jmespath => github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af
+
+replace github.com/jonboulle/clockwork => github.com/jonboulle/clockwork v0.1.0
+
+replace github.com/jstemmer/go-junit-report => github.com/jstemmer/go-junit-report v0.9.1
+
+replace github.com/jtolds/gls => github.com/jtolds/gls v4.20.0+incompatible
+
+replace github.com/julienschmidt/httprouter => github.com/julienschmidt/httprouter v1.2.0
+
+replace github.com/jung-kurt/gofpdf => github.com/jung-kurt/gofpdf v1.0.3-0.20190309125859-24315acbbda5
+
+replace github.com/karrick/godirwalk => github.com/karrick/godirwalk v1.7.5
+
+replace github.com/kisielk/errcheck => github.com/kisielk/errcheck v1.5.0
+
+replace github.com/kisielk/gotool => github.com/kisielk/gotool v1.0.0
+
+replace github.com/klauspost/cpuid => github.com/klauspost/cpuid v1.2.0
+
+replace github.com/konsorten/go-windows-terminal-sequences => github.com/konsorten/go-windows-terminal-sequences v1.0.3
+
+replace github.com/kr/logfmt => github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515
+
+replace github.com/kr/pretty => github.com/kr/pretty v0.2.0
+
+replace github.com/kr/pty => github.com/kr/pty v1.1.5
+
+replace github.com/kr/text => github.com/kr/text v0.1.0
+
+replace github.com/kylelemons/godebug => github.com/kylelemons/godebug v0.0.0-20170820004349-d65d576e9348
+
+replace github.com/liggitt/tabwriter => github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de
+
+replace github.com/lucas-clemente/aes12 => github.com/lucas-clemente/aes12 v0.0.0-20171027163421-cd47fb39b79f
+
+replace github.com/lucas-clemente/quic-clients => github.com/lucas-clemente/quic-clients v0.1.0
+
+replace github.com/lucas-clemente/quic-go => github.com/lucas-clemente/quic-go v0.10.2
+
+replace github.com/lucas-clemente/quic-go-certificates => github.com/lucas-clemente/quic-go-certificates v0.0.0-20160823095156-d2f86524cced
+
+replace github.com/mailru/easyjson => github.com/mailru/easyjson v0.7.0
+
+replace github.com/marten-seemann/qtls => github.com/marten-seemann/qtls v0.2.3
+
+replace github.com/mattn/go-colorable => github.com/mattn/go-colorable v0.0.9
+
+replace github.com/mattn/go-isatty => github.com/mattn/go-isatty v0.0.4
+
+replace github.com/mattn/go-runewidth => github.com/mattn/go-runewidth v0.0.2
+
+replace github.com/matttproud/golang_protobuf_extensions => github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369
+
+replace github.com/mholt/certmagic => github.com/mholt/certmagic v0.6.2-0.20190624175158-6a42ef9fe8c2
+
+replace github.com/mindprince/gonvml => github.com/mindprince/gonvml v0.0.0-20190828220739-9ebdce4bb989
+
+replace github.com/mistifyio/go-zfs => github.com/mistifyio/go-zfs v2.1.2-0.20190413222219-f784269be439+incompatible
+
+replace github.com/mitchellh/go-homedir => github.com/mitchellh/go-homedir v1.1.0
+
+replace github.com/mitchellh/go-wordwrap => github.com/mitchellh/go-wordwrap v1.0.0
+
+replace github.com/mitchellh/mapstructure => github.com/mitchellh/mapstructure v1.1.2
+
+replace github.com/moby/sys/mountinfo => github.com/moby/sys/mountinfo v0.1.3
+
+replace github.com/moby/term => github.com/moby/term v0.0.0-20200312100748-672ec06f55cd
+
+replace github.com/modern-go/concurrent => github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd
+
+replace github.com/modern-go/reflect2 => github.com/modern-go/reflect2 v1.0.1
+
+replace github.com/morikuni/aec => github.com/morikuni/aec v1.0.0
+
+replace github.com/mwitkow/go-conntrack => github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223
+
+replace github.com/mxk/go-flowrate => github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f
+
+replace github.com/naoina/go-stringutil => github.com/naoina/go-stringutil v0.1.0
+
+replace github.com/naoina/toml => github.com/naoina/toml v0.1.1
+
+replace github.com/olekukonko/tablewriter => github.com/olekukonko/tablewriter v0.0.0-20170122224234-a0225b3f23b5
+
+replace github.com/opencontainers/image-spec => github.com/opencontainers/image-spec v1.0.1
+
+replace github.com/opencontainers/runtime-spec => github.com/opencontainers/runtime-spec v1.0.3-0.20200520003142-237cc4f519e2
+
+replace github.com/pelletier/go-toml => github.com/pelletier/go-toml v1.2.0
+
+replace github.com/peterbourgon/diskv => github.com/peterbourgon/diskv v2.0.1+incompatible
+
+replace github.com/pquerna/cachecontrol => github.com/pquerna/cachecontrol v0.0.0-20171018203845-0dec1b30a021
+
+replace github.com/prometheus/procfs => github.com/prometheus/procfs v0.1.3
+
+replace github.com/remyoudompheng/bigfft => github.com/remyoudompheng/bigfft v0.0.0-20170806203942-52369c62f446
+
+replace github.com/rogpeppe/fastuuid => github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af
+
+replace github.com/rogpeppe/go-internal => github.com/rogpeppe/go-internal v1.3.0
+
+replace github.com/rubiojr/go-vhd => github.com/rubiojr/go-vhd v0.0.0-20200706105327-02e210299021
+
+replace github.com/russross/blackfriday => github.com/russross/blackfriday v1.5.2
+
+replace github.com/russross/blackfriday/v2 => github.com/russross/blackfriday/v2 v2.0.1
+
+replace github.com/satori/go.uuid => github.com/satori/go.uuid v1.2.0
+
+replace github.com/seccomp/libseccomp-golang => github.com/seccomp/libseccomp-golang v0.9.1
+
+replace github.com/sergi/go-diff => github.com/sergi/go-diff v1.0.0
+
+replace github.com/shurcooL/sanitized_anchor_name => github.com/shurcooL/sanitized_anchor_name v1.0.0
+
+replace github.com/sirupsen/logrus => github.com/sirupsen/logrus v1.6.0
+
+replace github.com/smartystreets/assertions => github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d
+
+replace github.com/smartystreets/goconvey => github.com/smartystreets/goconvey v1.6.4
+
+replace github.com/soheilhy/cmux => github.com/soheilhy/cmux v0.1.4
+
+replace github.com/spf13/cast => github.com/spf13/cast v1.3.0
+
+replace github.com/stretchr/objx => github.com/stretchr/objx v0.2.0
+
+replace github.com/syndtr/gocapability => github.com/syndtr/gocapability v0.0.0-20180916011248-d98352740cb2
+
+replace github.com/tidwall/pretty => github.com/tidwall/pretty v1.0.0
+
+replace github.com/tmc/grpc-websocket-proxy => github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5
+
+replace github.com/ugorji/go => github.com/ugorji/go v1.1.4
+
+replace github.com/urfave/cli => github.com/urfave/cli v1.22.2
+
+replace github.com/vektah/gqlparser => github.com/vektah/gqlparser v1.1.2
+
+replace github.com/vishvananda/netns => github.com/vishvananda/netns v0.0.0-20200520041808-52d707b772fe
+
+replace github.com/xiang90/probing => github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2
+
+replace github.com/xlab/handysort => github.com/xlab/handysort v0.0.0-20150421192137-fb3537ed64a1
+
+replace github.com/xordataexchange/crypt => github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77
+
+replace github.com/yuin/goldmark => github.com/yuin/goldmark v1.2.1
+
+replace go.etcd.io/bbolt => go.etcd.io/bbolt v1.3.5
+
+replace go.mongodb.org/mongo-driver => go.mongodb.org/mongo-driver v1.1.2
+
+replace go.opencensus.io => go.opencensus.io v0.22.2
+
+replace go.uber.org/atomic => go.uber.org/atomic v1.4.0
+
+replace go.uber.org/multierr => go.uber.org/multierr v1.1.0
+
+replace go.uber.org/zap => go.uber.org/zap v1.10.0
+
+replace golang.org/x/exp => golang.org/x/exp v0.0.0-20191227195350-da58074b4299
+
+replace golang.org/x/image => golang.org/x/image v0.0.0-20190802002840-cff245a6509b
+
+replace golang.org/x/lint => golang.org/x/lint v0.0.0-20191125180803-fdd1cda4f05f
+
+replace golang.org/x/mobile => golang.org/x/mobile v0.0.0-20190719004257-d2bd2a29d028
+
+replace golang.org/x/mod => golang.org/x/mod v0.3.0
+
+replace golang.org/x/sync => golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9
+
+replace golang.org/x/text => golang.org/x/text v0.3.3
+
+replace golang.org/x/xerrors => golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1
+
+replace gonum.org/v1/plot => gonum.org/v1/plot v0.0.0-20190515093506-e2840ee46a6b
+
+replace google.golang.org/appengine => google.golang.org/appengine v1.6.5
+
+replace google.golang.org/genproto => google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013
+
+replace google.golang.org/protobuf => google.golang.org/protobuf v1.24.0
+
+replace gopkg.in/alecthomas/kingpin.v2 => gopkg.in/alecthomas/kingpin.v2 v2.2.6
+
+replace gopkg.in/check.v1 => gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15
+
+replace gopkg.in/cheggaaa/pb.v1 => gopkg.in/cheggaaa/pb.v1 v1.0.25
+
+replace gopkg.in/errgo.v2 => gopkg.in/errgo.v2 v2.1.0
+
+replace gopkg.in/fsnotify.v1 => gopkg.in/fsnotify.v1 v1.4.7
+
+replace gopkg.in/inf.v0 => gopkg.in/inf.v0 v0.9.1
+
+replace gopkg.in/mcuadros/go-syslog.v2 => gopkg.in/mcuadros/go-syslog.v2 v2.2.1
+
+replace gopkg.in/natefinch/lumberjack.v2 => gopkg.in/natefinch/lumberjack.v2 v2.0.0
+
+replace gopkg.in/resty.v1 => gopkg.in/resty.v1 v1.12.0
+
+replace gopkg.in/tomb.v1 => gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7
+
+replace gopkg.in/warnings.v0 => gopkg.in/warnings.v0 v0.1.1
+
+replace gotest.tools => gotest.tools v2.2.0+incompatible
+
+replace gotest.tools/v3 => gotest.tools/v3 v3.0.2
+
+replace honnef.co/go/tools => honnef.co/go/tools v0.0.1-2019.2.3
+
+replace modernc.org/cc => modernc.org/cc v1.0.0
+
+replace modernc.org/golex => modernc.org/golex v1.0.0
+
+replace modernc.org/mathutil => modernc.org/mathutil v1.0.0
+
+replace modernc.org/strutil => modernc.org/strutil v1.0.0
+
+replace modernc.org/xc => modernc.org/xc v1.0.0
+
+replace rsc.io/pdf => rsc.io/pdf v0.1.1
+
+replace sigs.k8s.io/apiserver-network-proxy/konnectivity-client => sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.15
+
+replace sigs.k8s.io/structured-merge-diff/v4 => sigs.k8s.io/structured-merge-diff/v4 v4.1.2
+
+replace vbom.ml/util => vbom.ml/util v0.0.0-20160121211510-db5cfe13f5cc

--- a/staging/src/k8s.io/kube-proxy/go.mod
+++ b/staging/src/k8s.io/kube-proxy/go.mod
@@ -5,8 +5,118 @@ module k8s.io/kube-proxy
 go 1.15
 
 require (
+	bitbucket.org/bertimus9/systemstat v0.0.0-20180207000608-0eeff89b0690
+	github.com/Azure/azure-sdk-for-go v43.0.0+incompatible
+	github.com/Azure/go-autorest/autorest v0.9.6
+	github.com/Azure/go-autorest/autorest/adal v0.8.2
+	github.com/Azure/go-autorest/autorest/to v0.2.0
+	github.com/GoogleCloudPlatform/k8s-cloud-provider v0.0.0-20200415212048-7901bc822317
+	github.com/JeffAshton/win_pdh v0.0.0-20161109143554-76bb4ee9f0ab
+	github.com/Microsoft/go-winio v0.4.15-0.20190919025122-fc70bd9a86b5
+	github.com/Microsoft/hcsshim v0.8.10-0.20200715222032-5eafd1556990
+	github.com/PuerkitoBio/purell v1.1.1
+	github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e
+	github.com/auth0/go-jwt-middleware v0.0.0-20170425171159-5493cabe49f7
+	github.com/aws/aws-sdk-go v1.28.2
+	github.com/blang/semver v3.5.0+incompatible
+	github.com/boltdb/bolt v1.3.1
+	github.com/caddyserver/caddy v1.0.3
+	github.com/clusterhq/flocker-go v0.0.0-20160920122132-2b8b7259d313
+	github.com/codegangsta/negroni v1.0.0
+	github.com/container-storage-interface/spec v1.2.0
+	github.com/containernetworking/cni v0.8.0
+	github.com/coredns/corefile-migration v1.0.10
+	github.com/coreos/go-oidc v2.1.0+incompatible
+	github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e
+	github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f
+	github.com/cpuguy83/go-md2man/v2 v2.0.0
+	github.com/davecgh/go-spew v1.1.1
+	github.com/docker/distribution v2.7.1+incompatible
+	github.com/docker/docker v1.4.2-0.20200309214505-aa6a9891b09c
+	github.com/docker/go-connections v0.4.0
+	github.com/docker/go-units v0.4.0
+	github.com/elazarl/goproxy v0.0.0-20180725130230-947c36da3153
+	github.com/emicklei/go-restful v2.9.5+incompatible
+	github.com/evanphx/json-patch v4.9.0+incompatible
+	github.com/fsnotify/fsnotify v1.4.9
+	github.com/go-bindata/go-bindata v3.1.1+incompatible
+	github.com/go-openapi/analysis v0.19.5
+	github.com/go-openapi/loads v0.19.4
+	github.com/go-openapi/spec v0.19.3
+	github.com/go-openapi/strfmt v0.19.3
+	github.com/go-openapi/validate v0.19.5
+	github.com/go-ozzo/ozzo-validation v3.5.0+incompatible
+	github.com/gogo/protobuf v1.3.2
+	github.com/golang/groupcache v0.0.0-20191227052852-215e87163ea7
+	github.com/golang/mock v1.3.1
+	github.com/google/cadvisor v0.37.5
+	github.com/google/go-cmp v0.4.0
+	github.com/google/gofuzz v1.1.0
+	github.com/google/uuid v1.1.1
+	github.com/googleapis/gnostic v0.4.1
+	github.com/gorilla/context v1.1.1
+	github.com/hashicorp/golang-lru v0.5.1
+	github.com/heketi/heketi v9.0.1-0.20190917153846-c2e2a4ab7ab9+incompatible
+	github.com/heketi/tests v0.0.0-20151005000721-f3775cbcefd6
+	github.com/ishidawataru/sctp v0.0.0-20190723014705-7c296d48a2b5
+	github.com/json-iterator/go v1.1.10
+	github.com/libopenstorage/openstorage v1.0.0
+	github.com/lithammer/dedent v1.1.0
+	github.com/lpabon/godbc v0.1.1
+	github.com/magiconair/properties v1.8.1
+	github.com/miekg/dns v1.1.4
+	github.com/moby/ipvs v1.0.1
+	github.com/mohae/deepcopy v0.0.0-20170603005431-491d3605edfb
+	github.com/mrunalp/fileutils v0.0.0-20200520151820-abd8a0e76976
+	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822
+	github.com/mvdan/xurls v1.1.0
+	github.com/onsi/ginkgo v1.11.0
+	github.com/onsi/gomega v1.7.0
+	github.com/opencontainers/go-digest v1.0.0-rc1
+	github.com/opencontainers/runc v1.0.1
+	github.com/opencontainers/selinux v1.5.2
+	github.com/pkg/errors v0.9.1
+	github.com/pmezard/go-difflib v1.0.0
+	github.com/prometheus/client_golang v1.7.1
+	github.com/prometheus/client_model v0.2.0
+	github.com/prometheus/common v0.10.0
+	github.com/quobyte/api v0.1.2
+	github.com/robfig/cron v1.1.0
+	github.com/spf13/afero v1.2.2
+	github.com/spf13/cobra v1.0.0
+	github.com/spf13/jwalterweatherman v1.1.0
+	github.com/spf13/pflag v1.0.5
+	github.com/spf13/viper v1.4.0
+	github.com/storageos/go-api v0.0.0-20180912212459-343b3eff91fc
+	github.com/stretchr/testify v1.4.0
+	github.com/thecodeteam/goscaleio v0.1.0
+	github.com/urfave/negroni v1.0.0
+	github.com/vishvananda/netlink v1.1.0
+	github.com/vmware/govmomi v0.20.3
+	go.etcd.io/etcd v0.5.0-alpha.5.0.20200819165624-17cef6e3e9d5
+	golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9
+	golang.org/x/net v0.0.0-20201110031124-69a78807bb2b
+	golang.org/x/oauth2 v0.0.0-20191202225959-858c2ad4c8b6
+	golang.org/x/sys v0.0.0-20201112073958-5cba982894dd
+	golang.org/x/time v0.0.0-20191024005414-555d28b269f0
+	golang.org/x/tools v0.0.0-20210106214847-113979e3529a
+	gonum.org/v1/gonum v0.6.2
+	gonum.org/v1/netlib v0.0.0-20190331212654-76723241ea4e
+	google.golang.org/api v0.15.1
+	google.golang.org/grpc v1.27.0
+	gopkg.in/gcfg.v1 v1.2.0
+	gopkg.in/square/go-jose.v2 v2.2.2
+	gopkg.in/yaml.v2 v2.2.8
 	k8s.io/apimachinery v0.0.0
 	k8s.io/component-base v0.0.0
+	k8s.io/gengo v0.0.0-20200428234225-8167cfdcfc14
+	k8s.io/heapster v1.2.0-beta.1
+	k8s.io/klog/v2 v2.2.0
+	k8s.io/kube-openapi v0.0.0-20200805222855-6aeccd4b50c6
+	k8s.io/system-validators v1.1.2
+	k8s.io/utils v0.0.0-20200729134348-d5654de09c73
+	sigs.k8s.io/kustomize v2.0.3+incompatible
+	sigs.k8s.io/yaml v1.2.0
 )
 
 replace (
@@ -16,3 +126,669 @@ replace (
 	k8s.io/component-base => ../component-base
 	k8s.io/kube-proxy => ../kube-proxy
 )
+
+replace github.com/auth0/go-jwt-middleware => github.com/auth0/go-jwt-middleware v0.0.0-20170425171159-5493cabe49f7
+
+replace github.com/boltdb/bolt => github.com/boltdb/bolt v1.3.1
+
+replace github.com/codegangsta/negroni => github.com/codegangsta/negroni v1.0.0
+
+replace github.com/go-ozzo/ozzo-validation => github.com/go-ozzo/ozzo-validation v3.5.0+incompatible
+
+replace github.com/gorilla/context => github.com/gorilla/context v1.1.1
+
+replace github.com/heketi/tests => github.com/heketi/tests v0.0.0-20151005000721-f3775cbcefd6
+
+replace github.com/lpabon/godbc => github.com/lpabon/godbc v0.1.1
+
+replace github.com/magiconair/properties => github.com/magiconair/properties v1.8.1
+
+replace github.com/mohae/deepcopy => github.com/mohae/deepcopy v0.0.0-20170603005431-491d3605edfb
+
+replace github.com/spf13/jwalterweatherman => github.com/spf13/jwalterweatherman v1.1.0
+
+replace github.com/urfave/negroni => github.com/urfave/negroni v1.0.0
+
+replace gonum.org/v1/netlib => gonum.org/v1/netlib v0.0.0-20190331212654-76723241ea4e
+
+replace bitbucket.org/bertimus9/systemstat => bitbucket.org/bertimus9/systemstat v0.0.0-20180207000608-0eeff89b0690
+
+replace github.com/Azure/azure-sdk-for-go => github.com/Azure/azure-sdk-for-go v43.0.0+incompatible
+
+replace github.com/Azure/go-autorest/autorest => github.com/Azure/go-autorest/autorest v0.9.6
+
+replace github.com/Azure/go-autorest/autorest/adal => github.com/Azure/go-autorest/autorest/adal v0.8.2
+
+replace github.com/Azure/go-autorest/autorest/to => github.com/Azure/go-autorest/autorest/to v0.2.0
+
+replace github.com/GoogleCloudPlatform/k8s-cloud-provider => github.com/GoogleCloudPlatform/k8s-cloud-provider v0.0.0-20200415212048-7901bc822317
+
+replace github.com/JeffAshton/win_pdh => github.com/JeffAshton/win_pdh v0.0.0-20161109143554-76bb4ee9f0ab
+
+replace github.com/Microsoft/go-winio => github.com/Microsoft/go-winio v0.4.15-0.20190919025122-fc70bd9a86b5
+
+replace github.com/Microsoft/hcsshim => github.com/Microsoft/hcsshim v0.8.10-0.20200715222032-5eafd1556990
+
+replace github.com/PuerkitoBio/purell => github.com/PuerkitoBio/purell v1.1.1
+
+replace github.com/armon/circbuf => github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e
+
+replace github.com/aws/aws-sdk-go => github.com/aws/aws-sdk-go v1.28.2
+
+replace github.com/blang/semver => github.com/blang/semver v3.5.0+incompatible
+
+replace github.com/caddyserver/caddy => github.com/caddyserver/caddy v1.0.3
+
+replace github.com/clusterhq/flocker-go => github.com/clusterhq/flocker-go v0.0.0-20160920122132-2b8b7259d313
+
+replace github.com/container-storage-interface/spec => github.com/container-storage-interface/spec v1.2.0
+
+replace github.com/containernetworking/cni => github.com/containernetworking/cni v0.8.0
+
+replace github.com/coredns/corefile-migration => github.com/coredns/corefile-migration v1.0.10
+
+replace github.com/coreos/go-oidc => github.com/coreos/go-oidc v2.1.0+incompatible
+
+replace github.com/coreos/go-systemd => github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e
+
+replace github.com/coreos/pkg => github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f
+
+replace github.com/cpuguy83/go-md2man/v2 => github.com/cpuguy83/go-md2man/v2 v2.0.0
+
+replace github.com/davecgh/go-spew => github.com/davecgh/go-spew v1.1.1
+
+replace github.com/docker/distribution => github.com/docker/distribution v2.7.1+incompatible
+
+replace github.com/docker/docker => github.com/docker/docker v1.4.2-0.20200309214505-aa6a9891b09c
+
+replace github.com/docker/go-connections => github.com/docker/go-connections v0.4.0
+
+replace github.com/docker/go-units => github.com/docker/go-units v0.4.0
+
+replace github.com/elazarl/goproxy => github.com/elazarl/goproxy v0.0.0-20180725130230-947c36da3153
+
+replace github.com/emicklei/go-restful => github.com/emicklei/go-restful v2.9.5+incompatible
+
+replace github.com/evanphx/json-patch => github.com/evanphx/json-patch v4.9.0+incompatible
+
+replace github.com/fsnotify/fsnotify => github.com/fsnotify/fsnotify v1.4.9
+
+replace github.com/go-bindata/go-bindata => github.com/go-bindata/go-bindata v3.1.1+incompatible
+
+replace github.com/go-openapi/analysis => github.com/go-openapi/analysis v0.19.5
+
+replace github.com/go-openapi/loads => github.com/go-openapi/loads v0.19.4
+
+replace github.com/go-openapi/spec => github.com/go-openapi/spec v0.19.3
+
+replace github.com/go-openapi/strfmt => github.com/go-openapi/strfmt v0.19.3
+
+replace github.com/go-openapi/validate => github.com/go-openapi/validate v0.19.5
+
+replace github.com/gogo/protobuf => github.com/gogo/protobuf v1.3.2
+
+replace github.com/golang/groupcache => github.com/golang/groupcache v0.0.0-20191227052852-215e87163ea7
+
+replace github.com/golang/mock => github.com/golang/mock v1.3.1
+
+replace github.com/google/cadvisor => github.com/google/cadvisor v0.37.5
+
+replace github.com/google/go-cmp => github.com/google/go-cmp v0.4.0
+
+replace github.com/google/gofuzz => github.com/google/gofuzz v1.1.0
+
+replace github.com/google/uuid => github.com/google/uuid v1.1.1
+
+replace github.com/googleapis/gnostic => github.com/googleapis/gnostic v0.4.1
+
+replace github.com/hashicorp/golang-lru => github.com/hashicorp/golang-lru v0.5.1
+
+replace github.com/heketi/heketi => github.com/heketi/heketi v9.0.1-0.20190917153846-c2e2a4ab7ab9+incompatible
+
+replace github.com/ishidawataru/sctp => github.com/ishidawataru/sctp v0.0.0-20190723014705-7c296d48a2b5
+
+replace github.com/json-iterator/go => github.com/json-iterator/go v1.1.10
+
+replace github.com/libopenstorage/openstorage => github.com/libopenstorage/openstorage v1.0.0
+
+replace github.com/lithammer/dedent => github.com/lithammer/dedent v1.1.0
+
+replace github.com/miekg/dns => github.com/miekg/dns v1.1.4
+
+replace github.com/moby/ipvs => github.com/moby/ipvs v1.0.1
+
+replace github.com/mrunalp/fileutils => github.com/mrunalp/fileutils v0.0.0-20200520151820-abd8a0e76976
+
+replace github.com/munnerz/goautoneg => github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822
+
+replace github.com/mvdan/xurls => github.com/mvdan/xurls v1.1.0
+
+replace github.com/onsi/ginkgo => github.com/onsi/ginkgo v1.11.0
+
+replace github.com/onsi/gomega => github.com/onsi/gomega v1.7.0
+
+replace github.com/opencontainers/go-digest => github.com/opencontainers/go-digest v1.0.0-rc1
+
+replace github.com/opencontainers/runc => github.com/opencontainers/runc v1.0.1
+
+replace github.com/opencontainers/selinux => github.com/opencontainers/selinux v1.5.2
+
+replace github.com/pkg/errors => github.com/pkg/errors v0.9.1
+
+replace github.com/pmezard/go-difflib => github.com/pmezard/go-difflib v1.0.0
+
+replace github.com/prometheus/client_golang => github.com/prometheus/client_golang v1.7.1
+
+replace github.com/prometheus/client_model => github.com/prometheus/client_model v0.2.0
+
+replace github.com/prometheus/common => github.com/prometheus/common v0.10.0
+
+replace github.com/quobyte/api => github.com/quobyte/api v0.1.2
+
+replace github.com/robfig/cron => github.com/robfig/cron v1.1.0
+
+replace github.com/spf13/afero => github.com/spf13/afero v1.2.2
+
+replace github.com/spf13/cobra => github.com/spf13/cobra v1.0.0
+
+replace github.com/spf13/pflag => github.com/spf13/pflag v1.0.5
+
+replace github.com/spf13/viper => github.com/spf13/viper v1.4.0
+
+replace github.com/storageos/go-api => github.com/storageos/go-api v0.0.0-20180912212459-343b3eff91fc
+
+replace github.com/stretchr/testify => github.com/stretchr/testify v1.4.0
+
+replace github.com/thecodeteam/goscaleio => github.com/thecodeteam/goscaleio v0.1.0
+
+replace github.com/vishvananda/netlink => github.com/vishvananda/netlink v1.1.0
+
+replace github.com/vmware/govmomi => github.com/vmware/govmomi v0.20.3
+
+replace go.etcd.io/etcd => go.etcd.io/etcd v0.5.0-alpha.5.0.20200819165624-17cef6e3e9d5
+
+replace golang.org/x/crypto => golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9
+
+replace golang.org/x/net => golang.org/x/net v0.0.0-20201110031124-69a78807bb2b
+
+replace golang.org/x/oauth2 => golang.org/x/oauth2 v0.0.0-20191202225959-858c2ad4c8b6
+
+replace golang.org/x/sys => golang.org/x/sys v0.0.0-20201112073958-5cba982894dd
+
+replace golang.org/x/time => golang.org/x/time v0.0.0-20191024005414-555d28b269f0
+
+replace golang.org/x/tools => golang.org/x/tools v0.0.0-20210106214847-113979e3529a
+
+replace gonum.org/v1/gonum => gonum.org/v1/gonum v0.6.2
+
+replace google.golang.org/api => google.golang.org/api v0.15.1
+
+replace google.golang.org/grpc => google.golang.org/grpc v1.27.0
+
+replace gopkg.in/gcfg.v1 => gopkg.in/gcfg.v1 v1.2.0
+
+replace gopkg.in/square/go-jose.v2 => gopkg.in/square/go-jose.v2 v2.2.2
+
+replace gopkg.in/yaml.v2 => gopkg.in/yaml.v2 v2.2.8
+
+replace k8s.io/gengo => k8s.io/gengo v0.0.0-20200428234225-8167cfdcfc14
+
+replace k8s.io/heapster => k8s.io/heapster v1.2.0-beta.1
+
+replace k8s.io/klog/v2 => k8s.io/klog/v2 v2.2.0
+
+replace k8s.io/kube-openapi => k8s.io/kube-openapi v0.0.0-20200805222855-6aeccd4b50c6
+
+replace k8s.io/system-validators => k8s.io/system-validators v1.1.2
+
+replace k8s.io/utils => k8s.io/utils v0.0.0-20200729134348-d5654de09c73
+
+replace sigs.k8s.io/kustomize => sigs.k8s.io/kustomize v2.0.3+incompatible
+
+replace sigs.k8s.io/yaml => sigs.k8s.io/yaml v1.2.0
+
+replace cloud.google.com/go => cloud.google.com/go v0.51.0
+
+replace cloud.google.com/go/bigquery => cloud.google.com/go/bigquery v1.0.1
+
+replace cloud.google.com/go/datastore => cloud.google.com/go/datastore v1.0.0
+
+replace cloud.google.com/go/pubsub => cloud.google.com/go/pubsub v1.0.1
+
+replace cloud.google.com/go/storage => cloud.google.com/go/storage v1.0.0
+
+replace dmitri.shuralyov.com/gpu/mtl => dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9
+
+replace github.com/Azure/go-ansiterm => github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78
+
+replace github.com/Azure/go-autorest/autorest/date => github.com/Azure/go-autorest/autorest/date v0.2.0
+
+replace github.com/Azure/go-autorest/autorest/mocks => github.com/Azure/go-autorest/autorest/mocks v0.3.0
+
+replace github.com/Azure/go-autorest/autorest/validation => github.com/Azure/go-autorest/autorest/validation v0.1.0
+
+replace github.com/Azure/go-autorest/logger => github.com/Azure/go-autorest/logger v0.1.0
+
+replace github.com/Azure/go-autorest/tracing => github.com/Azure/go-autorest/tracing v0.5.0
+
+replace github.com/BurntSushi/toml => github.com/BurntSushi/toml v0.3.1
+
+replace github.com/BurntSushi/xgb => github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802
+
+replace github.com/MakeNowJust/heredoc => github.com/MakeNowJust/heredoc v0.0.0-20170808103936-bb23615498cd
+
+replace github.com/NYTimes/gziphandler => github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46
+
+replace github.com/PuerkitoBio/urlesc => github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578
+
+replace github.com/agnivade/levenshtein => github.com/agnivade/levenshtein v1.0.1
+
+replace github.com/ajstarks/svgo => github.com/ajstarks/svgo v0.0.0-20180226025133-644b8db467af
+
+replace github.com/alecthomas/template => github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751
+
+replace github.com/alecthomas/units => github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4
+
+replace github.com/andreyvit/diff => github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883
+
+replace github.com/armon/consul-api => github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6
+
+replace github.com/asaskevich/govalidator => github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a
+
+replace github.com/beorn7/perks => github.com/beorn7/perks v1.0.1
+
+replace github.com/bgentry/speakeasy => github.com/bgentry/speakeasy v0.1.0
+
+replace github.com/bifurcation/mint => github.com/bifurcation/mint v0.0.0-20180715133206-93c51c6ce115
+
+replace github.com/cenkalti/backoff => github.com/cenkalti/backoff v2.1.1+incompatible
+
+replace github.com/census-instrumentation/opencensus-proto => github.com/census-instrumentation/opencensus-proto v0.2.1
+
+replace github.com/cespare/xxhash/v2 => github.com/cespare/xxhash/v2 v2.1.1
+
+replace github.com/chai2010/gettext-go => github.com/chai2010/gettext-go v0.0.0-20160711120539-c6fed771bfd5
+
+replace github.com/checkpoint-restore/go-criu/v4 => github.com/checkpoint-restore/go-criu/v4 v4.0.2
+
+replace github.com/cheekybits/genny => github.com/cheekybits/genny v0.0.0-20170328200008-9127e812e1e9
+
+replace github.com/chzyer/logex => github.com/chzyer/logex v1.1.10
+
+replace github.com/chzyer/readline => github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e
+
+replace github.com/chzyer/test => github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1
+
+replace github.com/cilium/ebpf => github.com/cilium/ebpf v0.0.0-20200702112145-1c8d4c9ef775
+
+replace github.com/cockroachdb/datadriven => github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa
+
+replace github.com/containerd/cgroups => github.com/containerd/cgroups v0.0.0-20200531161412-0dbf7f05ba59
+
+replace github.com/containerd/console => github.com/containerd/console v1.0.0
+
+replace github.com/containerd/containerd => github.com/containerd/containerd v1.3.3
+
+replace github.com/containerd/continuity => github.com/containerd/continuity v0.0.0-20190426062206-aaeac12a7ffc
+
+replace github.com/containerd/fifo => github.com/containerd/fifo v0.0.0-20190226154929-a9fb20d87448
+
+replace github.com/containerd/go-runc => github.com/containerd/go-runc v0.0.0-20180907222934-5a6d9f37cfa3
+
+replace github.com/containerd/ttrpc => github.com/containerd/ttrpc v1.0.0
+
+replace github.com/containerd/typeurl => github.com/containerd/typeurl v1.0.0
+
+replace github.com/coreos/bbolt => github.com/coreos/bbolt v1.3.2
+
+replace github.com/coreos/etcd => github.com/coreos/etcd v3.3.10+incompatible
+
+replace github.com/coreos/go-semver => github.com/coreos/go-semver v0.3.0
+
+replace github.com/coreos/go-systemd/v22 => github.com/coreos/go-systemd/v22 v22.1.0
+
+replace github.com/creack/pty => github.com/creack/pty v1.1.7
+
+replace github.com/cyphar/filepath-securejoin => github.com/cyphar/filepath-securejoin v0.2.2
+
+replace github.com/daviddengcn/go-colortext => github.com/daviddengcn/go-colortext v0.0.0-20160507010035-511bcaf42ccd
+
+replace github.com/dgrijalva/jwt-go => github.com/dgrijalva/jwt-go v3.2.0+incompatible
+
+replace github.com/dnaeon/go-vcr => github.com/dnaeon/go-vcr v1.0.1
+
+replace github.com/docker/spdystream => github.com/docker/spdystream v0.0.0-20160310174837-449fdfce4d96
+
+replace github.com/docopt/docopt-go => github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815
+
+replace github.com/dustin/go-humanize => github.com/dustin/go-humanize v1.0.0
+
+replace github.com/envoyproxy/go-control-plane => github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473
+
+replace github.com/envoyproxy/protoc-gen-validate => github.com/envoyproxy/protoc-gen-validate v0.1.0
+
+replace github.com/euank/go-kmsg-parser => github.com/euank/go-kmsg-parser v2.0.0+incompatible
+
+replace github.com/exponent-io/jsonpath => github.com/exponent-io/jsonpath v0.0.0-20151013193312-d6023ce2651d
+
+replace github.com/fatih/camelcase => github.com/fatih/camelcase v1.0.0
+
+replace github.com/fatih/color => github.com/fatih/color v1.7.0
+
+replace github.com/flynn/go-shlex => github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568
+
+replace github.com/fogleman/gg => github.com/fogleman/gg v1.2.1-0.20190220221249-0403632d5b90
+
+replace github.com/ghodss/yaml => github.com/ghodss/yaml v1.0.0
+
+replace github.com/go-acme/lego => github.com/go-acme/lego v2.5.0+incompatible
+
+replace github.com/go-gl/glfw/v3.3/glfw => github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72
+
+replace github.com/go-ini/ini => github.com/go-ini/ini v1.9.0
+
+replace github.com/go-kit/kit => github.com/go-kit/kit v0.9.0
+
+replace github.com/go-logfmt/logfmt => github.com/go-logfmt/logfmt v0.4.0
+
+replace github.com/go-logr/logr => github.com/go-logr/logr v0.2.0
+
+replace github.com/go-openapi/errors => github.com/go-openapi/errors v0.19.2
+
+replace github.com/go-openapi/jsonpointer => github.com/go-openapi/jsonpointer v0.19.3
+
+replace github.com/go-openapi/jsonreference => github.com/go-openapi/jsonreference v0.19.3
+
+replace github.com/go-openapi/runtime => github.com/go-openapi/runtime v0.19.4
+
+replace github.com/go-openapi/swag => github.com/go-openapi/swag v0.19.5
+
+replace github.com/go-stack/stack => github.com/go-stack/stack v1.8.0
+
+replace github.com/godbus/dbus/v5 => github.com/godbus/dbus/v5 v5.0.3
+
+replace github.com/golang/freetype => github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0
+
+replace github.com/golang/glog => github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
+
+replace github.com/golang/protobuf => github.com/golang/protobuf v1.4.2
+
+replace github.com/golangplus/bytes => github.com/golangplus/bytes v0.0.0-20160111154220-45c989fe5450
+
+replace github.com/golangplus/fmt => github.com/golangplus/fmt v0.0.0-20150411045040-2a5d6d7d2995
+
+replace github.com/golangplus/testing => github.com/golangplus/testing v0.0.0-20180327235837-af21d9c3145e
+
+replace github.com/google/btree => github.com/google/btree v1.0.0
+
+replace github.com/google/martian => github.com/google/martian v2.1.0+incompatible
+
+replace github.com/google/pprof => github.com/google/pprof v0.0.0-20191218002539-d4f498aebedc
+
+replace github.com/google/renameio => github.com/google/renameio v0.1.0
+
+replace github.com/googleapis/gax-go/v2 => github.com/googleapis/gax-go/v2 v2.0.5
+
+replace github.com/gophercloud/gophercloud => github.com/gophercloud/gophercloud v0.1.0
+
+replace github.com/gopherjs/gopherjs => github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1
+
+replace github.com/gorilla/mux => github.com/gorilla/mux v1.7.3
+
+replace github.com/gorilla/websocket => github.com/gorilla/websocket v1.4.0
+
+replace github.com/gregjones/httpcache => github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7
+
+replace github.com/grpc-ecosystem/go-grpc-middleware => github.com/grpc-ecosystem/go-grpc-middleware v1.0.1-0.20190118093823-f849b5445de4
+
+replace github.com/grpc-ecosystem/go-grpc-prometheus => github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0
+
+replace github.com/grpc-ecosystem/grpc-gateway => github.com/grpc-ecosystem/grpc-gateway v1.9.5
+
+replace github.com/hashicorp/go-syslog => github.com/hashicorp/go-syslog v1.0.0
+
+replace github.com/hashicorp/hcl => github.com/hashicorp/hcl v1.0.0
+
+replace github.com/hpcloud/tail => github.com/hpcloud/tail v1.0.0
+
+replace github.com/ianlancetaylor/demangle => github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6
+
+replace github.com/imdario/mergo => github.com/imdario/mergo v0.3.5
+
+replace github.com/inconshreveable/mousetrap => github.com/inconshreveable/mousetrap v1.0.0
+
+replace github.com/jimstudt/http-authentication => github.com/jimstudt/http-authentication v0.0.0-20140401203705-3eca13d6893a
+
+replace github.com/jmespath/go-jmespath => github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af
+
+replace github.com/jonboulle/clockwork => github.com/jonboulle/clockwork v0.1.0
+
+replace github.com/jstemmer/go-junit-report => github.com/jstemmer/go-junit-report v0.9.1
+
+replace github.com/jtolds/gls => github.com/jtolds/gls v4.20.0+incompatible
+
+replace github.com/julienschmidt/httprouter => github.com/julienschmidt/httprouter v1.2.0
+
+replace github.com/jung-kurt/gofpdf => github.com/jung-kurt/gofpdf v1.0.3-0.20190309125859-24315acbbda5
+
+replace github.com/karrick/godirwalk => github.com/karrick/godirwalk v1.7.5
+
+replace github.com/kisielk/errcheck => github.com/kisielk/errcheck v1.5.0
+
+replace github.com/kisielk/gotool => github.com/kisielk/gotool v1.0.0
+
+replace github.com/klauspost/cpuid => github.com/klauspost/cpuid v1.2.0
+
+replace github.com/konsorten/go-windows-terminal-sequences => github.com/konsorten/go-windows-terminal-sequences v1.0.3
+
+replace github.com/kr/logfmt => github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515
+
+replace github.com/kr/pretty => github.com/kr/pretty v0.2.0
+
+replace github.com/kr/pty => github.com/kr/pty v1.1.5
+
+replace github.com/kr/text => github.com/kr/text v0.1.0
+
+replace github.com/kylelemons/godebug => github.com/kylelemons/godebug v0.0.0-20170820004349-d65d576e9348
+
+replace github.com/liggitt/tabwriter => github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de
+
+replace github.com/lucas-clemente/aes12 => github.com/lucas-clemente/aes12 v0.0.0-20171027163421-cd47fb39b79f
+
+replace github.com/lucas-clemente/quic-clients => github.com/lucas-clemente/quic-clients v0.1.0
+
+replace github.com/lucas-clemente/quic-go => github.com/lucas-clemente/quic-go v0.10.2
+
+replace github.com/lucas-clemente/quic-go-certificates => github.com/lucas-clemente/quic-go-certificates v0.0.0-20160823095156-d2f86524cced
+
+replace github.com/mailru/easyjson => github.com/mailru/easyjson v0.7.0
+
+replace github.com/marten-seemann/qtls => github.com/marten-seemann/qtls v0.2.3
+
+replace github.com/mattn/go-colorable => github.com/mattn/go-colorable v0.0.9
+
+replace github.com/mattn/go-isatty => github.com/mattn/go-isatty v0.0.4
+
+replace github.com/mattn/go-runewidth => github.com/mattn/go-runewidth v0.0.2
+
+replace github.com/matttproud/golang_protobuf_extensions => github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369
+
+replace github.com/mholt/certmagic => github.com/mholt/certmagic v0.6.2-0.20190624175158-6a42ef9fe8c2
+
+replace github.com/mindprince/gonvml => github.com/mindprince/gonvml v0.0.0-20190828220739-9ebdce4bb989
+
+replace github.com/mistifyio/go-zfs => github.com/mistifyio/go-zfs v2.1.2-0.20190413222219-f784269be439+incompatible
+
+replace github.com/mitchellh/go-homedir => github.com/mitchellh/go-homedir v1.1.0
+
+replace github.com/mitchellh/go-wordwrap => github.com/mitchellh/go-wordwrap v1.0.0
+
+replace github.com/mitchellh/mapstructure => github.com/mitchellh/mapstructure v1.1.2
+
+replace github.com/moby/sys/mountinfo => github.com/moby/sys/mountinfo v0.1.3
+
+replace github.com/moby/term => github.com/moby/term v0.0.0-20200312100748-672ec06f55cd
+
+replace github.com/modern-go/concurrent => github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd
+
+replace github.com/modern-go/reflect2 => github.com/modern-go/reflect2 v1.0.1
+
+replace github.com/morikuni/aec => github.com/morikuni/aec v1.0.0
+
+replace github.com/mwitkow/go-conntrack => github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223
+
+replace github.com/mxk/go-flowrate => github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f
+
+replace github.com/naoina/go-stringutil => github.com/naoina/go-stringutil v0.1.0
+
+replace github.com/naoina/toml => github.com/naoina/toml v0.1.1
+
+replace github.com/olekukonko/tablewriter => github.com/olekukonko/tablewriter v0.0.0-20170122224234-a0225b3f23b5
+
+replace github.com/opencontainers/image-spec => github.com/opencontainers/image-spec v1.0.1
+
+replace github.com/opencontainers/runtime-spec => github.com/opencontainers/runtime-spec v1.0.3-0.20200520003142-237cc4f519e2
+
+replace github.com/pelletier/go-toml => github.com/pelletier/go-toml v1.2.0
+
+replace github.com/peterbourgon/diskv => github.com/peterbourgon/diskv v2.0.1+incompatible
+
+replace github.com/pquerna/cachecontrol => github.com/pquerna/cachecontrol v0.0.0-20171018203845-0dec1b30a021
+
+replace github.com/prometheus/procfs => github.com/prometheus/procfs v0.1.3
+
+replace github.com/remyoudompheng/bigfft => github.com/remyoudompheng/bigfft v0.0.0-20170806203942-52369c62f446
+
+replace github.com/rogpeppe/fastuuid => github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af
+
+replace github.com/rogpeppe/go-internal => github.com/rogpeppe/go-internal v1.3.0
+
+replace github.com/rubiojr/go-vhd => github.com/rubiojr/go-vhd v0.0.0-20200706105327-02e210299021
+
+replace github.com/russross/blackfriday => github.com/russross/blackfriday v1.5.2
+
+replace github.com/russross/blackfriday/v2 => github.com/russross/blackfriday/v2 v2.0.1
+
+replace github.com/satori/go.uuid => github.com/satori/go.uuid v1.2.0
+
+replace github.com/seccomp/libseccomp-golang => github.com/seccomp/libseccomp-golang v0.9.1
+
+replace github.com/sergi/go-diff => github.com/sergi/go-diff v1.0.0
+
+replace github.com/shurcooL/sanitized_anchor_name => github.com/shurcooL/sanitized_anchor_name v1.0.0
+
+replace github.com/sirupsen/logrus => github.com/sirupsen/logrus v1.6.0
+
+replace github.com/smartystreets/assertions => github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d
+
+replace github.com/smartystreets/goconvey => github.com/smartystreets/goconvey v1.6.4
+
+replace github.com/soheilhy/cmux => github.com/soheilhy/cmux v0.1.4
+
+replace github.com/spf13/cast => github.com/spf13/cast v1.3.0
+
+replace github.com/stretchr/objx => github.com/stretchr/objx v0.2.0
+
+replace github.com/syndtr/gocapability => github.com/syndtr/gocapability v0.0.0-20180916011248-d98352740cb2
+
+replace github.com/tidwall/pretty => github.com/tidwall/pretty v1.0.0
+
+replace github.com/tmc/grpc-websocket-proxy => github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5
+
+replace github.com/ugorji/go => github.com/ugorji/go v1.1.4
+
+replace github.com/urfave/cli => github.com/urfave/cli v1.22.2
+
+replace github.com/vektah/gqlparser => github.com/vektah/gqlparser v1.1.2
+
+replace github.com/vishvananda/netns => github.com/vishvananda/netns v0.0.0-20200520041808-52d707b772fe
+
+replace github.com/xiang90/probing => github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2
+
+replace github.com/xlab/handysort => github.com/xlab/handysort v0.0.0-20150421192137-fb3537ed64a1
+
+replace github.com/xordataexchange/crypt => github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77
+
+replace github.com/yuin/goldmark => github.com/yuin/goldmark v1.2.1
+
+replace go.etcd.io/bbolt => go.etcd.io/bbolt v1.3.5
+
+replace go.mongodb.org/mongo-driver => go.mongodb.org/mongo-driver v1.1.2
+
+replace go.opencensus.io => go.opencensus.io v0.22.2
+
+replace go.uber.org/atomic => go.uber.org/atomic v1.4.0
+
+replace go.uber.org/multierr => go.uber.org/multierr v1.1.0
+
+replace go.uber.org/zap => go.uber.org/zap v1.10.0
+
+replace golang.org/x/exp => golang.org/x/exp v0.0.0-20191227195350-da58074b4299
+
+replace golang.org/x/image => golang.org/x/image v0.0.0-20190802002840-cff245a6509b
+
+replace golang.org/x/lint => golang.org/x/lint v0.0.0-20191125180803-fdd1cda4f05f
+
+replace golang.org/x/mobile => golang.org/x/mobile v0.0.0-20190719004257-d2bd2a29d028
+
+replace golang.org/x/mod => golang.org/x/mod v0.3.0
+
+replace golang.org/x/sync => golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9
+
+replace golang.org/x/text => golang.org/x/text v0.3.3
+
+replace golang.org/x/xerrors => golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1
+
+replace gonum.org/v1/plot => gonum.org/v1/plot v0.0.0-20190515093506-e2840ee46a6b
+
+replace google.golang.org/appengine => google.golang.org/appengine v1.6.5
+
+replace google.golang.org/genproto => google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013
+
+replace google.golang.org/protobuf => google.golang.org/protobuf v1.24.0
+
+replace gopkg.in/alecthomas/kingpin.v2 => gopkg.in/alecthomas/kingpin.v2 v2.2.6
+
+replace gopkg.in/check.v1 => gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15
+
+replace gopkg.in/cheggaaa/pb.v1 => gopkg.in/cheggaaa/pb.v1 v1.0.25
+
+replace gopkg.in/errgo.v2 => gopkg.in/errgo.v2 v2.1.0
+
+replace gopkg.in/fsnotify.v1 => gopkg.in/fsnotify.v1 v1.4.7
+
+replace gopkg.in/inf.v0 => gopkg.in/inf.v0 v0.9.1
+
+replace gopkg.in/mcuadros/go-syslog.v2 => gopkg.in/mcuadros/go-syslog.v2 v2.2.1
+
+replace gopkg.in/natefinch/lumberjack.v2 => gopkg.in/natefinch/lumberjack.v2 v2.0.0
+
+replace gopkg.in/resty.v1 => gopkg.in/resty.v1 v1.12.0
+
+replace gopkg.in/tomb.v1 => gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7
+
+replace gopkg.in/warnings.v0 => gopkg.in/warnings.v0 v0.1.1
+
+replace gotest.tools => gotest.tools v2.2.0+incompatible
+
+replace gotest.tools/v3 => gotest.tools/v3 v3.0.2
+
+replace honnef.co/go/tools => honnef.co/go/tools v0.0.1-2019.2.3
+
+replace modernc.org/cc => modernc.org/cc v1.0.0
+
+replace modernc.org/golex => modernc.org/golex v1.0.0
+
+replace modernc.org/mathutil => modernc.org/mathutil v1.0.0
+
+replace modernc.org/strutil => modernc.org/strutil v1.0.0
+
+replace modernc.org/xc => modernc.org/xc v1.0.0
+
+replace rsc.io/pdf => rsc.io/pdf v0.1.1
+
+replace sigs.k8s.io/apiserver-network-proxy/konnectivity-client => sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.15
+
+replace sigs.k8s.io/structured-merge-diff/v4 => sigs.k8s.io/structured-merge-diff/v4 v4.1.2
+
+replace vbom.ml/util => vbom.ml/util v0.0.0-20160121211510-db5cfe13f5cc

--- a/staging/src/k8s.io/kube-scheduler/go.mod
+++ b/staging/src/k8s.io/kube-scheduler/go.mod
@@ -5,10 +5,118 @@ module k8s.io/kube-scheduler
 go 1.15
 
 require (
+	bitbucket.org/bertimus9/systemstat v0.0.0-20180207000608-0eeff89b0690
+	github.com/Azure/azure-sdk-for-go v43.0.0+incompatible
+	github.com/Azure/go-autorest/autorest v0.9.6
+	github.com/Azure/go-autorest/autorest/adal v0.8.2
+	github.com/Azure/go-autorest/autorest/to v0.2.0
+	github.com/GoogleCloudPlatform/k8s-cloud-provider v0.0.0-20200415212048-7901bc822317
+	github.com/JeffAshton/win_pdh v0.0.0-20161109143554-76bb4ee9f0ab
+	github.com/Microsoft/go-winio v0.4.15-0.20190919025122-fc70bd9a86b5
+	github.com/Microsoft/hcsshim v0.8.10-0.20200715222032-5eafd1556990
+	github.com/PuerkitoBio/purell v1.1.1
+	github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e
+	github.com/auth0/go-jwt-middleware v0.0.0-20170425171159-5493cabe49f7
+	github.com/aws/aws-sdk-go v1.28.2
+	github.com/blang/semver v3.5.0+incompatible
+	github.com/boltdb/bolt v1.3.1
+	github.com/caddyserver/caddy v1.0.3
+	github.com/clusterhq/flocker-go v0.0.0-20160920122132-2b8b7259d313
+	github.com/codegangsta/negroni v1.0.0
+	github.com/container-storage-interface/spec v1.2.0
+	github.com/containernetworking/cni v0.8.0
+	github.com/coredns/corefile-migration v1.0.10
+	github.com/coreos/go-oidc v2.1.0+incompatible
+	github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e
+	github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f
+	github.com/cpuguy83/go-md2man/v2 v2.0.0
+	github.com/davecgh/go-spew v1.1.1
+	github.com/docker/distribution v2.7.1+incompatible
+	github.com/docker/docker v1.4.2-0.20200309214505-aa6a9891b09c
+	github.com/docker/go-connections v0.4.0
+	github.com/docker/go-units v0.4.0
+	github.com/elazarl/goproxy v0.0.0-20180725130230-947c36da3153
+	github.com/emicklei/go-restful v2.9.5+incompatible
+	github.com/evanphx/json-patch v4.9.0+incompatible
+	github.com/fsnotify/fsnotify v1.4.9
+	github.com/go-bindata/go-bindata v3.1.1+incompatible
+	github.com/go-openapi/analysis v0.19.5
+	github.com/go-openapi/loads v0.19.4
+	github.com/go-openapi/spec v0.19.3
+	github.com/go-openapi/strfmt v0.19.3
+	github.com/go-openapi/validate v0.19.5
+	github.com/go-ozzo/ozzo-validation v3.5.0+incompatible
+	github.com/gogo/protobuf v1.3.2
+	github.com/golang/groupcache v0.0.0-20191227052852-215e87163ea7
+	github.com/golang/mock v1.3.1
+	github.com/google/cadvisor v0.37.5
 	github.com/google/go-cmp v0.4.0
+	github.com/google/gofuzz v1.1.0
+	github.com/google/uuid v1.1.1
+	github.com/googleapis/gnostic v0.4.1
+	github.com/gorilla/context v1.1.1
+	github.com/hashicorp/golang-lru v0.5.1
+	github.com/heketi/heketi v9.0.1-0.20190917153846-c2e2a4ab7ab9+incompatible
+	github.com/heketi/tests v0.0.0-20151005000721-f3775cbcefd6
+	github.com/ishidawataru/sctp v0.0.0-20190723014705-7c296d48a2b5
+	github.com/json-iterator/go v1.1.10
+	github.com/libopenstorage/openstorage v1.0.0
+	github.com/lithammer/dedent v1.1.0
+	github.com/lpabon/godbc v0.1.1
+	github.com/magiconair/properties v1.8.1
+	github.com/miekg/dns v1.1.4
+	github.com/moby/ipvs v1.0.1
+	github.com/mohae/deepcopy v0.0.0-20170603005431-491d3605edfb
+	github.com/mrunalp/fileutils v0.0.0-20200520151820-abd8a0e76976
+	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822
+	github.com/mvdan/xurls v1.1.0
+	github.com/onsi/ginkgo v1.11.0
+	github.com/onsi/gomega v1.7.0
+	github.com/opencontainers/go-digest v1.0.0-rc1
+	github.com/opencontainers/runc v1.0.1
+	github.com/opencontainers/selinux v1.5.2
+	github.com/pkg/errors v0.9.1
+	github.com/pmezard/go-difflib v1.0.0
+	github.com/prometheus/client_golang v1.7.1
+	github.com/prometheus/client_model v0.2.0
+	github.com/prometheus/common v0.10.0
+	github.com/quobyte/api v0.1.2
+	github.com/robfig/cron v1.1.0
+	github.com/spf13/afero v1.2.2
+	github.com/spf13/cobra v1.0.0
+	github.com/spf13/jwalterweatherman v1.1.0
+	github.com/spf13/pflag v1.0.5
+	github.com/spf13/viper v1.4.0
+	github.com/storageos/go-api v0.0.0-20180912212459-343b3eff91fc
+	github.com/stretchr/testify v1.4.0
+	github.com/thecodeteam/goscaleio v0.1.0
+	github.com/urfave/negroni v1.0.0
+	github.com/vishvananda/netlink v1.1.0
+	github.com/vmware/govmomi v0.20.3
+	go.etcd.io/etcd v0.5.0-alpha.5.0.20200819165624-17cef6e3e9d5
+	golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9
+	golang.org/x/net v0.0.0-20201110031124-69a78807bb2b
+	golang.org/x/oauth2 v0.0.0-20191202225959-858c2ad4c8b6
+	golang.org/x/sys v0.0.0-20201112073958-5cba982894dd
+	golang.org/x/time v0.0.0-20191024005414-555d28b269f0
+	golang.org/x/tools v0.0.0-20210106214847-113979e3529a
+	gonum.org/v1/gonum v0.6.2
+	gonum.org/v1/netlib v0.0.0-20190331212654-76723241ea4e
+	google.golang.org/api v0.15.1
+	google.golang.org/grpc v1.27.0
+	gopkg.in/gcfg.v1 v1.2.0
+	gopkg.in/square/go-jose.v2 v2.2.2
+	gopkg.in/yaml.v2 v2.2.8
 	k8s.io/api v0.0.0
 	k8s.io/apimachinery v0.0.0
 	k8s.io/component-base v0.0.0
+	k8s.io/gengo v0.0.0-20200428234225-8167cfdcfc14
+	k8s.io/heapster v1.2.0-beta.1
+	k8s.io/klog/v2 v2.2.0
+	k8s.io/kube-openapi v0.0.0-20200805222855-6aeccd4b50c6
+	k8s.io/system-validators v1.1.2
+	k8s.io/utils v0.0.0-20200729134348-d5654de09c73
+	sigs.k8s.io/kustomize v2.0.3+incompatible
 	sigs.k8s.io/yaml v1.2.0
 )
 
@@ -19,3 +127,669 @@ replace (
 	k8s.io/component-base => ../component-base
 	k8s.io/kube-scheduler => ../kube-scheduler
 )
+
+replace github.com/auth0/go-jwt-middleware => github.com/auth0/go-jwt-middleware v0.0.0-20170425171159-5493cabe49f7
+
+replace github.com/boltdb/bolt => github.com/boltdb/bolt v1.3.1
+
+replace github.com/codegangsta/negroni => github.com/codegangsta/negroni v1.0.0
+
+replace github.com/go-ozzo/ozzo-validation => github.com/go-ozzo/ozzo-validation v3.5.0+incompatible
+
+replace github.com/gorilla/context => github.com/gorilla/context v1.1.1
+
+replace github.com/heketi/tests => github.com/heketi/tests v0.0.0-20151005000721-f3775cbcefd6
+
+replace github.com/lpabon/godbc => github.com/lpabon/godbc v0.1.1
+
+replace github.com/magiconair/properties => github.com/magiconair/properties v1.8.1
+
+replace github.com/mohae/deepcopy => github.com/mohae/deepcopy v0.0.0-20170603005431-491d3605edfb
+
+replace github.com/spf13/jwalterweatherman => github.com/spf13/jwalterweatherman v1.1.0
+
+replace github.com/urfave/negroni => github.com/urfave/negroni v1.0.0
+
+replace gonum.org/v1/netlib => gonum.org/v1/netlib v0.0.0-20190331212654-76723241ea4e
+
+replace bitbucket.org/bertimus9/systemstat => bitbucket.org/bertimus9/systemstat v0.0.0-20180207000608-0eeff89b0690
+
+replace github.com/Azure/azure-sdk-for-go => github.com/Azure/azure-sdk-for-go v43.0.0+incompatible
+
+replace github.com/Azure/go-autorest/autorest => github.com/Azure/go-autorest/autorest v0.9.6
+
+replace github.com/Azure/go-autorest/autorest/adal => github.com/Azure/go-autorest/autorest/adal v0.8.2
+
+replace github.com/Azure/go-autorest/autorest/to => github.com/Azure/go-autorest/autorest/to v0.2.0
+
+replace github.com/GoogleCloudPlatform/k8s-cloud-provider => github.com/GoogleCloudPlatform/k8s-cloud-provider v0.0.0-20200415212048-7901bc822317
+
+replace github.com/JeffAshton/win_pdh => github.com/JeffAshton/win_pdh v0.0.0-20161109143554-76bb4ee9f0ab
+
+replace github.com/Microsoft/go-winio => github.com/Microsoft/go-winio v0.4.15-0.20190919025122-fc70bd9a86b5
+
+replace github.com/Microsoft/hcsshim => github.com/Microsoft/hcsshim v0.8.10-0.20200715222032-5eafd1556990
+
+replace github.com/PuerkitoBio/purell => github.com/PuerkitoBio/purell v1.1.1
+
+replace github.com/armon/circbuf => github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e
+
+replace github.com/aws/aws-sdk-go => github.com/aws/aws-sdk-go v1.28.2
+
+replace github.com/blang/semver => github.com/blang/semver v3.5.0+incompatible
+
+replace github.com/caddyserver/caddy => github.com/caddyserver/caddy v1.0.3
+
+replace github.com/clusterhq/flocker-go => github.com/clusterhq/flocker-go v0.0.0-20160920122132-2b8b7259d313
+
+replace github.com/container-storage-interface/spec => github.com/container-storage-interface/spec v1.2.0
+
+replace github.com/containernetworking/cni => github.com/containernetworking/cni v0.8.0
+
+replace github.com/coredns/corefile-migration => github.com/coredns/corefile-migration v1.0.10
+
+replace github.com/coreos/go-oidc => github.com/coreos/go-oidc v2.1.0+incompatible
+
+replace github.com/coreos/go-systemd => github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e
+
+replace github.com/coreos/pkg => github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f
+
+replace github.com/cpuguy83/go-md2man/v2 => github.com/cpuguy83/go-md2man/v2 v2.0.0
+
+replace github.com/davecgh/go-spew => github.com/davecgh/go-spew v1.1.1
+
+replace github.com/docker/distribution => github.com/docker/distribution v2.7.1+incompatible
+
+replace github.com/docker/docker => github.com/docker/docker v1.4.2-0.20200309214505-aa6a9891b09c
+
+replace github.com/docker/go-connections => github.com/docker/go-connections v0.4.0
+
+replace github.com/docker/go-units => github.com/docker/go-units v0.4.0
+
+replace github.com/elazarl/goproxy => github.com/elazarl/goproxy v0.0.0-20180725130230-947c36da3153
+
+replace github.com/emicklei/go-restful => github.com/emicklei/go-restful v2.9.5+incompatible
+
+replace github.com/evanphx/json-patch => github.com/evanphx/json-patch v4.9.0+incompatible
+
+replace github.com/fsnotify/fsnotify => github.com/fsnotify/fsnotify v1.4.9
+
+replace github.com/go-bindata/go-bindata => github.com/go-bindata/go-bindata v3.1.1+incompatible
+
+replace github.com/go-openapi/analysis => github.com/go-openapi/analysis v0.19.5
+
+replace github.com/go-openapi/loads => github.com/go-openapi/loads v0.19.4
+
+replace github.com/go-openapi/spec => github.com/go-openapi/spec v0.19.3
+
+replace github.com/go-openapi/strfmt => github.com/go-openapi/strfmt v0.19.3
+
+replace github.com/go-openapi/validate => github.com/go-openapi/validate v0.19.5
+
+replace github.com/gogo/protobuf => github.com/gogo/protobuf v1.3.2
+
+replace github.com/golang/groupcache => github.com/golang/groupcache v0.0.0-20191227052852-215e87163ea7
+
+replace github.com/golang/mock => github.com/golang/mock v1.3.1
+
+replace github.com/google/cadvisor => github.com/google/cadvisor v0.37.5
+
+replace github.com/google/go-cmp => github.com/google/go-cmp v0.4.0
+
+replace github.com/google/gofuzz => github.com/google/gofuzz v1.1.0
+
+replace github.com/google/uuid => github.com/google/uuid v1.1.1
+
+replace github.com/googleapis/gnostic => github.com/googleapis/gnostic v0.4.1
+
+replace github.com/hashicorp/golang-lru => github.com/hashicorp/golang-lru v0.5.1
+
+replace github.com/heketi/heketi => github.com/heketi/heketi v9.0.1-0.20190917153846-c2e2a4ab7ab9+incompatible
+
+replace github.com/ishidawataru/sctp => github.com/ishidawataru/sctp v0.0.0-20190723014705-7c296d48a2b5
+
+replace github.com/json-iterator/go => github.com/json-iterator/go v1.1.10
+
+replace github.com/libopenstorage/openstorage => github.com/libopenstorage/openstorage v1.0.0
+
+replace github.com/lithammer/dedent => github.com/lithammer/dedent v1.1.0
+
+replace github.com/miekg/dns => github.com/miekg/dns v1.1.4
+
+replace github.com/moby/ipvs => github.com/moby/ipvs v1.0.1
+
+replace github.com/mrunalp/fileutils => github.com/mrunalp/fileutils v0.0.0-20200520151820-abd8a0e76976
+
+replace github.com/munnerz/goautoneg => github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822
+
+replace github.com/mvdan/xurls => github.com/mvdan/xurls v1.1.0
+
+replace github.com/onsi/ginkgo => github.com/onsi/ginkgo v1.11.0
+
+replace github.com/onsi/gomega => github.com/onsi/gomega v1.7.0
+
+replace github.com/opencontainers/go-digest => github.com/opencontainers/go-digest v1.0.0-rc1
+
+replace github.com/opencontainers/runc => github.com/opencontainers/runc v1.0.1
+
+replace github.com/opencontainers/selinux => github.com/opencontainers/selinux v1.5.2
+
+replace github.com/pkg/errors => github.com/pkg/errors v0.9.1
+
+replace github.com/pmezard/go-difflib => github.com/pmezard/go-difflib v1.0.0
+
+replace github.com/prometheus/client_golang => github.com/prometheus/client_golang v1.7.1
+
+replace github.com/prometheus/client_model => github.com/prometheus/client_model v0.2.0
+
+replace github.com/prometheus/common => github.com/prometheus/common v0.10.0
+
+replace github.com/quobyte/api => github.com/quobyte/api v0.1.2
+
+replace github.com/robfig/cron => github.com/robfig/cron v1.1.0
+
+replace github.com/spf13/afero => github.com/spf13/afero v1.2.2
+
+replace github.com/spf13/cobra => github.com/spf13/cobra v1.0.0
+
+replace github.com/spf13/pflag => github.com/spf13/pflag v1.0.5
+
+replace github.com/spf13/viper => github.com/spf13/viper v1.4.0
+
+replace github.com/storageos/go-api => github.com/storageos/go-api v0.0.0-20180912212459-343b3eff91fc
+
+replace github.com/stretchr/testify => github.com/stretchr/testify v1.4.0
+
+replace github.com/thecodeteam/goscaleio => github.com/thecodeteam/goscaleio v0.1.0
+
+replace github.com/vishvananda/netlink => github.com/vishvananda/netlink v1.1.0
+
+replace github.com/vmware/govmomi => github.com/vmware/govmomi v0.20.3
+
+replace go.etcd.io/etcd => go.etcd.io/etcd v0.5.0-alpha.5.0.20200819165624-17cef6e3e9d5
+
+replace golang.org/x/crypto => golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9
+
+replace golang.org/x/net => golang.org/x/net v0.0.0-20201110031124-69a78807bb2b
+
+replace golang.org/x/oauth2 => golang.org/x/oauth2 v0.0.0-20191202225959-858c2ad4c8b6
+
+replace golang.org/x/sys => golang.org/x/sys v0.0.0-20201112073958-5cba982894dd
+
+replace golang.org/x/time => golang.org/x/time v0.0.0-20191024005414-555d28b269f0
+
+replace golang.org/x/tools => golang.org/x/tools v0.0.0-20210106214847-113979e3529a
+
+replace gonum.org/v1/gonum => gonum.org/v1/gonum v0.6.2
+
+replace google.golang.org/api => google.golang.org/api v0.15.1
+
+replace google.golang.org/grpc => google.golang.org/grpc v1.27.0
+
+replace gopkg.in/gcfg.v1 => gopkg.in/gcfg.v1 v1.2.0
+
+replace gopkg.in/square/go-jose.v2 => gopkg.in/square/go-jose.v2 v2.2.2
+
+replace gopkg.in/yaml.v2 => gopkg.in/yaml.v2 v2.2.8
+
+replace k8s.io/gengo => k8s.io/gengo v0.0.0-20200428234225-8167cfdcfc14
+
+replace k8s.io/heapster => k8s.io/heapster v1.2.0-beta.1
+
+replace k8s.io/klog/v2 => k8s.io/klog/v2 v2.2.0
+
+replace k8s.io/kube-openapi => k8s.io/kube-openapi v0.0.0-20200805222855-6aeccd4b50c6
+
+replace k8s.io/system-validators => k8s.io/system-validators v1.1.2
+
+replace k8s.io/utils => k8s.io/utils v0.0.0-20200729134348-d5654de09c73
+
+replace sigs.k8s.io/kustomize => sigs.k8s.io/kustomize v2.0.3+incompatible
+
+replace sigs.k8s.io/yaml => sigs.k8s.io/yaml v1.2.0
+
+replace cloud.google.com/go => cloud.google.com/go v0.51.0
+
+replace cloud.google.com/go/bigquery => cloud.google.com/go/bigquery v1.0.1
+
+replace cloud.google.com/go/datastore => cloud.google.com/go/datastore v1.0.0
+
+replace cloud.google.com/go/pubsub => cloud.google.com/go/pubsub v1.0.1
+
+replace cloud.google.com/go/storage => cloud.google.com/go/storage v1.0.0
+
+replace dmitri.shuralyov.com/gpu/mtl => dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9
+
+replace github.com/Azure/go-ansiterm => github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78
+
+replace github.com/Azure/go-autorest/autorest/date => github.com/Azure/go-autorest/autorest/date v0.2.0
+
+replace github.com/Azure/go-autorest/autorest/mocks => github.com/Azure/go-autorest/autorest/mocks v0.3.0
+
+replace github.com/Azure/go-autorest/autorest/validation => github.com/Azure/go-autorest/autorest/validation v0.1.0
+
+replace github.com/Azure/go-autorest/logger => github.com/Azure/go-autorest/logger v0.1.0
+
+replace github.com/Azure/go-autorest/tracing => github.com/Azure/go-autorest/tracing v0.5.0
+
+replace github.com/BurntSushi/toml => github.com/BurntSushi/toml v0.3.1
+
+replace github.com/BurntSushi/xgb => github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802
+
+replace github.com/MakeNowJust/heredoc => github.com/MakeNowJust/heredoc v0.0.0-20170808103936-bb23615498cd
+
+replace github.com/NYTimes/gziphandler => github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46
+
+replace github.com/PuerkitoBio/urlesc => github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578
+
+replace github.com/agnivade/levenshtein => github.com/agnivade/levenshtein v1.0.1
+
+replace github.com/ajstarks/svgo => github.com/ajstarks/svgo v0.0.0-20180226025133-644b8db467af
+
+replace github.com/alecthomas/template => github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751
+
+replace github.com/alecthomas/units => github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4
+
+replace github.com/andreyvit/diff => github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883
+
+replace github.com/armon/consul-api => github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6
+
+replace github.com/asaskevich/govalidator => github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a
+
+replace github.com/beorn7/perks => github.com/beorn7/perks v1.0.1
+
+replace github.com/bgentry/speakeasy => github.com/bgentry/speakeasy v0.1.0
+
+replace github.com/bifurcation/mint => github.com/bifurcation/mint v0.0.0-20180715133206-93c51c6ce115
+
+replace github.com/cenkalti/backoff => github.com/cenkalti/backoff v2.1.1+incompatible
+
+replace github.com/census-instrumentation/opencensus-proto => github.com/census-instrumentation/opencensus-proto v0.2.1
+
+replace github.com/cespare/xxhash/v2 => github.com/cespare/xxhash/v2 v2.1.1
+
+replace github.com/chai2010/gettext-go => github.com/chai2010/gettext-go v0.0.0-20160711120539-c6fed771bfd5
+
+replace github.com/checkpoint-restore/go-criu/v4 => github.com/checkpoint-restore/go-criu/v4 v4.0.2
+
+replace github.com/cheekybits/genny => github.com/cheekybits/genny v0.0.0-20170328200008-9127e812e1e9
+
+replace github.com/chzyer/logex => github.com/chzyer/logex v1.1.10
+
+replace github.com/chzyer/readline => github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e
+
+replace github.com/chzyer/test => github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1
+
+replace github.com/cilium/ebpf => github.com/cilium/ebpf v0.0.0-20200702112145-1c8d4c9ef775
+
+replace github.com/cockroachdb/datadriven => github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa
+
+replace github.com/containerd/cgroups => github.com/containerd/cgroups v0.0.0-20200531161412-0dbf7f05ba59
+
+replace github.com/containerd/console => github.com/containerd/console v1.0.0
+
+replace github.com/containerd/containerd => github.com/containerd/containerd v1.3.3
+
+replace github.com/containerd/continuity => github.com/containerd/continuity v0.0.0-20190426062206-aaeac12a7ffc
+
+replace github.com/containerd/fifo => github.com/containerd/fifo v0.0.0-20190226154929-a9fb20d87448
+
+replace github.com/containerd/go-runc => github.com/containerd/go-runc v0.0.0-20180907222934-5a6d9f37cfa3
+
+replace github.com/containerd/ttrpc => github.com/containerd/ttrpc v1.0.0
+
+replace github.com/containerd/typeurl => github.com/containerd/typeurl v1.0.0
+
+replace github.com/coreos/bbolt => github.com/coreos/bbolt v1.3.2
+
+replace github.com/coreos/etcd => github.com/coreos/etcd v3.3.10+incompatible
+
+replace github.com/coreos/go-semver => github.com/coreos/go-semver v0.3.0
+
+replace github.com/coreos/go-systemd/v22 => github.com/coreos/go-systemd/v22 v22.1.0
+
+replace github.com/creack/pty => github.com/creack/pty v1.1.7
+
+replace github.com/cyphar/filepath-securejoin => github.com/cyphar/filepath-securejoin v0.2.2
+
+replace github.com/daviddengcn/go-colortext => github.com/daviddengcn/go-colortext v0.0.0-20160507010035-511bcaf42ccd
+
+replace github.com/dgrijalva/jwt-go => github.com/dgrijalva/jwt-go v3.2.0+incompatible
+
+replace github.com/dnaeon/go-vcr => github.com/dnaeon/go-vcr v1.0.1
+
+replace github.com/docker/spdystream => github.com/docker/spdystream v0.0.0-20160310174837-449fdfce4d96
+
+replace github.com/docopt/docopt-go => github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815
+
+replace github.com/dustin/go-humanize => github.com/dustin/go-humanize v1.0.0
+
+replace github.com/envoyproxy/go-control-plane => github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473
+
+replace github.com/envoyproxy/protoc-gen-validate => github.com/envoyproxy/protoc-gen-validate v0.1.0
+
+replace github.com/euank/go-kmsg-parser => github.com/euank/go-kmsg-parser v2.0.0+incompatible
+
+replace github.com/exponent-io/jsonpath => github.com/exponent-io/jsonpath v0.0.0-20151013193312-d6023ce2651d
+
+replace github.com/fatih/camelcase => github.com/fatih/camelcase v1.0.0
+
+replace github.com/fatih/color => github.com/fatih/color v1.7.0
+
+replace github.com/flynn/go-shlex => github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568
+
+replace github.com/fogleman/gg => github.com/fogleman/gg v1.2.1-0.20190220221249-0403632d5b90
+
+replace github.com/ghodss/yaml => github.com/ghodss/yaml v1.0.0
+
+replace github.com/go-acme/lego => github.com/go-acme/lego v2.5.0+incompatible
+
+replace github.com/go-gl/glfw/v3.3/glfw => github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72
+
+replace github.com/go-ini/ini => github.com/go-ini/ini v1.9.0
+
+replace github.com/go-kit/kit => github.com/go-kit/kit v0.9.0
+
+replace github.com/go-logfmt/logfmt => github.com/go-logfmt/logfmt v0.4.0
+
+replace github.com/go-logr/logr => github.com/go-logr/logr v0.2.0
+
+replace github.com/go-openapi/errors => github.com/go-openapi/errors v0.19.2
+
+replace github.com/go-openapi/jsonpointer => github.com/go-openapi/jsonpointer v0.19.3
+
+replace github.com/go-openapi/jsonreference => github.com/go-openapi/jsonreference v0.19.3
+
+replace github.com/go-openapi/runtime => github.com/go-openapi/runtime v0.19.4
+
+replace github.com/go-openapi/swag => github.com/go-openapi/swag v0.19.5
+
+replace github.com/go-stack/stack => github.com/go-stack/stack v1.8.0
+
+replace github.com/godbus/dbus/v5 => github.com/godbus/dbus/v5 v5.0.3
+
+replace github.com/golang/freetype => github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0
+
+replace github.com/golang/glog => github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
+
+replace github.com/golang/protobuf => github.com/golang/protobuf v1.4.2
+
+replace github.com/golangplus/bytes => github.com/golangplus/bytes v0.0.0-20160111154220-45c989fe5450
+
+replace github.com/golangplus/fmt => github.com/golangplus/fmt v0.0.0-20150411045040-2a5d6d7d2995
+
+replace github.com/golangplus/testing => github.com/golangplus/testing v0.0.0-20180327235837-af21d9c3145e
+
+replace github.com/google/btree => github.com/google/btree v1.0.0
+
+replace github.com/google/martian => github.com/google/martian v2.1.0+incompatible
+
+replace github.com/google/pprof => github.com/google/pprof v0.0.0-20191218002539-d4f498aebedc
+
+replace github.com/google/renameio => github.com/google/renameio v0.1.0
+
+replace github.com/googleapis/gax-go/v2 => github.com/googleapis/gax-go/v2 v2.0.5
+
+replace github.com/gophercloud/gophercloud => github.com/gophercloud/gophercloud v0.1.0
+
+replace github.com/gopherjs/gopherjs => github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1
+
+replace github.com/gorilla/mux => github.com/gorilla/mux v1.7.3
+
+replace github.com/gorilla/websocket => github.com/gorilla/websocket v1.4.0
+
+replace github.com/gregjones/httpcache => github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7
+
+replace github.com/grpc-ecosystem/go-grpc-middleware => github.com/grpc-ecosystem/go-grpc-middleware v1.0.1-0.20190118093823-f849b5445de4
+
+replace github.com/grpc-ecosystem/go-grpc-prometheus => github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0
+
+replace github.com/grpc-ecosystem/grpc-gateway => github.com/grpc-ecosystem/grpc-gateway v1.9.5
+
+replace github.com/hashicorp/go-syslog => github.com/hashicorp/go-syslog v1.0.0
+
+replace github.com/hashicorp/hcl => github.com/hashicorp/hcl v1.0.0
+
+replace github.com/hpcloud/tail => github.com/hpcloud/tail v1.0.0
+
+replace github.com/ianlancetaylor/demangle => github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6
+
+replace github.com/imdario/mergo => github.com/imdario/mergo v0.3.5
+
+replace github.com/inconshreveable/mousetrap => github.com/inconshreveable/mousetrap v1.0.0
+
+replace github.com/jimstudt/http-authentication => github.com/jimstudt/http-authentication v0.0.0-20140401203705-3eca13d6893a
+
+replace github.com/jmespath/go-jmespath => github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af
+
+replace github.com/jonboulle/clockwork => github.com/jonboulle/clockwork v0.1.0
+
+replace github.com/jstemmer/go-junit-report => github.com/jstemmer/go-junit-report v0.9.1
+
+replace github.com/jtolds/gls => github.com/jtolds/gls v4.20.0+incompatible
+
+replace github.com/julienschmidt/httprouter => github.com/julienschmidt/httprouter v1.2.0
+
+replace github.com/jung-kurt/gofpdf => github.com/jung-kurt/gofpdf v1.0.3-0.20190309125859-24315acbbda5
+
+replace github.com/karrick/godirwalk => github.com/karrick/godirwalk v1.7.5
+
+replace github.com/kisielk/errcheck => github.com/kisielk/errcheck v1.5.0
+
+replace github.com/kisielk/gotool => github.com/kisielk/gotool v1.0.0
+
+replace github.com/klauspost/cpuid => github.com/klauspost/cpuid v1.2.0
+
+replace github.com/konsorten/go-windows-terminal-sequences => github.com/konsorten/go-windows-terminal-sequences v1.0.3
+
+replace github.com/kr/logfmt => github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515
+
+replace github.com/kr/pretty => github.com/kr/pretty v0.2.0
+
+replace github.com/kr/pty => github.com/kr/pty v1.1.5
+
+replace github.com/kr/text => github.com/kr/text v0.1.0
+
+replace github.com/kylelemons/godebug => github.com/kylelemons/godebug v0.0.0-20170820004349-d65d576e9348
+
+replace github.com/liggitt/tabwriter => github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de
+
+replace github.com/lucas-clemente/aes12 => github.com/lucas-clemente/aes12 v0.0.0-20171027163421-cd47fb39b79f
+
+replace github.com/lucas-clemente/quic-clients => github.com/lucas-clemente/quic-clients v0.1.0
+
+replace github.com/lucas-clemente/quic-go => github.com/lucas-clemente/quic-go v0.10.2
+
+replace github.com/lucas-clemente/quic-go-certificates => github.com/lucas-clemente/quic-go-certificates v0.0.0-20160823095156-d2f86524cced
+
+replace github.com/mailru/easyjson => github.com/mailru/easyjson v0.7.0
+
+replace github.com/marten-seemann/qtls => github.com/marten-seemann/qtls v0.2.3
+
+replace github.com/mattn/go-colorable => github.com/mattn/go-colorable v0.0.9
+
+replace github.com/mattn/go-isatty => github.com/mattn/go-isatty v0.0.4
+
+replace github.com/mattn/go-runewidth => github.com/mattn/go-runewidth v0.0.2
+
+replace github.com/matttproud/golang_protobuf_extensions => github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369
+
+replace github.com/mholt/certmagic => github.com/mholt/certmagic v0.6.2-0.20190624175158-6a42ef9fe8c2
+
+replace github.com/mindprince/gonvml => github.com/mindprince/gonvml v0.0.0-20190828220739-9ebdce4bb989
+
+replace github.com/mistifyio/go-zfs => github.com/mistifyio/go-zfs v2.1.2-0.20190413222219-f784269be439+incompatible
+
+replace github.com/mitchellh/go-homedir => github.com/mitchellh/go-homedir v1.1.0
+
+replace github.com/mitchellh/go-wordwrap => github.com/mitchellh/go-wordwrap v1.0.0
+
+replace github.com/mitchellh/mapstructure => github.com/mitchellh/mapstructure v1.1.2
+
+replace github.com/moby/sys/mountinfo => github.com/moby/sys/mountinfo v0.1.3
+
+replace github.com/moby/term => github.com/moby/term v0.0.0-20200312100748-672ec06f55cd
+
+replace github.com/modern-go/concurrent => github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd
+
+replace github.com/modern-go/reflect2 => github.com/modern-go/reflect2 v1.0.1
+
+replace github.com/morikuni/aec => github.com/morikuni/aec v1.0.0
+
+replace github.com/mwitkow/go-conntrack => github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223
+
+replace github.com/mxk/go-flowrate => github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f
+
+replace github.com/naoina/go-stringutil => github.com/naoina/go-stringutil v0.1.0
+
+replace github.com/naoina/toml => github.com/naoina/toml v0.1.1
+
+replace github.com/olekukonko/tablewriter => github.com/olekukonko/tablewriter v0.0.0-20170122224234-a0225b3f23b5
+
+replace github.com/opencontainers/image-spec => github.com/opencontainers/image-spec v1.0.1
+
+replace github.com/opencontainers/runtime-spec => github.com/opencontainers/runtime-spec v1.0.3-0.20200520003142-237cc4f519e2
+
+replace github.com/pelletier/go-toml => github.com/pelletier/go-toml v1.2.0
+
+replace github.com/peterbourgon/diskv => github.com/peterbourgon/diskv v2.0.1+incompatible
+
+replace github.com/pquerna/cachecontrol => github.com/pquerna/cachecontrol v0.0.0-20171018203845-0dec1b30a021
+
+replace github.com/prometheus/procfs => github.com/prometheus/procfs v0.1.3
+
+replace github.com/remyoudompheng/bigfft => github.com/remyoudompheng/bigfft v0.0.0-20170806203942-52369c62f446
+
+replace github.com/rogpeppe/fastuuid => github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af
+
+replace github.com/rogpeppe/go-internal => github.com/rogpeppe/go-internal v1.3.0
+
+replace github.com/rubiojr/go-vhd => github.com/rubiojr/go-vhd v0.0.0-20200706105327-02e210299021
+
+replace github.com/russross/blackfriday => github.com/russross/blackfriday v1.5.2
+
+replace github.com/russross/blackfriday/v2 => github.com/russross/blackfriday/v2 v2.0.1
+
+replace github.com/satori/go.uuid => github.com/satori/go.uuid v1.2.0
+
+replace github.com/seccomp/libseccomp-golang => github.com/seccomp/libseccomp-golang v0.9.1
+
+replace github.com/sergi/go-diff => github.com/sergi/go-diff v1.0.0
+
+replace github.com/shurcooL/sanitized_anchor_name => github.com/shurcooL/sanitized_anchor_name v1.0.0
+
+replace github.com/sirupsen/logrus => github.com/sirupsen/logrus v1.6.0
+
+replace github.com/smartystreets/assertions => github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d
+
+replace github.com/smartystreets/goconvey => github.com/smartystreets/goconvey v1.6.4
+
+replace github.com/soheilhy/cmux => github.com/soheilhy/cmux v0.1.4
+
+replace github.com/spf13/cast => github.com/spf13/cast v1.3.0
+
+replace github.com/stretchr/objx => github.com/stretchr/objx v0.2.0
+
+replace github.com/syndtr/gocapability => github.com/syndtr/gocapability v0.0.0-20180916011248-d98352740cb2
+
+replace github.com/tidwall/pretty => github.com/tidwall/pretty v1.0.0
+
+replace github.com/tmc/grpc-websocket-proxy => github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5
+
+replace github.com/ugorji/go => github.com/ugorji/go v1.1.4
+
+replace github.com/urfave/cli => github.com/urfave/cli v1.22.2
+
+replace github.com/vektah/gqlparser => github.com/vektah/gqlparser v1.1.2
+
+replace github.com/vishvananda/netns => github.com/vishvananda/netns v0.0.0-20200520041808-52d707b772fe
+
+replace github.com/xiang90/probing => github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2
+
+replace github.com/xlab/handysort => github.com/xlab/handysort v0.0.0-20150421192137-fb3537ed64a1
+
+replace github.com/xordataexchange/crypt => github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77
+
+replace github.com/yuin/goldmark => github.com/yuin/goldmark v1.2.1
+
+replace go.etcd.io/bbolt => go.etcd.io/bbolt v1.3.5
+
+replace go.mongodb.org/mongo-driver => go.mongodb.org/mongo-driver v1.1.2
+
+replace go.opencensus.io => go.opencensus.io v0.22.2
+
+replace go.uber.org/atomic => go.uber.org/atomic v1.4.0
+
+replace go.uber.org/multierr => go.uber.org/multierr v1.1.0
+
+replace go.uber.org/zap => go.uber.org/zap v1.10.0
+
+replace golang.org/x/exp => golang.org/x/exp v0.0.0-20191227195350-da58074b4299
+
+replace golang.org/x/image => golang.org/x/image v0.0.0-20190802002840-cff245a6509b
+
+replace golang.org/x/lint => golang.org/x/lint v0.0.0-20191125180803-fdd1cda4f05f
+
+replace golang.org/x/mobile => golang.org/x/mobile v0.0.0-20190719004257-d2bd2a29d028
+
+replace golang.org/x/mod => golang.org/x/mod v0.3.0
+
+replace golang.org/x/sync => golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9
+
+replace golang.org/x/text => golang.org/x/text v0.3.3
+
+replace golang.org/x/xerrors => golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1
+
+replace gonum.org/v1/plot => gonum.org/v1/plot v0.0.0-20190515093506-e2840ee46a6b
+
+replace google.golang.org/appengine => google.golang.org/appengine v1.6.5
+
+replace google.golang.org/genproto => google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013
+
+replace google.golang.org/protobuf => google.golang.org/protobuf v1.24.0
+
+replace gopkg.in/alecthomas/kingpin.v2 => gopkg.in/alecthomas/kingpin.v2 v2.2.6
+
+replace gopkg.in/check.v1 => gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15
+
+replace gopkg.in/cheggaaa/pb.v1 => gopkg.in/cheggaaa/pb.v1 v1.0.25
+
+replace gopkg.in/errgo.v2 => gopkg.in/errgo.v2 v2.1.0
+
+replace gopkg.in/fsnotify.v1 => gopkg.in/fsnotify.v1 v1.4.7
+
+replace gopkg.in/inf.v0 => gopkg.in/inf.v0 v0.9.1
+
+replace gopkg.in/mcuadros/go-syslog.v2 => gopkg.in/mcuadros/go-syslog.v2 v2.2.1
+
+replace gopkg.in/natefinch/lumberjack.v2 => gopkg.in/natefinch/lumberjack.v2 v2.0.0
+
+replace gopkg.in/resty.v1 => gopkg.in/resty.v1 v1.12.0
+
+replace gopkg.in/tomb.v1 => gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7
+
+replace gopkg.in/warnings.v0 => gopkg.in/warnings.v0 v0.1.1
+
+replace gotest.tools => gotest.tools v2.2.0+incompatible
+
+replace gotest.tools/v3 => gotest.tools/v3 v3.0.2
+
+replace honnef.co/go/tools => honnef.co/go/tools v0.0.1-2019.2.3
+
+replace modernc.org/cc => modernc.org/cc v1.0.0
+
+replace modernc.org/golex => modernc.org/golex v1.0.0
+
+replace modernc.org/mathutil => modernc.org/mathutil v1.0.0
+
+replace modernc.org/strutil => modernc.org/strutil v1.0.0
+
+replace modernc.org/xc => modernc.org/xc v1.0.0
+
+replace rsc.io/pdf => rsc.io/pdf v0.1.1
+
+replace sigs.k8s.io/apiserver-network-proxy/konnectivity-client => sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.15
+
+replace sigs.k8s.io/structured-merge-diff/v4 => sigs.k8s.io/structured-merge-diff/v4 v4.1.2
+
+replace vbom.ml/util => vbom.ml/util v0.0.0-20160121211510-db5cfe13f5cc

--- a/staging/src/k8s.io/kubectl/go.mod
+++ b/staging/src/k8s.io/kubectl/go.mod
@@ -5,43 +5,133 @@ module k8s.io/kubectl
 go 1.15
 
 require (
+	bitbucket.org/bertimus9/systemstat v0.0.0-20180207000608-0eeff89b0690
+	github.com/Azure/azure-sdk-for-go v43.0.0+incompatible
+	github.com/Azure/go-autorest/autorest v0.9.6
+	github.com/Azure/go-autorest/autorest/adal v0.8.2
+	github.com/Azure/go-autorest/autorest/to v0.2.0
+	github.com/GoogleCloudPlatform/k8s-cloud-provider v0.0.0-20200415212048-7901bc822317
+	github.com/JeffAshton/win_pdh v0.0.0-20161109143554-76bb4ee9f0ab
 	github.com/MakeNowJust/heredoc v0.0.0-20170808103936-bb23615498cd
+	github.com/Microsoft/go-winio v0.4.15-0.20190919025122-fc70bd9a86b5
+	github.com/Microsoft/hcsshim v0.8.10-0.20200715222032-5eafd1556990
+	github.com/PuerkitoBio/purell v1.1.1
+	github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e
+	github.com/auth0/go-jwt-middleware v0.0.0-20170425171159-5493cabe49f7
+	github.com/aws/aws-sdk-go v1.28.2
+	github.com/blang/semver v3.5.0+incompatible
+	github.com/boltdb/bolt v1.3.1
+	github.com/caddyserver/caddy v1.0.3
 	github.com/chai2010/gettext-go v0.0.0-20160711120539-c6fed771bfd5
+	github.com/clusterhq/flocker-go v0.0.0-20160920122132-2b8b7259d313
+	github.com/codegangsta/negroni v1.0.0
+	github.com/container-storage-interface/spec v1.2.0
+	github.com/containernetworking/cni v0.8.0
+	github.com/coredns/corefile-migration v1.0.10
+	github.com/coreos/go-oidc v2.1.0+incompatible
+	github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e
+	github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f
+	github.com/cpuguy83/go-md2man/v2 v2.0.0
 	github.com/davecgh/go-spew v1.1.1
 	github.com/daviddengcn/go-colortext v0.0.0-20160507010035-511bcaf42ccd
 	github.com/docker/distribution v2.7.1+incompatible
+	github.com/docker/docker v1.4.2-0.20200309214505-aa6a9891b09c
+	github.com/docker/go-connections v0.4.0
+	github.com/docker/go-units v0.4.0
+	github.com/elazarl/goproxy v0.0.0-20180725130230-947c36da3153
+	github.com/emicklei/go-restful v2.9.5+incompatible
 	github.com/evanphx/json-patch v4.9.0+incompatible
 	github.com/exponent-io/jsonpath v0.0.0-20151013193312-d6023ce2651d
 	github.com/fatih/camelcase v1.0.0
+	github.com/fsnotify/fsnotify v1.4.9
+	github.com/go-bindata/go-bindata v3.1.1+incompatible
+	github.com/go-openapi/analysis v0.19.5
+	github.com/go-openapi/loads v0.19.4
 	github.com/go-openapi/spec v0.19.3
+	github.com/go-openapi/strfmt v0.19.3
+	github.com/go-openapi/validate v0.19.5
+	github.com/go-ozzo/ozzo-validation v3.5.0+incompatible
+	github.com/gogo/protobuf v1.3.2
+	github.com/golang/groupcache v0.0.0-20191227052852-215e87163ea7
+	github.com/golang/mock v1.3.1
 	github.com/golangplus/bytes v0.0.0-20160111154220-45c989fe5450 // indirect
 	github.com/golangplus/fmt v0.0.0-20150411045040-2a5d6d7d2995 // indirect
 	github.com/golangplus/testing v0.0.0-20180327235837-af21d9c3145e // indirect
+	github.com/google/cadvisor v0.37.5
 	github.com/google/go-cmp v0.4.0
+	github.com/google/gofuzz v1.1.0
+	github.com/google/uuid v1.1.1
 	github.com/googleapis/gnostic v0.4.1
+	github.com/gorilla/context v1.1.1
+	github.com/hashicorp/golang-lru v0.5.1
+	github.com/heketi/heketi v9.0.1-0.20190917153846-c2e2a4ab7ab9+incompatible
+	github.com/heketi/tests v0.0.0-20151005000721-f3775cbcefd6
+	github.com/ishidawataru/sctp v0.0.0-20190723014705-7c296d48a2b5
 	github.com/jonboulle/clockwork v0.1.0
+	github.com/json-iterator/go v1.1.10
+	github.com/libopenstorage/openstorage v1.0.0
 	github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de
 	github.com/lithammer/dedent v1.1.0
+	github.com/lpabon/godbc v0.1.1
+	github.com/magiconair/properties v1.8.1
+	github.com/miekg/dns v1.1.4
 	github.com/mitchellh/go-wordwrap v1.0.0
+	github.com/moby/ipvs v1.0.1
 	github.com/moby/term v0.0.0-20200312100748-672ec06f55cd
+	github.com/mohae/deepcopy v0.0.0-20170603005431-491d3605edfb
+	github.com/mrunalp/fileutils v0.0.0-20200520151820-abd8a0e76976
+	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822
+	github.com/mvdan/xurls v1.1.0
 	github.com/onsi/ginkgo v1.11.0
 	github.com/onsi/gomega v1.7.0
 	github.com/opencontainers/go-digest v1.0.0-rc1 // indirect
+	github.com/opencontainers/runc v1.0.1
+	github.com/opencontainers/selinux v1.5.2
+	github.com/pkg/errors v0.9.1
+	github.com/pmezard/go-difflib v1.0.0
+	github.com/prometheus/client_golang v1.7.1
+	github.com/prometheus/client_model v0.2.0
+	github.com/prometheus/common v0.10.0
+	github.com/quobyte/api v0.1.2
+	github.com/robfig/cron v1.1.0
 	github.com/russross/blackfriday v1.5.2
+	github.com/spf13/afero v1.2.2
 	github.com/spf13/cobra v1.0.0
+	github.com/spf13/jwalterweatherman v1.1.0
 	github.com/spf13/pflag v1.0.5
+	github.com/spf13/viper v1.4.0
+	github.com/storageos/go-api v0.0.0-20180912212459-343b3eff91fc
 	github.com/stretchr/testify v1.4.0
+	github.com/thecodeteam/goscaleio v0.1.0
+	github.com/urfave/negroni v1.0.0
+	github.com/vishvananda/netlink v1.1.0
+	github.com/vmware/govmomi v0.20.3
 	github.com/xlab/handysort v0.0.0-20150421192137-fb3537ed64a1 // indirect
+	go.etcd.io/etcd v0.5.0-alpha.5.0.20200819165624-17cef6e3e9d5
+	golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9
+	golang.org/x/net v0.0.0-20201110031124-69a78807bb2b
+	golang.org/x/oauth2 v0.0.0-20191202225959-858c2ad4c8b6
 	golang.org/x/sys v0.0.0-20201112073958-5cba982894dd
+	golang.org/x/time v0.0.0-20191024005414-555d28b269f0
+	golang.org/x/tools v0.0.0-20210106214847-113979e3529a
+	gonum.org/v1/gonum v0.6.2
+	gonum.org/v1/netlib v0.0.0-20190331212654-76723241ea4e
+	google.golang.org/api v0.15.1
+	google.golang.org/grpc v1.27.0
+	gopkg.in/gcfg.v1 v1.2.0
+	gopkg.in/square/go-jose.v2 v2.2.2
 	gopkg.in/yaml.v2 v2.2.8
 	k8s.io/api v0.0.0
 	k8s.io/apimachinery v0.0.0
 	k8s.io/cli-runtime v0.0.0
 	k8s.io/client-go v0.0.0
 	k8s.io/component-base v0.0.0
+	k8s.io/gengo v0.0.0-20200428234225-8167cfdcfc14
+	k8s.io/heapster v1.2.0-beta.1
 	k8s.io/klog/v2 v2.2.0
 	k8s.io/kube-openapi v0.0.0-20200805222855-6aeccd4b50c6
 	k8s.io/metrics v0.0.0
+	k8s.io/system-validators v1.1.2
 	k8s.io/utils v0.0.0-20200729134348-d5654de09c73
 	sigs.k8s.io/kustomize v2.0.3+incompatible
 	sigs.k8s.io/yaml v1.2.0
@@ -58,3 +148,669 @@ replace (
 	k8s.io/kubectl => ../kubectl
 	k8s.io/metrics => ../metrics
 )
+
+replace github.com/auth0/go-jwt-middleware => github.com/auth0/go-jwt-middleware v0.0.0-20170425171159-5493cabe49f7
+
+replace github.com/boltdb/bolt => github.com/boltdb/bolt v1.3.1
+
+replace github.com/codegangsta/negroni => github.com/codegangsta/negroni v1.0.0
+
+replace github.com/go-ozzo/ozzo-validation => github.com/go-ozzo/ozzo-validation v3.5.0+incompatible
+
+replace github.com/gorilla/context => github.com/gorilla/context v1.1.1
+
+replace github.com/heketi/tests => github.com/heketi/tests v0.0.0-20151005000721-f3775cbcefd6
+
+replace github.com/lpabon/godbc => github.com/lpabon/godbc v0.1.1
+
+replace github.com/magiconair/properties => github.com/magiconair/properties v1.8.1
+
+replace github.com/mohae/deepcopy => github.com/mohae/deepcopy v0.0.0-20170603005431-491d3605edfb
+
+replace github.com/spf13/jwalterweatherman => github.com/spf13/jwalterweatherman v1.1.0
+
+replace github.com/urfave/negroni => github.com/urfave/negroni v1.0.0
+
+replace gonum.org/v1/netlib => gonum.org/v1/netlib v0.0.0-20190331212654-76723241ea4e
+
+replace bitbucket.org/bertimus9/systemstat => bitbucket.org/bertimus9/systemstat v0.0.0-20180207000608-0eeff89b0690
+
+replace github.com/Azure/azure-sdk-for-go => github.com/Azure/azure-sdk-for-go v43.0.0+incompatible
+
+replace github.com/Azure/go-autorest/autorest => github.com/Azure/go-autorest/autorest v0.9.6
+
+replace github.com/Azure/go-autorest/autorest/adal => github.com/Azure/go-autorest/autorest/adal v0.8.2
+
+replace github.com/Azure/go-autorest/autorest/to => github.com/Azure/go-autorest/autorest/to v0.2.0
+
+replace github.com/GoogleCloudPlatform/k8s-cloud-provider => github.com/GoogleCloudPlatform/k8s-cloud-provider v0.0.0-20200415212048-7901bc822317
+
+replace github.com/JeffAshton/win_pdh => github.com/JeffAshton/win_pdh v0.0.0-20161109143554-76bb4ee9f0ab
+
+replace github.com/Microsoft/go-winio => github.com/Microsoft/go-winio v0.4.15-0.20190919025122-fc70bd9a86b5
+
+replace github.com/Microsoft/hcsshim => github.com/Microsoft/hcsshim v0.8.10-0.20200715222032-5eafd1556990
+
+replace github.com/PuerkitoBio/purell => github.com/PuerkitoBio/purell v1.1.1
+
+replace github.com/armon/circbuf => github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e
+
+replace github.com/aws/aws-sdk-go => github.com/aws/aws-sdk-go v1.28.2
+
+replace github.com/blang/semver => github.com/blang/semver v3.5.0+incompatible
+
+replace github.com/caddyserver/caddy => github.com/caddyserver/caddy v1.0.3
+
+replace github.com/clusterhq/flocker-go => github.com/clusterhq/flocker-go v0.0.0-20160920122132-2b8b7259d313
+
+replace github.com/container-storage-interface/spec => github.com/container-storage-interface/spec v1.2.0
+
+replace github.com/containernetworking/cni => github.com/containernetworking/cni v0.8.0
+
+replace github.com/coredns/corefile-migration => github.com/coredns/corefile-migration v1.0.10
+
+replace github.com/coreos/go-oidc => github.com/coreos/go-oidc v2.1.0+incompatible
+
+replace github.com/coreos/go-systemd => github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e
+
+replace github.com/coreos/pkg => github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f
+
+replace github.com/cpuguy83/go-md2man/v2 => github.com/cpuguy83/go-md2man/v2 v2.0.0
+
+replace github.com/davecgh/go-spew => github.com/davecgh/go-spew v1.1.1
+
+replace github.com/docker/distribution => github.com/docker/distribution v2.7.1+incompatible
+
+replace github.com/docker/docker => github.com/docker/docker v1.4.2-0.20200309214505-aa6a9891b09c
+
+replace github.com/docker/go-connections => github.com/docker/go-connections v0.4.0
+
+replace github.com/docker/go-units => github.com/docker/go-units v0.4.0
+
+replace github.com/elazarl/goproxy => github.com/elazarl/goproxy v0.0.0-20180725130230-947c36da3153
+
+replace github.com/emicklei/go-restful => github.com/emicklei/go-restful v2.9.5+incompatible
+
+replace github.com/evanphx/json-patch => github.com/evanphx/json-patch v4.9.0+incompatible
+
+replace github.com/fsnotify/fsnotify => github.com/fsnotify/fsnotify v1.4.9
+
+replace github.com/go-bindata/go-bindata => github.com/go-bindata/go-bindata v3.1.1+incompatible
+
+replace github.com/go-openapi/analysis => github.com/go-openapi/analysis v0.19.5
+
+replace github.com/go-openapi/loads => github.com/go-openapi/loads v0.19.4
+
+replace github.com/go-openapi/spec => github.com/go-openapi/spec v0.19.3
+
+replace github.com/go-openapi/strfmt => github.com/go-openapi/strfmt v0.19.3
+
+replace github.com/go-openapi/validate => github.com/go-openapi/validate v0.19.5
+
+replace github.com/gogo/protobuf => github.com/gogo/protobuf v1.3.2
+
+replace github.com/golang/groupcache => github.com/golang/groupcache v0.0.0-20191227052852-215e87163ea7
+
+replace github.com/golang/mock => github.com/golang/mock v1.3.1
+
+replace github.com/google/cadvisor => github.com/google/cadvisor v0.37.5
+
+replace github.com/google/go-cmp => github.com/google/go-cmp v0.4.0
+
+replace github.com/google/gofuzz => github.com/google/gofuzz v1.1.0
+
+replace github.com/google/uuid => github.com/google/uuid v1.1.1
+
+replace github.com/googleapis/gnostic => github.com/googleapis/gnostic v0.4.1
+
+replace github.com/hashicorp/golang-lru => github.com/hashicorp/golang-lru v0.5.1
+
+replace github.com/heketi/heketi => github.com/heketi/heketi v9.0.1-0.20190917153846-c2e2a4ab7ab9+incompatible
+
+replace github.com/ishidawataru/sctp => github.com/ishidawataru/sctp v0.0.0-20190723014705-7c296d48a2b5
+
+replace github.com/json-iterator/go => github.com/json-iterator/go v1.1.10
+
+replace github.com/libopenstorage/openstorage => github.com/libopenstorage/openstorage v1.0.0
+
+replace github.com/lithammer/dedent => github.com/lithammer/dedent v1.1.0
+
+replace github.com/miekg/dns => github.com/miekg/dns v1.1.4
+
+replace github.com/moby/ipvs => github.com/moby/ipvs v1.0.1
+
+replace github.com/mrunalp/fileutils => github.com/mrunalp/fileutils v0.0.0-20200520151820-abd8a0e76976
+
+replace github.com/munnerz/goautoneg => github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822
+
+replace github.com/mvdan/xurls => github.com/mvdan/xurls v1.1.0
+
+replace github.com/onsi/ginkgo => github.com/onsi/ginkgo v1.11.0
+
+replace github.com/onsi/gomega => github.com/onsi/gomega v1.7.0
+
+replace github.com/opencontainers/go-digest => github.com/opencontainers/go-digest v1.0.0-rc1
+
+replace github.com/opencontainers/runc => github.com/opencontainers/runc v1.0.1
+
+replace github.com/opencontainers/selinux => github.com/opencontainers/selinux v1.5.2
+
+replace github.com/pkg/errors => github.com/pkg/errors v0.9.1
+
+replace github.com/pmezard/go-difflib => github.com/pmezard/go-difflib v1.0.0
+
+replace github.com/prometheus/client_golang => github.com/prometheus/client_golang v1.7.1
+
+replace github.com/prometheus/client_model => github.com/prometheus/client_model v0.2.0
+
+replace github.com/prometheus/common => github.com/prometheus/common v0.10.0
+
+replace github.com/quobyte/api => github.com/quobyte/api v0.1.2
+
+replace github.com/robfig/cron => github.com/robfig/cron v1.1.0
+
+replace github.com/spf13/afero => github.com/spf13/afero v1.2.2
+
+replace github.com/spf13/cobra => github.com/spf13/cobra v1.0.0
+
+replace github.com/spf13/pflag => github.com/spf13/pflag v1.0.5
+
+replace github.com/spf13/viper => github.com/spf13/viper v1.4.0
+
+replace github.com/storageos/go-api => github.com/storageos/go-api v0.0.0-20180912212459-343b3eff91fc
+
+replace github.com/stretchr/testify => github.com/stretchr/testify v1.4.0
+
+replace github.com/thecodeteam/goscaleio => github.com/thecodeteam/goscaleio v0.1.0
+
+replace github.com/vishvananda/netlink => github.com/vishvananda/netlink v1.1.0
+
+replace github.com/vmware/govmomi => github.com/vmware/govmomi v0.20.3
+
+replace go.etcd.io/etcd => go.etcd.io/etcd v0.5.0-alpha.5.0.20200819165624-17cef6e3e9d5
+
+replace golang.org/x/crypto => golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9
+
+replace golang.org/x/net => golang.org/x/net v0.0.0-20201110031124-69a78807bb2b
+
+replace golang.org/x/oauth2 => golang.org/x/oauth2 v0.0.0-20191202225959-858c2ad4c8b6
+
+replace golang.org/x/sys => golang.org/x/sys v0.0.0-20201112073958-5cba982894dd
+
+replace golang.org/x/time => golang.org/x/time v0.0.0-20191024005414-555d28b269f0
+
+replace golang.org/x/tools => golang.org/x/tools v0.0.0-20210106214847-113979e3529a
+
+replace gonum.org/v1/gonum => gonum.org/v1/gonum v0.6.2
+
+replace google.golang.org/api => google.golang.org/api v0.15.1
+
+replace google.golang.org/grpc => google.golang.org/grpc v1.27.0
+
+replace gopkg.in/gcfg.v1 => gopkg.in/gcfg.v1 v1.2.0
+
+replace gopkg.in/square/go-jose.v2 => gopkg.in/square/go-jose.v2 v2.2.2
+
+replace gopkg.in/yaml.v2 => gopkg.in/yaml.v2 v2.2.8
+
+replace k8s.io/gengo => k8s.io/gengo v0.0.0-20200428234225-8167cfdcfc14
+
+replace k8s.io/heapster => k8s.io/heapster v1.2.0-beta.1
+
+replace k8s.io/klog/v2 => k8s.io/klog/v2 v2.2.0
+
+replace k8s.io/kube-openapi => k8s.io/kube-openapi v0.0.0-20200805222855-6aeccd4b50c6
+
+replace k8s.io/system-validators => k8s.io/system-validators v1.1.2
+
+replace k8s.io/utils => k8s.io/utils v0.0.0-20200729134348-d5654de09c73
+
+replace sigs.k8s.io/kustomize => sigs.k8s.io/kustomize v2.0.3+incompatible
+
+replace sigs.k8s.io/yaml => sigs.k8s.io/yaml v1.2.0
+
+replace cloud.google.com/go => cloud.google.com/go v0.51.0
+
+replace cloud.google.com/go/bigquery => cloud.google.com/go/bigquery v1.0.1
+
+replace cloud.google.com/go/datastore => cloud.google.com/go/datastore v1.0.0
+
+replace cloud.google.com/go/pubsub => cloud.google.com/go/pubsub v1.0.1
+
+replace cloud.google.com/go/storage => cloud.google.com/go/storage v1.0.0
+
+replace dmitri.shuralyov.com/gpu/mtl => dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9
+
+replace github.com/Azure/go-ansiterm => github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78
+
+replace github.com/Azure/go-autorest/autorest/date => github.com/Azure/go-autorest/autorest/date v0.2.0
+
+replace github.com/Azure/go-autorest/autorest/mocks => github.com/Azure/go-autorest/autorest/mocks v0.3.0
+
+replace github.com/Azure/go-autorest/autorest/validation => github.com/Azure/go-autorest/autorest/validation v0.1.0
+
+replace github.com/Azure/go-autorest/logger => github.com/Azure/go-autorest/logger v0.1.0
+
+replace github.com/Azure/go-autorest/tracing => github.com/Azure/go-autorest/tracing v0.5.0
+
+replace github.com/BurntSushi/toml => github.com/BurntSushi/toml v0.3.1
+
+replace github.com/BurntSushi/xgb => github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802
+
+replace github.com/MakeNowJust/heredoc => github.com/MakeNowJust/heredoc v0.0.0-20170808103936-bb23615498cd
+
+replace github.com/NYTimes/gziphandler => github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46
+
+replace github.com/PuerkitoBio/urlesc => github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578
+
+replace github.com/agnivade/levenshtein => github.com/agnivade/levenshtein v1.0.1
+
+replace github.com/ajstarks/svgo => github.com/ajstarks/svgo v0.0.0-20180226025133-644b8db467af
+
+replace github.com/alecthomas/template => github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751
+
+replace github.com/alecthomas/units => github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4
+
+replace github.com/andreyvit/diff => github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883
+
+replace github.com/armon/consul-api => github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6
+
+replace github.com/asaskevich/govalidator => github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a
+
+replace github.com/beorn7/perks => github.com/beorn7/perks v1.0.1
+
+replace github.com/bgentry/speakeasy => github.com/bgentry/speakeasy v0.1.0
+
+replace github.com/bifurcation/mint => github.com/bifurcation/mint v0.0.0-20180715133206-93c51c6ce115
+
+replace github.com/cenkalti/backoff => github.com/cenkalti/backoff v2.1.1+incompatible
+
+replace github.com/census-instrumentation/opencensus-proto => github.com/census-instrumentation/opencensus-proto v0.2.1
+
+replace github.com/cespare/xxhash/v2 => github.com/cespare/xxhash/v2 v2.1.1
+
+replace github.com/chai2010/gettext-go => github.com/chai2010/gettext-go v0.0.0-20160711120539-c6fed771bfd5
+
+replace github.com/checkpoint-restore/go-criu/v4 => github.com/checkpoint-restore/go-criu/v4 v4.0.2
+
+replace github.com/cheekybits/genny => github.com/cheekybits/genny v0.0.0-20170328200008-9127e812e1e9
+
+replace github.com/chzyer/logex => github.com/chzyer/logex v1.1.10
+
+replace github.com/chzyer/readline => github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e
+
+replace github.com/chzyer/test => github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1
+
+replace github.com/cilium/ebpf => github.com/cilium/ebpf v0.0.0-20200702112145-1c8d4c9ef775
+
+replace github.com/cockroachdb/datadriven => github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa
+
+replace github.com/containerd/cgroups => github.com/containerd/cgroups v0.0.0-20200531161412-0dbf7f05ba59
+
+replace github.com/containerd/console => github.com/containerd/console v1.0.0
+
+replace github.com/containerd/containerd => github.com/containerd/containerd v1.3.3
+
+replace github.com/containerd/continuity => github.com/containerd/continuity v0.0.0-20190426062206-aaeac12a7ffc
+
+replace github.com/containerd/fifo => github.com/containerd/fifo v0.0.0-20190226154929-a9fb20d87448
+
+replace github.com/containerd/go-runc => github.com/containerd/go-runc v0.0.0-20180907222934-5a6d9f37cfa3
+
+replace github.com/containerd/ttrpc => github.com/containerd/ttrpc v1.0.0
+
+replace github.com/containerd/typeurl => github.com/containerd/typeurl v1.0.0
+
+replace github.com/coreos/bbolt => github.com/coreos/bbolt v1.3.2
+
+replace github.com/coreos/etcd => github.com/coreos/etcd v3.3.10+incompatible
+
+replace github.com/coreos/go-semver => github.com/coreos/go-semver v0.3.0
+
+replace github.com/coreos/go-systemd/v22 => github.com/coreos/go-systemd/v22 v22.1.0
+
+replace github.com/creack/pty => github.com/creack/pty v1.1.7
+
+replace github.com/cyphar/filepath-securejoin => github.com/cyphar/filepath-securejoin v0.2.2
+
+replace github.com/daviddengcn/go-colortext => github.com/daviddengcn/go-colortext v0.0.0-20160507010035-511bcaf42ccd
+
+replace github.com/dgrijalva/jwt-go => github.com/dgrijalva/jwt-go v3.2.0+incompatible
+
+replace github.com/dnaeon/go-vcr => github.com/dnaeon/go-vcr v1.0.1
+
+replace github.com/docker/spdystream => github.com/docker/spdystream v0.0.0-20160310174837-449fdfce4d96
+
+replace github.com/docopt/docopt-go => github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815
+
+replace github.com/dustin/go-humanize => github.com/dustin/go-humanize v1.0.0
+
+replace github.com/envoyproxy/go-control-plane => github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473
+
+replace github.com/envoyproxy/protoc-gen-validate => github.com/envoyproxy/protoc-gen-validate v0.1.0
+
+replace github.com/euank/go-kmsg-parser => github.com/euank/go-kmsg-parser v2.0.0+incompatible
+
+replace github.com/exponent-io/jsonpath => github.com/exponent-io/jsonpath v0.0.0-20151013193312-d6023ce2651d
+
+replace github.com/fatih/camelcase => github.com/fatih/camelcase v1.0.0
+
+replace github.com/fatih/color => github.com/fatih/color v1.7.0
+
+replace github.com/flynn/go-shlex => github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568
+
+replace github.com/fogleman/gg => github.com/fogleman/gg v1.2.1-0.20190220221249-0403632d5b90
+
+replace github.com/ghodss/yaml => github.com/ghodss/yaml v1.0.0
+
+replace github.com/go-acme/lego => github.com/go-acme/lego v2.5.0+incompatible
+
+replace github.com/go-gl/glfw/v3.3/glfw => github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72
+
+replace github.com/go-ini/ini => github.com/go-ini/ini v1.9.0
+
+replace github.com/go-kit/kit => github.com/go-kit/kit v0.9.0
+
+replace github.com/go-logfmt/logfmt => github.com/go-logfmt/logfmt v0.4.0
+
+replace github.com/go-logr/logr => github.com/go-logr/logr v0.2.0
+
+replace github.com/go-openapi/errors => github.com/go-openapi/errors v0.19.2
+
+replace github.com/go-openapi/jsonpointer => github.com/go-openapi/jsonpointer v0.19.3
+
+replace github.com/go-openapi/jsonreference => github.com/go-openapi/jsonreference v0.19.3
+
+replace github.com/go-openapi/runtime => github.com/go-openapi/runtime v0.19.4
+
+replace github.com/go-openapi/swag => github.com/go-openapi/swag v0.19.5
+
+replace github.com/go-stack/stack => github.com/go-stack/stack v1.8.0
+
+replace github.com/godbus/dbus/v5 => github.com/godbus/dbus/v5 v5.0.3
+
+replace github.com/golang/freetype => github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0
+
+replace github.com/golang/glog => github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
+
+replace github.com/golang/protobuf => github.com/golang/protobuf v1.4.2
+
+replace github.com/golangplus/bytes => github.com/golangplus/bytes v0.0.0-20160111154220-45c989fe5450
+
+replace github.com/golangplus/fmt => github.com/golangplus/fmt v0.0.0-20150411045040-2a5d6d7d2995
+
+replace github.com/golangplus/testing => github.com/golangplus/testing v0.0.0-20180327235837-af21d9c3145e
+
+replace github.com/google/btree => github.com/google/btree v1.0.0
+
+replace github.com/google/martian => github.com/google/martian v2.1.0+incompatible
+
+replace github.com/google/pprof => github.com/google/pprof v0.0.0-20191218002539-d4f498aebedc
+
+replace github.com/google/renameio => github.com/google/renameio v0.1.0
+
+replace github.com/googleapis/gax-go/v2 => github.com/googleapis/gax-go/v2 v2.0.5
+
+replace github.com/gophercloud/gophercloud => github.com/gophercloud/gophercloud v0.1.0
+
+replace github.com/gopherjs/gopherjs => github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1
+
+replace github.com/gorilla/mux => github.com/gorilla/mux v1.7.3
+
+replace github.com/gorilla/websocket => github.com/gorilla/websocket v1.4.0
+
+replace github.com/gregjones/httpcache => github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7
+
+replace github.com/grpc-ecosystem/go-grpc-middleware => github.com/grpc-ecosystem/go-grpc-middleware v1.0.1-0.20190118093823-f849b5445de4
+
+replace github.com/grpc-ecosystem/go-grpc-prometheus => github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0
+
+replace github.com/grpc-ecosystem/grpc-gateway => github.com/grpc-ecosystem/grpc-gateway v1.9.5
+
+replace github.com/hashicorp/go-syslog => github.com/hashicorp/go-syslog v1.0.0
+
+replace github.com/hashicorp/hcl => github.com/hashicorp/hcl v1.0.0
+
+replace github.com/hpcloud/tail => github.com/hpcloud/tail v1.0.0
+
+replace github.com/ianlancetaylor/demangle => github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6
+
+replace github.com/imdario/mergo => github.com/imdario/mergo v0.3.5
+
+replace github.com/inconshreveable/mousetrap => github.com/inconshreveable/mousetrap v1.0.0
+
+replace github.com/jimstudt/http-authentication => github.com/jimstudt/http-authentication v0.0.0-20140401203705-3eca13d6893a
+
+replace github.com/jmespath/go-jmespath => github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af
+
+replace github.com/jonboulle/clockwork => github.com/jonboulle/clockwork v0.1.0
+
+replace github.com/jstemmer/go-junit-report => github.com/jstemmer/go-junit-report v0.9.1
+
+replace github.com/jtolds/gls => github.com/jtolds/gls v4.20.0+incompatible
+
+replace github.com/julienschmidt/httprouter => github.com/julienschmidt/httprouter v1.2.0
+
+replace github.com/jung-kurt/gofpdf => github.com/jung-kurt/gofpdf v1.0.3-0.20190309125859-24315acbbda5
+
+replace github.com/karrick/godirwalk => github.com/karrick/godirwalk v1.7.5
+
+replace github.com/kisielk/errcheck => github.com/kisielk/errcheck v1.5.0
+
+replace github.com/kisielk/gotool => github.com/kisielk/gotool v1.0.0
+
+replace github.com/klauspost/cpuid => github.com/klauspost/cpuid v1.2.0
+
+replace github.com/konsorten/go-windows-terminal-sequences => github.com/konsorten/go-windows-terminal-sequences v1.0.3
+
+replace github.com/kr/logfmt => github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515
+
+replace github.com/kr/pretty => github.com/kr/pretty v0.2.0
+
+replace github.com/kr/pty => github.com/kr/pty v1.1.5
+
+replace github.com/kr/text => github.com/kr/text v0.1.0
+
+replace github.com/kylelemons/godebug => github.com/kylelemons/godebug v0.0.0-20170820004349-d65d576e9348
+
+replace github.com/liggitt/tabwriter => github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de
+
+replace github.com/lucas-clemente/aes12 => github.com/lucas-clemente/aes12 v0.0.0-20171027163421-cd47fb39b79f
+
+replace github.com/lucas-clemente/quic-clients => github.com/lucas-clemente/quic-clients v0.1.0
+
+replace github.com/lucas-clemente/quic-go => github.com/lucas-clemente/quic-go v0.10.2
+
+replace github.com/lucas-clemente/quic-go-certificates => github.com/lucas-clemente/quic-go-certificates v0.0.0-20160823095156-d2f86524cced
+
+replace github.com/mailru/easyjson => github.com/mailru/easyjson v0.7.0
+
+replace github.com/marten-seemann/qtls => github.com/marten-seemann/qtls v0.2.3
+
+replace github.com/mattn/go-colorable => github.com/mattn/go-colorable v0.0.9
+
+replace github.com/mattn/go-isatty => github.com/mattn/go-isatty v0.0.4
+
+replace github.com/mattn/go-runewidth => github.com/mattn/go-runewidth v0.0.2
+
+replace github.com/matttproud/golang_protobuf_extensions => github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369
+
+replace github.com/mholt/certmagic => github.com/mholt/certmagic v0.6.2-0.20190624175158-6a42ef9fe8c2
+
+replace github.com/mindprince/gonvml => github.com/mindprince/gonvml v0.0.0-20190828220739-9ebdce4bb989
+
+replace github.com/mistifyio/go-zfs => github.com/mistifyio/go-zfs v2.1.2-0.20190413222219-f784269be439+incompatible
+
+replace github.com/mitchellh/go-homedir => github.com/mitchellh/go-homedir v1.1.0
+
+replace github.com/mitchellh/go-wordwrap => github.com/mitchellh/go-wordwrap v1.0.0
+
+replace github.com/mitchellh/mapstructure => github.com/mitchellh/mapstructure v1.1.2
+
+replace github.com/moby/sys/mountinfo => github.com/moby/sys/mountinfo v0.1.3
+
+replace github.com/moby/term => github.com/moby/term v0.0.0-20200312100748-672ec06f55cd
+
+replace github.com/modern-go/concurrent => github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd
+
+replace github.com/modern-go/reflect2 => github.com/modern-go/reflect2 v1.0.1
+
+replace github.com/morikuni/aec => github.com/morikuni/aec v1.0.0
+
+replace github.com/mwitkow/go-conntrack => github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223
+
+replace github.com/mxk/go-flowrate => github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f
+
+replace github.com/naoina/go-stringutil => github.com/naoina/go-stringutil v0.1.0
+
+replace github.com/naoina/toml => github.com/naoina/toml v0.1.1
+
+replace github.com/olekukonko/tablewriter => github.com/olekukonko/tablewriter v0.0.0-20170122224234-a0225b3f23b5
+
+replace github.com/opencontainers/image-spec => github.com/opencontainers/image-spec v1.0.1
+
+replace github.com/opencontainers/runtime-spec => github.com/opencontainers/runtime-spec v1.0.3-0.20200520003142-237cc4f519e2
+
+replace github.com/pelletier/go-toml => github.com/pelletier/go-toml v1.2.0
+
+replace github.com/peterbourgon/diskv => github.com/peterbourgon/diskv v2.0.1+incompatible
+
+replace github.com/pquerna/cachecontrol => github.com/pquerna/cachecontrol v0.0.0-20171018203845-0dec1b30a021
+
+replace github.com/prometheus/procfs => github.com/prometheus/procfs v0.1.3
+
+replace github.com/remyoudompheng/bigfft => github.com/remyoudompheng/bigfft v0.0.0-20170806203942-52369c62f446
+
+replace github.com/rogpeppe/fastuuid => github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af
+
+replace github.com/rogpeppe/go-internal => github.com/rogpeppe/go-internal v1.3.0
+
+replace github.com/rubiojr/go-vhd => github.com/rubiojr/go-vhd v0.0.0-20200706105327-02e210299021
+
+replace github.com/russross/blackfriday => github.com/russross/blackfriday v1.5.2
+
+replace github.com/russross/blackfriday/v2 => github.com/russross/blackfriday/v2 v2.0.1
+
+replace github.com/satori/go.uuid => github.com/satori/go.uuid v1.2.0
+
+replace github.com/seccomp/libseccomp-golang => github.com/seccomp/libseccomp-golang v0.9.1
+
+replace github.com/sergi/go-diff => github.com/sergi/go-diff v1.0.0
+
+replace github.com/shurcooL/sanitized_anchor_name => github.com/shurcooL/sanitized_anchor_name v1.0.0
+
+replace github.com/sirupsen/logrus => github.com/sirupsen/logrus v1.6.0
+
+replace github.com/smartystreets/assertions => github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d
+
+replace github.com/smartystreets/goconvey => github.com/smartystreets/goconvey v1.6.4
+
+replace github.com/soheilhy/cmux => github.com/soheilhy/cmux v0.1.4
+
+replace github.com/spf13/cast => github.com/spf13/cast v1.3.0
+
+replace github.com/stretchr/objx => github.com/stretchr/objx v0.2.0
+
+replace github.com/syndtr/gocapability => github.com/syndtr/gocapability v0.0.0-20180916011248-d98352740cb2
+
+replace github.com/tidwall/pretty => github.com/tidwall/pretty v1.0.0
+
+replace github.com/tmc/grpc-websocket-proxy => github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5
+
+replace github.com/ugorji/go => github.com/ugorji/go v1.1.4
+
+replace github.com/urfave/cli => github.com/urfave/cli v1.22.2
+
+replace github.com/vektah/gqlparser => github.com/vektah/gqlparser v1.1.2
+
+replace github.com/vishvananda/netns => github.com/vishvananda/netns v0.0.0-20200520041808-52d707b772fe
+
+replace github.com/xiang90/probing => github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2
+
+replace github.com/xlab/handysort => github.com/xlab/handysort v0.0.0-20150421192137-fb3537ed64a1
+
+replace github.com/xordataexchange/crypt => github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77
+
+replace github.com/yuin/goldmark => github.com/yuin/goldmark v1.2.1
+
+replace go.etcd.io/bbolt => go.etcd.io/bbolt v1.3.5
+
+replace go.mongodb.org/mongo-driver => go.mongodb.org/mongo-driver v1.1.2
+
+replace go.opencensus.io => go.opencensus.io v0.22.2
+
+replace go.uber.org/atomic => go.uber.org/atomic v1.4.0
+
+replace go.uber.org/multierr => go.uber.org/multierr v1.1.0
+
+replace go.uber.org/zap => go.uber.org/zap v1.10.0
+
+replace golang.org/x/exp => golang.org/x/exp v0.0.0-20191227195350-da58074b4299
+
+replace golang.org/x/image => golang.org/x/image v0.0.0-20190802002840-cff245a6509b
+
+replace golang.org/x/lint => golang.org/x/lint v0.0.0-20191125180803-fdd1cda4f05f
+
+replace golang.org/x/mobile => golang.org/x/mobile v0.0.0-20190719004257-d2bd2a29d028
+
+replace golang.org/x/mod => golang.org/x/mod v0.3.0
+
+replace golang.org/x/sync => golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9
+
+replace golang.org/x/text => golang.org/x/text v0.3.3
+
+replace golang.org/x/xerrors => golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1
+
+replace gonum.org/v1/plot => gonum.org/v1/plot v0.0.0-20190515093506-e2840ee46a6b
+
+replace google.golang.org/appengine => google.golang.org/appengine v1.6.5
+
+replace google.golang.org/genproto => google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013
+
+replace google.golang.org/protobuf => google.golang.org/protobuf v1.24.0
+
+replace gopkg.in/alecthomas/kingpin.v2 => gopkg.in/alecthomas/kingpin.v2 v2.2.6
+
+replace gopkg.in/check.v1 => gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15
+
+replace gopkg.in/cheggaaa/pb.v1 => gopkg.in/cheggaaa/pb.v1 v1.0.25
+
+replace gopkg.in/errgo.v2 => gopkg.in/errgo.v2 v2.1.0
+
+replace gopkg.in/fsnotify.v1 => gopkg.in/fsnotify.v1 v1.4.7
+
+replace gopkg.in/inf.v0 => gopkg.in/inf.v0 v0.9.1
+
+replace gopkg.in/mcuadros/go-syslog.v2 => gopkg.in/mcuadros/go-syslog.v2 v2.2.1
+
+replace gopkg.in/natefinch/lumberjack.v2 => gopkg.in/natefinch/lumberjack.v2 v2.0.0
+
+replace gopkg.in/resty.v1 => gopkg.in/resty.v1 v1.12.0
+
+replace gopkg.in/tomb.v1 => gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7
+
+replace gopkg.in/warnings.v0 => gopkg.in/warnings.v0 v0.1.1
+
+replace gotest.tools => gotest.tools v2.2.0+incompatible
+
+replace gotest.tools/v3 => gotest.tools/v3 v3.0.2
+
+replace honnef.co/go/tools => honnef.co/go/tools v0.0.1-2019.2.3
+
+replace modernc.org/cc => modernc.org/cc v1.0.0
+
+replace modernc.org/golex => modernc.org/golex v1.0.0
+
+replace modernc.org/mathutil => modernc.org/mathutil v1.0.0
+
+replace modernc.org/strutil => modernc.org/strutil v1.0.0
+
+replace modernc.org/xc => modernc.org/xc v1.0.0
+
+replace rsc.io/pdf => rsc.io/pdf v0.1.1
+
+replace sigs.k8s.io/apiserver-network-proxy/konnectivity-client => sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.15
+
+replace sigs.k8s.io/structured-merge-diff/v4 => sigs.k8s.io/structured-merge-diff/v4 v4.1.2
+
+replace vbom.ml/util => vbom.ml/util v0.0.0-20160121211510-db5cfe13f5cc

--- a/staging/src/k8s.io/kubelet/go.mod
+++ b/staging/src/k8s.io/kubelet/go.mod
@@ -5,12 +5,119 @@ module k8s.io/kubelet
 go 1.15
 
 require (
+	bitbucket.org/bertimus9/systemstat v0.0.0-20180207000608-0eeff89b0690
+	github.com/Azure/azure-sdk-for-go v43.0.0+incompatible
+	github.com/Azure/go-autorest/autorest v0.9.6
+	github.com/Azure/go-autorest/autorest/adal v0.8.2
+	github.com/Azure/go-autorest/autorest/to v0.2.0
+	github.com/GoogleCloudPlatform/k8s-cloud-provider v0.0.0-20200415212048-7901bc822317
+	github.com/JeffAshton/win_pdh v0.0.0-20161109143554-76bb4ee9f0ab
+	github.com/Microsoft/go-winio v0.4.15-0.20190919025122-fc70bd9a86b5
+	github.com/Microsoft/hcsshim v0.8.10-0.20200715222032-5eafd1556990
+	github.com/PuerkitoBio/purell v1.1.1
+	github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e
+	github.com/auth0/go-jwt-middleware v0.0.0-20170425171159-5493cabe49f7
+	github.com/aws/aws-sdk-go v1.28.2
+	github.com/blang/semver v3.5.0+incompatible
+	github.com/boltdb/bolt v1.3.1
+	github.com/caddyserver/caddy v1.0.3
+	github.com/clusterhq/flocker-go v0.0.0-20160920122132-2b8b7259d313
+	github.com/codegangsta/negroni v1.0.0
+	github.com/container-storage-interface/spec v1.2.0
+	github.com/containernetworking/cni v0.8.0
+	github.com/coredns/corefile-migration v1.0.10
+	github.com/coreos/go-oidc v2.1.0+incompatible
+	github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e
+	github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f
+	github.com/cpuguy83/go-md2man/v2 v2.0.0
+	github.com/davecgh/go-spew v1.1.1
+	github.com/docker/distribution v2.7.1+incompatible
+	github.com/docker/docker v1.4.2-0.20200309214505-aa6a9891b09c
+	github.com/docker/go-connections v0.4.0
+	github.com/docker/go-units v0.4.0
+	github.com/elazarl/goproxy v0.0.0-20180725130230-947c36da3153
+	github.com/emicklei/go-restful v2.9.5+incompatible
+	github.com/evanphx/json-patch v4.9.0+incompatible
+	github.com/fsnotify/fsnotify v1.4.9
+	github.com/go-bindata/go-bindata v3.1.1+incompatible
+	github.com/go-openapi/analysis v0.19.5
+	github.com/go-openapi/loads v0.19.4
+	github.com/go-openapi/spec v0.19.3
+	github.com/go-openapi/strfmt v0.19.3
+	github.com/go-openapi/validate v0.19.5
+	github.com/go-ozzo/ozzo-validation v3.5.0+incompatible
 	github.com/gogo/protobuf v1.3.2
+	github.com/golang/groupcache v0.0.0-20191227052852-215e87163ea7
+	github.com/golang/mock v1.3.1
+	github.com/google/cadvisor v0.37.5
+	github.com/google/go-cmp v0.4.0
+	github.com/google/gofuzz v1.1.0
+	github.com/google/uuid v1.1.1
+	github.com/googleapis/gnostic v0.4.1
+	github.com/gorilla/context v1.1.1
+	github.com/hashicorp/golang-lru v0.5.1
+	github.com/heketi/heketi v9.0.1-0.20190917153846-c2e2a4ab7ab9+incompatible
+	github.com/heketi/tests v0.0.0-20151005000721-f3775cbcefd6
+	github.com/ishidawataru/sctp v0.0.0-20190723014705-7c296d48a2b5
+	github.com/json-iterator/go v1.1.10
+	github.com/libopenstorage/openstorage v1.0.0
+	github.com/lithammer/dedent v1.1.0
+	github.com/lpabon/godbc v0.1.1
+	github.com/magiconair/properties v1.8.1
+	github.com/miekg/dns v1.1.4
+	github.com/moby/ipvs v1.0.1
+	github.com/mohae/deepcopy v0.0.0-20170603005431-491d3605edfb
+	github.com/mrunalp/fileutils v0.0.0-20200520151820-abd8a0e76976
+	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822
+	github.com/mvdan/xurls v1.1.0
+	github.com/onsi/ginkgo v1.11.0
+	github.com/onsi/gomega v1.7.0
+	github.com/opencontainers/go-digest v1.0.0-rc1
+	github.com/opencontainers/runc v1.0.1
+	github.com/opencontainers/selinux v1.5.2
+	github.com/pkg/errors v0.9.1
+	github.com/pmezard/go-difflib v1.0.0
+	github.com/prometheus/client_golang v1.7.1
+	github.com/prometheus/client_model v0.2.0
+	github.com/prometheus/common v0.10.0
+	github.com/quobyte/api v0.1.2
+	github.com/robfig/cron v1.1.0
+	github.com/spf13/afero v1.2.2
+	github.com/spf13/cobra v1.0.0
+	github.com/spf13/jwalterweatherman v1.1.0
+	github.com/spf13/pflag v1.0.5
+	github.com/spf13/viper v1.4.0
+	github.com/storageos/go-api v0.0.0-20180912212459-343b3eff91fc
+	github.com/stretchr/testify v1.4.0
+	github.com/thecodeteam/goscaleio v0.1.0
+	github.com/urfave/negroni v1.0.0
+	github.com/vishvananda/netlink v1.1.0
+	github.com/vmware/govmomi v0.20.3
+	go.etcd.io/etcd v0.5.0-alpha.5.0.20200819165624-17cef6e3e9d5
+	golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9
 	golang.org/x/net v0.0.0-20201110031124-69a78807bb2b
+	golang.org/x/oauth2 v0.0.0-20191202225959-858c2ad4c8b6
+	golang.org/x/sys v0.0.0-20201112073958-5cba982894dd
+	golang.org/x/time v0.0.0-20191024005414-555d28b269f0
+	golang.org/x/tools v0.0.0-20210106214847-113979e3529a
+	gonum.org/v1/gonum v0.6.2
+	gonum.org/v1/netlib v0.0.0-20190331212654-76723241ea4e
+	google.golang.org/api v0.15.1
 	google.golang.org/grpc v1.27.0
+	gopkg.in/gcfg.v1 v1.2.0
+	gopkg.in/square/go-jose.v2 v2.2.2
+	gopkg.in/yaml.v2 v2.2.8
 	k8s.io/api v0.0.0
 	k8s.io/apimachinery v0.0.0
 	k8s.io/component-base v0.0.0
+	k8s.io/gengo v0.0.0-20200428234225-8167cfdcfc14
+	k8s.io/heapster v1.2.0-beta.1
+	k8s.io/klog/v2 v2.2.0
+	k8s.io/kube-openapi v0.0.0-20200805222855-6aeccd4b50c6
+	k8s.io/system-validators v1.1.2
+	k8s.io/utils v0.0.0-20200729134348-d5654de09c73
+	sigs.k8s.io/kustomize v2.0.3+incompatible
+	sigs.k8s.io/yaml v1.2.0
 )
 
 replace (
@@ -20,3 +127,669 @@ replace (
 	k8s.io/component-base => ../component-base
 	k8s.io/kubelet => ../kubelet
 )
+
+replace github.com/auth0/go-jwt-middleware => github.com/auth0/go-jwt-middleware v0.0.0-20170425171159-5493cabe49f7
+
+replace github.com/boltdb/bolt => github.com/boltdb/bolt v1.3.1
+
+replace github.com/codegangsta/negroni => github.com/codegangsta/negroni v1.0.0
+
+replace github.com/go-ozzo/ozzo-validation => github.com/go-ozzo/ozzo-validation v3.5.0+incompatible
+
+replace github.com/gorilla/context => github.com/gorilla/context v1.1.1
+
+replace github.com/heketi/tests => github.com/heketi/tests v0.0.0-20151005000721-f3775cbcefd6
+
+replace github.com/lpabon/godbc => github.com/lpabon/godbc v0.1.1
+
+replace github.com/magiconair/properties => github.com/magiconair/properties v1.8.1
+
+replace github.com/mohae/deepcopy => github.com/mohae/deepcopy v0.0.0-20170603005431-491d3605edfb
+
+replace github.com/spf13/jwalterweatherman => github.com/spf13/jwalterweatherman v1.1.0
+
+replace github.com/urfave/negroni => github.com/urfave/negroni v1.0.0
+
+replace gonum.org/v1/netlib => gonum.org/v1/netlib v0.0.0-20190331212654-76723241ea4e
+
+replace bitbucket.org/bertimus9/systemstat => bitbucket.org/bertimus9/systemstat v0.0.0-20180207000608-0eeff89b0690
+
+replace github.com/Azure/azure-sdk-for-go => github.com/Azure/azure-sdk-for-go v43.0.0+incompatible
+
+replace github.com/Azure/go-autorest/autorest => github.com/Azure/go-autorest/autorest v0.9.6
+
+replace github.com/Azure/go-autorest/autorest/adal => github.com/Azure/go-autorest/autorest/adal v0.8.2
+
+replace github.com/Azure/go-autorest/autorest/to => github.com/Azure/go-autorest/autorest/to v0.2.0
+
+replace github.com/GoogleCloudPlatform/k8s-cloud-provider => github.com/GoogleCloudPlatform/k8s-cloud-provider v0.0.0-20200415212048-7901bc822317
+
+replace github.com/JeffAshton/win_pdh => github.com/JeffAshton/win_pdh v0.0.0-20161109143554-76bb4ee9f0ab
+
+replace github.com/Microsoft/go-winio => github.com/Microsoft/go-winio v0.4.15-0.20190919025122-fc70bd9a86b5
+
+replace github.com/Microsoft/hcsshim => github.com/Microsoft/hcsshim v0.8.10-0.20200715222032-5eafd1556990
+
+replace github.com/PuerkitoBio/purell => github.com/PuerkitoBio/purell v1.1.1
+
+replace github.com/armon/circbuf => github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e
+
+replace github.com/aws/aws-sdk-go => github.com/aws/aws-sdk-go v1.28.2
+
+replace github.com/blang/semver => github.com/blang/semver v3.5.0+incompatible
+
+replace github.com/caddyserver/caddy => github.com/caddyserver/caddy v1.0.3
+
+replace github.com/clusterhq/flocker-go => github.com/clusterhq/flocker-go v0.0.0-20160920122132-2b8b7259d313
+
+replace github.com/container-storage-interface/spec => github.com/container-storage-interface/spec v1.2.0
+
+replace github.com/containernetworking/cni => github.com/containernetworking/cni v0.8.0
+
+replace github.com/coredns/corefile-migration => github.com/coredns/corefile-migration v1.0.10
+
+replace github.com/coreos/go-oidc => github.com/coreos/go-oidc v2.1.0+incompatible
+
+replace github.com/coreos/go-systemd => github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e
+
+replace github.com/coreos/pkg => github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f
+
+replace github.com/cpuguy83/go-md2man/v2 => github.com/cpuguy83/go-md2man/v2 v2.0.0
+
+replace github.com/davecgh/go-spew => github.com/davecgh/go-spew v1.1.1
+
+replace github.com/docker/distribution => github.com/docker/distribution v2.7.1+incompatible
+
+replace github.com/docker/docker => github.com/docker/docker v1.4.2-0.20200309214505-aa6a9891b09c
+
+replace github.com/docker/go-connections => github.com/docker/go-connections v0.4.0
+
+replace github.com/docker/go-units => github.com/docker/go-units v0.4.0
+
+replace github.com/elazarl/goproxy => github.com/elazarl/goproxy v0.0.0-20180725130230-947c36da3153
+
+replace github.com/emicklei/go-restful => github.com/emicklei/go-restful v2.9.5+incompatible
+
+replace github.com/evanphx/json-patch => github.com/evanphx/json-patch v4.9.0+incompatible
+
+replace github.com/fsnotify/fsnotify => github.com/fsnotify/fsnotify v1.4.9
+
+replace github.com/go-bindata/go-bindata => github.com/go-bindata/go-bindata v3.1.1+incompatible
+
+replace github.com/go-openapi/analysis => github.com/go-openapi/analysis v0.19.5
+
+replace github.com/go-openapi/loads => github.com/go-openapi/loads v0.19.4
+
+replace github.com/go-openapi/spec => github.com/go-openapi/spec v0.19.3
+
+replace github.com/go-openapi/strfmt => github.com/go-openapi/strfmt v0.19.3
+
+replace github.com/go-openapi/validate => github.com/go-openapi/validate v0.19.5
+
+replace github.com/gogo/protobuf => github.com/gogo/protobuf v1.3.2
+
+replace github.com/golang/groupcache => github.com/golang/groupcache v0.0.0-20191227052852-215e87163ea7
+
+replace github.com/golang/mock => github.com/golang/mock v1.3.1
+
+replace github.com/google/cadvisor => github.com/google/cadvisor v0.37.5
+
+replace github.com/google/go-cmp => github.com/google/go-cmp v0.4.0
+
+replace github.com/google/gofuzz => github.com/google/gofuzz v1.1.0
+
+replace github.com/google/uuid => github.com/google/uuid v1.1.1
+
+replace github.com/googleapis/gnostic => github.com/googleapis/gnostic v0.4.1
+
+replace github.com/hashicorp/golang-lru => github.com/hashicorp/golang-lru v0.5.1
+
+replace github.com/heketi/heketi => github.com/heketi/heketi v9.0.1-0.20190917153846-c2e2a4ab7ab9+incompatible
+
+replace github.com/ishidawataru/sctp => github.com/ishidawataru/sctp v0.0.0-20190723014705-7c296d48a2b5
+
+replace github.com/json-iterator/go => github.com/json-iterator/go v1.1.10
+
+replace github.com/libopenstorage/openstorage => github.com/libopenstorage/openstorage v1.0.0
+
+replace github.com/lithammer/dedent => github.com/lithammer/dedent v1.1.0
+
+replace github.com/miekg/dns => github.com/miekg/dns v1.1.4
+
+replace github.com/moby/ipvs => github.com/moby/ipvs v1.0.1
+
+replace github.com/mrunalp/fileutils => github.com/mrunalp/fileutils v0.0.0-20200520151820-abd8a0e76976
+
+replace github.com/munnerz/goautoneg => github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822
+
+replace github.com/mvdan/xurls => github.com/mvdan/xurls v1.1.0
+
+replace github.com/onsi/ginkgo => github.com/onsi/ginkgo v1.11.0
+
+replace github.com/onsi/gomega => github.com/onsi/gomega v1.7.0
+
+replace github.com/opencontainers/go-digest => github.com/opencontainers/go-digest v1.0.0-rc1
+
+replace github.com/opencontainers/runc => github.com/opencontainers/runc v1.0.1
+
+replace github.com/opencontainers/selinux => github.com/opencontainers/selinux v1.5.2
+
+replace github.com/pkg/errors => github.com/pkg/errors v0.9.1
+
+replace github.com/pmezard/go-difflib => github.com/pmezard/go-difflib v1.0.0
+
+replace github.com/prometheus/client_golang => github.com/prometheus/client_golang v1.7.1
+
+replace github.com/prometheus/client_model => github.com/prometheus/client_model v0.2.0
+
+replace github.com/prometheus/common => github.com/prometheus/common v0.10.0
+
+replace github.com/quobyte/api => github.com/quobyte/api v0.1.2
+
+replace github.com/robfig/cron => github.com/robfig/cron v1.1.0
+
+replace github.com/spf13/afero => github.com/spf13/afero v1.2.2
+
+replace github.com/spf13/cobra => github.com/spf13/cobra v1.0.0
+
+replace github.com/spf13/pflag => github.com/spf13/pflag v1.0.5
+
+replace github.com/spf13/viper => github.com/spf13/viper v1.4.0
+
+replace github.com/storageos/go-api => github.com/storageos/go-api v0.0.0-20180912212459-343b3eff91fc
+
+replace github.com/stretchr/testify => github.com/stretchr/testify v1.4.0
+
+replace github.com/thecodeteam/goscaleio => github.com/thecodeteam/goscaleio v0.1.0
+
+replace github.com/vishvananda/netlink => github.com/vishvananda/netlink v1.1.0
+
+replace github.com/vmware/govmomi => github.com/vmware/govmomi v0.20.3
+
+replace go.etcd.io/etcd => go.etcd.io/etcd v0.5.0-alpha.5.0.20200819165624-17cef6e3e9d5
+
+replace golang.org/x/crypto => golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9
+
+replace golang.org/x/net => golang.org/x/net v0.0.0-20201110031124-69a78807bb2b
+
+replace golang.org/x/oauth2 => golang.org/x/oauth2 v0.0.0-20191202225959-858c2ad4c8b6
+
+replace golang.org/x/sys => golang.org/x/sys v0.0.0-20201112073958-5cba982894dd
+
+replace golang.org/x/time => golang.org/x/time v0.0.0-20191024005414-555d28b269f0
+
+replace golang.org/x/tools => golang.org/x/tools v0.0.0-20210106214847-113979e3529a
+
+replace gonum.org/v1/gonum => gonum.org/v1/gonum v0.6.2
+
+replace google.golang.org/api => google.golang.org/api v0.15.1
+
+replace google.golang.org/grpc => google.golang.org/grpc v1.27.0
+
+replace gopkg.in/gcfg.v1 => gopkg.in/gcfg.v1 v1.2.0
+
+replace gopkg.in/square/go-jose.v2 => gopkg.in/square/go-jose.v2 v2.2.2
+
+replace gopkg.in/yaml.v2 => gopkg.in/yaml.v2 v2.2.8
+
+replace k8s.io/gengo => k8s.io/gengo v0.0.0-20200428234225-8167cfdcfc14
+
+replace k8s.io/heapster => k8s.io/heapster v1.2.0-beta.1
+
+replace k8s.io/klog/v2 => k8s.io/klog/v2 v2.2.0
+
+replace k8s.io/kube-openapi => k8s.io/kube-openapi v0.0.0-20200805222855-6aeccd4b50c6
+
+replace k8s.io/system-validators => k8s.io/system-validators v1.1.2
+
+replace k8s.io/utils => k8s.io/utils v0.0.0-20200729134348-d5654de09c73
+
+replace sigs.k8s.io/kustomize => sigs.k8s.io/kustomize v2.0.3+incompatible
+
+replace sigs.k8s.io/yaml => sigs.k8s.io/yaml v1.2.0
+
+replace cloud.google.com/go => cloud.google.com/go v0.51.0
+
+replace cloud.google.com/go/bigquery => cloud.google.com/go/bigquery v1.0.1
+
+replace cloud.google.com/go/datastore => cloud.google.com/go/datastore v1.0.0
+
+replace cloud.google.com/go/pubsub => cloud.google.com/go/pubsub v1.0.1
+
+replace cloud.google.com/go/storage => cloud.google.com/go/storage v1.0.0
+
+replace dmitri.shuralyov.com/gpu/mtl => dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9
+
+replace github.com/Azure/go-ansiterm => github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78
+
+replace github.com/Azure/go-autorest/autorest/date => github.com/Azure/go-autorest/autorest/date v0.2.0
+
+replace github.com/Azure/go-autorest/autorest/mocks => github.com/Azure/go-autorest/autorest/mocks v0.3.0
+
+replace github.com/Azure/go-autorest/autorest/validation => github.com/Azure/go-autorest/autorest/validation v0.1.0
+
+replace github.com/Azure/go-autorest/logger => github.com/Azure/go-autorest/logger v0.1.0
+
+replace github.com/Azure/go-autorest/tracing => github.com/Azure/go-autorest/tracing v0.5.0
+
+replace github.com/BurntSushi/toml => github.com/BurntSushi/toml v0.3.1
+
+replace github.com/BurntSushi/xgb => github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802
+
+replace github.com/MakeNowJust/heredoc => github.com/MakeNowJust/heredoc v0.0.0-20170808103936-bb23615498cd
+
+replace github.com/NYTimes/gziphandler => github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46
+
+replace github.com/PuerkitoBio/urlesc => github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578
+
+replace github.com/agnivade/levenshtein => github.com/agnivade/levenshtein v1.0.1
+
+replace github.com/ajstarks/svgo => github.com/ajstarks/svgo v0.0.0-20180226025133-644b8db467af
+
+replace github.com/alecthomas/template => github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751
+
+replace github.com/alecthomas/units => github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4
+
+replace github.com/andreyvit/diff => github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883
+
+replace github.com/armon/consul-api => github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6
+
+replace github.com/asaskevich/govalidator => github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a
+
+replace github.com/beorn7/perks => github.com/beorn7/perks v1.0.1
+
+replace github.com/bgentry/speakeasy => github.com/bgentry/speakeasy v0.1.0
+
+replace github.com/bifurcation/mint => github.com/bifurcation/mint v0.0.0-20180715133206-93c51c6ce115
+
+replace github.com/cenkalti/backoff => github.com/cenkalti/backoff v2.1.1+incompatible
+
+replace github.com/census-instrumentation/opencensus-proto => github.com/census-instrumentation/opencensus-proto v0.2.1
+
+replace github.com/cespare/xxhash/v2 => github.com/cespare/xxhash/v2 v2.1.1
+
+replace github.com/chai2010/gettext-go => github.com/chai2010/gettext-go v0.0.0-20160711120539-c6fed771bfd5
+
+replace github.com/checkpoint-restore/go-criu/v4 => github.com/checkpoint-restore/go-criu/v4 v4.0.2
+
+replace github.com/cheekybits/genny => github.com/cheekybits/genny v0.0.0-20170328200008-9127e812e1e9
+
+replace github.com/chzyer/logex => github.com/chzyer/logex v1.1.10
+
+replace github.com/chzyer/readline => github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e
+
+replace github.com/chzyer/test => github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1
+
+replace github.com/cilium/ebpf => github.com/cilium/ebpf v0.0.0-20200702112145-1c8d4c9ef775
+
+replace github.com/cockroachdb/datadriven => github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa
+
+replace github.com/containerd/cgroups => github.com/containerd/cgroups v0.0.0-20200531161412-0dbf7f05ba59
+
+replace github.com/containerd/console => github.com/containerd/console v1.0.0
+
+replace github.com/containerd/containerd => github.com/containerd/containerd v1.3.3
+
+replace github.com/containerd/continuity => github.com/containerd/continuity v0.0.0-20190426062206-aaeac12a7ffc
+
+replace github.com/containerd/fifo => github.com/containerd/fifo v0.0.0-20190226154929-a9fb20d87448
+
+replace github.com/containerd/go-runc => github.com/containerd/go-runc v0.0.0-20180907222934-5a6d9f37cfa3
+
+replace github.com/containerd/ttrpc => github.com/containerd/ttrpc v1.0.0
+
+replace github.com/containerd/typeurl => github.com/containerd/typeurl v1.0.0
+
+replace github.com/coreos/bbolt => github.com/coreos/bbolt v1.3.2
+
+replace github.com/coreos/etcd => github.com/coreos/etcd v3.3.10+incompatible
+
+replace github.com/coreos/go-semver => github.com/coreos/go-semver v0.3.0
+
+replace github.com/coreos/go-systemd/v22 => github.com/coreos/go-systemd/v22 v22.1.0
+
+replace github.com/creack/pty => github.com/creack/pty v1.1.7
+
+replace github.com/cyphar/filepath-securejoin => github.com/cyphar/filepath-securejoin v0.2.2
+
+replace github.com/daviddengcn/go-colortext => github.com/daviddengcn/go-colortext v0.0.0-20160507010035-511bcaf42ccd
+
+replace github.com/dgrijalva/jwt-go => github.com/dgrijalva/jwt-go v3.2.0+incompatible
+
+replace github.com/dnaeon/go-vcr => github.com/dnaeon/go-vcr v1.0.1
+
+replace github.com/docker/spdystream => github.com/docker/spdystream v0.0.0-20160310174837-449fdfce4d96
+
+replace github.com/docopt/docopt-go => github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815
+
+replace github.com/dustin/go-humanize => github.com/dustin/go-humanize v1.0.0
+
+replace github.com/envoyproxy/go-control-plane => github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473
+
+replace github.com/envoyproxy/protoc-gen-validate => github.com/envoyproxy/protoc-gen-validate v0.1.0
+
+replace github.com/euank/go-kmsg-parser => github.com/euank/go-kmsg-parser v2.0.0+incompatible
+
+replace github.com/exponent-io/jsonpath => github.com/exponent-io/jsonpath v0.0.0-20151013193312-d6023ce2651d
+
+replace github.com/fatih/camelcase => github.com/fatih/camelcase v1.0.0
+
+replace github.com/fatih/color => github.com/fatih/color v1.7.0
+
+replace github.com/flynn/go-shlex => github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568
+
+replace github.com/fogleman/gg => github.com/fogleman/gg v1.2.1-0.20190220221249-0403632d5b90
+
+replace github.com/ghodss/yaml => github.com/ghodss/yaml v1.0.0
+
+replace github.com/go-acme/lego => github.com/go-acme/lego v2.5.0+incompatible
+
+replace github.com/go-gl/glfw/v3.3/glfw => github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72
+
+replace github.com/go-ini/ini => github.com/go-ini/ini v1.9.0
+
+replace github.com/go-kit/kit => github.com/go-kit/kit v0.9.0
+
+replace github.com/go-logfmt/logfmt => github.com/go-logfmt/logfmt v0.4.0
+
+replace github.com/go-logr/logr => github.com/go-logr/logr v0.2.0
+
+replace github.com/go-openapi/errors => github.com/go-openapi/errors v0.19.2
+
+replace github.com/go-openapi/jsonpointer => github.com/go-openapi/jsonpointer v0.19.3
+
+replace github.com/go-openapi/jsonreference => github.com/go-openapi/jsonreference v0.19.3
+
+replace github.com/go-openapi/runtime => github.com/go-openapi/runtime v0.19.4
+
+replace github.com/go-openapi/swag => github.com/go-openapi/swag v0.19.5
+
+replace github.com/go-stack/stack => github.com/go-stack/stack v1.8.0
+
+replace github.com/godbus/dbus/v5 => github.com/godbus/dbus/v5 v5.0.3
+
+replace github.com/golang/freetype => github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0
+
+replace github.com/golang/glog => github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
+
+replace github.com/golang/protobuf => github.com/golang/protobuf v1.4.2
+
+replace github.com/golangplus/bytes => github.com/golangplus/bytes v0.0.0-20160111154220-45c989fe5450
+
+replace github.com/golangplus/fmt => github.com/golangplus/fmt v0.0.0-20150411045040-2a5d6d7d2995
+
+replace github.com/golangplus/testing => github.com/golangplus/testing v0.0.0-20180327235837-af21d9c3145e
+
+replace github.com/google/btree => github.com/google/btree v1.0.0
+
+replace github.com/google/martian => github.com/google/martian v2.1.0+incompatible
+
+replace github.com/google/pprof => github.com/google/pprof v0.0.0-20191218002539-d4f498aebedc
+
+replace github.com/google/renameio => github.com/google/renameio v0.1.0
+
+replace github.com/googleapis/gax-go/v2 => github.com/googleapis/gax-go/v2 v2.0.5
+
+replace github.com/gophercloud/gophercloud => github.com/gophercloud/gophercloud v0.1.0
+
+replace github.com/gopherjs/gopherjs => github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1
+
+replace github.com/gorilla/mux => github.com/gorilla/mux v1.7.3
+
+replace github.com/gorilla/websocket => github.com/gorilla/websocket v1.4.0
+
+replace github.com/gregjones/httpcache => github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7
+
+replace github.com/grpc-ecosystem/go-grpc-middleware => github.com/grpc-ecosystem/go-grpc-middleware v1.0.1-0.20190118093823-f849b5445de4
+
+replace github.com/grpc-ecosystem/go-grpc-prometheus => github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0
+
+replace github.com/grpc-ecosystem/grpc-gateway => github.com/grpc-ecosystem/grpc-gateway v1.9.5
+
+replace github.com/hashicorp/go-syslog => github.com/hashicorp/go-syslog v1.0.0
+
+replace github.com/hashicorp/hcl => github.com/hashicorp/hcl v1.0.0
+
+replace github.com/hpcloud/tail => github.com/hpcloud/tail v1.0.0
+
+replace github.com/ianlancetaylor/demangle => github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6
+
+replace github.com/imdario/mergo => github.com/imdario/mergo v0.3.5
+
+replace github.com/inconshreveable/mousetrap => github.com/inconshreveable/mousetrap v1.0.0
+
+replace github.com/jimstudt/http-authentication => github.com/jimstudt/http-authentication v0.0.0-20140401203705-3eca13d6893a
+
+replace github.com/jmespath/go-jmespath => github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af
+
+replace github.com/jonboulle/clockwork => github.com/jonboulle/clockwork v0.1.0
+
+replace github.com/jstemmer/go-junit-report => github.com/jstemmer/go-junit-report v0.9.1
+
+replace github.com/jtolds/gls => github.com/jtolds/gls v4.20.0+incompatible
+
+replace github.com/julienschmidt/httprouter => github.com/julienschmidt/httprouter v1.2.0
+
+replace github.com/jung-kurt/gofpdf => github.com/jung-kurt/gofpdf v1.0.3-0.20190309125859-24315acbbda5
+
+replace github.com/karrick/godirwalk => github.com/karrick/godirwalk v1.7.5
+
+replace github.com/kisielk/errcheck => github.com/kisielk/errcheck v1.5.0
+
+replace github.com/kisielk/gotool => github.com/kisielk/gotool v1.0.0
+
+replace github.com/klauspost/cpuid => github.com/klauspost/cpuid v1.2.0
+
+replace github.com/konsorten/go-windows-terminal-sequences => github.com/konsorten/go-windows-terminal-sequences v1.0.3
+
+replace github.com/kr/logfmt => github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515
+
+replace github.com/kr/pretty => github.com/kr/pretty v0.2.0
+
+replace github.com/kr/pty => github.com/kr/pty v1.1.5
+
+replace github.com/kr/text => github.com/kr/text v0.1.0
+
+replace github.com/kylelemons/godebug => github.com/kylelemons/godebug v0.0.0-20170820004349-d65d576e9348
+
+replace github.com/liggitt/tabwriter => github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de
+
+replace github.com/lucas-clemente/aes12 => github.com/lucas-clemente/aes12 v0.0.0-20171027163421-cd47fb39b79f
+
+replace github.com/lucas-clemente/quic-clients => github.com/lucas-clemente/quic-clients v0.1.0
+
+replace github.com/lucas-clemente/quic-go => github.com/lucas-clemente/quic-go v0.10.2
+
+replace github.com/lucas-clemente/quic-go-certificates => github.com/lucas-clemente/quic-go-certificates v0.0.0-20160823095156-d2f86524cced
+
+replace github.com/mailru/easyjson => github.com/mailru/easyjson v0.7.0
+
+replace github.com/marten-seemann/qtls => github.com/marten-seemann/qtls v0.2.3
+
+replace github.com/mattn/go-colorable => github.com/mattn/go-colorable v0.0.9
+
+replace github.com/mattn/go-isatty => github.com/mattn/go-isatty v0.0.4
+
+replace github.com/mattn/go-runewidth => github.com/mattn/go-runewidth v0.0.2
+
+replace github.com/matttproud/golang_protobuf_extensions => github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369
+
+replace github.com/mholt/certmagic => github.com/mholt/certmagic v0.6.2-0.20190624175158-6a42ef9fe8c2
+
+replace github.com/mindprince/gonvml => github.com/mindprince/gonvml v0.0.0-20190828220739-9ebdce4bb989
+
+replace github.com/mistifyio/go-zfs => github.com/mistifyio/go-zfs v2.1.2-0.20190413222219-f784269be439+incompatible
+
+replace github.com/mitchellh/go-homedir => github.com/mitchellh/go-homedir v1.1.0
+
+replace github.com/mitchellh/go-wordwrap => github.com/mitchellh/go-wordwrap v1.0.0
+
+replace github.com/mitchellh/mapstructure => github.com/mitchellh/mapstructure v1.1.2
+
+replace github.com/moby/sys/mountinfo => github.com/moby/sys/mountinfo v0.1.3
+
+replace github.com/moby/term => github.com/moby/term v0.0.0-20200312100748-672ec06f55cd
+
+replace github.com/modern-go/concurrent => github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd
+
+replace github.com/modern-go/reflect2 => github.com/modern-go/reflect2 v1.0.1
+
+replace github.com/morikuni/aec => github.com/morikuni/aec v1.0.0
+
+replace github.com/mwitkow/go-conntrack => github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223
+
+replace github.com/mxk/go-flowrate => github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f
+
+replace github.com/naoina/go-stringutil => github.com/naoina/go-stringutil v0.1.0
+
+replace github.com/naoina/toml => github.com/naoina/toml v0.1.1
+
+replace github.com/olekukonko/tablewriter => github.com/olekukonko/tablewriter v0.0.0-20170122224234-a0225b3f23b5
+
+replace github.com/opencontainers/image-spec => github.com/opencontainers/image-spec v1.0.1
+
+replace github.com/opencontainers/runtime-spec => github.com/opencontainers/runtime-spec v1.0.3-0.20200520003142-237cc4f519e2
+
+replace github.com/pelletier/go-toml => github.com/pelletier/go-toml v1.2.0
+
+replace github.com/peterbourgon/diskv => github.com/peterbourgon/diskv v2.0.1+incompatible
+
+replace github.com/pquerna/cachecontrol => github.com/pquerna/cachecontrol v0.0.0-20171018203845-0dec1b30a021
+
+replace github.com/prometheus/procfs => github.com/prometheus/procfs v0.1.3
+
+replace github.com/remyoudompheng/bigfft => github.com/remyoudompheng/bigfft v0.0.0-20170806203942-52369c62f446
+
+replace github.com/rogpeppe/fastuuid => github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af
+
+replace github.com/rogpeppe/go-internal => github.com/rogpeppe/go-internal v1.3.0
+
+replace github.com/rubiojr/go-vhd => github.com/rubiojr/go-vhd v0.0.0-20200706105327-02e210299021
+
+replace github.com/russross/blackfriday => github.com/russross/blackfriday v1.5.2
+
+replace github.com/russross/blackfriday/v2 => github.com/russross/blackfriday/v2 v2.0.1
+
+replace github.com/satori/go.uuid => github.com/satori/go.uuid v1.2.0
+
+replace github.com/seccomp/libseccomp-golang => github.com/seccomp/libseccomp-golang v0.9.1
+
+replace github.com/sergi/go-diff => github.com/sergi/go-diff v1.0.0
+
+replace github.com/shurcooL/sanitized_anchor_name => github.com/shurcooL/sanitized_anchor_name v1.0.0
+
+replace github.com/sirupsen/logrus => github.com/sirupsen/logrus v1.6.0
+
+replace github.com/smartystreets/assertions => github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d
+
+replace github.com/smartystreets/goconvey => github.com/smartystreets/goconvey v1.6.4
+
+replace github.com/soheilhy/cmux => github.com/soheilhy/cmux v0.1.4
+
+replace github.com/spf13/cast => github.com/spf13/cast v1.3.0
+
+replace github.com/stretchr/objx => github.com/stretchr/objx v0.2.0
+
+replace github.com/syndtr/gocapability => github.com/syndtr/gocapability v0.0.0-20180916011248-d98352740cb2
+
+replace github.com/tidwall/pretty => github.com/tidwall/pretty v1.0.0
+
+replace github.com/tmc/grpc-websocket-proxy => github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5
+
+replace github.com/ugorji/go => github.com/ugorji/go v1.1.4
+
+replace github.com/urfave/cli => github.com/urfave/cli v1.22.2
+
+replace github.com/vektah/gqlparser => github.com/vektah/gqlparser v1.1.2
+
+replace github.com/vishvananda/netns => github.com/vishvananda/netns v0.0.0-20200520041808-52d707b772fe
+
+replace github.com/xiang90/probing => github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2
+
+replace github.com/xlab/handysort => github.com/xlab/handysort v0.0.0-20150421192137-fb3537ed64a1
+
+replace github.com/xordataexchange/crypt => github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77
+
+replace github.com/yuin/goldmark => github.com/yuin/goldmark v1.2.1
+
+replace go.etcd.io/bbolt => go.etcd.io/bbolt v1.3.5
+
+replace go.mongodb.org/mongo-driver => go.mongodb.org/mongo-driver v1.1.2
+
+replace go.opencensus.io => go.opencensus.io v0.22.2
+
+replace go.uber.org/atomic => go.uber.org/atomic v1.4.0
+
+replace go.uber.org/multierr => go.uber.org/multierr v1.1.0
+
+replace go.uber.org/zap => go.uber.org/zap v1.10.0
+
+replace golang.org/x/exp => golang.org/x/exp v0.0.0-20191227195350-da58074b4299
+
+replace golang.org/x/image => golang.org/x/image v0.0.0-20190802002840-cff245a6509b
+
+replace golang.org/x/lint => golang.org/x/lint v0.0.0-20191125180803-fdd1cda4f05f
+
+replace golang.org/x/mobile => golang.org/x/mobile v0.0.0-20190719004257-d2bd2a29d028
+
+replace golang.org/x/mod => golang.org/x/mod v0.3.0
+
+replace golang.org/x/sync => golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9
+
+replace golang.org/x/text => golang.org/x/text v0.3.3
+
+replace golang.org/x/xerrors => golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1
+
+replace gonum.org/v1/plot => gonum.org/v1/plot v0.0.0-20190515093506-e2840ee46a6b
+
+replace google.golang.org/appengine => google.golang.org/appengine v1.6.5
+
+replace google.golang.org/genproto => google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013
+
+replace google.golang.org/protobuf => google.golang.org/protobuf v1.24.0
+
+replace gopkg.in/alecthomas/kingpin.v2 => gopkg.in/alecthomas/kingpin.v2 v2.2.6
+
+replace gopkg.in/check.v1 => gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15
+
+replace gopkg.in/cheggaaa/pb.v1 => gopkg.in/cheggaaa/pb.v1 v1.0.25
+
+replace gopkg.in/errgo.v2 => gopkg.in/errgo.v2 v2.1.0
+
+replace gopkg.in/fsnotify.v1 => gopkg.in/fsnotify.v1 v1.4.7
+
+replace gopkg.in/inf.v0 => gopkg.in/inf.v0 v0.9.1
+
+replace gopkg.in/mcuadros/go-syslog.v2 => gopkg.in/mcuadros/go-syslog.v2 v2.2.1
+
+replace gopkg.in/natefinch/lumberjack.v2 => gopkg.in/natefinch/lumberjack.v2 v2.0.0
+
+replace gopkg.in/resty.v1 => gopkg.in/resty.v1 v1.12.0
+
+replace gopkg.in/tomb.v1 => gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7
+
+replace gopkg.in/warnings.v0 => gopkg.in/warnings.v0 v0.1.1
+
+replace gotest.tools => gotest.tools v2.2.0+incompatible
+
+replace gotest.tools/v3 => gotest.tools/v3 v3.0.2
+
+replace honnef.co/go/tools => honnef.co/go/tools v0.0.1-2019.2.3
+
+replace modernc.org/cc => modernc.org/cc v1.0.0
+
+replace modernc.org/golex => modernc.org/golex v1.0.0
+
+replace modernc.org/mathutil => modernc.org/mathutil v1.0.0
+
+replace modernc.org/strutil => modernc.org/strutil v1.0.0
+
+replace modernc.org/xc => modernc.org/xc v1.0.0
+
+replace rsc.io/pdf => rsc.io/pdf v0.1.1
+
+replace sigs.k8s.io/apiserver-network-proxy/konnectivity-client => sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.15
+
+replace sigs.k8s.io/structured-merge-diff/v4 => sigs.k8s.io/structured-merge-diff/v4 v4.1.2
+
+replace vbom.ml/util => vbom.ml/util v0.0.0-20160121211510-db5cfe13f5cc

--- a/staging/src/k8s.io/legacy-cloud-providers/go.mod
+++ b/staging/src/k8s.io/legacy-cloud-providers/go.mod
@@ -5,6 +5,7 @@ module k8s.io/legacy-cloud-providers
 go 1.15
 
 require (
+	bitbucket.org/bertimus9/systemstat v0.0.0-20180207000608-0eeff89b0690
 	cloud.google.com/go v0.51.0
 	github.com/Azure/azure-sdk-for-go v43.0.0+incompatible
 	github.com/Azure/go-autorest/autorest v0.9.6
@@ -13,21 +14,108 @@ require (
 	github.com/Azure/go-autorest/autorest/to v0.2.0
 	github.com/Azure/go-autorest/autorest/validation v0.1.0 // indirect
 	github.com/GoogleCloudPlatform/k8s-cloud-provider v0.0.0-20200415212048-7901bc822317
+	github.com/JeffAshton/win_pdh v0.0.0-20161109143554-76bb4ee9f0ab
+	github.com/Microsoft/go-winio v0.4.15-0.20190919025122-fc70bd9a86b5
+	github.com/Microsoft/hcsshim v0.8.10-0.20200715222032-5eafd1556990
+	github.com/PuerkitoBio/purell v1.1.1
+	github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e
+	github.com/auth0/go-jwt-middleware v0.0.0-20170425171159-5493cabe49f7
 	github.com/aws/aws-sdk-go v1.28.2
+	github.com/blang/semver v3.5.0+incompatible
+	github.com/boltdb/bolt v1.3.1
+	github.com/caddyserver/caddy v1.0.3
+	github.com/clusterhq/flocker-go v0.0.0-20160920122132-2b8b7259d313
+	github.com/codegangsta/negroni v1.0.0
+	github.com/container-storage-interface/spec v1.2.0
+	github.com/containernetworking/cni v0.8.0
+	github.com/coredns/corefile-migration v1.0.10
+	github.com/coreos/go-oidc v2.1.0+incompatible
+	github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e
+	github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f
+	github.com/cpuguy83/go-md2man/v2 v2.0.0
+	github.com/davecgh/go-spew v1.1.1
 	github.com/dnaeon/go-vcr v1.0.1 // indirect
+	github.com/docker/distribution v2.7.1+incompatible
+	github.com/docker/docker v1.4.2-0.20200309214505-aa6a9891b09c
+	github.com/docker/go-connections v0.4.0
+	github.com/docker/go-units v0.4.0
+	github.com/elazarl/goproxy v0.0.0-20180725130230-947c36da3153
+	github.com/emicklei/go-restful v2.9.5+incompatible
+	github.com/evanphx/json-patch v4.9.0+incompatible
+	github.com/fsnotify/fsnotify v1.4.9
+	github.com/go-bindata/go-bindata v3.1.1+incompatible
+	github.com/go-openapi/analysis v0.19.5
+	github.com/go-openapi/loads v0.19.4
+	github.com/go-openapi/spec v0.19.3
+	github.com/go-openapi/strfmt v0.19.3
+	github.com/go-openapi/validate v0.19.5
+	github.com/go-ozzo/ozzo-validation v3.5.0+incompatible
+	github.com/gogo/protobuf v1.3.2
+	github.com/golang/groupcache v0.0.0-20191227052852-215e87163ea7
 	github.com/golang/mock v1.3.1
+	github.com/google/cadvisor v0.37.5
 	github.com/google/go-cmp v0.4.0
+	github.com/google/gofuzz v1.1.0
+	github.com/google/uuid v1.1.1
+	github.com/googleapis/gnostic v0.4.1
 	github.com/gophercloud/gophercloud v0.1.0
+	github.com/gorilla/context v1.1.1
+	github.com/hashicorp/golang-lru v0.5.1
+	github.com/heketi/heketi v9.0.1-0.20190917153846-c2e2a4ab7ab9+incompatible
+	github.com/heketi/tests v0.0.0-20151005000721-f3775cbcefd6
+	github.com/ishidawataru/sctp v0.0.0-20190723014705-7c296d48a2b5
+	github.com/json-iterator/go v1.1.10
+	github.com/libopenstorage/openstorage v1.0.0
+	github.com/lithammer/dedent v1.1.0
+	github.com/lpabon/godbc v0.1.1
+	github.com/magiconair/properties v1.8.1
+	github.com/miekg/dns v1.1.4
 	github.com/mitchellh/mapstructure v1.1.2
+	github.com/moby/ipvs v1.0.1
+	github.com/mohae/deepcopy v0.0.0-20170603005431-491d3605edfb
+	github.com/mrunalp/fileutils v0.0.0-20200520151820-abd8a0e76976
+	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822
+	github.com/mvdan/xurls v1.1.0
+	github.com/onsi/ginkgo v1.11.0
+	github.com/onsi/gomega v1.7.0
+	github.com/opencontainers/go-digest v1.0.0-rc1
+	github.com/opencontainers/runc v1.0.1
+	github.com/opencontainers/selinux v1.5.2
+	github.com/pkg/errors v0.9.1
+	github.com/pmezard/go-difflib v1.0.0
+	github.com/prometheus/client_golang v1.7.1
+	github.com/prometheus/client_model v0.2.0
+	github.com/prometheus/common v0.10.0
+	github.com/quobyte/api v0.1.2
+	github.com/robfig/cron v1.1.0
 	github.com/rubiojr/go-vhd v0.0.0-20200706105327-02e210299021
 	github.com/satori/go.uuid v1.2.0 // indirect
+	github.com/spf13/afero v1.2.2
+	github.com/spf13/cobra v1.0.0
+	github.com/spf13/jwalterweatherman v1.1.0
+	github.com/spf13/pflag v1.0.5
+	github.com/spf13/viper v1.4.0
+	github.com/storageos/go-api v0.0.0-20180912212459-343b3eff91fc
 	github.com/stretchr/testify v1.4.0
+	github.com/thecodeteam/goscaleio v0.1.0
+	github.com/urfave/negroni v1.0.0
+	github.com/vishvananda/netlink v1.1.0
 	github.com/vmware/govmomi v0.20.3
+	go.etcd.io/etcd v0.5.0-alpha.5.0.20200819165624-17cef6e3e9d5
 	golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9
+	golang.org/x/net v0.0.0-20201110031124-69a78807bb2b
 	golang.org/x/oauth2 v0.0.0-20191202225959-858c2ad4c8b6
+	golang.org/x/sys v0.0.0-20201112073958-5cba982894dd
+	golang.org/x/time v0.0.0-20191024005414-555d28b269f0
+	golang.org/x/tools v0.0.0-20210106214847-113979e3529a
+	gonum.org/v1/gonum v0.6.2
+	gonum.org/v1/netlib v0.0.0-20190331212654-76723241ea4e
 	google.golang.org/api v0.15.1
+	google.golang.org/grpc v1.27.0
 	gopkg.in/gcfg.v1 v1.2.0
+	gopkg.in/square/go-jose.v2 v2.2.2
 	gopkg.in/warnings.v0 v0.1.1 // indirect
+	gopkg.in/yaml.v2 v2.2.8
 	k8s.io/api v0.0.0
 	k8s.io/apimachinery v0.0.0
 	k8s.io/apiserver v0.0.0
@@ -35,8 +123,13 @@ require (
 	k8s.io/cloud-provider v0.0.0
 	k8s.io/component-base v0.0.0
 	k8s.io/csi-translation-lib v0.0.0
+	k8s.io/gengo v0.0.0-20200428234225-8167cfdcfc14
+	k8s.io/heapster v1.2.0-beta.1
 	k8s.io/klog/v2 v2.2.0
+	k8s.io/kube-openapi v0.0.0-20200805222855-6aeccd4b50c6
+	k8s.io/system-validators v1.1.2
 	k8s.io/utils v0.0.0-20200729134348-d5654de09c73
+	sigs.k8s.io/kustomize v2.0.3+incompatible
 	sigs.k8s.io/yaml v1.2.0
 )
 
@@ -50,3 +143,669 @@ replace (
 	k8s.io/csi-translation-lib => ../csi-translation-lib
 	k8s.io/legacy-cloud-providers => ../legacy-cloud-providers
 )
+
+replace github.com/auth0/go-jwt-middleware => github.com/auth0/go-jwt-middleware v0.0.0-20170425171159-5493cabe49f7
+
+replace github.com/boltdb/bolt => github.com/boltdb/bolt v1.3.1
+
+replace github.com/codegangsta/negroni => github.com/codegangsta/negroni v1.0.0
+
+replace github.com/go-ozzo/ozzo-validation => github.com/go-ozzo/ozzo-validation v3.5.0+incompatible
+
+replace github.com/gorilla/context => github.com/gorilla/context v1.1.1
+
+replace github.com/heketi/tests => github.com/heketi/tests v0.0.0-20151005000721-f3775cbcefd6
+
+replace github.com/lpabon/godbc => github.com/lpabon/godbc v0.1.1
+
+replace github.com/magiconair/properties => github.com/magiconair/properties v1.8.1
+
+replace github.com/mohae/deepcopy => github.com/mohae/deepcopy v0.0.0-20170603005431-491d3605edfb
+
+replace github.com/spf13/jwalterweatherman => github.com/spf13/jwalterweatherman v1.1.0
+
+replace github.com/urfave/negroni => github.com/urfave/negroni v1.0.0
+
+replace gonum.org/v1/netlib => gonum.org/v1/netlib v0.0.0-20190331212654-76723241ea4e
+
+replace bitbucket.org/bertimus9/systemstat => bitbucket.org/bertimus9/systemstat v0.0.0-20180207000608-0eeff89b0690
+
+replace github.com/Azure/azure-sdk-for-go => github.com/Azure/azure-sdk-for-go v43.0.0+incompatible
+
+replace github.com/Azure/go-autorest/autorest => github.com/Azure/go-autorest/autorest v0.9.6
+
+replace github.com/Azure/go-autorest/autorest/adal => github.com/Azure/go-autorest/autorest/adal v0.8.2
+
+replace github.com/Azure/go-autorest/autorest/to => github.com/Azure/go-autorest/autorest/to v0.2.0
+
+replace github.com/GoogleCloudPlatform/k8s-cloud-provider => github.com/GoogleCloudPlatform/k8s-cloud-provider v0.0.0-20200415212048-7901bc822317
+
+replace github.com/JeffAshton/win_pdh => github.com/JeffAshton/win_pdh v0.0.0-20161109143554-76bb4ee9f0ab
+
+replace github.com/Microsoft/go-winio => github.com/Microsoft/go-winio v0.4.15-0.20190919025122-fc70bd9a86b5
+
+replace github.com/Microsoft/hcsshim => github.com/Microsoft/hcsshim v0.8.10-0.20200715222032-5eafd1556990
+
+replace github.com/PuerkitoBio/purell => github.com/PuerkitoBio/purell v1.1.1
+
+replace github.com/armon/circbuf => github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e
+
+replace github.com/aws/aws-sdk-go => github.com/aws/aws-sdk-go v1.28.2
+
+replace github.com/blang/semver => github.com/blang/semver v3.5.0+incompatible
+
+replace github.com/caddyserver/caddy => github.com/caddyserver/caddy v1.0.3
+
+replace github.com/clusterhq/flocker-go => github.com/clusterhq/flocker-go v0.0.0-20160920122132-2b8b7259d313
+
+replace github.com/container-storage-interface/spec => github.com/container-storage-interface/spec v1.2.0
+
+replace github.com/containernetworking/cni => github.com/containernetworking/cni v0.8.0
+
+replace github.com/coredns/corefile-migration => github.com/coredns/corefile-migration v1.0.10
+
+replace github.com/coreos/go-oidc => github.com/coreos/go-oidc v2.1.0+incompatible
+
+replace github.com/coreos/go-systemd => github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e
+
+replace github.com/coreos/pkg => github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f
+
+replace github.com/cpuguy83/go-md2man/v2 => github.com/cpuguy83/go-md2man/v2 v2.0.0
+
+replace github.com/davecgh/go-spew => github.com/davecgh/go-spew v1.1.1
+
+replace github.com/docker/distribution => github.com/docker/distribution v2.7.1+incompatible
+
+replace github.com/docker/docker => github.com/docker/docker v1.4.2-0.20200309214505-aa6a9891b09c
+
+replace github.com/docker/go-connections => github.com/docker/go-connections v0.4.0
+
+replace github.com/docker/go-units => github.com/docker/go-units v0.4.0
+
+replace github.com/elazarl/goproxy => github.com/elazarl/goproxy v0.0.0-20180725130230-947c36da3153
+
+replace github.com/emicklei/go-restful => github.com/emicklei/go-restful v2.9.5+incompatible
+
+replace github.com/evanphx/json-patch => github.com/evanphx/json-patch v4.9.0+incompatible
+
+replace github.com/fsnotify/fsnotify => github.com/fsnotify/fsnotify v1.4.9
+
+replace github.com/go-bindata/go-bindata => github.com/go-bindata/go-bindata v3.1.1+incompatible
+
+replace github.com/go-openapi/analysis => github.com/go-openapi/analysis v0.19.5
+
+replace github.com/go-openapi/loads => github.com/go-openapi/loads v0.19.4
+
+replace github.com/go-openapi/spec => github.com/go-openapi/spec v0.19.3
+
+replace github.com/go-openapi/strfmt => github.com/go-openapi/strfmt v0.19.3
+
+replace github.com/go-openapi/validate => github.com/go-openapi/validate v0.19.5
+
+replace github.com/gogo/protobuf => github.com/gogo/protobuf v1.3.2
+
+replace github.com/golang/groupcache => github.com/golang/groupcache v0.0.0-20191227052852-215e87163ea7
+
+replace github.com/golang/mock => github.com/golang/mock v1.3.1
+
+replace github.com/google/cadvisor => github.com/google/cadvisor v0.37.5
+
+replace github.com/google/go-cmp => github.com/google/go-cmp v0.4.0
+
+replace github.com/google/gofuzz => github.com/google/gofuzz v1.1.0
+
+replace github.com/google/uuid => github.com/google/uuid v1.1.1
+
+replace github.com/googleapis/gnostic => github.com/googleapis/gnostic v0.4.1
+
+replace github.com/hashicorp/golang-lru => github.com/hashicorp/golang-lru v0.5.1
+
+replace github.com/heketi/heketi => github.com/heketi/heketi v9.0.1-0.20190917153846-c2e2a4ab7ab9+incompatible
+
+replace github.com/ishidawataru/sctp => github.com/ishidawataru/sctp v0.0.0-20190723014705-7c296d48a2b5
+
+replace github.com/json-iterator/go => github.com/json-iterator/go v1.1.10
+
+replace github.com/libopenstorage/openstorage => github.com/libopenstorage/openstorage v1.0.0
+
+replace github.com/lithammer/dedent => github.com/lithammer/dedent v1.1.0
+
+replace github.com/miekg/dns => github.com/miekg/dns v1.1.4
+
+replace github.com/moby/ipvs => github.com/moby/ipvs v1.0.1
+
+replace github.com/mrunalp/fileutils => github.com/mrunalp/fileutils v0.0.0-20200520151820-abd8a0e76976
+
+replace github.com/munnerz/goautoneg => github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822
+
+replace github.com/mvdan/xurls => github.com/mvdan/xurls v1.1.0
+
+replace github.com/onsi/ginkgo => github.com/onsi/ginkgo v1.11.0
+
+replace github.com/onsi/gomega => github.com/onsi/gomega v1.7.0
+
+replace github.com/opencontainers/go-digest => github.com/opencontainers/go-digest v1.0.0-rc1
+
+replace github.com/opencontainers/runc => github.com/opencontainers/runc v1.0.1
+
+replace github.com/opencontainers/selinux => github.com/opencontainers/selinux v1.5.2
+
+replace github.com/pkg/errors => github.com/pkg/errors v0.9.1
+
+replace github.com/pmezard/go-difflib => github.com/pmezard/go-difflib v1.0.0
+
+replace github.com/prometheus/client_golang => github.com/prometheus/client_golang v1.7.1
+
+replace github.com/prometheus/client_model => github.com/prometheus/client_model v0.2.0
+
+replace github.com/prometheus/common => github.com/prometheus/common v0.10.0
+
+replace github.com/quobyte/api => github.com/quobyte/api v0.1.2
+
+replace github.com/robfig/cron => github.com/robfig/cron v1.1.0
+
+replace github.com/spf13/afero => github.com/spf13/afero v1.2.2
+
+replace github.com/spf13/cobra => github.com/spf13/cobra v1.0.0
+
+replace github.com/spf13/pflag => github.com/spf13/pflag v1.0.5
+
+replace github.com/spf13/viper => github.com/spf13/viper v1.4.0
+
+replace github.com/storageos/go-api => github.com/storageos/go-api v0.0.0-20180912212459-343b3eff91fc
+
+replace github.com/stretchr/testify => github.com/stretchr/testify v1.4.0
+
+replace github.com/thecodeteam/goscaleio => github.com/thecodeteam/goscaleio v0.1.0
+
+replace github.com/vishvananda/netlink => github.com/vishvananda/netlink v1.1.0
+
+replace github.com/vmware/govmomi => github.com/vmware/govmomi v0.20.3
+
+replace go.etcd.io/etcd => go.etcd.io/etcd v0.5.0-alpha.5.0.20200819165624-17cef6e3e9d5
+
+replace golang.org/x/crypto => golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9
+
+replace golang.org/x/net => golang.org/x/net v0.0.0-20201110031124-69a78807bb2b
+
+replace golang.org/x/oauth2 => golang.org/x/oauth2 v0.0.0-20191202225959-858c2ad4c8b6
+
+replace golang.org/x/sys => golang.org/x/sys v0.0.0-20201112073958-5cba982894dd
+
+replace golang.org/x/time => golang.org/x/time v0.0.0-20191024005414-555d28b269f0
+
+replace golang.org/x/tools => golang.org/x/tools v0.0.0-20210106214847-113979e3529a
+
+replace gonum.org/v1/gonum => gonum.org/v1/gonum v0.6.2
+
+replace google.golang.org/api => google.golang.org/api v0.15.1
+
+replace google.golang.org/grpc => google.golang.org/grpc v1.27.0
+
+replace gopkg.in/gcfg.v1 => gopkg.in/gcfg.v1 v1.2.0
+
+replace gopkg.in/square/go-jose.v2 => gopkg.in/square/go-jose.v2 v2.2.2
+
+replace gopkg.in/yaml.v2 => gopkg.in/yaml.v2 v2.2.8
+
+replace k8s.io/gengo => k8s.io/gengo v0.0.0-20200428234225-8167cfdcfc14
+
+replace k8s.io/heapster => k8s.io/heapster v1.2.0-beta.1
+
+replace k8s.io/klog/v2 => k8s.io/klog/v2 v2.2.0
+
+replace k8s.io/kube-openapi => k8s.io/kube-openapi v0.0.0-20200805222855-6aeccd4b50c6
+
+replace k8s.io/system-validators => k8s.io/system-validators v1.1.2
+
+replace k8s.io/utils => k8s.io/utils v0.0.0-20200729134348-d5654de09c73
+
+replace sigs.k8s.io/kustomize => sigs.k8s.io/kustomize v2.0.3+incompatible
+
+replace sigs.k8s.io/yaml => sigs.k8s.io/yaml v1.2.0
+
+replace cloud.google.com/go => cloud.google.com/go v0.51.0
+
+replace cloud.google.com/go/bigquery => cloud.google.com/go/bigquery v1.0.1
+
+replace cloud.google.com/go/datastore => cloud.google.com/go/datastore v1.0.0
+
+replace cloud.google.com/go/pubsub => cloud.google.com/go/pubsub v1.0.1
+
+replace cloud.google.com/go/storage => cloud.google.com/go/storage v1.0.0
+
+replace dmitri.shuralyov.com/gpu/mtl => dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9
+
+replace github.com/Azure/go-ansiterm => github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78
+
+replace github.com/Azure/go-autorest/autorest/date => github.com/Azure/go-autorest/autorest/date v0.2.0
+
+replace github.com/Azure/go-autorest/autorest/mocks => github.com/Azure/go-autorest/autorest/mocks v0.3.0
+
+replace github.com/Azure/go-autorest/autorest/validation => github.com/Azure/go-autorest/autorest/validation v0.1.0
+
+replace github.com/Azure/go-autorest/logger => github.com/Azure/go-autorest/logger v0.1.0
+
+replace github.com/Azure/go-autorest/tracing => github.com/Azure/go-autorest/tracing v0.5.0
+
+replace github.com/BurntSushi/toml => github.com/BurntSushi/toml v0.3.1
+
+replace github.com/BurntSushi/xgb => github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802
+
+replace github.com/MakeNowJust/heredoc => github.com/MakeNowJust/heredoc v0.0.0-20170808103936-bb23615498cd
+
+replace github.com/NYTimes/gziphandler => github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46
+
+replace github.com/PuerkitoBio/urlesc => github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578
+
+replace github.com/agnivade/levenshtein => github.com/agnivade/levenshtein v1.0.1
+
+replace github.com/ajstarks/svgo => github.com/ajstarks/svgo v0.0.0-20180226025133-644b8db467af
+
+replace github.com/alecthomas/template => github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751
+
+replace github.com/alecthomas/units => github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4
+
+replace github.com/andreyvit/diff => github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883
+
+replace github.com/armon/consul-api => github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6
+
+replace github.com/asaskevich/govalidator => github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a
+
+replace github.com/beorn7/perks => github.com/beorn7/perks v1.0.1
+
+replace github.com/bgentry/speakeasy => github.com/bgentry/speakeasy v0.1.0
+
+replace github.com/bifurcation/mint => github.com/bifurcation/mint v0.0.0-20180715133206-93c51c6ce115
+
+replace github.com/cenkalti/backoff => github.com/cenkalti/backoff v2.1.1+incompatible
+
+replace github.com/census-instrumentation/opencensus-proto => github.com/census-instrumentation/opencensus-proto v0.2.1
+
+replace github.com/cespare/xxhash/v2 => github.com/cespare/xxhash/v2 v2.1.1
+
+replace github.com/chai2010/gettext-go => github.com/chai2010/gettext-go v0.0.0-20160711120539-c6fed771bfd5
+
+replace github.com/checkpoint-restore/go-criu/v4 => github.com/checkpoint-restore/go-criu/v4 v4.0.2
+
+replace github.com/cheekybits/genny => github.com/cheekybits/genny v0.0.0-20170328200008-9127e812e1e9
+
+replace github.com/chzyer/logex => github.com/chzyer/logex v1.1.10
+
+replace github.com/chzyer/readline => github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e
+
+replace github.com/chzyer/test => github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1
+
+replace github.com/cilium/ebpf => github.com/cilium/ebpf v0.0.0-20200702112145-1c8d4c9ef775
+
+replace github.com/cockroachdb/datadriven => github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa
+
+replace github.com/containerd/cgroups => github.com/containerd/cgroups v0.0.0-20200531161412-0dbf7f05ba59
+
+replace github.com/containerd/console => github.com/containerd/console v1.0.0
+
+replace github.com/containerd/containerd => github.com/containerd/containerd v1.3.3
+
+replace github.com/containerd/continuity => github.com/containerd/continuity v0.0.0-20190426062206-aaeac12a7ffc
+
+replace github.com/containerd/fifo => github.com/containerd/fifo v0.0.0-20190226154929-a9fb20d87448
+
+replace github.com/containerd/go-runc => github.com/containerd/go-runc v0.0.0-20180907222934-5a6d9f37cfa3
+
+replace github.com/containerd/ttrpc => github.com/containerd/ttrpc v1.0.0
+
+replace github.com/containerd/typeurl => github.com/containerd/typeurl v1.0.0
+
+replace github.com/coreos/bbolt => github.com/coreos/bbolt v1.3.2
+
+replace github.com/coreos/etcd => github.com/coreos/etcd v3.3.10+incompatible
+
+replace github.com/coreos/go-semver => github.com/coreos/go-semver v0.3.0
+
+replace github.com/coreos/go-systemd/v22 => github.com/coreos/go-systemd/v22 v22.1.0
+
+replace github.com/creack/pty => github.com/creack/pty v1.1.7
+
+replace github.com/cyphar/filepath-securejoin => github.com/cyphar/filepath-securejoin v0.2.2
+
+replace github.com/daviddengcn/go-colortext => github.com/daviddengcn/go-colortext v0.0.0-20160507010035-511bcaf42ccd
+
+replace github.com/dgrijalva/jwt-go => github.com/dgrijalva/jwt-go v3.2.0+incompatible
+
+replace github.com/dnaeon/go-vcr => github.com/dnaeon/go-vcr v1.0.1
+
+replace github.com/docker/spdystream => github.com/docker/spdystream v0.0.0-20160310174837-449fdfce4d96
+
+replace github.com/docopt/docopt-go => github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815
+
+replace github.com/dustin/go-humanize => github.com/dustin/go-humanize v1.0.0
+
+replace github.com/envoyproxy/go-control-plane => github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473
+
+replace github.com/envoyproxy/protoc-gen-validate => github.com/envoyproxy/protoc-gen-validate v0.1.0
+
+replace github.com/euank/go-kmsg-parser => github.com/euank/go-kmsg-parser v2.0.0+incompatible
+
+replace github.com/exponent-io/jsonpath => github.com/exponent-io/jsonpath v0.0.0-20151013193312-d6023ce2651d
+
+replace github.com/fatih/camelcase => github.com/fatih/camelcase v1.0.0
+
+replace github.com/fatih/color => github.com/fatih/color v1.7.0
+
+replace github.com/flynn/go-shlex => github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568
+
+replace github.com/fogleman/gg => github.com/fogleman/gg v1.2.1-0.20190220221249-0403632d5b90
+
+replace github.com/ghodss/yaml => github.com/ghodss/yaml v1.0.0
+
+replace github.com/go-acme/lego => github.com/go-acme/lego v2.5.0+incompatible
+
+replace github.com/go-gl/glfw/v3.3/glfw => github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72
+
+replace github.com/go-ini/ini => github.com/go-ini/ini v1.9.0
+
+replace github.com/go-kit/kit => github.com/go-kit/kit v0.9.0
+
+replace github.com/go-logfmt/logfmt => github.com/go-logfmt/logfmt v0.4.0
+
+replace github.com/go-logr/logr => github.com/go-logr/logr v0.2.0
+
+replace github.com/go-openapi/errors => github.com/go-openapi/errors v0.19.2
+
+replace github.com/go-openapi/jsonpointer => github.com/go-openapi/jsonpointer v0.19.3
+
+replace github.com/go-openapi/jsonreference => github.com/go-openapi/jsonreference v0.19.3
+
+replace github.com/go-openapi/runtime => github.com/go-openapi/runtime v0.19.4
+
+replace github.com/go-openapi/swag => github.com/go-openapi/swag v0.19.5
+
+replace github.com/go-stack/stack => github.com/go-stack/stack v1.8.0
+
+replace github.com/godbus/dbus/v5 => github.com/godbus/dbus/v5 v5.0.3
+
+replace github.com/golang/freetype => github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0
+
+replace github.com/golang/glog => github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
+
+replace github.com/golang/protobuf => github.com/golang/protobuf v1.4.2
+
+replace github.com/golangplus/bytes => github.com/golangplus/bytes v0.0.0-20160111154220-45c989fe5450
+
+replace github.com/golangplus/fmt => github.com/golangplus/fmt v0.0.0-20150411045040-2a5d6d7d2995
+
+replace github.com/golangplus/testing => github.com/golangplus/testing v0.0.0-20180327235837-af21d9c3145e
+
+replace github.com/google/btree => github.com/google/btree v1.0.0
+
+replace github.com/google/martian => github.com/google/martian v2.1.0+incompatible
+
+replace github.com/google/pprof => github.com/google/pprof v0.0.0-20191218002539-d4f498aebedc
+
+replace github.com/google/renameio => github.com/google/renameio v0.1.0
+
+replace github.com/googleapis/gax-go/v2 => github.com/googleapis/gax-go/v2 v2.0.5
+
+replace github.com/gophercloud/gophercloud => github.com/gophercloud/gophercloud v0.1.0
+
+replace github.com/gopherjs/gopherjs => github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1
+
+replace github.com/gorilla/mux => github.com/gorilla/mux v1.7.3
+
+replace github.com/gorilla/websocket => github.com/gorilla/websocket v1.4.0
+
+replace github.com/gregjones/httpcache => github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7
+
+replace github.com/grpc-ecosystem/go-grpc-middleware => github.com/grpc-ecosystem/go-grpc-middleware v1.0.1-0.20190118093823-f849b5445de4
+
+replace github.com/grpc-ecosystem/go-grpc-prometheus => github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0
+
+replace github.com/grpc-ecosystem/grpc-gateway => github.com/grpc-ecosystem/grpc-gateway v1.9.5
+
+replace github.com/hashicorp/go-syslog => github.com/hashicorp/go-syslog v1.0.0
+
+replace github.com/hashicorp/hcl => github.com/hashicorp/hcl v1.0.0
+
+replace github.com/hpcloud/tail => github.com/hpcloud/tail v1.0.0
+
+replace github.com/ianlancetaylor/demangle => github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6
+
+replace github.com/imdario/mergo => github.com/imdario/mergo v0.3.5
+
+replace github.com/inconshreveable/mousetrap => github.com/inconshreveable/mousetrap v1.0.0
+
+replace github.com/jimstudt/http-authentication => github.com/jimstudt/http-authentication v0.0.0-20140401203705-3eca13d6893a
+
+replace github.com/jmespath/go-jmespath => github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af
+
+replace github.com/jonboulle/clockwork => github.com/jonboulle/clockwork v0.1.0
+
+replace github.com/jstemmer/go-junit-report => github.com/jstemmer/go-junit-report v0.9.1
+
+replace github.com/jtolds/gls => github.com/jtolds/gls v4.20.0+incompatible
+
+replace github.com/julienschmidt/httprouter => github.com/julienschmidt/httprouter v1.2.0
+
+replace github.com/jung-kurt/gofpdf => github.com/jung-kurt/gofpdf v1.0.3-0.20190309125859-24315acbbda5
+
+replace github.com/karrick/godirwalk => github.com/karrick/godirwalk v1.7.5
+
+replace github.com/kisielk/errcheck => github.com/kisielk/errcheck v1.5.0
+
+replace github.com/kisielk/gotool => github.com/kisielk/gotool v1.0.0
+
+replace github.com/klauspost/cpuid => github.com/klauspost/cpuid v1.2.0
+
+replace github.com/konsorten/go-windows-terminal-sequences => github.com/konsorten/go-windows-terminal-sequences v1.0.3
+
+replace github.com/kr/logfmt => github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515
+
+replace github.com/kr/pretty => github.com/kr/pretty v0.2.0
+
+replace github.com/kr/pty => github.com/kr/pty v1.1.5
+
+replace github.com/kr/text => github.com/kr/text v0.1.0
+
+replace github.com/kylelemons/godebug => github.com/kylelemons/godebug v0.0.0-20170820004349-d65d576e9348
+
+replace github.com/liggitt/tabwriter => github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de
+
+replace github.com/lucas-clemente/aes12 => github.com/lucas-clemente/aes12 v0.0.0-20171027163421-cd47fb39b79f
+
+replace github.com/lucas-clemente/quic-clients => github.com/lucas-clemente/quic-clients v0.1.0
+
+replace github.com/lucas-clemente/quic-go => github.com/lucas-clemente/quic-go v0.10.2
+
+replace github.com/lucas-clemente/quic-go-certificates => github.com/lucas-clemente/quic-go-certificates v0.0.0-20160823095156-d2f86524cced
+
+replace github.com/mailru/easyjson => github.com/mailru/easyjson v0.7.0
+
+replace github.com/marten-seemann/qtls => github.com/marten-seemann/qtls v0.2.3
+
+replace github.com/mattn/go-colorable => github.com/mattn/go-colorable v0.0.9
+
+replace github.com/mattn/go-isatty => github.com/mattn/go-isatty v0.0.4
+
+replace github.com/mattn/go-runewidth => github.com/mattn/go-runewidth v0.0.2
+
+replace github.com/matttproud/golang_protobuf_extensions => github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369
+
+replace github.com/mholt/certmagic => github.com/mholt/certmagic v0.6.2-0.20190624175158-6a42ef9fe8c2
+
+replace github.com/mindprince/gonvml => github.com/mindprince/gonvml v0.0.0-20190828220739-9ebdce4bb989
+
+replace github.com/mistifyio/go-zfs => github.com/mistifyio/go-zfs v2.1.2-0.20190413222219-f784269be439+incompatible
+
+replace github.com/mitchellh/go-homedir => github.com/mitchellh/go-homedir v1.1.0
+
+replace github.com/mitchellh/go-wordwrap => github.com/mitchellh/go-wordwrap v1.0.0
+
+replace github.com/mitchellh/mapstructure => github.com/mitchellh/mapstructure v1.1.2
+
+replace github.com/moby/sys/mountinfo => github.com/moby/sys/mountinfo v0.1.3
+
+replace github.com/moby/term => github.com/moby/term v0.0.0-20200312100748-672ec06f55cd
+
+replace github.com/modern-go/concurrent => github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd
+
+replace github.com/modern-go/reflect2 => github.com/modern-go/reflect2 v1.0.1
+
+replace github.com/morikuni/aec => github.com/morikuni/aec v1.0.0
+
+replace github.com/mwitkow/go-conntrack => github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223
+
+replace github.com/mxk/go-flowrate => github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f
+
+replace github.com/naoina/go-stringutil => github.com/naoina/go-stringutil v0.1.0
+
+replace github.com/naoina/toml => github.com/naoina/toml v0.1.1
+
+replace github.com/olekukonko/tablewriter => github.com/olekukonko/tablewriter v0.0.0-20170122224234-a0225b3f23b5
+
+replace github.com/opencontainers/image-spec => github.com/opencontainers/image-spec v1.0.1
+
+replace github.com/opencontainers/runtime-spec => github.com/opencontainers/runtime-spec v1.0.3-0.20200520003142-237cc4f519e2
+
+replace github.com/pelletier/go-toml => github.com/pelletier/go-toml v1.2.0
+
+replace github.com/peterbourgon/diskv => github.com/peterbourgon/diskv v2.0.1+incompatible
+
+replace github.com/pquerna/cachecontrol => github.com/pquerna/cachecontrol v0.0.0-20171018203845-0dec1b30a021
+
+replace github.com/prometheus/procfs => github.com/prometheus/procfs v0.1.3
+
+replace github.com/remyoudompheng/bigfft => github.com/remyoudompheng/bigfft v0.0.0-20170806203942-52369c62f446
+
+replace github.com/rogpeppe/fastuuid => github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af
+
+replace github.com/rogpeppe/go-internal => github.com/rogpeppe/go-internal v1.3.0
+
+replace github.com/rubiojr/go-vhd => github.com/rubiojr/go-vhd v0.0.0-20200706105327-02e210299021
+
+replace github.com/russross/blackfriday => github.com/russross/blackfriday v1.5.2
+
+replace github.com/russross/blackfriday/v2 => github.com/russross/blackfriday/v2 v2.0.1
+
+replace github.com/satori/go.uuid => github.com/satori/go.uuid v1.2.0
+
+replace github.com/seccomp/libseccomp-golang => github.com/seccomp/libseccomp-golang v0.9.1
+
+replace github.com/sergi/go-diff => github.com/sergi/go-diff v1.0.0
+
+replace github.com/shurcooL/sanitized_anchor_name => github.com/shurcooL/sanitized_anchor_name v1.0.0
+
+replace github.com/sirupsen/logrus => github.com/sirupsen/logrus v1.6.0
+
+replace github.com/smartystreets/assertions => github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d
+
+replace github.com/smartystreets/goconvey => github.com/smartystreets/goconvey v1.6.4
+
+replace github.com/soheilhy/cmux => github.com/soheilhy/cmux v0.1.4
+
+replace github.com/spf13/cast => github.com/spf13/cast v1.3.0
+
+replace github.com/stretchr/objx => github.com/stretchr/objx v0.2.0
+
+replace github.com/syndtr/gocapability => github.com/syndtr/gocapability v0.0.0-20180916011248-d98352740cb2
+
+replace github.com/tidwall/pretty => github.com/tidwall/pretty v1.0.0
+
+replace github.com/tmc/grpc-websocket-proxy => github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5
+
+replace github.com/ugorji/go => github.com/ugorji/go v1.1.4
+
+replace github.com/urfave/cli => github.com/urfave/cli v1.22.2
+
+replace github.com/vektah/gqlparser => github.com/vektah/gqlparser v1.1.2
+
+replace github.com/vishvananda/netns => github.com/vishvananda/netns v0.0.0-20200520041808-52d707b772fe
+
+replace github.com/xiang90/probing => github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2
+
+replace github.com/xlab/handysort => github.com/xlab/handysort v0.0.0-20150421192137-fb3537ed64a1
+
+replace github.com/xordataexchange/crypt => github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77
+
+replace github.com/yuin/goldmark => github.com/yuin/goldmark v1.2.1
+
+replace go.etcd.io/bbolt => go.etcd.io/bbolt v1.3.5
+
+replace go.mongodb.org/mongo-driver => go.mongodb.org/mongo-driver v1.1.2
+
+replace go.opencensus.io => go.opencensus.io v0.22.2
+
+replace go.uber.org/atomic => go.uber.org/atomic v1.4.0
+
+replace go.uber.org/multierr => go.uber.org/multierr v1.1.0
+
+replace go.uber.org/zap => go.uber.org/zap v1.10.0
+
+replace golang.org/x/exp => golang.org/x/exp v0.0.0-20191227195350-da58074b4299
+
+replace golang.org/x/image => golang.org/x/image v0.0.0-20190802002840-cff245a6509b
+
+replace golang.org/x/lint => golang.org/x/lint v0.0.0-20191125180803-fdd1cda4f05f
+
+replace golang.org/x/mobile => golang.org/x/mobile v0.0.0-20190719004257-d2bd2a29d028
+
+replace golang.org/x/mod => golang.org/x/mod v0.3.0
+
+replace golang.org/x/sync => golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9
+
+replace golang.org/x/text => golang.org/x/text v0.3.3
+
+replace golang.org/x/xerrors => golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1
+
+replace gonum.org/v1/plot => gonum.org/v1/plot v0.0.0-20190515093506-e2840ee46a6b
+
+replace google.golang.org/appengine => google.golang.org/appengine v1.6.5
+
+replace google.golang.org/genproto => google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013
+
+replace google.golang.org/protobuf => google.golang.org/protobuf v1.24.0
+
+replace gopkg.in/alecthomas/kingpin.v2 => gopkg.in/alecthomas/kingpin.v2 v2.2.6
+
+replace gopkg.in/check.v1 => gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15
+
+replace gopkg.in/cheggaaa/pb.v1 => gopkg.in/cheggaaa/pb.v1 v1.0.25
+
+replace gopkg.in/errgo.v2 => gopkg.in/errgo.v2 v2.1.0
+
+replace gopkg.in/fsnotify.v1 => gopkg.in/fsnotify.v1 v1.4.7
+
+replace gopkg.in/inf.v0 => gopkg.in/inf.v0 v0.9.1
+
+replace gopkg.in/mcuadros/go-syslog.v2 => gopkg.in/mcuadros/go-syslog.v2 v2.2.1
+
+replace gopkg.in/natefinch/lumberjack.v2 => gopkg.in/natefinch/lumberjack.v2 v2.0.0
+
+replace gopkg.in/resty.v1 => gopkg.in/resty.v1 v1.12.0
+
+replace gopkg.in/tomb.v1 => gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7
+
+replace gopkg.in/warnings.v0 => gopkg.in/warnings.v0 v0.1.1
+
+replace gotest.tools => gotest.tools v2.2.0+incompatible
+
+replace gotest.tools/v3 => gotest.tools/v3 v3.0.2
+
+replace honnef.co/go/tools => honnef.co/go/tools v0.0.1-2019.2.3
+
+replace modernc.org/cc => modernc.org/cc v1.0.0
+
+replace modernc.org/golex => modernc.org/golex v1.0.0
+
+replace modernc.org/mathutil => modernc.org/mathutil v1.0.0
+
+replace modernc.org/strutil => modernc.org/strutil v1.0.0
+
+replace modernc.org/xc => modernc.org/xc v1.0.0
+
+replace rsc.io/pdf => rsc.io/pdf v0.1.1
+
+replace sigs.k8s.io/apiserver-network-proxy/konnectivity-client => sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.15
+
+replace sigs.k8s.io/structured-merge-diff/v4 => sigs.k8s.io/structured-merge-diff/v4 v4.1.2
+
+replace vbom.ml/util => vbom.ml/util v0.0.0-20160121211510-db5cfe13f5cc

--- a/staging/src/k8s.io/metrics/go.mod
+++ b/staging/src/k8s.io/metrics/go.mod
@@ -5,12 +5,120 @@ module k8s.io/metrics
 go 1.15
 
 require (
+	bitbucket.org/bertimus9/systemstat v0.0.0-20180207000608-0eeff89b0690
+	github.com/Azure/azure-sdk-for-go v43.0.0+incompatible
+	github.com/Azure/go-autorest/autorest v0.9.6
+	github.com/Azure/go-autorest/autorest/adal v0.8.2
+	github.com/Azure/go-autorest/autorest/to v0.2.0
+	github.com/GoogleCloudPlatform/k8s-cloud-provider v0.0.0-20200415212048-7901bc822317
+	github.com/JeffAshton/win_pdh v0.0.0-20161109143554-76bb4ee9f0ab
+	github.com/Microsoft/go-winio v0.4.15-0.20190919025122-fc70bd9a86b5
+	github.com/Microsoft/hcsshim v0.8.10-0.20200715222032-5eafd1556990
+	github.com/PuerkitoBio/purell v1.1.1
+	github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e
+	github.com/auth0/go-jwt-middleware v0.0.0-20170425171159-5493cabe49f7
+	github.com/aws/aws-sdk-go v1.28.2
+	github.com/blang/semver v3.5.0+incompatible
+	github.com/boltdb/bolt v1.3.1
+	github.com/caddyserver/caddy v1.0.3
+	github.com/clusterhq/flocker-go v0.0.0-20160920122132-2b8b7259d313
+	github.com/codegangsta/negroni v1.0.0
+	github.com/container-storage-interface/spec v1.2.0
+	github.com/containernetworking/cni v0.8.0
+	github.com/coredns/corefile-migration v1.0.10
+	github.com/coreos/go-oidc v2.1.0+incompatible
+	github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e
+	github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f
+	github.com/cpuguy83/go-md2man/v2 v2.0.0
+	github.com/davecgh/go-spew v1.1.1
+	github.com/docker/distribution v2.7.1+incompatible
+	github.com/docker/docker v1.4.2-0.20200309214505-aa6a9891b09c
+	github.com/docker/go-connections v0.4.0
+	github.com/docker/go-units v0.4.0
+	github.com/elazarl/goproxy v0.0.0-20180725130230-947c36da3153
+	github.com/emicklei/go-restful v2.9.5+incompatible
+	github.com/evanphx/json-patch v4.9.0+incompatible
+	github.com/fsnotify/fsnotify v1.4.9
+	github.com/go-bindata/go-bindata v3.1.1+incompatible
+	github.com/go-openapi/analysis v0.19.5
+	github.com/go-openapi/loads v0.19.4
+	github.com/go-openapi/spec v0.19.3
+	github.com/go-openapi/strfmt v0.19.3
+	github.com/go-openapi/validate v0.19.5
+	github.com/go-ozzo/ozzo-validation v3.5.0+incompatible
 	github.com/gogo/protobuf v1.3.2
+	github.com/golang/groupcache v0.0.0-20191227052852-215e87163ea7
+	github.com/golang/mock v1.3.1
+	github.com/google/cadvisor v0.37.5
+	github.com/google/go-cmp v0.4.0
+	github.com/google/gofuzz v1.1.0
+	github.com/google/uuid v1.1.1
+	github.com/googleapis/gnostic v0.4.1
+	github.com/gorilla/context v1.1.1
+	github.com/hashicorp/golang-lru v0.5.1
+	github.com/heketi/heketi v9.0.1-0.20190917153846-c2e2a4ab7ab9+incompatible
+	github.com/heketi/tests v0.0.0-20151005000721-f3775cbcefd6
+	github.com/ishidawataru/sctp v0.0.0-20190723014705-7c296d48a2b5
+	github.com/json-iterator/go v1.1.10
+	github.com/libopenstorage/openstorage v1.0.0
+	github.com/lithammer/dedent v1.1.0
+	github.com/lpabon/godbc v0.1.1
+	github.com/magiconair/properties v1.8.1
+	github.com/miekg/dns v1.1.4
+	github.com/moby/ipvs v1.0.1
+	github.com/mohae/deepcopy v0.0.0-20170603005431-491d3605edfb
+	github.com/mrunalp/fileutils v0.0.0-20200520151820-abd8a0e76976
+	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822
+	github.com/mvdan/xurls v1.1.0
+	github.com/onsi/ginkgo v1.11.0
+	github.com/onsi/gomega v1.7.0
+	github.com/opencontainers/go-digest v1.0.0-rc1
+	github.com/opencontainers/runc v1.0.1
+	github.com/opencontainers/selinux v1.5.2
+	github.com/pkg/errors v0.9.1
+	github.com/pmezard/go-difflib v1.0.0
+	github.com/prometheus/client_golang v1.7.1
+	github.com/prometheus/client_model v0.2.0
+	github.com/prometheus/common v0.10.0
+	github.com/quobyte/api v0.1.2
+	github.com/robfig/cron v1.1.0
+	github.com/spf13/afero v1.2.2
+	github.com/spf13/cobra v1.0.0
+	github.com/spf13/jwalterweatherman v1.1.0
+	github.com/spf13/pflag v1.0.5
+	github.com/spf13/viper v1.4.0
+	github.com/storageos/go-api v0.0.0-20180912212459-343b3eff91fc
 	github.com/stretchr/testify v1.4.0
+	github.com/thecodeteam/goscaleio v0.1.0
+	github.com/urfave/negroni v1.0.0
+	github.com/vishvananda/netlink v1.1.0
+	github.com/vmware/govmomi v0.20.3
+	go.etcd.io/etcd v0.5.0-alpha.5.0.20200819165624-17cef6e3e9d5
+	golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9
+	golang.org/x/net v0.0.0-20201110031124-69a78807bb2b
+	golang.org/x/oauth2 v0.0.0-20191202225959-858c2ad4c8b6
+	golang.org/x/sys v0.0.0-20201112073958-5cba982894dd
+	golang.org/x/time v0.0.0-20191024005414-555d28b269f0
+	golang.org/x/tools v0.0.0-20210106214847-113979e3529a
+	gonum.org/v1/gonum v0.6.2
+	gonum.org/v1/netlib v0.0.0-20190331212654-76723241ea4e
+	google.golang.org/api v0.15.1
+	google.golang.org/grpc v1.27.0
+	gopkg.in/gcfg.v1 v1.2.0
+	gopkg.in/square/go-jose.v2 v2.2.2
+	gopkg.in/yaml.v2 v2.2.8
 	k8s.io/api v0.0.0
 	k8s.io/apimachinery v0.0.0
 	k8s.io/client-go v0.0.0
 	k8s.io/code-generator v0.0.0
+	k8s.io/gengo v0.0.0-20200428234225-8167cfdcfc14
+	k8s.io/heapster v1.2.0-beta.1
+	k8s.io/klog/v2 v2.2.0
+	k8s.io/kube-openapi v0.0.0-20200805222855-6aeccd4b50c6
+	k8s.io/system-validators v1.1.2
+	k8s.io/utils v0.0.0-20200729134348-d5654de09c73
+	sigs.k8s.io/kustomize v2.0.3+incompatible
+	sigs.k8s.io/yaml v1.2.0
 )
 
 replace (
@@ -20,3 +128,669 @@ replace (
 	k8s.io/code-generator => ../code-generator
 	k8s.io/metrics => ../metrics
 )
+
+replace github.com/auth0/go-jwt-middleware => github.com/auth0/go-jwt-middleware v0.0.0-20170425171159-5493cabe49f7
+
+replace github.com/boltdb/bolt => github.com/boltdb/bolt v1.3.1
+
+replace github.com/codegangsta/negroni => github.com/codegangsta/negroni v1.0.0
+
+replace github.com/go-ozzo/ozzo-validation => github.com/go-ozzo/ozzo-validation v3.5.0+incompatible
+
+replace github.com/gorilla/context => github.com/gorilla/context v1.1.1
+
+replace github.com/heketi/tests => github.com/heketi/tests v0.0.0-20151005000721-f3775cbcefd6
+
+replace github.com/lpabon/godbc => github.com/lpabon/godbc v0.1.1
+
+replace github.com/magiconair/properties => github.com/magiconair/properties v1.8.1
+
+replace github.com/mohae/deepcopy => github.com/mohae/deepcopy v0.0.0-20170603005431-491d3605edfb
+
+replace github.com/spf13/jwalterweatherman => github.com/spf13/jwalterweatherman v1.1.0
+
+replace github.com/urfave/negroni => github.com/urfave/negroni v1.0.0
+
+replace gonum.org/v1/netlib => gonum.org/v1/netlib v0.0.0-20190331212654-76723241ea4e
+
+replace bitbucket.org/bertimus9/systemstat => bitbucket.org/bertimus9/systemstat v0.0.0-20180207000608-0eeff89b0690
+
+replace github.com/Azure/azure-sdk-for-go => github.com/Azure/azure-sdk-for-go v43.0.0+incompatible
+
+replace github.com/Azure/go-autorest/autorest => github.com/Azure/go-autorest/autorest v0.9.6
+
+replace github.com/Azure/go-autorest/autorest/adal => github.com/Azure/go-autorest/autorest/adal v0.8.2
+
+replace github.com/Azure/go-autorest/autorest/to => github.com/Azure/go-autorest/autorest/to v0.2.0
+
+replace github.com/GoogleCloudPlatform/k8s-cloud-provider => github.com/GoogleCloudPlatform/k8s-cloud-provider v0.0.0-20200415212048-7901bc822317
+
+replace github.com/JeffAshton/win_pdh => github.com/JeffAshton/win_pdh v0.0.0-20161109143554-76bb4ee9f0ab
+
+replace github.com/Microsoft/go-winio => github.com/Microsoft/go-winio v0.4.15-0.20190919025122-fc70bd9a86b5
+
+replace github.com/Microsoft/hcsshim => github.com/Microsoft/hcsshim v0.8.10-0.20200715222032-5eafd1556990
+
+replace github.com/PuerkitoBio/purell => github.com/PuerkitoBio/purell v1.1.1
+
+replace github.com/armon/circbuf => github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e
+
+replace github.com/aws/aws-sdk-go => github.com/aws/aws-sdk-go v1.28.2
+
+replace github.com/blang/semver => github.com/blang/semver v3.5.0+incompatible
+
+replace github.com/caddyserver/caddy => github.com/caddyserver/caddy v1.0.3
+
+replace github.com/clusterhq/flocker-go => github.com/clusterhq/flocker-go v0.0.0-20160920122132-2b8b7259d313
+
+replace github.com/container-storage-interface/spec => github.com/container-storage-interface/spec v1.2.0
+
+replace github.com/containernetworking/cni => github.com/containernetworking/cni v0.8.0
+
+replace github.com/coredns/corefile-migration => github.com/coredns/corefile-migration v1.0.10
+
+replace github.com/coreos/go-oidc => github.com/coreos/go-oidc v2.1.0+incompatible
+
+replace github.com/coreos/go-systemd => github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e
+
+replace github.com/coreos/pkg => github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f
+
+replace github.com/cpuguy83/go-md2man/v2 => github.com/cpuguy83/go-md2man/v2 v2.0.0
+
+replace github.com/davecgh/go-spew => github.com/davecgh/go-spew v1.1.1
+
+replace github.com/docker/distribution => github.com/docker/distribution v2.7.1+incompatible
+
+replace github.com/docker/docker => github.com/docker/docker v1.4.2-0.20200309214505-aa6a9891b09c
+
+replace github.com/docker/go-connections => github.com/docker/go-connections v0.4.0
+
+replace github.com/docker/go-units => github.com/docker/go-units v0.4.0
+
+replace github.com/elazarl/goproxy => github.com/elazarl/goproxy v0.0.0-20180725130230-947c36da3153
+
+replace github.com/emicklei/go-restful => github.com/emicklei/go-restful v2.9.5+incompatible
+
+replace github.com/evanphx/json-patch => github.com/evanphx/json-patch v4.9.0+incompatible
+
+replace github.com/fsnotify/fsnotify => github.com/fsnotify/fsnotify v1.4.9
+
+replace github.com/go-bindata/go-bindata => github.com/go-bindata/go-bindata v3.1.1+incompatible
+
+replace github.com/go-openapi/analysis => github.com/go-openapi/analysis v0.19.5
+
+replace github.com/go-openapi/loads => github.com/go-openapi/loads v0.19.4
+
+replace github.com/go-openapi/spec => github.com/go-openapi/spec v0.19.3
+
+replace github.com/go-openapi/strfmt => github.com/go-openapi/strfmt v0.19.3
+
+replace github.com/go-openapi/validate => github.com/go-openapi/validate v0.19.5
+
+replace github.com/gogo/protobuf => github.com/gogo/protobuf v1.3.2
+
+replace github.com/golang/groupcache => github.com/golang/groupcache v0.0.0-20191227052852-215e87163ea7
+
+replace github.com/golang/mock => github.com/golang/mock v1.3.1
+
+replace github.com/google/cadvisor => github.com/google/cadvisor v0.37.5
+
+replace github.com/google/go-cmp => github.com/google/go-cmp v0.4.0
+
+replace github.com/google/gofuzz => github.com/google/gofuzz v1.1.0
+
+replace github.com/google/uuid => github.com/google/uuid v1.1.1
+
+replace github.com/googleapis/gnostic => github.com/googleapis/gnostic v0.4.1
+
+replace github.com/hashicorp/golang-lru => github.com/hashicorp/golang-lru v0.5.1
+
+replace github.com/heketi/heketi => github.com/heketi/heketi v9.0.1-0.20190917153846-c2e2a4ab7ab9+incompatible
+
+replace github.com/ishidawataru/sctp => github.com/ishidawataru/sctp v0.0.0-20190723014705-7c296d48a2b5
+
+replace github.com/json-iterator/go => github.com/json-iterator/go v1.1.10
+
+replace github.com/libopenstorage/openstorage => github.com/libopenstorage/openstorage v1.0.0
+
+replace github.com/lithammer/dedent => github.com/lithammer/dedent v1.1.0
+
+replace github.com/miekg/dns => github.com/miekg/dns v1.1.4
+
+replace github.com/moby/ipvs => github.com/moby/ipvs v1.0.1
+
+replace github.com/mrunalp/fileutils => github.com/mrunalp/fileutils v0.0.0-20200520151820-abd8a0e76976
+
+replace github.com/munnerz/goautoneg => github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822
+
+replace github.com/mvdan/xurls => github.com/mvdan/xurls v1.1.0
+
+replace github.com/onsi/ginkgo => github.com/onsi/ginkgo v1.11.0
+
+replace github.com/onsi/gomega => github.com/onsi/gomega v1.7.0
+
+replace github.com/opencontainers/go-digest => github.com/opencontainers/go-digest v1.0.0-rc1
+
+replace github.com/opencontainers/runc => github.com/opencontainers/runc v1.0.1
+
+replace github.com/opencontainers/selinux => github.com/opencontainers/selinux v1.5.2
+
+replace github.com/pkg/errors => github.com/pkg/errors v0.9.1
+
+replace github.com/pmezard/go-difflib => github.com/pmezard/go-difflib v1.0.0
+
+replace github.com/prometheus/client_golang => github.com/prometheus/client_golang v1.7.1
+
+replace github.com/prometheus/client_model => github.com/prometheus/client_model v0.2.0
+
+replace github.com/prometheus/common => github.com/prometheus/common v0.10.0
+
+replace github.com/quobyte/api => github.com/quobyte/api v0.1.2
+
+replace github.com/robfig/cron => github.com/robfig/cron v1.1.0
+
+replace github.com/spf13/afero => github.com/spf13/afero v1.2.2
+
+replace github.com/spf13/cobra => github.com/spf13/cobra v1.0.0
+
+replace github.com/spf13/pflag => github.com/spf13/pflag v1.0.5
+
+replace github.com/spf13/viper => github.com/spf13/viper v1.4.0
+
+replace github.com/storageos/go-api => github.com/storageos/go-api v0.0.0-20180912212459-343b3eff91fc
+
+replace github.com/stretchr/testify => github.com/stretchr/testify v1.4.0
+
+replace github.com/thecodeteam/goscaleio => github.com/thecodeteam/goscaleio v0.1.0
+
+replace github.com/vishvananda/netlink => github.com/vishvananda/netlink v1.1.0
+
+replace github.com/vmware/govmomi => github.com/vmware/govmomi v0.20.3
+
+replace go.etcd.io/etcd => go.etcd.io/etcd v0.5.0-alpha.5.0.20200819165624-17cef6e3e9d5
+
+replace golang.org/x/crypto => golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9
+
+replace golang.org/x/net => golang.org/x/net v0.0.0-20201110031124-69a78807bb2b
+
+replace golang.org/x/oauth2 => golang.org/x/oauth2 v0.0.0-20191202225959-858c2ad4c8b6
+
+replace golang.org/x/sys => golang.org/x/sys v0.0.0-20201112073958-5cba982894dd
+
+replace golang.org/x/time => golang.org/x/time v0.0.0-20191024005414-555d28b269f0
+
+replace golang.org/x/tools => golang.org/x/tools v0.0.0-20210106214847-113979e3529a
+
+replace gonum.org/v1/gonum => gonum.org/v1/gonum v0.6.2
+
+replace google.golang.org/api => google.golang.org/api v0.15.1
+
+replace google.golang.org/grpc => google.golang.org/grpc v1.27.0
+
+replace gopkg.in/gcfg.v1 => gopkg.in/gcfg.v1 v1.2.0
+
+replace gopkg.in/square/go-jose.v2 => gopkg.in/square/go-jose.v2 v2.2.2
+
+replace gopkg.in/yaml.v2 => gopkg.in/yaml.v2 v2.2.8
+
+replace k8s.io/gengo => k8s.io/gengo v0.0.0-20200428234225-8167cfdcfc14
+
+replace k8s.io/heapster => k8s.io/heapster v1.2.0-beta.1
+
+replace k8s.io/klog/v2 => k8s.io/klog/v2 v2.2.0
+
+replace k8s.io/kube-openapi => k8s.io/kube-openapi v0.0.0-20200805222855-6aeccd4b50c6
+
+replace k8s.io/system-validators => k8s.io/system-validators v1.1.2
+
+replace k8s.io/utils => k8s.io/utils v0.0.0-20200729134348-d5654de09c73
+
+replace sigs.k8s.io/kustomize => sigs.k8s.io/kustomize v2.0.3+incompatible
+
+replace sigs.k8s.io/yaml => sigs.k8s.io/yaml v1.2.0
+
+replace cloud.google.com/go => cloud.google.com/go v0.51.0
+
+replace cloud.google.com/go/bigquery => cloud.google.com/go/bigquery v1.0.1
+
+replace cloud.google.com/go/datastore => cloud.google.com/go/datastore v1.0.0
+
+replace cloud.google.com/go/pubsub => cloud.google.com/go/pubsub v1.0.1
+
+replace cloud.google.com/go/storage => cloud.google.com/go/storage v1.0.0
+
+replace dmitri.shuralyov.com/gpu/mtl => dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9
+
+replace github.com/Azure/go-ansiterm => github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78
+
+replace github.com/Azure/go-autorest/autorest/date => github.com/Azure/go-autorest/autorest/date v0.2.0
+
+replace github.com/Azure/go-autorest/autorest/mocks => github.com/Azure/go-autorest/autorest/mocks v0.3.0
+
+replace github.com/Azure/go-autorest/autorest/validation => github.com/Azure/go-autorest/autorest/validation v0.1.0
+
+replace github.com/Azure/go-autorest/logger => github.com/Azure/go-autorest/logger v0.1.0
+
+replace github.com/Azure/go-autorest/tracing => github.com/Azure/go-autorest/tracing v0.5.0
+
+replace github.com/BurntSushi/toml => github.com/BurntSushi/toml v0.3.1
+
+replace github.com/BurntSushi/xgb => github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802
+
+replace github.com/MakeNowJust/heredoc => github.com/MakeNowJust/heredoc v0.0.0-20170808103936-bb23615498cd
+
+replace github.com/NYTimes/gziphandler => github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46
+
+replace github.com/PuerkitoBio/urlesc => github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578
+
+replace github.com/agnivade/levenshtein => github.com/agnivade/levenshtein v1.0.1
+
+replace github.com/ajstarks/svgo => github.com/ajstarks/svgo v0.0.0-20180226025133-644b8db467af
+
+replace github.com/alecthomas/template => github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751
+
+replace github.com/alecthomas/units => github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4
+
+replace github.com/andreyvit/diff => github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883
+
+replace github.com/armon/consul-api => github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6
+
+replace github.com/asaskevich/govalidator => github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a
+
+replace github.com/beorn7/perks => github.com/beorn7/perks v1.0.1
+
+replace github.com/bgentry/speakeasy => github.com/bgentry/speakeasy v0.1.0
+
+replace github.com/bifurcation/mint => github.com/bifurcation/mint v0.0.0-20180715133206-93c51c6ce115
+
+replace github.com/cenkalti/backoff => github.com/cenkalti/backoff v2.1.1+incompatible
+
+replace github.com/census-instrumentation/opencensus-proto => github.com/census-instrumentation/opencensus-proto v0.2.1
+
+replace github.com/cespare/xxhash/v2 => github.com/cespare/xxhash/v2 v2.1.1
+
+replace github.com/chai2010/gettext-go => github.com/chai2010/gettext-go v0.0.0-20160711120539-c6fed771bfd5
+
+replace github.com/checkpoint-restore/go-criu/v4 => github.com/checkpoint-restore/go-criu/v4 v4.0.2
+
+replace github.com/cheekybits/genny => github.com/cheekybits/genny v0.0.0-20170328200008-9127e812e1e9
+
+replace github.com/chzyer/logex => github.com/chzyer/logex v1.1.10
+
+replace github.com/chzyer/readline => github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e
+
+replace github.com/chzyer/test => github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1
+
+replace github.com/cilium/ebpf => github.com/cilium/ebpf v0.0.0-20200702112145-1c8d4c9ef775
+
+replace github.com/cockroachdb/datadriven => github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa
+
+replace github.com/containerd/cgroups => github.com/containerd/cgroups v0.0.0-20200531161412-0dbf7f05ba59
+
+replace github.com/containerd/console => github.com/containerd/console v1.0.0
+
+replace github.com/containerd/containerd => github.com/containerd/containerd v1.3.3
+
+replace github.com/containerd/continuity => github.com/containerd/continuity v0.0.0-20190426062206-aaeac12a7ffc
+
+replace github.com/containerd/fifo => github.com/containerd/fifo v0.0.0-20190226154929-a9fb20d87448
+
+replace github.com/containerd/go-runc => github.com/containerd/go-runc v0.0.0-20180907222934-5a6d9f37cfa3
+
+replace github.com/containerd/ttrpc => github.com/containerd/ttrpc v1.0.0
+
+replace github.com/containerd/typeurl => github.com/containerd/typeurl v1.0.0
+
+replace github.com/coreos/bbolt => github.com/coreos/bbolt v1.3.2
+
+replace github.com/coreos/etcd => github.com/coreos/etcd v3.3.10+incompatible
+
+replace github.com/coreos/go-semver => github.com/coreos/go-semver v0.3.0
+
+replace github.com/coreos/go-systemd/v22 => github.com/coreos/go-systemd/v22 v22.1.0
+
+replace github.com/creack/pty => github.com/creack/pty v1.1.7
+
+replace github.com/cyphar/filepath-securejoin => github.com/cyphar/filepath-securejoin v0.2.2
+
+replace github.com/daviddengcn/go-colortext => github.com/daviddengcn/go-colortext v0.0.0-20160507010035-511bcaf42ccd
+
+replace github.com/dgrijalva/jwt-go => github.com/dgrijalva/jwt-go v3.2.0+incompatible
+
+replace github.com/dnaeon/go-vcr => github.com/dnaeon/go-vcr v1.0.1
+
+replace github.com/docker/spdystream => github.com/docker/spdystream v0.0.0-20160310174837-449fdfce4d96
+
+replace github.com/docopt/docopt-go => github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815
+
+replace github.com/dustin/go-humanize => github.com/dustin/go-humanize v1.0.0
+
+replace github.com/envoyproxy/go-control-plane => github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473
+
+replace github.com/envoyproxy/protoc-gen-validate => github.com/envoyproxy/protoc-gen-validate v0.1.0
+
+replace github.com/euank/go-kmsg-parser => github.com/euank/go-kmsg-parser v2.0.0+incompatible
+
+replace github.com/exponent-io/jsonpath => github.com/exponent-io/jsonpath v0.0.0-20151013193312-d6023ce2651d
+
+replace github.com/fatih/camelcase => github.com/fatih/camelcase v1.0.0
+
+replace github.com/fatih/color => github.com/fatih/color v1.7.0
+
+replace github.com/flynn/go-shlex => github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568
+
+replace github.com/fogleman/gg => github.com/fogleman/gg v1.2.1-0.20190220221249-0403632d5b90
+
+replace github.com/ghodss/yaml => github.com/ghodss/yaml v1.0.0
+
+replace github.com/go-acme/lego => github.com/go-acme/lego v2.5.0+incompatible
+
+replace github.com/go-gl/glfw/v3.3/glfw => github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72
+
+replace github.com/go-ini/ini => github.com/go-ini/ini v1.9.0
+
+replace github.com/go-kit/kit => github.com/go-kit/kit v0.9.0
+
+replace github.com/go-logfmt/logfmt => github.com/go-logfmt/logfmt v0.4.0
+
+replace github.com/go-logr/logr => github.com/go-logr/logr v0.2.0
+
+replace github.com/go-openapi/errors => github.com/go-openapi/errors v0.19.2
+
+replace github.com/go-openapi/jsonpointer => github.com/go-openapi/jsonpointer v0.19.3
+
+replace github.com/go-openapi/jsonreference => github.com/go-openapi/jsonreference v0.19.3
+
+replace github.com/go-openapi/runtime => github.com/go-openapi/runtime v0.19.4
+
+replace github.com/go-openapi/swag => github.com/go-openapi/swag v0.19.5
+
+replace github.com/go-stack/stack => github.com/go-stack/stack v1.8.0
+
+replace github.com/godbus/dbus/v5 => github.com/godbus/dbus/v5 v5.0.3
+
+replace github.com/golang/freetype => github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0
+
+replace github.com/golang/glog => github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
+
+replace github.com/golang/protobuf => github.com/golang/protobuf v1.4.2
+
+replace github.com/golangplus/bytes => github.com/golangplus/bytes v0.0.0-20160111154220-45c989fe5450
+
+replace github.com/golangplus/fmt => github.com/golangplus/fmt v0.0.0-20150411045040-2a5d6d7d2995
+
+replace github.com/golangplus/testing => github.com/golangplus/testing v0.0.0-20180327235837-af21d9c3145e
+
+replace github.com/google/btree => github.com/google/btree v1.0.0
+
+replace github.com/google/martian => github.com/google/martian v2.1.0+incompatible
+
+replace github.com/google/pprof => github.com/google/pprof v0.0.0-20191218002539-d4f498aebedc
+
+replace github.com/google/renameio => github.com/google/renameio v0.1.0
+
+replace github.com/googleapis/gax-go/v2 => github.com/googleapis/gax-go/v2 v2.0.5
+
+replace github.com/gophercloud/gophercloud => github.com/gophercloud/gophercloud v0.1.0
+
+replace github.com/gopherjs/gopherjs => github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1
+
+replace github.com/gorilla/mux => github.com/gorilla/mux v1.7.3
+
+replace github.com/gorilla/websocket => github.com/gorilla/websocket v1.4.0
+
+replace github.com/gregjones/httpcache => github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7
+
+replace github.com/grpc-ecosystem/go-grpc-middleware => github.com/grpc-ecosystem/go-grpc-middleware v1.0.1-0.20190118093823-f849b5445de4
+
+replace github.com/grpc-ecosystem/go-grpc-prometheus => github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0
+
+replace github.com/grpc-ecosystem/grpc-gateway => github.com/grpc-ecosystem/grpc-gateway v1.9.5
+
+replace github.com/hashicorp/go-syslog => github.com/hashicorp/go-syslog v1.0.0
+
+replace github.com/hashicorp/hcl => github.com/hashicorp/hcl v1.0.0
+
+replace github.com/hpcloud/tail => github.com/hpcloud/tail v1.0.0
+
+replace github.com/ianlancetaylor/demangle => github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6
+
+replace github.com/imdario/mergo => github.com/imdario/mergo v0.3.5
+
+replace github.com/inconshreveable/mousetrap => github.com/inconshreveable/mousetrap v1.0.0
+
+replace github.com/jimstudt/http-authentication => github.com/jimstudt/http-authentication v0.0.0-20140401203705-3eca13d6893a
+
+replace github.com/jmespath/go-jmespath => github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af
+
+replace github.com/jonboulle/clockwork => github.com/jonboulle/clockwork v0.1.0
+
+replace github.com/jstemmer/go-junit-report => github.com/jstemmer/go-junit-report v0.9.1
+
+replace github.com/jtolds/gls => github.com/jtolds/gls v4.20.0+incompatible
+
+replace github.com/julienschmidt/httprouter => github.com/julienschmidt/httprouter v1.2.0
+
+replace github.com/jung-kurt/gofpdf => github.com/jung-kurt/gofpdf v1.0.3-0.20190309125859-24315acbbda5
+
+replace github.com/karrick/godirwalk => github.com/karrick/godirwalk v1.7.5
+
+replace github.com/kisielk/errcheck => github.com/kisielk/errcheck v1.5.0
+
+replace github.com/kisielk/gotool => github.com/kisielk/gotool v1.0.0
+
+replace github.com/klauspost/cpuid => github.com/klauspost/cpuid v1.2.0
+
+replace github.com/konsorten/go-windows-terminal-sequences => github.com/konsorten/go-windows-terminal-sequences v1.0.3
+
+replace github.com/kr/logfmt => github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515
+
+replace github.com/kr/pretty => github.com/kr/pretty v0.2.0
+
+replace github.com/kr/pty => github.com/kr/pty v1.1.5
+
+replace github.com/kr/text => github.com/kr/text v0.1.0
+
+replace github.com/kylelemons/godebug => github.com/kylelemons/godebug v0.0.0-20170820004349-d65d576e9348
+
+replace github.com/liggitt/tabwriter => github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de
+
+replace github.com/lucas-clemente/aes12 => github.com/lucas-clemente/aes12 v0.0.0-20171027163421-cd47fb39b79f
+
+replace github.com/lucas-clemente/quic-clients => github.com/lucas-clemente/quic-clients v0.1.0
+
+replace github.com/lucas-clemente/quic-go => github.com/lucas-clemente/quic-go v0.10.2
+
+replace github.com/lucas-clemente/quic-go-certificates => github.com/lucas-clemente/quic-go-certificates v0.0.0-20160823095156-d2f86524cced
+
+replace github.com/mailru/easyjson => github.com/mailru/easyjson v0.7.0
+
+replace github.com/marten-seemann/qtls => github.com/marten-seemann/qtls v0.2.3
+
+replace github.com/mattn/go-colorable => github.com/mattn/go-colorable v0.0.9
+
+replace github.com/mattn/go-isatty => github.com/mattn/go-isatty v0.0.4
+
+replace github.com/mattn/go-runewidth => github.com/mattn/go-runewidth v0.0.2
+
+replace github.com/matttproud/golang_protobuf_extensions => github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369
+
+replace github.com/mholt/certmagic => github.com/mholt/certmagic v0.6.2-0.20190624175158-6a42ef9fe8c2
+
+replace github.com/mindprince/gonvml => github.com/mindprince/gonvml v0.0.0-20190828220739-9ebdce4bb989
+
+replace github.com/mistifyio/go-zfs => github.com/mistifyio/go-zfs v2.1.2-0.20190413222219-f784269be439+incompatible
+
+replace github.com/mitchellh/go-homedir => github.com/mitchellh/go-homedir v1.1.0
+
+replace github.com/mitchellh/go-wordwrap => github.com/mitchellh/go-wordwrap v1.0.0
+
+replace github.com/mitchellh/mapstructure => github.com/mitchellh/mapstructure v1.1.2
+
+replace github.com/moby/sys/mountinfo => github.com/moby/sys/mountinfo v0.1.3
+
+replace github.com/moby/term => github.com/moby/term v0.0.0-20200312100748-672ec06f55cd
+
+replace github.com/modern-go/concurrent => github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd
+
+replace github.com/modern-go/reflect2 => github.com/modern-go/reflect2 v1.0.1
+
+replace github.com/morikuni/aec => github.com/morikuni/aec v1.0.0
+
+replace github.com/mwitkow/go-conntrack => github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223
+
+replace github.com/mxk/go-flowrate => github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f
+
+replace github.com/naoina/go-stringutil => github.com/naoina/go-stringutil v0.1.0
+
+replace github.com/naoina/toml => github.com/naoina/toml v0.1.1
+
+replace github.com/olekukonko/tablewriter => github.com/olekukonko/tablewriter v0.0.0-20170122224234-a0225b3f23b5
+
+replace github.com/opencontainers/image-spec => github.com/opencontainers/image-spec v1.0.1
+
+replace github.com/opencontainers/runtime-spec => github.com/opencontainers/runtime-spec v1.0.3-0.20200520003142-237cc4f519e2
+
+replace github.com/pelletier/go-toml => github.com/pelletier/go-toml v1.2.0
+
+replace github.com/peterbourgon/diskv => github.com/peterbourgon/diskv v2.0.1+incompatible
+
+replace github.com/pquerna/cachecontrol => github.com/pquerna/cachecontrol v0.0.0-20171018203845-0dec1b30a021
+
+replace github.com/prometheus/procfs => github.com/prometheus/procfs v0.1.3
+
+replace github.com/remyoudompheng/bigfft => github.com/remyoudompheng/bigfft v0.0.0-20170806203942-52369c62f446
+
+replace github.com/rogpeppe/fastuuid => github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af
+
+replace github.com/rogpeppe/go-internal => github.com/rogpeppe/go-internal v1.3.0
+
+replace github.com/rubiojr/go-vhd => github.com/rubiojr/go-vhd v0.0.0-20200706105327-02e210299021
+
+replace github.com/russross/blackfriday => github.com/russross/blackfriday v1.5.2
+
+replace github.com/russross/blackfriday/v2 => github.com/russross/blackfriday/v2 v2.0.1
+
+replace github.com/satori/go.uuid => github.com/satori/go.uuid v1.2.0
+
+replace github.com/seccomp/libseccomp-golang => github.com/seccomp/libseccomp-golang v0.9.1
+
+replace github.com/sergi/go-diff => github.com/sergi/go-diff v1.0.0
+
+replace github.com/shurcooL/sanitized_anchor_name => github.com/shurcooL/sanitized_anchor_name v1.0.0
+
+replace github.com/sirupsen/logrus => github.com/sirupsen/logrus v1.6.0
+
+replace github.com/smartystreets/assertions => github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d
+
+replace github.com/smartystreets/goconvey => github.com/smartystreets/goconvey v1.6.4
+
+replace github.com/soheilhy/cmux => github.com/soheilhy/cmux v0.1.4
+
+replace github.com/spf13/cast => github.com/spf13/cast v1.3.0
+
+replace github.com/stretchr/objx => github.com/stretchr/objx v0.2.0
+
+replace github.com/syndtr/gocapability => github.com/syndtr/gocapability v0.0.0-20180916011248-d98352740cb2
+
+replace github.com/tidwall/pretty => github.com/tidwall/pretty v1.0.0
+
+replace github.com/tmc/grpc-websocket-proxy => github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5
+
+replace github.com/ugorji/go => github.com/ugorji/go v1.1.4
+
+replace github.com/urfave/cli => github.com/urfave/cli v1.22.2
+
+replace github.com/vektah/gqlparser => github.com/vektah/gqlparser v1.1.2
+
+replace github.com/vishvananda/netns => github.com/vishvananda/netns v0.0.0-20200520041808-52d707b772fe
+
+replace github.com/xiang90/probing => github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2
+
+replace github.com/xlab/handysort => github.com/xlab/handysort v0.0.0-20150421192137-fb3537ed64a1
+
+replace github.com/xordataexchange/crypt => github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77
+
+replace github.com/yuin/goldmark => github.com/yuin/goldmark v1.2.1
+
+replace go.etcd.io/bbolt => go.etcd.io/bbolt v1.3.5
+
+replace go.mongodb.org/mongo-driver => go.mongodb.org/mongo-driver v1.1.2
+
+replace go.opencensus.io => go.opencensus.io v0.22.2
+
+replace go.uber.org/atomic => go.uber.org/atomic v1.4.0
+
+replace go.uber.org/multierr => go.uber.org/multierr v1.1.0
+
+replace go.uber.org/zap => go.uber.org/zap v1.10.0
+
+replace golang.org/x/exp => golang.org/x/exp v0.0.0-20191227195350-da58074b4299
+
+replace golang.org/x/image => golang.org/x/image v0.0.0-20190802002840-cff245a6509b
+
+replace golang.org/x/lint => golang.org/x/lint v0.0.0-20191125180803-fdd1cda4f05f
+
+replace golang.org/x/mobile => golang.org/x/mobile v0.0.0-20190719004257-d2bd2a29d028
+
+replace golang.org/x/mod => golang.org/x/mod v0.3.0
+
+replace golang.org/x/sync => golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9
+
+replace golang.org/x/text => golang.org/x/text v0.3.3
+
+replace golang.org/x/xerrors => golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1
+
+replace gonum.org/v1/plot => gonum.org/v1/plot v0.0.0-20190515093506-e2840ee46a6b
+
+replace google.golang.org/appengine => google.golang.org/appengine v1.6.5
+
+replace google.golang.org/genproto => google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013
+
+replace google.golang.org/protobuf => google.golang.org/protobuf v1.24.0
+
+replace gopkg.in/alecthomas/kingpin.v2 => gopkg.in/alecthomas/kingpin.v2 v2.2.6
+
+replace gopkg.in/check.v1 => gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15
+
+replace gopkg.in/cheggaaa/pb.v1 => gopkg.in/cheggaaa/pb.v1 v1.0.25
+
+replace gopkg.in/errgo.v2 => gopkg.in/errgo.v2 v2.1.0
+
+replace gopkg.in/fsnotify.v1 => gopkg.in/fsnotify.v1 v1.4.7
+
+replace gopkg.in/inf.v0 => gopkg.in/inf.v0 v0.9.1
+
+replace gopkg.in/mcuadros/go-syslog.v2 => gopkg.in/mcuadros/go-syslog.v2 v2.2.1
+
+replace gopkg.in/natefinch/lumberjack.v2 => gopkg.in/natefinch/lumberjack.v2 v2.0.0
+
+replace gopkg.in/resty.v1 => gopkg.in/resty.v1 v1.12.0
+
+replace gopkg.in/tomb.v1 => gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7
+
+replace gopkg.in/warnings.v0 => gopkg.in/warnings.v0 v0.1.1
+
+replace gotest.tools => gotest.tools v2.2.0+incompatible
+
+replace gotest.tools/v3 => gotest.tools/v3 v3.0.2
+
+replace honnef.co/go/tools => honnef.co/go/tools v0.0.1-2019.2.3
+
+replace modernc.org/cc => modernc.org/cc v1.0.0
+
+replace modernc.org/golex => modernc.org/golex v1.0.0
+
+replace modernc.org/mathutil => modernc.org/mathutil v1.0.0
+
+replace modernc.org/strutil => modernc.org/strutil v1.0.0
+
+replace modernc.org/xc => modernc.org/xc v1.0.0
+
+replace rsc.io/pdf => rsc.io/pdf v0.1.1
+
+replace sigs.k8s.io/apiserver-network-proxy/konnectivity-client => sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.15
+
+replace sigs.k8s.io/structured-merge-diff/v4 => sigs.k8s.io/structured-merge-diff/v4 v4.1.2
+
+replace vbom.ml/util => vbom.ml/util v0.0.0-20160121211510-db5cfe13f5cc

--- a/staging/src/k8s.io/sample-apiserver/go.mod
+++ b/staging/src/k8s.io/sample-apiserver/go.mod
@@ -5,16 +5,121 @@ module k8s.io/sample-apiserver
 go 1.15
 
 require (
+	bitbucket.org/bertimus9/systemstat v0.0.0-20180207000608-0eeff89b0690
+	github.com/Azure/azure-sdk-for-go v43.0.0+incompatible
+	github.com/Azure/go-autorest/autorest v0.9.6
+	github.com/Azure/go-autorest/autorest/adal v0.8.2
+	github.com/Azure/go-autorest/autorest/to v0.2.0
+	github.com/GoogleCloudPlatform/k8s-cloud-provider v0.0.0-20200415212048-7901bc822317
+	github.com/JeffAshton/win_pdh v0.0.0-20161109143554-76bb4ee9f0ab
+	github.com/Microsoft/go-winio v0.4.15-0.20190919025122-fc70bd9a86b5
+	github.com/Microsoft/hcsshim v0.8.10-0.20200715222032-5eafd1556990
+	github.com/PuerkitoBio/purell v1.1.1
+	github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e
+	github.com/auth0/go-jwt-middleware v0.0.0-20170425171159-5493cabe49f7
+	github.com/aws/aws-sdk-go v1.28.2
+	github.com/blang/semver v3.5.0+incompatible
+	github.com/boltdb/bolt v1.3.1
+	github.com/caddyserver/caddy v1.0.3
+	github.com/clusterhq/flocker-go v0.0.0-20160920122132-2b8b7259d313
+	github.com/codegangsta/negroni v1.0.0
+	github.com/container-storage-interface/spec v1.2.0
+	github.com/containernetworking/cni v0.8.0
+	github.com/coredns/corefile-migration v1.0.10
+	github.com/coreos/go-oidc v2.1.0+incompatible
+	github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e
+	github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f
+	github.com/cpuguy83/go-md2man/v2 v2.0.0
+	github.com/davecgh/go-spew v1.1.1
+	github.com/docker/distribution v2.7.1+incompatible
+	github.com/docker/docker v1.4.2-0.20200309214505-aa6a9891b09c
+	github.com/docker/go-connections v0.4.0
+	github.com/docker/go-units v0.4.0
+	github.com/elazarl/goproxy v0.0.0-20180725130230-947c36da3153
+	github.com/emicklei/go-restful v2.9.5+incompatible
+	github.com/evanphx/json-patch v4.9.0+incompatible
+	github.com/fsnotify/fsnotify v1.4.9
+	github.com/go-bindata/go-bindata v3.1.1+incompatible
+	github.com/go-openapi/analysis v0.19.5
+	github.com/go-openapi/loads v0.19.4
 	github.com/go-openapi/spec v0.19.3
+	github.com/go-openapi/strfmt v0.19.3
+	github.com/go-openapi/validate v0.19.5
+	github.com/go-ozzo/ozzo-validation v3.5.0+incompatible
+	github.com/gogo/protobuf v1.3.2
+	github.com/golang/groupcache v0.0.0-20191227052852-215e87163ea7
+	github.com/golang/mock v1.3.1
+	github.com/google/cadvisor v0.37.5
+	github.com/google/go-cmp v0.4.0
 	github.com/google/gofuzz v1.1.0
+	github.com/google/uuid v1.1.1
+	github.com/googleapis/gnostic v0.4.1
+	github.com/gorilla/context v1.1.1
+	github.com/hashicorp/golang-lru v0.5.1
+	github.com/heketi/heketi v9.0.1-0.20190917153846-c2e2a4ab7ab9+incompatible
+	github.com/heketi/tests v0.0.0-20151005000721-f3775cbcefd6
+	github.com/ishidawataru/sctp v0.0.0-20190723014705-7c296d48a2b5
+	github.com/json-iterator/go v1.1.10
+	github.com/libopenstorage/openstorage v1.0.0
+	github.com/lithammer/dedent v1.1.0
+	github.com/lpabon/godbc v0.1.1
+	github.com/magiconair/properties v1.8.1
+	github.com/miekg/dns v1.1.4
+	github.com/moby/ipvs v1.0.1
+	github.com/mohae/deepcopy v0.0.0-20170603005431-491d3605edfb
+	github.com/mrunalp/fileutils v0.0.0-20200520151820-abd8a0e76976
+	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822
+	github.com/mvdan/xurls v1.1.0
+	github.com/onsi/ginkgo v1.11.0
+	github.com/onsi/gomega v1.7.0
+	github.com/opencontainers/go-digest v1.0.0-rc1
+	github.com/opencontainers/runc v1.0.1
+	github.com/opencontainers/selinux v1.5.2
+	github.com/pkg/errors v0.9.1
+	github.com/pmezard/go-difflib v1.0.0
+	github.com/prometheus/client_golang v1.7.1
+	github.com/prometheus/client_model v0.2.0
+	github.com/prometheus/common v0.10.0
+	github.com/quobyte/api v0.1.2
+	github.com/robfig/cron v1.1.0
+	github.com/spf13/afero v1.2.2
 	github.com/spf13/cobra v1.0.0
+	github.com/spf13/jwalterweatherman v1.1.0
+	github.com/spf13/pflag v1.0.5
+	github.com/spf13/viper v1.4.0
+	github.com/storageos/go-api v0.0.0-20180912212459-343b3eff91fc
+	github.com/stretchr/testify v1.4.0
+	github.com/thecodeteam/goscaleio v0.1.0
+	github.com/urfave/negroni v1.0.0
+	github.com/vishvananda/netlink v1.1.0
+	github.com/vmware/govmomi v0.20.3
+	go.etcd.io/etcd v0.5.0-alpha.5.0.20200819165624-17cef6e3e9d5
+	golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9
+	golang.org/x/net v0.0.0-20201110031124-69a78807bb2b
+	golang.org/x/oauth2 v0.0.0-20191202225959-858c2ad4c8b6
+	golang.org/x/sys v0.0.0-20201112073958-5cba982894dd
+	golang.org/x/time v0.0.0-20191024005414-555d28b269f0
+	golang.org/x/tools v0.0.0-20210106214847-113979e3529a
+	gonum.org/v1/gonum v0.6.2
+	gonum.org/v1/netlib v0.0.0-20190331212654-76723241ea4e
+	google.golang.org/api v0.15.1
+	google.golang.org/grpc v1.27.0
+	gopkg.in/gcfg.v1 v1.2.0
+	gopkg.in/square/go-jose.v2 v2.2.2
+	gopkg.in/yaml.v2 v2.2.8
 	k8s.io/apimachinery v0.0.0
 	k8s.io/apiserver v0.0.0
 	k8s.io/client-go v0.0.0
 	k8s.io/code-generator v0.0.0
 	k8s.io/component-base v0.0.0
+	k8s.io/gengo v0.0.0-20200428234225-8167cfdcfc14
+	k8s.io/heapster v1.2.0-beta.1
 	k8s.io/klog/v2 v2.2.0
 	k8s.io/kube-openapi v0.0.0-20200805222855-6aeccd4b50c6
+	k8s.io/system-validators v1.1.2
+	k8s.io/utils v0.0.0-20200729134348-d5654de09c73
+	sigs.k8s.io/kustomize v2.0.3+incompatible
+	sigs.k8s.io/yaml v1.2.0
 )
 
 replace (
@@ -26,3 +131,669 @@ replace (
 	k8s.io/component-base => ../component-base
 	k8s.io/sample-apiserver => ../sample-apiserver
 )
+
+replace github.com/auth0/go-jwt-middleware => github.com/auth0/go-jwt-middleware v0.0.0-20170425171159-5493cabe49f7
+
+replace github.com/boltdb/bolt => github.com/boltdb/bolt v1.3.1
+
+replace github.com/codegangsta/negroni => github.com/codegangsta/negroni v1.0.0
+
+replace github.com/go-ozzo/ozzo-validation => github.com/go-ozzo/ozzo-validation v3.5.0+incompatible
+
+replace github.com/gorilla/context => github.com/gorilla/context v1.1.1
+
+replace github.com/heketi/tests => github.com/heketi/tests v0.0.0-20151005000721-f3775cbcefd6
+
+replace github.com/lpabon/godbc => github.com/lpabon/godbc v0.1.1
+
+replace github.com/magiconair/properties => github.com/magiconair/properties v1.8.1
+
+replace github.com/mohae/deepcopy => github.com/mohae/deepcopy v0.0.0-20170603005431-491d3605edfb
+
+replace github.com/spf13/jwalterweatherman => github.com/spf13/jwalterweatherman v1.1.0
+
+replace github.com/urfave/negroni => github.com/urfave/negroni v1.0.0
+
+replace gonum.org/v1/netlib => gonum.org/v1/netlib v0.0.0-20190331212654-76723241ea4e
+
+replace bitbucket.org/bertimus9/systemstat => bitbucket.org/bertimus9/systemstat v0.0.0-20180207000608-0eeff89b0690
+
+replace github.com/Azure/azure-sdk-for-go => github.com/Azure/azure-sdk-for-go v43.0.0+incompatible
+
+replace github.com/Azure/go-autorest/autorest => github.com/Azure/go-autorest/autorest v0.9.6
+
+replace github.com/Azure/go-autorest/autorest/adal => github.com/Azure/go-autorest/autorest/adal v0.8.2
+
+replace github.com/Azure/go-autorest/autorest/to => github.com/Azure/go-autorest/autorest/to v0.2.0
+
+replace github.com/GoogleCloudPlatform/k8s-cloud-provider => github.com/GoogleCloudPlatform/k8s-cloud-provider v0.0.0-20200415212048-7901bc822317
+
+replace github.com/JeffAshton/win_pdh => github.com/JeffAshton/win_pdh v0.0.0-20161109143554-76bb4ee9f0ab
+
+replace github.com/Microsoft/go-winio => github.com/Microsoft/go-winio v0.4.15-0.20190919025122-fc70bd9a86b5
+
+replace github.com/Microsoft/hcsshim => github.com/Microsoft/hcsshim v0.8.10-0.20200715222032-5eafd1556990
+
+replace github.com/PuerkitoBio/purell => github.com/PuerkitoBio/purell v1.1.1
+
+replace github.com/armon/circbuf => github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e
+
+replace github.com/aws/aws-sdk-go => github.com/aws/aws-sdk-go v1.28.2
+
+replace github.com/blang/semver => github.com/blang/semver v3.5.0+incompatible
+
+replace github.com/caddyserver/caddy => github.com/caddyserver/caddy v1.0.3
+
+replace github.com/clusterhq/flocker-go => github.com/clusterhq/flocker-go v0.0.0-20160920122132-2b8b7259d313
+
+replace github.com/container-storage-interface/spec => github.com/container-storage-interface/spec v1.2.0
+
+replace github.com/containernetworking/cni => github.com/containernetworking/cni v0.8.0
+
+replace github.com/coredns/corefile-migration => github.com/coredns/corefile-migration v1.0.10
+
+replace github.com/coreos/go-oidc => github.com/coreos/go-oidc v2.1.0+incompatible
+
+replace github.com/coreos/go-systemd => github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e
+
+replace github.com/coreos/pkg => github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f
+
+replace github.com/cpuguy83/go-md2man/v2 => github.com/cpuguy83/go-md2man/v2 v2.0.0
+
+replace github.com/davecgh/go-spew => github.com/davecgh/go-spew v1.1.1
+
+replace github.com/docker/distribution => github.com/docker/distribution v2.7.1+incompatible
+
+replace github.com/docker/docker => github.com/docker/docker v1.4.2-0.20200309214505-aa6a9891b09c
+
+replace github.com/docker/go-connections => github.com/docker/go-connections v0.4.0
+
+replace github.com/docker/go-units => github.com/docker/go-units v0.4.0
+
+replace github.com/elazarl/goproxy => github.com/elazarl/goproxy v0.0.0-20180725130230-947c36da3153
+
+replace github.com/emicklei/go-restful => github.com/emicklei/go-restful v2.9.5+incompatible
+
+replace github.com/evanphx/json-patch => github.com/evanphx/json-patch v4.9.0+incompatible
+
+replace github.com/fsnotify/fsnotify => github.com/fsnotify/fsnotify v1.4.9
+
+replace github.com/go-bindata/go-bindata => github.com/go-bindata/go-bindata v3.1.1+incompatible
+
+replace github.com/go-openapi/analysis => github.com/go-openapi/analysis v0.19.5
+
+replace github.com/go-openapi/loads => github.com/go-openapi/loads v0.19.4
+
+replace github.com/go-openapi/spec => github.com/go-openapi/spec v0.19.3
+
+replace github.com/go-openapi/strfmt => github.com/go-openapi/strfmt v0.19.3
+
+replace github.com/go-openapi/validate => github.com/go-openapi/validate v0.19.5
+
+replace github.com/gogo/protobuf => github.com/gogo/protobuf v1.3.2
+
+replace github.com/golang/groupcache => github.com/golang/groupcache v0.0.0-20191227052852-215e87163ea7
+
+replace github.com/golang/mock => github.com/golang/mock v1.3.1
+
+replace github.com/google/cadvisor => github.com/google/cadvisor v0.37.5
+
+replace github.com/google/go-cmp => github.com/google/go-cmp v0.4.0
+
+replace github.com/google/gofuzz => github.com/google/gofuzz v1.1.0
+
+replace github.com/google/uuid => github.com/google/uuid v1.1.1
+
+replace github.com/googleapis/gnostic => github.com/googleapis/gnostic v0.4.1
+
+replace github.com/hashicorp/golang-lru => github.com/hashicorp/golang-lru v0.5.1
+
+replace github.com/heketi/heketi => github.com/heketi/heketi v9.0.1-0.20190917153846-c2e2a4ab7ab9+incompatible
+
+replace github.com/ishidawataru/sctp => github.com/ishidawataru/sctp v0.0.0-20190723014705-7c296d48a2b5
+
+replace github.com/json-iterator/go => github.com/json-iterator/go v1.1.10
+
+replace github.com/libopenstorage/openstorage => github.com/libopenstorage/openstorage v1.0.0
+
+replace github.com/lithammer/dedent => github.com/lithammer/dedent v1.1.0
+
+replace github.com/miekg/dns => github.com/miekg/dns v1.1.4
+
+replace github.com/moby/ipvs => github.com/moby/ipvs v1.0.1
+
+replace github.com/mrunalp/fileutils => github.com/mrunalp/fileutils v0.0.0-20200520151820-abd8a0e76976
+
+replace github.com/munnerz/goautoneg => github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822
+
+replace github.com/mvdan/xurls => github.com/mvdan/xurls v1.1.0
+
+replace github.com/onsi/ginkgo => github.com/onsi/ginkgo v1.11.0
+
+replace github.com/onsi/gomega => github.com/onsi/gomega v1.7.0
+
+replace github.com/opencontainers/go-digest => github.com/opencontainers/go-digest v1.0.0-rc1
+
+replace github.com/opencontainers/runc => github.com/opencontainers/runc v1.0.1
+
+replace github.com/opencontainers/selinux => github.com/opencontainers/selinux v1.5.2
+
+replace github.com/pkg/errors => github.com/pkg/errors v0.9.1
+
+replace github.com/pmezard/go-difflib => github.com/pmezard/go-difflib v1.0.0
+
+replace github.com/prometheus/client_golang => github.com/prometheus/client_golang v1.7.1
+
+replace github.com/prometheus/client_model => github.com/prometheus/client_model v0.2.0
+
+replace github.com/prometheus/common => github.com/prometheus/common v0.10.0
+
+replace github.com/quobyte/api => github.com/quobyte/api v0.1.2
+
+replace github.com/robfig/cron => github.com/robfig/cron v1.1.0
+
+replace github.com/spf13/afero => github.com/spf13/afero v1.2.2
+
+replace github.com/spf13/cobra => github.com/spf13/cobra v1.0.0
+
+replace github.com/spf13/pflag => github.com/spf13/pflag v1.0.5
+
+replace github.com/spf13/viper => github.com/spf13/viper v1.4.0
+
+replace github.com/storageos/go-api => github.com/storageos/go-api v0.0.0-20180912212459-343b3eff91fc
+
+replace github.com/stretchr/testify => github.com/stretchr/testify v1.4.0
+
+replace github.com/thecodeteam/goscaleio => github.com/thecodeteam/goscaleio v0.1.0
+
+replace github.com/vishvananda/netlink => github.com/vishvananda/netlink v1.1.0
+
+replace github.com/vmware/govmomi => github.com/vmware/govmomi v0.20.3
+
+replace go.etcd.io/etcd => go.etcd.io/etcd v0.5.0-alpha.5.0.20200819165624-17cef6e3e9d5
+
+replace golang.org/x/crypto => golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9
+
+replace golang.org/x/net => golang.org/x/net v0.0.0-20201110031124-69a78807bb2b
+
+replace golang.org/x/oauth2 => golang.org/x/oauth2 v0.0.0-20191202225959-858c2ad4c8b6
+
+replace golang.org/x/sys => golang.org/x/sys v0.0.0-20201112073958-5cba982894dd
+
+replace golang.org/x/time => golang.org/x/time v0.0.0-20191024005414-555d28b269f0
+
+replace golang.org/x/tools => golang.org/x/tools v0.0.0-20210106214847-113979e3529a
+
+replace gonum.org/v1/gonum => gonum.org/v1/gonum v0.6.2
+
+replace google.golang.org/api => google.golang.org/api v0.15.1
+
+replace google.golang.org/grpc => google.golang.org/grpc v1.27.0
+
+replace gopkg.in/gcfg.v1 => gopkg.in/gcfg.v1 v1.2.0
+
+replace gopkg.in/square/go-jose.v2 => gopkg.in/square/go-jose.v2 v2.2.2
+
+replace gopkg.in/yaml.v2 => gopkg.in/yaml.v2 v2.2.8
+
+replace k8s.io/gengo => k8s.io/gengo v0.0.0-20200428234225-8167cfdcfc14
+
+replace k8s.io/heapster => k8s.io/heapster v1.2.0-beta.1
+
+replace k8s.io/klog/v2 => k8s.io/klog/v2 v2.2.0
+
+replace k8s.io/kube-openapi => k8s.io/kube-openapi v0.0.0-20200805222855-6aeccd4b50c6
+
+replace k8s.io/system-validators => k8s.io/system-validators v1.1.2
+
+replace k8s.io/utils => k8s.io/utils v0.0.0-20200729134348-d5654de09c73
+
+replace sigs.k8s.io/kustomize => sigs.k8s.io/kustomize v2.0.3+incompatible
+
+replace sigs.k8s.io/yaml => sigs.k8s.io/yaml v1.2.0
+
+replace cloud.google.com/go => cloud.google.com/go v0.51.0
+
+replace cloud.google.com/go/bigquery => cloud.google.com/go/bigquery v1.0.1
+
+replace cloud.google.com/go/datastore => cloud.google.com/go/datastore v1.0.0
+
+replace cloud.google.com/go/pubsub => cloud.google.com/go/pubsub v1.0.1
+
+replace cloud.google.com/go/storage => cloud.google.com/go/storage v1.0.0
+
+replace dmitri.shuralyov.com/gpu/mtl => dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9
+
+replace github.com/Azure/go-ansiterm => github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78
+
+replace github.com/Azure/go-autorest/autorest/date => github.com/Azure/go-autorest/autorest/date v0.2.0
+
+replace github.com/Azure/go-autorest/autorest/mocks => github.com/Azure/go-autorest/autorest/mocks v0.3.0
+
+replace github.com/Azure/go-autorest/autorest/validation => github.com/Azure/go-autorest/autorest/validation v0.1.0
+
+replace github.com/Azure/go-autorest/logger => github.com/Azure/go-autorest/logger v0.1.0
+
+replace github.com/Azure/go-autorest/tracing => github.com/Azure/go-autorest/tracing v0.5.0
+
+replace github.com/BurntSushi/toml => github.com/BurntSushi/toml v0.3.1
+
+replace github.com/BurntSushi/xgb => github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802
+
+replace github.com/MakeNowJust/heredoc => github.com/MakeNowJust/heredoc v0.0.0-20170808103936-bb23615498cd
+
+replace github.com/NYTimes/gziphandler => github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46
+
+replace github.com/PuerkitoBio/urlesc => github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578
+
+replace github.com/agnivade/levenshtein => github.com/agnivade/levenshtein v1.0.1
+
+replace github.com/ajstarks/svgo => github.com/ajstarks/svgo v0.0.0-20180226025133-644b8db467af
+
+replace github.com/alecthomas/template => github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751
+
+replace github.com/alecthomas/units => github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4
+
+replace github.com/andreyvit/diff => github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883
+
+replace github.com/armon/consul-api => github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6
+
+replace github.com/asaskevich/govalidator => github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a
+
+replace github.com/beorn7/perks => github.com/beorn7/perks v1.0.1
+
+replace github.com/bgentry/speakeasy => github.com/bgentry/speakeasy v0.1.0
+
+replace github.com/bifurcation/mint => github.com/bifurcation/mint v0.0.0-20180715133206-93c51c6ce115
+
+replace github.com/cenkalti/backoff => github.com/cenkalti/backoff v2.1.1+incompatible
+
+replace github.com/census-instrumentation/opencensus-proto => github.com/census-instrumentation/opencensus-proto v0.2.1
+
+replace github.com/cespare/xxhash/v2 => github.com/cespare/xxhash/v2 v2.1.1
+
+replace github.com/chai2010/gettext-go => github.com/chai2010/gettext-go v0.0.0-20160711120539-c6fed771bfd5
+
+replace github.com/checkpoint-restore/go-criu/v4 => github.com/checkpoint-restore/go-criu/v4 v4.0.2
+
+replace github.com/cheekybits/genny => github.com/cheekybits/genny v0.0.0-20170328200008-9127e812e1e9
+
+replace github.com/chzyer/logex => github.com/chzyer/logex v1.1.10
+
+replace github.com/chzyer/readline => github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e
+
+replace github.com/chzyer/test => github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1
+
+replace github.com/cilium/ebpf => github.com/cilium/ebpf v0.0.0-20200702112145-1c8d4c9ef775
+
+replace github.com/cockroachdb/datadriven => github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa
+
+replace github.com/containerd/cgroups => github.com/containerd/cgroups v0.0.0-20200531161412-0dbf7f05ba59
+
+replace github.com/containerd/console => github.com/containerd/console v1.0.0
+
+replace github.com/containerd/containerd => github.com/containerd/containerd v1.3.3
+
+replace github.com/containerd/continuity => github.com/containerd/continuity v0.0.0-20190426062206-aaeac12a7ffc
+
+replace github.com/containerd/fifo => github.com/containerd/fifo v0.0.0-20190226154929-a9fb20d87448
+
+replace github.com/containerd/go-runc => github.com/containerd/go-runc v0.0.0-20180907222934-5a6d9f37cfa3
+
+replace github.com/containerd/ttrpc => github.com/containerd/ttrpc v1.0.0
+
+replace github.com/containerd/typeurl => github.com/containerd/typeurl v1.0.0
+
+replace github.com/coreos/bbolt => github.com/coreos/bbolt v1.3.2
+
+replace github.com/coreos/etcd => github.com/coreos/etcd v3.3.10+incompatible
+
+replace github.com/coreos/go-semver => github.com/coreos/go-semver v0.3.0
+
+replace github.com/coreos/go-systemd/v22 => github.com/coreos/go-systemd/v22 v22.1.0
+
+replace github.com/creack/pty => github.com/creack/pty v1.1.7
+
+replace github.com/cyphar/filepath-securejoin => github.com/cyphar/filepath-securejoin v0.2.2
+
+replace github.com/daviddengcn/go-colortext => github.com/daviddengcn/go-colortext v0.0.0-20160507010035-511bcaf42ccd
+
+replace github.com/dgrijalva/jwt-go => github.com/dgrijalva/jwt-go v3.2.0+incompatible
+
+replace github.com/dnaeon/go-vcr => github.com/dnaeon/go-vcr v1.0.1
+
+replace github.com/docker/spdystream => github.com/docker/spdystream v0.0.0-20160310174837-449fdfce4d96
+
+replace github.com/docopt/docopt-go => github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815
+
+replace github.com/dustin/go-humanize => github.com/dustin/go-humanize v1.0.0
+
+replace github.com/envoyproxy/go-control-plane => github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473
+
+replace github.com/envoyproxy/protoc-gen-validate => github.com/envoyproxy/protoc-gen-validate v0.1.0
+
+replace github.com/euank/go-kmsg-parser => github.com/euank/go-kmsg-parser v2.0.0+incompatible
+
+replace github.com/exponent-io/jsonpath => github.com/exponent-io/jsonpath v0.0.0-20151013193312-d6023ce2651d
+
+replace github.com/fatih/camelcase => github.com/fatih/camelcase v1.0.0
+
+replace github.com/fatih/color => github.com/fatih/color v1.7.0
+
+replace github.com/flynn/go-shlex => github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568
+
+replace github.com/fogleman/gg => github.com/fogleman/gg v1.2.1-0.20190220221249-0403632d5b90
+
+replace github.com/ghodss/yaml => github.com/ghodss/yaml v1.0.0
+
+replace github.com/go-acme/lego => github.com/go-acme/lego v2.5.0+incompatible
+
+replace github.com/go-gl/glfw/v3.3/glfw => github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72
+
+replace github.com/go-ini/ini => github.com/go-ini/ini v1.9.0
+
+replace github.com/go-kit/kit => github.com/go-kit/kit v0.9.0
+
+replace github.com/go-logfmt/logfmt => github.com/go-logfmt/logfmt v0.4.0
+
+replace github.com/go-logr/logr => github.com/go-logr/logr v0.2.0
+
+replace github.com/go-openapi/errors => github.com/go-openapi/errors v0.19.2
+
+replace github.com/go-openapi/jsonpointer => github.com/go-openapi/jsonpointer v0.19.3
+
+replace github.com/go-openapi/jsonreference => github.com/go-openapi/jsonreference v0.19.3
+
+replace github.com/go-openapi/runtime => github.com/go-openapi/runtime v0.19.4
+
+replace github.com/go-openapi/swag => github.com/go-openapi/swag v0.19.5
+
+replace github.com/go-stack/stack => github.com/go-stack/stack v1.8.0
+
+replace github.com/godbus/dbus/v5 => github.com/godbus/dbus/v5 v5.0.3
+
+replace github.com/golang/freetype => github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0
+
+replace github.com/golang/glog => github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
+
+replace github.com/golang/protobuf => github.com/golang/protobuf v1.4.2
+
+replace github.com/golangplus/bytes => github.com/golangplus/bytes v0.0.0-20160111154220-45c989fe5450
+
+replace github.com/golangplus/fmt => github.com/golangplus/fmt v0.0.0-20150411045040-2a5d6d7d2995
+
+replace github.com/golangplus/testing => github.com/golangplus/testing v0.0.0-20180327235837-af21d9c3145e
+
+replace github.com/google/btree => github.com/google/btree v1.0.0
+
+replace github.com/google/martian => github.com/google/martian v2.1.0+incompatible
+
+replace github.com/google/pprof => github.com/google/pprof v0.0.0-20191218002539-d4f498aebedc
+
+replace github.com/google/renameio => github.com/google/renameio v0.1.0
+
+replace github.com/googleapis/gax-go/v2 => github.com/googleapis/gax-go/v2 v2.0.5
+
+replace github.com/gophercloud/gophercloud => github.com/gophercloud/gophercloud v0.1.0
+
+replace github.com/gopherjs/gopherjs => github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1
+
+replace github.com/gorilla/mux => github.com/gorilla/mux v1.7.3
+
+replace github.com/gorilla/websocket => github.com/gorilla/websocket v1.4.0
+
+replace github.com/gregjones/httpcache => github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7
+
+replace github.com/grpc-ecosystem/go-grpc-middleware => github.com/grpc-ecosystem/go-grpc-middleware v1.0.1-0.20190118093823-f849b5445de4
+
+replace github.com/grpc-ecosystem/go-grpc-prometheus => github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0
+
+replace github.com/grpc-ecosystem/grpc-gateway => github.com/grpc-ecosystem/grpc-gateway v1.9.5
+
+replace github.com/hashicorp/go-syslog => github.com/hashicorp/go-syslog v1.0.0
+
+replace github.com/hashicorp/hcl => github.com/hashicorp/hcl v1.0.0
+
+replace github.com/hpcloud/tail => github.com/hpcloud/tail v1.0.0
+
+replace github.com/ianlancetaylor/demangle => github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6
+
+replace github.com/imdario/mergo => github.com/imdario/mergo v0.3.5
+
+replace github.com/inconshreveable/mousetrap => github.com/inconshreveable/mousetrap v1.0.0
+
+replace github.com/jimstudt/http-authentication => github.com/jimstudt/http-authentication v0.0.0-20140401203705-3eca13d6893a
+
+replace github.com/jmespath/go-jmespath => github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af
+
+replace github.com/jonboulle/clockwork => github.com/jonboulle/clockwork v0.1.0
+
+replace github.com/jstemmer/go-junit-report => github.com/jstemmer/go-junit-report v0.9.1
+
+replace github.com/jtolds/gls => github.com/jtolds/gls v4.20.0+incompatible
+
+replace github.com/julienschmidt/httprouter => github.com/julienschmidt/httprouter v1.2.0
+
+replace github.com/jung-kurt/gofpdf => github.com/jung-kurt/gofpdf v1.0.3-0.20190309125859-24315acbbda5
+
+replace github.com/karrick/godirwalk => github.com/karrick/godirwalk v1.7.5
+
+replace github.com/kisielk/errcheck => github.com/kisielk/errcheck v1.5.0
+
+replace github.com/kisielk/gotool => github.com/kisielk/gotool v1.0.0
+
+replace github.com/klauspost/cpuid => github.com/klauspost/cpuid v1.2.0
+
+replace github.com/konsorten/go-windows-terminal-sequences => github.com/konsorten/go-windows-terminal-sequences v1.0.3
+
+replace github.com/kr/logfmt => github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515
+
+replace github.com/kr/pretty => github.com/kr/pretty v0.2.0
+
+replace github.com/kr/pty => github.com/kr/pty v1.1.5
+
+replace github.com/kr/text => github.com/kr/text v0.1.0
+
+replace github.com/kylelemons/godebug => github.com/kylelemons/godebug v0.0.0-20170820004349-d65d576e9348
+
+replace github.com/liggitt/tabwriter => github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de
+
+replace github.com/lucas-clemente/aes12 => github.com/lucas-clemente/aes12 v0.0.0-20171027163421-cd47fb39b79f
+
+replace github.com/lucas-clemente/quic-clients => github.com/lucas-clemente/quic-clients v0.1.0
+
+replace github.com/lucas-clemente/quic-go => github.com/lucas-clemente/quic-go v0.10.2
+
+replace github.com/lucas-clemente/quic-go-certificates => github.com/lucas-clemente/quic-go-certificates v0.0.0-20160823095156-d2f86524cced
+
+replace github.com/mailru/easyjson => github.com/mailru/easyjson v0.7.0
+
+replace github.com/marten-seemann/qtls => github.com/marten-seemann/qtls v0.2.3
+
+replace github.com/mattn/go-colorable => github.com/mattn/go-colorable v0.0.9
+
+replace github.com/mattn/go-isatty => github.com/mattn/go-isatty v0.0.4
+
+replace github.com/mattn/go-runewidth => github.com/mattn/go-runewidth v0.0.2
+
+replace github.com/matttproud/golang_protobuf_extensions => github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369
+
+replace github.com/mholt/certmagic => github.com/mholt/certmagic v0.6.2-0.20190624175158-6a42ef9fe8c2
+
+replace github.com/mindprince/gonvml => github.com/mindprince/gonvml v0.0.0-20190828220739-9ebdce4bb989
+
+replace github.com/mistifyio/go-zfs => github.com/mistifyio/go-zfs v2.1.2-0.20190413222219-f784269be439+incompatible
+
+replace github.com/mitchellh/go-homedir => github.com/mitchellh/go-homedir v1.1.0
+
+replace github.com/mitchellh/go-wordwrap => github.com/mitchellh/go-wordwrap v1.0.0
+
+replace github.com/mitchellh/mapstructure => github.com/mitchellh/mapstructure v1.1.2
+
+replace github.com/moby/sys/mountinfo => github.com/moby/sys/mountinfo v0.1.3
+
+replace github.com/moby/term => github.com/moby/term v0.0.0-20200312100748-672ec06f55cd
+
+replace github.com/modern-go/concurrent => github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd
+
+replace github.com/modern-go/reflect2 => github.com/modern-go/reflect2 v1.0.1
+
+replace github.com/morikuni/aec => github.com/morikuni/aec v1.0.0
+
+replace github.com/mwitkow/go-conntrack => github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223
+
+replace github.com/mxk/go-flowrate => github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f
+
+replace github.com/naoina/go-stringutil => github.com/naoina/go-stringutil v0.1.0
+
+replace github.com/naoina/toml => github.com/naoina/toml v0.1.1
+
+replace github.com/olekukonko/tablewriter => github.com/olekukonko/tablewriter v0.0.0-20170122224234-a0225b3f23b5
+
+replace github.com/opencontainers/image-spec => github.com/opencontainers/image-spec v1.0.1
+
+replace github.com/opencontainers/runtime-spec => github.com/opencontainers/runtime-spec v1.0.3-0.20200520003142-237cc4f519e2
+
+replace github.com/pelletier/go-toml => github.com/pelletier/go-toml v1.2.0
+
+replace github.com/peterbourgon/diskv => github.com/peterbourgon/diskv v2.0.1+incompatible
+
+replace github.com/pquerna/cachecontrol => github.com/pquerna/cachecontrol v0.0.0-20171018203845-0dec1b30a021
+
+replace github.com/prometheus/procfs => github.com/prometheus/procfs v0.1.3
+
+replace github.com/remyoudompheng/bigfft => github.com/remyoudompheng/bigfft v0.0.0-20170806203942-52369c62f446
+
+replace github.com/rogpeppe/fastuuid => github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af
+
+replace github.com/rogpeppe/go-internal => github.com/rogpeppe/go-internal v1.3.0
+
+replace github.com/rubiojr/go-vhd => github.com/rubiojr/go-vhd v0.0.0-20200706105327-02e210299021
+
+replace github.com/russross/blackfriday => github.com/russross/blackfriday v1.5.2
+
+replace github.com/russross/blackfriday/v2 => github.com/russross/blackfriday/v2 v2.0.1
+
+replace github.com/satori/go.uuid => github.com/satori/go.uuid v1.2.0
+
+replace github.com/seccomp/libseccomp-golang => github.com/seccomp/libseccomp-golang v0.9.1
+
+replace github.com/sergi/go-diff => github.com/sergi/go-diff v1.0.0
+
+replace github.com/shurcooL/sanitized_anchor_name => github.com/shurcooL/sanitized_anchor_name v1.0.0
+
+replace github.com/sirupsen/logrus => github.com/sirupsen/logrus v1.6.0
+
+replace github.com/smartystreets/assertions => github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d
+
+replace github.com/smartystreets/goconvey => github.com/smartystreets/goconvey v1.6.4
+
+replace github.com/soheilhy/cmux => github.com/soheilhy/cmux v0.1.4
+
+replace github.com/spf13/cast => github.com/spf13/cast v1.3.0
+
+replace github.com/stretchr/objx => github.com/stretchr/objx v0.2.0
+
+replace github.com/syndtr/gocapability => github.com/syndtr/gocapability v0.0.0-20180916011248-d98352740cb2
+
+replace github.com/tidwall/pretty => github.com/tidwall/pretty v1.0.0
+
+replace github.com/tmc/grpc-websocket-proxy => github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5
+
+replace github.com/ugorji/go => github.com/ugorji/go v1.1.4
+
+replace github.com/urfave/cli => github.com/urfave/cli v1.22.2
+
+replace github.com/vektah/gqlparser => github.com/vektah/gqlparser v1.1.2
+
+replace github.com/vishvananda/netns => github.com/vishvananda/netns v0.0.0-20200520041808-52d707b772fe
+
+replace github.com/xiang90/probing => github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2
+
+replace github.com/xlab/handysort => github.com/xlab/handysort v0.0.0-20150421192137-fb3537ed64a1
+
+replace github.com/xordataexchange/crypt => github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77
+
+replace github.com/yuin/goldmark => github.com/yuin/goldmark v1.2.1
+
+replace go.etcd.io/bbolt => go.etcd.io/bbolt v1.3.5
+
+replace go.mongodb.org/mongo-driver => go.mongodb.org/mongo-driver v1.1.2
+
+replace go.opencensus.io => go.opencensus.io v0.22.2
+
+replace go.uber.org/atomic => go.uber.org/atomic v1.4.0
+
+replace go.uber.org/multierr => go.uber.org/multierr v1.1.0
+
+replace go.uber.org/zap => go.uber.org/zap v1.10.0
+
+replace golang.org/x/exp => golang.org/x/exp v0.0.0-20191227195350-da58074b4299
+
+replace golang.org/x/image => golang.org/x/image v0.0.0-20190802002840-cff245a6509b
+
+replace golang.org/x/lint => golang.org/x/lint v0.0.0-20191125180803-fdd1cda4f05f
+
+replace golang.org/x/mobile => golang.org/x/mobile v0.0.0-20190719004257-d2bd2a29d028
+
+replace golang.org/x/mod => golang.org/x/mod v0.3.0
+
+replace golang.org/x/sync => golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9
+
+replace golang.org/x/text => golang.org/x/text v0.3.3
+
+replace golang.org/x/xerrors => golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1
+
+replace gonum.org/v1/plot => gonum.org/v1/plot v0.0.0-20190515093506-e2840ee46a6b
+
+replace google.golang.org/appengine => google.golang.org/appengine v1.6.5
+
+replace google.golang.org/genproto => google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013
+
+replace google.golang.org/protobuf => google.golang.org/protobuf v1.24.0
+
+replace gopkg.in/alecthomas/kingpin.v2 => gopkg.in/alecthomas/kingpin.v2 v2.2.6
+
+replace gopkg.in/check.v1 => gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15
+
+replace gopkg.in/cheggaaa/pb.v1 => gopkg.in/cheggaaa/pb.v1 v1.0.25
+
+replace gopkg.in/errgo.v2 => gopkg.in/errgo.v2 v2.1.0
+
+replace gopkg.in/fsnotify.v1 => gopkg.in/fsnotify.v1 v1.4.7
+
+replace gopkg.in/inf.v0 => gopkg.in/inf.v0 v0.9.1
+
+replace gopkg.in/mcuadros/go-syslog.v2 => gopkg.in/mcuadros/go-syslog.v2 v2.2.1
+
+replace gopkg.in/natefinch/lumberjack.v2 => gopkg.in/natefinch/lumberjack.v2 v2.0.0
+
+replace gopkg.in/resty.v1 => gopkg.in/resty.v1 v1.12.0
+
+replace gopkg.in/tomb.v1 => gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7
+
+replace gopkg.in/warnings.v0 => gopkg.in/warnings.v0 v0.1.1
+
+replace gotest.tools => gotest.tools v2.2.0+incompatible
+
+replace gotest.tools/v3 => gotest.tools/v3 v3.0.2
+
+replace honnef.co/go/tools => honnef.co/go/tools v0.0.1-2019.2.3
+
+replace modernc.org/cc => modernc.org/cc v1.0.0
+
+replace modernc.org/golex => modernc.org/golex v1.0.0
+
+replace modernc.org/mathutil => modernc.org/mathutil v1.0.0
+
+replace modernc.org/strutil => modernc.org/strutil v1.0.0
+
+replace modernc.org/xc => modernc.org/xc v1.0.0
+
+replace rsc.io/pdf => rsc.io/pdf v0.1.1
+
+replace sigs.k8s.io/apiserver-network-proxy/konnectivity-client => sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.15
+
+replace sigs.k8s.io/structured-merge-diff/v4 => sigs.k8s.io/structured-merge-diff/v4 v4.1.2
+
+replace vbom.ml/util => vbom.ml/util v0.0.0-20160121211510-db5cfe13f5cc

--- a/staging/src/k8s.io/sample-cli-plugin/go.mod
+++ b/staging/src/k8s.io/sample-cli-plugin/go.mod
@@ -5,10 +5,118 @@ module k8s.io/sample-cli-plugin
 go 1.15
 
 require (
+	bitbucket.org/bertimus9/systemstat v0.0.0-20180207000608-0eeff89b0690
+	github.com/Azure/azure-sdk-for-go v43.0.0+incompatible
+	github.com/Azure/go-autorest/autorest v0.9.6
+	github.com/Azure/go-autorest/autorest/adal v0.8.2
+	github.com/Azure/go-autorest/autorest/to v0.2.0
+	github.com/GoogleCloudPlatform/k8s-cloud-provider v0.0.0-20200415212048-7901bc822317
+	github.com/JeffAshton/win_pdh v0.0.0-20161109143554-76bb4ee9f0ab
+	github.com/Microsoft/go-winio v0.4.15-0.20190919025122-fc70bd9a86b5
+	github.com/Microsoft/hcsshim v0.8.10-0.20200715222032-5eafd1556990
+	github.com/PuerkitoBio/purell v1.1.1
+	github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e
+	github.com/auth0/go-jwt-middleware v0.0.0-20170425171159-5493cabe49f7
+	github.com/aws/aws-sdk-go v1.28.2
+	github.com/blang/semver v3.5.0+incompatible
+	github.com/boltdb/bolt v1.3.1
+	github.com/caddyserver/caddy v1.0.3
+	github.com/clusterhq/flocker-go v0.0.0-20160920122132-2b8b7259d313
+	github.com/codegangsta/negroni v1.0.0
+	github.com/container-storage-interface/spec v1.2.0
+	github.com/containernetworking/cni v0.8.0
+	github.com/coredns/corefile-migration v1.0.10
+	github.com/coreos/go-oidc v2.1.0+incompatible
+	github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e
+	github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f
+	github.com/cpuguy83/go-md2man/v2 v2.0.0
+	github.com/davecgh/go-spew v1.1.1
+	github.com/docker/distribution v2.7.1+incompatible
+	github.com/docker/docker v1.4.2-0.20200309214505-aa6a9891b09c
+	github.com/docker/go-connections v0.4.0
+	github.com/docker/go-units v0.4.0
+	github.com/elazarl/goproxy v0.0.0-20180725130230-947c36da3153
+	github.com/emicklei/go-restful v2.9.5+incompatible
+	github.com/evanphx/json-patch v4.9.0+incompatible
+	github.com/fsnotify/fsnotify v1.4.9
+	github.com/go-bindata/go-bindata v3.1.1+incompatible
+	github.com/go-openapi/analysis v0.19.5
+	github.com/go-openapi/loads v0.19.4
+	github.com/go-openapi/spec v0.19.3
+	github.com/go-openapi/strfmt v0.19.3
+	github.com/go-openapi/validate v0.19.5
+	github.com/go-ozzo/ozzo-validation v3.5.0+incompatible
+	github.com/gogo/protobuf v1.3.2
+	github.com/golang/groupcache v0.0.0-20191227052852-215e87163ea7
+	github.com/golang/mock v1.3.1
+	github.com/google/cadvisor v0.37.5
+	github.com/google/go-cmp v0.4.0
+	github.com/google/gofuzz v1.1.0
+	github.com/google/uuid v1.1.1
+	github.com/googleapis/gnostic v0.4.1
+	github.com/gorilla/context v1.1.1
+	github.com/hashicorp/golang-lru v0.5.1
+	github.com/heketi/heketi v9.0.1-0.20190917153846-c2e2a4ab7ab9+incompatible
+	github.com/heketi/tests v0.0.0-20151005000721-f3775cbcefd6
+	github.com/ishidawataru/sctp v0.0.0-20190723014705-7c296d48a2b5
+	github.com/json-iterator/go v1.1.10
+	github.com/libopenstorage/openstorage v1.0.0
+	github.com/lithammer/dedent v1.1.0
+	github.com/lpabon/godbc v0.1.1
+	github.com/magiconair/properties v1.8.1
+	github.com/miekg/dns v1.1.4
+	github.com/moby/ipvs v1.0.1
+	github.com/mohae/deepcopy v0.0.0-20170603005431-491d3605edfb
+	github.com/mrunalp/fileutils v0.0.0-20200520151820-abd8a0e76976
+	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822
+	github.com/mvdan/xurls v1.1.0
+	github.com/onsi/ginkgo v1.11.0
+	github.com/onsi/gomega v1.7.0
+	github.com/opencontainers/go-digest v1.0.0-rc1
+	github.com/opencontainers/runc v1.0.1
+	github.com/opencontainers/selinux v1.5.2
+	github.com/pkg/errors v0.9.1
+	github.com/pmezard/go-difflib v1.0.0
+	github.com/prometheus/client_golang v1.7.1
+	github.com/prometheus/client_model v0.2.0
+	github.com/prometheus/common v0.10.0
+	github.com/quobyte/api v0.1.2
+	github.com/robfig/cron v1.1.0
+	github.com/spf13/afero v1.2.2
 	github.com/spf13/cobra v1.0.0
+	github.com/spf13/jwalterweatherman v1.1.0
 	github.com/spf13/pflag v1.0.5
+	github.com/spf13/viper v1.4.0
+	github.com/storageos/go-api v0.0.0-20180912212459-343b3eff91fc
+	github.com/stretchr/testify v1.4.0
+	github.com/thecodeteam/goscaleio v0.1.0
+	github.com/urfave/negroni v1.0.0
+	github.com/vishvananda/netlink v1.1.0
+	github.com/vmware/govmomi v0.20.3
+	go.etcd.io/etcd v0.5.0-alpha.5.0.20200819165624-17cef6e3e9d5
+	golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9
+	golang.org/x/net v0.0.0-20201110031124-69a78807bb2b
+	golang.org/x/oauth2 v0.0.0-20191202225959-858c2ad4c8b6
+	golang.org/x/sys v0.0.0-20201112073958-5cba982894dd
+	golang.org/x/time v0.0.0-20191024005414-555d28b269f0
+	golang.org/x/tools v0.0.0-20210106214847-113979e3529a
+	gonum.org/v1/gonum v0.6.2
+	gonum.org/v1/netlib v0.0.0-20190331212654-76723241ea4e
+	google.golang.org/api v0.15.1
+	google.golang.org/grpc v1.27.0
+	gopkg.in/gcfg.v1 v1.2.0
+	gopkg.in/square/go-jose.v2 v2.2.2
+	gopkg.in/yaml.v2 v2.2.8
 	k8s.io/cli-runtime v0.0.0
 	k8s.io/client-go v0.0.0
+	k8s.io/gengo v0.0.0-20200428234225-8167cfdcfc14
+	k8s.io/heapster v1.2.0-beta.1
+	k8s.io/klog/v2 v2.2.0
+	k8s.io/kube-openapi v0.0.0-20200805222855-6aeccd4b50c6
+	k8s.io/system-validators v1.1.2
+	k8s.io/utils v0.0.0-20200729134348-d5654de09c73
+	sigs.k8s.io/kustomize v2.0.3+incompatible
+	sigs.k8s.io/yaml v1.2.0
 )
 
 replace (
@@ -18,3 +126,669 @@ replace (
 	k8s.io/client-go => ../client-go
 	k8s.io/sample-cli-plugin => ../sample-cli-plugin
 )
+
+replace github.com/auth0/go-jwt-middleware => github.com/auth0/go-jwt-middleware v0.0.0-20170425171159-5493cabe49f7
+
+replace github.com/boltdb/bolt => github.com/boltdb/bolt v1.3.1
+
+replace github.com/codegangsta/negroni => github.com/codegangsta/negroni v1.0.0
+
+replace github.com/go-ozzo/ozzo-validation => github.com/go-ozzo/ozzo-validation v3.5.0+incompatible
+
+replace github.com/gorilla/context => github.com/gorilla/context v1.1.1
+
+replace github.com/heketi/tests => github.com/heketi/tests v0.0.0-20151005000721-f3775cbcefd6
+
+replace github.com/lpabon/godbc => github.com/lpabon/godbc v0.1.1
+
+replace github.com/magiconair/properties => github.com/magiconair/properties v1.8.1
+
+replace github.com/mohae/deepcopy => github.com/mohae/deepcopy v0.0.0-20170603005431-491d3605edfb
+
+replace github.com/spf13/jwalterweatherman => github.com/spf13/jwalterweatherman v1.1.0
+
+replace github.com/urfave/negroni => github.com/urfave/negroni v1.0.0
+
+replace gonum.org/v1/netlib => gonum.org/v1/netlib v0.0.0-20190331212654-76723241ea4e
+
+replace bitbucket.org/bertimus9/systemstat => bitbucket.org/bertimus9/systemstat v0.0.0-20180207000608-0eeff89b0690
+
+replace github.com/Azure/azure-sdk-for-go => github.com/Azure/azure-sdk-for-go v43.0.0+incompatible
+
+replace github.com/Azure/go-autorest/autorest => github.com/Azure/go-autorest/autorest v0.9.6
+
+replace github.com/Azure/go-autorest/autorest/adal => github.com/Azure/go-autorest/autorest/adal v0.8.2
+
+replace github.com/Azure/go-autorest/autorest/to => github.com/Azure/go-autorest/autorest/to v0.2.0
+
+replace github.com/GoogleCloudPlatform/k8s-cloud-provider => github.com/GoogleCloudPlatform/k8s-cloud-provider v0.0.0-20200415212048-7901bc822317
+
+replace github.com/JeffAshton/win_pdh => github.com/JeffAshton/win_pdh v0.0.0-20161109143554-76bb4ee9f0ab
+
+replace github.com/Microsoft/go-winio => github.com/Microsoft/go-winio v0.4.15-0.20190919025122-fc70bd9a86b5
+
+replace github.com/Microsoft/hcsshim => github.com/Microsoft/hcsshim v0.8.10-0.20200715222032-5eafd1556990
+
+replace github.com/PuerkitoBio/purell => github.com/PuerkitoBio/purell v1.1.1
+
+replace github.com/armon/circbuf => github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e
+
+replace github.com/aws/aws-sdk-go => github.com/aws/aws-sdk-go v1.28.2
+
+replace github.com/blang/semver => github.com/blang/semver v3.5.0+incompatible
+
+replace github.com/caddyserver/caddy => github.com/caddyserver/caddy v1.0.3
+
+replace github.com/clusterhq/flocker-go => github.com/clusterhq/flocker-go v0.0.0-20160920122132-2b8b7259d313
+
+replace github.com/container-storage-interface/spec => github.com/container-storage-interface/spec v1.2.0
+
+replace github.com/containernetworking/cni => github.com/containernetworking/cni v0.8.0
+
+replace github.com/coredns/corefile-migration => github.com/coredns/corefile-migration v1.0.10
+
+replace github.com/coreos/go-oidc => github.com/coreos/go-oidc v2.1.0+incompatible
+
+replace github.com/coreos/go-systemd => github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e
+
+replace github.com/coreos/pkg => github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f
+
+replace github.com/cpuguy83/go-md2man/v2 => github.com/cpuguy83/go-md2man/v2 v2.0.0
+
+replace github.com/davecgh/go-spew => github.com/davecgh/go-spew v1.1.1
+
+replace github.com/docker/distribution => github.com/docker/distribution v2.7.1+incompatible
+
+replace github.com/docker/docker => github.com/docker/docker v1.4.2-0.20200309214505-aa6a9891b09c
+
+replace github.com/docker/go-connections => github.com/docker/go-connections v0.4.0
+
+replace github.com/docker/go-units => github.com/docker/go-units v0.4.0
+
+replace github.com/elazarl/goproxy => github.com/elazarl/goproxy v0.0.0-20180725130230-947c36da3153
+
+replace github.com/emicklei/go-restful => github.com/emicklei/go-restful v2.9.5+incompatible
+
+replace github.com/evanphx/json-patch => github.com/evanphx/json-patch v4.9.0+incompatible
+
+replace github.com/fsnotify/fsnotify => github.com/fsnotify/fsnotify v1.4.9
+
+replace github.com/go-bindata/go-bindata => github.com/go-bindata/go-bindata v3.1.1+incompatible
+
+replace github.com/go-openapi/analysis => github.com/go-openapi/analysis v0.19.5
+
+replace github.com/go-openapi/loads => github.com/go-openapi/loads v0.19.4
+
+replace github.com/go-openapi/spec => github.com/go-openapi/spec v0.19.3
+
+replace github.com/go-openapi/strfmt => github.com/go-openapi/strfmt v0.19.3
+
+replace github.com/go-openapi/validate => github.com/go-openapi/validate v0.19.5
+
+replace github.com/gogo/protobuf => github.com/gogo/protobuf v1.3.2
+
+replace github.com/golang/groupcache => github.com/golang/groupcache v0.0.0-20191227052852-215e87163ea7
+
+replace github.com/golang/mock => github.com/golang/mock v1.3.1
+
+replace github.com/google/cadvisor => github.com/google/cadvisor v0.37.5
+
+replace github.com/google/go-cmp => github.com/google/go-cmp v0.4.0
+
+replace github.com/google/gofuzz => github.com/google/gofuzz v1.1.0
+
+replace github.com/google/uuid => github.com/google/uuid v1.1.1
+
+replace github.com/googleapis/gnostic => github.com/googleapis/gnostic v0.4.1
+
+replace github.com/hashicorp/golang-lru => github.com/hashicorp/golang-lru v0.5.1
+
+replace github.com/heketi/heketi => github.com/heketi/heketi v9.0.1-0.20190917153846-c2e2a4ab7ab9+incompatible
+
+replace github.com/ishidawataru/sctp => github.com/ishidawataru/sctp v0.0.0-20190723014705-7c296d48a2b5
+
+replace github.com/json-iterator/go => github.com/json-iterator/go v1.1.10
+
+replace github.com/libopenstorage/openstorage => github.com/libopenstorage/openstorage v1.0.0
+
+replace github.com/lithammer/dedent => github.com/lithammer/dedent v1.1.0
+
+replace github.com/miekg/dns => github.com/miekg/dns v1.1.4
+
+replace github.com/moby/ipvs => github.com/moby/ipvs v1.0.1
+
+replace github.com/mrunalp/fileutils => github.com/mrunalp/fileutils v0.0.0-20200520151820-abd8a0e76976
+
+replace github.com/munnerz/goautoneg => github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822
+
+replace github.com/mvdan/xurls => github.com/mvdan/xurls v1.1.0
+
+replace github.com/onsi/ginkgo => github.com/onsi/ginkgo v1.11.0
+
+replace github.com/onsi/gomega => github.com/onsi/gomega v1.7.0
+
+replace github.com/opencontainers/go-digest => github.com/opencontainers/go-digest v1.0.0-rc1
+
+replace github.com/opencontainers/runc => github.com/opencontainers/runc v1.0.1
+
+replace github.com/opencontainers/selinux => github.com/opencontainers/selinux v1.5.2
+
+replace github.com/pkg/errors => github.com/pkg/errors v0.9.1
+
+replace github.com/pmezard/go-difflib => github.com/pmezard/go-difflib v1.0.0
+
+replace github.com/prometheus/client_golang => github.com/prometheus/client_golang v1.7.1
+
+replace github.com/prometheus/client_model => github.com/prometheus/client_model v0.2.0
+
+replace github.com/prometheus/common => github.com/prometheus/common v0.10.0
+
+replace github.com/quobyte/api => github.com/quobyte/api v0.1.2
+
+replace github.com/robfig/cron => github.com/robfig/cron v1.1.0
+
+replace github.com/spf13/afero => github.com/spf13/afero v1.2.2
+
+replace github.com/spf13/cobra => github.com/spf13/cobra v1.0.0
+
+replace github.com/spf13/pflag => github.com/spf13/pflag v1.0.5
+
+replace github.com/spf13/viper => github.com/spf13/viper v1.4.0
+
+replace github.com/storageos/go-api => github.com/storageos/go-api v0.0.0-20180912212459-343b3eff91fc
+
+replace github.com/stretchr/testify => github.com/stretchr/testify v1.4.0
+
+replace github.com/thecodeteam/goscaleio => github.com/thecodeteam/goscaleio v0.1.0
+
+replace github.com/vishvananda/netlink => github.com/vishvananda/netlink v1.1.0
+
+replace github.com/vmware/govmomi => github.com/vmware/govmomi v0.20.3
+
+replace go.etcd.io/etcd => go.etcd.io/etcd v0.5.0-alpha.5.0.20200819165624-17cef6e3e9d5
+
+replace golang.org/x/crypto => golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9
+
+replace golang.org/x/net => golang.org/x/net v0.0.0-20201110031124-69a78807bb2b
+
+replace golang.org/x/oauth2 => golang.org/x/oauth2 v0.0.0-20191202225959-858c2ad4c8b6
+
+replace golang.org/x/sys => golang.org/x/sys v0.0.0-20201112073958-5cba982894dd
+
+replace golang.org/x/time => golang.org/x/time v0.0.0-20191024005414-555d28b269f0
+
+replace golang.org/x/tools => golang.org/x/tools v0.0.0-20210106214847-113979e3529a
+
+replace gonum.org/v1/gonum => gonum.org/v1/gonum v0.6.2
+
+replace google.golang.org/api => google.golang.org/api v0.15.1
+
+replace google.golang.org/grpc => google.golang.org/grpc v1.27.0
+
+replace gopkg.in/gcfg.v1 => gopkg.in/gcfg.v1 v1.2.0
+
+replace gopkg.in/square/go-jose.v2 => gopkg.in/square/go-jose.v2 v2.2.2
+
+replace gopkg.in/yaml.v2 => gopkg.in/yaml.v2 v2.2.8
+
+replace k8s.io/gengo => k8s.io/gengo v0.0.0-20200428234225-8167cfdcfc14
+
+replace k8s.io/heapster => k8s.io/heapster v1.2.0-beta.1
+
+replace k8s.io/klog/v2 => k8s.io/klog/v2 v2.2.0
+
+replace k8s.io/kube-openapi => k8s.io/kube-openapi v0.0.0-20200805222855-6aeccd4b50c6
+
+replace k8s.io/system-validators => k8s.io/system-validators v1.1.2
+
+replace k8s.io/utils => k8s.io/utils v0.0.0-20200729134348-d5654de09c73
+
+replace sigs.k8s.io/kustomize => sigs.k8s.io/kustomize v2.0.3+incompatible
+
+replace sigs.k8s.io/yaml => sigs.k8s.io/yaml v1.2.0
+
+replace cloud.google.com/go => cloud.google.com/go v0.51.0
+
+replace cloud.google.com/go/bigquery => cloud.google.com/go/bigquery v1.0.1
+
+replace cloud.google.com/go/datastore => cloud.google.com/go/datastore v1.0.0
+
+replace cloud.google.com/go/pubsub => cloud.google.com/go/pubsub v1.0.1
+
+replace cloud.google.com/go/storage => cloud.google.com/go/storage v1.0.0
+
+replace dmitri.shuralyov.com/gpu/mtl => dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9
+
+replace github.com/Azure/go-ansiterm => github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78
+
+replace github.com/Azure/go-autorest/autorest/date => github.com/Azure/go-autorest/autorest/date v0.2.0
+
+replace github.com/Azure/go-autorest/autorest/mocks => github.com/Azure/go-autorest/autorest/mocks v0.3.0
+
+replace github.com/Azure/go-autorest/autorest/validation => github.com/Azure/go-autorest/autorest/validation v0.1.0
+
+replace github.com/Azure/go-autorest/logger => github.com/Azure/go-autorest/logger v0.1.0
+
+replace github.com/Azure/go-autorest/tracing => github.com/Azure/go-autorest/tracing v0.5.0
+
+replace github.com/BurntSushi/toml => github.com/BurntSushi/toml v0.3.1
+
+replace github.com/BurntSushi/xgb => github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802
+
+replace github.com/MakeNowJust/heredoc => github.com/MakeNowJust/heredoc v0.0.0-20170808103936-bb23615498cd
+
+replace github.com/NYTimes/gziphandler => github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46
+
+replace github.com/PuerkitoBio/urlesc => github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578
+
+replace github.com/agnivade/levenshtein => github.com/agnivade/levenshtein v1.0.1
+
+replace github.com/ajstarks/svgo => github.com/ajstarks/svgo v0.0.0-20180226025133-644b8db467af
+
+replace github.com/alecthomas/template => github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751
+
+replace github.com/alecthomas/units => github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4
+
+replace github.com/andreyvit/diff => github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883
+
+replace github.com/armon/consul-api => github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6
+
+replace github.com/asaskevich/govalidator => github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a
+
+replace github.com/beorn7/perks => github.com/beorn7/perks v1.0.1
+
+replace github.com/bgentry/speakeasy => github.com/bgentry/speakeasy v0.1.0
+
+replace github.com/bifurcation/mint => github.com/bifurcation/mint v0.0.0-20180715133206-93c51c6ce115
+
+replace github.com/cenkalti/backoff => github.com/cenkalti/backoff v2.1.1+incompatible
+
+replace github.com/census-instrumentation/opencensus-proto => github.com/census-instrumentation/opencensus-proto v0.2.1
+
+replace github.com/cespare/xxhash/v2 => github.com/cespare/xxhash/v2 v2.1.1
+
+replace github.com/chai2010/gettext-go => github.com/chai2010/gettext-go v0.0.0-20160711120539-c6fed771bfd5
+
+replace github.com/checkpoint-restore/go-criu/v4 => github.com/checkpoint-restore/go-criu/v4 v4.0.2
+
+replace github.com/cheekybits/genny => github.com/cheekybits/genny v0.0.0-20170328200008-9127e812e1e9
+
+replace github.com/chzyer/logex => github.com/chzyer/logex v1.1.10
+
+replace github.com/chzyer/readline => github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e
+
+replace github.com/chzyer/test => github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1
+
+replace github.com/cilium/ebpf => github.com/cilium/ebpf v0.0.0-20200702112145-1c8d4c9ef775
+
+replace github.com/cockroachdb/datadriven => github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa
+
+replace github.com/containerd/cgroups => github.com/containerd/cgroups v0.0.0-20200531161412-0dbf7f05ba59
+
+replace github.com/containerd/console => github.com/containerd/console v1.0.0
+
+replace github.com/containerd/containerd => github.com/containerd/containerd v1.3.3
+
+replace github.com/containerd/continuity => github.com/containerd/continuity v0.0.0-20190426062206-aaeac12a7ffc
+
+replace github.com/containerd/fifo => github.com/containerd/fifo v0.0.0-20190226154929-a9fb20d87448
+
+replace github.com/containerd/go-runc => github.com/containerd/go-runc v0.0.0-20180907222934-5a6d9f37cfa3
+
+replace github.com/containerd/ttrpc => github.com/containerd/ttrpc v1.0.0
+
+replace github.com/containerd/typeurl => github.com/containerd/typeurl v1.0.0
+
+replace github.com/coreos/bbolt => github.com/coreos/bbolt v1.3.2
+
+replace github.com/coreos/etcd => github.com/coreos/etcd v3.3.10+incompatible
+
+replace github.com/coreos/go-semver => github.com/coreos/go-semver v0.3.0
+
+replace github.com/coreos/go-systemd/v22 => github.com/coreos/go-systemd/v22 v22.1.0
+
+replace github.com/creack/pty => github.com/creack/pty v1.1.7
+
+replace github.com/cyphar/filepath-securejoin => github.com/cyphar/filepath-securejoin v0.2.2
+
+replace github.com/daviddengcn/go-colortext => github.com/daviddengcn/go-colortext v0.0.0-20160507010035-511bcaf42ccd
+
+replace github.com/dgrijalva/jwt-go => github.com/dgrijalva/jwt-go v3.2.0+incompatible
+
+replace github.com/dnaeon/go-vcr => github.com/dnaeon/go-vcr v1.0.1
+
+replace github.com/docker/spdystream => github.com/docker/spdystream v0.0.0-20160310174837-449fdfce4d96
+
+replace github.com/docopt/docopt-go => github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815
+
+replace github.com/dustin/go-humanize => github.com/dustin/go-humanize v1.0.0
+
+replace github.com/envoyproxy/go-control-plane => github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473
+
+replace github.com/envoyproxy/protoc-gen-validate => github.com/envoyproxy/protoc-gen-validate v0.1.0
+
+replace github.com/euank/go-kmsg-parser => github.com/euank/go-kmsg-parser v2.0.0+incompatible
+
+replace github.com/exponent-io/jsonpath => github.com/exponent-io/jsonpath v0.0.0-20151013193312-d6023ce2651d
+
+replace github.com/fatih/camelcase => github.com/fatih/camelcase v1.0.0
+
+replace github.com/fatih/color => github.com/fatih/color v1.7.0
+
+replace github.com/flynn/go-shlex => github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568
+
+replace github.com/fogleman/gg => github.com/fogleman/gg v1.2.1-0.20190220221249-0403632d5b90
+
+replace github.com/ghodss/yaml => github.com/ghodss/yaml v1.0.0
+
+replace github.com/go-acme/lego => github.com/go-acme/lego v2.5.0+incompatible
+
+replace github.com/go-gl/glfw/v3.3/glfw => github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72
+
+replace github.com/go-ini/ini => github.com/go-ini/ini v1.9.0
+
+replace github.com/go-kit/kit => github.com/go-kit/kit v0.9.0
+
+replace github.com/go-logfmt/logfmt => github.com/go-logfmt/logfmt v0.4.0
+
+replace github.com/go-logr/logr => github.com/go-logr/logr v0.2.0
+
+replace github.com/go-openapi/errors => github.com/go-openapi/errors v0.19.2
+
+replace github.com/go-openapi/jsonpointer => github.com/go-openapi/jsonpointer v0.19.3
+
+replace github.com/go-openapi/jsonreference => github.com/go-openapi/jsonreference v0.19.3
+
+replace github.com/go-openapi/runtime => github.com/go-openapi/runtime v0.19.4
+
+replace github.com/go-openapi/swag => github.com/go-openapi/swag v0.19.5
+
+replace github.com/go-stack/stack => github.com/go-stack/stack v1.8.0
+
+replace github.com/godbus/dbus/v5 => github.com/godbus/dbus/v5 v5.0.3
+
+replace github.com/golang/freetype => github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0
+
+replace github.com/golang/glog => github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
+
+replace github.com/golang/protobuf => github.com/golang/protobuf v1.4.2
+
+replace github.com/golangplus/bytes => github.com/golangplus/bytes v0.0.0-20160111154220-45c989fe5450
+
+replace github.com/golangplus/fmt => github.com/golangplus/fmt v0.0.0-20150411045040-2a5d6d7d2995
+
+replace github.com/golangplus/testing => github.com/golangplus/testing v0.0.0-20180327235837-af21d9c3145e
+
+replace github.com/google/btree => github.com/google/btree v1.0.0
+
+replace github.com/google/martian => github.com/google/martian v2.1.0+incompatible
+
+replace github.com/google/pprof => github.com/google/pprof v0.0.0-20191218002539-d4f498aebedc
+
+replace github.com/google/renameio => github.com/google/renameio v0.1.0
+
+replace github.com/googleapis/gax-go/v2 => github.com/googleapis/gax-go/v2 v2.0.5
+
+replace github.com/gophercloud/gophercloud => github.com/gophercloud/gophercloud v0.1.0
+
+replace github.com/gopherjs/gopherjs => github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1
+
+replace github.com/gorilla/mux => github.com/gorilla/mux v1.7.3
+
+replace github.com/gorilla/websocket => github.com/gorilla/websocket v1.4.0
+
+replace github.com/gregjones/httpcache => github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7
+
+replace github.com/grpc-ecosystem/go-grpc-middleware => github.com/grpc-ecosystem/go-grpc-middleware v1.0.1-0.20190118093823-f849b5445de4
+
+replace github.com/grpc-ecosystem/go-grpc-prometheus => github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0
+
+replace github.com/grpc-ecosystem/grpc-gateway => github.com/grpc-ecosystem/grpc-gateway v1.9.5
+
+replace github.com/hashicorp/go-syslog => github.com/hashicorp/go-syslog v1.0.0
+
+replace github.com/hashicorp/hcl => github.com/hashicorp/hcl v1.0.0
+
+replace github.com/hpcloud/tail => github.com/hpcloud/tail v1.0.0
+
+replace github.com/ianlancetaylor/demangle => github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6
+
+replace github.com/imdario/mergo => github.com/imdario/mergo v0.3.5
+
+replace github.com/inconshreveable/mousetrap => github.com/inconshreveable/mousetrap v1.0.0
+
+replace github.com/jimstudt/http-authentication => github.com/jimstudt/http-authentication v0.0.0-20140401203705-3eca13d6893a
+
+replace github.com/jmespath/go-jmespath => github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af
+
+replace github.com/jonboulle/clockwork => github.com/jonboulle/clockwork v0.1.0
+
+replace github.com/jstemmer/go-junit-report => github.com/jstemmer/go-junit-report v0.9.1
+
+replace github.com/jtolds/gls => github.com/jtolds/gls v4.20.0+incompatible
+
+replace github.com/julienschmidt/httprouter => github.com/julienschmidt/httprouter v1.2.0
+
+replace github.com/jung-kurt/gofpdf => github.com/jung-kurt/gofpdf v1.0.3-0.20190309125859-24315acbbda5
+
+replace github.com/karrick/godirwalk => github.com/karrick/godirwalk v1.7.5
+
+replace github.com/kisielk/errcheck => github.com/kisielk/errcheck v1.5.0
+
+replace github.com/kisielk/gotool => github.com/kisielk/gotool v1.0.0
+
+replace github.com/klauspost/cpuid => github.com/klauspost/cpuid v1.2.0
+
+replace github.com/konsorten/go-windows-terminal-sequences => github.com/konsorten/go-windows-terminal-sequences v1.0.3
+
+replace github.com/kr/logfmt => github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515
+
+replace github.com/kr/pretty => github.com/kr/pretty v0.2.0
+
+replace github.com/kr/pty => github.com/kr/pty v1.1.5
+
+replace github.com/kr/text => github.com/kr/text v0.1.0
+
+replace github.com/kylelemons/godebug => github.com/kylelemons/godebug v0.0.0-20170820004349-d65d576e9348
+
+replace github.com/liggitt/tabwriter => github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de
+
+replace github.com/lucas-clemente/aes12 => github.com/lucas-clemente/aes12 v0.0.0-20171027163421-cd47fb39b79f
+
+replace github.com/lucas-clemente/quic-clients => github.com/lucas-clemente/quic-clients v0.1.0
+
+replace github.com/lucas-clemente/quic-go => github.com/lucas-clemente/quic-go v0.10.2
+
+replace github.com/lucas-clemente/quic-go-certificates => github.com/lucas-clemente/quic-go-certificates v0.0.0-20160823095156-d2f86524cced
+
+replace github.com/mailru/easyjson => github.com/mailru/easyjson v0.7.0
+
+replace github.com/marten-seemann/qtls => github.com/marten-seemann/qtls v0.2.3
+
+replace github.com/mattn/go-colorable => github.com/mattn/go-colorable v0.0.9
+
+replace github.com/mattn/go-isatty => github.com/mattn/go-isatty v0.0.4
+
+replace github.com/mattn/go-runewidth => github.com/mattn/go-runewidth v0.0.2
+
+replace github.com/matttproud/golang_protobuf_extensions => github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369
+
+replace github.com/mholt/certmagic => github.com/mholt/certmagic v0.6.2-0.20190624175158-6a42ef9fe8c2
+
+replace github.com/mindprince/gonvml => github.com/mindprince/gonvml v0.0.0-20190828220739-9ebdce4bb989
+
+replace github.com/mistifyio/go-zfs => github.com/mistifyio/go-zfs v2.1.2-0.20190413222219-f784269be439+incompatible
+
+replace github.com/mitchellh/go-homedir => github.com/mitchellh/go-homedir v1.1.0
+
+replace github.com/mitchellh/go-wordwrap => github.com/mitchellh/go-wordwrap v1.0.0
+
+replace github.com/mitchellh/mapstructure => github.com/mitchellh/mapstructure v1.1.2
+
+replace github.com/moby/sys/mountinfo => github.com/moby/sys/mountinfo v0.1.3
+
+replace github.com/moby/term => github.com/moby/term v0.0.0-20200312100748-672ec06f55cd
+
+replace github.com/modern-go/concurrent => github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd
+
+replace github.com/modern-go/reflect2 => github.com/modern-go/reflect2 v1.0.1
+
+replace github.com/morikuni/aec => github.com/morikuni/aec v1.0.0
+
+replace github.com/mwitkow/go-conntrack => github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223
+
+replace github.com/mxk/go-flowrate => github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f
+
+replace github.com/naoina/go-stringutil => github.com/naoina/go-stringutil v0.1.0
+
+replace github.com/naoina/toml => github.com/naoina/toml v0.1.1
+
+replace github.com/olekukonko/tablewriter => github.com/olekukonko/tablewriter v0.0.0-20170122224234-a0225b3f23b5
+
+replace github.com/opencontainers/image-spec => github.com/opencontainers/image-spec v1.0.1
+
+replace github.com/opencontainers/runtime-spec => github.com/opencontainers/runtime-spec v1.0.3-0.20200520003142-237cc4f519e2
+
+replace github.com/pelletier/go-toml => github.com/pelletier/go-toml v1.2.0
+
+replace github.com/peterbourgon/diskv => github.com/peterbourgon/diskv v2.0.1+incompatible
+
+replace github.com/pquerna/cachecontrol => github.com/pquerna/cachecontrol v0.0.0-20171018203845-0dec1b30a021
+
+replace github.com/prometheus/procfs => github.com/prometheus/procfs v0.1.3
+
+replace github.com/remyoudompheng/bigfft => github.com/remyoudompheng/bigfft v0.0.0-20170806203942-52369c62f446
+
+replace github.com/rogpeppe/fastuuid => github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af
+
+replace github.com/rogpeppe/go-internal => github.com/rogpeppe/go-internal v1.3.0
+
+replace github.com/rubiojr/go-vhd => github.com/rubiojr/go-vhd v0.0.0-20200706105327-02e210299021
+
+replace github.com/russross/blackfriday => github.com/russross/blackfriday v1.5.2
+
+replace github.com/russross/blackfriday/v2 => github.com/russross/blackfriday/v2 v2.0.1
+
+replace github.com/satori/go.uuid => github.com/satori/go.uuid v1.2.0
+
+replace github.com/seccomp/libseccomp-golang => github.com/seccomp/libseccomp-golang v0.9.1
+
+replace github.com/sergi/go-diff => github.com/sergi/go-diff v1.0.0
+
+replace github.com/shurcooL/sanitized_anchor_name => github.com/shurcooL/sanitized_anchor_name v1.0.0
+
+replace github.com/sirupsen/logrus => github.com/sirupsen/logrus v1.6.0
+
+replace github.com/smartystreets/assertions => github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d
+
+replace github.com/smartystreets/goconvey => github.com/smartystreets/goconvey v1.6.4
+
+replace github.com/soheilhy/cmux => github.com/soheilhy/cmux v0.1.4
+
+replace github.com/spf13/cast => github.com/spf13/cast v1.3.0
+
+replace github.com/stretchr/objx => github.com/stretchr/objx v0.2.0
+
+replace github.com/syndtr/gocapability => github.com/syndtr/gocapability v0.0.0-20180916011248-d98352740cb2
+
+replace github.com/tidwall/pretty => github.com/tidwall/pretty v1.0.0
+
+replace github.com/tmc/grpc-websocket-proxy => github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5
+
+replace github.com/ugorji/go => github.com/ugorji/go v1.1.4
+
+replace github.com/urfave/cli => github.com/urfave/cli v1.22.2
+
+replace github.com/vektah/gqlparser => github.com/vektah/gqlparser v1.1.2
+
+replace github.com/vishvananda/netns => github.com/vishvananda/netns v0.0.0-20200520041808-52d707b772fe
+
+replace github.com/xiang90/probing => github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2
+
+replace github.com/xlab/handysort => github.com/xlab/handysort v0.0.0-20150421192137-fb3537ed64a1
+
+replace github.com/xordataexchange/crypt => github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77
+
+replace github.com/yuin/goldmark => github.com/yuin/goldmark v1.2.1
+
+replace go.etcd.io/bbolt => go.etcd.io/bbolt v1.3.5
+
+replace go.mongodb.org/mongo-driver => go.mongodb.org/mongo-driver v1.1.2
+
+replace go.opencensus.io => go.opencensus.io v0.22.2
+
+replace go.uber.org/atomic => go.uber.org/atomic v1.4.0
+
+replace go.uber.org/multierr => go.uber.org/multierr v1.1.0
+
+replace go.uber.org/zap => go.uber.org/zap v1.10.0
+
+replace golang.org/x/exp => golang.org/x/exp v0.0.0-20191227195350-da58074b4299
+
+replace golang.org/x/image => golang.org/x/image v0.0.0-20190802002840-cff245a6509b
+
+replace golang.org/x/lint => golang.org/x/lint v0.0.0-20191125180803-fdd1cda4f05f
+
+replace golang.org/x/mobile => golang.org/x/mobile v0.0.0-20190719004257-d2bd2a29d028
+
+replace golang.org/x/mod => golang.org/x/mod v0.3.0
+
+replace golang.org/x/sync => golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9
+
+replace golang.org/x/text => golang.org/x/text v0.3.3
+
+replace golang.org/x/xerrors => golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1
+
+replace gonum.org/v1/plot => gonum.org/v1/plot v0.0.0-20190515093506-e2840ee46a6b
+
+replace google.golang.org/appengine => google.golang.org/appengine v1.6.5
+
+replace google.golang.org/genproto => google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013
+
+replace google.golang.org/protobuf => google.golang.org/protobuf v1.24.0
+
+replace gopkg.in/alecthomas/kingpin.v2 => gopkg.in/alecthomas/kingpin.v2 v2.2.6
+
+replace gopkg.in/check.v1 => gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15
+
+replace gopkg.in/cheggaaa/pb.v1 => gopkg.in/cheggaaa/pb.v1 v1.0.25
+
+replace gopkg.in/errgo.v2 => gopkg.in/errgo.v2 v2.1.0
+
+replace gopkg.in/fsnotify.v1 => gopkg.in/fsnotify.v1 v1.4.7
+
+replace gopkg.in/inf.v0 => gopkg.in/inf.v0 v0.9.1
+
+replace gopkg.in/mcuadros/go-syslog.v2 => gopkg.in/mcuadros/go-syslog.v2 v2.2.1
+
+replace gopkg.in/natefinch/lumberjack.v2 => gopkg.in/natefinch/lumberjack.v2 v2.0.0
+
+replace gopkg.in/resty.v1 => gopkg.in/resty.v1 v1.12.0
+
+replace gopkg.in/tomb.v1 => gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7
+
+replace gopkg.in/warnings.v0 => gopkg.in/warnings.v0 v0.1.1
+
+replace gotest.tools => gotest.tools v2.2.0+incompatible
+
+replace gotest.tools/v3 => gotest.tools/v3 v3.0.2
+
+replace honnef.co/go/tools => honnef.co/go/tools v0.0.1-2019.2.3
+
+replace modernc.org/cc => modernc.org/cc v1.0.0
+
+replace modernc.org/golex => modernc.org/golex v1.0.0
+
+replace modernc.org/mathutil => modernc.org/mathutil v1.0.0
+
+replace modernc.org/strutil => modernc.org/strutil v1.0.0
+
+replace modernc.org/xc => modernc.org/xc v1.0.0
+
+replace rsc.io/pdf => rsc.io/pdf v0.1.1
+
+replace sigs.k8s.io/apiserver-network-proxy/konnectivity-client => sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.15
+
+replace sigs.k8s.io/structured-merge-diff/v4 => sigs.k8s.io/structured-merge-diff/v4 v4.1.2
+
+replace vbom.ml/util => vbom.ml/util v0.0.0-20160121211510-db5cfe13f5cc

--- a/staging/src/k8s.io/sample-controller/go.mod
+++ b/staging/src/k8s.io/sample-controller/go.mod
@@ -5,11 +5,120 @@ module k8s.io/sample-controller
 go 1.15
 
 require (
+	bitbucket.org/bertimus9/systemstat v0.0.0-20180207000608-0eeff89b0690
+	github.com/Azure/azure-sdk-for-go v43.0.0+incompatible
+	github.com/Azure/go-autorest/autorest v0.9.6
+	github.com/Azure/go-autorest/autorest/adal v0.8.2
+	github.com/Azure/go-autorest/autorest/to v0.2.0
+	github.com/GoogleCloudPlatform/k8s-cloud-provider v0.0.0-20200415212048-7901bc822317
+	github.com/JeffAshton/win_pdh v0.0.0-20161109143554-76bb4ee9f0ab
+	github.com/Microsoft/go-winio v0.4.15-0.20190919025122-fc70bd9a86b5
+	github.com/Microsoft/hcsshim v0.8.10-0.20200715222032-5eafd1556990
+	github.com/PuerkitoBio/purell v1.1.1
+	github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e
+	github.com/auth0/go-jwt-middleware v0.0.0-20170425171159-5493cabe49f7
+	github.com/aws/aws-sdk-go v1.28.2
+	github.com/blang/semver v3.5.0+incompatible
+	github.com/boltdb/bolt v1.3.1
+	github.com/caddyserver/caddy v1.0.3
+	github.com/clusterhq/flocker-go v0.0.0-20160920122132-2b8b7259d313
+	github.com/codegangsta/negroni v1.0.0
+	github.com/container-storage-interface/spec v1.2.0
+	github.com/containernetworking/cni v0.8.0
+	github.com/coredns/corefile-migration v1.0.10
+	github.com/coreos/go-oidc v2.1.0+incompatible
+	github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e
+	github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f
+	github.com/cpuguy83/go-md2man/v2 v2.0.0
+	github.com/davecgh/go-spew v1.1.1
+	github.com/docker/distribution v2.7.1+incompatible
+	github.com/docker/docker v1.4.2-0.20200309214505-aa6a9891b09c
+	github.com/docker/go-connections v0.4.0
+	github.com/docker/go-units v0.4.0
+	github.com/elazarl/goproxy v0.0.0-20180725130230-947c36da3153
+	github.com/emicklei/go-restful v2.9.5+incompatible
+	github.com/evanphx/json-patch v4.9.0+incompatible
+	github.com/fsnotify/fsnotify v1.4.9
+	github.com/go-bindata/go-bindata v3.1.1+incompatible
+	github.com/go-openapi/analysis v0.19.5
+	github.com/go-openapi/loads v0.19.4
+	github.com/go-openapi/spec v0.19.3
+	github.com/go-openapi/strfmt v0.19.3
+	github.com/go-openapi/validate v0.19.5
+	github.com/go-ozzo/ozzo-validation v3.5.0+incompatible
+	github.com/gogo/protobuf v1.3.2
+	github.com/golang/groupcache v0.0.0-20191227052852-215e87163ea7
+	github.com/golang/mock v1.3.1
+	github.com/google/cadvisor v0.37.5
+	github.com/google/go-cmp v0.4.0
+	github.com/google/gofuzz v1.1.0
+	github.com/google/uuid v1.1.1
+	github.com/googleapis/gnostic v0.4.1
+	github.com/gorilla/context v1.1.1
+	github.com/hashicorp/golang-lru v0.5.1
+	github.com/heketi/heketi v9.0.1-0.20190917153846-c2e2a4ab7ab9+incompatible
+	github.com/heketi/tests v0.0.0-20151005000721-f3775cbcefd6
+	github.com/ishidawataru/sctp v0.0.0-20190723014705-7c296d48a2b5
+	github.com/json-iterator/go v1.1.10
+	github.com/libopenstorage/openstorage v1.0.0
+	github.com/lithammer/dedent v1.1.0
+	github.com/lpabon/godbc v0.1.1
+	github.com/magiconair/properties v1.8.1
+	github.com/miekg/dns v1.1.4
+	github.com/moby/ipvs v1.0.1
+	github.com/mohae/deepcopy v0.0.0-20170603005431-491d3605edfb
+	github.com/mrunalp/fileutils v0.0.0-20200520151820-abd8a0e76976
+	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822
+	github.com/mvdan/xurls v1.1.0
+	github.com/onsi/ginkgo v1.11.0
+	github.com/onsi/gomega v1.7.0
+	github.com/opencontainers/go-digest v1.0.0-rc1
+	github.com/opencontainers/runc v1.0.1
+	github.com/opencontainers/selinux v1.5.2
+	github.com/pkg/errors v0.9.1
+	github.com/pmezard/go-difflib v1.0.0
+	github.com/prometheus/client_golang v1.7.1
+	github.com/prometheus/client_model v0.2.0
+	github.com/prometheus/common v0.10.0
+	github.com/quobyte/api v0.1.2
+	github.com/robfig/cron v1.1.0
+	github.com/spf13/afero v1.2.2
+	github.com/spf13/cobra v1.0.0
+	github.com/spf13/jwalterweatherman v1.1.0
+	github.com/spf13/pflag v1.0.5
+	github.com/spf13/viper v1.4.0
+	github.com/storageos/go-api v0.0.0-20180912212459-343b3eff91fc
+	github.com/stretchr/testify v1.4.0
+	github.com/thecodeteam/goscaleio v0.1.0
+	github.com/urfave/negroni v1.0.0
+	github.com/vishvananda/netlink v1.1.0
+	github.com/vmware/govmomi v0.20.3
+	go.etcd.io/etcd v0.5.0-alpha.5.0.20200819165624-17cef6e3e9d5
+	golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9
+	golang.org/x/net v0.0.0-20201110031124-69a78807bb2b
+	golang.org/x/oauth2 v0.0.0-20191202225959-858c2ad4c8b6
+	golang.org/x/sys v0.0.0-20201112073958-5cba982894dd
+	golang.org/x/time v0.0.0-20191024005414-555d28b269f0
+	golang.org/x/tools v0.0.0-20210106214847-113979e3529a
+	gonum.org/v1/gonum v0.6.2
+	gonum.org/v1/netlib v0.0.0-20190331212654-76723241ea4e
+	google.golang.org/api v0.15.1
+	google.golang.org/grpc v1.27.0
+	gopkg.in/gcfg.v1 v1.2.0
+	gopkg.in/square/go-jose.v2 v2.2.2
+	gopkg.in/yaml.v2 v2.2.8
 	k8s.io/api v0.0.0
 	k8s.io/apimachinery v0.0.0
 	k8s.io/client-go v0.0.0
 	k8s.io/code-generator v0.0.0
+	k8s.io/gengo v0.0.0-20200428234225-8167cfdcfc14
+	k8s.io/heapster v1.2.0-beta.1
 	k8s.io/klog/v2 v2.2.0
+	k8s.io/kube-openapi v0.0.0-20200805222855-6aeccd4b50c6
+	k8s.io/system-validators v1.1.2
+	k8s.io/utils v0.0.0-20200729134348-d5654de09c73
+	sigs.k8s.io/kustomize v2.0.3+incompatible
+	sigs.k8s.io/yaml v1.2.0
 )
 
 replace (
@@ -19,3 +128,669 @@ replace (
 	k8s.io/code-generator => ../code-generator
 	k8s.io/sample-controller => ../sample-controller
 )
+
+replace github.com/auth0/go-jwt-middleware => github.com/auth0/go-jwt-middleware v0.0.0-20170425171159-5493cabe49f7
+
+replace github.com/boltdb/bolt => github.com/boltdb/bolt v1.3.1
+
+replace github.com/codegangsta/negroni => github.com/codegangsta/negroni v1.0.0
+
+replace github.com/go-ozzo/ozzo-validation => github.com/go-ozzo/ozzo-validation v3.5.0+incompatible
+
+replace github.com/gorilla/context => github.com/gorilla/context v1.1.1
+
+replace github.com/heketi/tests => github.com/heketi/tests v0.0.0-20151005000721-f3775cbcefd6
+
+replace github.com/lpabon/godbc => github.com/lpabon/godbc v0.1.1
+
+replace github.com/magiconair/properties => github.com/magiconair/properties v1.8.1
+
+replace github.com/mohae/deepcopy => github.com/mohae/deepcopy v0.0.0-20170603005431-491d3605edfb
+
+replace github.com/spf13/jwalterweatherman => github.com/spf13/jwalterweatherman v1.1.0
+
+replace github.com/urfave/negroni => github.com/urfave/negroni v1.0.0
+
+replace gonum.org/v1/netlib => gonum.org/v1/netlib v0.0.0-20190331212654-76723241ea4e
+
+replace bitbucket.org/bertimus9/systemstat => bitbucket.org/bertimus9/systemstat v0.0.0-20180207000608-0eeff89b0690
+
+replace github.com/Azure/azure-sdk-for-go => github.com/Azure/azure-sdk-for-go v43.0.0+incompatible
+
+replace github.com/Azure/go-autorest/autorest => github.com/Azure/go-autorest/autorest v0.9.6
+
+replace github.com/Azure/go-autorest/autorest/adal => github.com/Azure/go-autorest/autorest/adal v0.8.2
+
+replace github.com/Azure/go-autorest/autorest/to => github.com/Azure/go-autorest/autorest/to v0.2.0
+
+replace github.com/GoogleCloudPlatform/k8s-cloud-provider => github.com/GoogleCloudPlatform/k8s-cloud-provider v0.0.0-20200415212048-7901bc822317
+
+replace github.com/JeffAshton/win_pdh => github.com/JeffAshton/win_pdh v0.0.0-20161109143554-76bb4ee9f0ab
+
+replace github.com/Microsoft/go-winio => github.com/Microsoft/go-winio v0.4.15-0.20190919025122-fc70bd9a86b5
+
+replace github.com/Microsoft/hcsshim => github.com/Microsoft/hcsshim v0.8.10-0.20200715222032-5eafd1556990
+
+replace github.com/PuerkitoBio/purell => github.com/PuerkitoBio/purell v1.1.1
+
+replace github.com/armon/circbuf => github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e
+
+replace github.com/aws/aws-sdk-go => github.com/aws/aws-sdk-go v1.28.2
+
+replace github.com/blang/semver => github.com/blang/semver v3.5.0+incompatible
+
+replace github.com/caddyserver/caddy => github.com/caddyserver/caddy v1.0.3
+
+replace github.com/clusterhq/flocker-go => github.com/clusterhq/flocker-go v0.0.0-20160920122132-2b8b7259d313
+
+replace github.com/container-storage-interface/spec => github.com/container-storage-interface/spec v1.2.0
+
+replace github.com/containernetworking/cni => github.com/containernetworking/cni v0.8.0
+
+replace github.com/coredns/corefile-migration => github.com/coredns/corefile-migration v1.0.10
+
+replace github.com/coreos/go-oidc => github.com/coreos/go-oidc v2.1.0+incompatible
+
+replace github.com/coreos/go-systemd => github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e
+
+replace github.com/coreos/pkg => github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f
+
+replace github.com/cpuguy83/go-md2man/v2 => github.com/cpuguy83/go-md2man/v2 v2.0.0
+
+replace github.com/davecgh/go-spew => github.com/davecgh/go-spew v1.1.1
+
+replace github.com/docker/distribution => github.com/docker/distribution v2.7.1+incompatible
+
+replace github.com/docker/docker => github.com/docker/docker v1.4.2-0.20200309214505-aa6a9891b09c
+
+replace github.com/docker/go-connections => github.com/docker/go-connections v0.4.0
+
+replace github.com/docker/go-units => github.com/docker/go-units v0.4.0
+
+replace github.com/elazarl/goproxy => github.com/elazarl/goproxy v0.0.0-20180725130230-947c36da3153
+
+replace github.com/emicklei/go-restful => github.com/emicklei/go-restful v2.9.5+incompatible
+
+replace github.com/evanphx/json-patch => github.com/evanphx/json-patch v4.9.0+incompatible
+
+replace github.com/fsnotify/fsnotify => github.com/fsnotify/fsnotify v1.4.9
+
+replace github.com/go-bindata/go-bindata => github.com/go-bindata/go-bindata v3.1.1+incompatible
+
+replace github.com/go-openapi/analysis => github.com/go-openapi/analysis v0.19.5
+
+replace github.com/go-openapi/loads => github.com/go-openapi/loads v0.19.4
+
+replace github.com/go-openapi/spec => github.com/go-openapi/spec v0.19.3
+
+replace github.com/go-openapi/strfmt => github.com/go-openapi/strfmt v0.19.3
+
+replace github.com/go-openapi/validate => github.com/go-openapi/validate v0.19.5
+
+replace github.com/gogo/protobuf => github.com/gogo/protobuf v1.3.2
+
+replace github.com/golang/groupcache => github.com/golang/groupcache v0.0.0-20191227052852-215e87163ea7
+
+replace github.com/golang/mock => github.com/golang/mock v1.3.1
+
+replace github.com/google/cadvisor => github.com/google/cadvisor v0.37.5
+
+replace github.com/google/go-cmp => github.com/google/go-cmp v0.4.0
+
+replace github.com/google/gofuzz => github.com/google/gofuzz v1.1.0
+
+replace github.com/google/uuid => github.com/google/uuid v1.1.1
+
+replace github.com/googleapis/gnostic => github.com/googleapis/gnostic v0.4.1
+
+replace github.com/hashicorp/golang-lru => github.com/hashicorp/golang-lru v0.5.1
+
+replace github.com/heketi/heketi => github.com/heketi/heketi v9.0.1-0.20190917153846-c2e2a4ab7ab9+incompatible
+
+replace github.com/ishidawataru/sctp => github.com/ishidawataru/sctp v0.0.0-20190723014705-7c296d48a2b5
+
+replace github.com/json-iterator/go => github.com/json-iterator/go v1.1.10
+
+replace github.com/libopenstorage/openstorage => github.com/libopenstorage/openstorage v1.0.0
+
+replace github.com/lithammer/dedent => github.com/lithammer/dedent v1.1.0
+
+replace github.com/miekg/dns => github.com/miekg/dns v1.1.4
+
+replace github.com/moby/ipvs => github.com/moby/ipvs v1.0.1
+
+replace github.com/mrunalp/fileutils => github.com/mrunalp/fileutils v0.0.0-20200520151820-abd8a0e76976
+
+replace github.com/munnerz/goautoneg => github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822
+
+replace github.com/mvdan/xurls => github.com/mvdan/xurls v1.1.0
+
+replace github.com/onsi/ginkgo => github.com/onsi/ginkgo v1.11.0
+
+replace github.com/onsi/gomega => github.com/onsi/gomega v1.7.0
+
+replace github.com/opencontainers/go-digest => github.com/opencontainers/go-digest v1.0.0-rc1
+
+replace github.com/opencontainers/runc => github.com/opencontainers/runc v1.0.1
+
+replace github.com/opencontainers/selinux => github.com/opencontainers/selinux v1.5.2
+
+replace github.com/pkg/errors => github.com/pkg/errors v0.9.1
+
+replace github.com/pmezard/go-difflib => github.com/pmezard/go-difflib v1.0.0
+
+replace github.com/prometheus/client_golang => github.com/prometheus/client_golang v1.7.1
+
+replace github.com/prometheus/client_model => github.com/prometheus/client_model v0.2.0
+
+replace github.com/prometheus/common => github.com/prometheus/common v0.10.0
+
+replace github.com/quobyte/api => github.com/quobyte/api v0.1.2
+
+replace github.com/robfig/cron => github.com/robfig/cron v1.1.0
+
+replace github.com/spf13/afero => github.com/spf13/afero v1.2.2
+
+replace github.com/spf13/cobra => github.com/spf13/cobra v1.0.0
+
+replace github.com/spf13/pflag => github.com/spf13/pflag v1.0.5
+
+replace github.com/spf13/viper => github.com/spf13/viper v1.4.0
+
+replace github.com/storageos/go-api => github.com/storageos/go-api v0.0.0-20180912212459-343b3eff91fc
+
+replace github.com/stretchr/testify => github.com/stretchr/testify v1.4.0
+
+replace github.com/thecodeteam/goscaleio => github.com/thecodeteam/goscaleio v0.1.0
+
+replace github.com/vishvananda/netlink => github.com/vishvananda/netlink v1.1.0
+
+replace github.com/vmware/govmomi => github.com/vmware/govmomi v0.20.3
+
+replace go.etcd.io/etcd => go.etcd.io/etcd v0.5.0-alpha.5.0.20200819165624-17cef6e3e9d5
+
+replace golang.org/x/crypto => golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9
+
+replace golang.org/x/net => golang.org/x/net v0.0.0-20201110031124-69a78807bb2b
+
+replace golang.org/x/oauth2 => golang.org/x/oauth2 v0.0.0-20191202225959-858c2ad4c8b6
+
+replace golang.org/x/sys => golang.org/x/sys v0.0.0-20201112073958-5cba982894dd
+
+replace golang.org/x/time => golang.org/x/time v0.0.0-20191024005414-555d28b269f0
+
+replace golang.org/x/tools => golang.org/x/tools v0.0.0-20210106214847-113979e3529a
+
+replace gonum.org/v1/gonum => gonum.org/v1/gonum v0.6.2
+
+replace google.golang.org/api => google.golang.org/api v0.15.1
+
+replace google.golang.org/grpc => google.golang.org/grpc v1.27.0
+
+replace gopkg.in/gcfg.v1 => gopkg.in/gcfg.v1 v1.2.0
+
+replace gopkg.in/square/go-jose.v2 => gopkg.in/square/go-jose.v2 v2.2.2
+
+replace gopkg.in/yaml.v2 => gopkg.in/yaml.v2 v2.2.8
+
+replace k8s.io/gengo => k8s.io/gengo v0.0.0-20200428234225-8167cfdcfc14
+
+replace k8s.io/heapster => k8s.io/heapster v1.2.0-beta.1
+
+replace k8s.io/klog/v2 => k8s.io/klog/v2 v2.2.0
+
+replace k8s.io/kube-openapi => k8s.io/kube-openapi v0.0.0-20200805222855-6aeccd4b50c6
+
+replace k8s.io/system-validators => k8s.io/system-validators v1.1.2
+
+replace k8s.io/utils => k8s.io/utils v0.0.0-20200729134348-d5654de09c73
+
+replace sigs.k8s.io/kustomize => sigs.k8s.io/kustomize v2.0.3+incompatible
+
+replace sigs.k8s.io/yaml => sigs.k8s.io/yaml v1.2.0
+
+replace cloud.google.com/go => cloud.google.com/go v0.51.0
+
+replace cloud.google.com/go/bigquery => cloud.google.com/go/bigquery v1.0.1
+
+replace cloud.google.com/go/datastore => cloud.google.com/go/datastore v1.0.0
+
+replace cloud.google.com/go/pubsub => cloud.google.com/go/pubsub v1.0.1
+
+replace cloud.google.com/go/storage => cloud.google.com/go/storage v1.0.0
+
+replace dmitri.shuralyov.com/gpu/mtl => dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9
+
+replace github.com/Azure/go-ansiterm => github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78
+
+replace github.com/Azure/go-autorest/autorest/date => github.com/Azure/go-autorest/autorest/date v0.2.0
+
+replace github.com/Azure/go-autorest/autorest/mocks => github.com/Azure/go-autorest/autorest/mocks v0.3.0
+
+replace github.com/Azure/go-autorest/autorest/validation => github.com/Azure/go-autorest/autorest/validation v0.1.0
+
+replace github.com/Azure/go-autorest/logger => github.com/Azure/go-autorest/logger v0.1.0
+
+replace github.com/Azure/go-autorest/tracing => github.com/Azure/go-autorest/tracing v0.5.0
+
+replace github.com/BurntSushi/toml => github.com/BurntSushi/toml v0.3.1
+
+replace github.com/BurntSushi/xgb => github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802
+
+replace github.com/MakeNowJust/heredoc => github.com/MakeNowJust/heredoc v0.0.0-20170808103936-bb23615498cd
+
+replace github.com/NYTimes/gziphandler => github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46
+
+replace github.com/PuerkitoBio/urlesc => github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578
+
+replace github.com/agnivade/levenshtein => github.com/agnivade/levenshtein v1.0.1
+
+replace github.com/ajstarks/svgo => github.com/ajstarks/svgo v0.0.0-20180226025133-644b8db467af
+
+replace github.com/alecthomas/template => github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751
+
+replace github.com/alecthomas/units => github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4
+
+replace github.com/andreyvit/diff => github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883
+
+replace github.com/armon/consul-api => github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6
+
+replace github.com/asaskevich/govalidator => github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a
+
+replace github.com/beorn7/perks => github.com/beorn7/perks v1.0.1
+
+replace github.com/bgentry/speakeasy => github.com/bgentry/speakeasy v0.1.0
+
+replace github.com/bifurcation/mint => github.com/bifurcation/mint v0.0.0-20180715133206-93c51c6ce115
+
+replace github.com/cenkalti/backoff => github.com/cenkalti/backoff v2.1.1+incompatible
+
+replace github.com/census-instrumentation/opencensus-proto => github.com/census-instrumentation/opencensus-proto v0.2.1
+
+replace github.com/cespare/xxhash/v2 => github.com/cespare/xxhash/v2 v2.1.1
+
+replace github.com/chai2010/gettext-go => github.com/chai2010/gettext-go v0.0.0-20160711120539-c6fed771bfd5
+
+replace github.com/checkpoint-restore/go-criu/v4 => github.com/checkpoint-restore/go-criu/v4 v4.0.2
+
+replace github.com/cheekybits/genny => github.com/cheekybits/genny v0.0.0-20170328200008-9127e812e1e9
+
+replace github.com/chzyer/logex => github.com/chzyer/logex v1.1.10
+
+replace github.com/chzyer/readline => github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e
+
+replace github.com/chzyer/test => github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1
+
+replace github.com/cilium/ebpf => github.com/cilium/ebpf v0.0.0-20200702112145-1c8d4c9ef775
+
+replace github.com/cockroachdb/datadriven => github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa
+
+replace github.com/containerd/cgroups => github.com/containerd/cgroups v0.0.0-20200531161412-0dbf7f05ba59
+
+replace github.com/containerd/console => github.com/containerd/console v1.0.0
+
+replace github.com/containerd/containerd => github.com/containerd/containerd v1.3.3
+
+replace github.com/containerd/continuity => github.com/containerd/continuity v0.0.0-20190426062206-aaeac12a7ffc
+
+replace github.com/containerd/fifo => github.com/containerd/fifo v0.0.0-20190226154929-a9fb20d87448
+
+replace github.com/containerd/go-runc => github.com/containerd/go-runc v0.0.0-20180907222934-5a6d9f37cfa3
+
+replace github.com/containerd/ttrpc => github.com/containerd/ttrpc v1.0.0
+
+replace github.com/containerd/typeurl => github.com/containerd/typeurl v1.0.0
+
+replace github.com/coreos/bbolt => github.com/coreos/bbolt v1.3.2
+
+replace github.com/coreos/etcd => github.com/coreos/etcd v3.3.10+incompatible
+
+replace github.com/coreos/go-semver => github.com/coreos/go-semver v0.3.0
+
+replace github.com/coreos/go-systemd/v22 => github.com/coreos/go-systemd/v22 v22.1.0
+
+replace github.com/creack/pty => github.com/creack/pty v1.1.7
+
+replace github.com/cyphar/filepath-securejoin => github.com/cyphar/filepath-securejoin v0.2.2
+
+replace github.com/daviddengcn/go-colortext => github.com/daviddengcn/go-colortext v0.0.0-20160507010035-511bcaf42ccd
+
+replace github.com/dgrijalva/jwt-go => github.com/dgrijalva/jwt-go v3.2.0+incompatible
+
+replace github.com/dnaeon/go-vcr => github.com/dnaeon/go-vcr v1.0.1
+
+replace github.com/docker/spdystream => github.com/docker/spdystream v0.0.0-20160310174837-449fdfce4d96
+
+replace github.com/docopt/docopt-go => github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815
+
+replace github.com/dustin/go-humanize => github.com/dustin/go-humanize v1.0.0
+
+replace github.com/envoyproxy/go-control-plane => github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473
+
+replace github.com/envoyproxy/protoc-gen-validate => github.com/envoyproxy/protoc-gen-validate v0.1.0
+
+replace github.com/euank/go-kmsg-parser => github.com/euank/go-kmsg-parser v2.0.0+incompatible
+
+replace github.com/exponent-io/jsonpath => github.com/exponent-io/jsonpath v0.0.0-20151013193312-d6023ce2651d
+
+replace github.com/fatih/camelcase => github.com/fatih/camelcase v1.0.0
+
+replace github.com/fatih/color => github.com/fatih/color v1.7.0
+
+replace github.com/flynn/go-shlex => github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568
+
+replace github.com/fogleman/gg => github.com/fogleman/gg v1.2.1-0.20190220221249-0403632d5b90
+
+replace github.com/ghodss/yaml => github.com/ghodss/yaml v1.0.0
+
+replace github.com/go-acme/lego => github.com/go-acme/lego v2.5.0+incompatible
+
+replace github.com/go-gl/glfw/v3.3/glfw => github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72
+
+replace github.com/go-ini/ini => github.com/go-ini/ini v1.9.0
+
+replace github.com/go-kit/kit => github.com/go-kit/kit v0.9.0
+
+replace github.com/go-logfmt/logfmt => github.com/go-logfmt/logfmt v0.4.0
+
+replace github.com/go-logr/logr => github.com/go-logr/logr v0.2.0
+
+replace github.com/go-openapi/errors => github.com/go-openapi/errors v0.19.2
+
+replace github.com/go-openapi/jsonpointer => github.com/go-openapi/jsonpointer v0.19.3
+
+replace github.com/go-openapi/jsonreference => github.com/go-openapi/jsonreference v0.19.3
+
+replace github.com/go-openapi/runtime => github.com/go-openapi/runtime v0.19.4
+
+replace github.com/go-openapi/swag => github.com/go-openapi/swag v0.19.5
+
+replace github.com/go-stack/stack => github.com/go-stack/stack v1.8.0
+
+replace github.com/godbus/dbus/v5 => github.com/godbus/dbus/v5 v5.0.3
+
+replace github.com/golang/freetype => github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0
+
+replace github.com/golang/glog => github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
+
+replace github.com/golang/protobuf => github.com/golang/protobuf v1.4.2
+
+replace github.com/golangplus/bytes => github.com/golangplus/bytes v0.0.0-20160111154220-45c989fe5450
+
+replace github.com/golangplus/fmt => github.com/golangplus/fmt v0.0.0-20150411045040-2a5d6d7d2995
+
+replace github.com/golangplus/testing => github.com/golangplus/testing v0.0.0-20180327235837-af21d9c3145e
+
+replace github.com/google/btree => github.com/google/btree v1.0.0
+
+replace github.com/google/martian => github.com/google/martian v2.1.0+incompatible
+
+replace github.com/google/pprof => github.com/google/pprof v0.0.0-20191218002539-d4f498aebedc
+
+replace github.com/google/renameio => github.com/google/renameio v0.1.0
+
+replace github.com/googleapis/gax-go/v2 => github.com/googleapis/gax-go/v2 v2.0.5
+
+replace github.com/gophercloud/gophercloud => github.com/gophercloud/gophercloud v0.1.0
+
+replace github.com/gopherjs/gopherjs => github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1
+
+replace github.com/gorilla/mux => github.com/gorilla/mux v1.7.3
+
+replace github.com/gorilla/websocket => github.com/gorilla/websocket v1.4.0
+
+replace github.com/gregjones/httpcache => github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7
+
+replace github.com/grpc-ecosystem/go-grpc-middleware => github.com/grpc-ecosystem/go-grpc-middleware v1.0.1-0.20190118093823-f849b5445de4
+
+replace github.com/grpc-ecosystem/go-grpc-prometheus => github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0
+
+replace github.com/grpc-ecosystem/grpc-gateway => github.com/grpc-ecosystem/grpc-gateway v1.9.5
+
+replace github.com/hashicorp/go-syslog => github.com/hashicorp/go-syslog v1.0.0
+
+replace github.com/hashicorp/hcl => github.com/hashicorp/hcl v1.0.0
+
+replace github.com/hpcloud/tail => github.com/hpcloud/tail v1.0.0
+
+replace github.com/ianlancetaylor/demangle => github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6
+
+replace github.com/imdario/mergo => github.com/imdario/mergo v0.3.5
+
+replace github.com/inconshreveable/mousetrap => github.com/inconshreveable/mousetrap v1.0.0
+
+replace github.com/jimstudt/http-authentication => github.com/jimstudt/http-authentication v0.0.0-20140401203705-3eca13d6893a
+
+replace github.com/jmespath/go-jmespath => github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af
+
+replace github.com/jonboulle/clockwork => github.com/jonboulle/clockwork v0.1.0
+
+replace github.com/jstemmer/go-junit-report => github.com/jstemmer/go-junit-report v0.9.1
+
+replace github.com/jtolds/gls => github.com/jtolds/gls v4.20.0+incompatible
+
+replace github.com/julienschmidt/httprouter => github.com/julienschmidt/httprouter v1.2.0
+
+replace github.com/jung-kurt/gofpdf => github.com/jung-kurt/gofpdf v1.0.3-0.20190309125859-24315acbbda5
+
+replace github.com/karrick/godirwalk => github.com/karrick/godirwalk v1.7.5
+
+replace github.com/kisielk/errcheck => github.com/kisielk/errcheck v1.5.0
+
+replace github.com/kisielk/gotool => github.com/kisielk/gotool v1.0.0
+
+replace github.com/klauspost/cpuid => github.com/klauspost/cpuid v1.2.0
+
+replace github.com/konsorten/go-windows-terminal-sequences => github.com/konsorten/go-windows-terminal-sequences v1.0.3
+
+replace github.com/kr/logfmt => github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515
+
+replace github.com/kr/pretty => github.com/kr/pretty v0.2.0
+
+replace github.com/kr/pty => github.com/kr/pty v1.1.5
+
+replace github.com/kr/text => github.com/kr/text v0.1.0
+
+replace github.com/kylelemons/godebug => github.com/kylelemons/godebug v0.0.0-20170820004349-d65d576e9348
+
+replace github.com/liggitt/tabwriter => github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de
+
+replace github.com/lucas-clemente/aes12 => github.com/lucas-clemente/aes12 v0.0.0-20171027163421-cd47fb39b79f
+
+replace github.com/lucas-clemente/quic-clients => github.com/lucas-clemente/quic-clients v0.1.0
+
+replace github.com/lucas-clemente/quic-go => github.com/lucas-clemente/quic-go v0.10.2
+
+replace github.com/lucas-clemente/quic-go-certificates => github.com/lucas-clemente/quic-go-certificates v0.0.0-20160823095156-d2f86524cced
+
+replace github.com/mailru/easyjson => github.com/mailru/easyjson v0.7.0
+
+replace github.com/marten-seemann/qtls => github.com/marten-seemann/qtls v0.2.3
+
+replace github.com/mattn/go-colorable => github.com/mattn/go-colorable v0.0.9
+
+replace github.com/mattn/go-isatty => github.com/mattn/go-isatty v0.0.4
+
+replace github.com/mattn/go-runewidth => github.com/mattn/go-runewidth v0.0.2
+
+replace github.com/matttproud/golang_protobuf_extensions => github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369
+
+replace github.com/mholt/certmagic => github.com/mholt/certmagic v0.6.2-0.20190624175158-6a42ef9fe8c2
+
+replace github.com/mindprince/gonvml => github.com/mindprince/gonvml v0.0.0-20190828220739-9ebdce4bb989
+
+replace github.com/mistifyio/go-zfs => github.com/mistifyio/go-zfs v2.1.2-0.20190413222219-f784269be439+incompatible
+
+replace github.com/mitchellh/go-homedir => github.com/mitchellh/go-homedir v1.1.0
+
+replace github.com/mitchellh/go-wordwrap => github.com/mitchellh/go-wordwrap v1.0.0
+
+replace github.com/mitchellh/mapstructure => github.com/mitchellh/mapstructure v1.1.2
+
+replace github.com/moby/sys/mountinfo => github.com/moby/sys/mountinfo v0.1.3
+
+replace github.com/moby/term => github.com/moby/term v0.0.0-20200312100748-672ec06f55cd
+
+replace github.com/modern-go/concurrent => github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd
+
+replace github.com/modern-go/reflect2 => github.com/modern-go/reflect2 v1.0.1
+
+replace github.com/morikuni/aec => github.com/morikuni/aec v1.0.0
+
+replace github.com/mwitkow/go-conntrack => github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223
+
+replace github.com/mxk/go-flowrate => github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f
+
+replace github.com/naoina/go-stringutil => github.com/naoina/go-stringutil v0.1.0
+
+replace github.com/naoina/toml => github.com/naoina/toml v0.1.1
+
+replace github.com/olekukonko/tablewriter => github.com/olekukonko/tablewriter v0.0.0-20170122224234-a0225b3f23b5
+
+replace github.com/opencontainers/image-spec => github.com/opencontainers/image-spec v1.0.1
+
+replace github.com/opencontainers/runtime-spec => github.com/opencontainers/runtime-spec v1.0.3-0.20200520003142-237cc4f519e2
+
+replace github.com/pelletier/go-toml => github.com/pelletier/go-toml v1.2.0
+
+replace github.com/peterbourgon/diskv => github.com/peterbourgon/diskv v2.0.1+incompatible
+
+replace github.com/pquerna/cachecontrol => github.com/pquerna/cachecontrol v0.0.0-20171018203845-0dec1b30a021
+
+replace github.com/prometheus/procfs => github.com/prometheus/procfs v0.1.3
+
+replace github.com/remyoudompheng/bigfft => github.com/remyoudompheng/bigfft v0.0.0-20170806203942-52369c62f446
+
+replace github.com/rogpeppe/fastuuid => github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af
+
+replace github.com/rogpeppe/go-internal => github.com/rogpeppe/go-internal v1.3.0
+
+replace github.com/rubiojr/go-vhd => github.com/rubiojr/go-vhd v0.0.0-20200706105327-02e210299021
+
+replace github.com/russross/blackfriday => github.com/russross/blackfriday v1.5.2
+
+replace github.com/russross/blackfriday/v2 => github.com/russross/blackfriday/v2 v2.0.1
+
+replace github.com/satori/go.uuid => github.com/satori/go.uuid v1.2.0
+
+replace github.com/seccomp/libseccomp-golang => github.com/seccomp/libseccomp-golang v0.9.1
+
+replace github.com/sergi/go-diff => github.com/sergi/go-diff v1.0.0
+
+replace github.com/shurcooL/sanitized_anchor_name => github.com/shurcooL/sanitized_anchor_name v1.0.0
+
+replace github.com/sirupsen/logrus => github.com/sirupsen/logrus v1.6.0
+
+replace github.com/smartystreets/assertions => github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d
+
+replace github.com/smartystreets/goconvey => github.com/smartystreets/goconvey v1.6.4
+
+replace github.com/soheilhy/cmux => github.com/soheilhy/cmux v0.1.4
+
+replace github.com/spf13/cast => github.com/spf13/cast v1.3.0
+
+replace github.com/stretchr/objx => github.com/stretchr/objx v0.2.0
+
+replace github.com/syndtr/gocapability => github.com/syndtr/gocapability v0.0.0-20180916011248-d98352740cb2
+
+replace github.com/tidwall/pretty => github.com/tidwall/pretty v1.0.0
+
+replace github.com/tmc/grpc-websocket-proxy => github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5
+
+replace github.com/ugorji/go => github.com/ugorji/go v1.1.4
+
+replace github.com/urfave/cli => github.com/urfave/cli v1.22.2
+
+replace github.com/vektah/gqlparser => github.com/vektah/gqlparser v1.1.2
+
+replace github.com/vishvananda/netns => github.com/vishvananda/netns v0.0.0-20200520041808-52d707b772fe
+
+replace github.com/xiang90/probing => github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2
+
+replace github.com/xlab/handysort => github.com/xlab/handysort v0.0.0-20150421192137-fb3537ed64a1
+
+replace github.com/xordataexchange/crypt => github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77
+
+replace github.com/yuin/goldmark => github.com/yuin/goldmark v1.2.1
+
+replace go.etcd.io/bbolt => go.etcd.io/bbolt v1.3.5
+
+replace go.mongodb.org/mongo-driver => go.mongodb.org/mongo-driver v1.1.2
+
+replace go.opencensus.io => go.opencensus.io v0.22.2
+
+replace go.uber.org/atomic => go.uber.org/atomic v1.4.0
+
+replace go.uber.org/multierr => go.uber.org/multierr v1.1.0
+
+replace go.uber.org/zap => go.uber.org/zap v1.10.0
+
+replace golang.org/x/exp => golang.org/x/exp v0.0.0-20191227195350-da58074b4299
+
+replace golang.org/x/image => golang.org/x/image v0.0.0-20190802002840-cff245a6509b
+
+replace golang.org/x/lint => golang.org/x/lint v0.0.0-20191125180803-fdd1cda4f05f
+
+replace golang.org/x/mobile => golang.org/x/mobile v0.0.0-20190719004257-d2bd2a29d028
+
+replace golang.org/x/mod => golang.org/x/mod v0.3.0
+
+replace golang.org/x/sync => golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9
+
+replace golang.org/x/text => golang.org/x/text v0.3.3
+
+replace golang.org/x/xerrors => golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1
+
+replace gonum.org/v1/plot => gonum.org/v1/plot v0.0.0-20190515093506-e2840ee46a6b
+
+replace google.golang.org/appengine => google.golang.org/appengine v1.6.5
+
+replace google.golang.org/genproto => google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013
+
+replace google.golang.org/protobuf => google.golang.org/protobuf v1.24.0
+
+replace gopkg.in/alecthomas/kingpin.v2 => gopkg.in/alecthomas/kingpin.v2 v2.2.6
+
+replace gopkg.in/check.v1 => gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15
+
+replace gopkg.in/cheggaaa/pb.v1 => gopkg.in/cheggaaa/pb.v1 v1.0.25
+
+replace gopkg.in/errgo.v2 => gopkg.in/errgo.v2 v2.1.0
+
+replace gopkg.in/fsnotify.v1 => gopkg.in/fsnotify.v1 v1.4.7
+
+replace gopkg.in/inf.v0 => gopkg.in/inf.v0 v0.9.1
+
+replace gopkg.in/mcuadros/go-syslog.v2 => gopkg.in/mcuadros/go-syslog.v2 v2.2.1
+
+replace gopkg.in/natefinch/lumberjack.v2 => gopkg.in/natefinch/lumberjack.v2 v2.0.0
+
+replace gopkg.in/resty.v1 => gopkg.in/resty.v1 v1.12.0
+
+replace gopkg.in/tomb.v1 => gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7
+
+replace gopkg.in/warnings.v0 => gopkg.in/warnings.v0 v0.1.1
+
+replace gotest.tools => gotest.tools v2.2.0+incompatible
+
+replace gotest.tools/v3 => gotest.tools/v3 v3.0.2
+
+replace honnef.co/go/tools => honnef.co/go/tools v0.0.1-2019.2.3
+
+replace modernc.org/cc => modernc.org/cc v1.0.0
+
+replace modernc.org/golex => modernc.org/golex v1.0.0
+
+replace modernc.org/mathutil => modernc.org/mathutil v1.0.0
+
+replace modernc.org/strutil => modernc.org/strutil v1.0.0
+
+replace modernc.org/xc => modernc.org/xc v1.0.0
+
+replace rsc.io/pdf => rsc.io/pdf v0.1.1
+
+replace sigs.k8s.io/apiserver-network-proxy/konnectivity-client => sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.15
+
+replace sigs.k8s.io/structured-merge-diff/v4 => sigs.k8s.io/structured-merge-diff/v4 v4.1.2
+
+replace vbom.ml/util => vbom.ml/util v0.0.0-20160121211510-db5cfe13f5cc


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
Fixes cAdvisor exposing misleading IO metrics in cgroups v2

Runc release notes:
- 1.0.0: https://github.com/opencontainers/runc/releases/tag/v1.0.0
- 1.0.1: https://github.com/opencontainers/runc/releases/tag/v1.0.1

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #102285

#### Special notes for your reviewer:

- Fix already exists in master via PR: https://github.com/kubernetes/kubernetes/pull/103743
- Backport to release/1.21 pending via PR: https://github.com/kubernetes/kubernetes/pull/103746
- Backport to release/1.20 pending via PR: https://github.com/kubernetes/kubernetes/pull/104237

Commands
```
hack/pin-dependency.sh github.com/opencontainers/runc v1.0.1
hack/update-vendor.sh
hack/lint-dependencies.sh
```

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
