### PR TITLE
test(kubelet): fix failing test TestDefaultsYAML on non-linux OS

### DIFF
--- a/pkg/kubelet/apis/config/scheme/testdata/KubeletConfiguration/after/v1beta1_non_linux.yaml
+++ b/pkg/kubelet/apis/config/scheme/testdata/KubeletConfiguration/after/v1beta1_non_linux.yaml
@@ -1,0 +1,82 @@
+address: 0.0.0.0
+apiVersion: kubelet.config.k8s.io/v1beta1
+authentication:
+  anonymous:
+    enabled: false
+  webhook:
+    cacheTTL: 2m0s
+    enabled: true
+  x509: {}
+authorization:
+  mode: Webhook
+  webhook:
+    cacheAuthorizedTTL: 5m0s
+    cacheUnauthorizedTTL: 30s
+cgroupDriver: cgroupfs
+cgroupsPerQOS: true
+configMapAndSecretChangeDetectionStrategy: Watch
+containerLogMaxFiles: 5
+containerLogMaxSize: 10Mi
+contentType: application/vnd.kubernetes.protobuf
+cpuCFSQuota: true
+cpuCFSQuotaPeriod: 100ms
+cpuManagerPolicy: none
+cpuManagerReconcilePeriod: 10s
+enableControllerAttachDetach: true
+enableDebugFlagsHandler: true
+enableDebuggingHandlers: true
+enableProfilingHandler: true
+enableServer: true
+enableSystemLogHandler: true
+enforceNodeAllocatable:
+- pods
+eventBurst: 10
+eventRecordQPS: 5
+evictionHard:
+  imagefs.available: 15%
+  memory.available: 100Mi
+  nodefs.available: 10%
+evictionPressureTransitionPeriod: 5m0s
+failSwapOn: true
+fileCheckFrequency: 20s
+hairpinMode: promiscuous-bridge
+healthzBindAddress: 127.0.0.1
+healthzPort: 10248
+httpCheckFrequency: 20s
+imageGCHighThresholdPercent: 85
+imageGCLowThresholdPercent: 80
+imageMinimumGCAge: 2m0s
+iptablesDropBit: 15
+iptablesMasqueradeBit: 14
+kind: KubeletConfiguration
+kubeAPIBurst: 10
+kubeAPIQPS: 5
+logging:
+  format: text
+makeIPTablesUtilChains: true
+maxOpenFiles: 1000000
+maxPods: 110
+memoryManagerPolicy: None
+memorySwap: {}
+memoryThrottlingFactor: 0.8
+nodeLeaseDurationSeconds: 40
+nodeStatusMaxImages: 50
+nodeStatusReportFrequency: 5m0s
+nodeStatusUpdateFrequency: 10s
+oomScoreAdj: -999
+podPidsLimit: -1
+port: 10250
+registryBurst: 10
+registryPullQPS: 5
+resolvConf: /etc/resolv.conf
+runtimeRequestTimeout: 2m0s
+seccompDefault: false
+serializeImagePulls: true
+shutdownGracePeriod: 0s
+shutdownGracePeriodCriticalPods: 0s
+streamingConnectionIdleTimeout: 4h0m0s
+syncFrequency: 1m0s
+topologyManagerPolicy: none
+topologyManagerScope: container
+volumePluginDir: /usr/libexec/kubernetes/kubelet-plugins/volume/exec/
+volumeStatsAggPeriod: 1m0s

--- a/pkg/kubelet/apis/config/scheme/testdata/SerializedNodeConfigSource/after/v1beta1_non_linux.yaml
+++ b/pkg/kubelet/apis/config/scheme/testdata/SerializedNodeConfigSource/after/v1beta1_non_linux.yaml
@@ -1,0 +1,3 @@
+apiVersion: kubelet.config.k8s.io/v1beta1
+kind: SerializedNodeConfigSource
+source: {}

--- a/staging/src/k8s.io/component-base/config/testing/defaulting.go
+++ b/staging/src/k8s.io/component-base/config/testing/defaulting.go
@@ -19,6 +19,7 @@ package testing
 import (
 	"fmt"
 	"path/filepath"
+	goruntime "runtime"
 	"testing"
 
 	"k8s.io/apimachinery/pkg/runtime"
@@ -40,7 +41,12 @@ func GetDefaultingTestCases(t *testing.T, scheme *runtime.Scheme, codecs seriali
 		}
 		beforeDir := fmt.Sprintf("testdata/%s/before", gvk.Kind)
 		afterDir := fmt.Sprintf("testdata/%s/after", gvk.Kind)
-		filename := fmt.Sprintf("%s.yaml", gvk.Version)
+
+		suffix := ".yaml"
+		if goruntime.GOOS != "linux" {
+			suffix = "_non_linux.yaml"
+		}
+		outFilename := gvk.Version + suffix
 
 		codec, err := getCodecForGV(codecs, gvk.GroupVersion())
 		if err != nil {
@@ -49,8 +55,8 @@ func GetDefaultingTestCases(t *testing.T, scheme *runtime.Scheme, codecs seriali
 
 		cases = append(cases, TestCase{
 			name:  fmt.Sprintf("%s default_%s", gvk.Kind, gvk.Version),
-			in:    filepath.Join(beforeDir, filename),
-			out:   filepath.Join(afterDir, filename),
+			in:    filepath.Join(beforeDir, fmt.Sprintf("%s.yaml", gvk.Version)),
+			out:   filepath.Join(afterDir, outFilename),
 			codec: codec,
 		})
 	}


### PR DESCRIPTION
Signed-off-by: Jian Zeng <zengjian.zj@bytedance.com>

#### What type of PR is this?

/kind cleanup
/kind failing-test

#### What this PR does / why we need it:

The failing test `TestDefaultsYAML` on non-linux OS is caused by the different default `EvictionHard` on different OS:
* linux: https://github.com/kubernetes/kubernetes/blob/master/pkg/kubelet/apis/config/v1beta1/defaults_linux.go#L22
* others: https://github.com/kubernetes/kubernetes/blob/master/pkg/kubelet/apis/config/v1beta1/defaults_others.go#L22

This PR adds separate YAML files for non-linux test to match the different default `EvictionHard`.

#### Which issue(s) this PR fixes:

Fixes #73853

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
