### PR TITLE
client-go: Pager should use the last page's RV

### DIFF
--- a/staging/src/k8s.io/client-go/tools/pager/pager.go
+++ b/staging/src/k8s.io/client-go/tools/pager/pager.go
@@ -118,9 +118,12 @@ func (p *ListPager) List(ctx context.Context, options metav1.ListOptions) (runti
 		// initialize the list and fill its contents
 		if list == nil {
 			list = &metainternalversion.List{Items: make([]runtime.Object, 0, options.Limit+1)}
-			list.ResourceVersion = m.GetResourceVersion()
 			list.SelfLink = m.GetSelfLink()
 		}
+
+		// the resource version of the last page is the resource version for the list
+		list.ResourceVersion = m.GetResourceVersion()
+
 		if err := meta.EachListItem(obj, func(obj runtime.Object) error {
 			list.Items = append(list.Items, obj)
 			return nil


### PR DESCRIPTION
When paging each page is expected to have a list version. The current
impl assumes the RV cannot change across the list, but there's really
no reason that is true. Instead, use the last page's list. This has
no impact on existing list behavior, but ensures that if we find a
future reasons to have resource version add additional constraints
over a paged list that all clients newer than 1.22 will be safer.

Examples of a paging implementation on the server that could return
different resource versions - the retrieval of a resource could come
from multiple backend stores such that as a page is retrieved additional
constraints apply to the resource version. Future versions of paging
(GA) and resource version will further constrain rules about how to
utilize resource version in these environments, but this makes our
current client less dependent on the server implementation now.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

```release-note
NONE
```
```docs

```