### PR TITLE
fix detach disk issue on deleting vmss node

### DIFF
--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_controller_common.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_controller_common.go
@@ -454,5 +454,8 @@ func getValidCreationData(subscriptionID, resourceGroup, sourceResourceID, sourc
 
 func isInstanceNotFoundError(err error) bool {
 	errMsg := strings.ToLower(err.Error())
+	if strings.Contains(errMsg, strings.ToLower(vmssVMNotActiveErrorMessage)) {
+		return true
+	}
 	return strings.Contains(errMsg, errStatusCode400) && strings.Contains(errMsg, errInvalidParameter) && strings.Contains(errMsg, errTargetInstanceIds)
 }

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_controller_common_test.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_controller_common_test.go
@@ -809,8 +809,8 @@ func TestIsInstanceNotFoundError(t *testing.T) {
 			expectedResult: false,
 		},
 		{
-			errMsg:         "not an active Virtual Machine scale set vm",
-			expectedResult: false,
+			errMsg:         "The provided instanceId 857 is not an active Virtual Machine Scale Set VM instanceId.",
+			expectedResult: true,
 		},
 		{
 			errMsg:         `compute.VirtualMachineScaleSetVMsClient#Update: Failure sending request: StatusCode=400 -- Original Error: Code="InvalidParameter" Message="The provided instanceId 1181 is not an active Virtual Machine Scale Set VM instanceId." Target="instanceIds"`,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
fix detach disk issue on deleting node
This PR is a proceeding fix with https://github.com/kubernetes/kubernetes/pull/95177
There was error msg format change when vmss node is in deleting state, this PR tries to fix this issue to make sure detach disk return success on vmss node which is being deleting

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:
current error msg is like following:
```
Operation for \"{volumeName:kubernetes.io/azure-disk//subscriptions/xxxx/resourceGroups/prdgxyusw1res-collabaks2/providers/Microsoft.Compute/disks/kubernetes-dynamic-pvc-bd431821-2dfe-4d8c-bd6d-2bc1fa7367e1 podName: nodeName:}\" failed. No retries permitted until 2021-08-18 20:15:37.594995668 +0000 UTC m=+183633.754026437 (durationBeforeRetry 500ms). Error: \"DetachVolume.Detach failed for volume \\\"pvc-bd431821-2dfe-4d8c-bd6d-2bc1fa7367e1\\\" (UniqueName: \\\"kubernetes.io/azure-disk//subscriptions/xxx/resourceGroups/prdgxyusw1res-collabaks2/providers/Microsoft.Compute/disks/kubernetes-dynamic-pvc-bd431821-2dfe-4d8c-bd6d-2bc1fa7367e1\\\") on node \\\"aks-kubesys-14323105-vmss0000nt\\\" : Retriable: false, RetryAfter: 0s, HTTPStatusCode: 400, RawError: Retriable: false, RetryAfter: 0s, HTTPStatusCode: 400, RawError: {\\r\\n  \\\"error\\\": {\\r\\n    \\\"code\\\": \\\"InvalidParameter\\\",\\r\\n    \\\"message\\\": \\\"The provided instanceId 857 is not an active Virtual Machine Scale Set VM instanceId.\\\",\\r\\n    \\\"target\\\": \\\"instanceIds\\\"\\r\\n  }\\r\\n}\"\n","stream":"stderr","pod":"kube-controller-manager-9877769bf-rd9jj","containerID":"111e49911995816867f05557bdfa762622dd03036c8510ec85b5cc8a2a939db3"}
```

/kind bug
/assign @feiskyer 
/priority important-soon
/sig cloud-provider
/area provider/azure
/triage accepted

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
fix detach disk issue on deleting vmss node
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
fix detach disk issue on deleting node
```
