### PR TITLE
Fail to create static pod referencing ServiceAccount

### DIFF
--- a/pkg/kubelet/config/common.go
+++ b/pkg/kubelet/config/common.go
@@ -165,3 +165,10 @@ func tryDecodePodList(data []byte, defaultFn defaultFunc) (parsed bool, pods v1.
 	}
 	return true, *v1Pods, err
 }
+
+func validateStaticPod(pod *v1.Pod) error {
+	if pod.Spec.ServiceAccountName != "" {
+		return fmt.Errorf("static pod %s cannot reference service account", pod.Name)
+	}
+	return nil
+}

--- a/pkg/kubelet/config/file.go
+++ b/pkg/kubelet/config/file.go
@@ -230,7 +230,7 @@ func (s *sourceFile) extractFromFile(filename string) (pod *v1.Pod, err error) {
 		if podErr != nil {
 			return pod, podErr
 		}
-		return pod, nil
+		return pod, validateStaticPod(pod)
 	}
 
 	return pod, fmt.Errorf("%v: couldn't parse as pod(%v), please check config file", filename, podErr)

--- a/pkg/kubelet/config/http.go
+++ b/pkg/kubelet/config/http.go
@@ -118,6 +118,9 @@ func (s *sourceURL) extractFromURL() error {
 			// It parsed but could not be used.
 			return singlePodErr
 		}
+		if singlePodErr = validateStaticPod(pod); singlePodErr != nil {
+			return singlePodErr
+		}
 		s.updates <- kubetypes.PodUpdate{Pods: []*v1.Pod{pod}, Op: kubetypes.SET, Source: kubetypes.HTTPSource}
 		return nil
 	}
@@ -128,6 +131,11 @@ func (s *sourceURL) extractFromURL() error {
 		if multiPodErr != nil {
 			// It parsed but could not be used.
 			return multiPodErr
+		}
+		for i := range podList.Items {
+			if singlePodErr = validateStaticPod(&podList.Items[i]); singlePodErr != nil {
+				return singlePodErr
+			}
 		}
 		pods := make([]*v1.Pod, 0, len(podList.Items))
 		for i := range podList.Items {

--- a/pkg/kubelet/config/http_test.go
+++ b/pkg/kubelet/config/http_test.go
@@ -104,6 +104,16 @@ func TestExtractInvalidPods(t *testing.T) {
 				},
 			},
 		},
+		{
+			desc: "Static pod referencing service account",
+			pod: &v1.Pod{
+				TypeMeta: metav1.TypeMeta{APIVersion: "v1"},
+				Spec: v1.PodSpec{
+					Containers:         []v1.Container{{Name: "test"}},
+					ServiceAccountName: "default",
+				},
+			},
+		},
 	}
 	for _, testCase := range testCases {
 		data, err := json.Marshal(testCase.pod)


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/sig node

#### What this PR does / why we need it:

Kubelet can create static pods that reference ServiceAccount,
which should not be possible according to the [Kubernetes
Documentaion](https://kubernetes.io/docs/tasks/configure-pod-container/static-pod/)

This PR introduces new validation check that ensures
that static pod doesn't refer service accounts.

#### Which issue(s) this PR fixes:
Fixes #103587

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
bugfix: kubelet doesn't allow to create static pods referring service accounts anymore
```