### PR TITLE
Automated cherry pick of #105249: Clear initial UDP conntrack entries for loadBalancerIPs

### DIFF
--- a/pkg/proxy/ipvs/proxier.go
+++ b/pkg/proxy/ipvs/proxier.go
@@ -1041,6 +1041,9 @@ func (proxier *Proxier) syncProxyRules() {
 			for _, extIP := range svcInfo.ExternalIPStrings() {
 				staleServices.Insert(extIP)
 			}
+			for _, extIP := range svcInfo.LoadBalancerIPStrings() {
+				staleServices.Insert(extIP)
+			}
 		}
 	}
 


### PR DESCRIPTION
Cherry pick of #105249 on release-1.22.

#105249: Clear initial UDP conntrack entries for loadBalancerIPs

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
kube-proxy(ipvs mode) : delete stale conntrack UDP entries for loadbalancer ingress IP.
```