### PR TITLE
improve error message on control-plane endpoint reconciler

### DIFF
--- a/pkg/controlplane/controller.go
+++ b/pkg/controlplane/controller.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
 	genericapiserver "k8s.io/apiserver/pkg/server"
+	"k8s.io/apiserver/pkg/storage"
 	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/rest"
 	"k8s.io/klog/v2"
@@ -150,8 +151,10 @@ func (c *Controller) Start() {
 
 	// Reconcile during first run removing itself until server is ready.
 	endpointPorts := createEndpointPortSpec(c.PublicServicePort, "https", c.ExtraEndpointPorts)
-	if err := c.EndpointReconciler.RemoveEndpoints(kubernetesServiceName, c.PublicIP, endpointPorts); err != nil {
-		klog.Errorf("Unable to remove old endpoints from kubernetes service: %v", err)
+	if err := c.EndpointReconciler.RemoveEndpoints(kubernetesServiceName, c.PublicIP, endpointPorts); err == nil {
+		klog.Error("Found stale data, removed previous endpoints on kubernetes service, apiserver didn't exit successfully previously")
+	} else if !storage.IsNotFound(err) {
+		klog.Errorf("Error removing old endpoints from kubernetes service: %v", err)
 	}
 
 	repairClusterIPs := servicecontroller.NewRepair(c.ServiceClusterIPInterval, c.ServiceClient, c.EventClient, &c.ServiceClusterIPRange, c.ServiceClusterIPRegistry, &c.SecondaryServiceClusterIPRange, c.SecondaryServiceClusterIPRegistry)
@@ -183,7 +186,7 @@ func (c *Controller) Stop() {
 		klog.Infof("Shutting down kubernetes service endpoint reconciler")
 		c.EndpointReconciler.StopReconciling()
 		if err := c.EndpointReconciler.RemoveEndpoints(kubernetesServiceName, c.PublicIP, endpointPorts); err != nil {
-			klog.Error(err)
+			klog.Errorf("Unable to remove endpoints from kubernetes service: %v", err)
 		}
 	}()
 


### PR DESCRIPTION

/kind cleanup

#### What this PR does / why we need it:

The apiserver, on start, tries to remove the endpoints from etcd and throws an error if the endpoints doesn't exist.
On a new installation, this is going to fail always, and throw the error, but it will continue with the bootstrap process.

The problem is that if the apiserver is not able to start later for any reasons, this error seems to be a magnet for users, following that red-herring and confusing them.



#### Which issue(s) this PR fixes:
Fixes #76146

#### Special notes for your reviewer:

```release-note
NONE
```
