### PR TITLE
test images: Use PULL_BASE_SHA for non-git image building

### DIFF
--- a/test/images/cloudbuild.yaml
+++ b/test/images/cloudbuild.yaml
@@ -14,8 +14,8 @@ steps:
     dir: ./test/images/
     env:
     - DOCKER_CLI_EXPERIMENTAL=enabled
-    - TAG=$_GIT_TAG
     - BASE_REF=$_PULL_BASE_REF
+    - GIT_COMMIT_ID=$_PULL_BASE_SHA
     - WHAT=$_WHAT
     - REGISTRY=$_REGISTRY
     # The default cloudbuild has HOME=/builder/home and docker buildx is in /root/.docker/cli-plugins/docker-buildx
@@ -40,6 +40,8 @@ substitutions:
   # _PULL_BASE_REF will contain the ref that was pushed to to trigger this build -
   # a branch like 'master' or 'release-0.2', or a tag like 'v0.2'.
   _PULL_BASE_REF: 'master'
+  # _PULL_BASE_SHA will contain the git SHA from which the image will be built from.
+  _PULL_BASE_SHA: '12345'
   # _REGISTRY will contain the staging registry.
   _REGISTRY: 'gcr.io/k8s-staging-e2e-test-images'
   # _WHAT will contain the image name to be built and published to the staging registry.

--- a/test/images/image-util.sh
+++ b/test/images/image-util.sh
@@ -36,7 +36,9 @@ source "${KUBE_ROOT}/hack/lib/util.sh"
 # Mapping of go ARCH to actual architectures shipped part of multiarch/qemu-user-static project
 declare -A QEMUARCHS=( ["amd64"]="x86_64" ["arm"]="arm" ["arm64"]="aarch64" ["ppc64le"]="ppc64le" ["s390x"]="s390x" )
 
-GIT_COMMIT_ID=$(git log -1 --format=%h)
+# NOTE(claudiub): In the test image build jobs, this script is not being run in a git repository,
+# which would cause git log to fail. Instead, we can use the GIT_COMMIT_ID set in cloudbuild.yaml.
+GIT_COMMIT_ID=$(git log -1 --format=%h || echo "${GIT_COMMIT_ID}")
 windows_os_versions=(1809 2004 20H2)
 declare -A WINDOWS_OS_VERSIONS_MAP
 


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind bug
/sig testing

/priority important-soon

#### What this PR does / why we need it:

In the test image build jobs, the ``image-util.sh`` script is not being run in a git repository, which causes git log to fail [1]. In this case, we can use the ``PULL_BASE_SHA`` set in ``cloudbuild.yaml`` instead.

[1] https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/post-kubernetes-push-e2e-agnhost-test-images/1425869767360647168

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

Depends On: https://github.com/kubernetes/test-infra/pull/23257

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
