### PR TITLE
RESTClient factory: client-go share custom transports between different group/versions

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/examples/client-go/pkg/client/clientset/versioned/clientset.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/examples/client-go/pkg/client/clientset/versioned/clientset.go
@@ -63,12 +63,12 @@ func NewForConfig(c *rest.Config) (*Clientset, error) {
 		}
 		configShallowCopy.RateLimiter = flowcontrol.NewTokenBucketRateLimiter(configShallowCopy.QPS, configShallowCopy.Burst)
 	}
-	var cs Clientset
-	var err error
-	cs.crV1, err = crv1.NewForConfig(&configShallowCopy)
+	factory, err := rest.RESTClientFactoryFor(&configShallowCopy)
 	if err != nil {
 		return nil, err
 	}
+	var cs Clientset
+	cs.crV1 = crv1.NewForFactory(factory)
 
 	cs.DiscoveryClient, err = discovery.NewDiscoveryClientForConfig(&configShallowCopy)
 	if err != nil {
@@ -80,17 +80,22 @@ func NewForConfig(c *rest.Config) (*Clientset, error) {
 // NewForConfigOrDie creates a new Clientset for the given config and
 // panics if there is an error in the config.
 func NewForConfigOrDie(c *rest.Config) *Clientset {
-	var cs Clientset
-	cs.crV1 = crv1.NewForConfigOrDie(c)
-
-	cs.DiscoveryClient = discovery.NewDiscoveryClientForConfigOrDie(c)
-	return &cs
+	cs, err := NewForConfig(c)
+	if err != nil {
+		panic(err)
+	}
+	return cs
 }
 
 // New creates a new Clientset for the given RESTClient.
 func New(c rest.Interface) *Clientset {
+	client, ok := c.(*rest.RESTClient)
+	if !ok {
+		return nil
+	}
+	factory := rest.RESTClientFactoryFromClient(*client)
 	var cs Clientset
-	cs.crV1 = crv1.New(c)
+	cs.crV1 = crv1.NewForFactory(factory)
 
 	cs.DiscoveryClient = discovery.NewDiscoveryClient(c)
 	return &cs

--- a/staging/src/k8s.io/apiextensions-apiserver/examples/client-go/pkg/client/clientset/versioned/clientset.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/examples/client-go/pkg/client/clientset/versioned/clientset.go
@@ -67,8 +67,19 @@ func NewForConfig(c *rest.Config) (*Clientset, error) {
 	if err != nil {
 		return nil, err
 	}
+	options := []rest.RESTClientOption{}
+	if configShallowCopy.RateLimiter != nil {
+		options = append(options, rest.WithRateLimiter(configShallowCopy.RateLimiter))
+	}
+	if configShallowCopy.WarningHandler != nil {
+		options = append(options, rest.WithWarningHandler(configShallowCopy.WarningHandler))
+	}
+
 	var cs Clientset
-	cs.crV1 = crv1.NewForFactory(factory)
+	cs.crV1, err = crv1.NewForFactory(factory, options...)
+	if err != nil {
+		return nil, err
+	}
 
 	cs.DiscoveryClient, err = discovery.NewDiscoveryClientForConfig(&configShallowCopy)
 	if err != nil {
@@ -95,7 +106,11 @@ func New(c rest.Interface) *Clientset {
 	}
 	factory := rest.RESTClientFactoryFromClient(*client)
 	var cs Clientset
-	cs.crV1 = crv1.NewForFactory(factory)
+	var err error
+	cs.crV1, err = crv1.NewForFactory(factory)
+	if err != nil {
+		panic(err)
+	}
 
 	cs.DiscoveryClient = discovery.NewDiscoveryClient(c)
 	return &cs

--- a/staging/src/k8s.io/apiextensions-apiserver/examples/client-go/pkg/client/clientset/versioned/typed/cr/v1/cr_client.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/examples/client-go/pkg/client/clientset/versioned/typed/cr/v1/cr_client.go
@@ -68,13 +68,16 @@ func New(c rest.Interface) *CrV1Client {
 }
 
 // NewForFactory creates a new CrV1Client for the given RESTClientFactory.
-func NewForFactory(f *rest.RESTClientFactory) *CrV1Client {
+func NewForFactory(f *rest.RESTClientFactory, options ...rest.RESTClientOption) (*CrV1Client, error) {
 	var config rest.ClientContentConfig
 	config.GroupVersion = v1.SchemeGroupVersion
 	config.Negotiator = runtime.NewClientNegotiator(scheme.Codecs.WithoutConversion(), v1.SchemeGroupVersion)
 	apiPath := "/apis"
-	client := f.NewFor(apiPath, config)
-	return &CrV1Client{client}
+	client, err := f.NewClientWithOptions(apiPath, config, options...)
+	if err != nil {
+		return nil, err
+	}
+	return &CrV1Client{client}, nil
 }
 
 func setConfigDefaults(config *rest.Config) error {

--- a/staging/src/k8s.io/apiextensions-apiserver/examples/client-go/pkg/client/clientset/versioned/typed/cr/v1/cr_client.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/examples/client-go/pkg/client/clientset/versioned/typed/cr/v1/cr_client.go
@@ -21,6 +21,7 @@ package v1
 import (
 	v1 "k8s.io/apiextensions-apiserver/examples/client-go/pkg/apis/cr/v1"
 	"k8s.io/apiextensions-apiserver/examples/client-go/pkg/client/clientset/versioned/scheme"
+	runtime "k8s.io/apimachinery/pkg/runtime"
 	rest "k8s.io/client-go/rest"
 )
 
@@ -64,6 +65,16 @@ func NewForConfigOrDie(c *rest.Config) *CrV1Client {
 // New creates a new CrV1Client for the given RESTClient.
 func New(c rest.Interface) *CrV1Client {
 	return &CrV1Client{c}
+}
+
+// NewForFactory creates a new CrV1Client for the given RESTClientFactory.
+func NewForFactory(f *rest.RESTClientFactory) *CrV1Client {
+	var config rest.ClientContentConfig
+	config.GroupVersion = v1.SchemeGroupVersion
+	config.Negotiator = runtime.NewClientNegotiator(scheme.Codecs.WithoutConversion(), v1.SchemeGroupVersion)
+	apiPath := "/apis"
+	client := f.NewFor(apiPath, config)
+	return &CrV1Client{client}
 }
 
 func setConfigDefaults(config *rest.Config) error {

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/clientset.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/clientset.go
@@ -75,9 +75,23 @@ func NewForConfig(c *rest.Config) (*Clientset, error) {
 	if err != nil {
 		return nil, err
 	}
+	options := []rest.RESTClientOption{}
+	if configShallowCopy.RateLimiter != nil {
+		options = append(options, rest.WithRateLimiter(configShallowCopy.RateLimiter))
+	}
+	if configShallowCopy.WarningHandler != nil {
+		options = append(options, rest.WithWarningHandler(configShallowCopy.WarningHandler))
+	}
+
 	var cs Clientset
-	cs.apiextensionsV1beta1 = apiextensionsv1beta1.NewForFactory(factory)
-	cs.apiextensionsV1 = apiextensionsv1.NewForFactory(factory)
+	cs.apiextensionsV1beta1, err = apiextensionsv1beta1.NewForFactory(factory, options...)
+	if err != nil {
+		return nil, err
+	}
+	cs.apiextensionsV1, err = apiextensionsv1.NewForFactory(factory, options...)
+	if err != nil {
+		return nil, err
+	}
 
 	cs.DiscoveryClient, err = discovery.NewDiscoveryClientForConfig(&configShallowCopy)
 	if err != nil {
@@ -104,8 +118,15 @@ func New(c rest.Interface) *Clientset {
 	}
 	factory := rest.RESTClientFactoryFromClient(*client)
 	var cs Clientset
-	cs.apiextensionsV1beta1 = apiextensionsv1beta1.NewForFactory(factory)
-	cs.apiextensionsV1 = apiextensionsv1.NewForFactory(factory)
+	var err error
+	cs.apiextensionsV1beta1, err = apiextensionsv1beta1.NewForFactory(factory)
+	if err != nil {
+		panic(err)
+	}
+	cs.apiextensionsV1, err = apiextensionsv1.NewForFactory(factory)
+	if err != nil {
+		panic(err)
+	}
 
 	cs.DiscoveryClient = discovery.NewDiscoveryClient(c)
 	return &cs

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1/apiextensions_client.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1/apiextensions_client.go
@@ -21,6 +21,7 @@ package v1
 import (
 	v1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/scheme"
+	runtime "k8s.io/apimachinery/pkg/runtime"
 	rest "k8s.io/client-go/rest"
 )
 
@@ -64,6 +65,16 @@ func NewForConfigOrDie(c *rest.Config) *ApiextensionsV1Client {
 // New creates a new ApiextensionsV1Client for the given RESTClient.
 func New(c rest.Interface) *ApiextensionsV1Client {
 	return &ApiextensionsV1Client{c}
+}
+
+// NewForFactory creates a new ApiextensionsV1Client for the given RESTClientFactory.
+func NewForFactory(f *rest.RESTClientFactory) *ApiextensionsV1Client {
+	var config rest.ClientContentConfig
+	config.GroupVersion = v1.SchemeGroupVersion
+	config.Negotiator = runtime.NewClientNegotiator(scheme.Codecs.WithoutConversion(), v1.SchemeGroupVersion)
+	apiPath := "/apis"
+	client := f.NewFor(apiPath, config)
+	return &ApiextensionsV1Client{client}
 }
 
 func setConfigDefaults(config *rest.Config) error {

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1/apiextensions_client.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1/apiextensions_client.go
@@ -68,13 +68,16 @@ func New(c rest.Interface) *ApiextensionsV1Client {
 }
 
 // NewForFactory creates a new ApiextensionsV1Client for the given RESTClientFactory.
-func NewForFactory(f *rest.RESTClientFactory) *ApiextensionsV1Client {
+func NewForFactory(f *rest.RESTClientFactory, options ...rest.RESTClientOption) (*ApiextensionsV1Client, error) {
 	var config rest.ClientContentConfig
 	config.GroupVersion = v1.SchemeGroupVersion
 	config.Negotiator = runtime.NewClientNegotiator(scheme.Codecs.WithoutConversion(), v1.SchemeGroupVersion)
 	apiPath := "/apis"
-	client := f.NewFor(apiPath, config)
-	return &ApiextensionsV1Client{client}
+	client, err := f.NewClientWithOptions(apiPath, config, options...)
+	if err != nil {
+		return nil, err
+	}
+	return &ApiextensionsV1Client{client}, nil
 }
 
 func setConfigDefaults(config *rest.Config) error {

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1beta1/apiextensions_client.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1beta1/apiextensions_client.go
@@ -21,6 +21,7 @@ package v1beta1
 import (
 	v1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	"k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/scheme"
+	runtime "k8s.io/apimachinery/pkg/runtime"
 	rest "k8s.io/client-go/rest"
 )
 
@@ -64,6 +65,16 @@ func NewForConfigOrDie(c *rest.Config) *ApiextensionsV1beta1Client {
 // New creates a new ApiextensionsV1beta1Client for the given RESTClient.
 func New(c rest.Interface) *ApiextensionsV1beta1Client {
 	return &ApiextensionsV1beta1Client{c}
+}
+
+// NewForFactory creates a new ApiextensionsV1beta1Client for the given RESTClientFactory.
+func NewForFactory(f *rest.RESTClientFactory) *ApiextensionsV1beta1Client {
+	var config rest.ClientContentConfig
+	config.GroupVersion = v1beta1.SchemeGroupVersion
+	config.Negotiator = runtime.NewClientNegotiator(scheme.Codecs.WithoutConversion(), v1beta1.SchemeGroupVersion)
+	apiPath := "/apis"
+	client := f.NewFor(apiPath, config)
+	return &ApiextensionsV1beta1Client{client}
 }
 
 func setConfigDefaults(config *rest.Config) error {

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1beta1/apiextensions_client.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1beta1/apiextensions_client.go
@@ -68,13 +68,16 @@ func New(c rest.Interface) *ApiextensionsV1beta1Client {
 }
 
 // NewForFactory creates a new ApiextensionsV1beta1Client for the given RESTClientFactory.
-func NewForFactory(f *rest.RESTClientFactory) *ApiextensionsV1beta1Client {
+func NewForFactory(f *rest.RESTClientFactory, options ...rest.RESTClientOption) (*ApiextensionsV1beta1Client, error) {
 	var config rest.ClientContentConfig
 	config.GroupVersion = v1beta1.SchemeGroupVersion
 	config.Negotiator = runtime.NewClientNegotiator(scheme.Codecs.WithoutConversion(), v1beta1.SchemeGroupVersion)
 	apiPath := "/apis"
-	client := f.NewFor(apiPath, config)
-	return &ApiextensionsV1beta1Client{client}
+	client, err := f.NewClientWithOptions(apiPath, config, options...)
+	if err != nil {
+		return nil, err
+	}
+	return &ApiextensionsV1beta1Client{client}, nil
 }
 
 func setConfigDefaults(config *rest.Config) error {

--- a/staging/src/k8s.io/client-go/kubernetes/clientset.go
+++ b/staging/src/k8s.io/client-go/kubernetes/clientset.go
@@ -411,51 +411,191 @@ func NewForConfig(c *rest.Config) (*Clientset, error) {
 	if err != nil {
 		return nil, err
 	}
+	options := []rest.RESTClientOption{}
+	if configShallowCopy.RateLimiter != nil {
+		options = append(options, rest.WithRateLimiter(configShallowCopy.RateLimiter))
+	}
+	if configShallowCopy.WarningHandler != nil {
+		options = append(options, rest.WithWarningHandler(configShallowCopy.WarningHandler))
+	}
+
 	var cs Clientset
-	cs.admissionregistrationV1 = admissionregistrationv1.NewForFactory(factory)
-	cs.admissionregistrationV1beta1 = admissionregistrationv1beta1.NewForFactory(factory)
-	cs.internalV1alpha1 = internalv1alpha1.NewForFactory(factory)
-	cs.appsV1 = appsv1.NewForFactory(factory)
-	cs.appsV1beta1 = appsv1beta1.NewForFactory(factory)
-	cs.appsV1beta2 = appsv1beta2.NewForFactory(factory)
-	cs.authenticationV1 = authenticationv1.NewForFactory(factory)
-	cs.authenticationV1beta1 = authenticationv1beta1.NewForFactory(factory)
-	cs.authorizationV1 = authorizationv1.NewForFactory(factory)
-	cs.authorizationV1beta1 = authorizationv1beta1.NewForFactory(factory)
-	cs.autoscalingV1 = autoscalingv1.NewForFactory(factory)
-	cs.autoscalingV2beta1 = autoscalingv2beta1.NewForFactory(factory)
-	cs.autoscalingV2beta2 = autoscalingv2beta2.NewForFactory(factory)
-	cs.batchV1 = batchv1.NewForFactory(factory)
-	cs.batchV1beta1 = batchv1beta1.NewForFactory(factory)
-	cs.certificatesV1 = certificatesv1.NewForFactory(factory)
-	cs.certificatesV1beta1 = certificatesv1beta1.NewForFactory(factory)
-	cs.coordinationV1beta1 = coordinationv1beta1.NewForFactory(factory)
-	cs.coordinationV1 = coordinationv1.NewForFactory(factory)
-	cs.coreV1 = corev1.NewForFactory(factory)
-	cs.discoveryV1 = discoveryv1.NewForFactory(factory)
-	cs.discoveryV1beta1 = discoveryv1beta1.NewForFactory(factory)
-	cs.eventsV1 = eventsv1.NewForFactory(factory)
-	cs.eventsV1beta1 = eventsv1beta1.NewForFactory(factory)
-	cs.extensionsV1beta1 = extensionsv1beta1.NewForFactory(factory)
-	cs.flowcontrolV1alpha1 = flowcontrolv1alpha1.NewForFactory(factory)
-	cs.flowcontrolV1beta1 = flowcontrolv1beta1.NewForFactory(factory)
-	cs.flowcontrolV1beta2 = flowcontrolv1beta2.NewForFactory(factory)
-	cs.networkingV1 = networkingv1.NewForFactory(factory)
-	cs.networkingV1beta1 = networkingv1beta1.NewForFactory(factory)
-	cs.nodeV1 = nodev1.NewForFactory(factory)
-	cs.nodeV1alpha1 = nodev1alpha1.NewForFactory(factory)
-	cs.nodeV1beta1 = nodev1beta1.NewForFactory(factory)
-	cs.policyV1 = policyv1.NewForFactory(factory)
-	cs.policyV1beta1 = policyv1beta1.NewForFactory(factory)
-	cs.rbacV1 = rbacv1.NewForFactory(factory)
-	cs.rbacV1beta1 = rbacv1beta1.NewForFactory(factory)
-	cs.rbacV1alpha1 = rbacv1alpha1.NewForFactory(factory)
-	cs.schedulingV1alpha1 = schedulingv1alpha1.NewForFactory(factory)
-	cs.schedulingV1beta1 = schedulingv1beta1.NewForFactory(factory)
-	cs.schedulingV1 = schedulingv1.NewForFactory(factory)
-	cs.storageV1beta1 = storagev1beta1.NewForFactory(factory)
-	cs.storageV1 = storagev1.NewForFactory(factory)
-	cs.storageV1alpha1 = storagev1alpha1.NewForFactory(factory)
+	cs.admissionregistrationV1, err = admissionregistrationv1.NewForFactory(factory, options...)
+	if err != nil {
+		return nil, err
+	}
+	cs.admissionregistrationV1beta1, err = admissionregistrationv1beta1.NewForFactory(factory, options...)
+	if err != nil {
+		return nil, err
+	}
+	cs.internalV1alpha1, err = internalv1alpha1.NewForFactory(factory, options...)
+	if err != nil {
+		return nil, err
+	}
+	cs.appsV1, err = appsv1.NewForFactory(factory, options...)
+	if err != nil {
+		return nil, err
+	}
+	cs.appsV1beta1, err = appsv1beta1.NewForFactory(factory, options...)
+	if err != nil {
+		return nil, err
+	}
+	cs.appsV1beta2, err = appsv1beta2.NewForFactory(factory, options...)
+	if err != nil {
+		return nil, err
+	}
+	cs.authenticationV1, err = authenticationv1.NewForFactory(factory, options...)
+	if err != nil {
+		return nil, err
+	}
+	cs.authenticationV1beta1, err = authenticationv1beta1.NewForFactory(factory, options...)
+	if err != nil {
+		return nil, err
+	}
+	cs.authorizationV1, err = authorizationv1.NewForFactory(factory, options...)
+	if err != nil {
+		return nil, err
+	}
+	cs.authorizationV1beta1, err = authorizationv1beta1.NewForFactory(factory, options...)
+	if err != nil {
+		return nil, err
+	}
+	cs.autoscalingV1, err = autoscalingv1.NewForFactory(factory, options...)
+	if err != nil {
+		return nil, err
+	}
+	cs.autoscalingV2beta1, err = autoscalingv2beta1.NewForFactory(factory, options...)
+	if err != nil {
+		return nil, err
+	}
+	cs.autoscalingV2beta2, err = autoscalingv2beta2.NewForFactory(factory, options...)
+	if err != nil {
+		return nil, err
+	}
+	cs.batchV1, err = batchv1.NewForFactory(factory, options...)
+	if err != nil {
+		return nil, err
+	}
+	cs.batchV1beta1, err = batchv1beta1.NewForFactory(factory, options...)
+	if err != nil {
+		return nil, err
+	}
+	cs.certificatesV1, err = certificatesv1.NewForFactory(factory, options...)
+	if err != nil {
+		return nil, err
+	}
+	cs.certificatesV1beta1, err = certificatesv1beta1.NewForFactory(factory, options...)
+	if err != nil {
+		return nil, err
+	}
+	cs.coordinationV1beta1, err = coordinationv1beta1.NewForFactory(factory, options...)
+	if err != nil {
+		return nil, err
+	}
+	cs.coordinationV1, err = coordinationv1.NewForFactory(factory, options...)
+	if err != nil {
+		return nil, err
+	}
+	cs.coreV1, err = corev1.NewForFactory(factory, options...)
+	if err != nil {
+		return nil, err
+	}
+	cs.discoveryV1, err = discoveryv1.NewForFactory(factory, options...)
+	if err != nil {
+		return nil, err
+	}
+	cs.discoveryV1beta1, err = discoveryv1beta1.NewForFactory(factory, options...)
+	if err != nil {
+		return nil, err
+	}
+	cs.eventsV1, err = eventsv1.NewForFactory(factory, options...)
+	if err != nil {
+		return nil, err
+	}
+	cs.eventsV1beta1, err = eventsv1beta1.NewForFactory(factory, options...)
+	if err != nil {
+		return nil, err
+	}
+	cs.extensionsV1beta1, err = extensionsv1beta1.NewForFactory(factory, options...)
+	if err != nil {
+		return nil, err
+	}
+	cs.flowcontrolV1alpha1, err = flowcontrolv1alpha1.NewForFactory(factory, options...)
+	if err != nil {
+		return nil, err
+	}
+	cs.flowcontrolV1beta1, err = flowcontrolv1beta1.NewForFactory(factory, options...)
+	if err != nil {
+		return nil, err
+	}
+	cs.flowcontrolV1beta2, err = flowcontrolv1beta2.NewForFactory(factory, options...)
+	if err != nil {
+		return nil, err
+	}
+	cs.networkingV1, err = networkingv1.NewForFactory(factory, options...)
+	if err != nil {
+		return nil, err
+	}
+	cs.networkingV1beta1, err = networkingv1beta1.NewForFactory(factory, options...)
+	if err != nil {
+		return nil, err
+	}
+	cs.nodeV1, err = nodev1.NewForFactory(factory, options...)
+	if err != nil {
+		return nil, err
+	}
+	cs.nodeV1alpha1, err = nodev1alpha1.NewForFactory(factory, options...)
+	if err != nil {
+		return nil, err
+	}
+	cs.nodeV1beta1, err = nodev1beta1.NewForFactory(factory, options...)
+	if err != nil {
+		return nil, err
+	}
+	cs.policyV1, err = policyv1.NewForFactory(factory, options...)
+	if err != nil {
+		return nil, err
+	}
+	cs.policyV1beta1, err = policyv1beta1.NewForFactory(factory, options...)
+	if err != nil {
+		return nil, err
+	}
+	cs.rbacV1, err = rbacv1.NewForFactory(factory, options...)
+	if err != nil {
+		return nil, err
+	}
+	cs.rbacV1beta1, err = rbacv1beta1.NewForFactory(factory, options...)
+	if err != nil {
+		return nil, err
+	}
+	cs.rbacV1alpha1, err = rbacv1alpha1.NewForFactory(factory, options...)
+	if err != nil {
+		return nil, err
+	}
+	cs.schedulingV1alpha1, err = schedulingv1alpha1.NewForFactory(factory, options...)
+	if err != nil {
+		return nil, err
+	}
+	cs.schedulingV1beta1, err = schedulingv1beta1.NewForFactory(factory, options...)
+	if err != nil {
+		return nil, err
+	}
+	cs.schedulingV1, err = schedulingv1.NewForFactory(factory, options...)
+	if err != nil {
+		return nil, err
+	}
+	cs.storageV1beta1, err = storagev1beta1.NewForFactory(factory, options...)
+	if err != nil {
+		return nil, err
+	}
+	cs.storageV1, err = storagev1.NewForFactory(factory, options...)
+	if err != nil {
+		return nil, err
+	}
+	cs.storageV1alpha1, err = storagev1alpha1.NewForFactory(factory, options...)
+	if err != nil {
+		return nil, err
+	}
 
 	cs.DiscoveryClient, err = discovery.NewDiscoveryClientForConfig(&configShallowCopy)
 	if err != nil {
@@ -482,50 +622,183 @@ func New(c rest.Interface) *Clientset {
 	}
 	factory := rest.RESTClientFactoryFromClient(*client)
 	var cs Clientset
-	cs.admissionregistrationV1 = admissionregistrationv1.NewForFactory(factory)
-	cs.admissionregistrationV1beta1 = admissionregistrationv1beta1.NewForFactory(factory)
-	cs.internalV1alpha1 = internalv1alpha1.NewForFactory(factory)
-	cs.appsV1 = appsv1.NewForFactory(factory)
-	cs.appsV1beta1 = appsv1beta1.NewForFactory(factory)
-	cs.appsV1beta2 = appsv1beta2.NewForFactory(factory)
-	cs.authenticationV1 = authenticationv1.NewForFactory(factory)
-	cs.authenticationV1beta1 = authenticationv1beta1.NewForFactory(factory)
-	cs.authorizationV1 = authorizationv1.NewForFactory(factory)
-	cs.authorizationV1beta1 = authorizationv1beta1.NewForFactory(factory)
-	cs.autoscalingV1 = autoscalingv1.NewForFactory(factory)
-	cs.autoscalingV2beta1 = autoscalingv2beta1.NewForFactory(factory)
-	cs.autoscalingV2beta2 = autoscalingv2beta2.NewForFactory(factory)
-	cs.batchV1 = batchv1.NewForFactory(factory)
-	cs.batchV1beta1 = batchv1beta1.NewForFactory(factory)
-	cs.certificatesV1 = certificatesv1.NewForFactory(factory)
-	cs.certificatesV1beta1 = certificatesv1beta1.NewForFactory(factory)
-	cs.coordinationV1beta1 = coordinationv1beta1.NewForFactory(factory)
-	cs.coordinationV1 = coordinationv1.NewForFactory(factory)
-	cs.coreV1 = corev1.NewForFactory(factory)
-	cs.discoveryV1 = discoveryv1.NewForFactory(factory)
-	cs.discoveryV1beta1 = discoveryv1beta1.NewForFactory(factory)
-	cs.eventsV1 = eventsv1.NewForFactory(factory)
-	cs.eventsV1beta1 = eventsv1beta1.NewForFactory(factory)
-	cs.extensionsV1beta1 = extensionsv1beta1.NewForFactory(factory)
-	cs.flowcontrolV1alpha1 = flowcontrolv1alpha1.NewForFactory(factory)
-	cs.flowcontrolV1beta1 = flowcontrolv1beta1.NewForFactory(factory)
-	cs.flowcontrolV1beta2 = flowcontrolv1beta2.NewForFactory(factory)
-	cs.networkingV1 = networkingv1.NewForFactory(factory)
-	cs.networkingV1beta1 = networkingv1beta1.NewForFactory(factory)
-	cs.nodeV1 = nodev1.NewForFactory(factory)
-	cs.nodeV1alpha1 = nodev1alpha1.NewForFactory(factory)
-	cs.nodeV1beta1 = nodev1beta1.NewForFactory(factory)
-	cs.policyV1 = policyv1.NewForFactory(factory)
-	cs.policyV1beta1 = policyv1beta1.NewForFactory(factory)
-	cs.rbacV1 = rbacv1.NewForFactory(factory)
-	cs.rbacV1beta1 = rbacv1beta1.NewForFactory(factory)
-	cs.rbacV1alpha1 = rbacv1alpha1.NewForFactory(factory)
-	cs.schedulingV1alpha1 = schedulingv1alpha1.NewForFactory(factory)
-	cs.schedulingV1beta1 = schedulingv1beta1.NewForFactory(factory)
-	cs.schedulingV1 = schedulingv1.NewForFactory(factory)
-	cs.storageV1beta1 = storagev1beta1.NewForFactory(factory)
-	cs.storageV1 = storagev1.NewForFactory(factory)
-	cs.storageV1alpha1 = storagev1alpha1.NewForFactory(factory)
+	var err error
+	cs.admissionregistrationV1, err = admissionregistrationv1.NewForFactory(factory)
+	if err != nil {
+		panic(err)
+	}
+	cs.admissionregistrationV1beta1, err = admissionregistrationv1beta1.NewForFactory(factory)
+	if err != nil {
+		panic(err)
+	}
+	cs.internalV1alpha1, err = internalv1alpha1.NewForFactory(factory)
+	if err != nil {
+		panic(err)
+	}
+	cs.appsV1, err = appsv1.NewForFactory(factory)
+	if err != nil {
+		panic(err)
+	}
+	cs.appsV1beta1, err = appsv1beta1.NewForFactory(factory)
+	if err != nil {
+		panic(err)
+	}
+	cs.appsV1beta2, err = appsv1beta2.NewForFactory(factory)
+	if err != nil {
+		panic(err)
+	}
+	cs.authenticationV1, err = authenticationv1.NewForFactory(factory)
+	if err != nil {
+		panic(err)
+	}
+	cs.authenticationV1beta1, err = authenticationv1beta1.NewForFactory(factory)
+	if err != nil {
+		panic(err)
+	}
+	cs.authorizationV1, err = authorizationv1.NewForFactory(factory)
+	if err != nil {
+		panic(err)
+	}
+	cs.authorizationV1beta1, err = authorizationv1beta1.NewForFactory(factory)
+	if err != nil {
+		panic(err)
+	}
+	cs.autoscalingV1, err = autoscalingv1.NewForFactory(factory)
+	if err != nil {
+		panic(err)
+	}
+	cs.autoscalingV2beta1, err = autoscalingv2beta1.NewForFactory(factory)
+	if err != nil {
+		panic(err)
+	}
+	cs.autoscalingV2beta2, err = autoscalingv2beta2.NewForFactory(factory)
+	if err != nil {
+		panic(err)
+	}
+	cs.batchV1, err = batchv1.NewForFactory(factory)
+	if err != nil {
+		panic(err)
+	}
+	cs.batchV1beta1, err = batchv1beta1.NewForFactory(factory)
+	if err != nil {
+		panic(err)
+	}
+	cs.certificatesV1, err = certificatesv1.NewForFactory(factory)
+	if err != nil {
+		panic(err)
+	}
+	cs.certificatesV1beta1, err = certificatesv1beta1.NewForFactory(factory)
+	if err != nil {
+		panic(err)
+	}
+	cs.coordinationV1beta1, err = coordinationv1beta1.NewForFactory(factory)
+	if err != nil {
+		panic(err)
+	}
+	cs.coordinationV1, err = coordinationv1.NewForFactory(factory)
+	if err != nil {
+		panic(err)
+	}
+	cs.coreV1, err = corev1.NewForFactory(factory)
+	if err != nil {
+		panic(err)
+	}
+	cs.discoveryV1, err = discoveryv1.NewForFactory(factory)
+	if err != nil {
+		panic(err)
+	}
+	cs.discoveryV1beta1, err = discoveryv1beta1.NewForFactory(factory)
+	if err != nil {
+		panic(err)
+	}
+	cs.eventsV1, err = eventsv1.NewForFactory(factory)
+	if err != nil {
+		panic(err)
+	}
+	cs.eventsV1beta1, err = eventsv1beta1.NewForFactory(factory)
+	if err != nil {
+		panic(err)
+	}
+	cs.extensionsV1beta1, err = extensionsv1beta1.NewForFactory(factory)
+	if err != nil {
+		panic(err)
+	}
+	cs.flowcontrolV1alpha1, err = flowcontrolv1alpha1.NewForFactory(factory)
+	if err != nil {
+		panic(err)
+	}
+	cs.flowcontrolV1beta1, err = flowcontrolv1beta1.NewForFactory(factory)
+	if err != nil {
+		panic(err)
+	}
+	cs.flowcontrolV1beta2, err = flowcontrolv1beta2.NewForFactory(factory)
+	if err != nil {
+		panic(err)
+	}
+	cs.networkingV1, err = networkingv1.NewForFactory(factory)
+	if err != nil {
+		panic(err)
+	}
+	cs.networkingV1beta1, err = networkingv1beta1.NewForFactory(factory)
+	if err != nil {
+		panic(err)
+	}
+	cs.nodeV1, err = nodev1.NewForFactory(factory)
+	if err != nil {
+		panic(err)
+	}
+	cs.nodeV1alpha1, err = nodev1alpha1.NewForFactory(factory)
+	if err != nil {
+		panic(err)
+	}
+	cs.nodeV1beta1, err = nodev1beta1.NewForFactory(factory)
+	if err != nil {
+		panic(err)
+	}
+	cs.policyV1, err = policyv1.NewForFactory(factory)
+	if err != nil {
+		panic(err)
+	}
+	cs.policyV1beta1, err = policyv1beta1.NewForFactory(factory)
+	if err != nil {
+		panic(err)
+	}
+	cs.rbacV1, err = rbacv1.NewForFactory(factory)
+	if err != nil {
+		panic(err)
+	}
+	cs.rbacV1beta1, err = rbacv1beta1.NewForFactory(factory)
+	if err != nil {
+		panic(err)
+	}
+	cs.rbacV1alpha1, err = rbacv1alpha1.NewForFactory(factory)
+	if err != nil {
+		panic(err)
+	}
+	cs.schedulingV1alpha1, err = schedulingv1alpha1.NewForFactory(factory)
+	if err != nil {
+		panic(err)
+	}
+	cs.schedulingV1beta1, err = schedulingv1beta1.NewForFactory(factory)
+	if err != nil {
+		panic(err)
+	}
+	cs.schedulingV1, err = schedulingv1.NewForFactory(factory)
+	if err != nil {
+		panic(err)
+	}
+	cs.storageV1beta1, err = storagev1beta1.NewForFactory(factory)
+	if err != nil {
+		panic(err)
+	}
+	cs.storageV1, err = storagev1.NewForFactory(factory)
+	if err != nil {
+		panic(err)
+	}
+	cs.storageV1alpha1, err = storagev1alpha1.NewForFactory(factory)
+	if err != nil {
+		panic(err)
+	}
 
 	cs.DiscoveryClient = discovery.NewDiscoveryClient(c)
 	return &cs

--- a/staging/src/k8s.io/client-go/kubernetes/clientset.go
+++ b/staging/src/k8s.io/client-go/kubernetes/clientset.go
@@ -407,184 +407,55 @@ func NewForConfig(c *rest.Config) (*Clientset, error) {
 		}
 		configShallowCopy.RateLimiter = flowcontrol.NewTokenBucketRateLimiter(configShallowCopy.QPS, configShallowCopy.Burst)
 	}
+	factory, err := rest.RESTClientFactoryFor(&configShallowCopy)
+	if err != nil {
+		return nil, err
+	}
 	var cs Clientset
-	var err error
-	cs.admissionregistrationV1, err = admissionregistrationv1.NewForConfig(&configShallowCopy)
-	if err != nil {
-		return nil, err
-	}
-	cs.admissionregistrationV1beta1, err = admissionregistrationv1beta1.NewForConfig(&configShallowCopy)
-	if err != nil {
-		return nil, err
-	}
-	cs.internalV1alpha1, err = internalv1alpha1.NewForConfig(&configShallowCopy)
-	if err != nil {
-		return nil, err
-	}
-	cs.appsV1, err = appsv1.NewForConfig(&configShallowCopy)
-	if err != nil {
-		return nil, err
-	}
-	cs.appsV1beta1, err = appsv1beta1.NewForConfig(&configShallowCopy)
-	if err != nil {
-		return nil, err
-	}
-	cs.appsV1beta2, err = appsv1beta2.NewForConfig(&configShallowCopy)
-	if err != nil {
-		return nil, err
-	}
-	cs.authenticationV1, err = authenticationv1.NewForConfig(&configShallowCopy)
-	if err != nil {
-		return nil, err
-	}
-	cs.authenticationV1beta1, err = authenticationv1beta1.NewForConfig(&configShallowCopy)
-	if err != nil {
-		return nil, err
-	}
-	cs.authorizationV1, err = authorizationv1.NewForConfig(&configShallowCopy)
-	if err != nil {
-		return nil, err
-	}
-	cs.authorizationV1beta1, err = authorizationv1beta1.NewForConfig(&configShallowCopy)
-	if err != nil {
-		return nil, err
-	}
-	cs.autoscalingV1, err = autoscalingv1.NewForConfig(&configShallowCopy)
-	if err != nil {
-		return nil, err
-	}
-	cs.autoscalingV2beta1, err = autoscalingv2beta1.NewForConfig(&configShallowCopy)
-	if err != nil {
-		return nil, err
-	}
-	cs.autoscalingV2beta2, err = autoscalingv2beta2.NewForConfig(&configShallowCopy)
-	if err != nil {
-		return nil, err
-	}
-	cs.batchV1, err = batchv1.NewForConfig(&configShallowCopy)
-	if err != nil {
-		return nil, err
-	}
-	cs.batchV1beta1, err = batchv1beta1.NewForConfig(&configShallowCopy)
-	if err != nil {
-		return nil, err
-	}
-	cs.certificatesV1, err = certificatesv1.NewForConfig(&configShallowCopy)
-	if err != nil {
-		return nil, err
-	}
-	cs.certificatesV1beta1, err = certificatesv1beta1.NewForConfig(&configShallowCopy)
-	if err != nil {
-		return nil, err
-	}
-	cs.coordinationV1beta1, err = coordinationv1beta1.NewForConfig(&configShallowCopy)
-	if err != nil {
-		return nil, err
-	}
-	cs.coordinationV1, err = coordinationv1.NewForConfig(&configShallowCopy)
-	if err != nil {
-		return nil, err
-	}
-	cs.coreV1, err = corev1.NewForConfig(&configShallowCopy)
-	if err != nil {
-		return nil, err
-	}
-	cs.discoveryV1, err = discoveryv1.NewForConfig(&configShallowCopy)
-	if err != nil {
-		return nil, err
-	}
-	cs.discoveryV1beta1, err = discoveryv1beta1.NewForConfig(&configShallowCopy)
-	if err != nil {
-		return nil, err
-	}
-	cs.eventsV1, err = eventsv1.NewForConfig(&configShallowCopy)
-	if err != nil {
-		return nil, err
-	}
-	cs.eventsV1beta1, err = eventsv1beta1.NewForConfig(&configShallowCopy)
-	if err != nil {
-		return nil, err
-	}
-	cs.extensionsV1beta1, err = extensionsv1beta1.NewForConfig(&configShallowCopy)
-	if err != nil {
-		return nil, err
-	}
-	cs.flowcontrolV1alpha1, err = flowcontrolv1alpha1.NewForConfig(&configShallowCopy)
-	if err != nil {
-		return nil, err
-	}
-	cs.flowcontrolV1beta1, err = flowcontrolv1beta1.NewForConfig(&configShallowCopy)
-	if err != nil {
-		return nil, err
-	}
-	cs.flowcontrolV1beta2, err = flowcontrolv1beta2.NewForConfig(&configShallowCopy)
-	if err != nil {
-		return nil, err
-	}
-	cs.networkingV1, err = networkingv1.NewForConfig(&configShallowCopy)
-	if err != nil {
-		return nil, err
-	}
-	cs.networkingV1beta1, err = networkingv1beta1.NewForConfig(&configShallowCopy)
-	if err != nil {
-		return nil, err
-	}
-	cs.nodeV1, err = nodev1.NewForConfig(&configShallowCopy)
-	if err != nil {
-		return nil, err
-	}
-	cs.nodeV1alpha1, err = nodev1alpha1.NewForConfig(&configShallowCopy)
-	if err != nil {
-		return nil, err
-	}
-	cs.nodeV1beta1, err = nodev1beta1.NewForConfig(&configShallowCopy)
-	if err != nil {
-		return nil, err
-	}
-	cs.policyV1, err = policyv1.NewForConfig(&configShallowCopy)
-	if err != nil {
-		return nil, err
-	}
-	cs.policyV1beta1, err = policyv1beta1.NewForConfig(&configShallowCopy)
-	if err != nil {
-		return nil, err
-	}
-	cs.rbacV1, err = rbacv1.NewForConfig(&configShallowCopy)
-	if err != nil {
-		return nil, err
-	}
-	cs.rbacV1beta1, err = rbacv1beta1.NewForConfig(&configShallowCopy)
-	if err != nil {
-		return nil, err
-	}
-	cs.rbacV1alpha1, err = rbacv1alpha1.NewForConfig(&configShallowCopy)
-	if err != nil {
-		return nil, err
-	}
-	cs.schedulingV1alpha1, err = schedulingv1alpha1.NewForConfig(&configShallowCopy)
-	if err != nil {
-		return nil, err
-	}
-	cs.schedulingV1beta1, err = schedulingv1beta1.NewForConfig(&configShallowCopy)
-	if err != nil {
-		return nil, err
-	}
-	cs.schedulingV1, err = schedulingv1.NewForConfig(&configShallowCopy)
-	if err != nil {
-		return nil, err
-	}
-	cs.storageV1beta1, err = storagev1beta1.NewForConfig(&configShallowCopy)
-	if err != nil {
-		return nil, err
-	}
-	cs.storageV1, err = storagev1.NewForConfig(&configShallowCopy)
-	if err != nil {
-		return nil, err
-	}
-	cs.storageV1alpha1, err = storagev1alpha1.NewForConfig(&configShallowCopy)
-	if err != nil {
-		return nil, err
-	}
+	cs.admissionregistrationV1 = admissionregistrationv1.NewForFactory(factory)
+	cs.admissionregistrationV1beta1 = admissionregistrationv1beta1.NewForFactory(factory)
+	cs.internalV1alpha1 = internalv1alpha1.NewForFactory(factory)
+	cs.appsV1 = appsv1.NewForFactory(factory)
+	cs.appsV1beta1 = appsv1beta1.NewForFactory(factory)
+	cs.appsV1beta2 = appsv1beta2.NewForFactory(factory)
+	cs.authenticationV1 = authenticationv1.NewForFactory(factory)
+	cs.authenticationV1beta1 = authenticationv1beta1.NewForFactory(factory)
+	cs.authorizationV1 = authorizationv1.NewForFactory(factory)
+	cs.authorizationV1beta1 = authorizationv1beta1.NewForFactory(factory)
+	cs.autoscalingV1 = autoscalingv1.NewForFactory(factory)
+	cs.autoscalingV2beta1 = autoscalingv2beta1.NewForFactory(factory)
+	cs.autoscalingV2beta2 = autoscalingv2beta2.NewForFactory(factory)
+	cs.batchV1 = batchv1.NewForFactory(factory)
+	cs.batchV1beta1 = batchv1beta1.NewForFactory(factory)
+	cs.certificatesV1 = certificatesv1.NewForFactory(factory)
+	cs.certificatesV1beta1 = certificatesv1beta1.NewForFactory(factory)
+	cs.coordinationV1beta1 = coordinationv1beta1.NewForFactory(factory)
+	cs.coordinationV1 = coordinationv1.NewForFactory(factory)
+	cs.coreV1 = corev1.NewForFactory(factory)
+	cs.discoveryV1 = discoveryv1.NewForFactory(factory)
+	cs.discoveryV1beta1 = discoveryv1beta1.NewForFactory(factory)
+	cs.eventsV1 = eventsv1.NewForFactory(factory)
+	cs.eventsV1beta1 = eventsv1beta1.NewForFactory(factory)
+	cs.extensionsV1beta1 = extensionsv1beta1.NewForFactory(factory)
+	cs.flowcontrolV1alpha1 = flowcontrolv1alpha1.NewForFactory(factory)
+	cs.flowcontrolV1beta1 = flowcontrolv1beta1.NewForFactory(factory)
+	cs.flowcontrolV1beta2 = flowcontrolv1beta2.NewForFactory(factory)
+	cs.networkingV1 = networkingv1.NewForFactory(factory)
+	cs.networkingV1beta1 = networkingv1beta1.NewForFactory(factory)
+	cs.nodeV1 = nodev1.NewForFactory(factory)
+	cs.nodeV1alpha1 = nodev1alpha1.NewForFactory(factory)
+	cs.nodeV1beta1 = nodev1beta1.NewForFactory(factory)
+	cs.policyV1 = policyv1.NewForFactory(factory)
+	cs.policyV1beta1 = policyv1beta1.NewForFactory(factory)
+	cs.rbacV1 = rbacv1.NewForFactory(factory)
+	cs.rbacV1beta1 = rbacv1beta1.NewForFactory(factory)
+	cs.rbacV1alpha1 = rbacv1alpha1.NewForFactory(factory)
+	cs.schedulingV1alpha1 = schedulingv1alpha1.NewForFactory(factory)
+	cs.schedulingV1beta1 = schedulingv1beta1.NewForFactory(factory)
+	cs.schedulingV1 = schedulingv1.NewForFactory(factory)
+	cs.storageV1beta1 = storagev1beta1.NewForFactory(factory)
+	cs.storageV1 = storagev1.NewForFactory(factory)
+	cs.storageV1alpha1 = storagev1alpha1.NewForFactory(factory)
 
 	cs.DiscoveryClient, err = discovery.NewDiscoveryClientForConfig(&configShallowCopy)
 	if err != nil {
@@ -596,103 +467,65 @@ func NewForConfig(c *rest.Config) (*Clientset, error) {
 // NewForConfigOrDie creates a new Clientset for the given config and
 // panics if there is an error in the config.
 func NewForConfigOrDie(c *rest.Config) *Clientset {
-	var cs Clientset
-	cs.admissionregistrationV1 = admissionregistrationv1.NewForConfigOrDie(c)
-	cs.admissionregistrationV1beta1 = admissionregistrationv1beta1.NewForConfigOrDie(c)
-	cs.internalV1alpha1 = internalv1alpha1.NewForConfigOrDie(c)
-	cs.appsV1 = appsv1.NewForConfigOrDie(c)
-	cs.appsV1beta1 = appsv1beta1.NewForConfigOrDie(c)
-	cs.appsV1beta2 = appsv1beta2.NewForConfigOrDie(c)
-	cs.authenticationV1 = authenticationv1.NewForConfigOrDie(c)
-	cs.authenticationV1beta1 = authenticationv1beta1.NewForConfigOrDie(c)
-	cs.authorizationV1 = authorizationv1.NewForConfigOrDie(c)
-	cs.authorizationV1beta1 = authorizationv1beta1.NewForConfigOrDie(c)
-	cs.autoscalingV1 = autoscalingv1.NewForConfigOrDie(c)
-	cs.autoscalingV2beta1 = autoscalingv2beta1.NewForConfigOrDie(c)
-	cs.autoscalingV2beta2 = autoscalingv2beta2.NewForConfigOrDie(c)
-	cs.batchV1 = batchv1.NewForConfigOrDie(c)
-	cs.batchV1beta1 = batchv1beta1.NewForConfigOrDie(c)
-	cs.certificatesV1 = certificatesv1.NewForConfigOrDie(c)
-	cs.certificatesV1beta1 = certificatesv1beta1.NewForConfigOrDie(c)
-	cs.coordinationV1beta1 = coordinationv1beta1.NewForConfigOrDie(c)
-	cs.coordinationV1 = coordinationv1.NewForConfigOrDie(c)
-	cs.coreV1 = corev1.NewForConfigOrDie(c)
-	cs.discoveryV1 = discoveryv1.NewForConfigOrDie(c)
-	cs.discoveryV1beta1 = discoveryv1beta1.NewForConfigOrDie(c)
-	cs.eventsV1 = eventsv1.NewForConfigOrDie(c)
-	cs.eventsV1beta1 = eventsv1beta1.NewForConfigOrDie(c)
-	cs.extensionsV1beta1 = extensionsv1beta1.NewForConfigOrDie(c)
-	cs.flowcontrolV1alpha1 = flowcontrolv1alpha1.NewForConfigOrDie(c)
-	cs.flowcontrolV1beta1 = flowcontrolv1beta1.NewForConfigOrDie(c)
-	cs.flowcontrolV1beta2 = flowcontrolv1beta2.NewForConfigOrDie(c)
-	cs.networkingV1 = networkingv1.NewForConfigOrDie(c)
-	cs.networkingV1beta1 = networkingv1beta1.NewForConfigOrDie(c)
-	cs.nodeV1 = nodev1.NewForConfigOrDie(c)
-	cs.nodeV1alpha1 = nodev1alpha1.NewForConfigOrDie(c)
-	cs.nodeV1beta1 = nodev1beta1.NewForConfigOrDie(c)
-	cs.policyV1 = policyv1.NewForConfigOrDie(c)
-	cs.policyV1beta1 = policyv1beta1.NewForConfigOrDie(c)
-	cs.rbacV1 = rbacv1.NewForConfigOrDie(c)
-	cs.rbacV1beta1 = rbacv1beta1.NewForConfigOrDie(c)
-	cs.rbacV1alpha1 = rbacv1alpha1.NewForConfigOrDie(c)
-	cs.schedulingV1alpha1 = schedulingv1alpha1.NewForConfigOrDie(c)
-	cs.schedulingV1beta1 = schedulingv1beta1.NewForConfigOrDie(c)
-	cs.schedulingV1 = schedulingv1.NewForConfigOrDie(c)
-	cs.storageV1beta1 = storagev1beta1.NewForConfigOrDie(c)
-	cs.storageV1 = storagev1.NewForConfigOrDie(c)
-	cs.storageV1alpha1 = storagev1alpha1.NewForConfigOrDie(c)
-
-	cs.DiscoveryClient = discovery.NewDiscoveryClientForConfigOrDie(c)
-	return &cs
+	cs, err := NewForConfig(c)
+	if err != nil {
+		panic(err)
+	}
+	return cs
 }
 
 // New creates a new Clientset for the given RESTClient.
 func New(c rest.Interface) *Clientset {
+	client, ok := c.(*rest.RESTClient)
+	if !ok {
+		return nil
+	}
+	factory := rest.RESTClientFactoryFromClient(*client)
 	var cs Clientset
-	cs.admissionregistrationV1 = admissionregistrationv1.New(c)
-	cs.admissionregistrationV1beta1 = admissionregistrationv1beta1.New(c)
-	cs.internalV1alpha1 = internalv1alpha1.New(c)
-	cs.appsV1 = appsv1.New(c)
-	cs.appsV1beta1 = appsv1beta1.New(c)
-	cs.appsV1beta2 = appsv1beta2.New(c)
-	cs.authenticationV1 = authenticationv1.New(c)
-	cs.authenticationV1beta1 = authenticationv1beta1.New(c)
-	cs.authorizationV1 = authorizationv1.New(c)
-	cs.authorizationV1beta1 = authorizationv1beta1.New(c)
-	cs.autoscalingV1 = autoscalingv1.New(c)
-	cs.autoscalingV2beta1 = autoscalingv2beta1.New(c)
-	cs.autoscalingV2beta2 = autoscalingv2beta2.New(c)
-	cs.batchV1 = batchv1.New(c)
-	cs.batchV1beta1 = batchv1beta1.New(c)
-	cs.certificatesV1 = certificatesv1.New(c)
-	cs.certificatesV1beta1 = certificatesv1beta1.New(c)
-	cs.coordinationV1beta1 = coordinationv1beta1.New(c)
-	cs.coordinationV1 = coordinationv1.New(c)
-	cs.coreV1 = corev1.New(c)
-	cs.discoveryV1 = discoveryv1.New(c)
-	cs.discoveryV1beta1 = discoveryv1beta1.New(c)
-	cs.eventsV1 = eventsv1.New(c)
-	cs.eventsV1beta1 = eventsv1beta1.New(c)
-	cs.extensionsV1beta1 = extensionsv1beta1.New(c)
-	cs.flowcontrolV1alpha1 = flowcontrolv1alpha1.New(c)
-	cs.flowcontrolV1beta1 = flowcontrolv1beta1.New(c)
-	cs.flowcontrolV1beta2 = flowcontrolv1beta2.New(c)
-	cs.networkingV1 = networkingv1.New(c)
-	cs.networkingV1beta1 = networkingv1beta1.New(c)
-	cs.nodeV1 = nodev1.New(c)
-	cs.nodeV1alpha1 = nodev1alpha1.New(c)
-	cs.nodeV1beta1 = nodev1beta1.New(c)
-	cs.policyV1 = policyv1.New(c)
-	cs.policyV1beta1 = policyv1beta1.New(c)
-	cs.rbacV1 = rbacv1.New(c)
-	cs.rbacV1beta1 = rbacv1beta1.New(c)
-	cs.rbacV1alpha1 = rbacv1alpha1.New(c)
-	cs.schedulingV1alpha1 = schedulingv1alpha1.New(c)
-	cs.schedulingV1beta1 = schedulingv1beta1.New(c)
-	cs.schedulingV1 = schedulingv1.New(c)
-	cs.storageV1beta1 = storagev1beta1.New(c)
-	cs.storageV1 = storagev1.New(c)
-	cs.storageV1alpha1 = storagev1alpha1.New(c)
+	cs.admissionregistrationV1 = admissionregistrationv1.NewForFactory(factory)
+	cs.admissionregistrationV1beta1 = admissionregistrationv1beta1.NewForFactory(factory)
+	cs.internalV1alpha1 = internalv1alpha1.NewForFactory(factory)
+	cs.appsV1 = appsv1.NewForFactory(factory)
+	cs.appsV1beta1 = appsv1beta1.NewForFactory(factory)
+	cs.appsV1beta2 = appsv1beta2.NewForFactory(factory)
+	cs.authenticationV1 = authenticationv1.NewForFactory(factory)
+	cs.authenticationV1beta1 = authenticationv1beta1.NewForFactory(factory)
+	cs.authorizationV1 = authorizationv1.NewForFactory(factory)
+	cs.authorizationV1beta1 = authorizationv1beta1.NewForFactory(factory)
+	cs.autoscalingV1 = autoscalingv1.NewForFactory(factory)
+	cs.autoscalingV2beta1 = autoscalingv2beta1.NewForFactory(factory)
+	cs.autoscalingV2beta2 = autoscalingv2beta2.NewForFactory(factory)
+	cs.batchV1 = batchv1.NewForFactory(factory)
+	cs.batchV1beta1 = batchv1beta1.NewForFactory(factory)
+	cs.certificatesV1 = certificatesv1.NewForFactory(factory)
+	cs.certificatesV1beta1 = certificatesv1beta1.NewForFactory(factory)
+	cs.coordinationV1beta1 = coordinationv1beta1.NewForFactory(factory)
+	cs.coordinationV1 = coordinationv1.NewForFactory(factory)
+	cs.coreV1 = corev1.NewForFactory(factory)
+	cs.discoveryV1 = discoveryv1.NewForFactory(factory)
+	cs.discoveryV1beta1 = discoveryv1beta1.NewForFactory(factory)
+	cs.eventsV1 = eventsv1.NewForFactory(factory)
+	cs.eventsV1beta1 = eventsv1beta1.NewForFactory(factory)
+	cs.extensionsV1beta1 = extensionsv1beta1.NewForFactory(factory)
+	cs.flowcontrolV1alpha1 = flowcontrolv1alpha1.NewForFactory(factory)
+	cs.flowcontrolV1beta1 = flowcontrolv1beta1.NewForFactory(factory)
+	cs.flowcontrolV1beta2 = flowcontrolv1beta2.NewForFactory(factory)
+	cs.networkingV1 = networkingv1.NewForFactory(factory)
+	cs.networkingV1beta1 = networkingv1beta1.NewForFactory(factory)
+	cs.nodeV1 = nodev1.NewForFactory(factory)
+	cs.nodeV1alpha1 = nodev1alpha1.NewForFactory(factory)
+	cs.nodeV1beta1 = nodev1beta1.NewForFactory(factory)
+	cs.policyV1 = policyv1.NewForFactory(factory)
+	cs.policyV1beta1 = policyv1beta1.NewForFactory(factory)
+	cs.rbacV1 = rbacv1.NewForFactory(factory)
+	cs.rbacV1beta1 = rbacv1beta1.NewForFactory(factory)
+	cs.rbacV1alpha1 = rbacv1alpha1.NewForFactory(factory)
+	cs.schedulingV1alpha1 = schedulingv1alpha1.NewForFactory(factory)
+	cs.schedulingV1beta1 = schedulingv1beta1.NewForFactory(factory)
+	cs.schedulingV1 = schedulingv1.NewForFactory(factory)
+	cs.storageV1beta1 = storagev1beta1.NewForFactory(factory)
+	cs.storageV1 = storagev1.NewForFactory(factory)
+	cs.storageV1alpha1 = storagev1alpha1.NewForFactory(factory)
 
 	cs.DiscoveryClient = discovery.NewDiscoveryClient(c)
 	return &cs

--- a/staging/src/k8s.io/client-go/kubernetes/typed/admissionregistration/v1/admissionregistration_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/admissionregistration/v1/admissionregistration_client.go
@@ -20,6 +20,7 @@ package v1
 
 import (
 	v1 "k8s.io/api/admissionregistration/v1"
+	runtime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
 )
@@ -69,6 +70,16 @@ func NewForConfigOrDie(c *rest.Config) *AdmissionregistrationV1Client {
 // New creates a new AdmissionregistrationV1Client for the given RESTClient.
 func New(c rest.Interface) *AdmissionregistrationV1Client {
 	return &AdmissionregistrationV1Client{c}
+}
+
+// NewForFactory creates a new AdmissionregistrationV1Client for the given RESTClientFactory.
+func NewForFactory(f *rest.RESTClientFactory) *AdmissionregistrationV1Client {
+	var config rest.ClientContentConfig
+	config.GroupVersion = v1.SchemeGroupVersion
+	config.Negotiator = runtime.NewClientNegotiator(scheme.Codecs.WithoutConversion(), v1.SchemeGroupVersion)
+	apiPath := "/apis"
+	client := f.NewFor(apiPath, config)
+	return &AdmissionregistrationV1Client{client}
 }
 
 func setConfigDefaults(config *rest.Config) error {

--- a/staging/src/k8s.io/client-go/kubernetes/typed/admissionregistration/v1/admissionregistration_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/admissionregistration/v1/admissionregistration_client.go
@@ -73,13 +73,16 @@ func New(c rest.Interface) *AdmissionregistrationV1Client {
 }
 
 // NewForFactory creates a new AdmissionregistrationV1Client for the given RESTClientFactory.
-func NewForFactory(f *rest.RESTClientFactory) *AdmissionregistrationV1Client {
+func NewForFactory(f *rest.RESTClientFactory, options ...rest.RESTClientOption) (*AdmissionregistrationV1Client, error) {
 	var config rest.ClientContentConfig
 	config.GroupVersion = v1.SchemeGroupVersion
 	config.Negotiator = runtime.NewClientNegotiator(scheme.Codecs.WithoutConversion(), v1.SchemeGroupVersion)
 	apiPath := "/apis"
-	client := f.NewFor(apiPath, config)
-	return &AdmissionregistrationV1Client{client}
+	client, err := f.NewClientWithOptions(apiPath, config, options...)
+	if err != nil {
+		return nil, err
+	}
+	return &AdmissionregistrationV1Client{client}, nil
 }
 
 func setConfigDefaults(config *rest.Config) error {

--- a/staging/src/k8s.io/client-go/kubernetes/typed/admissionregistration/v1beta1/admissionregistration_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/admissionregistration/v1beta1/admissionregistration_client.go
@@ -73,13 +73,16 @@ func New(c rest.Interface) *AdmissionregistrationV1beta1Client {
 }
 
 // NewForFactory creates a new AdmissionregistrationV1beta1Client for the given RESTClientFactory.
-func NewForFactory(f *rest.RESTClientFactory) *AdmissionregistrationV1beta1Client {
+func NewForFactory(f *rest.RESTClientFactory, options ...rest.RESTClientOption) (*AdmissionregistrationV1beta1Client, error) {
 	var config rest.ClientContentConfig
 	config.GroupVersion = v1beta1.SchemeGroupVersion
 	config.Negotiator = runtime.NewClientNegotiator(scheme.Codecs.WithoutConversion(), v1beta1.SchemeGroupVersion)
 	apiPath := "/apis"
-	client := f.NewFor(apiPath, config)
-	return &AdmissionregistrationV1beta1Client{client}
+	client, err := f.NewClientWithOptions(apiPath, config, options...)
+	if err != nil {
+		return nil, err
+	}
+	return &AdmissionregistrationV1beta1Client{client}, nil
 }
 
 func setConfigDefaults(config *rest.Config) error {

--- a/staging/src/k8s.io/client-go/kubernetes/typed/admissionregistration/v1beta1/admissionregistration_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/admissionregistration/v1beta1/admissionregistration_client.go
@@ -20,6 +20,7 @@ package v1beta1
 
 import (
 	v1beta1 "k8s.io/api/admissionregistration/v1beta1"
+	runtime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
 )
@@ -69,6 +70,16 @@ func NewForConfigOrDie(c *rest.Config) *AdmissionregistrationV1beta1Client {
 // New creates a new AdmissionregistrationV1beta1Client for the given RESTClient.
 func New(c rest.Interface) *AdmissionregistrationV1beta1Client {
 	return &AdmissionregistrationV1beta1Client{c}
+}
+
+// NewForFactory creates a new AdmissionregistrationV1beta1Client for the given RESTClientFactory.
+func NewForFactory(f *rest.RESTClientFactory) *AdmissionregistrationV1beta1Client {
+	var config rest.ClientContentConfig
+	config.GroupVersion = v1beta1.SchemeGroupVersion
+	config.Negotiator = runtime.NewClientNegotiator(scheme.Codecs.WithoutConversion(), v1beta1.SchemeGroupVersion)
+	apiPath := "/apis"
+	client := f.NewFor(apiPath, config)
+	return &AdmissionregistrationV1beta1Client{client}
 }
 
 func setConfigDefaults(config *rest.Config) error {

--- a/staging/src/k8s.io/client-go/kubernetes/typed/apiserverinternal/v1alpha1/apiserverinternal_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/apiserverinternal/v1alpha1/apiserverinternal_client.go
@@ -20,6 +20,7 @@ package v1alpha1
 
 import (
 	v1alpha1 "k8s.io/api/apiserverinternal/v1alpha1"
+	runtime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
 )
@@ -64,6 +65,16 @@ func NewForConfigOrDie(c *rest.Config) *InternalV1alpha1Client {
 // New creates a new InternalV1alpha1Client for the given RESTClient.
 func New(c rest.Interface) *InternalV1alpha1Client {
 	return &InternalV1alpha1Client{c}
+}
+
+// NewForFactory creates a new InternalV1alpha1Client for the given RESTClientFactory.
+func NewForFactory(f *rest.RESTClientFactory) *InternalV1alpha1Client {
+	var config rest.ClientContentConfig
+	config.GroupVersion = v1alpha1.SchemeGroupVersion
+	config.Negotiator = runtime.NewClientNegotiator(scheme.Codecs.WithoutConversion(), v1alpha1.SchemeGroupVersion)
+	apiPath := "/apis"
+	client := f.NewFor(apiPath, config)
+	return &InternalV1alpha1Client{client}
 }
 
 func setConfigDefaults(config *rest.Config) error {

--- a/staging/src/k8s.io/client-go/kubernetes/typed/apiserverinternal/v1alpha1/apiserverinternal_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/apiserverinternal/v1alpha1/apiserverinternal_client.go
@@ -68,13 +68,16 @@ func New(c rest.Interface) *InternalV1alpha1Client {
 }
 
 // NewForFactory creates a new InternalV1alpha1Client for the given RESTClientFactory.
-func NewForFactory(f *rest.RESTClientFactory) *InternalV1alpha1Client {
+func NewForFactory(f *rest.RESTClientFactory, options ...rest.RESTClientOption) (*InternalV1alpha1Client, error) {
 	var config rest.ClientContentConfig
 	config.GroupVersion = v1alpha1.SchemeGroupVersion
 	config.Negotiator = runtime.NewClientNegotiator(scheme.Codecs.WithoutConversion(), v1alpha1.SchemeGroupVersion)
 	apiPath := "/apis"
-	client := f.NewFor(apiPath, config)
-	return &InternalV1alpha1Client{client}
+	client, err := f.NewClientWithOptions(apiPath, config, options...)
+	if err != nil {
+		return nil, err
+	}
+	return &InternalV1alpha1Client{client}, nil
 }
 
 func setConfigDefaults(config *rest.Config) error {

--- a/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1/apps_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1/apps_client.go
@@ -88,13 +88,16 @@ func New(c rest.Interface) *AppsV1Client {
 }
 
 // NewForFactory creates a new AppsV1Client for the given RESTClientFactory.
-func NewForFactory(f *rest.RESTClientFactory) *AppsV1Client {
+func NewForFactory(f *rest.RESTClientFactory, options ...rest.RESTClientOption) (*AppsV1Client, error) {
 	var config rest.ClientContentConfig
 	config.GroupVersion = v1.SchemeGroupVersion
 	config.Negotiator = runtime.NewClientNegotiator(scheme.Codecs.WithoutConversion(), v1.SchemeGroupVersion)
 	apiPath := "/apis"
-	client := f.NewFor(apiPath, config)
-	return &AppsV1Client{client}
+	client, err := f.NewClientWithOptions(apiPath, config, options...)
+	if err != nil {
+		return nil, err
+	}
+	return &AppsV1Client{client}, nil
 }
 
 func setConfigDefaults(config *rest.Config) error {

--- a/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1/apps_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1/apps_client.go
@@ -20,6 +20,7 @@ package v1
 
 import (
 	v1 "k8s.io/api/apps/v1"
+	runtime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
 )
@@ -84,6 +85,16 @@ func NewForConfigOrDie(c *rest.Config) *AppsV1Client {
 // New creates a new AppsV1Client for the given RESTClient.
 func New(c rest.Interface) *AppsV1Client {
 	return &AppsV1Client{c}
+}
+
+// NewForFactory creates a new AppsV1Client for the given RESTClientFactory.
+func NewForFactory(f *rest.RESTClientFactory) *AppsV1Client {
+	var config rest.ClientContentConfig
+	config.GroupVersion = v1.SchemeGroupVersion
+	config.Negotiator = runtime.NewClientNegotiator(scheme.Codecs.WithoutConversion(), v1.SchemeGroupVersion)
+	apiPath := "/apis"
+	client := f.NewFor(apiPath, config)
+	return &AppsV1Client{client}
 }
 
 func setConfigDefaults(config *rest.Config) error {

--- a/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta1/apps_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta1/apps_client.go
@@ -20,6 +20,7 @@ package v1beta1
 
 import (
 	v1beta1 "k8s.io/api/apps/v1beta1"
+	runtime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
 )
@@ -74,6 +75,16 @@ func NewForConfigOrDie(c *rest.Config) *AppsV1beta1Client {
 // New creates a new AppsV1beta1Client for the given RESTClient.
 func New(c rest.Interface) *AppsV1beta1Client {
 	return &AppsV1beta1Client{c}
+}
+
+// NewForFactory creates a new AppsV1beta1Client for the given RESTClientFactory.
+func NewForFactory(f *rest.RESTClientFactory) *AppsV1beta1Client {
+	var config rest.ClientContentConfig
+	config.GroupVersion = v1beta1.SchemeGroupVersion
+	config.Negotiator = runtime.NewClientNegotiator(scheme.Codecs.WithoutConversion(), v1beta1.SchemeGroupVersion)
+	apiPath := "/apis"
+	client := f.NewFor(apiPath, config)
+	return &AppsV1beta1Client{client}
 }
 
 func setConfigDefaults(config *rest.Config) error {

--- a/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta1/apps_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta1/apps_client.go
@@ -78,13 +78,16 @@ func New(c rest.Interface) *AppsV1beta1Client {
 }
 
 // NewForFactory creates a new AppsV1beta1Client for the given RESTClientFactory.
-func NewForFactory(f *rest.RESTClientFactory) *AppsV1beta1Client {
+func NewForFactory(f *rest.RESTClientFactory, options ...rest.RESTClientOption) (*AppsV1beta1Client, error) {
 	var config rest.ClientContentConfig
 	config.GroupVersion = v1beta1.SchemeGroupVersion
 	config.Negotiator = runtime.NewClientNegotiator(scheme.Codecs.WithoutConversion(), v1beta1.SchemeGroupVersion)
 	apiPath := "/apis"
-	client := f.NewFor(apiPath, config)
-	return &AppsV1beta1Client{client}
+	client, err := f.NewClientWithOptions(apiPath, config, options...)
+	if err != nil {
+		return nil, err
+	}
+	return &AppsV1beta1Client{client}, nil
 }
 
 func setConfigDefaults(config *rest.Config) error {

--- a/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta2/apps_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta2/apps_client.go
@@ -88,13 +88,16 @@ func New(c rest.Interface) *AppsV1beta2Client {
 }
 
 // NewForFactory creates a new AppsV1beta2Client for the given RESTClientFactory.
-func NewForFactory(f *rest.RESTClientFactory) *AppsV1beta2Client {
+func NewForFactory(f *rest.RESTClientFactory, options ...rest.RESTClientOption) (*AppsV1beta2Client, error) {
 	var config rest.ClientContentConfig
 	config.GroupVersion = v1beta2.SchemeGroupVersion
 	config.Negotiator = runtime.NewClientNegotiator(scheme.Codecs.WithoutConversion(), v1beta2.SchemeGroupVersion)
 	apiPath := "/apis"
-	client := f.NewFor(apiPath, config)
-	return &AppsV1beta2Client{client}
+	client, err := f.NewClientWithOptions(apiPath, config, options...)
+	if err != nil {
+		return nil, err
+	}
+	return &AppsV1beta2Client{client}, nil
 }
 
 func setConfigDefaults(config *rest.Config) error {

--- a/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta2/apps_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta2/apps_client.go
@@ -20,6 +20,7 @@ package v1beta2
 
 import (
 	v1beta2 "k8s.io/api/apps/v1beta2"
+	runtime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
 )
@@ -84,6 +85,16 @@ func NewForConfigOrDie(c *rest.Config) *AppsV1beta2Client {
 // New creates a new AppsV1beta2Client for the given RESTClient.
 func New(c rest.Interface) *AppsV1beta2Client {
 	return &AppsV1beta2Client{c}
+}
+
+// NewForFactory creates a new AppsV1beta2Client for the given RESTClientFactory.
+func NewForFactory(f *rest.RESTClientFactory) *AppsV1beta2Client {
+	var config rest.ClientContentConfig
+	config.GroupVersion = v1beta2.SchemeGroupVersion
+	config.Negotiator = runtime.NewClientNegotiator(scheme.Codecs.WithoutConversion(), v1beta2.SchemeGroupVersion)
+	apiPath := "/apis"
+	client := f.NewFor(apiPath, config)
+	return &AppsV1beta2Client{client}
 }
 
 func setConfigDefaults(config *rest.Config) error {

--- a/staging/src/k8s.io/client-go/kubernetes/typed/authentication/v1/authentication_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/authentication/v1/authentication_client.go
@@ -20,6 +20,7 @@ package v1
 
 import (
 	v1 "k8s.io/api/authentication/v1"
+	runtime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
 )
@@ -64,6 +65,16 @@ func NewForConfigOrDie(c *rest.Config) *AuthenticationV1Client {
 // New creates a new AuthenticationV1Client for the given RESTClient.
 func New(c rest.Interface) *AuthenticationV1Client {
 	return &AuthenticationV1Client{c}
+}
+
+// NewForFactory creates a new AuthenticationV1Client for the given RESTClientFactory.
+func NewForFactory(f *rest.RESTClientFactory) *AuthenticationV1Client {
+	var config rest.ClientContentConfig
+	config.GroupVersion = v1.SchemeGroupVersion
+	config.Negotiator = runtime.NewClientNegotiator(scheme.Codecs.WithoutConversion(), v1.SchemeGroupVersion)
+	apiPath := "/apis"
+	client := f.NewFor(apiPath, config)
+	return &AuthenticationV1Client{client}
 }
 
 func setConfigDefaults(config *rest.Config) error {

--- a/staging/src/k8s.io/client-go/kubernetes/typed/authentication/v1/authentication_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/authentication/v1/authentication_client.go
@@ -68,13 +68,16 @@ func New(c rest.Interface) *AuthenticationV1Client {
 }
 
 // NewForFactory creates a new AuthenticationV1Client for the given RESTClientFactory.
-func NewForFactory(f *rest.RESTClientFactory) *AuthenticationV1Client {
+func NewForFactory(f *rest.RESTClientFactory, options ...rest.RESTClientOption) (*AuthenticationV1Client, error) {
 	var config rest.ClientContentConfig
 	config.GroupVersion = v1.SchemeGroupVersion
 	config.Negotiator = runtime.NewClientNegotiator(scheme.Codecs.WithoutConversion(), v1.SchemeGroupVersion)
 	apiPath := "/apis"
-	client := f.NewFor(apiPath, config)
-	return &AuthenticationV1Client{client}
+	client, err := f.NewClientWithOptions(apiPath, config, options...)
+	if err != nil {
+		return nil, err
+	}
+	return &AuthenticationV1Client{client}, nil
 }
 
 func setConfigDefaults(config *rest.Config) error {

--- a/staging/src/k8s.io/client-go/kubernetes/typed/authentication/v1beta1/authentication_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/authentication/v1beta1/authentication_client.go
@@ -20,6 +20,7 @@ package v1beta1
 
 import (
 	v1beta1 "k8s.io/api/authentication/v1beta1"
+	runtime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
 )
@@ -64,6 +65,16 @@ func NewForConfigOrDie(c *rest.Config) *AuthenticationV1beta1Client {
 // New creates a new AuthenticationV1beta1Client for the given RESTClient.
 func New(c rest.Interface) *AuthenticationV1beta1Client {
 	return &AuthenticationV1beta1Client{c}
+}
+
+// NewForFactory creates a new AuthenticationV1beta1Client for the given RESTClientFactory.
+func NewForFactory(f *rest.RESTClientFactory) *AuthenticationV1beta1Client {
+	var config rest.ClientContentConfig
+	config.GroupVersion = v1beta1.SchemeGroupVersion
+	config.Negotiator = runtime.NewClientNegotiator(scheme.Codecs.WithoutConversion(), v1beta1.SchemeGroupVersion)
+	apiPath := "/apis"
+	client := f.NewFor(apiPath, config)
+	return &AuthenticationV1beta1Client{client}
 }
 
 func setConfigDefaults(config *rest.Config) error {

--- a/staging/src/k8s.io/client-go/kubernetes/typed/authentication/v1beta1/authentication_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/authentication/v1beta1/authentication_client.go
@@ -68,13 +68,16 @@ func New(c rest.Interface) *AuthenticationV1beta1Client {
 }
 
 // NewForFactory creates a new AuthenticationV1beta1Client for the given RESTClientFactory.
-func NewForFactory(f *rest.RESTClientFactory) *AuthenticationV1beta1Client {
+func NewForFactory(f *rest.RESTClientFactory, options ...rest.RESTClientOption) (*AuthenticationV1beta1Client, error) {
 	var config rest.ClientContentConfig
 	config.GroupVersion = v1beta1.SchemeGroupVersion
 	config.Negotiator = runtime.NewClientNegotiator(scheme.Codecs.WithoutConversion(), v1beta1.SchemeGroupVersion)
 	apiPath := "/apis"
-	client := f.NewFor(apiPath, config)
-	return &AuthenticationV1beta1Client{client}
+	client, err := f.NewClientWithOptions(apiPath, config, options...)
+	if err != nil {
+		return nil, err
+	}
+	return &AuthenticationV1beta1Client{client}, nil
 }
 
 func setConfigDefaults(config *rest.Config) error {

--- a/staging/src/k8s.io/client-go/kubernetes/typed/authorization/v1/authorization_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/authorization/v1/authorization_client.go
@@ -20,6 +20,7 @@ package v1
 
 import (
 	v1 "k8s.io/api/authorization/v1"
+	runtime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
 )
@@ -79,6 +80,16 @@ func NewForConfigOrDie(c *rest.Config) *AuthorizationV1Client {
 // New creates a new AuthorizationV1Client for the given RESTClient.
 func New(c rest.Interface) *AuthorizationV1Client {
 	return &AuthorizationV1Client{c}
+}
+
+// NewForFactory creates a new AuthorizationV1Client for the given RESTClientFactory.
+func NewForFactory(f *rest.RESTClientFactory) *AuthorizationV1Client {
+	var config rest.ClientContentConfig
+	config.GroupVersion = v1.SchemeGroupVersion
+	config.Negotiator = runtime.NewClientNegotiator(scheme.Codecs.WithoutConversion(), v1.SchemeGroupVersion)
+	apiPath := "/apis"
+	client := f.NewFor(apiPath, config)
+	return &AuthorizationV1Client{client}
 }
 
 func setConfigDefaults(config *rest.Config) error {

--- a/staging/src/k8s.io/client-go/kubernetes/typed/authorization/v1/authorization_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/authorization/v1/authorization_client.go
@@ -83,13 +83,16 @@ func New(c rest.Interface) *AuthorizationV1Client {
 }
 
 // NewForFactory creates a new AuthorizationV1Client for the given RESTClientFactory.
-func NewForFactory(f *rest.RESTClientFactory) *AuthorizationV1Client {
+func NewForFactory(f *rest.RESTClientFactory, options ...rest.RESTClientOption) (*AuthorizationV1Client, error) {
 	var config rest.ClientContentConfig
 	config.GroupVersion = v1.SchemeGroupVersion
 	config.Negotiator = runtime.NewClientNegotiator(scheme.Codecs.WithoutConversion(), v1.SchemeGroupVersion)
 	apiPath := "/apis"
-	client := f.NewFor(apiPath, config)
-	return &AuthorizationV1Client{client}
+	client, err := f.NewClientWithOptions(apiPath, config, options...)
+	if err != nil {
+		return nil, err
+	}
+	return &AuthorizationV1Client{client}, nil
 }
 
 func setConfigDefaults(config *rest.Config) error {

--- a/staging/src/k8s.io/client-go/kubernetes/typed/authorization/v1beta1/authorization_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/authorization/v1beta1/authorization_client.go
@@ -20,6 +20,7 @@ package v1beta1
 
 import (
 	v1beta1 "k8s.io/api/authorization/v1beta1"
+	runtime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
 )
@@ -79,6 +80,16 @@ func NewForConfigOrDie(c *rest.Config) *AuthorizationV1beta1Client {
 // New creates a new AuthorizationV1beta1Client for the given RESTClient.
 func New(c rest.Interface) *AuthorizationV1beta1Client {
 	return &AuthorizationV1beta1Client{c}
+}
+
+// NewForFactory creates a new AuthorizationV1beta1Client for the given RESTClientFactory.
+func NewForFactory(f *rest.RESTClientFactory) *AuthorizationV1beta1Client {
+	var config rest.ClientContentConfig
+	config.GroupVersion = v1beta1.SchemeGroupVersion
+	config.Negotiator = runtime.NewClientNegotiator(scheme.Codecs.WithoutConversion(), v1beta1.SchemeGroupVersion)
+	apiPath := "/apis"
+	client := f.NewFor(apiPath, config)
+	return &AuthorizationV1beta1Client{client}
 }
 
 func setConfigDefaults(config *rest.Config) error {

--- a/staging/src/k8s.io/client-go/kubernetes/typed/authorization/v1beta1/authorization_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/authorization/v1beta1/authorization_client.go
@@ -83,13 +83,16 @@ func New(c rest.Interface) *AuthorizationV1beta1Client {
 }
 
 // NewForFactory creates a new AuthorizationV1beta1Client for the given RESTClientFactory.
-func NewForFactory(f *rest.RESTClientFactory) *AuthorizationV1beta1Client {
+func NewForFactory(f *rest.RESTClientFactory, options ...rest.RESTClientOption) (*AuthorizationV1beta1Client, error) {
 	var config rest.ClientContentConfig
 	config.GroupVersion = v1beta1.SchemeGroupVersion
 	config.Negotiator = runtime.NewClientNegotiator(scheme.Codecs.WithoutConversion(), v1beta1.SchemeGroupVersion)
 	apiPath := "/apis"
-	client := f.NewFor(apiPath, config)
-	return &AuthorizationV1beta1Client{client}
+	client, err := f.NewClientWithOptions(apiPath, config, options...)
+	if err != nil {
+		return nil, err
+	}
+	return &AuthorizationV1beta1Client{client}, nil
 }
 
 func setConfigDefaults(config *rest.Config) error {

--- a/staging/src/k8s.io/client-go/kubernetes/typed/autoscaling/v1/autoscaling_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/autoscaling/v1/autoscaling_client.go
@@ -68,13 +68,16 @@ func New(c rest.Interface) *AutoscalingV1Client {
 }
 
 // NewForFactory creates a new AutoscalingV1Client for the given RESTClientFactory.
-func NewForFactory(f *rest.RESTClientFactory) *AutoscalingV1Client {
+func NewForFactory(f *rest.RESTClientFactory, options ...rest.RESTClientOption) (*AutoscalingV1Client, error) {
 	var config rest.ClientContentConfig
 	config.GroupVersion = v1.SchemeGroupVersion
 	config.Negotiator = runtime.NewClientNegotiator(scheme.Codecs.WithoutConversion(), v1.SchemeGroupVersion)
 	apiPath := "/apis"
-	client := f.NewFor(apiPath, config)
-	return &AutoscalingV1Client{client}
+	client, err := f.NewClientWithOptions(apiPath, config, options...)
+	if err != nil {
+		return nil, err
+	}
+	return &AutoscalingV1Client{client}, nil
 }
 
 func setConfigDefaults(config *rest.Config) error {

--- a/staging/src/k8s.io/client-go/kubernetes/typed/autoscaling/v1/autoscaling_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/autoscaling/v1/autoscaling_client.go
@@ -20,6 +20,7 @@ package v1
 
 import (
 	v1 "k8s.io/api/autoscaling/v1"
+	runtime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
 )
@@ -64,6 +65,16 @@ func NewForConfigOrDie(c *rest.Config) *AutoscalingV1Client {
 // New creates a new AutoscalingV1Client for the given RESTClient.
 func New(c rest.Interface) *AutoscalingV1Client {
 	return &AutoscalingV1Client{c}
+}
+
+// NewForFactory creates a new AutoscalingV1Client for the given RESTClientFactory.
+func NewForFactory(f *rest.RESTClientFactory) *AutoscalingV1Client {
+	var config rest.ClientContentConfig
+	config.GroupVersion = v1.SchemeGroupVersion
+	config.Negotiator = runtime.NewClientNegotiator(scheme.Codecs.WithoutConversion(), v1.SchemeGroupVersion)
+	apiPath := "/apis"
+	client := f.NewFor(apiPath, config)
+	return &AutoscalingV1Client{client}
 }
 
 func setConfigDefaults(config *rest.Config) error {

--- a/staging/src/k8s.io/client-go/kubernetes/typed/autoscaling/v2beta1/autoscaling_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/autoscaling/v2beta1/autoscaling_client.go
@@ -68,13 +68,16 @@ func New(c rest.Interface) *AutoscalingV2beta1Client {
 }
 
 // NewForFactory creates a new AutoscalingV2beta1Client for the given RESTClientFactory.
-func NewForFactory(f *rest.RESTClientFactory) *AutoscalingV2beta1Client {
+func NewForFactory(f *rest.RESTClientFactory, options ...rest.RESTClientOption) (*AutoscalingV2beta1Client, error) {
 	var config rest.ClientContentConfig
 	config.GroupVersion = v2beta1.SchemeGroupVersion
 	config.Negotiator = runtime.NewClientNegotiator(scheme.Codecs.WithoutConversion(), v2beta1.SchemeGroupVersion)
 	apiPath := "/apis"
-	client := f.NewFor(apiPath, config)
-	return &AutoscalingV2beta1Client{client}
+	client, err := f.NewClientWithOptions(apiPath, config, options...)
+	if err != nil {
+		return nil, err
+	}
+	return &AutoscalingV2beta1Client{client}, nil
 }
 
 func setConfigDefaults(config *rest.Config) error {

--- a/staging/src/k8s.io/client-go/kubernetes/typed/autoscaling/v2beta1/autoscaling_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/autoscaling/v2beta1/autoscaling_client.go
@@ -20,6 +20,7 @@ package v2beta1
 
 import (
 	v2beta1 "k8s.io/api/autoscaling/v2beta1"
+	runtime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
 )
@@ -64,6 +65,16 @@ func NewForConfigOrDie(c *rest.Config) *AutoscalingV2beta1Client {
 // New creates a new AutoscalingV2beta1Client for the given RESTClient.
 func New(c rest.Interface) *AutoscalingV2beta1Client {
 	return &AutoscalingV2beta1Client{c}
+}
+
+// NewForFactory creates a new AutoscalingV2beta1Client for the given RESTClientFactory.
+func NewForFactory(f *rest.RESTClientFactory) *AutoscalingV2beta1Client {
+	var config rest.ClientContentConfig
+	config.GroupVersion = v2beta1.SchemeGroupVersion
+	config.Negotiator = runtime.NewClientNegotiator(scheme.Codecs.WithoutConversion(), v2beta1.SchemeGroupVersion)
+	apiPath := "/apis"
+	client := f.NewFor(apiPath, config)
+	return &AutoscalingV2beta1Client{client}
 }
 
 func setConfigDefaults(config *rest.Config) error {

--- a/staging/src/k8s.io/client-go/kubernetes/typed/autoscaling/v2beta2/autoscaling_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/autoscaling/v2beta2/autoscaling_client.go
@@ -68,13 +68,16 @@ func New(c rest.Interface) *AutoscalingV2beta2Client {
 }
 
 // NewForFactory creates a new AutoscalingV2beta2Client for the given RESTClientFactory.
-func NewForFactory(f *rest.RESTClientFactory) *AutoscalingV2beta2Client {
+func NewForFactory(f *rest.RESTClientFactory, options ...rest.RESTClientOption) (*AutoscalingV2beta2Client, error) {
 	var config rest.ClientContentConfig
 	config.GroupVersion = v2beta2.SchemeGroupVersion
 	config.Negotiator = runtime.NewClientNegotiator(scheme.Codecs.WithoutConversion(), v2beta2.SchemeGroupVersion)
 	apiPath := "/apis"
-	client := f.NewFor(apiPath, config)
-	return &AutoscalingV2beta2Client{client}
+	client, err := f.NewClientWithOptions(apiPath, config, options...)
+	if err != nil {
+		return nil, err
+	}
+	return &AutoscalingV2beta2Client{client}, nil
 }
 
 func setConfigDefaults(config *rest.Config) error {

--- a/staging/src/k8s.io/client-go/kubernetes/typed/autoscaling/v2beta2/autoscaling_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/autoscaling/v2beta2/autoscaling_client.go
@@ -20,6 +20,7 @@ package v2beta2
 
 import (
 	v2beta2 "k8s.io/api/autoscaling/v2beta2"
+	runtime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
 )
@@ -64,6 +65,16 @@ func NewForConfigOrDie(c *rest.Config) *AutoscalingV2beta2Client {
 // New creates a new AutoscalingV2beta2Client for the given RESTClient.
 func New(c rest.Interface) *AutoscalingV2beta2Client {
 	return &AutoscalingV2beta2Client{c}
+}
+
+// NewForFactory creates a new AutoscalingV2beta2Client for the given RESTClientFactory.
+func NewForFactory(f *rest.RESTClientFactory) *AutoscalingV2beta2Client {
+	var config rest.ClientContentConfig
+	config.GroupVersion = v2beta2.SchemeGroupVersion
+	config.Negotiator = runtime.NewClientNegotiator(scheme.Codecs.WithoutConversion(), v2beta2.SchemeGroupVersion)
+	apiPath := "/apis"
+	client := f.NewFor(apiPath, config)
+	return &AutoscalingV2beta2Client{client}
 }
 
 func setConfigDefaults(config *rest.Config) error {

--- a/staging/src/k8s.io/client-go/kubernetes/typed/batch/v1/batch_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/batch/v1/batch_client.go
@@ -20,6 +20,7 @@ package v1
 
 import (
 	v1 "k8s.io/api/batch/v1"
+	runtime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
 )
@@ -69,6 +70,16 @@ func NewForConfigOrDie(c *rest.Config) *BatchV1Client {
 // New creates a new BatchV1Client for the given RESTClient.
 func New(c rest.Interface) *BatchV1Client {
 	return &BatchV1Client{c}
+}
+
+// NewForFactory creates a new BatchV1Client for the given RESTClientFactory.
+func NewForFactory(f *rest.RESTClientFactory) *BatchV1Client {
+	var config rest.ClientContentConfig
+	config.GroupVersion = v1.SchemeGroupVersion
+	config.Negotiator = runtime.NewClientNegotiator(scheme.Codecs.WithoutConversion(), v1.SchemeGroupVersion)
+	apiPath := "/apis"
+	client := f.NewFor(apiPath, config)
+	return &BatchV1Client{client}
 }
 
 func setConfigDefaults(config *rest.Config) error {

--- a/staging/src/k8s.io/client-go/kubernetes/typed/batch/v1/batch_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/batch/v1/batch_client.go
@@ -73,13 +73,16 @@ func New(c rest.Interface) *BatchV1Client {
 }
 
 // NewForFactory creates a new BatchV1Client for the given RESTClientFactory.
-func NewForFactory(f *rest.RESTClientFactory) *BatchV1Client {
+func NewForFactory(f *rest.RESTClientFactory, options ...rest.RESTClientOption) (*BatchV1Client, error) {
 	var config rest.ClientContentConfig
 	config.GroupVersion = v1.SchemeGroupVersion
 	config.Negotiator = runtime.NewClientNegotiator(scheme.Codecs.WithoutConversion(), v1.SchemeGroupVersion)
 	apiPath := "/apis"
-	client := f.NewFor(apiPath, config)
-	return &BatchV1Client{client}
+	client, err := f.NewClientWithOptions(apiPath, config, options...)
+	if err != nil {
+		return nil, err
+	}
+	return &BatchV1Client{client}, nil
 }
 
 func setConfigDefaults(config *rest.Config) error {

--- a/staging/src/k8s.io/client-go/kubernetes/typed/batch/v1beta1/batch_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/batch/v1beta1/batch_client.go
@@ -20,6 +20,7 @@ package v1beta1
 
 import (
 	v1beta1 "k8s.io/api/batch/v1beta1"
+	runtime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
 )
@@ -64,6 +65,16 @@ func NewForConfigOrDie(c *rest.Config) *BatchV1beta1Client {
 // New creates a new BatchV1beta1Client for the given RESTClient.
 func New(c rest.Interface) *BatchV1beta1Client {
 	return &BatchV1beta1Client{c}
+}
+
+// NewForFactory creates a new BatchV1beta1Client for the given RESTClientFactory.
+func NewForFactory(f *rest.RESTClientFactory) *BatchV1beta1Client {
+	var config rest.ClientContentConfig
+	config.GroupVersion = v1beta1.SchemeGroupVersion
+	config.Negotiator = runtime.NewClientNegotiator(scheme.Codecs.WithoutConversion(), v1beta1.SchemeGroupVersion)
+	apiPath := "/apis"
+	client := f.NewFor(apiPath, config)
+	return &BatchV1beta1Client{client}
 }
 
 func setConfigDefaults(config *rest.Config) error {

--- a/staging/src/k8s.io/client-go/kubernetes/typed/batch/v1beta1/batch_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/batch/v1beta1/batch_client.go
@@ -68,13 +68,16 @@ func New(c rest.Interface) *BatchV1beta1Client {
 }
 
 // NewForFactory creates a new BatchV1beta1Client for the given RESTClientFactory.
-func NewForFactory(f *rest.RESTClientFactory) *BatchV1beta1Client {
+func NewForFactory(f *rest.RESTClientFactory, options ...rest.RESTClientOption) (*BatchV1beta1Client, error) {
 	var config rest.ClientContentConfig
 	config.GroupVersion = v1beta1.SchemeGroupVersion
 	config.Negotiator = runtime.NewClientNegotiator(scheme.Codecs.WithoutConversion(), v1beta1.SchemeGroupVersion)
 	apiPath := "/apis"
-	client := f.NewFor(apiPath, config)
-	return &BatchV1beta1Client{client}
+	client, err := f.NewClientWithOptions(apiPath, config, options...)
+	if err != nil {
+		return nil, err
+	}
+	return &BatchV1beta1Client{client}, nil
 }
 
 func setConfigDefaults(config *rest.Config) error {

--- a/staging/src/k8s.io/client-go/kubernetes/typed/certificates/v1/certificates_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/certificates/v1/certificates_client.go
@@ -68,13 +68,16 @@ func New(c rest.Interface) *CertificatesV1Client {
 }
 
 // NewForFactory creates a new CertificatesV1Client for the given RESTClientFactory.
-func NewForFactory(f *rest.RESTClientFactory) *CertificatesV1Client {
+func NewForFactory(f *rest.RESTClientFactory, options ...rest.RESTClientOption) (*CertificatesV1Client, error) {
 	var config rest.ClientContentConfig
 	config.GroupVersion = v1.SchemeGroupVersion
 	config.Negotiator = runtime.NewClientNegotiator(scheme.Codecs.WithoutConversion(), v1.SchemeGroupVersion)
 	apiPath := "/apis"
-	client := f.NewFor(apiPath, config)
-	return &CertificatesV1Client{client}
+	client, err := f.NewClientWithOptions(apiPath, config, options...)
+	if err != nil {
+		return nil, err
+	}
+	return &CertificatesV1Client{client}, nil
 }
 
 func setConfigDefaults(config *rest.Config) error {

--- a/staging/src/k8s.io/client-go/kubernetes/typed/certificates/v1/certificates_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/certificates/v1/certificates_client.go
@@ -20,6 +20,7 @@ package v1
 
 import (
 	v1 "k8s.io/api/certificates/v1"
+	runtime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
 )
@@ -64,6 +65,16 @@ func NewForConfigOrDie(c *rest.Config) *CertificatesV1Client {
 // New creates a new CertificatesV1Client for the given RESTClient.
 func New(c rest.Interface) *CertificatesV1Client {
 	return &CertificatesV1Client{c}
+}
+
+// NewForFactory creates a new CertificatesV1Client for the given RESTClientFactory.
+func NewForFactory(f *rest.RESTClientFactory) *CertificatesV1Client {
+	var config rest.ClientContentConfig
+	config.GroupVersion = v1.SchemeGroupVersion
+	config.Negotiator = runtime.NewClientNegotiator(scheme.Codecs.WithoutConversion(), v1.SchemeGroupVersion)
+	apiPath := "/apis"
+	client := f.NewFor(apiPath, config)
+	return &CertificatesV1Client{client}
 }
 
 func setConfigDefaults(config *rest.Config) error {

--- a/staging/src/k8s.io/client-go/kubernetes/typed/certificates/v1beta1/certificates_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/certificates/v1beta1/certificates_client.go
@@ -68,13 +68,16 @@ func New(c rest.Interface) *CertificatesV1beta1Client {
 }
 
 // NewForFactory creates a new CertificatesV1beta1Client for the given RESTClientFactory.
-func NewForFactory(f *rest.RESTClientFactory) *CertificatesV1beta1Client {
+func NewForFactory(f *rest.RESTClientFactory, options ...rest.RESTClientOption) (*CertificatesV1beta1Client, error) {
 	var config rest.ClientContentConfig
 	config.GroupVersion = v1beta1.SchemeGroupVersion
 	config.Negotiator = runtime.NewClientNegotiator(scheme.Codecs.WithoutConversion(), v1beta1.SchemeGroupVersion)
 	apiPath := "/apis"
-	client := f.NewFor(apiPath, config)
-	return &CertificatesV1beta1Client{client}
+	client, err := f.NewClientWithOptions(apiPath, config, options...)
+	if err != nil {
+		return nil, err
+	}
+	return &CertificatesV1beta1Client{client}, nil
 }
 
 func setConfigDefaults(config *rest.Config) error {

--- a/staging/src/k8s.io/client-go/kubernetes/typed/certificates/v1beta1/certificates_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/certificates/v1beta1/certificates_client.go
@@ -20,6 +20,7 @@ package v1beta1
 
 import (
 	v1beta1 "k8s.io/api/certificates/v1beta1"
+	runtime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
 )
@@ -64,6 +65,16 @@ func NewForConfigOrDie(c *rest.Config) *CertificatesV1beta1Client {
 // New creates a new CertificatesV1beta1Client for the given RESTClient.
 func New(c rest.Interface) *CertificatesV1beta1Client {
 	return &CertificatesV1beta1Client{c}
+}
+
+// NewForFactory creates a new CertificatesV1beta1Client for the given RESTClientFactory.
+func NewForFactory(f *rest.RESTClientFactory) *CertificatesV1beta1Client {
+	var config rest.ClientContentConfig
+	config.GroupVersion = v1beta1.SchemeGroupVersion
+	config.Negotiator = runtime.NewClientNegotiator(scheme.Codecs.WithoutConversion(), v1beta1.SchemeGroupVersion)
+	apiPath := "/apis"
+	client := f.NewFor(apiPath, config)
+	return &CertificatesV1beta1Client{client}
 }
 
 func setConfigDefaults(config *rest.Config) error {

--- a/staging/src/k8s.io/client-go/kubernetes/typed/coordination/v1/coordination_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/coordination/v1/coordination_client.go
@@ -68,13 +68,16 @@ func New(c rest.Interface) *CoordinationV1Client {
 }
 
 // NewForFactory creates a new CoordinationV1Client for the given RESTClientFactory.
-func NewForFactory(f *rest.RESTClientFactory) *CoordinationV1Client {
+func NewForFactory(f *rest.RESTClientFactory, options ...rest.RESTClientOption) (*CoordinationV1Client, error) {
 	var config rest.ClientContentConfig
 	config.GroupVersion = v1.SchemeGroupVersion
 	config.Negotiator = runtime.NewClientNegotiator(scheme.Codecs.WithoutConversion(), v1.SchemeGroupVersion)
 	apiPath := "/apis"
-	client := f.NewFor(apiPath, config)
-	return &CoordinationV1Client{client}
+	client, err := f.NewClientWithOptions(apiPath, config, options...)
+	if err != nil {
+		return nil, err
+	}
+	return &CoordinationV1Client{client}, nil
 }
 
 func setConfigDefaults(config *rest.Config) error {

--- a/staging/src/k8s.io/client-go/kubernetes/typed/coordination/v1/coordination_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/coordination/v1/coordination_client.go
@@ -20,6 +20,7 @@ package v1
 
 import (
 	v1 "k8s.io/api/coordination/v1"
+	runtime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
 )
@@ -64,6 +65,16 @@ func NewForConfigOrDie(c *rest.Config) *CoordinationV1Client {
 // New creates a new CoordinationV1Client for the given RESTClient.
 func New(c rest.Interface) *CoordinationV1Client {
 	return &CoordinationV1Client{c}
+}
+
+// NewForFactory creates a new CoordinationV1Client for the given RESTClientFactory.
+func NewForFactory(f *rest.RESTClientFactory) *CoordinationV1Client {
+	var config rest.ClientContentConfig
+	config.GroupVersion = v1.SchemeGroupVersion
+	config.Negotiator = runtime.NewClientNegotiator(scheme.Codecs.WithoutConversion(), v1.SchemeGroupVersion)
+	apiPath := "/apis"
+	client := f.NewFor(apiPath, config)
+	return &CoordinationV1Client{client}
 }
 
 func setConfigDefaults(config *rest.Config) error {

--- a/staging/src/k8s.io/client-go/kubernetes/typed/coordination/v1beta1/coordination_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/coordination/v1beta1/coordination_client.go
@@ -20,6 +20,7 @@ package v1beta1
 
 import (
 	v1beta1 "k8s.io/api/coordination/v1beta1"
+	runtime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
 )
@@ -64,6 +65,16 @@ func NewForConfigOrDie(c *rest.Config) *CoordinationV1beta1Client {
 // New creates a new CoordinationV1beta1Client for the given RESTClient.
 func New(c rest.Interface) *CoordinationV1beta1Client {
 	return &CoordinationV1beta1Client{c}
+}
+
+// NewForFactory creates a new CoordinationV1beta1Client for the given RESTClientFactory.
+func NewForFactory(f *rest.RESTClientFactory) *CoordinationV1beta1Client {
+	var config rest.ClientContentConfig
+	config.GroupVersion = v1beta1.SchemeGroupVersion
+	config.Negotiator = runtime.NewClientNegotiator(scheme.Codecs.WithoutConversion(), v1beta1.SchemeGroupVersion)
+	apiPath := "/apis"
+	client := f.NewFor(apiPath, config)
+	return &CoordinationV1beta1Client{client}
 }
 
 func setConfigDefaults(config *rest.Config) error {

--- a/staging/src/k8s.io/client-go/kubernetes/typed/coordination/v1beta1/coordination_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/coordination/v1beta1/coordination_client.go
@@ -68,13 +68,16 @@ func New(c rest.Interface) *CoordinationV1beta1Client {
 }
 
 // NewForFactory creates a new CoordinationV1beta1Client for the given RESTClientFactory.
-func NewForFactory(f *rest.RESTClientFactory) *CoordinationV1beta1Client {
+func NewForFactory(f *rest.RESTClientFactory, options ...rest.RESTClientOption) (*CoordinationV1beta1Client, error) {
 	var config rest.ClientContentConfig
 	config.GroupVersion = v1beta1.SchemeGroupVersion
 	config.Negotiator = runtime.NewClientNegotiator(scheme.Codecs.WithoutConversion(), v1beta1.SchemeGroupVersion)
 	apiPath := "/apis"
-	client := f.NewFor(apiPath, config)
-	return &CoordinationV1beta1Client{client}
+	client, err := f.NewClientWithOptions(apiPath, config, options...)
+	if err != nil {
+		return nil, err
+	}
+	return &CoordinationV1beta1Client{client}, nil
 }
 
 func setConfigDefaults(config *rest.Config) error {

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/core_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/core_client.go
@@ -143,13 +143,16 @@ func New(c rest.Interface) *CoreV1Client {
 }
 
 // NewForFactory creates a new CoreV1Client for the given RESTClientFactory.
-func NewForFactory(f *rest.RESTClientFactory) *CoreV1Client {
+func NewForFactory(f *rest.RESTClientFactory, options ...rest.RESTClientOption) (*CoreV1Client, error) {
 	var config rest.ClientContentConfig
 	config.GroupVersion = v1.SchemeGroupVersion
 	config.Negotiator = runtime.NewClientNegotiator(scheme.Codecs.WithoutConversion(), v1.SchemeGroupVersion)
 	apiPath := "/api"
-	client := f.NewFor(apiPath, config)
-	return &CoreV1Client{client}
+	client, err := f.NewClientWithOptions(apiPath, config, options...)
+	if err != nil {
+		return nil, err
+	}
+	return &CoreV1Client{client}, nil
 }
 
 func setConfigDefaults(config *rest.Config) error {

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/core_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/core_client.go
@@ -20,6 +20,7 @@ package v1
 
 import (
 	v1 "k8s.io/api/core/v1"
+	runtime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
 )
@@ -139,6 +140,16 @@ func NewForConfigOrDie(c *rest.Config) *CoreV1Client {
 // New creates a new CoreV1Client for the given RESTClient.
 func New(c rest.Interface) *CoreV1Client {
 	return &CoreV1Client{c}
+}
+
+// NewForFactory creates a new CoreV1Client for the given RESTClientFactory.
+func NewForFactory(f *rest.RESTClientFactory) *CoreV1Client {
+	var config rest.ClientContentConfig
+	config.GroupVersion = v1.SchemeGroupVersion
+	config.Negotiator = runtime.NewClientNegotiator(scheme.Codecs.WithoutConversion(), v1.SchemeGroupVersion)
+	apiPath := "/api"
+	client := f.NewFor(apiPath, config)
+	return &CoreV1Client{client}
 }
 
 func setConfigDefaults(config *rest.Config) error {

--- a/staging/src/k8s.io/client-go/kubernetes/typed/discovery/v1/discovery_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/discovery/v1/discovery_client.go
@@ -68,13 +68,16 @@ func New(c rest.Interface) *DiscoveryV1Client {
 }
 
 // NewForFactory creates a new DiscoveryV1Client for the given RESTClientFactory.
-func NewForFactory(f *rest.RESTClientFactory) *DiscoveryV1Client {
+func NewForFactory(f *rest.RESTClientFactory, options ...rest.RESTClientOption) (*DiscoveryV1Client, error) {
 	var config rest.ClientContentConfig
 	config.GroupVersion = v1.SchemeGroupVersion
 	config.Negotiator = runtime.NewClientNegotiator(scheme.Codecs.WithoutConversion(), v1.SchemeGroupVersion)
 	apiPath := "/apis"
-	client := f.NewFor(apiPath, config)
-	return &DiscoveryV1Client{client}
+	client, err := f.NewClientWithOptions(apiPath, config, options...)
+	if err != nil {
+		return nil, err
+	}
+	return &DiscoveryV1Client{client}, nil
 }
 
 func setConfigDefaults(config *rest.Config) error {

--- a/staging/src/k8s.io/client-go/kubernetes/typed/discovery/v1/discovery_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/discovery/v1/discovery_client.go
@@ -20,6 +20,7 @@ package v1
 
 import (
 	v1 "k8s.io/api/discovery/v1"
+	runtime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
 )
@@ -64,6 +65,16 @@ func NewForConfigOrDie(c *rest.Config) *DiscoveryV1Client {
 // New creates a new DiscoveryV1Client for the given RESTClient.
 func New(c rest.Interface) *DiscoveryV1Client {
 	return &DiscoveryV1Client{c}
+}
+
+// NewForFactory creates a new DiscoveryV1Client for the given RESTClientFactory.
+func NewForFactory(f *rest.RESTClientFactory) *DiscoveryV1Client {
+	var config rest.ClientContentConfig
+	config.GroupVersion = v1.SchemeGroupVersion
+	config.Negotiator = runtime.NewClientNegotiator(scheme.Codecs.WithoutConversion(), v1.SchemeGroupVersion)
+	apiPath := "/apis"
+	client := f.NewFor(apiPath, config)
+	return &DiscoveryV1Client{client}
 }
 
 func setConfigDefaults(config *rest.Config) error {

--- a/staging/src/k8s.io/client-go/kubernetes/typed/discovery/v1beta1/discovery_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/discovery/v1beta1/discovery_client.go
@@ -68,13 +68,16 @@ func New(c rest.Interface) *DiscoveryV1beta1Client {
 }
 
 // NewForFactory creates a new DiscoveryV1beta1Client for the given RESTClientFactory.
-func NewForFactory(f *rest.RESTClientFactory) *DiscoveryV1beta1Client {
+func NewForFactory(f *rest.RESTClientFactory, options ...rest.RESTClientOption) (*DiscoveryV1beta1Client, error) {
 	var config rest.ClientContentConfig
 	config.GroupVersion = v1beta1.SchemeGroupVersion
 	config.Negotiator = runtime.NewClientNegotiator(scheme.Codecs.WithoutConversion(), v1beta1.SchemeGroupVersion)
 	apiPath := "/apis"
-	client := f.NewFor(apiPath, config)
-	return &DiscoveryV1beta1Client{client}
+	client, err := f.NewClientWithOptions(apiPath, config, options...)
+	if err != nil {
+		return nil, err
+	}
+	return &DiscoveryV1beta1Client{client}, nil
 }
 
 func setConfigDefaults(config *rest.Config) error {

--- a/staging/src/k8s.io/client-go/kubernetes/typed/discovery/v1beta1/discovery_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/discovery/v1beta1/discovery_client.go
@@ -20,6 +20,7 @@ package v1beta1
 
 import (
 	v1beta1 "k8s.io/api/discovery/v1beta1"
+	runtime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
 )
@@ -64,6 +65,16 @@ func NewForConfigOrDie(c *rest.Config) *DiscoveryV1beta1Client {
 // New creates a new DiscoveryV1beta1Client for the given RESTClient.
 func New(c rest.Interface) *DiscoveryV1beta1Client {
 	return &DiscoveryV1beta1Client{c}
+}
+
+// NewForFactory creates a new DiscoveryV1beta1Client for the given RESTClientFactory.
+func NewForFactory(f *rest.RESTClientFactory) *DiscoveryV1beta1Client {
+	var config rest.ClientContentConfig
+	config.GroupVersion = v1beta1.SchemeGroupVersion
+	config.Negotiator = runtime.NewClientNegotiator(scheme.Codecs.WithoutConversion(), v1beta1.SchemeGroupVersion)
+	apiPath := "/apis"
+	client := f.NewFor(apiPath, config)
+	return &DiscoveryV1beta1Client{client}
 }
 
 func setConfigDefaults(config *rest.Config) error {

--- a/staging/src/k8s.io/client-go/kubernetes/typed/events/v1/events_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/events/v1/events_client.go
@@ -68,13 +68,16 @@ func New(c rest.Interface) *EventsV1Client {
 }
 
 // NewForFactory creates a new EventsV1Client for the given RESTClientFactory.
-func NewForFactory(f *rest.RESTClientFactory) *EventsV1Client {
+func NewForFactory(f *rest.RESTClientFactory, options ...rest.RESTClientOption) (*EventsV1Client, error) {
 	var config rest.ClientContentConfig
 	config.GroupVersion = v1.SchemeGroupVersion
 	config.Negotiator = runtime.NewClientNegotiator(scheme.Codecs.WithoutConversion(), v1.SchemeGroupVersion)
 	apiPath := "/apis"
-	client := f.NewFor(apiPath, config)
-	return &EventsV1Client{client}
+	client, err := f.NewClientWithOptions(apiPath, config, options...)
+	if err != nil {
+		return nil, err
+	}
+	return &EventsV1Client{client}, nil
 }
 
 func setConfigDefaults(config *rest.Config) error {

--- a/staging/src/k8s.io/client-go/kubernetes/typed/events/v1/events_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/events/v1/events_client.go
@@ -20,6 +20,7 @@ package v1
 
 import (
 	v1 "k8s.io/api/events/v1"
+	runtime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
 )
@@ -64,6 +65,16 @@ func NewForConfigOrDie(c *rest.Config) *EventsV1Client {
 // New creates a new EventsV1Client for the given RESTClient.
 func New(c rest.Interface) *EventsV1Client {
 	return &EventsV1Client{c}
+}
+
+// NewForFactory creates a new EventsV1Client for the given RESTClientFactory.
+func NewForFactory(f *rest.RESTClientFactory) *EventsV1Client {
+	var config rest.ClientContentConfig
+	config.GroupVersion = v1.SchemeGroupVersion
+	config.Negotiator = runtime.NewClientNegotiator(scheme.Codecs.WithoutConversion(), v1.SchemeGroupVersion)
+	apiPath := "/apis"
+	client := f.NewFor(apiPath, config)
+	return &EventsV1Client{client}
 }
 
 func setConfigDefaults(config *rest.Config) error {

--- a/staging/src/k8s.io/client-go/kubernetes/typed/events/v1beta1/events_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/events/v1beta1/events_client.go
@@ -20,6 +20,7 @@ package v1beta1
 
 import (
 	v1beta1 "k8s.io/api/events/v1beta1"
+	runtime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
 )
@@ -64,6 +65,16 @@ func NewForConfigOrDie(c *rest.Config) *EventsV1beta1Client {
 // New creates a new EventsV1beta1Client for the given RESTClient.
 func New(c rest.Interface) *EventsV1beta1Client {
 	return &EventsV1beta1Client{c}
+}
+
+// NewForFactory creates a new EventsV1beta1Client for the given RESTClientFactory.
+func NewForFactory(f *rest.RESTClientFactory) *EventsV1beta1Client {
+	var config rest.ClientContentConfig
+	config.GroupVersion = v1beta1.SchemeGroupVersion
+	config.Negotiator = runtime.NewClientNegotiator(scheme.Codecs.WithoutConversion(), v1beta1.SchemeGroupVersion)
+	apiPath := "/apis"
+	client := f.NewFor(apiPath, config)
+	return &EventsV1beta1Client{client}
 }
 
 func setConfigDefaults(config *rest.Config) error {

--- a/staging/src/k8s.io/client-go/kubernetes/typed/events/v1beta1/events_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/events/v1beta1/events_client.go
@@ -68,13 +68,16 @@ func New(c rest.Interface) *EventsV1beta1Client {
 }
 
 // NewForFactory creates a new EventsV1beta1Client for the given RESTClientFactory.
-func NewForFactory(f *rest.RESTClientFactory) *EventsV1beta1Client {
+func NewForFactory(f *rest.RESTClientFactory, options ...rest.RESTClientOption) (*EventsV1beta1Client, error) {
 	var config rest.ClientContentConfig
 	config.GroupVersion = v1beta1.SchemeGroupVersion
 	config.Negotiator = runtime.NewClientNegotiator(scheme.Codecs.WithoutConversion(), v1beta1.SchemeGroupVersion)
 	apiPath := "/apis"
-	client := f.NewFor(apiPath, config)
-	return &EventsV1beta1Client{client}
+	client, err := f.NewClientWithOptions(apiPath, config, options...)
+	if err != nil {
+		return nil, err
+	}
+	return &EventsV1beta1Client{client}, nil
 }
 
 func setConfigDefaults(config *rest.Config) error {

--- a/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/extensions_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/extensions_client.go
@@ -20,6 +20,7 @@ package v1beta1
 
 import (
 	v1beta1 "k8s.io/api/extensions/v1beta1"
+	runtime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
 )
@@ -89,6 +90,16 @@ func NewForConfigOrDie(c *rest.Config) *ExtensionsV1beta1Client {
 // New creates a new ExtensionsV1beta1Client for the given RESTClient.
 func New(c rest.Interface) *ExtensionsV1beta1Client {
 	return &ExtensionsV1beta1Client{c}
+}
+
+// NewForFactory creates a new ExtensionsV1beta1Client for the given RESTClientFactory.
+func NewForFactory(f *rest.RESTClientFactory) *ExtensionsV1beta1Client {
+	var config rest.ClientContentConfig
+	config.GroupVersion = v1beta1.SchemeGroupVersion
+	config.Negotiator = runtime.NewClientNegotiator(scheme.Codecs.WithoutConversion(), v1beta1.SchemeGroupVersion)
+	apiPath := "/apis"
+	client := f.NewFor(apiPath, config)
+	return &ExtensionsV1beta1Client{client}
 }
 
 func setConfigDefaults(config *rest.Config) error {

--- a/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/extensions_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/extensions_client.go
@@ -93,13 +93,16 @@ func New(c rest.Interface) *ExtensionsV1beta1Client {
 }
 
 // NewForFactory creates a new ExtensionsV1beta1Client for the given RESTClientFactory.
-func NewForFactory(f *rest.RESTClientFactory) *ExtensionsV1beta1Client {
+func NewForFactory(f *rest.RESTClientFactory, options ...rest.RESTClientOption) (*ExtensionsV1beta1Client, error) {
 	var config rest.ClientContentConfig
 	config.GroupVersion = v1beta1.SchemeGroupVersion
 	config.Negotiator = runtime.NewClientNegotiator(scheme.Codecs.WithoutConversion(), v1beta1.SchemeGroupVersion)
 	apiPath := "/apis"
-	client := f.NewFor(apiPath, config)
-	return &ExtensionsV1beta1Client{client}
+	client, err := f.NewClientWithOptions(apiPath, config, options...)
+	if err != nil {
+		return nil, err
+	}
+	return &ExtensionsV1beta1Client{client}, nil
 }
 
 func setConfigDefaults(config *rest.Config) error {

--- a/staging/src/k8s.io/client-go/kubernetes/typed/flowcontrol/v1alpha1/flowcontrol_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/flowcontrol/v1alpha1/flowcontrol_client.go
@@ -73,13 +73,16 @@ func New(c rest.Interface) *FlowcontrolV1alpha1Client {
 }
 
 // NewForFactory creates a new FlowcontrolV1alpha1Client for the given RESTClientFactory.
-func NewForFactory(f *rest.RESTClientFactory) *FlowcontrolV1alpha1Client {
+func NewForFactory(f *rest.RESTClientFactory, options ...rest.RESTClientOption) (*FlowcontrolV1alpha1Client, error) {
 	var config rest.ClientContentConfig
 	config.GroupVersion = v1alpha1.SchemeGroupVersion
 	config.Negotiator = runtime.NewClientNegotiator(scheme.Codecs.WithoutConversion(), v1alpha1.SchemeGroupVersion)
 	apiPath := "/apis"
-	client := f.NewFor(apiPath, config)
-	return &FlowcontrolV1alpha1Client{client}
+	client, err := f.NewClientWithOptions(apiPath, config, options...)
+	if err != nil {
+		return nil, err
+	}
+	return &FlowcontrolV1alpha1Client{client}, nil
 }
 
 func setConfigDefaults(config *rest.Config) error {

--- a/staging/src/k8s.io/client-go/kubernetes/typed/flowcontrol/v1alpha1/flowcontrol_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/flowcontrol/v1alpha1/flowcontrol_client.go
@@ -20,6 +20,7 @@ package v1alpha1
 
 import (
 	v1alpha1 "k8s.io/api/flowcontrol/v1alpha1"
+	runtime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
 )
@@ -69,6 +70,16 @@ func NewForConfigOrDie(c *rest.Config) *FlowcontrolV1alpha1Client {
 // New creates a new FlowcontrolV1alpha1Client for the given RESTClient.
 func New(c rest.Interface) *FlowcontrolV1alpha1Client {
 	return &FlowcontrolV1alpha1Client{c}
+}
+
+// NewForFactory creates a new FlowcontrolV1alpha1Client for the given RESTClientFactory.
+func NewForFactory(f *rest.RESTClientFactory) *FlowcontrolV1alpha1Client {
+	var config rest.ClientContentConfig
+	config.GroupVersion = v1alpha1.SchemeGroupVersion
+	config.Negotiator = runtime.NewClientNegotiator(scheme.Codecs.WithoutConversion(), v1alpha1.SchemeGroupVersion)
+	apiPath := "/apis"
+	client := f.NewFor(apiPath, config)
+	return &FlowcontrolV1alpha1Client{client}
 }
 
 func setConfigDefaults(config *rest.Config) error {

--- a/staging/src/k8s.io/client-go/kubernetes/typed/flowcontrol/v1beta1/flowcontrol_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/flowcontrol/v1beta1/flowcontrol_client.go
@@ -73,13 +73,16 @@ func New(c rest.Interface) *FlowcontrolV1beta1Client {
 }
 
 // NewForFactory creates a new FlowcontrolV1beta1Client for the given RESTClientFactory.
-func NewForFactory(f *rest.RESTClientFactory) *FlowcontrolV1beta1Client {
+func NewForFactory(f *rest.RESTClientFactory, options ...rest.RESTClientOption) (*FlowcontrolV1beta1Client, error) {
 	var config rest.ClientContentConfig
 	config.GroupVersion = v1beta1.SchemeGroupVersion
 	config.Negotiator = runtime.NewClientNegotiator(scheme.Codecs.WithoutConversion(), v1beta1.SchemeGroupVersion)
 	apiPath := "/apis"
-	client := f.NewFor(apiPath, config)
-	return &FlowcontrolV1beta1Client{client}
+	client, err := f.NewClientWithOptions(apiPath, config, options...)
+	if err != nil {
+		return nil, err
+	}
+	return &FlowcontrolV1beta1Client{client}, nil
 }
 
 func setConfigDefaults(config *rest.Config) error {

--- a/staging/src/k8s.io/client-go/kubernetes/typed/flowcontrol/v1beta1/flowcontrol_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/flowcontrol/v1beta1/flowcontrol_client.go
@@ -20,6 +20,7 @@ package v1beta1
 
 import (
 	v1beta1 "k8s.io/api/flowcontrol/v1beta1"
+	runtime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
 )
@@ -69,6 +70,16 @@ func NewForConfigOrDie(c *rest.Config) *FlowcontrolV1beta1Client {
 // New creates a new FlowcontrolV1beta1Client for the given RESTClient.
 func New(c rest.Interface) *FlowcontrolV1beta1Client {
 	return &FlowcontrolV1beta1Client{c}
+}
+
+// NewForFactory creates a new FlowcontrolV1beta1Client for the given RESTClientFactory.
+func NewForFactory(f *rest.RESTClientFactory) *FlowcontrolV1beta1Client {
+	var config rest.ClientContentConfig
+	config.GroupVersion = v1beta1.SchemeGroupVersion
+	config.Negotiator = runtime.NewClientNegotiator(scheme.Codecs.WithoutConversion(), v1beta1.SchemeGroupVersion)
+	apiPath := "/apis"
+	client := f.NewFor(apiPath, config)
+	return &FlowcontrolV1beta1Client{client}
 }
 
 func setConfigDefaults(config *rest.Config) error {

--- a/staging/src/k8s.io/client-go/kubernetes/typed/flowcontrol/v1beta2/flowcontrol_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/flowcontrol/v1beta2/flowcontrol_client.go
@@ -20,6 +20,7 @@ package v1beta2
 
 import (
 	v1beta2 "k8s.io/api/flowcontrol/v1beta2"
+	runtime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
 )
@@ -69,6 +70,16 @@ func NewForConfigOrDie(c *rest.Config) *FlowcontrolV1beta2Client {
 // New creates a new FlowcontrolV1beta2Client for the given RESTClient.
 func New(c rest.Interface) *FlowcontrolV1beta2Client {
 	return &FlowcontrolV1beta2Client{c}
+}
+
+// NewForFactory creates a new FlowcontrolV1beta2Client for the given RESTClientFactory.
+func NewForFactory(f *rest.RESTClientFactory) *FlowcontrolV1beta2Client {
+	var config rest.ClientContentConfig
+	config.GroupVersion = v1beta2.SchemeGroupVersion
+	config.Negotiator = runtime.NewClientNegotiator(scheme.Codecs.WithoutConversion(), v1beta2.SchemeGroupVersion)
+	apiPath := "/apis"
+	client := f.NewFor(apiPath, config)
+	return &FlowcontrolV1beta2Client{client}
 }
 
 func setConfigDefaults(config *rest.Config) error {

--- a/staging/src/k8s.io/client-go/kubernetes/typed/flowcontrol/v1beta2/flowcontrol_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/flowcontrol/v1beta2/flowcontrol_client.go
@@ -73,13 +73,16 @@ func New(c rest.Interface) *FlowcontrolV1beta2Client {
 }
 
 // NewForFactory creates a new FlowcontrolV1beta2Client for the given RESTClientFactory.
-func NewForFactory(f *rest.RESTClientFactory) *FlowcontrolV1beta2Client {
+func NewForFactory(f *rest.RESTClientFactory, options ...rest.RESTClientOption) (*FlowcontrolV1beta2Client, error) {
 	var config rest.ClientContentConfig
 	config.GroupVersion = v1beta2.SchemeGroupVersion
 	config.Negotiator = runtime.NewClientNegotiator(scheme.Codecs.WithoutConversion(), v1beta2.SchemeGroupVersion)
 	apiPath := "/apis"
-	client := f.NewFor(apiPath, config)
-	return &FlowcontrolV1beta2Client{client}
+	client, err := f.NewClientWithOptions(apiPath, config, options...)
+	if err != nil {
+		return nil, err
+	}
+	return &FlowcontrolV1beta2Client{client}, nil
 }
 
 func setConfigDefaults(config *rest.Config) error {

--- a/staging/src/k8s.io/client-go/kubernetes/typed/networking/v1/networking_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/networking/v1/networking_client.go
@@ -78,13 +78,16 @@ func New(c rest.Interface) *NetworkingV1Client {
 }
 
 // NewForFactory creates a new NetworkingV1Client for the given RESTClientFactory.
-func NewForFactory(f *rest.RESTClientFactory) *NetworkingV1Client {
+func NewForFactory(f *rest.RESTClientFactory, options ...rest.RESTClientOption) (*NetworkingV1Client, error) {
 	var config rest.ClientContentConfig
 	config.GroupVersion = v1.SchemeGroupVersion
 	config.Negotiator = runtime.NewClientNegotiator(scheme.Codecs.WithoutConversion(), v1.SchemeGroupVersion)
 	apiPath := "/apis"
-	client := f.NewFor(apiPath, config)
-	return &NetworkingV1Client{client}
+	client, err := f.NewClientWithOptions(apiPath, config, options...)
+	if err != nil {
+		return nil, err
+	}
+	return &NetworkingV1Client{client}, nil
 }
 
 func setConfigDefaults(config *rest.Config) error {

--- a/staging/src/k8s.io/client-go/kubernetes/typed/networking/v1/networking_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/networking/v1/networking_client.go
@@ -20,6 +20,7 @@ package v1
 
 import (
 	v1 "k8s.io/api/networking/v1"
+	runtime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
 )
@@ -74,6 +75,16 @@ func NewForConfigOrDie(c *rest.Config) *NetworkingV1Client {
 // New creates a new NetworkingV1Client for the given RESTClient.
 func New(c rest.Interface) *NetworkingV1Client {
 	return &NetworkingV1Client{c}
+}
+
+// NewForFactory creates a new NetworkingV1Client for the given RESTClientFactory.
+func NewForFactory(f *rest.RESTClientFactory) *NetworkingV1Client {
+	var config rest.ClientContentConfig
+	config.GroupVersion = v1.SchemeGroupVersion
+	config.Negotiator = runtime.NewClientNegotiator(scheme.Codecs.WithoutConversion(), v1.SchemeGroupVersion)
+	apiPath := "/apis"
+	client := f.NewFor(apiPath, config)
+	return &NetworkingV1Client{client}
 }
 
 func setConfigDefaults(config *rest.Config) error {

--- a/staging/src/k8s.io/client-go/kubernetes/typed/networking/v1beta1/networking_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/networking/v1beta1/networking_client.go
@@ -73,13 +73,16 @@ func New(c rest.Interface) *NetworkingV1beta1Client {
 }
 
 // NewForFactory creates a new NetworkingV1beta1Client for the given RESTClientFactory.
-func NewForFactory(f *rest.RESTClientFactory) *NetworkingV1beta1Client {
+func NewForFactory(f *rest.RESTClientFactory, options ...rest.RESTClientOption) (*NetworkingV1beta1Client, error) {
 	var config rest.ClientContentConfig
 	config.GroupVersion = v1beta1.SchemeGroupVersion
 	config.Negotiator = runtime.NewClientNegotiator(scheme.Codecs.WithoutConversion(), v1beta1.SchemeGroupVersion)
 	apiPath := "/apis"
-	client := f.NewFor(apiPath, config)
-	return &NetworkingV1beta1Client{client}
+	client, err := f.NewClientWithOptions(apiPath, config, options...)
+	if err != nil {
+		return nil, err
+	}
+	return &NetworkingV1beta1Client{client}, nil
 }
 
 func setConfigDefaults(config *rest.Config) error {

--- a/staging/src/k8s.io/client-go/kubernetes/typed/networking/v1beta1/networking_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/networking/v1beta1/networking_client.go
@@ -20,6 +20,7 @@ package v1beta1
 
 import (
 	v1beta1 "k8s.io/api/networking/v1beta1"
+	runtime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
 )
@@ -69,6 +70,16 @@ func NewForConfigOrDie(c *rest.Config) *NetworkingV1beta1Client {
 // New creates a new NetworkingV1beta1Client for the given RESTClient.
 func New(c rest.Interface) *NetworkingV1beta1Client {
 	return &NetworkingV1beta1Client{c}
+}
+
+// NewForFactory creates a new NetworkingV1beta1Client for the given RESTClientFactory.
+func NewForFactory(f *rest.RESTClientFactory) *NetworkingV1beta1Client {
+	var config rest.ClientContentConfig
+	config.GroupVersion = v1beta1.SchemeGroupVersion
+	config.Negotiator = runtime.NewClientNegotiator(scheme.Codecs.WithoutConversion(), v1beta1.SchemeGroupVersion)
+	apiPath := "/apis"
+	client := f.NewFor(apiPath, config)
+	return &NetworkingV1beta1Client{client}
 }
 
 func setConfigDefaults(config *rest.Config) error {

--- a/staging/src/k8s.io/client-go/kubernetes/typed/node/v1/node_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/node/v1/node_client.go
@@ -20,6 +20,7 @@ package v1
 
 import (
 	v1 "k8s.io/api/node/v1"
+	runtime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
 )
@@ -64,6 +65,16 @@ func NewForConfigOrDie(c *rest.Config) *NodeV1Client {
 // New creates a new NodeV1Client for the given RESTClient.
 func New(c rest.Interface) *NodeV1Client {
 	return &NodeV1Client{c}
+}
+
+// NewForFactory creates a new NodeV1Client for the given RESTClientFactory.
+func NewForFactory(f *rest.RESTClientFactory) *NodeV1Client {
+	var config rest.ClientContentConfig
+	config.GroupVersion = v1.SchemeGroupVersion
+	config.Negotiator = runtime.NewClientNegotiator(scheme.Codecs.WithoutConversion(), v1.SchemeGroupVersion)
+	apiPath := "/apis"
+	client := f.NewFor(apiPath, config)
+	return &NodeV1Client{client}
 }
 
 func setConfigDefaults(config *rest.Config) error {

--- a/staging/src/k8s.io/client-go/kubernetes/typed/node/v1/node_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/node/v1/node_client.go
@@ -68,13 +68,16 @@ func New(c rest.Interface) *NodeV1Client {
 }
 
 // NewForFactory creates a new NodeV1Client for the given RESTClientFactory.
-func NewForFactory(f *rest.RESTClientFactory) *NodeV1Client {
+func NewForFactory(f *rest.RESTClientFactory, options ...rest.RESTClientOption) (*NodeV1Client, error) {
 	var config rest.ClientContentConfig
 	config.GroupVersion = v1.SchemeGroupVersion
 	config.Negotiator = runtime.NewClientNegotiator(scheme.Codecs.WithoutConversion(), v1.SchemeGroupVersion)
 	apiPath := "/apis"
-	client := f.NewFor(apiPath, config)
-	return &NodeV1Client{client}
+	client, err := f.NewClientWithOptions(apiPath, config, options...)
+	if err != nil {
+		return nil, err
+	}
+	return &NodeV1Client{client}, nil
 }
 
 func setConfigDefaults(config *rest.Config) error {

--- a/staging/src/k8s.io/client-go/kubernetes/typed/node/v1alpha1/node_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/node/v1alpha1/node_client.go
@@ -20,6 +20,7 @@ package v1alpha1
 
 import (
 	v1alpha1 "k8s.io/api/node/v1alpha1"
+	runtime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
 )
@@ -64,6 +65,16 @@ func NewForConfigOrDie(c *rest.Config) *NodeV1alpha1Client {
 // New creates a new NodeV1alpha1Client for the given RESTClient.
 func New(c rest.Interface) *NodeV1alpha1Client {
 	return &NodeV1alpha1Client{c}
+}
+
+// NewForFactory creates a new NodeV1alpha1Client for the given RESTClientFactory.
+func NewForFactory(f *rest.RESTClientFactory) *NodeV1alpha1Client {
+	var config rest.ClientContentConfig
+	config.GroupVersion = v1alpha1.SchemeGroupVersion
+	config.Negotiator = runtime.NewClientNegotiator(scheme.Codecs.WithoutConversion(), v1alpha1.SchemeGroupVersion)
+	apiPath := "/apis"
+	client := f.NewFor(apiPath, config)
+	return &NodeV1alpha1Client{client}
 }
 
 func setConfigDefaults(config *rest.Config) error {

--- a/staging/src/k8s.io/client-go/kubernetes/typed/node/v1alpha1/node_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/node/v1alpha1/node_client.go
@@ -68,13 +68,16 @@ func New(c rest.Interface) *NodeV1alpha1Client {
 }
 
 // NewForFactory creates a new NodeV1alpha1Client for the given RESTClientFactory.
-func NewForFactory(f *rest.RESTClientFactory) *NodeV1alpha1Client {
+func NewForFactory(f *rest.RESTClientFactory, options ...rest.RESTClientOption) (*NodeV1alpha1Client, error) {
 	var config rest.ClientContentConfig
 	config.GroupVersion = v1alpha1.SchemeGroupVersion
 	config.Negotiator = runtime.NewClientNegotiator(scheme.Codecs.WithoutConversion(), v1alpha1.SchemeGroupVersion)
 	apiPath := "/apis"
-	client := f.NewFor(apiPath, config)
-	return &NodeV1alpha1Client{client}
+	client, err := f.NewClientWithOptions(apiPath, config, options...)
+	if err != nil {
+		return nil, err
+	}
+	return &NodeV1alpha1Client{client}, nil
 }
 
 func setConfigDefaults(config *rest.Config) error {

--- a/staging/src/k8s.io/client-go/kubernetes/typed/node/v1beta1/node_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/node/v1beta1/node_client.go
@@ -20,6 +20,7 @@ package v1beta1
 
 import (
 	v1beta1 "k8s.io/api/node/v1beta1"
+	runtime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
 )
@@ -64,6 +65,16 @@ func NewForConfigOrDie(c *rest.Config) *NodeV1beta1Client {
 // New creates a new NodeV1beta1Client for the given RESTClient.
 func New(c rest.Interface) *NodeV1beta1Client {
 	return &NodeV1beta1Client{c}
+}
+
+// NewForFactory creates a new NodeV1beta1Client for the given RESTClientFactory.
+func NewForFactory(f *rest.RESTClientFactory) *NodeV1beta1Client {
+	var config rest.ClientContentConfig
+	config.GroupVersion = v1beta1.SchemeGroupVersion
+	config.Negotiator = runtime.NewClientNegotiator(scheme.Codecs.WithoutConversion(), v1beta1.SchemeGroupVersion)
+	apiPath := "/apis"
+	client := f.NewFor(apiPath, config)
+	return &NodeV1beta1Client{client}
 }
 
 func setConfigDefaults(config *rest.Config) error {

--- a/staging/src/k8s.io/client-go/kubernetes/typed/node/v1beta1/node_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/node/v1beta1/node_client.go
@@ -68,13 +68,16 @@ func New(c rest.Interface) *NodeV1beta1Client {
 }
 
 // NewForFactory creates a new NodeV1beta1Client for the given RESTClientFactory.
-func NewForFactory(f *rest.RESTClientFactory) *NodeV1beta1Client {
+func NewForFactory(f *rest.RESTClientFactory, options ...rest.RESTClientOption) (*NodeV1beta1Client, error) {
 	var config rest.ClientContentConfig
 	config.GroupVersion = v1beta1.SchemeGroupVersion
 	config.Negotiator = runtime.NewClientNegotiator(scheme.Codecs.WithoutConversion(), v1beta1.SchemeGroupVersion)
 	apiPath := "/apis"
-	client := f.NewFor(apiPath, config)
-	return &NodeV1beta1Client{client}
+	client, err := f.NewClientWithOptions(apiPath, config, options...)
+	if err != nil {
+		return nil, err
+	}
+	return &NodeV1beta1Client{client}, nil
 }
 
 func setConfigDefaults(config *rest.Config) error {

--- a/staging/src/k8s.io/client-go/kubernetes/typed/policy/v1/policy_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/policy/v1/policy_client.go
@@ -20,6 +20,7 @@ package v1
 
 import (
 	v1 "k8s.io/api/policy/v1"
+	runtime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
 )
@@ -69,6 +70,16 @@ func NewForConfigOrDie(c *rest.Config) *PolicyV1Client {
 // New creates a new PolicyV1Client for the given RESTClient.
 func New(c rest.Interface) *PolicyV1Client {
 	return &PolicyV1Client{c}
+}
+
+// NewForFactory creates a new PolicyV1Client for the given RESTClientFactory.
+func NewForFactory(f *rest.RESTClientFactory) *PolicyV1Client {
+	var config rest.ClientContentConfig
+	config.GroupVersion = v1.SchemeGroupVersion
+	config.Negotiator = runtime.NewClientNegotiator(scheme.Codecs.WithoutConversion(), v1.SchemeGroupVersion)
+	apiPath := "/apis"
+	client := f.NewFor(apiPath, config)
+	return &PolicyV1Client{client}
 }
 
 func setConfigDefaults(config *rest.Config) error {

--- a/staging/src/k8s.io/client-go/kubernetes/typed/policy/v1/policy_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/policy/v1/policy_client.go
@@ -73,13 +73,16 @@ func New(c rest.Interface) *PolicyV1Client {
 }
 
 // NewForFactory creates a new PolicyV1Client for the given RESTClientFactory.
-func NewForFactory(f *rest.RESTClientFactory) *PolicyV1Client {
+func NewForFactory(f *rest.RESTClientFactory, options ...rest.RESTClientOption) (*PolicyV1Client, error) {
 	var config rest.ClientContentConfig
 	config.GroupVersion = v1.SchemeGroupVersion
 	config.Negotiator = runtime.NewClientNegotiator(scheme.Codecs.WithoutConversion(), v1.SchemeGroupVersion)
 	apiPath := "/apis"
-	client := f.NewFor(apiPath, config)
-	return &PolicyV1Client{client}
+	client, err := f.NewClientWithOptions(apiPath, config, options...)
+	if err != nil {
+		return nil, err
+	}
+	return &PolicyV1Client{client}, nil
 }
 
 func setConfigDefaults(config *rest.Config) error {

--- a/staging/src/k8s.io/client-go/kubernetes/typed/policy/v1beta1/policy_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/policy/v1beta1/policy_client.go
@@ -78,13 +78,16 @@ func New(c rest.Interface) *PolicyV1beta1Client {
 }
 
 // NewForFactory creates a new PolicyV1beta1Client for the given RESTClientFactory.
-func NewForFactory(f *rest.RESTClientFactory) *PolicyV1beta1Client {
+func NewForFactory(f *rest.RESTClientFactory, options ...rest.RESTClientOption) (*PolicyV1beta1Client, error) {
 	var config rest.ClientContentConfig
 	config.GroupVersion = v1beta1.SchemeGroupVersion
 	config.Negotiator = runtime.NewClientNegotiator(scheme.Codecs.WithoutConversion(), v1beta1.SchemeGroupVersion)
 	apiPath := "/apis"
-	client := f.NewFor(apiPath, config)
-	return &PolicyV1beta1Client{client}
+	client, err := f.NewClientWithOptions(apiPath, config, options...)
+	if err != nil {
+		return nil, err
+	}
+	return &PolicyV1beta1Client{client}, nil
 }
 
 func setConfigDefaults(config *rest.Config) error {

--- a/staging/src/k8s.io/client-go/kubernetes/typed/policy/v1beta1/policy_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/policy/v1beta1/policy_client.go
@@ -20,6 +20,7 @@ package v1beta1
 
 import (
 	v1beta1 "k8s.io/api/policy/v1beta1"
+	runtime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
 )
@@ -74,6 +75,16 @@ func NewForConfigOrDie(c *rest.Config) *PolicyV1beta1Client {
 // New creates a new PolicyV1beta1Client for the given RESTClient.
 func New(c rest.Interface) *PolicyV1beta1Client {
 	return &PolicyV1beta1Client{c}
+}
+
+// NewForFactory creates a new PolicyV1beta1Client for the given RESTClientFactory.
+func NewForFactory(f *rest.RESTClientFactory) *PolicyV1beta1Client {
+	var config rest.ClientContentConfig
+	config.GroupVersion = v1beta1.SchemeGroupVersion
+	config.Negotiator = runtime.NewClientNegotiator(scheme.Codecs.WithoutConversion(), v1beta1.SchemeGroupVersion)
+	apiPath := "/apis"
+	client := f.NewFor(apiPath, config)
+	return &PolicyV1beta1Client{client}
 }
 
 func setConfigDefaults(config *rest.Config) error {

--- a/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1/rbac_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1/rbac_client.go
@@ -83,13 +83,16 @@ func New(c rest.Interface) *RbacV1Client {
 }
 
 // NewForFactory creates a new RbacV1Client for the given RESTClientFactory.
-func NewForFactory(f *rest.RESTClientFactory) *RbacV1Client {
+func NewForFactory(f *rest.RESTClientFactory, options ...rest.RESTClientOption) (*RbacV1Client, error) {
 	var config rest.ClientContentConfig
 	config.GroupVersion = v1.SchemeGroupVersion
 	config.Negotiator = runtime.NewClientNegotiator(scheme.Codecs.WithoutConversion(), v1.SchemeGroupVersion)
 	apiPath := "/apis"
-	client := f.NewFor(apiPath, config)
-	return &RbacV1Client{client}
+	client, err := f.NewClientWithOptions(apiPath, config, options...)
+	if err != nil {
+		return nil, err
+	}
+	return &RbacV1Client{client}, nil
 }
 
 func setConfigDefaults(config *rest.Config) error {

--- a/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1/rbac_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1/rbac_client.go
@@ -20,6 +20,7 @@ package v1
 
 import (
 	v1 "k8s.io/api/rbac/v1"
+	runtime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
 )
@@ -79,6 +80,16 @@ func NewForConfigOrDie(c *rest.Config) *RbacV1Client {
 // New creates a new RbacV1Client for the given RESTClient.
 func New(c rest.Interface) *RbacV1Client {
 	return &RbacV1Client{c}
+}
+
+// NewForFactory creates a new RbacV1Client for the given RESTClientFactory.
+func NewForFactory(f *rest.RESTClientFactory) *RbacV1Client {
+	var config rest.ClientContentConfig
+	config.GroupVersion = v1.SchemeGroupVersion
+	config.Negotiator = runtime.NewClientNegotiator(scheme.Codecs.WithoutConversion(), v1.SchemeGroupVersion)
+	apiPath := "/apis"
+	client := f.NewFor(apiPath, config)
+	return &RbacV1Client{client}
 }
 
 func setConfigDefaults(config *rest.Config) error {

--- a/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1alpha1/rbac_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1alpha1/rbac_client.go
@@ -83,13 +83,16 @@ func New(c rest.Interface) *RbacV1alpha1Client {
 }
 
 // NewForFactory creates a new RbacV1alpha1Client for the given RESTClientFactory.
-func NewForFactory(f *rest.RESTClientFactory) *RbacV1alpha1Client {
+func NewForFactory(f *rest.RESTClientFactory, options ...rest.RESTClientOption) (*RbacV1alpha1Client, error) {
 	var config rest.ClientContentConfig
 	config.GroupVersion = v1alpha1.SchemeGroupVersion
 	config.Negotiator = runtime.NewClientNegotiator(scheme.Codecs.WithoutConversion(), v1alpha1.SchemeGroupVersion)
 	apiPath := "/apis"
-	client := f.NewFor(apiPath, config)
-	return &RbacV1alpha1Client{client}
+	client, err := f.NewClientWithOptions(apiPath, config, options...)
+	if err != nil {
+		return nil, err
+	}
+	return &RbacV1alpha1Client{client}, nil
 }
 
 func setConfigDefaults(config *rest.Config) error {

--- a/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1alpha1/rbac_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1alpha1/rbac_client.go
@@ -20,6 +20,7 @@ package v1alpha1
 
 import (
 	v1alpha1 "k8s.io/api/rbac/v1alpha1"
+	runtime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
 )
@@ -79,6 +80,16 @@ func NewForConfigOrDie(c *rest.Config) *RbacV1alpha1Client {
 // New creates a new RbacV1alpha1Client for the given RESTClient.
 func New(c rest.Interface) *RbacV1alpha1Client {
 	return &RbacV1alpha1Client{c}
+}
+
+// NewForFactory creates a new RbacV1alpha1Client for the given RESTClientFactory.
+func NewForFactory(f *rest.RESTClientFactory) *RbacV1alpha1Client {
+	var config rest.ClientContentConfig
+	config.GroupVersion = v1alpha1.SchemeGroupVersion
+	config.Negotiator = runtime.NewClientNegotiator(scheme.Codecs.WithoutConversion(), v1alpha1.SchemeGroupVersion)
+	apiPath := "/apis"
+	client := f.NewFor(apiPath, config)
+	return &RbacV1alpha1Client{client}
 }
 
 func setConfigDefaults(config *rest.Config) error {

--- a/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1beta1/rbac_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1beta1/rbac_client.go
@@ -20,6 +20,7 @@ package v1beta1
 
 import (
 	v1beta1 "k8s.io/api/rbac/v1beta1"
+	runtime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
 )
@@ -79,6 +80,16 @@ func NewForConfigOrDie(c *rest.Config) *RbacV1beta1Client {
 // New creates a new RbacV1beta1Client for the given RESTClient.
 func New(c rest.Interface) *RbacV1beta1Client {
 	return &RbacV1beta1Client{c}
+}
+
+// NewForFactory creates a new RbacV1beta1Client for the given RESTClientFactory.
+func NewForFactory(f *rest.RESTClientFactory) *RbacV1beta1Client {
+	var config rest.ClientContentConfig
+	config.GroupVersion = v1beta1.SchemeGroupVersion
+	config.Negotiator = runtime.NewClientNegotiator(scheme.Codecs.WithoutConversion(), v1beta1.SchemeGroupVersion)
+	apiPath := "/apis"
+	client := f.NewFor(apiPath, config)
+	return &RbacV1beta1Client{client}
 }
 
 func setConfigDefaults(config *rest.Config) error {

--- a/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1beta1/rbac_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1beta1/rbac_client.go
@@ -83,13 +83,16 @@ func New(c rest.Interface) *RbacV1beta1Client {
 }
 
 // NewForFactory creates a new RbacV1beta1Client for the given RESTClientFactory.
-func NewForFactory(f *rest.RESTClientFactory) *RbacV1beta1Client {
+func NewForFactory(f *rest.RESTClientFactory, options ...rest.RESTClientOption) (*RbacV1beta1Client, error) {
 	var config rest.ClientContentConfig
 	config.GroupVersion = v1beta1.SchemeGroupVersion
 	config.Negotiator = runtime.NewClientNegotiator(scheme.Codecs.WithoutConversion(), v1beta1.SchemeGroupVersion)
 	apiPath := "/apis"
-	client := f.NewFor(apiPath, config)
-	return &RbacV1beta1Client{client}
+	client, err := f.NewClientWithOptions(apiPath, config, options...)
+	if err != nil {
+		return nil, err
+	}
+	return &RbacV1beta1Client{client}, nil
 }
 
 func setConfigDefaults(config *rest.Config) error {

--- a/staging/src/k8s.io/client-go/kubernetes/typed/scheduling/v1/scheduling_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/scheduling/v1/scheduling_client.go
@@ -68,13 +68,16 @@ func New(c rest.Interface) *SchedulingV1Client {
 }
 
 // NewForFactory creates a new SchedulingV1Client for the given RESTClientFactory.
-func NewForFactory(f *rest.RESTClientFactory) *SchedulingV1Client {
+func NewForFactory(f *rest.RESTClientFactory, options ...rest.RESTClientOption) (*SchedulingV1Client, error) {
 	var config rest.ClientContentConfig
 	config.GroupVersion = v1.SchemeGroupVersion
 	config.Negotiator = runtime.NewClientNegotiator(scheme.Codecs.WithoutConversion(), v1.SchemeGroupVersion)
 	apiPath := "/apis"
-	client := f.NewFor(apiPath, config)
-	return &SchedulingV1Client{client}
+	client, err := f.NewClientWithOptions(apiPath, config, options...)
+	if err != nil {
+		return nil, err
+	}
+	return &SchedulingV1Client{client}, nil
 }
 
 func setConfigDefaults(config *rest.Config) error {

--- a/staging/src/k8s.io/client-go/kubernetes/typed/scheduling/v1/scheduling_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/scheduling/v1/scheduling_client.go
@@ -20,6 +20,7 @@ package v1
 
 import (
 	v1 "k8s.io/api/scheduling/v1"
+	runtime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
 )
@@ -64,6 +65,16 @@ func NewForConfigOrDie(c *rest.Config) *SchedulingV1Client {
 // New creates a new SchedulingV1Client for the given RESTClient.
 func New(c rest.Interface) *SchedulingV1Client {
 	return &SchedulingV1Client{c}
+}
+
+// NewForFactory creates a new SchedulingV1Client for the given RESTClientFactory.
+func NewForFactory(f *rest.RESTClientFactory) *SchedulingV1Client {
+	var config rest.ClientContentConfig
+	config.GroupVersion = v1.SchemeGroupVersion
+	config.Negotiator = runtime.NewClientNegotiator(scheme.Codecs.WithoutConversion(), v1.SchemeGroupVersion)
+	apiPath := "/apis"
+	client := f.NewFor(apiPath, config)
+	return &SchedulingV1Client{client}
 }
 
 func setConfigDefaults(config *rest.Config) error {

--- a/staging/src/k8s.io/client-go/kubernetes/typed/scheduling/v1alpha1/scheduling_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/scheduling/v1alpha1/scheduling_client.go
@@ -68,13 +68,16 @@ func New(c rest.Interface) *SchedulingV1alpha1Client {
 }
 
 // NewForFactory creates a new SchedulingV1alpha1Client for the given RESTClientFactory.
-func NewForFactory(f *rest.RESTClientFactory) *SchedulingV1alpha1Client {
+func NewForFactory(f *rest.RESTClientFactory, options ...rest.RESTClientOption) (*SchedulingV1alpha1Client, error) {
 	var config rest.ClientContentConfig
 	config.GroupVersion = v1alpha1.SchemeGroupVersion
 	config.Negotiator = runtime.NewClientNegotiator(scheme.Codecs.WithoutConversion(), v1alpha1.SchemeGroupVersion)
 	apiPath := "/apis"
-	client := f.NewFor(apiPath, config)
-	return &SchedulingV1alpha1Client{client}
+	client, err := f.NewClientWithOptions(apiPath, config, options...)
+	if err != nil {
+		return nil, err
+	}
+	return &SchedulingV1alpha1Client{client}, nil
 }
 
 func setConfigDefaults(config *rest.Config) error {

--- a/staging/src/k8s.io/client-go/kubernetes/typed/scheduling/v1alpha1/scheduling_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/scheduling/v1alpha1/scheduling_client.go
@@ -20,6 +20,7 @@ package v1alpha1
 
 import (
 	v1alpha1 "k8s.io/api/scheduling/v1alpha1"
+	runtime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
 )
@@ -64,6 +65,16 @@ func NewForConfigOrDie(c *rest.Config) *SchedulingV1alpha1Client {
 // New creates a new SchedulingV1alpha1Client for the given RESTClient.
 func New(c rest.Interface) *SchedulingV1alpha1Client {
 	return &SchedulingV1alpha1Client{c}
+}
+
+// NewForFactory creates a new SchedulingV1alpha1Client for the given RESTClientFactory.
+func NewForFactory(f *rest.RESTClientFactory) *SchedulingV1alpha1Client {
+	var config rest.ClientContentConfig
+	config.GroupVersion = v1alpha1.SchemeGroupVersion
+	config.Negotiator = runtime.NewClientNegotiator(scheme.Codecs.WithoutConversion(), v1alpha1.SchemeGroupVersion)
+	apiPath := "/apis"
+	client := f.NewFor(apiPath, config)
+	return &SchedulingV1alpha1Client{client}
 }
 
 func setConfigDefaults(config *rest.Config) error {

--- a/staging/src/k8s.io/client-go/kubernetes/typed/scheduling/v1beta1/scheduling_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/scheduling/v1beta1/scheduling_client.go
@@ -68,13 +68,16 @@ func New(c rest.Interface) *SchedulingV1beta1Client {
 }
 
 // NewForFactory creates a new SchedulingV1beta1Client for the given RESTClientFactory.
-func NewForFactory(f *rest.RESTClientFactory) *SchedulingV1beta1Client {
+func NewForFactory(f *rest.RESTClientFactory, options ...rest.RESTClientOption) (*SchedulingV1beta1Client, error) {
 	var config rest.ClientContentConfig
 	config.GroupVersion = v1beta1.SchemeGroupVersion
 	config.Negotiator = runtime.NewClientNegotiator(scheme.Codecs.WithoutConversion(), v1beta1.SchemeGroupVersion)
 	apiPath := "/apis"
-	client := f.NewFor(apiPath, config)
-	return &SchedulingV1beta1Client{client}
+	client, err := f.NewClientWithOptions(apiPath, config, options...)
+	if err != nil {
+		return nil, err
+	}
+	return &SchedulingV1beta1Client{client}, nil
 }
 
 func setConfigDefaults(config *rest.Config) error {

--- a/staging/src/k8s.io/client-go/kubernetes/typed/scheduling/v1beta1/scheduling_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/scheduling/v1beta1/scheduling_client.go
@@ -20,6 +20,7 @@ package v1beta1
 
 import (
 	v1beta1 "k8s.io/api/scheduling/v1beta1"
+	runtime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
 )
@@ -64,6 +65,16 @@ func NewForConfigOrDie(c *rest.Config) *SchedulingV1beta1Client {
 // New creates a new SchedulingV1beta1Client for the given RESTClient.
 func New(c rest.Interface) *SchedulingV1beta1Client {
 	return &SchedulingV1beta1Client{c}
+}
+
+// NewForFactory creates a new SchedulingV1beta1Client for the given RESTClientFactory.
+func NewForFactory(f *rest.RESTClientFactory) *SchedulingV1beta1Client {
+	var config rest.ClientContentConfig
+	config.GroupVersion = v1beta1.SchemeGroupVersion
+	config.Negotiator = runtime.NewClientNegotiator(scheme.Codecs.WithoutConversion(), v1beta1.SchemeGroupVersion)
+	apiPath := "/apis"
+	client := f.NewFor(apiPath, config)
+	return &SchedulingV1beta1Client{client}
 }
 
 func setConfigDefaults(config *rest.Config) error {

--- a/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1/storage_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1/storage_client.go
@@ -20,6 +20,7 @@ package v1
 
 import (
 	v1 "k8s.io/api/storage/v1"
+	runtime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
 )
@@ -79,6 +80,16 @@ func NewForConfigOrDie(c *rest.Config) *StorageV1Client {
 // New creates a new StorageV1Client for the given RESTClient.
 func New(c rest.Interface) *StorageV1Client {
 	return &StorageV1Client{c}
+}
+
+// NewForFactory creates a new StorageV1Client for the given RESTClientFactory.
+func NewForFactory(f *rest.RESTClientFactory) *StorageV1Client {
+	var config rest.ClientContentConfig
+	config.GroupVersion = v1.SchemeGroupVersion
+	config.Negotiator = runtime.NewClientNegotiator(scheme.Codecs.WithoutConversion(), v1.SchemeGroupVersion)
+	apiPath := "/apis"
+	client := f.NewFor(apiPath, config)
+	return &StorageV1Client{client}
 }
 
 func setConfigDefaults(config *rest.Config) error {

--- a/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1/storage_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1/storage_client.go
@@ -83,13 +83,16 @@ func New(c rest.Interface) *StorageV1Client {
 }
 
 // NewForFactory creates a new StorageV1Client for the given RESTClientFactory.
-func NewForFactory(f *rest.RESTClientFactory) *StorageV1Client {
+func NewForFactory(f *rest.RESTClientFactory, options ...rest.RESTClientOption) (*StorageV1Client, error) {
 	var config rest.ClientContentConfig
 	config.GroupVersion = v1.SchemeGroupVersion
 	config.Negotiator = runtime.NewClientNegotiator(scheme.Codecs.WithoutConversion(), v1.SchemeGroupVersion)
 	apiPath := "/apis"
-	client := f.NewFor(apiPath, config)
-	return &StorageV1Client{client}
+	client, err := f.NewClientWithOptions(apiPath, config, options...)
+	if err != nil {
+		return nil, err
+	}
+	return &StorageV1Client{client}, nil
 }
 
 func setConfigDefaults(config *rest.Config) error {

--- a/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1alpha1/storage_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1alpha1/storage_client.go
@@ -20,6 +20,7 @@ package v1alpha1
 
 import (
 	v1alpha1 "k8s.io/api/storage/v1alpha1"
+	runtime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
 )
@@ -69,6 +70,16 @@ func NewForConfigOrDie(c *rest.Config) *StorageV1alpha1Client {
 // New creates a new StorageV1alpha1Client for the given RESTClient.
 func New(c rest.Interface) *StorageV1alpha1Client {
 	return &StorageV1alpha1Client{c}
+}
+
+// NewForFactory creates a new StorageV1alpha1Client for the given RESTClientFactory.
+func NewForFactory(f *rest.RESTClientFactory) *StorageV1alpha1Client {
+	var config rest.ClientContentConfig
+	config.GroupVersion = v1alpha1.SchemeGroupVersion
+	config.Negotiator = runtime.NewClientNegotiator(scheme.Codecs.WithoutConversion(), v1alpha1.SchemeGroupVersion)
+	apiPath := "/apis"
+	client := f.NewFor(apiPath, config)
+	return &StorageV1alpha1Client{client}
 }
 
 func setConfigDefaults(config *rest.Config) error {

--- a/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1alpha1/storage_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1alpha1/storage_client.go
@@ -73,13 +73,16 @@ func New(c rest.Interface) *StorageV1alpha1Client {
 }
 
 // NewForFactory creates a new StorageV1alpha1Client for the given RESTClientFactory.
-func NewForFactory(f *rest.RESTClientFactory) *StorageV1alpha1Client {
+func NewForFactory(f *rest.RESTClientFactory, options ...rest.RESTClientOption) (*StorageV1alpha1Client, error) {
 	var config rest.ClientContentConfig
 	config.GroupVersion = v1alpha1.SchemeGroupVersion
 	config.Negotiator = runtime.NewClientNegotiator(scheme.Codecs.WithoutConversion(), v1alpha1.SchemeGroupVersion)
 	apiPath := "/apis"
-	client := f.NewFor(apiPath, config)
-	return &StorageV1alpha1Client{client}
+	client, err := f.NewClientWithOptions(apiPath, config, options...)
+	if err != nil {
+		return nil, err
+	}
+	return &StorageV1alpha1Client{client}, nil
 }
 
 func setConfigDefaults(config *rest.Config) error {

--- a/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1beta1/storage_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1beta1/storage_client.go
@@ -20,6 +20,7 @@ package v1beta1
 
 import (
 	v1beta1 "k8s.io/api/storage/v1beta1"
+	runtime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
 )
@@ -84,6 +85,16 @@ func NewForConfigOrDie(c *rest.Config) *StorageV1beta1Client {
 // New creates a new StorageV1beta1Client for the given RESTClient.
 func New(c rest.Interface) *StorageV1beta1Client {
 	return &StorageV1beta1Client{c}
+}
+
+// NewForFactory creates a new StorageV1beta1Client for the given RESTClientFactory.
+func NewForFactory(f *rest.RESTClientFactory) *StorageV1beta1Client {
+	var config rest.ClientContentConfig
+	config.GroupVersion = v1beta1.SchemeGroupVersion
+	config.Negotiator = runtime.NewClientNegotiator(scheme.Codecs.WithoutConversion(), v1beta1.SchemeGroupVersion)
+	apiPath := "/apis"
+	client := f.NewFor(apiPath, config)
+	return &StorageV1beta1Client{client}
 }
 
 func setConfigDefaults(config *rest.Config) error {

--- a/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1beta1/storage_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1beta1/storage_client.go
@@ -88,13 +88,16 @@ func New(c rest.Interface) *StorageV1beta1Client {
 }
 
 // NewForFactory creates a new StorageV1beta1Client for the given RESTClientFactory.
-func NewForFactory(f *rest.RESTClientFactory) *StorageV1beta1Client {
+func NewForFactory(f *rest.RESTClientFactory, options ...rest.RESTClientOption) (*StorageV1beta1Client, error) {
 	var config rest.ClientContentConfig
 	config.GroupVersion = v1beta1.SchemeGroupVersion
 	config.Negotiator = runtime.NewClientNegotiator(scheme.Codecs.WithoutConversion(), v1beta1.SchemeGroupVersion)
 	apiPath := "/apis"
-	client := f.NewFor(apiPath, config)
-	return &StorageV1beta1Client{client}
+	client, err := f.NewClientWithOptions(apiPath, config, options...)
+	if err != nil {
+		return nil, err
+	}
+	return &StorageV1beta1Client{client}, nil
 }
 
 func setConfigDefaults(config *rest.Config) error {

--- a/staging/src/k8s.io/client-go/rest/config.go
+++ b/staging/src/k8s.io/client-go/rest/config.go
@@ -356,12 +356,12 @@ func RESTClientFor(config *Config) (*RESTClient, error) {
 		GroupVersion:       gv,
 		Negotiator:         runtime.NewClientNegotiator(config.NegotiatedSerializer, gv),
 	}
-
-	restClient, err := NewRESTClient(baseURL, versionedAPIPath, clientContent, rateLimiter, httpClient)
-	if err == nil && config.WarningHandler != nil {
-		restClient.warningHandler = config.WarningHandler
+	options := []RESTClientOption{WithRateLimiter(rateLimiter)}
+	if config.WarningHandler != nil {
+		options = append(options, WithWarningHandler(config.WarningHandler))
 	}
-	return restClient, err
+
+	return NewRESTClientWithOptions(baseURL, versionedAPIPath, clientContent, httpClient, options...)
 }
 
 // UnversionedRESTClientFor is the same as RESTClientFor, except that it allows
@@ -415,11 +415,12 @@ func UnversionedRESTClientFor(config *Config) (*RESTClient, error) {
 		Negotiator:         runtime.NewClientNegotiator(config.NegotiatedSerializer, gv),
 	}
 
-	restClient, err := NewRESTClient(baseURL, versionedAPIPath, clientContent, rateLimiter, httpClient)
-	if err == nil && config.WarningHandler != nil {
-		restClient.warningHandler = config.WarningHandler
+	options := []RESTClientOption{WithRateLimiter(rateLimiter)}
+	if config.WarningHandler != nil {
+		options = append(options, WithWarningHandler(config.WarningHandler))
 	}
-	return restClient, err
+
+	return NewRESTClientWithOptions(baseURL, versionedAPIPath, clientContent, httpClient, options...)
 }
 
 // SetKubernetesDefaults sets default values on the provided client config for accessing the

--- a/staging/src/k8s.io/client-go/rest/factory.go
+++ b/staging/src/k8s.io/client-go/rest/factory.go
@@ -1,0 +1,131 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rest
+
+import (
+	"net/http"
+	"net/url"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/util/flowcontrol"
+)
+
+type RESTClientFactory struct {
+	// base is the root URL for all invocations of the client
+	base *url.URL
+	// rateLimiter is shared among all requests created by this client unless specifically
+	// overridden.
+	rateLimiter flowcontrol.RateLimiter
+	// warningHandler is shared among all requests created by this client.
+	// If not set, defaultWarningHandler is used.
+	warningHandler WarningHandler
+	// creates BackoffManager that is passed to requests.
+	createBackoffMgr func() BackoffManager
+	// Set specific behavior of the client.  If not set http.DefaultClient will be used.
+	Client *http.Client
+}
+
+func RESTClientFactoryFor(config *Config) (*RESTClientFactory, error) {
+	// Base URL
+	base, _, err := defaultServerUrlFor(config)
+	if err != nil {
+		return nil, err
+	}
+
+	if !strings.HasSuffix(base.Path, "/") {
+		base.Path += "/"
+	}
+	base.RawQuery = ""
+	base.Fragment = ""
+
+	// Transport
+	if config.UserAgent == "" {
+		config.UserAgent = DefaultKubernetesUserAgent()
+	}
+
+	transport, err := TransportFor(config)
+	if err != nil {
+		return nil, err
+	}
+
+	var httpClient *http.Client
+	if transport != http.DefaultTransport {
+		httpClient = &http.Client{Transport: transport}
+		if config.Timeout > 0 {
+			httpClient.Timeout = config.Timeout
+		}
+	}
+
+	// RateLimiter
+	rateLimiter := config.RateLimiter
+	if rateLimiter == nil {
+		qps := config.QPS
+		if config.QPS == 0.0 {
+			qps = DefaultQPS
+		}
+		burst := config.Burst
+		if config.Burst == 0 {
+			burst = DefaultBurst
+		}
+		if qps > 0 {
+			rateLimiter = flowcontrol.NewTokenBucketRateLimiter(qps, burst)
+		}
+	}
+
+	return &RESTClientFactory{
+		base:             base,
+		rateLimiter:      rateLimiter,
+		warningHandler:   config.WarningHandler,
+		createBackoffMgr: readExpBackoffConfig,
+		Client:           httpClient,
+	}, err
+}
+
+func RESTClientFactoryFromClient(c RESTClient) *RESTClientFactory {
+	return &RESTClientFactory{
+		base:             c.base,
+		rateLimiter:      c.GetRateLimiter(),
+		warningHandler:   c.warningHandler,
+		createBackoffMgr: readExpBackoffConfig,
+		Client:           c.Client,
+	}
+}
+
+func (r RESTClientFactory) NewFor(apiPath string, config ClientContentConfig) *RESTClient {
+	// shallow copy
+	c := config
+	if len(c.ContentType) == 0 {
+		c.ContentType = "application/json"
+	}
+
+	if c.Negotiator == nil {
+		c.Negotiator = runtime.NewClientNegotiator(scheme.Codecs.WithoutConversion(), c.GroupVersion)
+	}
+
+	return &RESTClient{
+		// shared
+		base:           r.base,
+		rateLimiter:    r.rateLimiter,
+		warningHandler: r.warningHandler,
+		Client:         r.Client,
+		// per client values
+		versionedAPIPath: DefaultVersionedAPIPath(apiPath, c.GroupVersion),
+		content:          c,
+	}
+}

--- a/staging/src/k8s.io/client-go/rest/factory.go
+++ b/staging/src/k8s.io/client-go/rest/factory.go
@@ -23,7 +23,6 @@ import (
 	"strings"
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/client-go/util/flowcontrol"
 )
 
 // RESTClientFactory allows to create RESTClients sharing the same Transport.
@@ -99,7 +98,6 @@ func (r RESTClientFactory) NewClientWithOptions(apiPath string, config ClientCon
 		versionedAPIPath: DefaultVersionedAPIPath(apiPath, config.GroupVersion),
 		content:          config,
 		// defaults
-		rateLimiter:      flowcontrol.NewTokenBucketRateLimiter(DefaultQPS, DefaultBurst),
 		createBackoffMgr: readExpBackoffConfig,
 	}
 	// Apply all options

--- a/staging/src/k8s.io/code-generator/cmd/client-gen/generators/generator_for_group.go
+++ b/staging/src/k8s.io/code-generator/cmd/client-gen/generators/generator_for_group.go
@@ -105,6 +105,7 @@ func (g *genGroup) GenerateType(c *generator.Context, t *types.Type, w io.Writer
 		"restRESTClientInterface":        c.Universe.Type(types.Name{Package: "k8s.io/client-go/rest", Name: "Interface"}),
 		"restRESTClientFor":              c.Universe.Function(types.Name{Package: "k8s.io/client-go/rest", Name: "RESTClientFor"}),
 		"restRESTClientFactory":          c.Universe.Type(types.Name{Package: "k8s.io/client-go/rest", Name: "RESTClientFactory"}),
+		"restRESTClientOption":           c.Universe.Type(types.Name{Package: "k8s.io/client-go/rest", Name: "RESTClientOption"}),
 		"SchemeGroupVersion":             c.Universe.Variable(types.Name{Package: path.Vendorless(g.inputPackage), Name: "SchemeGroupVersion"}),
 	}
 	sw.Do(groupInterfaceTemplate, m)
@@ -195,13 +196,16 @@ func NewForConfigOrDie(c *$.restConfig|raw$) *$.GroupGoName$$.Version$Client {
 
 var newClientForFactoryTemplate = `
 // NewForFactory creates a new $.GroupGoName$$.Version$Client for the given RESTClientFactory.
-func NewForFactory(f *$.restRESTClientFactory|raw$) *$.GroupGoName$$.Version$Client {
+func NewForFactory(f *$.restRESTClientFactory|raw$, options ...$.restRESTClientOption|raw$) (*$.GroupGoName$$.Version$Client, error) {
 	var config $.restClientContentConfig|raw$
 	config.GroupVersion = $.SchemeGroupVersion|raw$
 	config.Negotiator = $.runtimeNewClientNegotiator|raw$(scheme.Codecs.WithoutConversion(), $.SchemeGroupVersion|raw$)
 	apiPath := $.apiPath$
-	client := f.NewFor(apiPath, config)
-	return &$.GroupGoName$$.Version$Client{client}
+	client, err := f.NewClientWithOptions(apiPath, config, options...)
+	if err != nil {
+		return nil, err
+	}
+	return &$.GroupGoName$$.Version$Client{client}, nil
 }
 `
 

--- a/staging/src/k8s.io/code-generator/examples/HyphenGroup/clientset/versioned/clientset.go
+++ b/staging/src/k8s.io/code-generator/examples/HyphenGroup/clientset/versioned/clientset.go
@@ -63,12 +63,12 @@ func NewForConfig(c *rest.Config) (*Clientset, error) {
 		}
 		configShallowCopy.RateLimiter = flowcontrol.NewTokenBucketRateLimiter(configShallowCopy.QPS, configShallowCopy.Burst)
 	}
-	var cs Clientset
-	var err error
-	cs.exampleGroupV1, err = examplegroupv1.NewForConfig(&configShallowCopy)
+	factory, err := rest.RESTClientFactoryFor(&configShallowCopy)
 	if err != nil {
 		return nil, err
 	}
+	var cs Clientset
+	cs.exampleGroupV1 = examplegroupv1.NewForFactory(factory)
 
 	cs.DiscoveryClient, err = discovery.NewDiscoveryClientForConfig(&configShallowCopy)
 	if err != nil {
@@ -80,17 +80,22 @@ func NewForConfig(c *rest.Config) (*Clientset, error) {
 // NewForConfigOrDie creates a new Clientset for the given config and
 // panics if there is an error in the config.
 func NewForConfigOrDie(c *rest.Config) *Clientset {
-	var cs Clientset
-	cs.exampleGroupV1 = examplegroupv1.NewForConfigOrDie(c)
-
-	cs.DiscoveryClient = discovery.NewDiscoveryClientForConfigOrDie(c)
-	return &cs
+	cs, err := NewForConfig(c)
+	if err != nil {
+		panic(err)
+	}
+	return cs
 }
 
 // New creates a new Clientset for the given RESTClient.
 func New(c rest.Interface) *Clientset {
+	client, ok := c.(*rest.RESTClient)
+	if !ok {
+		return nil
+	}
+	factory := rest.RESTClientFactoryFromClient(*client)
 	var cs Clientset
-	cs.exampleGroupV1 = examplegroupv1.New(c)
+	cs.exampleGroupV1 = examplegroupv1.NewForFactory(factory)
 
 	cs.DiscoveryClient = discovery.NewDiscoveryClient(c)
 	return &cs

--- a/staging/src/k8s.io/code-generator/examples/HyphenGroup/clientset/versioned/clientset.go
+++ b/staging/src/k8s.io/code-generator/examples/HyphenGroup/clientset/versioned/clientset.go
@@ -67,8 +67,19 @@ func NewForConfig(c *rest.Config) (*Clientset, error) {
 	if err != nil {
 		return nil, err
 	}
+	options := []rest.RESTClientOption{}
+	if configShallowCopy.RateLimiter != nil {
+		options = append(options, rest.WithRateLimiter(configShallowCopy.RateLimiter))
+	}
+	if configShallowCopy.WarningHandler != nil {
+		options = append(options, rest.WithWarningHandler(configShallowCopy.WarningHandler))
+	}
+
 	var cs Clientset
-	cs.exampleGroupV1 = examplegroupv1.NewForFactory(factory)
+	cs.exampleGroupV1, err = examplegroupv1.NewForFactory(factory, options...)
+	if err != nil {
+		return nil, err
+	}
 
 	cs.DiscoveryClient, err = discovery.NewDiscoveryClientForConfig(&configShallowCopy)
 	if err != nil {
@@ -95,7 +106,11 @@ func New(c rest.Interface) *Clientset {
 	}
 	factory := rest.RESTClientFactoryFromClient(*client)
 	var cs Clientset
-	cs.exampleGroupV1 = examplegroupv1.NewForFactory(factory)
+	var err error
+	cs.exampleGroupV1, err = examplegroupv1.NewForFactory(factory)
+	if err != nil {
+		panic(err)
+	}
 
 	cs.DiscoveryClient = discovery.NewDiscoveryClient(c)
 	return &cs

--- a/staging/src/k8s.io/code-generator/examples/HyphenGroup/clientset/versioned/typed/example/v1/example_client.go
+++ b/staging/src/k8s.io/code-generator/examples/HyphenGroup/clientset/versioned/typed/example/v1/example_client.go
@@ -73,13 +73,16 @@ func New(c rest.Interface) *ExampleGroupV1Client {
 }
 
 // NewForFactory creates a new ExampleGroupV1Client for the given RESTClientFactory.
-func NewForFactory(f *rest.RESTClientFactory) *ExampleGroupV1Client {
+func NewForFactory(f *rest.RESTClientFactory, options ...rest.RESTClientOption) (*ExampleGroupV1Client, error) {
 	var config rest.ClientContentConfig
 	config.GroupVersion = v1.SchemeGroupVersion
 	config.Negotiator = runtime.NewClientNegotiator(scheme.Codecs.WithoutConversion(), v1.SchemeGroupVersion)
 	apiPath := "/apis"
-	client := f.NewFor(apiPath, config)
-	return &ExampleGroupV1Client{client}
+	client, err := f.NewClientWithOptions(apiPath, config, options...)
+	if err != nil {
+		return nil, err
+	}
+	return &ExampleGroupV1Client{client}, nil
 }
 
 func setConfigDefaults(config *rest.Config) error {

--- a/staging/src/k8s.io/code-generator/examples/HyphenGroup/clientset/versioned/typed/example/v1/example_client.go
+++ b/staging/src/k8s.io/code-generator/examples/HyphenGroup/clientset/versioned/typed/example/v1/example_client.go
@@ -19,6 +19,7 @@ limitations under the License.
 package v1
 
 import (
+	runtime "k8s.io/apimachinery/pkg/runtime"
 	rest "k8s.io/client-go/rest"
 	v1 "k8s.io/code-generator/examples/HyphenGroup/apis/example/v1"
 	"k8s.io/code-generator/examples/HyphenGroup/clientset/versioned/scheme"
@@ -69,6 +70,16 @@ func NewForConfigOrDie(c *rest.Config) *ExampleGroupV1Client {
 // New creates a new ExampleGroupV1Client for the given RESTClient.
 func New(c rest.Interface) *ExampleGroupV1Client {
 	return &ExampleGroupV1Client{c}
+}
+
+// NewForFactory creates a new ExampleGroupV1Client for the given RESTClientFactory.
+func NewForFactory(f *rest.RESTClientFactory) *ExampleGroupV1Client {
+	var config rest.ClientContentConfig
+	config.GroupVersion = v1.SchemeGroupVersion
+	config.Negotiator = runtime.NewClientNegotiator(scheme.Codecs.WithoutConversion(), v1.SchemeGroupVersion)
+	apiPath := "/apis"
+	client := f.NewFor(apiPath, config)
+	return &ExampleGroupV1Client{client}
 }
 
 func setConfigDefaults(config *rest.Config) error {

--- a/staging/src/k8s.io/code-generator/examples/MixedCase/clientset/versioned/clientset.go
+++ b/staging/src/k8s.io/code-generator/examples/MixedCase/clientset/versioned/clientset.go
@@ -67,8 +67,19 @@ func NewForConfig(c *rest.Config) (*Clientset, error) {
 	if err != nil {
 		return nil, err
 	}
+	options := []rest.RESTClientOption{}
+	if configShallowCopy.RateLimiter != nil {
+		options = append(options, rest.WithRateLimiter(configShallowCopy.RateLimiter))
+	}
+	if configShallowCopy.WarningHandler != nil {
+		options = append(options, rest.WithWarningHandler(configShallowCopy.WarningHandler))
+	}
+
 	var cs Clientset
-	cs.exampleV1 = examplev1.NewForFactory(factory)
+	cs.exampleV1, err = examplev1.NewForFactory(factory, options...)
+	if err != nil {
+		return nil, err
+	}
 
 	cs.DiscoveryClient, err = discovery.NewDiscoveryClientForConfig(&configShallowCopy)
 	if err != nil {
@@ -95,7 +106,11 @@ func New(c rest.Interface) *Clientset {
 	}
 	factory := rest.RESTClientFactoryFromClient(*client)
 	var cs Clientset
-	cs.exampleV1 = examplev1.NewForFactory(factory)
+	var err error
+	cs.exampleV1, err = examplev1.NewForFactory(factory)
+	if err != nil {
+		panic(err)
+	}
 
 	cs.DiscoveryClient = discovery.NewDiscoveryClient(c)
 	return &cs

--- a/staging/src/k8s.io/code-generator/examples/MixedCase/clientset/versioned/clientset.go
+++ b/staging/src/k8s.io/code-generator/examples/MixedCase/clientset/versioned/clientset.go
@@ -63,12 +63,12 @@ func NewForConfig(c *rest.Config) (*Clientset, error) {
 		}
 		configShallowCopy.RateLimiter = flowcontrol.NewTokenBucketRateLimiter(configShallowCopy.QPS, configShallowCopy.Burst)
 	}
-	var cs Clientset
-	var err error
-	cs.exampleV1, err = examplev1.NewForConfig(&configShallowCopy)
+	factory, err := rest.RESTClientFactoryFor(&configShallowCopy)
 	if err != nil {
 		return nil, err
 	}
+	var cs Clientset
+	cs.exampleV1 = examplev1.NewForFactory(factory)
 
 	cs.DiscoveryClient, err = discovery.NewDiscoveryClientForConfig(&configShallowCopy)
 	if err != nil {
@@ -80,17 +80,22 @@ func NewForConfig(c *rest.Config) (*Clientset, error) {
 // NewForConfigOrDie creates a new Clientset for the given config and
 // panics if there is an error in the config.
 func NewForConfigOrDie(c *rest.Config) *Clientset {
-	var cs Clientset
-	cs.exampleV1 = examplev1.NewForConfigOrDie(c)
-
-	cs.DiscoveryClient = discovery.NewDiscoveryClientForConfigOrDie(c)
-	return &cs
+	cs, err := NewForConfig(c)
+	if err != nil {
+		panic(err)
+	}
+	return cs
 }
 
 // New creates a new Clientset for the given RESTClient.
 func New(c rest.Interface) *Clientset {
+	client, ok := c.(*rest.RESTClient)
+	if !ok {
+		return nil
+	}
+	factory := rest.RESTClientFactoryFromClient(*client)
 	var cs Clientset
-	cs.exampleV1 = examplev1.New(c)
+	cs.exampleV1 = examplev1.NewForFactory(factory)
 
 	cs.DiscoveryClient = discovery.NewDiscoveryClient(c)
 	return &cs

--- a/staging/src/k8s.io/code-generator/examples/MixedCase/clientset/versioned/typed/example/v1/example_client.go
+++ b/staging/src/k8s.io/code-generator/examples/MixedCase/clientset/versioned/typed/example/v1/example_client.go
@@ -73,13 +73,16 @@ func New(c rest.Interface) *ExampleV1Client {
 }
 
 // NewForFactory creates a new ExampleV1Client for the given RESTClientFactory.
-func NewForFactory(f *rest.RESTClientFactory) *ExampleV1Client {
+func NewForFactory(f *rest.RESTClientFactory, options ...rest.RESTClientOption) (*ExampleV1Client, error) {
 	var config rest.ClientContentConfig
 	config.GroupVersion = v1.SchemeGroupVersion
 	config.Negotiator = runtime.NewClientNegotiator(scheme.Codecs.WithoutConversion(), v1.SchemeGroupVersion)
 	apiPath := "/apis"
-	client := f.NewFor(apiPath, config)
-	return &ExampleV1Client{client}
+	client, err := f.NewClientWithOptions(apiPath, config, options...)
+	if err != nil {
+		return nil, err
+	}
+	return &ExampleV1Client{client}, nil
 }
 
 func setConfigDefaults(config *rest.Config) error {

--- a/staging/src/k8s.io/code-generator/examples/MixedCase/clientset/versioned/typed/example/v1/example_client.go
+++ b/staging/src/k8s.io/code-generator/examples/MixedCase/clientset/versioned/typed/example/v1/example_client.go
@@ -19,6 +19,7 @@ limitations under the License.
 package v1
 
 import (
+	runtime "k8s.io/apimachinery/pkg/runtime"
 	rest "k8s.io/client-go/rest"
 	v1 "k8s.io/code-generator/examples/MixedCase/apis/example/v1"
 	"k8s.io/code-generator/examples/MixedCase/clientset/versioned/scheme"
@@ -69,6 +70,16 @@ func NewForConfigOrDie(c *rest.Config) *ExampleV1Client {
 // New creates a new ExampleV1Client for the given RESTClient.
 func New(c rest.Interface) *ExampleV1Client {
 	return &ExampleV1Client{c}
+}
+
+// NewForFactory creates a new ExampleV1Client for the given RESTClientFactory.
+func NewForFactory(f *rest.RESTClientFactory) *ExampleV1Client {
+	var config rest.ClientContentConfig
+	config.GroupVersion = v1.SchemeGroupVersion
+	config.Negotiator = runtime.NewClientNegotiator(scheme.Codecs.WithoutConversion(), v1.SchemeGroupVersion)
+	apiPath := "/apis"
+	client := f.NewFor(apiPath, config)
+	return &ExampleV1Client{client}
 }
 
 func setConfigDefaults(config *rest.Config) error {

--- a/staging/src/k8s.io/code-generator/examples/apiserver/clientset/internalversion/clientset.go
+++ b/staging/src/k8s.io/code-generator/examples/apiserver/clientset/internalversion/clientset.go
@@ -83,10 +83,27 @@ func NewForConfig(c *rest.Config) (*Clientset, error) {
 	if err != nil {
 		return nil, err
 	}
+	options := []rest.RESTClientOption{}
+	if configShallowCopy.RateLimiter != nil {
+		options = append(options, rest.WithRateLimiter(configShallowCopy.RateLimiter))
+	}
+	if configShallowCopy.WarningHandler != nil {
+		options = append(options, rest.WithWarningHandler(configShallowCopy.WarningHandler))
+	}
+
 	var cs Clientset
-	cs.example = exampleinternalversion.NewForFactory(factory)
-	cs.secondExample = secondexampleinternalversion.NewForFactory(factory)
-	cs.thirdExample = thirdexampleinternalversion.NewForFactory(factory)
+	cs.example, err = exampleinternalversion.NewForFactory(factory, options...)
+	if err != nil {
+		return nil, err
+	}
+	cs.secondExample, err = secondexampleinternalversion.NewForFactory(factory, options...)
+	if err != nil {
+		return nil, err
+	}
+	cs.thirdExample, err = thirdexampleinternalversion.NewForFactory(factory, options...)
+	if err != nil {
+		return nil, err
+	}
 
 	cs.DiscoveryClient, err = discovery.NewDiscoveryClientForConfig(&configShallowCopy)
 	if err != nil {
@@ -113,9 +130,19 @@ func New(c rest.Interface) *Clientset {
 	}
 	factory := rest.RESTClientFactoryFromClient(*client)
 	var cs Clientset
-	cs.example = exampleinternalversion.NewForFactory(factory)
-	cs.secondExample = secondexampleinternalversion.NewForFactory(factory)
-	cs.thirdExample = thirdexampleinternalversion.NewForFactory(factory)
+	var err error
+	cs.example, err = exampleinternalversion.NewForFactory(factory)
+	if err != nil {
+		panic(err)
+	}
+	cs.secondExample, err = secondexampleinternalversion.NewForFactory(factory)
+	if err != nil {
+		panic(err)
+	}
+	cs.thirdExample, err = thirdexampleinternalversion.NewForFactory(factory)
+	if err != nil {
+		panic(err)
+	}
 
 	cs.DiscoveryClient = discovery.NewDiscoveryClient(c)
 	return &cs

--- a/staging/src/k8s.io/code-generator/examples/apiserver/clientset/internalversion/clientset.go
+++ b/staging/src/k8s.io/code-generator/examples/apiserver/clientset/internalversion/clientset.go
@@ -79,20 +79,14 @@ func NewForConfig(c *rest.Config) (*Clientset, error) {
 		}
 		configShallowCopy.RateLimiter = flowcontrol.NewTokenBucketRateLimiter(configShallowCopy.QPS, configShallowCopy.Burst)
 	}
+	factory, err := rest.RESTClientFactoryFor(&configShallowCopy)
+	if err != nil {
+		return nil, err
+	}
 	var cs Clientset
-	var err error
-	cs.example, err = exampleinternalversion.NewForConfig(&configShallowCopy)
-	if err != nil {
-		return nil, err
-	}
-	cs.secondExample, err = secondexampleinternalversion.NewForConfig(&configShallowCopy)
-	if err != nil {
-		return nil, err
-	}
-	cs.thirdExample, err = thirdexampleinternalversion.NewForConfig(&configShallowCopy)
-	if err != nil {
-		return nil, err
-	}
+	cs.example = exampleinternalversion.NewForFactory(factory)
+	cs.secondExample = secondexampleinternalversion.NewForFactory(factory)
+	cs.thirdExample = thirdexampleinternalversion.NewForFactory(factory)
 
 	cs.DiscoveryClient, err = discovery.NewDiscoveryClientForConfig(&configShallowCopy)
 	if err != nil {
@@ -104,21 +98,24 @@ func NewForConfig(c *rest.Config) (*Clientset, error) {
 // NewForConfigOrDie creates a new Clientset for the given config and
 // panics if there is an error in the config.
 func NewForConfigOrDie(c *rest.Config) *Clientset {
-	var cs Clientset
-	cs.example = exampleinternalversion.NewForConfigOrDie(c)
-	cs.secondExample = secondexampleinternalversion.NewForConfigOrDie(c)
-	cs.thirdExample = thirdexampleinternalversion.NewForConfigOrDie(c)
-
-	cs.DiscoveryClient = discovery.NewDiscoveryClientForConfigOrDie(c)
-	return &cs
+	cs, err := NewForConfig(c)
+	if err != nil {
+		panic(err)
+	}
+	return cs
 }
 
 // New creates a new Clientset for the given RESTClient.
 func New(c rest.Interface) *Clientset {
+	client, ok := c.(*rest.RESTClient)
+	if !ok {
+		return nil
+	}
+	factory := rest.RESTClientFactoryFromClient(*client)
 	var cs Clientset
-	cs.example = exampleinternalversion.New(c)
-	cs.secondExample = secondexampleinternalversion.New(c)
-	cs.thirdExample = thirdexampleinternalversion.New(c)
+	cs.example = exampleinternalversion.NewForFactory(factory)
+	cs.secondExample = secondexampleinternalversion.NewForFactory(factory)
+	cs.thirdExample = thirdexampleinternalversion.NewForFactory(factory)
 
 	cs.DiscoveryClient = discovery.NewDiscoveryClient(c)
 	return &cs

--- a/staging/src/k8s.io/code-generator/examples/apiserver/clientset/internalversion/typed/example/internalversion/example_client.go
+++ b/staging/src/k8s.io/code-generator/examples/apiserver/clientset/internalversion/typed/example/internalversion/example_client.go
@@ -19,7 +19,9 @@ limitations under the License.
 package internalversion
 
 import (
+	runtime "k8s.io/apimachinery/pkg/runtime"
 	rest "k8s.io/client-go/rest"
+	example "k8s.io/code-generator/examples/apiserver/apis/example"
 	"k8s.io/code-generator/examples/apiserver/clientset/internalversion/scheme"
 )
 
@@ -63,6 +65,16 @@ func NewForConfigOrDie(c *rest.Config) *ExampleClient {
 // New creates a new ExampleClient for the given RESTClient.
 func New(c rest.Interface) *ExampleClient {
 	return &ExampleClient{c}
+}
+
+// NewForFactory creates a new ExampleClient for the given RESTClientFactory.
+func NewForFactory(f *rest.RESTClientFactory) *ExampleClient {
+	var config rest.ClientContentConfig
+	config.GroupVersion = example.SchemeGroupVersion
+	config.Negotiator = runtime.NewClientNegotiator(scheme.Codecs.WithoutConversion(), example.SchemeGroupVersion)
+	apiPath := "/apis"
+	client := f.NewFor(apiPath, config)
+	return &ExampleClient{client}
 }
 
 func setConfigDefaults(config *rest.Config) error {

--- a/staging/src/k8s.io/code-generator/examples/apiserver/clientset/internalversion/typed/example/internalversion/example_client.go
+++ b/staging/src/k8s.io/code-generator/examples/apiserver/clientset/internalversion/typed/example/internalversion/example_client.go
@@ -68,13 +68,16 @@ func New(c rest.Interface) *ExampleClient {
 }
 
 // NewForFactory creates a new ExampleClient for the given RESTClientFactory.
-func NewForFactory(f *rest.RESTClientFactory) *ExampleClient {
+func NewForFactory(f *rest.RESTClientFactory, options ...rest.RESTClientOption) (*ExampleClient, error) {
 	var config rest.ClientContentConfig
 	config.GroupVersion = example.SchemeGroupVersion
 	config.Negotiator = runtime.NewClientNegotiator(scheme.Codecs.WithoutConversion(), example.SchemeGroupVersion)
 	apiPath := "/apis"
-	client := f.NewFor(apiPath, config)
-	return &ExampleClient{client}
+	client, err := f.NewClientWithOptions(apiPath, config, options...)
+	if err != nil {
+		return nil, err
+	}
+	return &ExampleClient{client}, nil
 }
 
 func setConfigDefaults(config *rest.Config) error {

--- a/staging/src/k8s.io/code-generator/examples/apiserver/clientset/internalversion/typed/example2/internalversion/example2_client.go
+++ b/staging/src/k8s.io/code-generator/examples/apiserver/clientset/internalversion/typed/example2/internalversion/example2_client.go
@@ -68,13 +68,16 @@ func New(c rest.Interface) *SecondExampleClient {
 }
 
 // NewForFactory creates a new SecondExampleClient for the given RESTClientFactory.
-func NewForFactory(f *rest.RESTClientFactory) *SecondExampleClient {
+func NewForFactory(f *rest.RESTClientFactory, options ...rest.RESTClientOption) (*SecondExampleClient, error) {
 	var config rest.ClientContentConfig
 	config.GroupVersion = example2.SchemeGroupVersion
 	config.Negotiator = runtime.NewClientNegotiator(scheme.Codecs.WithoutConversion(), example2.SchemeGroupVersion)
 	apiPath := "/apis"
-	client := f.NewFor(apiPath, config)
-	return &SecondExampleClient{client}
+	client, err := f.NewClientWithOptions(apiPath, config, options...)
+	if err != nil {
+		return nil, err
+	}
+	return &SecondExampleClient{client}, nil
 }
 
 func setConfigDefaults(config *rest.Config) error {

--- a/staging/src/k8s.io/code-generator/examples/apiserver/clientset/internalversion/typed/example2/internalversion/example2_client.go
+++ b/staging/src/k8s.io/code-generator/examples/apiserver/clientset/internalversion/typed/example2/internalversion/example2_client.go
@@ -19,7 +19,9 @@ limitations under the License.
 package internalversion
 
 import (
+	runtime "k8s.io/apimachinery/pkg/runtime"
 	rest "k8s.io/client-go/rest"
+	example2 "k8s.io/code-generator/examples/apiserver/apis/example2"
 	"k8s.io/code-generator/examples/apiserver/clientset/internalversion/scheme"
 )
 
@@ -63,6 +65,16 @@ func NewForConfigOrDie(c *rest.Config) *SecondExampleClient {
 // New creates a new SecondExampleClient for the given RESTClient.
 func New(c rest.Interface) *SecondExampleClient {
 	return &SecondExampleClient{c}
+}
+
+// NewForFactory creates a new SecondExampleClient for the given RESTClientFactory.
+func NewForFactory(f *rest.RESTClientFactory) *SecondExampleClient {
+	var config rest.ClientContentConfig
+	config.GroupVersion = example2.SchemeGroupVersion
+	config.Negotiator = runtime.NewClientNegotiator(scheme.Codecs.WithoutConversion(), example2.SchemeGroupVersion)
+	apiPath := "/apis"
+	client := f.NewFor(apiPath, config)
+	return &SecondExampleClient{client}
 }
 
 func setConfigDefaults(config *rest.Config) error {

--- a/staging/src/k8s.io/code-generator/examples/apiserver/clientset/internalversion/typed/example3.io/internalversion/example3.io_client.go
+++ b/staging/src/k8s.io/code-generator/examples/apiserver/clientset/internalversion/typed/example3.io/internalversion/example3.io_client.go
@@ -19,7 +19,9 @@ limitations under the License.
 package internalversion
 
 import (
+	runtime "k8s.io/apimachinery/pkg/runtime"
 	rest "k8s.io/client-go/rest"
+	example3io "k8s.io/code-generator/examples/apiserver/apis/example3.io"
 	"k8s.io/code-generator/examples/apiserver/clientset/internalversion/scheme"
 )
 
@@ -63,6 +65,16 @@ func NewForConfigOrDie(c *rest.Config) *ThirdExampleClient {
 // New creates a new ThirdExampleClient for the given RESTClient.
 func New(c rest.Interface) *ThirdExampleClient {
 	return &ThirdExampleClient{c}
+}
+
+// NewForFactory creates a new ThirdExampleClient for the given RESTClientFactory.
+func NewForFactory(f *rest.RESTClientFactory) *ThirdExampleClient {
+	var config rest.ClientContentConfig
+	config.GroupVersion = example3io.SchemeGroupVersion
+	config.Negotiator = runtime.NewClientNegotiator(scheme.Codecs.WithoutConversion(), example3io.SchemeGroupVersion)
+	apiPath := "/apis"
+	client := f.NewFor(apiPath, config)
+	return &ThirdExampleClient{client}
 }
 
 func setConfigDefaults(config *rest.Config) error {

--- a/staging/src/k8s.io/code-generator/examples/apiserver/clientset/internalversion/typed/example3.io/internalversion/example3.io_client.go
+++ b/staging/src/k8s.io/code-generator/examples/apiserver/clientset/internalversion/typed/example3.io/internalversion/example3.io_client.go
@@ -68,13 +68,16 @@ func New(c rest.Interface) *ThirdExampleClient {
 }
 
 // NewForFactory creates a new ThirdExampleClient for the given RESTClientFactory.
-func NewForFactory(f *rest.RESTClientFactory) *ThirdExampleClient {
+func NewForFactory(f *rest.RESTClientFactory, options ...rest.RESTClientOption) (*ThirdExampleClient, error) {
 	var config rest.ClientContentConfig
 	config.GroupVersion = example3io.SchemeGroupVersion
 	config.Negotiator = runtime.NewClientNegotiator(scheme.Codecs.WithoutConversion(), example3io.SchemeGroupVersion)
 	apiPath := "/apis"
-	client := f.NewFor(apiPath, config)
-	return &ThirdExampleClient{client}
+	client, err := f.NewClientWithOptions(apiPath, config, options...)
+	if err != nil {
+		return nil, err
+	}
+	return &ThirdExampleClient{client}, nil
 }
 
 func setConfigDefaults(config *rest.Config) error {

--- a/staging/src/k8s.io/code-generator/examples/apiserver/clientset/versioned/clientset.go
+++ b/staging/src/k8s.io/code-generator/examples/apiserver/clientset/versioned/clientset.go
@@ -79,20 +79,14 @@ func NewForConfig(c *rest.Config) (*Clientset, error) {
 		}
 		configShallowCopy.RateLimiter = flowcontrol.NewTokenBucketRateLimiter(configShallowCopy.QPS, configShallowCopy.Burst)
 	}
+	factory, err := rest.RESTClientFactoryFor(&configShallowCopy)
+	if err != nil {
+		return nil, err
+	}
 	var cs Clientset
-	var err error
-	cs.exampleV1, err = examplev1.NewForConfig(&configShallowCopy)
-	if err != nil {
-		return nil, err
-	}
-	cs.secondExampleV1, err = secondexamplev1.NewForConfig(&configShallowCopy)
-	if err != nil {
-		return nil, err
-	}
-	cs.thirdExampleV1, err = thirdexamplev1.NewForConfig(&configShallowCopy)
-	if err != nil {
-		return nil, err
-	}
+	cs.exampleV1 = examplev1.NewForFactory(factory)
+	cs.secondExampleV1 = secondexamplev1.NewForFactory(factory)
+	cs.thirdExampleV1 = thirdexamplev1.NewForFactory(factory)
 
 	cs.DiscoveryClient, err = discovery.NewDiscoveryClientForConfig(&configShallowCopy)
 	if err != nil {
@@ -104,21 +98,24 @@ func NewForConfig(c *rest.Config) (*Clientset, error) {
 // NewForConfigOrDie creates a new Clientset for the given config and
 // panics if there is an error in the config.
 func NewForConfigOrDie(c *rest.Config) *Clientset {
-	var cs Clientset
-	cs.exampleV1 = examplev1.NewForConfigOrDie(c)
-	cs.secondExampleV1 = secondexamplev1.NewForConfigOrDie(c)
-	cs.thirdExampleV1 = thirdexamplev1.NewForConfigOrDie(c)
-
-	cs.DiscoveryClient = discovery.NewDiscoveryClientForConfigOrDie(c)
-	return &cs
+	cs, err := NewForConfig(c)
+	if err != nil {
+		panic(err)
+	}
+	return cs
 }
 
 // New creates a new Clientset for the given RESTClient.
 func New(c rest.Interface) *Clientset {
+	client, ok := c.(*rest.RESTClient)
+	if !ok {
+		return nil
+	}
+	factory := rest.RESTClientFactoryFromClient(*client)
 	var cs Clientset
-	cs.exampleV1 = examplev1.New(c)
-	cs.secondExampleV1 = secondexamplev1.New(c)
-	cs.thirdExampleV1 = thirdexamplev1.New(c)
+	cs.exampleV1 = examplev1.NewForFactory(factory)
+	cs.secondExampleV1 = secondexamplev1.NewForFactory(factory)
+	cs.thirdExampleV1 = thirdexamplev1.NewForFactory(factory)
 
 	cs.DiscoveryClient = discovery.NewDiscoveryClient(c)
 	return &cs

--- a/staging/src/k8s.io/code-generator/examples/apiserver/clientset/versioned/clientset.go
+++ b/staging/src/k8s.io/code-generator/examples/apiserver/clientset/versioned/clientset.go
@@ -83,10 +83,27 @@ func NewForConfig(c *rest.Config) (*Clientset, error) {
 	if err != nil {
 		return nil, err
 	}
+	options := []rest.RESTClientOption{}
+	if configShallowCopy.RateLimiter != nil {
+		options = append(options, rest.WithRateLimiter(configShallowCopy.RateLimiter))
+	}
+	if configShallowCopy.WarningHandler != nil {
+		options = append(options, rest.WithWarningHandler(configShallowCopy.WarningHandler))
+	}
+
 	var cs Clientset
-	cs.exampleV1 = examplev1.NewForFactory(factory)
-	cs.secondExampleV1 = secondexamplev1.NewForFactory(factory)
-	cs.thirdExampleV1 = thirdexamplev1.NewForFactory(factory)
+	cs.exampleV1, err = examplev1.NewForFactory(factory, options...)
+	if err != nil {
+		return nil, err
+	}
+	cs.secondExampleV1, err = secondexamplev1.NewForFactory(factory, options...)
+	if err != nil {
+		return nil, err
+	}
+	cs.thirdExampleV1, err = thirdexamplev1.NewForFactory(factory, options...)
+	if err != nil {
+		return nil, err
+	}
 
 	cs.DiscoveryClient, err = discovery.NewDiscoveryClientForConfig(&configShallowCopy)
 	if err != nil {
@@ -113,9 +130,19 @@ func New(c rest.Interface) *Clientset {
 	}
 	factory := rest.RESTClientFactoryFromClient(*client)
 	var cs Clientset
-	cs.exampleV1 = examplev1.NewForFactory(factory)
-	cs.secondExampleV1 = secondexamplev1.NewForFactory(factory)
-	cs.thirdExampleV1 = thirdexamplev1.NewForFactory(factory)
+	var err error
+	cs.exampleV1, err = examplev1.NewForFactory(factory)
+	if err != nil {
+		panic(err)
+	}
+	cs.secondExampleV1, err = secondexamplev1.NewForFactory(factory)
+	if err != nil {
+		panic(err)
+	}
+	cs.thirdExampleV1, err = thirdexamplev1.NewForFactory(factory)
+	if err != nil {
+		panic(err)
+	}
 
 	cs.DiscoveryClient = discovery.NewDiscoveryClient(c)
 	return &cs

--- a/staging/src/k8s.io/code-generator/examples/apiserver/clientset/versioned/typed/example/v1/example_client.go
+++ b/staging/src/k8s.io/code-generator/examples/apiserver/clientset/versioned/typed/example/v1/example_client.go
@@ -19,6 +19,7 @@ limitations under the License.
 package v1
 
 import (
+	runtime "k8s.io/apimachinery/pkg/runtime"
 	rest "k8s.io/client-go/rest"
 	v1 "k8s.io/code-generator/examples/apiserver/apis/example/v1"
 	"k8s.io/code-generator/examples/apiserver/clientset/versioned/scheme"
@@ -64,6 +65,16 @@ func NewForConfigOrDie(c *rest.Config) *ExampleV1Client {
 // New creates a new ExampleV1Client for the given RESTClient.
 func New(c rest.Interface) *ExampleV1Client {
 	return &ExampleV1Client{c}
+}
+
+// NewForFactory creates a new ExampleV1Client for the given RESTClientFactory.
+func NewForFactory(f *rest.RESTClientFactory) *ExampleV1Client {
+	var config rest.ClientContentConfig
+	config.GroupVersion = v1.SchemeGroupVersion
+	config.Negotiator = runtime.NewClientNegotiator(scheme.Codecs.WithoutConversion(), v1.SchemeGroupVersion)
+	apiPath := "/apis"
+	client := f.NewFor(apiPath, config)
+	return &ExampleV1Client{client}
 }
 
 func setConfigDefaults(config *rest.Config) error {

--- a/staging/src/k8s.io/code-generator/examples/apiserver/clientset/versioned/typed/example/v1/example_client.go
+++ b/staging/src/k8s.io/code-generator/examples/apiserver/clientset/versioned/typed/example/v1/example_client.go
@@ -68,13 +68,16 @@ func New(c rest.Interface) *ExampleV1Client {
 }
 
 // NewForFactory creates a new ExampleV1Client for the given RESTClientFactory.
-func NewForFactory(f *rest.RESTClientFactory) *ExampleV1Client {
+func NewForFactory(f *rest.RESTClientFactory, options ...rest.RESTClientOption) (*ExampleV1Client, error) {
 	var config rest.ClientContentConfig
 	config.GroupVersion = v1.SchemeGroupVersion
 	config.Negotiator = runtime.NewClientNegotiator(scheme.Codecs.WithoutConversion(), v1.SchemeGroupVersion)
 	apiPath := "/apis"
-	client := f.NewFor(apiPath, config)
-	return &ExampleV1Client{client}
+	client, err := f.NewClientWithOptions(apiPath, config, options...)
+	if err != nil {
+		return nil, err
+	}
+	return &ExampleV1Client{client}, nil
 }
 
 func setConfigDefaults(config *rest.Config) error {

--- a/staging/src/k8s.io/code-generator/examples/apiserver/clientset/versioned/typed/example2/v1/example2_client.go
+++ b/staging/src/k8s.io/code-generator/examples/apiserver/clientset/versioned/typed/example2/v1/example2_client.go
@@ -68,13 +68,16 @@ func New(c rest.Interface) *SecondExampleV1Client {
 }
 
 // NewForFactory creates a new SecondExampleV1Client for the given RESTClientFactory.
-func NewForFactory(f *rest.RESTClientFactory) *SecondExampleV1Client {
+func NewForFactory(f *rest.RESTClientFactory, options ...rest.RESTClientOption) (*SecondExampleV1Client, error) {
 	var config rest.ClientContentConfig
 	config.GroupVersion = v1.SchemeGroupVersion
 	config.Negotiator = runtime.NewClientNegotiator(scheme.Codecs.WithoutConversion(), v1.SchemeGroupVersion)
 	apiPath := "/apis"
-	client := f.NewFor(apiPath, config)
-	return &SecondExampleV1Client{client}
+	client, err := f.NewClientWithOptions(apiPath, config, options...)
+	if err != nil {
+		return nil, err
+	}
+	return &SecondExampleV1Client{client}, nil
 }
 
 func setConfigDefaults(config *rest.Config) error {

--- a/staging/src/k8s.io/code-generator/examples/apiserver/clientset/versioned/typed/example2/v1/example2_client.go
+++ b/staging/src/k8s.io/code-generator/examples/apiserver/clientset/versioned/typed/example2/v1/example2_client.go
@@ -19,6 +19,7 @@ limitations under the License.
 package v1
 
 import (
+	runtime "k8s.io/apimachinery/pkg/runtime"
 	rest "k8s.io/client-go/rest"
 	v1 "k8s.io/code-generator/examples/apiserver/apis/example2/v1"
 	"k8s.io/code-generator/examples/apiserver/clientset/versioned/scheme"
@@ -64,6 +65,16 @@ func NewForConfigOrDie(c *rest.Config) *SecondExampleV1Client {
 // New creates a new SecondExampleV1Client for the given RESTClient.
 func New(c rest.Interface) *SecondExampleV1Client {
 	return &SecondExampleV1Client{c}
+}
+
+// NewForFactory creates a new SecondExampleV1Client for the given RESTClientFactory.
+func NewForFactory(f *rest.RESTClientFactory) *SecondExampleV1Client {
+	var config rest.ClientContentConfig
+	config.GroupVersion = v1.SchemeGroupVersion
+	config.Negotiator = runtime.NewClientNegotiator(scheme.Codecs.WithoutConversion(), v1.SchemeGroupVersion)
+	apiPath := "/apis"
+	client := f.NewFor(apiPath, config)
+	return &SecondExampleV1Client{client}
 }
 
 func setConfigDefaults(config *rest.Config) error {

--- a/staging/src/k8s.io/code-generator/examples/apiserver/clientset/versioned/typed/example3.io/v1/example3.io_client.go
+++ b/staging/src/k8s.io/code-generator/examples/apiserver/clientset/versioned/typed/example3.io/v1/example3.io_client.go
@@ -19,6 +19,7 @@ limitations under the License.
 package v1
 
 import (
+	runtime "k8s.io/apimachinery/pkg/runtime"
 	rest "k8s.io/client-go/rest"
 	v1 "k8s.io/code-generator/examples/apiserver/apis/example3.io/v1"
 	"k8s.io/code-generator/examples/apiserver/clientset/versioned/scheme"
@@ -64,6 +65,16 @@ func NewForConfigOrDie(c *rest.Config) *ThirdExampleV1Client {
 // New creates a new ThirdExampleV1Client for the given RESTClient.
 func New(c rest.Interface) *ThirdExampleV1Client {
 	return &ThirdExampleV1Client{c}
+}
+
+// NewForFactory creates a new ThirdExampleV1Client for the given RESTClientFactory.
+func NewForFactory(f *rest.RESTClientFactory) *ThirdExampleV1Client {
+	var config rest.ClientContentConfig
+	config.GroupVersion = v1.SchemeGroupVersion
+	config.Negotiator = runtime.NewClientNegotiator(scheme.Codecs.WithoutConversion(), v1.SchemeGroupVersion)
+	apiPath := "/apis"
+	client := f.NewFor(apiPath, config)
+	return &ThirdExampleV1Client{client}
 }
 
 func setConfigDefaults(config *rest.Config) error {

--- a/staging/src/k8s.io/code-generator/examples/apiserver/clientset/versioned/typed/example3.io/v1/example3.io_client.go
+++ b/staging/src/k8s.io/code-generator/examples/apiserver/clientset/versioned/typed/example3.io/v1/example3.io_client.go
@@ -68,13 +68,16 @@ func New(c rest.Interface) *ThirdExampleV1Client {
 }
 
 // NewForFactory creates a new ThirdExampleV1Client for the given RESTClientFactory.
-func NewForFactory(f *rest.RESTClientFactory) *ThirdExampleV1Client {
+func NewForFactory(f *rest.RESTClientFactory, options ...rest.RESTClientOption) (*ThirdExampleV1Client, error) {
 	var config rest.ClientContentConfig
 	config.GroupVersion = v1.SchemeGroupVersion
 	config.Negotiator = runtime.NewClientNegotiator(scheme.Codecs.WithoutConversion(), v1.SchemeGroupVersion)
 	apiPath := "/apis"
-	client := f.NewFor(apiPath, config)
-	return &ThirdExampleV1Client{client}
+	client, err := f.NewClientWithOptions(apiPath, config, options...)
+	if err != nil {
+		return nil, err
+	}
+	return &ThirdExampleV1Client{client}, nil
 }
 
 func setConfigDefaults(config *rest.Config) error {

--- a/staging/src/k8s.io/code-generator/examples/crd/clientset/versioned/clientset.go
+++ b/staging/src/k8s.io/code-generator/examples/crd/clientset/versioned/clientset.go
@@ -75,9 +75,23 @@ func NewForConfig(c *rest.Config) (*Clientset, error) {
 	if err != nil {
 		return nil, err
 	}
+	options := []rest.RESTClientOption{}
+	if configShallowCopy.RateLimiter != nil {
+		options = append(options, rest.WithRateLimiter(configShallowCopy.RateLimiter))
+	}
+	if configShallowCopy.WarningHandler != nil {
+		options = append(options, rest.WithWarningHandler(configShallowCopy.WarningHandler))
+	}
+
 	var cs Clientset
-	cs.exampleV1 = examplev1.NewForFactory(factory)
-	cs.secondExampleV1 = secondexamplev1.NewForFactory(factory)
+	cs.exampleV1, err = examplev1.NewForFactory(factory, options...)
+	if err != nil {
+		return nil, err
+	}
+	cs.secondExampleV1, err = secondexamplev1.NewForFactory(factory, options...)
+	if err != nil {
+		return nil, err
+	}
 
 	cs.DiscoveryClient, err = discovery.NewDiscoveryClientForConfig(&configShallowCopy)
 	if err != nil {
@@ -104,8 +118,15 @@ func New(c rest.Interface) *Clientset {
 	}
 	factory := rest.RESTClientFactoryFromClient(*client)
 	var cs Clientset
-	cs.exampleV1 = examplev1.NewForFactory(factory)
-	cs.secondExampleV1 = secondexamplev1.NewForFactory(factory)
+	var err error
+	cs.exampleV1, err = examplev1.NewForFactory(factory)
+	if err != nil {
+		panic(err)
+	}
+	cs.secondExampleV1, err = secondexamplev1.NewForFactory(factory)
+	if err != nil {
+		panic(err)
+	}
 
 	cs.DiscoveryClient = discovery.NewDiscoveryClient(c)
 	return &cs

--- a/staging/src/k8s.io/code-generator/examples/crd/clientset/versioned/typed/example/v1/example_client.go
+++ b/staging/src/k8s.io/code-generator/examples/crd/clientset/versioned/typed/example/v1/example_client.go
@@ -19,6 +19,7 @@ limitations under the License.
 package v1
 
 import (
+	runtime "k8s.io/apimachinery/pkg/runtime"
 	rest "k8s.io/client-go/rest"
 	v1 "k8s.io/code-generator/examples/crd/apis/example/v1"
 	"k8s.io/code-generator/examples/crd/clientset/versioned/scheme"
@@ -69,6 +70,16 @@ func NewForConfigOrDie(c *rest.Config) *ExampleV1Client {
 // New creates a new ExampleV1Client for the given RESTClient.
 func New(c rest.Interface) *ExampleV1Client {
 	return &ExampleV1Client{c}
+}
+
+// NewForFactory creates a new ExampleV1Client for the given RESTClientFactory.
+func NewForFactory(f *rest.RESTClientFactory) *ExampleV1Client {
+	var config rest.ClientContentConfig
+	config.GroupVersion = v1.SchemeGroupVersion
+	config.Negotiator = runtime.NewClientNegotiator(scheme.Codecs.WithoutConversion(), v1.SchemeGroupVersion)
+	apiPath := "/apis"
+	client := f.NewFor(apiPath, config)
+	return &ExampleV1Client{client}
 }
 
 func setConfigDefaults(config *rest.Config) error {

--- a/staging/src/k8s.io/code-generator/examples/crd/clientset/versioned/typed/example/v1/example_client.go
+++ b/staging/src/k8s.io/code-generator/examples/crd/clientset/versioned/typed/example/v1/example_client.go
@@ -73,13 +73,16 @@ func New(c rest.Interface) *ExampleV1Client {
 }
 
 // NewForFactory creates a new ExampleV1Client for the given RESTClientFactory.
-func NewForFactory(f *rest.RESTClientFactory) *ExampleV1Client {
+func NewForFactory(f *rest.RESTClientFactory, options ...rest.RESTClientOption) (*ExampleV1Client, error) {
 	var config rest.ClientContentConfig
 	config.GroupVersion = v1.SchemeGroupVersion
 	config.Negotiator = runtime.NewClientNegotiator(scheme.Codecs.WithoutConversion(), v1.SchemeGroupVersion)
 	apiPath := "/apis"
-	client := f.NewFor(apiPath, config)
-	return &ExampleV1Client{client}
+	client, err := f.NewClientWithOptions(apiPath, config, options...)
+	if err != nil {
+		return nil, err
+	}
+	return &ExampleV1Client{client}, nil
 }
 
 func setConfigDefaults(config *rest.Config) error {

--- a/staging/src/k8s.io/code-generator/examples/crd/clientset/versioned/typed/example2/v1/example2_client.go
+++ b/staging/src/k8s.io/code-generator/examples/crd/clientset/versioned/typed/example2/v1/example2_client.go
@@ -19,6 +19,7 @@ limitations under the License.
 package v1
 
 import (
+	runtime "k8s.io/apimachinery/pkg/runtime"
 	rest "k8s.io/client-go/rest"
 	v1 "k8s.io/code-generator/examples/crd/apis/example2/v1"
 	"k8s.io/code-generator/examples/crd/clientset/versioned/scheme"
@@ -64,6 +65,16 @@ func NewForConfigOrDie(c *rest.Config) *SecondExampleV1Client {
 // New creates a new SecondExampleV1Client for the given RESTClient.
 func New(c rest.Interface) *SecondExampleV1Client {
 	return &SecondExampleV1Client{c}
+}
+
+// NewForFactory creates a new SecondExampleV1Client for the given RESTClientFactory.
+func NewForFactory(f *rest.RESTClientFactory) *SecondExampleV1Client {
+	var config rest.ClientContentConfig
+	config.GroupVersion = v1.SchemeGroupVersion
+	config.Negotiator = runtime.NewClientNegotiator(scheme.Codecs.WithoutConversion(), v1.SchemeGroupVersion)
+	apiPath := "/apis"
+	client := f.NewFor(apiPath, config)
+	return &SecondExampleV1Client{client}
 }
 
 func setConfigDefaults(config *rest.Config) error {

--- a/staging/src/k8s.io/code-generator/examples/crd/clientset/versioned/typed/example2/v1/example2_client.go
+++ b/staging/src/k8s.io/code-generator/examples/crd/clientset/versioned/typed/example2/v1/example2_client.go
@@ -68,13 +68,16 @@ func New(c rest.Interface) *SecondExampleV1Client {
 }
 
 // NewForFactory creates a new SecondExampleV1Client for the given RESTClientFactory.
-func NewForFactory(f *rest.RESTClientFactory) *SecondExampleV1Client {
+func NewForFactory(f *rest.RESTClientFactory, options ...rest.RESTClientOption) (*SecondExampleV1Client, error) {
 	var config rest.ClientContentConfig
 	config.GroupVersion = v1.SchemeGroupVersion
 	config.Negotiator = runtime.NewClientNegotiator(scheme.Codecs.WithoutConversion(), v1.SchemeGroupVersion)
 	apiPath := "/apis"
-	client := f.NewFor(apiPath, config)
-	return &SecondExampleV1Client{client}
+	client, err := f.NewClientWithOptions(apiPath, config, options...)
+	if err != nil {
+		return nil, err
+	}
+	return &SecondExampleV1Client{client}, nil
 }
 
 func setConfigDefaults(config *rest.Config) error {

--- a/staging/src/k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/clientset.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/clientset.go
@@ -71,16 +71,13 @@ func NewForConfig(c *rest.Config) (*Clientset, error) {
 		}
 		configShallowCopy.RateLimiter = flowcontrol.NewTokenBucketRateLimiter(configShallowCopy.QPS, configShallowCopy.Burst)
 	}
+	factory, err := rest.RESTClientFactoryFor(&configShallowCopy)
+	if err != nil {
+		return nil, err
+	}
 	var cs Clientset
-	var err error
-	cs.apiregistrationV1beta1, err = apiregistrationv1beta1.NewForConfig(&configShallowCopy)
-	if err != nil {
-		return nil, err
-	}
-	cs.apiregistrationV1, err = apiregistrationv1.NewForConfig(&configShallowCopy)
-	if err != nil {
-		return nil, err
-	}
+	cs.apiregistrationV1beta1 = apiregistrationv1beta1.NewForFactory(factory)
+	cs.apiregistrationV1 = apiregistrationv1.NewForFactory(factory)
 
 	cs.DiscoveryClient, err = discovery.NewDiscoveryClientForConfig(&configShallowCopy)
 	if err != nil {
@@ -92,19 +89,23 @@ func NewForConfig(c *rest.Config) (*Clientset, error) {
 // NewForConfigOrDie creates a new Clientset for the given config and
 // panics if there is an error in the config.
 func NewForConfigOrDie(c *rest.Config) *Clientset {
-	var cs Clientset
-	cs.apiregistrationV1beta1 = apiregistrationv1beta1.NewForConfigOrDie(c)
-	cs.apiregistrationV1 = apiregistrationv1.NewForConfigOrDie(c)
-
-	cs.DiscoveryClient = discovery.NewDiscoveryClientForConfigOrDie(c)
-	return &cs
+	cs, err := NewForConfig(c)
+	if err != nil {
+		panic(err)
+	}
+	return cs
 }
 
 // New creates a new Clientset for the given RESTClient.
 func New(c rest.Interface) *Clientset {
+	client, ok := c.(*rest.RESTClient)
+	if !ok {
+		return nil
+	}
+	factory := rest.RESTClientFactoryFromClient(*client)
 	var cs Clientset
-	cs.apiregistrationV1beta1 = apiregistrationv1beta1.New(c)
-	cs.apiregistrationV1 = apiregistrationv1.New(c)
+	cs.apiregistrationV1beta1 = apiregistrationv1beta1.NewForFactory(factory)
+	cs.apiregistrationV1 = apiregistrationv1.NewForFactory(factory)
 
 	cs.DiscoveryClient = discovery.NewDiscoveryClient(c)
 	return &cs

--- a/staging/src/k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/typed/apiregistration/v1/apiregistration_client.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/typed/apiregistration/v1/apiregistration_client.go
@@ -68,13 +68,16 @@ func New(c rest.Interface) *ApiregistrationV1Client {
 }
 
 // NewForFactory creates a new ApiregistrationV1Client for the given RESTClientFactory.
-func NewForFactory(f *rest.RESTClientFactory) *ApiregistrationV1Client {
+func NewForFactory(f *rest.RESTClientFactory, options ...rest.RESTClientOption) (*ApiregistrationV1Client, error) {
 	var config rest.ClientContentConfig
 	config.GroupVersion = v1.SchemeGroupVersion
 	config.Negotiator = runtime.NewClientNegotiator(scheme.Codecs.WithoutConversion(), v1.SchemeGroupVersion)
 	apiPath := "/apis"
-	client := f.NewFor(apiPath, config)
-	return &ApiregistrationV1Client{client}
+	client, err := f.NewClientWithOptions(apiPath, config, options...)
+	if err != nil {
+		return nil, err
+	}
+	return &ApiregistrationV1Client{client}, nil
 }
 
 func setConfigDefaults(config *rest.Config) error {

--- a/staging/src/k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/typed/apiregistration/v1/apiregistration_client.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/typed/apiregistration/v1/apiregistration_client.go
@@ -19,6 +19,7 @@ limitations under the License.
 package v1
 
 import (
+	runtime "k8s.io/apimachinery/pkg/runtime"
 	rest "k8s.io/client-go/rest"
 	v1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
 	"k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
@@ -64,6 +65,16 @@ func NewForConfigOrDie(c *rest.Config) *ApiregistrationV1Client {
 // New creates a new ApiregistrationV1Client for the given RESTClient.
 func New(c rest.Interface) *ApiregistrationV1Client {
 	return &ApiregistrationV1Client{c}
+}
+
+// NewForFactory creates a new ApiregistrationV1Client for the given RESTClientFactory.
+func NewForFactory(f *rest.RESTClientFactory) *ApiregistrationV1Client {
+	var config rest.ClientContentConfig
+	config.GroupVersion = v1.SchemeGroupVersion
+	config.Negotiator = runtime.NewClientNegotiator(scheme.Codecs.WithoutConversion(), v1.SchemeGroupVersion)
+	apiPath := "/apis"
+	client := f.NewFor(apiPath, config)
+	return &ApiregistrationV1Client{client}
 }
 
 func setConfigDefaults(config *rest.Config) error {

--- a/staging/src/k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/typed/apiregistration/v1beta1/apiregistration_client.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/typed/apiregistration/v1beta1/apiregistration_client.go
@@ -19,6 +19,7 @@ limitations under the License.
 package v1beta1
 
 import (
+	runtime "k8s.io/apimachinery/pkg/runtime"
 	rest "k8s.io/client-go/rest"
 	v1beta1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1beta1"
 	"k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
@@ -64,6 +65,16 @@ func NewForConfigOrDie(c *rest.Config) *ApiregistrationV1beta1Client {
 // New creates a new ApiregistrationV1beta1Client for the given RESTClient.
 func New(c rest.Interface) *ApiregistrationV1beta1Client {
 	return &ApiregistrationV1beta1Client{c}
+}
+
+// NewForFactory creates a new ApiregistrationV1beta1Client for the given RESTClientFactory.
+func NewForFactory(f *rest.RESTClientFactory) *ApiregistrationV1beta1Client {
+	var config rest.ClientContentConfig
+	config.GroupVersion = v1beta1.SchemeGroupVersion
+	config.Negotiator = runtime.NewClientNegotiator(scheme.Codecs.WithoutConversion(), v1beta1.SchemeGroupVersion)
+	apiPath := "/apis"
+	client := f.NewFor(apiPath, config)
+	return &ApiregistrationV1beta1Client{client}
 }
 
 func setConfigDefaults(config *rest.Config) error {

--- a/staging/src/k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/typed/apiregistration/v1beta1/apiregistration_client.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/typed/apiregistration/v1beta1/apiregistration_client.go
@@ -68,13 +68,16 @@ func New(c rest.Interface) *ApiregistrationV1beta1Client {
 }
 
 // NewForFactory creates a new ApiregistrationV1beta1Client for the given RESTClientFactory.
-func NewForFactory(f *rest.RESTClientFactory) *ApiregistrationV1beta1Client {
+func NewForFactory(f *rest.RESTClientFactory, options ...rest.RESTClientOption) (*ApiregistrationV1beta1Client, error) {
 	var config rest.ClientContentConfig
 	config.GroupVersion = v1beta1.SchemeGroupVersion
 	config.Negotiator = runtime.NewClientNegotiator(scheme.Codecs.WithoutConversion(), v1beta1.SchemeGroupVersion)
 	apiPath := "/apis"
-	client := f.NewFor(apiPath, config)
-	return &ApiregistrationV1beta1Client{client}
+	client, err := f.NewClientWithOptions(apiPath, config, options...)
+	if err != nil {
+		return nil, err
+	}
+	return &ApiregistrationV1beta1Client{client}, nil
 }
 
 func setConfigDefaults(config *rest.Config) error {

--- a/staging/src/k8s.io/metrics/pkg/client/clientset/versioned/clientset.go
+++ b/staging/src/k8s.io/metrics/pkg/client/clientset/versioned/clientset.go
@@ -75,9 +75,23 @@ func NewForConfig(c *rest.Config) (*Clientset, error) {
 	if err != nil {
 		return nil, err
 	}
+	options := []rest.RESTClientOption{}
+	if configShallowCopy.RateLimiter != nil {
+		options = append(options, rest.WithRateLimiter(configShallowCopy.RateLimiter))
+	}
+	if configShallowCopy.WarningHandler != nil {
+		options = append(options, rest.WithWarningHandler(configShallowCopy.WarningHandler))
+	}
+
 	var cs Clientset
-	cs.metricsV1alpha1 = metricsv1alpha1.NewForFactory(factory)
-	cs.metricsV1beta1 = metricsv1beta1.NewForFactory(factory)
+	cs.metricsV1alpha1, err = metricsv1alpha1.NewForFactory(factory, options...)
+	if err != nil {
+		return nil, err
+	}
+	cs.metricsV1beta1, err = metricsv1beta1.NewForFactory(factory, options...)
+	if err != nil {
+		return nil, err
+	}
 
 	cs.DiscoveryClient, err = discovery.NewDiscoveryClientForConfig(&configShallowCopy)
 	if err != nil {
@@ -104,8 +118,15 @@ func New(c rest.Interface) *Clientset {
 	}
 	factory := rest.RESTClientFactoryFromClient(*client)
 	var cs Clientset
-	cs.metricsV1alpha1 = metricsv1alpha1.NewForFactory(factory)
-	cs.metricsV1beta1 = metricsv1beta1.NewForFactory(factory)
+	var err error
+	cs.metricsV1alpha1, err = metricsv1alpha1.NewForFactory(factory)
+	if err != nil {
+		panic(err)
+	}
+	cs.metricsV1beta1, err = metricsv1beta1.NewForFactory(factory)
+	if err != nil {
+		panic(err)
+	}
 
 	cs.DiscoveryClient = discovery.NewDiscoveryClient(c)
 	return &cs

--- a/staging/src/k8s.io/metrics/pkg/client/clientset/versioned/clientset.go
+++ b/staging/src/k8s.io/metrics/pkg/client/clientset/versioned/clientset.go
@@ -71,16 +71,13 @@ func NewForConfig(c *rest.Config) (*Clientset, error) {
 		}
 		configShallowCopy.RateLimiter = flowcontrol.NewTokenBucketRateLimiter(configShallowCopy.QPS, configShallowCopy.Burst)
 	}
+	factory, err := rest.RESTClientFactoryFor(&configShallowCopy)
+	if err != nil {
+		return nil, err
+	}
 	var cs Clientset
-	var err error
-	cs.metricsV1alpha1, err = metricsv1alpha1.NewForConfig(&configShallowCopy)
-	if err != nil {
-		return nil, err
-	}
-	cs.metricsV1beta1, err = metricsv1beta1.NewForConfig(&configShallowCopy)
-	if err != nil {
-		return nil, err
-	}
+	cs.metricsV1alpha1 = metricsv1alpha1.NewForFactory(factory)
+	cs.metricsV1beta1 = metricsv1beta1.NewForFactory(factory)
 
 	cs.DiscoveryClient, err = discovery.NewDiscoveryClientForConfig(&configShallowCopy)
 	if err != nil {
@@ -92,19 +89,23 @@ func NewForConfig(c *rest.Config) (*Clientset, error) {
 // NewForConfigOrDie creates a new Clientset for the given config and
 // panics if there is an error in the config.
 func NewForConfigOrDie(c *rest.Config) *Clientset {
-	var cs Clientset
-	cs.metricsV1alpha1 = metricsv1alpha1.NewForConfigOrDie(c)
-	cs.metricsV1beta1 = metricsv1beta1.NewForConfigOrDie(c)
-
-	cs.DiscoveryClient = discovery.NewDiscoveryClientForConfigOrDie(c)
-	return &cs
+	cs, err := NewForConfig(c)
+	if err != nil {
+		panic(err)
+	}
+	return cs
 }
 
 // New creates a new Clientset for the given RESTClient.
 func New(c rest.Interface) *Clientset {
+	client, ok := c.(*rest.RESTClient)
+	if !ok {
+		return nil
+	}
+	factory := rest.RESTClientFactoryFromClient(*client)
 	var cs Clientset
-	cs.metricsV1alpha1 = metricsv1alpha1.New(c)
-	cs.metricsV1beta1 = metricsv1beta1.New(c)
+	cs.metricsV1alpha1 = metricsv1alpha1.NewForFactory(factory)
+	cs.metricsV1beta1 = metricsv1beta1.NewForFactory(factory)
 
 	cs.DiscoveryClient = discovery.NewDiscoveryClient(c)
 	return &cs

--- a/staging/src/k8s.io/metrics/pkg/client/clientset/versioned/typed/metrics/v1alpha1/metrics_client.go
+++ b/staging/src/k8s.io/metrics/pkg/client/clientset/versioned/typed/metrics/v1alpha1/metrics_client.go
@@ -19,6 +19,7 @@ limitations under the License.
 package v1alpha1
 
 import (
+	runtime "k8s.io/apimachinery/pkg/runtime"
 	rest "k8s.io/client-go/rest"
 	v1alpha1 "k8s.io/metrics/pkg/apis/metrics/v1alpha1"
 	"k8s.io/metrics/pkg/client/clientset/versioned/scheme"
@@ -69,6 +70,16 @@ func NewForConfigOrDie(c *rest.Config) *MetricsV1alpha1Client {
 // New creates a new MetricsV1alpha1Client for the given RESTClient.
 func New(c rest.Interface) *MetricsV1alpha1Client {
 	return &MetricsV1alpha1Client{c}
+}
+
+// NewForFactory creates a new MetricsV1alpha1Client for the given RESTClientFactory.
+func NewForFactory(f *rest.RESTClientFactory) *MetricsV1alpha1Client {
+	var config rest.ClientContentConfig
+	config.GroupVersion = v1alpha1.SchemeGroupVersion
+	config.Negotiator = runtime.NewClientNegotiator(scheme.Codecs.WithoutConversion(), v1alpha1.SchemeGroupVersion)
+	apiPath := "/apis"
+	client := f.NewFor(apiPath, config)
+	return &MetricsV1alpha1Client{client}
 }
 
 func setConfigDefaults(config *rest.Config) error {

--- a/staging/src/k8s.io/metrics/pkg/client/clientset/versioned/typed/metrics/v1alpha1/metrics_client.go
+++ b/staging/src/k8s.io/metrics/pkg/client/clientset/versioned/typed/metrics/v1alpha1/metrics_client.go
@@ -73,13 +73,16 @@ func New(c rest.Interface) *MetricsV1alpha1Client {
 }
 
 // NewForFactory creates a new MetricsV1alpha1Client for the given RESTClientFactory.
-func NewForFactory(f *rest.RESTClientFactory) *MetricsV1alpha1Client {
+func NewForFactory(f *rest.RESTClientFactory, options ...rest.RESTClientOption) (*MetricsV1alpha1Client, error) {
 	var config rest.ClientContentConfig
 	config.GroupVersion = v1alpha1.SchemeGroupVersion
 	config.Negotiator = runtime.NewClientNegotiator(scheme.Codecs.WithoutConversion(), v1alpha1.SchemeGroupVersion)
 	apiPath := "/apis"
-	client := f.NewFor(apiPath, config)
-	return &MetricsV1alpha1Client{client}
+	client, err := f.NewClientWithOptions(apiPath, config, options...)
+	if err != nil {
+		return nil, err
+	}
+	return &MetricsV1alpha1Client{client}, nil
 }
 
 func setConfigDefaults(config *rest.Config) error {

--- a/staging/src/k8s.io/metrics/pkg/client/clientset/versioned/typed/metrics/v1beta1/metrics_client.go
+++ b/staging/src/k8s.io/metrics/pkg/client/clientset/versioned/typed/metrics/v1beta1/metrics_client.go
@@ -73,13 +73,16 @@ func New(c rest.Interface) *MetricsV1beta1Client {
 }
 
 // NewForFactory creates a new MetricsV1beta1Client for the given RESTClientFactory.
-func NewForFactory(f *rest.RESTClientFactory) *MetricsV1beta1Client {
+func NewForFactory(f *rest.RESTClientFactory, options ...rest.RESTClientOption) (*MetricsV1beta1Client, error) {
 	var config rest.ClientContentConfig
 	config.GroupVersion = v1beta1.SchemeGroupVersion
 	config.Negotiator = runtime.NewClientNegotiator(scheme.Codecs.WithoutConversion(), v1beta1.SchemeGroupVersion)
 	apiPath := "/apis"
-	client := f.NewFor(apiPath, config)
-	return &MetricsV1beta1Client{client}
+	client, err := f.NewClientWithOptions(apiPath, config, options...)
+	if err != nil {
+		return nil, err
+	}
+	return &MetricsV1beta1Client{client}, nil
 }
 
 func setConfigDefaults(config *rest.Config) error {

--- a/staging/src/k8s.io/metrics/pkg/client/clientset/versioned/typed/metrics/v1beta1/metrics_client.go
+++ b/staging/src/k8s.io/metrics/pkg/client/clientset/versioned/typed/metrics/v1beta1/metrics_client.go
@@ -19,6 +19,7 @@ limitations under the License.
 package v1beta1
 
 import (
+	runtime "k8s.io/apimachinery/pkg/runtime"
 	rest "k8s.io/client-go/rest"
 	v1beta1 "k8s.io/metrics/pkg/apis/metrics/v1beta1"
 	"k8s.io/metrics/pkg/client/clientset/versioned/scheme"
@@ -69,6 +70,16 @@ func NewForConfigOrDie(c *rest.Config) *MetricsV1beta1Client {
 // New creates a new MetricsV1beta1Client for the given RESTClient.
 func New(c rest.Interface) *MetricsV1beta1Client {
 	return &MetricsV1beta1Client{c}
+}
+
+// NewForFactory creates a new MetricsV1beta1Client for the given RESTClientFactory.
+func NewForFactory(f *rest.RESTClientFactory) *MetricsV1beta1Client {
+	var config rest.ClientContentConfig
+	config.GroupVersion = v1beta1.SchemeGroupVersion
+	config.Negotiator = runtime.NewClientNegotiator(scheme.Codecs.WithoutConversion(), v1beta1.SchemeGroupVersion)
+	apiPath := "/apis"
+	client := f.NewFor(apiPath, config)
+	return &MetricsV1beta1Client{client}
 }
 
 func setConfigDefaults(config *rest.Config) error {

--- a/staging/src/k8s.io/sample-apiserver/pkg/generated/clientset/versioned/clientset.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/generated/clientset/versioned/clientset.go
@@ -71,16 +71,13 @@ func NewForConfig(c *rest.Config) (*Clientset, error) {
 		}
 		configShallowCopy.RateLimiter = flowcontrol.NewTokenBucketRateLimiter(configShallowCopy.QPS, configShallowCopy.Burst)
 	}
+	factory, err := rest.RESTClientFactoryFor(&configShallowCopy)
+	if err != nil {
+		return nil, err
+	}
 	var cs Clientset
-	var err error
-	cs.wardleV1alpha1, err = wardlev1alpha1.NewForConfig(&configShallowCopy)
-	if err != nil {
-		return nil, err
-	}
-	cs.wardleV1beta1, err = wardlev1beta1.NewForConfig(&configShallowCopy)
-	if err != nil {
-		return nil, err
-	}
+	cs.wardleV1alpha1 = wardlev1alpha1.NewForFactory(factory)
+	cs.wardleV1beta1 = wardlev1beta1.NewForFactory(factory)
 
 	cs.DiscoveryClient, err = discovery.NewDiscoveryClientForConfig(&configShallowCopy)
 	if err != nil {
@@ -92,19 +89,23 @@ func NewForConfig(c *rest.Config) (*Clientset, error) {
 // NewForConfigOrDie creates a new Clientset for the given config and
 // panics if there is an error in the config.
 func NewForConfigOrDie(c *rest.Config) *Clientset {
-	var cs Clientset
-	cs.wardleV1alpha1 = wardlev1alpha1.NewForConfigOrDie(c)
-	cs.wardleV1beta1 = wardlev1beta1.NewForConfigOrDie(c)
-
-	cs.DiscoveryClient = discovery.NewDiscoveryClientForConfigOrDie(c)
-	return &cs
+	cs, err := NewForConfig(c)
+	if err != nil {
+		panic(err)
+	}
+	return cs
 }
 
 // New creates a new Clientset for the given RESTClient.
 func New(c rest.Interface) *Clientset {
+	client, ok := c.(*rest.RESTClient)
+	if !ok {
+		return nil
+	}
+	factory := rest.RESTClientFactoryFromClient(*client)
 	var cs Clientset
-	cs.wardleV1alpha1 = wardlev1alpha1.New(c)
-	cs.wardleV1beta1 = wardlev1beta1.New(c)
+	cs.wardleV1alpha1 = wardlev1alpha1.NewForFactory(factory)
+	cs.wardleV1beta1 = wardlev1beta1.NewForFactory(factory)
 
 	cs.DiscoveryClient = discovery.NewDiscoveryClient(c)
 	return &cs

--- a/staging/src/k8s.io/sample-apiserver/pkg/generated/clientset/versioned/typed/wardle/v1alpha1/wardle_client.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/generated/clientset/versioned/typed/wardle/v1alpha1/wardle_client.go
@@ -19,6 +19,7 @@ limitations under the License.
 package v1alpha1
 
 import (
+	runtime "k8s.io/apimachinery/pkg/runtime"
 	rest "k8s.io/client-go/rest"
 	v1alpha1 "k8s.io/sample-apiserver/pkg/apis/wardle/v1alpha1"
 	"k8s.io/sample-apiserver/pkg/generated/clientset/versioned/scheme"
@@ -69,6 +70,16 @@ func NewForConfigOrDie(c *rest.Config) *WardleV1alpha1Client {
 // New creates a new WardleV1alpha1Client for the given RESTClient.
 func New(c rest.Interface) *WardleV1alpha1Client {
 	return &WardleV1alpha1Client{c}
+}
+
+// NewForFactory creates a new WardleV1alpha1Client for the given RESTClientFactory.
+func NewForFactory(f *rest.RESTClientFactory) *WardleV1alpha1Client {
+	var config rest.ClientContentConfig
+	config.GroupVersion = v1alpha1.SchemeGroupVersion
+	config.Negotiator = runtime.NewClientNegotiator(scheme.Codecs.WithoutConversion(), v1alpha1.SchemeGroupVersion)
+	apiPath := "/apis"
+	client := f.NewFor(apiPath, config)
+	return &WardleV1alpha1Client{client}
 }
 
 func setConfigDefaults(config *rest.Config) error {

--- a/staging/src/k8s.io/sample-apiserver/pkg/generated/clientset/versioned/typed/wardle/v1alpha1/wardle_client.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/generated/clientset/versioned/typed/wardle/v1alpha1/wardle_client.go
@@ -73,13 +73,16 @@ func New(c rest.Interface) *WardleV1alpha1Client {
 }
 
 // NewForFactory creates a new WardleV1alpha1Client for the given RESTClientFactory.
-func NewForFactory(f *rest.RESTClientFactory) *WardleV1alpha1Client {
+func NewForFactory(f *rest.RESTClientFactory, options ...rest.RESTClientOption) (*WardleV1alpha1Client, error) {
 	var config rest.ClientContentConfig
 	config.GroupVersion = v1alpha1.SchemeGroupVersion
 	config.Negotiator = runtime.NewClientNegotiator(scheme.Codecs.WithoutConversion(), v1alpha1.SchemeGroupVersion)
 	apiPath := "/apis"
-	client := f.NewFor(apiPath, config)
-	return &WardleV1alpha1Client{client}
+	client, err := f.NewClientWithOptions(apiPath, config, options...)
+	if err != nil {
+		return nil, err
+	}
+	return &WardleV1alpha1Client{client}, nil
 }
 
 func setConfigDefaults(config *rest.Config) error {

--- a/staging/src/k8s.io/sample-apiserver/pkg/generated/clientset/versioned/typed/wardle/v1beta1/wardle_client.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/generated/clientset/versioned/typed/wardle/v1beta1/wardle_client.go
@@ -68,13 +68,16 @@ func New(c rest.Interface) *WardleV1beta1Client {
 }
 
 // NewForFactory creates a new WardleV1beta1Client for the given RESTClientFactory.
-func NewForFactory(f *rest.RESTClientFactory) *WardleV1beta1Client {
+func NewForFactory(f *rest.RESTClientFactory, options ...rest.RESTClientOption) (*WardleV1beta1Client, error) {
 	var config rest.ClientContentConfig
 	config.GroupVersion = v1beta1.SchemeGroupVersion
 	config.Negotiator = runtime.NewClientNegotiator(scheme.Codecs.WithoutConversion(), v1beta1.SchemeGroupVersion)
 	apiPath := "/apis"
-	client := f.NewFor(apiPath, config)
-	return &WardleV1beta1Client{client}
+	client, err := f.NewClientWithOptions(apiPath, config, options...)
+	if err != nil {
+		return nil, err
+	}
+	return &WardleV1beta1Client{client}, nil
 }
 
 func setConfigDefaults(config *rest.Config) error {

--- a/staging/src/k8s.io/sample-apiserver/pkg/generated/clientset/versioned/typed/wardle/v1beta1/wardle_client.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/generated/clientset/versioned/typed/wardle/v1beta1/wardle_client.go
@@ -19,6 +19,7 @@ limitations under the License.
 package v1beta1
 
 import (
+	runtime "k8s.io/apimachinery/pkg/runtime"
 	rest "k8s.io/client-go/rest"
 	v1beta1 "k8s.io/sample-apiserver/pkg/apis/wardle/v1beta1"
 	"k8s.io/sample-apiserver/pkg/generated/clientset/versioned/scheme"
@@ -64,6 +65,16 @@ func NewForConfigOrDie(c *rest.Config) *WardleV1beta1Client {
 // New creates a new WardleV1beta1Client for the given RESTClient.
 func New(c rest.Interface) *WardleV1beta1Client {
 	return &WardleV1beta1Client{c}
+}
+
+// NewForFactory creates a new WardleV1beta1Client for the given RESTClientFactory.
+func NewForFactory(f *rest.RESTClientFactory) *WardleV1beta1Client {
+	var config rest.ClientContentConfig
+	config.GroupVersion = v1beta1.SchemeGroupVersion
+	config.Negotiator = runtime.NewClientNegotiator(scheme.Codecs.WithoutConversion(), v1beta1.SchemeGroupVersion)
+	apiPath := "/apis"
+	client := f.NewFor(apiPath, config)
+	return &WardleV1beta1Client{client}
 }
 
 func setConfigDefaults(config *rest.Config) error {

--- a/staging/src/k8s.io/sample-controller/pkg/generated/clientset/versioned/clientset.go
+++ b/staging/src/k8s.io/sample-controller/pkg/generated/clientset/versioned/clientset.go
@@ -63,12 +63,12 @@ func NewForConfig(c *rest.Config) (*Clientset, error) {
 		}
 		configShallowCopy.RateLimiter = flowcontrol.NewTokenBucketRateLimiter(configShallowCopy.QPS, configShallowCopy.Burst)
 	}
-	var cs Clientset
-	var err error
-	cs.samplecontrollerV1alpha1, err = samplecontrollerv1alpha1.NewForConfig(&configShallowCopy)
+	factory, err := rest.RESTClientFactoryFor(&configShallowCopy)
 	if err != nil {
 		return nil, err
 	}
+	var cs Clientset
+	cs.samplecontrollerV1alpha1 = samplecontrollerv1alpha1.NewForFactory(factory)
 
 	cs.DiscoveryClient, err = discovery.NewDiscoveryClientForConfig(&configShallowCopy)
 	if err != nil {
@@ -80,17 +80,22 @@ func NewForConfig(c *rest.Config) (*Clientset, error) {
 // NewForConfigOrDie creates a new Clientset for the given config and
 // panics if there is an error in the config.
 func NewForConfigOrDie(c *rest.Config) *Clientset {
-	var cs Clientset
-	cs.samplecontrollerV1alpha1 = samplecontrollerv1alpha1.NewForConfigOrDie(c)
-
-	cs.DiscoveryClient = discovery.NewDiscoveryClientForConfigOrDie(c)
-	return &cs
+	cs, err := NewForConfig(c)
+	if err != nil {
+		panic(err)
+	}
+	return cs
 }
 
 // New creates a new Clientset for the given RESTClient.
 func New(c rest.Interface) *Clientset {
+	client, ok := c.(*rest.RESTClient)
+	if !ok {
+		return nil
+	}
+	factory := rest.RESTClientFactoryFromClient(*client)
 	var cs Clientset
-	cs.samplecontrollerV1alpha1 = samplecontrollerv1alpha1.New(c)
+	cs.samplecontrollerV1alpha1 = samplecontrollerv1alpha1.NewForFactory(factory)
 
 	cs.DiscoveryClient = discovery.NewDiscoveryClient(c)
 	return &cs

--- a/staging/src/k8s.io/sample-controller/pkg/generated/clientset/versioned/clientset.go
+++ b/staging/src/k8s.io/sample-controller/pkg/generated/clientset/versioned/clientset.go
@@ -67,8 +67,19 @@ func NewForConfig(c *rest.Config) (*Clientset, error) {
 	if err != nil {
 		return nil, err
 	}
+	options := []rest.RESTClientOption{}
+	if configShallowCopy.RateLimiter != nil {
+		options = append(options, rest.WithRateLimiter(configShallowCopy.RateLimiter))
+	}
+	if configShallowCopy.WarningHandler != nil {
+		options = append(options, rest.WithWarningHandler(configShallowCopy.WarningHandler))
+	}
+
 	var cs Clientset
-	cs.samplecontrollerV1alpha1 = samplecontrollerv1alpha1.NewForFactory(factory)
+	cs.samplecontrollerV1alpha1, err = samplecontrollerv1alpha1.NewForFactory(factory, options...)
+	if err != nil {
+		return nil, err
+	}
 
 	cs.DiscoveryClient, err = discovery.NewDiscoveryClientForConfig(&configShallowCopy)
 	if err != nil {
@@ -95,7 +106,11 @@ func New(c rest.Interface) *Clientset {
 	}
 	factory := rest.RESTClientFactoryFromClient(*client)
 	var cs Clientset
-	cs.samplecontrollerV1alpha1 = samplecontrollerv1alpha1.NewForFactory(factory)
+	var err error
+	cs.samplecontrollerV1alpha1, err = samplecontrollerv1alpha1.NewForFactory(factory)
+	if err != nil {
+		panic(err)
+	}
 
 	cs.DiscoveryClient = discovery.NewDiscoveryClient(c)
 	return &cs

--- a/staging/src/k8s.io/sample-controller/pkg/generated/clientset/versioned/typed/samplecontroller/v1alpha1/samplecontroller_client.go
+++ b/staging/src/k8s.io/sample-controller/pkg/generated/clientset/versioned/typed/samplecontroller/v1alpha1/samplecontroller_client.go
@@ -68,13 +68,16 @@ func New(c rest.Interface) *SamplecontrollerV1alpha1Client {
 }
 
 // NewForFactory creates a new SamplecontrollerV1alpha1Client for the given RESTClientFactory.
-func NewForFactory(f *rest.RESTClientFactory) *SamplecontrollerV1alpha1Client {
+func NewForFactory(f *rest.RESTClientFactory, options ...rest.RESTClientOption) (*SamplecontrollerV1alpha1Client, error) {
 	var config rest.ClientContentConfig
 	config.GroupVersion = v1alpha1.SchemeGroupVersion
 	config.Negotiator = runtime.NewClientNegotiator(scheme.Codecs.WithoutConversion(), v1alpha1.SchemeGroupVersion)
 	apiPath := "/apis"
-	client := f.NewFor(apiPath, config)
-	return &SamplecontrollerV1alpha1Client{client}
+	client, err := f.NewClientWithOptions(apiPath, config, options...)
+	if err != nil {
+		return nil, err
+	}
+	return &SamplecontrollerV1alpha1Client{client}, nil
 }
 
 func setConfigDefaults(config *rest.Config) error {

--- a/staging/src/k8s.io/sample-controller/pkg/generated/clientset/versioned/typed/samplecontroller/v1alpha1/samplecontroller_client.go
+++ b/staging/src/k8s.io/sample-controller/pkg/generated/clientset/versioned/typed/samplecontroller/v1alpha1/samplecontroller_client.go
@@ -19,6 +19,7 @@ limitations under the License.
 package v1alpha1
 
 import (
+	runtime "k8s.io/apimachinery/pkg/runtime"
 	rest "k8s.io/client-go/rest"
 	v1alpha1 "k8s.io/sample-controller/pkg/apis/samplecontroller/v1alpha1"
 	"k8s.io/sample-controller/pkg/generated/clientset/versioned/scheme"
@@ -64,6 +65,16 @@ func NewForConfigOrDie(c *rest.Config) *SamplecontrollerV1alpha1Client {
 // New creates a new SamplecontrollerV1alpha1Client for the given RESTClient.
 func New(c rest.Interface) *SamplecontrollerV1alpha1Client {
 	return &SamplecontrollerV1alpha1Client{c}
+}
+
+// NewForFactory creates a new SamplecontrollerV1alpha1Client for the given RESTClientFactory.
+func NewForFactory(f *rest.RESTClientFactory) *SamplecontrollerV1alpha1Client {
+	var config rest.ClientContentConfig
+	config.GroupVersion = v1alpha1.SchemeGroupVersion
+	config.Negotiator = runtime.NewClientNegotiator(scheme.Codecs.WithoutConversion(), v1alpha1.SchemeGroupVersion)
+	apiPath := "/apis"
+	client := f.NewFor(apiPath, config)
+	return &SamplecontrollerV1alpha1Client{client}
 }
 
 func setConfigDefaults(config *rest.Config) error {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind cleanup

#### What this PR does / why we need it:

Until now, when creating a Kubernetes Clientset, a new RESTClient was created per group/version. Since RESTClient transport can not be cached in some occasions, like when using a custom transport, this has the consequence that each group/version had an independent TCP connection to the API server.

Since the Transport, and another fields, of the RESTClient can be shared when creating a global Kubernetes Clientset, this PR adds a new RESTClientFactory types that allows to create RESTClients sharing the common fields.

#### Which issue(s) this PR fixes:

Fixes #103224

#### Special notes for your reviewer:

It turns out that some of the imported code in the generated clients is required to register the scheme and can not be generalized, specially the one required for apiextensions that uses its own Codecs

https://github.com/kubernetes/kubernetes/blob/e5976909c6fb129228a67515e0f86336a53884f0/staging/src/k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1beta1/apiextensions_client.go#L23

In order to make the implementation less disruptive, I've added a new constructor (similar to the ones used in the informers) to the generated clientset types, reusing current parametrization and making it totally compatible with current implementation.

#### Does this PR introduce a user-facing change?
```release-note
bugfix: client-go and RESTClient allow to share customized transports for multiple group/versions
```

/sig api-machinery