### PR TITLE
 Determine mount points without relying on /proc/mounts

### DIFF
--- a/staging/src/k8s.io/mount-utils/go.mod
+++ b/staging/src/k8s.io/mount-utils/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/kr/text v0.2.0 // indirect
 	github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e // indirect
 	github.com/stretchr/testify v1.7.0
+	golang.org/x/sys v0.0.0-20210820121016-41cdb8703e55
 	gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f // indirect
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 	k8s.io/klog/v2 v2.20.0

--- a/staging/src/k8s.io/mount-utils/go.sum
+++ b/staging/src/k8s.io/mount-utils/go.sum
@@ -19,6 +19,8 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+golang.org/x/sys v0.0.0-20210820121016-41cdb8703e55 h1:rw6UNGRMfarCepjI8qOepea/SXwIBVfTKjztZ5gBbq4=
+golang.org/x/sys v0.0.0-20210820121016-41cdb8703e55/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f h1:BLraFXnmrev5lT+xlilqcH8XK9/i0At2xKjWk4p6zsU=

--- a/staging/src/k8s.io/mount-utils/mount_linux.go
+++ b/staging/src/k8s.io/mount-utils/mount_linux.go
@@ -697,7 +697,6 @@ func isMountPointUsingOpenAt2(path string, openat2 func(int, string, *unix.OpenH
 	if openat2 == nil {
 		openat2 = unix.Openat2
 	}
-
 	// explicitly clean the path to remove trailing slashes.
 	// ref: https://pkg.go.dev/path/filepath#Clean
 	// otherwise, this will remove false +-ves or return errors.
@@ -746,7 +745,9 @@ func isMountPointUsingOpenAt2(path string, openat2 func(int, string, *unix.OpenH
 		return false, nil
 	case unix.EXDEV: // definitely a mount
 		// this is because for an absolute path, if we have RESOLVE_NO_XDEV, the only way to get
-		// this error is when a path is on a mount-point.
+		// this error is when a mount-point is crossed.
+		// Here are the following cases when a mount-point is crossed in Linux.
+		// Ref: https://github.com/torvalds/linux/blob/5bfc75d92efd494db37f5c4c173d3639d4772966/tools/testing/selftests/openat2/resolve_test.c#L301-L351
 		return true, nil
 	}
 	// not sure

--- a/staging/src/k8s.io/mount-utils/mount_unsupported.go
+++ b/staging/src/k8s.io/mount-utils/mount_unsupported.go
@@ -86,3 +86,10 @@ func (mounter *SafeFormatAndMount) formatAndMountSensitive(source string, target
 func (mounter *SafeFormatAndMount) diskLooksUnformatted(disk string) (bool, error) {
 	return true, errUnsupported
 }
+
+// isMountFastPath is a method of detecting a mount that really fast.
+// It should return a true and no-error ONLY when it is an actual mount point.
+// In cases, where it is not guaranteed or cannot be determined, it should return an error.
+func isMountFastPath(path string) (bool, error) {
+	return false, errUnsupported
+}

--- a/staging/src/k8s.io/mount-utils/mount_windows.go
+++ b/staging/src/k8s.io/mount-utils/mount_windows.go
@@ -20,6 +20,7 @@ limitations under the License.
 package mount
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -339,6 +340,6 @@ func getAllParentLinks(path string) ([]string, error) {
 // isMountFastPath is a method of detecting a mount that really fast.
 // It should return a true and no-error ONLY when it is an actual mount point.
 // In cases, where it is not guaranteed or cannot be determined, it should return an error.
-func isMountFastPath(path string) (bool, error) {
-	return false, fmt.Errorf("isMountFastPath is supported only on Linux")
+func isMountFastPath(_ string) (bool, error) {
+	return false, errors.New("isMountFastPath on this platform is not supported")
 }

--- a/staging/src/k8s.io/mount-utils/mount_windows.go
+++ b/staging/src/k8s.io/mount-utils/mount_windows.go
@@ -335,3 +335,10 @@ func getAllParentLinks(path string) ([]string, error) {
 
 	return links, nil
 }
+
+// isMountFastPath is a method of detecting a mount that really fast.
+// It should return a true and no-error ONLY when it is an actual mount point.
+// In cases, where it is not guaranteed or cannot be determined, it should return an error.
+func isMountFastPath(path string) (bool, error) {
+	return false, fmt.Errorf("isMountFastPath is supported only on Linux")
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug

#### What this PR does / why we need it:

use openat2 which is present in linux kernel 5.6+ to avoid
relying on /proc/mounts which is a slower operation.

For all other cases, fall back to rely on the list api which
consistently reads /proc/mounts for linux.

On a kernel 5.10, I can launch

With this case, I have been able to get around 5x more pod launches on
a single node. Earlier, I would be able to get ~400 pod launches with
performance degradation later ; but now; I have been able to launch >
2000 pods without any failure.

I was also able to launch pods much faster with these changes:
Earlier I was able to launch 400 pods in an hour
Now, I am able to launch 2000 pods in around 60 mins on Linux


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #105642

#### Special notes for your reviewer:

Follow up on sig-storage meeting.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Linux kernel 5.6+ should experience faster pod launch and unlaunch times.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

/sig storage

/assign @jsafrane @jingxu97 


