### PR TITLE
test(cronjobs): adding unit tests for timezones

### DIFF
--- a/pkg/apis/batch/validation/validation_test.go
+++ b/pkg/apis/batch/validation/validation_test.go
@@ -606,6 +606,22 @@ func TestValidateCronJob(t *testing.T) {
 				},
 			},
 		},
+		"basic scheduled job with timezone": {
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "mycronjob",
+				Namespace: metav1.NamespaceDefault,
+				UID:       types.UID("1a2b3c"),
+			},
+			Spec: batch.CronJobSpec{
+				Schedule:          "CRON_TZ=UTC * * * * ?",
+				ConcurrencyPolicy: batch.AllowConcurrent,
+				JobTemplate: batch.JobTemplateSpec{
+					Spec: batch.JobSpec{
+						Template: validPodTemplateSpec,
+					},
+				},
+			},
+		},
 		"non-standard scheduled": {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "mycronjob",


### PR DESCRIPTION
Signed-off-by: cndoit18 <cndoit18@outlook.com>

#### What type of PR is this?

/kind cleanup
/sig testing

#### What this PR does / why we need it:

I observed that the `github.com/robfig/cron` was upgraded a few months ago and it supports the ability to customize the time zone, so I added this part of the unit test

fixes: #47202 
relate: #102735
see: https://pkg.go.dev/github.com/robfig/cron/v3#hdr-Time_zones

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```