### PR TITLE
WIP: Strict schema validation for POST and PUT

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/runtime/interfaces.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/interfaces.go
@@ -125,6 +125,8 @@ type SerializerInfo struct {
 	// PrettySerializer, if set, can serialize this object in a form biased towards
 	// readability.
 	PrettySerializer Serializer
+	// StrictSerializer errors on unknown fields when deserializing an object
+	StrictSerializer Serializer
 	// StreamSerializer, if set, describes the streaming serialization format
 	// for this media type.
 	StreamSerializer *StreamSerializerInfo

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/codec_factory.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/codec_factory.go
@@ -40,6 +40,7 @@ type serializerType struct {
 
 	Serializer       runtime.Serializer
 	PrettySerializer runtime.Serializer
+	StrictSerializer runtime.Serializer
 
 	AcceptStreamContentTypes []string
 	StreamContentType        string
@@ -69,10 +70,18 @@ func newSerializersForScheme(scheme *runtime.Scheme, mf json.MetaFactory, option
 			json.SerializerOptions{Yaml: false, Pretty: true, Strict: options.Strict},
 		)
 	}
-
+	strictJSONSerializer := json.NewSerializerWithOptions(
+		mf, scheme, scheme,
+		json.SerializerOptions{Yaml: false, Pretty: false, Strict: true},
+	)
+	jsonSerializerType.StrictSerializer = strictJSONSerializer
 	yamlSerializer := json.NewSerializerWithOptions(
 		mf, scheme, scheme,
 		json.SerializerOptions{Yaml: true, Pretty: false, Strict: options.Strict},
+	)
+	strictYAMLSerializer := json.NewSerializerWithOptions(
+		mf, scheme, scheme,
+		json.SerializerOptions{Yaml: true, Pretty: false, Strict: true},
 	)
 	protoSerializer := protobuf.NewSerializer(scheme, scheme)
 	protoRawSerializer := protobuf.NewRawSerializer(scheme, scheme)
@@ -85,6 +94,7 @@ func newSerializersForScheme(scheme *runtime.Scheme, mf json.MetaFactory, option
 			FileExtensions:     []string{"yaml"},
 			EncodesAsText:      true,
 			Serializer:         yamlSerializer,
+			StrictSerializer:   strictYAMLSerializer,
 		},
 		{
 			AcceptContentTypes: []string{runtime.ContentTypeProtobuf},
@@ -187,6 +197,7 @@ func newCodecFactory(scheme *runtime.Scheme, serializers []serializerType) Codec
 				EncodesAsText:    d.EncodesAsText,
 				Serializer:       d.Serializer,
 				PrettySerializer: d.PrettySerializer,
+				StrictSerializer: d.StrictSerializer,
 			}
 
 			mediaType, _, err := mime.ParseMediaType(info.MediaType)

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/types.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/types.go
@@ -41,9 +41,10 @@ type TypeMeta struct {
 }
 
 const (
-	ContentTypeJSON     string = "application/json"
-	ContentTypeYAML     string = "application/yaml"
-	ContentTypeProtobuf string = "application/vnd.kubernetes.protobuf"
+	ContentTypeJSON           string = "application/json"
+	ContentTypeJSONMergePatch string = "application/merge-patch+json"
+	ContentTypeYAML           string = "application/yaml"
+	ContentTypeProtobuf       string = "application/vnd.kubernetes.protobuf"
 )
 
 // RawExtension is used to hold extensions in external versions.

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/apiserver_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/apiserver_test.go
@@ -4353,7 +4353,7 @@ func TestUpdateChecksAPIVersion(t *testing.T) {
 
 // runRequest is used by TestDryRun and TestFieldValidation since it runs the test
 // twice in a row with a slightly different URL (one has ?dryRun, one doesn't).
-func runRequest(t *testing.T, path, verb string, data []byte, contentType string) *http.Response {
+func runRequest(t testing.TB, path, verb string, data []byte, contentType string) *http.Response {
 	request, err := http.NewRequest(verb, path, bytes.NewBuffer(data))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -4364,22 +4364,6 @@ func runRequest(t *testing.T, path, verb string, data []byte, contentType string
 	response, err := http.DefaultClient.Do(request)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
-	}
-	return response
-}
-
-// runRequestOrDie is like runRequest, but used for benchmarking.
-func runRequestOrDie(path, verb string, data []byte, contentType string) *http.Response {
-	request, err := http.NewRequest(verb, path, bytes.NewBuffer(data))
-	if err != nil {
-		panic(err)
-	}
-	if contentType != "" {
-		request.Header.Set("Content-Type", contentType)
-	}
-	response, err := http.DefaultClient.Do(request)
-	if err != nil {
-		panic(err)
 	}
 	return response
 }
@@ -4495,12 +4479,12 @@ func BenchmarkFieldValidation(b *testing.B) {
 				postPath := "/namespaces/default/simples"
 				postData := []byte(`{"kind":"Simple","apiVersion":"test.group/version","metadata":{"creationTimestamp":null},"other":"bar"}`)
 				basePostURL := server.URL + "/" + prefix + "/" + testGroupVersion.Group + "/" + testGroupVersion.Version
-				_ = runRequestOrDie(basePostURL+postPath+bm.queryParam, "POST", postData, "")
+				_ = runRequest(b, basePostURL+postPath+bm.queryParam, "POST", postData, "")
 
 				putPath := "/namespaces/default/simples/id"
 				putData := []byte(`{"kind": "Simple", "apiVersion": "test.group/version", "metadata": {"name": "id", "creationTimestamp": null}, "other": "bar", "unknown": "baz"}`)
 				basePutURL := server.URL + "/" + prefix + "/" + testGroupVersion.Group + "/" + testGroupVersion.Version
-				_ = runRequestOrDie(basePutURL+putPath+bm.queryParam, "PUT", putData, "")
+				_ = runRequest(b, basePutURL+putPath+bm.queryParam, "PUT", putData, "")
 			}
 		})
 

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/apiserver_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/apiserver_test.go
@@ -4351,7 +4351,7 @@ func TestUpdateChecksAPIVersion(t *testing.T) {
 	}
 }
 
-// runRequest is used by TestDryRun and TestStrictValidation since it runs the test
+// runRequest is used by TestDryRun and TestFieldValidation since it runs the test
 // twice in a row with a slightly different URL (one has ?dryRun, one doesn't).
 func runRequest(t *testing.T, path, verb string, data []byte, contentType string) *http.Response {
 	request, err := http.NewRequest(verb, path, bytes.NewBuffer(data))
@@ -4404,7 +4404,7 @@ func (storage *SimpleRESTStorageWithDeleteCollection) DeleteCollection(ctx conte
 	return nil, nil
 }
 
-func TestStrictValidation(t *testing.T) {
+func TestFieldValidation(t *testing.T) {
 	strictDecoderErr := "strict decoder error for"
 	// TODO: add test cases for yaml validation and protobuf early exit.
 	tests := []struct {
@@ -4448,7 +4448,7 @@ func TestStrictValidation(t *testing.T) {
 		if response.StatusCode == http.StatusBadRequest {
 			t.Fatalf("unexpected BadRequest: %#v", response)
 		}
-		response = runRequest(t, baseURL+test.path+"?validate=strict", test.verb, test.data, test.contentType)
+		response = runRequest(t, baseURL+test.path+"?fieldValidation=Strict", test.verb, test.data, test.contentType)
 		buf := new(bytes.Buffer)
 		buf.ReadFrom(response.Body)
 		// TODO: better way of doing than string comparison since we are getting a response instead of a regular go error?
@@ -4459,45 +4459,14 @@ func TestStrictValidation(t *testing.T) {
 
 }
 
-// TODO: this is a pretty crude benchmark since it only operates on the simples resource
-// I imagine we want to benchmark some meatier resources too, because maybe the discrepancy in
-// performance is greater for bigger objects?
-func BenchmarkNonStrictValidationSimples(b *testing.B) {
-	server := httptest.NewServer(handle(map[string]rest.Storage{
-		"simples": &SimpleRESTStorageWithDeleteCollection{
-			SimpleRESTStorage{
-				item: genericapitesting.Simple{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "id",
-						Namespace: "",
-						UID:       "uid",
-					},
-					Other: "bar",
-				},
-			},
-		},
-		"simples/subsimple": &SimpleXGSubresourceRESTStorage{
-			item: genericapitesting.SimpleXGSubresource{
-				SubresourceInfo: "foo",
-			},
-			itemGVK: testGroup2Version.WithKind("SimpleXGSubresource"),
-		},
-	}))
-	defer server.Close()
-
-	for n := 0; n < b.N; n++ {
-		postPath := "/namespaces/default/simples"
-		postData := []byte(`{"kind":"Simple","apiVersion":"test.group/version","metadata":{"creationTimestamp":null},"other":"bar"}`)
-		basePostURL := server.URL + "/" + prefix + "/" + testGroupVersion.Group + "/" + testGroupVersion.Version
-		_ = runRequestOrDie(basePostURL+postPath, "POST", postData, "")
-
-		putPath := "/namespaces/default/simples/id"
-		putData := []byte(`{"kind": "Simple", "apiVersion": "test.group/version", "metadata": {"name": "id", "creationTimestamp": null}, "other": "bar", "unknown": "baz"}`)
-		basePutURL := server.URL + "/" + prefix + "/" + testGroupVersion.Group + "/" + testGroupVersion.Version
-		_ = runRequestOrDie(basePutURL+putPath, "POST", putData, "")
+func BenchmarkFieldValidation(b *testing.B) {
+	benchmarks := []struct {
+		name       string
+		queryParam string
+	}{
+		{"nonstrict simples", ""},
+		{"strict simples", "?fieldValidation=Strict"},
 	}
-}
-func BenchmarkStrictValidationSimples(b *testing.B) {
 	server := httptest.NewServer(handle(map[string]rest.Storage{
 		"simples": &SimpleRESTStorageWithDeleteCollection{
 			SimpleRESTStorage{
@@ -4520,16 +4489,21 @@ func BenchmarkStrictValidationSimples(b *testing.B) {
 	}))
 	defer server.Close()
 
-	for n := 0; n < b.N; n++ {
-		postPath := "/namespaces/default/simples"
-		postData := []byte(`{"kind":"Simple","apiVersion":"test.group/version","metadata":{"creationTimestamp":null},"other":"bar"}`)
-		basePostURL := server.URL + "/" + prefix + "/" + testGroupVersion.Group + "/" + testGroupVersion.Version
-		_ = runRequestOrDie(basePostURL+postPath+"?validate=strict", "POST", postData, "")
+	for _, bm := range benchmarks {
+		b.Run(bm.name, func(b *testing.B) {
+			for n := 0; n < b.N; n++ {
+				postPath := "/namespaces/default/simples"
+				postData := []byte(`{"kind":"Simple","apiVersion":"test.group/version","metadata":{"creationTimestamp":null},"other":"bar"}`)
+				basePostURL := server.URL + "/" + prefix + "/" + testGroupVersion.Group + "/" + testGroupVersion.Version
+				_ = runRequestOrDie(basePostURL+postPath+bm.queryParam, "POST", postData, "")
 
-		putPath := "/namespaces/default/simples/id"
-		putData := []byte(`{"kind": "Simple", "apiVersion": "test.group/version", "metadata": {"name": "id", "creationTimestamp": null}, "other": "bar", "unknown": "baz"}`)
-		basePutURL := server.URL + "/" + prefix + "/" + testGroupVersion.Group + "/" + testGroupVersion.Version
-		_ = runRequestOrDie(basePutURL+putPath+"?validate=strict", "POST", putData, "")
+				putPath := "/namespaces/default/simples/id"
+				putData := []byte(`{"kind": "Simple", "apiVersion": "test.group/version", "metadata": {"name": "id", "creationTimestamp": null}, "other": "bar", "unknown": "baz"}`)
+				basePutURL := server.URL + "/" + prefix + "/" + testGroupVersion.Group + "/" + testGroupVersion.Version
+				_ = runRequestOrDie(basePutURL+putPath+bm.queryParam, "PUT", putData, "")
+			}
+		})
+
 	}
 }
 

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/create.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/create.go
@@ -92,7 +92,12 @@ func createHandler(r rest.NamedCreater, scope *RequestScope, admit admission.Int
 			return
 		}
 
-		decoder := scope.Serializer.DecoderToVersion(s.Serializer, scope.HubGroupVersion)
+		decodeSerializer := s.Serializer
+		// TODO: put behind feature flag?
+		if strictValidation(req.URL) {
+			decodeSerializer = s.StrictSerializer
+		}
+		decoder := scope.Serializer.DecoderToVersion(decodeSerializer, scope.HubGroupVersion)
 
 		body, err := limitedReadBody(req, scope.MaxRequestBodyBytes)
 		if err != nil {

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/create.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/create.go
@@ -93,8 +93,13 @@ func createHandler(r rest.NamedCreater, scope *RequestScope, admit admission.Int
 		}
 
 		decodeSerializer := s.Serializer
-		// TODO: put behind feature flag?
-		if strictValidation(req.URL) {
+		// TODO: put behind feature gate?
+		validationDirective, err := fieldValidation(req)
+		if err != nil {
+			scope.err(err, w, req)
+			return
+		}
+		if validationDirective == strictFieldValidation {
 			decodeSerializer = s.StrictSerializer
 		}
 		decoder := scope.Serializer.DecoderToVersion(decodeSerializer, scope.HubGroupVersion)

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/patch.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/patch.go
@@ -70,8 +70,13 @@ func PatchResource(r rest.Patcher, scope *RequestScope, admit admission.Interfac
 			return
 		}
 
-		// TODO: put behind feature flag?
-		if strictValidation(req.URL) {
+		// TODO: put behind feature gate?
+		validationDirective, err := fieldValidation(req)
+		if err != nil {
+			scope.err(err, w, req)
+			return
+		}
+		if validationDirective == strictFieldValidation {
 			scope.err(errors.NewBadRequest("strict validation is not supported yet"), w, req)
 			return
 		}

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/patch.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/patch.go
@@ -70,6 +70,12 @@ func PatchResource(r rest.Patcher, scope *RequestScope, admit admission.Interfac
 			return
 		}
 
+		// TODO: put behind feature flag?
+		if strictValidation(req.URL) {
+			scope.err(errors.NewBadRequest("strict validation is not supported yet"), w, req)
+			return
+		}
+
 		// Do this first, otherwise name extraction can fail for unrecognized content types
 		// TODO: handle this in negotiation
 		contentType := req.Header.Get("Content-Type")

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/rest.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/rest.go
@@ -456,6 +456,15 @@ func isDryRun(url *url.URL) bool {
 	return len(url.Query()["dryRun"]) != 0
 }
 
+// TODO: currently strict validation is set via
+// query param. Alternatively we could use a request header.
+// TODO: maybe we should check content-type here and error for protobuf (ie take the full req instead of just the URL?)
+// TODO: what do we want the query param to actually be (I went with ?validate=strict but am open to whatever)
+func strictValidation(url *url.URL) bool {
+	validateParam := url.Query()["validate"]
+	return len(validateParam) == 1 && validateParam[0] == "strict"
+}
+
 type etcdError interface {
 	Code() grpccodes.Code
 	Error() string

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/rest.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/rest.go
@@ -470,17 +470,19 @@ const (
 // media type, because the list of media types that support field validation are a subset of
 // all supported media types (only json and yaml supports field validation).
 func fieldValidation(req *http.Request) (fieldValidationDirective, error) {
-	supportedMediaTypes := []string{"application/json", "application/yaml"}
+	supportedContentTypes := []string{runtime.ContentTypeJSON, runtime.ContentTypeJSONMergePatch, runtime.ContentTypeYAML}
 	supported := false
-	contentType := req.Header.Get("ContentType")
+	contentType := req.Header.Get("Content-Type")
+	//contentType := req.Header.Get("ContentType")
 	// TODO: not sure if it is okay to assume empty content type is a valid one
 	if contentType != "" {
 		for _, v := range strings.Split(contentType, ",") {
 			t, _, err := mime.ParseMediaType(v)
+			fmt.Printf("t = %+v\n", t)
 			if err != nil {
 				return ignoreFieldValidation, errors.NewBadRequest(fmt.Sprintf("could not parse media type: %v", v))
 			}
-			for _, mt := range supportedMediaTypes {
+			for _, mt := range supportedContentTypes {
 				if t == mt {
 					supported = true
 					break
@@ -488,7 +490,7 @@ func fieldValidation(req *http.Request) (fieldValidationDirective, error) {
 			}
 		}
 		if !supported {
-			return ignoreFieldValidation, errors.NewBadRequest(fmt.Sprintf("fieldValidation parameter only supports media types types %v\n content type provided: %s", supportedMediaTypes, contentType))
+			return ignoreFieldValidation, errors.NewBadRequest(fmt.Sprintf("fieldValidation parameter only supports content types %v\n content type provided: %s", supportedContentTypes, contentType))
 		}
 	}
 

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/update.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/update.go
@@ -104,8 +104,13 @@ func UpdateResource(r rest.Updater, scope *RequestScope, admit admission.Interfa
 
 		trace.Step("About to convert to expected version")
 		decodeSerializer := s.Serializer
-		// TODO: put behind feature flag?
-		if strictValidation(req.URL) {
+		// TODO: put behind feature gate?
+		validationDirective, err := fieldValidation(req)
+		if err != nil {
+			scope.err(err, w, req)
+			return
+		}
+		if validationDirective == strictFieldValidation {
 			decodeSerializer = s.StrictSerializer
 		}
 		decoder := scope.Serializer.DecoderToVersion(decodeSerializer, scope.HubGroupVersion)

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/update.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/update.go
@@ -103,7 +103,12 @@ func UpdateResource(r rest.Updater, scope *RequestScope, admit admission.Interfa
 		original := r.New()
 
 		trace.Step("About to convert to expected version")
-		decoder := scope.Serializer.DecoderToVersion(s.Serializer, scope.HubGroupVersion)
+		decodeSerializer := s.Serializer
+		// TODO: put behind feature flag?
+		if strictValidation(req.URL) {
+			decodeSerializer = s.StrictSerializer
+		}
+		decoder := scope.Serializer.DecoderToVersion(decodeSerializer, scope.HubGroupVersion)
 		obj, gvk, err := decoder.Decode(body, &defaultGVK, original)
 		if err != nil {
 			err = transformDecodeError(scope.Typer, err, original, gvk, body)

--- a/test/integration/apiserver/apiserver_test.go
+++ b/test/integration/apiserver/apiserver_test.go
@@ -2330,6 +2330,8 @@ func TestDedupOwnerReferences(t *testing.T) {
 	}
 }
 
+// Benchmark field validation for strict vs non-strict
+// TODO: add actual correctness integration tests too
 func BenchmarkFieldValidation(b *testing.B) {
 	_, client, closeFn := setup(b)
 	defer closeFn()
@@ -2366,17 +2368,22 @@ func BenchmarkFieldValidation(b *testing.B) {
 
 	// TODO: add bigger objects to benchmarks table once confirmed that this is how we want to do benchmarking.
 	// TODO: split POST and PUT into their own test-cases.
+	// TODO: add test for "Warn" validation once it is implemented.
 	benchmarks := []struct {
 		name   string
 		params map[string]string
 	}{
 		{
-			name:   "nonstrict-deployment",
+			name:   "default-ignore-validation-deployment",
 			params: map[string]string{},
 		},
 		{
-			name:   "strict-deployment",
-			params: map[string]string{"validate": "strict"},
+			name:   "ignore-validation-deployment",
+			params: map[string]string{"fieldValidation": "Ignore"},
+		},
+		{
+			name:   "strict-validation-deployment",
+			params: map[string]string{"fieldValidation": "Strict"},
 		},
 	}
 

--- a/test/integration/apiserver/testdata/deploy-small.json
+++ b/test/integration/apiserver/testdata/deploy-small.json
@@ -1,0 +1,28 @@
+{
+	"apiVersion": "apps/v1",
+	"kind": "Deployment",
+	"metadata": {
+		"name": %s,
+		"labels": {"app": "nginx"}
+	},
+	"spec": {
+		"selector": {
+			"matchLabels": {
+				"app": "nginx"
+			}
+		},
+		"template": {
+			"metadata": {
+				"labels": {
+					"app": "nginx"
+				}
+			},
+			"spec": {
+				"containers": [{
+					"name":  "nginx",
+					"image": "nginx:latest"
+				}]
+			}
+		}
+	}
+}

--- a/test/integration/apiserver/testdata/pod-large.json
+++ b/test/integration/apiserver/testdata/pod-large.json
@@ -1,0 +1,177 @@
+{
+   "apiVersion": "v1",
+   "kind": "Pod",
+   "metadata": {
+      "labels": {
+         "app": "some-app",
+         "plugin1": "some-value",
+         "plugin2": "some-value",
+         "plugin3": "some-value",
+         "plugin4": "some-value"
+      },
+      "name": %s,
+      "namespace": "default",
+      "ownerReferences": [
+         {
+            "apiVersion": "apps/v1",
+            "blockOwnerDeletion": true,
+            "controller": true,
+            "kind": "ReplicaSet",
+            "name": "some-name",
+            "uid": "0a9d2b9e-779e-11e7-b422-42010a8001be"
+         }
+      ]
+   },
+   "spec": {
+      "containers": [
+         {
+            "args": [
+               "one",
+               "two",
+               "three",
+               "four",
+               "five",
+               "six",
+               "seven",
+               "eight",
+               "nine"
+            ],
+            "env": [
+               {
+                  "name": "VAR_3",
+                  "valueFrom": {
+                     "secretKeyRef": {
+                        "key": "some-other-key",
+                        "name": "some-oher-name"
+                     }
+                  }
+               },
+               {
+                  "name": "VAR_2",
+                  "valueFrom": {
+                     "secretKeyRef": {
+                        "key": "other-key",
+                        "name": "other-name"
+                     }
+                  }
+               },
+               {
+                  "name": "VAR_1",
+                  "valueFrom": {
+                     "secretKeyRef": {
+                        "key": "some-key",
+                        "name": "some-name"
+                     }
+                  }
+               }
+            ],
+            "image": "some-image-name",
+            "imagePullPolicy": "IfNotPresent",
+            "name": "some-name",
+            "resources": {
+               "requests": {
+                  "cpu": "0"
+               }
+            },
+            "terminationMessagePath": "/dev/termination-log",
+            "terminationMessagePolicy": "File",
+            "volumeMounts": [
+               {
+                  "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
+                  "name": "default-token-hu5jz",
+                  "readOnly": true
+               }
+            ]
+         }
+      ],
+      "dnsPolicy": "ClusterFirst",
+      "nodeName": "node-name",
+      "priority": 0,
+      "restartPolicy": "Always",
+      "schedulerName": "default-scheduler",
+      "securityContext": {},
+      "serviceAccount": "default",
+      "serviceAccountName": "default",
+      "terminationGracePeriodSeconds": 30,
+      "tolerations": [
+         {
+            "effect": "NoExecute",
+            "key": "node.kubernetes.io/not-ready",
+            "operator": "Exists",
+            "tolerationSeconds": 300
+         },
+         {
+            "effect": "NoExecute",
+            "key": "node.kubernetes.io/unreachable",
+            "operator": "Exists",
+            "tolerationSeconds": 300
+         }
+      ],
+      "volumes": [
+         {
+            "name": "default-token-hu5jz",
+            "secret": {
+               "defaultMode": 420,
+               "secretName": "default-token-hu5jz"
+            }
+         }
+      ]
+   },
+   "status": {
+      "conditions": [
+         {
+            "lastProbeTime": null,
+            "lastTransitionTime": "2019-07-08T09:31:18Z",
+            "status": "True",
+            "type": "Initialized"
+         },
+         {
+            "lastProbeTime": null,
+            "lastTransitionTime": "2019-07-08T09:41:59Z",
+            "status": "True",
+            "type": "Ready"
+         },
+         {
+            "lastProbeTime": null,
+            "lastTransitionTime": null,
+            "status": "True",
+            "type": "ContainersReady"
+         },
+         {
+            "lastProbeTime": null,
+            "lastTransitionTime": "2019-07-08T09:31:18Z",
+            "status": "True",
+            "type": "PodScheduled"
+         }
+      ],
+      "containerStatuses": [
+         {
+            "containerID": "docker://885e82a1ed0b7356541bb410a0126921ac42439607c09875cd8097dd5d7b5376",
+            "image": "some-image-name",
+            "imageID": "docker-pullable://some-image-id",
+            "lastState": {
+               "terminated": {
+                  "containerID": "docker://d57290f9e00fad626b20d2dd87a3cf69bbc22edae07985374f86a8b2b4e39565",
+                  "exitCode": 255,
+                  "finishedAt": "2019-07-08T09:39:09Z",
+                  "reason": "Error",
+                  "startedAt": "2019-07-08T09:38:54Z"
+               }
+            },
+            "name": "name",
+            "ready": true,
+            "restartCount": 6,
+            "state": {
+               "running": {
+                  "startedAt": "2019-07-08T09:41:59Z"
+               }
+            }
+         }
+      ],
+      "hostIP": "10.0.0.1",
+      "phase": "Running",
+      "podIP": "10.0.0.1",
+      "qosClass": "BestEffort",
+      "startTime": "2019-07-08T09:31:18Z"
+   }
+}

--- a/test/integration/apiserver/testdata/pod-medium.json
+++ b/test/integration/apiserver/testdata/pod-medium.json
@@ -1,0 +1,37 @@
+{
+	"kind": "Pod",
+	"apiVersion": "v1",
+	"metadata": {
+		"name": %s
+	},
+	"spec": {
+		"containers": [
+			{
+				"name": "healthz",
+				"image": "k8s.gcr.io/exechealthz-amd64:1.2",
+				"args": [
+					"-cmd=nslookup localhost"
+				],
+				"ports": [
+					{
+						"containerPort": 8080,
+						"protocol": "TCP"
+					}
+				]
+			},
+			{
+				"name":"test-container",
+				"image":"ubuntu:14.04",
+				"command": ["bash", "-c", "while true; do sleep 100; done"],
+				"livenessProbe": {
+					"httpGet": {
+						"path": "/healthz",
+						"port":8080
+					},
+				"initialDelaySeconds": 10,
+				"timeoutSeconds": 2
+				}
+			}
+		]
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Performs strict server side schema validation for POST and PUT requests via the `validate=strict` query parameter. 

Step one of deprecating the very painful client side validation.


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
First step in solving #39434 and #5889 

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Performs strict server side schema validation for POST and PUT requests via the `validate=strict` query parameter.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
[design doc](https://docs.google.com/document/d/1MmEkA2xEr_vOJ9SrpWu92rAzvaxEY47PHeRKcfO86mc/edit?usp=sharing)
[KEP-2885](https://github.com/kubernetes/enhancements/issues/2885)
<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
[design doc](https://docs.google.com/document/d/1MmEkA2xEr_vOJ9SrpWu92rAzvaxEY47PHeRKcfO86mc/edit?usp=sharing)
[KEP-2885](https://github.com/kubernetes/enhancements/issues/2885)
```
