### PR TITLE
Errors: Change StatusError message formatting removing double quote

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/api/errors/errors.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/errors/errors.go
@@ -238,7 +238,7 @@ func NewConflict(qualifiedResource schema.GroupResource, name string, err error)
 			Kind:  qualifiedResource.Resource,
 			Name:  name,
 		},
-		Message: fmt.Sprintf("Operation cannot be fulfilled on %s %q: %v", qualifiedResource.String(), name, err),
+		Message: fmt.Sprintf("Operation cannot be fulfilled on %s '%s': %v", qualifiedResource.String(), name, err),
 	}}
 }
 

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/responsewriters/status_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/responsewriters/status_test.go
@@ -68,7 +68,7 @@ func TestAPIStatus(t *testing.T) {
 			Status:  metav1.StatusFailure,
 			Code:    http.StatusConflict,
 			Reason:  "Conflict",
-			Message: "Operation cannot be fulfilled on foos \"bar\": failure",
+			Message: "Operation cannot be fulfilled on foos 'bar': failure",
 			Details: &metav1.StatusDetails{
 				Group: "",
 				Kind:  "foos",

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/rest_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/rest_test.go
@@ -615,7 +615,7 @@ func TestPatchResourceWithStaleVersionConflict(t *testing.T) {
 		startingPod: &example.Pod{},
 		updatePod:   &example.Pod{},
 
-		expectedError: `Operation cannot be fulfilled on pods.example.apiserver.k8s.io "foo": existing 2, new 1`,
+		expectedError: `Operation cannot be fulfilled on pods.example.apiserver.k8s.io 'foo': existing 2, new 1`,
 		expectedTries: 1,
 	}
 
@@ -646,7 +646,7 @@ func TestPatchResourceWithRacingVersionConflict(t *testing.T) {
 		startingPod: &example.Pod{},
 		updatePod:   &example.Pod{},
 
-		expectedError: `Operation cannot be fulfilled on pods.example.apiserver.k8s.io "foo": existing 3, new 2`,
+		expectedError: `Operation cannot be fulfilled on pods.example.apiserver.k8s.io 'foo': existing 3, new 2`,
 		expectedTries: 2,
 	}
 


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
This PR removes %q usage and instead uses %s with quotes. %q prints
double quotes into messages and that makes events invalid jsons.

#### Which issue(s) this PR fixes:
Fixes #105821

#### Special notes for your reviewer:
Single quotes are added to emphasize resource name

#### Does this PR introduce a user-facing change?
```release-note
Change resource name formatting in "Operation cannot be fulfilled on" messages from double quote to single
```