### PR TITLE
Add new kubectl config set-credentials options

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/config/create_authinfo_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/config/create_authinfo_test.go
@@ -171,6 +171,54 @@ func TestCreateAuthInfoOptions(t *testing.T) {
 			name: "test11",
 			flags: []string{
 				"--exec-command=example-client-go-exec-plugin",
+				"--exec-api-version=client.authentication.k8s.io/v1",
+				"me",
+			},
+			wantOptions: &createAuthInfoOptions{
+				name:           "me",
+				execCommand:    stringFlagFor("example-client-go-exec-plugin"),
+				execAPIVersion: stringFlagFor("client.authentication.k8s.io/v1"),
+			},
+		},
+		{
+			name: "test12",
+			flags: []string{
+				"--exec-command=example-client-go-exec-plugin",
+				"--exec-interactive-mode=ifavailable",
+				"me",
+			},
+			wantOptions: &createAuthInfoOptions{
+				name:                "me",
+				execCommand:         stringFlagFor("example-client-go-exec-plugin"),
+				execInteractiveMode: stringFlagFor("ifavailable"),
+			},
+		},
+		{
+			name: "test13",
+			flags: []string{
+				"--exec-command=example-client-go-exec-plugin",
+				"--exec-interactive-mode=invalid", // invalid mode
+				"me",
+			},
+			wantValidateErr: true,
+		},
+		{
+			name: "test14",
+			flags: []string{
+				"--exec-command=example-client-go-exec-plugin",
+				"--exec-provide-cluster-info=true",
+				"me",
+			},
+			wantOptions: &createAuthInfoOptions{
+				name:                   "me",
+				execCommand:            stringFlagFor("example-client-go-exec-plugin"),
+				execProvideClusterInfo: cliflag.True,
+			},
+		},
+		{
+			name: "test15",
+			flags: []string{
+				"--exec-command=example-client-go-exec-plugin",
 				"--exec-arg=arg1",
 				"--exec-arg=arg2",
 				"me",
@@ -182,7 +230,7 @@ func TestCreateAuthInfoOptions(t *testing.T) {
 			},
 		},
 		{
-			name: "test12",
+			name: "test16",
 			flags: []string{
 				"--exec-command=example-client-go-exec-plugin",
 				"--exec-env=key1=val1",
@@ -274,7 +322,47 @@ func TestModifyExistingAuthInfo(t *testing.T) {
 			},
 		},
 		{
-			name: "2. redefine exec args",
+			name: "2. modify interactive mode",
+			flags: []string{
+				"--exec-interactive-mode=ifavailable",
+				"me",
+			},
+			existingAuthInfo: clientcmdapi.AuthInfo{
+				Exec: &clientcmdapi.ExecConfig{
+					Command:    "example-client-go-exec-plugin",
+					APIVersion: "client.authentication.k8s.io/v1",
+				},
+			},
+			wantAuthInfo: clientcmdapi.AuthInfo{
+				Exec: &clientcmdapi.ExecConfig{
+					Command:         "example-client-go-exec-plugin",
+					APIVersion:      "client.authentication.k8s.io/v1",
+					InteractiveMode: clientcmdapi.IfAvailableExecInteractiveMode,
+				},
+			},
+		},
+		{
+			name: "3. modify provide cluster info",
+			flags: []string{
+				"--exec-provide-cluster-info=true",
+				"me",
+			},
+			existingAuthInfo: clientcmdapi.AuthInfo{
+				Exec: &clientcmdapi.ExecConfig{
+					Command:    "example-client-go-exec-plugin",
+					APIVersion: "client.authentication.k8s.io/v1",
+				},
+			},
+			wantAuthInfo: clientcmdapi.AuthInfo{
+				Exec: &clientcmdapi.ExecConfig{
+					Command:            "example-client-go-exec-plugin",
+					APIVersion:         "client.authentication.k8s.io/v1",
+					ProvideClusterInfo: true,
+				},
+			},
+		},
+		{
+			name: "4. redefine exec args",
 			flags: []string{
 				"--exec-arg=new-arg1",
 				"--exec-arg=new-arg2",
@@ -296,7 +384,7 @@ func TestModifyExistingAuthInfo(t *testing.T) {
 			},
 		},
 		{
-			name: "3. reset exec args",
+			name: "5. reset exec args",
 			flags: []string{
 				"--exec-command=example-client-go-exec-plugin",
 				"me",
@@ -316,7 +404,7 @@ func TestModifyExistingAuthInfo(t *testing.T) {
 			},
 		},
 		{
-			name: "4. modify exec env variables",
+			name: "6. modify exec env variables",
 			flags: []string{
 				"--exec-command=example-client-go-exec-plugin",
 				"--exec-env=name1=value1000",
@@ -347,7 +435,7 @@ func TestModifyExistingAuthInfo(t *testing.T) {
 			},
 		},
 		{
-			name: "5. modify auth provider arguments",
+			name: "7. modify auth provider arguments",
 			flags: []string{
 				"--auth-provider=new-auth-provider",
 				"--auth-provider-arg=key1=val1000",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Add new `kubectl config set-credentials` options:
- `exec-interactive-mode`
- `exec-provide-cluster-info`

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes/kubectl/issues/1521

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Adds `--exec-interactive-mode` and `--exec-provide-cluster-info` options to `kubectl config set-crendtials` command.
```