### PR TITLE
Improve DeltaFIFO function 'ListKeys'

### DIFF
--- a/staging/src/k8s.io/client-go/tools/cache/delta_fifo.go
+++ b/staging/src/k8s.io/client-go/tools/cache/delta_fifo.go
@@ -458,8 +458,8 @@ func (f *DeltaFIFO) listLocked() []interface{} {
 func (f *DeltaFIFO) ListKeys() []string {
 	f.lock.RLock()
 	defer f.lock.RUnlock()
-	list := make([]string, 0, len(f.items))
-	for key := range f.items {
+	list := make([]string, 0, len(f.queue))
+	for _, key := range f.queue {
 		list = append(list, key)
 	}
 	return list

--- a/staging/src/k8s.io/client-go/tools/cache/delta_fifo_test.go
+++ b/staging/src/k8s.io/client-go/tools/cache/delta_fifo_test.go
@@ -694,3 +694,23 @@ func TestDeltaFIFO_PopShouldUnblockWhenClosed(t *testing.T) {
 		}
 	}
 }
+
+func BenchmarkDeltaFIFOListKeys(b *testing.B) {
+	f := NewDeltaFIFOWithOptions(DeltaFIFOOptions{KeyFunction: testFifoObjectKeyFunc})
+	const amount = 10000
+
+	for i := 0; i < amount; i++ {
+		f.Add(mkFifoObj(string([]rune{'a', rune(i)}), i+1))
+	}
+	for u := uint64(0); u < amount; u++ {
+		f.Add(mkFifoObj(string([]rune{'b', rune(u)}), u+1))
+	}
+
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			_ = f.ListKeys()
+		}
+	})
+	b.StopTimer()
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
In function ListKeys, it better to use ‘queue’ instead of 'items' to get all the keys.

Here is the reasons:
1. More efficient. After testing locally, it's nearly 5-10 times faster than using 'items', while the number of items in 'queue'/'items' is 10000 and the average time is obtained by 10000 repetitions in each testing. Since the type of 'items' is map, and the type of 'queue' is slice.
2. More reasonable. Although the keys are one-to-one correspondence in queue and items, it is more reasonable to get keys from the 'queue', since keys are queued in the 'queue' for processing by HandleDeltas, which reflects the idea of FIFO, and 'items' is considered as a kind of storage. Therefore, getting the keys from the 'queue' is more intuitive and easy to understand.
3. Ordered results. Golang maps is a collection of unordered pairs of key-value, thus the traversed key set from 'items' cannot reflect the queuing order of objects, but using 'queue' can provide this information.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:
benchmark results with DelfaFIFO:

current impl
```go
$ go test -test.bench DeltaFIFOListKeys -test.run DeltaFIFOListKeys -count=10
goos: darwin
goarch: amd64
pkg: k8s.io/client-go/tools/cache
cpu: Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
BenchmarkDeltaFIFOListKeys-12              77949             14921 ns/op
BenchmarkDeltaFIFOListKeys-12              82304             15016 ns/op
BenchmarkDeltaFIFOListKeys-12              82227             14624 ns/op
BenchmarkDeltaFIFOListKeys-12              80166             14884 ns/op
BenchmarkDeltaFIFOListKeys-12              83228             14847 ns/op
BenchmarkDeltaFIFOListKeys-12              80178             15167 ns/op
BenchmarkDeltaFIFOListKeys-12              80023             14952 ns/op
BenchmarkDeltaFIFOListKeys-12              78912             15647 ns/op
BenchmarkDeltaFIFOListKeys-12              73502             16353 ns/op
BenchmarkDeltaFIFOListKeys-12              73690             16669 ns/op
PASS
ok      k8s.io/client-go/tools/cache    14.151s
```
pull request impl
```go
$ go test -test.bench DeltaFIFOListKeys -test.run DeltaFIFOListKeys -count=10
goos: darwin
goarch: amd64
pkg: k8s.io/client-go/tools/cache
cpu: Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
BenchmarkDeltaFIFOListKeys-12             161652              7621 ns/op
BenchmarkDeltaFIFOListKeys-12             156442              7468 ns/op
BenchmarkDeltaFIFOListKeys-12             158258              7577 ns/op
BenchmarkDeltaFIFOListKeys-12             159350              7639 ns/op
BenchmarkDeltaFIFOListKeys-12             156450              8074 ns/op
BenchmarkDeltaFIFOListKeys-12             160190              7664 ns/op
BenchmarkDeltaFIFOListKeys-12             159818              7426 ns/op
BenchmarkDeltaFIFOListKeys-12             156006              7522 ns/op
BenchmarkDeltaFIFOListKeys-12             169120              7368 ns/op
BenchmarkDeltaFIFOListKeys-12             151201              7358 ns/op
PASS
ok      k8s.io/client-go/tools/cache    13.005s
```
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
