### PR TITLE
sched: start dynamicInformerFactory along with regular informerFactory

### DIFF
--- a/cmd/kube-scheduler/app/config/config.go
+++ b/cmd/kube-scheduler/app/config/config.go
@@ -18,6 +18,7 @@ package config
 
 import (
 	apiserver "k8s.io/apiserver/pkg/server"
+	"k8s.io/client-go/dynamic/dynamicinformer"
 	"k8s.io/client-go/informers"
 	clientset "k8s.io/client-go/kubernetes"
 	restclient "k8s.io/client-go/rest"
@@ -40,9 +41,10 @@ type Config struct {
 	Authorization  apiserver.AuthorizationInfo
 	SecureServing  *apiserver.SecureServingInfo
 
-	Client          clientset.Interface
-	KubeConfig      *restclient.Config
-	InformerFactory informers.SharedInformerFactory
+	Client             clientset.Interface
+	KubeConfig         *restclient.Config
+	InformerFactory    informers.SharedInformerFactory
+	DynInformerFactory dynamicinformer.DynamicSharedInformerFactory
 
 	//lint:ignore SA1019 this deprecated field still needs to be used for now. It will be removed once the migration is done.
 	EventBroadcaster events.EventBroadcasterAdapter

--- a/cmd/kube-scheduler/app/options/options.go
+++ b/cmd/kube-scheduler/app/options/options.go
@@ -27,6 +27,8 @@ import (
 	"k8s.io/apimachinery/pkg/util/uuid"
 	apiserveroptions "k8s.io/apiserver/pkg/server/options"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/dynamic/dynamicinformer"
 	clientset "k8s.io/client-go/kubernetes"
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
@@ -284,6 +286,8 @@ func (o *Options) Config() (*schedulerappconfig.Config, error) {
 	c.Client = client
 	c.KubeConfig = kubeConfig
 	c.InformerFactory = scheduler.NewInformerFactory(client, 0)
+	dynClient := dynamic.NewForConfigOrDie(kubeConfig)
+	c.DynInformerFactory = dynamicinformer.NewFilteredDynamicSharedInformerFactory(dynClient, 0, corev1.NamespaceAll, nil)
 	c.LeaderElection = leaderElectionConfig
 
 	return c, nil

--- a/cmd/kube-scheduler/app/server.go
+++ b/cmd/kube-scheduler/app/server.go
@@ -180,11 +180,15 @@ func Run(ctx context.Context, cc *schedulerserverconfig.CompletedConfig, sched *
 
 	// Start all informers.
 	cc.InformerFactory.Start(ctx.Done())
+	// DynInformerFactory can be nil in tests.
+	if cc.DynInformerFactory != nil {
+		cc.DynInformerFactory.Start(ctx.Done())
+	}
+
 	// Wait for all caches to sync before scheduling.
 	cc.InformerFactory.WaitForCacheSync(ctx.Done())
 	// DynInformerFactory can be nil in tests.
 	if cc.DynInformerFactory != nil {
-		cc.DynInformerFactory.Start(ctx.Done())
 		cc.DynInformerFactory.WaitForCacheSync(ctx.Done())
 	}
 

--- a/cmd/kube-scheduler/app/server.go
+++ b/cmd/kube-scheduler/app/server.go
@@ -180,9 +180,13 @@ func Run(ctx context.Context, cc *schedulerserverconfig.CompletedConfig, sched *
 
 	// Start all informers.
 	cc.InformerFactory.Start(ctx.Done())
-
 	// Wait for all caches to sync before scheduling.
 	cc.InformerFactory.WaitForCacheSync(ctx.Done())
+	// DynInformerFactory can be nil in tests.
+	if cc.DynInformerFactory != nil {
+		cc.DynInformerFactory.Start(ctx.Done())
+		cc.DynInformerFactory.WaitForCacheSync(ctx.Done())
+	}
 
 	// If leader election is enabled, runCommand via LeaderElector until done and exit.
 	if cc.LeaderElection != nil {
@@ -303,6 +307,7 @@ func Setup(ctx context.Context, opts *options.Options, outOfTreeRegistryOptions 
 	// Create the scheduler.
 	sched, err := scheduler.New(cc.Client,
 		cc.InformerFactory,
+		cc.DynInformerFactory,
 		recorderFactory,
 		ctx.Done(),
 		scheduler.WithComponentConfigVersion(cc.ComponentConfig.TypeMeta.APIVersion),

--- a/pkg/scheduler/apis/config/testing/compatibility_test.go
+++ b/pkg/scheduler/apis/config/testing/compatibility_test.go
@@ -245,6 +245,7 @@ func TestPolicyCompatibility(t *testing.T) {
 			sched, err := scheduler.New(
 				client,
 				informerFactory,
+				nil,
 				recorderFactory,
 				make(chan struct{}),
 				scheduler.WithProfiles([]config.KubeSchedulerProfile(nil)...),

--- a/pkg/scheduler/factory_test.go
+++ b/pkg/scheduler/factory_test.go
@@ -422,6 +422,7 @@ func TestCreateFromConfig(t *testing.T) {
 			_, err := New(
 				client,
 				informerFactory,
+				nil,
 				recorderFactory,
 				make(chan struct{}),
 				WithProfiles([]schedulerapi.KubeSchedulerProfile(nil)...),

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -245,6 +245,7 @@ func TestSchedulerCreation(t *testing.T) {
 			s, err := New(
 				client,
 				informerFactory,
+				nil,
 				profile.NewRecorderFactory(eventBroadcaster),
 				stopCh,
 				tc.opts...,
@@ -553,6 +554,7 @@ func TestSchedulerMultipleProfilesScheduling(t *testing.T) {
 	sched, err := New(
 		client,
 		informerFactory,
+		nil,
 		profile.NewRecorderFactory(broadcaster),
 		ctx.Done(),
 		WithProfiles(

--- a/test/integration/daemonset/daemonset_test.go
+++ b/test/integration/daemonset/daemonset_test.go
@@ -90,6 +90,7 @@ func setupScheduler(
 	sched, err := scheduler.New(
 		cs,
 		informerFactory,
+		nil,
 		profile.NewRecorderFactory(eventBroadcaster),
 		ctx.Done(),
 	)

--- a/test/integration/scheduler/scheduler_test.go
+++ b/test/integration/scheduler/scheduler_test.go
@@ -280,6 +280,7 @@ priorities: []
 
 		sched, err := scheduler.New(clientSet,
 			informerFactory,
+			nil,
 			profile.NewRecorderFactory(eventBroadcaster),
 			nil,
 			scheduler.WithProfiles([]config.KubeSchedulerProfile(nil)...),
@@ -337,6 +338,7 @@ func TestSchedulerCreationFromNonExistentConfigMap(t *testing.T) {
 
 	_, err := scheduler.New(clientSet,
 		informerFactory,
+		nil,
 		profile.NewRecorderFactory(eventBroadcaster),
 		nil,
 		scheduler.WithLegacyPolicySource(&config.SchedulerPolicySource{

--- a/test/integration/util/util.go
+++ b/test/integration/util/util.go
@@ -196,9 +196,11 @@ func PodDeleted(c clientset.Interface, podNamespace, podName string) wait.Condit
 // SyncInformerFactory starts informer and waits for caches to be synced
 func SyncInformerFactory(testCtx *TestContext) {
 	testCtx.InformerFactory.Start(testCtx.Ctx.Done())
-	testCtx.InformerFactory.WaitForCacheSync(testCtx.Ctx.Done())
 	if testCtx.DynInformerFactory != nil {
 		testCtx.DynInformerFactory.Start(testCtx.Ctx.Done())
+	}
+	testCtx.InformerFactory.WaitForCacheSync(testCtx.Ctx.Done())
+	if testCtx.DynInformerFactory != nil {
 		testCtx.DynInformerFactory.WaitForCacheSync(testCtx.Ctx.Done())
 	}
 }

--- a/test/integration/volumescheduling/util.go
+++ b/test/integration/volumescheduling/util.go
@@ -123,6 +123,7 @@ func initTestSchedulerWithOptions(
 	testCtx.scheduler, err = scheduler.New(
 		testCtx.clientSet,
 		testCtx.informerFactory,
+		nil,
 		profile.NewRecorderFactory(eventBroadcaster),
 		testCtx.ctx.Done())
 


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/sig scheduling

#### What this PR does / why we need it:

Followup of https://github.com/kubernetes/kubernetes/pull/104793#discussion_r706873499.

This PR moves the logic of starting dynamicInformerFactory right after regular informerFactory's start, and thus make the behavior intuitive and consistent.

#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
