### PR TITLE
PodSecurity: return namespace validation errors in standard field.ErrorList format

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/api/errors/errors.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/errors/errors.go
@@ -289,7 +289,7 @@ func NewInvalid(qualifiedKind schema.GroupKind, name string, errs field.ErrorLis
 			Field:   err.Field,
 		})
 	}
-	return &StatusError{metav1.Status{
+	err := &StatusError{metav1.Status{
 		Status: metav1.StatusFailure,
 		Code:   http.StatusUnprocessableEntity,
 		Reason: metav1.StatusReasonInvalid,
@@ -299,8 +299,14 @@ func NewInvalid(qualifiedKind schema.GroupKind, name string, errs field.ErrorLis
 			Name:   name,
 			Causes: causes,
 		},
-		Message: fmt.Sprintf("%s %q is invalid: %v", qualifiedKind.String(), name, errs.ToAggregate()),
 	}}
+	aggregatedErrs := errs.ToAggregate()
+	if aggregatedErrs == nil {
+		err.ErrStatus.Message = fmt.Sprintf("%s %q is invalid", qualifiedKind.String(), name)
+	} else {
+		err.ErrStatus.Message = fmt.Sprintf("%s %q is invalid: %v", qualifiedKind.String(), name, aggregatedErrs)
+	}
+	return err
 }
 
 // NewBadRequest creates an error that indicates that the request is invalid and can not be processed.

--- a/staging/src/k8s.io/apimachinery/pkg/util/validation/field/errors.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/validation/field/errors.go
@@ -239,6 +239,9 @@ func NewErrorTypeMatcher(t ErrorType) utilerrors.Matcher {
 
 // ToAggregate converts the ErrorList into an errors.Aggregate.
 func (list ErrorList) ToAggregate() utilerrors.Aggregate {
+	if len(list) == 0 {
+		return nil
+	}
 	errs := make([]error, 0, len(list))
 	errorMsgs := sets.NewString()
 	for _, err := range list {

--- a/staging/src/k8s.io/pod-security-admission/admission/api/helpers.go
+++ b/staging/src/k8s.io/pod-security-admission/admission/api/helpers.go
@@ -34,45 +34,45 @@ func ToPolicy(defaults PodSecurityDefaults) (policyapi.Policy, error) {
 	)
 
 	if len(defaults.Enforce) == 0 {
-		errs = appendErr(errs, requiredErr, "Enforce.Level")
+		errs = appendErr(errs, requiredErr, "enforce")
 	} else {
 		p.Enforce.Level, err = policyapi.ParseLevel(defaults.Enforce)
-		errs = appendErr(errs, err, "Enforce.Level")
+		errs = appendErr(errs, err, "enforce")
 	}
 
 	if len(defaults.EnforceVersion) == 0 {
-		errs = appendErr(errs, requiredErr, "Enforce.Version")
+		errs = appendErr(errs, requiredErr, "enforce-version")
 	} else {
 		p.Enforce.Version, err = policyapi.ParseVersion(defaults.EnforceVersion)
-		errs = appendErr(errs, err, "Enforce.Version")
+		errs = appendErr(errs, err, "enforce-version")
 	}
 
 	if len(defaults.Audit) == 0 {
-		errs = appendErr(errs, requiredErr, "Audit.Level")
+		errs = appendErr(errs, requiredErr, "audit")
 	} else {
 		p.Audit.Level, err = policyapi.ParseLevel(defaults.Audit)
-		errs = appendErr(errs, err, "Audit.Level")
+		errs = appendErr(errs, err, "audit")
 	}
 
 	if len(defaults.AuditVersion) == 0 {
-		errs = appendErr(errs, requiredErr, "Audit.Version")
+		errs = appendErr(errs, requiredErr, "audit-version")
 	} else {
 		p.Audit.Version, err = policyapi.ParseVersion(defaults.AuditVersion)
-		errs = appendErr(errs, err, "Audit.Version")
+		errs = appendErr(errs, err, "audit-version")
 	}
 
 	if len(defaults.Warn) == 0 {
-		errs = appendErr(errs, requiredErr, "Warn.Level")
+		errs = appendErr(errs, requiredErr, "warn")
 	} else {
 		p.Warn.Level, err = policyapi.ParseLevel(defaults.Warn)
-		errs = appendErr(errs, err, "Warn.Level")
+		errs = appendErr(errs, err, "warn")
 	}
 
 	if len(defaults.WarnVersion) == 0 {
-		errs = appendErr(errs, requiredErr, "Warn.Version")
+		errs = appendErr(errs, requiredErr, "warn-version")
 	} else {
 		p.Warn.Version, err = policyapi.ParseVersion(defaults.WarnVersion)
-		errs = appendErr(errs, err, "Warn.Version")
+		errs = appendErr(errs, err, "warn-version")
 	}
 
 	return p, errors.NewAggregate(errs)

--- a/staging/src/k8s.io/pod-security-admission/admission/attributes.go
+++ b/staging/src/k8s.io/pod-security-admission/admission/attributes.go
@@ -27,6 +27,7 @@ import (
 type AttributesRecord struct {
 	Name        string
 	Namespace   string
+	Kind        schema.GroupVersionKind
 	Resource    schema.GroupVersionResource
 	Subresource string
 	Operation   admissionv1.Operation
@@ -40,6 +41,9 @@ func (a *AttributesRecord) GetName() string {
 }
 func (a *AttributesRecord) GetNamespace() string {
 	return a.Namespace
+}
+func (a *AttributesRecord) GetKind() schema.GroupVersionKind {
+	return a.Kind
 }
 func (a *AttributesRecord) GetResource() schema.GroupVersionResource {
 	return a.Resource
@@ -80,6 +84,9 @@ func (a *attributes) GetName() string {
 }
 func (a *attributes) GetNamespace() string {
 	return a.r.Namespace
+}
+func (a *attributes) GetKind() schema.GroupVersionKind {
+	return schema.GroupVersionKind(a.r.Kind)
 }
 func (a *attributes) GetResource() schema.GroupVersionResource {
 	return schema.GroupVersionResource(a.r.Resource)

--- a/staging/src/k8s.io/pod-security-admission/api/helpers.go
+++ b/staging/src/k8s.io/pod-security-admission/api/helpers.go
@@ -158,33 +158,33 @@ func PolicyToEvaluate(labels map[string]string, defaults Policy) (Policy, error)
 	)
 	if level, ok := labels[EnforceLevelLabel]; ok {
 		p.Enforce.Level, err = ParseLevel(level)
-		errs = appendErr(errs, err, "Enforce.Level")
+		errs = appendErr(errs, err, EnforceLevelLabel)
 	}
 	if version, ok := labels[EnforceVersionLabel]; ok {
 		p.Enforce.Version, err = ParseVersion(version)
-		errs = appendErr(errs, err, "Enforce.Version")
+		errs = appendErr(errs, err, EnforceVersionLabel)
 	}
 	if level, ok := labels[AuditLevelLabel]; ok {
 		p.Audit.Level, err = ParseLevel(level)
-		errs = appendErr(errs, err, "Audit.Level")
+		errs = appendErr(errs, err, AuditLevelLabel)
 		if err != nil {
 			p.Audit.Level = LevelPrivileged // Fail open for audit.
 		}
 	}
 	if version, ok := labels[AuditVersionLabel]; ok {
 		p.Audit.Version, err = ParseVersion(version)
-		errs = appendErr(errs, err, "Audit.Version")
+		errs = appendErr(errs, err, AuditVersionLabel)
 	}
 	if level, ok := labels[WarnLevelLabel]; ok {
 		p.Warn.Level, err = ParseLevel(level)
-		errs = appendErr(errs, err, "Warn.Level")
+		errs = appendErr(errs, err, WarnLevelLabel)
 		if err != nil {
 			p.Warn.Level = LevelPrivileged // Fail open for warn.
 		}
 	}
 	if version, ok := labels[WarnVersionLabel]; ok {
 		p.Warn.Version, err = ParseVersion(version)
-		errs = appendErr(errs, err, "Warn.Version")
+		errs = appendErr(errs, err, WarnVersionLabel)
 	}
 	return p, errors.NewAggregate(errs)
 }

--- a/staging/src/k8s.io/pod-security-admission/api/helpers.go
+++ b/staging/src/k8s.io/pod-security-admission/api/helpers.go
@@ -22,7 +22,7 @@ import (
 	"strconv"
 	"strings"
 
-	"k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/component-base/version"
 )
 
@@ -149,44 +149,44 @@ type Policy struct {
 // falling back to the provided defaults when a label is unspecified. A valid policy is always
 // returned, even when an error is returned. If labels cannot be parsed correctly, the values of
 // "restricted" and "latest" are used for level and version respectively.
-func PolicyToEvaluate(labels map[string]string, defaults Policy) (Policy, error) {
+func PolicyToEvaluate(labels map[string]string, defaults Policy) (Policy, field.ErrorList) {
 	var (
 		err  error
-		errs []error
+		errs field.ErrorList
 
 		p = defaults
 	)
 	if level, ok := labels[EnforceLevelLabel]; ok {
 		p.Enforce.Level, err = ParseLevel(level)
-		errs = appendErr(errs, err, EnforceLevelLabel)
+		errs = appendErr(errs, err, EnforceLevelLabel, level)
 	}
 	if version, ok := labels[EnforceVersionLabel]; ok {
 		p.Enforce.Version, err = ParseVersion(version)
-		errs = appendErr(errs, err, EnforceVersionLabel)
+		errs = appendErr(errs, err, EnforceVersionLabel, version)
 	}
 	if level, ok := labels[AuditLevelLabel]; ok {
 		p.Audit.Level, err = ParseLevel(level)
-		errs = appendErr(errs, err, AuditLevelLabel)
+		errs = appendErr(errs, err, AuditLevelLabel, level)
 		if err != nil {
 			p.Audit.Level = LevelPrivileged // Fail open for audit.
 		}
 	}
 	if version, ok := labels[AuditVersionLabel]; ok {
 		p.Audit.Version, err = ParseVersion(version)
-		errs = appendErr(errs, err, AuditVersionLabel)
+		errs = appendErr(errs, err, AuditVersionLabel, version)
 	}
 	if level, ok := labels[WarnLevelLabel]; ok {
 		p.Warn.Level, err = ParseLevel(level)
-		errs = appendErr(errs, err, WarnLevelLabel)
+		errs = appendErr(errs, err, WarnLevelLabel, level)
 		if err != nil {
 			p.Warn.Level = LevelPrivileged // Fail open for warn.
 		}
 	}
 	if version, ok := labels[WarnVersionLabel]; ok {
 		p.Warn.Version, err = ParseVersion(version)
-		errs = appendErr(errs, err, WarnVersionLabel)
+		errs = appendErr(errs, err, WarnVersionLabel, version)
 	}
-	return p, errors.NewAggregate(errs)
+	return p, errs
 }
 
 // CompareLevels returns an integer comparing two levels by strictness. The result will be 0 if
@@ -211,10 +211,12 @@ func CompareLevels(a, b Level) int {
 	return 0
 }
 
-// appendErr is a helper function to collect field-specific errors.
-func appendErr(errs []error, err error, field string) []error {
+var labelsPath = field.NewPath("metadata", "labels")
+
+// appendErr is a helper function to collect label-specific errors.
+func appendErr(errs field.ErrorList, err error, label, value string) field.ErrorList {
 	if err != nil {
-		return append(errs, fmt.Errorf("%s: %s", field, err.Error()))
+		return append(errs, field.Invalid(labelsPath.Key(label), value, err.Error()))
 	}
 	return errs
 }

--- a/staging/src/k8s.io/pod-security-admission/api/interfaces.go
+++ b/staging/src/k8s.io/pod-security-admission/api/interfaces.go
@@ -30,6 +30,8 @@ type Attributes interface {
 	GetNamespace() string
 	// GetResource is the name of the resource being requested.  This is not the kind.  For example: pods
 	GetResource() schema.GroupVersionResource
+	// GetKind is the name of the kind being requested.  For example: Pod
+	GetKind() schema.GroupVersionKind
 	// GetSubresource is the name of the subresource being requested.  This is a different resource, scoped to the parent resource, but it may have a different kind.
 	// For instance, /pods has the resource "pods" and the kind "Pod", while /pods/foo/status has the resource "pods", the sub resource "status", and the kind "Pod"
 	// (because status operates on pods). The binding resource for a pod though may be /pods/foo/binding, which has resource "pods", subresource "binding", and kind "Binding".


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind feature

#### Which issue(s) this PR fixes:

Fixes the returned error for namespace label validation so that kubectl displays the error details (it only displays detail messages for "invalid request" errors)

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

/assign @tallclair 
/sig auth
/milestone v1.23