### PR TITLE
Migrated scheduler files `comparer.go`, `dumper.go`, `node_tree.go` to structured logging

### DIFF
--- a/pkg/scheduler/internal/cache/debugger/comparer.go
+++ b/pkg/scheduler/internal/cache/debugger/comparer.go
@@ -39,8 +39,8 @@ type CacheComparer struct {
 
 // Compare compares the nodes and pods of NodeLister with Cache.Snapshot.
 func (c *CacheComparer) Compare() error {
-	klog.V(3).Info("cache comparer started")
-	defer klog.V(3).Info("cache comparer finished")
+	klog.V(3).InfoS("Cache comparer started")
+	defer klog.V(3).InfoS("Cache comparer finished")
 
 	nodes, err := c.NodeLister.List(labels.Everything())
 	if err != nil {
@@ -57,11 +57,11 @@ func (c *CacheComparer) Compare() error {
 	pendingPods := c.PodQueue.PendingPods()
 
 	if missed, redundant := c.CompareNodes(nodes, dump.Nodes); len(missed)+len(redundant) != 0 {
-		klog.InfoS("cache mismatch", "missed nodes", missed, "redundant nodes", redundant)
+		klog.InfoS("Cache mismatch", "missedNodes", missed, "redundantNodes", redundant)
 	}
 
 	if missed, redundant := c.ComparePods(pods, pendingPods, dump.Nodes); len(missed)+len(redundant) != 0 {
-		klog.InfoS("cache mismatch", "missed pods", missed, "redundant pods", redundant)
+		klog.InfoS("Cache mismatch", "missedPods", missed, "redundantPods", redundant)
 	}
 
 	return nil

--- a/pkg/scheduler/internal/cache/debugger/dumper.go
+++ b/pkg/scheduler/internal/cache/debugger/dumper.go
@@ -44,7 +44,7 @@ func (d *CacheDumper) DumpAll() {
 // dumpNodes writes NodeInfo to the scheduler logs.
 func (d *CacheDumper) dumpNodes() {
 	dump := d.cache.Dump()
-	klog.Info("Dump of cached NodeInfo")
+	klog.InfoS("Dump of cached NodeInfo")
 	for name, nodeInfo := range dump.Nodes {
 		klog.Info(d.printNodeInfo(name, nodeInfo))
 	}

--- a/pkg/scheduler/internal/cache/node_tree.go
+++ b/pkg/scheduler/internal/cache/node_tree.go
@@ -53,7 +53,7 @@ func (nt *nodeTree) addNode(n *v1.Node) {
 	if na, ok := nt.tree[zone]; ok {
 		for _, nodeName := range na {
 			if nodeName == n.Name {
-				klog.Warningf("node %q already exist in the NodeTree", n.Name)
+				klog.InfoS("Node already exists in the NodeTree", "node", klog.KObj(n))
 				return
 			}
 		}
@@ -62,7 +62,7 @@ func (nt *nodeTree) addNode(n *v1.Node) {
 		nt.zones = append(nt.zones, zone)
 		nt.tree[zone] = []string{n.Name}
 	}
-	klog.V(2).Infof("Added node %q in group %q to NodeTree", n.Name, zone)
+	klog.V(2).InfoS("Added node in listed group to NodeTree", "node", klog.KObj(n), "zone", zone)
 	nt.numNodes++
 }
 
@@ -76,13 +76,13 @@ func (nt *nodeTree) removeNode(n *v1.Node) error {
 				if len(nt.tree[zone]) == 0 {
 					nt.removeZone(zone)
 				}
-				klog.V(2).Infof("Removed node %q in group %q from NodeTree", n.Name, zone)
+				klog.V(2).InfoS("Removed node in listed group from NodeTree", "node", klog.KObj(n), "zone", zone)
 				nt.numNodes--
 				return nil
 			}
 		}
 	}
-	klog.Errorf("Node %q in group %q was not found", n.Name, zone)
+	klog.ErrorS(nil, "Node in listed group was not found", "node", klog.KObj(n), "zone", zone)
 	return fmt.Errorf("node %q in group %q was not found", n.Name, zone)
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Migrated `pkg/scheduler/internal/cache/debugger/comparer.go`, `pkg/scheduler/internal/cache/debugger/dumper.go`, and `pkg/scheduler/internal/cache/node_tree.go` to structured logging
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Ref https://github.com/kubernetes/kubernetes/issues/105841

#### Special notes for your reviewer:
Added missing migration points, fixed previously migrated logs
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Migrated scheduler files `comparer.go`, `dumper.go`, `node_tree.go` to structured logging
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
