### PR TITLE
Fix insufficient privileges to bind to port

### DIFF
--- a/test/e2e/network/service.go
+++ b/test/e2e/network/service.go
@@ -2134,14 +2134,14 @@ var _ = common.SIGDescribe("Services", func() {
 
 		serviceName := "svc-itp"
 		ns := f.Namespace.Name
-		servicePort := 80
+		servicePort := 8000
 
 		ginkgo.By("creating a TCP service " + serviceName + " with type=ClusterIP and internalTrafficPolicy=Local in namespace " + ns)
 		local := v1.ServiceInternalTrafficPolicyLocal
 		jig := e2eservice.NewTestJig(cs, ns, serviceName)
 		svc, err := jig.CreateTCPService(func(svc *v1.Service) {
 			svc.Spec.Ports = []v1.ServicePort{
-				{Port: 80, Name: "http", Protocol: v1.ProtocolTCP, TargetPort: intstr.FromInt(80)},
+				{Port: 8000, Name: "http", Protocol: v1.ProtocolTCP, TargetPort: intstr.FromInt(8000)},
 			}
 			svc.Spec.InternalTrafficPolicy = &local
 		})
@@ -2214,14 +2214,14 @@ var _ = common.SIGDescribe("Services", func() {
 
 		serviceName := "svc-itp"
 		ns := f.Namespace.Name
-		servicePort := 80
+		servicePort := 8000
 
 		ginkgo.By("creating a TCP service " + serviceName + " with type=ClusterIP and internalTrafficPolicy=Local in namespace " + ns)
 		local := v1.ServiceInternalTrafficPolicyLocal
 		jig := e2eservice.NewTestJig(cs, ns, serviceName)
 		svc, err := jig.CreateTCPService(func(svc *v1.Service) {
 			svc.Spec.Ports = []v1.ServicePort{
-				{Port: 80, Name: "http", Protocol: v1.ProtocolTCP, TargetPort: intstr.FromInt(80)},
+				{Port: 8000, Name: "http", Protocol: v1.ProtocolTCP, TargetPort: intstr.FromInt(8000)},
 			}
 			svc.Spec.InternalTrafficPolicy = &local
 		})


### PR DESCRIPTION
Container without elevated privileges to bind to host port less than 1024 causes bind permission denied error.
Increase port number greater than 1024 to allow binding.

Signed-off-by: Martin Kennelly <mkennell@redhat.com>

#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
Fix networking e2e test case setup

#### Does this PR introduce a user-facing change?
No

```release-note
NONE
```