### PR TITLE
[WiP] [doc] Document exit code of "kubectl wait"

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/wait/wait.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/wait/wait.go
@@ -55,8 +55,11 @@ var (
 		Alternatively, the command can wait for the given set of resources to be deleted
 		by providing the "delete" keyword as the value to the --for flag.
 
+		The exit code will be zero if the condition has been met before the timeout,
+		nonzero otherwise.
+
 		A successful message will be printed to stdout indicating when the specified
-        condition has been met. You can use -o option to change to output destination.`))
+		condition has been met. You can use -o option to change to output destination.`))
 
 	waitExample = templates.Examples(i18n.T(`
 		# Wait for the pod "busybox1" to contain the status condition of type "Ready"


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind documentation

#### What this PR does / why we need it:
Document the exit code of "kubectl wait".
One of my colleagues started parsing the output instead of just using the exit code, so I thought this should be added.
The whole point of this command is to check a condition, so it should be clear how to obtain the result.

#### Which issue(s) this PR fixes:
none

#### Special notes for your reviewer:
@kubernetes/sig-cli-pr-reviews

#### Does this PR introduce a user-facing change?
```release-note
Document the exit code of "kubectl wait".
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.: