### PR TITLE
adding `--ssh-key` and `--ssh-user` for kubetest2

### DIFF
--- a/build/root/Makefile
+++ b/build/root/Makefile
@@ -254,7 +254,7 @@ define TEST_E2E_NODE_HELP_INFO
 #  GUBERNATOR: For REMOTE=true only. Produce link to Gubernator to view logs.
 #    Defaults to false.
 #  TEST_SUITE: For REMOTE=true only. Test suite to use. Defaults to "default".
-#  SSH_KEY: For existing SSH keys.
+#  SSH_KEY: For REMOTE=true only. Path to SSH key to use.
 #
 # Example:
 #   make test-e2e-node FOCUS=Kubelet SKIP=container

--- a/build/root/Makefile
+++ b/build/root/Makefile
@@ -254,6 +254,7 @@ define TEST_E2E_NODE_HELP_INFO
 #  GUBERNATOR: For REMOTE=true only. Produce link to Gubernator to view logs.
 #    Defaults to false.
 #  TEST_SUITE: For REMOTE=true only. Test suite to use. Defaults to "default".
+#  SSH_KEY: For existing SSH keys.
 #
 # Example:
 #   make test-e2e-node FOCUS=Kubelet SKIP=container

--- a/hack/make-rules/test-e2e-node.sh
+++ b/hack/make-rules/test-e2e-node.sh
@@ -48,7 +48,7 @@ system_spec_name=${SYSTEM_SPEC_NAME:-}
 extra_envs=${EXTRA_ENVS:-}
 runtime_config=${RUNTIME_CONFIG:-}
 ssh_user=${SSH_USER:-"${USER}"}
-ssh_key=${SSH_KEY:-}
+ssh_key=${SSH_KEY:-""}
 
 # Parse the flags to pass to ginkgo
 ginkgoflags=""

--- a/hack/make-rules/test-e2e-node.sh
+++ b/hack/make-rules/test-e2e-node.sh
@@ -48,7 +48,7 @@ system_spec_name=${SYSTEM_SPEC_NAME:-}
 extra_envs=${EXTRA_ENVS:-}
 runtime_config=${RUNTIME_CONFIG:-}
 ssh_user=${SSH_USER:-"${USER}"}
-ssh_key=${SSH_KEY:-""}
+ssh_key=${SSH_KEY:-}
 
 # Parse the flags to pass to ginkgo
 ginkgoflags=""

--- a/hack/make-rules/test-e2e-node.sh
+++ b/hack/make-rules/test-e2e-node.sh
@@ -47,6 +47,8 @@ timeout_arg=""
 system_spec_name=${SYSTEM_SPEC_NAME:-}
 extra_envs=${EXTRA_ENVS:-}
 runtime_config=${RUNTIME_CONFIG:-}
+ssh_user=${SSH_USER:-}
+ssh_key=${SSH_KEY:-}
 
 # Parse the flags to pass to ginkgo
 ginkgoflags=""
@@ -170,6 +172,7 @@ if [ "${remote}" = true ] ; then
     --delete-instances="${delete_instances}" --test_args="${test_args}" --instance-metadata="${metadata}" \
     --image-config-file="${image_config_file}" --system-spec-name="${system_spec_name}" \
     --runtime-config="${runtime_config}" --preemptible-instances="${preemptible_instances}" \
+    --ssh-user="${ssh_user}" --ssh-key="${ssh_key}" \
     --extra-envs="${extra_envs}" --test-suite="${test_suite}" \
     "${timeout_arg}" \
     2>&1 | tee -i "${artifacts}/build-log.txt"

--- a/hack/make-rules/test-e2e-node.sh
+++ b/hack/make-rules/test-e2e-node.sh
@@ -47,7 +47,7 @@ timeout_arg=""
 system_spec_name=${SYSTEM_SPEC_NAME:-}
 extra_envs=${EXTRA_ENVS:-}
 runtime_config=${RUNTIME_CONFIG:-}
-ssh_user=${SSH_USER:-}
+ssh_user=${SSH_USER:-${USER}}
 ssh_key=${SSH_KEY:-${GCE_SSH_PRIVATE_KEY_FILE:-${USER}/.ssh/google_compute_engine}}
 
 # Parse the flags to pass to ginkgo

--- a/hack/make-rules/test-e2e-node.sh
+++ b/hack/make-rules/test-e2e-node.sh
@@ -48,7 +48,7 @@ system_spec_name=${SYSTEM_SPEC_NAME:-}
 extra_envs=${EXTRA_ENVS:-}
 runtime_config=${RUNTIME_CONFIG:-}
 ssh_user=${SSH_USER:-}
-ssh_key=${SSH_KEY:-}
+ssh_key=${SSH_KEY:-${GCE_SSH_PRIVATE_KEY_FILE:-${USER}/.ssh/google_compute_engine}}
 
 # Parse the flags to pass to ginkgo
 ginkgoflags=""

--- a/hack/make-rules/test-e2e-node.sh
+++ b/hack/make-rules/test-e2e-node.sh
@@ -48,7 +48,7 @@ system_spec_name=${SYSTEM_SPEC_NAME:-}
 extra_envs=${EXTRA_ENVS:-}
 runtime_config=${RUNTIME_CONFIG:-}
 ssh_user=${SSH_USER:-${USER}}
-ssh_key=${SSH_KEY:-${GCE_SSH_PRIVATE_KEY_FILE:-${USER}/.ssh/google_compute_engine}}
+ssh_key=${SSH_KEY:-}
 
 # Parse the flags to pass to ginkgo
 ginkgoflags=""

--- a/hack/make-rules/test-e2e-node.sh
+++ b/hack/make-rules/test-e2e-node.sh
@@ -47,7 +47,7 @@ timeout_arg=""
 system_spec_name=${SYSTEM_SPEC_NAME:-}
 extra_envs=${EXTRA_ENVS:-}
 runtime_config=${RUNTIME_CONFIG:-}
-ssh_user=${SSH_USER:-${USER}}
+ssh_user=${SSH_USER:-"${USER}"}
 ssh_key=${SSH_KEY:-}
 
 # Parse the flags to pass to ginkgo

--- a/test/e2e_node/remote/ssh.go
+++ b/test/e2e_node/remote/ssh.go
@@ -44,8 +44,12 @@ func init() {
 	sshOptionsMap = map[string]string{
 		"gce": "-o UserKnownHostsFile=/dev/null -o IdentitiesOnly=yes -o CheckHostIP=no -o StrictHostKeyChecking=no -o ServerAliveInterval=30 -o LogLevel=ERROR",
 	}
+	defaultGceKey := os.Getenv("GCE_SSH_PRIVATE_KEY_FILE")
+	if defaultGceKey == "" {
+		defaultGceKey = fmt.Sprintf("%s/.ssh/google_compute_engine", usr.HomeDir)
+	}
 	sshDefaultKeyMap = map[string]string{
-		"gce": fmt.Sprintf("%s/.ssh/google_compute_engine", usr.HomeDir),
+		"gce": defaultGceKey,
 	}
 }
 


### PR DESCRIPTION
Signed-off-by: Namanl2001 <namanlakhwani@gmail.com>

This PR is part of the CI migration from kubetest to kubetest2
https://github.com/kubernetes/enhancements/tree/master/keps/sig-testing/2464-kubetest2-ci-migration

`--ssh-key` and `--ssh-user` are not present for kubetest2, which is leading to this error: `failed to run SSH command: out: Warning: Identity file /root/.ssh/google_compute_engine not accessible: No such file or directory :`
ref: https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/92316/pull-kubernetes-node-e2e-kubetest2/1446852497472753664#1:build-log.txt%3A114

Using these args in kubetest2 via https://github.com/kubernetes-sigs/kubetest2/pull/169
