### PR TITLE
Increase QPS in garbage collector controller

### DIFF
--- a/cmd/kube-controller-manager/app/core.go
+++ b/cmd/kube-controller-manager/app/core.go
@@ -538,6 +538,9 @@ func startGarbageCollectorController(ctx ControllerContext) (controller.Interfac
 	discoveryClient := ctx.ClientBuilder.DiscoveryClientOrDie("generic-garbage-collector")
 
 	config := ctx.ClientBuilder.ConfigOrDie("generic-garbage-collector")
+	// Increase garbage collector controller's throughput: each object deletion takes two API calls,
+	// so to get |config.QPS| deletion rate we need to allow 2x more requests for this controller.
+	config.QPS *= 2
 	metadataClient, err := metadata.NewForConfig(config)
 	if err != nil {
 		return nil, true, err


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:

Currently we do support ~2x pod creation rate than deletion rate (https://github.com/kubernetes/kubernetes/issues/96752). While it should be possible to rewrite the gc controller to reduce the number of API calls per deletion, it's quite complicated and requires more eng time than we can invest into this in the foreseeable future (see discussion in https://github.com/kubernetes/kubernetes/issues/96752).

While the GET calls are usually very cheap (much cheaper for the system than DELETE), we can achieve similar effect to rewrite by simply increasing QPS limit for the specific controller. 

Similar pattern has been already used by namespace controller: https://github.com/kubernetes/kubernetes/blob/dcfe8f5d5c9531e3196eb5036a86643c728eafe7/cmd/kube-controller-manager/app/core.go#L481-L484

/assign @wojtek-t
/assign @liggitt 

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
