### PR TITLE
update extension point PostFilter comment

### DIFF
--- a/pkg/scheduler/apis/config/types.go
+++ b/pkg/scheduler/apis/config/types.go
@@ -136,7 +136,7 @@ type Plugins struct {
 	// Filter is a list of plugins that should be invoked when filtering out nodes that cannot run the Pod.
 	Filter PluginSet
 
-	// PostFilter is a list of plugins that are invoked after filtering phase, no matter whether filtering succeeds or not.
+	// PostFilter is a list of plugins that are invoked after filtering phase, but only when no feasible nodes were found for the pod.
 	PostFilter PluginSet
 
 	// PreScore is a list of plugins that are invoked before scoring.

--- a/staging/src/k8s.io/kube-scheduler/config/v1beta2/types.go
+++ b/staging/src/k8s.io/kube-scheduler/config/v1beta2/types.go
@@ -167,7 +167,7 @@ type Plugins struct {
 	// Filter is a list of plugins that should be invoked when filtering out nodes that cannot run the Pod.
 	Filter PluginSet `json:"filter,omitempty"`
 
-	// PostFilter is a list of plugins that are invoked after filtering phase, no matter whether filtering succeeds or not.
+	// PostFilter is a list of plugins that are invoked after filtering phase, but only when no feasible nodes were found for the pod.
 	PostFilter PluginSet `json:"postFilter,omitempty"`
 
 	// PreScore is a list of plugins that are invoked before scoring.

--- a/staging/src/k8s.io/kube-scheduler/config/v1beta3/types.go
+++ b/staging/src/k8s.io/kube-scheduler/config/v1beta3/types.go
@@ -160,7 +160,7 @@ type Plugins struct {
 	// Filter is a list of plugins that should be invoked when filtering out nodes that cannot run the Pod.
 	Filter PluginSet `json:"filter,omitempty"`
 
-	// PostFilter is a list of plugins that are invoked after filtering phase, no matter whether filtering succeeds or not.
+	// PostFilter is a list of plugins that are invoked after filtering phase, but only when no feasible nodes were found for the pod.
 	PostFilter PluginSet `json:"postFilter,omitempty"`
 
 	// PreScore is a list of plugins that are invoked before scoring.


### PR DESCRIPTION
#### What type of PR is this?
/sig scheduling
/kind documentation

#### What this PR does / why we need it:
According to [KEP]: <https://github.com/kubernetes/enhancements/tree/master/keps/sig-scheduling/624-scheduling-framework#postfilter>
```
PostFilter Plugins are called after Filter phase, but only when no feasible nodes were found for the pod
```

Also I found the code: 
https://github.com/kubernetes/kubernetes/blob/80056f73a614b21c7d2165d65f3b74a2fbf2264e/pkg/scheduler/scheduler.go#L455-L469
#### Which issue(s) this PR fixes:
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
