### PR TITLE
Fix storage class setup in regional_pd.go

### DIFF
--- a/test/e2e/storage/regional_pd.go
+++ b/test/e2e/storage/regional_pd.go
@@ -154,16 +154,15 @@ func testVolumeProvisioning(c clientset.Interface, t *framework.TimeoutContext, 
 
 	for _, test := range tests {
 		test.Client = c
-		test.Class = newStorageClass(test, ns, "" /* suffix */)
+		computedStorageClass, clearStorageClass := testsuites.SetupStorageClass(test.Client, newStorageClass(test, ns, "" /* suffix */))
+		defer clearStorageClass()
+		test.Class = computedStorageClass
 		test.Claim = e2epv.MakePersistentVolumeClaim(e2epv.PersistentVolumeClaimConfig{
 			ClaimSize:        test.ClaimSize,
 			StorageClassName: &(test.Class.Name),
 			VolumeMode:       &test.VolumeMode,
 		}, ns)
-		sc, clearStorageClass := testsuites.SetupStorageClass(test.Client, test.Class)
-		defer clearStorageClass()
 
-		test.Class = sc
 		test.TestDynamicProvisioning()
 	}
 }
@@ -344,7 +343,10 @@ func testRegionalDelayedBinding(c clientset.Interface, ns string, pvcCount int) 
 	}
 
 	suffix := "delayed-regional"
-	test.Class = newStorageClass(test, ns, suffix)
+
+	computedStorageClass, clearStorageClass := testsuites.SetupStorageClass(test.Client, newStorageClass(test, ns, suffix))
+	defer clearStorageClass()
+	test.Class = computedStorageClass
 	var claims []*v1.PersistentVolumeClaim
 	for i := 0; i < pvcCount; i++ {
 		claim := e2epv.MakePersistentVolumeClaim(e2epv.PersistentVolumeClaimConfig{
@@ -382,7 +384,9 @@ func testRegionalAllowedTopologies(c clientset.Interface, ns string) {
 
 	suffix := "topo-regional"
 	test.Client = c
-	test.Class = newStorageClass(test, ns, suffix)
+	computedStorageClass, clearStorageClass := testsuites.SetupStorageClass(test.Client, newStorageClass(test, ns, suffix))
+	defer clearStorageClass()
+	test.Class = computedStorageClass
 	zones := getTwoRandomZones(c)
 	addAllowedTopologiesToStorageClass(c, test.Class, zones)
 	test.Claim = e2epv.MakePersistentVolumeClaim(e2epv.PersistentVolumeClaimConfig{
@@ -392,10 +396,6 @@ func testRegionalAllowedTopologies(c clientset.Interface, ns string) {
 		VolumeMode:       &test.VolumeMode,
 	}, ns)
 
-	sc, clearStorageClass := testsuites.SetupStorageClass(test.Client, test.Class)
-	defer clearStorageClass()
-
-	test.Class = sc
 	pv := test.TestDynamicProvisioning()
 	checkZonesFromLabelAndAffinity(pv, sets.NewString(zones...), true)
 }
@@ -415,7 +415,9 @@ func testRegionalAllowedTopologiesWithDelayedBinding(c clientset.Interface, ns s
 	}
 
 	suffix := "topo-delayed-regional"
-	test.Class = newStorageClass(test, ns, suffix)
+	computedStorageClass, clearStorageClass := testsuites.SetupStorageClass(test.Client, newStorageClass(test, ns, suffix))
+	defer clearStorageClass()
+	test.Class = computedStorageClass
 	topoZones := getTwoRandomZones(c)
 	addAllowedTopologiesToStorageClass(c, test.Class, topoZones)
 	var claims []*v1.PersistentVolumeClaim


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug
/area test
/sig storage

#### What this PR does / why we need it:

In https://github.com/kubernetes/kubernetes/pull/99346 I made a change to return the computed StorageClass from the API Server through `SetupStorageClass`, `SetupStorageClass` was changed to use `GenerateName` instead of `Name`, however `Name` is still being referenced in the regional_pd.go tests and because they're not using the result of `SetupStorageClass` they fail.

Follow up work for https://github.com/kubernetes/kubernetes/pull/99346.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

/cc @jingxu97 @mattcary 