### PR TITLE
fix redundant process endpintslice changes, such as A->B->A.

### DIFF
--- a/pkg/proxy/endpointslicecache.go
+++ b/pkg/proxy/endpointslicecache.go
@@ -319,7 +319,12 @@ func (cache *EndpointSliceCache) esInfoChanged(serviceKey types.NamespacedName, 
 		// If there's already a pending value, return whether or not this would
 		// change that.
 		if pendingOk {
-			return !reflect.DeepEqual(esInfo, pendingInfo)
+			pendingChanged := !reflect.DeepEqual(esInfo, pendingInfo)
+			// A->B->A
+			if pendingChanged && appliedOk {
+				return !reflect.DeepEqual(esInfo, appliedInfo)
+			}
+			return pendingChanged
 		}
 
 		// If there's already an applied value, return whether or not this would


### PR DESCRIPTION
#### What type of PR is this?
/kind bug


#### What this PR does / why we need it:
There is a situation that will cause redundant processing changes of endpointslice, for example,  when the current changes are different from pending, but are the same as the changes in applied, I think there is no need to process them anymore. In other words, a scene like A->B->A does not need to be processed.


#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:


#### Does this PR introduce a user-facing change?

```release-note
None
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs

```
