### PR TITLE
MOTD: Remove '-gke.*' in link to source version

### DIFF
--- a/cluster/gce/gci/configure-helper.sh
+++ b/cluster/gce/gci/configure-helper.sh
@@ -2923,7 +2923,7 @@ Or you can download it at:
   https://storage.googleapis.com/kubernetes-release/release/${version}/kubernetes-src.tar.gz
 
 It is based on the Kubernetes source at:
-  https://github.com/kubernetes/kubernetes/tree/${gitref}
+  https://github.com/kubernetes/kubernetes/tree/${gitref/-gke.*/}
 ${devel}
 For Kubernetes copyright and licensing information, see:
   /home/kubernetes/LICENSES


### PR DESCRIPTION
When actually running in GKE, the version will contain "-gke.*". This makes the reference / link to the source version invalid.
Workaround by using bash variable expansion to remove this gke version substring.

Ex following:
- https://github.com/kubernetes/kubernetes/tree/v1.18.20-gke.501
Should actually be:
- https://github.com/kubernetes/kubernetes/tree/v1.18.20

/kind bug
/kind cleanup

#### Which issue(s) this PR fixes:

Fixes #104517
