### PR TITLE
Use utils string-slice comparison

### DIFF
--- a/staging/publishing/import-restrictions.yaml
+++ b/staging/publishing/import-restrictions.yaml
@@ -36,6 +36,7 @@
   - k8s.io/apimachinery
   - k8s.io/kube-openapi
   - k8s.io/utils/net
+  - k8s.io/utils/strings
   - k8s.io/klog
 
 - baseImportPath: "./vendor/k8s.io/api/"

--- a/staging/src/k8s.io/apimachinery/pkg/labels/selector.go
+++ b/staging/src/k8s.io/apimachinery/pkg/labels/selector.go
@@ -22,12 +22,12 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/google/go-cmp/cmp"
 	"k8s.io/apimachinery/pkg/selection"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/klog/v2"
+	stringslices "k8s.io/utils/strings/slices"
 )
 
 var (
@@ -288,7 +288,7 @@ func (r Requirement) Equal(x Requirement) bool {
 	if r.operator != x.operator {
 		return false
 	}
-	return cmp.Equal(r.strValues, x.strValues)
+	return stringslices.Equal(r.strValues, x.strValues)
 }
 
 // Empty returns true if the internalSelector doesn't restrict selection space


### PR DESCRIPTION
go-cmp/cmp is intended for tests, and is much less efficient here.

/kind cleanup

```release-note
NONE
```

Issue #104821
