### PR TITLE
Fix duplicate CSI kube client

### DIFF
--- a/pkg/volume/csi/nodeinfomanager/nodeinfomanager.go
+++ b/pkg/volume/csi/nodeinfomanager/nodeinfomanager.go
@@ -432,17 +432,12 @@ func (nim *nodeInfoManager) tryInitializeCSINodeWithAnnotation(csiKubeClient cli
 
 func (nim *nodeInfoManager) CreateCSINode() (*storagev1.CSINode, error) {
 
-	kubeClient := nim.volumeHost.GetKubeClient()
-	if kubeClient == nil {
-		return nil, fmt.Errorf("error getting kube client")
-	}
-
 	csiKubeClient := nim.volumeHost.GetKubeClient()
 	if csiKubeClient == nil {
 		return nil, fmt.Errorf("error getting CSI client")
 	}
 
-	node, err := kubeClient.CoreV1().Nodes().Get(context.TODO(), string(nim.nodeName), metav1.GetOptions{})
+	node, err := csiKubeClient.CoreV1().Nodes().Get(context.TODO(), string(nim.nodeName), metav1.GetOptions{})
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
From the code: https://github.com/kubernetes/kubernetes/blob/25c7b6a2c723d3274691e6796f715668302d6339/pkg/volume/csi/nodeinfomanager/nodeinfomanager.go#L433
there is duplicate `nim.volumeHost.GetKubeClient()` to get kubeClient, so this PR remove one of them.

#### Special notes for your reviewer:
Reserve the `csiKubeClient` name, to be consistent with code in method `InitializeCSINodeWithAnnotation`.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
