### PR TITLE
feat: automatically fix incorrect case in first character of suffix

### DIFF
--- a/pkg/kubelet/apis/config/scheme/testdata/KubeletConfiguration/after/v1beta1.yaml
+++ b/pkg/kubelet/apis/config/scheme/testdata/KubeletConfiguration/after/v1beta1.yaml
@@ -36,7 +36,6 @@ evictionHard:
   imagefs.available: 15%
   memory.available: 100Mi
   nodefs.available: 10%
-  nodefs.inodesFree: 5%
 evictionPressureTransitionPeriod: 5m0s
 failSwapOn: true
 fileCheckFrequency: 20s

--- a/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity.go
@@ -133,7 +133,7 @@ func MustParse(str string) Quantity {
 const (
 	// splitREString is used to separate a number from its suffix; as such,
 	// this is overly permissive, but that's OK-- it will be checked later.
-	splitREString = "^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$"
+	splitREString = "^([+-]?[0-9.]+)([eEinumkKMGTPgtp]*[-+]?[0-9]*)$"
 )
 
 var (
@@ -231,7 +231,7 @@ Num:
 			suffix = str[suffixStart:end]
 			return
 		}
-		if !strings.ContainsAny(str[i:i+1], "eEinumkKMGTP") {
+		if !strings.ContainsAny(str[i:i+1], "eEinumkKMGTPgtp") {
 			pos = i
 			break
 		}

--- a/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity_test.go
@@ -333,6 +333,11 @@ func TestQuantityParse(t *testing.T) {
 		{"0.05Gi", decQuantity(536870912, -1, BinarySI)},
 		{"0.025Ti", decQuantity(274877906944, -1, BinarySI)},
 
+		// Things in the wrong case but can only mean one suffix
+		{"0.5mi", decQuantity(1024 * 1024 * .5, 0, BinarySI)},
+		{"10K", decQuantity(10, 3, DecimalSI)},
+		{"124g", decQuantity(124, 9, DecimalSI)},
+	
 		// Things written by trolls
 		{"0.000000000001Ki", decQuantity(2, -9, DecimalSI)}, // rounds up, changes format
 		{".001", decQuantity(1, -3, DecimalSI)},
@@ -482,7 +487,8 @@ func TestQuantityParse(t *testing.T) {
 	invalid := []string{
 		"1.1.M",
 		"1+1.0M",
-		"0.1mi",
+		"0.1MI",
+		"0.1mI",
 		"0.1am",
 		"aoeu",
 		".5i",

--- a/staging/src/k8s.io/apimachinery/pkg/api/resource/suffix.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/resource/suffix.go
@@ -17,7 +17,7 @@ limitations under the License.
 package resource
 
 import (
-	"strconv"
+  "strconv"
   "unicode"
 )
 


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
Allows people to use eg "mi" to mean "Mi" and "ti" to mean "Ti", but not "m" to mean "M" or vice versa. Only kicks in when otherwise the suffix lookup fails, so it should not introduce any issues with existing working suffixes.

#### Which issue(s) this PR fixes:
None

#### Special notes for your reviewer:
I understand why k8s does not full on support all case possibilities for suffixes, as eg "m" and "M" are abbreviations for different units, but I don't see the harm in supporting both cases when it does not introduce collisions. Recently had an issue where a deployment failed because a user input "500mi" instead of "500Mi", in my opinion this is unambiguous.

#### Does this PR introduce a user-facing change?
Technically yes, as users would now be able to use incorrectly cased suffixes, but _only_ when there's no collision. Since it's not exactly consistent (though in my opinion is logically consistent), it may not be desired to make it user-facing, but I'll add a release note just in case.

```release-note
Added handling for certain suffixes to start in upper or lower case, for example "500Mi" or "500mi" would both work.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
[Other doc]: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#meaning-of-memory
```
