### PR TITLE
Ignore non semantic changes

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/capmanagers_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/capmanagers_test.go
@@ -237,7 +237,7 @@ func TestCapUpdateManagers(t *testing.T) {
 			t.Fatalf("%v: couldn't get accessor: %v", tc.name, err)
 		}
 		accessor.SetManagedFields(tc.input)
-		if err := f.Update(f.liveObj, "no-op-update"); err != nil {
+		if err := f.Update(f.liveObj.DeepCopyObject(), "no-op-update"); err != nil {
 			t.Fatalf("%v: failed to do no-op update to object: %v", tc.name, err)
 		}
 

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/equality.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/equality.go
@@ -1,0 +1,57 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fieldmanager
+
+import (
+	"context"
+	"reflect"
+
+	"k8s.io/apimachinery/pkg/api/equality"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/conversion"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+var equalities = func() conversion.Equalities {
+	e := equality.Semantic
+	e.AddFunc(ignoreManagedFieldsTimestamp)
+	return e
+}()
+
+// EqualObjects returns true if the two objects are "equals".
+//
+// The two objects are equal if they have the exact same values, and
+// their managed fieldsets are the same, except for the timestamp.
+func EqualObjects(new, old runtime.Object) bool {
+	return equalities.DeepEqual(new, old)
+}
+
+// DropEqualTransformer is a transformer that cancels the change if the
+// objects are equal.
+func DropEqualTransformer(_ context.Context, newObj, oldObj runtime.Object) (runtime.Object, error) {
+	if EqualObjects(newObj, oldObj) {
+		return oldObj, nil
+	}
+	return newObj, nil
+}
+
+func ignoreManagedFieldsTimestamp(a, b metav1.ManagedFieldsEntry) bool {
+	a.Time = nil
+	b.Time = nil
+
+	return reflect.DeepEqual(a, b)
+}

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/patch.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/patch.go
@@ -583,7 +583,9 @@ func (p *patcher) patchResource(ctx context.Context, scope *RequestScope) (runti
 	}
 
 	wasCreated := false
-	p.updatedObjectInfo = rest.DefaultUpdatedObjectInfo(nil, p.applyPatch, p.applyAdmission, dedupOwnerReferencesTransformer)
+	p.updatedObjectInfo = rest.DefaultUpdatedObjectInfo(nil, p.applyPatch, p.applyAdmission, dedupOwnerReferencesTransformer,
+		fieldmanager.DropEqualTransformer) // Ignore changes that only affect managed fields timestamps.
+
 	requestFunc := func() (runtime.Object, error) {
 		// Pass in UpdateOptions to override UpdateStrategy.AllowUpdateOnCreate
 		options := patchToUpdateOptions(p.options)

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/update.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/update.go
@@ -165,6 +165,12 @@ func UpdateResource(r rest.Updater, scope *RequestScope, admit admission.Interfa
 			})
 		}
 
+		// Ignore changes that only affect managed fields
+		// timestamps. FieldManager can't know about changes
+		// like normalized fields, defaulted fields and other
+		// mutations.
+		transformers = append(transformers, fieldmanager.DropEqualTransformer)
+
 		createAuthorizerAttributes := authorizer.AttributesRecord{
 			User:            userInfo,
 			ResourceRequest: true,

--- a/test/integration/apiserver/apply/apply_test.go
+++ b/test/integration/apiserver/apply/apply_test.go
@@ -199,7 +199,7 @@ func TestNoOpUpdateSameResourceVersion(t *testing.T) {
 	}
 
 	// Sleep for one second to make sure that the times of each update operation is different.
-	time.Sleep(1 * time.Second)
+	time.Sleep(1200 * time.Millisecond)
 
 	createdObject, err := client.CoreV1().RESTClient().Get().Namespace("default").Resource(podResource).Name(podName).Do(context.TODO()).Get()
 	if err != nil {
@@ -325,7 +325,7 @@ func TestNoSemanticUpdateApplySameResourceVersion(t *testing.T) {
 	}
 
 	// Sleep for one second to make sure that the times of each update operation is different.
-	time.Sleep(1 * time.Second)
+	time.Sleep(1200 * time.Millisecond)
 
 	obj, err = client.AppsV1().RESTClient().Patch(types.ApplyPatchType).
 		Namespace("default").
@@ -410,7 +410,7 @@ func TestNoSemanticUpdatePutSameResourceVersion(t *testing.T) {
 	}
 
 	// Sleep for one second to make sure that the times of each update operation is different.
-	time.Sleep(1 * time.Second)
+	time.Sleep(1200 * time.Millisecond)
 
 	obj, err = client.AppsV1().RESTClient().Put().
 		Namespace("default").
@@ -835,7 +835,7 @@ func TestApplyManagedFields(t *testing.T) {
 	// Sleep for one second to make sure that the times of each update operation is different.
 	// This will let us check that update entries with the same manager name are grouped together,
 	// and that the most recent update time is recorded in the grouped entry.
-	time.Sleep(1 * time.Second)
+	time.Sleep(1200 * time.Millisecond)
 
 	_, err = client.CoreV1().RESTClient().Patch(types.MergePatchType).
 		Namespace("default").


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:
Ignores changes that only affect the timestamp in the managed fields. That can happen when someone merely updates a Quantity from 1024 to 1Ki or when accidentally removing a value that was a default.

#### Which issue(s) this PR fixes:
Fixes # // I'll set that later.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.: