### PR TITLE
Automated cherry pick of #103371: tests: Wait for the network connectivity first

### DIFF
--- a/test/e2e/windows/hybrid_network.go
+++ b/test/e2e/windows/hybrid_network.go
@@ -81,11 +81,13 @@ var (
 )
 
 func assertConsistentConnectivity(f *framework.Framework, podName string, os string, cmd []string) {
-	gomega.Consistently(func() error {
+	connChecker := func() error {
 		ginkgo.By(fmt.Sprintf("checking connectivity of %s-container in %s", os, podName))
 		_, _, err := f.ExecCommandInContainerWithFullOutput(podName, os+"-container", cmd...)
 		return err
-	}, duration, pollInterval).ShouldNot(gomega.HaveOccurred())
+	}
+	gomega.Eventually(connChecker, duration, pollInterval).ShouldNot(gomega.HaveOccurred())
+	gomega.Consistently(connChecker, duration, pollInterval).ShouldNot(gomega.HaveOccurred())
 }
 
 func linuxCheck(address string, port int) []string {


### PR DESCRIPTION
Cherry pick of #103371 on release-1.20.

#103371: tests: Wait for the network connectivity first

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

/kind flake

/sig testing
/sig windows

#### What this PR does / why we need it:

Some tests are checking the network connectivity using ``gomega.Consistently``, which will fail if any of the checks fails. This could lead to flakyness in some scenarios in which kube-proxy was supposed to apply Policies for Kubernetes services.

We can instead wait for the network connectivity to work first using ``gomega.Eventually``, after which we can check the consistency.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

Related: #98499

```release-note
NONE
```