### PR TITLE
refactor: moves CertDirectory from kubelet flags to kubelet config.

### DIFF
--- a/cmd/kubelet/app/options/options.go
+++ b/cmd/kubelet/app/options/options.go
@@ -67,10 +67,6 @@ type KubeletFlags struct {
 	// Container-runtime-specific options.
 	config.ContainerRuntimeOptions
 
-	// certDirectory is the directory where the TLS certs are located.
-	// If tlsCertFile and tlsPrivateKeyFile are provided, this flag will be ignored.
-	CertDirectory string
-
 	// cloudProvider is the provider for cloud services.
 	// +optional
 	CloudProvider string
@@ -168,7 +164,6 @@ func NewKubeletFlags() *KubeletFlags {
 
 	return &KubeletFlags{
 		ContainerRuntimeOptions: *NewContainerRuntimeOptions(),
-		CertDirectory:           "/var/lib/kubelet/pki",
 		RootDirectory:           defaultRootDir,
 		MasterServiceNamespace:  metav1.NamespaceDefault,
 		MaxContainerCount:       -1,
@@ -320,9 +315,6 @@ func (f *KubeletFlags) AddFlags(mainfs *pflag.FlagSet) {
 
 	fs.StringVar(&f.NodeIP, "node-ip", f.NodeIP, "IP address (or comma-separated dual-stack IP addresses) of the node. If unset, kubelet will use the node's default IPv4 address, if any, or its default IPv6 address if it has no IPv4 addresses. You can pass '::' to make it prefer the default IPv6 address rather than the default IPv4 address.")
 
-	fs.StringVar(&f.CertDirectory, "cert-dir", f.CertDirectory, "The directory where the TLS certs are located. "+
-		"If --tls-cert-file and --tls-private-key-file are provided, this flag will be ignored.")
-
 	fs.StringVar(&f.RootDirectory, "root-dir", f.RootDirectory, "Directory path for managing kubelet files (volume mounts,etc).")
 
 	fs.Var(&f.DynamicConfigDir, "dynamic-config-dir", "The Kubelet will use this directory for checkpointing downloaded configurations and tracking configuration health. The Kubelet will create this directory if it does not already exist. The path may be absolute or relative; relative paths start at the Kubelet's current working directory. Providing this flag enables dynamic Kubelet configuration. The DynamicKubeletConfig feature gate must be enabled to pass this flag.")
@@ -430,6 +422,9 @@ func AddKubeletConfigFlags(mainfs *pflag.FlagSet, c *kubeletconfig.KubeletConfig
 		"The duration to cache 'authorized' responses from the webhook authorizer.")
 	fs.DurationVar(&c.Authorization.Webhook.CacheUnauthorizedTTL.Duration, "authorization-webhook-cache-unauthorized-ttl", c.Authorization.Webhook.CacheUnauthorizedTTL.Duration, ""+
 		"The duration to cache 'unauthorized' responses from the webhook authorizer.")
+
+	fs.StringVar(&c.CertDirectory, "cert-dir", c.CertDirectory, "The directory where the TLS certs are located. "+
+		"If --tls-cert-file and --tls-private-key-file are specified or corresponding kubelet config flags set, this option will be ignored.")
 
 	fs.StringVar(&c.TLSCertFile, "tls-cert-file", c.TLSCertFile, ""+
 		"File containing x509 Certificate used for serving HTTPS (with intermediate certs, if any, concatenated after server cert). "+

--- a/cmd/kubelet/app/options/options.go
+++ b/cmd/kubelet/app/options/options.go
@@ -423,7 +423,7 @@ func AddKubeletConfigFlags(mainfs *pflag.FlagSet, c *kubeletconfig.KubeletConfig
 	fs.DurationVar(&c.Authorization.Webhook.CacheUnauthorizedTTL.Duration, "authorization-webhook-cache-unauthorized-ttl", c.Authorization.Webhook.CacheUnauthorizedTTL.Duration, ""+
 		"The duration to cache 'unauthorized' responses from the webhook authorizer.")
 
-	fs.StringVar(&c.CertDirectory, "cert-dir", c.CertDirectory, "The directory where the TLS certs are located. "+
+	fs.StringVar(&c.CertDir, "cert-dir", c.CertDir, "The directory where the TLS certs are located. "+
 		"If --tls-cert-file and --tls-private-key-file are specified or corresponding kubelet config flags set, this option will be ignored.")
 
 	fs.StringVar(&c.TLSCertFile, "tls-cert-file", c.TLSCertFile, ""+

--- a/cmd/kubelet/app/server.go
+++ b/cmd/kubelet/app/server.go
@@ -872,7 +872,7 @@ func buildKubeletClientConfig(ctx context.Context, s *options.KubeletServer, nod
 		// bootstrap the cert manager with the contents of the initial client config.
 
 		klog.InfoS("Client rotation is on, will bootstrap in background")
-		certConfig, clientConfig, err := bootstrap.LoadClientConfig(s.KubeConfig, s.BootstrapKubeconfig, s.CertDirectory)
+		certConfig, clientConfig, err := bootstrap.LoadClientConfig(s.KubeConfig, s.BootstrapKubeconfig, s.CertDir)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -882,7 +882,7 @@ func buildKubeletClientConfig(ctx context.Context, s *options.KubeletServer, nod
 
 		kubeClientConfigOverrides(s, clientConfig)
 
-		clientCertificateManager, err := buildClientCertificateManager(certConfig, clientConfig, s.CertDirectory, nodeName)
+		clientCertificateManager, err := buildClientCertificateManager(certConfig, clientConfig, s.CertDir, nodeName)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -922,7 +922,7 @@ func buildKubeletClientConfig(ctx context.Context, s *options.KubeletServer, nod
 	}
 
 	if len(s.BootstrapKubeconfig) > 0 {
-		if err := bootstrap.LoadClientCert(ctx, s.KubeConfig, s.BootstrapKubeconfig, s.CertDirectory, nodeName); err != nil {
+		if err := bootstrap.LoadClientCert(ctx, s.KubeConfig, s.BootstrapKubeconfig, s.CertDir, nodeName); err != nil {
 			return nil, nil, err
 		}
 	}
@@ -1032,8 +1032,8 @@ func getNodeName(cloud cloudprovider.Interface, hostname string) (types.NodeName
 // certificate and key file are generated. Returns a configured server.TLSOptions object.
 func InitializeTLS(kf *options.KubeletFlags, kc *kubeletconfiginternal.KubeletConfiguration) (*server.TLSOptions, error) {
 	if !kc.ServerTLSBootstrap && kc.TLSCertFile == "" && kc.TLSPrivateKeyFile == "" {
-		kc.TLSCertFile = path.Join(kc.CertDirectory, "kubelet.crt")
-		kc.TLSPrivateKeyFile = path.Join(kc.CertDirectory, "kubelet.key")
+		kc.TLSCertFile = path.Join(kc.CertDir, "kubelet.crt")
+		kc.TLSPrivateKeyFile = path.Join(kc.CertDir, "kubelet.key")
 
 		canReadCertAndKey, err := certutil.CanReadCertAndKey(kc.TLSCertFile, kc.TLSPrivateKeyFile)
 		if err != nil {
@@ -1184,7 +1184,7 @@ func RunKubelet(kubeServer *options.KubeletServer, kubeDeps *kubelet.Dependencie
 		nodeIPs,
 		kubeServer.ProviderID,
 		kubeServer.CloudProvider,
-		kubeServer.CertDirectory,
+		kubeServer.CertDir,
 		kubeServer.RootDirectory,
 		kubeServer.ImageCredentialProviderConfigFile,
 		kubeServer.ImageCredentialProviderBinDir,

--- a/cmd/kubelet/app/server.go
+++ b/cmd/kubelet/app/server.go
@@ -1032,8 +1032,8 @@ func getNodeName(cloud cloudprovider.Interface, hostname string) (types.NodeName
 // certificate and key file are generated. Returns a configured server.TLSOptions object.
 func InitializeTLS(kf *options.KubeletFlags, kc *kubeletconfiginternal.KubeletConfiguration) (*server.TLSOptions, error) {
 	if !kc.ServerTLSBootstrap && kc.TLSCertFile == "" && kc.TLSPrivateKeyFile == "" {
-		kc.TLSCertFile = path.Join(kf.CertDirectory, "kubelet.crt")
-		kc.TLSPrivateKeyFile = path.Join(kf.CertDirectory, "kubelet.key")
+		kc.TLSCertFile = path.Join(kc.CertDirectory, "kubelet.crt")
+		kc.TLSPrivateKeyFile = path.Join(kc.CertDirectory, "kubelet.key")
 
 		canReadCertAndKey, err := certutil.CanReadCertAndKey(kc.TLSCertFile, kc.TLSPrivateKeyFile)
 		if err != nil {

--- a/pkg/kubelet/apis/config/helpers.go
+++ b/pkg/kubelet/apis/config/helpers.go
@@ -27,5 +27,6 @@ func KubeletConfigurationPathRefs(kc *KubeletConfiguration) []*string {
 	paths = append(paths, &kc.TLSPrivateKeyFile)
 	paths = append(paths, &kc.ResolverConfig)
 	paths = append(paths, &kc.VolumePluginDir)
+	paths = append(paths, &kc.CertDirectory)
 	return paths
 }

--- a/pkg/kubelet/apis/config/helpers.go
+++ b/pkg/kubelet/apis/config/helpers.go
@@ -27,6 +27,6 @@ func KubeletConfigurationPathRefs(kc *KubeletConfiguration) []*string {
 	paths = append(paths, &kc.TLSPrivateKeyFile)
 	paths = append(paths, &kc.ResolverConfig)
 	paths = append(paths, &kc.VolumePluginDir)
-	paths = append(paths, &kc.CertDirectory)
+	paths = append(paths, &kc.CertDir)
 	return paths
 }

--- a/pkg/kubelet/apis/config/helpers_test.go
+++ b/pkg/kubelet/apis/config/helpers_test.go
@@ -153,7 +153,7 @@ var (
 	kubeletConfigurationPathFieldPaths = sets.NewString(
 		"StaticPodPath",
 		"Authentication.X509.ClientCAFile",
-		"CertDirectory",
+		"CertDir",
 		"TLSCertFile",
 		"TLSPrivateKeyFile",
 		"ResolverConfig",

--- a/pkg/kubelet/apis/config/helpers_test.go
+++ b/pkg/kubelet/apis/config/helpers_test.go
@@ -153,9 +153,11 @@ var (
 	kubeletConfigurationPathFieldPaths = sets.NewString(
 		"StaticPodPath",
 		"Authentication.X509.ClientCAFile",
+		"CertDirectory",
 		"TLSCertFile",
 		"TLSPrivateKeyFile",
 		"ResolverConfig",
+		"VolumePluginDir",
 	)
 
 	// KubeletConfiguration fields that do not contain file paths.
@@ -277,7 +279,6 @@ var (
 		"TypeMeta.APIVersion",
 		"TypeMeta.Kind",
 		"VolumeStatsAggPeriod.Duration",
-		"VolumePluginDir",
 		"ShutdownGracePeriod.Duration",
 		"ShutdownGracePeriodCriticalPods.Duration",
 		"MemoryThrottlingFactor",

--- a/pkg/kubelet/apis/config/scheme/testdata/KubeletConfiguration/after/v1beta1.yaml
+++ b/pkg/kubelet/apis/config/scheme/testdata/KubeletConfiguration/after/v1beta1.yaml
@@ -12,6 +12,7 @@ authorization:
   webhook:
     cacheAuthorizedTTL: 5m0s
     cacheUnauthorizedTTL: 30s
+certDirectory: /var/lib/kubelet/pki
 cgroupDriver: cgroupfs
 cgroupsPerQOS: true
 configMapAndSecretChangeDetectionStrategy: Watch

--- a/pkg/kubelet/apis/config/scheme/testdata/KubeletConfiguration/after/v1beta1.yaml
+++ b/pkg/kubelet/apis/config/scheme/testdata/KubeletConfiguration/after/v1beta1.yaml
@@ -12,7 +12,7 @@ authorization:
   webhook:
     cacheAuthorizedTTL: 5m0s
     cacheUnauthorizedTTL: 30s
-certDirectory: /var/lib/kubelet/pki
+certDir: /var/lib/kubelet/pki
 cgroupDriver: cgroupfs
 cgroupsPerQOS: true
 configMapAndSecretChangeDetectionStrategy: Watch

--- a/pkg/kubelet/apis/config/scheme/testdata/KubeletConfiguration/roundtrip/default/v1beta1.yaml
+++ b/pkg/kubelet/apis/config/scheme/testdata/KubeletConfiguration/roundtrip/default/v1beta1.yaml
@@ -12,6 +12,7 @@ authorization:
   webhook:
     cacheAuthorizedTTL: 5m0s
     cacheUnauthorizedTTL: 30s
+certDirectory: /var/lib/kubelet/pki
 cgroupDriver: cgroupfs
 cgroupsPerQOS: true
 configMapAndSecretChangeDetectionStrategy: Watch

--- a/pkg/kubelet/apis/config/scheme/testdata/KubeletConfiguration/roundtrip/default/v1beta1.yaml
+++ b/pkg/kubelet/apis/config/scheme/testdata/KubeletConfiguration/roundtrip/default/v1beta1.yaml
@@ -12,7 +12,7 @@ authorization:
   webhook:
     cacheAuthorizedTTL: 5m0s
     cacheUnauthorizedTTL: 30s
-certDirectory: /var/lib/kubelet/pki
+certDir: /var/lib/kubelet/pki
 cgroupDriver: cgroupfs
 cgroupsPerQOS: true
 configMapAndSecretChangeDetectionStrategy: Watch

--- a/pkg/kubelet/apis/config/types.go
+++ b/pkg/kubelet/apis/config/types.go
@@ -113,6 +113,9 @@ type KubeletConfiguration struct {
 	// providerID, if set, sets the unique id of the instance that an external provider (i.e. cloudprovider)
 	// can use to identify a specific node
 	ProviderID string
+	// certDirectory is the directory where the TLS certs are located.
+	// If tlsCertFile and tlsPrivateKeyFile are provided, this field will be ignored.
+	CertDirectory string
 	// tlsCertFile is the file containing x509 Certificate for HTTPS.  (CA cert,
 	// if any, concatenated after server cert). If tlsCertFile and
 	// tlsPrivateKeyFile are not provided, a self-signed certificate

--- a/pkg/kubelet/apis/config/types.go
+++ b/pkg/kubelet/apis/config/types.go
@@ -113,9 +113,9 @@ type KubeletConfiguration struct {
 	// providerID, if set, sets the unique id of the instance that an external provider (i.e. cloudprovider)
 	// can use to identify a specific node
 	ProviderID string
-	// certDirectory is the directory where the TLS certs are located.
+	// certDir is the directory where the TLS certs are located.
 	// If tlsCertFile and tlsPrivateKeyFile are provided, this field will be ignored.
-	CertDirectory string
+	CertDir string
 	// tlsCertFile is the file containing x509 Certificate for HTTPS.  (CA cert,
 	// if any, concatenated after server cert). If tlsCertFile and
 	// tlsPrivateKeyFile are not provided, a self-signed certificate

--- a/pkg/kubelet/apis/config/v1beta1/defaults.go
+++ b/pkg/kubelet/apis/config/v1beta1/defaults.go
@@ -265,8 +265,8 @@ func SetDefaults_KubeletConfiguration(obj *kubeletconfigv1beta1.KubeletConfigura
 	if obj.MemoryThrottlingFactor == nil {
 		obj.MemoryThrottlingFactor = utilpointer.Float64Ptr(DefaultMemoryThrottlingFactor)
 	}
-	if obj.CertDirectory == "" {
-		obj.CertDirectory = filepath.Join(DefaultKubeletRunDir, DefaultCertDirRelativeToKubeletRunDir)
+	if obj.CertDir == "" {
+		obj.CertDir = filepath.Join(DefaultKubeletRunDir, DefaultCertDirRelativeToKubeletRunDir)
 	}
 	if obj.RegisterNode == nil {
 		obj.RegisterNode = utilpointer.BoolPtr(true)

--- a/pkg/kubelet/apis/config/v1beta1/defaults.go
+++ b/pkg/kubelet/apis/config/v1beta1/defaults.go
@@ -17,6 +17,7 @@ limitations under the License.
 package v1beta1
 
 import (
+	"path/filepath"
 	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -39,6 +40,9 @@ const (
 
 	// See https://github.com/kubernetes/enhancements/tree/master/keps/sig-node/2570-memory-qos
 	DefaultMemoryThrottlingFactor = 0.8
+
+	DefaultKubeletRunDir                  = "/var/lib/kubelet"
+	DefaultCertDirRelativeToKubeletRunDir = "pki"
 )
 
 var (
@@ -260,6 +264,9 @@ func SetDefaults_KubeletConfiguration(obj *kubeletconfigv1beta1.KubeletConfigura
 	}
 	if obj.MemoryThrottlingFactor == nil {
 		obj.MemoryThrottlingFactor = utilpointer.Float64Ptr(DefaultMemoryThrottlingFactor)
+	}
+	if obj.CertDirectory == "" {
+		obj.CertDirectory = filepath.Join(DefaultKubeletRunDir, DefaultCertDirRelativeToKubeletRunDir)
 	}
 	if obj.RegisterNode == nil {
 		obj.RegisterNode = utilpointer.BoolPtr(true)

--- a/pkg/kubelet/apis/config/v1beta1/defaults_test.go
+++ b/pkg/kubelet/apis/config/v1beta1/defaults_test.go
@@ -120,6 +120,7 @@ func TestSetDefaultsKubeletConfiguration(t *testing.T) {
 				EnableDebugFlagsHandler: utilpointer.BoolPtr(true),
 				SeccompDefault:          utilpointer.BoolPtr(false),
 				MemoryThrottlingFactor:  utilpointer.Float64Ptr(DefaultMemoryThrottlingFactor),
+				CertDir:                 "/var/lib/kubelet/pki",
 				RegisterNode:            utilpointer.BoolPtr(true),
 			},
 		},
@@ -246,6 +247,7 @@ func TestSetDefaultsKubeletConfiguration(t *testing.T) {
 				SeccompDefault:                  utilpointer.Bool(false),
 				MemoryThrottlingFactor:          utilpointer.Float64(0),
 				RegisterNode:                    utilpointer.BoolPtr(false),
+				CertDir:                         "/var/lib/kubelet/pki",
 			},
 			&v1beta1.KubeletConfiguration{
 				EnableServer:       utilpointer.BoolPtr(false),
@@ -342,6 +344,7 @@ func TestSetDefaultsKubeletConfiguration(t *testing.T) {
 				SeccompDefault:          utilpointer.Bool(false),
 				MemoryThrottlingFactor:  utilpointer.Float64(0),
 				RegisterNode:            utilpointer.BoolPtr(false),
+				CertDir:                 "/var/lib/kubelet/pki",
 			},
 		},
 		{
@@ -357,6 +360,7 @@ func TestSetDefaultsKubeletConfiguration(t *testing.T) {
 				Address:            "192.168.1.2",
 				Port:               10250,
 				ReadOnlyPort:       10251,
+				CertDir:            "/var/lib/kubelet/pki",
 				TLSCertFile:        "tls-cert-file",
 				TLSPrivateKeyFile:  "tls-private-key-file",
 				TLSCipherSuites:    []string{"TLS_AES_128_GCM_SHA256"},
@@ -639,6 +643,7 @@ func TestSetDefaultsKubeletConfiguration(t *testing.T) {
 				SeccompDefault:          utilpointer.Bool(true),
 				MemoryThrottlingFactor:  utilpointer.Float64(1),
 				RegisterNode:            utilpointer.BoolPtr(true),
+				CertDir:                 "/var/lib/kubelet/pki",
 			},
 		},
 		{
@@ -725,6 +730,7 @@ func TestSetDefaultsKubeletConfiguration(t *testing.T) {
 				SeccompDefault:          utilpointer.BoolPtr(false),
 				MemoryThrottlingFactor:  utilpointer.Float64Ptr(DefaultMemoryThrottlingFactor),
 				RegisterNode:            utilpointer.BoolPtr(true),
+				CertDir:                 "/var/lib/kubelet/pki",
 			},
 		},
 	}

--- a/pkg/kubelet/apis/config/v1beta1/zz_generated.conversion.go
+++ b/pkg/kubelet/apis/config/v1beta1/zz_generated.conversion.go
@@ -252,6 +252,7 @@ func autoConvert_v1beta1_KubeletConfiguration_To_config_KubeletConfiguration(in 
 	out.Address = in.Address
 	out.Port = in.Port
 	out.ReadOnlyPort = in.ReadOnlyPort
+	out.CertDirectory = in.CertDirectory
 	out.TLSCertFile = in.TLSCertFile
 	out.TLSPrivateKeyFile = in.TLSPrivateKeyFile
 	out.TLSCipherSuites = *(*[]string)(unsafe.Pointer(&in.TLSCipherSuites))
@@ -430,6 +431,7 @@ func autoConvert_config_KubeletConfiguration_To_v1beta1_KubeletConfiguration(in 
 	out.ReadOnlyPort = in.ReadOnlyPort
 	out.VolumePluginDir = in.VolumePluginDir
 	out.ProviderID = in.ProviderID
+	out.CertDirectory = in.CertDirectory
 	out.TLSCertFile = in.TLSCertFile
 	out.TLSPrivateKeyFile = in.TLSPrivateKeyFile
 	out.TLSCipherSuites = *(*[]string)(unsafe.Pointer(&in.TLSCipherSuites))

--- a/pkg/kubelet/apis/config/v1beta1/zz_generated.conversion.go
+++ b/pkg/kubelet/apis/config/v1beta1/zz_generated.conversion.go
@@ -252,7 +252,7 @@ func autoConvert_v1beta1_KubeletConfiguration_To_config_KubeletConfiguration(in 
 	out.Address = in.Address
 	out.Port = in.Port
 	out.ReadOnlyPort = in.ReadOnlyPort
-	out.CertDirectory = in.CertDirectory
+	out.CertDir = in.CertDir
 	out.TLSCertFile = in.TLSCertFile
 	out.TLSPrivateKeyFile = in.TLSPrivateKeyFile
 	out.TLSCipherSuites = *(*[]string)(unsafe.Pointer(&in.TLSCipherSuites))
@@ -431,7 +431,7 @@ func autoConvert_config_KubeletConfiguration_To_v1beta1_KubeletConfiguration(in 
 	out.ReadOnlyPort = in.ReadOnlyPort
 	out.VolumePluginDir = in.VolumePluginDir
 	out.ProviderID = in.ProviderID
-	out.CertDirectory = in.CertDirectory
+	out.CertDir = in.CertDir
 	out.TLSCertFile = in.TLSCertFile
 	out.TLSPrivateKeyFile = in.TLSPrivateKeyFile
 	out.TLSCipherSuites = *(*[]string)(unsafe.Pointer(&in.TLSCipherSuites))

--- a/staging/src/k8s.io/kubelet/config/v1beta1/types.go
+++ b/staging/src/k8s.io/kubelet/config/v1beta1/types.go
@@ -172,11 +172,11 @@ type KubeletConfiguration struct {
 	// Default: 0 (disabled)
 	// +optional
 	ReadOnlyPort int32 `json:"readOnlyPort,omitempty"`
-	// CertDirectory is the directory where the TLS certs are located.
+	// CertDir is the directory where the TLS certs are located.
 	// If tlsCertFile and tlsPrivateKeyFile are provided, this option will be ignored.
 	// Default: "/var/lib/kubelet/pki"
 	// +optional
-	CertDirectory string `json:"certDirectory,omitempty"`
+	CertDir string `json:"certDir,omitempty"`
 	// tlsCertFile is the file containing x509 Certificate for HTTPS. (CA cert,
 	// if any, concatenated after server cert). If tlsCertFile and
 	// tlsPrivateKeyFile are not provided, a self-signed certificate

--- a/staging/src/k8s.io/kubelet/config/v1beta1/types.go
+++ b/staging/src/k8s.io/kubelet/config/v1beta1/types.go
@@ -172,6 +172,11 @@ type KubeletConfiguration struct {
 	// Default: 0 (disabled)
 	// +optional
 	ReadOnlyPort int32 `json:"readOnlyPort,omitempty"`
+	// CertDirectory is the directory where the TLS certs are located.
+	// If tlsCertFile and tlsPrivateKeyFile are provided, this option will be ignored.
+	// Default: "/var/lib/kubelet/pki"
+	// +optional
+	CertDirectory string `json:"certDirectory,omitempty"`
 	// tlsCertFile is the file containing x509 Certificate for HTTPS. (CA cert,
 	// if any, concatenated after server cert). If tlsCertFile and
 	// tlsPrivateKeyFile are not provided, a self-signed certificate


### PR DESCRIPTION
WG Component Standard group is moving certain kubelet flags to kubelet
config. CertDirectory is one of those flags.

More details can be found at:
https://github.com/kubernetes/kubernetes/issues/86843

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?



/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

Moves CertDirectory as a flag to kubelet config.
Required as part of WG Component Standard group migration.

#### Which issue(s) this PR fixes:

https://github.com/kubernetes/kubernetes/issues/86843

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
The Kubelet's `--cert-dir` option is now available via the Kubelet config file field `CertDir`.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

/area kubelet
/area kubelet-api
/sig node
