### PR TITLE
Fix caching of missing resource errors

### DIFF
--- a/staging/src/k8s.io/client-go/discovery/cached/memory/memcache.go
+++ b/staging/src/k8s.io/client-go/discovery/cached/memory/memcache.go
@@ -25,6 +25,7 @@ import (
 	openapi_v2 "github.com/googleapis/gnostic/openapiv2"
 
 	errorsutil "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/version"
@@ -71,6 +72,11 @@ func isTransientConnectionError(err error) bool {
 
 func isTransientError(err error) bool {
 	if isTransientConnectionError(err) {
+		return true
+	}
+
+	if meta.IsNoMatchError(err) {
+		// Kind not found, API / CRD for it may be registered later.
 		return true
 	}
 


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
`DeferredDiscoveryRESTMapper` / `MemCacheClient` caches errors from the API server, including `IsNoMatchError` (e.g. "no matches for kind foo in group bar"). Such Kind can be registered later, e.g. via a CRD, therefore the cached error should be refreshed with a new API server request.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fixed `DeferredDiscoveryRESTMapper` not refreshing caches after "no matches for kind" error.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
