### PR TITLE
Do not raise an error proposing to use '--overwrite' when labeling with the same value

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/label/label.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/label/label.go
@@ -408,9 +408,9 @@ func updateDataChangeMsg(oldObj []byte, newObj []byte, overwrite bool) string {
 
 func validateNoOverwrites(accessor metav1.Object, labels map[string]string) error {
 	allErrs := []error{}
-	for key := range labels {
-		if value, found := accessor.GetLabels()[key]; found {
-			allErrs = append(allErrs, fmt.Errorf("'%s' already has a value (%s), and --overwrite is false", key, value))
+	for key, value := range labels {
+		if currValue, found := accessor.GetLabels()[key]; found && currValue != value {
+			allErrs = append(allErrs, fmt.Errorf("'%s' already has a value (%s), and --overwrite is false", key, currValue))
 		}
 	}
 	return utilerrors.NewAggregate(allErrs)

--- a/staging/src/k8s.io/kubectl/pkg/cmd/label/label_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/label/label_test.go
@@ -174,7 +174,20 @@ func TestLabelFunc(t *testing.T) {
 					Labels: map[string]string{"a": "b"},
 				},
 			},
-			labels:    map[string]string{"a": "b"},
+			labels: map[string]string{"a": "b"},
+			expected: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{"a": "b"},
+				},
+			},
+		},
+		{
+			obj: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{"a": "b"},
+				},
+			},
+			labels:    map[string]string{"a": "c"},
 			expectErr: true,
 		},
 		{
@@ -586,7 +599,6 @@ func TestLabelMsg(t *testing.T) {
 			},
 			labels:    map[string]string{"a": "b"},
 			expectMsg: MsgNotLabeled,
-			expectErr: true,
 		},
 		{
 			obj: &v1.Pod{

--- a/staging/src/k8s.io/kubectl/pkg/cmd/label/label_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/label/label_test.go
@@ -166,7 +166,7 @@ func TestLabelFunc(t *testing.T) {
 		labels    map[string]string
 		remove    []string
 		expected  runtime.Object
-		expectErr bool
+		expectErr string
 	}{
 		{
 			obj: &v1.Pod{
@@ -188,7 +188,7 @@ func TestLabelFunc(t *testing.T) {
 				},
 			},
 			labels:    map[string]string{"a": "c"},
-			expectErr: true,
+			expectErr: "'a' already has a value (b), and --overwrite is false",
 		},
 		{
 			obj: &v1.Pod{
@@ -277,13 +277,16 @@ func TestLabelFunc(t *testing.T) {
 	}
 	for _, test := range tests {
 		err := labelFunc(test.obj, test.overwrite, test.version, test.labels, test.remove)
-		if test.expectErr {
+		if test.expectErr != "" {
 			if err == nil {
 				t.Errorf("unexpected non-error: %v", test)
 			}
+			if err.Error() != test.expectErr {
+				t.Errorf("error expected: %v, got: %v", test.expectErr, err.Error())
+			}
 			continue
 		}
-		if !test.expectErr && err != nil {
+		if test.expectErr == "" && err != nil {
 			t.Errorf("unexpected error: %v %v", err, test)
 		}
 		if !reflect.DeepEqual(test.obj, test.expected) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Currently, when trying to set a label with the same value as current one, `kubectl` advise to use the `--overwrite` option:

```shell-session
$ kubectl create namespace test
namespace/test created
$ kubectl label namespace test usage=test
namespace/test labeled
$ kubectl label namespace test usage=test
error: 'usage' already has a value (test), and --overwrite is false
```

But then, overwriting for the same value is a bit weird.

This PR propose to detect this situation and do nothing:

```shell-session
$ kubectl label namespace test usage=test
namespace/test not labeled
```

#### Which issue(s) this PR fixes:

No existing issue.

#### Special notes for your reviewer:

Maybe, it could give a better output like "xxx label unchanged".
But it would require quite more modifications.

#### Does this PR introduce a user-facing change?

```release-note
Do not raise an error when setting a label with the same value, just ignore it.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
