### PR TITLE
gets hostIPs(v1.NodeInternalIP and v1.NodeExternalIP) in a code block

### DIFF
--- a/pkg/util/node/node.go
+++ b/pkg/util/node/node.go
@@ -102,15 +102,7 @@ func GetNodeHostIPs(node *v1.Node) ([]net.IP, error) {
 	// Re-sort the addresses with InternalIPs first and then ExternalIPs
 	allIPs := make([]net.IP, 0, len(node.Status.Addresses))
 	for _, addr := range node.Status.Addresses {
-		if addr.Type == v1.NodeInternalIP {
-			ip := netutils.ParseIPSloppy(addr.Address)
-			if ip != nil {
-				allIPs = append(allIPs, ip)
-			}
-		}
-	}
-	for _, addr := range node.Status.Addresses {
-		if addr.Type == v1.NodeExternalIP {
+		if addr.Type == v1.NodeInternalIP || addr.Type == v1.NodeExternalIP {
 			ip := netutils.ParseIPSloppy(addr.Address)
 			if ip != nil {
 				allIPs = append(allIPs, ip)


### PR DESCRIPTION
What type of PR is this?
/kind bug

What this PR does / why we need it:
gets hostIPs(v1.NodeInternalIP and v1.NodeExternalIP) in a code block for better performance.

Which issue(s) this PR fixes:

Special notes for your reviewer:

Does this PR introduce a user-facing change?
```release-notes
NONE
```
Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```release-notes
NONE
```