### PR TITLE
Shell completion for plugins

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/cmd.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/cmd.go
@@ -279,8 +279,15 @@ func NewKubectlCommand(o KubectlOptions) *cobra.Command {
 		Run: runHelp,
 		// Hook before and after Run initialize and write profiles to disk,
 		// respectively.
-		PersistentPreRunE: func(*cobra.Command, []string) error {
+		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 			rest.SetDefaultWarningHandler(warningHandler)
+
+			if cmd.Name() == cobra.ShellCompRequestCmd {
+				// This is the __complete or __completeNoDesc command which
+				// indicates shell completion has been requested.
+				plugin.SetupPluginCompletion(cmd, args)
+			}
+
 			return initProfiling()
 		},
 		PersistentPostRunE: func(*cobra.Command, []string) error {

--- a/staging/src/k8s.io/kubectl/pkg/cmd/completion/completion.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/completion/completion.go
@@ -17,11 +17,17 @@ limitations under the License.
 package completion
 
 import (
+	"bytes"
 	"fmt"
 	"io"
+	"io/ioutil"
+	"path/filepath"
+	"strings"
 
 	"github.com/spf13/cobra"
 
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/kubectl/pkg/cmd/plugin"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 	"k8s.io/kubectl/pkg/util/i18n"
 	"k8s.io/kubectl/pkg/util/templates"
@@ -155,6 +161,7 @@ func RunCompletion(out io.Writer, boilerPlate string, cmd *cobra.Command, args [
 	if !found {
 		return cmdutil.UsageErrorf(cmd, "Unsupported shell type %q.", args[0])
 	}
+	addPluginCommands(cmd.Root())
 
 	return run(out, boilerPlate, cmd.Parent())
 }
@@ -205,4 +212,48 @@ func runCompletionPwsh(out io.Writer, boilerPlate string, kubectl *cobra.Command
 	}
 
 	return kubectl.GenPowerShellCompletionWithDesc(out)
+}
+
+// addPluginCommand adds plugin commands under the given command so that
+// completion includes them
+func addPluginCommands(kubectl *cobra.Command) {
+	streams := genericclioptions.IOStreams{
+		In:     &bytes.Buffer{},
+		Out:    ioutil.Discard,
+		ErrOut: ioutil.Discard,
+	}
+
+	o := &plugin.PluginListOptions{IOStreams: streams}
+	o.Complete(kubectl)
+	plugins, _ := o.ListPlugins()
+
+	for _, plugin := range plugins {
+		plugin = filepath.Base(plugin)
+		args := []string{}
+
+		// Plugins are named "kubectl-<name>" or with more - such as
+		// "kubectl-<name>-<subcmd1>..."
+		for _, arg := range strings.Split(plugin, "-")[1:] {
+			// Underscores (_) in plugin's filename are replaced with dashes(-)
+			// e.g. foo_bar -> foo-bar
+			args = append(args, strings.Replace(arg, "_", "-", -1))
+		}
+
+		// In order to avoid that the same plugin command is added,
+		// find the lowest command given args from the root command
+		parentCmd, remainingArgs, _ := kubectl.Find(args)
+		if parentCmd == nil {
+			parentCmd = kubectl
+		}
+
+		for _, remainingArg := range remainingArgs {
+			cmd := &cobra.Command{
+				Use: remainingArg,
+				// A Run is required for it to be a valid command
+				Run: func(cmd *cobra.Command, args []string) {},
+			}
+			parentCmd.AddCommand(cmd)
+			parentCmd = cmd
+		}
+	}
 }

--- a/staging/src/k8s.io/kubectl/pkg/cmd/plugin/plugin_completion.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/plugin/plugin_completion.go
@@ -1,0 +1,231 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package plugin
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+)
+
+// SetupPluginCompletion adds a Cobra command to the command tree for each
+// plugin.  This is only done when performing shell completion that relate
+// to plugins.
+func SetupPluginCompletion(cmd *cobra.Command, args []string) {
+	if len(args) > 0 {
+		if strings.HasPrefix(args[0], "-") {
+			// Plugins are not supported if the first argument is a flag,
+			// so no need to add them in that case.
+			return
+		}
+
+		if len(args) == 1 {
+			// We are completing a subcommand at the first level so
+			// we should include all plugins names.
+			addPluginCommands(cmd)
+			return
+		}
+
+		// We have more than one argument.
+		// Check if we know the first level subcommand.
+		// If we don't it could be a plugin and we'll need to add
+		// the plugin commands for completion to work.
+		found := false
+		for _, subCmd := range cmd.Root().Commands() {
+			if args[0] == subCmd.Name() {
+				found = true
+				break
+			}
+		}
+
+		if !found {
+			// We don't know the subcommand for which completion
+			// is being called: it could be a plugin.
+			//
+			// When using a plugin, the kubectl global flags are not supported.
+			// Therefore, when doing completion, we need to remove these flags
+			// to avoid them being included in the completion choices.
+			// This must be done *before* adding the plugin commands so that
+			// when creating those plugin commands, the flags don't exist.
+			cmd.Root().ResetFlags()
+			cobra.CompDebugln("Cleared global flags for plugin completion", true)
+
+			addPluginCommands(cmd)
+		}
+	}
+}
+
+// addPluginCommand adds a Cobra command to the command tree
+// for each plugin so that the completion logic knows about the plugins
+func addPluginCommands(cmd *cobra.Command) {
+	kubectl := cmd.Root()
+	streams := genericclioptions.IOStreams{
+		In:     &bytes.Buffer{},
+		Out:    ioutil.Discard,
+		ErrOut: ioutil.Discard,
+	}
+
+	o := &PluginListOptions{IOStreams: streams}
+	o.Complete(kubectl)
+	plugins, _ := o.ListPlugins()
+
+	for _, plugin := range plugins {
+		plugin = filepath.Base(plugin)
+		args := []string{}
+
+		// Plugins are named "kubectl-<name>" or with more - such as
+		// "kubectl-<name>-<subcmd1>..."
+		for _, arg := range strings.Split(plugin, "-")[1:] {
+			// Underscores (_) in plugin's filename are replaced with dashes(-)
+			// e.g. foo_bar -> foo-bar
+			args = append(args, strings.Replace(arg, "_", "-", -1))
+		}
+
+		// In order to avoid that the same plugin command is added more than once,
+		// find the lowest command given args from the root command
+		parentCmd, remainingArgs, _ := kubectl.Find(args)
+		if parentCmd == nil {
+			parentCmd = kubectl
+		}
+
+		for _, remainingArg := range remainingArgs {
+			cmd := &cobra.Command{
+				Use: remainingArg,
+				// Add a description that will be shown with completion choices.
+				// Make each one different by including the plugin name to avoid
+				// all plugins being grouped in a single line during completion for zsh.
+				Short:              fmt.Sprintf("The command %s is a plugin installed by the user", remainingArg),
+				DisableFlagParsing: true,
+				// Allow plugins to provide their own completion choices
+				ValidArgsFunction: pluginCompletion,
+				// A Run is required for it to be a valid command
+				Run: func(cmd *cobra.Command, args []string) {},
+			}
+			parentCmd.AddCommand(cmd)
+			parentCmd = cmd
+		}
+	}
+}
+
+// pluginCompletion deals with shell completion beyond the plugin name, it allows to complete
+// plugin arguments and flags.
+// It will look on $PATH for a specific executable file that will provide completions
+// for the plugin in question.
+//
+// When called, this completion executable should print the completion choices to stdout.
+// The arguments passed to the executable file will be the arguments for the plugin currently
+// on the command-line.  For example, if a user types:
+//
+//	kubectl myplugin arg1 arg2 a<TAB>
+//
+// the completion executable will be called with arguments: "arg1" "arg2" "a".
+// And if a user types:
+//
+//	kubectl myplugin arg1 arg2 <TAB>
+//
+// the completion executable will be called with arguments: "arg1" "arg2" "".  Notice the empty
+// last argument which indicates that a new word should be completed but that the user has not
+// typed anything for it yet.
+//
+// Kubectl's plugin completion logic supports Cobra's ShellCompDirective system.  This means a plugin
+// can optionally print :<value of a shell completion directive> as its very last line to provide
+// directives to the shell on how to perform completion.  If this directive is not present, the
+// cobra.ShellCompDirectiveDefault will be used. Please see Cobra's documentation for more details:
+// https://github.com/spf13/cobra/blob/master/shell_completions.md#dynamic-completion-of-nouns
+//
+// The completion executable should be named kubectl_complete-<plugin>.  For example, for a plugin
+// named kubectl-get_all, the completion file should be named kubectl_complete-get_all.  The completion
+// executable must have executable permissions set on it and must be on $PATH.
+func pluginCompletion(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	// Recreate the plugin name from the commandPath
+	pluginName := strings.Replace(strings.Replace(cmd.CommandPath(), "-", "_", -1), " ", "-", -1)
+
+	path, found := lookupCompletionExec(pluginName)
+	if !found {
+		cobra.CompDebugln(fmt.Sprintf("Plugin %s does not provide a matching completion executable", pluginName), true)
+		return nil, cobra.ShellCompDirectiveDefault
+	}
+
+	args = append(args, toComplete)
+	cobra.CompDebugln(fmt.Sprintf("About to call: %s %s", path, strings.Join(args, " ")), true)
+	return getPluginCompletions(path, args, os.Environ())
+}
+
+// lookupCompletionExec will look for the existence of an executable
+// that can provide completion for the given plugin name.
+// The first filepath to match is returned, or a boolean false if
+// such an executable is not found.
+func lookupCompletionExec(pluginName string) (string, bool) {
+	// Convert the plugin name into the plugin completion name by inserting "_complete" before the first -.
+	// For example, convert kubectl-get_all to kubectl_complete-get_all
+	pluginCompExec := strings.Replace(pluginName, "-", "_complete-", 1)
+	cobra.CompDebugln(fmt.Sprintf("About to look for: %s", pluginCompExec), true)
+	path, err := exec.LookPath(pluginCompExec)
+	if err != nil || len(path) == 0 {
+		return "", false
+	}
+	return path, true
+}
+
+// getPluginCompletions receives an executable's filepath, a slice
+// of arguments, and a slice of environment variables
+// to relay to the executable.
+// The executable is responsible for printing the completions of the
+// plugin for the current set of arguments.
+func getPluginCompletions(executablePath string, cmdArgs, environment []string) ([]string, cobra.ShellCompDirective) {
+	buf := new(bytes.Buffer)
+
+	prog := exec.Command(executablePath, cmdArgs...)
+	prog.Stdin = os.Stdin
+	prog.Stdout = buf
+	prog.Stderr = os.Stderr
+	prog.Env = environment
+
+	var comps []string
+	directive := cobra.ShellCompDirectiveDefault
+	if err := prog.Run(); err == nil {
+		for _, comp := range strings.Split(buf.String(), "\n") {
+			// Remove any empty lines
+			if len(comp) > 0 {
+				comps = append(comps, comp)
+			}
+		}
+
+		// Check if the last line of output is of the form :<integer>, which
+		// indicates a Cobra ShellCompDirective.  We do this for plugins
+		// that use Cobra or the ones that wish to use this directive to
+		// communicate a special behavior for the shell.
+		if len(comps) > 0 {
+			lastLine := comps[len(comps)-1]
+			if len(lastLine) > 1 && lastLine[0] == ':' {
+				if strInt, err := strconv.Atoi(lastLine[1:]); err == nil {
+					directive = cobra.ShellCompDirective(strInt)
+					comps = comps[:len(comps)-1]
+				}
+			}
+		}
+	}
+	return comps, directive
+}

--- a/staging/src/k8s.io/kubectl/pkg/cmd/plugin/plugin_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/plugin/plugin_test.go
@@ -20,6 +20,8 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -175,6 +177,34 @@ func TestPluginPathsAreValid(t *testing.T) {
 				t.Fatalf("unexpected output: expected to contain %v, but got %v", test.expectOut, out.String())
 			}
 		})
+	}
+}
+
+func TestListPlugins(t *testing.T) {
+	pluginPath, _ := filepath.Abs("./testdata")
+	expectPlugins := []string{
+		filepath.Join(pluginPath, "kubectl-foo"),
+		filepath.Join(pluginPath, "kubectl-version"),
+	}
+
+	verifier := newFakePluginPathVerifier()
+	ioStreams, _, _, _ := genericclioptions.NewTestIOStreams()
+	pluginPaths := []string{pluginPath}
+
+	o := &PluginListOptions{
+		Verifier:  verifier,
+		IOStreams: ioStreams,
+
+		PluginPaths: pluginPaths,
+	}
+
+	plugins, errs := o.ListPlugins()
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+
+	if !reflect.DeepEqual(expectPlugins, plugins) {
+		t.Fatalf("saw unexpected plugins. Expecting %v, got %v", expectPlugins, plugins)
 	}
 }
 

--- a/staging/src/k8s.io/sample-cli-plugin/README.md
+++ b/staging/src/k8s.io/sample-cli-plugin/README.md
@@ -58,6 +58,29 @@ that kubectl points to.
 It can also be used as a means of showcasing usage of the cli-runtime set of utilities to aid in
 third-party plugin development.
 
+## Shell completion
+
+This plugin supports shell completion when used through kubectl.  To enable shell completion for the plugin
+you must copy the file `./kubectl_complete-ns` somewhere on `$PATH` and give it executable permissions.
+
+The `./kubectl_complete-ns` script shows a hybrid approach to providing completions:
+1. it uses the builtin `__complete` command provided by [Cobra](https://github.com/spf13/cobra) for flags
+1. it calls `kubectl` to obtain the list of namespaces to complete arguments (note that a more elegant approach would be to have the `kubectl-ns` program itself provide completion of arguments by implementing Cobra's `ValidArgsFunction` to fetch the list of namespaces, but it would then be a less varied example)
+
+One can then do things like:
+```
+$ kubectl ns <TAB>
+default          kube-node-lease  kube-public      kube-system
+
+$ kubectl ns --<TAB>
+--as                        -- Username to impersonate for the operation. User could be a regular user or a service account in a namespace.
+--as-group                  -- Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
+--as-uid                    -- UID to impersonate for the operation.
+--cache-dir                 -- Default cache directory
+[...]
+```
+
+Note: kubectl v1.26 or higher is required for shell completion to work for plugins.
 ## Cleanup
 
 You can "uninstall" this plugin from kubectl by simply removing it from your PATH:

--- a/staging/src/k8s.io/sample-cli-plugin/kubectl_complete-ns
+++ b/staging/src/k8s.io/sample-cli-plugin/kubectl_complete-ns
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+# If we are completing a flag, use Cobra's builtin completion system.
+# To know if we are completing a flag we need the last argument starts with a `-` and does not contain an `=`
+args=("$@")
+lastArg=${args[((${#args[@]}-1))]}
+if [[ "$lastArg" == -* ]]; then
+   if [[ "$lastArg" != *=* ]]; then
+      kubectl ns __complete "$@"
+   fi
+else
+   # TODO Make sure we are not completing the value of a flag.
+   # TODO Only complete a single argument.
+   # Both are pretty hard to do in a shell script.  The better way to do this would be to let
+   # Cobra do all the completions by using `cobra.ValidArgsFunction` in the program.
+   # But the below, although imperfect, is a nice example for plugins that don't use Cobra.
+
+   # We are probably completing an argument.  This plugin only accepts namespaces, let's fetch them.
+   kubectl get namespaces --output go-template='{{ range .items }}{{ .metadata.name }}{{"\n"}}{{ end }}'
+
+   # Turn off file completion.  See the ShellCompDirective documentation within
+   # https://github.com/spf13/cobra/blob/main/shell_completions.md#completion-of-nouns
+   echo :4
+fi


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/sig cli

#### What this PR does / why we need it:

This PR does three things:
1- includes plugin names during kubectl shell completion (cherry-pick of @superbrothers's commit from #76561)
2- allows a plugin to provide completions through an executable script named `kubectl_complete-<pluginName>` present on `$PATH`
3- adds support for shell completion to the `sample-cli-plugin`

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #74178

#### Special notes for your reviewer:

Tests are missing at the moment.

When doing completion for arguments or flags for a plugin, kubectl will call `kubectl_complete-<plugin>` to obtain the list of completions.  For example, for the `krew` plugin, when the user triggers completion by doing:
```
kubectl krew <TAB>
```
kubectl will look on `$PATH` for an executable file called `kubectl_complete-krew`.  This file should print the list of valid completions for the plugin to stdout.  kubectl will then present these completion choices to the user.  This approach is the one used by the Helm project for its plugins: https://helm.sh/docs/topics/plugins/#dynamic-completion

**Backwards-compatibility**:

The solution is backwards-compatible with plugins in both cases:
1. existing plugins will work with a new `kubectl` using this solution
2. plugins supporting this solution will work with an old `kubectl`

**Krew**:

From what I can see from `krew` (I'm no expert), there is no current way to deliver a separate executable `kubectl_complete-<plugin>` completion file.  Therefore, if this solution is chosen, it may be interesting to add support for it in `krew`.

*Explanation*: `krew` installs one plugin binary on $PATH using the plugin naming convention.  That means that the only way for a plugin completion solution to work out-of-the-box with `krew` would be to call the binary plugin itself to get completions (using a special sub-command or flag).  This is not a viable solution because if a plugin ignores arguments and flags, calling it to obtain completions will mistakenly run the actual plugin logic.

**How to test**

_Manually creating a completion script:_

_For zsh (but very similar for bash, fish or powershell)._

We need a plugin to provide completion through a new `kubectl_complete-<pluginName>` file.  Let's create one ourselves.  Let's do it for the `krew` plugin, which I assume many in the community have installed.  Since `krew` uses Cobra, it has the `__complete` command, which makes it very easy to obtain completions, as will become clear below:
```
cat <<EOF >kubectl_complete-krew
#!/usr/bin/env sh

# Call the __complete command passing it all arguments
kubectl krew __complete "\$@"
EOF

chmod u+x kubectl_complete-krew
```
_Please put the `kubectl_complete-krew` file somewhere on your $PATH_.  Then:
```
cd $GOPATH/src/k8s.io/kubernetes
go build -o /tmp/kubectl ./cmd/kubectl
source <(/tmp/kubectl completion zsh)

/tmp/kubectl <TAB>
# Notice that plugins are now listed as choices

/tmp/kubectl krew <TAB>
# Notice that krew sub-commands are now listed
```

_Automatically generating completion scripts:_

I've written a new plugin, "[plugin-completion](https://github.com/marckhouzam/kubectl-plugin_completion)", which automatically generates the proper shell completion script for installed plugins that use Cobra.  It works with more than half the plugins registered with krew. It can help test this PR quite easily.

**NOTE**: Flag completion for plugins works with Cobra 1.3 which is now part of the master branch.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Shell completion will now show plugin names when appropriate.  Furthermore, shell completion will work for plugins that provide such support.
```

<!--

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
```docs

```
-->
