### PR TITLE
Change defaulter-gen input to package import path

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -118,7 +118,7 @@ require (
 	k8s.io/controller-manager v0.0.0
 	k8s.io/cri-api v0.0.0
 	k8s.io/csi-translation-lib v0.0.0
-	k8s.io/gengo v0.0.0-20201214224949-b6c5ce23f027
+	k8s.io/gengo v0.0.0-20210813121822-485abfe95c7c
 	k8s.io/klog/v2 v2.9.0
 	k8s.io/kube-aggregator v0.0.0
 	k8s.io/kube-controller-manager v0.0.0
@@ -495,7 +495,7 @@ replace (
 	k8s.io/controller-manager => ./staging/src/k8s.io/controller-manager
 	k8s.io/cri-api => ./staging/src/k8s.io/cri-api
 	k8s.io/csi-translation-lib => ./staging/src/k8s.io/csi-translation-lib
-	k8s.io/gengo => k8s.io/gengo v0.0.0-20201214224949-b6c5ce23f027
+	k8s.io/gengo => k8s.io/gengo v0.0.0-20210813121822-485abfe95c7c
 	k8s.io/klog/v2 => k8s.io/klog/v2 v2.9.0
 	k8s.io/kube-aggregator => ./staging/src/k8s.io/kube-aggregator
 	k8s.io/kube-controller-manager => ./staging/src/k8s.io/kube-controller-manager

--- a/go.sum
+++ b/go.sum
@@ -578,8 +578,8 @@ gotest.tools v2.2.0+incompatible/go.mod h1:DsYFclhRJ6vuDpmuTbkuFWG+y2sxOXAzmJt81
 gotest.tools/v3 v3.0.3 h1:4AuOwCGf4lLR9u3YOe2awrHygurzhO/HeQ6laiA6Sx0=
 gotest.tools/v3 v3.0.3/go.mod h1:Z7Lb0S5l+klDB31fvDQX8ss/FlKDxtlFlw3Oa8Ymbl8=
 honnef.co/go/tools v0.0.1-2020.1.4/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
-k8s.io/gengo v0.0.0-20201214224949-b6c5ce23f027 h1:Uusb3oh8XcdzDF/ndlI4ToKTYVlkCSJP39SRY2mfRAw=
-k8s.io/gengo v0.0.0-20201214224949-b6c5ce23f027/go.mod h1:FiNAH4ZV3gBg2Kwh89tzAEV2be7d5xI0vBa/VySYy3E=
+k8s.io/gengo v0.0.0-20210813121822-485abfe95c7c h1:GohjlNKauSai7gN4wsJkeZ3WAJx4Sh+oT/b5IYn5suA=
+k8s.io/gengo v0.0.0-20210813121822-485abfe95c7c/go.mod h1:FiNAH4ZV3gBg2Kwh89tzAEV2be7d5xI0vBa/VySYy3E=
 k8s.io/klog/v2 v2.9.0 h1:D7HV+n1V57XeZ0m6tdRkfknthUaM06VFbWldOFh8kzM=
 k8s.io/klog/v2 v2.9.0/go.mod h1:hy9LJ/NvuK+iVyP4Ehqva4HxZG/oXyIS3n3Jmire4Ec=
 k8s.io/kube-openapi v0.0.0-20210421082810-95288971da7e h1:KLHHjkdQFomZy8+06csTWZ0m1343QqxZhR2LJ1OxCYM=

--- a/pkg/apis/admission/v1/doc.go
+++ b/pkg/apis/admission/v1/doc.go
@@ -17,7 +17,7 @@ limitations under the License.
 // +k8s:conversion-gen=k8s.io/kubernetes/pkg/apis/admission
 // +k8s:conversion-gen-external-types=k8s.io/api/admission/v1
 // +k8s:defaulter-gen=TypeMeta
-// +k8s:defaulter-gen-input=../../../../vendor/k8s.io/api/admission/v1
+// +k8s:defaulter-gen-input=k8s.io/api/admission/v1
 
 // +groupName=admission.k8s.io
 

--- a/pkg/apis/admission/v1beta1/doc.go
+++ b/pkg/apis/admission/v1beta1/doc.go
@@ -17,7 +17,7 @@ limitations under the License.
 // +k8s:conversion-gen=k8s.io/kubernetes/pkg/apis/admission
 // +k8s:conversion-gen-external-types=k8s.io/api/admission/v1beta1
 // +k8s:defaulter-gen=TypeMeta
-// +k8s:defaulter-gen-input=../../../../vendor/k8s.io/api/admission/v1beta1
+// +k8s:defaulter-gen-input=k8s.io/api/admission/v1beta1
 
 // +groupName=admission.k8s.io
 

--- a/pkg/apis/admissionregistration/v1/doc.go
+++ b/pkg/apis/admissionregistration/v1/doc.go
@@ -17,7 +17,7 @@ limitations under the License.
 // +k8s:conversion-gen=k8s.io/kubernetes/pkg/apis/admissionregistration
 // +k8s:conversion-gen-external-types=k8s.io/api/admissionregistration/v1
 // +k8s:defaulter-gen=TypeMeta
-// +k8s:defaulter-gen-input=../../../../vendor/k8s.io/api/admissionregistration/v1
+// +k8s:defaulter-gen-input=k8s.io/api/admissionregistration/v1
 // +groupName=admissionregistration.k8s.io
 
 // Package v1 is the v1 version of the API.

--- a/pkg/apis/admissionregistration/v1beta1/doc.go
+++ b/pkg/apis/admissionregistration/v1beta1/doc.go
@@ -17,7 +17,7 @@ limitations under the License.
 // +k8s:conversion-gen=k8s.io/kubernetes/pkg/apis/admissionregistration
 // +k8s:conversion-gen-external-types=k8s.io/api/admissionregistration/v1beta1
 // +k8s:defaulter-gen=TypeMeta
-// +k8s:defaulter-gen-input=../../../../vendor/k8s.io/api/admissionregistration/v1beta1
+// +k8s:defaulter-gen-input=k8s.io/api/admissionregistration/v1beta1
 // +groupName=admissionregistration.k8s.io
 
 // Package v1beta1 is the v1beta1 version of the API.

--- a/pkg/apis/apiserverinternal/v1alpha1/doc.go
+++ b/pkg/apis/apiserverinternal/v1alpha1/doc.go
@@ -17,7 +17,7 @@ limitations under the License.
 // +k8s:conversion-gen=k8s.io/kubernetes/pkg/apis/apiserverinternal
 // +k8s:conversion-gen-external-types=k8s.io/api/apiserverinternal/v1alpha1
 // +k8s:defaulter-gen=TypeMeta
-// +k8s:defaulter-gen-input=../../../../vendor/k8s.io/api/apiserverinternal/v1alpha1
+// +k8s:defaulter-gen-input=k8s.io/api/apiserverinternal/v1alpha1
 
 // +groupName=internal.apiserver.k8s.io
 

--- a/pkg/apis/apps/v1/doc.go
+++ b/pkg/apis/apps/v1/doc.go
@@ -17,6 +17,6 @@ limitations under the License.
 // +k8s:conversion-gen=k8s.io/kubernetes/pkg/apis/apps
 // +k8s:conversion-gen-external-types=k8s.io/api/apps/v1
 // +k8s:defaulter-gen=TypeMeta
-// +k8s:defaulter-gen-input=../../../../vendor/k8s.io/api/apps/v1
+// +k8s:defaulter-gen-input=k8s.io/api/apps/v1
 
 package v1 // import "k8s.io/kubernetes/pkg/apis/apps/v1"

--- a/pkg/apis/apps/v1beta1/doc.go
+++ b/pkg/apis/apps/v1beta1/doc.go
@@ -18,6 +18,6 @@ limitations under the License.
 // +k8s:conversion-gen=k8s.io/kubernetes/pkg/apis/autoscaling
 // +k8s:conversion-gen-external-types=k8s.io/api/apps/v1beta1
 // +k8s:defaulter-gen=TypeMeta
-// +k8s:defaulter-gen-input=../../../../vendor/k8s.io/api/apps/v1beta1
+// +k8s:defaulter-gen-input=k8s.io/api/apps/v1beta1
 
 package v1beta1 // import "k8s.io/kubernetes/pkg/apis/apps/v1beta1"

--- a/pkg/apis/apps/v1beta2/doc.go
+++ b/pkg/apis/apps/v1beta2/doc.go
@@ -18,6 +18,6 @@ limitations under the License.
 // +k8s:conversion-gen=k8s.io/kubernetes/pkg/apis/autoscaling
 // +k8s:conversion-gen-external-types=k8s.io/api/apps/v1beta2
 // +k8s:defaulter-gen=TypeMeta
-// +k8s:defaulter-gen-input=../../../../vendor/k8s.io/api/apps/v1beta2
+// +k8s:defaulter-gen-input=k8s.io/api/apps/v1beta2
 
 package v1beta2 // import "k8s.io/kubernetes/pkg/apis/apps/v1beta2"

--- a/pkg/apis/authentication/v1/doc.go
+++ b/pkg/apis/authentication/v1/doc.go
@@ -18,6 +18,6 @@ limitations under the License.
 // +k8s:conversion-gen-external-types=k8s.io/api/authentication/v1
 // +groupName=authentication.k8s.io
 // +k8s:defaulter-gen=TypeMeta
-// +k8s:defaulter-gen-input=../../../../vendor/k8s.io/api/authentication/v1
+// +k8s:defaulter-gen-input=k8s.io/api/authentication/v1
 
 package v1 // import "k8s.io/kubernetes/pkg/apis/authentication/v1"

--- a/pkg/apis/authentication/v1beta1/doc.go
+++ b/pkg/apis/authentication/v1beta1/doc.go
@@ -18,6 +18,6 @@ limitations under the License.
 // +k8s:conversion-gen-external-types=k8s.io/api/authentication/v1beta1
 // +groupName=authentication.k8s.io
 // +k8s:defaulter-gen=TypeMeta
-// +k8s:defaulter-gen-input=../../../../vendor/k8s.io/api/authentication/v1beta1
+// +k8s:defaulter-gen-input=k8s.io/api/authentication/v1beta1
 
 package v1beta1 // import "k8s.io/kubernetes/pkg/apis/authentication/v1beta1"

--- a/pkg/apis/authorization/v1/doc.go
+++ b/pkg/apis/authorization/v1/doc.go
@@ -17,7 +17,7 @@ limitations under the License.
 // +k8s:conversion-gen=k8s.io/kubernetes/pkg/apis/authorization
 // +k8s:conversion-gen-external-types=k8s.io/api/authorization/v1
 // +k8s:defaulter-gen=TypeMeta
-// +k8s:defaulter-gen-input=../../../../vendor/k8s.io/api/authorization/v1
+// +k8s:defaulter-gen-input=k8s.io/api/authorization/v1
 
 // +groupName=authorization.k8s.io
 

--- a/pkg/apis/authorization/v1beta1/doc.go
+++ b/pkg/apis/authorization/v1beta1/doc.go
@@ -17,7 +17,7 @@ limitations under the License.
 // +k8s:conversion-gen=k8s.io/kubernetes/pkg/apis/authorization
 // +k8s:conversion-gen-external-types=k8s.io/api/authorization/v1beta1
 // +k8s:defaulter-gen=TypeMeta
-// +k8s:defaulter-gen-input=../../../../vendor/k8s.io/api/authorization/v1beta1
+// +k8s:defaulter-gen-input=k8s.io/api/authorization/v1beta1
 
 // +groupName=authorization.k8s.io
 

--- a/pkg/apis/autoscaling/v1/doc.go
+++ b/pkg/apis/autoscaling/v1/doc.go
@@ -17,6 +17,6 @@ limitations under the License.
 // +k8s:conversion-gen=k8s.io/kubernetes/pkg/apis/autoscaling
 // +k8s:conversion-gen-external-types=k8s.io/api/autoscaling/v1
 // +k8s:defaulter-gen=TypeMeta
-// +k8s:defaulter-gen-input=../../../../vendor/k8s.io/api/autoscaling/v1
+// +k8s:defaulter-gen-input=k8s.io/api/autoscaling/v1
 
 package v1 // import "k8s.io/kubernetes/pkg/apis/autoscaling/v1"

--- a/pkg/apis/autoscaling/v2beta1/doc.go
+++ b/pkg/apis/autoscaling/v2beta1/doc.go
@@ -17,6 +17,6 @@ limitations under the License.
 // +k8s:conversion-gen=k8s.io/kubernetes/pkg/apis/autoscaling
 // +k8s:conversion-gen-external-types=k8s.io/api/autoscaling/v2beta1
 // +k8s:defaulter-gen=TypeMeta
-// +k8s:defaulter-gen-input=../../../../vendor/k8s.io/api/autoscaling/v2beta1
+// +k8s:defaulter-gen-input=k8s.io/api/autoscaling/v2beta1
 
 package v2beta1 // import "k8s.io/kubernetes/pkg/apis/autoscaling/v2beta1"

--- a/pkg/apis/autoscaling/v2beta2/doc.go
+++ b/pkg/apis/autoscaling/v2beta2/doc.go
@@ -17,6 +17,6 @@ limitations under the License.
 // +k8s:conversion-gen=k8s.io/kubernetes/pkg/apis/autoscaling
 // +k8s:conversion-gen-external-types=k8s.io/api/autoscaling/v2beta2
 // +k8s:defaulter-gen=TypeMeta
-// +k8s:defaulter-gen-input=../../../../vendor/k8s.io/api/autoscaling/v2beta2
+// +k8s:defaulter-gen-input=k8s.io/api/autoscaling/v2beta2
 
 package v2beta2 // import "k8s.io/kubernetes/pkg/apis/autoscaling/v2beta2"

--- a/pkg/apis/batch/v1/doc.go
+++ b/pkg/apis/batch/v1/doc.go
@@ -17,6 +17,6 @@ limitations under the License.
 // +k8s:conversion-gen=k8s.io/kubernetes/pkg/apis/batch
 // +k8s:conversion-gen-external-types=k8s.io/api/batch/v1
 // +k8s:defaulter-gen=TypeMeta
-// +k8s:defaulter-gen-input=../../../../vendor/k8s.io/api/batch/v1
+// +k8s:defaulter-gen-input=k8s.io/api/batch/v1
 
 package v1 // import "k8s.io/kubernetes/pkg/apis/batch/v1"

--- a/pkg/apis/batch/v1beta1/doc.go
+++ b/pkg/apis/batch/v1beta1/doc.go
@@ -18,6 +18,6 @@ limitations under the License.
 // +k8s:conversion-gen=k8s.io/kubernetes/pkg/apis/batch/v1
 // +k8s:conversion-gen-external-types=k8s.io/api/batch/v1beta1
 // +k8s:defaulter-gen=TypeMeta
-// +k8s:defaulter-gen-input=../../../../vendor/k8s.io/api/batch/v1beta1
+// +k8s:defaulter-gen-input=k8s.io/api/batch/v1beta1
 
 package v1beta1 // import "k8s.io/kubernetes/pkg/apis/batch/v1beta1"

--- a/pkg/apis/certificates/v1/doc.go
+++ b/pkg/apis/certificates/v1/doc.go
@@ -17,7 +17,7 @@ limitations under the License.
 // +k8s:conversion-gen=k8s.io/kubernetes/pkg/apis/certificates
 // +k8s:conversion-gen-external-types=k8s.io/api/certificates/v1
 // +k8s:defaulter-gen=TypeMeta
-// +k8s:defaulter-gen-input=../../../../vendor/k8s.io/api/certificates/v1
+// +k8s:defaulter-gen-input=k8s.io/api/certificates/v1
 
 // +groupName=certificates.k8s.io
 

--- a/pkg/apis/certificates/v1beta1/doc.go
+++ b/pkg/apis/certificates/v1beta1/doc.go
@@ -17,7 +17,7 @@ limitations under the License.
 // +k8s:conversion-gen=k8s.io/kubernetes/pkg/apis/certificates
 // +k8s:conversion-gen-external-types=k8s.io/api/certificates/v1beta1
 // +k8s:defaulter-gen=TypeMeta
-// +k8s:defaulter-gen-input=../../../../vendor/k8s.io/api/certificates/v1beta1
+// +k8s:defaulter-gen-input=k8s.io/api/certificates/v1beta1
 
 // +groupName=certificates.k8s.io
 

--- a/pkg/apis/coordination/v1/doc.go
+++ b/pkg/apis/coordination/v1/doc.go
@@ -17,7 +17,7 @@ limitations under the License.
 // +k8s:conversion-gen=k8s.io/kubernetes/pkg/apis/coordination
 // +k8s:conversion-gen-external-types=k8s.io/api/coordination/v1
 // +k8s:defaulter-gen=TypeMeta
-// +k8s:defaulter-gen-input=../../../../vendor/k8s.io/api/coordination/v1
+// +k8s:defaulter-gen-input=k8s.io/api/coordination/v1
 
 // +groupName=coordination.k8s.io
 

--- a/pkg/apis/coordination/v1beta1/doc.go
+++ b/pkg/apis/coordination/v1beta1/doc.go
@@ -17,7 +17,7 @@ limitations under the License.
 // +k8s:conversion-gen=k8s.io/kubernetes/pkg/apis/coordination
 // +k8s:conversion-gen-external-types=k8s.io/api/coordination/v1beta1
 // +k8s:defaulter-gen=TypeMeta
-// +k8s:defaulter-gen-input=../../../../vendor/k8s.io/api/coordination/v1beta1
+// +k8s:defaulter-gen-input=k8s.io/api/coordination/v1beta1
 
 // +groupName=coordination.k8s.io
 

--- a/pkg/apis/core/v1/doc.go
+++ b/pkg/apis/core/v1/doc.go
@@ -17,7 +17,7 @@ limitations under the License.
 // +k8s:conversion-gen=k8s.io/kubernetes/pkg/apis/core
 // +k8s:conversion-gen-external-types=k8s.io/api/core/v1
 // +k8s:defaulter-gen=TypeMeta
-// +k8s:defaulter-gen-input=../../../../vendor/k8s.io/api/core/v1
+// +k8s:defaulter-gen-input=k8s.io/api/core/v1
 
 // Package v1 is the v1 version of the API.
 package v1 // import "k8s.io/kubernetes/pkg/apis/core/v1"

--- a/pkg/apis/discovery/v1/doc.go
+++ b/pkg/apis/discovery/v1/doc.go
@@ -17,6 +17,6 @@ limitations under the License.
 // +k8s:conversion-gen=k8s.io/kubernetes/pkg/apis/discovery
 // +k8s:conversion-gen-external-types=k8s.io/api/discovery/v1
 // +k8s:defaulter-gen=TypeMeta
-// +k8s:defaulter-gen-input=../../../../vendor/k8s.io/api/discovery/v1
+// +k8s:defaulter-gen-input=k8s.io/api/discovery/v1
 
 package v1 // import "k8s.io/kubernetes/pkg/apis/discovery/v1"

--- a/pkg/apis/discovery/v1beta1/doc.go
+++ b/pkg/apis/discovery/v1beta1/doc.go
@@ -17,6 +17,6 @@ limitations under the License.
 // +k8s:conversion-gen=k8s.io/kubernetes/pkg/apis/discovery
 // +k8s:conversion-gen-external-types=k8s.io/api/discovery/v1beta1
 // +k8s:defaulter-gen=TypeMeta
-// +k8s:defaulter-gen-input=../../../../vendor/k8s.io/api/discovery/v1beta1
+// +k8s:defaulter-gen-input=k8s.io/api/discovery/v1beta1
 
 package v1beta1 // import "k8s.io/kubernetes/pkg/apis/discovery/v1beta1"

--- a/pkg/apis/events/v1/doc.go
+++ b/pkg/apis/events/v1/doc.go
@@ -17,7 +17,7 @@ limitations under the License.
 // +k8s:conversion-gen=k8s.io/kubernetes/pkg/apis/events
 // +k8s:conversion-gen-external-types=k8s.io/api/events/v1
 // +k8s:defaulter-gen=TypeMeta
-// +k8s:defaulter-gen-input=../../../../vendor/k8s.io/api/events/v1
+// +k8s:defaulter-gen-input=k8s.io/api/events/v1
 
 // +groupName=events.k8s.io
 

--- a/pkg/apis/events/v1beta1/doc.go
+++ b/pkg/apis/events/v1beta1/doc.go
@@ -17,7 +17,7 @@ limitations under the License.
 // +k8s:conversion-gen=k8s.io/kubernetes/pkg/apis/events
 // +k8s:conversion-gen-external-types=k8s.io/api/events/v1beta1
 // +k8s:defaulter-gen=TypeMeta
-// +k8s:defaulter-gen-input=../../../../vendor/k8s.io/api/events/v1beta1
+// +k8s:defaulter-gen-input=k8s.io/api/events/v1beta1
 
 // +groupName=events.k8s.io
 

--- a/pkg/apis/extensions/v1beta1/doc.go
+++ b/pkg/apis/extensions/v1beta1/doc.go
@@ -21,6 +21,6 @@ limitations under the License.
 // +k8s:conversion-gen=k8s.io/kubernetes/pkg/apis/autoscaling
 // +k8s:conversion-gen-external-types=k8s.io/api/extensions/v1beta1
 // +k8s:defaulter-gen=TypeMeta
-// +k8s:defaulter-gen-input=../../../../vendor/k8s.io/api/extensions/v1beta1
+// +k8s:defaulter-gen-input=k8s.io/api/extensions/v1beta1
 
 package v1beta1 // import "k8s.io/kubernetes/pkg/apis/extensions/v1beta1"

--- a/pkg/apis/flowcontrol/v1alpha1/doc.go
+++ b/pkg/apis/flowcontrol/v1alpha1/doc.go
@@ -17,7 +17,7 @@ limitations under the License.
 // +k8s:conversion-gen=k8s.io/kubernetes/pkg/apis/flowcontrol
 // +k8s:conversion-gen-external-types=k8s.io/api/flowcontrol/v1alpha1
 // +k8s:defaulter-gen=TypeMeta
-// +k8s:defaulter-gen-input=../../../../vendor/k8s.io/api/flowcontrol/v1alpha1
+// +k8s:defaulter-gen-input=k8s.io/api/flowcontrol/v1alpha1
 
 // +groupName=flowcontrol.apiserver.k8s.io
 

--- a/pkg/apis/flowcontrol/v1beta1/doc.go
+++ b/pkg/apis/flowcontrol/v1beta1/doc.go
@@ -17,7 +17,7 @@ limitations under the License.
 // +k8s:conversion-gen=k8s.io/kubernetes/pkg/apis/flowcontrol
 // +k8s:conversion-gen-external-types=k8s.io/api/flowcontrol/v1beta1
 // +k8s:defaulter-gen=TypeMeta
-// +k8s:defaulter-gen-input=../../../../vendor/k8s.io/api/flowcontrol/v1beta1
+// +k8s:defaulter-gen-input=k8s.io/api/flowcontrol/v1beta1
 
 // +groupName=flowcontrol.apiserver.k8s.io
 

--- a/pkg/apis/imagepolicy/v1alpha1/doc.go
+++ b/pkg/apis/imagepolicy/v1alpha1/doc.go
@@ -17,7 +17,7 @@ limitations under the License.
 // +k8s:conversion-gen=k8s.io/kubernetes/pkg/apis/imagepolicy
 // +k8s:conversion-gen-external-types=k8s.io/api/imagepolicy/v1alpha1
 // +k8s:defaulter-gen=TypeMeta
-// +k8s:defaulter-gen-input=../../../../vendor/k8s.io/api/imagepolicy/v1alpha1
+// +k8s:defaulter-gen-input=k8s.io/api/imagepolicy/v1alpha1
 
 // +groupName=imagepolicy.k8s.io
 

--- a/pkg/apis/networking/v1/doc.go
+++ b/pkg/apis/networking/v1/doc.go
@@ -18,7 +18,7 @@ limitations under the License.
 // +k8s:conversion-gen-external-types=k8s.io/api/networking/v1
 // +k8s:conversion-gen=k8s.io/kubernetes/pkg/apis/extensions
 // +k8s:defaulter-gen=TypeMeta
-// +k8s:defaulter-gen-input=../../../../vendor/k8s.io/api/networking/v1
+// +k8s:defaulter-gen-input=k8s.io/api/networking/v1
 // +groupName=networking.k8s.io
 
 package v1 // import "k8s.io/kubernetes/pkg/apis/networking/v1"

--- a/pkg/apis/networking/v1beta1/doc.go
+++ b/pkg/apis/networking/v1beta1/doc.go
@@ -18,7 +18,7 @@ limitations under the License.
 // +k8s:conversion-gen-external-types=k8s.io/api/networking/v1beta1
 // +k8s:conversion-gen=k8s.io/kubernetes/pkg/apis/extensions
 // +k8s:defaulter-gen=TypeMeta
-// +k8s:defaulter-gen-input=../../../../vendor/k8s.io/api/networking/v1beta1
+// +k8s:defaulter-gen-input=k8s.io/api/networking/v1beta1
 // +groupName=networking.k8s.io
 
 package v1beta1 // import "k8s.io/kubernetes/pkg/apis/networking/v1beta1"

--- a/pkg/apis/policy/v1/doc.go
+++ b/pkg/apis/policy/v1/doc.go
@@ -17,7 +17,7 @@ limitations under the License.
 // +k8s:conversion-gen=k8s.io/kubernetes/pkg/apis/policy
 // +k8s:conversion-gen-external-types=k8s.io/api/policy/v1
 // +k8s:defaulter-gen=TypeMeta
-// +k8s:defaulter-gen-input=../../../../vendor/k8s.io/api/policy/v1
+// +k8s:defaulter-gen-input=k8s.io/api/policy/v1
 
 // Package policy is for any kind of policy object. Currently, this only
 // includes policyv1.PodDisruptionBudget

--- a/pkg/apis/policy/v1beta1/doc.go
+++ b/pkg/apis/policy/v1beta1/doc.go
@@ -17,7 +17,7 @@ limitations under the License.
 // +k8s:conversion-gen=k8s.io/kubernetes/pkg/apis/policy
 // +k8s:conversion-gen-external-types=k8s.io/api/policy/v1beta1
 // +k8s:defaulter-gen=TypeMeta
-// +k8s:defaulter-gen-input=../../../../vendor/k8s.io/api/policy/v1beta1
+// +k8s:defaulter-gen-input=k8s.io/api/policy/v1beta1
 
 // Package policy is for any kind of policy object.  Suitable examples, even if
 // they aren't all here, are policyv1beta1.PodDisruptionBudget, PodSecurityPolicy,

--- a/pkg/apis/rbac/v1/doc.go
+++ b/pkg/apis/rbac/v1/doc.go
@@ -17,7 +17,7 @@ limitations under the License.
 // +k8s:conversion-gen=k8s.io/kubernetes/pkg/apis/rbac
 // +k8s:conversion-gen-external-types=k8s.io/api/rbac/v1
 // +k8s:defaulter-gen=TypeMeta
-// +k8s:defaulter-gen-input=../../../../vendor/k8s.io/api/rbac/v1
+// +k8s:defaulter-gen-input=k8s.io/api/rbac/v1
 // +k8s:deepcopy-gen=package
 
 // +groupName=rbac.authorization.k8s.io

--- a/pkg/apis/rbac/v1alpha1/doc.go
+++ b/pkg/apis/rbac/v1alpha1/doc.go
@@ -17,7 +17,7 @@ limitations under the License.
 // +k8s:conversion-gen=k8s.io/kubernetes/pkg/apis/rbac
 // +k8s:conversion-gen-external-types=k8s.io/api/rbac/v1alpha1
 // +k8s:defaulter-gen=TypeMeta
-// +k8s:defaulter-gen-input=../../../../vendor/k8s.io/api/rbac/v1alpha1
+// +k8s:defaulter-gen-input=k8s.io/api/rbac/v1alpha1
 
 // +groupName=rbac.authorization.k8s.io
 

--- a/pkg/apis/rbac/v1beta1/doc.go
+++ b/pkg/apis/rbac/v1beta1/doc.go
@@ -17,7 +17,7 @@ limitations under the License.
 // +k8s:conversion-gen=k8s.io/kubernetes/pkg/apis/rbac
 // +k8s:conversion-gen-external-types=k8s.io/api/rbac/v1beta1
 // +k8s:defaulter-gen=TypeMeta
-// +k8s:defaulter-gen-input=../../../../vendor/k8s.io/api/rbac/v1beta1
+// +k8s:defaulter-gen-input=k8s.io/api/rbac/v1beta1
 
 // +groupName=rbac.authorization.k8s.io
 

--- a/pkg/apis/scheduling/v1/doc.go
+++ b/pkg/apis/scheduling/v1/doc.go
@@ -18,6 +18,6 @@ limitations under the License.
 // +k8s:conversion-gen-external-types=k8s.io/api/scheduling/v1
 // +groupName=scheduling.k8s.io
 // +k8s:defaulter-gen=TypeMeta
-// +k8s:defaulter-gen-input=../../../../vendor/k8s.io/api/scheduling/v1
+// +k8s:defaulter-gen-input=k8s.io/api/scheduling/v1
 
 package v1 // import "k8s.io/kubernetes/pkg/apis/scheduling/v1"

--- a/pkg/apis/scheduling/v1alpha1/doc.go
+++ b/pkg/apis/scheduling/v1alpha1/doc.go
@@ -18,6 +18,6 @@ limitations under the License.
 // +k8s:conversion-gen-external-types=k8s.io/api/scheduling/v1alpha1
 // +groupName=scheduling.k8s.io
 // +k8s:defaulter-gen=TypeMeta
-// +k8s:defaulter-gen-input=../../../../vendor/k8s.io/api/scheduling/v1alpha1
+// +k8s:defaulter-gen-input=k8s.io/api/scheduling/v1alpha1
 
 package v1alpha1 // import "k8s.io/kubernetes/pkg/apis/scheduling/v1alpha1"

--- a/pkg/apis/scheduling/v1beta1/doc.go
+++ b/pkg/apis/scheduling/v1beta1/doc.go
@@ -18,6 +18,6 @@ limitations under the License.
 // +k8s:conversion-gen-external-types=k8s.io/api/scheduling/v1beta1
 // +groupName=scheduling.k8s.io
 // +k8s:defaulter-gen=TypeMeta
-// +k8s:defaulter-gen-input=../../../../vendor/k8s.io/api/scheduling/v1beta1
+// +k8s:defaulter-gen-input=k8s.io/api/scheduling/v1beta1
 
 package v1beta1 // import "k8s.io/kubernetes/pkg/apis/scheduling/v1beta1"

--- a/pkg/apis/storage/v1/doc.go
+++ b/pkg/apis/storage/v1/doc.go
@@ -18,6 +18,6 @@ limitations under the License.
 // +k8s:conversion-gen-external-types=k8s.io/api/storage/v1
 // +groupName=storage.k8s.io
 // +k8s:defaulter-gen=TypeMeta
-// +k8s:defaulter-gen-input=../../../../vendor/k8s.io/api/storage/v1
+// +k8s:defaulter-gen-input=k8s.io/api/storage/v1
 
 package v1 // import "k8s.io/kubernetes/pkg/apis/storage/v1"

--- a/pkg/apis/storage/v1alpha1/doc.go
+++ b/pkg/apis/storage/v1alpha1/doc.go
@@ -18,6 +18,6 @@ limitations under the License.
 // +k8s:conversion-gen-external-types=k8s.io/api/storage/v1alpha1
 // +groupName=storage.k8s.io
 // +k8s:defaulter-gen=TypeMeta
-// +k8s:defaulter-gen-input=../../../../vendor/k8s.io/api/storage/v1alpha1
+// +k8s:defaulter-gen-input=k8s.io/api/storage/v1alpha1
 
 package v1alpha1 // import "k8s.io/kubernetes/pkg/apis/storage/v1alpha1"

--- a/pkg/apis/storage/v1beta1/doc.go
+++ b/pkg/apis/storage/v1beta1/doc.go
@@ -18,6 +18,6 @@ limitations under the License.
 // +k8s:conversion-gen-external-types=k8s.io/api/storage/v1beta1
 // +groupName=storage.k8s.io
 // +k8s:defaulter-gen=TypeMeta
-// +k8s:defaulter-gen-input=../../../../vendor/k8s.io/api/storage/v1beta1
+// +k8s:defaulter-gen-input=k8s.io/api/storage/v1beta1
 
 package v1beta1 // import "k8s.io/kubernetes/pkg/apis/storage/v1beta1"

--- a/pkg/controller/apis/config/v1alpha1/doc.go
+++ b/pkg/controller/apis/config/v1alpha1/doc.go
@@ -45,7 +45,7 @@ limitations under the License.
 // +k8s:conversion-gen=k8s.io/kubernetes/pkg/controller/volume/persistentvolume/config/v1alpha1
 // +k8s:conversion-gen-external-types=k8s.io/kube-controller-manager/config/v1alpha1
 // +k8s:defaulter-gen=TypeMeta
-// +k8s:defaulter-gen-input=../../../../../vendor/k8s.io/kube-controller-manager/config/v1alpha1
+// +k8s:defaulter-gen-input=k8s.io/kube-controller-manager/config/v1alpha1
 // +groupName=kubecontrollermanager.config.k8s.io
 
 package v1alpha1 // import "k8s.io/kubernetes/pkg/controller/apis/config/v1alpha1"

--- a/pkg/kubelet/apis/config/v1alpha1/doc.go
+++ b/pkg/kubelet/apis/config/v1alpha1/doc.go
@@ -18,7 +18,7 @@ limitations under the License.
 // +k8s:conversion-gen=k8s.io/kubernetes/pkg/kubelet/apis/config
 // +k8s:conversion-gen-external-types=k8s.io/kubelet/config/v1alpha1
 // +k8s:defaulter-gen=TypeMeta
-// +k8s:defaulter-gen-input=../../../../../vendor/k8s.io/kubelet/config/v1alpha1
+// +k8s:defaulter-gen-input=k8s.io/kubelet/config/v1alpha1
 // +groupName=kubelet.config.k8s.io
 
 package v1alpha1 // import "k8s.io/kubernetes/pkg/kubelet/apis/config/v1alpha1"

--- a/pkg/kubelet/apis/config/v1beta1/doc.go
+++ b/pkg/kubelet/apis/config/v1beta1/doc.go
@@ -18,7 +18,7 @@ limitations under the License.
 // +k8s:conversion-gen=k8s.io/kubernetes/pkg/kubelet/apis/config
 // +k8s:conversion-gen-external-types=k8s.io/kubelet/config/v1beta1
 // +k8s:defaulter-gen=TypeMeta
-// +k8s:defaulter-gen-input=../../../../../vendor/k8s.io/kubelet/config/v1beta1
+// +k8s:defaulter-gen-input=k8s.io/kubelet/config/v1beta1
 // +groupName=kubelet.config.k8s.io
 
 package v1beta1 // import "k8s.io/kubernetes/pkg/kubelet/apis/config/v1beta1"

--- a/pkg/proxy/apis/config/v1alpha1/doc.go
+++ b/pkg/proxy/apis/config/v1alpha1/doc.go
@@ -18,7 +18,7 @@ limitations under the License.
 // +k8s:conversion-gen=k8s.io/kubernetes/pkg/proxy/apis/config
 // +k8s:conversion-gen-external-types=k8s.io/kube-proxy/config/v1alpha1
 // +k8s:defaulter-gen=TypeMeta
-// +k8s:defaulter-gen-input=../../../../../vendor/k8s.io/kube-proxy/config/v1alpha1
+// +k8s:defaulter-gen-input=k8s.io/kube-proxy/config/v1alpha1
 // +groupName=kubeproxy.config.k8s.io
 
 package v1alpha1 // import "k8s.io/kubernetes/pkg/proxy/apis/config/v1alpha1"

--- a/pkg/scheduler/apis/config/v1/doc.go
+++ b/pkg/scheduler/apis/config/v1/doc.go
@@ -18,7 +18,7 @@ limitations under the License.
 // +k8s:conversion-gen=k8s.io/kubernetes/pkg/scheduler/apis/config
 // +k8s:conversion-gen-external-types=k8s.io/kube-scheduler/config/v1
 // +k8s:defaulter-gen=TypeMeta
-// +k8s:defaulter-gen-input=../../../../../vendor/k8s.io/kube-scheduler/config/v1
+// +k8s:defaulter-gen-input=k8s.io/kube-scheduler/config/v1
 // +groupName=kubescheduler.config.k8s.io
 
 package v1 // import "k8s.io/kubernetes/pkg/scheduler/apis/config/v1"

--- a/pkg/scheduler/apis/config/v1beta1/doc.go
+++ b/pkg/scheduler/apis/config/v1beta1/doc.go
@@ -18,7 +18,7 @@ limitations under the License.
 // +k8s:conversion-gen=k8s.io/kubernetes/pkg/scheduler/apis/config
 // +k8s:conversion-gen-external-types=k8s.io/kube-scheduler/config/v1beta1
 // +k8s:defaulter-gen=TypeMeta
-// +k8s:defaulter-gen-input=../../../../../vendor/k8s.io/kube-scheduler/config/v1beta1
+// +k8s:defaulter-gen-input=k8s.io/kube-scheduler/config/v1beta1
 // +groupName=kubescheduler.config.k8s.io
 
 package v1beta1 // import "k8s.io/kubernetes/pkg/scheduler/apis/config/v1beta1"

--- a/pkg/scheduler/apis/config/v1beta2/doc.go
+++ b/pkg/scheduler/apis/config/v1beta2/doc.go
@@ -18,7 +18,7 @@ limitations under the License.
 // +k8s:conversion-gen=k8s.io/kubernetes/pkg/scheduler/apis/config
 // +k8s:conversion-gen-external-types=k8s.io/kube-scheduler/config/v1beta2
 // +k8s:defaulter-gen=TypeMeta
-// +k8s:defaulter-gen-input=../../../../../vendor/k8s.io/kube-scheduler/config/v1beta2
+// +k8s:defaulter-gen-input=k8s.io/kube-scheduler/config/v1beta2
 // +groupName=kubescheduler.config.k8s.io
 
 package v1beta2 // import "k8s.io/kubernetes/pkg/scheduler/apis/config/v1beta2"

--- a/staging/src/k8s.io/apiextensions-apiserver/go.sum
+++ b/staging/src/k8s.io/apiextensions-apiserver/go.sum
@@ -925,8 +925,8 @@ honnef.co/go/tools v0.0.1-2019.2.3/go.mod h1:a3bituU0lyd329TUQxRnasdCoJDkEUEAqEt
 honnef.co/go/tools v0.0.1-2020.1.3/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
 honnef.co/go/tools v0.0.1-2020.1.4/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
 k8s.io/gengo v0.0.0-20200413195148-3a45101e95ac/go.mod h1:ezvh/TsK7cY6rbqRK0oQQ8IAqLxYwwyPxAX1Pzy0ii0=
-k8s.io/gengo v0.0.0-20201214224949-b6c5ce23f027 h1:Uusb3oh8XcdzDF/ndlI4ToKTYVlkCSJP39SRY2mfRAw=
-k8s.io/gengo v0.0.0-20201214224949-b6c5ce23f027/go.mod h1:FiNAH4ZV3gBg2Kwh89tzAEV2be7d5xI0vBa/VySYy3E=
+k8s.io/gengo v0.0.0-20210813121822-485abfe95c7c h1:GohjlNKauSai7gN4wsJkeZ3WAJx4Sh+oT/b5IYn5suA=
+k8s.io/gengo v0.0.0-20210813121822-485abfe95c7c/go.mod h1:FiNAH4ZV3gBg2Kwh89tzAEV2be7d5xI0vBa/VySYy3E=
 k8s.io/klog/v2 v2.0.0/go.mod h1:PBfzABfn139FHAV07az/IF9Wp1bkk3vpT2XSJ76fSDE=
 k8s.io/klog/v2 v2.2.0/go.mod h1:Od+F08eJP+W3HUb4pSrPpgp9DGU4GzlpG/TmITuYh/Y=
 k8s.io/klog/v2 v2.9.0 h1:D7HV+n1V57XeZ0m6tdRkfknthUaM06VFbWldOFh8kzM=

--- a/staging/src/k8s.io/code-generator/go.mod
+++ b/staging/src/k8s.io/code-generator/go.mod
@@ -20,7 +20,7 @@ require (
 	golang.org/x/tools v0.1.2
 	gopkg.in/yaml.v2 v2.4.0
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
-	k8s.io/gengo v0.0.0-20201214224949-b6c5ce23f027
+	k8s.io/gengo v0.0.0-20210813121822-485abfe95c7c
 	k8s.io/klog/v2 v2.9.0
 	k8s.io/kube-openapi v0.0.0-20210421082810-95288971da7e
 	sigs.k8s.io/structured-merge-diff/v4 v4.1.2 // indirect

--- a/staging/src/k8s.io/code-generator/go.sum
+++ b/staging/src/k8s.io/code-generator/go.sum
@@ -232,8 +232,8 @@ gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b/go.mod h1:K4uyk7z7BCEPqu6E+C
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 k8s.io/gengo v0.0.0-20200413195148-3a45101e95ac/go.mod h1:ezvh/TsK7cY6rbqRK0oQQ8IAqLxYwwyPxAX1Pzy0ii0=
-k8s.io/gengo v0.0.0-20201214224949-b6c5ce23f027 h1:Uusb3oh8XcdzDF/ndlI4ToKTYVlkCSJP39SRY2mfRAw=
-k8s.io/gengo v0.0.0-20201214224949-b6c5ce23f027/go.mod h1:FiNAH4ZV3gBg2Kwh89tzAEV2be7d5xI0vBa/VySYy3E=
+k8s.io/gengo v0.0.0-20210813121822-485abfe95c7c h1:GohjlNKauSai7gN4wsJkeZ3WAJx4Sh+oT/b5IYn5suA=
+k8s.io/gengo v0.0.0-20210813121822-485abfe95c7c/go.mod h1:FiNAH4ZV3gBg2Kwh89tzAEV2be7d5xI0vBa/VySYy3E=
 k8s.io/klog/v2 v2.0.0/go.mod h1:PBfzABfn139FHAV07az/IF9Wp1bkk3vpT2XSJ76fSDE=
 k8s.io/klog/v2 v2.2.0/go.mod h1:Od+F08eJP+W3HUb4pSrPpgp9DGU4GzlpG/TmITuYh/Y=
 k8s.io/klog/v2 v2.9.0 h1:D7HV+n1V57XeZ0m6tdRkfknthUaM06VFbWldOFh8kzM=

--- a/staging/src/k8s.io/kube-aggregator/go.sum
+++ b/staging/src/k8s.io/kube-aggregator/go.sum
@@ -916,8 +916,8 @@ honnef.co/go/tools v0.0.1-2019.2.3/go.mod h1:a3bituU0lyd329TUQxRnasdCoJDkEUEAqEt
 honnef.co/go/tools v0.0.1-2020.1.3/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
 honnef.co/go/tools v0.0.1-2020.1.4/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
 k8s.io/gengo v0.0.0-20200413195148-3a45101e95ac/go.mod h1:ezvh/TsK7cY6rbqRK0oQQ8IAqLxYwwyPxAX1Pzy0ii0=
-k8s.io/gengo v0.0.0-20201214224949-b6c5ce23f027 h1:Uusb3oh8XcdzDF/ndlI4ToKTYVlkCSJP39SRY2mfRAw=
-k8s.io/gengo v0.0.0-20201214224949-b6c5ce23f027/go.mod h1:FiNAH4ZV3gBg2Kwh89tzAEV2be7d5xI0vBa/VySYy3E=
+k8s.io/gengo v0.0.0-20210813121822-485abfe95c7c h1:GohjlNKauSai7gN4wsJkeZ3WAJx4Sh+oT/b5IYn5suA=
+k8s.io/gengo v0.0.0-20210813121822-485abfe95c7c/go.mod h1:FiNAH4ZV3gBg2Kwh89tzAEV2be7d5xI0vBa/VySYy3E=
 k8s.io/klog/v2 v2.0.0/go.mod h1:PBfzABfn139FHAV07az/IF9Wp1bkk3vpT2XSJ76fSDE=
 k8s.io/klog/v2 v2.2.0/go.mod h1:Od+F08eJP+W3HUb4pSrPpgp9DGU4GzlpG/TmITuYh/Y=
 k8s.io/klog/v2 v2.9.0 h1:D7HV+n1V57XeZ0m6tdRkfknthUaM06VFbWldOFh8kzM=

--- a/staging/src/k8s.io/kubectl/go.sum
+++ b/staging/src/k8s.io/kubectl/go.sum
@@ -874,7 +874,7 @@ honnef.co/go/tools v0.0.1-2019.2.3/go.mod h1:a3bituU0lyd329TUQxRnasdCoJDkEUEAqEt
 honnef.co/go/tools v0.0.1-2020.1.3/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
 honnef.co/go/tools v0.0.1-2020.1.4/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
 k8s.io/gengo v0.0.0-20200413195148-3a45101e95ac/go.mod h1:ezvh/TsK7cY6rbqRK0oQQ8IAqLxYwwyPxAX1Pzy0ii0=
-k8s.io/gengo v0.0.0-20201214224949-b6c5ce23f027/go.mod h1:FiNAH4ZV3gBg2Kwh89tzAEV2be7d5xI0vBa/VySYy3E=
+k8s.io/gengo v0.0.0-20210813121822-485abfe95c7c/go.mod h1:FiNAH4ZV3gBg2Kwh89tzAEV2be7d5xI0vBa/VySYy3E=
 k8s.io/klog/v2 v2.0.0/go.mod h1:PBfzABfn139FHAV07az/IF9Wp1bkk3vpT2XSJ76fSDE=
 k8s.io/klog/v2 v2.2.0/go.mod h1:Od+F08eJP+W3HUb4pSrPpgp9DGU4GzlpG/TmITuYh/Y=
 k8s.io/klog/v2 v2.9.0 h1:D7HV+n1V57XeZ0m6tdRkfknthUaM06VFbWldOFh8kzM=

--- a/staging/src/k8s.io/metrics/go.sum
+++ b/staging/src/k8s.io/metrics/go.sum
@@ -606,8 +606,8 @@ honnef.co/go/tools v0.0.1-2019.2.3/go.mod h1:a3bituU0lyd329TUQxRnasdCoJDkEUEAqEt
 honnef.co/go/tools v0.0.1-2020.1.3/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
 honnef.co/go/tools v0.0.1-2020.1.4/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
 k8s.io/gengo v0.0.0-20200413195148-3a45101e95ac/go.mod h1:ezvh/TsK7cY6rbqRK0oQQ8IAqLxYwwyPxAX1Pzy0ii0=
-k8s.io/gengo v0.0.0-20201214224949-b6c5ce23f027 h1:Uusb3oh8XcdzDF/ndlI4ToKTYVlkCSJP39SRY2mfRAw=
-k8s.io/gengo v0.0.0-20201214224949-b6c5ce23f027/go.mod h1:FiNAH4ZV3gBg2Kwh89tzAEV2be7d5xI0vBa/VySYy3E=
+k8s.io/gengo v0.0.0-20210813121822-485abfe95c7c h1:GohjlNKauSai7gN4wsJkeZ3WAJx4Sh+oT/b5IYn5suA=
+k8s.io/gengo v0.0.0-20210813121822-485abfe95c7c/go.mod h1:FiNAH4ZV3gBg2Kwh89tzAEV2be7d5xI0vBa/VySYy3E=
 k8s.io/klog/v2 v2.0.0/go.mod h1:PBfzABfn139FHAV07az/IF9Wp1bkk3vpT2XSJ76fSDE=
 k8s.io/klog/v2 v2.2.0/go.mod h1:Od+F08eJP+W3HUb4pSrPpgp9DGU4GzlpG/TmITuYh/Y=
 k8s.io/klog/v2 v2.9.0 h1:D7HV+n1V57XeZ0m6tdRkfknthUaM06VFbWldOFh8kzM=

--- a/staging/src/k8s.io/sample-apiserver/go.sum
+++ b/staging/src/k8s.io/sample-apiserver/go.sum
@@ -913,8 +913,8 @@ honnef.co/go/tools v0.0.1-2019.2.3/go.mod h1:a3bituU0lyd329TUQxRnasdCoJDkEUEAqEt
 honnef.co/go/tools v0.0.1-2020.1.3/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
 honnef.co/go/tools v0.0.1-2020.1.4/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
 k8s.io/gengo v0.0.0-20200413195148-3a45101e95ac/go.mod h1:ezvh/TsK7cY6rbqRK0oQQ8IAqLxYwwyPxAX1Pzy0ii0=
-k8s.io/gengo v0.0.0-20201214224949-b6c5ce23f027 h1:Uusb3oh8XcdzDF/ndlI4ToKTYVlkCSJP39SRY2mfRAw=
-k8s.io/gengo v0.0.0-20201214224949-b6c5ce23f027/go.mod h1:FiNAH4ZV3gBg2Kwh89tzAEV2be7d5xI0vBa/VySYy3E=
+k8s.io/gengo v0.0.0-20210813121822-485abfe95c7c h1:GohjlNKauSai7gN4wsJkeZ3WAJx4Sh+oT/b5IYn5suA=
+k8s.io/gengo v0.0.0-20210813121822-485abfe95c7c/go.mod h1:FiNAH4ZV3gBg2Kwh89tzAEV2be7d5xI0vBa/VySYy3E=
 k8s.io/klog/v2 v2.0.0/go.mod h1:PBfzABfn139FHAV07az/IF9Wp1bkk3vpT2XSJ76fSDE=
 k8s.io/klog/v2 v2.2.0/go.mod h1:Od+F08eJP+W3HUb4pSrPpgp9DGU4GzlpG/TmITuYh/Y=
 k8s.io/klog/v2 v2.9.0 h1:D7HV+n1V57XeZ0m6tdRkfknthUaM06VFbWldOFh8kzM=

--- a/staging/src/k8s.io/sample-controller/go.sum
+++ b/staging/src/k8s.io/sample-controller/go.sum
@@ -609,8 +609,8 @@ honnef.co/go/tools v0.0.1-2019.2.3/go.mod h1:a3bituU0lyd329TUQxRnasdCoJDkEUEAqEt
 honnef.co/go/tools v0.0.1-2020.1.3/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
 honnef.co/go/tools v0.0.1-2020.1.4/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
 k8s.io/gengo v0.0.0-20200413195148-3a45101e95ac/go.mod h1:ezvh/TsK7cY6rbqRK0oQQ8IAqLxYwwyPxAX1Pzy0ii0=
-k8s.io/gengo v0.0.0-20201214224949-b6c5ce23f027 h1:Uusb3oh8XcdzDF/ndlI4ToKTYVlkCSJP39SRY2mfRAw=
-k8s.io/gengo v0.0.0-20201214224949-b6c5ce23f027/go.mod h1:FiNAH4ZV3gBg2Kwh89tzAEV2be7d5xI0vBa/VySYy3E=
+k8s.io/gengo v0.0.0-20210813121822-485abfe95c7c h1:GohjlNKauSai7gN4wsJkeZ3WAJx4Sh+oT/b5IYn5suA=
+k8s.io/gengo v0.0.0-20210813121822-485abfe95c7c/go.mod h1:FiNAH4ZV3gBg2Kwh89tzAEV2be7d5xI0vBa/VySYy3E=
 k8s.io/klog/v2 v2.0.0/go.mod h1:PBfzABfn139FHAV07az/IF9Wp1bkk3vpT2XSJ76fSDE=
 k8s.io/klog/v2 v2.2.0/go.mod h1:Od+F08eJP+W3HUb4pSrPpgp9DGU4GzlpG/TmITuYh/Y=
 k8s.io/klog/v2 v2.9.0 h1:D7HV+n1V57XeZ0m6tdRkfknthUaM06VFbWldOFh8kzM=

--- a/vendor/k8s.io/gengo/examples/deepcopy-gen/generators/deepcopy.go
+++ b/vendor/k8s.io/gengo/examples/deepcopy-gen/generators/deepcopy.go
@@ -864,6 +864,8 @@ func (g *genDeepCopy) doStruct(t *types.Type, sw *generator.SnippetWriter) {
 			sw.Do("in, out := &in.$.name$, &out.$.name$\n", args)
 			g.generateFor(ft, sw)
 			sw.Do("}\n", nil)
+		case uft.Kind == types.Array:
+			sw.Do("out.$.name$ = in.$.name$\n", args)
 		case uft.Kind == types.Struct:
 			if ft.IsAssignable() {
 				sw.Do("out.$.name$ = in.$.name$\n", args)

--- a/vendor/k8s.io/gengo/examples/defaulter-gen/generators/defaulter.go
+++ b/vendor/k8s.io/gengo/examples/defaulter-gen/generators/defaulter.go
@@ -318,9 +318,18 @@ func Packages(context *generator.Context, arguments *args.GeneratorArgs) generat
 		}
 		if len(inputTags) == 1 {
 			var err error
-			typesPkg, err = context.AddDirectory(filepath.Join(pkg.Path, inputTags[0]))
+
+			inputPath := inputTags[0]
+			if strings.HasPrefix(inputPath, "./") || strings.HasPrefix(inputPath, "../") {
+				// this is a relative dir, which will not work under gomodules.
+				// join with the local package path, but warn
+				klog.Warningf("relative path %s=%s will not work under gomodule mode; use full package path (as used by 'import') instead", inputTagName, inputPath)
+				inputPath = filepath.Join(pkg.Path, inputTags[0])
+			}
+
+			typesPkg, err = context.AddDirectory(inputPath)
 			if err != nil {
-				klog.Fatalf("cannot import package %s", inputTags[0])
+				klog.Fatalf("cannot import package %s", inputPath)
 			}
 			// update context.Order to the latest context.Universe
 			orderer := namer.Orderer{Namer: namer.NewPublicNamer(1)}

--- a/vendor/k8s.io/gengo/namer/namer.go
+++ b/vendor/k8s.io/gengo/namer/namer.go
@@ -17,7 +17,9 @@ limitations under the License.
 package namer
 
 import (
+	"fmt"
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	"k8s.io/gengo/types"
@@ -246,6 +248,12 @@ func (ns *NameStrategy) Name(t *types.Type) string {
 			"Slice",
 			ns.removePrefixAndSuffix(ns.Name(t.Elem)),
 		}, ns.Suffix)
+	case types.Array:
+		name = ns.Join(ns.Prefix, []string{
+			"Array",
+			ns.removePrefixAndSuffix(fmt.Sprintf("%d", t.Len)),
+			ns.removePrefixAndSuffix(ns.Name(t.Elem)),
+		}, ns.Suffix)
 	case types.Pointer:
 		name = ns.Join(ns.Prefix, []string{
 			"Pointer",
@@ -340,6 +348,9 @@ func (r *rawNamer) Name(t *types.Type) string {
 		name = "map[" + r.Name(t.Key) + "]" + r.Name(t.Elem)
 	case types.Slice:
 		name = "[]" + r.Name(t.Elem)
+	case types.Array:
+		l := strconv.Itoa(int(t.Len))
+		name = "[" + l + "]" + r.Name(t.Elem)
 	case types.Pointer:
 		name = "*" + r.Name(t.Elem)
 	case types.Struct:

--- a/vendor/k8s.io/gengo/parser/parse.go
+++ b/vendor/k8s.io/gengo/parser/parse.go
@@ -723,8 +723,7 @@ func (b *Builder) walkType(u types.Universe, useName *types.Name, in tc.Type) *t
 		}
 		out.Kind = types.Array
 		out.Elem = b.walkType(u, nil, t.Elem())
-		// TODO: need to store array length, otherwise raw type name
-		// cannot be properly written.
+		out.Len = in.(*tc.Array).Len()
 		return out
 	case *tc.Chan:
 		out := u.Type(name)

--- a/vendor/k8s.io/gengo/types/types.go
+++ b/vendor/k8s.io/gengo/types/types.go
@@ -83,11 +83,13 @@ const (
 	// Interface is any type that could have differing types at run time.
 	Interface Kind = "Interface"
 
+	// Array is just like slice, but has a fixed length.
+	Array Kind = "Array"
+
 	// The remaining types are included for completeness, but are not well
 	// supported.
-	Array Kind = "Array" // Array is just like slice, but has a fixed length.
-	Chan  Kind = "Chan"
-	Func  Kind = "Func"
+	Chan Kind = "Chan"
+	Func Kind = "Func"
 
 	// DeclarationOf is different from other Kinds; it indicates that instead of
 	// representing an actual Type, the type is a declaration of an instance of
@@ -350,7 +352,9 @@ type Type struct {
 
 	// TODO: Add:
 	// * channel direction
-	// * array length
+
+	// If Kind == Array
+	Len int64
 }
 
 // String returns the name of the type.

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1984,7 +1984,7 @@ k8s.io/cri-api/pkg/apis/testing
 ## explicit
 k8s.io/csi-translation-lib
 k8s.io/csi-translation-lib/plugins
-# k8s.io/gengo v0.0.0-20201214224949-b6c5ce23f027 => k8s.io/gengo v0.0.0-20201214224949-b6c5ce23f027
+# k8s.io/gengo v0.0.0-20210813121822-485abfe95c7c => k8s.io/gengo v0.0.0-20210813121822-485abfe95c7c
 ## explicit
 k8s.io/gengo/args
 k8s.io/gengo/examples/deepcopy-gen/generators
@@ -2738,7 +2738,7 @@ sigs.k8s.io/yaml
 # k8s.io/controller-manager => ./staging/src/k8s.io/controller-manager
 # k8s.io/cri-api => ./staging/src/k8s.io/cri-api
 # k8s.io/csi-translation-lib => ./staging/src/k8s.io/csi-translation-lib
-# k8s.io/gengo => k8s.io/gengo v0.0.0-20201214224949-b6c5ce23f027
+# k8s.io/gengo => k8s.io/gengo v0.0.0-20210813121822-485abfe95c7c
 # k8s.io/klog/v2 => k8s.io/klog/v2 v2.9.0
 # k8s.io/kube-aggregator => ./staging/src/k8s.io/kube-aggregator
 # k8s.io/kube-controller-manager => ./staging/src/k8s.io/kube-controller-manager


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Part of work to make code generators work in module mode. Hoisted out of https://github.com/kubernetes/kubernetes/pull/99226

Defaulters were the only generator we had that was using relative paths across vendor boundaries. Switched to use package import paths instead which can be resolved in gopath or module mode.

#### Which issue(s) this PR fixes:
xref https://github.com/kubernetes/kubernetes/issues/82531

```release-note
NONE
```

/cc @sttts
/sig api-machinery