### PR TITLE
remove invalid nil check when writing project files

### DIFF
--- a/pkg/volume/util/fsquota/project.go
+++ b/pkg/volume/util/fsquota/project.go
@@ -301,18 +301,17 @@ func writeProjectFiles(fProjects *os.File, fProjid *os.File, writeProjid bool, l
 				}
 			}
 		}
+
+		err = os.Rename(tmpProjects, fProjects.Name())
 		if err == nil {
-			err = os.Rename(tmpProjects, fProjects.Name())
-			if err == nil {
-				return nil
-			}
-			// We're in a bit of trouble here; at this
-			// point we've successfully renamed tmpProjid
-			// to the real thing, but renaming tmpProject
-			// to the real file failed.  There's not much we
-			// can do in this position.  Anything we could do
-			// to try to undo it would itself be likely to fail.
+			return nil
 		}
+		// We're in a bit of trouble here; at this
+		// point we've successfully renamed tmpProjid
+		// to the real thing, but renaming tmpProject
+		// to the real file failed.  There's not much we
+		// can do in this position.  Anything we could do
+		// to try to undo it would itself be likely to fail.
 		os.Remove(tmpProjects)
 	}
 	return fmt.Errorf("unable to write project files: %v", err)


### PR DESCRIPTION
What type of PR is this?
/kind bug

What this PR does / why we need it:
there is a redundant nil check in writeProjectFiles(*)

Which issue(s) this PR fixes:

Special notes for your reviewer:

Does this PR introduce a user-facing change?
```release-notes
NONE
```

Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```release-notes
NONE
```