### PR TITLE
Update ldflags to work with gomodule build

### DIFF
--- a/hack/lib/version.sh
+++ b/hack/lib/version.sh
@@ -159,6 +159,8 @@ kube::version::ldflags() {
     ldflags+=(
       "-X '${KUBE_GO_PACKAGE}/vendor/k8s.io/client-go/pkg/version.${key}=${val}'"
       "-X '${KUBE_GO_PACKAGE}/vendor/k8s.io/component-base/version.${key}=${val}'"
+      "-X 'k8s.io/client-go/pkg/version.${key}=${val}'"
+      "-X 'k8s.io/component-base/version.${key}=${val}'"
     )
   }
 


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Updates the ldflags args to work whether the build is done with GOPATH or go module mode.

Extracted from https://github.com/kubernetes/kubernetes/pull/99226

xref #82531

```release-note
NONE
```
