### PR TITLE
[scheduler] Remove deprecated volumeSchedulingLatency metric

### DIFF
--- a/pkg/scheduler/framework/plugins/volumebinding/binder.go
+++ b/pkg/scheduler/framework/plugins/volumebinding/binder.go
@@ -290,9 +290,7 @@ func (b *volumeBinder) FindPodVolumes(pod *v1.Pod, boundClaims, claimsToBind []*
 		}
 	}()
 
-	start := time.Now()
 	defer func() {
-		metrics.VolumeSchedulingStageLatency.WithLabelValues("predicate").Observe(time.Since(start).Seconds())
 		if err != nil {
 			metrics.VolumeSchedulingStageFailed.WithLabelValues("predicate").Inc()
 		}
@@ -376,9 +374,7 @@ func (b *volumeBinder) AssumePodVolumes(assumedPod *v1.Pod, nodeName string, pod
 	podName := getPodName(assumedPod)
 
 	klog.V(4).Infof("AssumePodVolumes for pod %q, node %q", podName, nodeName)
-	start := time.Now()
 	defer func() {
-		metrics.VolumeSchedulingStageLatency.WithLabelValues("assume").Observe(time.Since(start).Seconds())
 		if err != nil {
 			metrics.VolumeSchedulingStageFailed.WithLabelValues("assume").Inc()
 		}
@@ -450,9 +446,7 @@ func (b *volumeBinder) BindPodVolumes(assumedPod *v1.Pod, podVolumes *PodVolumes
 	podName := getPodName(assumedPod)
 	klog.V(4).Infof("BindPodVolumes for pod %q, node %q", podName, assumedPod.Spec.NodeName)
 
-	start := time.Now()
 	defer func() {
-		metrics.VolumeSchedulingStageLatency.WithLabelValues("bind").Observe(time.Since(start).Seconds())
 		if err != nil {
 			metrics.VolumeSchedulingStageFailed.WithLabelValues("bind").Inc()
 		}

--- a/pkg/scheduler/framework/plugins/volumebinding/metrics/metrics.go
+++ b/pkg/scheduler/framework/plugins/volumebinding/metrics/metrics.go
@@ -35,18 +35,6 @@ var (
 		},
 		[]string{"operation"},
 	)
-	// VolumeSchedulingStageLatency tracks the latency of volume scheduling operations.
-	VolumeSchedulingStageLatency = metrics.NewHistogramVec(
-		&metrics.HistogramOpts{
-			Subsystem:         VolumeSchedulerSubsystem,
-			Name:              "scheduling_duration_seconds",
-			Help:              "Volume scheduling stage latency (Deprecated since 1.19.0)",
-			Buckets:           metrics.ExponentialBuckets(0.001, 2, 15),
-			StabilityLevel:    metrics.ALPHA,
-			DeprecatedVersion: "1.19.0",
-		},
-		[]string{"operation"},
-	)
 	// VolumeSchedulingStageFailed tracks the number of failed volume scheduling operations.
 	VolumeSchedulingStageFailed = metrics.NewCounterVec(
 		&metrics.CounterOpts{
@@ -63,6 +51,5 @@ var (
 // used by scheduler process.
 func RegisterVolumeSchedulingMetrics() {
 	legacyregistry.MustRegister(VolumeBindingRequestSchedulerBinderCache)
-	legacyregistry.MustRegister(VolumeSchedulingStageLatency)
 	legacyregistry.MustRegister(VolumeSchedulingStageFailed)
 }


### PR DESCRIPTION
As part of https://github.com/kubernetes/kubernetes/pull/100720 we backported fix on existing releases and 
in this commit we completely remove the deprecated metric from the master branch.

Signed-off-by: dntosas <ntosas@gmail.com>

#### What type of PR is this?
/kind cleanup
/kind deprecation

#### Does this PR introduce a user-facing change?
```release-note
Removed deprecated metric `scheduler_volume_scheduling_duration_seconds`
```

