### PR TITLE
e2e: enable generic ephemeral inline volume also for in-tree drivers

### DIFF
--- a/test/e2e/storage/testsuites/base.go
+++ b/test/e2e/storage/testsuites/base.go
@@ -68,11 +68,16 @@ var BaseSuites = []func() storageframework.TestSuite{
 	InitTopologyTestSuite,
 	InitVolumeStressTestSuite,
 	InitFsGroupChangePolicyTestSuite,
+	func() storageframework.TestSuite {
+		return InitCustomEphemeralTestSuite(GenericEphemeralTestPatterns())
+	},
 }
 
 // CSISuites is a list of storage test suites that work only for CSI drivers
 var CSISuites = append(BaseSuites,
-	InitEphemeralTestSuite,
+	func() storageframework.TestSuite {
+		return InitCustomEphemeralTestSuite(CSIEphemeralTestPatterns())
+	},
 	InitSnapshottableTestSuite,
 	InitSnapshottableStressTestSuite,
 	InitVolumePerformanceTestSuite,

--- a/test/e2e/storage/testsuites/ephemeral.go
+++ b/test/e2e/storage/testsuites/ephemeral.go
@@ -53,9 +53,9 @@ func InitCustomEphemeralTestSuite(patterns []storageframework.TestPattern) stora
 	}
 }
 
-// InitEphemeralTestSuite returns ephemeralTestSuite that implements TestSuite interface
-// using test suite default patterns
-func InitEphemeralTestSuite() storageframework.TestSuite {
+// GenericEphemeralTestPatterns returns the test patterns for
+// generic ephemeral inline volumes.
+func GenericEphemeralTestPatterns() []storageframework.TestPattern {
 	genericLateBinding := storageframework.DefaultFsGenericEphemeralVolume
 	genericLateBinding.Name += " (late-binding)"
 	genericLateBinding.BindingMode = storagev1.VolumeBindingWaitForFirstConsumer
@@ -64,13 +64,30 @@ func InitEphemeralTestSuite() storageframework.TestSuite {
 	genericImmediateBinding.Name += " (immediate-binding)"
 	genericImmediateBinding.BindingMode = storagev1.VolumeBindingImmediate
 
-	patterns := []storageframework.TestPattern{
-		storageframework.DefaultFsCSIEphemeralVolume,
+	return []storageframework.TestPattern{
 		genericLateBinding,
 		genericImmediateBinding,
 	}
+}
 
-	return InitCustomEphemeralTestSuite(patterns)
+// CSIEphemeralTestPatterns returns the test patterns for
+// CSI ephemeral inline volumes.
+func CSIEphemeralTestPatterns() []storageframework.TestPattern {
+	return []storageframework.TestPattern{
+		storageframework.DefaultFsCSIEphemeralVolume,
+	}
+}
+
+// AllEphemeralTestPatterns returns all pre-defined test patterns for
+// generic and CSI ephemeral inline volumes.
+func AllEphemeralTestPatterns() []storageframework.TestPattern {
+	return append(GenericEphemeralTestPatterns(), CSIEphemeralTestPatterns()...)
+}
+
+// InitEphemeralTestSuite returns ephemeralTestSuite that implements TestSuite interface
+// using test suite default patterns
+func InitEphemeralTestSuite() storageframework.TestSuite {
+	return InitCustomEphemeralTestSuite(AllEphemeralTestPatterns())
 }
 
 func (p *ephemeralTestSuite) GetTestSuiteInfo() storageframework.TestSuiteInfo {


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Previously, the ephemeral volume test suite was only enabled for CSI
drivers. By splitting the test patterns into those that work for all drivers
and the one for CSI ephemeral inline volumes it becomes possible to
define the former for all drivers and the latter only for CSI.

This increases test coverage, in particular also for migration to
CSI (https://testgrid.k8s.io/provider-gcp-compute-persistent-disk-csi-driver#Migration%20Kubernetes%20Master%20Driver%20Latest).

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
