### PR TITLE
Fix shellcheck output streams

### DIFF
--- a/hack/verify-shellcheck.sh
+++ b/hack/verify-shellcheck.sh
@@ -102,16 +102,18 @@ SHELLCHECK_OPTIONS=(
 )
 
 # tell the user which we've selected and lint all scripts
+# The shellcheck errors are printed to stdout by default, hence they need to be redirected
+# to stderr in order to be well parsed for Junit representation by juLog function
 res=0
 if ${HAVE_SHELLCHECK}; then
   echo "Using host shellcheck ${SHELLCHECK_VERSION} binary."
-  shellcheck "${SHELLCHECK_OPTIONS[@]}" "${all_shell_scripts[@]}" || res=$?
+  shellcheck "${SHELLCHECK_OPTIONS[@]}" "${all_shell_scripts[@]}" >&2 || res=$?
 else
   echo "Using shellcheck ${SHELLCHECK_VERSION} docker image."
   "${DOCKER}" run \
     --rm -v "${KUBE_ROOT}:${KUBE_ROOT}" -w "${KUBE_ROOT}" \
     "${SHELLCHECK_IMAGE}" \
-  shellcheck "${SHELLCHECK_OPTIONS[@]}" "${all_shell_scripts[@]}" || res=$?
+  shellcheck "${SHELLCHECK_OPTIONS[@]}" "${all_shell_scripts[@]}" >&2 || res=$?
 fi
 
 # print a message based on the result


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind documentation
/kind failing-test

#### What this PR does / why we need it:

`shellcheck` errors are printed to stdout by default, hence they need to be redirected
to stderr in order to be well parsed for Junit representation by `juLog` function.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #102975

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

Now the generated Junit would have the correct failures in it to be shown later on by Spyglass:
```xml
<?xml version="1.0" encoding="UTF-8"?>
<testsuites>
    <testsuite failures="1" assertions="" name="verify" tests="1" errors="1" time="33.3179">
    
    <testcase assertions="1" name="shellcheck" time="33.3179" classname="verify">
    
      <failure type="ScriptError" message="Script Error"><![CDATA[
In ./hack/verify-shellcheck.sh line 25:
BLA=3
^-^ SC2034: BLA appears unused. Verify use (or export if used externally).

For more information:
  https://www.shellcheck.net/wiki/SC2034 -- BLA appears unused. Verify use (o...]]></failure>
  
    <system-err><![CDATA[
In ./hack/verify-shellcheck.sh line 25:
BLA=3
^-^ SC2034: BLA appears unused. Verify use (or export if used externally).

For more information:
  https://www.shellcheck.net/wiki/SC2034 -- BLA appears unused. Verify use (o...]]></system-err>
    </testcase>
  
    </testsuite>
</testsuites>
```
