### PR TITLE
Fix[#104639] nodelifecycle SwapLimiter

### DIFF
--- a/pkg/controller/nodelifecycle/scheduler/rate_limited_queue.go
+++ b/pkg/controller/nodelifecycle/scheduler/rate_limited_queue.go
@@ -285,9 +285,7 @@ func (q *RateLimitedTimedQueue) Clear() {
 func (q *RateLimitedTimedQueue) SwapLimiter(newQPS float32) {
 	q.limiterLock.Lock()
 	defer q.limiterLock.Unlock()
-	if q.limiter.QPS() == newQPS {
-		return
-	}
+
 	var newLimiter flowcontrol.RateLimiter
 	if newQPS <= 0 {
 		newLimiter = flowcontrol.NewFakeNeverRateLimiter()


### PR DESCRIPTION

#### 1. What type of PR is this?
/kind bug
/sig cluster-lifecycle
/sig node

#### 2. What this PR does / why we need it:
Fix #104639, By setting the QPS to 1.0, the RateLimitedQueue should proceed at a rate of 1 QPS.

#### 3. Which issue(s) this PR fixes:
Fixes #104639

#### 4. Does this PR introduce a user-facing change?
NONE