### PR TITLE
Fix buffered signal channel go vet error

### DIFF
--- a/test/e2e_node/runner/remote/run_remote.go
+++ b/test/e2e_node/runner/remote/run_remote.go
@@ -205,7 +205,7 @@ func main() {
 	// process and all its children, we ignore it here, while our children ssh connections
 	// are stopped. This allows us to gather artifacts and print out test state before
 	// being killed.
-	c := make(chan os.Signal)
+	c := make(chan os.Signal, 2)
 	signal.Notify(c, os.Interrupt)
 	go func() {
 		<-c

--- a/test/images/agnhost/nettest/nettest.go
+++ b/test/images/agnhost/nettest/nettest.go
@@ -216,7 +216,7 @@ func main(cmd *cobra.Command, args []string) {
 	}
 
 	if delayShutdown > 0 {
-		termCh := make(chan os.Signal)
+		termCh := make(chan os.Signal, 1)
 		signal.Notify(termCh, syscall.SIGTERM)
 		go func() {
 			<-termCh

--- a/test/images/agnhost/pause/pause.go
+++ b/test/images/agnhost/pause/pause.go
@@ -36,7 +36,7 @@ var CmdPause = &cobra.Command{
 
 func pause(cmd *cobra.Command, args []string) {
 	fmt.Println("Paused")
-	sigCh := make(chan os.Signal)
+	sigCh := make(chan os.Signal, 1)
 	done := make(chan int, 1)
 	signal.Notify(sigCh, syscall.SIGINT)
 	signal.Notify(sigCh, syscall.SIGTERM)


### PR DESCRIPTION
/kind bug

Fixes go vet error identified in go 1.17 - https://github.com/kubernetes/kubernetes/pull/103692#issuecomment-898568692

Sized the buffers to match the max number of signals expected

/sig testing

```release-note
NONE
```
