### PR TITLE
Shell completion of multiple resource names

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/get/get.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/get/get.go
@@ -167,8 +167,11 @@ func NewCmdGet(parent string, f cmdutil.Factory, streams genericclioptions.IOStr
 			var comps []string
 			if len(args) == 0 {
 				comps = apiresources.CompGetResourceList(f, cmd, toComplete)
-			} else if len(args) == 1 {
+			} else {
 				comps = CompGetResource(f, cmd, args[0], toComplete)
+				if len(args) > 1 {
+					comps = cmdutil.Difference(comps, args[1:])
+				}
 			}
 			return comps, cobra.ShellCompDirectiveNoFileComp
 		},

--- a/staging/src/k8s.io/kubectl/pkg/cmd/rollout/rollout_status.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/rollout/rollout_status.go
@@ -102,7 +102,7 @@ func NewCmdRolloutStatus(f cmdutil.Factory, streams genericclioptions.IOStreams)
 		Short:                 i18n.T("Show the status of the rollout"),
 		Long:                  statusLong,
 		Example:               statusExample,
-		ValidArgsFunction:     util.SpecifiedResourceTypeAndNameCompletionFunc(f, validArgs),
+		ValidArgsFunction:     util.SpecifiedResourceTypeAndNameNoRepeatCompletionFunc(f, validArgs),
 		Run: func(cmd *cobra.Command, args []string) {
 			cmdutil.CheckErr(o.Complete(f, args))
 			cmdutil.CheckErr(o.Validate())

--- a/staging/src/k8s.io/kubectl/pkg/cmd/util/helpers.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/util/helpers.go
@@ -733,3 +733,18 @@ func Warning(cmdErr io.Writer, newGeneratorName, oldGeneratorName string) {
 		oldGeneratorName,
 	)
 }
+
+// Difference removes any elements of subArray from fullArray and returns the result
+func Difference(fullArray []string, subArray []string) []string {
+	exclude := make(map[string]bool, len(subArray))
+	for _, elem := range subArray {
+		exclude[elem] = true
+	}
+	var result []string
+	for _, elem := range fullArray {
+		if _, found := exclude[elem]; !found {
+			result = append(result, elem)
+		}
+	}
+	return result
+}

--- a/staging/src/k8s.io/kubectl/pkg/util/completion.go
+++ b/staging/src/k8s.io/kubectl/pkg/util/completion.go
@@ -34,15 +34,18 @@ func SetFactoryForCompletion(f cmdutil.Factory) {
 }
 
 // ResourceTypeAndNameCompletionFunc Returns a completion function that completes as a first argument
-// the resource types that match the toComplete prefix, and as a second argument the resource names that match
+// the resource types that match the toComplete prefix, and all following arguments as resource names that match
 // the toComplete prefix.
 func ResourceTypeAndNameCompletionFunc(f cmdutil.Factory) func(*cobra.Command, []string, string) ([]string, cobra.ShellCompDirective) {
 	return func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		var comps []string
 		if len(args) == 0 {
 			comps = apiresources.CompGetResourceList(f, cmd, toComplete)
-		} else if len(args) == 1 {
+		} else {
 			comps = get.CompGetResource(f, cmd, args[0], toComplete)
+			if len(args) > 1 {
+				comps = cmdutil.Difference(comps, args[1:])
+			}
 		}
 		return comps, cobra.ShellCompDirectiveNoFileComp
 	}
@@ -50,8 +53,19 @@ func ResourceTypeAndNameCompletionFunc(f cmdutil.Factory) func(*cobra.Command, [
 
 // SpecifiedResourceTypeAndNameCompletionFunc Returns a completion function that completes as a first
 // argument the resource types that match the toComplete prefix and are limited to the allowedTypes,
-// and as a second argument the specified resource names that match the toComplete prefix.
+// and all following arguments as resource names that match the toComplete prefix.
 func SpecifiedResourceTypeAndNameCompletionFunc(f cmdutil.Factory, allowedTypes []string) func(*cobra.Command, []string, string) ([]string, cobra.ShellCompDirective) {
+	return doSpecifiedResourceTypeAndNameComp(f, allowedTypes, true)
+}
+
+// SpecifiedResourceTypeAndNameNoRepeatCompletionFunc Returns a completion function that completes as a first
+// argument the resource types that match the toComplete prefix and are limited to the allowedTypes, and as
+// a second argument a resource name that match the toComplete prefix.
+func SpecifiedResourceTypeAndNameNoRepeatCompletionFunc(f cmdutil.Factory, allowedTypes []string) func(*cobra.Command, []string, string) ([]string, cobra.ShellCompDirective) {
+	return doSpecifiedResourceTypeAndNameComp(f, allowedTypes, false)
+}
+
+func doSpecifiedResourceTypeAndNameComp(f cmdutil.Factory, allowedTypes []string, repeat bool) func(*cobra.Command, []string, string) ([]string, cobra.ShellCompDirective) {
 	return func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		var comps []string
 		if len(args) == 0 {
@@ -60,8 +74,13 @@ func SpecifiedResourceTypeAndNameCompletionFunc(f cmdutil.Factory, allowedTypes 
 					comps = append(comps, comp)
 				}
 			}
-		} else if len(args) == 1 {
-			comps = get.CompGetResource(f, cmd, args[0], toComplete)
+		} else {
+			if repeat || len(args) == 1 {
+				comps = get.CompGetResource(f, cmd, args[0], toComplete)
+				if repeat && len(args) > 1 {
+					comps = cmdutil.Difference(comps, args[1:])
+				}
+			}
 		}
 		return comps, cobra.ShellCompDirectiveNoFileComp
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

This PR teaches the completion functions to repeat resource names when applicable and supported. The logic checks if a resource name has already been specified by the user and does not include it again when repeating the completion.

For example, the `get` command can receive multiple pods names, therefore with this commit:
  `kubectl get pod pod1 [tab]`
will provide completion of pod names again, but not show `pod1` a second time since it is already part of the command-line.

The improvement affects the following commands:
- annotate
- apply edit-last-applied
- apply view-last-applied
- autoscale
- delete
- describe
- edit
- expose
- get
- label
- patch
- rollout history
- rollout pause
- rollout restart
- rollout resume
- rollout undo
- scale
- taint

Note that "rollout status" only accepts a single resource name, unlike the other "rollout ..." commands; this required the creation of a special completion function that did not repeat just for that case.

#### Which issue(s) this PR fixes:

Replaces #101427

#### Special notes for your reviewer:

The PR adds a utility function to remove a list of values from an array.  It is used to prevent the completion from suggesting choices that are already on the command-line (as explained above).  I don't know if such a utility already existed in the code base or if I put it in the right place (`cmd/util/helpers.go#Unique(..)`)

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Shell completion now knows to continue suggesting resource names when the command supports it.  For example "kubectl get pod pod1 <TAB>" will suggest more pod names.
```

/cc @phil9909
