### PR TITLE
Enable setting proxyurl in kubeconfig via kubectl config

### DIFF
--- a/staging/src/k8s.io/client-go/tools/clientcmd/overrides.go
+++ b/staging/src/k8s.io/client-go/tools/clientcmd/overrides.go
@@ -72,6 +72,7 @@ type ClusterOverrideFlags struct {
 	CertificateAuthority  FlagInfo
 	InsecureSkipTLSVerify FlagInfo
 	TLSServerName         FlagInfo
+	ProxyURL              FlagInfo
 }
 
 // FlagInfo contains information about how to register a flag.  This struct is useful if you want to provide a way for an extender to
@@ -158,6 +159,7 @@ const (
 	FlagUsername         = "username"
 	FlagPassword         = "password"
 	FlagTimeout          = "request-timeout"
+	FlagProxyURL         = "proxy-url"
 )
 
 // RecommendedConfigOverrideFlags is a convenience method to return recommended flag names prefixed with a string of your choosing
@@ -192,6 +194,7 @@ func RecommendedClusterOverrideFlags(prefix string) ClusterOverrideFlags {
 		CertificateAuthority:  FlagInfo{prefix + FlagCAFile, "", "", "Path to a cert file for the certificate authority"},
 		InsecureSkipTLSVerify: FlagInfo{prefix + FlagInsecure, "", "false", "If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure"},
 		TLSServerName:         FlagInfo{prefix + FlagTLSServerName, "", "", "If provided, this name will be used to validate server certificate. If this is not provided, hostname used to contact the server is used."},
+		ProxyURL:              FlagInfo{prefix + FlagProxyURL, "", "", "If provided, this URL will be used to connect via proxy"},
 	}
 }
 
@@ -230,6 +233,7 @@ func BindClusterFlags(clusterInfo *clientcmdapi.Cluster, flags *pflag.FlagSet, f
 	flagNames.CertificateAuthority.BindStringFlag(flags, &clusterInfo.CertificateAuthority)
 	flagNames.InsecureSkipTLSVerify.BindBoolFlag(flags, &clusterInfo.InsecureSkipTLSVerify)
 	flagNames.TLSServerName.BindStringFlag(flags, &clusterInfo.TLSServerName)
+	flagNames.ProxyURL.BindStringFlag(flags, &clusterInfo.ProxyURL)
 }
 
 // BindFlags is a convenience method to bind the specified flags to their associated variables

--- a/staging/src/k8s.io/kubectl/pkg/cmd/config/create_cluster_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/config/create_cluster_test.go
@@ -55,6 +55,31 @@ func TestCreateCluster(t *testing.T) {
 	test.run(t)
 }
 
+func TestCreateClusterWithProxy(t *testing.T) {
+	conf := clientcmdapi.Config{}
+	test := createClusterTest{
+		description: "Testing 'kubectl config set-cluster' with a new cluster",
+		config:      conf,
+		args:        []string{"my-cluster"},
+		flags: []string{
+			"--server=http://192.168.0.1",
+			"--tls-server-name=my-cluster-name",
+			"--proxy-url=http://192.168.0.2",
+		},
+		expected: `Cluster "my-cluster" set.` + "\n",
+		expectedConfig: clientcmdapi.Config{
+			Clusters: map[string]*clientcmdapi.Cluster{
+				"my-cluster": {
+					Server:        "http://192.168.0.1",
+					TLSServerName: "my-cluster-name",
+					ProxyURL:      "http://192.168.0.2",
+				},
+			},
+		},
+	}
+	test.run(t)
+}
+
 func TestModifyCluster(t *testing.T) {
 	conf := clientcmdapi.Config{
 		Clusters: map[string]*clientcmdapi.Cluster{
@@ -72,6 +97,58 @@ func TestModifyCluster(t *testing.T) {
 		expectedConfig: clientcmdapi.Config{
 			Clusters: map[string]*clientcmdapi.Cluster{
 				"my-cluster": {Server: "https://192.168.0.99"},
+			},
+		},
+	}
+	test.run(t)
+}
+
+func TestModifyClusterWithProxy(t *testing.T) {
+	conf := clientcmdapi.Config{
+		Clusters: map[string]*clientcmdapi.Cluster{
+			"my-cluster": {Server: "https://192.168.0.1", TLSServerName: "to-be-cleared"},
+		},
+	}
+	test := createClusterTest{
+		description: "Testing 'kubectl config set-cluster' with an existing cluster",
+		config:      conf,
+		args:        []string{"my-cluster"},
+		flags: []string{
+			"--server=https://192.168.0.99",
+			"--proxy-url=https://192.168.0.100",
+		},
+		expected: `Cluster "my-cluster" set.` + "\n",
+		expectedConfig: clientcmdapi.Config{
+			Clusters: map[string]*clientcmdapi.Cluster{
+				"my-cluster": {Server: "https://192.168.0.99", ProxyURL: "https://192.168.0.100"},
+			},
+		},
+	}
+	test.run(t)
+}
+
+func TestModifyClusterWithProxyOverride(t *testing.T) {
+	conf := clientcmdapi.Config{
+		Clusters: map[string]*clientcmdapi.Cluster{
+			"my-cluster": {
+				Server:        "https://192.168.0.1",
+				TLSServerName: "to-be-cleared",
+				ProxyURL:      "https://192.168.0.2",
+			},
+		},
+	}
+	test := createClusterTest{
+		description: "Testing 'kubectl config set-cluster' with an existing cluster",
+		config:      conf,
+		args:        []string{"my-cluster"},
+		flags: []string{
+			"--server=https://192.168.0.99",
+			"--proxy-url=https://192.168.0.100",
+		},
+		expected: `Cluster "my-cluster" set.` + "\n",
+		expectedConfig: clientcmdapi.Config{
+			Clusters: map[string]*clientcmdapi.Cluster{
+				"my-cluster": {Server: "https://192.168.0.99", ProxyURL: "https://192.168.0.100"},
 			},
 		},
 	}

--- a/staging/src/k8s.io/kubectl/pkg/cmd/config/create_cluster_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/config/create_cluster_test.go
@@ -103,6 +103,7 @@ func TestModifyCluster(t *testing.T) {
 	test.run(t)
 }
 
+// TestModifyClusterWithProxy tests setting proxy-url in kubeconfig
 func TestModifyClusterWithProxy(t *testing.T) {
 	conf := clientcmdapi.Config{
 		Clusters: map[string]*clientcmdapi.Cluster{
@@ -127,6 +128,8 @@ func TestModifyClusterWithProxy(t *testing.T) {
 	test.run(t)
 }
 
+// TestModifyClusterWithProxyOverride tests updating proxy-url
+// in kubeconfig which already exists
 func TestModifyClusterWithProxyOverride(t *testing.T) {
 	conf := clientcmdapi.Config{
 		Clusters: map[string]*clientcmdapi.Cluster{


### PR DESCRIPTION
#### What type of PR is this?
This PR enables setting `proxy-url` in kubeconfig via kubectl config.
/kind bug

#### What this PR does / why we need it:
To set `proxy-url` via `kubectl config`

#### Which issue(s) this PR fixes:
Fixes #105565

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
Adds proxy-url flag into kubectl config set-cluster
```
