### PR TITLE
test images: Adds Windows Server 2022 to the BASEIMAGEs

### DIFF
--- a/test/images/busybox/BASEIMAGE
+++ b/test/images/busybox/BASEIMAGE
@@ -6,3 +6,4 @@ linux/s390x=s390x/busybox:1.29
 windows/amd64/1809=mcr.microsoft.com/windows/nanoserver:1809
 windows/amd64/2004=mcr.microsoft.com/windows/nanoserver:2004
 windows/amd64/20H2=mcr.microsoft.com/windows/nanoserver:20H2
+windows/amd64/ltsc2022=mcr.microsoft.com/windows/nanoserver:ltsc2022

--- a/test/images/image-util.sh
+++ b/test/images/image-util.sh
@@ -39,7 +39,7 @@ declare -A QEMUARCHS=( ["amd64"]="x86_64" ["arm"]="arm" ["arm64"]="aarch64" ["pp
 # NOTE(claudiub): In the test image build jobs, this script is not being run in a git repository,
 # which would cause git log to fail. Instead, we can use the GIT_COMMIT_ID set in cloudbuild.yaml.
 GIT_COMMIT_ID=$(git log -1 --format=%h || echo "${GIT_COMMIT_ID}")
-windows_os_versions=(1809 2004 20H2)
+windows_os_versions=(1809 2004 20H2 ltsc2022)
 declare -A WINDOWS_OS_VERSIONS_MAP
 
 initWindowsOsVersions() {
@@ -269,7 +269,7 @@ bin() {
         golang:"${GOLANG_VERSION}" \
         /bin/bash -c "\
                 cd /go/src/k8s.io/kubernetes/test/images/${SRC_DIR} && \
-                CGO_ENABLED=0 ${arch_prefix} GOOS=${OS} GOARCH=${ARCH} go build -a -installsuffix cgo --ldflags \"-w ${LD_FLAGS}\" -o ${TARGET}/${SRC} ./$(dirname "${SRC}")"
+                CGO_ENABLED=0 ${arch_prefix} GOOS=${OS} GOARCH=${ARCH} go build -a -installsuffix cgo --ldflags \"-w ${LD_FLAGS:-}\" -o ${TARGET}/${SRC} ./$(dirname "${SRC}")"
   done
 }
 

--- a/test/images/windows-servercore-cache/BASEIMAGE
+++ b/test/images/windows-servercore-cache/BASEIMAGE
@@ -1,3 +1,4 @@
 linux/amd64/1809=mcr.microsoft.com/windows/servercore:ltsc2019
 linux/amd64/2004=mcr.microsoft.com/windows/servercore:2004
 linux/amd64/20H2=mcr.microsoft.com/windows/servercore:20H2
+linux/amd64/ltsc2022=mcr.microsoft.com/windows/servercore:ltsc2022

--- a/test/images/windows-servercore-cache/Dockerfile
+++ b/test/images/windows-servercore-cache/Dockerfile
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG OS_VERSION
-FROM --platform=windows/amd64 mcr.microsoft.com/windows/servercore:$OS_VERSION as prep
+ARG BASEIMAGE
+FROM --platform=windows/amd64 $BASEIMAGE as prep
 FROM scratch
 
 COPY --from=prep /Windows/System32/en-US/nltest.exe.mui /Windows/System32/en-US/nltest.exe.mui


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/sig windows
/sig testing

/kind feature
/priority important-soon

#### What this PR does / why we need it:

The Container Images for Windows Server 2022 have been published, and we can start building test images using them, so we can start adding jobs for them.

The image versions for the e2e test images have been bumped in a previous commit [0], but haven't been promoted yet [1]. We don't need to bump them here.

We're starting with windows-servercore-cache and busybox images, since they are needed for the other images the most.

A previous added ``LD_FLAGS`` for the go binary compilation, but it's not defined for all images.

[0] https://github.com/kubernetes/kubernetes/pull/102599
[1] https://github.com/kubernetes/k8s.io/blob/c8b744d34f4f017ff6989557a2acc37ed2d3f1be/k8s.gcr.io/images/k8s-staging-e2e-test-images/images.yaml#L1

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
