### PR TITLE
Setting DescribedObject for AverageValue-based ObjectMetrics.

### DIFF
--- a/pkg/controller/podautoscaler/horizontal.go
+++ b/pkg/controller/podautoscaler/horizontal.go
@@ -402,6 +402,7 @@ func (a *HorizontalController) computeStatusForObjectMetric(specReplicas, status
 		*status = autoscalingv2.MetricStatus{
 			Type: autoscalingv2.ObjectMetricSourceType,
 			Object: &autoscalingv2.ObjectMetricStatus{
+				DescribedObject: metricSpec.Object.DescribedObject,
 				Metric: autoscalingv2.MetricIdentifier{
 					Name:     metricSpec.Object.Metric.Name,
 					Selector: metricSpec.Object.Metric.Selector,


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

If an HPA is created based on an Object metric, using an averageValue, HPA status does not populate describedObject properly, resulting in empty fields:
```
currentMetrics:
  - object:
[...]
      describedObject:
        kind: ""
        name: ""
```

This PR adds missing field population when creating ObjectMetricStatus object.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
