### PR TITLE
Lock StorageObjectInUseProtection feature gate to default

### DIFF
--- a/pkg/controller/volume/persistentvolume/index_test.go
+++ b/pkg/controller/volume/persistentvolume/index_test.go
@@ -1231,29 +1231,17 @@ func TestStorageObjectInUseProtectionFiltering(t *testing.T) {
 		pvc                                *v1.PersistentVolumeClaim
 		enableStorageObjectInUseProtection bool
 	}{
-		"feature enabled - pv deletionTimeStamp not set": {
+		"pv deletionTimeStamp not set": {
 			isExpectedMatch:                    true,
 			vol:                                pv,
 			pvc:                                pvc,
 			enableStorageObjectInUseProtection: true,
 		},
-		"feature enabled - pv deletionTimeStamp set": {
+		"pv deletionTimeStamp set": {
 			isExpectedMatch:                    false,
 			vol:                                pvToDelete,
 			pvc:                                pvc,
 			enableStorageObjectInUseProtection: true,
-		},
-		"feature disabled - pv deletionTimeStamp not set": {
-			isExpectedMatch:                    true,
-			vol:                                pv,
-			pvc:                                pvc,
-			enableStorageObjectInUseProtection: false,
-		},
-		"feature disabled - pv deletionTimeStamp set": {
-			isExpectedMatch:                    true,
-			vol:                                pvToDelete,
-			pvc:                                pvc,
-			enableStorageObjectInUseProtection: false,
 		},
 	}
 
@@ -1279,29 +1267,17 @@ func TestStorageObjectInUseProtectionFiltering(t *testing.T) {
 		pvc                                *v1.PersistentVolumeClaim
 		enableStorageObjectInUseProtection bool
 	}{
-		"feature enabled - pv deletionTimeStamp not set": {
+		"pv deletionTimeStamp not set": {
 			isExpectedMatch:                    true,
 			vol:                                createTestVolOrderedIndex(pv),
 			pvc:                                pvc,
 			enableStorageObjectInUseProtection: true,
 		},
-		"feature enabled - pv deletionTimeStamp set": {
+		"pv deletionTimeStamp set": {
 			isExpectedMatch:                    false,
 			vol:                                createTestVolOrderedIndex(pvToDelete),
 			pvc:                                pvc,
 			enableStorageObjectInUseProtection: true,
-		},
-		"feature disabled - pv deletionTimeStamp not set": {
-			isExpectedMatch:                    true,
-			vol:                                createTestVolOrderedIndex(pv),
-			pvc:                                pvc,
-			enableStorageObjectInUseProtection: false,
-		},
-		"feature disabled - pv deletionTimeStamp set": {
-			isExpectedMatch:                    true,
-			vol:                                createTestVolOrderedIndex(pvToDelete),
-			pvc:                                pvc,
-			enableStorageObjectInUseProtection: false,
 		},
 	}
 	for name, testCase := range filteringTestCases {

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -800,7 +800,7 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
 	MemoryManager:                                  {Default: true, PreRelease: featuregate.Beta},
 	CPUCFSQuotaPeriod:                              {Default: false, PreRelease: featuregate.Alpha},
 	TopologyManager:                                {Default: true, PreRelease: featuregate.Beta},
-	StorageObjectInUseProtection:                   {Default: true, PreRelease: featuregate.GA},
+	StorageObjectInUseProtection:                   {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.25
 	CSIMigration:                                   {Default: true, PreRelease: featuregate.Beta},
 	CSIMigrationGCE:                                {Default: false, PreRelease: featuregate.Beta}, // Off by default (requires GCE PD CSI Driver)
 	InTreePluginGCEUnregister:                      {Default: false, PreRelease: featuregate.Alpha},


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/kind feature

#### What this PR does / why we need it:

Lock `StorageObjectInUseProtection` feature gate to default.

#### Which issue(s) this PR fixes:

Fixes N/A

#### Special notes for your reviewer:

Additional PR to make locking to default first before removing feature gates logic (https://github.com/kubernetes/kubernetes/pull/104903).

#### Does this PR introduce a user-facing change?

```release-note
-  Feature-gate `StorageObjectInUseProtection` has been deprecated and cannot be disabled. It will be completely removed in 1.25
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
