### PR TITLE
Add [ibabou] & [pjh] to Cluster GCE directory OWNERS

### DIFF
--- a/cluster/gce/OWNERS
+++ b/cluster/gce/OWNERS
@@ -8,7 +8,8 @@ reviewers:
   - MaciekPytel
   - yujuhong
   - mtaufen
-  - jeremyje
+  - ibabou
+  - pjh
   - sig-scalability-reviewers
 approvers:
   - bowei
@@ -18,7 +19,8 @@ approvers:
   - MaciekPytel
   - yujuhong
   - mtaufen
-  - jeremyje
+  - ibabou
+  - pjh
   - sig-scalability-approvers
 emeritus_approvers:
   - gmarek


### PR DESCRIPTION
#### What type of PR is this?

The change adds [ibabou] and [pjh] to the OWNERS file of cluster/gce directory. and removes [jeremyje].

/kind cleanup

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
