### PR TITLE
Run kubelet in a job object in windows

### DIFF
--- a/cmd/kubelet/app/init_windows.go
+++ b/cmd/kubelet/app/init_windows.go
@@ -21,7 +21,9 @@ package app
 
 import (
 	"fmt"
+	"unsafe"
 
+	"github.com/pkg/errors"
 	"golang.org/x/sys/windows"
 	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/pkg/windows/service"
@@ -35,14 +37,40 @@ const (
 // Ref: https://docs.microsoft.com/en-us/windows/win32/cimwin32prov/setpriority-method-in-class-win32-process
 func getPriorityValue(priorityClassName string) uint32 {
 	var priorityClassMap = map[string]uint32{
-		"IDLE_PRIORITY_CLASS":         uint32(64),
-		"BELOW_NORMAL_PRIORITY_CLASS": uint32(16384),
-		"NORMAL_PRIORITY_CLASS":       uint32(32),
-		"ABOVE_NORMAL_PRIORITY_CLASS": uint32(32768),
-		"HIGH_PRIORITY_CLASS":         uint32(128),
-		"REALTIME_PRIORITY_CLASS":     uint32(256),
+		"IDLE_PRIORITY_CLASS":         uint32(windows.IDLE_PRIORITY_CLASS),
+		"BELOW_NORMAL_PRIORITY_CLASS": uint32(windows.BELOW_NORMAL_PRIORITY_CLASS),
+		"NORMAL_PRIORITY_CLASS":       uint32(windows.NORMAL_PRIORITY_CLASS),
+		"ABOVE_NORMAL_PRIORITY_CLASS": uint32(windows.ABOVE_NORMAL_PRIORITY_CLASS),
+		"HIGH_PRIORITY_CLASS":         uint32(windows.HIGH_PRIORITY_CLASS),
+		"REALTIME_PRIORITY_CLASS":     uint32(windows.REALTIME_PRIORITY_CLASS),
 	}
 	return priorityClassMap[priorityClassName]
+}
+
+// createWindowsJobObject creates a new Job Object
+// (https://docs.microsoft.com/en-us/windows/win32/procthread/job-objects),
+// and specifies the priority class for the job object to the specified value.
+// A job object is used here so that any spawned processes such as powershell or
+// wmic are created at the specified thread priority class.
+// Running kubelet with above normal / high priority  can help improve
+// responsiveness on machines with high CPU utilization.
+func createWindowsJobObject(pc uint32) (windows.Handle, error) {
+	job, err := windows.CreateJobObject(nil, nil)
+	if err != nil {
+		return windows.InvalidHandle, errors.Wrap(err, "windows.CreateJobObject failed")
+	}
+	limitInfo := windows.JOBOBJECT_BASIC_LIMIT_INFORMATION{
+		LimitFlags:    windows.JOB_OBJECT_LIMIT_PRIORITY_CLASS,
+		PriorityClass: pc,
+	}
+	if _, err := windows.SetInformationJobObject(
+		job,
+		windows.JobObjectBasicLimitInformation,
+		uintptr(unsafe.Pointer(&limitInfo)),
+		uint32(unsafe.Sizeof(limitInfo))); err != nil {
+		return windows.InvalidHandle, errors.Wrap(err, "windows.SetInformationJobObject failed")
+	}
+	return job, nil
 }
 
 func initForOS(windowsService bool, windowsPriorityClass string) error {
@@ -51,11 +79,13 @@ func initForOS(windowsService bool, windowsPriorityClass string) error {
 		return fmt.Errorf("unknown priority class %s, valid ones are available at "+
 			"https://docs.microsoft.com/en-us/windows/win32/procthread/scheduling-priorities", windowsPriorityClass)
 	}
-	kubeletProcessHandle := windows.CurrentProcess()
-	// Set the priority of the kubelet process to given priority
-	klog.InfoS("Setting the priority of kubelet process", "windowsPriorityClass", windowsPriorityClass)
-	if err := windows.SetPriorityClass(kubeletProcessHandle, priority); err != nil {
+	klog.InfoS("Creating a Windows job object and adding kubelet process to it", "windowsPriorityClass", windowsPriorityClass)
+	job, err := createWindowsJobObject(priority)
+	if err != nil {
 		return err
+	}
+	if err := windows.AssignProcessToJobObject(job, windows.CurrentProcess()); err != nil {
+		return errors.Wrap(err, "windows.AssignProcessToJobObject failed")
 	}
 
 	if windowsService {


### PR DESCRIPTION
Signed-off-by: Mark Rossetti <marosset@microsoft.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

Improves upon https://github.com/kubernetes/kubernetes/pull/96051 by running kubelet inside a Windows job object.
Running kubelet inside a job object means all spawned process will be associated with the job object an inherit properties like process priority. 
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:



#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
/sig windows
/sig node
/area kubelet
