### PR TITLE
Introduce new prune parameter into diff command

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/apply/apply.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/apply/apply.go
@@ -21,6 +21,8 @@ import (
 	"io"
 	"net/http"
 
+	"k8s.io/kubectl/pkg/util/prune"
+
 	"github.com/spf13/cobra"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -60,7 +62,7 @@ type ApplyFlags struct {
 	FieldManager   string
 	Selector       string
 	Prune          bool
-	PruneResources []pruneResource
+	PruneResources []prune.Resource
 	All            bool
 	Overwrite      bool
 	OpenAPIPatch   bool
@@ -85,7 +87,7 @@ type ApplyOptions struct {
 	DryRunStrategy  cmdutil.DryRunStrategy
 	DryRunVerifier  *resource.DryRunVerifier
 	Prune           bool
-	PruneResources  []pruneResource
+	PruneResources  []prune.Resource
 	cmdBaseName     string
 	All             bool
 	Overwrite       bool
@@ -278,7 +280,7 @@ func (flags *ApplyFlags) ToOptions(cmd *cobra.Command, baseName string, args []s
 	}
 
 	if flags.Prune {
-		flags.PruneResources, err = parsePruneResources(mapper, flags.PruneWhitelist)
+		flags.PruneResources, err = prune.ParseResources(mapper, flags.PruneWhitelist)
 		if err != nil {
 			return nil, err
 		}

--- a/staging/src/k8s.io/kubectl/pkg/cmd/apply/apply.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/apply/apply.go
@@ -21,9 +21,8 @@ import (
 	"io"
 	"net/http"
 
-	"k8s.io/kubectl/pkg/util/prune"
-
 	"github.com/spf13/cobra"
+
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -44,6 +43,7 @@ import (
 	"k8s.io/kubectl/pkg/util"
 	"k8s.io/kubectl/pkg/util/i18n"
 	"k8s.io/kubectl/pkg/util/openapi"
+	"k8s.io/kubectl/pkg/util/prune"
 	"k8s.io/kubectl/pkg/util/templates"
 	"k8s.io/kubectl/pkg/validation"
 )

--- a/staging/src/k8s.io/kubectl/pkg/cmd/apply/prune.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/apply/prune.go
@@ -20,12 +20,12 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"strings"
+
+	"k8s.io/kubectl/pkg/util/prune"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/cli-runtime/pkg/printers"
 	"k8s.io/client-go/dynamic"
@@ -71,7 +71,7 @@ func newPruner(o *ApplyOptions) pruner {
 
 func (p *pruner) pruneAll(o *ApplyOptions) error {
 
-	namespacedRESTMappings, nonNamespacedRESTMappings, err := getRESTMappings(o.Mapper, &(o.PruneResources))
+	namespacedRESTMappings, nonNamespacedRESTMappings, err := prune.GetRESTMappings(o.Mapper, &(o.PruneResources))
 	if err != nil {
 		return fmt.Errorf("error retrieving RESTMappings to prune: %v", err)
 	}
@@ -157,84 +157,4 @@ func asDeleteOptions(cascadingStrategy metav1.DeletionPropagation, gracePeriod i
 	}
 	options.PropagationPolicy = &cascadingStrategy
 	return options
-}
-
-type pruneResource struct {
-	group      string
-	version    string
-	kind       string
-	namespaced bool
-}
-
-func (pr pruneResource) String() string {
-	return fmt.Sprintf("%v/%v, Kind=%v, Namespaced=%v", pr.group, pr.version, pr.kind, pr.namespaced)
-}
-
-func getRESTMappings(mapper meta.RESTMapper, pruneResources *[]pruneResource) (namespaced, nonNamespaced []*meta.RESTMapping, err error) {
-	if len(*pruneResources) == 0 {
-		// default allowlist
-		*pruneResources = []pruneResource{
-			{"", "v1", "ConfigMap", true},
-			{"", "v1", "Endpoints", true},
-			{"", "v1", "Namespace", false},
-			{"", "v1", "PersistentVolumeClaim", true},
-			{"", "v1", "PersistentVolume", false},
-			{"", "v1", "Pod", true},
-			{"", "v1", "ReplicationController", true},
-			{"", "v1", "Secret", true},
-			{"", "v1", "Service", true},
-			{"batch", "v1", "Job", true},
-			{"batch", "v1", "CronJob", true},
-			{"networking.k8s.io", "v1", "Ingress", true},
-			{"apps", "v1", "DaemonSet", true},
-			{"apps", "v1", "Deployment", true},
-			{"apps", "v1", "ReplicaSet", true},
-			{"apps", "v1", "StatefulSet", true},
-		}
-	}
-
-	for _, resource := range *pruneResources {
-		addedMapping, err := mapper.RESTMapping(schema.GroupKind{Group: resource.group, Kind: resource.kind}, resource.version)
-		if err != nil {
-			return nil, nil, fmt.Errorf("invalid resource %v: %v", resource, err)
-		}
-		if resource.namespaced {
-			namespaced = append(namespaced, addedMapping)
-		} else {
-			nonNamespaced = append(nonNamespaced, addedMapping)
-		}
-	}
-
-	return namespaced, nonNamespaced, nil
-}
-
-func parsePruneResources(mapper meta.RESTMapper, gvks []string) ([]pruneResource, error) {
-	pruneResources := []pruneResource{}
-	for _, groupVersionKind := range gvks {
-		gvk := strings.Split(groupVersionKind, "/")
-		if len(gvk) != 3 {
-			return nil, fmt.Errorf("invalid GroupVersionKind format: %v, please follow <group/version/kind>", groupVersionKind)
-		}
-
-		if gvk[0] == "core" {
-			gvk[0] = ""
-		}
-		mapping, err := mapper.RESTMapping(schema.GroupKind{Group: gvk[0], Kind: gvk[2]}, gvk[1])
-		if err != nil {
-			return pruneResources, err
-		}
-		var namespaced bool
-		namespaceScope := mapping.Scope.Name()
-		switch namespaceScope {
-		case meta.RESTScopeNameNamespace:
-			namespaced = true
-		case meta.RESTScopeNameRoot:
-			namespaced = false
-		default:
-			return pruneResources, fmt.Errorf("Unknown namespace scope: %q", namespaceScope)
-		}
-
-		pruneResources = append(pruneResources, pruneResource{gvk[0], gvk[1], gvk[2], namespaced})
-	}
-	return pruneResources, nil
 }

--- a/staging/src/k8s.io/kubectl/pkg/cmd/apply/prune.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/apply/prune.go
@@ -21,8 +21,6 @@ import (
 	"fmt"
 	"io"
 
-	"k8s.io/kubectl/pkg/util/prune"
-
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -30,6 +28,7 @@ import (
 	"k8s.io/cli-runtime/pkg/printers"
 	"k8s.io/client-go/dynamic"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
+	"k8s.io/kubectl/pkg/util/prune"
 )
 
 type pruner struct {
@@ -71,7 +70,7 @@ func newPruner(o *ApplyOptions) pruner {
 
 func (p *pruner) pruneAll(o *ApplyOptions) error {
 
-	namespacedRESTMappings, nonNamespacedRESTMappings, err := prune.GetRESTMappings(o.Mapper, &(o.PruneResources))
+	namespacedRESTMappings, nonNamespacedRESTMappings, err := prune.GetRESTMappings(o.Mapper, o.PruneResources)
 	if err != nil {
 		return fmt.Errorf("error retrieving RESTMappings to prune: %v", err)
 	}

--- a/staging/src/k8s.io/kubectl/pkg/cmd/diff/prune.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/diff/prune.go
@@ -19,15 +19,17 @@ package diff
 import (
 	"context"
 	"fmt"
-	"io"
-	"strings"
+
+	"k8s.io/apimachinery/pkg/util/uuid"
+
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"k8s.io/kubectl/pkg/util/prune"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/sets"
-	"k8s.io/cli-runtime/pkg/printers"
 	"k8s.io/client-go/dynamic"
 )
 
@@ -38,199 +40,73 @@ type pruner struct {
 	visitedUids       sets.String
 	visitedNamespaces sets.String
 	labelSelector     string
-	fieldSelector     string
-
-	cascadingStrategy metav1.DeletionPropagation
-	gracePeriod       int
-
-	toPrinter func(string) (printers.ResourcePrinter, error)
-
-	out io.Writer
+	resources         []prune.Resource
 }
 
-func newPruner(o *DiffOptions) pruner {
-	return pruner{
-		mapper:        o.Mapper,
-		dynamicClient: o.DynamicClient,
-
-		labelSelector:     o.Selector,
-		visitedUids:       o.VisitedUids,
-		visitedNamespaces: o.VisitedNamespaces,
-
-		toPrinter: o.ToPrinter,
-
-		cascadingStrategy: metav1.DeletePropagationBackground,
-		gracePeriod:       -1,
-
-		out: o.ErrOut,
-	}
-}
-
-func (p *pruner) pruneAll(o *DiffOptions) error {
-
-	namespacedRESTMappings, nonNamespacedRESTMappings, err := getRESTMappings(o.Mapper, &(o.PruneResources))
+func (p *pruner) pruneAll() ([]runtime.Object, error) {
+	var allPruned []runtime.Object
+	namespacedRESTMappings, nonNamespacedRESTMappings, err := prune.GetRESTMappings(p.mapper, &(p.resources))
 	if err != nil {
-		return fmt.Errorf("error retrieving RESTMappings to prune: %v", err)
+		return allPruned, fmt.Errorf("error retrieving RESTMappings to prune: %v", err)
 	}
 
 	for n := range p.visitedNamespaces {
 		for _, m := range namespacedRESTMappings {
-			if err := p.prune(n, m); err != nil {
-				return fmt.Errorf("error pruning namespaced object %v: %v", m.GroupVersionKind, err)
+			if pobjs, err := p.prune(n, m); err != nil {
+				return pobjs, fmt.Errorf("error pruning namespaced object %v: %v", m.GroupVersionKind, err)
+			} else {
+				allPruned = append(allPruned, pobjs...)
 			}
 		}
 	}
 	for _, m := range nonNamespacedRESTMappings {
-		if err := p.prune(metav1.NamespaceNone, m); err != nil {
-			return fmt.Errorf("error pruning nonNamespaced object %v: %v", m.GroupVersionKind, err)
+		if pobjs, err := p.prune(metav1.NamespaceNone, m); err != nil {
+			return allPruned, fmt.Errorf("error pruning nonNamespaced object %v: %v", m.GroupVersionKind, err)
+		} else {
+			allPruned = append(allPruned, pobjs...)
 		}
 	}
 
-	return nil
+	return allPruned, nil
 }
 
-func (p *pruner) prune(namespace string, mapping *meta.RESTMapping) error {
+func (p *pruner) prune(namespace string, mapping *meta.RESTMapping) ([]runtime.Object, error) {
 	objList, err := p.dynamicClient.Resource(mapping.Resource).
 		Namespace(namespace).
 		List(context.TODO(), metav1.ListOptions{
 			LabelSelector: p.labelSelector,
-			FieldSelector: p.fieldSelector,
 		})
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	objs, err := meta.ExtractList(objList)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
+	var pobjs []runtime.Object
 	for _, obj := range objs {
 		metadata, err := meta.Accessor(obj)
 		if err != nil {
-			return err
+			return pobjs, err
 		}
 		annots := metadata.GetAnnotations()
 		if _, ok := annots[corev1.LastAppliedConfigAnnotation]; !ok {
-			// don't prune resources not created with apply
 			continue
 		}
 		uid := metadata.GetUID()
 		if p.visitedUids.Has(string(uid)) {
 			continue
 		}
-		name := metadata.GetName()
-		if err := p.delete(namespace, name, mapping); err != nil {
-			return err
-		}
 
-		printer, err := p.toPrinter("pruned")
-		if err != nil {
-			return err
-		}
-
-		printer.PrintObj(obj, p.out)
+		pobjs = append(pobjs, obj)
 	}
-	return nil
+	return pobjs, nil
 }
 
-func (p *pruner) delete(namespace, name string, mapping *meta.RESTMapping) error {
-	return runDelete(namespace, name, mapping, p.dynamicClient, p.cascadingStrategy, p.gracePeriod, true)
-}
-
-func runDelete(namespace, name string, mapping *meta.RESTMapping, c dynamic.Interface, cascadingStrategy metav1.DeletionPropagation, gracePeriod int, serverDryRun bool) error {
-	options := asDeleteOptions(cascadingStrategy, gracePeriod)
-	if serverDryRun {
-		options.DryRun = []string{metav1.DryRunAll}
-	}
-	return c.Resource(mapping.Resource).Namespace(namespace).Delete(context.TODO(), name, options)
-}
-
-func asDeleteOptions(cascadingStrategy metav1.DeletionPropagation, gracePeriod int) metav1.DeleteOptions {
-	options := metav1.DeleteOptions{}
-	if gracePeriod >= 0 {
-		options = *metav1.NewDeleteOptions(int64(gracePeriod))
-	}
-	options.PropagationPolicy = &cascadingStrategy
-	return options
-}
-
-type pruneResource struct {
-	group      string
-	version    string
-	kind       string
-	namespaced bool
-}
-
-func (pr pruneResource) String() string {
-	return fmt.Sprintf("%v/%v, Kind=%v, Namespaced=%v", pr.group, pr.version, pr.kind, pr.namespaced)
-}
-
-func getRESTMappings(mapper meta.RESTMapper, pruneResources *[]pruneResource) (namespaced, nonNamespaced []*meta.RESTMapping, err error) {
-	if len(*pruneResources) == 0 {
-		// default allowlist
-		*pruneResources = []pruneResource{
-			{"", "v1", "ConfigMap", true},
-			{"", "v1", "Endpoints", true},
-			{"", "v1", "Namespace", false},
-			{"", "v1", "PersistentVolumeClaim", true},
-			{"", "v1", "PersistentVolume", false},
-			{"", "v1", "Pod", true},
-			{"", "v1", "ReplicationController", true},
-			{"", "v1", "Secret", true},
-			{"", "v1", "Service", true},
-			{"batch", "v1", "Job", true},
-			{"batch", "v1", "CronJob", true},
-			{"networking.k8s.io", "v1", "Ingress", true},
-			{"apps", "v1", "DaemonSet", true},
-			{"apps", "v1", "Deployment", true},
-			{"apps", "v1", "ReplicaSet", true},
-			{"apps", "v1", "StatefulSet", true},
-		}
-	}
-
-	for _, resource := range *pruneResources {
-		addedMapping, err := mapper.RESTMapping(schema.GroupKind{Group: resource.group, Kind: resource.kind}, resource.version)
-		if err != nil {
-			return nil, nil, fmt.Errorf("invalid resource %v: %v", resource, err)
-		}
-		if resource.namespaced {
-			namespaced = append(namespaced, addedMapping)
-		} else {
-			nonNamespaced = append(nonNamespaced, addedMapping)
-		}
-	}
-
-	return namespaced, nonNamespaced, nil
-}
-
-func parsePruneResources(mapper meta.RESTMapper, gvks []string) ([]pruneResource, error) {
-	pruneResources := []pruneResource{}
-	for _, groupVersionKind := range gvks {
-		gvk := strings.Split(groupVersionKind, "/")
-		if len(gvk) != 3 {
-			return nil, fmt.Errorf("invalid GroupVersionKind format: %v, please follow <group/version/kind>", groupVersionKind)
-		}
-
-		if gvk[0] == "core" {
-			gvk[0] = ""
-		}
-		mapping, err := mapper.RESTMapping(schema.GroupKind{Group: gvk[0], Kind: gvk[2]}, gvk[1])
-		if err != nil {
-			return pruneResources, err
-		}
-		var namespaced bool
-		namespaceScope := mapping.Scope.Name()
-		switch namespaceScope {
-		case meta.RESTScopeNameNamespace:
-			namespaced = true
-		case meta.RESTScopeNameRoot:
-			namespaced = false
-		default:
-			return pruneResources, fmt.Errorf("Unknown namespace scope: %q", namespaceScope)
-		}
-
-		pruneResources = append(pruneResources, pruneResource{gvk[0], gvk[1], gvk[2], namespaced})
-	}
-	return pruneResources, nil
+func (p *pruner) GetObjectName(obj runtime.Object) string {
+	// Not compare anything, it is safe to assign random
+	// object name.
+	return string(uuid.NewUUID())
 }

--- a/staging/src/k8s.io/kubectl/pkg/cmd/diff/prune.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/diff/prune.go
@@ -1,0 +1,236 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package diff
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/cli-runtime/pkg/printers"
+	"k8s.io/client-go/dynamic"
+)
+
+type pruner struct {
+	mapper        meta.RESTMapper
+	dynamicClient dynamic.Interface
+
+	visitedUids       sets.String
+	visitedNamespaces sets.String
+	labelSelector     string
+	fieldSelector     string
+
+	cascadingStrategy metav1.DeletionPropagation
+	gracePeriod       int
+
+	toPrinter func(string) (printers.ResourcePrinter, error)
+
+	out io.Writer
+}
+
+func newPruner(o *DiffOptions) pruner {
+	return pruner{
+		mapper:        o.Mapper,
+		dynamicClient: o.DynamicClient,
+
+		labelSelector:     o.Selector,
+		visitedUids:       o.VisitedUids,
+		visitedNamespaces: o.VisitedNamespaces,
+
+		toPrinter: o.ToPrinter,
+
+		cascadingStrategy: metav1.DeletePropagationBackground,
+		gracePeriod:       -1,
+
+		out: o.ErrOut,
+	}
+}
+
+func (p *pruner) pruneAll(o *DiffOptions) error {
+
+	namespacedRESTMappings, nonNamespacedRESTMappings, err := getRESTMappings(o.Mapper, &(o.PruneResources))
+	if err != nil {
+		return fmt.Errorf("error retrieving RESTMappings to prune: %v", err)
+	}
+
+	for n := range p.visitedNamespaces {
+		for _, m := range namespacedRESTMappings {
+			if err := p.prune(n, m); err != nil {
+				return fmt.Errorf("error pruning namespaced object %v: %v", m.GroupVersionKind, err)
+			}
+		}
+	}
+	for _, m := range nonNamespacedRESTMappings {
+		if err := p.prune(metav1.NamespaceNone, m); err != nil {
+			return fmt.Errorf("error pruning nonNamespaced object %v: %v", m.GroupVersionKind, err)
+		}
+	}
+
+	return nil
+}
+
+func (p *pruner) prune(namespace string, mapping *meta.RESTMapping) error {
+	objList, err := p.dynamicClient.Resource(mapping.Resource).
+		Namespace(namespace).
+		List(context.TODO(), metav1.ListOptions{
+			LabelSelector: p.labelSelector,
+			FieldSelector: p.fieldSelector,
+		})
+	if err != nil {
+		return err
+	}
+
+	objs, err := meta.ExtractList(objList)
+	if err != nil {
+		return err
+	}
+
+	for _, obj := range objs {
+		metadata, err := meta.Accessor(obj)
+		if err != nil {
+			return err
+		}
+		annots := metadata.GetAnnotations()
+		if _, ok := annots[corev1.LastAppliedConfigAnnotation]; !ok {
+			// don't prune resources not created with apply
+			continue
+		}
+		uid := metadata.GetUID()
+		if p.visitedUids.Has(string(uid)) {
+			continue
+		}
+		name := metadata.GetName()
+		if err := p.delete(namespace, name, mapping); err != nil {
+			return err
+		}
+
+		printer, err := p.toPrinter("pruned")
+		if err != nil {
+			return err
+		}
+
+		printer.PrintObj(obj, p.out)
+	}
+	return nil
+}
+
+func (p *pruner) delete(namespace, name string, mapping *meta.RESTMapping) error {
+	return runDelete(namespace, name, mapping, p.dynamicClient, p.cascadingStrategy, p.gracePeriod, true)
+}
+
+func runDelete(namespace, name string, mapping *meta.RESTMapping, c dynamic.Interface, cascadingStrategy metav1.DeletionPropagation, gracePeriod int, serverDryRun bool) error {
+	options := asDeleteOptions(cascadingStrategy, gracePeriod)
+	if serverDryRun {
+		options.DryRun = []string{metav1.DryRunAll}
+	}
+	return c.Resource(mapping.Resource).Namespace(namespace).Delete(context.TODO(), name, options)
+}
+
+func asDeleteOptions(cascadingStrategy metav1.DeletionPropagation, gracePeriod int) metav1.DeleteOptions {
+	options := metav1.DeleteOptions{}
+	if gracePeriod >= 0 {
+		options = *metav1.NewDeleteOptions(int64(gracePeriod))
+	}
+	options.PropagationPolicy = &cascadingStrategy
+	return options
+}
+
+type pruneResource struct {
+	group      string
+	version    string
+	kind       string
+	namespaced bool
+}
+
+func (pr pruneResource) String() string {
+	return fmt.Sprintf("%v/%v, Kind=%v, Namespaced=%v", pr.group, pr.version, pr.kind, pr.namespaced)
+}
+
+func getRESTMappings(mapper meta.RESTMapper, pruneResources *[]pruneResource) (namespaced, nonNamespaced []*meta.RESTMapping, err error) {
+	if len(*pruneResources) == 0 {
+		// default allowlist
+		*pruneResources = []pruneResource{
+			{"", "v1", "ConfigMap", true},
+			{"", "v1", "Endpoints", true},
+			{"", "v1", "Namespace", false},
+			{"", "v1", "PersistentVolumeClaim", true},
+			{"", "v1", "PersistentVolume", false},
+			{"", "v1", "Pod", true},
+			{"", "v1", "ReplicationController", true},
+			{"", "v1", "Secret", true},
+			{"", "v1", "Service", true},
+			{"batch", "v1", "Job", true},
+			{"batch", "v1", "CronJob", true},
+			{"networking.k8s.io", "v1", "Ingress", true},
+			{"apps", "v1", "DaemonSet", true},
+			{"apps", "v1", "Deployment", true},
+			{"apps", "v1", "ReplicaSet", true},
+			{"apps", "v1", "StatefulSet", true},
+		}
+	}
+
+	for _, resource := range *pruneResources {
+		addedMapping, err := mapper.RESTMapping(schema.GroupKind{Group: resource.group, Kind: resource.kind}, resource.version)
+		if err != nil {
+			return nil, nil, fmt.Errorf("invalid resource %v: %v", resource, err)
+		}
+		if resource.namespaced {
+			namespaced = append(namespaced, addedMapping)
+		} else {
+			nonNamespaced = append(nonNamespaced, addedMapping)
+		}
+	}
+
+	return namespaced, nonNamespaced, nil
+}
+
+func parsePruneResources(mapper meta.RESTMapper, gvks []string) ([]pruneResource, error) {
+	pruneResources := []pruneResource{}
+	for _, groupVersionKind := range gvks {
+		gvk := strings.Split(groupVersionKind, "/")
+		if len(gvk) != 3 {
+			return nil, fmt.Errorf("invalid GroupVersionKind format: %v, please follow <group/version/kind>", groupVersionKind)
+		}
+
+		if gvk[0] == "core" {
+			gvk[0] = ""
+		}
+		mapping, err := mapper.RESTMapping(schema.GroupKind{Group: gvk[0], Kind: gvk[2]}, gvk[1])
+		if err != nil {
+			return pruneResources, err
+		}
+		var namespaced bool
+		namespaceScope := mapping.Scope.Name()
+		switch namespaceScope {
+		case meta.RESTScopeNameNamespace:
+			namespaced = true
+		case meta.RESTScopeNameRoot:
+			namespaced = false
+		default:
+			return pruneResources, fmt.Errorf("Unknown namespace scope: %q", namespaceScope)
+		}
+
+		pruneResources = append(pruneResources, pruneResource{gvk[0], gvk[1], gvk[2], namespaced})
+	}
+	return pruneResources, nil
+}

--- a/staging/src/k8s.io/kubectl/pkg/cmd/diff/prune.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/diff/prune.go
@@ -43,6 +43,13 @@ type pruner struct {
 	resources         []prune.Resource
 }
 
+func newPruner() *pruner {
+	return &pruner{
+		visitedUids:       sets.NewString(),
+		visitedNamespaces: sets.NewString(),
+	}
+}
+
 func (p *pruner) pruneAll() ([]runtime.Object, error) {
 	var allPruned []runtime.Object
 	namespacedRESTMappings, nonNamespacedRESTMappings, err := prune.GetRESTMappings(p.mapper, &(p.resources))

--- a/staging/src/k8s.io/kubectl/pkg/cmd/diff/prune_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/diff/prune_test.go
@@ -1,0 +1,98 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package diff
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+type testRESTMapper struct {
+	meta.RESTMapper
+	scope meta.RESTScope
+}
+
+func (m *testRESTMapper) RESTMapping(gk schema.GroupKind, versions ...string) (*meta.RESTMapping, error) {
+	return &meta.RESTMapping{
+		Resource: schema.GroupVersionResource{
+			Group:    gk.Group,
+			Version:  "",
+			Resource: "",
+		},
+		GroupVersionKind: schema.GroupVersionKind{
+			Group:   gk.Group,
+			Version: "",
+			Kind:    gk.Kind,
+		},
+		Scope: m.scope,
+	}, nil
+}
+
+func TestParsePruneResources(t *testing.T) {
+	tests := []struct {
+		mapper   *testRESTMapper
+		gvks     []string
+		expected []pruneResource
+		err      bool
+	}{
+		{
+			mapper: &testRESTMapper{
+				scope: meta.RESTScopeNamespace,
+			},
+			gvks:     nil,
+			expected: []pruneResource{},
+			err:      false,
+		},
+		{
+			mapper: &testRESTMapper{
+				scope: meta.RESTScopeNamespace,
+			},
+			gvks:     []string{"group/kind/version/test"},
+			expected: []pruneResource{},
+			err:      true,
+		},
+		{
+			mapper: &testRESTMapper{
+				scope: meta.RESTScopeNamespace,
+			},
+			gvks:     []string{"group/kind/version"},
+			expected: []pruneResource{{group: "group", version: "kind", kind: "version", namespaced: true}},
+			err:      false,
+		},
+		{
+			mapper: &testRESTMapper{
+				scope: meta.RESTScopeRoot,
+			},
+			gvks:     []string{"group/kind/version"},
+			expected: []pruneResource{{group: "group", version: "kind", kind: "version", namespaced: false}},
+			err:      false,
+		},
+	}
+
+	for _, tc := range tests {
+		actual, err := parsePruneResources(tc.mapper, tc.gvks)
+		if tc.err {
+			assert.NotEmptyf(t, err, "parsePruneResources error expected but not fired")
+		} else {
+			assert.Equal(t, actual, tc.expected, "parsePruneResources failed expected %v actual %v", tc.expected, actual)
+		}
+	}
+}

--- a/staging/src/k8s.io/kubectl/pkg/util/prune/prune.go
+++ b/staging/src/k8s.io/kubectl/pkg/util/prune/prune.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package prune
 
 import (

--- a/staging/src/k8s.io/kubectl/pkg/util/prune/prune.go
+++ b/staging/src/k8s.io/kubectl/pkg/util/prune/prune.go
@@ -1,0 +1,89 @@
+package prune
+
+import (
+	"fmt"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+type Resource struct {
+	group      string
+	version    string
+	kind       string
+	namespaced bool
+}
+
+func (pr Resource) String() string {
+	return fmt.Sprintf("%v/%v, Kind=%v, Namespaced=%v", pr.group, pr.version, pr.kind, pr.namespaced)
+}
+
+func GetRESTMappings(mapper meta.RESTMapper, pruneResources *[]Resource) (namespaced, nonNamespaced []*meta.RESTMapping, err error) {
+	if len(*pruneResources) == 0 {
+		// default allowlist
+		*pruneResources = []Resource{
+			{"", "v1", "ConfigMap", true},
+			{"", "v1", "Endpoints", true},
+			{"", "v1", "Namespace", false},
+			{"", "v1", "PersistentVolumeClaim", true},
+			{"", "v1", "PersistentVolume", false},
+			{"", "v1", "Pod", true},
+			{"", "v1", "ReplicationController", true},
+			{"", "v1", "Secret", true},
+			{"", "v1", "Service", true},
+			{"batch", "v1", "Job", true},
+			{"batch", "v1", "CronJob", true},
+			{"networking.k8s.io", "v1", "Ingress", true},
+			{"apps", "v1", "DaemonSet", true},
+			{"apps", "v1", "Deployment", true},
+			{"apps", "v1", "ReplicaSet", true},
+			{"apps", "v1", "StatefulSet", true},
+		}
+	}
+
+	for _, resource := range *pruneResources {
+		addedMapping, err := mapper.RESTMapping(schema.GroupKind{Group: resource.group, Kind: resource.kind}, resource.version)
+		if err != nil {
+			return nil, nil, fmt.Errorf("invalid resource %v: %v", resource, err)
+		}
+		if resource.namespaced {
+			namespaced = append(namespaced, addedMapping)
+		} else {
+			nonNamespaced = append(nonNamespaced, addedMapping)
+		}
+	}
+
+	return namespaced, nonNamespaced, nil
+}
+
+func ParseResources(mapper meta.RESTMapper, gvks []string) ([]Resource, error) {
+	pruneResources := []Resource{}
+	for _, groupVersionKind := range gvks {
+		gvk := strings.Split(groupVersionKind, "/")
+		if len(gvk) != 3 {
+			return nil, fmt.Errorf("invalid GroupVersionKind format: %v, please follow <group/version/kind>", groupVersionKind)
+		}
+
+		if gvk[0] == "core" {
+			gvk[0] = ""
+		}
+		mapping, err := mapper.RESTMapping(schema.GroupKind{Group: gvk[0], Kind: gvk[2]}, gvk[1])
+		if err != nil {
+			return pruneResources, err
+		}
+		var namespaced bool
+		namespaceScope := mapping.Scope.Name()
+		switch namespaceScope {
+		case meta.RESTScopeNameNamespace:
+			namespaced = true
+		case meta.RESTScopeNameRoot:
+			namespaced = false
+		default:
+			return pruneResources, fmt.Errorf("Unknown namespace scope: %q", namespaceScope)
+		}
+
+		pruneResources = append(pruneResources, Resource{gvk[0], gvk[1], gvk[2], namespaced})
+	}
+	return pruneResources, nil
+}

--- a/staging/src/k8s.io/kubectl/pkg/util/prune/prune.go
+++ b/staging/src/k8s.io/kubectl/pkg/util/prune/prune.go
@@ -35,10 +35,10 @@ func (pr Resource) String() string {
 	return fmt.Sprintf("%v/%v, Kind=%v, Namespaced=%v", pr.group, pr.version, pr.kind, pr.namespaced)
 }
 
-func GetRESTMappings(mapper meta.RESTMapper, pruneResources *[]Resource) (namespaced, nonNamespaced []*meta.RESTMapping, err error) {
-	if len(*pruneResources) == 0 {
+func GetRESTMappings(mapper meta.RESTMapper, pruneResources []Resource) (namespaced, nonNamespaced []*meta.RESTMapping, err error) {
+	if len(pruneResources) == 0 {
 		// default allowlist
-		*pruneResources = []Resource{
+		pruneResources = []Resource{
 			{"", "v1", "ConfigMap", true},
 			{"", "v1", "Endpoints", true},
 			{"", "v1", "Namespace", false},
@@ -58,7 +58,7 @@ func GetRESTMappings(mapper meta.RESTMapper, pruneResources *[]Resource) (namesp
 		}
 	}
 
-	for _, resource := range *pruneResources {
+	for _, resource := range pruneResources {
 		addedMapping, err := mapper.RESTMapping(schema.GroupKind{Group: resource.group, Kind: resource.kind}, resource.version)
 		if err != nil {
 			return nil, nil, fmt.Errorf("invalid resource %v: %v", resource, err)

--- a/staging/src/k8s.io/kubectl/pkg/util/prune/prune_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/util/prune/prune_test.go
@@ -49,14 +49,14 @@ func (m *testRESTMapper) RESTMapping(gk schema.GroupKind, versions ...string) (*
 func TestGetRESTMappings(t *testing.T) {
 	tests := []struct {
 		mapper      *testRESTMapper
-		pr          *[]Resource
+		pr          []Resource
 		expectedns  int
 		expectednns int
 		expectederr error
 	}{
 		{
 			mapper:      &testRESTMapper{},
-			pr:          &[]Resource{},
+			pr:          []Resource{},
 			expectedns:  14,
 			expectednns: 2,
 			expectederr: nil,

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -2156,6 +2156,7 @@ k8s.io/kubectl/pkg/util/openapi
 k8s.io/kubectl/pkg/util/openapi/testing
 k8s.io/kubectl/pkg/util/openapi/validation
 k8s.io/kubectl/pkg/util/podutils
+k8s.io/kubectl/pkg/util/prune
 k8s.io/kubectl/pkg/util/qos
 k8s.io/kubectl/pkg/util/rbac
 k8s.io/kubectl/pkg/util/resource


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
This PR introduces new prune and it's dependent parameters to simulate
`kubectl apply --prune` command. It works exactly the same way how
`kubectl apply --prune` works. Thanks to that, users can run this command 
to find out which resources will be pruned.

#### Which issue(s) this PR fixes:
Fixes #105043

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Added prune flag into diff command to simulate `apply --prune` 
```
