### PR TITLE
Fix CAP_SYS_ADMIN verification

### DIFF
--- a/pkg/apis/core/validation/validation.go
+++ b/pkg/apis/core/validation/validation.go
@@ -6179,8 +6179,15 @@ func ValidateSecurityContext(sc *core.SecurityContext, fldPath *field.Path) fiel
 
 		if sc.Capabilities != nil {
 			for _, cap := range sc.Capabilities.Add {
+				var capVerify *field.Error
 				if string(cap) == "CAP_SYS_ADMIN" {
-					allErrs = append(allErrs, field.Invalid(fldPath, sc, "cannot set `allowPrivilegeEscalation` to false and `capabilities.Add` CAP_SYS_ADMIN"))
+					capVerify = field.Invalid(fldPath, sc, "cannot set `allowPrivilegeEscalation` to false and `capabilities.Add` CAP_SYS_ADMIN")
+				}
+				if capVerify == nil && strings.HasSuffix(string(cap), "SYS_ADMIN") {
+					capVerify = field.Invalid(fldPath, sc, "cannot set `allowPrivilegeEscalation` to false and `capabilities.Add` CAP_SYS_ADMIN")
+				}
+				if capVerify != nil {
+					allErrs = append(allErrs, capVerify)
 				}
 			}
 		}

--- a/pkg/apis/core/validation/validation_test.go
+++ b/pkg/apis/core/validation/validation_test.go
@@ -17676,6 +17676,9 @@ func TestValidateSecurityContext(t *testing.T) {
 	capSysAdminWithoutEscalation.Capabilities.Add = []core.Capability{"CAP_SYS_ADMIN"}
 	capSysAdminWithoutEscalation.AllowPrivilegeEscalation = utilpointer.BoolPtr(false)
 
+	sysAdminWithoutEscalation := capSysAdminWithoutEscalation.DeepCopy()
+	sysAdminWithoutEscalation.Capabilities.Add = []core.Capability{"SYS_ADMIN"}
+
 	errorCases := map[string]struct {
 		sc           *core.SecurityContext
 		errorType    field.ErrorType
@@ -17694,6 +17697,11 @@ func TestValidateSecurityContext(t *testing.T) {
 		},
 		"with CAP_SYS_ADMIN and allowPrivilegeEscalation false": {
 			sc:          capSysAdminWithoutEscalation,
+			errorType:   "FieldValueInvalid",
+			errorDetail: "cannot set `allowPrivilegeEscalation` to false and `capabilities.Add` CAP_SYS_ADMIN",
+		},
+		"with SYS_ADMIN and allowPrivilegeEscalation false": {
+			sc:          sysAdminWithoutEscalation,
 			errorType:   "FieldValueInvalid",
 			errorDetail: "cannot set `allowPrivilegeEscalation` to false and `capabilities.Add` CAP_SYS_ADMIN",
 		},


### PR DESCRIPTION
This PR fix issues of incorrect CAP_SYS_ADMIN verification in following situation:
securityContext:
        allowPrivilegeEscalation: false
        capabilities:
          add: ["SYS_ADMIN"]

Before this fix SYS_ADMIN with allowPrivilegeEscalation equal to false passed, but
CAP_SYS_ADMIN was not, but specifying CAP_SYS_ADMIN doesn't make sense, since
it will be passed by OCI as CAP_CAP_SYS_ADMIN.


Initially end user had to specify capabilities with CAP_
prefix, but this specification was changed, now container runtime
concatenates it, so cri-api as well as core api passes it without
CAP_ prefix.

BTW, e2e tests was fixed in https://github.com/kubernetes/kubernetes/blob/7bff8adaf683dc7e25b5548e2c16e7393ff8a036/test/e2e/auth/pod_security_policy.go#L186

/kind bug
```release-note
Fix an incorrect verification of `CAP_SYS_ADMIN` in cases where `allowPrivilegeEscalation` is set to `false`.
```
