### PR TITLE
Backport 104410 to release-1.22

### DIFF
--- a/staging/src/k8s.io/legacy-cloud-providers/vsphere/vsphere_util.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/vsphere/vsphere_util.go
@@ -639,7 +639,7 @@ func (vs *VSphere) BuildMissingVolumeNodeMap(ctx context.Context) {
 		// Start go routines per VC-DC to check disks are attached
 		wg.Add(1)
 		go func(nodes []k8stypes.NodeName) {
-			err := vs.checkNodeDisks(ctx, nodeNames)
+			err := vs.checkNodeDisks(ctx, nodes)
 			if err != nil {
 				klog.Errorf("Failed to check disk attached for nodes: %+v. err: %+v", nodes, err)
 			}


### PR DESCRIPTION
What type of PR is this?
/kind bug

What this PR does / why we need it:
As discussed in https://github.com/kubernetes/kubernetes/pull/104410, this pr is to backport this fix to release-1.22, thanks

```release-note
NONE
```
