### PR TITLE
fix the error when cleaning up finished jobs for cronjob

### DIFF
--- a/pkg/controller/cronjob/cronjob_controllerv2.go
+++ b/pkg/controller/cronjob/cronjob_controllerv2.go
@@ -613,13 +613,14 @@ func (jm *ControllerV2) syncCronJob(
 	}
 	cj.Status.Active = append(cj.Status.Active, *jobRef)
 	cj.Status.LastScheduleTime = &metav1.Time{Time: *scheduledTime}
-	if _, err := jm.cronJobControl.UpdateStatus(ctx, cj); err != nil {
+	updatedCJ, err = jm.cronJobControl.UpdateStatus(ctx, cj)
+	if err != nil {
 		klog.InfoS("Unable to update status", "cronjob", klog.KRef(cj.GetNamespace(), cj.GetName()), "resourceVersion", cj.ResourceVersion, "err", err)
 		return cj, nil, fmt.Errorf("unable to update status for %s (rv = %s): %v", klog.KRef(cj.GetNamespace(), cj.GetName()), cj.ResourceVersion, err)
 	}
 
 	t := nextScheduledTimeDuration(sched, now)
-	return cj, t, nil
+	return updatedCJ, t, nil
 }
 
 func getJobName(cj *batchv1.CronJob, scheduledTime time.Time) string {

--- a/test/integration/cronjob/cronjob_test.go
+++ b/test/integration/cronjob/cronjob_test.go
@@ -26,6 +26,7 @@ import (
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/informers"
 	clientset "k8s.io/client-go/kubernetes"
@@ -152,6 +153,14 @@ func TestCronJobLaunchesPodAndCleansUp(t *testing.T) {
 
 	ns := framework.CreateTestingNamespace(namespaceName, server, t)
 	defer framework.DeleteTestingNamespace(ns, server, t)
+
+	backupHandlers := runtime.ErrorHandlers
+	runtime.ErrorHandlers = append(runtime.ErrorHandlers, func(e error) {
+		t.Fatalf("Failed with error: %v", e)
+	})
+	defer func() {
+		runtime.ErrorHandlers = backupHandlers
+	}()
 
 	cjClient := clientSet.BatchV1().CronJobs(ns.Name)
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug


#### What this PR does / why we need it:
Before this change, the updated cronjob is not recived and returned in function `syncCronJob`, as shown below: 
https://github.com/kubernetes/kubernetes/blob/eb729620c522753bc7ae61fc2c7b7ea19d4aad2f/pkg/controller/cronjob/cronjob_controllerv2.go#L603-L609
So, it will pass the cronjob object with old resource version to update its status when cleaning up the finished jobs, which results in an error with message "Operation cannot be fulfilled on cronjobs.batch 'xxxxx': the object has been modified; please apply your changes to the latest version and try again".
https://github.com/kubernetes/kubernetes/blob/eb729620c522753bc7ae61fc2c7b7ea19d4aad2f/pkg/controller/cronjob/cronjob_controllerv2.go#L185-L195

As for testing, I modified the integration test code of cronjob to catch this error through `runtime.ErrorHandlers`.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes/kubernetes/issues/103607

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fix regression in 1.21 cleaning up finished cronjobs
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
NONE
```
