### PR TITLE
Remove Error Message Check Dynamic PV Tests

### DIFF
--- a/test/e2e/storage/testsuites/volumemode.go
+++ b/test/e2e/storage/testsuites/volumemode.go
@@ -275,7 +275,8 @@ func (t *volumeModeTestSuite) DefineTests(driver storageframework.TestDriver, pa
 					"involvedObject.namespace": l.ns.Name,
 					"reason":                   volevents.ProvisioningFailed,
 				}.AsSelector().String()
-				msg := "does not support block volume provisioning"
+				// The error message is different for each storage driver
+				msg := ""
 
 				err = e2eevents.WaitTimeoutForEvent(l.cs, l.ns.Name, eventSelector, msg, f.Timeouts.ClaimProvision)
 				// Events are unreliable, don't depend on the event. It's used only to speed up the test.


### PR DESCRIPTION
Different CSI drivers have different error messages, making it difficult
to check them accurately. We remove the check for the error message and
only check the failure type instead, since that is all we need.

/kind bug
/assign @jsafrane 