### PR TITLE
Fix the doc string of GetOldObject func

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/admission/interfaces.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/interfaces.go
@@ -52,7 +52,7 @@ type Attributes interface {
 	IsDryRun() bool
 	// GetObject is the object from the incoming request prior to default values being applied
 	GetObject() runtime.Object
-	// GetOldObject is the existing object. Only populated for UPDATE requests.
+	// GetOldObject is the existing object. Only populated for UPDATE and DELETE requests.
 	GetOldObject() runtime.Object
 	// GetKind is the type of object being manipulated.  For example: Pod
 	GetKind() schema.GroupVersionKind


### PR DESCRIPTION
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind documentation
/sig api-machinery
/area apiserver

Currently the doc string of the GetOldObject func states that OldObject is populated only for `Update` requests.
But actually the OldObject is populated for `Delete` requests as well.

https://github.com/kubernetes/kubernetes/blob/9fdcc4b1999c273d7e156880df646ac905b8adf0/staging/src/k8s.io/apiserver/pkg/registry/rest/delete.go#L176-L189


#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
