### PR TITLE
[client-go] Result.Into method sets GVK for the object

### DIFF
--- a/staging/src/k8s.io/client-go/kubernetes_test/fake_client_test.go
+++ b/staging/src/k8s.io/client-go/kubernetes_test/fake_client_test.go
@@ -18,6 +18,7 @@ package kubernetes
 
 import (
 	"context"
+	"reflect"
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
@@ -64,8 +65,8 @@ func TestGetDecoding(t *testing.T) {
 	if err != nil || out != obj {
 		t.Fatal(err)
 	}
-
-	if obj.GetObjectKind().GroupVersionKind() != (schema.GroupVersionKind{}) {
+	// GVK for the object is expected to be empty
+	if !reflect.DeepEqual(obj.GetObjectKind().GroupVersionKind(), schema.GroupVersionKind{}) {
 		t.Fatal(obj.GetObjectKind().GroupVersionKind())
 	}
 }
@@ -86,8 +87,8 @@ func TestListDecoding(t *testing.T) {
 	if err != nil || out != obj {
 		t.Fatal(err)
 	}
-
-	if obj.GetObjectKind().GroupVersionKind() != (schema.GroupVersionKind{}) {
+	// GVK for the object is expected to be empty
+	if !reflect.DeepEqual(obj.GetObjectKind().GroupVersionKind(), schema.GroupVersionKind{}) {
 		t.Fatal(obj.GetObjectKind().GroupVersionKind())
 	}
 }

--- a/staging/src/k8s.io/client-go/rest/request.go
+++ b/staging/src/k8s.io/client-go/rest/request.go
@@ -1331,9 +1331,15 @@ func (r Result) Into(obj runtime.Object) error {
 			r.statusCode, r.contentType)
 	}
 
-	out, _, err := r.decoder.Decode(r.body, nil, obj)
-	if err != nil || out == obj {
+	out, gvk, err := r.decoder.Decode(r.body, nil, obj)
+	if err != nil {
 		return err
+	}
+	if out == obj {
+		if gvk != nil {
+			obj.GetObjectKind().SetGroupVersionKind(*gvk)
+		}
+		return nil
 	}
 	// if a different object is returned, see if it is Status and avoid double decoding
 	// the object.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Object [returned](https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/client-go/rest/request.go#L1321) from client-go for GET call doesn't contain the GVK.
This PR adds the GVK for the object before returning.


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes # https://github.com/kubernetes/client-go/issues/1004

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
