### PR TITLE
remove nodeLease feature GA

### DIFF
--- a/pkg/controller/nodelifecycle/node_lifecycle_controller.go
+++ b/pkg/controller/nodelifecycle/node_lifecycle_controller.go
@@ -314,8 +314,7 @@ type Controller struct {
 
 	// Controller will not proactively sync node health, but will monitor node
 	// health signal updated from kubelet. There are 2 kinds of node healthiness
-	// signals: NodeStatus and NodeLease. NodeLease signal is generated only when
-	// NodeLease feature is enabled. If it doesn't receive update for this amount
+	// signals: NodeStatus and NodeLease. If it doesn't receive update for this amount
 	// of time, it will start posting "NodeReady==ConditionUnknown". The amount of
 	// time before which Controller start evicting pods is controlled via flag
 	// 'pod-eviction-timeout'.

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -185,15 +185,6 @@ const (
 	// Enables RuntimeClass, for selecting between multiple runtimes to run a pod.
 	RuntimeClass featuregate.Feature = "RuntimeClass"
 
-	// owner: @mtaufen
-	// alpha: v1.12
-	// beta:  v1.14
-	// GA: v1.17
-	//
-	// Kubelet uses the new Lease API to report node heartbeats,
-	// (Kube) Node Lifecycle Controller uses these heartbeats as a node health signal.
-	NodeLease featuregate.Feature = "NodeLease"
-
 	// owner: @rikatz
 	// kep: http://kep.k8s.io/2079
 	// alpha: v1.21
@@ -786,7 +777,6 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
 	GenericEphemeralVolume:                         {Default: true, PreRelease: featuregate.Beta},
 	CSIVolumeFSGroupPolicy:                         {Default: true, PreRelease: featuregate.Beta},
 	RuntimeClass:                                   {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.23
-	NodeLease:                                      {Default: true, PreRelease: featuregate.GA, LockToDefault: true},
 	NetworkPolicyEndPort:                           {Default: true, PreRelease: featuregate.Beta},
 	ProcMountType:                                  {Default: false, PreRelease: featuregate.Alpha},
 	TTLAfterFinished:                               {Default: true, PreRelease: featuregate.Beta},

--- a/staging/src/k8s.io/kubelet/config/v1beta1/types.go
+++ b/staging/src/k8s.io/kubelet/config/v1beta1/types.go
@@ -383,14 +383,13 @@ type KubeletConfiguration struct {
 	// Default: "5m"
 	// +optional
 	NodeStatusReportFrequency metav1.Duration `json:"nodeStatusReportFrequency,omitempty"`
-	// nodeLeaseDurationSeconds is the duration the Kubelet will set on its corresponding Lease,
-	// when the NodeLease feature is enabled. This feature provides an indicator of node
-	// health by having the Kubelet create and periodically renew a lease, named after the node,
-	// in the kube-node-lease namespace. If the lease expires, the node can be considered unhealthy.
-	// The lease is currently renewed every 10s, per KEP-0009. In the future, the lease renewal interval
-	// may be set based on the lease duration.
+	// nodeLeaseDurationSeconds is the duration the Kubelet will set on its corresponding Lease.
+	// NodeLease provides an indicator of node health by having the Kubelet create and
+	// periodically renew a lease, named after the node, in the kube-node-lease namespace.
+	// If the lease expires, the node can be considered unhealthy.
+	// The lease is currently renewed every 10s, per KEP-0009. In the future, the lease renewal
+	// interval may be set based on the lease duration.
 	// The field value must be greater than 0.
-	// Requires the NodeLease feature gate to be enabled.
 	// If DynamicKubeletConfig (deprecated; default off) is on, when
 	// dynamically updating this field, consider that
 	// decreasing the duration may reduce tolerance for issues that temporarily prevent
@@ -399,11 +398,9 @@ type KubeletConfiguration struct {
 	// +optional
 	NodeLeaseDurationSeconds int32 `json:"nodeLeaseDurationSeconds,omitempty"`
 	// imageMinimumGCAge is the minimum age for an unused image before it is
-	// garbage collected.
-	// If DynamicKubeletConfig (deprecated; default off) is on, when
-	// dynamically updating this field, consider that
-	// it may trigger or delay garbage collection, and may change the image overhead
-	// on the node.
+	// garbage collected. If DynamicKubeletConfig (deprecated; default off)
+	// is on, when dynamically updating this field, consider that  it may trigger or
+	// delay garbage collection, and may change the image overhead on the node.
 	// Default: "2m"
 	// +optional
 	ImageMinimumGCAge metav1.Duration `json:"imageMinimumGCAge,omitempty"`

--- a/test/e2e/common/node/node_lease.go
+++ b/test/e2e/common/node/node_lease.go
@@ -46,7 +46,7 @@ var _ = SIGDescribe("NodeLease", func() {
 		nodeName = node.Name
 	})
 
-	ginkgo.Context("when the NodeLease feature is enabled", func() {
+	ginkgo.Context("NodeLease", func() {
 		ginkgo.It("the kubelet should create and update a lease in the kube-node-lease namespace", func() {
 			leaseClient := f.ClientSet.CoordinationV1().Leases(v1.NamespaceNodeLease)
 			var (


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind cleanup

Optionally add one or more of the following kinds if applicable:

/kind deprecation

-->

#### What this PR does / why we need it:
remove nodeLease feature GA

<!--
#### Which issue(s) this PR fixes:

*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*

Fixes #
-->

#### Special notes for your reviewer:

Feature gate convention has been updated since this feature gate was introduced to indicate that they are intended to be deprecated and removed after a feature becomes GA or is dropped

in v1.17 node lease has been promoted to GA,but in 
[https://github.com/kubernetes/blob/005dfcd09e643312d12b0b4838186c7727065c73/pkg/features/kube_features.go#L195](https://github.com/kubernetes/kubernetes/blob/005dfcd09e643312d12b0b4838186c7727065c73/pkg/features/kube_features.go#L195) node lease feature still exist,so i deleted it and edit some describption info about node lease.
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Remove NodeLease feature gate that was graduated and locked to stable in 1.17 release.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
