### PR TITLE
Report unrecognized HTTP options properly

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/audit/request.go
+++ b/staging/src/k8s.io/apiserver/pkg/audit/request.go
@@ -47,7 +47,7 @@ const (
 func NewEventFromRequest(req *http.Request, requestReceivedTimestamp time.Time, level auditinternal.Level, attribs authorizer.Attributes) (*auditinternal.Event, error) {
 	ev := &auditinternal.Event{
 		RequestReceivedTimestamp: metav1.NewMicroTime(requestReceivedTimestamp),
-		Verb:                     attribs.GetVerb(),
+		Verb:                     maybeReplaceVerb(attribs, req),
 		RequestURI:               req.URL.RequestURI(),
 		UserAgent:                maybeTruncateUserAgent(req),
 		Level:                    level,
@@ -91,6 +91,14 @@ func NewEventFromRequest(req *http.Request, requestReceivedTimestamp time.Time, 
 	}
 
 	return ev, nil
+}
+
+func maybeReplaceVerb(attributes authorizer.Attributes, req *http.Request) string {
+	verbFromTheAttributes := attributes.GetVerb()
+	if len(verbFromTheAttributes) == 0 {
+		return fmt.Sprintf("unrecognized(%v)", req.Method)
+	}
+	return verbFromTheAttributes
 }
 
 // LogImpersonatedUser fills in the impersonated user attributes into an audit event.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind bug

#### What this PR does / why we need it:

This Pull Request fixes the way the API Server and audit logs handle unsupported and unrecognized HTTP options. Here's an example for calling OPTIONS method:


```API Server
$ curl -X OPTIONS https://localhost:6443/api/v1/namespaces/default/pods/busybox-sleep --header "Authorization: Bearer $TOKEN" --insecure
{
  "kind": "Status",
  "apiVersion": "v1",
  "metadata": {
    
  },
  "status": "Failure",
  "message": "the server does not allow this method on the requested resource",
  "reason": "MethodNotAllowed",
  "details": {
    
  },
  "code": 405
}                              
```

```Audit logs
{"kind":"Event","apiVersion":"audit.k8s.io/v1","level":"RequestResponse","auditID":"31730841-83b5-436b-a04d-abe68af04771","stage":"ResponseComplete","requestURI":"/api/v1/namespaces/default/pods/busybox-sleep","verb":"unrecognized(OPTIONS)","user":{"username":"system:serviceaccount:default:default","uid":"13db4a1f-c60f-4f9c-afc4-b97ec020f246","groups":["system:serviceaccounts","system:serviceaccounts:default","system:authenticated"]},"sourceIPs":["::1"],"userAgent":"curl/7.76.1","objectRef":{"resource":"pods","namespace":"default","name":"busybox-sleep","apiVersion":"v1"},"responseStatus":{"metadata":{},"status":"Failure","reason":"MethodNotAllowed","code":405},"responseObject":{"kind":"Status","apiVersion":"v1","metadata":{},"status":"Failure","message":"the server does not allow this method on the requested resource","reason":"MethodNotAllowed","details":{},"code":405},"requestReceivedTimestamp":"2021-09-06T10:03:09.394342Z","stageTimestamp":"2021-09-06T10:03:09.399289Z","annotations":{"authentication.k8s.io/legacy-token":"system:serviceaccount:default:default","authorization.k8s.io/decision":"allow","authorization.k8s.io/reason":"RBAC: allowed by ClusterRoleBinding \"slaskawi-cluster-admin\" of ClusterRole \"cluster-admin\" to ServiceAccount \"default/default\""}}
```

Note, the API Server responds HTTP 405 and the audit logs reports `unrecognized(OPTIONS)`. 

*Previous audit logs contained an empty string as verb ("").*

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
fixes #95966

#### Special notes for your reviewer:

N/A

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

N/A

```release-note
Fix unknown HTTP method handling
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
