### PR TITLE
Replace hardcoded docker images in e2e tests with images configured in image utils

### DIFF
--- a/test/e2e/apimachinery/resource_quota.go
+++ b/test/e2e/apimachinery/resource_quota.go
@@ -393,7 +393,7 @@ var _ = SIGDescribe("ResourceQuota", func() {
 		framework.ExpectNoError(err)
 
 		ginkgo.By("Creating a ReplicationController")
-		replicationController := newTestReplicationControllerForQuota("test-rc", "nginx", 0)
+		replicationController := newTestReplicationControllerForQuota("test-rc", imageutils.GetE2EImage(imageutils.Nginx), 0)
 		replicationController, err = f.ClientSet.CoreV1().ReplicationControllers(f.Namespace.Name).Create(context.TODO(), replicationController, metav1.CreateOptions{})
 		framework.ExpectNoError(err)
 
@@ -449,7 +449,7 @@ var _ = SIGDescribe("ResourceQuota", func() {
 		framework.ExpectNoError(err)
 
 		ginkgo.By("Creating a ReplicaSet")
-		replicaSet := newTestReplicaSetForQuota("test-rs", "nginx", 0)
+		replicaSet := newTestReplicaSetForQuota("test-rs", imageutils.GetE2EImage(imageutils.Nginx), 0)
 		replicaSet, err = f.ClientSet.AppsV1().ReplicaSets(f.Namespace.Name).Create(context.TODO(), replicaSet, metav1.CreateOptions{})
 		framework.ExpectNoError(err)
 

--- a/test/e2e/apps/daemon_set.go
+++ b/test/e2e/apps/daemon_set.go
@@ -442,7 +442,7 @@ var _ = SIGDescribe("Daemon set [Serial]", func() {
 
 		framework.Logf("Update the DaemonSet to trigger a rollout")
 		// We use a nonexistent image here, so that we make sure it won't finish
-		newImage := "foo:non-existent"
+		newImage := InvalidImage
 		newDS, err := updateDaemonSetWithRetries(c, ns, ds.Name, func(update *appsv1.DaemonSet) {
 			update.Spec.Template.Spec.Containers[0].Image = newImage
 		})

--- a/test/e2e/apps/deployment.go
+++ b/test/e2e/apps/deployment.go
@@ -928,7 +928,7 @@ func testRolloverDeployment(f *framework.Framework) {
 	// We use a nonexistent image here, so that we make sure it won't finish
 	deploymentName, deploymentImageName := "test-rollover-deployment", "redis-slave"
 	deploymentReplicas := int32(1)
-	deploymentImage := "gcr.io/google_samples/gb-redisslave:nonexistent"
+	deploymentImage := InvalidImage
 	deploymentStrategyType := appsv1.RollingUpdateDeploymentStrategyType
 	framework.Logf("Creating deployment %q", deploymentName)
 	newDeployment := e2edeployment.NewDeployment(deploymentName, deploymentReplicas, deploymentPodLabels, deploymentImageName, deploymentImage, deploymentStrategyType)
@@ -1229,7 +1229,7 @@ func testProportionalScalingDeployment(f *framework.Framework) {
 	// will be blocked to simulate a partial rollout.
 	framework.Logf("Updating deployment %q with a non-existent image", deploymentName)
 	deployment, err = e2edeployment.UpdateDeploymentWithRetries(c, ns, d.Name, func(update *appsv1.Deployment) {
-		update.Spec.Template.Spec.Containers[0].Image = "webserver:404"
+		update.Spec.Template.Spec.Containers[0].Image = InvalidImage
 	})
 	framework.ExpectNoError(err)
 

--- a/test/e2e/apps/types.go
+++ b/test/e2e/apps/types.go
@@ -36,6 +36,6 @@ var (
 	// AgnhostImage is the fully qualified URI to the Agnhost image
 	AgnhostImage = imageutils.GetE2EImage(imageutils.Agnhost)
 
-	// InvalidImage is a fully qualified URI pointing to an unexisting image
+	// InvalidImage is a fully qualified URI pointing to an non-existent image
 	InvalidImage = imageutils.GetE2EImage(imageutils.InvalidRegistryImage)
 )

--- a/test/e2e/apps/types.go
+++ b/test/e2e/apps/types.go
@@ -35,4 +35,7 @@ var (
 
 	// AgnhostImage is the fully qualified URI to the Agnhost image
 	AgnhostImage = imageutils.GetE2EImage(imageutils.Agnhost)
+
+	// InvalidImage is a fully qualified URI pointing to an unexisting image
+	InvalidImage = imageutils.GetE2EImage(imageutils.InvalidRegistryImage)
 )


### PR DESCRIPTION
#### What type of PR is this?

/kind cleaning

#### What this PR does / why we need it:

This PR replaces several hardcoded docker images in conformance tests with images defined in the `test/utils/image` package.
This will allow more configuration when running conformance tests, since images defined in the utils package can be modified through a yaml configuration.

This need was identified when running conformance tests on a k8s cluster where an admission webhook controls the docker image registries used in pods. Most tests were OK since most images where correctly configured in through the `test/utils/image` package, but the few tests treated by this PR were failing because of hardcoded images.

Environment the problem was identified in:
k8s v1.18.6 running on a bare metal cluster, deployed with kubespray
Mutating Webhook controlling image registries, runned with OPA
Conformance tests launched with sonobuoy v0.53.2

#### Special notes for your reviewer:

This PR does not aim to replace all hardcoded images in e2e tests, only the ones identified in the environment described above.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
