### PR TITLE
Stop passing WindowsHostProcessContainer annotations for CRI calls in kubelet

### DIFF
--- a/pkg/kubelet/kuberuntime/labels.go
+++ b/pkg/kubelet/kuberuntime/labels.go
@@ -18,17 +18,13 @@ package kuberuntime
 
 import (
 	"encoding/json"
-	"runtime"
 	"strconv"
 
 	v1 "k8s.io/api/core/v1"
 	kubetypes "k8s.io/apimachinery/pkg/types"
-	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/klog/v2"
-	"k8s.io/kubernetes/pkg/features"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
 	"k8s.io/kubernetes/pkg/kubelet/types"
-	sc "k8s.io/kubernetes/pkg/securitycontext"
 )
 
 const (
@@ -42,12 +38,6 @@ const (
 	containerTerminationMessagePolicyLabel = "io.kubernetes.container.terminationMessagePolicy"
 	containerPreStopHandlerLabel           = "io.kubernetes.container.preStopHandler"
 	containerPortsLabel                    = "io.kubernetes.container.ports"
-
-	// TODO: remove this annotation when moving to beta for Windows hostprocess containers
-	// xref: https://github.com/kubernetes/kubernetes/pull/99576/commits/42fb66073214eed6fe43fa8b1586f396e30e73e3#r635392090
-	// Currently, ContainerD on Windows does not yet fully support HostProcess containers
-	// but will pass annotations to hcsshim which does have support.
-	windowsHostProcessContainer = "microsoft.com/hostprocess-container"
 )
 
 type labeledPodSandboxInfo struct {
@@ -99,23 +89,7 @@ func newPodLabels(pod *v1.Pod) map[string]string {
 
 // newPodAnnotations creates pod annotations from v1.Pod.
 func newPodAnnotations(pod *v1.Pod) map[string]string {
-	annotations := map[string]string{}
-
-	// Get annotations from v1.Pod
-	for k, v := range pod.Annotations {
-		annotations[k] = v
-	}
-
-	if runtime.GOOS == "windows" && utilfeature.DefaultFeatureGate.Enabled(features.WindowsHostProcessContainers) {
-		if kubecontainer.HasWindowsHostProcessContainer(pod) {
-			// While WindowsHostProcessContainers is in alpha pass 'microsoft.com/hostprocess-container' annotation
-			// to pod sandbox creations request. ContainerD on Windows does not yet fully support HostProcess
-			// containers but will pass annotations to hcsshim which does have support.
-			annotations[windowsHostProcessContainer] = "true"
-		}
-	}
-
-	return annotations
+	return pod.Annotations
 }
 
 // newContainerLabels creates container labels from v1.Container and v1.Pod.
@@ -166,15 +140,6 @@ func newContainerAnnotations(container *v1.Container, pod *v1.Pod, restartCount 
 			klog.ErrorS(err, "Unable to marshal container ports for container", "containerName", container.Name, "pod", klog.KObj(pod))
 		} else {
 			annotations[containerPortsLabel] = string(rawContainerPorts)
-		}
-	}
-
-	if runtime.GOOS == "windows" && utilfeature.DefaultFeatureGate.Enabled(features.WindowsHostProcessContainers) {
-		if sc.HasWindowsHostProcessRequest(pod, container) {
-			// While WindowsHostProcessContainers is in alpha pass 'microsoft.com/hostprocess-container' annotation
-			// to create containers request. ContainerD on Windows does not yet fully support HostProcess containers
-			// but will pass annotations to hcsshim which does have support.
-			annotations[windowsHostProcessContainer] = "true"
 		}
 	}
 


### PR DESCRIPTION


Signed-off-by: Mark Rossetti <marosset@microsoft.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This PR removes annotations added to CRI pod and container creation calls for Windows HostProcess containers.
These annotations were added to enable Windows HostProcess containers ahead of containerD understanding the new CRI fields for this feature.

https://github.com/kubernetes/kubernetes/blob/master/pkg/kubelet/kuberuntime/labels.go#L46-L50

https://github.com/containerd/containerd/pull/5131 added support for the CRI frields relating to HostProcess containers

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Part of https://github.com/kubernetes/enhancements/issues/1981

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
https://github.com/kubernetes/enhancements/tree/master/keps/sig-windows/1981-windows-privileged-container-support#cri-implementation-details
```

/sig windows
/sig node
/area kubelet
/milestone v1.23
