### PR TITLE
node: test file use k8s.io/utils/clock instead

### DIFF
--- a/pkg/controller/nodelifecycle/scheduler/timed_workers.go
+++ b/pkg/controller/nodelifecycle/scheduler/timed_workers.go
@@ -22,8 +22,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/klog/v2"
-	// TODO: Switch to k8s.io/utils/clock once it supports AfterFunc()
-	"k8s.io/apimachinery/pkg/util/clock"
+	"k8s.io/utils/clock"
 )
 
 // WorkArgs keeps arguments that will be passed to the function executed by the worker.
@@ -50,7 +49,7 @@ type TimedWorker struct {
 }
 
 // createWorker creates a TimedWorker that will execute `f` not earlier than `fireAt`.
-func createWorker(args *WorkArgs, createdAt time.Time, fireAt time.Time, f func(args *WorkArgs) error, clock clock.Clock) *TimedWorker {
+func createWorker(args *WorkArgs, createdAt time.Time, fireAt time.Time, f func(args *WorkArgs) error, clock clock.WithDelayedExecution) *TimedWorker {
 	delay := fireAt.Sub(createdAt)
 	if delay <= 0 {
 		go f(args)
@@ -78,7 +77,7 @@ type TimedWorkerQueue struct {
 	// map of workers keyed by string returned by 'KeyFromWorkArgs' from the given worker.
 	workers  map[string]*TimedWorker
 	workFunc func(args *WorkArgs) error
-	clock    clock.Clock
+	clock    clock.WithDelayedExecution
 }
 
 // CreateWorkerQueue creates a new TimedWorkerQueue for workers that will execute

--- a/pkg/controller/nodelifecycle/scheduler/timed_workers_test.go
+++ b/pkg/controller/nodelifecycle/scheduler/timed_workers_test.go
@@ -22,7 +22,7 @@ import (
 	"testing"
 	"time"
 
-	"k8s.io/apimachinery/pkg/util/clock"
+	testingclock "k8s.io/utils/clock/testing"
 )
 
 func TestExecute(t *testing.T) {
@@ -64,7 +64,7 @@ func TestExecuteDelayed(t *testing.T) {
 	})
 	now := time.Now()
 	then := now.Add(10 * time.Second)
-	fakeClock := clock.NewFakeClock(now)
+	fakeClock := testingclock.NewFakeClock(now)
 	queue.clock = fakeClock
 	queue.AddWork(NewWorkArgs("1", "1"), now, then)
 	queue.AddWork(NewWorkArgs("2", "2"), now, then)
@@ -95,7 +95,7 @@ func TestCancel(t *testing.T) {
 	})
 	now := time.Now()
 	then := now.Add(10 * time.Second)
-	fakeClock := clock.NewFakeClock(now)
+	fakeClock := testingclock.NewFakeClock(now)
 	queue.clock = fakeClock
 	queue.AddWork(NewWorkArgs("1", "1"), now, then)
 	queue.AddWork(NewWorkArgs("2", "2"), now, then)
@@ -128,7 +128,7 @@ func TestCancelAndReadd(t *testing.T) {
 	})
 	now := time.Now()
 	then := now.Add(10 * time.Second)
-	fakeClock := clock.NewFakeClock(now)
+	fakeClock := testingclock.NewFakeClock(now)
 	queue.clock = fakeClock
 	queue.AddWork(NewWorkArgs("1", "1"), now, then)
 	queue.AddWork(NewWorkArgs("2", "2"), now, then)

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1398,7 +1398,6 @@ k8s.io/apimachinery/pkg/runtime/serializer/yaml
 k8s.io/apimachinery/pkg/selection
 k8s.io/apimachinery/pkg/types
 k8s.io/apimachinery/pkg/util/cache
-k8s.io/apimachinery/pkg/util/clock
 k8s.io/apimachinery/pkg/util/diff
 k8s.io/apimachinery/pkg/util/duration
 k8s.io/apimachinery/pkg/util/errors


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

replace `k8s.io/apimachinery/pkg/util/clock` with `k8s.io/utils/clock`  since [kubernetes/utils#221](https://github.com/kubernetes/utils/pull/221) has been merged

#### Special notes for your reviewer:

