### PR TITLE
Expose ConfigFlags to CLI creators

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/cmd.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/cmd.go
@@ -430,19 +430,19 @@ func addCmdHeaderHooks(cmds *cobra.Command, kubeConfigFlags *genericclioptions.C
 		return existingPreRunE(cmd, args)
 	}
 	if kubeConfigFlags.WrapConfigFn == nil {
-	        // Wraps CommandHeaderRoundTripper around standard RoundTripper.
-	        kubeConfigFlags.WrapConfigFn = func(c *rest.Config) *rest.Config {
-		        c.Wrap(func(rt http.RoundTripper) http.RoundTripper {
-			        // Must be separate RoundTripper; not "crt" closure.
-			        // Fixes: https://github.com/kubernetes/kubectl/issues/1098
-			        return &genericclioptions.CommandHeaderRoundTripper{
-				        Delegate: rt,
-				        Headers:  crt.Headers,
-			        }
-		        })
-		        return c
-	        }
-        }
+		// Wraps CommandHeaderRoundTripper around standard RoundTripper.
+		kubeConfigFlags.WrapConfigFn = func(c *rest.Config) *rest.Config {
+			c.Wrap(func(rt http.RoundTripper) http.RoundTripper {
+				// Must be separate RoundTripper; not "crt" closure.
+				// Fixes: https://github.com/kubernetes/kubectl/issues/1098
+				return &genericclioptions.CommandHeaderRoundTripper{
+					Delegate: rt,
+					Headers:  crt.Headers,
+				}
+			})
+			return c
+		}
+	}
 }
 
 func runHelp(cmd *cobra.Command, args []string) {

--- a/staging/src/k8s.io/kubectl/pkg/cmd/cmd.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/cmd.go
@@ -89,7 +89,12 @@ func NewDefaultKubectlCommand() *cobra.Command {
 
 // NewDefaultKubectlCommandWithArgs creates the `kubectl` command with arguments
 func NewDefaultKubectlCommandWithArgs(pluginHandler PluginHandler, args []string, in io.Reader, out, errout io.Writer) *cobra.Command {
-	cmd := NewKubectlCommand(in, out, errout)
+	return NewDefaultKubectlCommandWithArgsAndConfigFlags(pluginHandler, args, in, out, errout, nil)
+}
+
+// NewDefaultKubectlCommandWithArgsAndConfigFlags creates the `kubectl` command with arguments as well as ConfigFlags
+func NewDefaultKubectlCommandWithArgsAndConfigFlags(pluginHandler PluginHandler, args []string, in io.Reader, out, errout io.Writer, kubeConfigFlags *genericclioptions.ConfigFlags) *cobra.Command {
+	cmd := NewKubectlCommandWithConfigFlags(in, out, errout, kubeConfigFlags)
 
 	if pluginHandler == nil {
 		return cmd
@@ -218,6 +223,11 @@ func HandlePluginCommand(pluginHandler PluginHandler, cmdArgs []string) error {
 
 // NewKubectlCommand creates the `kubectl` command and its nested children.
 func NewKubectlCommand(in io.Reader, out, err io.Writer) *cobra.Command {
+	return NewKubectlCommandWithConfigFlags(in, out, err, nil)
+}
+
+// NewKubectlCommandWithConfigFlags creates the `kubectl` command and its nested children and allows specifying ConfigFlags
+func NewKubectlCommandWithConfigFlags(in io.Reader, out, err io.Writer, kubeConfigFlags *genericclioptions.ConfigFlags) *cobra.Command {
 	warningHandler := rest.NewWarningWriter(err, rest.WarningWriterOptions{Deduplicate: true, Color: term.AllowsColorOutput(err)})
 	warningsAsErrors := false
 	// Parent command to which all subcommands are added.
@@ -264,7 +274,9 @@ func NewKubectlCommand(in io.Reader, out, err io.Writer) *cobra.Command {
 
 	flags.BoolVar(&warningsAsErrors, "warnings-as-errors", warningsAsErrors, "Treat warnings received from the server as errors and exit with a non-zero exit code")
 
-	kubeConfigFlags := genericclioptions.NewConfigFlags(true).WithDeprecatedPasswordFlag()
+	if kubeConfigFlags == nil {
+		kubeConfigFlags = genericclioptions.NewConfigFlags(true).WithDeprecatedPasswordFlag()
+	}
 	kubeConfigFlags.AddFlags(flags)
 	matchVersionKubeConfigFlags := cmdutil.NewMatchVersionFlags(kubeConfigFlags)
 	matchVersionKubeConfigFlags.AddFlags(flags)
@@ -417,18 +429,20 @@ func addCmdHeaderHooks(cmds *cobra.Command, kubeConfigFlags *genericclioptions.C
 		crt.ParseCommandHeaders(cmd, args)
 		return existingPreRunE(cmd, args)
 	}
-	// Wraps CommandHeaderRoundTripper around standard RoundTripper.
-	kubeConfigFlags.WrapConfigFn = func(c *rest.Config) *rest.Config {
-		c.Wrap(func(rt http.RoundTripper) http.RoundTripper {
-			// Must be separate RoundTripper; not "crt" closure.
-			// Fixes: https://github.com/kubernetes/kubectl/issues/1098
-			return &genericclioptions.CommandHeaderRoundTripper{
-				Delegate: rt,
-				Headers:  crt.Headers,
-			}
-		})
-		return c
-	}
+	if kubeConfigFlags.WrapConfigFn == nil {
+	        // Wraps CommandHeaderRoundTripper around standard RoundTripper.
+	        kubeConfigFlags.WrapConfigFn = func(c *rest.Config) *rest.Config {
+		        c.Wrap(func(rt http.RoundTripper) http.RoundTripper {
+			        // Must be separate RoundTripper; not "crt" closure.
+			        // Fixes: https://github.com/kubernetes/kubectl/issues/1098
+			        return &genericclioptions.CommandHeaderRoundTripper{
+				        Delegate: rt,
+				        Headers:  crt.Headers,
+			        }
+		        })
+		        return c
+	        }
+        }
 }
 
 func runHelp(cmd *cobra.Command, args []string) {


### PR DESCRIPTION
#### What type of PR is this?

/kind design
/kind api-change

#### What this PR does / why we need it:

NewKubectlCommand does not appear to expose a mechanism to override the Dial function when creating a connection to the kubernetes API.  The structures are in place - they are just not exposed at this time. This PR will expose the ConfigFlags pointer so that the `wrapConfigFn` and subsequently the `restConfig.Dial` can be overridden by a consumer

#### Which issue(s) this PR fixes:

I didn't create an issue yet - though I could if desired. I haven't seen this as a 'requirement' for submitting a PR yet (thus I didn't make one)

#### Special notes for your reviewer:

This might be exposed in some other fashion but if so I didn't discover how. I'm happy to be pointed at how to override the Dial function if a better mechanism exists. We followed the existing "With" pattern when making these two new functions

#### Does this PR introduce a user-facing change?

```release-note
Added: NewDefaultKubectlCommandWithArgsAndConfigFlags
    creates the `kubectl` command with arguments as well as ConfigFlags

Added: NewKubectlCommandWithConfigFlags
   creates the `kubectl` command and its nested children and allows specifying ConfigFlags
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

/sig cli