### PR TITLE
OWNERS(releng): Set reviewers to `release-managers`

### DIFF
--- a/CHANGELOG/OWNERS
+++ b/CHANGELOG/OWNERS
@@ -2,7 +2,7 @@
 
 approvers:
   - release-engineering-approvers
-  - release-engineering-reviewers
+  - release-managers
   - pmmalinov01 # 1.22 Release Notes Lead
   - wilsonehusin # 1.21 Release Notes Lead
 reviewers:

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -111,13 +111,12 @@ aliases:
     - justaugustus # SIG Chair / RelEng subproject owner / Release Manager
     - puerco # SIG Technical Lead / RelEng subproject owner / Release Manager
     - saschagrunert # SIG Chair / RelEng subproject owner / Release Manager
-  release-engineering-reviewers:
-    - cpanato # SIG Technical Lead / RelEng subproject owner / Release Manager
-    - jeremyrickard # SIG Technical Lead / RelEng subproject owner
-    - justaugustus # SIG Chair / RelEng subproject owner / Release Manager
-    - puerco # SIG Technical Lead / RelEng subproject owner / Release Manager
-    - saschagrunert # SIG Chair / RelEng subproject owner / Release Manager
-    - xmudrii # Release Manager
+  release-managers:
+    - cpanato
+    - justaugustus
+    - puerco
+    - saschagrunert
+    - xmudrii
   build-image-approvers:
     - BenTheElder
     - cblecker

--- a/staging/src/k8s.io/component-base/version/OWNERS
+++ b/staging/src/k8s.io/component-base/version/OWNERS
@@ -10,7 +10,7 @@ approvers:
 - release-engineering-approvers
 reviewers:
 - sig-api-machinery-api-reviewers
-- release-engineering-reviewers
+- release-managers
 
 labels:
 - sig/api-machinery


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

From @liggitt's review in https://github.com/kubernetes/kubernetes/pull/104586#discussion_r696591323 and https://github.com/kubernetes/kubernetes/pull/104586#discussion_r696594239:

> maybe aliases like this would be clearer?

```
approvers:
  - release-engineering-approvers
  - release-managers
  - ...
reviewers:
  - release-engineering-reviewers
  - ...
```

> I suspect that might make the membership of the aliases easier to reason about as well... when the release managers change, the release-managers alias gets updated, etc

Opting to drop `release-engineering-reviewers`, since the group was already the set of @kubernetes/release-managers, modulo @jeremyrickard.

(Jeremy remains in `release-engineering-approvers`.)

Signed-off-by: Stephen Augustus <foo@auggie.dev>

/assign @liggitt 
cc: @kubernetes/sig-release-admins @kubernetes/release-engineering 

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
