### PR TITLE
Increment OpenAPI v2 regeneration counter

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/controller/openapi/controller.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/controller/openapi/controller.go
@@ -169,7 +169,7 @@ func (c *Controller) sync(name string) error {
 		}
 		delete(c.crdSpecs, name)
 		klog.V(2).Infof("Updating CRD OpenAPI spec because %s was removed", name)
-		regenerationCounter.With(map[string]string{"crd": name, "reason": "remove"})
+		regenerationCounter.With(map[string]string{"crd": name, "reason": "remove"}).Inc()
 		return c.updateSpecLocked()
 	}
 
@@ -190,7 +190,7 @@ func (c *Controller) sync(name string) error {
 	if updated {
 		reason = "update"
 	}
-	regenerationCounter.With(map[string]string{"crd": name, "reason": reason})
+	regenerationCounter.With(map[string]string{"crd": name, "reason": reason}).Inc()
 	return c.updateSpecLocked()
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind bug

#### What this PR does / why we need it:

The `apiextensions_openapi_v2_regeneration_count` counter is incremented whenever adding, removing, or updating a CRD causes the API server to regenerate its aggregate OpenAPI v2 spec. It appears that when this counter was initially added in #81786 the author forgot to call Inc(), so the counter is created but is always 0.

#### Special notes for your reviewer:

It's worth noting that if https://github.com/kubernetes/kube-openapi/pull/251 is merged the operation this counter counts will become a lot less expensive and thus potentially a lot less interesting.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Makes the apiextensions_openapi_v2_regeneration_count metric increment as originally intended.
```
