### PR TITLE
[Failing Test] Fix GPU Device Driver test in kubelet-serial

### DIFF
--- a/test/e2e_node/gpu_device_plugin_test.go
+++ b/test/e2e_node/gpu_device_plugin_test.go
@@ -107,7 +107,7 @@ var _ = SIGDescribe("NVIDIA GPU Device Plugin [Feature:GPUDevicePlugin][NodeFeat
 
 		ginkgo.It("checks that when Kubelet restarts exclusive GPU assignation to pods is kept.", func() {
 			ginkgo.By("Creating one GPU pod on a node with at least two GPUs")
-			podRECMD := "devs=$(ls /dev/ | egrep '^nvidia[0-9]+$') && echo gpu devices: $devs"
+			podRECMD := "devs=$(ls /dev/ | egrep '^nvidia[0-9]+$') && echo gpu devices: $devs && sleep 120"
 			p1 := f.PodClient().CreateSync(makeBusyboxPod(e2egpu.NVIDIAGPUResourceName, podRECMD))
 
 			deviceIDRE := "gpu devices: (nvidia[0-9]+)"

--- a/test/e2e_node/jenkins/gci-init-gpu.yaml
+++ b/test/e2e_node/jenkins/gci-init-gpu.yaml
@@ -2,7 +2,18 @@
 
 runcmd:
   - modprobe configs
-  - docker run -v /dev:/dev -v /home/kubernetes/bin/nvidia:/rootfs/nvidia -v /etc/os-release:/rootfs/etc/os-release -v /proc/sysrq-trigger:/sysrq -e BASE_DIR=/rootfs/nvidia --privileged k8s.gcr.io/cos-nvidia-driver-install@sha256:cb55c7971c337fece62f2bfe858662522a01e43ac9984a2dd1dd5c71487d225c
+  # Setup the installation target at make it executable
+  - mkdir -p /home/kubernetes/bin/nvidia
+  - mount --bind /home/kubernetes/bin/nvidia /home/kubernetes/bin/nvidia
+  - mount -o remount,exec /home/kubernetes/bin/nvidia
+  # Compile and install the nvidia driver (precompiled driver installation currently fails)
+  - docker run --net=host --pid=host -v /dev:/dev -v /:/root -v /home/kubernetes/bin/nvidia:/usr/local/nvidia -e NVIDIA_INSTALL_DIR_HOST=/home/kubernetes/bin/nvidia -e NVIDIA_INSTALL_DIR_CONTAINER=/usr/local/nvidia -e NVIDIA_DRIVER_VERSION=460.91.03 --privileged gcr.io/cos-cloud/cos-gpu-installer:latest
+  # Run the installer again, as on the first try it doesn't detect the libnvidia-ml.so
+  # on the second attempt we detect it and update the ld cache.
+  - docker run --net=host --pid=host -v /dev:/dev -v /:/root -v /home/kubernetes/bin/nvidia:/usr/local/nvidia -e NVIDIA_INSTALL_DIR_HOST=/home/kubernetes/bin/nvidia -e NVIDIA_INSTALL_DIR_CONTAINER=/usr/local/nvidia -e NVIDIA_DRIVER_VERSION=460.91.03 --privileged gcr.io/cos-cloud/cos-gpu-installer:latest
+  # Remove build containers. They're very large.
+  - docker rm -f $(docker ps -aq)
+  # Standard installation proceeds
   - mount /tmp /tmp -o remount,exec,suid
   - usermod -a -G docker jenkins
   - mkdir -p /var/lib/kubelet


### PR DESCRIPTION
#### What type of PR is this?

/kind failing-test
/kind cleanup

#### What this PR does / why we need it:

The GPU device plugin tests have been failing for an extended period of time. I've been unable to find a SHA in which they would pass naturally, or the last time they definitely succeeded.

##### Issue 1, GPU Drivers

Fixing this proved to be quite interesting, as there are a few issues at play. The first is that the GPU drivers no longer successfully install on the COS release that is currently used in test-infra for them. it failed to build the driver as the kernel sha was no longer available.

In the process I discovered that the image we used to build those hasn't been rebuilt since 2017, and the code hasn't been in k/k for about as long. [image source](https://github.com/kubernetes/kubernetes/blob/1e77594958e346e26e4d29fa0d018729fdce1d86/cluster/gce/gci/nvidia-gpus/Dockerfile).

After being unable to make that work on newer cos releases either, I moved on to finding an alternative installation mechanism. I settled on [GoogleCloudPlatform/cos-gpu-installer](https://github.com/GoogleCloudPlatform/cos-gpu-installer). This was chosen over the newer [googlesource/cos_gpu_installer](https://cos.googlesource.com/cos/tools/+/refs/heads/master/src/cmd/cos_gpu_installer/) mostly due to documentation. This can be updated later if any Googler's have a chance to update it.

The way this ends up working is a little bit weird, but is documented a little inline.

##### Issue 2, Installing the driver

The driver wasn't being installed by the PodClient, and due to the lack of scheduler in node_e2e, never managed to run. This fixes that by migrating it to use the PodClient, into the test namespace, and automatically assigns the node under test.

##### Issue 3, Behaviour has changed

In older versions of Kubernetes (at least pre-0.19, it's the earliest this test will run unmodified on), Pods that depended on devices could be restarted after the device plugin had been removed. Currently however, this isn't possible, as during ContainerManager.GetResources(), we attempt to DeviceManager.GetDeviceRunContainerOptions() which fails as there's no cached endpoint information for the plugin type.

This change therefore breaks apart the existing test into two:
- One active test that validates that assignments are maintained across restarts
- One skipped test that validates the behaviour after GPU plugins have been removed, in case we decide that this is a bug that should be fixed in the future.

#### Related Issue

https://github.com/kubernetes/kubernetes/issues/104175

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
