### PR TITLE
kubectl: Document --for's Unicode case-folding condition-value comparison

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/wait/wait.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/wait/wait.go
@@ -65,7 +65,7 @@ var (
 		# Wait for the pod "busybox1" to contain the status condition of type "Ready"
 		kubectl wait --for=condition=Ready pod/busybox1
 
-		# The default value of status condition is true; you can set it to false
+		# The default value of status condition is true; you can wait for other targets after an equal delimiter (compared after Unicode simple case folding, which is a more general form of case-insensitivity):
 		kubectl wait --for=condition=Ready=false pod/busybox1
 
 		# Wait for the pod "busybox1" to contain the status phase to be "Running".
@@ -142,7 +142,7 @@ func (flags *WaitFlags) AddFlags(cmd *cobra.Command) {
 	flags.ResourceBuilderFlags.AddFlags(cmd.Flags())
 
 	cmd.Flags().DurationVar(&flags.Timeout, "timeout", flags.Timeout, "The length of time to wait before giving up.  Zero means check once and don't wait, negative means wait for a week.")
-	cmd.Flags().StringVar(&flags.ForCondition, "for", flags.ForCondition, "The condition to wait on: [delete|condition=condition-name|jsonpath='{JSONPath expression}'=JSONPath Condition]. The default status value of condition-name is true, you can set false with condition=condition-name=false.")
+	cmd.Flags().StringVar(&flags.ForCondition, "for", flags.ForCondition, "The condition to wait on: [delete|condition=condition-name[=condition-value]|jsonpath='{JSONPath expression}'=JSONPath Condition]. The default condition-value is true.  Condition values are compared after Unicode simple case folding, which is a more general form of case-insensitivity.")
 }
 
 // ToOptions converts from CLI inputs to runtime inputs


### PR DESCRIPTION
When the wait command was added in 76794643c5 (#64034), this comparison was via [ToLower][1].  It moved to [use][1] [Unicode case folding][2] in f4940cf55f (#87403).

It's possible that saying "string-insensitive matching" is sufficient.  Seems like [Go is using `SimpleFold` to implement `EqualFold`][3], and that means full case-fold situations like [ß ⇒ ss][4] aren't implemented.  In some brief poking around, I haven't found a situation where `EqualFold(a,b)` diverges from `ToLower(a) == ToLower(b)`.

```release-note
NONE
```

[1]: https://pkg.go.dev/strings#EqualFold
[2]: http://www.unicode.org/reports/tr30/tr30-1.html
[3]: https://cs.opensource.google/go/go/+/refs/tags/go1.17:src/strings/strings.go;l=1009
[4]: https://www.w3.org/TR/charmod-norm/#example-7