### PR TITLE
storage validation: accept generic ephemeral volumes as volume device

### DIFF
--- a/test/e2e/storage/framework/testpattern.go
+++ b/test/e2e/storage/framework/testpattern.go
@@ -297,6 +297,13 @@ var (
 		SnapshotType:           DynamicCreatedSnapshot,
 		SnapshotDeletionPolicy: DeleteSnapshot,
 	}
+	// BlockVolModeGenericEphemeralVolume is for generic ephemeral inline volumes in raw block mode.
+	BlockVolModeGenericEphemeralVolume = TestPattern{
+		Name:        "Generic Ephemeral-volume (block volmode) (late-binding)",
+		VolType:     GenericEphemeralVolume,
+		VolMode:     v1.PersistentVolumeBlock,
+		BindingMode: storagev1.VolumeBindingWaitForFirstConsumer,
+	}
 
 	// Definitions for snapshot case
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Raw block devices are possible with generic ephemeral volumes, so rejecting a
pod with that combination is wrong.

#### Special notes for your reviewer:

Found while working on E2E tests. Here's an example of a failures from those tests: https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/105659/pull-kubernetes-e2e-gce-csi-serial/1448711002941034496/

#### Does this PR introduce a user-facing change?

```release-note
Generic ephemeral volumes can be used also as raw block devices, but the Pod validation was refusing to create pods with that combination.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
- [KEP]: https://github.com/kubernetes/enhancements/tree/master/keps/sig-storage/1698-generic-ephemeral-volumes
```
