### PR TITLE
Automated cherry pick of #103855: Update Containerd version - GCE Windows

### DIFF
--- a/cluster/gce/windows/k8s-node-setup.psm1
+++ b/cluster/gce/windows/k8s-node-setup.psm1
@@ -1585,7 +1585,7 @@ function Install_Containerd {
   New-Item $tmp_dir -ItemType 'directory' -Force | Out-Null
 
   # TODO(ibrahimab) Change this to a gcs bucket with CI maintained and accessible by community.
-  $version = '1.4.4'
+  $version = '1.5.4'
   $tar_url = ("https://github.com/containerd/containerd/releases/download/v${version}/" +
               "cri-containerd-cni-${version}-windows-amd64.tar.gz")
   $sha_url = $tar_url + ".sha256sum"


### PR DESCRIPTION
Cherry pick of #103855 on release-1.22.

#103855: Update Containerd version - GCE Windows

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

#### What type of PR is this?

/kind bug


#### What this PR does / why we need it:

The cherry-pick is needed to update the containerd runtime used with v1.22. Prior containerd runtime (v1.5.2) had an issue with csi-drivers that causes failures on mount.

#### Which issue(s) this PR fixes:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```