### PR TITLE
fix flake on TestRecordOperation unit test

### DIFF
--- a/pkg/kubelet/kuberuntime/instrumented_services_test.go
+++ b/pkg/kubelet/kuberuntime/instrumented_services_test.go
@@ -19,6 +19,7 @@ package kuberuntime
 import (
 	"net"
 	"net/http"
+	"sync"
 	"testing"
 	"time"
 
@@ -29,10 +30,17 @@ import (
 	"k8s.io/kubernetes/pkg/kubelet/metrics"
 )
 
+var registerMetrics sync.Once
+
 func TestRecordOperation(t *testing.T) {
-	legacyregistry.MustRegister(metrics.RuntimeOperations)
-	legacyregistry.MustRegister(metrics.RuntimeOperationsDuration)
-	legacyregistry.MustRegister(metrics.RuntimeOperationsErrors)
+
+	registerMetrics.Do(func() {
+		legacyregistry.MustRegister(metrics.RuntimeOperations)
+		legacyregistry.MustRegister(metrics.RuntimeOperationsDuration)
+		legacyregistry.MustRegister(metrics.RuntimeOperationsErrors)
+	},
+	)
+	defer legacyregistry.Reset()
 
 	l, err := net.Listen("tcp", "127.0.0.1:0")
 	assert.NoError(t, err)


### PR DESCRIPTION
/kind flake

```
go test -timeout 100s -run ^TestRecordOperation$ k8s.io/kubernetes/pkg/kubelet/kuberuntime -v -count 10
=== RUN   TestRecordOperation
--- PASS: TestRecordOperation (0.00s)
=== RUN   TestRecordOperation
--- PASS: TestRecordOperation (0.00s)
=== RUN   TestRecordOperation
--- PASS: TestRecordOperation (0.00s)
=== RUN   TestRecordOperation
--- PASS: TestRecordOperation (0.00s)
=== RUN   TestRecordOperation
--- PASS: TestRecordOperation (0.00s)
=== RUN   TestRecordOperation
--- PASS: TestRecordOperation (0.00s)
=== RUN   TestRecordOperation
--- PASS: TestRecordOperation (0.00s)
=== RUN   TestRecordOperation
--- PASS: TestRecordOperation (0.00s)
=== RUN   TestRecordOperation
--- PASS: TestRecordOperation (0.00s)
=== RUN   TestRecordOperation
--- PASS: TestRecordOperation (0.00s)
PASS
ok      k8s.io/kubernetes/pkg/kubelet/kuberuntime       0.038s
```


```release-note
NONE
```
Fixes #104940 