### PR TITLE
Fix typo `a` to `an` in the whole project

### DIFF
--- a/CHANGELOG/CHANGELOG-1.18.md
+++ b/CHANGELOG/CHANGELOG-1.18.md
@@ -2422,7 +2422,7 @@ No Known Issues Reported
 
 - Fixed a regression with clients prior to 1.15 not being able to update podIP in pod status, or podCIDR in node spec, against >= 1.16 API servers ([#88505](https://github.com/kubernetes/kubernetes/pull/88505), [@liggitt](https://github.com/liggitt)) [SIG Apps and Network]
 - Fixed "kubectl describe statefulsets.apps" printing garbage for rolling update partition ([#85846](https://github.com/kubernetes/kubernetes/pull/85846), [@phil9909](https://github.com/phil9909)) [SIG CLI]
-- Add a event to PV when filesystem on PV does not match actual filesystem on disk ([#86982](https://github.com/kubernetes/kubernetes/pull/86982), [@gnufied](https://github.com/gnufied)) [SIG Storage]
+- Add an event to PV when filesystem on PV does not match actual filesystem on disk ([#86982](https://github.com/kubernetes/kubernetes/pull/86982), [@gnufied](https://github.com/gnufied)) [SIG Storage]
 - Add azure disk WriteAccelerator support ([#87945](https://github.com/kubernetes/kubernetes/pull/87945), [@andyzhangx](https://github.com/andyzhangx)) [SIG Cloud Provider and Storage]
 - Add delays between goroutines for vm instance update ([#88094](https://github.com/kubernetes/kubernetes/pull/88094), [@aramase](https://github.com/aramase)) [SIG Cloud Provider]
 - Add init containers log to cluster dump info. ([#88324](https://github.com/kubernetes/kubernetes/pull/88324), [@zhouya0](https://github.com/zhouya0)) [SIG CLI]

--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -15080,7 +15080,7 @@
       ]
     },
     "io.k8s.apimachinery.pkg.apis.meta.v1.FieldsV1": {
-      "description": "FieldsV1 stores a set of fields in a data structure like a Trie, in JSON format.\n\nEach key is either a '.' representing the field itself, and will always map to an empty set, or a string representing a sub-field or item. The string will follow one of these four formats: 'f:<name>', where <name> is the name of a field in a struct, or key in a map 'v:<value>', where <value> is the exact json formatted value of a list item 'i:<index>', where <index> is position of a item in a list 'k:<keys>', where <keys> is a map of  a list item's key fields to their unique values If a key maps to an empty Fields value, the field that key represents is part of the set.\n\nThe exact format is defined in sigs.k8s.io/structured-merge-diff",
+      "description": "FieldsV1 stores a set of fields in a data structure like a Trie, in JSON format.\n\nEach key is either a '.' representing the field itself, and will always map to an empty set, or a string representing a sub-field or item. The string will follow one of these four formats: 'f:<name>', where <name> is the name of a field in a struct, or key in a map 'v:<value>', where <value> is the exact json formatted value of a list item 'i:<index>', where <index> is position of an item in a list 'k:<keys>', where <keys> is a map of  a list item's key fields to their unique values If a key maps to an empty Fields value, the field that key represents is part of the set.\n\nThe exact format is defined in sigs.k8s.io/structured-merge-diff",
       "type": "object"
     },
     "io.k8s.apimachinery.pkg.apis.meta.v1.GroupVersionForDiscovery": {

--- a/hack/lib/test.sh
+++ b/hack/lib/test.sh
@@ -44,7 +44,7 @@ kube::test::get_caller() {
   echo "$(basename "${caller_file}"):${caller_line}"
 }
 
-# Force exact match of a returned result for a object query.  Wrap this with || to support multiple
+# Force exact match of a returned result for an object query.  Wrap this with || to support multiple
 # valid return types.
 # This runs `kubectl get` once and asserts that the result is as expected.
 # $1: Object on which get should be run

--- a/pkg/controller/endpoint/endpoints_controller_test.go
+++ b/pkg/controller/endpoint/endpoints_controller_test.go
@@ -162,7 +162,7 @@ func makeTestServer(t *testing.T, namespace string) (*httptest.Server, *utiltest
 }
 
 // makeBlockingEndpointDeleteTestServer will signal the blockNextAction channel on endpoint "POST" & "DELETE" requests. All
-// block endpoint "DELETE" requestsi will wait on a blockDelete signal to delete endpoint. If controller is nil, a error will
+// block endpoint "DELETE" requestsi will wait on a blockDelete signal to delete endpoint. If controller is nil, an error will
 // be sent in the response.
 func makeBlockingEndpointDeleteTestServer(t *testing.T, controller *endpointController, endpoint *v1.Endpoints, blockDelete, blockNextAction chan struct{}, namespace string) *httptest.Server {
 

--- a/pkg/controller/nodeipam/ipam/controller_legacyprovider.go
+++ b/pkg/controller/nodeipam/ipam/controller_legacyprovider.go
@@ -43,7 +43,7 @@ import (
 type Config struct {
 	// Resync is the default timeout duration when there are no errors.
 	Resync time.Duration
-	// MaxBackoff is the maximum timeout when in a error backoff state.
+	// MaxBackoff is the maximum timeout when in an error backoff state.
 	MaxBackoff time.Duration
 	// InitialRetry is the initial retry interval when an error is reported.
 	InitialRetry time.Duration

--- a/pkg/controller/nodeipam/ipam/timeout.go
+++ b/pkg/controller/nodeipam/ipam/timeout.go
@@ -27,7 +27,7 @@ import (
 type Timeout struct {
 	// Resync is the default timeout duration when there are no errors.
 	Resync time.Duration
-	// MaxBackoff is the maximum timeout when in a error backoff state.
+	// MaxBackoff is the maximum timeout when in an error backoff state.
 	MaxBackoff time.Duration
 	// InitialRetry is the initial retry interval when an error is reported.
 	InitialRetry time.Duration

--- a/pkg/controller/util/node/controller_utils.go
+++ b/pkg/controller/util/node/controller_utils.go
@@ -29,7 +29,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	clientset "k8s.io/client-go/kubernetes"
 	appsv1listers "k8s.io/client-go/listers/apps/v1"
 	utilpod "k8s.io/kubernetes/pkg/api/v1/pod"
@@ -160,7 +160,7 @@ func MarkPodsNotReady(kubeClient clientset.Interface, recorder record.EventRecor
 	return fmt.Errorf("%v", strings.Join(errMsg, "; "))
 }
 
-// RecordNodeEvent records a event related to a node.
+// RecordNodeEvent records an event related to a node.
 func RecordNodeEvent(recorder record.EventRecorder, nodeName, nodeUID, eventtype, reason, event string) {
 	ref := &v1.ObjectReference{
 		APIVersion: "v1",
@@ -173,7 +173,7 @@ func RecordNodeEvent(recorder record.EventRecorder, nodeName, nodeUID, eventtype
 	recorder.Eventf(ref, eventtype, reason, "Node %s event: %s", nodeName, event)
 }
 
-// RecordNodeStatusChange records a event related to a node status change. (Common to lifecycle and ipam)
+// RecordNodeStatusChange records an event related to a node status change. (Common to lifecycle and ipam)
 func RecordNodeStatusChange(recorder record.EventRecorder, node *v1.Node, newStatus string) {
 	ref := &v1.ObjectReference{
 		APIVersion: "v1",

--- a/pkg/kubelet/dockershim/exec_test.go
+++ b/pkg/kubelet/dockershim/exec_test.go
@@ -123,7 +123,7 @@ func TestExecInContainer(t *testing.T) {
 		execProbeTimeout:   true,
 		expectError:        context.DeadlineExceeded,
 	}, {
-		description:        "[ExecProbeTimeout=false] StartExec that takes longer than the probe timeout returns a error",
+		description:        "[ExecProbeTimeout=false] StartExec that takes longer than the probe timeout returns an error",
 		timeout:            1 * time.Second,
 		returnCreateExec1:  &dockertypes.IDResponse{ID: "12345678"},
 		returnCreateExec2:  nil,

--- a/pkg/kubelet/util/manager/manager.go
+++ b/pkg/kubelet/util/manager/manager.go
@@ -17,7 +17,7 @@ limitations under the License.
 package manager
 
 import (
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -43,7 +43,7 @@ type Manager interface {
 	UnregisterPod(pod *v1.Pod)
 }
 
-// Store is the interface for a object cache that
+// Store is the interface for an object cache that
 // can be used by cacheBasedManager.
 type Store interface {
 	// AddReference adds a reference to the object to the store.

--- a/pkg/volume/util/hostutil/hostutil_linux_test.go
+++ b/pkg/volume/util/hostutil/hostutil_linux_test.go
@@ -284,7 +284,7 @@ func TestGetFileType(t *testing.T) {
 
 	for idx, tc := range testCase {
 		path, cleanUpPath, err := tc.setUp()
-		defer os.RemoveAll(cleanUpPath) // RemoveAll can deal with a empty path ""
+		defer os.RemoveAll(cleanUpPath) // RemoveAll can deal with an empty path ""
 		if err != nil {
 			// Locally passed, but upstream CI is not friendly to create such device files
 			// Leave "Operation not permitted" out, which can be covered in an e2e test

--- a/plugin/pkg/auth/authenticator/token/bootstrap/bootstrap.go
+++ b/plugin/pkg/auth/authenticator/token/bootstrap/bootstrap.go
@@ -53,7 +53,7 @@ type TokenAuthenticator struct {
 	lister corev1listers.SecretNamespaceLister
 }
 
-// tokenErrorf prints a error message for a secret that has matched a bearer
+// tokenErrorf prints an error message for a secret that has matched a bearer
 // token but fails to meet some other criteria.
 //
 //    tokenErrorf(secret, "has invalid value for key %s", key)

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/generated/openapi/zz_generated.openapi.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/generated/openapi/zz_generated.openapi.go
@@ -1629,7 +1629,7 @@ func schema_pkg_apis_meta_v1_FieldsV1(ref common.ReferenceCallback) common.OpenA
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Description: "FieldsV1 stores a set of fields in a data structure like a Trie, in JSON format.\n\nEach key is either a '.' representing the field itself, and will always map to an empty set, or a string representing a sub-field or item. The string will follow one of these four formats: 'f:<name>', where <name> is the name of a field in a struct, or key in a map 'v:<value>', where <value> is the exact json formatted value of a list item 'i:<index>', where <index> is position of a item in a list 'k:<keys>', where <keys> is a map of  a list item's key fields to their unique values If a key maps to an empty Fields value, the field that key represents is part of the set.\n\nThe exact format is defined in sigs.k8s.io/structured-merge-diff",
+				Description: "FieldsV1 stores a set of fields in a data structure like a Trie, in JSON format.\n\nEach key is either a '.' representing the field itself, and will always map to an empty set, or a string representing a sub-field or item. The string will follow one of these four formats: 'f:<name>', where <name> is the name of a field in a struct, or key in a map 'v:<value>', where <value> is the exact json formatted value of a list item 'i:<index>', where <index> is position of an item in a list 'k:<keys>', where <keys> is a map of  a list item's key fields to their unique values If a key maps to an empty Fields value, the field that key represents is part of the set.\n\nThe exact format is defined in sigs.k8s.io/structured-merge-diff",
 				Type:        []string{"object"},
 			},
 		},

--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/storage/objectreader.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/storage/objectreader.go
@@ -46,7 +46,7 @@ func NewEtcdObjectReader(etcdClient *clientv3.Client, restOptions *generic.RESTO
 
 // WaitForStorageVersion calls the updateObjFn periodically and waits for the version of the custom resource stored in etcd to be set to the provided version.
 // Typically updateObjFn should perform a noop update to the object so that when stored version of a CRD changes, the object is written at the updated storage version.
-// If the timeout is exceeded a error is returned.
+// If the timeout is exceeded an error is returned.
 // This is useful when updating the stored version of an existing CRD because the update does not take effect immediately.
 func (s *EtcdObjectReader) WaitForStorageVersion(version string, ns, name string, timeout time.Duration, updateObjFn func()) error {
 	waitCh := time.After(timeout)

--- a/staging/src/k8s.io/apimachinery/pkg/api/validation/generic.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/validation/generic.go
@@ -23,7 +23,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation/field"
 )
 
-// IsNegativeErrorMsg is a error message for value must be greater than or equal to 0.
+// IsNegativeErrorMsg is an error message for value must be greater than or equal to 0.
 const IsNegativeErrorMsg string = `must be greater than or equal to 0`
 
 // ValidateNameFunc validates that the provided name is valid for a given resource type.

--- a/staging/src/k8s.io/apimachinery/pkg/api/validation/objectmeta.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/validation/objectmeta.go
@@ -30,7 +30,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation/field"
 )
 
-// FieldImmutableErrorMsg is a error message for field is immutable.
+// FieldImmutableErrorMsg is an error message for field is immutable.
 const FieldImmutableErrorMsg string = `field is immutable`
 
 const TotalAnnotationSizeLimitB int = 256 * (1 << 10) // 256 kB

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/generated.proto
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/generated.proto
@@ -299,7 +299,7 @@ message Duration {
 // or a string representing a sub-field or item. The string will follow one of these four formats:
 // 'f:<name>', where <name> is the name of a field in a struct, or key in a map
 // 'v:<value>', where <value> is the exact json formatted value of a list item
-// 'i:<index>', where <index> is position of a item in a list
+// 'i:<index>', where <index> is position of an item in a list
 // 'k:<keys>', where <keys> is a map of  a list item's key fields to their unique values
 // If a key maps to an empty Fields value, the field that key represents is part of the set.
 //

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/types.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/types.go
@@ -1204,7 +1204,7 @@ const (
 // or a string representing a sub-field or item. The string will follow one of these four formats:
 // 'f:<name>', where <name> is the name of a field in a struct, or key in a map
 // 'v:<value>', where <value> is the exact json formatted value of a list item
-// 'i:<index>', where <index> is position of a item in a list
+// 'i:<index>', where <index> is position of an item in a list
 // 'k:<keys>', where <keys> is a map of  a list item's key fields to their unique values
 // If a key maps to an empty Fields value, the field that key represents is part of the set.
 //

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/types_swagger_doc_generated.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/types_swagger_doc_generated.go
@@ -135,7 +135,7 @@ func (DeleteOptions) SwaggerDoc() map[string]string {
 }
 
 var map_FieldsV1 = map[string]string{
-	"": "FieldsV1 stores a set of fields in a data structure like a Trie, in JSON format.\n\nEach key is either a '.' representing the field itself, and will always map to an empty set, or a string representing a sub-field or item. The string will follow one of these four formats: 'f:<name>', where <name> is the name of a field in a struct, or key in a map 'v:<value>', where <value> is the exact json formatted value of a list item 'i:<index>', where <index> is position of a item in a list 'k:<keys>', where <keys> is a map of  a list item's key fields to their unique values If a key maps to an empty Fields value, the field that key represents is part of the set.\n\nThe exact format is defined in sigs.k8s.io/structured-merge-diff",
+	"": "FieldsV1 stores a set of fields in a data structure like a Trie, in JSON format.\n\nEach key is either a '.' representing the field itself, and will always map to an empty set, or a string representing a sub-field or item. The string will follow one of these four formats: 'f:<name>', where <name> is the name of a field in a struct, or key in a map 'v:<value>', where <value> is the exact json formatted value of a list item 'i:<index>', where <index> is position of an item in a list 'k:<keys>', where <keys> is a map of  a list item's key fields to their unique values If a key maps to an empty Fields value, the field that key represents is part of the set.\n\nThe exact format is defined in sigs.k8s.io/structured-merge-diff",
 }
 
 func (FieldsV1) SwaggerDoc() map[string]string {

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/validation/validation.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/validation/validation.go
@@ -132,7 +132,7 @@ var FieldManagerMaxLength = 128
 // only has printable characters.
 func ValidateFieldManager(fieldManager string, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
-	// the field can not be set as a `*string`, so a empty string ("") is
+	// the field can not be set as a `*string`, so an empty string ("") is
 	// considered as not set and is defaulted by the rest of the process
 	// (unless apply is used, in which case it is required).
 	if len(fieldManager) > FieldManagerMaxLength {

--- a/staging/src/k8s.io/apimachinery/pkg/util/strategicpatch/patch.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/strategicpatch/patch.go
@@ -419,7 +419,7 @@ func normalizeElementOrder(patch, serverOnly, patchOrder, serverOrder []interfac
 // It will insert each item in `left` list to `right` list. In most cases, the 2 lists will be interleaved.
 // The relative order of left and right are guaranteed to be kept.
 // They have higher precedence than the order in the live list.
-// The place for a item in `left` is found by:
+// The place for an item in `left` is found by:
 // scan from the place of last insertion in `right` to the end of `right`,
 // the place is before the first item that is greater than the item we want to insert.
 // example usage: using server-only items as left and patch items as right. We insert server-only items

--- a/staging/src/k8s.io/apimachinery/pkg/util/validation/field/errors.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/validation/field/errors.go
@@ -125,7 +125,7 @@ const (
 	ErrorTypeInternal ErrorType = "InternalError"
 )
 
-// String converts a ErrorType into its corresponding canonical error message.
+// String converts an ErrorType into its corresponding canonical error message.
 func (t ErrorType) String() string {
 	switch t {
 	case ErrorTypeNotFound:
@@ -227,7 +227,7 @@ func InternalError(field *Path, err error) *Error {
 type ErrorList []*Error
 
 // NewErrorTypeMatcher returns an errors.Matcher that returns true
-// if the provided error is a Error and has the provided ErrorType.
+// if the provided error is an Error and has the provided ErrorType.
 func NewErrorTypeMatcher(t ErrorType) utilerrors.Matcher {
 	return func(err error) bool {
 		if e, ok := err.(*Error); ok {

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/testdata/swagger.json
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/testdata/swagger.json
@@ -3945,7 +3945,7 @@
       "type": "string"
     },
     "io.k8s.apimachinery.pkg.apis.meta.v1.FieldsV1": {
-      "description": "FieldsV1 stores a set of fields in a data structure like a Trie, in JSON format.\n\nEach key is either a '.' representing the field itself, and will always map to an empty set, or a string representing a sub-field or item. The string will follow one of these four formats: 'f:<name>', where <name> is the name of a field in a struct, or key in a map 'v:<value>', where <value> is the exact json formatted value of a list item 'i:<index>', where <index> is position of a item in a list 'k:<keys>', where <keys> is a map of  a list item's key fields to their unique values If a key maps to an empty Fields value, the field that key represents is part of the set.\n\nThe exact format is defined in sigs.k8s.io/structured-merge-diff",
+      "description": "FieldsV1 stores a set of fields in a data structure like a Trie, in JSON format.\n\nEach key is either a '.' representing the field itself, and will always map to an empty set, or a string representing a sub-field or item. The string will follow one of these four formats: 'f:<name>', where <name> is the name of a field in a struct, or key in a map 'v:<value>', where <value> is the exact json formatted value of a list item 'i:<index>', where <index> is position of an item in a list 'k:<keys>', where <keys> is a map of  a list item's key fields to their unique values If a key maps to an empty Fields value, the field that key represents is part of the set.\n\nThe exact format is defined in sigs.k8s.io/structured-merge-diff",
       "type": "object"
     },
     "io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector": {

--- a/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/store_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/store_test.go
@@ -1242,7 +1242,7 @@ func TestStoreDelete(t *testing.T) {
 		t.Errorf("Expected call to AfterDelete, but got none")
 	}
 
-	// try to get a item which should be deleted
+	// try to get an item which should be deleted
 	_, err = registry.Get(testContext, podA.Name, &metav1.GetOptions{})
 	if !errors.IsNotFound(err) {
 		t.Errorf("Unexpected error: %v", err)
@@ -1274,7 +1274,7 @@ func TestStoreGracefulDeleteWithResourceVersion(t *testing.T) {
 		t.Errorf("Unexpected error: %v", err)
 	}
 
-	// try to get a item which should be deleted
+	// try to get an item which should be deleted
 	obj, err := registry.Get(testContext, podA.Name, &metav1.GetOptions{})
 	if errors.IsNotFound(err) {
 		t.Errorf("Unexpected error: %v", err)
@@ -1299,7 +1299,7 @@ func TestStoreGracefulDeleteWithResourceVersion(t *testing.T) {
 		t.Errorf("unexpected, pod %s should have been deleted immediately", podA.Name)
 	}
 
-	// try to get a item which should be deleted
+	// try to get an item which should be deleted
 	_, err = registry.Get(testContext, podA.Name, &metav1.GetOptions{})
 	if !errors.IsNotFound(err) {
 		t.Errorf("Unexpected error: %v", err)

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher.go
@@ -85,7 +85,7 @@ type Config struct {
 	// operation if no indexer found.
 	Indexers *cache.Indexers
 
-	// NewFunc is a function that creates new empty object storing a object of type Type.
+	// NewFunc is a function that creates new empty object storing an object of type Type.
 	NewFunc func() runtime.Object
 
 	// NewList is a function that creates new empty object storing a list of
@@ -254,7 +254,7 @@ type Cacher struct {
 	// Versioner is used to handle resource versions.
 	versioner storage.Versioner
 
-	// newFunc is a function that creates new empty object storing a object of type Type.
+	// newFunc is a function that creates new empty object storing an object of type Type.
 	newFunc func() runtime.Object
 
 	// indexedTrigger is used for optimizing amount of watchers that needs to process

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher_whitebox_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher_whitebox_test.go
@@ -547,7 +547,7 @@ func TestCacheWatcherStoppedInAnotherGoroutine(t *testing.T) {
 		select {
 		case <-w.ResultChan():
 		case <-time.After(time.Second):
-			t.Fatal("expected received a event on ResultChan")
+			t.Fatal("expected received an event on ResultChan")
 		}
 		w.Stop()
 	}

--- a/staging/src/k8s.io/client-go/informers/core/v1/interface.go
+++ b/staging/src/k8s.io/client-go/informers/core/v1/interface.go
@@ -30,7 +30,7 @@ type Interface interface {
 	ConfigMaps() ConfigMapInformer
 	// Endpoints returns a EndpointsInformer.
 	Endpoints() EndpointsInformer
-	// Events returns a EventInformer.
+	// Events returns an EventInformer.
 	Events() EventInformer
 	// LimitRanges returns a LimitRangeInformer.
 	LimitRanges() LimitRangeInformer
@@ -84,7 +84,7 @@ func (v *version) Endpoints() EndpointsInformer {
 	return &endpointsInformer{factory: v.factory, namespace: v.namespace, tweakListOptions: v.tweakListOptions}
 }
 
-// Events returns a EventInformer.
+// Events returns an EventInformer.
 func (v *version) Events() EventInformer {
 	return &eventInformer{factory: v.factory, namespace: v.namespace, tweakListOptions: v.tweakListOptions}
 }

--- a/staging/src/k8s.io/client-go/informers/events/v1/interface.go
+++ b/staging/src/k8s.io/client-go/informers/events/v1/interface.go
@@ -24,7 +24,7 @@ import (
 
 // Interface provides access to all the informers in this group version.
 type Interface interface {
-	// Events returns a EventInformer.
+	// Events returns an EventInformer.
 	Events() EventInformer
 }
 
@@ -39,7 +39,7 @@ func New(f internalinterfaces.SharedInformerFactory, namespace string, tweakList
 	return &version{factory: f, namespace: namespace, tweakListOptions: tweakListOptions}
 }
 
-// Events returns a EventInformer.
+// Events returns an EventInformer.
 func (v *version) Events() EventInformer {
 	return &eventInformer{factory: v.factory, namespace: v.namespace, tweakListOptions: v.tweakListOptions}
 }

--- a/staging/src/k8s.io/client-go/informers/events/v1beta1/interface.go
+++ b/staging/src/k8s.io/client-go/informers/events/v1beta1/interface.go
@@ -24,7 +24,7 @@ import (
 
 // Interface provides access to all the informers in this group version.
 type Interface interface {
-	// Events returns a EventInformer.
+	// Events returns an EventInformer.
 	Events() EventInformer
 }
 
@@ -39,7 +39,7 @@ func New(f internalinterfaces.SharedInformerFactory, namespace string, tweakList
 	return &version{factory: f, namespace: namespace, tweakListOptions: tweakListOptions}
 }
 
-// Events returns a EventInformer.
+// Events returns an EventInformer.
 func (v *version) Events() EventInformer {
 	return &eventInformer{factory: v.factory, namespace: v.namespace, tweakListOptions: v.tweakListOptions}
 }

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/event.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/event.go
@@ -33,7 +33,7 @@ import (
 	rest "k8s.io/client-go/rest"
 )
 
-// EventsGetter has a method to return a EventInterface.
+// EventsGetter has a method to return an EventInterface.
 // A group's client should implement this interface.
 type EventsGetter interface {
 	Events(namespace string) EventInterface
@@ -59,7 +59,7 @@ type events struct {
 	ns     string
 }
 
-// newEvents returns a Events
+// newEvents returns an events
 func newEvents(c *CoreV1Client, namespace string) *events {
 	return &events{
 		client: c.RESTClient(),
@@ -112,7 +112,7 @@ func (c *events) Watch(ctx context.Context, opts metav1.ListOptions) (watch.Inte
 		Watch(ctx)
 }
 
-// Create takes the representation of a event and creates it.  Returns the server's representation of the event, and an error, if there is any.
+// Create takes the representation of an event and creates it.  Returns the server's representation of the event, and an error, if there is any.
 func (c *events) Create(ctx context.Context, event *v1.Event, opts metav1.CreateOptions) (result *v1.Event, err error) {
 	result = &v1.Event{}
 	err = c.client.Post().
@@ -125,7 +125,7 @@ func (c *events) Create(ctx context.Context, event *v1.Event, opts metav1.Create
 	return
 }
 
-// Update takes the representation of a event and updates it. Returns the server's representation of the event, and an error, if there is any.
+// Update takes the representation of an event and updates it. Returns the server's representation of the event, and an error, if there is any.
 func (c *events) Update(ctx context.Context, event *v1.Event, opts metav1.UpdateOptions) (result *v1.Event, err error) {
 	result = &v1.Event{}
 	err = c.client.Put().

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/fake/fake_event.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/fake/fake_event.go
@@ -83,7 +83,7 @@ func (c *FakeEvents) Watch(ctx context.Context, opts v1.ListOptions) (watch.Inte
 
 }
 
-// Create takes the representation of a event and creates it.  Returns the server's representation of the event, and an error, if there is any.
+// Create takes the representation of an event and creates it.  Returns the server's representation of the event, and an error, if there is any.
 func (c *FakeEvents) Create(ctx context.Context, event *corev1.Event, opts v1.CreateOptions) (result *corev1.Event, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewCreateAction(eventsResource, c.ns, event), &corev1.Event{})
@@ -94,7 +94,7 @@ func (c *FakeEvents) Create(ctx context.Context, event *corev1.Event, opts v1.Cr
 	return obj.(*corev1.Event), err
 }
 
-// Update takes the representation of a event and updates it. Returns the server's representation of the event, and an error, if there is any.
+// Update takes the representation of an event and updates it. Returns the server's representation of the event, and an error, if there is any.
 func (c *FakeEvents) Update(ctx context.Context, event *corev1.Event, opts v1.UpdateOptions) (result *corev1.Event, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewUpdateAction(eventsResource, c.ns, event), &corev1.Event{})

--- a/staging/src/k8s.io/client-go/kubernetes/typed/events/v1/event.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/events/v1/event.go
@@ -33,7 +33,7 @@ import (
 	rest "k8s.io/client-go/rest"
 )
 
-// EventsGetter has a method to return a EventInterface.
+// EventsGetter has a method to return an EventInterface.
 // A group's client should implement this interface.
 type EventsGetter interface {
 	Events(namespace string) EventInterface
@@ -59,7 +59,7 @@ type events struct {
 	ns     string
 }
 
-// newEvents returns a Events
+// newEvents returns an events
 func newEvents(c *EventsV1Client, namespace string) *events {
 	return &events{
 		client: c.RESTClient(),
@@ -112,7 +112,7 @@ func (c *events) Watch(ctx context.Context, opts metav1.ListOptions) (watch.Inte
 		Watch(ctx)
 }
 
-// Create takes the representation of a event and creates it.  Returns the server's representation of the event, and an error, if there is any.
+// Create takes the representation of an event and creates it.  Returns the server's representation of the event, and an error, if there is any.
 func (c *events) Create(ctx context.Context, event *v1.Event, opts metav1.CreateOptions) (result *v1.Event, err error) {
 	result = &v1.Event{}
 	err = c.client.Post().
@@ -125,7 +125,7 @@ func (c *events) Create(ctx context.Context, event *v1.Event, opts metav1.Create
 	return
 }
 
-// Update takes the representation of a event and updates it. Returns the server's representation of the event, and an error, if there is any.
+// Update takes the representation of an event and updates it. Returns the server's representation of the event, and an error, if there is any.
 func (c *events) Update(ctx context.Context, event *v1.Event, opts metav1.UpdateOptions) (result *v1.Event, err error) {
 	result = &v1.Event{}
 	err = c.client.Put().

--- a/staging/src/k8s.io/client-go/kubernetes/typed/events/v1/fake/fake_event.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/events/v1/fake/fake_event.go
@@ -83,7 +83,7 @@ func (c *FakeEvents) Watch(ctx context.Context, opts v1.ListOptions) (watch.Inte
 
 }
 
-// Create takes the representation of a event and creates it.  Returns the server's representation of the event, and an error, if there is any.
+// Create takes the representation of an event and creates it.  Returns the server's representation of the event, and an error, if there is any.
 func (c *FakeEvents) Create(ctx context.Context, event *eventsv1.Event, opts v1.CreateOptions) (result *eventsv1.Event, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewCreateAction(eventsResource, c.ns, event), &eventsv1.Event{})
@@ -94,7 +94,7 @@ func (c *FakeEvents) Create(ctx context.Context, event *eventsv1.Event, opts v1.
 	return obj.(*eventsv1.Event), err
 }
 
-// Update takes the representation of a event and updates it. Returns the server's representation of the event, and an error, if there is any.
+// Update takes the representation of an event and updates it. Returns the server's representation of the event, and an error, if there is any.
 func (c *FakeEvents) Update(ctx context.Context, event *eventsv1.Event, opts v1.UpdateOptions) (result *eventsv1.Event, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewUpdateAction(eventsResource, c.ns, event), &eventsv1.Event{})

--- a/staging/src/k8s.io/client-go/kubernetes/typed/events/v1beta1/event.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/events/v1beta1/event.go
@@ -33,7 +33,7 @@ import (
 	rest "k8s.io/client-go/rest"
 )
 
-// EventsGetter has a method to return a EventInterface.
+// EventsGetter has a method to return an EventInterface.
 // A group's client should implement this interface.
 type EventsGetter interface {
 	Events(namespace string) EventInterface
@@ -59,7 +59,7 @@ type events struct {
 	ns     string
 }
 
-// newEvents returns a Events
+// newEvents returns an events
 func newEvents(c *EventsV1beta1Client, namespace string) *events {
 	return &events{
 		client: c.RESTClient(),
@@ -112,7 +112,7 @@ func (c *events) Watch(ctx context.Context, opts v1.ListOptions) (watch.Interfac
 		Watch(ctx)
 }
 
-// Create takes the representation of a event and creates it.  Returns the server's representation of the event, and an error, if there is any.
+// Create takes the representation of an event and creates it.  Returns the server's representation of the event, and an error, if there is any.
 func (c *events) Create(ctx context.Context, event *v1beta1.Event, opts v1.CreateOptions) (result *v1beta1.Event, err error) {
 	result = &v1beta1.Event{}
 	err = c.client.Post().
@@ -125,7 +125,7 @@ func (c *events) Create(ctx context.Context, event *v1beta1.Event, opts v1.Creat
 	return
 }
 
-// Update takes the representation of a event and updates it. Returns the server's representation of the event, and an error, if there is any.
+// Update takes the representation of an event and updates it. Returns the server's representation of the event, and an error, if there is any.
 func (c *events) Update(ctx context.Context, event *v1beta1.Event, opts v1.UpdateOptions) (result *v1beta1.Event, err error) {
 	result = &v1beta1.Event{}
 	err = c.client.Put().

--- a/staging/src/k8s.io/client-go/kubernetes/typed/events/v1beta1/fake/fake_event.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/events/v1beta1/fake/fake_event.go
@@ -83,7 +83,7 @@ func (c *FakeEvents) Watch(ctx context.Context, opts v1.ListOptions) (watch.Inte
 
 }
 
-// Create takes the representation of a event and creates it.  Returns the server's representation of the event, and an error, if there is any.
+// Create takes the representation of an event and creates it.  Returns the server's representation of the event, and an error, if there is any.
 func (c *FakeEvents) Create(ctx context.Context, event *v1beta1.Event, opts v1.CreateOptions) (result *v1beta1.Event, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewCreateAction(eventsResource, c.ns, event), &v1beta1.Event{})
@@ -94,7 +94,7 @@ func (c *FakeEvents) Create(ctx context.Context, event *v1beta1.Event, opts v1.C
 	return obj.(*v1beta1.Event), err
 }
 
-// Update takes the representation of a event and updates it. Returns the server's representation of the event, and an error, if there is any.
+// Update takes the representation of an event and updates it. Returns the server's representation of the event, and an error, if there is any.
 func (c *FakeEvents) Update(ctx context.Context, event *v1beta1.Event, opts v1.UpdateOptions) (result *v1beta1.Event, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewUpdateAction(eventsResource, c.ns, event), &v1beta1.Event{})

--- a/staging/src/k8s.io/client-go/tools/cache/controller_test.go
+++ b/staging/src/k8s.io/client-go/tools/cache/controller_test.go
@@ -23,7 +23,7 @@ import (
 	"testing"
 	"time"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -31,7 +31,7 @@ import (
 	"k8s.io/apimachinery/pkg/watch"
 	fcache "k8s.io/client-go/tools/cache/testing"
 
-	"github.com/google/gofuzz"
+	fuzz "github.com/google/gofuzz"
 )
 
 func Example() {
@@ -436,7 +436,7 @@ func TestPanicPropagated(t *testing.T) {
 		}()
 		controller.Run(stop)
 	}()
-	// Let's add a object to the source. It will trigger a panic.
+	// Let's add an object to the source. It will trigger a panic.
 	source.Add(&v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "test"}})
 
 	// Check if the panic propagated up.

--- a/staging/src/k8s.io/client-go/tools/cache/index.go
+++ b/staging/src/k8s.io/client-go/tools/cache/index.go
@@ -94,7 +94,7 @@ func MetaNamespaceIndexFunc(obj interface{}) ([]string, error) {
 // Index maps the indexed value to a set of keys in the store that match on that value
 type Index map[string]sets.String
 
-// Indexers maps a name to a IndexFunc
+// Indexers maps a name to an IndexFunc
 type Indexers map[string]IndexFunc
 
 // Indices maps a name to an Index

--- a/staging/src/k8s.io/client-go/tools/events/event_broadcaster.go
+++ b/staging/src/k8s.io/client-go/tools/events/event_broadcaster.go
@@ -78,7 +78,7 @@ type EventSinkImpl struct {
 	Interface typedeventsv1.EventsV1Interface
 }
 
-// Create takes the representation of a event and creates it. Returns the server's representation of the event, and an error, if there is any.
+// Create takes the representation of an event and creates it. Returns the server's representation of the event, and an error, if there is any.
 func (e *EventSinkImpl) Create(event *eventsv1.Event) (*eventsv1.Event, error) {
 	if event.Namespace == "" {
 		return nil, fmt.Errorf("can't create an event with empty namespace")
@@ -86,7 +86,7 @@ func (e *EventSinkImpl) Create(event *eventsv1.Event) (*eventsv1.Event, error) {
 	return e.Interface.Events(event.Namespace).Create(context.TODO(), event, metav1.CreateOptions{})
 }
 
-// Update takes the representation of a event and updates it. Returns the server's representation of the event, and an error, if there is any.
+// Update takes the representation of an event and updates it. Returns the server's representation of the event, and an error, if there is any.
 func (e *EventSinkImpl) Update(event *eventsv1.Event) (*eventsv1.Event, error) {
 	if event.Namespace == "" {
 		return nil, fmt.Errorf("can't update an event with empty namespace")

--- a/staging/src/k8s.io/client-go/util/jsonpath/jsonpath_test.go
+++ b/staging/src/k8s.io/client-go/util/jsonpath/jsonpath_test.go
@@ -720,7 +720,7 @@ func TestNegativeIndex(t *testing.T) {
 				false,
 			},
 			{
-				"test containers[-5], expect a error cause it out of bounds",
+				"test containers[-5], expect an error cause it out of bounds",
 				`{.spec.containers[-5].name}`,
 				data,
 				"",
@@ -741,14 +741,14 @@ func TestNegativeIndex(t *testing.T) {
 				false,
 			},
 			{
-				"test containers[3:1], expect a error cause start index is greater than end index",
+				"test containers[3:1], expect an error cause start index is greater than end index",
 				`{.spec.containers[3:1].name}`,
 				data,
 				"",
 				true,
 			},
 			{
-				"test containers[-1:-2], it equals containers[3:2], expect a error cause start index is greater than end index",
+				"test containers[-1:-2], it equals containers[3:2], expect an error cause start index is greater than end index",
 				`{.spec.containers[-1:-2].name}`,
 				data,
 				"",

--- a/staging/src/k8s.io/cloud-provider/controllers/service/controller.go
+++ b/staging/src/k8s.io/cloud-provider/controllers/service/controller.go
@@ -441,7 +441,7 @@ func (s *Controller) ensureLoadBalancer(service *v1.Service) (*v1.LoadBalancerSt
 		return nil, err
 	}
 
-	// If there are no available nodes for LoadBalancer service, make a EventTypeWarning event for it.
+	// If there are no available nodes for LoadBalancer service, make an EventTypeWarning event for it.
 	if len(nodes) == 0 {
 		s.eventRecorder.Event(service, v1.EventTypeWarning, "UnAvailableLoadBalancer", "There are no available nodes for LoadBalancer")
 	}
@@ -794,7 +794,7 @@ func (s *Controller) lockedUpdateLoadBalancerHosts(service *v1.Service, hosts []
 	// This operation doesn't normally take very long (and happens pretty often), so we only record the final event
 	err := s.balancer.UpdateLoadBalancer(context.TODO(), s.clusterName, service, hosts)
 	if err == nil {
-		// If there are no available nodes for LoadBalancer service, make a EventTypeWarning event for it.
+		// If there are no available nodes for LoadBalancer service, make an EventTypeWarning event for it.
 		if len(hosts) == 0 {
 			s.eventRecorder.Event(service, v1.EventTypeWarning, "UnAvailableLoadBalancer", "There are no available nodes for LoadBalancer")
 		} else {

--- a/staging/src/k8s.io/code-generator/cmd/client-gen/generators/fake/generator_fake_for_type.go
+++ b/staging/src/k8s.io/code-generator/cmd/client-gen/generators/fake/generator_fake_for_type.go
@@ -75,7 +75,7 @@ func genStatus(t *types.Type) bool {
 	return hasStatus && !tags.NoStatus
 }
 
-// hasObjectMeta returns true if the type has a ObjectMeta field.
+// hasObjectMeta returns true if the type has an ObjectMeta field.
 func hasObjectMeta(t *types.Type) bool {
 	for _, m := range t.Members {
 		if m.Embedded == true && m.Name == "ObjectMeta" {

--- a/staging/src/k8s.io/code-generator/examples/apiserver/openapi/zz_generated.openapi.go
+++ b/staging/src/k8s.io/code-generator/examples/apiserver/openapi/zz_generated.openapi.go
@@ -692,7 +692,7 @@ func schema_pkg_apis_meta_v1_FieldsV1(ref common.ReferenceCallback) common.OpenA
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Description: "FieldsV1 stores a set of fields in a data structure like a Trie, in JSON format.\n\nEach key is either a '.' representing the field itself, and will always map to an empty set, or a string representing a sub-field or item. The string will follow one of these four formats: 'f:<name>', where <name> is the name of a field in a struct, or key in a map 'v:<value>', where <value> is the exact json formatted value of a list item 'i:<index>', where <index> is position of a item in a list 'k:<keys>', where <keys> is a map of  a list item's key fields to their unique values If a key maps to an empty Fields value, the field that key represents is part of the set.\n\nThe exact format is defined in sigs.k8s.io/structured-merge-diff",
+				Description: "FieldsV1 stores a set of fields in a data structure like a Trie, in JSON format.\n\nEach key is either a '.' representing the field itself, and will always map to an empty set, or a string representing a sub-field or item. The string will follow one of these four formats: 'f:<name>', where <name> is the name of a field in a struct, or key in a map 'v:<value>', where <value> is the exact json formatted value of a list item 'i:<index>', where <index> is position of an item in a list 'k:<keys>', where <keys> is a map of  a list item's key fields to their unique values If a key maps to an empty Fields value, the field that key represents is part of the set.\n\nThe exact format is defined in sigs.k8s.io/structured-merge-diff",
 				Type:        []string{"object"},
 			},
 		},

--- a/staging/src/k8s.io/kube-aggregator/pkg/generated/openapi/zz_generated.openapi.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/generated/openapi/zz_generated.openapi.go
@@ -695,7 +695,7 @@ func schema_pkg_apis_meta_v1_FieldsV1(ref common.ReferenceCallback) common.OpenA
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Description: "FieldsV1 stores a set of fields in a data structure like a Trie, in JSON format.\n\nEach key is either a '.' representing the field itself, and will always map to an empty set, or a string representing a sub-field or item. The string will follow one of these four formats: 'f:<name>', where <name> is the name of a field in a struct, or key in a map 'v:<value>', where <value> is the exact json formatted value of a list item 'i:<index>', where <index> is position of a item in a list 'k:<keys>', where <keys> is a map of  a list item's key fields to their unique values If a key maps to an empty Fields value, the field that key represents is part of the set.\n\nThe exact format is defined in sigs.k8s.io/structured-merge-diff",
+				Description: "FieldsV1 stores a set of fields in a data structure like a Trie, in JSON format.\n\nEach key is either a '.' representing the field itself, and will always map to an empty set, or a string representing a sub-field or item. The string will follow one of these four formats: 'f:<name>', where <name> is the name of a field in a struct, or key in a map 'v:<value>', where <value> is the exact json formatted value of a list item 'i:<index>', where <index> is position of an item in a list 'k:<keys>', where <keys> is a map of  a list item's key fields to their unique values If a key maps to an empty Fields value, the field that key represents is part of the set.\n\nThe exact format is defined in sigs.k8s.io/structured-merge-diff",
 				Type:        []string{"object"},
 			},
 		},

--- a/staging/src/k8s.io/kubectl/pkg/util/util.go
+++ b/staging/src/k8s.io/kubectl/pkg/util/util.go
@@ -41,7 +41,7 @@ func ParseRFC3339(s string, nowFn func() metav1.Time) (metav1.Time, error) {
 	return metav1.Time{Time: t}, nil
 }
 
-// HashObject returns the hash of a Object hash by a Codec
+// HashObject returns the hash of an Object hash by a Codec
 func HashObject(obj runtime.Object, codec runtime.Codec) (string, error) {
 	data, err := runtime.Encode(codec, obj)
 	if err != nil {

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_backoff.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_backoff.go
@@ -68,7 +68,7 @@ func (az *Cloud) RequestBackoff() (resourceRequestBackoff wait.Backoff) {
 	return resourceRequestBackoff
 }
 
-// Event creates a event for the specified object.
+// Event creates an event for the specified object.
 func (az *Cloud) Event(obj runtime.Object, eventType, reason, message string) {
 	if obj != nil && reason != "" {
 		az.eventRecorder.Event(obj, eventType, reason, message)

--- a/staging/src/k8s.io/sample-apiserver/pkg/generated/openapi/zz_generated.openapi.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/generated/openapi/zz_generated.openapi.go
@@ -693,7 +693,7 @@ func schema_pkg_apis_meta_v1_FieldsV1(ref common.ReferenceCallback) common.OpenA
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Description: "FieldsV1 stores a set of fields in a data structure like a Trie, in JSON format.\n\nEach key is either a '.' representing the field itself, and will always map to an empty set, or a string representing a sub-field or item. The string will follow one of these four formats: 'f:<name>', where <name> is the name of a field in a struct, or key in a map 'v:<value>', where <value> is the exact json formatted value of a list item 'i:<index>', where <index> is position of a item in a list 'k:<keys>', where <keys> is a map of  a list item's key fields to their unique values If a key maps to an empty Fields value, the field that key represents is part of the set.\n\nThe exact format is defined in sigs.k8s.io/structured-merge-diff",
+				Description: "FieldsV1 stores a set of fields in a data structure like a Trie, in JSON format.\n\nEach key is either a '.' representing the field itself, and will always map to an empty set, or a string representing a sub-field or item. The string will follow one of these four formats: 'f:<name>', where <name> is the name of a field in a struct, or key in a map 'v:<value>', where <value> is the exact json formatted value of a list item 'i:<index>', where <index> is position of an item in a list 'k:<keys>', where <keys> is a map of  a list item's key fields to their unique values If a key maps to an empty Fields value, the field that key represents is part of the set.\n\nThe exact format is defined in sigs.k8s.io/structured-merge-diff",
 				Type:        []string{"object"},
 			},
 		},

--- a/test/conformance/testdata/conformance.yaml
+++ b/test/conformance/testdata/conformance.yaml
@@ -1790,9 +1790,9 @@
 - testname: Pod events, verify event from Scheduler and Kubelet
   codename: '[sig-node] Events should be sent by kubelets and the scheduler about
     pods scheduling and running  [Conformance]'
-  description: Create a Pod, make sure that the Pod can be queried. Create a event
+  description: Create a Pod, make sure that the Pod can be queried. Create an event
     selector for the kind=Pod and the source is the Scheduler. List of the events
-    MUST be at least one. Create a event selector for kind=Pod and the source is the
+    MUST be at least one. Create an event selector for kind=Pod and the source is the
     Kubelet. List of the events MUST be at least one. Both Scheduler and Kubelet MUST
     send events when scheduling and running a Pod.
   release: v1.9
@@ -2344,7 +2344,7 @@
     created Pod using the volume mount that is mapped to custom path in the Pod. When
     the config map is updated the change to the config map MUST be verified by reading
     the content from the mounted file in the Pod. Also when the item(file) is deleted
-    from the map that MUST result in a error reading that item(file).
+    from the map that MUST result in an error reading that item(file).
   release: v1.9
   file: test/e2e/common/storage/configmap_volume.go
 - testname: ConfigMap Volume, without mapping
@@ -2442,7 +2442,7 @@
   codename: '[sig-storage] Downward API volume should provide container''s cpu limit
     [NodeConformance] [Conformance]'
   description: A Pod is configured with DownwardAPIVolumeSource and DownwardAPIVolumeFiles
-    contains a item for the CPU limits. The container runtime MUST be able to access
+    contains an item for the CPU limits. The container runtime MUST be able to access
     CPU limits from the specified path on the mounted volume.
   release: v1.9
   file: test/e2e/common/storage/downwardapi_volume.go
@@ -2450,7 +2450,7 @@
   codename: '[sig-storage] Downward API volume should provide container''s cpu request
     [NodeConformance] [Conformance]'
   description: A Pod is configured with DownwardAPIVolumeSource and DownwardAPIVolumeFiles
-    contains a item for the CPU request. The container runtime MUST be able to access
+    contains an item for the CPU request. The container runtime MUST be able to access
     CPU request from the specified path on the mounted volume.
   release: v1.9
   file: test/e2e/common/storage/downwardapi_volume.go
@@ -2458,7 +2458,7 @@
   codename: '[sig-storage] Downward API volume should provide container''s memory
     limit [NodeConformance] [Conformance]'
   description: A Pod is configured with DownwardAPIVolumeSource and DownwardAPIVolumeFiles
-    contains a item for the memory limits. The container runtime MUST be able to access
+    contains an item for the memory limits. The container runtime MUST be able to access
     memory limits from the specified path on the mounted volume.
   release: v1.9
   file: test/e2e/common/storage/downwardapi_volume.go
@@ -2466,7 +2466,7 @@
   codename: '[sig-storage] Downward API volume should provide container''s memory
     request [NodeConformance] [Conformance]'
   description: A Pod is configured with DownwardAPIVolumeSource and DownwardAPIVolumeFiles
-    contains a item for the memory request. The container runtime MUST be able to
+    contains an item for the memory request. The container runtime MUST be able to
     access memory request from the specified path on the mounted volume.
   release: v1.9
   file: test/e2e/common/storage/downwardapi_volume.go
@@ -2474,7 +2474,7 @@
   codename: '[sig-storage] Downward API volume should provide node allocatable (cpu)
     as default cpu limit if the limit is not set [NodeConformance] [Conformance]'
   description: A Pod is configured with DownwardAPIVolumeSource and DownwardAPIVolumeFiles
-    contains a item for the CPU limits. CPU limits is not specified for the container.
+    contains an item for the CPU limits. CPU limits is not specified for the container.
     The container runtime MUST be able to access CPU limits from the specified path
     on the mounted volume and the value MUST be default node allocatable.
   release: v1.9
@@ -2483,7 +2483,7 @@
   codename: '[sig-storage] Downward API volume should provide node allocatable (memory)
     as default memory limit if the limit is not set [NodeConformance] [Conformance]'
   description: A Pod is configured with DownwardAPIVolumeSource and DownwardAPIVolumeFiles
-    contains a item for the memory limits. memory limits is not specified for the
+    contains an item for the memory limits. memory limits is not specified for the
     container. The container runtime MUST be able to access memory limits from the
     specified path on the mounted volume and the value MUST be default node allocatable.
   release: v1.9
@@ -2492,7 +2492,7 @@
   codename: '[sig-storage] Downward API volume should provide podname only [NodeConformance]
     [Conformance]'
   description: A Pod is configured with DownwardAPIVolumeSource and DownwardAPIVolumeFiles
-    contains a item for the Pod name. The container runtime MUST be able to access
+    contains an item for the Pod name. The container runtime MUST be able to access
     Pod name from the specified path on the mounted volume.
   release: v1.9
   file: test/e2e/common/storage/downwardapi_volume.go
@@ -2500,7 +2500,7 @@
   codename: '[sig-storage] Downward API volume should set DefaultMode on files [LinuxOnly]
     [NodeConformance] [Conformance]'
   description: A Pod is configured with DownwardAPIVolumeSource with the volumesource
-    mode set to -r-------- and DownwardAPIVolumeFiles contains a item for the Pod
+    mode set to -r-------- and DownwardAPIVolumeFiles contains an item for the Pod
     name. The container runtime MUST be able to access Pod name from the specified
     path on the mounted volume. This test is marked LinuxOnly since Windows does not
     support setting specific file permissions.
@@ -2510,7 +2510,7 @@
   codename: '[sig-storage] Downward API volume should set mode on item file [LinuxOnly]
     [NodeConformance] [Conformance]'
   description: A Pod is configured with DownwardAPIVolumeSource and DownwardAPIVolumeFiles
-    contains a item for the Pod name with the file mode set to -r--------. The container
+    contains an item for the Pod name with the file mode set to -r--------. The container
     runtime MUST be able to access Pod name from the specified path on the mounted
     volume. This test is marked LinuxOnly since Windows does not support setting specific
     file permissions.

--- a/test/e2e/common/storage/configmap_volume.go
+++ b/test/e2e/common/storage/configmap_volume.go
@@ -232,7 +232,7 @@ var _ = SIGDescribe("ConfigMap", func() {
 	/*
 		Release: v1.9
 		Testname: ConfigMap Volume, create, update and delete
-		Description: The ConfigMap that is created MUST be accessible to read from the newly created Pod using the volume mount that is mapped to custom path in the Pod. When the config map is updated the change to the config map MUST be verified by reading the content from the mounted file in the Pod. Also when the item(file) is deleted from the map that MUST result in a error reading that item(file).
+		Description: The ConfigMap that is created MUST be accessible to read from the newly created Pod using the volume mount that is mapped to custom path in the Pod. When the config map is updated the change to the config map MUST be verified by reading the content from the mounted file in the Pod. Also when the item(file) is deleted from the map that MUST result in an error reading that item(file).
 	*/
 	framework.ConformanceIt("optional updates should be reflected in volume [NodeConformance]", func() {
 		podLogTimeout := e2epod.GetPodSecretUpdateTimeout(f.ClientSet)

--- a/test/e2e/common/storage/downwardapi_volume.go
+++ b/test/e2e/common/storage/downwardapi_volume.go
@@ -45,7 +45,7 @@ var _ = SIGDescribe("Downward API volume", func() {
 	/*
 		Release: v1.9
 		Testname: DownwardAPI volume, pod name
-		Description: A Pod is configured with DownwardAPIVolumeSource and DownwardAPIVolumeFiles contains a item for the Pod name. The container runtime MUST be able to access Pod name from the specified path on the mounted volume.
+		Description: A Pod is configured with DownwardAPIVolumeSource and DownwardAPIVolumeFiles contains an item for the Pod name. The container runtime MUST be able to access Pod name from the specified path on the mounted volume.
 	*/
 	framework.ConformanceIt("should provide podname only [NodeConformance]", func() {
 		podName := "downwardapi-volume-" + string(uuid.NewUUID())
@@ -59,7 +59,7 @@ var _ = SIGDescribe("Downward API volume", func() {
 	/*
 		Release: v1.9
 		Testname: DownwardAPI volume, volume mode 0400
-		Description: A Pod is configured with DownwardAPIVolumeSource with the volumesource mode set to -r-------- and DownwardAPIVolumeFiles contains a item for the Pod name. The container runtime MUST be able to access Pod name from the specified path on the mounted volume.
+		Description: A Pod is configured with DownwardAPIVolumeSource with the volumesource mode set to -r-------- and DownwardAPIVolumeFiles contains an item for the Pod name. The container runtime MUST be able to access Pod name from the specified path on the mounted volume.
 		This test is marked LinuxOnly since Windows does not support setting specific file permissions.
 	*/
 	framework.ConformanceIt("should set DefaultMode on files [LinuxOnly] [NodeConformance]", func() {
@@ -75,7 +75,7 @@ var _ = SIGDescribe("Downward API volume", func() {
 	/*
 		Release: v1.9
 		Testname: DownwardAPI volume, file mode 0400
-		Description: A Pod is configured with DownwardAPIVolumeSource and DownwardAPIVolumeFiles contains a item for the Pod name with the file mode set to -r--------. The container runtime MUST be able to access Pod name from the specified path on the mounted volume.
+		Description: A Pod is configured with DownwardAPIVolumeSource and DownwardAPIVolumeFiles contains an item for the Pod name with the file mode set to -r--------. The container runtime MUST be able to access Pod name from the specified path on the mounted volume.
 		This test is marked LinuxOnly since Windows does not support setting specific file permissions.
 	*/
 	framework.ConformanceIt("should set mode on item file [LinuxOnly] [NodeConformance]", func() {
@@ -185,7 +185,7 @@ var _ = SIGDescribe("Downward API volume", func() {
 	/*
 		Release: v1.9
 		Testname: DownwardAPI volume, CPU limits
-		Description: A Pod is configured with DownwardAPIVolumeSource and DownwardAPIVolumeFiles contains a item for the CPU limits. The container runtime MUST be able to access CPU limits from the specified path on the mounted volume.
+		Description: A Pod is configured with DownwardAPIVolumeSource and DownwardAPIVolumeFiles contains an item for the CPU limits. The container runtime MUST be able to access CPU limits from the specified path on the mounted volume.
 	*/
 	framework.ConformanceIt("should provide container's cpu limit [NodeConformance]", func() {
 		podName := "downwardapi-volume-" + string(uuid.NewUUID())
@@ -199,7 +199,7 @@ var _ = SIGDescribe("Downward API volume", func() {
 	/*
 		Release: v1.9
 		Testname: DownwardAPI volume, memory limits
-		Description: A Pod is configured with DownwardAPIVolumeSource and DownwardAPIVolumeFiles contains a item for the memory limits. The container runtime MUST be able to access memory limits from the specified path on the mounted volume.
+		Description: A Pod is configured with DownwardAPIVolumeSource and DownwardAPIVolumeFiles contains an item for the memory limits. The container runtime MUST be able to access memory limits from the specified path on the mounted volume.
 	*/
 	framework.ConformanceIt("should provide container's memory limit [NodeConformance]", func() {
 		podName := "downwardapi-volume-" + string(uuid.NewUUID())
@@ -213,7 +213,7 @@ var _ = SIGDescribe("Downward API volume", func() {
 	/*
 		Release: v1.9
 		Testname: DownwardAPI volume, CPU request
-		Description: A Pod is configured with DownwardAPIVolumeSource and DownwardAPIVolumeFiles contains a item for the CPU request. The container runtime MUST be able to access CPU request from the specified path on the mounted volume.
+		Description: A Pod is configured with DownwardAPIVolumeSource and DownwardAPIVolumeFiles contains an item for the CPU request. The container runtime MUST be able to access CPU request from the specified path on the mounted volume.
 	*/
 	framework.ConformanceIt("should provide container's cpu request [NodeConformance]", func() {
 		podName := "downwardapi-volume-" + string(uuid.NewUUID())
@@ -227,7 +227,7 @@ var _ = SIGDescribe("Downward API volume", func() {
 	/*
 		Release: v1.9
 		Testname: DownwardAPI volume, memory request
-		Description: A Pod is configured with DownwardAPIVolumeSource and DownwardAPIVolumeFiles contains a item for the memory request. The container runtime MUST be able to access memory request from the specified path on the mounted volume.
+		Description: A Pod is configured with DownwardAPIVolumeSource and DownwardAPIVolumeFiles contains an item for the memory request. The container runtime MUST be able to access memory request from the specified path on the mounted volume.
 	*/
 	framework.ConformanceIt("should provide container's memory request [NodeConformance]", func() {
 		podName := "downwardapi-volume-" + string(uuid.NewUUID())
@@ -241,7 +241,7 @@ var _ = SIGDescribe("Downward API volume", func() {
 	/*
 		Release: v1.9
 		Testname: DownwardAPI volume, CPU limit, default node allocatable
-		Description: A Pod is configured with DownwardAPIVolumeSource and DownwardAPIVolumeFiles contains a item for the CPU limits. CPU limits is not specified for the container. The container runtime MUST be able to access CPU limits from the specified path on the mounted volume and the value MUST be default node allocatable.
+		Description: A Pod is configured with DownwardAPIVolumeSource and DownwardAPIVolumeFiles contains an item for the CPU limits. CPU limits is not specified for the container. The container runtime MUST be able to access CPU limits from the specified path on the mounted volume and the value MUST be default node allocatable.
 	*/
 	framework.ConformanceIt("should provide node allocatable (cpu) as default cpu limit if the limit is not set [NodeConformance]", func() {
 		podName := "downwardapi-volume-" + string(uuid.NewUUID())
@@ -253,7 +253,7 @@ var _ = SIGDescribe("Downward API volume", func() {
 	/*
 		Release: v1.9
 		Testname: DownwardAPI volume, memory limit, default node allocatable
-		Description: A Pod is configured with DownwardAPIVolumeSource and DownwardAPIVolumeFiles contains a item for the memory limits. memory limits is not specified for the container. The container runtime MUST be able to access memory limits from the specified path on the mounted volume and the value MUST be default node allocatable.
+		Description: A Pod is configured with DownwardAPIVolumeSource and DownwardAPIVolumeFiles contains an item for the memory limits. memory limits is not specified for the container. The container runtime MUST be able to access memory limits from the specified path on the mounted volume and the value MUST be default node allocatable.
 	*/
 	framework.ConformanceIt("should provide node allocatable (memory) as default memory limit if the limit is not set [NodeConformance]", func() {
 		podName := "downwardapi-volume-" + string(uuid.NewUUID())

--- a/test/e2e/framework/statefulset/rest.go
+++ b/test/e2e/framework/statefulset/rest.go
@@ -232,7 +232,7 @@ func CheckServiceName(ss *appsv1.StatefulSet, expectedServiceName string) error 
 	return nil
 }
 
-// ExecInStatefulPods executes cmd in all Pods in ss. If a error occurs it is returned and cmd is not execute in any subsequent Pods.
+// ExecInStatefulPods executes cmd in all Pods in ss. If an error occurs it is returned and cmd is not execute in any subsequent Pods.
 func ExecInStatefulPods(c clientset.Interface, ss *appsv1.StatefulSet, cmd string) error {
 	podList := GetPodList(c, ss)
 	for _, statefulPod := range podList.Items {

--- a/test/e2e/node/events.go
+++ b/test/e2e/node/events.go
@@ -39,7 +39,7 @@ var _ = SIGDescribe("Events", func() {
 	/*
 		Release: v1.9
 		Testname: Pod events, verify event from Scheduler and Kubelet
-		Description: Create a Pod, make sure that the Pod can be queried. Create a event selector for the kind=Pod and the source is the Scheduler. List of the events MUST be at least one. Create a event selector for kind=Pod and the source is the Kubelet. List of the events MUST be at least one. Both Scheduler and Kubelet MUST send events when scheduling and running a Pod.
+		Description: Create a Pod, make sure that the Pod can be queried. Create an event selector for the kind=Pod and the source is the Scheduler. List of the events MUST be at least one. Create an event selector for kind=Pod and the source is the Kubelet. List of the events MUST be at least one. Both Scheduler and Kubelet MUST send events when scheduling and running a Pod.
 	*/
 	framework.ConformanceIt("should be sent by kubelets and the scheduler about pods scheduling and running ", func() {
 

--- a/test/e2e/storage/utils/utils.go
+++ b/test/e2e/storage/utils/utils.go
@@ -683,7 +683,7 @@ func WaitUntil(poll, timeout time.Duration, checkDone func() bool) bool {
 	return false
 }
 
-// WaitForGVRFinalizer waits until a object from a given GVR contains a finalizer
+// WaitForGVRFinalizer waits until an object from a given GVR contains a finalizer
 // If namespace is empty, assume it is a non-namespaced object
 func WaitForGVRFinalizer(ctx context.Context, c dynamic.Interface, gvr schema.GroupVersionResource, objectName, objectNamespace, finalizer string, poll, timeout time.Duration) error {
 	framework.Logf("Waiting up to %v for object %s %s of resource %s to contain finalizer %s", timeout, objectNamespace, objectName, gvr.Resource, finalizer)


### PR DESCRIPTION
#### What type of PR is this?
/kind documentation

#### What this PR does / why we need it:
Fix typo `a` to `an` in the whole project, to better the documents.

#### Special notes for your reviewer:
The `v1` alias is automatically added by IDE(Goland), to better differentiate from other v1 packages.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```