### PR TITLE
Set default namespace in Event.Regarding if namespace is empty

### DIFF
--- a/staging/src/k8s.io/client-go/tools/events/event_recorder.go
+++ b/staging/src/k8s.io/client-go/tools/events/event_recorder.go
@@ -69,14 +69,14 @@ func (recorder *recorderImpl) Eventf(regarding runtime.Object, related runtime.O
 
 func (recorder *recorderImpl) makeEvent(refRegarding *v1.ObjectReference, refRelated *v1.ObjectReference, timestamp metav1.MicroTime, eventtype, reason, message string, reportingController string, reportingInstance string, action string) *eventsv1.Event {
 	t := metav1.Time{Time: recorder.clock.Now()}
-	namespace := refRegarding.Namespace
-	if namespace == "" {
-		namespace = metav1.NamespaceDefault
+	regarding := refRegarding.DeepCopy()
+	if regarding.Namespace == "" {
+		regarding.Namespace = metav1.NamespaceDefault
 	}
 	return &eventsv1.Event{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      fmt.Sprintf("%v.%x", refRegarding.Name, t.UnixNano()),
-			Namespace: namespace,
+			Namespace: regarding.Namespace,
 		},
 		EventTime:           timestamp,
 		Series:              nil,
@@ -84,7 +84,7 @@ func (recorder *recorderImpl) makeEvent(refRegarding *v1.ObjectReference, refRel
 		ReportingInstance:   reportingInstance,
 		Action:              action,
 		Reason:              reason,
-		Regarding:           *refRegarding,
+		Regarding:           *regarding,
 		Related:             refRelated,
 		Note:                message,
 		Type:                eventtype,


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
kube-apisever will rejected event when regarding.Namespace is empty

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #104394

#### Special notes for your reviewer:
@thockin @Yuan-Junliang

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
