### PR TITLE
Make package paths referenced by import boss valid

### DIFF
--- a/staging/src/k8s.io/api/doc.go
+++ b/staging/src/k8s.io/api/doc.go
@@ -1,0 +1,17 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package api // import "k8s.io/api"

--- a/staging/src/k8s.io/api/roundtrip_test.go
+++ b/staging/src/k8s.io/api/roundtrip_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package testing
+package api
 
 import (
 	"math/rand"

--- a/staging/src/k8s.io/apimachinery/doc.go
+++ b/staging/src/k8s.io/apimachinery/doc.go
@@ -1,0 +1,17 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package apimachinery // import "k8s.io/apimachinery"

--- a/staging/src/k8s.io/apiserver/doc.go
+++ b/staging/src/k8s.io/apiserver/doc.go
@@ -1,0 +1,17 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package apiserver // import "k8s.io/apiserver"

--- a/staging/src/k8s.io/cli-runtime/doc.go
+++ b/staging/src/k8s.io/cli-runtime/doc.go
@@ -1,0 +1,17 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cliruntime // import "k8s.io/cli-runtime"

--- a/staging/src/k8s.io/client-go/doc.go
+++ b/staging/src/k8s.io/client-go/doc.go
@@ -1,0 +1,17 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package clientgo // import "k8s.io/client-go"

--- a/staging/src/k8s.io/cluster-bootstrap/doc.go
+++ b/staging/src/k8s.io/cluster-bootstrap/doc.go
@@ -1,0 +1,17 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package clusterbootstrap // import "k8s.io/cluster-bootstrap"

--- a/staging/src/k8s.io/code-generator/doc.go
+++ b/staging/src/k8s.io/code-generator/doc.go
@@ -1,0 +1,17 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package codegenerator // import "k8s.io/code-generator"

--- a/staging/src/k8s.io/code-generator/tools.go
+++ b/staging/src/k8s.io/code-generator/tools.go
@@ -19,7 +19,7 @@ limitations under the License.
 
 // This package contains code generation utilities
 // This package imports things required by build scripts, to force `go mod` to see them as dependencies
-package tools
+package codegenerator
 
 import (
 	_ "k8s.io/code-generator/cmd/client-gen"

--- a/staging/src/k8s.io/component-base/doc.go
+++ b/staging/src/k8s.io/component-base/doc.go
@@ -1,0 +1,17 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package componentbase // import "k8s.io/component-base"

--- a/staging/src/k8s.io/component-helpers/doc.go
+++ b/staging/src/k8s.io/component-helpers/doc.go
@@ -1,0 +1,17 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package componenthelpers // import "k8s.io/component-helpers"

--- a/staging/src/k8s.io/cri-api/doc.go
+++ b/staging/src/k8s.io/cri-api/doc.go
@@ -1,0 +1,17 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package criapi // import "k8s.io/cri-api"

--- a/staging/src/k8s.io/kube-controller-manager/doc.go
+++ b/staging/src/k8s.io/kube-controller-manager/doc.go
@@ -1,0 +1,17 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubecontrollermanager // import "k8s.io/kube-controller-manager"

--- a/staging/src/k8s.io/kube-proxy/doc.go
+++ b/staging/src/k8s.io/kube-proxy/doc.go
@@ -1,0 +1,17 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubeproxy // import "k8s.io/kube-proxy"

--- a/staging/src/k8s.io/kube-scheduler/doc.go
+++ b/staging/src/k8s.io/kube-scheduler/doc.go
@@ -1,0 +1,17 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubescheduler // import "k8s.io/kube-scheduler"

--- a/staging/src/k8s.io/kubectl/doc.go
+++ b/staging/src/k8s.io/kubectl/doc.go
@@ -1,0 +1,17 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubectl // import "k8s.io/kubectl"

--- a/staging/src/k8s.io/kubelet/doc.go
+++ b/staging/src/k8s.io/kubelet/doc.go
@@ -1,0 +1,17 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubelet // import "k8s.io/kubelet"

--- a/staging/src/k8s.io/legacy-cloud-providers/doc.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/doc.go
@@ -1,0 +1,17 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package legacycloudproviders // import "k8s.io/legacy-cloud-providers"

--- a/staging/src/k8s.io/metrics/doc.go
+++ b/staging/src/k8s.io/metrics/doc.go
@@ -1,0 +1,17 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics // import "k8s.io/metrics"

--- a/staging/src/k8s.io/sample-cli-plugin/doc.go
+++ b/staging/src/k8s.io/sample-cli-plugin/doc.go
@@ -1,0 +1,17 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package samplecliplugin // import "k8s.io/sample-cli-plugin"


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

verify-import-boss.sh references package paths of the form `k8s.io/api/...`, but many of the staging repos roots are not valid go packages.

This adds doc.go files to make them valid packages so that go package resolution works properly in gopath and go module mode.

Hoisted out of #99226. Prereq to https://github.com/kubernetes/kubernetes/pull/105299

#### Which issue(s) this PR fixes:

xref #82531

```release-note
NONE
```

/area code-organization
/cc @dims