### PR TITLE
Add named container validation -- Show errors for duplicated named ports.

### DIFF
--- a/pkg/apis/core/v1/validation/validation.go
+++ b/pkg/apis/core/v1/validation/validation.go
@@ -156,8 +156,10 @@ func checkPortConflicts(containers []v1.Container, fldPath *field.Path) field.Er
 		portsPath := idxPath.Child("ports")
 		for pi := range ctr.Ports {
 			idxPath := portsPath.Index(pi)
+
+			// Check for duplicate port
+
 			port := ctr.Ports[pi].HostPort
-			name := ctr.Ports[pi].Name
 			if port == 0 {
 				continue
 			}
@@ -169,13 +171,17 @@ func checkPortConflicts(containers []v1.Container, fldPath *field.Path) field.Er
 				portAccumulator.Insert(str)
 			}
 
+			// Check for duplicate named ports
+
+			name := ctr.Ports[pi].Name
 			// Don't error on no name.
-			if name != "" {
-				if nameAccumulator.Has(name) {
-					allErrs = append(allErrs, field.Duplicate(idxPath.Child("namedPort"), name))
-				} else {
-					nameAccumulator.Insert(name)
-				}
+			if name == "" {
+				continue
+			}
+			if nameAccumulator.Has(name) {
+				allErrs = append(allErrs, field.Duplicate(idxPath.Child("namedPort"), name))
+			} else {
+				nameAccumulator.Insert(name)
 			}
 		}
 	}

--- a/pkg/apis/core/v1/validation/validation.go
+++ b/pkg/apis/core/v1/validation/validation.go
@@ -158,7 +158,6 @@ func checkPortConflicts(containers []v1.Container, fldPath *field.Path) field.Er
 			idxPath := portsPath.Index(pi)
 
 			// Check for duplicate port
-
 			port := ctr.Ports[pi].HostPort
 			if port == 0 {
 				continue
@@ -172,7 +171,6 @@ func checkPortConflicts(containers []v1.Container, fldPath *field.Path) field.Er
 			}
 
 			// Check for duplicate named ports
-
 			name := ctr.Ports[pi].Name
 			// Don't error on no name.
 			if name == "" {

--- a/pkg/apis/core/validation/validation.go
+++ b/pkg/apis/core/validation/validation.go
@@ -2701,7 +2701,6 @@ func checkPortConflicts(containers []core.Container, fldPath *field.Path) field.
 			idxPath := portsPath.Index(pi)
 
 			// Check for duplicate port
-
 			port := ctr.Ports[pi].HostPort
 			if port == 0 {
 				continue
@@ -2715,7 +2714,6 @@ func checkPortConflicts(containers []core.Container, fldPath *field.Path) field.
 			}
 
 			// Check for duplicate named ports
-
 			name := ctr.Ports[pi].Name
 			// Don't error on no name.
 			if name == "" {

--- a/pkg/apis/core/validation/validation.go
+++ b/pkg/apis/core/validation/validation.go
@@ -2699,8 +2699,10 @@ func checkPortConflicts(containers []core.Container, fldPath *field.Path) field.
 		portsPath := idxPath.Child("ports")
 		for pi := range ctr.Ports {
 			idxPath := portsPath.Index(pi)
+
+			// Check for duplicate port
+
 			port := ctr.Ports[pi].HostPort
-			name := ctr.Ports[pi].Name
 			if port == 0 {
 				continue
 			}
@@ -2712,13 +2714,17 @@ func checkPortConflicts(containers []core.Container, fldPath *field.Path) field.
 				portAccumulator.Insert(str)
 			}
 
+			// Check for duplicate named ports
+
+			name := ctr.Ports[pi].Name
 			// Don't error on no name.
-			if name != "" {
-				if nameAccumulator.Has(name) {
-					allErrs = append(allErrs, field.Duplicate(idxPath.Child("namedPort"), name))
-				} else {
-					nameAccumulator.Insert(name)
-				}
+			if name == "" {
+				continue
+			}
+			if nameAccumulator.Has(name) {
+				allErrs = append(allErrs, field.Duplicate(idxPath.Child("namedPort"), name))
+			} else {
+				nameAccumulator.Insert(name)
 			}
 		}
 	}


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

This PR adds error messaging for duplicate named ports. Giving multiple ports within a podSpec the same name is likely a bug in most use cases. This PR prevents the creation of objects where such duplication appears.

#### Which issue(s) this PR fixes:

Fixes https://github.com/kubernetes/kubectl/issues/1048

#### Special notes for your reviewer:

First PR -- Not sure if this requires a few versions of warnings before defaulting to errors as this could affect upgrading clusters that utilize operators. 

#### Does this PR introduce a user-facing change?

yes.

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Port names on objects implementing the podSpec are now required to be unique and errors will be thrown.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

Co Author: Po-Yu Liu <p.liu@salesforce.com>