### PR TITLE
Fix err of GrabFromAPIServer()

### DIFF
--- a/test/e2e/framework/metrics/metrics_grabber.go
+++ b/test/e2e/framework/metrics/metrics_grabber.go
@@ -318,7 +318,7 @@ func (g *Grabber) GrabFromSnapshotController(podName string, port int) (Snapshot
 func (g *Grabber) GrabFromAPIServer() (APIServerMetrics, error) {
 	output, err := g.getMetricsFromAPIServer()
 	if err != nil {
-		return APIServerMetrics{}, nil
+		return APIServerMetrics{}, err
 	}
 	return parseAPIServerMetrics(output)
 }


### PR DESCRIPTION

#### What type of PR is this?

/kind bug
/kind cleanup

#### What this PR does / why we need it:

If getting an error from internal funcation call, GrabFromAPIServer() didn't return it to the caller.
This fixes it.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

