### PR TITLE
Move `YamlPrinter` to its own file

### DIFF
--- a/staging/src/k8s.io/cli-runtime/pkg/printers/json_test.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/printers/json_test.go
@@ -27,7 +27,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/diff"
 	"k8s.io/apimachinery/pkg/util/json"
 	"k8s.io/client-go/kubernetes/scheme"
-	"sigs.k8s.io/yaml"
 )
 
 var testData = TestStruct{
@@ -49,10 +48,6 @@ type TestStruct struct {
 
 func (in *TestStruct) DeepCopyObject() runtime.Object {
 	panic("never called")
-}
-
-func TestYAMLPrinter(t *testing.T) {
-	testPrinter(t, NewTypeSetter(scheme.Scheme).ToPrinter(&YAMLPrinter{}), yamlUnmarshal)
 }
 
 func TestJSONPrinter(t *testing.T) {
@@ -104,10 +99,6 @@ func testPrinter(t *testing.T, printer ResourcePrinter, unmarshalFunc func(data 
 	if !reflect.DeepEqual(obj, &objOut) {
 		t.Errorf("Unexpected inequality:\n%v", diff.ObjectDiff(obj, &objOut))
 	}
-}
-
-func yamlUnmarshal(data []byte, v interface{}) error {
-	return yaml.Unmarshal(data, v)
 }
 
 func TestPrintersSuccess(t *testing.T) {

--- a/staging/src/k8s.io/cli-runtime/pkg/printers/yaml.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/printers/yaml.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2017 The Kubernetes Authors.
+Copyright 2021 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -17,26 +17,40 @@ limitations under the License.
 package printers
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 	"io"
 	"reflect"
+	"sync/atomic"
+
+	"sigs.k8s.io/yaml"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
-// JSONPrinter is an implementation of ResourcePrinter which outputs an object as JSON.
-type JSONPrinter struct{}
+// YAMLPrinter is an implementation of ResourcePrinter which outputs an object as YAML.
+// The input object is assumed to be in the internal version of an API and is converted
+// to the given version first.
+// If PrintObj() is called multiple times, objects are separated with a '---' separator.
+type YAMLPrinter struct {
+	printCount int64
+}
 
-// PrintObj is an implementation of ResourcePrinter.PrintObj which simply writes the object to the Writer.
-func (p *JSONPrinter) PrintObj(obj runtime.Object, w io.Writer) error {
+// PrintObj prints the data as YAML.
+func (p *YAMLPrinter) PrintObj(obj runtime.Object, w io.Writer) error {
 	// we use reflect.Indirect here in order to obtain the actual value from a pointer.
 	// we need an actual value in order to retrieve the package path for an object.
 	// using reflect.Indirect indiscriminately is valid here, as all runtime.Objects are supposed to be pointers.
 	if InternalObjectPreventer.IsForbidden(reflect.Indirect(reflect.ValueOf(obj)).Type().PkgPath()) {
 		return fmt.Errorf(InternalObjectPrinterErr)
+	}
+
+	count := atomic.AddInt64(&p.printCount, 1)
+	if count > 1 {
+		if _, err := w.Write([]byte("---\n")); err != nil {
+			return err
+		}
 	}
 
 	switch obj := obj.(type) {
@@ -48,20 +62,18 @@ func (p *JSONPrinter) PrintObj(obj runtime.Object, w io.Writer) error {
 		if err != nil {
 			return err
 		}
-		_, err = w.Write(data)
+		data, err = yaml.JSONToYAML(data)
 		if err != nil {
 			return err
 		}
-		_, err = w.Write([]byte{'\n'})
+		_, err = w.Write(data)
 		return err
 	case *runtime.Unknown:
-		var buf bytes.Buffer
-		err := json.Indent(&buf, obj.Raw, "", "    ")
+		data, err := yaml.JSONToYAML(obj.Raw)
 		if err != nil {
 			return err
 		}
-		buf.WriteRune('\n')
-		_, err = buf.WriteTo(w)
+		_, err = w.Write(data)
 		return err
 	}
 
@@ -69,11 +81,10 @@ func (p *JSONPrinter) PrintObj(obj runtime.Object, w io.Writer) error {
 		return fmt.Errorf("missing apiVersion or kind; try GetObjectKind().SetGroupVersionKind() if you know the type")
 	}
 
-	data, err := json.MarshalIndent(obj, "", "    ")
+	output, err := yaml.Marshal(obj)
 	if err != nil {
 		return err
 	}
-	data = append(data, '\n')
-	_, err = w.Write(data)
+	_, err = fmt.Fprint(w, string(output))
 	return err
 }

--- a/staging/src/k8s.io/cli-runtime/pkg/printers/yaml_test.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/printers/yaml_test.go
@@ -1,0 +1,33 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package printers
+
+import (
+	"testing"
+
+	"sigs.k8s.io/yaml"
+
+	"k8s.io/client-go/kubernetes/scheme"
+)
+
+func TestYAMLPrinter(t *testing.T) {
+	testPrinter(t, NewTypeSetter(scheme.Scheme).ToPrinter(&YAMLPrinter{}), yamlUnmarshal)
+}
+
+func yamlUnmarshal(data []byte, v interface{}) error {
+	return yaml.Unmarshal(data, v)
+}


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
Currently `YamlPrinter` was living inside `json.go` which was confusing and I always end up grepping to find it. This PR moves the printer to its own file for ease of finding it between other printers. 

#### Special notes for your reviewer:
/assign @eddiezane 
@deejross

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

