### PR TITLE
DO NOT MERGE: Additional resource quantity testing

### DIFF
--- a/pkg/scheduler/metrics/resources/resources_test.go
+++ b/pkg/scheduler/metrics/resources/resources_test.go
@@ -71,7 +71,7 @@ func Test_podResourceCollector_Handler(t *testing.T) {
 							"custom": resource.MustParse("0"),
 						},
 						Limits: v1.ResourceList{
-							"memory": resource.MustParse("2G"),
+							"memory": resource.MustParse("2.5Gi"),
 							"custom": resource.MustParse("6"),
 						},
 					}},
@@ -95,7 +95,7 @@ func Test_podResourceCollector_Handler(t *testing.T) {
 	expected := `# HELP kube_pod_resource_limit [ALPHA] Resources limit for workloads on the cluster, broken down by pod. This shows the resource usage the scheduler and kubelet expect per pod for resources along with the unit for the resource if any.
 # TYPE kube_pod_resource_limit gauge
 kube_pod_resource_limit{namespace="test",node="node-one",pod="foo",priority="",resource="custom",scheduler="",unit=""} 6
-kube_pod_resource_limit{namespace="test",node="node-one",pod="foo",priority="",resource="memory",scheduler="",unit="bytes"} 2e+09
+kube_pod_resource_limit{namespace="test",node="node-one",pod="foo",priority="",resource="memory",scheduler="",unit="bytes"} 2.68435456e+09
 # HELP kube_pod_resource_request [ALPHA] Resources requested by workloads on the cluster, broken down by pod. This shows the resource usage the scheduler and kubelet expect per pod for resources along with the unit for the resource if any.
 # TYPE kube_pod_resource_request gauge
 kube_pod_resource_request{namespace="test",node="node-one",pod="foo",priority="",resource="cpu",scheduler="",unit="cores"} 2

--- a/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity.go
@@ -460,17 +460,7 @@ func (q *Quantity) AsApproximateFloat64() float64 {
 		return base
 	}
 
-	// multiply by the appropriate exponential scale
-	switch q.Format {
-	case DecimalExponent, DecimalSI:
-		return base * math.Pow10(exponent)
-	default:
-		// fast path for exponents that can fit in 64 bits
-		if exponent > 0 && exponent < 7 {
-			return base * float64(int64(1)<<(exponent*10))
-		}
-		return base * math.Pow(2, float64(exponent*10))
-	}
+	return base * math.Pow10(exponent)
 }
 
 // AsInt64 returns a representation of the current value as an int64 if a fast conversion


### PR DESCRIPTION
Fractional binary SI quantities that cannot be represented as decimal
internally were incorrectly calculated.

Additional test for #103751