### PR TITLE
kubelet: Rejected pods should be filtered from admission

### DIFF
--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -2217,7 +2217,7 @@ func (kl *Kubelet) HandlePodAdditions(pods []*v1.Pod) {
 		if !kl.podWorkers.IsPodTerminationRequested(pod.UID) {
 			// We failed pods that we rejected, so activePods include all admitted
 			// pods that are alive.
-			activePods := kl.filterOutTerminatedPods(existingPods)
+			activePods := kl.filterOutInactivePods(existingPods)
 
 			// Check if we can admit the pod; if not, reject it.
 			if ok, reason, message := kl.canAdmitPod(activePods, pod); !ok {

--- a/pkg/kubelet/kubelet_pods.go
+++ b/pkg/kubelet/kubelet_pods.go
@@ -92,16 +92,17 @@ func (kl *Kubelet) listPodsFromDisk() ([]types.UID, error) {
 	return pods, nil
 }
 
-// GetActivePods returns pods that may have a running container (a
-// terminated pod is one that is known to have no running containers and
-// will not get any more).
+// GetActivePods returns pods that have been admitted to the kubelet that
+// are not fully terminated. This is mapped to the "desired state" of the
+// kubelet - what pods should be running.
 //
-// TODO: This method must include pods that have been force deleted from
-// the config source (and thus removed from the pod manager) but are still
-// terminating.
+// WARNING: Currently this list does not include pods that have been force
+// deleted but may still be terminating, which means resources assigned to
+// those pods during admission may still be in use. See
+// https://github.com/kubernetes/kubernetes/issues/104824
 func (kl *Kubelet) GetActivePods() []*v1.Pod {
 	allPods := kl.podManager.GetPods()
-	activePods := kl.filterOutTerminatedPods(allPods)
+	activePods := kl.filterOutInactivePods(allPods)
 	return activePods
 }
 
@@ -968,19 +969,32 @@ func (kl *Kubelet) podResourcesAreReclaimed(pod *v1.Pod) bool {
 	return kl.PodResourcesAreReclaimed(pod, status)
 }
 
-// filterOutTerminatedPods returns pods that are not in a terminal phase
+// filterOutInactivePods returns pods that are not in a terminal phase
 // or are known to be fully terminated. This method should only be used
 // when the set of pods being filtered is upstream of the pod worker, i.e.
 // the pods the pod manager is aware of.
-func (kl *Kubelet) filterOutTerminatedPods(pods []*v1.Pod) []*v1.Pod {
+func (kl *Kubelet) filterOutInactivePods(pods []*v1.Pod) []*v1.Pod {
 	filteredPods := make([]*v1.Pod, 0, len(pods))
 	for _, p := range pods {
+		// if a pod is fully terminated by UID, it should be excluded from the
+		// list of pods
 		if kl.podWorkers.IsPodKnownTerminated(p.UID) {
 			continue
 		}
-		if p.Status.Phase == v1.PodSucceeded || p.Status.Phase == v1.PodFailed {
+
+		// terminal pods are considered inactive UNLESS they are actively terminating
+		isTerminal := p.Status.Phase == v1.PodSucceeded || p.Status.Phase == v1.PodFailed
+		if !isTerminal {
+			// a pod that has been marked terminal within the Kubelet is considered
+			// inactive (may have been rejected by Kubelet admision)
+			if status, ok := kl.statusManager.GetPodStatus(p.UID); ok {
+				isTerminal = status.Phase == v1.PodSucceeded || status.Phase == v1.PodFailed
+			}
+		}
+		if isTerminal && !kl.podWorkers.IsPodTerminationRequested(p.UID) {
 			continue
 		}
+
 		filteredPods = append(filteredPods, p)
 	}
 	return filteredPods


### PR DESCRIPTION
A pod that has been rejected by admission will have status manager set the phase to Failed locally, which make take some time to propagate to the apiserver. The rejected pod will be included in admission until the apiserver propagates the change back, which was an unintended regression when checking pod worker state as authoritative.

A pod that is terminal in the API may still be consuming resources  on the system, so it should still be included in admission.

Discovered while reviewing implications of #104577 on static pods and admission - the way a rejection is recorded isn't by excluding the pod from the active list in pod manager, it's by reporting it to statusManager.  That was regressed by #103668 (we started allowing pods that were rejected but not yet propagated to the apiserver to be included), and #104577 was not complete.

Created https://github.com/kubernetes/kubernetes/issues/104824 to reference the broader issue - that not all pods are part of this loop.

```release-note
Fix a 1.22 regression where a pod that the Kubelet rejects was still considered as being accepted for a brief period of time after rejection, which might cause some pods to be rejected briefly that could fit on the node.  A pod that is still terminating (but has status indicating it has failed) may also still be consuming resources and so should also be considered.
```

```docs

```