### PR TITLE
Added --sum flag to kubectl top pod

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/metricsutil/metrics_resource_adder.go
+++ b/staging/src/k8s.io/kubectl/pkg/metricsutil/metrics_resource_adder.go
@@ -1,0 +1,45 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metricsutil
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	metricsapi "k8s.io/metrics/pkg/apis/metrics"
+)
+
+type ResourceAdder struct {
+	resources []corev1.ResourceName
+	total     corev1.ResourceList
+}
+
+func NewResourceAdder(resources []corev1.ResourceName) *ResourceAdder {
+	return &ResourceAdder{
+		resources: resources,
+		total:     make(corev1.ResourceList),
+	}
+}
+
+// AddPodMetrics adds each pod metric to the total
+func (adder *ResourceAdder) AddPodMetrics(m *metricsapi.PodMetrics) {
+	for _, c := range m.Containers {
+		for _, res := range adder.resources {
+			total := adder.total[res]
+			total.Add(c.Usage[res])
+			adder.total[res] = total
+		}
+	}
+}

--- a/staging/src/k8s.io/kubectl/pkg/metricsutil/metrics_resource_adder_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/metricsutil/metrics_resource_adder_test.go
@@ -1,0 +1,119 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metricsutil
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/metrics/pkg/apis/metrics"
+)
+
+func getResourceQuantity(t *testing.T, quantityStr string) resource.Quantity {
+	t.Helper()
+	var err error
+	quantity, err := resource.ParseQuantity("0")
+	if err != nil {
+		t.Errorf("failed when parsing 0 into resource.Quantity")
+	}
+	if quantityStr != "" {
+		quantity, err = resource.ParseQuantity(quantityStr)
+		if err != nil {
+			t.Errorf("%s is not a valid resource value", quantityStr)
+		}
+	}
+	return quantity
+}
+
+func addContainerMetricsToPodMetrics(t *testing.T, podMetrics *metrics.PodMetrics, cpuUsage, memUsage string) {
+	t.Helper()
+	containerMetrics := metrics.ContainerMetrics{
+		Usage: corev1.ResourceList{},
+	}
+
+	containerMetrics.Usage["cpu"] = getResourceQuantity(t, cpuUsage)
+	containerMetrics.Usage["memory"] = getResourceQuantity(t, memUsage)
+
+	podMetrics.Containers = append(podMetrics.Containers, containerMetrics)
+}
+
+func initResourceAdder() *ResourceAdder {
+	resources := []corev1.ResourceName{
+		corev1.ResourceCPU,
+		corev1.ResourceMemory,
+	}
+	return NewResourceAdder(resources)
+}
+
+func TestAddPodMetrics(t *testing.T) {
+	resourceAdder := initResourceAdder()
+
+	tests := []struct {
+		name             string
+		cpuUsage         string
+		memUsage         string
+		expectedCpuUsage resource.Quantity
+		expectedMemUsage resource.Quantity
+	}{
+		{
+			name:             "initial value",
+			cpuUsage:         "0",
+			memUsage:         "0",
+			expectedCpuUsage: getResourceQuantity(t, "0"),
+			expectedMemUsage: getResourceQuantity(t, "0"),
+		},
+		{
+			name:             "add first container metric",
+			cpuUsage:         "1m",
+			memUsage:         "10Mi",
+			expectedCpuUsage: getResourceQuantity(t, "1m"),
+			expectedMemUsage: getResourceQuantity(t, "10Mi"),
+		},
+		{
+			name:             "add second container metric",
+			cpuUsage:         "5m",
+			memUsage:         "25Mi",
+			expectedCpuUsage: getResourceQuantity(t, "6m"),
+			expectedMemUsage: getResourceQuantity(t, "35Mi"),
+		},
+		{
+			name:             "add third container zero metric",
+			cpuUsage:         "0m",
+			memUsage:         "0Mi",
+			expectedCpuUsage: getResourceQuantity(t, "6m"),
+			expectedMemUsage: getResourceQuantity(t, "35Mi"),
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			podMetrics := metrics.PodMetrics{}
+			addContainerMetricsToPodMetrics(t, &podMetrics, test.cpuUsage, test.memUsage)
+
+			resourceAdder.AddPodMetrics(&podMetrics)
+			cpuUsage := resourceAdder.total["cpu"]
+			memUsage := resourceAdder.total["memory"]
+
+			if !test.expectedCpuUsage.Equal(cpuUsage) {
+				t.Errorf("expecting cpu usage %s but getting %s", test.expectedCpuUsage.String(), cpuUsage.String())
+			}
+			if !test.expectedMemUsage.Equal(memUsage) {
+				t.Errorf("expecting memeory usage %s but getting %s", test.expectedMemUsage.String(), memUsage.String())
+			}
+		})
+	}
+}

--- a/staging/src/k8s.io/kubectl/pkg/metricsutil/metrics_sorter.go
+++ b/staging/src/k8s.io/kubectl/pkg/metricsutil/metrics_sorter.go
@@ -1,0 +1,130 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metricsutil
+
+import (
+	"k8s.io/api/core/v1"
+	metricsapi "k8s.io/metrics/pkg/apis/metrics"
+)
+
+type NodeMetricsSorter struct {
+	metrics []metricsapi.NodeMetrics
+	sortBy  string
+}
+
+func (n *NodeMetricsSorter) Len() int {
+	return len(n.metrics)
+}
+
+func (n *NodeMetricsSorter) Swap(i, j int) {
+	n.metrics[i], n.metrics[j] = n.metrics[j], n.metrics[i]
+}
+
+func (n *NodeMetricsSorter) Less(i, j int) bool {
+	switch n.sortBy {
+	case "cpu":
+		return n.metrics[i].Usage.Cpu().MilliValue() > n.metrics[j].Usage.Cpu().MilliValue()
+	case "memory":
+		return n.metrics[i].Usage.Memory().Value() > n.metrics[j].Usage.Memory().Value()
+	default:
+		return n.metrics[i].Name < n.metrics[j].Name
+	}
+}
+
+func NewNodeMetricsSorter(metrics []metricsapi.NodeMetrics, sortBy string) *NodeMetricsSorter {
+	return &NodeMetricsSorter{
+		metrics: metrics,
+		sortBy:  sortBy,
+	}
+}
+
+type PodMetricsSorter struct {
+	metrics       []metricsapi.PodMetrics
+	sortBy        string
+	withNamespace bool
+	podMetrics    []v1.ResourceList
+}
+
+func (p *PodMetricsSorter) Len() int {
+	return len(p.metrics)
+}
+
+func (p *PodMetricsSorter) Swap(i, j int) {
+	p.metrics[i], p.metrics[j] = p.metrics[j], p.metrics[i]
+	p.podMetrics[i], p.podMetrics[j] = p.podMetrics[j], p.podMetrics[i]
+}
+
+func (p *PodMetricsSorter) Less(i, j int) bool {
+	switch p.sortBy {
+	case "cpu":
+		return p.podMetrics[i].Cpu().MilliValue() > p.podMetrics[j].Cpu().MilliValue()
+	case "memory":
+		return p.podMetrics[i].Memory().Value() > p.podMetrics[j].Memory().Value()
+	default:
+		if p.withNamespace && p.metrics[i].Namespace != p.metrics[j].Namespace {
+			return p.metrics[i].Namespace < p.metrics[j].Namespace
+		}
+		return p.metrics[i].Name < p.metrics[j].Name
+	}
+}
+
+func NewPodMetricsSorter(metrics []metricsapi.PodMetrics, withNamespace bool, sortBy string) *PodMetricsSorter {
+	var podMetrics = make([]v1.ResourceList, len(metrics))
+	if len(sortBy) > 0 {
+		for i, v := range metrics {
+			podMetrics[i] = getPodMetrics(&v)
+		}
+	}
+
+	return &PodMetricsSorter{
+		metrics:       metrics,
+		sortBy:        sortBy,
+		withNamespace: withNamespace,
+		podMetrics:    podMetrics,
+	}
+}
+
+type ContainerMetricsSorter struct {
+	metrics []metricsapi.ContainerMetrics
+	sortBy  string
+}
+
+func (s *ContainerMetricsSorter) Len() int {
+	return len(s.metrics)
+}
+
+func (s *ContainerMetricsSorter) Swap(i, j int) {
+	s.metrics[i], s.metrics[j] = s.metrics[j], s.metrics[i]
+}
+
+func (s *ContainerMetricsSorter) Less(i, j int) bool {
+	switch s.sortBy {
+	case "cpu":
+		return s.metrics[i].Usage.Cpu().MilliValue() > s.metrics[j].Usage.Cpu().MilliValue()
+	case "memory":
+		return s.metrics[i].Usage.Memory().Value() > s.metrics[j].Usage.Memory().Value()
+	default:
+		return s.metrics[i].Name < s.metrics[j].Name
+	}
+}
+
+func NewContainerMetricsSorter(metrics []metricsapi.ContainerMetrics, sortBy string) *ContainerMetricsSorter {
+	return &ContainerMetricsSorter{
+		metrics: metrics,
+		sortBy:  sortBy,
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #https://github.com/kubernetes/kubectl/issues/1061

#### Special notes for your reviewer:
```
 $ ./kubectl top pods --sum -A
NAMESPACE        NAME                                          CPU(cores)   MEMORY(bytes)   
cert-manager     cert-manager-7998c69865-m5pjn                 11m          14Mi            
cert-manager     cert-manager-cainjector-7b744d56fb-jd66q      12m          19Mi            
cert-manager     cert-manager-webhook-97f8b47bc-4smlq          14m          8Mi             
default          personal-website-deployment-b6699dcfb-bl6cp   0m           2Mi             
default          personal-website-deployment-b6699dcfb-rnv7t   0m           2Mi             
default          personal-website-deployment-b6699dcfb-z5lm2   0m           2Mi             
gallery          gallery-deployment-8db9454f9-6rlkk            1m           8Mi             
kube-system      coredns-7448499f4d-5p4ht                      9m           9Mi             
kube-system      local-path-provisioner-5ff76fc89d-8qct7       4m           5Mi             
kube-system      metrics-server-6995b8fd7d-hczx7               16m          12Mi            
kube-system      nginx-ingress-controller-699bf59c5-j6dfw      6m           74Mi            
metallb-system   metallb-controller-df647b67b-q84kg            1m           3Mi             
metallb-system   metallb-speaker-6sk9z                         2m           6Mi             
metallb-system   metallb-speaker-qxbrs                         3m           4Mi             
web-analytics    mysql-bb9597d6f-5czf9                         2m           64Mi            
web-analytics    web-analytics-deployment-75d65dd4f8-5zrwq     1m           31Mi            
web-analytics    web-analytics-deployment-75d65dd4f8-fv2s2     1m           29Mi            
web-analytics    web-analytics-deployment-75d65dd4f8-xs4l5     1m           32Mi            
                                                               ________     ________        
                                                               74m          333Mi     
```

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Added sum feature to `kubectl top pod`
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
