### PR TITLE
Remove deprecated kubectl --dry-run values.

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/util/helpers.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/util/helpers.go
@@ -23,7 +23,6 @@ import (
 	"io"
 	"net/url"
 	"os"
-	"strconv"
 	"strings"
 	"time"
 
@@ -547,30 +546,18 @@ const (
 
 func GetDryRunStrategy(cmd *cobra.Command) (DryRunStrategy, error) {
 	var dryRunFlag = GetFlagString(cmd, "dry-run")
-	b, err := strconv.ParseBool(dryRunFlag)
-	// The flag is not a boolean
-	if err != nil {
-		switch dryRunFlag {
-		case cmd.Flag("dry-run").NoOptDefVal:
-			klog.Warning(`--dry-run is deprecated and can be replaced with --dry-run=client.`)
-			return DryRunClient, nil
-		case "client":
-			return DryRunClient, nil
-		case "server":
-			return DryRunServer, nil
-		case "none":
-			return DryRunNone, nil
-		default:
-			return DryRunNone, fmt.Errorf(`Invalid dry-run value (%v). Must be "none", "server", or "client".`, dryRunFlag)
-		}
-	}
-	// The flag was a boolean
-	if b {
-		klog.Warningf(`--dry-run=%v is deprecated (boolean value) and can be replaced with --dry-run=%s.`, dryRunFlag, "client")
+	switch dryRunFlag {
+	case cmd.Flag("dry-run").NoOptDefVal:
+		return DryRunNone, errors.New(`--dry-run flag without a value was specified. A value must be set: "none", "server", or "client".`)
+	case "client":
 		return DryRunClient, nil
+	case "server":
+		return DryRunServer, nil
+	case "none":
+		return DryRunNone, nil
+	default:
+		return DryRunNone, fmt.Errorf(`Invalid dry-run value (%v). Must be "none", "server", or "client".`, dryRunFlag)
 	}
-	klog.Warningf(`--dry-run=%v is deprecated (boolean value) and can be replaced with --dry-run=%s.`, dryRunFlag, "none")
-	return DryRunNone, nil
 }
 
 // PrintFlagsWithDryRunStrategy sets a success message at print time for the dry run strategy

--- a/test/cmd/apply.sh
+++ b/test/cmd/apply.sh
@@ -101,7 +101,6 @@ run_kubectl_apply_tests() {
   kube::test::get_object_assert pods "{{range.items}}{{${id_field:?}}}:{{end}}" ''
 
   # apply dry-run
-  kubectl apply --dry-run=true -f hack/testdata/pod.yaml "${kube_flags[@]:?}"
   kubectl apply --dry-run=client -f hack/testdata/pod.yaml "${kube_flags[@]:?}"
   kubectl apply --dry-run=server -f hack/testdata/pod.yaml "${kube_flags[@]:?}"
   # No pod exists

--- a/test/cmd/batch.sh
+++ b/test/cmd/batch.sh
@@ -49,7 +49,7 @@ run_job_tests() {
   kube::test::describe_resource_chunk_size_assert cronjobs events "--namespace=test-jobs"
 
   ### Create a job in dry-run mode
-  output_message=$(kubectl create job test-job --from=cronjob/pi --dry-run=true --namespace=test-jobs -o name)
+  output_message=$(kubectl create job test-job --from=cronjob/pi --dry-run=client --namespace=test-jobs -o name)
   # Post-condition: The text 'job.batch/test-job' should be part of the output
   kube::test::if_has_string "${output_message}" 'job.batch/test-job'
   # Post-condition: The test-job wasn't created actually


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/kind deprecation

#### What this PR does / why we need it:

The boolean values for --dry-run have been deprecated for removal since
1.18, more than 2 releases.

The default value for --dry-run with the flag set and unspecified has
been deprecated for removal since 1.18, more than 2 releases.

Both values are now removed in this change. Any kubectl --dry-run
usage no longer accepts --dry-run=(true|false) boolean values and usage
now requires that a value of (client|server|none) is specified.

#### Which issue(s) this PR fixes:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Removed kubectl --dry-run empty default value and boolean values. Action required: kubectl --dry-run usage must be specified with --dry-run=(server|client|none).
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
- [KEP]: https://github.com/kubernetes/enhancements/blob/0e4d5df19d396511fe41ed0860b0ab9b96f46a2d/keps/sig-api-machinery/576-dry-run/README.md
```
