### PR TITLE
Fix using variables in the loop in vsphere_util

### DIFF
--- a/staging/src/k8s.io/legacy-cloud-providers/vsphere/vsphere_util.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/vsphere/vsphere_util.go
@@ -639,7 +639,7 @@ func (vs *VSphere) BuildMissingVolumeNodeMap(ctx context.Context) {
 		// Start go routines per VC-DC to check disks are attached
 		wg.Add(1)
 		go func(nodes []k8stypes.NodeName) {
-			err := vs.checkNodeDisks(ctx, nodeNames)
+			err := vs.checkNodeDisks(ctx, nodes)
 			if err != nil {
 				klog.Errorf("Failed to check disk attached for nodes: %+v. err: %+v", nodes, err)
 			}


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
Use loop variables from within func literals in defer and go statements. Such variables might have unexpected values because they are not copied to func literals, and the func literals in defer and go are not executed immediately.
For more information about closures and goroutines, see https://golang.org/doc/faq#closures_and_goroutines, thanks

```release-note
NONE
```
