### PR TITLE
updated errors pkg to native go pkg for test/e2e/network/netopol test_helper

### DIFF
--- a/test/e2e/network/netpol/test_helper.go
+++ b/test/e2e/network/netpol/test_helper.go
@@ -22,7 +22,6 @@ import (
 	"time"
 
 	"github.com/onsi/ginkgo"
-	"github.com/pkg/errors"
 	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -105,7 +104,7 @@ func waitForHTTPServers(k *kubeManager, model *Model) error {
 		}
 		time.Sleep(waitInterval)
 	}
-	return errors.Errorf("after %d tries, %d HTTP servers are not ready", maxTries, len(notReady))
+	return fmt.Errorf("after %d tries, %d HTTP servers are not ready", maxTries, len(notReady))
 }
 
 // ValidateOrFail validates connectivity


### PR DESCRIPTION
Signed-off-by: ishangupta-ds <ishangupta.ds@gmail.com>

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

removing usage of `github.com/pkg/errors` from `test/e2e/network/netopol/test_helper.go`

#### Which issue(s) this PR fixes:

Fixes part of #103043

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
