### PR TITLE
--as-uid flag in kubectl and kubeconfigs.

### DIFF
--- a/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/config_flags.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/config_flags.go
@@ -48,6 +48,7 @@ const (
 	flagCAFile           = "certificate-authority"
 	flagBearerToken      = "token"
 	flagImpersonate      = "as"
+	flagImpersonateUID   = "as-uid"
 	flagImpersonateGroup = "as-group"
 	flagUsername         = "username"
 	flagPassword         = "password"
@@ -94,6 +95,7 @@ type ConfigFlags struct {
 	CAFile           *string
 	BearerToken      *string
 	Impersonate      *string
+	ImpersonateUID   *string
 	ImpersonateGroup *[]string
 	Username         *string
 	Password         *string
@@ -170,6 +172,9 @@ func (f *ConfigFlags) toRawKubeConfigLoader() clientcmd.ClientConfig {
 	}
 	if f.Impersonate != nil {
 		overrides.AuthInfo.Impersonate = *f.Impersonate
+	}
+	if f.ImpersonateUID != nil {
+		overrides.AuthInfo.ImpersonateUID = *f.ImpersonateUID
 	}
 	if f.ImpersonateGroup != nil {
 		overrides.AuthInfo.ImpersonateGroups = *f.ImpersonateGroup
@@ -336,6 +341,9 @@ func (f *ConfigFlags) AddFlags(flags *pflag.FlagSet) {
 	if f.Impersonate != nil {
 		flags.StringVar(f.Impersonate, flagImpersonate, *f.Impersonate, "Username to impersonate for the operation. User could be a regular user or a service account in a namespace.")
 	}
+	if f.ImpersonateUID != nil {
+		flags.StringVar(f.ImpersonateUID, flagImpersonateUID, *f.ImpersonateUID, "UID to impersonate for the operation.")
+	}
 	if f.ImpersonateGroup != nil {
 		flags.StringArrayVar(f.ImpersonateGroup, flagImpersonateGroup, *f.ImpersonateGroup, "Group to impersonate for the operation, this flag can be repeated to specify multiple groups.")
 	}
@@ -410,6 +418,7 @@ func NewConfigFlags(usePersistentConfig bool) *ConfigFlags {
 		CAFile:           stringptr(""),
 		BearerToken:      stringptr(""),
 		Impersonate:      stringptr(""),
+		ImpersonateUID:   stringptr(""),
 		ImpersonateGroup: &impersonateGroup,
 
 		usePersistentConfig: usePersistentConfig,

--- a/staging/src/k8s.io/client-go/tools/clientcmd/api/types.go
+++ b/staging/src/k8s.io/client-go/tools/clientcmd/api/types.go
@@ -124,7 +124,10 @@ type AuthInfo struct {
 	// Impersonate is the username to act-as.
 	// +optional
 	Impersonate string `json:"act-as,omitempty"`
-	// ImpersonateGroups is the groups to imperonate.
+	// ImpersonateUID is the uid to impersonate.
+	// +optional
+	ImpersonateUID string `json:"act-as-uid,omitempty"`
+	// ImpersonateGroups is the groups to impersonate.
 	// +optional
 	ImpersonateGroups []string `json:"act-as-groups,omitempty"`
 	// ImpersonateUserExtra contains additional information for impersonated user.

--- a/staging/src/k8s.io/client-go/tools/clientcmd/api/v1/types.go
+++ b/staging/src/k8s.io/client-go/tools/clientcmd/api/v1/types.go
@@ -111,10 +111,13 @@ type AuthInfo struct {
 	// TokenFile is a pointer to a file that contains a bearer token (as described above).  If both Token and TokenFile are present, Token takes precedence.
 	// +optional
 	TokenFile string `json:"tokenFile,omitempty"`
-	// Impersonate is the username to imperonate.  The name matches the flag.
+	// Impersonate is the username to impersonate.  The name matches the flag.
 	// +optional
 	Impersonate string `json:"as,omitempty"`
-	// ImpersonateGroups is the groups to imperonate.
+	// ImpersonateUID is the uid to impersonate.
+	// +optional
+	ImpersonateUID string `json:"as-uid,omitempty"`
+	// ImpersonateGroups is the groups to impersonate.
 	// +optional
 	ImpersonateGroups []string `json:"as-groups,omitempty"`
 	// ImpersonateUserExtra contains additional information for impersonated user.

--- a/staging/src/k8s.io/client-go/tools/clientcmd/api/v1/zz_generated.conversion.go
+++ b/staging/src/k8s.io/client-go/tools/clientcmd/api/v1/zz_generated.conversion.go
@@ -167,6 +167,7 @@ func autoConvert_v1_AuthInfo_To_api_AuthInfo(in *AuthInfo, out *api.AuthInfo, s 
 	out.Token = in.Token
 	out.TokenFile = in.TokenFile
 	out.Impersonate = in.Impersonate
+	out.ImpersonateUID = in.ImpersonateUID
 	out.ImpersonateGroups = *(*[]string)(unsafe.Pointer(&in.ImpersonateGroups))
 	out.ImpersonateUserExtra = *(*map[string][]string)(unsafe.Pointer(&in.ImpersonateUserExtra))
 	out.Username = in.Username
@@ -201,6 +202,7 @@ func autoConvert_api_AuthInfo_To_v1_AuthInfo(in *api.AuthInfo, out *AuthInfo, s 
 	out.Token = in.Token
 	out.TokenFile = in.TokenFile
 	out.Impersonate = in.Impersonate
+	out.ImpersonateUID = in.ImpersonateUID
 	out.ImpersonateGroups = *(*[]string)(unsafe.Pointer(&in.ImpersonateGroups))
 	out.ImpersonateUserExtra = *(*map[string][]string)(unsafe.Pointer(&in.ImpersonateUserExtra))
 	out.Username = in.Username

--- a/staging/src/k8s.io/client-go/tools/clientcmd/client_config.go
+++ b/staging/src/k8s.io/client-go/tools/clientcmd/client_config.go
@@ -181,6 +181,7 @@ func (config *DirectClientConfig) ClientConfig() (*restclient.Config, error) {
 	if len(configAuthInfo.Impersonate) > 0 {
 		clientConfig.Impersonate = restclient.ImpersonationConfig{
 			UserName: configAuthInfo.Impersonate,
+			UID:      configAuthInfo.ImpersonateUID,
 			Groups:   configAuthInfo.ImpersonateGroups,
 			Extra:    configAuthInfo.ImpersonateUserExtra,
 		}
@@ -255,6 +256,7 @@ func (config *DirectClientConfig) getUserIdentificationPartialConfig(configAuthI
 	if len(configAuthInfo.Impersonate) > 0 {
 		mergedConfig.Impersonate = restclient.ImpersonationConfig{
 			UserName: configAuthInfo.Impersonate,
+			UID:      configAuthInfo.ImpersonateUID,
 			Groups:   configAuthInfo.ImpersonateGroups,
 			Extra:    configAuthInfo.ImpersonateUserExtra,
 		}

--- a/staging/src/k8s.io/client-go/tools/clientcmd/overrides.go
+++ b/staging/src/k8s.io/client-go/tools/clientcmd/overrides.go
@@ -53,6 +53,7 @@ type AuthOverrideFlags struct {
 	ClientKey         FlagInfo
 	Token             FlagInfo
 	Impersonate       FlagInfo
+	ImpersonateUID    FlagInfo
 	ImpersonateGroups FlagInfo
 	Username          FlagInfo
 	Password          FlagInfo
@@ -154,6 +155,7 @@ const (
 	FlagEmbedCerts       = "embed-certs"
 	FlagBearerToken      = "token"
 	FlagImpersonate      = "as"
+	FlagImpersonateUID   = "as-uid"
 	FlagImpersonateGroup = "as-group"
 	FlagUsername         = "username"
 	FlagPassword         = "password"
@@ -179,6 +181,7 @@ func RecommendedAuthOverrideFlags(prefix string) AuthOverrideFlags {
 		ClientKey:         FlagInfo{prefix + FlagKeyFile, "", "", "Path to a client key file for TLS"},
 		Token:             FlagInfo{prefix + FlagBearerToken, "", "", "Bearer token for authentication to the API server"},
 		Impersonate:       FlagInfo{prefix + FlagImpersonate, "", "", "Username to impersonate for the operation"},
+		ImpersonateUID:    FlagInfo{prefix + FlagImpersonateUID, "", "", "UID to impersonate for the operation"},
 		ImpersonateGroups: FlagInfo{prefix + FlagImpersonateGroup, "", "", "Group to impersonate for the operation, this flag can be repeated to specify multiple groups."},
 		Username:          FlagInfo{prefix + FlagUsername, "", "", "Username for basic authentication to the API server"},
 		Password:          FlagInfo{prefix + FlagPassword, "", "", "Password for basic authentication to the API server"},
@@ -219,6 +222,7 @@ func BindAuthInfoFlags(authInfo *clientcmdapi.AuthInfo, flags *pflag.FlagSet, fl
 	flagNames.ClientKey.BindStringFlag(flags, &authInfo.ClientKey).AddSecretAnnotation(flags)
 	flagNames.Token.BindStringFlag(flags, &authInfo.Token).AddSecretAnnotation(flags)
 	flagNames.Impersonate.BindStringFlag(flags, &authInfo.Impersonate).AddSecretAnnotation(flags)
+	flagNames.ImpersonateUID.BindStringFlag(flags, &authInfo.ImpersonateUID).AddSecretAnnotation(flags)
 	flagNames.ImpersonateGroups.BindStringArrayFlag(flags, &authInfo.ImpersonateGroups).AddSecretAnnotation(flags)
 	flagNames.Username.BindStringFlag(flags, &authInfo.Username).AddSecretAnnotation(flags)
 	flagNames.Password.BindStringFlag(flags, &authInfo.Password).AddSecretAnnotation(flags)

--- a/staging/src/k8s.io/client-go/tools/clientcmd/validation.go
+++ b/staging/src/k8s.io/client-go/tools/clientcmd/validation.go
@@ -323,9 +323,9 @@ func validateAuthInfo(authInfoName string, authInfo clientcmdapi.AuthInfo) []err
 		validationErrors = append(validationErrors, fmt.Errorf("more than one authentication method found for %v; found %v, only one is allowed", authInfoName, methods))
 	}
 
-	// ImpersonateGroups or ImpersonateUserExtra should be requested with a user
-	if (len(authInfo.ImpersonateGroups) > 0 || len(authInfo.ImpersonateUserExtra) > 0) && (len(authInfo.Impersonate) == 0) {
-		validationErrors = append(validationErrors, fmt.Errorf("requesting groups or user-extra for %v without impersonating a user", authInfoName))
+	// ImpersonateUID, ImpersonateGroups or ImpersonateUserExtra should be requested with a user
+	if (len(authInfo.ImpersonateUID) > 0 || len(authInfo.ImpersonateGroups) > 0 || len(authInfo.ImpersonateUserExtra) > 0) && (len(authInfo.Impersonate) == 0) {
+		validationErrors = append(validationErrors, fmt.Errorf("requesting uid, groups or user-extra for %v without impersonating a user", authInfoName))
 	}
 	return validationErrors
 }

--- a/staging/src/k8s.io/client-go/tools/clientcmd/validation_test.go
+++ b/staging/src/k8s.io/client-go/tools/clientcmd/validation_test.go
@@ -508,6 +508,78 @@ func TestValidateAuthInfoExecInteractiveModeInvalid(t *testing.T) {
 	test.testConfig(t)
 }
 
+func TestValidateAuthInfoImpersonateUser(t *testing.T) {
+	config := clientcmdapi.NewConfig()
+	config.AuthInfos["user"] = &clientcmdapi.AuthInfo{
+		Impersonate: "user",
+	}
+	test := configValidationTest{
+		config: config,
+	}
+	test.testAuthInfo("user", t)
+	test.testConfig(t)
+}
+
+func TestValidateAuthInfoImpersonateEverything(t *testing.T) {
+	config := clientcmdapi.NewConfig()
+	config.AuthInfos["user"] = &clientcmdapi.AuthInfo{
+		Impersonate:          "user",
+		ImpersonateUID:       "abc123",
+		ImpersonateGroups:    []string{"group-1", "group-2"},
+		ImpersonateUserExtra: map[string][]string{"key": {"val1", "val2"}},
+	}
+	test := configValidationTest{
+		config: config,
+	}
+	test.testAuthInfo("user", t)
+	test.testConfig(t)
+}
+
+func TestValidateAuthInfoImpersonateGroupsWithoutUserInvalid(t *testing.T) {
+	config := clientcmdapi.NewConfig()
+	config.AuthInfos["user"] = &clientcmdapi.AuthInfo{
+		ImpersonateGroups: []string{"group-1", "group-2"},
+	}
+	test := configValidationTest{
+		config: config,
+		expectedErrorSubstring: []string{
+			`requesting uid, groups or user-extra for user without impersonating a user`,
+		},
+	}
+	test.testAuthInfo("user", t)
+	test.testConfig(t)
+}
+
+func TestValidateAuthInfoImpersonateExtraWithoutUserInvalid(t *testing.T) {
+	config := clientcmdapi.NewConfig()
+	config.AuthInfos["user"] = &clientcmdapi.AuthInfo{
+		ImpersonateUserExtra: map[string][]string{"key": {"val1", "val2"}},
+	}
+	test := configValidationTest{
+		config: config,
+		expectedErrorSubstring: []string{
+			`requesting uid, groups or user-extra for user without impersonating a user`,
+		},
+	}
+	test.testAuthInfo("user", t)
+	test.testConfig(t)
+}
+
+func TestValidateAuthInfoImpersonateUIDWithoutUserInvalid(t *testing.T) {
+	config := clientcmdapi.NewConfig()
+	config.AuthInfos["user"] = &clientcmdapi.AuthInfo{
+		ImpersonateUID: "abc123",
+	}
+	test := configValidationTest{
+		config: config,
+		expectedErrorSubstring: []string{
+			`requesting uid, groups or user-extra for user without impersonating a user`,
+		},
+	}
+	test.testAuthInfo("user", t)
+	test.testConfig(t)
+}
+
 type configValidationTest struct {
 	config                 *clientcmdapi.Config
 	expectedErrorSubstring []string

--- a/test/cmd/authorization.sh
+++ b/test/cmd/authorization.sh
@@ -51,6 +51,9 @@ run_impersonation_tests() {
   output_message=$(! kubectl get pods "${kube_flags_with_token[@]:?}" --as-group=foo 2>&1)
   kube::test::if_has_string "${output_message}" 'without impersonating a user'
 
+  output_message=$(! kubectl get pods "${kube_flags_with_token[@]:?}" --as-uid=abc123 2>&1)
+  kube::test::if_has_string "${output_message}" 'without impersonating a user'
+
   if kube::test::if_supports_resource "${csr:?}" ; then
     # --as
     kubectl create -f hack/testdata/csr.yml "${kube_flags_with_token[@]:?}" --as=user1
@@ -63,6 +66,13 @@ run_impersonation_tests() {
     kube::test::get_object_assert 'csr/foo' '{{len .spec.groups}}' '4'
     kube::test::get_object_assert 'csr/foo' '{{range .spec.groups}}{{.}} {{end}}' 'group2 group1 ,,,chameleon system:authenticated '
     kubectl delete -f hack/testdata/csr.yml "${kube_flags_with_token[@]:?}"
+
+    # --as-uid
+    kubectl create -f hack/testdata/csr.yml "${kube_flags_with_token[@]:?}" --as=user1 --as-uid=abc123
+    kube::test::get_object_assert 'csr/foo' '{{.spec.username}}' 'user1'
+    kube::test::get_object_assert 'csr/foo' '{{.spec.uid}}' 'abc123'
+    kubectl delete -f hack/testdata/csr.yml "${kube_flags_with_token[@]:?}"
+
   fi
 
   set +o nounset


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
kind/feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Adds --as-uid flag in kubectl and user.as-uid key for kubeconfigs.

This corresponds to previous work to allow impersonating UIDs:
* Introduce Impersonate-UID header: #99961
* Add UID to client-go impersonation config #104483

This change includes:
* Changes to `config_flags.go` to allow the as-uid flag to be set
* Changes to `api.AuthInfo` to add the ImpersonateUID field
* Changes to `v1.AuthInfo` to add ImpersonateUID field
* Integration tests for the flag and the kubeconfig value that create a `CertificateSigningRequest` and ensure that the API server populates the correct impersonated `spec.uid` upon creation.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
This is further work towards #93699

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Adds --as-uid flag to kubectl to allow uid impersonation in the same way as user and group impersonation.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
