### PR TITLE
Fix build with multiple GOFLAGS

### DIFF
--- a/hack/lib/golang.sh
+++ b/hack/lib/golang.sh
@@ -807,7 +807,7 @@ kube::golang::build_binaries() {
 
     # extract tags if any specified in GOFLAGS
     # shellcheck disable=SC2001
-    gotags="selinux,notest,$(echo "${GOFLAGS:-}" | sed -e 's|.*-tags=\([^-]*\).*|\1|')"
+    gotags="selinux,notest,$(echo "${GOFLAGS:-}" | sed -ne 's|.*-tags=\([^-]*\).*|\1|p')"
 
     local -a targets=()
     local arg


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

﻿The tag extraction from GOFLAGS doesn't do anything if -tags is not
present in GOFLAGS.  Not only does that mean non-sensical tags are
passed, but because GOFLAGS is a space-separated variable, the build
will fail because the build flags because -tags must be comma-separated.

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
