### PR TITLE
Revert 102925: "Fix Node Resources plugins score when there are pods with no requests

### DIFF
--- a/pkg/scheduler/framework/plugins/noderesources/balanced_allocation.go
+++ b/pkg/scheduler/framework/plugins/noderesources/balanced_allocation.go
@@ -80,16 +80,12 @@ func NewBalancedAllocation(_ runtime.Object, h framework.FrameworkHandle) (frame
 
 // todo: use resource weights in the scorer function
 func balancedResourceScorer(requested, allocable resourceToValueMap, includeVolumes bool, requestedVolumes int, allocatableVolumes int) int64 {
-	// This to find a node which has most balanced CPU, memory and volume usage.
 	cpuFraction := fractionOfCapacity(requested[v1.ResourceCPU], allocable[v1.ResourceCPU])
 	memoryFraction := fractionOfCapacity(requested[v1.ResourceMemory], allocable[v1.ResourceMemory])
-	// fractions might be greater than 1 because pods with no requests get minimum
-	// values.
-	if cpuFraction > 1 {
-		cpuFraction = 1
-	}
-	if memoryFraction > 1 {
-		memoryFraction = 1
+	// This to find a node which has most balanced CPU, memory and volume usage.
+	if cpuFraction >= 1 || memoryFraction >= 1 {
+		// if requested >= capacity, the corresponding host should never be preferred.
+		return 0
 	}
 
 	if includeVolumes && utilfeature.DefaultFeatureGate.Enabled(features.BalanceAttachedNodeVolumes) && allocatableVolumes > 0 {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind regression

#### What this PR does / why we need it:
Ref #105220, this partially reverts the changes from #102925 which caused unexpected spreading behavior in the BalancedResourceAllocation plugin

This partially reverts commit f7b2ca58586d2197fff5ad88d6b727d6bfcacf36.

#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for your reviewer:

This introduces the same revert for branch 1.19 as seen in PRs #105239 (for 1.20) and #105238 (for 1.21)

#### Does this PR introduce a user-facing change?

```release-note
Fixes a regression in 1.19.13 which introduced unexpected scheduling behavior based on balanced resource allocation
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
/sig scheduling