### PR TITLE
local-cluster-up: allow to specify the kubelet resolv.conf

### DIFF
--- a/hack/local-up-cluster.sh
+++ b/hack/local-up-cluster.sh
@@ -222,6 +222,7 @@ API_BIND_ADDR=${API_BIND_ADDR:-"0.0.0.0"}
 EXTERNAL_HOSTNAME=${EXTERNAL_HOSTNAME:-localhost}
 
 KUBELET_HOST=${KUBELET_HOST:-"127.0.0.1"}
+KUBELET_RESOLV_CONF=${KUBELET_RESOLV_CONF:-"/etc/resolv.conf"}
 # By default only allow CORS for requests on localhost
 API_CORS_ALLOWED_ORIGINS=${API_CORS_ALLOWED_ORIGINS:-/127.0.0.1(:[0-9]+)?$,/localhost(:[0-9]+)?$}
 KUBELET_PORT=${KUBELET_PORT:-10250}
@@ -815,6 +816,7 @@ readOnlyPort: ${KUBELET_READ_ONLY_PORT}
 rotateCertificates: true
 runtimeRequestTimeout: "${RUNTIME_REQUEST_TIMEOUT}"
 staticPodPath: "${POD_MANIFEST_PATH}"
+resolvConf: "${KUBELET_RESOLV_CONF}"
 EOF
     {
       # authentication


### PR DESCRIPTION
/kind cleanup

If the host uses a local dns caching server, like with systemd-resolved, the `/etc/resolv.conf` nameserver uses a loopback addresses, breaking Pod DNS resolution and coreDNS.

Since there can be multiple situations when an user can have a loopback in their resolv.conf, instead of trying to automatically fix it with the risk of complicating the script and end in hard to debug situations picking a wrong nameserver, we just expose an option so the user can override the resolv.conf with an environment variable.

As example, for using with systemd-resolved in my system:
```sh
KUBELET_RESOLV_CONF="/run/systemd/resolve/resolv.conf" DNS_ADDON="coredns" hack/local-up-cluster.sh
$ kubectl get pods -A
NAMESPACE     NAME                       READY   STATUS    RESTARTS   AGE
kube-system   coredns-755cd654d4-h25fp   1/1     Running   0          2m5s
$ kubectl -n kube-system logs coredns-755cd654d4-h25fp
.:53
[INFO] plugin/reload: Running configuration MD5 = db32ca3650231d74073ff4cf814959a7
CoreDNS-1.8.0
linux/amd64, go1.15.3, 054c9ae

```

```release-note
NONE
```

Fixes: #104862