### PR TITLE
Consistent job/cronjob controller's naming styles

### DIFF
--- a/cmd/kube-controller-manager/app/batch.go
+++ b/cmd/kube-controller-manager/app/batch.go
@@ -31,7 +31,7 @@ import (
 )
 
 func startJobController(ctx ControllerContext) (controller.Interface, bool, error) {
-	go job.NewController(
+	go job.NewJobController(
 		ctx.InformerFactory.Core().V1().Pods(),
 		ctx.InformerFactory.Batch().V1().Jobs(),
 		ctx.ClientBuilder.ClientOrDie("job-controller"),
@@ -51,7 +51,7 @@ func startCronJobController(ctx ControllerContext) (controller.Interface, bool, 
 		go cj2c.Run(int(ctx.ComponentConfig.CronJobController.ConcurrentCronJobSyncs), ctx.Stop)
 		return nil, true, nil
 	}
-	cjc, err := cronjob.NewController(
+	cjc, err := cronjob.NewCronjobController(
 		ctx.ClientBuilder.ClientOrDie("cronjob-controller"),
 	)
 	if err != nil {

--- a/pkg/controller/cronjob/cronjob_controller.go
+++ b/pkg/controller/cronjob/cronjob_controller.go
@@ -57,8 +57,8 @@ import (
 // controllerKind contains the schema.GroupVersionKind for this controller type.
 var controllerKind = batchv1.SchemeGroupVersion.WithKind("CronJob")
 
-// Controller is a controller for CronJobs.
-type Controller struct {
+// CronjobController is a controller for CronJobs.
+type CronjobController struct {
 	kubeClient clientset.Interface
 	jobControl jobControlInterface
 	cjControl  cjControlInterface
@@ -66,8 +66,8 @@ type Controller struct {
 	recorder   record.EventRecorder
 }
 
-// NewController creates and initializes a new Controller.
-func NewController(kubeClient clientset.Interface) (*Controller, error) {
+// NewCronjobController creates and initializes a new CronjobController.
+func NewCronjobController(kubeClient clientset.Interface) (*CronjobController, error) {
 	eventBroadcaster := record.NewBroadcaster()
 	eventBroadcaster.StartStructuredLogging(0)
 	eventBroadcaster.StartRecordingToSink(&v1core.EventSinkImpl{Interface: kubeClient.CoreV1().Events("")})
@@ -78,7 +78,7 @@ func NewController(kubeClient clientset.Interface) (*Controller, error) {
 		}
 	}
 
-	jm := &Controller{
+	jm := &CronjobController{
 		kubeClient: kubeClient,
 		jobControl: realJobControl{KubeClient: kubeClient},
 		cjControl:  &realCJControl{KubeClient: kubeClient},
@@ -90,7 +90,7 @@ func NewController(kubeClient clientset.Interface) (*Controller, error) {
 }
 
 // Run starts the main goroutine responsible for watching and syncing jobs.
-func (jm *Controller) Run(stopCh <-chan struct{}) {
+func (jm *CronjobController) Run(stopCh <-chan struct{}) {
 	defer utilruntime.HandleCrash()
 	klog.Infof("Starting CronJob Manager")
 	// Check things every 10 second.
@@ -100,7 +100,7 @@ func (jm *Controller) Run(stopCh <-chan struct{}) {
 }
 
 // syncAll lists all the CronJobs and Jobs and reconciles them.
-func (jm *Controller) syncAll() {
+func (jm *CronjobController) syncAll() {
 	// List children (Jobs) before parents (CronJob).
 	// This guarantees that if we see any Job that got orphaned by the GC orphan finalizer,
 	// we must also see that the parent CronJob has non-nil DeletionTimestamp (see #42639).

--- a/pkg/controller/cronjob/cronjob_controller_test.go
+++ b/pkg/controller/cronjob/cronjob_controller_test.go
@@ -237,7 +237,7 @@ func TestSyncOne_RunOrNot(t *testing.T) {
 		"still active, is time, past deadline":     {A, F, onTheHour, shortDead, T, T, *justAfterTheHour(), F, F, 1, 0},
 		"still active, is time, not past deadline": {A, F, onTheHour, longDead, T, T, *justAfterTheHour(), T, F, 2, 0},
 
-		// Controller should fail to schedule these, as there are too many missed starting times
+		// CronjobController should fail to schedule these, as there are too many missed starting times
 		// and either no deadline or a too long deadline.
 		"prev ran but done, long overdue, not past deadline, A": {A, F, onTheHour, longDead, T, F, weekAfterTheHour(), F, F, 0, 1},
 		"prev ran but done, long overdue, not past deadline, R": {R, F, onTheHour, longDead, T, F, weekAfterTheHour(), F, F, 0, 1},
@@ -324,7 +324,7 @@ func TestSyncOne_RunOrNot(t *testing.T) {
 						t.Errorf("%s: controllerRef.UID = %q, want %q", name, got, want)
 					}
 					if controllerRef.Controller == nil || *controllerRef.Controller != true {
-						t.Errorf("%s: controllerRef.Controller is not set to true", name)
+						t.Errorf("%s: controllerRef.CronjobController is not set to true", name)
 					}
 				}
 			}

--- a/pkg/controller/cronjob/cronjob_controllerv2.go
+++ b/pkg/controller/cronjob/cronjob_controllerv2.go
@@ -69,7 +69,7 @@ type ControllerV2 struct {
 	now func() time.Time
 }
 
-// NewControllerV2 creates and initializes a new Controller.
+// NewControllerV2 creates and initializes a new CronjobController.
 func NewControllerV2(jobInformer batchv1informers.JobInformer, cronJobsInformer batchv1informers.CronJobInformer, kubeClient clientset.Interface) (*ControllerV2, error) {
 	eventBroadcaster := record.NewBroadcaster()
 	eventBroadcaster.StartStructuredLogging(0)
@@ -151,7 +151,7 @@ func (jm *ControllerV2) processNextWorkItem() bool {
 	requeueAfter, err := jm.sync(key.(string))
 	switch {
 	case err != nil:
-		utilruntime.HandleError(fmt.Errorf("error syncing CronJobController %v, requeuing: %v", key.(string), err))
+		utilruntime.HandleError(fmt.Errorf("error syncing CronjobController %v, requeuing: %v", key.(string), err))
 		jm.queue.AddRateLimited(key)
 	case requeueAfter != nil:
 		jm.queue.Forget(key)

--- a/pkg/controller/cronjob/cronjob_controllerv2_test.go
+++ b/pkg/controller/cronjob/cronjob_controllerv2_test.go
@@ -121,7 +121,7 @@ func TestControllerV2SyncCronJob(t *testing.T) {
 		"still active, is time, past deadline":     {A, F, onTheHour, shortDead, T, T, justAfterThePriorHour(), *justAfterTheHour(), F, F, 1, 0, F, T, F, T, nil},
 		"still active, is time, not past deadline": {A, F, onTheHour, longDead, T, T, justAfterThePriorHour(), *justAfterTheHour(), T, F, 2, 0, F, T, F, T, nil},
 
-		// Controller should fail to schedule these, as there are too many missed starting times
+		// CronjobController should fail to schedule these, as there are too many missed starting times
 		// and either no deadline or a too long deadline.
 		"prev ran but done, long overdue, not past deadline, A": {A, F, onTheHour, longDead, T, F, justAfterThePriorHour(), weekAfterTheHour(), T, F, 1, 1, F, T, F, T, nil},
 		"prev ran but done, long overdue, not past deadline, R": {R, F, onTheHour, longDead, T, F, justAfterThePriorHour(), weekAfterTheHour(), T, F, 1, 1, F, T, F, T, nil},
@@ -267,7 +267,7 @@ func TestControllerV2SyncCronJob(t *testing.T) {
 						t.Errorf("%s: controllerRef.UID = %q, want %q", name, got, want)
 					}
 					if controllerRef.Controller == nil || *controllerRef.Controller != true {
-						t.Errorf("%s: controllerRef.Controller is not set to true", name)
+						t.Errorf("%s: controllerRef.CronjobController is not set to true", name)
 					}
 				}
 			}

--- a/pkg/controller/cronjob/utils.go
+++ b/pkg/controller/cronjob/utils.go
@@ -111,7 +111,7 @@ func getRecentUnmetScheduleTimes(cj batchv1.CronJob, now time.Time) ([]time.Time
 		earliestTime = cj.ObjectMeta.CreationTimestamp.Time
 	}
 	if cj.Spec.StartingDeadlineSeconds != nil {
-		// Controller is not going to schedule anything below this point
+		// CronjobController is not going to schedule anything below this point
 		schedulingDeadline := now.Add(-time.Second * time.Duration(*cj.Spec.StartingDeadlineSeconds))
 
 		if schedulingDeadline.After(earliestTime) {
@@ -169,7 +169,7 @@ func getNextScheduleTime(cj batchv1.CronJob, now time.Time, schedule cron.Schedu
 		earliestTime = cj.ObjectMeta.CreationTimestamp.Time
 	}
 	if cj.Spec.StartingDeadlineSeconds != nil {
-		// Controller is not going to schedule anything below this point
+		// CronjobController is not going to schedule anything below this point
 		schedulingDeadline := now.Add(-time.Second * time.Duration(*cj.Spec.StartingDeadlineSeconds))
 
 		if schedulingDeadline.After(earliestTime) {

--- a/pkg/controller/job/job_controller_test.go
+++ b/pkg/controller/job/job_controller_test.go
@@ -101,9 +101,9 @@ func newJob(parallelism, completions, backoffLimit int32, completionMode batch.C
 	return j
 }
 
-func newControllerFromClient(kubeClient clientset.Interface, resyncPeriod controller.ResyncPeriodFunc) (*Controller, informers.SharedInformerFactory) {
+func newControllerFromClient(kubeClient clientset.Interface, resyncPeriod controller.ResyncPeriodFunc) (*JobController, informers.SharedInformerFactory) {
 	sharedInformers := informers.NewSharedInformerFactory(kubeClient, resyncPeriod())
-	jm := NewController(sharedInformers.Core().V1().Pods(), sharedInformers.Batch().V1().Jobs(), kubeClient)
+	jm := NewJobController(sharedInformers.Core().V1().Pods(), sharedInformers.Batch().V1().Jobs(), kubeClient)
 	jm.podControl = &controller.FakePodControl{}
 
 	return jm, sharedInformers
@@ -801,7 +801,7 @@ func TestControllerSyncJob(t *testing.T) {
 						t.Errorf("controllerRef.UID = %q, want %q", got, want)
 					}
 					if controllerRef.Controller == nil || *controllerRef.Controller != true {
-						t.Errorf("controllerRef.Controller is not set to true")
+						t.Errorf("controllerRef.JobController is not set to true")
 					}
 				}
 				// validate status
@@ -2442,7 +2442,7 @@ func TestWatchPods(t *testing.T) {
 func TestWatchOrphanPods(t *testing.T) {
 	clientset := fake.NewSimpleClientset()
 	sharedInformers := informers.NewSharedInformerFactory(clientset, controller.NoResyncPeriodFunc())
-	manager := NewController(sharedInformers.Core().V1().Pods(), sharedInformers.Batch().V1().Jobs(), clientset)
+	manager := NewJobController(sharedInformers.Core().V1().Pods(), sharedInformers.Batch().V1().Jobs(), clientset)
 	manager.podStoreSynced = alwaysReady
 	manager.jobStoreSynced = alwaysReady
 

--- a/staging/src/k8s.io/client-go/util/workqueue/delaying_queue.go
+++ b/staging/src/k8s.io/client-go/util/workqueue/delaying_queue.go
@@ -199,7 +199,7 @@ func (q *delayingType) waitingLoop() {
 	waitingEntryByData := map[t]*waitFor{}
 
 	for {
-		if q.Interface.ShuttingDown() {
+		if q.ShuttingDown() {
 			return
 		}
 

--- a/test/integration/cronjob/cronjob_test.go
+++ b/test/integration/cronjob/cronjob_test.go
@@ -36,7 +36,7 @@ import (
 	"k8s.io/kubernetes/test/integration/framework"
 )
 
-func setup(t *testing.T) (*httptest.Server, framework.CloseFunc, *cronjob.ControllerV2, *job.Controller, informers.SharedInformerFactory, clientset.Interface, restclient.Config) {
+func setup(t *testing.T) (*httptest.Server, framework.CloseFunc, *cronjob.ControllerV2, *job.JobController, informers.SharedInformerFactory, clientset.Interface, restclient.Config) {
 	controlPlaneConfig := framework.NewIntegrationTestControlPlaneConfig()
 	_, server, closeFn := framework.RunAnAPIServer(controlPlaneConfig)
 
@@ -51,7 +51,7 @@ func setup(t *testing.T) (*httptest.Server, framework.CloseFunc, *cronjob.Contro
 	if err != nil {
 		t.Fatalf("Error creating CronJob controller: %v", err)
 	}
-	jc := job.NewController(informerSet.Core().V1().Pods(), informerSet.Batch().V1().Jobs(), clientSet)
+	jc := job.NewJobController(informerSet.Core().V1().Pods(), informerSet.Batch().V1().Jobs(), clientSet)
 
 	return server, closeFn, cjc, jc, informerSet, clientSet, config
 }

--- a/test/integration/job/job_test.go
+++ b/test/integration/job/job_test.go
@@ -877,7 +877,7 @@ func startJobController(restConfig *restclient.Config, clientSet clientset.Inter
 	ctx, cancel := context.WithCancel(context.Background())
 	resyncPeriod := 12 * time.Hour
 	informerSet := informers.NewSharedInformerFactory(clientset.NewForConfigOrDie(restclient.AddUserAgent(restConfig, "cronjob-informers")), resyncPeriod)
-	jc := jobcontroller.NewController(informerSet.Core().V1().Pods(), informerSet.Batch().V1().Jobs(), clientSet)
+	jc := jobcontroller.NewJobController(informerSet.Core().V1().Pods(), informerSet.Batch().V1().Jobs(), clientSet)
 	informerSet.Start(ctx.Done())
 	go jc.Run(1, ctx.Done())
 	return ctx, cancel


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

The naming style of the job/cronjob controller should be consistent with other controllers in controller-manager. For example, the name of the deployment controller is called `DeploymentController`, which is a clear and readable naming method. The job/cronjob's controller is called `Controller`, which is not friendly to users

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
NONE
```
