### PR TITLE
remove format specifiers from structured logs

### DIFF
--- a/pkg/proxy/winkernel/proxier.go
+++ b/pkg/proxy/winkernel/proxier.go
@@ -149,7 +149,7 @@ func newHostNetworkService() (HostNetworkService, hcn.SupportedFeatures) {
 
 func getNetworkName(hnsNetworkName string) (string, error) {
 	if len(hnsNetworkName) == 0 {
-		klog.V(3).InfoS("network-name flag not set. Checking environment variable")
+		klog.V(3).InfoS("network-name flag not set, checking environment variable")
 		hnsNetworkName = os.Getenv("KUBE_NETWORK")
 		if len(hnsNetworkName) == 0 {
 			return "", fmt.Errorf("Environment variable KUBE_NETWORK and network-flag not initialized")
@@ -161,7 +161,7 @@ func getNetworkName(hnsNetworkName string) (string, error) {
 func getNetworkInfo(hns HostNetworkService, hnsNetworkName string) (*hnsNetworkInfo, error) {
 	hnsNetworkInfo, err := hns.getNetworkByName(hnsNetworkName)
 	for err != nil {
-		klog.ErrorS(err, "Unable to find HNS Network specified. Please check network name and CNI deployment", "hnsNetworkName", hnsNetworkName)
+		klog.ErrorS(err, "Unable to find HNS Network specified, please check network name and CNI deployment", "hnsNetworkName", hnsNetworkName)
 		time.Sleep(1 * time.Second)
 		hnsNetworkInfo, err = hns.getNetworkByName(hnsNetworkName)
 	}
@@ -189,7 +189,7 @@ func (t DualStackCompatTester) DualStackCompatible(networkName string) bool {
 		// used here. For now, seeming as how nothing before ws2019 (1809) is listed as supported for k8s we can pretty much assume
 		// any error here isn't because the query failed, it's just that dualstack simply isn't supported on the host. With all
 		// that in mind, just log as info and not error to let the user know we're falling back.
-		klog.InfoS("This version of Windows does not support dual-stack. Falling back to single-stack", "err", err.Error())
+		klog.InfoS("This version of Windows does not support dual-stack, falling back to single-stack", "err", err.Error())
 		return false
 	}
 
@@ -197,18 +197,18 @@ func (t DualStackCompatTester) DualStackCompatible(networkName string) bool {
 	hns, _ := newHostNetworkService()
 	networkName, err := getNetworkName(networkName)
 	if err != nil {
-		klog.ErrorS(err, "unable to determine dual-stack status %v. Falling back to single-stack")
+		klog.ErrorS(err, "Unable to determine dual-stack status, falling back to single-stack")
 		return false
 	}
 	networkInfo, err := getNetworkInfo(hns, networkName)
 	if err != nil {
-		klog.ErrorS(err, "unable to determine dual-stack status %v. Falling back to single-stack")
+		klog.ErrorS(err, "Unable to determine dual-stack status, falling back to single-stack")
 		return false
 	}
 
 	if utilfeature.DefaultFeatureGate.Enabled(kubefeatures.WinOverlay) && isOverlay(networkInfo) {
 		// Overlay (VXLAN) networks on Windows do not support dual-stack networking today
-		klog.InfoS("Winoverlay does not support dual-stack. Falling back to single-stack")
+		klog.InfoS("Winoverlay does not support dual-stack, falling back to single-stack")
 		return false
 	}
 
@@ -328,7 +328,7 @@ func (proxier *Proxier) onEndpointsMapChange(svcPortName *proxy.ServicePortName)
 		svcInfo.cleanupAllPolicies(proxier.endpointsMap[*svcPortName])
 	} else {
 		// If no service exists, just cleanup the remote endpoints
-		klog.V(3).InfoS("Endpoints are orphaned. Cleaning up")
+		klog.V(3).InfoS("Endpoints are orphaned, cleaning up")
 		// Cleanup Endpoints references
 		epInfos, exists := proxier.endpointsMap[*svcPortName]
 
@@ -659,7 +659,7 @@ func NewProxier(
 
 		if nodeIP.IsUnspecified() {
 			// attempt to get the correct ip address
-			klog.V(2).InfoS("node ip was unspecified.  Attempting to find node ip")
+			klog.V(2).InfoS("node ip was unspecified, attempting to find node ip")
 			nodeIP, err = apiutil.ResolveBindAddress(nodeIP)
 			if err != nil {
 				klog.InfoS("failed to find an ip. You may need set the --bind-address flag", "err", err)
@@ -989,7 +989,7 @@ func (proxier *Proxier) syncProxyRules() {
 	prevNetworkID := proxier.network.id
 	updatedNetwork, err := hns.getNetworkByName(hnsNetworkName)
 	if updatedNetwork == nil || updatedNetwork.id != prevNetworkID || isNetworkNotFoundError(err) {
-		klog.InfoS("The HNS network %s is not present or has changed since the last sync. Please check the CNI deployment", "hnsNetworkName", hnsNetworkName)
+		klog.InfoS("The HNS network is not present or has changed since the last sync, please check the CNI deployment", "hnsNetworkName", hnsNetworkName)
 		proxier.cleanupAllPolicies()
 		if updatedNetwork != nil {
 			proxier.network = *updatedNetwork
@@ -1111,14 +1111,14 @@ func (proxier *Proxier) syncProxyRules() {
 					networkName := proxier.network.name
 					updatedNetwork, err := hns.getNetworkByName(networkName)
 					if err != nil {
-						klog.ErrorS(err, "Unable to find HNS Network specified. Please check network name and CNI deployment", "hnsNetworkName", hnsNetworkName)
+						klog.ErrorS(err, "Unable to find HNS Network specified, please check network name and CNI deployment", "hnsNetworkName", hnsNetworkName)
 						proxier.cleanupAllPolicies()
 						return
 					}
 					proxier.network = *updatedNetwork
 					providerAddress := proxier.network.findRemoteSubnetProviderAddress(ep.IP())
 					if len(providerAddress) == 0 {
-						klog.InfoS("Could not find provider address. Assuming it is a public IP", "ip", ep.IP())
+						klog.InfoS("Could not find provider address, assuming it is a public IP", "ip", ep.IP())
 						providerAddress = proxier.nodeIP.String()
 					}
 
@@ -1197,7 +1197,7 @@ func (proxier *Proxier) syncProxyRules() {
 		}
 
 		if len(hnsEndpoints) == 0 {
-			klog.ErrorS(nil, "Endpoint information not available for service. Not applying any policy", "svcName", svcName.String())
+			klog.ErrorS(nil, "Endpoint information not available for service, not applying any policy", "svcName", svcName.String())
 			continue
 		}
 


### PR DESCRIPTION
proxy/winkernel/proxier.go was using format specifier with
structured logging pattern which is wrong. This commit removes
use of format specifiers to align with the pattern.

Signed-off-by: Umanga Chapagain <chapagainumanga@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Fixes incorrectly migrated structured logs

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #105122 

#### Special notes for your reviewer:
This issue surfaced while running structured logging checks https://github.com/kubernetes/kubernetes/pull/103293#issuecomment-922694019.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
