### PR TITLE
Object creation with generateName should return AlreadyExists instead of a Timeout

### DIFF
--- a/pkg/registry/core/service/storage/rest.go
+++ b/pkg/registry/core/service/storage/rest.go
@@ -247,7 +247,7 @@ func (rs *REST) Create(ctx context.Context, obj runtime.Object, createValidation
 
 	out, err := rs.services.Create(ctx, service, createValidation, options)
 	if err != nil {
-		err = rest.CheckGeneratedNameError(rs.strategy, err, service)
+		err = rest.CheckGeneratedNameError(ctx, rs.strategy, err, service)
 	}
 
 	if err == nil {

--- a/staging/src/k8s.io/apimachinery/pkg/api/errors/errors.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/errors/errors.go
@@ -170,6 +170,25 @@ func NewAlreadyExists(qualifiedResource schema.GroupResource, name string) *Stat
 	}}
 }
 
+// NewGenerateNameConflict returns an error indicating the server
+// was not able to generate a valid name for a resource.
+func NewGenerateNameConflict(qualifiedResource schema.GroupResource, name string, retryAfterSeconds int) *StatusError {
+	return &StatusError{metav1.Status{
+		Status: metav1.StatusFailure,
+		Code:   http.StatusConflict,
+		Reason: metav1.StatusReasonAlreadyExists,
+		Details: &metav1.StatusDetails{
+			Group:             qualifiedResource.Group,
+			Kind:              qualifiedResource.Resource,
+			Name:              name,
+			RetryAfterSeconds: int32(retryAfterSeconds),
+		},
+		Message: fmt.Sprintf(
+			"%s %q already exists, the server was not able to generate a unique name for the object",
+			qualifiedResource.String(), name),
+	}}
+}
+
 // NewUnauthorized returns an error indicating the client is not authorized to perform the requested
 // action.
 func NewUnauthorized(reason string) *StatusError {

--- a/staging/src/k8s.io/apimachinery/pkg/api/errors/errors_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/errors/errors_test.go
@@ -64,7 +64,7 @@ func TestErrorNew(t *testing.T) {
 	}
 
 	if !IsConflict(NewConflict(resource("tests"), "2", errors.New("message"))) {
-		t.Errorf("expected to be conflict")
+		t.Errorf("expected to be %s", metav1.StatusReasonAlreadyExists)
 	}
 	if !IsNotFound(NewNotFound(resource("tests"), "3")) {
 		t.Errorf("expected to be %s", metav1.StatusReasonNotFound)
@@ -86,6 +86,13 @@ func TestErrorNew(t *testing.T) {
 	}
 	if !IsMethodNotSupported(NewMethodNotSupported(resource("foos"), "delete")) {
 		t.Errorf("expected to be %s", metav1.StatusReasonMethodNotAllowed)
+	}
+
+	if !IsAlreadyExists(NewGenerateNameConflict(resource("tests"), "3", 1)) {
+		t.Errorf("expected to be %s", metav1.StatusReasonAlreadyExists)
+	}
+	if time, ok := SuggestsClientDelay(NewGenerateNameConflict(resource("tests"), "3", 1)); time != 1 || !ok {
+		t.Errorf("unexpected %d", time)
 	}
 
 	if time, ok := SuggestsClientDelay(NewServerTimeout(resource("tests"), "doing something", 10)); time != 10 || !ok {

--- a/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/store.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/store.go
@@ -404,7 +404,7 @@ func (e *Store) Create(ctx context.Context, obj runtime.Object, createValidation
 	out := e.NewFunc()
 	if err := e.Storage.Create(ctx, key, obj, out, ttl, dryrun.IsDryRun(options.DryRun)); err != nil {
 		err = storeerr.InterpretCreateError(err, qualifiedResource, name)
-		err = rest.CheckGeneratedNameError(e.CreateStrategy, err, obj)
+		err = rest.CheckGeneratedNameError(ctx, e.CreateStrategy, err, obj)
 		if !apierrors.IsAlreadyExists(err) {
 			return nil, err
 		}
@@ -659,7 +659,7 @@ func (e *Store) Update(ctx context.Context, name string, objInfo rest.UpdatedObj
 		}
 		if creating {
 			err = storeerr.InterpretCreateError(err, qualifiedResource, name)
-			err = rest.CheckGeneratedNameError(e.CreateStrategy, err, creatingObj)
+			err = rest.CheckGeneratedNameError(ctx, e.CreateStrategy, err, creatingObj)
 		} else {
 			err = storeerr.InterpretUpdateError(err, qualifiedResource, name)
 		}


### PR DESCRIPTION
Signed-off-by: Vince Prignano <vincepri@vmware.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind cleanup
/kind api-change
Marking this as api-change given that it's a behavioral change for clients, feel free to remove if it's not appropriate.

#### What this PR does / why we need it:

This PR solves a long standing issue where we now allow objects being created to have both name and generateName set. If the object already exists, the `CheckGeneratedNameError` function is called which can then throw a timeout error (500) instead of actually informing the user that the name generated has caused a conflict.

In alternative to the approach proposed in this PR, I've also considered allowing the both generatedName and name to be set, but give precedence to the name; this assumes user intent and we should probably discuss if that's the best way to move forward or not. If this is the case, we can also opt to completely remove the `CheckGeneratedNameError` like @lavalamp suggested in the related issue.

The current function throws the timeout error in two cases today:
- If the name was generated and it caused a conflict.
- If both `generatedName` and `name` are provided by the user and the object already exists.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #32220

#### Special notes for your reviewer:

- The current behavior might break a lot of clients out there, I'm happy to consider an option where we keep the current behavior and find a more backward compatible solution.
- The timeout error is very confusing, the underlying code is a `500`, which leads users to think there is something wrong with the api-server or underlying infrastructure.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
When creating an object with generateName, if a conflict occurs the server now returns an AlreadyExists error with a retry option.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
