### PR TITLE
[WIP] Restclient allow to set group version per request and use only one transport for all generated clients

### DIFF
--- a/pkg/client/tests/listwatch_test.go
+++ b/pkg/client/tests/listwatch_test.go
@@ -96,7 +96,7 @@ func TestListWatchesCanList(t *testing.T) {
 		}
 		server := httptest.NewServer(&handler)
 		defer server.Close()
-		client := clientset.NewForConfigOrDie(&restclient.Config{Host: server.URL, ContentConfig: restclient.ContentConfig{GroupVersion: &schema.GroupVersion{Group: "", Version: "v1"}}})
+		client := clientset.NewForConfigOrDie(&restclient.Config{Host: server.URL, APIPath: "/api", ContentConfig: restclient.ContentConfig{GroupVersion: &schema.GroupVersion{Group: "", Version: "v1"}}})
 		lw := NewListWatchFromClient(client.CoreV1().RESTClient(), item.resource, item.namespace, item.fieldSelector)
 		lw.DisableChunking = true
 		// This test merely tests that the correct request is made.
@@ -163,7 +163,7 @@ func TestListWatchesCanWatch(t *testing.T) {
 		}
 		server := httptest.NewServer(&handler)
 		defer server.Close()
-		client := clientset.NewForConfigOrDie(&restclient.Config{Host: server.URL, ContentConfig: restclient.ContentConfig{GroupVersion: &schema.GroupVersion{Group: "", Version: "v1"}}})
+		client := clientset.NewForConfigOrDie(&restclient.Config{Host: server.URL, APIPath: "/api", ContentConfig: restclient.ContentConfig{GroupVersion: &schema.GroupVersion{Group: "", Version: "v1"}}})
 		lw := NewListWatchFromClient(client.CoreV1().RESTClient(), item.resource, item.namespace, item.fieldSelector)
 		// This test merely tests that the correct request is made.
 		lw.Watch(metav1.ListOptions{ResourceVersion: item.rv})

--- a/pkg/controller/endpoint/endpoints_controller_test.go
+++ b/pkg/controller/endpoint/endpoints_controller_test.go
@@ -212,7 +212,7 @@ type endpointController struct {
 }
 
 func newController(url string, batchPeriod time.Duration) *endpointController {
-	client := clientset.NewForConfigOrDie(&restclient.Config{Host: url, ContentConfig: restclient.ContentConfig{GroupVersion: &schema.GroupVersion{Group: "", Version: "v1"}}})
+	client := clientset.NewForConfigOrDie(&restclient.Config{Host: url, APIPath: "/api", ContentConfig: restclient.ContentConfig{GroupVersion: &schema.GroupVersion{Group: "", Version: "v1"}}})
 	informerFactory := informers.NewSharedInformerFactory(client, controllerpkg.NoResyncPeriodFunc())
 	endpoints := NewEndpointController(informerFactory.Core().V1().Pods(), informerFactory.Core().V1().Services(),
 		informerFactory.Core().V1().Endpoints(), client, batchPeriod)

--- a/staging/src/k8s.io/apiextensions-apiserver/examples/client-go/pkg/client/clientset/versioned/typed/cr/v1/example.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/examples/client-go/pkg/client/clientset/versioned/typed/cr/v1/example.go
@@ -68,6 +68,7 @@ func (c *examples) Get(ctx context.Context, name string, options metav1.GetOptio
 	result = &v1.Example{}
 	err = c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("examples").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
@@ -85,6 +86,7 @@ func (c *examples) List(ctx context.Context, opts metav1.ListOptions) (result *v
 	result = &v1.ExampleList{}
 	err = c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("examples").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -102,6 +104,7 @@ func (c *examples) Watch(ctx context.Context, opts metav1.ListOptions) (watch.In
 	opts.Watch = true
 	return c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("examples").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -113,6 +116,7 @@ func (c *examples) Create(ctx context.Context, example *v1.Example, opts metav1.
 	result = &v1.Example{}
 	err = c.client.Post().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("examples").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Body(example).
@@ -126,6 +130,7 @@ func (c *examples) Update(ctx context.Context, example *v1.Example, opts metav1.
 	result = &v1.Example{}
 	err = c.client.Put().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("examples").
 		Name(example.Name).
 		VersionedParams(&opts, scheme.ParameterCodec).
@@ -139,6 +144,7 @@ func (c *examples) Update(ctx context.Context, example *v1.Example, opts metav1.
 func (c *examples) Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error {
 	return c.client.Delete().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("examples").
 		Name(name).
 		Body(&opts).
@@ -154,6 +160,7 @@ func (c *examples) DeleteCollection(ctx context.Context, opts metav1.DeleteOptio
 	}
 	return c.client.Delete().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("examples").
 		VersionedParams(&listOpts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -167,6 +174,7 @@ func (c *examples) Patch(ctx context.Context, name string, pt types.PatchType, d
 	result = &v1.Example{}
 	err = c.client.Patch(pt).
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("examples").
 		Name(name).
 		SubResource(subresources...).

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1/customresourcedefinition.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1/customresourcedefinition.go
@@ -66,6 +66,7 @@ func newCustomResourceDefinitions(c *ApiextensionsV1Client) *customResourceDefin
 func (c *customResourceDefinitions) Get(ctx context.Context, name string, options metav1.GetOptions) (result *v1.CustomResourceDefinition, err error) {
 	result = &v1.CustomResourceDefinition{}
 	err = c.client.Get().
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("customresourcedefinitions").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
@@ -82,6 +83,7 @@ func (c *customResourceDefinitions) List(ctx context.Context, opts metav1.ListOp
 	}
 	result = &v1.CustomResourceDefinitionList{}
 	err = c.client.Get().
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("customresourcedefinitions").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -98,6 +100,7 @@ func (c *customResourceDefinitions) Watch(ctx context.Context, opts metav1.ListO
 	}
 	opts.Watch = true
 	return c.client.Get().
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("customresourcedefinitions").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -108,6 +111,7 @@ func (c *customResourceDefinitions) Watch(ctx context.Context, opts metav1.ListO
 func (c *customResourceDefinitions) Create(ctx context.Context, customResourceDefinition *v1.CustomResourceDefinition, opts metav1.CreateOptions) (result *v1.CustomResourceDefinition, err error) {
 	result = &v1.CustomResourceDefinition{}
 	err = c.client.Post().
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("customresourcedefinitions").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Body(customResourceDefinition).
@@ -120,6 +124,7 @@ func (c *customResourceDefinitions) Create(ctx context.Context, customResourceDe
 func (c *customResourceDefinitions) Update(ctx context.Context, customResourceDefinition *v1.CustomResourceDefinition, opts metav1.UpdateOptions) (result *v1.CustomResourceDefinition, err error) {
 	result = &v1.CustomResourceDefinition{}
 	err = c.client.Put().
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("customresourcedefinitions").
 		Name(customResourceDefinition.Name).
 		VersionedParams(&opts, scheme.ParameterCodec).
@@ -134,6 +139,7 @@ func (c *customResourceDefinitions) Update(ctx context.Context, customResourceDe
 func (c *customResourceDefinitions) UpdateStatus(ctx context.Context, customResourceDefinition *v1.CustomResourceDefinition, opts metav1.UpdateOptions) (result *v1.CustomResourceDefinition, err error) {
 	result = &v1.CustomResourceDefinition{}
 	err = c.client.Put().
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("customresourcedefinitions").
 		Name(customResourceDefinition.Name).
 		SubResource("status").
@@ -147,6 +153,7 @@ func (c *customResourceDefinitions) UpdateStatus(ctx context.Context, customReso
 // Delete takes name of the customResourceDefinition and deletes it. Returns an error if one occurs.
 func (c *customResourceDefinitions) Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error {
 	return c.client.Delete().
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("customresourcedefinitions").
 		Name(name).
 		Body(&opts).
@@ -161,6 +168,7 @@ func (c *customResourceDefinitions) DeleteCollection(ctx context.Context, opts m
 		timeout = time.Duration(*listOpts.TimeoutSeconds) * time.Second
 	}
 	return c.client.Delete().
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("customresourcedefinitions").
 		VersionedParams(&listOpts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -173,6 +181,7 @@ func (c *customResourceDefinitions) DeleteCollection(ctx context.Context, opts m
 func (c *customResourceDefinitions) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts metav1.PatchOptions, subresources ...string) (result *v1.CustomResourceDefinition, err error) {
 	result = &v1.CustomResourceDefinition{}
 	err = c.client.Patch(pt).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("customresourcedefinitions").
 		Name(name).
 		SubResource(subresources...).

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1beta1/customresourcedefinition.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1beta1/customresourcedefinition.go
@@ -66,6 +66,7 @@ func newCustomResourceDefinitions(c *ApiextensionsV1beta1Client) *customResource
 func (c *customResourceDefinitions) Get(ctx context.Context, name string, options v1.GetOptions) (result *v1beta1.CustomResourceDefinition, err error) {
 	result = &v1beta1.CustomResourceDefinition{}
 	err = c.client.Get().
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("customresourcedefinitions").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
@@ -82,6 +83,7 @@ func (c *customResourceDefinitions) List(ctx context.Context, opts v1.ListOption
 	}
 	result = &v1beta1.CustomResourceDefinitionList{}
 	err = c.client.Get().
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("customresourcedefinitions").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -98,6 +100,7 @@ func (c *customResourceDefinitions) Watch(ctx context.Context, opts v1.ListOptio
 	}
 	opts.Watch = true
 	return c.client.Get().
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("customresourcedefinitions").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -108,6 +111,7 @@ func (c *customResourceDefinitions) Watch(ctx context.Context, opts v1.ListOptio
 func (c *customResourceDefinitions) Create(ctx context.Context, customResourceDefinition *v1beta1.CustomResourceDefinition, opts v1.CreateOptions) (result *v1beta1.CustomResourceDefinition, err error) {
 	result = &v1beta1.CustomResourceDefinition{}
 	err = c.client.Post().
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("customresourcedefinitions").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Body(customResourceDefinition).
@@ -120,6 +124,7 @@ func (c *customResourceDefinitions) Create(ctx context.Context, customResourceDe
 func (c *customResourceDefinitions) Update(ctx context.Context, customResourceDefinition *v1beta1.CustomResourceDefinition, opts v1.UpdateOptions) (result *v1beta1.CustomResourceDefinition, err error) {
 	result = &v1beta1.CustomResourceDefinition{}
 	err = c.client.Put().
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("customresourcedefinitions").
 		Name(customResourceDefinition.Name).
 		VersionedParams(&opts, scheme.ParameterCodec).
@@ -134,6 +139,7 @@ func (c *customResourceDefinitions) Update(ctx context.Context, customResourceDe
 func (c *customResourceDefinitions) UpdateStatus(ctx context.Context, customResourceDefinition *v1beta1.CustomResourceDefinition, opts v1.UpdateOptions) (result *v1beta1.CustomResourceDefinition, err error) {
 	result = &v1beta1.CustomResourceDefinition{}
 	err = c.client.Put().
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("customresourcedefinitions").
 		Name(customResourceDefinition.Name).
 		SubResource("status").
@@ -147,6 +153,7 @@ func (c *customResourceDefinitions) UpdateStatus(ctx context.Context, customReso
 // Delete takes name of the customResourceDefinition and deletes it. Returns an error if one occurs.
 func (c *customResourceDefinitions) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
 	return c.client.Delete().
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("customresourcedefinitions").
 		Name(name).
 		Body(&opts).
@@ -161,6 +168,7 @@ func (c *customResourceDefinitions) DeleteCollection(ctx context.Context, opts v
 		timeout = time.Duration(*listOpts.TimeoutSeconds) * time.Second
 	}
 	return c.client.Delete().
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("customresourcedefinitions").
 		VersionedParams(&listOpts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -173,6 +181,7 @@ func (c *customResourceDefinitions) DeleteCollection(ctx context.Context, opts v
 func (c *customResourceDefinitions) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts v1.PatchOptions, subresources ...string) (result *v1beta1.CustomResourceDefinition, err error) {
 	result = &v1beta1.CustomResourceDefinition{}
 	err = c.client.Patch(pt).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("customresourcedefinitions").
 		Name(name).
 		SubResource(subresources...).

--- a/staging/src/k8s.io/client-go/kubernetes/clientset.go
+++ b/staging/src/k8s.io/client-go/kubernetes/clientset.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 
 	discovery "k8s.io/client-go/discovery"
+	"k8s.io/client-go/kubernetes/scheme"
 	admissionregistrationv1 "k8s.io/client-go/kubernetes/typed/admissionregistration/v1"
 	admissionregistrationv1beta1 "k8s.io/client-go/kubernetes/typed/admissionregistration/v1beta1"
 	internalv1alpha1 "k8s.io/client-go/kubernetes/typed/apiserverinternal/v1alpha1"
@@ -407,184 +408,63 @@ func NewForConfig(c *rest.Config) (*Clientset, error) {
 		}
 		configShallowCopy.RateLimiter = flowcontrol.NewTokenBucketRateLimiter(configShallowCopy.QPS, configShallowCopy.Burst)
 	}
+
+	configShallowCopy.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
+
+	if configShallowCopy.UserAgent == "" {
+		configShallowCopy.UserAgent = rest.DefaultKubernetesUserAgent()
+	}
+
+	restClient, err := rest.RESTClientFor(&configShallowCopy)
+	if err != nil {
+		return nil, err
+	}
+
 	var cs Clientset
-	var err error
-	cs.admissionregistrationV1, err = admissionregistrationv1.NewForConfig(&configShallowCopy)
-	if err != nil {
-		return nil, err
-	}
-	cs.admissionregistrationV1beta1, err = admissionregistrationv1beta1.NewForConfig(&configShallowCopy)
-	if err != nil {
-		return nil, err
-	}
-	cs.internalV1alpha1, err = internalv1alpha1.NewForConfig(&configShallowCopy)
-	if err != nil {
-		return nil, err
-	}
-	cs.appsV1, err = appsv1.NewForConfig(&configShallowCopy)
-	if err != nil {
-		return nil, err
-	}
-	cs.appsV1beta1, err = appsv1beta1.NewForConfig(&configShallowCopy)
-	if err != nil {
-		return nil, err
-	}
-	cs.appsV1beta2, err = appsv1beta2.NewForConfig(&configShallowCopy)
-	if err != nil {
-		return nil, err
-	}
-	cs.authenticationV1, err = authenticationv1.NewForConfig(&configShallowCopy)
-	if err != nil {
-		return nil, err
-	}
-	cs.authenticationV1beta1, err = authenticationv1beta1.NewForConfig(&configShallowCopy)
-	if err != nil {
-		return nil, err
-	}
-	cs.authorizationV1, err = authorizationv1.NewForConfig(&configShallowCopy)
-	if err != nil {
-		return nil, err
-	}
-	cs.authorizationV1beta1, err = authorizationv1beta1.NewForConfig(&configShallowCopy)
-	if err != nil {
-		return nil, err
-	}
-	cs.autoscalingV1, err = autoscalingv1.NewForConfig(&configShallowCopy)
-	if err != nil {
-		return nil, err
-	}
-	cs.autoscalingV2beta1, err = autoscalingv2beta1.NewForConfig(&configShallowCopy)
-	if err != nil {
-		return nil, err
-	}
-	cs.autoscalingV2beta2, err = autoscalingv2beta2.NewForConfig(&configShallowCopy)
-	if err != nil {
-		return nil, err
-	}
-	cs.batchV1, err = batchv1.NewForConfig(&configShallowCopy)
-	if err != nil {
-		return nil, err
-	}
-	cs.batchV1beta1, err = batchv1beta1.NewForConfig(&configShallowCopy)
-	if err != nil {
-		return nil, err
-	}
-	cs.certificatesV1, err = certificatesv1.NewForConfig(&configShallowCopy)
-	if err != nil {
-		return nil, err
-	}
-	cs.certificatesV1beta1, err = certificatesv1beta1.NewForConfig(&configShallowCopy)
-	if err != nil {
-		return nil, err
-	}
-	cs.coordinationV1beta1, err = coordinationv1beta1.NewForConfig(&configShallowCopy)
-	if err != nil {
-		return nil, err
-	}
-	cs.coordinationV1, err = coordinationv1.NewForConfig(&configShallowCopy)
-	if err != nil {
-		return nil, err
-	}
-	cs.coreV1, err = corev1.NewForConfig(&configShallowCopy)
-	if err != nil {
-		return nil, err
-	}
-	cs.discoveryV1, err = discoveryv1.NewForConfig(&configShallowCopy)
-	if err != nil {
-		return nil, err
-	}
-	cs.discoveryV1beta1, err = discoveryv1beta1.NewForConfig(&configShallowCopy)
-	if err != nil {
-		return nil, err
-	}
-	cs.eventsV1, err = eventsv1.NewForConfig(&configShallowCopy)
-	if err != nil {
-		return nil, err
-	}
-	cs.eventsV1beta1, err = eventsv1beta1.NewForConfig(&configShallowCopy)
-	if err != nil {
-		return nil, err
-	}
-	cs.extensionsV1beta1, err = extensionsv1beta1.NewForConfig(&configShallowCopy)
-	if err != nil {
-		return nil, err
-	}
-	cs.flowcontrolV1alpha1, err = flowcontrolv1alpha1.NewForConfig(&configShallowCopy)
-	if err != nil {
-		return nil, err
-	}
-	cs.flowcontrolV1beta1, err = flowcontrolv1beta1.NewForConfig(&configShallowCopy)
-	if err != nil {
-		return nil, err
-	}
-	cs.flowcontrolV1beta2, err = flowcontrolv1beta2.NewForConfig(&configShallowCopy)
-	if err != nil {
-		return nil, err
-	}
-	cs.networkingV1, err = networkingv1.NewForConfig(&configShallowCopy)
-	if err != nil {
-		return nil, err
-	}
-	cs.networkingV1beta1, err = networkingv1beta1.NewForConfig(&configShallowCopy)
-	if err != nil {
-		return nil, err
-	}
-	cs.nodeV1, err = nodev1.NewForConfig(&configShallowCopy)
-	if err != nil {
-		return nil, err
-	}
-	cs.nodeV1alpha1, err = nodev1alpha1.NewForConfig(&configShallowCopy)
-	if err != nil {
-		return nil, err
-	}
-	cs.nodeV1beta1, err = nodev1beta1.NewForConfig(&configShallowCopy)
-	if err != nil {
-		return nil, err
-	}
-	cs.policyV1, err = policyv1.NewForConfig(&configShallowCopy)
-	if err != nil {
-		return nil, err
-	}
-	cs.policyV1beta1, err = policyv1beta1.NewForConfig(&configShallowCopy)
-	if err != nil {
-		return nil, err
-	}
-	cs.rbacV1, err = rbacv1.NewForConfig(&configShallowCopy)
-	if err != nil {
-		return nil, err
-	}
-	cs.rbacV1beta1, err = rbacv1beta1.NewForConfig(&configShallowCopy)
-	if err != nil {
-		return nil, err
-	}
-	cs.rbacV1alpha1, err = rbacv1alpha1.NewForConfig(&configShallowCopy)
-	if err != nil {
-		return nil, err
-	}
-	cs.schedulingV1alpha1, err = schedulingv1alpha1.NewForConfig(&configShallowCopy)
-	if err != nil {
-		return nil, err
-	}
-	cs.schedulingV1beta1, err = schedulingv1beta1.NewForConfig(&configShallowCopy)
-	if err != nil {
-		return nil, err
-	}
-	cs.schedulingV1, err = schedulingv1.NewForConfig(&configShallowCopy)
-	if err != nil {
-		return nil, err
-	}
-	cs.storageV1beta1, err = storagev1beta1.NewForConfig(&configShallowCopy)
-	if err != nil {
-		return nil, err
-	}
-	cs.storageV1, err = storagev1.NewForConfig(&configShallowCopy)
-	if err != nil {
-		return nil, err
-	}
-	cs.storageV1alpha1, err = storagev1alpha1.NewForConfig(&configShallowCopy)
-	if err != nil {
-		return nil, err
-	}
+	cs.admissionregistrationV1 = admissionregistrationv1.New(restClient)
+	cs.admissionregistrationV1beta1 = admissionregistrationv1beta1.New(restClient)
+	cs.internalV1alpha1 = internalv1alpha1.New(restClient)
+	cs.appsV1 = appsv1.New(restClient)
+	cs.appsV1beta1 = appsv1beta1.New(restClient)
+	cs.appsV1beta2 = appsv1beta2.New(restClient)
+	cs.authenticationV1 = authenticationv1.New(restClient)
+	cs.authenticationV1beta1 = authenticationv1beta1.New(restClient)
+	cs.authorizationV1 = authorizationv1.New(restClient)
+	cs.authorizationV1beta1 = authorizationv1beta1.New(restClient)
+	cs.autoscalingV1 = autoscalingv1.New(restClient)
+	cs.autoscalingV2beta1 = autoscalingv2beta1.New(restClient)
+	cs.autoscalingV2beta2 = autoscalingv2beta2.New(restClient)
+	cs.batchV1 = batchv1.New(restClient)
+	cs.batchV1beta1 = batchv1beta1.New(restClient)
+	cs.certificatesV1 = certificatesv1.New(restClient)
+	cs.certificatesV1beta1 = certificatesv1beta1.New(restClient)
+	cs.coordinationV1beta1 = coordinationv1beta1.New(restClient)
+	cs.coordinationV1 = coordinationv1.New(restClient)
+	cs.coreV1 = corev1.New(restClient)
+	cs.discoveryV1 = discoveryv1.New(restClient)
+	cs.discoveryV1beta1 = discoveryv1beta1.New(restClient)
+	cs.eventsV1 = eventsv1.New(restClient)
+	cs.eventsV1beta1 = eventsv1beta1.New(restClient)
+	cs.extensionsV1beta1 = extensionsv1beta1.New(restClient)
+	cs.flowcontrolV1alpha1 = flowcontrolv1alpha1.New(restClient)
+	cs.flowcontrolV1beta1 = flowcontrolv1beta1.New(restClient)
+	cs.flowcontrolV1beta2 = flowcontrolv1beta2.New(restClient)
+	cs.networkingV1 = networkingv1.New(restClient)
+	cs.networkingV1beta1 = networkingv1beta1.New(restClient)
+	cs.nodeV1 = nodev1.New(restClient)
+	cs.nodeV1alpha1 = nodev1alpha1.New(restClient)
+	cs.nodeV1beta1 = nodev1beta1.New(restClient)
+	cs.policyV1 = policyv1.New(restClient)
+	cs.policyV1beta1 = policyv1beta1.New(restClient)
+	cs.rbacV1 = rbacv1.New(restClient)
+	cs.rbacV1beta1 = rbacv1beta1.New(restClient)
+	cs.rbacV1alpha1 = rbacv1alpha1.New(restClient)
+	cs.schedulingV1alpha1 = schedulingv1alpha1.New(restClient)
+	cs.schedulingV1beta1 = schedulingv1beta1.New(restClient)
+	cs.schedulingV1 = schedulingv1.New(restClient)
+	cs.storageV1beta1 = storagev1beta1.New(restClient)
+	cs.storageV1 = storagev1.New(restClient)
+	cs.storageV1alpha1 = storagev1alpha1.New(restClient)
 
 	cs.DiscoveryClient, err = discovery.NewDiscoveryClientForConfig(&configShallowCopy)
 	if err != nil {
@@ -596,54 +476,11 @@ func NewForConfig(c *rest.Config) (*Clientset, error) {
 // NewForConfigOrDie creates a new Clientset for the given config and
 // panics if there is an error in the config.
 func NewForConfigOrDie(c *rest.Config) *Clientset {
-	var cs Clientset
-	cs.admissionregistrationV1 = admissionregistrationv1.NewForConfigOrDie(c)
-	cs.admissionregistrationV1beta1 = admissionregistrationv1beta1.NewForConfigOrDie(c)
-	cs.internalV1alpha1 = internalv1alpha1.NewForConfigOrDie(c)
-	cs.appsV1 = appsv1.NewForConfigOrDie(c)
-	cs.appsV1beta1 = appsv1beta1.NewForConfigOrDie(c)
-	cs.appsV1beta2 = appsv1beta2.NewForConfigOrDie(c)
-	cs.authenticationV1 = authenticationv1.NewForConfigOrDie(c)
-	cs.authenticationV1beta1 = authenticationv1beta1.NewForConfigOrDie(c)
-	cs.authorizationV1 = authorizationv1.NewForConfigOrDie(c)
-	cs.authorizationV1beta1 = authorizationv1beta1.NewForConfigOrDie(c)
-	cs.autoscalingV1 = autoscalingv1.NewForConfigOrDie(c)
-	cs.autoscalingV2beta1 = autoscalingv2beta1.NewForConfigOrDie(c)
-	cs.autoscalingV2beta2 = autoscalingv2beta2.NewForConfigOrDie(c)
-	cs.batchV1 = batchv1.NewForConfigOrDie(c)
-	cs.batchV1beta1 = batchv1beta1.NewForConfigOrDie(c)
-	cs.certificatesV1 = certificatesv1.NewForConfigOrDie(c)
-	cs.certificatesV1beta1 = certificatesv1beta1.NewForConfigOrDie(c)
-	cs.coordinationV1beta1 = coordinationv1beta1.NewForConfigOrDie(c)
-	cs.coordinationV1 = coordinationv1.NewForConfigOrDie(c)
-	cs.coreV1 = corev1.NewForConfigOrDie(c)
-	cs.discoveryV1 = discoveryv1.NewForConfigOrDie(c)
-	cs.discoveryV1beta1 = discoveryv1beta1.NewForConfigOrDie(c)
-	cs.eventsV1 = eventsv1.NewForConfigOrDie(c)
-	cs.eventsV1beta1 = eventsv1beta1.NewForConfigOrDie(c)
-	cs.extensionsV1beta1 = extensionsv1beta1.NewForConfigOrDie(c)
-	cs.flowcontrolV1alpha1 = flowcontrolv1alpha1.NewForConfigOrDie(c)
-	cs.flowcontrolV1beta1 = flowcontrolv1beta1.NewForConfigOrDie(c)
-	cs.flowcontrolV1beta2 = flowcontrolv1beta2.NewForConfigOrDie(c)
-	cs.networkingV1 = networkingv1.NewForConfigOrDie(c)
-	cs.networkingV1beta1 = networkingv1beta1.NewForConfigOrDie(c)
-	cs.nodeV1 = nodev1.NewForConfigOrDie(c)
-	cs.nodeV1alpha1 = nodev1alpha1.NewForConfigOrDie(c)
-	cs.nodeV1beta1 = nodev1beta1.NewForConfigOrDie(c)
-	cs.policyV1 = policyv1.NewForConfigOrDie(c)
-	cs.policyV1beta1 = policyv1beta1.NewForConfigOrDie(c)
-	cs.rbacV1 = rbacv1.NewForConfigOrDie(c)
-	cs.rbacV1beta1 = rbacv1beta1.NewForConfigOrDie(c)
-	cs.rbacV1alpha1 = rbacv1alpha1.NewForConfigOrDie(c)
-	cs.schedulingV1alpha1 = schedulingv1alpha1.NewForConfigOrDie(c)
-	cs.schedulingV1beta1 = schedulingv1beta1.NewForConfigOrDie(c)
-	cs.schedulingV1 = schedulingv1.NewForConfigOrDie(c)
-	cs.storageV1beta1 = storagev1beta1.NewForConfigOrDie(c)
-	cs.storageV1 = storagev1.NewForConfigOrDie(c)
-	cs.storageV1alpha1 = storagev1alpha1.NewForConfigOrDie(c)
-
-	cs.DiscoveryClient = discovery.NewDiscoveryClientForConfigOrDie(c)
-	return &cs
+	cs, err := NewForConfig(c)
+	if err != nil {
+		panic(err)
+	}
+	return cs
 }
 
 // New creates a new Clientset for the given RESTClient.

--- a/staging/src/k8s.io/client-go/kubernetes/typed/admissionregistration/v1/mutatingwebhookconfiguration.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/admissionregistration/v1/mutatingwebhookconfiguration.go
@@ -69,6 +69,7 @@ func newMutatingWebhookConfigurations(c *AdmissionregistrationV1Client) *mutatin
 func (c *mutatingWebhookConfigurations) Get(ctx context.Context, name string, options metav1.GetOptions) (result *v1.MutatingWebhookConfiguration, err error) {
 	result = &v1.MutatingWebhookConfiguration{}
 	err = c.client.Get().
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("mutatingwebhookconfigurations").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
@@ -85,6 +86,7 @@ func (c *mutatingWebhookConfigurations) List(ctx context.Context, opts metav1.Li
 	}
 	result = &v1.MutatingWebhookConfigurationList{}
 	err = c.client.Get().
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("mutatingwebhookconfigurations").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -101,6 +103,7 @@ func (c *mutatingWebhookConfigurations) Watch(ctx context.Context, opts metav1.L
 	}
 	opts.Watch = true
 	return c.client.Get().
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("mutatingwebhookconfigurations").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -111,6 +114,7 @@ func (c *mutatingWebhookConfigurations) Watch(ctx context.Context, opts metav1.L
 func (c *mutatingWebhookConfigurations) Create(ctx context.Context, mutatingWebhookConfiguration *v1.MutatingWebhookConfiguration, opts metav1.CreateOptions) (result *v1.MutatingWebhookConfiguration, err error) {
 	result = &v1.MutatingWebhookConfiguration{}
 	err = c.client.Post().
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("mutatingwebhookconfigurations").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Body(mutatingWebhookConfiguration).
@@ -123,6 +127,7 @@ func (c *mutatingWebhookConfigurations) Create(ctx context.Context, mutatingWebh
 func (c *mutatingWebhookConfigurations) Update(ctx context.Context, mutatingWebhookConfiguration *v1.MutatingWebhookConfiguration, opts metav1.UpdateOptions) (result *v1.MutatingWebhookConfiguration, err error) {
 	result = &v1.MutatingWebhookConfiguration{}
 	err = c.client.Put().
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("mutatingwebhookconfigurations").
 		Name(mutatingWebhookConfiguration.Name).
 		VersionedParams(&opts, scheme.ParameterCodec).
@@ -135,6 +140,7 @@ func (c *mutatingWebhookConfigurations) Update(ctx context.Context, mutatingWebh
 // Delete takes name of the mutatingWebhookConfiguration and deletes it. Returns an error if one occurs.
 func (c *mutatingWebhookConfigurations) Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error {
 	return c.client.Delete().
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("mutatingwebhookconfigurations").
 		Name(name).
 		Body(&opts).
@@ -149,6 +155,7 @@ func (c *mutatingWebhookConfigurations) DeleteCollection(ctx context.Context, op
 		timeout = time.Duration(*listOpts.TimeoutSeconds) * time.Second
 	}
 	return c.client.Delete().
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("mutatingwebhookconfigurations").
 		VersionedParams(&listOpts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -161,6 +168,7 @@ func (c *mutatingWebhookConfigurations) DeleteCollection(ctx context.Context, op
 func (c *mutatingWebhookConfigurations) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts metav1.PatchOptions, subresources ...string) (result *v1.MutatingWebhookConfiguration, err error) {
 	result = &v1.MutatingWebhookConfiguration{}
 	err = c.client.Patch(pt).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("mutatingwebhookconfigurations").
 		Name(name).
 		SubResource(subresources...).
@@ -187,6 +195,7 @@ func (c *mutatingWebhookConfigurations) Apply(ctx context.Context, mutatingWebho
 	}
 	result = &v1.MutatingWebhookConfiguration{}
 	err = c.client.Patch(types.ApplyPatchType).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("mutatingwebhookconfigurations").
 		Name(*name).
 		VersionedParams(&patchOpts, scheme.ParameterCodec).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/admissionregistration/v1/validatingwebhookconfiguration.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/admissionregistration/v1/validatingwebhookconfiguration.go
@@ -69,6 +69,7 @@ func newValidatingWebhookConfigurations(c *AdmissionregistrationV1Client) *valid
 func (c *validatingWebhookConfigurations) Get(ctx context.Context, name string, options metav1.GetOptions) (result *v1.ValidatingWebhookConfiguration, err error) {
 	result = &v1.ValidatingWebhookConfiguration{}
 	err = c.client.Get().
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("validatingwebhookconfigurations").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
@@ -85,6 +86,7 @@ func (c *validatingWebhookConfigurations) List(ctx context.Context, opts metav1.
 	}
 	result = &v1.ValidatingWebhookConfigurationList{}
 	err = c.client.Get().
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("validatingwebhookconfigurations").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -101,6 +103,7 @@ func (c *validatingWebhookConfigurations) Watch(ctx context.Context, opts metav1
 	}
 	opts.Watch = true
 	return c.client.Get().
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("validatingwebhookconfigurations").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -111,6 +114,7 @@ func (c *validatingWebhookConfigurations) Watch(ctx context.Context, opts metav1
 func (c *validatingWebhookConfigurations) Create(ctx context.Context, validatingWebhookConfiguration *v1.ValidatingWebhookConfiguration, opts metav1.CreateOptions) (result *v1.ValidatingWebhookConfiguration, err error) {
 	result = &v1.ValidatingWebhookConfiguration{}
 	err = c.client.Post().
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("validatingwebhookconfigurations").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Body(validatingWebhookConfiguration).
@@ -123,6 +127,7 @@ func (c *validatingWebhookConfigurations) Create(ctx context.Context, validating
 func (c *validatingWebhookConfigurations) Update(ctx context.Context, validatingWebhookConfiguration *v1.ValidatingWebhookConfiguration, opts metav1.UpdateOptions) (result *v1.ValidatingWebhookConfiguration, err error) {
 	result = &v1.ValidatingWebhookConfiguration{}
 	err = c.client.Put().
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("validatingwebhookconfigurations").
 		Name(validatingWebhookConfiguration.Name).
 		VersionedParams(&opts, scheme.ParameterCodec).
@@ -135,6 +140,7 @@ func (c *validatingWebhookConfigurations) Update(ctx context.Context, validating
 // Delete takes name of the validatingWebhookConfiguration and deletes it. Returns an error if one occurs.
 func (c *validatingWebhookConfigurations) Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error {
 	return c.client.Delete().
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("validatingwebhookconfigurations").
 		Name(name).
 		Body(&opts).
@@ -149,6 +155,7 @@ func (c *validatingWebhookConfigurations) DeleteCollection(ctx context.Context, 
 		timeout = time.Duration(*listOpts.TimeoutSeconds) * time.Second
 	}
 	return c.client.Delete().
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("validatingwebhookconfigurations").
 		VersionedParams(&listOpts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -161,6 +168,7 @@ func (c *validatingWebhookConfigurations) DeleteCollection(ctx context.Context, 
 func (c *validatingWebhookConfigurations) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts metav1.PatchOptions, subresources ...string) (result *v1.ValidatingWebhookConfiguration, err error) {
 	result = &v1.ValidatingWebhookConfiguration{}
 	err = c.client.Patch(pt).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("validatingwebhookconfigurations").
 		Name(name).
 		SubResource(subresources...).
@@ -187,6 +195,7 @@ func (c *validatingWebhookConfigurations) Apply(ctx context.Context, validatingW
 	}
 	result = &v1.ValidatingWebhookConfiguration{}
 	err = c.client.Patch(types.ApplyPatchType).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("validatingwebhookconfigurations").
 		Name(*name).
 		VersionedParams(&patchOpts, scheme.ParameterCodec).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/admissionregistration/v1beta1/mutatingwebhookconfiguration.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/admissionregistration/v1beta1/mutatingwebhookconfiguration.go
@@ -69,6 +69,7 @@ func newMutatingWebhookConfigurations(c *AdmissionregistrationV1beta1Client) *mu
 func (c *mutatingWebhookConfigurations) Get(ctx context.Context, name string, options v1.GetOptions) (result *v1beta1.MutatingWebhookConfiguration, err error) {
 	result = &v1beta1.MutatingWebhookConfiguration{}
 	err = c.client.Get().
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("mutatingwebhookconfigurations").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
@@ -85,6 +86,7 @@ func (c *mutatingWebhookConfigurations) List(ctx context.Context, opts v1.ListOp
 	}
 	result = &v1beta1.MutatingWebhookConfigurationList{}
 	err = c.client.Get().
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("mutatingwebhookconfigurations").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -101,6 +103,7 @@ func (c *mutatingWebhookConfigurations) Watch(ctx context.Context, opts v1.ListO
 	}
 	opts.Watch = true
 	return c.client.Get().
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("mutatingwebhookconfigurations").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -111,6 +114,7 @@ func (c *mutatingWebhookConfigurations) Watch(ctx context.Context, opts v1.ListO
 func (c *mutatingWebhookConfigurations) Create(ctx context.Context, mutatingWebhookConfiguration *v1beta1.MutatingWebhookConfiguration, opts v1.CreateOptions) (result *v1beta1.MutatingWebhookConfiguration, err error) {
 	result = &v1beta1.MutatingWebhookConfiguration{}
 	err = c.client.Post().
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("mutatingwebhookconfigurations").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Body(mutatingWebhookConfiguration).
@@ -123,6 +127,7 @@ func (c *mutatingWebhookConfigurations) Create(ctx context.Context, mutatingWebh
 func (c *mutatingWebhookConfigurations) Update(ctx context.Context, mutatingWebhookConfiguration *v1beta1.MutatingWebhookConfiguration, opts v1.UpdateOptions) (result *v1beta1.MutatingWebhookConfiguration, err error) {
 	result = &v1beta1.MutatingWebhookConfiguration{}
 	err = c.client.Put().
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("mutatingwebhookconfigurations").
 		Name(mutatingWebhookConfiguration.Name).
 		VersionedParams(&opts, scheme.ParameterCodec).
@@ -135,6 +140,7 @@ func (c *mutatingWebhookConfigurations) Update(ctx context.Context, mutatingWebh
 // Delete takes name of the mutatingWebhookConfiguration and deletes it. Returns an error if one occurs.
 func (c *mutatingWebhookConfigurations) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
 	return c.client.Delete().
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("mutatingwebhookconfigurations").
 		Name(name).
 		Body(&opts).
@@ -149,6 +155,7 @@ func (c *mutatingWebhookConfigurations) DeleteCollection(ctx context.Context, op
 		timeout = time.Duration(*listOpts.TimeoutSeconds) * time.Second
 	}
 	return c.client.Delete().
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("mutatingwebhookconfigurations").
 		VersionedParams(&listOpts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -161,6 +168,7 @@ func (c *mutatingWebhookConfigurations) DeleteCollection(ctx context.Context, op
 func (c *mutatingWebhookConfigurations) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts v1.PatchOptions, subresources ...string) (result *v1beta1.MutatingWebhookConfiguration, err error) {
 	result = &v1beta1.MutatingWebhookConfiguration{}
 	err = c.client.Patch(pt).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("mutatingwebhookconfigurations").
 		Name(name).
 		SubResource(subresources...).
@@ -187,6 +195,7 @@ func (c *mutatingWebhookConfigurations) Apply(ctx context.Context, mutatingWebho
 	}
 	result = &v1beta1.MutatingWebhookConfiguration{}
 	err = c.client.Patch(types.ApplyPatchType).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("mutatingwebhookconfigurations").
 		Name(*name).
 		VersionedParams(&patchOpts, scheme.ParameterCodec).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/admissionregistration/v1beta1/validatingwebhookconfiguration.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/admissionregistration/v1beta1/validatingwebhookconfiguration.go
@@ -69,6 +69,7 @@ func newValidatingWebhookConfigurations(c *AdmissionregistrationV1beta1Client) *
 func (c *validatingWebhookConfigurations) Get(ctx context.Context, name string, options v1.GetOptions) (result *v1beta1.ValidatingWebhookConfiguration, err error) {
 	result = &v1beta1.ValidatingWebhookConfiguration{}
 	err = c.client.Get().
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("validatingwebhookconfigurations").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
@@ -85,6 +86,7 @@ func (c *validatingWebhookConfigurations) List(ctx context.Context, opts v1.List
 	}
 	result = &v1beta1.ValidatingWebhookConfigurationList{}
 	err = c.client.Get().
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("validatingwebhookconfigurations").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -101,6 +103,7 @@ func (c *validatingWebhookConfigurations) Watch(ctx context.Context, opts v1.Lis
 	}
 	opts.Watch = true
 	return c.client.Get().
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("validatingwebhookconfigurations").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -111,6 +114,7 @@ func (c *validatingWebhookConfigurations) Watch(ctx context.Context, opts v1.Lis
 func (c *validatingWebhookConfigurations) Create(ctx context.Context, validatingWebhookConfiguration *v1beta1.ValidatingWebhookConfiguration, opts v1.CreateOptions) (result *v1beta1.ValidatingWebhookConfiguration, err error) {
 	result = &v1beta1.ValidatingWebhookConfiguration{}
 	err = c.client.Post().
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("validatingwebhookconfigurations").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Body(validatingWebhookConfiguration).
@@ -123,6 +127,7 @@ func (c *validatingWebhookConfigurations) Create(ctx context.Context, validating
 func (c *validatingWebhookConfigurations) Update(ctx context.Context, validatingWebhookConfiguration *v1beta1.ValidatingWebhookConfiguration, opts v1.UpdateOptions) (result *v1beta1.ValidatingWebhookConfiguration, err error) {
 	result = &v1beta1.ValidatingWebhookConfiguration{}
 	err = c.client.Put().
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("validatingwebhookconfigurations").
 		Name(validatingWebhookConfiguration.Name).
 		VersionedParams(&opts, scheme.ParameterCodec).
@@ -135,6 +140,7 @@ func (c *validatingWebhookConfigurations) Update(ctx context.Context, validating
 // Delete takes name of the validatingWebhookConfiguration and deletes it. Returns an error if one occurs.
 func (c *validatingWebhookConfigurations) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
 	return c.client.Delete().
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("validatingwebhookconfigurations").
 		Name(name).
 		Body(&opts).
@@ -149,6 +155,7 @@ func (c *validatingWebhookConfigurations) DeleteCollection(ctx context.Context, 
 		timeout = time.Duration(*listOpts.TimeoutSeconds) * time.Second
 	}
 	return c.client.Delete().
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("validatingwebhookconfigurations").
 		VersionedParams(&listOpts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -161,6 +168,7 @@ func (c *validatingWebhookConfigurations) DeleteCollection(ctx context.Context, 
 func (c *validatingWebhookConfigurations) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts v1.PatchOptions, subresources ...string) (result *v1beta1.ValidatingWebhookConfiguration, err error) {
 	result = &v1beta1.ValidatingWebhookConfiguration{}
 	err = c.client.Patch(pt).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("validatingwebhookconfigurations").
 		Name(name).
 		SubResource(subresources...).
@@ -187,6 +195,7 @@ func (c *validatingWebhookConfigurations) Apply(ctx context.Context, validatingW
 	}
 	result = &v1beta1.ValidatingWebhookConfiguration{}
 	err = c.client.Patch(types.ApplyPatchType).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("validatingwebhookconfigurations").
 		Name(*name).
 		VersionedParams(&patchOpts, scheme.ParameterCodec).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/apiserverinternal/v1alpha1/storageversion.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/apiserverinternal/v1alpha1/storageversion.go
@@ -71,6 +71,7 @@ func newStorageVersions(c *InternalV1alpha1Client) *storageVersions {
 func (c *storageVersions) Get(ctx context.Context, name string, options v1.GetOptions) (result *v1alpha1.StorageVersion, err error) {
 	result = &v1alpha1.StorageVersion{}
 	err = c.client.Get().
+		GroupVersion(v1alpha1.SchemeGroupVersion).
 		Resource("storageversions").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
@@ -87,6 +88,7 @@ func (c *storageVersions) List(ctx context.Context, opts v1.ListOptions) (result
 	}
 	result = &v1alpha1.StorageVersionList{}
 	err = c.client.Get().
+		GroupVersion(v1alpha1.SchemeGroupVersion).
 		Resource("storageversions").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -103,6 +105,7 @@ func (c *storageVersions) Watch(ctx context.Context, opts v1.ListOptions) (watch
 	}
 	opts.Watch = true
 	return c.client.Get().
+		GroupVersion(v1alpha1.SchemeGroupVersion).
 		Resource("storageversions").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -113,6 +116,7 @@ func (c *storageVersions) Watch(ctx context.Context, opts v1.ListOptions) (watch
 func (c *storageVersions) Create(ctx context.Context, storageVersion *v1alpha1.StorageVersion, opts v1.CreateOptions) (result *v1alpha1.StorageVersion, err error) {
 	result = &v1alpha1.StorageVersion{}
 	err = c.client.Post().
+		GroupVersion(v1alpha1.SchemeGroupVersion).
 		Resource("storageversions").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Body(storageVersion).
@@ -125,6 +129,7 @@ func (c *storageVersions) Create(ctx context.Context, storageVersion *v1alpha1.S
 func (c *storageVersions) Update(ctx context.Context, storageVersion *v1alpha1.StorageVersion, opts v1.UpdateOptions) (result *v1alpha1.StorageVersion, err error) {
 	result = &v1alpha1.StorageVersion{}
 	err = c.client.Put().
+		GroupVersion(v1alpha1.SchemeGroupVersion).
 		Resource("storageversions").
 		Name(storageVersion.Name).
 		VersionedParams(&opts, scheme.ParameterCodec).
@@ -139,6 +144,7 @@ func (c *storageVersions) Update(ctx context.Context, storageVersion *v1alpha1.S
 func (c *storageVersions) UpdateStatus(ctx context.Context, storageVersion *v1alpha1.StorageVersion, opts v1.UpdateOptions) (result *v1alpha1.StorageVersion, err error) {
 	result = &v1alpha1.StorageVersion{}
 	err = c.client.Put().
+		GroupVersion(v1alpha1.SchemeGroupVersion).
 		Resource("storageversions").
 		Name(storageVersion.Name).
 		SubResource("status").
@@ -152,6 +158,7 @@ func (c *storageVersions) UpdateStatus(ctx context.Context, storageVersion *v1al
 // Delete takes name of the storageVersion and deletes it. Returns an error if one occurs.
 func (c *storageVersions) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
 	return c.client.Delete().
+		GroupVersion(v1alpha1.SchemeGroupVersion).
 		Resource("storageversions").
 		Name(name).
 		Body(&opts).
@@ -166,6 +173,7 @@ func (c *storageVersions) DeleteCollection(ctx context.Context, opts v1.DeleteOp
 		timeout = time.Duration(*listOpts.TimeoutSeconds) * time.Second
 	}
 	return c.client.Delete().
+		GroupVersion(v1alpha1.SchemeGroupVersion).
 		Resource("storageversions").
 		VersionedParams(&listOpts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -178,6 +186,7 @@ func (c *storageVersions) DeleteCollection(ctx context.Context, opts v1.DeleteOp
 func (c *storageVersions) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts v1.PatchOptions, subresources ...string) (result *v1alpha1.StorageVersion, err error) {
 	result = &v1alpha1.StorageVersion{}
 	err = c.client.Patch(pt).
+		GroupVersion(v1alpha1.SchemeGroupVersion).
 		Resource("storageversions").
 		Name(name).
 		SubResource(subresources...).
@@ -204,6 +213,7 @@ func (c *storageVersions) Apply(ctx context.Context, storageVersion *apiserverin
 	}
 	result = &v1alpha1.StorageVersion{}
 	err = c.client.Patch(types.ApplyPatchType).
+		GroupVersion(v1alpha1.SchemeGroupVersion).
 		Resource("storageversions").
 		Name(*name).
 		VersionedParams(&patchOpts, scheme.ParameterCodec).
@@ -232,6 +242,7 @@ func (c *storageVersions) ApplyStatus(ctx context.Context, storageVersion *apise
 
 	result = &v1alpha1.StorageVersion{}
 	err = c.client.Patch(types.ApplyPatchType).
+		GroupVersion(v1alpha1.SchemeGroupVersion).
 		Resource("storageversions").
 		Name(*name).
 		SubResource("status").

--- a/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1/controllerrevision.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1/controllerrevision.go
@@ -72,6 +72,7 @@ func (c *controllerRevisions) Get(ctx context.Context, name string, options meta
 	result = &v1.ControllerRevision{}
 	err = c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("controllerrevisions").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
@@ -89,6 +90,7 @@ func (c *controllerRevisions) List(ctx context.Context, opts metav1.ListOptions)
 	result = &v1.ControllerRevisionList{}
 	err = c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("controllerrevisions").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -106,6 +108,7 @@ func (c *controllerRevisions) Watch(ctx context.Context, opts metav1.ListOptions
 	opts.Watch = true
 	return c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("controllerrevisions").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -117,6 +120,7 @@ func (c *controllerRevisions) Create(ctx context.Context, controllerRevision *v1
 	result = &v1.ControllerRevision{}
 	err = c.client.Post().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("controllerrevisions").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Body(controllerRevision).
@@ -130,6 +134,7 @@ func (c *controllerRevisions) Update(ctx context.Context, controllerRevision *v1
 	result = &v1.ControllerRevision{}
 	err = c.client.Put().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("controllerrevisions").
 		Name(controllerRevision.Name).
 		VersionedParams(&opts, scheme.ParameterCodec).
@@ -143,6 +148,7 @@ func (c *controllerRevisions) Update(ctx context.Context, controllerRevision *v1
 func (c *controllerRevisions) Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error {
 	return c.client.Delete().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("controllerrevisions").
 		Name(name).
 		Body(&opts).
@@ -158,6 +164,7 @@ func (c *controllerRevisions) DeleteCollection(ctx context.Context, opts metav1.
 	}
 	return c.client.Delete().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("controllerrevisions").
 		VersionedParams(&listOpts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -171,6 +178,7 @@ func (c *controllerRevisions) Patch(ctx context.Context, name string, pt types.P
 	result = &v1.ControllerRevision{}
 	err = c.client.Patch(pt).
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("controllerrevisions").
 		Name(name).
 		SubResource(subresources...).
@@ -198,6 +206,7 @@ func (c *controllerRevisions) Apply(ctx context.Context, controllerRevision *app
 	result = &v1.ControllerRevision{}
 	err = c.client.Patch(types.ApplyPatchType).
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("controllerrevisions").
 		Name(*name).
 		VersionedParams(&patchOpts, scheme.ParameterCodec).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1/daemonset.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1/daemonset.go
@@ -74,6 +74,7 @@ func (c *daemonSets) Get(ctx context.Context, name string, options metav1.GetOpt
 	result = &v1.DaemonSet{}
 	err = c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("daemonsets").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
@@ -91,6 +92,7 @@ func (c *daemonSets) List(ctx context.Context, opts metav1.ListOptions) (result 
 	result = &v1.DaemonSetList{}
 	err = c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("daemonsets").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -108,6 +110,7 @@ func (c *daemonSets) Watch(ctx context.Context, opts metav1.ListOptions) (watch.
 	opts.Watch = true
 	return c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("daemonsets").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -119,6 +122,7 @@ func (c *daemonSets) Create(ctx context.Context, daemonSet *v1.DaemonSet, opts m
 	result = &v1.DaemonSet{}
 	err = c.client.Post().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("daemonsets").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Body(daemonSet).
@@ -132,6 +136,7 @@ func (c *daemonSets) Update(ctx context.Context, daemonSet *v1.DaemonSet, opts m
 	result = &v1.DaemonSet{}
 	err = c.client.Put().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("daemonsets").
 		Name(daemonSet.Name).
 		VersionedParams(&opts, scheme.ParameterCodec).
@@ -147,6 +152,7 @@ func (c *daemonSets) UpdateStatus(ctx context.Context, daemonSet *v1.DaemonSet, 
 	result = &v1.DaemonSet{}
 	err = c.client.Put().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("daemonsets").
 		Name(daemonSet.Name).
 		SubResource("status").
@@ -161,6 +167,7 @@ func (c *daemonSets) UpdateStatus(ctx context.Context, daemonSet *v1.DaemonSet, 
 func (c *daemonSets) Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error {
 	return c.client.Delete().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("daemonsets").
 		Name(name).
 		Body(&opts).
@@ -176,6 +183,7 @@ func (c *daemonSets) DeleteCollection(ctx context.Context, opts metav1.DeleteOpt
 	}
 	return c.client.Delete().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("daemonsets").
 		VersionedParams(&listOpts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -189,6 +197,7 @@ func (c *daemonSets) Patch(ctx context.Context, name string, pt types.PatchType,
 	result = &v1.DaemonSet{}
 	err = c.client.Patch(pt).
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("daemonsets").
 		Name(name).
 		SubResource(subresources...).
@@ -216,6 +225,7 @@ func (c *daemonSets) Apply(ctx context.Context, daemonSet *appsv1.DaemonSetApply
 	result = &v1.DaemonSet{}
 	err = c.client.Patch(types.ApplyPatchType).
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("daemonsets").
 		Name(*name).
 		VersionedParams(&patchOpts, scheme.ParameterCodec).
@@ -245,6 +255,7 @@ func (c *daemonSets) ApplyStatus(ctx context.Context, daemonSet *appsv1.DaemonSe
 	result = &v1.DaemonSet{}
 	err = c.client.Patch(types.ApplyPatchType).
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("daemonsets").
 		Name(*name).
 		SubResource("status").

--- a/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1/deployment.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1/deployment.go
@@ -80,6 +80,7 @@ func (c *deployments) Get(ctx context.Context, name string, options metav1.GetOp
 	result = &v1.Deployment{}
 	err = c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("deployments").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
@@ -97,6 +98,7 @@ func (c *deployments) List(ctx context.Context, opts metav1.ListOptions) (result
 	result = &v1.DeploymentList{}
 	err = c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("deployments").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -114,6 +116,7 @@ func (c *deployments) Watch(ctx context.Context, opts metav1.ListOptions) (watch
 	opts.Watch = true
 	return c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("deployments").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -125,6 +128,7 @@ func (c *deployments) Create(ctx context.Context, deployment *v1.Deployment, opt
 	result = &v1.Deployment{}
 	err = c.client.Post().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("deployments").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Body(deployment).
@@ -138,6 +142,7 @@ func (c *deployments) Update(ctx context.Context, deployment *v1.Deployment, opt
 	result = &v1.Deployment{}
 	err = c.client.Put().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("deployments").
 		Name(deployment.Name).
 		VersionedParams(&opts, scheme.ParameterCodec).
@@ -153,6 +158,7 @@ func (c *deployments) UpdateStatus(ctx context.Context, deployment *v1.Deploymen
 	result = &v1.Deployment{}
 	err = c.client.Put().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("deployments").
 		Name(deployment.Name).
 		SubResource("status").
@@ -167,6 +173,7 @@ func (c *deployments) UpdateStatus(ctx context.Context, deployment *v1.Deploymen
 func (c *deployments) Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error {
 	return c.client.Delete().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("deployments").
 		Name(name).
 		Body(&opts).
@@ -182,6 +189,7 @@ func (c *deployments) DeleteCollection(ctx context.Context, opts metav1.DeleteOp
 	}
 	return c.client.Delete().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("deployments").
 		VersionedParams(&listOpts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -195,6 +203,7 @@ func (c *deployments) Patch(ctx context.Context, name string, pt types.PatchType
 	result = &v1.Deployment{}
 	err = c.client.Patch(pt).
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("deployments").
 		Name(name).
 		SubResource(subresources...).
@@ -222,6 +231,7 @@ func (c *deployments) Apply(ctx context.Context, deployment *appsv1.DeploymentAp
 	result = &v1.Deployment{}
 	err = c.client.Patch(types.ApplyPatchType).
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("deployments").
 		Name(*name).
 		VersionedParams(&patchOpts, scheme.ParameterCodec).
@@ -251,6 +261,7 @@ func (c *deployments) ApplyStatus(ctx context.Context, deployment *appsv1.Deploy
 	result = &v1.Deployment{}
 	err = c.client.Patch(types.ApplyPatchType).
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("deployments").
 		Name(*name).
 		SubResource("status").
@@ -266,6 +277,7 @@ func (c *deployments) GetScale(ctx context.Context, deploymentName string, optio
 	result = &autoscalingv1.Scale{}
 	err = c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("deployments").
 		Name(deploymentName).
 		SubResource("scale").
@@ -280,6 +292,7 @@ func (c *deployments) UpdateScale(ctx context.Context, deploymentName string, sc
 	result = &autoscalingv1.Scale{}
 	err = c.client.Put().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("deployments").
 		Name(deploymentName).
 		SubResource("scale").
@@ -305,6 +318,7 @@ func (c *deployments) ApplyScale(ctx context.Context, deploymentName string, sca
 	result = &autoscalingv1.Scale{}
 	err = c.client.Patch(types.ApplyPatchType).
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("deployments").
 		Name(deploymentName).
 		SubResource("scale").

--- a/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1/replicaset.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1/replicaset.go
@@ -80,6 +80,7 @@ func (c *replicaSets) Get(ctx context.Context, name string, options metav1.GetOp
 	result = &v1.ReplicaSet{}
 	err = c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("replicasets").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
@@ -97,6 +98,7 @@ func (c *replicaSets) List(ctx context.Context, opts metav1.ListOptions) (result
 	result = &v1.ReplicaSetList{}
 	err = c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("replicasets").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -114,6 +116,7 @@ func (c *replicaSets) Watch(ctx context.Context, opts metav1.ListOptions) (watch
 	opts.Watch = true
 	return c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("replicasets").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -125,6 +128,7 @@ func (c *replicaSets) Create(ctx context.Context, replicaSet *v1.ReplicaSet, opt
 	result = &v1.ReplicaSet{}
 	err = c.client.Post().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("replicasets").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Body(replicaSet).
@@ -138,6 +142,7 @@ func (c *replicaSets) Update(ctx context.Context, replicaSet *v1.ReplicaSet, opt
 	result = &v1.ReplicaSet{}
 	err = c.client.Put().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("replicasets").
 		Name(replicaSet.Name).
 		VersionedParams(&opts, scheme.ParameterCodec).
@@ -153,6 +158,7 @@ func (c *replicaSets) UpdateStatus(ctx context.Context, replicaSet *v1.ReplicaSe
 	result = &v1.ReplicaSet{}
 	err = c.client.Put().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("replicasets").
 		Name(replicaSet.Name).
 		SubResource("status").
@@ -167,6 +173,7 @@ func (c *replicaSets) UpdateStatus(ctx context.Context, replicaSet *v1.ReplicaSe
 func (c *replicaSets) Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error {
 	return c.client.Delete().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("replicasets").
 		Name(name).
 		Body(&opts).
@@ -182,6 +189,7 @@ func (c *replicaSets) DeleteCollection(ctx context.Context, opts metav1.DeleteOp
 	}
 	return c.client.Delete().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("replicasets").
 		VersionedParams(&listOpts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -195,6 +203,7 @@ func (c *replicaSets) Patch(ctx context.Context, name string, pt types.PatchType
 	result = &v1.ReplicaSet{}
 	err = c.client.Patch(pt).
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("replicasets").
 		Name(name).
 		SubResource(subresources...).
@@ -222,6 +231,7 @@ func (c *replicaSets) Apply(ctx context.Context, replicaSet *appsv1.ReplicaSetAp
 	result = &v1.ReplicaSet{}
 	err = c.client.Patch(types.ApplyPatchType).
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("replicasets").
 		Name(*name).
 		VersionedParams(&patchOpts, scheme.ParameterCodec).
@@ -251,6 +261,7 @@ func (c *replicaSets) ApplyStatus(ctx context.Context, replicaSet *appsv1.Replic
 	result = &v1.ReplicaSet{}
 	err = c.client.Patch(types.ApplyPatchType).
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("replicasets").
 		Name(*name).
 		SubResource("status").
@@ -266,6 +277,7 @@ func (c *replicaSets) GetScale(ctx context.Context, replicaSetName string, optio
 	result = &autoscalingv1.Scale{}
 	err = c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("replicasets").
 		Name(replicaSetName).
 		SubResource("scale").
@@ -280,6 +292,7 @@ func (c *replicaSets) UpdateScale(ctx context.Context, replicaSetName string, sc
 	result = &autoscalingv1.Scale{}
 	err = c.client.Put().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("replicasets").
 		Name(replicaSetName).
 		SubResource("scale").
@@ -305,6 +318,7 @@ func (c *replicaSets) ApplyScale(ctx context.Context, replicaSetName string, sca
 	result = &autoscalingv1.Scale{}
 	err = c.client.Patch(types.ApplyPatchType).
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("replicasets").
 		Name(replicaSetName).
 		SubResource("scale").

--- a/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1/statefulset.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1/statefulset.go
@@ -80,6 +80,7 @@ func (c *statefulSets) Get(ctx context.Context, name string, options metav1.GetO
 	result = &v1.StatefulSet{}
 	err = c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("statefulsets").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
@@ -97,6 +98,7 @@ func (c *statefulSets) List(ctx context.Context, opts metav1.ListOptions) (resul
 	result = &v1.StatefulSetList{}
 	err = c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("statefulsets").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -114,6 +116,7 @@ func (c *statefulSets) Watch(ctx context.Context, opts metav1.ListOptions) (watc
 	opts.Watch = true
 	return c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("statefulsets").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -125,6 +128,7 @@ func (c *statefulSets) Create(ctx context.Context, statefulSet *v1.StatefulSet, 
 	result = &v1.StatefulSet{}
 	err = c.client.Post().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("statefulsets").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Body(statefulSet).
@@ -138,6 +142,7 @@ func (c *statefulSets) Update(ctx context.Context, statefulSet *v1.StatefulSet, 
 	result = &v1.StatefulSet{}
 	err = c.client.Put().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("statefulsets").
 		Name(statefulSet.Name).
 		VersionedParams(&opts, scheme.ParameterCodec).
@@ -153,6 +158,7 @@ func (c *statefulSets) UpdateStatus(ctx context.Context, statefulSet *v1.Statefu
 	result = &v1.StatefulSet{}
 	err = c.client.Put().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("statefulsets").
 		Name(statefulSet.Name).
 		SubResource("status").
@@ -167,6 +173,7 @@ func (c *statefulSets) UpdateStatus(ctx context.Context, statefulSet *v1.Statefu
 func (c *statefulSets) Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error {
 	return c.client.Delete().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("statefulsets").
 		Name(name).
 		Body(&opts).
@@ -182,6 +189,7 @@ func (c *statefulSets) DeleteCollection(ctx context.Context, opts metav1.DeleteO
 	}
 	return c.client.Delete().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("statefulsets").
 		VersionedParams(&listOpts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -195,6 +203,7 @@ func (c *statefulSets) Patch(ctx context.Context, name string, pt types.PatchTyp
 	result = &v1.StatefulSet{}
 	err = c.client.Patch(pt).
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("statefulsets").
 		Name(name).
 		SubResource(subresources...).
@@ -222,6 +231,7 @@ func (c *statefulSets) Apply(ctx context.Context, statefulSet *appsv1.StatefulSe
 	result = &v1.StatefulSet{}
 	err = c.client.Patch(types.ApplyPatchType).
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("statefulsets").
 		Name(*name).
 		VersionedParams(&patchOpts, scheme.ParameterCodec).
@@ -251,6 +261,7 @@ func (c *statefulSets) ApplyStatus(ctx context.Context, statefulSet *appsv1.Stat
 	result = &v1.StatefulSet{}
 	err = c.client.Patch(types.ApplyPatchType).
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("statefulsets").
 		Name(*name).
 		SubResource("status").
@@ -266,6 +277,7 @@ func (c *statefulSets) GetScale(ctx context.Context, statefulSetName string, opt
 	result = &autoscalingv1.Scale{}
 	err = c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("statefulsets").
 		Name(statefulSetName).
 		SubResource("scale").
@@ -280,6 +292,7 @@ func (c *statefulSets) UpdateScale(ctx context.Context, statefulSetName string, 
 	result = &autoscalingv1.Scale{}
 	err = c.client.Put().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("statefulsets").
 		Name(statefulSetName).
 		SubResource("scale").
@@ -305,6 +318,7 @@ func (c *statefulSets) ApplyScale(ctx context.Context, statefulSetName string, s
 	result = &autoscalingv1.Scale{}
 	err = c.client.Patch(types.ApplyPatchType).
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("statefulsets").
 		Name(statefulSetName).
 		SubResource("scale").

--- a/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta1/controllerrevision.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta1/controllerrevision.go
@@ -72,6 +72,7 @@ func (c *controllerRevisions) Get(ctx context.Context, name string, options v1.G
 	result = &v1beta1.ControllerRevision{}
 	err = c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("controllerrevisions").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
@@ -89,6 +90,7 @@ func (c *controllerRevisions) List(ctx context.Context, opts v1.ListOptions) (re
 	result = &v1beta1.ControllerRevisionList{}
 	err = c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("controllerrevisions").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -106,6 +108,7 @@ func (c *controllerRevisions) Watch(ctx context.Context, opts v1.ListOptions) (w
 	opts.Watch = true
 	return c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("controllerrevisions").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -117,6 +120,7 @@ func (c *controllerRevisions) Create(ctx context.Context, controllerRevision *v1
 	result = &v1beta1.ControllerRevision{}
 	err = c.client.Post().
 		Namespace(c.ns).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("controllerrevisions").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Body(controllerRevision).
@@ -130,6 +134,7 @@ func (c *controllerRevisions) Update(ctx context.Context, controllerRevision *v1
 	result = &v1beta1.ControllerRevision{}
 	err = c.client.Put().
 		Namespace(c.ns).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("controllerrevisions").
 		Name(controllerRevision.Name).
 		VersionedParams(&opts, scheme.ParameterCodec).
@@ -143,6 +148,7 @@ func (c *controllerRevisions) Update(ctx context.Context, controllerRevision *v1
 func (c *controllerRevisions) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
 	return c.client.Delete().
 		Namespace(c.ns).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("controllerrevisions").
 		Name(name).
 		Body(&opts).
@@ -158,6 +164,7 @@ func (c *controllerRevisions) DeleteCollection(ctx context.Context, opts v1.Dele
 	}
 	return c.client.Delete().
 		Namespace(c.ns).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("controllerrevisions").
 		VersionedParams(&listOpts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -171,6 +178,7 @@ func (c *controllerRevisions) Patch(ctx context.Context, name string, pt types.P
 	result = &v1beta1.ControllerRevision{}
 	err = c.client.Patch(pt).
 		Namespace(c.ns).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("controllerrevisions").
 		Name(name).
 		SubResource(subresources...).
@@ -198,6 +206,7 @@ func (c *controllerRevisions) Apply(ctx context.Context, controllerRevision *app
 	result = &v1beta1.ControllerRevision{}
 	err = c.client.Patch(types.ApplyPatchType).
 		Namespace(c.ns).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("controllerrevisions").
 		Name(*name).
 		VersionedParams(&patchOpts, scheme.ParameterCodec).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta1/deployment.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta1/deployment.go
@@ -74,6 +74,7 @@ func (c *deployments) Get(ctx context.Context, name string, options v1.GetOption
 	result = &v1beta1.Deployment{}
 	err = c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("deployments").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
@@ -91,6 +92,7 @@ func (c *deployments) List(ctx context.Context, opts v1.ListOptions) (result *v1
 	result = &v1beta1.DeploymentList{}
 	err = c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("deployments").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -108,6 +110,7 @@ func (c *deployments) Watch(ctx context.Context, opts v1.ListOptions) (watch.Int
 	opts.Watch = true
 	return c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("deployments").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -119,6 +122,7 @@ func (c *deployments) Create(ctx context.Context, deployment *v1beta1.Deployment
 	result = &v1beta1.Deployment{}
 	err = c.client.Post().
 		Namespace(c.ns).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("deployments").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Body(deployment).
@@ -132,6 +136,7 @@ func (c *deployments) Update(ctx context.Context, deployment *v1beta1.Deployment
 	result = &v1beta1.Deployment{}
 	err = c.client.Put().
 		Namespace(c.ns).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("deployments").
 		Name(deployment.Name).
 		VersionedParams(&opts, scheme.ParameterCodec).
@@ -147,6 +152,7 @@ func (c *deployments) UpdateStatus(ctx context.Context, deployment *v1beta1.Depl
 	result = &v1beta1.Deployment{}
 	err = c.client.Put().
 		Namespace(c.ns).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("deployments").
 		Name(deployment.Name).
 		SubResource("status").
@@ -161,6 +167,7 @@ func (c *deployments) UpdateStatus(ctx context.Context, deployment *v1beta1.Depl
 func (c *deployments) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
 	return c.client.Delete().
 		Namespace(c.ns).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("deployments").
 		Name(name).
 		Body(&opts).
@@ -176,6 +183,7 @@ func (c *deployments) DeleteCollection(ctx context.Context, opts v1.DeleteOption
 	}
 	return c.client.Delete().
 		Namespace(c.ns).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("deployments").
 		VersionedParams(&listOpts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -189,6 +197,7 @@ func (c *deployments) Patch(ctx context.Context, name string, pt types.PatchType
 	result = &v1beta1.Deployment{}
 	err = c.client.Patch(pt).
 		Namespace(c.ns).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("deployments").
 		Name(name).
 		SubResource(subresources...).
@@ -216,6 +225,7 @@ func (c *deployments) Apply(ctx context.Context, deployment *appsv1beta1.Deploym
 	result = &v1beta1.Deployment{}
 	err = c.client.Patch(types.ApplyPatchType).
 		Namespace(c.ns).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("deployments").
 		Name(*name).
 		VersionedParams(&patchOpts, scheme.ParameterCodec).
@@ -245,6 +255,7 @@ func (c *deployments) ApplyStatus(ctx context.Context, deployment *appsv1beta1.D
 	result = &v1beta1.Deployment{}
 	err = c.client.Patch(types.ApplyPatchType).
 		Namespace(c.ns).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("deployments").
 		Name(*name).
 		SubResource("status").

--- a/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta1/statefulset.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta1/statefulset.go
@@ -74,6 +74,7 @@ func (c *statefulSets) Get(ctx context.Context, name string, options v1.GetOptio
 	result = &v1beta1.StatefulSet{}
 	err = c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("statefulsets").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
@@ -91,6 +92,7 @@ func (c *statefulSets) List(ctx context.Context, opts v1.ListOptions) (result *v
 	result = &v1beta1.StatefulSetList{}
 	err = c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("statefulsets").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -108,6 +110,7 @@ func (c *statefulSets) Watch(ctx context.Context, opts v1.ListOptions) (watch.In
 	opts.Watch = true
 	return c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("statefulsets").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -119,6 +122,7 @@ func (c *statefulSets) Create(ctx context.Context, statefulSet *v1beta1.Stateful
 	result = &v1beta1.StatefulSet{}
 	err = c.client.Post().
 		Namespace(c.ns).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("statefulsets").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Body(statefulSet).
@@ -132,6 +136,7 @@ func (c *statefulSets) Update(ctx context.Context, statefulSet *v1beta1.Stateful
 	result = &v1beta1.StatefulSet{}
 	err = c.client.Put().
 		Namespace(c.ns).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("statefulsets").
 		Name(statefulSet.Name).
 		VersionedParams(&opts, scheme.ParameterCodec).
@@ -147,6 +152,7 @@ func (c *statefulSets) UpdateStatus(ctx context.Context, statefulSet *v1beta1.St
 	result = &v1beta1.StatefulSet{}
 	err = c.client.Put().
 		Namespace(c.ns).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("statefulsets").
 		Name(statefulSet.Name).
 		SubResource("status").
@@ -161,6 +167,7 @@ func (c *statefulSets) UpdateStatus(ctx context.Context, statefulSet *v1beta1.St
 func (c *statefulSets) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
 	return c.client.Delete().
 		Namespace(c.ns).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("statefulsets").
 		Name(name).
 		Body(&opts).
@@ -176,6 +183,7 @@ func (c *statefulSets) DeleteCollection(ctx context.Context, opts v1.DeleteOptio
 	}
 	return c.client.Delete().
 		Namespace(c.ns).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("statefulsets").
 		VersionedParams(&listOpts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -189,6 +197,7 @@ func (c *statefulSets) Patch(ctx context.Context, name string, pt types.PatchTyp
 	result = &v1beta1.StatefulSet{}
 	err = c.client.Patch(pt).
 		Namespace(c.ns).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("statefulsets").
 		Name(name).
 		SubResource(subresources...).
@@ -216,6 +225,7 @@ func (c *statefulSets) Apply(ctx context.Context, statefulSet *appsv1beta1.State
 	result = &v1beta1.StatefulSet{}
 	err = c.client.Patch(types.ApplyPatchType).
 		Namespace(c.ns).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("statefulsets").
 		Name(*name).
 		VersionedParams(&patchOpts, scheme.ParameterCodec).
@@ -245,6 +255,7 @@ func (c *statefulSets) ApplyStatus(ctx context.Context, statefulSet *appsv1beta1
 	result = &v1beta1.StatefulSet{}
 	err = c.client.Patch(types.ApplyPatchType).
 		Namespace(c.ns).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("statefulsets").
 		Name(*name).
 		SubResource("status").

--- a/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta2/controllerrevision.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta2/controllerrevision.go
@@ -72,6 +72,7 @@ func (c *controllerRevisions) Get(ctx context.Context, name string, options v1.G
 	result = &v1beta2.ControllerRevision{}
 	err = c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(v1beta2.SchemeGroupVersion).
 		Resource("controllerrevisions").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
@@ -89,6 +90,7 @@ func (c *controllerRevisions) List(ctx context.Context, opts v1.ListOptions) (re
 	result = &v1beta2.ControllerRevisionList{}
 	err = c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(v1beta2.SchemeGroupVersion).
 		Resource("controllerrevisions").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -106,6 +108,7 @@ func (c *controllerRevisions) Watch(ctx context.Context, opts v1.ListOptions) (w
 	opts.Watch = true
 	return c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(v1beta2.SchemeGroupVersion).
 		Resource("controllerrevisions").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -117,6 +120,7 @@ func (c *controllerRevisions) Create(ctx context.Context, controllerRevision *v1
 	result = &v1beta2.ControllerRevision{}
 	err = c.client.Post().
 		Namespace(c.ns).
+		GroupVersion(v1beta2.SchemeGroupVersion).
 		Resource("controllerrevisions").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Body(controllerRevision).
@@ -130,6 +134,7 @@ func (c *controllerRevisions) Update(ctx context.Context, controllerRevision *v1
 	result = &v1beta2.ControllerRevision{}
 	err = c.client.Put().
 		Namespace(c.ns).
+		GroupVersion(v1beta2.SchemeGroupVersion).
 		Resource("controllerrevisions").
 		Name(controllerRevision.Name).
 		VersionedParams(&opts, scheme.ParameterCodec).
@@ -143,6 +148,7 @@ func (c *controllerRevisions) Update(ctx context.Context, controllerRevision *v1
 func (c *controllerRevisions) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
 	return c.client.Delete().
 		Namespace(c.ns).
+		GroupVersion(v1beta2.SchemeGroupVersion).
 		Resource("controllerrevisions").
 		Name(name).
 		Body(&opts).
@@ -158,6 +164,7 @@ func (c *controllerRevisions) DeleteCollection(ctx context.Context, opts v1.Dele
 	}
 	return c.client.Delete().
 		Namespace(c.ns).
+		GroupVersion(v1beta2.SchemeGroupVersion).
 		Resource("controllerrevisions").
 		VersionedParams(&listOpts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -171,6 +178,7 @@ func (c *controllerRevisions) Patch(ctx context.Context, name string, pt types.P
 	result = &v1beta2.ControllerRevision{}
 	err = c.client.Patch(pt).
 		Namespace(c.ns).
+		GroupVersion(v1beta2.SchemeGroupVersion).
 		Resource("controllerrevisions").
 		Name(name).
 		SubResource(subresources...).
@@ -198,6 +206,7 @@ func (c *controllerRevisions) Apply(ctx context.Context, controllerRevision *app
 	result = &v1beta2.ControllerRevision{}
 	err = c.client.Patch(types.ApplyPatchType).
 		Namespace(c.ns).
+		GroupVersion(v1beta2.SchemeGroupVersion).
 		Resource("controllerrevisions").
 		Name(*name).
 		VersionedParams(&patchOpts, scheme.ParameterCodec).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta2/daemonset.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta2/daemonset.go
@@ -74,6 +74,7 @@ func (c *daemonSets) Get(ctx context.Context, name string, options v1.GetOptions
 	result = &v1beta2.DaemonSet{}
 	err = c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(v1beta2.SchemeGroupVersion).
 		Resource("daemonsets").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
@@ -91,6 +92,7 @@ func (c *daemonSets) List(ctx context.Context, opts v1.ListOptions) (result *v1b
 	result = &v1beta2.DaemonSetList{}
 	err = c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(v1beta2.SchemeGroupVersion).
 		Resource("daemonsets").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -108,6 +110,7 @@ func (c *daemonSets) Watch(ctx context.Context, opts v1.ListOptions) (watch.Inte
 	opts.Watch = true
 	return c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(v1beta2.SchemeGroupVersion).
 		Resource("daemonsets").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -119,6 +122,7 @@ func (c *daemonSets) Create(ctx context.Context, daemonSet *v1beta2.DaemonSet, o
 	result = &v1beta2.DaemonSet{}
 	err = c.client.Post().
 		Namespace(c.ns).
+		GroupVersion(v1beta2.SchemeGroupVersion).
 		Resource("daemonsets").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Body(daemonSet).
@@ -132,6 +136,7 @@ func (c *daemonSets) Update(ctx context.Context, daemonSet *v1beta2.DaemonSet, o
 	result = &v1beta2.DaemonSet{}
 	err = c.client.Put().
 		Namespace(c.ns).
+		GroupVersion(v1beta2.SchemeGroupVersion).
 		Resource("daemonsets").
 		Name(daemonSet.Name).
 		VersionedParams(&opts, scheme.ParameterCodec).
@@ -147,6 +152,7 @@ func (c *daemonSets) UpdateStatus(ctx context.Context, daemonSet *v1beta2.Daemon
 	result = &v1beta2.DaemonSet{}
 	err = c.client.Put().
 		Namespace(c.ns).
+		GroupVersion(v1beta2.SchemeGroupVersion).
 		Resource("daemonsets").
 		Name(daemonSet.Name).
 		SubResource("status").
@@ -161,6 +167,7 @@ func (c *daemonSets) UpdateStatus(ctx context.Context, daemonSet *v1beta2.Daemon
 func (c *daemonSets) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
 	return c.client.Delete().
 		Namespace(c.ns).
+		GroupVersion(v1beta2.SchemeGroupVersion).
 		Resource("daemonsets").
 		Name(name).
 		Body(&opts).
@@ -176,6 +183,7 @@ func (c *daemonSets) DeleteCollection(ctx context.Context, opts v1.DeleteOptions
 	}
 	return c.client.Delete().
 		Namespace(c.ns).
+		GroupVersion(v1beta2.SchemeGroupVersion).
 		Resource("daemonsets").
 		VersionedParams(&listOpts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -189,6 +197,7 @@ func (c *daemonSets) Patch(ctx context.Context, name string, pt types.PatchType,
 	result = &v1beta2.DaemonSet{}
 	err = c.client.Patch(pt).
 		Namespace(c.ns).
+		GroupVersion(v1beta2.SchemeGroupVersion).
 		Resource("daemonsets").
 		Name(name).
 		SubResource(subresources...).
@@ -216,6 +225,7 @@ func (c *daemonSets) Apply(ctx context.Context, daemonSet *appsv1beta2.DaemonSet
 	result = &v1beta2.DaemonSet{}
 	err = c.client.Patch(types.ApplyPatchType).
 		Namespace(c.ns).
+		GroupVersion(v1beta2.SchemeGroupVersion).
 		Resource("daemonsets").
 		Name(*name).
 		VersionedParams(&patchOpts, scheme.ParameterCodec).
@@ -245,6 +255,7 @@ func (c *daemonSets) ApplyStatus(ctx context.Context, daemonSet *appsv1beta2.Dae
 	result = &v1beta2.DaemonSet{}
 	err = c.client.Patch(types.ApplyPatchType).
 		Namespace(c.ns).
+		GroupVersion(v1beta2.SchemeGroupVersion).
 		Resource("daemonsets").
 		Name(*name).
 		SubResource("status").

--- a/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta2/deployment.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta2/deployment.go
@@ -74,6 +74,7 @@ func (c *deployments) Get(ctx context.Context, name string, options v1.GetOption
 	result = &v1beta2.Deployment{}
 	err = c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(v1beta2.SchemeGroupVersion).
 		Resource("deployments").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
@@ -91,6 +92,7 @@ func (c *deployments) List(ctx context.Context, opts v1.ListOptions) (result *v1
 	result = &v1beta2.DeploymentList{}
 	err = c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(v1beta2.SchemeGroupVersion).
 		Resource("deployments").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -108,6 +110,7 @@ func (c *deployments) Watch(ctx context.Context, opts v1.ListOptions) (watch.Int
 	opts.Watch = true
 	return c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(v1beta2.SchemeGroupVersion).
 		Resource("deployments").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -119,6 +122,7 @@ func (c *deployments) Create(ctx context.Context, deployment *v1beta2.Deployment
 	result = &v1beta2.Deployment{}
 	err = c.client.Post().
 		Namespace(c.ns).
+		GroupVersion(v1beta2.SchemeGroupVersion).
 		Resource("deployments").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Body(deployment).
@@ -132,6 +136,7 @@ func (c *deployments) Update(ctx context.Context, deployment *v1beta2.Deployment
 	result = &v1beta2.Deployment{}
 	err = c.client.Put().
 		Namespace(c.ns).
+		GroupVersion(v1beta2.SchemeGroupVersion).
 		Resource("deployments").
 		Name(deployment.Name).
 		VersionedParams(&opts, scheme.ParameterCodec).
@@ -147,6 +152,7 @@ func (c *deployments) UpdateStatus(ctx context.Context, deployment *v1beta2.Depl
 	result = &v1beta2.Deployment{}
 	err = c.client.Put().
 		Namespace(c.ns).
+		GroupVersion(v1beta2.SchemeGroupVersion).
 		Resource("deployments").
 		Name(deployment.Name).
 		SubResource("status").
@@ -161,6 +167,7 @@ func (c *deployments) UpdateStatus(ctx context.Context, deployment *v1beta2.Depl
 func (c *deployments) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
 	return c.client.Delete().
 		Namespace(c.ns).
+		GroupVersion(v1beta2.SchemeGroupVersion).
 		Resource("deployments").
 		Name(name).
 		Body(&opts).
@@ -176,6 +183,7 @@ func (c *deployments) DeleteCollection(ctx context.Context, opts v1.DeleteOption
 	}
 	return c.client.Delete().
 		Namespace(c.ns).
+		GroupVersion(v1beta2.SchemeGroupVersion).
 		Resource("deployments").
 		VersionedParams(&listOpts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -189,6 +197,7 @@ func (c *deployments) Patch(ctx context.Context, name string, pt types.PatchType
 	result = &v1beta2.Deployment{}
 	err = c.client.Patch(pt).
 		Namespace(c.ns).
+		GroupVersion(v1beta2.SchemeGroupVersion).
 		Resource("deployments").
 		Name(name).
 		SubResource(subresources...).
@@ -216,6 +225,7 @@ func (c *deployments) Apply(ctx context.Context, deployment *appsv1beta2.Deploym
 	result = &v1beta2.Deployment{}
 	err = c.client.Patch(types.ApplyPatchType).
 		Namespace(c.ns).
+		GroupVersion(v1beta2.SchemeGroupVersion).
 		Resource("deployments").
 		Name(*name).
 		VersionedParams(&patchOpts, scheme.ParameterCodec).
@@ -245,6 +255,7 @@ func (c *deployments) ApplyStatus(ctx context.Context, deployment *appsv1beta2.D
 	result = &v1beta2.Deployment{}
 	err = c.client.Patch(types.ApplyPatchType).
 		Namespace(c.ns).
+		GroupVersion(v1beta2.SchemeGroupVersion).
 		Resource("deployments").
 		Name(*name).
 		SubResource("status").

--- a/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta2/replicaset.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta2/replicaset.go
@@ -74,6 +74,7 @@ func (c *replicaSets) Get(ctx context.Context, name string, options v1.GetOption
 	result = &v1beta2.ReplicaSet{}
 	err = c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(v1beta2.SchemeGroupVersion).
 		Resource("replicasets").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
@@ -91,6 +92,7 @@ func (c *replicaSets) List(ctx context.Context, opts v1.ListOptions) (result *v1
 	result = &v1beta2.ReplicaSetList{}
 	err = c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(v1beta2.SchemeGroupVersion).
 		Resource("replicasets").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -108,6 +110,7 @@ func (c *replicaSets) Watch(ctx context.Context, opts v1.ListOptions) (watch.Int
 	opts.Watch = true
 	return c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(v1beta2.SchemeGroupVersion).
 		Resource("replicasets").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -119,6 +122,7 @@ func (c *replicaSets) Create(ctx context.Context, replicaSet *v1beta2.ReplicaSet
 	result = &v1beta2.ReplicaSet{}
 	err = c.client.Post().
 		Namespace(c.ns).
+		GroupVersion(v1beta2.SchemeGroupVersion).
 		Resource("replicasets").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Body(replicaSet).
@@ -132,6 +136,7 @@ func (c *replicaSets) Update(ctx context.Context, replicaSet *v1beta2.ReplicaSet
 	result = &v1beta2.ReplicaSet{}
 	err = c.client.Put().
 		Namespace(c.ns).
+		GroupVersion(v1beta2.SchemeGroupVersion).
 		Resource("replicasets").
 		Name(replicaSet.Name).
 		VersionedParams(&opts, scheme.ParameterCodec).
@@ -147,6 +152,7 @@ func (c *replicaSets) UpdateStatus(ctx context.Context, replicaSet *v1beta2.Repl
 	result = &v1beta2.ReplicaSet{}
 	err = c.client.Put().
 		Namespace(c.ns).
+		GroupVersion(v1beta2.SchemeGroupVersion).
 		Resource("replicasets").
 		Name(replicaSet.Name).
 		SubResource("status").
@@ -161,6 +167,7 @@ func (c *replicaSets) UpdateStatus(ctx context.Context, replicaSet *v1beta2.Repl
 func (c *replicaSets) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
 	return c.client.Delete().
 		Namespace(c.ns).
+		GroupVersion(v1beta2.SchemeGroupVersion).
 		Resource("replicasets").
 		Name(name).
 		Body(&opts).
@@ -176,6 +183,7 @@ func (c *replicaSets) DeleteCollection(ctx context.Context, opts v1.DeleteOption
 	}
 	return c.client.Delete().
 		Namespace(c.ns).
+		GroupVersion(v1beta2.SchemeGroupVersion).
 		Resource("replicasets").
 		VersionedParams(&listOpts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -189,6 +197,7 @@ func (c *replicaSets) Patch(ctx context.Context, name string, pt types.PatchType
 	result = &v1beta2.ReplicaSet{}
 	err = c.client.Patch(pt).
 		Namespace(c.ns).
+		GroupVersion(v1beta2.SchemeGroupVersion).
 		Resource("replicasets").
 		Name(name).
 		SubResource(subresources...).
@@ -216,6 +225,7 @@ func (c *replicaSets) Apply(ctx context.Context, replicaSet *appsv1beta2.Replica
 	result = &v1beta2.ReplicaSet{}
 	err = c.client.Patch(types.ApplyPatchType).
 		Namespace(c.ns).
+		GroupVersion(v1beta2.SchemeGroupVersion).
 		Resource("replicasets").
 		Name(*name).
 		VersionedParams(&patchOpts, scheme.ParameterCodec).
@@ -245,6 +255,7 @@ func (c *replicaSets) ApplyStatus(ctx context.Context, replicaSet *appsv1beta2.R
 	result = &v1beta2.ReplicaSet{}
 	err = c.client.Patch(types.ApplyPatchType).
 		Namespace(c.ns).
+		GroupVersion(v1beta2.SchemeGroupVersion).
 		Resource("replicasets").
 		Name(*name).
 		SubResource("status").

--- a/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta2/statefulset.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta2/statefulset.go
@@ -78,6 +78,7 @@ func (c *statefulSets) Get(ctx context.Context, name string, options v1.GetOptio
 	result = &v1beta2.StatefulSet{}
 	err = c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(v1beta2.SchemeGroupVersion).
 		Resource("statefulsets").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
@@ -95,6 +96,7 @@ func (c *statefulSets) List(ctx context.Context, opts v1.ListOptions) (result *v
 	result = &v1beta2.StatefulSetList{}
 	err = c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(v1beta2.SchemeGroupVersion).
 		Resource("statefulsets").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -112,6 +114,7 @@ func (c *statefulSets) Watch(ctx context.Context, opts v1.ListOptions) (watch.In
 	opts.Watch = true
 	return c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(v1beta2.SchemeGroupVersion).
 		Resource("statefulsets").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -123,6 +126,7 @@ func (c *statefulSets) Create(ctx context.Context, statefulSet *v1beta2.Stateful
 	result = &v1beta2.StatefulSet{}
 	err = c.client.Post().
 		Namespace(c.ns).
+		GroupVersion(v1beta2.SchemeGroupVersion).
 		Resource("statefulsets").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Body(statefulSet).
@@ -136,6 +140,7 @@ func (c *statefulSets) Update(ctx context.Context, statefulSet *v1beta2.Stateful
 	result = &v1beta2.StatefulSet{}
 	err = c.client.Put().
 		Namespace(c.ns).
+		GroupVersion(v1beta2.SchemeGroupVersion).
 		Resource("statefulsets").
 		Name(statefulSet.Name).
 		VersionedParams(&opts, scheme.ParameterCodec).
@@ -151,6 +156,7 @@ func (c *statefulSets) UpdateStatus(ctx context.Context, statefulSet *v1beta2.St
 	result = &v1beta2.StatefulSet{}
 	err = c.client.Put().
 		Namespace(c.ns).
+		GroupVersion(v1beta2.SchemeGroupVersion).
 		Resource("statefulsets").
 		Name(statefulSet.Name).
 		SubResource("status").
@@ -165,6 +171,7 @@ func (c *statefulSets) UpdateStatus(ctx context.Context, statefulSet *v1beta2.St
 func (c *statefulSets) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
 	return c.client.Delete().
 		Namespace(c.ns).
+		GroupVersion(v1beta2.SchemeGroupVersion).
 		Resource("statefulsets").
 		Name(name).
 		Body(&opts).
@@ -180,6 +187,7 @@ func (c *statefulSets) DeleteCollection(ctx context.Context, opts v1.DeleteOptio
 	}
 	return c.client.Delete().
 		Namespace(c.ns).
+		GroupVersion(v1beta2.SchemeGroupVersion).
 		Resource("statefulsets").
 		VersionedParams(&listOpts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -193,6 +201,7 @@ func (c *statefulSets) Patch(ctx context.Context, name string, pt types.PatchTyp
 	result = &v1beta2.StatefulSet{}
 	err = c.client.Patch(pt).
 		Namespace(c.ns).
+		GroupVersion(v1beta2.SchemeGroupVersion).
 		Resource("statefulsets").
 		Name(name).
 		SubResource(subresources...).
@@ -220,6 +229,7 @@ func (c *statefulSets) Apply(ctx context.Context, statefulSet *appsv1beta2.State
 	result = &v1beta2.StatefulSet{}
 	err = c.client.Patch(types.ApplyPatchType).
 		Namespace(c.ns).
+		GroupVersion(v1beta2.SchemeGroupVersion).
 		Resource("statefulsets").
 		Name(*name).
 		VersionedParams(&patchOpts, scheme.ParameterCodec).
@@ -249,6 +259,7 @@ func (c *statefulSets) ApplyStatus(ctx context.Context, statefulSet *appsv1beta2
 	result = &v1beta2.StatefulSet{}
 	err = c.client.Patch(types.ApplyPatchType).
 		Namespace(c.ns).
+		GroupVersion(v1beta2.SchemeGroupVersion).
 		Resource("statefulsets").
 		Name(*name).
 		SubResource("status").
@@ -264,6 +275,7 @@ func (c *statefulSets) GetScale(ctx context.Context, statefulSetName string, opt
 	result = &v1beta2.Scale{}
 	err = c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(v1beta2.SchemeGroupVersion).
 		Resource("statefulsets").
 		Name(statefulSetName).
 		SubResource("scale").
@@ -278,6 +290,7 @@ func (c *statefulSets) UpdateScale(ctx context.Context, statefulSetName string, 
 	result = &v1beta2.Scale{}
 	err = c.client.Put().
 		Namespace(c.ns).
+		GroupVersion(v1beta2.SchemeGroupVersion).
 		Resource("statefulsets").
 		Name(statefulSetName).
 		SubResource("scale").
@@ -303,6 +316,7 @@ func (c *statefulSets) ApplyScale(ctx context.Context, statefulSetName string, s
 	result = &v1beta2.Scale{}
 	err = c.client.Patch(types.ApplyPatchType).
 		Namespace(c.ns).
+		GroupVersion(v1beta2.SchemeGroupVersion).
 		Resource("statefulsets").
 		Name(statefulSetName).
 		SubResource("scale").

--- a/staging/src/k8s.io/client-go/kubernetes/typed/authentication/v1/tokenreview.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/authentication/v1/tokenreview.go
@@ -55,6 +55,7 @@ func newTokenReviews(c *AuthenticationV1Client) *tokenReviews {
 func (c *tokenReviews) Create(ctx context.Context, tokenReview *v1.TokenReview, opts metav1.CreateOptions) (result *v1.TokenReview, err error) {
 	result = &v1.TokenReview{}
 	err = c.client.Post().
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("tokenreviews").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Body(tokenReview).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/authentication/v1beta1/tokenreview.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/authentication/v1beta1/tokenreview.go
@@ -55,6 +55,7 @@ func newTokenReviews(c *AuthenticationV1beta1Client) *tokenReviews {
 func (c *tokenReviews) Create(ctx context.Context, tokenReview *v1beta1.TokenReview, opts v1.CreateOptions) (result *v1beta1.TokenReview, err error) {
 	result = &v1beta1.TokenReview{}
 	err = c.client.Post().
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("tokenreviews").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Body(tokenReview).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/authorization/v1/localsubjectaccessreview.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/authorization/v1/localsubjectaccessreview.go
@@ -58,6 +58,7 @@ func (c *localSubjectAccessReviews) Create(ctx context.Context, localSubjectAcce
 	result = &v1.LocalSubjectAccessReview{}
 	err = c.client.Post().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("localsubjectaccessreviews").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Body(localSubjectAccessReview).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/authorization/v1/selfsubjectaccessreview.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/authorization/v1/selfsubjectaccessreview.go
@@ -55,6 +55,7 @@ func newSelfSubjectAccessReviews(c *AuthorizationV1Client) *selfSubjectAccessRev
 func (c *selfSubjectAccessReviews) Create(ctx context.Context, selfSubjectAccessReview *v1.SelfSubjectAccessReview, opts metav1.CreateOptions) (result *v1.SelfSubjectAccessReview, err error) {
 	result = &v1.SelfSubjectAccessReview{}
 	err = c.client.Post().
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("selfsubjectaccessreviews").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Body(selfSubjectAccessReview).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/authorization/v1/selfsubjectrulesreview.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/authorization/v1/selfsubjectrulesreview.go
@@ -55,6 +55,7 @@ func newSelfSubjectRulesReviews(c *AuthorizationV1Client) *selfSubjectRulesRevie
 func (c *selfSubjectRulesReviews) Create(ctx context.Context, selfSubjectRulesReview *v1.SelfSubjectRulesReview, opts metav1.CreateOptions) (result *v1.SelfSubjectRulesReview, err error) {
 	result = &v1.SelfSubjectRulesReview{}
 	err = c.client.Post().
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("selfsubjectrulesreviews").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Body(selfSubjectRulesReview).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/authorization/v1/subjectaccessreview.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/authorization/v1/subjectaccessreview.go
@@ -55,6 +55,7 @@ func newSubjectAccessReviews(c *AuthorizationV1Client) *subjectAccessReviews {
 func (c *subjectAccessReviews) Create(ctx context.Context, subjectAccessReview *v1.SubjectAccessReview, opts metav1.CreateOptions) (result *v1.SubjectAccessReview, err error) {
 	result = &v1.SubjectAccessReview{}
 	err = c.client.Post().
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("subjectaccessreviews").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Body(subjectAccessReview).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/authorization/v1beta1/localsubjectaccessreview.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/authorization/v1beta1/localsubjectaccessreview.go
@@ -58,6 +58,7 @@ func (c *localSubjectAccessReviews) Create(ctx context.Context, localSubjectAcce
 	result = &v1beta1.LocalSubjectAccessReview{}
 	err = c.client.Post().
 		Namespace(c.ns).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("localsubjectaccessreviews").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Body(localSubjectAccessReview).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/authorization/v1beta1/selfsubjectaccessreview.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/authorization/v1beta1/selfsubjectaccessreview.go
@@ -55,6 +55,7 @@ func newSelfSubjectAccessReviews(c *AuthorizationV1beta1Client) *selfSubjectAcce
 func (c *selfSubjectAccessReviews) Create(ctx context.Context, selfSubjectAccessReview *v1beta1.SelfSubjectAccessReview, opts v1.CreateOptions) (result *v1beta1.SelfSubjectAccessReview, err error) {
 	result = &v1beta1.SelfSubjectAccessReview{}
 	err = c.client.Post().
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("selfsubjectaccessreviews").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Body(selfSubjectAccessReview).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/authorization/v1beta1/selfsubjectrulesreview.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/authorization/v1beta1/selfsubjectrulesreview.go
@@ -55,6 +55,7 @@ func newSelfSubjectRulesReviews(c *AuthorizationV1beta1Client) *selfSubjectRules
 func (c *selfSubjectRulesReviews) Create(ctx context.Context, selfSubjectRulesReview *v1beta1.SelfSubjectRulesReview, opts v1.CreateOptions) (result *v1beta1.SelfSubjectRulesReview, err error) {
 	result = &v1beta1.SelfSubjectRulesReview{}
 	err = c.client.Post().
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("selfsubjectrulesreviews").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Body(selfSubjectRulesReview).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/authorization/v1beta1/subjectaccessreview.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/authorization/v1beta1/subjectaccessreview.go
@@ -55,6 +55,7 @@ func newSubjectAccessReviews(c *AuthorizationV1beta1Client) *subjectAccessReview
 func (c *subjectAccessReviews) Create(ctx context.Context, subjectAccessReview *v1beta1.SubjectAccessReview, opts v1.CreateOptions) (result *v1beta1.SubjectAccessReview, err error) {
 	result = &v1beta1.SubjectAccessReview{}
 	err = c.client.Post().
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("subjectaccessreviews").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Body(subjectAccessReview).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/autoscaling/v1/horizontalpodautoscaler.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/autoscaling/v1/horizontalpodautoscaler.go
@@ -74,6 +74,7 @@ func (c *horizontalPodAutoscalers) Get(ctx context.Context, name string, options
 	result = &v1.HorizontalPodAutoscaler{}
 	err = c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("horizontalpodautoscalers").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
@@ -91,6 +92,7 @@ func (c *horizontalPodAutoscalers) List(ctx context.Context, opts metav1.ListOpt
 	result = &v1.HorizontalPodAutoscalerList{}
 	err = c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("horizontalpodautoscalers").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -108,6 +110,7 @@ func (c *horizontalPodAutoscalers) Watch(ctx context.Context, opts metav1.ListOp
 	opts.Watch = true
 	return c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("horizontalpodautoscalers").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -119,6 +122,7 @@ func (c *horizontalPodAutoscalers) Create(ctx context.Context, horizontalPodAuto
 	result = &v1.HorizontalPodAutoscaler{}
 	err = c.client.Post().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("horizontalpodautoscalers").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Body(horizontalPodAutoscaler).
@@ -132,6 +136,7 @@ func (c *horizontalPodAutoscalers) Update(ctx context.Context, horizontalPodAuto
 	result = &v1.HorizontalPodAutoscaler{}
 	err = c.client.Put().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("horizontalpodautoscalers").
 		Name(horizontalPodAutoscaler.Name).
 		VersionedParams(&opts, scheme.ParameterCodec).
@@ -147,6 +152,7 @@ func (c *horizontalPodAutoscalers) UpdateStatus(ctx context.Context, horizontalP
 	result = &v1.HorizontalPodAutoscaler{}
 	err = c.client.Put().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("horizontalpodautoscalers").
 		Name(horizontalPodAutoscaler.Name).
 		SubResource("status").
@@ -161,6 +167,7 @@ func (c *horizontalPodAutoscalers) UpdateStatus(ctx context.Context, horizontalP
 func (c *horizontalPodAutoscalers) Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error {
 	return c.client.Delete().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("horizontalpodautoscalers").
 		Name(name).
 		Body(&opts).
@@ -176,6 +183,7 @@ func (c *horizontalPodAutoscalers) DeleteCollection(ctx context.Context, opts me
 	}
 	return c.client.Delete().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("horizontalpodautoscalers").
 		VersionedParams(&listOpts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -189,6 +197,7 @@ func (c *horizontalPodAutoscalers) Patch(ctx context.Context, name string, pt ty
 	result = &v1.HorizontalPodAutoscaler{}
 	err = c.client.Patch(pt).
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("horizontalpodautoscalers").
 		Name(name).
 		SubResource(subresources...).
@@ -216,6 +225,7 @@ func (c *horizontalPodAutoscalers) Apply(ctx context.Context, horizontalPodAutos
 	result = &v1.HorizontalPodAutoscaler{}
 	err = c.client.Patch(types.ApplyPatchType).
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("horizontalpodautoscalers").
 		Name(*name).
 		VersionedParams(&patchOpts, scheme.ParameterCodec).
@@ -245,6 +255,7 @@ func (c *horizontalPodAutoscalers) ApplyStatus(ctx context.Context, horizontalPo
 	result = &v1.HorizontalPodAutoscaler{}
 	err = c.client.Patch(types.ApplyPatchType).
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("horizontalpodautoscalers").
 		Name(*name).
 		SubResource("status").

--- a/staging/src/k8s.io/client-go/kubernetes/typed/autoscaling/v2beta1/horizontalpodautoscaler.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/autoscaling/v2beta1/horizontalpodautoscaler.go
@@ -74,6 +74,7 @@ func (c *horizontalPodAutoscalers) Get(ctx context.Context, name string, options
 	result = &v2beta1.HorizontalPodAutoscaler{}
 	err = c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(v2beta1.SchemeGroupVersion).
 		Resource("horizontalpodautoscalers").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
@@ -91,6 +92,7 @@ func (c *horizontalPodAutoscalers) List(ctx context.Context, opts v1.ListOptions
 	result = &v2beta1.HorizontalPodAutoscalerList{}
 	err = c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(v2beta1.SchemeGroupVersion).
 		Resource("horizontalpodautoscalers").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -108,6 +110,7 @@ func (c *horizontalPodAutoscalers) Watch(ctx context.Context, opts v1.ListOption
 	opts.Watch = true
 	return c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(v2beta1.SchemeGroupVersion).
 		Resource("horizontalpodautoscalers").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -119,6 +122,7 @@ func (c *horizontalPodAutoscalers) Create(ctx context.Context, horizontalPodAuto
 	result = &v2beta1.HorizontalPodAutoscaler{}
 	err = c.client.Post().
 		Namespace(c.ns).
+		GroupVersion(v2beta1.SchemeGroupVersion).
 		Resource("horizontalpodautoscalers").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Body(horizontalPodAutoscaler).
@@ -132,6 +136,7 @@ func (c *horizontalPodAutoscalers) Update(ctx context.Context, horizontalPodAuto
 	result = &v2beta1.HorizontalPodAutoscaler{}
 	err = c.client.Put().
 		Namespace(c.ns).
+		GroupVersion(v2beta1.SchemeGroupVersion).
 		Resource("horizontalpodautoscalers").
 		Name(horizontalPodAutoscaler.Name).
 		VersionedParams(&opts, scheme.ParameterCodec).
@@ -147,6 +152,7 @@ func (c *horizontalPodAutoscalers) UpdateStatus(ctx context.Context, horizontalP
 	result = &v2beta1.HorizontalPodAutoscaler{}
 	err = c.client.Put().
 		Namespace(c.ns).
+		GroupVersion(v2beta1.SchemeGroupVersion).
 		Resource("horizontalpodautoscalers").
 		Name(horizontalPodAutoscaler.Name).
 		SubResource("status").
@@ -161,6 +167,7 @@ func (c *horizontalPodAutoscalers) UpdateStatus(ctx context.Context, horizontalP
 func (c *horizontalPodAutoscalers) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
 	return c.client.Delete().
 		Namespace(c.ns).
+		GroupVersion(v2beta1.SchemeGroupVersion).
 		Resource("horizontalpodautoscalers").
 		Name(name).
 		Body(&opts).
@@ -176,6 +183,7 @@ func (c *horizontalPodAutoscalers) DeleteCollection(ctx context.Context, opts v1
 	}
 	return c.client.Delete().
 		Namespace(c.ns).
+		GroupVersion(v2beta1.SchemeGroupVersion).
 		Resource("horizontalpodautoscalers").
 		VersionedParams(&listOpts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -189,6 +197,7 @@ func (c *horizontalPodAutoscalers) Patch(ctx context.Context, name string, pt ty
 	result = &v2beta1.HorizontalPodAutoscaler{}
 	err = c.client.Patch(pt).
 		Namespace(c.ns).
+		GroupVersion(v2beta1.SchemeGroupVersion).
 		Resource("horizontalpodautoscalers").
 		Name(name).
 		SubResource(subresources...).
@@ -216,6 +225,7 @@ func (c *horizontalPodAutoscalers) Apply(ctx context.Context, horizontalPodAutos
 	result = &v2beta1.HorizontalPodAutoscaler{}
 	err = c.client.Patch(types.ApplyPatchType).
 		Namespace(c.ns).
+		GroupVersion(v2beta1.SchemeGroupVersion).
 		Resource("horizontalpodautoscalers").
 		Name(*name).
 		VersionedParams(&patchOpts, scheme.ParameterCodec).
@@ -245,6 +255,7 @@ func (c *horizontalPodAutoscalers) ApplyStatus(ctx context.Context, horizontalPo
 	result = &v2beta1.HorizontalPodAutoscaler{}
 	err = c.client.Patch(types.ApplyPatchType).
 		Namespace(c.ns).
+		GroupVersion(v2beta1.SchemeGroupVersion).
 		Resource("horizontalpodautoscalers").
 		Name(*name).
 		SubResource("status").

--- a/staging/src/k8s.io/client-go/kubernetes/typed/autoscaling/v2beta2/horizontalpodautoscaler.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/autoscaling/v2beta2/horizontalpodautoscaler.go
@@ -74,6 +74,7 @@ func (c *horizontalPodAutoscalers) Get(ctx context.Context, name string, options
 	result = &v2beta2.HorizontalPodAutoscaler{}
 	err = c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(v2beta2.SchemeGroupVersion).
 		Resource("horizontalpodautoscalers").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
@@ -91,6 +92,7 @@ func (c *horizontalPodAutoscalers) List(ctx context.Context, opts v1.ListOptions
 	result = &v2beta2.HorizontalPodAutoscalerList{}
 	err = c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(v2beta2.SchemeGroupVersion).
 		Resource("horizontalpodautoscalers").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -108,6 +110,7 @@ func (c *horizontalPodAutoscalers) Watch(ctx context.Context, opts v1.ListOption
 	opts.Watch = true
 	return c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(v2beta2.SchemeGroupVersion).
 		Resource("horizontalpodautoscalers").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -119,6 +122,7 @@ func (c *horizontalPodAutoscalers) Create(ctx context.Context, horizontalPodAuto
 	result = &v2beta2.HorizontalPodAutoscaler{}
 	err = c.client.Post().
 		Namespace(c.ns).
+		GroupVersion(v2beta2.SchemeGroupVersion).
 		Resource("horizontalpodautoscalers").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Body(horizontalPodAutoscaler).
@@ -132,6 +136,7 @@ func (c *horizontalPodAutoscalers) Update(ctx context.Context, horizontalPodAuto
 	result = &v2beta2.HorizontalPodAutoscaler{}
 	err = c.client.Put().
 		Namespace(c.ns).
+		GroupVersion(v2beta2.SchemeGroupVersion).
 		Resource("horizontalpodautoscalers").
 		Name(horizontalPodAutoscaler.Name).
 		VersionedParams(&opts, scheme.ParameterCodec).
@@ -147,6 +152,7 @@ func (c *horizontalPodAutoscalers) UpdateStatus(ctx context.Context, horizontalP
 	result = &v2beta2.HorizontalPodAutoscaler{}
 	err = c.client.Put().
 		Namespace(c.ns).
+		GroupVersion(v2beta2.SchemeGroupVersion).
 		Resource("horizontalpodautoscalers").
 		Name(horizontalPodAutoscaler.Name).
 		SubResource("status").
@@ -161,6 +167,7 @@ func (c *horizontalPodAutoscalers) UpdateStatus(ctx context.Context, horizontalP
 func (c *horizontalPodAutoscalers) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
 	return c.client.Delete().
 		Namespace(c.ns).
+		GroupVersion(v2beta2.SchemeGroupVersion).
 		Resource("horizontalpodautoscalers").
 		Name(name).
 		Body(&opts).
@@ -176,6 +183,7 @@ func (c *horizontalPodAutoscalers) DeleteCollection(ctx context.Context, opts v1
 	}
 	return c.client.Delete().
 		Namespace(c.ns).
+		GroupVersion(v2beta2.SchemeGroupVersion).
 		Resource("horizontalpodautoscalers").
 		VersionedParams(&listOpts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -189,6 +197,7 @@ func (c *horizontalPodAutoscalers) Patch(ctx context.Context, name string, pt ty
 	result = &v2beta2.HorizontalPodAutoscaler{}
 	err = c.client.Patch(pt).
 		Namespace(c.ns).
+		GroupVersion(v2beta2.SchemeGroupVersion).
 		Resource("horizontalpodautoscalers").
 		Name(name).
 		SubResource(subresources...).
@@ -216,6 +225,7 @@ func (c *horizontalPodAutoscalers) Apply(ctx context.Context, horizontalPodAutos
 	result = &v2beta2.HorizontalPodAutoscaler{}
 	err = c.client.Patch(types.ApplyPatchType).
 		Namespace(c.ns).
+		GroupVersion(v2beta2.SchemeGroupVersion).
 		Resource("horizontalpodautoscalers").
 		Name(*name).
 		VersionedParams(&patchOpts, scheme.ParameterCodec).
@@ -245,6 +255,7 @@ func (c *horizontalPodAutoscalers) ApplyStatus(ctx context.Context, horizontalPo
 	result = &v2beta2.HorizontalPodAutoscaler{}
 	err = c.client.Patch(types.ApplyPatchType).
 		Namespace(c.ns).
+		GroupVersion(v2beta2.SchemeGroupVersion).
 		Resource("horizontalpodautoscalers").
 		Name(*name).
 		SubResource("status").

--- a/staging/src/k8s.io/client-go/kubernetes/typed/batch/v1/cronjob.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/batch/v1/cronjob.go
@@ -74,6 +74,7 @@ func (c *cronJobs) Get(ctx context.Context, name string, options metav1.GetOptio
 	result = &v1.CronJob{}
 	err = c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("cronjobs").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
@@ -91,6 +92,7 @@ func (c *cronJobs) List(ctx context.Context, opts metav1.ListOptions) (result *v
 	result = &v1.CronJobList{}
 	err = c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("cronjobs").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -108,6 +110,7 @@ func (c *cronJobs) Watch(ctx context.Context, opts metav1.ListOptions) (watch.In
 	opts.Watch = true
 	return c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("cronjobs").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -119,6 +122,7 @@ func (c *cronJobs) Create(ctx context.Context, cronJob *v1.CronJob, opts metav1.
 	result = &v1.CronJob{}
 	err = c.client.Post().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("cronjobs").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Body(cronJob).
@@ -132,6 +136,7 @@ func (c *cronJobs) Update(ctx context.Context, cronJob *v1.CronJob, opts metav1.
 	result = &v1.CronJob{}
 	err = c.client.Put().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("cronjobs").
 		Name(cronJob.Name).
 		VersionedParams(&opts, scheme.ParameterCodec).
@@ -147,6 +152,7 @@ func (c *cronJobs) UpdateStatus(ctx context.Context, cronJob *v1.CronJob, opts m
 	result = &v1.CronJob{}
 	err = c.client.Put().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("cronjobs").
 		Name(cronJob.Name).
 		SubResource("status").
@@ -161,6 +167,7 @@ func (c *cronJobs) UpdateStatus(ctx context.Context, cronJob *v1.CronJob, opts m
 func (c *cronJobs) Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error {
 	return c.client.Delete().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("cronjobs").
 		Name(name).
 		Body(&opts).
@@ -176,6 +183,7 @@ func (c *cronJobs) DeleteCollection(ctx context.Context, opts metav1.DeleteOptio
 	}
 	return c.client.Delete().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("cronjobs").
 		VersionedParams(&listOpts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -189,6 +197,7 @@ func (c *cronJobs) Patch(ctx context.Context, name string, pt types.PatchType, d
 	result = &v1.CronJob{}
 	err = c.client.Patch(pt).
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("cronjobs").
 		Name(name).
 		SubResource(subresources...).
@@ -216,6 +225,7 @@ func (c *cronJobs) Apply(ctx context.Context, cronJob *batchv1.CronJobApplyConfi
 	result = &v1.CronJob{}
 	err = c.client.Patch(types.ApplyPatchType).
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("cronjobs").
 		Name(*name).
 		VersionedParams(&patchOpts, scheme.ParameterCodec).
@@ -245,6 +255,7 @@ func (c *cronJobs) ApplyStatus(ctx context.Context, cronJob *batchv1.CronJobAppl
 	result = &v1.CronJob{}
 	err = c.client.Patch(types.ApplyPatchType).
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("cronjobs").
 		Name(*name).
 		SubResource("status").

--- a/staging/src/k8s.io/client-go/kubernetes/typed/batch/v1/job.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/batch/v1/job.go
@@ -74,6 +74,7 @@ func (c *jobs) Get(ctx context.Context, name string, options metav1.GetOptions) 
 	result = &v1.Job{}
 	err = c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("jobs").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
@@ -91,6 +92,7 @@ func (c *jobs) List(ctx context.Context, opts metav1.ListOptions) (result *v1.Jo
 	result = &v1.JobList{}
 	err = c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("jobs").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -108,6 +110,7 @@ func (c *jobs) Watch(ctx context.Context, opts metav1.ListOptions) (watch.Interf
 	opts.Watch = true
 	return c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("jobs").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -119,6 +122,7 @@ func (c *jobs) Create(ctx context.Context, job *v1.Job, opts metav1.CreateOption
 	result = &v1.Job{}
 	err = c.client.Post().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("jobs").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Body(job).
@@ -132,6 +136,7 @@ func (c *jobs) Update(ctx context.Context, job *v1.Job, opts metav1.UpdateOption
 	result = &v1.Job{}
 	err = c.client.Put().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("jobs").
 		Name(job.Name).
 		VersionedParams(&opts, scheme.ParameterCodec).
@@ -147,6 +152,7 @@ func (c *jobs) UpdateStatus(ctx context.Context, job *v1.Job, opts metav1.Update
 	result = &v1.Job{}
 	err = c.client.Put().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("jobs").
 		Name(job.Name).
 		SubResource("status").
@@ -161,6 +167,7 @@ func (c *jobs) UpdateStatus(ctx context.Context, job *v1.Job, opts metav1.Update
 func (c *jobs) Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error {
 	return c.client.Delete().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("jobs").
 		Name(name).
 		Body(&opts).
@@ -176,6 +183,7 @@ func (c *jobs) DeleteCollection(ctx context.Context, opts metav1.DeleteOptions, 
 	}
 	return c.client.Delete().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("jobs").
 		VersionedParams(&listOpts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -189,6 +197,7 @@ func (c *jobs) Patch(ctx context.Context, name string, pt types.PatchType, data 
 	result = &v1.Job{}
 	err = c.client.Patch(pt).
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("jobs").
 		Name(name).
 		SubResource(subresources...).
@@ -216,6 +225,7 @@ func (c *jobs) Apply(ctx context.Context, job *batchv1.JobApplyConfiguration, op
 	result = &v1.Job{}
 	err = c.client.Patch(types.ApplyPatchType).
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("jobs").
 		Name(*name).
 		VersionedParams(&patchOpts, scheme.ParameterCodec).
@@ -245,6 +255,7 @@ func (c *jobs) ApplyStatus(ctx context.Context, job *batchv1.JobApplyConfigurati
 	result = &v1.Job{}
 	err = c.client.Patch(types.ApplyPatchType).
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("jobs").
 		Name(*name).
 		SubResource("status").

--- a/staging/src/k8s.io/client-go/kubernetes/typed/batch/v1beta1/cronjob.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/batch/v1beta1/cronjob.go
@@ -74,6 +74,7 @@ func (c *cronJobs) Get(ctx context.Context, name string, options v1.GetOptions) 
 	result = &v1beta1.CronJob{}
 	err = c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("cronjobs").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
@@ -91,6 +92,7 @@ func (c *cronJobs) List(ctx context.Context, opts v1.ListOptions) (result *v1bet
 	result = &v1beta1.CronJobList{}
 	err = c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("cronjobs").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -108,6 +110,7 @@ func (c *cronJobs) Watch(ctx context.Context, opts v1.ListOptions) (watch.Interf
 	opts.Watch = true
 	return c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("cronjobs").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -119,6 +122,7 @@ func (c *cronJobs) Create(ctx context.Context, cronJob *v1beta1.CronJob, opts v1
 	result = &v1beta1.CronJob{}
 	err = c.client.Post().
 		Namespace(c.ns).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("cronjobs").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Body(cronJob).
@@ -132,6 +136,7 @@ func (c *cronJobs) Update(ctx context.Context, cronJob *v1beta1.CronJob, opts v1
 	result = &v1beta1.CronJob{}
 	err = c.client.Put().
 		Namespace(c.ns).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("cronjobs").
 		Name(cronJob.Name).
 		VersionedParams(&opts, scheme.ParameterCodec).
@@ -147,6 +152,7 @@ func (c *cronJobs) UpdateStatus(ctx context.Context, cronJob *v1beta1.CronJob, o
 	result = &v1beta1.CronJob{}
 	err = c.client.Put().
 		Namespace(c.ns).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("cronjobs").
 		Name(cronJob.Name).
 		SubResource("status").
@@ -161,6 +167,7 @@ func (c *cronJobs) UpdateStatus(ctx context.Context, cronJob *v1beta1.CronJob, o
 func (c *cronJobs) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
 	return c.client.Delete().
 		Namespace(c.ns).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("cronjobs").
 		Name(name).
 		Body(&opts).
@@ -176,6 +183,7 @@ func (c *cronJobs) DeleteCollection(ctx context.Context, opts v1.DeleteOptions, 
 	}
 	return c.client.Delete().
 		Namespace(c.ns).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("cronjobs").
 		VersionedParams(&listOpts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -189,6 +197,7 @@ func (c *cronJobs) Patch(ctx context.Context, name string, pt types.PatchType, d
 	result = &v1beta1.CronJob{}
 	err = c.client.Patch(pt).
 		Namespace(c.ns).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("cronjobs").
 		Name(name).
 		SubResource(subresources...).
@@ -216,6 +225,7 @@ func (c *cronJobs) Apply(ctx context.Context, cronJob *batchv1beta1.CronJobApply
 	result = &v1beta1.CronJob{}
 	err = c.client.Patch(types.ApplyPatchType).
 		Namespace(c.ns).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("cronjobs").
 		Name(*name).
 		VersionedParams(&patchOpts, scheme.ParameterCodec).
@@ -245,6 +255,7 @@ func (c *cronJobs) ApplyStatus(ctx context.Context, cronJob *batchv1beta1.CronJo
 	result = &v1beta1.CronJob{}
 	err = c.client.Patch(types.ApplyPatchType).
 		Namespace(c.ns).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("cronjobs").
 		Name(*name).
 		SubResource("status").

--- a/staging/src/k8s.io/client-go/kubernetes/typed/certificates/v1/certificatesigningrequest.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/certificates/v1/certificatesigningrequest.go
@@ -73,6 +73,7 @@ func newCertificateSigningRequests(c *CertificatesV1Client) *certificateSigningR
 func (c *certificateSigningRequests) Get(ctx context.Context, name string, options metav1.GetOptions) (result *v1.CertificateSigningRequest, err error) {
 	result = &v1.CertificateSigningRequest{}
 	err = c.client.Get().
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("certificatesigningrequests").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
@@ -89,6 +90,7 @@ func (c *certificateSigningRequests) List(ctx context.Context, opts metav1.ListO
 	}
 	result = &v1.CertificateSigningRequestList{}
 	err = c.client.Get().
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("certificatesigningrequests").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -105,6 +107,7 @@ func (c *certificateSigningRequests) Watch(ctx context.Context, opts metav1.List
 	}
 	opts.Watch = true
 	return c.client.Get().
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("certificatesigningrequests").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -115,6 +118,7 @@ func (c *certificateSigningRequests) Watch(ctx context.Context, opts metav1.List
 func (c *certificateSigningRequests) Create(ctx context.Context, certificateSigningRequest *v1.CertificateSigningRequest, opts metav1.CreateOptions) (result *v1.CertificateSigningRequest, err error) {
 	result = &v1.CertificateSigningRequest{}
 	err = c.client.Post().
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("certificatesigningrequests").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Body(certificateSigningRequest).
@@ -127,6 +131,7 @@ func (c *certificateSigningRequests) Create(ctx context.Context, certificateSign
 func (c *certificateSigningRequests) Update(ctx context.Context, certificateSigningRequest *v1.CertificateSigningRequest, opts metav1.UpdateOptions) (result *v1.CertificateSigningRequest, err error) {
 	result = &v1.CertificateSigningRequest{}
 	err = c.client.Put().
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("certificatesigningrequests").
 		Name(certificateSigningRequest.Name).
 		VersionedParams(&opts, scheme.ParameterCodec).
@@ -141,6 +146,7 @@ func (c *certificateSigningRequests) Update(ctx context.Context, certificateSign
 func (c *certificateSigningRequests) UpdateStatus(ctx context.Context, certificateSigningRequest *v1.CertificateSigningRequest, opts metav1.UpdateOptions) (result *v1.CertificateSigningRequest, err error) {
 	result = &v1.CertificateSigningRequest{}
 	err = c.client.Put().
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("certificatesigningrequests").
 		Name(certificateSigningRequest.Name).
 		SubResource("status").
@@ -154,6 +160,7 @@ func (c *certificateSigningRequests) UpdateStatus(ctx context.Context, certifica
 // Delete takes name of the certificateSigningRequest and deletes it. Returns an error if one occurs.
 func (c *certificateSigningRequests) Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error {
 	return c.client.Delete().
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("certificatesigningrequests").
 		Name(name).
 		Body(&opts).
@@ -168,6 +175,7 @@ func (c *certificateSigningRequests) DeleteCollection(ctx context.Context, opts 
 		timeout = time.Duration(*listOpts.TimeoutSeconds) * time.Second
 	}
 	return c.client.Delete().
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("certificatesigningrequests").
 		VersionedParams(&listOpts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -180,6 +188,7 @@ func (c *certificateSigningRequests) DeleteCollection(ctx context.Context, opts 
 func (c *certificateSigningRequests) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts metav1.PatchOptions, subresources ...string) (result *v1.CertificateSigningRequest, err error) {
 	result = &v1.CertificateSigningRequest{}
 	err = c.client.Patch(pt).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("certificatesigningrequests").
 		Name(name).
 		SubResource(subresources...).
@@ -206,6 +215,7 @@ func (c *certificateSigningRequests) Apply(ctx context.Context, certificateSigni
 	}
 	result = &v1.CertificateSigningRequest{}
 	err = c.client.Patch(types.ApplyPatchType).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("certificatesigningrequests").
 		Name(*name).
 		VersionedParams(&patchOpts, scheme.ParameterCodec).
@@ -234,6 +244,7 @@ func (c *certificateSigningRequests) ApplyStatus(ctx context.Context, certificat
 
 	result = &v1.CertificateSigningRequest{}
 	err = c.client.Patch(types.ApplyPatchType).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("certificatesigningrequests").
 		Name(*name).
 		SubResource("status").
@@ -248,6 +259,7 @@ func (c *certificateSigningRequests) ApplyStatus(ctx context.Context, certificat
 func (c *certificateSigningRequests) UpdateApproval(ctx context.Context, certificateSigningRequestName string, certificateSigningRequest *v1.CertificateSigningRequest, opts metav1.UpdateOptions) (result *v1.CertificateSigningRequest, err error) {
 	result = &v1.CertificateSigningRequest{}
 	err = c.client.Put().
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("certificatesigningrequests").
 		Name(certificateSigningRequestName).
 		SubResource("approval").

--- a/staging/src/k8s.io/client-go/kubernetes/typed/certificates/v1beta1/certificatesigningrequest.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/certificates/v1beta1/certificatesigningrequest.go
@@ -71,6 +71,7 @@ func newCertificateSigningRequests(c *CertificatesV1beta1Client) *certificateSig
 func (c *certificateSigningRequests) Get(ctx context.Context, name string, options v1.GetOptions) (result *v1beta1.CertificateSigningRequest, err error) {
 	result = &v1beta1.CertificateSigningRequest{}
 	err = c.client.Get().
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("certificatesigningrequests").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
@@ -87,6 +88,7 @@ func (c *certificateSigningRequests) List(ctx context.Context, opts v1.ListOptio
 	}
 	result = &v1beta1.CertificateSigningRequestList{}
 	err = c.client.Get().
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("certificatesigningrequests").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -103,6 +105,7 @@ func (c *certificateSigningRequests) Watch(ctx context.Context, opts v1.ListOpti
 	}
 	opts.Watch = true
 	return c.client.Get().
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("certificatesigningrequests").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -113,6 +116,7 @@ func (c *certificateSigningRequests) Watch(ctx context.Context, opts v1.ListOpti
 func (c *certificateSigningRequests) Create(ctx context.Context, certificateSigningRequest *v1beta1.CertificateSigningRequest, opts v1.CreateOptions) (result *v1beta1.CertificateSigningRequest, err error) {
 	result = &v1beta1.CertificateSigningRequest{}
 	err = c.client.Post().
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("certificatesigningrequests").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Body(certificateSigningRequest).
@@ -125,6 +129,7 @@ func (c *certificateSigningRequests) Create(ctx context.Context, certificateSign
 func (c *certificateSigningRequests) Update(ctx context.Context, certificateSigningRequest *v1beta1.CertificateSigningRequest, opts v1.UpdateOptions) (result *v1beta1.CertificateSigningRequest, err error) {
 	result = &v1beta1.CertificateSigningRequest{}
 	err = c.client.Put().
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("certificatesigningrequests").
 		Name(certificateSigningRequest.Name).
 		VersionedParams(&opts, scheme.ParameterCodec).
@@ -139,6 +144,7 @@ func (c *certificateSigningRequests) Update(ctx context.Context, certificateSign
 func (c *certificateSigningRequests) UpdateStatus(ctx context.Context, certificateSigningRequest *v1beta1.CertificateSigningRequest, opts v1.UpdateOptions) (result *v1beta1.CertificateSigningRequest, err error) {
 	result = &v1beta1.CertificateSigningRequest{}
 	err = c.client.Put().
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("certificatesigningrequests").
 		Name(certificateSigningRequest.Name).
 		SubResource("status").
@@ -152,6 +158,7 @@ func (c *certificateSigningRequests) UpdateStatus(ctx context.Context, certifica
 // Delete takes name of the certificateSigningRequest and deletes it. Returns an error if one occurs.
 func (c *certificateSigningRequests) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
 	return c.client.Delete().
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("certificatesigningrequests").
 		Name(name).
 		Body(&opts).
@@ -166,6 +173,7 @@ func (c *certificateSigningRequests) DeleteCollection(ctx context.Context, opts 
 		timeout = time.Duration(*listOpts.TimeoutSeconds) * time.Second
 	}
 	return c.client.Delete().
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("certificatesigningrequests").
 		VersionedParams(&listOpts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -178,6 +186,7 @@ func (c *certificateSigningRequests) DeleteCollection(ctx context.Context, opts 
 func (c *certificateSigningRequests) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts v1.PatchOptions, subresources ...string) (result *v1beta1.CertificateSigningRequest, err error) {
 	result = &v1beta1.CertificateSigningRequest{}
 	err = c.client.Patch(pt).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("certificatesigningrequests").
 		Name(name).
 		SubResource(subresources...).
@@ -204,6 +213,7 @@ func (c *certificateSigningRequests) Apply(ctx context.Context, certificateSigni
 	}
 	result = &v1beta1.CertificateSigningRequest{}
 	err = c.client.Patch(types.ApplyPatchType).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("certificatesigningrequests").
 		Name(*name).
 		VersionedParams(&patchOpts, scheme.ParameterCodec).
@@ -232,6 +242,7 @@ func (c *certificateSigningRequests) ApplyStatus(ctx context.Context, certificat
 
 	result = &v1beta1.CertificateSigningRequest{}
 	err = c.client.Patch(types.ApplyPatchType).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("certificatesigningrequests").
 		Name(*name).
 		SubResource("status").

--- a/staging/src/k8s.io/client-go/kubernetes/typed/certificates/v1beta1/certificatesigningrequest_expansion.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/certificates/v1beta1/certificatesigningrequest_expansion.go
@@ -31,6 +31,7 @@ type CertificateSigningRequestExpansion interface {
 func (c *certificateSigningRequests) UpdateApproval(ctx context.Context, certificateSigningRequest *certificates.CertificateSigningRequest, opts metav1.UpdateOptions) (result *certificates.CertificateSigningRequest, err error) {
 	result = &certificates.CertificateSigningRequest{}
 	err = c.client.Put().
+		GroupVersion(certificates.SchemeGroupVersion).
 		Resource("certificatesigningrequests").
 		Name(certificateSigningRequest.Name).
 		VersionedParams(&opts, scheme.ParameterCodec).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/coordination/v1/lease.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/coordination/v1/lease.go
@@ -72,6 +72,7 @@ func (c *leases) Get(ctx context.Context, name string, options metav1.GetOptions
 	result = &v1.Lease{}
 	err = c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("leases").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
@@ -89,6 +90,7 @@ func (c *leases) List(ctx context.Context, opts metav1.ListOptions) (result *v1.
 	result = &v1.LeaseList{}
 	err = c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("leases").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -106,6 +108,7 @@ func (c *leases) Watch(ctx context.Context, opts metav1.ListOptions) (watch.Inte
 	opts.Watch = true
 	return c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("leases").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -117,6 +120,7 @@ func (c *leases) Create(ctx context.Context, lease *v1.Lease, opts metav1.Create
 	result = &v1.Lease{}
 	err = c.client.Post().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("leases").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Body(lease).
@@ -130,6 +134,7 @@ func (c *leases) Update(ctx context.Context, lease *v1.Lease, opts metav1.Update
 	result = &v1.Lease{}
 	err = c.client.Put().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("leases").
 		Name(lease.Name).
 		VersionedParams(&opts, scheme.ParameterCodec).
@@ -143,6 +148,7 @@ func (c *leases) Update(ctx context.Context, lease *v1.Lease, opts metav1.Update
 func (c *leases) Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error {
 	return c.client.Delete().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("leases").
 		Name(name).
 		Body(&opts).
@@ -158,6 +164,7 @@ func (c *leases) DeleteCollection(ctx context.Context, opts metav1.DeleteOptions
 	}
 	return c.client.Delete().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("leases").
 		VersionedParams(&listOpts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -171,6 +178,7 @@ func (c *leases) Patch(ctx context.Context, name string, pt types.PatchType, dat
 	result = &v1.Lease{}
 	err = c.client.Patch(pt).
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("leases").
 		Name(name).
 		SubResource(subresources...).
@@ -198,6 +206,7 @@ func (c *leases) Apply(ctx context.Context, lease *coordinationv1.LeaseApplyConf
 	result = &v1.Lease{}
 	err = c.client.Patch(types.ApplyPatchType).
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("leases").
 		Name(*name).
 		VersionedParams(&patchOpts, scheme.ParameterCodec).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/coordination/v1beta1/lease.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/coordination/v1beta1/lease.go
@@ -72,6 +72,7 @@ func (c *leases) Get(ctx context.Context, name string, options v1.GetOptions) (r
 	result = &v1beta1.Lease{}
 	err = c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("leases").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
@@ -89,6 +90,7 @@ func (c *leases) List(ctx context.Context, opts v1.ListOptions) (result *v1beta1
 	result = &v1beta1.LeaseList{}
 	err = c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("leases").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -106,6 +108,7 @@ func (c *leases) Watch(ctx context.Context, opts v1.ListOptions) (watch.Interfac
 	opts.Watch = true
 	return c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("leases").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -117,6 +120,7 @@ func (c *leases) Create(ctx context.Context, lease *v1beta1.Lease, opts v1.Creat
 	result = &v1beta1.Lease{}
 	err = c.client.Post().
 		Namespace(c.ns).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("leases").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Body(lease).
@@ -130,6 +134,7 @@ func (c *leases) Update(ctx context.Context, lease *v1beta1.Lease, opts v1.Updat
 	result = &v1beta1.Lease{}
 	err = c.client.Put().
 		Namespace(c.ns).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("leases").
 		Name(lease.Name).
 		VersionedParams(&opts, scheme.ParameterCodec).
@@ -143,6 +148,7 @@ func (c *leases) Update(ctx context.Context, lease *v1beta1.Lease, opts v1.Updat
 func (c *leases) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
 	return c.client.Delete().
 		Namespace(c.ns).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("leases").
 		Name(name).
 		Body(&opts).
@@ -158,6 +164,7 @@ func (c *leases) DeleteCollection(ctx context.Context, opts v1.DeleteOptions, li
 	}
 	return c.client.Delete().
 		Namespace(c.ns).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("leases").
 		VersionedParams(&listOpts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -171,6 +178,7 @@ func (c *leases) Patch(ctx context.Context, name string, pt types.PatchType, dat
 	result = &v1beta1.Lease{}
 	err = c.client.Patch(pt).
 		Namespace(c.ns).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("leases").
 		Name(name).
 		SubResource(subresources...).
@@ -198,6 +206,7 @@ func (c *leases) Apply(ctx context.Context, lease *coordinationv1beta1.LeaseAppl
 	result = &v1beta1.Lease{}
 	err = c.client.Patch(types.ApplyPatchType).
 		Namespace(c.ns).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("leases").
 		Name(*name).
 		VersionedParams(&patchOpts, scheme.ParameterCodec).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/componentstatus.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/componentstatus.go
@@ -69,6 +69,7 @@ func newComponentStatuses(c *CoreV1Client) *componentStatuses {
 func (c *componentStatuses) Get(ctx context.Context, name string, options metav1.GetOptions) (result *v1.ComponentStatus, err error) {
 	result = &v1.ComponentStatus{}
 	err = c.client.Get().
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("componentstatuses").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
@@ -85,6 +86,7 @@ func (c *componentStatuses) List(ctx context.Context, opts metav1.ListOptions) (
 	}
 	result = &v1.ComponentStatusList{}
 	err = c.client.Get().
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("componentstatuses").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -101,6 +103,7 @@ func (c *componentStatuses) Watch(ctx context.Context, opts metav1.ListOptions) 
 	}
 	opts.Watch = true
 	return c.client.Get().
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("componentstatuses").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -111,6 +114,7 @@ func (c *componentStatuses) Watch(ctx context.Context, opts metav1.ListOptions) 
 func (c *componentStatuses) Create(ctx context.Context, componentStatus *v1.ComponentStatus, opts metav1.CreateOptions) (result *v1.ComponentStatus, err error) {
 	result = &v1.ComponentStatus{}
 	err = c.client.Post().
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("componentstatuses").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Body(componentStatus).
@@ -123,6 +127,7 @@ func (c *componentStatuses) Create(ctx context.Context, componentStatus *v1.Comp
 func (c *componentStatuses) Update(ctx context.Context, componentStatus *v1.ComponentStatus, opts metav1.UpdateOptions) (result *v1.ComponentStatus, err error) {
 	result = &v1.ComponentStatus{}
 	err = c.client.Put().
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("componentstatuses").
 		Name(componentStatus.Name).
 		VersionedParams(&opts, scheme.ParameterCodec).
@@ -135,6 +140,7 @@ func (c *componentStatuses) Update(ctx context.Context, componentStatus *v1.Comp
 // Delete takes name of the componentStatus and deletes it. Returns an error if one occurs.
 func (c *componentStatuses) Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error {
 	return c.client.Delete().
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("componentstatuses").
 		Name(name).
 		Body(&opts).
@@ -149,6 +155,7 @@ func (c *componentStatuses) DeleteCollection(ctx context.Context, opts metav1.De
 		timeout = time.Duration(*listOpts.TimeoutSeconds) * time.Second
 	}
 	return c.client.Delete().
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("componentstatuses").
 		VersionedParams(&listOpts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -161,6 +168,7 @@ func (c *componentStatuses) DeleteCollection(ctx context.Context, opts metav1.De
 func (c *componentStatuses) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts metav1.PatchOptions, subresources ...string) (result *v1.ComponentStatus, err error) {
 	result = &v1.ComponentStatus{}
 	err = c.client.Patch(pt).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("componentstatuses").
 		Name(name).
 		SubResource(subresources...).
@@ -187,6 +195,7 @@ func (c *componentStatuses) Apply(ctx context.Context, componentStatus *corev1.C
 	}
 	result = &v1.ComponentStatus{}
 	err = c.client.Patch(types.ApplyPatchType).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("componentstatuses").
 		Name(*name).
 		VersionedParams(&patchOpts, scheme.ParameterCodec).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/configmap.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/configmap.go
@@ -72,6 +72,7 @@ func (c *configMaps) Get(ctx context.Context, name string, options metav1.GetOpt
 	result = &v1.ConfigMap{}
 	err = c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("configmaps").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
@@ -89,6 +90,7 @@ func (c *configMaps) List(ctx context.Context, opts metav1.ListOptions) (result 
 	result = &v1.ConfigMapList{}
 	err = c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("configmaps").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -106,6 +108,7 @@ func (c *configMaps) Watch(ctx context.Context, opts metav1.ListOptions) (watch.
 	opts.Watch = true
 	return c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("configmaps").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -117,6 +120,7 @@ func (c *configMaps) Create(ctx context.Context, configMap *v1.ConfigMap, opts m
 	result = &v1.ConfigMap{}
 	err = c.client.Post().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("configmaps").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Body(configMap).
@@ -130,6 +134,7 @@ func (c *configMaps) Update(ctx context.Context, configMap *v1.ConfigMap, opts m
 	result = &v1.ConfigMap{}
 	err = c.client.Put().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("configmaps").
 		Name(configMap.Name).
 		VersionedParams(&opts, scheme.ParameterCodec).
@@ -143,6 +148,7 @@ func (c *configMaps) Update(ctx context.Context, configMap *v1.ConfigMap, opts m
 func (c *configMaps) Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error {
 	return c.client.Delete().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("configmaps").
 		Name(name).
 		Body(&opts).
@@ -158,6 +164,7 @@ func (c *configMaps) DeleteCollection(ctx context.Context, opts metav1.DeleteOpt
 	}
 	return c.client.Delete().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("configmaps").
 		VersionedParams(&listOpts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -171,6 +178,7 @@ func (c *configMaps) Patch(ctx context.Context, name string, pt types.PatchType,
 	result = &v1.ConfigMap{}
 	err = c.client.Patch(pt).
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("configmaps").
 		Name(name).
 		SubResource(subresources...).
@@ -198,6 +206,7 @@ func (c *configMaps) Apply(ctx context.Context, configMap *corev1.ConfigMapApply
 	result = &v1.ConfigMap{}
 	err = c.client.Patch(types.ApplyPatchType).
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("configmaps").
 		Name(*name).
 		VersionedParams(&patchOpts, scheme.ParameterCodec).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/endpoints.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/endpoints.go
@@ -72,6 +72,7 @@ func (c *endpoints) Get(ctx context.Context, name string, options metav1.GetOpti
 	result = &v1.Endpoints{}
 	err = c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("endpoints").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
@@ -89,6 +90,7 @@ func (c *endpoints) List(ctx context.Context, opts metav1.ListOptions) (result *
 	result = &v1.EndpointsList{}
 	err = c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("endpoints").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -106,6 +108,7 @@ func (c *endpoints) Watch(ctx context.Context, opts metav1.ListOptions) (watch.I
 	opts.Watch = true
 	return c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("endpoints").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -117,6 +120,7 @@ func (c *endpoints) Create(ctx context.Context, endpoints *v1.Endpoints, opts me
 	result = &v1.Endpoints{}
 	err = c.client.Post().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("endpoints").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Body(endpoints).
@@ -130,6 +134,7 @@ func (c *endpoints) Update(ctx context.Context, endpoints *v1.Endpoints, opts me
 	result = &v1.Endpoints{}
 	err = c.client.Put().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("endpoints").
 		Name(endpoints.Name).
 		VersionedParams(&opts, scheme.ParameterCodec).
@@ -143,6 +148,7 @@ func (c *endpoints) Update(ctx context.Context, endpoints *v1.Endpoints, opts me
 func (c *endpoints) Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error {
 	return c.client.Delete().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("endpoints").
 		Name(name).
 		Body(&opts).
@@ -158,6 +164,7 @@ func (c *endpoints) DeleteCollection(ctx context.Context, opts metav1.DeleteOpti
 	}
 	return c.client.Delete().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("endpoints").
 		VersionedParams(&listOpts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -171,6 +178,7 @@ func (c *endpoints) Patch(ctx context.Context, name string, pt types.PatchType, 
 	result = &v1.Endpoints{}
 	err = c.client.Patch(pt).
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("endpoints").
 		Name(name).
 		SubResource(subresources...).
@@ -198,6 +206,7 @@ func (c *endpoints) Apply(ctx context.Context, endpoints *corev1.EndpointsApplyC
 	result = &v1.Endpoints{}
 	err = c.client.Patch(types.ApplyPatchType).
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("endpoints").
 		Name(*name).
 		VersionedParams(&patchOpts, scheme.ParameterCodec).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/event.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/event.go
@@ -72,6 +72,7 @@ func (c *events) Get(ctx context.Context, name string, options metav1.GetOptions
 	result = &v1.Event{}
 	err = c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("events").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
@@ -89,6 +90,7 @@ func (c *events) List(ctx context.Context, opts metav1.ListOptions) (result *v1.
 	result = &v1.EventList{}
 	err = c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("events").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -106,6 +108,7 @@ func (c *events) Watch(ctx context.Context, opts metav1.ListOptions) (watch.Inte
 	opts.Watch = true
 	return c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("events").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -117,6 +120,7 @@ func (c *events) Create(ctx context.Context, event *v1.Event, opts metav1.Create
 	result = &v1.Event{}
 	err = c.client.Post().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("events").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Body(event).
@@ -130,6 +134,7 @@ func (c *events) Update(ctx context.Context, event *v1.Event, opts metav1.Update
 	result = &v1.Event{}
 	err = c.client.Put().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("events").
 		Name(event.Name).
 		VersionedParams(&opts, scheme.ParameterCodec).
@@ -143,6 +148,7 @@ func (c *events) Update(ctx context.Context, event *v1.Event, opts metav1.Update
 func (c *events) Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error {
 	return c.client.Delete().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("events").
 		Name(name).
 		Body(&opts).
@@ -158,6 +164,7 @@ func (c *events) DeleteCollection(ctx context.Context, opts metav1.DeleteOptions
 	}
 	return c.client.Delete().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("events").
 		VersionedParams(&listOpts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -171,6 +178,7 @@ func (c *events) Patch(ctx context.Context, name string, pt types.PatchType, dat
 	result = &v1.Event{}
 	err = c.client.Patch(pt).
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("events").
 		Name(name).
 		SubResource(subresources...).
@@ -198,6 +206,7 @@ func (c *events) Apply(ctx context.Context, event *corev1.EventApplyConfiguratio
 	result = &v1.Event{}
 	err = c.client.Patch(types.ApplyPatchType).
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("events").
 		Name(*name).
 		VersionedParams(&patchOpts, scheme.ParameterCodec).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/limitrange.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/limitrange.go
@@ -72,6 +72,7 @@ func (c *limitRanges) Get(ctx context.Context, name string, options metav1.GetOp
 	result = &v1.LimitRange{}
 	err = c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("limitranges").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
@@ -89,6 +90,7 @@ func (c *limitRanges) List(ctx context.Context, opts metav1.ListOptions) (result
 	result = &v1.LimitRangeList{}
 	err = c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("limitranges").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -106,6 +108,7 @@ func (c *limitRanges) Watch(ctx context.Context, opts metav1.ListOptions) (watch
 	opts.Watch = true
 	return c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("limitranges").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -117,6 +120,7 @@ func (c *limitRanges) Create(ctx context.Context, limitRange *v1.LimitRange, opt
 	result = &v1.LimitRange{}
 	err = c.client.Post().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("limitranges").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Body(limitRange).
@@ -130,6 +134,7 @@ func (c *limitRanges) Update(ctx context.Context, limitRange *v1.LimitRange, opt
 	result = &v1.LimitRange{}
 	err = c.client.Put().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("limitranges").
 		Name(limitRange.Name).
 		VersionedParams(&opts, scheme.ParameterCodec).
@@ -143,6 +148,7 @@ func (c *limitRanges) Update(ctx context.Context, limitRange *v1.LimitRange, opt
 func (c *limitRanges) Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error {
 	return c.client.Delete().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("limitranges").
 		Name(name).
 		Body(&opts).
@@ -158,6 +164,7 @@ func (c *limitRanges) DeleteCollection(ctx context.Context, opts metav1.DeleteOp
 	}
 	return c.client.Delete().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("limitranges").
 		VersionedParams(&listOpts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -171,6 +178,7 @@ func (c *limitRanges) Patch(ctx context.Context, name string, pt types.PatchType
 	result = &v1.LimitRange{}
 	err = c.client.Patch(pt).
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("limitranges").
 		Name(name).
 		SubResource(subresources...).
@@ -198,6 +206,7 @@ func (c *limitRanges) Apply(ctx context.Context, limitRange *corev1.LimitRangeAp
 	result = &v1.LimitRange{}
 	err = c.client.Patch(types.ApplyPatchType).
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("limitranges").
 		Name(*name).
 		VersionedParams(&patchOpts, scheme.ParameterCodec).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/namespace.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/namespace.go
@@ -70,6 +70,7 @@ func newNamespaces(c *CoreV1Client) *namespaces {
 func (c *namespaces) Get(ctx context.Context, name string, options metav1.GetOptions) (result *v1.Namespace, err error) {
 	result = &v1.Namespace{}
 	err = c.client.Get().
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("namespaces").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
@@ -86,6 +87,7 @@ func (c *namespaces) List(ctx context.Context, opts metav1.ListOptions) (result 
 	}
 	result = &v1.NamespaceList{}
 	err = c.client.Get().
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("namespaces").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -102,6 +104,7 @@ func (c *namespaces) Watch(ctx context.Context, opts metav1.ListOptions) (watch.
 	}
 	opts.Watch = true
 	return c.client.Get().
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("namespaces").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -112,6 +115,7 @@ func (c *namespaces) Watch(ctx context.Context, opts metav1.ListOptions) (watch.
 func (c *namespaces) Create(ctx context.Context, namespace *v1.Namespace, opts metav1.CreateOptions) (result *v1.Namespace, err error) {
 	result = &v1.Namespace{}
 	err = c.client.Post().
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("namespaces").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Body(namespace).
@@ -124,6 +128,7 @@ func (c *namespaces) Create(ctx context.Context, namespace *v1.Namespace, opts m
 func (c *namespaces) Update(ctx context.Context, namespace *v1.Namespace, opts metav1.UpdateOptions) (result *v1.Namespace, err error) {
 	result = &v1.Namespace{}
 	err = c.client.Put().
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("namespaces").
 		Name(namespace.Name).
 		VersionedParams(&opts, scheme.ParameterCodec).
@@ -138,6 +143,7 @@ func (c *namespaces) Update(ctx context.Context, namespace *v1.Namespace, opts m
 func (c *namespaces) UpdateStatus(ctx context.Context, namespace *v1.Namespace, opts metav1.UpdateOptions) (result *v1.Namespace, err error) {
 	result = &v1.Namespace{}
 	err = c.client.Put().
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("namespaces").
 		Name(namespace.Name).
 		SubResource("status").
@@ -151,6 +157,7 @@ func (c *namespaces) UpdateStatus(ctx context.Context, namespace *v1.Namespace, 
 // Delete takes name of the namespace and deletes it. Returns an error if one occurs.
 func (c *namespaces) Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error {
 	return c.client.Delete().
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("namespaces").
 		Name(name).
 		Body(&opts).
@@ -162,6 +169,7 @@ func (c *namespaces) Delete(ctx context.Context, name string, opts metav1.Delete
 func (c *namespaces) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts metav1.PatchOptions, subresources ...string) (result *v1.Namespace, err error) {
 	result = &v1.Namespace{}
 	err = c.client.Patch(pt).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("namespaces").
 		Name(name).
 		SubResource(subresources...).
@@ -188,6 +196,7 @@ func (c *namespaces) Apply(ctx context.Context, namespace *corev1.NamespaceApply
 	}
 	result = &v1.Namespace{}
 	err = c.client.Patch(types.ApplyPatchType).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("namespaces").
 		Name(*name).
 		VersionedParams(&patchOpts, scheme.ParameterCodec).
@@ -216,6 +225,7 @@ func (c *namespaces) ApplyStatus(ctx context.Context, namespace *corev1.Namespac
 
 	result = &v1.Namespace{}
 	err = c.client.Patch(types.ApplyPatchType).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("namespaces").
 		Name(*name).
 		SubResource("status").

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/node.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/node.go
@@ -71,6 +71,7 @@ func newNodes(c *CoreV1Client) *nodes {
 func (c *nodes) Get(ctx context.Context, name string, options metav1.GetOptions) (result *v1.Node, err error) {
 	result = &v1.Node{}
 	err = c.client.Get().
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("nodes").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
@@ -87,6 +88,7 @@ func (c *nodes) List(ctx context.Context, opts metav1.ListOptions) (result *v1.N
 	}
 	result = &v1.NodeList{}
 	err = c.client.Get().
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("nodes").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -103,6 +105,7 @@ func (c *nodes) Watch(ctx context.Context, opts metav1.ListOptions) (watch.Inter
 	}
 	opts.Watch = true
 	return c.client.Get().
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("nodes").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -113,6 +116,7 @@ func (c *nodes) Watch(ctx context.Context, opts metav1.ListOptions) (watch.Inter
 func (c *nodes) Create(ctx context.Context, node *v1.Node, opts metav1.CreateOptions) (result *v1.Node, err error) {
 	result = &v1.Node{}
 	err = c.client.Post().
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("nodes").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Body(node).
@@ -125,6 +129,7 @@ func (c *nodes) Create(ctx context.Context, node *v1.Node, opts metav1.CreateOpt
 func (c *nodes) Update(ctx context.Context, node *v1.Node, opts metav1.UpdateOptions) (result *v1.Node, err error) {
 	result = &v1.Node{}
 	err = c.client.Put().
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("nodes").
 		Name(node.Name).
 		VersionedParams(&opts, scheme.ParameterCodec).
@@ -139,6 +144,7 @@ func (c *nodes) Update(ctx context.Context, node *v1.Node, opts metav1.UpdateOpt
 func (c *nodes) UpdateStatus(ctx context.Context, node *v1.Node, opts metav1.UpdateOptions) (result *v1.Node, err error) {
 	result = &v1.Node{}
 	err = c.client.Put().
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("nodes").
 		Name(node.Name).
 		SubResource("status").
@@ -152,6 +158,7 @@ func (c *nodes) UpdateStatus(ctx context.Context, node *v1.Node, opts metav1.Upd
 // Delete takes name of the node and deletes it. Returns an error if one occurs.
 func (c *nodes) Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error {
 	return c.client.Delete().
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("nodes").
 		Name(name).
 		Body(&opts).
@@ -166,6 +173,7 @@ func (c *nodes) DeleteCollection(ctx context.Context, opts metav1.DeleteOptions,
 		timeout = time.Duration(*listOpts.TimeoutSeconds) * time.Second
 	}
 	return c.client.Delete().
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("nodes").
 		VersionedParams(&listOpts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -178,6 +186,7 @@ func (c *nodes) DeleteCollection(ctx context.Context, opts metav1.DeleteOptions,
 func (c *nodes) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts metav1.PatchOptions, subresources ...string) (result *v1.Node, err error) {
 	result = &v1.Node{}
 	err = c.client.Patch(pt).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("nodes").
 		Name(name).
 		SubResource(subresources...).
@@ -204,6 +213,7 @@ func (c *nodes) Apply(ctx context.Context, node *corev1.NodeApplyConfiguration, 
 	}
 	result = &v1.Node{}
 	err = c.client.Patch(types.ApplyPatchType).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("nodes").
 		Name(*name).
 		VersionedParams(&patchOpts, scheme.ParameterCodec).
@@ -232,6 +242,7 @@ func (c *nodes) ApplyStatus(ctx context.Context, node *corev1.NodeApplyConfigura
 
 	result = &v1.Node{}
 	err = c.client.Patch(types.ApplyPatchType).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("nodes").
 		Name(*name).
 		SubResource("status").

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/persistentvolume.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/persistentvolume.go
@@ -71,6 +71,7 @@ func newPersistentVolumes(c *CoreV1Client) *persistentVolumes {
 func (c *persistentVolumes) Get(ctx context.Context, name string, options metav1.GetOptions) (result *v1.PersistentVolume, err error) {
 	result = &v1.PersistentVolume{}
 	err = c.client.Get().
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("persistentvolumes").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
@@ -87,6 +88,7 @@ func (c *persistentVolumes) List(ctx context.Context, opts metav1.ListOptions) (
 	}
 	result = &v1.PersistentVolumeList{}
 	err = c.client.Get().
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("persistentvolumes").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -103,6 +105,7 @@ func (c *persistentVolumes) Watch(ctx context.Context, opts metav1.ListOptions) 
 	}
 	opts.Watch = true
 	return c.client.Get().
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("persistentvolumes").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -113,6 +116,7 @@ func (c *persistentVolumes) Watch(ctx context.Context, opts metav1.ListOptions) 
 func (c *persistentVolumes) Create(ctx context.Context, persistentVolume *v1.PersistentVolume, opts metav1.CreateOptions) (result *v1.PersistentVolume, err error) {
 	result = &v1.PersistentVolume{}
 	err = c.client.Post().
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("persistentvolumes").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Body(persistentVolume).
@@ -125,6 +129,7 @@ func (c *persistentVolumes) Create(ctx context.Context, persistentVolume *v1.Per
 func (c *persistentVolumes) Update(ctx context.Context, persistentVolume *v1.PersistentVolume, opts metav1.UpdateOptions) (result *v1.PersistentVolume, err error) {
 	result = &v1.PersistentVolume{}
 	err = c.client.Put().
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("persistentvolumes").
 		Name(persistentVolume.Name).
 		VersionedParams(&opts, scheme.ParameterCodec).
@@ -139,6 +144,7 @@ func (c *persistentVolumes) Update(ctx context.Context, persistentVolume *v1.Per
 func (c *persistentVolumes) UpdateStatus(ctx context.Context, persistentVolume *v1.PersistentVolume, opts metav1.UpdateOptions) (result *v1.PersistentVolume, err error) {
 	result = &v1.PersistentVolume{}
 	err = c.client.Put().
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("persistentvolumes").
 		Name(persistentVolume.Name).
 		SubResource("status").
@@ -152,6 +158,7 @@ func (c *persistentVolumes) UpdateStatus(ctx context.Context, persistentVolume *
 // Delete takes name of the persistentVolume and deletes it. Returns an error if one occurs.
 func (c *persistentVolumes) Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error {
 	return c.client.Delete().
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("persistentvolumes").
 		Name(name).
 		Body(&opts).
@@ -166,6 +173,7 @@ func (c *persistentVolumes) DeleteCollection(ctx context.Context, opts metav1.De
 		timeout = time.Duration(*listOpts.TimeoutSeconds) * time.Second
 	}
 	return c.client.Delete().
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("persistentvolumes").
 		VersionedParams(&listOpts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -178,6 +186,7 @@ func (c *persistentVolumes) DeleteCollection(ctx context.Context, opts metav1.De
 func (c *persistentVolumes) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts metav1.PatchOptions, subresources ...string) (result *v1.PersistentVolume, err error) {
 	result = &v1.PersistentVolume{}
 	err = c.client.Patch(pt).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("persistentvolumes").
 		Name(name).
 		SubResource(subresources...).
@@ -204,6 +213,7 @@ func (c *persistentVolumes) Apply(ctx context.Context, persistentVolume *corev1.
 	}
 	result = &v1.PersistentVolume{}
 	err = c.client.Patch(types.ApplyPatchType).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("persistentvolumes").
 		Name(*name).
 		VersionedParams(&patchOpts, scheme.ParameterCodec).
@@ -232,6 +242,7 @@ func (c *persistentVolumes) ApplyStatus(ctx context.Context, persistentVolume *c
 
 	result = &v1.PersistentVolume{}
 	err = c.client.Patch(types.ApplyPatchType).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("persistentvolumes").
 		Name(*name).
 		SubResource("status").

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/persistentvolumeclaim.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/persistentvolumeclaim.go
@@ -74,6 +74,7 @@ func (c *persistentVolumeClaims) Get(ctx context.Context, name string, options m
 	result = &v1.PersistentVolumeClaim{}
 	err = c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("persistentvolumeclaims").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
@@ -91,6 +92,7 @@ func (c *persistentVolumeClaims) List(ctx context.Context, opts metav1.ListOptio
 	result = &v1.PersistentVolumeClaimList{}
 	err = c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("persistentvolumeclaims").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -108,6 +110,7 @@ func (c *persistentVolumeClaims) Watch(ctx context.Context, opts metav1.ListOpti
 	opts.Watch = true
 	return c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("persistentvolumeclaims").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -119,6 +122,7 @@ func (c *persistentVolumeClaims) Create(ctx context.Context, persistentVolumeCla
 	result = &v1.PersistentVolumeClaim{}
 	err = c.client.Post().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("persistentvolumeclaims").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Body(persistentVolumeClaim).
@@ -132,6 +136,7 @@ func (c *persistentVolumeClaims) Update(ctx context.Context, persistentVolumeCla
 	result = &v1.PersistentVolumeClaim{}
 	err = c.client.Put().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("persistentvolumeclaims").
 		Name(persistentVolumeClaim.Name).
 		VersionedParams(&opts, scheme.ParameterCodec).
@@ -147,6 +152,7 @@ func (c *persistentVolumeClaims) UpdateStatus(ctx context.Context, persistentVol
 	result = &v1.PersistentVolumeClaim{}
 	err = c.client.Put().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("persistentvolumeclaims").
 		Name(persistentVolumeClaim.Name).
 		SubResource("status").
@@ -161,6 +167,7 @@ func (c *persistentVolumeClaims) UpdateStatus(ctx context.Context, persistentVol
 func (c *persistentVolumeClaims) Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error {
 	return c.client.Delete().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("persistentvolumeclaims").
 		Name(name).
 		Body(&opts).
@@ -176,6 +183,7 @@ func (c *persistentVolumeClaims) DeleteCollection(ctx context.Context, opts meta
 	}
 	return c.client.Delete().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("persistentvolumeclaims").
 		VersionedParams(&listOpts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -189,6 +197,7 @@ func (c *persistentVolumeClaims) Patch(ctx context.Context, name string, pt type
 	result = &v1.PersistentVolumeClaim{}
 	err = c.client.Patch(pt).
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("persistentvolumeclaims").
 		Name(name).
 		SubResource(subresources...).
@@ -216,6 +225,7 @@ func (c *persistentVolumeClaims) Apply(ctx context.Context, persistentVolumeClai
 	result = &v1.PersistentVolumeClaim{}
 	err = c.client.Patch(types.ApplyPatchType).
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("persistentvolumeclaims").
 		Name(*name).
 		VersionedParams(&patchOpts, scheme.ParameterCodec).
@@ -245,6 +255,7 @@ func (c *persistentVolumeClaims) ApplyStatus(ctx context.Context, persistentVolu
 	result = &v1.PersistentVolumeClaim{}
 	err = c.client.Patch(types.ApplyPatchType).
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("persistentvolumeclaims").
 		Name(*name).
 		SubResource("status").

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/pod.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/pod.go
@@ -76,6 +76,7 @@ func (c *pods) Get(ctx context.Context, name string, options metav1.GetOptions) 
 	result = &v1.Pod{}
 	err = c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("pods").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
@@ -93,6 +94,7 @@ func (c *pods) List(ctx context.Context, opts metav1.ListOptions) (result *v1.Po
 	result = &v1.PodList{}
 	err = c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("pods").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -110,6 +112,7 @@ func (c *pods) Watch(ctx context.Context, opts metav1.ListOptions) (watch.Interf
 	opts.Watch = true
 	return c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("pods").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -121,6 +124,7 @@ func (c *pods) Create(ctx context.Context, pod *v1.Pod, opts metav1.CreateOption
 	result = &v1.Pod{}
 	err = c.client.Post().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("pods").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Body(pod).
@@ -134,6 +138,7 @@ func (c *pods) Update(ctx context.Context, pod *v1.Pod, opts metav1.UpdateOption
 	result = &v1.Pod{}
 	err = c.client.Put().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("pods").
 		Name(pod.Name).
 		VersionedParams(&opts, scheme.ParameterCodec).
@@ -149,6 +154,7 @@ func (c *pods) UpdateStatus(ctx context.Context, pod *v1.Pod, opts metav1.Update
 	result = &v1.Pod{}
 	err = c.client.Put().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("pods").
 		Name(pod.Name).
 		SubResource("status").
@@ -163,6 +169,7 @@ func (c *pods) UpdateStatus(ctx context.Context, pod *v1.Pod, opts metav1.Update
 func (c *pods) Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error {
 	return c.client.Delete().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("pods").
 		Name(name).
 		Body(&opts).
@@ -178,6 +185,7 @@ func (c *pods) DeleteCollection(ctx context.Context, opts metav1.DeleteOptions, 
 	}
 	return c.client.Delete().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("pods").
 		VersionedParams(&listOpts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -191,6 +199,7 @@ func (c *pods) Patch(ctx context.Context, name string, pt types.PatchType, data 
 	result = &v1.Pod{}
 	err = c.client.Patch(pt).
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("pods").
 		Name(name).
 		SubResource(subresources...).
@@ -218,6 +227,7 @@ func (c *pods) Apply(ctx context.Context, pod *corev1.PodApplyConfiguration, opt
 	result = &v1.Pod{}
 	err = c.client.Patch(types.ApplyPatchType).
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("pods").
 		Name(*name).
 		VersionedParams(&patchOpts, scheme.ParameterCodec).
@@ -247,6 +257,7 @@ func (c *pods) ApplyStatus(ctx context.Context, pod *corev1.PodApplyConfiguratio
 	result = &v1.Pod{}
 	err = c.client.Patch(types.ApplyPatchType).
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("pods").
 		Name(*name).
 		SubResource("status").
@@ -262,6 +273,7 @@ func (c *pods) UpdateEphemeralContainers(ctx context.Context, podName string, po
 	result = &v1.Pod{}
 	err = c.client.Put().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("pods").
 		Name(podName).
 		SubResource("ephemeralcontainers").

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/pod_expansion.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/pod_expansion.go
@@ -54,26 +54,27 @@ func (c *pods) Bind(ctx context.Context, binding *v1.Binding, opts metav1.Create
 // Equivalent to calling EvictV1beta1.
 // Deprecated: Use EvictV1() (supported in 1.22+) or EvictV1beta1().
 func (c *pods) Evict(ctx context.Context, eviction *policyv1beta1.Eviction) error {
-	return c.client.Post().Namespace(c.ns).Resource("pods").Name(eviction.Name).SubResource("eviction").Body(eviction).Do(ctx).Error()
+	return c.client.Post().Namespace(c.ns).GroupVersion(policyv1beta1.SchemeGroupVersion).Resource("pods").Name(eviction.Name).SubResource("eviction").Body(eviction).Do(ctx).Error()
 }
 
 func (c *pods) EvictV1beta1(ctx context.Context, eviction *policyv1beta1.Eviction) error {
-	return c.client.Post().Namespace(c.ns).Resource("pods").Name(eviction.Name).SubResource("eviction").Body(eviction).Do(ctx).Error()
+	return c.client.Post().Namespace(c.ns).GroupVersion(policyv1beta1.SchemeGroupVersion).Resource("pods").Name(eviction.Name).SubResource("eviction").Body(eviction).Do(ctx).Error()
 }
 
 func (c *pods) EvictV1(ctx context.Context, eviction *policyv1.Eviction) error {
-	return c.client.Post().Namespace(c.ns).Resource("pods").Name(eviction.Name).SubResource("eviction").Body(eviction).Do(ctx).Error()
+	return c.client.Post().Namespace(c.ns).GroupVersion(policyv1.SchemeGroupVersion).Resource("pods").Name(eviction.Name).SubResource("eviction").Body(eviction).Do(ctx).Error()
 }
 
 // Get constructs a request for getting the logs for a pod
 func (c *pods) GetLogs(name string, opts *v1.PodLogOptions) *restclient.Request {
-	return c.client.Get().Namespace(c.ns).Name(name).Resource("pods").SubResource("log").VersionedParams(opts, scheme.ParameterCodec)
+	return c.client.Get().Namespace(c.ns).Name(name).GroupVersion(v1.SchemeGroupVersion).Resource("pods").SubResource("log").VersionedParams(opts, scheme.ParameterCodec)
 }
 
 // ProxyGet returns a response of the pod by calling it through the proxy.
 func (c *pods) ProxyGet(scheme, name, port, path string, params map[string]string) restclient.ResponseWrapper {
 	request := c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("pods").
 		SubResource("proxy").
 		Name(net.JoinSchemeNamePort(scheme, name, port)).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/podtemplate.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/podtemplate.go
@@ -72,6 +72,7 @@ func (c *podTemplates) Get(ctx context.Context, name string, options metav1.GetO
 	result = &v1.PodTemplate{}
 	err = c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("podtemplates").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
@@ -89,6 +90,7 @@ func (c *podTemplates) List(ctx context.Context, opts metav1.ListOptions) (resul
 	result = &v1.PodTemplateList{}
 	err = c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("podtemplates").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -106,6 +108,7 @@ func (c *podTemplates) Watch(ctx context.Context, opts metav1.ListOptions) (watc
 	opts.Watch = true
 	return c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("podtemplates").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -117,6 +120,7 @@ func (c *podTemplates) Create(ctx context.Context, podTemplate *v1.PodTemplate, 
 	result = &v1.PodTemplate{}
 	err = c.client.Post().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("podtemplates").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Body(podTemplate).
@@ -130,6 +134,7 @@ func (c *podTemplates) Update(ctx context.Context, podTemplate *v1.PodTemplate, 
 	result = &v1.PodTemplate{}
 	err = c.client.Put().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("podtemplates").
 		Name(podTemplate.Name).
 		VersionedParams(&opts, scheme.ParameterCodec).
@@ -143,6 +148,7 @@ func (c *podTemplates) Update(ctx context.Context, podTemplate *v1.PodTemplate, 
 func (c *podTemplates) Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error {
 	return c.client.Delete().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("podtemplates").
 		Name(name).
 		Body(&opts).
@@ -158,6 +164,7 @@ func (c *podTemplates) DeleteCollection(ctx context.Context, opts metav1.DeleteO
 	}
 	return c.client.Delete().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("podtemplates").
 		VersionedParams(&listOpts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -171,6 +178,7 @@ func (c *podTemplates) Patch(ctx context.Context, name string, pt types.PatchTyp
 	result = &v1.PodTemplate{}
 	err = c.client.Patch(pt).
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("podtemplates").
 		Name(name).
 		SubResource(subresources...).
@@ -198,6 +206,7 @@ func (c *podTemplates) Apply(ctx context.Context, podTemplate *corev1.PodTemplat
 	result = &v1.PodTemplate{}
 	err = c.client.Patch(types.ApplyPatchType).
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("podtemplates").
 		Name(*name).
 		VersionedParams(&patchOpts, scheme.ParameterCodec).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/replicationcontroller.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/replicationcontroller.go
@@ -78,6 +78,7 @@ func (c *replicationControllers) Get(ctx context.Context, name string, options m
 	result = &v1.ReplicationController{}
 	err = c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("replicationcontrollers").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
@@ -95,6 +96,7 @@ func (c *replicationControllers) List(ctx context.Context, opts metav1.ListOptio
 	result = &v1.ReplicationControllerList{}
 	err = c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("replicationcontrollers").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -112,6 +114,7 @@ func (c *replicationControllers) Watch(ctx context.Context, opts metav1.ListOpti
 	opts.Watch = true
 	return c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("replicationcontrollers").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -123,6 +126,7 @@ func (c *replicationControllers) Create(ctx context.Context, replicationControll
 	result = &v1.ReplicationController{}
 	err = c.client.Post().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("replicationcontrollers").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Body(replicationController).
@@ -136,6 +140,7 @@ func (c *replicationControllers) Update(ctx context.Context, replicationControll
 	result = &v1.ReplicationController{}
 	err = c.client.Put().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("replicationcontrollers").
 		Name(replicationController.Name).
 		VersionedParams(&opts, scheme.ParameterCodec).
@@ -151,6 +156,7 @@ func (c *replicationControllers) UpdateStatus(ctx context.Context, replicationCo
 	result = &v1.ReplicationController{}
 	err = c.client.Put().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("replicationcontrollers").
 		Name(replicationController.Name).
 		SubResource("status").
@@ -165,6 +171,7 @@ func (c *replicationControllers) UpdateStatus(ctx context.Context, replicationCo
 func (c *replicationControllers) Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error {
 	return c.client.Delete().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("replicationcontrollers").
 		Name(name).
 		Body(&opts).
@@ -180,6 +187,7 @@ func (c *replicationControllers) DeleteCollection(ctx context.Context, opts meta
 	}
 	return c.client.Delete().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("replicationcontrollers").
 		VersionedParams(&listOpts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -193,6 +201,7 @@ func (c *replicationControllers) Patch(ctx context.Context, name string, pt type
 	result = &v1.ReplicationController{}
 	err = c.client.Patch(pt).
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("replicationcontrollers").
 		Name(name).
 		SubResource(subresources...).
@@ -220,6 +229,7 @@ func (c *replicationControllers) Apply(ctx context.Context, replicationControlle
 	result = &v1.ReplicationController{}
 	err = c.client.Patch(types.ApplyPatchType).
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("replicationcontrollers").
 		Name(*name).
 		VersionedParams(&patchOpts, scheme.ParameterCodec).
@@ -249,6 +259,7 @@ func (c *replicationControllers) ApplyStatus(ctx context.Context, replicationCon
 	result = &v1.ReplicationController{}
 	err = c.client.Patch(types.ApplyPatchType).
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("replicationcontrollers").
 		Name(*name).
 		SubResource("status").
@@ -264,6 +275,7 @@ func (c *replicationControllers) GetScale(ctx context.Context, replicationContro
 	result = &autoscalingv1.Scale{}
 	err = c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("replicationcontrollers").
 		Name(replicationControllerName).
 		SubResource("scale").
@@ -278,6 +290,7 @@ func (c *replicationControllers) UpdateScale(ctx context.Context, replicationCon
 	result = &autoscalingv1.Scale{}
 	err = c.client.Put().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("replicationcontrollers").
 		Name(replicationControllerName).
 		SubResource("scale").

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/resourcequota.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/resourcequota.go
@@ -74,6 +74,7 @@ func (c *resourceQuotas) Get(ctx context.Context, name string, options metav1.Ge
 	result = &v1.ResourceQuota{}
 	err = c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("resourcequotas").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
@@ -91,6 +92,7 @@ func (c *resourceQuotas) List(ctx context.Context, opts metav1.ListOptions) (res
 	result = &v1.ResourceQuotaList{}
 	err = c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("resourcequotas").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -108,6 +110,7 @@ func (c *resourceQuotas) Watch(ctx context.Context, opts metav1.ListOptions) (wa
 	opts.Watch = true
 	return c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("resourcequotas").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -119,6 +122,7 @@ func (c *resourceQuotas) Create(ctx context.Context, resourceQuota *v1.ResourceQ
 	result = &v1.ResourceQuota{}
 	err = c.client.Post().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("resourcequotas").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Body(resourceQuota).
@@ -132,6 +136,7 @@ func (c *resourceQuotas) Update(ctx context.Context, resourceQuota *v1.ResourceQ
 	result = &v1.ResourceQuota{}
 	err = c.client.Put().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("resourcequotas").
 		Name(resourceQuota.Name).
 		VersionedParams(&opts, scheme.ParameterCodec).
@@ -147,6 +152,7 @@ func (c *resourceQuotas) UpdateStatus(ctx context.Context, resourceQuota *v1.Res
 	result = &v1.ResourceQuota{}
 	err = c.client.Put().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("resourcequotas").
 		Name(resourceQuota.Name).
 		SubResource("status").
@@ -161,6 +167,7 @@ func (c *resourceQuotas) UpdateStatus(ctx context.Context, resourceQuota *v1.Res
 func (c *resourceQuotas) Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error {
 	return c.client.Delete().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("resourcequotas").
 		Name(name).
 		Body(&opts).
@@ -176,6 +183,7 @@ func (c *resourceQuotas) DeleteCollection(ctx context.Context, opts metav1.Delet
 	}
 	return c.client.Delete().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("resourcequotas").
 		VersionedParams(&listOpts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -189,6 +197,7 @@ func (c *resourceQuotas) Patch(ctx context.Context, name string, pt types.PatchT
 	result = &v1.ResourceQuota{}
 	err = c.client.Patch(pt).
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("resourcequotas").
 		Name(name).
 		SubResource(subresources...).
@@ -216,6 +225,7 @@ func (c *resourceQuotas) Apply(ctx context.Context, resourceQuota *corev1.Resour
 	result = &v1.ResourceQuota{}
 	err = c.client.Patch(types.ApplyPatchType).
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("resourcequotas").
 		Name(*name).
 		VersionedParams(&patchOpts, scheme.ParameterCodec).
@@ -245,6 +255,7 @@ func (c *resourceQuotas) ApplyStatus(ctx context.Context, resourceQuota *corev1.
 	result = &v1.ResourceQuota{}
 	err = c.client.Patch(types.ApplyPatchType).
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("resourcequotas").
 		Name(*name).
 		SubResource("status").

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/secret.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/secret.go
@@ -72,6 +72,7 @@ func (c *secrets) Get(ctx context.Context, name string, options metav1.GetOption
 	result = &v1.Secret{}
 	err = c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("secrets").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
@@ -89,6 +90,7 @@ func (c *secrets) List(ctx context.Context, opts metav1.ListOptions) (result *v1
 	result = &v1.SecretList{}
 	err = c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("secrets").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -106,6 +108,7 @@ func (c *secrets) Watch(ctx context.Context, opts metav1.ListOptions) (watch.Int
 	opts.Watch = true
 	return c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("secrets").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -117,6 +120,7 @@ func (c *secrets) Create(ctx context.Context, secret *v1.Secret, opts metav1.Cre
 	result = &v1.Secret{}
 	err = c.client.Post().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("secrets").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Body(secret).
@@ -130,6 +134,7 @@ func (c *secrets) Update(ctx context.Context, secret *v1.Secret, opts metav1.Upd
 	result = &v1.Secret{}
 	err = c.client.Put().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("secrets").
 		Name(secret.Name).
 		VersionedParams(&opts, scheme.ParameterCodec).
@@ -143,6 +148,7 @@ func (c *secrets) Update(ctx context.Context, secret *v1.Secret, opts metav1.Upd
 func (c *secrets) Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error {
 	return c.client.Delete().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("secrets").
 		Name(name).
 		Body(&opts).
@@ -158,6 +164,7 @@ func (c *secrets) DeleteCollection(ctx context.Context, opts metav1.DeleteOption
 	}
 	return c.client.Delete().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("secrets").
 		VersionedParams(&listOpts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -171,6 +178,7 @@ func (c *secrets) Patch(ctx context.Context, name string, pt types.PatchType, da
 	result = &v1.Secret{}
 	err = c.client.Patch(pt).
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("secrets").
 		Name(name).
 		SubResource(subresources...).
@@ -198,6 +206,7 @@ func (c *secrets) Apply(ctx context.Context, secret *corev1.SecretApplyConfigura
 	result = &v1.Secret{}
 	err = c.client.Patch(types.ApplyPatchType).
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("secrets").
 		Name(*name).
 		VersionedParams(&patchOpts, scheme.ParameterCodec).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/service.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/service.go
@@ -73,6 +73,7 @@ func (c *services) Get(ctx context.Context, name string, options metav1.GetOptio
 	result = &v1.Service{}
 	err = c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("services").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
@@ -90,6 +91,7 @@ func (c *services) List(ctx context.Context, opts metav1.ListOptions) (result *v
 	result = &v1.ServiceList{}
 	err = c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("services").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -107,6 +109,7 @@ func (c *services) Watch(ctx context.Context, opts metav1.ListOptions) (watch.In
 	opts.Watch = true
 	return c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("services").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -118,6 +121,7 @@ func (c *services) Create(ctx context.Context, service *v1.Service, opts metav1.
 	result = &v1.Service{}
 	err = c.client.Post().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("services").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Body(service).
@@ -131,6 +135,7 @@ func (c *services) Update(ctx context.Context, service *v1.Service, opts metav1.
 	result = &v1.Service{}
 	err = c.client.Put().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("services").
 		Name(service.Name).
 		VersionedParams(&opts, scheme.ParameterCodec).
@@ -146,6 +151,7 @@ func (c *services) UpdateStatus(ctx context.Context, service *v1.Service, opts m
 	result = &v1.Service{}
 	err = c.client.Put().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("services").
 		Name(service.Name).
 		SubResource("status").
@@ -160,6 +166,7 @@ func (c *services) UpdateStatus(ctx context.Context, service *v1.Service, opts m
 func (c *services) Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error {
 	return c.client.Delete().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("services").
 		Name(name).
 		Body(&opts).
@@ -172,6 +179,7 @@ func (c *services) Patch(ctx context.Context, name string, pt types.PatchType, d
 	result = &v1.Service{}
 	err = c.client.Patch(pt).
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("services").
 		Name(name).
 		SubResource(subresources...).
@@ -199,6 +207,7 @@ func (c *services) Apply(ctx context.Context, service *corev1.ServiceApplyConfig
 	result = &v1.Service{}
 	err = c.client.Patch(types.ApplyPatchType).
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("services").
 		Name(*name).
 		VersionedParams(&patchOpts, scheme.ParameterCodec).
@@ -228,6 +237,7 @@ func (c *services) ApplyStatus(ctx context.Context, service *corev1.ServiceApply
 	result = &v1.Service{}
 	err = c.client.Patch(types.ApplyPatchType).
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("services").
 		Name(*name).
 		SubResource("status").

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/serviceaccount.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/serviceaccount.go
@@ -75,6 +75,7 @@ func (c *serviceAccounts) Get(ctx context.Context, name string, options metav1.G
 	result = &v1.ServiceAccount{}
 	err = c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("serviceaccounts").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
@@ -92,6 +93,7 @@ func (c *serviceAccounts) List(ctx context.Context, opts metav1.ListOptions) (re
 	result = &v1.ServiceAccountList{}
 	err = c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("serviceaccounts").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -109,6 +111,7 @@ func (c *serviceAccounts) Watch(ctx context.Context, opts metav1.ListOptions) (w
 	opts.Watch = true
 	return c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("serviceaccounts").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -120,6 +123,7 @@ func (c *serviceAccounts) Create(ctx context.Context, serviceAccount *v1.Service
 	result = &v1.ServiceAccount{}
 	err = c.client.Post().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("serviceaccounts").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Body(serviceAccount).
@@ -133,6 +137,7 @@ func (c *serviceAccounts) Update(ctx context.Context, serviceAccount *v1.Service
 	result = &v1.ServiceAccount{}
 	err = c.client.Put().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("serviceaccounts").
 		Name(serviceAccount.Name).
 		VersionedParams(&opts, scheme.ParameterCodec).
@@ -146,6 +151,7 @@ func (c *serviceAccounts) Update(ctx context.Context, serviceAccount *v1.Service
 func (c *serviceAccounts) Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error {
 	return c.client.Delete().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("serviceaccounts").
 		Name(name).
 		Body(&opts).
@@ -161,6 +167,7 @@ func (c *serviceAccounts) DeleteCollection(ctx context.Context, opts metav1.Dele
 	}
 	return c.client.Delete().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("serviceaccounts").
 		VersionedParams(&listOpts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -174,6 +181,7 @@ func (c *serviceAccounts) Patch(ctx context.Context, name string, pt types.Patch
 	result = &v1.ServiceAccount{}
 	err = c.client.Patch(pt).
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("serviceaccounts").
 		Name(name).
 		SubResource(subresources...).
@@ -201,6 +209,7 @@ func (c *serviceAccounts) Apply(ctx context.Context, serviceAccount *corev1.Serv
 	result = &v1.ServiceAccount{}
 	err = c.client.Patch(types.ApplyPatchType).
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("serviceaccounts").
 		Name(*name).
 		VersionedParams(&patchOpts, scheme.ParameterCodec).
@@ -215,6 +224,7 @@ func (c *serviceAccounts) CreateToken(ctx context.Context, serviceAccountName st
 	result = &authenticationv1.TokenRequest{}
 	err = c.client.Post().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("serviceaccounts").
 		Name(serviceAccountName).
 		SubResource("token").

--- a/staging/src/k8s.io/client-go/kubernetes/typed/discovery/v1/endpointslice.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/discovery/v1/endpointslice.go
@@ -72,6 +72,7 @@ func (c *endpointSlices) Get(ctx context.Context, name string, options metav1.Ge
 	result = &v1.EndpointSlice{}
 	err = c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("endpointslices").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
@@ -89,6 +90,7 @@ func (c *endpointSlices) List(ctx context.Context, opts metav1.ListOptions) (res
 	result = &v1.EndpointSliceList{}
 	err = c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("endpointslices").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -106,6 +108,7 @@ func (c *endpointSlices) Watch(ctx context.Context, opts metav1.ListOptions) (wa
 	opts.Watch = true
 	return c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("endpointslices").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -117,6 +120,7 @@ func (c *endpointSlices) Create(ctx context.Context, endpointSlice *v1.EndpointS
 	result = &v1.EndpointSlice{}
 	err = c.client.Post().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("endpointslices").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Body(endpointSlice).
@@ -130,6 +134,7 @@ func (c *endpointSlices) Update(ctx context.Context, endpointSlice *v1.EndpointS
 	result = &v1.EndpointSlice{}
 	err = c.client.Put().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("endpointslices").
 		Name(endpointSlice.Name).
 		VersionedParams(&opts, scheme.ParameterCodec).
@@ -143,6 +148,7 @@ func (c *endpointSlices) Update(ctx context.Context, endpointSlice *v1.EndpointS
 func (c *endpointSlices) Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error {
 	return c.client.Delete().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("endpointslices").
 		Name(name).
 		Body(&opts).
@@ -158,6 +164,7 @@ func (c *endpointSlices) DeleteCollection(ctx context.Context, opts metav1.Delet
 	}
 	return c.client.Delete().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("endpointslices").
 		VersionedParams(&listOpts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -171,6 +178,7 @@ func (c *endpointSlices) Patch(ctx context.Context, name string, pt types.PatchT
 	result = &v1.EndpointSlice{}
 	err = c.client.Patch(pt).
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("endpointslices").
 		Name(name).
 		SubResource(subresources...).
@@ -198,6 +206,7 @@ func (c *endpointSlices) Apply(ctx context.Context, endpointSlice *discoveryv1.E
 	result = &v1.EndpointSlice{}
 	err = c.client.Patch(types.ApplyPatchType).
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("endpointslices").
 		Name(*name).
 		VersionedParams(&patchOpts, scheme.ParameterCodec).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/discovery/v1beta1/endpointslice.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/discovery/v1beta1/endpointslice.go
@@ -72,6 +72,7 @@ func (c *endpointSlices) Get(ctx context.Context, name string, options v1.GetOpt
 	result = &v1beta1.EndpointSlice{}
 	err = c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("endpointslices").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
@@ -89,6 +90,7 @@ func (c *endpointSlices) List(ctx context.Context, opts v1.ListOptions) (result 
 	result = &v1beta1.EndpointSliceList{}
 	err = c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("endpointslices").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -106,6 +108,7 @@ func (c *endpointSlices) Watch(ctx context.Context, opts v1.ListOptions) (watch.
 	opts.Watch = true
 	return c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("endpointslices").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -117,6 +120,7 @@ func (c *endpointSlices) Create(ctx context.Context, endpointSlice *v1beta1.Endp
 	result = &v1beta1.EndpointSlice{}
 	err = c.client.Post().
 		Namespace(c.ns).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("endpointslices").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Body(endpointSlice).
@@ -130,6 +134,7 @@ func (c *endpointSlices) Update(ctx context.Context, endpointSlice *v1beta1.Endp
 	result = &v1beta1.EndpointSlice{}
 	err = c.client.Put().
 		Namespace(c.ns).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("endpointslices").
 		Name(endpointSlice.Name).
 		VersionedParams(&opts, scheme.ParameterCodec).
@@ -143,6 +148,7 @@ func (c *endpointSlices) Update(ctx context.Context, endpointSlice *v1beta1.Endp
 func (c *endpointSlices) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
 	return c.client.Delete().
 		Namespace(c.ns).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("endpointslices").
 		Name(name).
 		Body(&opts).
@@ -158,6 +164,7 @@ func (c *endpointSlices) DeleteCollection(ctx context.Context, opts v1.DeleteOpt
 	}
 	return c.client.Delete().
 		Namespace(c.ns).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("endpointslices").
 		VersionedParams(&listOpts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -171,6 +178,7 @@ func (c *endpointSlices) Patch(ctx context.Context, name string, pt types.PatchT
 	result = &v1beta1.EndpointSlice{}
 	err = c.client.Patch(pt).
 		Namespace(c.ns).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("endpointslices").
 		Name(name).
 		SubResource(subresources...).
@@ -198,6 +206,7 @@ func (c *endpointSlices) Apply(ctx context.Context, endpointSlice *discoveryv1be
 	result = &v1beta1.EndpointSlice{}
 	err = c.client.Patch(types.ApplyPatchType).
 		Namespace(c.ns).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("endpointslices").
 		Name(*name).
 		VersionedParams(&patchOpts, scheme.ParameterCodec).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/events/v1/event.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/events/v1/event.go
@@ -72,6 +72,7 @@ func (c *events) Get(ctx context.Context, name string, options metav1.GetOptions
 	result = &v1.Event{}
 	err = c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("events").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
@@ -89,6 +90,7 @@ func (c *events) List(ctx context.Context, opts metav1.ListOptions) (result *v1.
 	result = &v1.EventList{}
 	err = c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("events").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -106,6 +108,7 @@ func (c *events) Watch(ctx context.Context, opts metav1.ListOptions) (watch.Inte
 	opts.Watch = true
 	return c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("events").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -117,6 +120,7 @@ func (c *events) Create(ctx context.Context, event *v1.Event, opts metav1.Create
 	result = &v1.Event{}
 	err = c.client.Post().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("events").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Body(event).
@@ -130,6 +134,7 @@ func (c *events) Update(ctx context.Context, event *v1.Event, opts metav1.Update
 	result = &v1.Event{}
 	err = c.client.Put().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("events").
 		Name(event.Name).
 		VersionedParams(&opts, scheme.ParameterCodec).
@@ -143,6 +148,7 @@ func (c *events) Update(ctx context.Context, event *v1.Event, opts metav1.Update
 func (c *events) Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error {
 	return c.client.Delete().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("events").
 		Name(name).
 		Body(&opts).
@@ -158,6 +164,7 @@ func (c *events) DeleteCollection(ctx context.Context, opts metav1.DeleteOptions
 	}
 	return c.client.Delete().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("events").
 		VersionedParams(&listOpts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -171,6 +178,7 @@ func (c *events) Patch(ctx context.Context, name string, pt types.PatchType, dat
 	result = &v1.Event{}
 	err = c.client.Patch(pt).
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("events").
 		Name(name).
 		SubResource(subresources...).
@@ -198,6 +206,7 @@ func (c *events) Apply(ctx context.Context, event *eventsv1.EventApplyConfigurat
 	result = &v1.Event{}
 	err = c.client.Patch(types.ApplyPatchType).
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("events").
 		Name(*name).
 		VersionedParams(&patchOpts, scheme.ParameterCodec).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/events/v1beta1/event.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/events/v1beta1/event.go
@@ -72,6 +72,7 @@ func (c *events) Get(ctx context.Context, name string, options v1.GetOptions) (r
 	result = &v1beta1.Event{}
 	err = c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("events").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
@@ -89,6 +90,7 @@ func (c *events) List(ctx context.Context, opts v1.ListOptions) (result *v1beta1
 	result = &v1beta1.EventList{}
 	err = c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("events").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -106,6 +108,7 @@ func (c *events) Watch(ctx context.Context, opts v1.ListOptions) (watch.Interfac
 	opts.Watch = true
 	return c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("events").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -117,6 +120,7 @@ func (c *events) Create(ctx context.Context, event *v1beta1.Event, opts v1.Creat
 	result = &v1beta1.Event{}
 	err = c.client.Post().
 		Namespace(c.ns).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("events").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Body(event).
@@ -130,6 +134,7 @@ func (c *events) Update(ctx context.Context, event *v1beta1.Event, opts v1.Updat
 	result = &v1beta1.Event{}
 	err = c.client.Put().
 		Namespace(c.ns).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("events").
 		Name(event.Name).
 		VersionedParams(&opts, scheme.ParameterCodec).
@@ -143,6 +148,7 @@ func (c *events) Update(ctx context.Context, event *v1beta1.Event, opts v1.Updat
 func (c *events) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
 	return c.client.Delete().
 		Namespace(c.ns).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("events").
 		Name(name).
 		Body(&opts).
@@ -158,6 +164,7 @@ func (c *events) DeleteCollection(ctx context.Context, opts v1.DeleteOptions, li
 	}
 	return c.client.Delete().
 		Namespace(c.ns).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("events").
 		VersionedParams(&listOpts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -171,6 +178,7 @@ func (c *events) Patch(ctx context.Context, name string, pt types.PatchType, dat
 	result = &v1beta1.Event{}
 	err = c.client.Patch(pt).
 		Namespace(c.ns).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("events").
 		Name(name).
 		SubResource(subresources...).
@@ -198,6 +206,7 @@ func (c *events) Apply(ctx context.Context, event *eventsv1beta1.EventApplyConfi
 	result = &v1beta1.Event{}
 	err = c.client.Patch(types.ApplyPatchType).
 		Namespace(c.ns).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("events").
 		Name(*name).
 		VersionedParams(&patchOpts, scheme.ParameterCodec).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/daemonset.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/daemonset.go
@@ -74,6 +74,7 @@ func (c *daemonSets) Get(ctx context.Context, name string, options v1.GetOptions
 	result = &v1beta1.DaemonSet{}
 	err = c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("daemonsets").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
@@ -91,6 +92,7 @@ func (c *daemonSets) List(ctx context.Context, opts v1.ListOptions) (result *v1b
 	result = &v1beta1.DaemonSetList{}
 	err = c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("daemonsets").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -108,6 +110,7 @@ func (c *daemonSets) Watch(ctx context.Context, opts v1.ListOptions) (watch.Inte
 	opts.Watch = true
 	return c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("daemonsets").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -119,6 +122,7 @@ func (c *daemonSets) Create(ctx context.Context, daemonSet *v1beta1.DaemonSet, o
 	result = &v1beta1.DaemonSet{}
 	err = c.client.Post().
 		Namespace(c.ns).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("daemonsets").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Body(daemonSet).
@@ -132,6 +136,7 @@ func (c *daemonSets) Update(ctx context.Context, daemonSet *v1beta1.DaemonSet, o
 	result = &v1beta1.DaemonSet{}
 	err = c.client.Put().
 		Namespace(c.ns).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("daemonsets").
 		Name(daemonSet.Name).
 		VersionedParams(&opts, scheme.ParameterCodec).
@@ -147,6 +152,7 @@ func (c *daemonSets) UpdateStatus(ctx context.Context, daemonSet *v1beta1.Daemon
 	result = &v1beta1.DaemonSet{}
 	err = c.client.Put().
 		Namespace(c.ns).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("daemonsets").
 		Name(daemonSet.Name).
 		SubResource("status").
@@ -161,6 +167,7 @@ func (c *daemonSets) UpdateStatus(ctx context.Context, daemonSet *v1beta1.Daemon
 func (c *daemonSets) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
 	return c.client.Delete().
 		Namespace(c.ns).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("daemonsets").
 		Name(name).
 		Body(&opts).
@@ -176,6 +183,7 @@ func (c *daemonSets) DeleteCollection(ctx context.Context, opts v1.DeleteOptions
 	}
 	return c.client.Delete().
 		Namespace(c.ns).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("daemonsets").
 		VersionedParams(&listOpts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -189,6 +197,7 @@ func (c *daemonSets) Patch(ctx context.Context, name string, pt types.PatchType,
 	result = &v1beta1.DaemonSet{}
 	err = c.client.Patch(pt).
 		Namespace(c.ns).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("daemonsets").
 		Name(name).
 		SubResource(subresources...).
@@ -216,6 +225,7 @@ func (c *daemonSets) Apply(ctx context.Context, daemonSet *extensionsv1beta1.Dae
 	result = &v1beta1.DaemonSet{}
 	err = c.client.Patch(types.ApplyPatchType).
 		Namespace(c.ns).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("daemonsets").
 		Name(*name).
 		VersionedParams(&patchOpts, scheme.ParameterCodec).
@@ -245,6 +255,7 @@ func (c *daemonSets) ApplyStatus(ctx context.Context, daemonSet *extensionsv1bet
 	result = &v1beta1.DaemonSet{}
 	err = c.client.Patch(types.ApplyPatchType).
 		Namespace(c.ns).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("daemonsets").
 		Name(*name).
 		SubResource("status").

--- a/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/deployment.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/deployment.go
@@ -78,6 +78,7 @@ func (c *deployments) Get(ctx context.Context, name string, options v1.GetOption
 	result = &v1beta1.Deployment{}
 	err = c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("deployments").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
@@ -95,6 +96,7 @@ func (c *deployments) List(ctx context.Context, opts v1.ListOptions) (result *v1
 	result = &v1beta1.DeploymentList{}
 	err = c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("deployments").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -112,6 +114,7 @@ func (c *deployments) Watch(ctx context.Context, opts v1.ListOptions) (watch.Int
 	opts.Watch = true
 	return c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("deployments").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -123,6 +126,7 @@ func (c *deployments) Create(ctx context.Context, deployment *v1beta1.Deployment
 	result = &v1beta1.Deployment{}
 	err = c.client.Post().
 		Namespace(c.ns).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("deployments").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Body(deployment).
@@ -136,6 +140,7 @@ func (c *deployments) Update(ctx context.Context, deployment *v1beta1.Deployment
 	result = &v1beta1.Deployment{}
 	err = c.client.Put().
 		Namespace(c.ns).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("deployments").
 		Name(deployment.Name).
 		VersionedParams(&opts, scheme.ParameterCodec).
@@ -151,6 +156,7 @@ func (c *deployments) UpdateStatus(ctx context.Context, deployment *v1beta1.Depl
 	result = &v1beta1.Deployment{}
 	err = c.client.Put().
 		Namespace(c.ns).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("deployments").
 		Name(deployment.Name).
 		SubResource("status").
@@ -165,6 +171,7 @@ func (c *deployments) UpdateStatus(ctx context.Context, deployment *v1beta1.Depl
 func (c *deployments) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
 	return c.client.Delete().
 		Namespace(c.ns).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("deployments").
 		Name(name).
 		Body(&opts).
@@ -180,6 +187,7 @@ func (c *deployments) DeleteCollection(ctx context.Context, opts v1.DeleteOption
 	}
 	return c.client.Delete().
 		Namespace(c.ns).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("deployments").
 		VersionedParams(&listOpts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -193,6 +201,7 @@ func (c *deployments) Patch(ctx context.Context, name string, pt types.PatchType
 	result = &v1beta1.Deployment{}
 	err = c.client.Patch(pt).
 		Namespace(c.ns).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("deployments").
 		Name(name).
 		SubResource(subresources...).
@@ -220,6 +229,7 @@ func (c *deployments) Apply(ctx context.Context, deployment *extensionsv1beta1.D
 	result = &v1beta1.Deployment{}
 	err = c.client.Patch(types.ApplyPatchType).
 		Namespace(c.ns).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("deployments").
 		Name(*name).
 		VersionedParams(&patchOpts, scheme.ParameterCodec).
@@ -249,6 +259,7 @@ func (c *deployments) ApplyStatus(ctx context.Context, deployment *extensionsv1b
 	result = &v1beta1.Deployment{}
 	err = c.client.Patch(types.ApplyPatchType).
 		Namespace(c.ns).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("deployments").
 		Name(*name).
 		SubResource("status").
@@ -264,6 +275,7 @@ func (c *deployments) GetScale(ctx context.Context, deploymentName string, optio
 	result = &v1beta1.Scale{}
 	err = c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("deployments").
 		Name(deploymentName).
 		SubResource("scale").
@@ -278,6 +290,7 @@ func (c *deployments) UpdateScale(ctx context.Context, deploymentName string, sc
 	result = &v1beta1.Scale{}
 	err = c.client.Put().
 		Namespace(c.ns).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("deployments").
 		Name(deploymentName).
 		SubResource("scale").
@@ -303,6 +316,7 @@ func (c *deployments) ApplyScale(ctx context.Context, deploymentName string, sca
 	result = &v1beta1.Scale{}
 	err = c.client.Patch(types.ApplyPatchType).
 		Namespace(c.ns).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("deployments").
 		Name(deploymentName).
 		SubResource("scale").

--- a/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/ingress.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/ingress.go
@@ -74,6 +74,7 @@ func (c *ingresses) Get(ctx context.Context, name string, options v1.GetOptions)
 	result = &v1beta1.Ingress{}
 	err = c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("ingresses").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
@@ -91,6 +92,7 @@ func (c *ingresses) List(ctx context.Context, opts v1.ListOptions) (result *v1be
 	result = &v1beta1.IngressList{}
 	err = c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("ingresses").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -108,6 +110,7 @@ func (c *ingresses) Watch(ctx context.Context, opts v1.ListOptions) (watch.Inter
 	opts.Watch = true
 	return c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("ingresses").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -119,6 +122,7 @@ func (c *ingresses) Create(ctx context.Context, ingress *v1beta1.Ingress, opts v
 	result = &v1beta1.Ingress{}
 	err = c.client.Post().
 		Namespace(c.ns).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("ingresses").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Body(ingress).
@@ -132,6 +136,7 @@ func (c *ingresses) Update(ctx context.Context, ingress *v1beta1.Ingress, opts v
 	result = &v1beta1.Ingress{}
 	err = c.client.Put().
 		Namespace(c.ns).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("ingresses").
 		Name(ingress.Name).
 		VersionedParams(&opts, scheme.ParameterCodec).
@@ -147,6 +152,7 @@ func (c *ingresses) UpdateStatus(ctx context.Context, ingress *v1beta1.Ingress, 
 	result = &v1beta1.Ingress{}
 	err = c.client.Put().
 		Namespace(c.ns).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("ingresses").
 		Name(ingress.Name).
 		SubResource("status").
@@ -161,6 +167,7 @@ func (c *ingresses) UpdateStatus(ctx context.Context, ingress *v1beta1.Ingress, 
 func (c *ingresses) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
 	return c.client.Delete().
 		Namespace(c.ns).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("ingresses").
 		Name(name).
 		Body(&opts).
@@ -176,6 +183,7 @@ func (c *ingresses) DeleteCollection(ctx context.Context, opts v1.DeleteOptions,
 	}
 	return c.client.Delete().
 		Namespace(c.ns).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("ingresses").
 		VersionedParams(&listOpts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -189,6 +197,7 @@ func (c *ingresses) Patch(ctx context.Context, name string, pt types.PatchType, 
 	result = &v1beta1.Ingress{}
 	err = c.client.Patch(pt).
 		Namespace(c.ns).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("ingresses").
 		Name(name).
 		SubResource(subresources...).
@@ -216,6 +225,7 @@ func (c *ingresses) Apply(ctx context.Context, ingress *extensionsv1beta1.Ingres
 	result = &v1beta1.Ingress{}
 	err = c.client.Patch(types.ApplyPatchType).
 		Namespace(c.ns).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("ingresses").
 		Name(*name).
 		VersionedParams(&patchOpts, scheme.ParameterCodec).
@@ -245,6 +255,7 @@ func (c *ingresses) ApplyStatus(ctx context.Context, ingress *extensionsv1beta1.
 	result = &v1beta1.Ingress{}
 	err = c.client.Patch(types.ApplyPatchType).
 		Namespace(c.ns).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("ingresses").
 		Name(*name).
 		SubResource("status").

--- a/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/networkpolicy.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/networkpolicy.go
@@ -72,6 +72,7 @@ func (c *networkPolicies) Get(ctx context.Context, name string, options v1.GetOp
 	result = &v1beta1.NetworkPolicy{}
 	err = c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("networkpolicies").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
@@ -89,6 +90,7 @@ func (c *networkPolicies) List(ctx context.Context, opts v1.ListOptions) (result
 	result = &v1beta1.NetworkPolicyList{}
 	err = c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("networkpolicies").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -106,6 +108,7 @@ func (c *networkPolicies) Watch(ctx context.Context, opts v1.ListOptions) (watch
 	opts.Watch = true
 	return c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("networkpolicies").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -117,6 +120,7 @@ func (c *networkPolicies) Create(ctx context.Context, networkPolicy *v1beta1.Net
 	result = &v1beta1.NetworkPolicy{}
 	err = c.client.Post().
 		Namespace(c.ns).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("networkpolicies").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Body(networkPolicy).
@@ -130,6 +134,7 @@ func (c *networkPolicies) Update(ctx context.Context, networkPolicy *v1beta1.Net
 	result = &v1beta1.NetworkPolicy{}
 	err = c.client.Put().
 		Namespace(c.ns).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("networkpolicies").
 		Name(networkPolicy.Name).
 		VersionedParams(&opts, scheme.ParameterCodec).
@@ -143,6 +148,7 @@ func (c *networkPolicies) Update(ctx context.Context, networkPolicy *v1beta1.Net
 func (c *networkPolicies) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
 	return c.client.Delete().
 		Namespace(c.ns).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("networkpolicies").
 		Name(name).
 		Body(&opts).
@@ -158,6 +164,7 @@ func (c *networkPolicies) DeleteCollection(ctx context.Context, opts v1.DeleteOp
 	}
 	return c.client.Delete().
 		Namespace(c.ns).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("networkpolicies").
 		VersionedParams(&listOpts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -171,6 +178,7 @@ func (c *networkPolicies) Patch(ctx context.Context, name string, pt types.Patch
 	result = &v1beta1.NetworkPolicy{}
 	err = c.client.Patch(pt).
 		Namespace(c.ns).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("networkpolicies").
 		Name(name).
 		SubResource(subresources...).
@@ -198,6 +206,7 @@ func (c *networkPolicies) Apply(ctx context.Context, networkPolicy *extensionsv1
 	result = &v1beta1.NetworkPolicy{}
 	err = c.client.Patch(types.ApplyPatchType).
 		Namespace(c.ns).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("networkpolicies").
 		Name(*name).
 		VersionedParams(&patchOpts, scheme.ParameterCodec).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/podsecuritypolicy.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/podsecuritypolicy.go
@@ -69,6 +69,7 @@ func newPodSecurityPolicies(c *ExtensionsV1beta1Client) *podSecurityPolicies {
 func (c *podSecurityPolicies) Get(ctx context.Context, name string, options v1.GetOptions) (result *v1beta1.PodSecurityPolicy, err error) {
 	result = &v1beta1.PodSecurityPolicy{}
 	err = c.client.Get().
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("podsecuritypolicies").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
@@ -85,6 +86,7 @@ func (c *podSecurityPolicies) List(ctx context.Context, opts v1.ListOptions) (re
 	}
 	result = &v1beta1.PodSecurityPolicyList{}
 	err = c.client.Get().
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("podsecuritypolicies").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -101,6 +103,7 @@ func (c *podSecurityPolicies) Watch(ctx context.Context, opts v1.ListOptions) (w
 	}
 	opts.Watch = true
 	return c.client.Get().
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("podsecuritypolicies").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -111,6 +114,7 @@ func (c *podSecurityPolicies) Watch(ctx context.Context, opts v1.ListOptions) (w
 func (c *podSecurityPolicies) Create(ctx context.Context, podSecurityPolicy *v1beta1.PodSecurityPolicy, opts v1.CreateOptions) (result *v1beta1.PodSecurityPolicy, err error) {
 	result = &v1beta1.PodSecurityPolicy{}
 	err = c.client.Post().
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("podsecuritypolicies").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Body(podSecurityPolicy).
@@ -123,6 +127,7 @@ func (c *podSecurityPolicies) Create(ctx context.Context, podSecurityPolicy *v1b
 func (c *podSecurityPolicies) Update(ctx context.Context, podSecurityPolicy *v1beta1.PodSecurityPolicy, opts v1.UpdateOptions) (result *v1beta1.PodSecurityPolicy, err error) {
 	result = &v1beta1.PodSecurityPolicy{}
 	err = c.client.Put().
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("podsecuritypolicies").
 		Name(podSecurityPolicy.Name).
 		VersionedParams(&opts, scheme.ParameterCodec).
@@ -135,6 +140,7 @@ func (c *podSecurityPolicies) Update(ctx context.Context, podSecurityPolicy *v1b
 // Delete takes name of the podSecurityPolicy and deletes it. Returns an error if one occurs.
 func (c *podSecurityPolicies) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
 	return c.client.Delete().
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("podsecuritypolicies").
 		Name(name).
 		Body(&opts).
@@ -149,6 +155,7 @@ func (c *podSecurityPolicies) DeleteCollection(ctx context.Context, opts v1.Dele
 		timeout = time.Duration(*listOpts.TimeoutSeconds) * time.Second
 	}
 	return c.client.Delete().
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("podsecuritypolicies").
 		VersionedParams(&listOpts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -161,6 +168,7 @@ func (c *podSecurityPolicies) DeleteCollection(ctx context.Context, opts v1.Dele
 func (c *podSecurityPolicies) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts v1.PatchOptions, subresources ...string) (result *v1beta1.PodSecurityPolicy, err error) {
 	result = &v1beta1.PodSecurityPolicy{}
 	err = c.client.Patch(pt).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("podsecuritypolicies").
 		Name(name).
 		SubResource(subresources...).
@@ -187,6 +195,7 @@ func (c *podSecurityPolicies) Apply(ctx context.Context, podSecurityPolicy *exte
 	}
 	result = &v1beta1.PodSecurityPolicy{}
 	err = c.client.Patch(types.ApplyPatchType).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("podsecuritypolicies").
 		Name(*name).
 		VersionedParams(&patchOpts, scheme.ParameterCodec).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/replicaset.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/replicaset.go
@@ -78,6 +78,7 @@ func (c *replicaSets) Get(ctx context.Context, name string, options v1.GetOption
 	result = &v1beta1.ReplicaSet{}
 	err = c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("replicasets").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
@@ -95,6 +96,7 @@ func (c *replicaSets) List(ctx context.Context, opts v1.ListOptions) (result *v1
 	result = &v1beta1.ReplicaSetList{}
 	err = c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("replicasets").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -112,6 +114,7 @@ func (c *replicaSets) Watch(ctx context.Context, opts v1.ListOptions) (watch.Int
 	opts.Watch = true
 	return c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("replicasets").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -123,6 +126,7 @@ func (c *replicaSets) Create(ctx context.Context, replicaSet *v1beta1.ReplicaSet
 	result = &v1beta1.ReplicaSet{}
 	err = c.client.Post().
 		Namespace(c.ns).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("replicasets").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Body(replicaSet).
@@ -136,6 +140,7 @@ func (c *replicaSets) Update(ctx context.Context, replicaSet *v1beta1.ReplicaSet
 	result = &v1beta1.ReplicaSet{}
 	err = c.client.Put().
 		Namespace(c.ns).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("replicasets").
 		Name(replicaSet.Name).
 		VersionedParams(&opts, scheme.ParameterCodec).
@@ -151,6 +156,7 @@ func (c *replicaSets) UpdateStatus(ctx context.Context, replicaSet *v1beta1.Repl
 	result = &v1beta1.ReplicaSet{}
 	err = c.client.Put().
 		Namespace(c.ns).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("replicasets").
 		Name(replicaSet.Name).
 		SubResource("status").
@@ -165,6 +171,7 @@ func (c *replicaSets) UpdateStatus(ctx context.Context, replicaSet *v1beta1.Repl
 func (c *replicaSets) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
 	return c.client.Delete().
 		Namespace(c.ns).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("replicasets").
 		Name(name).
 		Body(&opts).
@@ -180,6 +187,7 @@ func (c *replicaSets) DeleteCollection(ctx context.Context, opts v1.DeleteOption
 	}
 	return c.client.Delete().
 		Namespace(c.ns).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("replicasets").
 		VersionedParams(&listOpts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -193,6 +201,7 @@ func (c *replicaSets) Patch(ctx context.Context, name string, pt types.PatchType
 	result = &v1beta1.ReplicaSet{}
 	err = c.client.Patch(pt).
 		Namespace(c.ns).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("replicasets").
 		Name(name).
 		SubResource(subresources...).
@@ -220,6 +229,7 @@ func (c *replicaSets) Apply(ctx context.Context, replicaSet *extensionsv1beta1.R
 	result = &v1beta1.ReplicaSet{}
 	err = c.client.Patch(types.ApplyPatchType).
 		Namespace(c.ns).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("replicasets").
 		Name(*name).
 		VersionedParams(&patchOpts, scheme.ParameterCodec).
@@ -249,6 +259,7 @@ func (c *replicaSets) ApplyStatus(ctx context.Context, replicaSet *extensionsv1b
 	result = &v1beta1.ReplicaSet{}
 	err = c.client.Patch(types.ApplyPatchType).
 		Namespace(c.ns).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("replicasets").
 		Name(*name).
 		SubResource("status").
@@ -264,6 +275,7 @@ func (c *replicaSets) GetScale(ctx context.Context, replicaSetName string, optio
 	result = &v1beta1.Scale{}
 	err = c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("replicasets").
 		Name(replicaSetName).
 		SubResource("scale").
@@ -278,6 +290,7 @@ func (c *replicaSets) UpdateScale(ctx context.Context, replicaSetName string, sc
 	result = &v1beta1.Scale{}
 	err = c.client.Put().
 		Namespace(c.ns).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("replicasets").
 		Name(replicaSetName).
 		SubResource("scale").
@@ -303,6 +316,7 @@ func (c *replicaSets) ApplyScale(ctx context.Context, replicaSetName string, sca
 	result = &v1beta1.Scale{}
 	err = c.client.Patch(types.ApplyPatchType).
 		Namespace(c.ns).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("replicasets").
 		Name(replicaSetName).
 		SubResource("scale").

--- a/staging/src/k8s.io/client-go/kubernetes/typed/flowcontrol/v1alpha1/flowschema.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/flowcontrol/v1alpha1/flowschema.go
@@ -71,6 +71,7 @@ func newFlowSchemas(c *FlowcontrolV1alpha1Client) *flowSchemas {
 func (c *flowSchemas) Get(ctx context.Context, name string, options v1.GetOptions) (result *v1alpha1.FlowSchema, err error) {
 	result = &v1alpha1.FlowSchema{}
 	err = c.client.Get().
+		GroupVersion(v1alpha1.SchemeGroupVersion).
 		Resource("flowschemas").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
@@ -87,6 +88,7 @@ func (c *flowSchemas) List(ctx context.Context, opts v1.ListOptions) (result *v1
 	}
 	result = &v1alpha1.FlowSchemaList{}
 	err = c.client.Get().
+		GroupVersion(v1alpha1.SchemeGroupVersion).
 		Resource("flowschemas").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -103,6 +105,7 @@ func (c *flowSchemas) Watch(ctx context.Context, opts v1.ListOptions) (watch.Int
 	}
 	opts.Watch = true
 	return c.client.Get().
+		GroupVersion(v1alpha1.SchemeGroupVersion).
 		Resource("flowschemas").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -113,6 +116,7 @@ func (c *flowSchemas) Watch(ctx context.Context, opts v1.ListOptions) (watch.Int
 func (c *flowSchemas) Create(ctx context.Context, flowSchema *v1alpha1.FlowSchema, opts v1.CreateOptions) (result *v1alpha1.FlowSchema, err error) {
 	result = &v1alpha1.FlowSchema{}
 	err = c.client.Post().
+		GroupVersion(v1alpha1.SchemeGroupVersion).
 		Resource("flowschemas").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Body(flowSchema).
@@ -125,6 +129,7 @@ func (c *flowSchemas) Create(ctx context.Context, flowSchema *v1alpha1.FlowSchem
 func (c *flowSchemas) Update(ctx context.Context, flowSchema *v1alpha1.FlowSchema, opts v1.UpdateOptions) (result *v1alpha1.FlowSchema, err error) {
 	result = &v1alpha1.FlowSchema{}
 	err = c.client.Put().
+		GroupVersion(v1alpha1.SchemeGroupVersion).
 		Resource("flowschemas").
 		Name(flowSchema.Name).
 		VersionedParams(&opts, scheme.ParameterCodec).
@@ -139,6 +144,7 @@ func (c *flowSchemas) Update(ctx context.Context, flowSchema *v1alpha1.FlowSchem
 func (c *flowSchemas) UpdateStatus(ctx context.Context, flowSchema *v1alpha1.FlowSchema, opts v1.UpdateOptions) (result *v1alpha1.FlowSchema, err error) {
 	result = &v1alpha1.FlowSchema{}
 	err = c.client.Put().
+		GroupVersion(v1alpha1.SchemeGroupVersion).
 		Resource("flowschemas").
 		Name(flowSchema.Name).
 		SubResource("status").
@@ -152,6 +158,7 @@ func (c *flowSchemas) UpdateStatus(ctx context.Context, flowSchema *v1alpha1.Flo
 // Delete takes name of the flowSchema and deletes it. Returns an error if one occurs.
 func (c *flowSchemas) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
 	return c.client.Delete().
+		GroupVersion(v1alpha1.SchemeGroupVersion).
 		Resource("flowschemas").
 		Name(name).
 		Body(&opts).
@@ -166,6 +173,7 @@ func (c *flowSchemas) DeleteCollection(ctx context.Context, opts v1.DeleteOption
 		timeout = time.Duration(*listOpts.TimeoutSeconds) * time.Second
 	}
 	return c.client.Delete().
+		GroupVersion(v1alpha1.SchemeGroupVersion).
 		Resource("flowschemas").
 		VersionedParams(&listOpts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -178,6 +186,7 @@ func (c *flowSchemas) DeleteCollection(ctx context.Context, opts v1.DeleteOption
 func (c *flowSchemas) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts v1.PatchOptions, subresources ...string) (result *v1alpha1.FlowSchema, err error) {
 	result = &v1alpha1.FlowSchema{}
 	err = c.client.Patch(pt).
+		GroupVersion(v1alpha1.SchemeGroupVersion).
 		Resource("flowschemas").
 		Name(name).
 		SubResource(subresources...).
@@ -204,6 +213,7 @@ func (c *flowSchemas) Apply(ctx context.Context, flowSchema *flowcontrolv1alpha1
 	}
 	result = &v1alpha1.FlowSchema{}
 	err = c.client.Patch(types.ApplyPatchType).
+		GroupVersion(v1alpha1.SchemeGroupVersion).
 		Resource("flowschemas").
 		Name(*name).
 		VersionedParams(&patchOpts, scheme.ParameterCodec).
@@ -232,6 +242,7 @@ func (c *flowSchemas) ApplyStatus(ctx context.Context, flowSchema *flowcontrolv1
 
 	result = &v1alpha1.FlowSchema{}
 	err = c.client.Patch(types.ApplyPatchType).
+		GroupVersion(v1alpha1.SchemeGroupVersion).
 		Resource("flowschemas").
 		Name(*name).
 		SubResource("status").

--- a/staging/src/k8s.io/client-go/kubernetes/typed/flowcontrol/v1alpha1/prioritylevelconfiguration.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/flowcontrol/v1alpha1/prioritylevelconfiguration.go
@@ -71,6 +71,7 @@ func newPriorityLevelConfigurations(c *FlowcontrolV1alpha1Client) *priorityLevel
 func (c *priorityLevelConfigurations) Get(ctx context.Context, name string, options v1.GetOptions) (result *v1alpha1.PriorityLevelConfiguration, err error) {
 	result = &v1alpha1.PriorityLevelConfiguration{}
 	err = c.client.Get().
+		GroupVersion(v1alpha1.SchemeGroupVersion).
 		Resource("prioritylevelconfigurations").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
@@ -87,6 +88,7 @@ func (c *priorityLevelConfigurations) List(ctx context.Context, opts v1.ListOpti
 	}
 	result = &v1alpha1.PriorityLevelConfigurationList{}
 	err = c.client.Get().
+		GroupVersion(v1alpha1.SchemeGroupVersion).
 		Resource("prioritylevelconfigurations").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -103,6 +105,7 @@ func (c *priorityLevelConfigurations) Watch(ctx context.Context, opts v1.ListOpt
 	}
 	opts.Watch = true
 	return c.client.Get().
+		GroupVersion(v1alpha1.SchemeGroupVersion).
 		Resource("prioritylevelconfigurations").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -113,6 +116,7 @@ func (c *priorityLevelConfigurations) Watch(ctx context.Context, opts v1.ListOpt
 func (c *priorityLevelConfigurations) Create(ctx context.Context, priorityLevelConfiguration *v1alpha1.PriorityLevelConfiguration, opts v1.CreateOptions) (result *v1alpha1.PriorityLevelConfiguration, err error) {
 	result = &v1alpha1.PriorityLevelConfiguration{}
 	err = c.client.Post().
+		GroupVersion(v1alpha1.SchemeGroupVersion).
 		Resource("prioritylevelconfigurations").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Body(priorityLevelConfiguration).
@@ -125,6 +129,7 @@ func (c *priorityLevelConfigurations) Create(ctx context.Context, priorityLevelC
 func (c *priorityLevelConfigurations) Update(ctx context.Context, priorityLevelConfiguration *v1alpha1.PriorityLevelConfiguration, opts v1.UpdateOptions) (result *v1alpha1.PriorityLevelConfiguration, err error) {
 	result = &v1alpha1.PriorityLevelConfiguration{}
 	err = c.client.Put().
+		GroupVersion(v1alpha1.SchemeGroupVersion).
 		Resource("prioritylevelconfigurations").
 		Name(priorityLevelConfiguration.Name).
 		VersionedParams(&opts, scheme.ParameterCodec).
@@ -139,6 +144,7 @@ func (c *priorityLevelConfigurations) Update(ctx context.Context, priorityLevelC
 func (c *priorityLevelConfigurations) UpdateStatus(ctx context.Context, priorityLevelConfiguration *v1alpha1.PriorityLevelConfiguration, opts v1.UpdateOptions) (result *v1alpha1.PriorityLevelConfiguration, err error) {
 	result = &v1alpha1.PriorityLevelConfiguration{}
 	err = c.client.Put().
+		GroupVersion(v1alpha1.SchemeGroupVersion).
 		Resource("prioritylevelconfigurations").
 		Name(priorityLevelConfiguration.Name).
 		SubResource("status").
@@ -152,6 +158,7 @@ func (c *priorityLevelConfigurations) UpdateStatus(ctx context.Context, priority
 // Delete takes name of the priorityLevelConfiguration and deletes it. Returns an error if one occurs.
 func (c *priorityLevelConfigurations) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
 	return c.client.Delete().
+		GroupVersion(v1alpha1.SchemeGroupVersion).
 		Resource("prioritylevelconfigurations").
 		Name(name).
 		Body(&opts).
@@ -166,6 +173,7 @@ func (c *priorityLevelConfigurations) DeleteCollection(ctx context.Context, opts
 		timeout = time.Duration(*listOpts.TimeoutSeconds) * time.Second
 	}
 	return c.client.Delete().
+		GroupVersion(v1alpha1.SchemeGroupVersion).
 		Resource("prioritylevelconfigurations").
 		VersionedParams(&listOpts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -178,6 +186,7 @@ func (c *priorityLevelConfigurations) DeleteCollection(ctx context.Context, opts
 func (c *priorityLevelConfigurations) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts v1.PatchOptions, subresources ...string) (result *v1alpha1.PriorityLevelConfiguration, err error) {
 	result = &v1alpha1.PriorityLevelConfiguration{}
 	err = c.client.Patch(pt).
+		GroupVersion(v1alpha1.SchemeGroupVersion).
 		Resource("prioritylevelconfigurations").
 		Name(name).
 		SubResource(subresources...).
@@ -204,6 +213,7 @@ func (c *priorityLevelConfigurations) Apply(ctx context.Context, priorityLevelCo
 	}
 	result = &v1alpha1.PriorityLevelConfiguration{}
 	err = c.client.Patch(types.ApplyPatchType).
+		GroupVersion(v1alpha1.SchemeGroupVersion).
 		Resource("prioritylevelconfigurations").
 		Name(*name).
 		VersionedParams(&patchOpts, scheme.ParameterCodec).
@@ -232,6 +242,7 @@ func (c *priorityLevelConfigurations) ApplyStatus(ctx context.Context, priorityL
 
 	result = &v1alpha1.PriorityLevelConfiguration{}
 	err = c.client.Patch(types.ApplyPatchType).
+		GroupVersion(v1alpha1.SchemeGroupVersion).
 		Resource("prioritylevelconfigurations").
 		Name(*name).
 		SubResource("status").

--- a/staging/src/k8s.io/client-go/kubernetes/typed/flowcontrol/v1beta1/flowschema.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/flowcontrol/v1beta1/flowschema.go
@@ -71,6 +71,7 @@ func newFlowSchemas(c *FlowcontrolV1beta1Client) *flowSchemas {
 func (c *flowSchemas) Get(ctx context.Context, name string, options v1.GetOptions) (result *v1beta1.FlowSchema, err error) {
 	result = &v1beta1.FlowSchema{}
 	err = c.client.Get().
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("flowschemas").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
@@ -87,6 +88,7 @@ func (c *flowSchemas) List(ctx context.Context, opts v1.ListOptions) (result *v1
 	}
 	result = &v1beta1.FlowSchemaList{}
 	err = c.client.Get().
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("flowschemas").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -103,6 +105,7 @@ func (c *flowSchemas) Watch(ctx context.Context, opts v1.ListOptions) (watch.Int
 	}
 	opts.Watch = true
 	return c.client.Get().
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("flowschemas").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -113,6 +116,7 @@ func (c *flowSchemas) Watch(ctx context.Context, opts v1.ListOptions) (watch.Int
 func (c *flowSchemas) Create(ctx context.Context, flowSchema *v1beta1.FlowSchema, opts v1.CreateOptions) (result *v1beta1.FlowSchema, err error) {
 	result = &v1beta1.FlowSchema{}
 	err = c.client.Post().
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("flowschemas").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Body(flowSchema).
@@ -125,6 +129,7 @@ func (c *flowSchemas) Create(ctx context.Context, flowSchema *v1beta1.FlowSchema
 func (c *flowSchemas) Update(ctx context.Context, flowSchema *v1beta1.FlowSchema, opts v1.UpdateOptions) (result *v1beta1.FlowSchema, err error) {
 	result = &v1beta1.FlowSchema{}
 	err = c.client.Put().
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("flowschemas").
 		Name(flowSchema.Name).
 		VersionedParams(&opts, scheme.ParameterCodec).
@@ -139,6 +144,7 @@ func (c *flowSchemas) Update(ctx context.Context, flowSchema *v1beta1.FlowSchema
 func (c *flowSchemas) UpdateStatus(ctx context.Context, flowSchema *v1beta1.FlowSchema, opts v1.UpdateOptions) (result *v1beta1.FlowSchema, err error) {
 	result = &v1beta1.FlowSchema{}
 	err = c.client.Put().
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("flowschemas").
 		Name(flowSchema.Name).
 		SubResource("status").
@@ -152,6 +158,7 @@ func (c *flowSchemas) UpdateStatus(ctx context.Context, flowSchema *v1beta1.Flow
 // Delete takes name of the flowSchema and deletes it. Returns an error if one occurs.
 func (c *flowSchemas) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
 	return c.client.Delete().
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("flowschemas").
 		Name(name).
 		Body(&opts).
@@ -166,6 +173,7 @@ func (c *flowSchemas) DeleteCollection(ctx context.Context, opts v1.DeleteOption
 		timeout = time.Duration(*listOpts.TimeoutSeconds) * time.Second
 	}
 	return c.client.Delete().
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("flowschemas").
 		VersionedParams(&listOpts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -178,6 +186,7 @@ func (c *flowSchemas) DeleteCollection(ctx context.Context, opts v1.DeleteOption
 func (c *flowSchemas) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts v1.PatchOptions, subresources ...string) (result *v1beta1.FlowSchema, err error) {
 	result = &v1beta1.FlowSchema{}
 	err = c.client.Patch(pt).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("flowschemas").
 		Name(name).
 		SubResource(subresources...).
@@ -204,6 +213,7 @@ func (c *flowSchemas) Apply(ctx context.Context, flowSchema *flowcontrolv1beta1.
 	}
 	result = &v1beta1.FlowSchema{}
 	err = c.client.Patch(types.ApplyPatchType).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("flowschemas").
 		Name(*name).
 		VersionedParams(&patchOpts, scheme.ParameterCodec).
@@ -232,6 +242,7 @@ func (c *flowSchemas) ApplyStatus(ctx context.Context, flowSchema *flowcontrolv1
 
 	result = &v1beta1.FlowSchema{}
 	err = c.client.Patch(types.ApplyPatchType).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("flowschemas").
 		Name(*name).
 		SubResource("status").

--- a/staging/src/k8s.io/client-go/kubernetes/typed/flowcontrol/v1beta1/prioritylevelconfiguration.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/flowcontrol/v1beta1/prioritylevelconfiguration.go
@@ -71,6 +71,7 @@ func newPriorityLevelConfigurations(c *FlowcontrolV1beta1Client) *priorityLevelC
 func (c *priorityLevelConfigurations) Get(ctx context.Context, name string, options v1.GetOptions) (result *v1beta1.PriorityLevelConfiguration, err error) {
 	result = &v1beta1.PriorityLevelConfiguration{}
 	err = c.client.Get().
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("prioritylevelconfigurations").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
@@ -87,6 +88,7 @@ func (c *priorityLevelConfigurations) List(ctx context.Context, opts v1.ListOpti
 	}
 	result = &v1beta1.PriorityLevelConfigurationList{}
 	err = c.client.Get().
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("prioritylevelconfigurations").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -103,6 +105,7 @@ func (c *priorityLevelConfigurations) Watch(ctx context.Context, opts v1.ListOpt
 	}
 	opts.Watch = true
 	return c.client.Get().
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("prioritylevelconfigurations").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -113,6 +116,7 @@ func (c *priorityLevelConfigurations) Watch(ctx context.Context, opts v1.ListOpt
 func (c *priorityLevelConfigurations) Create(ctx context.Context, priorityLevelConfiguration *v1beta1.PriorityLevelConfiguration, opts v1.CreateOptions) (result *v1beta1.PriorityLevelConfiguration, err error) {
 	result = &v1beta1.PriorityLevelConfiguration{}
 	err = c.client.Post().
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("prioritylevelconfigurations").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Body(priorityLevelConfiguration).
@@ -125,6 +129,7 @@ func (c *priorityLevelConfigurations) Create(ctx context.Context, priorityLevelC
 func (c *priorityLevelConfigurations) Update(ctx context.Context, priorityLevelConfiguration *v1beta1.PriorityLevelConfiguration, opts v1.UpdateOptions) (result *v1beta1.PriorityLevelConfiguration, err error) {
 	result = &v1beta1.PriorityLevelConfiguration{}
 	err = c.client.Put().
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("prioritylevelconfigurations").
 		Name(priorityLevelConfiguration.Name).
 		VersionedParams(&opts, scheme.ParameterCodec).
@@ -139,6 +144,7 @@ func (c *priorityLevelConfigurations) Update(ctx context.Context, priorityLevelC
 func (c *priorityLevelConfigurations) UpdateStatus(ctx context.Context, priorityLevelConfiguration *v1beta1.PriorityLevelConfiguration, opts v1.UpdateOptions) (result *v1beta1.PriorityLevelConfiguration, err error) {
 	result = &v1beta1.PriorityLevelConfiguration{}
 	err = c.client.Put().
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("prioritylevelconfigurations").
 		Name(priorityLevelConfiguration.Name).
 		SubResource("status").
@@ -152,6 +158,7 @@ func (c *priorityLevelConfigurations) UpdateStatus(ctx context.Context, priority
 // Delete takes name of the priorityLevelConfiguration and deletes it. Returns an error if one occurs.
 func (c *priorityLevelConfigurations) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
 	return c.client.Delete().
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("prioritylevelconfigurations").
 		Name(name).
 		Body(&opts).
@@ -166,6 +173,7 @@ func (c *priorityLevelConfigurations) DeleteCollection(ctx context.Context, opts
 		timeout = time.Duration(*listOpts.TimeoutSeconds) * time.Second
 	}
 	return c.client.Delete().
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("prioritylevelconfigurations").
 		VersionedParams(&listOpts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -178,6 +186,7 @@ func (c *priorityLevelConfigurations) DeleteCollection(ctx context.Context, opts
 func (c *priorityLevelConfigurations) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts v1.PatchOptions, subresources ...string) (result *v1beta1.PriorityLevelConfiguration, err error) {
 	result = &v1beta1.PriorityLevelConfiguration{}
 	err = c.client.Patch(pt).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("prioritylevelconfigurations").
 		Name(name).
 		SubResource(subresources...).
@@ -204,6 +213,7 @@ func (c *priorityLevelConfigurations) Apply(ctx context.Context, priorityLevelCo
 	}
 	result = &v1beta1.PriorityLevelConfiguration{}
 	err = c.client.Patch(types.ApplyPatchType).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("prioritylevelconfigurations").
 		Name(*name).
 		VersionedParams(&patchOpts, scheme.ParameterCodec).
@@ -232,6 +242,7 @@ func (c *priorityLevelConfigurations) ApplyStatus(ctx context.Context, priorityL
 
 	result = &v1beta1.PriorityLevelConfiguration{}
 	err = c.client.Patch(types.ApplyPatchType).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("prioritylevelconfigurations").
 		Name(*name).
 		SubResource("status").

--- a/staging/src/k8s.io/client-go/kubernetes/typed/flowcontrol/v1beta2/flowschema.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/flowcontrol/v1beta2/flowschema.go
@@ -71,6 +71,7 @@ func newFlowSchemas(c *FlowcontrolV1beta2Client) *flowSchemas {
 func (c *flowSchemas) Get(ctx context.Context, name string, options v1.GetOptions) (result *v1beta2.FlowSchema, err error) {
 	result = &v1beta2.FlowSchema{}
 	err = c.client.Get().
+		GroupVersion(v1beta2.SchemeGroupVersion).
 		Resource("flowschemas").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
@@ -87,6 +88,7 @@ func (c *flowSchemas) List(ctx context.Context, opts v1.ListOptions) (result *v1
 	}
 	result = &v1beta2.FlowSchemaList{}
 	err = c.client.Get().
+		GroupVersion(v1beta2.SchemeGroupVersion).
 		Resource("flowschemas").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -103,6 +105,7 @@ func (c *flowSchemas) Watch(ctx context.Context, opts v1.ListOptions) (watch.Int
 	}
 	opts.Watch = true
 	return c.client.Get().
+		GroupVersion(v1beta2.SchemeGroupVersion).
 		Resource("flowschemas").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -113,6 +116,7 @@ func (c *flowSchemas) Watch(ctx context.Context, opts v1.ListOptions) (watch.Int
 func (c *flowSchemas) Create(ctx context.Context, flowSchema *v1beta2.FlowSchema, opts v1.CreateOptions) (result *v1beta2.FlowSchema, err error) {
 	result = &v1beta2.FlowSchema{}
 	err = c.client.Post().
+		GroupVersion(v1beta2.SchemeGroupVersion).
 		Resource("flowschemas").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Body(flowSchema).
@@ -125,6 +129,7 @@ func (c *flowSchemas) Create(ctx context.Context, flowSchema *v1beta2.FlowSchema
 func (c *flowSchemas) Update(ctx context.Context, flowSchema *v1beta2.FlowSchema, opts v1.UpdateOptions) (result *v1beta2.FlowSchema, err error) {
 	result = &v1beta2.FlowSchema{}
 	err = c.client.Put().
+		GroupVersion(v1beta2.SchemeGroupVersion).
 		Resource("flowschemas").
 		Name(flowSchema.Name).
 		VersionedParams(&opts, scheme.ParameterCodec).
@@ -139,6 +144,7 @@ func (c *flowSchemas) Update(ctx context.Context, flowSchema *v1beta2.FlowSchema
 func (c *flowSchemas) UpdateStatus(ctx context.Context, flowSchema *v1beta2.FlowSchema, opts v1.UpdateOptions) (result *v1beta2.FlowSchema, err error) {
 	result = &v1beta2.FlowSchema{}
 	err = c.client.Put().
+		GroupVersion(v1beta2.SchemeGroupVersion).
 		Resource("flowschemas").
 		Name(flowSchema.Name).
 		SubResource("status").
@@ -152,6 +158,7 @@ func (c *flowSchemas) UpdateStatus(ctx context.Context, flowSchema *v1beta2.Flow
 // Delete takes name of the flowSchema and deletes it. Returns an error if one occurs.
 func (c *flowSchemas) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
 	return c.client.Delete().
+		GroupVersion(v1beta2.SchemeGroupVersion).
 		Resource("flowschemas").
 		Name(name).
 		Body(&opts).
@@ -166,6 +173,7 @@ func (c *flowSchemas) DeleteCollection(ctx context.Context, opts v1.DeleteOption
 		timeout = time.Duration(*listOpts.TimeoutSeconds) * time.Second
 	}
 	return c.client.Delete().
+		GroupVersion(v1beta2.SchemeGroupVersion).
 		Resource("flowschemas").
 		VersionedParams(&listOpts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -178,6 +186,7 @@ func (c *flowSchemas) DeleteCollection(ctx context.Context, opts v1.DeleteOption
 func (c *flowSchemas) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts v1.PatchOptions, subresources ...string) (result *v1beta2.FlowSchema, err error) {
 	result = &v1beta2.FlowSchema{}
 	err = c.client.Patch(pt).
+		GroupVersion(v1beta2.SchemeGroupVersion).
 		Resource("flowschemas").
 		Name(name).
 		SubResource(subresources...).
@@ -204,6 +213,7 @@ func (c *flowSchemas) Apply(ctx context.Context, flowSchema *flowcontrolv1beta2.
 	}
 	result = &v1beta2.FlowSchema{}
 	err = c.client.Patch(types.ApplyPatchType).
+		GroupVersion(v1beta2.SchemeGroupVersion).
 		Resource("flowschemas").
 		Name(*name).
 		VersionedParams(&patchOpts, scheme.ParameterCodec).
@@ -232,6 +242,7 @@ func (c *flowSchemas) ApplyStatus(ctx context.Context, flowSchema *flowcontrolv1
 
 	result = &v1beta2.FlowSchema{}
 	err = c.client.Patch(types.ApplyPatchType).
+		GroupVersion(v1beta2.SchemeGroupVersion).
 		Resource("flowschemas").
 		Name(*name).
 		SubResource("status").

--- a/staging/src/k8s.io/client-go/kubernetes/typed/flowcontrol/v1beta2/prioritylevelconfiguration.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/flowcontrol/v1beta2/prioritylevelconfiguration.go
@@ -71,6 +71,7 @@ func newPriorityLevelConfigurations(c *FlowcontrolV1beta2Client) *priorityLevelC
 func (c *priorityLevelConfigurations) Get(ctx context.Context, name string, options v1.GetOptions) (result *v1beta2.PriorityLevelConfiguration, err error) {
 	result = &v1beta2.PriorityLevelConfiguration{}
 	err = c.client.Get().
+		GroupVersion(v1beta2.SchemeGroupVersion).
 		Resource("prioritylevelconfigurations").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
@@ -87,6 +88,7 @@ func (c *priorityLevelConfigurations) List(ctx context.Context, opts v1.ListOpti
 	}
 	result = &v1beta2.PriorityLevelConfigurationList{}
 	err = c.client.Get().
+		GroupVersion(v1beta2.SchemeGroupVersion).
 		Resource("prioritylevelconfigurations").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -103,6 +105,7 @@ func (c *priorityLevelConfigurations) Watch(ctx context.Context, opts v1.ListOpt
 	}
 	opts.Watch = true
 	return c.client.Get().
+		GroupVersion(v1beta2.SchemeGroupVersion).
 		Resource("prioritylevelconfigurations").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -113,6 +116,7 @@ func (c *priorityLevelConfigurations) Watch(ctx context.Context, opts v1.ListOpt
 func (c *priorityLevelConfigurations) Create(ctx context.Context, priorityLevelConfiguration *v1beta2.PriorityLevelConfiguration, opts v1.CreateOptions) (result *v1beta2.PriorityLevelConfiguration, err error) {
 	result = &v1beta2.PriorityLevelConfiguration{}
 	err = c.client.Post().
+		GroupVersion(v1beta2.SchemeGroupVersion).
 		Resource("prioritylevelconfigurations").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Body(priorityLevelConfiguration).
@@ -125,6 +129,7 @@ func (c *priorityLevelConfigurations) Create(ctx context.Context, priorityLevelC
 func (c *priorityLevelConfigurations) Update(ctx context.Context, priorityLevelConfiguration *v1beta2.PriorityLevelConfiguration, opts v1.UpdateOptions) (result *v1beta2.PriorityLevelConfiguration, err error) {
 	result = &v1beta2.PriorityLevelConfiguration{}
 	err = c.client.Put().
+		GroupVersion(v1beta2.SchemeGroupVersion).
 		Resource("prioritylevelconfigurations").
 		Name(priorityLevelConfiguration.Name).
 		VersionedParams(&opts, scheme.ParameterCodec).
@@ -139,6 +144,7 @@ func (c *priorityLevelConfigurations) Update(ctx context.Context, priorityLevelC
 func (c *priorityLevelConfigurations) UpdateStatus(ctx context.Context, priorityLevelConfiguration *v1beta2.PriorityLevelConfiguration, opts v1.UpdateOptions) (result *v1beta2.PriorityLevelConfiguration, err error) {
 	result = &v1beta2.PriorityLevelConfiguration{}
 	err = c.client.Put().
+		GroupVersion(v1beta2.SchemeGroupVersion).
 		Resource("prioritylevelconfigurations").
 		Name(priorityLevelConfiguration.Name).
 		SubResource("status").
@@ -152,6 +158,7 @@ func (c *priorityLevelConfigurations) UpdateStatus(ctx context.Context, priority
 // Delete takes name of the priorityLevelConfiguration and deletes it. Returns an error if one occurs.
 func (c *priorityLevelConfigurations) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
 	return c.client.Delete().
+		GroupVersion(v1beta2.SchemeGroupVersion).
 		Resource("prioritylevelconfigurations").
 		Name(name).
 		Body(&opts).
@@ -166,6 +173,7 @@ func (c *priorityLevelConfigurations) DeleteCollection(ctx context.Context, opts
 		timeout = time.Duration(*listOpts.TimeoutSeconds) * time.Second
 	}
 	return c.client.Delete().
+		GroupVersion(v1beta2.SchemeGroupVersion).
 		Resource("prioritylevelconfigurations").
 		VersionedParams(&listOpts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -178,6 +186,7 @@ func (c *priorityLevelConfigurations) DeleteCollection(ctx context.Context, opts
 func (c *priorityLevelConfigurations) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts v1.PatchOptions, subresources ...string) (result *v1beta2.PriorityLevelConfiguration, err error) {
 	result = &v1beta2.PriorityLevelConfiguration{}
 	err = c.client.Patch(pt).
+		GroupVersion(v1beta2.SchemeGroupVersion).
 		Resource("prioritylevelconfigurations").
 		Name(name).
 		SubResource(subresources...).
@@ -204,6 +213,7 @@ func (c *priorityLevelConfigurations) Apply(ctx context.Context, priorityLevelCo
 	}
 	result = &v1beta2.PriorityLevelConfiguration{}
 	err = c.client.Patch(types.ApplyPatchType).
+		GroupVersion(v1beta2.SchemeGroupVersion).
 		Resource("prioritylevelconfigurations").
 		Name(*name).
 		VersionedParams(&patchOpts, scheme.ParameterCodec).
@@ -232,6 +242,7 @@ func (c *priorityLevelConfigurations) ApplyStatus(ctx context.Context, priorityL
 
 	result = &v1beta2.PriorityLevelConfiguration{}
 	err = c.client.Patch(types.ApplyPatchType).
+		GroupVersion(v1beta2.SchemeGroupVersion).
 		Resource("prioritylevelconfigurations").
 		Name(*name).
 		SubResource("status").

--- a/staging/src/k8s.io/client-go/kubernetes/typed/networking/v1/ingress.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/networking/v1/ingress.go
@@ -74,6 +74,7 @@ func (c *ingresses) Get(ctx context.Context, name string, options metav1.GetOpti
 	result = &v1.Ingress{}
 	err = c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("ingresses").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
@@ -91,6 +92,7 @@ func (c *ingresses) List(ctx context.Context, opts metav1.ListOptions) (result *
 	result = &v1.IngressList{}
 	err = c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("ingresses").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -108,6 +110,7 @@ func (c *ingresses) Watch(ctx context.Context, opts metav1.ListOptions) (watch.I
 	opts.Watch = true
 	return c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("ingresses").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -119,6 +122,7 @@ func (c *ingresses) Create(ctx context.Context, ingress *v1.Ingress, opts metav1
 	result = &v1.Ingress{}
 	err = c.client.Post().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("ingresses").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Body(ingress).
@@ -132,6 +136,7 @@ func (c *ingresses) Update(ctx context.Context, ingress *v1.Ingress, opts metav1
 	result = &v1.Ingress{}
 	err = c.client.Put().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("ingresses").
 		Name(ingress.Name).
 		VersionedParams(&opts, scheme.ParameterCodec).
@@ -147,6 +152,7 @@ func (c *ingresses) UpdateStatus(ctx context.Context, ingress *v1.Ingress, opts 
 	result = &v1.Ingress{}
 	err = c.client.Put().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("ingresses").
 		Name(ingress.Name).
 		SubResource("status").
@@ -161,6 +167,7 @@ func (c *ingresses) UpdateStatus(ctx context.Context, ingress *v1.Ingress, opts 
 func (c *ingresses) Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error {
 	return c.client.Delete().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("ingresses").
 		Name(name).
 		Body(&opts).
@@ -176,6 +183,7 @@ func (c *ingresses) DeleteCollection(ctx context.Context, opts metav1.DeleteOpti
 	}
 	return c.client.Delete().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("ingresses").
 		VersionedParams(&listOpts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -189,6 +197,7 @@ func (c *ingresses) Patch(ctx context.Context, name string, pt types.PatchType, 
 	result = &v1.Ingress{}
 	err = c.client.Patch(pt).
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("ingresses").
 		Name(name).
 		SubResource(subresources...).
@@ -216,6 +225,7 @@ func (c *ingresses) Apply(ctx context.Context, ingress *networkingv1.IngressAppl
 	result = &v1.Ingress{}
 	err = c.client.Patch(types.ApplyPatchType).
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("ingresses").
 		Name(*name).
 		VersionedParams(&patchOpts, scheme.ParameterCodec).
@@ -245,6 +255,7 @@ func (c *ingresses) ApplyStatus(ctx context.Context, ingress *networkingv1.Ingre
 	result = &v1.Ingress{}
 	err = c.client.Patch(types.ApplyPatchType).
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("ingresses").
 		Name(*name).
 		SubResource("status").

--- a/staging/src/k8s.io/client-go/kubernetes/typed/networking/v1/ingressclass.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/networking/v1/ingressclass.go
@@ -69,6 +69,7 @@ func newIngressClasses(c *NetworkingV1Client) *ingressClasses {
 func (c *ingressClasses) Get(ctx context.Context, name string, options metav1.GetOptions) (result *v1.IngressClass, err error) {
 	result = &v1.IngressClass{}
 	err = c.client.Get().
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("ingressclasses").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
@@ -85,6 +86,7 @@ func (c *ingressClasses) List(ctx context.Context, opts metav1.ListOptions) (res
 	}
 	result = &v1.IngressClassList{}
 	err = c.client.Get().
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("ingressclasses").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -101,6 +103,7 @@ func (c *ingressClasses) Watch(ctx context.Context, opts metav1.ListOptions) (wa
 	}
 	opts.Watch = true
 	return c.client.Get().
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("ingressclasses").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -111,6 +114,7 @@ func (c *ingressClasses) Watch(ctx context.Context, opts metav1.ListOptions) (wa
 func (c *ingressClasses) Create(ctx context.Context, ingressClass *v1.IngressClass, opts metav1.CreateOptions) (result *v1.IngressClass, err error) {
 	result = &v1.IngressClass{}
 	err = c.client.Post().
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("ingressclasses").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Body(ingressClass).
@@ -123,6 +127,7 @@ func (c *ingressClasses) Create(ctx context.Context, ingressClass *v1.IngressCla
 func (c *ingressClasses) Update(ctx context.Context, ingressClass *v1.IngressClass, opts metav1.UpdateOptions) (result *v1.IngressClass, err error) {
 	result = &v1.IngressClass{}
 	err = c.client.Put().
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("ingressclasses").
 		Name(ingressClass.Name).
 		VersionedParams(&opts, scheme.ParameterCodec).
@@ -135,6 +140,7 @@ func (c *ingressClasses) Update(ctx context.Context, ingressClass *v1.IngressCla
 // Delete takes name of the ingressClass and deletes it. Returns an error if one occurs.
 func (c *ingressClasses) Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error {
 	return c.client.Delete().
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("ingressclasses").
 		Name(name).
 		Body(&opts).
@@ -149,6 +155,7 @@ func (c *ingressClasses) DeleteCollection(ctx context.Context, opts metav1.Delet
 		timeout = time.Duration(*listOpts.TimeoutSeconds) * time.Second
 	}
 	return c.client.Delete().
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("ingressclasses").
 		VersionedParams(&listOpts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -161,6 +168,7 @@ func (c *ingressClasses) DeleteCollection(ctx context.Context, opts metav1.Delet
 func (c *ingressClasses) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts metav1.PatchOptions, subresources ...string) (result *v1.IngressClass, err error) {
 	result = &v1.IngressClass{}
 	err = c.client.Patch(pt).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("ingressclasses").
 		Name(name).
 		SubResource(subresources...).
@@ -187,6 +195,7 @@ func (c *ingressClasses) Apply(ctx context.Context, ingressClass *networkingv1.I
 	}
 	result = &v1.IngressClass{}
 	err = c.client.Patch(types.ApplyPatchType).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("ingressclasses").
 		Name(*name).
 		VersionedParams(&patchOpts, scheme.ParameterCodec).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/networking/v1/networkpolicy.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/networking/v1/networkpolicy.go
@@ -72,6 +72,7 @@ func (c *networkPolicies) Get(ctx context.Context, name string, options metav1.G
 	result = &v1.NetworkPolicy{}
 	err = c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("networkpolicies").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
@@ -89,6 +90,7 @@ func (c *networkPolicies) List(ctx context.Context, opts metav1.ListOptions) (re
 	result = &v1.NetworkPolicyList{}
 	err = c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("networkpolicies").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -106,6 +108,7 @@ func (c *networkPolicies) Watch(ctx context.Context, opts metav1.ListOptions) (w
 	opts.Watch = true
 	return c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("networkpolicies").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -117,6 +120,7 @@ func (c *networkPolicies) Create(ctx context.Context, networkPolicy *v1.NetworkP
 	result = &v1.NetworkPolicy{}
 	err = c.client.Post().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("networkpolicies").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Body(networkPolicy).
@@ -130,6 +134,7 @@ func (c *networkPolicies) Update(ctx context.Context, networkPolicy *v1.NetworkP
 	result = &v1.NetworkPolicy{}
 	err = c.client.Put().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("networkpolicies").
 		Name(networkPolicy.Name).
 		VersionedParams(&opts, scheme.ParameterCodec).
@@ -143,6 +148,7 @@ func (c *networkPolicies) Update(ctx context.Context, networkPolicy *v1.NetworkP
 func (c *networkPolicies) Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error {
 	return c.client.Delete().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("networkpolicies").
 		Name(name).
 		Body(&opts).
@@ -158,6 +164,7 @@ func (c *networkPolicies) DeleteCollection(ctx context.Context, opts metav1.Dele
 	}
 	return c.client.Delete().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("networkpolicies").
 		VersionedParams(&listOpts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -171,6 +178,7 @@ func (c *networkPolicies) Patch(ctx context.Context, name string, pt types.Patch
 	result = &v1.NetworkPolicy{}
 	err = c.client.Patch(pt).
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("networkpolicies").
 		Name(name).
 		SubResource(subresources...).
@@ -198,6 +206,7 @@ func (c *networkPolicies) Apply(ctx context.Context, networkPolicy *networkingv1
 	result = &v1.NetworkPolicy{}
 	err = c.client.Patch(types.ApplyPatchType).
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("networkpolicies").
 		Name(*name).
 		VersionedParams(&patchOpts, scheme.ParameterCodec).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/networking/v1beta1/ingress.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/networking/v1beta1/ingress.go
@@ -74,6 +74,7 @@ func (c *ingresses) Get(ctx context.Context, name string, options v1.GetOptions)
 	result = &v1beta1.Ingress{}
 	err = c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("ingresses").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
@@ -91,6 +92,7 @@ func (c *ingresses) List(ctx context.Context, opts v1.ListOptions) (result *v1be
 	result = &v1beta1.IngressList{}
 	err = c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("ingresses").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -108,6 +110,7 @@ func (c *ingresses) Watch(ctx context.Context, opts v1.ListOptions) (watch.Inter
 	opts.Watch = true
 	return c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("ingresses").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -119,6 +122,7 @@ func (c *ingresses) Create(ctx context.Context, ingress *v1beta1.Ingress, opts v
 	result = &v1beta1.Ingress{}
 	err = c.client.Post().
 		Namespace(c.ns).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("ingresses").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Body(ingress).
@@ -132,6 +136,7 @@ func (c *ingresses) Update(ctx context.Context, ingress *v1beta1.Ingress, opts v
 	result = &v1beta1.Ingress{}
 	err = c.client.Put().
 		Namespace(c.ns).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("ingresses").
 		Name(ingress.Name).
 		VersionedParams(&opts, scheme.ParameterCodec).
@@ -147,6 +152,7 @@ func (c *ingresses) UpdateStatus(ctx context.Context, ingress *v1beta1.Ingress, 
 	result = &v1beta1.Ingress{}
 	err = c.client.Put().
 		Namespace(c.ns).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("ingresses").
 		Name(ingress.Name).
 		SubResource("status").
@@ -161,6 +167,7 @@ func (c *ingresses) UpdateStatus(ctx context.Context, ingress *v1beta1.Ingress, 
 func (c *ingresses) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
 	return c.client.Delete().
 		Namespace(c.ns).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("ingresses").
 		Name(name).
 		Body(&opts).
@@ -176,6 +183,7 @@ func (c *ingresses) DeleteCollection(ctx context.Context, opts v1.DeleteOptions,
 	}
 	return c.client.Delete().
 		Namespace(c.ns).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("ingresses").
 		VersionedParams(&listOpts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -189,6 +197,7 @@ func (c *ingresses) Patch(ctx context.Context, name string, pt types.PatchType, 
 	result = &v1beta1.Ingress{}
 	err = c.client.Patch(pt).
 		Namespace(c.ns).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("ingresses").
 		Name(name).
 		SubResource(subresources...).
@@ -216,6 +225,7 @@ func (c *ingresses) Apply(ctx context.Context, ingress *networkingv1beta1.Ingres
 	result = &v1beta1.Ingress{}
 	err = c.client.Patch(types.ApplyPatchType).
 		Namespace(c.ns).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("ingresses").
 		Name(*name).
 		VersionedParams(&patchOpts, scheme.ParameterCodec).
@@ -245,6 +255,7 @@ func (c *ingresses) ApplyStatus(ctx context.Context, ingress *networkingv1beta1.
 	result = &v1beta1.Ingress{}
 	err = c.client.Patch(types.ApplyPatchType).
 		Namespace(c.ns).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("ingresses").
 		Name(*name).
 		SubResource("status").

--- a/staging/src/k8s.io/client-go/kubernetes/typed/networking/v1beta1/ingressclass.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/networking/v1beta1/ingressclass.go
@@ -69,6 +69,7 @@ func newIngressClasses(c *NetworkingV1beta1Client) *ingressClasses {
 func (c *ingressClasses) Get(ctx context.Context, name string, options v1.GetOptions) (result *v1beta1.IngressClass, err error) {
 	result = &v1beta1.IngressClass{}
 	err = c.client.Get().
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("ingressclasses").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
@@ -85,6 +86,7 @@ func (c *ingressClasses) List(ctx context.Context, opts v1.ListOptions) (result 
 	}
 	result = &v1beta1.IngressClassList{}
 	err = c.client.Get().
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("ingressclasses").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -101,6 +103,7 @@ func (c *ingressClasses) Watch(ctx context.Context, opts v1.ListOptions) (watch.
 	}
 	opts.Watch = true
 	return c.client.Get().
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("ingressclasses").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -111,6 +114,7 @@ func (c *ingressClasses) Watch(ctx context.Context, opts v1.ListOptions) (watch.
 func (c *ingressClasses) Create(ctx context.Context, ingressClass *v1beta1.IngressClass, opts v1.CreateOptions) (result *v1beta1.IngressClass, err error) {
 	result = &v1beta1.IngressClass{}
 	err = c.client.Post().
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("ingressclasses").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Body(ingressClass).
@@ -123,6 +127,7 @@ func (c *ingressClasses) Create(ctx context.Context, ingressClass *v1beta1.Ingre
 func (c *ingressClasses) Update(ctx context.Context, ingressClass *v1beta1.IngressClass, opts v1.UpdateOptions) (result *v1beta1.IngressClass, err error) {
 	result = &v1beta1.IngressClass{}
 	err = c.client.Put().
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("ingressclasses").
 		Name(ingressClass.Name).
 		VersionedParams(&opts, scheme.ParameterCodec).
@@ -135,6 +140,7 @@ func (c *ingressClasses) Update(ctx context.Context, ingressClass *v1beta1.Ingre
 // Delete takes name of the ingressClass and deletes it. Returns an error if one occurs.
 func (c *ingressClasses) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
 	return c.client.Delete().
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("ingressclasses").
 		Name(name).
 		Body(&opts).
@@ -149,6 +155,7 @@ func (c *ingressClasses) DeleteCollection(ctx context.Context, opts v1.DeleteOpt
 		timeout = time.Duration(*listOpts.TimeoutSeconds) * time.Second
 	}
 	return c.client.Delete().
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("ingressclasses").
 		VersionedParams(&listOpts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -161,6 +168,7 @@ func (c *ingressClasses) DeleteCollection(ctx context.Context, opts v1.DeleteOpt
 func (c *ingressClasses) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts v1.PatchOptions, subresources ...string) (result *v1beta1.IngressClass, err error) {
 	result = &v1beta1.IngressClass{}
 	err = c.client.Patch(pt).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("ingressclasses").
 		Name(name).
 		SubResource(subresources...).
@@ -187,6 +195,7 @@ func (c *ingressClasses) Apply(ctx context.Context, ingressClass *networkingv1be
 	}
 	result = &v1beta1.IngressClass{}
 	err = c.client.Patch(types.ApplyPatchType).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("ingressclasses").
 		Name(*name).
 		VersionedParams(&patchOpts, scheme.ParameterCodec).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/node/v1/runtimeclass.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/node/v1/runtimeclass.go
@@ -69,6 +69,7 @@ func newRuntimeClasses(c *NodeV1Client) *runtimeClasses {
 func (c *runtimeClasses) Get(ctx context.Context, name string, options metav1.GetOptions) (result *v1.RuntimeClass, err error) {
 	result = &v1.RuntimeClass{}
 	err = c.client.Get().
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("runtimeclasses").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
@@ -85,6 +86,7 @@ func (c *runtimeClasses) List(ctx context.Context, opts metav1.ListOptions) (res
 	}
 	result = &v1.RuntimeClassList{}
 	err = c.client.Get().
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("runtimeclasses").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -101,6 +103,7 @@ func (c *runtimeClasses) Watch(ctx context.Context, opts metav1.ListOptions) (wa
 	}
 	opts.Watch = true
 	return c.client.Get().
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("runtimeclasses").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -111,6 +114,7 @@ func (c *runtimeClasses) Watch(ctx context.Context, opts metav1.ListOptions) (wa
 func (c *runtimeClasses) Create(ctx context.Context, runtimeClass *v1.RuntimeClass, opts metav1.CreateOptions) (result *v1.RuntimeClass, err error) {
 	result = &v1.RuntimeClass{}
 	err = c.client.Post().
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("runtimeclasses").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Body(runtimeClass).
@@ -123,6 +127,7 @@ func (c *runtimeClasses) Create(ctx context.Context, runtimeClass *v1.RuntimeCla
 func (c *runtimeClasses) Update(ctx context.Context, runtimeClass *v1.RuntimeClass, opts metav1.UpdateOptions) (result *v1.RuntimeClass, err error) {
 	result = &v1.RuntimeClass{}
 	err = c.client.Put().
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("runtimeclasses").
 		Name(runtimeClass.Name).
 		VersionedParams(&opts, scheme.ParameterCodec).
@@ -135,6 +140,7 @@ func (c *runtimeClasses) Update(ctx context.Context, runtimeClass *v1.RuntimeCla
 // Delete takes name of the runtimeClass and deletes it. Returns an error if one occurs.
 func (c *runtimeClasses) Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error {
 	return c.client.Delete().
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("runtimeclasses").
 		Name(name).
 		Body(&opts).
@@ -149,6 +155,7 @@ func (c *runtimeClasses) DeleteCollection(ctx context.Context, opts metav1.Delet
 		timeout = time.Duration(*listOpts.TimeoutSeconds) * time.Second
 	}
 	return c.client.Delete().
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("runtimeclasses").
 		VersionedParams(&listOpts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -161,6 +168,7 @@ func (c *runtimeClasses) DeleteCollection(ctx context.Context, opts metav1.Delet
 func (c *runtimeClasses) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts metav1.PatchOptions, subresources ...string) (result *v1.RuntimeClass, err error) {
 	result = &v1.RuntimeClass{}
 	err = c.client.Patch(pt).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("runtimeclasses").
 		Name(name).
 		SubResource(subresources...).
@@ -187,6 +195,7 @@ func (c *runtimeClasses) Apply(ctx context.Context, runtimeClass *nodev1.Runtime
 	}
 	result = &v1.RuntimeClass{}
 	err = c.client.Patch(types.ApplyPatchType).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("runtimeclasses").
 		Name(*name).
 		VersionedParams(&patchOpts, scheme.ParameterCodec).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/node/v1alpha1/runtimeclass.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/node/v1alpha1/runtimeclass.go
@@ -69,6 +69,7 @@ func newRuntimeClasses(c *NodeV1alpha1Client) *runtimeClasses {
 func (c *runtimeClasses) Get(ctx context.Context, name string, options v1.GetOptions) (result *v1alpha1.RuntimeClass, err error) {
 	result = &v1alpha1.RuntimeClass{}
 	err = c.client.Get().
+		GroupVersion(v1alpha1.SchemeGroupVersion).
 		Resource("runtimeclasses").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
@@ -85,6 +86,7 @@ func (c *runtimeClasses) List(ctx context.Context, opts v1.ListOptions) (result 
 	}
 	result = &v1alpha1.RuntimeClassList{}
 	err = c.client.Get().
+		GroupVersion(v1alpha1.SchemeGroupVersion).
 		Resource("runtimeclasses").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -101,6 +103,7 @@ func (c *runtimeClasses) Watch(ctx context.Context, opts v1.ListOptions) (watch.
 	}
 	opts.Watch = true
 	return c.client.Get().
+		GroupVersion(v1alpha1.SchemeGroupVersion).
 		Resource("runtimeclasses").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -111,6 +114,7 @@ func (c *runtimeClasses) Watch(ctx context.Context, opts v1.ListOptions) (watch.
 func (c *runtimeClasses) Create(ctx context.Context, runtimeClass *v1alpha1.RuntimeClass, opts v1.CreateOptions) (result *v1alpha1.RuntimeClass, err error) {
 	result = &v1alpha1.RuntimeClass{}
 	err = c.client.Post().
+		GroupVersion(v1alpha1.SchemeGroupVersion).
 		Resource("runtimeclasses").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Body(runtimeClass).
@@ -123,6 +127,7 @@ func (c *runtimeClasses) Create(ctx context.Context, runtimeClass *v1alpha1.Runt
 func (c *runtimeClasses) Update(ctx context.Context, runtimeClass *v1alpha1.RuntimeClass, opts v1.UpdateOptions) (result *v1alpha1.RuntimeClass, err error) {
 	result = &v1alpha1.RuntimeClass{}
 	err = c.client.Put().
+		GroupVersion(v1alpha1.SchemeGroupVersion).
 		Resource("runtimeclasses").
 		Name(runtimeClass.Name).
 		VersionedParams(&opts, scheme.ParameterCodec).
@@ -135,6 +140,7 @@ func (c *runtimeClasses) Update(ctx context.Context, runtimeClass *v1alpha1.Runt
 // Delete takes name of the runtimeClass and deletes it. Returns an error if one occurs.
 func (c *runtimeClasses) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
 	return c.client.Delete().
+		GroupVersion(v1alpha1.SchemeGroupVersion).
 		Resource("runtimeclasses").
 		Name(name).
 		Body(&opts).
@@ -149,6 +155,7 @@ func (c *runtimeClasses) DeleteCollection(ctx context.Context, opts v1.DeleteOpt
 		timeout = time.Duration(*listOpts.TimeoutSeconds) * time.Second
 	}
 	return c.client.Delete().
+		GroupVersion(v1alpha1.SchemeGroupVersion).
 		Resource("runtimeclasses").
 		VersionedParams(&listOpts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -161,6 +168,7 @@ func (c *runtimeClasses) DeleteCollection(ctx context.Context, opts v1.DeleteOpt
 func (c *runtimeClasses) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts v1.PatchOptions, subresources ...string) (result *v1alpha1.RuntimeClass, err error) {
 	result = &v1alpha1.RuntimeClass{}
 	err = c.client.Patch(pt).
+		GroupVersion(v1alpha1.SchemeGroupVersion).
 		Resource("runtimeclasses").
 		Name(name).
 		SubResource(subresources...).
@@ -187,6 +195,7 @@ func (c *runtimeClasses) Apply(ctx context.Context, runtimeClass *nodev1alpha1.R
 	}
 	result = &v1alpha1.RuntimeClass{}
 	err = c.client.Patch(types.ApplyPatchType).
+		GroupVersion(v1alpha1.SchemeGroupVersion).
 		Resource("runtimeclasses").
 		Name(*name).
 		VersionedParams(&patchOpts, scheme.ParameterCodec).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/node/v1beta1/runtimeclass.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/node/v1beta1/runtimeclass.go
@@ -69,6 +69,7 @@ func newRuntimeClasses(c *NodeV1beta1Client) *runtimeClasses {
 func (c *runtimeClasses) Get(ctx context.Context, name string, options v1.GetOptions) (result *v1beta1.RuntimeClass, err error) {
 	result = &v1beta1.RuntimeClass{}
 	err = c.client.Get().
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("runtimeclasses").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
@@ -85,6 +86,7 @@ func (c *runtimeClasses) List(ctx context.Context, opts v1.ListOptions) (result 
 	}
 	result = &v1beta1.RuntimeClassList{}
 	err = c.client.Get().
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("runtimeclasses").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -101,6 +103,7 @@ func (c *runtimeClasses) Watch(ctx context.Context, opts v1.ListOptions) (watch.
 	}
 	opts.Watch = true
 	return c.client.Get().
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("runtimeclasses").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -111,6 +114,7 @@ func (c *runtimeClasses) Watch(ctx context.Context, opts v1.ListOptions) (watch.
 func (c *runtimeClasses) Create(ctx context.Context, runtimeClass *v1beta1.RuntimeClass, opts v1.CreateOptions) (result *v1beta1.RuntimeClass, err error) {
 	result = &v1beta1.RuntimeClass{}
 	err = c.client.Post().
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("runtimeclasses").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Body(runtimeClass).
@@ -123,6 +127,7 @@ func (c *runtimeClasses) Create(ctx context.Context, runtimeClass *v1beta1.Runti
 func (c *runtimeClasses) Update(ctx context.Context, runtimeClass *v1beta1.RuntimeClass, opts v1.UpdateOptions) (result *v1beta1.RuntimeClass, err error) {
 	result = &v1beta1.RuntimeClass{}
 	err = c.client.Put().
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("runtimeclasses").
 		Name(runtimeClass.Name).
 		VersionedParams(&opts, scheme.ParameterCodec).
@@ -135,6 +140,7 @@ func (c *runtimeClasses) Update(ctx context.Context, runtimeClass *v1beta1.Runti
 // Delete takes name of the runtimeClass and deletes it. Returns an error if one occurs.
 func (c *runtimeClasses) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
 	return c.client.Delete().
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("runtimeclasses").
 		Name(name).
 		Body(&opts).
@@ -149,6 +155,7 @@ func (c *runtimeClasses) DeleteCollection(ctx context.Context, opts v1.DeleteOpt
 		timeout = time.Duration(*listOpts.TimeoutSeconds) * time.Second
 	}
 	return c.client.Delete().
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("runtimeclasses").
 		VersionedParams(&listOpts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -161,6 +168,7 @@ func (c *runtimeClasses) DeleteCollection(ctx context.Context, opts v1.DeleteOpt
 func (c *runtimeClasses) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts v1.PatchOptions, subresources ...string) (result *v1beta1.RuntimeClass, err error) {
 	result = &v1beta1.RuntimeClass{}
 	err = c.client.Patch(pt).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("runtimeclasses").
 		Name(name).
 		SubResource(subresources...).
@@ -187,6 +195,7 @@ func (c *runtimeClasses) Apply(ctx context.Context, runtimeClass *nodev1beta1.Ru
 	}
 	result = &v1beta1.RuntimeClass{}
 	err = c.client.Patch(types.ApplyPatchType).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("runtimeclasses").
 		Name(*name).
 		VersionedParams(&patchOpts, scheme.ParameterCodec).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/policy/v1/poddisruptionbudget.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/policy/v1/poddisruptionbudget.go
@@ -74,6 +74,7 @@ func (c *podDisruptionBudgets) Get(ctx context.Context, name string, options met
 	result = &v1.PodDisruptionBudget{}
 	err = c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("poddisruptionbudgets").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
@@ -91,6 +92,7 @@ func (c *podDisruptionBudgets) List(ctx context.Context, opts metav1.ListOptions
 	result = &v1.PodDisruptionBudgetList{}
 	err = c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("poddisruptionbudgets").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -108,6 +110,7 @@ func (c *podDisruptionBudgets) Watch(ctx context.Context, opts metav1.ListOption
 	opts.Watch = true
 	return c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("poddisruptionbudgets").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -119,6 +122,7 @@ func (c *podDisruptionBudgets) Create(ctx context.Context, podDisruptionBudget *
 	result = &v1.PodDisruptionBudget{}
 	err = c.client.Post().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("poddisruptionbudgets").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Body(podDisruptionBudget).
@@ -132,6 +136,7 @@ func (c *podDisruptionBudgets) Update(ctx context.Context, podDisruptionBudget *
 	result = &v1.PodDisruptionBudget{}
 	err = c.client.Put().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("poddisruptionbudgets").
 		Name(podDisruptionBudget.Name).
 		VersionedParams(&opts, scheme.ParameterCodec).
@@ -147,6 +152,7 @@ func (c *podDisruptionBudgets) UpdateStatus(ctx context.Context, podDisruptionBu
 	result = &v1.PodDisruptionBudget{}
 	err = c.client.Put().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("poddisruptionbudgets").
 		Name(podDisruptionBudget.Name).
 		SubResource("status").
@@ -161,6 +167,7 @@ func (c *podDisruptionBudgets) UpdateStatus(ctx context.Context, podDisruptionBu
 func (c *podDisruptionBudgets) Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error {
 	return c.client.Delete().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("poddisruptionbudgets").
 		Name(name).
 		Body(&opts).
@@ -176,6 +183,7 @@ func (c *podDisruptionBudgets) DeleteCollection(ctx context.Context, opts metav1
 	}
 	return c.client.Delete().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("poddisruptionbudgets").
 		VersionedParams(&listOpts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -189,6 +197,7 @@ func (c *podDisruptionBudgets) Patch(ctx context.Context, name string, pt types.
 	result = &v1.PodDisruptionBudget{}
 	err = c.client.Patch(pt).
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("poddisruptionbudgets").
 		Name(name).
 		SubResource(subresources...).
@@ -216,6 +225,7 @@ func (c *podDisruptionBudgets) Apply(ctx context.Context, podDisruptionBudget *p
 	result = &v1.PodDisruptionBudget{}
 	err = c.client.Patch(types.ApplyPatchType).
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("poddisruptionbudgets").
 		Name(*name).
 		VersionedParams(&patchOpts, scheme.ParameterCodec).
@@ -245,6 +255,7 @@ func (c *podDisruptionBudgets) ApplyStatus(ctx context.Context, podDisruptionBud
 	result = &v1.PodDisruptionBudget{}
 	err = c.client.Patch(types.ApplyPatchType).
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("poddisruptionbudgets").
 		Name(*name).
 		SubResource("status").

--- a/staging/src/k8s.io/client-go/kubernetes/typed/policy/v1beta1/poddisruptionbudget.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/policy/v1beta1/poddisruptionbudget.go
@@ -74,6 +74,7 @@ func (c *podDisruptionBudgets) Get(ctx context.Context, name string, options v1.
 	result = &v1beta1.PodDisruptionBudget{}
 	err = c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("poddisruptionbudgets").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
@@ -91,6 +92,7 @@ func (c *podDisruptionBudgets) List(ctx context.Context, opts v1.ListOptions) (r
 	result = &v1beta1.PodDisruptionBudgetList{}
 	err = c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("poddisruptionbudgets").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -108,6 +110,7 @@ func (c *podDisruptionBudgets) Watch(ctx context.Context, opts v1.ListOptions) (
 	opts.Watch = true
 	return c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("poddisruptionbudgets").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -119,6 +122,7 @@ func (c *podDisruptionBudgets) Create(ctx context.Context, podDisruptionBudget *
 	result = &v1beta1.PodDisruptionBudget{}
 	err = c.client.Post().
 		Namespace(c.ns).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("poddisruptionbudgets").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Body(podDisruptionBudget).
@@ -132,6 +136,7 @@ func (c *podDisruptionBudgets) Update(ctx context.Context, podDisruptionBudget *
 	result = &v1beta1.PodDisruptionBudget{}
 	err = c.client.Put().
 		Namespace(c.ns).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("poddisruptionbudgets").
 		Name(podDisruptionBudget.Name).
 		VersionedParams(&opts, scheme.ParameterCodec).
@@ -147,6 +152,7 @@ func (c *podDisruptionBudgets) UpdateStatus(ctx context.Context, podDisruptionBu
 	result = &v1beta1.PodDisruptionBudget{}
 	err = c.client.Put().
 		Namespace(c.ns).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("poddisruptionbudgets").
 		Name(podDisruptionBudget.Name).
 		SubResource("status").
@@ -161,6 +167,7 @@ func (c *podDisruptionBudgets) UpdateStatus(ctx context.Context, podDisruptionBu
 func (c *podDisruptionBudgets) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
 	return c.client.Delete().
 		Namespace(c.ns).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("poddisruptionbudgets").
 		Name(name).
 		Body(&opts).
@@ -176,6 +183,7 @@ func (c *podDisruptionBudgets) DeleteCollection(ctx context.Context, opts v1.Del
 	}
 	return c.client.Delete().
 		Namespace(c.ns).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("poddisruptionbudgets").
 		VersionedParams(&listOpts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -189,6 +197,7 @@ func (c *podDisruptionBudgets) Patch(ctx context.Context, name string, pt types.
 	result = &v1beta1.PodDisruptionBudget{}
 	err = c.client.Patch(pt).
 		Namespace(c.ns).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("poddisruptionbudgets").
 		Name(name).
 		SubResource(subresources...).
@@ -216,6 +225,7 @@ func (c *podDisruptionBudgets) Apply(ctx context.Context, podDisruptionBudget *p
 	result = &v1beta1.PodDisruptionBudget{}
 	err = c.client.Patch(types.ApplyPatchType).
 		Namespace(c.ns).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("poddisruptionbudgets").
 		Name(*name).
 		VersionedParams(&patchOpts, scheme.ParameterCodec).
@@ -245,6 +255,7 @@ func (c *podDisruptionBudgets) ApplyStatus(ctx context.Context, podDisruptionBud
 	result = &v1beta1.PodDisruptionBudget{}
 	err = c.client.Patch(types.ApplyPatchType).
 		Namespace(c.ns).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("poddisruptionbudgets").
 		Name(*name).
 		SubResource("status").

--- a/staging/src/k8s.io/client-go/kubernetes/typed/policy/v1beta1/podsecuritypolicy.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/policy/v1beta1/podsecuritypolicy.go
@@ -69,6 +69,7 @@ func newPodSecurityPolicies(c *PolicyV1beta1Client) *podSecurityPolicies {
 func (c *podSecurityPolicies) Get(ctx context.Context, name string, options v1.GetOptions) (result *v1beta1.PodSecurityPolicy, err error) {
 	result = &v1beta1.PodSecurityPolicy{}
 	err = c.client.Get().
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("podsecuritypolicies").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
@@ -85,6 +86,7 @@ func (c *podSecurityPolicies) List(ctx context.Context, opts v1.ListOptions) (re
 	}
 	result = &v1beta1.PodSecurityPolicyList{}
 	err = c.client.Get().
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("podsecuritypolicies").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -101,6 +103,7 @@ func (c *podSecurityPolicies) Watch(ctx context.Context, opts v1.ListOptions) (w
 	}
 	opts.Watch = true
 	return c.client.Get().
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("podsecuritypolicies").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -111,6 +114,7 @@ func (c *podSecurityPolicies) Watch(ctx context.Context, opts v1.ListOptions) (w
 func (c *podSecurityPolicies) Create(ctx context.Context, podSecurityPolicy *v1beta1.PodSecurityPolicy, opts v1.CreateOptions) (result *v1beta1.PodSecurityPolicy, err error) {
 	result = &v1beta1.PodSecurityPolicy{}
 	err = c.client.Post().
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("podsecuritypolicies").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Body(podSecurityPolicy).
@@ -123,6 +127,7 @@ func (c *podSecurityPolicies) Create(ctx context.Context, podSecurityPolicy *v1b
 func (c *podSecurityPolicies) Update(ctx context.Context, podSecurityPolicy *v1beta1.PodSecurityPolicy, opts v1.UpdateOptions) (result *v1beta1.PodSecurityPolicy, err error) {
 	result = &v1beta1.PodSecurityPolicy{}
 	err = c.client.Put().
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("podsecuritypolicies").
 		Name(podSecurityPolicy.Name).
 		VersionedParams(&opts, scheme.ParameterCodec).
@@ -135,6 +140,7 @@ func (c *podSecurityPolicies) Update(ctx context.Context, podSecurityPolicy *v1b
 // Delete takes name of the podSecurityPolicy and deletes it. Returns an error if one occurs.
 func (c *podSecurityPolicies) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
 	return c.client.Delete().
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("podsecuritypolicies").
 		Name(name).
 		Body(&opts).
@@ -149,6 +155,7 @@ func (c *podSecurityPolicies) DeleteCollection(ctx context.Context, opts v1.Dele
 		timeout = time.Duration(*listOpts.TimeoutSeconds) * time.Second
 	}
 	return c.client.Delete().
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("podsecuritypolicies").
 		VersionedParams(&listOpts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -161,6 +168,7 @@ func (c *podSecurityPolicies) DeleteCollection(ctx context.Context, opts v1.Dele
 func (c *podSecurityPolicies) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts v1.PatchOptions, subresources ...string) (result *v1beta1.PodSecurityPolicy, err error) {
 	result = &v1beta1.PodSecurityPolicy{}
 	err = c.client.Patch(pt).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("podsecuritypolicies").
 		Name(name).
 		SubResource(subresources...).
@@ -187,6 +195,7 @@ func (c *podSecurityPolicies) Apply(ctx context.Context, podSecurityPolicy *poli
 	}
 	result = &v1beta1.PodSecurityPolicy{}
 	err = c.client.Patch(types.ApplyPatchType).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("podsecuritypolicies").
 		Name(*name).
 		VersionedParams(&patchOpts, scheme.ParameterCodec).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1/clusterrole.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1/clusterrole.go
@@ -69,6 +69,7 @@ func newClusterRoles(c *RbacV1Client) *clusterRoles {
 func (c *clusterRoles) Get(ctx context.Context, name string, options metav1.GetOptions) (result *v1.ClusterRole, err error) {
 	result = &v1.ClusterRole{}
 	err = c.client.Get().
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("clusterroles").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
@@ -85,6 +86,7 @@ func (c *clusterRoles) List(ctx context.Context, opts metav1.ListOptions) (resul
 	}
 	result = &v1.ClusterRoleList{}
 	err = c.client.Get().
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("clusterroles").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -101,6 +103,7 @@ func (c *clusterRoles) Watch(ctx context.Context, opts metav1.ListOptions) (watc
 	}
 	opts.Watch = true
 	return c.client.Get().
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("clusterroles").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -111,6 +114,7 @@ func (c *clusterRoles) Watch(ctx context.Context, opts metav1.ListOptions) (watc
 func (c *clusterRoles) Create(ctx context.Context, clusterRole *v1.ClusterRole, opts metav1.CreateOptions) (result *v1.ClusterRole, err error) {
 	result = &v1.ClusterRole{}
 	err = c.client.Post().
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("clusterroles").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Body(clusterRole).
@@ -123,6 +127,7 @@ func (c *clusterRoles) Create(ctx context.Context, clusterRole *v1.ClusterRole, 
 func (c *clusterRoles) Update(ctx context.Context, clusterRole *v1.ClusterRole, opts metav1.UpdateOptions) (result *v1.ClusterRole, err error) {
 	result = &v1.ClusterRole{}
 	err = c.client.Put().
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("clusterroles").
 		Name(clusterRole.Name).
 		VersionedParams(&opts, scheme.ParameterCodec).
@@ -135,6 +140,7 @@ func (c *clusterRoles) Update(ctx context.Context, clusterRole *v1.ClusterRole, 
 // Delete takes name of the clusterRole and deletes it. Returns an error if one occurs.
 func (c *clusterRoles) Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error {
 	return c.client.Delete().
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("clusterroles").
 		Name(name).
 		Body(&opts).
@@ -149,6 +155,7 @@ func (c *clusterRoles) DeleteCollection(ctx context.Context, opts metav1.DeleteO
 		timeout = time.Duration(*listOpts.TimeoutSeconds) * time.Second
 	}
 	return c.client.Delete().
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("clusterroles").
 		VersionedParams(&listOpts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -161,6 +168,7 @@ func (c *clusterRoles) DeleteCollection(ctx context.Context, opts metav1.DeleteO
 func (c *clusterRoles) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts metav1.PatchOptions, subresources ...string) (result *v1.ClusterRole, err error) {
 	result = &v1.ClusterRole{}
 	err = c.client.Patch(pt).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("clusterroles").
 		Name(name).
 		SubResource(subresources...).
@@ -187,6 +195,7 @@ func (c *clusterRoles) Apply(ctx context.Context, clusterRole *rbacv1.ClusterRol
 	}
 	result = &v1.ClusterRole{}
 	err = c.client.Patch(types.ApplyPatchType).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("clusterroles").
 		Name(*name).
 		VersionedParams(&patchOpts, scheme.ParameterCodec).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1/clusterrolebinding.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1/clusterrolebinding.go
@@ -69,6 +69,7 @@ func newClusterRoleBindings(c *RbacV1Client) *clusterRoleBindings {
 func (c *clusterRoleBindings) Get(ctx context.Context, name string, options metav1.GetOptions) (result *v1.ClusterRoleBinding, err error) {
 	result = &v1.ClusterRoleBinding{}
 	err = c.client.Get().
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("clusterrolebindings").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
@@ -85,6 +86,7 @@ func (c *clusterRoleBindings) List(ctx context.Context, opts metav1.ListOptions)
 	}
 	result = &v1.ClusterRoleBindingList{}
 	err = c.client.Get().
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("clusterrolebindings").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -101,6 +103,7 @@ func (c *clusterRoleBindings) Watch(ctx context.Context, opts metav1.ListOptions
 	}
 	opts.Watch = true
 	return c.client.Get().
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("clusterrolebindings").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -111,6 +114,7 @@ func (c *clusterRoleBindings) Watch(ctx context.Context, opts metav1.ListOptions
 func (c *clusterRoleBindings) Create(ctx context.Context, clusterRoleBinding *v1.ClusterRoleBinding, opts metav1.CreateOptions) (result *v1.ClusterRoleBinding, err error) {
 	result = &v1.ClusterRoleBinding{}
 	err = c.client.Post().
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("clusterrolebindings").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Body(clusterRoleBinding).
@@ -123,6 +127,7 @@ func (c *clusterRoleBindings) Create(ctx context.Context, clusterRoleBinding *v1
 func (c *clusterRoleBindings) Update(ctx context.Context, clusterRoleBinding *v1.ClusterRoleBinding, opts metav1.UpdateOptions) (result *v1.ClusterRoleBinding, err error) {
 	result = &v1.ClusterRoleBinding{}
 	err = c.client.Put().
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("clusterrolebindings").
 		Name(clusterRoleBinding.Name).
 		VersionedParams(&opts, scheme.ParameterCodec).
@@ -135,6 +140,7 @@ func (c *clusterRoleBindings) Update(ctx context.Context, clusterRoleBinding *v1
 // Delete takes name of the clusterRoleBinding and deletes it. Returns an error if one occurs.
 func (c *clusterRoleBindings) Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error {
 	return c.client.Delete().
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("clusterrolebindings").
 		Name(name).
 		Body(&opts).
@@ -149,6 +155,7 @@ func (c *clusterRoleBindings) DeleteCollection(ctx context.Context, opts metav1.
 		timeout = time.Duration(*listOpts.TimeoutSeconds) * time.Second
 	}
 	return c.client.Delete().
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("clusterrolebindings").
 		VersionedParams(&listOpts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -161,6 +168,7 @@ func (c *clusterRoleBindings) DeleteCollection(ctx context.Context, opts metav1.
 func (c *clusterRoleBindings) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts metav1.PatchOptions, subresources ...string) (result *v1.ClusterRoleBinding, err error) {
 	result = &v1.ClusterRoleBinding{}
 	err = c.client.Patch(pt).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("clusterrolebindings").
 		Name(name).
 		SubResource(subresources...).
@@ -187,6 +195,7 @@ func (c *clusterRoleBindings) Apply(ctx context.Context, clusterRoleBinding *rba
 	}
 	result = &v1.ClusterRoleBinding{}
 	err = c.client.Patch(types.ApplyPatchType).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("clusterrolebindings").
 		Name(*name).
 		VersionedParams(&patchOpts, scheme.ParameterCodec).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1/role.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1/role.go
@@ -72,6 +72,7 @@ func (c *roles) Get(ctx context.Context, name string, options metav1.GetOptions)
 	result = &v1.Role{}
 	err = c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("roles").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
@@ -89,6 +90,7 @@ func (c *roles) List(ctx context.Context, opts metav1.ListOptions) (result *v1.R
 	result = &v1.RoleList{}
 	err = c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("roles").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -106,6 +108,7 @@ func (c *roles) Watch(ctx context.Context, opts metav1.ListOptions) (watch.Inter
 	opts.Watch = true
 	return c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("roles").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -117,6 +120,7 @@ func (c *roles) Create(ctx context.Context, role *v1.Role, opts metav1.CreateOpt
 	result = &v1.Role{}
 	err = c.client.Post().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("roles").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Body(role).
@@ -130,6 +134,7 @@ func (c *roles) Update(ctx context.Context, role *v1.Role, opts metav1.UpdateOpt
 	result = &v1.Role{}
 	err = c.client.Put().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("roles").
 		Name(role.Name).
 		VersionedParams(&opts, scheme.ParameterCodec).
@@ -143,6 +148,7 @@ func (c *roles) Update(ctx context.Context, role *v1.Role, opts metav1.UpdateOpt
 func (c *roles) Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error {
 	return c.client.Delete().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("roles").
 		Name(name).
 		Body(&opts).
@@ -158,6 +164,7 @@ func (c *roles) DeleteCollection(ctx context.Context, opts metav1.DeleteOptions,
 	}
 	return c.client.Delete().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("roles").
 		VersionedParams(&listOpts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -171,6 +178,7 @@ func (c *roles) Patch(ctx context.Context, name string, pt types.PatchType, data
 	result = &v1.Role{}
 	err = c.client.Patch(pt).
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("roles").
 		Name(name).
 		SubResource(subresources...).
@@ -198,6 +206,7 @@ func (c *roles) Apply(ctx context.Context, role *rbacv1.RoleApplyConfiguration, 
 	result = &v1.Role{}
 	err = c.client.Patch(types.ApplyPatchType).
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("roles").
 		Name(*name).
 		VersionedParams(&patchOpts, scheme.ParameterCodec).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1/rolebinding.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1/rolebinding.go
@@ -72,6 +72,7 @@ func (c *roleBindings) Get(ctx context.Context, name string, options metav1.GetO
 	result = &v1.RoleBinding{}
 	err = c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("rolebindings").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
@@ -89,6 +90,7 @@ func (c *roleBindings) List(ctx context.Context, opts metav1.ListOptions) (resul
 	result = &v1.RoleBindingList{}
 	err = c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("rolebindings").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -106,6 +108,7 @@ func (c *roleBindings) Watch(ctx context.Context, opts metav1.ListOptions) (watc
 	opts.Watch = true
 	return c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("rolebindings").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -117,6 +120,7 @@ func (c *roleBindings) Create(ctx context.Context, roleBinding *v1.RoleBinding, 
 	result = &v1.RoleBinding{}
 	err = c.client.Post().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("rolebindings").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Body(roleBinding).
@@ -130,6 +134,7 @@ func (c *roleBindings) Update(ctx context.Context, roleBinding *v1.RoleBinding, 
 	result = &v1.RoleBinding{}
 	err = c.client.Put().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("rolebindings").
 		Name(roleBinding.Name).
 		VersionedParams(&opts, scheme.ParameterCodec).
@@ -143,6 +148,7 @@ func (c *roleBindings) Update(ctx context.Context, roleBinding *v1.RoleBinding, 
 func (c *roleBindings) Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error {
 	return c.client.Delete().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("rolebindings").
 		Name(name).
 		Body(&opts).
@@ -158,6 +164,7 @@ func (c *roleBindings) DeleteCollection(ctx context.Context, opts metav1.DeleteO
 	}
 	return c.client.Delete().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("rolebindings").
 		VersionedParams(&listOpts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -171,6 +178,7 @@ func (c *roleBindings) Patch(ctx context.Context, name string, pt types.PatchTyp
 	result = &v1.RoleBinding{}
 	err = c.client.Patch(pt).
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("rolebindings").
 		Name(name).
 		SubResource(subresources...).
@@ -198,6 +206,7 @@ func (c *roleBindings) Apply(ctx context.Context, roleBinding *rbacv1.RoleBindin
 	result = &v1.RoleBinding{}
 	err = c.client.Patch(types.ApplyPatchType).
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("rolebindings").
 		Name(*name).
 		VersionedParams(&patchOpts, scheme.ParameterCodec).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1alpha1/clusterrole.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1alpha1/clusterrole.go
@@ -69,6 +69,7 @@ func newClusterRoles(c *RbacV1alpha1Client) *clusterRoles {
 func (c *clusterRoles) Get(ctx context.Context, name string, options v1.GetOptions) (result *v1alpha1.ClusterRole, err error) {
 	result = &v1alpha1.ClusterRole{}
 	err = c.client.Get().
+		GroupVersion(v1alpha1.SchemeGroupVersion).
 		Resource("clusterroles").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
@@ -85,6 +86,7 @@ func (c *clusterRoles) List(ctx context.Context, opts v1.ListOptions) (result *v
 	}
 	result = &v1alpha1.ClusterRoleList{}
 	err = c.client.Get().
+		GroupVersion(v1alpha1.SchemeGroupVersion).
 		Resource("clusterroles").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -101,6 +103,7 @@ func (c *clusterRoles) Watch(ctx context.Context, opts v1.ListOptions) (watch.In
 	}
 	opts.Watch = true
 	return c.client.Get().
+		GroupVersion(v1alpha1.SchemeGroupVersion).
 		Resource("clusterroles").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -111,6 +114,7 @@ func (c *clusterRoles) Watch(ctx context.Context, opts v1.ListOptions) (watch.In
 func (c *clusterRoles) Create(ctx context.Context, clusterRole *v1alpha1.ClusterRole, opts v1.CreateOptions) (result *v1alpha1.ClusterRole, err error) {
 	result = &v1alpha1.ClusterRole{}
 	err = c.client.Post().
+		GroupVersion(v1alpha1.SchemeGroupVersion).
 		Resource("clusterroles").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Body(clusterRole).
@@ -123,6 +127,7 @@ func (c *clusterRoles) Create(ctx context.Context, clusterRole *v1alpha1.Cluster
 func (c *clusterRoles) Update(ctx context.Context, clusterRole *v1alpha1.ClusterRole, opts v1.UpdateOptions) (result *v1alpha1.ClusterRole, err error) {
 	result = &v1alpha1.ClusterRole{}
 	err = c.client.Put().
+		GroupVersion(v1alpha1.SchemeGroupVersion).
 		Resource("clusterroles").
 		Name(clusterRole.Name).
 		VersionedParams(&opts, scheme.ParameterCodec).
@@ -135,6 +140,7 @@ func (c *clusterRoles) Update(ctx context.Context, clusterRole *v1alpha1.Cluster
 // Delete takes name of the clusterRole and deletes it. Returns an error if one occurs.
 func (c *clusterRoles) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
 	return c.client.Delete().
+		GroupVersion(v1alpha1.SchemeGroupVersion).
 		Resource("clusterroles").
 		Name(name).
 		Body(&opts).
@@ -149,6 +155,7 @@ func (c *clusterRoles) DeleteCollection(ctx context.Context, opts v1.DeleteOptio
 		timeout = time.Duration(*listOpts.TimeoutSeconds) * time.Second
 	}
 	return c.client.Delete().
+		GroupVersion(v1alpha1.SchemeGroupVersion).
 		Resource("clusterroles").
 		VersionedParams(&listOpts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -161,6 +168,7 @@ func (c *clusterRoles) DeleteCollection(ctx context.Context, opts v1.DeleteOptio
 func (c *clusterRoles) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts v1.PatchOptions, subresources ...string) (result *v1alpha1.ClusterRole, err error) {
 	result = &v1alpha1.ClusterRole{}
 	err = c.client.Patch(pt).
+		GroupVersion(v1alpha1.SchemeGroupVersion).
 		Resource("clusterroles").
 		Name(name).
 		SubResource(subresources...).
@@ -187,6 +195,7 @@ func (c *clusterRoles) Apply(ctx context.Context, clusterRole *rbacv1alpha1.Clus
 	}
 	result = &v1alpha1.ClusterRole{}
 	err = c.client.Patch(types.ApplyPatchType).
+		GroupVersion(v1alpha1.SchemeGroupVersion).
 		Resource("clusterroles").
 		Name(*name).
 		VersionedParams(&patchOpts, scheme.ParameterCodec).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1alpha1/clusterrolebinding.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1alpha1/clusterrolebinding.go
@@ -69,6 +69,7 @@ func newClusterRoleBindings(c *RbacV1alpha1Client) *clusterRoleBindings {
 func (c *clusterRoleBindings) Get(ctx context.Context, name string, options v1.GetOptions) (result *v1alpha1.ClusterRoleBinding, err error) {
 	result = &v1alpha1.ClusterRoleBinding{}
 	err = c.client.Get().
+		GroupVersion(v1alpha1.SchemeGroupVersion).
 		Resource("clusterrolebindings").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
@@ -85,6 +86,7 @@ func (c *clusterRoleBindings) List(ctx context.Context, opts v1.ListOptions) (re
 	}
 	result = &v1alpha1.ClusterRoleBindingList{}
 	err = c.client.Get().
+		GroupVersion(v1alpha1.SchemeGroupVersion).
 		Resource("clusterrolebindings").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -101,6 +103,7 @@ func (c *clusterRoleBindings) Watch(ctx context.Context, opts v1.ListOptions) (w
 	}
 	opts.Watch = true
 	return c.client.Get().
+		GroupVersion(v1alpha1.SchemeGroupVersion).
 		Resource("clusterrolebindings").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -111,6 +114,7 @@ func (c *clusterRoleBindings) Watch(ctx context.Context, opts v1.ListOptions) (w
 func (c *clusterRoleBindings) Create(ctx context.Context, clusterRoleBinding *v1alpha1.ClusterRoleBinding, opts v1.CreateOptions) (result *v1alpha1.ClusterRoleBinding, err error) {
 	result = &v1alpha1.ClusterRoleBinding{}
 	err = c.client.Post().
+		GroupVersion(v1alpha1.SchemeGroupVersion).
 		Resource("clusterrolebindings").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Body(clusterRoleBinding).
@@ -123,6 +127,7 @@ func (c *clusterRoleBindings) Create(ctx context.Context, clusterRoleBinding *v1
 func (c *clusterRoleBindings) Update(ctx context.Context, clusterRoleBinding *v1alpha1.ClusterRoleBinding, opts v1.UpdateOptions) (result *v1alpha1.ClusterRoleBinding, err error) {
 	result = &v1alpha1.ClusterRoleBinding{}
 	err = c.client.Put().
+		GroupVersion(v1alpha1.SchemeGroupVersion).
 		Resource("clusterrolebindings").
 		Name(clusterRoleBinding.Name).
 		VersionedParams(&opts, scheme.ParameterCodec).
@@ -135,6 +140,7 @@ func (c *clusterRoleBindings) Update(ctx context.Context, clusterRoleBinding *v1
 // Delete takes name of the clusterRoleBinding and deletes it. Returns an error if one occurs.
 func (c *clusterRoleBindings) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
 	return c.client.Delete().
+		GroupVersion(v1alpha1.SchemeGroupVersion).
 		Resource("clusterrolebindings").
 		Name(name).
 		Body(&opts).
@@ -149,6 +155,7 @@ func (c *clusterRoleBindings) DeleteCollection(ctx context.Context, opts v1.Dele
 		timeout = time.Duration(*listOpts.TimeoutSeconds) * time.Second
 	}
 	return c.client.Delete().
+		GroupVersion(v1alpha1.SchemeGroupVersion).
 		Resource("clusterrolebindings").
 		VersionedParams(&listOpts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -161,6 +168,7 @@ func (c *clusterRoleBindings) DeleteCollection(ctx context.Context, opts v1.Dele
 func (c *clusterRoleBindings) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts v1.PatchOptions, subresources ...string) (result *v1alpha1.ClusterRoleBinding, err error) {
 	result = &v1alpha1.ClusterRoleBinding{}
 	err = c.client.Patch(pt).
+		GroupVersion(v1alpha1.SchemeGroupVersion).
 		Resource("clusterrolebindings").
 		Name(name).
 		SubResource(subresources...).
@@ -187,6 +195,7 @@ func (c *clusterRoleBindings) Apply(ctx context.Context, clusterRoleBinding *rba
 	}
 	result = &v1alpha1.ClusterRoleBinding{}
 	err = c.client.Patch(types.ApplyPatchType).
+		GroupVersion(v1alpha1.SchemeGroupVersion).
 		Resource("clusterrolebindings").
 		Name(*name).
 		VersionedParams(&patchOpts, scheme.ParameterCodec).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1alpha1/role.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1alpha1/role.go
@@ -72,6 +72,7 @@ func (c *roles) Get(ctx context.Context, name string, options v1.GetOptions) (re
 	result = &v1alpha1.Role{}
 	err = c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(v1alpha1.SchemeGroupVersion).
 		Resource("roles").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
@@ -89,6 +90,7 @@ func (c *roles) List(ctx context.Context, opts v1.ListOptions) (result *v1alpha1
 	result = &v1alpha1.RoleList{}
 	err = c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(v1alpha1.SchemeGroupVersion).
 		Resource("roles").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -106,6 +108,7 @@ func (c *roles) Watch(ctx context.Context, opts v1.ListOptions) (watch.Interface
 	opts.Watch = true
 	return c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(v1alpha1.SchemeGroupVersion).
 		Resource("roles").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -117,6 +120,7 @@ func (c *roles) Create(ctx context.Context, role *v1alpha1.Role, opts v1.CreateO
 	result = &v1alpha1.Role{}
 	err = c.client.Post().
 		Namespace(c.ns).
+		GroupVersion(v1alpha1.SchemeGroupVersion).
 		Resource("roles").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Body(role).
@@ -130,6 +134,7 @@ func (c *roles) Update(ctx context.Context, role *v1alpha1.Role, opts v1.UpdateO
 	result = &v1alpha1.Role{}
 	err = c.client.Put().
 		Namespace(c.ns).
+		GroupVersion(v1alpha1.SchemeGroupVersion).
 		Resource("roles").
 		Name(role.Name).
 		VersionedParams(&opts, scheme.ParameterCodec).
@@ -143,6 +148,7 @@ func (c *roles) Update(ctx context.Context, role *v1alpha1.Role, opts v1.UpdateO
 func (c *roles) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
 	return c.client.Delete().
 		Namespace(c.ns).
+		GroupVersion(v1alpha1.SchemeGroupVersion).
 		Resource("roles").
 		Name(name).
 		Body(&opts).
@@ -158,6 +164,7 @@ func (c *roles) DeleteCollection(ctx context.Context, opts v1.DeleteOptions, lis
 	}
 	return c.client.Delete().
 		Namespace(c.ns).
+		GroupVersion(v1alpha1.SchemeGroupVersion).
 		Resource("roles").
 		VersionedParams(&listOpts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -171,6 +178,7 @@ func (c *roles) Patch(ctx context.Context, name string, pt types.PatchType, data
 	result = &v1alpha1.Role{}
 	err = c.client.Patch(pt).
 		Namespace(c.ns).
+		GroupVersion(v1alpha1.SchemeGroupVersion).
 		Resource("roles").
 		Name(name).
 		SubResource(subresources...).
@@ -198,6 +206,7 @@ func (c *roles) Apply(ctx context.Context, role *rbacv1alpha1.RoleApplyConfigura
 	result = &v1alpha1.Role{}
 	err = c.client.Patch(types.ApplyPatchType).
 		Namespace(c.ns).
+		GroupVersion(v1alpha1.SchemeGroupVersion).
 		Resource("roles").
 		Name(*name).
 		VersionedParams(&patchOpts, scheme.ParameterCodec).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1alpha1/rolebinding.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1alpha1/rolebinding.go
@@ -72,6 +72,7 @@ func (c *roleBindings) Get(ctx context.Context, name string, options v1.GetOptio
 	result = &v1alpha1.RoleBinding{}
 	err = c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(v1alpha1.SchemeGroupVersion).
 		Resource("rolebindings").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
@@ -89,6 +90,7 @@ func (c *roleBindings) List(ctx context.Context, opts v1.ListOptions) (result *v
 	result = &v1alpha1.RoleBindingList{}
 	err = c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(v1alpha1.SchemeGroupVersion).
 		Resource("rolebindings").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -106,6 +108,7 @@ func (c *roleBindings) Watch(ctx context.Context, opts v1.ListOptions) (watch.In
 	opts.Watch = true
 	return c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(v1alpha1.SchemeGroupVersion).
 		Resource("rolebindings").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -117,6 +120,7 @@ func (c *roleBindings) Create(ctx context.Context, roleBinding *v1alpha1.RoleBin
 	result = &v1alpha1.RoleBinding{}
 	err = c.client.Post().
 		Namespace(c.ns).
+		GroupVersion(v1alpha1.SchemeGroupVersion).
 		Resource("rolebindings").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Body(roleBinding).
@@ -130,6 +134,7 @@ func (c *roleBindings) Update(ctx context.Context, roleBinding *v1alpha1.RoleBin
 	result = &v1alpha1.RoleBinding{}
 	err = c.client.Put().
 		Namespace(c.ns).
+		GroupVersion(v1alpha1.SchemeGroupVersion).
 		Resource("rolebindings").
 		Name(roleBinding.Name).
 		VersionedParams(&opts, scheme.ParameterCodec).
@@ -143,6 +148,7 @@ func (c *roleBindings) Update(ctx context.Context, roleBinding *v1alpha1.RoleBin
 func (c *roleBindings) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
 	return c.client.Delete().
 		Namespace(c.ns).
+		GroupVersion(v1alpha1.SchemeGroupVersion).
 		Resource("rolebindings").
 		Name(name).
 		Body(&opts).
@@ -158,6 +164,7 @@ func (c *roleBindings) DeleteCollection(ctx context.Context, opts v1.DeleteOptio
 	}
 	return c.client.Delete().
 		Namespace(c.ns).
+		GroupVersion(v1alpha1.SchemeGroupVersion).
 		Resource("rolebindings").
 		VersionedParams(&listOpts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -171,6 +178,7 @@ func (c *roleBindings) Patch(ctx context.Context, name string, pt types.PatchTyp
 	result = &v1alpha1.RoleBinding{}
 	err = c.client.Patch(pt).
 		Namespace(c.ns).
+		GroupVersion(v1alpha1.SchemeGroupVersion).
 		Resource("rolebindings").
 		Name(name).
 		SubResource(subresources...).
@@ -198,6 +206,7 @@ func (c *roleBindings) Apply(ctx context.Context, roleBinding *rbacv1alpha1.Role
 	result = &v1alpha1.RoleBinding{}
 	err = c.client.Patch(types.ApplyPatchType).
 		Namespace(c.ns).
+		GroupVersion(v1alpha1.SchemeGroupVersion).
 		Resource("rolebindings").
 		Name(*name).
 		VersionedParams(&patchOpts, scheme.ParameterCodec).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1beta1/clusterrole.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1beta1/clusterrole.go
@@ -69,6 +69,7 @@ func newClusterRoles(c *RbacV1beta1Client) *clusterRoles {
 func (c *clusterRoles) Get(ctx context.Context, name string, options v1.GetOptions) (result *v1beta1.ClusterRole, err error) {
 	result = &v1beta1.ClusterRole{}
 	err = c.client.Get().
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("clusterroles").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
@@ -85,6 +86,7 @@ func (c *clusterRoles) List(ctx context.Context, opts v1.ListOptions) (result *v
 	}
 	result = &v1beta1.ClusterRoleList{}
 	err = c.client.Get().
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("clusterroles").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -101,6 +103,7 @@ func (c *clusterRoles) Watch(ctx context.Context, opts v1.ListOptions) (watch.In
 	}
 	opts.Watch = true
 	return c.client.Get().
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("clusterroles").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -111,6 +114,7 @@ func (c *clusterRoles) Watch(ctx context.Context, opts v1.ListOptions) (watch.In
 func (c *clusterRoles) Create(ctx context.Context, clusterRole *v1beta1.ClusterRole, opts v1.CreateOptions) (result *v1beta1.ClusterRole, err error) {
 	result = &v1beta1.ClusterRole{}
 	err = c.client.Post().
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("clusterroles").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Body(clusterRole).
@@ -123,6 +127,7 @@ func (c *clusterRoles) Create(ctx context.Context, clusterRole *v1beta1.ClusterR
 func (c *clusterRoles) Update(ctx context.Context, clusterRole *v1beta1.ClusterRole, opts v1.UpdateOptions) (result *v1beta1.ClusterRole, err error) {
 	result = &v1beta1.ClusterRole{}
 	err = c.client.Put().
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("clusterroles").
 		Name(clusterRole.Name).
 		VersionedParams(&opts, scheme.ParameterCodec).
@@ -135,6 +140,7 @@ func (c *clusterRoles) Update(ctx context.Context, clusterRole *v1beta1.ClusterR
 // Delete takes name of the clusterRole and deletes it. Returns an error if one occurs.
 func (c *clusterRoles) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
 	return c.client.Delete().
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("clusterroles").
 		Name(name).
 		Body(&opts).
@@ -149,6 +155,7 @@ func (c *clusterRoles) DeleteCollection(ctx context.Context, opts v1.DeleteOptio
 		timeout = time.Duration(*listOpts.TimeoutSeconds) * time.Second
 	}
 	return c.client.Delete().
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("clusterroles").
 		VersionedParams(&listOpts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -161,6 +168,7 @@ func (c *clusterRoles) DeleteCollection(ctx context.Context, opts v1.DeleteOptio
 func (c *clusterRoles) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts v1.PatchOptions, subresources ...string) (result *v1beta1.ClusterRole, err error) {
 	result = &v1beta1.ClusterRole{}
 	err = c.client.Patch(pt).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("clusterroles").
 		Name(name).
 		SubResource(subresources...).
@@ -187,6 +195,7 @@ func (c *clusterRoles) Apply(ctx context.Context, clusterRole *rbacv1beta1.Clust
 	}
 	result = &v1beta1.ClusterRole{}
 	err = c.client.Patch(types.ApplyPatchType).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("clusterroles").
 		Name(*name).
 		VersionedParams(&patchOpts, scheme.ParameterCodec).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1beta1/clusterrolebinding.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1beta1/clusterrolebinding.go
@@ -69,6 +69,7 @@ func newClusterRoleBindings(c *RbacV1beta1Client) *clusterRoleBindings {
 func (c *clusterRoleBindings) Get(ctx context.Context, name string, options v1.GetOptions) (result *v1beta1.ClusterRoleBinding, err error) {
 	result = &v1beta1.ClusterRoleBinding{}
 	err = c.client.Get().
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("clusterrolebindings").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
@@ -85,6 +86,7 @@ func (c *clusterRoleBindings) List(ctx context.Context, opts v1.ListOptions) (re
 	}
 	result = &v1beta1.ClusterRoleBindingList{}
 	err = c.client.Get().
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("clusterrolebindings").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -101,6 +103,7 @@ func (c *clusterRoleBindings) Watch(ctx context.Context, opts v1.ListOptions) (w
 	}
 	opts.Watch = true
 	return c.client.Get().
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("clusterrolebindings").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -111,6 +114,7 @@ func (c *clusterRoleBindings) Watch(ctx context.Context, opts v1.ListOptions) (w
 func (c *clusterRoleBindings) Create(ctx context.Context, clusterRoleBinding *v1beta1.ClusterRoleBinding, opts v1.CreateOptions) (result *v1beta1.ClusterRoleBinding, err error) {
 	result = &v1beta1.ClusterRoleBinding{}
 	err = c.client.Post().
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("clusterrolebindings").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Body(clusterRoleBinding).
@@ -123,6 +127,7 @@ func (c *clusterRoleBindings) Create(ctx context.Context, clusterRoleBinding *v1
 func (c *clusterRoleBindings) Update(ctx context.Context, clusterRoleBinding *v1beta1.ClusterRoleBinding, opts v1.UpdateOptions) (result *v1beta1.ClusterRoleBinding, err error) {
 	result = &v1beta1.ClusterRoleBinding{}
 	err = c.client.Put().
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("clusterrolebindings").
 		Name(clusterRoleBinding.Name).
 		VersionedParams(&opts, scheme.ParameterCodec).
@@ -135,6 +140,7 @@ func (c *clusterRoleBindings) Update(ctx context.Context, clusterRoleBinding *v1
 // Delete takes name of the clusterRoleBinding and deletes it. Returns an error if one occurs.
 func (c *clusterRoleBindings) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
 	return c.client.Delete().
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("clusterrolebindings").
 		Name(name).
 		Body(&opts).
@@ -149,6 +155,7 @@ func (c *clusterRoleBindings) DeleteCollection(ctx context.Context, opts v1.Dele
 		timeout = time.Duration(*listOpts.TimeoutSeconds) * time.Second
 	}
 	return c.client.Delete().
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("clusterrolebindings").
 		VersionedParams(&listOpts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -161,6 +168,7 @@ func (c *clusterRoleBindings) DeleteCollection(ctx context.Context, opts v1.Dele
 func (c *clusterRoleBindings) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts v1.PatchOptions, subresources ...string) (result *v1beta1.ClusterRoleBinding, err error) {
 	result = &v1beta1.ClusterRoleBinding{}
 	err = c.client.Patch(pt).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("clusterrolebindings").
 		Name(name).
 		SubResource(subresources...).
@@ -187,6 +195,7 @@ func (c *clusterRoleBindings) Apply(ctx context.Context, clusterRoleBinding *rba
 	}
 	result = &v1beta1.ClusterRoleBinding{}
 	err = c.client.Patch(types.ApplyPatchType).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("clusterrolebindings").
 		Name(*name).
 		VersionedParams(&patchOpts, scheme.ParameterCodec).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1beta1/role.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1beta1/role.go
@@ -72,6 +72,7 @@ func (c *roles) Get(ctx context.Context, name string, options v1.GetOptions) (re
 	result = &v1beta1.Role{}
 	err = c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("roles").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
@@ -89,6 +90,7 @@ func (c *roles) List(ctx context.Context, opts v1.ListOptions) (result *v1beta1.
 	result = &v1beta1.RoleList{}
 	err = c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("roles").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -106,6 +108,7 @@ func (c *roles) Watch(ctx context.Context, opts v1.ListOptions) (watch.Interface
 	opts.Watch = true
 	return c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("roles").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -117,6 +120,7 @@ func (c *roles) Create(ctx context.Context, role *v1beta1.Role, opts v1.CreateOp
 	result = &v1beta1.Role{}
 	err = c.client.Post().
 		Namespace(c.ns).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("roles").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Body(role).
@@ -130,6 +134,7 @@ func (c *roles) Update(ctx context.Context, role *v1beta1.Role, opts v1.UpdateOp
 	result = &v1beta1.Role{}
 	err = c.client.Put().
 		Namespace(c.ns).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("roles").
 		Name(role.Name).
 		VersionedParams(&opts, scheme.ParameterCodec).
@@ -143,6 +148,7 @@ func (c *roles) Update(ctx context.Context, role *v1beta1.Role, opts v1.UpdateOp
 func (c *roles) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
 	return c.client.Delete().
 		Namespace(c.ns).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("roles").
 		Name(name).
 		Body(&opts).
@@ -158,6 +164,7 @@ func (c *roles) DeleteCollection(ctx context.Context, opts v1.DeleteOptions, lis
 	}
 	return c.client.Delete().
 		Namespace(c.ns).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("roles").
 		VersionedParams(&listOpts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -171,6 +178,7 @@ func (c *roles) Patch(ctx context.Context, name string, pt types.PatchType, data
 	result = &v1beta1.Role{}
 	err = c.client.Patch(pt).
 		Namespace(c.ns).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("roles").
 		Name(name).
 		SubResource(subresources...).
@@ -198,6 +206,7 @@ func (c *roles) Apply(ctx context.Context, role *rbacv1beta1.RoleApplyConfigurat
 	result = &v1beta1.Role{}
 	err = c.client.Patch(types.ApplyPatchType).
 		Namespace(c.ns).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("roles").
 		Name(*name).
 		VersionedParams(&patchOpts, scheme.ParameterCodec).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1beta1/rolebinding.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1beta1/rolebinding.go
@@ -72,6 +72,7 @@ func (c *roleBindings) Get(ctx context.Context, name string, options v1.GetOptio
 	result = &v1beta1.RoleBinding{}
 	err = c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("rolebindings").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
@@ -89,6 +90,7 @@ func (c *roleBindings) List(ctx context.Context, opts v1.ListOptions) (result *v
 	result = &v1beta1.RoleBindingList{}
 	err = c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("rolebindings").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -106,6 +108,7 @@ func (c *roleBindings) Watch(ctx context.Context, opts v1.ListOptions) (watch.In
 	opts.Watch = true
 	return c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("rolebindings").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -117,6 +120,7 @@ func (c *roleBindings) Create(ctx context.Context, roleBinding *v1beta1.RoleBind
 	result = &v1beta1.RoleBinding{}
 	err = c.client.Post().
 		Namespace(c.ns).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("rolebindings").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Body(roleBinding).
@@ -130,6 +134,7 @@ func (c *roleBindings) Update(ctx context.Context, roleBinding *v1beta1.RoleBind
 	result = &v1beta1.RoleBinding{}
 	err = c.client.Put().
 		Namespace(c.ns).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("rolebindings").
 		Name(roleBinding.Name).
 		VersionedParams(&opts, scheme.ParameterCodec).
@@ -143,6 +148,7 @@ func (c *roleBindings) Update(ctx context.Context, roleBinding *v1beta1.RoleBind
 func (c *roleBindings) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
 	return c.client.Delete().
 		Namespace(c.ns).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("rolebindings").
 		Name(name).
 		Body(&opts).
@@ -158,6 +164,7 @@ func (c *roleBindings) DeleteCollection(ctx context.Context, opts v1.DeleteOptio
 	}
 	return c.client.Delete().
 		Namespace(c.ns).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("rolebindings").
 		VersionedParams(&listOpts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -171,6 +178,7 @@ func (c *roleBindings) Patch(ctx context.Context, name string, pt types.PatchTyp
 	result = &v1beta1.RoleBinding{}
 	err = c.client.Patch(pt).
 		Namespace(c.ns).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("rolebindings").
 		Name(name).
 		SubResource(subresources...).
@@ -198,6 +206,7 @@ func (c *roleBindings) Apply(ctx context.Context, roleBinding *rbacv1beta1.RoleB
 	result = &v1beta1.RoleBinding{}
 	err = c.client.Patch(types.ApplyPatchType).
 		Namespace(c.ns).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("rolebindings").
 		Name(*name).
 		VersionedParams(&patchOpts, scheme.ParameterCodec).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/scheduling/v1/priorityclass.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/scheduling/v1/priorityclass.go
@@ -69,6 +69,7 @@ func newPriorityClasses(c *SchedulingV1Client) *priorityClasses {
 func (c *priorityClasses) Get(ctx context.Context, name string, options metav1.GetOptions) (result *v1.PriorityClass, err error) {
 	result = &v1.PriorityClass{}
 	err = c.client.Get().
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("priorityclasses").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
@@ -85,6 +86,7 @@ func (c *priorityClasses) List(ctx context.Context, opts metav1.ListOptions) (re
 	}
 	result = &v1.PriorityClassList{}
 	err = c.client.Get().
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("priorityclasses").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -101,6 +103,7 @@ func (c *priorityClasses) Watch(ctx context.Context, opts metav1.ListOptions) (w
 	}
 	opts.Watch = true
 	return c.client.Get().
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("priorityclasses").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -111,6 +114,7 @@ func (c *priorityClasses) Watch(ctx context.Context, opts metav1.ListOptions) (w
 func (c *priorityClasses) Create(ctx context.Context, priorityClass *v1.PriorityClass, opts metav1.CreateOptions) (result *v1.PriorityClass, err error) {
 	result = &v1.PriorityClass{}
 	err = c.client.Post().
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("priorityclasses").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Body(priorityClass).
@@ -123,6 +127,7 @@ func (c *priorityClasses) Create(ctx context.Context, priorityClass *v1.Priority
 func (c *priorityClasses) Update(ctx context.Context, priorityClass *v1.PriorityClass, opts metav1.UpdateOptions) (result *v1.PriorityClass, err error) {
 	result = &v1.PriorityClass{}
 	err = c.client.Put().
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("priorityclasses").
 		Name(priorityClass.Name).
 		VersionedParams(&opts, scheme.ParameterCodec).
@@ -135,6 +140,7 @@ func (c *priorityClasses) Update(ctx context.Context, priorityClass *v1.Priority
 // Delete takes name of the priorityClass and deletes it. Returns an error if one occurs.
 func (c *priorityClasses) Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error {
 	return c.client.Delete().
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("priorityclasses").
 		Name(name).
 		Body(&opts).
@@ -149,6 +155,7 @@ func (c *priorityClasses) DeleteCollection(ctx context.Context, opts metav1.Dele
 		timeout = time.Duration(*listOpts.TimeoutSeconds) * time.Second
 	}
 	return c.client.Delete().
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("priorityclasses").
 		VersionedParams(&listOpts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -161,6 +168,7 @@ func (c *priorityClasses) DeleteCollection(ctx context.Context, opts metav1.Dele
 func (c *priorityClasses) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts metav1.PatchOptions, subresources ...string) (result *v1.PriorityClass, err error) {
 	result = &v1.PriorityClass{}
 	err = c.client.Patch(pt).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("priorityclasses").
 		Name(name).
 		SubResource(subresources...).
@@ -187,6 +195,7 @@ func (c *priorityClasses) Apply(ctx context.Context, priorityClass *schedulingv1
 	}
 	result = &v1.PriorityClass{}
 	err = c.client.Patch(types.ApplyPatchType).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("priorityclasses").
 		Name(*name).
 		VersionedParams(&patchOpts, scheme.ParameterCodec).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/scheduling/v1alpha1/priorityclass.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/scheduling/v1alpha1/priorityclass.go
@@ -69,6 +69,7 @@ func newPriorityClasses(c *SchedulingV1alpha1Client) *priorityClasses {
 func (c *priorityClasses) Get(ctx context.Context, name string, options v1.GetOptions) (result *v1alpha1.PriorityClass, err error) {
 	result = &v1alpha1.PriorityClass{}
 	err = c.client.Get().
+		GroupVersion(v1alpha1.SchemeGroupVersion).
 		Resource("priorityclasses").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
@@ -85,6 +86,7 @@ func (c *priorityClasses) List(ctx context.Context, opts v1.ListOptions) (result
 	}
 	result = &v1alpha1.PriorityClassList{}
 	err = c.client.Get().
+		GroupVersion(v1alpha1.SchemeGroupVersion).
 		Resource("priorityclasses").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -101,6 +103,7 @@ func (c *priorityClasses) Watch(ctx context.Context, opts v1.ListOptions) (watch
 	}
 	opts.Watch = true
 	return c.client.Get().
+		GroupVersion(v1alpha1.SchemeGroupVersion).
 		Resource("priorityclasses").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -111,6 +114,7 @@ func (c *priorityClasses) Watch(ctx context.Context, opts v1.ListOptions) (watch
 func (c *priorityClasses) Create(ctx context.Context, priorityClass *v1alpha1.PriorityClass, opts v1.CreateOptions) (result *v1alpha1.PriorityClass, err error) {
 	result = &v1alpha1.PriorityClass{}
 	err = c.client.Post().
+		GroupVersion(v1alpha1.SchemeGroupVersion).
 		Resource("priorityclasses").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Body(priorityClass).
@@ -123,6 +127,7 @@ func (c *priorityClasses) Create(ctx context.Context, priorityClass *v1alpha1.Pr
 func (c *priorityClasses) Update(ctx context.Context, priorityClass *v1alpha1.PriorityClass, opts v1.UpdateOptions) (result *v1alpha1.PriorityClass, err error) {
 	result = &v1alpha1.PriorityClass{}
 	err = c.client.Put().
+		GroupVersion(v1alpha1.SchemeGroupVersion).
 		Resource("priorityclasses").
 		Name(priorityClass.Name).
 		VersionedParams(&opts, scheme.ParameterCodec).
@@ -135,6 +140,7 @@ func (c *priorityClasses) Update(ctx context.Context, priorityClass *v1alpha1.Pr
 // Delete takes name of the priorityClass and deletes it. Returns an error if one occurs.
 func (c *priorityClasses) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
 	return c.client.Delete().
+		GroupVersion(v1alpha1.SchemeGroupVersion).
 		Resource("priorityclasses").
 		Name(name).
 		Body(&opts).
@@ -149,6 +155,7 @@ func (c *priorityClasses) DeleteCollection(ctx context.Context, opts v1.DeleteOp
 		timeout = time.Duration(*listOpts.TimeoutSeconds) * time.Second
 	}
 	return c.client.Delete().
+		GroupVersion(v1alpha1.SchemeGroupVersion).
 		Resource("priorityclasses").
 		VersionedParams(&listOpts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -161,6 +168,7 @@ func (c *priorityClasses) DeleteCollection(ctx context.Context, opts v1.DeleteOp
 func (c *priorityClasses) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts v1.PatchOptions, subresources ...string) (result *v1alpha1.PriorityClass, err error) {
 	result = &v1alpha1.PriorityClass{}
 	err = c.client.Patch(pt).
+		GroupVersion(v1alpha1.SchemeGroupVersion).
 		Resource("priorityclasses").
 		Name(name).
 		SubResource(subresources...).
@@ -187,6 +195,7 @@ func (c *priorityClasses) Apply(ctx context.Context, priorityClass *schedulingv1
 	}
 	result = &v1alpha1.PriorityClass{}
 	err = c.client.Patch(types.ApplyPatchType).
+		GroupVersion(v1alpha1.SchemeGroupVersion).
 		Resource("priorityclasses").
 		Name(*name).
 		VersionedParams(&patchOpts, scheme.ParameterCodec).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/scheduling/v1beta1/priorityclass.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/scheduling/v1beta1/priorityclass.go
@@ -69,6 +69,7 @@ func newPriorityClasses(c *SchedulingV1beta1Client) *priorityClasses {
 func (c *priorityClasses) Get(ctx context.Context, name string, options v1.GetOptions) (result *v1beta1.PriorityClass, err error) {
 	result = &v1beta1.PriorityClass{}
 	err = c.client.Get().
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("priorityclasses").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
@@ -85,6 +86,7 @@ func (c *priorityClasses) List(ctx context.Context, opts v1.ListOptions) (result
 	}
 	result = &v1beta1.PriorityClassList{}
 	err = c.client.Get().
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("priorityclasses").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -101,6 +103,7 @@ func (c *priorityClasses) Watch(ctx context.Context, opts v1.ListOptions) (watch
 	}
 	opts.Watch = true
 	return c.client.Get().
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("priorityclasses").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -111,6 +114,7 @@ func (c *priorityClasses) Watch(ctx context.Context, opts v1.ListOptions) (watch
 func (c *priorityClasses) Create(ctx context.Context, priorityClass *v1beta1.PriorityClass, opts v1.CreateOptions) (result *v1beta1.PriorityClass, err error) {
 	result = &v1beta1.PriorityClass{}
 	err = c.client.Post().
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("priorityclasses").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Body(priorityClass).
@@ -123,6 +127,7 @@ func (c *priorityClasses) Create(ctx context.Context, priorityClass *v1beta1.Pri
 func (c *priorityClasses) Update(ctx context.Context, priorityClass *v1beta1.PriorityClass, opts v1.UpdateOptions) (result *v1beta1.PriorityClass, err error) {
 	result = &v1beta1.PriorityClass{}
 	err = c.client.Put().
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("priorityclasses").
 		Name(priorityClass.Name).
 		VersionedParams(&opts, scheme.ParameterCodec).
@@ -135,6 +140,7 @@ func (c *priorityClasses) Update(ctx context.Context, priorityClass *v1beta1.Pri
 // Delete takes name of the priorityClass and deletes it. Returns an error if one occurs.
 func (c *priorityClasses) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
 	return c.client.Delete().
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("priorityclasses").
 		Name(name).
 		Body(&opts).
@@ -149,6 +155,7 @@ func (c *priorityClasses) DeleteCollection(ctx context.Context, opts v1.DeleteOp
 		timeout = time.Duration(*listOpts.TimeoutSeconds) * time.Second
 	}
 	return c.client.Delete().
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("priorityclasses").
 		VersionedParams(&listOpts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -161,6 +168,7 @@ func (c *priorityClasses) DeleteCollection(ctx context.Context, opts v1.DeleteOp
 func (c *priorityClasses) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts v1.PatchOptions, subresources ...string) (result *v1beta1.PriorityClass, err error) {
 	result = &v1beta1.PriorityClass{}
 	err = c.client.Patch(pt).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("priorityclasses").
 		Name(name).
 		SubResource(subresources...).
@@ -187,6 +195,7 @@ func (c *priorityClasses) Apply(ctx context.Context, priorityClass *schedulingv1
 	}
 	result = &v1beta1.PriorityClass{}
 	err = c.client.Patch(types.ApplyPatchType).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("priorityclasses").
 		Name(*name).
 		VersionedParams(&patchOpts, scheme.ParameterCodec).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1/csidriver.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1/csidriver.go
@@ -69,6 +69,7 @@ func newCSIDrivers(c *StorageV1Client) *cSIDrivers {
 func (c *cSIDrivers) Get(ctx context.Context, name string, options metav1.GetOptions) (result *v1.CSIDriver, err error) {
 	result = &v1.CSIDriver{}
 	err = c.client.Get().
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("csidrivers").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
@@ -85,6 +86,7 @@ func (c *cSIDrivers) List(ctx context.Context, opts metav1.ListOptions) (result 
 	}
 	result = &v1.CSIDriverList{}
 	err = c.client.Get().
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("csidrivers").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -101,6 +103,7 @@ func (c *cSIDrivers) Watch(ctx context.Context, opts metav1.ListOptions) (watch.
 	}
 	opts.Watch = true
 	return c.client.Get().
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("csidrivers").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -111,6 +114,7 @@ func (c *cSIDrivers) Watch(ctx context.Context, opts metav1.ListOptions) (watch.
 func (c *cSIDrivers) Create(ctx context.Context, cSIDriver *v1.CSIDriver, opts metav1.CreateOptions) (result *v1.CSIDriver, err error) {
 	result = &v1.CSIDriver{}
 	err = c.client.Post().
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("csidrivers").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Body(cSIDriver).
@@ -123,6 +127,7 @@ func (c *cSIDrivers) Create(ctx context.Context, cSIDriver *v1.CSIDriver, opts m
 func (c *cSIDrivers) Update(ctx context.Context, cSIDriver *v1.CSIDriver, opts metav1.UpdateOptions) (result *v1.CSIDriver, err error) {
 	result = &v1.CSIDriver{}
 	err = c.client.Put().
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("csidrivers").
 		Name(cSIDriver.Name).
 		VersionedParams(&opts, scheme.ParameterCodec).
@@ -135,6 +140,7 @@ func (c *cSIDrivers) Update(ctx context.Context, cSIDriver *v1.CSIDriver, opts m
 // Delete takes name of the cSIDriver and deletes it. Returns an error if one occurs.
 func (c *cSIDrivers) Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error {
 	return c.client.Delete().
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("csidrivers").
 		Name(name).
 		Body(&opts).
@@ -149,6 +155,7 @@ func (c *cSIDrivers) DeleteCollection(ctx context.Context, opts metav1.DeleteOpt
 		timeout = time.Duration(*listOpts.TimeoutSeconds) * time.Second
 	}
 	return c.client.Delete().
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("csidrivers").
 		VersionedParams(&listOpts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -161,6 +168,7 @@ func (c *cSIDrivers) DeleteCollection(ctx context.Context, opts metav1.DeleteOpt
 func (c *cSIDrivers) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts metav1.PatchOptions, subresources ...string) (result *v1.CSIDriver, err error) {
 	result = &v1.CSIDriver{}
 	err = c.client.Patch(pt).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("csidrivers").
 		Name(name).
 		SubResource(subresources...).
@@ -187,6 +195,7 @@ func (c *cSIDrivers) Apply(ctx context.Context, cSIDriver *storagev1.CSIDriverAp
 	}
 	result = &v1.CSIDriver{}
 	err = c.client.Patch(types.ApplyPatchType).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("csidrivers").
 		Name(*name).
 		VersionedParams(&patchOpts, scheme.ParameterCodec).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1/csinode.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1/csinode.go
@@ -69,6 +69,7 @@ func newCSINodes(c *StorageV1Client) *cSINodes {
 func (c *cSINodes) Get(ctx context.Context, name string, options metav1.GetOptions) (result *v1.CSINode, err error) {
 	result = &v1.CSINode{}
 	err = c.client.Get().
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("csinodes").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
@@ -85,6 +86,7 @@ func (c *cSINodes) List(ctx context.Context, opts metav1.ListOptions) (result *v
 	}
 	result = &v1.CSINodeList{}
 	err = c.client.Get().
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("csinodes").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -101,6 +103,7 @@ func (c *cSINodes) Watch(ctx context.Context, opts metav1.ListOptions) (watch.In
 	}
 	opts.Watch = true
 	return c.client.Get().
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("csinodes").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -111,6 +114,7 @@ func (c *cSINodes) Watch(ctx context.Context, opts metav1.ListOptions) (watch.In
 func (c *cSINodes) Create(ctx context.Context, cSINode *v1.CSINode, opts metav1.CreateOptions) (result *v1.CSINode, err error) {
 	result = &v1.CSINode{}
 	err = c.client.Post().
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("csinodes").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Body(cSINode).
@@ -123,6 +127,7 @@ func (c *cSINodes) Create(ctx context.Context, cSINode *v1.CSINode, opts metav1.
 func (c *cSINodes) Update(ctx context.Context, cSINode *v1.CSINode, opts metav1.UpdateOptions) (result *v1.CSINode, err error) {
 	result = &v1.CSINode{}
 	err = c.client.Put().
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("csinodes").
 		Name(cSINode.Name).
 		VersionedParams(&opts, scheme.ParameterCodec).
@@ -135,6 +140,7 @@ func (c *cSINodes) Update(ctx context.Context, cSINode *v1.CSINode, opts metav1.
 // Delete takes name of the cSINode and deletes it. Returns an error if one occurs.
 func (c *cSINodes) Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error {
 	return c.client.Delete().
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("csinodes").
 		Name(name).
 		Body(&opts).
@@ -149,6 +155,7 @@ func (c *cSINodes) DeleteCollection(ctx context.Context, opts metav1.DeleteOptio
 		timeout = time.Duration(*listOpts.TimeoutSeconds) * time.Second
 	}
 	return c.client.Delete().
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("csinodes").
 		VersionedParams(&listOpts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -161,6 +168,7 @@ func (c *cSINodes) DeleteCollection(ctx context.Context, opts metav1.DeleteOptio
 func (c *cSINodes) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts metav1.PatchOptions, subresources ...string) (result *v1.CSINode, err error) {
 	result = &v1.CSINode{}
 	err = c.client.Patch(pt).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("csinodes").
 		Name(name).
 		SubResource(subresources...).
@@ -187,6 +195,7 @@ func (c *cSINodes) Apply(ctx context.Context, cSINode *storagev1.CSINodeApplyCon
 	}
 	result = &v1.CSINode{}
 	err = c.client.Patch(types.ApplyPatchType).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("csinodes").
 		Name(*name).
 		VersionedParams(&patchOpts, scheme.ParameterCodec).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1/storageclass.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1/storageclass.go
@@ -69,6 +69,7 @@ func newStorageClasses(c *StorageV1Client) *storageClasses {
 func (c *storageClasses) Get(ctx context.Context, name string, options metav1.GetOptions) (result *v1.StorageClass, err error) {
 	result = &v1.StorageClass{}
 	err = c.client.Get().
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("storageclasses").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
@@ -85,6 +86,7 @@ func (c *storageClasses) List(ctx context.Context, opts metav1.ListOptions) (res
 	}
 	result = &v1.StorageClassList{}
 	err = c.client.Get().
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("storageclasses").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -101,6 +103,7 @@ func (c *storageClasses) Watch(ctx context.Context, opts metav1.ListOptions) (wa
 	}
 	opts.Watch = true
 	return c.client.Get().
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("storageclasses").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -111,6 +114,7 @@ func (c *storageClasses) Watch(ctx context.Context, opts metav1.ListOptions) (wa
 func (c *storageClasses) Create(ctx context.Context, storageClass *v1.StorageClass, opts metav1.CreateOptions) (result *v1.StorageClass, err error) {
 	result = &v1.StorageClass{}
 	err = c.client.Post().
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("storageclasses").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Body(storageClass).
@@ -123,6 +127,7 @@ func (c *storageClasses) Create(ctx context.Context, storageClass *v1.StorageCla
 func (c *storageClasses) Update(ctx context.Context, storageClass *v1.StorageClass, opts metav1.UpdateOptions) (result *v1.StorageClass, err error) {
 	result = &v1.StorageClass{}
 	err = c.client.Put().
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("storageclasses").
 		Name(storageClass.Name).
 		VersionedParams(&opts, scheme.ParameterCodec).
@@ -135,6 +140,7 @@ func (c *storageClasses) Update(ctx context.Context, storageClass *v1.StorageCla
 // Delete takes name of the storageClass and deletes it. Returns an error if one occurs.
 func (c *storageClasses) Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error {
 	return c.client.Delete().
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("storageclasses").
 		Name(name).
 		Body(&opts).
@@ -149,6 +155,7 @@ func (c *storageClasses) DeleteCollection(ctx context.Context, opts metav1.Delet
 		timeout = time.Duration(*listOpts.TimeoutSeconds) * time.Second
 	}
 	return c.client.Delete().
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("storageclasses").
 		VersionedParams(&listOpts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -161,6 +168,7 @@ func (c *storageClasses) DeleteCollection(ctx context.Context, opts metav1.Delet
 func (c *storageClasses) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts metav1.PatchOptions, subresources ...string) (result *v1.StorageClass, err error) {
 	result = &v1.StorageClass{}
 	err = c.client.Patch(pt).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("storageclasses").
 		Name(name).
 		SubResource(subresources...).
@@ -187,6 +195,7 @@ func (c *storageClasses) Apply(ctx context.Context, storageClass *storagev1.Stor
 	}
 	result = &v1.StorageClass{}
 	err = c.client.Patch(types.ApplyPatchType).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("storageclasses").
 		Name(*name).
 		VersionedParams(&patchOpts, scheme.ParameterCodec).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1/volumeattachment.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1/volumeattachment.go
@@ -71,6 +71,7 @@ func newVolumeAttachments(c *StorageV1Client) *volumeAttachments {
 func (c *volumeAttachments) Get(ctx context.Context, name string, options metav1.GetOptions) (result *v1.VolumeAttachment, err error) {
 	result = &v1.VolumeAttachment{}
 	err = c.client.Get().
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("volumeattachments").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
@@ -87,6 +88,7 @@ func (c *volumeAttachments) List(ctx context.Context, opts metav1.ListOptions) (
 	}
 	result = &v1.VolumeAttachmentList{}
 	err = c.client.Get().
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("volumeattachments").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -103,6 +105,7 @@ func (c *volumeAttachments) Watch(ctx context.Context, opts metav1.ListOptions) 
 	}
 	opts.Watch = true
 	return c.client.Get().
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("volumeattachments").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -113,6 +116,7 @@ func (c *volumeAttachments) Watch(ctx context.Context, opts metav1.ListOptions) 
 func (c *volumeAttachments) Create(ctx context.Context, volumeAttachment *v1.VolumeAttachment, opts metav1.CreateOptions) (result *v1.VolumeAttachment, err error) {
 	result = &v1.VolumeAttachment{}
 	err = c.client.Post().
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("volumeattachments").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Body(volumeAttachment).
@@ -125,6 +129,7 @@ func (c *volumeAttachments) Create(ctx context.Context, volumeAttachment *v1.Vol
 func (c *volumeAttachments) Update(ctx context.Context, volumeAttachment *v1.VolumeAttachment, opts metav1.UpdateOptions) (result *v1.VolumeAttachment, err error) {
 	result = &v1.VolumeAttachment{}
 	err = c.client.Put().
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("volumeattachments").
 		Name(volumeAttachment.Name).
 		VersionedParams(&opts, scheme.ParameterCodec).
@@ -139,6 +144,7 @@ func (c *volumeAttachments) Update(ctx context.Context, volumeAttachment *v1.Vol
 func (c *volumeAttachments) UpdateStatus(ctx context.Context, volumeAttachment *v1.VolumeAttachment, opts metav1.UpdateOptions) (result *v1.VolumeAttachment, err error) {
 	result = &v1.VolumeAttachment{}
 	err = c.client.Put().
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("volumeattachments").
 		Name(volumeAttachment.Name).
 		SubResource("status").
@@ -152,6 +158,7 @@ func (c *volumeAttachments) UpdateStatus(ctx context.Context, volumeAttachment *
 // Delete takes name of the volumeAttachment and deletes it. Returns an error if one occurs.
 func (c *volumeAttachments) Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error {
 	return c.client.Delete().
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("volumeattachments").
 		Name(name).
 		Body(&opts).
@@ -166,6 +173,7 @@ func (c *volumeAttachments) DeleteCollection(ctx context.Context, opts metav1.De
 		timeout = time.Duration(*listOpts.TimeoutSeconds) * time.Second
 	}
 	return c.client.Delete().
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("volumeattachments").
 		VersionedParams(&listOpts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -178,6 +186,7 @@ func (c *volumeAttachments) DeleteCollection(ctx context.Context, opts metav1.De
 func (c *volumeAttachments) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts metav1.PatchOptions, subresources ...string) (result *v1.VolumeAttachment, err error) {
 	result = &v1.VolumeAttachment{}
 	err = c.client.Patch(pt).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("volumeattachments").
 		Name(name).
 		SubResource(subresources...).
@@ -204,6 +213,7 @@ func (c *volumeAttachments) Apply(ctx context.Context, volumeAttachment *storage
 	}
 	result = &v1.VolumeAttachment{}
 	err = c.client.Patch(types.ApplyPatchType).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("volumeattachments").
 		Name(*name).
 		VersionedParams(&patchOpts, scheme.ParameterCodec).
@@ -232,6 +242,7 @@ func (c *volumeAttachments) ApplyStatus(ctx context.Context, volumeAttachment *s
 
 	result = &v1.VolumeAttachment{}
 	err = c.client.Patch(types.ApplyPatchType).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("volumeattachments").
 		Name(*name).
 		SubResource("status").

--- a/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1alpha1/csistoragecapacity.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1alpha1/csistoragecapacity.go
@@ -72,6 +72,7 @@ func (c *cSIStorageCapacities) Get(ctx context.Context, name string, options v1.
 	result = &v1alpha1.CSIStorageCapacity{}
 	err = c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(v1alpha1.SchemeGroupVersion).
 		Resource("csistoragecapacities").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
@@ -89,6 +90,7 @@ func (c *cSIStorageCapacities) List(ctx context.Context, opts v1.ListOptions) (r
 	result = &v1alpha1.CSIStorageCapacityList{}
 	err = c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(v1alpha1.SchemeGroupVersion).
 		Resource("csistoragecapacities").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -106,6 +108,7 @@ func (c *cSIStorageCapacities) Watch(ctx context.Context, opts v1.ListOptions) (
 	opts.Watch = true
 	return c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(v1alpha1.SchemeGroupVersion).
 		Resource("csistoragecapacities").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -117,6 +120,7 @@ func (c *cSIStorageCapacities) Create(ctx context.Context, cSIStorageCapacity *v
 	result = &v1alpha1.CSIStorageCapacity{}
 	err = c.client.Post().
 		Namespace(c.ns).
+		GroupVersion(v1alpha1.SchemeGroupVersion).
 		Resource("csistoragecapacities").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Body(cSIStorageCapacity).
@@ -130,6 +134,7 @@ func (c *cSIStorageCapacities) Update(ctx context.Context, cSIStorageCapacity *v
 	result = &v1alpha1.CSIStorageCapacity{}
 	err = c.client.Put().
 		Namespace(c.ns).
+		GroupVersion(v1alpha1.SchemeGroupVersion).
 		Resource("csistoragecapacities").
 		Name(cSIStorageCapacity.Name).
 		VersionedParams(&opts, scheme.ParameterCodec).
@@ -143,6 +148,7 @@ func (c *cSIStorageCapacities) Update(ctx context.Context, cSIStorageCapacity *v
 func (c *cSIStorageCapacities) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
 	return c.client.Delete().
 		Namespace(c.ns).
+		GroupVersion(v1alpha1.SchemeGroupVersion).
 		Resource("csistoragecapacities").
 		Name(name).
 		Body(&opts).
@@ -158,6 +164,7 @@ func (c *cSIStorageCapacities) DeleteCollection(ctx context.Context, opts v1.Del
 	}
 	return c.client.Delete().
 		Namespace(c.ns).
+		GroupVersion(v1alpha1.SchemeGroupVersion).
 		Resource("csistoragecapacities").
 		VersionedParams(&listOpts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -171,6 +178,7 @@ func (c *cSIStorageCapacities) Patch(ctx context.Context, name string, pt types.
 	result = &v1alpha1.CSIStorageCapacity{}
 	err = c.client.Patch(pt).
 		Namespace(c.ns).
+		GroupVersion(v1alpha1.SchemeGroupVersion).
 		Resource("csistoragecapacities").
 		Name(name).
 		SubResource(subresources...).
@@ -198,6 +206,7 @@ func (c *cSIStorageCapacities) Apply(ctx context.Context, cSIStorageCapacity *st
 	result = &v1alpha1.CSIStorageCapacity{}
 	err = c.client.Patch(types.ApplyPatchType).
 		Namespace(c.ns).
+		GroupVersion(v1alpha1.SchemeGroupVersion).
 		Resource("csistoragecapacities").
 		Name(*name).
 		VersionedParams(&patchOpts, scheme.ParameterCodec).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1alpha1/volumeattachment.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1alpha1/volumeattachment.go
@@ -71,6 +71,7 @@ func newVolumeAttachments(c *StorageV1alpha1Client) *volumeAttachments {
 func (c *volumeAttachments) Get(ctx context.Context, name string, options v1.GetOptions) (result *v1alpha1.VolumeAttachment, err error) {
 	result = &v1alpha1.VolumeAttachment{}
 	err = c.client.Get().
+		GroupVersion(v1alpha1.SchemeGroupVersion).
 		Resource("volumeattachments").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
@@ -87,6 +88,7 @@ func (c *volumeAttachments) List(ctx context.Context, opts v1.ListOptions) (resu
 	}
 	result = &v1alpha1.VolumeAttachmentList{}
 	err = c.client.Get().
+		GroupVersion(v1alpha1.SchemeGroupVersion).
 		Resource("volumeattachments").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -103,6 +105,7 @@ func (c *volumeAttachments) Watch(ctx context.Context, opts v1.ListOptions) (wat
 	}
 	opts.Watch = true
 	return c.client.Get().
+		GroupVersion(v1alpha1.SchemeGroupVersion).
 		Resource("volumeattachments").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -113,6 +116,7 @@ func (c *volumeAttachments) Watch(ctx context.Context, opts v1.ListOptions) (wat
 func (c *volumeAttachments) Create(ctx context.Context, volumeAttachment *v1alpha1.VolumeAttachment, opts v1.CreateOptions) (result *v1alpha1.VolumeAttachment, err error) {
 	result = &v1alpha1.VolumeAttachment{}
 	err = c.client.Post().
+		GroupVersion(v1alpha1.SchemeGroupVersion).
 		Resource("volumeattachments").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Body(volumeAttachment).
@@ -125,6 +129,7 @@ func (c *volumeAttachments) Create(ctx context.Context, volumeAttachment *v1alph
 func (c *volumeAttachments) Update(ctx context.Context, volumeAttachment *v1alpha1.VolumeAttachment, opts v1.UpdateOptions) (result *v1alpha1.VolumeAttachment, err error) {
 	result = &v1alpha1.VolumeAttachment{}
 	err = c.client.Put().
+		GroupVersion(v1alpha1.SchemeGroupVersion).
 		Resource("volumeattachments").
 		Name(volumeAttachment.Name).
 		VersionedParams(&opts, scheme.ParameterCodec).
@@ -139,6 +144,7 @@ func (c *volumeAttachments) Update(ctx context.Context, volumeAttachment *v1alph
 func (c *volumeAttachments) UpdateStatus(ctx context.Context, volumeAttachment *v1alpha1.VolumeAttachment, opts v1.UpdateOptions) (result *v1alpha1.VolumeAttachment, err error) {
 	result = &v1alpha1.VolumeAttachment{}
 	err = c.client.Put().
+		GroupVersion(v1alpha1.SchemeGroupVersion).
 		Resource("volumeattachments").
 		Name(volumeAttachment.Name).
 		SubResource("status").
@@ -152,6 +158,7 @@ func (c *volumeAttachments) UpdateStatus(ctx context.Context, volumeAttachment *
 // Delete takes name of the volumeAttachment and deletes it. Returns an error if one occurs.
 func (c *volumeAttachments) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
 	return c.client.Delete().
+		GroupVersion(v1alpha1.SchemeGroupVersion).
 		Resource("volumeattachments").
 		Name(name).
 		Body(&opts).
@@ -166,6 +173,7 @@ func (c *volumeAttachments) DeleteCollection(ctx context.Context, opts v1.Delete
 		timeout = time.Duration(*listOpts.TimeoutSeconds) * time.Second
 	}
 	return c.client.Delete().
+		GroupVersion(v1alpha1.SchemeGroupVersion).
 		Resource("volumeattachments").
 		VersionedParams(&listOpts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -178,6 +186,7 @@ func (c *volumeAttachments) DeleteCollection(ctx context.Context, opts v1.Delete
 func (c *volumeAttachments) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts v1.PatchOptions, subresources ...string) (result *v1alpha1.VolumeAttachment, err error) {
 	result = &v1alpha1.VolumeAttachment{}
 	err = c.client.Patch(pt).
+		GroupVersion(v1alpha1.SchemeGroupVersion).
 		Resource("volumeattachments").
 		Name(name).
 		SubResource(subresources...).
@@ -204,6 +213,7 @@ func (c *volumeAttachments) Apply(ctx context.Context, volumeAttachment *storage
 	}
 	result = &v1alpha1.VolumeAttachment{}
 	err = c.client.Patch(types.ApplyPatchType).
+		GroupVersion(v1alpha1.SchemeGroupVersion).
 		Resource("volumeattachments").
 		Name(*name).
 		VersionedParams(&patchOpts, scheme.ParameterCodec).
@@ -232,6 +242,7 @@ func (c *volumeAttachments) ApplyStatus(ctx context.Context, volumeAttachment *s
 
 	result = &v1alpha1.VolumeAttachment{}
 	err = c.client.Patch(types.ApplyPatchType).
+		GroupVersion(v1alpha1.SchemeGroupVersion).
 		Resource("volumeattachments").
 		Name(*name).
 		SubResource("status").

--- a/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1beta1/csidriver.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1beta1/csidriver.go
@@ -69,6 +69,7 @@ func newCSIDrivers(c *StorageV1beta1Client) *cSIDrivers {
 func (c *cSIDrivers) Get(ctx context.Context, name string, options v1.GetOptions) (result *v1beta1.CSIDriver, err error) {
 	result = &v1beta1.CSIDriver{}
 	err = c.client.Get().
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("csidrivers").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
@@ -85,6 +86,7 @@ func (c *cSIDrivers) List(ctx context.Context, opts v1.ListOptions) (result *v1b
 	}
 	result = &v1beta1.CSIDriverList{}
 	err = c.client.Get().
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("csidrivers").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -101,6 +103,7 @@ func (c *cSIDrivers) Watch(ctx context.Context, opts v1.ListOptions) (watch.Inte
 	}
 	opts.Watch = true
 	return c.client.Get().
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("csidrivers").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -111,6 +114,7 @@ func (c *cSIDrivers) Watch(ctx context.Context, opts v1.ListOptions) (watch.Inte
 func (c *cSIDrivers) Create(ctx context.Context, cSIDriver *v1beta1.CSIDriver, opts v1.CreateOptions) (result *v1beta1.CSIDriver, err error) {
 	result = &v1beta1.CSIDriver{}
 	err = c.client.Post().
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("csidrivers").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Body(cSIDriver).
@@ -123,6 +127,7 @@ func (c *cSIDrivers) Create(ctx context.Context, cSIDriver *v1beta1.CSIDriver, o
 func (c *cSIDrivers) Update(ctx context.Context, cSIDriver *v1beta1.CSIDriver, opts v1.UpdateOptions) (result *v1beta1.CSIDriver, err error) {
 	result = &v1beta1.CSIDriver{}
 	err = c.client.Put().
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("csidrivers").
 		Name(cSIDriver.Name).
 		VersionedParams(&opts, scheme.ParameterCodec).
@@ -135,6 +140,7 @@ func (c *cSIDrivers) Update(ctx context.Context, cSIDriver *v1beta1.CSIDriver, o
 // Delete takes name of the cSIDriver and deletes it. Returns an error if one occurs.
 func (c *cSIDrivers) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
 	return c.client.Delete().
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("csidrivers").
 		Name(name).
 		Body(&opts).
@@ -149,6 +155,7 @@ func (c *cSIDrivers) DeleteCollection(ctx context.Context, opts v1.DeleteOptions
 		timeout = time.Duration(*listOpts.TimeoutSeconds) * time.Second
 	}
 	return c.client.Delete().
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("csidrivers").
 		VersionedParams(&listOpts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -161,6 +168,7 @@ func (c *cSIDrivers) DeleteCollection(ctx context.Context, opts v1.DeleteOptions
 func (c *cSIDrivers) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts v1.PatchOptions, subresources ...string) (result *v1beta1.CSIDriver, err error) {
 	result = &v1beta1.CSIDriver{}
 	err = c.client.Patch(pt).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("csidrivers").
 		Name(name).
 		SubResource(subresources...).
@@ -187,6 +195,7 @@ func (c *cSIDrivers) Apply(ctx context.Context, cSIDriver *storagev1beta1.CSIDri
 	}
 	result = &v1beta1.CSIDriver{}
 	err = c.client.Patch(types.ApplyPatchType).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("csidrivers").
 		Name(*name).
 		VersionedParams(&patchOpts, scheme.ParameterCodec).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1beta1/csinode.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1beta1/csinode.go
@@ -69,6 +69,7 @@ func newCSINodes(c *StorageV1beta1Client) *cSINodes {
 func (c *cSINodes) Get(ctx context.Context, name string, options v1.GetOptions) (result *v1beta1.CSINode, err error) {
 	result = &v1beta1.CSINode{}
 	err = c.client.Get().
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("csinodes").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
@@ -85,6 +86,7 @@ func (c *cSINodes) List(ctx context.Context, opts v1.ListOptions) (result *v1bet
 	}
 	result = &v1beta1.CSINodeList{}
 	err = c.client.Get().
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("csinodes").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -101,6 +103,7 @@ func (c *cSINodes) Watch(ctx context.Context, opts v1.ListOptions) (watch.Interf
 	}
 	opts.Watch = true
 	return c.client.Get().
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("csinodes").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -111,6 +114,7 @@ func (c *cSINodes) Watch(ctx context.Context, opts v1.ListOptions) (watch.Interf
 func (c *cSINodes) Create(ctx context.Context, cSINode *v1beta1.CSINode, opts v1.CreateOptions) (result *v1beta1.CSINode, err error) {
 	result = &v1beta1.CSINode{}
 	err = c.client.Post().
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("csinodes").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Body(cSINode).
@@ -123,6 +127,7 @@ func (c *cSINodes) Create(ctx context.Context, cSINode *v1beta1.CSINode, opts v1
 func (c *cSINodes) Update(ctx context.Context, cSINode *v1beta1.CSINode, opts v1.UpdateOptions) (result *v1beta1.CSINode, err error) {
 	result = &v1beta1.CSINode{}
 	err = c.client.Put().
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("csinodes").
 		Name(cSINode.Name).
 		VersionedParams(&opts, scheme.ParameterCodec).
@@ -135,6 +140,7 @@ func (c *cSINodes) Update(ctx context.Context, cSINode *v1beta1.CSINode, opts v1
 // Delete takes name of the cSINode and deletes it. Returns an error if one occurs.
 func (c *cSINodes) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
 	return c.client.Delete().
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("csinodes").
 		Name(name).
 		Body(&opts).
@@ -149,6 +155,7 @@ func (c *cSINodes) DeleteCollection(ctx context.Context, opts v1.DeleteOptions, 
 		timeout = time.Duration(*listOpts.TimeoutSeconds) * time.Second
 	}
 	return c.client.Delete().
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("csinodes").
 		VersionedParams(&listOpts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -161,6 +168,7 @@ func (c *cSINodes) DeleteCollection(ctx context.Context, opts v1.DeleteOptions, 
 func (c *cSINodes) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts v1.PatchOptions, subresources ...string) (result *v1beta1.CSINode, err error) {
 	result = &v1beta1.CSINode{}
 	err = c.client.Patch(pt).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("csinodes").
 		Name(name).
 		SubResource(subresources...).
@@ -187,6 +195,7 @@ func (c *cSINodes) Apply(ctx context.Context, cSINode *storagev1beta1.CSINodeApp
 	}
 	result = &v1beta1.CSINode{}
 	err = c.client.Patch(types.ApplyPatchType).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("csinodes").
 		Name(*name).
 		VersionedParams(&patchOpts, scheme.ParameterCodec).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1beta1/csistoragecapacity.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1beta1/csistoragecapacity.go
@@ -72,6 +72,7 @@ func (c *cSIStorageCapacities) Get(ctx context.Context, name string, options v1.
 	result = &v1beta1.CSIStorageCapacity{}
 	err = c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("csistoragecapacities").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
@@ -89,6 +90,7 @@ func (c *cSIStorageCapacities) List(ctx context.Context, opts v1.ListOptions) (r
 	result = &v1beta1.CSIStorageCapacityList{}
 	err = c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("csistoragecapacities").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -106,6 +108,7 @@ func (c *cSIStorageCapacities) Watch(ctx context.Context, opts v1.ListOptions) (
 	opts.Watch = true
 	return c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("csistoragecapacities").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -117,6 +120,7 @@ func (c *cSIStorageCapacities) Create(ctx context.Context, cSIStorageCapacity *v
 	result = &v1beta1.CSIStorageCapacity{}
 	err = c.client.Post().
 		Namespace(c.ns).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("csistoragecapacities").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Body(cSIStorageCapacity).
@@ -130,6 +134,7 @@ func (c *cSIStorageCapacities) Update(ctx context.Context, cSIStorageCapacity *v
 	result = &v1beta1.CSIStorageCapacity{}
 	err = c.client.Put().
 		Namespace(c.ns).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("csistoragecapacities").
 		Name(cSIStorageCapacity.Name).
 		VersionedParams(&opts, scheme.ParameterCodec).
@@ -143,6 +148,7 @@ func (c *cSIStorageCapacities) Update(ctx context.Context, cSIStorageCapacity *v
 func (c *cSIStorageCapacities) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
 	return c.client.Delete().
 		Namespace(c.ns).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("csistoragecapacities").
 		Name(name).
 		Body(&opts).
@@ -158,6 +164,7 @@ func (c *cSIStorageCapacities) DeleteCollection(ctx context.Context, opts v1.Del
 	}
 	return c.client.Delete().
 		Namespace(c.ns).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("csistoragecapacities").
 		VersionedParams(&listOpts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -171,6 +178,7 @@ func (c *cSIStorageCapacities) Patch(ctx context.Context, name string, pt types.
 	result = &v1beta1.CSIStorageCapacity{}
 	err = c.client.Patch(pt).
 		Namespace(c.ns).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("csistoragecapacities").
 		Name(name).
 		SubResource(subresources...).
@@ -198,6 +206,7 @@ func (c *cSIStorageCapacities) Apply(ctx context.Context, cSIStorageCapacity *st
 	result = &v1beta1.CSIStorageCapacity{}
 	err = c.client.Patch(types.ApplyPatchType).
 		Namespace(c.ns).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("csistoragecapacities").
 		Name(*name).
 		VersionedParams(&patchOpts, scheme.ParameterCodec).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1beta1/storageclass.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1beta1/storageclass.go
@@ -69,6 +69,7 @@ func newStorageClasses(c *StorageV1beta1Client) *storageClasses {
 func (c *storageClasses) Get(ctx context.Context, name string, options v1.GetOptions) (result *v1beta1.StorageClass, err error) {
 	result = &v1beta1.StorageClass{}
 	err = c.client.Get().
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("storageclasses").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
@@ -85,6 +86,7 @@ func (c *storageClasses) List(ctx context.Context, opts v1.ListOptions) (result 
 	}
 	result = &v1beta1.StorageClassList{}
 	err = c.client.Get().
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("storageclasses").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -101,6 +103,7 @@ func (c *storageClasses) Watch(ctx context.Context, opts v1.ListOptions) (watch.
 	}
 	opts.Watch = true
 	return c.client.Get().
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("storageclasses").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -111,6 +114,7 @@ func (c *storageClasses) Watch(ctx context.Context, opts v1.ListOptions) (watch.
 func (c *storageClasses) Create(ctx context.Context, storageClass *v1beta1.StorageClass, opts v1.CreateOptions) (result *v1beta1.StorageClass, err error) {
 	result = &v1beta1.StorageClass{}
 	err = c.client.Post().
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("storageclasses").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Body(storageClass).
@@ -123,6 +127,7 @@ func (c *storageClasses) Create(ctx context.Context, storageClass *v1beta1.Stora
 func (c *storageClasses) Update(ctx context.Context, storageClass *v1beta1.StorageClass, opts v1.UpdateOptions) (result *v1beta1.StorageClass, err error) {
 	result = &v1beta1.StorageClass{}
 	err = c.client.Put().
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("storageclasses").
 		Name(storageClass.Name).
 		VersionedParams(&opts, scheme.ParameterCodec).
@@ -135,6 +140,7 @@ func (c *storageClasses) Update(ctx context.Context, storageClass *v1beta1.Stora
 // Delete takes name of the storageClass and deletes it. Returns an error if one occurs.
 func (c *storageClasses) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
 	return c.client.Delete().
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("storageclasses").
 		Name(name).
 		Body(&opts).
@@ -149,6 +155,7 @@ func (c *storageClasses) DeleteCollection(ctx context.Context, opts v1.DeleteOpt
 		timeout = time.Duration(*listOpts.TimeoutSeconds) * time.Second
 	}
 	return c.client.Delete().
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("storageclasses").
 		VersionedParams(&listOpts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -161,6 +168,7 @@ func (c *storageClasses) DeleteCollection(ctx context.Context, opts v1.DeleteOpt
 func (c *storageClasses) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts v1.PatchOptions, subresources ...string) (result *v1beta1.StorageClass, err error) {
 	result = &v1beta1.StorageClass{}
 	err = c.client.Patch(pt).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("storageclasses").
 		Name(name).
 		SubResource(subresources...).
@@ -187,6 +195,7 @@ func (c *storageClasses) Apply(ctx context.Context, storageClass *storagev1beta1
 	}
 	result = &v1beta1.StorageClass{}
 	err = c.client.Patch(types.ApplyPatchType).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("storageclasses").
 		Name(*name).
 		VersionedParams(&patchOpts, scheme.ParameterCodec).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1beta1/volumeattachment.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1beta1/volumeattachment.go
@@ -71,6 +71,7 @@ func newVolumeAttachments(c *StorageV1beta1Client) *volumeAttachments {
 func (c *volumeAttachments) Get(ctx context.Context, name string, options v1.GetOptions) (result *v1beta1.VolumeAttachment, err error) {
 	result = &v1beta1.VolumeAttachment{}
 	err = c.client.Get().
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("volumeattachments").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
@@ -87,6 +88,7 @@ func (c *volumeAttachments) List(ctx context.Context, opts v1.ListOptions) (resu
 	}
 	result = &v1beta1.VolumeAttachmentList{}
 	err = c.client.Get().
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("volumeattachments").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -103,6 +105,7 @@ func (c *volumeAttachments) Watch(ctx context.Context, opts v1.ListOptions) (wat
 	}
 	opts.Watch = true
 	return c.client.Get().
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("volumeattachments").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -113,6 +116,7 @@ func (c *volumeAttachments) Watch(ctx context.Context, opts v1.ListOptions) (wat
 func (c *volumeAttachments) Create(ctx context.Context, volumeAttachment *v1beta1.VolumeAttachment, opts v1.CreateOptions) (result *v1beta1.VolumeAttachment, err error) {
 	result = &v1beta1.VolumeAttachment{}
 	err = c.client.Post().
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("volumeattachments").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Body(volumeAttachment).
@@ -125,6 +129,7 @@ func (c *volumeAttachments) Create(ctx context.Context, volumeAttachment *v1beta
 func (c *volumeAttachments) Update(ctx context.Context, volumeAttachment *v1beta1.VolumeAttachment, opts v1.UpdateOptions) (result *v1beta1.VolumeAttachment, err error) {
 	result = &v1beta1.VolumeAttachment{}
 	err = c.client.Put().
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("volumeattachments").
 		Name(volumeAttachment.Name).
 		VersionedParams(&opts, scheme.ParameterCodec).
@@ -139,6 +144,7 @@ func (c *volumeAttachments) Update(ctx context.Context, volumeAttachment *v1beta
 func (c *volumeAttachments) UpdateStatus(ctx context.Context, volumeAttachment *v1beta1.VolumeAttachment, opts v1.UpdateOptions) (result *v1beta1.VolumeAttachment, err error) {
 	result = &v1beta1.VolumeAttachment{}
 	err = c.client.Put().
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("volumeattachments").
 		Name(volumeAttachment.Name).
 		SubResource("status").
@@ -152,6 +158,7 @@ func (c *volumeAttachments) UpdateStatus(ctx context.Context, volumeAttachment *
 // Delete takes name of the volumeAttachment and deletes it. Returns an error if one occurs.
 func (c *volumeAttachments) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
 	return c.client.Delete().
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("volumeattachments").
 		Name(name).
 		Body(&opts).
@@ -166,6 +173,7 @@ func (c *volumeAttachments) DeleteCollection(ctx context.Context, opts v1.Delete
 		timeout = time.Duration(*listOpts.TimeoutSeconds) * time.Second
 	}
 	return c.client.Delete().
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("volumeattachments").
 		VersionedParams(&listOpts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -178,6 +186,7 @@ func (c *volumeAttachments) DeleteCollection(ctx context.Context, opts v1.Delete
 func (c *volumeAttachments) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts v1.PatchOptions, subresources ...string) (result *v1beta1.VolumeAttachment, err error) {
 	result = &v1beta1.VolumeAttachment{}
 	err = c.client.Patch(pt).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("volumeattachments").
 		Name(name).
 		SubResource(subresources...).
@@ -204,6 +213,7 @@ func (c *volumeAttachments) Apply(ctx context.Context, volumeAttachment *storage
 	}
 	result = &v1beta1.VolumeAttachment{}
 	err = c.client.Patch(types.ApplyPatchType).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("volumeattachments").
 		Name(*name).
 		VersionedParams(&patchOpts, scheme.ParameterCodec).
@@ -232,6 +242,7 @@ func (c *volumeAttachments) ApplyStatus(ctx context.Context, volumeAttachment *s
 
 	result = &v1beta1.VolumeAttachment{}
 	err = c.client.Patch(types.ApplyPatchType).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("volumeattachments").
 		Name(*name).
 		SubResource("status").

--- a/staging/src/k8s.io/client-go/rest/config.go
+++ b/staging/src/k8s.io/client-go/rest/config.go
@@ -304,13 +304,9 @@ type ContentConfig struct {
 // A RESTClient created by this method is generic - it expects to operate on an API that follows
 // the Kubernetes conventions, but may not be the Kubernetes API.
 func RESTClientFor(config *Config) (*RESTClient, error) {
-	if config.GroupVersion == nil {
-		return nil, fmt.Errorf("GroupVersion is required when initializing a RESTClient")
-	}
 	if config.NegotiatedSerializer == nil {
 		return nil, fmt.Errorf("NegotiatedSerializer is required when initializing a RESTClient")
 	}
-
 	baseURL, versionedAPIPath, err := defaultServerUrlFor(config)
 	if err != nil {
 		return nil, err

--- a/staging/src/k8s.io/client-go/rest/config_test.go
+++ b/staging/src/k8s.io/client-go/rest/config_test.go
@@ -145,9 +145,6 @@ func TestDefaultKubernetesUserAgent(t *testing.T) {
 }
 
 func TestRESTClientRequires(t *testing.T) {
-	if _, err := RESTClientFor(&Config{Host: "127.0.0.1", ContentConfig: ContentConfig{NegotiatedSerializer: scheme.Codecs}}); err == nil {
-		t.Errorf("unexpected non-error")
-	}
 	if _, err := RESTClientFor(&Config{Host: "127.0.0.1", ContentConfig: ContentConfig{GroupVersion: &v1.SchemeGroupVersion}}); err == nil {
 		t.Errorf("unexpected non-error")
 	}

--- a/staging/src/k8s.io/client-go/rest/request_test.go
+++ b/staging/src/k8s.io/client-go/rest/request_test.go
@@ -284,7 +284,7 @@ func TestRequestParam(t *testing.T) {
 }
 
 func TestRequestVersionedParams(t *testing.T) {
-	r := (&Request{c: &RESTClient{content: ClientContentConfig{GroupVersion: v1.SchemeGroupVersion}}}).Param("foo", "a")
+	r := (&Request{c: &RESTClient{content: ClientContentConfig{GroupVersion: v1.SchemeGroupVersion}}, groupVersion: v1.SchemeGroupVersion}).Param("foo", "a")
 	if !reflect.DeepEqual(r.params, url.Values{"foo": []string{"a"}}) {
 		t.Errorf("should have set a param: %#v", r)
 	}
@@ -300,7 +300,7 @@ func TestRequestVersionedParams(t *testing.T) {
 }
 
 func TestRequestVersionedParamsFromListOptions(t *testing.T) {
-	r := &Request{c: &RESTClient{content: ClientContentConfig{GroupVersion: v1.SchemeGroupVersion}}}
+	r := &Request{c: &RESTClient{content: ClientContentConfig{GroupVersion: v1.SchemeGroupVersion}}, groupVersion: v1.SchemeGroupVersion}
 	r.VersionedParams(&metav1.ListOptions{ResourceVersion: "1"}, scheme.ParameterCodec)
 	if !reflect.DeepEqual(r.params, url.Values{
 		"resourceVersion": []string{"1"},

--- a/staging/src/k8s.io/code-generator/cmd/client-gen/generators/generator_for_clientset.go
+++ b/staging/src/k8s.io/code-generator/cmd/client-gen/generators/generator_for_clientset.go
@@ -152,7 +152,7 @@ func NewForConfig(c *$.Config|raw$) (*Clientset, error) {
 		configShallowCopy.UserAgent = $.DefaultKubernetesUserAgent|raw$()
 	}
 
-	restClient, err := rest.RESTClientFor(&configShallowCopy)
+	restClient, err := rest.UnversionedRESTClientFor(&configShallowCopy)
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/code-generator/cmd/client-gen/generators/generator_for_type.go
+++ b/staging/src/k8s.io/code-generator/cmd/client-gen/generators/generator_for_type.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/gengo/types"
 
 	"k8s.io/code-generator/cmd/client-gen/generators/util"
+	genpath "k8s.io/code-generator/cmd/client-gen/path"
 )
 
 // genClientForType produces a file for each top-level type.
@@ -169,6 +170,7 @@ func (g *genClientForType) GenerateType(c *generator.Context, t *types.Type, w i
 		"RESTClientInterface":  c.Universe.Type(types.Name{Package: "k8s.io/client-go/rest", Name: "Interface"}),
 		"schemeParameterCodec": c.Universe.Variable(types.Name{Package: filepath.Join(g.clientsetPackage, "scheme"), Name: "ParameterCodec"}),
 		"jsonMarshal":          c.Universe.Type(types.Name{Package: "encoding/json", Name: "Marshal"}),
+		"SchemeGroupVersion":   c.Universe.Variable(types.Name{Package: genpath.Vendorless(g.inputPackage), Name: "SchemeGroupVersion"}),
 	}
 
 	if generateApply {
@@ -463,6 +465,7 @@ func (c *$.type|privatePlural$) List(ctx context.Context, opts $.ListOptions|raw
 	result = &$.resultType|raw$List{}
 	err = c.client.Get().
 		$if .namespaced$Namespace(c.ns).$end$
+		GroupVersion($.SchemeGroupVersion|raw$).
 		Resource("$.type|resource$").
 		VersionedParams(&opts, $.schemeParameterCodec|raw$).
 		Timeout(timeout).
@@ -482,6 +485,7 @@ func (c *$.type|privatePlural$) List(ctx context.Context, $.type|private$Name st
 	result = &$.resultType|raw$List{}
 	err = c.client.Get().
 		$if .namespaced$Namespace(c.ns).$end$
+		GroupVersion($.SchemeGroupVersion|raw$).
 		Resource("$.type|resource$").
 		Name($.type|private$Name).
 		SubResource("$.subresourcePath$").
@@ -499,6 +503,7 @@ func (c *$.type|privatePlural$) Get(ctx context.Context, name string, options $.
 	result = &$.resultType|raw${}
 	err = c.client.Get().
 		$if .namespaced$Namespace(c.ns).$end$
+		GroupVersion($.SchemeGroupVersion|raw$).
 		Resource("$.type|resource$").
 		Name(name).
 		VersionedParams(&options, $.schemeParameterCodec|raw$).
@@ -514,6 +519,7 @@ func (c *$.type|privatePlural$) Get(ctx context.Context, $.type|private$Name str
 	result = &$.resultType|raw${}
 	err = c.client.Get().
 		$if .namespaced$Namespace(c.ns).$end$
+		GroupVersion($.SchemeGroupVersion|raw$).
 		Resource("$.type|resource$").
 		Name($.type|private$Name).
 		SubResource("$.subresourcePath$").
@@ -529,6 +535,7 @@ var deleteTemplate = `
 func (c *$.type|privatePlural$) Delete(ctx context.Context, name string, opts $.DeleteOptions|raw$) error {
 	return c.client.Delete().
 		$if .namespaced$Namespace(c.ns).$end$
+		GroupVersion($.SchemeGroupVersion|raw$).
 		Resource("$.type|resource$").
 		Name(name).
 		Body(&opts).
@@ -546,6 +553,7 @@ func (c *$.type|privatePlural$) DeleteCollection(ctx context.Context, opts $.Del
 	}
 	return c.client.Delete().
 		$if .namespaced$Namespace(c.ns).$end$
+		GroupVersion($.SchemeGroupVersion|raw$).
 		Resource("$.type|resource$").
 		VersionedParams(&listOpts, $.schemeParameterCodec|raw$).
 		Timeout(timeout).
@@ -561,6 +569,7 @@ func (c *$.type|privatePlural$) Create(ctx context.Context, $.type|private$Name 
 	result = &$.resultType|raw${}
 	err = c.client.Post().
 		$if .namespaced$Namespace(c.ns).$end$
+		GroupVersion($.SchemeGroupVersion|raw$).
 		Resource("$.type|resource$").
 		Name($.type|private$Name).
 		SubResource("$.subresourcePath$").
@@ -578,6 +587,7 @@ func (c *$.type|privatePlural$) Create(ctx context.Context, $.inputType|private$
 	result = &$.resultType|raw${}
 	err = c.client.Post().
 		$if .namespaced$Namespace(c.ns).$end$
+		GroupVersion($.SchemeGroupVersion|raw$).
 		Resource("$.type|resource$").
 		VersionedParams(&opts, $.schemeParameterCodec|raw$).
 		Body($.inputType|private$).
@@ -593,6 +603,7 @@ func (c *$.type|privatePlural$) Update(ctx context.Context, $.type|private$Name 
 	result = &$.resultType|raw${}
 	err = c.client.Put().
 		$if .namespaced$Namespace(c.ns).$end$
+		GroupVersion($.SchemeGroupVersion|raw$).
 		Resource("$.type|resource$").
 		Name($.type|private$Name).
 		SubResource("$.subresourcePath$").
@@ -610,6 +621,7 @@ func (c *$.type|privatePlural$) Update(ctx context.Context, $.inputType|private$
 	result = &$.resultType|raw${}
 	err = c.client.Put().
 		$if .namespaced$Namespace(c.ns).$end$
+		GroupVersion($.SchemeGroupVersion|raw$).
 		Resource("$.type|resource$").
 		Name($.inputType|private$.Name).
 		VersionedParams(&opts, $.schemeParameterCodec|raw$).
@@ -627,6 +639,7 @@ func (c *$.type|privatePlural$) UpdateStatus(ctx context.Context, $.type|private
 	result = &$.type|raw${}
 	err = c.client.Put().
 		$if .namespaced$Namespace(c.ns).$end$
+		GroupVersion($.SchemeGroupVersion|raw$).
 		Resource("$.type|resource$").
 		Name($.type|private$.Name).
 		SubResource("status").
@@ -648,6 +661,7 @@ func (c *$.type|privatePlural$) Watch(ctx context.Context, opts $.ListOptions|ra
 	opts.Watch = true
 	return c.client.Get().
 		$if .namespaced$Namespace(c.ns).$end$
+		GroupVersion($.SchemeGroupVersion|raw$).
 		Resource("$.type|resource$").
 		VersionedParams(&opts, $.schemeParameterCodec|raw$).
 		Timeout(timeout).
@@ -661,6 +675,7 @@ func (c *$.type|privatePlural$) Patch(ctx context.Context, name string, pt $.Pat
 	result = &$.resultType|raw${}
 	err = c.client.Patch(pt).
 		$if .namespaced$Namespace(c.ns).$end$
+		GroupVersion($.SchemeGroupVersion|raw$).
 		Resource("$.type|resource$").
 		Name(name).
 		SubResource(subresources...).
@@ -690,6 +705,7 @@ func (c *$.type|privatePlural$) Apply(ctx context.Context, $.inputType|private$ 
 	result = &$.resultType|raw${}
 	err = c.client.Patch($.ApplyPatchType|raw$).
 		$if .namespaced$Namespace(c.ns).$end$
+		GroupVersion($.SchemeGroupVersion|raw$).
 		Resource("$.type|resource$").
 		Name(*name).
 		VersionedParams(&patchOpts, $.schemeParameterCodec|raw$).
@@ -721,6 +737,7 @@ func (c *$.type|privatePlural$) ApplyStatus(ctx context.Context, $.inputType|pri
 	result = &$.resultType|raw${}
 	err = c.client.Patch($.ApplyPatchType|raw$).
 		$if .namespaced$Namespace(c.ns).$end$
+		GroupVersion($.SchemeGroupVersion|raw$).
 		Resource("$.type|resource$").
 		Name(*name).
 		SubResource("status").
@@ -748,6 +765,7 @@ func (c *$.type|privatePlural$) Apply(ctx context.Context, $.type|private$Name s
 	result = &$.resultType|raw${}
 	err = c.client.Patch($.ApplyPatchType|raw$).
 		$if .namespaced$Namespace(c.ns).$end$
+		GroupVersion($.SchemeGroupVersion|raw$).
 		Resource("$.type|resource$").
 		Name($.type|private$Name).
 		SubResource("$.subresourcePath$").

--- a/staging/src/k8s.io/code-generator/examples/HyphenGroup/clientset/versioned/clientset.go
+++ b/staging/src/k8s.io/code-generator/examples/HyphenGroup/clientset/versioned/clientset.go
@@ -24,6 +24,7 @@ import (
 	discovery "k8s.io/client-go/discovery"
 	rest "k8s.io/client-go/rest"
 	flowcontrol "k8s.io/client-go/util/flowcontrol"
+	"k8s.io/code-generator/examples/HyphenGroup/clientset/versioned/scheme"
 	examplegroupv1 "k8s.io/code-generator/examples/HyphenGroup/clientset/versioned/typed/example/v1"
 )
 
@@ -63,12 +64,20 @@ func NewForConfig(c *rest.Config) (*Clientset, error) {
 		}
 		configShallowCopy.RateLimiter = flowcontrol.NewTokenBucketRateLimiter(configShallowCopy.QPS, configShallowCopy.Burst)
 	}
-	var cs Clientset
-	var err error
-	cs.exampleGroupV1, err = examplegroupv1.NewForConfig(&configShallowCopy)
+
+	configShallowCopy.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
+
+	if configShallowCopy.UserAgent == "" {
+		configShallowCopy.UserAgent = rest.DefaultKubernetesUserAgent()
+	}
+
+	restClient, err := rest.RESTClientFor(&configShallowCopy)
 	if err != nil {
 		return nil, err
 	}
+
+	var cs Clientset
+	cs.exampleGroupV1 = examplegroupv1.New(restClient)
 
 	cs.DiscoveryClient, err = discovery.NewDiscoveryClientForConfig(&configShallowCopy)
 	if err != nil {
@@ -80,11 +89,11 @@ func NewForConfig(c *rest.Config) (*Clientset, error) {
 // NewForConfigOrDie creates a new Clientset for the given config and
 // panics if there is an error in the config.
 func NewForConfigOrDie(c *rest.Config) *Clientset {
-	var cs Clientset
-	cs.exampleGroupV1 = examplegroupv1.NewForConfigOrDie(c)
-
-	cs.DiscoveryClient = discovery.NewDiscoveryClientForConfigOrDie(c)
-	return &cs
+	cs, err := NewForConfig(c)
+	if err != nil {
+		panic(err)
+	}
+	return cs
 }
 
 // New creates a new Clientset for the given RESTClient.

--- a/staging/src/k8s.io/code-generator/examples/HyphenGroup/clientset/versioned/typed/example/v1/clustertesttype.go
+++ b/staging/src/k8s.io/code-generator/examples/HyphenGroup/clientset/versioned/typed/example/v1/clustertesttype.go
@@ -70,6 +70,7 @@ func newClusterTestTypes(c *ExampleGroupV1Client) *clusterTestTypes {
 func (c *clusterTestTypes) Get(ctx context.Context, name string, options metav1.GetOptions) (result *v1.ClusterTestType, err error) {
 	result = &v1.ClusterTestType{}
 	err = c.client.Get().
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("clustertesttypes").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
@@ -86,6 +87,7 @@ func (c *clusterTestTypes) List(ctx context.Context, opts metav1.ListOptions) (r
 	}
 	result = &v1.ClusterTestTypeList{}
 	err = c.client.Get().
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("clustertesttypes").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -102,6 +104,7 @@ func (c *clusterTestTypes) Watch(ctx context.Context, opts metav1.ListOptions) (
 	}
 	opts.Watch = true
 	return c.client.Get().
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("clustertesttypes").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -112,6 +115,7 @@ func (c *clusterTestTypes) Watch(ctx context.Context, opts metav1.ListOptions) (
 func (c *clusterTestTypes) Create(ctx context.Context, clusterTestType *v1.ClusterTestType, opts metav1.CreateOptions) (result *v1.ClusterTestType, err error) {
 	result = &v1.ClusterTestType{}
 	err = c.client.Post().
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("clustertesttypes").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Body(clusterTestType).
@@ -124,6 +128,7 @@ func (c *clusterTestTypes) Create(ctx context.Context, clusterTestType *v1.Clust
 func (c *clusterTestTypes) Update(ctx context.Context, clusterTestType *v1.ClusterTestType, opts metav1.UpdateOptions) (result *v1.ClusterTestType, err error) {
 	result = &v1.ClusterTestType{}
 	err = c.client.Put().
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("clustertesttypes").
 		Name(clusterTestType.Name).
 		VersionedParams(&opts, scheme.ParameterCodec).
@@ -138,6 +143,7 @@ func (c *clusterTestTypes) Update(ctx context.Context, clusterTestType *v1.Clust
 func (c *clusterTestTypes) UpdateStatus(ctx context.Context, clusterTestType *v1.ClusterTestType, opts metav1.UpdateOptions) (result *v1.ClusterTestType, err error) {
 	result = &v1.ClusterTestType{}
 	err = c.client.Put().
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("clustertesttypes").
 		Name(clusterTestType.Name).
 		SubResource("status").
@@ -151,6 +157,7 @@ func (c *clusterTestTypes) UpdateStatus(ctx context.Context, clusterTestType *v1
 // Delete takes name of the clusterTestType and deletes it. Returns an error if one occurs.
 func (c *clusterTestTypes) Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error {
 	return c.client.Delete().
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("clustertesttypes").
 		Name(name).
 		Body(&opts).
@@ -165,6 +172,7 @@ func (c *clusterTestTypes) DeleteCollection(ctx context.Context, opts metav1.Del
 		timeout = time.Duration(*listOpts.TimeoutSeconds) * time.Second
 	}
 	return c.client.Delete().
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("clustertesttypes").
 		VersionedParams(&listOpts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -177,6 +185,7 @@ func (c *clusterTestTypes) DeleteCollection(ctx context.Context, opts metav1.Del
 func (c *clusterTestTypes) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts metav1.PatchOptions, subresources ...string) (result *v1.ClusterTestType, err error) {
 	result = &v1.ClusterTestType{}
 	err = c.client.Patch(pt).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("clustertesttypes").
 		Name(name).
 		SubResource(subresources...).
@@ -191,6 +200,7 @@ func (c *clusterTestTypes) Patch(ctx context.Context, name string, pt types.Patc
 func (c *clusterTestTypes) GetScale(ctx context.Context, clusterTestTypeName string, options metav1.GetOptions) (result *autoscalingv1.Scale, err error) {
 	result = &autoscalingv1.Scale{}
 	err = c.client.Get().
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("clustertesttypes").
 		Name(clusterTestTypeName).
 		SubResource("scale").
@@ -204,6 +214,7 @@ func (c *clusterTestTypes) GetScale(ctx context.Context, clusterTestTypeName str
 func (c *clusterTestTypes) UpdateScale(ctx context.Context, clusterTestTypeName string, scale *autoscalingv1.Scale, opts metav1.UpdateOptions) (result *autoscalingv1.Scale, err error) {
 	result = &autoscalingv1.Scale{}
 	err = c.client.Put().
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("clustertesttypes").
 		Name(clusterTestTypeName).
 		SubResource("scale").

--- a/staging/src/k8s.io/code-generator/examples/HyphenGroup/clientset/versioned/typed/example/v1/testtype.go
+++ b/staging/src/k8s.io/code-generator/examples/HyphenGroup/clientset/versioned/typed/example/v1/testtype.go
@@ -69,6 +69,7 @@ func (c *testTypes) Get(ctx context.Context, name string, options metav1.GetOpti
 	result = &v1.TestType{}
 	err = c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("testtypes").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
@@ -86,6 +87,7 @@ func (c *testTypes) List(ctx context.Context, opts metav1.ListOptions) (result *
 	result = &v1.TestTypeList{}
 	err = c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("testtypes").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -103,6 +105,7 @@ func (c *testTypes) Watch(ctx context.Context, opts metav1.ListOptions) (watch.I
 	opts.Watch = true
 	return c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("testtypes").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -114,6 +117,7 @@ func (c *testTypes) Create(ctx context.Context, testType *v1.TestType, opts meta
 	result = &v1.TestType{}
 	err = c.client.Post().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("testtypes").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Body(testType).
@@ -127,6 +131,7 @@ func (c *testTypes) Update(ctx context.Context, testType *v1.TestType, opts meta
 	result = &v1.TestType{}
 	err = c.client.Put().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("testtypes").
 		Name(testType.Name).
 		VersionedParams(&opts, scheme.ParameterCodec).
@@ -142,6 +147,7 @@ func (c *testTypes) UpdateStatus(ctx context.Context, testType *v1.TestType, opt
 	result = &v1.TestType{}
 	err = c.client.Put().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("testtypes").
 		Name(testType.Name).
 		SubResource("status").
@@ -156,6 +162,7 @@ func (c *testTypes) UpdateStatus(ctx context.Context, testType *v1.TestType, opt
 func (c *testTypes) Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error {
 	return c.client.Delete().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("testtypes").
 		Name(name).
 		Body(&opts).
@@ -171,6 +178,7 @@ func (c *testTypes) DeleteCollection(ctx context.Context, opts metav1.DeleteOpti
 	}
 	return c.client.Delete().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("testtypes").
 		VersionedParams(&listOpts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -184,6 +192,7 @@ func (c *testTypes) Patch(ctx context.Context, name string, pt types.PatchType, 
 	result = &v1.TestType{}
 	err = c.client.Patch(pt).
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("testtypes").
 		Name(name).
 		SubResource(subresources...).

--- a/staging/src/k8s.io/code-generator/examples/MixedCase/clientset/versioned/typed/example/v1/clustertesttype.go
+++ b/staging/src/k8s.io/code-generator/examples/MixedCase/clientset/versioned/typed/example/v1/clustertesttype.go
@@ -71,6 +71,7 @@ func newClusterTestTypes(c *ExampleV1Client) *clusterTestTypes {
 func (c *clusterTestTypes) Get(ctx context.Context, name string, options metav1.GetOptions) (result *v1.ClusterTestType, err error) {
 	result = &v1.ClusterTestType{}
 	err = c.client.Get().
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("clustertesttypes").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
@@ -87,6 +88,7 @@ func (c *clusterTestTypes) List(ctx context.Context, opts metav1.ListOptions) (r
 	}
 	result = &v1.ClusterTestTypeList{}
 	err = c.client.Get().
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("clustertesttypes").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -103,6 +105,7 @@ func (c *clusterTestTypes) Watch(ctx context.Context, opts metav1.ListOptions) (
 	}
 	opts.Watch = true
 	return c.client.Get().
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("clustertesttypes").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -113,6 +116,7 @@ func (c *clusterTestTypes) Watch(ctx context.Context, opts metav1.ListOptions) (
 func (c *clusterTestTypes) Create(ctx context.Context, clusterTestType *v1.ClusterTestType, opts metav1.CreateOptions) (result *v1.ClusterTestType, err error) {
 	result = &v1.ClusterTestType{}
 	err = c.client.Post().
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("clustertesttypes").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Body(clusterTestType).
@@ -125,6 +129,7 @@ func (c *clusterTestTypes) Create(ctx context.Context, clusterTestType *v1.Clust
 func (c *clusterTestTypes) Update(ctx context.Context, clusterTestType *v1.ClusterTestType, opts metav1.UpdateOptions) (result *v1.ClusterTestType, err error) {
 	result = &v1.ClusterTestType{}
 	err = c.client.Put().
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("clustertesttypes").
 		Name(clusterTestType.Name).
 		VersionedParams(&opts, scheme.ParameterCodec).
@@ -139,6 +144,7 @@ func (c *clusterTestTypes) Update(ctx context.Context, clusterTestType *v1.Clust
 func (c *clusterTestTypes) UpdateStatus(ctx context.Context, clusterTestType *v1.ClusterTestType, opts metav1.UpdateOptions) (result *v1.ClusterTestType, err error) {
 	result = &v1.ClusterTestType{}
 	err = c.client.Put().
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("clustertesttypes").
 		Name(clusterTestType.Name).
 		SubResource("status").
@@ -152,6 +158,7 @@ func (c *clusterTestTypes) UpdateStatus(ctx context.Context, clusterTestType *v1
 // Delete takes name of the clusterTestType and deletes it. Returns an error if one occurs.
 func (c *clusterTestTypes) Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error {
 	return c.client.Delete().
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("clustertesttypes").
 		Name(name).
 		Body(&opts).
@@ -166,6 +173,7 @@ func (c *clusterTestTypes) DeleteCollection(ctx context.Context, opts metav1.Del
 		timeout = time.Duration(*listOpts.TimeoutSeconds) * time.Second
 	}
 	return c.client.Delete().
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("clustertesttypes").
 		VersionedParams(&listOpts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -178,6 +186,7 @@ func (c *clusterTestTypes) DeleteCollection(ctx context.Context, opts metav1.Del
 func (c *clusterTestTypes) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts metav1.PatchOptions, subresources ...string) (result *v1.ClusterTestType, err error) {
 	result = &v1.ClusterTestType{}
 	err = c.client.Patch(pt).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("clustertesttypes").
 		Name(name).
 		SubResource(subresources...).
@@ -192,6 +201,7 @@ func (c *clusterTestTypes) Patch(ctx context.Context, name string, pt types.Patc
 func (c *clusterTestTypes) GetScale(ctx context.Context, clusterTestTypeName string, options metav1.GetOptions) (result *autoscalingv1.Scale, err error) {
 	result = &autoscalingv1.Scale{}
 	err = c.client.Get().
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("clustertesttypes").
 		Name(clusterTestTypeName).
 		SubResource("scale").
@@ -205,6 +215,7 @@ func (c *clusterTestTypes) GetScale(ctx context.Context, clusterTestTypeName str
 func (c *clusterTestTypes) UpdateScale(ctx context.Context, clusterTestTypeName string, scale *autoscalingv1.Scale, opts metav1.UpdateOptions) (result *autoscalingv1.Scale, err error) {
 	result = &autoscalingv1.Scale{}
 	err = c.client.Put().
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("clustertesttypes").
 		Name(clusterTestTypeName).
 		SubResource("scale").
@@ -219,6 +230,7 @@ func (c *clusterTestTypes) UpdateScale(ctx context.Context, clusterTestTypeName 
 func (c *clusterTestTypes) CreateScale(ctx context.Context, clusterTestTypeName string, scale *autoscalingv1.Scale, opts metav1.CreateOptions) (result *autoscalingv1.Scale, err error) {
 	result = &autoscalingv1.Scale{}
 	err = c.client.Post().
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("clustertesttypes").
 		Name(clusterTestTypeName).
 		SubResource("scale").

--- a/staging/src/k8s.io/code-generator/examples/MixedCase/clientset/versioned/typed/example/v1/testtype.go
+++ b/staging/src/k8s.io/code-generator/examples/MixedCase/clientset/versioned/typed/example/v1/testtype.go
@@ -69,6 +69,7 @@ func (c *testTypes) Get(ctx context.Context, name string, options metav1.GetOpti
 	result = &v1.TestType{}
 	err = c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("testtypes").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
@@ -86,6 +87,7 @@ func (c *testTypes) List(ctx context.Context, opts metav1.ListOptions) (result *
 	result = &v1.TestTypeList{}
 	err = c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("testtypes").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -103,6 +105,7 @@ func (c *testTypes) Watch(ctx context.Context, opts metav1.ListOptions) (watch.I
 	opts.Watch = true
 	return c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("testtypes").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -114,6 +117,7 @@ func (c *testTypes) Create(ctx context.Context, testType *v1.TestType, opts meta
 	result = &v1.TestType{}
 	err = c.client.Post().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("testtypes").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Body(testType).
@@ -127,6 +131,7 @@ func (c *testTypes) Update(ctx context.Context, testType *v1.TestType, opts meta
 	result = &v1.TestType{}
 	err = c.client.Put().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("testtypes").
 		Name(testType.Name).
 		VersionedParams(&opts, scheme.ParameterCodec).
@@ -142,6 +147,7 @@ func (c *testTypes) UpdateStatus(ctx context.Context, testType *v1.TestType, opt
 	result = &v1.TestType{}
 	err = c.client.Put().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("testtypes").
 		Name(testType.Name).
 		SubResource("status").
@@ -156,6 +162,7 @@ func (c *testTypes) UpdateStatus(ctx context.Context, testType *v1.TestType, opt
 func (c *testTypes) Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error {
 	return c.client.Delete().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("testtypes").
 		Name(name).
 		Body(&opts).
@@ -171,6 +178,7 @@ func (c *testTypes) DeleteCollection(ctx context.Context, opts metav1.DeleteOpti
 	}
 	return c.client.Delete().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("testtypes").
 		VersionedParams(&listOpts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -184,6 +192,7 @@ func (c *testTypes) Patch(ctx context.Context, name string, pt types.PatchType, 
 	result = &v1.TestType{}
 	err = c.client.Patch(pt).
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("testtypes").
 		Name(name).
 		SubResource(subresources...).

--- a/staging/src/k8s.io/code-generator/examples/apiserver/clientset/internalversion/clientset.go
+++ b/staging/src/k8s.io/code-generator/examples/apiserver/clientset/internalversion/clientset.go
@@ -24,6 +24,7 @@ import (
 	discovery "k8s.io/client-go/discovery"
 	rest "k8s.io/client-go/rest"
 	flowcontrol "k8s.io/client-go/util/flowcontrol"
+	"k8s.io/code-generator/examples/apiserver/clientset/internalversion/scheme"
 	exampleinternalversion "k8s.io/code-generator/examples/apiserver/clientset/internalversion/typed/example/internalversion"
 	secondexampleinternalversion "k8s.io/code-generator/examples/apiserver/clientset/internalversion/typed/example2/internalversion"
 	thirdexampleinternalversion "k8s.io/code-generator/examples/apiserver/clientset/internalversion/typed/example3.io/internalversion"
@@ -79,20 +80,22 @@ func NewForConfig(c *rest.Config) (*Clientset, error) {
 		}
 		configShallowCopy.RateLimiter = flowcontrol.NewTokenBucketRateLimiter(configShallowCopy.QPS, configShallowCopy.Burst)
 	}
+
+	configShallowCopy.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
+
+	if configShallowCopy.UserAgent == "" {
+		configShallowCopy.UserAgent = rest.DefaultKubernetesUserAgent()
+	}
+
+	restClient, err := rest.RESTClientFor(&configShallowCopy)
+	if err != nil {
+		return nil, err
+	}
+
 	var cs Clientset
-	var err error
-	cs.example, err = exampleinternalversion.NewForConfig(&configShallowCopy)
-	if err != nil {
-		return nil, err
-	}
-	cs.secondExample, err = secondexampleinternalversion.NewForConfig(&configShallowCopy)
-	if err != nil {
-		return nil, err
-	}
-	cs.thirdExample, err = thirdexampleinternalversion.NewForConfig(&configShallowCopy)
-	if err != nil {
-		return nil, err
-	}
+	cs.example = exampleinternalversion.New(restClient)
+	cs.secondExample = secondexampleinternalversion.New(restClient)
+	cs.thirdExample = thirdexampleinternalversion.New(restClient)
 
 	cs.DiscoveryClient, err = discovery.NewDiscoveryClientForConfig(&configShallowCopy)
 	if err != nil {
@@ -104,13 +107,11 @@ func NewForConfig(c *rest.Config) (*Clientset, error) {
 // NewForConfigOrDie creates a new Clientset for the given config and
 // panics if there is an error in the config.
 func NewForConfigOrDie(c *rest.Config) *Clientset {
-	var cs Clientset
-	cs.example = exampleinternalversion.NewForConfigOrDie(c)
-	cs.secondExample = secondexampleinternalversion.NewForConfigOrDie(c)
-	cs.thirdExample = thirdexampleinternalversion.NewForConfigOrDie(c)
-
-	cs.DiscoveryClient = discovery.NewDiscoveryClientForConfigOrDie(c)
-	return &cs
+	cs, err := NewForConfig(c)
+	if err != nil {
+		panic(err)
+	}
+	return cs
 }
 
 // New creates a new Clientset for the given RESTClient.

--- a/staging/src/k8s.io/code-generator/examples/apiserver/clientset/internalversion/typed/example/internalversion/testtype.go
+++ b/staging/src/k8s.io/code-generator/examples/apiserver/clientset/internalversion/typed/example/internalversion/testtype.go
@@ -69,6 +69,7 @@ func (c *testTypes) Get(ctx context.Context, name string, options v1.GetOptions)
 	result = &example.TestType{}
 	err = c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(example.SchemeGroupVersion).
 		Resource("testtypes").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
@@ -86,6 +87,7 @@ func (c *testTypes) List(ctx context.Context, opts v1.ListOptions) (result *exam
 	result = &example.TestTypeList{}
 	err = c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(example.SchemeGroupVersion).
 		Resource("testtypes").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -103,6 +105,7 @@ func (c *testTypes) Watch(ctx context.Context, opts v1.ListOptions) (watch.Inter
 	opts.Watch = true
 	return c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(example.SchemeGroupVersion).
 		Resource("testtypes").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -114,6 +117,7 @@ func (c *testTypes) Create(ctx context.Context, testType *example.TestType, opts
 	result = &example.TestType{}
 	err = c.client.Post().
 		Namespace(c.ns).
+		GroupVersion(example.SchemeGroupVersion).
 		Resource("testtypes").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Body(testType).
@@ -127,6 +131,7 @@ func (c *testTypes) Update(ctx context.Context, testType *example.TestType, opts
 	result = &example.TestType{}
 	err = c.client.Put().
 		Namespace(c.ns).
+		GroupVersion(example.SchemeGroupVersion).
 		Resource("testtypes").
 		Name(testType.Name).
 		VersionedParams(&opts, scheme.ParameterCodec).
@@ -142,6 +147,7 @@ func (c *testTypes) UpdateStatus(ctx context.Context, testType *example.TestType
 	result = &example.TestType{}
 	err = c.client.Put().
 		Namespace(c.ns).
+		GroupVersion(example.SchemeGroupVersion).
 		Resource("testtypes").
 		Name(testType.Name).
 		SubResource("status").
@@ -156,6 +162,7 @@ func (c *testTypes) UpdateStatus(ctx context.Context, testType *example.TestType
 func (c *testTypes) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
 	return c.client.Delete().
 		Namespace(c.ns).
+		GroupVersion(example.SchemeGroupVersion).
 		Resource("testtypes").
 		Name(name).
 		Body(&opts).
@@ -171,6 +178,7 @@ func (c *testTypes) DeleteCollection(ctx context.Context, opts v1.DeleteOptions,
 	}
 	return c.client.Delete().
 		Namespace(c.ns).
+		GroupVersion(example.SchemeGroupVersion).
 		Resource("testtypes").
 		VersionedParams(&listOpts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -184,6 +192,7 @@ func (c *testTypes) Patch(ctx context.Context, name string, pt types.PatchType, 
 	result = &example.TestType{}
 	err = c.client.Patch(pt).
 		Namespace(c.ns).
+		GroupVersion(example.SchemeGroupVersion).
 		Resource("testtypes").
 		Name(name).
 		SubResource(subresources...).

--- a/staging/src/k8s.io/code-generator/examples/apiserver/clientset/internalversion/typed/example2/internalversion/testtype.go
+++ b/staging/src/k8s.io/code-generator/examples/apiserver/clientset/internalversion/typed/example2/internalversion/testtype.go
@@ -66,6 +66,7 @@ func newTestTypes(c *SecondExampleClient) *testTypes {
 func (c *testTypes) Get(ctx context.Context, name string, options v1.GetOptions) (result *example2.TestType, err error) {
 	result = &example2.TestType{}
 	err = c.client.Get().
+		GroupVersion(example2.SchemeGroupVersion).
 		Resource("testtypes").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
@@ -82,6 +83,7 @@ func (c *testTypes) List(ctx context.Context, opts v1.ListOptions) (result *exam
 	}
 	result = &example2.TestTypeList{}
 	err = c.client.Get().
+		GroupVersion(example2.SchemeGroupVersion).
 		Resource("testtypes").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -98,6 +100,7 @@ func (c *testTypes) Watch(ctx context.Context, opts v1.ListOptions) (watch.Inter
 	}
 	opts.Watch = true
 	return c.client.Get().
+		GroupVersion(example2.SchemeGroupVersion).
 		Resource("testtypes").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -108,6 +111,7 @@ func (c *testTypes) Watch(ctx context.Context, opts v1.ListOptions) (watch.Inter
 func (c *testTypes) Create(ctx context.Context, testType *example2.TestType, opts v1.CreateOptions) (result *example2.TestType, err error) {
 	result = &example2.TestType{}
 	err = c.client.Post().
+		GroupVersion(example2.SchemeGroupVersion).
 		Resource("testtypes").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Body(testType).
@@ -120,6 +124,7 @@ func (c *testTypes) Create(ctx context.Context, testType *example2.TestType, opt
 func (c *testTypes) Update(ctx context.Context, testType *example2.TestType, opts v1.UpdateOptions) (result *example2.TestType, err error) {
 	result = &example2.TestType{}
 	err = c.client.Put().
+		GroupVersion(example2.SchemeGroupVersion).
 		Resource("testtypes").
 		Name(testType.Name).
 		VersionedParams(&opts, scheme.ParameterCodec).
@@ -134,6 +139,7 @@ func (c *testTypes) Update(ctx context.Context, testType *example2.TestType, opt
 func (c *testTypes) UpdateStatus(ctx context.Context, testType *example2.TestType, opts v1.UpdateOptions) (result *example2.TestType, err error) {
 	result = &example2.TestType{}
 	err = c.client.Put().
+		GroupVersion(example2.SchemeGroupVersion).
 		Resource("testtypes").
 		Name(testType.Name).
 		SubResource("status").
@@ -147,6 +153,7 @@ func (c *testTypes) UpdateStatus(ctx context.Context, testType *example2.TestTyp
 // Delete takes name of the testType and deletes it. Returns an error if one occurs.
 func (c *testTypes) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
 	return c.client.Delete().
+		GroupVersion(example2.SchemeGroupVersion).
 		Resource("testtypes").
 		Name(name).
 		Body(&opts).
@@ -161,6 +168,7 @@ func (c *testTypes) DeleteCollection(ctx context.Context, opts v1.DeleteOptions,
 		timeout = time.Duration(*listOpts.TimeoutSeconds) * time.Second
 	}
 	return c.client.Delete().
+		GroupVersion(example2.SchemeGroupVersion).
 		Resource("testtypes").
 		VersionedParams(&listOpts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -173,6 +181,7 @@ func (c *testTypes) DeleteCollection(ctx context.Context, opts v1.DeleteOptions,
 func (c *testTypes) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts v1.PatchOptions, subresources ...string) (result *example2.TestType, err error) {
 	result = &example2.TestType{}
 	err = c.client.Patch(pt).
+		GroupVersion(example2.SchemeGroupVersion).
 		Resource("testtypes").
 		Name(name).
 		SubResource(subresources...).

--- a/staging/src/k8s.io/code-generator/examples/apiserver/clientset/internalversion/typed/example3.io/internalversion/testtype.go
+++ b/staging/src/k8s.io/code-generator/examples/apiserver/clientset/internalversion/typed/example3.io/internalversion/testtype.go
@@ -69,6 +69,7 @@ func (c *testTypes) Get(ctx context.Context, name string, options v1.GetOptions)
 	result = &example3io.TestType{}
 	err = c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(example3io.SchemeGroupVersion).
 		Resource("testtypes").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
@@ -86,6 +87,7 @@ func (c *testTypes) List(ctx context.Context, opts v1.ListOptions) (result *exam
 	result = &example3io.TestTypeList{}
 	err = c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(example3io.SchemeGroupVersion).
 		Resource("testtypes").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -103,6 +105,7 @@ func (c *testTypes) Watch(ctx context.Context, opts v1.ListOptions) (watch.Inter
 	opts.Watch = true
 	return c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(example3io.SchemeGroupVersion).
 		Resource("testtypes").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -114,6 +117,7 @@ func (c *testTypes) Create(ctx context.Context, testType *example3io.TestType, o
 	result = &example3io.TestType{}
 	err = c.client.Post().
 		Namespace(c.ns).
+		GroupVersion(example3io.SchemeGroupVersion).
 		Resource("testtypes").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Body(testType).
@@ -127,6 +131,7 @@ func (c *testTypes) Update(ctx context.Context, testType *example3io.TestType, o
 	result = &example3io.TestType{}
 	err = c.client.Put().
 		Namespace(c.ns).
+		GroupVersion(example3io.SchemeGroupVersion).
 		Resource("testtypes").
 		Name(testType.Name).
 		VersionedParams(&opts, scheme.ParameterCodec).
@@ -142,6 +147,7 @@ func (c *testTypes) UpdateStatus(ctx context.Context, testType *example3io.TestT
 	result = &example3io.TestType{}
 	err = c.client.Put().
 		Namespace(c.ns).
+		GroupVersion(example3io.SchemeGroupVersion).
 		Resource("testtypes").
 		Name(testType.Name).
 		SubResource("status").
@@ -156,6 +162,7 @@ func (c *testTypes) UpdateStatus(ctx context.Context, testType *example3io.TestT
 func (c *testTypes) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
 	return c.client.Delete().
 		Namespace(c.ns).
+		GroupVersion(example3io.SchemeGroupVersion).
 		Resource("testtypes").
 		Name(name).
 		Body(&opts).
@@ -171,6 +178,7 @@ func (c *testTypes) DeleteCollection(ctx context.Context, opts v1.DeleteOptions,
 	}
 	return c.client.Delete().
 		Namespace(c.ns).
+		GroupVersion(example3io.SchemeGroupVersion).
 		Resource("testtypes").
 		VersionedParams(&listOpts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -184,6 +192,7 @@ func (c *testTypes) Patch(ctx context.Context, name string, pt types.PatchType, 
 	result = &example3io.TestType{}
 	err = c.client.Patch(pt).
 		Namespace(c.ns).
+		GroupVersion(example3io.SchemeGroupVersion).
 		Resource("testtypes").
 		Name(name).
 		SubResource(subresources...).

--- a/staging/src/k8s.io/code-generator/examples/apiserver/clientset/versioned/typed/example/v1/testtype.go
+++ b/staging/src/k8s.io/code-generator/examples/apiserver/clientset/versioned/typed/example/v1/testtype.go
@@ -69,6 +69,7 @@ func (c *testTypes) Get(ctx context.Context, name string, options metav1.GetOpti
 	result = &v1.TestType{}
 	err = c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("testtypes").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
@@ -86,6 +87,7 @@ func (c *testTypes) List(ctx context.Context, opts metav1.ListOptions) (result *
 	result = &v1.TestTypeList{}
 	err = c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("testtypes").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -103,6 +105,7 @@ func (c *testTypes) Watch(ctx context.Context, opts metav1.ListOptions) (watch.I
 	opts.Watch = true
 	return c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("testtypes").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -114,6 +117,7 @@ func (c *testTypes) Create(ctx context.Context, testType *v1.TestType, opts meta
 	result = &v1.TestType{}
 	err = c.client.Post().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("testtypes").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Body(testType).
@@ -127,6 +131,7 @@ func (c *testTypes) Update(ctx context.Context, testType *v1.TestType, opts meta
 	result = &v1.TestType{}
 	err = c.client.Put().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("testtypes").
 		Name(testType.Name).
 		VersionedParams(&opts, scheme.ParameterCodec).
@@ -142,6 +147,7 @@ func (c *testTypes) UpdateStatus(ctx context.Context, testType *v1.TestType, opt
 	result = &v1.TestType{}
 	err = c.client.Put().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("testtypes").
 		Name(testType.Name).
 		SubResource("status").
@@ -156,6 +162,7 @@ func (c *testTypes) UpdateStatus(ctx context.Context, testType *v1.TestType, opt
 func (c *testTypes) Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error {
 	return c.client.Delete().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("testtypes").
 		Name(name).
 		Body(&opts).
@@ -171,6 +178,7 @@ func (c *testTypes) DeleteCollection(ctx context.Context, opts metav1.DeleteOpti
 	}
 	return c.client.Delete().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("testtypes").
 		VersionedParams(&listOpts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -184,6 +192,7 @@ func (c *testTypes) Patch(ctx context.Context, name string, pt types.PatchType, 
 	result = &v1.TestType{}
 	err = c.client.Patch(pt).
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("testtypes").
 		Name(name).
 		SubResource(subresources...).

--- a/staging/src/k8s.io/code-generator/examples/apiserver/clientset/versioned/typed/example2/v1/testtype.go
+++ b/staging/src/k8s.io/code-generator/examples/apiserver/clientset/versioned/typed/example2/v1/testtype.go
@@ -69,6 +69,7 @@ func (c *testTypes) Get(ctx context.Context, name string, options metav1.GetOpti
 	result = &v1.TestType{}
 	err = c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("testtypes").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
@@ -86,6 +87,7 @@ func (c *testTypes) List(ctx context.Context, opts metav1.ListOptions) (result *
 	result = &v1.TestTypeList{}
 	err = c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("testtypes").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -103,6 +105,7 @@ func (c *testTypes) Watch(ctx context.Context, opts metav1.ListOptions) (watch.I
 	opts.Watch = true
 	return c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("testtypes").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -114,6 +117,7 @@ func (c *testTypes) Create(ctx context.Context, testType *v1.TestType, opts meta
 	result = &v1.TestType{}
 	err = c.client.Post().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("testtypes").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Body(testType).
@@ -127,6 +131,7 @@ func (c *testTypes) Update(ctx context.Context, testType *v1.TestType, opts meta
 	result = &v1.TestType{}
 	err = c.client.Put().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("testtypes").
 		Name(testType.Name).
 		VersionedParams(&opts, scheme.ParameterCodec).
@@ -142,6 +147,7 @@ func (c *testTypes) UpdateStatus(ctx context.Context, testType *v1.TestType, opt
 	result = &v1.TestType{}
 	err = c.client.Put().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("testtypes").
 		Name(testType.Name).
 		SubResource("status").
@@ -156,6 +162,7 @@ func (c *testTypes) UpdateStatus(ctx context.Context, testType *v1.TestType, opt
 func (c *testTypes) Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error {
 	return c.client.Delete().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("testtypes").
 		Name(name).
 		Body(&opts).
@@ -171,6 +178,7 @@ func (c *testTypes) DeleteCollection(ctx context.Context, opts metav1.DeleteOpti
 	}
 	return c.client.Delete().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("testtypes").
 		VersionedParams(&listOpts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -184,6 +192,7 @@ func (c *testTypes) Patch(ctx context.Context, name string, pt types.PatchType, 
 	result = &v1.TestType{}
 	err = c.client.Patch(pt).
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("testtypes").
 		Name(name).
 		SubResource(subresources...).

--- a/staging/src/k8s.io/code-generator/examples/apiserver/clientset/versioned/typed/example3.io/v1/testtype.go
+++ b/staging/src/k8s.io/code-generator/examples/apiserver/clientset/versioned/typed/example3.io/v1/testtype.go
@@ -69,6 +69,7 @@ func (c *testTypes) Get(ctx context.Context, name string, options metav1.GetOpti
 	result = &v1.TestType{}
 	err = c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("testtypes").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
@@ -86,6 +87,7 @@ func (c *testTypes) List(ctx context.Context, opts metav1.ListOptions) (result *
 	result = &v1.TestTypeList{}
 	err = c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("testtypes").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -103,6 +105,7 @@ func (c *testTypes) Watch(ctx context.Context, opts metav1.ListOptions) (watch.I
 	opts.Watch = true
 	return c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("testtypes").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -114,6 +117,7 @@ func (c *testTypes) Create(ctx context.Context, testType *v1.TestType, opts meta
 	result = &v1.TestType{}
 	err = c.client.Post().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("testtypes").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Body(testType).
@@ -127,6 +131,7 @@ func (c *testTypes) Update(ctx context.Context, testType *v1.TestType, opts meta
 	result = &v1.TestType{}
 	err = c.client.Put().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("testtypes").
 		Name(testType.Name).
 		VersionedParams(&opts, scheme.ParameterCodec).
@@ -142,6 +147,7 @@ func (c *testTypes) UpdateStatus(ctx context.Context, testType *v1.TestType, opt
 	result = &v1.TestType{}
 	err = c.client.Put().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("testtypes").
 		Name(testType.Name).
 		SubResource("status").
@@ -156,6 +162,7 @@ func (c *testTypes) UpdateStatus(ctx context.Context, testType *v1.TestType, opt
 func (c *testTypes) Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error {
 	return c.client.Delete().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("testtypes").
 		Name(name).
 		Body(&opts).
@@ -171,6 +178,7 @@ func (c *testTypes) DeleteCollection(ctx context.Context, opts metav1.DeleteOpti
 	}
 	return c.client.Delete().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("testtypes").
 		VersionedParams(&listOpts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -184,6 +192,7 @@ func (c *testTypes) Patch(ctx context.Context, name string, pt types.PatchType, 
 	result = &v1.TestType{}
 	err = c.client.Patch(pt).
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("testtypes").
 		Name(name).
 		SubResource(subresources...).

--- a/staging/src/k8s.io/code-generator/examples/crd/clientset/versioned/clientset.go
+++ b/staging/src/k8s.io/code-generator/examples/crd/clientset/versioned/clientset.go
@@ -24,6 +24,7 @@ import (
 	discovery "k8s.io/client-go/discovery"
 	rest "k8s.io/client-go/rest"
 	flowcontrol "k8s.io/client-go/util/flowcontrol"
+	"k8s.io/code-generator/examples/crd/clientset/versioned/scheme"
 	examplev1 "k8s.io/code-generator/examples/crd/clientset/versioned/typed/example/v1"
 	secondexamplev1 "k8s.io/code-generator/examples/crd/clientset/versioned/typed/example2/v1"
 )
@@ -71,16 +72,21 @@ func NewForConfig(c *rest.Config) (*Clientset, error) {
 		}
 		configShallowCopy.RateLimiter = flowcontrol.NewTokenBucketRateLimiter(configShallowCopy.QPS, configShallowCopy.Burst)
 	}
+
+	configShallowCopy.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
+
+	if configShallowCopy.UserAgent == "" {
+		configShallowCopy.UserAgent = rest.DefaultKubernetesUserAgent()
+	}
+
+	restClient, err := rest.RESTClientFor(&configShallowCopy)
+	if err != nil {
+		return nil, err
+	}
+
 	var cs Clientset
-	var err error
-	cs.exampleV1, err = examplev1.NewForConfig(&configShallowCopy)
-	if err != nil {
-		return nil, err
-	}
-	cs.secondExampleV1, err = secondexamplev1.NewForConfig(&configShallowCopy)
-	if err != nil {
-		return nil, err
-	}
+	cs.exampleV1 = examplev1.New(restClient)
+	cs.secondExampleV1 = secondexamplev1.New(restClient)
 
 	cs.DiscoveryClient, err = discovery.NewDiscoveryClientForConfig(&configShallowCopy)
 	if err != nil {
@@ -92,12 +98,11 @@ func NewForConfig(c *rest.Config) (*Clientset, error) {
 // NewForConfigOrDie creates a new Clientset for the given config and
 // panics if there is an error in the config.
 func NewForConfigOrDie(c *rest.Config) *Clientset {
-	var cs Clientset
-	cs.exampleV1 = examplev1.NewForConfigOrDie(c)
-	cs.secondExampleV1 = secondexamplev1.NewForConfigOrDie(c)
-
-	cs.DiscoveryClient = discovery.NewDiscoveryClientForConfigOrDie(c)
-	return &cs
+	cs, err := NewForConfig(c)
+	if err != nil {
+		panic(err)
+	}
+	return cs
 }
 
 // New creates a new Clientset for the given RESTClient.

--- a/staging/src/k8s.io/code-generator/examples/crd/clientset/versioned/typed/example/v1/clustertesttype.go
+++ b/staging/src/k8s.io/code-generator/examples/crd/clientset/versioned/typed/example/v1/clustertesttype.go
@@ -70,6 +70,7 @@ func newClusterTestTypes(c *ExampleV1Client) *clusterTestTypes {
 func (c *clusterTestTypes) Get(ctx context.Context, name string, options metav1.GetOptions) (result *v1.ClusterTestType, err error) {
 	result = &v1.ClusterTestType{}
 	err = c.client.Get().
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("clustertesttypes").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
@@ -86,6 +87,7 @@ func (c *clusterTestTypes) List(ctx context.Context, opts metav1.ListOptions) (r
 	}
 	result = &v1.ClusterTestTypeList{}
 	err = c.client.Get().
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("clustertesttypes").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -102,6 +104,7 @@ func (c *clusterTestTypes) Watch(ctx context.Context, opts metav1.ListOptions) (
 	}
 	opts.Watch = true
 	return c.client.Get().
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("clustertesttypes").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -112,6 +115,7 @@ func (c *clusterTestTypes) Watch(ctx context.Context, opts metav1.ListOptions) (
 func (c *clusterTestTypes) Create(ctx context.Context, clusterTestType *v1.ClusterTestType, opts metav1.CreateOptions) (result *v1.ClusterTestType, err error) {
 	result = &v1.ClusterTestType{}
 	err = c.client.Post().
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("clustertesttypes").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Body(clusterTestType).
@@ -124,6 +128,7 @@ func (c *clusterTestTypes) Create(ctx context.Context, clusterTestType *v1.Clust
 func (c *clusterTestTypes) Update(ctx context.Context, clusterTestType *v1.ClusterTestType, opts metav1.UpdateOptions) (result *v1.ClusterTestType, err error) {
 	result = &v1.ClusterTestType{}
 	err = c.client.Put().
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("clustertesttypes").
 		Name(clusterTestType.Name).
 		VersionedParams(&opts, scheme.ParameterCodec).
@@ -138,6 +143,7 @@ func (c *clusterTestTypes) Update(ctx context.Context, clusterTestType *v1.Clust
 func (c *clusterTestTypes) UpdateStatus(ctx context.Context, clusterTestType *v1.ClusterTestType, opts metav1.UpdateOptions) (result *v1.ClusterTestType, err error) {
 	result = &v1.ClusterTestType{}
 	err = c.client.Put().
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("clustertesttypes").
 		Name(clusterTestType.Name).
 		SubResource("status").
@@ -151,6 +157,7 @@ func (c *clusterTestTypes) UpdateStatus(ctx context.Context, clusterTestType *v1
 // Delete takes name of the clusterTestType and deletes it. Returns an error if one occurs.
 func (c *clusterTestTypes) Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error {
 	return c.client.Delete().
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("clustertesttypes").
 		Name(name).
 		Body(&opts).
@@ -165,6 +172,7 @@ func (c *clusterTestTypes) DeleteCollection(ctx context.Context, opts metav1.Del
 		timeout = time.Duration(*listOpts.TimeoutSeconds) * time.Second
 	}
 	return c.client.Delete().
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("clustertesttypes").
 		VersionedParams(&listOpts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -177,6 +185,7 @@ func (c *clusterTestTypes) DeleteCollection(ctx context.Context, opts metav1.Del
 func (c *clusterTestTypes) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts metav1.PatchOptions, subresources ...string) (result *v1.ClusterTestType, err error) {
 	result = &v1.ClusterTestType{}
 	err = c.client.Patch(pt).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("clustertesttypes").
 		Name(name).
 		SubResource(subresources...).
@@ -191,6 +200,7 @@ func (c *clusterTestTypes) Patch(ctx context.Context, name string, pt types.Patc
 func (c *clusterTestTypes) GetScale(ctx context.Context, clusterTestTypeName string, options metav1.GetOptions) (result *autoscalingv1.Scale, err error) {
 	result = &autoscalingv1.Scale{}
 	err = c.client.Get().
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("clustertesttypes").
 		Name(clusterTestTypeName).
 		SubResource("scale").
@@ -204,6 +214,7 @@ func (c *clusterTestTypes) GetScale(ctx context.Context, clusterTestTypeName str
 func (c *clusterTestTypes) UpdateScale(ctx context.Context, clusterTestTypeName string, scale *autoscalingv1.Scale, opts metav1.UpdateOptions) (result *autoscalingv1.Scale, err error) {
 	result = &autoscalingv1.Scale{}
 	err = c.client.Put().
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("clustertesttypes").
 		Name(clusterTestTypeName).
 		SubResource("scale").

--- a/staging/src/k8s.io/code-generator/examples/crd/clientset/versioned/typed/example/v1/testtype.go
+++ b/staging/src/k8s.io/code-generator/examples/crd/clientset/versioned/typed/example/v1/testtype.go
@@ -69,6 +69,7 @@ func (c *testTypes) Get(ctx context.Context, name string, options metav1.GetOpti
 	result = &v1.TestType{}
 	err = c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("testtypes").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
@@ -86,6 +87,7 @@ func (c *testTypes) List(ctx context.Context, opts metav1.ListOptions) (result *
 	result = &v1.TestTypeList{}
 	err = c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("testtypes").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -103,6 +105,7 @@ func (c *testTypes) Watch(ctx context.Context, opts metav1.ListOptions) (watch.I
 	opts.Watch = true
 	return c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("testtypes").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -114,6 +117,7 @@ func (c *testTypes) Create(ctx context.Context, testType *v1.TestType, opts meta
 	result = &v1.TestType{}
 	err = c.client.Post().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("testtypes").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Body(testType).
@@ -127,6 +131,7 @@ func (c *testTypes) Update(ctx context.Context, testType *v1.TestType, opts meta
 	result = &v1.TestType{}
 	err = c.client.Put().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("testtypes").
 		Name(testType.Name).
 		VersionedParams(&opts, scheme.ParameterCodec).
@@ -142,6 +147,7 @@ func (c *testTypes) UpdateStatus(ctx context.Context, testType *v1.TestType, opt
 	result = &v1.TestType{}
 	err = c.client.Put().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("testtypes").
 		Name(testType.Name).
 		SubResource("status").
@@ -156,6 +162,7 @@ func (c *testTypes) UpdateStatus(ctx context.Context, testType *v1.TestType, opt
 func (c *testTypes) Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error {
 	return c.client.Delete().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("testtypes").
 		Name(name).
 		Body(&opts).
@@ -171,6 +178,7 @@ func (c *testTypes) DeleteCollection(ctx context.Context, opts metav1.DeleteOpti
 	}
 	return c.client.Delete().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("testtypes").
 		VersionedParams(&listOpts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -184,6 +192,7 @@ func (c *testTypes) Patch(ctx context.Context, name string, pt types.PatchType, 
 	result = &v1.TestType{}
 	err = c.client.Patch(pt).
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("testtypes").
 		Name(name).
 		SubResource(subresources...).

--- a/staging/src/k8s.io/code-generator/examples/crd/clientset/versioned/typed/example2/v1/testtype.go
+++ b/staging/src/k8s.io/code-generator/examples/crd/clientset/versioned/typed/example2/v1/testtype.go
@@ -69,6 +69,7 @@ func (c *testTypes) Get(ctx context.Context, name string, options metav1.GetOpti
 	result = &v1.TestType{}
 	err = c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("testtypes").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
@@ -86,6 +87,7 @@ func (c *testTypes) List(ctx context.Context, opts metav1.ListOptions) (result *
 	result = &v1.TestTypeList{}
 	err = c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("testtypes").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -103,6 +105,7 @@ func (c *testTypes) Watch(ctx context.Context, opts metav1.ListOptions) (watch.I
 	opts.Watch = true
 	return c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("testtypes").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -114,6 +117,7 @@ func (c *testTypes) Create(ctx context.Context, testType *v1.TestType, opts meta
 	result = &v1.TestType{}
 	err = c.client.Post().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("testtypes").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Body(testType).
@@ -127,6 +131,7 @@ func (c *testTypes) Update(ctx context.Context, testType *v1.TestType, opts meta
 	result = &v1.TestType{}
 	err = c.client.Put().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("testtypes").
 		Name(testType.Name).
 		VersionedParams(&opts, scheme.ParameterCodec).
@@ -142,6 +147,7 @@ func (c *testTypes) UpdateStatus(ctx context.Context, testType *v1.TestType, opt
 	result = &v1.TestType{}
 	err = c.client.Put().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("testtypes").
 		Name(testType.Name).
 		SubResource("status").
@@ -156,6 +162,7 @@ func (c *testTypes) UpdateStatus(ctx context.Context, testType *v1.TestType, opt
 func (c *testTypes) Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error {
 	return c.client.Delete().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("testtypes").
 		Name(name).
 		Body(&opts).
@@ -171,6 +178,7 @@ func (c *testTypes) DeleteCollection(ctx context.Context, opts metav1.DeleteOpti
 	}
 	return c.client.Delete().
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("testtypes").
 		VersionedParams(&listOpts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -184,6 +192,7 @@ func (c *testTypes) Patch(ctx context.Context, name string, pt types.PatchType, 
 	result = &v1.TestType{}
 	err = c.client.Patch(pt).
 		Namespace(c.ns).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("testtypes").
 		Name(name).
 		SubResource(subresources...).

--- a/staging/src/k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/typed/apiregistration/v1/apiservice.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/typed/apiregistration/v1/apiservice.go
@@ -66,6 +66,7 @@ func newAPIServices(c *ApiregistrationV1Client) *aPIServices {
 func (c *aPIServices) Get(ctx context.Context, name string, options metav1.GetOptions) (result *v1.APIService, err error) {
 	result = &v1.APIService{}
 	err = c.client.Get().
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("apiservices").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
@@ -82,6 +83,7 @@ func (c *aPIServices) List(ctx context.Context, opts metav1.ListOptions) (result
 	}
 	result = &v1.APIServiceList{}
 	err = c.client.Get().
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("apiservices").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -98,6 +100,7 @@ func (c *aPIServices) Watch(ctx context.Context, opts metav1.ListOptions) (watch
 	}
 	opts.Watch = true
 	return c.client.Get().
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("apiservices").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -108,6 +111,7 @@ func (c *aPIServices) Watch(ctx context.Context, opts metav1.ListOptions) (watch
 func (c *aPIServices) Create(ctx context.Context, aPIService *v1.APIService, opts metav1.CreateOptions) (result *v1.APIService, err error) {
 	result = &v1.APIService{}
 	err = c.client.Post().
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("apiservices").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Body(aPIService).
@@ -120,6 +124,7 @@ func (c *aPIServices) Create(ctx context.Context, aPIService *v1.APIService, opt
 func (c *aPIServices) Update(ctx context.Context, aPIService *v1.APIService, opts metav1.UpdateOptions) (result *v1.APIService, err error) {
 	result = &v1.APIService{}
 	err = c.client.Put().
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("apiservices").
 		Name(aPIService.Name).
 		VersionedParams(&opts, scheme.ParameterCodec).
@@ -134,6 +139,7 @@ func (c *aPIServices) Update(ctx context.Context, aPIService *v1.APIService, opt
 func (c *aPIServices) UpdateStatus(ctx context.Context, aPIService *v1.APIService, opts metav1.UpdateOptions) (result *v1.APIService, err error) {
 	result = &v1.APIService{}
 	err = c.client.Put().
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("apiservices").
 		Name(aPIService.Name).
 		SubResource("status").
@@ -147,6 +153,7 @@ func (c *aPIServices) UpdateStatus(ctx context.Context, aPIService *v1.APIServic
 // Delete takes name of the aPIService and deletes it. Returns an error if one occurs.
 func (c *aPIServices) Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error {
 	return c.client.Delete().
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("apiservices").
 		Name(name).
 		Body(&opts).
@@ -161,6 +168,7 @@ func (c *aPIServices) DeleteCollection(ctx context.Context, opts metav1.DeleteOp
 		timeout = time.Duration(*listOpts.TimeoutSeconds) * time.Second
 	}
 	return c.client.Delete().
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("apiservices").
 		VersionedParams(&listOpts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -173,6 +181,7 @@ func (c *aPIServices) DeleteCollection(ctx context.Context, opts metav1.DeleteOp
 func (c *aPIServices) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts metav1.PatchOptions, subresources ...string) (result *v1.APIService, err error) {
 	result = &v1.APIService{}
 	err = c.client.Patch(pt).
+		GroupVersion(v1.SchemeGroupVersion).
 		Resource("apiservices").
 		Name(name).
 		SubResource(subresources...).

--- a/staging/src/k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/typed/apiregistration/v1beta1/apiservice.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/typed/apiregistration/v1beta1/apiservice.go
@@ -66,6 +66,7 @@ func newAPIServices(c *ApiregistrationV1beta1Client) *aPIServices {
 func (c *aPIServices) Get(ctx context.Context, name string, options v1.GetOptions) (result *v1beta1.APIService, err error) {
 	result = &v1beta1.APIService{}
 	err = c.client.Get().
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("apiservices").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
@@ -82,6 +83,7 @@ func (c *aPIServices) List(ctx context.Context, opts v1.ListOptions) (result *v1
 	}
 	result = &v1beta1.APIServiceList{}
 	err = c.client.Get().
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("apiservices").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -98,6 +100,7 @@ func (c *aPIServices) Watch(ctx context.Context, opts v1.ListOptions) (watch.Int
 	}
 	opts.Watch = true
 	return c.client.Get().
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("apiservices").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -108,6 +111,7 @@ func (c *aPIServices) Watch(ctx context.Context, opts v1.ListOptions) (watch.Int
 func (c *aPIServices) Create(ctx context.Context, aPIService *v1beta1.APIService, opts v1.CreateOptions) (result *v1beta1.APIService, err error) {
 	result = &v1beta1.APIService{}
 	err = c.client.Post().
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("apiservices").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Body(aPIService).
@@ -120,6 +124,7 @@ func (c *aPIServices) Create(ctx context.Context, aPIService *v1beta1.APIService
 func (c *aPIServices) Update(ctx context.Context, aPIService *v1beta1.APIService, opts v1.UpdateOptions) (result *v1beta1.APIService, err error) {
 	result = &v1beta1.APIService{}
 	err = c.client.Put().
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("apiservices").
 		Name(aPIService.Name).
 		VersionedParams(&opts, scheme.ParameterCodec).
@@ -134,6 +139,7 @@ func (c *aPIServices) Update(ctx context.Context, aPIService *v1beta1.APIService
 func (c *aPIServices) UpdateStatus(ctx context.Context, aPIService *v1beta1.APIService, opts v1.UpdateOptions) (result *v1beta1.APIService, err error) {
 	result = &v1beta1.APIService{}
 	err = c.client.Put().
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("apiservices").
 		Name(aPIService.Name).
 		SubResource("status").
@@ -147,6 +153,7 @@ func (c *aPIServices) UpdateStatus(ctx context.Context, aPIService *v1beta1.APIS
 // Delete takes name of the aPIService and deletes it. Returns an error if one occurs.
 func (c *aPIServices) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
 	return c.client.Delete().
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("apiservices").
 		Name(name).
 		Body(&opts).
@@ -161,6 +168,7 @@ func (c *aPIServices) DeleteCollection(ctx context.Context, opts v1.DeleteOption
 		timeout = time.Duration(*listOpts.TimeoutSeconds) * time.Second
 	}
 	return c.client.Delete().
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("apiservices").
 		VersionedParams(&listOpts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -173,6 +181,7 @@ func (c *aPIServices) DeleteCollection(ctx context.Context, opts v1.DeleteOption
 func (c *aPIServices) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts v1.PatchOptions, subresources ...string) (result *v1beta1.APIService, err error) {
 	result = &v1beta1.APIService{}
 	err = c.client.Patch(pt).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("apiservices").
 		Name(name).
 		SubResource(subresources...).

--- a/staging/src/k8s.io/metrics/pkg/client/clientset/versioned/clientset.go
+++ b/staging/src/k8s.io/metrics/pkg/client/clientset/versioned/clientset.go
@@ -24,6 +24,7 @@ import (
 	discovery "k8s.io/client-go/discovery"
 	rest "k8s.io/client-go/rest"
 	flowcontrol "k8s.io/client-go/util/flowcontrol"
+	"k8s.io/metrics/pkg/client/clientset/versioned/scheme"
 	metricsv1alpha1 "k8s.io/metrics/pkg/client/clientset/versioned/typed/metrics/v1alpha1"
 	metricsv1beta1 "k8s.io/metrics/pkg/client/clientset/versioned/typed/metrics/v1beta1"
 )
@@ -71,16 +72,21 @@ func NewForConfig(c *rest.Config) (*Clientset, error) {
 		}
 		configShallowCopy.RateLimiter = flowcontrol.NewTokenBucketRateLimiter(configShallowCopy.QPS, configShallowCopy.Burst)
 	}
+
+	configShallowCopy.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
+
+	if configShallowCopy.UserAgent == "" {
+		configShallowCopy.UserAgent = rest.DefaultKubernetesUserAgent()
+	}
+
+	restClient, err := rest.RESTClientFor(&configShallowCopy)
+	if err != nil {
+		return nil, err
+	}
+
 	var cs Clientset
-	var err error
-	cs.metricsV1alpha1, err = metricsv1alpha1.NewForConfig(&configShallowCopy)
-	if err != nil {
-		return nil, err
-	}
-	cs.metricsV1beta1, err = metricsv1beta1.NewForConfig(&configShallowCopy)
-	if err != nil {
-		return nil, err
-	}
+	cs.metricsV1alpha1 = metricsv1alpha1.New(restClient)
+	cs.metricsV1beta1 = metricsv1beta1.New(restClient)
 
 	cs.DiscoveryClient, err = discovery.NewDiscoveryClientForConfig(&configShallowCopy)
 	if err != nil {
@@ -92,12 +98,11 @@ func NewForConfig(c *rest.Config) (*Clientset, error) {
 // NewForConfigOrDie creates a new Clientset for the given config and
 // panics if there is an error in the config.
 func NewForConfigOrDie(c *rest.Config) *Clientset {
-	var cs Clientset
-	cs.metricsV1alpha1 = metricsv1alpha1.NewForConfigOrDie(c)
-	cs.metricsV1beta1 = metricsv1beta1.NewForConfigOrDie(c)
-
-	cs.DiscoveryClient = discovery.NewDiscoveryClientForConfigOrDie(c)
-	return &cs
+	cs, err := NewForConfig(c)
+	if err != nil {
+		panic(err)
+	}
+	return cs
 }
 
 // New creates a new Clientset for the given RESTClient.

--- a/staging/src/k8s.io/metrics/pkg/client/clientset/versioned/typed/metrics/v1alpha1/nodemetrics.go
+++ b/staging/src/k8s.io/metrics/pkg/client/clientset/versioned/typed/metrics/v1alpha1/nodemetrics.go
@@ -59,6 +59,7 @@ func newNodeMetricses(c *MetricsV1alpha1Client) *nodeMetricses {
 func (c *nodeMetricses) Get(ctx context.Context, name string, options v1.GetOptions) (result *v1alpha1.NodeMetrics, err error) {
 	result = &v1alpha1.NodeMetrics{}
 	err = c.client.Get().
+		GroupVersion(v1alpha1.SchemeGroupVersion).
 		Resource("nodes").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
@@ -75,6 +76,7 @@ func (c *nodeMetricses) List(ctx context.Context, opts v1.ListOptions) (result *
 	}
 	result = &v1alpha1.NodeMetricsList{}
 	err = c.client.Get().
+		GroupVersion(v1alpha1.SchemeGroupVersion).
 		Resource("nodes").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -91,6 +93,7 @@ func (c *nodeMetricses) Watch(ctx context.Context, opts v1.ListOptions) (watch.I
 	}
 	opts.Watch = true
 	return c.client.Get().
+		GroupVersion(v1alpha1.SchemeGroupVersion).
 		Resource("nodes").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).

--- a/staging/src/k8s.io/metrics/pkg/client/clientset/versioned/typed/metrics/v1alpha1/podmetrics.go
+++ b/staging/src/k8s.io/metrics/pkg/client/clientset/versioned/typed/metrics/v1alpha1/podmetrics.go
@@ -62,6 +62,7 @@ func (c *podMetricses) Get(ctx context.Context, name string, options v1.GetOptio
 	result = &v1alpha1.PodMetrics{}
 	err = c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(v1alpha1.SchemeGroupVersion).
 		Resource("pods").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
@@ -79,6 +80,7 @@ func (c *podMetricses) List(ctx context.Context, opts v1.ListOptions) (result *v
 	result = &v1alpha1.PodMetricsList{}
 	err = c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(v1alpha1.SchemeGroupVersion).
 		Resource("pods").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -96,6 +98,7 @@ func (c *podMetricses) Watch(ctx context.Context, opts v1.ListOptions) (watch.In
 	opts.Watch = true
 	return c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(v1alpha1.SchemeGroupVersion).
 		Resource("pods").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).

--- a/staging/src/k8s.io/metrics/pkg/client/clientset/versioned/typed/metrics/v1beta1/nodemetrics.go
+++ b/staging/src/k8s.io/metrics/pkg/client/clientset/versioned/typed/metrics/v1beta1/nodemetrics.go
@@ -59,6 +59,7 @@ func newNodeMetricses(c *MetricsV1beta1Client) *nodeMetricses {
 func (c *nodeMetricses) Get(ctx context.Context, name string, options v1.GetOptions) (result *v1beta1.NodeMetrics, err error) {
 	result = &v1beta1.NodeMetrics{}
 	err = c.client.Get().
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("nodes").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
@@ -75,6 +76,7 @@ func (c *nodeMetricses) List(ctx context.Context, opts v1.ListOptions) (result *
 	}
 	result = &v1beta1.NodeMetricsList{}
 	err = c.client.Get().
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("nodes").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -91,6 +93,7 @@ func (c *nodeMetricses) Watch(ctx context.Context, opts v1.ListOptions) (watch.I
 	}
 	opts.Watch = true
 	return c.client.Get().
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("nodes").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).

--- a/staging/src/k8s.io/metrics/pkg/client/clientset/versioned/typed/metrics/v1beta1/podmetrics.go
+++ b/staging/src/k8s.io/metrics/pkg/client/clientset/versioned/typed/metrics/v1beta1/podmetrics.go
@@ -62,6 +62,7 @@ func (c *podMetricses) Get(ctx context.Context, name string, options v1.GetOptio
 	result = &v1beta1.PodMetrics{}
 	err = c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("pods").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
@@ -79,6 +80,7 @@ func (c *podMetricses) List(ctx context.Context, opts v1.ListOptions) (result *v
 	result = &v1beta1.PodMetricsList{}
 	err = c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("pods").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -96,6 +98,7 @@ func (c *podMetricses) Watch(ctx context.Context, opts v1.ListOptions) (watch.In
 	opts.Watch = true
 	return c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("pods").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).

--- a/staging/src/k8s.io/sample-apiserver/pkg/generated/clientset/versioned/clientset.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/generated/clientset/versioned/clientset.go
@@ -24,6 +24,7 @@ import (
 	discovery "k8s.io/client-go/discovery"
 	rest "k8s.io/client-go/rest"
 	flowcontrol "k8s.io/client-go/util/flowcontrol"
+	"k8s.io/sample-apiserver/pkg/generated/clientset/versioned/scheme"
 	wardlev1alpha1 "k8s.io/sample-apiserver/pkg/generated/clientset/versioned/typed/wardle/v1alpha1"
 	wardlev1beta1 "k8s.io/sample-apiserver/pkg/generated/clientset/versioned/typed/wardle/v1beta1"
 )
@@ -71,16 +72,21 @@ func NewForConfig(c *rest.Config) (*Clientset, error) {
 		}
 		configShallowCopy.RateLimiter = flowcontrol.NewTokenBucketRateLimiter(configShallowCopy.QPS, configShallowCopy.Burst)
 	}
+
+	configShallowCopy.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
+
+	if configShallowCopy.UserAgent == "" {
+		configShallowCopy.UserAgent = rest.DefaultKubernetesUserAgent()
+	}
+
+	restClient, err := rest.RESTClientFor(&configShallowCopy)
+	if err != nil {
+		return nil, err
+	}
+
 	var cs Clientset
-	var err error
-	cs.wardleV1alpha1, err = wardlev1alpha1.NewForConfig(&configShallowCopy)
-	if err != nil {
-		return nil, err
-	}
-	cs.wardleV1beta1, err = wardlev1beta1.NewForConfig(&configShallowCopy)
-	if err != nil {
-		return nil, err
-	}
+	cs.wardleV1alpha1 = wardlev1alpha1.New(restClient)
+	cs.wardleV1beta1 = wardlev1beta1.New(restClient)
 
 	cs.DiscoveryClient, err = discovery.NewDiscoveryClientForConfig(&configShallowCopy)
 	if err != nil {
@@ -92,12 +98,11 @@ func NewForConfig(c *rest.Config) (*Clientset, error) {
 // NewForConfigOrDie creates a new Clientset for the given config and
 // panics if there is an error in the config.
 func NewForConfigOrDie(c *rest.Config) *Clientset {
-	var cs Clientset
-	cs.wardleV1alpha1 = wardlev1alpha1.NewForConfigOrDie(c)
-	cs.wardleV1beta1 = wardlev1beta1.NewForConfigOrDie(c)
-
-	cs.DiscoveryClient = discovery.NewDiscoveryClientForConfigOrDie(c)
-	return &cs
+	cs, err := NewForConfig(c)
+	if err != nil {
+		panic(err)
+	}
+	return cs
 }
 
 // New creates a new Clientset for the given RESTClient.

--- a/staging/src/k8s.io/sample-apiserver/pkg/generated/clientset/versioned/typed/wardle/v1alpha1/fischer.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/generated/clientset/versioned/typed/wardle/v1alpha1/fischer.go
@@ -65,6 +65,7 @@ func newFischers(c *WardleV1alpha1Client) *fischers {
 func (c *fischers) Get(ctx context.Context, name string, options v1.GetOptions) (result *v1alpha1.Fischer, err error) {
 	result = &v1alpha1.Fischer{}
 	err = c.client.Get().
+		GroupVersion(v1alpha1.SchemeGroupVersion).
 		Resource("fischers").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
@@ -81,6 +82,7 @@ func (c *fischers) List(ctx context.Context, opts v1.ListOptions) (result *v1alp
 	}
 	result = &v1alpha1.FischerList{}
 	err = c.client.Get().
+		GroupVersion(v1alpha1.SchemeGroupVersion).
 		Resource("fischers").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -97,6 +99,7 @@ func (c *fischers) Watch(ctx context.Context, opts v1.ListOptions) (watch.Interf
 	}
 	opts.Watch = true
 	return c.client.Get().
+		GroupVersion(v1alpha1.SchemeGroupVersion).
 		Resource("fischers").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -107,6 +110,7 @@ func (c *fischers) Watch(ctx context.Context, opts v1.ListOptions) (watch.Interf
 func (c *fischers) Create(ctx context.Context, fischer *v1alpha1.Fischer, opts v1.CreateOptions) (result *v1alpha1.Fischer, err error) {
 	result = &v1alpha1.Fischer{}
 	err = c.client.Post().
+		GroupVersion(v1alpha1.SchemeGroupVersion).
 		Resource("fischers").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Body(fischer).
@@ -119,6 +123,7 @@ func (c *fischers) Create(ctx context.Context, fischer *v1alpha1.Fischer, opts v
 func (c *fischers) Update(ctx context.Context, fischer *v1alpha1.Fischer, opts v1.UpdateOptions) (result *v1alpha1.Fischer, err error) {
 	result = &v1alpha1.Fischer{}
 	err = c.client.Put().
+		GroupVersion(v1alpha1.SchemeGroupVersion).
 		Resource("fischers").
 		Name(fischer.Name).
 		VersionedParams(&opts, scheme.ParameterCodec).
@@ -131,6 +136,7 @@ func (c *fischers) Update(ctx context.Context, fischer *v1alpha1.Fischer, opts v
 // Delete takes name of the fischer and deletes it. Returns an error if one occurs.
 func (c *fischers) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
 	return c.client.Delete().
+		GroupVersion(v1alpha1.SchemeGroupVersion).
 		Resource("fischers").
 		Name(name).
 		Body(&opts).
@@ -145,6 +151,7 @@ func (c *fischers) DeleteCollection(ctx context.Context, opts v1.DeleteOptions, 
 		timeout = time.Duration(*listOpts.TimeoutSeconds) * time.Second
 	}
 	return c.client.Delete().
+		GroupVersion(v1alpha1.SchemeGroupVersion).
 		Resource("fischers").
 		VersionedParams(&listOpts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -157,6 +164,7 @@ func (c *fischers) DeleteCollection(ctx context.Context, opts v1.DeleteOptions, 
 func (c *fischers) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts v1.PatchOptions, subresources ...string) (result *v1alpha1.Fischer, err error) {
 	result = &v1alpha1.Fischer{}
 	err = c.client.Patch(pt).
+		GroupVersion(v1alpha1.SchemeGroupVersion).
 		Resource("fischers").
 		Name(name).
 		SubResource(subresources...).

--- a/staging/src/k8s.io/sample-apiserver/pkg/generated/clientset/versioned/typed/wardle/v1alpha1/flunder.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/generated/clientset/versioned/typed/wardle/v1alpha1/flunder.go
@@ -69,6 +69,7 @@ func (c *flunders) Get(ctx context.Context, name string, options v1.GetOptions) 
 	result = &v1alpha1.Flunder{}
 	err = c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(v1alpha1.SchemeGroupVersion).
 		Resource("flunders").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
@@ -86,6 +87,7 @@ func (c *flunders) List(ctx context.Context, opts v1.ListOptions) (result *v1alp
 	result = &v1alpha1.FlunderList{}
 	err = c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(v1alpha1.SchemeGroupVersion).
 		Resource("flunders").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -103,6 +105,7 @@ func (c *flunders) Watch(ctx context.Context, opts v1.ListOptions) (watch.Interf
 	opts.Watch = true
 	return c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(v1alpha1.SchemeGroupVersion).
 		Resource("flunders").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -114,6 +117,7 @@ func (c *flunders) Create(ctx context.Context, flunder *v1alpha1.Flunder, opts v
 	result = &v1alpha1.Flunder{}
 	err = c.client.Post().
 		Namespace(c.ns).
+		GroupVersion(v1alpha1.SchemeGroupVersion).
 		Resource("flunders").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Body(flunder).
@@ -127,6 +131,7 @@ func (c *flunders) Update(ctx context.Context, flunder *v1alpha1.Flunder, opts v
 	result = &v1alpha1.Flunder{}
 	err = c.client.Put().
 		Namespace(c.ns).
+		GroupVersion(v1alpha1.SchemeGroupVersion).
 		Resource("flunders").
 		Name(flunder.Name).
 		VersionedParams(&opts, scheme.ParameterCodec).
@@ -142,6 +147,7 @@ func (c *flunders) UpdateStatus(ctx context.Context, flunder *v1alpha1.Flunder, 
 	result = &v1alpha1.Flunder{}
 	err = c.client.Put().
 		Namespace(c.ns).
+		GroupVersion(v1alpha1.SchemeGroupVersion).
 		Resource("flunders").
 		Name(flunder.Name).
 		SubResource("status").
@@ -156,6 +162,7 @@ func (c *flunders) UpdateStatus(ctx context.Context, flunder *v1alpha1.Flunder, 
 func (c *flunders) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
 	return c.client.Delete().
 		Namespace(c.ns).
+		GroupVersion(v1alpha1.SchemeGroupVersion).
 		Resource("flunders").
 		Name(name).
 		Body(&opts).
@@ -171,6 +178,7 @@ func (c *flunders) DeleteCollection(ctx context.Context, opts v1.DeleteOptions, 
 	}
 	return c.client.Delete().
 		Namespace(c.ns).
+		GroupVersion(v1alpha1.SchemeGroupVersion).
 		Resource("flunders").
 		VersionedParams(&listOpts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -184,6 +192,7 @@ func (c *flunders) Patch(ctx context.Context, name string, pt types.PatchType, d
 	result = &v1alpha1.Flunder{}
 	err = c.client.Patch(pt).
 		Namespace(c.ns).
+		GroupVersion(v1alpha1.SchemeGroupVersion).
 		Resource("flunders").
 		Name(name).
 		SubResource(subresources...).

--- a/staging/src/k8s.io/sample-apiserver/pkg/generated/clientset/versioned/typed/wardle/v1beta1/flunder.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/generated/clientset/versioned/typed/wardle/v1beta1/flunder.go
@@ -69,6 +69,7 @@ func (c *flunders) Get(ctx context.Context, name string, options v1.GetOptions) 
 	result = &v1beta1.Flunder{}
 	err = c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("flunders").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
@@ -86,6 +87,7 @@ func (c *flunders) List(ctx context.Context, opts v1.ListOptions) (result *v1bet
 	result = &v1beta1.FlunderList{}
 	err = c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("flunders").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -103,6 +105,7 @@ func (c *flunders) Watch(ctx context.Context, opts v1.ListOptions) (watch.Interf
 	opts.Watch = true
 	return c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("flunders").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -114,6 +117,7 @@ func (c *flunders) Create(ctx context.Context, flunder *v1beta1.Flunder, opts v1
 	result = &v1beta1.Flunder{}
 	err = c.client.Post().
 		Namespace(c.ns).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("flunders").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Body(flunder).
@@ -127,6 +131,7 @@ func (c *flunders) Update(ctx context.Context, flunder *v1beta1.Flunder, opts v1
 	result = &v1beta1.Flunder{}
 	err = c.client.Put().
 		Namespace(c.ns).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("flunders").
 		Name(flunder.Name).
 		VersionedParams(&opts, scheme.ParameterCodec).
@@ -142,6 +147,7 @@ func (c *flunders) UpdateStatus(ctx context.Context, flunder *v1beta1.Flunder, o
 	result = &v1beta1.Flunder{}
 	err = c.client.Put().
 		Namespace(c.ns).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("flunders").
 		Name(flunder.Name).
 		SubResource("status").
@@ -156,6 +162,7 @@ func (c *flunders) UpdateStatus(ctx context.Context, flunder *v1beta1.Flunder, o
 func (c *flunders) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
 	return c.client.Delete().
 		Namespace(c.ns).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("flunders").
 		Name(name).
 		Body(&opts).
@@ -171,6 +178,7 @@ func (c *flunders) DeleteCollection(ctx context.Context, opts v1.DeleteOptions, 
 	}
 	return c.client.Delete().
 		Namespace(c.ns).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("flunders").
 		VersionedParams(&listOpts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -184,6 +192,7 @@ func (c *flunders) Patch(ctx context.Context, name string, pt types.PatchType, d
 	result = &v1beta1.Flunder{}
 	err = c.client.Patch(pt).
 		Namespace(c.ns).
+		GroupVersion(v1beta1.SchemeGroupVersion).
 		Resource("flunders").
 		Name(name).
 		SubResource(subresources...).

--- a/staging/src/k8s.io/sample-controller/pkg/generated/clientset/versioned/clientset.go
+++ b/staging/src/k8s.io/sample-controller/pkg/generated/clientset/versioned/clientset.go
@@ -24,6 +24,7 @@ import (
 	discovery "k8s.io/client-go/discovery"
 	rest "k8s.io/client-go/rest"
 	flowcontrol "k8s.io/client-go/util/flowcontrol"
+	"k8s.io/sample-controller/pkg/generated/clientset/versioned/scheme"
 	samplecontrollerv1alpha1 "k8s.io/sample-controller/pkg/generated/clientset/versioned/typed/samplecontroller/v1alpha1"
 )
 
@@ -63,12 +64,20 @@ func NewForConfig(c *rest.Config) (*Clientset, error) {
 		}
 		configShallowCopy.RateLimiter = flowcontrol.NewTokenBucketRateLimiter(configShallowCopy.QPS, configShallowCopy.Burst)
 	}
-	var cs Clientset
-	var err error
-	cs.samplecontrollerV1alpha1, err = samplecontrollerv1alpha1.NewForConfig(&configShallowCopy)
+
+	configShallowCopy.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
+
+	if configShallowCopy.UserAgent == "" {
+		configShallowCopy.UserAgent = rest.DefaultKubernetesUserAgent()
+	}
+
+	restClient, err := rest.RESTClientFor(&configShallowCopy)
 	if err != nil {
 		return nil, err
 	}
+
+	var cs Clientset
+	cs.samplecontrollerV1alpha1 = samplecontrollerv1alpha1.New(restClient)
 
 	cs.DiscoveryClient, err = discovery.NewDiscoveryClientForConfig(&configShallowCopy)
 	if err != nil {
@@ -80,11 +89,11 @@ func NewForConfig(c *rest.Config) (*Clientset, error) {
 // NewForConfigOrDie creates a new Clientset for the given config and
 // panics if there is an error in the config.
 func NewForConfigOrDie(c *rest.Config) *Clientset {
-	var cs Clientset
-	cs.samplecontrollerV1alpha1 = samplecontrollerv1alpha1.NewForConfigOrDie(c)
-
-	cs.DiscoveryClient = discovery.NewDiscoveryClientForConfigOrDie(c)
-	return &cs
+	cs, err := NewForConfig(c)
+	if err != nil {
+		panic(err)
+	}
+	return cs
 }
 
 // New creates a new Clientset for the given RESTClient.

--- a/staging/src/k8s.io/sample-controller/pkg/generated/clientset/versioned/typed/samplecontroller/v1alpha1/foo.go
+++ b/staging/src/k8s.io/sample-controller/pkg/generated/clientset/versioned/typed/samplecontroller/v1alpha1/foo.go
@@ -69,6 +69,7 @@ func (c *foos) Get(ctx context.Context, name string, options v1.GetOptions) (res
 	result = &v1alpha1.Foo{}
 	err = c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(v1alpha1.SchemeGroupVersion).
 		Resource("foos").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
@@ -86,6 +87,7 @@ func (c *foos) List(ctx context.Context, opts v1.ListOptions) (result *v1alpha1.
 	result = &v1alpha1.FooList{}
 	err = c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(v1alpha1.SchemeGroupVersion).
 		Resource("foos").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -103,6 +105,7 @@ func (c *foos) Watch(ctx context.Context, opts v1.ListOptions) (watch.Interface,
 	opts.Watch = true
 	return c.client.Get().
 		Namespace(c.ns).
+		GroupVersion(v1alpha1.SchemeGroupVersion).
 		Resource("foos").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -114,6 +117,7 @@ func (c *foos) Create(ctx context.Context, foo *v1alpha1.Foo, opts v1.CreateOpti
 	result = &v1alpha1.Foo{}
 	err = c.client.Post().
 		Namespace(c.ns).
+		GroupVersion(v1alpha1.SchemeGroupVersion).
 		Resource("foos").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Body(foo).
@@ -127,6 +131,7 @@ func (c *foos) Update(ctx context.Context, foo *v1alpha1.Foo, opts v1.UpdateOpti
 	result = &v1alpha1.Foo{}
 	err = c.client.Put().
 		Namespace(c.ns).
+		GroupVersion(v1alpha1.SchemeGroupVersion).
 		Resource("foos").
 		Name(foo.Name).
 		VersionedParams(&opts, scheme.ParameterCodec).
@@ -142,6 +147,7 @@ func (c *foos) UpdateStatus(ctx context.Context, foo *v1alpha1.Foo, opts v1.Upda
 	result = &v1alpha1.Foo{}
 	err = c.client.Put().
 		Namespace(c.ns).
+		GroupVersion(v1alpha1.SchemeGroupVersion).
 		Resource("foos").
 		Name(foo.Name).
 		SubResource("status").
@@ -156,6 +162,7 @@ func (c *foos) UpdateStatus(ctx context.Context, foo *v1alpha1.Foo, opts v1.Upda
 func (c *foos) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
 	return c.client.Delete().
 		Namespace(c.ns).
+		GroupVersion(v1alpha1.SchemeGroupVersion).
 		Resource("foos").
 		Name(name).
 		Body(&opts).
@@ -171,6 +178,7 @@ func (c *foos) DeleteCollection(ctx context.Context, opts v1.DeleteOptions, list
 	}
 	return c.client.Delete().
 		Namespace(c.ns).
+		GroupVersion(v1alpha1.SchemeGroupVersion).
 		Resource("foos").
 		VersionedParams(&listOpts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -184,6 +192,7 @@ func (c *foos) Patch(ctx context.Context, name string, pt types.PatchType, data 
 	result = &v1alpha1.Foo{}
 	err = c.client.Patch(pt).
 		Namespace(c.ns).
+		GroupVersion(v1alpha1.SchemeGroupVersion).
 		Resource("foos").
 		Name(name).
 		SubResource(subresources...).


### PR DESCRIPTION
/kind feature
/kind bug

Building on top of https://github.com/kubernetes/kubernetes/pull/97821 , allow to set the groupVersion per request and to create a RESTClient without the groupVersion set.

It defaults to the configured one, if set, for backwards compatibility.

There are multiple issues related
https://github.com/kubernetes/kubernetes/issues/100849
https://github.com/kubernetes/kubernetes/issues/103224

The end goal is to have a single transport for everything ...

```
	// create the RESTClient
	r, err := rest.RESTClientFor(config)
	if err != nil {
		panic(err.Error())
	}
        // create the clientset
	clientset := kubernetes.New(r)
```

```release-note
RESTClient allows to set the group and version
```

