### PR TITLE
Optimize the resource consumption of networkpolicy tests by reducing the containers created

### DIFF
--- a/test/e2e/network/netpol/network_policy.go
+++ b/test/e2e/network/netpol/network_policy.go
@@ -130,7 +130,8 @@ var _ = common.SIGDescribe("Netpol", func() {
 		ginkgo.It("should support a 'default-deny-ingress' policy [Feature:NetworkPolicy]", func() {
 			nsX, _, _, k8s := getK8sNamespaces(f)
 			protocols := []v1.Protocol{protocolTCP}
-			model = initializeResourcesByFixedNS(f, protocols)
+			ports := []int32{80}
+			model = initializeResourcesByFixedNS(f, protocols, ports)
 			policy := GenNetworkPolicyWithNameAndPodSelector("deny-ingress", metav1.LabelSelector{}, SetSpecIngressRules())
 			CreatePolicy(k8s, policy, nsX)
 
@@ -145,7 +146,8 @@ var _ = common.SIGDescribe("Netpol", func() {
 
 			nsX, _, _, k8s := getK8sNamespaces(f)
 			protocols := []v1.Protocol{protocolTCP}
-			model = initializeResourcesByFixedNS(f, protocols)
+			ports := []int32{80}
+			model = initializeResourcesByFixedNS(f, protocols, ports)
 			CreatePolicy(k8s, policy, nsX)
 
 			reachability := NewReachability(model.AllPods(), true)
@@ -167,7 +169,8 @@ var _ = common.SIGDescribe("Netpol", func() {
 
 			nsX, _, _, k8s := getK8sNamespaces(f)
 			protocols := []v1.Protocol{protocolTCP}
-			model = initializeResourcesByFixedNS(f, protocols)
+			ports := []int32{80}
+			model = initializeResourcesByFixedNS(f, protocols, ports)
 			CreatePolicy(k8s, policy, nsX)
 
 			reachability := NewReachability(model.AllPods(), true)
@@ -180,7 +183,8 @@ var _ = common.SIGDescribe("Netpol", func() {
 		ginkgo.It("should enforce policy to allow ingress traffic for a target [Feature:NetworkPolicy] ", func() {
 			nsX, _, _, k8s := getK8sNamespaces(f)
 			protocols := []v1.Protocol{protocolTCP}
-			model = initializeResourcesByFixedNS(f, protocols)
+			ports := []int32{80}
+			model = initializeResourcesByFixedNS(f, protocols, ports)
 			ginkgo.By("having a deny all ingress policy", func() {
 				// Deny all Ingress traffic policy to pods on namespace nsX
 				policy := GenNetworkPolicyWithNameAndPodSelector("deny-all", metav1.LabelSelector{}, SetSpecIngressRules())
@@ -204,7 +208,8 @@ var _ = common.SIGDescribe("Netpol", func() {
 		ginkgo.It("should enforce policy to allow ingress traffic from pods in all namespaces [Feature:NetworkPolicy]", func() {
 			nsX, _, _, k8s := getK8sNamespaces(f)
 			protocols := []v1.Protocol{protocolTCP}
-			model = initializeResourcesByFixedNS(f, protocols)
+			ports := []int32{80}
+			model = initializeResourcesByFixedNS(f, protocols, ports)
 			ingressRule := networkingv1.NetworkPolicyIngressRule{}
 			ingressRule.From = append(ingressRule.From, networkingv1.NetworkPolicyPeer{NamespaceSelector: &metav1.LabelSelector{MatchLabels: map[string]string{}}})
 			policy := GenNetworkPolicyWithNameAndPodMatchLabel("allow-from-another-ns", map[string]string{"pod": "a"}, SetSpecIngressRules(ingressRule))
@@ -217,7 +222,8 @@ var _ = common.SIGDescribe("Netpol", func() {
 		ginkgo.It("should enforce policy to allow traffic only from a different namespace, based on NamespaceSelector [Feature:NetworkPolicy]", func() {
 			nsX, nsY, nsZ, k8s := getK8sNamespaces(f)
 			protocols := []v1.Protocol{protocolTCP}
-			model = initializeResourcesByFixedNS(f, protocols)
+			ports := []int32{80}
+			model = initializeResourcesByFixedNS(f, protocols, ports)
 			ingressRule := networkingv1.NetworkPolicyIngressRule{}
 			ingressRule.From = append(ingressRule.From, networkingv1.NetworkPolicyPeer{NamespaceSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"ns": nsY}}})
 			policy := GenNetworkPolicyWithNameAndPodMatchLabel("allow-client-a-via-ns-selector", map[string]string{"pod": "a"}, SetSpecIngressRules(ingressRule))
@@ -245,7 +251,8 @@ var _ = common.SIGDescribe("Netpol", func() {
 
 			nsX, _, _, k8s := getK8sNamespaces(f)
 			protocols := []v1.Protocol{protocolTCP}
-			model = initializeResourcesByFixedNS(f, protocols)
+			ports := []int32{80}
+			model = initializeResourcesByFixedNS(f, protocols, ports)
 			CreatePolicy(k8s, policy, nsX)
 
 			reachability := NewReachability(model.AllPods(), true)
@@ -258,7 +265,8 @@ var _ = common.SIGDescribe("Netpol", func() {
 		ginkgo.It("should enforce policy based on NamespaceSelector with MatchExpressions[Feature:NetworkPolicy]", func() {
 			nsX, nsY, nsZ, k8s := getK8sNamespaces(f)
 			protocols := []v1.Protocol{protocolTCP}
-			model = initializeResourcesByFixedNS(f, protocols)
+			ports := []int32{80}
+			model = initializeResourcesByFixedNS(f, protocols, ports)
 			allowedNamespaces := &metav1.LabelSelector{
 				MatchExpressions: []metav1.LabelSelectorRequirement{{
 					Key:      "ns",
@@ -282,7 +290,8 @@ var _ = common.SIGDescribe("Netpol", func() {
 		ginkgo.It("should enforce policy based on PodSelector or NamespaceSelector [Feature:NetworkPolicy]", func() {
 			nsX, _, _, k8s := getK8sNamespaces(f)
 			protocols := []v1.Protocol{protocolTCP}
-			model = initializeResourcesByFixedNS(f, protocols)
+			ports := []int32{80}
+			model = initializeResourcesByFixedNS(f, protocols, ports)
 			allowedNamespaces := &metav1.LabelSelector{
 				MatchExpressions: []metav1.LabelSelectorRequirement{{
 					Key:      "ns",
@@ -310,7 +319,8 @@ var _ = common.SIGDescribe("Netpol", func() {
 		ginkgo.It("should enforce policy based on PodSelector and NamespaceSelector [Feature:NetworkPolicy]", func() {
 			nsX, nsY, nsZ, k8s := getK8sNamespaces(f)
 			protocols := []v1.Protocol{protocolTCP}
-			model = initializeResourcesByFixedNS(f, protocols)
+			ports := []int32{80}
+			model = initializeResourcesByFixedNS(f, protocols, ports)
 			allowedNamespaces := &metav1.LabelSelector{
 				MatchExpressions: []metav1.LabelSelectorRequirement{{
 					Key:      "ns",
@@ -339,7 +349,8 @@ var _ = common.SIGDescribe("Netpol", func() {
 		ginkgo.It("should enforce policy based on Multiple PodSelectors and NamespaceSelectors [Feature:NetworkPolicy]", func() {
 			nsX, nsY, nsZ, k8s := getK8sNamespaces(f)
 			protocols := []v1.Protocol{protocolTCP}
-			model = initializeResourcesByFixedNS(f, protocols)
+			ports := []int32{80}
+			model = initializeResourcesByFixedNS(f, protocols, ports)
 			allowedNamespaces := &metav1.LabelSelector{
 				MatchExpressions: []metav1.LabelSelectorRequirement{{
 					Key:      "ns",
@@ -371,7 +382,8 @@ var _ = common.SIGDescribe("Netpol", func() {
 		ginkgo.It("should enforce policy based on any PodSelectors [Feature:NetworkPolicy]", func() {
 			nsX, _, _, k8s := getK8sNamespaces(f)
 			protocols := []v1.Protocol{protocolTCP}
-			model = initializeResourcesByFixedNS(f, protocols)
+			ports := []int32{80}
+			model = initializeResourcesByFixedNS(f, protocols, ports)
 			ingressRule := networkingv1.NetworkPolicyIngressRule{}
 			for _, label := range []map[string]string{{"pod": "b"}, {"pod": "c"}} {
 				ingressRule.From = append(ingressRule.From, networkingv1.NetworkPolicyPeer{PodSelector: &metav1.LabelSelector{MatchLabels: label}})
@@ -392,7 +404,8 @@ var _ = common.SIGDescribe("Netpol", func() {
 		ginkgo.It("should enforce policy to allow traffic only from a pod in a different namespace based on PodSelector and NamespaceSelector [Feature:NetworkPolicy]", func() {
 			nsX, nsY, _, k8s := getK8sNamespaces(f)
 			protocols := []v1.Protocol{protocolTCP}
-			model = initializeResourcesByFixedNS(f, protocols)
+			ports := []int32{80}
+			model = initializeResourcesByFixedNS(f, protocols, ports)
 			allowedNamespaces := &metav1.LabelSelector{
 				MatchLabels: map[string]string{
 					"ns": nsY,
@@ -419,7 +432,8 @@ var _ = common.SIGDescribe("Netpol", func() {
 			ginkgo.By("Creating a network allowPort81Policy which only allows allow listed namespaces (y) to connect on exactly one port (81)")
 			nsX, nsY, nsZ, k8s := getK8sNamespaces(f)
 			protocols := []v1.Protocol{protocolTCP}
-			model = initializeResourcesByFixedNS(f, protocols)
+			ports := []int32{81}
+			model = initializeResourcesByFixedNS(f, protocols, ports)
 			allowedLabels := &metav1.LabelSelector{
 				MatchLabels: map[string]string{
 					"ns": nsY,
@@ -443,7 +457,8 @@ var _ = common.SIGDescribe("Netpol", func() {
 			ginkgo.By("Creating a network allowPort81Policy which only allows allow listed namespaces (y) to connect on exactly one port (81)")
 			nsX, nsY, nsZ, k8s := getK8sNamespaces(f)
 			protocols := []v1.Protocol{protocolTCP}
-			model = initializeResourcesByFixedNS(f, protocols)
+			ports := []int32{80, 81}
+			model = initializeResourcesByFixedNS(f, protocols, ports)
 			allowedLabels := &metav1.LabelSelector{
 				MatchLabels: map[string]string{
 					"ns": nsY,
@@ -485,7 +500,8 @@ var _ = common.SIGDescribe("Netpol", func() {
 			policy := GenNetworkPolicyWithNameAndPodMatchLabel("allow-all", map[string]string{}, SetSpecIngressRules(networkingv1.NetworkPolicyIngressRule{}))
 			nsX, _, _, k8s := getK8sNamespaces(f)
 			protocols := []v1.Protocol{protocolTCP}
-			model = initializeResourcesByFixedNS(f, protocols)
+			ports := []int32{80, 81}
+			model = initializeResourcesByFixedNS(f, protocols, ports)
 			CreatePolicy(k8s, policy, nsX)
 
 			ginkgo.By("Testing pods can connect to both ports when an 'allow-all' policy is present.")
@@ -500,7 +516,8 @@ var _ = common.SIGDescribe("Netpol", func() {
 			policy := GenNetworkPolicyWithNameAndPodMatchLabel("allow-all", map[string]string{}, SetSpecIngressRules(IngressRules))
 			nsX, _, _, k8s := getK8sNamespaces(f)
 			protocols := []v1.Protocol{protocolTCP}
-			model = initializeResourcesByFixedNS(f, protocols)
+			ports := []int32{80, 81}
+			model = initializeResourcesByFixedNS(f, protocols, ports)
 			CreatePolicy(k8s, policy, nsX)
 
 			ginkgo.By("Blocking all ports other then 81 in the entire namespace")
@@ -517,7 +534,8 @@ var _ = common.SIGDescribe("Netpol", func() {
 		ginkgo.It("should allow ingress access from namespace on one named port [Feature:NetworkPolicy]", func() {
 			nsX, nsY, nsZ, k8s := getK8sNamespaces(f)
 			protocols := []v1.Protocol{protocolTCP}
-			model = initializeResourcesByFixedNS(f, protocols)
+			ports := []int32{80, 81}
+			model = initializeResourcesByFixedNS(f, protocols, ports)
 			allowedLabels := &metav1.LabelSelector{
 				MatchLabels: map[string]string{
 					"ns": nsY,
@@ -551,7 +569,8 @@ var _ = common.SIGDescribe("Netpol", func() {
 
 			nsX, _, _, k8s := getK8sNamespaces(f)
 			protocols := []v1.Protocol{protocolTCP}
-			model = initializeResourcesByFixedNS(f, protocols)
+			ports := []int32{80, 81}
+			model = initializeResourcesByFixedNS(f, protocols, ports)
 			CreatePolicy(k8s, policy, nsX)
 
 			reachabilityPort80 := NewReachability(model.AllPods(), true)
@@ -569,7 +588,8 @@ var _ = common.SIGDescribe("Netpol", func() {
 			policy := GenNetworkPolicyWithNameAndPodMatchLabel("allow-all-mutate-to-deny-all", map[string]string{}, SetSpecIngressRules(networkingv1.NetworkPolicyIngressRule{}))
 			nsX, _, _, k8s := getK8sNamespaces(f)
 			protocols := []v1.Protocol{protocolTCP}
-			model = initializeResourcesByFixedNS(f, protocols)
+			ports := []int32{81}
+			model = initializeResourcesByFixedNS(f, protocols, ports)
 			CreatePolicy(k8s, policy, nsX)
 
 			reachability := NewReachability(model.AllPods(), true)
@@ -587,7 +607,8 @@ var _ = common.SIGDescribe("Netpol", func() {
 		ginkgo.It("should allow ingress access from updated namespace [Feature:NetworkPolicy]", func() {
 			nsX, nsY, _, k8s := getK8sNamespaces(f)
 			protocols := []v1.Protocol{protocolTCP}
-			model = initializeResourcesByFixedNS(f, protocols)
+			ports := []int32{80}
+			model = initializeResourcesByFixedNS(f, protocols, ports)
 			defer ResetNamespaceLabels(k8s, nsY)
 
 			allowedLabels := &metav1.LabelSelector{
@@ -621,7 +642,8 @@ var _ = common.SIGDescribe("Netpol", func() {
 		ginkgo.It("should allow ingress access from updated pod [Feature:NetworkPolicy]", func() {
 			nsX, _, _, k8s := getK8sNamespaces(f)
 			protocols := []v1.Protocol{protocolTCP}
-			model = initializeResourcesByFixedNS(f, protocols)
+			ports := []int32{80}
+			model = initializeResourcesByFixedNS(f, protocols, ports)
 			podXB, err := model.FindPod(nsX, "b")
 			framework.ExpectNoError(err, "find pod x/b")
 			defer ResetPodLabels(k8s, podXB)
@@ -652,8 +674,8 @@ var _ = common.SIGDescribe("Netpol", func() {
 		ginkgo.It("should deny ingress from pods on other namespaces [Feature:NetworkPolicy]", func() {
 			nsX, nsY, nsZ, k8s := getK8sNamespaces(f)
 			protocols := []v1.Protocol{protocolTCP}
-			model = initializeResourcesByFixedNS(f, protocols)
-
+			ports := []int32{80}
+			model = initializeResourcesByFixedNS(f, protocols, ports)
 			IngressRules := networkingv1.NetworkPolicyIngressRule{}
 			IngressRules.From = append(IngressRules.From, networkingv1.NetworkPolicyPeer{PodSelector: &metav1.LabelSelector{MatchLabels: map[string]string{}}})
 			policy := GenNetworkPolicyWithNameAndPodSelector("deny-empty-policy", metav1.LabelSelector{}, SetSpecIngressRules(IngressRules))
@@ -669,7 +691,8 @@ var _ = common.SIGDescribe("Netpol", func() {
 		ginkgo.It("should deny ingress access to updated pod [Feature:NetworkPolicy]", func() {
 			nsX, _, _, k8s := getK8sNamespaces(f)
 			protocols := []v1.Protocol{protocolTCP}
-			model = initializeResourcesByFixedNS(f, protocols)
+			ports := []int32{80}
+			model = initializeResourcesByFixedNS(f, protocols, ports)
 			podXA, err := model.FindPod(nsX, "a")
 			framework.ExpectNoError(err, "find pod x/a")
 			defer ResetPodLabels(k8s, podXA)
@@ -692,7 +715,8 @@ var _ = common.SIGDescribe("Netpol", func() {
 		ginkgo.It("should deny egress from pods based on PodSelector [Feature:NetworkPolicy] ", func() {
 			nsX, _, _, k8s := getK8sNamespaces(f)
 			protocols := []v1.Protocol{protocolTCP}
-			model = initializeResourcesByFixedNS(f, protocols)
+			ports := []int32{80}
+			model = initializeResourcesByFixedNS(f, protocols, ports)
 			policy := GenNetworkPolicyWithNameAndPodSelector("deny-egress-pod-a", metav1.LabelSelector{MatchLabels: map[string]string{"pod": "a"}}, SetSpecEgressRules())
 			CreatePolicy(k8s, policy, nsX)
 
@@ -705,7 +729,8 @@ var _ = common.SIGDescribe("Netpol", func() {
 		ginkgo.It("should deny egress from all pods in a namespace [Feature:NetworkPolicy] ", func() {
 			nsX, _, _, k8s := getK8sNamespaces(f)
 			protocols := []v1.Protocol{protocolTCP}
-			model = initializeResourcesByFixedNS(f, protocols)
+			ports := []int32{80}
+			model = initializeResourcesByFixedNS(f, protocols, ports)
 			policy := GenNetworkPolicyWithNameAndPodSelector("deny-egress-ns-x", metav1.LabelSelector{}, SetSpecEgressRules())
 			CreatePolicy(k8s, policy, nsX)
 
@@ -735,7 +760,8 @@ var _ = common.SIGDescribe("Netpol", func() {
 			policy.Spec.PolicyTypes = []networkingv1.PolicyType{networkingv1.PolicyTypeEgress, networkingv1.PolicyTypeIngress}
 			nsX, _, _, k8s := getK8sNamespaces(f)
 			protocols := []v1.Protocol{protocolTCP}
-			model = initializeResourcesByFixedNS(f, protocols)
+			ports := []int32{80, 81}
+			model = initializeResourcesByFixedNS(f, protocols, ports)
 			CreatePolicy(k8s, policy, nsX)
 
 			reachabilityPort80 := NewReachability(model.AllPods(), true)
@@ -760,7 +786,8 @@ var _ = common.SIGDescribe("Netpol", func() {
 
 			nsX, nsY, _, k8s := getK8sNamespaces(f)
 			protocols := []v1.Protocol{protocolTCP}
-			model = initializeResourcesByFixedNS(f, protocols)
+			ports := []int32{80}
+			model = initializeResourcesByFixedNS(f, protocols, ports)
 
 			// Building egress policy for x/a to y/a only
 			allowedEgressNamespaces := &metav1.LabelSelector{
@@ -850,7 +877,8 @@ var _ = common.SIGDescribe("Netpol", func() {
 		ginkgo.It("should enforce egress policy allowing traffic to a server in a different namespace based on PodSelector and NamespaceSelector [Feature:NetworkPolicy]", func() {
 			nsX, nsY, _, k8s := getK8sNamespaces(f)
 			protocols := []v1.Protocol{protocolTCP}
-			model = initializeResourcesByFixedNS(f, protocols)
+			ports := []int32{80}
+			model = initializeResourcesByFixedNS(f, protocols, ports)
 			allowedNamespaces := &metav1.LabelSelector{
 				MatchLabels: map[string]string{
 					"ns": nsY,
@@ -875,7 +903,8 @@ var _ = common.SIGDescribe("Netpol", func() {
 		ginkgo.It("should enforce ingress policy allowing any port traffic to a server on a specific protocol [Feature:NetworkPolicy] [Feature:UDP]", func() {
 			nsX, _, _, k8s := getK8sNamespaces(f)
 			protocols := []v1.Protocol{protocolTCP, protocolUDP}
-			model = initializeResourcesByFixedNS(f, protocols)
+			ports := []int32{80}
+			model = initializeResourcesByFixedNS(f, protocols, ports)
 			ingressRule := networkingv1.NetworkPolicyIngressRule{}
 			ingressRule.Ports = append(ingressRule.Ports, networkingv1.NetworkPolicyPort{Protocol: &protocolTCP})
 			policy := GenNetworkPolicyWithNameAndPodMatchLabel("allow-ingress-by-proto", map[string]string{"pod": "a"}, SetSpecIngressRules(ingressRule))
@@ -892,7 +921,8 @@ var _ = common.SIGDescribe("Netpol", func() {
 		ginkgo.It("should enforce multiple ingress policies with ingress allow-all policy taking precedence [Feature:NetworkPolicy]", func() {
 			nsX, _, _, k8s := getK8sNamespaces(f)
 			protocols := []v1.Protocol{protocolTCP}
-			model = initializeResourcesByFixedNS(f, protocols)
+			ports := []int32{81}
+			model = initializeResourcesByFixedNS(f, protocols, ports)
 			IngressRules := networkingv1.NetworkPolicyIngressRule{}
 			IngressRules.Ports = append(IngressRules.Ports, networkingv1.NetworkPolicyPort{Port: &intstr.IntOrString{Type: intstr.Int, IntVal: 80}})
 			policyAllowOnlyPort80 := GenNetworkPolicyWithNameAndPodMatchLabel("allow-ingress-port-80", map[string]string{}, SetSpecIngressRules(IngressRules))
@@ -919,7 +949,8 @@ var _ = common.SIGDescribe("Netpol", func() {
 			policyAllowPort80 := GenNetworkPolicyWithNameAndPodMatchLabel("allow-egress-port-80", map[string]string{}, SetSpecEgressRules(egressRule))
 			nsX, _, _, k8s := getK8sNamespaces(f)
 			protocols := []v1.Protocol{protocolTCP}
-			model = initializeResourcesByFixedNS(f, protocols)
+			ports := []int32{81}
+			model = initializeResourcesByFixedNS(f, protocols, ports)
 			CreatePolicy(k8s, policyAllowPort80, nsX)
 
 			ginkgo.By("Making sure ingress doesn't work other than port 80")
@@ -944,7 +975,8 @@ var _ = common.SIGDescribe("Netpol", func() {
 			policy := GenNetworkPolicyWithNameAndPodSelector("deny-all", metav1.LabelSelector{}, SetSpecIngressRules(), SetSpecEgressRules())
 			nsX, _, _, k8s := getK8sNamespaces(f)
 			protocols := []v1.Protocol{protocolTCP}
-			model = initializeResourcesByFixedNS(f, protocols)
+			ports := []int32{80}
+			model = initializeResourcesByFixedNS(f, protocols, ports)
 			CreatePolicy(k8s, policy, nsX)
 			reachability := NewReachability(model.AllPods(), true)
 
@@ -968,7 +1000,8 @@ var _ = common.SIGDescribe("Netpol", func() {
 			// Getting podServer's status to get podServer's IP, to create the CIDR
 			nsX, nsY, _, k8s := getK8sNamespaces(f)
 			protocols := []v1.Protocol{protocolTCP}
-			model = initializeResourcesByFixedNS(f, protocols)
+			ports := []int32{80}
+			model = initializeResourcesByFixedNS(f, protocols, ports)
 			podList, err := f.ClientSet.CoreV1().Pods(nsY).List(context.TODO(), metav1.ListOptions{LabelSelector: "pod=b"})
 			framework.ExpectNoError(err, "Failing to list pods in namespace y")
 			pod := podList.Items[0]
@@ -994,7 +1027,8 @@ var _ = common.SIGDescribe("Netpol", func() {
 			// Getting podServer's status to get podServer's IP, to create the CIDR with except clause
 			nsX, _, _, k8s := getK8sNamespaces(f)
 			protocols := []v1.Protocol{protocolTCP}
-			model = initializeResourcesByFixedNS(f, protocols)
+			ports := []int32{80}
+			model = initializeResourcesByFixedNS(f, protocols, ports)
 			podList, err := f.ClientSet.CoreV1().Pods(nsX).List(context.TODO(), metav1.ListOptions{LabelSelector: "pod=a"})
 			framework.ExpectNoError(err, "Failing to find pod x/a")
 			podA := podList.Items[0]
@@ -1027,7 +1061,8 @@ var _ = common.SIGDescribe("Netpol", func() {
 			// Getting podServer's status to get podServer's IP, to create the CIDR with except clause
 			nsX, _, _, k8s := getK8sNamespaces(f)
 			protocols := []v1.Protocol{protocolTCP}
-			model = initializeResourcesByFixedNS(f, protocols)
+			ports := []int32{80}
+			model = initializeResourcesByFixedNS(f, protocols, ports)
 			podList, err := f.ClientSet.CoreV1().Pods(nsX).List(context.TODO(), metav1.ListOptions{LabelSelector: "pod=a"})
 			framework.ExpectNoError(err, "Failing to find pod x/a")
 			podA := podList.Items[0]
@@ -1088,7 +1123,8 @@ var _ = common.SIGDescribe("Netpol", func() {
 				metav1.LabelSelector{MatchLabels: targetLabels}, SetSpecEgressRules(networkingv1.NetworkPolicyEgressRule{}))
 			nsX, _, _, k8s := getK8sNamespaces(f)
 			protocols := []v1.Protocol{protocolTCP}
-			model = initializeResourcesByFixedNS(f, protocols)
+			ports := []int32{80}
+			model = initializeResourcesByFixedNS(f, protocols, ports)
 			CreatePolicy(k8s, allowEgressPolicy, nsX)
 
 			allowEgressReachability := NewReachability(model.AllPods(), true)
@@ -1110,7 +1146,8 @@ var _ = common.SIGDescribe("Netpol", func() {
 		ginkgo.It("should not mistakenly treat 'protocol: SCTP' as 'protocol: TCP', even if the plugin doesn't support SCTP [Feature:NetworkPolicy]", func() {
 			nsX, _, _, k8s := getK8sNamespaces(f)
 			protocols := []v1.Protocol{protocolTCP}
-			model = initializeResourcesByFixedNS(f, protocols)
+			ports := []int32{81}
+			model = initializeResourcesByFixedNS(f, protocols, ports)
 
 			ginkgo.By("Creating a default-deny ingress policy.")
 			// Empty podSelector blocks the entire namespace
@@ -1139,7 +1176,8 @@ var _ = common.SIGDescribe("Netpol", func() {
 			policy := GenNetworkPolicyWithNameAndPodMatchLabel("allow-only-sctp-ingress-on-port-80", map[string]string{"pod": "a"}, SetSpecIngressRules(ingressRule))
 			nsX, _, _, k8s := getK8sNamespaces(f)
 			protocols := []v1.Protocol{protocolTCP}
-			model = initializeResourcesByFixedNS(f, protocols)
+			ports := []int32{81}
+			model = initializeResourcesByFixedNS(f, protocols, ports)
 			CreatePolicy(k8s, policy, nsX)
 
 			ginkgo.By("Trying to connect to TCP port 81, which should be blocked by implicit isolation.")
@@ -1154,7 +1192,8 @@ var _ = common.SIGDescribe("Netpol", func() {
 			policy := GenNetworkPolicyWithNameAndPodMatchLabel("allow-only-udp-ingress-on-port-81", map[string]string{"pod": "a"}, SetSpecIngressRules(ingressRule))
 			nsX, _, _, k8s := getK8sNamespaces(f)
 			protocols := []v1.Protocol{protocolTCP}
-			model = initializeResourcesByFixedNS(f, protocols)
+			ports := []int32{81}
+			model = initializeResourcesByFixedNS(f, protocols, ports)
 			CreatePolicy(k8s, policy, nsX)
 
 			ginkgo.By("Creating a network policy for the server which allows traffic only via UDP on port 81.")
@@ -1169,7 +1208,8 @@ var _ = common.SIGDescribe("Netpol", func() {
 		ginkgo.It("should enforce policy to allow traffic based on NamespaceSelector with MatchLabels using default ns label [Feature:NetworkPolicy]", func() {
 			nsX, nsY, nsZ, k8s := getK8sNamespaces(f)
 			protocols := []v1.Protocol{protocolTCP}
-			model = initializeResourcesByFixedNS(f, protocols)
+			ports := []int32{80}
+			model = initializeResourcesByFixedNS(f, protocols, ports)
 			allowedLabels := &metav1.LabelSelector{
 				MatchLabels: map[string]string{
 					v1.LabelMetadataName: nsY,
@@ -1191,7 +1231,8 @@ var _ = common.SIGDescribe("Netpol", func() {
 		ginkgo.It("should enforce policy based on NamespaceSelector with MatchExpressions using default ns label [Feature:NetworkPolicy]", func() {
 			nsX, nsY, _, k8s := getK8sNamespaces(f)
 			protocols := []v1.Protocol{protocolTCP}
-			model = initializeResourcesByFixedNS(f, protocols)
+			ports := []int32{80}
+			model = initializeResourcesByFixedNS(f, protocols, ports)
 			allowedNamespaces := &metav1.LabelSelector{
 				MatchExpressions: []metav1.LabelSelectorRequirement{{
 					Key:      v1.LabelMetadataName,
@@ -1231,7 +1272,8 @@ var _ = common.SIGDescribe("Netpol [LinuxOnly]", func() {
 		ginkgo.It("should support a 'default-deny-ingress' policy [Feature:NetworkPolicy]", func() {
 			nsX, _, _, k8s := getK8sNamespaces(f)
 			protocols := []v1.Protocol{protocolUDP}
-			model = initializeResourcesByFixedNS(f, protocols)
+			ports := []int32{80}
+			model = initializeResourcesByFixedNS(f, protocols, ports)
 			policy := GenNetworkPolicyWithNameAndPodSelector("deny-all", metav1.LabelSelector{}, SetSpecIngressRules())
 			CreatePolicy(k8s, policy, nsX)
 
@@ -1245,7 +1287,8 @@ var _ = common.SIGDescribe("Netpol [LinuxOnly]", func() {
 			ginkgo.By("Creating a network policy allowPort81Policy which only allows allow listed namespaces (y) to connect on exactly one port (81)")
 			nsX, nsY, nsZ, k8s := getK8sNamespaces(f)
 			protocols := []v1.Protocol{protocolUDP}
-			model = initializeResourcesByFixedNS(f, protocols)
+			ports := []int32{81}
+			model = initializeResourcesByFixedNS(f, protocols, ports)
 			allowedLabels := &metav1.LabelSelector{
 				MatchLabels: map[string]string{
 					"ns": nsY,
@@ -1268,7 +1311,8 @@ var _ = common.SIGDescribe("Netpol [LinuxOnly]", func() {
 		ginkgo.It("should enforce policy to allow traffic only from a pod in a different namespace based on PodSelector and NamespaceSelector [Feature:NetworkPolicy]", func() {
 			nsX, nsY, _, k8s := getK8sNamespaces(f)
 			protocols := []v1.Protocol{protocolUDP}
-			model = initializeResourcesByFixedNS(f, protocols)
+			ports := []int32{80}
+			model = initializeResourcesByFixedNS(f, protocols, ports)
 			allowedNamespaces := &metav1.LabelSelector{
 				MatchLabels: map[string]string{
 					"ns": nsY,
@@ -1313,7 +1357,8 @@ var _ = common.SIGDescribe("Netpol [Feature:SCTPConnectivity][LinuxOnly][Disrupt
 		ginkgo.It("should support a 'default-deny-ingress' policy [Feature:NetworkPolicy]", func() {
 			nsX, _, _, k8s := getK8sNamespaces(f)
 			protocols := []v1.Protocol{protocolSCTP}
-			model = initializeResourcesByFixedNS(f, protocols)
+			ports := []int32{80}
+			model = initializeResourcesByFixedNS(f, protocols, ports)
 			policy := GenNetworkPolicyWithNameAndPodSelector("deny-all", metav1.LabelSelector{}, SetSpecIngressRules())
 			CreatePolicy(k8s, policy, nsX)
 
@@ -1327,7 +1372,8 @@ var _ = common.SIGDescribe("Netpol [Feature:SCTPConnectivity][LinuxOnly][Disrupt
 			ginkgo.By("Creating a network allowPort81Policy which only allows allow listed namespaces (y) to connect on exactly one port (81)")
 			nsX, nsY, nsZ, k8s := getK8sNamespaces(f)
 			protocols := []v1.Protocol{protocolSCTP}
-			model = initializeResourcesByFixedNS(f, protocols)
+			ports := []int32{81}
+			model = initializeResourcesByFixedNS(f, protocols, ports)
 			allowedLabels := &metav1.LabelSelector{
 				MatchLabels: map[string]string{
 					"ns": nsY,
@@ -1349,7 +1395,8 @@ var _ = common.SIGDescribe("Netpol [Feature:SCTPConnectivity][LinuxOnly][Disrupt
 		ginkgo.It("should enforce policy to allow traffic only from a pod in a different namespace based on PodSelector and NamespaceSelector [Feature:NetworkPolicy]", func() {
 			nsX, nsY, _, k8s := getK8sNamespaces(f)
 			protocols := []v1.Protocol{protocolSCTP}
-			model = initializeResourcesByFixedNS(f, protocols)
+			ports := []int32{80}
+			model = initializeResourcesByFixedNS(f, protocols, ports)
 			allowedNamespaces := &metav1.LabelSelector{
 				MatchLabels: map[string]string{
 					"ns": nsY,
@@ -1389,11 +1436,11 @@ func getNamespaces(rootNs string) (string, string, string, []string) {
 
 // defaultModel creates a new "model" pod system under namespaces (x,y,z) which has pods a, b, and c.  Thus resulting in the
 // truth table matrix that is identical for all tests, comprising 81 total connections between 9 pods (x/a, x/b, x/c, ..., z/c).
-func defaultModel(namespaces []string, dnsDomain string, protocols []v1.Protocol) *Model {
+func defaultModel(namespaces []string, dnsDomain string, protocols []v1.Protocol, ports []int32) *Model {
 	if framework.NodeOSDistroIs("windows") {
-		return NewWindowsModel(namespaces, []string{"a", "b", "c"}, []int32{80, 81}, dnsDomain)
+		return NewWindowsModel(namespaces, []string{"a", "b", "c"}, ports, dnsDomain)
 	}
-	return NewModel(namespaces, []string{"a", "b", "c"}, []int32{80, 81}, protocols, dnsDomain)
+	return NewModel(namespaces, []string{"a", "b", "c"}, ports, protocols, dnsDomain)
 }
 
 // getK8sNamespaces returns the canonical set of namespaces using the framework's root namespace
@@ -1404,9 +1451,9 @@ func getK8sNamespaces(f *framework.Framework) (string, string, string, *kubeMana
 
 // initializeResourcesByFixedNS uses the e2e framework to create all necessary namespace resources, cleaning up
 // network policies from the namespace if useFixedNamespace is set true, avoiding policies overlap of new tests.
-func initializeResourcesByFixedNS(f *framework.Framework, protocols []v1.Protocol) *Model {
+func initializeResourcesByFixedNS(f *framework.Framework, protocols []v1.Protocol, ports []int32) *Model {
 	if useFixedNamespaces {
-		model, _ := initializeResources(f, protocols)
+		model, _ := initializeResources(f, protocols, ports)
 		k8s := newKubeManager(f)
 		framework.ExpectNoError(k8s.cleanNetworkPolicies(model.NamespaceNames), "unable to clean network policies")
 		err := wait.Poll(waitInterval, waitTimeout, func() (done bool, err error) {
@@ -1423,7 +1470,7 @@ func initializeResourcesByFixedNS(f *framework.Framework, protocols []v1.Protoco
 		return model
 	} else {
 		framework.Logf("Using %v as the default dns domain for this cluster... ", framework.TestContext.ClusterDNSDomain)
-		model, err := initializeResources(f, protocols)
+		model, err := initializeResources(f, protocols, ports)
 		framework.ExpectNoError(err, "unable to initialize resources")
 		return model
 	}
@@ -1432,12 +1479,12 @@ func initializeResourcesByFixedNS(f *framework.Framework, protocols []v1.Protoco
 // initializeResources uses the e2e framework to create all necessary namespace resources, based on the network policy
 // model derived from the framework.  It then waits for the resources described by the model to be up and running
 // (i.e. all pods are ready and running in their namespaces).
-func initializeResources(f *framework.Framework, protocols []v1.Protocol) (*Model, error) {
+func initializeResources(f *framework.Framework, protocols []v1.Protocol, ports []int32) (*Model, error) {
 	k8s := newKubeManager(f)
 	rootNs := f.Namespace.GetName()
 	_, _, _, namespaces := getNamespaces(rootNs)
 
-	model := defaultModel(namespaces, framework.TestContext.ClusterDNSDomain, protocols)
+	model := defaultModel(namespaces, framework.TestContext.ClusterDNSDomain, protocols, ports)
 
 	framework.Logf("initializing cluster: ensuring namespaces, deployments, and pods exist and are ready")
 

--- a/test/e2e/network/netpol/test_helper.go
+++ b/test/e2e/network/netpol/test_helper.go
@@ -69,7 +69,7 @@ func UpdatePolicy(k8s *kubeManager, policy *networkingv1.NetworkPolicy, namespac
 // waitForHTTPServers waits for all webservers to be up, on all protocols sent in the input,  and then validates them using the same probe logic as the rest of the suite.
 func waitForHTTPServers(k *kubeManager, model *Model) error {
 	const maxTries = 10
-	framework.Logf("waiting for HTTP servers (ports 80 and 81) to become ready")
+	framework.Logf("waiting for HTTP servers (ports 80 and/or 81) to become ready")
 
 	testCases := map[string]*TestCase{}
 	for _, port := range model.Ports {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug


Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This is a followup on #104086. As of now the pods in networkpolicy tests create two containers on ports 80 and 81 by default. We can optimize this resource consumption by creating containers only for the port(s) used in the tests.
#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #104277

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
