### PR TITLE
remove listx from OWNERS_ALIASES

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -134,7 +134,6 @@ aliases:
     - cblecker
     - dims
     - justaugustus # Release Manager / SIG Chair
-    - listx
   build-image-reviewers:
     - BenTheElder
     - cblecker
@@ -144,7 +143,6 @@ aliases:
     - hasheddan # Release Manager / SIG Technical Lead
     - idealhack # Release Manager
     - justaugustus # Release Manager / SIG Chair
-    - listx
     - puerco # Release Manager
     - saschagrunert # Release Manager / SIG Chair
     - xmudrii # Release Manager


### PR DESCRIPTION
Removing myself for now as I navigate the transition to the Prow team.

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
