### PR TITLE
component-base: avoid accumulating default labels

### DIFF
--- a/staging/src/k8s.io/component-base/OWNERS
+++ b/staging/src/k8s.io/component-base/OWNERS
@@ -15,7 +15,3 @@ emeritus_reviewers:
 - dixudx
 - rosti
 - stewart-yu
-labels:
-- sig/architecture
-- sig/cluster-lifecycle
-- sig/api-machinery


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

The intention in
https://github.com/kubernetes/kubernetes/commit/ecb38137269cfc6fecb46434d8d8f1abad0e08e4
was to use the component-base/OWNERS labels only as fallback when the OWNERS
files in the sub-directories don't set labels. This should never have been
necessary because all of those sub-directories have reasonable labels
configured.

But in practice, the labels were also added to PRs that only touched files in
sub-directory because OWNERS files are inherited, which created noise in
various sigs that shouldn't have been tagged for those PRs.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
