### PR TITLE
Beautify kubectl help flag commands

### DIFF
--- a/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/print_flags.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/print_flags.go
@@ -136,7 +136,7 @@ func (f *PrintFlags) AddFlags(cmd *cobra.Command) {
 	f.TemplatePrinterFlags.AddFlags(cmd)
 
 	if f.OutputFormat != nil {
-		cmd.Flags().StringVarP(f.OutputFormat, "output", "o", *f.OutputFormat, fmt.Sprintf("Output format. One of: %s.", strings.Join(f.AllowedFormats(), "|")))
+		cmd.Flags().StringVarP(f.OutputFormat, "output", "o", *f.OutputFormat, fmt.Sprintf(`Output format. One of: (%s).`, strings.Join(f.AllowedFormats(), ", ")))
 		if f.OutputFlagSpecified == nil {
 			f.OutputFlagSpecified = func() bool {
 				return cmd.Flag("output").Changed

--- a/staging/src/k8s.io/kubectl/pkg/cmd/apiresources/apiresources.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/apiresources/apiresources.go
@@ -105,7 +105,7 @@ func NewCmdAPIResources(f cmdutil.Factory, ioStreams genericclioptions.IOStreams
 	}
 
 	cmd.Flags().BoolVar(&o.NoHeaders, "no-headers", o.NoHeaders, "When using the default or custom-column output format, don't print headers (default print headers).")
-	cmd.Flags().StringVarP(&o.Output, "output", "o", o.Output, "Output format. One of: wide|name.")
+	cmd.Flags().StringVarP(&o.Output, "output", "o", o.Output, `Output format. One of: (wide, name).`)
 
 	cmd.Flags().StringVar(&o.APIGroup, "api-group", o.APIGroup, "Limit to resources in the specified API group.")
 	cmd.Flags().BoolVar(&o.Namespaced, "namespaced", o.Namespaced, "If false, non-namespaced resources will be returned, otherwise returning namespaced resources by default.")

--- a/staging/src/k8s.io/kubectl/pkg/cmd/apply/apply_view_last_applied.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/apply/apply_view_last_applied.go
@@ -85,7 +85,7 @@ func NewCmdApplyViewLastApplied(f cmdutil.Factory, ioStreams genericclioptions.I
 		},
 	}
 
-	cmd.Flags().StringVarP(&options.OutputFormat, "output", "o", options.OutputFormat, "Output format. Must be one of yaml|json")
+	cmd.Flags().StringVarP(&options.OutputFormat, "output", "o", options.OutputFormat, `Output format. Must be one of (yaml, json)`)
 	cmd.Flags().BoolVar(&options.All, "all", options.All, "Select all resources in the namespace of the specified resource types")
 	usage := "that contains the last-applied-configuration annotations"
 	cmdutil.AddFilenameOptionFlags(cmd, &options.FilenameOptions, usage)

--- a/staging/src/k8s.io/kubectl/pkg/cmd/config/get_contexts.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/config/get_contexts.go
@@ -80,7 +80,7 @@ func NewCmdConfigGetContexts(streams genericclioptions.IOStreams, configAccess c
 	}
 
 	cmd.Flags().Bool("no-headers", false, "When using the default or custom-column output format, don't print headers (default print headers).")
-	cmd.Flags().StringP("output", "o", "", "Output format. One of: name")
+	cmd.Flags().StringP("output", "o", "", `Output format. One of: (name).`)
 	return cmd
 }
 

--- a/staging/src/k8s.io/kubectl/pkg/cmd/get/get_flags.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/get/get_flags.go
@@ -162,7 +162,7 @@ func (f *PrintFlags) AddFlags(cmd *cobra.Command) {
 	f.CustomColumnsFlags.AddFlags(cmd)
 
 	if f.OutputFormat != nil {
-		cmd.Flags().StringVarP(f.OutputFormat, "output", "o", *f.OutputFormat, fmt.Sprintf("Output format. One of: %s See custom columns [https://kubernetes.io/docs/reference/kubectl/overview/#custom-columns], golang template [http://golang.org/pkg/text/template/#pkg-overview] and jsonpath template [https://kubernetes.io/docs/reference/kubectl/jsonpath/].", strings.Join(f.AllowedFormats(), "|")))
+		cmd.Flags().StringVarP(f.OutputFormat, "output", "o", *f.OutputFormat, fmt.Sprintf(`Output format. One of: (%s). See custom columns [https://kubernetes.io/docs/reference/kubectl/overview/#custom-columns], golang template [http://golang.org/pkg/text/template/#pkg-overview] and jsonpath template [https://kubernetes.io/docs/reference/kubectl/jsonpath/].`, strings.Join(f.AllowedFormats(), ", ")))
 		util.CheckErr(cmd.RegisterFlagCompletionFunc(
 			"output",
 			func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {

--- a/staging/src/k8s.io/kubectl/pkg/util/templates/help_flags_printer.go
+++ b/staging/src/k8s.io/kubectl/pkg/util/templates/help_flags_printer.go
@@ -1,0 +1,76 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package templates
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/mitchellh/go-wordwrap"
+	flag "github.com/spf13/pflag"
+)
+
+const offset = 10
+
+// HelpFlagPrinter is a printer that
+// processes the help flag and print
+// it to i/o writer
+type HelpFlagPrinter struct {
+	wrapLimit uint
+	out       io.Writer
+}
+
+// NewHelpFlagPrinter will initialize a HelpFlagPrinter given the
+// i/o writer
+func NewHelpFlagPrinter(out io.Writer, wrapLimit uint) *HelpFlagPrinter {
+	return &HelpFlagPrinter{
+		wrapLimit: wrapLimit,
+		out:       out,
+	}
+}
+
+// PrintHelpFlag will beautify the help flags and print it out to p.out
+func (p *HelpFlagPrinter) PrintHelpFlag(flag *flag.Flag) {
+	formatBuf := new(bytes.Buffer)
+	writeFlag(formatBuf, flag)
+
+	wrappedStr := formatBuf.String()
+	flagAndUsage := strings.Split(formatBuf.String(), "\n")
+	flagStr := flagAndUsage[0]
+
+	// if the flag usage is longer than one line, wrap it again
+	if len(flagAndUsage) > 1 {
+		nextLines := strings.Join(flagAndUsage[1:], " ")
+		wrappedUsages := wordwrap.WrapString(nextLines, p.wrapLimit-offset)
+		wrappedStr = flagStr + "\n" + wrappedUsages
+	}
+	appendTabStr := strings.ReplaceAll(wrappedStr, "\n", "\n\t")
+
+	fmt.Fprintf(p.out, appendTabStr+"\n\n")
+}
+
+// writeFlag will output the help flag based
+// on the format provided by getFlagFormat to i/o writer
+func writeFlag(out io.Writer, f *flag.Flag) {
+	deprecated := ""
+	if f.Deprecated != "" {
+		deprecated = fmt.Sprintf(" (DEPRECATED: %s)", f.Deprecated)
+	}
+	fmt.Fprintf(out, getFlagFormat(f), f.Shorthand, f.Name, f.DefValue, f.Usage, deprecated)
+}

--- a/staging/src/k8s.io/kubectl/pkg/util/templates/templater.go
+++ b/staging/src/k8s.io/kubectl/pkg/util/templates/templater.go
@@ -23,10 +23,10 @@ import (
 	"text/template"
 	"unicode"
 
-	"k8s.io/kubectl/pkg/util/term"
-
 	"github.com/spf13/cobra"
 	flag "github.com/spf13/pflag"
+
+	"k8s.io/kubectl/pkg/util/term"
 )
 
 type FlagExposer interface {
@@ -160,7 +160,7 @@ func (t *templater) cmdGroupsString(c *cobra.Command) string {
 		cmds := []string{cmdGroup.Message}
 		for _, cmd := range cmdGroup.Commands {
 			if cmd.IsAvailableCommand() {
-				cmds = append(cmds, "  "+rpad(cmd.Name(), cmd.NamePadding())+" "+cmd.Short)
+				cmds = append(cmds, "  "+rpad(cmd.Name(), cmd.NamePadding())+"   "+cmd.Short)
 			}
 		}
 		groups = append(groups, strings.Join(cmds, "\n"))
@@ -218,34 +218,40 @@ func (t *templater) usageLine(c *cobra.Command) string {
 	return usage
 }
 
-func flagsUsages(f *flag.FlagSet) string {
-	x := new(bytes.Buffer)
+// flagsUsages will print out the kubectl help flags
+func flagsUsages(f *flag.FlagSet) (string, error) {
+	flagBuf := new(bytes.Buffer)
+	wrapLimit, err := term.GetWordWrapperLimit()
+	if err != nil {
+		return "", err
+	}
+	printer := NewHelpFlagPrinter(flagBuf, wrapLimit)
 
 	f.VisitAll(func(flag *flag.Flag) {
 		if flag.Hidden {
 			return
 		}
-		format := "--%s=%s: %s%s\n"
-
-		if flag.Value.Type() == "string" {
-			format = "--%s='%s': %s%s\n"
-		}
-
-		if len(flag.Shorthand) > 0 {
-			format = "  -%s, " + format
-		} else {
-			format = "   %s   " + format
-		}
-
-		deprecated := ""
-		if flag.Deprecated != "" {
-			deprecated = fmt.Sprintf(" (DEPRECATED: %s)", flag.Deprecated)
-		}
-
-		fmt.Fprintf(x, format, flag.Shorthand, flag.Name, flag.DefValue, flag.Usage, deprecated)
+		printer.PrintHelpFlag(flag)
 	})
 
-	return x.String()
+	return flagBuf.String(), nil
+}
+
+// getFlagFormat will output the flag format
+func getFlagFormat(f *flag.Flag) string {
+	var format string
+	format = "--%s=%s:\n%s%s"
+	if f.Value.Type() == "string" {
+		format = "--%s='%s':\n%s%s"
+	}
+
+	if len(f.Shorthand) > 0 {
+		format = "    -%s, " + format
+	} else {
+		format = "    %s" + format
+	}
+
+	return format
 }
 
 func rpad(s string, padding int) string {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind design


#### What this PR does / why we need it:
Make the help flags of kubectl more readable / user friendly

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes/kubectl/issues/1069

#### Special notes for your reviewer:

Before,
```
Apply a configuration to a resource by file name or stdin. The resource name must be specified. This
resource will be created if it doesn't exist yet. To use 'apply', always create the resource
initially with either 'apply' or 'create --save-config'.

 JSON and YAML formats are accepted.

 Alpha Disclaimer: the --prune functionality is not yet complete. Do not use unless you are aware of
what the current state is. See https://issues.k8s.io/34274.

Examples:
  # Apply the configuration in pod.json to a pod
  kubectl apply -f ./pod.json
  
  # Apply resources from a directory containing kustomization.yaml - e.g. dir/kustomization.yaml
  kubectl apply -k dir/
  
  # Apply the JSON passed into stdin to a pod
  cat pod.json | kubectl apply -f -
  
  # Note: --prune is still in Alpha
  # Apply the configuration in manifest.yaml that matches label app=nginx and delete all other
resources that are not in the file and match label app=nginx
  kubectl apply --prune -f manifest.yaml -l app=nginx
  
  # Apply the configuration in manifest.yaml and delete all the other config maps that are not in
the file
  kubectl apply --prune -f manifest.yaml --all --prune-whitelist=core/v1/ConfigMap

Available Commands:
  edit-last-applied Edit latest last-applied-configuration annotations of a resource/object
  set-last-applied  Set the last-applied-configuration annotation on a live object to match the
contents of a file
  view-last-applied View the latest last-applied-configuration annotations of a resource/object

Options:
      --all=false: Select all resources in the namespace of the specified resource types.
      --allow-missing-template-keys=true: If true, ignore any errors in templates when a field or
map key is missing in the template. Only applies to golang and jsonpath output formats.
      --cascade='background': Must be "background", "orphan", or "foreground". Selects the deletion
cascading strategy for the dependents (e.g. Pods created by a ReplicationController). Defaults to
background.
      --dry-run='none': Must be "none", "server", or "client". If client strategy, only print the
object that would be sent, without sending it. If server strategy, submit server-side request
without persisting the resource.
      --field-manager='kubectl-client-side-apply': Name of the manager used to track field
ownership.
  -f, --filename=[]: that contains the configuration to apply
      --force=false: If true, immediately remove resources from API and bypass graceful deletion.
Note that immediate deletion of some resources may result in inconsistency or data loss and requires
confirmation.
      --force-conflicts=false: If true, server-side apply will force the changes against conflicts.
      --grace-period=-1: Period of time in seconds given to the resource to terminate gracefully.
Ignored if negative. Set to 1 for immediate shutdown. Can only be set to 0 when --force is true
(force deletion).
  -k, --kustomize='': Process a kustomization directory. This flag can't be used together with -f or
-R.
      --openapi-patch=true: If true, use openapi to calculate diff when the openapi presents and the
resource can be found in the openapi spec. Otherwise, fall back to use baked-in types.
  -o, --output='': Output format. One of:
json|yaml|name|go-template|go-template-file|template|templatefile|jsonpath|jsonpath-as-json|jsonpath-file.
      --overwrite=true: Automatically resolve conflicts between the modified and live configuration
by using values from the modified configuration
      --prune=false: Automatically delete resource objects, including the uninitialized ones, that
do not appear in the configs and are created by either apply or create --save-config. Should be used
with either -l or --all.
      --prune-whitelist=[]: Overwrite the default whitelist with <group/version/kind> for --prune
  -R, --recursive=false: Process the directory used in -f, --filename recursively. Useful when you
want to manage related manifests organized within the same directory.
  -l, --selector='': Selector (label query) to filter on, supports '=', '==', and '!='.(e.g. -l
key1=value1,key2=value2)
      --server-side=false: If true, apply runs in the server instead of the client.
      --show-managed-fields=false: If true, keep the managedFields when printing objects in JSON or
YAML format.
      --template='': Template string or path to template file to use when -o=go-template,
-o=go-template-file. The template format is golang templates
[http://golang.org/pkg/text/template/#pkg-overview].
      --timeout=0s: The length of time to wait before giving up on a delete, zero means determine a
timeout from the size of the object
      --validate=true: If true, use a schema to validate the input before sending it
      --wait=false: If true, wait for resources to be gone before returning. This waits for
finalizers.

Usage:
  kubectl apply (-f FILENAME | -k DIRECTORY) [options]

Use "kubectl <command> --help" for more information about a given command.
Use "kubectl options" for a list of global command-line options (applies to all commands).

```

After,
```
Apply a configuration to a resource by file name or stdin. The resource name must be specified. This resource will be
created if it doesn't exist yet. To use 'apply', always create the resource initially with either 'apply' or 'create
--save-config'.

 JSON and YAML formats are accepted.

 Alpha Disclaimer: the --prune functionality is not yet complete. Do not use unless you are aware of what the current
state is. See https://issues.k8s.io/34274.

Examples:
  # Apply the configuration in pod.json to a pod
  kubectl apply -f ./pod.json
  
  # Apply resources from a directory containing kustomization.yaml - e.g. dir/kustomization.yaml
  kubectl apply -k dir/
  
  # Apply the JSON passed into stdin to a pod
  cat pod.json | kubectl apply -f -
  
  # Note: --prune is still in Alpha
  # Apply the configuration in manifest.yaml that matches label app=nginx and delete all other resources that are not in
the file and match label app=nginx
  kubectl apply --prune -f manifest.yaml -l app=nginx
  
  # Apply the configuration in manifest.yaml and delete all the other config maps that are not in the file
  kubectl apply --prune -f manifest.yaml --all --prune-whitelist=core/v1/ConfigMap

Available Commands:
  edit-last-applied   Edit latest last-applied-configuration annotations of a resource/object
  set-last-applied    Set the last-applied-configuration annotation on a live object to match the contents of a file
  view-last-applied   View the latest last-applied-configuration annotations of a resource/object

Options:
    --all=false:
	Select all resources in the namespace of the specified resource types.

    --allow-missing-template-keys=true:
	If true, ignore any errors in templates when a field or map key is missing in the template. Only applies to
	golang and jsonpath output formats.

    --cascade='background':
	Must be "background", "orphan", or "foreground". Selects the deletion cascading strategy for the dependents
	(e.g. Pods created by a ReplicationController). Defaults to background.

    --dry-run='none':
	Must be "none", "server", or "client". If client strategy, only print the object that would be sent, without
	sending it. If server strategy, submit server-side request without persisting the resource.

    --field-manager='kubectl-client-side-apply':
	Name of the manager used to track field ownership.

    -f, --filename=[]:
	that contains the configuration to apply

    --force=false:
	If true, immediately remove resources from API and bypass graceful deletion. Note that immediate deletion of
	some resources may result in inconsistency or data loss and requires confirmation.

    --force-conflicts=false:
	If true, server-side apply will force the changes against conflicts.

    --grace-period=-1:
	Period of time in seconds given to the resource to terminate gracefully. Ignored if negative. Set to 1 for
	immediate shutdown. Can only be set to 0 when --force is true (force deletion).

    -k, --kustomize='':
	Process a kustomization directory. This flag can't be used together with -f or -R.

    --openapi-patch=true:
	If true, use openapi to calculate diff when the openapi presents and the resource can be found in the openapi
	spec. Otherwise, fall back to use baked-in types.

    -o, --output='':
	Output format. One of: (json, yaml, name, go-template, go-template-file, template, templatefile, jsonpath,
	jsonpath-as-json, jsonpath-file).

    --overwrite=true:
	Automatically resolve conflicts between the modified and live configuration by using values from the modified
	configuration

    --prune=false:
	Automatically delete resource objects, that do not appear in the configs and are created by either apply or
	create --save-config. Should be used with either -l or --all.

    --prune-whitelist=[]:
	Overwrite the default whitelist with <group/version/kind> for --prune

    -R, --recursive=false:
	Process the directory used in -f, --filename recursively. Useful when you want to manage related manifests
	organized within the same directory.

    -l, --selector='':
	Selector (label query) to filter on, supports '=', '==', and '!='.(e.g. -l key1=value1,key2=value2). Matching
	objects must satisfy all of the specified label constraints.

    --server-side=false:
	If true, apply runs in the server instead of the client.

    --show-managed-fields=false:
	If true, keep the managedFields when printing objects in JSON or YAML format.

    --template='':
	Template string or path to template file to use when -o=go-template, -o=go-template-file. The template format
	is golang templates [http://golang.org/pkg/text/template/#pkg-overview].

    --timeout=0s:
	The length of time to wait before giving up on a delete, zero means determine a timeout from the size of the
	object

    --validate=true:
	If true, use a schema to validate the input before sending it

    --wait=false:
	If true, wait for resources to be gone before returning. This waits for finalizers.

Usage:
  kubectl apply (-f FILENAME | -k DIRECTORY) [options]

Use "kubectl <command> --help" for more information about a given command.
Use "kubectl options" for a list of global command-line options (applies to all commands).


```

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Improve kubectl's user help commands readability 
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
