### PR TITLE
Automated cherry pick of #105673: support more than 100 disk mounts on Windows

### DIFF
--- a/staging/src/k8s.io/mount-utils/mount_helper_windows.go
+++ b/staging/src/k8s.io/mount-utils/mount_helper_windows.go
@@ -84,15 +84,9 @@ func NormalizeWindowsPath(path string) string {
 
 // ValidateDiskNumber : disk number should be a number in [0, 99]
 func ValidateDiskNumber(disk string) error {
-	diskNum, err := strconv.Atoi(disk)
-	if err != nil {
-		return fmt.Errorf("wrong disk number format: %q, err:%v", disk, err)
+	if _, err := strconv.Atoi(disk); err != nil {
+		return fmt.Errorf("wrong disk number format: %q, err: %v", disk, err)
 	}
-
-	if diskNum < 0 || diskNum > 99 {
-		return fmt.Errorf("disk number out of range: %q", disk)
-	}
-
 	return nil
 }
 

--- a/staging/src/k8s.io/mount-utils/mount_helper_windows_test.go
+++ b/staging/src/k8s.io/mount-utils/mount_helper_windows_test.go
@@ -43,23 +43,36 @@ func TestNormalizeWindowsPath(t *testing.T) {
 }
 
 func TestValidateDiskNumber(t *testing.T) {
-	diskNum := "0"
-	if err := ValidateDiskNumber(diskNum); err != nil {
-		t.Errorf("TestValidateDiskNumber test failed, disk number : %s", diskNum)
+	tests := []struct {
+		diskNum     string
+		expectError bool
+	}{
+		{
+			diskNum:     "0",
+			expectError: false,
+		},
+		{
+			diskNum:     "invalid",
+			expectError: true,
+		},
+		{
+			diskNum:     "99",
+			expectError: false,
+		},
+		{
+			diskNum:     "100",
+			expectError: false,
+		},
+		{
+			diskNum:     "200",
+			expectError: false,
+		},
 	}
 
-	diskNum = "99"
-	if err := ValidateDiskNumber(diskNum); err != nil {
-		t.Errorf("TestValidateDiskNumber test failed, disk number : %s", diskNum)
-	}
-
-	diskNum = "ab"
-	if err := ValidateDiskNumber(diskNum); err == nil {
-		t.Errorf("TestValidateDiskNumber test failed, disk number : %s", diskNum)
-	}
-
-	diskNum = "100"
-	if err := ValidateDiskNumber(diskNum); err == nil {
-		t.Errorf("TestValidateDiskNumber test failed, disk number : %s", diskNum)
+	for _, test := range tests {
+		err := ValidateDiskNumber(test.diskNum)
+		if (err != nil) != test.expectError {
+			t.Errorf("TestValidateDiskNumber test failed, disk number: %s, error: %v", test.diskNum, err)
+		}
 	}
 }


### PR DESCRIPTION
Cherry pick of #105673 on release-1.22.

#105673: support more than 100 disk mounts on Windows

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.