### PR TITLE
Don't apply cluster TLS options to connections to HTTPS proxy

### DIFF
--- a/staging/src/k8s.io/client-go/transport/cache.go
+++ b/staging/src/k8s.io/client-go/transport/cache.go
@@ -17,6 +17,7 @@ limitations under the License.
 package transport
 
 import (
+	"crypto/tls"
 	"fmt"
 	"net"
 	"net/http"
@@ -117,6 +118,14 @@ func (c *tlsTransportCache) get(config *Config) (http.RoundTripper, error) {
 		DialContext:         dial,
 		DisableCompression:  config.DisableCompression,
 	})
+
+	if config.Proxy != nil {
+		// DialTLSContext provides an optional dial function for non-proxied HTTPS requests.
+		// The function will be used for connections to the proxy if the proxy itself is using HTTPS.
+		// In this case TLSClientConfig and TLSHandshakeTimeout will be ignored for connections to the proxy.
+		// We do this because we don't want options such as tls-server-name to be applied to the proxy connection.
+		transport.DialTLSContext = (&tls.Dialer{}).DialContext
+	}
 
 	if canCache {
 		// Cache a single transport for these options


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind bug

#### What this PR does / why we need it:

Currently TLS-related options such as `tls-server-name` and `certificate-authority-data` which are meant to be applied to connections to the cluster are applied to connections to HTTPS proxies as well. Note: I don't mean (unencrypted) HTTP proxies that support HTTPS via CONNECT - I mean cases where the proxy itself is reachable via HTTPS (and supports CONNECT - basically TLS in TLS - this is useful when the proxy requires authentication and you don't want to send proxy credentials over an unencrypted connection).

For example, a Kube config entry like this:

```yaml
clusters:
  - name: example
    cluster:
      # Proxy can be set in Kube config or via HTTPS_PROXY environment variable
      proxy-url: https://user:token@proxy.example.com
      server: https://10.1.1.1:6443
      # These options are meant to be applied to connections to the cluster only
      tls-server-name: kube-apiserver.cluster.internal
      certificate-authority-data: ...
```

...could produce this error:

```sh
# kubectl get nodes
Unable to connect to the server: proxyconnect tcp: x509: certificate is valid for proxy.example.com, not kube-apiserver.cluster.internal
```



#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

#### Special notes for your reviewer:

I could have added this to the existing `if config.Proxy != nil` block above (in `cache.go`) but then I would have had to add more imports and the whole `DialContext()` function signature (for the variable declaration). It seemed nicer this way.

Might want to read the docs for `DialTLSContext()`: https://pkg.go.dev/net/http#Transport.Proxy

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fixed a bug that caused TLS-related options for the cluster to be applied to HTTPS proxies as well
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
