### PR TITLE
fix staticcheck

### DIFF
--- a/hack/.staticcheck_failures
+++ b/hack/.staticcheck_failures
@@ -1,10 +1,6 @@
 pkg/util/flag
 test/e2e/apimachinery
-vendor/k8s.io/apimachinery/pkg/util/json
 vendor/k8s.io/apimachinery/pkg/util/strategicpatch
 vendor/k8s.io/apiserver/pkg/server/dynamiccertificates
 vendor/k8s.io/apiserver/pkg/server/filters
 vendor/k8s.io/apiserver/pkg/server/routes
-vendor/k8s.io/apiserver/pkg/storage/value/encrypt/envelope
-vendor/k8s.io/apiserver/pkg/util/wsstream
-vendor/k8s.io/client-go/rest

--- a/staging/src/k8s.io/apimachinery/pkg/util/json/json_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/json/json_test.go
@@ -122,7 +122,7 @@ func TestEvaluateTypes(t *testing.T) {
 		},
 		{
 			In:   `-0.0`,
-			Data: float64(-0.0), //nolint:staticcheck // SA4026: in Go, the floating-point literal '-0.0' is the same as '0.0'
+			Data: float64(0.0),
 			Out:  `-0`,
 		},
 		{

--- a/staging/src/k8s.io/apiserver/pkg/storage/value/encrypt/envelope/grpc_service_unix_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/value/encrypt/envelope/grpc_service_unix_test.go
@@ -139,7 +139,7 @@ func TestTimeouts(t *testing.T) {
 
 				service, err = NewGRPCService(socketName.endpoint, tt.callTimeout)
 				if err != nil {
-					t.Fatalf("failed to create envelope service, error: %v", err)
+					t.Errorf("failed to create envelope service, error: %v", err)
 				}
 				defer destroyService(service)
 				kubeAPIServerWG.Done()
@@ -154,10 +154,10 @@ func TestTimeouts(t *testing.T) {
 
 				f, err := mock.NewBase64Plugin(socketName.path)
 				if err != nil {
-					t.Fatalf("failed to construct test KMS provider server, error: %v", err)
+					t.Errorf("failed to construct test KMS provider server, error: %v", err)
 				}
 				if err := f.Start(); err != nil {
-					t.Fatalf("Failed to start test KMS provider server, error: %v", err)
+					t.Errorf("Failed to start test KMS provider server, error: %v", err)
 				}
 				defer f.CleanUp()
 				kmsPluginWG.Done()

--- a/staging/src/k8s.io/apiserver/pkg/util/wsstream/conn_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/wsstream/conn_test.go
@@ -59,7 +59,7 @@ func TestRawConn(t *testing.T) {
 		defer wg.Done()
 		data, err := ioutil.ReadAll(conn.channels[0])
 		if err != nil {
-			t.Fatal(err)
+			t.Error(err)
 		}
 		if !reflect.DeepEqual(data, []byte("client")) {
 			t.Errorf("unexpected server read: %v", data)
@@ -75,7 +75,7 @@ func TestRawConn(t *testing.T) {
 	go func() {
 		defer wg.Done()
 		if n, err := conn.channels[1].Write([]byte("server")); err != nil && n != 6 {
-			t.Fatalf("%d: %v", n, err)
+			t.Errorf("%d: %v", n, err)
 		}
 	}()
 
@@ -141,7 +141,7 @@ func TestBase64Conn(t *testing.T) {
 		defer wg.Done()
 		data, err := ioutil.ReadAll(conn.channels[0])
 		if err != nil {
-			t.Fatal(err)
+			t.Error(err)
 		}
 		if !reflect.DeepEqual(data, []byte("client")) {
 			t.Errorf("unexpected server read: %s", string(data))
@@ -157,7 +157,7 @@ func TestBase64Conn(t *testing.T) {
 	go func() {
 		defer wg.Done()
 		if n, err := conn.channels[1].Write([]byte("server")); err != nil && n != 6 {
-			t.Fatalf("%d: %v", n, err)
+			t.Errorf("%d: %v", n, err)
 		}
 	}()
 

--- a/staging/src/k8s.io/client-go/rest/connection_test.go
+++ b/staging/src/k8s.io/client-go/rest/connection_test.go
@@ -54,14 +54,14 @@ func (lb *tcpLB) handleConnection(in net.Conn, stopCh chan struct{}) {
 	go io.Copy(in, out)
 	<-stopCh
 	if err := out.Close(); err != nil {
-		lb.t.Fatalf("failed to close connection: %v", err)
+		lb.t.Errorf("failed to close connection: %v", err)
 	}
 }
 
 func (lb *tcpLB) serve(stopCh chan struct{}) {
 	conn, err := lb.ln.Accept()
 	if err != nil {
-		lb.t.Fatalf("failed to accept: %v", err)
+		lb.t.Errorf("failed to accept: %v", err)
 	}
 	atomic.AddInt32(&lb.dials, 1)
 	go lb.handleConnection(conn, stopCh)


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it: 

fixes `vendor/k8s.io/apimachinery/pkg/util/json`, `vendor/k8s.io/apiserver/pkg/storage/value/encrypt/envelope`, `vendor/k8s.io/apiserver/pkg/util/wsstream`, `vendor/k8s.io/client-go/rest` staticcheck errors

#### Which issue(s) this PR fixes: 

Part of [#92402](https://github.com/kubernetes/kubernetes/issues/92402)

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
