### PR TITLE
sched: remove unneeded json tags in unversioned API objs

### DIFF
--- a/pkg/scheduler/apis/config/legacy_types.go
+++ b/pkg/scheduler/apis/config/legacy_types.go
@@ -130,6 +130,6 @@ type LabelPreference struct {
 // RequestedToCapacityRatioArguments holds arguments specific to RequestedToCapacityRatio priority function.
 type RequestedToCapacityRatioArguments struct {
 	// Array of point defining priority function shape.
-	Shape     []UtilizationShapePoint `json:"shape"`
-	Resources []ResourceSpec          `json:"resources,omitempty"`
+	Shape     []UtilizationShapePoint
+	Resources []ResourceSpec
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/sig scheduling

#### What this PR does / why we need it:

The internal API objects don't need a json tag. This PR does the cleanup work to make the internal types.go consistent.

#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```