### PR TITLE
Add unit test coverage for events expansion

### DIFF
--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/event_expansion.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/event_expansion.go
@@ -34,6 +34,7 @@ type EventExpansion interface {
 	CreateWithEventNamespace(event *v1.Event) (*v1.Event, error)
 	// UpdateWithEventNamespace is the same as a Update, except that it sends the request to the event.Namespace.
 	UpdateWithEventNamespace(event *v1.Event) (*v1.Event, error)
+	// PatchWithEventNamespace is the same as a Patch, except that it sends the request to the event.Namespace.
 	PatchWithEventNamespace(event *v1.Event, data []byte) (*v1.Event, error)
 	// Search finds events about the specified object
 	Search(scheme *runtime.Scheme, objOrRef runtime.Object) (*v1.EventList, error)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/event_expansion_test.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/event_expansion_test.go
@@ -1,0 +1,176 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1
+
+import (
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/scheme"
+	restfake "k8s.io/client-go/rest/fake"
+)
+
+func TestCreateWithEventNamespace(t *testing.T) {
+	event := &v1.Event{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: "default",
+		},
+	}
+	cli := &restfake.RESTClient{
+		Client: restfake.CreateHTTPClient(func(request *http.Request) (*http.Response, error) {
+			resp := &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader("{}")),
+			}
+			return resp, nil
+		}),
+		NegotiatedSerializer: scheme.Codecs.WithoutConversion(),
+	}
+
+	tests := []struct {
+		name    string
+		ns      string
+		event   *v1.Event
+		wantErr bool
+	}{
+		{
+			name:  "create event",
+			ns:    "default",
+			event: event,
+		},
+		{
+			name:    "create event with different namespace",
+			ns:      "other",
+			event:   event,
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			e := newEvents(New(cli), tt.ns)
+			_, err := e.CreateWithEventNamespace(tt.event)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("CreateWithEventNamespace() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+		})
+	}
+}
+
+func TestPatchWithEventNamespace(t *testing.T) {
+	event := &v1.Event{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: "default",
+		},
+	}
+	cli := &restfake.RESTClient{
+		Client: restfake.CreateHTTPClient(func(request *http.Request) (*http.Response, error) {
+			resp := &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader("{}")),
+			}
+			return resp, nil
+		}),
+		NegotiatedSerializer: scheme.Codecs.WithoutConversion(),
+	}
+
+	tests := []struct {
+		name    string
+		ns      string
+		event   *v1.Event
+		data    []byte
+		wantErr bool
+	}{
+		{
+			name:  "patch event",
+			ns:    "default",
+			event: event,
+			data:  []byte{},
+		},
+		{
+			name:    "patch event with different namespace",
+			ns:      "other",
+			event:   event,
+			data:    []byte{},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			e := newEvents(New(cli), tt.ns)
+			_, err := e.PatchWithEventNamespace(tt.event, tt.data)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("PatchWithEventNamespace() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+		})
+	}
+}
+
+func TestUpdateWithEventNamespace(t *testing.T) {
+	event := &v1.Event{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: "default",
+		},
+	}
+	cli := &restfake.RESTClient{
+		Client: restfake.CreateHTTPClient(func(request *http.Request) (*http.Response, error) {
+			resp := &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader("{}")),
+			}
+			return resp, nil
+		}),
+		NegotiatedSerializer: scheme.Codecs.WithoutConversion(),
+	}
+
+	tests := []struct {
+		name    string
+		ns      string
+		event   *v1.Event
+		wantErr bool
+	}{
+		{
+			name:  "patch event",
+			ns:    "default",
+			event: event,
+		},
+		{
+			name:    "patch event with different namespace",
+			ns:      "other",
+			event:   event,
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			e := newEvents(New(cli), tt.ns)
+			_, err := e.UpdateWithEventNamespace(tt.event)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("UpdateWithEventNamespace() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+		})
+	}
+}

--- a/staging/src/k8s.io/client-go/kubernetes/typed/events/v1beta1/event_expansion.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/events/v1beta1/event_expansion.go
@@ -33,7 +33,7 @@ type EventExpansion interface {
 	// UpdateWithEventNamespace is the same as a Update
 	// except that it sends the request to the event.Namespace.
 	UpdateWithEventNamespace(event *v1beta1.Event) (*v1beta1.Event, error)
-	// PatchWithEventNamespace is the same as an Update
+	// PatchWithEventNamespace is the same as a Patch
 	// except that it sends the request to the event.Namespace.
 	PatchWithEventNamespace(event *v1beta1.Event, data []byte) (*v1beta1.Event, error)
 }

--- a/staging/src/k8s.io/client-go/kubernetes/typed/events/v1beta1/event_expansion_test.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/events/v1beta1/event_expansion_test.go
@@ -1,0 +1,176 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1beta1
+
+import (
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"k8s.io/api/events/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/scheme"
+	restfake "k8s.io/client-go/rest/fake"
+)
+
+func TestCreateWithEventNamespace(t *testing.T) {
+	event := &v1beta1.Event{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: "default",
+		},
+	}
+	cli := &restfake.RESTClient{
+		Client: restfake.CreateHTTPClient(func(request *http.Request) (*http.Response, error) {
+			resp := &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader("{}")),
+			}
+			return resp, nil
+		}),
+		NegotiatedSerializer: scheme.Codecs.WithoutConversion(),
+	}
+
+	tests := []struct {
+		name    string
+		ns      string
+		event   *v1beta1.Event
+		wantErr bool
+	}{
+		{
+			name:  "create event",
+			ns:    "default",
+			event: event,
+		},
+		{
+			name:    "create event with different namespace",
+			ns:      "other",
+			event:   event,
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			e := newEvents(New(cli), tt.ns)
+			_, err := e.CreateWithEventNamespace(tt.event)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("CreateWithEventNamespace() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+		})
+	}
+}
+
+func TestPatchWithEventNamespace(t *testing.T) {
+	event := &v1beta1.Event{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: "default",
+		},
+	}
+	cli := &restfake.RESTClient{
+		Client: restfake.CreateHTTPClient(func(request *http.Request) (*http.Response, error) {
+			resp := &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader("{}")),
+			}
+			return resp, nil
+		}),
+		NegotiatedSerializer: scheme.Codecs.WithoutConversion(),
+	}
+
+	tests := []struct {
+		name    string
+		ns      string
+		event   *v1beta1.Event
+		data    []byte
+		wantErr bool
+	}{
+		{
+			name:  "patch event",
+			ns:    "default",
+			event: event,
+			data:  []byte{},
+		},
+		{
+			name:    "patch event with different namespace",
+			ns:      "other",
+			event:   event,
+			data:    []byte{},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			e := newEvents(New(cli), tt.ns)
+			_, err := e.PatchWithEventNamespace(tt.event, tt.data)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("PatchWithEventNamespace() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+		})
+	}
+}
+
+func TestUpdateWithEventNamespace(t *testing.T) {
+	event := &v1beta1.Event{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: "default",
+		},
+	}
+	cli := &restfake.RESTClient{
+		Client: restfake.CreateHTTPClient(func(request *http.Request) (*http.Response, error) {
+			resp := &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader("{}")),
+			}
+			return resp, nil
+		}),
+		NegotiatedSerializer: scheme.Codecs.WithoutConversion(),
+	}
+
+	tests := []struct {
+		name    string
+		ns      string
+		event   *v1beta1.Event
+		wantErr bool
+	}{
+		{
+			name:  "patch event",
+			ns:    "default",
+			event: event,
+		},
+		{
+			name:    "patch event with different namespace",
+			ns:      "other",
+			event:   event,
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			e := newEvents(New(cli), tt.ns)
+			_, err := e.UpdateWithEventNamespace(tt.event)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("UpdateWithEventNamespace() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup
/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #105276

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
NONE
```

/cc @wojtek-t 