### PR TITLE
Aggregator uses the regular transport when handling upgrade requests

### DIFF
--- a/staging/src/k8s.io/kube-aggregator/go.sum
+++ b/staging/src/k8s.io/kube-aggregator/go.sum
@@ -118,7 +118,6 @@ github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8
 github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815/go.mod h1:WwZ+bS3ebgob9U8Nd0kOddGdZWjyMGR8Wziv+TBNwSE=
 github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4zYo=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
-github.com/elazarl/goproxy v0.0.0-20180725130230-947c36da3153 h1:yUdfgN0XgIJw7foRItutHYUIhlcKzcSf5vDpdhQAKTc=
 github.com/elazarl/goproxy v0.0.0-20180725130230-947c36da3153/go.mod h1:/Zj4wYkgs4iZTTu3o/KG3Itv/qCCa8VVMlb3i9OVuzc=
 github.com/emicklei/go-restful v0.0.0-20170410110728-ff4f55a20633/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
 github.com/emicklei/go-restful v2.9.5+incompatible h1:spTtZBk5DYEvbxMVutUuTyh1Ao2r4iyvLdACqsl/Ljk=
@@ -338,7 +337,6 @@ github.com/mitchellh/iochan v1.0.0/go.mod h1:JwYml1nuB7xOzsp52dPpHFffvOCDupsG0Qu
 github.com/mitchellh/mapstructure v0.0.0-20160808181253-ca63d7c062ee/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/mitchellh/mapstructure v1.4.1/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
-github.com/moby/spdystream v0.2.0 h1:cjW1zVyyoiM0T7b6UoySUFqzXMoqRckQtXwGPiBhOM8=
 github.com/moby/spdystream v0.2.0/go.mod h1:f7i0iNDQJ059oMTcWxx8MA/zKFIuD/lY+0GqbN2Wy8c=
 github.com/moby/term v0.0.0-20210610120745-9d4ed1856297/go.mod h1:vgPCkQMyxTZ7IDy8SXRufE172gr8+K/JE/7hHFxHW3A=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=


### PR DESCRIPTION
/sig api-machinery
/kind bug
/assign
/release-note none

Currently aggregator creates a [SPDY transport](https://github.com/kubernetes/kubernetes/blob/35ae8c9fe4589bbe99e174929f78f8228c2da528/staging/src/k8s.io/kube-aggregator/pkg/apiserver/handler_proxy.go#L227) to the remote if the request contains upgrade headers. This seems wrong to me:
* what if the request is trying to upgrade not to SPDY but to websocket?
* more fundamentally, aggregator as a proxy should only care about the transport level connectivity. Aggregator should create a transport connection to the aggregated apiserver and then stitch it together with the connection between the client and the aggregator, just like how it treats a non-upgrade request.

This PR let's the aggregator use the original normal transport for upgrade requests. As a side-effect, this fixes #71808, which points out that that the SPDY transport doesn't honor the custom dialer in the original transport. The consequence of #71808 is that upgraded requests to aggregated APIs do not work if SSH tunnels or [Konnectivity](https://github.com/kubernetes-sigs/apiserver-network-proxy) is used. A real life issue we met is that [virtctl console](https://kubevirt.io/user-guide/virtual_machines/accessing_virtual_machines/#accessing-the-serial-console)(similar to `kubectl exec`) doesn't work when Konnectivity is used. We verified that this PR fixed the `virtctl console` use case.

### Side note: how upgrade requests for aggregated apis worked with the SPDY transport when there was _NO_ ssh tunnels or konnectivity involved

It worked because SPDY transport was only used here: https://github.com/kubernetes/kubernetes/blob/35ae8c9fe4589bbe99e174929f78f8228c2da528/staging/src/k8s.io/apimachinery/pkg/util/proxy/dial.go#L38-L41

`utilnet.DialerFor` will return an empty dialer and error, because it doesn't recognize a SPDY transport. `dialURL` then uses the default golang net.Dialer. So the SPDY transport never actually gets used. 

(Supersedes https://github.com/kubernetes/kubernetes/pull/104763)

Fixes #71808

