### PR TITLE
Fix CSR test to accept certs shorter than the requested duration

### DIFF
--- a/test/e2e/auth/certificates.go
+++ b/test/e2e/auth/certificates.go
@@ -166,7 +166,10 @@ var _ = SIGDescribe("Certificates API [Privileged:ClusterAdmin]", func() {
 		framework.ExpectNoError(err)
 		framework.ExpectEqual(len(certs), 1, "expected a single cert, got %#v", certs)
 		cert := certs[0]
-		framework.ExpectEqual(cert.NotAfter.Sub(cert.NotBefore), time.Hour+5*time.Minute, "unexpected cert duration: %s", dynamiccertificates.GetHumanCertDetail(cert))
+		// make sure the cert is not valid for longer than our requested time (plus allowance for backdating)
+		if e, a := time.Hour+5*time.Minute, cert.NotAfter.Sub(cert.NotBefore); a > e {
+			framework.Failf("expected cert valid for %s or less, got %s: %s", e, a, dynamiccertificates.GetHumanCertDetail(cert))
+		}
 
 		newClient, err := certificatesclient.NewForConfig(rcfg)
 		framework.ExpectNoError(err)


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Signers are free to sign certificates for shorter than the requested duration. Fix the test to only check a max, rather than require an exact duration match.

```release-note
Fixes the `should support building a client with a CSR` e2e test to work with clusters configured with short certificate lifetimes
```

/assign @enj 
/sig auth