### PR TITLE
Support load balancer connect to pods directly if using VPC-CNI

### DIFF
--- a/staging/src/k8s.io/cloud-provider/app/core.go
+++ b/staging/src/k8s.io/cloud-provider/app/core.go
@@ -84,6 +84,8 @@ func startServiceController(initContext ControllerInitContext, ctx *config.Compl
 		ctx.ClientBuilder.ClientOrDie(initContext.ClientName),
 		ctx.SharedInformers.Core().V1().Services(),
 		ctx.SharedInformers.Core().V1().Nodes(),
+		ctx.SharedInformers.Core().V1().Endpoints(),
+		ctx.ComponentConfig.ServiceController.EnableDirectConnect,
 		ctx.ComponentConfig.KubeCloudShared.ClusterName,
 		utilfeature.DefaultFeatureGate,
 	)

--- a/staging/src/k8s.io/cloud-provider/controllers/service/config/types.go
+++ b/staging/src/k8s.io/cloud-provider/controllers/service/config/types.go
@@ -22,4 +22,7 @@ type ServiceControllerConfiguration struct {
 	// allowed to sync concurrently. Larger number = more responsive service
 	// management, but more CPU (and network) load.
 	ConcurrentServiceSyncs int32
+
+	// EnableDirectConnect is whether to enable loadbalancer connect to pod directly
+	EnableDirectConnect bool
 }

--- a/staging/src/k8s.io/cloud-provider/options/servicecontroller.go
+++ b/staging/src/k8s.io/cloud-provider/options/servicecontroller.go
@@ -33,6 +33,7 @@ func (o *ServiceControllerOptions) AddFlags(fs *pflag.FlagSet) {
 	}
 
 	fs.Int32Var(&o.ConcurrentServiceSyncs, "concurrent-service-syncs", o.ConcurrentServiceSyncs, "The number of services that are allowed to sync concurrently. Larger number = more responsive service management, but more CPU (and network) load")
+	fs.BoolVar(&o.EnableDirectConnect, "enable-direct-connect", false, "Whether to enable loadbalancer connect to pods directly.")
 }
 
 // ApplyTo fills up ServiceController config with options.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Most main cloud providers ([AWS](https://github.com/aws/amazon-vpc-cni-k8s), [Alibaba Cloud](https://github.com/AliyunContainerService/terway), [Tencent Cloud](https://intl.cloud.tencent.com/document/product/457/38970), etc.) support VPC-CNI now. If using VPC-CNI, pods can be attached to a load balancer directly, which reduces the cost of NodePort forwarding. However, in cloud-provider, the service controller doesn't watch Endpoints object. So changes of Endpoints won't trigger changes to the backends of the load balancer.

This PR adds watching for endpoints to the service controller. And add a start parameter as a switch to specify whether this cluster is using VPC-CNI and enables pods to be attached to a load balancer directly.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:
NONE
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
NONE
```
