### PR TITLE
kubelet: When apiserver is down, kubelet should restart static pods

### DIFF
--- a/pkg/kubelet/pod_workers_test.go
+++ b/pkg/kubelet/pod_workers_test.go
@@ -54,6 +54,8 @@ type fakePodWorkers struct {
 	removeRuntime         map[types.UID]bool
 	removeContent         map[types.UID]bool
 	terminatingStaticPods map[string]bool
+
+	syncState map[types.UID]PodWorkerState
 }
 
 func (f *fakePodWorkers) UpdatePod(options UpdatePodOptions) {
@@ -83,7 +85,9 @@ func (f *fakePodWorkers) UpdatePod(options UpdatePodOptions) {
 }
 
 func (f *fakePodWorkers) SyncKnownPods(desiredPods []*v1.Pod) map[types.UID]PodWorkerState {
-	return nil
+	f.statusLock.Lock()
+	defer f.statusLock.Unlock()
+	return f.syncState
 }
 
 func (f *fakePodWorkers) IsPodKnownTerminated(uid types.UID) bool {


### PR DESCRIPTION
HandlePodCleanups is responsible for restarting static pods for the
pod worker after the following sequence:

static pod with UID 1 created
static pod with UID 1 deleted from disk
static pod with UID 1 still terminating in pod worker
static pod with UID 1 recreated on disk

because we know what pods should be running but aren't. However,
HandlePodCleanups doesn't run when one or more config sources aren't
ready such as when the apiserver is partitioned. Since static pods
might be used to self-host the apiserver, we need to ensure a failed
static pod restarts even when the apiserver is down.

Have HandlePodCleanups() run even when some sources are not ready,
but only perform pod worker sync and pod restart functions. The
other cleanup duties (resynchronizing kubelet with the container
runtime) can't be performed without knowing what sources those
resources are attributed to.

#### What type of PR is this?

/kind bug

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #105543

Does not fix the fact that static pods don't get housekept when the apiserver is down for extended periods.

#### Special notes for your reviewer:

We need an e2e test that verifies the behavior of static pods when an apiserver config source is down.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Static pods with fixed UIDs that are changed on disk while the apiserver is down are now properly restarted.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```