### PR TITLE
apf: print watch initialization latency in httplog

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/server/filters/priority-and-fairness.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/filters/priority-and-fairness.go
@@ -22,6 +22,7 @@ import (
 	"net/http"
 	"runtime"
 	"sync/atomic"
+	"time"
 
 	flowcontrol "k8s.io/api/flowcontrol/v1beta2"
 	apitypes "k8s.io/apimachinery/pkg/types"
@@ -176,6 +177,10 @@ func WithPriorityAndFairness(
 			}()
 
 			execute := func() {
+				startedAt := time.Now()
+				defer func() {
+					httplog.AddKeyValue(ctx, "apf_init_latency", time.Now().Sub(startedAt))
+				}()
 				noteExecutingDelta(1)
 				defer noteExecutingDelta(-1)
 				served = true


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:
show watch initialization latency in `httplog` for watch requests

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
