### PR TITLE
fix:claim cached in pvcontroller is not the newest may cause unexpected issue

### DIFF
--- a/pkg/controller/volume/persistentvolume/binder_test.go
+++ b/pkg/controller/volume/persistentvolume/binder_test.go
@@ -563,6 +563,21 @@ func TestSync(t *testing.T) {
 			noevents, noerrors, testSyncVolume,
 		},
 
+		{
+			// syncVolume with volume bound to claim which exists in etcd but not updated to local cache.
+			"4-12 - volume bound to newest claim but not updated to local cache",
+			newVolumeArray("volume4-12", "10Gi", "uid4-12-new", "claim4-12", v1.VolumeAvailable, v1.PersistentVolumeReclaimDelete, classEmpty),
+			newVolumeArray("volume4-12", "10Gi", "uid4-12-new", "claim4-12", v1.VolumeBound, v1.PersistentVolumeReclaimDelete, classEmpty),
+			func() []*v1.PersistentVolumeClaim {
+				newClaim := newClaimArray("claim4-12", "uid4-12", "10Gi", "volume4-12", v1.ClaimBound, nil, "")
+				// update uid to new-uid and not sync to cache.
+				newClaim = append(newClaim, newClaimArray("claim4-12", "uid4-12-new", "10Gi", "volume4-12", v1.ClaimBound, nil, annSkipLocalStore)...)
+				return newClaim
+			}(),
+			newClaimArray("claim4-12", "uid4-12-new", "10Gi", "volume4-12", v1.ClaimBound, nil, annSkipLocalStore),
+			noevents, noerrors, testSyncVolume,
+		},
+
 		// PVC with class
 		{
 			// syncVolume binds a claim to requested class even if there is a


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
What this PR does / why we need it:
fix issue: https://github.com/kubernetes/kubernetes/issues/105131

Which issue(s) this PR fixes:
Fixes #<105131>

```release-note
Fixed a bug that prevents PersistentVolume that has a Claim UID which doesn't exist in local cache but exists in ETCD from being updated to Released phase. 
```