### PR TITLE
fix 104329: check for headless before trying to release the ClusterIPs

### DIFF
--- a/pkg/registry/core/service/storage/rest.go
+++ b/pkg/registry/core/service/storage/rest.go
@@ -759,6 +759,12 @@ func (rs *REST) handleClusterIPsForUpdatedService(oldService *api.Service, servi
 	}
 
 	// CASE B:
+
+	// if headless service then we bail out early (no clusterIPs management needed)
+	if len(oldService.Spec.ClusterIPs) > 0 && oldService.Spec.ClusterIPs[0] == api.ClusterIPNone {
+		return nil, nil, nil
+	}
+
 	// Update service from non-ExternalName to ExternalName, should release ClusterIP if exists.
 	if oldService.Spec.Type != api.ServiceTypeExternalName && service.Spec.Type == api.ServiceTypeExternalName {
 		toRelease = make(map[api.IPFamily]string)
@@ -773,11 +779,6 @@ func (rs *REST) handleClusterIPsForUpdatedService(oldService *api.Service, servi
 		}
 
 		return nil, toRelease, nil
-	}
-
-	// if headless service then we bail out early (no clusterIPs management needed)
-	if len(oldService.Spec.ClusterIPs) > 0 && oldService.Spec.ClusterIPs[0] == api.ClusterIPNone {
-		return nil, nil, nil
 	}
 
 	// upgrade and downgrade are specific to dualstack


### PR DESCRIPTION
#### What type of PR is this?
/kind bug


#### What this PR does / why we need it:
fixes #104329 where the api-server tries to release ClusterIPs for a headless service when it gets converted to ExternalName

#### Which issue(s) this PR fixes:

Fixes #104329 



#### Does this PR introduce a user-facing change?
```release-note
NONE
```