### PR TITLE
Automated cherry pick of #101063: tests: Spawn poststart / prestop pods on the same node as the

### DIFF
--- a/test/conformance/testdata/conformance.yaml
+++ b/test/conformance/testdata/conformance.yaml
@@ -1641,9 +1641,9 @@
     hook should execute poststart http hook properly [NodeConformance] [Conformance]'
   description: When a post start handler is specified in the container lifecycle using
     a HttpGet action, then the handler MUST be invoked after the start of the container.
-    A server pod is created that will serve http requests, create a second pod with
-    a container lifecycle specifying a post start that invokes the server pod to validate
-    that the post start is executed.
+    A server pod is created that will serve http requests, create a second pod on
+    the same node with a container lifecycle specifying a post start that invokes
+    the server pod to validate that the post start is executed.
   release: v1.9
   file: test/e2e/common/node/lifecycle_hook.go
 - testname: Pod Lifecycle, prestop exec hook
@@ -1661,9 +1661,9 @@
     hook should execute prestop http hook properly [NodeConformance] [Conformance]'
   description: When a pre-stop handler is specified in the container lifecycle using
     a 'HttpGet' action, then the handler MUST be invoked before the container is terminated.
-    A server pod is created that will serve http requests, create a second pod with
-    a container lifecycle specifying a pre-stop that invokes the server pod to validate
-    that the pre-stop is executed.
+    A server pod is created that will serve http requests, create a second pod on
+    the same node with a container lifecycle specifying a pre-stop that invokes the
+    server pod to validate that the pre-stop is executed.
   release: v1.9
   file: test/e2e/common/node/lifecycle_hook.go
 - testname: Container Runtime, TerminationMessage, from log output of succeeding container


### PR DESCRIPTION
Cherry pick of #101063 on release-1.22.

#101063: tests: Spawn poststart / prestop pods on the same node as the

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

/kind flake
/sig testing
/sig networking

/priority important-soon

#### What this PR does / why we need it:

In the case of multinode clusters, the http server pod and the test cluster can spawn on different nodes, which can be problematic for  poststart / prestop hooks, as they are executed by the kubelet itself, and the cross-node lifecycle hook might
fail (according to the [Kubernetes network model], it is not mandatory for kubelet to be able to access pods on a different node).

This PR ensures that the test pod spawns on the same node as the http server pod.

[Kubernetes network model]: https://kubernetes.io/docs/concepts/cluster-administration/networking/#the-kubernetes-network-model

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #101062


```release-note
NONE
```