### PR TITLE
Revert 102925: Fix Node Resources plugins score when there are pods with no requests

### DIFF
--- a/pkg/scheduler/framework/plugins/noderesources/balanced_allocation.go
+++ b/pkg/scheduler/framework/plugins/noderesources/balanced_allocation.go
@@ -80,16 +80,12 @@ func NewBalancedAllocation(_ runtime.Object, h framework.Handle) (framework.Plug
 
 // todo: use resource weights in the scorer function
 func balancedResourceScorer(requested, allocable resourceToValueMap, includeVolumes bool, requestedVolumes int, allocatableVolumes int) int64 {
-	// This to find a node which has most balanced CPU, memory and volume usage.
 	cpuFraction := fractionOfCapacity(requested[v1.ResourceCPU], allocable[v1.ResourceCPU])
 	memoryFraction := fractionOfCapacity(requested[v1.ResourceMemory], allocable[v1.ResourceMemory])
-	// fractions might be greater than 1 because pods with no requests get minimum
-	// values.
-	if cpuFraction > 1 {
-		cpuFraction = 1
-	}
-	if memoryFraction > 1 {
-		memoryFraction = 1
+	// This to find a node which has most balanced CPU, memory and volume usage.
+	if cpuFraction >= 1 || memoryFraction >= 1 {
+		// if requested >= capacity, the corresponding host should never be preferred.
+		return 0
 	}
 
 	if includeVolumes && utilfeature.DefaultFeatureGate.Enabled(features.BalanceAttachedNodeVolumes) && allocatableVolumes > 0 {


### PR DESCRIPTION
#### What type of PR is this?
/kind bug
/kind regression


#### What this PR does / why we need it:
Ref https://github.com/kubernetes/kubernetes/issues/105220, this partially reverts the changes from https://github.com/kubernetes/kubernetes/pull/102925 which caused unexpected spreading behavior in the BalancedResourceAllocation plugin

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fixes a regression in 1.20.9 which introduced unexpected scheduling behavior based on balanced resource allocation
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
/sig scheduling
