### PR TITLE
WIP: Node e2e test for completed pods

### DIFF
--- a/test/e2e_node/multiple_pod_additions_test.go
+++ b/test/e2e_node/multiple_pod_additions_test.go
@@ -1,0 +1,112 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2enode
+
+import (
+	"strconv"
+	"time"
+
+	"github.com/onsi/ginkgo"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/kubernetes/test/e2e/framework"
+	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
+	imageutils "k8s.io/kubernetes/test/utils/image"
+)
+
+func getAvailableBytes() uint64 {
+	summary, err := getNodeSummary()
+	if err != nil {
+		framework.ExpectNoError(err)
+	}
+	return *(summary.Node.Memory.AvailableBytes)
+}
+
+func makePod(name string, namespace string, requestedBytes string) *v1.Pod {
+
+	return &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: v1.PodSpec{
+			Containers: []v1.Container{
+				{
+					Name:    "busybox",
+					Image:   imageutils.GetE2EImage(imageutils.BusyBox),
+					Command: []string{"sleep", "30"},
+					Resources: v1.ResourceRequirements{
+						Requests: v1.ResourceList{
+							v1.ResourceMemory: resource.MustParse(requestedBytes),
+						},
+					},
+				},
+			},
+			RestartPolicy: v1.RestartPolicyNever,
+		},
+	}
+}
+
+var _ = SIGDescribe("Multiple Pods Addition TEST123", func() {
+	f := framework.NewDefaultFramework("multiple-pods-additions")
+	podNames := []string{"test1-pod", "test2-pod", "test3-pod"}
+
+	ginkgo.Context("when creating multiple pods ", func() {
+
+		ginkgo.BeforeEach(func() {
+
+		})
+
+		ginkgo.AfterEach(func() {
+			for _, podName := range podNames {
+				gp := int64(0)
+				f.PodClient().DeleteSync(podName, metav1.DeleteOptions{GracePeriodSeconds: &gp}, 2*time.Minute)
+			}
+		})
+
+		ginkgo.It("should be create pods that reach completion TEST321 [NodeConformance]", func() {
+			ginkgo.By("create pods")
+
+			availableBytes := getAvailableBytes()
+			requestedBytes := strconv.FormatUint(availableBytes/2, 10)
+
+			for _, podName := range podNames {
+				framework.Logf("requested memory %s out of available memory %d for pod %s", requestedBytes, availableBytes, podName)
+				pod := makePod(podName, f.Namespace.Name, requestedBytes)
+				f.PodClient().Create(pod)
+				err := e2epod.WaitForPodSuccessInNamespace(f.ClientSet, podName, f.Namespace.Name)
+				framework.ExpectNoError(err)
+			}
+
+			// ginkgo.By("wait for a pod to be completed")
+
+			// var wg sync.WaitGroup
+			// for _, podName := range podNames {
+			// 	wg.Add(1)
+			// 	go func(podname string) {
+			// 		// defer ginkgo.GinkgoRecover()
+
+			// 		wg.Done()
+			// 	}(podName)
+			// }
+			// wg.Wait()
+
+		})
+	})
+
+})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/king bug

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes # https://github.com/kubernetes/kubernetes/issues/104560

#### Special notes for your reviewer:
Node e2e test for testing https://github.com/kubernetes/kubernetes/pull/104577

Without Clayton changes, as expected the test fails because of failing to admit the pod due to node `OutOfmemory`
```bash
[root@localhost results]# grep test3 kubelet.log 
I0830 10:09:34.826277    5481 config.go:383] "Receiving a new pod" pod="multiple-pods-additions-7998/test3-pod"
I0830 10:09:34.826332    5481 kubelet.go:2054] "SyncLoop ADD" source="api" pods=[multiple-pods-additions-7998/test3-pod]
I0830 10:09:34.826450    5481 predicate.go:144] "Predicate failed on Pod" pod="multiple-pods-additions-7998/test3-pod" err="Node didn't have enough resource: memory, requested: 1224572928, used: 2449145856, capacity: 3575099392"
I0830 10:09:34.831867    5481 event.go:294] "Event occurred" object="multiple-pods-additions-7998/test3-pod" kind="Pod" apiVersion="v1" type="Warning" reason="OutOfmemory" message="Node didn't have enough resource: memory, requested: 1224572928, used: 2449145856, capacity: 3575099392"
I0830 10:09:34.890805    5481 kubelet.go:2067] "SyncLoop RECONCILE" source="api" pods=[multiple-pods-additions-7998/test3-pod]
I0830 10:09:34.898655    5481 status_manager.go:621] "Patch status for pod" pod="multiple-pods-additions-7998/test3-pod" patch="{\"metadata\":{\"uid\":\"b6424220-a0b4-4f80-a09e-50eb9e01a5e5\"},\"status\":{\"message\":\"Pod Node didn't have enough resource: memory, requested: 1224572928, used: 2449145856, capacity: 3575099392\",\"phase\":\"Failed\",\"qosClass\":null,\"reason\":\"OutOfmemory\",\"startTime\":\"2021-08-30T10:09:34Z\"}}"
I0830 10:09:34.898704    5481 status_manager.go:630] "Status for pod updated successfully" pod="multiple-pods-additions-7998/test3-pod" statusVersion=1 status={Phase:Failed Conditions:[] Message:Pod Node didn't have enough resource: memory, requested: 1224572928, used: 2449145856, capacity: 3575099392 Reason:OutOfmemory NominatedNodeName: HostIP: PodIP: PodIPs:[] StartTime:2021-08-30 10:09:34 +0000 UTC InitContainerStatuses:[] ContainerStatuses:[] QOSClass: EphemeralContainerStatuses:[]}
```

However with fixes proposed in https://github.com/kubernetes/kubernetes/pull/104577, the test passes fine. 


#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
