### PR TITLE
apf: manage request queue wait with context

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/queueset/queueset_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/queueset/queueset_test.go
@@ -551,7 +551,6 @@ func TestBaseline(t *testing.T) {
 		DesiredNumQueues: 9,
 		QueueLengthLimit: 8,
 		HandSize:         3,
-		RequestWaitLimit: 10 * time.Minute,
 	}
 	seatDemandIntegratorSubject := fq.NewNamedIntegrator(clk, "seatDemandSubject")
 	qsc, err := qsf.BeginConstruction(qCfg, newGaugePair(clk), newExecSeatsGauge(clk), seatDemandIntegratorSubject)
@@ -590,7 +589,6 @@ func TestExampt(t *testing.T) {
 				DesiredNumQueues: -1,
 				QueueLengthLimit: 2,
 				HandSize:         3,
-				RequestWaitLimit: 10 * time.Minute,
 			}
 			seatDemandIntegratorSubject := fq.NewNamedIntegrator(clk, "seatDemandSubject")
 			qsc, err := qsf.BeginConstruction(qCfg, newGaugePair(clk), newExecSeatsGauge(clk), seatDemandIntegratorSubject)
@@ -663,7 +661,6 @@ func TestSeparations(t *testing.T) {
 				DesiredNumQueues: 9,
 				QueueLengthLimit: 8,
 				HandSize:         3,
-				RequestWaitLimit: 10 * time.Minute,
 			}
 			seatDemandIntegratorSubject := fq.NewNamedIntegrator(clk, caseName+" seatDemandSubject")
 			qsc, err := qsf.BeginConstruction(qCfg, newGaugePair(clk), newExecSeatsGauge(clk), seatDemandIntegratorSubject)
@@ -704,7 +701,6 @@ func TestUniformFlowsHandSize1(t *testing.T) {
 		DesiredNumQueues: 9,
 		QueueLengthLimit: 8,
 		HandSize:         1,
-		RequestWaitLimit: 10 * time.Minute,
 	}
 	seatDemandIntegratorSubject := fq.NewNamedIntegrator(clk, "seatDemandSubject")
 	qsc, err := qsf.BeginConstruction(qCfg, newGaugePair(clk), newExecSeatsGauge(clk), seatDemandIntegratorSubject)
@@ -743,7 +739,6 @@ func TestUniformFlowsHandSize3(t *testing.T) {
 		DesiredNumQueues: 8,
 		QueueLengthLimit: 16,
 		HandSize:         3,
-		RequestWaitLimit: 10 * time.Minute,
 	}
 	seatDemandIntegratorSubject := fq.NewNamedIntegrator(clk, qCfg.Name)
 	qsc, err := qsf.BeginConstruction(qCfg, newGaugePair(clk), newExecSeatsGauge(clk), seatDemandIntegratorSubject)
@@ -781,7 +776,6 @@ func TestDifferentFlowsExpectEqual(t *testing.T) {
 		DesiredNumQueues: 9,
 		QueueLengthLimit: 8,
 		HandSize:         1,
-		RequestWaitLimit: 10 * time.Minute,
 	}
 	seatDemandIntegratorSubject := fq.NewNamedIntegrator(clk, qCfg.Name)
 	qsc, err := qsf.BeginConstruction(qCfg, newGaugePair(clk), newExecSeatsGauge(clk), seatDemandIntegratorSubject)
@@ -823,7 +817,6 @@ func TestSeatSecondsRollover(t *testing.T) {
 		DesiredNumQueues: 9,
 		QueueLengthLimit: 8,
 		HandSize:         1,
-		RequestWaitLimit: 40 * Quarter,
 	}
 	seatDemandIntegratorSubject := fq.NewNamedIntegrator(clk, qCfg.Name)
 	qsc, err := qsf.BeginConstruction(qCfg, newGaugePair(clk), newExecSeatsGauge(clk), seatDemandIntegratorSubject)
@@ -863,7 +856,6 @@ func TestDifferentFlowsExpectUnequal(t *testing.T) {
 		DesiredNumQueues: 9,
 		QueueLengthLimit: 6,
 		HandSize:         1,
-		RequestWaitLimit: 10 * time.Minute,
 	}
 	seatDemandIntegratorSubject := fq.NewNamedIntegrator(clk, qCfg.Name)
 	qsc, err := qsf.BeginConstruction(qCfg, newGaugePair(clk), newExecSeatsGauge(clk), seatDemandIntegratorSubject)
@@ -902,7 +894,6 @@ func TestDifferentWidths(t *testing.T) {
 		DesiredNumQueues: 64,
 		QueueLengthLimit: 13,
 		HandSize:         7,
-		RequestWaitLimit: 10 * time.Minute,
 	}
 	seatDemandIntegratorSubject := fq.NewNamedIntegrator(clk, qCfg.Name)
 	qsc, err := qsf.BeginConstruction(qCfg, newGaugePair(clk), newExecSeatsGauge(clk), seatDemandIntegratorSubject)
@@ -940,7 +931,6 @@ func TestTooWide(t *testing.T) {
 		DesiredNumQueues: 64,
 		QueueLengthLimit: 35,
 		HandSize:         7,
-		RequestWaitLimit: 10 * time.Minute,
 	}
 	seatDemandIntegratorSubject := fq.NewNamedIntegrator(clk, qCfg.Name)
 	qsc, err := qsf.BeginConstruction(qCfg, newGaugePair(clk), newExecSeatsGauge(clk), seatDemandIntegratorSubject)
@@ -1003,7 +993,6 @@ func TestWindup(t *testing.T) {
 				DesiredNumQueues: 9,
 				QueueLengthLimit: 6,
 				HandSize:         1,
-				RequestWaitLimit: 10 * time.Minute,
 			}
 			seatDemandIntegratorSubject := fq.NewNamedIntegrator(clk, qCfg.Name)
 			qsc, err := qsf.BeginConstruction(qCfg, newGaugePair(clk), newExecSeatsGauge(clk), seatDemandIntegratorSubject)
@@ -1078,7 +1067,7 @@ func TestTimeout(t *testing.T) {
 		DesiredNumQueues: 128,
 		QueueLengthLimit: 128,
 		HandSize:         1,
-		RequestWaitLimit: 0,
+		RequestWaitLimit: time.Second,
 	}
 	seatDemandIntegratorSubject := fq.NewNamedIntegrator(clk, qCfg.Name)
 	qsc, err := qsf.BeginConstruction(qCfg, newGaugePair(clk), newExecSeatsGauge(clk), seatDemandIntegratorSubject)
@@ -1131,7 +1120,6 @@ func TestContextCancel(t *testing.T) {
 		DesiredNumQueues: 11,
 		QueueLengthLimit: 11,
 		HandSize:         1,
-		RequestWaitLimit: 15 * time.Second,
 	}
 	seatDemandIntegratorSubject := fq.NewNamedIntegrator(clk, qCfg.Name)
 	qsc, err := qsf.BeginConstruction(qCfg, newGaugePair(clk), newExecSeatsGauge(clk), seatDemandIntegratorSubject)
@@ -1175,17 +1163,8 @@ func TestContextCancel(t *testing.T) {
 		defer counter.Add(-1) // account completion of this goroutine
 		idle1 = req1.Finish(func() {
 			executed1 = true
-			ctx2, cancel2 := context.WithCancel(context.Background())
+			ctx2 := testpromise.NewQueueWaitTimeWithContext(context.Background(), time.Second)
 			tBefore := clk.Now()
-			counter.Add(1) // account for the following goroutine
-			go func() {
-				defer counter.Add(-1) // account completion of this goroutine
-				clk.Sleep(time.Second)
-				expectQNCounts(2, 0, 1)
-				// account for unblocking the goroutine that waits on cancelation
-				counter.Add(1)
-				cancel2()
-			}()
 			req2, idle2a := qs.StartRequest(ctx2, &fcrequest.WorkEstimate{InitialSeats: 1}, 2, "", "fs2", "test", "two", queueNoteFn(2))
 			if idle2a {
 				t.Error("2nd StartRequest returned idle")
@@ -1224,7 +1203,7 @@ func TestContextCancel(t *testing.T) {
 func countingPromiseFactoryFactory(activeCounter counter.GoRoutineCounter) promiseFactoryFactory {
 	return func(qs *queueSet) promiseFactory {
 		return func(initial interface{}, doneCtx context.Context, doneVal interface{}) promise.WriteOnce {
-			return testpromise.NewCountingWriteOnce(activeCounter, &qs.lock, initial, doneCtx.Done(), doneVal)
+			return testpromise.NewCountingWriteOnce(doneCtx, qs.clock, activeCounter, &qs.lock, initial, doneVal)
 		}
 	}
 }
@@ -1238,7 +1217,6 @@ func TestTotalRequestsExecutingWithPanic(t *testing.T) {
 	qCfg := fq.QueuingConfig{
 		Name:             "TestTotalRequestsExecutingWithPanic",
 		DesiredNumQueues: 0,
-		RequestWaitLimit: 15 * time.Second,
 	}
 	qsc, err := qsf.BeginConstruction(qCfg, newGaugePair(clk), newExecSeatsGauge(clk), fq.NewNamedIntegrator(clk, qCfg.Name))
 	if err != nil {

--- a/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/queueset/queueset_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/queueset/queueset_test.go
@@ -545,7 +545,7 @@ func TestBaseline(t *testing.T) {
 	now := time.Now()
 
 	clk, counter := testeventclock.NewFake(now, 0, nil)
-	qsf := newTestableQueueSetFactory(clk, countingPromiseFactoryFactory(counter))
+	qsf := newTestableQueueSetFactory(clk, countingPromiseFactoryFactory(counter), test.NewFakeQueueWait())
 	qCfg := fq.QueuingConfig{
 		Name:             "TestBaseline",
 		DesiredNumQueues: 9,
@@ -584,7 +584,7 @@ func TestExampt(t *testing.T) {
 		t.Run(fmt.Sprintf("concurrency=%d", concurrencyLimit), func(t *testing.T) {
 			now := time.Now()
 			clk, counter := testeventclock.NewFake(now, 0, nil)
-			qsf := newTestableQueueSetFactory(clk, countingPromiseFactoryFactory(counter))
+			qsf := newTestableQueueSetFactory(clk, countingPromiseFactoryFactory(counter), test.NewFakeQueueWait())
 			qCfg := fq.QueuingConfig{
 				Name:             "TestBaseline",
 				DesiredNumQueues: -1,
@@ -657,7 +657,7 @@ func TestSeparations(t *testing.T) {
 			now := time.Now()
 
 			clk, counter := testeventclock.NewFake(now, 0, nil)
-			qsf := newTestableQueueSetFactory(clk, countingPromiseFactoryFactory(counter))
+			qsf := newTestableQueueSetFactory(clk, countingPromiseFactoryFactory(counter), test.NewFakeQueueWait())
 			qCfg := fq.QueuingConfig{
 				Name:             "TestSeparations/" + caseName,
 				DesiredNumQueues: 9,
@@ -698,7 +698,7 @@ func TestUniformFlowsHandSize1(t *testing.T) {
 	now := time.Now()
 
 	clk, counter := testeventclock.NewFake(now, 0, nil)
-	qsf := newTestableQueueSetFactory(clk, countingPromiseFactoryFactory(counter))
+	qsf := newTestableQueueSetFactory(clk, countingPromiseFactoryFactory(counter), test.NewFakeQueueWait())
 	qCfg := fq.QueuingConfig{
 		Name:             "TestUniformFlowsHandSize1",
 		DesiredNumQueues: 9,
@@ -737,7 +737,7 @@ func TestUniformFlowsHandSize3(t *testing.T) {
 	now := time.Now()
 
 	clk, counter := testeventclock.NewFake(now, 0, nil)
-	qsf := newTestableQueueSetFactory(clk, countingPromiseFactoryFactory(counter))
+	qsf := newTestableQueueSetFactory(clk, countingPromiseFactoryFactory(counter), test.NewFakeQueueWait())
 	qCfg := fq.QueuingConfig{
 		Name:             "TestUniformFlowsHandSize3",
 		DesiredNumQueues: 8,
@@ -775,7 +775,7 @@ func TestDifferentFlowsExpectEqual(t *testing.T) {
 	now := time.Now()
 
 	clk, counter := testeventclock.NewFake(now, 0, nil)
-	qsf := newTestableQueueSetFactory(clk, countingPromiseFactoryFactory(counter))
+	qsf := newTestableQueueSetFactory(clk, countingPromiseFactoryFactory(counter), test.NewFakeQueueWait())
 	qCfg := fq.QueuingConfig{
 		Name:             "DiffFlowsExpectEqual",
 		DesiredNumQueues: 9,
@@ -817,7 +817,7 @@ func TestSeatSecondsRollover(t *testing.T) {
 	const Quarter = 91 * 24 * time.Hour
 
 	clk, counter := testeventclock.NewFake(now, 0, nil)
-	qsf := newTestableQueueSetFactory(clk, countingPromiseFactoryFactory(counter))
+	qsf := newTestableQueueSetFactory(clk, countingPromiseFactoryFactory(counter), test.NewFakeQueueWait())
 	qCfg := fq.QueuingConfig{
 		Name:             "TestSeatSecondsRollover",
 		DesiredNumQueues: 9,
@@ -857,7 +857,7 @@ func TestDifferentFlowsExpectUnequal(t *testing.T) {
 	now := time.Now()
 
 	clk, counter := testeventclock.NewFake(now, 0, nil)
-	qsf := newTestableQueueSetFactory(clk, countingPromiseFactoryFactory(counter))
+	qsf := newTestableQueueSetFactory(clk, countingPromiseFactoryFactory(counter), test.NewFakeQueueWait())
 	qCfg := fq.QueuingConfig{
 		Name:             "DiffFlowsExpectUnequal",
 		DesiredNumQueues: 9,
@@ -896,7 +896,7 @@ func TestDifferentWidths(t *testing.T) {
 	now := time.Now()
 
 	clk, counter := testeventclock.NewFake(now, 0, nil)
-	qsf := newTestableQueueSetFactory(clk, countingPromiseFactoryFactory(counter))
+	qsf := newTestableQueueSetFactory(clk, countingPromiseFactoryFactory(counter), test.NewFakeQueueWait())
 	qCfg := fq.QueuingConfig{
 		Name:             "TestDifferentWidths",
 		DesiredNumQueues: 64,
@@ -934,7 +934,7 @@ func TestTooWide(t *testing.T) {
 	now := time.Now()
 
 	clk, counter := testeventclock.NewFake(now, 0, nil)
-	qsf := newTestableQueueSetFactory(clk, countingPromiseFactoryFactory(counter))
+	qsf := newTestableQueueSetFactory(clk, countingPromiseFactoryFactory(counter), test.NewFakeQueueWait())
 	qCfg := fq.QueuingConfig{
 		Name:             "TestTooWide",
 		DesiredNumQueues: 64,
@@ -997,7 +997,7 @@ func TestWindup(t *testing.T) {
 		t.Run(testCase.name, func(t *testing.T) {
 			now := time.Now()
 			clk, counter := testeventclock.NewFake(now, 0, nil)
-			qsf := newTestableQueueSetFactory(clk, countingPromiseFactoryFactory(counter))
+			qsf := newTestableQueueSetFactory(clk, countingPromiseFactoryFactory(counter), test.NewFakeQueueWait())
 			qCfg := fq.QueuingConfig{
 				Name:             "TestWindup/" + testCase.name,
 				DesiredNumQueues: 9,
@@ -1037,7 +1037,7 @@ func TestDifferentFlowsWithoutQueuing(t *testing.T) {
 	now := time.Now()
 
 	clk, counter := testeventclock.NewFake(now, 0, nil)
-	qsf := newTestableQueueSetFactory(clk, countingPromiseFactoryFactory(counter))
+	qsf := newTestableQueueSetFactory(clk, countingPromiseFactoryFactory(counter), test.NewFakeQueueWait())
 	qCfg := fq.QueuingConfig{
 		Name:             "TestDifferentFlowsWithoutQueuing",
 		DesiredNumQueues: 0,
@@ -1072,7 +1072,7 @@ func TestTimeout(t *testing.T) {
 	now := time.Now()
 
 	clk, counter := testeventclock.NewFake(now, 0, nil)
-	qsf := newTestableQueueSetFactory(clk, countingPromiseFactoryFactory(counter))
+	qsf := newTestableQueueSetFactory(clk, countingPromiseFactoryFactory(counter), test.NewFakeQueueWait())
 	qCfg := fq.QueuingConfig{
 		Name:             "TestTimeout",
 		DesiredNumQueues: 128,
@@ -1125,7 +1125,7 @@ func TestContextCancel(t *testing.T) {
 	metrics.Reset()
 	now := time.Now()
 	clk, counter := testeventclock.NewFake(now, 0, nil)
-	qsf := newTestableQueueSetFactory(clk, countingPromiseFactoryFactory(counter))
+	qsf := newTestableQueueSetFactory(clk, countingPromiseFactoryFactory(counter), test.NewFakeQueueWait())
 	qCfg := fq.QueuingConfig{
 		Name:             "TestContextCancel",
 		DesiredNumQueues: 11,
@@ -1234,7 +1234,7 @@ func TestTotalRequestsExecutingWithPanic(t *testing.T) {
 	metrics.Reset()
 	now := time.Now()
 	clk, counter := testeventclock.NewFake(now, 0, nil)
-	qsf := newTestableQueueSetFactory(clk, countingPromiseFactoryFactory(counter))
+	qsf := newTestableQueueSetFactory(clk, countingPromiseFactoryFactory(counter), test.NewFakeQueueWait())
 	qCfg := fq.QueuingConfig{
 		Name:             "TestTotalRequestsExecutingWithPanic",
 		DesiredNumQueues: 0,

--- a/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/queueset/queuewait.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/queueset/queuewait.go
@@ -1,0 +1,68 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package queueset
+
+import (
+	"context"
+	"time"
+
+	"k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/eventclock"
+)
+
+// newQueueWaitContextFactory returns a new instance of queueWaitContextFactory
+func newQueueWaitContextFactory(clock eventclock.Interface) *queueWaitFactory {
+	return &queueWaitFactory{
+		clock:    clock,
+		newCtxFn: context.WithTimeout,
+	}
+}
+
+type queueWaitFactory struct {
+	clock eventclock.Interface
+	// comes handy to write unit test
+	newCtxFn func(parent context.Context, timeout time.Duration) (context.Context, context.CancelFunc)
+}
+
+// queueWaitContextFactory returns a new context with a deadline of how
+// long the request is allowed to wait before it is removed from its
+// queue and rejcted.
+// The context.CancelFunc returned must never be nil and the caller is
+// responsible for calling the CancelFunc function for cleanup.
+//   - ctx: the context associated with the request (it may or may
+//     not have a deadline).
+//   - defaultQueueWaitTime: the default wait duration that is used if
+//     the request context does not have any deadline.
+func (qw *queueWaitFactory) GetQueueWaitContext(parent context.Context, defaultQueueWaitTime time.Duration) (context.Context, context.CancelFunc) {
+	if parent.Err() != nil {
+		return parent, func() {}
+	}
+
+	if deadline, ok := parent.Deadline(); ok {
+		// we will allow the request to wait in the queue for one fourth of the time
+		// of its remaining deadline. (This is a new behavior).
+		// if the request context does not have any deadline then we default to
+		// 'defaultQueueWaitTime' which is 15s today. (This is in keeping with
+		// the current behavior)
+		queueWaitTime := deadline.Sub(qw.clock.Now()) / 4
+		if queueWaitTime <= 0 {
+			return parent, func() {}
+		}
+		return qw.newCtxFn(parent, queueWaitTime)
+	}
+
+	return qw.newCtxFn(parent, defaultQueueWaitTime)
+}

--- a/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/queueset/queuewait_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/queueset/queuewait_test.go
@@ -1,0 +1,111 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package queueset
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	testeventclock "k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/testing/eventclock"
+)
+
+func TestGetQueueWaitContext(t *testing.T) {
+	tests := []struct {
+		name                      string
+		defaultQueueWaitTime      time.Duration
+		parent                    func(t time.Time) (context.Context, context.CancelFunc)
+		queueWaitCtxExpected      bool
+		queueWaitDeadlineExpected time.Duration
+	}{
+		{
+			name:                 "parent context has already expired",
+			defaultQueueWaitTime: 15 * time.Second,
+			parent: func(_ time.Time) (context.Context, context.CancelFunc) {
+				ctx, cancel := context.WithCancel(context.Background())
+				defer cancel()
+				return ctx, cancel
+			},
+			queueWaitCtxExpected: false,
+		},
+		{
+			name:                 "parent context has a deadline, queue wait deadline should be approximately one fourth",
+			defaultQueueWaitTime: 30 * time.Second,
+			parent: func(t time.Time) (context.Context, context.CancelFunc) {
+				return context.WithDeadline(context.Background(), t.Add(40*time.Second))
+			},
+			queueWaitCtxExpected:      true,
+			queueWaitDeadlineExpected: 10 * time.Second,
+		},
+		{
+			name:                 "parent does not have any deadline",
+			defaultQueueWaitTime: 15 * time.Second,
+			parent: func(_ time.Time) (context.Context, context.CancelFunc) {
+				return context.WithCancel(context.Background())
+			},
+			queueWaitCtxExpected:      true,
+			queueWaitDeadlineExpected: 15 * time.Second,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			now := time.Now()
+			parent, cancel := test.parent(now)
+			defer cancel()
+
+			clock, _ := testeventclock.NewFake(now, 0, nil)
+			qw := newQueueWaitContextFactory(clock)
+
+			var queueWaitTimeGot time.Duration
+			var parentGot context.Context
+			delegatedCtxFn := qw.newCtxFn
+			qw.newCtxFn = func(parent context.Context, queueWaitTime time.Duration) (context.Context, context.CancelFunc) {
+				parentGot = parent
+				queueWaitTimeGot = queueWaitTime
+				return delegatedCtxFn(parent, queueWaitTime)
+			}
+			queueWaitCtxGot, cancelGot := qw.GetQueueWaitContext(parent, test.defaultQueueWaitTime)
+			if cancelGot == nil {
+				t.Errorf("Expected a non nil context.CancelFunc")
+				return
+			}
+			defer cancelGot()
+
+			switch {
+			case test.queueWaitCtxExpected:
+				if _, ok := queueWaitCtxGot.Deadline(); !ok {
+					t.Errorf("Expected the context to have a deadline")
+				}
+				if test.queueWaitDeadlineExpected != queueWaitTimeGot {
+					t.Errorf("Expected the context with a deadline of %s, but got: %s", test.queueWaitDeadlineExpected, queueWaitTimeGot)
+				}
+				if parent != parentGot {
+					t.Errorf("Expected the parent context to be used")
+				}
+
+			default:
+				if queueWaitCtxGot != parent {
+					t.Errorf("Expected the parent context to be returned")
+				}
+				if parentGot != nil {
+					t.Errorf("Did not expect the new context func to be invoked")
+				}
+			}
+		})
+	}
+}

--- a/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/queueset/types.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/queueset/types.go
@@ -54,6 +54,13 @@ type request struct {
 	// decision.Get is called without the queueSet locked.
 	decision promise.WriteOnce
 
+	// queueWaitDeadlineCtxCancel is the context.CancelFunc
+	// associated with the queue wait deadline context.
+	// It is nil if a request is not enqueued.
+	// This should be called as soon as the request queue wait
+	// is over in order to prevent memory leaking.
+	queueWaitDeadlineCtxCancel context.CancelFunc
+
 	// arrivalTime is the real time when the request entered this system
 	arrivalTime time.Time
 

--- a/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/testing/fake_queuewait.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/testing/fake_queuewait.go
@@ -1,0 +1,32 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testing
+
+import (
+	"context"
+	"time"
+)
+
+func NewFakeQueueWait() fakeQueueWait {
+	return fakeQueueWait{}
+}
+
+type fakeQueueWait struct{}
+
+func (qw fakeQueueWait) GetQueueWaitContext(parent context.Context, defaultQueueWaitTime time.Duration) (context.Context, context.CancelFunc) {
+	return parent, func() {}
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1569,12 +1569,14 @@ k8s.io/apiserver/pkg/util/apihelpers
 k8s.io/apiserver/pkg/util/dryrun
 k8s.io/apiserver/pkg/util/feature
 k8s.io/apiserver/pkg/util/flowcontrol
+k8s.io/apiserver/pkg/util/flowcontrol/counter
 k8s.io/apiserver/pkg/util/flowcontrol/debug
 k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing
 k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/eventclock
 k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/promise
 k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/queueset
 k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/testing
+k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/testing/promise
 k8s.io/apiserver/pkg/util/flowcontrol/format
 k8s.io/apiserver/pkg/util/flowcontrol/metrics
 k8s.io/apiserver/pkg/util/flowcontrol/request


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:
manage request queue wait with deadline bound context

#### Which issue(s) this PR fixes:
Fixes #119799

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
