### PR TITLE
Fixed using reference in for loop

### DIFF
--- a/test/e2e/autoscaling/cluster_size_autoscaling.go
+++ b/test/e2e/autoscaling/cluster_size_autoscaling.go
@@ -1250,6 +1250,7 @@ func getPoolNodes(f *framework.Framework, poolName string) []*v1.Node {
 	framework.ExpectNoErrorWithOffset(0, err)
 	for _, node := range nodeList.Items {
 		if node.Labels[gkeNodepoolNameKey] == poolName {
+			node := node
 			nodes = append(nodes, &node)
 		}
 	}

--- a/test/e2e/storage/volume_provisioning.go
+++ b/test/e2e/storage/volume_provisioning.go
@@ -968,6 +968,7 @@ func waitForProvisionedVolumesDeleted(c clientset.Interface, scName string) ([]*
 		}
 		for _, pv := range allPVs.Items {
 			if pv.Spec.StorageClassName == scName {
+				pv := pv
 				remainingPVs = append(remainingPVs, &pv)
 			}
 		}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Current code incorrectly uses for loop and passes wrong value as reference
Guide to refer https://github.com/golang/go/wiki/CommonMistakes#using-reference-to-loop-iterator-variable

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes/kubernetes/issues/105426
Fixes https://github.com/kubernetes/kubernetes/issues/105425

#### Special notes for your reviewer:
Please refer to sample code to understand the bug https://goplay.space/#TIT_IZEAEud

```
package main

import "fmt"

type st struct {
	it []string
}

func main() {
	rp := &st{[]string{"value1", "value2"}}
	ownedReplicaSets1 := make([]*string, 0, len(rp.it))
	ownedReplicaSets2 := make([]*string, 0, len(rp.it))

	// similar to current implementation
	for _, t := range rp.it {
		ownedReplicaSets1 = append(ownedReplicaSets1, &t)
	}

	fmt.Println(ownedReplicaSets1)
	fmt.Println(*ownedReplicaSets1[0], *ownedReplicaSets1[1])

	// similar new change
	for i := range rp.it {
		ownedReplicaSets2 = append(ownedReplicaSets2, &rp.it[i])
	}

	fmt.Println(ownedReplicaSets2)
	fmt.Println(*ownedReplicaSets2[0], *ownedReplicaSets2[1])
}
```


```
output:
value2 value2
[0xc000054020 0xc000054030]
value1 value2
```

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
