### PR TITLE
Automated cherry pick of #105712: sched: ensure --leader-elect* CLI args are honored

### DIFF
--- a/cmd/kube-scheduler/app/options/options.go
+++ b/cmd/kube-scheduler/app/options/options.go
@@ -67,12 +67,21 @@ type Options struct {
 	WriteConfigTo string
 
 	Master string
+
+	// flags hold the parsed CLI flags.
+	flags *cliflag.NamedFlagSets
 }
 
 // NewOptions returns default scheduler app options.
 func NewOptions() (*Options, error) {
+	cfg, err := latest.Default()
+	if err != nil {
+		return nil, err
+	}
+
 	o := &Options{
-		SecureServing: apiserveroptions.NewSecureServingOptions().WithLoopback(),
+		ComponentConfig: *cfg,
+		SecureServing:   apiserveroptions.NewSecureServingOptions().WithLoopback(),
 		CombinedInsecureServing: &CombinedInsecureServingOptions{
 			Healthz: (&apiserveroptions.DeprecatedInsecureServingOptions{
 				BindNetwork: "tcp",
@@ -102,55 +111,26 @@ func NewOptions() (*Options, error) {
 	return o, nil
 }
 
-// Complete completes the remaining instantiation of the options obj.
-// In particular, it injects the latest internal versioned ComponentConfig.
-func (o *Options) Complete(nfs *cliflag.NamedFlagSets) error {
-	cfg, err := latest.Default()
-	if err != nil {
-		return err
-	}
-
+// Complete obtains the CLI args related with insecure serving and leader election,
+// and override the values in `cfg`.
+// Then the `cfg` object is injected into the `options` object.
+func (o *Options) Complete(cfg *kubeschedulerconfig.KubeSchedulerConfiguration) error {
 	hhost, hport, err := splitHostIntPort(cfg.HealthzBindAddress)
 	if err != nil {
 		return err
 	}
 	// Obtain CLI args related with insecure serving.
 	// If not specified in command line, derive the default settings from cfg.
-	insecureServing := nfs.FlagSet("insecure serving")
+	insecureServing := o.Flags().FlagSet("insecure serving")
 	if !insecureServing.Changed("address") {
 		o.CombinedInsecureServing.BindAddress = hhost
 	}
 	if !insecureServing.Changed("port") {
 		o.CombinedInsecureServing.BindPort = hport
 	}
-	// Obtain deprecated CLI args. Set them to cfg if specified in command line.
-	deprecated := nfs.FlagSet("deprecated")
-	if deprecated.Changed("profiling") {
-		cfg.EnableProfiling = o.ComponentConfig.EnableProfiling
-	}
-	if deprecated.Changed("contention-profiling") {
-		cfg.EnableContentionProfiling = o.ComponentConfig.EnableContentionProfiling
-	}
-	if deprecated.Changed("kubeconfig") {
-		cfg.ClientConnection.Kubeconfig = o.ComponentConfig.ClientConnection.Kubeconfig
-	}
-	if deprecated.Changed("kube-api-content-type") {
-		cfg.ClientConnection.ContentType = o.ComponentConfig.ClientConnection.ContentType
-	}
-	if deprecated.Changed("kube-api-qps") {
-		cfg.ClientConnection.QPS = o.ComponentConfig.ClientConnection.QPS
-	}
-	if deprecated.Changed("kube-api-burst") {
-		cfg.ClientConnection.Burst = o.ComponentConfig.ClientConnection.Burst
-	}
-	if deprecated.Changed("lock-object-namespace") {
-		cfg.LeaderElection.ResourceNamespace = o.ComponentConfig.LeaderElection.ResourceNamespace
-	}
-	if deprecated.Changed("lock-object-name") {
-		cfg.LeaderElection.ResourceName = o.ComponentConfig.LeaderElection.ResourceName
-	}
-	// Obtain CLI args related with leaderelection. Set them to cfg if specified in command line.
-	leaderelection := nfs.FlagSet("leader election")
+
+	// Obtain CLI args related with leaderelection. Set them to `cfg` if specified in command line.
+	leaderelection := o.Flags().FlagSet("leader election")
 	if leaderelection.Changed("leader-elect") {
 		cfg.LeaderElection.LeaderElect = o.ComponentConfig.LeaderElection.LeaderElect
 	}
@@ -190,7 +170,12 @@ func splitHostIntPort(s string) (string, int, error) {
 }
 
 // Flags returns flags for a specific scheduler by section name
-func (o *Options) Flags() (nfs cliflag.NamedFlagSets) {
+func (o *Options) Flags() *cliflag.NamedFlagSets {
+	if o.flags != nil {
+		return o.flags
+	}
+
+	nfs := cliflag.NamedFlagSets{}
 	fs := nfs.FlagSet("misc")
 	fs.StringVar(&o.ConfigFile, "config", o.ConfigFile, `The path to the configuration file. The following flags can overwrite fields in this file:
   --policy-config-file
@@ -199,7 +184,10 @@ func (o *Options) Flags() (nfs cliflag.NamedFlagSets) {
 	fs.StringVar(&o.WriteConfigTo, "write-config-to", o.WriteConfigTo, "If set, write the configuration values to this file and exit.")
 	fs.StringVar(&o.Master, "master", o.Master, "The address of the Kubernetes API server (overrides any value in kubeconfig)")
 
-	o.SecureServing.AddFlags(nfs.FlagSet("secure serving"))
+	// In some tests, o.SecureServing can be nil.
+	if o.SecureServing != nil {
+		o.SecureServing.AddFlags(nfs.FlagSet("secure serving"))
+	}
 	o.CombinedInsecureServing.AddFlags(nfs.FlagSet("insecure serving"))
 	o.Authentication.AddFlags(nfs.FlagSet("authentication"))
 	o.Authorization.AddFlags(nfs.FlagSet("authorization"))
@@ -210,7 +198,8 @@ func (o *Options) Flags() (nfs cliflag.NamedFlagSets) {
 	o.Metrics.AddFlags(nfs.FlagSet("metrics"))
 	o.Logs.AddFlags(nfs.FlagSet("logs"))
 
-	return nfs
+	o.flags = &nfs
+	return o.flags
 }
 
 // ApplyTo applies the scheduler options to the given scheduler app configuration.
@@ -228,6 +217,11 @@ func (o *Options) ApplyTo(c *schedulerappconfig.Config) error {
 		if err != nil {
 			return err
 		}
+		// Honor the CLI args before assigning `cfg` to `c.ComponentConfig`.
+		if err := o.Complete(cfg); err != nil {
+			return err
+		}
+
 		if err := validation.ValidateKubeSchedulerConfiguration(cfg); err != nil {
 			return err
 		}

--- a/cmd/kube-scheduler/app/server.go
+++ b/cmd/kube-scheduler/app/server.go
@@ -68,7 +68,6 @@ func NewSchedulerCommand(registryOptions ...Option) *cobra.Command {
 		klog.Fatalf("unable to initialize command options: %v", err)
 	}
 
-	namedFlagSets := opts.Flags()
 	cmd := &cobra.Command{
 		Use: "kube-scheduler",
 		Long: `The Kubernetes scheduler is a control plane process which assigns
@@ -80,10 +79,6 @@ kube-scheduler is the reference implementation.
 See [scheduling](https://kubernetes.io/docs/concepts/scheduling-eviction/)
 for more information about scheduling and the kube-scheduler component.`,
 		Run: func(cmd *cobra.Command, args []string) {
-			if err := opts.Complete(&namedFlagSets); err != nil {
-				fmt.Fprintf(os.Stderr, "%v\n", err)
-				os.Exit(1)
-			}
 			if err := runCommand(cmd, opts, registryOptions...); err != nil {
 				fmt.Fprintf(os.Stderr, "%v\n", err)
 				os.Exit(1)
@@ -99,6 +94,7 @@ for more information about scheduling and the kube-scheduler component.`,
 		},
 	}
 	fs := cmd.Flags()
+	namedFlagSets := opts.Flags()
 	verflag.AddFlags(namedFlagSets.FlagSet("global"))
 	globalflag.AddGlobalFlags(namedFlagSets.FlagSet("global"), cmd.Name())
 	for _, f := range namedFlagSets.FlagSets {
@@ -106,7 +102,7 @@ for more information about scheduling and the kube-scheduler component.`,
 	}
 
 	cols, _, _ := term.TerminalSize(cmd.OutOrStdout())
-	cliflag.SetUsageAndHelpFunc(cmd, namedFlagSets, cols)
+	cliflag.SetUsageAndHelpFunc(cmd, *namedFlagSets, cols)
 
 	cmd.MarkFlagFilename("config", "yaml", "yml", "json")
 

--- a/cmd/kube-scheduler/app/server_test.go
+++ b/cmd/kube-scheduler/app/server_test.go
@@ -26,9 +26,13 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/spf13/pflag"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	componentbaseconfig "k8s.io/component-base/config"
+	"k8s.io/kube-scheduler/config/v1beta2"
 	"k8s.io/kubernetes/cmd/kube-scheduler/app/options"
 	"k8s.io/kubernetes/pkg/scheduler/apis/config"
 	"k8s.io/kubernetes/pkg/scheduler/apis/config/testing/defaults"
@@ -152,10 +156,35 @@ profiles:
 		t.Fatal(err)
 	}
 
+	// empty leader-election config
+	emptyLeaderElectionConfig := filepath.Join(tmpDir, "empty-leader-election-config.yaml")
+	if err := ioutil.WriteFile(emptyLeaderElectionConfig, []byte(fmt.Sprintf(`
+apiVersion: kubescheduler.config.k8s.io/v1beta2
+kind: KubeSchedulerConfiguration
+clientConnection:
+  kubeconfig: "%s"
+`, configKubeconfig)), os.FileMode(0600)); err != nil {
+		t.Fatal(err)
+	}
+
+	// leader-election config
+	leaderElectionConfig := filepath.Join(tmpDir, "leader-election-config.yaml")
+	if err := ioutil.WriteFile(leaderElectionConfig, []byte(fmt.Sprintf(`
+apiVersion: kubescheduler.config.k8s.io/v1beta2
+kind: KubeSchedulerConfiguration
+clientConnection:
+  kubeconfig: "%s"
+leaderElection:
+  leaseDuration: 1h
+`, configKubeconfig)), os.FileMode(0600)); err != nil {
+		t.Fatal(err)
+	}
+
 	testcases := []struct {
-		name        string
-		flags       []string
-		wantPlugins map[string]*config.Plugins
+		name               string
+		flags              []string
+		wantPlugins        map[string]*config.Plugins
+		wantLeaderElection *componentbaseconfig.LeaderElectionConfiguration
 	}{
 		{
 			name: "default config",
@@ -230,6 +259,75 @@ profiles:
 				},
 			},
 		},
+		{
+			name: "leader election CLI args, along with --config arg",
+			flags: []string{
+				"--leader-elect=false",
+				"--leader-elect-lease-duration=2h", // CLI args are favored over the fields in ComponentConfig
+				"--lock-object-namespace=default",  // deprecated CLI arg will be ignored if --config is specified
+				"--config", emptyLeaderElectionConfig,
+			},
+			wantLeaderElection: &componentbaseconfig.LeaderElectionConfiguration{
+				LeaderElect:       false,                                    // from CLI args
+				LeaseDuration:     metav1.Duration{Duration: 2 * time.Hour}, // from CLI args
+				RenewDeadline:     metav1.Duration{Duration: 10 * time.Second},
+				RetryPeriod:       metav1.Duration{Duration: 2 * time.Second},
+				ResourceLock:      "leases",
+				ResourceName:      v1beta2.SchedulerDefaultLockObjectName,
+				ResourceNamespace: v1beta2.SchedulerDefaultLockObjectNamespace,
+			},
+		},
+		{
+			name: "leader election CLI args, without --config arg",
+			flags: []string{
+				"--leader-elect=false",
+				"--leader-elect-lease-duration=2h",
+				"--lock-object-namespace=default", // deprecated CLI arg is honored if --config is not specified
+				"--kubeconfig", configKubeconfig,
+			},
+			wantLeaderElection: &componentbaseconfig.LeaderElectionConfiguration{
+				LeaderElect:       false,                                    // from CLI args
+				LeaseDuration:     metav1.Duration{Duration: 2 * time.Hour}, // from CLI args
+				RenewDeadline:     metav1.Duration{Duration: 10 * time.Second},
+				RetryPeriod:       metav1.Duration{Duration: 2 * time.Second},
+				ResourceLock:      "leases",
+				ResourceName:      v1beta2.SchedulerDefaultLockObjectName,
+				ResourceNamespace: "default", // from deprecated CLI args
+			},
+		},
+		{
+			name: "leader election settings specified by ComponentConfig only",
+			flags: []string{
+				"--config", leaderElectionConfig,
+			},
+			wantLeaderElection: &componentbaseconfig.LeaderElectionConfiguration{
+				LeaderElect:       true,
+				LeaseDuration:     metav1.Duration{Duration: 1 * time.Hour}, // from CC
+				RenewDeadline:     metav1.Duration{Duration: 10 * time.Second},
+				RetryPeriod:       metav1.Duration{Duration: 2 * time.Second},
+				ResourceLock:      "leases",
+				ResourceName:      v1beta2.SchedulerDefaultLockObjectName,
+				ResourceNamespace: v1beta2.SchedulerDefaultLockObjectNamespace,
+			},
+		},
+		{
+			name: "leader election settings specified by CLI args and ComponentConfig",
+			flags: []string{
+				"--leader-elect=true",
+				"--leader-elect-renew-deadline=5s",
+				"--leader-elect-retry-period=1s",
+				"--config", leaderElectionConfig,
+			},
+			wantLeaderElection: &componentbaseconfig.LeaderElectionConfiguration{
+				LeaderElect:       true,
+				LeaseDuration:     metav1.Duration{Duration: 1 * time.Hour},   // from CC
+				RenewDeadline:     metav1.Duration{Duration: 5 * time.Second}, // from CLI args
+				RetryPeriod:       metav1.Duration{Duration: 1 * time.Second}, // from CLI args
+				ResourceLock:      "leases",
+				ResourceName:      v1beta2.SchedulerDefaultLockObjectName,
+				ResourceNamespace: v1beta2.SchedulerDefaultLockObjectNamespace,
+			},
+		},
 	}
 
 	makeListener := func(t *testing.T) net.Listener {
@@ -248,6 +346,13 @@ profiles:
 			if err != nil {
 				t.Fatal(err)
 			}
+			// use listeners instead of static ports so parallel test runs don't conflict
+			opts.SecureServing.Listener = makeListener(t)
+			defer opts.SecureServing.Listener.Close()
+			opts.CombinedInsecureServing.Metrics.Listener = makeListener(t)
+			defer opts.CombinedInsecureServing.Metrics.Listener.Close()
+			opts.CombinedInsecureServing.Healthz.Listener = makeListener(t)
+			defer opts.CombinedInsecureServing.Healthz.Listener.Close()
 
 			nfs := opts.Flags()
 			for _, f := range nfs.FlagSets {
@@ -257,18 +362,6 @@ profiles:
 				t.Fatal(err)
 			}
 
-			if err := opts.Complete(&nfs); err != nil {
-				t.Fatal(err)
-			}
-
-			// use listeners instead of static ports so parallel test runs don't conflict
-			opts.SecureServing.Listener = makeListener(t)
-			defer opts.SecureServing.Listener.Close()
-			opts.CombinedInsecureServing.Metrics.Listener = makeListener(t)
-			defer opts.CombinedInsecureServing.Metrics.Listener.Close()
-			opts.CombinedInsecureServing.Healthz.Listener = makeListener(t)
-			defer opts.CombinedInsecureServing.Healthz.Listener.Close()
-
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
 			_, sched, err := Setup(ctx, opts)
@@ -276,13 +369,22 @@ profiles:
 				t.Fatal(err)
 			}
 
-			gotPlugins := make(map[string]*config.Plugins)
-			for n, p := range sched.Profiles {
-				gotPlugins[n] = p.ListPlugins()
+			if tc.wantPlugins != nil {
+				gotPlugins := make(map[string]*config.Plugins)
+				for n, p := range sched.Profiles {
+					gotPlugins[n] = p.ListPlugins()
+				}
+
+				if diff := cmp.Diff(tc.wantPlugins, gotPlugins); diff != "" {
+					t.Errorf("Unexpected plugins diff (-want, +got): %s", diff)
+				}
 			}
 
-			if diff := cmp.Diff(tc.wantPlugins, gotPlugins); diff != "" {
-				t.Errorf("unexpected plugins diff (-want, +got): %s", diff)
+			if tc.wantLeaderElection != nil {
+				gotLeaderElection := opts.ComponentConfig.LeaderElection
+				if diff := cmp.Diff(*tc.wantLeaderElection, gotLeaderElection); diff != "" {
+					t.Errorf("Unexpected leaderElection diff (-want, +got): %s", diff)
+				}
 			}
 		})
 	}

--- a/cmd/kube-scheduler/app/testing/testserver.go
+++ b/cmd/kube-scheduler/app/testing/testserver.go
@@ -93,10 +93,6 @@ func StartTestServer(t Logger, customFlags []string) (result TestServer, err err
 	}
 	fs.Parse(customFlags)
 
-	if err := opts.Complete(&namedFlagSets); err != nil {
-		return TestServer{}, err
-	}
-
 	if opts.SecureServing.BindPort != 0 {
 		opts.SecureServing.Listener, opts.SecureServing.BindPort, err = createListenerOnFreePort()
 		if err != nil {


### PR DESCRIPTION
Cherry pick of #105712 on release-1.22.

#105712: sched: ensure --leader-elect* CLI args are honored

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
The --leader-elect* CLI args are now honored in scheduler.
```