### PR TITLE
etcd-storage-test: mark node ready to save it for 5min from cloud provider deletion

### DIFF
--- a/test/integration/etcd/data.go
+++ b/test/integration/etcd/data.go
@@ -72,7 +72,7 @@ func GetEtcdStorageDataForNamespace(namespace string) map[schema.GroupVersionRes
 			ExpectedEtcdPath: "/registry/namespaces/namespace1",
 		},
 		gvr("", "v1", "nodes"): {
-			Stub:             `{"metadata": {"name": "node1"}, "spec": {"unschedulable": true}}`,
+			Stub:             `{"metadata": {"name": "node1"}, "spec": {"unschedulable": true}, "status": {"conditions":[{"type":"Ready", "status":"True"}]}}`,
 			ExpectedEtcdPath: "/registry/minions/node1",
 		},
 		gvr("", "v1", "persistentvolumes"): {


### PR DESCRIPTION
The test creates a node1 node object without any condition. Some cloud providers delete nodes without matching VMs. Hence, the etcd storage test races with the node controller.

Compare https://bugzilla.redhat.com/show_bug.cgi?id=2008926.

/kind bug
/kind flake

```release-note
NONE
```