### PR TITLE
Add a networkd monitor systemd unit for COS master.

### DIFF
--- a/build/lib/release.sh
+++ b/build/lib/release.sh
@@ -452,6 +452,7 @@ function kube::release::package_kube_manifests_tarball() {
     cp "${KUBE_ROOT}/cluster/gce/gci/gke-internal-configure-helper.sh" "${dst_dir}/"
   fi
   cp "${KUBE_ROOT}/cluster/gce/gci/health-monitor.sh" "${dst_dir}/health-monitor.sh"
+  cp "${KUBE_ROOT}/cluster/gce/gci/networkd-monitor.sh" "${dst_dir}/networkd-monitor.sh"
   # Merge GCE-specific addons with general purpose addons.
   for d in cluster/addons cluster/gce/addons; do
     find "${KUBE_ROOT}/${d}" \( \( -name \*.yaml -o -name \*.yaml.in -o -name \*.json \) -a ! \( -name \*demo\* \) \) -print0 | "${TAR}" c --transform "s|${KUBE_ROOT#/*}/${d}||" --null -T - | "${TAR}" x -C "${dst_dir}"

--- a/cluster/gce/gci/configure.sh
+++ b/cluster/gce/gci/configure.sh
@@ -421,6 +421,7 @@ function install-kube-manifests {
   fi
 
   cp "${dst_dir}/kubernetes/gci-trusty/health-monitor.sh" "${KUBE_BIN}/health-monitor.sh"
+  cp "${dst_dir}/kubernetes/gci-trusty/networkd-monitor.sh" "${KUBE_BIN}/networkd-monitor.sh"
 
   rm -f "${KUBE_HOME}/${manifests_tar}"
   rm -f "${KUBE_HOME}/${manifests_tar}.sha512"

--- a/cluster/gce/gci/master.yaml
+++ b/cluster/gce/gci/master.yaml
@@ -126,6 +126,24 @@ write_files:
       [Install]
       WantedBy=kubernetes.target
 
+  - path: /etc/systemd/system/networkd-monitor.service
+    permissions: 0644
+    owner: root
+    content: |
+      [Unit]
+      Description=Health monitoring for networkd
+      After=kube-master-configuration.service
+
+      [Service]
+      Restart=always
+      RestartSec=10
+      RemainAfterExit=yes
+      ExecStartPre=/bin/chmod 544 /home/kubernetes/bin/networkd-monitor.sh
+      ExecStart=/home/kubernetes/bin/networkd-monitor.sh
+
+      [Install]
+      WantedBy=kubernetes.target
+
   - path: /etc/systemd/system/kube-logrotate.timer
     permissions: 0644
     owner: root

--- a/cluster/gce/gci/networkd-monitor.sh
+++ b/cluster/gce/gci/networkd-monitor.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+# Copyright 2021 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This script is for master and node instance health monitoring, which is
+# packed in kube-manifest tarball. It is executed through a systemd service
+# in cluster/gce/gci/<master/node>.yaml. The env variables come from an env
+# file provided by the systemd service.
+
+while true; do
+  2>&1 systemctl status systemd-networkd>/dev/null
+  if [[ $? -ne 0 ]]; then
+    echo "$(date) systemd-networkd has stopped, restarting..."
+    echo "Dumping journalctl logs systemd-networkd..."
+    journalctl --since="-1d" --no-pager -u systemd-networkd --dir=/var/log/journal
+    echo "Now running systemctl restart systemd-networkd..."
+    systemctl restart systemd-networkd
+  fi
+  sleep 60
+done


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

There is a known COS bug that networkd may be stopped during bootstrap or sometime after the bootstrap and we are adding this networkd monitor unit for mitigating that.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #NONE

#### Special notes for your reviewer:

/assign @zmerlynn 

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
