### PR TITLE
Capture spew.Sprintf() with all our favorite config into a util func

### DIFF
--- a/cmd/cloud-controller-manager/.import-restrictions
+++ b/cmd/cloud-controller-manager/.import-restrictions
@@ -35,6 +35,7 @@ rules:
       - k8s.io/kubernetes/pkg/securitycontext
       - k8s.io/kubernetes/pkg/util/hash
       - k8s.io/kubernetes/pkg/util/node
+      - k8s.io/kubernetes/pkg/util/print
       - k8s.io/kubernetes/pkg/util/parsers
       - k8s.io/kubernetes/pkg/util/taints
       - k8s.io/kubernetes/pkg/proxy/util

--- a/pkg/api/v1/endpoints/util_test.go
+++ b/pkg/api/v1/endpoints/util_test.go
@@ -20,9 +20,9 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/davecgh/go-spew/spew"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/kubernetes/pkg/util/print"
 )
 
 func podRef(uid string) *v1.ObjectReference {
@@ -458,7 +458,7 @@ func TestPackSubsets(t *testing.T) {
 	for _, tc := range testCases {
 		result := RepackSubsets(tc.given)
 		if !reflect.DeepEqual(result, SortSubsets(tc.expect)) {
-			t.Errorf("case %q: expected %s, got %s", tc.name, spew.Sprintf("%#v", SortSubsets(tc.expect)), spew.Sprintf("%#v", result))
+			t.Errorf("case %q: expected %s, got %s", tc.name, print.PrettyPrintObject(SortSubsets(tc.expect), true), print.PrettyPrintObject(result, true))
 		}
 	}
 }

--- a/pkg/apis/apps/validation/validation_test.go
+++ b/pkg/apis/apps/validation/validation_test.go
@@ -21,7 +21,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/davecgh/go-spew/spew"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -32,6 +31,7 @@ import (
 	api "k8s.io/kubernetes/pkg/apis/core"
 	corevalidation "k8s.io/kubernetes/pkg/apis/core/validation"
 	"k8s.io/kubernetes/pkg/features"
+	"k8s.io/kubernetes/pkg/util/print"
 )
 
 func TestValidateStatefulSet(t *testing.T) {
@@ -2403,7 +2403,7 @@ func TestValidateDeploymentStatus(t *testing.T) {
 
 		errs := ValidateDeploymentStatus(&status, field.NewPath("status"))
 		if hasErr := len(errs) > 0; hasErr != test.expectedErr {
-			errString := spew.Sprintf("%#v", errs)
+			errString := print.PrettyPrintObject(errs, true)
 			t.Errorf("%s: expected error: %t, got error: %t\nerrors: %s", test.name, test.expectedErr, hasErr, errString)
 		}
 	}
@@ -2474,7 +2474,7 @@ func TestValidateDeploymentStatusUpdate(t *testing.T) {
 
 		errs := ValidateDeploymentStatusUpdate(to, from)
 		if hasErr := len(errs) > 0; hasErr != test.expectedErr {
-			errString := spew.Sprintf("%#v", errs)
+			errString := print.PrettyPrintObject(errs, true)
 			t.Errorf("%s: expected error: %t, got error: %t\nerrors: %s", test.name, test.expectedErr, hasErr, errString)
 		}
 	}

--- a/pkg/util/hash/hash_test.go
+++ b/pkg/util/hash/hash_test.go
@@ -21,7 +21,7 @@ import (
 	"hash/adler32"
 	"testing"
 
-	"github.com/davecgh/go-spew/spew"
+	"k8s.io/kubernetes/pkg/util/print"
 )
 
 type A struct {
@@ -93,7 +93,7 @@ func TestDeepHashObject(t *testing.T) {
 }
 
 func toString(obj interface{}) string {
-	return spew.Sprintf("%#v", obj)
+	return print.PrettyPrintObject(obj, true)
 }
 
 type wheel struct {

--- a/pkg/util/print/print.go
+++ b/pkg/util/print/print.go
@@ -1,0 +1,32 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package print
+
+import (
+	"github.com/davecgh/go-spew/spew"
+)
+
+// PrettyPrintObejct wrap the spew.Sprintf, it returns object's value with or without type in string
+func PrettyPrintObject(a interface{}, withType bool) string {
+	format := "%#v"
+
+	if !withType {
+		format = "%+v"
+	}
+
+	return spew.Sprintf(format, a)
+}

--- a/pkg/util/print/print_test.go
+++ b/pkg/util/print/print_test.go
@@ -1,0 +1,117 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package print
+
+import (
+	"testing"
+)
+
+func ptrint(i int) *int {
+	return &i
+}
+
+func ptrstr(s string) *string {
+	return &s
+}
+
+func TestPrettyPrintObject(t *testing.T) {
+	testCases := []struct {
+		a        interface{}
+		withType bool
+		want     string
+	}{
+		{int8(93), true, "(int8)93"},
+		{int16(93), true, "(int16)93"},
+		{int32(93), true, "(int32)93"},
+		{int64(93), true, "(int64)93"},
+		{int(-93), true, "(int)-93"},
+		{int8(-93), true, "(int8)-93"},
+		{int16(-93), true, "(int16)-93"},
+		{int32(-93), true, "(int32)-93"},
+		{int64(-93), true, "(int64)-93"},
+		{uint(93), true, "(uint)93"},
+		{uint8(93), true, "(uint8)93"},
+		{uint16(93), true, "(uint16)93"},
+		{uint32(93), true, "(uint32)93"},
+		{uint64(93), true, "(uint64)93"},
+		{uintptr(93), true, "(uintptr)0x5d"},
+		{ptrint(93), true, "(*int)93"},
+		{float32(93.76), true, "(float32)93.76"},
+		{float64(93.76), true, "(float64)93.76"},
+		{complex64(93i), true, "(complex64)(0+93i)"},
+		{complex128(93i), true, "(complex128)(0+93i)"},
+		{bool(true), true, "(bool)true"},
+		{bool(false), true, "(bool)false"},
+		{string("test"), true, "(string)test"},
+		{ptrstr("test"), true, "(*string)test"},
+		{
+			struct {
+				arr   [1]string
+				slice []string
+				m     map[string]int
+			}{
+				[1]string{"arr"},
+				[]string{"slice"},
+				map[string]int{"one": 1},
+			},
+			true,
+			"(struct { arr [1]string; slice []string; m map[string]int }){arr:([1]string)[arr] slice:([]string)[slice] m:(map[string]int)map[one:1]}",
+		},
+		{int8(93), false, "93"},
+		{int16(93), false, "93"},
+		{int32(93), false, "93"},
+		{int64(93), false, "93"},
+		{int(-93), false, "-93"},
+		{int8(-93), false, "-93"},
+		{int16(-93), false, "-93"},
+		{int32(-93), false, "-93"},
+		{int64(-93), false, "-93"},
+		{uint(93), false, "93"},
+		{uint8(93), false, "93"},
+		{uint16(93), false, "93"},
+		{uint32(93), false, "93"},
+		{uint64(93), false, "93"},
+		{uintptr(93), false, "0x5d"},
+		{float32(93.76), false, "93.76"},
+		{float64(93.76), false, "93.76"},
+		{complex64(93i), false, "(0+93i)"},
+		{complex128(93i), false, "(0+93i)"},
+		{bool(true), false, "true"},
+		{bool(false), false, "false"},
+		{string("test"), false, "test"},
+		{
+			struct {
+				arr   [1]string
+				slice []string
+				m     map[string]int
+			}{
+				[1]string{"arr"},
+				[]string{"slice"},
+				map[string]int{"one": 1},
+			},
+			false,
+			"{arr:[arr] slice:[slice] m:map[one:1]}",
+		},
+	}
+
+	for i, tc := range testCases {
+		s := PrettyPrintObject(tc.a, tc.withType)
+		if tc.want != s {
+			t.Errorf("[%d]:\n\texpected %q\n\tgot      %q", i, tc.want, s)
+		}
+	}
+}

--- a/staging/src/k8s.io/client-go/tools/watch/retrywatcher.go
+++ b/staging/src/k8s.io/client-go/tools/watch/retrywatcher.go
@@ -24,8 +24,6 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/davecgh/go-spew/spew"
-
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/net"
@@ -33,6 +31,7 @@ import (
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
+	"k8s.io/kubernetes/pkg/util/print"
 )
 
 // resourceVersionGetter is an interface used to get resource version from events.
@@ -191,7 +190,7 @@ func (rw *RetryWatcher) doReceive() (bool, time.Duration) {
 				errObject := apierrors.FromObject(event.Object)
 				statusErr, ok := errObject.(*apierrors.StatusError)
 				if !ok {
-					klog.Error(spew.Sprintf("Received an error which is not *metav1.Status but %#+v", event.Object))
+					klog.Error("Received an error which is not *metav1.Status but %s", print.PrettyPrintObject(event.Object, true))
 					// Retry unknown errors
 					return false, 0
 				}
@@ -220,7 +219,7 @@ func (rw *RetryWatcher) doReceive() (bool, time.Duration) {
 
 					// Log here so we have a record of hitting the unexpected error
 					// and we can whitelist some error codes if we missed any that are expected.
-					klog.V(5).Info(spew.Sprintf("Retrying after unexpected error: %#+v", event.Object))
+					klog.V(5).Info("Retrying after unexpected error: %s", print.PrettyPrintObject(event.Object, true))
 
 					// Retry
 					return false, statusDelay

--- a/test/e2e/apps/deployment.go
+++ b/test/e2e/apps/deployment.go
@@ -24,7 +24,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/davecgh/go-spew/spew"
 	"github.com/onsi/ginkgo"
 	"github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/fields"
@@ -51,6 +50,7 @@ import (
 	"k8s.io/client-go/util/retry"
 	appsinternal "k8s.io/kubernetes/pkg/apis/apps"
 	deploymentutil "k8s.io/kubernetes/pkg/controller/deployment/util"
+	"k8s.io/kubernetes/pkg/util/print"
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2edeployment "k8s.io/kubernetes/test/e2e/framework/deployment"
 	e2enode "k8s.io/kubernetes/test/e2e/framework/node"
@@ -636,7 +636,7 @@ func failureTrap(c clientset.Interface, ns string) {
 	for i := range deployments.Items {
 		d := deployments.Items[i]
 
-		framework.Logf(spew.Sprintf("Deployment %q:\n%+v\n", d.Name, d))
+		framework.Logf("Deployment %q:\n%s\n", d.Name, print.PrettyPrintObject(d, false))
 		_, allOldRSs, newRS, err := testutil.GetAllReplicaSets(&d, c)
 		if err != nil {
 			framework.Logf("Could not list ReplicaSets for Deployment %q: %v", d.Name, err)
@@ -660,7 +660,7 @@ func failureTrap(c clientset.Interface, ns string) {
 		return
 	}
 	for _, rs := range rss.Items {
-		framework.Logf(spew.Sprintf("ReplicaSet %q:\n%+v\n", rs.Name, rs))
+		framework.Logf("ReplicaSet %q:\n%s\n", rs.Name, print.PrettyPrintObject(rs, false))
 		selector, err := metav1.LabelSelectorAsSelector(rs.Spec.Selector)
 		if err != nil {
 			framework.Logf("failed to get selector of ReplicaSet %s: %v", rs.Name, err)
@@ -672,7 +672,7 @@ func failureTrap(c clientset.Interface, ns string) {
 			continue
 		}
 		for _, pod := range podList.Items {
-			framework.Logf(spew.Sprintf("pod: %q:\n%+v\n", pod.Name, pod))
+			framework.Logf("pod: %q:\n%s\n", pod.Name, print.PrettyPrintObject(pod, false))
 		}
 	}
 }

--- a/test/e2e/framework/.import-restrictions
+++ b/test/e2e/framework/.import-restrictions
@@ -222,6 +222,7 @@ rules:
       - k8s.io/kubernetes/pkg/util/oom
       - k8s.io/kubernetes/pkg/util/parsers
       - k8s.io/kubernetes/pkg/util/pod
+      - k8s.io/kubernetes/pkg/util/print
       - k8s.io/kubernetes/pkg/util/procfs
       - k8s.io/kubernetes/pkg/util/removeall
       - k8s.io/kubernetes/pkg/util/resizefs

--- a/test/e2e_node/dynamic_kubelet_config_test.go
+++ b/test/e2e_node/dynamic_kubelet_config_test.go
@@ -23,8 +23,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/davecgh/go-spew/spew"
-
 	v1 "k8s.io/api/core/v1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -34,6 +32,7 @@ import (
 	controller "k8s.io/kubernetes/pkg/kubelet/kubeletconfig"
 	"k8s.io/kubernetes/pkg/kubelet/kubeletconfig/status"
 	"k8s.io/kubernetes/pkg/kubelet/metrics"
+	"k8s.io/kubernetes/pkg/util/print"
 	e2emetrics "k8s.io/kubernetes/test/e2e/framework/metrics"
 
 	"k8s.io/kubernetes/test/e2e/framework"
@@ -960,7 +959,7 @@ func (tc *nodeConfigTestCase) checkNodeConfigSource(f *framework.Framework) {
 		}
 		actual := node.Spec.ConfigSource
 		if !apiequality.Semantic.DeepEqual(tc.configSource, actual) {
-			return fmt.Errorf(spew.Sprintf("checkNodeConfigSource: case %s: expected %#v but got %#v", tc.desc, tc.configSource, actual))
+			return fmt.Errorf("checkNodeConfigSource: case %s: expected %s but got %s", tc.desc, print.PrettyPrintObject(tc.configSource, true), print.PrettyPrintObject(actual, true))
 		}
 		return nil
 	}, timeout, interval).Should(gomega.BeNil())
@@ -997,11 +996,11 @@ func expectConfigStatus(tc *nodeConfigTestCase, actual *v1.NodeConfigStatus) err
 		expectAssigned.ConfigMap.ResourceVersion = tc.configMap.ResourceVersion
 	}
 	if !apiequality.Semantic.DeepEqual(expectAssigned, actual.Assigned) {
-		errs = append(errs, spew.Sprintf("expected Assigned %#v but got %#v", expectAssigned, actual.Assigned))
+		errs = append(errs, fmt.Sprintf("expected Assigned %s but got %s", print.PrettyPrintObject(expectAssigned, true), print.PrettyPrintObject(actual.Assigned, true)))
 	}
 	// check LastKnownGood matches tc.expectConfigStatus.lastKnownGood
 	if !apiequality.Semantic.DeepEqual(tc.expectConfigStatus.lastKnownGood, actual.LastKnownGood) {
-		errs = append(errs, spew.Sprintf("expected LastKnownGood %#v but got %#v", tc.expectConfigStatus.lastKnownGood, actual.LastKnownGood))
+		errs = append(errs, fmt.Sprintf("expected LastKnownGood %s but got %s", print.PrettyPrintObject(tc.expectConfigStatus.lastKnownGood, true), print.PrettyPrintObject(actual.LastKnownGood, true)))
 	}
 	// check Active matches Assigned or LastKnownGood, depending on tc.expectConfigStatus.lkgActive
 	expectActive := expectAssigned
@@ -1009,7 +1008,7 @@ func expectConfigStatus(tc *nodeConfigTestCase, actual *v1.NodeConfigStatus) err
 		expectActive = tc.expectConfigStatus.lastKnownGood
 	}
 	if !apiequality.Semantic.DeepEqual(expectActive, actual.Active) {
-		errs = append(errs, spew.Sprintf("expected Active %#v but got %#v", expectActive, actual.Active))
+		errs = append(errs, fmt.Sprintf("expected Active %s but got %s", print.PrettyPrintObject(expectActive, true), print.PrettyPrintObject(actual.Active, true)))
 	}
 	// check Error
 	if tc.expectConfigStatus.err != actual.Error {
@@ -1034,7 +1033,7 @@ func (tc *nodeConfigTestCase) checkConfig(f *framework.Framework) {
 			return fmt.Errorf("checkConfig: case %s: %v", tc.desc, err)
 		}
 		if !apiequality.Semantic.DeepEqual(tc.expectConfig, actual) {
-			return fmt.Errorf(spew.Sprintf("checkConfig: case %s: expected %#v but got %#v", tc.desc, tc.expectConfig, actual))
+			return fmt.Errorf("checkConfig: case %s: expected %s but got %s", tc.desc, print.PrettyPrintObject(tc.expectConfig, true), print.PrettyPrintObject(actual, true))
 		}
 		return nil
 	}, timeout, interval).Should(gomega.BeNil())
@@ -1186,7 +1185,7 @@ func (tc *nodeConfigTestCase) checkConfigMetrics(f *framework.Framework) {
 		}
 		// compare to expected
 		if !reflect.DeepEqual(expect, actual) {
-			return fmt.Errorf("checkConfigMetrics: case: %s: expect metrics %s but got %s", tc.desc, spew.Sprintf("%#v", expect), spew.Sprintf("%#v", actual))
+			return fmt.Errorf("checkConfigMetrics: case: %s: expect metrics %s but got %s", tc.desc, print.PrettyPrintObject(expect, true), print.PrettyPrintObject(actual, true))
 		}
 		return nil
 	}, timeout, interval).Should(gomega.BeNil())

--- a/test/integration/client/exec_test.go
+++ b/test/integration/client/exec_test.go
@@ -34,7 +34,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/davecgh/go-spew/spew"
 	"github.com/google/go-cmp/cmp"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -53,6 +52,7 @@ import (
 	"k8s.io/client-go/util/cert"
 	"k8s.io/client-go/util/connrotation"
 	kubeapiservertesting "k8s.io/kubernetes/cmd/kube-apiserver/app/testing"
+	"k8s.io/kubernetes/pkg/util/print"
 	"k8s.io/kubernetes/test/integration/framework"
 )
 
@@ -614,7 +614,7 @@ func (is *informerSpy) waitForEvents(t *testing.T, wantEvents bool) {
 			if err != nil {
 				t.Fatalf("wanted no events, but got error: %v", err)
 			} else {
-				t.Fatalf("wanted no events, but got some: %s", spew.Sprintf("%#v", is))
+				t.Fatalf("wanted no events, but got some: %s", print.PrettyPrintObject(is, true))
 			}
 		}
 	}

--- a/test/utils/deployment.go
+++ b/test/utils/deployment.go
@@ -21,23 +21,22 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/davecgh/go-spew/spew"
-
 	apps "k8s.io/api/apps/v1"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	clientset "k8s.io/client-go/kubernetes"
 	podutil "k8s.io/kubernetes/pkg/api/v1/pod"
 	deploymentutil "k8s.io/kubernetes/pkg/controller/deployment/util"
 	labelsutil "k8s.io/kubernetes/pkg/util/labels"
+	"k8s.io/kubernetes/pkg/util/print"
 )
 
 type LogfFn func(format string, args ...interface{})
 
 func LogReplicaSetsOfDeployment(deployment *apps.Deployment, allOldRSs []*apps.ReplicaSet, newRS *apps.ReplicaSet, logf LogfFn) {
 	if newRS != nil {
-		logf(spew.Sprintf("New ReplicaSet %q of Deployment %q:\n%+v", newRS.Name, deployment.Name, *newRS))
+		logf("New ReplicaSet %q of Deployment %q:\n%s", newRS.Name, deployment.Name, print.PrettyPrintObject(*newRS, false))
 	} else {
 		logf("New ReplicaSet of Deployment %q is nil.", deployment.Name)
 	}
@@ -45,7 +44,7 @@ func LogReplicaSetsOfDeployment(deployment *apps.Deployment, allOldRSs []*apps.R
 		logf("All old ReplicaSets of Deployment %q:", deployment.Name)
 	}
 	for i := range allOldRSs {
-		logf(spew.Sprintf("%+v", *allOldRSs[i]))
+		logf(print.PrettyPrintObject(*allOldRSs[i], false))
 	}
 }
 
@@ -65,7 +64,7 @@ func LogPodsOfDeployment(c clientset.Interface, deployment *apps.Deployment, rsL
 		if podutil.IsPodAvailable(&pod, minReadySeconds, metav1.Now()) {
 			availability = "available"
 		}
-		logf(spew.Sprintf("Pod %q is %s:\n%+v", pod.Name, availability, pod))
+		logf("Pod %q is %s:\n%s", pod.Name, availability, print.PrettyPrintObject(pod, false))
 	}
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
A wrapper of spew.Sprintf, so to pretty print object with a util function

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #8976

#### Special notes for your reviewer:
With existing usage of spew.Sprintf, the wapper function print object with type info by %#v, and without type info by %+v

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
None
```
