### PR TITLE
fix 104554: client-go bucket rate limiter add maxDelay

### DIFF
--- a/staging/src/k8s.io/client-go/util/workqueue/default_rate_limiters_test.go
+++ b/staging/src/k8s.io/client-go/util/workqueue/default_rate_limiters_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package workqueue
 
 import (
+	"golang.org/x/time/rate"
 	"testing"
 	"time"
 )
@@ -181,4 +182,24 @@ func TestMaxOfRateLimiter(t *testing.T) {
 		t.Errorf("expected %v, got %v", e, a)
 	}
 
+}
+
+func TestBucketRateLimiterOverFlow(t *testing.T)  {
+	limiter := DefaultBucketRateLimiter(rate.NewLimiter(rate.Limit(10), 100))
+
+	for i := 0; i < 50; i++ {
+		if e, a := 0 * time.Second, limiter.When(i); e != a {
+			t.Errorf("expected %v, got %v", e, a)
+		}
+	}
+
+	for i := 50; i < 3000; i++ {
+		limiter.When(i)
+	}
+
+	for i := 3000; i < 3100; i++ {
+		if e, a := 500 * time.Second, limiter.When(i); e != a {
+			t.Errorf("expected %v, got %v", e, a)
+		}
+	}
 }


### PR DESCRIPTION
#### 1. What type of PR is this?
/kind bug
/sig client-go

#### 2. What this PR does / why we need it:
client-go bucket rate limiter add maxDelay, avoiding waiting for too long to enqueue

#### 3. Which issue(s) this PR fixes:
Fixes [#104554](https://github.com/kubernetes/kubernetes/issues/104554)

#### 4.  Does this PR introduce a user-facing change?
NONE

#### 5. Special notes for your reviewer:
 Not sure what maxDelay is valid

