### PR TITLE
PodSecurity: OS based updates to restricted standard

### DIFF
--- a/staging/src/k8s.io/pod-security-admission/policy/check_allowPrivilegeEscalation_test.go
+++ b/staging/src/k8s.io/pod-security-admission/policy/check_allowPrivilegeEscalation_test.go
@@ -23,7 +23,66 @@ import (
 	utilpointer "k8s.io/utils/pointer"
 )
 
-func TestAllowPrivilegeEscalation(t *testing.T) {
+func TestAllowPrivilegeEscalation_1_25(t *testing.T) {
+	tests := []struct {
+		name         string
+		pod          *corev1.Pod
+		expectReason string
+		expectDetail string
+		allowed      bool
+	}{
+		{
+			name: "multiple containers",
+			pod: &corev1.Pod{Spec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{Name: "a"},
+					{Name: "b", SecurityContext: &corev1.SecurityContext{AllowPrivilegeEscalation: nil}},
+					{Name: "c", SecurityContext: &corev1.SecurityContext{AllowPrivilegeEscalation: utilpointer.Bool(true)}},
+					{Name: "d", SecurityContext: &corev1.SecurityContext{AllowPrivilegeEscalation: utilpointer.Bool(false)}},
+				}}},
+			expectReason: `allowPrivilegeEscalation != false`,
+			expectDetail: `containers "a", "b", "c" must set securityContext.allowPrivilegeEscalation=false`,
+			allowed:      false,
+		},
+		{
+			name: "windows pod, admit without checking privilegeEscalation",
+			pod: &corev1.Pod{Spec: corev1.PodSpec{
+				OS: &corev1.PodOS{Name: corev1.Windows},
+				Containers: []corev1.Container{
+					{Name: "a"},
+				}}},
+			allowed: true,
+		},
+		{
+			name: "linux pod, reject if security context is not set",
+			pod: &corev1.Pod{Spec: corev1.PodSpec{
+				OS: &corev1.PodOS{Name: corev1.Linux},
+				Containers: []corev1.Container{
+					{Name: "a"},
+				}}},
+			expectReason: `allowPrivilegeEscalation != false`,
+			expectDetail: `container "a" must set securityContext.allowPrivilegeEscalation=false`,
+			allowed:      false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result := allowPrivilegeEscalation_1_25(&tc.pod.ObjectMeta, &tc.pod.Spec)
+			if result.Allowed && !tc.allowed {
+				t.Fatal("expected disallowed")
+			}
+			if e, a := tc.expectReason, result.ForbiddenReason; e != a {
+				t.Errorf("expected\n%s\ngot\n%s", e, a)
+			}
+			if e, a := tc.expectDetail, result.ForbiddenDetail; e != a {
+				t.Errorf("expected\n%s\ngot\n%s", e, a)
+			}
+		})
+	}
+}
+
+func TestAllowPrivilegeEscalation_1_8(t *testing.T) {
 	tests := []struct {
 		name         string
 		pod          *corev1.Pod

--- a/staging/src/k8s.io/pod-security-admission/policy/check_capabilities_restricted.go
+++ b/staging/src/k8s.io/pod-security-admission/policy/check_capabilities_restricted.go
@@ -66,6 +66,12 @@ func CheckCapabilitiesRestricted() Check {
 				CheckPod:         capabilitiesRestricted_1_22,
 				OverrideCheckIDs: []CheckID{checkCapabilitiesBaselineID},
 			},
+			// Starting 1.25, windows pods would be exempted from this check using pod.spec.os field when set to windows.
+			{
+				MinimumVersion:   api.MajorMinorVersion(1, 25),
+				CheckPod:         capabilitiesRestricted_1_25,
+				OverrideCheckIDs: []CheckID{checkCapabilitiesBaselineID},
+			},
 		},
 	}
 }
@@ -127,4 +133,13 @@ func capabilitiesRestricted_1_22(podMetadata *metav1.ObjectMeta, podSpec *corev1
 		}
 	}
 	return CheckResult{Allowed: true}
+}
+
+func capabilitiesRestricted_1_25(podMetadata *metav1.ObjectMeta, podSpec *corev1.PodSpec) CheckResult {
+	// Pod API validation would have failed if podOS == Windows and if capabilities have been set.
+	// We can admit the Windows pod even if capabilities has not been set.
+	if podSpec.OS != nil && podSpec.OS.Name == corev1.Windows {
+		return CheckResult{Allowed: true}
+	}
+	return capabilitiesRestricted_1_22(podMetadata, podSpec)
 }

--- a/staging/src/k8s.io/pod-security-admission/policy/check_capabilities_restricted_test.go
+++ b/staging/src/k8s.io/pod-security-admission/policy/check_capabilities_restricted_test.go
@@ -22,7 +22,63 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
-func TestCapabilitiesRestricted(t *testing.T) {
+func TestCapabilitiesRestricted_1_25(t *testing.T) {
+	tests := []struct {
+		name         string
+		pod          *corev1.Pod
+		expectReason string
+		expectDetail string
+		allowed      bool
+	}{
+		{
+			name: "multiple containers",
+			pod: &corev1.Pod{Spec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{Name: "a", SecurityContext: &corev1.SecurityContext{Capabilities: &corev1.Capabilities{Add: []corev1.Capability{"FOO", "BAR"}}}},
+					{Name: "b", SecurityContext: &corev1.SecurityContext{Capabilities: &corev1.Capabilities{Add: []corev1.Capability{"BAR", "BAZ"}}}},
+					{Name: "c", SecurityContext: &corev1.SecurityContext{Capabilities: &corev1.Capabilities{Add: []corev1.Capability{"NET_BIND_SERVICE", "CHOWN"}, Drop: []corev1.Capability{"ALL", "FOO"}}}},
+				}}},
+			expectReason: `unrestricted capabilities`,
+			expectDetail: `containers "a", "b" must set securityContext.capabilities.drop=["ALL"]; containers "a", "b", "c" must not include "BAR", "BAZ", "CHOWN", "FOO" in securityContext.capabilities.add`,
+		},
+		{
+			name: "windows pod, admit without checking capabilities",
+			pod: &corev1.Pod{Spec: corev1.PodSpec{
+				OS: &corev1.PodOS{Name: corev1.Windows},
+				Containers: []corev1.Container{
+					{Name: "a"},
+				}}},
+			allowed: true,
+		},
+		{
+			name: "linux pod, reject if security context is not set",
+			pod: &corev1.Pod{Spec: corev1.PodSpec{
+				OS: &corev1.PodOS{Name: corev1.Linux},
+				Containers: []corev1.Container{
+					{Name: "a"},
+				}}},
+			expectReason: `unrestricted capabilities`,
+			expectDetail: `container "a" must set securityContext.capabilities.drop=["ALL"]`,
+			allowed:      false,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result := capabilitiesRestricted_1_25(&tc.pod.ObjectMeta, &tc.pod.Spec)
+			if result.Allowed && !tc.allowed {
+				t.Fatal("expected disallowed")
+			}
+			if e, a := tc.expectReason, result.ForbiddenReason; e != a {
+				t.Errorf("expected\n%s\ngot\n%s", e, a)
+			}
+			if e, a := tc.expectDetail, result.ForbiddenDetail; e != a {
+				t.Errorf("expected\n%s\ngot\n%s", e, a)
+			}
+		})
+	}
+}
+
+func TestCapabilitiesRestricted_1_22(t *testing.T) {
 	tests := []struct {
 		name         string
 		pod          *corev1.Pod
@@ -41,7 +97,6 @@ func TestCapabilitiesRestricted(t *testing.T) {
 			expectDetail: `containers "a", "b" must set securityContext.capabilities.drop=["ALL"]; containers "a", "b", "c" must not include "BAR", "BAZ", "CHOWN", "FOO" in securityContext.capabilities.add`,
 		},
 	}
-
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			result := capabilitiesRestricted_1_22(&tc.pod.ObjectMeta, &tc.pod.Spec)

--- a/staging/src/k8s.io/pod-security-admission/policy/check_seccompProfile_restricted_test.go
+++ b/staging/src/k8s.io/pod-security-admission/policy/check_seccompProfile_restricted_test.go
@@ -22,7 +22,105 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
-func TestSeccompProfileRestricted(t *testing.T) {
+func TestSeccompProfileRestricted_1_25(t *testing.T) {
+	tests := []struct {
+		name         string
+		pod          *corev1.Pod
+		expectReason string
+		expectDetail string
+		allowed      bool
+	}{
+		{
+			name: "no explicit seccomp",
+			pod: &corev1.Pod{Spec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{Name: "a"},
+				},
+			}},
+			expectReason: `seccompProfile`,
+			expectDetail: `pod or container "a" must set securityContext.seccompProfile.type to "RuntimeDefault" or "Localhost"`,
+		},
+		{
+			name: "no explicit seccomp, windows Pod",
+			pod: &corev1.Pod{Spec: corev1.PodSpec{
+				OS: &corev1.PodOS{Name: corev1.Windows},
+				Containers: []corev1.Container{
+					{Name: "a"},
+				},
+			}},
+			allowed: true,
+		},
+		{
+			name: "no explicit seccomp, linux pod",
+			pod: &corev1.Pod{Spec: corev1.PodSpec{
+				OS: &corev1.PodOS{Name: corev1.Linux},
+				Containers: []corev1.Container{
+					{Name: "a"},
+				},
+			}},
+			expectReason: `seccompProfile`,
+			expectDetail: `pod or container "a" must set securityContext.seccompProfile.type to "RuntimeDefault" or "Localhost"`,
+			allowed:      false,
+		},
+		{
+			name: "pod seccomp invalid",
+			pod: &corev1.Pod{Spec: corev1.PodSpec{
+				SecurityContext: &corev1.PodSecurityContext{SeccompProfile: &corev1.SeccompProfile{Type: corev1.SeccompProfileTypeUnconfined}},
+				Containers: []corev1.Container{
+					{Name: "a", SecurityContext: nil},
+				},
+			}},
+			expectReason: `seccompProfile`,
+			expectDetail: `pod must not set securityContext.seccompProfile.type to "Unconfined"`,
+		},
+		{
+			name: "containers seccomp invalid",
+			pod: &corev1.Pod{Spec: corev1.PodSpec{
+				SecurityContext: &corev1.PodSecurityContext{SeccompProfile: &corev1.SeccompProfile{Type: corev1.SeccompProfileTypeRuntimeDefault}},
+				Containers: []corev1.Container{
+					{Name: "a", SecurityContext: nil},
+					{Name: "b", SecurityContext: &corev1.SecurityContext{}},
+					{Name: "c", SecurityContext: &corev1.SecurityContext{SeccompProfile: &corev1.SeccompProfile{Type: corev1.SeccompProfileTypeUnconfined}}},
+					{Name: "d", SecurityContext: &corev1.SecurityContext{SeccompProfile: &corev1.SeccompProfile{Type: corev1.SeccompProfileTypeUnconfined}}},
+					{Name: "e", SecurityContext: &corev1.SecurityContext{SeccompProfile: &corev1.SeccompProfile{Type: corev1.SeccompProfileTypeRuntimeDefault}}},
+					{Name: "f", SecurityContext: &corev1.SecurityContext{SeccompProfile: &corev1.SeccompProfile{Type: corev1.SeccompProfileTypeRuntimeDefault}}},
+				},
+			}},
+			expectReason: `seccompProfile`,
+			expectDetail: `containers "c", "d" must not set securityContext.seccompProfile.type to "Unconfined"`,
+		},
+		{
+			name: "pod nil, container fallthrough",
+			pod: &corev1.Pod{Spec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{Name: "a", SecurityContext: nil},
+					{Name: "b", SecurityContext: &corev1.SecurityContext{}},
+					{Name: "d", SecurityContext: &corev1.SecurityContext{SeccompProfile: &corev1.SeccompProfile{Type: corev1.SeccompProfileTypeRuntimeDefault}}},
+					{Name: "e", SecurityContext: &corev1.SecurityContext{SeccompProfile: &corev1.SeccompProfile{Type: corev1.SeccompProfileTypeRuntimeDefault}}},
+				},
+			}},
+			expectReason: `seccompProfile`,
+			expectDetail: `pod or containers "a", "b" must set securityContext.seccompProfile.type to "RuntimeDefault" or "Localhost"`,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result := seccompProfileRestricted_1_25(&tc.pod.ObjectMeta, &tc.pod.Spec)
+			if result.Allowed && !tc.allowed {
+				t.Fatal("expected disallowed")
+			}
+			if e, a := tc.expectReason, result.ForbiddenReason; e != a {
+				t.Errorf("expected\n%s\ngot\n%s", e, a)
+			}
+			if e, a := tc.expectDetail, result.ForbiddenDetail; e != a {
+				t.Errorf("expected\n%s\ngot\n%s", e, a)
+			}
+		})
+	}
+}
+
+func TestSeccompProfileRestricted_1_19(t *testing.T) {
 	tests := []struct {
 		name         string
 		pod          *corev1.Pod

--- a/staging/src/k8s.io/pod-security-admission/test/fixtures_allowPrivilegeEscalation.go
+++ b/staging/src/k8s.io/pod-security-admission/test/fixtures_allowPrivilegeEscalation.go
@@ -38,6 +38,9 @@ func init() {
 			return nil
 		},
 		generateFail: func(p *corev1.Pod) []*corev1.Pod {
+			if p.Spec.OS != nil && p.Spec.OS.Name == corev1.Windows {
+				return []*corev1.Pod{}
+			}
 			return []*corev1.Pod{
 				// explicit true
 				tweak(p, func(p *corev1.Pod) {

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.24/fail/apparmorprofile0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.24/fail/apparmorprofile0.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    container.apparmor.security.beta.kubernetes.io/container1: unconfined
+  name: apparmorprofile0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.24/fail/apparmorprofile1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.24/fail/apparmorprofile1.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    container.apparmor.security.beta.kubernetes.io/initcontainer1: unconfined
+  name: apparmorprofile1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.24/fail/capabilities_baseline0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.24/fail/capabilities_baseline0.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: capabilities_baseline0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      capabilities:
+        add:
+        - NET_RAW
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      capabilities: {}
+  securityContext: {}

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.24/fail/capabilities_baseline1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.24/fail/capabilities_baseline1.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: capabilities_baseline1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      capabilities: {}
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      capabilities:
+        add:
+        - NET_RAW
+  securityContext: {}

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.24/fail/capabilities_baseline2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.24/fail/capabilities_baseline2.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: capabilities_baseline2
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      capabilities:
+        add:
+        - chown
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      capabilities: {}
+  securityContext: {}

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.24/fail/capabilities_baseline3.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.24/fail/capabilities_baseline3.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: capabilities_baseline3
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      capabilities:
+        add:
+        - CAP_CHOWN
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      capabilities: {}
+  securityContext: {}

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.24/fail/hostnamespaces0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.24/fail/hostnamespaces0.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  hostIPC: true
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.24/fail/hostnamespaces1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.24/fail/hostnamespaces1.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  hostNetwork: true
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.24/fail/hostnamespaces2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.24/fail/hostnamespaces2.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces2
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  hostPID: true
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.24/fail/hostpathvolumes0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.24/fail/hostpathvolumes0.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostpathvolumes0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+  volumes:
+  - emptyDir: {}
+    name: volume-emptydir
+  - hostPath:
+      path: /a
+    name: volume-hostpath

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.24/fail/hostpathvolumes1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.24/fail/hostpathvolumes1.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostpathvolumes1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+  volumes:
+  - hostPath:
+      path: /a
+    name: volume-hostpath-a
+  - hostPath:
+      path: /b
+    name: volume-hostpath-b

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.24/fail/hostports0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.24/fail/hostports0.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    ports:
+    - containerPort: 12345
+      hostPort: 12345
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.24/fail/hostports1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.24/fail/hostports1.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    ports:
+    - containerPort: 12346
+      hostPort: 12346

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.24/fail/hostports2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.24/fail/hostports2.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports2
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    ports:
+    - containerPort: 12345
+      hostPort: 12345
+    - containerPort: 12347
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    ports:
+    - containerPort: 12346
+      hostPort: 12346
+    - containerPort: 12348

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.24/fail/privileged0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.24/fail/privileged0.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: privileged0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      privileged: true
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext: {}
+  securityContext: {}

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.24/fail/privileged1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.24/fail/privileged1.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: privileged1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext: {}
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      privileged: true
+  securityContext: {}

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.24/fail/procmount0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.24/fail/procmount0.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: procmount0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      procMount: Unmasked
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext: {}
+  securityContext: {}

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.24/fail/procmount1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.24/fail/procmount1.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: procmount1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext: {}
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      procMount: Unmasked
+  securityContext: {}

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.24/fail/seccompprofile_baseline0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.24/fail/seccompprofile_baseline0.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: seccompprofile_baseline0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext: {}
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext: {}
+  securityContext:
+    seccompProfile:
+      type: Unconfined

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.24/fail/seccompprofile_baseline1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.24/fail/seccompprofile_baseline1.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: seccompprofile_baseline1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      seccompProfile:
+        type: Unconfined
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext: {}
+  securityContext: {}

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.24/fail/seccompprofile_baseline2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.24/fail/seccompprofile_baseline2.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: seccompprofile_baseline2
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext: {}
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      seccompProfile:
+        type: Unconfined
+  securityContext: {}

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.24/fail/selinuxoptions0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.24/fail/selinuxoptions0.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: selinuxoptions0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      seLinuxOptions: {}
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      seLinuxOptions: {}
+  securityContext:
+    seLinuxOptions:
+      type: somevalue

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.24/fail/selinuxoptions1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.24/fail/selinuxoptions1.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: selinuxoptions1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      seLinuxOptions:
+        type: somevalue
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      seLinuxOptions: {}
+  securityContext:
+    seLinuxOptions: {}

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.24/fail/selinuxoptions2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.24/fail/selinuxoptions2.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: selinuxoptions2
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      seLinuxOptions: {}
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      seLinuxOptions:
+        type: somevalue
+  securityContext:
+    seLinuxOptions: {}

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.24/fail/selinuxoptions3.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.24/fail/selinuxoptions3.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: selinuxoptions3
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      seLinuxOptions: {}
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      seLinuxOptions: {}
+  securityContext:
+    seLinuxOptions:
+      user: somevalue

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.24/fail/selinuxoptions4.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.24/fail/selinuxoptions4.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: selinuxoptions4
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      seLinuxOptions: {}
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      seLinuxOptions: {}
+  securityContext:
+    seLinuxOptions:
+      role: somevalue

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.24/fail/sysctls0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.24/fail/sysctls0.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: sysctls0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+  securityContext:
+    sysctls:
+    - name: othersysctl
+      value: other

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.24/fail/windowshostprocess0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.24/fail/windowshostprocess0.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: windowshostprocess0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      windowsOptions: {}
+  hostNetwork: true
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      windowsOptions: {}
+  securityContext:
+    windowsOptions:
+      hostProcess: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.24/fail/windowshostprocess1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.24/fail/windowshostprocess1.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: windowshostprocess1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      windowsOptions:
+        hostProcess: true
+  hostNetwork: true
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      windowsOptions:
+        hostProcess: true
+  securityContext:
+    windowsOptions: {}

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.24/pass/apparmorprofile0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.24/pass/apparmorprofile0.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    container.apparmor.security.beta.kubernetes.io/container1: localhost/foo
+  name: apparmorprofile0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.24/pass/base.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.24/pass/base.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: base
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.24/pass/capabilities_baseline0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.24/pass/capabilities_baseline0.yaml
@@ -1,0 +1,44 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: capabilities_baseline0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      capabilities:
+        add:
+        - AUDIT_WRITE
+        - CHOWN
+        - DAC_OVERRIDE
+        - FOWNER
+        - FSETID
+        - KILL
+        - MKNOD
+        - NET_BIND_SERVICE
+        - SETFCAP
+        - SETGID
+        - SETPCAP
+        - SETUID
+        - SYS_CHROOT
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      capabilities:
+        add:
+        - AUDIT_WRITE
+        - CHOWN
+        - DAC_OVERRIDE
+        - FOWNER
+        - FSETID
+        - KILL
+        - MKNOD
+        - NET_BIND_SERVICE
+        - SETFCAP
+        - SETGID
+        - SETPCAP
+        - SETUID
+        - SYS_CHROOT
+  securityContext: {}

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.24/pass/hostports0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.24/pass/hostports0.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    ports:
+    - containerPort: 12345
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    ports:
+    - containerPort: 12346

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.24/pass/privileged0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.24/pass/privileged0.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: privileged0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      privileged: false
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      privileged: false
+  securityContext: {}

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.24/pass/procmount0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.24/pass/procmount0.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: procmount0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      procMount: Default
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      procMount: Default
+  securityContext: {}

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.24/pass/seccompprofile_baseline0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.24/pass/seccompprofile_baseline0.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: seccompprofile_baseline0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      seccompProfile:
+        type: RuntimeDefault
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext: {}
+  securityContext:
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.24/pass/selinuxoptions0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.24/pass/selinuxoptions0.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: selinuxoptions0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext: {}
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      seLinuxOptions: {}
+  securityContext: {}

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.24/pass/selinuxoptions1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.24/pass/selinuxoptions1.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: selinuxoptions1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      seLinuxOptions:
+        level: somevalue
+        type: container_init_t
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      seLinuxOptions:
+        type: container_kvm_t
+  securityContext:
+    seLinuxOptions:
+      type: container_t

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.24/pass/sysctls0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.24/pass/sysctls0.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: sysctls0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+  securityContext: {}

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.24/pass/sysctls1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.24/pass/sysctls1.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: sysctls1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+  securityContext:
+    sysctls:
+    - name: kernel.shm_rmid_forced
+      value: "0"
+    - name: net.ipv4.ip_local_port_range
+      value: 1024 65535
+    - name: net.ipv4.tcp_syncookies
+      value: "0"
+    - name: net.ipv4.ping_group_range
+      value: 1 0
+    - name: net.ipv4.ip_unprivileged_port_start
+      value: "1024"

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.25/fail/apparmorprofile0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.25/fail/apparmorprofile0.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    container.apparmor.security.beta.kubernetes.io/container1: unconfined
+  name: apparmorprofile0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.25/fail/apparmorprofile1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.25/fail/apparmorprofile1.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    container.apparmor.security.beta.kubernetes.io/initcontainer1: unconfined
+  name: apparmorprofile1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.25/fail/capabilities_baseline0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.25/fail/capabilities_baseline0.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: capabilities_baseline0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      capabilities:
+        add:
+        - NET_RAW
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      capabilities: {}
+  securityContext: {}

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.25/fail/capabilities_baseline1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.25/fail/capabilities_baseline1.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: capabilities_baseline1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      capabilities: {}
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      capabilities:
+        add:
+        - NET_RAW
+  securityContext: {}

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.25/fail/capabilities_baseline2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.25/fail/capabilities_baseline2.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: capabilities_baseline2
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      capabilities:
+        add:
+        - chown
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      capabilities: {}
+  securityContext: {}

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.25/fail/capabilities_baseline3.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.25/fail/capabilities_baseline3.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: capabilities_baseline3
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      capabilities:
+        add:
+        - CAP_CHOWN
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      capabilities: {}
+  securityContext: {}

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.25/fail/hostnamespaces0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.25/fail/hostnamespaces0.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  hostIPC: true
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.25/fail/hostnamespaces1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.25/fail/hostnamespaces1.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  hostNetwork: true
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.25/fail/hostnamespaces2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.25/fail/hostnamespaces2.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces2
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  hostPID: true
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.25/fail/hostpathvolumes0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.25/fail/hostpathvolumes0.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostpathvolumes0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+  volumes:
+  - emptyDir: {}
+    name: volume-emptydir
+  - hostPath:
+      path: /a
+    name: volume-hostpath

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.25/fail/hostpathvolumes1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.25/fail/hostpathvolumes1.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostpathvolumes1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+  volumes:
+  - hostPath:
+      path: /a
+    name: volume-hostpath-a
+  - hostPath:
+      path: /b
+    name: volume-hostpath-b

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.25/fail/hostports0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.25/fail/hostports0.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    ports:
+    - containerPort: 12345
+      hostPort: 12345
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.25/fail/hostports1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.25/fail/hostports1.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    ports:
+    - containerPort: 12346
+      hostPort: 12346

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.25/fail/hostports2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.25/fail/hostports2.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports2
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    ports:
+    - containerPort: 12345
+      hostPort: 12345
+    - containerPort: 12347
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    ports:
+    - containerPort: 12346
+      hostPort: 12346
+    - containerPort: 12348

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.25/fail/privileged0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.25/fail/privileged0.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: privileged0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      privileged: true
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext: {}
+  securityContext: {}

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.25/fail/privileged1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.25/fail/privileged1.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: privileged1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext: {}
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      privileged: true
+  securityContext: {}

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.25/fail/procmount0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.25/fail/procmount0.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: procmount0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      procMount: Unmasked
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext: {}
+  securityContext: {}

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.25/fail/procmount1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.25/fail/procmount1.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: procmount1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext: {}
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      procMount: Unmasked
+  securityContext: {}

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.25/fail/seccompprofile_baseline0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.25/fail/seccompprofile_baseline0.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: seccompprofile_baseline0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext: {}
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext: {}
+  securityContext:
+    seccompProfile:
+      type: Unconfined

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.25/fail/seccompprofile_baseline1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.25/fail/seccompprofile_baseline1.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: seccompprofile_baseline1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      seccompProfile:
+        type: Unconfined
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext: {}
+  securityContext: {}

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.25/fail/seccompprofile_baseline2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.25/fail/seccompprofile_baseline2.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: seccompprofile_baseline2
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext: {}
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      seccompProfile:
+        type: Unconfined
+  securityContext: {}

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.25/fail/selinuxoptions0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.25/fail/selinuxoptions0.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: selinuxoptions0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      seLinuxOptions: {}
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      seLinuxOptions: {}
+  securityContext:
+    seLinuxOptions:
+      type: somevalue

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.25/fail/selinuxoptions1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.25/fail/selinuxoptions1.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: selinuxoptions1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      seLinuxOptions:
+        type: somevalue
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      seLinuxOptions: {}
+  securityContext:
+    seLinuxOptions: {}

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.25/fail/selinuxoptions2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.25/fail/selinuxoptions2.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: selinuxoptions2
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      seLinuxOptions: {}
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      seLinuxOptions:
+        type: somevalue
+  securityContext:
+    seLinuxOptions: {}

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.25/fail/selinuxoptions3.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.25/fail/selinuxoptions3.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: selinuxoptions3
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      seLinuxOptions: {}
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      seLinuxOptions: {}
+  securityContext:
+    seLinuxOptions:
+      user: somevalue

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.25/fail/selinuxoptions4.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.25/fail/selinuxoptions4.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: selinuxoptions4
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      seLinuxOptions: {}
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      seLinuxOptions: {}
+  securityContext:
+    seLinuxOptions:
+      role: somevalue

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.25/fail/sysctls0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.25/fail/sysctls0.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: sysctls0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+  securityContext:
+    sysctls:
+    - name: othersysctl
+      value: other

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.25/fail/windowshostprocess0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.25/fail/windowshostprocess0.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: windowshostprocess0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      windowsOptions: {}
+  hostNetwork: true
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      windowsOptions: {}
+  securityContext:
+    windowsOptions:
+      hostProcess: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.25/fail/windowshostprocess1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.25/fail/windowshostprocess1.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: windowshostprocess1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      windowsOptions:
+        hostProcess: true
+  hostNetwork: true
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      windowsOptions:
+        hostProcess: true
+  securityContext:
+    windowsOptions: {}

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.25/pass/apparmorprofile0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.25/pass/apparmorprofile0.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    container.apparmor.security.beta.kubernetes.io/container1: localhost/foo
+  name: apparmorprofile0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.25/pass/base.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.25/pass/base.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: base
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.25/pass/capabilities_baseline0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.25/pass/capabilities_baseline0.yaml
@@ -1,0 +1,44 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: capabilities_baseline0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      capabilities:
+        add:
+        - AUDIT_WRITE
+        - CHOWN
+        - DAC_OVERRIDE
+        - FOWNER
+        - FSETID
+        - KILL
+        - MKNOD
+        - NET_BIND_SERVICE
+        - SETFCAP
+        - SETGID
+        - SETPCAP
+        - SETUID
+        - SYS_CHROOT
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      capabilities:
+        add:
+        - AUDIT_WRITE
+        - CHOWN
+        - DAC_OVERRIDE
+        - FOWNER
+        - FSETID
+        - KILL
+        - MKNOD
+        - NET_BIND_SERVICE
+        - SETFCAP
+        - SETGID
+        - SETPCAP
+        - SETUID
+        - SYS_CHROOT
+  securityContext: {}

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.25/pass/hostports0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.25/pass/hostports0.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    ports:
+    - containerPort: 12345
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    ports:
+    - containerPort: 12346

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.25/pass/privileged0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.25/pass/privileged0.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: privileged0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      privileged: false
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      privileged: false
+  securityContext: {}

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.25/pass/procmount0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.25/pass/procmount0.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: procmount0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      procMount: Default
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      procMount: Default
+  securityContext: {}

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.25/pass/seccompprofile_baseline0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.25/pass/seccompprofile_baseline0.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: seccompprofile_baseline0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      seccompProfile:
+        type: RuntimeDefault
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext: {}
+  securityContext:
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.25/pass/selinuxoptions0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.25/pass/selinuxoptions0.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: selinuxoptions0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext: {}
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      seLinuxOptions: {}
+  securityContext: {}

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.25/pass/selinuxoptions1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.25/pass/selinuxoptions1.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: selinuxoptions1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      seLinuxOptions:
+        level: somevalue
+        type: container_init_t
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      seLinuxOptions:
+        type: container_kvm_t
+  securityContext:
+    seLinuxOptions:
+      type: container_t

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.25/pass/sysctls0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.25/pass/sysctls0.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: sysctls0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+  securityContext: {}

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.25/pass/sysctls1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.25/pass/sysctls1.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: sysctls1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+  securityContext:
+    sysctls:
+    - name: kernel.shm_rmid_forced
+      value: "0"
+    - name: net.ipv4.ip_local_port_range
+      value: 1024 65535
+    - name: net.ipv4.tcp_syncookies
+      value: "0"
+    - name: net.ipv4.ping_group_range
+      value: 1 0
+    - name: net.ipv4.ip_unprivileged_port_start
+      value: "1024"

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.24/fail/allowprivilegeescalation0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.24/fail/allowprivilegeescalation0.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: allowprivilegeescalation0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: true
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.24/fail/allowprivilegeescalation1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.24/fail/allowprivilegeescalation1.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: allowprivilegeescalation1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: true
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.24/fail/allowprivilegeescalation2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.24/fail/allowprivilegeescalation2.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: allowprivilegeescalation2
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.24/fail/allowprivilegeescalation3.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.24/fail/allowprivilegeescalation3.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: allowprivilegeescalation3
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.24/fail/apparmorprofile0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.24/fail/apparmorprofile0.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    container.apparmor.security.beta.kubernetes.io/container1: unconfined
+  name: apparmorprofile0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.24/fail/apparmorprofile1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.24/fail/apparmorprofile1.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    container.apparmor.security.beta.kubernetes.io/initcontainer1: unconfined
+  name: apparmorprofile1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.24/fail/capabilities_baseline0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.24/fail/capabilities_baseline0.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: capabilities_baseline0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        add:
+        - NET_RAW
+        drop:
+        - ALL
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.24/fail/capabilities_baseline1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.24/fail/capabilities_baseline1.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: capabilities_baseline1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        add:
+        - NET_RAW
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.24/fail/capabilities_baseline2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.24/fail/capabilities_baseline2.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: capabilities_baseline2
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        add:
+        - chown
+        drop:
+        - ALL
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.24/fail/capabilities_baseline3.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.24/fail/capabilities_baseline3.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: capabilities_baseline3
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        add:
+        - CAP_CHOWN
+        drop:
+        - ALL
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.24/fail/capabilities_restricted0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.24/fail/capabilities_restricted0.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: capabilities_restricted0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities: {}
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.24/fail/capabilities_restricted1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.24/fail/capabilities_restricted1.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: capabilities_restricted1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities: {}
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.24/fail/capabilities_restricted2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.24/fail/capabilities_restricted2.yaml
@@ -1,0 +1,97 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: capabilities_restricted2
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - SYS_TIME
+        - SYS_MODULE
+        - SYS_RAWIO
+        - SYS_PACCT
+        - SYS_ADMIN
+        - SYS_NICE
+        - SYS_RESOURCE
+        - SYS_TIME
+        - SYS_TTY_CONFIG
+        - MKNOD
+        - AUDIT_WRITE
+        - AUDIT_CONTROL
+        - MAC_OVERRIDE
+        - MAC_ADMIN
+        - NET_ADMIN
+        - SYSLOG
+        - CHOWN
+        - NET_RAW
+        - DAC_OVERRIDE
+        - FOWNER
+        - DAC_READ_SEARCH
+        - FSETID
+        - KILL
+        - SETGID
+        - SETUID
+        - LINUX_IMMUTABLE
+        - NET_BIND_SERVICE
+        - NET_BROADCAST
+        - IPC_LOCK
+        - IPC_OWNER
+        - SYS_CHROOT
+        - SYS_PTRACE
+        - SYS_BOOT
+        - LEASE
+        - SETFCAP
+        - WAKE_ALARM
+        - BLOCK_SUSPEND
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - SYS_TIME
+        - SYS_MODULE
+        - SYS_RAWIO
+        - SYS_PACCT
+        - SYS_ADMIN
+        - SYS_NICE
+        - SYS_RESOURCE
+        - SYS_TIME
+        - SYS_TTY_CONFIG
+        - MKNOD
+        - AUDIT_WRITE
+        - AUDIT_CONTROL
+        - MAC_OVERRIDE
+        - MAC_ADMIN
+        - NET_ADMIN
+        - SYSLOG
+        - CHOWN
+        - NET_RAW
+        - DAC_OVERRIDE
+        - FOWNER
+        - DAC_READ_SEARCH
+        - FSETID
+        - KILL
+        - SETGID
+        - SETUID
+        - LINUX_IMMUTABLE
+        - NET_BIND_SERVICE
+        - NET_BROADCAST
+        - IPC_LOCK
+        - IPC_OWNER
+        - SYS_CHROOT
+        - SYS_PTRACE
+        - SYS_BOOT
+        - LEASE
+        - SETFCAP
+        - WAKE_ALARM
+        - BLOCK_SUSPEND
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.24/fail/capabilities_restricted3.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.24/fail/capabilities_restricted3.yaml
@@ -1,0 +1,53 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: capabilities_restricted3
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        add:
+        - AUDIT_WRITE
+        - CHOWN
+        - DAC_OVERRIDE
+        - FOWNER
+        - FSETID
+        - KILL
+        - MKNOD
+        - NET_BIND_SERVICE
+        - SETFCAP
+        - SETGID
+        - SETPCAP
+        - SETUID
+        - SYS_CHROOT
+        drop:
+        - ALL
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        add:
+        - AUDIT_WRITE
+        - CHOWN
+        - DAC_OVERRIDE
+        - FOWNER
+        - FSETID
+        - KILL
+        - MKNOD
+        - NET_BIND_SERVICE
+        - SETFCAP
+        - SETGID
+        - SETPCAP
+        - SETUID
+        - SYS_CHROOT
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.24/fail/hostnamespaces0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.24/fail/hostnamespaces0.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  hostIPC: true
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.24/fail/hostnamespaces1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.24/fail/hostnamespaces1.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  hostNetwork: true
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.24/fail/hostnamespaces2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.24/fail/hostnamespaces2.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces2
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  hostPID: true
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.24/fail/hostpathvolumes0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.24/fail/hostpathvolumes0.yaml
@@ -1,0 +1,31 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostpathvolumes0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  volumes:
+  - emptyDir: {}
+    name: volume-emptydir
+  - hostPath:
+      path: /a
+    name: volume-hostpath

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.24/fail/hostpathvolumes1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.24/fail/hostpathvolumes1.yaml
@@ -1,0 +1,32 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostpathvolumes1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  volumes:
+  - hostPath:
+      path: /a
+    name: volume-hostpath-a
+  - hostPath:
+      path: /b
+    name: volume-hostpath-b

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.24/fail/hostports0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.24/fail/hostports0.yaml
@@ -1,0 +1,28 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    ports:
+    - containerPort: 12345
+      hostPort: 12345
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.24/fail/hostports1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.24/fail/hostports1.yaml
@@ -1,0 +1,28 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    ports:
+    - containerPort: 12346
+      hostPort: 12346
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.24/fail/hostports2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.24/fail/hostports2.yaml
@@ -1,0 +1,33 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports2
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    ports:
+    - containerPort: 12345
+      hostPort: 12345
+    - containerPort: 12347
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    ports:
+    - containerPort: 12346
+      hostPort: 12346
+    - containerPort: 12348
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.24/fail/privileged0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.24/fail/privileged0.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: privileged0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      capabilities:
+        drop:
+        - ALL
+      privileged: true
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.24/fail/privileged1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.24/fail/privileged1.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: privileged1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      capabilities:
+        drop:
+        - ALL
+      privileged: true
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.24/fail/procmount0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.24/fail/procmount0.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: procmount0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      procMount: Unmasked
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.24/fail/procmount1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.24/fail/procmount1.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: procmount1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      procMount: Unmasked
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.24/fail/restrictedvolumes0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.24/fail/restrictedvolumes0.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: restrictedvolumes0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  volumes:
+  - gcePersistentDisk:
+      pdName: test
+    name: volume1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.24/fail/restrictedvolumes1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.24/fail/restrictedvolumes1.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: restrictedvolumes1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  volumes:
+  - awsElasticBlockStore:
+      volumeID: test
+    name: volume1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.24/fail/restrictedvolumes10.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.24/fail/restrictedvolumes10.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: restrictedvolumes10
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  volumes:
+  - flocker:
+      datasetName: test
+    name: volume1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.24/fail/restrictedvolumes11.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.24/fail/restrictedvolumes11.yaml
@@ -1,0 +1,30 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: restrictedvolumes11
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  volumes:
+  - fc:
+      wwids:
+      - test
+    name: volume1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.24/fail/restrictedvolumes12.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.24/fail/restrictedvolumes12.yaml
@@ -1,0 +1,30 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: restrictedvolumes12
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  volumes:
+  - azureFile:
+      secretName: test
+      shareName: test
+    name: volume1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.24/fail/restrictedvolumes13.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.24/fail/restrictedvolumes13.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: restrictedvolumes13
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  volumes:
+  - name: volume1
+    vsphereVolume:
+      volumePath: test

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.24/fail/restrictedvolumes14.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.24/fail/restrictedvolumes14.yaml
@@ -1,0 +1,30 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: restrictedvolumes14
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  volumes:
+  - name: volume1
+    quobyte:
+      registry: localhost:1234
+      volume: test

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.24/fail/restrictedvolumes15.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.24/fail/restrictedvolumes15.yaml
@@ -1,0 +1,30 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: restrictedvolumes15
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  volumes:
+  - azureDisk:
+      diskName: test
+      diskURI: https://test.blob.core.windows.net/test/test.vhd
+    name: volume1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.24/fail/restrictedvolumes16.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.24/fail/restrictedvolumes16.yaml
@@ -1,0 +1,30 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: restrictedvolumes16
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  volumes:
+  - name: volume1
+    portworxVolume:
+      fsType: ext4
+      volumeID: test

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.24/fail/restrictedvolumes17.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.24/fail/restrictedvolumes17.yaml
@@ -1,0 +1,32 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: restrictedvolumes17
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  volumes:
+  - name: volume1
+    scaleIO:
+      gateway: localhost
+      secretRef: null
+      system: test
+      volumeName: test

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.24/fail/restrictedvolumes18.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.24/fail/restrictedvolumes18.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: restrictedvolumes18
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  volumes:
+  - name: volume1
+    storageos:
+      volumeName: test

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.24/fail/restrictedvolumes19.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.24/fail/restrictedvolumes19.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: restrictedvolumes19
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  volumes:
+  - hostPath:
+      path: /dev/null
+    name: volume1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.24/fail/restrictedvolumes2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.24/fail/restrictedvolumes2.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: restrictedvolumes2
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  volumes:
+  - gitRepo:
+      repository: github.com/kubernetes/kubernetes
+    name: volume1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.24/fail/restrictedvolumes3.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.24/fail/restrictedvolumes3.yaml
@@ -1,0 +1,30 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: restrictedvolumes3
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  volumes:
+  - name: volume1
+    nfs:
+      path: /test
+      server: test

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.24/fail/restrictedvolumes4.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.24/fail/restrictedvolumes4.yaml
@@ -1,0 +1,31 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: restrictedvolumes4
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  volumes:
+  - iscsi:
+      iqn: iqn.2001-04.com.example:storage.kube.sys1.xyz
+      lun: 0
+      targetPortal: test
+    name: volume1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.24/fail/restrictedvolumes5.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.24/fail/restrictedvolumes5.yaml
@@ -1,0 +1,30 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: restrictedvolumes5
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  volumes:
+  - glusterfs:
+      endpoints: test
+      path: test
+    name: volume1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.24/fail/restrictedvolumes6.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.24/fail/restrictedvolumes6.yaml
@@ -1,0 +1,31 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: restrictedvolumes6
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  volumes:
+  - name: volume1
+    rbd:
+      image: test
+      monitors:
+      - test

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.24/fail/restrictedvolumes7.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.24/fail/restrictedvolumes7.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: restrictedvolumes7
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  volumes:
+  - flexVolume:
+      driver: test
+    name: volume1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.24/fail/restrictedvolumes8.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.24/fail/restrictedvolumes8.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: restrictedvolumes8
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  volumes:
+  - cinder:
+      volumeID: test
+    name: volume1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.24/fail/restrictedvolumes9.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.24/fail/restrictedvolumes9.yaml
@@ -1,0 +1,30 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: restrictedvolumes9
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  volumes:
+  - cephfs:
+      monitors:
+      - test
+    name: volume1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.24/fail/runasnonroot0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.24/fail/runasnonroot0.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: runasnonroot0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.24/fail/runasnonroot1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.24/fail/runasnonroot1.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: runasnonroot1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: false
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.24/fail/runasnonroot2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.24/fail/runasnonroot2.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: runasnonroot2
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      runAsNonRoot: false
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.24/fail/runasnonroot3.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.24/fail/runasnonroot3.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: runasnonroot3
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      runAsNonRoot: false
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.24/fail/runasuser0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.24/fail/runasuser0.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: runasuser0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    runAsUser: 0
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.24/fail/runasuser1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.24/fail/runasuser1.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: runasuser1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      runAsUser: 0
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.24/fail/runasuser2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.24/fail/runasuser2.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: runasuser2
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      runAsUser: 0
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.24/fail/seccompprofile_baseline0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.24/fail/seccompprofile_baseline0.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: seccompprofile_baseline0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: Unconfined

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.24/fail/seccompprofile_baseline1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.24/fail/seccompprofile_baseline1.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: seccompprofile_baseline1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      seccompProfile:
+        type: Unconfined
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.24/fail/seccompprofile_baseline2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.24/fail/seccompprofile_baseline2.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: seccompprofile_baseline2
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      seccompProfile:
+        type: Unconfined
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.24/fail/seccompprofile_restricted0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.24/fail/seccompprofile_restricted0.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: seccompprofile_restricted0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.24/fail/seccompprofile_restricted1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.24/fail/seccompprofile_restricted1.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: seccompprofile_restricted1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: Unconfined

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.24/fail/seccompprofile_restricted2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.24/fail/seccompprofile_restricted2.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: seccompprofile_restricted2
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      seccompProfile:
+        type: RuntimeDefault
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.24/fail/seccompprofile_restricted3.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.24/fail/seccompprofile_restricted3.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: seccompprofile_restricted3
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      seccompProfile:
+        type: RuntimeDefault
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.24/fail/seccompprofile_restricted4.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.24/fail/seccompprofile_restricted4.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: seccompprofile_restricted4
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      seccompProfile:
+        type: RuntimeDefault
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      seccompProfile:
+        type: Unconfined
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.24/fail/selinuxoptions0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.24/fail/selinuxoptions0.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: selinuxoptions0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      seLinuxOptions: {}
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      seLinuxOptions: {}
+  securityContext:
+    runAsNonRoot: true
+    seLinuxOptions:
+      type: somevalue
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.24/fail/selinuxoptions1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.24/fail/selinuxoptions1.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: selinuxoptions1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      seLinuxOptions:
+        type: somevalue
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      seLinuxOptions: {}
+  securityContext:
+    runAsNonRoot: true
+    seLinuxOptions: {}
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.24/fail/selinuxoptions2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.24/fail/selinuxoptions2.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: selinuxoptions2
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      seLinuxOptions: {}
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      seLinuxOptions:
+        type: somevalue
+  securityContext:
+    runAsNonRoot: true
+    seLinuxOptions: {}
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.24/fail/selinuxoptions3.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.24/fail/selinuxoptions3.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: selinuxoptions3
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      seLinuxOptions: {}
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      seLinuxOptions: {}
+  securityContext:
+    runAsNonRoot: true
+    seLinuxOptions:
+      user: somevalue
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.24/fail/selinuxoptions4.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.24/fail/selinuxoptions4.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: selinuxoptions4
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      seLinuxOptions: {}
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      seLinuxOptions: {}
+  securityContext:
+    runAsNonRoot: true
+    seLinuxOptions:
+      role: somevalue
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.24/fail/sysctls0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.24/fail/sysctls0.yaml
@@ -1,0 +1,28 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: sysctls0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+    sysctls:
+    - name: othersysctl
+      value: other

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.24/fail/windowshostprocess0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.24/fail/windowshostprocess0.yaml
@@ -1,0 +1,30 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: windowshostprocess0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      windowsOptions: {}
+  hostNetwork: true
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      windowsOptions: {}
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+    windowsOptions:
+      hostProcess: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.24/fail/windowshostprocess1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.24/fail/windowshostprocess1.yaml
@@ -1,0 +1,31 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: windowshostprocess1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      windowsOptions:
+        hostProcess: true
+  hostNetwork: true
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      windowsOptions:
+        hostProcess: true
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+    windowsOptions: {}

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.24/pass/apparmorprofile0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.24/pass/apparmorprofile0.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    container.apparmor.security.beta.kubernetes.io/container1: localhost/foo
+  name: apparmorprofile0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.24/pass/base.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.24/pass/base.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: base
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.24/pass/capabilities_restricted0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.24/pass/capabilities_restricted0.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: capabilities_restricted0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        add:
+        - NET_BIND_SERVICE
+        drop:
+        - ALL
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        add:
+        - NET_BIND_SERVICE
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.24/pass/hostports0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.24/pass/hostports0.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    ports:
+    - containerPort: 12345
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    ports:
+    - containerPort: 12346
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.24/pass/privileged0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.24/pass/privileged0.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: privileged0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      privileged: false
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      privileged: false
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.24/pass/procmount0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.24/pass/procmount0.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: procmount0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      procMount: Default
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      procMount: Default
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.24/pass/restrictedvolumes0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.24/pass/restrictedvolumes0.yaml
@@ -1,0 +1,47 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: restrictedvolumes0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  volumes:
+  - name: volume0
+  - emptyDir: {}
+    name: volume1
+  - name: volume2
+    secret:
+      secretName: test
+  - name: volume3
+    persistentVolumeClaim:
+      claimName: test
+  - downwardAPI:
+      items:
+      - fieldRef:
+          fieldPath: metadata.labels
+        path: labels
+    name: volume4
+  - configMap:
+      name: test
+    name: volume5
+  - name: volume6
+    projected:
+      sources: []

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.24/pass/runasnonroot0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.24/pass/runasnonroot0.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: runasnonroot0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.24/pass/runasnonroot1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.24/pass/runasnonroot1.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: runasnonroot1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      runAsNonRoot: true
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      runAsNonRoot: true
+  securityContext:
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.24/pass/runasuser0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.24/pass/runasuser0.yaml
@@ -1,0 +1,28 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: runasuser0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      runAsUser: 1000
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      runAsUser: 1000
+  securityContext:
+    runAsNonRoot: true
+    runAsUser: 1000
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.24/pass/seccompprofile_restricted0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.24/pass/seccompprofile_restricted0.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: seccompprofile_restricted0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.24/pass/seccompprofile_restricted1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.24/pass/seccompprofile_restricted1.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: seccompprofile_restricted1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      localhostProfile: testing
+      type: Localhost

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.24/pass/seccompprofile_restricted2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.24/pass/seccompprofile_restricted2.yaml
@@ -1,0 +1,28 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: seccompprofile_restricted2
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      seccompProfile:
+        type: RuntimeDefault
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      seccompProfile:
+        localhostProfile: testing
+        type: Localhost
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.24/pass/selinuxoptions0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.24/pass/selinuxoptions0.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: selinuxoptions0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      seLinuxOptions: {}
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.24/pass/selinuxoptions1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.24/pass/selinuxoptions1.yaml
@@ -1,0 +1,32 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: selinuxoptions1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      seLinuxOptions:
+        level: somevalue
+        type: container_init_t
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      seLinuxOptions:
+        type: container_kvm_t
+  securityContext:
+    runAsNonRoot: true
+    seLinuxOptions:
+      type: container_t
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.24/pass/sysctls0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.24/pass/sysctls0.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: sysctls0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.24/pass/sysctls1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.24/pass/sysctls1.yaml
@@ -1,0 +1,36 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: sysctls1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+    sysctls:
+    - name: kernel.shm_rmid_forced
+      value: "0"
+    - name: net.ipv4.ip_local_port_range
+      value: 1024 65535
+    - name: net.ipv4.tcp_syncookies
+      value: "0"
+    - name: net.ipv4.ping_group_range
+      value: 1 0
+    - name: net.ipv4.ip_unprivileged_port_start
+      value: "1024"

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.25/fail/allowprivilegeescalation0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.25/fail/allowprivilegeescalation0.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: allowprivilegeescalation0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: true
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.25/fail/allowprivilegeescalation1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.25/fail/allowprivilegeescalation1.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: allowprivilegeescalation1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: true
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.25/fail/allowprivilegeescalation2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.25/fail/allowprivilegeescalation2.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: allowprivilegeescalation2
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.25/fail/allowprivilegeescalation3.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.25/fail/allowprivilegeescalation3.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: allowprivilegeescalation3
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.25/fail/apparmorprofile0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.25/fail/apparmorprofile0.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    container.apparmor.security.beta.kubernetes.io/container1: unconfined
+  name: apparmorprofile0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.25/fail/apparmorprofile1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.25/fail/apparmorprofile1.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    container.apparmor.security.beta.kubernetes.io/initcontainer1: unconfined
+  name: apparmorprofile1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.25/fail/capabilities_baseline0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.25/fail/capabilities_baseline0.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: capabilities_baseline0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        add:
+        - NET_RAW
+        drop:
+        - ALL
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.25/fail/capabilities_baseline1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.25/fail/capabilities_baseline1.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: capabilities_baseline1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        add:
+        - NET_RAW
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.25/fail/capabilities_baseline2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.25/fail/capabilities_baseline2.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: capabilities_baseline2
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        add:
+        - chown
+        drop:
+        - ALL
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.25/fail/capabilities_baseline3.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.25/fail/capabilities_baseline3.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: capabilities_baseline3
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        add:
+        - CAP_CHOWN
+        drop:
+        - ALL
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.25/fail/capabilities_restricted0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.25/fail/capabilities_restricted0.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: capabilities_restricted0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities: {}
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.25/fail/capabilities_restricted1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.25/fail/capabilities_restricted1.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: capabilities_restricted1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities: {}
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.25/fail/capabilities_restricted2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.25/fail/capabilities_restricted2.yaml
@@ -1,0 +1,97 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: capabilities_restricted2
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - SYS_TIME
+        - SYS_MODULE
+        - SYS_RAWIO
+        - SYS_PACCT
+        - SYS_ADMIN
+        - SYS_NICE
+        - SYS_RESOURCE
+        - SYS_TIME
+        - SYS_TTY_CONFIG
+        - MKNOD
+        - AUDIT_WRITE
+        - AUDIT_CONTROL
+        - MAC_OVERRIDE
+        - MAC_ADMIN
+        - NET_ADMIN
+        - SYSLOG
+        - CHOWN
+        - NET_RAW
+        - DAC_OVERRIDE
+        - FOWNER
+        - DAC_READ_SEARCH
+        - FSETID
+        - KILL
+        - SETGID
+        - SETUID
+        - LINUX_IMMUTABLE
+        - NET_BIND_SERVICE
+        - NET_BROADCAST
+        - IPC_LOCK
+        - IPC_OWNER
+        - SYS_CHROOT
+        - SYS_PTRACE
+        - SYS_BOOT
+        - LEASE
+        - SETFCAP
+        - WAKE_ALARM
+        - BLOCK_SUSPEND
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - SYS_TIME
+        - SYS_MODULE
+        - SYS_RAWIO
+        - SYS_PACCT
+        - SYS_ADMIN
+        - SYS_NICE
+        - SYS_RESOURCE
+        - SYS_TIME
+        - SYS_TTY_CONFIG
+        - MKNOD
+        - AUDIT_WRITE
+        - AUDIT_CONTROL
+        - MAC_OVERRIDE
+        - MAC_ADMIN
+        - NET_ADMIN
+        - SYSLOG
+        - CHOWN
+        - NET_RAW
+        - DAC_OVERRIDE
+        - FOWNER
+        - DAC_READ_SEARCH
+        - FSETID
+        - KILL
+        - SETGID
+        - SETUID
+        - LINUX_IMMUTABLE
+        - NET_BIND_SERVICE
+        - NET_BROADCAST
+        - IPC_LOCK
+        - IPC_OWNER
+        - SYS_CHROOT
+        - SYS_PTRACE
+        - SYS_BOOT
+        - LEASE
+        - SETFCAP
+        - WAKE_ALARM
+        - BLOCK_SUSPEND
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.25/fail/capabilities_restricted3.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.25/fail/capabilities_restricted3.yaml
@@ -1,0 +1,53 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: capabilities_restricted3
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        add:
+        - AUDIT_WRITE
+        - CHOWN
+        - DAC_OVERRIDE
+        - FOWNER
+        - FSETID
+        - KILL
+        - MKNOD
+        - NET_BIND_SERVICE
+        - SETFCAP
+        - SETGID
+        - SETPCAP
+        - SETUID
+        - SYS_CHROOT
+        drop:
+        - ALL
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        add:
+        - AUDIT_WRITE
+        - CHOWN
+        - DAC_OVERRIDE
+        - FOWNER
+        - FSETID
+        - KILL
+        - MKNOD
+        - NET_BIND_SERVICE
+        - SETFCAP
+        - SETGID
+        - SETPCAP
+        - SETUID
+        - SYS_CHROOT
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.25/fail/hostnamespaces0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.25/fail/hostnamespaces0.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  hostIPC: true
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.25/fail/hostnamespaces1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.25/fail/hostnamespaces1.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  hostNetwork: true
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.25/fail/hostnamespaces2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.25/fail/hostnamespaces2.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces2
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  hostPID: true
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.25/fail/hostpathvolumes0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.25/fail/hostpathvolumes0.yaml
@@ -1,0 +1,31 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostpathvolumes0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  volumes:
+  - emptyDir: {}
+    name: volume-emptydir
+  - hostPath:
+      path: /a
+    name: volume-hostpath

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.25/fail/hostpathvolumes1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.25/fail/hostpathvolumes1.yaml
@@ -1,0 +1,32 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostpathvolumes1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  volumes:
+  - hostPath:
+      path: /a
+    name: volume-hostpath-a
+  - hostPath:
+      path: /b
+    name: volume-hostpath-b

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.25/fail/hostports0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.25/fail/hostports0.yaml
@@ -1,0 +1,28 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    ports:
+    - containerPort: 12345
+      hostPort: 12345
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.25/fail/hostports1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.25/fail/hostports1.yaml
@@ -1,0 +1,28 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    ports:
+    - containerPort: 12346
+      hostPort: 12346
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.25/fail/hostports2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.25/fail/hostports2.yaml
@@ -1,0 +1,33 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports2
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    ports:
+    - containerPort: 12345
+      hostPort: 12345
+    - containerPort: 12347
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    ports:
+    - containerPort: 12346
+      hostPort: 12346
+    - containerPort: 12348
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.25/fail/privileged0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.25/fail/privileged0.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: privileged0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      capabilities:
+        drop:
+        - ALL
+      privileged: true
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.25/fail/privileged1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.25/fail/privileged1.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: privileged1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      capabilities:
+        drop:
+        - ALL
+      privileged: true
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.25/fail/procmount0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.25/fail/procmount0.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: procmount0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      procMount: Unmasked
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.25/fail/procmount1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.25/fail/procmount1.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: procmount1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      procMount: Unmasked
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.25/fail/restrictedvolumes0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.25/fail/restrictedvolumes0.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: restrictedvolumes0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  volumes:
+  - gcePersistentDisk:
+      pdName: test
+    name: volume1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.25/fail/restrictedvolumes1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.25/fail/restrictedvolumes1.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: restrictedvolumes1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  volumes:
+  - awsElasticBlockStore:
+      volumeID: test
+    name: volume1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.25/fail/restrictedvolumes10.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.25/fail/restrictedvolumes10.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: restrictedvolumes10
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  volumes:
+  - flocker:
+      datasetName: test
+    name: volume1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.25/fail/restrictedvolumes11.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.25/fail/restrictedvolumes11.yaml
@@ -1,0 +1,30 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: restrictedvolumes11
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  volumes:
+  - fc:
+      wwids:
+      - test
+    name: volume1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.25/fail/restrictedvolumes12.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.25/fail/restrictedvolumes12.yaml
@@ -1,0 +1,30 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: restrictedvolumes12
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  volumes:
+  - azureFile:
+      secretName: test
+      shareName: test
+    name: volume1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.25/fail/restrictedvolumes13.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.25/fail/restrictedvolumes13.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: restrictedvolumes13
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  volumes:
+  - name: volume1
+    vsphereVolume:
+      volumePath: test

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.25/fail/restrictedvolumes14.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.25/fail/restrictedvolumes14.yaml
@@ -1,0 +1,30 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: restrictedvolumes14
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  volumes:
+  - name: volume1
+    quobyte:
+      registry: localhost:1234
+      volume: test

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.25/fail/restrictedvolumes15.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.25/fail/restrictedvolumes15.yaml
@@ -1,0 +1,30 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: restrictedvolumes15
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  volumes:
+  - azureDisk:
+      diskName: test
+      diskURI: https://test.blob.core.windows.net/test/test.vhd
+    name: volume1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.25/fail/restrictedvolumes16.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.25/fail/restrictedvolumes16.yaml
@@ -1,0 +1,30 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: restrictedvolumes16
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  volumes:
+  - name: volume1
+    portworxVolume:
+      fsType: ext4
+      volumeID: test

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.25/fail/restrictedvolumes17.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.25/fail/restrictedvolumes17.yaml
@@ -1,0 +1,32 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: restrictedvolumes17
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  volumes:
+  - name: volume1
+    scaleIO:
+      gateway: localhost
+      secretRef: null
+      system: test
+      volumeName: test

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.25/fail/restrictedvolumes18.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.25/fail/restrictedvolumes18.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: restrictedvolumes18
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  volumes:
+  - name: volume1
+    storageos:
+      volumeName: test

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.25/fail/restrictedvolumes19.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.25/fail/restrictedvolumes19.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: restrictedvolumes19
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  volumes:
+  - hostPath:
+      path: /dev/null
+    name: volume1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.25/fail/restrictedvolumes2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.25/fail/restrictedvolumes2.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: restrictedvolumes2
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  volumes:
+  - gitRepo:
+      repository: github.com/kubernetes/kubernetes
+    name: volume1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.25/fail/restrictedvolumes3.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.25/fail/restrictedvolumes3.yaml
@@ -1,0 +1,30 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: restrictedvolumes3
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  volumes:
+  - name: volume1
+    nfs:
+      path: /test
+      server: test

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.25/fail/restrictedvolumes4.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.25/fail/restrictedvolumes4.yaml
@@ -1,0 +1,31 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: restrictedvolumes4
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  volumes:
+  - iscsi:
+      iqn: iqn.2001-04.com.example:storage.kube.sys1.xyz
+      lun: 0
+      targetPortal: test
+    name: volume1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.25/fail/restrictedvolumes5.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.25/fail/restrictedvolumes5.yaml
@@ -1,0 +1,30 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: restrictedvolumes5
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  volumes:
+  - glusterfs:
+      endpoints: test
+      path: test
+    name: volume1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.25/fail/restrictedvolumes6.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.25/fail/restrictedvolumes6.yaml
@@ -1,0 +1,31 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: restrictedvolumes6
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  volumes:
+  - name: volume1
+    rbd:
+      image: test
+      monitors:
+      - test

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.25/fail/restrictedvolumes7.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.25/fail/restrictedvolumes7.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: restrictedvolumes7
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  volumes:
+  - flexVolume:
+      driver: test
+    name: volume1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.25/fail/restrictedvolumes8.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.25/fail/restrictedvolumes8.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: restrictedvolumes8
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  volumes:
+  - cinder:
+      volumeID: test
+    name: volume1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.25/fail/restrictedvolumes9.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.25/fail/restrictedvolumes9.yaml
@@ -1,0 +1,30 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: restrictedvolumes9
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  volumes:
+  - cephfs:
+      monitors:
+      - test
+    name: volume1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.25/fail/runasnonroot0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.25/fail/runasnonroot0.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: runasnonroot0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.25/fail/runasnonroot1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.25/fail/runasnonroot1.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: runasnonroot1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: false
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.25/fail/runasnonroot2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.25/fail/runasnonroot2.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: runasnonroot2
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      runAsNonRoot: false
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.25/fail/runasnonroot3.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.25/fail/runasnonroot3.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: runasnonroot3
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      runAsNonRoot: false
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.25/fail/runasuser0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.25/fail/runasuser0.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: runasuser0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    runAsUser: 0
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.25/fail/runasuser1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.25/fail/runasuser1.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: runasuser1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      runAsUser: 0
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.25/fail/runasuser2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.25/fail/runasuser2.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: runasuser2
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      runAsUser: 0
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.25/fail/seccompprofile_baseline0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.25/fail/seccompprofile_baseline0.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: seccompprofile_baseline0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: Unconfined

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.25/fail/seccompprofile_baseline1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.25/fail/seccompprofile_baseline1.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: seccompprofile_baseline1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      seccompProfile:
+        type: Unconfined
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.25/fail/seccompprofile_baseline2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.25/fail/seccompprofile_baseline2.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: seccompprofile_baseline2
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      seccompProfile:
+        type: Unconfined
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.25/fail/seccompprofile_restricted0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.25/fail/seccompprofile_restricted0.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: seccompprofile_restricted0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.25/fail/seccompprofile_restricted1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.25/fail/seccompprofile_restricted1.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: seccompprofile_restricted1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: Unconfined

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.25/fail/seccompprofile_restricted2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.25/fail/seccompprofile_restricted2.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: seccompprofile_restricted2
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      seccompProfile:
+        type: RuntimeDefault
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.25/fail/seccompprofile_restricted3.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.25/fail/seccompprofile_restricted3.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: seccompprofile_restricted3
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      seccompProfile:
+        type: RuntimeDefault
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.25/fail/seccompprofile_restricted4.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.25/fail/seccompprofile_restricted4.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: seccompprofile_restricted4
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      seccompProfile:
+        type: RuntimeDefault
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      seccompProfile:
+        type: Unconfined
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.25/fail/selinuxoptions0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.25/fail/selinuxoptions0.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: selinuxoptions0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      seLinuxOptions: {}
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      seLinuxOptions: {}
+  securityContext:
+    runAsNonRoot: true
+    seLinuxOptions:
+      type: somevalue
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.25/fail/selinuxoptions1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.25/fail/selinuxoptions1.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: selinuxoptions1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      seLinuxOptions:
+        type: somevalue
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      seLinuxOptions: {}
+  securityContext:
+    runAsNonRoot: true
+    seLinuxOptions: {}
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.25/fail/selinuxoptions2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.25/fail/selinuxoptions2.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: selinuxoptions2
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      seLinuxOptions: {}
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      seLinuxOptions:
+        type: somevalue
+  securityContext:
+    runAsNonRoot: true
+    seLinuxOptions: {}
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.25/fail/selinuxoptions3.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.25/fail/selinuxoptions3.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: selinuxoptions3
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      seLinuxOptions: {}
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      seLinuxOptions: {}
+  securityContext:
+    runAsNonRoot: true
+    seLinuxOptions:
+      user: somevalue
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.25/fail/selinuxoptions4.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.25/fail/selinuxoptions4.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: selinuxoptions4
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      seLinuxOptions: {}
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      seLinuxOptions: {}
+  securityContext:
+    runAsNonRoot: true
+    seLinuxOptions:
+      role: somevalue
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.25/fail/sysctls0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.25/fail/sysctls0.yaml
@@ -1,0 +1,28 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: sysctls0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+    sysctls:
+    - name: othersysctl
+      value: other

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.25/fail/windowshostprocess0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.25/fail/windowshostprocess0.yaml
@@ -1,0 +1,30 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: windowshostprocess0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      windowsOptions: {}
+  hostNetwork: true
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      windowsOptions: {}
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+    windowsOptions:
+      hostProcess: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.25/fail/windowshostprocess1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.25/fail/windowshostprocess1.yaml
@@ -1,0 +1,31 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: windowshostprocess1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      windowsOptions:
+        hostProcess: true
+  hostNetwork: true
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      windowsOptions:
+        hostProcess: true
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+    windowsOptions: {}

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.25/pass/apparmorprofile0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.25/pass/apparmorprofile0.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    container.apparmor.security.beta.kubernetes.io/container1: localhost/foo
+  name: apparmorprofile0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.25/pass/base.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.25/pass/base.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: base
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.25/pass/base_linux.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.25/pass/base_linux.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: base_linux
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  os:
+    name: linux
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.25/pass/base_windows.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.25/pass/base_windows.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: base_windows
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+  os:
+    name: windows
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.25/pass/capabilities_restricted0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.25/pass/capabilities_restricted0.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: capabilities_restricted0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        add:
+        - NET_BIND_SERVICE
+        drop:
+        - ALL
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        add:
+        - NET_BIND_SERVICE
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.25/pass/hostports0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.25/pass/hostports0.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    ports:
+    - containerPort: 12345
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    ports:
+    - containerPort: 12346
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.25/pass/privileged0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.25/pass/privileged0.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: privileged0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      privileged: false
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      privileged: false
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.25/pass/procmount0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.25/pass/procmount0.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: procmount0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      procMount: Default
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      procMount: Default
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.25/pass/restrictedvolumes0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.25/pass/restrictedvolumes0.yaml
@@ -1,0 +1,47 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: restrictedvolumes0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  volumes:
+  - name: volume0
+  - emptyDir: {}
+    name: volume1
+  - name: volume2
+    secret:
+      secretName: test
+  - name: volume3
+    persistentVolumeClaim:
+      claimName: test
+  - downwardAPI:
+      items:
+      - fieldRef:
+          fieldPath: metadata.labels
+        path: labels
+    name: volume4
+  - configMap:
+      name: test
+    name: volume5
+  - name: volume6
+    projected:
+      sources: []

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.25/pass/runasnonroot0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.25/pass/runasnonroot0.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: runasnonroot0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.25/pass/runasnonroot1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.25/pass/runasnonroot1.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: runasnonroot1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      runAsNonRoot: true
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      runAsNonRoot: true
+  securityContext:
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.25/pass/runasuser0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.25/pass/runasuser0.yaml
@@ -1,0 +1,28 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: runasuser0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      runAsUser: 1000
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      runAsUser: 1000
+  securityContext:
+    runAsNonRoot: true
+    runAsUser: 1000
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.25/pass/seccompprofile_restricted0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.25/pass/seccompprofile_restricted0.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: seccompprofile_restricted0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.25/pass/seccompprofile_restricted1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.25/pass/seccompprofile_restricted1.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: seccompprofile_restricted1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      localhostProfile: testing
+      type: Localhost

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.25/pass/seccompprofile_restricted2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.25/pass/seccompprofile_restricted2.yaml
@@ -1,0 +1,28 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: seccompprofile_restricted2
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      seccompProfile:
+        type: RuntimeDefault
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      seccompProfile:
+        localhostProfile: testing
+        type: Localhost
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.25/pass/selinuxoptions0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.25/pass/selinuxoptions0.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: selinuxoptions0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      seLinuxOptions: {}
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.25/pass/selinuxoptions1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.25/pass/selinuxoptions1.yaml
@@ -1,0 +1,32 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: selinuxoptions1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      seLinuxOptions:
+        level: somevalue
+        type: container_init_t
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      seLinuxOptions:
+        type: container_kvm_t
+  securityContext:
+    runAsNonRoot: true
+    seLinuxOptions:
+      type: container_t
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.25/pass/sysctls0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.25/pass/sysctls0.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: sysctls0
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.25/pass/sysctls1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.25/pass/sysctls1.yaml
@@ -1,0 +1,36 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: sysctls1
+spec:
+  containers:
+  - image: k8s.gcr.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: k8s.gcr.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+    sysctls:
+    - name: kernel.shm_rmid_forced
+      value: "0"
+    - name: net.ipv4.ip_local_port_range
+      value: 1024 65535
+    - name: net.ipv4.tcp_syncookies
+      value: "0"
+    - name: net.ipv4.ping_group_range
+      value: 1 0
+    - name: net.ipv4.ip_unprivileged_port_start
+      value: "1024"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind feature
#### What this PR does / why we need it:
This PR ensures that the restricted standard is updated based on the newly added OS field to the pod spec.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes # 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
As of v1.25, the PodSecurity `restricted` level no longer requires pods that set .spec.os.name="windows" to also set Linux-specific securityContext fields. If a 1.25+ cluster has unsupported [out-of-skew](https://kubernetes.io/releases/version-skew-policy/#kubelet) nodes prior to v1.23 and wants to ensure namespaces enforcing the `restricted` policy continue to require Linux-specific securityContext fields on all pods, ensure a version of the `restricted` prior to v1.25 is selected by labeling the namespace (for example, `pod-security.kubernetes.io/enforce-version: v1.24`)
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]:  https://github.com/kubernetes/enhancements/pull/3303
- [Usage]: <link>
- [Other doc]: <link>
-->

```docs
[KEP]:  https://github.com/kubernetes/enhancements/pull/3303
[Other doc]: https://kubernetes.io/docs/concepts/security/pod-security-standards/
```
