### PR TITLE
Automated cherry pick of #105352: Revert "Build non-static binaries with PIE buildmode"

### DIFF
--- a/hack/lib/golang.sh
+++ b/hack/lib/golang.sh
@@ -412,10 +412,6 @@ kube::golang::set_platform_envs() {
         export CGO_ENABLED=1
         export CC=${KUBE_LINUX_AMD64_CC:-x86_64-linux-gnu-gcc}
         ;;
-      "linux/386")
-        export CGO_ENABLED=1
-        export CC=${KUBE_LINUX_386_CC:-i686-linux-gnu-gcc}
-        ;;
       "linux/arm")
         export CGO_ENABLED=1
         export CC=${KUBE_LINUX_ARM_CC:-arm-linux-gnueabihf-gcc}
@@ -725,7 +721,6 @@ kube::golang::build_binaries_for_platform() {
       -gcflags "${gogcflags:-}"
       -asmflags "${goasmflags:-}"
       -ldflags "${goldflags:-}"
-      -buildmode pie
       -tags "${gotags:-}"
     )
     kube::golang::build_some_binaries "${nonstatics[@]}"


### PR DESCRIPTION
Cherry pick of #105352 on release-1.22.

Fixes #105294

#105352: Revert "Build non-static binaries with PIE buildmode"

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
Fixes kubelet memory regression in 1.22
```