### PR TITLE
ResettableRESTMapper to make it possible to reset wrapped mappers

### DIFF
--- a/pkg/controller/garbagecollector/garbagecollector.go
+++ b/pkg/controller/garbagecollector/garbagecollector.go
@@ -24,8 +24,6 @@ import (
 	"sync"
 	"time"
 
-	"k8s.io/klog/v2"
-
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -45,6 +43,7 @@ import (
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/controller-manager/controller"
 	"k8s.io/controller-manager/pkg/informerfactory"
+	"k8s.io/klog/v2"
 	c "k8s.io/kubernetes/pkg/controller"
 	"k8s.io/kubernetes/pkg/controller/apis/config/scheme"
 
@@ -67,7 +66,7 @@ const ResourceResyncTime time.Duration = 0
 // ensures that the garbage collector operates with a graph that is at least as
 // up to date as the notification is sent.
 type GarbageCollector struct {
-	restMapper     resettableRESTMapper
+	restMapper     meta.ResettableRESTMapper
 	metadataClient metadata.Interface
 	// garbage collector attempts to delete the items in attemptToDelete queue when the time is ripe.
 	attemptToDelete workqueue.RateLimitingInterface
@@ -87,7 +86,7 @@ var _ controller.Debuggable = (*GarbageCollector)(nil)
 func NewGarbageCollector(
 	kubeClient clientset.Interface,
 	metadataClient metadata.Interface,
-	mapper resettableRESTMapper,
+	mapper meta.ResettableRESTMapper,
 	ignoredResources map[schema.GroupResource]struct{},
 	sharedInformers informerfactory.InformerFactory,
 	informersStarted <-chan struct{},
@@ -162,13 +161,6 @@ func (gc *GarbageCollector) Run(ctx context.Context, workers int) {
 	}
 
 	<-ctx.Done()
-}
-
-// resettableRESTMapper is a RESTMapper which is capable of resetting itself
-// from discovery.
-type resettableRESTMapper interface {
-	meta.RESTMapper
-	Reset()
 }
 
 // Sync periodically resyncs the garbage collector when new resources are

--- a/pkg/controller/garbagecollector/garbagecollector_test.go
+++ b/pkg/controller/garbagecollector/garbagecollector_test.go
@@ -67,7 +67,9 @@ type testRESTMapper struct {
 	meta.RESTMapper
 }
 
-func (*testRESTMapper) Reset() {}
+func (m *testRESTMapper) Reset() {
+	meta.MaybeResetRESTMapper(m.RESTMapper)
+}
 
 func TestGarbageCollectorConstruction(t *testing.T) {
 	config := &restclient.Config{}

--- a/staging/src/k8s.io/apimachinery/pkg/api/meta/firsthit_restmapper.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/meta/firsthit_restmapper.go
@@ -23,6 +23,10 @@ import (
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 )
 
+var (
+	_ ResettableRESTMapper = &FirstHitRESTMapper{}
+)
+
 // FirstHitRESTMapper is a wrapper for multiple RESTMappers which returns the
 // first successful result for the singular requests
 type FirstHitRESTMapper struct {
@@ -73,6 +77,10 @@ func (m FirstHitRESTMapper) RESTMapping(gk schema.GroupKind, versions ...string)
 	}
 
 	return nil, collapseAggregateErrors(errors)
+}
+
+func (m FirstHitRESTMapper) Reset() {
+	m.MultiRESTMapper.Reset()
 }
 
 // collapseAggregateErrors returns the minimal errors.  it handles empty as nil, handles one item in a list

--- a/staging/src/k8s.io/apimachinery/pkg/api/meta/interfaces.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/meta/interfaces.go
@@ -132,3 +132,12 @@ type RESTMapper interface {
 
 	ResourceSingularizer(resource string) (singular string, err error)
 }
+
+// ResettableRESTMapper is a RESTMapper which is capable of resetting itself
+// from discovery.
+// All rest mappers that delegate to other rest mappers must implement this interface and dynamically
+// check if the delegate mapper supports the Reset() operation.
+type ResettableRESTMapper interface {
+	RESTMapper
+	Reset()
+}

--- a/staging/src/k8s.io/apimachinery/pkg/api/meta/multirestmapper.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/meta/multirestmapper.go
@@ -24,11 +24,15 @@ import (
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 )
 
+var (
+	_ ResettableRESTMapper = MultiRESTMapper{}
+)
+
 // MultiRESTMapper is a wrapper for multiple RESTMappers.
 type MultiRESTMapper []RESTMapper
 
 func (m MultiRESTMapper) String() string {
-	nested := []string{}
+	nested := make([]string, 0, len(m))
 	for _, t := range m {
 		currString := fmt.Sprintf("%v", t)
 		splitStrings := strings.Split(currString, "\n")
@@ -207,4 +211,10 @@ func (m MultiRESTMapper) RESTMappings(gk schema.GroupKind, versions ...string) (
 		return nil, &NoKindMatchError{GroupKind: gk, SearchedVersions: versions}
 	}
 	return allMappings, nil
+}
+
+func (m MultiRESTMapper) Reset() {
+	for _, t := range m {
+		MaybeResetRESTMapper(t)
+	}
 }

--- a/staging/src/k8s.io/apimachinery/pkg/api/meta/priority.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/meta/priority.go
@@ -29,6 +29,10 @@ const (
 	AnyKind     = "*"
 )
 
+var (
+	_ ResettableRESTMapper = PriorityRESTMapper{}
+)
+
 // PriorityRESTMapper is a wrapper for automatically choosing a particular Resource or Kind
 // when multiple matches are possible
 type PriorityRESTMapper struct {
@@ -219,4 +223,8 @@ func (m PriorityRESTMapper) ResourcesFor(partiallySpecifiedResource schema.Group
 
 func (m PriorityRESTMapper) KindsFor(partiallySpecifiedResource schema.GroupVersionResource) (gvk []schema.GroupVersionKind, err error) {
 	return m.Delegate.KindsFor(partiallySpecifiedResource)
+}
+
+func (m PriorityRESTMapper) Reset() {
+	MaybeResetRESTMapper(m.Delegate)
 }

--- a/staging/src/k8s.io/apimachinery/pkg/api/meta/restmapper.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/meta/restmapper.go
@@ -519,3 +519,12 @@ func (m *DefaultRESTMapper) RESTMappings(gk schema.GroupKind, versions ...string
 	}
 	return mappings, nil
 }
+
+// MaybeResetRESTMapper calls Reset() on the mapper if it is a ResettableRESTMapper.
+func MaybeResetRESTMapper(mapper RESTMapper) bool {
+	m, ok := mapper.(ResettableRESTMapper)
+	if ok {
+		m.Reset()
+	}
+	return ok
+}

--- a/staging/src/k8s.io/cli-runtime/pkg/resource/builder_test.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/resource/builder_test.go
@@ -335,6 +335,10 @@ func (l *errorRestMapper) RESTMapping(gk schema.GroupKind, versions ...string) (
 	return nil, l.err
 }
 
+func (l *errorRestMapper) Reset() {
+	meta.MaybeResetRESTMapper(l.RESTMapper)
+}
+
 func newDefaultBuilderWithMapperError(fakeClientFn FakeClientFunc, err error) *Builder {
 	return NewFakeBuilder(
 		fakeClientFn,

--- a/staging/src/k8s.io/client-go/restmapper/discovery.go
+++ b/staging/src/k8s.io/client-go/restmapper/discovery.go
@@ -335,4 +335,4 @@ func (d *DeferredDiscoveryRESTMapper) String() string {
 }
 
 // Make sure it satisfies the interface
-var _ meta.RESTMapper = &DeferredDiscoveryRESTMapper{}
+var _ meta.ResettableRESTMapper = &DeferredDiscoveryRESTMapper{}

--- a/staging/src/k8s.io/client-go/restmapper/shortcut.go
+++ b/staging/src/k8s.io/client-go/restmapper/shortcut.go
@@ -34,7 +34,7 @@ type shortcutExpander struct {
 	discoveryClient discovery.DiscoveryInterface
 }
 
-var _ meta.RESTMapper = &shortcutExpander{}
+var _ meta.ResettableRESTMapper = shortcutExpander{}
 
 // NewShortcutExpander wraps a restmapper in a layer that expands shortcuts found via discovery
 func NewShortcutExpander(delegate meta.RESTMapper, client discovery.DiscoveryInterface) meta.RESTMapper {
@@ -162,6 +162,10 @@ func (e shortcutExpander) expandResourceShortcut(resource schema.GroupVersionRes
 	}
 
 	return resource
+}
+
+func (e shortcutExpander) Reset() {
+	meta.MaybeResetRESTMapper(e.RESTMapper)
 }
 
 // ResourceShortcuts represents a structure that holds the information how to


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/sig api-machinery
/sig cli

#### What this PR does / why we need it:

Having a proper API to reset a REST mapper is useful:
1. As it is seen in this PR, garbage collector uses this functionality.
2. `cli-util` uses this functionality via reflection [here](https://github.com/kubernetes-sigs/cli-utils/blob/a1b40b59d5981ecd257a9ff8caa525c4fa1dadb4/pkg/apply/taskrunner/task.go#L196-L211) (see also https://github.com/kubernetes-sigs/cli-utils/issues/421#issuecomment-938475274).

Currently those implementations are fragile as if a mapper is wrapped, it becomes impossible to reset it properly (i.e. reset the delegate).

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
