### PR TITLE
remove listx from OWNERS_ALIASES

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -139,7 +139,6 @@ aliases:
     - cblecker
     - dims
     - justaugustus # Release Manager / SIG Chair
-    - listx
   build-image-reviewers:
     - BenTheElder
     - cblecker
@@ -149,7 +148,6 @@ aliases:
     - hasheddan # Release Manager / SIG Technical Lead
     - idealhack # Release Manager
     - justaugustus # Release Manager / SIG Chair
-    - listx
     - puerco # Release Manager
     - saschagrunert # Release Manager / SIG Chair
     - xmudrii # Release Manager

--- a/test/images/OWNERS
+++ b/test/images/OWNERS
@@ -3,10 +3,8 @@
 reviewers:
   - mkumatag
   - justaugustus
-  - listx
 approvers:
   - mkumatag
-  - listx
 emeritus_approvers:
   - ixdy
   - luxas

--- a/test/utils/image/OWNERS
+++ b/test/utils/image/OWNERS
@@ -4,10 +4,8 @@ reviewers:
   - justaugustus
   - luxas
   - mkumatag
-  - listx
 approvers:
   - luxas
   - mkumatag
-  - listx
 emeritus_approvers:
   - ixdy


### PR DESCRIPTION
Removing myself for now as I navigate the transition to the Prow team.

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
