### PR TITLE
PodSecurity: Add runAsUser check to restricted policy

### DIFF
--- a/staging/src/k8s.io/pod-security-admission/policy/check_runAsUser.go
+++ b/staging/src/k8s.io/pod-security-admission/policy/check_runAsUser.go
@@ -1,0 +1,99 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package policy
+
+import (
+	"fmt"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/pod-security-admission/api"
+)
+
+/*
+Containers must not set runAsUser: 0
+
+**Restricted Fields:**
+
+spec.securityContext.runAsUser
+spec.containers[*].securityContext.runAsUser
+spec.initContainers[*].securityContext.runAsUser
+
+**Allowed Values:**
+non-zero values
+undefined/null
+
+*/
+
+func init() {
+	addCheck(CheckRunAsUser)
+}
+
+// CheckRunAsUser returns a restricted level check
+// that forbides runAsUser=0 in 1.23+
+func CheckRunAsUser() Check {
+	return Check{
+		ID:    "runAsUser",
+		Level: api.LevelRestricted,
+		Versions: []VersionedCheck{
+			{
+				MinimumVersion: api.MajorMinorVersion(1, 23),
+				CheckPod:       runAsUser_1_23,
+			},
+		},
+	}
+}
+
+func runAsUser_1_23(podMetadata *metav1.ObjectMeta, podSpec *corev1.PodSpec) CheckResult {
+	// things that explicitly set runAsUser=0
+	var badSetters []string
+
+	if podSpec.SecurityContext != nil && podSpec.SecurityContext.RunAsUser != nil && *podSpec.SecurityContext.RunAsUser == 0 {
+		badSetters = append(badSetters, "pod")
+	}
+
+	// containers that explicitly set runAsUser=0
+	var explicitlyBadContainers []string
+
+	visitContainers(podSpec, func(container *corev1.Container) {
+		if container.SecurityContext != nil && container.SecurityContext.RunAsUser != nil && *container.SecurityContext.RunAsUser == 0 {
+			explicitlyBadContainers = append(explicitlyBadContainers, container.Name)
+		}
+	})
+
+	if len(explicitlyBadContainers) > 0 {
+		badSetters = append(
+			badSetters,
+			fmt.Sprintf(
+				"%s %s",
+				pluralize("container", "containers", len(explicitlyBadContainers)),
+				joinQuote(explicitlyBadContainers),
+			),
+		)
+	}
+	// pod or containers explicitly set runAsUser=0
+	if len(badSetters) > 0 {
+		return CheckResult{
+			Allowed:         false,
+			ForbiddenReason: "runAsUser=0",
+			ForbiddenDetail: fmt.Sprintf("%s must not set runAsUser=0", strings.Join(badSetters, " and ")),
+		}
+	}
+
+	return CheckResult{Allowed: true}
+}

--- a/staging/src/k8s.io/pod-security-admission/policy/check_runAsUser_test.go
+++ b/staging/src/k8s.io/pod-security-admission/policy/check_runAsUser_test.go
@@ -1,0 +1,115 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package policy
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	utilpointer "k8s.io/utils/pointer"
+)
+
+func TestRunAsUser(t *testing.T) {
+	tests := []struct {
+		name         string
+		pod          *corev1.Pod
+		expectAllow  bool
+		expectReason string
+		expectDetail string
+	}{
+		{
+			name: "pod runAsUser=0",
+			pod: &corev1.Pod{Spec: corev1.PodSpec{
+				SecurityContext: &corev1.PodSecurityContext{RunAsUser: utilpointer.Int64(0)},
+				Containers: []corev1.Container{
+					{Name: "a", SecurityContext: nil},
+				},
+			}},
+			expectReason: `runAsUser=0`,
+			expectDetail: `pod must not set runAsUser=0`,
+		},
+		{
+			name: "pod runAsUser=non-zero",
+			pod: &corev1.Pod{Spec: corev1.PodSpec{
+				SecurityContext: &corev1.PodSecurityContext{RunAsUser: utilpointer.Int64(1000)},
+				Containers: []corev1.Container{
+					{Name: "a", SecurityContext: nil},
+				},
+			}},
+			expectAllow: true,
+		},
+		{
+			name: "pod runAsUser=nil",
+			pod: &corev1.Pod{Spec: corev1.PodSpec{
+				SecurityContext: &corev1.PodSecurityContext{RunAsUser: nil},
+				Containers: []corev1.Container{
+					{Name: "a", SecurityContext: nil},
+				},
+			}},
+			expectAllow: true,
+		},
+		{
+			name: "containers runAsUser=0",
+			pod: &corev1.Pod{Spec: corev1.PodSpec{
+				SecurityContext: &corev1.PodSecurityContext{RunAsUser: utilpointer.Int64(1000)},
+				Containers: []corev1.Container{
+					{Name: "a", SecurityContext: nil},
+					{Name: "b", SecurityContext: &corev1.SecurityContext{}},
+					{Name: "c", SecurityContext: &corev1.SecurityContext{RunAsUser: utilpointer.Int64(0)}},
+					{Name: "d", SecurityContext: &corev1.SecurityContext{RunAsUser: utilpointer.Int64(0)}},
+					{Name: "e", SecurityContext: &corev1.SecurityContext{RunAsUser: utilpointer.Int64(1)}},
+					{Name: "f", SecurityContext: &corev1.SecurityContext{RunAsUser: utilpointer.Int64(1)}},
+				},
+			}},
+			expectReason: `runAsUser=0`,
+			expectDetail: `containers "c", "d" must not set runAsUser=0`,
+		},
+		{
+			name: "containers runAsUser=non-zero",
+			pod: &corev1.Pod{Spec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{Name: "c", SecurityContext: &corev1.SecurityContext{RunAsUser: utilpointer.Int64(1)}},
+					{Name: "d", SecurityContext: &corev1.SecurityContext{RunAsUser: utilpointer.Int64(2)}},
+					{Name: "e", SecurityContext: &corev1.SecurityContext{RunAsUser: utilpointer.Int64(3)}},
+					{Name: "f", SecurityContext: &corev1.SecurityContext{RunAsUser: utilpointer.Int64(4)}},
+				},
+			}},
+			expectAllow: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result := runAsUser_1_23(&tc.pod.ObjectMeta, &tc.pod.Spec)
+			if tc.expectAllow {
+				if !result.Allowed {
+					t.Fatalf("expected to be allowed, disallowed: %s, %s", result.ForbiddenReason, result.ForbiddenDetail)
+				}
+				return
+			}
+			if result.Allowed {
+				t.Fatal("expected disallowed")
+			}
+			if e, a := tc.expectReason, result.ForbiddenReason; e != a {
+				t.Errorf("expected\n%s\ngot\n%s", e, a)
+			}
+			if e, a := tc.expectDetail, result.ForbiddenDetail; e != a {
+				t.Errorf("expected\n%s\ngot\n%s", e, a)
+			}
+		})
+	}
+}

--- a/staging/src/k8s.io/pod-security-admission/test/fixtures_runAsUser.go
+++ b/staging/src/k8s.io/pod-security-admission/test/fixtures_runAsUser.go
@@ -1,0 +1,66 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package test
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/pod-security-admission/api"
+	"k8s.io/utils/pointer"
+)
+
+/*
+TODO: include field paths in reflect-based unit test
+
+podFields: []string{
+	`securityContext.runAsUser`,
+},
+containerFields: []string{
+	`securityContext.runAsUser`,
+},
+
+*/
+
+func init() {
+
+	fixtureData_1_23 := fixtureGenerator{
+		generatePass: func(p *corev1.Pod) []*corev1.Pod {
+			p = ensureSecurityContext(p)
+			return []*corev1.Pod{
+				tweak(p, func(p *corev1.Pod) {
+					p.Spec.SecurityContext.RunAsUser = pointer.Int64Ptr(1000)
+					p.Spec.Containers[0].SecurityContext.RunAsUser = pointer.Int64Ptr(1000)
+					p.Spec.InitContainers[0].SecurityContext.RunAsUser = pointer.Int64Ptr(1000)
+				}),
+			}
+		},
+		generateFail: func(p *corev1.Pod) []*corev1.Pod {
+			p = ensureSecurityContext(p)
+			return []*corev1.Pod{
+				// explicit 0 on pod
+				tweak(p, func(p *corev1.Pod) { p.Spec.SecurityContext.RunAsUser = pointer.Int64Ptr(0) }),
+				// explicit 0 on containers
+				tweak(p, func(p *corev1.Pod) { p.Spec.Containers[0].SecurityContext.RunAsUser = pointer.Int64Ptr(0) }),
+				tweak(p, func(p *corev1.Pod) { p.Spec.InitContainers[0].SecurityContext.RunAsUser = pointer.Int64Ptr(0) }),
+			}
+		},
+	}
+
+	registerFixtureGenerator(
+		fixtureKey{level: api.LevelRestricted, version: api.MajorMinorVersion(1, 23), check: "runAsUser"},
+		fixtureData_1_23,
+	)
+}

--- a/staging/src/k8s.io/pod-security-admission/test/fixtures_test.go
+++ b/staging/src/k8s.io/pod-security-admission/test/fixtures_test.go
@@ -46,9 +46,17 @@ func TestFixtures(t *testing.T) {
 
 	defaultChecks := policy.DefaultChecks()
 
+	const newestMinorVersionToTest = 22
+
+	policyVersions := computeVersionsToTest(t, defaultChecks)
+	newestMinorVersionWithPolicyChanges := policyVersions[len(policyVersions)-1].Minor()
+
+	if newestMinorVersionToTest < newestMinorVersionWithPolicyChanges {
+		t.Fatalf("fixtures only tested up to %d, but policy changes exist up to %d", newestMinorVersionToTest, newestMinorVersionWithPolicyChanges)
+	}
+
 	for _, level := range []api.Level{api.LevelBaseline, api.LevelRestricted} {
-		// TODO: derive from registered levels
-		for version := 0; version <= 22; version++ {
+		for version := 0; version <= newestMinorVersionToTest; version++ {
 			passDir := filepath.Join("testdata", string(level), fmt.Sprintf("v1.%d", version), "pass")
 			failDir := filepath.Join("testdata", string(level), fmt.Sprintf("v1.%d", version), "fail")
 

--- a/staging/src/k8s.io/pod-security-admission/test/fixtures_test.go
+++ b/staging/src/k8s.io/pod-security-admission/test/fixtures_test.go
@@ -46,7 +46,7 @@ func TestFixtures(t *testing.T) {
 
 	defaultChecks := policy.DefaultChecks()
 
-	const newestMinorVersionToTest = 22
+	const newestMinorVersionToTest = 23
 
 	policyVersions := computeVersionsToTest(t, defaultChecks)
 	newestMinorVersionWithPolicyChanges := policyVersions[len(policyVersions)-1].Minor()

--- a/staging/src/k8s.io/pod-security-admission/test/run.go
+++ b/staging/src/k8s.io/pod-security-admission/test/run.go
@@ -118,10 +118,10 @@ func computeVersionsToTest(t *testing.T, checks []policy.Check) []api.Version {
 	alwaysIncludeVersions := []api.Version{
 		// include the oldest version by default
 		api.MajorMinorVersion(1, 0),
-		// include the release under development (1.22 at time of writing).
+		// include the release under development (1.23 at time of writing).
 		// this can be incremented to the current version whenever is convenient.
 		// TODO: find a way to use api.LatestVersion() here
-		api.MajorMinorVersion(1, 22),
+		api.MajorMinorVersion(1, 23),
 	}
 	for _, version := range alwaysIncludeVersions {
 		seenVersions[version] = true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.23/fail/apparmorprofile0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.23/fail/apparmorprofile0.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    container.apparmor.security.beta.kubernetes.io/container1: unconfined
+  name: apparmorprofile0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.23/fail/apparmorprofile1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.23/fail/apparmorprofile1.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    container.apparmor.security.beta.kubernetes.io/initcontainer1: unconfined
+  name: apparmorprofile1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.23/fail/capabilities_baseline0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.23/fail/capabilities_baseline0.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: capabilities_baseline0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      capabilities:
+        add:
+        - NET_RAW
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      capabilities: {}
+  securityContext: {}

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.23/fail/capabilities_baseline1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.23/fail/capabilities_baseline1.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: capabilities_baseline1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      capabilities: {}
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      capabilities:
+        add:
+        - NET_RAW
+  securityContext: {}

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.23/fail/capabilities_baseline2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.23/fail/capabilities_baseline2.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: capabilities_baseline2
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      capabilities:
+        add:
+        - chown
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      capabilities: {}
+  securityContext: {}

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.23/fail/capabilities_baseline3.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.23/fail/capabilities_baseline3.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: capabilities_baseline3
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      capabilities:
+        add:
+        - CAP_CHOWN
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      capabilities: {}
+  securityContext: {}

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.23/fail/hostnamespaces0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.23/fail/hostnamespaces0.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  hostIPC: true
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.23/fail/hostnamespaces1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.23/fail/hostnamespaces1.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  hostNetwork: true
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.23/fail/hostnamespaces2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.23/fail/hostnamespaces2.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces2
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  hostPID: true
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.23/fail/hostpathvolumes0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.23/fail/hostpathvolumes0.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostpathvolumes0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+  volumes:
+  - emptyDir: {}
+    name: volume-emptydir
+  - hostPath:
+      path: /a
+    name: volume-hostpath

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.23/fail/hostpathvolumes1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.23/fail/hostpathvolumes1.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostpathvolumes1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+  volumes:
+  - hostPath:
+      path: /a
+    name: volume-hostpath-a
+  - hostPath:
+      path: /b
+    name: volume-hostpath-b

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.23/fail/hostports0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.23/fail/hostports0.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    ports:
+    - containerPort: 12345
+      hostPort: 12345
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.23/fail/hostports1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.23/fail/hostports1.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    ports:
+    - containerPort: 12346
+      hostPort: 12346

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.23/fail/hostports2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.23/fail/hostports2.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports2
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    ports:
+    - containerPort: 12345
+      hostPort: 12345
+    - containerPort: 12347
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    ports:
+    - containerPort: 12346
+      hostPort: 12346
+    - containerPort: 12348

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.23/fail/privileged0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.23/fail/privileged0.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: privileged0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      privileged: true
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext: {}
+  securityContext: {}

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.23/fail/privileged1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.23/fail/privileged1.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: privileged1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext: {}
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      privileged: true
+  securityContext: {}

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.23/fail/procmount0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.23/fail/procmount0.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: procmount0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      procMount: Unmasked
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext: {}
+  securityContext: {}

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.23/fail/procmount1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.23/fail/procmount1.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: procmount1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext: {}
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      procMount: Unmasked
+  securityContext: {}

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.23/fail/seccompprofile_baseline0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.23/fail/seccompprofile_baseline0.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: seccompprofile_baseline0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext: {}
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext: {}
+  securityContext:
+    seccompProfile:
+      type: Unconfined

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.23/fail/seccompprofile_baseline1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.23/fail/seccompprofile_baseline1.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: seccompprofile_baseline1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      seccompProfile:
+        type: Unconfined
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext: {}
+  securityContext: {}

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.23/fail/seccompprofile_baseline2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.23/fail/seccompprofile_baseline2.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: seccompprofile_baseline2
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext: {}
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      seccompProfile:
+        type: Unconfined
+  securityContext: {}

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.23/fail/selinuxoptions0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.23/fail/selinuxoptions0.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: selinuxoptions0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      seLinuxOptions: {}
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      seLinuxOptions: {}
+  securityContext:
+    seLinuxOptions:
+      type: somevalue

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.23/fail/selinuxoptions1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.23/fail/selinuxoptions1.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: selinuxoptions1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      seLinuxOptions:
+        type: somevalue
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      seLinuxOptions: {}
+  securityContext:
+    seLinuxOptions: {}

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.23/fail/selinuxoptions2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.23/fail/selinuxoptions2.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: selinuxoptions2
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      seLinuxOptions: {}
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      seLinuxOptions:
+        type: somevalue
+  securityContext:
+    seLinuxOptions: {}

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.23/fail/selinuxoptions3.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.23/fail/selinuxoptions3.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: selinuxoptions3
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      seLinuxOptions: {}
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      seLinuxOptions: {}
+  securityContext:
+    seLinuxOptions:
+      user: somevalue

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.23/fail/selinuxoptions4.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.23/fail/selinuxoptions4.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: selinuxoptions4
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      seLinuxOptions: {}
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      seLinuxOptions: {}
+  securityContext:
+    seLinuxOptions:
+      role: somevalue

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.23/fail/sysctls0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.23/fail/sysctls0.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: sysctls0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+  securityContext:
+    sysctls:
+    - name: othersysctl
+      value: other

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.23/fail/windowshostprocess0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.23/fail/windowshostprocess0.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: windowshostprocess0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      windowsOptions: {}
+  hostNetwork: true
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      windowsOptions: {}
+  securityContext:
+    windowsOptions:
+      hostProcess: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.23/fail/windowshostprocess1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.23/fail/windowshostprocess1.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: windowshostprocess1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      windowsOptions:
+        hostProcess: true
+  hostNetwork: true
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      windowsOptions:
+        hostProcess: true
+  securityContext:
+    windowsOptions: {}

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.23/pass/apparmorprofile0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.23/pass/apparmorprofile0.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    container.apparmor.security.beta.kubernetes.io/container1: localhost/foo
+  name: apparmorprofile0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.23/pass/base.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.23/pass/base.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: base
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.23/pass/capabilities_baseline0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.23/pass/capabilities_baseline0.yaml
@@ -1,0 +1,44 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: capabilities_baseline0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      capabilities:
+        add:
+        - AUDIT_WRITE
+        - CHOWN
+        - DAC_OVERRIDE
+        - FOWNER
+        - FSETID
+        - KILL
+        - MKNOD
+        - NET_BIND_SERVICE
+        - SETFCAP
+        - SETGID
+        - SETPCAP
+        - SETUID
+        - SYS_CHROOT
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      capabilities:
+        add:
+        - AUDIT_WRITE
+        - CHOWN
+        - DAC_OVERRIDE
+        - FOWNER
+        - FSETID
+        - KILL
+        - MKNOD
+        - NET_BIND_SERVICE
+        - SETFCAP
+        - SETGID
+        - SETPCAP
+        - SETUID
+        - SYS_CHROOT
+  securityContext: {}

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.23/pass/hostports0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.23/pass/hostports0.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    ports:
+    - containerPort: 12345
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    ports:
+    - containerPort: 12346

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.23/pass/privileged0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.23/pass/privileged0.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: privileged0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      privileged: false
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      privileged: false
+  securityContext: {}

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.23/pass/procmount0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.23/pass/procmount0.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: procmount0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      procMount: Default
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      procMount: Default
+  securityContext: {}

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.23/pass/seccompprofile_baseline0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.23/pass/seccompprofile_baseline0.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: seccompprofile_baseline0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      seccompProfile:
+        type: RuntimeDefault
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext: {}
+  securityContext:
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.23/pass/selinuxoptions0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.23/pass/selinuxoptions0.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: selinuxoptions0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext: {}
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      seLinuxOptions: {}
+  securityContext: {}

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.23/pass/selinuxoptions1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.23/pass/selinuxoptions1.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: selinuxoptions1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      seLinuxOptions:
+        level: somevalue
+        type: container_init_t
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      seLinuxOptions:
+        type: container_kvm_t
+  securityContext:
+    seLinuxOptions:
+      type: container_t

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.23/pass/sysctls0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.23/pass/sysctls0.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: sysctls0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+  securityContext: {}

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.23/pass/sysctls1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.23/pass/sysctls1.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: sysctls1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+  securityContext:
+    sysctls:
+    - name: kernel.shm_rmid_forced
+      value: "0"
+    - name: net.ipv4.ip_local_port_range
+      value: 1024 65535
+    - name: net.ipv4.tcp_syncookies
+      value: "0"
+    - name: net.ipv4.ping_group_range
+      value: 1 0
+    - name: net.ipv4.ip_unprivileged_port_start
+      value: "1024"

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.23/fail/allowprivilegeescalation0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.23/fail/allowprivilegeescalation0.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: allowprivilegeescalation0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: true
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.23/fail/allowprivilegeescalation1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.23/fail/allowprivilegeescalation1.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: allowprivilegeescalation1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: true
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.23/fail/allowprivilegeescalation2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.23/fail/allowprivilegeescalation2.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: allowprivilegeescalation2
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.23/fail/allowprivilegeescalation3.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.23/fail/allowprivilegeescalation3.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: allowprivilegeescalation3
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.23/fail/apparmorprofile0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.23/fail/apparmorprofile0.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    container.apparmor.security.beta.kubernetes.io/container1: unconfined
+  name: apparmorprofile0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.23/fail/apparmorprofile1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.23/fail/apparmorprofile1.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    container.apparmor.security.beta.kubernetes.io/initcontainer1: unconfined
+  name: apparmorprofile1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.23/fail/capabilities_baseline0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.23/fail/capabilities_baseline0.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: capabilities_baseline0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        add:
+        - NET_RAW
+        drop:
+        - ALL
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.23/fail/capabilities_baseline1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.23/fail/capabilities_baseline1.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: capabilities_baseline1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        add:
+        - NET_RAW
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.23/fail/capabilities_baseline2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.23/fail/capabilities_baseline2.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: capabilities_baseline2
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        add:
+        - chown
+        drop:
+        - ALL
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.23/fail/capabilities_baseline3.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.23/fail/capabilities_baseline3.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: capabilities_baseline3
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        add:
+        - CAP_CHOWN
+        drop:
+        - ALL
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.23/fail/capabilities_restricted0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.23/fail/capabilities_restricted0.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: capabilities_restricted0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities: {}
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.23/fail/capabilities_restricted1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.23/fail/capabilities_restricted1.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: capabilities_restricted1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities: {}
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.23/fail/capabilities_restricted2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.23/fail/capabilities_restricted2.yaml
@@ -1,0 +1,97 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: capabilities_restricted2
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - SYS_TIME
+        - SYS_MODULE
+        - SYS_RAWIO
+        - SYS_PACCT
+        - SYS_ADMIN
+        - SYS_NICE
+        - SYS_RESOURCE
+        - SYS_TIME
+        - SYS_TTY_CONFIG
+        - MKNOD
+        - AUDIT_WRITE
+        - AUDIT_CONTROL
+        - MAC_OVERRIDE
+        - MAC_ADMIN
+        - NET_ADMIN
+        - SYSLOG
+        - CHOWN
+        - NET_RAW
+        - DAC_OVERRIDE
+        - FOWNER
+        - DAC_READ_SEARCH
+        - FSETID
+        - KILL
+        - SETGID
+        - SETUID
+        - LINUX_IMMUTABLE
+        - NET_BIND_SERVICE
+        - NET_BROADCAST
+        - IPC_LOCK
+        - IPC_OWNER
+        - SYS_CHROOT
+        - SYS_PTRACE
+        - SYS_BOOT
+        - LEASE
+        - SETFCAP
+        - WAKE_ALARM
+        - BLOCK_SUSPEND
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - SYS_TIME
+        - SYS_MODULE
+        - SYS_RAWIO
+        - SYS_PACCT
+        - SYS_ADMIN
+        - SYS_NICE
+        - SYS_RESOURCE
+        - SYS_TIME
+        - SYS_TTY_CONFIG
+        - MKNOD
+        - AUDIT_WRITE
+        - AUDIT_CONTROL
+        - MAC_OVERRIDE
+        - MAC_ADMIN
+        - NET_ADMIN
+        - SYSLOG
+        - CHOWN
+        - NET_RAW
+        - DAC_OVERRIDE
+        - FOWNER
+        - DAC_READ_SEARCH
+        - FSETID
+        - KILL
+        - SETGID
+        - SETUID
+        - LINUX_IMMUTABLE
+        - NET_BIND_SERVICE
+        - NET_BROADCAST
+        - IPC_LOCK
+        - IPC_OWNER
+        - SYS_CHROOT
+        - SYS_PTRACE
+        - SYS_BOOT
+        - LEASE
+        - SETFCAP
+        - WAKE_ALARM
+        - BLOCK_SUSPEND
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.23/fail/capabilities_restricted3.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.23/fail/capabilities_restricted3.yaml
@@ -1,0 +1,53 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: capabilities_restricted3
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        add:
+        - AUDIT_WRITE
+        - CHOWN
+        - DAC_OVERRIDE
+        - FOWNER
+        - FSETID
+        - KILL
+        - MKNOD
+        - NET_BIND_SERVICE
+        - SETFCAP
+        - SETGID
+        - SETPCAP
+        - SETUID
+        - SYS_CHROOT
+        drop:
+        - ALL
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        add:
+        - AUDIT_WRITE
+        - CHOWN
+        - DAC_OVERRIDE
+        - FOWNER
+        - FSETID
+        - KILL
+        - MKNOD
+        - NET_BIND_SERVICE
+        - SETFCAP
+        - SETGID
+        - SETPCAP
+        - SETUID
+        - SYS_CHROOT
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.23/fail/hostnamespaces0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.23/fail/hostnamespaces0.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  hostIPC: true
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.23/fail/hostnamespaces1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.23/fail/hostnamespaces1.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  hostNetwork: true
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.23/fail/hostnamespaces2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.23/fail/hostnamespaces2.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces2
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  hostPID: true
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.23/fail/hostpathvolumes0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.23/fail/hostpathvolumes0.yaml
@@ -1,0 +1,31 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostpathvolumes0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  volumes:
+  - emptyDir: {}
+    name: volume-emptydir
+  - hostPath:
+      path: /a
+    name: volume-hostpath

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.23/fail/hostpathvolumes1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.23/fail/hostpathvolumes1.yaml
@@ -1,0 +1,32 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostpathvolumes1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  volumes:
+  - hostPath:
+      path: /a
+    name: volume-hostpath-a
+  - hostPath:
+      path: /b
+    name: volume-hostpath-b

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.23/fail/hostports0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.23/fail/hostports0.yaml
@@ -1,0 +1,28 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    ports:
+    - containerPort: 12345
+      hostPort: 12345
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.23/fail/hostports1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.23/fail/hostports1.yaml
@@ -1,0 +1,28 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    ports:
+    - containerPort: 12346
+      hostPort: 12346
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.23/fail/hostports2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.23/fail/hostports2.yaml
@@ -1,0 +1,33 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports2
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    ports:
+    - containerPort: 12345
+      hostPort: 12345
+    - containerPort: 12347
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    ports:
+    - containerPort: 12346
+      hostPort: 12346
+    - containerPort: 12348
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.23/fail/privileged0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.23/fail/privileged0.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: privileged0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      capabilities:
+        drop:
+        - ALL
+      privileged: true
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.23/fail/privileged1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.23/fail/privileged1.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: privileged1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      capabilities:
+        drop:
+        - ALL
+      privileged: true
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.23/fail/procmount0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.23/fail/procmount0.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: procmount0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      procMount: Unmasked
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.23/fail/procmount1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.23/fail/procmount1.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: procmount1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      procMount: Unmasked
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.23/fail/restrictedvolumes0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.23/fail/restrictedvolumes0.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: restrictedvolumes0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  volumes:
+  - gcePersistentDisk:
+      pdName: test
+    name: volume1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.23/fail/restrictedvolumes1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.23/fail/restrictedvolumes1.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: restrictedvolumes1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  volumes:
+  - awsElasticBlockStore:
+      volumeID: test
+    name: volume1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.23/fail/restrictedvolumes10.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.23/fail/restrictedvolumes10.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: restrictedvolumes10
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  volumes:
+  - flocker:
+      datasetName: test
+    name: volume1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.23/fail/restrictedvolumes11.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.23/fail/restrictedvolumes11.yaml
@@ -1,0 +1,30 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: restrictedvolumes11
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  volumes:
+  - fc:
+      wwids:
+      - test
+    name: volume1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.23/fail/restrictedvolumes12.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.23/fail/restrictedvolumes12.yaml
@@ -1,0 +1,30 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: restrictedvolumes12
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  volumes:
+  - azureFile:
+      secretName: test
+      shareName: test
+    name: volume1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.23/fail/restrictedvolumes13.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.23/fail/restrictedvolumes13.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: restrictedvolumes13
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  volumes:
+  - name: volume1
+    vsphereVolume:
+      volumePath: test

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.23/fail/restrictedvolumes14.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.23/fail/restrictedvolumes14.yaml
@@ -1,0 +1,30 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: restrictedvolumes14
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  volumes:
+  - name: volume1
+    quobyte:
+      registry: localhost:1234
+      volume: test

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.23/fail/restrictedvolumes15.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.23/fail/restrictedvolumes15.yaml
@@ -1,0 +1,30 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: restrictedvolumes15
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  volumes:
+  - azureDisk:
+      diskName: test
+      diskURI: https://test.blob.core.windows.net/test/test.vhd
+    name: volume1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.23/fail/restrictedvolumes16.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.23/fail/restrictedvolumes16.yaml
@@ -1,0 +1,30 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: restrictedvolumes16
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  volumes:
+  - name: volume1
+    portworxVolume:
+      fsType: ext4
+      volumeID: test

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.23/fail/restrictedvolumes17.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.23/fail/restrictedvolumes17.yaml
@@ -1,0 +1,32 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: restrictedvolumes17
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  volumes:
+  - name: volume1
+    scaleIO:
+      gateway: localhost
+      secretRef: null
+      system: test
+      volumeName: test

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.23/fail/restrictedvolumes18.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.23/fail/restrictedvolumes18.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: restrictedvolumes18
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  volumes:
+  - name: volume1
+    storageos:
+      volumeName: test

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.23/fail/restrictedvolumes19.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.23/fail/restrictedvolumes19.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: restrictedvolumes19
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  volumes:
+  - hostPath:
+      path: /dev/null
+    name: volume1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.23/fail/restrictedvolumes2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.23/fail/restrictedvolumes2.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: restrictedvolumes2
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  volumes:
+  - gitRepo:
+      repository: github.com/kubernetes/kubernetes
+    name: volume1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.23/fail/restrictedvolumes3.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.23/fail/restrictedvolumes3.yaml
@@ -1,0 +1,30 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: restrictedvolumes3
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  volumes:
+  - name: volume1
+    nfs:
+      path: /test
+      server: test

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.23/fail/restrictedvolumes4.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.23/fail/restrictedvolumes4.yaml
@@ -1,0 +1,31 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: restrictedvolumes4
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  volumes:
+  - iscsi:
+      iqn: iqn.2001-04.com.example:storage.kube.sys1.xyz
+      lun: 0
+      targetPortal: test
+    name: volume1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.23/fail/restrictedvolumes5.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.23/fail/restrictedvolumes5.yaml
@@ -1,0 +1,30 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: restrictedvolumes5
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  volumes:
+  - glusterfs:
+      endpoints: test
+      path: test
+    name: volume1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.23/fail/restrictedvolumes6.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.23/fail/restrictedvolumes6.yaml
@@ -1,0 +1,31 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: restrictedvolumes6
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  volumes:
+  - name: volume1
+    rbd:
+      image: test
+      monitors:
+      - test

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.23/fail/restrictedvolumes7.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.23/fail/restrictedvolumes7.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: restrictedvolumes7
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  volumes:
+  - flexVolume:
+      driver: test
+    name: volume1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.23/fail/restrictedvolumes8.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.23/fail/restrictedvolumes8.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: restrictedvolumes8
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  volumes:
+  - cinder:
+      volumeID: test
+    name: volume1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.23/fail/restrictedvolumes9.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.23/fail/restrictedvolumes9.yaml
@@ -1,0 +1,30 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: restrictedvolumes9
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  volumes:
+  - cephfs:
+      monitors:
+      - test
+    name: volume1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.23/fail/runasnonroot0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.23/fail/runasnonroot0.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: runasnonroot0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.23/fail/runasnonroot1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.23/fail/runasnonroot1.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: runasnonroot1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: false
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.23/fail/runasnonroot2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.23/fail/runasnonroot2.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: runasnonroot2
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      runAsNonRoot: false
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.23/fail/runasnonroot3.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.23/fail/runasnonroot3.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: runasnonroot3
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      runAsNonRoot: false
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.23/fail/runasuser0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.23/fail/runasuser0.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: runasuser0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    runAsUser: 0
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.23/fail/runasuser1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.23/fail/runasuser1.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: runasuser1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      runAsUser: 0
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.23/fail/runasuser2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.23/fail/runasuser2.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: runasuser2
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      runAsUser: 0
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.23/fail/seccompprofile_baseline0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.23/fail/seccompprofile_baseline0.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: seccompprofile_baseline0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: Unconfined

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.23/fail/seccompprofile_baseline1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.23/fail/seccompprofile_baseline1.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: seccompprofile_baseline1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      seccompProfile:
+        type: Unconfined
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.23/fail/seccompprofile_baseline2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.23/fail/seccompprofile_baseline2.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: seccompprofile_baseline2
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      seccompProfile:
+        type: Unconfined
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.23/fail/seccompprofile_restricted0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.23/fail/seccompprofile_restricted0.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: seccompprofile_restricted0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.23/fail/seccompprofile_restricted1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.23/fail/seccompprofile_restricted1.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: seccompprofile_restricted1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: Unconfined

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.23/fail/seccompprofile_restricted2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.23/fail/seccompprofile_restricted2.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: seccompprofile_restricted2
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      seccompProfile:
+        type: RuntimeDefault
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.23/fail/seccompprofile_restricted3.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.23/fail/seccompprofile_restricted3.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: seccompprofile_restricted3
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      seccompProfile:
+        type: RuntimeDefault
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.23/fail/seccompprofile_restricted4.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.23/fail/seccompprofile_restricted4.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: seccompprofile_restricted4
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      seccompProfile:
+        type: RuntimeDefault
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      seccompProfile:
+        type: Unconfined
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.23/fail/selinuxoptions0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.23/fail/selinuxoptions0.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: selinuxoptions0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      seLinuxOptions: {}
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      seLinuxOptions: {}
+  securityContext:
+    runAsNonRoot: true
+    seLinuxOptions:
+      type: somevalue
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.23/fail/selinuxoptions1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.23/fail/selinuxoptions1.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: selinuxoptions1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      seLinuxOptions:
+        type: somevalue
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      seLinuxOptions: {}
+  securityContext:
+    runAsNonRoot: true
+    seLinuxOptions: {}
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.23/fail/selinuxoptions2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.23/fail/selinuxoptions2.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: selinuxoptions2
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      seLinuxOptions: {}
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      seLinuxOptions:
+        type: somevalue
+  securityContext:
+    runAsNonRoot: true
+    seLinuxOptions: {}
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.23/fail/selinuxoptions3.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.23/fail/selinuxoptions3.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: selinuxoptions3
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      seLinuxOptions: {}
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      seLinuxOptions: {}
+  securityContext:
+    runAsNonRoot: true
+    seLinuxOptions:
+      user: somevalue
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.23/fail/selinuxoptions4.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.23/fail/selinuxoptions4.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: selinuxoptions4
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      seLinuxOptions: {}
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      seLinuxOptions: {}
+  securityContext:
+    runAsNonRoot: true
+    seLinuxOptions:
+      role: somevalue
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.23/fail/sysctls0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.23/fail/sysctls0.yaml
@@ -1,0 +1,28 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: sysctls0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+    sysctls:
+    - name: othersysctl
+      value: other

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.23/fail/windowshostprocess0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.23/fail/windowshostprocess0.yaml
@@ -1,0 +1,30 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: windowshostprocess0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      windowsOptions: {}
+  hostNetwork: true
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      windowsOptions: {}
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+    windowsOptions:
+      hostProcess: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.23/fail/windowshostprocess1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.23/fail/windowshostprocess1.yaml
@@ -1,0 +1,31 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: windowshostprocess1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      windowsOptions:
+        hostProcess: true
+  hostNetwork: true
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      windowsOptions:
+        hostProcess: true
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+    windowsOptions: {}

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.23/pass/apparmorprofile0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.23/pass/apparmorprofile0.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    container.apparmor.security.beta.kubernetes.io/container1: localhost/foo
+  name: apparmorprofile0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.23/pass/base.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.23/pass/base.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: base
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.23/pass/capabilities_restricted0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.23/pass/capabilities_restricted0.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: capabilities_restricted0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        add:
+        - NET_BIND_SERVICE
+        drop:
+        - ALL
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        add:
+        - NET_BIND_SERVICE
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.23/pass/hostports0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.23/pass/hostports0.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    ports:
+    - containerPort: 12345
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    ports:
+    - containerPort: 12346
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.23/pass/privileged0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.23/pass/privileged0.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: privileged0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      privileged: false
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      privileged: false
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.23/pass/procmount0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.23/pass/procmount0.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: procmount0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      procMount: Default
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      procMount: Default
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.23/pass/restrictedvolumes0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.23/pass/restrictedvolumes0.yaml
@@ -1,0 +1,47 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: restrictedvolumes0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  volumes:
+  - name: volume0
+  - emptyDir: {}
+    name: volume1
+  - name: volume2
+    secret:
+      secretName: test
+  - name: volume3
+    persistentVolumeClaim:
+      claimName: test
+  - downwardAPI:
+      items:
+      - fieldRef:
+          fieldPath: metadata.labels
+        path: labels
+    name: volume4
+  - configMap:
+      name: test
+    name: volume5
+  - name: volume6
+    projected:
+      sources: []

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.23/pass/runasnonroot0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.23/pass/runasnonroot0.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: runasnonroot0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.23/pass/runasnonroot1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.23/pass/runasnonroot1.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: runasnonroot1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      runAsNonRoot: true
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      runAsNonRoot: true
+  securityContext:
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.23/pass/runasuser0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.23/pass/runasuser0.yaml
@@ -1,0 +1,28 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: runasuser0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      runAsUser: 1000
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      runAsUser: 1000
+  securityContext:
+    runAsNonRoot: true
+    runAsUser: 1000
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.23/pass/seccompprofile_restricted0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.23/pass/seccompprofile_restricted0.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: seccompprofile_restricted0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.23/pass/seccompprofile_restricted1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.23/pass/seccompprofile_restricted1.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: seccompprofile_restricted1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      localhostProfile: testing
+      type: Localhost

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.23/pass/seccompprofile_restricted2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.23/pass/seccompprofile_restricted2.yaml
@@ -1,0 +1,28 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: seccompprofile_restricted2
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      seccompProfile:
+        type: RuntimeDefault
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      seccompProfile:
+        localhostProfile: testing
+        type: Localhost
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.23/pass/selinuxoptions0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.23/pass/selinuxoptions0.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: selinuxoptions0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      seLinuxOptions: {}
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.23/pass/selinuxoptions1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.23/pass/selinuxoptions1.yaml
@@ -1,0 +1,32 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: selinuxoptions1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      seLinuxOptions:
+        level: somevalue
+        type: container_init_t
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      seLinuxOptions:
+        type: container_kvm_t
+  securityContext:
+    runAsNonRoot: true
+    seLinuxOptions:
+      type: container_t
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.23/pass/sysctls0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.23/pass/sysctls0.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: sysctls0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.23/pass/sysctls1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.23/pass/sysctls1.yaml
@@ -1,0 +1,36 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: sysctls1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+    sysctls:
+    - name: kernel.shm_rmid_forced
+      value: "0"
+    - name: net.ipv4.ip_local_port_range
+      value: 1024 65535
+    - name: net.ipv4.tcp_syncookies
+      value: "0"
+    - name: net.ipv4.ping_group_range
+      value: 1 0
+    - name: net.ipv4.ip_unprivileged_port_start
+      value: "1024"


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### Which issue(s) this PR fixes:
Fixes #105186

1. Add a `runAsUser` restricted check that forbids setting `runAsUser=0` in 1.23+ (previously this would have resulted in a runtime error, now it results in an admission error)
3. Update the test version from 1.22 to 1.23
4. Generate fixtures for 1.23

```release-note
PodSecurity: in 1.23+ restricted policy levels, pods and containers which set runAsUser=0 are forbidden at admission-time; previously, they would be rejected at runtime
```

/assign @tallclair 
/sig auth