### PR TITLE
Free APF seats for watches handled by an aggregated apiserver.

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/apf_context.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/apf_context.go
@@ -52,6 +52,17 @@ func WatchInitialized(ctx context.Context) {
 	}
 }
 
+// RequestDelegated informs the priority and fairness dispatcher that
+// a given request has been delegated to an aggregated API
+// server. No-op when priority and fairness is disabled.
+func RequestDelegated(ctx context.Context) {
+	// The watch initialization signal doesn't traverse request
+	// boundaries, so we generously fire it as soon as we know
+	// that the request won't be serviced locally. Safe to call
+	// for non-watch requests.
+	WatchInitialized(ctx)
+}
+
 // InitializationSignal is an interface that allows sending and handling
 // initialization signals.
 type InitializationSignal interface {

--- a/staging/src/k8s.io/kube-aggregator/pkg/apiserver/handler_proxy.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/apiserver/handler_proxy.go
@@ -35,6 +35,7 @@ import (
 	genericfeatures "k8s.io/apiserver/pkg/features"
 	"k8s.io/apiserver/pkg/server/egressselector"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	utilflowcontrol "k8s.io/apiserver/pkg/util/flowcontrol"
 	"k8s.io/apiserver/pkg/util/x509metrics"
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/client-go/transport"
@@ -175,6 +176,7 @@ func (r *proxyHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	handler := proxy.NewUpgradeAwareHandler(location, proxyRoundTripper, true, upgrade, &responder{w: w})
 	handler.InterceptRedirects = utilfeature.DefaultFeatureGate.Enabled(genericfeatures.StreamingProxyRedirects)
 	handler.RequireSameHostRedirects = utilfeature.DefaultFeatureGate.Enabled(genericfeatures.ValidateProxyRedirects)
+	utilflowcontrol.RequestDelegated(req.Context())
 	handler.ServeHTTP(w, newReq)
 }
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Fires the APF initialization signal before proxying a request to an aggregated apiserver.

#### Which issue(s) this PR fixes:

Fixes https://github.com/kubernetes/kubernetes/issues/105409.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
Fix a 1.22 regression where watch requests that are delegated to aggregated apiservers no longer reserve concurrency units (seats) in the API Priority and Fairness dispatcher for their entire duration.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
