### PR TITLE
Define and usse datatype for seat-seconds

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/queueset/queueset_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/queueset/queueset_test.go
@@ -247,7 +247,7 @@ type uniformScenarioThread struct {
 }
 
 func (ust *uniformScenarioThread) start() {
-	initialDelay := time.Duration(11*ust.j + 2*ust.i)
+	initialDelay := time.Duration(90*ust.j + 20*ust.i)
 	if ust.uc.split && ust.j >= ust.uc.nThreads/2 {
 		initialDelay += ust.uss.evalDuration / 2
 		ust.nCalls = ust.nCalls / 2
@@ -601,7 +601,7 @@ func TestUniformFlowsHandSize3(t *testing.T) {
 		concurrencyLimit:       4,
 		evalDuration:           time.Second * 60,
 		expectedFair:           []bool{true},
-		expectedFairnessMargin: []float64{0.01},
+		expectedFairnessMargin: []float64{0.03},
 		expectAllRequests:      true,
 		evalInqueueMetrics:     true,
 		evalExecutingMetrics:   true,
@@ -638,6 +638,46 @@ func TestDifferentFlowsExpectEqual(t *testing.T) {
 		concurrencyLimit:       4,
 		evalDuration:           time.Second * 40,
 		expectedFair:           []bool{true},
+		expectedFairnessMargin: []float64{0.01},
+		expectAllRequests:      true,
+		evalInqueueMetrics:     true,
+		evalExecutingMetrics:   true,
+		clk:                    clk,
+		counter:                counter,
+	}.exercise(t)
+}
+
+// TestSeatSecondsRollover demonstrates that SeatSeconds overflow can cause bad stuff to happen.
+func TestSeatSecondsRollover(t *testing.T) {
+	metrics.Register()
+	now := time.Now()
+
+	const Quarter = 91 * 24 * time.Hour
+
+	clk, counter := testeventclock.NewFake(now, 0, nil)
+	qsf := newTestableQueueSetFactory(clk, countingPromiseFactoryFactory(counter))
+	qCfg := fq.QueuingConfig{
+		Name:             "TestSeatSecondsRollover",
+		DesiredNumQueues: 9,
+		QueueLengthLimit: 8,
+		HandSize:         1,
+		RequestWaitLimit: 40 * Quarter,
+	}
+	qsc, err := qsf.BeginConstruction(qCfg, newObserverPair(clk))
+	if err != nil {
+		t.Fatal(err)
+	}
+	qs := qsc.Complete(fq.DispatchingConfig{ConcurrencyLimit: 2000})
+
+	uniformScenario{name: qCfg.Name,
+		qs: qs,
+		clients: []uniformClient{
+			newUniformClient(1001001001, 8, 20, Quarter, Quarter).seats(500),
+			newUniformClient(2002002002, 7, 30, Quarter, Quarter/2).seats(500),
+		},
+		concurrencyLimit:       2000,
+		evalDuration:           Quarter * 40,
+		expectedFair:           []bool{false},
 		expectedFairnessMargin: []float64{0.01},
 		expectAllRequests:      true,
 		evalInqueueMetrics:     true,
@@ -1073,7 +1113,7 @@ func TestTotalRequestsExecutingWithPanic(t *testing.T) {
 }
 
 func TestFindDispatchQueueLocked(t *testing.T) {
-	var G float64 = 0.003
+	const G = 3 * time.Millisecond
 	tests := []struct {
 		name                    string
 		robinIndex              int
@@ -1092,13 +1132,13 @@ func TestFindDispatchQueueLocked(t *testing.T) {
 			robinIndex:       -1,
 			queues: []*queue{
 				{
-					virtualStart: 200,
+					nextDispatchR: SeatsTimesDuration(1, 200*time.Second),
 					requests: newFIFO(
 						&request{workEstimate: fcrequest.WorkEstimate{InitialSeats: 1}},
 					),
 				},
 				{
-					virtualStart: 100,
+					nextDispatchR: SeatsTimesDuration(1, 100*time.Second),
 					requests: newFIFO(
 						&request{workEstimate: fcrequest.WorkEstimate{InitialSeats: 1}},
 					),
@@ -1115,7 +1155,7 @@ func TestFindDispatchQueueLocked(t *testing.T) {
 			robinIndex:       -1,
 			queues: []*queue{
 				{
-					virtualStart: 200,
+					nextDispatchR: SeatsTimesDuration(1, 200*time.Second),
 					requests: newFIFO(
 						&request{workEstimate: fcrequest.WorkEstimate{InitialSeats: 1}},
 					),
@@ -1132,13 +1172,13 @@ func TestFindDispatchQueueLocked(t *testing.T) {
 			robinIndex:       -1,
 			queues: []*queue{
 				{
-					virtualStart: 200,
+					nextDispatchR: SeatsTimesDuration(1, 200*time.Second),
 					requests: newFIFO(
 						&request{workEstimate: fcrequest.WorkEstimate{InitialSeats: 50}},
 					),
 				},
 				{
-					virtualStart: 100,
+					nextDispatchR: SeatsTimesDuration(1, 100*time.Second),
 					requests: newFIFO(
 						&request{workEstimate: fcrequest.WorkEstimate{InitialSeats: 25}},
 					),
@@ -1155,13 +1195,13 @@ func TestFindDispatchQueueLocked(t *testing.T) {
 			robinIndex:       -1,
 			queues: []*queue{
 				{
-					virtualStart: 200,
+					nextDispatchR: SeatsTimesDuration(1, 200*time.Second),
 					requests: newFIFO(
 						&request{workEstimate: fcrequest.WorkEstimate{InitialSeats: 10}},
 					),
 				},
 				{
-					virtualStart: 100,
+					nextDispatchR: SeatsTimesDuration(1, 100*time.Second),
 					requests: newFIFO(
 						&request{workEstimate: fcrequest.WorkEstimate{InitialSeats: 25}},
 					),
@@ -1178,13 +1218,13 @@ func TestFindDispatchQueueLocked(t *testing.T) {
 			robinIndex:       -1,
 			queues: []*queue{
 				{
-					virtualStart: 200,
+					nextDispatchR: SeatsTimesDuration(1, 200*time.Second),
 					requests: newFIFO(
 						&request{workEstimate: fcrequest.WorkEstimate{InitialSeats: 10}},
 					),
 				},
 				{
-					virtualStart: 100,
+					nextDispatchR: SeatsTimesDuration(1, 100*time.Second),
 					requests: newFIFO(
 						&request{workEstimate: fcrequest.WorkEstimate{InitialSeats: 25}},
 					),
@@ -1204,10 +1244,10 @@ func TestFindDispatchQueueLocked(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			qs := &queueSet{
-				estimatedServiceSeconds: G,
-				robinIndex:              test.robinIndex,
-				totSeatsInUse:           test.totSeatsInUse,
-				qCfg:                    fq.QueuingConfig{Name: "TestSelectQueueLocked/" + test.name},
+				estimatedServiceDuration: G,
+				robinIndex:               test.robinIndex,
+				totSeatsInUse:            test.totSeatsInUse,
+				qCfg:                     fq.QueuingConfig{Name: "TestSelectQueueLocked/" + test.name},
 				dCfg: fq.DispatchingConfig{
 					ConcurrencyLimit: test.concurrencyLimit,
 				},

--- a/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/queueset/seatsecs_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/queueset/seatsecs_test.go
@@ -1,0 +1,45 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package queueset
+
+import (
+	"fmt"
+	"math"
+	"testing"
+	"time"
+)
+
+func TestSeatSecondsString(t *testing.T) {
+	digits := math.Log10(ssScale)
+	expectFmt := fmt.Sprintf("%%%d.%dfss", int(digits+2), int(digits))
+	testCases := []struct {
+		ss     SeatSeconds
+		expect string
+	}{
+		{ss: SeatSeconds(1), expect: fmt.Sprintf(expectFmt, 1.0/ssScale)},
+		{ss: 0, expect: "0.00000000ss"},
+		{ss: SeatsTimesDuration(1, time.Second), expect: "1.00000000ss"},
+		{ss: SeatsTimesDuration(123, 100*time.Millisecond), expect: "12.30000000ss"},
+		{ss: SeatsTimesDuration(1203, 10*time.Millisecond), expect: "12.03000000ss"},
+	}
+	for _, testCase := range testCases {
+		actualStr := testCase.ss.String()
+		if actualStr != testCase.expect {
+			t.Errorf("SeatSeonds(%d) formatted as %q rather than expected %q", uint64(testCase.ss), actualStr, testCase.expect)
+		}
+	}
+}

--- a/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/queueset/types.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/queueset/types.go
@@ -62,7 +62,7 @@ type request struct {
 	arrivalTime time.Time
 
 	// arrivalR is R(arrivalTime).  R is, confusingly, also called "virtual time".
-	arrivalR float64
+	arrivalR SeatSeconds
 
 	// descr1 and descr2 are not used in any logic but they appear in
 	// log messages
@@ -84,9 +84,9 @@ type queue struct {
 	// The requests not yet executing in the real world are stored in a FIFO list.
 	requests fifo
 
-	// virtualStart is the "virtual time" (R progress meter reading) at
+	// nextDispatchR is the R progress meter reading at
 	// which the next request will be dispatched in the virtual world.
-	virtualStart float64
+	nextDispatchR SeatSeconds
 
 	// requestsExecuting is the count in the real world
 	requestsExecuting int
@@ -130,7 +130,7 @@ func (q *queue) dump(includeDetails bool) debug.QueueDump {
 		return true
 	})
 	return debug.QueueDump{
-		VirtualStart:      q.virtualStart,
+		VirtualStart:      q.nextDispatchR.ToFloat(), // TODO: change QueueDump to use SeatSeconds
 		Requests:          digest,
 		ExecutingRequests: q.requestsExecuting,
 		SeatsInUse:        q.seatsInUse,

--- a/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/queueset/types.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/queueset/types.go
@@ -18,6 +18,8 @@ package queueset
 
 import (
 	"context"
+	"fmt"
+	"math"
 	"time"
 
 	genericrequest "k8s.io/apiserver/pkg/endpoints/request"
@@ -134,3 +136,39 @@ func (q *queue) dump(includeDetails bool) debug.QueueDump {
 		SeatsInUse:        q.seatsInUse,
 	}
 }
+
+// SeatSeconds is a measure of work, in units of seat-seconds, using a fixed-point representation.
+// `SeatSeconds(n)` represents `n/ssScale` seat-seconds.
+// The constants `ssScale` and `ssScaleDigits` are private to the implementation here,
+// no other code should use them.
+type SeatSeconds uint64
+
+// MaxSeatsSeconds is the maximum representable value of SeatSeconds
+const MaxSeatSeconds = SeatSeconds(math.MaxUint64)
+
+// MinSeatSeconds is the lowest representable value of SeatSeconds
+const MinSeatSeconds = SeatSeconds(0)
+
+// SeatsTimeDuration produces the SeatSeconds value for the given factors.
+// This is intended only to produce small values, increments in work
+// rather than amount of work done since process start.
+func SeatsTimesDuration(seats float64, duration time.Duration) SeatSeconds {
+	return SeatSeconds(math.Round(seats * float64(duration/time.Nanosecond) / (1e9 / ssScale)))
+}
+
+// ToFloat converts to a floating-point representation.
+// This conversion may lose precision.
+func (ss SeatSeconds) ToFloat() float64 {
+	return float64(ss) / ssScale
+}
+
+// String converts to a string.
+// This is suitable for large as well as small values.
+func (ss SeatSeconds) String() string {
+	const div = SeatSeconds(ssScale)
+	quo := ss / div
+	rem := ss - quo*div
+	return fmt.Sprintf("%d.%08dss", quo, rem)
+}
+
+const ssScale = 1e8


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind cleanup

#### What this PR does / why we need it:
The first commit of this PR defines a fixed-point datatype for seat-seconds.

The second commit of this PR revises the queueset code to use the new datatype in place of `float64`.  This includes a little relaxation of one queueset unit test to keep it passing, and making the staggering of events larger so that it does not get lost in the truncation.  This PR also renames the fields that held seat-seconds values.

The third commit adds code to prevent overflow of the global progress meter R.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:
This is an alternative to #105322 , defining a datatype for the new representation.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
