### PR TITLE
sched: ensure --leader-elect* CLI args are honored

### DIFF
--- a/cmd/kube-scheduler/app/server.go
+++ b/cmd/kube-scheduler/app/server.go
@@ -68,7 +68,6 @@ func NewSchedulerCommand(registryOptions ...Option) *cobra.Command {
 		klog.Fatalf("unable to initialize command options: %v", err)
 	}
 
-	namedFlagSets := opts.Flags()
 	cmd := &cobra.Command{
 		Use: "kube-scheduler",
 		Long: `The Kubernetes scheduler is a control plane process which assigns
@@ -80,9 +79,6 @@ kube-scheduler is the reference implementation.
 See [scheduling](https://kubernetes.io/docs/concepts/scheduling-eviction/)
 for more information about scheduling and the kube-scheduler component.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if err := opts.Complete(&namedFlagSets); err != nil {
-				return err
-			}
 			return runCommand(cmd, opts, registryOptions...)
 		},
 		Args: func(cmd *cobra.Command, args []string) error {
@@ -96,6 +92,7 @@ for more information about scheduling and the kube-scheduler component.`,
 	}
 
 	fs := cmd.Flags()
+	namedFlagSets := opts.Flags()
 	verflag.AddFlags(namedFlagSets.FlagSet("global"))
 	globalflag.AddGlobalFlags(namedFlagSets.FlagSet("global"), cmd.Name())
 	for _, f := range namedFlagSets.FlagSets {
@@ -103,7 +100,7 @@ for more information about scheduling and the kube-scheduler component.`,
 	}
 
 	cols, _, _ := term.TerminalSize(cmd.OutOrStdout())
-	cliflag.SetUsageAndHelpFunc(cmd, namedFlagSets, cols)
+	cliflag.SetUsageAndHelpFunc(cmd, *namedFlagSets, cols)
 
 	cmd.MarkFlagFilename("config", "yaml", "yml", "json")
 

--- a/cmd/kube-scheduler/app/server_test.go
+++ b/cmd/kube-scheduler/app/server_test.go
@@ -26,9 +26,13 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/spf13/pflag"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	componentbaseconfig "k8s.io/component-base/config"
+	"k8s.io/kube-scheduler/config/v1beta3"
 	"k8s.io/kubernetes/cmd/kube-scheduler/app/options"
 	"k8s.io/kubernetes/pkg/scheduler/apis/config"
 	"k8s.io/kubernetes/pkg/scheduler/apis/config/testing/defaults"
@@ -139,10 +143,35 @@ profiles:
 		t.Fatal(err)
 	}
 
+	// empty leader-election config
+	emptyLeaderElectionConfig := filepath.Join(tmpDir, "empty-leader-election-config.yaml")
+	if err := ioutil.WriteFile(emptyLeaderElectionConfig, []byte(fmt.Sprintf(`
+apiVersion: kubescheduler.config.k8s.io/v1beta3
+kind: KubeSchedulerConfiguration
+clientConnection:
+  kubeconfig: "%s"
+`, configKubeconfig)), os.FileMode(0600)); err != nil {
+		t.Fatal(err)
+	}
+
+	// leader-election config
+	leaderElectionConfig := filepath.Join(tmpDir, "leader-election-config.yaml")
+	if err := ioutil.WriteFile(leaderElectionConfig, []byte(fmt.Sprintf(`
+apiVersion: kubescheduler.config.k8s.io/v1beta3
+kind: KubeSchedulerConfiguration
+clientConnection:
+  kubeconfig: "%s"
+leaderElection:
+  leaseDuration: 1h
+`, configKubeconfig)), os.FileMode(0600)); err != nil {
+		t.Fatal(err)
+	}
+
 	testcases := []struct {
-		name        string
-		flags       []string
-		wantPlugins map[string]*config.Plugins
+		name               string
+		flags              []string
+		wantPlugins        map[string]*config.Plugins
+		wantLeaderElection *componentbaseconfig.LeaderElectionConfiguration
 	}{
 		{
 			name: "default config",
@@ -193,6 +222,75 @@ profiles:
 				},
 			},
 		},
+		{
+			name: "leader election CLI args, along with --config arg",
+			flags: []string{
+				"--leader-elect=false",
+				"--leader-elect-lease-duration=2h", // CLI args are favored over the fields in ComponentConfig
+				"--lock-object-namespace=default",  // deprecated CLI arg will be ignored if --config is specified
+				"--config", emptyLeaderElectionConfig,
+			},
+			wantLeaderElection: &componentbaseconfig.LeaderElectionConfiguration{
+				LeaderElect:       false,                                    // from CLI args
+				LeaseDuration:     metav1.Duration{Duration: 2 * time.Hour}, // from CLI args
+				RenewDeadline:     metav1.Duration{Duration: 10 * time.Second},
+				RetryPeriod:       metav1.Duration{Duration: 2 * time.Second},
+				ResourceLock:      "leases",
+				ResourceName:      v1beta3.SchedulerDefaultLockObjectName,
+				ResourceNamespace: v1beta3.SchedulerDefaultLockObjectNamespace,
+			},
+		},
+		{
+			name: "leader election CLI args, without --config arg",
+			flags: []string{
+				"--leader-elect=false",
+				"--leader-elect-lease-duration=2h",
+				"--lock-object-namespace=default", // deprecated CLI arg is honored if --config is not specified
+				"--kubeconfig", configKubeconfig,
+			},
+			wantLeaderElection: &componentbaseconfig.LeaderElectionConfiguration{
+				LeaderElect:       false,                                    // from CLI args
+				LeaseDuration:     metav1.Duration{Duration: 2 * time.Hour}, // from CLI args
+				RenewDeadline:     metav1.Duration{Duration: 10 * time.Second},
+				RetryPeriod:       metav1.Duration{Duration: 2 * time.Second},
+				ResourceLock:      "leases",
+				ResourceName:      v1beta3.SchedulerDefaultLockObjectName,
+				ResourceNamespace: "default", // from deprecated CLI args
+			},
+		},
+		{
+			name: "leader election settings specified by ComponentConfig only",
+			flags: []string{
+				"--config", leaderElectionConfig,
+			},
+			wantLeaderElection: &componentbaseconfig.LeaderElectionConfiguration{
+				LeaderElect:       true,
+				LeaseDuration:     metav1.Duration{Duration: 1 * time.Hour}, // from CC
+				RenewDeadline:     metav1.Duration{Duration: 10 * time.Second},
+				RetryPeriod:       metav1.Duration{Duration: 2 * time.Second},
+				ResourceLock:      "leases",
+				ResourceName:      v1beta3.SchedulerDefaultLockObjectName,
+				ResourceNamespace: v1beta3.SchedulerDefaultLockObjectNamespace,
+			},
+		},
+		{
+			name: "leader election settings specified by CLI args and ComponentConfig",
+			flags: []string{
+				"--leader-elect=true",
+				"--leader-elect-renew-deadline=5s",
+				"--leader-elect-retry-period=1s",
+				"--config", leaderElectionConfig,
+			},
+			wantLeaderElection: &componentbaseconfig.LeaderElectionConfiguration{
+				LeaderElect:       true,
+				LeaseDuration:     metav1.Duration{Duration: 1 * time.Hour},   // from CC
+				RenewDeadline:     metav1.Duration{Duration: 5 * time.Second}, // from CLI args
+				RetryPeriod:       metav1.Duration{Duration: 1 * time.Second}, // from CLI args
+				ResourceLock:      "leases",
+				ResourceName:      v1beta3.SchedulerDefaultLockObjectName,
+				ResourceNamespace: v1beta3.SchedulerDefaultLockObjectNamespace,
+			},
+		},
 	}
 
 	makeListener := func(t *testing.T) net.Listener {
@@ -211,6 +309,9 @@ profiles:
 			if err != nil {
 				t.Fatal(err)
 			}
+			// use listeners instead of static ports so parallel test runs don't conflict
+			opts.SecureServing.Listener = makeListener(t)
+			defer opts.SecureServing.Listener.Close()
 
 			nfs := opts.Flags()
 			for _, f := range nfs.FlagSets {
@@ -220,14 +321,6 @@ profiles:
 				t.Fatal(err)
 			}
 
-			if err := opts.Complete(&nfs); err != nil {
-				t.Fatal(err)
-			}
-
-			// use listeners instead of static ports so parallel test runs don't conflict
-			opts.SecureServing.Listener = makeListener(t)
-			defer opts.SecureServing.Listener.Close()
-
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
 			_, sched, err := Setup(ctx, opts)
@@ -235,13 +328,22 @@ profiles:
 				t.Fatal(err)
 			}
 
-			gotPlugins := make(map[string]*config.Plugins)
-			for n, p := range sched.Profiles {
-				gotPlugins[n] = p.ListPlugins()
+			if tc.wantPlugins != nil {
+				gotPlugins := make(map[string]*config.Plugins)
+				for n, p := range sched.Profiles {
+					gotPlugins[n] = p.ListPlugins()
+				}
+
+				if diff := cmp.Diff(tc.wantPlugins, gotPlugins); diff != "" {
+					t.Errorf("Unexpected plugins diff (-want, +got): %s", diff)
+				}
 			}
 
-			if diff := cmp.Diff(tc.wantPlugins, gotPlugins); diff != "" {
-				t.Errorf("unexpected plugins diff (-want, +got): %s", diff)
+			if tc.wantLeaderElection != nil {
+				gotLeaderElection := opts.ComponentConfig.LeaderElection
+				if diff := cmp.Diff(*tc.wantLeaderElection, gotLeaderElection); diff != "" {
+					t.Errorf("Unexpected leaderElection diff (-want, +got): %s", diff)
+				}
 			}
 		})
 	}

--- a/cmd/kube-scheduler/app/testing/testserver.go
+++ b/cmd/kube-scheduler/app/testing/testserver.go
@@ -93,10 +93,6 @@ func StartTestServer(t Logger, customFlags []string) (result TestServer, err err
 	}
 	fs.Parse(customFlags)
 
-	if err := opts.Complete(&namedFlagSets); err != nil {
-		return TestServer{}, err
-	}
-
 	if opts.SecureServing.BindPort != 0 {
 		opts.SecureServing.Listener, opts.SecureServing.BindPort, err = createListenerOnFreePort()
 		if err != nil {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/sig scheduling

#### What this PR does / why we need it:

`--leader-elect*` consists of a collection of CLI arguments. They were handled as individuals which ends up with buggy behavior like what #105704 described - CLI arg gets overwritten by internal defaulted ComponentConfig.LeaderElection. Moreover, some other potential bugs can also occur.

Basically, there are 3 scenarios to specify leader elect related options:

- by CLI arguments only
- by ComponentConfig only
- jointly by CLI arguments and ComponentConfig

This PR unifies the behavior to always honor CLI arguments over ComponentConfig.

#### Which issue(s) this PR fixes:

Fixes #105704 

#### Special notes for your reviewer:

The fix should be backported to v1.22.

#### Does this PR introduce a user-facing change?

```release-note
The --leader-elect* CLI args are now honored in scheduler.
```