### PR TITLE
Relax csi node id length limit to 256

### DIFF
--- a/pkg/apis/storage/validation/validation_test.go
+++ b/pkg/apis/storage/validation/validation_test.go
@@ -1230,7 +1230,7 @@ func TestCSINodeValidation(t *testing.T) {
 	}
 
 	nodeIDCase := storage.CSINode{
-		// node ID length > 128 but < 192
+		// node ID length > 192 but < 256
 		ObjectMeta: metav1.ObjectMeta{Name: "foo7"},
 		Spec: storage.CSINodeSpec{
 			Drivers: []storage.CSINodeDriver{

--- a/pkg/registry/storage/csinode/strategy.go
+++ b/pkg/registry/storage/csinode/strategy.go
@@ -48,10 +48,8 @@ func (csiNodeStrategy) PrepareForCreate(ctx context.Context, obj runtime.Object)
 func (csiNodeStrategy) Validate(ctx context.Context, obj runtime.Object) field.ErrorList {
 	csiNode := obj.(*storage.CSINode)
 
-	// in 1.22, on create, set AllowLongNodeID=false
-	// in 1.23, on create, set AllowLongNodeID=true
 	validateOptions := validation.CSINodeValidationOptions{
-		AllowLongNodeID: false,
+		AllowLongNodeID: true,
 	}
 
 	errs := validation.ValidateCSINode(csiNode, validateOptions)
@@ -77,16 +75,8 @@ func (csiNodeStrategy) PrepareForUpdate(ctx context.Context, obj, old runtime.Ob
 func (csiNodeStrategy) ValidateUpdate(ctx context.Context, obj, old runtime.Object) field.ErrorList {
 	newCSINodeObj := obj.(*storage.CSINode)
 	oldCSINodeObj := old.(*storage.CSINode)
-	// in 1.22 on update, set AllowLongNodeID to true only if the old object already has a long node ID
-	// in 1.23 on update, set AllowLongNodeID=true
-	allowLongNodeID := false
-	for _, nodeDriver := range oldCSINodeObj.Spec.Drivers {
-		if validation.CSINodeLongerID(nodeDriver.NodeID) {
-			allowLongNodeID = true
-		}
-	}
 	validateOptions := validation.CSINodeValidationOptions{
-		AllowLongNodeID: allowLongNodeID,
+		AllowLongNodeID: true,
 	}
 
 	errorList := validation.ValidateCSINode(newCSINodeObj, validateOptions)


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup


#### What this PR does / why we need it:

This PR release csi node length constraint to 256. This is a follow up PR of two previous PR:

- https://github.com/kubernetes/kubernetes/pull/98753
- https://github.com/kubernetes/kubernetes/pull/101256



#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes # https://github.com/kubernetes/kubernetes/issues/99981

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Relax CSI Node ID length limit from 192 to 256.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

/sig storage
/cc @liggitt @msau42 
