### PR TITLE
Fix slice type comparison bug

### DIFF
--- a/plugin/pkg/admission/serviceaccount/admission_test.go
+++ b/plugin/pkg/admission/serviceaccount/admission_test.go
@@ -747,6 +747,11 @@ func TestAddImagePullSecrets(t *testing.T) {
 			{Name: "bar"},
 		},
 	}
+	originalSA := sa.DeepCopy()
+	expected := []api.LocalObjectReference{
+		{Name: "foo"},
+		{Name: "bar"},
+	}
 	// Add the default service account for the ns with a secret reference into the cache
 	informerFactory.Core().V1().ServiceAccounts().Informer().GetStore().Add(sa)
 
@@ -757,10 +762,10 @@ func TestAddImagePullSecrets(t *testing.T) {
 		t.Errorf("Unexpected error: %v", err)
 	}
 
-	assert.EqualValues(t, sa.ImagePullSecrets, pod.Spec.ImagePullSecrets, "expected %v, got %v", sa.ImagePullSecrets, pod.Spec.ImagePullSecrets)
+	assert.EqualValues(t, expected, pod.Spec.ImagePullSecrets, "expected %v, got %v", expected, pod.Spec.ImagePullSecrets)
 
 	pod.Spec.ImagePullSecrets[1] = api.LocalObjectReference{Name: "baz"}
-	if reflect.DeepEqual(sa.ImagePullSecrets, pod.Spec.ImagePullSecrets) {
+	if !reflect.DeepEqual(originalSA, sa) {
 		t.Errorf("accidentally mutated the ServiceAccount.ImagePullSecrets: %v", sa.ImagePullSecrets)
 	}
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Fixes a unit test bug comparing slices of different types that happened to work from go1.8-go1.16 due to a bug introduced in the reflect package

xref https://github.com/golang/go/issues/47785 https://github.com/kubernetes/kubernetes/pull/103692#issuecomment-901177030

```release-note
NONE
```