### PR TITLE
remove redundant nil check

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/create.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/create.go
@@ -195,7 +195,7 @@ func createHandler(r rest.NamedCreater, scope *RequestScope, admit admission.Int
 
 		code := http.StatusCreated
 		status, ok := result.(*metav1.Status)
-		if ok && err == nil && status.Code == 0 {
+		if ok && status.Code == 0 {
 			status.Code = int32(code)
 		}
 


### PR DESCRIPTION
What type of PR is this?
/kind bug

What this PR does / why we need it:
there is redundant nil check in createHandler(*)

Which issue(s) this PR fixes:

Special notes for your reviewer:

Does this PR introduce a user-facing change?
```release-notes
NONE
```

Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```release-notes
NONE
```