### PR TITLE
Refactor to use structure to pass parameters for GracefulNodeShutdown

### DIFF
--- a/pkg/kubelet/kubelet_test.go
+++ b/pkg/kubelet/kubelet_test.go
@@ -314,7 +314,16 @@ func newTestKubeletWithImageList(
 	kubelet.admitHandlers.AddPodAdmitHandler(evictionAdmitHandler)
 
 	// setup shutdown manager
-	shutdownManager, shutdownAdmitHandler := nodeshutdown.NewManager(kubelet.probeManager, fakeRecorder, nodeRef, kubelet.podManager.GetPods, killPodNow(kubelet.podWorkers, fakeRecorder), func() {}, 0 /* shutdownGracePeriodRequested*/, 0 /*shutdownGracePeriodCriticalPods */)
+	shutdownManager, shutdownAdmitHandler := nodeshutdown.NewManager(&nodeshutdown.Config{
+		ProbeManager:                    kubelet.probeManager,
+		Recorder:                        fakeRecorder,
+		NodeRef:                         nodeRef,
+		GetPodsFunc:                     kubelet.podManager.GetPods,
+		KillPodFunc:                     killPodNow(kubelet.podWorkers, fakeRecorder),
+		SyncNodeStatusFunc:              func() {},
+		ShutdownGracePeriodRequested:    0,
+		ShutdownGracePeriodCriticalPods: 0,
+	})
 	kubelet.shutdownManager = shutdownManager
 	kubelet.admitHandlers.AddPodAdmitHandler(shutdownAdmitHandler)
 

--- a/pkg/kubelet/nodeshutdown/nodeshutdown_manager.go
+++ b/pkg/kubelet/nodeshutdown/nodeshutdown_manager.go
@@ -1,0 +1,66 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package nodeshutdown
+
+import (
+	"time"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/tools/record"
+	"k8s.io/kubernetes/pkg/kubelet/eviction"
+	"k8s.io/kubernetes/pkg/kubelet/lifecycle"
+	"k8s.io/kubernetes/pkg/kubelet/prober"
+	"k8s.io/utils/clock"
+)
+
+// Manager interface provides methods for Kubelet to manage node shutdown.
+type Manager interface {
+	Admit(attrs *lifecycle.PodAdmitAttributes) lifecycle.PodAdmitResult
+	Start() error
+	ShutdownStatus() error
+}
+
+// Config represents Manager configuration
+type Config struct {
+	ProbeManager                    prober.Manager
+	Recorder                        record.EventRecorder
+	NodeRef                         *v1.ObjectReference
+	GetPodsFunc                     eviction.ActivePodsFunc
+	KillPodFunc                     eviction.KillPodFunc
+	SyncNodeStatusFunc              func()
+	ShutdownGracePeriodRequested    time.Duration
+	ShutdownGracePeriodCriticalPods time.Duration
+	Clock                           clock.Clock
+}
+
+// managerStub is a fake node shutdown managerImpl .
+type managerStub struct{}
+
+// Admit returns a fake Pod admission which always returns true
+func (managerStub) Admit(attrs *lifecycle.PodAdmitAttributes) lifecycle.PodAdmitResult {
+	return lifecycle.PodAdmitResult{Admit: true}
+}
+
+// Start is a no-op always returning nil for non linux platforms.
+func (managerStub) Start() error {
+	return nil
+}
+
+// ShutdownStatus is a no-op always returning nil for non linux platforms.
+func (managerStub) ShutdownStatus() error {
+	return nil
+}

--- a/pkg/kubelet/nodeshutdown/nodeshutdown_manager_linux.go
+++ b/pkg/kubelet/nodeshutdown/nodeshutdown_manager_linux.go
@@ -103,6 +103,10 @@ func NewManager(conf *Config) (Manager, lifecycle.PodAdmitHandler) {
 		shutdownGracePeriodCriticalPods: conf.ShutdownGracePeriodCriticalPods,
 		clock:                           conf.Clock,
 	}
+	klog.InfoS("Creating node shutdown manager",
+		"shutdownGracePeriodRequested", conf.ShutdownGracePeriodRequested,
+		"shutdownGracePeriodCriticalPods", conf.ShutdownGracePeriodCriticalPods,
+	)
 	return manager, manager
 }
 

--- a/pkg/kubelet/nodeshutdown/nodeshutdown_manager_linux.go
+++ b/pkg/kubelet/nodeshutdown/nodeshutdown_manager_linux.go
@@ -60,8 +60,8 @@ type dbusInhibiter interface {
 	OverrideInhibitDelay(inhibitDelayMax time.Duration) error
 }
 
-// Manager has functions that can be used to interact with the Node Shutdown Manager.
-type Manager struct {
+// managerImpl has functions that can be used to interact with the Node Shutdown Manager.
+type managerImpl struct {
 	recorder     record.EventRecorder
 	nodeRef      *v1.ObjectReference
 	probeManager prober.Manager
@@ -83,23 +83,31 @@ type Manager struct {
 }
 
 // NewManager returns a new node shutdown manager.
-func NewManager(probeManager prober.Manager, recorder record.EventRecorder, nodeRef *v1.ObjectReference, getPodsFunc eviction.ActivePodsFunc, killPodFunc eviction.KillPodFunc, syncNodeStatus func(), shutdownGracePeriodRequested, shutdownGracePeriodCriticalPods time.Duration) (*Manager, lifecycle.PodAdmitHandler) {
-	manager := &Manager{
-		recorder:                        recorder,
-		nodeRef:                         nodeRef,
-		getPods:                         getPodsFunc,
-		killPodFunc:                     killPodFunc,
-		syncNodeStatus:                  syncNodeStatus,
-		shutdownGracePeriodRequested:    shutdownGracePeriodRequested,
-		shutdownGracePeriodCriticalPods: shutdownGracePeriodCriticalPods,
-		clock:                           clock.RealClock{},
-		probeManager:                    probeManager,
+func NewManager(conf *Config) (Manager, lifecycle.PodAdmitHandler) {
+	if !utilfeature.DefaultFeatureGate.Enabled(features.GracefulNodeShutdown) ||
+		(conf.ShutdownGracePeriodRequested == 0 && conf.ShutdownGracePeriodCriticalPods == 0) {
+		m := managerStub{}
+		return m, m
+	}
+	if conf.Clock == nil {
+		conf.Clock = clock.RealClock{}
+	}
+	manager := &managerImpl{
+		probeManager:                    conf.ProbeManager,
+		recorder:                        conf.Recorder,
+		nodeRef:                         conf.NodeRef,
+		getPods:                         conf.GetPodsFunc,
+		killPodFunc:                     conf.KillPodFunc,
+		syncNodeStatus:                  conf.SyncNodeStatusFunc,
+		shutdownGracePeriodRequested:    conf.ShutdownGracePeriodRequested,
+		shutdownGracePeriodCriticalPods: conf.ShutdownGracePeriodCriticalPods,
+		clock:                           conf.Clock,
 	}
 	return manager, manager
 }
 
 // Admit rejects all pods if node is shutting
-func (m *Manager) Admit(attrs *lifecycle.PodAdmitAttributes) lifecycle.PodAdmitResult {
+func (m *managerImpl) Admit(attrs *lifecycle.PodAdmitAttributes) lifecycle.PodAdmitResult {
 	nodeShuttingDown := m.ShutdownStatus() != nil
 
 	if nodeShuttingDown {
@@ -113,10 +121,7 @@ func (m *Manager) Admit(attrs *lifecycle.PodAdmitAttributes) lifecycle.PodAdmitR
 }
 
 // Start starts the node shutdown manager and will start watching the node for shutdown events.
-func (m *Manager) Start() error {
-	if !m.isFeatureEnabled() {
-		return nil
-	}
+func (m *managerImpl) Start() error {
 	stop, err := m.start()
 	if err != nil {
 		return err
@@ -138,7 +143,7 @@ func (m *Manager) Start() error {
 	return nil
 }
 
-func (m *Manager) start() (chan struct{}, error) {
+func (m *managerImpl) start() (chan struct{}, error) {
 	systemBus, err := systemDbus()
 	if err != nil {
 		return nil, err
@@ -234,7 +239,7 @@ func (m *Manager) start() (chan struct{}, error) {
 	return stop, nil
 }
 
-func (m *Manager) aquireInhibitLock() error {
+func (m *managerImpl) aquireInhibitLock() error {
 	lock, err := m.dbusCon.InhibitShutdown()
 	if err != nil {
 		return err
@@ -246,17 +251,8 @@ func (m *Manager) aquireInhibitLock() error {
 	return nil
 }
 
-// Returns if the feature is enabled
-func (m *Manager) isFeatureEnabled() bool {
-	return utilfeature.DefaultFeatureGate.Enabled(features.GracefulNodeShutdown) && m.shutdownGracePeriodRequested > 0
-}
-
 // ShutdownStatus will return an error if the node is currently shutting down.
-func (m *Manager) ShutdownStatus() error {
-	if !m.isFeatureEnabled() {
-		return nil
-	}
-
+func (m *managerImpl) ShutdownStatus() error {
 	m.nodeShuttingDownMutex.Lock()
 	defer m.nodeShuttingDownMutex.Unlock()
 
@@ -266,7 +262,7 @@ func (m *Manager) ShutdownStatus() error {
 	return nil
 }
 
-func (m *Manager) processShutdownEvent() error {
+func (m *managerImpl) processShutdownEvent() error {
 	klog.V(1).InfoS("Shutdown manager processing shutdown event")
 	activePods := m.getPods()
 

--- a/pkg/kubelet/nodeshutdown/nodeshutdown_manager_others.go
+++ b/pkg/kubelet/nodeshutdown/nodeshutdown_manager_others.go
@@ -20,35 +20,11 @@ limitations under the License.
 package nodeshutdown
 
 import (
-	"time"
-
-	v1 "k8s.io/api/core/v1"
-	"k8s.io/client-go/tools/record"
-	"k8s.io/kubernetes/pkg/kubelet/eviction"
 	"k8s.io/kubernetes/pkg/kubelet/lifecycle"
-	"k8s.io/kubernetes/pkg/kubelet/prober"
 )
 
-// Manager is a fake node shutdown manager for non linux platforms.
-type Manager struct{}
-
 // NewManager returns a fake node shutdown manager for non linux platforms.
-func NewManager(proberManager prober.Manager, recorder record.EventRecorder, nodeRef *v1.ObjectReference, getPodsFunc eviction.ActivePodsFunc, killPodFunc eviction.KillPodFunc, syncNodeStatus func(), shutdownGracePeriodRequested, shutdownGracePeriodCriticalPods time.Duration) (*Manager, lifecycle.PodAdmitHandler) {
-	m := &Manager{}
+func NewManager(conf *Config) (Manager, lifecycle.PodAdmitHandler) {
+	m := managerStub{}
 	return m, m
-}
-
-// Admit returns a fake Pod admission which always returns true
-func (m *Manager) Admit(attrs *lifecycle.PodAdmitAttributes) lifecycle.PodAdmitResult {
-	return lifecycle.PodAdmitResult{Admit: true}
-}
-
-// Start is a no-op always returning nil for non linux platforms.
-func (m *Manager) Start() error {
-	return nil
-}
-
-// ShutdownStatus is a no-op always returning nil for non linux platforms.
-func (m *Manager) ShutdownStatus() error {
-	return nil
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
xref #102915

#### Special notes for your reviewer:

#102915, I think this naming is still a bit controversial, I sent a new PR to do the refactoring part to use structure to pass parameters to reduce the workload of conflict resolution.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
NONE
```

/cc @mrunalp @bobbypage 
