### PR TITLE
[scheduler] [test]: Fix PreferNominatedNode test

### DIFF
--- a/test/integration/scheduler/preemption_test.go
+++ b/test/integration/scheduler/preemption_test.go
@@ -1341,52 +1341,37 @@ func initTestPreferNominatedNode(t *testing.T, nsPrefix string, opts ...schedule
 // enabled.
 func TestPreferNominatedNode(t *testing.T) {
 	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.PreferNominatedNode, true)()
-	testCtx := initTestPreferNominatedNode(t, "perfer-nominated-node")
-	t.Cleanup(func() {
-		testutils.CleanupTest(t, testCtx)
-	})
-	cs := testCtx.ClientSet
-	defaultPodRes := &v1.ResourceRequirements{Requests: v1.ResourceList{
-		v1.ResourceCPU:    *resource.NewMilliQuantity(100, resource.DecimalSI),
-		v1.ResourceMemory: *resource.NewQuantity(100, resource.DecimalSI)},
-	}
+
 	defaultNodeRes := map[v1.ResourceName]string{
 		v1.ResourcePods:   "32",
 		v1.ResourceCPU:    "500m",
 		v1.ResourceMemory: "500",
 	}
-
-	type nodeConfig struct {
-		name string
-		res  map[v1.ResourceName]string
+	defaultPodRes := &v1.ResourceRequirements{Requests: v1.ResourceList{
+		v1.ResourceCPU:    *resource.NewMilliQuantity(100, resource.DecimalSI),
+		v1.ResourceMemory: *resource.NewQuantity(100, resource.DecimalSI)},
 	}
-
 	tests := []struct {
 		name         string
-		nodes        []*nodeConfig
+		nodeNames    []string
 		existingPods []*v1.Pod
 		pod          *v1.Pod
 		runnningNode string
 	}{
 		{
-			name: "nominated node released all resource, preemptor is scheduled to the nominated node",
-			nodes: []*nodeConfig{
-				{name: "node-1", res: defaultNodeRes},
-				{name: "node-2", res: defaultNodeRes},
-			},
+			name:      "nominated node released all resource, preemptor is scheduled to the nominated node",
+			nodeNames: []string{"node-1", "node-2"},
 			existingPods: []*v1.Pod{
 				initPausePod(&pausePodConfig{
 					Name:      "low-pod1",
-					Namespace: testCtx.NS.Name,
 					Priority:  &lowPriority,
 					NodeName:  "node-2",
 					Resources: defaultPodRes,
 				}),
 			},
 			pod: initPausePod(&pausePodConfig{
-				Name:      "preemptor-pod",
-				Namespace: testCtx.NS.Name,
-				Priority:  &highPriority,
+				Name:     "preemptor-pod",
+				Priority: &highPriority,
 				Resources: &v1.ResourceRequirements{Requests: v1.ResourceList{
 					v1.ResourceCPU:    *resource.NewMilliQuantity(500, resource.DecimalSI),
 					v1.ResourceMemory: *resource.NewQuantity(200, resource.DecimalSI)},
@@ -1395,24 +1380,19 @@ func TestPreferNominatedNode(t *testing.T) {
 			runnningNode: "node-1",
 		},
 		{
-			name: "nominated node cannot pass all the filters, preemptor should find a different node",
-			nodes: []*nodeConfig{
-				{name: "node-1", res: defaultNodeRes},
-				{name: "node-2", res: defaultNodeRes},
-			},
+			name:      "nominated node cannot pass all the filters, preemptor should find a different node",
+			nodeNames: []string{"node-1", "node-2"},
 			existingPods: []*v1.Pod{
 				initPausePod(&pausePodConfig{
-					Name:      "low-pod1",
-					Namespace: testCtx.NS.Name,
+					Name:      "low-pod",
 					Priority:  &lowPriority,
 					Resources: defaultPodRes,
 					NodeName:  "node-1",
 				}),
 			},
 			pod: initPausePod(&pausePodConfig{
-				Name:      "preemptor-pod",
-				Namespace: testCtx.NS.Name,
-				Priority:  &highPriority,
+				Name:     "preemptor-pod1",
+				Priority: &highPriority,
 				Resources: &v1.ResourceRequirements{Requests: v1.ResourceList{
 					v1.ResourceCPU:    *resource.NewMilliQuantity(500, resource.DecimalSI),
 					v1.ResourceMemory: *resource.NewQuantity(200, resource.DecimalSI)},
@@ -1424,22 +1404,31 @@ func TestPreferNominatedNode(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
+			testCtx := initTestPreferNominatedNode(t, "perfer-nominated-node")
+			t.Cleanup(func() {
+				testutils.CleanupTest(t, testCtx)
+			})
+			cs := testCtx.ClientSet
+			nsName := testCtx.NS.Name
 			var err error
 			var preemptor *v1.Pod
-			for _, nodeConf := range test.nodes {
-				_, err := createNode(cs, st.MakeNode().Name(nodeConf.name).Capacity(nodeConf.res).Obj())
+			for _, nodeName := range test.nodeNames {
+				_, err := createNode(cs, st.MakeNode().Name(nodeName).Capacity(defaultNodeRes).Obj())
 				if err != nil {
-					t.Fatalf("Error creating node %v: %v", nodeConf.name, err)
+					t.Fatalf("Error creating node %v: %v", nodeName, err)
 				}
 			}
+
 			pods := make([]*v1.Pod, len(test.existingPods))
 			// Create and run existingPods.
 			for i, p := range test.existingPods {
+				p.Namespace = nsName
 				pods[i], err = runPausePod(cs, p)
 				if err != nil {
 					t.Fatalf("Error running pause pod: %v", err)
 				}
 			}
+			test.pod.Namespace = nsName
 			preemptor, err = createPausePod(cs, test.pod)
 			if err != nil {
 				t.Errorf("Error while creating high priority pod: %v", err)
@@ -1461,10 +1450,6 @@ func TestPreferNominatedNode(t *testing.T) {
 			if preemptor.Spec.NodeName != test.runnningNode {
 				t.Errorf("Expect pod running on %v, got %v.", test.runnningNode, preemptor.Spec.NodeName)
 			}
-			pods = append(pods, preemptor)
-			// cleanup
-			defer testutils.CleanupPods(cs, t, pods)
-			cs.CoreV1().Nodes().DeleteCollection(context.TODO(), metav1.DeleteOptions{}, metav1.ListOptions{})
 		})
 	}
 }


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind flake
#### What this PR does / why we need it:
Once the node gets deleted, the nodelifecycle controller
is racing to update pod status and the pod deletion logic
is failing causing tests to flake. This commit moves
the testContext creation to within the test loop and deletes nodes,
namespace within the test loop. We don't explicitly call the node
deletion within the loop but the `testutils.CleanupTest(t, testCtx)`
call ensures that the namespace, nodes gets deleted.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #105492

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
cc @Huang-Wei @alculquicondor @chendave 
