### PR TITLE
test/integration/scheduler_perf: check for unused template parameters

### DIFF
--- a/test/integration/scheduler_perf/scheduler_perf_test.go
+++ b/test/integration/scheduler_perf/scheduler_perf_test.go
@@ -134,16 +134,16 @@ type workload struct {
 	// Name of the workload.
 	Name string
 	// Values of parameters used in the workloadTemplate.
-	Params Params
+	Params params
 }
 
-type Params struct {
+type params struct {
 	params map[string]int
 	// isUsed field records whether params is used or not.
 	isUsed map[string]bool
 }
 
-// UnmarshalJSON is a custom unmarshaler for Params.
+// UnmarshalJSON is a custom unmarshaler for params.
 //
 // from(json):
 // 	{
@@ -152,7 +152,7 @@ type Params struct {
 // 	}
 //
 // to:
-//	Params{
+//	params{
 //		params: map[string]int{
 //			"intNodes": 500,
 //			"initPods": 50,
@@ -160,7 +160,7 @@ type Params struct {
 //		isUsed: map[string]bool{}, // empty map
 //	}
 //
-func (p *Params) UnmarshalJSON(b []byte) error {
+func (p *params) UnmarshalJSON(b []byte) error {
 	aux := map[string]int{}
 
 	if err := json.Unmarshal(b, &aux); err != nil {
@@ -173,7 +173,7 @@ func (p *Params) UnmarshalJSON(b []byte) error {
 }
 
 // getParam gets param with key.
-func (p Params) getParam(key string) (int, error) {
+func (p params) getParam(key string) (int, error) {
 	p.isUsed[key] = true
 	param, ok := p.params[key]
 	if ok {

--- a/test/integration/scheduler_perf/scheduler_perf_test.go
+++ b/test/integration/scheduler_perf/scheduler_perf_test.go
@@ -816,8 +816,8 @@ func runWorkload(b *testing.B, tc *testCase, w *workload) []DataItem {
 
 	// check unused params and inform users
 	unusedParams := w.unusedParams()
-	for _, p := range unusedParams {
-		b.Logf("the parameter %s is defined on workload %s, but it is unused. Please make sure there are no typos.", p, w.Name)
+	if len(unusedParams) != 0 {
+		b.Fatalf("the parameters %v are defined on workload %s, but unused.\nPlease make sure there are no typos.", unusedParams, w.Name)
 	}
 
 	// Some tests have unschedulable pods. Do not add an implicit barrier at the

--- a/test/integration/scheduler_perf/scheduler_perf_test.go
+++ b/test/integration/scheduler_perf/scheduler_perf_test.go
@@ -172,8 +172,8 @@ func (p *params) UnmarshalJSON(b []byte) error {
 	return nil
 }
 
-// getParam gets param with key.
-func (p params) getParam(key string) (int, error) {
+// get returns param.
+func (p params) get(key string) (int, error) {
 	p.isUsed[key] = true
 	param, ok := p.params[key]
 	if ok {
@@ -284,7 +284,7 @@ func (*createNodesOp) collectsMetrics() bool {
 func (cno createNodesOp) patchParams(w *workload) (realOp, error) {
 	if cno.CountParam != "" {
 		var err error
-		cno.Count, err = w.Params.getParam(cno.CountParam[1:])
+		cno.Count, err = w.Params.get(cno.CountParam[1:])
 		if err != nil {
 			return nil, err
 		}
@@ -326,7 +326,7 @@ func (*createNamespacesOp) collectsMetrics() bool {
 func (cmo createNamespacesOp) patchParams(w *workload) (realOp, error) {
 	if cmo.CountParam != "" {
 		var err error
-		cmo.Count, err = w.Params.getParam(cmo.CountParam[1:])
+		cmo.Count, err = w.Params.get(cmo.CountParam[1:])
 		if err != nil {
 			return nil, err
 		}
@@ -386,7 +386,7 @@ func (cpo *createPodsOp) collectsMetrics() bool {
 func (cpo createPodsOp) patchParams(w *workload) (realOp, error) {
 	if cpo.CountParam != "" {
 		var err error
-		cpo.Count, err = w.Params.getParam(cpo.CountParam[1:])
+		cpo.Count, err = w.Params.get(cpo.CountParam[1:])
 		if err != nil {
 			return nil, err
 		}
@@ -428,7 +428,7 @@ func (cpso *createPodSetsOp) collectsMetrics() bool {
 func (cpso createPodSetsOp) patchParams(w *workload) (realOp, error) {
 	if cpso.CountParam != "" {
 		var err error
-		cpso.Count, err = w.Params.getParam(cpso.CountParam[1:])
+		cpso.Count, err = w.Params.get(cpso.CountParam[1:])
 		if err != nil {
 			return nil, err
 		}

--- a/test/integration/scheduler_perf/scheduler_perf_test.go
+++ b/test/integration/scheduler_perf/scheduler_perf_test.go
@@ -134,7 +134,63 @@ type workload struct {
 	// Name of the workload.
 	Name string
 	// Values of parameters used in the workloadTemplate.
-	Params map[string]int
+	Params Params
+}
+
+type Params struct {
+	params map[string]int
+	// isUsed field records whether params is used or not.
+	isUsed map[string]bool
+}
+
+// UnmarshalJSON is a custom unmarshaler for Params.
+//
+// from(json):
+// 	{
+// 		"initNodes": 500,
+// 		"initPods": 50
+// 	}
+//
+// to:
+//	Params{
+//		params: map[string]int{
+//			"intNodes": 500,
+//			"initPods": 50,
+//		},
+//		isUsed: map[string]bool{}, // empty map
+//	}
+//
+func (p *Params) UnmarshalJSON(b []byte) error {
+	aux := map[string]int{}
+
+	if err := json.Unmarshal(b, &aux); err != nil {
+		return err
+	}
+
+	p.params = aux
+	p.isUsed = map[string]bool{}
+	return nil
+}
+
+// getParam gets param with key.
+func (p Params) getParam(key string) (int, error) {
+	p.isUsed[key] = true
+	param, ok := p.params[key]
+	if ok {
+		return param, nil
+	}
+	return 0, fmt.Errorf("parameter %s is undefined", key)
+}
+
+// unusedParams returns the names of unusedParams
+func (w workload) unusedParams() []string {
+	var ret []string
+	for name := range w.Params.params {
+		if !w.Params.isUsed[name] {
+			ret = append(ret, name)
+		}
+	}
+	return ret
 }
 
 // op is a dummy struct which stores the real op in itself.
@@ -227,9 +283,10 @@ func (*createNodesOp) collectsMetrics() bool {
 
 func (cno createNodesOp) patchParams(w *workload) (realOp, error) {
 	if cno.CountParam != "" {
-		var ok bool
-		if cno.Count, ok = w.Params[cno.CountParam[1:]]; !ok {
-			return nil, fmt.Errorf("parameter %s is undefined", cno.CountParam)
+		var err error
+		cno.Count, err = w.Params.getParam(cno.CountParam[1:])
+		if err != nil {
+			return nil, err
 		}
 	}
 	return &cno, (&cno).isValid(false)
@@ -268,9 +325,10 @@ func (*createNamespacesOp) collectsMetrics() bool {
 
 func (cmo createNamespacesOp) patchParams(w *workload) (realOp, error) {
 	if cmo.CountParam != "" {
-		var ok bool
-		if cmo.Count, ok = w.Params[cmo.CountParam[1:]]; !ok {
-			return nil, fmt.Errorf("parameter %s is undefined", cmo.CountParam)
+		var err error
+		cmo.Count, err = w.Params.getParam(cmo.CountParam[1:])
+		if err != nil {
+			return nil, err
 		}
 	}
 	return &cmo, (&cmo).isValid(false)
@@ -327,9 +385,10 @@ func (cpo *createPodsOp) collectsMetrics() bool {
 
 func (cpo createPodsOp) patchParams(w *workload) (realOp, error) {
 	if cpo.CountParam != "" {
-		var ok bool
-		if cpo.Count, ok = w.Params[cpo.CountParam[1:]]; !ok {
-			return nil, fmt.Errorf("parameter %s is undefined", cpo.CountParam)
+		var err error
+		cpo.Count, err = w.Params.getParam(cpo.CountParam[1:])
+		if err != nil {
+			return nil, err
 		}
 	}
 	return &cpo, (&cpo).isValid(false)
@@ -368,9 +427,10 @@ func (cpso *createPodSetsOp) collectsMetrics() bool {
 
 func (cpso createPodSetsOp) patchParams(w *workload) (realOp, error) {
 	if cpso.CountParam != "" {
-		var ok bool
-		if cpso.Count, ok = w.Params[cpso.CountParam[1:]]; !ok {
-			return nil, fmt.Errorf("parameter %s is undefined", cpso.CountParam)
+		var err error
+		cpso.Count, err = w.Params.getParam(cpso.CountParam[1:])
+		if err != nil {
+			return nil, err
 		}
 	}
 	return &cpso, (&cpso).isValid(true)
@@ -753,6 +813,13 @@ func runWorkload(b *testing.B, tc *testCase, w *workload) []DataItem {
 			b.Fatalf("op %d: invalid op %v", opIndex, concreteOp)
 		}
 	}
+
+	// check unused params and inform users
+	unusedParams := w.unusedParams()
+	for _, p := range unusedParams {
+		b.Logf("the parameter %s is defined on workload %s, but it is unused. Please make sure there are no typos.", p, w.Name)
+	}
+
 	// Some tests have unschedulable pods. Do not add an implicit barrier at the
 	// end as we do not want to wait for them.
 	return dataItems


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind feature

#### What this PR does / why we need it:

Add check for unused template parameters on scheduler_perf test.
Unused params are informed to users like below

**performance-config.yaml**
```
- name: SchedulingBasic
  workloadTemplate:
  - opcode: createNodes
    countParam: $initNodes
  - opcode: createPods
    countParam: $initPods
    podTemplatePath: config/pod-default.yaml
  - opcode: createPods
    countParam: $measurePods
    podTemplatePath: config/pod-default.yaml
    collectMetrics: true
  workloads:
  - name: 500Nodes
    params:
      initNodes: 500
      unusedParam: 500 # this is unused param
      unusedParam2: 500 # this is unused param
      initPods: 500
      measurePods: 1000
```

**result**
```
--- FAIL: BenchmarkPerfScheduling/SchedulingBasic/500Nodes
    scheduler_perf_test.go:820: the parameters [unusedParam unusedParam2] are defined on workload 500Nodes, but unused.
        Please make sure there are no typos.


```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #94404 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
