### PR TITLE
TopologyAwareHints: fix getHintsByZone bug

### DIFF
--- a/pkg/controller/endpointslice/topologycache/utils.go
+++ b/pkg/controller/endpointslice/topologycache/utils.go
@@ -188,9 +188,13 @@ func getHintsByZone(slice *discovery.EndpointSlice, allocatedHintsByZone Endpoin
 		if endpoint.Hints == nil || len(endpoint.Hints.ForZones) == 0 {
 			return nil
 		}
-		zone := endpoint.Hints.ForZones[0].Name
-		if _, ok := allocations[zone]; ok {
-			return nil
+
+		for i := range endpoint.Hints.ForZones {
+			zone := endpoint.Hints.ForZones[i].Name
+			if _, ok := allocations[zone]; !ok {
+				return nil
+			}
+			hintsByZone[zone]++
 		}
 	}
 

--- a/pkg/controller/endpointslice/topologycache/utils_test.go
+++ b/pkg/controller/endpointslice/topologycache/utils_test.go
@@ -193,3 +193,137 @@ func Test_getGivingAndReceivingZones(t *testing.T) {
 		})
 	}
 }
+
+func Test_getHintsByZone(t *testing.T) {
+	testCases := []struct {
+		name                 string
+		slice                discovery.EndpointSlice
+		allocatedHintsByZone EndpointZoneInfo
+		allocations          map[string]Allocation
+		expectedHintsByZone  map[string]int
+	}{{
+		name:                 "empty",
+		slice:                discovery.EndpointSlice{},
+		allocations:          map[string]Allocation{},
+		allocatedHintsByZone: EndpointZoneInfo{},
+		expectedHintsByZone:  map[string]int{},
+	}, {
+		name: "single zone hint",
+		slice: discovery.EndpointSlice{
+			Endpoints: []discovery.Endpoint{{
+				Zone:  utilpointer.StringPtr("zone-a"),
+				Hints: &discovery.EndpointHints{ForZones: []discovery.ForZone{{Name: "zone-a"}}},
+			}},
+		},
+		allocations: map[string]Allocation{
+			"zone-a": {Maximum: 3},
+		},
+		allocatedHintsByZone: EndpointZoneInfo{"zone-a": 1},
+		expectedHintsByZone: map[string]int{
+			"zone-a": 1,
+		},
+	}, {
+		name: "multiple zone hints",
+		slice: discovery.EndpointSlice{
+			Endpoints: []discovery.Endpoint{
+				{
+					Zone:  utilpointer.StringPtr("zone-a"),
+					Hints: &discovery.EndpointHints{ForZones: []discovery.ForZone{{Name: "zone-a"}}},
+				},
+				{
+					Zone:  utilpointer.StringPtr("zone-a"),
+					Hints: &discovery.EndpointHints{ForZones: []discovery.ForZone{{Name: "zone-b"}}},
+				},
+				{
+					Zone:  utilpointer.StringPtr("zone-b"),
+					Hints: &discovery.EndpointHints{ForZones: []discovery.ForZone{{Name: "zone-b"}}},
+				},
+			},
+		},
+		allocations: map[string]Allocation{
+			"zone-a": {Maximum: 3},
+			"zone-b": {Maximum: 3},
+			"zone-c": {Maximum: 3},
+		},
+		allocatedHintsByZone: EndpointZoneInfo{"zone-a": 1, "zone-b": 1, "zone-c": 1},
+		expectedHintsByZone: map[string]int{
+			"zone-a": 1,
+			"zone-b": 2,
+		},
+	}, {
+		name: "invalid by zones that no longer requires any allocations",
+		slice: discovery.EndpointSlice{
+			Endpoints: []discovery.Endpoint{
+				{
+					Zone:  utilpointer.StringPtr("zone-a"),
+					Hints: &discovery.EndpointHints{ForZones: []discovery.ForZone{{Name: "zone-non-existent"}}},
+				},
+			},
+		},
+		allocations: map[string]Allocation{
+			"zone-a": {Maximum: 3},
+		},
+		allocatedHintsByZone: EndpointZoneInfo{"zone-a": 1, "zone-b": 1, "zone-c": 1},
+		expectedHintsByZone:  nil,
+	}, {
+		name: "invalid by endpoints with nil hints",
+		slice: discovery.EndpointSlice{
+			Endpoints: []discovery.Endpoint{
+				{
+					Zone:  utilpointer.StringPtr("zone-a"),
+					Hints: nil,
+				},
+			},
+		},
+		allocations: map[string]Allocation{
+			"zone-a": {Maximum: 3},
+		},
+		allocatedHintsByZone: EndpointZoneInfo{},
+		expectedHintsByZone:  nil,
+	}, {
+		name: "invalid by endpoint with no hints",
+		slice: discovery.EndpointSlice{
+			Endpoints: []discovery.Endpoint{
+				{
+					Zone:  utilpointer.StringPtr("zone-a"),
+					Hints: &discovery.EndpointHints{ForZones: []discovery.ForZone{}},
+				},
+			},
+		},
+		allocations: map[string]Allocation{
+			"zone-a": {Maximum: 3},
+		},
+		allocatedHintsByZone: EndpointZoneInfo{},
+		expectedHintsByZone:  nil,
+	}, {
+		name: "invalid by hints that would make minimum allocations impossible",
+		slice: discovery.EndpointSlice{
+			Endpoints: []discovery.Endpoint{
+				{
+					Zone:  utilpointer.StringPtr("zone-a"),
+					Hints: &discovery.EndpointHints{ForZones: []discovery.ForZone{{Name: "zone-a"}}},
+				},
+				{
+					Zone:  utilpointer.StringPtr("zone-a"),
+					Hints: &discovery.EndpointHints{ForZones: []discovery.ForZone{{Name: "zone-a"}}},
+				},
+			},
+		},
+		allocations: map[string]Allocation{
+			"zone-a": {Maximum: 2},
+		},
+		allocatedHintsByZone: EndpointZoneInfo{"zone-a": 1},
+		expectedHintsByZone:  nil,
+	}}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			actualHintsByZone := getHintsByZone(&tc.slice, tc.allocatedHintsByZone, tc.allocations)
+
+			if !reflect.DeepEqual(actualHintsByZone, tc.expectedHintsByZone) {
+				// %#v for distinguishing between nil and empty map
+				t.Errorf("Expected %#v hints by zones, got %#v", tc.expectedHintsByZone, actualHintsByZone)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fixes a bug that could result in the EndpointSlice controller unnecessarily updating EndpointSlices associated with a Service that had Topology Aware Hints enabled.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
