### PR TITLE
kubeadm: add mutation for Linux paths in KubeletConfiguration on Windows

### DIFF
--- a/cmd/kubeadm/app/apis/kubeadm/types.go
+++ b/cmd/kubeadm/app/apis/kubeadm/types.go
@@ -453,6 +453,9 @@ type ComponentConfig interface {
 	// SetUserSupplied sets the state of the component config "user supplied" flag to, either true, or false.
 	SetUserSupplied(userSupplied bool)
 
+	// Mutate allows applying pre-defined modifications to the config before it's marshaled.
+	Mutate() error
+
 	// Set can be used to set the internal configuration in the ComponentConfig
 	Set(interface{})
 

--- a/cmd/kubeadm/app/componentconfigs/fakeconfig_test.go
+++ b/cmd/kubeadm/app/componentconfigs/fakeconfig_test.go
@@ -110,6 +110,10 @@ func (cc *clusterConfig) Default(_ *kubeadmapi.ClusterConfiguration, _ *kubeadma
 	cc.config.KubernetesVersion = "bar"
 }
 
+func (cc *clusterConfig) Mutate() error {
+	return nil
+}
+
 // fakeKnown replaces temporarily during the execution of each test here known (in configset.go)
 var fakeKnown = []*handler{
 	&clusterConfigHandler,

--- a/cmd/kubeadm/app/componentconfigs/kubelet.go
+++ b/cmd/kubeadm/app/componentconfigs/kubelet.go
@@ -17,8 +17,12 @@ limitations under the License.
 package componentconfigs
 
 import (
+	"os"
 	"path/filepath"
+	"runtime"
+	"strings"
 
+	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/util/version"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/klog/v2"
@@ -210,6 +214,60 @@ func (kc *kubeletConfig) Default(cfg *kubeadmapi.ClusterConfiguration, _ *kubead
 			}
 		}
 	}
+}
+
+// Mutate modifies absolute path fields in the KubeletConfiguration to be Windows compatible absolute paths.
+func (kc *kubeletConfig) Mutate() error {
+	// TODO: use build tags and move the Windows related logic to _windows.go files
+	// once the kubeadm code base is unit tested for Windows as part of CI - "GOOS=windows go test ...".
+	if runtime.GOOS != "windows" {
+		return nil
+	}
+
+	// When "kubeadm join" downloads the KubeletConfiguration from the cluster on Windows
+	// nodes, it would contain absolute paths that may lack drive letters, since the config
+	// could have been generated on a Linux control-plane node. On Windows the
+	// Golang path.IsAbs() function returns false unless the path contains a drive letter.
+	// This trips client-go and the kubelet, creating problems on Windows nodes.
+	// Fixing it in client-go or the kubelet is a breaking change to existing Windows
+	// users that rely on relative paths:
+	//   https://github.com/kubernetes/kubernetes/pull/77710#issuecomment-491989621
+	//
+	// Thus, a workaround here is to adapt the KubeletConfiguration paths for Windows.
+	// Note this is currently bound to KubeletConfiguration v1beta1.
+	klog.V(2).Infoln("[componentconfig] Adapting the paths in the KubeletConfiguration for Windows...")
+
+	// Get the drive from where the kubeadm binary was called.
+	exe, err := os.Executable()
+	if err != nil {
+		return errors.Wrap(err, "could not obtain information about the kubeadm executable")
+	}
+	drive := filepath.VolumeName(filepath.Dir(exe))
+	klog.V(2).Infof("[componentconfig] Assuming Windows drive %q", drive)
+
+	// Mutate the paths in the config.
+	mutatePathsOnWindows(&kc.config, drive)
+	return nil
+}
+
+func mutatePathsOnWindows(cfg *kubeletconfig.KubeletConfiguration, drive string) {
+	mutateStringField := func(name string, field *string) {
+		// path.IsAbs() is not reliable here in the Windows runtime, so check if the
+		// path starts with "/" instead. This means the path originated from a Unix node and
+		// is an absolute path.
+		if !strings.HasPrefix(*field, "/") {
+			return
+		}
+		// Prepend the drive letter to the path and update the field.
+		*field = filepath.Join(drive, *field)
+		klog.V(2).Infof("[componentconfig] kubelet/Windows: adapted path for field %q to %q", name, *field)
+	}
+
+	// Mutate the fields we care about.
+	klog.V(2).Infof("[componentconfig] kubelet/Windows: changing field \"resolverConfig\" to empty")
+	cfg.ResolverConfig = utilpointer.String("")
+	mutateStringField("staticPodPath", &cfg.StaticPodPath)
+	mutateStringField("authentication.x509.clientCAFile", &cfg.Authentication.X509.ClientCAFile)
 }
 
 // isServiceActive checks whether the given service exists and is running

--- a/cmd/kubeadm/app/componentconfigs/kubelet_test.go
+++ b/cmd/kubeadm/app/componentconfigs/kubelet_test.go
@@ -288,3 +288,67 @@ func TestKubeletFromCluster(t *testing.T) {
 		return kubeletHandler.FromCluster(client, testClusterCfg())
 	})
 }
+
+func TestMutatePathsOnWindows(t *testing.T) {
+	const drive = "C:"
+	var fooResolverConfig string = "/foo/resolver"
+
+	tests := []struct {
+		name     string
+		cfg      *kubeletconfig.KubeletConfiguration
+		expected *kubeletconfig.KubeletConfiguration
+	}{
+		{
+			name: "valid: all fields are absolute paths",
+			cfg: &kubeletconfig.KubeletConfiguration{
+				ResolverConfig: &fooResolverConfig,
+				StaticPodPath:  "/foo/staticpods",
+				Authentication: kubeletconfig.KubeletAuthentication{
+					X509: kubeletconfig.KubeletX509Authentication{
+						ClientCAFile: "/foo/ca.crt",
+					},
+				},
+			},
+			expected: &kubeletconfig.KubeletConfiguration{
+				ResolverConfig: utilpointer.String(""),
+				StaticPodPath:  filepath.Join(drive, "/foo/staticpods"),
+				Authentication: kubeletconfig.KubeletAuthentication{
+					X509: kubeletconfig.KubeletX509Authentication{
+						ClientCAFile: filepath.Join(drive, "/foo/ca.crt"),
+					},
+				},
+			},
+		},
+		{
+			name: "valid: some fields are not absolute paths",
+			cfg: &kubeletconfig.KubeletConfiguration{
+				ResolverConfig: &fooResolverConfig,
+				StaticPodPath:  "./foo/staticpods", // not an absolute Unix path
+				Authentication: kubeletconfig.KubeletAuthentication{
+					X509: kubeletconfig.KubeletX509Authentication{
+						ClientCAFile: "/foo/ca.crt",
+					},
+				},
+			},
+			expected: &kubeletconfig.KubeletConfiguration{
+				ResolverConfig: utilpointer.String(""),
+				StaticPodPath:  "./foo/staticpods",
+				Authentication: kubeletconfig.KubeletAuthentication{
+					X509: kubeletconfig.KubeletX509Authentication{
+						ClientCAFile: filepath.Join(drive, "/foo/ca.crt"),
+					},
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			mutatePathsOnWindows(test.cfg, drive)
+			if !reflect.DeepEqual(test.cfg, test.expected) {
+				t.Errorf("Missmatch between expected and got:\nExpected:\n%+v\n---\nGot:\n%+v",
+					test.expected, test.cfg)
+			}
+		})
+	}
+}

--- a/cmd/kubeadm/app/componentconfigs/kubeproxy.go
+++ b/cmd/kubeadm/app/componentconfigs/kubeproxy.go
@@ -118,3 +118,8 @@ func (kp *kubeProxyConfig) Default(cfg *kubeadmapi.ClusterConfiguration, localAP
 		warnDefaultComponentConfigValue(kind, "clientConnection.kubeconfig", kubeproxyKubeConfigFileName, kp.config.ClientConnection.Kubeconfig)
 	}
 }
+
+// Mutate is NOP for the kube-proxy config
+func (kp *kubeProxyConfig) Mutate() error {
+	return nil
+}

--- a/cmd/kubeadm/app/phases/kubelet/config.go
+++ b/cmd/kubeadm/app/phases/kubelet/config.go
@@ -44,6 +44,10 @@ func WriteConfigToDisk(cfg *kubeadmapi.ClusterConfiguration, kubeletDir string) 
 		return errors.New("no kubelet component config found")
 	}
 
+	if err := kubeletCfg.Mutate(); err != nil {
+		return err
+	}
+
 	kubeletBytes, err := kubeletCfg.Marshal()
 	if err != nil {
 		return err


### PR DESCRIPTION

fix absolute paths do not work properly in config files in windows

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

<!--
Add one of the following kinds:

/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

Because linux and windows express the absolute path differently, some errors may be caused.

This pr fixes this bug, the fix method comes from https://gist.github.com/neolit123/1b7375c8a956155a2ca1cdd901336bce


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes # https://github.com/kubernetes/kubeadm/issues/2419

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
kubeadm: fix a bug on Windows worker nodes, where the downloaded KubeletConfiguration from the cluster can contain Linux paths that do not work on Windows and can trip the kubelet binary.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
