### PR TITLE
Add String method to v1.Time that protects nil values

### DIFF
--- a/pkg/proxy/apis/config/validation/validation_test.go
+++ b/pkg/proxy/apis/config/validation/validation_test.go
@@ -607,7 +607,7 @@ func TestValidateKubeProxyConntrackConfiguration(t *testing.T) {
 				TCPEstablishedTimeout: &metav1.Duration{Duration: -5 * time.Second},
 				TCPCloseWaitTimeout:   &metav1.Duration{Duration: 5 * time.Second},
 			},
-			expectedErrs: field.ErrorList{field.Invalid(newPath.Child("KubeConntrackConfiguration.TCPEstablishedTimeout"), metav1.Duration{Duration: -5 * time.Second}, "must be greater than or equal to 0")},
+			expectedErrs: field.ErrorList{field.Invalid(newPath.Child("KubeConntrackConfiguration.TCPEstablishedTimeout"), &metav1.Duration{Duration: -5 * time.Second}, "must be greater than or equal to 0")},
 		},
 		"invalid CloseWaitTimeout < 0": {
 			config: kubeproxyconfig.KubeProxyConntrackConfiguration{
@@ -616,7 +616,7 @@ func TestValidateKubeProxyConntrackConfiguration(t *testing.T) {
 				TCPEstablishedTimeout: &metav1.Duration{Duration: 5 * time.Second},
 				TCPCloseWaitTimeout:   &metav1.Duration{Duration: -5 * time.Second},
 			},
-			expectedErrs: field.ErrorList{field.Invalid(newPath.Child("KubeConntrackConfiguration.TCPCloseWaitTimeout"), metav1.Duration{Duration: -5 * time.Second}, "must be greater than or equal to 0")},
+			expectedErrs: field.ErrorList{field.Invalid(newPath.Child("KubeConntrackConfiguration.TCPCloseWaitTimeout"), &metav1.Duration{Duration: -5 * time.Second}, "must be greater than or equal to 0")},
 		},
 	}
 

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/time.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/time.go
@@ -55,6 +55,15 @@ func Now() Time {
 	return Time{time.Now()}
 }
 
+// String returns "<nil>" if the value is nil otherwise calls String on the
+// underlying time.Time
+func (t *Time) String() string {
+	if t == nil {
+		return "<nil>"
+	}
+	return t.Time.String()
+}
+
 // IsZero returns true if the value is nil or time is zero.
 func (t *Time) IsZero() bool {
 	if t == nil {

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/time_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/time_test.go
@@ -239,3 +239,51 @@ func TestTimeIsZero(t *testing.T) {
 		})
 	}
 }
+
+func TestPointerTimeString(t *testing.T) {
+	now := time.Now()
+	t1 := NewTime(now)
+	t2 := NewTime(time.Unix(2000, 0).UTC())
+	cases := []struct {
+		name   string
+		x      *Time
+		result string
+	}{
+		{"nil", nil, "<nil>"},
+		{"!nil", &t1, now.String()},
+		{"explicit !nil", &t2, "1970-01-01 00:33:20 +0000 UTC"},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			result := c.x.String()
+			if result != c.result {
+				t.Errorf("Failed equality test for '%v': expected %+v, got %+v", c.x, c.result, result)
+			}
+		})
+	}
+}
+
+func TestTimeString(t *testing.T) {
+	now := time.Now()
+	t1 := NewTime(now)
+	t2 := NewTime(time.Unix(1000, 0).UTC())
+	cases := []struct {
+		name   string
+		x      Time
+		result string
+	}{
+		{"zero", NewTime(time.Time{}), "0001-01-01 00:00:00 +0000 UTC"},
+		{"now", t1, now.String()},
+		{"explicit", t2, "1970-01-01 00:16:40 +0000 UTC"},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			result := c.x.String()
+			if result != c.result {
+				t.Errorf("Failed equality test for '%v': expected %+v, got %+v", c.x, c.result, result)
+			}
+		})
+	}
+}

--- a/staging/src/k8s.io/apimachinery/pkg/util/validation/field/errors.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/validation/field/errors.go
@@ -58,7 +58,12 @@ func (v *Error) ErrorBody() string {
 			if reflectValue := reflect.ValueOf(value); reflectValue.IsNil() {
 				value = "null"
 			} else {
-				value = reflectValue.Elem().Interface()
+				var ok bool
+				// It is possible for the pointer to a type to be a Stringer, but not the type itself.
+				// If the pointer is a Stringer, then use the Stringer implementation of the pointer.
+				if value, ok = reflectValue.Interface().(fmt.Stringer); !ok {
+					value = reflectValue.Elem().Interface()
+				}
 			}
 		}
 		switch t := value.(type) {

--- a/staging/src/k8s.io/kubectl/pkg/describe/describe.go
+++ b/staging/src/k8s.io/kubectl/pkg/describe/describe.go
@@ -4357,7 +4357,8 @@ func describeNetworkPolicy(networkPolicy *networkingv1.NetworkPolicy) (string, e
 		w := NewPrefixWriter(out)
 		w.Write(LEVEL_0, "Name:\t%s\n", networkPolicy.Name)
 		w.Write(LEVEL_0, "Namespace:\t%s\n", networkPolicy.Namespace)
-		w.Write(LEVEL_0, "Created on:\t%s\n", networkPolicy.CreationTimestamp)
+		// Use a pointer to the CreationTimestamp because *v1.Time is a Stringer.
+		w.Write(LEVEL_0, "Created on:\t%s\n", &networkPolicy.CreationTimestamp)
 		printLabelsMultiline(w, "Labels", networkPolicy.Labels)
 		printAnnotationsMultiline(w, "Annotations", networkPolicy.Annotations)
 		describeNetworkPolicySpec(networkPolicy.Spec, w)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
This PR adds a `String` method to the `v1.Time` object to protect against nil-pointer dereferences.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #105981

#### Does this PR introduce a user-facing change?
```release-note
NONE
```