### PR TITLE
Provide a timeout function to fail quick on blocking operations

### DIFF
--- a/test/integration/scheduler/queue_test.go
+++ b/test/integration/scheduler/queue_test.go
@@ -139,7 +139,7 @@ func TestServiceAffinityEnqueue(t *testing.T) {
 	}
 
 	// Pop Pod2 out. It should be unschedulable.
-	podInfo := testCtx.Scheduler.NextPod()
+	podInfo := nextPodOrDie(t, testCtx)
 	fwk, ok := testCtx.Scheduler.Profiles[podInfo.Pod.Spec.SchedulerName]
 	if !ok {
 		t.Fatalf("Cannot find the profile for Pod %v", podInfo.Pod.Name)
@@ -164,7 +164,7 @@ func TestServiceAffinityEnqueue(t *testing.T) {
 	}
 
 	// Now we should be able to pop the Pod from activeQ again.
-	podInfo = testCtx.Scheduler.NextPod()
+	podInfo = nextPodOrDie(t, testCtx)
 	if podInfo.Attempts != 2 {
 		t.Errorf("Expected the Pod to be attempted 2 times, but got %v", podInfo.Attempts)
 	}
@@ -304,7 +304,7 @@ func TestCustomResourceEnqueue(t *testing.T) {
 	}
 
 	// Pop fake-pod out. It should be unschedulable.
-	podInfo := testCtx.Scheduler.NextPod()
+	podInfo := nextPodOrDie(t, testCtx)
 	fwk, ok := testCtx.Scheduler.Profiles[podInfo.Pod.Spec.SchedulerName]
 	if !ok {
 		t.Fatalf("Cannot find the profile for Pod %v", podInfo.Pod.Name)
@@ -336,7 +336,7 @@ func TestCustomResourceEnqueue(t *testing.T) {
 	}
 
 	// Now we should be able to pop the Pod from activeQ again.
-	podInfo = testCtx.Scheduler.NextPod()
+	podInfo = nextPodOrDie(t, testCtx)
 	if podInfo.Attempts != 2 {
 		t.Errorf("Expected the Pod to be attempted 2 times, but got %v", podInfo.Attempts)
 	}


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/sig scheduling

#### What this PR does / why we need it:

Follow-up of https://github.com/kubernetes/kubernetes/pull/105016#discussion_r708558567.

When we run a blocking operation in the integration test, if the operation function well, the entire test would complete properly. But in terms of abnormal cases, like a PR introduces faulty changes, the blocking operation would hang there until the default go test timeout (10m) is reached.

```
$ go help testflag
...
	-timeout d
	    If a test binary runs longer than duration d, panic.
	    If d is 0, the timeout is disabled.
	    The default is 10 minutes (10m).
```

This PR introduces a timeout function to fail quickly in this scenario. It works similarly to the Linux `timeout` utility. 

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```