### PR TITLE
[WIP] [DO-NOT-MERGE] Lazy aggregation for OpenAPI v2 spec

### DIFF
--- a/staging/src/k8s.io/kube-aggregator/pkg/controllers/openapi/aggregator/aggregator.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/controllers/openapi/aggregator/aggregator.go
@@ -120,7 +120,7 @@ func BuildAndRegisterAggregator(downloader *Downloader, delegationTarget server.
 	}
 
 	// Install handler
-	s.openAPIVersionedService, err = handler.NewOpenAPIService(specToServe, s.GetNewOpenAPISpec)
+	s.openAPIVersionedService, err = handler.NewOpenAPIService(specToServe)
 	if err != nil {
 		return nil, err
 	}
@@ -214,9 +214,11 @@ func (s *specAggregator) updateOpenAPISpec() error {
 	if s.openAPIVersionedService == nil {
 		return nil
 	}
-	s.openAPIVersionedService.MarkCacheDirty()
-	// TODO(DangerOnTheRanger): This function could return an error before, but not now - remove error-checking references from callers
-	return nil
+	specToServe, err := s.buildOpenAPISpec()
+	if err != nil {
+		return err
+	}
+	return s.openAPIVersionedService.UpdateSpec(specToServe)
 }
 
 // tryUpdatingServiceSpecs tries updating openAPISpecs map with specified specInfo, and keeps the map intact

--- a/vendor/k8s.io/kube-openapi/pkg/handler/handler.go
+++ b/vendor/k8s.io/kube-openapi/pkg/handler/handler.go
@@ -78,6 +78,13 @@ func computeETag(data []byte) string {
 	return fmt.Sprintf("\"%X\"", sha512.Sum512(data))
 }
 
+func (c *cache) Get() ([]byte, string, error) {
+	c.once.Do(func() {
+		c.bytes, c.etag, c.err = c.BuildCache()
+	})
+	return c.bytes, c.etag, c.err
+}
+
 // NewOpenAPIService builds an OpenAPIService starting with the given spec.
 func NewOpenAPIService(spec *spec.Swagger) (*OpenAPIService, error) {
 	o := &OpenAPIService{}
@@ -281,17 +288,4 @@ func BuildAndRegisterOpenAPIVersionedService(servePath string, webServices []*re
 		return nil, err
 	}
 	return o, o.RegisterOpenAPIVersionedService(servePath, handler)
-}
-
-func (c *cache) Get() ([]byte, string, error) {
-	c.once.Do(func() {
-		bytes, etag, err := c.BuildCache()
-		c.bytes = bytes
-		c.etag = etag
-		c.err = err
-	})
-	if c.err != nil {
-		return nil, "", c.err
-	}
-	return c.bytes, c.etag, nil
 }

--- a/vendor/k8s.io/kube-openapi/pkg/handler/handler.go
+++ b/vendor/k8s.io/kube-openapi/pkg/handler/handler.go
@@ -96,6 +96,8 @@ func NewOpenAPIService(spec *spec.Swagger) (*OpenAPIService, error) {
 }
 
 func (o *OpenAPIService) getSwaggerBytes() ([]byte, string, time.Time) {
+	o.rwMutex.RLock()
+	defer o.rwMutex.RUnlock()
 	specBytes, etag, err := o.jsonCache.Get()
 	if err != nil {
 		// TODO(DangerOnTheRanger): add panic here after further testing
@@ -104,6 +106,8 @@ func (o *OpenAPIService) getSwaggerBytes() ([]byte, string, time.Time) {
 }
 
 func (o *OpenAPIService) getSwaggerPbBytes() ([]byte, string, time.Time) {
+	o.rwMutex.RLock()
+	defer o.rwMutex.RUnlock()
 	specPb, etag, err := o.protoCache.Get()
 	if err != nil {
 		// TODO(DangerOnTheRanger): add panic here after further testing
@@ -112,6 +116,8 @@ func (o *OpenAPIService) getSwaggerPbBytes() ([]byte, string, time.Time) {
 }
 
 func (o *OpenAPIService) getSwaggerPbGzBytes() ([]byte, string, time.Time) {
+	o.rwMutex.RLock()
+	defer o.rwMutex.RUnlock()
 	specPbGz, etag, err := o.protoGzCache.Get()
 	if err != nil {
 		// TODO(DangerOnTheRanger): add panic here after further testing

--- a/vendor/k8s.io/kube-openapi/pkg/handler/handler_test.go
+++ b/vendor/k8s.io/kube-openapi/pkg/handler/handler_test.go
@@ -1,0 +1,53 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package handler
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestCache(t *testing.T) {
+	calledCount := 0
+	expectedBytes := []byte("ABC")
+	cacheObj := cache{
+		BuildCache: func() ([]byte, string, error) {
+			calledCount++
+			return expectedBytes, "", nil
+		},
+	}
+	bytes, _, _ := cacheObj.Get()
+	if string(bytes) != string(expectedBytes) {
+		t.Fatalf("got value of %q from cache (expected %q)", bytes, expectedBytes)
+	}
+	cacheObj.Get()
+	if calledCount != 1 {
+		t.Fatalf("expected BuildCache to be called once (called %d times)", calledCount)
+	}
+}
+
+func TestCacheError(t *testing.T) {
+	cacheObj := cache{
+		BuildCache: func() ([]byte, string, error) {
+			return nil, "", errors.New("cache error")
+		},
+	}
+	_, _, err := cacheObj.Get()
+	if err == nil {
+		t.Fatalf("expected non-nil err from cache.Get()")
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

This branch is meant to explore how to add lazy aggregation for OpenAPI v2 - that is, the API spec only re-aggregates immediately before a new request to the endpoint is made, instead of every time the spec itself changes.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

#### Special notes for your reviewer:

This PR is never meant to merge into k/k. It will be broken up into separate PRs for other repositories at a later date.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
