### PR TITLE
e2e: restore volume lifecycle check for most tests, II

### DIFF
--- a/test/e2e/storage/drivers/csi.go
+++ b/test/e2e/storage/drivers/csi.go
@@ -40,6 +40,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"regexp"
 	"strconv"
 	"strings"
 	"sync"
@@ -248,8 +249,7 @@ func (h *hostpathCSIDriver) PrepareTest(f *framework.Framework) (*storageframewo
 	// test that it breaks.
 	// TODO: enable this check once issue is resolved for csi-host-path driver
 	// (https://github.com/kubernetes/kubernetes/pull/104858).
-	if strings.Contains(ginkgo.CurrentGinkgoTestDescription().FullTestText,
-		"should unmount if pod is gracefully deleted while kubelet is down") {
+	if regexp.MustCompile("should unmount if pod is.*deleted while kubelet is down").MatchString(ginkgo.CurrentGinkgoTestDescription().FullTestText) {
 		o.DriverContainerArguments = append(o.DriverContainerArguments, "--check-volume-lifecycle=false")
 	}
 


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/kind failing-test

#### What this PR does / why we need it:

Besides "subPath should unmount if pod is *gracefully* deleted while kubelet is
down" we also need a special case for "subPath should unmount if pod is *force*
deleted while kubelet is down".

#### Which issue(s) this PR fixes:

This fixes a test failure in https://testgrid.k8s.io/sig-storage-kubernetes#gce-serial

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
