### PR TITLE
kubelet: add last write time to static pod uid creation

### DIFF
--- a/pkg/kubelet/config/common.go
+++ b/pkg/kubelet/config/common.go
@@ -21,6 +21,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"strings"
+	"time"
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -53,7 +54,7 @@ func generatePodName(name string, nodeName types.NodeName) string {
 	return fmt.Sprintf("%s-%s", name, strings.ToLower(string(nodeName)))
 }
 
-func applyDefaults(pod *api.Pod, source string, isFile bool, nodeName types.NodeName) error {
+func applyDefaults(pod *api.Pod, source string, isFile bool, nodeName types.NodeName, lastWriteTime time.Time) error {
 	if len(pod.UID) == 0 {
 		hasher := md5.New()
 		hash.DeepHashObject(hasher, pod)
@@ -62,6 +63,7 @@ func applyDefaults(pod *api.Pod, source string, isFile bool, nodeName types.Node
 		if isFile {
 			fmt.Fprintf(hasher, "host:%s", nodeName)
 			fmt.Fprintf(hasher, "file:%s", source)
+			fmt.Fprintf(hasher, "lastWriteTime:%v", lastWriteTime.UTC())
 		} else {
 			fmt.Fprintf(hasher, "url:%s", source)
 		}

--- a/pkg/kubelet/config/http.go
+++ b/pkg/kubelet/config/http.go
@@ -79,7 +79,7 @@ func (s *sourceURL) run() {
 }
 
 func (s *sourceURL) applyDefaults(pod *api.Pod) error {
-	return applyDefaults(pod, s.url, false, s.nodeName)
+	return applyDefaults(pod, s.url, false, s.nodeName, time.Time{})
 }
 
 func (s *sourceURL) extractFromURL() error {


### PR DESCRIPTION
#### What type of PR is this?
/kind bug
/sig node
/priority important-soon

#### What this PR does / why we need it:
Fixes an issue where static pods could get stuck in a failure state due to the UID being the same during a create and delete operation. This patch mixes in the static pod's last modified time to the UID generation.
#### Which issue(s) this PR fixes:
Fixes #104648

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
Static pod UIDs are now generated with the write timestamp.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs

```
