### PR TITLE
Improve create configmap test

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_configmap_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_configmap_test.go
@@ -21,6 +21,8 @@ import (
 	"os"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	corev1 "k8s.io/api/core/v1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -441,21 +443,18 @@ func TestCreateConfigMap(t *testing.T) {
 				}
 			}
 			err := configMapOptions.Validate()
+
 			if err == nil {
 				configMap, err = configMapOptions.createConfigMap()
 			}
-
-			if test.expectErr == "" && err != nil {
-				t.Errorf("unexpected error: %v", err)
-			}
-			if test.expectErr != "" && err == nil {
-				t.Errorf("was expecting an error but no error occurred")
-			}
-			if test.expectErr != "" && test.expectErr != err.Error() {
-				t.Errorf("\nexpected error:\n%s\ngot error:\n%s", test.expectErr, err.Error())
-			}
-			if !apiequality.Semantic.DeepEqual(configMap, test.expected) {
-				t.Errorf("\nexpected:\n%#v\ngot:\n%#v", test.expected, configMap)
+			if test.expectErr == "" {
+				require.NoError(t, err)
+				if !apiequality.Semantic.DeepEqual(configMap, test.expected) {
+					t.Errorf("\nexpected:\n%#v\ngot:\n%#v", test.expected, configMap)
+				}
+			} else {
+				require.Error(t, err)
+				require.EqualError(t, err, test.expectErr)
 			}
 		})
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?


/kind cleanup


#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:
This will fix the panic when we are expecting error `expectErr != ""` but the `err` is `nil` 
```
if test.expectErr != "" && test.expectErr != err.Error()
```

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
