### PR TITLE
avoid hostNetwork pods conflict binding UDP ports

### DIFF
--- a/test/e2e/network/service.go
+++ b/test/e2e/network/service.go
@@ -2235,7 +2235,7 @@ var _ = common.SIGDescribe("Services", func() {
 		framework.ExpectNoError(err)
 
 		ginkgo.By("Creating 1 webserver pod to be part of the TCP service")
-		webserverPod0 := e2epod.NewAgnhostPod(ns, "echo-hostname-0", nil, nil, nil, "netexec", "--http-port", strconv.Itoa(endpointPort))
+		webserverPod0 := e2epod.NewAgnhostPod(ns, "echo-hostname-0", nil, nil, nil, "netexec", "--http-port", strconv.Itoa(endpointPort), "--udp-port", strconv.Itoa(endpointPort))
 		webserverPod0.Labels = jig.Labels
 		webserverPod0.Spec.HostNetwork = true
 		e2epod.SetNodeSelection(&webserverPod0.Spec, e2epod.NodeSelection{Name: node0.Name})


### PR DESCRIPTION
The agnhost pods using netexec will bind by default to the UDP
port 8081, use a different port for hostNetwork pods to avoid
scheduling conflicts and fail the tests.

After https://github.com/kubernetes/kubernetes/pull/105143 we can completely disable UDP for this test, by setting the UDP port to -1, but in the meantime this will solve some of the flakiness, since this test was binding to UDP port 8081 and failing because of the port conflict as reported in slack  https://kubernetes.slack.com/archives/C09QZ4DQB/p1631869484079100


/kind failing-test
/kind flake
```release-note
NONE
```

