### PR TITLE
kubeadm: introduce the UnversionedKubeletConfigMap feature gate

### DIFF
--- a/cmd/kubeadm/app/componentconfigs/configset_test.go
+++ b/cmd/kubeadm/app/componentconfigs/configset_test.go
@@ -26,24 +26,34 @@ import (
 
 	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
 	"k8s.io/kubernetes/cmd/kubeadm/app/constants"
+	"k8s.io/kubernetes/cmd/kubeadm/app/features"
 	kubeadmutil "k8s.io/kubernetes/cmd/kubeadm/app/util"
 )
 
-func testClusterCfg() *kubeadmapi.ClusterConfiguration {
+// TODO: cleanup after UnversionedKubeletConfigMap goes GA:
+// https://github.com/kubernetes/kubeadm/issues/1582
+func testClusterCfg(legacyKubeletConfigMap bool) *kubeadmapi.ClusterConfiguration {
+	if legacyKubeletConfigMap {
+		return &kubeadmapi.ClusterConfiguration{
+			KubernetesVersion: constants.CurrentKubernetesVersion.String(),
+		}
+	}
 	return &kubeadmapi.ClusterConfiguration{
 		KubernetesVersion: constants.CurrentKubernetesVersion.String(),
+		FeatureGates:      map[string]bool{features.UnversionedKubeletConfigMap: true},
 	}
 }
 
 func TestDefault(t *testing.T) {
-	clusterCfg := testClusterCfg()
+	legacyKubeletConfigMap := false
+	clusterCfg := testClusterCfg(legacyKubeletConfigMap)
 	localAPIEndpoint := &kubeadmapi.APIEndpoint{}
 	nodeRegOps := &kubeadmapi.NodeRegistrationOptions{}
 
 	Default(clusterCfg, localAPIEndpoint, nodeRegOps)
 
 	if len(clusterCfg.ComponentConfigs) != len(known) {
-		t.Errorf("missmatch between supported and defaulted type numbers:\n\tgot: %d\n\texpected: %d", len(clusterCfg.ComponentConfigs), len(known))
+		t.Errorf("mismatch between supported and defaulted type numbers:\n\tgot: %d\n\texpected: %d", len(clusterCfg.ComponentConfigs), len(known))
 	}
 }
 
@@ -56,17 +66,42 @@ func TestFromCluster(t *testing.T) {
 		testKubeletConfigMap(`
 			apiVersion: kubelet.config.k8s.io/v1beta1
 			kind: KubeletConfiguration
-		`),
+		`, false),
 	}
 	client := clientsetfake.NewSimpleClientset(objects...)
-	clusterCfg := testClusterCfg()
+	legacyKubeletConfigMap := false
+	clusterCfg := testClusterCfg(legacyKubeletConfigMap)
 
 	if err := FetchFromCluster(clusterCfg, client); err != nil {
 		t.Fatalf("FetchFromCluster failed: %v", err)
 	}
 
 	if len(clusterCfg.ComponentConfigs) != len(objects) {
-		t.Fatalf("missmatch between supplied and loaded type numbers:\n\tgot: %d\n\texpected: %d", len(clusterCfg.ComponentConfigs), len(objects))
+		t.Fatalf("mismatch between supplied and loaded type numbers:\n\tgot: %d\n\texpected: %d", len(clusterCfg.ComponentConfigs), len(objects))
+	}
+
+	// TODO: cleanup the legacy case below after UnversionedKubeletConfigMap goes GA:
+	// https://github.com/kubernetes/kubeadm/issues/1582
+	objectsLegacyKubelet := []runtime.Object{
+		testKubeProxyConfigMap(`
+			apiVersion: kubeproxy.config.k8s.io/v1alpha1
+			kind: KubeProxyConfiguration
+		`),
+		testKubeletConfigMap(`
+			apiVersion: kubelet.config.k8s.io/v1beta1
+			kind: KubeletConfiguration
+		`, true),
+	}
+	clientLegacyKubelet := clientsetfake.NewSimpleClientset(objectsLegacyKubelet...)
+	legacyKubeletConfigMap = true
+	clusterCfgLegacyKubelet := testClusterCfg(legacyKubeletConfigMap)
+
+	if err := FetchFromCluster(clusterCfgLegacyKubelet, clientLegacyKubelet); err != nil {
+		t.Fatalf("FetchFromCluster failed: %v", err)
+	}
+
+	if len(clusterCfgLegacyKubelet.ComponentConfigs) != len(objectsLegacyKubelet) {
+		t.Fatalf("mismatch between supplied and loaded type numbers:\n\tgot: %d\n\texpected: %d", len(clusterCfg.ComponentConfigs), len(objects))
 	}
 }
 
@@ -83,12 +118,13 @@ func TestFetchFromDocumentMap(t *testing.T) {
 		t.Fatalf("unexpected failure of SplitYAMLDocuments: %v", err)
 	}
 
-	clusterCfg := testClusterCfg()
+	legacyKubeletConfigMap := false
+	clusterCfg := testClusterCfg(legacyKubeletConfigMap)
 	if err = FetchFromDocumentMap(clusterCfg, gvkmap); err != nil {
 		t.Fatalf("FetchFromDocumentMap failed: %v", err)
 	}
 
 	if len(clusterCfg.ComponentConfigs) != len(gvkmap) {
-		t.Fatalf("missmatch between supplied and loaded type numbers:\n\tgot: %d\n\texpected: %d", len(clusterCfg.ComponentConfigs), len(gvkmap))
+		t.Fatalf("mismatch between supplied and loaded type numbers:\n\tgot: %d\n\texpected: %d", len(clusterCfg.ComponentConfigs), len(gvkmap))
 	}
 }

--- a/cmd/kubeadm/app/componentconfigs/fakeconfig_test.go
+++ b/cmd/kubeadm/app/componentconfigs/fakeconfig_test.go
@@ -357,7 +357,8 @@ func TestGeneratedConfigFromCluster(t *testing.T) {
 				}
 
 				client := clientsetfake.NewSimpleClientset(configMap)
-				cfg, err := clusterConfigHandler.FromCluster(client, testClusterCfg())
+				legacyKubeletConfigMap := true
+				cfg, err := clusterConfigHandler.FromCluster(client, testClusterCfg(legacyKubeletConfigMap))
 				if err != nil {
 					t.Fatalf("unexpected failure of FromCluster: %v", err)
 				}
@@ -453,7 +454,7 @@ func runClusterConfigFromTest(t *testing.T, perform func(t *testing.T, in string
 									t.Errorf("unexpected result: %v", got)
 								} else {
 									if !reflect.DeepEqual(test.out, got) {
-										t.Errorf("missmatch between expected and got:\nExpected:\n%v\n---\nGot:\n%v", test.out, got)
+										t.Errorf("mismatch between expected and got:\nExpected:\n%v\n---\nGot:\n%v", test.out, got)
 									}
 								}
 							}
@@ -482,7 +483,8 @@ func TestLoadingFromCluster(t *testing.T) {
 			testClusterConfigMap(in, false),
 		)
 
-		return clusterConfigHandler.FromCluster(client, testClusterCfg())
+		legacyKubeletConfigMap := true
+		return clusterConfigHandler.FromCluster(client, testClusterCfg(legacyKubeletConfigMap))
 	})
 }
 
@@ -575,7 +577,8 @@ func TestFetchFromClusterWithLocalOverwrites(t *testing.T) {
 					t.Fatalf("unexpected failure of SplitYAMLDocuments: %v", err)
 				}
 
-				clusterCfg := testClusterCfg()
+				legacyKubeletConfigMap := true
+				clusterCfg := testClusterCfg(legacyKubeletConfigMap)
 
 				err = FetchFromClusterWithLocalOverwrites(clusterCfg, client, docmap)
 				if err != nil {
@@ -709,7 +712,8 @@ func TestGetVersionStates(t *testing.T) {
 					t.Fatalf("unexpected failure of SplitYAMLDocuments: %v", err)
 				}
 
-				clusterCfg := testClusterCfg()
+				legacyKubeletConfigMap := true
+				clusterCfg := testClusterCfg(legacyKubeletConfigMap)
 
 				got, err := GetVersionStates(clusterCfg, client, docmap)
 				if err != nil {

--- a/cmd/kubeadm/app/componentconfigs/kubelet.go
+++ b/cmd/kubeadm/app/componentconfigs/kubelet.go
@@ -19,6 +19,7 @@ package componentconfigs
 import (
 	"path/filepath"
 
+	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/util/version"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/klog/v2"
@@ -76,8 +77,25 @@ func kubeletConfigFromCluster(h *handler, clientset clientset.Interface, cluster
 		return nil, err
 	}
 
-	configMapName := constants.GetKubeletConfigMapName(k8sVersion)
-	return h.fromConfigMap(clientset, configMapName, constants.KubeletBaseConfigurationConfigMapKey, true)
+	// TODO: https://github.com/kubernetes/kubeadm/issues/1582
+	// During the first "kubeadm upgrade apply" when the feature gate goes "true" by default and
+	// a preferred user value is missing in the ClusterConfiguration, "kubeadm upgrade apply" will try
+	// to fetch using the new format and that CM will not exist yet.
+	// Tollerate both the old a new format until UnversionedKubeletConfigMap goes GA and is locked.
+	// This makes it easier for the users and the code base (avoids changes in /cmd/upgrade/common.go#enforceRequirements).
+	configMapNameLegacy := constants.GetKubeletConfigMapName(k8sVersion, true)
+	configMapName := constants.GetKubeletConfigMapName(k8sVersion, false)
+	klog.V(1).Infof("attempting to download the KubeletConfiguration from the new format location (UnversionedKubeletConfigMap=true)")
+	cm, err := h.fromConfigMap(clientset, configMapName, constants.KubeletBaseConfigurationConfigMapKey, true)
+	if err != nil {
+		klog.V(1).Infof("attempting to download the KubeletConfiguration from the DEPRECATED location (UnversionedKubeletConfigMap=false)")
+		cm, err = h.fromConfigMap(clientset, configMapNameLegacy, constants.KubeletBaseConfigurationConfigMapKey, true)
+		if err != nil {
+			return nil, errors.Wrapf(err, "could not download the kubelet configuration from ConfigMap %q or %q",
+				configMapName, configMapNameLegacy)
+		}
+	}
+	return cm, nil
 }
 
 // kubeletConfig implements the kubeadmapi.ComponentConfig interface for kubelet

--- a/cmd/kubeadm/app/componentconfigs/kubeproxy_test.go
+++ b/cmd/kubeadm/app/componentconfigs/kubeproxy_test.go
@@ -163,6 +163,7 @@ func TestKubeProxyFromCluster(t *testing.T) {
 			testKubeProxyConfigMap(yaml),
 		)
 
-		return kubeProxyHandler.FromCluster(client, testClusterCfg())
+		legacyKubeletConfigMap := true
+		return kubeProxyHandler.FromCluster(client, testClusterCfg(legacyKubeletConfigMap))
 	})
 }

--- a/cmd/kubeadm/app/constants/constants.go
+++ b/cmd/kubeadm/app/constants/constants.go
@@ -260,13 +260,23 @@ const (
 	KubeProxyConfigMapKey = "config.conf"
 
 	// KubeletBaseConfigurationConfigMapPrefix specifies in what ConfigMap in the kube-system namespace the initial remote configuration of kubelet should be stored
+	// TODO: Remove once UnversionedKubeletConfigMap graduates to GA:
+	// https://github.com/kubernetes/kubeadm/issues/1582
 	KubeletBaseConfigurationConfigMapPrefix = "kubelet-config-"
+
+	// KubeletBaseConfigurationConfigMap specifies in what ConfigMap in the kube-system namespace the initial remote configuration of kubelet should be stored
+	KubeletBaseConfigurationConfigMap = "kubelet-config"
 
 	// KubeletBaseConfigurationConfigMapKey specifies in what ConfigMap key the initial remote configuration of kubelet should be stored
 	KubeletBaseConfigurationConfigMapKey = "kubelet"
 
 	// KubeletBaseConfigMapRolePrefix defines the base kubelet configuration ConfigMap.
+	// TODO: Remove once UnversionedKubeletConfigMap graduates to GA:
+	// https://github.com/kubernetes/kubeadm/issues/1582
 	KubeletBaseConfigMapRolePrefix = "kubeadm:kubelet-config-"
+
+	// KubeletBaseConfigMapRolePrefix defines the base kubelet configuration ConfigMap.
+	KubeletBaseConfigMapRole = "kubeadm:kubelet-config"
 
 	// KubeletRunDirectory specifies the directory where the kubelet runtime information is stored.
 	KubeletRunDirectory = "/var/lib/kubelet"
@@ -672,6 +682,11 @@ func GetAPIServerVirtualIP(svcSubnetList string) (net.IP, error) {
 }
 
 // GetKubeletConfigMapName returns the right ConfigMap name for the right branch of k8s
-func GetKubeletConfigMapName(k8sVersion *version.Version) string {
+// TODO: Remove the legacy arg once UnversionedKubeletConfigMap graduates to GA:
+// https://github.com/kubernetes/kubeadm/issues/1582
+func GetKubeletConfigMapName(k8sVersion *version.Version, legacy bool) string {
+	if !legacy {
+		return KubeletBaseConfigurationConfigMap
+	}
 	return fmt.Sprintf("%s%d.%d", KubeletBaseConfigurationConfigMapPrefix, k8sVersion.Major(), k8sVersion.Minor())
 }

--- a/cmd/kubeadm/app/features/features.go
+++ b/cmd/kubeadm/app/features/features.go
@@ -35,13 +35,16 @@ const (
 	PublicKeysECDSA = "PublicKeysECDSA"
 	// RootlessControlPlane is expected to be in alpha in v1.22
 	RootlessControlPlane = "RootlessControlPlane"
+	// UnversionedKubeletConfigMap is expected to be alpha in 1.23
+	UnversionedKubeletConfigMap = "UnversionedKubeletConfigMap"
 )
 
 // InitFeatureGates are the default feature gates for the init command
 var InitFeatureGates = FeatureList{
-	IPv6DualStack:        {FeatureSpec: featuregate.FeatureSpec{Default: true, LockToDefault: true, PreRelease: featuregate.GA}, HiddenInHelpText: true},
-	PublicKeysECDSA:      {FeatureSpec: featuregate.FeatureSpec{Default: false, PreRelease: featuregate.Alpha}},
-	RootlessControlPlane: {FeatureSpec: featuregate.FeatureSpec{Default: false, PreRelease: featuregate.Alpha}},
+	IPv6DualStack:               {FeatureSpec: featuregate.FeatureSpec{Default: true, LockToDefault: true, PreRelease: featuregate.GA}, HiddenInHelpText: true},
+	PublicKeysECDSA:             {FeatureSpec: featuregate.FeatureSpec{Default: false, PreRelease: featuregate.Alpha}},
+	RootlessControlPlane:        {FeatureSpec: featuregate.FeatureSpec{Default: false, PreRelease: featuregate.Alpha}},
+	UnversionedKubeletConfigMap: {FeatureSpec: featuregate.FeatureSpec{Default: false, PreRelease: featuregate.Alpha}},
 }
 
 // Feature represents a feature being gated

--- a/cmd/kubeadm/app/phases/kubelet/config.go
+++ b/cmd/kubeadm/app/phases/kubelet/config.go
@@ -152,35 +152,6 @@ func createConfigMapRBACRules(client clientset.Interface, k8sVersion *version.Ve
 	})
 }
 
-// DownloadConfig downloads the kubelet configuration from a ConfigMap and writes it to disk.
-// DEPRECATED: Do not use in new code!
-func DownloadConfig(client clientset.Interface, kubeletVersionStr string, kubeletDir string) error {
-	// Parse the desired kubelet version
-	kubeletVersion, err := version.ParseSemantic(kubeletVersionStr)
-	if err != nil {
-		return err
-	}
-
-	// Download the ConfigMap from the cluster based on what version the kubelet is
-	configMapName := kubeadmconstants.GetKubeletConfigMapName(kubeletVersion)
-
-	fmt.Printf("[kubelet-start] Downloading configuration for the kubelet from the %q ConfigMap in the %s namespace\n",
-		configMapName, metav1.NamespaceSystem)
-
-	kubeletCfgMap, err := apiclient.GetConfigMapWithRetry(client, metav1.NamespaceSystem, configMapName)
-	if err != nil {
-		return err
-	}
-
-	// Check for the key existence, otherwise we'll panic here
-	kubeletCfg, ok := kubeletCfgMap.Data[kubeadmconstants.KubeletBaseConfigurationConfigMapKey]
-	if !ok {
-		return errors.Errorf("no key %q found in config map %s", kubeadmconstants.KubeletBaseConfigurationConfigMapKey, configMapName)
-	}
-
-	return writeConfigBytesToDisk([]byte(kubeletCfg), kubeletDir)
-}
-
 // configMapRBACName returns the name for the Role/RoleBinding for the kubelet config configmap for the right branch of k8s
 // TODO: Remove the legacy arg once UnversionedKubeletConfigMap graduates to GA:
 // https://github.com/kubernetes/kubeadm/issues/1582

--- a/cmd/kubeadm/app/phases/kubelet/config_test.go
+++ b/cmd/kubeadm/app/phases/kubelet/config_test.go
@@ -69,7 +69,7 @@ func TestCreateConfigMapRBACRules(t *testing.T) {
 		return true, nil, nil
 	})
 
-	if err := createConfigMapRBACRules(client, version.MustParseSemantic("v1.11.0")); err != nil {
+	if err := createConfigMapRBACRules(client, version.MustParseSemantic("v1.11.0"), false); err != nil {
 		t.Errorf("createConfigMapRBACRules: unexpected error %v", err)
 	}
 }

--- a/cmd/kubeadm/app/util/config/cluster_test.go
+++ b/cmd/kubeadm/app/util/config/cluster_test.go
@@ -545,7 +545,7 @@ func TestGetInitConfigurationFromCluster(t *testing.T) {
 					},
 				},
 				{
-					Name: kubeadmconstants.GetKubeletConfigMapName(k8sVersion), // Kubelet component config from corresponding ConfigMap.
+					Name: kubeadmconstants.GetKubeletConfigMapName(k8sVersion, false), // Kubelet component config from corresponding ConfigMap.
 					Data: map[string]string{
 						kubeadmconstants.KubeletBaseConfigurationConfigMapKey: string(cfgFiles["Kubelet_componentconfig"]),
 					},
@@ -589,7 +589,7 @@ func TestGetInitConfigurationFromCluster(t *testing.T) {
 					},
 				},
 				{
-					Name: kubeadmconstants.GetKubeletConfigMapName(k8sVersion), // Kubelet component config from corresponding ConfigMap.
+					Name: kubeadmconstants.GetKubeletConfigMapName(k8sVersion, false), // Kubelet component config from corresponding ConfigMap.
 					Data: map[string]string{
 						kubeadmconstants.KubeletBaseConfigurationConfigMapKey: string(cfgFiles["Kubelet_componentconfig"]),
 					},
@@ -622,7 +622,7 @@ func TestGetInitConfigurationFromCluster(t *testing.T) {
 					},
 				},
 				{
-					Name: kubeadmconstants.GetKubeletConfigMapName(k8sVersion), // Kubelet component config from corresponding ConfigMap.
+					Name: kubeadmconstants.GetKubeletConfigMapName(k8sVersion, false), // Kubelet component config from corresponding ConfigMap.
 					Data: map[string]string{
 						kubeadmconstants.KubeletBaseConfigurationConfigMapKey: string(cfgFiles["Kubelet_componentconfig"]),
 					},
@@ -666,7 +666,7 @@ func TestGetInitConfigurationFromCluster(t *testing.T) {
 					},
 				},
 				{
-					Name: kubeadmconstants.GetKubeletConfigMapName(k8sVersion), // Kubelet component config from corresponding ConfigMap.
+					Name: kubeadmconstants.GetKubeletConfigMapName(k8sVersion, false), // Kubelet component config from corresponding ConfigMap.
 					Data: map[string]string{
 						kubeadmconstants.KubeletBaseConfigurationConfigMapKey: string(cfgFiles["Kubelet_componentconfig"]),
 					},

--- a/test/e2e_kubeadm/kubelet_config_test.go
+++ b/test/e2e_kubeadm/kubelet_config_test.go
@@ -69,6 +69,9 @@ var _ = Describe("kubelet-config ConfigMap", func() {
 		m := getClusterConfiguration(f.ClientSet)
 
 		// Extract the kubernetesVersion
+		// TODO: remove this after the UnversionedKubeletConfigMap feature gate goes GA:
+		// https://github.com/kubernetes/kubeadm/issues/1582
+		// At that point parsing the k8s version will no longer be needed in this test.
 		gomega.Expect(m).To(gomega.HaveKey("kubernetesVersion"))
 		k8sVersionString := m["kubernetesVersion"].(string)
 		k8sVersion, err := version.ParseSemantic(k8sVersionString)
@@ -76,9 +79,31 @@ var _ = Describe("kubelet-config ConfigMap", func() {
 			framework.Failf("error reading kubernetesVersion from %s ConfigMap: %v", kubeadmConfigName, err)
 		}
 
+		// Extract the value of the UnversionedKubeletConfigMap feature gate if its present.
+		// TODO: remove this after the UnversionedKubeletConfigMap feature gate goes GA:
+		// https://github.com/kubernetes/kubeadm/issues/1582
+		var UnversionedKubeletConfigMap bool
+		if _, ok := m["featureGates"]; ok {
+			if featureGates, ok := m["featureGates"].(map[string]bool); ok {
+				// TODO: update the default to true once this graduates to Beta.
+				UnversionedKubeletConfigMap = false
+				if val, ok := featureGates["UnversionedKubeletConfigMap"]; ok {
+					UnversionedKubeletConfigMap = val
+				}
+			} else {
+				framework.Failf("unable to cast the featureGates field in the %s ConfigMap", kubeadmConfigName)
+			}
+		}
+
 		// Computes all the names derived from the kubernetesVersion
-		kubeletConfigConfigMapName = fmt.Sprintf("kubelet-config-%d.%d", k8sVersion.Major(), k8sVersion.Minor())
-		kubeletConfigRoleName = fmt.Sprintf("kubeadm:kubelet-config-%d.%d", k8sVersion.Major(), k8sVersion.Minor())
+		kubeletConfigConfigMapName = "kubelet-config"
+		kubeletConfigRoleName = "kubeadm:kubelet-config"
+		// TODO: remove this after the UnversionedKubeletConfigMap feature gate goes GA:
+		// https://github.com/kubernetes/kubeadm/issues/1582
+		if !UnversionedKubeletConfigMap {
+			kubeletConfigConfigMapName = fmt.Sprintf("kubelet-config-%d.%d", k8sVersion.Major(), k8sVersion.Minor())
+			kubeletConfigRoleName = fmt.Sprintf("kubeadm:kubelet-config-%d.%d", k8sVersion.Major(), k8sVersion.Minor())
+		}
 		kubeletConfigRoleBindingName = kubeletConfigRoleName
 		kubeletConfigConfigMapResource.Name = kubeletConfigConfigMapName
 	})


### PR DESCRIPTION
#### What this PR does / why we need it:

introduce a new kubeadm specific FG called UnversionedKubeletConfigMap.
this feature controls the old vs new formatting of the kubelet config map used for storing the KubeletConfiguration.

also:
- adapt unit tests and e2e tests
- remove unused function DownloadConfig in kubelet.go

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
xref https://github.com/kubernetes/kubeadm/issues/1582

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
kubeadm: add the kubeadm specific, Alpha (disabled by default) feature gate UnversionedKubeletConfigMap. When this feature is enabled kubeadm will start using a new naming format for the ConfigMap where it stores the KubeletConfiguration structure. The old format included the Kubernetes version - "kube-system/kubelet-config-1.22", while the new format does not - "kube-system/kubelet-config". A similar formatting change is done for the related RBAC rules. The old format is now DEPRECATED and will be removed after the feature graduates to GA. When writing the ConfigMap kubeadm (init, upgrade apply) will respect the value of UnversionedKubeletConfigMap, while when reading it (join, reset, upgrade), it would attempt to use new format first and fallback to the legacy format if needed.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- [KEP]: https://github.com/kubernetes/enhancements/tree/master/keps/sig-cluster-lifecycle/kubeadm/2915-kubeadm-replace-kubelet-config-x.y
- [Enhancement tracking issue]: https://github.com/kubernetes/enhancements/issues/2915
```
