### PR TITLE
skip hack/tools/vendor folder

### DIFF
--- a/hack/make-rules/helpers/cache_go_dirs.sh
+++ b/hack/make-rules/helpers/cache_go_dirs.sh
@@ -39,14 +39,17 @@ function kfind() {
     # We want to include the "special" vendor directories which are actually
     # part of the Kubernetes source tree (./staging/*) but we need them to be
     # named as their ./vendor/* equivalents.  Also, we  do not want all of
-    # ./vendor or even all of ./vendor/k8s.io.
+    # ./vendor , ./hack/tools/vendor or even all of ./vendor/k8s.io.
     find -H .                      \
         \(                         \
         -not \(                    \
             \(                     \
                 -name '_*' -o      \
                 -name '.[^.]*' -o  \
-                -path './vendor'   \
+                \(                 \
+                  -name 'vendor'   \
+                  -type d          \
+                \)                 \
             \) -prune              \
         \)                         \
         \)                         \


### PR DESCRIPTION
The makefiles scripts create a variable with all the go files
that are part of the Kubernetes source tree, including staging.

As today, this variable has a size of < 100kb

wc .make/all_go_dirs.mk
2326  2326 98905 .make/all_go_dirs.mk

This variable is passed as argument in the Makefiles, where it
is expanded. In Linux, there is a limit to the max size of
the arguments MAX_ARG_STRLEN.

If the arguments go above 128k, (depends on the kernel, by default #define MAX_ARG_STRLEN (PAGE_SIZE * 32))
you get a nice:

execvp: /usr/bin/env: Argument list too long

If you, for whatever reason, do some go mod vendor inside the
hack/tools folder, these files will be added to the variable
and most probably you'll go above the limit and get that error.

Then, you'll learn a lot about Makefils, shell expansion, strace,
execpve, ARG_MAX and MAX_ARG_STRLEN,until you realize what is
the real problem :).

/kind cleanup
```release-note
NONE
```


### How to reproduce it

```
$ cd hack/tools/
$ go mod vendor
$ git status
nothing to commit, working tree clean
$ cd -
$ make
make[1]: execvp: /usr/bin/env: Argument list too long
$ grep hack/tools/vendor .make/all_go_dirs.mk  | wc
    575     575   32739
```

### Special notes

I know that nobody should vendor anything in that hack/tools/ folder, and I did it only to experiment with some things, but the fact that `make clean` don't delete the folder and `git status` doesn't report nothing made me spend more than 3 hours with this :upside_down_face: 
