### PR TITLE
apiserver: clarify watcher fanout deepcopy and self-link code

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/patch.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/patch.go
@@ -228,11 +228,13 @@ func PatchResource(r rest.Patcher, scope *RequestScope, admit admission.Interfac
 		}
 		trace.Step("Object stored in database")
 
-		if err := setObjectSelfLink(ctx, result, req, scope.Namer); err != nil {
-			scope.err(err, w, req)
-			return
+		if !utilfeature.DefaultFeatureGate.Enabled(features.RemoveSelfLink) {
+			if err := setObjectSelfLink(ctx, result, req, scope.Namer); err != nil {
+				scope.err(err, w, req)
+				return
+			}
+			trace.Step("Self-link added")
 		}
-		trace.Step("Self-link added")
 
 		status := http.StatusOK
 		if wasCreated {

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/response.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/response.go
@@ -63,6 +63,13 @@ func doTransformObject(ctx context.Context, obj runtime.Object, opts interface{}
 		return nil, err
 	}
 
+	// Ensure that for empty lists we don't return <nil> items.
+	if meta.IsListType(obj) && meta.LenList(obj) == 0 {
+		if err := meta.SetList(obj, []runtime.Object{}); err != nil {
+			return nil, err
+		}
+	}
+
 	switch target := mediaType.Convert; {
 	case target == nil:
 		return obj, nil

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/rest.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/rest.go
@@ -370,12 +370,6 @@ func dedupOwnerReferencesAndAddWarning(obj runtime.Object, requestContext contex
 //   interfaces
 func setObjectSelfLink(ctx context.Context, obj runtime.Object, req *http.Request, namer ScopeNamer) error {
 	if utilfeature.DefaultFeatureGate.Enabled(features.RemoveSelfLink) {
-		// Ensure that for empty lists we don't return <nil> items.
-		if meta.IsListType(obj) && meta.LenList(obj) == 0 {
-			if err := meta.SetList(obj, []runtime.Object{}); err != nil {
-				return err
-			}
-		}
 		return nil
 	}
 
@@ -402,17 +396,9 @@ func setObjectSelfLink(ctx context.Context, obj runtime.Object, req *http.Reques
 		return fmt.Errorf("missing requestInfo")
 	}
 
-	count := 0
 	err = meta.EachListItem(obj, func(obj runtime.Object) error {
-		count++
 		return setSelfLink(obj, requestInfo, namer)
 	})
-
-	if count == 0 {
-		if err := meta.SetList(obj, []runtime.Object{}); err != nil {
-			return err
-		}
-	}
 
 	return err
 }

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/rest.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/rest.go
@@ -45,9 +45,7 @@ import (
 	"k8s.io/apiserver/pkg/endpoints/handlers/responsewriters"
 	"k8s.io/apiserver/pkg/endpoints/metrics"
 	"k8s.io/apiserver/pkg/endpoints/request"
-	"k8s.io/apiserver/pkg/features"
 	"k8s.io/apiserver/pkg/registry/rest"
-	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/apiserver/pkg/warning"
 	"k8s.io/klog/v2"
 )
@@ -369,10 +367,6 @@ func dedupOwnerReferencesAndAddWarning(obj runtime.Object, requestContext contex
 // TODO: remove the need for the namer LinkSetters by requiring objects implement either Object or List
 //   interfaces
 func setObjectSelfLink(ctx context.Context, obj runtime.Object, req *http.Request, namer ScopeNamer) error {
-	if utilfeature.DefaultFeatureGate.Enabled(features.RemoveSelfLink) {
-		return nil
-	}
-
 	// We only generate list links on objects that implement ListInterface - historically we duck typed this
 	// check via reflection, but as we move away from reflection we require that you not only carry Items but
 	// ListMeta into order to be identified as a list.


### PR DESCRIPTION
Some pre-factoring for https://github.com/kubernetes/kubernetes/pull/104802 or for removal of the self-link code.

/kind cleanup

```release-note
NONE
```