### PR TITLE
fix termination log causes nodes to run out of inodes on filesystem

### DIFF
--- a/pkg/kubelet/kuberuntime/kuberuntime_manager_test.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_manager_test.go
@@ -17,6 +17,8 @@ limitations under the License.
 package kuberuntime
 
 import (
+	"fmt"
+	"math/rand"
 	"path/filepath"
 	"reflect"
 	"sort"
@@ -43,6 +45,7 @@ import (
 	podutil "k8s.io/kubernetes/pkg/api/v1/pod"
 	"k8s.io/kubernetes/pkg/credentialprovider"
 	"k8s.io/kubernetes/pkg/features"
+	"k8s.io/kubernetes/pkg/kubelet/config"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
 	containertest "k8s.io/kubernetes/pkg/kubelet/container/testing"
 	proberesults "k8s.io/kubernetes/pkg/kubelet/prober/results"
@@ -172,6 +175,16 @@ func makeFakeContainer(t *testing.T, m *kubeGenericRuntimeManager, template cont
 	podSandboxID := apitest.BuildSandboxName(sandboxConfig.Metadata)
 	containerID := apitest.BuildContainerName(containerConfig.Metadata, podSandboxID)
 	imageRef := containerConfig.Image.Image
+
+	const defaultRootDir = "/var/lib/kubelet"
+	// termination log path
+	hostPath := filepath.Join(defaultRootDir,
+		config.DefaultKubeletPodsDirName,
+		string(template.pod.GetUID()),
+		config.DefaultKubeletContainersDirName,
+		template.container.Name,
+		fmt.Sprintf("%08x", rand.Uint32()))
+
 	return &apitest.FakeContainer{
 		ContainerStatus: runtimeapi.ContainerStatus{
 			Id:          containerID,
@@ -182,7 +195,11 @@ func makeFakeContainer(t *testing.T, m *kubeGenericRuntimeManager, template cont
 			State:       template.state,
 			Labels:      containerConfig.Labels,
 			Annotations: containerConfig.Annotations,
-			LogPath:     filepath.Join(sandboxConfig.GetLogDirectory(), containerConfig.GetLogPath()),
+			Mounts: []*runtimeapi.Mount{{
+				HostPath:      hostPath,
+				ContainerPath: v1.TerminationMessagePathDefault,
+			}},
+			LogPath: filepath.Join(sandboxConfig.GetLogDirectory(), containerConfig.GetLogPath()),
 		},
 		SandboxID: podSandboxID,
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
/sig node
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
For each start of the pod, kubelet will mount a termination log to the container with path `/dev/termination-log`.
On k8s clusters where many pods are stuck in `CrashLoopBackOff` state, kubelet will create millions of these files, which can lead to nodes running out of inodes on a filesystem where /var/lib/kubelet is located.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #104592

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### My thoughts
1. When kubelet removes evictable containers, it will remove container logs ([code here](https://github.com/kubernetes/kubernetes/blob/587132131071a0342e81d6b023d65ca7191162a5/pkg/kubelet/kuberuntime/kuberuntime_container.go#L946)), but omitting the termination log.
2. Is the previous termination log useful for pod failure analysis?
   - The termination log is for message log right before the container exits. Its size is limited to 4096 bytes. The drop of containers also includes the  removal of the log files, which I think are more helpful for troubleshooting.
   - The last termination log message has been stored in the `lastState` of `status.containerStatuses`. We can send request to api-server and ask `lastState`'s message for further analysis.
   - After the removal of the container, the bound termination log is out of kubernetes's scope. Since the container it bound to has already been removed. It is left alone in the `/var/lib/kubelet/pods/<pod-uid>/containers/<container-name>` before the pod gets dropped, as well as the folder `/var/lib/kubelet/pods/<pod-uid>`.
