### PR TITLE
use stat command with 300ms timeout to get device ids for IsLikelyNotMountPoint

### DIFF
--- a/staging/src/k8s.io/mount-utils/mount_linux_test.go
+++ b/staging/src/k8s.io/mount-utils/mount_linux_test.go
@@ -20,6 +20,7 @@ limitations under the License.
 package mount
 
 import (
+	"errors"
 	"io/ioutil"
 	"os"
 	"reflect"
@@ -544,4 +545,29 @@ func mountArgsContainOption(t *testing.T, mountArgs []string, option string) boo
 	}
 
 	return strings.Contains(mountArgs[optionsIndex], option)
+}
+
+func TestGetDeviceFromStat(t *testing.T) {
+	t.Run("expect no error when a path exists", func(t *testing.T) {
+		dir, err := ioutil.TempDir("/tmp", "get_device_from_stat")
+		if err != nil {
+			t.Errorf("Unable to create directory in temp folder %s", err.Error())
+			return
+		}
+		defer os.RemoveAll(dir)
+
+		_, err = GetDeviceFromStat(dir)
+
+		if err != nil {
+			t.Errorf("Unexpected error occurred while getting device %s", err.Error())
+			return
+		}
+	})
+
+	t.Run("expect os.ErrNotExist when a path does not exist", func(t *testing.T) {
+		_, err := GetDeviceFromStat("/some/path/does/not/exist")
+		if !errors.Is(err, os.ErrNotExist) {
+			t.Errorf("unexpected not error:%s", err)
+		}
+	})
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

<!--
Add one of the following kinds:

/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:



syscall.Stat can get blocked on NFS calls; therefore the kubelet
can get wedged as seen in
https://github.com/kubernetes/kubernetes/issues/101622

Using a go routine would lead to a go routine leak and there is
currently no good way to handle the go routine leak.
Ref: https://github.com/golang/go/issues/41054

This change calls stat command to get a device major and minor id
using the stat command within 300ms (because this is supposed to be
a fast operation).

This commit takes in inspiration from this command:
https://github.com/kubernetes/kubernetes/pull/102038/files#r644892910

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #101622

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

/sig node storage
/assign @gnufied 

cc @MadhavJivrajani @pacoxu 