### PR TITLE
Chnage the simple Kubernetes logo into image link

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![GoPkg Widget]][GoPkg] [![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/569/badge)](https://bestpractices.coreinfrastructure.org/projects/569)
 
-<img src="https://github.com/kubernetes/kubernetes/raw/master/logo/logo.png" width="100">
+<a href="https://kubernetes.io" target="_blank" ><img src="https://github.com/kubernetes/kubernetes/raw/master/logo/logo.png" width="100"></a>
 
 ----
 


### PR DESCRIPTION
#### What type of PR is this?
/kind documentation

#### What this PR does / why we need it:
Convert the simple Kubernetes logo into the Image link, which now opens Kubernetes official site -https://kubernetes.io/

we need this because it will be more convenient for visitors. It's a common practice that, by clicking on the logo you will be redirected to the official site or home page. Almost all the good documentation follows that.
(currently, it's opening the Kubernetes png file)

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
