### PR TITLE
staging/publishing: Set go1.16 version to go1.16.9

### DIFF
--- a/staging/publishing/rules.yaml
+++ b/staging/publishing/rules.yaml
@@ -29,12 +29,12 @@ rules:
       branch: release-1.21
       dir: staging/src/k8s.io/code-generator
     name: release-1.21
-    go: 1.16.8
+    go: 1.16.9
   - source:
       branch: release-1.22
       dir: staging/src/k8s.io/code-generator
     name: release-1.22
-    go: 1.16.8
+    go: 1.16.9
 
 - destination: apimachinery
   library: true
@@ -57,12 +57,12 @@ rules:
       branch: release-1.21
       dir: staging/src/k8s.io/apimachinery
     name: release-1.21
-    go: 1.16.8
+    go: 1.16.9
   - source:
       branch: release-1.22
       dir: staging/src/k8s.io/apimachinery
     name: release-1.22
-    go: 1.16.8
+    go: 1.16.9
 
 - destination: api
   library: true
@@ -94,7 +94,7 @@ rules:
       branch: release-1.21
       dir: staging/src/k8s.io/api
     name: release-1.21
-    go: 1.16.8
+    go: 1.16.9
     dependencies:
       - repository: apimachinery
         branch: release-1.21
@@ -102,7 +102,7 @@ rules:
       branch: release-1.22
       dir: staging/src/k8s.io/api
     name: release-1.22
-    go: 1.16.8
+    go: 1.16.9
     dependencies:
     - repository: apimachinery
       branch: release-1.22
@@ -155,7 +155,7 @@ rules:
       branch: release-1.21
       dir: staging/src/k8s.io/client-go
     name: release-1.21
-    go: 1.16.8
+    go: 1.16.9
     dependencies:
       - repository: apimachinery
         branch: release-1.21
@@ -169,7 +169,7 @@ rules:
       branch: release-1.22
       dir: staging/src/k8s.io/client-go
     name: release-1.22
-    go: 1.16.8
+    go: 1.16.9
     dependencies:
       - repository: apimachinery
         branch: release-1.22
@@ -222,7 +222,7 @@ rules:
       branch: release-1.21
       dir: staging/src/k8s.io/component-base
     name: release-1.21
-    go: 1.16.8
+    go: 1.16.9
     dependencies:
     - repository: apimachinery
       branch: release-1.21
@@ -234,7 +234,7 @@ rules:
       branch: release-1.22
       dir: staging/src/k8s.io/component-base
     name: release-1.22
-    go: 1.16.8
+    go: 1.16.9
     dependencies:
     - repository: apimachinery
       branch: release-1.22
@@ -273,7 +273,7 @@ rules:
       branch: release-1.21
       dir: staging/src/k8s.io/component-helpers
     name: release-1.21
-    go: 1.16.8
+    go: 1.16.9
     dependencies:
     - repository: apimachinery
       branch: release-1.21
@@ -285,7 +285,7 @@ rules:
       branch: release-1.22
       dir: staging/src/k8s.io/component-helpers
     name: release-1.22
-    go: 1.16.8
+    go: 1.16.9
     dependencies:
     - repository: apimachinery
       branch: release-1.22
@@ -342,7 +342,7 @@ rules:
       branch: release-1.21
       dir: staging/src/k8s.io/apiserver
     name: release-1.21
-    go: 1.16.8
+    go: 1.16.9
     dependencies:
     - repository: apimachinery
       branch: release-1.21
@@ -356,7 +356,7 @@ rules:
       branch: release-1.22
       dir: staging/src/k8s.io/apiserver
     name: release-1.22
-    go: 1.16.8
+    go: 1.16.9
     dependencies:
     - repository: apimachinery
       branch: release-1.22
@@ -426,7 +426,7 @@ rules:
       branch: release-1.21
       dir: staging/src/k8s.io/kube-aggregator
     name: release-1.21
-    go: 1.16.8
+    go: 1.16.9
     dependencies:
     - repository: apimachinery
       branch: release-1.21
@@ -444,7 +444,7 @@ rules:
       branch: release-1.22
       dir: staging/src/k8s.io/kube-aggregator
     name: release-1.22
-    go: 1.16.8
+    go: 1.16.9
     dependencies:
     - repository: apimachinery
       branch: release-1.22
@@ -533,7 +533,7 @@ rules:
       branch: release-1.21
       dir: staging/src/k8s.io/sample-apiserver
     name: release-1.21
-    go: 1.16.8
+    go: 1.16.9
     dependencies:
     - repository: apimachinery
       branch: release-1.21
@@ -556,7 +556,7 @@ rules:
       branch: release-1.22
       dir: staging/src/k8s.io/sample-apiserver
     name: release-1.22
-    go: 1.16.8
+    go: 1.16.9
     dependencies:
     - repository: apimachinery
       branch: release-1.22
@@ -638,7 +638,7 @@ rules:
       branch: release-1.21
       dir: staging/src/k8s.io/sample-controller
     name: release-1.21
-    go: 1.16.8
+    go: 1.16.9
     dependencies:
     - repository: apimachinery
       branch: release-1.21
@@ -657,7 +657,7 @@ rules:
       branch: release-1.22
       dir: staging/src/k8s.io/sample-controller
     name: release-1.22
-    go: 1.16.8
+    go: 1.16.9
     dependencies:
     - repository: apimachinery
       branch: release-1.22
@@ -738,7 +738,7 @@ rules:
       branch: release-1.21
       dir: staging/src/k8s.io/apiextensions-apiserver
     name: release-1.21
-    go: 1.16.8
+    go: 1.16.9
     dependencies:
     - repository: apimachinery
       branch: release-1.21
@@ -758,7 +758,7 @@ rules:
       branch: release-1.22
       dir: staging/src/k8s.io/apiextensions-apiserver
     name: release-1.22
-    go: 1.16.8
+    go: 1.16.9
     dependencies:
     - repository: apimachinery
       branch: release-1.22
@@ -823,7 +823,7 @@ rules:
       branch: release-1.21
       dir: staging/src/k8s.io/metrics
     name: release-1.21
-    go: 1.16.8
+    go: 1.16.9
     dependencies:
     - repository: apimachinery
       branch: release-1.21
@@ -837,7 +837,7 @@ rules:
       branch: release-1.22
       dir: staging/src/k8s.io/metrics
     name: release-1.22
-    go: 1.16.8
+    go: 1.16.9
     dependencies:
     - repository: apimachinery
       branch: release-1.22
@@ -890,7 +890,7 @@ rules:
       branch: release-1.21
       dir: staging/src/k8s.io/cli-runtime
     name: release-1.21
-    go: 1.16.8
+    go: 1.16.9
     dependencies:
     - repository: api
       branch: release-1.21
@@ -902,7 +902,7 @@ rules:
       branch: release-1.22
       dir: staging/src/k8s.io/cli-runtime
     name: release-1.22
-    go: 1.16.8
+    go: 1.16.9
     dependencies:
     - repository: api
       branch: release-1.22
@@ -959,7 +959,7 @@ rules:
       branch: release-1.21
       dir: staging/src/k8s.io/sample-cli-plugin
     name: release-1.21
-    go: 1.16.8
+    go: 1.16.9
     dependencies:
     - repository: api
       branch: release-1.21
@@ -973,7 +973,7 @@ rules:
       branch: release-1.22
       dir: staging/src/k8s.io/sample-cli-plugin
     name: release-1.22
-    go: 1.16.8
+    go: 1.16.9
     dependencies:
     - repository: api
       branch: release-1.22
@@ -1032,7 +1032,7 @@ rules:
       branch: release-1.21
       dir: staging/src/k8s.io/kube-proxy
     name: release-1.21
-    go: 1.16.8
+    go: 1.16.9
     dependencies:
     - repository: apimachinery
       branch: release-1.21
@@ -1046,7 +1046,7 @@ rules:
       branch: release-1.22
       dir: staging/src/k8s.io/kube-proxy
     name: release-1.22
-    go: 1.16.8
+    go: 1.16.9
     dependencies:
     - repository: apimachinery
       branch: release-1.22
@@ -1105,7 +1105,7 @@ rules:
       branch: release-1.21
       dir: staging/src/k8s.io/kubelet
     name: release-1.21
-    go: 1.16.8
+    go: 1.16.9
     dependencies:
     - repository: apimachinery
       branch: release-1.21
@@ -1119,7 +1119,7 @@ rules:
       branch: release-1.22
       dir: staging/src/k8s.io/kubelet
     name: release-1.22
-    go: 1.16.8
+    go: 1.16.9
     dependencies:
     - repository: apimachinery
       branch: release-1.22
@@ -1178,7 +1178,7 @@ rules:
       branch: release-1.21
       dir: staging/src/k8s.io/kube-scheduler
     name: release-1.21
-    go: 1.16.8
+    go: 1.16.9
     dependencies:
     - repository: apimachinery
       branch: release-1.21
@@ -1192,7 +1192,7 @@ rules:
       branch: release-1.22
       dir: staging/src/k8s.io/kube-scheduler
     name: release-1.22
-    go: 1.16.8
+    go: 1.16.9
     dependencies:
     - repository: apimachinery
       branch: release-1.22
@@ -1246,7 +1246,7 @@ rules:
       branch: release-1.21
       dir: staging/src/k8s.io/controller-manager
     name: release-1.21
-    go: 1.16.8
+    go: 1.16.9
     dependencies:
     - repository: api
       branch: release-1.21
@@ -1262,7 +1262,7 @@ rules:
       branch: release-1.22
       dir: staging/src/k8s.io/controller-manager
     name: release-1.22
-    go: 1.16.8
+    go: 1.16.9
     dependencies:
     - repository: api
       branch: release-1.22
@@ -1331,7 +1331,7 @@ rules:
       branch: release-1.21
       dir: staging/src/k8s.io/cloud-provider
     name: release-1.21
-    go: 1.16.8
+    go: 1.16.9
     dependencies:
     - repository: api
       branch: release-1.21
@@ -1349,7 +1349,7 @@ rules:
       branch: release-1.22
       dir: staging/src/k8s.io/cloud-provider
     name: release-1.22
-    go: 1.16.8
+    go: 1.16.9
     dependencies:
     - repository: api
       branch: release-1.22
@@ -1424,7 +1424,7 @@ rules:
       branch: release-1.21
       dir: staging/src/k8s.io/kube-controller-manager
     name: release-1.21
-    go: 1.16.8
+    go: 1.16.9
     dependencies:
     - repository: apimachinery
       branch: release-1.21
@@ -1444,7 +1444,7 @@ rules:
       branch: release-1.22
       dir: staging/src/k8s.io/kube-controller-manager
     name: release-1.22
-    go: 1.16.8
+    go: 1.16.9
     dependencies:
     - repository: apimachinery
       branch: release-1.22
@@ -1497,7 +1497,7 @@ rules:
       branch: release-1.21
       dir: staging/src/k8s.io/cluster-bootstrap
     name: release-1.21
-    go: 1.16.8
+    go: 1.16.9
     dependencies:
     - repository: apimachinery
       branch: release-1.21
@@ -1507,7 +1507,7 @@ rules:
       branch: release-1.22
       dir: staging/src/k8s.io/cluster-bootstrap
     name: release-1.22
-    go: 1.16.8
+    go: 1.16.9
     dependencies:
     - repository: apimachinery
       branch: release-1.22
@@ -1556,7 +1556,7 @@ rules:
       branch: release-1.21
       dir: staging/src/k8s.io/csi-translation-lib
     name: release-1.21
-    go: 1.16.8
+    go: 1.16.9
     dependencies:
     - repository: api
       branch: release-1.21
@@ -1566,7 +1566,7 @@ rules:
       branch: release-1.22
       dir: staging/src/k8s.io/csi-translation-lib
     name: release-1.22
-    go: 1.16.8
+    go: 1.16.9
     dependencies:
     - repository: api
       branch: release-1.22
@@ -1589,12 +1589,12 @@ rules:
       branch: release-1.21
       dir: staging/src/k8s.io/mount-utils
     name: release-1.21
-    go: 1.16.8
+    go: 1.16.9
   - source:
       branch: release-1.22
       dir: staging/src/k8s.io/mount-utils
     name: release-1.22
-    go: 1.16.8
+    go: 1.16.9
 
 - destination: legacy-cloud-providers
   library: true
@@ -1668,7 +1668,7 @@ rules:
       branch: release-1.21
       dir: staging/src/k8s.io/legacy-cloud-providers
     name: release-1.21
-    go: 1.16.8
+    go: 1.16.9
     dependencies:
     - repository: api
       branch: release-1.21
@@ -1690,7 +1690,7 @@ rules:
       branch: release-1.22
       dir: staging/src/k8s.io/legacy-cloud-providers
     name: release-1.22
-    go: 1.16.8
+    go: 1.16.9
     dependencies:
     - repository: api
       branch: release-1.22
@@ -1732,12 +1732,12 @@ rules:
       branch: release-1.21
       dir: staging/src/k8s.io/cri-api
     name: release-1.21
-    go: 1.16.8
+    go: 1.16.9
   - source:
       branch: release-1.22
       dir: staging/src/k8s.io/cri-api
     name: release-1.22
-    go: 1.16.8
+    go: 1.16.9
 
 - destination: kubectl
   library: true
@@ -1809,7 +1809,7 @@ rules:
       branch: release-1.21
       dir: staging/src/k8s.io/kubectl
     name: release-1.21
-    go: 1.16.8
+    go: 1.16.9
     dependencies:
     - repository: api
       branch: release-1.21
@@ -1831,7 +1831,7 @@ rules:
       branch: release-1.22
       dir: staging/src/k8s.io/kubectl
     name: release-1.22
-    go: 1.16.8
+    go: 1.16.9
     dependencies:
     - repository: api
       branch: release-1.22
@@ -1872,7 +1872,7 @@ rules:
       branch: release-1.22
       dir: staging/src/k8s.io/pod-security-admission
     name: release-1.22
-    go: 1.16.8
+    go: 1.16.9
     dependencies:
     - repository: api
       branch: release-1.22


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/area dependency security

#### What this PR does / why we need it:

staging/publishing: Set go1.16 version to go1.16.9
Part of https://github.com/kubernetes/release/issues/2254

/assign @nikhita @dims @justaugustus 
cc: @kubernetes/release-engineering 

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
