### PR TITLE
kubelet: activate logging sooner

### DIFF
--- a/cmd/kubelet/app/server.go
+++ b/cmd/kubelet/app/server.go
@@ -227,6 +227,11 @@ HTTP server: The kubelet can also listen for HTTP and respond to a simple API
 				os.Exit(1)
 			}
 
+			// Activate final logging options as soon as we have
+			// them validated.
+			logOption := &logs.Options{Config: kubeletConfig.Logging}
+			logOption.Apply()
+
 			if (kubeletConfig.KubeletCgroups != "" && kubeletConfig.KubeReservedCgroup != "") && (strings.Index(kubeletConfig.KubeletCgroups, kubeletConfig.KubeReservedCgroup) != 0) {
 				klog.InfoS("unsupported configuration:KubeletCgroups is not within KubeReservedCgroup")
 			}
@@ -434,8 +439,6 @@ func UnsecuredDependencies(s *options.KubeletServer, featureGate featuregate.Fea
 // Otherwise, the caller is assumed to have set up the Dependencies object and a default one will
 // not be generated.
 func Run(ctx context.Context, s *options.KubeletServer, kubeDeps *kubelet.Dependencies, featureGate featuregate.FeatureGate) error {
-	logOption := &logs.Options{Config: s.Logging}
-	logOption.Apply()
 	// To help debugging, immediately log version
 	klog.InfoS("Kubelet version", "kubeletVersion", version.Get())
 	if err := initForOS(s.KubeletFlags.WindowsService, s.KubeletFlags.WindowsPriorityClass); err != nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Without this, some error messages during startup are printed in
text format although JSON was requested.

Before:
```
   $ go run ./cmd/kubelet --logging-format=json
   ...
   E0914 10:54:57.540301   69656 server.go:271] "Failed to construct kubelet dependencies" err="error reading /var/lib/kubelet/pki/kubelet.key, certificate and key must be supplied as a pair"
   exit status 1
```
After:
```
  $ go run ./cmd/kubelet --logging-format=json
  ...
  {"ts":1631610094233.7605,"caller":"app/server.go:276","msg":"Failed to construct kubelet dependencies","err":"error reading /var/lib/kubelet/pki/kubelet.key, certificate and key must be supplied as a pair"}
```

#### Special notes for your reviewer:

I noticed this while working on logging configuration for kubelet and other commands.

#### Does this PR introduce a user-facing change?
```release-note
kubelet activates the logging settings sooner, so some more early error messages get printed as configured.
```
