### PR TITLE
Update GKE kubernetes sources download link

### DIFF
--- a/cluster/gce/gci/configure-helper.sh
+++ b/cluster/gce/gci/configure-helper.sh
@@ -2920,7 +2920,7 @@ You can find documentation for Kubernetes at:
 The source for this release can be found at:
   /home/kubernetes/kubernetes-src.tar.gz
 Or you can download it at:
-  https://storage.googleapis.com/kubernetes-release/release/${version}/kubernetes-src.tar.gz
+  https://storage.googleapis.com/gke-release/kubernetes/release/${version}/kubernetes-src.tar.gz
 
 It is based on the Kubernetes source at:
   https://github.com/kubernetes/kubernetes/tree/${gitref}


### PR DESCRIPTION
Fix non-working link provided on MOTD to download GKE source release.
Now point to correct location, confirmed same file as provided in "/home/kubernetes/kubernetes-src.tar.gz"

/kind bug
/kind cleanup

/area provider/gcp

#### Which issue(s) this PR fixes:

Bug: #104517
