### PR TITLE
Fix bug where using kubectl patch with $deleteFromPrimitiveList on an empty or nonexistent list adds the item to be removed

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/util/strategicpatch/patch.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/strategicpatch/patch.go
@@ -1328,15 +1328,19 @@ func mergeMap(original, patch map[string]interface{}, schema LookupPatchMeta, me
 
 		_, ok := original[k]
 		if !ok {
-			// If it's not in the original document, just take the patch value.
-			original[k] = patchV
+			if !isDeleteList {
+				// If it's not in the original document, just take the patch value.
+				original[k] = patchV
+			}
 			continue
 		}
 
 		originalType := reflect.TypeOf(original[k])
 		patchType := reflect.TypeOf(patchV)
 		if originalType != patchType {
-			original[k] = patchV
+			if !isDeleteList {
+				original[k] = patchV
+			}
 			continue
 		}
 		// If they're both maps or lists, recurse into the value.

--- a/staging/src/k8s.io/apimachinery/pkg/util/strategicpatch/patch_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/strategicpatch/patch_test.go
@@ -669,6 +669,57 @@ mergingList:
 			ExpectedError: "does not contain declared merge key",
 		},
 	},
+	{
+		Description: "$deleteFromPrimitiveList of nonexistent item in primitive list should not add the item to the list",
+		StrategicMergePatchRawTestCaseData: StrategicMergePatchRawTestCaseData{
+			Original: []byte(`
+mergingIntList:
+  - 1
+  - 2
+`),
+			TwoWay: []byte(`
+$deleteFromPrimitiveList/mergingIntList:
+  - 3
+`),
+			Modified: []byte(`
+mergingIntList:
+  - 1
+  - 2
+`),
+		},
+	},
+	{
+		Description: "$deleteFromPrimitiveList on empty primitive list should not add the item to the list",
+		StrategicMergePatchRawTestCaseData: StrategicMergePatchRawTestCaseData{
+			Original: []byte(`
+mergingIntList:
+`),
+			TwoWay: []byte(`
+$deleteFromPrimitiveList/mergingIntList:
+  - 3
+`),
+			Modified: []byte(`
+mergingIntList:
+`),
+		},
+	},
+	{
+		Description: "$deleteFromPrimitiveList on nonexistent primitive list should not add the primitive list",
+		StrategicMergePatchRawTestCaseData: StrategicMergePatchRawTestCaseData{
+			Original: []byte(`
+foo:
+  - bar
+`),
+			TwoWay: []byte(`
+$deleteFromPrimitiveList/mergingIntList:
+  - 3
+`),
+			Modified: []byte(`
+foo:
+  - bar
+`),
+		},
+	},
 }
 
 func TestCustomStrategicMergePatch(t *testing.T) {


### PR DESCRIPTION

#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
Fixes bug where using kubectl patch with $deleteFromPrimitiveList on a nonexistent or empty list would add the item to the list

Here is a command that illustrates the problem:
```
kubectl patch --local -f <(kubectl create cm foo --dry-run=client -o yaml) --dry-run=client --type=strategic -p '{"metadata":{"$deleteFromPrimitiveList/finalizers":["fancy.io/foo"]}}' -o yaml
```

Current output with the bug.  Notice the finalizer is added:
```
apiVersion: v1
kind: ConfigMap
metadata:
  creationTimestamp: null
  finalizers:
  - fancy.io/foo
  name: foo
```

Output after this PR fixes the bug:
```
apiVersion: v1
kind: ConfigMap
metadata:
  creationTimestamp: null
  name: foo
```

#### Which issue(s) this PR fixes:
Fixes #105146 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
Fixed bug where using kubectl patch with $deleteFromPrimitiveList on a nonexistent or empty list would add the item to the list
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs

```
