### PR TITLE
server-side-apply: print object name in SHOULD NOT HAPPEN message

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/fieldmanager.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/fieldmanager.go
@@ -194,8 +194,15 @@ func (f *FieldManager) UpdateNoErrors(liveObj, newObj runtime.Object, manager st
 	obj, err := f.Update(liveObj, newObj, manager)
 	if err != nil {
 		atMostEverySecond.Do(func() {
+			ns, name := "unknown", "unknown"
+			accessor, err := meta.Accessor(newObj)
+			if err == nil {
+				ns = accessor.GetNamespace()
+				name = accessor.GetName()
+			}
+
 			klog.ErrorS(err, "[SHOULD NOT HAPPEN] failed to update managedFields", "VersionKind",
-				newObj.GetObjectKind().GroupVersionKind())
+				newObj.GetObjectKind().GroupVersionKind(), "namespace", ns, "name", name)
 		})
 		// Explicitly remove managedFields on failure, so that
 		// we can't have garbage in it.


### PR DESCRIPTION
This SHOULD NOT HAPPEN error message should not happen obviously, but it does and it is hard to track down the root causes. This PR adds the object namespace and name to the log output.

/kind bug
```release-note
NONE
```