### PR TITLE
Update migratedplugin annotation on csinode to GA

### DIFF
--- a/pkg/apis/core/annotation_key_constants.go
+++ b/pkg/apis/core/annotation_key_constants.go
@@ -110,7 +110,8 @@ const (
 	// list of in-tree plugins that will be serviced by the CSI backend on the Node represented by CSINode.
 	// This annotation is used by the Attach Detach Controller to determine whether to use the in-tree or
 	// CSI Backend for a volume plugin on a specific node.
-	MigratedPluginsAnnotationKey = "storage.alpha.kubernetes.io/migrated-plugins"
+	MigratedPluginsAnnotationKey      = "storage.kubernetes.io/migrated-plugins"
+	MigratedAlphaPluginsAnnotationKey = "storage.alpha.kubernetes.io/migrated-plugins"
 
 	// PodDeletionCost can be used to set to an int32 that represent the cost of deleting
 	// a pod compared to other pods belonging to the same ReplicaSet. Pods with lower

--- a/pkg/controller/volume/attachdetach/util/util.go
+++ b/pkg/controller/volume/attachdetach/util/util.go
@@ -366,7 +366,10 @@ func isCSIMigrationSupportedOnNode(nodeName types.NodeName, spec *volume.Spec, v
 		return false, nil
 	}
 
-	mpa := ann[v1.MigratedPluginsAnnotationKey]
+	mpa, ok := ann[v1.MigratedPluginsAnnotationKey]
+	if !ok {
+		mpa = ann[v1.MigratedPluginsAlphaAnnotationKey]
+	}
 	tok := strings.Split(mpa, ",")
 	mpaSet := sets.NewString(tok...)
 

--- a/pkg/scheduler/framework/plugins/nodevolumelimits/utils.go
+++ b/pkg/scheduler/framework/plugins/nodevolumelimits/utils.go
@@ -19,7 +19,7 @@ package nodevolumelimits
 import (
 	"strings"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
@@ -71,7 +71,10 @@ func isCSIMigrationOn(csiNode *storagev1.CSINode, pluginName string) bool {
 	}
 
 	var mpaSet sets.String
-	mpa := csiNodeAnn[v1.MigratedPluginsAnnotationKey]
+	mpa, ok := csiNodeAnn[v1.MigratedPluginsAnnotationKey]
+	if !ok {
+		mpa = csiNodeAnn[v1.MigratedPluginsAlphaAnnotationKey]
+	}
 	if len(mpa) == 0 {
 		mpaSet = sets.NewString()
 	} else {

--- a/pkg/scheduler/framework/plugins/volumebinding/binder.go
+++ b/pkg/scheduler/framework/plugins/volumebinding/binder.go
@@ -1056,7 +1056,10 @@ func isPluginMigratedToCSIOnNode(pluginName string, csiNode *storagev1.CSINode) 
 	}
 
 	var mpaSet sets.String
-	mpa := csiNodeAnn[v1.MigratedPluginsAnnotationKey]
+	mpa, ok := csiNodeAnn[v1.MigratedPluginsAnnotationKey]
+	if !ok {
+		mpa = csiNodeAnn[v1.MigratedPluginsAlphaAnnotationKey]
+	}
 	if len(mpa) == 0 {
 		mpaSet = sets.NewString()
 	} else {

--- a/pkg/volume/csi/nodeinfomanager/nodeinfomanager.go
+++ b/pkg/volume/csi/nodeinfomanager/nodeinfomanager.go
@@ -480,7 +480,10 @@ func setMigrationAnnotation(migratedPlugins map[string](func() bool), nodeInfo *
 	}
 
 	var oldAnnotationSet sets.String
-	mpa := nodeInfoAnnotations[v1.MigratedPluginsAnnotationKey]
+	mpa, ok := nodeInfoAnnotations[v1.MigratedPluginsAnnotationKey]
+	if !ok {
+		mpa = nodeInfoAnnotations[v1.MigratedPluginsAlphaAnnotationKey]
+	}
 	tok := strings.Split(mpa, ",")
 	if len(mpa) == 0 {
 		oldAnnotationSet = sets.NewString()
@@ -503,7 +506,9 @@ func setMigrationAnnotation(migratedPlugins map[string](func() bool), nodeInfo *
 	if len(nas) != 0 {
 		nodeInfoAnnotations[v1.MigratedPluginsAnnotationKey] = nas
 	} else {
+		// delete both alpha and ga version annotation
 		delete(nodeInfoAnnotations, v1.MigratedPluginsAnnotationKey)
+		delete(nodeInfoAnnotations, v1.MigratedPluginsAlphaAnnotationKey)
 	}
 
 	nodeInfo.Annotations = nodeInfoAnnotations

--- a/staging/src/k8s.io/api/core/v1/annotation_key_constants.go
+++ b/staging/src/k8s.io/api/core/v1/annotation_key_constants.go
@@ -132,7 +132,8 @@ const (
 	// list of in-tree plugins that will be serviced by the CSI backend on the Node represented by CSINode.
 	// This annotation is used by the Attach Detach Controller to determine whether to use the in-tree or
 	// CSI Backend for a volume plugin on a specific node.
-	MigratedPluginsAnnotationKey = "storage.alpha.kubernetes.io/migrated-plugins"
+	MigratedPluginsAnnotationKey      = "storage.kubernetes.io/migrated-plugins"
+	MigratedPluginsAlphaAnnotationKey = "storage.alpha.kubernetes.io/migrated-plugins"
 
 	// PodDeletionCost can be used to set to an int32 that represent the cost of deleting
 	// a pod compared to other pods belonging to the same ReplicaSet. Pods with lower


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
Update `storage.alpha.kubernetes.io/migrated-plugins` to GA version.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
CSI Migration Annotation on CSINode `storage.alpha.kubernetes.io/migrated-plugins` is updated to GA version.
```

/sig storage
/cc @msau42 @jsafrane @gnufied 
/triage accepted
Issue: https://github.com/kubernetes/kubernetes/issues/102357