### PR TITLE
Fixing spacing for IANA standard service name link Fixes #29986

### DIFF
--- a/pkg/apis/core/types.go
+++ b/pkg/apis/core/types.go
@@ -3803,7 +3803,7 @@ type ServicePort struct {
 	// The application protocol for this port.
 	// This field follows standard Kubernetes label syntax.
 	// Un-prefixed names are reserved for IANA standard service names (as per
-	// RFC-6335 and http://www.iana.org/assignments/service-names).
+	// https://www.iana.org/assignments/service-names and RFC 6335).
 	// Non-standard protocols should use prefixed names such as
 	// mycompany.com/my-custom-protocol.
 	// +optional
@@ -3953,7 +3953,7 @@ type EndpointPort struct {
 	// The application protocol for this port.
 	// This field follows standard Kubernetes label syntax.
 	// Un-prefixed names are reserved for IANA standard service names (as per
-	// RFC-6335 and http://www.iana.org/assignments/service-names).
+	// https://www.iana.org/assignments/service-names and RFC 6335).
 	// Non-standard protocols should use prefixed names such as
 	// mycompany.com/my-custom-protocol.
 	// +optional

--- a/pkg/apis/discovery/types.go
+++ b/pkg/apis/discovery/types.go
@@ -165,7 +165,7 @@ type EndpointPort struct {
 	// The application protocol for this port.
 	// This field follows standard Kubernetes label syntax.
 	// Un-prefixed names are reserved for IANA standard service names (as per
-	// RFC-6335 and http://www.iana.org/assignments/service-names).
+	// https://www.iana.org/assignments/service-names and RFC 6335).
 	// Non-standard protocols should use prefixed names such as
 	// mycompany.com/my-custom-protocol.
 	// +optional

--- a/staging/src/k8s.io/api/core/v1/generated.proto
+++ b/staging/src/k8s.io/api/core/v1/generated.proto
@@ -1054,7 +1054,7 @@ message EndpointPort {
   // The application protocol for this port.
   // This field follows standard Kubernetes label syntax.
   // Un-prefixed names are reserved for IANA standard service names (as per
-  // RFC-6335 and http://www.iana.org/assignments/service-names).
+	// https://www.iana.org/assignments/service-names and RFC 6335).
   // Non-standard protocols should use prefixed names such as
   // mycompany.com/my-custom-protocol.
   // +optional
@@ -4807,7 +4807,7 @@ message ServicePort {
   // The application protocol for this port.
   // This field follows standard Kubernetes label syntax.
   // Un-prefixed names are reserved for IANA standard service names (as per
-  // RFC-6335 and http://www.iana.org/assignments/service-names).
+	// https://www.iana.org/assignments/service-names and RFC 6335).
   // Non-standard protocols should use prefixed names such as
   // mycompany.com/my-custom-protocol.
   // +optional

--- a/staging/src/k8s.io/api/core/v1/types.go
+++ b/staging/src/k8s.io/api/core/v1/types.go
@@ -4350,7 +4350,7 @@ type ServicePort struct {
 	// The application protocol for this port.
 	// This field follows standard Kubernetes label syntax.
 	// Un-prefixed names are reserved for IANA standard service names (as per
-	// RFC-6335 and http://www.iana.org/assignments/service-names).
+	// https://www.iana.org/assignments/service-names and RFC 6335).
 	// Non-standard protocols should use prefixed names such as
 	// mycompany.com/my-custom-protocol.
 	// +optional
@@ -4581,7 +4581,7 @@ type EndpointPort struct {
 	// The application protocol for this port.
 	// This field follows standard Kubernetes label syntax.
 	// Un-prefixed names are reserved for IANA standard service names (as per
-	// RFC-6335 and http://www.iana.org/assignments/service-names).
+	// https://www.iana.org/assignments/service-names and RFC 6335).
 	// Non-standard protocols should use prefixed names such as
 	// mycompany.com/my-custom-protocol.
 	// +optional

--- a/staging/src/k8s.io/api/discovery/v1/generated.proto
+++ b/staging/src/k8s.io/api/discovery/v1/generated.proto
@@ -140,7 +140,7 @@ message EndpointPort {
   // The application protocol for this port.
   // This field follows standard Kubernetes label syntax.
   // Un-prefixed names are reserved for IANA standard service names (as per
-  // RFC-6335 and http://www.iana.org/assignments/service-names).
+	// https://www.iana.org/assignments/service-names and RFC 6335).
   // Non-standard protocols should use prefixed names such as
   // mycompany.com/my-custom-protocol.
   // +optional

--- a/staging/src/k8s.io/api/discovery/v1/types.go
+++ b/staging/src/k8s.io/api/discovery/v1/types.go
@@ -175,7 +175,7 @@ type EndpointPort struct {
 	// The application protocol for this port.
 	// This field follows standard Kubernetes label syntax.
 	// Un-prefixed names are reserved for IANA standard service names (as per
-	// RFC-6335 and http://www.iana.org/assignments/service-names).
+	// https://www.iana.org/assignments/service-names and RFC 6335).
 	// Non-standard protocols should use prefixed names such as
 	// mycompany.com/my-custom-protocol.
 	// +optional

--- a/staging/src/k8s.io/api/discovery/v1beta1/generated.proto
+++ b/staging/src/k8s.io/api/discovery/v1beta1/generated.proto
@@ -143,7 +143,7 @@ message EndpointPort {
   // The application protocol for this port.
   // This field follows standard Kubernetes label syntax.
   // Un-prefixed names are reserved for IANA standard service names (as per
-  // RFC-6335 and http://www.iana.org/assignments/service-names).
+	// https://www.iana.org/assignments/service-names and RFC 6335).
   // Non-standard protocols should use prefixed names such as
   // mycompany.com/my-custom-protocol.
   // +optional


### PR DESCRIPTION
This pull request is addressing Issue #29986, I changed the wording of the link so that the link wouldn't be broken anymore.
```
