### PR TITLE
Automated cherry pick of #95447: Fix vsphere disk detach failing

### DIFF
--- a/pkg/volume/vsphere_volume/attacher.go
+++ b/pkg/volume/vsphere_volume/attacher.go
@@ -277,7 +277,7 @@ func (plugin *vsphereVolumePlugin) NewDeviceUnmounter() (volume.DeviceUnmounter,
 func (detacher *vsphereVMDKDetacher) Detach(volumeName string, nodeName types.NodeName) error {
 
 	volPath := getVolPathfromVolumeName(volumeName)
-	attached, err := detacher.vsphereVolumes.DiskIsAttached(volPath, nodeName)
+	attached, newVolumePath, err := detacher.vsphereVolumes.DiskIsAttached(volPath, nodeName)
 	if err != nil {
 		// Log error and continue with detach
 		klog.Errorf(
@@ -293,7 +293,7 @@ func (detacher *vsphereVMDKDetacher) Detach(volumeName string, nodeName types.No
 
 	attachdetachMutex.LockKey(string(nodeName))
 	defer attachdetachMutex.UnlockKey(string(nodeName))
-	if err := detacher.vsphereVolumes.DetachDisk(volPath, nodeName); err != nil {
+	if err := detacher.vsphereVolumes.DetachDisk(newVolumePath, nodeName); err != nil {
 		klog.Errorf("Error detaching volume %q: %v", volPath, err)
 		return err
 	}

--- a/pkg/volume/vsphere_volume/attacher_test.go
+++ b/pkg/volume/vsphere_volume/attacher_test.go
@@ -22,7 +22,7 @@ import (
 	"errors"
 	"testing"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/kubernetes/pkg/volume"
 	volumetest "k8s.io/kubernetes/pkg/volume/testing"
@@ -285,29 +285,29 @@ func (testcase *testcase) DetachDisk(diskName string, nodeName types.NodeName) e
 	return expected.ret
 }
 
-func (testcase *testcase) DiskIsAttached(diskName string, nodeName types.NodeName) (bool, error) {
+func (testcase *testcase) DiskIsAttached(diskName string, nodeName types.NodeName) (bool, string, error) {
 	expected := &testcase.diskIsAttached
 
 	if expected.diskName == "" && expected.nodeName == "" {
 		// testcase.diskIsAttached looks uninitialized, test did not expect to
 		// call DiskIsAttached
 		testcase.t.Errorf("Unexpected DiskIsAttached call!")
-		return false, errors.New("Unexpected DiskIsAttached call!")
+		return false, diskName, errors.New("Unexpected DiskIsAttached call!")
 	}
 
 	if expected.diskName != diskName {
 		testcase.t.Errorf("Unexpected DiskIsAttached call: expected diskName %s, got %s", expected.diskName, diskName)
-		return false, errors.New("Unexpected DiskIsAttached call: wrong diskName")
+		return false, diskName, errors.New("Unexpected DiskIsAttached call: wrong diskName")
 	}
 
 	if expected.nodeName != nodeName {
 		testcase.t.Errorf("Unexpected DiskIsAttached call: expected nodeName %s, got %s", expected.nodeName, nodeName)
-		return false, errors.New("Unexpected DiskIsAttached call: wrong nodeName")
+		return false, diskName, errors.New("Unexpected DiskIsAttached call: wrong nodeName")
 	}
 
 	klog.V(4).Infof("DiskIsAttached call: %s, %s, returning %v, %v", diskName, nodeName, expected.isAttached, expected.ret)
 
-	return expected.isAttached, expected.ret
+	return expected.isAttached, diskName, expected.ret
 }
 
 func (testcase *testcase) DisksAreAttached(nodeVolumes map[types.NodeName][]string) (map[types.NodeName]map[string]bool, error) {

--- a/staging/src/k8s.io/legacy-cloud-providers/vsphere/vclib/virtualmachine.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/vsphere/vclib/virtualmachine.go
@@ -186,7 +186,6 @@ func (vm *VirtualMachine) GetHost(ctx context.Context) (mo.HostSystem, error) {
 
 // DetachDisk detaches the disk specified by vmDiskPath
 func (vm *VirtualMachine) DetachDisk(ctx context.Context, vmDiskPath string) error {
-	vmDiskPath = RemoveStorageClusterORFolderNameFromVDiskPath(vmDiskPath)
 	device, err := vm.getVirtualDeviceByPath(ctx, vmDiskPath)
 	if err != nil {
 		klog.Errorf("Disk ID not found for VM: %q with diskPath: %q", vm.InventoryPath, vmDiskPath)

--- a/staging/src/k8s.io/legacy-cloud-providers/vsphere/vsphere.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/vsphere/vsphere.go
@@ -924,11 +924,10 @@ func (vs *VSphere) AttachDisk(vmDiskPath string, storagePolicyName string, nodeN
 			return "", err
 		}
 
-		// try and get canonical path for disk and if we can't throw error
-		vmDiskPath, err = getcanonicalVolumePath(ctx, vm.Datacenter, vmDiskPath)
-		if err != nil {
-			klog.Errorf("failed to get canonical path for %s on node %s: %v", vmDiskPath, convertToString(nodeName), err)
-			return "", err
+		// try and get canonical path for disk and if we can't use provided vmDiskPath
+		canonicalPath, pathFetchErr := getcanonicalVolumePath(ctx, vm.Datacenter, vmDiskPath)
+		if canonicalPath != "" && pathFetchErr == nil {
+			vmDiskPath = canonicalPath
 		}
 
 		diskUUID, err = vm.AttachDisk(ctx, vmDiskPath, &vclib.VolumeOptions{SCSIControllerType: vclib.PVSCSIControllerType, StoragePolicyName: storagePolicyName})


### PR DESCRIPTION
Cherry pick of #95447 and #102892 on release-1.19.

#95447: Fix vsphere disk detach failing

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
For statically provisioned PVs ensure that we use canonical path whenever possible for attach/detach
```
