### PR TITLE
Add diff command return status code greater than 1 when flags invalid

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/diff/diff.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/diff/diff.go
@@ -160,6 +160,14 @@ func NewCmdDiff(f cmdutil.Factory, streams genericclioptions.IOStreams) *cobra.C
 		},
 	}
 
+	// Flag errors exit with code 1, however according to the diff
+	// command it means changes were found.
+	// Thus, it should return status code greater than 1.
+	cmd.SetFlagErrorFunc(func(command *cobra.Command, err error) error {
+		cmdutil.CheckDiffErr(cmdutil.UsageErrorf(cmd, err.Error()))
+		return nil
+	})
+
 	usage := "contains the configuration to diff"
 	cmd.Flags().StringVarP(&options.Selector, "selector", "l", options.Selector, "Selector (label query) to filter on, supports '=', '==', and '!='.(e.g. -l key1=value1,key2=value2)")
 	cmdutil.AddFilenameOptionFlags(cmd, &options.FilenameOptions, usage)


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
This PR adds flagerror handler function to detect when flags are invalid.
Default flag handler returns status code 1. However, diff command embraces
this status code as changes are found. By overriding flag errors,
this PR shows same message with default case and returns status code 2.

#### Which issue(s) this PR fixes:
Fixes #99354

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Change `kubectl diff --invalid-arg` status code from 1 to 2 to match docs
```