### PR TITLE
Fix all staticcheck logic code errors on vendor/k8s.io/apiserver/pkg/storage/value/encrypt

### DIFF
--- a/hack/.staticcheck_failures
+++ b/hack/.staticcheck_failures
@@ -6,6 +6,5 @@ vendor/k8s.io/apimachinery/pkg/util/strategicpatch
 vendor/k8s.io/apiserver/pkg/server/dynamiccertificates
 vendor/k8s.io/apiserver/pkg/server/filters
 vendor/k8s.io/apiserver/pkg/server/routes
-vendor/k8s.io/apiserver/pkg/storage/value/encrypt/envelope
 vendor/k8s.io/apiserver/pkg/util/wsstream
 vendor/k8s.io/client-go/rest

--- a/test/e2e/framework/autoscaling/autoscaling_utils.go
+++ b/test/e2e/framework/autoscaling/autoscaling_utils.go
@@ -372,6 +372,7 @@ func (rc *ResourceConsumer) GetReplicas() int {
 		if replicationController == nil {
 			framework.Failf(rcIsNil)
 		}
+		//lint:ignore SA5011 nil check happens above, can't be nil.
 		return int(replicationController.Status.ReadyReplicas)
 	case KindDeployment:
 		deployment, err := rc.clientSet.AppsV1().Deployments(rc.nsName).Get(context.TODO(), rc.name, metav1.GetOptions{})
@@ -379,6 +380,7 @@ func (rc *ResourceConsumer) GetReplicas() int {
 		if deployment == nil {
 			framework.Failf(deploymentIsNil)
 		}
+		//lint:ignore SA5011 nil check happens above, can't be nil.
 		return int(deployment.Status.ReadyReplicas)
 	case KindReplicaSet:
 		rs, err := rc.clientSet.AppsV1().ReplicaSets(rc.nsName).Get(context.TODO(), rc.name, metav1.GetOptions{})
@@ -386,6 +388,7 @@ func (rc *ResourceConsumer) GetReplicas() int {
 		if rs == nil {
 			framework.Failf(rsIsNil)
 		}
+		//lint:ignore SA5011 nil check happens above, can't be nil.
 		return int(rs.Status.ReadyReplicas)
 	default:
 		framework.Failf(invalidKind)


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This cleans up linting mistakes on `vendor/k8s.io/apiserver/pkg/storage/value/encrypt/*` referenced by `hack/.staticcheck_failures`. It's needed due to #92402. Note that, currently, `golangci-lint`'s `//lint:ignore` is not working properly, so linting errors still happen in that folder because the error is not properly ignored. We took care to fix only the errors that were not previously addressed on that folder.

#### Which issue(s) this PR fixes:

Fixes #105540

Part of #92402

#### Does this PR introduce a user-facing change?

NONE
