### PR TITLE
test/integration: skip etcd startup for -help flag

### DIFF
--- a/test/integration/framework/etcd.go
+++ b/test/integration/framework/etcd.go
@@ -18,6 +18,7 @@ package framework
 
 import (
 	"context"
+	"flag"
 	"fmt"
 	"io/ioutil"
 	"net"
@@ -168,6 +169,9 @@ func RunCustomEtcd(dataDir string, customFlags []string) (url string, stopFn fun
 
 // EtcdMain starts an etcd instance before running tests.
 func EtcdMain(tests func() int) {
+	// Bail out early when -help was given as parameter.
+	flag.Parse()
+
 	stop, err := startEtcd()
 	if err != nil {
 		klog.Fatalf("cannot run integration tests: unable to start etcd: %v", err)

--- a/test/integration/scheduler_perf/main_test.go
+++ b/test/integration/scheduler_perf/main_test.go
@@ -17,13 +17,11 @@ limitations under the License.
 package benchmark
 
 import (
-	"flag"
 	"testing"
 
 	"k8s.io/kubernetes/test/integration/framework"
 )
 
 func TestMain(m *testing.M) {
-	flag.Parse()
 	framework.EtcdMain(m.Run)
 }


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:

By parsing flags in the test's main function before starting etcd we bail out
early without ever starting etcd when the test was invoked with -help.

Otherwise etcd must be available, gets started and then hangs because
flag.Parse itself exits when called by testing.go. This bypasses the code in
EtcdMain which normally stops etcd.

#### Special notes for your reviewer:

Parsing flags in Main is explicitly allowed by the testing package: https://pkg.go.dev/testing#hdr-Main

This was fixed before for one integration test in https://github.com/kubernetes/kubernetes/pull/89139. With this PR that change gets reverted in favor of fixing it for all integration tests that use etcd.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
