### PR TITLE
Update unit tests to handle go1.17 certificate parsing error messages

### DIFF
--- a/pkg/apis/certificates/validation/validation_test.go
+++ b/pkg/apis/certificates/validation/validation_test.go
@@ -24,6 +24,7 @@ import (
 	"encoding/pem"
 	"fmt"
 	"reflect"
+	"regexp"
 	"strings"
 	"testing"
 	"time"
@@ -895,7 +896,10 @@ func Test_validateCertificateSigningRequestOptions(t *testing.T) {
 		// options that allow the csr to pass validation
 		lenientOpts certificateValidationOptions
 
-		// expected errors when validating strictly
+		// regexes matching expected errors when validating strictly
+		strictRegexes []regexp.Regexp
+
+		// expected errors (after filtering out errors matched by strictRegexes) when validating strictly
 		strictErrs []string
 	}{
 		// valid strict cases
@@ -1048,8 +1052,8 @@ func Test_validateCertificateSigningRequestOptions(t *testing.T) {
 					Certificate: invalidCertificateNonASN1Data,
 				},
 			},
-			lenientOpts: certificateValidationOptions{allowArbitraryCertificate: true},
-			strictErrs:  []string{`status.certificate: Invalid value: "<certificate data>": asn1: structure error: sequence tag mismatch`},
+			lenientOpts:   certificateValidationOptions{allowArbitraryCertificate: true},
+			strictRegexes: []regexp.Regexp{*regexp.MustCompile(`status.certificate: Invalid value: "\<certificate data\>": (asn1: structure error: sequence tag mismatch|x509: invalid RDNSequence)`)},
 		},
 	}
 
@@ -1065,12 +1069,27 @@ func Test_validateCertificateSigningRequestOptions(t *testing.T) {
 			for _, err := range validateCertificateSigningRequest(tt.csr, certificateValidationOptions{}) {
 				gotErrs.Insert(err.Error())
 			}
+
+			// filter errors matching strictRegexes and ensure every strictRegex matches at least one error
+			for _, expectedRegex := range tt.strictRegexes {
+				matched := false
+				for _, err := range gotErrs.List() {
+					if expectedRegex.MatchString(err) {
+						gotErrs.Delete(err)
+						matched = true
+					}
+				}
+				if !matched {
+					t.Errorf("missing expected error matching: %s", expectedRegex.String())
+				}
+			}
+
 			wantErrs := sets.NewString(tt.strictErrs...)
 			for _, missing := range wantErrs.Difference(gotErrs).List() {
 				t.Errorf("missing expected strict error: %s", missing)
 			}
 			for _, unexpected := range gotErrs.Difference(wantErrs).List() {
-				t.Errorf("unexpected strict error: %s", unexpected)
+				t.Errorf("unexpected errors: %s", unexpected)
 			}
 		})
 	}

--- a/staging/src/k8s.io/apiserver/pkg/util/webhook/webhook_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/webhook/webhook_test.go
@@ -197,7 +197,7 @@ MIIDGTCCAgGgAwIBAgIUOS2M
 				},
 			},
 			user:     &defaultUser,
-			errRegex: "unable to load root certificates: failed to parse certificate: asn1: syntax error: data truncated",
+			errRegex: "unable to load root certificates: failed to parse certificate: (asn1: syntax error: data truncated|x509: malformed certificate)",
 		},
 		{
 			test:    "user with invalid client certificate path",


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### Which issue(s) this PR fixes:
xref https://github.com/kubernetes/kubernetes/pull/103692#issuecomment-898697054 https://github.com/kubernetes/release/issues/2169

```release-note
NONE
```

/cc @justaugustus 