### PR TITLE
IP Allocator cleanups

### DIFF
--- a/pkg/registry/core/rest/storage_core.go
+++ b/pkg/registry/core/rest/storage_core.go
@@ -198,7 +198,7 @@ func (c LegacyRESTStorageProvider) NewLegacyRESTStorage(restOptionsGetter generi
 		return LegacyRESTStorage{}, genericapiserver.APIGroupInfo{}, err
 	}
 
-	serviceClusterIPAllocator, err := ipallocator.NewAllocatorCIDRRange(&serviceClusterIPRange, func(max int, rangeSpec string) (allocator.Interface, error) {
+	serviceClusterIPAllocator, err := ipallocator.New(&serviceClusterIPRange, func(max int, rangeSpec string) (allocator.Interface, error) {
 		mem := allocator.NewAllocationMap(max, rangeSpec)
 		// TODO etcdallocator package to return a storage interface via the storageFactory
 		etcd, err := serviceallocator.NewEtcd(mem, "/ranges/serviceips", api.Resource("serviceipallocations"), serviceStorageConfig)
@@ -217,7 +217,7 @@ func (c LegacyRESTStorageProvider) NewLegacyRESTStorage(restOptionsGetter generi
 	var secondaryServiceClusterIPAllocator ipallocator.Interface
 	if utilfeature.DefaultFeatureGate.Enabled(features.IPv6DualStack) && c.SecondaryServiceIPRange.IP != nil {
 		var secondaryServiceClusterIPRegistry rangeallocation.RangeRegistry
-		secondaryServiceClusterIPAllocator, err = ipallocator.NewAllocatorCIDRRange(&c.SecondaryServiceIPRange, func(max int, rangeSpec string) (allocator.Interface, error) {
+		secondaryServiceClusterIPAllocator, err = ipallocator.New(&c.SecondaryServiceIPRange, func(max int, rangeSpec string) (allocator.Interface, error) {
 			mem := allocator.NewAllocationMap(max, rangeSpec)
 			// TODO etcdallocator package to return a storage interface via the storageFactory
 			etcd, err := serviceallocator.NewEtcd(mem, "/ranges/secondaryserviceips", api.Resource("serviceipallocations"), serviceStorageConfig)
@@ -234,7 +234,7 @@ func (c LegacyRESTStorageProvider) NewLegacyRESTStorage(restOptionsGetter generi
 	}
 
 	var serviceNodePortRegistry rangeallocation.RangeRegistry
-	serviceNodePortAllocator, err := portallocator.NewPortAllocatorCustom(c.ServiceNodePortRange, func(max int, rangeSpec string) (allocator.Interface, error) {
+	serviceNodePortAllocator, err := portallocator.New(c.ServiceNodePortRange, func(max int, rangeSpec string) (allocator.Interface, error) {
 		mem := allocator.NewAllocationMap(max, rangeSpec)
 		// TODO etcdallocator package to return a storage interface via the storageFactory
 		etcd, err := serviceallocator.NewEtcd(mem, "/ranges/servicenodeports", api.Resource("servicenodeportallocations"), serviceStorageConfig)

--- a/pkg/registry/core/service/allocator/bitmap.go
+++ b/pkg/registry/core/service/allocator/bitmap.go
@@ -72,18 +72,6 @@ func NewAllocationMap(max int, rangeSpec string) *AllocationBitmap {
 	return &a
 }
 
-// NewContiguousAllocationMap creates an allocation bitmap using the contiguous scan strategy.
-func NewContiguousAllocationMap(max int, rangeSpec string) *AllocationBitmap {
-	a := AllocationBitmap{
-		strategy:  contiguousScanStrategy{},
-		allocated: big.NewInt(0),
-		count:     0,
-		max:       max,
-		rangeSpec: rangeSpec,
-	}
-	return &a
-}
-
 // Allocate attempts to reserve the provided item.
 // Returns true if it was allocated, false if it was already in use
 func (r *AllocationBitmap) Allocate(offset int) (bool, error) {
@@ -217,20 +205,3 @@ func (rss randomScanStrategy) AllocateBit(allocated *big.Int, max, count int) (i
 }
 
 var _ bitAllocator = randomScanStrategy{}
-
-// contiguousScanStrategy tries to allocate starting at 0 and filling in any gaps
-type contiguousScanStrategy struct{}
-
-func (contiguousScanStrategy) AllocateBit(allocated *big.Int, max, count int) (int, bool) {
-	if count >= max {
-		return 0, false
-	}
-	for i := 0; i < max; i++ {
-		if allocated.Bit(i) == 0 {
-			return i, true
-		}
-	}
-	return 0, false
-}
-
-var _ bitAllocator = contiguousScanStrategy{}

--- a/pkg/registry/core/service/allocator/bitmap_test.go
+++ b/pkg/registry/core/service/allocator/bitmap_test.go
@@ -136,22 +136,3 @@ func TestSnapshotAndRestore(t *testing.T) {
 		t.Errorf("expect offset %v allocated", offset)
 	}
 }
-
-func TestContiguousAllocation(t *testing.T) {
-	max := 10
-	m := NewContiguousAllocationMap(max, "test")
-
-	for i := 0; i < max; i++ {
-		next, ok, _ := m.AllocateNext()
-		if !ok {
-			t.Fatalf("unexpected error")
-		}
-		if next != i {
-			t.Fatalf("expect next to %d, but got %d", i, next)
-		}
-	}
-
-	if _, ok, _ := m.AllocateNext(); ok {
-		t.Errorf("unexpected success")
-	}
-}

--- a/pkg/registry/core/service/ipallocator/allocator.go
+++ b/pkg/registry/core/service/ipallocator/allocator.go
@@ -81,8 +81,8 @@ type Range struct {
 	alloc allocator.Interface
 }
 
-// NewAllocatorCIDRRange creates a Range over a net.IPNet, calling allocatorFactory to construct the backing store.
-func NewAllocatorCIDRRange(cidr *net.IPNet, allocatorFactory allocator.AllocatorFactory) (*Range, error) {
+// New creates a Range over a net.IPNet, calling allocatorFactory to construct the backing store.
+func New(cidr *net.IPNet, allocatorFactory allocator.AllocatorFactory) (*Range, error) {
 	registerMetrics()
 
 	max := utilnet.RangeSize(cidr)
@@ -117,9 +117,9 @@ func NewAllocatorCIDRRange(cidr *net.IPNet, allocatorFactory allocator.Allocator
 	return &r, err
 }
 
-// Helper that wraps NewAllocatorCIDRRange, for creating a range backed by an in-memory store.
-func NewCIDRRange(cidr *net.IPNet) (*Range, error) {
-	return NewAllocatorCIDRRange(cidr, func(max int, rangeSpec string) (allocator.Interface, error) {
+// NewInMemory creates an in-memory allocator.
+func NewInMemory(cidr *net.IPNet) (*Range, error) {
+	return New(cidr, func(max int, rangeSpec string) (allocator.Interface, error) {
 		return allocator.NewAllocationMap(max, rangeSpec), nil
 	})
 }
@@ -130,7 +130,7 @@ func NewFromSnapshot(snap *api.RangeAllocation) (*Range, error) {
 	if err != nil {
 		return nil, err
 	}
-	r, err := NewCIDRRange(ipnet)
+	r, err := NewInMemory(ipnet)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/registry/core/service/ipallocator/allocator_test.go
+++ b/pkg/registry/core/service/ipallocator/allocator_test.go
@@ -69,7 +69,7 @@ func TestAllocate(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		r, err := NewCIDRRange(cidr)
+		r, err := NewInMemory(cidr)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -163,7 +163,7 @@ func TestAllocateTiny(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	r, err := NewCIDRRange(cidr)
+	r, err := NewInMemory(cidr)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -180,7 +180,7 @@ func TestAllocateSmall(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	r, err := NewCIDRRange(cidr)
+	r, err := NewInMemory(cidr)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -233,7 +233,7 @@ func TestForEach(t *testing.T) {
 	}
 
 	for i, tc := range testCases {
-		r, err := NewCIDRRange(cidr)
+		r, err := NewInMemory(cidr)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -264,7 +264,7 @@ func TestSnapshot(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	r, err := NewCIDRRange(cidr)
+	r, err := NewInMemory(cidr)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -296,14 +296,14 @@ func TestSnapshot(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = NewCIDRRange(otherCidr)
+	_, err = NewInMemory(otherCidr)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if err := r.Restore(otherCidr, dst.Data); err != ErrMismatchedNetwork {
 		t.Fatal(err)
 	}
-	other, err := NewCIDRRange(network)
+	other, err := NewInMemory(network)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -326,7 +326,7 @@ func TestNewFromSnapshot(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	r, err := NewCIDRRange(cidr)
+	r, err := NewInMemory(cidr)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -367,7 +367,7 @@ func TestClusterIPMetrics(t *testing.T) {
 	// create IPv4 allocator
 	cidrIPv4 := "10.0.0.0/24"
 	_, clusterCIDRv4, _ := net.ParseCIDR(cidrIPv4)
-	a, err := NewCIDRRange(clusterCIDRv4)
+	a, err := NewInMemory(clusterCIDRv4)
 	if err != nil {
 		t.Fatalf("unexpected error creating CidrSet: %v", err)
 	}
@@ -375,7 +375,7 @@ func TestClusterIPMetrics(t *testing.T) {
 	// create IPv6 allocator
 	cidrIPv6 := "2001:db8::/112"
 	_, clusterCIDRv6, _ := net.ParseCIDR(cidrIPv6)
-	b, err := NewCIDRRange(clusterCIDRv6)
+	b, err := NewInMemory(clusterCIDRv6)
 	if err != nil {
 		t.Fatalf("unexpected error creating CidrSet: %v", err)
 	}

--- a/pkg/registry/core/service/ipallocator/controller/repair.go
+++ b/pkg/registry/core/service/ipallocator/controller/repair.go
@@ -22,7 +22,7 @@ import (
 	"net"
 	"time"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/runtime"
@@ -178,7 +178,7 @@ func (c *Repair) runOnce() error {
 	rebuiltByFamily := make(map[v1.IPFamily]*ipallocator.Range)
 
 	for family, network := range c.networkByFamily {
-		rebuilt, err := ipallocator.NewCIDRRange(network)
+		rebuilt, err := ipallocator.NewInMemory(network)
 		if err != nil {
 			return fmt.Errorf("unable to create CIDR range for family %v: %v", family, err)
 		}

--- a/pkg/registry/core/service/ipallocator/controller/repair_test.go
+++ b/pkg/registry/core/service/ipallocator/controller/repair_test.go
@@ -82,7 +82,7 @@ func TestRepair(t *testing.T) {
 
 func TestRepairLeak(t *testing.T) {
 	_, cidr, _ := net.ParseCIDR("192.168.1.0/24")
-	previous, err := ipallocator.NewCIDRRange(cidr)
+	previous, err := ipallocator.NewInMemory(cidr)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -134,7 +134,7 @@ func TestRepairLeak(t *testing.T) {
 
 func TestRepairWithExisting(t *testing.T) {
 	_, cidr, _ := net.ParseCIDR("192.168.1.0/24")
-	previous, err := ipallocator.NewCIDRRange(cidr)
+	previous, err := ipallocator.NewInMemory(cidr)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -221,7 +221,7 @@ func TestRepairWithExisting(t *testing.T) {
 
 func makeRangeRegistry(t *testing.T, cidrRange string) *mockRangeRegistry {
 	_, cidr, _ := net.ParseCIDR(cidrRange)
-	previous, err := ipallocator.NewCIDRRange(cidr)
+	previous, err := ipallocator.NewInMemory(cidr)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -370,7 +370,7 @@ func TestRepairLeakDualStack(t *testing.T) {
 	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.IPv6DualStack, true)()
 
 	_, cidr, _ := net.ParseCIDR("192.168.1.0/24")
-	previous, err := ipallocator.NewCIDRRange(cidr)
+	previous, err := ipallocator.NewInMemory(cidr)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -378,7 +378,7 @@ func TestRepairLeakDualStack(t *testing.T) {
 	previous.Allocate(net.ParseIP("192.168.1.10"))
 
 	_, secondaryCIDR, _ := net.ParseCIDR("2000::/108")
-	secondaryPrevious, err := ipallocator.NewCIDRRange(secondaryCIDR)
+	secondaryPrevious, err := ipallocator.NewInMemory(secondaryCIDR)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -467,13 +467,13 @@ func TestRepairWithExistingDualStack(t *testing.T) {
 
 	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.IPv6DualStack, true)()
 	_, cidr, _ := net.ParseCIDR("192.168.1.0/24")
-	previous, err := ipallocator.NewCIDRRange(cidr)
+	previous, err := ipallocator.NewInMemory(cidr)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	_, secondaryCIDR, _ := net.ParseCIDR("2000::/108")
-	secondaryPrevious, err := ipallocator.NewCIDRRange(secondaryCIDR)
+	secondaryPrevious, err := ipallocator.NewInMemory(secondaryCIDR)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/registry/core/service/ipallocator/storage/storage_test.go
+++ b/pkg/registry/core/service/ipallocator/storage/storage_test.go
@@ -42,7 +42,7 @@ func newStorage(t *testing.T) (*etcd3testing.EtcdTestServer, ipallocator.Interfa
 	}
 
 	var backing allocator.Interface
-	storage, err := ipallocator.NewAllocatorCIDRRange(cidr, func(max int, rangeSpec string) (allocator.Interface, error) {
+	storage, err := ipallocator.New(cidr, func(max int, rangeSpec string) (allocator.Interface, error) {
 		mem := allocator.NewAllocationMap(max, rangeSpec)
 		backing = mem
 		etcd, err := allocatorstore.NewEtcd(mem, "/ranges/serviceips", api.Resource("serviceipallocations"), etcdStorage)

--- a/pkg/registry/core/service/portallocator/allocator.go
+++ b/pkg/registry/core/service/portallocator/allocator.go
@@ -60,8 +60,8 @@ type PortAllocator struct {
 // PortAllocator implements Interface and Snapshottable
 var _ Interface = &PortAllocator{}
 
-// NewPortAllocatorCustom creates a PortAllocator over a net.PortRange, calling allocatorFactory to construct the backing store.
-func NewPortAllocatorCustom(pr net.PortRange, allocatorFactory allocator.AllocatorFactory) (*PortAllocator, error) {
+// New creates a PortAllocator over a net.PortRange, calling allocatorFactory to construct the backing store.
+func New(pr net.PortRange, allocatorFactory allocator.AllocatorFactory) (*PortAllocator, error) {
 	max := pr.Size
 	rangeSpec := pr.String()
 
@@ -73,9 +73,9 @@ func NewPortAllocatorCustom(pr net.PortRange, allocatorFactory allocator.Allocat
 	return a, err
 }
 
-// Helper that wraps NewPortAllocatorCustom, for creating a range backed by an in-memory store.
-func NewPortAllocator(pr net.PortRange) (*PortAllocator, error) {
-	return NewPortAllocatorCustom(pr, func(max int, rangeSpec string) (allocator.Interface, error) {
+// NewInMemory creates an in-memory allocator.
+func NewInMemory(pr net.PortRange) (*PortAllocator, error) {
+	return New(pr, func(max int, rangeSpec string) (allocator.Interface, error) {
 		return allocator.NewAllocationMap(max, rangeSpec), nil
 	})
 }
@@ -86,7 +86,7 @@ func NewFromSnapshot(snap *api.RangeAllocation) (*PortAllocator, error) {
 	if err != nil {
 		return nil, err
 	}
-	r, err := NewPortAllocator(*pr)
+	r, err := NewInMemory(*pr)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/registry/core/service/portallocator/allocator_test.go
+++ b/pkg/registry/core/service/portallocator/allocator_test.go
@@ -31,7 +31,7 @@ func TestAllocate(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	r, err := NewPortAllocator(*pr)
+	r, err := NewInMemory(*pr)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -132,7 +132,7 @@ func TestForEach(t *testing.T) {
 	}
 
 	for i, tc := range testCases {
-		r, err := NewPortAllocator(*pr)
+		r, err := NewInMemory(*pr)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -164,7 +164,7 @@ func TestSnapshot(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	r, err := NewPortAllocator(*pr)
+	r, err := NewInMemory(*pr)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -196,14 +196,14 @@ func TestSnapshot(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = NewPortAllocator(*otherPr)
+	_, err = NewInMemory(*otherPr)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if err := r.Restore(*otherPr, dst.Data); err != ErrMismatchedNetwork {
 		t.Fatal(err)
 	}
-	other, err := NewPortAllocator(*pr2)
+	other, err := NewInMemory(*pr2)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -226,7 +226,7 @@ func TestNewFromSnapshot(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	r, err := NewPortAllocator(*pr)
+	r, err := NewInMemory(*pr)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/registry/core/service/portallocator/controller/repair.go
+++ b/pkg/registry/core/service/portallocator/controller/repair.go
@@ -123,7 +123,7 @@ func (c *Repair) runOnce() error {
 		return fmt.Errorf("unable to refresh the port block: %v", err)
 	}
 
-	rebuilt, err := portallocator.NewPortAllocator(c.portRange)
+	rebuilt, err := portallocator.NewInMemory(c.portRange)
 	if err != nil {
 		return fmt.Errorf("unable to create port allocator: %v", err)
 	}

--- a/pkg/registry/core/service/portallocator/controller/repair_test.go
+++ b/pkg/registry/core/service/portallocator/controller/repair_test.go
@@ -79,7 +79,7 @@ func TestRepair(t *testing.T) {
 
 func TestRepairLeak(t *testing.T) {
 	pr, _ := net.ParsePortRange("100-200")
-	previous, err := portallocator.NewPortAllocator(*pr)
+	previous, err := portallocator.NewInMemory(*pr)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -131,7 +131,7 @@ func TestRepairLeak(t *testing.T) {
 
 func TestRepairWithExisting(t *testing.T) {
 	pr, _ := net.ParsePortRange("100-200")
-	previous, err := portallocator.NewPortAllocator(*pr)
+	previous, err := portallocator.NewInMemory(*pr)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/registry/core/service/portallocator/operation_test.go
+++ b/pkg/registry/core/service/portallocator/operation_test.go
@@ -31,7 +31,7 @@ func TestDryRunAllocate(t *testing.T) {
 
 	// Allocate some ports before calling
 	previouslyAllocated := []int{10000, 10010, 10020}
-	r, err := NewPortAllocator(*pr)
+	r, err := NewInMemory(*pr)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -77,7 +77,7 @@ func TestDryRunAllocateNext(t *testing.T) {
 
 	// Allocate some ports before calling
 	previouslyAllocated := []int{10000, 10010, 10020}
-	r, err := NewPortAllocator(*pr)
+	r, err := NewInMemory(*pr)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/registry/core/service/portallocator/storage/storage_test.go
+++ b/pkg/registry/core/service/portallocator/storage/storage_test.go
@@ -45,7 +45,7 @@ func newStorage(t *testing.T) (*etcd3testing.EtcdTestServer, portallocator.Inter
 
 	serviceNodePortRange := utilnet.PortRange{Base: basePortRange, Size: sizePortRange}
 	var backing allocator.Interface
-	storage, err := portallocator.NewPortAllocatorCustom(serviceNodePortRange, func(max int, rangeSpec string) (allocator.Interface, error) {
+	storage, err := portallocator.New(serviceNodePortRange, func(max int, rangeSpec string) (allocator.Interface, error) {
 		mem := allocator.NewAllocationMap(max, rangeSpec)
 		backing = mem
 		etcd, err := allocatorstore.NewEtcd(mem, "/ranges/servicenodeports", api.Resource("servicenodeportallocations"), etcdStorage)

--- a/pkg/registry/core/service/storage/rest_test.go
+++ b/pkg/registry/core/service/storage/rest_test.go
@@ -215,12 +215,12 @@ func NewTestRESTWithPods(t *testing.T, endpoints []*api.Endpoints, pods []api.Po
 		var r ipallocator.Interface
 		switch family {
 		case api.IPv4Protocol:
-			r, err = ipallocator.NewCIDRRange(makeIPNet(t))
+			r, err = ipallocator.NewInMemory(makeIPNet(t))
 			if err != nil {
 				t.Fatalf("cannot create CIDR Range %v", err)
 			}
 		case api.IPv6Protocol:
-			r, err = ipallocator.NewCIDRRange(makeIPNet6(t))
+			r, err = ipallocator.NewInMemory(makeIPNet6(t))
 			if err != nil {
 				t.Fatalf("cannot create CIDR Range %v", err)
 			}
@@ -234,7 +234,7 @@ func NewTestRESTWithPods(t *testing.T, endpoints []*api.Endpoints, pods []api.Po
 	}
 
 	portRange := utilnet.PortRange{Base: 30000, Size: 1000}
-	portAllocator, err := portallocator.NewPortAllocator(portRange)
+	portAllocator, err := portallocator.NewInMemory(portRange)
 	if err != nil {
 		t.Fatalf("cannot create port allocator %v", err)
 	}


### PR DESCRIPTION
Some dead-code removal and API renames. 

I peeled these commits off the large Service REST overhaul.

/kind cleanup

```release-note
NONE
```
