### PR TITLE
storage e2e: fix volume metric test for PVC

### DIFF
--- a/test/e2e/storage/volume_metrics.go
+++ b/test/e2e/storage/volume_metrics.go
@@ -213,7 +213,6 @@ var _ = utils.SIGDescribe("[Serial] Volume metrics", func() {
 	}
 
 	filesystemMode := func(isEphemeral bool) {
-		pvcName := pvc.Name
 		if !isEphemeral {
 			pvc, err = c.CoreV1().PersistentVolumeClaims(pvc.Namespace).Create(context.TODO(), pvc, metav1.CreateOptions{})
 			framework.ExpectNoError(err)
@@ -230,6 +229,7 @@ var _ = utils.SIGDescribe("[Serial] Volume metrics", func() {
 		pod, err = c.CoreV1().Pods(ns).Get(context.TODO(), pod.Name, metav1.GetOptions{})
 		framework.ExpectNoError(err)
 
+		pvcName := pvc.Name
 		if isEphemeral {
 			pvcName = ephemeral.VolumeClaimName(pod, &pod.Spec.Volumes[0])
 		}


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/kind failing-test

#### What this PR does / why we need it:

The fix for the ephemeral volume
case (7538d089d5cb5305c3558bb9614ae82bdad7bc2b) broke the other variant with
PVC because pvc.Name is only set *after* creating the PVC.

#### Special notes for your reviewer:

/assign @mauriciopoppe 

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
