### PR TITLE
kubelet: fix sandbox creation error suppression when pods are quickly deleted

### DIFF
--- a/pkg/kubelet/kuberuntime/fake_kuberuntime_manager.go
+++ b/pkg/kubelet/kuberuntime/fake_kuberuntime_manager.go
@@ -67,6 +67,11 @@ func newFakePodStateProvider() *fakePodStateProvider {
 	}
 }
 
+func (f *fakePodStateProvider) IsPodTerminationRequested(uid types.UID) bool {
+	_, found := f.removed[uid]
+	return found
+}
+
 func (f *fakePodStateProvider) ShouldPodRuntimeBeRemoved(uid types.UID) bool {
 	_, found := f.terminated[uid]
 	return found


### PR DESCRIPTION
#### What type of PR is this?
/kind bug
/sig node

#### What this PR does / why we need it:
While testing 1.22 in Openshift, we found a regression when pods are quickly created then force deleted where a previously suppressed CNI error (pod not found from the CNI plugin) was no longer suppressed. The correct method to call is `IsPodTerminationRequested` to see if the pod has been requested to terminate *and* is still pending termination.

#### Which issue(s) this PR fixes:
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
Fixes a 1.22 regression in kubelet handling of pods which are quickly deleted
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs

```
