### PR TITLE
apf: return nil for a request that has been removed from queue

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/queueset/fifo_list.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/queueset/fifo_list.go
@@ -22,7 +22,8 @@ import (
 
 // removeFromFIFOFunc removes a designated element from the list.
 // The complexity of the runtime cost is O(1)
-// It returns the request removed from the list.
+// It returns the request that has been removed from the list,
+// it returns nil if the request has already been removed.
 type removeFromFIFOFunc func() *request
 
 // walkFunc is called for each request in the list in the
@@ -89,11 +90,12 @@ func (l *requestFIFO) Enqueue(req *request) removeFromFIFOFunc {
 	addToQueueSum(&l.sum, req)
 
 	return func() *request {
-		if e.Value != nil {
-			l.Remove(e)
-			e.Value = nil
-			deductFromQueueSum(&l.sum, req)
+		if e.Value == nil {
+			return nil
 		}
+		l.Remove(e)
+		e.Value = nil
+		deductFromQueueSum(&l.sum, req)
 		return req
 	}
 }

--- a/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/queueset/fifo_list_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/queueset/fifo_list_test.go
@@ -100,6 +100,21 @@ func TestFIFOWithRemoveMultipleRequestsInArrivalOrder(t *testing.T) {
 	verifyOrder(t, arrival, dequeued)
 }
 
+func TestFIFORemoveFromFIFOFunc(t *testing.T) {
+	list := newRequestFIFO()
+	reqWant := &request{}
+	removeFn := list.Enqueue(reqWant)
+
+	reqGot := removeFn()
+	if reqWant != reqGot {
+		t.Errorf("Expected request identity: %p, but got: %p)", reqWant, reqGot)
+	}
+
+	if got := removeFn(); got != nil {
+		t.Errorf("Expected a nil request, but got: %v)", got)
+	}
+}
+
 func TestFIFOWithRemoveMultipleRequestsInRandomOrder(t *testing.T) {
 	list := newRequestFIFO()
 

--- a/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/queueset/queueset.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/queueset/queueset.go
@@ -386,11 +386,12 @@ func (req *request) wait() (bool, bool) {
 	// TODO(aaron-prindle) add metrics for this case
 	klog.V(5).Infof("QS(%s): Ejecting request %#+v %#+v from its queue", qs.qCfg.Name, req.descr1, req.descr2)
 	// remove the request from the queue as it has timed out
-	req.removeFromQueueLocked()
-	qs.totRequestsWaiting--
-	metrics.AddRequestsInQueues(req.ctx, qs.qCfg.Name, req.fsName, -1)
-	req.NoteQueued(false)
-	qs.obsPair.RequestsWaiting.Add(-1)
+	if req.removeFromQueueLocked() != nil {
+		qs.totRequestsWaiting--
+		metrics.AddRequestsInQueues(req.ctx, qs.qCfg.Name, req.fsName, -1)
+		req.NoteQueued(false)
+		qs.obsPair.RequestsWaiting.Add(-1)
+	}
 	return false, qs.isIdleLocked()
 }
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:
removeFromFIFOFunc should return nil for a request that has been removed from queue.

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
