### PR TITLE
Add --override-type flag to kubectl run and kubectl expose

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/expose/expose.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/expose/expose.go
@@ -23,6 +23,7 @@ import (
 	"github.com/spf13/cobra"
 	"k8s.io/klog/v2"
 
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured/unstructuredscheme"
@@ -82,6 +83,8 @@ var (
 )
 
 type ExposeServiceOptions struct {
+	cmdutil.OverrideOptions
+
 	FilenameOptions resource.FilenameOptions
 	RecordFlags     *genericclioptions.RecordFlags
 	PrintFlags      *genericclioptions.PrintFlags
@@ -155,11 +158,11 @@ func NewCmdExposeService(f cmdutil.Factory, streams genericclioptions.IOStreams)
 	cmd.Flags().MarkDeprecated("container-port", "--container-port will be removed in the future, please use --target-port instead")
 	cmd.Flags().String("target-port", "", i18n.T("Name or number for the port on the container that the service should direct traffic to. Optional."))
 	cmd.Flags().String("external-ip", "", i18n.T("Additional external IP address (not managed by Kubernetes) to accept for the service. If this IP is routed to a node, the service can be accessed by this IP in addition to its generated service IP."))
-	cmd.Flags().String("overrides", "", i18n.T("An inline JSON override for the generated object. If this is non-empty, it is used to override the generated object. Requires that the object supply a valid apiVersion field."))
 	cmd.Flags().String("name", "", i18n.T("The name for the newly created object."))
 	cmd.Flags().String("session-affinity", "", i18n.T("If non-empty, set the session affinity for the service to this; legal values: 'None', 'ClientIP'"))
 	cmd.Flags().String("cluster-ip", "", i18n.T("ClusterIP to be assigned to the service. Leave empty to auto-allocate, or set to 'None' to create a headless service."))
 	cmdutil.AddFieldManagerFlagVar(cmd, &o.fieldManager, "kubectl-expose")
+	o.AddOverrideFlags(cmd)
 
 	usage := "identifying the resource to expose a service"
 	cmdutil.AddFilenameOptionFlags(cmd, &o.FilenameOptions, usage)
@@ -318,12 +321,9 @@ func (o *ExposeServiceOptions) RunExpose(cmd *cobra.Command, args []string) erro
 			return err
 		}
 
-		if inline := cmdutil.GetFlagString(cmd, "overrides"); len(inline) > 0 {
-			codec := runtime.NewCodec(scheme.DefaultJSONEncoder(), scheme.Codecs.UniversalDecoder(scheme.Scheme.PrioritizedVersionsAllGroups()...))
-			object, err = cmdutil.Merge(codec, object, inline)
-			if err != nil {
-				return err
-			}
+		object, err = o.NewOverrider(&corev1.Service{}).Apply(object)
+		if err != nil {
+			return err
 		}
 
 		if err := o.Recorder.Record(object); err != nil {

--- a/staging/src/k8s.io/kubectl/pkg/cmd/util/helpers_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/util/helpers_test.go
@@ -63,45 +63,6 @@ func TestMerge(t *testing.T) {
 				Spec: corev1.PodSpec{},
 			},
 		},
-		/* TODO: uncomment this test once Merge is updated to use
-		strategic-merge-patch. See #8449.
-		{
-			obj: &corev1.Pod{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "foo",
-				},
-				Spec: corev1.PodSpec{
-					Containers: []corev1.Container{
-						corev1.Container{
-							Name:  "c1",
-							Image: "red-image",
-						},
-						corev1.Container{
-							Name:  "c2",
-							Image: "blue-image",
-						},
-					},
-				},
-			},
-			fragment: fmt.Sprintf(`{ "apiVersion": "%s", "spec": { "containers": [ { "name": "c1", "image": "green-image" } ] } }`, schema.GroupVersion{Group:"", Version: "v1"}.String()),
-			expected: &corev1.Pod{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "foo",
-				},
-				Spec: corev1.PodSpec{
-					Containers: []corev1.Container{
-						corev1.Container{
-							Name:  "c1",
-							Image: "green-image",
-						},
-						corev1.Container{
-							Name:  "c2",
-							Image: "blue-image",
-						},
-					},
-				},
-			},
-		}, */
 		{
 			obj: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
@@ -186,6 +147,151 @@ func TestMerge(t *testing.T) {
 		scheme.Codecs.UniversalDecoder(scheme.Scheme.PrioritizedVersionsAllGroups()...))
 	for i, test := range tests {
 		out, err := Merge(codec, test.obj, test.fragment)
+		if !test.expectErr {
+			if err != nil {
+				t.Errorf("testcase[%d], unexpected error: %v", i, err)
+			} else if !apiequality.Semantic.DeepEqual(test.expected, out) {
+				t.Errorf("\n\ntestcase[%d]\nexpected:\n%s", i, diff.ObjectReflectDiff(test.expected, out))
+			}
+		}
+		if test.expectErr && err == nil {
+			t.Errorf("testcase[%d], unexpected non-error", i)
+		}
+	}
+}
+
+func TestStrategicMerge(t *testing.T) {
+	tests := []struct {
+		obj        runtime.Object
+		dataStruct runtime.Object
+		fragment   string
+		expected   runtime.Object
+		expectErr  bool
+	}{
+		{
+			obj: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "foo",
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:  "c1",
+							Image: "red-image",
+						},
+						{
+							Name:  "c2",
+							Image: "blue-image",
+						},
+					},
+				},
+			},
+			dataStruct: &corev1.Pod{},
+			fragment: fmt.Sprintf(`{ "apiVersion": "%s", "spec": { "containers": [ { "name": "c1", "image": "green-image" } ] } }`,
+				schema.GroupVersion{Group: "", Version: "v1"}.String()),
+			expected: &corev1.Pod{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "Pod",
+					APIVersion: "v1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "foo",
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:  "c1",
+							Image: "green-image",
+						},
+						{
+							Name:  "c2",
+							Image: "blue-image",
+						},
+					},
+				},
+			},
+		},
+		{
+			obj:        &corev1.Pod{},
+			dataStruct: &corev1.Pod{},
+			fragment:   "invalid json",
+			expected:   &corev1.Pod{},
+			expectErr:  true,
+		},
+		{
+			obj:        &corev1.Service{},
+			dataStruct: &corev1.Pod{},
+			fragment:   `{ "apiVersion": "badVersion" }`,
+			expectErr:  true,
+		},
+	}
+
+	codec := runtime.NewCodec(scheme.DefaultJSONEncoder(),
+		scheme.Codecs.UniversalDecoder(scheme.Scheme.PrioritizedVersionsAllGroups()...))
+	for i, test := range tests {
+		out, err := StrategicMerge(codec, test.obj, test.fragment, test.dataStruct)
+		if !test.expectErr {
+			if err != nil {
+				t.Errorf("testcase[%d], unexpected error: %v", i, err)
+			} else if !apiequality.Semantic.DeepEqual(test.expected, out) {
+				t.Errorf("\n\ntestcase[%d]\nexpected:\n%s", i, diff.ObjectReflectDiff(test.expected, out))
+			}
+		}
+		if test.expectErr && err == nil {
+			t.Errorf("testcase[%d], unexpected non-error", i)
+		}
+	}
+}
+
+func TestJSONPatch(t *testing.T) {
+	tests := []struct {
+		obj       runtime.Object
+		fragment  string
+		expected  runtime.Object
+		expectErr bool
+	}{
+		{
+			obj: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "foo",
+					Labels: map[string]string{
+						"run": "test",
+					},
+				},
+			},
+			fragment: `[ {"op": "add", "path": "/metadata/labels/foo", "value": "bar"} ]`,
+			expected: &corev1.Pod{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "Pod",
+					APIVersion: "v1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "foo",
+					Labels: map[string]string{
+						"run": "test",
+						"foo": "bar",
+					},
+				},
+				Spec: corev1.PodSpec{},
+			},
+		},
+		{
+			obj:       &corev1.Pod{},
+			fragment:  "invalid json",
+			expected:  &corev1.Pod{},
+			expectErr: true,
+		},
+		{
+			obj:       &corev1.Pod{},
+			fragment:  `[ {"op": "add", "path": "/metadata/labels/foo", "value": "bar"} ]`,
+			expectErr: true,
+		},
+	}
+
+	codec := runtime.NewCodec(scheme.DefaultJSONEncoder(),
+		scheme.Codecs.UniversalDecoder(scheme.Scheme.PrioritizedVersionsAllGroups()...))
+	for i, test := range tests {
+		out, err := JSONPatch(codec, test.obj, test.fragment)
 		if !test.expectErr {
 			if err != nil {
 				t.Errorf("testcase[%d], unexpected error: %v", i, err)

--- a/staging/src/k8s.io/kubectl/pkg/cmd/util/override_options.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/util/override_options.go
@@ -1,0 +1,90 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/kubectl/pkg/scheme"
+	"k8s.io/kubectl/pkg/util/i18n"
+)
+
+type OverrideType string
+
+const (
+	// OverrideTypeJSON will use an RFC6902 JSON Patch to alter the generated output
+	OverrideTypeJSON OverrideType = "json"
+
+	// OverrideTypeMerge will use an RFC7396 JSON Merge Patch to alter the generated output
+	OverrideTypeMerge OverrideType = "merge"
+
+	// OverrideTypeStrategic will use a Strategic Merge Patch to alter the generated output
+	OverrideTypeStrategic OverrideType = "strategic"
+)
+
+const DefaultOverrideType = OverrideTypeMerge
+
+type OverrideOptions struct {
+	Overrides    string
+	OverrideType OverrideType
+}
+
+func (o *OverrideOptions) AddOverrideFlags(cmd *cobra.Command) {
+	cmd.Flags().StringVar(&o.Overrides, "overrides", "", i18n.T("An inline JSON override for the generated object. If this is non-empty, it is used to override the generated object. Requires that the object supply a valid apiVersion field."))
+	cmd.Flags().StringVar((*string)(&o.OverrideType), "override-type", string(DefaultOverrideType), fmt.Sprintf("The method used to override the generated object: %s, %s, or %s.", OverrideTypeJSON, OverrideTypeMerge, OverrideTypeStrategic))
+}
+
+func (o *OverrideOptions) NewOverrider(dataStruct runtime.Object) *Overrider {
+	return &Overrider{
+		Options:    o,
+		DataStruct: dataStruct,
+	}
+}
+
+type Overrider struct {
+	Options    *OverrideOptions
+	DataStruct runtime.Object
+}
+
+func (o *Overrider) Apply(obj runtime.Object) (runtime.Object, error) {
+	if len(o.Options.Overrides) == 0 {
+		return obj, nil
+	}
+
+	codec := runtime.NewCodec(scheme.DefaultJSONEncoder(), scheme.Codecs.UniversalDecoder(scheme.Scheme.PrioritizedVersionsAllGroups()...))
+
+	var overrideType OverrideType
+	if len(o.Options.OverrideType) == 0 {
+		overrideType = DefaultOverrideType
+	} else {
+		overrideType = o.Options.OverrideType
+	}
+
+	switch overrideType {
+	case OverrideTypeJSON:
+		return JSONPatch(codec, obj, o.Options.Overrides)
+	case OverrideTypeMerge:
+		return Merge(codec, obj, o.Options.Overrides)
+	case OverrideTypeStrategic:
+		return StrategicMerge(codec, obj, o.Options.Overrides, o.DataStruct)
+	default:
+		return nil, fmt.Errorf("invalid override type: %v", overrideType)
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
Currently if you use the `--overrides` flag when running `kubectl run` or `kubectl expose`, it uses an RFC7396 JSON Merge Patch to override the generated JSON.

Sometimes though, it is helpful to have more flexibility and control over what gets replaced.

This PR adds a new `--override-type` flag which allows you to choose one of the following ways for the override to be performed:

|Override Type|Description|
|---|---|
|`merge`|Use an [RFC7396 JSON Merge Patch](https://datatracker.ietf.org/doc/html/rfc7396). *This is the current behavior and remains the default if you don't specify an override type*|
|`json`|Use an [RFC6902 JSON Patch](https://datatracker.ietf.org/doc/html/rfc6902)|
|`strategic`|Use a Strategic Merge Patch|

For consistency, these override type names mirror the [type names used by `kubectl patch`](https://github.com/kubernetes/kubernetes/blob/b1fc5b367dc7618f1bda17606258eb44ac2e3279/staging/src/k8s.io/kubectl/pkg/cmd/patch/patch.go#L47).

##### Example 1: `--override-type merge` (RFC7396 JSON Merge Patch)
*This is the default and the current behavior of `--overrides` before this PR*
```
$ kubectl run curl -n a0008 --image=mcr.microsoft.com/azure-cli --dry-run=client -o yaml --overrides='{"spec":{"containers":[{"name":"curl","resources":{"limits":{"cpu":"200m"}}}]}}' --override-type merge
apiVersion: v1
kind: Pod
metadata:
  creationTimestamp: null
  labels:
    run: curl
  name: curl
  namespace: a0008
spec:
  containers:
  - name: curl
    resources:
      limits:
        cpu: 200m
  dnsPolicy: ClusterFirst
  restartPolicy: Always
status: {}
```

##### Example 2: `--override-type json` (RFC6902 JSON Patch)
```
$ kubectl run curl -n a0008 --image=mcr.microsoft.com/azure-cli --dry-run=client -o yaml --overrides='[{"op":"add","path":"/spec/containers/0/resources","value":{"limits":{"cpu":"200m"}}}]' --override-type json
apiVersion: v1
kind: Pod
metadata:
  creationTimestamp: null
  labels:
    run: curl
  name: curl
  namespace: a0008
spec:
  containers:
  - image: mcr.microsoft.com/azure-cli
    name: curl
    resources:
      limits:
        cpu: 200m
  dnsPolicy: ClusterFirst
  restartPolicy: Always
status: {}
```

##### Example 3: `--override-type strategic` (Strategic Merge Patch)
```
$ kubectl run curl -n a0008 --image=mcr.microsoft.com/azure-cli --dry-run=client -o yaml --overrides='{"spec":{"containers":[{"name":"curl","resources":{"limits":{"cpu":"200m"}}}]}}' --override-type strategic
apiVersion: v1
kind: Pod
metadata:
  creationTimestamp: null
  labels:
    run: curl
  name: curl
  namespace: a0008
spec:
  containers:
  - image: mcr.microsoft.com/azure-cli
    name: curl
    resources:
      limits:
        cpu: 200m
  dnsPolicy: ClusterFirst
  restartPolicy: Always
status: {}
```

#### Which issue(s) this PR fixes:
Fixes https://github.com/kubernetes/kubectl/issues/1101

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
Added the ability to specify whether to use an RFC7396 JSON Merge Patch, an RFC6902 JSON Patch, or a Strategic Merge Patch to perform an override of the resources created by kubectl run and kubectl expose.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs

```
