### PR TITLE
test: Assert max unavailable for PDB test cases

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_pdb_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_pdb_test.go
@@ -132,8 +132,8 @@ func TestCreatePdb(t *testing.T) {
 	minAvailableNumber := intstr.Parse(podAmountNumber)
 	minAvailablePercent := intstr.Parse(podAmountPercent)
 
-	minUnavailableNumber := intstr.Parse(podAmountNumber)
-	minUnavailablePercent := intstr.Parse(podAmountPercent)
+	maxUnavailableNumber := intstr.Parse(podAmountNumber)
+	maxUnavailablePercent := intstr.Parse(podAmountPercent)
 
 	tests := map[string]struct {
 		options  *PodDisruptionBudgetOpts
@@ -181,9 +181,9 @@ func TestCreatePdb(t *testing.T) {
 		},
 		"test-valid-max-unavailable-pods-number": {
 			options: &PodDisruptionBudgetOpts{
-				Name:         "my-pdb",
-				Selector:     selectorOpts,
-				MinAvailable: podAmountNumber,
+				Name:           "my-pdb",
+				Selector:       selectorOpts,
+				MaxUnavailable: podAmountNumber,
 			},
 			expected: &policyv1.PodDisruptionBudget{
 				TypeMeta: metav1.TypeMeta{
@@ -194,16 +194,16 @@ func TestCreatePdb(t *testing.T) {
 					Name: "my-pdb",
 				},
 				Spec: policyv1.PodDisruptionBudgetSpec{
-					Selector:     selector,
-					MinAvailable: &minUnavailableNumber,
+					Selector:       selector,
+					MaxUnavailable: &maxUnavailableNumber,
 				},
 			},
 		},
 		"test-valid-max-unavailable-pods-percentage": {
 			options: &PodDisruptionBudgetOpts{
-				Name:         "my-pdb",
-				Selector:     selectorOpts,
-				MinAvailable: podAmountPercent,
+				Name:           "my-pdb",
+				Selector:       selectorOpts,
+				MaxUnavailable: podAmountPercent,
 			},
 			expected: &policyv1.PodDisruptionBudget{
 				TypeMeta: metav1.TypeMeta{
@@ -214,8 +214,8 @@ func TestCreatePdb(t *testing.T) {
 					Name: "my-pdb",
 				},
 				Spec: policyv1.PodDisruptionBudgetSpec{
-					Selector:     selector,
-					MinAvailable: &minUnavailablePercent,
+					Selector:       selector,
+					MaxUnavailable: &maxUnavailablePercent,
 				},
 			},
 		},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

This change asserts max unavailable for PDB test cases. Test cases "test-valid-max-unavailable-pods-***" has been asserted MinAvailable rather than MaxUnavailable. I believe they had incorrect parameter.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:



#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
