### PR TITLE
Improve formatting in CHANGELOGs

### DIFF
--- a/CHANGELOG/CHANGELOG-1.19.md
+++ b/CHANGELOG/CHANGELOG-1.19.md
@@ -487,18 +487,20 @@ This release contains changes that address the following vulnerabilities:
 A security issue was discovered in Kubernetes where a user may be able to
 create a container with subpath volume mounts to access files &
 directories outside of the volume, including on the host filesystem.
+
 **Affected Versions**:
   - kubelet v1.22.0 - v1.22.1
   - kubelet v1.21.0 - v1.21.4
   - kubelet v1.20.0 - v1.20.10
   - kubelet <= v1.19.14
+
 **Fixed Versions**:
   - kubelet v1.22.2
   - kubelet v1.21.5
   - kubelet v1.20.11
   - kubelet v1.19.15
-This vulnerability was reported by Fabricio Voznika and Mark Wolters of Google.
 
+This vulnerability was reported by Fabricio Voznika and Mark Wolters of Google.
 
 **CVSS Rating:** High (8.8) [CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H](https://www.first.org/cvss/calculator/3.0#CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H)
 

--- a/CHANGELOG/CHANGELOG-1.20.md
+++ b/CHANGELOG/CHANGELOG-1.20.md
@@ -393,18 +393,20 @@ This release contains changes that address the following vulnerabilities:
 A security issue was discovered in Kubernetes where a user may be able to
 create a container with subpath volume mounts to access files &
 directories outside of the volume, including on the host filesystem.
+
 **Affected Versions**:
   - kubelet v1.22.0 - v1.22.1
   - kubelet v1.21.0 - v1.21.4
   - kubelet v1.20.0 - v1.20.10
   - kubelet <= v1.19.14
+
 **Fixed Versions**:
   - kubelet v1.22.2
   - kubelet v1.21.5
   - kubelet v1.20.11
   - kubelet v1.19.15
-This vulnerability was reported by Fabricio Voznika and Mark Wolters of Google.
 
+This vulnerability was reported by Fabricio Voznika and Mark Wolters of Google.
 
 **CVSS Rating:** High (8.8) [CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H](https://www.first.org/cvss/calculator/3.0#CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H)
 

--- a/CHANGELOG/CHANGELOG-1.21.md
+++ b/CHANGELOG/CHANGELOG-1.21.md
@@ -292,18 +292,20 @@ This release contains changes that address the following vulnerabilities:
 A security issue was discovered in Kubernetes where a user may be able to
 create a container with subpath volume mounts to access files &
 directories outside of the volume, including on the host filesystem.
+
 **Affected Versions**:
   - kubelet v1.22.0 - v1.22.1
   - kubelet v1.21.0 - v1.21.4
   - kubelet v1.20.0 - v1.20.10
   - kubelet <= v1.19.14
+
 **Fixed Versions**:
   - kubelet v1.22.2
   - kubelet v1.21.5
   - kubelet v1.20.11
   - kubelet v1.19.15
-This vulnerability was reported by Fabricio Voznika and Mark Wolters of Google.
 
+This vulnerability was reported by Fabricio Voznika and Mark Wolters of Google.
 
 **CVSS Rating:** High (8.8) [CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H](https://www.first.org/cvss/calculator/3.0#CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H)
 


### PR DESCRIPTION
/sig release
/kind cleanup

**Before:**

![Screenshot 2021-09-17 at 10 09 20](https://user-images.githubusercontent.com/9372594/133740031-1077d0ce-817e-47c2-bd49-74e9e8f4e08f.png)

**After:**

![Screenshot 2021-09-17 at 10 09 47](https://user-images.githubusercontent.com/9372594/133740053-34828a65-e1c8-47c2-97bf-014d6ad05d1a.png)



#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
