### PR TITLE
Refactoring TestConcurrentAccessToRelatedVolumes for enabling Block Volume tests

### DIFF
--- a/test/e2e/framework/volume/fixtures.go
+++ b/test/e2e/framework/volume/fixtures.go
@@ -454,7 +454,7 @@ func testVolumeContent(f *framework.Framework, pod *v1.Pod, fsGroup *int64, fsTy
 		if test.Mode == v1.PersistentVolumeBlock {
 			// Block: check content
 			deviceName := fmt.Sprintf("/opt/%d", i)
-			commands := generateReadBlockCmd(deviceName, len(test.ExpectedContent))
+			commands := GenerateReadBlockCmd(deviceName, len(test.ExpectedContent))
 			_, err := framework.LookForStringInPodExec(pod.Namespace, pod.Name, commands, test.ExpectedContent, time.Minute)
 			framework.ExpectNoError(err, "failed: finding the contents of the block device %s.", deviceName)
 
@@ -573,7 +573,7 @@ func generateWriteCmd(content, path string) []string {
 }
 
 // generateReadBlockCmd generates the corresponding command lines to read from a block device with the given file path.
-func generateReadBlockCmd(fullPath string, numberOfCharacters int) []string {
+func GenerateReadBlockCmd(fullPath string, numberOfCharacters int) []string {
 	var commands []string
 	commands = []string{"head", "-c", strconv.Itoa(numberOfCharacters), fullPath}
 	return commands

--- a/test/e2e/storage/testsuites/multivolume.go
+++ b/test/e2e/storage/testsuites/multivolume.go
@@ -328,12 +328,6 @@ func (t *multiVolumeTestSuite) DefineTests(driver storageframework.TestDriver, p
 		if pattern.SnapshotType == "" {
 			e2eskipper.Skipf("Driver %q does not support snapshots - skipping", dInfo.Name)
 		}
-		if pattern.VolMode == v1.PersistentVolumeBlock {
-			// TODO: refactor prepareSnapshotDataSourceForProvisioning() below to use
-			// utils.CheckWriteToPath / utils.CheckReadFromPath and remove
-			// redundant InjectContent(). This will enable block volume tests.
-			e2eskipper.Skipf("This test does not support block volumes -- skipping")
-		}
 
 		// Create a volume
 		testVolumeSizeRange := t.GetTestSuiteInfo().SupportedSizeRange
@@ -385,12 +379,6 @@ func (t *multiVolumeTestSuite) DefineTests(driver storageframework.TestDriver, p
 
 		if !l.driver.GetDriverInfo().Capabilities[storageframework.CapPVCDataSource] {
 			e2eskipper.Skipf("Driver %q does not support volume clone - skipping", dInfo.Name)
-		}
-		if pattern.VolMode == v1.PersistentVolumeBlock {
-			// TODO: refactor preparePVCDataSourceForProvisioning() below to use
-			// utils.CheckWriteToPath / utils.CheckReadFromPath and remove
-			// redundant InjectContent(). This will enable block volume tests.
-			e2eskipper.Skipf("This test does not support block volumes -- skipping")
 		}
 
 		// Create a volume
@@ -711,15 +699,26 @@ func TestConcurrentAccessToRelatedVolumes(f *framework.Framework, cs clientset.I
 		e2epod.SetAffinity(&node, actualNodeName)
 	}
 
-	// Check that all pods the same content
-	for i, pod := range pods {
-		fileName := "/mnt/volume1/index.html"
-		index := i + 1
+	for i, pvc := range pvcs {
+		var commands []string
 
-		ginkgo.By(fmt.Sprintf("Checking if the volume in pod%d has expected initial content", index))
-		commands := e2evolume.GenerateReadFileCmd(fileName)
-		_, err := framework.LookForStringInPodExec(pod.Namespace, pod.Name, commands, expectedContent, time.Minute)
-		framework.ExpectNoError(err, "failed: finding the contents of the mounted file %s.", fileName)
+		if *pvc.Spec.VolumeMode == v1.PersistentVolumeBlock {
+			fileName := "/mnt/volume1"
+			commands = e2evolume.GenerateReadBlockCmd(fileName, len(expectedContent))
+			// Check that all pods have the same content
+			index := i + 1
+			ginkgo.By(fmt.Sprintf("Checking if the volume in pod%d has expected initial content", index))
+			_, err := framework.LookForStringInPodExec(pods[i].Namespace, pods[i].Name, commands, expectedContent, time.Minute)
+			framework.ExpectNoError(err, "failed: finding the contents of the block volume %s.", fileName)
+		} else {
+			fileName := "/mnt/volume1/index.html"
+			commands = e2evolume.GenerateReadFileCmd(fileName)
+			// Check that all pods have the same content
+			index := i + 1
+			ginkgo.By(fmt.Sprintf("Checking if the volume in pod%d has expected initial content", index))
+			_, err := framework.LookForStringInPodExec(pods[i].Namespace, pods[i].Name, commands, expectedContent, time.Minute)
+			framework.ExpectNoError(err, "failed: finding the contents of the mounted file %s.", fileName)
+		}
 	}
 }
 


### PR DESCRIPTION
#### What type of PR is this?

<!--
/kind feature
/kind bug
-->

#### What this PR does / why we need it:
Enables block volume tests on the e2e framework (storage) by testing access to the block volumes using *e2evolume.GenerateReadBlockCmd*. With can further test storage CSI drivers like gce-pd driver.

#### Which issue(s) this PR fixes:
Fixes #102787.

#### Does this PR introduce a user-facing change?
NONE

