### PR TITLE
Automated cherry pick of #104172: revert "fix wrong output when using jsonpath"

### DIFF
--- a/staging/src/k8s.io/client-go/util/jsonpath/jsonpath.go
+++ b/staging/src/k8s.io/client-go/util/jsonpath/jsonpath.go
@@ -132,9 +132,6 @@ func (j *JSONPath) FindResults(data interface{}) ([][]reflect.Value, error) {
 			}
 			continue
 		}
-		if len(results) == 0 {
-			break
-		}
 		fullResult = append(fullResult, results)
 	}
 	return fullResult, nil

--- a/staging/src/k8s.io/client-go/util/jsonpath/jsonpath_test.go
+++ b/staging/src/k8s.io/client-go/util/jsonpath/jsonpath_test.go
@@ -280,6 +280,7 @@ func TestStructInput(t *testing.T) {
 
 	missingKeyTests := []jsonpathTest{
 		{"nonexistent field", "{.hello}", storeData, "", false},
+		{"nonexistent field 2", "before-{.hello}after", storeData, "before-after", false},
 	}
 	testJSONPath(missingKeyTests, true, t)
 

--- a/staging/src/k8s.io/client-go/util/jsonpath/jsonpath_test.go
+++ b/staging/src/k8s.io/client-go/util/jsonpath/jsonpath_test.go
@@ -806,8 +806,8 @@ func TestRunningPodsJSONPathOutput(t *testing.T) {
 	testJSONPath(
 		[]jsonpathTest{
 			{
-				"when range is used in a certain way in script, additional line is printed",
-				`{range .items[?(.status.phase=="Running")]}{.metadata.name}{" is Running\n"}`,
+				"range over pods without selecting the last one",
+				`{range .items[?(.status.phase=="Running")]}{.metadata.name}{" is Running\n"}{end}`,
 				data,
 				"pod1 is Running\npod2 is Running\npod3 is Running\n",
 				false, // expect no error


### PR DESCRIPTION
Cherry pick of #104172 on release-1.22.

#104172: revert "fix wrong output when using jsonpath"

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
Fix a 1.22 regression with wrong output using jsonpath
```
