### PR TITLE
remove the --csr* flags from "kubeadm certs renew"

### DIFF
--- a/cmd/kubeadm/app/cmd/certs.go
+++ b/cmd/kubeadm/app/cmd/certs.go
@@ -301,14 +301,6 @@ func addRenewFlags(cmd *cobra.Command, flags *renewFlags) {
 	options.AddConfigFlag(cmd.Flags(), &flags.cfgPath)
 	options.AddCertificateDirFlag(cmd.Flags(), &flags.cfg.CertificatesDir)
 	options.AddKubeConfigFlag(cmd.Flags(), &flags.kubeconfigPath)
-
-	// TODO: remove these flags in a future version:
-	// https://github.com/kubernetes/kubeadm/issues/2163
-	const deprecationMessage = "This flag will be removed in a future version. Please use 'kubeadm certs generate-csr' instead."
-	options.AddCSRFlag(cmd.Flags(), &flags.csrOnly)
-	cmd.Flags().MarkDeprecated(options.CSROnly, deprecationMessage)
-	options.AddCSRDirFlag(cmd.Flags(), &flags.csrPath)
-	cmd.Flags().MarkDeprecated(options.CSRDir, deprecationMessage)
 }
 
 func renewCert(flags *renewFlags, kdir string, internalcfg *kubeadmapi.InitConfiguration, handler *renewal.CertificateRenewHandler) error {

--- a/cmd/kubeadm/app/cmd/certs_test.go
+++ b/cmd/kubeadm/app/cmd/certs_test.go
@@ -269,31 +269,6 @@ func TestRunRenewCommands(t *testing.T) {
 	}
 }
 
-func TestRenewUsingCSR(t *testing.T) {
-	tmpDir := testutil.SetupTempDir(t)
-	defer os.RemoveAll(tmpDir)
-	cert := certsphase.KubeadmCertEtcdServer()
-
-	cfg := testutil.GetDefaultInternalConfig(t)
-	cfg.CertificatesDir = tmpDir
-
-	caCert, caKey, err := certsphase.KubeadmCertEtcdCA().CreateAsCA(cfg)
-	if err != nil {
-		t.Fatalf("couldn't write out CA %s: %v", certsphase.KubeadmCertEtcdCA().Name, err)
-	}
-
-	if err := cert.CreateFromCA(cfg, caCert, caKey); err != nil {
-		t.Fatalf("couldn't write certificate %s: %v", cert.Name, err)
-	}
-
-	renewCmds := getRenewSubCommands(os.Stdout, tmpDir)
-	cmdtestutil.RunSubCommand(t, renewCmds, cert.Name, "--csr-only", "--csr-dir="+tmpDir, fmt.Sprintf("--cert-dir=%s", tmpDir))
-
-	if _, _, err := pkiutil.TryLoadCSRAndKeyFromDisk(tmpDir, cert.Name); err != nil {
-		t.Fatalf("couldn't load certificate %q: %v", cert.Name, err)
-	}
-}
-
 func TestRunGenCSR(t *testing.T) {
 	tmpDir := testutil.SetupTempDir(t)
 	defer os.RemoveAll(tmpDir)


### PR DESCRIPTION
#### What this PR does / why we need it:

- Remove the deprecated --csr* flags from "kubeadm certs renew"

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes # https://github.com/kubernetes/kubeadm/issues/2163

#### Special notes for your reviewer:
NONE

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
kubeadm: remove the deprecated flags "--csr-only" and "--csr-dir" from "kubeadm certs renew". Please use "kubeadm certs generate-csr" instead.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```