### PR TITLE
Move test utils where they belong

### DIFF
--- a/pkg/controller/deployment/util/deployment_util.go
+++ b/pkg/controller/deployment/util/deployment_util.go
@@ -509,40 +509,6 @@ func getReplicaSetFraction(rs apps.ReplicaSet, d apps.Deployment) int32 {
 	return integer.RoundToInt32(newRSsize) - *(rs.Spec.Replicas)
 }
 
-// GetAllReplicaSets returns the old and new replica sets targeted by the given Deployment. It gets PodList and ReplicaSetList from client interface.
-// Note that the first set of old replica sets doesn't include the ones with no pods, and the second set of old replica sets include all old replica sets.
-// The third returned value is the new replica set, and it may be nil if it doesn't exist yet.
-func GetAllReplicaSets(deployment *apps.Deployment, c appsclient.AppsV1Interface) ([]*apps.ReplicaSet, []*apps.ReplicaSet, *apps.ReplicaSet, error) {
-	rsList, err := ListReplicaSets(deployment, RsListFromClient(c))
-	if err != nil {
-		return nil, nil, nil, err
-	}
-	oldRSes, allOldRSes := FindOldReplicaSets(deployment, rsList)
-	newRS := FindNewReplicaSet(deployment, rsList)
-	return oldRSes, allOldRSes, newRS, nil
-}
-
-// GetOldReplicaSets returns the old replica sets targeted by the given Deployment; get PodList and ReplicaSetList from client interface.
-// Note that the first set of old replica sets doesn't include the ones with no pods, and the second set of old replica sets include all old replica sets.
-func GetOldReplicaSets(deployment *apps.Deployment, c appsclient.AppsV1Interface) ([]*apps.ReplicaSet, []*apps.ReplicaSet, error) {
-	rsList, err := ListReplicaSets(deployment, RsListFromClient(c))
-	if err != nil {
-		return nil, nil, err
-	}
-	oldRSes, allOldRSes := FindOldReplicaSets(deployment, rsList)
-	return oldRSes, allOldRSes, nil
-}
-
-// GetNewReplicaSet returns a replica set that matches the intent of the given deployment; get ReplicaSetList from client interface.
-// Returns nil if the new replica set doesn't exist yet.
-func GetNewReplicaSet(deployment *apps.Deployment, c appsclient.AppsV1Interface) (*apps.ReplicaSet, error) {
-	rsList, err := ListReplicaSets(deployment, RsListFromClient(c))
-	if err != nil {
-		return nil, err
-	}
-	return FindNewReplicaSet(deployment, rsList), nil
-}
-
 // RsListFromClient returns an rsListFunc that wraps the given client.
 func RsListFromClient(c appsclient.AppsV1Interface) RsListFunc {
 	return func(namespace string, options metav1.ListOptions) ([]*apps.ReplicaSet, error) {

--- a/pkg/controller/deployment/util/deployment_util_test.go
+++ b/pkg/controller/deployment/util/deployment_util_test.go
@@ -28,92 +28,14 @@ import (
 
 	apps "k8s.io/api/apps/v1"
 	"k8s.io/api/core/v1"
-	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apiserver/pkg/storage/names"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes/fake"
-	core "k8s.io/client-go/testing"
 	"k8s.io/kubernetes/pkg/controller"
 )
-
-func addListRSReactor(fakeClient *fake.Clientset, obj runtime.Object) *fake.Clientset {
-	fakeClient.AddReactor("list", "replicasets", func(action core.Action) (handled bool, ret runtime.Object, err error) {
-		return true, obj, nil
-	})
-	return fakeClient
-}
-
-func addListPodsReactor(fakeClient *fake.Clientset, obj runtime.Object) *fake.Clientset {
-	fakeClient.AddReactor("list", "pods", func(action core.Action) (handled bool, ret runtime.Object, err error) {
-		return true, obj, nil
-	})
-	return fakeClient
-}
-
-func addGetRSReactor(fakeClient *fake.Clientset, obj runtime.Object) *fake.Clientset {
-	rsList, ok := obj.(*apps.ReplicaSetList)
-	fakeClient.AddReactor("get", "replicasets", func(action core.Action) (handled bool, ret runtime.Object, err error) {
-		name := action.(core.GetAction).GetName()
-		if ok {
-			for _, rs := range rsList.Items {
-				if rs.Name == name {
-					return true, &rs, nil
-				}
-			}
-		}
-		return false, nil, fmt.Errorf("could not find the requested replica set: %s", name)
-
-	})
-	return fakeClient
-}
-
-func addUpdateRSReactor(fakeClient *fake.Clientset) *fake.Clientset {
-	fakeClient.AddReactor("update", "replicasets", func(action core.Action) (handled bool, ret runtime.Object, err error) {
-		obj := action.(core.UpdateAction).GetObject().(*apps.ReplicaSet)
-		return true, obj, nil
-	})
-	return fakeClient
-}
-
-func addUpdatePodsReactor(fakeClient *fake.Clientset) *fake.Clientset {
-	fakeClient.AddReactor("update", "pods", func(action core.Action) (handled bool, ret runtime.Object, err error) {
-		obj := action.(core.UpdateAction).GetObject().(*v1.Pod)
-		return true, obj, nil
-	})
-	return fakeClient
-}
-
-func generateRSWithLabel(labels map[string]string, image string) apps.ReplicaSet {
-	return apps.ReplicaSet{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:   names.SimpleNameGenerator.GenerateName("replicaset"),
-			Labels: labels,
-		},
-		Spec: apps.ReplicaSetSpec{
-			Replicas: func(i int32) *int32 { return &i }(1),
-			Selector: &metav1.LabelSelector{MatchLabels: labels},
-			Template: v1.PodTemplateSpec{
-				ObjectMeta: metav1.ObjectMeta{
-					Labels: labels,
-				},
-				Spec: v1.PodSpec{
-					Containers: []v1.Container{
-						{
-							Name:                   image,
-							Image:                  image,
-							ImagePullPolicy:        v1.PullAlways,
-							TerminationMessagePath: v1.TerminationMessagePathDefault,
-						},
-					},
-				},
-			},
-		},
-	}
-}
 
 func newDControllerRef(d *apps.Deployment) *metav1.OwnerReference {
 	isController := true
@@ -182,144 +104,6 @@ func generateDeployment(image string) apps.Deployment {
 				},
 			},
 		},
-	}
-}
-
-func TestGetNewRS(t *testing.T) {
-	newDeployment := generateDeployment("nginx")
-	newRC := generateRS(newDeployment)
-
-	tests := []struct {
-		Name     string
-		objs     []runtime.Object
-		expected *apps.ReplicaSet
-	}{
-		{
-			"No new ReplicaSet",
-			[]runtime.Object{
-				&v1.PodList{},
-				&apps.ReplicaSetList{
-					Items: []apps.ReplicaSet{
-						generateRS(generateDeployment("foo")),
-						generateRS(generateDeployment("bar")),
-					},
-				},
-			},
-			nil,
-		},
-		{
-			"Has new ReplicaSet",
-			[]runtime.Object{
-				&v1.PodList{},
-				&apps.ReplicaSetList{
-					Items: []apps.ReplicaSet{
-						generateRS(generateDeployment("foo")),
-						generateRS(generateDeployment("bar")),
-						generateRS(generateDeployment("abc")),
-						newRC,
-						generateRS(generateDeployment("xyz")),
-					},
-				},
-			},
-			&newRC,
-		},
-	}
-
-	for _, test := range tests {
-		t.Run(test.Name, func(t *testing.T) {
-			fakeClient := &fake.Clientset{}
-			fakeClient = addListPodsReactor(fakeClient, test.objs[0])
-			fakeClient = addListRSReactor(fakeClient, test.objs[1])
-			fakeClient = addUpdatePodsReactor(fakeClient)
-			fakeClient = addUpdateRSReactor(fakeClient)
-			rs, err := GetNewReplicaSet(&newDeployment, fakeClient.AppsV1())
-			if err != nil {
-				t.Errorf("In test case %s, got unexpected error %v", test.Name, err)
-			}
-			if !apiequality.Semantic.DeepEqual(rs, test.expected) {
-				t.Errorf("In test case %s, expected %#v, got %#v", test.Name, test.expected, rs)
-			}
-		})
-	}
-}
-
-func TestGetOldRSs(t *testing.T) {
-	newDeployment := generateDeployment("nginx")
-	newRS := generateRS(newDeployment)
-	newRS.Status.FullyLabeledReplicas = *(newRS.Spec.Replicas)
-
-	// create 2 old deployments and related replica sets/pods, with the same labels but different template
-	oldDeployment := generateDeployment("nginx")
-	oldDeployment.Spec.Template.Spec.Containers[0].Name = "nginx-old-1"
-	oldRS := generateRS(oldDeployment)
-	oldRS.Status.FullyLabeledReplicas = *(oldRS.Spec.Replicas)
-	oldDeployment2 := generateDeployment("nginx")
-	oldDeployment2.Spec.Template.Spec.Containers[0].Name = "nginx-old-2"
-	oldRS2 := generateRS(oldDeployment2)
-	oldRS2.Status.FullyLabeledReplicas = *(oldRS2.Spec.Replicas)
-
-	// create 1 ReplicaSet that existed before the deployment,
-	// with the same labels as the deployment, but no ControllerRef.
-	existedRS := generateRSWithLabel(newDeployment.Spec.Template.Labels, "foo")
-	existedRS.Status.FullyLabeledReplicas = *(existedRS.Spec.Replicas)
-
-	tests := []struct {
-		Name     string
-		objs     []runtime.Object
-		expected []*apps.ReplicaSet
-	}{
-		{
-			"No old ReplicaSets",
-			[]runtime.Object{
-				&apps.ReplicaSetList{
-					Items: []apps.ReplicaSet{
-						generateRS(generateDeployment("foo")),
-						newRS,
-						generateRS(generateDeployment("bar")),
-					},
-				},
-			},
-			nil,
-		},
-		{
-			"Has old ReplicaSet",
-			[]runtime.Object{
-				&apps.ReplicaSetList{
-					Items: []apps.ReplicaSet{
-						oldRS2,
-						oldRS,
-						existedRS,
-						newRS,
-						generateRSWithLabel(map[string]string{"name": "xyz"}, "xyz"),
-						generateRSWithLabel(map[string]string{"name": "bar"}, "bar"),
-					},
-				},
-			},
-			[]*apps.ReplicaSet{&oldRS, &oldRS2},
-		},
-	}
-
-	for _, test := range tests {
-		t.Run(test.Name, func(t *testing.T) {
-			fakeClient := &fake.Clientset{}
-			fakeClient = addListRSReactor(fakeClient, test.objs[0])
-			fakeClient = addGetRSReactor(fakeClient, test.objs[0])
-			fakeClient = addUpdateRSReactor(fakeClient)
-			_, rss, err := GetOldReplicaSets(&newDeployment, fakeClient.AppsV1())
-			if err != nil {
-				t.Errorf("In test case %s, got unexpected error %v", test.Name, err)
-			}
-			if !equal(rss, test.expected) {
-				t.Errorf("In test case %q, expected:", test.Name)
-				for _, rs := range test.expected {
-					t.Errorf("rs = %#v", rs)
-				}
-				t.Errorf("In test case %q, got:", test.Name)
-				for _, rs := range rss {
-					t.Errorf("rs = %#v", rs)
-				}
-			}
-		})
 	}
 }
 
@@ -554,26 +338,6 @@ func TestFindOldReplicaSets(t *testing.T) {
 			}
 		})
 	}
-}
-
-// equal compares the equality of two ReplicaSet slices regardless of their ordering
-func equal(rss1, rss2 []*apps.ReplicaSet) bool {
-	if reflect.DeepEqual(rss1, rss2) {
-		return true
-	}
-	if rss1 == nil || rss2 == nil || len(rss1) != len(rss2) {
-		return false
-	}
-	count := 0
-	for _, rs1 := range rss1 {
-		for _, rs2 := range rss2 {
-			if reflect.DeepEqual(rs1, rs2) {
-				count++
-				break
-			}
-		}
-	}
-	return count == len(rss1)
 }
 
 func TestGetReplicaCountForReplicaSets(t *testing.T) {

--- a/pkg/controller/replication/conversion.go
+++ b/pkg/controller/replication/conversion.go
@@ -224,7 +224,7 @@ func (c conversionClient) UpdateStatus(ctx context.Context, rs *apps.ReplicaSet,
 }
 
 func (c conversionClient) Get(ctx context.Context, name string, options metav1.GetOptions) (*apps.ReplicaSet, error) {
-	rc, err := c.ReplicationControllerInterface.Get(context.TODO(), name, options)
+	rc, err := c.ReplicationControllerInterface.Get(ctx, name, options)
 	if err != nil {
 		return nil, err
 	}
@@ -232,7 +232,7 @@ func (c conversionClient) Get(ctx context.Context, name string, options metav1.G
 }
 
 func (c conversionClient) List(ctx context.Context, opts metav1.ListOptions) (*apps.ReplicaSetList, error) {
-	rcList, err := c.ReplicationControllerInterface.List(context.TODO(), opts)
+	rcList, err := c.ReplicationControllerInterface.List(ctx, opts)
 	if err != nil {
 		return nil, err
 	}

--- a/test/e2e/apps/deployment.go
+++ b/test/e2e/apps/deployment.go
@@ -637,7 +637,7 @@ func failureTrap(c clientset.Interface, ns string) {
 		d := deployments.Items[i]
 
 		framework.Logf(spew.Sprintf("Deployment %q:\n%+v\n", d.Name, d))
-		_, allOldRSs, newRS, err := deploymentutil.GetAllReplicaSets(&d, c.AppsV1())
+		_, allOldRSs, newRS, err := testutil.GetAllReplicaSets(&d, c)
 		if err != nil {
 			framework.Logf("Could not list ReplicaSets for Deployment %q: %v", d.Name, err)
 			return
@@ -740,7 +740,7 @@ func testDeleteDeployment(f *framework.Framework) {
 
 	deployment, err := c.AppsV1().Deployments(ns).Get(context.TODO(), deploymentName, metav1.GetOptions{})
 	framework.ExpectNoError(err)
-	newRS, err := deploymentutil.GetNewReplicaSet(deployment, c.AppsV1())
+	newRS, err := testutil.GetNewReplicaSet(deployment, c)
 	framework.ExpectNoError(err)
 	framework.ExpectNotEqual(newRS, nilRs)
 	stopDeployment(c, ns, deploymentName)
@@ -790,7 +790,7 @@ func testRollingUpdateDeployment(f *framework.Framework) {
 	framework.Logf("Ensuring deployment %q has one old replica set (the one it adopted)", deploy.Name)
 	deployment, err := c.AppsV1().Deployments(ns).Get(context.TODO(), deploymentName, metav1.GetOptions{})
 	framework.ExpectNoError(err)
-	_, allOldRSs, err := deploymentutil.GetOldReplicaSets(deployment, c.AppsV1())
+	_, allOldRSs, err := testutil.GetOldReplicaSets(deployment, c)
 	framework.ExpectNoError(err)
 	framework.ExpectEqual(len(allOldRSs), 1)
 }
@@ -956,7 +956,7 @@ func testRolloverDeployment(f *framework.Framework) {
 	oldRS, err := c.AppsV1().ReplicaSets(ns).Get(context.TODO(), rsName, metav1.GetOptions{})
 	framework.ExpectNoError(err)
 	ensureReplicas(oldRS, int32(1))
-	newRS, err := deploymentutil.GetNewReplicaSet(deployment, c.AppsV1())
+	newRS, err := testutil.GetNewReplicaSet(deployment, c)
 	framework.ExpectNoError(err)
 	ensureReplicas(newRS, int32(1))
 
@@ -1222,7 +1222,7 @@ func testProportionalScalingDeployment(f *framework.Framework) {
 	err = e2edeployment.WaitForDeploymentComplete(c, deployment)
 	framework.ExpectNoError(err)
 
-	firstRS, err := deploymentutil.GetNewReplicaSet(deployment, c.AppsV1())
+	firstRS, err := testutil.GetNewReplicaSet(deployment, c)
 	framework.ExpectNoError(err)
 
 	// Update the deployment with a non-existent image so that the new replica set
@@ -1260,7 +1260,7 @@ func testProportionalScalingDeployment(f *framework.Framework) {
 	framework.ExpectNoError(err)
 
 	// Checking state of second rollout's replicaset.
-	secondRS, err := deploymentutil.GetNewReplicaSet(deployment, c.AppsV1())
+	secondRS, err := testutil.GetNewReplicaSet(deployment, c)
 	framework.ExpectNoError(err)
 
 	maxSurge, err := intstr.GetScaledValueFromIntOrPercent(deployment.Spec.Strategy.RollingUpdate.MaxSurge, int(*(deployment.Spec.Replicas)), false)
@@ -1536,8 +1536,8 @@ func watchRecreateDeployment(c clientset.Interface, d *appsv1.Deployment) error 
 		status = d.Status
 
 		if d.Status.UpdatedReplicas > 0 && d.Status.Replicas != d.Status.UpdatedReplicas {
-			_, allOldRSs, err := deploymentutil.GetOldReplicaSets(d, c.AppsV1())
-			newRS, nerr := deploymentutil.GetNewReplicaSet(d, c.AppsV1())
+			_, allOldRSs, err := testutil.GetOldReplicaSets(d, c)
+			newRS, nerr := testutil.GetNewReplicaSet(d, c)
 			if err == nil && nerr == nil {
 				framework.Logf("%+v", d)
 				testutil.LogReplicaSetsOfDeployment(d, allOldRSs, newRS, framework.Logf)
@@ -1572,7 +1572,7 @@ func waitForDeploymentOldRSsNum(c clientset.Interface, ns, deploymentName string
 		}
 		d = deployment
 
-		_, oldRSs, err = deploymentutil.GetOldReplicaSets(deployment, c.AppsV1())
+		_, oldRSs, err = testutil.GetOldReplicaSets(deployment, c)
 		if err != nil {
 			return false, err
 		}

--- a/test/integration/deployment/deployment_test.go
+++ b/test/integration/deployment/deployment_test.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/client-go/util/retry"
 	deploymentutil "k8s.io/kubernetes/pkg/controller/deployment/util"
 	"k8s.io/kubernetes/test/integration/framework"
+	testutil "k8s.io/kubernetes/test/utils"
 	"k8s.io/utils/pointer"
 )
 
@@ -197,7 +198,7 @@ func TestDeploymentRollingUpdate(t *testing.T) {
 	if err := tester.waitForDeploymentCompleteAndCheckRollingAndMarkPodsReady(); err != nil {
 		t.Fatal(err)
 	}
-	_, allOldRSs, err := deploymentutil.GetOldReplicaSets(tester.deployment, c.AppsV1())
+	_, allOldRSs, err := testutil.GetOldReplicaSets(tester.deployment, c)
 	if err != nil {
 		t.Fatalf("failed retrieving old replicasets of deployment %s: %v", tester.deployment.Name, err)
 	}
@@ -332,7 +333,7 @@ func TestPausedDeployment(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, allOldRs, err := deploymentutil.GetOldReplicaSets(tester.deployment, c.AppsV1())
+	_, allOldRs, err := testutil.GetOldReplicaSets(tester.deployment, c)
 	if err != nil {
 		t.Fatalf("failed retrieving old replicasets of deployment %s: %v", tester.deployment.Name, err)
 	}
@@ -457,7 +458,7 @@ func TestDeploymentHashCollision(t *testing.T) {
 	}
 
 	// Mock a hash collision
-	newRS, err := deploymentutil.GetNewReplicaSet(tester.deployment, c.AppsV1())
+	newRS, err := testutil.GetNewReplicaSet(tester.deployment, c)
 	if err != nil {
 		t.Fatalf("failed getting new replicaset of deployment %s: %v", tester.deployment.Name, err)
 	}
@@ -751,7 +752,7 @@ func TestScaledRolloutDeployment(t *testing.T) {
 	}
 
 	// Verify every replicaset has correct desiredReplicas annotation after 3rd rollout
-	thirdRS, err := deploymentutil.GetNewReplicaSet(tester.deployment, c.AppsV1())
+	thirdRS, err := testutil.GetNewReplicaSet(tester.deployment, c)
 	if err != nil {
 		t.Fatalf("failed getting new revision 3 replicaset for deployment %q: %v", name, err)
 	}
@@ -828,7 +829,7 @@ func TestScaledRolloutDeployment(t *testing.T) {
 	}
 
 	// Verify every replicaset has correct desiredReplicas annotation after 5th rollout
-	fifthRS, err := deploymentutil.GetNewReplicaSet(tester.deployment, c.AppsV1())
+	fifthRS, err := testutil.GetNewReplicaSet(tester.deployment, c)
 	if err != nil {
 		t.Fatalf("failed getting new revision 5 replicaset for deployment %q: %v", name, err)
 	}
@@ -1059,7 +1060,7 @@ func TestGeneralReplicaSetAdoption(t *testing.T) {
 	}
 
 	// Get replicaset of the deployment
-	rs, err := deploymentutil.GetNewReplicaSet(tester.deployment, c.AppsV1())
+	rs, err := testutil.GetNewReplicaSet(tester.deployment, c)
 	if err != nil {
 		t.Fatalf("failed to get replicaset of deployment %q: %v", deploymentName, err)
 	}
@@ -1197,7 +1198,7 @@ func TestReplicaSetOrphaningAndAdoptionWhenLabelsChange(t *testing.T) {
 	// Orphaning: deployment should remove OwnerReference from a RS when the RS's labels change to not match its labels
 
 	// Get replicaset of the deployment
-	rs, err := deploymentutil.GetNewReplicaSet(tester.deployment, c.AppsV1())
+	rs, err := testutil.GetNewReplicaSet(tester.deployment, c)
 	if err != nil {
 		t.Fatalf("failed to get replicaset of deployment %q: %v", deploymentName, err)
 	}
@@ -1240,7 +1241,7 @@ func TestReplicaSetOrphaningAndAdoptionWhenLabelsChange(t *testing.T) {
 	// i.e., the new replicaset will have a name with different hash to preserve name uniqueness
 	var newRS *apps.ReplicaSet
 	if err = wait.PollImmediate(pollInterval, pollTimeout, func() (bool, error) {
-		newRS, err = deploymentutil.GetNewReplicaSet(tester.deployment, c.AppsV1())
+		newRS, err = testutil.GetNewReplicaSet(tester.deployment, c)
 		if err != nil {
 			return false, fmt.Errorf("failed to get new replicaset of deployment %q after orphaning: %v", deploymentName, err)
 		}

--- a/test/integration/deployment/util.go
+++ b/test/integration/deployment/util.go
@@ -293,7 +293,7 @@ func (d *deploymentTester) getNewReplicaSet() (*apps.ReplicaSet, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed retrieving deployment %s: %v", d.deployment.Name, err)
 	}
-	rs, err := deploymentutil.GetNewReplicaSet(deployment, d.c.AppsV1())
+	rs, err := testutil.GetNewReplicaSet(deployment, d.c)
 	if err != nil {
 		return nil, fmt.Errorf("failed retrieving new replicaset of deployment %s: %v", d.deployment.Name, err)
 	}


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup
/sig apps
/sig testing
/priority backlog

#### What this PR does / why we need it:
1. These utility functions are only used in tests and so this PR moves them where it belongs. Looks like this was a leftover from when we were moving utils to kubectl. 
2. Leftovers from `context.TODO`. 

#### Special notes for your reviewer:
/assign @damemi 

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
