### PR TITLE
Add termination hook to the startup script - GCE Windows

### DIFF
--- a/cluster/gce/windows/configure.ps1
+++ b/cluster/gce/windows/configure.ps1
@@ -205,5 +205,8 @@ catch {
   Write-Host 'Exception caught in script:'
   Write-Host $_.InvocationInfo.PositionMessage
   Write-Host "Kubernetes Windows node setup failed: $($_.Exception.Message)"
+  # Make sure kubelet won't remain running in case any failure happened during the startup.
+  Write-Host "Cleaning up, Unregistering WorkerServices..."
+  Unregister-WorkerServices
   exit 1
 }

--- a/cluster/gce/windows/k8s-node-setup.psm1
+++ b/cluster/gce/windows/k8s-node-setup.psm1
@@ -1286,6 +1286,12 @@ function Start-WorkerServices {
   Log-Output "Kubernetes components started successfully"
 }
 
+# Stop and unregister both kubelet & kube-proxy services.
+function Unregister-WorkerServices {
+  & sc.exe delete kube-proxy
+  & sc.exe delete kubelet
+}
+
 # Wait for kubelet and kube-proxy to be ready within 10s.
 function WaitFor_KubeletAndKubeProxyReady {
   $waited = 0


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup


#### What this PR does / why we need it:

The change adds a termination hook to make sure kubelet service will be deleted in case the startup script failed for any reason. This would avoid cases where other system services might have failed but the node stayed in a joined state to its cluster.

#### Which issue(s) this PR fixes:


#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
