### PR TITLE
fixing test flake caused by mkfs.xfs

### DIFF
--- a/pkg/volume/gcepd/attacher.go
+++ b/pkg/volume/gcepd/attacher.go
@@ -319,6 +319,9 @@ func (attacher *gcePersistentDiskAttacher) MountDevice(spec *volume.Spec, device
 	}
 	if notMnt {
 		diskMounter := volumeutil.NewSafeFormatAndMountFromHost(gcePersistentDiskPluginName, attacher.host)
+		// because we want to speed up mkfs, we're not going to discard used blocks at mkfs time, which is fine
+		// for PD if the disk is unused before
+		diskMounter.MkfsNodiscard = true
 		mountOptions := volumeutil.MountOptionFromSpec(spec, options...)
 		err = diskMounter.FormatAndMount(devicePath, deviceMountPath, volumeSource.FSType, mountOptions)
 		if err != nil {

--- a/staging/src/k8s.io/mount-utils/mount.go
+++ b/staging/src/k8s.io/mount-utils/mount.go
@@ -135,7 +135,8 @@ func NewMountError(mountErrorValue MountErrorType, format string, args ...interf
 // mounts it otherwise the device is formatted first then mounted.
 type SafeFormatAndMount struct {
 	Interface
-	Exec utilexec.Interface
+	Exec          utilexec.Interface
+	MkfsNodiscard bool
 }
 
 // FormatAndMount formats the given disk, if needed, and mounts it.


### PR DESCRIPTION
#### What type of PR is this?
/kind bug
/kind flake

#### What this PR does / why we need it:
Based on findings [here](https://github.com/kubernetes/kubernetes/issues/97071#issuecomment-739059509), the xfs test flakes are caused by `mkfs.xfs` hanging, by adding [`-K`](https://linux.die.net/man/8/mkfs.xfs#:~:text=the%20file%20system.-,-K,-Do%20not%20attempt) argument which stops `mkfs` from trying to delete existing blocks solves this issue.

This issue is also vendor-specific so instead of changing the default behavior, we're adding an extra option in the mounter and existing code can keep functioning without behavioral change. 

#### Which issue(s) this PR fixes:
Fixes #97071

#### Special notes for your reviewer:
ran xfs related e2e tests and no issue found. That said, I couldn't repro the original issue as well as they succeed on my runs.


```release-note
NONE
```