### PR TITLE
kubelet: use generic ephemeral volume helper functions

### DIFF
--- a/pkg/kubelet/kubelet_pods.go
+++ b/pkg/kubelet/kubelet_pods.go
@@ -39,6 +39,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	utilvalidation "k8s.io/apimachinery/pkg/util/validation"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	"k8s.io/component-helpers/storage/ephemeral"
 	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
 	"k8s.io/klog/v2"
 	podutil "k8s.io/kubernetes/pkg/api/v1/pod"
@@ -2040,7 +2041,7 @@ func (kl *Kubelet) hasHostMountPVC(pod *v1.Pod) bool {
 			if !utilfeature.DefaultFeatureGate.Enabled(features.GenericEphemeralVolume) {
 				continue
 			}
-			pvcName = pod.Name + "-" + volume.Name
+			pvcName = ephemeral.VolumeClaimName(pod, &volume)
 		default:
 			continue
 		}


### PR DESCRIPTION

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

The name concatenation and ownership check were originally considered small
enough to not warrant dedicated functions, but the intent of the code is more
readable with them.

#### Special notes for your reviewer:

The API was reviewed in https://github.com/kubernetes/kubernetes/pull/105345

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
