### PR TITLE
Automated cherry pick of #105755: Support cgroupv2 in node problem detector test

### DIFF
--- a/test/e2e/node/node_problem_detector.go
+++ b/test/e2e/node/node_problem_detector.go
@@ -257,7 +257,15 @@ func verifyNodeCondition(f *framework.Framework, condition v1.NodeConditionType,
 }
 
 func getMemoryStat(f *framework.Framework, host string) (rss, workingSet float64) {
-	memCmd := "cat /sys/fs/cgroup/memory/system.slice/node-problem-detector.service/memory.usage_in_bytes && cat /sys/fs/cgroup/memory/system.slice/node-problem-detector.service/memory.stat"
+	var memCmd string
+
+	isCgroupV2 := isHostRunningCgroupV2(f, host)
+	if isCgroupV2 {
+		memCmd = "cat /sys/fs/cgroup/system.slice/node-problem-detector.service/memory.current && cat /sys/fs/cgroup/system.slice/node-problem-detector.service/memory.stat"
+	} else {
+		memCmd = "cat /sys/fs/cgroup/memory/system.slice/node-problem-detector.service/memory.usage_in_bytes && cat /sys/fs/cgroup/memory/system.slice/node-problem-detector.service/memory.stat"
+	}
+
 	result, err := e2essh.SSH(memCmd, host, framework.TestContext.Provider)
 	framework.ExpectNoError(err)
 	framework.ExpectEqual(result.Code, 0)
@@ -266,14 +274,26 @@ func getMemoryStat(f *framework.Framework, host string) (rss, workingSet float64
 	memoryUsage, err := strconv.ParseFloat(lines[0], 64)
 	framework.ExpectNoError(err)
 
+	var rssToken, inactiveFileToken string
+	if isCgroupV2 {
+		// Use Anon memory for RSS as cAdvisor on cgroupv2
+		// see https://github.com/google/cadvisor/blob/a9858972e75642c2b1914c8d5428e33e6392c08a/container/libcontainer/handler.go#L799
+		rssToken = "anon"
+		inactiveFileToken = "inactive_file"
+	} else {
+		rssToken = "total_rss"
+		inactiveFileToken = "total_inactive_file"
+	}
+
 	var totalInactiveFile float64
 	for _, line := range lines[1:] {
 		tokens := strings.Split(line, " ")
-		if tokens[0] == "total_rss" {
+
+		if tokens[0] == rssToken {
 			rss, err = strconv.ParseFloat(tokens[1], 64)
 			framework.ExpectNoError(err)
 		}
-		if tokens[0] == "total_inactive_file" {
+		if tokens[0] == inactiveFileToken {
 			totalInactiveFile, err = strconv.ParseFloat(tokens[1], 64)
 			framework.ExpectNoError(err)
 		}
@@ -293,7 +313,13 @@ func getMemoryStat(f *framework.Framework, host string) (rss, workingSet float64
 }
 
 func getCPUStat(f *framework.Framework, host string) (usage, uptime float64) {
-	cpuCmd := "cat /sys/fs/cgroup/cpu/system.slice/node-problem-detector.service/cpuacct.usage && cat /proc/uptime | awk '{print $1}'"
+	var cpuCmd string
+	if isHostRunningCgroupV2(f, host) {
+		cpuCmd = " cat /sys/fs/cgroup/cpu.stat | grep 'usage_usec' | sed 's/[^0-9]*//g' && cat /proc/uptime | awk '{print $1}'"
+	} else {
+		cpuCmd = "cat /sys/fs/cgroup/cpu/system.slice/node-problem-detector.service/cpuacct.usage && cat /proc/uptime | awk '{print $1}'"
+	}
+
 	result, err := e2essh.SSH(cpuCmd, host, framework.TestContext.Provider)
 	framework.ExpectNoError(err)
 	framework.ExpectEqual(result.Code, 0)
@@ -307,6 +333,16 @@ func getCPUStat(f *framework.Framework, host string) (usage, uptime float64) {
 	// Convert from nanoseconds to seconds
 	usage *= 1e-9
 	return
+}
+
+func isHostRunningCgroupV2(f *framework.Framework, host string) bool {
+	result, err := e2essh.SSH("stat -fc %T /sys/fs/cgroup/", host, framework.TestContext.Provider)
+	framework.ExpectNoError(err)
+	framework.ExpectEqual(result.Code, 0)
+
+	// 0x63677270 == CGROUP2_SUPER_MAGIC
+	// https://www.kernel.org/doc/html/latest/admin-guide/cgroup-v2.html
+	return strings.Contains(result.Stdout, "cgroup2") || strings.Contains(result.Stdout, "0x63677270")
 }
 
 func getNpdPodStat(f *framework.Framework, nodeName string) (cpuUsage, rss, workingSet float64) {


### PR DESCRIPTION
Cherry pick of #105755 on release-1.21.

#105755: Support cgroupv2 in node problem detector test

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
NONE
```