### PR TITLE
Bump discovery burst for kubectl to 300

### DIFF
--- a/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/config_flags.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/config_flags.go
@@ -120,6 +120,9 @@ type ConfigFlags struct {
 	// Allows increasing burst used for discovery, this is useful
 	// in clusters with many registered resources
 	discoveryBurst int
+	// Allows increasing qps used for discovery, this is useful
+	// in clusters with many registered resources
+	discoveryQPS float32
 }
 
 // ToRESTConfig implements RESTClientGetter.
@@ -269,6 +272,7 @@ func (f *ConfigFlags) toDiscoveryClient() (discovery.CachedDiscoveryInterface, e
 	}
 
 	config.Burst = f.discoveryBurst
+	config.QPS = f.discoveryQPS
 
 	cacheDir := defaultCacheDir
 
@@ -390,6 +394,12 @@ func (f *ConfigFlags) WithDeprecatedPasswordFlag() *ConfigFlags {
 // WithDiscoveryBurst sets the RESTClient burst for discovery.
 func (f *ConfigFlags) WithDiscoveryBurst(discoveryBurst int) *ConfigFlags {
 	f.discoveryBurst = discoveryBurst
+	return f
+}
+
+// WithDiscoveryBurst sets the RESTClient burst for discovery.
+func (f *ConfigFlags) WithDiscoveryQPS(discoveryQPS float32) *ConfigFlags {
+	f.discoveryQPS = discoveryQPS
 	return f
 }
 

--- a/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/config_flags.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/config_flags.go
@@ -268,9 +268,6 @@ func (f *ConfigFlags) toDiscoveryClient() (discovery.CachedDiscoveryInterface, e
 		return nil, err
 	}
 
-	// The more groups you have, the more discovery requests you need to make.
-	// given 25 groups (our groups + a few custom resources) with one-ish version each, discovery needs to make 50 requests
-	// double it just so we don't end up here again for a while.  This config is only used for discovery.
 	config.Burst = f.discoveryBurst
 
 	cacheDir := defaultCacheDir

--- a/staging/src/k8s.io/kubectl/pkg/cmd/cmd.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/cmd.go
@@ -294,7 +294,7 @@ func NewKubectlCommand(o KubectlOptions) *cobra.Command {
 
 	kubeConfigFlags := o.ConfigFlags
 	if kubeConfigFlags == nil {
-		kubeConfigFlags = genericclioptions.NewConfigFlags(true).WithDeprecatedPasswordFlag()
+		kubeConfigFlags = genericclioptions.NewConfigFlags(true).WithDeprecatedPasswordFlag().WithDiscoveryBurst(300)
 	}
 	kubeConfigFlags.AddFlags(flags)
 	matchVersionKubeConfigFlags := cmdutil.NewMatchVersionFlags(kubeConfigFlags)

--- a/staging/src/k8s.io/kubectl/pkg/cmd/cmd.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/cmd.go
@@ -294,7 +294,7 @@ func NewKubectlCommand(o KubectlOptions) *cobra.Command {
 
 	kubeConfigFlags := o.ConfigFlags
 	if kubeConfigFlags == nil {
-		kubeConfigFlags = genericclioptions.NewConfigFlags(true).WithDeprecatedPasswordFlag().WithDiscoveryBurst(300)
+		kubeConfigFlags = genericclioptions.NewConfigFlags(true).WithDeprecatedPasswordFlag().WithDiscoveryBurst(300).WithDiscoveryQPS(50.0)
 	}
 	kubeConfigFlags.AddFlags(flags)
 	matchVersionKubeConfigFlags := cmdutil.NewMatchVersionFlags(kubeConfigFlags)


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup
/sig cli
/priority backlog

#### What this PR does / why we need it:
This bumps discovery burst for kubectl command from 100 defined in https://github.com/kubernetes/kubernetes/blob/a861de6d162f6197971dffbf09ae101545a9c2e7/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/config_flags.go#L416-L419 to 150. 

#### Which issue(s) this PR fixes:
Fixes https://github.com/kubernetes/kubectl/issues/1126

#### Special notes for your reviewer:
/assign @seans3 @lavalamp @justinsb 

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
