### PR TITLE
Stop defaulting Service internalTrafficPolicy when type is ExternalName

### DIFF
--- a/pkg/api/service/testing/make.go
+++ b/pkg/api/service/testing/make.go
@@ -48,9 +48,6 @@ func MakeService(name string, tweaks ...Tweak) *api.Service {
 	SetTypeClusterIP(svc)
 	// Default to 1 port
 	SetPorts(MakeServicePort("", 93, intstr.FromInt(76), api.ProtocolTCP))(svc)
-	// Default internalTrafficPolicy to "Cluster".  This probably should not
-	// apply to ExternalName, but it went into beta and is not worth breaking.
-	SetInternalTrafficPolicy(api.ServiceInternalTrafficPolicyCluster)(svc)
 
 	for _, tweak := range tweaks {
 		tweak(svc)
@@ -68,6 +65,8 @@ func SetTypeClusterIP(svc *api.Service) {
 	svc.Spec.ExternalName = ""
 	svc.Spec.ExternalTrafficPolicy = ""
 	svc.Spec.AllocateLoadBalancerNodePorts = nil
+	internalTrafficPolicy := api.ServiceInternalTrafficPolicyCluster
+	svc.Spec.InternalTrafficPolicy = &internalTrafficPolicy
 }
 
 // SetTypeNodePort sets the service type to NodePort and clears other fields.
@@ -76,6 +75,8 @@ func SetTypeNodePort(svc *api.Service) {
 	svc.Spec.ExternalTrafficPolicy = api.ServiceExternalTrafficPolicyTypeCluster
 	svc.Spec.ExternalName = ""
 	svc.Spec.AllocateLoadBalancerNodePorts = nil
+	internalTrafficPolicy := api.ServiceInternalTrafficPolicyCluster
+	svc.Spec.InternalTrafficPolicy = &internalTrafficPolicy
 }
 
 // SetTypeLoadBalancer sets the service type to LoadBalancer and clears other fields.
@@ -84,6 +85,8 @@ func SetTypeLoadBalancer(svc *api.Service) {
 	svc.Spec.ExternalTrafficPolicy = api.ServiceExternalTrafficPolicyTypeCluster
 	svc.Spec.AllocateLoadBalancerNodePorts = utilpointer.BoolPtr(true)
 	svc.Spec.ExternalName = ""
+	internalTrafficPolicy := api.ServiceInternalTrafficPolicyCluster
+	svc.Spec.InternalTrafficPolicy = &internalTrafficPolicy
 }
 
 // SetTypeExternalName sets the service type to ExternalName and clears other fields.
@@ -94,6 +97,7 @@ func SetTypeExternalName(svc *api.Service) {
 	svc.Spec.ClusterIP = ""
 	svc.Spec.ClusterIPs = nil
 	svc.Spec.AllocateLoadBalancerNodePorts = nil
+	svc.Spec.InternalTrafficPolicy = nil
 }
 
 // SetPorts sets the service ports list.

--- a/pkg/apis/core/v1/defaults.go
+++ b/pkg/apis/core/v1/defaults.go
@@ -131,9 +131,14 @@ func SetDefaults_Service(obj *v1.Service) {
 		obj.Spec.ExternalTrafficPolicy = v1.ServiceExternalTrafficPolicyTypeCluster
 	}
 
-	if utilfeature.DefaultFeatureGate.Enabled(features.ServiceInternalTrafficPolicy) && obj.Spec.InternalTrafficPolicy == nil {
-		serviceInternalTrafficPolicyCluster := v1.ServiceInternalTrafficPolicyCluster
-		obj.Spec.InternalTrafficPolicy = &serviceInternalTrafficPolicyCluster
+	if utilfeature.DefaultFeatureGate.Enabled(features.ServiceInternalTrafficPolicy) {
+		if obj.Spec.InternalTrafficPolicy == nil {
+			if obj.Spec.Type == v1.ServiceTypeNodePort || obj.Spec.Type == v1.ServiceTypeLoadBalancer || obj.Spec.Type == v1.ServiceTypeClusterIP {
+				serviceInternalTrafficPolicyCluster := v1.ServiceInternalTrafficPolicyCluster
+				obj.Spec.InternalTrafficPolicy = &serviceInternalTrafficPolicyCluster
+			}
+		}
+
 	}
 
 	if obj.Spec.Type == v1.ServiceTypeLoadBalancer {

--- a/pkg/apis/core/validation/validation.go
+++ b/pkg/apis/core/validation/validation.go
@@ -4809,7 +4809,10 @@ func validateServiceInternalTrafficFieldsValue(service *core.Service) field.Erro
 
 	if utilfeature.DefaultFeatureGate.Enabled(features.ServiceInternalTrafficPolicy) {
 		if service.Spec.InternalTrafficPolicy == nil {
-			allErrs = append(allErrs, field.Required(field.NewPath("spec").Child("internalTrafficPolicy"), ""))
+			if service.Spec.Type == core.ServiceTypeNodePort ||
+				service.Spec.Type == core.ServiceTypeLoadBalancer || service.Spec.Type == core.ServiceTypeClusterIP {
+				allErrs = append(allErrs, field.Required(field.NewPath("spec").Child("internalTrafficPolicy"), ""))
+			}
 		}
 	}
 

--- a/pkg/apis/core/validation/validation.go
+++ b/pkg/apis/core/validation/validation.go
@@ -4809,6 +4809,8 @@ func validateServiceInternalTrafficFieldsValue(service *core.Service) field.Erro
 
 	if utilfeature.DefaultFeatureGate.Enabled(features.ServiceInternalTrafficPolicy) {
 		if service.Spec.InternalTrafficPolicy == nil {
+			// We do not forbid internalTrafficPolicy on other Service types because of historical reasons.
+			// We did not check that before it went beta and we don't want to invalidate existing stored objects.
 			if service.Spec.Type == core.ServiceTypeNodePort ||
 				service.Spec.Type == core.ServiceTypeLoadBalancer || service.Spec.Type == core.ServiceTypeClusterIP {
 				allErrs = append(allErrs, field.Required(field.NewPath("spec").Child("internalTrafficPolicy"), ""))

--- a/pkg/apis/core/validation/validation_test.go
+++ b/pkg/apis/core/validation/validation_test.go
@@ -12292,6 +12292,21 @@ func TestValidateServiceCreate(t *testing.T) {
 			numErrs:      0,
 		},
 		{
+			// Typically this should fail validation, but in v1.22 we have existing clusters
+			// that may have allowed internalTrafficPolicy when Type=ExternalName.
+			// This test case ensures we don't break compatibility for internalTrafficPolicy
+			// when Type=ExternalName
+			name: "internalTrafficPolicy field is set when type is ExternalName",
+			tweakSvc: func(s *core.Service) {
+				cluster := core.ServiceInternalTrafficPolicyCluster
+				s.Spec.InternalTrafficPolicy = &cluster
+				s.Spec.Type = core.ServiceTypeExternalName
+				s.Spec.ExternalName = "foo.bar.com"
+			},
+			featureGates: []featuregate.Feature{features.ServiceInternalTrafficPolicy},
+			numErrs:      0,
+		},
+		{
 			name: "invalid internalTraffic field",
 			tweakSvc: func(s *core.Service) {
 				invalid := core.ServiceInternalTrafficPolicyType("invalid")

--- a/pkg/apis/core/validation/validation_test.go
+++ b/pkg/apis/core/validation/validation_test.go
@@ -12282,6 +12282,16 @@ func TestValidateServiceCreate(t *testing.T) {
 			numErrs:      1,
 		},
 		{
+			name: "internalTrafficPolicy field nil when type is ExternalName",
+			tweakSvc: func(s *core.Service) {
+				s.Spec.InternalTrafficPolicy = nil
+				s.Spec.Type = core.ServiceTypeExternalName
+				s.Spec.ExternalName = "foo.bar.com"
+			},
+			featureGates: []featuregate.Feature{features.ServiceInternalTrafficPolicy},
+			numErrs:      0,
+		},
+		{
 			name: "invalid internalTraffic field",
 			tweakSvc: func(s *core.Service) {
 				invalid := core.ServiceInternalTrafficPolicyType("invalid")

--- a/pkg/registry/core/service/storage/storage.go
+++ b/pkg/registry/core/service/storage/storage.go
@@ -242,6 +242,17 @@ func (r *REST) defaultOnReadService(service *api.Service) {
 
 	// Set ipFamilies and ipFamilyPolicy if needed.
 	r.defaultOnReadIPFamilies(service)
+
+	// We unintentionally defaulted internalTrafficPolicy when it's not needed
+	// for the ExternalName type. It's too late to change the field in storage,
+	// but we can drop the field when read.
+	defaultOnReadInternalTrafficPolicy(service)
+}
+
+func defaultOnReadInternalTrafficPolicy(service *api.Service) {
+	if service.Spec.Type == api.ServiceTypeExternalName {
+		service.Spec.InternalTrafficPolicy = nil
+	}
 }
 
 func (r *REST) defaultOnReadIPFamilies(service *api.Service) {

--- a/pkg/registry/core/service/storage/storage_test.go
+++ b/pkg/registry/core/service/storage/storage_test.go
@@ -597,12 +597,9 @@ func TestServiceDefaultOnRead(t *testing.T) {
 			svctest.SetIPFamilyPolicy(api.IPFamilyPolicySingleStack),
 			svctest.SetIPFamilies(api.IPv4Protocol)),
 	}, {
-		name:  "external name",
-		input: makeServiceList(svctest.SetTypeExternalName),
-		expect: makeServiceList(svctest.SetTypeExternalName, func(svc *api.Service) {
-			// we now drop internalTrafficPolicy on read when Type=ExternalName
-			svc.Spec.InternalTrafficPolicy = nil
-		}),
+		name:   "external name",
+		input:  makeServiceList(svctest.SetTypeExternalName, svctest.SetInternalTrafficPolicy(api.ServiceInternalTrafficPolicyCluster)),
+		expect: makeServiceList(svctest.SetTypeExternalName),
 	}, {
 		name:  "dual v4v6",
 		input: svctest.MakeService("foo", svctest.SetClusterIPs("10.0.0.1", "2000::1")),
@@ -11391,31 +11388,16 @@ func TestFeatureInternalTrafficPolicy(t *testing.T) {
 	}
 
 	testCases := []cudTestCase{{
-		name: "ExternalName_policy:none-ExternalName_policy:Local",
+		name: "ExternalName_policy:none-ExternalName_policy:none",
 		create: svcTestCase{
 			svc: svctest.MakeService("foo",
 				svctest.SetTypeExternalName),
-			prove: prove(proveITP(api.ServiceInternalTrafficPolicyCluster)),
+			prove: prove(proveITP("")),
 		},
 		update: svcTestCase{
 			svc: svctest.MakeService("foo",
-				svctest.SetTypeExternalName,
-				svctest.SetInternalTrafficPolicy(api.ServiceInternalTrafficPolicyLocal)),
-			prove: prove(proveITP(api.ServiceInternalTrafficPolicyLocal)),
-		},
-	}, {
-		name: "ExternalName_policy:Cluster-ExternalName_policy:Local",
-		create: svcTestCase{
-			svc: svctest.MakeService("foo",
-				svctest.SetTypeExternalName,
-				svctest.SetInternalTrafficPolicy(api.ServiceInternalTrafficPolicyCluster)),
-			prove: prove(proveITP(api.ServiceInternalTrafficPolicyCluster)),
-		},
-		update: svcTestCase{
-			svc: svctest.MakeService("foo",
-				svctest.SetTypeExternalName,
-				svctest.SetInternalTrafficPolicy(api.ServiceInternalTrafficPolicyLocal)),
-			prove: prove(proveITP(api.ServiceInternalTrafficPolicyLocal)),
+				svctest.SetTypeExternalName),
+			prove: prove(proveITP("")),
 		},
 	}, {
 		name: "ClusterIP_policy:none-ClusterIP_policy:Local",


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
When the Service type is ExternalName, we shouldn't default the internalTrafficPolicy field since it is not relevant. However, since there are existing uses of ExternalName that may have already defaulted the internalTrafficPolicy field, we shouldn't disallow it in validation, otherwise we invalidate already stored objects. We also can't drop the field on any existing objects, so the best we can do is drop the field on read if it exists.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
The Service field spec.internalTrafficPolicy is no longer defaulted for Services when the type is ExternalName. The field is also dropped on read when the Service type is ExternalName.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
