### PR TITLE
Change execution duration guess from 1 minute to 3 milliseconds

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/queueset/queueset_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/queueset/queueset_test.go
@@ -1034,7 +1034,7 @@ func TestTotalRequestsExecutingWithPanic(t *testing.T) {
 }
 
 func TestSelectQueueLocked(t *testing.T) {
-	var G float64 = 60
+	var G float64 = 0.003
 	tests := []struct {
 		name                    string
 		robinIndex              int
@@ -1087,7 +1087,7 @@ func TestSelectQueueLocked(t *testing.T) {
 			robinIndexExpected:    []int{0},
 		},
 		{
-			name:             "width > 1, seats are available for request with the least finish time, queue is picked",
+			name:             "width > 1, seats are available for request with the least finish R, queue is picked",
 			concurrencyLimit: 50,
 			totSeatsInUse:    25,
 			robinIndex:       -1,
@@ -1110,7 +1110,7 @@ func TestSelectQueueLocked(t *testing.T) {
 			robinIndexExpected:    []int{1},
 		},
 		{
-			name:             "width > 1, seats are not available for request with the least finish time, queue is not picked",
+			name:             "width > 1, seats are not available for request with the least finish R, queue is not picked",
 			concurrencyLimit: 50,
 			totSeatsInUse:    26,
 			robinIndex:       -1,
@@ -1165,9 +1165,10 @@ func TestSelectQueueLocked(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			qs := &queueSet{
-				estimatedServiceTime: G,
-				robinIndex:           test.robinIndex,
-				totSeatsInUse:        test.totSeatsInUse,
+				estimatedServiceSeconds: G,
+				robinIndex:              test.robinIndex,
+				totSeatsInUse:           test.totSeatsInUse,
+				qCfg:                    fq.QueuingConfig{Name: "TestSelectQueueLocked/" + test.name},
 				dCfg: fq.DispatchingConfig{
 					ConcurrencyLimit: test.concurrencyLimit,
 				},

--- a/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/queueset/types.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/queueset/types.go
@@ -76,13 +76,14 @@ type request struct {
 // queue is an array of requests with additional metadata required for
 // the FQScheduler
 type queue struct {
-	// The requests are stored in a FIFO list.
+	// The requests not yet executing in the real world are stored in a FIFO list.
 	requests fifo
 
 	// virtualStart is the "virtual time" (R progress meter reading) at
 	// which the next request will be dispatched in the virtual world.
 	virtualStart float64
 
+	// requestsExecuting is the count in the real world
 	requestsExecuting int
 	index             int
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind cleanup

#### What this PR does / why we need it:
In `apiserver/pkg/util/flowcontrol/fairqueuing/queueset`, this PR changes the execution duration guess from 1 minute to 3 milliseconds, so that the width estimate has some effect but not a grossly excessive
one.

This PR also adds the `fifo::Peek` method to simplify the fifo client code.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:
See https://github.com/kubernetes/enhancements/pull/2944 for a KEP update that includes this change.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
