### PR TITLE
Initial Readystatus from API-Server

### DIFF
--- a/pkg/kubelet/prober/common_test.go
+++ b/pkg/kubelet/prober/common_test.go
@@ -120,7 +120,6 @@ func newTestManager(client *fake.Clientset) *manager {
 		nil, // runner
 		&record.FakeRecorder{},
 	).(*manager)
-	m.statusManager.Start()
 	// Don't actually execute probes.
 	m.prober.exec = fakeExecProber{probe.Success, nil}
 	return m

--- a/pkg/kubelet/prober/common_test.go
+++ b/pkg/kubelet/prober/common_test.go
@@ -103,18 +103,24 @@ func setTestProbe(pod *v1.Pod, probeType probeType, probeSpec v1.Probe) {
 	}
 }
 
-func newTestManager() *manager {
+func newTestManager(client *fake.Clientset) *manager {
+
+	if client == nil {
+		client = &fake.Clientset{}
+	}
+
 	podManager := kubepod.NewBasicPodManager(nil, nil, nil)
 	// Add test pod to pod manager, so that status manager can get the pod from pod manager if needed.
 	podManager.AddPod(getTestPod())
 	m := NewManager(
-		status.NewManager(&fake.Clientset{}, podManager, &statustest.FakePodDeletionSafetyProvider{}),
+		status.NewManager(client, podManager, &statustest.FakePodDeletionSafetyProvider{}),
 		results.NewManager(),
 		results.NewManager(),
 		results.NewManager(),
 		nil, // runner
 		&record.FakeRecorder{},
 	).(*manager)
+	m.statusManager.Start()
 	// Don't actually execute probes.
 	m.prober.exec = fakeExecProber{probe.Success, nil}
 	return m

--- a/pkg/kubelet/prober/prober_manager.go
+++ b/pkg/kubelet/prober/prober_manager.go
@@ -254,7 +254,7 @@ func (m *manager) UpdatePodStatus(podUID types.UID, podStatus *v1.PodStatus) {
 					// The readiness worker has not yet reported to readinessManager, instead of just returning ready=false consult status_Manager
 					podStatus, found := m.statusManager.GetPodStatus(podUID)
 					if found {
-						for _,containerStatus := range podStatus.ContainerStatuses {
+						for _, containerStatus := range podStatus.ContainerStatuses {
 							if c.ContainerID == containerStatus.ContainerID {
 								ready = containerStatus.Ready
 								break

--- a/pkg/kubelet/prober/prober_manager_test.go
+++ b/pkg/kubelet/prober/prober_manager_test.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes/fake"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/runtime"
@@ -87,7 +88,7 @@ func TestAddRemovePods(t *testing.T) {
 		},
 	}
 
-	m := newTestManager()
+	m := newTestManager(nil)
 	defer cleanup(t, m)
 	if err := expectProbes(m, nil); err != nil {
 		t.Error(err)
@@ -133,7 +134,7 @@ func TestAddRemovePods(t *testing.T) {
 }
 
 func TestCleanupPods(t *testing.T) {
-	m := newTestManager()
+	m := newTestManager(nil)
 	defer cleanup(t, m)
 	podToCleanup := v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
@@ -195,7 +196,7 @@ func TestCleanupPods(t *testing.T) {
 }
 
 func TestCleanupRepeated(t *testing.T) {
-	m := newTestManager()
+	m := newTestManager(nil)
 	defer cleanup(t, m)
 	podTemplate := v1.Pod{
 		Spec: v1.PodSpec{
@@ -277,7 +278,7 @@ func TestUpdatePodStatus(t *testing.T) {
 		},
 	}
 
-	m := newTestManager()
+	m := newTestManager(nil)
 	// no cleanup: using fake workers.
 
 	// Setup probe "workers" and cached results.
@@ -318,6 +319,103 @@ func TestUpdatePodStatus(t *testing.T) {
 	}
 }
 
+func TestUpdatePodStatusWithInitialState(t *testing.T){
+	
+	alreadyRunningPodName := "alreadyRunningPod"
+	alreadyRunningPodUID := types.UID("alreadyRunningPodUID")
+	alreadyRunningContainerName := "alreadyRunningContainer"
+	alreadyRunningContainerID := "test://already_running_container"
+
+	alreadyRunningContainerInitialReadyState := v1.ContainerStatus{
+		Name: alreadyRunningContainerName,
+		ContainerID: alreadyRunningContainerID,
+		State: v1.ContainerState{
+			Running: &v1.ContainerStateRunning{},
+		},
+
+	}
+	alreadyRunningContainerActualReadyState := v1.ContainerStatus{
+		Name: alreadyRunningContainerName,
+		ContainerID: alreadyRunningContainerID,
+		Ready: true,
+		State: v1.ContainerState{
+			Running: &v1.ContainerStateRunning{
+				StartedAt: metav1.Now(),
+			},
+		},
+	}
+
+	podStatusInitialReadyStatus := v1.PodStatus{
+		Phase: v1.PodRunning,
+		ContainerStatuses: []v1.ContainerStatus{
+			alreadyRunningContainerInitialReadyState,
+		},
+	}
+
+	podStatusActualReadyState := v1.PodStatus{
+		Phase: v1.PodRunning,
+		ContainerStatuses: []v1.ContainerStatus{
+			alreadyRunningContainerActualReadyState,
+		},
+	}
+
+	alreadyRunningPod := &v1.Pod{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Pod",
+			APIVersion: "v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			UID:       alreadyRunningPodUID,
+			Name:      alreadyRunningPodName,
+			Namespace: "default",
+		},
+		Spec: v1.PodSpec{
+			Containers: []v1.Container{
+				v1.Container{
+					Name: alreadyRunningContainerName,
+					ReadinessProbe: &v1.Probe{
+						Handler: v1.Handler{
+							Exec: &v1.ExecAction{},
+						},
+						PeriodSeconds: 4,
+						SuccessThreshold: 1,
+						FailureThreshold: 1,
+					},
+				},
+			},
+		},
+		Status: podStatusActualReadyState,
+	}
+
+	client := fake.NewSimpleClientset(alreadyRunningPod)
+
+	m := newTestManager(client)
+
+	// We set the prober to always fail
+	m.prober.exec = fakeExecProber{probe.Failure, nil}
+
+	m.AddPod(alreadyRunningPod)
+	m.UpdatePodStatus("alreadyRunningPodUID", &podStatusInitialReadyStatus)
+
+	//first updateStatus will just initiate the readiness check, in that case consult status_manager for last known status
+	for _, c := range podStatusInitialReadyStatus.ContainerStatuses {
+		if !c.Ready {
+			t.Errorf("Expected container to be ready")
+		}
+	}
+	m.readinessManager.Set(kubecontainer.ParseContainerID(alreadyRunningContainerID), results.Failure, &v1.Pod{})
+
+	m.UpdatePodStatus("alreadyRunningPodUID", &podStatusInitialReadyStatus)
+	
+	// in case the container is not ready anymore no state from status_manager is used
+	for _, c := range podStatusInitialReadyStatus.ContainerStatuses {
+		if c.Ready {
+			t.Errorf("Expected container to be not ready")
+		}
+	}
+
+}
+
 func (m *manager) extractedReadinessHandling() {
 	update := <-m.readinessManager.Updates()
 	// This code corresponds to an extract from kubelet.syncLoopIteration()
@@ -328,7 +426,7 @@ func (m *manager) extractedReadinessHandling() {
 func TestUpdateReadiness(t *testing.T) {
 	testPod := getTestPod()
 	setTestProbe(testPod, readiness, v1.Probe{})
-	m := newTestManager()
+	m := newTestManager(nil)
 	defer cleanup(t, m)
 
 	// Start syncing readiness without leaking goroutine.

--- a/pkg/kubelet/prober/results/results_manager.go
+++ b/pkg/kubelet/prober/results/results_manager.go
@@ -22,7 +22,6 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
-
 )
 
 // Manager provides a probe results cache and channel of updates.

--- a/pkg/kubelet/prober/results/results_manager.go
+++ b/pkg/kubelet/prober/results/results_manager.go
@@ -22,6 +22,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
+
 )
 
 // Manager provides a probe results cache and channel of updates.

--- a/pkg/kubelet/prober/worker.go
+++ b/pkg/kubelet/prober/worker.go
@@ -203,9 +203,7 @@ func (w *worker) doProbe() (keepGoing bool) {
 		return true // Wait for more information.
 	}
 
-
 	if w.containerID.String() != c.ContainerID {
-		klog.Infof("w.Container %+v c.ContainerID %+v",w.containerID.String(),c.ContainerID)
 		if !w.containerID.IsEmpty() {
 			w.resultsManager.Remove(w.containerID)
 		}
@@ -232,7 +230,6 @@ func (w *worker) doProbe() (keepGoing bool) {
 		return c.State.Terminated == nil ||
 			w.pod.Spec.RestartPolicy != v1.RestartPolicyNever
 	}
-
 
 	// Graceful shutdown of the pod.
 	if w.pod.ObjectMeta.DeletionTimestamp != nil && (w.probeType == liveness || w.probeType == startup) {

--- a/pkg/kubelet/prober/worker_test.go
+++ b/pkg/kubelet/prober/worker_test.go
@@ -40,7 +40,7 @@ func init() {
 }
 
 func TestDoProbe(t *testing.T) {
-	m := newTestManager()
+	m := newTestManager(nil)
 
 	for _, probeType := range [...]probeType{liveness, readiness, startup} {
 		// Test statuses.
@@ -160,7 +160,7 @@ func TestDoProbe(t *testing.T) {
 }
 
 func TestInitialDelay(t *testing.T) {
-	m := newTestManager()
+	m := newTestManager(nil)
 
 	for _, probeType := range [...]probeType{liveness, readiness, startup} {
 		w := newTestWorker(m, probeType, v1.Probe{
@@ -192,7 +192,7 @@ func TestInitialDelay(t *testing.T) {
 }
 
 func TestFailureThreshold(t *testing.T) {
-	m := newTestManager()
+	m := newTestManager(nil)
 	w := newTestWorker(m, readiness, v1.Probe{SuccessThreshold: 1, FailureThreshold: 3})
 	m.statusManager.SetPodStatus(w.pod, getTestRunningStatus())
 
@@ -226,7 +226,7 @@ func TestFailureThreshold(t *testing.T) {
 }
 
 func TestSuccessThreshold(t *testing.T) {
-	m := newTestManager()
+	m := newTestManager(nil)
 	w := newTestWorker(m, readiness, v1.Probe{SuccessThreshold: 3, FailureThreshold: 1})
 	m.statusManager.SetPodStatus(w.pod, getTestRunningStatus())
 
@@ -260,7 +260,7 @@ func TestSuccessThreshold(t *testing.T) {
 }
 
 func TestCleanUp(t *testing.T) {
-	m := newTestManager()
+	m := newTestManager(nil)
 
 	for _, probeType := range [...]probeType{liveness, readiness, startup} {
 		key := probeKey{testPodUID, testContainerName, probeType}
@@ -299,7 +299,7 @@ func TestCleanUp(t *testing.T) {
 func TestHandleCrash(t *testing.T) {
 	runtime.ReallyCrash = false // Test that we *don't* really crash.
 
-	m := newTestManager()
+	m := newTestManager(nil)
 	w := newTestWorker(m, readiness, v1.Probe{})
 	m.statusManager.SetPodStatus(w.pod, getTestRunningStatus())
 
@@ -352,7 +352,7 @@ func (p crashingExecProber) Probe(_ exec.Cmd) (probe.Result, string, error) {
 }
 
 func TestOnHoldOnLivenessOrStartupCheckFailure(t *testing.T) {
-	m := newTestManager()
+	m := newTestManager(nil)
 
 	for _, probeType := range [...]probeType{liveness, startup} {
 		w := newTestWorker(m, probeType, v1.Probe{SuccessThreshold: 1, FailureThreshold: 1})
@@ -390,7 +390,7 @@ func TestOnHoldOnLivenessOrStartupCheckFailure(t *testing.T) {
 }
 
 func TestResultRunOnLivenessCheckFailure(t *testing.T) {
-	m := newTestManager()
+	m := newTestManager(nil)
 	w := newTestWorker(m, liveness, v1.Probe{SuccessThreshold: 1, FailureThreshold: 3})
 	m.statusManager.SetPodStatus(w.pod, getTestRunningStatus())
 
@@ -431,7 +431,7 @@ func TestResultRunOnLivenessCheckFailure(t *testing.T) {
 }
 
 func TestResultRunOnStartupCheckFailure(t *testing.T) {
-	m := newTestManager()
+	m := newTestManager(nil)
 	w := newTestWorker(m, startup, v1.Probe{SuccessThreshold: 1, FailureThreshold: 3})
 	m.statusManager.SetPodStatus(w.pod, getTestRunningStatusWithStarted(false))
 
@@ -466,7 +466,7 @@ func TestResultRunOnStartupCheckFailure(t *testing.T) {
 }
 
 func TestLivenessProbeDisabledByStarted(t *testing.T) {
-	m := newTestManager()
+	m := newTestManager(nil)
 	w := newTestWorker(m, liveness, v1.Probe{SuccessThreshold: 1, FailureThreshold: 1})
 	m.statusManager.SetPodStatus(w.pod, getTestRunningStatusWithStarted(false))
 	// livenessProbe fails, but is disabled
@@ -484,7 +484,7 @@ func TestLivenessProbeDisabledByStarted(t *testing.T) {
 }
 
 func TestStartupProbeDisabledByStarted(t *testing.T) {
-	m := newTestManager()
+	m := newTestManager(nil)
 	w := newTestWorker(m, startup, v1.Probe{SuccessThreshold: 1, FailureThreshold: 2})
 	m.statusManager.SetPodStatus(w.pod, getTestRunningStatusWithStarted(false))
 	// startupProbe fails < FailureThreshold, stays unknown

--- a/pkg/kubelet/status/status_manager.go
+++ b/pkg/kubelet/status/status_manager.go
@@ -205,16 +205,16 @@ func (m *manager) SetPodStatus(pod *v1.Pod, status v1.PodStatus) {
 func (m *manager) initializePodStatuses() {
 	m.podStatusesLock.Lock()
 	defer m.podStatusesLock.Unlock()
-	
+
 	pods, err := m.kubeClient.CoreV1().Pods("").List(context.TODO(), metav1.ListOptions{})
 	if err != nil {
-		klog.InfoS("Error while receiving all existing pods",err)
+		klog.ErrorS(err, "Error while receiving all existing pods: ")
 		return
 	}
 
 	for _, pod := range pods.Items {
 		status := *pod.Status.DeepCopy()
-		m.updateStatusInternal(&pod,status,false)
+		m.updateStatusInternal(&pod, status, false)
 	}
 }
 

--- a/test/e2e_node/kubelet_restart_ready_test.go
+++ b/test/e2e_node/kubelet_restart_ready_test.go
@@ -1,0 +1,145 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2enode
+
+import (
+	"context"
+	"time"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"k8s.io/kubernetes/test/e2e/framework"
+	e2emetrics "k8s.io/kubernetes/test/e2e/framework/metrics"
+	imageutils "k8s.io/kubernetes/test/utils/image"
+
+	"github.com/onsi/ginkgo"
+	"github.com/onsi/gomega"
+)
+
+// Serial because the test restarts Kubelet
+var _ = SIGDescribe("Kubelet Restart [Serial]", func() {
+	f := framework.NewDefaultFramework("kubelet-restart")
+	testKubeletRestart(f)
+})
+
+func testKubeletRestart(f *framework.Framework) {
+	ginkgo.Context("KubeletRestart", func() {
+		ginkgo.It("Verifies that Kubelet restart does not interfere with pod readiness.", func() {
+
+			ginkgo.By("Create a pod with a readiness probe that always returns true")
+			podName := "always-passing-readiness-probe-test-pod"
+			f.PodClient().CreateSync(&v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: podName},
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						{
+							Name:    "test-container",
+							Image:   imageutils.GetE2EImage(imageutils.BusyBox),
+							Command: []string{"/bin/sleep"},
+							Args:    []string{"10000"},
+							ReadinessProbe: &v1.Probe{
+								Handler: v1.Handler{
+									Exec: &v1.ExecAction{
+										Command: []string{
+											"/bin/true",
+										},
+									},
+								},
+								PeriodSeconds: 10, // A larger period here helps expose the bug
+							},
+						},
+					},
+				},
+			})
+
+			ginkgo.By("Wait for pod to become ready")
+			gomega.Eventually(func() bool {
+				return f.PodClient().PodIsReady(podName)
+			}, 5*time.Minute, framework.Poll).Should(gomega.BeTrue())
+			originalTransitionTime := getPodReadyLastTransisionTime(f, podName)
+
+			originalProbeCount := getReadyProbeCount(f, podName)
+
+			ginkgo.By("Restarting Kubelet")
+			restartTime := time.Now()
+			restartKubelet()
+
+			// We wait for the node to become ready as a proxy for kubelet finishing restarting.
+			// This is needed so that we don't error out trying to poll the kubelet probe metrics below.
+			ginkgo.By("Wait for node to be ready")
+			gomega.Eventually(func() bool {
+				node, err := f.ClientSet.CoreV1().Nodes().Get(context.TODO(), framework.TestContext.NodeName, metav1.GetOptions{})
+				framework.ExpectNoError(err)
+				for _, cond := range node.Status.Conditions {
+					if cond.Type == v1.NodeReady && cond.Status == v1.ConditionTrue && cond.LastHeartbeatTime.After(restartTime) {
+						return true
+					}
+				}
+				return false
+			}, 5*time.Minute, framework.Poll).Should(gomega.BeTrue())
+
+			ginkgo.By("Wait until the pod has been probed again")
+			gomega.Eventually(func() int {
+				return getReadyProbeCount(f, podName)
+			}, 5*time.Minute, framework.Poll).Should(gomega.BeNumerically(">", originalProbeCount))
+
+			ginkgo.By("Check if pod readiness has changed")
+			updatedTransitionTime := getPodReadyLastTransisionTime(f, podName)
+			framework.ExpectEqual(updatedTransitionTime, originalTransitionTime)
+		})
+	})
+}
+
+func getReadyProbeCount(f *framework.Framework, podName string) int {
+	total := 0
+	m, err := e2emetrics.GrabKubeletMetricsWithoutProxy(framework.TestContext.NodeName+":10255", "/metrics/probes")
+	framework.ExpectNoError(err)
+	samples, ok := m["prober_probe_total"]
+	// Note: We return 0 in the case that the metric doesn't exist yet after
+	//       kubelet is restarted and no probes have been done yet.
+	if ok {
+		for _, sample := range samples {
+			ns := string(sample.Metric["namespace"])
+			pod := string(sample.Metric["pod"])
+			probe_type := string(sample.Metric["probe_type"])
+			if ns == f.Namespace.Name && pod == podName && probe_type == "Readiness" {
+				total += int(sample.Value)
+			}
+		}
+	}
+	return total
+}
+
+func getPodReadyLastTransisionTime(f *framework.Framework, podName string) metav1.Time {
+	pod, err := f.PodClient().Get(context.TODO(), podName, metav1.GetOptions{})
+	framework.ExpectNoError(err)
+	cond := getPodReadyCondition(pod)
+	framework.ExpectNotEqual(cond, nil)
+	return cond.LastTransitionTime
+}
+
+func getPodReadyCondition(pod *v1.Pod) *v1.PodCondition {
+	framework.ExpectNotEqual(pod.Status, nil)
+	framework.ExpectNotEqual(pod.Status.Conditions, nil)
+	for _, cond := range pod.Status.Conditions {
+		if cond.Type == v1.PodReady {
+			return &cond
+		}
+	}
+	return nil // not found
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:
When kubelet is restarted and kubelet is running syncPod for first time, it is not considering readiness probe state at all. Call stack on first run is:

https://github.com/kubernetes/kubernetes/blob/355bc3df228d9529a15e53d4bb59757e191c0225/pkg/kubelet/kubelet.go#L1556

https://github.com/kubernetes/kubernetes/blob/355bc3df228d9529a15e53d4bb59757e191c0225/pkg/kubelet/kubelet_pods.go#L1425

https://github.com/kubernetes/kubernetes/blob/355bc3df228d9529a15e53d4bb59757e191c0225/pkg/kubelet/prober/prober_manager.go#L240-L259

And Line 259 is the problem here, as it just returns the initialValue to the upper calling layer which will get persisted to API-Server and then cause some minor service-outages because Pods once where notReady although this state never reflected actual container status.

Changes to overcome this problem:

1. StatusManager in starting phase will populate all podStatuses with status from API-Server
2. ProberManager will recognize that readinessManager has not reported a status yet. In this case we will consult statusManager and give back latest ready state from API-Server. This state from API-Server should be returned only for short amount of time as readinessManager should eventually report something

I also took the chance import changes from #79555 as it prevents that a wrong initial ready state is set to readinessManager. The aim of this PR is clearly that when readiness probes report something, they do this with correct state and not some default, non true value as it can cause service disruptions.

Happy to dicuss if this PR is the right approach :)

#### Which issue(s) this PR fixes:
Fixes #78733

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
NONE

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
