### PR TITLE
Fix core calculation for dns autoscaler test.

### DIFF
--- a/test/e2e/autoscaling/dns_autoscaling.go
+++ b/test/e2e/autoscaling/dns_autoscaling.go
@@ -255,13 +255,7 @@ func getSchedulableCores(nodes []v1.Node) int64 {
 			sc.Add(node.Status.Allocatable[v1.ResourceCPU])
 		}
 	}
-
-	scInt64, scOk := sc.AsInt64()
-	if !scOk {
-		framework.Logf("Unable to compute integer values of schedulable cores in the cluster")
-		return 0
-	}
-	return scInt64
+	return sc.Value()
 }
 
 func fetchDNSScalingConfigMap(c clientset.Interface) (*v1.ConfigMap, error) {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

This is a follow up of https://github.com/kubernetes/kubernetes/pull/102112. The previous change didn't account for the return value being a string instead of an integer.

This is essentially the same as https://github.com/kubernetes-sigs/cluster-proportional-autoscaler/pull/88.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #NONE

#### Special notes for your reviewer:

/assign @prameshj @jkaniuk

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
