### PR TITLE
Automated cherry pick of #104268: kubelet: fix sandbox creation error suppression when pods are

### DIFF
--- a/pkg/kubelet/kuberuntime/fake_kuberuntime_manager.go
+++ b/pkg/kubelet/kuberuntime/fake_kuberuntime_manager.go
@@ -67,6 +67,11 @@ func newFakePodStateProvider() *fakePodStateProvider {
 	}
 }
 
+func (f *fakePodStateProvider) IsPodTerminationRequested(uid types.UID) bool {
+	_, found := f.removed[uid]
+	return found
+}
+
 func (f *fakePodStateProvider) ShouldPodRuntimeBeRemoved(uid types.UID) bool {
 	_, found := f.terminated[uid]
 	return found


### PR DESCRIPTION
Cherry pick of #104268 on release-1.22.

#104268: kubelet: fix sandbox creation error suppression when pods are

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
Fixes a 1.22 regression in kubelet handling of pods which are quickly deleted
```

/kind bug
/sig node
/priority important-soon