### PR TITLE
staging/publishing: Set go1.16 version to go1.16.8

### DIFF
--- a/staging/publishing/rules.yaml
+++ b/staging/publishing/rules.yaml
@@ -29,10 +29,12 @@ rules:
       branch: release-1.21
       dir: staging/src/k8s.io/code-generator
     name: release-1.21
+    go: 1.16.8
   - source:
       branch: release-1.22
       dir: staging/src/k8s.io/code-generator
     name: release-1.22
+    go: 1.16.8
 
 - destination: apimachinery
   library: true
@@ -55,10 +57,12 @@ rules:
       branch: release-1.21
       dir: staging/src/k8s.io/apimachinery
     name: release-1.21
+    go: 1.16.8
   - source:
       branch: release-1.22
       dir: staging/src/k8s.io/apimachinery
     name: release-1.22
+    go: 1.16.8
 
 - destination: api
   library: true
@@ -90,6 +94,7 @@ rules:
       branch: release-1.21
       dir: staging/src/k8s.io/api
     name: release-1.21
+    go: 1.16.8
     dependencies:
       - repository: apimachinery
         branch: release-1.21
@@ -97,6 +102,7 @@ rules:
       branch: release-1.22
       dir: staging/src/k8s.io/api
     name: release-1.22
+    go: 1.16.8
     dependencies:
     - repository: apimachinery
       branch: release-1.22
@@ -149,6 +155,7 @@ rules:
       branch: release-1.21
       dir: staging/src/k8s.io/client-go
     name: release-1.21
+    go: 1.16.8
     dependencies:
       - repository: apimachinery
         branch: release-1.21
@@ -162,6 +169,7 @@ rules:
       branch: release-1.22
       dir: staging/src/k8s.io/client-go
     name: release-1.22
+    go: 1.16.8
     dependencies:
       - repository: apimachinery
         branch: release-1.22
@@ -214,6 +222,7 @@ rules:
       branch: release-1.21
       dir: staging/src/k8s.io/component-base
     name: release-1.21
+    go: 1.16.8
     dependencies:
     - repository: apimachinery
       branch: release-1.21
@@ -225,6 +234,7 @@ rules:
       branch: release-1.22
       dir: staging/src/k8s.io/component-base
     name: release-1.22
+    go: 1.16.8
     dependencies:
     - repository: apimachinery
       branch: release-1.22
@@ -263,6 +273,7 @@ rules:
       branch: release-1.21
       dir: staging/src/k8s.io/component-helpers
     name: release-1.21
+    go: 1.16.8
     dependencies:
     - repository: apimachinery
       branch: release-1.21
@@ -274,6 +285,7 @@ rules:
       branch: release-1.22
       dir: staging/src/k8s.io/component-helpers
     name: release-1.22
+    go: 1.16.8
     dependencies:
     - repository: apimachinery
       branch: release-1.22
@@ -330,6 +342,7 @@ rules:
       branch: release-1.21
       dir: staging/src/k8s.io/apiserver
     name: release-1.21
+    go: 1.16.8
     dependencies:
     - repository: apimachinery
       branch: release-1.21
@@ -343,6 +356,7 @@ rules:
       branch: release-1.22
       dir: staging/src/k8s.io/apiserver
     name: release-1.22
+    go: 1.16.8
     dependencies:
     - repository: apimachinery
       branch: release-1.22
@@ -412,6 +426,7 @@ rules:
       branch: release-1.21
       dir: staging/src/k8s.io/kube-aggregator
     name: release-1.21
+    go: 1.16.8
     dependencies:
     - repository: apimachinery
       branch: release-1.21
@@ -429,6 +444,7 @@ rules:
       branch: release-1.22
       dir: staging/src/k8s.io/kube-aggregator
     name: release-1.22
+    go: 1.16.8
     dependencies:
     - repository: apimachinery
       branch: release-1.22
@@ -517,6 +533,7 @@ rules:
       branch: release-1.21
       dir: staging/src/k8s.io/sample-apiserver
     name: release-1.21
+    go: 1.16.8
     dependencies:
     - repository: apimachinery
       branch: release-1.21
@@ -539,6 +556,7 @@ rules:
       branch: release-1.22
       dir: staging/src/k8s.io/sample-apiserver
     name: release-1.22
+    go: 1.16.8
     dependencies:
     - repository: apimachinery
       branch: release-1.22
@@ -620,6 +638,7 @@ rules:
       branch: release-1.21
       dir: staging/src/k8s.io/sample-controller
     name: release-1.21
+    go: 1.16.8
     dependencies:
     - repository: apimachinery
       branch: release-1.21
@@ -638,6 +657,7 @@ rules:
       branch: release-1.22
       dir: staging/src/k8s.io/sample-controller
     name: release-1.22
+    go: 1.16.8
     dependencies:
     - repository: apimachinery
       branch: release-1.22
@@ -718,6 +738,7 @@ rules:
       branch: release-1.21
       dir: staging/src/k8s.io/apiextensions-apiserver
     name: release-1.21
+    go: 1.16.8
     dependencies:
     - repository: apimachinery
       branch: release-1.21
@@ -737,6 +758,7 @@ rules:
       branch: release-1.22
       dir: staging/src/k8s.io/apiextensions-apiserver
     name: release-1.22
+    go: 1.16.8
     dependencies:
     - repository: apimachinery
       branch: release-1.22
@@ -801,6 +823,7 @@ rules:
       branch: release-1.21
       dir: staging/src/k8s.io/metrics
     name: release-1.21
+    go: 1.16.8
     dependencies:
     - repository: apimachinery
       branch: release-1.21
@@ -814,6 +837,7 @@ rules:
       branch: release-1.22
       dir: staging/src/k8s.io/metrics
     name: release-1.22
+    go: 1.16.8
     dependencies:
     - repository: apimachinery
       branch: release-1.22
@@ -866,6 +890,7 @@ rules:
       branch: release-1.21
       dir: staging/src/k8s.io/cli-runtime
     name: release-1.21
+    go: 1.16.8
     dependencies:
     - repository: api
       branch: release-1.21
@@ -877,6 +902,7 @@ rules:
       branch: release-1.22
       dir: staging/src/k8s.io/cli-runtime
     name: release-1.22
+    go: 1.16.8
     dependencies:
     - repository: api
       branch: release-1.22
@@ -933,6 +959,7 @@ rules:
       branch: release-1.21
       dir: staging/src/k8s.io/sample-cli-plugin
     name: release-1.21
+    go: 1.16.8
     dependencies:
     - repository: api
       branch: release-1.21
@@ -946,6 +973,7 @@ rules:
       branch: release-1.22
       dir: staging/src/k8s.io/sample-cli-plugin
     name: release-1.22
+    go: 1.16.8
     dependencies:
     - repository: api
       branch: release-1.22
@@ -1004,6 +1032,7 @@ rules:
       branch: release-1.21
       dir: staging/src/k8s.io/kube-proxy
     name: release-1.21
+    go: 1.16.8
     dependencies:
     - repository: apimachinery
       branch: release-1.21
@@ -1017,6 +1046,7 @@ rules:
       branch: release-1.22
       dir: staging/src/k8s.io/kube-proxy
     name: release-1.22
+    go: 1.16.8
     dependencies:
     - repository: apimachinery
       branch: release-1.22
@@ -1075,6 +1105,7 @@ rules:
       branch: release-1.21
       dir: staging/src/k8s.io/kubelet
     name: release-1.21
+    go: 1.16.8
     dependencies:
     - repository: apimachinery
       branch: release-1.21
@@ -1088,6 +1119,7 @@ rules:
       branch: release-1.22
       dir: staging/src/k8s.io/kubelet
     name: release-1.22
+    go: 1.16.8
     dependencies:
     - repository: apimachinery
       branch: release-1.22
@@ -1146,6 +1178,7 @@ rules:
       branch: release-1.21
       dir: staging/src/k8s.io/kube-scheduler
     name: release-1.21
+    go: 1.16.8
     dependencies:
     - repository: apimachinery
       branch: release-1.21
@@ -1159,6 +1192,7 @@ rules:
       branch: release-1.22
       dir: staging/src/k8s.io/kube-scheduler
     name: release-1.22
+    go: 1.16.8
     dependencies:
     - repository: apimachinery
       branch: release-1.22
@@ -1212,6 +1246,7 @@ rules:
       branch: release-1.21
       dir: staging/src/k8s.io/controller-manager
     name: release-1.21
+    go: 1.16.8
     dependencies:
     - repository: api
       branch: release-1.21
@@ -1227,6 +1262,7 @@ rules:
       branch: release-1.22
       dir: staging/src/k8s.io/controller-manager
     name: release-1.22
+    go: 1.16.8
     dependencies:
     - repository: api
       branch: release-1.22
@@ -1295,6 +1331,7 @@ rules:
       branch: release-1.21
       dir: staging/src/k8s.io/cloud-provider
     name: release-1.21
+    go: 1.16.8
     dependencies:
     - repository: api
       branch: release-1.21
@@ -1312,6 +1349,7 @@ rules:
       branch: release-1.22
       dir: staging/src/k8s.io/cloud-provider
     name: release-1.22
+    go: 1.16.8
     dependencies:
     - repository: api
       branch: release-1.22
@@ -1386,6 +1424,7 @@ rules:
       branch: release-1.21
       dir: staging/src/k8s.io/kube-controller-manager
     name: release-1.21
+    go: 1.16.8
     dependencies:
     - repository: apimachinery
       branch: release-1.21
@@ -1405,6 +1444,7 @@ rules:
       branch: release-1.22
       dir: staging/src/k8s.io/kube-controller-manager
     name: release-1.22
+    go: 1.16.8
     dependencies:
     - repository: apimachinery
       branch: release-1.22
@@ -1457,6 +1497,7 @@ rules:
       branch: release-1.21
       dir: staging/src/k8s.io/cluster-bootstrap
     name: release-1.21
+    go: 1.16.8
     dependencies:
     - repository: apimachinery
       branch: release-1.21
@@ -1466,6 +1507,7 @@ rules:
       branch: release-1.22
       dir: staging/src/k8s.io/cluster-bootstrap
     name: release-1.22
+    go: 1.16.8
     dependencies:
     - repository: apimachinery
       branch: release-1.22
@@ -1514,6 +1556,7 @@ rules:
       branch: release-1.21
       dir: staging/src/k8s.io/csi-translation-lib
     name: release-1.21
+    go: 1.16.8
     dependencies:
     - repository: api
       branch: release-1.21
@@ -1523,6 +1566,7 @@ rules:
       branch: release-1.22
       dir: staging/src/k8s.io/csi-translation-lib
     name: release-1.22
+    go: 1.16.8
     dependencies:
     - repository: api
       branch: release-1.22
@@ -1545,10 +1589,12 @@ rules:
       branch: release-1.21
       dir: staging/src/k8s.io/mount-utils
     name: release-1.21
+    go: 1.16.8
   - source:
       branch: release-1.22
       dir: staging/src/k8s.io/mount-utils
     name: release-1.22
+    go: 1.16.8
 
 - destination: legacy-cloud-providers
   library: true
@@ -1622,6 +1668,7 @@ rules:
       branch: release-1.21
       dir: staging/src/k8s.io/legacy-cloud-providers
     name: release-1.21
+    go: 1.16.8
     dependencies:
     - repository: api
       branch: release-1.21
@@ -1643,6 +1690,7 @@ rules:
       branch: release-1.22
       dir: staging/src/k8s.io/legacy-cloud-providers
     name: release-1.22
+    go: 1.16.8
     dependencies:
     - repository: api
       branch: release-1.22
@@ -1684,10 +1732,12 @@ rules:
       branch: release-1.21
       dir: staging/src/k8s.io/cri-api
     name: release-1.21
+    go: 1.16.8
   - source:
       branch: release-1.22
       dir: staging/src/k8s.io/cri-api
     name: release-1.22
+    go: 1.16.8
 
 - destination: kubectl
   library: true
@@ -1759,6 +1809,7 @@ rules:
       branch: release-1.21
       dir: staging/src/k8s.io/kubectl
     name: release-1.21
+    go: 1.16.8
     dependencies:
     - repository: api
       branch: release-1.21
@@ -1780,6 +1831,7 @@ rules:
       branch: release-1.22
       dir: staging/src/k8s.io/kubectl
     name: release-1.22
+    go: 1.16.8
     dependencies:
     - repository: api
       branch: release-1.22
@@ -1820,6 +1872,7 @@ rules:
       branch: release-1.22
       dir: staging/src/k8s.io/pod-security-admission
     name: release-1.22
+    go: 1.16.8
     dependencies:
     - repository: api
       branch: release-1.22


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/area dependency security

#### What this PR does / why we need it:

staging/publishing: Set go1.16 version to go1.16.8
Part of https://github.com/kubernetes/release/issues/2238

/assign @nikhita @dims @justaugustus 
cc: @kubernetes/release-engineering 

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
