### PR TITLE
Memory manager test refactoring

### DIFF
--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -122,6 +122,8 @@ type Framework struct {
 
 	// Timeouts contains the custom timeouts used during the test execution.
 	Timeouts *TimeoutContext
+
+	MemoryProblemOccured bool
 }
 
 // AfterEachActionFunc is a function that can be called after each test
@@ -460,6 +462,10 @@ func (f *Framework) AfterEach() {
 			(*e2emetrics.ComponentCollection)(&received).ComputeClusterAutoscalerMetricsDelta(f.clusterAutoscalerMetricsBeforeTest)
 			f.TestSummaries = append(f.TestSummaries, (*e2emetrics.ComponentCollection)(&received))
 		}
+	}
+
+	if TestContext.GatherMemoryAfterTest && f.MemoryProblemOccured {
+		f.TestSummaries = append(f.TestSummaries, getMemorySummaries(f))
 	}
 
 	TestContext.CloudConfig.Provider.FrameworkAfterEach(f)

--- a/test/e2e/framework/memory_utils.go
+++ b/test/e2e/framework/memory_utils.go
@@ -1,0 +1,80 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package framework
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type MemorySummary map[string]string
+
+func getMemInfo() string {
+	buf, err := os.ReadFile("/proc/meminfo")
+	if err != nil {
+		Logf("Can't read meminfo %v", err)
+		return ""
+	}
+	return string(buf)
+}
+
+//getMemorySummaries construct memory summary
+func getMemorySummaries(f *Framework) *MemorySummary {
+	var sb strings.Builder
+
+	result := make(MemorySummary)
+	result["meminfo"] = getMemInfo()
+
+	if output, err := exec.Command("/bin/sh", "-c", "ps -aux --sort=-rss|head -n20").Output(); err == nil {
+		result["topmemconsumer"] = string(output)
+	} else {
+		Logf("Can't get processes: %v\n", err)
+	}
+
+	pods, err := f.ClientSet.CoreV1().Pods(f.Namespace.Name).List(context.TODO(), metav1.ListOptions{})
+	ExpectNoError(err)
+	for _, p := range pods.Items {
+		fmt.Fprintf(&sb, "pod: %s\n", p.Name)
+	}
+
+	result["podsummary"] = sb.String()
+	return &result
+}
+
+// PrintHumanReadable return human readable representation of MemorySummary
+func (ms *MemorySummary) PrintHumanReadable() string {
+	buf := bytes.Buffer{}
+	for _, v := range *ms {
+		buf.WriteString(fmt.Sprintf("%v\n", v))
+	}
+	return buf.String()
+}
+
+// SummaryKind returns the summary of memory usage.
+func (f *MemorySummary) SummaryKind() string {
+	return "MemorySummary"
+}
+
+func (f *MemorySummary) PrintJSON() string {
+	return PrettyPrintJSON(f)
+}

--- a/test/e2e/framework/test_context.go
+++ b/test/e2e/framework/test_context.go
@@ -134,6 +134,7 @@ type TestContextType struct {
 	GatherLogsSizes                   bool
 	GatherMetricsAfterTest            string
 	GatherSuiteMetricsAfterTest       bool
+	GatherMemoryAfterTest             bool
 	MaxNodesToGather                  int
 	// If set to 'true' framework will gather ClusterAutoscaler metrics when gathering them for other components.
 	IncludeClusterAutoscalerMetrics bool

--- a/test/e2e_node/memory_manager_test.go
+++ b/test/e2e_node/memory_manager_test.go
@@ -323,9 +323,8 @@ var _ = SIGDescribe("Memory Manager [Disruptive] [Serial] [Feature:MemoryManager
 		// allocate hugepages
 		if *is2MiHugepagesSupported {
 			ginkgo.By("Configuring hugepages")
-			gomega.Eventually(func() error {
-				return configureHugePages(hugepagesSize2M, hugepages2MiCount, pointer.IntPtr(0), true)
-			}, 30*time.Second, framework.Poll).Should(gomega.BeNil())
+			err := configureHugePages(hugepagesSize2M, hugepages2MiCount, pointer.IntPtr(0), true, &f.MemoryProblemOccured)
+			framework.ExpectNoError(err)
 		}
 	})
 
@@ -355,10 +354,7 @@ var _ = SIGDescribe("Memory Manager [Disruptive] [Serial] [Feature:MemoryManager
 		// release hugepages
 		if *is2MiHugepagesSupported {
 			ginkgo.By("Releasing allocated hugepages")
-			gomega.Eventually(func() error {
-				// configure hugepages on the NUMA node 0 to avoid hugepages split across NUMA nodes
-				return configureHugePages(hugepagesSize2M, 0, pointer.IntPtr(0), false)
-			}, 90*time.Second, 15*time.Second).ShouldNot(gomega.HaveOccurred(), "failed to release hugepages")
+			configureHugePages(hugepagesSize2M, 0, pointer.IntPtr(0), false, &f.MemoryProblemOccured)
 		}
 	})
 

--- a/test/e2e_node/memory_manager_test.go
+++ b/test/e2e_node/memory_manager_test.go
@@ -324,7 +324,7 @@ var _ = SIGDescribe("Memory Manager [Disruptive] [Serial] [Feature:MemoryManager
 		if *is2MiHugepagesSupported {
 			ginkgo.By("Configuring hugepages")
 			gomega.Eventually(func() error {
-				return configureHugePages(hugepagesSize2M, hugepages2MiCount, pointer.IntPtr(0))
+				return configureHugePages(hugepagesSize2M, hugepages2MiCount, pointer.IntPtr(0), true)
 			}, 30*time.Second, framework.Poll).Should(gomega.BeNil())
 		}
 	})
@@ -357,7 +357,7 @@ var _ = SIGDescribe("Memory Manager [Disruptive] [Serial] [Feature:MemoryManager
 			ginkgo.By("Releasing allocated hugepages")
 			gomega.Eventually(func() error {
 				// configure hugepages on the NUMA node 0 to avoid hugepages split across NUMA nodes
-				return configureHugePages(hugepagesSize2M, 0, pointer.IntPtr(0))
+				return configureHugePages(hugepagesSize2M, 0, pointer.IntPtr(0), false)
 			}, 90*time.Second, 15*time.Second).ShouldNot(gomega.HaveOccurred(), "failed to release hugepages")
 		}
 	})


### PR DESCRIPTION
This PR aims to reduce number of flaky test,
It just doesn't include HugePages into MemoryManager e2e_node tests if is not enough hugepages on the node. MemoryManager test already skip the part of the test related to hugepage, but not the whole test, if there is no hugepages support on the host.

Also it factoring out original configureHugePages function, add /proc/meminfo traces there to be able understand what happen on the node. 

/kind cleanup
/kind failing-test
