### PR TITLE
 [kubelet] Reduce ConfigMap and Secret projection delay on update

### DIFF
--- a/pkg/kubelet/configmap/configmap_manager.go
+++ b/pkg/kubelet/configmap/configmap_manager.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
 	clientset "k8s.io/client-go/kubernetes"
 	podutil "k8s.io/kubernetes/pkg/api/v1/pod"
 	corev1 "k8s.io/kubernetes/pkg/apis/core/v1"
@@ -135,7 +136,9 @@ func NewCachingConfigMapManager(kubeClient clientset.Interface, getTTL manager.G
 // - whenever a pod is created or updated, we start individual watches for all
 //   referenced objects that aren't referenced from other registered pods
 // - every GetObject() returns a value from local cache propagated via watches
-func NewWatchingConfigMapManager(kubeClient clientset.Interface, resyncInterval time.Duration) Manager {
+// - whenever a referenced object is created or updated or deleted, onPodUpdate
+//   will be called with all pods that reference it.
+func NewWatchingConfigMapManager(kubeClient clientset.Interface, resyncInterval time.Duration, onPodUpdate func(uid types.UID)) Manager {
 	listConfigMap := func(namespace string, opts metav1.ListOptions) (runtime.Object, error) {
 		return kubeClient.CoreV1().ConfigMaps(namespace).List(context.TODO(), opts)
 	}
@@ -153,6 +156,6 @@ func NewWatchingConfigMapManager(kubeClient clientset.Interface, resyncInterval 
 	}
 	gr := corev1.Resource("configmap")
 	return &configMapManager{
-		manager: manager.NewWatchBasedManager(listConfigMap, watchConfigMap, newConfigMap, isImmutable, gr, resyncInterval, getConfigMapNames),
+		manager: manager.NewWatchBasedManager(listConfigMap, watchConfigMap, newConfigMap, onPodUpdate, isImmutable, gr, resyncInterval, getConfigMapNames),
 	}
 }

--- a/pkg/kubelet/util/manager/cache_based_manager_test.go
+++ b/pkg/kubelet/util/manager/cache_based_manager_test.go
@@ -30,6 +30,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 
 	clientset "k8s.io/client-go/kubernetes"
@@ -88,13 +89,13 @@ func newCacheBasedSecretManager(store Store) Manager {
 func TestSecretStore(t *testing.T) {
 	fakeClient := &fake.Clientset{}
 	store := newSecretStore(fakeClient, clock.RealClock{}, noObjectTTL, 0)
-	store.AddReference("ns1", "name1")
-	store.AddReference("ns2", "name2")
-	store.AddReference("ns1", "name1")
-	store.AddReference("ns1", "name1")
-	store.DeleteReference("ns1", "name1")
-	store.DeleteReference("ns2", "name2")
-	store.AddReference("ns3", "name3")
+	store.AddReference("ns1", "name1", "pod1")
+	store.AddReference("ns2", "name2", "pod2")
+	store.AddReference("ns1", "name1", "pod3")
+	store.AddReference("ns1", "name1", "pod4")
+	store.DeleteReference("ns1", "name1", "pod1")
+	store.DeleteReference("ns2", "name2", "pod2")
+	store.AddReference("ns3", "name3", "pod5")
 
 	// Adds don't issue Get requests.
 	actions := fakeClient.Actions()
@@ -122,7 +123,7 @@ func TestSecretStore(t *testing.T) {
 func TestSecretStoreDeletingSecret(t *testing.T) {
 	fakeClient := &fake.Clientset{}
 	store := newSecretStore(fakeClient, clock.RealClock{}, noObjectTTL, 0)
-	store.AddReference("ns", "name")
+	store.AddReference("ns", "name", "pod")
 
 	result := &v1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "name", ResourceVersion: "10"}}
 	fakeClient.AddReactor("get", "secrets", func(action core.Action) (bool, runtime.Object, error) {
@@ -154,7 +155,7 @@ func TestSecretStoreGetAlwaysRefresh(t *testing.T) {
 	store := newSecretStore(fakeClient, fakeClock, noObjectTTL, 0)
 
 	for i := 0; i < 10; i++ {
-		store.AddReference(fmt.Sprintf("ns-%d", i), fmt.Sprintf("name-%d", i))
+		store.AddReference(fmt.Sprintf("ns-%d", i), fmt.Sprintf("name-%d", i), types.UID(fmt.Sprintf("pod-%d", i)))
 	}
 	fakeClient.ClearActions()
 
@@ -181,7 +182,7 @@ func TestSecretStoreGetNeverRefresh(t *testing.T) {
 	store := newSecretStore(fakeClient, fakeClock, noObjectTTL, time.Minute)
 
 	for i := 0; i < 10; i++ {
-		store.AddReference(fmt.Sprintf("ns-%d", i), fmt.Sprintf("name-%d", i))
+		store.AddReference(fmt.Sprintf("ns-%d", i), fmt.Sprintf("name-%d", i), types.UID(fmt.Sprintf("pod-%d", i)))
 	}
 	fakeClient.ClearActions()
 
@@ -210,7 +211,7 @@ func TestCustomTTL(t *testing.T) {
 	fakeClock := testingclock.NewFakeClock(time.Time{})
 	store := newSecretStore(fakeClient, fakeClock, customTTL, time.Minute)
 
-	store.AddReference("ns", "name")
+	store.AddReference("ns", "name", "pod")
 	store.Get("ns", "name")
 	fakeClient.ClearActions()
 

--- a/pkg/kubelet/util/manager/manager.go
+++ b/pkg/kubelet/util/manager/manager.go
@@ -19,6 +19,7 @@ package manager
 import (
 	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 )
 
 // Manager is the interface for registering and unregistering
@@ -49,12 +50,12 @@ type Store interface {
 	// AddReference adds a reference to the object to the store.
 	// Note that multiple additions to the store has to be allowed
 	// in the implementations and effectively treated as refcounted.
-	AddReference(namespace, name string)
+	AddReference(namespace, name string, podUID types.UID)
 	// DeleteReference deletes reference to the object from the store.
 	// Note that object should be deleted only when there was a
 	// corresponding Delete call for each of Add calls (effectively
 	// when refcount was reduced to zero).
-	DeleteReference(namespace, name string)
+	DeleteReference(namespace, name string, podUID types.UID)
 	// Get an object from a store.
 	Get(namespace, name string) (runtime.Object, error)
 }

--- a/test/e2e_node/volume_manager_test.go
+++ b/test/e2e_node/volume_manager_test.go
@@ -18,21 +18,152 @@ package e2enode
 
 import (
 	"context"
+	"fmt"
+	"path"
 	"time"
 
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/uuid"
+	"k8s.io/kubernetes/pkg/kubelet/apis/config"
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
-
-	"fmt"
+	e2eskipper "k8s.io/kubernetes/test/e2e/framework/skipper"
 
 	"github.com/onsi/ginkgo"
+	"github.com/onsi/gomega"
 )
 
 var _ = SIGDescribe("Kubelet Volume Manager", func() {
 	f := framework.NewDefaultFramework("kubelet-volume-manager")
+	ginkgo.Context("with Watch ResourceChangeDetectionStrategy", func() {
+		podName := "pod-with-volume"
+		key := "data-1"
+		createContent := "value-1"
+		updateContent := "value-2"
+		trueVal := true
+
+		runPodAndVerifyVolume := func(volumeSource v1.VolumeSource, createVolumeSource, updateVolumeSource func()) {
+			var pod *v1.Pod
+
+			ginkgo.By("Creating a pod with the volume mounted", func() {
+				volumes := []v1.Volume{
+					{
+						Name:         volumeName,
+						VolumeSource: volumeSource,
+					},
+				}
+				mounts := []v1.VolumeMount{
+					{
+						Name:      volumeName,
+						MountPath: volumeMountPath,
+					},
+				}
+				mounttestArgs := []string{"mounttest", "--break_on_expected_content=false", fmt.Sprintf("--file_content_in_loop=%s", path.Join(volumeMountPath, key))}
+				pod = e2epod.NewAgnhostPod(f.Namespace.Name, podName, volumes, mounts, nil, mounttestArgs...)
+				pod = f.PodClient().CreateSync(pod)
+			})
+
+			ginkgo.By("Creating the volume source", createVolumeSource)
+
+			ginkgo.By("Verifying volume is updated on source creation", func() {
+				gomega.Eventually(func() error {
+					return f.PodClient().MatchContainerOutput(pod.Name, pod.Spec.Containers[0].Name, createContent)
+				}, 5*time.Second, 1*time.Second).Should(gomega.BeNil())
+			})
+
+			ginkgo.By("Updating the volume source", updateVolumeSource)
+
+			ginkgo.By("Verifying volume is updated on source update", func() {
+				gomega.Eventually(func() error {
+					return f.PodClient().MatchContainerOutput(pod.Name, pod.Spec.Containers[0].Name, updateContent)
+				}, 5*time.Second, 1*time.Second).Should(gomega.BeNil())
+			})
+		}
+
+		ginkgo.BeforeEach(func() {
+			if framework.TestContext.KubeletConfig.ConfigMapAndSecretChangeDetectionStrategy != config.WatchChangeDetectionStrategy {
+				e2eskipper.Skipf("This test is meant to run with ConfigMapAndSecretChangeDetectionStrategy set to Watch")
+			}
+		})
+
+		ginkgo.It("ConfigMap update should be reflected in volume immediately", func() {
+			configMapName := "configmap-" + string(uuid.NewUUID())
+			volumeSource := v1.VolumeSource{
+				ConfigMap: &v1.ConfigMapVolumeSource{
+					LocalObjectReference: v1.LocalObjectReference{
+						Name: configMapName,
+					},
+					Optional: &trueVal,
+				},
+			}
+			configMap := &v1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: f.Namespace.Name,
+					Name:      configMapName,
+				},
+				Data: map[string]string{
+					"data-1": createContent,
+				},
+			}
+			createConfigMap := func() {
+				ginkgo.By(fmt.Sprintf("Creating configMap %v", configMap.Name))
+				if _, err := f.ClientSet.CoreV1().ConfigMaps(f.Namespace.Name).Create(context.TODO(), configMap, metav1.CreateOptions{}); err != nil {
+					framework.Failf("Failed to create configMap %s: %v", configMap.Name, err)
+				}
+			}
+			updateConfigMap := func() {
+				toUpdate := configMap.DeepCopy()
+				toUpdate.Data["data-1"] = updateContent
+				ginkgo.By(fmt.Sprintf("Updating configMap %v", configMap.Name))
+				if _, err := f.ClientSet.CoreV1().ConfigMaps(f.Namespace.Name).Update(context.TODO(), toUpdate, metav1.UpdateOptions{}); err != nil {
+					framework.Failf("Failed to update configMap %s: %v", toUpdate.Name, err)
+				}
+			}
+			runPodAndVerifyVolume(volumeSource, createConfigMap, updateConfigMap)
+			f.ClientSet.CoreV1().ConfigMaps(f.Namespace.Name).Delete(context.TODO(), configMapName, metav1.DeleteOptions{})
+		})
+
+		ginkgo.It("Secret update should be reflected in volume immediately", func() {
+			secretName := "secret-" + string(uuid.NewUUID())
+			volumeSource := v1.VolumeSource{
+				Secret: &v1.SecretVolumeSource{
+					SecretName: secretName,
+					Optional:   &trueVal,
+				},
+			}
+			secret := &v1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: f.Namespace.Name,
+					Name:      secretName,
+				},
+				StringData: map[string]string{
+					"data-1": createContent,
+				},
+			}
+			createSecret := func() {
+				ginkgo.By(fmt.Sprintf("Creating secret %v", secret.Name))
+				if _, err := f.ClientSet.CoreV1().Secrets(f.Namespace.Name).Create(context.TODO(), secret, metav1.CreateOptions{}); err != nil {
+					framework.Failf("Failed to create serect %s: %v", secret.Name, err)
+				}
+			}
+			updateSecret := func() {
+				toUpdate := secret.DeepCopy()
+				toUpdate.StringData["data-1"] = updateContent
+				ginkgo.By(fmt.Sprintf("Updating secret %v", secret.Name))
+				if _, err := f.ClientSet.CoreV1().Secrets(f.Namespace.Name).Update(context.TODO(), toUpdate, metav1.UpdateOptions{}); err != nil {
+					framework.Failf("Failed to update secret %s: %v", toUpdate.Name, err)
+				}
+			}
+			runPodAndVerifyVolume(volumeSource, createSecret, updateSecret)
+			f.ClientSet.CoreV1().Secrets(f.Namespace.Name).Delete(context.TODO(), secretName, metav1.DeleteOptions{})
+		})
+
+		ginkgo.AfterEach(func() {
+			f.PodClient().DeleteSync(podName, metav1.DeleteOptions{}, framework.DefaultPodDeletionTimeout)
+		})
+	})
+
 	ginkgo.Describe("Volume Manager", func() {
 		ginkgo.Context("On termination of pod with memory backed volume", func() {
 			ginkgo.It("should remove the volume from the node [NodeConformance]", func() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:
Even when ResourceChangeDetectionStrategy was set to Watch, ConfigMap and Secret update were not projected to the pod until next periodic sync, which resulted in long delay. As Kubelet watches the resources and is aware of which pods should be updated, it can sync the relevant pods immediately after receiving watch events, minimizing the update delay. 

This patch adds a callback to ConfigMap and Secret WatchBasedManager. Whenever a referenced object is created or updated or deleted, WatchBasedManager will call the callback with all pods that reference it. The callback then triggers pod workers to sync the pods. Ideally, ConfigMap and Secret update will be projected to pods immediately after Kubelet receives the watch events.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
With Watch ConfigMapAndSecretChangeDetectionStrategy, ConfigMap and Secret update will be projected to Pod immediately
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
