### PR TITLE
Validate initial KubeletFlags only after parsing the config file

### DIFF
--- a/cmd/kubelet/app/server.go
+++ b/cmd/kubelet/app/server.go
@@ -189,12 +189,6 @@ HTTP server: The kubelet can also listen for HTTP and respond to a simple API
 				os.Exit(1)
 			}
 
-			// validate the initial KubeletFlags
-			if err := options.ValidateKubeletFlags(kubeletFlags); err != nil {
-				klog.ErrorS(err, "Failed to validate kubelet flags")
-				os.Exit(1)
-			}
-
 			if kubeletFlags.ContainerRuntime == "remote" && cleanFlagSet.Changed("pod-infra-container-image") {
 				klog.InfoS("Warning: For remote container runtime, --pod-infra-container-image is ignored in kubelet, which should be set in that remote runtime instead")
 			}
@@ -218,6 +212,12 @@ HTTP server: The kubelet can also listen for HTTP and respond to a simple API
 					klog.ErrorS(err, "Failed to set feature gates from initial flags-based config")
 					os.Exit(1)
 				}
+			}
+
+			// validate the initial KubeletFlags
+			if err := options.ValidateKubeletFlags(kubeletFlags); err != nil {
+				klog.ErrorS(err, "Failed to validate kubelet flags")
+				os.Exit(1)
 			}
 
 			// We always validate the local configuration (command line + config file).


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

We're currently validating the initial KubeletFlags at the very beginning when starting Kubelet. The KubeletFlags validation also
validates that the appropriate FeatureGates are enabled for some command-line flags. Concretely:

* `DynamicKubeletConfig` feature gate must be enabled if `--dynamic-config-dir` command-line flag is used
* `SeccompDefault` feature gate must be enabled if `--seccomp-default` command-line flag is used

This works well if the feature flags are managed with the `--feature-gates` command-line flag. However, that flag is considered
deprecated and it's recommended to use the KubeletConfiguration file instead.

However, the validation fails if the feature gates are enabled in the configuration file. That's because the validation happens before parsing the configuration file.

This commit proposes moving the validation at the point after parsing the configuration file, which should solve this issue.

See #104298 for more details including the logs.

#### Which issue(s) this PR fixes:
Fixes #104298

#### Does this PR introduce a user-facing change?
```release-note
Validate initial KubeletFlags only after parsing the KubeletConfiguration file. This fixes the issue causing Kubelet to fail to start if the command-line flags gated by feature gates are enabled in the configuration file.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs

```

/sig node
/area kubelet