### PR TITLE
Fix COS GPU driver installation

### DIFF
--- a/test/e2e_node/jenkins/gci-init-gpu.yaml
+++ b/test/e2e_node/jenkins/gci-init-gpu.yaml
@@ -2,15 +2,12 @@
 
 runcmd:
   - modprobe configs
-  # Setup the installation target at make it executable
-  - mkdir -p /home/kubernetes/bin/nvidia
-  - mount --bind /home/kubernetes/bin/nvidia /home/kubernetes/bin/nvidia
-  - mount -o remount,exec /home/kubernetes/bin/nvidia
-  # Compile and install the nvidia driver (precompiled driver installation currently fails)
-  - docker run --net=host --pid=host -v /dev:/dev -v /:/root -v /home/kubernetes/bin/nvidia:/usr/local/nvidia -e NVIDIA_INSTALL_DIR_HOST=/home/kubernetes/bin/nvidia -e NVIDIA_INSTALL_DIR_CONTAINER=/usr/local/nvidia -e NVIDIA_DRIVER_VERSION=460.91.03 --privileged gcr.io/cos-cloud/cos-gpu-installer:latest
-  # Run the installer again, as on the first try it doesn't detect the libnvidia-ml.so
-  # on the second attempt we detect it and update the ld cache.
-  - docker run --net=host --pid=host -v /dev:/dev -v /:/root -v /home/kubernetes/bin/nvidia:/usr/local/nvidia -e NVIDIA_INSTALL_DIR_HOST=/home/kubernetes/bin/nvidia -e NVIDIA_INSTALL_DIR_CONTAINER=/usr/local/nvidia -e NVIDIA_DRIVER_VERSION=460.91.03 --privileged gcr.io/cos-cloud/cos-gpu-installer:latest
+  # Install GPU drivers - https://cloud.google.com/container-optimized-os/docs/how-to/run-gpus
+  - cos-extensions install gpu
+  - mount --bind /var/lib/nvidia /var/lib/nvidia
+  - mount -o remount,exec /var/lib/nvidia /var/lib/nvidia
+  # Run nvidia-smi to verify installation
+  - /var/lib/nvidia/bin/nvidia-smi
   # Remove build containers. They're very large.
   - docker rm -f $(docker ps -aq)
   # Standard installation proceeds


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind failing-test

#### What this PR does / why we need it:

* Rely on the built in GPU driver installer in COS as recommended in
  public docs - https://cloud.google.com/container-optimized-os/docs/how-to/run-gpus
* Run `nvidia-smi` after installation to verify installation

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #104175

#### Special notes for your reviewer:

Tested by running kubetest manually

Invocation - https://gist.github.com/d97bbe0717bf3c8234fec10beda4ff0a
Build log - https://gist.github.com/88b3096ba1338e659d68e83857e13ab5


```
• [SLOW TEST:297.012 seconds]
[sig-node] NVIDIA GPU Device Plugin [Feature:GPUDevicePlugin][NodeFeature:GPUDevicePlugin][Serial] [Disruptive]
_output/local/go/src/k8s.io/kubernetes/test/e2e_node/framework.go:23
  DevicePlugin
  _output/local/go/src/k8s.io/kubernetes/test/e2e_node/gpu_device_plugin_test.go:66
    keeps GPU assignment to pods across pod and kubelet restarts.
    _output/local/go/src/k8s.io/kubernetes/test/e2e_node/gpu_device_plugin_test.go:157
------------------------------
SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSI1029 01:07:31.171986    1188 e2e_node_suite_test.go:237] Stopping node services...
I1029 01:07:31.172032    1188 server.go:257] Kill server "services"
I1029 01:07:31.172187    1188 server.go:294] Killing process 2280 (services) with -TERM
E1029 01:07:31.228088    1188 services.go:95] Failed to stop services: error stopping "services": waitid: no child processes
I1029 01:07:31.228122    1188 server.go:257] Kill server "kubelet"
I1029 01:07:31.239057    1188 services.go:156] Fetching log files...
I1029 01:07:31.239138    1188 services.go:165] Get log file "kern.log" with journalctl command [-k].
I1029 01:07:31.248936    1188 services.go:165] Get log file "cloud-init.log" with journalctl command [-u cloud*].
I1029 01:07:31.606801    1188 services.go:165] Get log file "docker.log" with journalctl command [-u docker].
I1029 01:07:31.612496    1188 services.go:165] Get log file "containerd.log" with journalctl command [-u containerd].
I1029 01:07:31.618332    1188 services.go:165] Get log file "containerd-installation.log" with journalctl command [-u containerd-installation].
I1029 01:07:31.621690    1188 e2e_node_suite_test.go:242] Tests Finished

JUnit report was created: /tmp/node-e2e-20211028T180026/results/junit_cos-stable2_01.xml

Ran 1 of 359 Specs in 413.040 seconds
SUCCESS! -- 1 Passed | 0 Failed | 1 Pending | 357 Skipped
PASS

Ginkgo ran 1 suite in 6m53.257503373s
Test Suite Passed

Success Finished Test Suite on Host n1-standard-2-cos-93-16623-39-6-1f4a05b2
```

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
