### PR TITLE
Do not try to load plugins for cobra commands

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/cmd.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/cmd.go
@@ -105,7 +105,15 @@ func NewDefaultKubectlCommandWithArgs(pluginHandler PluginHandler, args []string
 			// Also check the commands that will be added by Cobra.
 			// These commands are only added once rootCmd.Execute() is called, so we
 			// need to check them explicitly here.
-			switch cmdPathPieces[0] {
+			var cmdName string // first "non-flag" arguments
+			for _, arg := range cmdPathPieces {
+				if !strings.HasPrefix(arg, "-") {
+					cmdName = arg
+					break
+				}
+			}
+
+			switch cmdName {
 			case "help", cobra.ShellCompRequestCmd, cobra.ShellCompNoDescRequestCmd:
 				// Don't search for a plugin
 			default:

--- a/staging/src/k8s.io/kubectl/pkg/cmd/cmd.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/cmd.go
@@ -102,9 +102,17 @@ func NewDefaultKubectlCommandWithArgs(pluginHandler PluginHandler, args []string
 		// only look for suitable extension executables if
 		// the specified command does not already exist
 		if _, _, err := cmd.Find(cmdPathPieces); err != nil {
-			if err := HandlePluginCommand(pluginHandler, cmdPathPieces); err != nil {
-				fmt.Fprintf(errout, "Error: %v\n", err)
-				os.Exit(1)
+			// Also check the commands that will be added by Cobra.
+			// These commands are only added once rootCmd.Execute() is called, so we
+			// need to check them explicitly here.
+			switch cmdPathPieces[0] {
+			case "help", cobra.ShellCompRequestCmd, cobra.ShellCompNoDescRequestCmd:
+				// Don't search for a plugin
+			default:
+				if err := HandlePluginCommand(pluginHandler, cmdPathPieces); err != nil {
+					fmt.Fprintf(errout, "Error: %v\n", err)
+					os.Exit(1)
+				}
 			}
 		}
 	}

--- a/staging/src/k8s.io/kubectl/pkg/cmd/cmd_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/cmd_test.go
@@ -79,6 +79,7 @@ func TestKubectlCommandHandlesPlugins(t *testing.T) {
 			args: []string{"kubectl", "version"},
 		},
 		// The following tests make sure that commands added by Cobra cannot be shadowed by a plugin
+		// See https://github.com/kubernetes/kubectl/issues/1116
 		{
 			name: "test that a plugin does not execute over Cobra's help command",
 			args: []string{"kubectl", "help"},
@@ -91,6 +92,36 @@ func TestKubectlCommandHandlesPlugins(t *testing.T) {
 			name: "test that a plugin does not execute over Cobra's __completeNoDesc command",
 			args: []string{"kubectl", cobra.ShellCompNoDescRequestCmd},
 		},
+		// The following tests make sure that commands added by Cobra cannot be shadowed by a plugin
+		// even when a flag is specified first.  This can happen when using aliases.
+		// See https://github.com/kubernetes/kubectl/issues/1119
+		{
+			name: "test that a flag does not break Cobra's help command",
+			args: []string{"kubectl", "--kubeconfig=/path/to/kubeconfig", "help"},
+		},
+		{
+			name: "test that a flag does not break Cobra's __complete command",
+			args: []string{"kubectl", "--kubeconfig=/path/to/kubeconfig", cobra.ShellCompRequestCmd},
+		},
+		{
+			name: "test that a flag does not break Cobra's __completeNoDesc command",
+			args: []string{"kubectl", "--kubeconfig=/path/to/kubeconfig", cobra.ShellCompNoDescRequestCmd},
+		},
+		// As for the previous tests, an alias could add a flag without using the = form.
+		// We don't support this case as parsing the flags becomes quite complicated (flags
+		// that take a value, versus flags that don't)
+		// {
+		// 	name: "test that a flag with a space does not break Cobra's help command",
+		// 	args: []string{"kubectl", "--kubeconfig", "/path/to/kubeconfig", "help"},
+		// },
+		// {
+		// 	name: "test that a flag with a space does not break Cobra's __complete command",
+		// 	args: []string{"kubectl", "--kubeconfig", "/path/to/kubeconfig", cobra.ShellCompRequestCmd},
+		// },
+		// {
+		// 	name: "test that a flag with a space does not break Cobra's __completeNoDesc command",
+		// 	args: []string{"kubectl", "--kubeconfig", "/path/to/kubeconfig", cobra.ShellCompNoDescRequestCmd},
+		// },
 	}
 
 	for _, test := range tests {
@@ -105,6 +136,7 @@ func TestKubectlCommandHandlesPlugins(t *testing.T) {
 			})
 
 			root := NewDefaultKubectlCommandWithArgs(pluginsHandler, test.args, in, out, errOut)
+			root.SetOut(out)
 			if err := root.Execute(); err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}

--- a/staging/src/k8s.io/kubectl/pkg/cmd/cmd_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/cmd_test.go
@@ -78,6 +78,19 @@ func TestKubectlCommandHandlesPlugins(t *testing.T) {
 			name: "test that a plugin does not execute over an existing command by the same name",
 			args: []string{"kubectl", "version"},
 		},
+		// The following tests make sure that commands added by Cobra cannot be shadowed by a plugin
+		{
+			name: "test that a plugin does not execute over Cobra's help command",
+			args: []string{"kubectl", "help"},
+		},
+		{
+			name: "test that a plugin does not execute over Cobra's __complete command",
+			args: []string{"kubectl", cobra.ShellCompRequestCmd},
+		},
+		{
+			name: "test that a plugin does not execute over Cobra's __completeNoDesc command",
+			args: []string{"kubectl", cobra.ShellCompNoDescRequestCmd},
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug
#### What this PR does / why we need it:

A plugin called `kubectl-help` or `kubectl-__complete` or `kubectl-__completeNoDesc` will prevent the corresponding Cobra command from working.  It would prevent shell completion from working in the case of `kubectl-__complete`.

Also, even if such plugins don't exist, `kubectl` needlessly searches for a plugin every time completion is triggered, which could slow it down.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes/kubectl/issues/1116
Fixes https://github.com/kubernetes/kubectl/issues/1119

#### Special notes for your reviewer:

Cobra adds the commands `help`, `__complete` and `__completeNoDesc` inside `rootCmd.Execute()`, however, when `kubectl` decides if it should lookup plugins, `rootCmd.Execute()` has not been called yet.  Therefore, the call to `cmd.Find(cmdPathPieces)` done by `kubectl` does not find the commands added by Cobra.  To fix this we must check for them explicitly.

_Is there a backwards-compatibility issue that we need to worry about in preventing a plugin named `kubectl-help` or `kubectl-__complete` or `kubectl-__completeNoDesc` from being called?_

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
