### PR TITLE
Clear initial UDP conntrack entries for loadBalancerIPs for proxy-mode=ipvs

### DIFF
--- a/pkg/proxy/ipvs/proxier.go
+++ b/pkg/proxy/ipvs/proxier.go
@@ -1025,6 +1025,9 @@ func (proxier *Proxier) syncProxyRules() {
 			for _, extIP := range svcInfo.ExternalIPStrings() {
 				staleServices.Insert(extIP)
 			}
+			for _, extIP := range svcInfo.LoadBalancerIPStrings() {
+				staleServices.Insert(extIP)
+			}
 		}
 	}
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area ipvs
/area kube-proxy

#### What this PR does / why we need it:

Fixes a problem with invalid udp conntrack entries on node reboot.

#### Which issue(s) this PR fixes:

Fixes #105192

#### Special notes for your reviewer:

Already corrected for proxy-mode=iptables in https://github.com/kubernetes/kubernetes/pull/104151

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

N/A
