### PR TITLE
Warn when TTL field is not set on Job spec

### DIFF
--- a/pkg/api/batch/warnings.go
+++ b/pkg/api/batch/warnings.go
@@ -1,0 +1,38 @@
+package batch
+
+import (
+	"fmt"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	"k8s.io/kubernetes/pkg/apis/batch"
+	"k8s.io/kubernetes/pkg/features"
+)
+
+var TTLWarningMsg = "This job doesn't have TTLAfterFinished field and not managed by a higher level controller. " +
+	"Setting TTLAfterFinished on job.spec helps in removal of dependant pods"
+
+func GetWarningsForJob(job *batch.Job) []string {
+	if job == nil {
+		return nil
+	}
+	return warningsForJobSpec(&job.Spec, &job.ObjectMeta)
+}
+
+func warningsForJobSpec(jobSpec *batch.JobSpec, meta *metav1.ObjectMeta) []string {
+	var warnings []string
+	hasManagingController := false
+	for _, ownerRef := range meta.OwnerReferences {
+		if *ownerRef.Controller {
+			hasManagingController = true
+		}
+	}
+	// If it is a stand alone job(not created via another controller) and if TTLAfterFinished enabled but value is not
+	// set pods may get orphaned because the deletion policy of job by default is orphanDependents. If the job is
+	// managed by higher level controller, like cronjob controller, it will delete the dependents.
+	if utilfeature.DefaultFeatureGate.Enabled(features.TTLAfterFinished) && !hasManagingController &&
+		jobSpec.TTLSecondsAfterFinished == nil {
+		warnings = append(warnings, fmt.Sprint(TTLWarningMsg))
+	}
+	return warnings
+}

--- a/pkg/api/batch/warnings_test.go
+++ b/pkg/api/batch/warnings_test.go
@@ -1,0 +1,93 @@
+package batch
+
+import (
+	"reflect"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	featuregatetesting "k8s.io/component-base/featuregate/testing"
+	"k8s.io/kubernetes/pkg/apis/batch"
+	"k8s.io/kubernetes/pkg/features"
+)
+
+func TestGetWarningsForJob(t *testing.T) {
+	one := int32(1)
+	hasBackingController := true
+	testCases := []struct {
+		name                   string
+		job                    *batch.Job
+		enableTTLAfterFinished bool
+		expected               []string
+	}{
+		{
+			name:     "null",
+			job:      nil,
+			expected: nil,
+		},
+		{
+			name:                   "no ownerRef, TTL enabled, TTLfield not set, expect warning",
+			enableTTLAfterFinished: true,
+			job:                    &batch.Job{Spec: batch.JobSpec{}},
+			expected:               []string{TTLWarningMsg},
+		},
+		{
+			name:                   "no ownerRef, TTL enabled, TTLfield set, no warning expected",
+			enableTTLAfterFinished: true,
+			job:                    &batch.Job{Spec: batch.JobSpec{TTLSecondsAfterFinished: &one}},
+			expected:               nil,
+		},
+		{
+			name:                   "no ownerRef, TTL disabled, TTLfield not set, no warning expected",
+			enableTTLAfterFinished: false,
+			job:                    &batch.Job{Spec: batch.JobSpec{}},
+			expected:               nil,
+		},
+		{
+			name:                   "no ownerRef, TTL disabled, TTLfield set, no warning expected",
+			enableTTLAfterFinished: false,
+			job:                    &batch.Job{Spec: batch.JobSpec{TTLSecondsAfterFinished: &one}},
+			expected:               nil,
+		},
+		{
+			name:                   "ownerRef, TTL disabled, TTLfield set, no warning expected",
+			enableTTLAfterFinished: false,
+			job: &batch.Job{ObjectMeta: metav1.ObjectMeta{
+				OwnerReferences: []metav1.OwnerReference{{Controller: &hasBackingController}}}, Spec: batch.JobSpec{
+				TTLSecondsAfterFinished: &one}},
+			expected: nil,
+		},
+		{
+			name:                   "ownerRef, TTL disabled, TTLfield not set, no warning expected",
+			enableTTLAfterFinished: false,
+			job: &batch.Job{ObjectMeta: metav1.ObjectMeta{
+				OwnerReferences: []metav1.OwnerReference{{Controller: &hasBackingController}}}, Spec: batch.JobSpec{}},
+			expected: nil,
+		},
+		{
+			name:                   "ownerRef, TTL enabled, TTLfield not set, no warning expected",
+			enableTTLAfterFinished: true,
+			job: &batch.Job{ObjectMeta: metav1.ObjectMeta{
+				OwnerReferences: []metav1.OwnerReference{{Controller: &hasBackingController}}}, Spec: batch.JobSpec{}},
+			expected: nil,
+		},
+		{
+			name:                   "ownerRef, TTL enabled, TTLfield set, no warning expected",
+			enableTTLAfterFinished: true,
+			job: &batch.Job{ObjectMeta: metav1.ObjectMeta{
+				OwnerReferences: []metav1.OwnerReference{{Controller: &hasBackingController}}}, Spec: batch.JobSpec{
+				TTLSecondsAfterFinished: &one}},
+			expected: nil,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.TTLAfterFinished,
+				tc.enableTTLAfterFinished)()
+			actualWarnings := GetWarningsForJob(tc.job)
+			if !reflect.DeepEqual(tc.expected, actualWarnings) {
+				t.Errorf("expected %v, but got %v", tc.expected, actualWarnings)
+			}
+		})
+	}
+}

--- a/pkg/registry/batch/job/strategy.go
+++ b/pkg/registry/batch/job/strategy.go
@@ -35,6 +35,7 @@ import (
 	"k8s.io/apiserver/pkg/storage"
 	"k8s.io/apiserver/pkg/storage/names"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	batchapi "k8s.io/kubernetes/pkg/api/batch"
 	"k8s.io/kubernetes/pkg/api/legacyscheme"
 	"k8s.io/kubernetes/pkg/api/pod"
 	"k8s.io/kubernetes/pkg/apis/batch"
@@ -206,7 +207,10 @@ func validationOptionsForJob(newJob, oldJob *batch.Job) validation.JobValidation
 // WarningsOnCreate returns warnings for the creation of the given object.
 func (jobStrategy) WarningsOnCreate(ctx context.Context, obj runtime.Object) []string {
 	newJob := obj.(*batch.Job)
-	return pod.GetWarningsForPodTemplate(ctx, field.NewPath("spec", "template"), &newJob.Spec.Template, nil)
+	var warnings []string
+	warnings = append(warnings, pod.GetWarningsForPodTemplate(ctx, field.NewPath("spec", "template"), &newJob.Spec.Template, nil)...)
+	warnings = append(warnings, batchapi.GetWarningsForJob(newJob)...)
+	return warnings
 }
 
 // generateSelector adds a selector to a job and labels to its template


### PR DESCRIPTION
As of today, jobs when created solely without
backing higher level controllers like cronjob
controller, can leave the pods orphaned. This
patch ensures that a proper warning will be
sent to the user when such a job gets created

xref: https://github.com/kubernetes/kubernetes/pull/103449#discussion_r691541804

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind cleanup
#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Warn users when job gets created without TTL field in job spec
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
cc @liggitt @soltysh 