### PR TITLE
Replace custom dualstack support logic in Windows Kube-proxy

### DIFF
--- a/pkg/proxy/winkernel/proxier_test.go
+++ b/pkg/proxy/winkernel/proxier_test.go
@@ -26,7 +26,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/Microsoft/hcsshim/hcn"
 	v1 "k8s.io/api/core/v1"
 	discovery "k8s.io/api/discovery/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -930,55 +929,4 @@ func makeTestEndpointSlice(namespace, name string, sliceNum int, epsFunc func(*d
 	}
 	epsFunc(eps)
 	return eps
-}
-
-func Test_kernelSupportsDualstack(t *testing.T) {
-	tests := []struct {
-		currentVersion hcn.Version
-		name           string
-		want           bool
-	}{
-		{
-			hcn.Version{Major: 10, Minor: 10},
-			"Less than minimal should not be supported",
-			false,
-		},
-		{
-			hcn.Version{Major: 9, Minor: 11},
-			"Less than minimal should not be supported",
-			false,
-		},
-		{
-			hcn.Version{Major: 11, Minor: 1},
-			"Less than minimal should not be supported",
-			false,
-		},
-		{
-			hcn.Version{Major: 11, Minor: 10},
-			"Current version should be supported",
-			true,
-		},
-		{
-			hcn.Version{Major: 11, Minor: 11},
-			"Greater than minimal version should be supported",
-			true,
-		},
-		{
-			hcn.Version{Major: 12, Minor: 1},
-			"Greater than minimal version should be supported",
-			true,
-		},
-		{
-			hcn.Version{Major: 12, Minor: 12},
-			"Greater than minimal should be supported",
-			true,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := kernelSupportsDualstack(tt.currentVersion); got != tt.want {
-				t.Errorf("kernelSupportsDualstack on version %v: got %v, want %v", tt.currentVersion, got, tt.want)
-			}
-		})
-	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Due to an incorrect version range definition in hcsshim for dualstack support, the Windows kube-proxy had to define its own version range logic to check if dualstack was supported on the host. This was remedied in hcsshim (https://github.com/microsoft/hcsshim/pull/1003) and this work has been vendored into K8s as well (https://github.com/kubernetes/kubernetes/pull/104880). This change simply makes use of the now correct version range to check if dual stack is supported, and gets rid of the old custom logic.

cc @marosset @sbangari 

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```