### PR TITLE
Added requestSloLatencies metric

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/mutating/plugin_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/mutating/plugin_test.go
@@ -26,6 +26,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"k8s.io/apiserver/pkg/endpoints/request"
+	clocktesting "k8s.io/utils/clock/testing"
 
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -249,5 +251,71 @@ func TestAdmitCachedClient(t *testing.T) {
 		if !tt.ExpectCacheMiss && *cacheMisses > 0 {
 			t.Errorf("%s: expected client to be cached, but got %d AuthenticationInfoResolver calls", tt.Name, *cacheMisses)
 		}
+	}
+}
+
+// TestWebhookDuration tests that MutatingWebhook#Admit sets webhook duration in context correctly
+func TestWebhookDuration(ts *testing.T) {
+	clk := clocktesting.FakeClock{}
+	testServer := webhooktesting.NewTestServerWithHandler(ts, webhooktesting.ClockSteppingWebhookHandler(ts, &clk))
+	testServer.StartTLS()
+	defer testServer.Close()
+	serverURL, err := url.ParseRequestURI(testServer.URL)
+	if err != nil {
+		ts.Fatalf("this should never happen? %v", err)
+	}
+
+	objectInterfaces := webhooktesting.NewObjectInterfacesForTest()
+
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+
+	for _, test := range webhooktesting.NewValidationDurationTestCases(serverURL) {
+		ts.Run(test.Name, func(t *testing.T) {
+			ctx := context.TODO()
+			if test.InitContext {
+				ctx = request.WithWebhookDurationAndCustomClock(ctx, &clk)
+			}
+			wh, err := NewMutatingWebhook(nil)
+			if err != nil {
+				t.Errorf("failed to create mutating webhook: %v", err)
+				return
+			}
+
+			ns := "webhook-test"
+			client, informer := webhooktesting.NewFakeMutatingDataSource(ns, webhooktesting.ConvertToMutatingWebhooks(test.Webhooks), stopCh)
+
+			wh.SetAuthenticationInfoResolverWrapper(webhooktesting.Wrapper(webhooktesting.NewAuthenticationInfoResolver(new(int32))))
+			wh.SetServiceResolver(webhooktesting.NewServiceResolver(*serverURL))
+			wh.SetExternalKubeClientSet(client)
+			wh.SetExternalKubeInformerFactory(informer)
+
+			informer.Start(stopCh)
+			informer.WaitForCacheSync(stopCh)
+
+			if err = wh.ValidateInitialization(); err != nil {
+				t.Errorf("failed to validate initialization: %v", err)
+				return
+			}
+
+			_ = wh.Admit(ctx, webhooktesting.NewAttribute(ns, nil, test.IsDryRun), objectInterfaces)
+			wd, ok := request.WebhookDurationFrom(ctx)
+			if !ok {
+				if test.InitContext {
+					t.Errorf("expected webhook duration to be initialized")
+				}
+				return
+			}
+			if !test.InitContext {
+				t.Errorf("expected webhook duration to not be initialized")
+				return
+			}
+			if wd.AdmitTracker.GetLatency() != test.ExpectedDurationSum {
+				t.Errorf("expected admit duration %q got %q", test.ExpectedDurationSum, wd.AdmitTracker.GetLatency())
+			}
+			if wd.ValidateTracker.GetLatency() != 0 {
+				t.Errorf("expected validate duraion to be equal to 0 got %q", wd.ValidateTracker.GetLatency())
+			}
+		})
 	}
 }

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/validating/dispatcher.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/validating/dispatcher.go
@@ -32,6 +32,7 @@ import (
 	webhookerrors "k8s.io/apiserver/pkg/admission/plugin/webhook/errors"
 	"k8s.io/apiserver/pkg/admission/plugin/webhook/generic"
 	webhookrequest "k8s.io/apiserver/pkg/admission/plugin/webhook/request"
+	endpointsrequest "k8s.io/apiserver/pkg/endpoints/request"
 	webhookutil "k8s.io/apiserver/pkg/util/webhook"
 	"k8s.io/apiserver/pkg/warning"
 	"k8s.io/klog/v2"
@@ -230,7 +231,13 @@ func (d *validatingDispatcher) callHook(ctx context.Context, h *v1.ValidatingWeb
 		}
 	}
 
-	if err := r.Do(ctx).Into(response); err != nil {
+	do := func() { err = r.Do(ctx).Into(response) }
+	if wd, ok := endpointsrequest.WebhookDurationFrom(ctx); ok {
+		tmp := do
+		do = func() { wd.ValidateTracker.Track(tmp) }
+	}
+	do()
+	if err != nil {
 		var status *apierrors.StatusError
 		if se, ok := err.(*apierrors.StatusError); ok {
 			status = se

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/validating/plugin_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/validating/plugin_test.go
@@ -24,6 +24,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"k8s.io/apiserver/pkg/endpoints/request"
+	clocktesting "k8s.io/utils/clock/testing"
 
 	"k8s.io/apimachinery/pkg/api/errors"
 	webhooktesting "k8s.io/apiserver/pkg/admission/plugin/webhook/testing"
@@ -211,5 +213,71 @@ func TestValidateCachedClient(t *testing.T) {
 		if !tt.ExpectCacheMiss && *cacheMisses > 0 {
 			t.Errorf("%s: expected client to be cached, but got %d AuthenticationInfoResolver calls", tt.Name, *cacheMisses)
 		}
+	}
+}
+
+// TestValidateWebhookDuration tests that ValidatingWebhook#Validate sets webhook duration in context correctly
+func TestValidateWebhookDuration(ts *testing.T) {
+	clk := clocktesting.FakeClock{}
+	testServer := webhooktesting.NewTestServerWithHandler(ts, webhooktesting.ClockSteppingWebhookHandler(ts, &clk))
+	testServer.StartTLS()
+	defer testServer.Close()
+	serverURL, err := url.ParseRequestURI(testServer.URL)
+	if err != nil {
+		ts.Fatalf("this should never happen? %v", err)
+	}
+
+	objectInterfaces := webhooktesting.NewObjectInterfacesForTest()
+
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+
+	for _, test := range webhooktesting.NewValidationDurationTestCases(serverURL) {
+		ts.Run(test.Name, func(t *testing.T) {
+			ctx := context.TODO()
+			if test.InitContext {
+				ctx = request.WithWebhookDurationAndCustomClock(ctx, &clk)
+			}
+			wh, err := NewValidatingAdmissionWebhook(nil)
+			if err != nil {
+				t.Errorf("failed to create mutating webhook: %v", err)
+				return
+			}
+
+			ns := "webhook-test"
+			client, informer := webhooktesting.NewFakeValidatingDataSource(ns, test.Webhooks, stopCh)
+
+			wh.SetAuthenticationInfoResolverWrapper(webhooktesting.Wrapper(webhooktesting.NewAuthenticationInfoResolver(new(int32))))
+			wh.SetServiceResolver(webhooktesting.NewServiceResolver(*serverURL))
+			wh.SetExternalKubeClientSet(client)
+			wh.SetExternalKubeInformerFactory(informer)
+
+			informer.Start(stopCh)
+			informer.WaitForCacheSync(stopCh)
+
+			if err = wh.ValidateInitialization(); err != nil {
+				t.Errorf("failed to validate initialization: %v", err)
+				return
+			}
+
+			_ = wh.Validate(ctx, webhooktesting.NewAttribute(ns, nil, test.IsDryRun), objectInterfaces)
+			wd, ok := request.WebhookDurationFrom(ctx)
+			if !ok {
+				if test.InitContext {
+					t.Errorf("expected webhook duration to be initialized")
+				}
+				return
+			}
+			if !test.InitContext {
+				t.Errorf("expected webhook duration to not be initialized")
+				return
+			}
+			if wd.AdmitTracker.GetLatency() != 0 {
+				t.Errorf("expected admit duration to be equal to 0 got %q", wd.AdmitTracker.GetLatency())
+			}
+			if wd.ValidateTracker.GetLatency() < test.ExpectedDurationMax {
+				t.Errorf("expected validate duraion to be greater or equal to %q got %q", test.ExpectedDurationMax, wd.ValidateTracker.GetLatency())
+			}
+		})
 	}
 }

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/filters/webhook_duration.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/filters/webhook_duration.go
@@ -1,0 +1,33 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package filters
+
+import (
+	"net/http"
+
+	"k8s.io/apiserver/pkg/endpoints/request"
+)
+
+// WithWebhookDuration adds WebhookDuration trackers to the
+// context associated with a request.
+func WithWebhookDuration(handler http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		ctx := req.Context()
+		req = req.WithContext(request.WithWebhookDuration(ctx))
+		handler.ServeHTTP(w, req)
+	})
+}

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/request/webhook_duration.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/request/webhook_duration.go
@@ -1,0 +1,122 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package request
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"k8s.io/utils/clock"
+)
+
+func sumDuration(d1 time.Duration, d2 time.Duration) time.Duration {
+	return d1 + d2
+}
+
+func maxDuration(d1 time.Duration, d2 time.Duration) time.Duration {
+	if d1 > d2 {
+		return d1
+	}
+	return d2
+}
+
+// DurationTracker is a simple interface for tracking functions duration
+type DurationTracker interface {
+	Track(func())
+	GetLatency() time.Duration
+}
+
+// durationTracker implements DurationTracker by measuring function time
+// using given clock and aggregates the duration using given aggregate function
+type durationTracker struct {
+	clock             clock.Clock
+	latency           time.Duration
+	mu                sync.Mutex
+	aggregateFunction func(time.Duration, time.Duration) time.Duration
+}
+
+// Track measures time spent in given function and aggregates measured
+// duration using aggregateFunction
+func (t *durationTracker) Track(f func()) {
+	startedAt := t.clock.Now()
+	defer func() {
+		duration := t.clock.Since(startedAt)
+		t.mu.Lock()
+		defer t.mu.Unlock()
+		t.latency = t.aggregateFunction(t.latency, duration)
+	}()
+
+	f()
+}
+
+// GetLatency returns aggregated latency tracked by a tracker
+func (t *durationTracker) GetLatency() time.Duration {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.latency
+}
+
+func newSumLatencyTracker(c clock.Clock) DurationTracker {
+	return &durationTracker{
+		clock:             c,
+		aggregateFunction: sumDuration,
+	}
+}
+
+func newMaxLatencyTracker(c clock.Clock) DurationTracker {
+	return &durationTracker{
+		clock:             c,
+		aggregateFunction: maxDuration,
+	}
+}
+
+// WebhookDuration stores trackers used to measure webhook request durations.
+// Since admit webhooks are done sequentially duration is aggregated using
+// sum function. Validate webhooks are done in parallel so max function
+// is used.
+type WebhookDuration struct {
+	AdmitTracker    DurationTracker
+	ValidateTracker DurationTracker
+}
+
+type webhookDurationKeyType int
+
+// webhookDurationKey is the WebhookDuration (the time the request spent waiting
+// for the webhooks to finish) key for the context.
+const webhookDurationKey webhookDurationKeyType = iota
+
+// WithWebhookDuration returns a copy of parent context to which the
+// WebhookDuration trackers are added.
+func WithWebhookDuration(parent context.Context) context.Context {
+	return WithWebhookDurationAndCustomClock(parent, clock.RealClock{})
+}
+
+// WithWebhookDurationAndCustomClock returns a copy of parent context to which
+// the WebhookDuration trackers are added. Tracers use given clock.
+func WithWebhookDurationAndCustomClock(parent context.Context, c clock.Clock) context.Context {
+	return WithValue(parent, webhookDurationKey, &WebhookDuration{
+		AdmitTracker:    newSumLatencyTracker(c),
+		ValidateTracker: newMaxLatencyTracker(c),
+	})
+}
+
+// WebhookDurationFrom returns the value of the WebhookDuration key from the specified context.
+func WebhookDurationFrom(ctx context.Context) (*WebhookDuration, bool) {
+	wd, ok := ctx.Value(webhookDurationKey).(*WebhookDuration)
+	return wd, ok && wd != nil
+}

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/request/webhook_duration_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/request/webhook_duration_test.go
@@ -1,0 +1,73 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package request
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	clocktesting "k8s.io/utils/clock/testing"
+)
+
+func TestWebhookDurationFrom(t *testing.T) {
+	type testCase struct {
+		Durations    []time.Duration
+		SumDurations time.Duration
+		MaxDuration  time.Duration
+	}
+	tc := testCase{
+		Durations:    []time.Duration{100, 200, 300, 200, 400, 300, 100},
+		SumDurations: 1600,
+		MaxDuration:  400,
+	}
+	t.Run("TestWebhookDurationFrom", func(t *testing.T) {
+		parent := context.TODO()
+		_, ok := WebhookDurationFrom(parent)
+		if ok {
+			t.Error("expected WebhookDurationFrom to not be initialized")
+		}
+
+		clk := clocktesting.FakeClock{}
+		ctx := WithWebhookDurationAndCustomClock(parent, &clk)
+		wd, ok := WebhookDurationFrom(ctx)
+		if !ok {
+			t.Error("expected webhook duration to be initialized")
+		}
+		if wd.AdmitTracker.GetLatency() != 0 || wd.ValidateTracker.GetLatency() != 0 {
+			t.Error("expected values to be initialized to 0")
+		}
+
+		for _, d := range tc.Durations {
+			wd.AdmitTracker.Track(func() { clk.Step(d) })
+			wd.ValidateTracker.Track(func() { clk.Step(d) })
+		}
+
+		wd, ok = WebhookDurationFrom(ctx)
+		if !ok {
+			t.Errorf("expected webhook duration to be initialized")
+		}
+
+		if wd.AdmitTracker.GetLatency() != tc.SumDurations {
+			t.Errorf("expected admit duration: %q, but got: %q", tc.SumDurations, wd.AdmitTracker.GetLatency())
+		}
+
+		if wd.ValidateTracker.GetLatency() != tc.MaxDuration {
+			t.Errorf("expected validate duration: %q, but got: %q", tc.MaxDuration, wd.ValidateTracker.GetLatency())
+		}
+	})
+}

--- a/staging/src/k8s.io/apiserver/pkg/server/config.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/config.go
@@ -762,7 +762,8 @@ func BuildHandlerChainWithStorageVersionPrecondition(apiHandler http.Handler, c 
 }
 
 func DefaultBuildHandlerChain(apiHandler http.Handler, c *Config) http.Handler {
-	handler := filterlatency.TrackCompleted(apiHandler)
+	handler := genericapifilters.WithWebhookDuration(apiHandler)
+	handler = filterlatency.TrackCompleted(handler)
 	handler = genericapifilters.WithAuthorization(handler, c.Authorization.Authorizer, c.Serializer)
 	handler = filterlatency.TrackStarted(handler, "authorization")
 


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Current apiserver_request_duration_* metrics measure whole request duration including time spent processing webhooks. Webhook duration is mostly dependant on user configuration de so they should not be counted when considering request latency SLOs.

#### Which issue(s) this PR fixes:

This PR introduces better metric for measuring request latency SLOs.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```