### PR TITLE
Reduce the number of expensive calls in the Windows stats queries for dockershim

### DIFF
--- a/pkg/kubelet/dockershim/docker_image_linux.go
+++ b/pkg/kubelet/dockershim/docker_image_linux.go
@@ -25,20 +25,12 @@ import (
 	"path/filepath"
 	"time"
 
-	"k8s.io/klog/v2"
-
 	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
 )
 
 // ImageFsInfo returns information of the filesystem that is used to store images.
 func (ds *dockerService) ImageFsInfo(_ context.Context, _ *runtimeapi.ImageFsInfoRequest) (*runtimeapi.ImageFsInfoResponse, error) {
-	info, err := ds.client.Info()
-	if err != nil {
-		klog.ErrorS(err, "Failed to get docker info")
-		return nil, err
-	}
-
-	bytes, inodes, err := dirSize(filepath.Join(info.DockerRootDir, "image"))
+	bytes, inodes, err := dirSize(filepath.Join(ds.dockerRootDir, "image"))
 	if err != nil {
 		return nil, err
 	}
@@ -48,7 +40,7 @@ func (ds *dockerService) ImageFsInfo(_ context.Context, _ *runtimeapi.ImageFsInf
 			{
 				Timestamp: time.Now().Unix(),
 				FsId: &runtimeapi.FilesystemIdentifier{
-					Mountpoint: info.DockerRootDir,
+					Mountpoint: ds.dockerRootDir,
 				},
 				UsedBytes: &runtimeapi.UInt64Value{
 					Value: uint64(bytes),

--- a/pkg/kubelet/dockershim/docker_image_windows.go
+++ b/pkg/kubelet/dockershim/docker_image_windows.go
@@ -31,16 +31,10 @@ import (
 
 // ImageFsInfo returns information of the filesystem that is used to store images.
 func (ds *dockerService) ImageFsInfo(_ context.Context, _ *runtimeapi.ImageFsInfoRequest) (*runtimeapi.ImageFsInfoResponse, error) {
-	info, err := ds.client.Info()
-	if err != nil {
-		klog.ErrorS(err, "Failed to get docker info")
-		return nil, err
-	}
-
 	statsClient := &winstats.StatsClient{}
-	fsinfo, err := statsClient.GetDirFsInfo(info.DockerRootDir)
+	fsinfo, err := statsClient.GetDirFsInfo(ds.dockerRootDir)
 	if err != nil {
-		klog.ErrorS(err, "Failed to get fsInfo for dockerRootDir", "path", info.DockerRootDir)
+		klog.ErrorS(err, "Failed to get fsInfo for dockerRootDir", "path", ds.dockerRootDir)
 		return nil, err
 	}
 
@@ -49,7 +43,7 @@ func (ds *dockerService) ImageFsInfo(_ context.Context, _ *runtimeapi.ImageFsInf
 			Timestamp: time.Now().UnixNano(),
 			UsedBytes: &runtimeapi.UInt64Value{Value: fsinfo.Usage},
 			FsId: &runtimeapi.FilesystemIdentifier{
-				Mountpoint: info.DockerRootDir,
+				Mountpoint: ds.dockerRootDir,
 			},
 		},
 	}

--- a/pkg/kubelet/dockershim/docker_service.go
+++ b/pkg/kubelet/dockershim/docker_service.go
@@ -257,16 +257,17 @@ func NewDockerService(config *ClientConfig, podSandboxImage string, streamingCon
 	ds.network = network.NewPluginManager(plug)
 	klog.InfoS("Docker cri networking managed by the network plugin", "networkPluginName", plug.Name())
 
+	dockerInfo, err := ds.client.Info()
+	if err != nil {
+		return nil, fmt.Errorf("Failed to execute Info() call to the Docker client")
+	}
+	klog.InfoS("Docker Info", "dockerInfo", dockerInfo)
+	ds.dockerRootDir = dockerInfo.DockerRootDir
+
 	// skipping cgroup driver checks for Windows
 	if runtime.GOOS == "linux" {
-		// NOTE: cgroup driver is only detectable in docker 1.11+
 		cgroupDriver := defaultCgroupDriver
-		dockerInfo, err := ds.client.Info()
-		klog.InfoS("Docker Info", "dockerInfo", dockerInfo)
-		if err != nil {
-			klog.ErrorS(err, "Failed to execute Info() call to the Docker client")
-			klog.InfoS("Falling back to use the default driver", "cgroupDriver", cgroupDriver)
-		} else if len(dockerInfo.CgroupDriver) == 0 {
+		if len(dockerInfo.CgroupDriver) == 0 {
 			klog.InfoS("No cgroup driver is set in Docker")
 			klog.InfoS("Falling back to use the default driver", "cgroupDriver", cgroupDriver)
 		} else {
@@ -313,6 +314,9 @@ type dockerService struct {
 	// version checking for some operations. Use this cache to avoid querying
 	// the docker daemon every time we need to do such checks.
 	versionCache *cache.ObjectCache
+
+	// docker root directory
+	dockerRootDir string
 
 	// containerCleanupInfos maps container IDs to the `containerCleanupInfo` structs
 	// needed to clean up after containers have been removed.

--- a/pkg/kubelet/dockershim/docker_service_test.go
+++ b/pkg/kubelet/dockershim/docker_service_test.go
@@ -85,6 +85,7 @@ func newTestDockerService() (*dockerService, *libdocker.FakeDockerClient, *testi
 		network:           pm,
 		checkpointManager: ckm,
 		networkReady:      make(map[string]bool),
+		dockerRootDir:     "/docker/root/dir",
 	}, c, fakeClock
 }
 

--- a/pkg/kubelet/dockershim/docker_stats.go
+++ b/pkg/kubelet/dockershim/docker_stats.go
@@ -22,6 +22,7 @@ package dockershim
 import (
 	"context"
 	"errors"
+	"fmt"
 
 	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
 )
@@ -29,8 +30,18 @@ import (
 var ErrNotImplemented = errors.New("Not implemented")
 
 // ContainerStats returns stats for a container stats request based on container id.
-func (ds *dockerService) ContainerStats(_ context.Context, r *runtimeapi.ContainerStatsRequest) (*runtimeapi.ContainerStatsResponse, error) {
-	stats, err := ds.getContainerStats(r.ContainerId)
+func (ds *dockerService) ContainerStats(ctx context.Context, r *runtimeapi.ContainerStatsRequest) (*runtimeapi.ContainerStatsResponse, error) {
+	filter := &runtimeapi.ContainerFilter{
+		Id: r.ContainerId,
+	}
+	listResp, err := ds.ListContainers(ctx, &runtimeapi.ListContainersRequest{Filter: filter})
+	if err != nil {
+		return nil, err
+	}
+	if len(listResp.Containers) != 1 {
+		return nil, fmt.Errorf("container with id %s not found", r.ContainerId)
+	}
+	stats, err := ds.getContainerStats(listResp.Containers[0])
 	if err != nil {
 		return nil, err
 	}
@@ -55,7 +66,7 @@ func (ds *dockerService) ListContainerStats(ctx context.Context, r *runtimeapi.L
 
 	var stats []*runtimeapi.ContainerStats
 	for _, container := range listResp.Containers {
-		containerStats, err := ds.getContainerStats(container.Id)
+		containerStats, err := ds.getContainerStats(container)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/kubelet/dockershim/docker_stats_test.go
+++ b/pkg/kubelet/dockershim/docker_stats_test.go
@@ -23,12 +23,14 @@ import (
 	"testing"
 
 	dockertypes "github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/container"
 	"github.com/stretchr/testify/assert"
 	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
 	"k8s.io/kubernetes/pkg/kubelet/dockershim/libdocker"
 )
 
 func TestContainerStats(t *testing.T) {
+	labels := map[string]string{containerTypeLabelKey: containerTypeLabelContainer}
 	tests := map[string]struct {
 		containerID    string
 		container      *libdocker.FakeContainer
@@ -36,22 +38,33 @@ func TestContainerStats(t *testing.T) {
 		calledDetails  []libdocker.CalledDetail
 	}{
 		"container exists": {
-			"fake_container",
-			&libdocker.FakeContainer{ID: "fake_container"},
+			"k8s_fake_container",
+			&libdocker.FakeContainer{
+				ID:   "k8s_fake_container",
+				Name: "k8s_fake_container_1_2_1",
+				Config: &container.Config{
+					Labels: labels,
+				},
+			},
 			&dockertypes.StatsJSON{},
 			[]libdocker.CalledDetail{
+				libdocker.NewCalledDetail("list", nil),
 				libdocker.NewCalledDetail("get_container_stats", nil),
 				libdocker.NewCalledDetail("inspect_container_withsize", nil),
-				libdocker.NewCalledDetail("inspect_container", nil),
-				libdocker.NewCalledDetail("inspect_image", nil),
 			},
 		},
 		"container doesn't exists": {
-			"nonexistant_fake_container",
-			&libdocker.FakeContainer{ID: "fake_container"},
+			"k8s_nonexistant_fake_container",
+			&libdocker.FakeContainer{
+				ID:   "k8s_fake_container",
+				Name: "k8s_fake_container_1_2_1",
+				Config: &container.Config{
+					Labels: labels,
+				},
+			},
 			&dockertypes.StatsJSON{},
 			[]libdocker.CalledDetail{
-				libdocker.NewCalledDetail("get_container_stats", nil),
+				libdocker.NewCalledDetail("list", nil),
 			},
 		},
 	}

--- a/pkg/kubelet/dockershim/docker_stats_unsupported.go
+++ b/pkg/kubelet/dockershim/docker_stats_unsupported.go
@@ -25,6 +25,6 @@ import (
 	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
 )
 
-func (ds *dockerService) getContainerStats(containerID string) (*runtimeapi.ContainerStats, error) {
+func (ds *dockerService) getContainerStats(c *runtimeapi.Container) (*runtimeapi.ContainerStats, error) {
 	return nil, fmt.Errorf("not implemented")
 }

--- a/pkg/kubelet/dockershim/libdocker/fake_client.go
+++ b/pkg/kubelet/dockershim/libdocker/fake_client.go
@@ -35,7 +35,7 @@ import (
 	dockercontainer "github.com/docker/docker/api/types/container"
 	dockerimagetypes "github.com/docker/docker/api/types/image"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/utils/clock"
 )
 
@@ -226,6 +226,7 @@ func convertFakeContainer(f *FakeContainer) *dockertypes.ContainerJSON {
 	if f.HostConfig == nil {
 		f.HostConfig = &dockercontainer.HostConfig{}
 	}
+	fakeRWSize := int64(40)
 	return &dockertypes.ContainerJSON{
 		ContainerJSONBase: &dockertypes.ContainerJSONBase{
 			ID:    f.ID,
@@ -240,6 +241,7 @@ func convertFakeContainer(f *FakeContainer) *dockertypes.ContainerJSON {
 			},
 			Created:    dockerTimestampToString(f.CreatedAt),
 			HostConfig: f.HostConfig,
+			SizeRw:     &fakeRWSize,
 		},
 		Config:          f.Config,
 		NetworkSettings: &dockertypes.NetworkSettings{},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:

/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This improves the response time and minimizes the calls to the system stats which reduces overall cpu for kubelet.  This is done by passing the container object, which has the information required, instead of querying for it on every container via the dockerservice. It also caches some information like the runtime info so it is not queried on every container.

Dockershim create a  new namepiped instance to docker every call causing reads and higher cpu usage.  (Containerd re-uses the same namedpipe instance so doesn't see the same cpu spike).


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #104283 
#### Special notes for your reviewer:

I initially included the commits from https://github.com/kubernetes/kubernetes/pull/105744 but moved it to a separate PR.  That PR also improves the overall CPU used here but not opening and list all the containers twice.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Reduce the number of calls to docker for stats via dockershim. For Windows this reduces the latency when calling docker, for Linux this saves cpu cycles. 
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
