### PR TITLE
Revert "Build non-static binaries with PIE buildmode"

### DIFF
--- a/hack/lib/golang.sh
+++ b/hack/lib/golang.sh
@@ -412,10 +412,6 @@ kube::golang::set_platform_envs() {
         export CGO_ENABLED=1
         export CC=${KUBE_LINUX_AMD64_CC:-x86_64-linux-gnu-gcc}
         ;;
-      "linux/386")
-        export CGO_ENABLED=1
-        export CC=${KUBE_LINUX_386_CC:-i686-linux-gnu-gcc}
-        ;;
       "linux/arm")
         export CGO_ENABLED=1
         export CC=${KUBE_LINUX_ARM_CC:-arm-linux-gnueabihf-gcc}
@@ -726,7 +722,6 @@ kube::golang::build_binaries_for_platform() {
       -gcflags "${gogcflags:-}"
       -asmflags "${goasmflags:-}"
       -ldflags "${goldflags:-}"
-      -buildmode pie
       -tags "${gotags:-}"
     )
     V=1 kube::log::info "> non-static build: ${nonstatics[*]}"


### PR DESCRIPTION
Reverts kubernetes/kubernetes#102323

In https://github.com/kubernetes/kubernetes/issues/105294 we identified that this change has caused a ~30% memory utilization increase for the Kubelet in 1.22.

As far as I'm aware, there were no comms from SIG Release on making this change on k-dev or in the release note regarding what the possible impact would be; we found the memory increase while investigating regressions and had to perform a full git tree bisect to pinpoint it.

I see there is discussion in https://github.com/kubernetes/kubernetes/pull/102323/#issuecomment-848649664 around the individual binary sizes, but not on ASLR's impact on memory utilization. If this impacted Kubelet, it likely impacted other components as well. 

I'd like to have a wider discussion on the impact of turning this feature on. Have we seen any evidence of attacks against Golang binaries that exploit this? +30% is a significant memory regression, especially in resource-constrained environments, and I want to make sure that we understand the tradeoffs.

/sig node release security
/kind regression
/priority important-soon

```release-note
Revert building binaries with PIE mode.
```