### PR TITLE
Fix Documentation of Default params for PodExecOptions Function

### DIFF
--- a/staging/src/k8s.io/api/core/v1/generated.proto
+++ b/staging/src/k8s.io/api/core/v1/generated.proto
@@ -3172,12 +3172,10 @@ message PodExecOptions {
   optional bool stdin = 1;
 
   // Redirect the standard output stream of the pod for this call.
-  // Defaults to true.
   // +optional
   optional bool stdout = 2;
 
   // Redirect the standard error stream of the pod for this call.
-  // Defaults to true.
   // +optional
   optional bool stderr = 3;
 

--- a/staging/src/k8s.io/api/core/v1/types.go
+++ b/staging/src/k8s.io/api/core/v1/types.go
@@ -5294,12 +5294,10 @@ type PodExecOptions struct {
 	Stdin bool `json:"stdin,omitempty" protobuf:"varint,1,opt,name=stdin"`
 
 	// Redirect the standard output stream of the pod for this call.
-	// Defaults to true.
 	// +optional
 	Stdout bool `json:"stdout,omitempty" protobuf:"varint,2,opt,name=stdout"`
 
 	// Redirect the standard error stream of the pod for this call.
-	// Defaults to true.
 	// +optional
 	Stderr bool `json:"stderr,omitempty" protobuf:"varint,3,opt,name=stderr"`
 

--- a/staging/src/k8s.io/api/core/v1/types_swagger_doc_generated.go
+++ b/staging/src/k8s.io/api/core/v1/types_swagger_doc_generated.go
@@ -1511,8 +1511,8 @@ func (PodDNSConfigOption) SwaggerDoc() map[string]string {
 var map_PodExecOptions = map[string]string{
 	"":          "PodExecOptions is the query options to a Pod's remote exec call.",
 	"stdin":     "Redirect the standard input stream of the pod for this call. Defaults to false.",
-	"stdout":    "Redirect the standard output stream of the pod for this call. Defaults to true.",
-	"stderr":    "Redirect the standard error stream of the pod for this call. Defaults to true.",
+	"stdout":    "Redirect the standard output stream of the pod for this call.",
+	"stderr":    "Redirect the standard error stream of the pod for this call.",
 	"tty":       "TTY if true indicates that a tty will be allocated for the exec call. Defaults to false.",
 	"container": "Container in which to execute the command. Defaults to only container if there is only one container in the pod.",
 	"command":   "Command is the remote command to execute. argv array. Not executed within a shell.",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind cleanup
/kind documentation


Optionally add one or more of the following kinds if applicable:
/kind deprecation
-->
/kind cleanup
/kind documentation
/kind deprecation
#### What this PR does / why we need it:
This PR removes the comment for stdout and stderr default values of TRUE and re generates the OpenApiSpec for the same .
The default values were changed in the PR  #49579 #49586 and in the current file https://github.com/kubernetes/kubernetes/blob/a53e2eaeaba064309dceca2dc27f3ac09c6375b0/staging/src/k8s.io/api/core/v1/types.go#L5296-L5304   the default value comment is still present

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #105717 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
None
```
