### PR TITLE
Revert --kubelet-port to use 10255 for metrics-server

### DIFF
--- a/cluster/addons/metrics-server/metrics-server-deployment.yaml
+++ b/cluster/addons/metrics-server/metrics-server-deployment.yaml
@@ -54,8 +54,10 @@ spec:
         command:
         - /metrics-server
         - --metric-resolution=30s
-        - --kubelet-use-node-status-port
-        - --kubelet-insecure-tls
+        # These are needed for GKE, which doesn't support secure communication yet.
+        # Remove these lines for non-GKE clusters, and when GKE supports token-based auth.
+        - --kubelet-port=10255
+        - --deprecated-kubelet-completely-insecure=true
         - --kubelet-preferred-address-types=InternalIP,Hostname,InternalDNS,ExternalDNS,ExternalIP
         - --cert-dir=/tmp
         - --secure-port=443


### PR DESCRIPTION
Kubelet serves summay API using insecure port 10255. Metrics-server used
to query kubelet summary API using port 10255 through command line
overwritting --kubelet-port=10255.

However, this commit c5aead020b659b72dd022b919a95ed9d5174a507 removed
--kubelet-port=10255 overwritting and now metrics-server uses 10250
to scrape kubelet for resource metrics. This causes metrics-server
failure of scraping resource metrics from kubelet and **HPA e2e tests are failing**.

#### Testing
Create a k8s cluster using kubetest2 with gce as provider and manually query metrics.k8s.io API.
* kubectl get --raw /apis/metrics.k8s.io/v1beta1/nodes
* kubectl get --raw /apis/metrics.k8s.io/v1beta1/nodes/${worker_node}
* kubectl get --raw /apis/metrics.k8s.io/v1beta1/pods
* kubectl get --raw /apis/metrics.k8s.io/v1beta1/namespaces/kube-system/pods/${system_pod}
* kubectl get --raw /apis/metrics.k8s.io/v1beta1/namespaces/default/pods/${user_pod}

#### What type of PR is this?
/kind bug
/kind failing-test

#### What this PR does / why we need it:
What: this PR reverts --kubelet-port to use 10255.
Why: this PR fixes metrics-server's failure of scraping resource metrics from kubelet.
