### PR TITLE
kubelet: fix isAdmittedPodTerminal refactor

### DIFF
--- a/pkg/kubelet/kubelet_pods.go
+++ b/pkg/kubelet/kubelet_pods.go
@@ -993,17 +993,17 @@ func (kl *Kubelet) isAdmittedPodTerminal(pod *v1.Pod) bool {
 	// pods are considered inactive if the config source has observed a
 	// terminal phase (if the Kubelet recorded that the pod reached a terminal
 	// phase the pod should never be restarted)
-	if pod.Status.Phase == v1.PodSucceeded || pod.Status.Phase == v1.PodFailed {
-		return true
-	}
+	isTerminal := pod.Status.Phase == v1.PodSucceeded || pod.Status.Phase == v1.PodFailed
+
 	// a pod that has been marked terminal within the Kubelet is considered
 	// inactive (may have been rejected by Kubelet admision)
-	if status, ok := kl.statusManager.GetPodStatus(pod.UID); ok {
-		if status.Phase == v1.PodSucceeded || status.Phase == v1.PodFailed {
-			return true
+	if !isTerminal {
+		if status, ok := kl.statusManager.GetPodStatus(pod.UID); ok {
+			isTerminal = status.Phase == v1.PodSucceeded || status.Phase == v1.PodFailed
 		}
 	}
-	return false
+
+	return isTerminal
 }
 
 // removeOrphanedPodStatuses removes obsolete entries in podStatus where


### PR DESCRIPTION
#### What type of PR is this?
/bug
/regression

#### What this PR does / why we need it:
[#964](https://github.com/openshift/kubernetes/pull/964/files#diff-e81aa7518bebe9f4412cb375a9008b3481b19ec3e851d3187b3021ee94148f0dL986-R1016) added a refactor to `filterOutInactivePods` which changed the behavior in isAdmittedPodTerminal to not check the statusManager. This PR fixes the regression that was added back in for #104560.

#### Which issue(s) this PR fixes:
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
