### PR TITLE
Fix `kubectl unlabel` response msg

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/label/label.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/label/label.go
@@ -44,6 +44,12 @@ import (
 	"k8s.io/kubectl/pkg/util/templates"
 )
 
+const (
+	MsgNotLabeled = "not labeled"
+	MsgLabeled    = "labeled"
+	MsgUnLabeled  = "unlabeled"
+)
+
 // LabelOptions have the data required to perform the label operation
 type LabelOptions struct {
 	// Filename options
@@ -390,9 +396,12 @@ func (o *LabelOptions) RunLabel() error {
 }
 
 func updateDataChangeMsg(oldObj []byte, newObj []byte) string {
-	msg := "not labeled"
+	msg := MsgNotLabeled
 	if !reflect.DeepEqual(oldObj, newObj) {
-		msg = "labeled"
+		msg = MsgLabeled
+		if len(newObj) < len(oldObj) {
+			msg = MsgUnLabeled
+		}
 	}
 	return msg
 }

--- a/staging/src/k8s.io/kubectl/pkg/cmd/label/label_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/label/label_test.go
@@ -24,10 +24,11 @@ import (
 	"strings"
 	"testing"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/json"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/cli-runtime/pkg/resource"
 	"k8s.io/client-go/rest/fake"
@@ -563,5 +564,145 @@ func TestLabelResourceVersion(t *testing.T) {
 	}
 	if err := options.RunLabel(); err != nil {
 		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestLabelMsg(t *testing.T) {
+	tests := []struct {
+		obj             runtime.Object
+		overwrite       bool
+		resourceVersion string
+		labels          map[string]string
+		remove          []string
+		expectObj       runtime.Object
+		expectMsg       string
+		expectErr       bool
+	}{
+		{
+			obj: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{"a": "b"},
+				},
+			},
+			labels:    map[string]string{"a": "b"},
+			expectMsg: MsgNotLabeled,
+			expectErr: true,
+		},
+		{
+			obj: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{},
+			},
+			labels: map[string]string{"a": "b"},
+			expectObj: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{"a": "b"},
+				},
+			},
+			expectMsg: MsgLabeled,
+		},
+		{
+			obj: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{"a": "b"},
+				},
+			},
+			labels:    map[string]string{"a": "c"},
+			overwrite: true,
+			expectObj: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{"a": "c"},
+				},
+			},
+			expectMsg: MsgLabeled,
+		},
+		{
+			obj: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{"a": "b"},
+				},
+			},
+			labels: map[string]string{"c": "d"},
+			expectObj: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{"a": "b", "c": "d"},
+				},
+			},
+			expectMsg: MsgLabeled,
+		},
+		{
+			obj: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{"a": "b"},
+				},
+			},
+			labels:          map[string]string{"c": "d"},
+			resourceVersion: "2",
+			expectObj: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels:          map[string]string{"a": "b", "c": "d"},
+					ResourceVersion: "2",
+				},
+			},
+			expectMsg: MsgLabeled,
+		},
+		{
+			obj: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{"a": "b"},
+				},
+			},
+			labels: map[string]string{},
+			remove: []string{"a"},
+			expectObj: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{},
+				},
+			},
+			expectMsg: MsgUnLabeled,
+		},
+		{
+			obj: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{"a": "b", "c": "d"},
+				},
+			},
+			labels: map[string]string{"e": "f"},
+			remove: []string{"a"},
+			expectObj: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"c": "d",
+						"e": "f",
+					},
+				},
+			},
+			expectMsg: MsgLabeled,
+		},
+	}
+
+	for _, test := range tests {
+		oldData, err := json.Marshal(test.obj)
+		if err != nil {
+			t.Errorf("unexpected error: %v %v", err, test)
+		}
+
+		err = labelFunc(test.obj, test.overwrite, test.resourceVersion, test.labels, test.remove)
+		if test.expectErr && err == nil {
+			t.Errorf("unexpected non-error: %v", test)
+			continue
+		}
+		if !test.expectErr && err != nil {
+			t.Errorf("unexpected error: %v %v", err, test)
+		}
+
+		newObj, err := json.Marshal(test.obj)
+		if err != nil {
+			t.Errorf("unexpected error: %v %v", err, test)
+		}
+
+		dataChangeMsg := updateDataChangeMsg(oldData, newObj)
+		if dataChangeMsg != test.expectMsg {
+			t.Errorf("unexpected dataChangeMsg: %v != %v, %v", dataChangeMsg, test.expectMsg, test)
+		}
 	}
 }


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
To distinguish between label and unlabel msg: `labeled/unlabeled`, just like `tainted/untainted`.

#### Which issue(s) this PR fixes:
Fixes #104371

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
