### PR TITLE
Add more info to the ListAndWatch trace

### DIFF
--- a/staging/src/k8s.io/client-go/tools/cache/reflector.go
+++ b/staging/src/k8s.io/client-go/tools/cache/reflector.go
@@ -319,7 +319,9 @@ func (r *Reflector) ListAndWatch(stopCh <-chan struct{}) error {
 			panic(r)
 		case <-listCh:
 		}
+		initTrace.Step("Objects listed", trace.Field{"error", err})
 		if err != nil {
+			klog.Warningf("%s: failed to list %v: %v", r.name, r.expectedTypeName, err)
 			return fmt.Errorf("failed to list %v: %v", r.expectedTypeName, err)
 		}
 
@@ -338,7 +340,6 @@ func (r *Reflector) ListAndWatch(stopCh <-chan struct{}) error {
 		}
 
 		r.setIsLastSyncResourceVersionUnavailable(false) // list was successful
-		initTrace.Step("Objects listed")
 		listMetaInterface, err := meta.ListAccessor(list)
 		if err != nil {
 			return fmt.Errorf("unable to understand list result %#v: %v", list, err)


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
During scalability tests we sometimes run into issues where the kube-apiserver says it has quickly responded to the list-and-watch client but the client times out during waiting for the list response resulting in a trace like this:

```
Trace[1278792655]: "Reflector ListAndWatch" name:*v1.PodStore: namespace(test-c4fygz-19), labelSelector(name=latency-deployment-87) (started: 2021-10-15 09:15:15.677742785 +0000 UTC m=+3349.793617611) (total time: 2m0.000883547s):
Trace[1278792655]: [2m0.000883547s] [2m0.000883547s] END
```

This change is to increase the debuggability so we know what is the actual culprit visible from the client point of view

#### Which issue(s) this PR fixes:
No issue is opened for that.

#### Special notes for your reviewer:
/sig scalability
/assign @mborsz 

#### Does this PR introduce a user-facing change?
```release-note
NONE
```