### PR TITLE
[WIP][DEBUG CI]Test integration 1.22

### DIFF
--- a/hack/make-rules/test-integration.sh
+++ b/hack/make-rules/test-integration.sh
@@ -69,7 +69,7 @@ runTests() {
   make -C "${KUBE_ROOT}" test \
       WHAT="${WHAT:-$(kube::test::find_integration_test_dirs | paste -sd' ' -)}" \
       GOFLAGS="${GOFLAGS:-}" \
-      KUBE_TEST_ARGS="--alsologtostderr=true ${KUBE_TEST_ARGS:-} ${SHORT:--short=true} --vmodule=${KUBE_TEST_VMODULE}" \
+      KUBE_TEST_ARGS="--alsologtostderr=true ${KUBE_TEST_ARGS:-} --short=true --vmodule=${KUBE_TEST_VMODULE}" \
       KUBE_TIMEOUT="${KUBE_TIMEOUT}" \
       KUBE_RACE=""
 

--- a/pkg/kubelet/cm/memorymanager/policy_static.go
+++ b/pkg/kubelet/cm/memorymanager/policy_static.go
@@ -936,13 +936,13 @@ func isInitContainer(pod *v1.Pod, container *v1.Container) bool {
 func isNUMAAffinitiesEqual(numaAffinity1, numaAffinity2 []int) bool {
 	bitMask1, err := bitmask.NewBitMask(numaAffinity1...)
 	if err != nil {
-		klog.ErrorS(err, "failed to create bit mask", numaAffinity1)
+		klog.ErrorS(err, "failed to create bit mask", "numaAffinity1", numaAffinity1)
 		return false
 	}
 
 	bitMask2, err := bitmask.NewBitMask(numaAffinity2...)
 	if err != nil {
-		klog.ErrorS(err, "failed to create bit mask", numaAffinity2)
+		klog.ErrorS(err, "failed to create bit mask", "numaAffinity2", numaAffinity2)
 		return false
 	}
 


### PR DESCRIPTION
Downloaded results from a failing job in 1.22 and obtained the tests names

```
wget https://storage.googleapis.com/kubernetes-jenkins/pr-logs/pull/105139/pull-kubernetes-integration/1445661690602459136/artifacts/junit_20211006-082501.stdout -O junit_1.22.stdout
cat junit_1.22.stdout  | jq '.Test' | sort -u > 1.22.tests
```

same for a working job in master
```
wget https://storage.googleapis.com/kubernetes-jenkins/pr-logs/pull/102740/pull-kubernetes-integration/1445671306849685504/artifacts/junit_20211006-090548.stdout -O junit_master.stdout
cat junit_master.stdout  | jq '.Test' | sort -u > master.tests
```

Number of tests is lower in master
```
$ wc 1.22.tests 
  3768   3777 272718 1.22.tests
$ wc master.tests 
  3206   3215 232901 master.tests
```

The diff points to podsecurity policy, that exhibited a similar behavior https://github.com/kubernetes/kubernetes/issues/103512
```
diff 1.22.tests master.tests | grep security | wc
    636    1272   45344
```


However, this doesn't explain why the periodic works https://testgrid.k8s.io/sig-release-1.22-blocking#integration-1.22