### PR TITLE
replace ioutil.TempDir by os.MkdirTemp

### DIFF
--- a/cluster/gce/gci/audit_policy_test.go
+++ b/cluster/gce/gci/audit_policy_test.go
@@ -18,7 +18,7 @@ package gci
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -40,7 +40,7 @@ func init() {
 }
 
 func TestCreateMasterAuditPolicy(t *testing.T) {
-	baseDir, err := ioutil.TempDir("", "configure-helper-test") // cleaned up by c.tearDown()
+	baseDir, err := os.MkdirTemp("", "configure-helper-test") // cleaned up by c.tearDown()
 	require.NoError(t, err, "Failed to create temp directory")
 
 	policyFile := filepath.Join(baseDir, "audit_policy.yaml")

--- a/cluster/gce/gci/configure_helper_test.go
+++ b/cluster/gce/gci/configure_helper_test.go
@@ -56,7 +56,7 @@ func newManifestTestCase(t *testing.T, manifest, funcName string, auxManifests [
 		manifestFuncName: funcName,
 	}
 
-	d, err := ioutil.TempDir("", "configure-helper-test")
+	d, err := os.MkdirTemp("", "configure-helper-test")
 	if err != nil {
 		c.t.Fatalf("Failed to create temp directory: %v", err)
 	}

--- a/cluster/images/etcd/migrate/data_dir_test.go
+++ b/cluster/images/etcd/migrate/data_dir_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package main
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -156,7 +155,7 @@ func TestBackup(t *testing.T) {
 }
 
 func newTestPath(t *testing.T) string {
-	path, err := ioutil.TempDir("", "etcd-migrate-test-")
+	path, err := os.MkdirTemp("", "etcd-migrate-test-")
 	if err != nil {
 		t.Fatalf("Failed to create tmp dir for test: %v", err)
 	}

--- a/cmd/kube-apiserver/app/testing/testserver.go
+++ b/cmd/kube-apiserver/app/testing/testserver.go
@@ -127,7 +127,7 @@ func StartTestServer(t Logger, instanceOptions *TestServerInstanceOptions, custo
 		}
 	}()
 
-	result.TmpDir, err = ioutil.TempDir("", "kubernetes-kube-apiserver")
+	result.TmpDir, err = os.MkdirTemp("", "kubernetes-kube-apiserver")
 	if err != nil {
 		return result, fmt.Errorf("failed to create temp dir: %v", err)
 	}

--- a/cmd/kube-controller-manager/app/testing/testserver.go
+++ b/cmd/kube-controller-manager/app/testing/testserver.go
@@ -19,7 +19,6 @@ package testing
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"os"
 	"time"
@@ -73,7 +72,7 @@ func StartTestServer(t Logger, customFlags []string) (result TestServer, err err
 		}
 	}()
 
-	result.TmpDir, err = ioutil.TempDir("", "kube-controller-manager")
+	result.TmpDir, err = os.MkdirTemp("", "kube-controller-manager")
 	if err != nil {
 		return result, fmt.Errorf("failed to create temp dir: %v", err)
 	}

--- a/cmd/kube-proxy/app/server_test.go
+++ b/cmd/kube-proxy/app/server_test.go
@@ -19,7 +19,6 @@ package app
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -406,7 +405,7 @@ func TestProcessHostnameOverrideFlag(t *testing.T) {
 
 func TestConfigChange(t *testing.T) {
 	setUp := func() (*os.File, string, error) {
-		tempDir, err := ioutil.TempDir("", "kubeproxy-config-change")
+		tempDir, err := os.MkdirTemp("", "kubeproxy-config-change")
 		if err != nil {
 			return nil, "", fmt.Errorf("unable to create temporary directory: %v", err)
 		}

--- a/cmd/kube-scheduler/app/options/options_test.go
+++ b/cmd/kube-scheduler/app/options/options_test.go
@@ -46,7 +46,7 @@ import (
 
 func TestSchedulerOptions(t *testing.T) {
 	// temp dir
-	tmpDir, err := ioutil.TempDir("", "scheduler-options")
+	tmpDir, err := os.MkdirTemp("", "scheduler-options")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/kube-scheduler/app/server_test.go
+++ b/cmd/kube-scheduler/app/server_test.go
@@ -36,7 +36,7 @@ import (
 
 func TestSetup(t *testing.T) {
 	// temp dir
-	tmpDir, err := ioutil.TempDir("", "scheduler-options")
+	tmpDir, err := os.MkdirTemp("", "scheduler-options")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/kube-scheduler/app/testing/testserver.go
+++ b/cmd/kube-scheduler/app/testing/testserver.go
@@ -19,7 +19,6 @@ package testing
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"os"
 	"time"
@@ -75,7 +74,7 @@ func StartTestServer(t Logger, customFlags []string) (result TestServer, err err
 		}
 	}()
 
-	result.TmpDir, err = ioutil.TempDir("", "kube-scheduler")
+	result.TmpDir, err = os.MkdirTemp("", "kube-scheduler")
 	if err != nil {
 		return result, fmt.Errorf("failed to create temp dir: %v", err)
 	}

--- a/cmd/kubeadm/app/cmd/config_test.go
+++ b/cmd/kubeadm/app/cmd/config_test.go
@@ -111,7 +111,7 @@ func TestImagesListRunWithCustomConfigPath(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
-			tmpDir, err := ioutil.TempDir("", "kubeadm-images-test")
+			tmpDir, err := os.MkdirTemp("", "kubeadm-images-test")
 			if err != nil {
 				t.Fatalf("Unable to create temporary directory: %v", err)
 			}
@@ -413,7 +413,7 @@ func TestMigrate(t *testing.T) {
 // Returns the name of the file created and a cleanup callback
 func tempConfig(t *testing.T, config []byte) (string, func()) {
 	t.Helper()
-	tmpDir, err := ioutil.TempDir("", "kubeadm-migration-test")
+	tmpDir, err := os.MkdirTemp("", "kubeadm-migration-test")
 	if err != nil {
 		t.Fatalf("Unable to create temporary directory: %v", err)
 	}

--- a/cmd/kubeadm/app/cmd/init_test.go
+++ b/cmd/kubeadm/app/cmd/init_test.go
@@ -18,7 +18,6 @@ package cmd
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -50,7 +49,7 @@ controlPlaneEndpoint: "3.4.5.6"
 
 func TestNewInitData(t *testing.T) {
 	// create temp directory
-	tmpDir, err := ioutil.TempDir("", "kubeadm-init-test")
+	tmpDir, err := os.MkdirTemp("", "kubeadm-init-test")
 	if err != nil {
 		t.Errorf("Unable to create temporary directory: %v", err)
 	}

--- a/cmd/kubeadm/app/cmd/join_test.go
+++ b/cmd/kubeadm/app/cmd/join_test.go
@@ -18,7 +18,6 @@ package cmd
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -47,7 +46,7 @@ nodeRegistration:
 
 func TestNewJoinData(t *testing.T) {
 	// create temp directory
-	tmpDir, err := ioutil.TempDir("", "kubeadm-join-test")
+	tmpDir, err := os.MkdirTemp("", "kubeadm-join-test")
 	if err != nil {
 		t.Errorf("Unable to create temporary directory: %v", err)
 	}

--- a/cmd/kubeadm/app/cmd/phases/reset/cleanupnode_test.go
+++ b/cmd/kubeadm/app/cmd/phases/reset/cleanupnode_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package phases
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -150,7 +149,7 @@ func TestConfigDirCleaner(t *testing.T) {
 			t.Logf("Running test: %s", name)
 
 			// Create a temporary directory for our fake config dir:
-			tmpDir, err := ioutil.TempDir("", "kubeadm-reset-test")
+			tmpDir, err := os.MkdirTemp("", "kubeadm-reset-test")
 			if err != nil {
 				t.Errorf("Unable to create temporary directory: %s", err)
 			}

--- a/cmd/kubeadm/app/cmd/token_test.go
+++ b/cmd/kubeadm/app/cmd/token_test.go
@@ -18,7 +18,6 @@ package cmd
 
 import (
 	"bytes"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -201,7 +200,7 @@ func TestNewCmdToken(t *testing.T) {
 	var buf, bufErr bytes.Buffer
 	testConfigTokenFile := "test-config-file"
 
-	tmpDir, err := ioutil.TempDir("", "kubeadm-token-test")
+	tmpDir, err := os.MkdirTemp("", "kubeadm-token-test")
 	if err != nil {
 		t.Errorf("Unable to create temporary directory: %v", err)
 	}
@@ -269,7 +268,7 @@ func TestNewCmdToken(t *testing.T) {
 func TestGetClientset(t *testing.T) {
 	testConfigTokenFile := "test-config-file"
 
-	tmpDir, err := ioutil.TempDir("", "kubeadm-token-test")
+	tmpDir, err := os.MkdirTemp("", "kubeadm-token-test")
 	if err != nil {
 		t.Errorf("Unable to create temporary directory: %v", err)
 	}
@@ -305,7 +304,7 @@ func TestGetClientset(t *testing.T) {
 func TestRunDeleteTokens(t *testing.T) {
 	var buf bytes.Buffer
 
-	tmpDir, err := ioutil.TempDir("", "kubeadm-token-test")
+	tmpDir, err := os.MkdirTemp("", "kubeadm-token-test")
 	if err != nil {
 		t.Errorf("Unable to create temporary directory: %v", err)
 	}

--- a/cmd/kubeadm/app/constants/constants.go
+++ b/cmd/kubeadm/app/constants/constants.go
@@ -18,7 +18,6 @@ package constants
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net"
 	"os"
 	"path"
@@ -598,7 +597,7 @@ func CreateTempDirForKubeadm(kubernetesDir, dirName string) (string, error) {
 		return "", errors.Wrapf(err, "failed to create directory %q", tempDir)
 	}
 
-	tempDir, err := ioutil.TempDir(tempDir, dirName)
+	tempDir, err := os.MkdirTemp(tempDir, dirName)
 	if err != nil {
 		return "", errors.Wrap(err, "couldn't create a temporary directory")
 	}

--- a/cmd/kubeadm/app/phases/certs/certlist_test.go
+++ b/cmd/kubeadm/app/phases/certs/certlist_test.go
@@ -20,7 +20,6 @@ import (
 	"crypto"
 	"crypto/tls"
 	"crypto/x509"
-	"io/ioutil"
 	"os"
 	"path"
 	"testing"
@@ -145,7 +144,7 @@ func TestMakeCertTree(t *testing.T) {
 }
 
 func TestCreateCertificateChain(t *testing.T) {
-	dir, err := ioutil.TempDir("", t.Name())
+	dir, err := os.MkdirTemp("", t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/kubeadm/app/phases/controlplane/volumes_test.go
+++ b/cmd/kubeadm/app/phases/controlplane/volumes_test.go
@@ -18,7 +18,6 @@ package controlplane
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"reflect"
 	"testing"
@@ -507,7 +506,7 @@ func TestGetHostPathVolumesForTheControlPlane(t *testing.T) {
 		},
 	}
 
-	tmpdir, err := ioutil.TempDir("", "")
+	tmpdir, err := os.MkdirTemp("", "")
 	if err != nil {
 		t.Fatalf("Couldn't create tmpdir")
 	}

--- a/cmd/kubeadm/app/phases/upgrade/compute_test.go
+++ b/cmd/kubeadm/app/phases/upgrade/compute_test.go
@@ -643,7 +643,7 @@ func TestGetAvailableUpgrades(t *testing.T) {
 				},
 			})
 
-			manifestsDir, err := ioutil.TempDir("", "GetAvailableUpgrades-test-manifests")
+			manifestsDir, err := os.MkdirTemp("", "GetAvailableUpgrades-test-manifests")
 			if err != nil {
 				t.Fatalf("Unable to create temporary directory: %v", err)
 			}

--- a/cmd/kubeadm/app/phases/upgrade/staticpods_test.go
+++ b/cmd/kubeadm/app/phases/upgrade/staticpods_test.go
@@ -154,7 +154,7 @@ type fakeStaticPodPathManager struct {
 }
 
 func NewFakeStaticPodPathManager(moveFileFunc func(string, string) error) (StaticPodPathManager, error) {
-	kubernetesDir, err := ioutil.TempDir("", "kubeadm-pathmanager-")
+	kubernetesDir, err := os.MkdirTemp("", "kubeadm-pathmanager-")
 	if err != nil {
 		return nil, errors.Wrapf(err, "couldn't create a temporary directory for the upgrade")
 	}
@@ -453,12 +453,12 @@ func TestStaticPodControlPlane(t *testing.T) {
 			defer os.RemoveAll(pathMgr.(*fakeStaticPodPathManager).KubernetesDir())
 			tmpKubernetesDir := pathMgr.(*fakeStaticPodPathManager).KubernetesDir()
 
-			tempCertsDir, err := ioutil.TempDir("", "kubeadm-certs")
+			tempCertsDir, err := os.MkdirTemp("", "kubeadm-certs")
 			if err != nil {
 				t.Fatalf("couldn't create temporary certificates directory: %v", err)
 			}
 			defer os.RemoveAll(tempCertsDir)
-			tmpEtcdDataDir, err := ioutil.TempDir("", "kubeadm-etcd-data")
+			tmpEtcdDataDir, err := os.MkdirTemp("", "kubeadm-etcd-data")
 			if err != nil {
 				t.Fatalf("couldn't create temporary etcd data directory: %v", err)
 			}
@@ -589,7 +589,7 @@ func getConfig(version, certsDir, etcdDataDir string) (*kubeadmapi.InitConfigura
 }
 
 func getTempDir(t *testing.T, name string) (string, func()) {
-	dir, err := ioutil.TempDir(os.TempDir(), name)
+	dir, err := os.MkdirTemp(os.TempDir(), name)
 	if err != nil {
 		t.Fatalf("couldn't make temporary directory: %v", err)
 	}
@@ -942,7 +942,7 @@ func TestGetPathManagerForUpgrade(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			// Use a temporary directory
-			tmpdir, err := ioutil.TempDir("", "TestGetPathManagerForUpgrade")
+			tmpdir, err := os.MkdirTemp("", "TestGetPathManagerForUpgrade")
 			if err != nil {
 				t.Fatalf("unexpected error making temporary directory: %v", err)
 			}
@@ -1000,7 +1000,7 @@ spec:
   - name: etcd
     image: k8s.gcr.io/etcd:` + expectedEtcdVersion
 
-	manifestsDir, err := ioutil.TempDir("", "GetEtcdImageTagFromStaticPod-test-manifests")
+	manifestsDir, err := os.MkdirTemp("", "GetEtcdImageTagFromStaticPod-test-manifests")
 	if err != nil {
 		t.Fatalf("Unable to create temporary directory: %v", err)
 	}

--- a/cmd/kubeadm/app/preflight/checks_test.go
+++ b/cmd/kubeadm/app/preflight/checks_test.go
@@ -335,7 +335,7 @@ func TestFileContentCheck(t *testing.T) {
 }
 
 func TestDirAvailableCheck(t *testing.T) {
-	fileDir, err := ioutil.TempDir("", "dir-avail-check")
+	fileDir, err := os.MkdirTemp("", "dir-avail-check")
 	if err != nil {
 		t.Fatalf("failed creating directory: %v", err)
 	}

--- a/cmd/kubeadm/app/util/config/cluster_test.go
+++ b/cmd/kubeadm/app/util/config/cluster_test.go
@@ -199,7 +199,7 @@ G+2/lm8TaVjoU7Fi5Ka5G5HY2GLaR7P+IxYcrMHCl62Y7Rqcrnc=
 }
 
 func TestGetNodeNameFromKubeletConfig(t *testing.T) {
-	tmpdir, err := ioutil.TempDir("", "")
+	tmpdir, err := os.MkdirTemp("", "")
 	if err != nil {
 		t.Fatalf("Couldn't create tmpdir")
 	}
@@ -278,7 +278,7 @@ func TestGetNodeNameFromKubeletConfig(t *testing.T) {
 }
 
 func TestGetNodeRegistration(t *testing.T) {
-	tmpdir, err := ioutil.TempDir("", "")
+	tmpdir, err := os.MkdirTemp("", "")
 	if err != nil {
 		t.Fatalf("Couldn't create tmpdir")
 	}
@@ -491,7 +491,7 @@ func TestGetAPIEndpointWithBackoff(t *testing.T) {
 }
 
 func TestGetInitConfigurationFromCluster(t *testing.T) {
-	tmpdir, err := ioutil.TempDir("", "")
+	tmpdir, err := os.MkdirTemp("", "")
 	if err != nil {
 		t.Fatalf("Couldn't create tmpdir")
 	}

--- a/cmd/kubeadm/app/util/config/initconfiguration_test.go
+++ b/cmd/kubeadm/app/util/config/initconfiguration_test.go
@@ -33,7 +33,7 @@ import (
 
 func TestLoadInitConfigurationFromFile(t *testing.T) {
 	// Create temp folder for the test case
-	tmpdir, err := ioutil.TempDir("", "")
+	tmpdir, err := os.MkdirTemp("", "")
 	if err != nil {
 		t.Fatalf("Couldn't create tmpdir: %v", err)
 	}

--- a/cmd/kubeadm/app/util/config/joinconfiguration_test.go
+++ b/cmd/kubeadm/app/util/config/joinconfiguration_test.go
@@ -30,7 +30,7 @@ import (
 
 func TestLoadJoinConfigurationFromFile(t *testing.T) {
 	// Create temp folder for the test case
-	tmpdir, err := ioutil.TempDir("", "")
+	tmpdir, err := os.MkdirTemp("", "")
 	if err != nil {
 		t.Fatalf("Couldn't create tmpdir: %v", err)
 	}

--- a/cmd/kubeadm/app/util/kubeconfig/kubeconfig_test.go
+++ b/cmd/kubeadm/app/util/kubeconfig/kubeconfig_test.go
@@ -143,7 +143,7 @@ func TestCreateWithToken(t *testing.T) {
 }
 
 func TestWriteKubeconfigToDisk(t *testing.T) {
-	tmpdir, err := ioutil.TempDir("", "")
+	tmpdir, err := os.MkdirTemp("", "")
 	if err != nil {
 		t.Fatalf("Couldn't create tmpdir")
 	}

--- a/cmd/kubeadm/app/util/patches/patches_test.go
+++ b/cmd/kubeadm/app/util/patches/patches_test.go
@@ -233,7 +233,7 @@ func TestGetPatchSetsForPath(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			tempDir, err := ioutil.TempDir("", testDirPattern)
+			tempDir, err := os.MkdirTemp("", testDirPattern)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -361,7 +361,7 @@ func TestGetPatchManagerForPath(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			tempDir, err := ioutil.TempDir("", testDirPattern)
+			tempDir, err := os.MkdirTemp("", testDirPattern)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -396,7 +396,7 @@ func TestGetPatchManagerForPath(t *testing.T) {
 }
 
 func TestGetPatchManagerForPathCache(t *testing.T) {
-	tempDir, err := ioutil.TempDir("", testDirPattern)
+	tempDir, err := os.MkdirTemp("", testDirPattern)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/kubeadm/app/util/pkiutil/pki_helpers_test.go
+++ b/cmd/kubeadm/app/util/pkiutil/pki_helpers_test.go
@@ -23,7 +23,6 @@ import (
 	"crypto/rand"
 	"crypto/x509"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"os"
 	"reflect"
@@ -175,7 +174,7 @@ func TestHasServerAuth(t *testing.T) {
 }
 
 func TestWriteCertAndKey(t *testing.T) {
-	tmpdir, err := ioutil.TempDir("", "")
+	tmpdir, err := os.MkdirTemp("", "")
 	if err != nil {
 		t.Fatalf("Couldn't create tmpdir")
 	}
@@ -192,7 +191,7 @@ func TestWriteCertAndKey(t *testing.T) {
 }
 
 func TestWriteCert(t *testing.T) {
-	tmpdir, err := ioutil.TempDir("", "")
+	tmpdir, err := os.MkdirTemp("", "")
 	if err != nil {
 		t.Fatalf("Couldn't create tmpdir")
 	}
@@ -209,7 +208,7 @@ func TestWriteCert(t *testing.T) {
 }
 
 func TestWriteCertBundle(t *testing.T) {
-	tmpdir, err := ioutil.TempDir("", "")
+	tmpdir, err := os.MkdirTemp("", "")
 	if err != nil {
 		t.Fatalf("Couldn't create tmpdir")
 	}
@@ -224,7 +223,7 @@ func TestWriteCertBundle(t *testing.T) {
 }
 
 func TestWriteKey(t *testing.T) {
-	tmpdir, err := ioutil.TempDir("", "")
+	tmpdir, err := os.MkdirTemp("", "")
 	if err != nil {
 		t.Fatalf("Couldn't create tmpdir")
 	}
@@ -240,7 +239,7 @@ func TestWriteKey(t *testing.T) {
 }
 
 func TestWritePublicKey(t *testing.T) {
-	tmpdir, err := ioutil.TempDir("", "")
+	tmpdir, err := os.MkdirTemp("", "")
 	if err != nil {
 		t.Fatalf("Couldn't create tmpdir")
 	}
@@ -256,7 +255,7 @@ func TestWritePublicKey(t *testing.T) {
 }
 
 func TestCertOrKeyExist(t *testing.T) {
-	tmpdir, err := ioutil.TempDir("", "")
+	tmpdir, err := os.MkdirTemp("", "")
 	if err != nil {
 		t.Fatalf("Couldn't create tmpdir")
 	}
@@ -305,7 +304,7 @@ func TestCertOrKeyExist(t *testing.T) {
 }
 
 func TestTryLoadCertAndKeyFromDisk(t *testing.T) {
-	tmpdir, err := ioutil.TempDir("", "")
+	tmpdir, err := os.MkdirTemp("", "")
 	if err != nil {
 		t.Fatalf("Couldn't create tmpdir")
 	}
@@ -353,7 +352,7 @@ func TestTryLoadCertAndKeyFromDisk(t *testing.T) {
 }
 
 func TestTryLoadCertFromDisk(t *testing.T) {
-	tmpdir, err := ioutil.TempDir("", "")
+	tmpdir, err := os.MkdirTemp("", "")
 	if err != nil {
 		t.Fatalf("Couldn't create tmpdir")
 	}
@@ -401,7 +400,7 @@ func TestTryLoadCertFromDisk(t *testing.T) {
 }
 
 func TestTryLoadCertChainFromDisk(t *testing.T) {
-	tmpdir, err := ioutil.TempDir("", "")
+	tmpdir, err := os.MkdirTemp("", "")
 	if err != nil {
 		t.Fatalf("Couldn't create tmpdir")
 	}
@@ -501,7 +500,7 @@ func TestTryLoadKeyFromDisk(t *testing.T) {
 	}
 	for _, rt := range tests {
 		t.Run(rt.desc, func(t *testing.T) {
-			tmpdir, err := ioutil.TempDir("", "")
+			tmpdir, err := os.MkdirTemp("", "")
 			if err != nil {
 				t.Fatalf("Couldn't create tmpdir")
 			}
@@ -848,7 +847,7 @@ func TestRemoveDuplicateAltNames(t *testing.T) {
 }
 
 func TestVerifyCertChain(t *testing.T) {
-	tmpdir, err := ioutil.TempDir("", "")
+	tmpdir, err := os.MkdirTemp("", "")
 	if err != nil {
 		t.Fatalf("Couldn't create tmpdir")
 	}

--- a/cmd/kubeadm/app/util/staticpod/utils_test.go
+++ b/cmd/kubeadm/app/util/staticpod/utils_test.go
@@ -812,7 +812,7 @@ func TestPatchStaticPod(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			tempDir, err := ioutil.TempDir("", "patch-files")
+			tempDir, err := os.MkdirTemp("", "patch-files")
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/cmd/kubeadm/test/util.go
+++ b/cmd/kubeadm/test/util.go
@@ -32,7 +32,7 @@ import (
 // SetupTempDir is a utility function for kubeadm testing, that creates a temporary directory
 // NB. it is up to the caller to cleanup the folder at the end of the test with defer os.RemoveAll(tmpdir)
 func SetupTempDir(t *testing.T) string {
-	tmpdir, err := ioutil.TempDir("", "")
+	tmpdir, err := os.MkdirTemp("", "")
 	if err != nil {
 		t.Fatalf("Couldn't create tmpdir")
 	}

--- a/cmd/kubelet/app/server_bootstrap_test.go
+++ b/cmd/kubelet/app/server_bootstrap_test.go
@@ -48,7 +48,7 @@ import (
 // manager that will use the bootstrap client until we get a valid cert, then use our
 // provided identity on subsequent requests.
 func Test_buildClientCertificateManager(t *testing.T) {
-	testDir, err := ioutil.TempDir("", "kubeletcert")
+	testDir, err := os.MkdirTemp("", "kubeletcert")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -134,7 +134,7 @@ func Test_buildClientCertificateManager(t *testing.T) {
 }
 
 func Test_buildClientCertificateManager_populateCertDir(t *testing.T) {
-	testDir, err := ioutil.TempDir("", "kubeletcert")
+	testDir, err := os.MkdirTemp("", "kubeletcert")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/credentialprovider/config_test.go
+++ b/pkg/credentialprovider/config_test.go
@@ -19,7 +19,6 @@ package credentialprovider
 import (
 	"encoding/base64"
 	"encoding/json"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -33,7 +32,7 @@ func TestReadDockerConfigFile(t *testing.T) {
 	//test dockerconfig json
 	inputDockerconfigJSONFile := "{ \"auths\": { \"http://foo.example.com\":{\"auth\":\"Zm9vOmJhcgo=\",\"email\":\"foo@example.com\"}}}"
 
-	preferredPath, err := ioutil.TempDir("", "test_foo_bar_dockerconfigjson_")
+	preferredPath, err := os.MkdirTemp("", "test_foo_bar_dockerconfigjson_")
 	if err != nil {
 		t.Fatalf("Creating tmp dir fail: %v", err)
 		return

--- a/pkg/kubelet/certificate/bootstrap/bootstrap_test.go
+++ b/pkg/kubelet/certificate/bootstrap/bootstrap_test.go
@@ -184,7 +184,7 @@ users:
 	}
 	ioutil.WriteFile(fileboot.Name(), testDatabootstrap, os.FileMode(0755))
 
-	dir, err := ioutil.TempDir(fileDir, "k8s-test-certstore-current")
+	dir, err := os.MkdirTemp(fileDir, "k8s-test-certstore-current")
 	if err != nil {
 		t.Fatalf("Unable to create the test directory %q: %v", dir, err)
 	}

--- a/pkg/kubelet/cm/container_manager_linux_test.go
+++ b/pkg/kubelet/cm/container_manager_linux_test.go
@@ -137,7 +137,7 @@ func TestSoftRequirementsValidationSuccess(t *testing.T) {
 		t.Skip("skipping cgroup v1 test on a cgroup v2 system")
 	}
 	req := require.New(t)
-	tempDir, err := ioutil.TempDir("", "")
+	tempDir, err := os.MkdirTemp("", "")
 	req.NoError(err)
 	defer os.RemoveAll(tempDir)
 	req.NoError(ioutil.WriteFile(path.Join(tempDir, "cpu.cfs_period_us"), []byte("0"), os.ModePerm))

--- a/pkg/kubelet/cm/cpumanager/cpu_manager_test.go
+++ b/pkg/kubelet/cm/cpumanager/cpu_manager_test.go
@@ -24,7 +24,6 @@ import (
 	"testing"
 	"time"
 
-	"io/ioutil"
 	"os"
 
 	cadvisorapi "github.com/google/cadvisor/info/v1"
@@ -629,7 +628,7 @@ func TestCPUManagerGenerate(t *testing.T) {
 			if testCase.isTopologyBroken {
 				machineInfo = &cadvisorapi.MachineInfo{}
 			}
-			sDir, err := ioutil.TempDir("/tmp/", "cpu_manager_test")
+			sDir, err := os.MkdirTemp("/tmp/", "cpu_manager_test")
 			if err != nil {
 				t.Errorf("cannot create state file: %s", err.Error())
 			}
@@ -1112,7 +1111,7 @@ func TestCPUManagerHandlePolicyOptions(t *testing.T) {
 		t.Run(testCase.description, func(t *testing.T) {
 			machineInfo := &mockedMachineInfo
 			nodeAllocatableReservation := v1.ResourceList{}
-			sDir, err := ioutil.TempDir("/tmp/", "cpu_manager_test")
+			sDir, err := os.MkdirTemp("/tmp/", "cpu_manager_test")
 			if err != nil {
 				t.Errorf("cannot create state file: %s", err.Error())
 			}

--- a/pkg/kubelet/cm/cpumanager/state/state_checkpoint_test.go
+++ b/pkg/kubelet/cm/cpumanager/state/state_checkpoint_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package state
 
 import (
-	"io/ioutil"
 	"os"
 	"reflect"
 	"strings"
@@ -200,7 +199,7 @@ func TestCheckpointStateRestore(t *testing.T) {
 	}
 
 	// create temp dir
-	testingDir, err := ioutil.TempDir("", "cpumanager_state_test")
+	testingDir, err := os.MkdirTemp("", "cpumanager_state_test")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -264,7 +263,7 @@ func TestCheckpointStateStore(t *testing.T) {
 	}
 
 	// create temp dir
-	testingDir, err := ioutil.TempDir("", "cpumanager_state_test")
+	testingDir, err := os.MkdirTemp("", "cpumanager_state_test")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -337,7 +336,7 @@ func TestCheckpointStateHelpers(t *testing.T) {
 	}
 
 	// create temp dir
-	testingDir, err := ioutil.TempDir("", "cpumanager_state_test")
+	testingDir, err := os.MkdirTemp("", "cpumanager_state_test")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -396,7 +395,7 @@ func TestCheckpointStateClear(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.description, func(t *testing.T) {
 			// create temp dir
-			testingDir, err := ioutil.TempDir("", "cpumanager_state_test")
+			testingDir, err := os.MkdirTemp("", "cpumanager_state_test")
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/kubelet/cm/devicemanager/manager_test.go
+++ b/pkg/kubelet/cm/devicemanager/manager_test.go
@@ -18,7 +18,6 @@ package devicemanager
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -52,7 +51,7 @@ const (
 )
 
 func tmpSocketDir() (socketDir, socketName, pluginSocketName string, err error) {
-	socketDir, err = ioutil.TempDir("", "device_plugin")
+	socketDir, err = os.MkdirTemp("", "device_plugin")
 	if err != nil {
 		return
 	}
@@ -469,7 +468,7 @@ func TestCheckpoint(t *testing.T) {
 	resourceName1 := "domain1.com/resource1"
 	resourceName2 := "domain2.com/resource2"
 	as := assert.New(t)
-	tmpDir, err := ioutil.TempDir("", "checkpoint")
+	tmpDir, err := os.MkdirTemp("", "checkpoint")
 	as.Nil(err)
 	defer os.RemoveAll(tmpDir)
 	ckm, err := checkpointmanager.NewCheckpointManager(tmpDir)
@@ -778,7 +777,7 @@ func TestPodContainerDeviceAllocation(t *testing.T) {
 	podsStub := activePodsStub{
 		activePods: []*v1.Pod{},
 	}
-	tmpDir, err := ioutil.TempDir("", "checkpoint")
+	tmpDir, err := os.MkdirTemp("", "checkpoint")
 	as.Nil(err)
 	defer os.RemoveAll(tmpDir)
 	testManager, err := getTestManager(tmpDir, podsStub.getActivePods, testResources)
@@ -876,7 +875,7 @@ func TestInitContainerDeviceAllocation(t *testing.T) {
 	podsStub := activePodsStub{
 		activePods: []*v1.Pod{},
 	}
-	tmpDir, err := ioutil.TempDir("", "checkpoint")
+	tmpDir, err := os.MkdirTemp("", "checkpoint")
 	as.Nil(err)
 	defer os.RemoveAll(tmpDir)
 
@@ -967,7 +966,7 @@ func TestUpdatePluginResources(t *testing.T) {
 
 	as := assert.New(t)
 	monitorCallback := func(resourceName string, devices []pluginapi.Device) {}
-	tmpDir, err := ioutil.TempDir("", "checkpoint")
+	tmpDir, err := os.MkdirTemp("", "checkpoint")
 	as.Nil(err)
 	defer os.RemoveAll(tmpDir)
 
@@ -1022,7 +1021,7 @@ func TestDevicePreStartContainer(t *testing.T) {
 	podsStub := activePodsStub{
 		activePods: []*v1.Pod{},
 	}
-	tmpDir, err := ioutil.TempDir("", "checkpoint")
+	tmpDir, err := os.MkdirTemp("", "checkpoint")
 	as.Nil(err)
 	defer os.RemoveAll(tmpDir)
 
@@ -1084,7 +1083,7 @@ func TestDevicePreStartContainer(t *testing.T) {
 
 func TestResetExtendedResource(t *testing.T) {
 	as := assert.New(t)
-	tmpDir, err := ioutil.TempDir("", "checkpoint")
+	tmpDir, err := os.MkdirTemp("", "checkpoint")
 	as.Nil(err)
 	defer os.RemoveAll(tmpDir)
 	ckm, err := checkpointmanager.NewCheckpointManager(tmpDir)

--- a/pkg/kubelet/cm/memorymanager/memory_manager_test.go
+++ b/pkg/kubelet/cm/memorymanager/memory_manager_test.go
@@ -18,7 +18,6 @@ package memorymanager
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"reflect"
 	"strings"
@@ -1982,7 +1981,7 @@ func TestNewManager(t *testing.T) {
 	}
 	for _, testCase := range testCases {
 		t.Run(testCase.description, func(t *testing.T) {
-			stateFileDirectory, err := ioutil.TempDir("/tmp/", "memory_manager_tests")
+			stateFileDirectory, err := os.MkdirTemp("/tmp/", "memory_manager_tests")
 			if err != nil {
 				t.Errorf("Cannot create state file: %s", err.Error())
 			}

--- a/pkg/kubelet/cm/memorymanager/state/state_checkpoint_test.go
+++ b/pkg/kubelet/cm/memorymanager/state/state_checkpoint_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package state
 
 import (
-	"io/ioutil"
 	"os"
 	"strings"
 	"testing"
@@ -111,7 +110,7 @@ func TestCheckpointStateRestore(t *testing.T) {
 	}
 
 	// create temp dir
-	testingDir, err := ioutil.TempDir("", "memorymanager_state_test")
+	testingDir, err := os.MkdirTemp("", "memorymanager_state_test")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -174,7 +173,7 @@ func TestCheckpointStateStore(t *testing.T) {
 	}
 
 	// create temp dir
-	testingDir, err := ioutil.TempDir("", "memorymanager_state_test")
+	testingDir, err := os.MkdirTemp("", "memorymanager_state_test")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -293,7 +292,7 @@ func TestCheckpointStateHelpers(t *testing.T) {
 	}
 
 	// create temp dir
-	testingDir, err := ioutil.TempDir("", "memorymanager_state_test")
+	testingDir, err := os.MkdirTemp("", "memorymanager_state_test")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -362,7 +361,7 @@ func TestCheckpointStateClear(t *testing.T) {
 	}
 
 	// create temp dir
-	testingDir, err := ioutil.TempDir("", "memorymanager_state_test")
+	testingDir, err := os.MkdirTemp("", "memorymanager_state_test")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/kubelet/config/file_test.go
+++ b/pkg/kubelet/config/file_test.go
@@ -74,7 +74,7 @@ func TestExtractFromEmptyDir(t *testing.T) {
 }
 
 func mkTempDir(prefix string) (string, error) {
-	return ioutil.TempDir(os.TempDir(), prefix)
+	return os.MkdirTemp(os.TempDir(), prefix)
 }
 
 func removeAll(dir string, t *testing.T) {

--- a/pkg/kubelet/dockershim/helpers_linux_test.go
+++ b/pkg/kubelet/dockershim/helpers_linux_test.go
@@ -64,7 +64,7 @@ func TestGetSeccompSecurityOpts(t *testing.T) {
 }
 
 func TestLoadSeccompLocalhostProfiles(t *testing.T) {
-	tmpdir, err := ioutil.TempDir("", "seccomp-local-profile-test")
+	tmpdir, err := os.MkdirTemp("", "seccomp-local-profile-test")
 	require.NoError(t, err)
 	defer os.RemoveAll(tmpdir)
 	testProfile := `{"foo": "bar"}`

--- a/pkg/kubelet/kubelet_pods_test.go
+++ b/pkg/kubelet/kubelet_pods_test.go
@@ -241,7 +241,7 @@ fe00::2	ip6-allrouters
 // writeHostsFile will write a hosts file into a temporary dir, and return that dir.
 // Caller is responsible for deleting the dir and its contents.
 func writeHostsFile(filename string, cfg string) (string, error) {
-	tmpdir, err := ioutil.TempDir("", "kubelet=kubelet_pods_test.go=")
+	tmpdir, err := os.MkdirTemp("", "kubelet=kubelet_pods_test.go=")
 	if err != nil {
 		return "", err
 	}

--- a/pkg/kubelet/kubelet_test.go
+++ b/pkg/kubelet/kubelet_test.go
@@ -19,7 +19,6 @@ package kubelet
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"reflect"
 	"sort"
@@ -177,7 +176,7 @@ func newTestKubeletWithImageList(
 	kubelet.nodeName = types.NodeName(testKubeletHostname)
 	kubelet.runtimeState = newRuntimeState(maxWaitForContainerRuntime)
 	kubelet.runtimeState.setNetworkState(nil)
-	if tempDir, err := ioutil.TempDir("", "kubelet_test."); err != nil {
+	if tempDir, err := os.MkdirTemp("", "kubelet_test."); err != nil {
 		t.Fatalf("can't make a temp rootdir: %v", err)
 	} else {
 		kubelet.rootDirectory = tempDir

--- a/pkg/kubelet/kuberuntime/kuberuntime_container_test.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_container_test.go
@@ -455,7 +455,7 @@ func TestRestartCountByLogDir(t *testing.T) {
 			restartCount: 8,
 		},
 	} {
-		tempDirPath, err := ioutil.TempDir("", "test-restart-count-")
+		tempDirPath, err := os.MkdirTemp("", "test-restart-count-")
 		assert.NoError(t, err, "create tempdir error")
 		defer os.RemoveAll(tempDirPath)
 		for _, filename := range tc.filenames {

--- a/pkg/kubelet/logs/container_log_manager_test.go
+++ b/pkg/kubelet/logs/container_log_manager_test.go
@@ -36,7 +36,7 @@ import (
 )
 
 func TestGetAllLogs(t *testing.T) {
-	dir, err := ioutil.TempDir("", "test-get-all-logs")
+	dir, err := os.MkdirTemp("", "test-get-all-logs")
 	require.NoError(t, err)
 	defer os.RemoveAll(dir)
 	testLogs := []string{
@@ -75,7 +75,7 @@ func TestGetAllLogs(t *testing.T) {
 }
 
 func TestRotateLogs(t *testing.T) {
-	dir, err := ioutil.TempDir("", "test-rotate-logs")
+	dir, err := os.MkdirTemp("", "test-rotate-logs")
 	require.NoError(t, err)
 	defer os.RemoveAll(dir)
 
@@ -162,7 +162,7 @@ func TestRotateLogs(t *testing.T) {
 }
 
 func TestClean(t *testing.T) {
-	dir, err := ioutil.TempDir("", "test-clean")
+	dir, err := os.MkdirTemp("", "test-clean")
 	require.NoError(t, err)
 	defer os.RemoveAll(dir)
 
@@ -233,7 +233,7 @@ func TestClean(t *testing.T) {
 }
 
 func TestCleanupUnusedLog(t *testing.T) {
-	dir, err := ioutil.TempDir("", "test-cleanup-unused-log")
+	dir, err := os.MkdirTemp("", "test-cleanup-unused-log")
 	require.NoError(t, err)
 	defer os.RemoveAll(dir)
 
@@ -285,7 +285,7 @@ func TestRemoveExcessLog(t *testing.T) {
 		},
 	} {
 		t.Logf("TestCase %q", desc)
-		dir, err := ioutil.TempDir("", "test-remove-excess-log")
+		dir, err := os.MkdirTemp("", "test-remove-excess-log")
 		require.NoError(t, err)
 		defer os.RemoveAll(dir)
 
@@ -319,7 +319,7 @@ func TestRemoveExcessLog(t *testing.T) {
 }
 
 func TestCompressLog(t *testing.T) {
-	dir, err := ioutil.TempDir("", "test-compress-log")
+	dir, err := os.MkdirTemp("", "test-compress-log")
 	require.NoError(t, err)
 	defer os.RemoveAll(dir)
 
@@ -350,7 +350,7 @@ func TestCompressLog(t *testing.T) {
 }
 
 func TestRotateLatestLog(t *testing.T) {
-	dir, err := ioutil.TempDir("", "test-rotate-latest-log")
+	dir, err := os.MkdirTemp("", "test-rotate-latest-log")
 	require.NoError(t, err)
 	defer os.RemoveAll(dir)
 

--- a/pkg/kubelet/pluginmanager/operationexecutor/operation_executor_test.go
+++ b/pkg/kubelet/pluginmanager/operationexecutor/operation_executor_test.go
@@ -18,7 +18,7 @@ package operationexecutor
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strconv"
 	"testing"
 	"time"
@@ -35,7 +35,7 @@ var _ OperationGenerator = &fakeOperationGenerator{}
 var socketDir string
 
 func init() {
-	d, err := ioutil.TempDir("", "operation_executor_test")
+	d, err := os.MkdirTemp("", "operation_executor_test")
 	if err != nil {
 		panic(fmt.Sprintf("Could not create a temp directory: %s", d))
 	}

--- a/pkg/kubelet/pluginmanager/plugin_manager_test.go
+++ b/pkg/kubelet/pluginmanager/plugin_manager_test.go
@@ -18,7 +18,6 @@ package pluginmanager
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -81,7 +80,7 @@ func (f *fakePluginHandler) Reset() {
 }
 
 func init() {
-	d, err := ioutil.TempDir("", "plugin_manager_test")
+	d, err := os.MkdirTemp("", "plugin_manager_test")
 	if err != nil {
 		panic(fmt.Sprintf("Could not create a temp directory: %s", d))
 	}

--- a/pkg/kubelet/pluginmanager/pluginwatcher/plugin_watcher_test.go
+++ b/pkg/kubelet/pluginmanager/pluginwatcher/plugin_watcher_test.go
@@ -19,7 +19,6 @@ package pluginwatcher
 import (
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"sync"
 	"testing"
@@ -46,7 +45,7 @@ func init() {
 	flag.StringVar(&logLevel, "logLevel", "6", "test")
 	flag.Lookup("v").Value.Set(logLevel)
 
-	d, err := ioutil.TempDir("", "plugin_test")
+	d, err := os.MkdirTemp("", "plugin_test")
 	if err != nil {
 		panic(fmt.Sprintf("Could not create a temp directory: %s", d))
 	}

--- a/pkg/kubelet/pluginmanager/reconciler/reconciler_test.go
+++ b/pkg/kubelet/pluginmanager/reconciler/reconciler_test.go
@@ -18,7 +18,6 @@ package reconciler
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"testing"
 	"time"
@@ -44,7 +43,7 @@ var (
 )
 
 func init() {
-	d, err := ioutil.TempDir("", "reconciler_test")
+	d, err := os.MkdirTemp("", "reconciler_test")
 	if err != nil {
 		panic(fmt.Sprintf("Could not create a temp directory: %s", d))
 	}

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -1138,7 +1138,7 @@ func TestSchedulerWithVolumeBinding(t *testing.T) {
 }
 
 func TestInitPolicyFromFile(t *testing.T) {
-	dir, err := ioutil.TempDir(os.TempDir(), "policy")
+	dir, err := os.MkdirTemp(os.TempDir(), "policy")
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}

--- a/pkg/util/filesystem/defaultfs.go
+++ b/pkg/util/filesystem/defaultfs.go
@@ -33,7 +33,7 @@ var _ Filesystem = &DefaultFs{}
 
 // NewTempFs returns a fake Filesystem in temporary directory, useful for unit tests
 func NewTempFs() Filesystem {
-	path, _ := ioutil.TempDir(
+	path, _ := os.MkdirTemp(
 		"",
 		"tmpfs",
 	)
@@ -99,9 +99,9 @@ func (fs *DefaultFs) ReadFile(filename string) ([]byte, error) {
 	return ioutil.ReadFile(fs.prefix(filename))
 }
 
-// TempDir via ioutil.TempDir
+// TempDir via os.MkdirTemp
 func (fs *DefaultFs) TempDir(dir, prefix string) (string, error) {
-	return ioutil.TempDir(fs.prefix(dir), prefix)
+	return os.MkdirTemp(fs.prefix(dir), prefix)
 }
 
 // TempFile via ioutil.TempFile

--- a/pkg/volume/azure_file/azure_file_test.go
+++ b/pkg/volume/azure_file/azure_file_test.go
@@ -20,7 +20,6 @@ package azure_file
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -41,7 +40,7 @@ import (
 )
 
 func TestCanSupport(t *testing.T) {
-	tmpDir, err := ioutil.TempDir(os.TempDir(), "azureFileTest")
+	tmpDir, err := os.MkdirTemp(os.TempDir(), "azureFileTest")
 	if err != nil {
 		t.Fatalf("can't make a temp dir: %v", err)
 	}
@@ -65,7 +64,7 @@ func TestCanSupport(t *testing.T) {
 }
 
 func TestGetAccessModes(t *testing.T) {
-	tmpDir, err := ioutil.TempDir(os.TempDir(), "azureFileTest")
+	tmpDir, err := os.MkdirTemp(os.TempDir(), "azureFileTest")
 	if err != nil {
 		t.Fatalf("can't make a temp dir: %v", err)
 	}
@@ -96,7 +95,7 @@ func getAzureTestCloud(t *testing.T) *azure.Cloud {
 }
 
 func getTestTempDir(t *testing.T) string {
-	tmpDir, err := ioutil.TempDir(os.TempDir(), "azurefileTest")
+	tmpDir, err := os.MkdirTemp(os.TempDir(), "azurefileTest")
 	if err != nil {
 		t.Fatalf("can't make a temp dir: %v", err)
 	}
@@ -240,7 +239,7 @@ func (s *fakeAzureSvc) SetAzureCredentials(host volume.VolumeHost, nameSpace, ac
 }
 
 func TestMounterAndUnmounterTypeAssert(t *testing.T) {
-	tmpDir, err := ioutil.TempDir(os.TempDir(), "azurefileTest")
+	tmpDir, err := os.MkdirTemp(os.TempDir(), "azurefileTest")
 	if err != nil {
 		t.Fatalf("can't make a temp dir: %v", err)
 	}

--- a/pkg/volume/configmap/configmap_test.go
+++ b/pkg/volume/configmap/configmap_test.go
@@ -292,7 +292,7 @@ func TestMakePayload(t *testing.T) {
 }
 
 func newTestHost(t *testing.T, clientset clientset.Interface) (string, volume.VolumeHost) {
-	tempDir, err := ioutil.TempDir("/tmp", "configmap_volume_test.")
+	tempDir, err := os.MkdirTemp("/tmp", "configmap_volume_test.")
 	if err != nil {
 		t.Fatalf("can't make a temp rootdir: %v", err)
 	}

--- a/pkg/volume/csi/csi_mounter_test.go
+++ b/pkg/volume/csi/csi_mounter_test.go
@@ -19,7 +19,6 @@ package csi
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"math/rand"
 	"os"
 	"path"
@@ -950,7 +949,7 @@ func TestUnmounterTeardown(t *testing.T) {
 }
 
 func TestIsCorruptedDir(t *testing.T) {
-	existingMountPath, err := ioutil.TempDir(os.TempDir(), "blobfuse-csi-mount-test")
+	existingMountPath, err := os.MkdirTemp(os.TempDir(), "blobfuse-csi-mount-test")
 	if err != nil {
 		t.Fatalf("failed to create tmp dir: %v", err)
 	}

--- a/pkg/volume/emptydir/empty_dir_test.go
+++ b/pkg/volume/emptydir/empty_dir_test.go
@@ -20,7 +20,6 @@ package emptydir
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -633,7 +632,7 @@ func (md *testMountDetector) GetMountMedium(path string, requestedMedium v1.Stor
 }
 
 func TestSetupHugepages(t *testing.T) {
-	tmpdir, err := ioutil.TempDir("", "TestSetupHugepages")
+	tmpdir, err := os.MkdirTemp("", "TestSetupHugepages")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/volume/git_repo/git_repo_test.go
+++ b/pkg/volume/git_repo/git_repo_test.go
@@ -18,7 +18,6 @@ package git_repo
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -36,7 +35,7 @@ import (
 )
 
 func newTestHost(t *testing.T) (string, volume.VolumeHost) {
-	tempDir, err := ioutil.TempDir("/tmp", "git_repo_test.")
+	tempDir, err := os.MkdirTemp("/tmp", "git_repo_test.")
 	if err != nil {
 		t.Fatalf("can't make a temp rootdir: %v", err)
 	}

--- a/pkg/volume/iscsi/iscsi_util_test.go
+++ b/pkg/volume/iscsi/iscsi_util_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package iscsi
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -434,7 +433,7 @@ func TestGetVolCount(t *testing.T) {
 }
 
 func createFakePluginDirs() (string, error) {
-	dir, err := ioutil.TempDir("", "refcounter")
+	dir, err := os.MkdirTemp("", "refcounter")
 	if err != nil {
 		return "", err
 	}

--- a/pkg/volume/projected/projected_test.go
+++ b/pkg/volume/projected/projected_test.go
@@ -874,7 +874,7 @@ func TestCollectDataWithServiceAccountToken(t *testing.T) {
 }
 
 func newTestHost(t *testing.T, clientset clientset.Interface) (string, volume.VolumeHost) {
-	tempDir, err := ioutil.TempDir("/tmp", "projected_volume_test.")
+	tempDir, err := os.MkdirTemp("/tmp", "projected_volume_test.")
 	if err != nil {
 		t.Fatalf("can't make a temp rootdir: %v", err)
 	}

--- a/pkg/volume/secret/secret_test.go
+++ b/pkg/volume/secret/secret_test.go
@@ -263,7 +263,7 @@ func TestMakePayload(t *testing.T) {
 }
 
 func newTestHost(t *testing.T, clientset clientset.Interface) (string, volume.VolumeHost) {
-	tempDir, err := ioutil.TempDir("/tmp", "secret_volume_test.")
+	tempDir, err := os.MkdirTemp("/tmp", "secret_volume_test.")
 	if err != nil {
 		t.Fatalf("can't make a temp rootdir: %v", err)
 	}

--- a/pkg/volume/util/atomic_writer.go
+++ b/pkg/volume/util/atomic_writer.go
@@ -355,7 +355,7 @@ func (w *AtomicWriter) pathsToRemove(payload map[string]FileProjection, oldTsDir
 
 // newTimestampDir creates a new timestamp directory
 func (w *AtomicWriter) newTimestampDir() (string, error) {
-	tsDir, err := ioutil.TempDir(w.targetDir, time.Now().UTC().Format("..2006_01_02_15_04_05."))
+	tsDir, err := os.MkdirTemp(w.targetDir, time.Now().UTC().Format("..2006_01_02_15_04_05."))
 	if err != nil {
 		klog.Errorf("%s: unable to create new temp directory: %v", w.logContext, err)
 		return "", err

--- a/pkg/volume/util/fs/fs_windows_test.go
+++ b/pkg/volume/util/fs/fs_windows_test.go
@@ -28,7 +28,7 @@ import (
 
 func TestDiskUsage(t *testing.T) {
 
-	dir1, err := ioutil.TempDir("", "dir_1")
+	dir1, err := os.MkdirTemp("", "dir_1")
 	if err != nil {
 		t.Fatalf("TestDiskUsage failed: %s", err.Error())
 	}
@@ -38,7 +38,7 @@ func TestDiskUsage(t *testing.T) {
 	if _, err = tmpfile1.WriteString("just for testing"); err != nil {
 		t.Fatalf("TestDiskUsage failed: %s", err.Error())
 	}
-	dir2, err := ioutil.TempDir(dir1, "dir_2")
+	dir2, err := os.MkdirTemp(dir1, "dir_2")
 	if err != nil {
 		t.Fatalf("TestDiskUsage failed: %s", err.Error())
 	}
@@ -86,7 +86,7 @@ func TestDiskUsage(t *testing.T) {
 }
 
 func TestInfo(t *testing.T) {
-	dir1, err := ioutil.TempDir("", "dir_1")
+	dir1, err := os.MkdirTemp("", "dir_1")
 	if err != nil {
 		t.Fatalf("TestInfo failed: %s", err.Error())
 	}

--- a/pkg/volume/util/hostutil/hostutil_linux_test.go
+++ b/pkg/volume/util/hostutil/hostutil_linux_test.go
@@ -217,7 +217,7 @@ func TestGetFileType(t *testing.T) {
 			"Directory Test",
 			FileTypeDirectory,
 			func() (string, string, error) {
-				tempDir, err := ioutil.TempDir("", "test-get-filetype-")
+				tempDir, err := os.MkdirTemp("", "test-get-filetype-")
 				return tempDir, tempDir, err
 			},
 		},
@@ -237,7 +237,7 @@ func TestGetFileType(t *testing.T) {
 			"Socket Test",
 			FileTypeSocket,
 			func() (string, string, error) {
-				tempDir, err := ioutil.TempDir("", "test-get-filetype-")
+				tempDir, err := os.MkdirTemp("", "test-get-filetype-")
 				if err != nil {
 					return "", "", err
 				}
@@ -249,7 +249,7 @@ func TestGetFileType(t *testing.T) {
 			"Block Device Test",
 			FileTypeBlockDev,
 			func() (string, string, error) {
-				tempDir, err := ioutil.TempDir("", "test-get-filetype-")
+				tempDir, err := os.MkdirTemp("", "test-get-filetype-")
 				if err != nil {
 					return "", "", err
 				}
@@ -266,7 +266,7 @@ func TestGetFileType(t *testing.T) {
 			"Character Device Test",
 			FileTypeCharDev,
 			func() (string, string, error) {
-				tempDir, err := ioutil.TempDir("", "test-get-filetype-")
+				tempDir, err := os.MkdirTemp("", "test-get-filetype-")
 				if err != nil {
 					return "", "", err
 				}
@@ -308,7 +308,7 @@ func isOperationNotPermittedError(err error) bool {
 }
 
 func writeFile(content string) (string, string, error) {
-	tempDir, err := ioutil.TempDir("", "mounter_shared_test")
+	tempDir, err := os.MkdirTemp("", "mounter_shared_test")
 	if err != nil {
 		return "", "", err
 	}

--- a/pkg/volume/util/hostutil/hostutil_windows_test.go
+++ b/pkg/volume/util/hostutil/hostutil_windows_test.go
@@ -36,7 +36,7 @@ func TestGetFileType(t *testing.T) {
 			"Directory Test",
 			FileTypeDirectory,
 			func() (string, string, error) {
-				tempDir, err := ioutil.TempDir("", "test-get-filetype-")
+				tempDir, err := os.MkdirTemp("", "test-get-filetype-")
 				return tempDir, tempDir, err
 			},
 		},

--- a/pkg/volume/util/nested_volumes_test.go
+++ b/pkg/volume/util/nested_volumes_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package util
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -199,7 +198,7 @@ func TestGetNestedMountpoints(t *testing.T) {
 		},
 	}
 	for _, test := range tc {
-		dir, err := ioutil.TempDir("", "TestMakeNestedMountpoints.")
+		dir, err := os.MkdirTemp("", "TestMakeNestedMountpoints.")
 		if err != nil {
 			t.Errorf("Unexpected error trying to create temp directory: %v", err)
 			return

--- a/pkg/volume/util/subpath/subpath_linux_test.go
+++ b/pkg/volume/util/subpath/subpath_linux_test.go
@@ -256,7 +256,7 @@ func TestSafeMakeDir(t *testing.T) {
 	for i := range tests {
 		test := tests[i]
 		t.Run(test.name, func(t *testing.T) {
-			base, err := ioutil.TempDir("", "safe-make-dir-"+test.name+"-")
+			base, err := os.MkdirTemp("", "safe-make-dir-"+test.name+"-")
 			if err != nil {
 				t.Fatalf(err.Error())
 			}
@@ -382,7 +382,7 @@ func TestRemoveEmptyDirs(t *testing.T) {
 
 	for _, test := range tests {
 		klog.V(4).Infof("test %q", test.name)
-		base, err := ioutil.TempDir("", "remove-empty-dirs-"+test.name+"-")
+		base, err := os.MkdirTemp("", "remove-empty-dirs-"+test.name+"-")
 		if err != nil {
 			t.Fatalf(err.Error())
 		}
@@ -612,7 +612,7 @@ func TestCleanSubPaths(t *testing.T) {
 
 	for _, test := range tests {
 		klog.V(4).Infof("test %q", test.name)
-		base, err := ioutil.TempDir("", "clean-subpaths-"+test.name+"-")
+		base, err := os.MkdirTemp("", "clean-subpaths-"+test.name+"-")
 		if err != nil {
 			t.Fatalf(err.Error())
 		}
@@ -869,7 +869,7 @@ func TestBindSubPath(t *testing.T) {
 
 	for _, test := range tests {
 		klog.V(4).Infof("test %q", test.name)
-		base, err := ioutil.TempDir("", "bind-subpath-"+test.name+"-")
+		base, err := os.MkdirTemp("", "bind-subpath-"+test.name+"-")
 		if err != nil {
 			t.Fatalf(err.Error())
 		}
@@ -1080,7 +1080,7 @@ func TestSafeOpen(t *testing.T) {
 
 	for _, test := range tests {
 		klog.V(4).Infof("test %q", test.name)
-		base, err := ioutil.TempDir("", "safe-open-"+test.name+"-")
+		base, err := os.MkdirTemp("", "safe-open-"+test.name+"-")
 		if err != nil {
 			t.Fatalf(err.Error())
 		}
@@ -1227,7 +1227,7 @@ func TestFindExistingPrefix(t *testing.T) {
 
 	for _, test := range tests {
 		klog.V(4).Infof("test %q", test.name)
-		base, err := ioutil.TempDir("", "find-prefix-"+test.name+"-")
+		base, err := os.MkdirTemp("", "find-prefix-"+test.name+"-")
 		if err != nil {
 			t.Fatalf(err.Error())
 		}

--- a/pkg/volume/util/subpath/subpath_windows_test.go
+++ b/pkg/volume/util/subpath/subpath_windows_test.go
@@ -20,7 +20,6 @@ package subpath
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -37,7 +36,7 @@ func makeLink(link, target string) error {
 }
 
 func TestDoSafeMakeDir(t *testing.T) {
-	base, err := ioutil.TempDir("", "TestDoSafeMakeDir")
+	base, err := os.MkdirTemp("", "TestDoSafeMakeDir")
 	if err != nil {
 		t.Fatalf(err.Error())
 	}
@@ -133,7 +132,7 @@ func TestDoSafeMakeDir(t *testing.T) {
 }
 
 func TestLockAndCheckSubPath(t *testing.T) {
-	base, err := ioutil.TempDir("", "TestLockAndCheckSubPath")
+	base, err := os.MkdirTemp("", "TestLockAndCheckSubPath")
 	if err != nil {
 		t.Fatalf(err.Error())
 	}
@@ -237,7 +236,7 @@ func TestLockAndCheckSubPath(t *testing.T) {
 }
 
 func TestLockAndCheckSubPathWithoutSymlink(t *testing.T) {
-	base, err := ioutil.TempDir("", "TestLockAndCheckSubPathWithoutSymlink")
+	base, err := os.MkdirTemp("", "TestLockAndCheckSubPathWithoutSymlink")
 	if err != nil {
 		t.Fatalf(err.Error())
 	}
@@ -341,7 +340,7 @@ func TestLockAndCheckSubPathWithoutSymlink(t *testing.T) {
 }
 
 func TestFindExistingPrefix(t *testing.T) {
-	base, err := ioutil.TempDir("", "TestFindExistingPrefix")
+	base, err := os.MkdirTemp("", "TestFindExistingPrefix")
 	if err != nil {
 		t.Fatalf(err.Error())
 	}

--- a/plugin/pkg/admission/imagepolicy/admission_test.go
+++ b/plugin/pkg/admission/imagepolicy/admission_test.go
@@ -67,7 +67,7 @@ imagePolicy:
 `
 
 func TestNewFromConfig(t *testing.T) {
-	dir, err := ioutil.TempDir("", "")
+	dir, err := os.MkdirTemp("", "")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/cmd/server/testing/testserver.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/cmd/server/testing/testserver.go
@@ -19,7 +19,6 @@ package testing
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"os"
 	"path/filepath"
@@ -102,7 +101,7 @@ func StartTestServer(t Logger, instanceOptions *TestServerInstanceOptions, custo
 		}
 	}()
 
-	result.TmpDir, err = ioutil.TempDir("", "apiextensions-apiserver")
+	result.TmpDir, err = os.MkdirTemp("", "apiextensions-apiserver")
 	if err != nil {
 		return result, fmt.Errorf("failed to create temp dir: %v", err)
 	}

--- a/staging/src/k8s.io/apiserver/pkg/storage/storagebackend/factory/tls_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/storagebackend/factory/tls_test.go
@@ -91,7 +91,7 @@ func TestTLSConnection(t *testing.T) {
 
 func configureTLSCerts(t *testing.T) (certFile, keyFile, caFile string) {
 	baseDir := os.TempDir()
-	tempDir, err := ioutil.TempDir(baseDir, "etcd_certificates")
+	tempDir, err := os.MkdirTemp(baseDir, "etcd_certificates")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/staging/src/k8s.io/apiserver/pkg/util/webhook/webhook_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/webhook/webhook_test.go
@@ -636,7 +636,7 @@ func TestWithExponentialBackoff(t *testing.T) {
 }
 
 func bootstrapTestDir(t *testing.T) string {
-	dir, err := ioutil.TempDir("", "")
+	dir, err := os.MkdirTemp("", "")
 
 	if err != nil {
 		t.Fatal(err)

--- a/staging/src/k8s.io/apiserver/plugin/pkg/authorizer/webhook/webhook_v1_test.go
+++ b/staging/src/k8s.io/apiserver/plugin/pkg/authorizer/webhook/webhook_v1_test.go
@@ -51,7 +51,7 @@ var testRetryBackoff = wait.Backoff{
 }
 
 func TestV1NewFromConfig(t *testing.T) {
-	dir, err := ioutil.TempDir("", "")
+	dir, err := os.MkdirTemp("", "")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/staging/src/k8s.io/apiserver/plugin/pkg/authorizer/webhook/webhook_v1beta1_test.go
+++ b/staging/src/k8s.io/apiserver/plugin/pkg/authorizer/webhook/webhook_v1beta1_test.go
@@ -43,7 +43,7 @@ import (
 )
 
 func TestV1beta1NewFromConfig(t *testing.T) {
-	dir, err := ioutil.TempDir("", "")
+	dir, err := os.MkdirTemp("", "")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/staging/src/k8s.io/cli-runtime/pkg/resource/builder_test.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/resource/builder_test.go
@@ -614,7 +614,7 @@ func TestDirectoryBuilder(t *testing.T) {
 }
 
 func setupKustomizeDirectory() (string, error) {
-	path, err := ioutil.TempDir("/tmp", "")
+	path, err := os.MkdirTemp("/tmp", "")
 	if err != nil {
 		return "", err
 	}

--- a/staging/src/k8s.io/client-go/discovery/cached/disk/cached_discovery_test.go
+++ b/staging/src/k8s.io/client-go/discovery/cached/disk/cached_discovery_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package disk
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -38,7 +37,7 @@ import (
 func TestCachedDiscoveryClient_Fresh(t *testing.T) {
 	assert := assert.New(t)
 
-	d, err := ioutil.TempDir("", "")
+	d, err := os.MkdirTemp("", "")
 	assert.NoError(err)
 	defer os.RemoveAll(d)
 
@@ -82,7 +81,7 @@ func TestCachedDiscoveryClient_Fresh(t *testing.T) {
 func TestNewCachedDiscoveryClient_TTL(t *testing.T) {
 	assert := assert.New(t)
 
-	d, err := ioutil.TempDir("", "")
+	d, err := os.MkdirTemp("", "")
 	assert.NoError(err)
 	defer os.RemoveAll(d)
 
@@ -100,7 +99,7 @@ func TestNewCachedDiscoveryClient_TTL(t *testing.T) {
 func TestNewCachedDiscoveryClient_PathPerm(t *testing.T) {
 	assert := assert.New(t)
 
-	d, err := ioutil.TempDir("", "")
+	d, err := os.MkdirTemp("", "")
 	assert.NoError(err)
 	os.RemoveAll(d)
 	defer os.RemoveAll(d)

--- a/staging/src/k8s.io/client-go/discovery/cached/disk/round_tripper_test.go
+++ b/staging/src/k8s.io/client-go/discovery/cached/disk/round_tripper_test.go
@@ -42,7 +42,7 @@ func (rt *testRoundTripper) RoundTrip(req *http.Request) (*http.Response, error)
 
 func TestCacheRoundTripper(t *testing.T) {
 	rt := &testRoundTripper{}
-	cacheDir, err := ioutil.TempDir("", "cache-rt")
+	cacheDir, err := os.MkdirTemp("", "cache-rt")
 	defer os.RemoveAll(cacheDir)
 	if err != nil {
 		t.Fatal(err)
@@ -101,7 +101,7 @@ func TestCacheRoundTripperPathPerm(t *testing.T) {
 	assert := assert.New(t)
 
 	rt := &testRoundTripper{}
-	cacheDir, err := ioutil.TempDir("", "cache-rt")
+	cacheDir, err := os.MkdirTemp("", "cache-rt")
 	os.RemoveAll(cacheDir)
 	defer os.RemoveAll(cacheDir)
 

--- a/staging/src/k8s.io/client-go/tools/clientcmd/loader_test.go
+++ b/staging/src/k8s.io/client-go/tools/clientcmd/loader_test.go
@@ -153,7 +153,7 @@ func TestErrorReadingFile(t *testing.T) {
 }
 
 func TestErrorReadingNonFile(t *testing.T) {
-	tmpdir, err := ioutil.TempDir("", "")
+	tmpdir, err := os.MkdirTemp("", "")
 	if err != nil {
 		t.Fatalf("Couldn't create tmpdir")
 	}
@@ -472,14 +472,14 @@ func TestResolveRelativePaths(t *testing.T) {
 		},
 	}
 
-	configDir1, _ := ioutil.TempDir("", "")
+	configDir1, _ := os.MkdirTemp("", "")
 	defer os.RemoveAll(configDir1)
 	configFile1 := path.Join(configDir1, ".kubeconfig")
 	configDir1, _ = filepath.Abs(configDir1)
 
-	configDir2, _ := ioutil.TempDir("", "")
+	configDir2, _ := os.MkdirTemp("", "")
 	defer os.RemoveAll(configDir2)
-	configDir2, _ = ioutil.TempDir(configDir2, "")
+	configDir2, _ = os.MkdirTemp(configDir2, "")
 	configFile2 := path.Join(configDir2, ".kubeconfig")
 	configDir2, _ = filepath.Abs(configDir2)
 

--- a/staging/src/k8s.io/client-go/tools/clientcmd/main_test.go
+++ b/staging/src/k8s.io/client-go/tools/clientcmd/main_test.go
@@ -17,14 +17,13 @@ limitations under the License.
 package clientcmd
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
 )
 
 func TestMain(m *testing.M) {
-	tmp, err := ioutil.TempDir("", "testkubeconfig")
+	tmp, err := os.MkdirTemp("", "testkubeconfig")
 	if err != nil {
 		panic(err)
 	}

--- a/staging/src/k8s.io/client-go/util/certificate/certificate_store_test.go
+++ b/staging/src/k8s.io/client-go/util/certificate/certificate_store_test.go
@@ -25,7 +25,7 @@ import (
 )
 
 func TestUpdateSymlinkExistingFileError(t *testing.T) {
-	dir, err := ioutil.TempDir("", "k8s-test-update-symlink")
+	dir, err := os.MkdirTemp("", "k8s-test-update-symlink")
 	if err != nil {
 		t.Fatalf("Unable to create the test directory %q: %v", dir, err)
 	}
@@ -49,7 +49,7 @@ func TestUpdateSymlinkExistingFileError(t *testing.T) {
 }
 
 func TestUpdateSymlinkNewFileNotExist(t *testing.T) {
-	dir, err := ioutil.TempDir("", "k8s-test-update-symlink")
+	dir, err := os.MkdirTemp("", "k8s-test-update-symlink")
 	if err != nil {
 		t.Fatalf("Unable to create the test directory %q: %v", dir, err)
 	}
@@ -89,7 +89,7 @@ func TestUpdateSymlinkNewFileNotExist(t *testing.T) {
 }
 
 func TestUpdateSymlinkNoSymlink(t *testing.T) {
-	dir, err := ioutil.TempDir("", "k8s-test-update-symlink")
+	dir, err := os.MkdirTemp("", "k8s-test-update-symlink")
 	if err != nil {
 		t.Fatalf("Unable to create the test directory %q: %v", dir, err)
 	}
@@ -124,7 +124,7 @@ func TestUpdateSymlinkNoSymlink(t *testing.T) {
 
 func TestUpdateSymlinkReplaceExistingSymlink(t *testing.T) {
 	prefix := "kubelet"
-	dir, err := ioutil.TempDir("", "k8s-test-update-symlink")
+	dir, err := os.MkdirTemp("", "k8s-test-update-symlink")
 	if err != nil {
 		t.Fatalf("Unable to create the test directory %q: %v", dir, err)
 	}
@@ -178,7 +178,7 @@ func TestUpdateSymlinkReplaceExistingSymlink(t *testing.T) {
 }
 
 func TestLoadFile(t *testing.T) {
-	dir, err := ioutil.TempDir("", "k8s-test-load-cert-key-blocks")
+	dir, err := os.MkdirTemp("", "k8s-test-load-cert-key-blocks")
 	if err != nil {
 		t.Fatalf("Unable to create the test directory %q: %v", dir, err)
 	}
@@ -218,7 +218,7 @@ func TestLoadFile(t *testing.T) {
 
 func TestUpdateNoRotation(t *testing.T) {
 	prefix := "kubelet-server"
-	dir, err := ioutil.TempDir("", "k8s-test-certstore-current")
+	dir, err := os.MkdirTemp("", "k8s-test-certstore-current")
 	if err != nil {
 		t.Fatalf("Unable to create the test directory %q: %v", dir, err)
 	}
@@ -252,7 +252,7 @@ func TestUpdateNoRotation(t *testing.T) {
 
 func TestUpdateRotation(t *testing.T) {
 	prefix := "kubelet-server"
-	dir, err := ioutil.TempDir("", "k8s-test-certstore-current")
+	dir, err := os.MkdirTemp("", "k8s-test-certstore-current")
 	if err != nil {
 		t.Fatalf("Unable to create the test directory %q: %v", dir, err)
 	}
@@ -286,7 +286,7 @@ func TestUpdateRotation(t *testing.T) {
 
 func TestUpdateTwoCerts(t *testing.T) {
 	prefix := "kubelet-server"
-	dir, err := ioutil.TempDir("", "k8s-test-certstore-current")
+	dir, err := os.MkdirTemp("", "k8s-test-certstore-current")
 	if err != nil {
 		t.Fatalf("Unable to create the test directory %q: %v", dir, err)
 	}
@@ -323,7 +323,7 @@ func TestUpdateTwoCerts(t *testing.T) {
 
 func TestUpdateWithBadCertKeyData(t *testing.T) {
 	prefix := "kubelet-server"
-	dir, err := ioutil.TempDir("", "k8s-test-certstore-current")
+	dir, err := os.MkdirTemp("", "k8s-test-certstore-current")
 	if err != nil {
 		t.Fatalf("Unable to create the test directory %q: %v", dir, err)
 	}
@@ -357,7 +357,7 @@ func TestUpdateWithBadCertKeyData(t *testing.T) {
 
 func TestCurrentPairFile(t *testing.T) {
 	prefix := "kubelet-server"
-	dir, err := ioutil.TempDir("", "k8s-test-certstore-current")
+	dir, err := os.MkdirTemp("", "k8s-test-certstore-current")
 	if err != nil {
 		t.Fatalf("Unable to create the test directory %q: %v", dir, err)
 	}
@@ -396,7 +396,7 @@ func TestCurrentPairFile(t *testing.T) {
 
 func TestCurrentCertKeyFiles(t *testing.T) {
 	prefix := "kubelet-server"
-	dir, err := ioutil.TempDir("", "k8s-test-certstore-current")
+	dir, err := os.MkdirTemp("", "k8s-test-certstore-current")
 	if err != nil {
 		t.Fatalf("Unable to create the test directory %q: %v", dir, err)
 	}
@@ -433,7 +433,7 @@ func TestCurrentCertKeyFiles(t *testing.T) {
 
 func TestCurrentTwoCerts(t *testing.T) {
 	prefix := "kubelet-server"
-	dir, err := ioutil.TempDir("", "k8s-test-certstore-current")
+	dir, err := os.MkdirTemp("", "k8s-test-certstore-current")
 	if err != nil {
 		t.Fatalf("Unable to create the test directory %q: %v", dir, err)
 	}
@@ -472,7 +472,7 @@ func TestCurrentTwoCerts(t *testing.T) {
 }
 
 func TestCurrentNoFiles(t *testing.T) {
-	dir, err := ioutil.TempDir("", "k8s-test-certstore-current")
+	dir, err := os.MkdirTemp("", "k8s-test-certstore-current")
 	if err != nil {
 		t.Fatalf("Unable to create the test directory %q: %v", dir, err)
 	}

--- a/staging/src/k8s.io/client-go/util/testing/tmpdir.go
+++ b/staging/src/k8s.io/client-go/util/testing/tmpdir.go
@@ -17,7 +17,6 @@ limitations under the License.
 package testing
 
 import (
-	"io/ioutil"
 	"os"
 )
 
@@ -26,7 +25,7 @@ import (
 // deleted with a call to "os.RemoveAll(...)".
 // In case of error, it'll return an empty string and the error.
 func MkTmpdir(prefix string) (string, error) {
-	tmpDir, err := ioutil.TempDir(os.TempDir(), prefix)
+	tmpDir, err := os.MkdirTemp(os.TempDir(), prefix)
 	if err != nil {
 		return "", err
 	}

--- a/staging/src/k8s.io/cloud-provider/app/testing/testserver.go
+++ b/staging/src/k8s.io/cloud-provider/app/testing/testserver.go
@@ -19,7 +19,6 @@ package testing
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"os"
 	"strings"
@@ -77,7 +76,7 @@ func StartTestServer(t Logger, customFlags []string) (result TestServer, err err
 		}
 	}()
 
-	result.TmpDir, err = ioutil.TempDir("", "cloud-controller-manager")
+	result.TmpDir, err = os.MkdirTemp("", "cloud-controller-manager")
 	if err != nil {
 		return result, fmt.Errorf("failed to create temp dir: %v", err)
 	}

--- a/staging/src/k8s.io/kube-aggregator/pkg/apiserver/handler_proxy_test.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/apiserver/handler_proxy_test.go
@@ -810,7 +810,7 @@ func TestProxyCertReload(t *testing.T) {
 }
 
 func getCertAndKeyPaths(t *testing.T) (string, string, string) {
-	dir, err := ioutil.TempDir(os.TempDir(), "k8s-test-handler-proxy-cert")
+	dir, err := os.MkdirTemp(os.TempDir(), "k8s-test-handler-proxy-cert")
 	if err != nil {
 		t.Fatalf("Unable to create the test directory %q: %v", dir, err)
 	}

--- a/staging/src/k8s.io/kubectl/pkg/cmd/clusterinfo/clusterinfo_dump_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/clusterinfo/clusterinfo_dump_test.go
@@ -43,7 +43,7 @@ func TestSetupOutputWriterNoOp(t *testing.T) {
 func TestSetupOutputWriterFile(t *testing.T) {
 	file := "output"
 	extension := ".json"
-	dir, err := ioutil.TempDir(os.TempDir(), "out")
+	dir, err := os.MkdirTemp(os.TempDir(), "out")
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}

--- a/staging/src/k8s.io/kubectl/pkg/cmd/cp/cp_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/cp/cp_test.go
@@ -258,11 +258,11 @@ func checkErr(t *testing.T, err error) {
 }
 
 func TestTarUntar(t *testing.T) {
-	dir, err := ioutil.TempDir("", "input")
+	dir, err := os.MkdirTemp("", "input")
 	checkErr(t, err)
-	dir2, err := ioutil.TempDir("", "output")
+	dir2, err := os.MkdirTemp("", "output")
 	checkErr(t, err)
-	dir3, err := ioutil.TempDir("", "dir")
+	dir3, err := os.MkdirTemp("", "dir")
 	checkErr(t, err)
 
 	dir = dir + "/"
@@ -396,9 +396,9 @@ func TestTarUntar(t *testing.T) {
 }
 
 func TestTarUntarWrongPrefix(t *testing.T) {
-	dir, err := ioutil.TempDir("", "input")
+	dir, err := os.MkdirTemp("", "input")
 	checkErr(t, err)
-	dir2, err := ioutil.TempDir("", "output")
+	dir2, err := os.MkdirTemp("", "output")
 	checkErr(t, err)
 
 	dir = dir + "/"
@@ -428,8 +428,8 @@ func TestTarUntarWrongPrefix(t *testing.T) {
 }
 
 func TestTarDestinationName(t *testing.T) {
-	dir, err := ioutil.TempDir(os.TempDir(), "input")
-	dir2, err2 := ioutil.TempDir(os.TempDir(), "output")
+	dir, err := os.MkdirTemp(os.TempDir(), "input")
+	dir2, err2 := os.MkdirTemp(os.TempDir(), "output")
 	if err != nil || err2 != nil {
 		t.Errorf("unexpected error: %v | %v", err, err2)
 		t.FailNow()
@@ -499,7 +499,7 @@ func TestTarDestinationName(t *testing.T) {
 }
 
 func TestBadTar(t *testing.T) {
-	dir, err := ioutil.TempDir(os.TempDir(), "dest")
+	dir, err := os.MkdirTemp(os.TempDir(), "dest")
 	if err != nil {
 		t.Errorf("unexpected error: %v ", err)
 		t.FailNow()
@@ -568,7 +568,7 @@ func TestCopyToPod(t *testing.T) {
 
 	cmd := NewCmdCp(tf, ioStreams)
 
-	srcFile, err := ioutil.TempDir("", "test")
+	srcFile, err := os.MkdirTemp("", "test")
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 		t.FailNow()
@@ -647,7 +647,7 @@ func TestCopyToPodNoPreserve(t *testing.T) {
 
 	cmd := NewCmdCp(tf, ioStreams)
 
-	srcFile, err := ioutil.TempDir("", "test")
+	srcFile, err := os.MkdirTemp("", "test")
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 		t.FailNow()
@@ -723,7 +723,7 @@ func TestValidate(t *testing.T) {
 }
 
 func TestUntar(t *testing.T) {
-	testdir, err := ioutil.TempDir("", "test-untar")
+	testdir, err := os.MkdirTemp("", "test-untar")
 	require.NoError(t, err)
 	defer os.RemoveAll(testdir)
 	t.Logf("Test base: %s", testdir)
@@ -883,7 +883,7 @@ func TestUntar(t *testing.T) {
 }
 
 func TestUntar_SingleFile(t *testing.T) {
-	testdir, err := ioutil.TempDir("", "test-untar")
+	testdir, err := os.MkdirTemp("", "test-untar")
 	require.NoError(t, err)
 	defer os.RemoveAll(testdir)
 

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_configmap_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_configmap_test.go
@@ -490,7 +490,7 @@ func setupEnvFile(lines [][]string) func(*testing.T, *ConfigMapOptions) func() {
 
 func setupBinaryFile(data []byte) func(*testing.T, *ConfigMapOptions) func() {
 	return func(t *testing.T, configMapOptions *ConfigMapOptions) func() {
-		tmp, _ := ioutil.TempDir("", "")
+		tmp, _ := os.MkdirTemp("", "")
 		files := configMapOptions.FileSources
 		for i, file := range files {
 			f := tmp + "/" + file

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_secret_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_secret_test.go
@@ -515,7 +515,7 @@ func setupSecretEnvFile(lines ...string) func(*testing.T, *CreateSecretOptions) 
 
 func setupSecretBinaryFile(data []byte, files ...string) func(*testing.T, *CreateSecretOptions) func() {
 	return func(t *testing.T, secretOptions *CreateSecretOptions) func() {
-		tmp, _ := ioutil.TempDir("", "")
+		tmp, _ := os.MkdirTemp("", "")
 		for i, file := range files {
 			f := tmp + "/" + file
 			ioutil.WriteFile(f, data, 0644)

--- a/staging/src/k8s.io/kubectl/pkg/cmd/diff/diff.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/diff/diff.go
@@ -19,7 +19,6 @@ package diff
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -281,7 +280,7 @@ type Directory struct {
 // CreateDirectory does create the actual disk directory, and return a
 // new representation of it.
 func CreateDirectory(prefix string) (*Directory, error) {
-	name, err := ioutil.TempDir("", prefix+"-")
+	name, err := os.MkdirTemp("", prefix+"-")
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/kubectl/pkg/cmd/plugin/plugin_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/plugin/plugin_test.go
@@ -27,11 +27,11 @@ import (
 )
 
 func TestPluginPathsAreUnaltered(t *testing.T) {
-	tempDir, err := ioutil.TempDir(os.TempDir(), "test-cmd-plugins")
+	tempDir, err := os.MkdirTemp(os.TempDir(), "test-cmd-plugins")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	tempDir2, err := ioutil.TempDir(os.TempDir(), "test-cmd-plugins2")
+	tempDir2, err := os.MkdirTemp(os.TempDir(), "test-cmd-plugins2")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -79,7 +79,7 @@ func TestPluginPathsAreUnaltered(t *testing.T) {
 }
 
 func TestPluginPathsAreValid(t *testing.T) {
-	tempDir, err := ioutil.TempDir(os.TempDir(), "test-cmd-plugins")
+	tempDir, err := os.MkdirTemp(os.TempDir(), "test-cmd-plugins")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/staging/src/k8s.io/kubectl/pkg/cmd/replace/replace.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/replace/replace.go
@@ -18,7 +18,6 @@ package replace
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -309,7 +308,7 @@ func (o *ReplaceOptions) forceReplace() error {
 	stdinInUse := false
 	for i, filename := range o.DeleteOptions.FilenameOptions.Filenames {
 		if filename == "-" {
-			tempDir, err := ioutil.TempDir("", "kubectl_replace_")
+			tempDir, err := os.MkdirTemp("", "kubectl_replace_")
 			if err != nil {
 				return err
 			}

--- a/staging/src/k8s.io/kubectl/pkg/proxy/proxy_server_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/proxy/proxy_server_test.go
@@ -361,7 +361,7 @@ func TestFileServing(t *testing.T) {
 		fname = "test.txt"
 		data  = "This is test data"
 	)
-	dir, err := ioutil.TempDir("", "data")
+	dir, err := os.MkdirTemp("", "data")
 	if err != nil {
 		t.Fatalf("error creating tmp dir: %v", err)
 	}

--- a/staging/src/k8s.io/legacy-cloud-providers/openstack/metadata.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/openstack/metadata.go
@@ -23,7 +23,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -117,7 +116,7 @@ func getMetadataFromConfigDrive(metadataVersion string) (*Metadata, error) {
 		dev = strings.TrimSpace(string(out))
 	}
 
-	mntdir, err := ioutil.TempDir("", "configdrive")
+	mntdir, err := os.MkdirTemp("", "configdrive")
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/mount-utils/mount_helper_test.go
+++ b/staging/src/k8s.io/mount-utils/mount_helper_test.go
@@ -84,7 +84,7 @@ func TestDoCleanupMountPoint(t *testing.T) {
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
 
-			tmpDir, err := ioutil.TempDir("", "unmount-mount-point-test")
+			tmpDir, err := os.MkdirTemp("", "unmount-mount-point-test")
 			if err != nil {
 				t.Fatalf("failed to create tmpdir: %v", err)
 			}

--- a/staging/src/k8s.io/mount-utils/mount_helper_unix_test.go
+++ b/staging/src/k8s.io/mount-utils/mount_helper_unix_test.go
@@ -27,7 +27,7 @@ import (
 )
 
 func writeFile(content string) (string, string, error) {
-	tempDir, err := ioutil.TempDir("", "mounter_shared_test")
+	tempDir, err := os.MkdirTemp("", "mounter_shared_test")
 	if err != nil {
 		return "", "", err
 	}

--- a/staging/src/k8s.io/mount-utils/mount_windows_test.go
+++ b/staging/src/k8s.io/mount-utils/mount_windows_test.go
@@ -20,7 +20,6 @@ package mount
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -199,7 +198,7 @@ func TestIsLikelyNotMountPoint(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		base, err := ioutil.TempDir("", test.fileName)
+		base, err := os.MkdirTemp("", test.fileName)
 		if err != nil {
 			t.Fatalf(err.Error())
 		}
@@ -279,7 +278,7 @@ func TestFormatAndMount(t *testing.T) {
 			Interface: &fakeMounter,
 			Exec:      fakeExec,
 		}
-		base, err := ioutil.TempDir("", test.device)
+		base, err := os.MkdirTemp("", test.device)
 		if err != nil {
 			t.Fatalf(err.Error())
 		}

--- a/staging/src/k8s.io/mount-utils/safe_format_and_mount_test.go
+++ b/staging/src/k8s.io/mount-utils/safe_format_and_mount_test.go
@@ -18,7 +18,6 @@ package mount
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"runtime"
 	"strings"
@@ -58,7 +57,7 @@ func TestSafeFormatAndMount(t *testing.T) {
 	if runtime.GOOS == "darwin" || runtime.GOOS == "windows" {
 		t.Skipf("not supported on GOOS=%s", runtime.GOOS)
 	}
-	mntDir, err := ioutil.TempDir(os.TempDir(), "mount")
+	mntDir, err := os.MkdirTemp(os.TempDir(), "mount")
 	if err != nil {
 		t.Fatalf("failed to create tmp dir: %v", err)
 	}

--- a/test/conformance/image/go-runner/tar_test.go
+++ b/test/conformance/image/go-runner/tar_test.go
@@ -32,7 +32,7 @@ import (
 )
 
 func TestTar(t *testing.T) {
-	tmp, err := ioutil.TempDir("", "testtar")
+	tmp, err := os.MkdirTemp("", "testtar")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/test/e2e/apimachinery/certs.go
+++ b/test/e2e/apimachinery/certs.go
@@ -36,7 +36,7 @@ type certContext struct {
 // Setup the server cert. For example, user apiservers and admission webhooks
 // can use the cert to prove their identify to the kube-apiserver
 func setupServerCert(namespaceName, serviceName string) *certContext {
-	certDir, err := ioutil.TempDir("", "test-e2e-server-cert")
+	certDir, err := os.MkdirTemp("", "test-e2e-server-cert")
 	if err != nil {
 		framework.Failf("Failed to create a temp dir for cert generation %v", err)
 	}

--- a/test/e2e/framework/ingress/ingress_utils_test.go
+++ b/test/e2e/framework/ingress/ingress_utils_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package ingress
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -28,7 +27,7 @@ import (
 func TestIngressToManifest(t *testing.T) {
 	ing := &networkingv1.Ingress{}
 	// Create a temp dir.
-	tmpDir, err := ioutil.TempDir("", "kubemci")
+	tmpDir, err := os.MkdirTemp("", "kubemci")
 	if err != nil {
 		t.Fatalf("unexpected error in creating temp dir: %s", err)
 	}

--- a/test/e2e/kubectl/kubectl.go
+++ b/test/e2e/kubectl/kubectl.go
@@ -683,7 +683,7 @@ var _ = SIGDescribe("Kubectl client", func() {
 
 			// Build a kubeconfig file that will make use of the injected ca and token,
 			// but point at the DNS host and the default namespace
-			tmpDir, err := ioutil.TempDir("", "icc-override")
+			tmpDir, err := os.MkdirTemp("", "icc-override")
 			overrideKubeconfigName := "icc-override.kubeconfig"
 			framework.ExpectNoError(err)
 			defer func() { os.Remove(tmpDir) }()
@@ -1640,7 +1640,7 @@ metadata:
 		*/
 		framework.ConformanceIt("should support --unix-socket=/path ", func() {
 			ginkgo.By("Starting the proxy")
-			tmpdir, err := ioutil.TempDir("", "kubectl-proxy-unix")
+			tmpdir, err := os.MkdirTemp("", "kubectl-proxy-unix")
 			if err != nil {
 				framework.Failf("Failed to create temporary directory: %v", err)
 			}

--- a/test/e2e/windows/gmsa_full.go
+++ b/test/e2e/windows/gmsa_full.go
@@ -245,7 +245,7 @@ func retrieveCRDManifestFileContents(f *framework.Framework, node v1.Node) strin
 func deployGmsaWebhook(f *framework.Framework, deployScriptPath string) (func(), error) {
 	cleanUpFunc := func() {}
 
-	tempDir, err := ioutil.TempDir("", "")
+	tempDir, err := os.MkdirTemp("", "")
 	if err != nil {
 		return cleanUpFunc, fmt.Errorf("unable to create temp dir: %w", err)
 	}

--- a/test/e2e_node/remote/remote.go
+++ b/test/e2e_node/remote/remote.go
@@ -19,7 +19,6 @@ package remote
 import (
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -39,7 +38,7 @@ const archiveName = "e2e_node_test.tar.gz"
 // CreateTestArchive creates the archive package for the node e2e test.
 func CreateTestArchive(suite TestSuite, systemSpecName string) (string, error) {
 	klog.V(2).Infof("Building archive...")
-	tardir, err := ioutil.TempDir("", "node-e2e-archive")
+	tardir, err := os.MkdirTemp("", "node-e2e-archive")
 	if err != nil {
 		return "", fmt.Errorf("failed to create temporary directory %v", err)
 	}

--- a/test/e2e_node/services/kubelet.go
+++ b/test/e2e_node/services/kubelet.go
@@ -344,7 +344,7 @@ func createPodDirectory() (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("failed to get current working directory: %v", err)
 	}
-	path, err := ioutil.TempDir(cwd, "static-pods")
+	path, err := os.MkdirTemp(cwd, "static-pods")
 	if err != nil {
 		return "", fmt.Errorf("failed to create static pod directory: %v", err)
 	}

--- a/test/integration/apiserver/print_test.go
+++ b/test/integration/apiserver/print_test.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"reflect"
 	"strings"
@@ -161,7 +160,7 @@ func TestServerSidePrint(t *testing.T) {
 		t.Errorf("unexpected error: %v", err)
 	}
 
-	cacheDir, err := ioutil.TempDir(os.TempDir(), "test-integration-apiserver-print")
+	cacheDir, err := os.MkdirTemp(os.TempDir(), "test-integration-apiserver-print")
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}

--- a/test/integration/client/exec_test.go
+++ b/test/integration/client/exec_test.go
@@ -806,7 +806,7 @@ func TestExecPluginRotationViaInformer(t *testing.T) {
 }
 
 func startTestServer(t *testing.T) (result *kubeapiservertesting.TestServer, clientAuthorizedToken string, clientCertFileName string, clientKeyFileName string) {
-	certDir, err := ioutil.TempDir("", "kubernetes-client-exec-test-cert-dir-*")
+	certDir, err := os.MkdirTemp("", "kubernetes-client-exec-test-cert-dir-*")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/test/integration/controlplane/transformation_testcase.go
+++ b/test/integration/controlplane/transformation_testcase.go
@@ -173,7 +173,7 @@ func (e *transformTest) getEncryptionOptions() []string {
 }
 
 func (e *transformTest) createEncryptionConfig() (string, error) {
-	tempDir, err := ioutil.TempDir("", "secrets-encryption-test")
+	tempDir, err := os.MkdirTemp("", "secrets-encryption-test")
 	if err != nil {
 		return "", fmt.Errorf("failed to create temp directory: %v", err)
 	}

--- a/test/integration/etcd/server.go
+++ b/test/integration/etcd/server.go
@@ -63,7 +63,7 @@ AwEHoUQDQgAEH6cuzP8XuD5wal6wf9M6xDljTOPLX2i8uIp/C/ASqiIGUeeKQtX0
 
 // StartRealAPIServerOrDie starts an API server that is appropriate for use in tests that require one of every resource
 func StartRealAPIServerOrDie(t *testing.T, configFuncs ...func(*options.ServerRunOptions)) *APIServer {
-	certDir, err := ioutil.TempDir("", t.Name())
+	certDir, err := os.MkdirTemp("", t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/test/integration/examples/apiserver_test.go
+++ b/test/integration/examples/apiserver_test.go
@@ -71,7 +71,7 @@ func TestAggregatedAPIServer(t *testing.T) {
 	// start the wardle server to prove we can aggregate it
 	wardleToKASKubeConfigFile := writeKubeConfigForWardleServerToKASConnection(t, rest.CopyConfig(kubeClientConfig))
 	defer os.Remove(wardleToKASKubeConfigFile)
-	wardleCertDir, _ := ioutil.TempDir("", "test-integration-wardle-server")
+	wardleCertDir, _ := os.MkdirTemp("", "test-integration-wardle-server")
 	defer os.RemoveAll(wardleCertDir)
 	listener, wardlePort, err := genericapiserveroptions.CreateListener("tcp", "127.0.0.1:0", net.ListenConfig{})
 	if err != nil {

--- a/test/integration/framework/etcd.go
+++ b/test/integration/framework/etcd.go
@@ -103,7 +103,7 @@ func RunCustomEtcd(dataDir string, customFlags []string) (url string, stopFn fun
 
 	klog.Infof("starting etcd on %s", customURL)
 
-	etcdDataDir, err := ioutil.TempDir(os.TempDir(), dataDir)
+	etcdDataDir, err := os.MkdirTemp(os.TempDir(), dataDir)
 	if err != nil {
 		return "", nil, fmt.Errorf("unable to make temp etcd data dir %s: %v", dataDir, err)
 	}

--- a/test/integration/framework/test_server.go
+++ b/test/integration/framework/test_server.go
@@ -57,7 +57,7 @@ type TestServerSetup struct {
 
 // StartTestServer runs a kube-apiserver, optionally calling out to the setup.ModifyServerRunOptions and setup.ModifyServerConfig functions
 func StartTestServer(t *testing.T, stopCh <-chan struct{}, setup TestServerSetup) (client.Interface, *rest.Config) {
-	certDir, _ := ioutil.TempDir("", "test-integration-"+t.Name())
+	certDir, _ := os.MkdirTemp("", "test-integration-"+t.Name())
 	go func() {
 		<-stopCh
 		os.RemoveAll(certDir)

--- a/test/utils/harness/harness.go
+++ b/test/utils/harness/harness.go
@@ -17,7 +17,6 @@ limitations under the License.
 package harness
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -56,11 +55,11 @@ func (h *Harness) Close() {
 	}
 }
 
-// TempDir is a wrapper around ioutil.TempDir for tests.
+// TempDir is a wrapper around os.MkdirTemp for tests.
 // It automatically fails the test if we can't create a temp file,
 // and deletes the temp directory when Close is called on the Harness
 func (h *Harness) TempDir(baseDir string, prefix string) string {
-	tempDir, err := ioutil.TempDir(baseDir, prefix)
+	tempDir, err := os.MkdirTemp(baseDir, prefix)
 	if err != nil {
 		h.Fatalf("unable to create tempdir: %v", err)
 	}

--- a/test/utils/tmpdir.go
+++ b/test/utils/tmpdir.go
@@ -17,16 +17,15 @@ limitations under the License.
 package utils
 
 import (
-	"io/ioutil"
-
 	"k8s.io/klog/v2"
+	"os"
 )
 
 func MakeTempDirOrDie(prefix string, baseDir string) string {
 	if baseDir == "" {
 		baseDir = "/tmp"
 	}
-	tempDir, err := ioutil.TempDir(baseDir, prefix)
+	tempDir, err := os.MkdirTemp(baseDir, prefix)
 	if err != nil {
 		klog.Fatalf("Can't make a temp rootdir: %v", err)
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
because ioutil.TempDir has been deprecated since Go 1.16, replace it by using `os.MkdirTemp`, FYI https://golang.org/doc/go1.16#ioutil

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
