### PR TITLE
Automated cherry pick of #105065: parameter 'disabled-metrics' is invalid

### DIFF
--- a/staging/src/k8s.io/component-base/metrics/options.go
+++ b/staging/src/k8s.io/component-base/metrics/options.go
@@ -58,8 +58,8 @@ func (o *Options) Validate() []error {
 
 // AddFlags adds flags for exposing component metrics.
 func (o *Options) AddFlags(fs *pflag.FlagSet) {
-	if o != nil {
-		o = NewOptions()
+	if o == nil {
+		return
 	}
 	fs.StringVar(&o.ShowHiddenMetricsForVersion, "show-hidden-metrics-for-version", o.ShowHiddenMetricsForVersion,
 		"The previous version for which you want to show hidden metrics. "+


### PR DESCRIPTION
Cherry pick of #105065 on release-1.22.

#105065: parameter 'disabled-metrics' is invalid

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
Fix a bug that `--disabled-metrics` doesn't function well.
```