### PR TITLE
auth: use generic ephemeral volume helper functions

### DIFF
--- a/plugin/pkg/auth/authorizer/node/graph.go
+++ b/plugin/pkg/auth/authorizer/node/graph.go
@@ -22,6 +22,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	"k8s.io/component-helpers/storage/ephemeral"
 	pvutil "k8s.io/kubernetes/pkg/api/v1/persistentvolume"
 	podutil "k8s.io/kubernetes/pkg/api/v1/pod"
 	"k8s.io/kubernetes/pkg/features"
@@ -386,7 +387,7 @@ func (g *Graph) AddPod(pod *corev1.Pod) {
 		if v.PersistentVolumeClaim != nil {
 			claimName = v.PersistentVolumeClaim.ClaimName
 		} else if v.Ephemeral != nil && utilfeature.DefaultFeatureGate.Enabled(features.GenericEphemeralVolume) {
-			claimName = pod.Name + "-" + v.Name
+			claimName = ephemeral.VolumeClaimName(pod, &v)
 		}
 		if claimName != "" {
 			pvcVertex := g.getOrCreateVertex_locked(pvcVertexType, pod.Namespace, claimName)


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

The name concatenation and ownership check were originally considered small
enough to not warrant dedicated functions, but the intent of the code is more
readable with them.

#### Special notes for your reviewer:

The API was reviewed in https://github.com/kubernetes/kubernetes/pull/105345

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
