### PR TITLE
kube-apiserver: add --assume-pruned-custom-resource-metadata-in-storage to optimize read-path

### DIFF
--- a/cmd/kube-apiserver/app/apiextensions.go
+++ b/cmd/kube-apiserver/app/apiextensions.go
@@ -87,10 +87,11 @@ func createAPIExtensionsConfig(
 			SharedInformerFactory: externalInformers,
 		},
 		ExtraConfig: apiextensionsapiserver.ExtraConfig{
-			CRDRESTOptionsGetter: apiextensionsoptions.NewCRDRESTOptionsGetter(etcdOptions),
-			MasterCount:          masterCount,
-			AuthResolverWrapper:  authResolverWrapper,
-			ServiceResolver:      serviceResolver,
+			CRDRESTOptionsGetter:            apiextensionsoptions.NewCRDRESTOptionsGetter(etcdOptions),
+			MasterCount:                     masterCount,
+			AuthResolverWrapper:             authResolverWrapper,
+			ServiceResolver:                 serviceResolver,
+			AssumePrunedObjectMetaInStorage: commandOptions.AssumePrunedCustomResourceMetaDataInStorage,
 		},
 	}
 

--- a/cmd/kube-apiserver/app/options/options.go
+++ b/cmd/kube-apiserver/app/options/options.go
@@ -93,6 +93,12 @@ type ServerRunOptions struct {
 	ServiceAccountTokenMaxExpiration time.Duration
 
 	ShowHiddenMetricsForVersion string
+
+	// AssumePrunedCustomResourceMetaDataInStorage set to true optimizes the read code-path for CRs
+	// assuming that ObjectMeta has been pruned when writing the objects. This can be
+	// assumed for every cluster installed with or after 1.11 when ObjectMeta pruning
+	// was added.
+	AssumePrunedCustomResourceMetaDataInStorage bool
 }
 
 // NewServerRunOptions creates a new ServerRunOptions object with default parameters
@@ -270,6 +276,10 @@ func (s *ServerRunOptions) Flags() (fss cliflag.NamedFlagSets) {
 
 	fs.StringVar(&s.ServiceAccountSigningKeyFile, "service-account-signing-key-file", s.ServiceAccountSigningKeyFile, ""+
 		"Path to the file that contains the current private key of the service account token issuer. The issuer will sign issued ID tokens with this private key.")
+
+	fs.BoolVar(&s.AssumePrunedCustomResourceMetaDataInStorage, "assume-pruned-custom-resource-metadata-in-storage", s.AssumePrunedCustomResourceMetaDataInStorage, ""+
+		"Optimizes the read code-path for CustomResources assuming that metadata has been pruned when writing the objects. "+
+		"This can be  assumed for every cluster installed with or after Kubernetes 1.11 when metadata pruning was added.")
 
 	return fss
 }

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/apiserver.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/apiserver.go
@@ -84,6 +84,11 @@ type ExtraConfig struct {
 	ServiceResolver webhook.ServiceResolver
 	// AuthResolverWrapper is used in CR webhook converters
 	AuthResolverWrapper webhook.AuthenticationInfoResolverWrapper
+	// AssumePrunedObjectMetaInStorage set to true optimizes the read code-path for CRs
+	// assuming that ObjectMeta has been pruned when writing the objects. This can be
+	// assumed for every cluster installed with or after 1.11 when ObjectMeta pruning
+	// was added.
+	AssumePrunedObjectMetaInStorage bool
 }
 
 type Config struct {
@@ -194,6 +199,7 @@ func (c completedConfig) New(delegationTarget genericapiserver.DelegationTarget)
 		time.Duration(c.GenericConfig.MinRequestTimeout)*time.Second,
 		apiGroupInfo.StaticOpenAPISpec,
 		c.GenericConfig.MaxRequestBodyBytes,
+		c.ExtraConfig.AssumePrunedObjectMetaInStorage,
 	)
 	if err != nil {
 		return nil, err

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/customresource_handler_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/customresource_handler_test.go
@@ -492,7 +492,7 @@ func testHandlerConversion(t *testing.T, enableWatchCache bool) {
 		func(r webhook.AuthenticationInfoResolver) webhook.AuthenticationInfoResolver { return r },
 		1,
 		dummyAuthorizerImpl{},
-		time.Minute, time.Minute, nil, 3*1024*1024)
+		time.Minute, time.Minute, nil, 3*1024*1024, false)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Due to missing ObjectMeta pruning we have a marshal/unmarshal orgy going on in the CR read-path:

  1. unmarshal JSON string from etcd into `obj := map[string]interface{}{}`
  2. marshal `obj[metadata]` back into a JSON string
  3. a) unmarshal JSON string into `metadata := meta.ObjectMeta{}` – this prunes
     b) unmarshal field by field in case the complete `json.Unmarshal` fails – this drops invalid fields, but is even slower. Usually only a) runs.
  4. marshal `metadata` to JSON string
  5. unmarshal JSON string into `metadata := map[string]interface{}{}`
  6. `obj[metadata] = metadata`
  7. marshal `obj` into JSON string an send to the client

Since Kubernetes 1.11 we have metadata pruning in place for new(ly written) CustomResources. Hence, we could assume that pruning is unnecessary, and hence speed up our CR read path considerably.

Note: there is one catch if you have embedded objects in your CRD schema. These technically can always be unpruned in etcd because you don't know which schema was used when writing them. When setting `x-kubernetes-embedded-object: true` at some point, data in etcd might be invalid.

/kind cleanup

```release-note
kube-apiserver: add --assume-pruned-custom-resource-metadata-in-storage to optimize read-path
```