### PR TITLE
add windows arm support on client-side since go 1.17 supports

### DIFF
--- a/hack/lib/golang.sh
+++ b/hack/lib/golang.sh
@@ -52,6 +52,7 @@ readonly KUBE_SUPPORTED_CLIENT_PLATFORMS=(
   darwin/arm64
   windows/amd64
   windows/386
+  windows/arm64
 )
 
 # Which platforms we should compile test targets for.
@@ -65,6 +66,7 @@ readonly KUBE_SUPPORTED_TEST_PLATFORMS=(
   darwin/amd64
   darwin/arm64
   windows/amd64
+  windows/arm64
 )
 
 # The set of server targets that we are only building for Linux

--- a/test/typecheck/main.go
+++ b/test/typecheck/main.go
@@ -52,6 +52,7 @@ var (
 		"linux/arm", "linux/386",
 		"windows/amd64", "linux/arm64",
 		"linux/ppc64le", "linux/s390x",
+		"windows/arm64",
 	}
 
 	// directories we always ignore


### PR DESCRIPTION
/kind feature
xref #99948
It only fixes the `cli` part of #99948.

```release-note
Add support to generate client-side binaries for windows/arm64 platform 
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
