### PR TITLE
removing referencing loop variables from component helper and plugin of scheduler

### DIFF
--- a/pkg/scheduler/framework/plugins/interpodaffinity/scoring.go
+++ b/pkg/scheduler/framework/plugins/interpodaffinity/scoring.go
@@ -22,7 +22,7 @@ import (
 	"math"
 	"sync/atomic"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/kubernetes/pkg/scheduler/framework"
 )
@@ -58,8 +58,8 @@ func (m scoreMap) processTerm(term *framework.AffinityTerm, weight int32, pod *v
 }
 
 func (m scoreMap) processTerms(terms []framework.WeightedAffinityTerm, pod *v1.Pod, nsLabels labels.Set, node *v1.Node, multiplier int32, enableNamespaceSelector bool) {
-	for _, term := range terms {
-		m.processTerm(&term.AffinityTerm, term.Weight, pod, nsLabels, node, multiplier, enableNamespaceSelector)
+	for i := range terms {
+		m.processTerm(&terms[i].AffinityTerm, terms[i].Weight, pod, nsLabels, node, multiplier, enableNamespaceSelector)
 	}
 }
 

--- a/staging/src/k8s.io/component-helpers/scheduling/corev1/nodeaffinity/nodeaffinity.go
+++ b/staging/src/k8s.io/component-helpers/scheduling/corev1/nodeaffinity/nodeaffinity.go
@@ -57,13 +57,13 @@ func NewLazyErrorNodeSelector(ns *v1.NodeSelector, opts ...field.PathOption) *La
 	p := field.ToPath(opts...)
 	parsedTerms := make([]nodeSelectorTerm, 0, len(ns.NodeSelectorTerms))
 	path := p.Child("nodeSelectorTerms")
-	for i, term := range ns.NodeSelectorTerms {
+	for i := range ns.NodeSelectorTerms {
 		// nil or empty term selects no objects
-		if isEmptyNodeSelectorTerm(&term) {
+		if isEmptyNodeSelectorTerm(&ns.NodeSelectorTerms[i]) {
 			continue
 		}
 		p := path.Index(i)
-		parsedTerms = append(parsedTerms, newNodeSelectorTerm(&term, p))
+		parsedTerms = append(parsedTerms, newNodeSelectorTerm(&ns.NodeSelectorTerms[i], p))
 	}
 	return &LazyErrorNodeSelector{
 		terms: parsedTerms,
@@ -113,14 +113,14 @@ func NewPreferredSchedulingTerms(terms []v1.PreferredSchedulingTerm, opts ...fie
 	p := field.ToPath(opts...)
 	var errs []error
 	parsedTerms := make([]preferredSchedulingTerm, 0, len(terms))
-	for i, term := range terms {
+	for i := range terms {
 		path := p.Index(i)
-		if term.Weight == 0 || isEmptyNodeSelectorTerm(&term.Preference) {
+		if terms[i].Weight == 0 || isEmptyNodeSelectorTerm(&terms[i].Preference) {
 			continue
 		}
 		parsedTerm := preferredSchedulingTerm{
-			nodeSelectorTerm: newNodeSelectorTerm(&term.Preference, path),
-			weight:           int(term.Weight),
+			nodeSelectorTerm: newNodeSelectorTerm(&terms[i].Preference, path),
+			weight:           int(terms[i].Weight),
 		}
 		if len(parsedTerm.parseErrs) > 0 {
 			errs = append(errs, parsedTerm.parseErrs...)


### PR DESCRIPTION
Signed-off-by: ishangupta-ds <ishangupta.ds@gmail.com>

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

PR for best practices

Removes reference to loop variables from component helper and plugin of scheduler:

* `pkg/scheduler/framework/plugins/interpodaffinity/scoring.go`
* `staging/src/k8s.io/component-helpers/scheduling/corev1/nodeaffinity/nodeaffinity.go`

#### Which issue(s) this PR fixes:

Fixes #105305 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
