### PR TITLE
Add GroupResourceString to storagebackend.Config and factor

### DIFF
--- a/cmd/kube-apiserver/app/options/options_test.go
+++ b/cmd/kube-apiserver/app/options/options_test.go
@@ -150,7 +150,7 @@ func TestAddFlags(t *testing.T) {
 			},
 		},
 		Etcd: &apiserveroptions.EtcdOptions{
-			StorageConfig: storagebackend.Config{
+			StorageConfig: storagebackend.FactoryConfig{
 				Type: "etcd3",
 				Transport: storagebackend.TransportConfig{
 					ServerList:    nil,

--- a/cmd/kube-apiserver/app/testing/testserver.go
+++ b/cmd/kube-apiserver/app/testing/testserver.go
@@ -99,7 +99,7 @@ func NewDefaultTestServerOptions() *TestServerInstanceOptions {
 // Note: we return a tear-down func instead of a stop channel because the later will leak temporary
 // 		 files that because Golang testing's call to os.Exit will not give a stop channel go routine
 // 		 enough time to remove temporary files.
-func StartTestServer(t Logger, instanceOptions *TestServerInstanceOptions, customFlags []string, storageConfig *storagebackend.Config) (result TestServer, err error) {
+func StartTestServer(t Logger, instanceOptions *TestServerInstanceOptions, customFlags []string, storageConfig *storagebackend.FactoryConfig) (result TestServer, err error) {
 	if instanceOptions == nil {
 		instanceOptions = NewDefaultTestServerOptions()
 	}
@@ -323,7 +323,7 @@ func StartTestServer(t Logger, instanceOptions *TestServerInstanceOptions, custo
 }
 
 // StartTestServerOrDie calls StartTestServer t.Fatal if it does not succeed.
-func StartTestServerOrDie(t Logger, instanceOptions *TestServerInstanceOptions, flags []string, storageConfig *storagebackend.Config) *TestServer {
+func StartTestServerOrDie(t Logger, instanceOptions *TestServerInstanceOptions, flags []string, storageConfig *storagebackend.FactoryConfig) *TestServer {
 	result, err := StartTestServer(t, instanceOptions, flags, storageConfig)
 	if err == nil {
 		return &result

--- a/pkg/kubeapiserver/default_storage_factory_builder.go
+++ b/pkg/kubeapiserver/default_storage_factory_builder.go
@@ -73,7 +73,7 @@ func NewStorageFactoryConfig() *StorageFactoryConfig {
 
 // StorageFactoryConfig is a configuration for creating storage factory.
 type StorageFactoryConfig struct {
-	StorageConfig                    storagebackend.Config
+	StorageConfig                    storagebackend.FactoryConfig
 	APIResourceConfig                *serverstorage.ResourceConfig
 	DefaultResourceEncoding          *serverstorage.DefaultResourceEncodingConfig
 	DefaultStorageMediaType          string

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/customresource_handler.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/customresource_handler.go
@@ -1135,7 +1135,7 @@ func (d unstructuredDefaulter) Default(in runtime.Object) {
 }
 
 type CRDRESTOptionsGetter struct {
-	StorageConfig             storagebackend.Config
+	StorageConfig             storagebackend.FactoryConfig
 	StoragePrefix             string
 	EnableWatchCache          bool
 	DefaultWatchCacheSize     int
@@ -1147,7 +1147,7 @@ type CRDRESTOptionsGetter struct {
 
 func (t CRDRESTOptionsGetter) GetRESTOptions(resource schema.GroupResource) (generic.RESTOptions, error) {
 	ret := generic.RESTOptions{
-		StorageConfig:             &t.StorageConfig,
+		StorageConfig:             t.StorageConfig.ForGroupResource(resource),
 		Decorator:                 generic.UndecoratedStorage,
 		EnableGarbageCollection:   t.EnableGarbageCollection,
 		DeleteCollectionWorkers:   t.DeleteCollectionWorkers,

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/cmd/server/testing/testserver.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/cmd/server/testing/testserver.go
@@ -126,7 +126,7 @@ func StartTestServer(t Logger, instanceOptions *TestServerInstanceOptions, custo
 	s.RecommendedOptions.SecureServing.ServerCert.FixtureDirectory = filepath.Join(pkgPath, "testdata")
 
 	if storageConfig != nil {
-		s.RecommendedOptions.Etcd.StorageConfig = *storageConfig
+		s.RecommendedOptions.Etcd.StorageConfig = storageConfig.FactoryConfig
 	}
 	s.APIEnablement.RuntimeConfig.Set("api/all=true")
 

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/registry/customresource/etcd_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/registry/customresource/etcd_test.go
@@ -49,9 +49,10 @@ import (
 )
 
 func newStorage(t *testing.T) (customresource.CustomResourceStorage, *etcd3testing.EtcdTestServer) {
+	groupResource := schema.GroupResource{Group: "mygroup.example.com", Resource: "noxus"}
 	server, etcdStorage := etcd3testing.NewUnsecuredEtcd3TestClientServer(t)
 	etcdStorage.Codec = unstructured.UnstructuredJSONScheme
-	restOptions := generic.RESTOptions{StorageConfig: etcdStorage, Decorator: generic.UndecoratedStorage, DeleteCollectionWorkers: 1, ResourcePrefix: "noxus"}
+	restOptions := generic.RESTOptions{StorageConfig: etcdStorage.ForGroupResource(groupResource), Decorator: generic.UndecoratedStorage, DeleteCollectionWorkers: 1, ResourcePrefix: "noxus"}
 
 	parameterScheme := runtime.NewScheme()
 	parameterScheme.AddUnversionedTypes(schema.GroupVersion{Group: "mygroup.example.com", Version: "v1beta1"},
@@ -91,7 +92,7 @@ func newStorage(t *testing.T) (customresource.CustomResourceStorage, *etcd3testi
 	table, _ := tableconvertor.New(headers)
 
 	storage := customresource.NewStorage(
-		schema.GroupResource{Group: "mygroup.example.com", Resource: "noxus"},
+		groupResource,
 		kind,
 		schema.GroupVersionKind{Group: "mygroup.example.com", Version: "v1beta1", Kind: "NoxuItemList"},
 		customresource.NewStrategy(

--- a/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/dryrun_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/dryrun_test.go
@@ -38,7 +38,7 @@ import (
 func NewDryRunnableTestStorage(t *testing.T) (DryRunnableStorage, func()) {
 	server, sc := etcd3testing.NewUnsecuredEtcd3TestClientServer(t)
 	sc.Codec = apitesting.TestStorageCodec(codecs, examplev1.SchemeGroupVersion)
-	s, destroy, err := factory.Create(*sc, nil)
+	s, destroy, err := factory.Create(*sc.ForGroupResource(examplev1.Resource("widgets")), nil)
 	if err != nil {
 		t.Fatalf("Error creating storage: %v", err)
 	}

--- a/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/store_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/store_test.go
@@ -2230,7 +2230,7 @@ func newTestGenericStoreRegistry(t *testing.T, scheme *runtime.Scheme, hasCacheE
 	newListFunc := func() runtime.Object { return &example.PodList{} }
 
 	sc.Codec = apitesting.TestStorageCodec(codecs, examplev1.SchemeGroupVersion)
-	s, dFunc, err := factory.Create(*sc, newFunc)
+	s, dFunc, err := factory.Create(*sc.ForGroupResource(schema.GroupResource{Group: "", Resource: "pods"}), newFunc)
 	if err != nil {
 		t.Fatalf("Error creating storage: %v", err)
 	}

--- a/staging/src/k8s.io/apiserver/pkg/server/options/etcd.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/etcd.go
@@ -42,7 +42,7 @@ import (
 type EtcdOptions struct {
 	// The value of Paging on StorageConfig will be overridden by the
 	// calculated feature gate value.
-	StorageConfig                    storagebackend.Config
+	StorageConfig                    storagebackend.FactoryConfig
 	EncryptionProviderConfigFilepath string
 
 	EtcdServersOverrides []string
@@ -65,7 +65,7 @@ var storageTypes = sets.NewString(
 	storagebackend.StorageTypeETCD3,
 )
 
-func NewEtcdOptions(backendConfig *storagebackend.Config) *EtcdOptions {
+func NewEtcdOptions(backendConfig *storagebackend.FactoryConfig) *EtcdOptions {
 	options := &EtcdOptions{
 		StorageConfig:           *backendConfig,
 		DefaultStorageMediaType: "application/json",
@@ -255,7 +255,7 @@ type SimpleRestOptionsFactory struct {
 
 func (f *SimpleRestOptionsFactory) GetRESTOptions(resource schema.GroupResource) (generic.RESTOptions, error) {
 	ret := generic.RESTOptions{
-		StorageConfig:             &f.Options.StorageConfig,
+		StorageConfig:             f.Options.StorageConfig.ForGroupResource(resource),
 		Decorator:                 generic.UndecoratedStorage,
 		EnableGarbageCollection:   f.Options.EnableGarbageCollection,
 		DeleteCollectionWorkers:   f.Options.DeleteCollectionWorkers,

--- a/staging/src/k8s.io/apiserver/pkg/server/options/etcd_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/etcd_test.go
@@ -36,7 +36,7 @@ func TestEtcdOptionsValidate(t *testing.T) {
 		{
 			name: "test when ServerList is not specified",
 			testOptions: &EtcdOptions{
-				StorageConfig: storagebackend.Config{
+				StorageConfig: storagebackend.FactoryConfig{
 					Type:   "etcd3",
 					Prefix: "/registry",
 					Transport: storagebackend.TransportConfig{
@@ -60,7 +60,7 @@ func TestEtcdOptionsValidate(t *testing.T) {
 		{
 			name: "test when storage-backend is invalid",
 			testOptions: &EtcdOptions{
-				StorageConfig: storagebackend.Config{
+				StorageConfig: storagebackend.FactoryConfig{
 					Type:   "etcd4",
 					Prefix: "/registry",
 					Transport: storagebackend.TransportConfig{
@@ -84,7 +84,7 @@ func TestEtcdOptionsValidate(t *testing.T) {
 		{
 			name: "test when etcd-servers-overrides is invalid",
 			testOptions: &EtcdOptions{
-				StorageConfig: storagebackend.Config{
+				StorageConfig: storagebackend.FactoryConfig{
 					Type: "etcd3",
 					Transport: storagebackend.TransportConfig{
 						ServerList:    []string{"http://127.0.0.1"},
@@ -108,7 +108,7 @@ func TestEtcdOptionsValidate(t *testing.T) {
 		{
 			name: "test when EtcdOptions is valid",
 			testOptions: &EtcdOptions{
-				StorageConfig: storagebackend.Config{
+				StorageConfig: storagebackend.FactoryConfig{
 					Type:   "etcd3",
 					Prefix: "/registry",
 					Transport: storagebackend.TransportConfig{

--- a/staging/src/k8s.io/apiserver/pkg/server/storage/storage_factory.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/storage/storage_factory.go
@@ -65,7 +65,7 @@ type StorageFactory interface {
 type DefaultStorageFactory struct {
 	// StorageConfig describes how to create a storage backend in general.
 	// Its authentication information will be used for every storage.Interface returned.
-	StorageConfig storagebackend.Config
+	StorageConfig storagebackend.FactoryConfig
 
 	Overrides map[schema.GroupResource]groupResourceOverrides
 
@@ -152,7 +152,7 @@ var _ StorageFactory = &DefaultStorageFactory{}
 const AllResources = "*"
 
 func NewDefaultStorageFactory(
-	config storagebackend.Config,
+	config storagebackend.FactoryConfig,
 	defaultMediaType string,
 	defaultSerializer runtime.StorageSerializer,
 	resourceEncodingConfig ResourceEncodingConfig,
@@ -254,7 +254,7 @@ func (s *DefaultStorageFactory) NewConfig(groupResource schema.GroupResource) (*
 	chosenStorageResource := s.getStorageGroupResource(groupResource)
 
 	// operate on copy
-	storageConfig := s.StorageConfig
+	storageConfig := storagebackend.Config{FactoryConfig: s.StorageConfig, GroupResourceString: groupResource.String()}
 	codecConfig := StorageCodecConfig{
 		StorageMediaType:  s.DefaultMediaType,
 		StorageSerializer: s.DefaultSerializer,

--- a/staging/src/k8s.io/apiserver/pkg/server/storage/storage_factory_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/storage/storage_factory_test.go
@@ -107,7 +107,7 @@ func (n *fakeNegotiater) DecoderToVersion(serializer runtime.Decoder, gv runtime
 
 func TestConfigurableStorageFactory(t *testing.T) {
 	ns := &fakeNegotiater{types: []string{"test/test"}}
-	f := NewDefaultStorageFactory(storagebackend.Config{}, "test/test", ns, NewDefaultResourceEncodingConfig(scheme), NewResourceConfig(), nil)
+	f := NewDefaultStorageFactory(storagebackend.FactoryConfig{}, "test/test", ns, NewDefaultResourceEncodingConfig(scheme), NewResourceConfig(), nil)
 	f.AddCohabitatingResources(example.Resource("test"), schema.GroupResource{Resource: "test2", Group: "2"})
 	called := false
 	testEncoderChain := func(e runtime.Encoder) runtime.Encoder {
@@ -153,7 +153,7 @@ func TestUpdateEtcdOverrides(t *testing.T) {
 
 	defaultEtcdLocation := []string{"http://127.0.0.1"}
 	for i, test := range testCases {
-		defaultConfig := storagebackend.Config{
+		defaultConfig := storagebackend.FactoryConfig{
 			Prefix: "/registry",
 			Transport: storagebackend.TransportConfig{
 				ServerList: defaultEtcdLocation,

--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/testing/test_server.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/testing/test_server.go
@@ -35,10 +35,10 @@ func (e *EtcdTestServer) Terminate(t *testing.T) {
 }
 
 // NewUnsecuredEtcd3TestClientServer creates a new client and server for testing
-func NewUnsecuredEtcd3TestClientServer(t *testing.T) (*EtcdTestServer, *storagebackend.Config) {
+func NewUnsecuredEtcd3TestClientServer(t *testing.T) (*EtcdTestServer, *storagebackend.FactoryConfig) {
 	server := &EtcdTestServer{}
 	server.V3Client = testserver.RunEtcd(t, nil)
-	config := &storagebackend.Config{
+	config := &storagebackend.FactoryConfig{
 		Type:   "etcd3",
 		Prefix: PathPrefix(),
 		Transport: storagebackend.TransportConfig{

--- a/staging/src/k8s.io/apiserver/pkg/storage/storagebackend/factory/etcd3.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/storagebackend/factory/etcd3.go
@@ -72,7 +72,7 @@ func init() {
 	dbMetricsMonitors = make(map[string]struct{})
 }
 
-func newETCD3HealthCheck(c storagebackend.Config) (func() error, error) {
+func newETCD3HealthCheck(c storagebackend.FactoryConfig) (func() error, error) {
 	// constructing the etcd v3 client blocks and times out if etcd is not available.
 	// retry in a loop in the background until we successfully create the client, storing the client or error encountered
 

--- a/staging/src/k8s.io/apiserver/pkg/storage/storagebackend/factory/factory.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/storagebackend/factory/factory.go
@@ -40,7 +40,7 @@ func Create(c storagebackend.Config, newFunc func() runtime.Object) (storage.Int
 }
 
 // CreateHealthCheck creates a healthcheck function based on given config.
-func CreateHealthCheck(c storagebackend.Config) (func() error, error) {
+func CreateHealthCheck(c storagebackend.FactoryConfig) (func() error, error) {
 	switch c.Type {
 	case storagebackend.StorageTypeETCD2:
 		return nil, fmt.Errorf("%s is no longer a supported storage backend", c.Type)

--- a/staging/src/k8s.io/apiserver/pkg/storage/storagebackend/factory/tls_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/storagebackend/factory/tls_test.go
@@ -29,6 +29,7 @@ import (
 	apitesting "k8s.io/apimachinery/pkg/api/apitesting"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apiserver/pkg/apis/example"
@@ -68,7 +69,7 @@ func TestTLSConnection(t *testing.T) {
 	}
 
 	client := testserver.RunEtcd(t, etcdConfig)
-	cfg := storagebackend.Config{
+	cfg := storagebackend.FactoryConfig{
 		Type: storagebackend.StorageTypeETCD3,
 		Transport: storagebackend.TransportConfig{
 			ServerList:    client.Endpoints(),
@@ -77,8 +78,8 @@ func TestTLSConnection(t *testing.T) {
 			TrustedCAFile: caFile,
 		},
 		Codec: codec,
-	}
-	storage, destroyFunc, err := newETCD3Storage(cfg, nil)
+	}.ForGroupResource(schema.GroupResource{Group: "", Resource: "abc"})
+	storage, destroyFunc, err := newETCD3Storage(*cfg, nil)
 	defer destroyFunc()
 	if err != nil {
 		t.Fatal(err)

--- a/test/e2e_node/services/apiserver.go
+++ b/test/e2e_node/services/apiserver.go
@@ -42,12 +42,12 @@ AwEHoUQDQgAEH6cuzP8XuD5wal6wf9M6xDljTOPLX2i8uIp/C/ASqiIGUeeKQtX0
 
 // APIServer is a server which manages apiserver.
 type APIServer struct {
-	storageConfig storagebackend.Config
+	storageConfig storagebackend.FactoryConfig
 	stopCh        chan struct{}
 }
 
 // NewAPIServer creates an apiserver.
-func NewAPIServer(storageConfig storagebackend.Config) *APIServer {
+func NewAPIServer(storageConfig storagebackend.FactoryConfig) *APIServer {
 	return &APIServer{
 		storageConfig: storageConfig,
 		stopCh:        make(chan struct{}),

--- a/test/e2e_node/services/internal_services.go
+++ b/test/e2e_node/services/internal_services.go
@@ -32,7 +32,7 @@ type e2eServices struct {
 	rmDirs []string
 	// statically linked e2e services
 	etcdServer   *etcd3testing.EtcdTestServer
-	etcdStorage  *storagebackend.Config
+	etcdStorage  *storagebackend.FactoryConfig
 	apiServer    *APIServer
 	nsController *NamespaceController
 }
@@ -117,7 +117,7 @@ func (es *e2eServices) startEtcd(t *testing.T) error {
 }
 
 // startAPIServer starts the embedded API server or returns an error.
-func (es *e2eServices) startAPIServer(etcdStorage *storagebackend.Config) error {
+func (es *e2eServices) startAPIServer(etcdStorage *storagebackend.FactoryConfig) error {
 	klog.Info("Starting API server")
 	es.apiServer = NewAPIServer(*etcdStorage)
 	return es.apiServer.Start()

--- a/test/integration/controlplane/transformation_testcase.go
+++ b/test/integration/controlplane/transformation_testcase.go
@@ -57,7 +57,7 @@ type unSealSecret func(cipherText []byte, ctx value.Context, config apiservercon
 
 type transformTest struct {
 	logger            kubeapiservertesting.Logger
-	storageConfig     *storagebackend.Config
+	storageConfig     *storagebackend.FactoryConfig
 	configDir         string
 	transformerConfig string
 	kubeAPIServer     kubeapiservertesting.TestServer

--- a/test/integration/framework/controlplane_utils.go
+++ b/test/integration/framework/controlplane_utils.go
@@ -360,7 +360,7 @@ func RunAnAPIServerUsingServer(controlPlaneConfig *controlplane.Config, s *httpt
 }
 
 // SharedEtcd creates a storage config for a shared etcd instance, with a unique prefix.
-func SharedEtcd() *storagebackend.Config {
+func SharedEtcd() *storagebackend.FactoryConfig {
 	cfg := storagebackend.NewDefaultConfig(path.Join(uuid.New().String(), "registry"), nil)
 	cfg.Transport.ServerList = []string{GetEtcdURL()}
 	return cfg


### PR DESCRIPTION
Pull the non-resource-specific parts into new type FactoryConfig.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind feature

#### What this PR does / why we need it:
This PR adds a field to `storagebackend.Config` to hold the string representation of the `schema.GroupResource` that the Config is being used for.  That will facilitate future metrics enhancements.  See https://github.com/kubernetes/kubernetes/pull/104587#discussion_r697423238

But, some uses of Config are not resource-specific.  So this PR also collects the resource-independent parts to a new struct `storagebackend.FactoryConfig` and replaces the non-resource-specific uses of Config with uses of FactoryConfig.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:
This ended up requiring changes to a _lot_ of files.  I think I will try making another PR with an alternative approach, introducing a new struct for the resource-specific type rather than for the resource-independent type.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
