### PR TITLE
Update comment on ResourcePolicyRule

### DIFF
--- a/staging/src/k8s.io/api/flowcontrol/v1alpha1/generated.proto
+++ b/staging/src/k8s.io/api/flowcontrol/v1alpha1/generated.proto
@@ -352,8 +352,10 @@ message QueuingConfiguration {
 // ResourcePolicyRule matches a resource request if and only if: (a)
 // at least one member of verbs matches the request, (b) at least one
 // member of apiGroups matches the request, (c) at least one member of
-// resources matches the request, and (d) least one member of
-// namespaces matches the request.
+// resources matches the request, and (d) either (d1) the request does
+// not specify a namespace (i.e., `Namespace==""`) and clusterScope is
+// true or (d2) the request specifies a namespace and least one member
+// of namespaces matches the request's namespace.
 message ResourcePolicyRule {
   // `verbs` is a list of matching verbs and may not be empty.
   // "*" matches all verbs and, if present, must be the only entry.

--- a/staging/src/k8s.io/api/flowcontrol/v1alpha1/types.go
+++ b/staging/src/k8s.io/api/flowcontrol/v1alpha1/types.go
@@ -241,8 +241,10 @@ type ServiceAccountSubject struct {
 // ResourcePolicyRule matches a resource request if and only if: (a)
 // at least one member of verbs matches the request, (b) at least one
 // member of apiGroups matches the request, (c) at least one member of
-// resources matches the request, and (d) least one member of
-// namespaces matches the request.
+// resources matches the request, and (d) either (d1) the request does
+// not specify a namespace (i.e., `Namespace==""`) and clusterScope is
+// true or (d2) the request specifies a namespace and least one member
+// of namespaces matches the request's namespace.
 type ResourcePolicyRule struct {
 	// `verbs` is a list of matching verbs and may not be empty.
 	// "*" matches all verbs and, if present, must be the only entry.

--- a/staging/src/k8s.io/api/flowcontrol/v1alpha1/types_swagger_doc_generated.go
+++ b/staging/src/k8s.io/api/flowcontrol/v1alpha1/types_swagger_doc_generated.go
@@ -215,7 +215,7 @@ func (QueuingConfiguration) SwaggerDoc() map[string]string {
 }
 
 var map_ResourcePolicyRule = map[string]string{
-	"":             "ResourcePolicyRule is a predicate that matches some resource requests, testing the request's verb and the target resource. A ResourcePolicyRule matches a resource request if and only if: (a) at least one member of verbs matches the request, (b) at least one member of apiGroups matches the request, (c) at least one member of resources matches the request, and (d) least one member of namespaces matches the request.",
+	"":             "ResourcePolicyRule is a predicate that matches some resource requests, testing the request's verb and the target resource. A ResourcePolicyRule matches a resource request if and only if: (a) at least one member of verbs matches the request, (b) at least one member of apiGroups matches the request, (c) at least one member of resources matches the request, and (d) either (d1) the request does not specify a namespace (i.e., `Namespace==\"\"`) and clusterScope is true or (d2) the request specifies a namespace and least one member of namespaces matches the request's namespace.",
 	"verbs":        "`verbs` is a list of matching verbs and may not be empty. \"*\" matches all verbs and, if present, must be the only entry. Required.",
 	"apiGroups":    "`apiGroups` is a list of matching API groups and may not be empty. \"*\" matches all API groups and, if present, must be the only entry. Required.",
 	"resources":    "`resources` is a list of matching resources (i.e., lowercase and plural) with, if desired, subresource.  For example, [ \"services\", \"nodes/status\" ].  This list may not be empty. \"*\" matches all resources and, if present, must be the only entry. Required.",

--- a/staging/src/k8s.io/api/flowcontrol/v1beta1/generated.proto
+++ b/staging/src/k8s.io/api/flowcontrol/v1beta1/generated.proto
@@ -352,8 +352,10 @@ message QueuingConfiguration {
 // ResourcePolicyRule matches a resource request if and only if: (a)
 // at least one member of verbs matches the request, (b) at least one
 // member of apiGroups matches the request, (c) at least one member of
-// resources matches the request, and (d) least one member of
-// namespaces matches the request.
+// resources matches the request, and (d) either (d1) the request does
+// not specify a namespace (i.e., `Namespace==""`) and clusterScope is
+// true or (d2) the request specifies a namespace and least one member
+// of namespaces matches the request's namespace.
 message ResourcePolicyRule {
   // `verbs` is a list of matching verbs and may not be empty.
   // "*" matches all verbs and, if present, must be the only entry.

--- a/staging/src/k8s.io/api/flowcontrol/v1beta1/types.go
+++ b/staging/src/k8s.io/api/flowcontrol/v1beta1/types.go
@@ -279,8 +279,10 @@ type ServiceAccountSubject struct {
 // ResourcePolicyRule matches a resource request if and only if: (a)
 // at least one member of verbs matches the request, (b) at least one
 // member of apiGroups matches the request, (c) at least one member of
-// resources matches the request, and (d) least one member of
-// namespaces matches the request.
+// resources matches the request, and (d) either (d1) the request does
+// not specify a namespace (i.e., `Namespace==""`) and clusterScope is
+// true or (d2) the request specifies a namespace and least one member
+// of namespaces matches the request's namespace.
 type ResourcePolicyRule struct {
 	// `verbs` is a list of matching verbs and may not be empty.
 	// "*" matches all verbs and, if present, must be the only entry.

--- a/staging/src/k8s.io/api/flowcontrol/v1beta1/types_swagger_doc_generated.go
+++ b/staging/src/k8s.io/api/flowcontrol/v1beta1/types_swagger_doc_generated.go
@@ -215,7 +215,7 @@ func (QueuingConfiguration) SwaggerDoc() map[string]string {
 }
 
 var map_ResourcePolicyRule = map[string]string{
-	"":             "ResourcePolicyRule is a predicate that matches some resource requests, testing the request's verb and the target resource. A ResourcePolicyRule matches a resource request if and only if: (a) at least one member of verbs matches the request, (b) at least one member of apiGroups matches the request, (c) at least one member of resources matches the request, and (d) least one member of namespaces matches the request.",
+	"":             "ResourcePolicyRule is a predicate that matches some resource requests, testing the request's verb and the target resource. A ResourcePolicyRule matches a resource request if and only if: (a) at least one member of verbs matches the request, (b) at least one member of apiGroups matches the request, (c) at least one member of resources matches the request, and (d) either (d1) the request does not specify a namespace (i.e., `Namespace==\"\"`) and clusterScope is true or (d2) the request specifies a namespace and least one member of namespaces matches the request's namespace.",
 	"verbs":        "`verbs` is a list of matching verbs and may not be empty. \"*\" matches all verbs and, if present, must be the only entry. Required.",
 	"apiGroups":    "`apiGroups` is a list of matching API groups and may not be empty. \"*\" matches all API groups and, if present, must be the only entry. Required.",
 	"resources":    "`resources` is a list of matching resources (i.e., lowercase and plural) with, if desired, subresource.  For example, [ \"services\", \"nodes/status\" ].  This list may not be empty. \"*\" matches all resources and, if present, must be the only entry. Required.",

--- a/staging/src/k8s.io/api/flowcontrol/v1beta2/generated.proto
+++ b/staging/src/k8s.io/api/flowcontrol/v1beta2/generated.proto
@@ -352,8 +352,10 @@ message QueuingConfiguration {
 // ResourcePolicyRule matches a resource request if and only if: (a)
 // at least one member of verbs matches the request, (b) at least one
 // member of apiGroups matches the request, (c) at least one member of
-// resources matches the request, and (d) least one member of
-// namespaces matches the request.
+// resources matches the request, and (d) either (d1) the request does
+// not specify a namespace (i.e., `Namespace==""`) and clusterScope is
+// true or (d2) the request specifies a namespace and least one member
+// of namespaces matches the request's namespace.
 message ResourcePolicyRule {
   // `verbs` is a list of matching verbs and may not be empty.
   // "*" matches all verbs and, if present, must be the only entry.

--- a/staging/src/k8s.io/api/flowcontrol/v1beta2/types.go
+++ b/staging/src/k8s.io/api/flowcontrol/v1beta2/types.go
@@ -279,8 +279,10 @@ type ServiceAccountSubject struct {
 // ResourcePolicyRule matches a resource request if and only if: (a)
 // at least one member of verbs matches the request, (b) at least one
 // member of apiGroups matches the request, (c) at least one member of
-// resources matches the request, and (d) least one member of
-// namespaces matches the request.
+// resources matches the request, and (d) either (d1) the request does
+// not specify a namespace (i.e., `Namespace==""`) and clusterScope is
+// true or (d2) the request specifies a namespace and least one member
+// of namespaces matches the request's namespace.
 type ResourcePolicyRule struct {
 	// `verbs` is a list of matching verbs and may not be empty.
 	// "*" matches all verbs and, if present, must be the only entry.

--- a/staging/src/k8s.io/api/flowcontrol/v1beta2/types_swagger_doc_generated.go
+++ b/staging/src/k8s.io/api/flowcontrol/v1beta2/types_swagger_doc_generated.go
@@ -215,7 +215,7 @@ func (QueuingConfiguration) SwaggerDoc() map[string]string {
 }
 
 var map_ResourcePolicyRule = map[string]string{
-	"":             "ResourcePolicyRule is a predicate that matches some resource requests, testing the request's verb and the target resource. A ResourcePolicyRule matches a resource request if and only if: (a) at least one member of verbs matches the request, (b) at least one member of apiGroups matches the request, (c) at least one member of resources matches the request, and (d) least one member of namespaces matches the request.",
+	"":             "ResourcePolicyRule is a predicate that matches some resource requests, testing the request's verb and the target resource. A ResourcePolicyRule matches a resource request if and only if: (a) at least one member of verbs matches the request, (b) at least one member of apiGroups matches the request, (c) at least one member of resources matches the request, and (d) either (d1) the request does not specify a namespace (i.e., `Namespace==\"\"`) and clusterScope is true or (d2) the request specifies a namespace and least one member of namespaces matches the request's namespace.",
 	"verbs":        "`verbs` is a list of matching verbs and may not be empty. \"*\" matches all verbs and, if present, must be the only entry. Required.",
 	"apiGroups":    "`apiGroups` is a list of matching API groups and may not be empty. \"*\" matches all API groups and, if present, must be the only entry. Required.",
 	"resources":    "`resources` is a list of matching resources (i.e., lowercase and plural) with, if desired, subresource.  For example, [ \"services\", \"nodes/status\" ].  This list may not be empty. \"*\" matches all resources and, if present, must be the only entry. Required.",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug

/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind cleanup

#### What this PR does / why we need it:
This PR updates the comment on ResourcePolicyRule to account for the ClusterScope field, which was added long ago.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #105393

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
