### PR TITLE
WIP: ruleguard and new net.ParseIP and ParseCIDR functions

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,0 +1,29 @@
+run:
+  timeout: 30m
+  skip-files:
+    - "^zz_generated.*"
+
+issues:
+  max-same-issues: 0
+
+linters:
+  disable-all: true
+  enable: # please keep this alphabetized
+    - deadcode
+    - gocritic
+    - ineffassign
+    - staticcheck
+    - unused
+    - varcheck
+linters-settings: # please keep this alphabetized
+  gocritic:
+    enabled-checks:
+      - ruleguard
+    settings:
+      ruleguard:
+        rules: ".ruleguard_rules.go"
+  staticcheck:
+    go: "1.16"
+    checks: [ "all" ]
+  unused:
+    go: "1.16"

--- a/.ruleguard_rules.go
+++ b/.ruleguard_rules.go
@@ -1,0 +1,7 @@
+package gorules
+
+import "github.com/quasilyte/go-ruleguard/dsl"
+
+func netParseIP(m dsl.Matcher) {
+	m.Match(`net.ParseIP($_)`).Report("prefer utilnet.ParseIPSloppy()")
+}

--- a/hack/verify-golangci-lint.sh
+++ b/hack/verify-golangci-lint.sh
@@ -43,11 +43,6 @@ popd >/dev/null
 
 cd "${KUBE_ROOT}"
 
+# The config is in ${REPOROOT}/.golangci.yaml
 echo 'running golangci-lint '
-golangci-lint run \
-  --timeout 30m \
-  --disable-all \
-  -E deadcode \
-  -E unused \
-  -E varcheck \
-  -E ineffassign
+golangci-lint -v run "$@"


### PR DESCRIPTION
/kind bug
/kind cleanup

#### What this PR does / why we need it:

Since golang 1.17, https://github.com/golang/go/issues/30999,  "In both net.ParseIP and net.ParseCIDR reject leading zeros in the dot-decimal notation of IPv4 addresses."

This can cause that previous valid data becomes invalid, so we should guarantee that this doesn't happen.
However, this applies only to the API data that we store, not to the other places, like flags, where we can tight validation.

In addition, since this change in the golang stdlib as associated a security  CVE-2021-29923, we should check

> While you triage those callsites, it would be good to also check if they are affected by the kind of issues that are motivating the change: if you are validating the inputs with Go and then passing the inputs to the OS or to non-Go applications, the two might disagree on the inputs validity or meaning. This can cause issues, which we would love to hear about at security@golang.org or on the issue, to assess the security risk.

#### Which issue(s) this PR fixes:

Fixes #100895


```release-note
Kubernetes allows IPs with leading zeroes in any API field, however, non API fields, like flags and configuration files, will not allow leading zeroes on IP addresses.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
