### PR TITLE
Automated cherry pick of #105205: e2e scheduling priorities: do not reference control loop

### DIFF
--- a/test/e2e/scheduling/priorities.go
+++ b/test/e2e/scheduling/priorities.go
@@ -485,9 +485,9 @@ func podListForEachNode(cs clientset.Interface) map[string][]*v1.Pod {
 	if err != nil {
 		framework.Failf("Expect error of invalid, got : %v", err)
 	}
-	for _, pod := range allPods.Items {
+	for i, pod := range allPods.Items {
 		nodeName := pod.Spec.NodeName
-		nodeNameToPodList[nodeName] = append(nodeNameToPodList[nodeName], &pod)
+		nodeNameToPodList[nodeName] = append(nodeNameToPodList[nodeName], &allPods.Items[i])
 	}
 	return nodeNameToPodList
 }


### PR DESCRIPTION
Cherry pick of #105205 on release-1.22.

#105205: e2e scheduling priorities: do not reference control loop

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
None
```