### PR TITLE
apf: update queue debug to include queue sum stats and next dispatch R in seat-seconds

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/apf_controller_debug.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/apf_controller_debug.go
@@ -19,6 +19,7 @@ package flowcontrol
 import (
 	"fmt"
 	"io"
+	"k8s.io/apiserver/pkg/util/flowcontrol/debug"
 	"net/http"
 	"strconv"
 	"strings"
@@ -103,6 +104,9 @@ func (cfgCtlr *configController) dumpQueues(w http.ResponseWriter, r *http.Reque
 		"PendingRequests",   // 3
 		"ExecutingRequests", // 4
 		"VirtualStart",      // 5
+		"InitialSeatsSum",   // 6
+		"MaxSeatsSum",       // 7
+		"TotalWorkSum",      // 8
 	}
 	tabPrint(tabWriter, rowForHeaders(columnHeaders))
 	endLine(tabWriter)
@@ -114,6 +118,9 @@ func (cfgCtlr *configController) dumpQueues(w http.ResponseWriter, r *http.Reque
 				"<none>",        // 3
 				"<none>",        // 4
 				"<none>",        // 5
+				"<none>",        // 6
+				"<none>",        // 7
+				"<none>",        // 8
 			))
 			endLine(tabWriter)
 			continue
@@ -126,6 +133,7 @@ func (cfgCtlr *configController) dumpQueues(w http.ResponseWriter, r *http.Reque
 				len(q.Requests),     // 3
 				q.ExecutingRequests, // 4
 				q.VirtualStart,      // 5
+				q.QueueSum,          // 6, 7, 8
 			))
 			endLine(tabWriter)
 		}
@@ -229,13 +237,16 @@ func rowForPriorityLevel(plName string, activeQueues int, isIdle, isQuiescing bo
 	)
 }
 
-func rowForQueue(plName string, index, waitingRequests, executingRequests int, virtualStart float64) string {
+func rowForQueue(plName string, index, waitingRequests, executingRequests int, virtualStart float64, sum debug.QueueSum) string {
 	return row(
 		plName,
 		strconv.Itoa(index),
 		strconv.Itoa(waitingRequests),
 		strconv.Itoa(executingRequests),
 		fmt.Sprintf("%.4f", virtualStart),
+		strconv.Itoa(sum.InitialSeatsSum),
+		strconv.Itoa(sum.MaxSeatsSum),
+		sum.TotalWorkSum,
 	)
 }
 

--- a/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/apf_controller_debug.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/apf_controller_debug.go
@@ -19,7 +19,6 @@ package flowcontrol
 import (
 	"fmt"
 	"io"
-	"k8s.io/apiserver/pkg/util/flowcontrol/debug"
 	"net/http"
 	"strconv"
 	"strings"
@@ -103,10 +102,11 @@ func (cfgCtlr *configController) dumpQueues(w http.ResponseWriter, r *http.Reque
 		"Index",             // 2
 		"PendingRequests",   // 3
 		"ExecutingRequests", // 4
-		"NextDispatchR",     // 5
-		"InitialSeatsSum",   // 6
-		"MaxSeatsSum",       // 7
-		"TotalWorkSum",      // 8
+		"SeatsInUse",        // 5
+		"NextDispatchR",     // 6
+		"InitialSeatsSum",   // 7
+		"MaxSeatsSum",       // 8
+		"TotalWorkSum",      // 9
 	}
 	tabPrint(tabWriter, rowForHeaders(columnHeaders))
 	endLine(tabWriter)
@@ -121,19 +121,23 @@ func (cfgCtlr *configController) dumpQueues(w http.ResponseWriter, r *http.Reque
 				"<none>",        // 6
 				"<none>",        // 7
 				"<none>",        // 8
+				"<none>",        // 9
 			))
 			endLine(tabWriter)
 			continue
 		}
 		queueSetDigest := plState.queues.Dump(false)
 		for i, q := range queueSetDigest.Queues {
-			tabPrint(tabWriter, rowForQueue(
-				plState.pl.Name,     // 1
-				i,                   // 2
-				len(q.Requests),     // 3
-				q.ExecutingRequests, // 4
-				q.NextDispatchR,     // 5
-				q.QueueSum,          // 6, 7, 8
+			tabPrint(tabWriter, row(
+				plState.pl.Name,                          // 1 - "PriorityLevelName"
+				strconv.Itoa(i),                          // 2 - "Index"
+				strconv.Itoa(len(q.Requests)),            // 3 - "PendingRequests"
+				strconv.Itoa(q.ExecutingRequests),        // 4 - "ExecutingRequests"
+				strconv.Itoa(q.SeatsInUse),               // 5 - "SeatsInUse"
+				q.NextDispatchR,                          // 6 - "NextDispatchR"
+				strconv.Itoa(q.QueueSum.InitialSeatsSum), // 7 - "InitialSeatsSum"
+				strconv.Itoa(q.QueueSum.MaxSeatsSum),     // 8 - "MaxSeatsSum"
+				q.QueueSum.TotalWorkSum,                  // 9 - "TotalWorkSum"
 			))
 			endLine(tabWriter)
 		}
@@ -234,19 +238,6 @@ func rowForPriorityLevel(plName string, activeQueues int, isIdle, isQuiescing bo
 		strconv.FormatBool(isQuiescing),
 		strconv.Itoa(waitingRequests),
 		strconv.Itoa(executingRequests),
-	)
-}
-
-func rowForQueue(plName string, index, waitingRequests, executingRequests int, nextDispatchR string, sum debug.QueueSum) string {
-	return row(
-		plName,
-		strconv.Itoa(index),
-		strconv.Itoa(waitingRequests),
-		strconv.Itoa(executingRequests),
-		nextDispatchR,
-		strconv.Itoa(sum.InitialSeatsSum),
-		strconv.Itoa(sum.MaxSeatsSum),
-		sum.TotalWorkSum,
 	)
 }
 

--- a/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/apf_controller_debug.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/apf_controller_debug.go
@@ -103,7 +103,7 @@ func (cfgCtlr *configController) dumpQueues(w http.ResponseWriter, r *http.Reque
 		"Index",             // 2
 		"PendingRequests",   // 3
 		"ExecutingRequests", // 4
-		"VirtualStart",      // 5
+		"NextDispatchR",     // 5
 		"InitialSeatsSum",   // 6
 		"MaxSeatsSum",       // 7
 		"TotalWorkSum",      // 8
@@ -132,7 +132,7 @@ func (cfgCtlr *configController) dumpQueues(w http.ResponseWriter, r *http.Reque
 				i,                   // 2
 				len(q.Requests),     // 3
 				q.ExecutingRequests, // 4
-				q.VirtualStart,      // 5
+				q.NextDispatchR,     // 5
 				q.QueueSum,          // 6, 7, 8
 			))
 			endLine(tabWriter)
@@ -237,13 +237,13 @@ func rowForPriorityLevel(plName string, activeQueues int, isIdle, isQuiescing bo
 	)
 }
 
-func rowForQueue(plName string, index, waitingRequests, executingRequests int, virtualStart float64, sum debug.QueueSum) string {
+func rowForQueue(plName string, index, waitingRequests, executingRequests int, nextDispatchR string, sum debug.QueueSum) string {
 	return row(
 		plName,
 		strconv.Itoa(index),
 		strconv.Itoa(waitingRequests),
 		strconv.Itoa(executingRequests),
-		fmt.Sprintf("%.4f", virtualStart),
+		nextDispatchR,
 		strconv.Itoa(sum.InitialSeatsSum),
 		strconv.Itoa(sum.MaxSeatsSum),
 		sum.TotalWorkSum,

--- a/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/debug/dump.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/debug/dump.go
@@ -32,10 +32,17 @@ type QueueSetDump struct {
 
 // QueueDump is an instant dump of one queue in a queue-set.
 type QueueDump struct {
+	QueueSum          QueueSum
 	Requests          []RequestDump
 	VirtualStart      float64
 	ExecutingRequests int
 	SeatsInUse        int
+}
+
+type QueueSum struct {
+	InitialSeatsSum int
+	MaxSeatsSum     int
+	TotalWorkSum    string
 }
 
 // RequestDump is an instant dump of one requests pending in the queue.

--- a/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/debug/dump.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/debug/dump.go
@@ -34,7 +34,7 @@ type QueueSetDump struct {
 type QueueDump struct {
 	QueueSum          QueueSum
 	Requests          []RequestDump
-	VirtualStart      float64
+	NextDispatchR     string
 	ExecutingRequests int
 	SeatsInUse        int
 }

--- a/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/queueset/types.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/queueset/types.go
@@ -181,7 +181,7 @@ func (q *queue) dump(includeDetails bool) debug.QueueDump {
 	}
 
 	return debug.QueueDump{
-		VirtualStart:      q.nextDispatchR.ToFloat(), // TODO: change QueueDump to use SeatSeconds
+		NextDispatchR:     q.nextDispatchR.String(),
 		Requests:          digest,
 		ExecutingRequests: q.requestsExecuting,
 		SeatsInUse:        q.seatsInUse,

--- a/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/queueset/types.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/queueset/types.go
@@ -173,12 +173,19 @@ func (q *queue) dump(includeDetails bool) debug.QueueDump {
 		return true
 	})
 
-	// TODO: change QueueDump to include queueSum stats
+	sum := q.requests.QueueSum()
+	queueSum := debug.QueueSum{
+		InitialSeatsSum: sum.InitialSeatsSum,
+		MaxSeatsSum:     sum.MaxSeatsSum,
+		TotalWorkSum:    sum.TotalWorkSum.String(),
+	}
+
 	return debug.QueueDump{
 		VirtualStart:      q.nextDispatchR.ToFloat(), // TODO: change QueueDump to use SeatSeconds
 		Requests:          digest,
 		ExecutingRequests: q.requestsExecuting,
 		SeatsInUse:        q.seatsInUse,
+		QueueSum:          queueSum,
 	}
 }
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:
update queue dump to include the new counters and next dispatch R in seat-seconds

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
