### PR TITLE
Add PodSecurity Webhook Container Image + Manifests

### DIFF
--- a/staging/src/k8s.io/pod-security-admission/.gitignore
+++ b/staging/src/k8s.io/pod-security-admission/.gitignore
@@ -1,0 +1,2 @@
+# Webhook binary
+pod-security-webhook

--- a/staging/src/k8s.io/pod-security-admission/webhook/Dockerfile
+++ b/staging/src/k8s.io/pod-security-admission/webhook/Dockerfile
@@ -1,0 +1,19 @@
+# Copyright 2021 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM gcr.io/distroless/static:latest
+
+COPY pod-security-webhook /pod-security-webhook
+
+ENTRYPOINT [ "/pod-security-webhook" ]

--- a/staging/src/k8s.io/pod-security-admission/webhook/Makefile
+++ b/staging/src/k8s.io/pod-security-admission/webhook/Makefile
@@ -1,0 +1,49 @@
+# Copyright 2021 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+.PHONY: build container push clean
+
+ENTRYPOINT = "../cmd/webhook/webhook.go"
+EXECUTABLE = "pod-security-webhook"
+
+IMAGE_DOCKERFILE = "Dockerfile"
+REGISTRY ?= "gcr.io/k8s-staging-sig-auth"
+IMAGE ?= "$(REGISTRY)/pod-security-webhook"
+TAG ?= "latest"
+
+OS ?= linux
+ARCH ?= amd64
+
+# Builds the PodSecurity webhook binary.
+build:
+	@echo Building PodSecurity webhook...
+	@GOOS=$(OS) GOARCH=$(ARCH) CGO_ENABLED=0 \
+		go build -o $(EXECUTABLE) $(ENTRYPOINT)
+	@echo Done!
+
+# Builds the PodSecurity webhook Docker image.
+container: build
+	@echo Building PodSecurity webhook image...
+	@docker build \
+		-f $(IMAGE_DOCKERFILE) \
+		-t $(IMAGE):$(TAG) .
+	@echo Done!
+
+# Publishes the PodSecurity webhook Docker image to the configured registry.
+push:
+	@docker push $(IMAGE):$(TAG)
+
+# Removes Pod Security Webhook artifacts.
+clean:
+	rm $(EXECUTABLE)

--- a/staging/src/k8s.io/pod-security-admission/webhook/README.md
+++ b/staging/src/k8s.io/pod-security-admission/webhook/README.md
@@ -1,0 +1,44 @@
+# Pod Security Admission Webhook
+
+This directory contains files for a _Validating Admission Webhook_ that checks for conformance to the Pod Security Standards. It is built with the same Go package as the [Pod Security Admission Controller](https://kubernetes.io/docs/concepts/security/pod-security-admission/). The webhook is suitable for environments where the built-in PodSecurity admission controller cannot be used.
+
+For more information, see the [Dynamic Admission Control](https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/) documentation on the Kubernetes website.
+
+## Getting Started
+
+The webhook is available as a Docker image that lives within the SIG-Auth container registry. In addition to the `Dockerfile` for the webhook, this directory also contains sample Kubernetes manifests that can be used to deploy the webhook to a Kubernetes cluster.
+
+### Configuring the Webhook Certificate
+
+You will need to provide a cert-key pair to serve the webhook securely. See the [Kubernetes documentation on certificates](https://kubernetes.io/docs/tasks/administer-cluster/certificates/#cfssl) for instructions on generating these files.
+
+```bash
+export CERT_PATH="..."
+export KEY_PATH="..."
+
+kubectl create secret tls pod-security-webhook -n pod-security-webhook \
+  --cert=$CERT_PATH \
+  --key=$KEY_PATH
+```
+
+### Deploying the Webhook
+
+Apply the manifests to install the webhook in your cluster:
+
+```bash
+kubectl apply -f manifests
+```
+
+Optionally, override the default configuration with [Kustomize](https://kustomize.io):
+
+```bash
+kustomize build $OVERLAY_DIRECTORY
+```
+
+### Configuring the Webhook
+
+Similar to the Pod Security Admission Controller, the webhook requires a configuration file to determine how incoming resources are validated. For real-world deployments, we highly recommend reviewing our [documentation on selecting appropriate policy levels](https://kubernetes.io/docs/tasks/configure-pod-container/migrate-from-psp/#steps).
+
+## Contributing
+
+Please see the [contributing guidelines](../CONTRIBUTING.md) in the parent directory for general information about contributing to this project.

--- a/staging/src/k8s.io/pod-security-admission/webhook/kustomization.yaml
+++ b/staging/src/k8s.io/pod-security-admission/webhook/kustomization.yaml
@@ -1,0 +1,10 @@
+resources:
+- manifests/clusterrole.yaml
+- manifests/clusterrolebinding.yaml
+- manifests/configmap.yaml
+- manifests/deployment.yaml
+- manifests/namespace.yaml
+- manifests/secret.yaml
+- manifests/service.yaml
+- manifests/serviceaccount.yaml
+- manifests/validatingwebhookconfiguration.yaml

--- a/staging/src/k8s.io/pod-security-admission/webhook/manifests/clusterrole.yaml
+++ b/staging/src/k8s.io/pod-security-admission/webhook/manifests/clusterrole.yaml
@@ -1,0 +1,8 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: pod-security-webhook
+rules:
+  - apiGroups: [""]
+    resources: ["pods", "namespaces"]
+    verbs: ["get", "watch", "list"]

--- a/staging/src/k8s.io/pod-security-admission/webhook/manifests/clusterrolebinding.yaml
+++ b/staging/src/k8s.io/pod-security-admission/webhook/manifests/clusterrolebinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: pod-security-webhook
+subjects:
+  - kind: ServiceAccount
+    name: pod-security-webhook
+    namespace: pod-security-webhook
+roleRef:
+  kind: ClusterRole
+  name: pod-security-webhook
+  apiGroup: rbac.authorization.k8s.io

--- a/staging/src/k8s.io/pod-security-admission/webhook/manifests/configmap.yaml
+++ b/staging/src/k8s.io/pod-security-admission/webhook/manifests/configmap.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: pod-security-webhook
+  namespace: pod-security-webhook
+data:
+  podsecurityconfiguration.yaml: |
+    apiVersion: pod-security.admission.config.k8s.io/v1alpha1
+    kind: PodSecurityConfiguration
+    defaults:
+      enforce: "baseline"
+      enforce-version: "latest"
+      audit: "restricted"
+      audit-version: "latest"
+      warn: "restricted"
+      warn-version: "latest"
+    exemptions:
+      usernames: []
+      namespaces: []
+      runtimeClasses: []

--- a/staging/src/k8s.io/pod-security-admission/webhook/manifests/deployment.yaml
+++ b/staging/src/k8s.io/pod-security-admission/webhook/manifests/deployment.yaml
@@ -1,0 +1,62 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: pod-security-webhook
+  namespace: pod-security-webhook
+  labels:
+    app: pod-security-webhook
+spec:
+  selector:
+    matchLabels:
+      app: pod-security-webhook
+  template:
+    metadata:
+      labels:
+        app: pod-security-webhook
+    spec:
+      serviceAccountName: pod-security-webhook
+      priorityClassName: system-cluster-critical
+      volumes:
+        - name: config
+          configMap:
+            name: pod-security-webhook
+        - name: pki
+          secret:
+            secretName: pod-security-webhook
+      containers:
+        - name: pod-security-webhook
+          image: samuelroth/pod-security-webhook:latest
+          # image: k8s.gcr.io/sig-auth/pod-security-webhook:v1.22-alpha.0
+          ports:
+            - containerPort: 8443
+          command: ["/pod-security-webhook"]
+          args:
+            [
+              "--config",
+              "/etc/config/podsecurityconfiguration.yaml",
+              "--tls-cert-file",
+              "/etc/pki/tls.crt",
+              "--tls-private-key-file",
+              "/etc/pki/tls.key",
+            ]
+          resources:
+            requests:
+              cpu: "0.25"
+            limits:
+              cpu: "0.5"
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            runAsNonRoot: true
+            runAsUser: 1000
+            seccompProfile:
+              type: RuntimeDefault
+          volumeMounts:
+            - name: config
+              mountPath: "/etc/config"
+              readOnly: true
+            - name: pki
+              mountPath: "/etc/pki"
+              readOnly: true

--- a/staging/src/k8s.io/pod-security-admission/webhook/manifests/namespace.yaml
+++ b/staging/src/k8s.io/pod-security-admission/webhook/manifests/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: pod-security-webhook

--- a/staging/src/k8s.io/pod-security-admission/webhook/manifests/secret.yaml
+++ b/staging/src/k8s.io/pod-security-admission/webhook/manifests/secret.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: pod-security-webhook
+  namespace: pod-security-webhook
+type: kubernetes.io/tls
+data:
+  tls.crt: Y2hhbmdlbWUK # changeme
+  tls.key: Y2hhbmdlbWUK # changeme

--- a/staging/src/k8s.io/pod-security-admission/webhook/manifests/service.yaml
+++ b/staging/src/k8s.io/pod-security-admission/webhook/manifests/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: webhook
+  namespace: pod-security-webhook
+  labels:
+    app: pod-security-webhook
+spec:
+  ports:
+    - port: 443
+      targetPort: 8443
+      protocol: TCP
+      name: https
+  selector:
+    app: pod-security-webhook

--- a/staging/src/k8s.io/pod-security-admission/webhook/manifests/serviceaccount.yaml
+++ b/staging/src/k8s.io/pod-security-admission/webhook/manifests/serviceaccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: pod-security-webhook
+  namespace: pod-security-webhook

--- a/staging/src/k8s.io/pod-security-admission/webhook/manifests/validatingwebhookconfiguration.yaml
+++ b/staging/src/k8s.io/pod-security-admission/webhook/manifests/validatingwebhookconfiguration.yaml
@@ -1,0 +1,68 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: "webhook.pod-security-webhook.svc.cluster.local"
+webhooks:
+  - name: "webhook.pod-security-webhook.svc.cluster.local"
+    # Fail-closed admission webhooks can present operational challenges.
+    # You may want to consider using a failure policy of Ignore, but should 
+    # consider the security tradeoffs.
+    failurePolicy: Fail
+    namespaceSelector:
+      # Exempt the webhook itself to avoid a circular dependency.
+      matchExpressions:
+        - key: kubernetes.io/metadata.name
+          operator: NotIn
+          values: ["pod-security-webhook"]
+    rules:
+      - apiGroups: [""]
+        apiVersions: ["v1"]
+        operations: ["CREATE", "UPDATE"]
+        resources:
+          - namespaces
+          - pods
+          - pods/ephemeralcontainers
+    clientConfig:
+      service:
+        namespace: "pod-security-webhook"
+        name: "webhook"
+    admissionReviewVersions: ["v1"]
+    sideEffects: None
+    timeoutSeconds: 5
+
+  # Non-enforcing resources can safely fail-open.
+  - name: "webhook-advisory.pod-security-webhook.svc.cluster.local"
+    failurePolicy: Ignore
+    namespaceSelector:
+      matchExpressions:
+        - key: kubernetes.io/metadata.name
+          operator: NotIn
+          values: ["pod-security-webhook"]
+    rules:
+      - apiGroups: [""]
+        apiVersions: ["v1"]
+        operations: ["CREATE", "UPDATE"]
+        resources:
+          - podtemplates
+          - replicationcontrollers
+      - apiGroups: ["apps"]
+        apiVersions: ["v1"]
+        operations: ["CREATE", "UPDATE"]
+        resources:
+          - daemonsets
+          - deployments
+          - replicasets
+          - statefulsets
+      - apiGroups: ["batch"]
+        apiVersions: ["v1"]
+        operations: ["CREATE", "UPDATE"]
+        resources:
+          - cronjobs
+          - jobs
+    clientConfig:
+      service:
+        namespace: "pod-security-webhook"
+        name: "webhook"
+    admissionReviewVersions: ["v1"]
+    sideEffects: None
+    timeoutSeconds: 5


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/sig auth
/kind feature

#### What this PR does / why we need it:

This PR adds the Docker image and necessary manifests to use the PodSecurity webhook server. This is a [validating admission webhook](https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#validatingadmissionwebhook) that checks if submitted pods conform to the configured Pod Security Standards.

#### Which issue(s) this PR fixes:

Resolves #103559

#### Special notes for your reviewer:

WIP. We'd like to publish this image with other Kubernetes artifacts.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Added a Docker image and manifests for the PodSecurity validating admission webhook. This webhook can used to ensure that pods conform to the Pod Security Standards.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
