### PR TITLE
update github.com/pkg/errors in test/conformance/image/go-runner/ with native go pkg

### DIFF
--- a/test/conformance/image/go-runner/tar_test.go
+++ b/test/conformance/image/go-runner/tar_test.go
@@ -27,8 +27,6 @@ import (
 	"reflect"
 	"strings"
 	"testing"
-
-	"github.com/pkg/errors"
 )
 
 func TestTar(t *testing.T) {
@@ -123,7 +121,7 @@ func readAllTar(tarPath string) (map[string]string, error) {
 
 	gzStream, err := gzip.NewReader(fileReader)
 	if err != nil {
-		return nil, errors.Wrap(err, "couldn't uncompress reader")
+		return nil, fmt.Errorf("couldn't uncompress reader: %w", err)
 	}
 	defer gzStream.Close()
 


### PR DESCRIPTION
Signed-off-by: ishangupta-ds <ishangupta.ds@gmail.com>

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

removing usage of github.com/pkg/errors from test/conformance/image/go-runner/ directory

#### Which issue(s) this PR fixes:

Fixes part of #103043

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
