### PR TITLE
leaderElector release will painc if le.config.Lock.Get failed

### DIFF
--- a/staging/src/k8s.io/client-go/tools/leaderelection/resourcelock/configmaplock.go
+++ b/staging/src/k8s.io/client-go/tools/leaderelection/resourcelock/configmaplock.go
@@ -82,7 +82,7 @@ func (cml *ConfigMapLock) Create(ctx context.Context, ler LeaderElectionRecord) 
 
 // Update will update an existing annotation on a given resource.
 func (cml *ConfigMapLock) Update(ctx context.Context, ler LeaderElectionRecord) error {
-	if cml.cm == nil {
+	if cml.cm == nil || cml.cm.Annotations == nil {
 		return errors.New("configmap not initialized, call get or create first")
 	}
 	recordBytes, err := json.Marshal(ler)


### PR DESCRIPTION

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
E0813 03:03:14.314418       1 leaderelection.go:327] error retrieving resource lock xxx: Get xxx: connect: connection refused
E0813 03:03:16.715534       1 leaderelection.go:327] error retrieving resource lock xxx: Get xxx: connect: connection refused
I0813 03:03:17.313662       1 leaderelection.go:284] failed to renew lease xxx: timed out waiting for the condition
I0813 03:03:17.313761       1 election.go:119] xxx: lost
panic: assignment to entry in nil map

goroutine 8 [running]:
xxx/vendor/k8s.io/client-go/tools/leaderelection/resourcelock.(*ConfigMapLock).Update(0xc0003d8c80, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
	xxx/vendor/k8s.io/client-go/tools/leaderelection/resourcelock/configmaplock.go:89 +0x12b
        xxx/vendor/k8s.io/client-go/tools/leaderelection.(*LeaderElector).release(0xc000198d80, 0x8f0d1800)
	xxx/vendor/k8s.io/client-go/tools/leaderelection/leaderelection.go:302 +0xcc
        xxx/vendor/k8s.io/client-go/tools/leaderelection.(*LeaderElector).renew(0xc000198d80, 0x19dc740, 0xc0000c52c0)
	xxx/vendor/k8s.io/client-go/tools/leaderelection/leaderelection.go:290 +0x124
        xxx/vendor/k8s.io/client-go/tools/leaderelection.(*LeaderElector).Run(0xc000198d80, 0x19dc740, 0xc0000c5280)
	xxx/vendor/k8s.io/client-go/tools/leaderelection/leaderelection.go:204 +0x110
        xxx/vendor/k8s.io/client-go/tools/leaderelection.RunOrDie(0x19dc740, 0xc0002326c0, 0x19e90e0, 0xc0003d8c80, 0x2cb417800, 0xb2d05e00, 0x8f0d1800, 0xc000215c20, 0xc000215c60, 0xc000215ca0, ...)
	xxx/vendor/k8s.io/client-go/tools/leaderelection/leaderelection.go:217 +0x98
-->

    1. `LeaderElector` need to `tryAcquireOrRenew`, 
    2.  if renew failed and need to go to `le.release()`, 
    3. `le.config.Lock.Update` will panic as `le.config.Lock.cml.cm.Annotations` is not initialized because `le.config.Lock.Get` return directly before initialized.

Fixes #


