### PR TITLE
kubeadm: loose the liveness health of etcd to avoid some known failures

### DIFF
--- a/cmd/kubeadm/app/phases/etcd/local.go
+++ b/cmd/kubeadm/app/phases/etcd/local.go
@@ -203,7 +203,7 @@ func GetEtcdPodSpec(cfg *kubeadmapi.ClusterConfiguration, endpoint *kubeadmapi.A
 					v1.ResourceMemory: resource.MustParse("100Mi"),
 				},
 			},
-			LivenessProbe: staticpodutil.LivenessProbe(probeHostname, "/health", probePort, probeScheme),
+			LivenessProbe: staticpodutil.LivenessProbe(probeHostname, "/health?exclude=NORAFTLEADER&consistency=s", probePort, probeScheme),
 			StartupProbe:  staticpodutil.StartupProbe(probeHostname, "/health", probePort, probeScheme, cfg.APIServer.TimeoutForControlPlane),
 		},
 		etcdMounts,


### PR DESCRIPTION
/kind bug
Fixes https://github.com/kubernetes/kubeadm/issues/2567

```release-note
NONE
```

Test for "/health?exclude=NORAFTLEADER&consistency=s" 


- **Updated: Fixed by https://github.com/kubernetes/kubernetes/pull/110744.**