### PR TITLE
podresource-api: getAllocatableResources to Beta

### DIFF
--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -683,7 +683,7 @@ const (
 
 	// owner: @fromanirh
 	// alpha: v1.21
-	//
+	// beta: v1.23
 	// Enable POD resources API to return allocatable resources
 	KubeletPodResourcesGetAllocatable featuregate.Feature = "KubeletPodResourcesGetAllocatable"
 
@@ -870,7 +870,7 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
 	ServiceInternalTrafficPolicy:                   {Default: true, PreRelease: featuregate.Beta},
 	LogarithmicScaleDown:                           {Default: true, PreRelease: featuregate.Beta},
 	SuspendJob:                                     {Default: true, PreRelease: featuregate.Beta},
-	KubeletPodResourcesGetAllocatable:              {Default: false, PreRelease: featuregate.Alpha},
+	KubeletPodResourcesGetAllocatable:              {Default: true, PreRelease: featuregate.Beta},
 	NamespaceDefaultLabelName:                      {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.24
 	CSIVolumeHealth:                                {Default: false, PreRelease: featuregate.Alpha},
 	WindowsHostProcessContainers:                   {Default: false, PreRelease: featuregate.Alpha},

--- a/test/e2e_node/memory_manager_test.go
+++ b/test/e2e_node/memory_manager_test.go
@@ -176,12 +176,11 @@ func getAllocatableMemoryFromStateFile(s *state.MemoryManagerCheckpoint) []state
 }
 
 type kubeletParams struct {
-	podResourcesGetAllocatableFeatureGate bool
-	memoryManagerPolicy                   string
-	systemReservedMemory                  []kubeletconfig.MemoryReservation
-	systemReserved                        map[string]string
-	kubeReserved                          map[string]string
-	evictionHard                          map[string]string
+	memoryManagerPolicy  string
+	systemReservedMemory []kubeletconfig.MemoryReservation
+	systemReserved       map[string]string
+	kubeReserved         map[string]string
+	evictionHard         map[string]string
 }
 
 func getUpdatedKubeletConfig(oldCfg *kubeletconfig.KubeletConfiguration, params *kubeletParams) *kubeletconfig.KubeletConfiguration {
@@ -190,8 +189,6 @@ func getUpdatedKubeletConfig(oldCfg *kubeletconfig.KubeletConfiguration, params 
 	if newCfg.FeatureGates == nil {
 		newCfg.FeatureGates = map[string]bool{}
 	}
-
-	newCfg.FeatureGates["KubeletPodResourcesGetAllocatable"] = params.podResourcesGetAllocatableFeatureGate
 
 	newCfg.MemoryManagerPolicy = params.memoryManagerPolicy
 
@@ -283,7 +280,6 @@ var _ = SIGDescribe("Memory Manager [Serial] [Feature:MemoryManager]", func() {
 
 	memoryQuantity := resource.MustParse("1100Mi")
 	defaultKubeParams := &kubeletParams{
-		podResourcesGetAllocatableFeatureGate: true,
 		systemReservedMemory: []kubeletconfig.MemoryReservation{
 			{
 				NumaNode: 0,

--- a/test/e2e_node/podresources_test.go
+++ b/test/e2e_node/podresources_test.go
@@ -725,7 +725,6 @@ func enablePodResourcesFeatureGateInKubelet(f *framework.Framework) (oldCfg *kub
 	if newCfg.FeatureGates == nil {
 		newCfg.FeatureGates = make(map[string]bool)
 	}
-	newCfg.FeatureGates["KubeletPodResourcesGetAllocatable"] = true
 
 	// Update the Kubelet configuration.
 	framework.ExpectNoError(setKubeletConfiguration(f, newCfg))


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
Move the getAllocatableResources endpoint in podresource-api to beta.

#### Special notes for your reviewer:
Issue link: Extend podresources API to report allocatable resources https://github.com/kubernetes/enhancements/issues/2403

#### Does this PR introduce a user-facing change?

```release-note
Move the getAllocatableResources endpoint in podresource-api to the beta that will make it enabled by default.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
 [KEP]: https://github.com/kubernetes/enhancements/blob/master/keps/sig-node/2403-pod-resources-allocatable-resources/README.md
```
