### PR TITLE
patch host-net pod status for changing node IPs

### DIFF
--- a/pkg/kubelet/kubelet_pods_test.go
+++ b/pkg/kubelet/kubelet_pods_test.go
@@ -3165,39 +3165,37 @@ func TestGenerateAPIPodStatusHostNetworkPodIPs(t *testing.T) {
 			},
 		},
 		{
-			name: "CRI PodIPs override NodeAddresses",
+			name: "single-stack CRI PodIPs DOES NOT override NodeAddresses",
 			nodeAddresses: []v1.NodeAddress{
 				{Type: v1.NodeInternalIP, Address: "10.0.0.1"},
-				{Type: v1.NodeInternalIP, Address: "fd01::1234"},
 			},
 			criPodIPs: []string{"192.168.0.1"},
 			podIPs: []v1.PodIP{
-				{IP: "192.168.0.1"},
+				{IP: "10.0.0.1"},
 			},
 		},
 		{
-			name: "CRI dual-stack PodIPs override NodeAddresses",
+			name: "CRI dual-stack PodIPs DOES NOT override NodeAddresses",
 			nodeAddresses: []v1.NodeAddress{
 				{Type: v1.NodeInternalIP, Address: "10.0.0.1"},
 				{Type: v1.NodeInternalIP, Address: "fd01::1234"},
 			},
 			criPodIPs: []string{"192.168.0.1", "2001:db8::2"},
 			podIPs: []v1.PodIP{
-				{IP: "192.168.0.1"},
-				{IP: "2001:db8::2"},
+				{IP: "10.0.0.1"},
+				{IP: "fd01::1234"},
 			},
 		},
 		{
-			// by default the cluster prefers IPv4
-			name: "CRI dual-stack PodIPs override NodeAddresses prefer IPv4",
+			name: "set according to ip family order of host and CRI DOES NOT override host IPs",
 			nodeAddresses: []v1.NodeAddress{
-				{Type: v1.NodeInternalIP, Address: "10.0.0.1"},
 				{Type: v1.NodeInternalIP, Address: "fd01::1234"},
+				{Type: v1.NodeInternalIP, Address: "10.0.0.1"},
 			},
 			criPodIPs: []string{"2001:db8::2", "192.168.0.1"},
 			podIPs: []v1.PodIP{
-				{IP: "192.168.0.1"},
-				{IP: "2001:db8::2"},
+				{IP: "fd01::1234"},
+				{IP: "10.0.0.1"},
 			},
 		},
 	}


### PR DESCRIPTION
 #### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
Pods using host-net does not get updated PodIPs when the host changes its own IPs. That happens in the following situation:
1. Voluntary by the user changing node IPs.
2. Racy specifically host-net static pods where they can start before cloud provider may have a chance to update node IPs.

This results in (static host-net) pods that are single stack on a dual stack cluster. Or host-net pods (all types) that are running with old node IPs.   


#### Which issue(s) this PR fixes:
Fixes #105320



#### Special notes for your reviewer:
Replaces https://github.com/kubernetes/kubernetes/pull/93898 in adds further change

#### Does this PR introduce a user-facing change?

```release-note
Pods that are running with host-net will get their `.Status.PodIP` `.Status.PodIPs` updated if the node they are running on are updated. Please note the following:
1. Containers running inside these pods will not be notified with the IP(s) change. Nor downward apis will change.
2. Pods that wants to operate correctly independently from nodeIP change **must** listen to `::0` if they need to listen to node IPs.

The behavior of static host-net pods has changed in cloud provider configured kubelet environment has changed. These pods could start before cloud provider gets a chance to set dual-stack or cloud specific IPs hence the IPs are set to local node IPs and don't change until they restart. With this PR this has changed and pod objects will be patched with correct node IP whenever it changes.  
```