### PR TITLE
Add VolumeSubpath feature gate back in preparation for its removal

### DIFF
--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -138,6 +138,14 @@ const (
 	// Postpone deletion of a PV or a PVC when they are being used
 	StorageObjectInUseProtection featuregate.Feature = "StorageObjectInUseProtection"
 
+	// owner: @saad-ali
+	// ga: 	  v1.10
+	//
+	// Allow mounting a subpath of a volume in a container
+	// NOTE: This feature gate has been deprecated and is no longer enforced.
+	// It will be completely removed in 1.25. Until then, it's still visible in `kubelet --help`
+	VolumeSubpath featuregate.Feature = "VolumeSubpath"
+
 	// owner: @pohly
 	// alpha: v1.14
 	// beta: v1.16
@@ -785,6 +793,7 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
 	CSIServiceAccountToken:                         {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.23
 	GenericEphemeralVolume:                         {Default: true, PreRelease: featuregate.Beta},
 	CSIVolumeFSGroupPolicy:                         {Default: true, PreRelease: featuregate.Beta},
+	VolumeSubpath:                                  {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.25
 	RuntimeClass:                                   {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.23
 	NodeLease:                                      {Default: true, PreRelease: featuregate.GA, LockToDefault: true},
 	NetworkPolicyEndPort:                           {Default: true, PreRelease: featuregate.Beta},


### PR DESCRIPTION
#### What type of PR is this?

/kind deprecation
/sig storage

#### What this PR does / why we need it:

Followup of https://github.com/kubernetes/kubernetes/pull/105090, in preparation for the deprecation notice of the `VolumeSubpath` feature gate we're still going to keep it but locked to its default value of `true` and add a notice that it'll be removed in a couple of releases from now.

```release-note
Feature-gate VolumeSubpath has been deprecated and cannot be disabled. It will be completely removed in 1.25
```

/assign @saad-ali 
