### PR TITLE
add status endpoint to GC debug handler

### DIFF
--- a/pkg/controller/garbagecollector/dump.go
+++ b/pkg/controller/garbagecollector/dump.go
@@ -254,11 +254,18 @@ type debugHTTPHandler struct {
 }
 
 func (h *debugHTTPHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
-	if req.URL.Path != "/graph" {
+	switch req.URL.Path {
+	case "/graph":
+		h.serveHTTPGraph(w, req)
+	case "/status":
+		h.serveHTTPStatus(w, req)
+	default:
 		http.Error(w, "", http.StatusNotFound)
-		return
 	}
+}
 
+// serveHTTPGraph responds to an HTTP request on /graph endpoint.
+func (h *debugHTTPHandler) serveHTTPGraph(w http.ResponseWriter, req *http.Request) {
 	var graph graph.Directed
 	if uidStrings := req.URL.Query()["uid"]; len(uidStrings) > 0 {
 		uids := []types.UID{}

--- a/pkg/controller/garbagecollector/dump_status.go
+++ b/pkg/controller/garbagecollector/dump_status.go
@@ -21,6 +21,8 @@ import (
 	"net/http"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	kubefeatures "k8s.io/kubernetes/pkg/features"
 )
 
 type ErrorType string
@@ -62,6 +64,11 @@ func newErrorResult(errorType ErrorType, record *errorRecord, identity *objectRe
 
 // serveHTTPStatus responds to an HTTP request on /status endpoint.
 func (h *debugHTTPHandler) serveHTTPStatus(w http.ResponseWriter, req *http.Request) {
+	if !utilfeature.DefaultFeatureGate.Enabled(kubefeatures.GCDebugStatus) {
+		http.Error(w, "", http.StatusMethodNotAllowed)
+		return
+	}
+
 	errors := h.controller.errorRecorder.DumpErrors()
 	if errors == nil {
 		errors = make([]errorResult, 0)

--- a/pkg/controller/garbagecollector/dump_status.go
+++ b/pkg/controller/garbagecollector/dump_status.go
@@ -1,0 +1,83 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package garbagecollector
+
+import (
+	"encoding/json"
+	"net/http"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type ErrorType string
+
+const (
+	SyncError            ErrorType = "Sync"
+	AttemptToDeleteError ErrorType = "AttemptToDelete"
+	AttemptToOrphanError ErrorType = "AttemptToOrphan"
+)
+
+// errorResult represents an error and its metadata that are to be marshalled into JSON.
+type errorResult struct {
+	ErrorTime      metav1.Time      `json:"errorTime"`
+	Error          string           `json:"error"`
+	ErrorType      ErrorType        `json:"errorType"`
+	InvolvedObject *objectReference `json:"involvedObject,omitempty"`
+}
+
+// statusResult represents a status that is to be marshalled into JSON.
+type statusResult struct {
+	Errors []errorResult `json:"errors"`
+}
+
+// newErrorResult creates a new errorResult.
+func newErrorResult(errorType ErrorType, record *errorRecord, identity *objectReference) errorResult {
+	result := errorResult{
+		InvolvedObject: identity,
+		ErrorType:      errorType,
+	}
+
+	if record != nil {
+		result.ErrorTime = metav1.NewTime(record.ErrorTime)
+		if record.Error != nil {
+			result.Error = record.Error.Error()
+		}
+	}
+	return result
+}
+
+// serveHTTPStatus responds to an HTTP request on /status endpoint.
+func (h *debugHTTPHandler) serveHTTPStatus(w http.ResponseWriter, req *http.Request) {
+	errors := h.controller.errorRecorder.DumpErrors()
+	if errors == nil {
+		errors = make([]errorResult, 0)
+	}
+
+	status := statusResult{
+		Errors: errors,
+	}
+
+	data, err := json.MarshalIndent(status, "", "  ")
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("X-Content-Type-Options", "nosniff")
+	w.Write(data)
+	w.WriteHeader(http.StatusOK)
+}

--- a/pkg/controller/garbagecollector/error_recorder.go
+++ b/pkg/controller/garbagecollector/error_recorder.go
@@ -34,8 +34,20 @@ func NewErrorRecord(err error) *errorRecord {
 	}
 }
 
-// errorRecorder stores various types of errors for later debugging. Its methods are thread-safe.
-type errorRecorder struct {
+type errorRecorder interface {
+	SetAttemptToDeleteError(node *node, err error)
+	SetAttemptToOrphanError(node *node, err error)
+	SetSyncError(err error)
+	ClearAttemptToDeleteError(node *node)
+	ClearAttemptToOrphanError(node *node)
+	ClearSyncError()
+	DumpErrors() []errorResult
+}
+
+var _ errorRecorder = &errRecorder{}
+
+// errRecorder stores various types of errors for later debugging. Its methods are thread-safe.
+type errRecorder struct {
 	attemptToDeleteErrorsLock sync.RWMutex
 	attemptToOrphanErrorsLock sync.RWMutex
 	syncErrorLock             sync.RWMutex
@@ -45,50 +57,50 @@ type errorRecorder struct {
 }
 
 // newErrorRecorder creates a new errorRecorder.
-func newErrorRecorder() *errorRecorder {
-	return &errorRecorder{
+func newErrorRecorder() errorRecorder {
+	return &errRecorder{
 		attemptToDeleteErrors: make(map[*node]*errorRecord),
 		attemptToOrphanErrors: make(map[*node]*errorRecord),
 	}
 }
 
-func (r *errorRecorder) SetAttemptToDeleteError(node *node, err error) {
+func (r *errRecorder) SetAttemptToDeleteError(node *node, err error) {
 	r.attemptToDeleteErrorsLock.Lock()
 	defer r.attemptToDeleteErrorsLock.Unlock()
 	r.attemptToDeleteErrors[node] = NewErrorRecord(err)
 }
 
-func (r *errorRecorder) SetAttemptToOrphanError(node *node, err error) {
+func (r *errRecorder) SetAttemptToOrphanError(node *node, err error) {
 	r.attemptToOrphanErrorsLock.Lock()
 	defer r.attemptToOrphanErrorsLock.Unlock()
 	r.attemptToOrphanErrors[node] = NewErrorRecord(err)
 }
 
-func (r *errorRecorder) SetSyncError(err error) {
+func (r *errRecorder) SetSyncError(err error) {
 	r.syncErrorLock.Lock()
 	defer r.syncErrorLock.Unlock()
 	r.syncError = NewErrorRecord(err)
 }
 
-func (r *errorRecorder) ClearAttemptToDeleteError(node *node) {
+func (r *errRecorder) ClearAttemptToDeleteError(node *node) {
 	r.attemptToDeleteErrorsLock.Lock()
 	defer r.attemptToDeleteErrorsLock.Unlock()
 	delete(r.attemptToDeleteErrors, node)
 }
 
-func (r *errorRecorder) ClearAttemptToOrphanError(node *node) {
+func (r *errRecorder) ClearAttemptToOrphanError(node *node) {
 	r.attemptToOrphanErrorsLock.Lock()
 	defer r.attemptToOrphanErrorsLock.Unlock()
 	delete(r.attemptToOrphanErrors, node)
 }
 
-func (r *errorRecorder) ClearSyncError() {
+func (r *errRecorder) ClearSyncError() {
 	r.syncErrorLock.Lock()
 	defer r.syncErrorLock.Unlock()
 	r.syncError = nil
 }
 
-func (r *errorRecorder) DumpErrors() []errorResult {
+func (r *errRecorder) DumpErrors() []errorResult {
 	var results []errorResult
 
 	func() {
@@ -121,4 +133,37 @@ func (r *errorRecorder) DumpErrors() []errorResult {
 	}()
 
 	return results
+}
+
+// noopErrRecorder
+type noopErrRecorder struct {
+}
+
+// newNoopErrorRecorder creates a new noopErrRecorder.
+func newNoopErrorRecorder() errorRecorder {
+	return &noopErrRecorder{}
+}
+
+var _ errorRecorder = &noopErrRecorder{}
+
+func (n noopErrRecorder) SetAttemptToDeleteError(node *node, err error) {
+}
+
+func (n noopErrRecorder) SetAttemptToOrphanError(node *node, err error) {
+}
+
+func (n noopErrRecorder) SetSyncError(err error) {
+}
+
+func (n noopErrRecorder) ClearAttemptToDeleteError(node *node) {
+}
+
+func (n noopErrRecorder) ClearAttemptToOrphanError(node *node) {
+}
+
+func (n noopErrRecorder) ClearSyncError() {
+}
+
+func (n noopErrRecorder) DumpErrors() []errorResult {
+	return nil
 }

--- a/pkg/controller/garbagecollector/error_recorder.go
+++ b/pkg/controller/garbagecollector/error_recorder.go
@@ -1,0 +1,124 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package garbagecollector
+
+import (
+	"sync"
+	"time"
+)
+
+// errorRecord represents an error with additional metadata
+type errorRecord struct {
+	ErrorTime time.Time
+	Error     error
+}
+
+func NewErrorRecord(err error) *errorRecord {
+	return &errorRecord{
+		ErrorTime: time.Now(),
+		Error:     err,
+	}
+}
+
+// errorRecorder stores various types of errors for later debugging. Its methods are thread-safe.
+type errorRecorder struct {
+	attemptToDeleteErrorsLock sync.RWMutex
+	attemptToOrphanErrorsLock sync.RWMutex
+	syncErrorLock             sync.RWMutex
+	attemptToDeleteErrors     map[*node]*errorRecord
+	attemptToOrphanErrors     map[*node]*errorRecord
+	syncError                 *errorRecord
+}
+
+// newErrorRecorder creates a new errorRecorder.
+func newErrorRecorder() *errorRecorder {
+	return &errorRecorder{
+		attemptToDeleteErrors: make(map[*node]*errorRecord),
+		attemptToOrphanErrors: make(map[*node]*errorRecord),
+	}
+}
+
+func (r *errorRecorder) SetAttemptToDeleteError(node *node, err error) {
+	r.attemptToDeleteErrorsLock.Lock()
+	defer r.attemptToDeleteErrorsLock.Unlock()
+	r.attemptToDeleteErrors[node] = NewErrorRecord(err)
+}
+
+func (r *errorRecorder) SetAttemptToOrphanError(node *node, err error) {
+	r.attemptToOrphanErrorsLock.Lock()
+	defer r.attemptToOrphanErrorsLock.Unlock()
+	r.attemptToOrphanErrors[node] = NewErrorRecord(err)
+}
+
+func (r *errorRecorder) SetSyncError(err error) {
+	r.syncErrorLock.Lock()
+	defer r.syncErrorLock.Unlock()
+	r.syncError = NewErrorRecord(err)
+}
+
+func (r *errorRecorder) ClearAttemptToDeleteError(node *node) {
+	r.attemptToDeleteErrorsLock.Lock()
+	defer r.attemptToDeleteErrorsLock.Unlock()
+	delete(r.attemptToDeleteErrors, node)
+}
+
+func (r *errorRecorder) ClearAttemptToOrphanError(node *node) {
+	r.attemptToOrphanErrorsLock.Lock()
+	defer r.attemptToOrphanErrorsLock.Unlock()
+	delete(r.attemptToOrphanErrors, node)
+}
+
+func (r *errorRecorder) ClearSyncError() {
+	r.syncErrorLock.Lock()
+	defer r.syncErrorLock.Unlock()
+	r.syncError = nil
+}
+
+func (r *errorRecorder) DumpErrors() []errorResult {
+	var results []errorResult
+
+	func() {
+		r.syncErrorLock.Lock()
+		defer r.syncErrorLock.Unlock()
+
+		if syncError := r.syncError; syncError != nil {
+			results = append(results, newErrorResult(SyncError, syncError, nil))
+		}
+	}()
+
+	func() {
+		r.attemptToDeleteErrorsLock.Lock()
+		defer r.attemptToDeleteErrorsLock.Unlock()
+
+		for node, errRecord := range r.attemptToDeleteErrors {
+			identity := node.identity
+			results = append(results, newErrorResult(AttemptToDeleteError, errRecord, &identity))
+		}
+	}()
+
+	func() {
+		r.attemptToOrphanErrorsLock.Lock()
+		defer r.attemptToOrphanErrorsLock.Unlock()
+
+		for node, errRecord := range r.attemptToOrphanErrors {
+			identity := node.identity
+			results = append(results, newErrorResult(AttemptToOrphanError, errRecord, &identity))
+		}
+	}()
+
+	return results
+}

--- a/pkg/controller/garbagecollector/error_recorder_test.go
+++ b/pkg/controller/garbagecollector/error_recorder_test.go
@@ -123,6 +123,30 @@ func TestErrorRecorder(t *testing.T) {
 	}
 }
 
+func TestNoopErrorRecorder(t *testing.T) {
+	recorder := newNoopErrorRecorder()
+
+	xNode, yNode, zNode := newXNode(), newYNode(), newZNode()
+
+	recorder.SetSyncError(goerrors.New("sync failed"))
+	recorder.SetAttemptToOrphanError(xNode, goerrors.New(testErrMessage("orphan", "x")))
+	recorder.SetAttemptToOrphanError(yNode, goerrors.New(testErrMessage("orphan", "y")))
+	recorder.ClearAttemptToOrphanError(xNode)
+	recorder.SetAttemptToOrphanError(zNode, goerrors.New(testErrMessage("orphan", "z")))
+	recorder.SetAttemptToDeleteError(xNode, goerrors.New(testErrMessage("delete", "x")))
+
+	errors := recorder.DumpErrors()
+
+	if errors != nil {
+		t.Errorf("unexpected non nil errors result: %v: noopErrorRecorder should not implement any fuctionality", errors)
+	}
+
+	// check for no panics
+	recorder.ClearAttemptToOrphanError(zNode)
+	recorder.ClearAttemptToDeleteError(xNode)
+	recorder.ClearSyncError()
+}
+
 func testErrMessage(action, what string) string {
 	return fmt.Sprintf("attempt to %s %s failed", action, what)
 }

--- a/pkg/controller/garbagecollector/error_recorder_test.go
+++ b/pkg/controller/garbagecollector/error_recorder_test.go
@@ -1,0 +1,128 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package garbagecollector
+
+import (
+	goerrors "errors"
+	"fmt"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var (
+	newXNode = func() *node {
+		return &node{
+			identity: objectReference{
+				OwnerReference: metav1.OwnerReference{
+					Name:       "x",
+					UID:        "xnode",
+					APIVersion: "xnodeapiversion",
+					Kind:       "XNode",
+				},
+				Namespace: "xnodens",
+			},
+		}
+	}
+	newYNode = func() *node {
+		return &node{
+			identity: objectReference{
+				OwnerReference: metav1.OwnerReference{
+					Name: "y",
+				},
+			},
+		}
+	}
+	newZNode = func() *node {
+		return &node{
+			identity: objectReference{
+				OwnerReference: metav1.OwnerReference{
+					Name: "z",
+				},
+			},
+		}
+	}
+)
+
+func TestErrorRecorder(t *testing.T) {
+	recorder := newErrorRecorder()
+
+	xNode, yNode, zNode := newXNode(), newYNode(), newZNode()
+
+	recorder.SetSyncError(goerrors.New("sync failed"))
+	recorder.SetAttemptToOrphanError(xNode, goerrors.New(testErrMessage("orphan", "x")))
+	recorder.SetAttemptToOrphanError(yNode, goerrors.New(testErrMessage("orphan", "y")))
+	recorder.ClearAttemptToOrphanError(xNode)
+	recorder.SetAttemptToOrphanError(zNode, goerrors.New(testErrMessage("orphan", "z")))
+	recorder.SetAttemptToDeleteError(xNode, goerrors.New(testErrMessage("delete", "x")))
+
+	errors := recorder.DumpErrors()
+
+	if len(errors) != 4 {
+		t.Errorf("unexpected number of errors number of errors, expected %v, got %v", 4, errors)
+	}
+
+	for _, errResult := range errors {
+		if errResult.ErrorTime.IsZero() {
+			t.Errorf("error time is unitialized for: %v", errResult)
+		}
+	}
+
+	// check sync error
+	syncError := errors[0]
+	if syncError.ErrorType != SyncError || syncError.Error != "sync failed" {
+		t.Errorf("syncError error result not found: %v", errors)
+	}
+
+	// check delete error
+	deleteError := errors[1]
+	if deleteError.ErrorType != AttemptToDeleteError || deleteError.Error != testErrMessage("delete", "x") {
+		t.Errorf("attemptToDelete error result not found: %v", errors)
+	}
+	if deleteError.InvolvedObject == nil ||
+		deleteError.InvolvedObject.Name != "x" ||
+		deleteError.InvolvedObject.UID != "xnode" ||
+		deleteError.InvolvedObject.APIVersion != "xnodeapiversion" ||
+		deleteError.InvolvedObject.Kind != "XNode" ||
+		deleteError.InvolvedObject.Namespace != "xnodens" {
+		t.Errorf("attemptToDelete error result InvolvedObject is invalid: %v", deleteError)
+	}
+
+	// check orphan errors
+	for _, orphanError := range errors[2:] {
+		isOrphanError := orphanError.ErrorType == AttemptToOrphanError && orphanError.InvolvedObject != nil && (orphanError.InvolvedObject.Name == "y" || orphanError.InvolvedObject.Name == "z")
+		if !isOrphanError || orphanError.Error != testErrMessage("orphan", orphanError.InvolvedObject.Name) {
+			t.Errorf("attemptToOrphan error result not found: %v", errors)
+		}
+	}
+
+	recorder.ClearSyncError()
+	for _, n := range []*node{xNode, yNode, zNode} {
+		recorder.ClearAttemptToOrphanError(n)
+		recorder.ClearAttemptToDeleteError(n)
+	}
+
+	errors = recorder.DumpErrors()
+
+	if len(errors) != 0 {
+		t.Errorf("unsuccessful clear: got unexpected %v", errors)
+	}
+}
+
+func testErrMessage(action, what string) string {
+	return fmt.Sprintf("attempt to %s %s failed", action, what)
+}

--- a/pkg/controller/garbagecollector/garbagecollector_test.go
+++ b/pkg/controller/garbagecollector/garbagecollector_test.go
@@ -2266,6 +2266,8 @@ func TestConflictingData(t *testing.T) {
 			attemptToOrphan := newTrackingWorkqueue()
 			graphChanges := newTrackingWorkqueue()
 
+			errorRecorder := newErrorRecorder()
+
 			gc := &GarbageCollector{
 				metadataClient:   metadataClient,
 				restMapper:       restMapper,
@@ -2284,6 +2286,7 @@ func TestConflictingData(t *testing.T) {
 					attemptToDelete:  attemptToDelete,
 					absentOwnerCache: absentOwnerCache,
 				},
+				errorRecorder: errorRecorder,
 			}
 
 			ctx := stepContext{

--- a/pkg/controller/garbagecollector/graph.go
+++ b/pkg/controller/garbagecollector/graph.go
@@ -27,7 +27,7 @@ import (
 type objectReference struct {
 	metav1.OwnerReference
 	// This is needed by the dynamic client
-	Namespace string
+	Namespace string `json:"namespace"`
 }
 
 func (s objectReference) String() string {

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -871,6 +871,13 @@ const (
 	//
 	// Enables NetworkPolicy status subresource
 	NetworkPolicyStatus featuregate.Feature = "NetworkPolicyStatus"
+
+	// owner: @atiratree
+	// alpha: v1.24
+	//
+	// GCDebugStatus makes a new endpoint /debug/controllers/garbagecollector/status in kube-controller-manager
+	// which allows querying for errors that prevent garbage collection.
+	GCDebugStatus featuregate.Feature = "GCDebugStatus"
 )
 
 func init() {
@@ -997,6 +1004,7 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
 	NodeOutOfServiceVolumeDetach:                   {Default: false, PreRelease: featuregate.Alpha},
 	MaxUnavailableStatefulSet:                      {Default: false, PreRelease: featuregate.Alpha},
 	NetworkPolicyStatus:                            {Default: false, PreRelease: featuregate.Alpha},
+	GCDebugStatus:                                  {Default: false, PreRelease: featuregate.Alpha},
 
 	// inherited features from generic apiserver, relisted here to get a conflict if it is changed
 	// unintentionally on either side:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

Currently it is hard to distinguish when GC is in degraded state and some resources are stuck. This PR exposes  long term errors that prevent garbage collection through debug handler. The `status` endpoint is to be used for debugging or by clients to asses the status of the GC controller.

usage: 

```
curl -k --header "Authorization: Bearer $TOKEN" https://localhost:10257/debug/controllers/garbagecollector/status
```

output:

```
{
  "errors": [
    {
      "errorTime": "2021-10-14T19:53:03Z",
      "lastUpdateTime": "2021-10-14T20:31:34Z",
      "error": "unable to get REST mapping for apps.openshift.io/v1/DeploymentConfig.",
      "errorType": "attemptToDelete",
      "involvedObject": {
        "apiVersion": "apps.openshift.io/v1",
        "kind": "DeploymentConfig",
        "name": "example",
        "uid": "b5404376-2d1e-42ee-b44b-19d3daa3f9a7",
        "namespace": "test"
      }
    },
    {
      "errorTime": "2021-10-14T19:53:03Z",
      "lastUpdateTime": "2021-10-14T20:31:34Z",
      "error": "unable to get REST mapping for build.openshift.io/v1/BuildConfig.",
      "errorType": "attemptToDelete",
      "involvedObject": {
        "apiVersion": "build.openshift.io/v1",
        "kind": "BuildConfig",
        "name": "ruby-hello-world",
        "uid": "1fbb08e2-f4d9-49d7-9ac1-2106d4782012",
        "namespace": "test"
      }
    }
  ]
}
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
