### PR TITLE
Fix delete collection error channel size

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/store.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/store.go
@@ -1126,7 +1126,7 @@ func (e *Store) DeleteCollection(ctx context.Context, deleteValidation rest.Vali
 	}
 	wg := sync.WaitGroup{}
 	toProcess := make(chan int, 2*workersNumber)
-	errs := make(chan error, workersNumber)
+	errs := make(chan error, workersNumber+1)
 	workersExited := make(chan struct{})
 	distributorExited := make(chan struct{})
 


### PR DESCRIPTION
I don't think it's strictly needed, because I can't see any way of the goroutine to actually crash (which is also a reason why I don't see any way of adding reasonable test). So just adding it to be on the safe side.

```release-note
NONE
```

/kind cleanup
/priority important-soon
/sig api-machinery

/cc @liggitt 