### PR TITLE
update github.com/pkg/errors in test/conformance/image/go-runner/ with native go pkg

### DIFF
--- a/test/conformance/image/go-runner/main.go
+++ b/test/conformance/image/go-runner/main.go
@@ -17,6 +17,7 @@ limitations under the License.
 package main
 
 import (
+	"fmt"
 	"io"
 	"io/ioutil"
 	"log"
@@ -24,8 +25,6 @@ import (
 	"os/signal"
 	"path/filepath"
 	"strings"
-
-	"github.com/pkg/errors"
 )
 
 func main() {
@@ -62,7 +61,7 @@ func configureAndRunWithEnv(env Getenver) error {
 	logFilePath := filepath.Join(resultsDir, logFileName)
 	logFile, err := os.Create(logFilePath)
 	if err != nil {
-		return errors.Wrapf(err, "failed to create log file %v", logFilePath)
+		return fmt.Errorf("failed to create log file %v: %w", logFilePath, err)
 	}
 	mw := io.MultiWriter(os.Stdout, logFile)
 	cmd := getCmd(env, mw)
@@ -70,12 +69,12 @@ func configureAndRunWithEnv(env Getenver) error {
 	log.Printf("Running command:\n%v\n", cmdInfo(cmd))
 	err = cmd.Start()
 	if err != nil {
-		return errors.Wrap(err, "starting command")
+		return  fmt.Errorf("starting command: %w", err)
 	}
 
 	// Handle signals and shutdown process gracefully.
 	go setupSigHandler(cmd.Process.Pid)
-	return errors.Wrap(cmd.Wait(), "running command")
+	return fmt.Errorf("running command: %w", cmd.Wait())
 }
 
 // setupSigHandler will kill the process identified by the given PID if it
@@ -107,7 +106,7 @@ func saveResults(resultsDir string) error {
 
 	err := tarDir(resultsDir, filepath.Join(resultsDir, resultsTarballName))
 	if err != nil {
-		return errors.Wrapf(err, "tar directory %v", resultsDir)
+		return fmt.Errorf("tar directory %v: %w", resultsDir, err)
 	}
 
 	doneFile := filepath.Join(resultsDir, doneFileName)
@@ -115,11 +114,10 @@ func saveResults(resultsDir string) error {
 	resultsTarball := filepath.Join(resultsDir, resultsTarballName)
 	resultsTarball, err = filepath.Abs(resultsTarball)
 	if err != nil {
-		return errors.Wrapf(err, "failed to find absolute path for %v", resultsTarball)
+		return fmt.Errorf("failed to find absolute path for %v: %w", resultsTarball, err)
 	}
 
-	return errors.Wrap(
+	return fmt.Errorf("writing donefile: %w",
 		ioutil.WriteFile(doneFile, []byte(resultsTarball), os.FileMode(0777)),
-		"writing donefile",
 	)
 }

--- a/test/conformance/image/go-runner/tar.go
+++ b/test/conformance/image/go-runner/tar.go
@@ -19,12 +19,11 @@ package main
 import (
 	"archive/tar"
 	"compress/gzip"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
 	"strings"
-
-	"github.com/pkg/errors"
 )
 
 // tarDir takes a source and variable writers and walks 'source' writing each file
@@ -32,12 +31,12 @@ import (
 func tarDir(dir, outpath string) error {
 	// ensure the src actually exists before trying to tar it
 	if _, err := os.Stat(dir); err != nil {
-		return errors.Wrapf(err, "tar unable to stat directory %v", dir)
+		return fmt.Errorf("tar unable to stat directory %v: %w", dir, err)
 	}
 
 	outfile, err := os.Create(outpath)
 	if err != nil {
-		return errors.Wrapf(err, "creating tarball %v", outpath)
+		return fmt.Errorf("creating tarball %v: %w", outpath, err)
 	}
 	defer outfile.Close()
 
@@ -61,23 +60,23 @@ func tarDir(dir, outpath string) error {
 		// Create a new dir/file header.
 		header, err := tar.FileInfoHeader(fi, fi.Name())
 		if err != nil {
-			return errors.Wrapf(err, "creating file info header %v", fi.Name())
+			return fmt.Errorf("creating file info header %v: %w", fi.Name(), err)
 		}
 
 		// Update the name to correctly reflect the desired destination when untaring.
 		header.Name = strings.TrimPrefix(strings.Replace(file, dir, "", -1), string(filepath.Separator))
 		if err := tw.WriteHeader(header); err != nil {
-			return errors.Wrapf(err, "writing header for tarball %v", header.Name)
+			return fmt.Errorf("writing header for tarball %v: %w", header.Name, err)
 		}
 
 		// Open files, copy into tarfile, and close.
 		f, err := os.Open(file)
 		if err != nil {
-			return errors.Wrapf(err, "opening file %v for writing into tarball", file)
+			return fmt.Errorf("opening file %v for writing into tarball: %w", file, err)
 		}
 		defer f.Close()
 
 		_, err = io.Copy(tw, f)
-		return errors.Wrapf(err, "creating file %v contents into tarball", file)
+		return fmt.Errorf("creating file %v contents into tarball: %w", file, err)
 	})
 }

--- a/test/conformance/image/go-runner/tar_test.go
+++ b/test/conformance/image/go-runner/tar_test.go
@@ -27,8 +27,6 @@ import (
 	"reflect"
 	"strings"
 	"testing"
-
-	"github.com/pkg/errors"
 )
 
 func TestTar(t *testing.T) {
@@ -123,7 +121,7 @@ func readAllTar(tarPath string) (map[string]string, error) {
 
 	gzStream, err := gzip.NewReader(fileReader)
 	if err != nil {
-		return nil, errors.Wrap(err, "couldn't uncompress reader")
+		return nil, fmt.Errorf("couldn't uncompress reader: %w", err)
 	}
 	defer gzStream.Close()
 


### PR DESCRIPTION
Signed-off-by: ishangupta-ds <ishan@chaosnative.com>

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

removing usage of github.com/pkg/errors from test/conformance/image/go-runner/ directory

#### Which issue(s) this PR fixes:

Fixes part of #103043

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
