### PR TITLE
Wire contexts to Core controllers

### DIFF
--- a/cmd/cloud-controller-manager/nodeipamcontroller.go
+++ b/cmd/cloud-controller-manager/nodeipamcontroller.go
@@ -20,6 +20,7 @@ limitations under the License.
 package main
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"net"
@@ -57,8 +58,8 @@ func (nodeIpamController *nodeIPAMController) StartNodeIpamControllerWrapper(ini
 	}
 	nodeIpamController.nodeIPAMControllerOptions.ApplyTo(&nodeIpamController.nodeIPAMControllerConfiguration)
 
-	return func(ctx genericcontrollermanager.ControllerContext) (controller.Interface, bool, error) {
-		return startNodeIpamController(initContext, completedConfig, nodeIpamController.nodeIPAMControllerConfiguration, ctx, cloud)
+	return func(ctx context.Context, controllerContext genericcontrollermanager.ControllerContext) (controller.Interface, bool, error) {
+		return startNodeIpamController(initContext, completedConfig, nodeIpamController.nodeIPAMControllerConfiguration, controllerContext, cloud)
 	}
 }
 

--- a/pkg/controller/controller_utils_test.go
+++ b/pkg/controller/controller_utils_test.go
@@ -815,7 +815,7 @@ func TestRemoveTaintOffNode(t *testing.T) {
 	}
 	for _, test := range tests {
 		node, _ := test.nodeHandler.Get(context.TODO(), test.nodeName, metav1.GetOptions{})
-		err := RemoveTaintOffNode(test.nodeHandler, test.nodeName, node, test.taintsToRemove...)
+		err := RemoveTaintOffNode(context.TODO(), test.nodeHandler, test.nodeName, node, test.taintsToRemove...)
 		assert.NoError(t, err, "%s: RemoveTaintOffNode() error = %v", test.name, err)
 
 		node, _ = test.nodeHandler.Get(context.TODO(), test.nodeName, metav1.GetOptions{})
@@ -990,7 +990,7 @@ func TestAddOrUpdateTaintOnNode(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		err := AddOrUpdateTaintOnNode(test.nodeHandler, test.nodeName, test.taintsToAdd...)
+		err := AddOrUpdateTaintOnNode(context.TODO(), test.nodeHandler, test.nodeName, test.taintsToAdd...)
 		assert.NoError(t, err, "%s: AddOrUpdateTaintOnNode() error = %v", test.name, err)
 
 		node, _ := test.nodeHandler.Get(context.TODO(), test.nodeName, metav1.GetOptions{})

--- a/pkg/controller/endpoint/endpoints_controller_test.go
+++ b/pkg/controller/endpoint/endpoints_controller_test.go
@@ -267,7 +267,7 @@ func TestSyncEndpointsItemsPreserveNoSelector(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: ns},
 		Spec:       v1.ServiceSpec{Ports: []v1.ServicePort{{Port: 80}}},
 	})
-	endpoints.syncService(ns + "/foo")
+	endpoints.syncService(context.TODO(), ns+"/foo")
 	endpointsHandler.ValidateRequestCount(t, 0)
 }
 
@@ -291,7 +291,7 @@ func TestSyncEndpointsExistingNilSubsets(t *testing.T) {
 			Ports:    []v1.ServicePort{{Port: 80}},
 		},
 	})
-	endpoints.syncService(ns + "/foo")
+	endpoints.syncService(context.TODO(), ns+"/foo")
 	endpointsHandler.ValidateRequestCount(t, 0)
 }
 
@@ -315,7 +315,7 @@ func TestSyncEndpointsExistingEmptySubsets(t *testing.T) {
 			Ports:    []v1.ServicePort{{Port: 80}},
 		},
 	})
-	endpoints.syncService(ns + "/foo")
+	endpoints.syncService(context.TODO(), ns+"/foo")
 	endpointsHandler.ValidateRequestCount(t, 0)
 }
 
@@ -331,7 +331,7 @@ func TestSyncEndpointsNewNoSubsets(t *testing.T) {
 			Ports:    []v1.ServicePort{{Port: 80}},
 		},
 	})
-	endpoints.syncService(ns + "/foo")
+	endpoints.syncService(context.TODO(), ns+"/foo")
 	endpointsHandler.ValidateRequestCount(t, 1)
 }
 
@@ -385,7 +385,7 @@ func TestSyncEndpointsProtocolTCP(t *testing.T) {
 			Ports:    []v1.ServicePort{{Port: 80, TargetPort: intstr.FromInt(8080), Protocol: "TCP"}},
 		},
 	})
-	endpoints.syncService(ns + "/foo")
+	endpoints.syncService(context.TODO(), ns+"/foo")
 
 	endpointsHandler.ValidateRequestCount(t, 1)
 	data := runtime.EncodeOrDie(clientscheme.Codecs.LegacyCodec(v1.SchemeGroupVersion), &v1.Endpoints{
@@ -428,7 +428,7 @@ func TestSyncEndpointsHeadlessServiceLabel(t *testing.T) {
 			Ports:    []v1.ServicePort{{Port: 80}},
 		},
 	})
-	endpoints.syncService(ns + "/foo")
+	endpoints.syncService(context.TODO(), ns+"/foo")
 	endpointsHandler.ValidateRequestCount(t, 0)
 }
 
@@ -456,7 +456,7 @@ func TestSyncEndpointsProtocolUDP(t *testing.T) {
 			Ports:    []v1.ServicePort{{Port: 80, TargetPort: intstr.FromInt(8080), Protocol: "UDP"}},
 		},
 	})
-	endpoints.syncService(ns + "/foo")
+	endpoints.syncService(context.TODO(), ns+"/foo")
 
 	endpointsHandler.ValidateRequestCount(t, 1)
 	data := runtime.EncodeOrDie(clientscheme.Codecs.LegacyCodec(v1.SchemeGroupVersion), &v1.Endpoints{
@@ -500,7 +500,7 @@ func TestSyncEndpointsProtocolSCTP(t *testing.T) {
 			Ports:    []v1.ServicePort{{Port: 80, TargetPort: intstr.FromInt(8080), Protocol: "SCTP"}},
 		},
 	})
-	endpoints.syncService(ns + "/foo")
+	endpoints.syncService(context.TODO(), ns+"/foo")
 
 	endpointsHandler.ValidateRequestCount(t, 1)
 	data := runtime.EncodeOrDie(clientscheme.Codecs.LegacyCodec(v1.SchemeGroupVersion), &v1.Endpoints{
@@ -541,7 +541,7 @@ func TestSyncEndpointsItemsEmptySelectorSelectsAll(t *testing.T) {
 			Ports:    []v1.ServicePort{{Port: 80, Protocol: "TCP", TargetPort: intstr.FromInt(8080)}},
 		},
 	})
-	endpoints.syncService(ns + "/foo")
+	endpoints.syncService(context.TODO(), ns+"/foo")
 
 	data := runtime.EncodeOrDie(clientscheme.Codecs.LegacyCodec(v1.SchemeGroupVersion), &v1.Endpoints{
 		ObjectMeta: metav1.ObjectMeta{
@@ -581,7 +581,7 @@ func TestSyncEndpointsItemsEmptySelectorSelectsAllNotReady(t *testing.T) {
 			Ports:    []v1.ServicePort{{Port: 80, Protocol: "TCP", TargetPort: intstr.FromInt(8080)}},
 		},
 	})
-	endpoints.syncService(ns + "/foo")
+	endpoints.syncService(context.TODO(), ns+"/foo")
 
 	data := runtime.EncodeOrDie(clientscheme.Codecs.LegacyCodec(v1.SchemeGroupVersion), &v1.Endpoints{
 		ObjectMeta: metav1.ObjectMeta{
@@ -621,7 +621,7 @@ func TestSyncEndpointsItemsEmptySelectorSelectsAllMixed(t *testing.T) {
 			Ports:    []v1.ServicePort{{Port: 80, Protocol: "TCP", TargetPort: intstr.FromInt(8080)}},
 		},
 	})
-	endpoints.syncService(ns + "/foo")
+	endpoints.syncService(context.TODO(), ns+"/foo")
 
 	data := runtime.EncodeOrDie(clientscheme.Codecs.LegacyCodec(v1.SchemeGroupVersion), &v1.Endpoints{
 		ObjectMeta: metav1.ObjectMeta{
@@ -665,7 +665,7 @@ func TestSyncEndpointsItemsPreexisting(t *testing.T) {
 			Ports:    []v1.ServicePort{{Port: 80, Protocol: "TCP", TargetPort: intstr.FromInt(8080)}},
 		},
 	})
-	endpoints.syncService(ns + "/foo")
+	endpoints.syncService(context.TODO(), ns+"/foo")
 
 	data := runtime.EncodeOrDie(clientscheme.Codecs.LegacyCodec(v1.SchemeGroupVersion), &v1.Endpoints{
 		ObjectMeta: metav1.ObjectMeta{
@@ -708,7 +708,7 @@ func TestSyncEndpointsItemsPreexistingIdentical(t *testing.T) {
 			Ports:    []v1.ServicePort{{Port: 80, Protocol: "TCP", TargetPort: intstr.FromInt(8080)}},
 		},
 	})
-	endpoints.syncService(ns + "/foo")
+	endpoints.syncService(context.TODO(), ns+"/foo")
 	endpointsHandler.ValidateRequestCount(t, 0)
 }
 
@@ -730,7 +730,7 @@ func TestSyncEndpointsItems(t *testing.T) {
 			},
 		},
 	})
-	endpoints.syncService("other/foo")
+	endpoints.syncService(context.TODO(), "other/foo")
 
 	expectedSubsets := []v1.EndpointSubset{{
 		Addresses: []v1.EndpointAddress{
@@ -778,7 +778,7 @@ func TestSyncEndpointsItemsWithLabels(t *testing.T) {
 			},
 		},
 	})
-	endpoints.syncService(ns + "/foo")
+	endpoints.syncService(context.TODO(), ns+"/foo")
 
 	expectedSubsets := []v1.EndpointSubset{{
 		Addresses: []v1.EndpointAddress{
@@ -837,7 +837,7 @@ func TestSyncEndpointsItemsPreexistingLabelsChange(t *testing.T) {
 			Ports:    []v1.ServicePort{{Port: 80, Protocol: "TCP", TargetPort: intstr.FromInt(8080)}},
 		},
 	})
-	endpoints.syncService(ns + "/foo")
+	endpoints.syncService(context.TODO(), ns+"/foo")
 
 	serviceLabels[v1.IsHeadlessService] = ""
 	data := runtime.EncodeOrDie(clientscheme.Codecs.LegacyCodec(v1.SchemeGroupVersion), &v1.Endpoints{
@@ -891,7 +891,7 @@ func TestWaitsForAllInformersToBeSynced2(t *testing.T) {
 			endpoints.workerLoopPeriod = 10 * time.Millisecond
 			stopCh := make(chan struct{})
 			defer close(stopCh)
-			go endpoints.Run(1, stopCh)
+			go endpoints.Run(context.TODO(), 1)
 
 			// cache.WaitForNamedCacheSync has a 100ms poll period, and the endpoints worker has a 10ms period.
 			// To ensure we get all updates, including unexpected ones, we need to wait at least as long as
@@ -937,7 +937,7 @@ func TestSyncEndpointsHeadlessService(t *testing.T) {
 	}
 	originalService := service.DeepCopy()
 	endpoints.serviceStore.Add(service)
-	endpoints.syncService(ns + "/foo")
+	endpoints.syncService(context.TODO(), ns+"/foo")
 	data := runtime.EncodeOrDie(clientscheme.Codecs.LegacyCodec(v1.SchemeGroupVersion), &v1.Endpoints{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            "foo",
@@ -984,7 +984,7 @@ func TestSyncEndpointsItemsExcludeNotReadyPodsWithRestartPolicyNeverAndPhaseFail
 			Ports:    []v1.ServicePort{{Port: 80, Protocol: "TCP", TargetPort: intstr.FromInt(8080)}},
 		},
 	})
-	endpoints.syncService(ns + "/foo")
+	endpoints.syncService(context.TODO(), ns+"/foo")
 	data := runtime.EncodeOrDie(clientscheme.Codecs.LegacyCodec(v1.SchemeGroupVersion), &v1.Endpoints{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            "foo",
@@ -1023,7 +1023,7 @@ func TestSyncEndpointsItemsExcludeNotReadyPodsWithRestartPolicyNeverAndPhaseSucc
 			Ports:    []v1.ServicePort{{Port: 80, Protocol: "TCP", TargetPort: intstr.FromInt(8080)}},
 		},
 	})
-	endpoints.syncService(ns + "/foo")
+	endpoints.syncService(context.TODO(), ns+"/foo")
 	data := runtime.EncodeOrDie(clientscheme.Codecs.LegacyCodec(v1.SchemeGroupVersion), &v1.Endpoints{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            "foo",
@@ -1062,7 +1062,7 @@ func TestSyncEndpointsItemsExcludeNotReadyPodsWithRestartPolicyOnFailureAndPhase
 			Ports:    []v1.ServicePort{{Port: 80, Protocol: "TCP", TargetPort: intstr.FromInt(8080)}},
 		},
 	})
-	endpoints.syncService(ns + "/foo")
+	endpoints.syncService(context.TODO(), ns+"/foo")
 	data := runtime.EncodeOrDie(clientscheme.Codecs.LegacyCodec(v1.SchemeGroupVersion), &v1.Endpoints{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            "foo",
@@ -1091,7 +1091,7 @@ func TestSyncEndpointsHeadlessWithoutPort(t *testing.T) {
 		},
 	})
 	addPods(endpoints.podStore, ns, 1, 1, 0, ipv4only)
-	endpoints.syncService(ns + "/foo")
+	endpoints.syncService(context.TODO(), ns+"/foo")
 	endpointsHandler.ValidateRequestCount(t, 1)
 	data := runtime.EncodeOrDie(clientscheme.Codecs.LegacyCodec(v1.SchemeGroupVersion), &v1.Endpoints{
 		ObjectMeta: metav1.ObjectMeta{
@@ -1424,7 +1424,7 @@ func TestLastTriggerChangeTimeAnnotation(t *testing.T) {
 			Ports:    []v1.ServicePort{{Port: 80, TargetPort: intstr.FromInt(8080), Protocol: "TCP"}},
 		},
 	})
-	endpoints.syncService(ns + "/foo")
+	endpoints.syncService(context.TODO(), ns+"/foo")
 
 	endpointsHandler.ValidateRequestCount(t, 1)
 	data := runtime.EncodeOrDie(clientscheme.Codecs.LegacyCodec(v1.SchemeGroupVersion), &v1.Endpoints{
@@ -1474,7 +1474,7 @@ func TestLastTriggerChangeTimeAnnotation_AnnotationOverridden(t *testing.T) {
 			Ports:    []v1.ServicePort{{Port: 80, TargetPort: intstr.FromInt(8080), Protocol: "TCP"}},
 		},
 	})
-	endpoints.syncService(ns + "/foo")
+	endpoints.syncService(context.TODO(), ns+"/foo")
 
 	endpointsHandler.ValidateRequestCount(t, 1)
 	data := runtime.EncodeOrDie(clientscheme.Codecs.LegacyCodec(v1.SchemeGroupVersion), &v1.Endpoints{
@@ -1525,7 +1525,7 @@ func TestLastTriggerChangeTimeAnnotation_AnnotationCleared(t *testing.T) {
 			Ports:    []v1.ServicePort{{Port: 80, TargetPort: intstr.FromInt(8080), Protocol: "TCP"}},
 		},
 	})
-	endpoints.syncService(ns + "/foo")
+	endpoints.syncService(context.TODO(), ns+"/foo")
 
 	endpointsHandler.ValidateRequestCount(t, 1)
 	data := runtime.EncodeOrDie(clientscheme.Codecs.LegacyCodec(v1.SchemeGroupVersion), &v1.Endpoints{
@@ -1654,7 +1654,7 @@ func TestPodUpdatesBatching(t *testing.T) {
 			endpoints.endpointsSynced = alwaysReady
 			endpoints.workerLoopPeriod = 10 * time.Millisecond
 
-			go endpoints.Run(1, stopCh)
+			go endpoints.Run(context.TODO(), 1)
 
 			addPods(endpoints.podStore, ns, tc.podsCount, 1, 0, ipv4only)
 
@@ -1777,7 +1777,7 @@ func TestPodAddsBatching(t *testing.T) {
 			endpoints.endpointsSynced = alwaysReady
 			endpoints.workerLoopPeriod = 10 * time.Millisecond
 
-			go endpoints.Run(1, stopCh)
+			go endpoints.Run(context.TODO(), 1)
 
 			endpoints.serviceStore.Add(&v1.Service{
 				ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: ns},
@@ -1899,7 +1899,7 @@ func TestPodDeleteBatching(t *testing.T) {
 			endpoints.endpointsSynced = alwaysReady
 			endpoints.workerLoopPeriod = 10 * time.Millisecond
 
-			go endpoints.Run(1, stopCh)
+			go endpoints.Run(context.TODO(), 1)
 
 			addPods(endpoints.podStore, ns, tc.podsCount, 1, 0, ipv4only)
 
@@ -1943,7 +1943,7 @@ func TestSyncEndpointsServiceNotFound(t *testing.T) {
 			ResourceVersion: "1",
 		},
 	})
-	endpoints.syncService(ns + "/foo")
+	endpoints.syncService(context.TODO(), ns+"/foo")
 	endpointsHandler.ValidateRequestCount(t, 1)
 	endpointsHandler.ValidateRequest(t, "/api/v1/namespaces/"+ns+"/endpoints/foo", "DELETE", nil)
 }
@@ -2069,7 +2069,7 @@ func TestSyncServiceOverCapacity(t *testing.T) {
 			c.endpointsStore.Add(endpoints)
 			client.CoreV1().Endpoints(ns).Create(context.TODO(), endpoints, metav1.CreateOptions{})
 
-			c.syncService(fmt.Sprintf("%s/%s", ns, svc.Name))
+			c.syncService(context.TODO(), fmt.Sprintf("%s/%s", ns, svc.Name))
 
 			actualEndpoints, err := client.CoreV1().Endpoints(ns).Get(context.TODO(), endpoints.Name, metav1.GetOptions{})
 			if err != nil {
@@ -2228,7 +2228,7 @@ func TestMultipleServiceChanges(t *testing.T) {
 	*controller = *newController(testServer.URL, 0*time.Second)
 	addPods(controller.podStore, ns, 1, 1, 0, ipv4only)
 
-	go func() { controller.Run(1, stopChan) }()
+	go func() { controller.Run(context.TODO(), 1) }()
 
 	svc := &v1.Service{
 		ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: ns},

--- a/pkg/controller/garbagecollector/garbagecollector.go
+++ b/pkg/controller/garbagecollector/garbagecollector.go
@@ -137,7 +137,7 @@ func (gc *GarbageCollector) resyncMonitors(deletableResources map[schema.GroupVe
 }
 
 // Run starts garbage collector workers.
-func (gc *GarbageCollector) Run(workers int, stopCh <-chan struct{}) {
+func (gc *GarbageCollector) Run(ctx context.Context, workers int) {
 	defer utilruntime.HandleCrash()
 	defer gc.attemptToDelete.ShutDown()
 	defer gc.attemptToOrphan.ShutDown()
@@ -146,9 +146,9 @@ func (gc *GarbageCollector) Run(workers int, stopCh <-chan struct{}) {
 	klog.Infof("Starting garbage collector controller")
 	defer klog.Infof("Shutting down garbage collector controller")
 
-	go gc.dependencyGraphBuilder.Run(stopCh)
+	go gc.dependencyGraphBuilder.Run(ctx.Done())
 
-	if !cache.WaitForNamedCacheSync("garbage collector", stopCh, gc.dependencyGraphBuilder.IsSynced) {
+	if !cache.WaitForNamedCacheSync("garbage collector", ctx.Done(), gc.dependencyGraphBuilder.IsSynced) {
 		return
 	}
 
@@ -156,11 +156,11 @@ func (gc *GarbageCollector) Run(workers int, stopCh <-chan struct{}) {
 
 	// gc workers
 	for i := 0; i < workers; i++ {
-		go wait.Until(gc.runAttemptToDeleteWorker, 1*time.Second, stopCh)
-		go wait.Until(gc.runAttemptToOrphanWorker, 1*time.Second, stopCh)
+		go wait.UntilWithContext(ctx, gc.runAttemptToDeleteWorker, 1*time.Second)
+		go wait.Until(gc.runAttemptToOrphanWorker, 1*time.Second, ctx.Done())
 	}
 
-	<-stopCh
+	<-ctx.Done()
 }
 
 // resettableRESTMapper is a RESTMapper which is capable of resetting itself
@@ -294,8 +294,8 @@ func (gc *GarbageCollector) IsSynced() bool {
 	return gc.dependencyGraphBuilder.IsSynced()
 }
 
-func (gc *GarbageCollector) runAttemptToDeleteWorker() {
-	for gc.attemptToDeleteWorker() {
+func (gc *GarbageCollector) runAttemptToDeleteWorker(ctx context.Context) {
+	for gc.attemptToDeleteWorker(ctx) {
 	}
 }
 
@@ -303,7 +303,7 @@ var enqueuedVirtualDeleteEventErr = goerrors.New("enqueued virtual delete event"
 
 var namespacedOwnerOfClusterScopedObjectErr = goerrors.New("cluster-scoped objects cannot refer to namespaced owners")
 
-func (gc *GarbageCollector) attemptToDeleteWorker() bool {
+func (gc *GarbageCollector) attemptToDeleteWorker(ctx context.Context) bool {
 	item, quit := gc.attemptToDelete.Get()
 	gc.workerLock.RLock()
 	defer gc.workerLock.RUnlock()
@@ -333,7 +333,7 @@ func (gc *GarbageCollector) attemptToDeleteWorker() bool {
 		}
 	}
 
-	err := gc.attemptToDeleteItem(n)
+	err := gc.attemptToDeleteItem(ctx, n)
 	if err == enqueuedVirtualDeleteEventErr {
 		// a virtual event was produced and will be handled by processGraphChanges, no need to requeue this node
 		return true
@@ -368,7 +368,7 @@ func (gc *GarbageCollector) attemptToDeleteWorker() bool {
 // isDangling check if a reference is pointing to an object that doesn't exist.
 // If isDangling looks up the referenced object at the API server, it also
 // returns its latest state.
-func (gc *GarbageCollector) isDangling(reference metav1.OwnerReference, item *node) (
+func (gc *GarbageCollector) isDangling(ctx context.Context, reference metav1.OwnerReference, item *node) (
 	dangling bool, owner *metav1.PartialObjectMetadata, err error) {
 
 	// check for recorded absent cluster-scoped parent
@@ -408,7 +408,7 @@ func (gc *GarbageCollector) isDangling(reference metav1.OwnerReference, item *no
 	// TODO: It's only necessary to talk to the API server if the owner node
 	// is a "virtual" node. The local graph could lag behind the real
 	// status, but in practice, the difference is small.
-	owner, err = gc.metadataClient.Resource(resource).Namespace(resourceDefaultNamespace(namespaced, item.identity.Namespace)).Get(context.TODO(), reference.Name, metav1.GetOptions{})
+	owner, err = gc.metadataClient.Resource(resource).Namespace(resourceDefaultNamespace(namespaced, item.identity.Namespace)).Get(ctx, reference.Name, metav1.GetOptions{})
 	switch {
 	case errors.IsNotFound(err):
 		gc.absentOwnerCache.Add(absentOwnerCacheKey)
@@ -432,10 +432,10 @@ func (gc *GarbageCollector) isDangling(reference metav1.OwnerReference, item *no
 // waitingForDependentsDeletion: the owner exists, its deletionTimestamp is non-nil, and it has
 // FinalizerDeletingDependents
 // This function communicates with the server.
-func (gc *GarbageCollector) classifyReferences(item *node, latestReferences []metav1.OwnerReference) (
+func (gc *GarbageCollector) classifyReferences(ctx context.Context, item *node, latestReferences []metav1.OwnerReference) (
 	solid, dangling, waitingForDependentsDeletion []metav1.OwnerReference, err error) {
 	for _, reference := range latestReferences {
-		isDangling, owner, err := gc.isDangling(reference, item)
+		isDangling, owner, err := gc.isDangling(ctx, reference, item)
 		if err != nil {
 			return nil, nil, nil, err
 		}
@@ -471,7 +471,7 @@ func ownerRefsToUIDs(refs []metav1.OwnerReference) []types.UID {
 //
 // if the API get request returns a NotFound error, or the retrieved item's uid does not match,
 // a virtual delete event for the node is enqueued and enqueuedVirtualDeleteEventErr is returned.
-func (gc *GarbageCollector) attemptToDeleteItem(item *node) error {
+func (gc *GarbageCollector) attemptToDeleteItem(ctx context.Context, item *node) error {
 	klog.V(2).InfoS("Processing object", "object", klog.KRef(item.identity.Namespace, item.identity.Name),
 		"objectUID", item.identity.UID, "kind", item.identity.Kind, "virtual", !item.isObserved())
 
@@ -515,7 +515,7 @@ func (gc *GarbageCollector) attemptToDeleteItem(item *node) error {
 		return nil
 	}
 
-	solid, dangling, waitingForDependentsDeletion, err := gc.classifyReferences(item, ownerReferences)
+	solid, dangling, waitingForDependentsDeletion, err := gc.classifyReferences(ctx, item, ownerReferences)
 	if err != nil {
 		return err
 	}

--- a/pkg/controller/nodelifecycle/node_lifecycle_controller_test.go
+++ b/pkg/controller/nodelifecycle/node_lifecycle_controller_test.go
@@ -95,7 +95,7 @@ func (nc *nodeLifecycleController) doEviction(fakeNodeHandler *testutil.FakeNode
 		nc.zonePodEvictor[zone].Try(func(value scheduler.TimedValue) (bool, time.Duration) {
 			uid, _ := value.UID.(string)
 			pods, _ := nc.getPodsAssignedToNode(value.Value)
-			nodeutil.DeletePods(fakeNodeHandler, pods, nc.recorder, value.Value, uid, nc.daemonSetStore)
+			nodeutil.DeletePods(context.TODO(), fakeNodeHandler, pods, nc.recorder, value.Value, uid, nc.daemonSetStore)
 			_ = nc.nodeEvictionMap.setStatus(value.Value, evicted)
 			return true, 0
 		})
@@ -144,6 +144,7 @@ func (nc *nodeLifecycleController) syncNodeStore(fakeNodeHandler *testutil.FakeN
 }
 
 func newNodeLifecycleControllerFromClient(
+	ctx context.Context,
 	kubeClient clientset.Interface,
 	podEvictionTimeout time.Duration,
 	evictionLimiterQPS float32,
@@ -163,6 +164,7 @@ func newNodeLifecycleControllerFromClient(
 	daemonSetInformer := factory.Apps().V1().DaemonSets()
 
 	nc, err := NewNodeLifecycleController(
+		ctx,
 		leaseInformer,
 		factory.Core().V1().Pods(),
 		nodeInformer,
@@ -679,6 +681,7 @@ func TestMonitorNodeHealthEvictPods(t *testing.T) {
 
 	for _, item := range table {
 		nodeController, _ := newNodeLifecycleControllerFromClient(
+			context.TODO(),
 			item.fakeNodeHandler,
 			evictionTimeout,
 			testRateLimiterQPS,
@@ -698,7 +701,7 @@ func TestMonitorNodeHealthEvictPods(t *testing.T) {
 		if err := nodeController.syncNodeStore(item.fakeNodeHandler); err != nil {
 			t.Errorf("unexpected error: %v", err)
 		}
-		if err := nodeController.monitorNodeHealth(); err != nil {
+		if err := nodeController.monitorNodeHealth(context.TODO()); err != nil {
 			t.Errorf("unexpected error: %v", err)
 		}
 		if item.timeToPass > 0 {
@@ -713,7 +716,7 @@ func TestMonitorNodeHealthEvictPods(t *testing.T) {
 		if err := nodeController.syncNodeStore(item.fakeNodeHandler); err != nil {
 			t.Errorf("unexpected error: %v", err)
 		}
-		if err := nodeController.monitorNodeHealth(); err != nil {
+		if err := nodeController.monitorNodeHealth(context.TODO()); err != nil {
 			t.Errorf("unexpected error: %v", err)
 		}
 		zones := testutil.GetZones(item.fakeNodeHandler)
@@ -726,7 +729,7 @@ func TestMonitorNodeHealthEvictPods(t *testing.T) {
 						t.Errorf("unexpected error: %v", err)
 					}
 					t.Logf("listed pods %d for node %v", len(pods), value.Value)
-					nodeutil.DeletePods(item.fakeNodeHandler, pods, nodeController.recorder, value.Value, nodeUID, nodeController.daemonSetInformer.Lister())
+					nodeutil.DeletePods(context.TODO(), item.fakeNodeHandler, pods, nodeController.recorder, value.Value, nodeUID, nodeController.daemonSetInformer.Lister())
 					return true, 0
 				})
 			} else {
@@ -847,6 +850,7 @@ func TestPodStatusChange(t *testing.T) {
 
 	for _, item := range table {
 		nodeController, _ := newNodeLifecycleControllerFromClient(
+			context.TODO(),
 			item.fakeNodeHandler,
 			evictionTimeout,
 			testRateLimiterQPS,
@@ -863,7 +867,7 @@ func TestPodStatusChange(t *testing.T) {
 		if err := nodeController.syncNodeStore(item.fakeNodeHandler); err != nil {
 			t.Errorf("unexpected error: %v", err)
 		}
-		if err := nodeController.monitorNodeHealth(); err != nil {
+		if err := nodeController.monitorNodeHealth(context.TODO()); err != nil {
 			t.Errorf("unexpected error: %v", err)
 		}
 		if item.timeToPass > 0 {
@@ -874,7 +878,7 @@ func TestPodStatusChange(t *testing.T) {
 		if err := nodeController.syncNodeStore(item.fakeNodeHandler); err != nil {
 			t.Errorf("unexpected error: %v", err)
 		}
-		if err := nodeController.monitorNodeHealth(); err != nil {
+		if err := nodeController.monitorNodeHealth(context.TODO()); err != nil {
 			t.Errorf("unexpected error: %v", err)
 		}
 		zones := testutil.GetZones(item.fakeNodeHandler)
@@ -885,7 +889,7 @@ func TestPodStatusChange(t *testing.T) {
 				if err != nil {
 					t.Errorf("unexpected error: %v", err)
 				}
-				nodeutil.DeletePods(item.fakeNodeHandler, pods, nodeController.recorder, value.Value, nodeUID, nodeController.daemonSetStore)
+				nodeutil.DeletePods(context.TODO(), item.fakeNodeHandler, pods, nodeController.recorder, value.Value, nodeUID, nodeController.daemonSetStore)
 				return true, 0
 			})
 		}
@@ -1408,6 +1412,7 @@ func TestMonitorNodeHealthEvictPodsWithDisruption(t *testing.T) {
 			Clientset: fake.NewSimpleClientset(&v1.PodList{Items: item.podList}),
 		}
 		nodeController, _ := newNodeLifecycleControllerFromClient(
+			context.TODO(),
 			fakeNodeHandler,
 			evictionTimeout,
 			testRateLimiterQPS,
@@ -1430,7 +1435,7 @@ func TestMonitorNodeHealthEvictPodsWithDisruption(t *testing.T) {
 		if err := nodeController.syncNodeStore(fakeNodeHandler); err != nil {
 			t.Errorf("unexpected error: %v", err)
 		}
-		if err := nodeController.monitorNodeHealth(); err != nil {
+		if err := nodeController.monitorNodeHealth(context.TODO()); err != nil {
 			t.Errorf("%v: unexpected error: %v", item.description, err)
 		}
 
@@ -1448,7 +1453,7 @@ func TestMonitorNodeHealthEvictPodsWithDisruption(t *testing.T) {
 		if err := nodeController.syncNodeStore(fakeNodeHandler); err != nil {
 			t.Errorf("unexpected error: %v", err)
 		}
-		if err := nodeController.monitorNodeHealth(); err != nil {
+		if err := nodeController.monitorNodeHealth(context.TODO()); err != nil {
 			t.Errorf("%v: unexpected error: %v", item.description, err)
 		}
 		for zone, state := range item.expectedFollowingStates {
@@ -1694,6 +1699,7 @@ func TestMonitorNodeHealthUpdateStatus(t *testing.T) {
 	}
 	for i, item := range table {
 		nodeController, _ := newNodeLifecycleControllerFromClient(
+			context.TODO(),
 			item.fakeNodeHandler,
 			5*time.Minute,
 			testRateLimiterQPS,
@@ -1710,7 +1716,7 @@ func TestMonitorNodeHealthUpdateStatus(t *testing.T) {
 		if err := nodeController.syncNodeStore(item.fakeNodeHandler); err != nil {
 			t.Errorf("unexpected error: %v", err)
 		}
-		if err := nodeController.monitorNodeHealth(); err != nil {
+		if err := nodeController.monitorNodeHealth(context.TODO()); err != nil {
 			t.Errorf("unexpected error: %v", err)
 		}
 		if item.timeToPass > 0 {
@@ -1719,7 +1725,7 @@ func TestMonitorNodeHealthUpdateStatus(t *testing.T) {
 			if err := nodeController.syncNodeStore(item.fakeNodeHandler); err != nil {
 				t.Errorf("unexpected error: %v", err)
 			}
-			if err := nodeController.monitorNodeHealth(); err != nil {
+			if err := nodeController.monitorNodeHealth(context.TODO()); err != nil {
 				t.Errorf("unexpected error: %v", err)
 			}
 		}
@@ -2237,6 +2243,7 @@ func TestMonitorNodeHealthUpdateNodeAndPodStatusWithLease(t *testing.T) {
 	for _, item := range testcases {
 		t.Run(item.description, func(t *testing.T) {
 			nodeController, _ := newNodeLifecycleControllerFromClient(
+				context.TODO(),
 				item.fakeNodeHandler,
 				5*time.Minute,
 				testRateLimiterQPS,
@@ -2256,7 +2263,7 @@ func TestMonitorNodeHealthUpdateNodeAndPodStatusWithLease(t *testing.T) {
 			if err := nodeController.syncLeaseStore(item.lease); err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
-			if err := nodeController.monitorNodeHealth(); err != nil {
+			if err := nodeController.monitorNodeHealth(context.TODO()); err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
 			if item.timeToPass > 0 {
@@ -2268,7 +2275,7 @@ func TestMonitorNodeHealthUpdateNodeAndPodStatusWithLease(t *testing.T) {
 				if err := nodeController.syncLeaseStore(item.newLease); err != nil {
 					t.Fatalf("unexpected error: %v", err)
 				}
-				if err := nodeController.monitorNodeHealth(); err != nil {
+				if err := nodeController.monitorNodeHealth(context.TODO()); err != nil {
 					t.Fatalf("unexpected error: %v", err)
 				}
 			}
@@ -2401,6 +2408,7 @@ func TestMonitorNodeHealthMarkPodsNotReady(t *testing.T) {
 
 	for i, item := range table {
 		nodeController, _ := newNodeLifecycleControllerFromClient(
+			context.TODO(),
 			item.fakeNodeHandler,
 			5*time.Minute,
 			testRateLimiterQPS,
@@ -2417,7 +2425,7 @@ func TestMonitorNodeHealthMarkPodsNotReady(t *testing.T) {
 		if err := nodeController.syncNodeStore(item.fakeNodeHandler); err != nil {
 			t.Errorf("unexpected error: %v", err)
 		}
-		if err := nodeController.monitorNodeHealth(); err != nil {
+		if err := nodeController.monitorNodeHealth(context.TODO()); err != nil {
 			t.Errorf("Case[%d] unexpected error: %v", i, err)
 		}
 		if item.timeToPass > 0 {
@@ -2426,7 +2434,7 @@ func TestMonitorNodeHealthMarkPodsNotReady(t *testing.T) {
 			if err := nodeController.syncNodeStore(item.fakeNodeHandler); err != nil {
 				t.Errorf("unexpected error: %v", err)
 			}
-			if err := nodeController.monitorNodeHealth(); err != nil {
+			if err := nodeController.monitorNodeHealth(context.TODO()); err != nil {
 				t.Errorf("Case[%d] unexpected error: %v", i, err)
 			}
 		}
@@ -2584,6 +2592,7 @@ func TestMonitorNodeHealthMarkPodsNotReadyRetry(t *testing.T) {
 	for _, item := range table {
 		t.Run(item.desc, func(t *testing.T) {
 			nodeController, _ := newNodeLifecycleControllerFromClient(
+				context.TODO(),
 				item.fakeNodeHandler,
 				5*time.Minute,
 				testRateLimiterQPS,
@@ -2606,7 +2615,7 @@ func TestMonitorNodeHealthMarkPodsNotReadyRetry(t *testing.T) {
 				if err := nodeController.syncNodeStore(item.fakeNodeHandler); err != nil {
 					t.Errorf("unexpected error: %v", err)
 				}
-				if err := nodeController.monitorNodeHealth(); err != nil {
+				if err := nodeController.monitorNodeHealth(context.TODO()); err != nil {
 					t.Errorf("unexpected error: %v", err)
 				}
 			}
@@ -2718,6 +2727,7 @@ func TestApplyNoExecuteTaints(t *testing.T) {
 	}
 	originalTaint := UnreachableTaintTemplate
 	nodeController, _ := newNodeLifecycleControllerFromClient(
+		context.TODO(),
 		fakeNodeHandler,
 		evictionTimeout,
 		testRateLimiterQPS,
@@ -2734,10 +2744,10 @@ func TestApplyNoExecuteTaints(t *testing.T) {
 	if err := nodeController.syncNodeStore(fakeNodeHandler); err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
-	if err := nodeController.monitorNodeHealth(); err != nil {
+	if err := nodeController.monitorNodeHealth(context.TODO()); err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
-	nodeController.doNoExecuteTaintingPass()
+	nodeController.doNoExecuteTaintingPass(context.TODO())
 	node0, err := fakeNodeHandler.Get(context.TODO(), "node0", metav1.GetOptions{})
 	if err != nil {
 		t.Errorf("Can't get current node0...")
@@ -2765,10 +2775,10 @@ func TestApplyNoExecuteTaints(t *testing.T) {
 	if err := nodeController.syncNodeStore(fakeNodeHandler); err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
-	if err := nodeController.monitorNodeHealth(); err != nil {
+	if err := nodeController.monitorNodeHealth(context.TODO()); err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
-	nodeController.doNoExecuteTaintingPass()
+	nodeController.doNoExecuteTaintingPass(context.TODO())
 
 	node2, err = fakeNodeHandler.Get(context.TODO(), "node2", metav1.GetOptions{})
 	if err != nil {
@@ -2872,6 +2882,7 @@ func TestApplyNoExecuteTaintsToNodesEnqueueTwice(t *testing.T) {
 		},
 	}
 	nodeController, _ := newNodeLifecycleControllerFromClient(
+		context.TODO(),
 		fakeNodeHandler,
 		evictionTimeout,
 		testRateLimiterQPS,
@@ -2889,10 +2900,10 @@ func TestApplyNoExecuteTaintsToNodesEnqueueTwice(t *testing.T) {
 		t.Errorf("unexpected error: %v", err)
 	}
 	// 1. monitor node health twice, add untainted node once
-	if err := nodeController.monitorNodeHealth(); err != nil {
+	if err := nodeController.monitorNodeHealth(context.TODO()); err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
-	if err := nodeController.monitorNodeHealth(); err != nil {
+	if err := nodeController.monitorNodeHealth(context.TODO()); err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
 
@@ -2986,14 +2997,14 @@ func TestApplyNoExecuteTaintsToNodesEnqueueTwice(t *testing.T) {
 		t.Errorf("unexpected error: %v", err)
 	}
 	// 3. start monitor node health again, add untainted node twice, construct UniqueQueue with duplicated node cache
-	if err := nodeController.monitorNodeHealth(); err != nil {
+	if err := nodeController.monitorNodeHealth(context.TODO()); err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
 
 	// 4. do NoExecute taint pass
 	// when processing with node0, condition.Status is NodeReady, and return true with default case
 	// then remove the set value and queue value both, the taint job never stuck
-	nodeController.doNoExecuteTaintingPass()
+	nodeController.doNoExecuteTaintingPass(context.TODO())
 
 	// 5. get node3 and node5, see if it has ready got NoExecute taint
 	node3, err := fakeNodeHandler.Get(context.TODO(), "node3", metav1.GetOptions{})
@@ -3096,6 +3107,7 @@ func TestSwapUnreachableNotReadyTaints(t *testing.T) {
 	updatedTaint := NotReadyTaintTemplate
 
 	nodeController, _ := newNodeLifecycleControllerFromClient(
+		context.TODO(),
 		fakeNodeHandler,
 		evictionTimeout,
 		testRateLimiterQPS,
@@ -3112,10 +3124,10 @@ func TestSwapUnreachableNotReadyTaints(t *testing.T) {
 	if err := nodeController.syncNodeStore(fakeNodeHandler); err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
-	if err := nodeController.monitorNodeHealth(); err != nil {
+	if err := nodeController.monitorNodeHealth(context.TODO()); err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
-	nodeController.doNoExecuteTaintingPass()
+	nodeController.doNoExecuteTaintingPass(context.TODO())
 
 	node0, err := fakeNodeHandler.Get(context.TODO(), "node0", metav1.GetOptions{})
 	if err != nil {
@@ -3150,10 +3162,10 @@ func TestSwapUnreachableNotReadyTaints(t *testing.T) {
 	if err := nodeController.syncNodeStore(fakeNodeHandler); err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
-	if err := nodeController.monitorNodeHealth(); err != nil {
+	if err := nodeController.monitorNodeHealth(context.TODO()); err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
-	nodeController.doNoExecuteTaintingPass()
+	nodeController.doNoExecuteTaintingPass(context.TODO())
 
 	node0, err = fakeNodeHandler.Get(context.TODO(), "node0", metav1.GetOptions{})
 	if err != nil {
@@ -3200,6 +3212,7 @@ func TestTaintsNodeByCondition(t *testing.T) {
 	}
 
 	nodeController, _ := newNodeLifecycleControllerFromClient(
+		context.TODO(),
 		fakeNodeHandler,
 		evictionTimeout,
 		testRateLimiterQPS,
@@ -3355,7 +3368,7 @@ func TestTaintsNodeByCondition(t *testing.T) {
 		if err := nodeController.syncNodeStore(fakeNodeHandler); err != nil {
 			t.Errorf("unexpected error: %v", err)
 		}
-		nodeController.doNoScheduleTaintingPass(test.Node.Name)
+		nodeController.doNoScheduleTaintingPass(context.TODO(), test.Node.Name)
 		if err := nodeController.syncNodeStore(fakeNodeHandler); err != nil {
 			t.Errorf("unexpected error: %v", err)
 		}
@@ -3402,6 +3415,7 @@ func TestNodeEventGeneration(t *testing.T) {
 	}
 
 	nodeController, _ := newNodeLifecycleControllerFromClient(
+		context.TODO(),
 		fakeNodeHandler,
 		5*time.Minute,
 		testRateLimiterQPS,
@@ -3420,7 +3434,7 @@ func TestNodeEventGeneration(t *testing.T) {
 	if err := nodeController.syncNodeStore(fakeNodeHandler); err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
-	if err := nodeController.monitorNodeHealth(); err != nil {
+	if err := nodeController.monitorNodeHealth(context.TODO()); err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
 	if len(fakeRecorder.Events) != 1 {
@@ -3475,6 +3489,7 @@ func TestReconcileNodeLabels(t *testing.T) {
 	}
 
 	nodeController, _ := newNodeLifecycleControllerFromClient(
+		context.TODO(),
 		fakeNodeHandler,
 		evictionTimeout,
 		testRateLimiterQPS,
@@ -3618,6 +3633,7 @@ func TestTryUpdateNodeHealth(t *testing.T) {
 	}
 
 	nodeController, _ := newNodeLifecycleControllerFromClient(
+		context.TODO(),
 		fakeNodeHandler,
 		evictionTimeout,
 		testRateLimiterQPS,
@@ -3790,7 +3806,7 @@ func TestTryUpdateNodeHealth(t *testing.T) {
 				probeTimestamp:           test.node.CreationTimestamp,
 				readyTransitionTimestamp: test.node.CreationTimestamp,
 			})
-			_, _, currentReadyCondition, err := nodeController.tryUpdateNodeHealth(test.node)
+			_, _, currentReadyCondition, err := nodeController.tryUpdateNodeHealth(context.TODO(), test.node)
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}

--- a/pkg/controller/nodelifecycle/scheduler/taint_manager_test.go
+++ b/pkg/controller/nodelifecycle/scheduler/taint_manager_test.go
@@ -217,11 +217,11 @@ func TestCreatePod(t *testing.T) {
 	}
 
 	for _, item := range testCases {
-		stopCh := make(chan struct{})
+		ctx, cancel := context.WithCancel(context.Background())
 		fakeClientset := fake.NewSimpleClientset()
-		controller := NewNoExecuteTaintManager(fakeClientset, (&podHolder{pod: item.pod}).getPod, getNodeFromClientset(fakeClientset), getPodsAssignedToNode(fakeClientset))
+		controller := NewNoExecuteTaintManager(ctx, fakeClientset, (&podHolder{pod: item.pod}).getPod, getNodeFromClientset(fakeClientset), getPodsAssignedToNode(fakeClientset))
 		controller.recorder = testutil.NewFakeRecorder()
-		go controller.Run(stopCh)
+		go controller.Run(ctx)
 		controller.taintedNodes = item.taintedNodes
 		controller.PodUpdated(nil, item.pod)
 		// wait a bit
@@ -236,16 +236,16 @@ func TestCreatePod(t *testing.T) {
 		if podDeleted != item.expectDelete {
 			t.Errorf("%v: Unexpected test result. Expected delete %v, got %v", item.description, item.expectDelete, podDeleted)
 		}
-		close(stopCh)
+		cancel()
 	}
 }
 
 func TestDeletePod(t *testing.T) {
 	stopCh := make(chan struct{})
 	fakeClientset := fake.NewSimpleClientset()
-	controller := NewNoExecuteTaintManager(fakeClientset, getPodFromClientset(fakeClientset), getNodeFromClientset(fakeClientset), getPodsAssignedToNode(fakeClientset))
+	controller := NewNoExecuteTaintManager(context.TODO(), fakeClientset, getPodFromClientset(fakeClientset), getNodeFromClientset(fakeClientset), getPodsAssignedToNode(fakeClientset))
 	controller.recorder = testutil.NewFakeRecorder()
-	go controller.Run(stopCh)
+	go controller.Run(context.TODO())
 	controller.taintedNodes = map[string][]v1.Taint{
 		"node1": {createNoExecuteTaint(1)},
 	}
@@ -304,12 +304,12 @@ func TestUpdatePod(t *testing.T) {
 	}
 
 	for _, item := range testCases {
-		stopCh := make(chan struct{})
+		ctx, cancel := context.WithCancel(context.Background())
 		fakeClientset := fake.NewSimpleClientset()
 		holder := &podHolder{}
-		controller := NewNoExecuteTaintManager(fakeClientset, holder.getPod, getNodeFromClientset(fakeClientset), getPodsAssignedToNode(fakeClientset))
+		controller := NewNoExecuteTaintManager(ctx, fakeClientset, holder.getPod, getNodeFromClientset(fakeClientset), getPodsAssignedToNode(fakeClientset))
 		controller.recorder = testutil.NewFakeRecorder()
-		go controller.Run(stopCh)
+		go controller.Run(ctx)
 		controller.taintedNodes = item.taintedNodes
 
 		holder.setPod(item.prevPod)
@@ -333,7 +333,7 @@ func TestUpdatePod(t *testing.T) {
 		if podDeleted != item.expectDelete {
 			t.Errorf("%v: Unexpected test result. Expected delete %v, got %v", item.description, item.expectDelete, podDeleted)
 		}
-		close(stopCh)
+		cancel()
 	}
 }
 
@@ -371,11 +371,11 @@ func TestCreateNode(t *testing.T) {
 	}
 
 	for _, item := range testCases {
-		stopCh := make(chan struct{})
+		ctx, cancel := context.WithCancel(context.Background())
 		fakeClientset := fake.NewSimpleClientset(&v1.PodList{Items: item.pods})
-		controller := NewNoExecuteTaintManager(fakeClientset, getPodFromClientset(fakeClientset), (&nodeHolder{node: item.node}).getNode, getPodsAssignedToNode(fakeClientset))
+		controller := NewNoExecuteTaintManager(ctx, fakeClientset, getPodFromClientset(fakeClientset), (&nodeHolder{node: item.node}).getNode, getPodsAssignedToNode(fakeClientset))
 		controller.recorder = testutil.NewFakeRecorder()
-		go controller.Run(stopCh)
+		go controller.Run(ctx)
 		controller.NodeUpdated(nil, item.node)
 		// wait a bit
 		time.Sleep(timeForControllerToProgress)
@@ -389,19 +389,19 @@ func TestCreateNode(t *testing.T) {
 		if podDeleted != item.expectDelete {
 			t.Errorf("%v: Unexpected test result. Expected delete %v, got %v", item.description, item.expectDelete, podDeleted)
 		}
-		close(stopCh)
+		cancel()
 	}
 }
 
 func TestDeleteNode(t *testing.T) {
-	stopCh := make(chan struct{})
+	ctx, cancel := context.WithCancel(context.Background())
 	fakeClientset := fake.NewSimpleClientset()
-	controller := NewNoExecuteTaintManager(fakeClientset, getPodFromClientset(fakeClientset), getNodeFromClientset(fakeClientset), getPodsAssignedToNode(fakeClientset))
+	controller := NewNoExecuteTaintManager(ctx, fakeClientset, getPodFromClientset(fakeClientset), getNodeFromClientset(fakeClientset), getPodsAssignedToNode(fakeClientset))
 	controller.recorder = testutil.NewFakeRecorder()
 	controller.taintedNodes = map[string][]v1.Taint{
 		"node1": {createNoExecuteTaint(1)},
 	}
-	go controller.Run(stopCh)
+	go controller.Run(ctx)
 	controller.NodeUpdated(testutil.NewNode("node1"), nil)
 	// wait a bit to see if nothing will panic
 	time.Sleep(timeForControllerToProgress)
@@ -410,7 +410,7 @@ func TestDeleteNode(t *testing.T) {
 		t.Error("Node should have been deleted from taintedNodes list")
 	}
 	controller.taintedNodesLock.Unlock()
-	close(stopCh)
+	cancel()
 }
 
 func TestUpdateNode(t *testing.T) {
@@ -494,9 +494,9 @@ func TestUpdateNode(t *testing.T) {
 	for _, item := range testCases {
 		stopCh := make(chan struct{})
 		fakeClientset := fake.NewSimpleClientset(&v1.PodList{Items: item.pods})
-		controller := NewNoExecuteTaintManager(fakeClientset, getPodFromClientset(fakeClientset), (&nodeHolder{node: item.newNode}).getNode, getPodsAssignedToNode(fakeClientset))
+		controller := NewNoExecuteTaintManager(context.TODO(), fakeClientset, getPodFromClientset(fakeClientset), (&nodeHolder{node: item.newNode}).getNode, getPodsAssignedToNode(fakeClientset))
 		controller.recorder = testutil.NewFakeRecorder()
-		go controller.Run(stopCh)
+		go controller.Run(context.TODO())
 		controller.NodeUpdated(item.oldNode, item.newNode)
 		// wait a bit
 		time.Sleep(timeForControllerToProgress)
@@ -537,16 +537,16 @@ func TestUpdateNodeWithMultipleTaints(t *testing.T) {
 	singleTaintedNode := testutil.NewNode("node1")
 	singleTaintedNode.Spec.Taints = []v1.Taint{taint1}
 
-	stopCh := make(chan struct{})
+	ctx, cancel := context.WithCancel(context.TODO())
 	fakeClientset := fake.NewSimpleClientset(pod)
 	holder := &nodeHolder{node: untaintedNode}
-	controller := NewNoExecuteTaintManager(fakeClientset, getPodFromClientset(fakeClientset), (holder).getNode, getPodsAssignedToNode(fakeClientset))
+	controller := NewNoExecuteTaintManager(context.TODO(), fakeClientset, getPodFromClientset(fakeClientset), (holder).getNode, getPodsAssignedToNode(fakeClientset))
 	controller.recorder = testutil.NewFakeRecorder()
-	go controller.Run(stopCh)
+	go controller.Run(context.TODO())
 
 	// no taint
 	holder.setNode(untaintedNode)
-	controller.handleNodeUpdate(nodeUpdateItem{"node1"})
+	controller.handleNodeUpdate(ctx, nodeUpdateItem{"node1"})
 	// verify pod is not queued for deletion
 	if controller.taintEvictionQueue.GetWorkerUnsafe(podNamespacedName.String()) != nil {
 		t.Fatalf("pod queued for deletion with no taints")
@@ -554,7 +554,7 @@ func TestUpdateNodeWithMultipleTaints(t *testing.T) {
 
 	// no taint -> infinitely tolerated taint
 	holder.setNode(singleTaintedNode)
-	controller.handleNodeUpdate(nodeUpdateItem{"node1"})
+	controller.handleNodeUpdate(ctx, nodeUpdateItem{"node1"})
 	// verify pod is not queued for deletion
 	if controller.taintEvictionQueue.GetWorkerUnsafe(podNamespacedName.String()) != nil {
 		t.Fatalf("pod queued for deletion with permanently tolerated taint")
@@ -562,7 +562,7 @@ func TestUpdateNodeWithMultipleTaints(t *testing.T) {
 
 	// infinitely tolerated taint -> temporarily tolerated taint
 	holder.setNode(doubleTaintedNode)
-	controller.handleNodeUpdate(nodeUpdateItem{"node1"})
+	controller.handleNodeUpdate(ctx, nodeUpdateItem{"node1"})
 	// verify pod is queued for deletion
 	if controller.taintEvictionQueue.GetWorkerUnsafe(podNamespacedName.String()) == nil {
 		t.Fatalf("pod not queued for deletion after addition of temporarily tolerated taint")
@@ -570,7 +570,7 @@ func TestUpdateNodeWithMultipleTaints(t *testing.T) {
 
 	// temporarily tolerated taint -> infinitely tolerated taint
 	holder.setNode(singleTaintedNode)
-	controller.handleNodeUpdate(nodeUpdateItem{"node1"})
+	controller.handleNodeUpdate(ctx, nodeUpdateItem{"node1"})
 	// verify pod is not queued for deletion
 	if controller.taintEvictionQueue.GetWorkerUnsafe(podNamespacedName.String()) != nil {
 		t.Fatalf("pod queued for deletion after removal of temporarily tolerated taint")
@@ -582,7 +582,7 @@ func TestUpdateNodeWithMultipleTaints(t *testing.T) {
 			t.Error("Unexpected deletion")
 		}
 	}
-	close(stopCh)
+	cancel()
 }
 
 func TestUpdateNodeWithMultiplePods(t *testing.T) {
@@ -628,9 +628,9 @@ func TestUpdateNodeWithMultiplePods(t *testing.T) {
 		stopCh := make(chan struct{})
 		fakeClientset := fake.NewSimpleClientset(&v1.PodList{Items: item.pods})
 		sort.Sort(item.expectedDeleteTimes)
-		controller := NewNoExecuteTaintManager(fakeClientset, getPodFromClientset(fakeClientset), (&nodeHolder{node: item.newNode}).getNode, getPodsAssignedToNode(fakeClientset))
+		controller := NewNoExecuteTaintManager(context.TODO(), fakeClientset, getPodFromClientset(fakeClientset), (&nodeHolder{node: item.newNode}).getNode, getPodsAssignedToNode(fakeClientset))
 		controller.recorder = testutil.NewFakeRecorder()
-		go controller.Run(stopCh)
+		go controller.Run(context.TODO())
 		controller.NodeUpdated(item.oldNode, item.newNode)
 
 		startedAt := time.Now()
@@ -828,9 +828,9 @@ func TestEventualConsistency(t *testing.T) {
 		stopCh := make(chan struct{})
 		fakeClientset := fake.NewSimpleClientset(&v1.PodList{Items: item.pods})
 		holder := &podHolder{}
-		controller := NewNoExecuteTaintManager(fakeClientset, holder.getPod, (&nodeHolder{node: item.newNode}).getNode, getPodsAssignedToNode(fakeClientset))
+		controller := NewNoExecuteTaintManager(context.TODO(), fakeClientset, holder.getPod, (&nodeHolder{node: item.newNode}).getNode, getPodsAssignedToNode(fakeClientset))
 		controller.recorder = testutil.NewFakeRecorder()
-		go controller.Run(stopCh)
+		go controller.Run(context.TODO())
 
 		if item.prevPod != nil {
 			holder.setPod(item.prevPod)

--- a/pkg/controller/nodelifecycle/scheduler/timed_workers_test.go
+++ b/pkg/controller/nodelifecycle/scheduler/timed_workers_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package scheduler
 
 import (
+	"context"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -29,23 +30,23 @@ func TestExecute(t *testing.T) {
 	testVal := int32(0)
 	wg := sync.WaitGroup{}
 	wg.Add(5)
-	queue := CreateWorkerQueue(func(args *WorkArgs) error {
+	queue := CreateWorkerQueue(func(ctx context.Context, args *WorkArgs) error {
 		atomic.AddInt32(&testVal, 1)
 		wg.Done()
 		return nil
 	})
 	now := time.Now()
-	queue.AddWork(NewWorkArgs("1", "1"), now, now)
-	queue.AddWork(NewWorkArgs("2", "2"), now, now)
-	queue.AddWork(NewWorkArgs("3", "3"), now, now)
-	queue.AddWork(NewWorkArgs("4", "4"), now, now)
-	queue.AddWork(NewWorkArgs("5", "5"), now, now)
+	queue.AddWork(context.TODO(), NewWorkArgs("1", "1"), now, now)
+	queue.AddWork(context.TODO(), NewWorkArgs("2", "2"), now, now)
+	queue.AddWork(context.TODO(), NewWorkArgs("3", "3"), now, now)
+	queue.AddWork(context.TODO(), NewWorkArgs("4", "4"), now, now)
+	queue.AddWork(context.TODO(), NewWorkArgs("5", "5"), now, now)
 	// Adding the same thing second time should be no-op
-	queue.AddWork(NewWorkArgs("1", "1"), now, now)
-	queue.AddWork(NewWorkArgs("2", "2"), now, now)
-	queue.AddWork(NewWorkArgs("3", "3"), now, now)
-	queue.AddWork(NewWorkArgs("4", "4"), now, now)
-	queue.AddWork(NewWorkArgs("5", "5"), now, now)
+	queue.AddWork(context.TODO(), NewWorkArgs("1", "1"), now, now)
+	queue.AddWork(context.TODO(), NewWorkArgs("2", "2"), now, now)
+	queue.AddWork(context.TODO(), NewWorkArgs("3", "3"), now, now)
+	queue.AddWork(context.TODO(), NewWorkArgs("4", "4"), now, now)
+	queue.AddWork(context.TODO(), NewWorkArgs("5", "5"), now, now)
 	wg.Wait()
 	lastVal := atomic.LoadInt32(&testVal)
 	if lastVal != 5 {
@@ -57,7 +58,7 @@ func TestExecuteDelayed(t *testing.T) {
 	testVal := int32(0)
 	wg := sync.WaitGroup{}
 	wg.Add(5)
-	queue := CreateWorkerQueue(func(args *WorkArgs) error {
+	queue := CreateWorkerQueue(func(ctx context.Context, args *WorkArgs) error {
 		atomic.AddInt32(&testVal, 1)
 		wg.Done()
 		return nil
@@ -66,16 +67,16 @@ func TestExecuteDelayed(t *testing.T) {
 	then := now.Add(10 * time.Second)
 	fakeClock := testingclock.NewFakeClock(now)
 	queue.clock = fakeClock
-	queue.AddWork(NewWorkArgs("1", "1"), now, then)
-	queue.AddWork(NewWorkArgs("2", "2"), now, then)
-	queue.AddWork(NewWorkArgs("3", "3"), now, then)
-	queue.AddWork(NewWorkArgs("4", "4"), now, then)
-	queue.AddWork(NewWorkArgs("5", "5"), now, then)
-	queue.AddWork(NewWorkArgs("1", "1"), now, then)
-	queue.AddWork(NewWorkArgs("2", "2"), now, then)
-	queue.AddWork(NewWorkArgs("3", "3"), now, then)
-	queue.AddWork(NewWorkArgs("4", "4"), now, then)
-	queue.AddWork(NewWorkArgs("5", "5"), now, then)
+	queue.AddWork(context.TODO(), NewWorkArgs("1", "1"), now, then)
+	queue.AddWork(context.TODO(), NewWorkArgs("2", "2"), now, then)
+	queue.AddWork(context.TODO(), NewWorkArgs("3", "3"), now, then)
+	queue.AddWork(context.TODO(), NewWorkArgs("4", "4"), now, then)
+	queue.AddWork(context.TODO(), NewWorkArgs("5", "5"), now, then)
+	queue.AddWork(context.TODO(), NewWorkArgs("1", "1"), now, then)
+	queue.AddWork(context.TODO(), NewWorkArgs("2", "2"), now, then)
+	queue.AddWork(context.TODO(), NewWorkArgs("3", "3"), now, then)
+	queue.AddWork(context.TODO(), NewWorkArgs("4", "4"), now, then)
+	queue.AddWork(context.TODO(), NewWorkArgs("5", "5"), now, then)
 	fakeClock.Step(11 * time.Second)
 	wg.Wait()
 	lastVal := atomic.LoadInt32(&testVal)
@@ -88,7 +89,7 @@ func TestCancel(t *testing.T) {
 	testVal := int32(0)
 	wg := sync.WaitGroup{}
 	wg.Add(3)
-	queue := CreateWorkerQueue(func(args *WorkArgs) error {
+	queue := CreateWorkerQueue(func(ctx context.Context, args *WorkArgs) error {
 		atomic.AddInt32(&testVal, 1)
 		wg.Done()
 		return nil
@@ -97,16 +98,16 @@ func TestCancel(t *testing.T) {
 	then := now.Add(10 * time.Second)
 	fakeClock := testingclock.NewFakeClock(now)
 	queue.clock = fakeClock
-	queue.AddWork(NewWorkArgs("1", "1"), now, then)
-	queue.AddWork(NewWorkArgs("2", "2"), now, then)
-	queue.AddWork(NewWorkArgs("3", "3"), now, then)
-	queue.AddWork(NewWorkArgs("4", "4"), now, then)
-	queue.AddWork(NewWorkArgs("5", "5"), now, then)
-	queue.AddWork(NewWorkArgs("1", "1"), now, then)
-	queue.AddWork(NewWorkArgs("2", "2"), now, then)
-	queue.AddWork(NewWorkArgs("3", "3"), now, then)
-	queue.AddWork(NewWorkArgs("4", "4"), now, then)
-	queue.AddWork(NewWorkArgs("5", "5"), now, then)
+	queue.AddWork(context.TODO(), NewWorkArgs("1", "1"), now, then)
+	queue.AddWork(context.TODO(), NewWorkArgs("2", "2"), now, then)
+	queue.AddWork(context.TODO(), NewWorkArgs("3", "3"), now, then)
+	queue.AddWork(context.TODO(), NewWorkArgs("4", "4"), now, then)
+	queue.AddWork(context.TODO(), NewWorkArgs("5", "5"), now, then)
+	queue.AddWork(context.TODO(), NewWorkArgs("1", "1"), now, then)
+	queue.AddWork(context.TODO(), NewWorkArgs("2", "2"), now, then)
+	queue.AddWork(context.TODO(), NewWorkArgs("3", "3"), now, then)
+	queue.AddWork(context.TODO(), NewWorkArgs("4", "4"), now, then)
+	queue.AddWork(context.TODO(), NewWorkArgs("5", "5"), now, then)
 	queue.CancelWork(NewWorkArgs("2", "2").KeyFromWorkArgs())
 	queue.CancelWork(NewWorkArgs("4", "4").KeyFromWorkArgs())
 	fakeClock.Step(11 * time.Second)
@@ -121,7 +122,7 @@ func TestCancelAndReadd(t *testing.T) {
 	testVal := int32(0)
 	wg := sync.WaitGroup{}
 	wg.Add(4)
-	queue := CreateWorkerQueue(func(args *WorkArgs) error {
+	queue := CreateWorkerQueue(func(ctx context.Context, args *WorkArgs) error {
 		atomic.AddInt32(&testVal, 1)
 		wg.Done()
 		return nil
@@ -130,19 +131,19 @@ func TestCancelAndReadd(t *testing.T) {
 	then := now.Add(10 * time.Second)
 	fakeClock := testingclock.NewFakeClock(now)
 	queue.clock = fakeClock
-	queue.AddWork(NewWorkArgs("1", "1"), now, then)
-	queue.AddWork(NewWorkArgs("2", "2"), now, then)
-	queue.AddWork(NewWorkArgs("3", "3"), now, then)
-	queue.AddWork(NewWorkArgs("4", "4"), now, then)
-	queue.AddWork(NewWorkArgs("5", "5"), now, then)
-	queue.AddWork(NewWorkArgs("1", "1"), now, then)
-	queue.AddWork(NewWorkArgs("2", "2"), now, then)
-	queue.AddWork(NewWorkArgs("3", "3"), now, then)
-	queue.AddWork(NewWorkArgs("4", "4"), now, then)
-	queue.AddWork(NewWorkArgs("5", "5"), now, then)
+	queue.AddWork(context.TODO(), NewWorkArgs("1", "1"), now, then)
+	queue.AddWork(context.TODO(), NewWorkArgs("2", "2"), now, then)
+	queue.AddWork(context.TODO(), NewWorkArgs("3", "3"), now, then)
+	queue.AddWork(context.TODO(), NewWorkArgs("4", "4"), now, then)
+	queue.AddWork(context.TODO(), NewWorkArgs("5", "5"), now, then)
+	queue.AddWork(context.TODO(), NewWorkArgs("1", "1"), now, then)
+	queue.AddWork(context.TODO(), NewWorkArgs("2", "2"), now, then)
+	queue.AddWork(context.TODO(), NewWorkArgs("3", "3"), now, then)
+	queue.AddWork(context.TODO(), NewWorkArgs("4", "4"), now, then)
+	queue.AddWork(context.TODO(), NewWorkArgs("5", "5"), now, then)
 	queue.CancelWork(NewWorkArgs("2", "2").KeyFromWorkArgs())
 	queue.CancelWork(NewWorkArgs("4", "4").KeyFromWorkArgs())
-	queue.AddWork(NewWorkArgs("2", "2"), now, then)
+	queue.AddWork(context.TODO(), NewWorkArgs("2", "2"), now, then)
 	fakeClock.Step(11 * time.Second)
 	wg.Wait()
 	lastVal := atomic.LoadInt32(&testVal)

--- a/pkg/controller/podgc/gc_controller.go
+++ b/pkg/controller/podgc/gc_controller.go
@@ -61,7 +61,7 @@ type PodGCController struct {
 	terminatedPodThreshold int
 }
 
-func NewPodGC(kubeClient clientset.Interface, podInformer coreinformers.PodInformer,
+func NewPodGC(ctx context.Context, kubeClient clientset.Interface, podInformer coreinformers.PodInformer,
 	nodeInformer coreinformers.NodeInformer, terminatedPodThreshold int) *PodGCController {
 	if kubeClient != nil && kubeClient.CoreV1().RESTClient().GetRateLimiter() != nil {
 		ratelimiter.RegisterMetricAndTrackRateLimiterUsage("gc_controller", kubeClient.CoreV1().RESTClient().GetRateLimiter())
@@ -76,30 +76,30 @@ func NewPodGC(kubeClient clientset.Interface, podInformer coreinformers.PodInfor
 		nodeQueue:              workqueue.NewNamedDelayingQueue("orphaned_pods_nodes"),
 		deletePod: func(namespace, name string) error {
 			klog.InfoS("PodGC is force deleting Pod", "pod", klog.KRef(namespace, name))
-			return kubeClient.CoreV1().Pods(namespace).Delete(context.TODO(), name, *metav1.NewDeleteOptions(0))
+			return kubeClient.CoreV1().Pods(namespace).Delete(ctx, name, *metav1.NewDeleteOptions(0))
 		},
 	}
 
 	return gcc
 }
 
-func (gcc *PodGCController) Run(stop <-chan struct{}) {
+func (gcc *PodGCController) Run(ctx context.Context) {
 	defer utilruntime.HandleCrash()
 
 	klog.Infof("Starting GC controller")
 	defer gcc.nodeQueue.ShutDown()
 	defer klog.Infof("Shutting down GC controller")
 
-	if !cache.WaitForNamedCacheSync("GC", stop, gcc.podListerSynced, gcc.nodeListerSynced) {
+	if !cache.WaitForNamedCacheSync("GC", ctx.Done(), gcc.podListerSynced, gcc.nodeListerSynced) {
 		return
 	}
 
-	go wait.Until(gcc.gc, gcCheckPeriod, stop)
+	go wait.UntilWithContext(ctx, gcc.gc, gcCheckPeriod)
 
-	<-stop
+	<-ctx.Done()
 }
 
-func (gcc *PodGCController) gc() {
+func (gcc *PodGCController) gc(ctx context.Context) {
 	pods, err := gcc.podLister.List(labels.Everything())
 	if err != nil {
 		klog.Errorf("Error while listing all pods: %v", err)
@@ -113,7 +113,7 @@ func (gcc *PodGCController) gc() {
 	if gcc.terminatedPodThreshold > 0 {
 		gcc.gcTerminated(pods)
 	}
-	gcc.gcOrphaned(pods, nodes)
+	gcc.gcOrphaned(ctx, pods, nodes)
 	gcc.gcUnscheduledTerminating(pods)
 }
 
@@ -157,7 +157,7 @@ func (gcc *PodGCController) gcTerminated(pods []*v1.Pod) {
 }
 
 // gcOrphaned deletes pods that are bound to nodes that don't exist.
-func (gcc *PodGCController) gcOrphaned(pods []*v1.Pod, nodes []*v1.Node) {
+func (gcc *PodGCController) gcOrphaned(ctx context.Context, pods []*v1.Pod, nodes []*v1.Node) {
 	klog.V(4).Infof("GC'ing orphaned")
 	existingNodeNames := sets.NewString()
 	for _, node := range nodes {
@@ -170,7 +170,7 @@ func (gcc *PodGCController) gcOrphaned(pods []*v1.Pod, nodes []*v1.Node) {
 		}
 	}
 	// Check if nodes are still missing after quarantine period
-	deletedNodesNames, quit := gcc.discoverDeletedNodes(existingNodeNames)
+	deletedNodesNames, quit := gcc.discoverDeletedNodes(ctx, existingNodeNames)
 	if quit {
 		return
 	}
@@ -188,7 +188,7 @@ func (gcc *PodGCController) gcOrphaned(pods []*v1.Pod, nodes []*v1.Node) {
 	}
 }
 
-func (gcc *PodGCController) discoverDeletedNodes(existingNodeNames sets.String) (sets.String, bool) {
+func (gcc *PodGCController) discoverDeletedNodes(ctx context.Context, existingNodeNames sets.String) (sets.String, bool) {
 	deletedNodesNames := sets.NewString()
 	for gcc.nodeQueue.Len() > 0 {
 		item, quit := gcc.nodeQueue.Get()
@@ -197,7 +197,7 @@ func (gcc *PodGCController) discoverDeletedNodes(existingNodeNames sets.String) 
 		}
 		nodeName := item.(string)
 		if !existingNodeNames.Has(nodeName) {
-			exists, err := gcc.checkIfNodeExists(nodeName)
+			exists, err := gcc.checkIfNodeExists(ctx, nodeName)
 			switch {
 			case err != nil:
 				klog.ErrorS(err, "Error while getting node", "node", nodeName)
@@ -211,8 +211,8 @@ func (gcc *PodGCController) discoverDeletedNodes(existingNodeNames sets.String) 
 	return deletedNodesNames, false
 }
 
-func (gcc *PodGCController) checkIfNodeExists(name string) (bool, error) {
-	_, fetchErr := gcc.kubeClient.CoreV1().Nodes().Get(context.TODO(), name, metav1.GetOptions{})
+func (gcc *PodGCController) checkIfNodeExists(ctx context.Context, name string) (bool, error) {
+	_, fetchErr := gcc.kubeClient.CoreV1().Nodes().Get(ctx, name, metav1.GetOptions{})
 	if errors.IsNotFound(fetchErr) {
 		return false, nil
 	}

--- a/pkg/controller/podgc/gc_controller_test.go
+++ b/pkg/controller/podgc/gc_controller_test.go
@@ -43,7 +43,7 @@ func NewFromClient(kubeClient clientset.Interface, terminatedPodThreshold int) (
 	informerFactory := informers.NewSharedInformerFactory(kubeClient, controller.NoResyncPeriodFunc())
 	podInformer := informerFactory.Core().V1().Pods()
 	nodeInformer := informerFactory.Core().V1().Nodes()
-	controller := NewPodGC(kubeClient, podInformer, nodeInformer, terminatedPodThreshold)
+	controller := NewPodGC(context.TODO(), kubeClient, podInformer, nodeInformer, terminatedPodThreshold)
 	controller.podListerSynced = alwaysReady
 	return controller, podInformer, nodeInformer
 }
@@ -145,7 +145,7 @@ func TestGCTerminated(t *testing.T) {
 				})
 			}
 
-			gcc.gc()
+			gcc.gc(context.TODO())
 
 			if pass := compareStringSetToList(test.deletedPodNames, deletedPodNames); !pass {
 				t.Errorf("[%v]pod's deleted expected and actual did not match.\n\texpected: %v\n\tactual: %v",
@@ -336,7 +336,7 @@ func TestGCOrphaned(t *testing.T) {
 			}
 
 			// First GC of orphaned pods
-			gcc.gc()
+			gcc.gc(context.TODO())
 			if len(deletedPodNames) > 0 {
 				t.Errorf("no pods should be deleted at this point.\n\tactual: %v", deletedPodNames)
 			}
@@ -367,7 +367,7 @@ func TestGCOrphaned(t *testing.T) {
 			}
 
 			// Actual pod deletion
-			gcc.gc()
+			gcc.gc(context.TODO())
 
 			if pass := compareStringSetToList(test.deletedPodNames, deletedPodNames); !pass {
 				t.Errorf("pod's deleted expected and actual did not match.\n\texpected: %v\n\tactual: %v",

--- a/pkg/controller/resourcequota/resource_quota_controller.go
+++ b/pkg/controller/resourcequota/resource_quota_controller.go
@@ -88,7 +88,7 @@ type Controller struct {
 	// missingUsageQueue holds objects that are missing the initial usage information
 	missingUsageQueue workqueue.RateLimitingInterface
 	// To allow injection of syncUsage for testing.
-	syncHandler func(key string) error
+	syncHandler func(ctx context.Context, key string) error
 	// function that controls full recalculation of quota usage
 	resyncPeriod controller.ResyncPeriodFunc
 	// knows how to calculate usage
@@ -236,8 +236,8 @@ func (rq *Controller) addQuota(obj interface{}) {
 }
 
 // worker runs a worker thread that just dequeues items, processes them, and marks them done.
-func (rq *Controller) worker(queue workqueue.RateLimitingInterface) func() {
-	workFunc := func() bool {
+func (rq *Controller) worker(ctx context.Context, queue workqueue.RateLimitingInterface) func(context.Context) {
+	workFunc := func(ctx context.Context) bool {
 		key, quit := queue.Get()
 		if quit {
 			return true
@@ -245,7 +245,7 @@ func (rq *Controller) worker(queue workqueue.RateLimitingInterface) func() {
 		defer queue.Done(key)
 		rq.workerLock.RLock()
 		defer rq.workerLock.RUnlock()
-		err := rq.syncHandler(key.(string))
+		err := rq.syncHandler(ctx, key.(string))
 		if err == nil {
 			queue.Forget(key)
 			return false
@@ -255,9 +255,9 @@ func (rq *Controller) worker(queue workqueue.RateLimitingInterface) func() {
 		return false
 	}
 
-	return func() {
+	return func(ctx context.Context) {
 		for {
-			if quit := workFunc(); quit {
+			if quit := workFunc(ctx); quit {
 				klog.Infof("resource quota controller worker shutting down")
 				return
 			}
@@ -266,7 +266,7 @@ func (rq *Controller) worker(queue workqueue.RateLimitingInterface) func() {
 }
 
 // Run begins quota controller using the specified number of workers
-func (rq *Controller) Run(workers int, stopCh <-chan struct{}) {
+func (rq *Controller) Run(ctx context.Context, workers int) {
 	defer utilruntime.HandleCrash()
 	defer rq.queue.ShutDown()
 
@@ -274,29 +274,29 @@ func (rq *Controller) Run(workers int, stopCh <-chan struct{}) {
 	defer klog.Infof("Shutting down resource quota controller")
 
 	if rq.quotaMonitor != nil {
-		go rq.quotaMonitor.Run(stopCh)
+		go rq.quotaMonitor.Run(ctx.Done())
 	}
 
-	if !cache.WaitForNamedCacheSync("resource quota", stopCh, rq.informerSyncedFuncs...) {
+	if !cache.WaitForNamedCacheSync("resource quota", ctx.Done(), rq.informerSyncedFuncs...) {
 		return
 	}
 
 	// the workers that chug through the quota calculation backlog
 	for i := 0; i < workers; i++ {
-		go wait.Until(rq.worker(rq.queue), time.Second, stopCh)
-		go wait.Until(rq.worker(rq.missingUsageQueue), time.Second, stopCh)
+		go wait.UntilWithContext(ctx, rq.worker(ctx, rq.queue), time.Second)
+		go wait.UntilWithContext(ctx, rq.worker(ctx, rq.missingUsageQueue), time.Second)
 	}
 	// the timer for how often we do a full recalculation across all quotas
 	if rq.resyncPeriod() > 0 {
-		go wait.Until(func() { rq.enqueueAll() }, rq.resyncPeriod(), stopCh)
+		go wait.Until(func() { rq.enqueueAll() }, rq.resyncPeriod(), ctx.Done())
 	} else {
 		klog.Warningf("periodic quota controller resync disabled")
 	}
-	<-stopCh
+	<-ctx.Done()
 }
 
 // syncResourceQuotaFromKey syncs a quota key
-func (rq *Controller) syncResourceQuotaFromKey(key string) (err error) {
+func (rq *Controller) syncResourceQuotaFromKey(ctx context.Context, key string) (err error) {
 	startTime := time.Now()
 	defer func() {
 		klog.V(4).Infof("Finished syncing resource quota %q (%v)", key, time.Since(startTime))
@@ -315,11 +315,11 @@ func (rq *Controller) syncResourceQuotaFromKey(key string) (err error) {
 		klog.Infof("Unable to retrieve resource quota %v from store: %v", key, err)
 		return err
 	}
-	return rq.syncResourceQuota(resourceQuota)
+	return rq.syncResourceQuota(ctx, resourceQuota)
 }
 
 // syncResourceQuota runs a complete sync of resource quota status across all known kinds
-func (rq *Controller) syncResourceQuota(resourceQuota *v1.ResourceQuota) (err error) {
+func (rq *Controller) syncResourceQuota(ctx context.Context, resourceQuota *v1.ResourceQuota) (err error) {
 	// quota is dirty if any part of spec hard limits differs from the status hard limits
 	statusLimitsDirty := !apiequality.Semantic.DeepEqual(resourceQuota.Spec.Hard, resourceQuota.Status.Hard)
 
@@ -361,7 +361,7 @@ func (rq *Controller) syncResourceQuota(resourceQuota *v1.ResourceQuota) (err er
 
 	// there was a change observed by this controller that requires we update quota
 	if dirty {
-		_, err = rq.rqClient.ResourceQuotas(usage.Namespace).UpdateStatus(context.TODO(), usage, metav1.UpdateOptions{})
+		_, err = rq.rqClient.ResourceQuotas(usage.Namespace).UpdateStatus(ctx, usage, metav1.UpdateOptions{})
 		if err != nil {
 			errs = append(errs, err)
 		}

--- a/pkg/controller/resourcequota/resource_quota_controller_test.go
+++ b/pkg/controller/resourcequota/resource_quota_controller_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package resourcequota
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -782,7 +783,7 @@ func TestSyncResourceQuota(t *testing.T) {
 		qc := setupQuotaController(t, kubeClient, mockListerForResourceFunc(listersForResourceConfig), mockDiscoveryFunc)
 		defer close(qc.stop)
 
-		if err := qc.syncResourceQuota(&testCase.quota); err != nil {
+		if err := qc.syncResourceQuota(context.TODO(), &testCase.quota); err != nil {
 			if len(testCase.expectedError) == 0 || !strings.Contains(err.Error(), testCase.expectedError) {
 				t.Fatalf("test: %s, unexpected error: %v", testName, err)
 			}

--- a/pkg/controller/serviceaccount/serviceaccounts_controller.go
+++ b/pkg/controller/serviceaccount/serviceaccounts_controller.go
@@ -98,7 +98,7 @@ type ServiceAccountsController struct {
 	serviceAccountsToEnsure []v1.ServiceAccount
 
 	// To allow injection for testing.
-	syncHandler func(key string) error
+	syncHandler func(ctx context.Context, key string) error
 
 	saLister       corelisters.ServiceAccountLister
 	saListerSynced cache.InformerSynced
@@ -110,22 +110,22 @@ type ServiceAccountsController struct {
 }
 
 // Run runs the ServiceAccountsController blocks until receiving signal from stopCh.
-func (c *ServiceAccountsController) Run(workers int, stopCh <-chan struct{}) {
+func (c *ServiceAccountsController) Run(ctx context.Context, workers int) {
 	defer utilruntime.HandleCrash()
 	defer c.queue.ShutDown()
 
 	klog.Infof("Starting service account controller")
 	defer klog.Infof("Shutting down service account controller")
 
-	if !cache.WaitForNamedCacheSync("service account", stopCh, c.saListerSynced, c.nsListerSynced) {
+	if !cache.WaitForNamedCacheSync("service account", ctx.Done(), c.saListerSynced, c.nsListerSynced) {
 		return
 	}
 
 	for i := 0; i < workers; i++ {
-		go wait.Until(c.runWorker, time.Second, stopCh)
+		go wait.UntilWithContext(ctx, c.runWorker, time.Second)
 	}
 
-	<-stopCh
+	<-ctx.Done()
 }
 
 // serviceAccountDeleted reacts to a ServiceAccount deletion by recreating a default ServiceAccount in the namespace if needed
@@ -158,20 +158,20 @@ func (c *ServiceAccountsController) namespaceUpdated(oldObj interface{}, newObj 
 	c.queue.Add(newNamespace.Name)
 }
 
-func (c *ServiceAccountsController) runWorker() {
-	for c.processNextWorkItem() {
+func (c *ServiceAccountsController) runWorker(ctx context.Context) {
+	for c.processNextWorkItem(ctx) {
 	}
 }
 
 // processNextWorkItem deals with one key off the queue.  It returns false when it's time to quit.
-func (c *ServiceAccountsController) processNextWorkItem() bool {
+func (c *ServiceAccountsController) processNextWorkItem(ctx context.Context) bool {
 	key, quit := c.queue.Get()
 	if quit {
 		return false
 	}
 	defer c.queue.Done(key)
 
-	err := c.syncHandler(key.(string))
+	err := c.syncHandler(ctx, key.(string))
 	if err == nil {
 		c.queue.Forget(key)
 		return true
@@ -182,7 +182,7 @@ func (c *ServiceAccountsController) processNextWorkItem() bool {
 
 	return true
 }
-func (c *ServiceAccountsController) syncNamespace(key string) error {
+func (c *ServiceAccountsController) syncNamespace(ctx context.Context, key string) error {
 	startTime := time.Now()
 	defer func() {
 		klog.V(4).Infof("Finished syncing namespace %q (%v)", key, time.Since(startTime))
@@ -213,7 +213,7 @@ func (c *ServiceAccountsController) syncNamespace(key string) error {
 		// TODO eliminate this once the fake client can handle creation without NS
 		sa.Namespace = ns.Name
 
-		if _, err := c.client.CoreV1().ServiceAccounts(ns.Name).Create(context.TODO(), &sa, metav1.CreateOptions{}); err != nil && !apierrors.IsAlreadyExists(err) {
+		if _, err := c.client.CoreV1().ServiceAccounts(ns.Name).Create(ctx, &sa, metav1.CreateOptions{}); err != nil && !apierrors.IsAlreadyExists(err) {
 			// we can safely ignore terminating namespace errors
 			if !apierrors.HasStatusCause(err, v1.NamespaceTerminatingCause) {
 				createFailures = append(createFailures, err)

--- a/pkg/controller/serviceaccount/serviceaccounts_controller_test.go
+++ b/pkg/controller/serviceaccount/serviceaccounts_controller_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package serviceaccount
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -176,8 +177,8 @@ func TestServiceAccountCreation(t *testing.T) {
 		nsStore := nsInformer.Informer().GetStore()
 
 		syncCalls := make(chan struct{})
-		controller.syncHandler = func(key string) error {
-			err := controller.syncNamespace(key)
+		controller.syncHandler = func(ctx context.Context, key string) error {
+			err := controller.syncNamespace(ctx, key)
 			if err != nil {
 				t.Logf("%s: %v", k, err)
 			}
@@ -187,7 +188,7 @@ func TestServiceAccountCreation(t *testing.T) {
 		}
 		stopCh := make(chan struct{})
 		defer close(stopCh)
-		go controller.Run(1, stopCh)
+		go controller.Run(context.TODO(), 1)
 
 		if tc.ExistingNamespace != nil {
 			nsStore.Add(tc.ExistingNamespace)

--- a/pkg/controller/ttl/ttl_controller_test.go
+++ b/pkg/controller/ttl/ttl_controller_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package ttl
 
 import (
+	"context"
 	"testing"
 
 	"k8s.io/api/core/v1"
@@ -78,7 +79,7 @@ func TestPatchNode(t *testing.T) {
 		ttlController := &Controller{
 			kubeClient: fakeClient,
 		}
-		err := ttlController.patchNodeWithAnnotation(testCase.node, v1.ObjectTTLAnnotationKey, testCase.ttlSeconds)
+		err := ttlController.patchNodeWithAnnotation(context.TODO(), testCase.node, v1.ObjectTTLAnnotationKey, testCase.ttlSeconds)
 		if err != nil {
 			t.Errorf("%d: unexpected error: %v", i, err)
 			continue
@@ -137,7 +138,7 @@ func TestUpdateNodeIfNeeded(t *testing.T) {
 			nodeStore:         listers.NewNodeLister(nodeStore),
 			desiredTTLSeconds: testCase.desiredTTL,
 		}
-		if err := ttlController.updateNodeIfNeeded(testCase.node.Name); err != nil {
+		if err := ttlController.updateNodeIfNeeded(context.TODO(), testCase.node.Name); err != nil {
 			t.Errorf("%d: unexpected error: %v", i, err)
 			continue
 		}

--- a/pkg/controller/ttlafterfinished/ttlafterfinished_controller.go
+++ b/pkg/controller/ttlafterfinished/ttlafterfinished_controller.go
@@ -102,22 +102,22 @@ func New(jobInformer batchinformers.JobInformer, client clientset.Interface) *Co
 }
 
 // Run starts the workers to clean up Jobs.
-func (tc *Controller) Run(workers int, stopCh <-chan struct{}) {
+func (tc *Controller) Run(ctx context.Context, workers int) {
 	defer utilruntime.HandleCrash()
 	defer tc.queue.ShutDown()
 
 	klog.Infof("Starting TTL after finished controller")
 	defer klog.Infof("Shutting down TTL after finished controller")
 
-	if !cache.WaitForNamedCacheSync("TTL after finished", stopCh, tc.jListerSynced) {
+	if !cache.WaitForNamedCacheSync("TTL after finished", ctx.Done(), tc.jListerSynced) {
 		return
 	}
 
 	for i := 0; i < workers; i++ {
-		go wait.Until(tc.worker, time.Second, stopCh)
+		go wait.UntilWithContext(ctx, tc.worker, time.Second)
 	}
 
-	<-stopCh
+	<-ctx.Done()
 }
 
 func (tc *Controller) addJob(obj interface{}) {
@@ -159,19 +159,19 @@ func (tc *Controller) enqueueAfter(job *batch.Job, after time.Duration) {
 	tc.queue.AddAfter(key, after)
 }
 
-func (tc *Controller) worker() {
-	for tc.processNextWorkItem() {
+func (tc *Controller) worker(ctx context.Context) {
+	for tc.processNextWorkItem(ctx) {
 	}
 }
 
-func (tc *Controller) processNextWorkItem() bool {
+func (tc *Controller) processNextWorkItem(ctx context.Context) bool {
 	key, quit := tc.queue.Get()
 	if quit {
 		return false
 	}
 	defer tc.queue.Done(key)
 
-	err := tc.processJob(key.(string))
+	err := tc.processJob(ctx, key.(string))
 	tc.handleErr(err, key)
 
 	return true
@@ -192,7 +192,7 @@ func (tc *Controller) handleErr(err error, key interface{}) {
 // its TTL hasn't expired, it will be added to the queue after the TTL is expected
 // to expire.
 // This function is not meant to be invoked concurrently with the same key.
-func (tc *Controller) processJob(key string) error {
+func (tc *Controller) processJob(ctx context.Context, key string) error {
 	namespace, name, err := cache.SplitMetaNamespaceKey(key)
 	if err != nil {
 		return err
@@ -218,7 +218,7 @@ func (tc *Controller) processJob(key string) error {
 	// Before deleting the Job, do a final sanity check.
 	// If TTL is modified before we do this check, we cannot be sure if the TTL truly expires.
 	// The latest Job may have a different UID, but it's fine because the checks will be run again.
-	fresh, err := tc.client.BatchV1().Jobs(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+	fresh, err := tc.client.BatchV1().Jobs(namespace).Get(ctx, name, metav1.GetOptions{})
 	if errors.IsNotFound(err) {
 		return nil
 	}
@@ -239,7 +239,7 @@ func (tc *Controller) processJob(key string) error {
 		Preconditions:     &metav1.Preconditions{UID: &fresh.UID},
 	}
 	klog.V(4).Infof("Cleaning up Job %s/%s", namespace, name)
-	if err := tc.client.BatchV1().Jobs(fresh.Namespace).Delete(context.TODO(), fresh.Name, options); err != nil {
+	if err := tc.client.BatchV1().Jobs(fresh.Namespace).Delete(ctx, fresh.Name, options); err != nil {
 		return err
 	}
 	metrics.JobDeletionDurationSeconds.Observe(time.Since(*expiredAt).Seconds())

--- a/pkg/controller/volume/ephemeral/controller.go
+++ b/pkg/controller/volume/ephemeral/controller.go
@@ -45,7 +45,7 @@ import (
 
 // Controller creates PVCs for ephemeral inline volumes in a pod spec.
 type Controller interface {
-	Run(workers int, stopCh <-chan struct{})
+	Run(ctx context.Context, workers int)
 }
 
 type ephemeralController struct {
@@ -163,37 +163,37 @@ func (ec *ephemeralController) onPVCDelete(obj interface{}) {
 	}
 }
 
-func (ec *ephemeralController) Run(workers int, stopCh <-chan struct{}) {
+func (ec *ephemeralController) Run(ctx context.Context, workers int) {
 	defer runtime.HandleCrash()
 	defer ec.queue.ShutDown()
 
 	klog.Infof("Starting ephemeral volume controller")
 	defer klog.Infof("Shutting down ephemeral volume controller")
 
-	if !cache.WaitForNamedCacheSync("ephemeral", stopCh, ec.podSynced, ec.pvcsSynced) {
+	if !cache.WaitForNamedCacheSync("ephemeral", ctx.Done(), ec.podSynced, ec.pvcsSynced) {
 		return
 	}
 
 	for i := 0; i < workers; i++ {
-		go wait.Until(ec.runWorker, time.Second, stopCh)
+		go wait.UntilWithContext(ctx, ec.runWorker, time.Second)
 	}
 
-	<-stopCh
+	<-ctx.Done()
 }
 
-func (ec *ephemeralController) runWorker() {
-	for ec.processNextWorkItem() {
+func (ec *ephemeralController) runWorker(ctx context.Context) {
+	for ec.processNextWorkItem(ctx) {
 	}
 }
 
-func (ec *ephemeralController) processNextWorkItem() bool {
+func (ec *ephemeralController) processNextWorkItem(ctx context.Context) bool {
 	key, shutdown := ec.queue.Get()
 	if shutdown {
 		return false
 	}
 	defer ec.queue.Done(key)
 
-	err := ec.syncHandler(key.(string))
+	err := ec.syncHandler(ctx, key.(string))
 	if err == nil {
 		ec.queue.Forget(key)
 		return true
@@ -207,7 +207,7 @@ func (ec *ephemeralController) processNextWorkItem() bool {
 
 // syncHandler is invoked for each pod which might need to be processed.
 // If an error is returned from this function, the pod will be requeued.
-func (ec *ephemeralController) syncHandler(key string) error {
+func (ec *ephemeralController) syncHandler(ctx context.Context, key string) error {
 	namespace, name, err := kcache.SplitMetaNamespaceKey(key)
 	if err != nil {
 		return err
@@ -229,7 +229,7 @@ func (ec *ephemeralController) syncHandler(key string) error {
 	}
 
 	for _, vol := range pod.Spec.Volumes {
-		if err := ec.handleVolume(pod, vol); err != nil {
+		if err := ec.handleVolume(ctx, pod, vol); err != nil {
 			ec.recorder.Event(pod, v1.EventTypeWarning, events.FailedBinding, fmt.Sprintf("ephemeral volume %s: %v", vol.Name, err))
 			return fmt.Errorf("pod %s, ephemeral volume %s: %v", key, vol.Name, err)
 		}
@@ -239,7 +239,7 @@ func (ec *ephemeralController) syncHandler(key string) error {
 }
 
 // handleEphemeralVolume is invoked for each volume of a pod.
-func (ec *ephemeralController) handleVolume(pod *v1.Pod, vol v1.Volume) error {
+func (ec *ephemeralController) handleVolume(ctx context.Context, pod *v1.Pod, vol v1.Volume) error {
 	klog.V(5).Infof("ephemeral: checking volume %s", vol.Name)
 	if vol.Ephemeral == nil {
 		return nil
@@ -280,7 +280,7 @@ func (ec *ephemeralController) handleVolume(pod *v1.Pod, vol v1.Volume) error {
 		Spec: vol.Ephemeral.VolumeClaimTemplate.Spec,
 	}
 	ephemeralvolumemetrics.EphemeralVolumeCreateAttempts.Inc()
-	_, err = ec.kubeClient.CoreV1().PersistentVolumeClaims(pod.Namespace).Create(context.TODO(), pvc, metav1.CreateOptions{})
+	_, err = ec.kubeClient.CoreV1().PersistentVolumeClaims(pod.Namespace).Create(ctx, pvc, metav1.CreateOptions{})
 	if err != nil {
 		ephemeralvolumemetrics.EphemeralVolumeCreateFailures.Inc()
 		return fmt.Errorf("create PVC %s: %v", pvcName, err)

--- a/pkg/controller/volume/ephemeral/controller_test.go
+++ b/pkg/controller/volume/ephemeral/controller_test.go
@@ -160,7 +160,7 @@ func TestSyncHandler(t *testing.T) {
 			informerFactory.WaitForCacheSync(ctx.Done())
 			cache.WaitForCacheSync(ctx.Done(), podInformer.Informer().HasSynced, pvcInformer.Informer().HasSynced)
 
-			err = ec.syncHandler(tc.podKey)
+			err = ec.syncHandler(context.TODO(), tc.podKey)
 			if err != nil && !tc.expectedError {
 				t.Fatalf("unexpected error while running handler: %v", err)
 			}

--- a/pkg/controller/volume/expand/expand_controller_test.go
+++ b/pkg/controller/volume/expand/expand_controller_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package expand
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"reflect"
@@ -157,7 +158,7 @@ func TestSyncHandler(t *testing.T) {
 			return true, pvc, nil
 		})
 
-		err = expController.syncHandler(test.pvcKey)
+		err = expController.syncHandler(context.TODO(), test.pvcKey)
 		if err != nil && !test.hasError {
 			t.Fatalf("for: %s; unexpected error while running handler : %v", test.name, err)
 		}

--- a/pkg/controller/volume/persistentvolume/framework_test.go
+++ b/pkg/controller/volume/persistentvolume/framework_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package persistentvolume
 
 import (
+	"context"
 	"fmt"
 	"reflect"
 	"strings"
@@ -490,11 +491,11 @@ func claimWithAccessMode(modes []v1.PersistentVolumeAccessMode, claims []*v1.Per
 }
 
 func testSyncClaim(ctrl *PersistentVolumeController, reactor *pvtesting.VolumeReactor, test controllerTest) error {
-	return ctrl.syncClaim(test.initialClaims[0])
+	return ctrl.syncClaim(context.TODO(), test.initialClaims[0])
 }
 
 func testSyncClaimError(ctrl *PersistentVolumeController, reactor *pvtesting.VolumeReactor, test controllerTest) error {
-	err := ctrl.syncClaim(test.initialClaims[0])
+	err := ctrl.syncClaim(context.TODO(), test.initialClaims[0])
 
 	if err != nil {
 		return nil
@@ -503,7 +504,7 @@ func testSyncClaimError(ctrl *PersistentVolumeController, reactor *pvtesting.Vol
 }
 
 func testSyncVolume(ctrl *PersistentVolumeController, reactor *pvtesting.VolumeReactor, test controllerTest) error {
-	return ctrl.syncVolume(test.initialVolumes[0])
+	return ctrl.syncVolume(context.TODO(), test.initialVolumes[0])
 }
 
 type operationType string
@@ -797,7 +798,7 @@ func runMultisyncTests(t *testing.T, tests []controllerTest, storageClasses []*s
 				claim := obj.(*v1.PersistentVolumeClaim)
 				// Simulate "claim updated" event
 				ctrl.claims.Update(claim)
-				err = ctrl.syncClaim(claim)
+				err = ctrl.syncClaim(context.TODO(), claim)
 				if err != nil {
 					if err == pvtesting.ErrVersionConflict {
 						// Ignore version errors
@@ -814,7 +815,7 @@ func runMultisyncTests(t *testing.T, tests []controllerTest, storageClasses []*s
 				volume := obj.(*v1.PersistentVolume)
 				// Simulate "volume updated" event
 				ctrl.volumes.store.Update(volume)
-				err = ctrl.syncVolume(volume)
+				err = ctrl.syncVolume(context.TODO(), volume)
 				if err != nil {
 					if err == pvtesting.ErrVersionConflict {
 						// Ignore version errors

--- a/pkg/controller/volume/persistentvolume/provision_test.go
+++ b/pkg/controller/volume/persistentvolume/provision_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package persistentvolume
 
 import (
+	"context"
 	"errors"
 	"testing"
 
@@ -652,7 +653,7 @@ func TestDisablingDynamicProvisioner(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Construct PersistentVolume controller failed: %v", err)
 	}
-	retVal := ctrl.provisionClaim(nil)
+	retVal := ctrl.provisionClaim(context.TODO(), nil)
 	if retVal != nil {
 		t.Errorf("Expected nil return but got %v", retVal)
 	}

--- a/pkg/controller/volume/pvcprotection/pvc_protection_controller.go
+++ b/pkg/controller/volume/pvcprotection/pvc_protection_controller.go
@@ -100,31 +100,31 @@ func NewPVCProtectionController(pvcInformer coreinformers.PersistentVolumeClaimI
 }
 
 // Run runs the controller goroutines.
-func (c *Controller) Run(workers int, stopCh <-chan struct{}) {
+func (c *Controller) Run(ctx context.Context, workers int) {
 	defer utilruntime.HandleCrash()
 	defer c.queue.ShutDown()
 
 	klog.InfoS("Starting PVC protection controller")
 	defer klog.InfoS("Shutting down PVC protection controller")
 
-	if !cache.WaitForNamedCacheSync("PVC protection", stopCh, c.pvcListerSynced, c.podListerSynced) {
+	if !cache.WaitForNamedCacheSync("PVC protection", ctx.Done(), c.pvcListerSynced, c.podListerSynced) {
 		return
 	}
 
 	for i := 0; i < workers; i++ {
-		go wait.Until(c.runWorker, time.Second, stopCh)
+		go wait.UntilWithContext(ctx, c.runWorker, time.Second)
 	}
 
-	<-stopCh
+	<-ctx.Done()
 }
 
-func (c *Controller) runWorker() {
-	for c.processNextWorkItem() {
+func (c *Controller) runWorker(ctx context.Context) {
+	for c.processNextWorkItem(ctx) {
 	}
 }
 
 // processNextWorkItem deals with one pvcKey off the queue.  It returns false when it's time to quit.
-func (c *Controller) processNextWorkItem() bool {
+func (c *Controller) processNextWorkItem(ctx context.Context) bool {
 	pvcKey, quit := c.queue.Get()
 	if quit {
 		return false
@@ -137,7 +137,7 @@ func (c *Controller) processNextWorkItem() bool {
 		return true
 	}
 
-	err = c.processPVC(pvcNamespace, pvcName)
+	err = c.processPVC(ctx, pvcNamespace, pvcName)
 	if err == nil {
 		c.queue.Forget(pvcKey)
 		return true
@@ -149,7 +149,7 @@ func (c *Controller) processNextWorkItem() bool {
 	return true
 }
 
-func (c *Controller) processPVC(pvcNamespace, pvcName string) error {
+func (c *Controller) processPVC(ctx context.Context, pvcNamespace, pvcName string) error {
 	klog.V(4).InfoS("Processing PVC", "PVC", klog.KRef(pvcNamespace, pvcName))
 	startTime := time.Now()
 	defer func() {
@@ -168,12 +168,12 @@ func (c *Controller) processPVC(pvcNamespace, pvcName string) error {
 	if protectionutil.IsDeletionCandidate(pvc, volumeutil.PVCProtectionFinalizer) {
 		// PVC should be deleted. Check if it's used and remove finalizer if
 		// it's not.
-		isUsed, err := c.isBeingUsed(pvc)
+		isUsed, err := c.isBeingUsed(ctx, pvc)
 		if err != nil {
 			return err
 		}
 		if !isUsed {
-			return c.removeFinalizer(pvc)
+			return c.removeFinalizer(ctx, pvc)
 		}
 		klog.V(2).InfoS("Keeping PVC because it is being used", "PVC", klog.KObj(pvc))
 	}
@@ -183,19 +183,19 @@ func (c *Controller) processPVC(pvcNamespace, pvcName string) error {
 		// finalizer should be added by admission plugin, this is just to add
 		// the finalizer to old PVCs that were created before the admission
 		// plugin was enabled.
-		return c.addFinalizer(pvc)
+		return c.addFinalizer(ctx, pvc)
 	}
 	return nil
 }
 
-func (c *Controller) addFinalizer(pvc *v1.PersistentVolumeClaim) error {
+func (c *Controller) addFinalizer(ctx context.Context, pvc *v1.PersistentVolumeClaim) error {
 	// Skip adding Finalizer in case the StorageObjectInUseProtection feature is not enabled
 	if !c.storageObjectInUseProtectionEnabled {
 		return nil
 	}
 	claimClone := pvc.DeepCopy()
 	claimClone.ObjectMeta.Finalizers = append(claimClone.ObjectMeta.Finalizers, volumeutil.PVCProtectionFinalizer)
-	_, err := c.client.CoreV1().PersistentVolumeClaims(claimClone.Namespace).Update(context.TODO(), claimClone, metav1.UpdateOptions{})
+	_, err := c.client.CoreV1().PersistentVolumeClaims(claimClone.Namespace).Update(ctx, claimClone, metav1.UpdateOptions{})
 	if err != nil {
 		klog.ErrorS(err, "Error adding protection finalizer to PVC", "PVC", klog.KObj(pvc))
 		return err
@@ -204,10 +204,10 @@ func (c *Controller) addFinalizer(pvc *v1.PersistentVolumeClaim) error {
 	return nil
 }
 
-func (c *Controller) removeFinalizer(pvc *v1.PersistentVolumeClaim) error {
+func (c *Controller) removeFinalizer(ctx context.Context, pvc *v1.PersistentVolumeClaim) error {
 	claimClone := pvc.DeepCopy()
 	claimClone.ObjectMeta.Finalizers = slice.RemoveString(claimClone.ObjectMeta.Finalizers, volumeutil.PVCProtectionFinalizer, nil)
-	_, err := c.client.CoreV1().PersistentVolumeClaims(claimClone.Namespace).Update(context.TODO(), claimClone, metav1.UpdateOptions{})
+	_, err := c.client.CoreV1().PersistentVolumeClaims(claimClone.Namespace).Update(ctx, claimClone, metav1.UpdateOptions{})
 	if err != nil {
 		klog.ErrorS(err, "Error removing protection finalizer from PVC", "PVC", klog.KObj(pvc))
 		return err
@@ -216,7 +216,7 @@ func (c *Controller) removeFinalizer(pvc *v1.PersistentVolumeClaim) error {
 	return nil
 }
 
-func (c *Controller) isBeingUsed(pvc *v1.PersistentVolumeClaim) (bool, error) {
+func (c *Controller) isBeingUsed(ctx context.Context, pvc *v1.PersistentVolumeClaim) (bool, error) {
 	// Look for a Pod using pvc in the Informer's cache. If one is found the
 	// correct decision to keep pvc is taken without doing an expensive live
 	// list.
@@ -231,7 +231,7 @@ func (c *Controller) isBeingUsed(pvc *v1.PersistentVolumeClaim) (bool, error) {
 	// mean such a Pod doesn't exist: it might just not be in the cache yet. To
 	// be 100% confident that it is safe to delete pvc make sure no Pod is using
 	// it among those returned by a live list.
-	return c.askAPIServer(pvc)
+	return c.askAPIServer(ctx, pvc)
 }
 
 func (c *Controller) askInformer(pvc *v1.PersistentVolumeClaim) (bool, error) {
@@ -260,10 +260,10 @@ func (c *Controller) askInformer(pvc *v1.PersistentVolumeClaim) (bool, error) {
 	return false, nil
 }
 
-func (c *Controller) askAPIServer(pvc *v1.PersistentVolumeClaim) (bool, error) {
+func (c *Controller) askAPIServer(ctx context.Context, pvc *v1.PersistentVolumeClaim) (bool, error) {
 	klog.V(4).InfoS("Looking for Pods using PVC with a live list", "PVC", klog.KObj(pvc))
 
-	podsList, err := c.client.CoreV1().Pods(pvc.Namespace).List(context.TODO(), metav1.ListOptions{})
+	podsList, err := c.client.CoreV1().Pods(pvc.Namespace).List(ctx, metav1.ListOptions{})
 	if err != nil {
 		return false, fmt.Errorf("live list of pods failed: %s", err.Error())
 	}

--- a/pkg/controller/volume/pvcprotection/pvc_protection_controller_test.go
+++ b/pkg/controller/volume/pvcprotection/pvc_protection_controller_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package pvcprotection
 
 import (
+	"context"
 	"errors"
 	"reflect"
 	"testing"
@@ -476,7 +477,7 @@ func TestPVCProtectionController(t *testing.T) {
 			}
 			if ctrl.queue.Len() > 0 {
 				klog.V(5).Infof("Test %q: %d events queue, processing one", test.name, ctrl.queue.Len())
-				ctrl.processNextWorkItem()
+				ctrl.processNextWorkItem(context.TODO())
 			}
 			if ctrl.queue.Len() > 0 {
 				// There is still some work in the queue, process it now

--- a/pkg/controller/volume/pvprotection/pv_protection_controller_test.go
+++ b/pkg/controller/volume/pvprotection/pv_protection_controller_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package pvprotection
 
 import (
+	"context"
 	"errors"
 	"reflect"
 	"testing"
@@ -247,7 +248,7 @@ func TestPVProtectionController(t *testing.T) {
 			}
 			if ctrl.queue.Len() > 0 {
 				klog.V(5).Infof("Test %q: %d events queue, processing one", test.name, ctrl.queue.Len())
-				ctrl.processNextWorkItem()
+				ctrl.processNextWorkItem(context.TODO())
 			}
 			if ctrl.queue.Len() > 0 {
 				// There is still some work in the queue, process it now

--- a/staging/src/k8s.io/cloud-provider/app/core.go
+++ b/staging/src/k8s.io/cloud-provider/app/core.go
@@ -21,6 +21,7 @@ limitations under the License.
 package app
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"strings"
@@ -39,52 +40,52 @@ import (
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 )
 
-func startCloudNodeController(initContext ControllerInitContext, ctx *config.CompletedConfig, cloud cloudprovider.Interface, stopCh <-chan struct{}) (controller.Interface, bool, error) {
+func startCloudNodeController(ctx context.Context, initContext ControllerInitContext, completedConfig *config.CompletedConfig, cloud cloudprovider.Interface) (controller.Interface, bool, error) {
 	// Start the CloudNodeController
 	nodeController, err := cloudnodecontroller.NewCloudNodeController(
-		ctx.SharedInformers.Core().V1().Nodes(),
+		completedConfig.SharedInformers.Core().V1().Nodes(),
 		// cloud node controller uses existing cluster role from node-controller
-		ctx.ClientBuilder.ClientOrDie(initContext.ClientName),
+		completedConfig.ClientBuilder.ClientOrDie(initContext.ClientName),
 		cloud,
-		ctx.ComponentConfig.NodeStatusUpdateFrequency.Duration,
+		completedConfig.ComponentConfig.NodeStatusUpdateFrequency.Duration,
 	)
 	if err != nil {
 		klog.Warningf("failed to start cloud node controller: %s", err)
 		return nil, false, nil
 	}
 
-	go nodeController.Run(stopCh)
+	go nodeController.Run(ctx.Done())
 
 	return nil, true, nil
 }
 
-func startCloudNodeLifecycleController(initContext ControllerInitContext, ctx *config.CompletedConfig, cloud cloudprovider.Interface, stopCh <-chan struct{}) (controller.Interface, bool, error) {
+func startCloudNodeLifecycleController(ctx context.Context, initContext ControllerInitContext, completedConfig *config.CompletedConfig, cloud cloudprovider.Interface) (controller.Interface, bool, error) {
 	// Start the cloudNodeLifecycleController
 	cloudNodeLifecycleController, err := cloudnodelifecyclecontroller.NewCloudNodeLifecycleController(
-		ctx.SharedInformers.Core().V1().Nodes(),
+		completedConfig.SharedInformers.Core().V1().Nodes(),
 		// cloud node lifecycle controller uses existing cluster role from node-controller
-		ctx.ClientBuilder.ClientOrDie(initContext.ClientName),
+		completedConfig.ClientBuilder.ClientOrDie(initContext.ClientName),
 		cloud,
-		ctx.ComponentConfig.KubeCloudShared.NodeMonitorPeriod.Duration,
+		completedConfig.ComponentConfig.KubeCloudShared.NodeMonitorPeriod.Duration,
 	)
 	if err != nil {
 		klog.Warningf("failed to start cloud node lifecycle controller: %s", err)
 		return nil, false, nil
 	}
 
-	go cloudNodeLifecycleController.Run(stopCh)
+	go cloudNodeLifecycleController.Run(ctx)
 
 	return nil, true, nil
 }
 
-func startServiceController(initContext ControllerInitContext, ctx *config.CompletedConfig, cloud cloudprovider.Interface, stopCh <-chan struct{}) (controller.Interface, bool, error) {
+func startServiceController(ctx context.Context, initContext ControllerInitContext, completedConfig *config.CompletedConfig, cloud cloudprovider.Interface) (controller.Interface, bool, error) {
 	// Start the service controller
 	serviceController, err := servicecontroller.New(
 		cloud,
-		ctx.ClientBuilder.ClientOrDie(initContext.ClientName),
-		ctx.SharedInformers.Core().V1().Services(),
-		ctx.SharedInformers.Core().V1().Nodes(),
-		ctx.ComponentConfig.KubeCloudShared.ClusterName,
+		completedConfig.ClientBuilder.ClientOrDie(initContext.ClientName),
+		completedConfig.SharedInformers.Core().V1().Services(),
+		completedConfig.SharedInformers.Core().V1().Nodes(),
+		completedConfig.ComponentConfig.KubeCloudShared.ClusterName,
 		utilfeature.DefaultFeatureGate,
 	)
 	if err != nil {
@@ -93,14 +94,14 @@ func startServiceController(initContext ControllerInitContext, ctx *config.Compl
 		return nil, false, nil
 	}
 
-	go serviceController.Run(stopCh, int(ctx.ComponentConfig.ServiceController.ConcurrentServiceSyncs))
+	go serviceController.Run(ctx, int(completedConfig.ComponentConfig.ServiceController.ConcurrentServiceSyncs))
 
 	return nil, true, nil
 }
 
-func startRouteController(initContext ControllerInitContext, ctx *config.CompletedConfig, cloud cloudprovider.Interface, stopCh <-chan struct{}) (controller.Interface, bool, error) {
-	if !ctx.ComponentConfig.KubeCloudShared.ConfigureCloudRoutes {
-		klog.Infof("Will not configure cloud provider routes, --configure-cloud-routes: %v", ctx.ComponentConfig.KubeCloudShared.ConfigureCloudRoutes)
+func startRouteController(ctx context.Context, initContext ControllerInitContext, completedConfig *config.CompletedConfig, cloud cloudprovider.Interface) (controller.Interface, bool, error) {
+	if !completedConfig.ComponentConfig.KubeCloudShared.ConfigureCloudRoutes {
+		klog.Infof("Will not configure cloud provider routes, --configure-cloud-routes: %v", completedConfig.ComponentConfig.KubeCloudShared.ConfigureCloudRoutes)
 		return nil, false, nil
 	}
 
@@ -112,7 +113,7 @@ func startRouteController(initContext ControllerInitContext, ctx *config.Complet
 	}
 
 	// failure: bad cidrs in config
-	clusterCIDRs, dualStack, err := processCIDRs(ctx.ComponentConfig.KubeCloudShared.ClusterCIDR)
+	clusterCIDRs, dualStack, err := processCIDRs(completedConfig.ComponentConfig.KubeCloudShared.ClusterCIDR)
 	if err != nil {
 		return nil, false, err
 	}
@@ -134,12 +135,12 @@ func startRouteController(initContext ControllerInitContext, ctx *config.Complet
 
 	routeController := routecontroller.New(
 		routes,
-		ctx.ClientBuilder.ClientOrDie(initContext.ClientName),
-		ctx.SharedInformers.Core().V1().Nodes(),
-		ctx.ComponentConfig.KubeCloudShared.ClusterName,
+		completedConfig.ClientBuilder.ClientOrDie(initContext.ClientName),
+		completedConfig.SharedInformers.Core().V1().Nodes(),
+		completedConfig.ComponentConfig.KubeCloudShared.ClusterName,
 		clusterCIDRs,
 	)
-	go routeController.Run(stopCh, ctx.ComponentConfig.KubeCloudShared.RouteReconciliationPeriod.Duration)
+	go routeController.Run(ctx, completedConfig.ComponentConfig.KubeCloudShared.RouteReconciliationPeriod.Duration)
 
 	return nil, true, nil
 }

--- a/staging/src/k8s.io/cloud-provider/controllers/nodelifecycle/node_lifecycle_controller.go
+++ b/staging/src/k8s.io/cloud-provider/controllers/nodelifecycle/node_lifecycle_controller.go
@@ -103,7 +103,7 @@ func NewCloudNodeLifecycleController(
 
 // Run starts the main loop for this controller. Run is blocking so should
 // be called via a goroutine
-func (c *CloudNodeLifecycleController) Run(stopCh <-chan struct{}) {
+func (c *CloudNodeLifecycleController) Run(ctx context.Context) {
 	defer utilruntime.HandleCrash()
 
 	// The following loops run communicate with the APIServer with a worst case complexity
@@ -112,13 +112,13 @@ func (c *CloudNodeLifecycleController) Run(stopCh <-chan struct{}) {
 
 	// Start a loop to periodically check if any nodes have been
 	// deleted or shutdown from the cloudprovider
-	wait.Until(c.MonitorNodes, c.nodeMonitorPeriod, stopCh)
+	wait.UntilWithContext(ctx, c.MonitorNodes, c.nodeMonitorPeriod)
 }
 
 // MonitorNodes checks to see if nodes in the cluster have been deleted
 // or shutdown. If deleted, it deletes the node resource. If shutdown it
 // applies a shutdown taint to the node
-func (c *CloudNodeLifecycleController) MonitorNodes() {
+func (c *CloudNodeLifecycleController) MonitorNodes(ctx context.Context) {
 	nodes, err := c.nodeLister.List(labels.Everything())
 	if err != nil {
 		klog.Errorf("error listing nodes from cache: %s", err)
@@ -143,7 +143,7 @@ func (c *CloudNodeLifecycleController) MonitorNodes() {
 
 		// At this point the node has NotReady status, we need to check if the node has been removed
 		// from the cloud provider. If node cannot be found in cloudprovider, then delete the node
-		exists, err := ensureNodeExistsByProviderID(context.TODO(), c.cloud, node)
+		exists, err := ensureNodeExistsByProviderID(ctx, c.cloud, node)
 		if err != nil {
 			klog.Errorf("error checking if node %s exists: %v", node.Name, err)
 			continue
@@ -164,14 +164,14 @@ func (c *CloudNodeLifecycleController) MonitorNodes() {
 			c.recorder.Eventf(ref, v1.EventTypeNormal, deleteNodeEvent,
 				"Deleting node %s because it does not exist in the cloud provider", node.Name)
 
-			if err := c.kubeClient.CoreV1().Nodes().Delete(context.TODO(), node.Name, metav1.DeleteOptions{}); err != nil {
+			if err := c.kubeClient.CoreV1().Nodes().Delete(ctx, node.Name, metav1.DeleteOptions{}); err != nil {
 				klog.Errorf("unable to delete node %q: %v", node.Name, err)
 			}
 		} else {
 			// Node exists. We need to check this to get taint working in similar in all cloudproviders
 			// current problem is that shutdown nodes are not working in similar way ie. all cloudproviders
 			// does not delete node from kubernetes cluster when instance it is shutdown see issue #46442
-			shutdown, err := shutdownInCloudProvider(context.TODO(), c.cloud, node)
+			shutdown, err := shutdownInCloudProvider(ctx, c.cloud, node)
 			if err != nil {
 				klog.Errorf("error checking if node %s is shutdown: %v", node.Name, err)
 			}

--- a/staging/src/k8s.io/cloud-provider/controllers/nodelifecycle/node_lifecycle_controller_test.go
+++ b/staging/src/k8s.io/cloud-provider/controllers/nodelifecycle/node_lifecycle_controller_test.go
@@ -504,6 +504,8 @@ func Test_NodesDeleted(t *testing.T) {
 
 	for _, testcase := range testcases {
 		t.Run(testcase.name, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
 			clientset := fake.NewSimpleClientset(testcase.existingNode)
 			informer := informers.NewSharedInformerFactory(clientset, time.Second)
 			nodeInformer := informer.Core().V1().Nodes()
@@ -523,9 +525,9 @@ func Test_NodesDeleted(t *testing.T) {
 
 			w := eventBroadcaster.StartLogging(klog.Infof)
 			defer w.Stop()
-			cloudNodeLifecycleController.MonitorNodes()
+			cloudNodeLifecycleController.MonitorNodes(ctx)
 
-			updatedNode, err := clientset.CoreV1().Nodes().Get(context.TODO(), testcase.existingNode.Name, metav1.GetOptions{})
+			updatedNode, err := clientset.CoreV1().Nodes().Get(ctx, testcase.existingNode.Name, metav1.GetOptions{})
 			if testcase.expectedDeleted != apierrors.IsNotFound(err) {
 				t.Fatalf("unexpected error happens when getting the node: %v", err)
 			}
@@ -732,7 +734,7 @@ func Test_NodesShutdown(t *testing.T) {
 
 			w := eventBroadcaster.StartLogging(klog.Infof)
 			defer w.Stop()
-			cloudNodeLifecycleController.MonitorNodes()
+			cloudNodeLifecycleController.MonitorNodes(context.TODO())
 
 			updatedNode, err := clientset.CoreV1().Nodes().Get(context.TODO(), testcase.existingNode.Name, metav1.GetOptions{})
 			if testcase.expectedDeleted != apierrors.IsNotFound(err) {

--- a/staging/src/k8s.io/cloud-provider/controllers/route/route_controller.go
+++ b/staging/src/k8s.io/cloud-provider/controllers/route/route_controller.go
@@ -95,13 +95,13 @@ func New(routes cloudprovider.Routes, kubeClient clientset.Interface, nodeInform
 	return rc
 }
 
-func (rc *RouteController) Run(stopCh <-chan struct{}, syncPeriod time.Duration) {
+func (rc *RouteController) Run(ctx context.Context, syncPeriod time.Duration) {
 	defer utilruntime.HandleCrash()
 
 	klog.Info("Starting route controller")
 	defer klog.Info("Shutting down route controller")
 
-	if !cache.WaitForNamedCacheSync("route", stopCh, rc.nodeListerSynced) {
+	if !cache.WaitForNamedCacheSync("route", ctx.Done(), rc.nodeListerSynced) {
 		return
 	}
 
@@ -115,16 +115,16 @@ func (rc *RouteController) Run(stopCh <-chan struct{}, syncPeriod time.Duration)
 	// We should have a watch on node and if we observe a new node (with CIDR?)
 	// trigger reconciliation for that node.
 	go wait.NonSlidingUntil(func() {
-		if err := rc.reconcileNodeRoutes(); err != nil {
+		if err := rc.reconcileNodeRoutes(ctx); err != nil {
 			klog.Errorf("Couldn't reconcile node routes: %v", err)
 		}
-	}, syncPeriod, stopCh)
+	}, syncPeriod, ctx.Done())
 
-	<-stopCh
+	<-ctx.Done()
 }
 
-func (rc *RouteController) reconcileNodeRoutes() error {
-	routeList, err := rc.routes.ListRoutes(context.TODO(), rc.clusterName)
+func (rc *RouteController) reconcileNodeRoutes(ctx context.Context) error {
+	routeList, err := rc.routes.ListRoutes(ctx, rc.clusterName)
 	if err != nil {
 		return fmt.Errorf("error listing routes: %v", err)
 	}
@@ -132,10 +132,10 @@ func (rc *RouteController) reconcileNodeRoutes() error {
 	if err != nil {
 		return fmt.Errorf("error listing nodes: %v", err)
 	}
-	return rc.reconcile(nodes, routeList)
+	return rc.reconcile(ctx, nodes, routeList)
 }
 
-func (rc *RouteController) reconcile(nodes []*v1.Node, routes []*cloudprovider.Route) error {
+func (rc *RouteController) reconcile(ctx context.Context, nodes []*v1.Node, routes []*cloudprovider.Route) error {
 	var l sync.Mutex
 	// for each node a map of podCIDRs and their created status
 	nodeRoutesStatuses := make(map[types.NodeName]map[string]bool)
@@ -192,7 +192,7 @@ func (rc *RouteController) reconcile(nodes []*v1.Node, routes []*cloudprovider.R
 					// CreateRoute calls in flight.
 					rateLimiter <- struct{}{}
 					klog.Infof("Creating route for node %s %s with hint %s, throttled %v", nodeName, route.DestinationCIDR, nameHint, time.Since(startTime))
-					err := rc.routes.CreateRoute(context.TODO(), rc.clusterName, nameHint, route)
+					err := rc.routes.CreateRoute(ctx, rc.clusterName, nameHint, route)
 					<-rateLimiter
 					if err != nil {
 						msg := fmt.Sprintf("Could not create route %s %s for node %s after %v: %v", nameHint, route.DestinationCIDR, nodeName, time.Since(startTime), err)
@@ -245,7 +245,7 @@ func (rc *RouteController) reconcile(nodes []*v1.Node, routes []*cloudprovider.R
 					// respect the rate limiter
 					rateLimiter <- struct{}{}
 					klog.Infof("Deleting route %s %s", route.Name, route.DestinationCIDR)
-					if err := rc.routes.DeleteRoute(context.TODO(), rc.clusterName, route); err != nil {
+					if err := rc.routes.DeleteRoute(ctx, rc.clusterName, route); err != nil {
 						klog.Errorf("Could not delete route %s %s after %v: %v", route.Name, route.DestinationCIDR, time.Since(startTime), err)
 					} else {
 						klog.Infof("Deleted route %s %s after %v", route.Name, route.DestinationCIDR, time.Since(startTime))

--- a/staging/src/k8s.io/cloud-provider/controllers/service/controller.go
+++ b/staging/src/k8s.io/cloud-provider/controllers/service/controller.go
@@ -223,25 +223,25 @@ func (s *Controller) enqueueService(obj interface{}) {
 //
 // It's an error to call Run() more than once for a given ServiceController
 // object.
-func (s *Controller) Run(stopCh <-chan struct{}, workers int) {
+func (s *Controller) Run(ctx context.Context, workers int) {
 	defer runtime.HandleCrash()
 	defer s.queue.ShutDown()
 
 	klog.Info("Starting service controller")
 	defer klog.Info("Shutting down service controller")
 
-	if !cache.WaitForNamedCacheSync("service", stopCh, s.serviceListerSynced, s.nodeListerSynced) {
+	if !cache.WaitForNamedCacheSync("service", ctx.Done(), s.serviceListerSynced, s.nodeListerSynced) {
 		return
 	}
 
 	for i := 0; i < workers; i++ {
-		go wait.Until(s.worker, time.Second, stopCh)
+		go wait.UntilWithContext(ctx, s.worker, time.Second)
 	}
 
-	go s.nodeSyncLoop(workers)
-	go wait.Until(s.triggerNodeSync, nodeSyncPeriod, stopCh)
+	go s.nodeSyncLoop(ctx, workers)
+	go wait.Until(s.triggerNodeSync, nodeSyncPeriod, ctx.Done())
 
-	<-stopCh
+	<-ctx.Done()
 }
 
 // triggerNodeSync triggers a nodeSync asynchronously
@@ -276,29 +276,29 @@ func (s *Controller) triggerNodeSync() {
 
 // worker runs a worker thread that just dequeues items, processes them, and marks them done.
 // It enforces that the syncHandler is never invoked concurrently with the same key.
-func (s *Controller) worker() {
-	for s.processNextWorkItem() {
+func (s *Controller) worker(ctx context.Context) {
+	for s.processNextWorkItem(ctx) {
 	}
 }
 
 // nodeSyncLoop takes nodeSync signal and triggers nodeSync
-func (s *Controller) nodeSyncLoop(workers int) {
+func (s *Controller) nodeSyncLoop(ctx context.Context, workers int) {
 	klog.V(4).Info("nodeSyncLoop Started")
 	for range s.nodeSyncCh {
 		klog.V(4).Info("nodeSync has been triggered")
-		s.nodeSyncInternal(workers)
+		s.nodeSyncInternal(ctx, workers)
 	}
 	klog.V(2).Info("s.nodeSyncCh is closed. Exiting nodeSyncLoop")
 }
 
-func (s *Controller) processNextWorkItem() bool {
+func (s *Controller) processNextWorkItem(ctx context.Context) bool {
 	key, quit := s.queue.Get()
 	if quit {
 		return false
 	}
 	defer s.queue.Done(key)
 
-	err := s.syncService(key.(string))
+	err := s.syncService(ctx, key.(string))
 	if err == nil {
 		s.queue.Forget(key)
 		return true
@@ -325,7 +325,7 @@ func (s *Controller) init() error {
 
 // processServiceCreateOrUpdate operates loadbalancers for the incoming service accordingly.
 // Returns an error if processing the service update failed.
-func (s *Controller) processServiceCreateOrUpdate(service *v1.Service, key string) error {
+func (s *Controller) processServiceCreateOrUpdate(ctx context.Context, service *v1.Service, key string) error {
 	// TODO(@MrHohn): Remove the cache once we get rid of the non-finalizer deletion
 	// path. Ref https://github.com/kubernetes/enhancements/issues/980.
 	cachedService := s.cache.getOrCreate(key)
@@ -333,14 +333,14 @@ func (s *Controller) processServiceCreateOrUpdate(service *v1.Service, key strin
 		// This happens only when a service is deleted and re-created
 		// in a short period, which is only possible when it doesn't
 		// contain finalizer.
-		if err := s.processLoadBalancerDelete(cachedService.state, key); err != nil {
+		if err := s.processLoadBalancerDelete(ctx, cachedService.state, key); err != nil {
 			return err
 		}
 	}
 	// Always cache the service, we need the info for service deletion in case
 	// when load balancer cleanup is not handled via finalizer.
 	cachedService.state = service
-	op, err := s.syncLoadBalancerIfNeeded(service, key)
+	op, err := s.syncLoadBalancerIfNeeded(ctx, service, key)
 	if err != nil {
 		s.eventRecorder.Eventf(service, v1.EventTypeWarning, "SyncLoadBalancerFailed", "Error syncing load balancer: %v", err)
 		return err
@@ -363,7 +363,7 @@ const (
 // syncLoadBalancerIfNeeded ensures that service's status is synced up with loadbalancer
 // i.e. creates loadbalancer for service if requested and deletes loadbalancer if the service
 // doesn't want a loadbalancer no more. Returns whatever error occurred.
-func (s *Controller) syncLoadBalancerIfNeeded(service *v1.Service, key string) (loadBalancerOperation, error) {
+func (s *Controller) syncLoadBalancerIfNeeded(ctx context.Context, service *v1.Service, key string) (loadBalancerOperation, error) {
 	// Note: It is safe to just call EnsureLoadBalancer.  But, on some clouds that requires a delete & create,
 	// which may involve service interruption.  Also, we would like user-friendly events.
 
@@ -377,14 +377,14 @@ func (s *Controller) syncLoadBalancerIfNeeded(service *v1.Service, key string) (
 		// Delete the load balancer if service no longer wants one, or if service needs cleanup.
 		op = deleteLoadBalancer
 		newStatus = &v1.LoadBalancerStatus{}
-		_, exists, err := s.balancer.GetLoadBalancer(context.TODO(), s.clusterName, service)
+		_, exists, err := s.balancer.GetLoadBalancer(ctx, s.clusterName, service)
 		if err != nil {
 			return op, fmt.Errorf("failed to check if load balancer exists before cleanup: %v", err)
 		}
 		if exists {
 			klog.V(2).Infof("Deleting existing load balancer for service %s", key)
 			s.eventRecorder.Event(service, v1.EventTypeNormal, "DeletingLoadBalancer", "Deleting load balancer")
-			if err := s.balancer.EnsureLoadBalancerDeleted(context.TODO(), s.clusterName, service); err != nil {
+			if err := s.balancer.EnsureLoadBalancerDeleted(ctx, s.clusterName, service); err != nil {
 				return op, fmt.Errorf("failed to delete load balancer: %v", err)
 			}
 		}
@@ -404,7 +404,7 @@ func (s *Controller) syncLoadBalancerIfNeeded(service *v1.Service, key string) (
 		if err := s.addFinalizer(service); err != nil {
 			return op, fmt.Errorf("failed to add load balancer cleanup finalizer: %v", err)
 		}
-		newStatus, err = s.ensureLoadBalancer(service)
+		newStatus, err = s.ensureLoadBalancer(ctx, service)
 		if err != nil {
 			if err == cloudprovider.ImplementedElsewhere {
 				// ImplementedElsewhere indicates that the ensureLoadBalancer is a nop and the
@@ -435,7 +435,7 @@ func (s *Controller) syncLoadBalancerIfNeeded(service *v1.Service, key string) (
 	return op, nil
 }
 
-func (s *Controller) ensureLoadBalancer(service *v1.Service) (*v1.LoadBalancerStatus, error) {
+func (s *Controller) ensureLoadBalancer(ctx context.Context, service *v1.Service) (*v1.LoadBalancerStatus, error) {
 	nodes, err := listWithPredicate(s.nodeLister, s.getNodeConditionPredicate())
 	if err != nil {
 		return nil, err
@@ -449,7 +449,7 @@ func (s *Controller) ensureLoadBalancer(service *v1.Service) (*v1.LoadBalancerSt
 	// - Only one protocol supported per service
 	// - Not all cloud providers support all protocols and the next step is expected to return
 	//   an error for unsupported protocols
-	return s.balancer.EnsureLoadBalancer(context.TODO(), s.clusterName, service, nodes)
+	return s.balancer.EnsureLoadBalancer(ctx, s.clusterName, service, nodes)
 }
 
 // ListKeys implements the interface required by DeltaFIFO to list the keys we
@@ -713,7 +713,7 @@ func nodeReadyConditionStatus(node *v1.Node) v1.ConditionStatus {
 
 // nodeSyncInternal handles updating the hosts pointed to by all load
 // balancers whenever the set of nodes in the cluster changes.
-func (s *Controller) nodeSyncInternal(workers int) {
+func (s *Controller) nodeSyncInternal(ctx context.Context, workers int) {
 	startTime := time.Now()
 	defer func() {
 		latency := time.Since(startTime).Seconds()
@@ -724,7 +724,7 @@ func (s *Controller) nodeSyncInternal(workers int) {
 	if !s.needFullSyncAndUnmark() {
 		// The set of nodes in the cluster hasn't changed, but we can retry
 		// updating any services that we failed to update last time around.
-		s.servicesToUpdate = s.updateLoadBalancerHosts(s.servicesToUpdate, workers)
+		s.servicesToUpdate = s.updateLoadBalancerHosts(ctx, s.servicesToUpdate, workers)
 		return
 	}
 	klog.V(2).Infof("Syncing backends for all LB services.")
@@ -733,7 +733,7 @@ func (s *Controller) nodeSyncInternal(workers int) {
 	// round.
 	s.servicesToUpdate = s.cache.allServices()
 	numServices := len(s.servicesToUpdate)
-	s.servicesToUpdate = s.updateLoadBalancerHosts(s.servicesToUpdate, workers)
+	s.servicesToUpdate = s.updateLoadBalancerHosts(ctx, s.servicesToUpdate, workers)
 	klog.V(2).Infof("Successfully updated %d out of %d load balancers to direct traffic to the updated set of nodes",
 		numServices-len(s.servicesToUpdate), numServices)
 }
@@ -761,7 +761,7 @@ func (s *Controller) nodeSyncService(svc *v1.Service) bool {
 // updateLoadBalancerHosts updates all existing load balancers so that
 // they will match the latest list of nodes with input number of workers.
 // Returns the list of services that couldn't be updated.
-func (s *Controller) updateLoadBalancerHosts(services []*v1.Service, workers int) (servicesToRetry []*v1.Service) {
+func (s *Controller) updateLoadBalancerHosts(ctx context.Context, services []*v1.Service, workers int) (servicesToRetry []*v1.Service) {
 	klog.V(4).Infof("Running updateLoadBalancerHosts(len(services)==%d, workers==%d)", len(services), workers)
 
 	// lock for servicesToRetry
@@ -775,7 +775,7 @@ func (s *Controller) updateLoadBalancerHosts(services []*v1.Service, workers int
 		servicesToRetry = append(servicesToRetry, services[piece])
 	}
 
-	workqueue.ParallelizeUntil(context.TODO(), workers, len(services), doWork)
+	workqueue.ParallelizeUntil(ctx, workers, len(services), doWork)
 	klog.V(4).Infof("Finished updateLoadBalancerHosts")
 	return servicesToRetry
 }
@@ -831,7 +831,7 @@ func loadBalancerIPsAreEqual(oldService, newService *v1.Service) bool {
 // syncService will sync the Service with the given key if it has had its expectations fulfilled,
 // meaning it did not expect to see any more of its pods created or deleted. This function is not meant to be
 // invoked concurrently with the same key.
-func (s *Controller) syncService(key string) error {
+func (s *Controller) syncService(ctx context.Context, key string) error {
 	startTime := time.Now()
 	defer func() {
 		klog.V(4).Infof("Finished syncing service %q (%v)", key, time.Since(startTime))
@@ -847,17 +847,17 @@ func (s *Controller) syncService(key string) error {
 	switch {
 	case errors.IsNotFound(err):
 		// service absence in store means watcher caught the deletion, ensure LB info is cleaned
-		err = s.processServiceDeletion(key)
+		err = s.processServiceDeletion(ctx, key)
 	case err != nil:
 		runtime.HandleError(fmt.Errorf("Unable to retrieve service %v from store: %v", key, err))
 	default:
-		err = s.processServiceCreateOrUpdate(service, key)
+		err = s.processServiceCreateOrUpdate(ctx, service, key)
 	}
 
 	return err
 }
 
-func (s *Controller) processServiceDeletion(key string) error {
+func (s *Controller) processServiceDeletion(ctx context.Context, key string) error {
 	cachedService, ok := s.cache.get(key)
 	if !ok {
 		// Cache does not contains the key means:
@@ -867,20 +867,20 @@ func (s *Controller) processServiceDeletion(key string) error {
 		return nil
 	}
 	klog.V(2).Infof("Service %v has been deleted. Attempting to cleanup load balancer resources", key)
-	if err := s.processLoadBalancerDelete(cachedService.state, key); err != nil {
+	if err := s.processLoadBalancerDelete(ctx, cachedService.state, key); err != nil {
 		return err
 	}
 	s.cache.delete(key)
 	return nil
 }
 
-func (s *Controller) processLoadBalancerDelete(service *v1.Service, key string) error {
+func (s *Controller) processLoadBalancerDelete(ctx context.Context, service *v1.Service, key string) error {
 	// delete load balancer info only if the service type is LoadBalancer
 	if !wantsLoadBalancer(service) {
 		return nil
 	}
 	s.eventRecorder.Event(service, v1.EventTypeNormal, "DeletingLoadBalancer", "Deleting load balancer")
-	if err := s.balancer.EnsureLoadBalancerDeleted(context.TODO(), s.clusterName, service); err != nil {
+	if err := s.balancer.EnsureLoadBalancerDeleted(ctx, s.clusterName, service); err != nil {
 		s.eventRecorder.Eventf(service, v1.EventTypeWarning, "DeleteLoadBalancerFailed", "Error deleting load balancer: %v", err)
 		return err
 	}

--- a/staging/src/k8s.io/cloud-provider/controllers/service/controller_test.go
+++ b/staging/src/k8s.io/cloud-provider/controllers/service/controller_test.go
@@ -368,15 +368,17 @@ func TestSyncLoadBalancerIfNeeded(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
 			controller, cloud, client := newController()
 			cloud.Exists = tc.lbExists
 			key := fmt.Sprintf("%s/%s", tc.service.Namespace, tc.service.Name)
-			if _, err := client.CoreV1().Services(tc.service.Namespace).Create(context.TODO(), tc.service, metav1.CreateOptions{}); err != nil {
+			if _, err := client.CoreV1().Services(tc.service.Namespace).Create(ctx, tc.service, metav1.CreateOptions{}); err != nil {
 				t.Fatalf("Failed to prepare service %s for testing: %v", key, err)
 			}
 			client.ClearActions()
 
-			op, err := controller.syncLoadBalancerIfNeeded(tc.service, key)
+			op, err := controller.syncLoadBalancerIfNeeded(ctx, tc.service, key)
 			if err != nil {
 				t.Errorf("Got error: %v, want nil", err)
 			}
@@ -548,10 +550,12 @@ func TestUpdateNodesInExternalLoadBalancer(t *testing.T) {
 	}
 	for _, item := range table {
 		t.Run(item.desc, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
 			controller, cloud, _ := newController()
 			controller.nodeLister = newFakeNodeLister(nil, nodes...)
 
-			if servicesToRetry := controller.updateLoadBalancerHosts(item.services, item.workers); servicesToRetry != nil {
+			if servicesToRetry := controller.updateLoadBalancerHosts(ctx, item.services, item.workers); servicesToRetry != nil {
 				t.Errorf("for case %q, unexpected servicesToRetry: %v", item.desc, servicesToRetry)
 			}
 			compareUpdateCalls(t, item.expectedUpdateCalls, cloud.UpdateCalls)
@@ -638,8 +642,10 @@ func TestNodeChangesInExternalLoadBalancer(t *testing.T) {
 		},
 	} {
 		t.Run(tc.desc, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
 			controller.nodeLister = newFakeNodeLister(tc.nodeListerErr, tc.nodes...)
-			servicesToRetry := controller.updateLoadBalancerHosts(services, tc.worker)
+			servicesToRetry := controller.updateLoadBalancerHosts(ctx, services, tc.worker)
 			compareServiceList(t, tc.expectedRetryServices, servicesToRetry)
 			compareUpdateCalls(t, tc.expectedUpdateCalls, cloud.UpdateCalls)
 			cloud.UpdateCalls = []fakecloud.UpdateBalancerCall{}
@@ -772,11 +778,13 @@ func TestProcessServiceCreateOrUpdate(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
 		newSvc := tc.updateFn(tc.svc)
-		if _, err := client.CoreV1().Services(tc.svc.Namespace).Create(context.TODO(), tc.svc, metav1.CreateOptions{}); err != nil {
+		if _, err := client.CoreV1().Services(tc.svc.Namespace).Create(ctx, tc.svc, metav1.CreateOptions{}); err != nil {
 			t.Fatalf("Failed to prepare service %s for testing: %v", tc.key, err)
 		}
-		obtErr := controller.processServiceCreateOrUpdate(newSvc, tc.key)
+		obtErr := controller.processServiceCreateOrUpdate(ctx, newSvc, tc.key)
 		if err := tc.expectedFn(newSvc, obtErr); err != nil {
 			t.Errorf("%v processServiceCreateOrUpdate() %v", tc.testName, err)
 		}
@@ -810,6 +818,8 @@ func TestProcessServiceCreateOrUpdateK8sError(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
 			svc := newService(svcName, types.UID("123"), v1.ServiceTypeLoadBalancer)
 			// Preset finalizer so k8s error only happens when patching status.
 			svc.Finalizers = []string{servicehelper.LoadBalancerCleanupFinalizer}
@@ -818,7 +828,7 @@ func TestProcessServiceCreateOrUpdateK8sError(t *testing.T) {
 				return true, nil, tc.k8sErr
 			})
 
-			if err := controller.processServiceCreateOrUpdate(svc, svcName); !reflect.DeepEqual(err, tc.expectErr) {
+			if err := controller.processServiceCreateOrUpdate(ctx, svc, svcName); !reflect.DeepEqual(err, tc.expectErr) {
 				t.Fatalf("processServiceCreateOrUpdate() = %v, want %v", err, tc.expectErr)
 			}
 			if tc.expectErr == nil {
@@ -905,9 +915,11 @@ func TestSyncService(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
 
 		tc.updateFn()
-		obtainedErr := controller.syncService(tc.key)
+		obtainedErr := controller.syncService(ctx, tc.key)
 
 		//expected matches obtained ??.
 		if exp := tc.expectedFn(obtainedErr); exp != nil {
@@ -991,10 +1003,13 @@ func TestProcessServiceDeletion(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
 		//Create a new controller.
 		controller, cloud, _ = newController()
 		tc.updateFn(controller)
-		obtainedErr := controller.processServiceDeletion(svcKey)
+		obtainedErr := controller.processServiceDeletion(ctx, svcKey)
 		if err := tc.expectedFn(obtainedErr); err != nil {
 			t.Errorf("%v processServiceDeletion() %v", tc.testName, err)
 		}
@@ -1388,11 +1403,13 @@ func TestAddFinalizer(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
 			c := fake.NewSimpleClientset()
 			s := &Controller{
 				kubeClient: c,
 			}
-			if _, err := s.kubeClient.CoreV1().Services(tc.svc.Namespace).Create(context.TODO(), tc.svc, metav1.CreateOptions{}); err != nil {
+			if _, err := s.kubeClient.CoreV1().Services(tc.svc.Namespace).Create(ctx, tc.svc, metav1.CreateOptions{}); err != nil {
 				t.Fatalf("Failed to prepare service for testing: %v", err)
 			}
 			if err := s.addFinalizer(tc.svc); err != nil {
@@ -1442,11 +1459,13 @@ func TestRemoveFinalizer(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
 			c := fake.NewSimpleClientset()
 			s := &Controller{
 				kubeClient: c,
 			}
-			if _, err := s.kubeClient.CoreV1().Services(tc.svc.Namespace).Create(context.TODO(), tc.svc, metav1.CreateOptions{}); err != nil {
+			if _, err := s.kubeClient.CoreV1().Services(tc.svc.Namespace).Create(ctx, tc.svc, metav1.CreateOptions{}); err != nil {
 				t.Fatalf("Failed to prepare service for testing: %v", err)
 			}
 			if err := s.removeFinalizer(tc.svc); err != nil {
@@ -1542,11 +1561,13 @@ func TestPatchStatus(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
 			c := fake.NewSimpleClientset()
 			s := &Controller{
 				kubeClient: c,
 			}
-			if _, err := s.kubeClient.CoreV1().Services(tc.svc.Namespace).Create(context.TODO(), tc.svc, metav1.CreateOptions{}); err != nil {
+			if _, err := s.kubeClient.CoreV1().Services(tc.svc.Namespace).Create(ctx, tc.svc, metav1.CreateOptions{}); err != nil {
 				t.Fatalf("Failed to prepare service for testing: %v", err)
 			}
 			if err := s.patchStatus(tc.svc, &tc.svc.Status.LoadBalancer, tc.newStatus); err != nil {

--- a/test/integration/dualstack/dualstack_endpoints_test.go
+++ b/test/integration/dualstack/dualstack_endpoints_test.go
@@ -114,13 +114,13 @@ func TestDualStackEndpoints(t *testing.T) {
 		client,
 		1*time.Second)
 
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 	// Start informer and controllers
-	stopCh := make(chan struct{})
-	defer close(stopCh)
-	informers.Start(stopCh)
+	informers.Start(ctx.Done())
 	// use only one worker to serialize the updates
-	go epController.Run(1, stopCh)
-	go epsController.Run(1, stopCh)
+	go epController.Run(ctx, 1)
+	go epsController.Run(1, ctx.Done())
 
 	var testcases = []struct {
 		name           string

--- a/test/integration/garbagecollector/garbage_collector_test.go
+++ b/test/integration/garbagecollector/garbage_collector_test.go
@@ -258,9 +258,9 @@ func setupWithServer(t *testing.T, result *kubeapiservertesting.TestServer, work
 		t.Fatalf("failed to create garbage collector: %v", err)
 	}
 
-	stopCh := make(chan struct{})
+	ctx, cancel := context.WithCancel(context.Background())
 	tearDown := func() {
-		close(stopCh)
+		cancel()
 		result.TearDownFn()
 	}
 	syncPeriod := 5 * time.Second
@@ -270,9 +270,9 @@ func setupWithServer(t *testing.T, result *kubeapiservertesting.TestServer, work
 			// client. This is a leaky abstraction and assumes behavior about the REST
 			// mapper, but we'll deal with it for now.
 			restMapper.Reset()
-		}, syncPeriod, stopCh)
-		go gc.Run(workers, stopCh)
-		go gc.Sync(clientSet.Discovery(), syncPeriod, stopCh)
+		}, syncPeriod, ctx.Done())
+		go gc.Run(ctx, workers)
+		go gc.Sync(clientSet.Discovery(), syncPeriod, ctx.Done())
 	}
 
 	if workerCount > 0 {

--- a/test/integration/node/lifecycle_test.go
+++ b/test/integration/node/lifecycle_test.go
@@ -141,6 +141,7 @@ func TestTaintBasedEvictions(t *testing.T) {
 
 			// Start NodeLifecycleController for taint.
 			nc, err := nodelifecycle.NewNodeLifecycleController(
+				testCtx.Ctx,
 				externalInformers.Coordination().V1().Leases(),
 				externalInformers.Core().V1().Pods(),
 				externalInformers.Core().V1().Nodes(),
@@ -167,7 +168,7 @@ func TestTaintBasedEvictions(t *testing.T) {
 			testutils.SyncInformerFactory(testCtx)
 
 			// Run all controllers
-			go nc.Run(testCtx.Ctx.Done())
+			go nc.Run(testCtx.Ctx)
 			go testCtx.Scheduler.Run(testCtx.Ctx)
 
 			nodeRes := v1.ResourceList{

--- a/test/integration/quota/quota_test.go
+++ b/test/integration/quota/quota_test.go
@@ -95,8 +95,8 @@ func TestQuota(t *testing.T) {
 	ns2 := framework.CreateTestingNamespace("non-quotaed", s, t)
 	defer framework.DeleteTestingNamespace(ns2, s, t)
 
-	controllerCh := make(chan struct{})
-	defer close(controllerCh)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 
 	informers := informers.NewSharedInformerFactory(clientset, controller.NoResyncPeriodFunc())
 	rm := replicationcontroller.NewReplicationManager(
@@ -106,7 +106,7 @@ func TestQuota(t *testing.T) {
 		replicationcontroller.BurstReplicas,
 	)
 	rm.SetEventRecorder(&record.FakeRecorder{})
-	go rm.Run(context.TODO(), 3)
+	go rm.Run(ctx, 3)
 
 	discoveryFunc := clientset.Discovery().ServerPreferredNamespacedResources
 	listerFuncForResource := generic.ListerFuncForResourceFunc(informers.ForResource)
@@ -127,13 +127,13 @@ func TestQuota(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected err: %v", err)
 	}
-	go resourceQuotaController.Run(2, controllerCh)
+	go resourceQuotaController.Run(ctx, 2)
 
 	// Periodically the quota controller to detect new resource types
-	go resourceQuotaController.Sync(discoveryFunc, 30*time.Second, controllerCh)
+	go resourceQuotaController.Sync(discoveryFunc, 30*time.Second, ctx.Done())
 
-	internalInformers.Start(controllerCh)
-	informers.Start(controllerCh)
+	internalInformers.Start(ctx.Done())
+	informers.Start(ctx.Done())
 	close(informersStarted)
 
 	startTime := time.Now()
@@ -326,8 +326,8 @@ func TestQuotaLimitedResourceDenial(t *testing.T) {
 	ns := framework.CreateTestingNamespace("quota", s, t)
 	defer framework.DeleteTestingNamespace(ns, s, t)
 
-	controllerCh := make(chan struct{})
-	defer close(controllerCh)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 
 	informers := informers.NewSharedInformerFactory(clientset, controller.NoResyncPeriodFunc())
 	rm := replicationcontroller.NewReplicationManager(
@@ -337,7 +337,7 @@ func TestQuotaLimitedResourceDenial(t *testing.T) {
 		replicationcontroller.BurstReplicas,
 	)
 	rm.SetEventRecorder(&record.FakeRecorder{})
-	go rm.Run(context.TODO(), 3)
+	go rm.Run(ctx, 3)
 
 	discoveryFunc := clientset.Discovery().ServerPreferredNamespacedResources
 	listerFuncForResource := generic.ListerFuncForResourceFunc(informers.ForResource)
@@ -358,13 +358,13 @@ func TestQuotaLimitedResourceDenial(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected err: %v", err)
 	}
-	go resourceQuotaController.Run(2, controllerCh)
+	go resourceQuotaController.Run(ctx, 2)
 
 	// Periodically the quota controller to detect new resource types
-	go resourceQuotaController.Sync(discoveryFunc, 30*time.Second, controllerCh)
+	go resourceQuotaController.Sync(discoveryFunc, 30*time.Second, ctx.Done())
 
-	externalInformers.Start(controllerCh)
-	informers.Start(controllerCh)
+	externalInformers.Start(ctx.Done())
+	informers.Start(ctx.Done())
 	close(informersStarted)
 
 	// try to create a pod
@@ -382,7 +382,7 @@ func TestQuotaLimitedResourceDenial(t *testing.T) {
 			},
 		},
 	}
-	if _, err := clientset.CoreV1().Pods(ns.Name).Create(context.TODO(), pod, metav1.CreateOptions{}); err == nil {
+	if _, err := clientset.CoreV1().Pods(ns.Name).Create(ctx, pod, metav1.CreateOptions{}); err == nil {
 		t.Fatalf("expected error for insufficient quota")
 	}
 
@@ -405,7 +405,7 @@ func TestQuotaLimitedResourceDenial(t *testing.T) {
 	// attempt to create a new pod once the quota is propagated
 	err = wait.PollImmediate(5*time.Second, time.Minute, func() (bool, error) {
 		// retry until we succeed (to allow time for all changes to propagate)
-		if _, err := clientset.CoreV1().Pods(ns.Name).Create(context.TODO(), pod, metav1.CreateOptions{}); err == nil {
+		if _, err := clientset.CoreV1().Pods(ns.Name).Create(ctx, pod, metav1.CreateOptions{}); err == nil {
 			return true, nil
 		}
 		return false, nil
@@ -456,8 +456,8 @@ func TestQuotaLimitService(t *testing.T) {
 	ns := framework.CreateTestingNamespace("quota", s, t)
 	defer framework.DeleteTestingNamespace(ns, s, t)
 
-	controllerCh := make(chan struct{})
-	defer close(controllerCh)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 
 	informers := informers.NewSharedInformerFactory(clientset, controller.NoResyncPeriodFunc())
 	rm := replicationcontroller.NewReplicationManager(
@@ -467,7 +467,7 @@ func TestQuotaLimitService(t *testing.T) {
 		replicationcontroller.BurstReplicas,
 	)
 	rm.SetEventRecorder(&record.FakeRecorder{})
-	go rm.Run(context.TODO(), 3)
+	go rm.Run(ctx, 3)
 
 	discoveryFunc := clientset.Discovery().ServerPreferredNamespacedResources
 	listerFuncForResource := generic.ListerFuncForResourceFunc(informers.ForResource)
@@ -488,13 +488,13 @@ func TestQuotaLimitService(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected err: %v", err)
 	}
-	go resourceQuotaController.Run(2, controllerCh)
+	go resourceQuotaController.Run(ctx, 2)
 
 	// Periodically the quota controller to detect new resource types
-	go resourceQuotaController.Sync(discoveryFunc, 30*time.Second, controllerCh)
+	go resourceQuotaController.Sync(discoveryFunc, 30*time.Second, ctx.Done())
 
-	externalInformers.Start(controllerCh)
-	informers.Start(controllerCh)
+	externalInformers.Start(ctx.Done())
+	informers.Start(ctx.Done())
 	close(informersStarted)
 
 	// now create a covering quota
@@ -517,14 +517,14 @@ func TestQuotaLimitService(t *testing.T) {
 
 	// Creating the first node port service should succeed
 	nodePortService := newService("np-svc", v1.ServiceTypeNodePort, true)
-	_, err = clientset.CoreV1().Services(ns.Name).Create(context.TODO(), nodePortService, metav1.CreateOptions{})
+	_, err = clientset.CoreV1().Services(ns.Name).Create(ctx, nodePortService, metav1.CreateOptions{})
 	if err != nil {
 		t.Errorf("creating first node port Service should not have returned error: %v", err)
 	}
 
 	// Creating the first loadbalancer service should succeed
 	lbServiceWithNodePort1 := newService("lb-svc-withnp1", v1.ServiceTypeLoadBalancer, true)
-	_, err = clientset.CoreV1().Services(ns.Name).Create(context.TODO(), lbServiceWithNodePort1, metav1.CreateOptions{})
+	_, err = clientset.CoreV1().Services(ns.Name).Create(ctx, lbServiceWithNodePort1, metav1.CreateOptions{})
 	if err != nil {
 		t.Errorf("creating first loadbalancer Service should not have returned error: %v", err)
 	}
@@ -543,7 +543,7 @@ func TestQuotaLimitService(t *testing.T) {
 
 	// Creating a loadbalancer Service without node ports should succeed
 	lbServiceWithoutNodePort1 := newService("lb-svc-wonp1", v1.ServiceTypeLoadBalancer, false)
-	_, err = clientset.CoreV1().Services(ns.Name).Create(context.TODO(), lbServiceWithoutNodePort1, metav1.CreateOptions{})
+	_, err = clientset.CoreV1().Services(ns.Name).Create(ctx, lbServiceWithoutNodePort1, metav1.CreateOptions{})
 	if err != nil {
 		t.Errorf("creating another loadbalancer Service without node ports should not have returned error: %v", err)
 	}
@@ -562,7 +562,7 @@ func TestQuotaLimitService(t *testing.T) {
 
 	// Creating a ClusterIP Service should succeed
 	clusterIPService1 := newService("clusterip-svc1", v1.ServiceTypeClusterIP, false)
-	_, err = clientset.CoreV1().Services(ns.Name).Create(context.TODO(), clusterIPService1, metav1.CreateOptions{})
+	_, err = clientset.CoreV1().Services(ns.Name).Create(ctx, clusterIPService1, metav1.CreateOptions{})
 	if err != nil {
 		t.Errorf("creating a cluster IP Service should not have returned error: %v", err)
 	}

--- a/test/integration/scheduler/taint_test.go
+++ b/test/integration/scheduler/taint_test.go
@@ -83,6 +83,7 @@ func TestTaintNodeByCondition(t *testing.T) {
 
 	// Start NodeLifecycleController for taint.
 	nc, err := nodelifecycle.NewNodeLifecycleController(
+		context.TODO(),
 		externalInformers.Coordination().V1().Leases(),
 		externalInformers.Core().V1().Pods(),
 		externalInformers.Core().V1().Nodes(),
@@ -109,7 +110,7 @@ func TestTaintNodeByCondition(t *testing.T) {
 	testutils.SyncInformerFactory(testCtx)
 
 	// Run all controllers
-	go nc.Run(testCtx.Ctx.Done())
+	go nc.Run(testCtx.Ctx)
 	go testCtx.Scheduler.Run(testCtx.Ctx)
 
 	// -------------------------------------------

--- a/test/integration/service/loadbalancer_test.go
+++ b/test/integration/service/loadbalancer_test.go
@@ -162,10 +162,10 @@ func Test_ServiceLoadBalancerEnableLoadBalancerClass(t *testing.T) {
 
 	controller, cloud, informer := newServiceController(t, client)
 
-	stopCh := make(chan struct{})
-	informer.Start(stopCh)
-	go controller.Run(stopCh, 1)
-	defer close(stopCh)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	informer.Start(ctx.Done())
+	go controller.Run(ctx, 1)
 
 	service := &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
@@ -180,7 +180,7 @@ func Test_ServiceLoadBalancerEnableLoadBalancerClass(t *testing.T) {
 		},
 	}
 
-	_, err = client.CoreV1().Services(ns.Name).Create(context.TODO(), service, metav1.CreateOptions{})
+	_, err = client.CoreV1().Services(ns.Name).Create(ctx, service, metav1.CreateOptions{})
 	if err != nil {
 		t.Fatalf("Error creating test service: %v", err)
 	}
@@ -211,10 +211,10 @@ func Test_ServiceLoadBalancerEnableLoadBalancerClassThenUpdateLoadBalancerClass(
 
 	controller, cloud, informer := newServiceController(t, client)
 
-	stopCh := make(chan struct{})
-	informer.Start(stopCh)
-	go controller.Run(stopCh, 1)
-	defer close(stopCh)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	informer.Start(ctx.Done())
+	go controller.Run(ctx, 1)
 
 	service := &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
@@ -229,7 +229,7 @@ func Test_ServiceLoadBalancerEnableLoadBalancerClassThenUpdateLoadBalancerClass(
 		},
 	}
 
-	service, err = client.CoreV1().Services(ns.Name).Create(context.TODO(), service, metav1.CreateOptions{})
+	service, err = client.CoreV1().Services(ns.Name).Create(ctx, service, metav1.CreateOptions{})
 	if err != nil {
 		t.Fatalf("Error creating test service: %v", err)
 	}
@@ -239,7 +239,7 @@ func Test_ServiceLoadBalancerEnableLoadBalancerClassThenUpdateLoadBalancerClass(
 	}
 
 	service.Spec.LoadBalancerClass = utilpointer.StringPtr("test.com/update")
-	_, err = client.CoreV1().Services(ns.Name).Update(context.TODO(), service, metav1.UpdateOptions{})
+	_, err = client.CoreV1().Services(ns.Name).Update(ctx, service, metav1.UpdateOptions{})
 	if err == nil {
 		t.Fatal("Error updating test service load balancer class should throw error")
 	}

--- a/test/integration/storageversion/gc_test.go
+++ b/test/integration/storageversion/gc_test.go
@@ -64,11 +64,11 @@ func TestStorageVersionGarbageCollection(t *testing.T) {
 
 	controller := storageversiongc.NewStorageVersionGC(kubeclient, leaseInformer, storageVersionInformer)
 
-	stopCh := make(chan struct{})
-	defer close(stopCh)
-	go leaseInformer.Informer().Run(stopCh)
-	go storageVersionInformer.Informer().Run(stopCh)
-	go controller.Run(stopCh)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go leaseInformer.Informer().Run(ctx.Done())
+	go storageVersionInformer.Informer().Run(ctx.Done())
+	go controller.Run(ctx)
 
 	createTestAPIServerIdentityLease(t, kubeclient, idA)
 	createTestAPIServerIdentityLease(t, kubeclient, idB)

--- a/test/integration/ttlcontroller/ttlcontroller_test.go
+++ b/test/integration/ttlcontroller/ttlcontroller_test.go
@@ -141,10 +141,10 @@ func TestTTLAnnotations(t *testing.T) {
 	nodeInformer := informers.Core().V1().Nodes()
 	ttlc := ttl.NewTTLController(nodeInformer, testClient)
 
-	stopCh := make(chan struct{})
-	defer close(stopCh)
-	go nodeInformer.Informer().Run(stopCh)
-	go ttlc.Run(1, stopCh)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go nodeInformer.Informer().Run(ctx.Done())
+	go ttlc.Run(ctx, 1)
 
 	// Create 100 nodes all should have annotation equal to 0.
 	createNodes(t, testClient, 0, 100)

--- a/test/integration/volume/persistent_volumes_test.go
+++ b/test/integration/volume/persistent_volumes_test.go
@@ -119,10 +119,10 @@ func TestPersistentVolumeRecycler(t *testing.T) {
 	// non-namespaced objects (PersistenceVolumes).
 	defer testClient.CoreV1().PersistentVolumes().DeleteCollection(context.TODO(), metav1.DeleteOptions{}, metav1.ListOptions{})
 
-	stopCh := make(chan struct{})
-	informers.Start(stopCh)
-	go ctrl.Run(stopCh)
-	defer close(stopCh)
+	ctx, cancel := context.WithCancel(context.TODO())
+	informers.Start(ctx.Done())
+	go ctrl.Run(ctx)
+	defer cancel()
 
 	// This PV will be claimed, released, and recycled.
 	pv := createPV("fake-pv-recycler", "/tmp/foo", "10G", []v1.PersistentVolumeAccessMode{v1.ReadWriteOnce}, v1.PersistentVolumeReclaimRecycle)
@@ -174,10 +174,10 @@ func TestPersistentVolumeDeleter(t *testing.T) {
 	// non-namespaced objects (PersistenceVolumes).
 	defer testClient.CoreV1().PersistentVolumes().DeleteCollection(context.TODO(), metav1.DeleteOptions{}, metav1.ListOptions{})
 
-	stopCh := make(chan struct{})
-	informers.Start(stopCh)
-	go ctrl.Run(stopCh)
-	defer close(stopCh)
+	ctx, cancel := context.WithCancel(context.TODO())
+	informers.Start(ctx.Done())
+	go ctrl.Run(ctx)
+	defer cancel()
 
 	// This PV will be claimed, released, and deleted.
 	pv := createPV("fake-pv-deleter", "/tmp/foo", "10G", []v1.PersistentVolumeAccessMode{v1.ReadWriteOnce}, v1.PersistentVolumeReclaimDelete)
@@ -234,10 +234,10 @@ func TestPersistentVolumeBindRace(t *testing.T) {
 	// non-namespaced objects (PersistenceVolumes).
 	defer testClient.CoreV1().PersistentVolumes().DeleteCollection(context.TODO(), metav1.DeleteOptions{}, metav1.ListOptions{})
 
-	stopCh := make(chan struct{})
-	informers.Start(stopCh)
-	go ctrl.Run(stopCh)
-	defer close(stopCh)
+	ctx, cancel := context.WithCancel(context.TODO())
+	informers.Start(ctx.Done())
+	go ctrl.Run(ctx)
+	defer cancel()
 
 	pv := createPV("fake-pv-race", "/tmp/foo", "10G", []v1.PersistentVolumeAccessMode{v1.ReadWriteOnce}, v1.PersistentVolumeReclaimRetain)
 	pvc := createPVC("fake-pvc-race", ns.Name, "5G", []v1.PersistentVolumeAccessMode{v1.ReadWriteOnce}, "")
@@ -304,10 +304,10 @@ func TestPersistentVolumeClaimLabelSelector(t *testing.T) {
 	// non-namespaced objects (PersistenceVolumes).
 	defer testClient.CoreV1().PersistentVolumes().DeleteCollection(context.TODO(), metav1.DeleteOptions{}, metav1.ListOptions{})
 
-	stopCh := make(chan struct{})
-	informers.Start(stopCh)
-	go controller.Run(stopCh)
-	defer close(stopCh)
+	ctx, cancel := context.WithCancel(context.TODO())
+	informers.Start(ctx.Done())
+	go controller.Run(ctx)
+	defer cancel()
 
 	var (
 		err     error
@@ -385,10 +385,10 @@ func TestPersistentVolumeClaimLabelSelectorMatchExpressions(t *testing.T) {
 	// non-namespaced objects (PersistenceVolumes).
 	defer testClient.CoreV1().PersistentVolumes().DeleteCollection(context.TODO(), metav1.DeleteOptions{}, metav1.ListOptions{})
 
-	stopCh := make(chan struct{})
-	informers.Start(stopCh)
-	go controller.Run(stopCh)
-	defer close(stopCh)
+	ctx, cancel := context.WithCancel(context.TODO())
+	informers.Start(ctx.Done())
+	go controller.Run(ctx)
+	defer cancel()
 
 	var (
 		err     error
@@ -485,10 +485,10 @@ func TestPersistentVolumeMultiPVs(t *testing.T) {
 	// non-namespaced objects (PersistenceVolumes).
 	defer testClient.CoreV1().PersistentVolumes().DeleteCollection(context.TODO(), metav1.DeleteOptions{}, metav1.ListOptions{})
 
-	stopCh := make(chan struct{})
-	informers.Start(stopCh)
-	go controller.Run(stopCh)
-	defer close(stopCh)
+	ctx, cancel := context.WithCancel(context.TODO())
+	informers.Start(ctx.Done())
+	go controller.Run(ctx)
+	defer cancel()
 
 	maxPVs := getObjectCount()
 	pvs := make([]*v1.PersistentVolume, maxPVs)
@@ -575,10 +575,10 @@ func TestPersistentVolumeMultiPVsPVCs(t *testing.T) {
 	// non-namespaced objects (PersistenceVolumes).
 	defer testClient.CoreV1().PersistentVolumes().DeleteCollection(context.TODO(), metav1.DeleteOptions{}, metav1.ListOptions{})
 
-	controllerStopCh := make(chan struct{})
-	informers.Start(controllerStopCh)
-	go binder.Run(controllerStopCh)
-	defer close(controllerStopCh)
+	ctx, cancel := context.WithCancel(context.TODO())
+	informers.Start(ctx.Done())
+	go binder.Run(ctx)
+	defer cancel()
 
 	objCount := getObjectCount()
 	pvs := make([]*v1.PersistentVolume, objCount)
@@ -788,10 +788,10 @@ func TestPersistentVolumeControllerStartup(t *testing.T) {
 	}
 
 	// Start the controller when all PVs and PVCs are already saved in etcd
-	stopCh := make(chan struct{})
-	informers.Start(stopCh)
-	go binder.Run(stopCh)
-	defer close(stopCh)
+	ctx, cancel := context.WithCancel(context.TODO())
+	informers.Start(ctx.Done())
+	go binder.Run(ctx)
+	defer cancel()
 
 	// wait for at least two sync periods for changes. No volume should be
 	// Released and no claim should be Lost during this time.
@@ -876,10 +876,10 @@ func TestPersistentVolumeProvisionMultiPVCs(t *testing.T) {
 	}
 	testClient.StorageV1().StorageClasses().Create(context.TODO(), &storageClass, metav1.CreateOptions{})
 
-	stopCh := make(chan struct{})
-	informers.Start(stopCh)
-	go binder.Run(stopCh)
-	defer close(stopCh)
+	ctx, cancel := context.WithCancel(context.TODO())
+	informers.Start(ctx.Done())
+	go binder.Run(ctx)
+	defer cancel()
 
 	objCount := getObjectCount()
 	pvcs := make([]*v1.PersistentVolumeClaim, objCount)
@@ -959,10 +959,10 @@ func TestPersistentVolumeMultiPVsDiffAccessModes(t *testing.T) {
 	// non-namespaced objects (PersistenceVolumes).
 	defer testClient.CoreV1().PersistentVolumes().DeleteCollection(context.TODO(), metav1.DeleteOptions{}, metav1.ListOptions{})
 
-	stopCh := make(chan struct{})
-	informers.Start(stopCh)
-	go controller.Run(stopCh)
-	defer close(stopCh)
+	ctx, cancel := context.WithCancel(context.TODO())
+	informers.Start(ctx.Done())
+	go controller.Run(ctx)
+	defer cancel()
 
 	// This PV will be claimed, released, and deleted
 	pvRwo := createPV("pv-rwo", "/tmp/foo", "10G",

--- a/test/integration/volumescheduling/volume_capacity_priority_test.go
+++ b/test/integration/volumescheduling/volume_capacity_priority_test.go
@@ -54,7 +54,7 @@ func setupClusterForVolumeCapacityPriority(t *testing.T, nsName string, resyncPe
 	if err != nil {
 		t.Fatalf("Failed to create PV controller: %v", err)
 	}
-	go ctrl.Run(textCtx.ctx.Done())
+	go ctrl.Run(context.TODO())
 
 	// Start informer factory after all controllers are configured and running.
 	informerFactory.Start(textCtx.ctx.Done())


### PR DESCRIPTION
#### What type of PR is this?
/kind design

#### What this PR does / why we need it:
This wires a context to Core controllers in kube-controller-manager, so that KCM can eventually release on cancel.

This originally came from PR https://github.com/kubernetes/kubernetes/pull/101379, which builds on top of https://github.com/kubernetes/kubernetes/pull/101125

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
