### PR TITLE
apf: rename WorkEstimate.Seats to InitialSeats

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/server/filters/priority-and-fairness_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/filters/priority-and-fairness_test.go
@@ -71,7 +71,7 @@ const (
 )
 
 var defaultRequestWorkEstimator = func(*http.Request) fcrequest.WorkEstimate {
-	return fcrequest.WorkEstimate{Seats: 1}
+	return fcrequest.WorkEstimate{InitialSeats: 1}
 }
 
 type fakeApfFilter struct {
@@ -653,7 +653,7 @@ func TestApfWithRequestDigest(t *testing.T) {
 		RequestInfo: &apirequest.RequestInfo{Verb: "get"},
 		User:        &user.DefaultInfo{Name: "foo"},
 		WorkEstimate: fcrequest.WorkEstimate{
-			Seats: 5,
+			InitialSeats: 5,
 		},
 	}
 

--- a/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/queueset/fifo_list_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/queueset/fifo_list_test.go
@@ -154,7 +154,7 @@ func TestFIFOSeatsSum(t *testing.T) {
 	list := newRequestFIFO()
 
 	newRequest := func(width uint) *request {
-		return &request{workEstimate: fcrequest.WorkEstimate{Seats: width}}
+		return &request{workEstimate: fcrequest.WorkEstimate{InitialSeats: width}}
 	}
 	arrival := []*request{newRequest(1), newRequest(2), newRequest(3)}
 	removeFn := make([]removeFromFIFOFunc, 0)

--- a/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/queueset/queueset_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/queueset/queueset_test.go
@@ -266,7 +266,7 @@ func (ust *uniformScenarioThread) callK(k int) {
 	if k >= ust.nCalls {
 		return
 	}
-	req, idle := ust.uss.qs.StartRequest(context.Background(), &fcrequest.WorkEstimate{Seats: ust.uc.width, AdditionalLatency: ust.uc.padDuration}, ust.uc.hash, "", ust.fsName, ust.uss.name, []int{ust.i, ust.j, k}, nil)
+	req, idle := ust.uss.qs.StartRequest(context.Background(), &fcrequest.WorkEstimate{InitialSeats: ust.uc.width, AdditionalLatency: ust.uc.padDuration}, ust.uc.hash, "", ust.fsName, ust.uss.name, []int{ust.i, ust.j, k}, nil)
 	ust.uss.t.Logf("%s: %d, %d, %d got req=%p, idle=%v", ust.uss.clk.Now().Format(nsTimeFmt), ust.i, ust.j, k, req, idle)
 	if req == nil {
 		atomic.AddUint64(&ust.uss.failedCount, 1)
@@ -945,7 +945,7 @@ func TestContextCancel(t *testing.T) {
 		expectQNCount(fn, false, expectF)
 		expectQNCount(fn, true, expectT)
 	}
-	req1, _ := qs.StartRequest(ctx1, &fcrequest.WorkEstimate{Seats: 1}, 1, "", "fs1", "test", "one", queueNoteFn(1))
+	req1, _ := qs.StartRequest(ctx1, &fcrequest.WorkEstimate{InitialSeats: 1}, 1, "", "fs1", "test", "one", queueNoteFn(1))
 	if req1 == nil {
 		t.Error("Request rejected")
 		return
@@ -968,7 +968,7 @@ func TestContextCancel(t *testing.T) {
 				counter.Add(1)
 				cancel2()
 			}()
-			req2, idle2a := qs.StartRequest(ctx2, &fcrequest.WorkEstimate{Seats: 1}, 2, "", "fs2", "test", "two", queueNoteFn(2))
+			req2, idle2a := qs.StartRequest(ctx2, &fcrequest.WorkEstimate{InitialSeats: 1}, 2, "", "fs2", "test", "two", queueNoteFn(2))
 			if idle2a {
 				t.Error("2nd StartRequest returned idle")
 			}
@@ -1041,7 +1041,7 @@ func TestTotalRequestsExecutingWithPanic(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	req, _ := qs.StartRequest(ctx, &fcrequest.WorkEstimate{Seats: 1}, 1, "", "fs", "test", "one", func(inQueue bool) {})
+	req, _ := qs.StartRequest(ctx, &fcrequest.WorkEstimate{InitialSeats: 1}, 1, "", "fs", "test", "one", func(inQueue bool) {})
 	if req == nil {
 		t.Fatal("expected a Request object from StartRequest, but got nil")
 	}
@@ -1094,13 +1094,13 @@ func TestFindDispatchQueueLocked(t *testing.T) {
 				{
 					virtualStart: 200,
 					requests: newFIFO(
-						&request{workEstimate: fcrequest.WorkEstimate{Seats: 1}},
+						&request{workEstimate: fcrequest.WorkEstimate{InitialSeats: 1}},
 					),
 				},
 				{
 					virtualStart: 100,
 					requests: newFIFO(
-						&request{workEstimate: fcrequest.WorkEstimate{Seats: 1}},
+						&request{workEstimate: fcrequest.WorkEstimate{InitialSeats: 1}},
 					),
 				},
 			},
@@ -1117,7 +1117,7 @@ func TestFindDispatchQueueLocked(t *testing.T) {
 				{
 					virtualStart: 200,
 					requests: newFIFO(
-						&request{workEstimate: fcrequest.WorkEstimate{Seats: 1}},
+						&request{workEstimate: fcrequest.WorkEstimate{InitialSeats: 1}},
 					),
 				},
 			},
@@ -1134,13 +1134,13 @@ func TestFindDispatchQueueLocked(t *testing.T) {
 				{
 					virtualStart: 200,
 					requests: newFIFO(
-						&request{workEstimate: fcrequest.WorkEstimate{Seats: 50}},
+						&request{workEstimate: fcrequest.WorkEstimate{InitialSeats: 50}},
 					),
 				},
 				{
 					virtualStart: 100,
 					requests: newFIFO(
-						&request{workEstimate: fcrequest.WorkEstimate{Seats: 25}},
+						&request{workEstimate: fcrequest.WorkEstimate{InitialSeats: 25}},
 					),
 				},
 			},
@@ -1157,13 +1157,13 @@ func TestFindDispatchQueueLocked(t *testing.T) {
 				{
 					virtualStart: 200,
 					requests: newFIFO(
-						&request{workEstimate: fcrequest.WorkEstimate{Seats: 10}},
+						&request{workEstimate: fcrequest.WorkEstimate{InitialSeats: 10}},
 					),
 				},
 				{
 					virtualStart: 100,
 					requests: newFIFO(
-						&request{workEstimate: fcrequest.WorkEstimate{Seats: 25}},
+						&request{workEstimate: fcrequest.WorkEstimate{InitialSeats: 25}},
 					),
 				},
 			},
@@ -1180,13 +1180,13 @@ func TestFindDispatchQueueLocked(t *testing.T) {
 				{
 					virtualStart: 200,
 					requests: newFIFO(
-						&request{workEstimate: fcrequest.WorkEstimate{Seats: 10}},
+						&request{workEstimate: fcrequest.WorkEstimate{InitialSeats: 10}},
 					),
 				},
 				{
 					virtualStart: 100,
 					requests: newFIFO(
-						&request{workEstimate: fcrequest.WorkEstimate{Seats: 25}},
+						&request{workEstimate: fcrequest.WorkEstimate{InitialSeats: 25}},
 					),
 				},
 			},
@@ -1249,14 +1249,14 @@ func TestFinishRequestLocked(t *testing.T) {
 		{
 			name: "request has additional latency",
 			workEstimate: fcrequest.WorkEstimate{
-				Seats:             10,
+				InitialSeats:      10,
 				AdditionalLatency: time.Minute,
 			},
 		},
 		{
 			name: "request has no additional latency",
 			workEstimate: fcrequest.WorkEstimate{
-				Seats: 10,
+				InitialSeats: 10,
 			},
 		},
 	}
@@ -1288,9 +1288,9 @@ func TestFinishRequestLocked(t *testing.T) {
 
 			var (
 				queuesetTotalRequestsExecutingExpected = qs.totRequestsExecuting - 1
-				queuesetTotalSeatsInUseExpected        = qs.totSeatsInUse - int(test.workEstimate.Seats)
+				queuesetTotalSeatsInUseExpected        = qs.totSeatsInUse - int(test.workEstimate.InitialSeats)
 				queueRequestsExecutingExpected         = queue.requestsExecuting - 1
-				queueSeatsInUseExpected                = queue.seatsInUse - int(test.workEstimate.Seats)
+				queueSeatsInUseExpected                = queue.seatsInUse - int(test.workEstimate.InitialSeats)
 			)
 
 			qs.finishRequestLocked(r)

--- a/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/match_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/match_test.go
@@ -103,7 +103,7 @@ func TestLiterals(t *testing.T) {
 			Parts:             []string{"goodrscs", "eman"},
 		},
 		User:         ui,
-		WorkEstimate: fcrequest.WorkEstimate{Seats: 1},
+		WorkEstimate: fcrequest.WorkEstimate{InitialSeats: 1},
 	}
 	reqRU := RequestDigest{
 		RequestInfo: &request.RequestInfo{
@@ -119,7 +119,7 @@ func TestLiterals(t *testing.T) {
 			Parts:             []string{"goodrscs", "eman"},
 		},
 		User:         ui,
-		WorkEstimate: fcrequest.WorkEstimate{Seats: 1},
+		WorkEstimate: fcrequest.WorkEstimate{InitialSeats: 1},
 	}
 	reqN := RequestDigest{
 		RequestInfo: &request.RequestInfo{
@@ -128,7 +128,7 @@ func TestLiterals(t *testing.T) {
 			Verb:              "goodverb",
 		},
 		User:         ui,
-		WorkEstimate: fcrequest.WorkEstimate{Seats: 1},
+		WorkEstimate: fcrequest.WorkEstimate{InitialSeats: 1},
 	}
 	checkRules(t, true, reqRN, []flowcontrol.PolicyRulesWithSubjects{{
 		Subjects: []flowcontrol.Subject{{Kind: flowcontrol.SubjectKindUser,

--- a/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/request/list_work_estimator.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/request/list_work_estimator.go
@@ -45,7 +45,7 @@ func (e *listWorkEstimator) estimate(r *http.Request) WorkEstimate {
 	if !ok {
 		// no RequestInfo should never happen, but to be on the safe side
 		// let's return maximumSeats
-		return WorkEstimate{Seats: maximumSeats}
+		return WorkEstimate{InitialSeats: maximumSeats}
 	}
 
 	query := r.URL.Query()
@@ -55,7 +55,7 @@ func (e *listWorkEstimator) estimate(r *http.Request) WorkEstimate {
 
 		// This request is destined to fail in the validation layer,
 		// return maximumSeats for this request to be consistent.
-		return WorkEstimate{Seats: maximumSeats}
+		return WorkEstimate{InitialSeats: maximumSeats}
 	}
 	isListFromCache := !shouldListFromStorage(query, &listOptions)
 
@@ -66,7 +66,7 @@ func (e *listWorkEstimator) estimate(r *http.Request) WorkEstimate {
 		// be conservative here and allocate maximum seats to this list request.
 		// NOTE: if a CRD is removed, its count will go stale first and then the
 		// pruner will eventually remove the CRD from the cache.
-		return WorkEstimate{Seats: maximumSeats}
+		return WorkEstimate{InitialSeats: maximumSeats}
 	case err == ObjectCountNotFoundErr:
 		// there are two scenarios in which we can see this error:
 		//  a. the type is truly unknown, a typo on the caller's part.
@@ -75,11 +75,11 @@ func (e *listWorkEstimator) estimate(r *http.Request) WorkEstimate {
 		// we don't have a way to distinguish between a and b. b seems to indicate
 		// to a more severe case of degradation, although b can naturally trigger
 		// when a CRD is removed. let's be conservative and allocate maximum seats.
-		return WorkEstimate{Seats: maximumSeats}
+		return WorkEstimate{InitialSeats: maximumSeats}
 	case err != nil:
 		// we should never be here since Get returns either ObjectCountStaleErr or
 		// ObjectCountNotFoundErr, return maximumSeats to be on the safe side.
-		return WorkEstimate{Seats: maximumSeats}
+		return WorkEstimate{InitialSeats: maximumSeats}
 	}
 
 	limit := numStored
@@ -114,7 +114,7 @@ func (e *listWorkEstimator) estimate(r *http.Request) WorkEstimate {
 	if seats > maximumSeats {
 		seats = maximumSeats
 	}
-	return WorkEstimate{Seats: seats}
+	return WorkEstimate{InitialSeats: seats}
 }
 
 func key(requestInfo *apirequest.RequestInfo) string {

--- a/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/request/width.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/request/width.go
@@ -34,8 +34,8 @@ const (
 )
 
 type WorkEstimate struct {
-	// Seats represents the number of seats associated with this request
-	Seats uint
+	// InitialSeats represents the number of initial seats associated with this request
+	InitialSeats uint
 
 	// AdditionalLatency specifies the additional duration the seats allocated
 	// to this request must be reserved after the given request had finished.
@@ -77,7 +77,7 @@ func (e *workEstimator) estimate(r *http.Request) WorkEstimate {
 	if !ok {
 		klog.ErrorS(fmt.Errorf("no RequestInfo found in context"), "Failed to estimate work for the request", "URI", r.RequestURI)
 		// no RequestInfo should never happen, but to be on the safe side let's return maximumSeats
-		return WorkEstimate{Seats: maximumSeats}
+		return WorkEstimate{InitialSeats: maximumSeats}
 	}
 
 	switch requestInfo.Verb {
@@ -85,5 +85,5 @@ func (e *workEstimator) estimate(r *http.Request) WorkEstimate {
 		return e.listWorkEstimator.EstimateWork(r)
 	}
 
-	return WorkEstimate{Seats: minimumSeats}
+	return WorkEstimate{InitialSeats: minimumSeats}
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:
Rename `WorkEstimate.Seats` to `WorkEstimate.InitialSeats`. This will pave the way for https://github.com/kubernetes/kubernetes/pull/105243

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
