### PR TITLE
fix(kubectl debug): add privileged to let debug node container to access process root

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/debug/debug.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/debug/debug.go
@@ -534,6 +534,7 @@ func (o *DebugOptions) generateNodeDebugPod(node *corev1.Node) *corev1.Pod {
 		fmt.Fprintf(o.Out, "Creating debugging pod %s with container %s on node %s.\n", pn, cn, node.Name)
 	}
 
+	bTrue := true
 	p := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: pn,
@@ -553,6 +554,9 @@ func (o *DebugOptions) generateNodeDebugPod(node *corev1.Node) *corev1.Pod {
 							MountPath: "/host",
 							Name:      "host-root",
 						},
+					},
+					SecurityContext: &corev1.SecurityContext{
+						Privileged: &bTrue,
 					},
 				},
 			},

--- a/staging/src/k8s.io/kubectl/pkg/cmd/debug/debug_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/debug/debug_test.go
@@ -1026,6 +1026,7 @@ func TestGenerateNodeDebugPod(t *testing.T) {
 		return fmt.Sprint(suffixCounter)
 	}
 
+	bTrue := true
 	for _, tc := range []struct {
 		name     string
 		node     *corev1.Node
@@ -1059,6 +1060,9 @@ func TestGenerateNodeDebugPod(t *testing.T) {
 									MountPath: "/host",
 									Name:      "host-root",
 								},
+							},
+							SecurityContext: &corev1.SecurityContext{
+								Privileged: &bTrue,
 							},
 						},
 					},
@@ -1114,6 +1118,9 @@ func TestGenerateNodeDebugPod(t *testing.T) {
 									Name:      "host-root",
 								},
 							},
+							SecurityContext: &corev1.SecurityContext{
+								Privileged: &bTrue,
+							},
 						},
 					},
 					HostIPC:       true,
@@ -1168,6 +1175,9 @@ func TestGenerateNodeDebugPod(t *testing.T) {
 									MountPath: "/host",
 									Name:      "host-root",
 								},
+							},
+							SecurityContext: &corev1.SecurityContext{
+								Privileged: &bTrue,
 							},
 						},
 					},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug


#### What this PR does / why we need it:

From my comment in https://github.com/kubernetes/enhancements/issues/277#issuecomment-949320689
> I have a sidecar container with distroless image running as a user. And I want to debug it without restarting the pod as the issue may not be reproduceable.
I tried both kube debug pod and node, both return me Permission denied error when I am trying to access the storage of the process. /proc/$pid/root. The workaround for me is to deploy a privileged pod on that node (similar to kube debug node but with privileged) and I can access everything.

and the docs of `kube debug` [here](https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/kubectl/pkg/cmd/debug/debug.go#L371)
> visitNode handles debugging for node targets by creating a privileged pod running in the host namespaces.

The node created by `kube debug node` should be a privileged pod, however, it is not. [KEP](https://github.com/kubernetes/enhancements/tree/master/keps/sig-cli/1441-kubectl-debug#node-troubleshooting-with-privileged-containers)

The current `kube debug node` cannot access the root of the container running as a NonRoot User.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #105846

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
