### PR TITLE
ignore register already exist error for metrics

### DIFF
--- a/staging/src/k8s.io/component-base/metrics/registry.go
+++ b/staging/src/k8s.io/component-base/metrics/registry.go
@@ -173,7 +173,18 @@ func (kr *kubeRegistry) MustRegister(cs ...Registerable) {
 			kr.trackHiddenCollector(c)
 		}
 	}
-	kr.PromRegistry.MustRegister(metrics...)
+
+	// implement MustRegister to ignore AlreadyRegisteredError
+	for _, c := range metrics {
+		err := kr.PromRegistry.Register(c)
+		if err != nil {
+			// skip if it is already registered
+			_, ok := err.(prometheus.AlreadyRegisteredError)
+			if !ok {
+				panic(err)
+			}
+		}
+	}
 }
 
 // CustomRegister registers a new custom collector.


### PR DESCRIPTION
/kind bug

xref #104940

The problem is similar to https://github.com/prometheus/client_golang/issues/716#issuecomment-590282553.

I tried to fix 104940 by ignoring AlreadyRegisteredError in the implementation of MustRegister. (I am inspired by https://github.com/weaveworks/promrus/pull/9/files)

https://github.com/kubernetes/kubernetes/blob/005dfcd09e643312d12b0b4838186c7727065c73/vendor/github.com/prometheus/client_golang/prometheus/registry.go#L400-L406

```release-note
None
```

