### PR TITLE
Replace wait.Until and wait.PollUntil with appropriate alternatives

### DIFF
--- a/cmd/kube-proxy/app/server.go
+++ b/cmd/kube-proxy/app/server.go
@@ -611,7 +611,7 @@ func serveHealthz(hz healthcheck.ProxierHealthUpdater, errCh chan error) {
 			klog.ErrorS(nil, "Healthz server returned without error")
 		}
 	}
-	go wait.Until(fn, 5*time.Second, wait.NeverStop)
+	go wait.Forever(fn, 5*time.Second)
 }
 
 func serveMetrics(bindAddress, proxyMode string, enableProfiling bool, errCh chan error) {
@@ -650,7 +650,7 @@ func serveMetrics(bindAddress, proxyMode string, enableProfiling bool, errCh cha
 			}
 		}
 	}
-	go wait.Until(fn, 5*time.Second, wait.NeverStop)
+	go wait.Forever(fn, 5*time.Second)
 }
 
 // Run runs the specified ProxyServer.  This should never exit (unless CleanupAndExit is set).

--- a/cmd/kubelet/app/server.go
+++ b/cmd/kubelet/app/server.go
@@ -822,12 +822,12 @@ func run(ctx context.Context, s *options.KubeletServer, kubeDeps *kubelet.Depend
 	if s.HealthzPort > 0 {
 		mux := http.NewServeMux()
 		healthz.InstallHandler(mux)
-		go wait.Until(func() {
+		go wait.Forever(func() {
 			err := http.ListenAndServe(net.JoinHostPort(s.HealthzBindAddress, strconv.Itoa(int(s.HealthzPort))), mux)
 			if err != nil {
 				klog.ErrorS(err, "Failed to start healthz server")
 			}
-		}, 5*time.Second, wait.NeverStop)
+		}, 5*time.Second)
 	}
 
 	if s.RunOnce {

--- a/pkg/kubelet/cm/container_manager_linux.go
+++ b/pkg/kubelet/cm/container_manager_linux.go
@@ -669,7 +669,7 @@ func (cm *containerManagerImpl) Start(node *v1.Node,
 	}
 	if hasEnsureStateFuncs {
 		// Run ensure state functions every minute.
-		go wait.Until(func() {
+		go wait.Forever(func() {
 			for _, cont := range cm.systemContainers {
 				if cont.ensureStateFunc != nil {
 					if err := cont.ensureStateFunc(cont.manager); err != nil {
@@ -677,18 +677,18 @@ func (cm *containerManagerImpl) Start(node *v1.Node,
 					}
 				}
 			}
-		}, time.Minute, wait.NeverStop)
+		}, time.Minute)
 
 	}
 
 	if len(cm.periodicTasks) > 0 {
-		go wait.Until(func() {
+		go wait.Forever(func() {
 			for _, task := range cm.periodicTasks {
 				if task != nil {
 					task()
 				}
 			}
-		}, 5*time.Minute, wait.NeverStop)
+		}, 5*time.Minute)
 	}
 
 	// Starts device manager.

--- a/pkg/kubelet/cm/cpumanager/cpu_manager.go
+++ b/pkg/kubelet/cm/cpumanager/cpu_manager.go
@@ -234,7 +234,7 @@ func (m *manager) Start(activePods ActivePodsFunc, sourcesReady config.SourcesRe
 	}
 	// Periodically call m.reconcileState() to continue to keep the CPU sets of
 	// all pods in sync with and guaranteed CPUs handed out among them.
-	go wait.Until(func() { m.reconcileState() }, m.reconcilePeriod, wait.NeverStop)
+	go wait.Forever(func() { m.reconcileState() }, m.reconcilePeriod)
 	return nil
 }
 

--- a/pkg/kubelet/cm/qos_container_manager_linux.go
+++ b/pkg/kubelet/cm/qos_container_manager_linux.go
@@ -134,12 +134,12 @@ func (m *qosContainerManagerImpl) Start(getNodeAllocatable func() v1.ResourceLis
 
 	// update qos cgroup tiers on startup and in periodic intervals
 	// to ensure desired state is in sync with actual state.
-	go wait.Until(func() {
+	go wait.Forever(func() {
 		err := m.UpdateCgroups()
 		if err != nil {
 			klog.InfoS("Failed to reserve QoS requests", "err", err)
 		}
-	}, periodicQOSCgroupUpdateInterval, wait.NeverStop)
+	}, periodicQOSCgroupUpdateInterval)
 
 	return nil
 }

--- a/pkg/kubelet/config/http.go
+++ b/pkg/kubelet/config/http.go
@@ -55,7 +55,7 @@ func NewSourceURL(url string, header http.Header, nodeName types.NodeName, perio
 		client: &http.Client{Timeout: 10 * time.Second},
 	}
 	klog.V(1).InfoS("Watching URL", "URL", url)
-	go wait.Until(config.run, period, wait.NeverStop)
+	go wait.Forever(config.run, period)
 }
 
 func (s *sourceURL) run() {

--- a/pkg/kubelet/dockershim/cm/container_manager_linux.go
+++ b/pkg/kubelet/dockershim/cm/container_manager_linux.go
@@ -82,7 +82,7 @@ func (m *containerManager) Start() error {
 		}
 		m.cgroupsManager = manager
 	}
-	go wait.Until(m.doWork, 5*time.Minute, wait.NeverStop)
+	go wait.Forever(m.doWork, 5*time.Minute)
 	return nil
 }
 

--- a/pkg/kubelet/images/image_gc_manager.go
+++ b/pkg/kubelet/images/image_gc_manager.go
@@ -24,9 +24,9 @@ import (
 	"sync"
 	"time"
 
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/klog/v2"
 
-	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -175,7 +175,7 @@ func NewImageGCManager(runtime container.Runtime, statsProvider StatsProvider, r
 }
 
 func (im *realImageGCManager) Start() {
-	go wait.Until(func() {
+	go wait.Forever(func() {
 		// Initial detection make detected time "unknown" in the past.
 		var ts time.Time
 		if im.initialized {
@@ -187,17 +187,17 @@ func (im *realImageGCManager) Start() {
 		} else {
 			im.initialized = true
 		}
-	}, 5*time.Minute, wait.NeverStop)
+	}, 5*time.Minute)
 
 	// Start a goroutine periodically updates image cache.
-	go wait.Until(func() {
+	go wait.Forever(func() {
 		images, err := im.runtime.ListImages()
 		if err != nil {
 			klog.InfoS("Failed to update image list", "err", err)
 		} else {
 			im.imageCache.set(images)
 		}
-	}, 30*time.Second, wait.NeverStop)
+	}, 30*time.Second)
 
 }
 

--- a/pkg/kubelet/images/puller.go
+++ b/pkg/kubelet/images/puller.go
@@ -19,7 +19,7 @@ package images
 import (
 	"time"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
@@ -64,7 +64,7 @@ type serialImagePuller struct {
 
 func newSerialImagePuller(imageService kubecontainer.ImageService) imagePuller {
 	imagePuller := &serialImagePuller{imageService, make(chan *imagePullRequest, maxImagePullRequests)}
-	go wait.Until(imagePuller.processImagePullRequests, time.Second, wait.NeverStop)
+	go wait.Forever(imagePuller.processImagePullRequests, time.Second)
 	return imagePuller
 }
 

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -1477,7 +1477,7 @@ func (kl *Kubelet) Run(updates <-chan kubetypes.PodUpdate) {
 		// start syncing lease
 		go kl.nodeLeaseController.Run(wait.NeverStop)
 	}
-	go wait.Until(kl.updateRuntimeUp, 5*time.Second, wait.NeverStop)
+	go wait.Forever(kl.updateRuntimeUp, 5*time.Second)
 
 	// Set up iptables util rules
 	if kl.makeIPTablesUtilChains {

--- a/pkg/kubelet/pleg/generic.go
+++ b/pkg/kubelet/pleg/generic.go
@@ -128,7 +128,7 @@ func (g *GenericPLEG) Watch() chan *PodLifecycleEvent {
 
 // Start spawns a goroutine to relist periodically.
 func (g *GenericPLEG) Start() {
-	go wait.Until(g.relist, g.relistPeriod, wait.NeverStop)
+	go wait.Forever(g.relist, g.relistPeriod)
 }
 
 // Healthy check if PLEG work properly.

--- a/pkg/kubelet/pod_container_deletor.go
+++ b/pkg/kubelet/pod_container_deletor.go
@@ -45,14 +45,14 @@ func (a containerStatusbyCreatedList) Less(i, j int) bool {
 
 func newPodContainerDeletor(runtime kubecontainer.Runtime, containersToKeep int) *podContainerDeletor {
 	buffer := make(chan kubecontainer.ContainerID, containerDeletorBufferLimit)
-	go wait.Until(func() {
+	go wait.Forever(func() {
 		for {
 			id := <-buffer
 			if err := runtime.DeleteContainer(id); err != nil {
 				klog.InfoS("DeleteContainer returned error", "containerID", id, "err", err)
 			}
 		}
-	}, 0, wait.NeverStop)
+	}, 0)
 
 	return &podContainerDeletor{
 		worker:           buffer,

--- a/pkg/kubelet/util/manager/watch_based_manager.go
+++ b/pkg/kubelet/util/manager/watch_based_manager.go
@@ -21,7 +21,7 @@ import (
 	"sync"
 	"time"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/tools/cache"
 
 	"k8s.io/klog/v2"
@@ -196,7 +196,7 @@ func NewObjectCache(
 	}
 
 	// TODO propagate stopCh from the higher level.
-	go wait.Until(store.startRecycleIdleWatch, time.Minute, wait.NeverStop)
+	go wait.Forever(store.startRecycleIdleWatch, time.Minute)
 	return store
 }
 

--- a/pkg/proxy/ipvs/graceful_termination.go
+++ b/pkg/proxy/ipvs/graceful_termination.go
@@ -203,5 +203,5 @@ func (m *GracefulTerminationManager) MoveRSOutofGracefulDeleteList(uniqueRS stri
 
 // Run start a goroutine to try to delete rs in the graceful delete rsList with an interval 1 minute
 func (m *GracefulTerminationManager) Run() {
-	go wait.Until(m.tryDeleteRs, rsCheckDeleteInterval, wait.NeverStop)
+	go wait.Forever(m.tryDeleteRs, rsCheckDeleteInterval)
 }

--- a/pkg/util/config/config.go
+++ b/pkg/util/config/config.go
@@ -74,7 +74,7 @@ func (m *Mux) Channel(source string) chan interface{} {
 	}
 	newChannel := make(chan interface{})
 	m.sources[source] = newChannel
-	go wait.Until(func() { m.listen(source, newChannel) }, 0, wait.NeverStop)
+	go wait.Forever(func() { m.listen(source, newChannel) }, 0)
 	return newChannel
 }
 

--- a/staging/src/k8s.io/apiserver/pkg/storage/storagebackend/factory/etcd3.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/storagebackend/factory/etcd3.go
@@ -81,7 +81,7 @@ func newETCD3HealthCheck(c storagebackend.Config) (func() error, error) {
 	clientErrMsg := &atomic.Value{}
 	clientErrMsg.Store("etcd client connection not yet established")
 
-	go wait.PollUntil(time.Second, func() (bool, error) {
+	go wait.PollInfinite(time.Second, func() (bool, error) {
 		client, err := newETCD3Client(c.Transport)
 		if err != nil {
 			clientErrMsg.Store(err.Error())
@@ -90,7 +90,7 @@ func newETCD3HealthCheck(c storagebackend.Config) (func() error, error) {
 		clientValue.Store(client)
 		clientErrMsg.Store("")
 		return true, nil
-	}, wait.NeverStop)
+	})
 
 	return func() error {
 		if errMsg := clientErrMsg.Load().(string); len(errMsg) > 0 {


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

We don't really need this but going through, it seemed odd to use `wait.Until` with `wait.NeverStop` rather than just using `wait.Forever` instead, which also denotes the meaning better. No change in behavior intended.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
