### PR TITLE
mount-utils: force-format xfs-filesystems too

### DIFF
--- a/staging/src/k8s.io/mount-utils/mount_linux.go
+++ b/staging/src/k8s.io/mount-utils/mount_linux.go
@@ -30,7 +30,7 @@ import (
 	"syscall"
 	"time"
 
-        "k8s.io/klog/v2"
+       "k8s.io/klog/v2"
 	utilexec "k8s.io/utils/exec"
 	utilio "k8s.io/utils/io"
 )

--- a/staging/src/k8s.io/mount-utils/mount_linux.go
+++ b/staging/src/k8s.io/mount-utils/mount_linux.go
@@ -30,7 +30,7 @@ import (
 	"syscall"
 	"time"
 
-	"k8s.io/klog/v2"
+        "k8s.io/klog/v2"
 	utilexec "k8s.io/utils/exec"
 	utilio "k8s.io/utils/io"
 )
@@ -437,6 +437,11 @@ func (mounter *SafeFormatAndMount) formatAndMountSensitive(source string, target
 			args = []string{
 				"-F",  // Force flag
 				"-m0", // Zero blocks reserved for super-user
+				source,
+			}
+		} else if fstype == "xfs" {
+			args = []string{
+				"-f",  // force flag
 				source,
 			}
 		}

--- a/staging/src/k8s.io/mount-utils/mount_linux.go
+++ b/staging/src/k8s.io/mount-utils/mount_linux.go
@@ -30,7 +30,7 @@ import (
 	"syscall"
 	"time"
 
-       "k8s.io/klog/v2"
+	"k8s.io/klog/v2"
 	utilexec "k8s.io/utils/exec"
 	utilio "k8s.io/utils/io"
 )
@@ -441,7 +441,7 @@ func (mounter *SafeFormatAndMount) formatAndMountSensitive(source string, target
 			}
 		} else if fstype == "xfs" {
 			args = []string{
-				"-f",  // force flag
+				"-f", // force flag
 				source,
 			}
 		}

--- a/staging/src/k8s.io/mount-utils/safe_format_and_mount_test.go
+++ b/staging/src/k8s.io/mount-utils/safe_format_and_mount_test.go
@@ -181,7 +181,7 @@ func TestSafeFormatAndMount(t *testing.T) {
 			fstype:      "xfs",
 			execScripts: []ExecArgs{
 				{"blkid", []string{"-p", "-s", "TYPE", "-s", "PTTYPE", "-o", "export", "/dev/foo"}, "", &testingexec.FakeExitError{Status: 2}},
-				{"mkfs.xfs", []string{"/dev/foo"}, "", nil},
+				{"mkfs.xfs", []string{"-f", "/dev/foo"}, "", nil},
 			},
 		},
 		{
@@ -198,7 +198,7 @@ func TestSafeFormatAndMount(t *testing.T) {
 			mountErrs:   []error{fmt.Errorf("unknown filesystem type '(null)'"), nil},
 			execScripts: []ExecArgs{
 				{"blkid", []string{"-p", "-s", "TYPE", "-s", "PTTYPE", "-o", "export", "/dev/foo"}, "", &testingexec.FakeExitError{Status: 4}},
-				{"mkfs.xfs", []string{"/dev/foo"}, "", nil},
+				{"mkfs.xfs", []string{"-f", "/dev/foo"}, "", nil},
 			},
 			expErrorType: GetDiskFormatFailed,
 		},


### PR DESCRIPTION
Signed-off-by: David J. M. Karlsen <david@davidkarlsen.com>

#### What type of PR is this?

/kind bug
/sig storage

#### What this PR does / why we need it:

XFS filesystems are not force-formatted, this might lead to failures as initially experienced in https://github.com/openebs/lvm-localpv/issues/135 

#### Which issue(s) this PR fixes:

Fixes: https://github.com/openebs/lvm-localpv/issues/135
Fixes: https://github.com/kubernetes/mount-utils/issues/4

*Should I maybe clone the issue into this repo?*

#### Special notes for your reviewer:
See similar behaviour for ext3/4 filesystems.

#### Does this PR introduce a user-facing change?
NONE

```release-note
XFS-filesystems are now force-formatted (option `-f`) in order to avoid problems being formatted due to detection of magic super-blocks. This aligns with the behaviour of formatting of ext3/4 filesystems.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
