### PR TITLE
Update ineligible_endpoint.yaml to include RBAC

### DIFF
--- a/test/conformance/testdata/ineligible_endpoints.yaml
+++ b/test/conformance/testdata/ineligible_endpoints.yaml
@@ -256,3 +256,99 @@
 - endpoint: deleteNetworkingV1NamespacedNetworkPolicy
   reason: optional feature
   link: https://github.com/kubernetes/kubernetes/pull/100149#issuecomment-800501953
+ - Endpoint: createRbacAuthorizationV1ClusterRole
+  reason: optional feature
+  link: https://kubernetes.io/docs/reference/access-authn-authz/rbac/
+- Endpoint: createRbacAuthorizationV1ClusterRoleBinding
+  reason: optional feature
+  link: https://kubernetes.io/docs/reference/access-authn-authz/rbac/
+- Endpoint: createRbacAuthorizationV1NamespacedRoleBinding
+  reason: optional feature
+  link: https://kubernetes.io/docs/reference/access-authn-authz/rbac/
+- Endpoint: deleteRbacAuthorizationV1ClusterRole
+  reason: optional feature
+  link: https://kubernetes.io/docs/reference/access-authn-authz/rbac/
+- Endpoint: deleteRbacAuthorizationV1ClusterRoleBinding
+  reason: optional feature
+  link: https://kubernetes.io/docs/reference/access-authn-authz/rbac/
+- Endpoint: deleteRbacAuthorizationV1NamespacedRoleBinding
+  reason: optional feature
+  link: https://kubernetes.io/docs/reference/access-authn-authz/rbac/
+- Endpoint: getRbacAuthorizationV1APIResources
+  reason: optional feature
+  link: https://kubernetes.io/docs/reference/access-authn-authz/rbac/
+- Endpoint: getRbacAuthorizationAPIGroup
+  reason: optional feature
+  link: https://kubernetes.io/docs/reference/access-authn-authz/rbac/
+- Endpoint: createRbacAuthorizationV1NamespacedRole
+  reason: optional feature
+  link: https://kubernetes.io/docs/reference/access-authn-authz/rbac/
+- Endpoint: deleteRbacAuthorizationV1CollectionClusterRole
+  reason: optional feature
+  link: https://kubernetes.io/docs/reference/access-authn-authz/rbac/
+- Endpoint: deleteRbacAuthorizationV1CollectionClusterRoleBinding
+  reason: optional feature
+  link: https://kubernetes.io/docs/reference/access-authn-authz/rbac/
+- Endpoint: deleteRbacAuthorizationV1CollectionNamespacedRole
+  reason: optional feature
+  link: https://kubernetes.io/docs/reference/access-authn-authz/rbac/
+- Endpoint: deleteRbacAuthorizationV1CollectionNamespacedRoleBinding
+  reason: optional feature
+  link: https://kubernetes.io/docs/reference/access-authn-authz/rbac/
+- Endpoint: deleteRbacAuthorizationV1NamespacedRole
+  reason: optional feature
+  link: https://kubernetes.io/docs/reference/access-authn-authz/rbac/
+- Endpoint: listRbacAuthorizationV1ClusterRole
+  reason: optional feature
+  link: https://kubernetes.io/docs/reference/access-authn-authz/rbac/
+- Endpoint: listRbacAuthorizationV1ClusterRoleBinding
+  reason: optional feature
+  link: https://kubernetes.io/docs/reference/access-authn-authz/rbac/
+- Endpoint: listRbacAuthorizationV1NamespacedRole
+  reason: optional feature
+  link: https://kubernetes.io/docs/reference/access-authn-authz/rbac/
+- Endpoint: listRbacAuthorizationV1NamespacedRoleBinding
+  reason: optional feature
+  link: https://kubernetes.io/docs/reference/access-authn-authz/rbac/
+- Endpoint: listRbacAuthorizationV1RoleBindingForAllNamespaces
+  reason: optional feature
+  link: https://kubernetes.io/docs/reference/access-authn-authz/rbac/
+- Endpoint: listRbacAuthorizationV1RoleForAllNamespaces
+  reason: optional feature
+  link: https://kubernetes.io/docs/reference/access-authn-authz/rbac/
+- Endpoint: patchRbacAuthorizationV1ClusterRole
+  reason: optional feature
+  link: https://kubernetes.io/docs/reference/access-authn-authz/rbac/
+- Endpoint: patchRbacAuthorizationV1ClusterRoleBinding
+  reason: optional feature
+  link: https://kubernetes.io/docs/reference/access-authn-authz/rbac/
+- Endpoint: patchRbacAuthorizationV1NamespacedRole
+  reason: optional feature
+  link: https://kubernetes.io/docs/reference/access-authn-authz/rbac/
+- Endpoint: patchRbacAuthorizationV1NamespacedRoleBinding
+  reason: optional feature
+  link: https://kubernetes.io/docs/reference/access-authn-authz/rbac/
+- Endpoint: readRbacAuthorizationV1ClusterRole
+  reason: optional feature
+  link: https://kubernetes.io/docs/reference/access-authn-authz/rbac/
+- Endpoint: readRbacAuthorizationV1ClusterRoleBinding
+  reason: optional feature
+  link: https://kubernetes.io/docs/reference/access-authn-authz/rbac/
+- Endpoint: readRbacAuthorizationV1NamespacedRole
+  reason: optional feature
+  link: https://kubernetes.io/docs/reference/access-authn-authz/rbac/
+- Endpoint: readRbacAuthorizationV1NamespacedRoleBinding
+  reason: optional feature
+  link: https://kubernetes.io/docs/reference/access-authn-authz/rbac/
+- Endpoint: replaceRbacAuthorizationV1ClusterRole
+  reason: optional feature
+  link: https://kubernetes.io/docs/reference/access-authn-authz/rbac/
+- Endpoint: replaceRbacAuthorizationV1ClusterRoleBinding
+  reason: optional feature
+  link: https://kubernetes.io/docs/reference/access-authn-authz/rbac/
+- Endpoint: replaceRbacAuthorizationV1NamespacedRole
+  reason: optional feature
+  link: https://kubernetes.io/docs/reference/access-authn-authz/rbac/
+- Endpoint: replaceRbacAuthorizationV1NamespacedRoleBinding
+  reason: optional feature
+  link: https://kubernetes.io/docs/reference/access-authn-authz/rbac/ 


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it:**
This PR adds the `RBAC` endpoints to the `Ineligible_endpoint.yaml` because the endpoints are  [optional features](https://kubernetes.io/docs/reference/access-authn-authz/rbac/)
- createRbacAuthorizationV1ClusterRole
- createRbacAuthorizationV1ClusterRoleBinding
- createRbacAuthorizationV1NamespacedRoleBinding
- deleteRbacAuthorizationV1ClusterRole
- deleteRbacAuthorizationV1ClusterRoleBinding
- deleteRbacAuthorizationV1NamespacedRoleBinding
- getRbacAuthorizationV1APIResources
- getRbacAuthorizationAPIGroup
- createRbacAuthorizationV1NamespacedRole
- deleteRbacAuthorizationV1CollectionClusterRole
- deleteRbacAuthorizationV1CollectionClusterRoleBinding
- deleteRbacAuthorizationV1CollectionNamespacedRole
- deleteRbacAuthorizationV1CollectionNamespacedRoleBinding
- deleteRbacAuthorizationV1NamespacedRole
- listRbacAuthorizationV1ClusterRole
- listRbacAuthorizationV1ClusterRoleBinding
- listRbacAuthorizationV1NamespacedRole
- listRbacAuthorizationV1NamespacedRoleBinding
- listRbacAuthorizationV1RoleBindingForAllNamespaces
- listRbacAuthorizationV1RoleForAllNamespaces
- patchRbacAuthorizationV1ClusterRole
- patchRbacAuthorizationV1ClusterRoleBinding
- patchRbacAuthorizationV1NamespacedRole
- patchRbacAuthorizationV1NamespacedRoleBinding
- readRbacAuthorizationV1ClusterRole
- readRbacAuthorizationV1ClusterRoleBinding
- readRbacAuthorizationV1NamespacedRole
- readRbacAuthorizationV1NamespacedRoleBinding
- replaceRbacAuthorizationV1ClusterRole
- replaceRbacAuthorizationV1ClusterRoleBinding
- replaceRbacAuthorizationV1NamespacedRole
- replaceRbacAuthorizationV1NamespacedRoleBinding

**Special notes for your reviewer:**
As of 1.22 APISnoop [Ineligible endpoints](https://apisnoop.cncf.io/conformance-progress/ineligible-endpoints) are pulled from the community owned `inelegible_endpoint.yaml` file

**Does this PR introduce a user-facing change?:**
```
NONE

```

**Release note:**
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:**
```
NONE

```

/sig architecture
/area conformance