### PR TITLE
kube-controller-manager: properly check generic ephemeral volume feature

### DIFF
--- a/cmd/kube-controller-manager/app/core.go
+++ b/cmd/kube-controller-manager/app/core.go
@@ -576,7 +576,7 @@ func startPVCProtectionController(ctx ControllerContext) (controller.Interface, 
 		ctx.InformerFactory.Core().V1().Pods(),
 		ctx.ClientBuilder.ClientOrDie("pvc-protection-controller"),
 		utilfeature.DefaultFeatureGate.Enabled(features.StorageObjectInUseProtection),
-		utilfeature.DefaultFeatureGate.Enabled(features.StorageObjectInUseProtection),
+		utilfeature.DefaultFeatureGate.Enabled(features.GenericEphemeralVolume),
 	)
 	if err != nil {
 		return nil, true, fmt.Errorf("failed to start the pvc protection controller: %v", err)


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Due to a cut-and-paste error in the original implementation in Kubernetes 1.19,
support for generic ephemeral inline volumes in the PVC protection controller
was incorrectly tied to the "storage object in use" feature gate.

#### Special notes for your reviewer:

Found by @ikeeip when removing the StorageObjectInUseProtection feature gate (https://github.com/kubernetes/kubernetes/pull/104903#discussion_r706194870).

#### Does this PR introduce a user-facing change?
```release-note
kube-controller incorrectly enabled support for generic ephemeral inline volumes if the storage object in use protection feature was enabled.
```
