### PR TITLE
kubectl/pkg/cmd/apiresources: support JSON and YAML output

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/apiresources/apiresources.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/apiresources/apiresources.go
@@ -107,7 +107,7 @@ func NewCmdAPIResources(f cmdutil.Factory, ioStreams genericclioptions.IOStreams
 	}
 
 	cmd.Flags().BoolVar(&o.NoHeaders, "no-headers", o.NoHeaders, "When using the default or custom-column output format, don't print headers (default print headers).")
-	cmd.Flags().StringVarP(&o.Output, "output", "o", o.Output, "Output format. One of: wide|name.")
+	cmd.Flags().StringVarP(&o.Output, "output", "o", o.Output, "Output format. One of: wide|name|yaml|json.")
 
 	cmd.Flags().StringVar(&o.APIGroup, "api-group", o.APIGroup, "Limit to resources in the specified API group.")
 	cmd.Flags().BoolVar(&o.Namespaced, "namespaced", o.Namespaced, "If false, non-namespaced resources will be returned, otherwise returning namespaced resources by default.")


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Currently the `kubectl api-resources` command only supports tabular output.
This output format is not very amenable to tooling, particularly in the
presence of empty columns (we can't just look for non-blank fields).

This PR adds support for JSON and YAML output. I've done it very naively,
and there's quite probably some kind of `Printer` mechanism that would
be more appropriate, but at first glance it wasn't clear that was possible.



#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
kubectl api-resources now supports JSON and YAML output.
```
