### PR TITLE
apiserver/pkg/storage/interfaces.go: Add backticks to comments misparsed as HTML by IDEs 

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/interfaces.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/interfaces.go
@@ -75,11 +75,11 @@ type ResponseMeta struct {
 }
 
 // IndexerFunc is a function that for a given object computes
-// <value of an index> for a particular <index>.
+// `<value of an index>` for a particular `<index>`.
 type IndexerFunc func(obj runtime.Object) string
 
-// IndexerFuncs is a mapping from <index name> to function that
-// for a given object computes <value for that index>.
+// IndexerFuncs is a mapping from `<index name>` to function that
+// for a given object computes `<value for that index>`.
 type IndexerFuncs map[string]IndexerFunc
 
 // Everything accepts all objects.
@@ -88,7 +88,7 @@ var Everything = SelectionPredicate{
 	Field: fields.Everything(),
 }
 
-// MatchValue defines a pair (<index name>, <value for that index>).
+// MatchValue defines a pair (`<index name>`, `<value for that index>`).
 type MatchValue struct {
 	IndexName string
 	Value     string


### PR DESCRIPTION
/kind bug

#### What this PR does / why we need it:

Adds backticks to comments inside of interfaces.go so that brackets ('<' and '>') are not interpreted as HTML tags by IDE features.

#### Which issue(s) this PR fixes:
Fixes #104457 

#### Special notes for your reviewer:
@DangerOnTheRanger I hope it's okay that I took this issue, I know it's assigned to you but I figured I'd throw it up anyway :)

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs

```
