### PR TITLE
RunCordonOrUncordon error if drainer has nil Ctx or Client

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/drain/default.go
+++ b/staging/src/k8s.io/kubectl/pkg/drain/default.go
@@ -49,6 +49,12 @@ func RunNodeDrain(drainer *Helper, nodeName string) error {
 
 // RunCordonOrUncordon demonstrates the canonical way to cordon or uncordon a Node
 func RunCordonOrUncordon(drainer *Helper, node *corev1.Node, desired bool) error {
+	if drainer.Ctx == nil {
+		return fmt.Errorf("RunCordonOrUncordon error: drainer.Ctx can't be nil")
+	}
+	if drainer.Client == nil {
+		return fmt.Errorf("RunCordonOrUncordon error: drainer.Client can't be nil")
+	}
 	// TODO(justinsb): Ensure we have adequate e2e coverage of this function in library consumers
 	c := NewCordonHelper(node)
 

--- a/staging/src/k8s.io/kubectl/pkg/drain/default_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/drain/default_test.go
@@ -1,0 +1,69 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package drain
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func TestRunCordonOrUncordon(t *testing.T) {
+	nilContextError := fmt.Errorf("RunCordonOrUncordon error: drainer.Ctx can't be nil")
+	nilClientError := fmt.Errorf("RunCordonOrUncordon error: drainer.Client can't be nil")
+	tests := []struct {
+		description   string
+		drainer       *Helper
+		node          *corev1.Node
+		desired       bool
+		expectedError *error
+	}{
+		{
+			description: "nil context object",
+			drainer: &Helper{
+				Client: fake.NewSimpleClientset(),
+			},
+			desired:       true,
+			expectedError: &nilContextError,
+		},
+		{
+			description: "nil client object",
+			drainer: &Helper{
+				Ctx: context.TODO(),
+			},
+			desired:       true,
+			expectedError: &nilClientError,
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.description, func(t *testing.T) {
+			err := RunCordonOrUncordon(test.drainer, test.node, test.desired)
+			if test.expectedError == nil {
+				if err != nil {
+					t.Fatalf("%s: did not expect error, got err=%s", test.description, err.Error())
+				}
+			} else if err.Error() != (*test.expectedError).Error() {
+				t.Fatalf("%s: the error does not match expected error, got err=%s, expected err=%s", test.description, err, *test.expectedError)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind bug

#### What this PR does / why we need it:

The following change modified the way that `drain.RunCordonOrUncordon` runs a patch or replace operation under the hood to use a client context object:

https://github.com/kubernetes/kubernetes/commit/017eaa519de5926fd75a9ddc61bedf2398b69653

As a result, certain clients of `drain.RunCordonOrUncordon` that weren't previously defining a context are encountering runtime Panics. E.g., the `kured` project is in the process of fixing this:

```
time="2021-09-27T18:36:31Z" level=info msg="Uncordoning node k8s-agentpool1-18671695-vmss000000"
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x20 pc=0x12755da]

goroutine 22 [running]:
golang.org/x/time/rate.(*Limiter).WaitN(0xc000088820, 0x0, 0x0, 0x1, 0x0, 0x0)
	/Users/jackfrancis/go/pkg/mod/golang.org/x/time@v0.0.0-20210220033141-f8bda1e9f3ba/rate/rate.go:237 +0xba
golang.org/x/time/rate.(*Limiter).Wait(...)
	/Users/jackfrancis/go/pkg/mod/golang.org/x/time@v0.0.0-20210220033141-f8bda1e9f3ba/rate/rate.go:219
k8s.io/client-go/util/flowcontrol.(*tokenBucketRateLimiter).Wait(0xc0001acd80, 0x0, 0x0, 0x0, 0x0)
	/Users/jackfrancis/go/pkg/mod/k8s.io/client-go@v0.21.4/util/flowcontrol/throttle.go:106 +0x4b
k8s.io/client-go/rest.(*Request).tryThrottleWithInfo(0xc00008e4b0, 0x0, 0x0, 0x0, 0x0, 0x42, 0x40)
	/Users/jackfrancis/go/pkg/mod/k8s.io/client-go@v0.21.4/rest/request.go:587 +0xa5
k8s.io/client-go/rest.(*Request).tryThrottle(...)
	/Users/jackfrancis/go/pkg/mod/k8s.io/client-go@v0.21.4/rest/request.go:613
k8s.io/client-go/rest.(*Request).request(0xc00008e4b0, 0x0, 0x0, 0xc0005df688, 0x0, 0x0)
	/Users/jackfrancis/go/pkg/mod/k8s.io/client-go@v0.21.4/rest/request.go:873 +0x2fc
k8s.io/client-go/rest.(*Request).Do(0xc00008e4b0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
	/Users/jackfrancis/go/pkg/mod/k8s.io/client-go@v0.21.4/rest/request.go:980 +0xf1
k8s.io/client-go/kubernetes/typed/core/v1.(*nodes).Patch(0xc0004ab480, 0x0, 0x0, 0xc00045c7e0, 0x22, 0x1ac2546, 0x26, 0xc0004c11a0, 0x1f, 0x20, ...)
	/Users/jackfrancis/go/pkg/mod/k8s.io/client-go@v0.21.4/kubernetes/typed/core/v1/node.go:186 +0x237
k8s.io/kubectl/pkg/drain.(*CordonHelper).PatchOrReplaceWithContext(0xc0005dfa70, 0x0, 0x0, 0x1cf2b48, 0xc0000de160, 0x0, 0x19d67a0, 0x1, 0xc0005dfa60, 0x47825c)
	/Users/jackfrancis/go/pkg/mod/k8s.io/kubectl@v0.21.4/pkg/drain/cordon.go:102 +0x416
k8s.io/kubectl/pkg/drain.RunCordonOrUncordon(0xc0005dfb48, 0xc000614c00, 0x1aa8e00, 0x13, 0xc0005dfb18)
	/Users/jackfrancis/go/pkg/mod/k8s.io/kubectl@v0.21.4/pkg/drain/default.go:60 +0xb3
main.uncordon(0xc0000de160, 0xc000614c00)
	/Users/jackfrancis/go/src/github.com/weaveworks/kured/cmd/kured/main.go:405 +0x16a
main.rebootAsRequired(0xc00004200e, 0x22, 0xc000339320, 0x5, 0x6, 0xc0003392c0, 0x6, 0x6, 0xc000491280, 0x0, ...)
	/Users/jackfrancis/go/src/github.com/weaveworks/kured/cmd/kured/main.go:504 +0xf98
created by main.root
	/Users/jackfrancis/go/src/github.com/weaveworks/kured/cmd/kured/main.go:667 +0xc05
```

(forgive the custom GOPATH data there that is a side-effect of my debugging this)

There is a relatively easy fix for clients to simply define any valid context object going forward, but this PR will replace nil panics with error responses from `drain.RunCordonOrUncordon` if invalid nil child properties of the `drainer *Helper` function parameter are detected. This should provide clients with a more clear indication of the error, and how to update their client code to fulfill the `drainer *Helper` requirements successfully.

https://github.com/kubernetes/kubernetes/commit/017eaa519de5926fd75a9ddc61bedf2398b69653#diff-c01ad8d48575a89edaadf2f9e9b984eaf454e22a0711c6e244422c3a40f9d162

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

Includes unit tests (no UT exist for `pkg/drainer/default.go` so I scaffolded out a simple one, covering the changes added in this PR).

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
RunCordonOrUncordon error if drainer has nil Ctx or Client
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
