### PR TITLE
serviceaccount/claims: include validation failure error in the log

### DIFF
--- a/pkg/serviceaccount/claims.go
+++ b/pkg/serviceaccount/claims.go
@@ -111,20 +111,31 @@ var _ = Validator(&validator{})
 func (v *validator) Validate(ctx context.Context, _ string, public *jwt.Claims, privateObj interface{}) (*apiserverserviceaccount.ServiceAccountInfo, error) {
 	private, ok := privateObj.(*privateClaims)
 	if !ok {
-		klog.Errorf("jwt validator expected private claim of type *privateClaims but got: %T", privateObj)
-		return nil, errors.New("Token could not be validated.")
+		klog.Errorf("service account jwt validator expected private claim of type *privateClaims but got: %T", privateObj)
+		return nil, errors.New("service account token claims could not be validated due to unexpected private claim")
 	}
 	nowTime := now()
 	err := public.Validate(jwt.Expected{
 		Time: nowTime,
 	})
-	switch {
-	case err == nil:
-	case err == jwt.ErrExpired:
-		return nil, errors.New("Token has expired.")
+	switch err {
+	case nil:
+		// successful validation
+
+	case jwt.ErrExpired:
+		return nil, errors.New("service account token has expired")
+
+	case jwt.ErrNotValidYet:
+		return nil, errors.New("service account token is not valid yet")
+
+	// our current use of jwt.Expected above should make these cases impossible to hit
+	case jwt.ErrInvalidAudience, jwt.ErrInvalidID, jwt.ErrInvalidIssuer, jwt.ErrInvalidSubject:
+		klog.Errorf("service account token claim validation got unexpected validation failure: %v", err)
+		return nil, fmt.Errorf("service account token claims could not be validated: %w", err) // safe to pass these errors back to the user
+
 	default:
-		klog.Errorf("unexpected validation error: %T", err)
-		return nil, errors.New("Token could not be validated.")
+		klog.Errorf("service account token claim validation got unexpected error type: %T", err)                         // avoid leaking unexpected information into the logs
+		return nil, errors.New("service account token claims could not be validated due to unexpected validation error") // return an opaque error
 	}
 
 	// consider things deleted prior to now()-leeway to be invalid
@@ -141,11 +152,11 @@ func (v *validator) Validate(ctx context.Context, _ string, public *jwt.Claims, 
 	}
 	if serviceAccount.DeletionTimestamp != nil && serviceAccount.DeletionTimestamp.Time.Before(invalidIfDeletedBefore) {
 		klog.V(4).Infof("Service account has been deleted %s/%s", namespace, saref.Name)
-		return nil, fmt.Errorf("ServiceAccount %s/%s has been deleted", namespace, saref.Name)
+		return nil, fmt.Errorf("service account %s/%s has been deleted", namespace, saref.Name)
 	}
 	if string(serviceAccount.UID) != saref.UID {
 		klog.V(4).Infof("Service account UID no longer matches %s/%s: %q != %q", namespace, saref.Name, string(serviceAccount.UID), saref.UID)
-		return nil, fmt.Errorf("ServiceAccount UID (%s) does not match claim (%s)", serviceAccount.UID, saref.UID)
+		return nil, fmt.Errorf("service account UID (%s) does not match claim (%s)", serviceAccount.UID, saref.UID)
 	}
 
 	if secref != nil {
@@ -153,15 +164,15 @@ func (v *validator) Validate(ctx context.Context, _ string, public *jwt.Claims, 
 		secret, err := v.getter.GetSecret(namespace, secref.Name)
 		if err != nil {
 			klog.V(4).Infof("Could not retrieve bound secret %s/%s for service account %s/%s: %v", namespace, secref.Name, namespace, saref.Name, err)
-			return nil, errors.New("Token has been invalidated")
+			return nil, errors.New("service account token has been invalidated")
 		}
 		if secret.DeletionTimestamp != nil && secret.DeletionTimestamp.Time.Before(invalidIfDeletedBefore) {
 			klog.V(4).Infof("Bound secret is deleted and awaiting removal: %s/%s for service account %s/%s", namespace, secref.Name, namespace, saref.Name)
-			return nil, errors.New("Token has been invalidated")
+			return nil, errors.New("service account token has been invalidated")
 		}
 		if secref.UID != string(secret.UID) {
 			klog.V(4).Infof("Secret UID no longer matches %s/%s: %q != %q", namespace, secref.Name, string(secret.UID), secref.UID)
-			return nil, fmt.Errorf("Secret UID (%s) does not match claim (%s)", secret.UID, secref.UID)
+			return nil, fmt.Errorf("secret UID (%s) does not match service account secret ref claim (%s)", secret.UID, secref.UID)
 		}
 	}
 
@@ -171,15 +182,15 @@ func (v *validator) Validate(ctx context.Context, _ string, public *jwt.Claims, 
 		pod, err := v.getter.GetPod(namespace, podref.Name)
 		if err != nil {
 			klog.V(4).Infof("Could not retrieve bound pod %s/%s for service account %s/%s: %v", namespace, podref.Name, namespace, saref.Name, err)
-			return nil, errors.New("Token has been invalidated")
+			return nil, errors.New("service account token has been invalidated")
 		}
 		if pod.DeletionTimestamp != nil && pod.DeletionTimestamp.Time.Before(invalidIfDeletedBefore) {
 			klog.V(4).Infof("Bound pod is deleted and awaiting removal: %s/%s for service account %s/%s", namespace, podref.Name, namespace, saref.Name)
-			return nil, errors.New("Token has been invalidated")
+			return nil, errors.New("service account token has been invalidated")
 		}
 		if podref.UID != string(pod.UID) {
 			klog.V(4).Infof("Pod UID no longer matches %s/%s: %q != %q", namespace, podref.Name, string(pod.UID), podref.UID)
-			return nil, fmt.Errorf("Pod UID (%s) does not match claim (%s)", pod.UID, podref.UID)
+			return nil, fmt.Errorf("pod UID (%s) does not match service account pod ref claim (%s)", pod.UID, podref.UID)
 		}
 		podName = podref.Name
 		podUID = podref.UID


### PR DESCRIPTION
Without this fix, the errors are logged as:

```
unexpected validation error: *errors.errorString
```

Signed-off-by: Monis Khan <mok@vmware.com>

/kind bug
/milestone v1.23
/triage accepted
/priority important-longterm
/assign @liggitt 

```release-note
NONE
```