### PR TITLE
[PodSecurity] Aggregate identical warnings for multiple pods in a namespace

### DIFF
--- a/staging/src/k8s.io/pod-security-admission/admission/admission_test.go
+++ b/staging/src/k8s.io/pod-security-admission/admission/admission_test.go
@@ -18,6 +18,7 @@ package admission
 
 import (
 	"context"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -462,7 +463,9 @@ func TestValidateNamespace(t *testing.T) {
 			if evaluator.lv != tc.expectEvaluate {
 				t.Errorf("expected to evaluate %v, got %v", tc.expectEvaluate, evaluator.lv)
 			}
-			assertAggregatePodsWarnings(t, tc.expectWarnings, result.Warnings)
+			if !reflect.DeepEqual(result.Warnings, tc.expectWarnings) {
+				t.Errorf("expected warnings:\n%v\ngot\n%v", tc.expectWarnings, result.Warnings)
+			}
 		})
 	}
 }
@@ -651,22 +654,4 @@ func NewMockRecorder() *MockRecorder {
 }
 
 func (r MockRecorder) RecordEvaluation(decision metrics.Decision, policy api.LevelVersion, evalMode metrics.Mode, attrs api.Attributes) {
-}
-
-func assertAggregatePodsWarnings(t *testing.T, expected, actual []string) {
-	e, a := make(map[string]string), make(map[string]string)
-	for _, warning := range expected {
-		warningSplit := strings.Split(warning, ": ")
-		podNames := warningSplit[0]
-		reasons := warningSplit[1]
-		e[podNames] = reasons
-	}
-	for _, warning := range actual {
-		warningSplit := strings.Split(warning, ": ")
-		podNames := warningSplit[0]
-		reasons := warningSplit[1]
-		a[podNames] = reasons
-	}
-
-	assert.Equal(t, e, a, "unexpected warnings")
 }


### PR DESCRIPTION
Addressing review comments from #103585.

First commit is by @njuptlzf

/kind feature

#### What this PR does / why we need it:

Fixes #103213

Aggregates identical warnings when validating multiple pods in a namespace

Benchmark comparison against master:

```
benchmark                                 old allocs     new allocs     delta
BenchmarkVerifyNamespace-12               54050          45041          -16.67%

benchmark                                 old bytes     new bytes     delta
BenchmarkVerifyNamespace-12               5401188       5030556       -6.86%
```

```release-note
NONE
```

/assign @tallclair 