### PR TITLE
🐛 Fix quota admission PriorityClass returns fmt.Errorf

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/resourcequota/controller.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/resourcequota/controller.go
@@ -535,7 +535,7 @@ func CheckRequest(quotas []corev1.ResourceQuota, a admission.Attributes, evaluat
 		return quotas, err
 	}
 	if len(scopesHasNoCoveringQuota) > 0 {
-		return quotas, fmt.Errorf("insufficient quota to match these scopes: %v", scopesHasNoCoveringQuota)
+		return quotas, admission.NewForbidden(a, fmt.Errorf("insufficient quota to match these scopes: %v", scopesHasNoCoveringQuota))
 	}
 
 	if len(interestingQuotaIndexes) == 0 {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:
Currently when you use the Quota Admission Handler with scoped PriorityClasses and there is insufficient handling it will return an `fmt.Errorf` which caused the status response hander to have to reformat the error instead of the admission controller returning an expected response.

https://github.com/kubernetes/kubernetes/blob/ea0764452222146c47ec826977f49d7001b0ea8c/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/responsewriters/status.go#L60-L82

#### Which issue(s) this PR fixes:

Fixes #104505

#### Does this PR introduce a user-facing change?

```release-note
Fixes Quota Admission PriorityClass Scope handling when insufficient quota is requested.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

Signed-off-by: Chris Hein <me@chrishein.com>