### PR TITLE
Update ServiceInternalTrafficPolicy feature state

### DIFF
--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -668,6 +668,7 @@ const (
 	// owner: @maplain @andrewsykim
 	// kep: http://kep.k8s.io/2086
 	// alpha: v1.21
+	// beta: v1.22
 	//
 	// Enables node-local routing for Service internal traffic
 	ServiceInternalTrafficPolicy featuregate.Feature = "ServiceInternalTrafficPolicy"


### PR DESCRIPTION
Feature state is beta in v1.22.0 [1]

Signed-off-by: Martin Kennelly <mkennell@redhat.com>

/kind documentation

[1] https://github.com/kubernetes/kubernetes/pull/103462