### PR TITLE
Use a lister for bootstrap flowcontrol config objects.

### DIFF
--- a/pkg/controlplane/instance.go
+++ b/pkg/controlplane/instance.go
@@ -433,7 +433,7 @@ func (c completedConfig) New(delegationTarget genericapiserver.DelegationTarget)
 		rbacrest.RESTStorageProvider{Authorizer: c.GenericConfig.Authorization.Authorizer},
 		schedulingrest.RESTStorageProvider{},
 		storagerest.RESTStorageProvider{},
-		flowcontrolrest.RESTStorageProvider{},
+		flowcontrolrest.RESTStorageProvider{InformerFactory: c.GenericConfig.SharedInformerFactory},
 		// keep apps after extensions so legacy clients resolve the extensions versions of shared resource names.
 		// See https://github.com/kubernetes/kubernetes/issues/42392
 		appsrest.StorageProvider{},

--- a/pkg/registry/flowcontrol/ensurer/prioritylevelconfiguration_test.go
+++ b/pkg/registry/flowcontrol/ensurer/prioritylevelconfiguration_test.go
@@ -27,43 +27,41 @@ import (
 	"k8s.io/apiserver/pkg/apis/flowcontrol/bootstrap"
 	"k8s.io/client-go/kubernetes/fake"
 	flowcontrolclient "k8s.io/client-go/kubernetes/typed/flowcontrol/v1beta2"
+	flowcontrollisters "k8s.io/client-go/listers/flowcontrol/v1beta2"
+	"k8s.io/client-go/tools/cache"
 	flowcontrolapisv1beta2 "k8s.io/kubernetes/pkg/apis/flowcontrol/v1beta2"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestEnsurePriorityLevel(t *testing.T) {
 	tests := []struct {
 		name      string
-		strategy  func(flowcontrolclient.PriorityLevelConfigurationInterface) PriorityLevelEnsurer
+		strategy  func(flowcontrolclient.PriorityLevelConfigurationInterface, flowcontrollisters.PriorityLevelConfigurationLister) PriorityLevelEnsurer
 		current   *flowcontrolv1beta2.PriorityLevelConfiguration
 		bootstrap *flowcontrolv1beta2.PriorityLevelConfiguration
 		expected  *flowcontrolv1beta2.PriorityLevelConfiguration
 	}{
 		// for suggested configurations
 		{
-			name: "suggested priority level configuration does not exist - the object should always be re-created",
-			strategy: func(client flowcontrolclient.PriorityLevelConfigurationInterface) PriorityLevelEnsurer {
-				return NewSuggestedPriorityLevelEnsurerEnsurer(client)
-			},
+			name:      "suggested priority level configuration does not exist - the object should always be re-created",
+			strategy:  NewSuggestedPriorityLevelEnsurerEnsurer,
 			bootstrap: newPLConfiguration("pl1").WithLimited(10).Object(),
 			current:   nil,
 			expected:  newPLConfiguration("pl1").WithLimited(10).Object(),
 		},
 		{
-			name: "suggested priority level configuration exists, auto update is enabled, spec does not match - current object should be updated",
-			strategy: func(client flowcontrolclient.PriorityLevelConfigurationInterface) PriorityLevelEnsurer {
-				return NewSuggestedPriorityLevelEnsurerEnsurer(client)
-			}, bootstrap: newPLConfiguration("pl1").WithLimited(20).Object(),
-			current:  newPLConfiguration("pl1").WithAutoUpdateAnnotation("true").WithLimited(10).Object(),
-			expected: newPLConfiguration("pl1").WithAutoUpdateAnnotation("true").WithLimited(20).Object(),
+			name:      "suggested priority level configuration exists, auto update is enabled, spec does not match - current object should be updated",
+			strategy:  NewSuggestedPriorityLevelEnsurerEnsurer,
+			bootstrap: newPLConfiguration("pl1").WithLimited(20).Object(),
+			current:   newPLConfiguration("pl1").WithAutoUpdateAnnotation("true").WithLimited(10).Object(),
+			expected:  newPLConfiguration("pl1").WithAutoUpdateAnnotation("true").WithLimited(20).Object(),
 		},
 		{
-			name: "suggested priority level configuration exists, auto update is disabled, spec does not match - current object should not be updated",
-			strategy: func(client flowcontrolclient.PriorityLevelConfigurationInterface) PriorityLevelEnsurer {
-				return NewSuggestedPriorityLevelEnsurerEnsurer(client)
-			},
+			name:      "suggested priority level configuration exists, auto update is disabled, spec does not match - current object should not be updated",
+			strategy:  NewSuggestedPriorityLevelEnsurerEnsurer,
 			bootstrap: newPLConfiguration("pl1").WithLimited(20).Object(),
 			current:   newPLConfiguration("pl1").WithAutoUpdateAnnotation("false").WithLimited(10).Object(),
 			expected:  newPLConfiguration("pl1").WithAutoUpdateAnnotation("false").WithLimited(10).Object(),
@@ -71,28 +69,22 @@ func TestEnsurePriorityLevel(t *testing.T) {
 
 		// for mandatory configurations
 		{
-			name: "mandatory priority level configuration does not exist - new object should be created",
-			strategy: func(client flowcontrolclient.PriorityLevelConfigurationInterface) PriorityLevelEnsurer {
-				return NewMandatoryPriorityLevelEnsurer(client)
-			},
+			name:      "mandatory priority level configuration does not exist - new object should be created",
+			strategy:  NewMandatoryPriorityLevelEnsurer,
 			bootstrap: newPLConfiguration("pl1").WithLimited(10).WithAutoUpdateAnnotation("true").Object(),
 			current:   nil,
 			expected:  newPLConfiguration("pl1").WithLimited(10).WithAutoUpdateAnnotation("true").Object(),
 		},
 		{
-			name: "mandatory priority level configuration exists, annotation is missing - annotation is added",
-			strategy: func(client flowcontrolclient.PriorityLevelConfigurationInterface) PriorityLevelEnsurer {
-				return NewMandatoryPriorityLevelEnsurer(client)
-			},
+			name:      "mandatory priority level configuration exists, annotation is missing - annotation is added",
+			strategy:  NewMandatoryPriorityLevelEnsurer,
 			bootstrap: newPLConfiguration("pl1").WithLimited(20).Object(),
 			current:   newPLConfiguration("pl1").WithLimited(20).Object(),
 			expected:  newPLConfiguration("pl1").WithAutoUpdateAnnotation("true").WithLimited(20).Object(),
 		},
 		{
-			name: "mandatory priority level configuration exists, auto update is disabled, spec does not match - current object should be updated",
-			strategy: func(client flowcontrolclient.PriorityLevelConfigurationInterface) PriorityLevelEnsurer {
-				return NewMandatoryPriorityLevelEnsurer(client)
-			},
+			name:      "mandatory priority level configuration exists, auto update is disabled, spec does not match - current object should be updated",
+			strategy:  NewMandatoryPriorityLevelEnsurer,
 			bootstrap: newPLConfiguration("pl1").WithLimited(20).Object(),
 			current:   newPLConfiguration("pl1").WithAutoUpdateAnnotation("false").WithLimited(10).Object(),
 			expected:  newPLConfiguration("pl1").WithAutoUpdateAnnotation("true").WithLimited(20).Object(),
@@ -101,13 +93,14 @@ func TestEnsurePriorityLevel(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-
 			client := fake.NewSimpleClientset().FlowcontrolV1beta2().PriorityLevelConfigurations()
+			indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
 			if test.current != nil {
 				client.Create(context.TODO(), test.current, metav1.CreateOptions{})
+				indexer.Add(test.current)
 			}
 
-			ensurer := test.strategy(client)
+			ensurer := test.strategy(client, flowcontrollisters.NewPriorityLevelConfigurationLister(indexer))
 
 			err := ensurer.Ensure([]*flowcontrolv1beta2.PriorityLevelConfiguration{test.bootstrap})
 			if err != nil {
@@ -338,11 +331,13 @@ func TestRemovePriorityLevelConfiguration(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			client := fake.NewSimpleClientset().FlowcontrolV1beta2().PriorityLevelConfigurations()
+			indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
 			if test.current != nil {
 				client.Create(context.TODO(), test.current, metav1.CreateOptions{})
+				indexer.Add(test.current)
 			}
 
-			remover := NewPriorityLevelRemover(client)
+			remover := NewPriorityLevelRemover(client, flowcontrollisters.NewPriorityLevelConfigurationLister(indexer))
 			err := remover.Remove([]string{test.bootstrapName})
 			if err != nil {
 				t.Fatalf("Expected no error, but got: %v", err)
@@ -425,17 +420,20 @@ func TestGetPriorityLevelRemoveCandidate(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			client := fake.NewSimpleClientset().FlowcontrolV1beta2().PriorityLevelConfigurations()
+			indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
 			for i := range test.current {
-				client.Create(context.TODO(), test.current[i], metav1.CreateOptions{})
+				indexer.Add(test.current[i])
 			}
 
-			removeListGot, err := GetPriorityLevelRemoveCandidate(client, test.bootstrap)
+			lister := flowcontrollisters.NewPriorityLevelConfigurationLister(indexer)
+			removeListGot, err := GetPriorityLevelRemoveCandidate(lister, test.bootstrap)
 			if err != nil {
 				t.Fatalf("Expected no error, but got: %v", err)
 			}
 
-			if !cmp.Equal(test.expected, removeListGot) {
+			if !cmp.Equal(test.expected, removeListGot, cmpopts.SortSlices(func(a string, b string) bool {
+				return a < b
+			})) {
 				t.Errorf("Remove candidate list does not match - diff: %s", cmp.Diff(test.expected, removeListGot))
 			}
 		})


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Instead of listing all flowschemas and prioritylevelconfigurations periodically, read from local informer caches when ensuring the APF bootstrap configuration.

#### Which issue(s) this PR fixes:

Fixes https://github.com/kubernetes/kubernetes/issues/101667.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
