### PR TITLE
Warn if docker buildx is not available

### DIFF
--- a/build/lib/release.sh
+++ b/build/lib/release.sh
@@ -216,6 +216,8 @@ function kube::release::package_node_tarballs() {
 
 # Package up all of the server binaries in docker images
 function kube::release::build_server_images() {
+  kube::util::ensure-docker-buildx
+
   # Clean out any old images
   rm -rf "${RELEASE_IMAGES}"
   local platform

--- a/hack/lib/util.sh
+++ b/hack/lib/util.sh
@@ -707,14 +707,14 @@ function kube::util::ensure-cfssl {
   popd > /dev/null || return 1
 }
 
-# kube::util::ensure_dockerized
-# Confirms that the script is being run inside a kube-build image
+# kube::util::ensure-docker-buildx
+# Check if we have "docker buildx" commands available
 #
-function kube::util::ensure_dockerized {
-  if [[ -f /kube-build-image ]]; then
+function kube::util::ensure-docker-buildx {
+  if docker buildx >/dev/null 2>&1; then
     return 0
   else
-    echo "ERROR: This script is designed to be run inside a kube-build container"
+    echo "ERROR: docker buildx not available. Docker 19.03 or higher is required with experimental features enabled"
     exit 1
   fi
 }

--- a/test/images/image-util.sh
+++ b/test/images/image-util.sh
@@ -111,6 +111,7 @@ build() {
   fi
 
   kube::util::ensure-gnu-sed
+  kube::util::ensure-docker-buildx
 
   for os_arch in ${os_archs}; do
     splitOsArch "${image}" "${os_arch}"


### PR DESCRIPTION
Follow up to https://github.com/kubernetes/kubernetes/pull/104245 Let us warn folks with a better error message.

cc @m-Bilal 

Signed-off-by: Davanum Srinivas <davanum@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:
`ensure_dockerized` was not being used anywhere ( https://cs.k8s.io/?q=ensure_dockerized&i=nope&files=&excludeFiles=&repos=kubernetes/kubernetes,kubernetes/test-infra )

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
