### PR TITLE
fix DATA RACE in TestVolumeUnmountAndDetachControllerEnabled

### DIFF
--- a/pkg/kubelet/kubelet_volumes_test.go
+++ b/pkg/kubelet/kubelet_volumes_test.go
@@ -504,7 +504,9 @@ func TestVolumeUnmountAndDetachControllerEnabled(t *testing.T) {
 		1 /* expectedSetUpCallCount */, testKubelet.volumePlugin))
 
 	// Remove pod
+	kubelet.podWorkers.(*fakePodWorkers).statusLock.Lock()
 	kubelet.podWorkers.(*fakePodWorkers).removeRuntime = map[types.UID]bool{pod.UID: true}
+	kubelet.podWorkers.(*fakePodWorkers).statusLock.Unlock()
 	kubelet.podManager.SetPods([]*v1.Pod{})
 
 	assert.NoError(t, waitForVolumeUnmount(kubelet.volumeManager, pod))


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
fix DATA RACE in TestVolumeUnmountAndDetachControllerEnabled
```
=== RUN   TestVolumeUnmountAndDetachControllerEnabled
W0802 20:40:10.390406   62960 mutation_detector.go:53] Mutation detector is enabled, this will result in memory leakage.
I0802 20:40:10.391274   62960 volume_manager.go:291] "Starting Kubelet Volume Manager"
I0802 20:40:10.391480   62960 desired_state_of_world_populator.go:146] "Desired state populator starts to run"
E0802 20:40:10.394703   62960 reflector.go:138] k8s.io/client-go/informers/factory.go:134: Failed to watch *v1.CSIDriver: failed to list *v1.CSIDriver: no reaction implemented for {{ list storage.k8s.io/v1, Resource=csidrivers } storage.k8s.io/v1, Kind=CSIDriver  { }}
I0802 20:40:10.594831   62960 reconciler.go:224] "operationExecutor.VerifyControllerAttachedVolume started for volume \"vol1\" (UniqueName: \"fake/fake-device\") pod \"foo\" (UID: \"12345678\") "
I0802 20:40:10.594924   62960 operation_generator.go:1523] Controller attach succeeded for volume "vol1" (UniqueName: "fake/fake-device") pod "foo" (UID: "12345678") device path: "fake/path"
I0802 20:40:10.594997   62960 reconciler.go:157] "Reconciler: start to sync state"
I0802 20:40:10.744204   62960 operation_generator.go:587] MountVolume.WaitForAttach entering for volume "vol1" (UniqueName: "fake/fake-device") pod "foo" (UID: "12345678") DevicePath "fake/path"
I0802 20:40:10.744366   62960 operation_generator.go:597] MountVolume.WaitForAttach succeeded for volume "vol1" (UniqueName: "fake/fake-device") pod "foo" (UID: "12345678") DevicePath "/dev/sdb"
I0802 20:40:10.744484   62960 operation_generator.go:630] MountVolume.MountDevice succeeded for volume "vol1" (UniqueName: "fake/fake-device") pod "foo" (UID: "12345678") device mount path ""
==================
WARNING: DATA RACE
Write at 0x00c0002fe8e8 by goroutine 51:
  k8s.io/kubernetes/pkg/kubelet.TestVolumeUnmountAndDetachControllerEnabled()
      /home/prow/go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/pkg/kubelet/kubelet_volumes_test.go:507 +0x1193
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:1193 +0x202

Previous read at 0x00c0002fe8e8 by goroutine 77:
  k8s.io/kubernetes/pkg/kubelet.(*fakePodWorkers).ShouldPodRuntimeBeRemoved()
      /home/prow/go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/pkg/kubelet/pod_workers_test.go:106 +0xbc
  k8s.io/kubernetes/pkg/kubelet/volumemanager/populator.(*desiredStateOfWorldPopulator).findAndRemoveDeletedPods()
      /home/prow/go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/pkg/kubelet/volumemanager/populator/desired_state_of_world_populator.go:232 +0x241
  k8s.io/kubernetes/pkg/kubelet/volumemanager/populator.(*desiredStateOfWorldPopulator).populatorLoop()
      /home/prow/go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/pkg/kubelet/volumemanager/populator/desired_state_of_world_populator.go:182 +0x464
  k8s.io/kubernetes/pkg/kubelet/volumemanager/populator.(*desiredStateOfWorldPopulator).populatorLoop-fm()
      /home/prow/go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/pkg/kubelet/volumemanager/populator/desired_state_of_world_populator.go:169 +0x4a
  k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1()
      /home/prow/go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:155 +0x75
  k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/util/wait.BackoffUntil()
      /home/prow/go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:156 +0xba
  k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/util/wait.JitterUntil()
      /home/prow/go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:133 +0x114
  k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/util/wait.Until()
      /home/prow/go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:90 +0x299
  k8s.io/kubernetes/pkg/kubelet/volumemanager/populator.(*desiredStateOfWorldPopulator).Run()
      /home/prow/go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/pkg/kubelet/volumemanager/populator/desired_state_of_world_populator.go:155 +0x225

Goroutine 51 (running) created at:
  testing.(*T).Run()
      /usr/local/go/src/testing/testing.go:1238 +0x5d7
  testing.runTests.func1()
      /usr/local/go/src/testing/testing.go:1511 +0xa6
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:1193 +0x202
  testing.runTests()
      /usr/local/go/src/testing/testing.go:1509 +0x612
  testing.(*M).Run()
      /usr/local/go/src/testing/testing.go:1417 +0x3b3
  main.main()
      _testmain.go:247 +0x236
  runtime.main()
      /usr/local/go/src/runtime/proc.go:225 +0x255
  k8s.io/kubernetes/vendor/github.com/cilium/ebpf/link.init()
      /home/prow/go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/vendor/github.com/cilium/ebpf/link/syscalls.go:50 +0x2eb
  k8s.io/kubernetes/vendor/github.com/cilium/ebpf/link.init()
      /home/prow/go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/vendor/github.com/cilium/ebpf/link/syscalls.go:29 +0x279
  runtime.doInit()
      /usr/local/go/src/runtime/proc.go:6309 +0xeb
  k8s.io/kubernetes/vendor/github.com/cilium/ebpf.init()
      /home/prow/go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/vendor/github.com/cilium/ebpf/syscalls.go:426 +0x6cb
  k8s.io/kubernetes/vendor/github.com/cilium/ebpf.init()
      /home/prow/go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/vendor/github.com/cilium/ebpf/prog.go:458 +0x658
  k8s.io/kubernetes/vendor/github.com/cilium/ebpf.init()
      /home/prow/go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/vendor/github.com/cilium/ebpf/syscalls.go:408 +0x5eb
  k8s.io/kubernetes/vendor/github.com/cilium/ebpf.init()
      /home/prow/go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/vendor/github.com/cilium/ebpf/syscalls.go:236 +0x578
  k8s.io/kubernetes/vendor/github.com/cilium/ebpf.init()
      /home/prow/go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/vendor/github.com/cilium/ebpf/syscalls.go:220 +0x50b
  k8s.io/kubernetes/vendor/github.com/cilium/ebpf.init()
      /home/prow/go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/vendor/github.com/cilium/ebpf/syscalls.go:203 +0x498
  k8s.io/kubernetes/vendor/github.com/cilium/ebpf.init()
      /home/prow/go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/vendor/github.com/cilium/ebpf/syscalls.go:185 +0x42b
  runtime.doInit()
      /usr/local/go/src/runtime/proc.go:6309 +0xeb
  k8s.io/kubernetes/vendor/github.com/cilium/ebpf/internal/btf.init()
      /home/prow/go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/vendor/github.com/cilium/ebpf/internal/btf/btf.go:728 +0x1cc

Goroutine 77 (running) created at:
  k8s.io/kubernetes/pkg/kubelet/volumemanager.(*volumeManager).Run()
      /home/prow/go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/pkg/kubelet/volumemanager/volume_manager.go:288 +0x117
==================
I0802 20:40:11.247466   62960 reconciler.go:196] "operationExecutor.UnmountVolume started for volume \"vol1\" (UniqueName: \"fake/fake-device\") pod \"12345678\" (UID: \"12345678\") "
I0802 20:40:11.247776   62960 operation_generator.go:866] UnmountVolume.TearDown succeeded for volume "fake/fake-device" (OuterVolumeSpecName: "vol1") pod "12345678" (UID: "12345678"). InnerVolumeSpecName "vol1". PluginName "fake", VolumeGidValue ""
I0802 20:40:11.348553   62960 reconciler.go:312] "operationExecutor.UnmountDevice started for volume \"vol1\" (UniqueName: \"fake/fake-device\") on node \"127.0.0.1\" "
I0802 20:40:11.348769   62960 operation_generator.go:974] UnmountDevice succeeded for volume "vol1" %!(EXTRA string=UnmountDevice succeeded for volume "vol1" (UniqueName: "fake/fake-device") on node "127.0.0.1" )
E0802 20:40:11.444253   62960 reflector.go:138] k8s.io/client-go/informers/factory.go:134: Failed to watch *v1.CSIDriver: failed to list *v1.CSIDriver: no reaction implemented for {{ list storage.k8s.io/v1, Resource=csidrivers } storage.k8s.io/v1, Kind=CSIDriver  { }}
I0802 20:40:11.448928   62960 reconciler.go:319] "Volume detached for volume \"vol1\" (UniqueName: \"fake/fake-device\") on node \"127.0.0.1\" DevicePath \"/dev/sdb\""
I0802 20:40:11.544191   62960 volume_manager.go:297] "Shutting down Kubelet Volume Manager"
    testing.go:1092: race detected during execution of test
--- FAIL: TestVolumeUnmountAndDetachControllerEnabled (1.16s)
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
