### PR TITLE
Fix name for Pods of NonIndexed Jobs

### DIFF
--- a/pkg/controller/controller_utils.go
+++ b/pkg/controller/controller_utils.go
@@ -627,18 +627,7 @@ func (f *FakePodControl) PatchPod(namespace, name string, data []byte) error {
 }
 
 func (f *FakePodControl) CreatePods(namespace string, spec *v1.PodTemplateSpec, object runtime.Object, controllerRef *metav1.OwnerReference) error {
-	f.Lock()
-	defer f.Unlock()
-	f.CreateCallCount++
-	if f.CreateLimit != 0 && f.CreateCallCount > f.CreateLimit {
-		return fmt.Errorf("not creating pod, limit %d already reached (create call %d)", f.CreateLimit, f.CreateCallCount)
-	}
-	f.Templates = append(f.Templates, *spec)
-	f.ControllerRefs = append(f.ControllerRefs, *controllerRef)
-	if f.Err != nil {
-		return f.Err
-	}
-	return nil
+	return f.CreatePodsWithGenerateName(namespace, spec, object, controllerRef, "")
 }
 
 func (f *FakePodControl) CreatePodsWithGenerateName(namespace string, spec *v1.PodTemplateSpec, object runtime.Object, controllerRef *metav1.OwnerReference, generateNamePrefix string) error {
@@ -648,6 +637,7 @@ func (f *FakePodControl) CreatePodsWithGenerateName(namespace string, spec *v1.P
 	if f.CreateLimit != 0 && f.CreateCallCount > f.CreateLimit {
 		return fmt.Errorf("not creating pod, limit %d already reached (create call %d)", f.CreateLimit, f.CreateCallCount)
 	}
+	spec.GenerateName = generateNamePrefix
 	f.Templates = append(f.Templates, *spec)
 	f.ControllerRefs = append(f.ControllerRefs, *controllerRef)
 	if f.Err != nil {

--- a/pkg/controller/job/job_controller.go
+++ b/pkg/controller/job/job_controller.go
@@ -1348,13 +1348,14 @@ func (jm *Controller) manageJob(job *batch.Job, activePods []*v1.Pod, succeeded 
 				}
 				go func() {
 					template := podTemplate
+					generateName := ""
 					if completionIndex != unknownCompletionIndex {
 						template = podTemplate.DeepCopy()
 						addCompletionIndexAnnotation(template, completionIndex)
 						template.Spec.Hostname = fmt.Sprintf("%s-%d", job.Name, completionIndex)
+						generateName = podGenerateNameWithIndex(job.Name, completionIndex)
 					}
 					defer wait.Done()
-					generateName := podGenerateNameWithIndex(job.Name, completionIndex)
 					err := jm.podControl.CreatePodsWithGenerateName(job.Namespace, template, job, metav1.NewControllerRef(job, controllerKind), generateName)
 					if err != nil {
 						if apierrors.HasStatusCause(err, v1.NamespaceTerminatingCause) {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind regression

#### What this PR does / why we need it:

Removes generate name from NonIndexed Jobs. Otherwise, the name has the form:

`job-name--1-`

where `-1` comes from the invalid completion index.

#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for your reviewer:

This was accidentally added in #101601. I'm pretty sure this is just a cosmetic issue: pods would still be created because podGenerateNameWithIndex already truncates the names to fit the pod name limits.

#### Does this PR introduce a user-facing change?

```release-note
Fix 1.22 regression so pod name of NonIndexed jobs does not include rogue -1 substring
```