### PR TITLE
Get Windows network stats directly for Containerd

### DIFF
--- a/pkg/kubelet/stats/cri_stats_provider.go
+++ b/pkg/kubelet/stats/cri_stats_provider.go
@@ -38,6 +38,7 @@ import (
 	"k8s.io/kubernetes/pkg/kubelet/cadvisor"
 	"k8s.io/kubernetes/pkg/kubelet/server/stats"
 	kubetypes "k8s.io/kubernetes/pkg/kubelet/types"
+	"k8s.io/utils/clock"
 )
 
 var (
@@ -67,7 +68,11 @@ type criStatsProvider struct {
 	imageService internalapi.ImageManagerService
 	// hostStatsProvider is used to get the status of the host filesystem consumed by pods.
 	hostStatsProvider HostStatsProvider
-	hcsshimInterface  interface{}
+	//lint:ignore U1000 We can't import hcsshim due to Build constraints in hcsshim
+	// windowsNetworkStatsProvider is used by kubelet to gather networking stats on Windows
+	windowsNetworkStatsProvider interface{}
+	// clock is used report current time
+	clock clock.Clock
 
 	// cpuUsageCache caches the cpu usage for containers.
 	cpuUsageCache                  map[string]*cpuUsageRecord
@@ -96,6 +101,7 @@ func newCRIStatsProvider(
 		cpuUsageCache:                  make(map[string]*cpuUsageRecord),
 		disableAcceleratorUsageMetrics: disableAcceleratorUsageMetrics,
 		podAndContainerStatsFromCRI:    podAndContainerStatsFromCRI,
+		clock:                          clock.RealClock{},
 	}
 }
 

--- a/pkg/kubelet/stats/cri_stats_provider.go
+++ b/pkg/kubelet/stats/cri_stats_provider.go
@@ -67,6 +67,7 @@ type criStatsProvider struct {
 	imageService internalapi.ImageManagerService
 	// hostStatsProvider is used to get the status of the host filesystem consumed by pods.
 	hostStatsProvider HostStatsProvider
+	hcsshimInterface  interface{}
 
 	// cpuUsageCache caches the cpu usage for containers.
 	cpuUsageCache                  map[string]*cpuUsageRecord

--- a/pkg/kubelet/stats/cri_stats_provider_windows.go
+++ b/pkg/kubelet/stats/cri_stats_provider_windows.go
@@ -20,135 +20,98 @@ limitations under the License.
 package stats
 
 import (
-	"fmt"
 	"time"
 
-	"github.com/Microsoft/hcsshim"
-
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/klog/v2"
+
+	"github.com/Microsoft/hcsshim"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	statsapi "k8s.io/kubelet/pkg/apis/stats/v1alpha1"
 )
 
-type hcsShimInterface interface {
-	GetContainers(q hcsshim.ComputeSystemQuery) ([]hcsshim.ContainerProperties, error)
-	GetHNSEndpointByID(endpointID string) (*hcsshim.HNSEndpoint, error)
-	OpenContainer(id string) (hcsshim.Container, error)
+// windowsNetworkStatsProvider creates an interface that allows for testing the logic without needing to create a container
+type windowsNetworkStatsProvider interface {
+	HNSListEndpointRequest() ([]hcsshim.HNSEndpoint, error)
+	GetHNSEndpointStats(endpointName string) (*hcsshim.HNSEndpointStats, error)
 }
 
-type windowshim struct{}
+// networkStats exposes the required functionality for hcsshim in this scenario
+type networkStats struct{}
 
-func (s windowshim) GetContainers(q hcsshim.ComputeSystemQuery) ([]hcsshim.ContainerProperties, error) {
-	return hcsshim.GetContainers(q)
+func (s networkStats) HNSListEndpointRequest() ([]hcsshim.HNSEndpoint, error) {
+	return hcsshim.HNSListEndpointRequest()
 }
 
-func (s windowshim) GetHNSEndpointByID(endpointID string) (*hcsshim.HNSEndpoint, error) {
-	return hcsshim.GetHNSEndpointByID(endpointID)
-}
-
-func (s windowshim) OpenContainer(id string) (hcsshim.Container, error) {
-	return hcsshim.OpenContainer(id)
+func (s networkStats) GetHNSEndpointStats(endpointName string) (*hcsshim.HNSEndpointStats, error) {
+	return hcsshim.GetHNSEndpointStats(endpointName)
 }
 
 // listContainerNetworkStats returns the network stats of all the running containers.
 func (p *criStatsProvider) listContainerNetworkStats() (map[string]*statsapi.NetworkStats, error) {
-	shim := newHcsShim(p)
-	containers, err := shim.GetContainers(hcsshim.ComputeSystemQuery{
-		Types: []string{"Container"},
-	})
+	networkStatsProvider := newNetworkStatsProvider(p)
+
+	endpoints, err := networkStatsProvider.HNSListEndpointRequest()
 	if err != nil {
+		klog.ErrorS(err, "Failed to fetch current HNS endpoints")
 		return nil, err
 	}
 
-	stats := make(map[string]*statsapi.NetworkStats)
-	for _, c := range containers {
-		cstats, err := fetchContainerStats(shim, c)
+	networkStats := make(map[string]*statsapi.NetworkStats)
+	for _, endpoint := range endpoints {
+		endpointStats, err := networkStatsProvider.GetHNSEndpointStats(endpoint.Id)
 		if err != nil {
-			klog.V(4).InfoS("Failed to fetch statistics for container, continue to get stats for other containers", "containerID", c.ID, "err", err)
+			klog.V(2).InfoS("Failed to fetch statistics for endpoint, continue to get stats for other endpoints", "endpointId", endpoint.Id, "containers", endpoint.SharedContainers)
 			continue
 		}
-		if len(cstats.Network) > 0 {
-			stats[c.ID] = hcsStatsToNetworkStats(shim, cstats.Timestamp, cstats.Network)
-		}
-	}
 
-	return stats, nil
-}
-
-func newHcsShim(p *criStatsProvider) hcsShimInterface {
-	var shim hcsShimInterface
-	if p.hcsshimInterface == nil {
-		shim = windowshim{}
-	} else {
-		shim = p.hcsshimInterface.(hcsShimInterface)
-	}
-	return shim
-}
-
-func fetchContainerStats(hcsshimInterface hcsShimInterface, c hcsshim.ContainerProperties) (stats hcsshim.Statistics, err error) {
-	var (
-		container hcsshim.Container
-	)
-	container, err = hcsshimInterface.OpenContainer(c.ID)
-	if err != nil {
-		return
-	}
-	defer func() {
-		if closeErr := container.Close(); closeErr != nil {
-			if err != nil {
-				err = fmt.Errorf("failed to close container after error %v; close error: %v", err, closeErr)
-			} else {
-				err = closeErr
+		// only add the interface for each container if not already in the list
+		for _, cId := range endpoint.SharedContainers {
+			networkStat, found := networkStats[cId]
+			if found && networkStat.Name != endpoint.Name {
+				iStat := hcsStatToInterfaceStat(endpointStats, endpoint.Name)
+				networkStat.Interfaces = append(networkStat.Interfaces, iStat)
+				continue
 			}
+			networkStats[cId] = hcsStatsToNetworkStats(p.clock.Now(), endpointStats, endpoint.Name)
 		}
-	}()
+	}
 
-	return container.Statistics()
+	return networkStats, nil
 }
 
 // hcsStatsToNetworkStats converts hcsshim.Statistics.Network to statsapi.NetworkStats
-func hcsStatsToNetworkStats(hcsshimInterface hcsShimInterface, timestamp time.Time, hcsStats []hcsshim.NetworkStats) *statsapi.NetworkStats {
+func hcsStatsToNetworkStats(timestamp time.Time, hcsStats *hcsshim.HNSEndpointStats, endpointName string) *statsapi.NetworkStats {
 	result := &statsapi.NetworkStats{
 		Time:       metav1.NewTime(timestamp),
 		Interfaces: make([]statsapi.InterfaceStats, 0),
 	}
 
-	adapters := sets.NewString()
-	for _, stat := range hcsStats {
-		iStat, err := hcsStatsToInterfaceStats(hcsshimInterface, stat)
-		if err != nil {
-			klog.InfoS("Failed to get HNS endpoint, continue to get stats for other endpoints", "endpointID", stat.EndpointId, "err", err)
-			continue
-		}
+	iStat := hcsStatToInterfaceStat(hcsStats, endpointName)
 
-		// Only count each adapter once.
-		if adapters.Has(iStat.Name) {
-			continue
-		}
-
-		result.Interfaces = append(result.Interfaces, *iStat)
-		adapters.Insert(iStat.Name)
-	}
-
-	// TODO(feiskyer): add support of multiple interfaces for getting default interface.
-	if len(result.Interfaces) > 0 {
-		result.InterfaceStats = result.Interfaces[0]
-	}
+	// TODO: add support of multiple interfaces for getting default interface.
+	result.Interfaces = append(result.Interfaces, iStat)
+	result.InterfaceStats = iStat
 
 	return result
 }
 
-// hcsStatsToInterfaceStats converts hcsshim.NetworkStats to statsapi.InterfaceStats.
-func hcsStatsToInterfaceStats(hcsshimInterface hcsShimInterface, stat hcsshim.NetworkStats) (*statsapi.InterfaceStats, error) {
-	endpoint, err := hcsshimInterface.GetHNSEndpointByID(stat.EndpointId)
-	if err != nil {
-		return nil, err
+func hcsStatToInterfaceStat(hcsStats *hcsshim.HNSEndpointStats, endpointName string) statsapi.InterfaceStats {
+	iStat := statsapi.InterfaceStats{
+		Name:    endpointName,
+		RxBytes: &hcsStats.BytesReceived,
+		TxBytes: &hcsStats.BytesSent,
 	}
+	return iStat
+}
 
-	return &statsapi.InterfaceStats{
-		Name:    endpoint.Name,
-		RxBytes: &stat.BytesReceived,
-		TxBytes: &stat.BytesSent,
-	}, nil
+// newNetworkStatsProvider uses the real windows hcsshim if not provided otherwise if the interface is provided
+// by the cristatsprovider in testing scenarios it uses that one
+func newNetworkStatsProvider(p *criStatsProvider) windowsNetworkStatsProvider {
+	var statsProvider windowsNetworkStatsProvider
+	if p.windowsNetworkStatsProvider == nil {
+		statsProvider = networkStats{}
+	} else {
+		statsProvider = p.windowsNetworkStatsProvider.(windowsNetworkStatsProvider)
+	}
+	return statsProvider
 }

--- a/pkg/kubelet/stats/cri_stats_provider_windows_test.go
+++ b/pkg/kubelet/stats/cri_stats_provider_windows_test.go
@@ -1,0 +1,453 @@
+package stats
+
+import (
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/Microsoft/hcsshim"
+
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	statsapi "k8s.io/kubelet/pkg/apis/stats/v1alpha1"
+)
+
+
+
+type fakeConatiner struct {
+	stat hcsshim.Statistics
+}
+
+func (f fakeConatiner) Start() error {
+	return nil
+}
+
+func (f fakeConatiner) Shutdown() error {
+	return nil
+}
+
+func (f fakeConatiner) Terminate() error {
+	return nil
+}
+
+func (f fakeConatiner) Wait() error {
+	return nil
+}
+
+func (f fakeConatiner) WaitTimeout(duration time.Duration) error {
+	return nil
+}
+
+func (f fakeConatiner) Pause() error {
+	return nil
+}
+
+func (f fakeConatiner) Resume() error {
+	return nil
+}
+
+func (f fakeConatiner) HasPendingUpdates() (bool, error) {
+	return false, nil
+}
+
+func (f fakeConatiner) Statistics() (hcsshim.Statistics, error) {
+	return f.stat, nil
+}
+
+func (f fakeConatiner) ProcessList() ([]hcsshim.ProcessListItem, error) {
+	return []hcsshim.ProcessListItem{}, nil
+}
+
+func (f fakeConatiner) MappedVirtualDisks() (map[int]hcsshim.MappedVirtualDiskController, error) {
+	return map[int]hcsshim.MappedVirtualDiskController{}, nil
+}
+
+func (f fakeConatiner) CreateProcess(c *hcsshim.ProcessConfig) (hcsshim.Process, error) {
+	return nil, nil
+}
+
+func (f fakeConatiner) OpenProcess(pid int) (hcsshim.Process, error) {
+	return nil, nil
+}
+
+func (f fakeConatiner) Close() error {
+	return nil
+}
+
+func (f fakeConatiner) Modify(config *hcsshim.ResourceModificationRequestResponse) error {
+	return nil
+}
+
+func (s fakehcsshim) GetContainers(q hcsshim.ComputeSystemQuery) ([]hcsshim.ContainerProperties, error) {
+	cp := []hcsshim.ContainerProperties{}
+	for _, c := range s.containers  {
+		cp = append(cp, c.container)
+	}
+
+	return cp, nil
+}
+
+func (s fakehcsshim) GetHNSEndpointByID(endpointID string) (*hcsshim.HNSEndpoint, error) {
+	e := hcsshim.HNSEndpoint{
+		Name: endpointID,
+	}
+	return &e, nil
+}
+
+func (s fakehcsshim) OpenContainer(id string) (hcsshim.Container, error) {
+	fc := fakeConatiner{}
+	for _, c := range s.containers {
+		if c.container.ID == id {
+			for _, s := range c.hcsStats{
+				fc.stat.Network = append(fc.stat.Network, s)
+			}
+		}
+	}
+
+	return fc, nil
+}
+
+type fakehcsshim struct {
+	containers       []containerStats
+}
+
+type containerStats struct {
+	container       hcsshim.ContainerProperties
+	hcsStats         []hcsshim.NetworkStats
+}
+
+
+func Test_criStatsProvider_listContainerNetworkStats(t *testing.T) {
+	tests := []struct {
+		name    string
+		fields  fakehcsshim
+		want    map[string]*statsapi.NetworkStats
+		wantErr bool
+	}{
+		{
+			name: "basic example",
+			fields: fakehcsshim{
+				containers: []containerStats{
+					{
+						container: hcsshim.ContainerProperties{
+						ID: "c1",
+						}, hcsStats: []hcsshim.NetworkStats{
+					{
+						BytesReceived: 1,
+						BytesSent:     10,
+						EndpointId:    "test",
+						InstanceId:    "test",
+							},
+						},
+					},
+					{
+						container: hcsshim.ContainerProperties{
+						ID: "c2",
+						}, hcsStats: []hcsshim.NetworkStats{
+							{
+						BytesReceived: 2,
+						BytesSent:     20,
+						EndpointId:    "test2",
+						InstanceId:    "test2",
+					},
+				},
+					},
+				},
+			},
+			want: map[string]*statsapi.NetworkStats{
+				"c1": &statsapi.NetworkStats{
+					Time: v1.Time{},
+					InterfaceStats: statsapi.InterfaceStats{
+						Name:    "test",
+						RxBytes: toP(1),
+						TxBytes: toP(10),
+					},
+					Interfaces: []statsapi.InterfaceStats{
+						{
+							Name:    "test",
+							RxBytes: toP(1),
+
+							TxBytes: toP(10),
+						},
+					},
+				},
+				"c2": &statsapi.NetworkStats{
+					Time: v1.Time{},
+					InterfaceStats: statsapi.InterfaceStats{
+						Name:    "test2",
+						RxBytes: toP(2),
+						TxBytes: toP(20),
+					},
+					Interfaces: []statsapi.InterfaceStats{
+						{
+							Name:    "test2",
+							RxBytes: toP(2),
+							TxBytes: toP(20),
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "multiple containers same endpoint",
+			fields: fakehcsshim{
+				containers: []containerStats{
+					{
+						container: hcsshim.ContainerProperties{
+						ID: "c1",
+						}, hcsStats: []hcsshim.NetworkStats{
+					{
+						BytesReceived: 1,
+						BytesSent:     10,
+						EndpointId:    "test",
+						InstanceId:    "test",
+							},
+						},
+					},
+					{
+						container: hcsshim.ContainerProperties{
+						ID: "c2",
+						}, hcsStats: []hcsshim.NetworkStats{
+							{
+						BytesReceived: 2,
+						BytesSent:     20,
+						EndpointId:    "test2",
+						InstanceId:    "test2",
+							},
+						},
+					},
+					{
+						container: hcsshim.ContainerProperties{
+						ID: "c3",
+						}, hcsStats: []hcsshim.NetworkStats{
+							{
+						BytesReceived: 3,
+						BytesSent:     30,
+						EndpointId:    "test2",
+						InstanceId:    "test3",
+					},
+				},
+					},
+				},
+			},
+			want: map[string]*statsapi.NetworkStats{
+				"c1": &statsapi.NetworkStats{
+					Time: v1.Time{},
+					InterfaceStats: statsapi.InterfaceStats{
+						Name:    "test",
+						RxBytes: toP(1),
+						TxBytes: toP(10),
+					},
+					Interfaces: []statsapi.InterfaceStats{
+						{
+							Name:    "test",
+							RxBytes: toP(1),
+
+							TxBytes: toP(10),
+						},
+					},
+				},
+				"c2": &statsapi.NetworkStats{
+					Time: v1.Time{},
+					InterfaceStats: statsapi.InterfaceStats{
+						Name:    "test2",
+						RxBytes: toP(2),
+						TxBytes: toP(20),
+					},
+					Interfaces: []statsapi.InterfaceStats{
+						{
+							Name:    "test2",
+							RxBytes: toP(2),
+							TxBytes: toP(20),
+						},
+					},
+				},
+				"c3": &statsapi.NetworkStats{
+					Time: v1.Time{},
+					InterfaceStats: statsapi.InterfaceStats{
+						Name:    "test2",
+						RxBytes: toP(3),
+						TxBytes: toP(30),
+					},
+					Interfaces: []statsapi.InterfaceStats{
+						{
+							Name:    "test2",
+							RxBytes: toP(3),
+							TxBytes: toP(30),
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "multiple stats instances of same interface only picks up first",
+			fields: fakehcsshim{
+				containers: []containerStats{
+					{
+						container: hcsshim.ContainerProperties{
+							ID: "c1",
+						}, hcsStats: []hcsshim.NetworkStats{
+					{
+						BytesReceived: 1,
+						BytesSent:     10,
+						EndpointId:    "test",
+						InstanceId:    "test",
+					},
+					{
+								BytesReceived: 3,
+								BytesSent:     30,
+								EndpointId:    "test",
+								InstanceId:    "test3",
+							},
+						},
+					},
+					{
+						container: hcsshim.ContainerProperties{
+							ID: "c2",
+						}, hcsStats: []hcsshim.NetworkStats{
+							{
+						BytesReceived: 2,
+						BytesSent:     20,
+						EndpointId:    "test2",
+						InstanceId:    "test2",
+					},
+					},
+				},
+				},
+			},
+			want: map[string]*statsapi.NetworkStats{
+				"c1": &statsapi.NetworkStats{
+					Time: v1.Time{},
+					InterfaceStats: statsapi.InterfaceStats{
+						Name:    "test",
+						RxBytes: toP(1),
+						TxBytes: toP(10),
+					},
+					Interfaces: []statsapi.InterfaceStats{
+						{
+							Name:    "test",
+							RxBytes: toP(1),
+
+							TxBytes: toP(10),
+						},
+					},
+				},
+				"c2": &statsapi.NetworkStats{
+					Time: v1.Time{},
+					InterfaceStats: statsapi.InterfaceStats{
+						Name:    "test2",
+						RxBytes: toP(2),
+						TxBytes: toP(20),
+					},
+					Interfaces: []statsapi.InterfaceStats{
+						{
+							Name:    "test2",
+							RxBytes: toP(2),
+							TxBytes: toP(20),
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "multiple endpoints per container",
+			fields: fakehcsshim{
+				containers: []containerStats{
+					{
+						container: hcsshim.ContainerProperties{
+							ID: "c1",
+						}, hcsStats: []hcsshim.NetworkStats{
+					{
+						BytesReceived: 1,
+						BytesSent:     10,
+						EndpointId:    "test",
+						InstanceId:    "test",
+					},
+												{
+								BytesReceived: 3,
+								BytesSent:     30,
+								EndpointId:    "test3",
+								InstanceId:    "test3",
+							},
+						},
+					},
+					{
+						container: hcsshim.ContainerProperties{
+							ID: "c2",
+						}, hcsStats: []hcsshim.NetworkStats{
+					{
+						BytesReceived: 2,
+						BytesSent:     20,
+						EndpointId:    "test2",
+						InstanceId:    "test2",
+					},
+					},
+				},
+				},
+			},
+			want: map[string]*statsapi.NetworkStats{
+				"c1": &statsapi.NetworkStats{
+					Time: v1.Time{},
+					InterfaceStats: statsapi.InterfaceStats{
+						Name:    "test",
+						RxBytes: toP(1),
+						TxBytes: toP(10),
+					},
+					Interfaces: []statsapi.InterfaceStats{
+						{
+							Name:    "test",
+							RxBytes: toP(1),
+
+							TxBytes: toP(10),
+						},
+						{
+							Name:    "test3",
+							RxBytes: toP(3),
+
+							TxBytes: toP(30),
+						},
+					},
+				},
+				"c2": &statsapi.NetworkStats{
+					Time: v1.Time{},
+					InterfaceStats: statsapi.InterfaceStats{
+						Name:    "test2",
+						RxBytes: toP(2),
+						TxBytes: toP(20),
+					},
+					Interfaces: []statsapi.InterfaceStats{
+						{
+							Name:    "test2",
+							RxBytes: toP(2),
+							TxBytes: toP(20),
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := &criStatsProvider{
+				hcsshimInterface: fakehcsshim{
+					containers:       tt.fields.containers,
+				},
+			}
+			got, err := p.listContainerNetworkStats()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("listContainerNetworkStats() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("listContainerNetworkStats() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func toP(i uint64) *uint64 {
+	return &i
+}

--- a/test/e2e/windows/kubelet_stats.go
+++ b/test/e2e/windows/kubelet_stats.go
@@ -80,6 +80,11 @@ var _ = SIGDescribe("[Feature:Windows] Kubelet-Stats [Serial]", func() {
 						framework.ExpectEqual(*podStats.CPU.UsageCoreNanoSeconds > 0, true, "Pod stats should not report 0 cpu usage")
 						framework.ExpectEqual(*podStats.Memory.WorkingSetBytes > 0, true, "Pod stats should not report 0 bytes for memory working set ")
 
+						framework.ExpectEqual(podStats.Network != nil, true, "Pod stats should report network stats")
+						framework.ExpectEqual(podStats.Network.Name != "", true, "Pod stats should report network name")
+						framework.ExpectEqual(*podStats.Network.TxBytes > 0, true, "Pod stats should report network Tx stats")
+						framework.ExpectEqual(len(podStats.Network.Interfaces) > 0, true, "Pod Stats should report individual interfaces stats")
+
 						for _, containerStats := range podStats.Containers {
 							framework.ExpectEqual(containerStats.Logs != nil, true, "Pod stats should have container log stats")
 							framework.ExpectEqual(*containerStats.Logs.AvailableBytes > 0, true, "container log stats should not report 0 bytes for AvailableBytes")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
/kind cleanup

<!--
Add one of the following kinds:


/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

This ensures we have Network stats for containerd on Windows by querying for the stats were directly.  By going to network component directly we also minimize the calls the to listing containers (https://github.com/kubernetes/kubernetes/issues/104285)

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #104286 #104285

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Add support for Windows Network stats in Containerd
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
