### PR TITLE
bump e2e loadbalancer timeouts to 15m

### DIFF
--- a/test/e2e/framework/service/const.go
+++ b/test/e2e/framework/service/const.go
@@ -51,7 +51,7 @@ const (
 	// LoadBalancerCreateTimeoutDefault is the default time to wait for a load balancer to be created/modified.
 	// TODO: once support ticket 21807001 is resolved, reduce this timeout back to something reasonable
 	// Hideen - use GetServiceLoadBalancerCreateTimeout function instead.
-	loadBalancerCreateTimeoutDefault = 10 * time.Minute
+	loadBalancerCreateTimeoutDefault = 15 * time.Minute
 	// LoadBalancerCreateTimeoutLarge is the maximum time to wait for a load balancer to be created/modified.
 	// Hideen - use GetServiceLoadBalancerCreateTimeout function instead.
 	loadBalancerCreateTimeoutLarge = 45 * time.Minute


### PR DESCRIPTION

/kind flake
```release-note
NONE
```

Apply the suggested timeout value to the e2e tests
https://github.com/kubernetes/kubernetes/issues/104110#issuecomment-902307990