### PR TITLE
OWNERS: SIG Release cleanups

### DIFF
--- a/CHANGELOG/OWNERS
+++ b/CHANGELOG/OWNERS
@@ -1,15 +1,10 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
+  - release-engineering-approvers
+  - release-engineering-reviewers
   - pmmalinov01 # 1.22 Release Notes Lead
   - wilsonehusin # 1.21 Release Notes Lead
-  - cpanato # Release Manager
-  - feiskyer # Release Manager
-  - idealhack # Release Manager
-  - justaugustus # Release Manager / SIG Chair
-  - puerco # Release Manager
-  - saschagrunert # Release Manager / SIG Chair
-  - xmudrii # Release Manager
 reviewers:
   - pmmalinov01 # 1.22 Release Notes Lead
   - cici37 # 1.22 Release Notes shadow

--- a/CHANGELOG/OWNERS
+++ b/CHANGELOG/OWNERS
@@ -5,7 +5,6 @@ approvers:
   - wilsonehusin # 1.21 Release Notes Lead
   - cpanato # Release Manager
   - feiskyer # Release Manager
-  - hasheddan # Release Manager / SIG Technical Lead
   - idealhack # Release Manager
   - justaugustus # Release Manager / SIG Chair
   - puerco # Release Manager

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -121,8 +121,12 @@ aliases:
   build-image-approvers:
     - BenTheElder
     - cblecker
+    - cpanato # SIG Technical Lead / RelEng subproject owner / Release Manager
     - dims
     - justaugustus # SIG Chair / RelEng subproject owner / Release Manager
+    - puerco # SIG Technical Lead / RelEng subproject owner / Release Manager
+    - saschagrunert # SIG Chair / RelEng subproject owner / Release Manager
+    - xmudrii # Release Manager
   build-image-reviewers:
     - BenTheElder
     - cblecker

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -106,33 +106,32 @@ aliases:
 
   # SIG Release
   release-engineering-approvers:
-    - cpanato # Release Manager / SIG Technical Lead
+    - cpanato # SIG Technical Lead / RelEng subproject owner / Release Manager
     - jeremyrickard # SIG Technical Lead / RelEng subproject owner
-    - justaugustus # Release Manager / SIG Chair
-    - puerco # Release Manager / SIG Technical Lead
-    - saschagrunert # Release Manager / SIG Chair
-    - xmudrii # Release Manager
+    - justaugustus # SIG Chair / RelEng subproject owner / Release Manager
+    - puerco # SIG Technical Lead / RelEng subproject owner / Release Manager
+    - saschagrunert # SIG Chair / RelEng subproject owner / Release Manager
   release-engineering-reviewers:
-    - cpanato # Release Manager / SIG Technical Lead
+    - cpanato # SIG Technical Lead / RelEng subproject owner / Release Manager
     - jeremyrickard # SIG Technical Lead / RelEng subproject owner
-    - justaugustus # Release Manager / SIG Chair
-    - puerco # Release Manager / SIG Technical Lead
-    - saschagrunert # Release Manager / SIG Chair
+    - justaugustus # SIG Chair / RelEng subproject owner / Release Manager
+    - puerco # SIG Technical Lead / RelEng subproject owner / Release Manager
+    - saschagrunert # SIG Chair / RelEng subproject owner / Release Manager
     - xmudrii # Release Manager
   build-image-approvers:
     - BenTheElder
     - cblecker
     - dims
-    - justaugustus # Release Manager / SIG Chair
+    - justaugustus # SIG Chair / RelEng subproject owner / Release Manager
   build-image-reviewers:
     - BenTheElder
     - cblecker
-    - cpanato # Release Manager / SIG Technical Lead
+    - cpanato # SIG Technical Lead / RelEng subproject owner / Release Manager
     - dims
     - jeremyrickard # SIG Technical Lead / RelEng subproject owner
-    - justaugustus # Release Manager / SIG Chair
-    - puerco # Release Manager / SIG Technical Lead
-    - saschagrunert # Release Manager / SIG Chair
+    - justaugustus # SIG Chair / RelEng subproject owner / Release Manager
+    - puerco # SIG Technical Lead / RelEng subproject owner / Release Manager
+    - saschagrunert # SIG Chair / RelEng subproject owner / Release Manager
     - xmudrii # Release Manager
 
   sig-storage-approvers:

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -107,14 +107,12 @@ aliases:
   # SIG Release
   release-engineering-approvers:
     - cpanato # Release Manager / SIG Technical Lead
-    - hasheddan # Release Manager / SIG Technical Lead
     - justaugustus # Release Manager / SIG Chair
     - puerco # Release Manager / SIG Technical Lead
     - saschagrunert # Release Manager / SIG Chair
     - xmudrii # Release Manager
   release-engineering-reviewers:
     - cpanato # Release Manager / SIG Technical Lead
-    - hasheddan # Release Manager / SIG Technical Lead
     - justaugustus # Release Manager / SIG Chair
     - puerco # Release Manager / SIG Technical Lead
     - saschagrunert # Release Manager / SIG Chair
@@ -129,7 +127,6 @@ aliases:
     - cblecker
     - cpanato # Release Manager / SIG Technical Lead
     - dims
-    - hasheddan # Release Manager / SIG Technical Lead
     - justaugustus # Release Manager / SIG Chair
     - puerco # Release Manager / SIG Technical Lead
     - saschagrunert # Release Manager / SIG Chair

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -107,12 +107,14 @@ aliases:
   # SIG Release
   release-engineering-approvers:
     - cpanato # Release Manager / SIG Technical Lead
+    - jeremyrickard # SIG Technical Lead / RelEng subproject owner
     - justaugustus # Release Manager / SIG Chair
     - puerco # Release Manager / SIG Technical Lead
     - saschagrunert # Release Manager / SIG Chair
     - xmudrii # Release Manager
   release-engineering-reviewers:
     - cpanato # Release Manager / SIG Technical Lead
+    - jeremyrickard # SIG Technical Lead / RelEng subproject owner
     - justaugustus # Release Manager / SIG Chair
     - puerco # Release Manager / SIG Technical Lead
     - saschagrunert # Release Manager / SIG Chair
@@ -127,6 +129,7 @@ aliases:
     - cblecker
     - cpanato # Release Manager / SIG Technical Lead
     - dims
+    - jeremyrickard # SIG Technical Lead / RelEng subproject owner
     - justaugustus # Release Manager / SIG Chair
     - puerco # Release Manager / SIG Technical Lead
     - saschagrunert # Release Manager / SIG Chair

--- a/build/OWNERS
+++ b/build/OWNERS
@@ -5,7 +5,6 @@ reviewers:
   - cblecker
   - dims
   - fejta
-  - hasheddan # Release Manager / SIG Technical Lead
   - justaugustus # Release Manager / SIG Chair
   - lavalamp
   - saschagrunert # Release Manager / SIG Chair

--- a/build/OWNERS
+++ b/build/OWNERS
@@ -3,12 +3,16 @@
 reviewers:
   - bentheelder
   - cblecker
+  - cpanato # SIG Technical Lead / RelEng subproject owner / Release Manager
   - dims
   - fejta
-  - justaugustus # Release Manager / SIG Chair
+  - jeremyrickard # SIG Technical Lead / RelEng subproject owner
+  - justaugustus # SIG Chair / RelEng subproject owner / Release Manager
   - lavalamp
-  - saschagrunert # Release Manager / SIG Chair
+  - puerco # SIG Technical Lead / RelEng subproject owner / Release Manager
+  - saschagrunert # SIG Chair / RelEng subproject owner / Release Manager
   - spiffxp
+  - xmudrii # Release Manager
 approvers:
   - bentheelder
   - cblecker

--- a/cmd/dependencycheck/OWNERS
+++ b/cmd/dependencycheck/OWNERS
@@ -1,8 +1,5 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
-reviewers:
-  - hasheddan
 approvers:
   - bentheelder
-  - hasheddan
   - liggitt


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

- OWNERS: @hasheddan is now Emeritus (https://github.com/kubernetes/sig-release/issues/1667)
- OWNERS(releng): Add @jeremyrickard 
- OWNERS(releng): Tidy approver/reviewer descriptions
- OWNERS(build-image): Add previous RelEng reviewers to approvers
- build/OWNERS: Add Release Engineering as reviewers
- CHANGELOG/OWNERS: Use RelEng aliases for approvals

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
