### PR TITLE
Automated cherry pick of #100720: Fix buckets initialization

### DIFF
--- a/pkg/controller/volume/scheduling/metrics/metrics.go
+++ b/pkg/controller/volume/scheduling/metrics/metrics.go
@@ -41,7 +41,7 @@ var (
 			Subsystem:         VolumeSchedulerSubsystem,
 			Name:              "scheduling_duration_seconds",
 			Help:              "Volume scheduling stage latency (Deprecated since 1.19.0)",
-			Buckets:           metrics.ExponentialBuckets(1000, 2, 15),
+			Buckets:           metrics.ExponentialBuckets(0.001, 2, 15),
 			StabilityLevel:    metrics.ALPHA,
 			DeprecatedVersion: "1.19.0",
 		},


### PR DESCRIPTION
Cherry pick of #100720 on release-1.21.

#100720: Fix buckets initialization

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.