### PR TITLE
Automated cherry pick of #104369: Fix storage class setup in regional_pd.go

### DIFF
--- a/test/e2e/storage/regional_pd.go
+++ b/test/e2e/storage/regional_pd.go
@@ -154,16 +154,15 @@ func testVolumeProvisioning(c clientset.Interface, t *framework.TimeoutContext, 
 
 	for _, test := range tests {
 		test.Client = c
-		test.Class = newStorageClass(test, ns, "" /* suffix */)
+		computedStorageClass, clearStorageClass := testsuites.SetupStorageClass(test.Client, newStorageClass(test, ns, "" /* suffix */))
+		defer clearStorageClass()
+		test.Class = computedStorageClass
 		test.Claim = e2epv.MakePersistentVolumeClaim(e2epv.PersistentVolumeClaimConfig{
 			ClaimSize:        test.ClaimSize,
 			StorageClassName: &(test.Class.Name),
 			VolumeMode:       &test.VolumeMode,
 		}, ns)
-		sc, clearStorageClass := testsuites.SetupStorageClass(test.Client, test.Class)
-		defer clearStorageClass()
 
-		test.Class = sc
 		test.TestDynamicProvisioning()
 	}
 }
@@ -344,7 +343,10 @@ func testRegionalDelayedBinding(c clientset.Interface, ns string, pvcCount int) 
 	}
 
 	suffix := "delayed-regional"
-	test.Class = newStorageClass(test, ns, suffix)
+
+	computedStorageClass, clearStorageClass := testsuites.SetupStorageClass(test.Client, newStorageClass(test, ns, suffix))
+	defer clearStorageClass()
+	test.Class = computedStorageClass
 	var claims []*v1.PersistentVolumeClaim
 	for i := 0; i < pvcCount; i++ {
 		claim := e2epv.MakePersistentVolumeClaim(e2epv.PersistentVolumeClaimConfig{
@@ -382,7 +384,9 @@ func testRegionalAllowedTopologies(c clientset.Interface, ns string) {
 
 	suffix := "topo-regional"
 	test.Client = c
-	test.Class = newStorageClass(test, ns, suffix)
+	computedStorageClass, clearStorageClass := testsuites.SetupStorageClass(test.Client, newStorageClass(test, ns, suffix))
+	defer clearStorageClass()
+	test.Class = computedStorageClass
 	zones := getTwoRandomZones(c)
 	addAllowedTopologiesToStorageClass(c, test.Class, zones)
 	test.Claim = e2epv.MakePersistentVolumeClaim(e2epv.PersistentVolumeClaimConfig{
@@ -392,10 +396,6 @@ func testRegionalAllowedTopologies(c clientset.Interface, ns string) {
 		VolumeMode:       &test.VolumeMode,
 	}, ns)
 
-	sc, clearStorageClass := testsuites.SetupStorageClass(test.Client, test.Class)
-	defer clearStorageClass()
-
-	test.Class = sc
 	pv := test.TestDynamicProvisioning()
 	checkZonesFromLabelAndAffinity(pv, sets.NewString(zones...), true)
 }
@@ -415,7 +415,9 @@ func testRegionalAllowedTopologiesWithDelayedBinding(c clientset.Interface, ns s
 	}
 
 	suffix := "topo-delayed-regional"
-	test.Class = newStorageClass(test, ns, suffix)
+	computedStorageClass, clearStorageClass := testsuites.SetupStorageClass(test.Client, newStorageClass(test, ns, suffix))
+	defer clearStorageClass()
+	test.Class = computedStorageClass
 	topoZones := getTwoRandomZones(c)
 	addAllowedTopologiesToStorageClass(c, test.Class, topoZones)
 	var claims []*v1.PersistentVolumeClaim


### PR DESCRIPTION
Cherry pick of #104369 on release-1.22.

#104369: Fix storage class setup in regional_pd.go

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
NONE
```