### PR TITLE
Delete redundant function for TokensController

### DIFF
--- a/pkg/controller/serviceaccount/tokens_controller.go
+++ b/pkg/controller/serviceaccount/tokens_controller.go
@@ -98,7 +98,7 @@ func NewTokensController(serviceAccounts informers.ServiceAccountInformer, secre
 	serviceAccounts.Informer().AddEventHandlerWithResyncPeriod(
 		cache.ResourceEventHandlerFuncs{
 			AddFunc:    e.queueServiceAccountSync,
-			UpdateFunc: e.queueServiceAccountUpdateSync,
+			UpdateFunc: e.queueServiceAccountSync,
 			DeleteFunc: e.queueServiceAccountSync,
 		},
 		options.ServiceAccountResync,
@@ -120,7 +120,7 @@ func NewTokensController(serviceAccounts informers.ServiceAccountInformer, secre
 			},
 			Handler: cache.ResourceEventHandlerFuncs{
 				AddFunc:    e.queueSecretSync,
-				UpdateFunc: e.queueSecretUpdateSync,
+				UpdateFunc: e.queueSecretSync,
 				DeleteFunc: e.queueSecretSync,
 			},
 		},
@@ -189,12 +189,6 @@ func (e *TokensController) queueServiceAccountSync(obj interface{}) {
 	}
 }
 
-func (e *TokensController) queueServiceAccountUpdateSync(oldObj interface{}, newObj interface{}) {
-	if serviceAccount, ok := newObj.(*v1.ServiceAccount); ok {
-		e.syncServiceAccountQueue.Add(makeServiceAccountKey(serviceAccount))
-	}
-}
-
 // complete optionally requeues key, then calls queue.Done(key)
 func (e *TokensController) retryOrForget(queue workqueue.RateLimitingInterface, key interface{}, requeue bool) {
 	if !requeue {
@@ -214,12 +208,6 @@ func (e *TokensController) retryOrForget(queue workqueue.RateLimitingInterface, 
 
 func (e *TokensController) queueSecretSync(obj interface{}) {
 	if secret, ok := obj.(*v1.Secret); ok {
-		e.syncSecretQueue.Add(makeSecretQueueKey(secret))
-	}
-}
-
-func (e *TokensController) queueSecretUpdateSync(oldObj interface{}, newObj interface{}) {
-	if secret, ok := newObj.(*v1.Secret); ok {
 		e.syncSecretQueue.Add(makeSecretQueueKey(secret))
 	}
 }

--- a/pkg/controller/serviceaccount/tokens_controller_test.go
+++ b/pkg/controller/serviceaccount/tokens_controller_test.go
@@ -601,7 +601,7 @@ func TestTokenCreation(t *testing.T) {
 		}
 		if tc.UpdatedServiceAccount != nil {
 			serviceAccounts.Add(tc.UpdatedServiceAccount)
-			controller.queueServiceAccountUpdateSync(nil, tc.UpdatedServiceAccount)
+			controller.queueServiceAccountSync(tc.UpdatedServiceAccount)
 		}
 		if tc.DeletedServiceAccount != nil {
 			serviceAccounts.Delete(tc.DeletedServiceAccount)
@@ -616,7 +616,7 @@ func TestTokenCreation(t *testing.T) {
 		}
 		if tc.UpdatedSecret != nil {
 			secrets.Add(tc.UpdatedSecret)
-			controller.queueSecretUpdateSync(nil, tc.UpdatedSecret)
+			controller.queueSecretSync(tc.UpdatedSecret)
 		}
 		if tc.DeletedSecret != nil {
 			secrets.Delete(tc.DeletedSecret)


### PR DESCRIPTION
What type of PR is this?
/kind cleanup

What this PR does / why we need it:
The func "queueSecretUpdateSync" is the same with queueSecretSync, except for the redundant parameter "oldObj". The same thing happened in func "queueServiceAccountUpdateSync". So we can delete the redundant function.

Which issue(s) this PR fixes:

Fixes #

Special notes for your reviewer:

Does this PR introduce a user-facing change?:

Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

/release-note-none
/priority backlog
/triage accepted