### PR TITLE
add aojea to test OWNERS approvers

### DIFF
--- a/test/OWNERS
+++ b/test/OWNERS
@@ -9,6 +9,7 @@ reviewers:
 approvers:
   - alejandrox1
   - andrewsykim
+  - aojea
   - BenTheElder
   - bowei # for test/e2e/{dns*,network}.go
   - caseydavenport # for test/e2e/{dns*,network}.go


### PR DESCRIPTION
/kind cleanup

Following the community guidelines, I'd like to nominate myself as an approver for test/

https://github.com/kubernetes/community/blob/master/community-membership.md#approver

- [x] Reviewer of the codebase for at least 3 months

https://github.com/kubernetes/kubernetes/commit/bafea472d20b5d420c9e4cba079c2e1f5516874b --> Sep 24, 2020

- [x] Primary reviewer for at least 10 substantial PRs to the codebase

https://github.com/kubernetes/kubernetes/issues?q=assignee%3A%40me+is%3Aclosed+test  --> 315


- [x] Reviewed or merged at least 30 PRs to the codebase

```
git shortlog -n -s -- test/
  3374  Kubernetes Prow Robot
  3130  Kubernetes Submit Queue
   846  k8s-merge-robot
   314  Jordan Liggitt
   311  Wojciech Tyczynski
   277  k8s-ci-robot
   246  gmarek
   183  Clayton Coleman
   165  Chao Xu
   165  Claudiu Belu
   163  Patrick Ohly
   162  Mike Danese
   158  Jan Safranek
   157  Dr. Stefan Schimanski
   153  Caleb Woodbine
   146  Antonio Ojea  <---------- 
   144  Janet Kuo
   140  Kenichi Omichi
```

- [] Nominated by a subproject owner
- [] With no objections from other subproject owners
- [] Done through PR to update the top-level OWNERS file


```release-note
NONE
```

