### PR TITLE
use kubectl proxy --append-server-path for e2e proxy [Conformance] test

### DIFF
--- a/test/e2e/kubectl/kubectl.go
+++ b/test/e2e/kubectl/kubectl.go
@@ -1910,7 +1910,7 @@ func getAPIVersions(apiEndpoint string) (*metav1.APIVersions, error) {
 func startProxyServer(ns string) (int, *exec.Cmd, error) {
 	// Specifying port 0 indicates we want the os to pick a random port.
 	tk := e2ekubectl.NewTestKubeconfig(framework.TestContext.CertDir, framework.TestContext.Host, framework.TestContext.KubeConfig, framework.TestContext.KubeContext, framework.TestContext.KubectlPath, ns)
-	cmd := tk.KubectlCmd("proxy", "-p", "0", "--disable-filter")
+	cmd := tk.KubectlCmd("proxy", "-p", "0", "--disable-filter", "--append-server-path")
 	stdout, stderr, err := framework.StartCmdAndStreamOutput(cmd)
 	if err != nil {
 		return -1, nil, err


### PR DESCRIPTION
Signed-off-by: Sven Dowideit <sven.dowideit@portainer.io>

#### What type of PR is this?

/kind bug
/kind failing-test


#### What this PR does / why we need it:

our Kube API proxy server uses a setting like `server: https://100.90.14.63:9011/api/endpoints/1/kubernetes` and without this change, `go test ./test/e2e/ -v -timeout=0 -ginkgo.focus='should support proxy with --port 0'` fails.

the `--append-server-path` functionality was added in 1.23, this just uses it in the e2e test.
see https://github.com/kubernetes/kubernetes/pull/97350

#### Which issue(s) this PR fixes:


#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

