### PR TITLE
kubeadm: move swap on check error to warning since NodeSwap is beta

### DIFF
--- a/cmd/kubeadm/app/preflight/checks.go
+++ b/cmd/kubeadm/app/preflight/checks.go
@@ -664,11 +664,11 @@ func (swc SwapCheck) Check() (warnings, errorList []error) {
 		buf = append(buf, scanner.Text())
 	}
 	if err := scanner.Err(); err != nil {
-		return nil, []error{errors.Wrap(err, "error parsing /proc/swaps")}
+		return []error{errors.Wrap(err, "error parsing /proc/swaps")}, nil
 	}
 
 	if len(buf) > 1 {
-		return nil, []error{errors.New("running with swap on is not supported. Please disable swap")}
+		return []error{errors.New("swap is enabled; production deployments should disable swap unless testing NodeSwap feature.")}, nil
 	}
 
 	return nil, nil

--- a/cmd/kubeadm/app/preflight/checks.go
+++ b/cmd/kubeadm/app/preflight/checks.go
@@ -668,7 +668,7 @@ func (swc SwapCheck) Check() (warnings, errorList []error) {
 	}
 
 	if len(buf) > 1 {
-		return []error{errors.New("swap is enabled; production deployments should disable swap unless testing NodeSwap feature.")}, nil
+		return []error{errors.New("swap is enabled; production deployments should disable swap unless testing the NodeSwap feature gate of the kubelet")}, nil
 	}
 
 	return nil, nil


### PR DESCRIPTION
/kind bug
xref https://github.com/kubernetes/kubeadm/issues/2563
/priority important-soon
/hold 
util NodeSwap is promoted to beta.


#### Does this PR introduce a user-facing change?
```release-note
kubeadm: switch the preflight check (called 'Swap') that verifies if swap is enabled on Linux hosts to report a warning instead of an error. This is related to the graduation of the NodeSwap feature gate in the kubelet to Beta and being enabled by default in 1.23 - allows swap support on Linux hosts. In the next release of kubeadm (1.24) the preflight check will be removed, thus we recommend that you stop using it - e.g. via --ignore-preflight-errors or the kubeadm config.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs
- [KEP]: https://github.com/kubernetes/enhancements/tree/master/keps/sig-node/2400-node-swap
```
