### PR TITLE
Automated cherry pick of #103532: Service: Fix semantics for Update wrt allocations

### DIFF
--- a/pkg/api/service/testing/make.go
+++ b/pkg/api/service/testing/make.go
@@ -1,0 +1,170 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testing
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	utilpointer "k8s.io/utils/pointer"
+
+	api "k8s.io/kubernetes/pkg/apis/core"
+)
+
+// Tweak is a function that modifies a Service.
+type Tweak func(*api.Service)
+
+// MakeService helps construct Service objects (which pass API validation) more
+// legibly and tersely than a Go struct definition.  By default this produces
+// a ClusterIP service with a single port and a trivial selector.  The caller
+// can pass any number of tweak functions to further modify the result.
+func MakeService(name string, tweaks ...Tweak) *api.Service {
+	// NOTE: Any field that would be populated by defaulting needs to be
+	// present and valid here.
+	svc := &api.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: metav1.NamespaceDefault,
+		},
+		Spec: api.ServiceSpec{
+			Selector:        map[string]string{"k": "v"},
+			SessionAffinity: api.ServiceAffinityNone,
+		},
+	}
+	// Default to ClusterIP
+	SetTypeClusterIP(svc)
+	// Default to 1 port
+	SetPorts(MakeServicePort("", 93, intstr.FromInt(76), api.ProtocolTCP))(svc)
+	// Default internalTrafficPolicy to "Cluster"
+	SetInternalTrafficPolicy(api.ServiceInternalTrafficPolicyCluster)(svc)
+
+	for _, tweak := range tweaks {
+		tweak(svc)
+	}
+
+	return svc
+}
+
+// SetTypeClusterIP sets the service type to ClusterIP and clears other fields.
+func SetTypeClusterIP(svc *api.Service) {
+	svc.Spec.Type = api.ServiceTypeClusterIP
+	for i := range svc.Spec.Ports {
+		svc.Spec.Ports[i].NodePort = 0
+	}
+	svc.Spec.ExternalName = ""
+	svc.Spec.ExternalTrafficPolicy = ""
+	svc.Spec.AllocateLoadBalancerNodePorts = nil
+}
+
+// SetTypeNodePort sets the service type to NodePort and clears other fields.
+func SetTypeNodePort(svc *api.Service) {
+	svc.Spec.Type = api.ServiceTypeNodePort
+	svc.Spec.ExternalTrafficPolicy = api.ServiceExternalTrafficPolicyTypeCluster
+	svc.Spec.ExternalName = ""
+	svc.Spec.AllocateLoadBalancerNodePorts = nil
+}
+
+// SetTypeLoadBalancer sets the service type to LoadBalancer and clears other fields.
+func SetTypeLoadBalancer(svc *api.Service) {
+	svc.Spec.Type = api.ServiceTypeLoadBalancer
+	svc.Spec.ExternalTrafficPolicy = api.ServiceExternalTrafficPolicyTypeCluster
+	svc.Spec.AllocateLoadBalancerNodePorts = utilpointer.BoolPtr(true)
+	svc.Spec.ExternalName = ""
+}
+
+// SetTypeExternalName sets the service type to ExternalName and clears other fields.
+func SetTypeExternalName(svc *api.Service) {
+	svc.Spec.Type = api.ServiceTypeExternalName
+	svc.Spec.ExternalName = "example.com"
+	svc.Spec.ExternalTrafficPolicy = ""
+	svc.Spec.ClusterIP = ""
+	svc.Spec.ClusterIPs = nil
+	svc.Spec.AllocateLoadBalancerNodePorts = nil
+}
+
+// SetPorts sets the service ports list.
+func SetPorts(ports ...api.ServicePort) Tweak {
+	return func(svc *api.Service) {
+		svc.Spec.Ports = ports
+	}
+}
+
+// MakeServicePort helps construct ServicePort objects which pass API
+// validation.
+func MakeServicePort(name string, port int, tgtPort intstr.IntOrString, proto api.Protocol) api.ServicePort {
+	return api.ServicePort{
+		Name:       name,
+		Port:       int32(port),
+		TargetPort: tgtPort,
+		Protocol:   proto,
+	}
+}
+
+// SetClusterIPs sets the service ClusterIP and ClusterIPs fields.
+func SetClusterIPs(ips ...string) Tweak {
+	return func(svc *api.Service) {
+		svc.Spec.ClusterIP = ips[0]
+		svc.Spec.ClusterIPs = ips
+	}
+}
+
+// SetIPFamilies sets the service IPFamilies field.
+func SetIPFamilies(families ...api.IPFamily) Tweak {
+	return func(svc *api.Service) {
+		svc.Spec.IPFamilies = families
+	}
+}
+
+// SetIPFamilyPolicy sets the service IPFamilyPolicy field.
+func SetIPFamilyPolicy(policy api.IPFamilyPolicyType) Tweak {
+	return func(svc *api.Service) {
+		svc.Spec.IPFamilyPolicy = &policy
+	}
+}
+
+// SetNodePorts sets the values for each node port, in order.  If less values
+// are specified than there are ports, the rest are untouched.
+func SetNodePorts(values ...int) Tweak {
+	return func(svc *api.Service) {
+		for i := range svc.Spec.Ports {
+			if i >= len(values) {
+				break
+			}
+			svc.Spec.Ports[i].NodePort = int32(values[i])
+		}
+	}
+}
+
+// SetInternalTrafficPolicy sets the internalTrafficPolicy field for a Service.
+func SetInternalTrafficPolicy(policy api.ServiceInternalTrafficPolicyType) Tweak {
+	return func(svc *api.Service) {
+		svc.Spec.InternalTrafficPolicy = &policy
+	}
+}
+
+// SetExternalTrafficPolicy sets the externalTrafficPolicy field for a Service.
+func SetExternalTrafficPolicy(policy api.ServiceExternalTrafficPolicyType) Tweak {
+	return func(svc *api.Service) {
+		svc.Spec.ExternalTrafficPolicy = policy
+	}
+}
+
+// SetAllocateLoadBalancerNodePorts sets the allocate LB node port field.
+func SetAllocateLoadBalancerNodePorts(val bool) Tweak {
+	return func(svc *api.Service) {
+		svc.Spec.AllocateLoadBalancerNodePorts = utilpointer.BoolPtr(val)
+	}
+}

--- a/pkg/api/service/testing/make.go
+++ b/pkg/api/service/testing/make.go
@@ -168,3 +168,10 @@ func SetAllocateLoadBalancerNodePorts(val bool) Tweak {
 		svc.Spec.AllocateLoadBalancerNodePorts = utilpointer.BoolPtr(val)
 	}
 }
+
+// SetHealthCheckNodePort sets the healthCheckNodePort field for a Service.
+func SetHealthCheckNodePort(value int32) Tweak {
+	return func(svc *api.Service) {
+		svc.Spec.HealthCheckNodePort = value
+	}
+}

--- a/pkg/registry/core/service/strategy.go
+++ b/pkg/registry/core/service/strategy.go
@@ -119,6 +119,7 @@ func (strategy svcStrategy) PrepareForUpdate(ctx context.Context, obj, old runti
 	oldService := old.(*api.Service)
 	newService.Status = oldService.Status
 
+	patchAllocatedValues(newService, oldService)
 	NormalizeClusterIPs(oldService, newService)
 	dropServiceDisabledFields(newService, oldService)
 	dropTypeDependentFields(newService, oldService)
@@ -300,6 +301,48 @@ func (serviceStatusStrategy) PrepareForUpdate(ctx context.Context, obj, old runt
 // ValidateUpdate is the default update validation for an end user updating status
 func (serviceStatusStrategy) ValidateUpdate(ctx context.Context, obj, old runtime.Object) field.ErrorList {
 	return validation.ValidateServiceStatusUpdate(obj.(*api.Service), old.(*api.Service))
+}
+
+// WarningsOnUpdate returns warnings for the given update.
+func (serviceStatusStrategy) WarningsOnUpdate(ctx context.Context, obj, old runtime.Object) []string {
+	return nil
+}
+
+// patchAllocatedValues allows clients to avoid a read-modify-write cycle while
+// preserving values that we allocated on their behalf.  For example, they
+// might create a Service without specifying the ClusterIP, in which case we
+// allocate one.  If they resubmit that same YAML, we want it to succeed.
+func patchAllocatedValues(newSvc, oldSvc *api.Service) {
+	if needsClusterIP(oldSvc) && needsClusterIP(newSvc) {
+		if newSvc.Spec.ClusterIP == "" {
+			newSvc.Spec.ClusterIP = oldSvc.Spec.ClusterIP
+		}
+		if len(newSvc.Spec.ClusterIPs) == 0 {
+			newSvc.Spec.ClusterIPs = oldSvc.Spec.ClusterIPs
+		}
+	}
+
+	if needsNodePort(oldSvc) && needsNodePort(newSvc) {
+		// Map NodePorts by name.  The user may have changed other properties
+		// of the port, but we won't see that here.
+		np := map[string]int32{}
+		for i := range oldSvc.Spec.Ports {
+			p := &oldSvc.Spec.Ports[i]
+			np[p.Name] = p.NodePort
+		}
+		for i := range newSvc.Spec.Ports {
+			p := &newSvc.Spec.Ports[i]
+			if p.NodePort == 0 {
+				p.NodePort = np[p.Name]
+			}
+		}
+	}
+
+	if needsHCNodePort(oldSvc) && needsHCNodePort(newSvc) {
+		if newSvc.Spec.HealthCheckNodePort == 0 {
+			newSvc.Spec.HealthCheckNodePort = oldSvc.Spec.HealthCheckNodePort
+		}
+	}
 }
 
 // NormalizeClusterIPs adjust clusterIPs based on ClusterIP.  This must not


### PR DESCRIPTION
Cherry pick of #103532 #104601 on release-1.21.

#103532: Service: Fix semantics for Update wrt allocations

This has now manifested as user-reported outages (errant controller looping and allocating ports causing DoS in HA apiservers), hence the backport.

It is not uncommon for users to Create a Service and not specify things
like ClusterIP and NodePort, which we then allocate for them.  They same
that YAML somewhere and later use it again in an Update, but then it
fails.

That's because we detected them trying to set a ClusterIP from a value
to "", which is not allowed.  If it was just NodePort, they would
actually succeed and reallocate a new port.

After this change, we try to "patch" updates where the user did not
specify those values from the old object.


/kind bug
/kind api-change

```release-note
When using `kubectl replace` (or the equivalent API call) on a Service, the caller no longer needs to do a read-modify-write cycle to fetch the allocated values for `.spec.clusterIP` and `.spec.ports[].nodePort`.  Instead the API server will automatically carry these forward from the original object when the new object does not specify them.  
```