### PR TITLE
add kube proxy error metrics

### DIFF
--- a/pkg/proxy/metrics/metrics.go
+++ b/pkg/proxy/metrics/metrics.go
@@ -137,6 +137,28 @@ var (
 		[]string{"table"},
 	)
 
+	// IptablesConntrackErrorsTotal is the number of conntrack errors that the proxy has
+	// seen when syncing iptables rules.
+	IptablesConntrackErrorsTotal = metrics.NewCounter(
+		&metrics.CounterOpts{
+			Subsystem:      kubeProxySubsystem,
+			Name:           "sync_proxy_rules_iptables_conntrack_errors_total",
+			Help:           "Cumulative conntrack errors in the sync of iptables rules",
+			StabilityLevel: metrics.ALPHA,
+		},
+	)
+
+	// IptablesLocalPortBindingErrorsTotal is the number of local port binding errors that the proxy has
+	// seen when syncing iptables rules.
+	IptablesLocalPortBindingErrorsTotal = metrics.NewCounter(
+		&metrics.CounterOpts{
+			Subsystem:      kubeProxySubsystem,
+			Name:           "sync_proxy_rules_iptables_local_port_binding_errors_total",
+			Help:           "Cumulative local port binding errors in the sync of iptables rules",
+			StabilityLevel: metrics.ALPHA,
+		},
+	)
+
 	// SyncProxyRulesLastQueuedTimestamp is the last time a proxy sync was
 	// requested. If this is much larger than
 	// kubeproxy_sync_proxy_rules_last_timestamp_seconds, then something is hung.
@@ -164,6 +186,8 @@ func RegisterMetrics() {
 		legacyregistry.MustRegister(ServiceChangesTotal)
 		legacyregistry.MustRegister(IptablesRulesTotal)
 		legacyregistry.MustRegister(IptablesRestoreFailuresTotal)
+		legacyregistry.MustRegister(IptablesConntrackErrorsTotal)
+		legacyregistry.MustRegister(IptablesLocalPortBindingErrorsTotal)
 		legacyregistry.MustRegister(SyncProxyRulesLastQueuedTimestamp)
 	})
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

I would like to add `sync_proxy_rules_errors_total` metric, which would make it possible to expose kube-proxy error conditions, such as https://github.com/kubernetes/kubernetes/blob/master/pkg/proxy/iptables/proxier.go#L1080-L1089, for which we log errors and sometimes send Kubernetes events. The metric would be helpful for alerting on kube-proxy errors and allow Kubernetes operators investigate the logs / events.


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

Didn't create an issue.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
Add `kubeproxy_sync_proxy_rules_iptables_conntrack_errors_total` ALPHA stability metric, which provides the number of conntrack errors that the proxy has seen when syncing iptables rules.
Add `kubeproxy_sync_proxy_rules_iptables_local_port_binding_errors_total` ALPHA stability metric, which provides the number of local port binding errors that the proxy has seen when syncing Iptables rules.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:


