### PR TITLE
Increase time to wait for nodes to become unready

### DIFF
--- a/test/e2e/autoscaling/cluster_size_autoscaling.go
+++ b/test/e2e/autoscaling/cluster_size_autoscaling.go
@@ -888,15 +888,11 @@ var _ = SIGDescribe("Cluster size autoscaling [Slow]", func() {
 		// If new nodes are disconnected too soon, they'll be considered not started
 		// instead of unready, and cluster won't be considered unhealthy.
 		//
-		// More precisely, Cluster Autoscaler compares last transition time of
-		// several readiness conditions to node create time. If it's within
-		// 2 minutes, it'll assume node is just starting and not unhealthy.
-		//
-		// Nodes become ready in less than 1 minute after being created,
-		// so waiting extra 2 minutes before breaking them (which triggers
-		// readiness condition transition) should be sufficient, while
-		// making no assumptions about minimal node startup time.
-		time.Sleep(2 * time.Minute)
+		// More precisely, Cluster Autoscaler will never consider a
+		// node to be unhealthy unless it was created more than 15m
+		// ago. Within that 15m window, it'll assume node is just
+		// starting and not unhealthy.
+		time.Sleep(15 * time.Minute)
 
 		ginkgo.By("Block network connectivity to some nodes to simulate unhealthy cluster")
 		nodesToBreakCount := int(math.Ceil(math.Max(float64(unhealthyClusterThreshold), 0.5*float64(clusterSize))))


### PR DESCRIPTION
https://github.com/kubernetes/autoscaler/pull/3924 changed Cluster
Autoscaler behavior to mark nodes as unhealthy only if at least 15m
passed since node creation time.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug
/kind failing-test
/kind regression

#### What this PR does / why we need it:

An attempt to fix a regression in e2e test.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

/assign @MaciekPytel 
