### PR TITLE
Automated cherry pick of #104845: e2e iperf2 change threshold to 10MBps = 80 Mbps

### DIFF
--- a/test/e2e/network/networking_perf.go
+++ b/test/e2e/network/networking_perf.go
@@ -39,8 +39,9 @@ import (
 const (
 	// use this timeout for larger clusters
 	largeClusterTimeout = 400 * time.Second
-	// iperf2BaselineBandwidthMegabytesPerSecond sets a baseline for iperf2 bandwidth of 90 MB/s
-	iperf2BaselineBandwidthMegabytesPerSecond = 90
+	// iperf2BaselineBandwidthMegabytesPerSecond sets a baseline for iperf2 bandwidth of 10 MBps = 80 Mbps
+	// this limits is chosen in order to support small devices with 100 mbps cards.
+	iperf2BaselineBandwidthMegabytesPerSecond = 10
 	// iperf2Port selects an arbitrary, unique port to run iperf2's client and server on
 	iperf2Port = 6789
 	// labelKey is used as a key for selectors


### PR DESCRIPTION
Cherry pick of #104845 on release-1.22.

#104845: e2e iperf2 change threshold to 10MBps = 80 Mbps

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
NONE
```