### PR TITLE
Cherry-pick of #101708: Fix log spam for du failure on pod etc-hosts metrics

### DIFF
--- a/pkg/kubelet/stats/host_stats_provider.go
+++ b/pkg/kubelet/stats/host_stats_provider.go
@@ -18,6 +18,7 @@ package stats
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 
 	cadvisorapiv2 "github.com/google/cadvisor/info/v2"
@@ -82,6 +83,10 @@ func (h hostStatsProvider) getPodEtcHostsStats(podUID types.UID, rootFsInfo *cad
 	// Runtimes may not support etc hosts file (Windows with docker)
 	podEtcHostsPath, isEtcHostsSupported := h.podEtcHostsPathFunc(podUID)
 	if !isEtcHostsSupported {
+		return nil, nil
+	}
+	// Some pods have an explicit /etc/hosts mount and the Kubelet will not create an etc-hosts file for them
+	if _, err := os.Stat(podEtcHostsPath); os.IsNotExist(err) {
 		return nil, nil
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

 Cherry-pick of #101708

/kind bug

#### What this PR does / why we need it:

#97042 added changes in 1.21 version that caused log spam in kubelet logs with the following message - 
```
"Unable to fetch pod etc hosts stats" err="failed to get stats failed command 'du' ($ nice -n 19 du -x -s -B 1) on path /var/lib/kubelet/pods/d451e557-9ff8-4cc6-91d3-6cfc21e7ea4f/etc-hosts with error exit status 1" pod="openshift-dns/node-resolver-tckq7"
```
#101708 was sent to fix this but it was merged in 1.22 version only. This PR cherry-picks the commit to 1.21 version.

So we were wondering if this can be cherry-picked onto 1.21

#### Which issue(s) this PR fixes:

 Cherry-pick of #101708

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
