### PR TITLE
Allow fast builds on ppc64le

### DIFF
--- a/hack/lib/golang.sh
+++ b/hack/lib/golang.sh
@@ -209,8 +209,8 @@ kube::golang::setup_platforms() {
 
   elif [[ "${KUBE_FASTBUILD:-}" == "true" ]]; then
     host_arch=$(kube::util::host_arch)
-    if [[ "${host_arch}" != "amd64" && "${host_arch}" != "arm64" ]]; then
-      # on any platform other than amd64 and arm64, we just default to amd64
+    if [[ "${host_arch}" != "amd64" && "${host_arch}" != "arm64" && "${host_arch}" != "ppc64le" ]]; then
+      # on any platform other than amd64, arm64 and ppc64le, we just default to amd64
       host_arch="amd64"
     fi
     KUBE_SERVER_PLATFORMS=("linux/${host_arch}")


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

On a ppc64le host, fast build was failing:

    # make KUBE_FASTBUILD=true quick-release
    +++ [0908 15:56:36] Verifying Prerequisites....
    +++ [0908 15:56:36] Building Docker image kube-build:build-fd009aaa81-5-v1.23.0-go1.17-buster.0
    +++ [0908 15:56:44] Syncing sources to container
    +++ [0908 15:56:48] Running build command...
    +++ [0908 15:56:56] Building go targets for linux/ppc64le:
        ./vendor/k8s.io/code-generator/cmd/prerelease-lifecycle-gen
    > non-static build: k8s.io/kubernetes/./vendor/k8s.io/code-generator/cmd/prerelease-lifecycle-gen
    touch: cannot touch '_output/bin/prerelease-lifecycle-gen': No such file or directory
    make[2]: *** [Makefile.generated_files:209: _output/bin/prerelease-lifecycle-gen] Error 1
    make[1]: *** [Makefile:552: generated_files] Error 2
    make: *** [Makefile:512: cross] Error 1
    !!! [0908 15:56:58] Call tree:
    !!! [0908 15:56:58]  1: build/../build/common.sh:476 kube::build::run_build_command_ex(...)
    !!! [0908 15:56:58]  2: build/release.sh:36 kube::build::run_build_command(...)
    make: *** [Makefile:454: quick-release] Error 1

This error happened because the _output/bin/ directory didn't exist at
the moment the file _output/bin/prerelease-lifecycle-gen was touched, so
the path didn't exist.

The _output/bin symlink was not created by kube::golang::place_bins()
because kube::golang::setup_platforms() assumed
KUBE_CLIENT_PLATFORMS=linux/amd64 despite being on a ppc64le host.

Fix build error by not assuming host_arch=amd64 when on ppc64le in
kube::golang::setup_platforms().

#### Which issue(s) this PR fixes:

Fixes #105398

#### Special notes for your reviewer:

This is a minor fix to allow building fast builds on a ppc64le host.  Change does not affect other architectures.

#### Does this PR introduce a user-facing change?

NONE

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.: