### PR TITLE
tests: Fetch the pod logs in failed cases

### DIFF
--- a/test/e2e/framework/pod/resource.go
+++ b/test/e2e/framework/pod/resource.go
@@ -19,6 +19,8 @@ package pod
 import (
 	"context"
 	"fmt"
+	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
@@ -42,6 +44,11 @@ import (
 // errPodCompleted is returned by PodRunning or PodContainerRunning to indicate that
 // the pod has already reached completed state.
 var errPodCompleted = fmt.Errorf("pod ran to completion")
+
+// LabelLogOnPodFailure can be used to mark which Pods will have their logs logged in the case of
+// a test failure. By default, if there are no Pods with this label, only the first 5 Pods will
+// have their logs fetched.
+const LabelLogOnPodFailure = "log-on-pod-failure"
 
 // TODO: Move to its own subpkg.
 // expectNoError checks if "err" is set, and if so, fails assertion while logging the error.
@@ -388,14 +395,68 @@ func logPodTerminationMessages(pods []v1.Pod) {
 	}
 }
 
+// logPodLogs logs the container logs from pods in the given namespace. This can be helpful for debugging
+// issues that do not cause the container to fail (e.g.: network connectivity issues)
+// We will log the Pods that have the LabelLogOnPodFailure label. If there aren't any, we default to
+// logging only the first 5 Pods. This requires the reportDir to be set, and the pods are logged into:
+// {report_dir}/pods/{namespace}/{pod}/{container_name}/logs.txt
+func logPodLogs(c clientset.Interface, namespace string, pods []v1.Pod, reportDir string) {
+	if reportDir == "" {
+		return
+	}
+
+	var logPods []v1.Pod
+	for _, pod := range pods {
+		if _, ok := pod.Labels[LabelLogOnPodFailure]; ok {
+			logPods = append(logPods, pod)
+		}
+	}
+	maxPods := len(logPods)
+
+	// There are no pods with the LabelLogOnPodFailure label, we default to the first 5 Pods.
+	if maxPods == 0 {
+		logPods = pods
+		maxPods = len(pods)
+		if maxPods > 5 {
+			maxPods = 5
+		}
+	}
+
+	tailLen := 42
+	for i := 0; i < maxPods; i++ {
+		pod := logPods[i]
+		for _, container := range pod.Spec.Containers {
+			logs, err := getPodLogsInternal(c, namespace, pod.Name, container.Name, false, nil, &tailLen)
+			if err != nil {
+				e2elog.Logf("Unable to fetch %s/%s/%s logs: %v", pod.Namespace, pod.Name, container.Name, err)
+				continue
+			}
+
+			logDir := filepath.Join(reportDir, namespace, pod.Name, container.Name)
+			err = os.MkdirAll(logDir, 0755)
+			if err != nil {
+				e2elog.Logf("Unable to create path '%s'. Err: %v", logDir, err)
+				continue
+			}
+
+			logPath := filepath.Join(logDir, "logs.txt")
+			err = os.WriteFile(logPath, []byte(logs), 0644)
+			if err != nil {
+				e2elog.Logf("Could not write the container logs in: %s. Err: %v", logPath, err)
+			}
+		}
+	}
+}
+
 // DumpAllPodInfoForNamespace logs all pod information for a given namespace.
-func DumpAllPodInfoForNamespace(c clientset.Interface, namespace string) {
+func DumpAllPodInfoForNamespace(c clientset.Interface, namespace, reportDir string) {
 	pods, err := c.CoreV1().Pods(namespace).List(context.TODO(), metav1.ListOptions{})
 	if err != nil {
 		e2elog.Logf("unable to fetch pod debug info: %v", err)
 	}
 	LogPodStates(pods.Items)
 	logPodTerminationMessages(pods.Items)
+	logPodLogs(c, namespace, pods.Items, reportDir)
 }
 
 // FilterNonRestartablePods filters out pods that will never get recreated if
@@ -544,23 +605,23 @@ func checkPodsCondition(c clientset.Interface, ns string, podNames []string, tim
 
 // GetPodLogs returns the logs of the specified container (namespace/pod/container).
 func GetPodLogs(c clientset.Interface, namespace, podName, containerName string) (string, error) {
-	return getPodLogsInternal(c, namespace, podName, containerName, false, nil)
+	return getPodLogsInternal(c, namespace, podName, containerName, false, nil, nil)
 }
 
 // GetPodLogsSince returns the logs of the specified container (namespace/pod/container) since a timestamp.
 func GetPodLogsSince(c clientset.Interface, namespace, podName, containerName string, since time.Time) (string, error) {
 	sinceTime := metav1.NewTime(since)
-	return getPodLogsInternal(c, namespace, podName, containerName, false, &sinceTime)
+	return getPodLogsInternal(c, namespace, podName, containerName, false, &sinceTime, nil)
 }
 
 // GetPreviousPodLogs returns the logs of the previous instance of the
 // specified container (namespace/pod/container).
 func GetPreviousPodLogs(c clientset.Interface, namespace, podName, containerName string) (string, error) {
-	return getPodLogsInternal(c, namespace, podName, containerName, true, nil)
+	return getPodLogsInternal(c, namespace, podName, containerName, true, nil, nil)
 }
 
 // utility function for gomega Eventually
-func getPodLogsInternal(c clientset.Interface, namespace, podName, containerName string, previous bool, sinceTime *metav1.Time) (string, error) {
+func getPodLogsInternal(c clientset.Interface, namespace, podName, containerName string, previous bool, sinceTime *metav1.Time, tailLines *int) (string, error) {
 	request := c.CoreV1().RESTClient().Get().
 		Resource("pods").
 		Namespace(namespace).
@@ -569,6 +630,9 @@ func getPodLogsInternal(c clientset.Interface, namespace, podName, containerName
 		Param("previous", strconv.FormatBool(previous))
 	if sinceTime != nil {
 		request.Param("sinceTime", sinceTime.Format(time.RFC3339))
+	}
+	if tailLines != nil {
+		request.Param("tailLines", strconv.Itoa(*tailLines))
 	}
 	logs, err := request.Do(context.TODO()).Raw()
 	if err != nil {

--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -899,7 +899,7 @@ func DumpAllNamespaceInfo(c clientset.Interface, namespace string) {
 		return c.CoreV1().Events(ns).List(context.TODO(), opts)
 	}, namespace)
 
-	e2epod.DumpAllPodInfoForNamespace(c, namespace)
+	e2epod.DumpAllPodInfoForNamespace(c, namespace, TestContext.ReportDir)
 
 	// If cluster is large, then the following logs are basically useless, because:
 	// 1. it takes tens of minutes or hours to grab all of them


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind failing-test
/sig testing

#### What this PR does / why we need it:

For some test failures, checking the pod logs could potentially yield some interesting information, which could be used to further
investigate certain failures / flakes (for example, if there are some networking issues, we could at least see if requests reach the containers, (agnhost logs the connections / requests), or if there were any other issues during the container's startup).

Sample test failure: https://paste.ubuntu.com/p/FT9KBmNrjV/

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
