### PR TITLE
Update conformance image to use debian-base:buster-v1.9.0

### DIFF
--- a/build/dependencies.yaml
+++ b/build/dependencies.yaml
@@ -132,6 +132,8 @@ dependencies:
       match: BASEIMAGE\?\=k8s\.gcr\.io\/build-image\/debian-base-ppc64le:[a-zA-Z]+\-v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)
     - path: cluster/images/etcd/Makefile
       match: BASEIMAGE\?\=k8s\.gcr\.io\/build-image\/debian-base-s390x:[a-zA-Z]+\-v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)
+    - path: test/conformance/image/Makefile
+      match: BASE_IMAGE_VERSION\?=
 
   - name: "k8s.gcr.io/debian-iptables: dependents"
     version: buster-v1.6.6

--- a/test/conformance/image/Makefile
+++ b/test/conformance/image/Makefile
@@ -33,14 +33,13 @@ CLUSTER_DIR?=$(shell pwd)/../../../cluster/
 
 # This is defined in root Makefile, but some build contexts do not refer to them
 KUBE_BASE_IMAGE_REGISTRY?=k8s.gcr.io
+BASE_IMAGE_VERSION?=buster-v1.9.0
+BASEIMAGE?=${KUBE_BASE_IMAGE_REGISTRY}/build-image/debian-base-${ARCH}:${BASE_IMAGE_VERSION}
 
-ifeq ($(ARCH),amd64)
-    BASEIMAGE?=${KUBE_BASE_IMAGE_REGISTRY}/build-image/debian-base:v2.1.3
-else
-    BASEIMAGE?=${KUBE_BASE_IMAGE_REGISTRY}/build-image/debian-base-${ARCH}:v2.1.3
-endif
-
-RUNNERIMAGE?=gcr.io/distroless/base:latest
+# Keep debian releases (e.g. debian 10 == buster) consistent 
+# between BASE_IMAGE_VERSION and DISTROLESS_IMAGE images
+DISTROLESS_IMAGE?=base-debian10
+RUNNERIMAGE?=gcr.io/distroless/${DISTROLESS_IMAGE}:latest
 
 TEMP_DIR:=$(shell mktemp -d -t conformance-XXXXXX)
 


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:
- Debian base used was older missing multiple fixed CVEs

#### Special notes for your reviewer:
Not sure, how can these images be promoted to k8s.gcr.io, but I am assuming it will happen as part of next release build getting published. If not, happy to submit a PR to promote these images

/area conformance 
/sig release testing architecture security

```release-note
Update conformance image to use debian-base:buster-v1.9.0
```