### PR TITLE
kubeadm: Bump minimum supported versions and add etcd version for 1.2…

### DIFF
--- a/cmd/kubeadm/app/constants/constants.go
+++ b/cmd/kubeadm/app/constants/constants.go
@@ -469,6 +469,7 @@ var (
 		21: "3.4.13-0",
 		22: "3.5.0-0",
 		23: "3.5.0-0",
+		24: "3.5.0-0",
 	}
 
 	// KubeadmCertsClusterRoleName sets the name for the ClusterRole that allows


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

With great pleasure to contribute to Kubernetes!

#### What this PR does / why we need it:
#### Which issue(s) this PR fixes:
kubernetes/kubeadm#2539

Clean up 1.23 housekeeping tasks:

Bump minimum supported versions and add etcd version for 1.23 and placeholder for 1.24
Does this PR introduce a user-facing change?
```
None
```
Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```
None
```