### PR TITLE
kubeadm: further improve the dynamic version population

### DIFF
--- a/cmd/kubeadm/app/constants/constants_test.go
+++ b/cmd/kubeadm/app/constants/constants_test.go
@@ -241,22 +241,15 @@ func TestGetKubernetesServiceCIDR(t *testing.T) {
 
 func TestGetSkewedKubernetesVersionImpl(t *testing.T) {
 	tests := []struct {
-		name                string
-		versionInfo         *apimachineryversion.Info
-		n                   int
-		isRunningInTestFunc func() bool
-		expectedResult      *version.Version
+		name           string
+		versionInfo    *apimachineryversion.Info
+		n              int
+		expectedResult *version.Version
 	}{
 		{
-			name:           "invalid versionInfo; running in test",
+			name:           "invalid versionInfo; placeholder version is returned",
 			versionInfo:    &apimachineryversion.Info{},
-			expectedResult: defaultKubernetesVersionForTests,
-		},
-		{
-			name:                "invalid versionInfo; not running in test",
-			versionInfo:         &apimachineryversion.Info{},
-			isRunningInTestFunc: func() bool { return false },
-			expectedResult:      nil,
+			expectedResult: defaultKubernetesPlaceholderVersion,
 		},
 		{
 			name:           "valid skew of -1",
@@ -280,16 +273,7 @@ func TestGetSkewedKubernetesVersionImpl(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			if tc.isRunningInTestFunc == nil {
-				tc.isRunningInTestFunc = func() bool { return true }
-			}
-			result := getSkewedKubernetesVersionImpl(tc.versionInfo, tc.n, tc.isRunningInTestFunc)
-			if (tc.expectedResult == nil) != (result == nil) {
-				t.Errorf("expected result: %v, got: %v", tc.expectedResult, result)
-			}
-			if result == nil {
-				return
-			}
+			result := getSkewedKubernetesVersionImpl(tc.versionInfo, tc.n)
 			if cmp, _ := result.Compare(tc.expectedResult.String()); cmp != 0 {
 				t.Errorf("expected result: %v, got %v", tc.expectedResult, result)
 			}

--- a/cmd/kubeadm/app/phases/upgrade/compute_test.go
+++ b/cmd/kubeadm/app/phases/upgrade/compute_test.go
@@ -29,6 +29,7 @@ import (
 	apps "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/version"
 	versionutil "k8s.io/apimachinery/pkg/util/version"
 	clientsetfake "k8s.io/client-go/kubernetes/fake"
 )
@@ -97,11 +98,11 @@ func TestGetAvailableUpgrades(t *testing.T) {
 	// variables are in the form v{MAJOR}{MINOR}{PATCH}, where MINOR is a variable so test are automatically uptodate to the latest MinimumControlPlaneVersion/
 
 	// v1.X series, e.g. v1.14
-	v1X0 := constants.MinimumControlPlaneVersion.WithMinor(constants.MinimumControlPlaneVersion.Minor() - 1)
+	v1X0 := version.MustParseSemantic("v1.14.0")
 	v1X5 := v1X0.WithPatch(5)
 
 	// v1.Y series, where Y = X+1, e.g. v1.15
-	v1Y0 := constants.MinimumControlPlaneVersion
+	v1Y0 := version.MustParseSemantic("v1.15.0")
 	v1Y0alpha0 := v1Y0.WithPreRelease("alpha.0")
 	v1Y0alpha1 := v1Y0.WithPreRelease("alpha.1")
 	v1Y1 := v1Y0.WithPatch(1)
@@ -110,7 +111,7 @@ func TestGetAvailableUpgrades(t *testing.T) {
 	v1Y5 := v1Y0.WithPatch(5)
 
 	// v1.Z series, where Z = Y+1, e.g. v1.16
-	v1Z0 := constants.CurrentKubernetesVersion
+	v1Z0 := version.MustParseSemantic("v1.16.0")
 	v1Z0alpha1 := v1Z0.WithPreRelease("alpha.1")
 	v1Z0alpha2 := v1Z0.WithPreRelease("alpha.2")
 	v1Z0beta1 := v1Z0.WithPreRelease("beta.1")

--- a/cmd/kubeadm/app/phases/upgrade/policy_test.go
+++ b/cmd/kubeadm/app/phases/upgrade/policy_test.go
@@ -19,12 +19,13 @@ package upgrade
 import (
 	"testing"
 
-	"k8s.io/kubernetes/cmd/kubeadm/app/constants"
-
 	"k8s.io/apimachinery/pkg/util/version"
 )
 
 func TestEnforceVersionPolicies(t *testing.T) {
+	minimumKubeletVersion := version.MustParseSemantic("v1.3.0")
+	minimumControlPlaneVersion := version.MustParseSemantic("v1.3.0")
+	currentKubernetesVersion := version.MustParseSemantic("v1.4.0")
 	tests := []struct {
 		name                        string
 		vg                          *fakeVersionGetter
@@ -36,38 +37,38 @@ func TestEnforceVersionPolicies(t *testing.T) {
 		{
 			name: "minor upgrade",
 			vg: &fakeVersionGetter{
-				clusterVersion: constants.MinimumControlPlaneVersion.WithPatch(3).String(),
-				kubeletVersion: constants.MinimumControlPlaneVersion.WithPatch(3).String(),
-				kubeadmVersion: constants.MinimumControlPlaneVersion.WithPatch(5).String(),
+				clusterVersion: minimumControlPlaneVersion.WithPatch(3).String(),
+				kubeletVersion: minimumControlPlaneVersion.WithPatch(3).String(),
+				kubeadmVersion: minimumControlPlaneVersion.WithPatch(5).String(),
 			},
-			newK8sVersion: constants.MinimumControlPlaneVersion.WithPatch(5).String(),
+			newK8sVersion: minimumControlPlaneVersion.WithPatch(5).String(),
 		},
 		{
 			name: "major upgrade",
 			vg: &fakeVersionGetter{
-				clusterVersion: constants.MinimumControlPlaneVersion.WithPatch(3).String(),
-				kubeletVersion: constants.MinimumControlPlaneVersion.WithPatch(2).String(),
-				kubeadmVersion: constants.CurrentKubernetesVersion.WithPatch(1).String(),
+				clusterVersion: minimumControlPlaneVersion.WithPatch(3).String(),
+				kubeletVersion: minimumControlPlaneVersion.WithPatch(2).String(),
+				kubeadmVersion: currentKubernetesVersion.WithPatch(1).String(),
 			},
-			newK8sVersion: constants.CurrentKubernetesVersion.String(),
+			newK8sVersion: currentKubernetesVersion.String(),
 		},
 		{
 			name: "downgrade",
 			vg: &fakeVersionGetter{
-				clusterVersion: constants.MinimumControlPlaneVersion.WithPatch(3).String(),
-				kubeletVersion: constants.MinimumKubeletVersion.String(),
-				kubeadmVersion: constants.MinimumControlPlaneVersion.WithPatch(3).String(),
+				clusterVersion: minimumControlPlaneVersion.WithPatch(3).String(),
+				kubeletVersion: minimumKubeletVersion.String(),
+				kubeadmVersion: minimumControlPlaneVersion.WithPatch(3).String(),
 			},
-			newK8sVersion: constants.MinimumControlPlaneVersion.WithPatch(2).String(),
+			newK8sVersion: minimumControlPlaneVersion.WithPatch(2).String(),
 		},
 		{
 			name: "same version upgrade",
 			vg: &fakeVersionGetter{
-				clusterVersion: constants.MinimumControlPlaneVersion.WithPatch(3).String(),
-				kubeletVersion: constants.MinimumKubeletVersion.WithPatch(3).String(),
-				kubeadmVersion: constants.MinimumControlPlaneVersion.WithPatch(3).String(),
+				clusterVersion: minimumControlPlaneVersion.WithPatch(3).String(),
+				kubeletVersion: minimumKubeletVersion.WithPatch(3).String(),
+				kubeadmVersion: minimumControlPlaneVersion.WithPatch(3).String(),
 			},
-			newK8sVersion: constants.MinimumControlPlaneVersion.WithPatch(3).String(),
+			newK8sVersion: minimumControlPlaneVersion.WithPatch(3).String(),
 		},
 		{
 			name: "new version must be higher than v1.12.0",
@@ -94,31 +95,31 @@ func TestEnforceVersionPolicies(t *testing.T) {
 		{
 			name: "downgrading two minor versions in one go is not supported",
 			vg: &fakeVersionGetter{
-				clusterVersion: constants.CurrentKubernetesVersion.WithMinor(constants.CurrentKubernetesVersion.Minor() + 2).String(),
-				kubeletVersion: constants.CurrentKubernetesVersion.WithMinor(constants.CurrentKubernetesVersion.Minor() + 2).String(),
-				kubeadmVersion: constants.CurrentKubernetesVersion.String(),
+				clusterVersion: currentKubernetesVersion.WithMinor(currentKubernetesVersion.Minor() + 2).String(),
+				kubeletVersion: currentKubernetesVersion.WithMinor(currentKubernetesVersion.Minor() + 2).String(),
+				kubeadmVersion: currentKubernetesVersion.String(),
 			},
-			newK8sVersion:         constants.CurrentKubernetesVersion.String(),
+			newK8sVersion:         currentKubernetesVersion.String(),
 			expectedMandatoryErrs: 1, // can't downgrade two minor versions
 		},
 		{
 			name: "kubeadm version must be higher than the new kube version. However, patch version skews may be forced",
 			vg: &fakeVersionGetter{
-				clusterVersion: constants.MinimumControlPlaneVersion.WithPatch(3).String(),
-				kubeletVersion: constants.MinimumKubeletVersion.WithPatch(3).String(),
-				kubeadmVersion: constants.MinimumControlPlaneVersion.WithPatch(3).String(),
+				clusterVersion: minimumControlPlaneVersion.WithPatch(3).String(),
+				kubeletVersion: minimumKubeletVersion.WithPatch(3).String(),
+				kubeadmVersion: minimumControlPlaneVersion.WithPatch(3).String(),
 			},
-			newK8sVersion:         constants.MinimumControlPlaneVersion.WithPatch(5).String(),
+			newK8sVersion:         minimumControlPlaneVersion.WithPatch(5).String(),
 			expectedSkippableErrs: 1,
 		},
 		{
 			name: "kubeadm version must be higher than the new kube version. Trying to upgrade k8s to a higher minor version than kubeadm itself should never be supported",
 			vg: &fakeVersionGetter{
-				clusterVersion: constants.MinimumControlPlaneVersion.WithPatch(3).String(),
-				kubeletVersion: constants.MinimumKubeletVersion.WithPatch(3).String(),
-				kubeadmVersion: constants.MinimumControlPlaneVersion.WithPatch(3).String(),
+				clusterVersion: minimumControlPlaneVersion.WithPatch(3).String(),
+				kubeletVersion: minimumKubeletVersion.WithPatch(3).String(),
+				kubeadmVersion: minimumControlPlaneVersion.WithPatch(3).String(),
 			},
-			newK8sVersion:         constants.CurrentKubernetesVersion.String(),
+			newK8sVersion:         currentKubernetesVersion.String(),
 			expectedMandatoryErrs: 1,
 		},
 		{
@@ -134,72 +135,72 @@ func TestEnforceVersionPolicies(t *testing.T) {
 		{
 			name: "experimental upgrades supported if the flag is set",
 			vg: &fakeVersionGetter{
-				clusterVersion: constants.MinimumControlPlaneVersion.WithPatch(3).String(),
-				kubeletVersion: constants.MinimumKubeletVersion.WithPatch(3).String(),
-				kubeadmVersion: constants.CurrentKubernetesVersion.WithPreRelease("beta.1").String(),
+				clusterVersion: minimumControlPlaneVersion.WithPatch(3).String(),
+				kubeletVersion: minimumKubeletVersion.WithPatch(3).String(),
+				kubeadmVersion: currentKubernetesVersion.WithPreRelease("beta.1").String(),
 			},
-			newK8sVersion:     constants.CurrentKubernetesVersion.WithPreRelease("beta.1").String(),
+			newK8sVersion:     currentKubernetesVersion.WithPreRelease("beta.1").String(),
 			allowExperimental: true,
 		},
 		{
 			name: "release candidate upgrades supported if the flag is set",
 			vg: &fakeVersionGetter{
-				clusterVersion: constants.MinimumControlPlaneVersion.WithPatch(3).String(),
-				kubeletVersion: constants.MinimumKubeletVersion.WithPatch(3).String(),
-				kubeadmVersion: constants.CurrentKubernetesVersion.WithPreRelease("rc.1").String(),
+				clusterVersion: minimumControlPlaneVersion.WithPatch(3).String(),
+				kubeletVersion: minimumKubeletVersion.WithPatch(3).String(),
+				kubeadmVersion: currentKubernetesVersion.WithPreRelease("rc.1").String(),
 			},
-			newK8sVersion: constants.CurrentKubernetesVersion.WithPreRelease("rc.1").String(),
+			newK8sVersion: currentKubernetesVersion.WithPreRelease("rc.1").String(),
 			allowRCs:      true,
 		},
 		{
 			name: "release candidate upgrades supported if the flag is set",
 			vg: &fakeVersionGetter{
-				clusterVersion: constants.MinimumControlPlaneVersion.WithPatch(3).String(),
-				kubeletVersion: constants.MinimumKubeletVersion.WithPatch(3).String(),
-				kubeadmVersion: constants.CurrentKubernetesVersion.WithPreRelease("rc.1").String(),
+				clusterVersion: minimumControlPlaneVersion.WithPatch(3).String(),
+				kubeletVersion: minimumKubeletVersion.WithPatch(3).String(),
+				kubeadmVersion: currentKubernetesVersion.WithPreRelease("rc.1").String(),
 			},
-			newK8sVersion:     constants.CurrentKubernetesVersion.WithPreRelease("rc.1").String(),
+			newK8sVersion:     currentKubernetesVersion.WithPreRelease("rc.1").String(),
 			allowExperimental: true,
 		},
 		{
 			name: "the user should not be able to upgrade to an experimental version if they haven't opted into that",
 			vg: &fakeVersionGetter{
-				clusterVersion: constants.MinimumControlPlaneVersion.WithPatch(3).String(),
-				kubeletVersion: constants.MinimumKubeletVersion.WithPatch(3).String(),
-				kubeadmVersion: constants.CurrentKubernetesVersion.WithPreRelease("beta.1").String(),
+				clusterVersion: minimumControlPlaneVersion.WithPatch(3).String(),
+				kubeletVersion: minimumKubeletVersion.WithPatch(3).String(),
+				kubeadmVersion: currentKubernetesVersion.WithPreRelease("beta.1").String(),
 			},
-			newK8sVersion:         constants.CurrentKubernetesVersion.WithPreRelease("beta.1").String(),
+			newK8sVersion:         currentKubernetesVersion.WithPreRelease("beta.1").String(),
 			allowRCs:              true,
 			expectedSkippableErrs: 1,
 		},
 		{
 			name: "the user should not be able to upgrade to an release candidate version if they haven't opted into that",
 			vg: &fakeVersionGetter{
-				clusterVersion: constants.MinimumControlPlaneVersion.WithPatch(3).String(),
-				kubeletVersion: constants.MinimumKubeletVersion.WithPatch(3).String(),
-				kubeadmVersion: constants.CurrentKubernetesVersion.WithPreRelease("rc.1").String(),
+				clusterVersion: minimumControlPlaneVersion.WithPatch(3).String(),
+				kubeletVersion: minimumKubeletVersion.WithPatch(3).String(),
+				kubeadmVersion: currentKubernetesVersion.WithPreRelease("rc.1").String(),
 			},
-			newK8sVersion:         constants.CurrentKubernetesVersion.WithPreRelease("rc.1").String(),
+			newK8sVersion:         currentKubernetesVersion.WithPreRelease("rc.1").String(),
 			expectedSkippableErrs: 1,
 		},
 		{
 			name: "the user can't use a newer minor version of kubeadm to upgrade an older version of kubeadm",
 			vg: &fakeVersionGetter{
-				clusterVersion: constants.MinimumControlPlaneVersion.WithPatch(3).String(),
-				kubeletVersion: constants.MinimumKubeletVersion.WithPatch(3).String(),
-				kubeadmVersion: constants.CurrentKubernetesVersion.String(),
+				clusterVersion: minimumControlPlaneVersion.WithPatch(3).String(),
+				kubeletVersion: minimumKubeletVersion.WithPatch(3).String(),
+				kubeadmVersion: currentKubernetesVersion.String(),
 			},
-			newK8sVersion:         constants.MinimumControlPlaneVersion.WithPatch(6).String(),
+			newK8sVersion:         minimumControlPlaneVersion.WithPatch(6).String(),
 			expectedSkippableErrs: 1, // can't upgrade old k8s with newer kubeadm
 		},
 		{
 			name: "build release supported at MinimumControlPlaneVersion",
 			vg: &fakeVersionGetter{
-				clusterVersion: constants.MinimumControlPlaneVersion.String(),
-				kubeletVersion: constants.MinimumControlPlaneVersion.String(),
-				kubeadmVersion: constants.MinimumControlPlaneVersion.WithBuildMetadata("build").String(),
+				clusterVersion: minimumControlPlaneVersion.String(),
+				kubeletVersion: minimumControlPlaneVersion.String(),
+				kubeadmVersion: minimumControlPlaneVersion.WithBuildMetadata("build").String(),
 			},
-			newK8sVersion: constants.MinimumControlPlaneVersion.WithBuildMetadata("build").String(),
+			newK8sVersion: minimumControlPlaneVersion.WithBuildMetadata("build").String(),
 		},
 	}
 

--- a/cmd/kubeadm/app/phases/upgrade/staticpods_test.go
+++ b/cmd/kubeadm/app/phases/upgrade/staticpods_test.go
@@ -464,7 +464,7 @@ func TestStaticPodControlPlane(t *testing.T) {
 			}
 			defer os.RemoveAll(tmpEtcdDataDir)
 
-			oldcfg, err := getConfig(constants.MinimumControlPlaneVersion.String(), tempCertsDir, tmpEtcdDataDir)
+			oldcfg, err := getConfig("v1.3.0", tempCertsDir, tmpEtcdDataDir)
 			if err != nil {
 				t.Fatalf("couldn't create config: %v", err)
 			}

--- a/cmd/kubeadm/app/preflight/checks_test.go
+++ b/cmd/kubeadm/app/preflight/checks_test.go
@@ -33,6 +33,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/version"
 	"k8s.io/utils/exec"
 	fakeexec "k8s.io/utils/exec/testing"
 
@@ -786,19 +787,22 @@ func restoreEnv(e map[string]string) {
 }
 
 func TestKubeletVersionCheck(t *testing.T) {
+	minimumKubeletVersion := version.MustParseSemantic("v1.3.0")
+	minimumControlPlaneVersion := version.MustParseSemantic("v1.3.0")
+	currentKubernetesVersion := version.MustParseSemantic("v1.4.0")
 	cases := []struct {
 		kubeletVersion string
 		k8sVersion     string
 		expectErrors   bool
 		expectWarnings bool
 	}{
-		{"v" + constants.CurrentKubernetesVersion.WithPatch(2).String(), "", false, false},                                                                     // check minimally supported version when there is no information about control plane
-		{"v1.1.0", "v1.11.8", true, false},                                                                                                                     // too old kubelet, should fail.
-		{"v" + constants.MinimumKubeletVersion.String(), constants.MinimumControlPlaneVersion.WithPatch(5).String(), false, false},                             // kubelet within same major.minor as control plane
-		{"v" + constants.MinimumKubeletVersion.WithPatch(5).String(), constants.MinimumControlPlaneVersion.WithPatch(1).String(), false, false},                // kubelet is newer, but still within same major.minor as control plane
-		{"v" + constants.MinimumKubeletVersion.String(), constants.CurrentKubernetesVersion.WithPatch(1).String(), false, false},                               // kubelet is lower than control plane, but newer than minimally supported
-		{"v" + constants.CurrentKubernetesVersion.WithPreRelease("alpha.1").String(), constants.MinimumControlPlaneVersion.WithPatch(1).String(), true, false}, // kubelet is newer (development build) than control plane, should fail.
-		{"v" + constants.CurrentKubernetesVersion.String(), constants.MinimumControlPlaneVersion.WithPatch(5).String(), true, false},                           // kubelet is newer (release) than control plane, should fail.
+		{"v" + currentKubernetesVersion.WithPatch(2).String(), "", false, false},                                                           // check minimally supported version when there is no information about control plane
+		{"v1.1.0", "v1.11.8", true, false},                                                                                                 // too old kubelet, should fail.
+		{"v" + minimumKubeletVersion.String(), minimumControlPlaneVersion.WithPatch(5).String(), false, false},                             // kubelet within same major.minor as control plane
+		{"v" + minimumKubeletVersion.WithPatch(5).String(), minimumControlPlaneVersion.WithPatch(1).String(), false, false},                // kubelet is newer, but still within same major.minor as control plane
+		{"v" + minimumKubeletVersion.String(), currentKubernetesVersion.WithPatch(1).String(), false, false},                               // kubelet is lower than control plane, but newer than minimally supported
+		{"v" + currentKubernetesVersion.WithPreRelease("alpha.1").String(), minimumControlPlaneVersion.WithPatch(1).String(), true, false}, // kubelet is newer (development build) than control plane, should fail.
+		{"v" + currentKubernetesVersion.String(), minimumControlPlaneVersion.WithPatch(5).String(), true, false},                           // kubelet is newer (release) than control plane, should fail.
 	}
 
 	for _, tc := range cases {
@@ -814,7 +818,7 @@ func TestKubeletVersionCheck(t *testing.T) {
 				},
 			}
 
-			check := KubeletVersionCheck{KubernetesVersion: tc.k8sVersion, exec: fexec}
+			check := KubeletVersionCheck{KubernetesVersion: tc.k8sVersion, exec: fexec, minKubeletVersion: minimumKubeletVersion}
 			warnings, errors := check.Check()
 
 			switch {


### PR DESCRIPTION
#### What this PR does / why we need it:

Panicing if not running in a test and if the component-base/version
variables are empty is not ideal. At some point sections
of kubeadm could be exposed as a library and if these sections
import the constants package, they would panic on the library
users unless they set the version information in component-base
with ldflags.

Instead:
- If the component-base version is empty, return a placeholder version
that should indicate to users that something is not
right (e.g. they did not use 'make'). During library usage or unit
tests these versions should not be relevant, but can also be updated on demand.
(as these are public vars).
- Update unit tests to use hardcoded versions instead of the versions
from the constants package. Using the constants package for testing
is good but during unit tests these versions are already placeholders
since unit tests do not populate the actual component-base versions
(e.g. 1.23).

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
NONE

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

will update the old PR release note to remove the note about panicing.
https://github.com/kubernetes/kubernetes/pull/104015

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
