### PR TITLE
Speed up counting of bits in allocator

### DIFF
--- a/pkg/registry/core/service/allocator/utils.go
+++ b/pkg/registry/core/service/allocator/utils.go
@@ -24,8 +24,8 @@ import (
 // countBits returns the number of set bits in n
 func countBits(n *big.Int) int {
 	var count int = 0
-	for _, b := range n.Bytes() {
-		count += bits.OnesCount8(uint8(b))
+	for _, w := range n.Bits() {
+		count += bits.OnesCount64(uint64(w))
 	}
 	return count
 }

--- a/pkg/registry/core/service/allocator/utils_test.go
+++ b/pkg/registry/core/service/allocator/utils_test.go
@@ -22,17 +22,33 @@ import (
 )
 
 func TestCountBits(t *testing.T) {
+	// bigN is an integer that occupies more than one big.Word.
+	bigN, ok := big.NewInt(0).SetString("10000000000000000000000000000000000000000000000000000000000000000", 16)
+	if !ok {
+		t.Fatal("Failed to set bigN")
+	}
 	tests := []struct {
 		n        *big.Int
 		expected int
 	}{
 		{n: big.NewInt(int64(0)), expected: 0},
 		{n: big.NewInt(int64(0xffffffffff)), expected: 40},
+		{n: bigN, expected: 1},
 	}
 	for _, test := range tests {
 		actual := countBits(test.n)
 		if test.expected != actual {
 			t.Errorf("%s should have %d bits but recorded as %d", test.n, test.expected, actual)
 		}
+	}
+}
+
+func BenchmarkCountBits(b *testing.B) {
+	bigN, ok := big.NewInt(0).SetString("10000000000000000000000000000000000000000000000000000000000000000", 16)
+	if !ok {
+		b.Fatal("Failed to set bigN")
+	}
+	for i := 0; i < b.N; i++ {
+		countBits(bigN)
 	}
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This PR tidies up counting of bits in `pkg/registry/core/service/allocator`.

Switching from using [`math/big.Int.Bytes`](https://pkg.go.dev/math/big#Int.Bytes) to [`math/big.Int.Bits`](https://pkg.go.dev/math/big#Int.Bits) has two effects:
* It removes an allocation (there is no longer a need for an intermediate `[]byte`).
* It allows the bits to be counted 64 at a time instead of 8 at a time.

#### Which issue(s) this PR fixes:

NONE

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
