### PR TITLE
Close HTTP response body on failed GET attempts

### DIFF
--- a/staging/src/k8s.io/cli-runtime/pkg/resource/builder.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/resource/builder.go
@@ -1155,10 +1155,9 @@ func (b *Builder) Do() *Result {
 		helpers = append(helpers, RetrieveLazy)
 	}
 	if b.continueOnError {
-		r.visitor = NewDecoratedVisitor(ContinueOnErrorVisitor{r.visitor}, helpers...)
-	} else {
-		r.visitor = NewDecoratedVisitor(r.visitor, helpers...)
+		r.visitor = ContinueOnErrorVisitor{Visitor: r.visitor}
 	}
+	r.visitor = NewDecoratedVisitor(r.visitor, helpers...)
 	return r
 }
 

--- a/staging/src/k8s.io/cli-runtime/pkg/resource/visitor.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/resource/visitor.go
@@ -204,9 +204,9 @@ type EagerVisitorList []Visitor
 // Visit implements Visitor, and gathers errors that occur during processing until
 // all sub visitors have been visited.
 func (l EagerVisitorList) Visit(fn VisitorFunc) error {
-	errs := []error(nil)
+	var errs []error
 	for i := range l {
-		if err := l[i].Visit(func(info *Info, err error) error {
+		err := l[i].Visit(func(info *Info, err error) error {
 			if err != nil {
 				errs = append(errs, err)
 				return nil
@@ -215,7 +215,8 @@ func (l EagerVisitorList) Visit(fn VisitorFunc) error {
 				errs = append(errs, err)
 			}
 			return nil
-		}); err != nil {
+		})
+		if err != nil {
 			errs = append(errs, err)
 		}
 	}
@@ -350,7 +351,7 @@ type ContinueOnErrorVisitor struct {
 // returned by the visitor directly may still result in some items
 // not being visited.
 func (v ContinueOnErrorVisitor) Visit(fn VisitorFunc) error {
-	errs := []error{}
+	var errs []error
 	err := v.Visitor.Visit(func(info *Info, err error) error {
 		if err != nil {
 			errs = append(errs, err)
@@ -424,7 +425,7 @@ func (v FlattenListVisitor) Visit(fn VisitorFunc) error {
 		if info.Mapping != nil && !info.Mapping.GroupVersionKind.Empty() {
 			preferredGVKs = append(preferredGVKs, info.Mapping.GroupVersionKind)
 		}
-		errs := []error{}
+		var errs []error
 		for i := range items {
 			item, err := v.mapper.infoForObject(items[i], v.typer, preferredGVKs)
 			if err != nil {
@@ -443,7 +444,6 @@ func (v FlattenListVisitor) Visit(fn VisitorFunc) error {
 			}
 		}
 		return utilerrors.NewAggregate(errs)
-
 	})
 }
 

--- a/staging/src/k8s.io/cli-runtime/pkg/resource/visitor_test.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/resource/visitor_test.go
@@ -75,7 +75,7 @@ func TestVisitorHttpGet(t *testing.T) {
 			httpRetries: func(url string) (int, string, io.ReadCloser, error) {
 				assert.Equal(t, "hello", url)
 				i++
-				return 501, "Status", nil, nil
+				return 501, "Status", ioutil.NopCloser(new(bytes.Buffer)), nil
 			},
 			args: httpArgs{
 				duration: 0,
@@ -89,7 +89,7 @@ func TestVisitorHttpGet(t *testing.T) {
 			httpRetries: func(url string) (int, string, io.ReadCloser, error) {
 				assert.Equal(t, "hello", url)
 				i++
-				return 300, "Status", nil, nil
+				return 300, "Status", ioutil.NopCloser(new(bytes.Buffer)), nil
 
 			},
 			args: httpArgs{
@@ -104,7 +104,7 @@ func TestVisitorHttpGet(t *testing.T) {
 			httpRetries: func(url string) (int, string, io.ReadCloser, error) {
 				assert.Equal(t, "hello", url)
 				i++
-				return 501, "Status", nil, nil
+				return 501, "Status", ioutil.NopCloser(new(bytes.Buffer)), nil
 
 			},
 			args: httpArgs{
@@ -135,7 +135,7 @@ func TestVisitorHttpGet(t *testing.T) {
 				if i > 1 {
 					return 200, "Status", ioutil.NopCloser(new(bytes.Buffer)), nil
 				}
-				return 501, "Status", nil, nil
+				return 501, "Status", ioutil.NopCloser(new(bytes.Buffer)), nil
 
 			},
 			args: httpArgs{


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/sig cli

#### What this PR does / why we need it:

When more than one HTTP GET request is made and it fails, the response body must be closed before retrying or returning from the function.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
