### PR TITLE
Add metrics about LIST handler executions

### DIFF
--- a/pkg/controlplane/instance.go
+++ b/pkg/controlplane/instance.go
@@ -249,11 +249,12 @@ func (c *Config) createLeaseReconciler() reconcilers.EndpointReconciler {
 	endpointsAdapter := reconcilers.NewEndpointsAdapter(endpointClient, endpointSliceClient)
 
 	ttl := c.ExtraConfig.MasterEndpointReconcileTTL
-	config, err := c.ExtraConfig.StorageFactory.NewConfig(api.Resource("apiServerIPInfo"))
+	ipInfoResource := api.Resource("apiServerIPInfo")
+	config, err := c.ExtraConfig.StorageFactory.NewConfig(ipInfoResource)
 	if err != nil {
 		klog.Fatalf("Error determining service IP ranges: %v", err)
 	}
-	leaseStorage, _, err := storagefactory.Create(*config, nil)
+	leaseStorage, _, err := storagefactory.Create(*config, c.ExtraConfig.StorageFactory.ResourcePrefix(ipInfoResource), nil)
 	if err != nil {
 		klog.Fatalf("Error creating storage factory: %v", err)
 	}

--- a/pkg/registry/core/componentstatus/rest.go
+++ b/pkg/registry/core/componentstatus/rest.go
@@ -115,11 +115,9 @@ func componentStatusPredicate(options *metainternalversion.ListOptions) storage.
 func matchesPredicate(status api.ComponentStatus, pred *storage.SelectionPredicate) bool {
 	// currently no fields except the generic meta fields are supported for predicate matching
 	fieldsSet := generic.AddObjectMetaFieldsSet(make(fields.Set, 2), &status.ObjectMeta, true)
-	var numSelectorEvals int
 	return pred.MatchesObjectAttributes(
 		status.ObjectMeta.Labels,
 		fieldsSet,
-		&numSelectorEvals,
 	)
 }
 

--- a/pkg/registry/core/componentstatus/rest.go
+++ b/pkg/registry/core/componentstatus/rest.go
@@ -115,9 +115,11 @@ func componentStatusPredicate(options *metainternalversion.ListOptions) storage.
 func matchesPredicate(status api.ComponentStatus, pred *storage.SelectionPredicate) bool {
 	// currently no fields except the generic meta fields are supported for predicate matching
 	fieldsSet := generic.AddObjectMetaFieldsSet(make(fields.Set, 2), &status.ObjectMeta, true)
+	var numSelectorEvals int
 	return pred.MatchesObjectAttributes(
 		status.ObjectMeta.Labels,
 		fieldsSet,
+		&numSelectorEvals,
 	)
 }
 

--- a/pkg/registry/core/pod/rest/log_test.go
+++ b/pkg/registry/core/pod/rest/log_test.go
@@ -30,7 +30,7 @@ import (
 func TestPodLogValidates(t *testing.T) {
 	config, server := registrytest.NewEtcdStorage(t, "")
 	defer server.Terminate(t)
-	s, destroyFunc, err := generic.NewRawStorage(config, nil)
+	s, destroyFunc, err := generic.NewRawStorage(config, "/pods", nil)
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}

--- a/pkg/registry/core/service/allocator/storage/storage.go
+++ b/pkg/registry/core/service/allocator/storage/storage.go
@@ -62,7 +62,7 @@ var _ rangeallocation.RangeRegistry = &Etcd{}
 // NewEtcd returns an allocator that is backed by Etcd and can manage
 // persisting the snapshot state of allocation after each allocation is made.
 func NewEtcd(alloc allocator.Snapshottable, baseKey string, resource schema.GroupResource, config *storagebackend.Config) (*Etcd, error) {
-	storage, d, err := generic.NewRawStorage(config, nil)
+	storage, d, err := generic.NewRawStorage(config, baseKey+"/"+resource.String(), nil)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/registry/core/service/ipallocator/storage/storage_test.go
+++ b/pkg/registry/core/service/ipallocator/storage/storage_test.go
@@ -54,7 +54,7 @@ func newStorage(t *testing.T) (*etcd3testing.EtcdTestServer, ipallocator.Interfa
 	if err != nil {
 		t.Fatalf("unexpected error creating etcd: %v", err)
 	}
-	s, d, err := generic.NewRawStorage(etcdStorage, nil)
+	s, d, err := generic.NewRawStorage(etcdStorage, "/serviceipallocations", nil)
 	if err != nil {
 		t.Fatalf("Couldn't create storage: %v", err)
 	}

--- a/pkg/registry/core/service/portallocator/storage/storage_test.go
+++ b/pkg/registry/core/service/portallocator/storage/storage_test.go
@@ -57,7 +57,7 @@ func newStorage(t *testing.T) (*etcd3testing.EtcdTestServer, portallocator.Inter
 	if err != nil {
 		t.Fatalf("unexpected error creating etcd: %v", err)
 	}
-	s, d, err := generic.NewRawStorage(etcdStorage, nil)
+	s, d, err := generic.NewRawStorage(etcdStorage, "/servicenodeportallocations", nil)
 	if err != nil {
 		t.Fatalf("Couldn't create storage: %v", err)
 	}

--- a/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/dryrun_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/dryrun_test.go
@@ -38,7 +38,7 @@ import (
 func NewDryRunnableTestStorage(t *testing.T) (DryRunnableStorage, func()) {
 	server, sc := etcd3testing.NewUnsecuredEtcd3TestClientServer(t)
 	sc.Codec = apitesting.TestStorageCodec(codecs, examplev1.SchemeGroupVersion)
-	s, destroy, err := factory.Create(*sc, nil)
+	s, destroy, err := factory.Create(*sc, "", nil)
 	if err != nil {
 		t.Fatalf("Error creating storage: %v", err)
 	}

--- a/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/storage_factory.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/storage_factory.go
@@ -45,7 +45,7 @@ func StorageWithCacher() generic.StorageDecorator {
 		triggerFuncs storage.IndexerFuncs,
 		indexers *cache.Indexers) (storage.Interface, factory.DestroyFunc, error) {
 
-		s, d, err := generic.NewRawStorage(storageConfig, newFunc)
+		s, d, err := generic.NewRawStorage(storageConfig, resourcePrefix, newFunc)
 		if err != nil {
 			return s, d, err
 		}

--- a/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/store_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/store_test.go
@@ -2230,7 +2230,7 @@ func newTestGenericStoreRegistry(t *testing.T, scheme *runtime.Scheme, hasCacheE
 	newListFunc := func() runtime.Object { return &example.PodList{} }
 
 	sc.Codec = apitesting.TestStorageCodec(codecs, examplev1.SchemeGroupVersion)
-	s, dFunc, err := factory.Create(*sc, newFunc)
+	s, dFunc, err := factory.Create(*sc, "", newFunc)
 	if err != nil {
 		t.Fatalf("Error creating storage: %v", err)
 	}

--- a/staging/src/k8s.io/apiserver/pkg/registry/generic/storage_decorator.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/generic/storage_decorator.go
@@ -47,12 +47,12 @@ func UndecoratedStorage(
 	getAttrsFunc storage.AttrFunc,
 	trigger storage.IndexerFuncs,
 	indexers *cache.Indexers) (storage.Interface, factory.DestroyFunc, error) {
-	return NewRawStorage(config, newFunc)
+	return NewRawStorage(config, resourcePrefix, newFunc)
 }
 
 // NewRawStorage creates the low level kv storage. This is a work-around for current
 // two layer of same storage interface.
 // TODO: Once cacher is enabled on all registries (event registry is special), we will remove this method.
-func NewRawStorage(config *storagebackend.Config, newFunc func() runtime.Object) (storage.Interface, factory.DestroyFunc, error) {
-	return factory.Create(*config, newFunc)
+func NewRawStorage(config *storagebackend.Config, resourcePrefix string, newFunc func() runtime.Object) (storage.Interface, factory.DestroyFunc, error) {
+	return factory.Create(*config, resourcePrefix, newFunc)
 }

--- a/staging/src/k8s.io/apiserver/pkg/server/routes/metrics.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/routes/metrics.go
@@ -19,6 +19,7 @@ package routes
 import (
 	apimetrics "k8s.io/apiserver/pkg/endpoints/metrics"
 	"k8s.io/apiserver/pkg/server/mux"
+	cachermetrics "k8s.io/apiserver/pkg/storage/cacher/metrics"
 	etcd3metrics "k8s.io/apiserver/pkg/storage/etcd3/metrics"
 	flowcontrolmetrics "k8s.io/apiserver/pkg/util/flowcontrol/metrics"
 	"k8s.io/component-base/metrics/legacyregistry"
@@ -47,5 +48,6 @@ func (m MetricsWithReset) Install(c *mux.PathRecorderMux) {
 func register() {
 	apimetrics.Register()
 	etcd3metrics.Register()
+	cachermetrics.Register()
 	flowcontrolmetrics.Register()
 }

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/metrics/OWNERS
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/metrics/OWNERS
@@ -1,0 +1,4 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+  - logicalhan

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/metrics/metrics.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/metrics/metrics.go
@@ -1,0 +1,81 @@
+/*
+Copyright 2015 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"sync"
+
+	compbasemetrics "k8s.io/component-base/metrics"
+	"k8s.io/component-base/metrics/legacyregistry"
+)
+
+/*
+ * By default, all the following metrics are defined as falling under
+ * ALPHA stability level https://github.com/kubernetes/enhancements/blob/master/keps/sig-instrumentation/1209-metrics-stability/kubernetes-control-plane-metrics-stability.md#stability-classes)
+ *
+ * Promoting the stability level of the metric is a responsibility of the component owner, since it
+ * involves explicitly acknowledging support for the metric across multiple releases, in accordance with
+ * the metric stability policy.
+ */
+var (
+	listCacheNumFetched = compbasemetrics.NewHistogramVec(
+		&compbasemetrics.HistogramOpts{
+			Name:           "apiserver_list_cache_num_fetched",
+			Help:           "Number of objects read from watch cache in the course of serving a LIST request, split by path_prefix and index_used",
+			Buckets:        []float64{40, 80, 160, 320, 640, 1280, 2560, 5120, 10240},
+			StabilityLevel: compbasemetrics.ALPHA,
+		},
+		[]string{"path_prefix", "index_used"},
+	)
+	listCacheNumSelectorEvals = compbasemetrics.NewHistogramVec(
+		&compbasemetrics.HistogramOpts{
+			Name:           "apiserver_list_cache_num_selector_evals",
+			Help:           "Number of label or field selector evaluations in the course of serving a LIST request from watch cache, split by path_prefix and index_used",
+			Buckets:        []float64{40, 80, 160, 320, 640, 1280, 2560, 5120, 10240, 20480},
+			StabilityLevel: compbasemetrics.ALPHA,
+		},
+		[]string{"path_prefix", "index_used"},
+	)
+	listCacheNumReturned = compbasemetrics.NewHistogramVec(
+		&compbasemetrics.HistogramOpts{
+			Name:           "apiserver_list_cache_num_returned",
+			Help:           "Number of objects returned for a LIST request from watch cache, split by path_prefix and index_used",
+			Buckets:        []float64{40, 80, 160, 320, 640, 1280, 2560, 5120, 10240},
+			StabilityLevel: compbasemetrics.ALPHA,
+		},
+		[]string{"path_prefix", "index_used"},
+	)
+)
+
+var registerMetrics sync.Once
+
+// Register all metrics.
+func Register() {
+	// Register the metrics.
+	registerMetrics.Do(func() {
+		legacyregistry.MustRegister(listCacheNumFetched)
+		legacyregistry.MustRegister(listCacheNumSelectorEvals)
+		legacyregistry.MustRegister(listCacheNumReturned)
+	})
+}
+
+// RecordListCacheMetrics notes various metrics of the cost to serve a LIST request
+func RecordListCacheMetrics(pathPrefix, indexUsed string, numFetched, numSelectorEvals, numReturned int) {
+	listCacheNumFetched.WithLabelValues(pathPrefix, indexUsed).Observe(float64(numFetched))
+	listCacheNumSelectorEvals.WithLabelValues(pathPrefix, indexUsed).Observe(float64(numSelectorEvals))
+	listCacheNumReturned.WithLabelValues(pathPrefix, indexUsed).Observe(float64(numReturned))
+}

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/watch_cache.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/watch_cache.go
@@ -449,12 +449,13 @@ func (w *watchCache) waitUntilFreshAndBlock(resourceVersion uint64, trace *utilt
 	return nil
 }
 
-// WaitUntilFreshAndList returns list of pointers to <storeElement> objects.
-func (w *watchCache) WaitUntilFreshAndList(resourceVersion uint64, matchValues []storage.MatchValue, trace *utiltrace.Trace) ([]interface{}, uint64, error) {
+// WaitUntilFreshAndList returns list of pointers to `storeElement` objects along
+// with their ResourceVersion and the name of the index, if any, that was used
+func (w *watchCache) WaitUntilFreshAndList(resourceVersion uint64, matchValues []storage.MatchValue, trace *utiltrace.Trace) ([]interface{}, uint64, string, error) {
 	err := w.waitUntilFreshAndBlock(resourceVersion, trace)
 	defer w.RUnlock()
 	if err != nil {
-		return nil, 0, err
+		return nil, 0, "", err
 	}
 
 	// This isn't the place where we do "final filtering" - only some "prefiltering" is happening here. So the only
@@ -463,10 +464,10 @@ func (w *watchCache) WaitUntilFreshAndList(resourceVersion uint64, matchValues [
 	// TODO: if multiple indexes match, return the one with the fewest items, so as to do as much filtering as possible.
 	for _, matchValue := range matchValues {
 		if result, err := w.store.ByIndex(matchValue.IndexName, matchValue.Value); err == nil {
-			return result, w.resourceVersion, nil
+			return result, w.resourceVersion, matchValue.IndexName, nil
 		}
 	}
-	return w.store.List(), w.resourceVersion, nil
+	return w.store.List(), w.resourceVersion, "", nil
 }
 
 // WaitUntilFreshAndGet returns a pointers to <storeElement> object.

--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/metrics/metrics.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/metrics/metrics.go
@@ -17,6 +17,7 @@ limitations under the License.
 package metrics
 
 import (
+	"strconv"
 	"sync"
 	"time"
 
@@ -88,47 +89,47 @@ var (
 	listEtcd3Queries = compbasemetrics.NewHistogramVec(
 		&compbasemetrics.HistogramOpts{
 			Name:           "apiserver_list_etcd3_queries",
-			Help:           "Number of etcd range queries used to satisfy a LIST request, split by path_prefix",
+			Help:           "Number of etcd range queries used to satisfy a LIST request, split by resource_prefix",
 			Buckets:        []float64{1, 2, 4, 8, 16},
 			StabilityLevel: compbasemetrics.ALPHA,
 		},
-		[]string{"path_prefix"},
+		[]string{"resource_prefix"},
 	)
 	listEtcd3SansVersion = compbasemetrics.NewHistogramVec(
 		&compbasemetrics.HistogramOpts{
 			Name:           "apiserver_list_etcd3_sans_version",
-			Help:           "Number of etcd range queries without specified ResourceVersion used to satisfy a LIST request, split by path_prefix",
-			Buckets:        []float64{0, 1},
+			Help:           "Number of etcd range queries without specified ResourceVersion used to satisfy a LIST request, split by resource_prefix",
+			Buckets:        []float64{0},
 			StabilityLevel: compbasemetrics.ALPHA,
 		},
-		[]string{"path_prefix"},
+		[]string{"path_presource_prefixrefix"},
 	)
 	listEtcd3NumFetched = compbasemetrics.NewHistogramVec(
 		&compbasemetrics.HistogramOpts{
 			Name:           "apiserver_list_etcd3_num_fetched",
-			Help:           "Number of objects read from etcd in the course of serving a LIST request, split by path_prefix",
+			Help:           "Number of objects read from etcd in the course of serving a LIST request, split by resource_prefix",
 			Buckets:        []float64{40, 80, 160, 320, 640, 1280, 2560, 5120, 10240},
 			StabilityLevel: compbasemetrics.ALPHA,
 		},
-		[]string{"path_prefix"},
+		[]string{"resource_prefix"},
 	)
 	listEtcd3NumSelectorEvals = compbasemetrics.NewHistogramVec(
 		&compbasemetrics.HistogramOpts{
 			Name:           "apiserver_list_etcd3_num_selector_evals",
-			Help:           "Number of label or field selector evaluations in the course of serving a LIST request from etcd, split by path_prefix",
+			Help:           "Number of objects tested in the course of serving a LIST request from etcd, split by resource_prefix and predicate complexity",
 			Buckets:        []float64{40, 80, 160, 320, 640, 1280, 2560, 5120, 10240, 20480},
 			StabilityLevel: compbasemetrics.ALPHA,
 		},
-		[]string{"path_prefix"},
+		[]string{"resource_prefix", "predicate_complexity"},
 	)
 	listEtcd3NumReturned = compbasemetrics.NewHistogramVec(
 		&compbasemetrics.HistogramOpts{
 			Name:           "apiserver_list_etcd3_num_returned",
-			Help:           "Number of objects returned for a LIST request from etcd, split by path_prefix",
+			Help:           "Number of objects returned for a LIST request from etcd, split by resource_prefix",
 			Buckets:        []float64{40, 80, 160, 320, 640, 1280, 2560, 5120, 10240},
 			StabilityLevel: compbasemetrics.ALPHA,
 		},
-		[]string{"path_prefix"},
+		[]string{"resource_prefix"},
 	)
 )
 
@@ -191,10 +192,10 @@ func UpdateLeaseObjectCount(count int64) {
 }
 
 // RecordListEtcd3Metrics notes various metrics of the cost to serve a LIST request
-func RecordListEtcd3Metrics(pathPrefix string, numQueries, numSansVersion, numFetched, numSelectorEvals, numReturned int) {
-	listEtcd3Queries.WithLabelValues(pathPrefix).Observe(float64(numQueries))
-	listEtcd3SansVersion.WithLabelValues(pathPrefix).Observe(float64(numSansVersion))
-	listEtcd3NumFetched.WithLabelValues(pathPrefix).Observe(float64(numFetched))
-	listEtcd3NumSelectorEvals.WithLabelValues(pathPrefix).Observe(float64(numSelectorEvals))
-	listEtcd3NumReturned.WithLabelValues(pathPrefix).Observe(float64(numReturned))
+func RecordListEtcd3Metrics(resourcePrefix string, numQueries, numSansVersion, numFetched, predicateComplexity, numEvald, numReturned int) {
+	listEtcd3Queries.WithLabelValues(resourcePrefix).Observe(float64(numQueries))
+	listEtcd3SansVersion.WithLabelValues(resourcePrefix).Observe(float64(numSansVersion))
+	listEtcd3NumFetched.WithLabelValues(resourcePrefix).Observe(float64(numFetched))
+	listEtcd3NumSelectorEvals.WithLabelValues(resourcePrefix, strconv.FormatInt(int64(predicateComplexity), 10)).Observe(float64(numEvald))
+	listEtcd3NumReturned.WithLabelValues(resourcePrefix).Observe(float64(numReturned))
 }

--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/store_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/store_test.go
@@ -1000,7 +1000,7 @@ func TestGuaranteedUpdateWithSuggestionAndConflict(t *testing.T) {
 func TestTransformationFailure(t *testing.T) {
 	client := testserver.RunEtcd(t, nil)
 	codec := apitesting.TestCodec(codecs, examplev1.SchemeGroupVersion)
-	store := newStore(client, codec, newPod, "", &prefixTransformer{prefix: []byte(defaultTestPrefix)}, false, NewDefaultLeaseManagerConfig())
+	store := newStore(client, codec, newPod, "", "", &prefixTransformer{prefix: []byte(defaultTestPrefix)}, false, NewDefaultLeaseManagerConfig())
 	ctx := context.Background()
 
 	preset := []struct {
@@ -1076,8 +1076,8 @@ func TestList(t *testing.T) {
 	client := testserver.RunEtcd(t, nil)
 	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.RemainingItemCount, true)()
 	codec := apitesting.TestCodec(codecs, examplev1.SchemeGroupVersion)
-	store := newStore(client, codec, newPod, "", &prefixTransformer{prefix: []byte(defaultTestPrefix)}, true, NewDefaultLeaseManagerConfig())
-	disablePagingStore := newStore(client, codec, newPod, "", &prefixTransformer{prefix: []byte(defaultTestPrefix)}, false, NewDefaultLeaseManagerConfig())
+	store := newStore(client, codec, newPod, "", "", &prefixTransformer{prefix: []byte(defaultTestPrefix)}, true, NewDefaultLeaseManagerConfig())
+	disablePagingStore := newStore(client, codec, newPod, "", "", &prefixTransformer{prefix: []byte(defaultTestPrefix)}, false, NewDefaultLeaseManagerConfig())
 	ctx := context.Background()
 
 	// Setup storage with the following structure:
@@ -1573,7 +1573,7 @@ func TestListContinuation(t *testing.T) {
 	transformer := &prefixTransformer{prefix: []byte(defaultTestPrefix)}
 	recorder := &clientRecorder{KV: etcdClient.KV}
 	etcdClient.KV = recorder
-	store := newStore(etcdClient, codec, newPod, "", transformer, true, NewDefaultLeaseManagerConfig())
+	store := newStore(etcdClient, codec, newPod, "", "", transformer, true, NewDefaultLeaseManagerConfig())
 	ctx := context.Background()
 
 	// Setup storage with the following structure:
@@ -1733,7 +1733,7 @@ func TestListContinuationWithFilter(t *testing.T) {
 	transformer := &prefixTransformer{prefix: []byte(defaultTestPrefix)}
 	recorder := &clientRecorder{KV: etcdClient.KV}
 	etcdClient.KV = recorder
-	store := newStore(etcdClient, codec, newPod, "", transformer, true, NewDefaultLeaseManagerConfig())
+	store := newStore(etcdClient, codec, newPod, "", "", transformer, true, NewDefaultLeaseManagerConfig())
 	ctx := context.Background()
 
 	preset := []struct {
@@ -1835,7 +1835,7 @@ func TestListContinuationWithFilter(t *testing.T) {
 func TestListInconsistentContinuation(t *testing.T) {
 	client := testserver.RunEtcd(t, nil)
 	codec := apitesting.TestCodec(codecs, examplev1.SchemeGroupVersion)
-	store := newStore(client, codec, newPod, "", &prefixTransformer{prefix: []byte(defaultTestPrefix)}, true, NewDefaultLeaseManagerConfig())
+	store := newStore(client, codec, newPod, "", "", &prefixTransformer{prefix: []byte(defaultTestPrefix)}, true, NewDefaultLeaseManagerConfig())
 	ctx := context.Background()
 
 	// Setup storage with the following structure:
@@ -1983,7 +1983,7 @@ func testSetup(t *testing.T) (context.Context, *store, *clientv3.Client) {
 	// As 30s is the default timeout for testing in glboal configuration,
 	// we cannot wait longer than that in a single time: change it to 10
 	// for testing purposes. See apimachinery/pkg/util/wait/wait.go
-	store := newStore(client, codec, newPod, "", &prefixTransformer{prefix: []byte(defaultTestPrefix)}, true, LeaseManagerConfig{
+	store := newStore(client, codec, newPod, "", "", &prefixTransformer{prefix: []byte(defaultTestPrefix)}, true, LeaseManagerConfig{
 		ReuseDurationSeconds: 1,
 		MaxObjectCount:       defaultLeaseMaxObjectCount,
 	})
@@ -2027,7 +2027,7 @@ func TestPrefix(t *testing.T) {
 		"/registry":         "/registry",
 	}
 	for configuredPrefix, effectivePrefix := range testcases {
-		store := newStore(client, codec, nil, configuredPrefix, transformer, true, NewDefaultLeaseManagerConfig())
+		store := newStore(client, codec, nil, configuredPrefix, "", transformer, true, NewDefaultLeaseManagerConfig())
 		if store.pathPrefix != effectivePrefix {
 			t.Errorf("configured prefix of %s, expected effective prefix of %s, got %s", configuredPrefix, effectivePrefix, store.pathPrefix)
 		}
@@ -2192,7 +2192,7 @@ func TestConsistentList(t *testing.T) {
 	transformer := &fancyTransformer{
 		transformer: &prefixTransformer{prefix: []byte(defaultTestPrefix)},
 	}
-	store := newStore(client, codec, newPod, "", transformer, true, NewDefaultLeaseManagerConfig())
+	store := newStore(client, codec, newPod, "", "", transformer, true, NewDefaultLeaseManagerConfig())
 	transformer.store = store
 
 	for i := 0; i < 5; i++ {
@@ -2296,7 +2296,7 @@ func TestCount(t *testing.T) {
 func TestLeaseMaxObjectCount(t *testing.T) {
 	codec := apitesting.TestCodec(codecs, examplev1.SchemeGroupVersion)
 	client := testserver.RunEtcd(t, nil)
-	store := newStore(client, codec, newPod, "", &prefixTransformer{prefix: []byte(defaultTestPrefix)}, true, LeaseManagerConfig{
+	store := newStore(client, codec, newPod, "", "", &prefixTransformer{prefix: []byte(defaultTestPrefix)}, true, LeaseManagerConfig{
 		ReuseDurationSeconds: defaultLeaseReuseDurationSeconds,
 		MaxObjectCount:       2,
 	})

--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/watcher.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/watcher.go
@@ -312,8 +312,7 @@ func (wc *watchChan) filter(obj runtime.Object) bool {
 	if wc.internalPred.Empty() {
 		return true
 	}
-	var selectorEvalCount int
-	matched, err := wc.internalPred.Matches(obj, &selectorEvalCount)
+	matched, err := wc.internalPred.Matches(obj)
 	return err == nil && matched
 }
 

--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/watcher.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/watcher.go
@@ -312,7 +312,8 @@ func (wc *watchChan) filter(obj runtime.Object) bool {
 	if wc.internalPred.Empty() {
 		return true
 	}
-	matched, err := wc.internalPred.Matches(obj)
+	var selectorEvalCount int
+	matched, err := wc.internalPred.Matches(obj, &selectorEvalCount)
 	return err == nil && matched
 }
 

--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/watcher_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/watcher_test.go
@@ -221,13 +221,13 @@ func TestWatchFromNoneZero(t *testing.T) {
 func TestWatchError(t *testing.T) {
 	codec := &testCodec{apitesting.TestCodec(codecs, examplev1.SchemeGroupVersion)}
 	client := testserver.RunEtcd(t, nil)
-	invalidStore := newStore(client, codec, newPod, "", &prefixTransformer{prefix: []byte("test!")}, true, NewDefaultLeaseManagerConfig())
+	invalidStore := newStore(client, codec, newPod, "", "", &prefixTransformer{prefix: []byte("test!")}, true, NewDefaultLeaseManagerConfig())
 	ctx := context.Background()
 	w, err := invalidStore.Watch(ctx, "/abc", storage.ListOptions{ResourceVersion: "0", Predicate: storage.Everything})
 	if err != nil {
 		t.Fatalf("Watch failed: %v", err)
 	}
-	validStore := newStore(client, codec, newPod, "", &prefixTransformer{prefix: []byte("test!")}, true, NewDefaultLeaseManagerConfig())
+	validStore := newStore(client, codec, newPod, "", "", &prefixTransformer{prefix: []byte("test!")}, true, NewDefaultLeaseManagerConfig())
 	validStore.GuaranteedUpdate(ctx, "/abc", &example.Pod{}, true, nil, storage.SimpleUpdate(
 		func(runtime.Object) (runtime.Object, error) {
 			return &example.Pod{ObjectMeta: metav1.ObjectMeta{Name: "foo"}}, nil
@@ -327,7 +327,7 @@ func TestProgressNotify(t *testing.T) {
 	clusterConfig := testserver.NewTestConfig(t)
 	clusterConfig.ExperimentalWatchProgressNotifyInterval = time.Second
 	client := testserver.RunEtcd(t, clusterConfig)
-	store := newStore(client, codec, newPod, "", &prefixTransformer{prefix: []byte(defaultTestPrefix)}, false, NewDefaultLeaseManagerConfig())
+	store := newStore(client, codec, newPod, "", "", &prefixTransformer{prefix: []byte(defaultTestPrefix)}, false, NewDefaultLeaseManagerConfig())
 	ctx := context.Background()
 
 	key := "/somekey"

--- a/staging/src/k8s.io/apiserver/pkg/storage/selection_predicate.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/selection_predicate.go
@@ -84,7 +84,7 @@ type SelectionPredicate struct {
 // Matches returns true if the given object's labels and fields (as
 // returned by s.GetAttrs) match s.Label and s.Field. An error is
 // returned if s.GetAttrs fails.
-func (s *SelectionPredicate) Matches(obj runtime.Object, selectorEvalCount *int) (bool, error) {
+func (s *SelectionPredicate) Matches(obj runtime.Object) (bool, error) {
 	if s.Empty() {
 		return true, nil
 	}
@@ -92,10 +92,8 @@ func (s *SelectionPredicate) Matches(obj runtime.Object, selectorEvalCount *int)
 	if err != nil {
 		return false, err
 	}
-	(*selectorEvalCount)++
 	matched := s.Label.Matches(labels)
 	if matched && s.Field != nil {
-		(*selectorEvalCount)++
 		matched = s.Field.Matches(fields)
 	}
 	return matched, nil
@@ -103,14 +101,12 @@ func (s *SelectionPredicate) Matches(obj runtime.Object, selectorEvalCount *int)
 
 // MatchesObjectAttributes returns true if the given labels and fields
 // match s.Label and s.Field.
-func (s *SelectionPredicate) MatchesObjectAttributes(l labels.Set, f fields.Set, selectorEvalCount *int) bool {
+func (s *SelectionPredicate) MatchesObjectAttributes(l labels.Set, f fields.Set) bool {
 	if s.Label.Empty() && s.Field.Empty() {
 		return true
 	}
-	(*selectorEvalCount)++
 	matched := s.Label.Matches(l)
 	if matched && s.Field != nil {
-		(*selectorEvalCount)++
 		matched = s.Field.Matches(f)
 	}
 	return matched

--- a/staging/src/k8s.io/apiserver/pkg/storage/selection_predicate.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/selection_predicate.go
@@ -84,7 +84,7 @@ type SelectionPredicate struct {
 // Matches returns true if the given object's labels and fields (as
 // returned by s.GetAttrs) match s.Label and s.Field. An error is
 // returned if s.GetAttrs fails.
-func (s *SelectionPredicate) Matches(obj runtime.Object) (bool, error) {
+func (s *SelectionPredicate) Matches(obj runtime.Object, selectorEvalCount *int) (bool, error) {
 	if s.Empty() {
 		return true, nil
 	}
@@ -92,22 +92,26 @@ func (s *SelectionPredicate) Matches(obj runtime.Object) (bool, error) {
 	if err != nil {
 		return false, err
 	}
+	(*selectorEvalCount)++
 	matched := s.Label.Matches(labels)
 	if matched && s.Field != nil {
-		matched = matched && s.Field.Matches(fields)
+		(*selectorEvalCount)++
+		matched = s.Field.Matches(fields)
 	}
 	return matched, nil
 }
 
 // MatchesObjectAttributes returns true if the given labels and fields
 // match s.Label and s.Field.
-func (s *SelectionPredicate) MatchesObjectAttributes(l labels.Set, f fields.Set) bool {
+func (s *SelectionPredicate) MatchesObjectAttributes(l labels.Set, f fields.Set, selectorEvalCount *int) bool {
 	if s.Label.Empty() && s.Field.Empty() {
 		return true
 	}
+	(*selectorEvalCount)++
 	matched := s.Label.Matches(l)
 	if matched && s.Field != nil {
-		matched = (matched && s.Field.Matches(f))
+		(*selectorEvalCount)++
+		matched = s.Field.Matches(f)
 	}
 	return matched
 }

--- a/staging/src/k8s.io/apiserver/pkg/storage/storagebackend/factory/etcd3.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/storagebackend/factory/etcd3.go
@@ -244,7 +244,7 @@ func startCompactorOnce(c storagebackend.TransportConfig, interval time.Duration
 	}, nil
 }
 
-func newETCD3Storage(c storagebackend.Config, newFunc func() runtime.Object) (storage.Interface, DestroyFunc, error) {
+func newETCD3Storage(c storagebackend.Config, resourcePrefix string, newFunc func() runtime.Object) (storage.Interface, DestroyFunc, error) {
 	stopCompactor, err := startCompactorOnce(c.Transport, c.CompactionInterval)
 	if err != nil {
 		return nil, nil, err
@@ -276,7 +276,7 @@ func newETCD3Storage(c storagebackend.Config, newFunc func() runtime.Object) (st
 	if transformer == nil {
 		transformer = value.IdentityTransformer
 	}
-	return etcd3.New(client, c.Codec, newFunc, c.Prefix, transformer, c.Paging, c.LeaseManagerConfig), destroyFunc, nil
+	return etcd3.New(client, c.Codec, newFunc, c.Prefix, resourcePrefix, transformer, c.Paging, c.LeaseManagerConfig), destroyFunc, nil
 }
 
 // startDBSizeMonitorPerEndpoint starts a loop to monitor etcd database size and update the

--- a/staging/src/k8s.io/apiserver/pkg/storage/storagebackend/factory/factory.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/storagebackend/factory/factory.go
@@ -28,12 +28,12 @@ import (
 type DestroyFunc func()
 
 // Create creates a storage backend based on given config.
-func Create(c storagebackend.Config, newFunc func() runtime.Object) (storage.Interface, DestroyFunc, error) {
+func Create(c storagebackend.Config, resourcePrefix string, newFunc func() runtime.Object) (storage.Interface, DestroyFunc, error) {
 	switch c.Type {
 	case storagebackend.StorageTypeETCD2:
 		return nil, nil, fmt.Errorf("%s is no longer a supported storage backend", c.Type)
 	case storagebackend.StorageTypeUnset, storagebackend.StorageTypeETCD3:
-		return newETCD3Storage(c, newFunc)
+		return newETCD3Storage(c, resourcePrefix, newFunc)
 	default:
 		return nil, nil, fmt.Errorf("unknown storage type: %s", c.Type)
 	}

--- a/staging/src/k8s.io/apiserver/pkg/storage/storagebackend/factory/tls_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/storagebackend/factory/tls_test.go
@@ -78,7 +78,7 @@ func TestTLSConnection(t *testing.T) {
 		},
 		Codec: codec,
 	}
-	storage, destroyFunc, err := newETCD3Storage(cfg, nil)
+	storage, destroyFunc, err := newETCD3Storage(cfg, "/pods", nil)
 	defer destroyFunc()
 	if err != nil {
 		t.Fatal(err)

--- a/staging/src/k8s.io/apiserver/pkg/storage/tests/cacher_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/tests/cacher_test.go
@@ -105,7 +105,7 @@ func newPodList() runtime.Object { return &example.PodList{} }
 
 func newEtcdTestStorage(t *testing.T, prefix string) (*etcd3testing.EtcdTestServer, storage.Interface) {
 	server, _ := etcd3testing.NewUnsecuredEtcd3TestClientServer(t)
-	storage := etcd3.New(server.V3Client, apitesting.TestCodec(codecs, examplev1.SchemeGroupVersion), newPod, prefix, value.IdentityTransformer, true, etcd3.NewDefaultLeaseManagerConfig())
+	storage := etcd3.New(server.V3Client, apitesting.TestCodec(codecs, examplev1.SchemeGroupVersion), newPod, prefix, "/pods", value.IdentityTransformer, true, etcd3.NewDefaultLeaseManagerConfig())
 	return server, storage
 }
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1526,6 +1526,7 @@ k8s.io/apiserver/pkg/server/routes
 k8s.io/apiserver/pkg/server/storage
 k8s.io/apiserver/pkg/storage
 k8s.io/apiserver/pkg/storage/cacher
+k8s.io/apiserver/pkg/storage/cacher/metrics
 k8s.io/apiserver/pkg/storage/errors
 k8s.io/apiserver/pkg/storage/etcd3
 k8s.io/apiserver/pkg/storage/etcd3/metrics


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind feature

#### What this PR does / why we need it:
This PR adds metrics about how LIST requests were handled.
Some LIST requests take a lot more CPU per unit of execution duration than most requests, making concurrency limiters (the max-in-flight filter, the API Priority and Fairness (APF) filter) not very effective at managing the CPU usage of apiservers.
We are modifying the APF filter to recognize that some LIST requests are exceptionally costly, but:
1. we need data to tune this, and
2. we want to be able to get useful data from customers in the field.

The following typescript shows the impact on the size of a scrape (this added 4207 lines total, the typescript shows the breakdown too).

```
mspreitz@ubu20:~/go/src/k8s.io/kubernetes$ kubectl get --raw /metrics > /tmp/m.txt

mspreitz@ubu20:~/go/src/k8s.io/kubernetes$ wc /tmp/m.txt 
  16121   34156 2146206 /tmp/m.txt

mspreitz@ubu20:~/go/src/k8s.io/kubernetes$ grep -c apiserver_list_ /tmp/m.txt
4207

mspreitz@ubu20:~/go/src/k8s.io/kubernetes$ grep -c apiserver_list_cache_num_fetched /tmp/m.txt 
578

mspreitz@ubu20:~/go/src/k8s.io/kubernetes$ grep -c apiserver_list_cache_num_selector_evals /tmp/m.txt 
652

mspreitz@ubu20:~/go/src/k8s.io/kubernetes$ grep -c apiserver_list_cache_num_returned /tmp/m.txt 
566

mspreitz@ubu20:~/go/src/k8s.io/kubernetes$ grep -c apiserver_list_etcd3_queries /tmp/m.txt 
394

mspreitz@ubu20:~/go/src/k8s.io/kubernetes$ grep -c apiserver_list_etcd3_sans_version /tmp/m.txt 
198

mspreitz@ubu20:~/go/src/k8s.io/kubernetes$ grep -c apiserver_list_etcd3_num_fetched /tmp/m.txt 
590

mspreitz@ubu20:~/go/src/k8s.io/kubernetes$ grep -c apiserver_list_etcd3_num_selector_evals /tmp/m.txt 
639

mspreitz@ubu20:~/go/src/k8s.io/kubernetes$ grep -c apiserver_list_etcd3_num_returned /tmp/m.txt 
590
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Added the following metrics about the costs of serving LIST requests.

- `apiserver_list_etcd3_queries`, histogram of number of etcd queries involved in handling a LIST request; broken down by resource_prefix.
- `apiserver_list_etcd3_sans_version`, histogram of Number of etcd range queries without specified ResourceVersion used to satisfy a LIST request; broken down by resource_prefix.
- `apiserver_list_etcd3_num_fetched`, histogram of Number of objects read from etcd in the course of serving a LIST request; broken down by resource_prefix.
- `apiserver_list_etcd3_num_selector_evals`, histogram of Number of objects tested in the course of serving a LIST request from etcd; broken down by resource_prefix and predicate complexity (int 0--3 depending on label and field selectors).
- `apiserver_list_etcd3_num_returned`, histogram of Number of objects returned for a LIST request from etcd; broken down by resource_prefix.
- `apiserver_list_cache_num_fetched`, histogram of Number of objects read from watch cache in the course of serving a LIST request; broken down by path_prefix and index_used.
- `apiserver_list_cache_num_selector_evals`, histogram of Number of objects tested in the course of serving a LIST request from watch cache; broken down by path_prefix and predicate_complexity.
- `apiserver_list_cache_num_returned`, histogram of Number of objects returned for a LIST request from watch cache; broken down by path_prefix.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
