### PR TITLE
Automated cherry pick of #102690: CSI e2e: stop leaking pvs in CSI mock snapshot test

### DIFF
--- a/test/e2e/storage/csi_mock_volume.go
+++ b/test/e2e/storage/csi_mock_volume.go
@@ -1585,6 +1585,8 @@ var _ = utils.SIGDescribe("CSI mock volume", func() {
 				_, err = e2epv.WaitForPVClaimBoundPhase(m.cs, []*v1.PersistentVolumeClaim{pvc}, 1*time.Minute)
 				framework.ExpectNoError(err, "Failed to create claim: %v", err)
 
+				m.pvcs = append(m.pvcs, pvc)
+
 				ginkgo.By("Creating Secret")
 				secret := &v1.Secret{
 					ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
Cherry pick of #102690 on release-1.21.

#102690: CSI e2e: stop leaking pvs in CSI mock snapshot test

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.