### PR TITLE
Add --version flag to podsecurity-webhook command

### DIFF
--- a/staging/publishing/import-restrictions.yaml
+++ b/staging/publishing/import-restrictions.yaml
@@ -275,11 +275,7 @@
   - k8s.io/apiserver/pkg/admission
   - k8s.io/apiserver/pkg/server
   - k8s.io/client-go
+  - k8s.io/component-base
   - k8s.io/klog
   - k8s.io/pod-security-admission
-  - k8s.io/component-base/featuregate
-  - k8s.io/component-base/logs
-  - k8s.io/component-base/cli
-  - k8s.io/component-base/metrics
-  - k8s.io/component-base/version
   - k8s.io/utils

--- a/staging/src/k8s.io/pod-security-admission/cmd/webhook/server/server.go
+++ b/staging/src/k8s.io/pod-security-admission/cmd/webhook/server/server.go
@@ -25,6 +25,8 @@ import (
 	"io"
 	"io/ioutil"
 	"net/http"
+	"os"
+	"path/filepath"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -38,6 +40,7 @@ import (
 	clientset "k8s.io/client-go/kubernetes"
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/component-base/version/verflag"
 	"k8s.io/klog/v2"
 	"k8s.io/pod-security-admission/admission"
 	admissionapi "k8s.io/pod-security-admission/admission/api"
@@ -54,16 +57,22 @@ const maxRequestSize = int64(3 * 1024 * 1024)
 func NewServerCommand() *cobra.Command {
 	opts := options.NewOptions()
 
+	cmdName := "podsecurity-webhook"
+	if executable, err := os.Executable(); err == nil {
+		cmdName = filepath.Base(executable)
+	}
 	cmd := &cobra.Command{
-		Use: "podsecurity-webhook",
+		Use: cmdName,
 		Long: `The PodSecurity webhook is a standalone webhook server implementing the Pod
 Security Standards.`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
+			verflag.PrintAndExitIfRequested()
 			return runServer(cmd.Context(), opts)
 		},
 		Args: cobra.NoArgs,
 	}
 	opts.AddFlags(cmd.Flags())
+	verflag.AddFlags(cmd.Flags())
 
 	return cmd
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Add the `--version` flag to the webhook command. This will be important with the inclusion of version information in the metrics (https://github.com/kubernetes/kubernetes/pull/104217) to ensure we're properly including the version the webhook binary, and also be useful to users of the binary to know what version they have.

```release-note
NONE
```

/sig auth