### PR TITLE
Allow the e2e_node runner to receive a KubeletConfiguration rather than requiring flags

### DIFF
--- a/hack/make-rules/test-e2e-node.sh
+++ b/hack/make-rules/test-e2e-node.sh
@@ -49,7 +49,7 @@ extra_envs=${EXTRA_ENVS:-}
 runtime_config=${RUNTIME_CONFIG:-}
 ssh_user=${SSH_USER:-"${USER}"}
 ssh_key=${SSH_KEY:-}
-kubelet_config_file=${KUBELET_CONFIG_FILE:-""}
+kubelet_config_file=${KUBELET_CONFIG_FILE:-"test/e2e_node/jenkins/default-kubelet-config.yaml"}
 
 # Parse the flags to pass to ginkgo
 ginkgoflags=""

--- a/hack/make-rules/test-e2e-node.sh
+++ b/hack/make-rules/test-e2e-node.sh
@@ -213,6 +213,7 @@ else
     --ginkgo-flags="${ginkgoflags}" --test-flags="--container-runtime=${runtime} \
     --alsologtostderr --v 4 --report-dir=${artifacts} --node-name $(hostname) \
     ${test_args}" --runtime-config="${runtime_config}" \
+    --kubelet-config-file="${kubelet_config_file}" \
     --build-dependencies=true 2>&1 | tee -i "${artifacts}/build-log.txt"
   exit $?
 fi

--- a/hack/make-rules/test-e2e-node.sh
+++ b/hack/make-rules/test-e2e-node.sh
@@ -49,6 +49,7 @@ extra_envs=${EXTRA_ENVS:-}
 runtime_config=${RUNTIME_CONFIG:-}
 ssh_user=${SSH_USER:-"${USER}"}
 ssh_key=${SSH_KEY:-}
+kubelet_config_file=${KUBELET_CONFIG_FILE:-""}
 
 # Parse the flags to pass to ginkgo
 ginkgoflags=""
@@ -164,6 +165,8 @@ if [ "${remote}" = true ] ; then
   echo "Ginkgo Flags: ${ginkgoflags}"
   echo "Instance Metadata: ${metadata}"
   echo "Image Config File: ${image_config_file}"
+  echo "Kubelet Config File: ${kubelet_config_file}"
+
   # Invoke the runner
   go run test/e2e_node/runner/remote/run_remote.go  --logtostderr --vmodule=*=4 --ssh-env="gce" \
     --zone="${zone}" --project="${project}" --gubernator="${gubernator}" \
@@ -174,7 +177,7 @@ if [ "${remote}" = true ] ; then
     --image-config-file="${image_config_file}" --system-spec-name="${system_spec_name}" \
     --runtime-config="${runtime_config}" --preemptible-instances="${preemptible_instances}" \
     --ssh-user="${ssh_user}" --ssh-key="${ssh_key}" --image-config-dir="${image_config_dir}" \
-    --extra-envs="${extra_envs}" --test-suite="${test_suite}" \
+    --extra-envs="${extra_envs}" --kubelet-config-file="${kubelet_config_file}"  --test-suite="${test_suite}" \
     "${timeout_arg}" \
     2>&1 | tee -i "${artifacts}/build-log.txt"
   exit $?

--- a/test/e2e_node/e2e_node_suite_test.go
+++ b/test/e2e_node/e2e_node_suite_test.go
@@ -168,12 +168,13 @@ func TestE2eNode(t *testing.T) {
 		}
 		return
 	}
-	// If run-services-mode is not specified, run test.
+
+	// We're not running in a special mode so lets run tests.
 	gomega.RegisterFailHandler(ginkgo.Fail)
 	reporters := []ginkgo.Reporter{}
 	reportDir := framework.TestContext.ReportDir
 	if reportDir != "" {
-		// Create the directory if it doesn't already exists
+		// Create the directory if it doesn't already exist
 		if err := os.MkdirAll(reportDir, 0755); err != nil {
 			klog.Errorf("Failed creating report directory: %v", err)
 		} else {
@@ -294,8 +295,6 @@ func waitForNodeReady() {
 }
 
 // updateTestContext updates the test context with the node name.
-// TODO(random-liu): Using dynamic kubelet configuration feature to
-// update test context with node configuration.
 func updateTestContext() error {
 	setExtraEnvs()
 	updateImageAllowList()

--- a/test/e2e_node/jenkins/default-kubelet-config.yaml
+++ b/test/e2e_node/jenkins/default-kubelet-config.yaml
@@ -1,0 +1,27 @@
+apiVersion: kubelet.config.k8s.io/v1beta1
+kind: KubeletConfiguration
+cgroupDriver: cgroupfs
+cgroupRoot: /
+
+# Assign a fixed CIDR to the node because we do not run a node controller
+# This MUST be in sync with IPs in:
+# - cluster/gce/config-test.sh and
+# - test/e2e_node/conformance/run_test.sh
+podCIDR: "10.100.0.0/24"
+
+# Aggregate volumes frequently to reduce test wait times
+volumeStatsAggPeriod: 10s
+# Check files frequently to reduce test wait times
+fileCheckFrequency: 10s
+
+evictionPressureTransitionPeriod: 30s
+evictionHard:
+  memory.available: 250Mi
+  nodefs.available: 10%
+  nodefs.inodesFree: 5%
+evictionMinimumReclaim:
+  nodefs.available: 5%
+  nodefs.inodesFree: 5%
+
+serializeImagePulls: false
+

--- a/test/e2e_node/remote/remote.go
+++ b/test/e2e_node/remote/remote.go
@@ -65,8 +65,7 @@ func CreateTestArchive(suite TestSuite, systemSpecName string) (string, error) {
 }
 
 // RunRemote returns the command output, whether the exit was ok, and any errors
-// TODO(random-liu): junitFilePrefix is not prefix actually, the file name is junit-junitFilePrefix.xml. Change the variable name.
-func RunRemote(suite TestSuite, archive string, host string, cleanup bool, imageDesc, junitFilePrefix, testArgs, ginkgoArgs, systemSpecName, extraEnvs, runtimeConfig string) (string, bool, error) {
+func RunRemote(suite TestSuite, archive string, host string, cleanup bool, imageDesc, junitFileName, testArgs, ginkgoArgs, systemSpecName, extraEnvs, runtimeConfig string) (string, bool, error) {
 	// Create the temp staging directory
 	klog.V(2).Infof("Staging test binaries on %q", host)
 	workspace := newWorkspaceDir()
@@ -111,7 +110,7 @@ func RunRemote(suite TestSuite, archive string, host string, cleanup bool, image
 	}
 
 	klog.V(2).Infof("Running test on %q", host)
-	output, err := suite.RunTest(host, workspace, resultDir, imageDesc, junitFilePrefix, testArgs, ginkgoArgs, systemSpecName, extraEnvs, runtimeConfig, *testTimeout)
+	output, err := suite.RunTest(host, workspace, resultDir, imageDesc, junitFileName, testArgs, ginkgoArgs, systemSpecName, extraEnvs, runtimeConfig, *testTimeout)
 
 	aggErrs := []error{}
 	// Do not log the output here, let the caller deal with the test output.

--- a/test/e2e_node/remote/remote.go
+++ b/test/e2e_node/remote/remote.go
@@ -65,11 +65,7 @@ func copyKubeletConfigIfExists(kubeletConfigFile, dstDir string) error {
 	defer destination.Close()
 
 	_, err = io.Copy(destination, source)
-	if err != nil {
-		return err
-	}
-
-	return os.Chmod(dst, 0x644)
+	return err
 }
 
 // CreateTestArchive creates the archive package for the node e2e test.

--- a/test/e2e_node/runner/local/run_local.go
+++ b/test/e2e_node/runner/local/run_local.go
@@ -37,6 +37,7 @@ var testFlags = flag.String("test-flags", "", "Space-separated list of arguments
 var systemSpecName = flag.String("system-spec-name", "", fmt.Sprintf("The name of the system spec used for validating the image in the node conformance test. The specs are at %s. If unspecified, the default built-in spec (system.DefaultSpec) will be used.", system.SystemSpecPath))
 var extraEnvs = flag.String("extra-envs", "", "The extra environment variables needed for node e2e tests. Format: a list of key=value pairs, e.g., env1=val1,env2=val2")
 var runtimeConfig = flag.String("runtime-config", "", "The runtime configuration for the API server on the node e2e tests. Format: a list of key=value pairs, e.g., env1=val1,env2=val2")
+var kubeletConfigFile = flag.String("kubelet-config-file", "", "The KubeletConfiguration file that should be applied to the kubelet")
 
 func main() {
 	klog.InitFlags(nil)
@@ -66,6 +67,9 @@ func main() {
 		}
 		systemSpecFile := filepath.Join(rootDir, system.SystemSpecPath, *systemSpecName+".yaml")
 		args = append(args, fmt.Sprintf("--system-spec-name=%s --system-spec-file=%s --extra-envs=%s", *systemSpecName, systemSpecFile, *extraEnvs))
+	}
+	if *kubeletConfigFile != "" {
+		args = append(args, fmt.Sprintf("--kubelet-config-file=\"%s\"", *kubeletConfigFile))
 	}
 	if err := runCommand(ginkgo, args...); err != nil {
 		klog.Exitf("Test failed: %v", err)

--- a/test/e2e_node/runner/remote/run_remote.go
+++ b/test/e2e_node/runner/remote/run_remote.go
@@ -405,7 +405,7 @@ func callGubernator(gubernator bool) {
 }
 
 func (a *Archive) getArchive() (string, error) {
-	a.Do(func() { a.path, a.err = remote.CreateTestArchive(suite, *systemSpecName) })
+	a.Do(func() { a.path, a.err = remote.CreateTestArchive(suite, *systemSpecName, *kubeletConfigFile) })
 	return a.path, a.err
 }
 

--- a/test/e2e_node/runner/remote/run_remote.go
+++ b/test/e2e_node/runner/remote/run_remote.go
@@ -69,6 +69,7 @@ var ginkgoFlags = flag.String("ginkgo-flags", "", "Passed to ginkgo to specify a
 var systemSpecName = flag.String("system-spec-name", "", fmt.Sprintf("The name of the system spec used for validating the image in the node conformance test. The specs are at %s. If unspecified, the default built-in spec (system.DefaultSpec) will be used.", system.SystemSpecPath))
 var extraEnvs = flag.String("extra-envs", "", "The extra environment variables needed for node e2e tests. Format: a list of key=value pairs, e.g., env1=val1,env2=val2")
 var runtimeConfig = flag.String("runtime-config", "", "The runtime configuration for the API server on the node e2e tests.. Format: a list of key=value pairs, e.g., env1=val1,env2=val2")
+var kubeletConfigFile = flag.String("kubelet-config-file", "", "The KubeletConfiguration file that should be applied to the kubelet")
 
 // envs is the type used to collect all node envs. The key is the env name,
 // and the value is the env value
@@ -218,7 +219,7 @@ func main() {
 	rand.Seed(time.Now().UnixNano())
 	if *buildOnly {
 		// Build the archive and exit
-		remote.CreateTestArchive(suite, *systemSpecName)
+		remote.CreateTestArchive(suite, *systemSpecName, *kubeletConfigFile)
 		return
 	}
 

--- a/test/e2e_node/services/kubelet.go
+++ b/test/e2e_node/services/kubelet.go
@@ -24,9 +24,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
-	"time"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	cliflag "k8s.io/component-base/cli/flag"
 	"k8s.io/klog/v2"
@@ -173,37 +171,8 @@ func (e *E2EServices) startKubelet() (*server, error) {
 	// --read-only-port
 	kc.ReadOnlyPort = ports.KubeletReadOnlyPort
 
-	// Setup general overrides for the kubelet.
-	// TODO(endocrimes): Move the following to a `default` configuration file
-
-	kc.CgroupRoot = "/"
-
-	kc.VolumeStatsAggPeriod = metav1.Duration{Duration: 10 * time.Second} // Aggregate volumes frequently so tests don't need to wait as long
-
-	kc.SerializeImagePulls = false
-
+	// Static Pods are in a per-test location, so we override them for tests.
 	kc.StaticPodPath = podPath
-
-	kc.FileCheckFrequency = metav1.Duration{Duration: 10 * time.Second} // Check file frequently so tests won't wait too long
-
-	// Assign a fixed CIDR to the node because there is no node controller.
-	// Note: this MUST be in sync with the IP in
-	// - cluster/gce/config-test.sh and
-	// - test/e2e_node/conformance/run_test.sh.
-	kc.PodCIDR = "10.100.0.0/24"
-
-	kc.EvictionPressureTransitionPeriod = metav1.Duration{Duration: 30 * time.Second}
-
-	kc.EvictionHard = map[string]string{
-		"memory.available":  "250Mi",
-		"nodefs.available":  "10%",
-		"nodefs.inodesFree": "5%",
-	}
-
-	kc.EvictionMinimumReclaim = map[string]string{
-		"nodefs.available":  "5%",
-		"nodefs.inodesFree": "5%",
-	}
 
 	var killCommand, restartCommand *exec.Cmd
 	var isSystemd bool


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:

This PR is one of the pre-requisites to removing dynamickubeletconfiguration - Currently the e2e_node suite only allowed the Kubelet to be configured using flags, which does not expose all config options, and makes providing per-job configuration relatively difficult.

It introduces the ability to provide a `KubeletConfiguration` file that will be used to source configuration for the tests. This allows us to customize the kubelet across various jobs as things are required for different tests, rather than any test requiring new configuration to update the config at runtime.

#### Which issue(s) this PR fixes:

Related to: #105047 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```