### PR TITLE
Update debian-iptables to pick CVE fixes

### DIFF
--- a/build/common.sh
+++ b/build/common.sh
@@ -90,7 +90,7 @@ readonly KUBE_RSYNC_PORT="${KUBE_RSYNC_PORT:-}"
 readonly KUBE_CONTAINER_RSYNC_PORT=8730
 
 # These are the default versions (image tags) for their respective base images.
-readonly __default_debian_iptables_version=buster-v1.6.6
+readonly __default_debian_iptables_version=buster-v1.6.7
 readonly __default_go_runner_version=v2.3.1-go1.17-buster.0
 readonly __default_setcap_version=buster-v2.0.4
 

--- a/build/dependencies.yaml
+++ b/build/dependencies.yaml
@@ -134,7 +134,7 @@ dependencies:
       match: BASEIMAGE\?\=k8s\.gcr\.io\/build-image\/debian-base-s390x:[a-zA-Z]+\-v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)
 
   - name: "k8s.gcr.io/debian-iptables: dependents"
-    version: buster-v1.6.6
+    version: buster-v1.6.7
     refPaths:
     - path: build/common.sh
       match: __default_debian_iptables_version=

--- a/test/utils/image/manifest.go
+++ b/test/utils/image/manifest.go
@@ -208,7 +208,7 @@ func initImageConfigs(list RegistryList) (map[int]Config, map[int]Config) {
 	configs[CheckMetadataConcealment] = Config{list.PromoterE2eRegistry, "metadata-concealment", "1.6"}
 	configs[CudaVectorAdd] = Config{list.PromoterE2eRegistry, "cuda-vector-add", "1.0"}
 	configs[CudaVectorAdd2] = Config{list.PromoterE2eRegistry, "cuda-vector-add", "2.2"}
-	configs[DebianIptables] = Config{list.BuildImageRegistry, "debian-iptables", "buster-v1.6.6"}
+	configs[DebianIptables] = Config{list.BuildImageRegistry, "debian-iptables", "buster-v1.6.7"}
 	configs[EchoServer] = Config{list.PromoterE2eRegistry, "echoserver", "2.4"}
 	configs[Etcd] = Config{list.GcEtcdRegistry, "etcd", "3.4.13-0"}
 	configs[GlusterDynamicProvisioner] = Config{list.PromoterE2eRegistry, "glusterdynamic-provisioner", "v1.0"}


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:
- This image has fixes for CVE-2021-3711, CVE-2021-3712
- This will allow kube-proxy to be built on newer base image
  which has fixes for these CVEs


#### Special notes for your reviewer:
- Base image bump: https://github.com/kubernetes/k8s.io/pull/2698
- Release note here may need to be merged with the one in this PR: https://github.com/kubernetes/kubernetes/pull/104142

#### Does this PR introduce a user-facing change?
```release-note
Updates  debian-iptables to v1.6.7 to pick up CVE fixes
```
/sig security release testing api-machinery
/area security release-eng dependency