### PR TITLE
Automated cherry pick of #103231: Overlaid OS's environment variables with the ones specified

### DIFF
--- a/pkg/credentialprovider/plugin/plugin_test.go
+++ b/pkg/credentialprovider/plugin/plugin_test.go
@@ -18,6 +18,7 @@ package plugin
 
 import (
 	"context"
+	"errors"
 	"reflect"
 	"testing"
 	"time"
@@ -502,4 +503,111 @@ func Test_NoCacheResponse(t *testing.T) {
 		t.Logf("expected cache keys: %v", expectedCacheKeys)
 		t.Error("unexpected cache keys")
 	}
+}
+
+func Test_ExecPluginEnvVars(t *testing.T) {
+	testcases := []struct {
+		name            string
+		systemEnvVars   []string
+		execPlugin      *execPlugin
+		expectedEnvVars []string
+	}{
+		{
+			name:          "positive append system env vars",
+			systemEnvVars: []string{"HOME=/home/foo", "PATH=/usr/bin"},
+			execPlugin: &execPlugin{
+				envVars: []kubeletconfig.ExecEnvVar{
+					{
+						Name:  "SUPER_SECRET_STRONG_ACCESS_KEY",
+						Value: "123456789",
+					},
+				},
+			},
+			expectedEnvVars: []string{
+				"HOME=/home/foo",
+				"PATH=/usr/bin",
+				"SUPER_SECRET_STRONG_ACCESS_KEY=123456789",
+			},
+		},
+		{
+			name:          "positive no env vars provided in plugin",
+			systemEnvVars: []string{"HOME=/home/foo", "PATH=/usr/bin"},
+			execPlugin:    &execPlugin{},
+			expectedEnvVars: []string{
+				"HOME=/home/foo",
+				"PATH=/usr/bin",
+			},
+		},
+		{
+			name: "positive no system env vars but env vars are provided in plugin",
+			execPlugin: &execPlugin{
+				envVars: []kubeletconfig.ExecEnvVar{
+					{
+						Name:  "SUPER_SECRET_STRONG_ACCESS_KEY",
+						Value: "123456789",
+					},
+				},
+			},
+			expectedEnvVars: []string{
+				"SUPER_SECRET_STRONG_ACCESS_KEY=123456789",
+			},
+		},
+		{
+			name:            "positive no system or plugin provided env vars",
+			execPlugin:      &execPlugin{},
+			expectedEnvVars: nil,
+		},
+		{
+			name:          "positive plugin provided vars takes priority",
+			systemEnvVars: []string{"HOME=/home/foo", "PATH=/usr/bin", "SUPER_SECRET_STRONG_ACCESS_KEY=1111"},
+			execPlugin: &execPlugin{
+				envVars: []kubeletconfig.ExecEnvVar{
+					{
+						Name:  "SUPER_SECRET_STRONG_ACCESS_KEY",
+						Value: "123456789",
+					},
+				},
+			},
+			expectedEnvVars: []string{
+				"HOME=/home/foo",
+				"PATH=/usr/bin",
+				"SUPER_SECRET_STRONG_ACCESS_KEY=1111",
+				"SUPER_SECRET_STRONG_ACCESS_KEY=123456789",
+			},
+		},
+	}
+
+	for _, testcase := range testcases {
+		t.Run(testcase.name, func(t *testing.T) {
+			testcase.execPlugin.environ = func() []string {
+				return testcase.systemEnvVars
+			}
+
+			var configVars []string
+			for _, envVar := range testcase.execPlugin.envVars {
+				configVars = append(configVars, fmt.Sprintf("%s=%s", envVar.Name, envVar.Value))
+			}
+			merged := mergeEnvVars(testcase.systemEnvVars, configVars)
+
+			err := validate(testcase.expectedEnvVars, merged)
+			if err != nil {
+				t.Logf("unexpecged error %v", err)
+			}
+		})
+	}
+}
+
+func validate(expected, actual []string) error {
+	if len(actual) != len(expected) {
+		return errors.New(fmt.Sprintf("actual env var length [%d] and expected env var length [%d] don't match",
+			len(actual), len(expected)))
+	}
+
+	for i := range actual {
+		if actual[i] != expected[i] {
+			return fmt.Errorf("mismatch in expected env var %s and actual env var %s", actual[i], expected[i])
+		}
+	}
+
+	return nil
 }


### PR DESCRIPTION
Cherry pick of #103231 on release-1.21.

#103231: Overlaid OS's environment variables with the ones specified

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.