### PR TITLE
Fix metrics AlreadyRegisteredError on TestSampler unit test 

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/metrics/sample_and_watermark_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/metrics/sample_and_watermark_test.go
@@ -37,7 +37,7 @@ const (
 	numIterations         = 100
 )
 
-var once sync.Once
+var registerMetrics sync.Once
 
 /* TestSampler does a rough behavioral test of the sampling in a
    SampleAndWatermarkHistograms.  The test creates one and exercises
@@ -64,7 +64,7 @@ func TestSampler(t *testing.T) {
 	saw := gen.Generate(0, 1, []string{})
 	regs := gen.metrics()
 	for _, reg := range regs {
-		once.Do(func() {
+		registerMetrics.Do(func() {
 			legacyregistry.MustRegister(reg)
 		})
 	}

--- a/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/metrics/sample_and_watermark_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/metrics/sample_and_watermark_test.go
@@ -36,7 +36,6 @@ const (
 	numIterations         = 100
 )
 
-
 /* TestSampler does a rough behavioral test of the sampling in a
    SampleAndWatermarkHistograms.  The test creates one and exercises
    it, checking that the count in the sampling histogram is correct at

--- a/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/metrics/sample_and_watermark_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/metrics/sample_and_watermark_test.go
@@ -19,7 +19,6 @@ package metrics
 import (
 	"fmt"
 	"math/rand"
-	"sync"
 	"testing"
 	"time"
 
@@ -37,7 +36,6 @@ const (
 	numIterations         = 100
 )
 
-var registerMetrics sync.Once
 
 /* TestSampler does a rough behavioral test of the sampling in a
    SampleAndWatermarkHistograms.  The test creates one and exercises
@@ -64,9 +62,7 @@ func TestSampler(t *testing.T) {
 	saw := gen.Generate(0, 1, []string{})
 	regs := gen.metrics()
 	for _, reg := range regs {
-		registerMetrics.Do(func() {
-			legacyregistry.MustRegister(reg)
-		})
+		legacyregistry.Register(reg)
 	}
 	// `dt` is the admitted cumulative difference in fake time
 	// since the start of the test.  "admitted" means this is

--- a/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/metrics/sample_and_watermark_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/metrics/sample_and_watermark_test.go
@@ -19,6 +19,7 @@ package metrics
 import (
 	"fmt"
 	"math/rand"
+	"sync"
 	"testing"
 	"time"
 
@@ -35,6 +36,8 @@ const (
 	ddtOffsetCentiPeriods = 50
 	numIterations         = 100
 )
+
+var once sync.Once
 
 /* TestSampler does a rough behavioral test of the sampling in a
    SampleAndWatermarkHistograms.  The test creates one and exercises
@@ -61,7 +64,9 @@ func TestSampler(t *testing.T) {
 	saw := gen.Generate(0, 1, []string{})
 	regs := gen.metrics()
 	for _, reg := range regs {
-		legacyregistry.MustRegister(reg)
+		once.Do(func() {
+			legacyregistry.MustRegister(reg)
+		})
 	}
 	// `dt` is the admitted cumulative difference in fake time
 	// since the start of the test.  "admitted" means this is

--- a/staging/src/k8s.io/component-base/metrics/testutil/metrics_test.go
+++ b/staging/src/k8s.io/component-base/metrics/testutil/metrics_test.go
@@ -29,7 +29,6 @@ import (
 	"k8s.io/utils/pointer"
 )
 
-
 func samples2Histogram(samples []float64, upperBounds []float64) Histogram {
 	histogram := dto.Histogram{
 		SampleCount: uint64Ptr(0),
@@ -576,7 +575,6 @@ func TestGetHistogramVecFromGatherer(t *testing.T) {
 			}
 			vec := metrics.NewHistogramVec(HistogramOpts, labels)
 			legacyregistry.Register(vec)
-
 			// Observe two metrics with same value for label1 but different value of label2.
 			vec.WithLabelValues("value1-0", "value2-0").Observe(1.5)
 			vec.WithLabelValues("value1-0", "value2-1").Observe(2.5)

--- a/staging/src/k8s.io/component-base/metrics/testutil/metrics_test.go
+++ b/staging/src/k8s.io/component-base/metrics/testutil/metrics_test.go
@@ -580,6 +580,8 @@ func TestGetHistogramVecFromGatherer(t *testing.T) {
 			registerMetrics.Do(func() {
 				legacyregistry.MustRegister(vec)
 			})
+			defer legacyregistry.Reset()
+
 			// Observe two metrics with same value for label1 but different value of label2.
 			vec.WithLabelValues("value1-0", "value2-0").Observe(1.5)
 			vec.WithLabelValues("value1-0", "value2-1").Observe(2.5)

--- a/staging/src/k8s.io/component-base/metrics/testutil/metrics_test.go
+++ b/staging/src/k8s.io/component-base/metrics/testutil/metrics_test.go
@@ -587,7 +587,6 @@ func TestGetHistogramVecFromGatherer(t *testing.T) {
 			if diff := cmp.Diff(tt.wantVec, histogramVec); diff != "" {
 				t.Errorf("Got unexpected HistogramVec (-want +got):\n%s", diff)
 			}
-			registry.Reset()
 		})
 	}
 }

--- a/staging/src/k8s.io/component-base/metrics/testutil/metrics_test.go
+++ b/staging/src/k8s.io/component-base/metrics/testutil/metrics_test.go
@@ -20,11 +20,13 @@ import (
 	"fmt"
 	"math"
 	"reflect"
+	"sync"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
 	dto "github.com/prometheus/client_model/go"
 	"k8s.io/component-base/metrics"
+	"k8s.io/component-base/metrics/legacyregistry"
 	"k8s.io/utils/pointer"
 )
 
@@ -515,6 +517,7 @@ func TestHistogramVec_Validate(t *testing.T) {
 }
 
 func TestGetHistogramVecFromGatherer(t *testing.T) {
+	var registerMetrics sync.Once
 	tests := []struct {
 		name    string
 		lvMap   map[string]string
@@ -573,17 +576,16 @@ func TestGetHistogramVecFromGatherer(t *testing.T) {
 				Buckets:   buckets,
 			}
 			vec := metrics.NewHistogramVec(HistogramOpts, labels)
-			// Use local registry
-			var registry = metrics.NewKubeRegistry()
-			var gather metrics.Gatherer = registry
-			registry.MustRegister(vec)
+			registerMetrics.Do(func() {
+				legacyregistry.MustRegister(vec)
+			})
 			// Observe two metrics with same value for label1 but different value of label2.
 			vec.WithLabelValues("value1-0", "value2-0").Observe(1.5)
 			vec.WithLabelValues("value1-0", "value2-1").Observe(2.5)
 			vec.WithLabelValues("value1-1", "value2-0").Observe(3.5)
 			vec.WithLabelValues("value1-1", "value2-1").Observe(4.5)
 			metricName := fmt.Sprintf("%s_%s_%s", HistogramOpts.Namespace, HistogramOpts.Subsystem, HistogramOpts.Name)
-			histogramVec, _ := GetHistogramVecFromGatherer(gather, metricName, tt.lvMap)
+			histogramVec, _ := GetHistogramVecFromGatherer(legacyregistry.DefaultGatherer, metricName, tt.lvMap)
 			if diff := cmp.Diff(tt.wantVec, histogramVec); diff != "" {
 				t.Errorf("Got unexpected HistogramVec (-want +got):\n%s", diff)
 			}

--- a/staging/src/k8s.io/component-base/metrics/testutil/metrics_test.go
+++ b/staging/src/k8s.io/component-base/metrics/testutil/metrics_test.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"math"
 	"reflect"
-	"sync"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -30,7 +29,6 @@ import (
 	"k8s.io/utils/pointer"
 )
 
-var registerMetrics sync.Once
 
 func samples2Histogram(samples []float64, upperBounds []float64) Histogram {
 	histogram := dto.Histogram{
@@ -577,10 +575,7 @@ func TestGetHistogramVecFromGatherer(t *testing.T) {
 				Buckets:   buckets,
 			}
 			vec := metrics.NewHistogramVec(HistogramOpts, labels)
-			registerMetrics.Do(func() {
-				legacyregistry.MustRegister(vec)
-			})
-			defer legacyregistry.Reset()
+			legacyregistry.Register(vec)
 
 			// Observe two metrics with same value for label1 but different value of label2.
 			vec.WithLabelValues("value1-0", "value2-0").Observe(1.5)

--- a/staging/src/k8s.io/component-base/metrics/testutil/metrics_test.go
+++ b/staging/src/k8s.io/component-base/metrics/testutil/metrics_test.go
@@ -30,6 +30,8 @@ import (
 	"k8s.io/utils/pointer"
 )
 
+var registerMetrics sync.Once
+
 func samples2Histogram(samples []float64, upperBounds []float64) Histogram {
 	histogram := dto.Histogram{
 		SampleCount: uint64Ptr(0),
@@ -517,7 +519,6 @@ func TestHistogramVec_Validate(t *testing.T) {
 }
 
 func TestGetHistogramVecFromGatherer(t *testing.T) {
-	var registerMetrics sync.Once
 	tests := []struct {
 		name    string
 		lvMap   map[string]string


### PR DESCRIPTION
Fixes #104940

Test: 
```
make test KUBE_RACE=-race KUBE_TIMEOUT=--timeout=600s GOFLAGS=-count=10 WHAT=./staging/src/k8s.io/apiserver/pkg/util/flowcontrol/metrics/
```

