### PR TITLE
fixed using reference to loop iterator

### DIFF
--- a/test/e2e/framework/deployment/fixtures.go
+++ b/test/e2e/framework/deployment/fixtures.go
@@ -99,12 +99,12 @@ func GetPodsForDeployment(client clientset.Interface, deployment *appsv1.Deploym
 	}
 
 	ownedReplicaSets := make([]*appsv1.ReplicaSet, 0, len(allReplicaSets.Items))
-	for _, rs := range allReplicaSets.Items {
-		if !metav1.IsControlledBy(&rs, deployment) {
+	for i := range allReplicaSets.Items {
+		if !metav1.IsControlledBy(&allReplicaSets.Items[i], deployment) {
 			continue
 		}
 
-		ownedReplicaSets = append(ownedReplicaSets, &rs)
+		ownedReplicaSets = append(ownedReplicaSets, &allReplicaSets.Items[i])
 	}
 
 	// We ignore pod-template-hash because:

--- a/test/e2e/framework/deployment/fixtures.go
+++ b/test/e2e/framework/deployment/fixtures.go
@@ -126,8 +126,8 @@ func GetPodsForDeployment(client clientset.Interface, deployment *appsv1.Deploym
 	// see https://github.com/kubernetes/kubernetes/issues/40415
 	// We deterministically choose the oldest new ReplicaSet.
 	sort.Sort(replicaSetsByCreationTimestamp(ownedReplicaSets))
-	for _, rs := range ownedReplicaSets {
-		if !podTemplatesEqualsIgnoringHash(&rs.Spec.Template, &deployment.Spec.Template) {
+	for i, rs := range ownedReplicaSets {
+		if !podTemplatesEqualsIgnoringHash(&ownedReplicaSets[i].Spec.Template, &deployment.Spec.Template) {
 			continue
 		}
 
@@ -151,8 +151,8 @@ func GetPodsForDeployment(client clientset.Interface, deployment *appsv1.Deploym
 
 	replicaSetUID := replicaSet.UID
 	ownedPods := &v1.PodList{Items: make([]v1.Pod, 0, len(allPods.Items))}
-	for _, pod := range allPods.Items {
-		controllerRef := metav1.GetControllerOf(&pod)
+	for i, pod := range allPods.Items {
+		controllerRef := metav1.GetControllerOf(&allPods.Items[i])
 		if controllerRef != nil && controllerRef.UID == replicaSetUID {
 			ownedPods.Items = append(ownedPods.Items, pod)
 		}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Current code incorrectly uses for loop and passes wrong value as reference
Guide to refer https://github.com/golang/go/wiki/CommonMistakes#using-reference-to-loop-iterator-variable

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes/kubernetes/issues/105427

#### Special notes for your reviewer:
Please refer to sample code to understand the bug https://goplay.space/#TIT_IZEAEud

```
package main

import "fmt"

type st struct {
	it []string
}

func main() {
	rp := &st{[]string{"value1", "value2"}}
	ownedReplicaSets1 := make([]*string, 0, len(rp.it))
	ownedReplicaSets2 := make([]*string, 0, len(rp.it))

	// similar to current implementation
	for _, t := range rp.it {
		ownedReplicaSets1 = append(ownedReplicaSets1, &t)
	}

	fmt.Println(ownedReplicaSets1)
	fmt.Println(*ownedReplicaSets1[0], *ownedReplicaSets1[1])

	// similar new change
	for i := range rp.it {
		ownedReplicaSets2 = append(ownedReplicaSets2, &rp.it[i])
	}

	fmt.Println(ownedReplicaSets2)
	fmt.Println(*ownedReplicaSets2[0], *ownedReplicaSets2[1])
}
```


```
output:
value2 value2
[0xc000054020 0xc000054030]
value1 value2
```


#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NA
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
