### PR TITLE
cmd/kubectl: make 'kubectl logs' default to the first container when default container cannot be determined or found by annotations

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/util/podcmd/podcmd.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/util/podcmd/podcmd.go
@@ -82,14 +82,14 @@ func FindOrDefaultContainerByName(pod *v1.Pod, name string, quiet bool, warn io.
 	// pick the first container as per existing behavior
 	container = &pod.Spec.Containers[0]
 	if !quiet && (len(pod.Spec.Containers) > 1 || len(pod.Spec.InitContainers) > 0 || len(pod.Spec.EphemeralContainers) > 0) {
-		fmt.Fprintf(warn, "Defaulted container %q out of: %s\n", container.Name, allContainerNames(pod))
+		fmt.Fprintf(warn, "Defaulted container %q out of: %s\n", container.Name, AllContainerNames(pod))
 	}
 
 	klog.V(4).Infof("Defaulting container name to %s", container.Name)
 	return &pod.Spec.Containers[0], nil
 }
 
-func allContainerNames(pod *v1.Pod) string {
+func AllContainerNames(pod *v1.Pod) string {
 	var containers []string
 	for _, container := range pod.Spec.Containers {
 		containers = append(containers, container.Name)

--- a/staging/src/k8s.io/kubectl/pkg/polymorphichelpers/logsforobject.go
+++ b/staging/src/k8s.io/kubectl/pkg/polymorphichelpers/logsforobject.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"os"
 	"sort"
-	"strings"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -104,23 +103,11 @@ func logsForObjectWithClient(clientset corev1client.CoreV1Interface, object, opt
 			}
 
 			if currOpts.Container == "" {
-				// We don't know container name. In this case we expect only one container to be present in the pod (ignoring InitContainers).
-				// If there is more than one container, we should return an error showing all container names.
-				if len(t.Spec.Containers) != 1 {
-					containerNames := getContainerNames(t.Spec.Containers)
-					initContainerNames := getContainerNames(t.Spec.InitContainers)
-					ephemeralContainerNames := getContainerNames(ephemeralContainersToContainers(t.Spec.EphemeralContainers))
-					err := fmt.Sprintf("a container name must be specified for pod %s, choose one of: [%s]", t.Name, containerNames)
-					if len(initContainerNames) > 0 {
-						err += fmt.Sprintf(" or one of the init containers: [%s]", initContainerNames)
-					}
-					if len(ephemeralContainerNames) > 0 {
-						err += fmt.Sprintf(" or one of the ephemeral containers: [%s]", ephemeralContainerNames)
-					}
-
-					return nil, errors.New(err)
-				}
+				// Default to the first container name(aligning behavior with `kubectl exec').
 				currOpts.Container = t.Spec.Containers[0].Name
+				if len(t.Spec.Containers) > 1 || len(t.Spec.InitContainers) > 0 || len(t.Spec.EphemeralContainers) > 0 {
+					fmt.Fprintf(os.Stderr, "Defaulted container %q out of: %s\n", currOpts.Container, podcmd.AllContainerNames(t))
+				}
 			}
 
 			container, fieldPath := podcmd.FindContainerByName(t, currOpts.Container)
@@ -190,21 +177,4 @@ func logsForObjectWithClient(clientset corev1client.CoreV1Interface, object, opt
 	}
 
 	return logsForObjectWithClient(clientset, pod, options, timeout, allContainers)
-}
-
-// getContainerNames returns a formatted string containing the container names
-func getContainerNames(containers []corev1.Container) string {
-	names := []string{}
-	for _, c := range containers {
-		names = append(names, c.Name)
-	}
-	return strings.Join(names, " ")
-}
-
-func ephemeralContainersToContainers(containers []corev1.EphemeralContainer) []corev1.Container {
-	var ec []corev1.Container
-	for i := range containers {
-		ec = append(ec, corev1.Container(containers[i].EphemeralContainerCommon))
-	}
-	return ec
 }

--- a/staging/src/k8s.io/kubectl/pkg/polymorphichelpers/logsforobject_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/polymorphichelpers/logsforobject_test.go
@@ -119,9 +119,20 @@ func TestLogsForObject(t *testing.T) {
 			},
 		},
 		{
-			name:        "pod logs: error - must provide container name",
-			obj:         testPodWithTwoContainers(),
-			expectedErr: "a container name must be specified for pod foo-two-containers, choose one of: [foo-2-c1 foo-2-c2]",
+			name: "pod logs: default to first container",
+			obj:  testPodWithTwoContainers(),
+			actions: []testclient.Action{
+				getLogsAction("test", &corev1.PodLogOptions{Container: "foo-2-c1"}),
+			},
+			expectedSources: []corev1.ObjectReference{
+				{
+					Kind:       testPodWithTwoContainers().Kind,
+					APIVersion: testPodWithTwoContainers().APIVersion,
+					Name:       testPodWithTwoContainers().Name,
+					Namespace:  testPodWithTwoContainers().Namespace,
+					FieldPath:  fmt.Sprintf("spec.containers{%s}", testPodWithTwoContainers().Spec.Containers[0].Name),
+				},
+			},
 		},
 		{
 			name: "pods list logs",
@@ -248,11 +259,22 @@ func TestLogsForObject(t *testing.T) {
 			},
 		},
 		{
-			name: "pods list logs: error - must provide container name",
+			name: "pods list logs: default to first container",
 			obj: &corev1.PodList{
 				Items: []corev1.Pod{*testPodWithTwoContainersAndTwoInitAndOneEphemeralContainers()},
 			},
-			expectedErr: "a container name must be specified for pod foo-two-containers-and-two-init-containers, choose one of: [foo-2-and-2-and-1-c1 foo-2-and-2-and-1-c2] or one of the init containers: [foo-2-and-2-and-1-initc1 foo-2-and-2-and-1-initc2] or one of the ephemeral containers: [foo-2-and-2-and-1-e1]",
+			actions: []testclient.Action{
+				getLogsAction("test", &corev1.PodLogOptions{Container: "foo-2-and-2-and-1-c1"}),
+			},
+			expectedSources: []corev1.ObjectReference{
+				{
+					Kind:       testPodWithTwoContainersAndTwoInitAndOneEphemeralContainers().Kind,
+					APIVersion: testPodWithTwoContainersAndTwoInitAndOneEphemeralContainers().APIVersion,
+					Name:       testPodWithTwoContainersAndTwoInitAndOneEphemeralContainers().Name,
+					Namespace:  testPodWithTwoContainersAndTwoInitAndOneEphemeralContainers().Namespace,
+					FieldPath:  fmt.Sprintf("spec.containers{%s}", testPodWithTwoContainersAndTwoInitAndOneEphemeralContainers().Spec.Containers[0].Name),
+				},
+			},
 		},
 		{
 			name: "replication controller logs",

--- a/staging/src/k8s.io/kubectl/pkg/polymorphichelpers/logsforobject_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/polymorphichelpers/logsforobject_test.go
@@ -507,10 +507,10 @@ func TestLogsForObjectWithClient(t *testing.T) {
 		expectedError     string
 	}{
 		{
-			name:          "two container pod without default container selected",
-			podFn:         testPodWithTwoContainers,
-			podLogOptions: &corev1.PodLogOptions{},
-			expectedError: `a container name must be specified for pod foo-two-containers, choose one of: [foo-2-c1 foo-2-c2]`,
+			name:              "two container pod without default container selected should default to the first one",
+			podFn:             testPodWithTwoContainers,
+			podLogOptions:     &corev1.PodLogOptions{},
+			expectedFieldPath: `spec.containers{foo-2-c1}`,
 		},
 		{
 			name: "two container pod with default container selected",
@@ -535,14 +535,14 @@ func TestLogsForObjectWithClient(t *testing.T) {
 			expectedFieldPath: `spec.containers{foo-2-c2}`,
 		},
 		{
-			name: "two container pod with non-existing default container selected",
+			name: "two container pod with non-existing default container selected should defualt to the first container",
 			podFn: func() *corev1.Pod {
 				pod := testPodWithTwoContainers()
 				pod.Annotations = map[string]string{podcmd.DefaultContainerAnnotationName: "non-existing"}
 				return pod
 			},
-			podLogOptions: &corev1.PodLogOptions{},
-			expectedError: `a container name must be specified for pod foo-two-containers, choose one of: [foo-2-c1 foo-2-c2]`,
+			podLogOptions:     &corev1.PodLogOptions{},
+			expectedFieldPath: `spec.containers{foo-2-c1}`,
 		},
 		{
 			name: "two container pod with default container set, but allContainers also set",

--- a/staging/src/k8s.io/kubectl/pkg/polymorphichelpers/logsforobject_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/polymorphichelpers/logsforobject_test.go
@@ -535,7 +535,7 @@ func TestLogsForObjectWithClient(t *testing.T) {
 			expectedFieldPath: `spec.containers{foo-2-c2}`,
 		},
 		{
-			name: "two container pod with non-existing default container selected should defualt to the first container",
+			name: "two container pod with non-existing default container selected should default to the first container",
 			podFn: func() *corev1.Pod {
 				pod := testPodWithTwoContainers()
 				pod.Annotations = map[string]string{podcmd.DefaultContainerAnnotationName: "non-existing"}


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind feature

#### What this PR does / why we need it:

While running `kubectl logs <pod>`, If `-c` is omitted and the pod has more than one container, and no default container can be determined from annotations, this command shows an error message and exits. With this fix, it defaults to the first container in such scenarios and show its logs. This aligns behavior with what `kubectl exec` does currently, and is more in line with [KEP SIG-CLI 2227](https://github.com/kubernetes/enhancements/tree/master/keps/sig-cli/2227-kubectl-default-container) design.

Old behavior:
<img width="1218" alt="old_behavior" src="https://user-images.githubusercontent.com/300616/139211158-4cd50ba1-eab1-4e74-9320-f9fea7c911cb.png">

New behavior, aligning with `kubectl exec`.
<img width="790" alt="new_behavior" src="https://user-images.githubusercontent.com/300616/139211223-c270d857-1a3f-4a0d-9123-773bab253536.png">



#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

Fixes  https://github.com/kubernetes/kubectl/issues/1124

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
kubectl logs will now warn and default to the first container in a pod. This new behavior brings it in line with kubectl exec.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
-->
```docs
- [KEP]: https://github.com/kubernetes/enhancements/tree/master/keps/sig-cli/2227-kubectl-default-container

```
