### PR TITLE
kubelet: also provide filesystem stats for generic ephemeral volumes

### DIFF
--- a/pkg/kubelet/server/stats/volume_stat_calculator.go
+++ b/pkg/kubelet/server/stats/volume_stat_calculator.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/client-go/tools/record"
+	"k8s.io/component-helpers/storage/ephemeral"
 	"k8s.io/klog/v2"
 	stats "k8s.io/kubelet/pkg/apis/stats/v1alpha1"
 	"k8s.io/kubernetes/pkg/features"
@@ -146,6 +147,12 @@ func (s *volumeStatCalculator) calcAndStoreStats() {
 		if pvcSource := volSpec.PersistentVolumeClaim; pvcSource != nil {
 			pvcRef = &stats.PVCReference{
 				Name:      pvcSource.ClaimName,
+				Namespace: s.pod.GetNamespace(),
+			}
+		}
+		if volSpec.Ephemeral != nil && utilfeature.DefaultFeatureGate.Enabled(features.GenericEphemeralVolume) {
+			pvcRef = &stats.PVCReference{
+				Name:      ephemeral.VolumeClaimName(s.pod, &volSpec),
 				Namespace: s.pod.GetNamespace(),
 			}
 		}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

When checking for a reference to a PVC, the code also needs to consider that a
PVC might be referenced indirectly through an ephemeral volume source.

#### Which issue(s) this PR fixes:

Reported on Slack: https://kubernetes.slack.com/archives/C09QZFCE5/p1633675452222400

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
kubelet did not report `kubelet_volume_stats_*` metrics for generic ephemeral voiumes.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
- [KEP]: https://github.com/kubernetes/enhancements/tree/master/keps/sig-storage/1698-generic-ephemeral-volumes
```
