### PR TITLE
Automated cherry pick of #104577: kubelet: Admission must exclude completed pods and avoid

### DIFF
--- a/pkg/kubelet/pod_workers_test.go
+++ b/pkg/kubelet/pod_workers_test.go
@@ -49,6 +49,7 @@ type fakePodWorkers struct {
 	statusLock            sync.Mutex
 	running               map[types.UID]bool
 	terminating           map[types.UID]bool
+	terminated            map[types.UID]bool
 	terminationRequested  map[types.UID]bool
 	removeRuntime         map[types.UID]bool
 	removeContent         map[types.UID]bool
@@ -85,6 +86,11 @@ func (f *fakePodWorkers) SyncKnownPods(desiredPods []*v1.Pod) map[types.UID]PodW
 	return nil
 }
 
+func (f *fakePodWorkers) IsPodKnownTerminated(uid types.UID) bool {
+	f.statusLock.Lock()
+	defer f.statusLock.Unlock()
+	return f.terminated[uid]
+}
 func (f *fakePodWorkers) CouldHaveRunningContainers(uid types.UID) bool {
 	f.statusLock.Lock()
 	defer f.statusLock.Unlock()


### PR DESCRIPTION
Cherry pick of #104577 on release-1.22.

#104577: kubelet: Admission must exclude completed pods and avoid

Fixes https://github.com/kubernetes/kubernetes/issues/104560

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
Fix a 1.22 regression where the Kubelet failed to exclude already completed pods from calculations about how many resources it was currently using when deciding whether to allow more pods.
```
