### PR TITLE
pkg/volume/util: remove out-dated OWNERS

### DIFF
--- a/pkg/volume/util/OWNERS
+++ b/pkg/volume/util/OWNERS
@@ -1,8 +1,0 @@
-# See the OWNERS docs at https://go.k8s.io/owners
-
-approvers:
-- saad-ali
-reviewers:
-- saad-ali
-- rootfs
-- jingxu97


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

There is no reason for having separate owners for this folder. The parent
folder has a much better OWNERS file with references to the SIG-Storage
aliases.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

/cc @msau42 @xing-yang 