### PR TITLE
Make CRI `v1` the default and allow a fallback to `v1alpha2`

### DIFF
--- a/pkg/kubelet/cm/cpumanager/cpu_manager.go
+++ b/pkg/kubelet/cm/cpumanager/cpu_manager.go
@@ -27,7 +27,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/klog/v2"
 
-	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
 	"k8s.io/kubernetes/pkg/kubelet/cm/containermap"
 	"k8s.io/kubernetes/pkg/kubelet/cm/cpumanager/state"
 	"k8s.io/kubernetes/pkg/kubelet/cm/cpumanager/topology"

--- a/pkg/kubelet/cm/cpumanager/cpu_manager_test.go
+++ b/pkg/kubelet/cm/cpumanager/cpu_manager_test.go
@@ -32,7 +32,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
 	"k8s.io/kubernetes/pkg/kubelet/cm/containermap"
 	"k8s.io/kubernetes/pkg/kubelet/cm/cpumanager/state"
 	"k8s.io/kubernetes/pkg/kubelet/cm/cpumanager/topology"

--- a/pkg/kubelet/cm/fake_internal_container_lifecycle.go
+++ b/pkg/kubelet/cm/fake_internal_container_lifecycle.go
@@ -18,7 +18,7 @@ package cm
 
 import (
 	"k8s.io/api/core/v1"
-	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
 )
 
 func NewFakeInternalContainerLifecycle() *fakeInternalContainerLifecycle {

--- a/pkg/kubelet/cm/internal_container_lifecycle.go
+++ b/pkg/kubelet/cm/internal_container_lifecycle.go
@@ -19,7 +19,7 @@ package cm
 import (
 	"k8s.io/api/core/v1"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
-	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
 	kubefeatures "k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/pkg/kubelet/cm/cpumanager"
 	"k8s.io/kubernetes/pkg/kubelet/cm/memorymanager"

--- a/pkg/kubelet/cm/internal_container_lifecycle_linux.go
+++ b/pkg/kubelet/cm/internal_container_lifecycle_linux.go
@@ -24,7 +24,7 @@ import (
 	"strings"
 
 	"k8s.io/api/core/v1"
-	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
 )
 
 func (i *internalContainerLifecycleImpl) PreCreateContainer(pod *v1.Pod, container *v1.Container, containerConfig *runtimeapi.ContainerConfig) error {

--- a/pkg/kubelet/cm/internal_container_lifecycle_unsupported.go
+++ b/pkg/kubelet/cm/internal_container_lifecycle_unsupported.go
@@ -21,7 +21,7 @@ package cm
 
 import (
 	"k8s.io/api/core/v1"
-	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
 )
 
 func (i *internalContainerLifecycleImpl) PreCreateContainer(pod *v1.Pod, container *v1.Container, containerConfig *runtimeapi.ContainerConfig) error {

--- a/pkg/kubelet/cm/internal_container_lifecycle_windows.go
+++ b/pkg/kubelet/cm/internal_container_lifecycle_windows.go
@@ -21,7 +21,7 @@ package cm
 
 import (
 	"k8s.io/api/core/v1"
-	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
 )
 
 func (i *internalContainerLifecycleImpl) PreCreateContainer(pod *v1.Pod, container *v1.Container, containerConfig *runtimeapi.ContainerConfig) error {

--- a/pkg/kubelet/cm/memorymanager/memory_manager.go
+++ b/pkg/kubelet/cm/memorymanager/memory_manager.go
@@ -25,7 +25,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/util/sets"
-	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
 	"k8s.io/klog/v2"
 	corev1helper "k8s.io/kubernetes/pkg/apis/core/v1/helper"
 	kubeletconfig "k8s.io/kubernetes/pkg/kubelet/apis/config"

--- a/pkg/kubelet/cm/memorymanager/memory_manager_test.go
+++ b/pkg/kubelet/cm/memorymanager/memory_manager_test.go
@@ -33,7 +33,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
 	kubeletconfig "k8s.io/kubernetes/pkg/kubelet/apis/config"
 	"k8s.io/kubernetes/pkg/kubelet/cm/containermap"
 	"k8s.io/kubernetes/pkg/kubelet/cm/memorymanager/state"

--- a/pkg/kubelet/container/helpers.go
+++ b/pkg/kubelet/container/helpers.go
@@ -29,7 +29,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/tools/record"
-	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
 	podutil "k8s.io/kubernetes/pkg/api/v1/pod"
 	sc "k8s.io/kubernetes/pkg/securitycontext"
 	hashutil "k8s.io/kubernetes/pkg/util/hash"

--- a/pkg/kubelet/container/runtime.go
+++ b/pkg/kubelet/container/runtime.go
@@ -30,7 +30,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/remotecommand"
 	"k8s.io/client-go/util/flowcontrol"
-	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
 	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/pkg/volume"
 )

--- a/pkg/kubelet/container/testing/fake_runtime.go
+++ b/pkg/kubelet/container/testing/fake_runtime.go
@@ -28,7 +28,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/util/flowcontrol"
-	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
 	"k8s.io/kubernetes/pkg/volume"
 )

--- a/pkg/kubelet/container/testing/fake_runtime_helper.go
+++ b/pkg/kubelet/container/testing/fake_runtime_helper.go
@@ -19,7 +19,7 @@ package testing
 import (
 	"k8s.io/api/core/v1"
 	kubetypes "k8s.io/apimachinery/pkg/types"
-	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
 )
 

--- a/pkg/kubelet/container/testing/runtime_mock.go
+++ b/pkg/kubelet/container/testing/runtime_mock.go
@@ -28,7 +28,7 @@ import (
 	types "k8s.io/apimachinery/pkg/types"
 	remotecommand "k8s.io/client-go/tools/remotecommand"
 	flowcontrol "k8s.io/client-go/util/flowcontrol"
-	v1alpha2 "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+	v10 "k8s.io/cri-api/pkg/apis/runtime/v1"
 	container "k8s.io/kubernetes/pkg/kubelet/container"
 	url "net/url"
 	reflect "reflect"
@@ -284,7 +284,7 @@ func (mr *MockRuntimeMockRecorder) DeleteContainer(containerID interface{}) *gom
 }
 
 // PullImage mocks base method
-func (m *MockRuntime) PullImage(image container.ImageSpec, pullSecrets []v1.Secret, podSandboxConfig *v1alpha2.PodSandboxConfig) (string, error) {
+func (m *MockRuntime) PullImage(image container.ImageSpec, pullSecrets []v1.Secret, podSandboxConfig *v10.PodSandboxConfig) (string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "PullImage", image, pullSecrets, podSandboxConfig)
 	ret0, _ := ret[0].(string)
@@ -463,7 +463,7 @@ func (m *MockImageService) EXPECT() *MockImageServiceMockRecorder {
 }
 
 // PullImage mocks base method
-func (m *MockImageService) PullImage(image container.ImageSpec, pullSecrets []v1.Secret, podSandboxConfig *v1alpha2.PodSandboxConfig) (string, error) {
+func (m *MockImageService) PullImage(image container.ImageSpec, pullSecrets []v1.Secret, podSandboxConfig *v10.PodSandboxConfig) (string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "PullImage", image, pullSecrets, podSandboxConfig)
 	ret0, _ := ret[0].(string)

--- a/pkg/kubelet/cri/remote/conversion.go
+++ b/pkg/kubelet/cri/remote/conversion.go
@@ -1,0 +1,144 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package remote
+
+import (
+	"unsafe"
+
+	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
+	"k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+)
+
+func fromV1alpha2VersionResponse(from *v1alpha2.VersionResponse) *runtimeapi.VersionResponse {
+	return (*runtimeapi.VersionResponse)(unsafe.Pointer(from))
+}
+
+func fromV1alpha2PodSandboxStatus(from *v1alpha2.PodSandboxStatus) *runtimeapi.PodSandboxStatus {
+	return (*runtimeapi.PodSandboxStatus)(unsafe.Pointer(from))
+}
+
+func fromV1alpha2ListPodSandboxResponse(from *v1alpha2.ListPodSandboxResponse) *runtimeapi.ListPodSandboxResponse {
+	return (*runtimeapi.ListPodSandboxResponse)(unsafe.Pointer(from))
+}
+
+func fromV1alpha2ListContainersResponse(from *v1alpha2.ListContainersResponse) *runtimeapi.ListContainersResponse {
+	return (*runtimeapi.ListContainersResponse)(unsafe.Pointer(from))
+}
+
+func fromV1alpha2ContainerStatus(from *v1alpha2.ContainerStatus) *runtimeapi.ContainerStatus {
+	return (*runtimeapi.ContainerStatus)(unsafe.Pointer(from))
+}
+
+func fromV1alpha2ExecResponse(from *v1alpha2.ExecResponse) *runtimeapi.ExecResponse {
+	return (*runtimeapi.ExecResponse)(unsafe.Pointer(from))
+}
+
+func fromV1alpha2AttachResponse(from *v1alpha2.AttachResponse) *runtimeapi.AttachResponse {
+	return (*runtimeapi.AttachResponse)(unsafe.Pointer(from))
+}
+
+func fromV1alpha2PortForwardResponse(from *v1alpha2.PortForwardResponse) *runtimeapi.PortForwardResponse {
+	return (*runtimeapi.PortForwardResponse)(unsafe.Pointer(from))
+}
+
+func fromV1alpha2RuntimeStatus(from *v1alpha2.RuntimeStatus) *runtimeapi.RuntimeStatus {
+	return (*runtimeapi.RuntimeStatus)(unsafe.Pointer(from))
+}
+
+func fromV1alpha2ContainerStats(from *v1alpha2.ContainerStats) *runtimeapi.ContainerStats {
+	return (*runtimeapi.ContainerStats)(unsafe.Pointer(from))
+}
+
+func fromV1alpha2ImageFsInfoResponse(from *v1alpha2.ImageFsInfoResponse) *runtimeapi.ImageFsInfoResponse {
+	return (*runtimeapi.ImageFsInfoResponse)(unsafe.Pointer(from))
+}
+
+func fromV1alpha2ListContainerStatsResponse(from *v1alpha2.ListContainerStatsResponse) *runtimeapi.ListContainerStatsResponse {
+	return (*runtimeapi.ListContainerStatsResponse)(unsafe.Pointer(from))
+}
+
+func fromV1alpha2PodSandboxStats(from *v1alpha2.PodSandboxStats) *runtimeapi.PodSandboxStats {
+	return (*runtimeapi.PodSandboxStats)(unsafe.Pointer(from))
+}
+
+func fromV1alpha2ListPodSandboxStatsResponse(from *v1alpha2.ListPodSandboxStatsResponse) *runtimeapi.ListPodSandboxStatsResponse {
+	return (*runtimeapi.ListPodSandboxStatsResponse)(unsafe.Pointer(from))
+}
+
+func fromV1alpha2Image(from *v1alpha2.Image) *runtimeapi.Image {
+	return (*runtimeapi.Image)(unsafe.Pointer(from))
+}
+
+func fromV1alpha2ListImagesResponse(from *v1alpha2.ListImagesResponse) *runtimeapi.ListImagesResponse {
+	return (*runtimeapi.ListImagesResponse)(unsafe.Pointer(from))
+}
+
+func v1alpha2PodSandboxConfig(from *runtimeapi.PodSandboxConfig) *v1alpha2.PodSandboxConfig {
+	return (*v1alpha2.PodSandboxConfig)(unsafe.Pointer(from))
+}
+
+func v1alpha2PodSandboxFilter(from *runtimeapi.PodSandboxFilter) *v1alpha2.PodSandboxFilter {
+	return (*v1alpha2.PodSandboxFilter)(unsafe.Pointer(from))
+}
+
+func v1alpha2ContainerConfig(from *runtimeapi.ContainerConfig) *v1alpha2.ContainerConfig {
+	return (*v1alpha2.ContainerConfig)(unsafe.Pointer(from))
+}
+
+func v1alpha2ContainerFilter(from *runtimeapi.ContainerFilter) *v1alpha2.ContainerFilter {
+	return (*v1alpha2.ContainerFilter)(unsafe.Pointer(from))
+}
+
+func v1alpha2LinuxContainerResources(from *runtimeapi.LinuxContainerResources) *v1alpha2.LinuxContainerResources {
+	return (*v1alpha2.LinuxContainerResources)(unsafe.Pointer(from))
+}
+
+func v1alpha2ExecRequest(from *runtimeapi.ExecRequest) *v1alpha2.ExecRequest {
+	return (*v1alpha2.ExecRequest)(unsafe.Pointer(from))
+}
+
+func v1alpha2AttachRequest(from *runtimeapi.AttachRequest) *v1alpha2.AttachRequest {
+	return (*v1alpha2.AttachRequest)(unsafe.Pointer(from))
+}
+
+func v1alpha2PortForwardRequest(from *runtimeapi.PortForwardRequest) *v1alpha2.PortForwardRequest {
+	return (*v1alpha2.PortForwardRequest)(unsafe.Pointer(from))
+}
+
+func v1alpha2RuntimeConfig(from *runtimeapi.RuntimeConfig) *v1alpha2.RuntimeConfig {
+	return (*v1alpha2.RuntimeConfig)(unsafe.Pointer(from))
+}
+
+func v1alpha2ContainerStatsFilter(from *runtimeapi.ContainerStatsFilter) *v1alpha2.ContainerStatsFilter {
+	return (*v1alpha2.ContainerStatsFilter)(unsafe.Pointer(from))
+}
+
+func v1alpha2PodSandboxStatsFilter(from *runtimeapi.PodSandboxStatsFilter) *v1alpha2.PodSandboxStatsFilter {
+	return (*v1alpha2.PodSandboxStatsFilter)(unsafe.Pointer(from))
+}
+
+func v1alpha2ImageFilter(from *runtimeapi.ImageFilter) *v1alpha2.ImageFilter {
+	return (*v1alpha2.ImageFilter)(unsafe.Pointer(from))
+}
+
+func v1alpha2ImageSpec(from *runtimeapi.ImageSpec) *v1alpha2.ImageSpec {
+	return (*v1alpha2.ImageSpec)(unsafe.Pointer(from))
+}
+
+func v1alpha2AuthConfig(from *runtimeapi.AuthConfig) *v1alpha2.AuthConfig {
+	return (*v1alpha2.AuthConfig)(unsafe.Pointer(from))
+}

--- a/pkg/kubelet/cri/remote/conversion_test.go
+++ b/pkg/kubelet/cri/remote/conversion_test.go
@@ -1,0 +1,314 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package remote
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/gogo/protobuf/proto"
+	"github.com/stretchr/testify/assert"
+	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
+	"k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+)
+
+func fillFields(s interface{}) {
+	fillFieldsOffset(s, 0)
+}
+
+func fillFieldsOffset(s interface{}, offset int) {
+	reflectType := reflect.TypeOf(s).Elem()
+	reflectValue := reflect.ValueOf(s).Elem()
+
+	for i := 0; i < reflectType.NumField(); i++ {
+		field := reflectValue.Field(i)
+		typeName := reflectType.Field(i).Name
+
+		// Skipping protobuf internal values
+		if strings.HasPrefix(typeName, "XXX_") {
+			continue
+		}
+
+		fillField(field, i+offset)
+	}
+}
+
+func fillField(field reflect.Value, v int) {
+	switch field.Kind() {
+	case reflect.Bool:
+		field.SetBool(true)
+
+	case reflect.Float32, reflect.Float64:
+		field.SetFloat(float64(v))
+
+	case reflect.String:
+		field.SetString(fmt.Sprint(v))
+
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		field.SetInt(int64(v))
+
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		field.SetUint(uint64(v))
+
+	case reflect.Map:
+		field.Set(reflect.MakeMap(field.Type()))
+
+	case reflect.Array, reflect.Slice:
+		slice := reflect.MakeSlice(field.Type(), 1, 1)
+		field.Set(slice)
+		first := slice.Index(0)
+
+		if first.Type().Kind() == reflect.Ptr {
+			first.Set(reflect.New(first.Type().Elem()))
+			fillFieldsOffset(first.Interface(), v)
+		} else {
+			fillField(first, v)
+		}
+
+	case reflect.Ptr:
+		val := reflect.New(field.Type().Elem())
+		field.Set(val)
+		fillFieldsOffset(field.Interface(), v)
+
+	case reflect.Struct:
+		fillFieldsOffset(field.Addr().Interface(), v)
+	}
+
+}
+
+func assertEqual(t *testing.T, a, b proto.Message) {
+	aBytes, err := proto.Marshal(a)
+	assert.Nil(t, err)
+
+	bBytes, err := proto.Marshal(b)
+	assert.Nil(t, err)
+
+	assert.Equal(t, aBytes, bBytes)
+}
+
+func TestFromV1alpha2VersionResponse(t *testing.T) {
+	from := &v1alpha2.VersionResponse{}
+	fillFields(from)
+	to := fromV1alpha2VersionResponse(from)
+	assertEqual(t, from, to)
+}
+
+func TestFromV1alpha2PodSandboxStatus(t *testing.T) {
+	from := &v1alpha2.PodSandboxStatus{}
+	fillFields(from)
+	to := fromV1alpha2PodSandboxStatus(from)
+	assertEqual(t, from, to)
+}
+
+func TestFromV1alpha2ListPodSandboxResponse(t *testing.T) {
+	from := &v1alpha2.ListPodSandboxResponse{}
+	fillFields(from)
+	to := fromV1alpha2ListPodSandboxResponse(from)
+	assertEqual(t, from, to)
+}
+
+func TestFromV1alpha2ListContainersResponse(t *testing.T) {
+	from := &v1alpha2.ListContainersResponse{}
+	fillFields(from)
+	to := fromV1alpha2ListContainersResponse(from)
+	assertEqual(t, from, to)
+}
+
+func TestFromV1alpha2ContainerStatus(t *testing.T) {
+	from := &v1alpha2.ContainerStatus{}
+	fillFields(from)
+	to := fromV1alpha2ContainerStatus(from)
+	assertEqual(t, from, to)
+}
+
+func TestFromV1alpha2ExecResponse(t *testing.T) {
+	from := &v1alpha2.ExecResponse{}
+	fillFields(from)
+	to := fromV1alpha2ExecResponse(from)
+	assertEqual(t, from, to)
+}
+
+func TestFromV1alpha2AttachResponse(t *testing.T) {
+	from := &v1alpha2.AttachResponse{}
+	fillFields(from)
+	to := fromV1alpha2AttachResponse(from)
+	assertEqual(t, from, to)
+}
+
+func TestFromV1alpha2PortForwardResponse(t *testing.T) {
+	from := &v1alpha2.PortForwardResponse{}
+	fillFields(from)
+	to := fromV1alpha2PortForwardResponse(from)
+	assertEqual(t, from, to)
+}
+
+func TestFromV1alpha2RuntimeStatus(t *testing.T) {
+	from := &v1alpha2.RuntimeStatus{}
+	fillFields(from)
+	to := fromV1alpha2RuntimeStatus(from)
+	assertEqual(t, from, to)
+}
+
+func TestFromV1alpha2ContainerStats(t *testing.T) {
+	from := &v1alpha2.ContainerStats{}
+	fillFields(from)
+	to := fromV1alpha2ContainerStats(from)
+	assertEqual(t, from, to)
+}
+
+func TestFromV1alpha2ImageFsInfoResponse(t *testing.T) {
+	from := &v1alpha2.ImageFsInfoResponse{}
+	fillFields(from)
+	to := fromV1alpha2ImageFsInfoResponse(from)
+	assertEqual(t, from, to)
+}
+
+func TestFromV1alpha2ListContainerStatsResponse(t *testing.T) {
+	from := &v1alpha2.ListContainerStatsResponse{}
+	fillFields(from)
+	to := fromV1alpha2ListContainerStatsResponse(from)
+	assertEqual(t, from, to)
+}
+
+func TestFromV1alpha2PodSandboxStats(t *testing.T) {
+	from := &v1alpha2.PodSandboxStats{}
+	fillFields(from)
+	to := fromV1alpha2PodSandboxStats(from)
+	assertEqual(t, from, to)
+}
+
+func TestFromV1alpha2ListPodSandboxStatsResponse(t *testing.T) {
+	from := &v1alpha2.ListPodSandboxStatsResponse{}
+	fillFields(from)
+	to := fromV1alpha2ListPodSandboxStatsResponse(from)
+	assertEqual(t, from, to)
+}
+
+func TestFromV1alpha2Image(t *testing.T) {
+	from := &v1alpha2.Image{}
+	fillFields(from)
+	to := fromV1alpha2Image(from)
+	fmt.Printf(":%+v\n", to)
+	assertEqual(t, from, to)
+}
+
+func TestFromV1alpha2ListImagesResponse(t *testing.T) {
+	from := &v1alpha2.ListImagesResponse{}
+	fillFields(from)
+	to := fromV1alpha2ListImagesResponse(from)
+	assertEqual(t, from, to)
+}
+
+func TestV1alpha2PodSandboxConfig(t *testing.T) {
+	from := &runtimeapi.PodSandboxConfig{}
+	fillFields(from)
+	to := v1alpha2PodSandboxConfig(from)
+	assertEqual(t, from, to)
+}
+
+func TestV1alpha2PodSandboxFilter(t *testing.T) {
+	from := &runtimeapi.PodSandboxFilter{}
+	fillFields(from)
+	to := v1alpha2PodSandboxFilter(from)
+	assertEqual(t, from, to)
+}
+
+func TestV1alpha2ContainerConfig(t *testing.T) {
+	from := &runtimeapi.ContainerConfig{}
+	fillFields(from)
+	to := v1alpha2ContainerConfig(from)
+	assertEqual(t, from, to)
+}
+
+func TestV1alpha2ContainerFilter(t *testing.T) {
+	from := &runtimeapi.ContainerFilter{}
+	fillFields(from)
+	to := v1alpha2ContainerFilter(from)
+	assertEqual(t, from, to)
+}
+
+func TestV1alpha2LinuxContainerResources(t *testing.T) {
+	from := &runtimeapi.LinuxContainerResources{}
+	fillFields(from)
+	to := v1alpha2LinuxContainerResources(from)
+	assertEqual(t, from, to)
+}
+
+func TestV1alpha2ExecRequest(t *testing.T) {
+	from := &runtimeapi.ExecRequest{}
+	fillFields(from)
+	to := v1alpha2ExecRequest(from)
+	assertEqual(t, from, to)
+}
+
+func TestV1alpha2AttachRequest(t *testing.T) {
+	from := &runtimeapi.AttachRequest{}
+	fillFields(from)
+	to := v1alpha2AttachRequest(from)
+	assertEqual(t, from, to)
+}
+
+func TestV1alpha2PortForwardRequest(t *testing.T) {
+	from := &runtimeapi.PortForwardRequest{}
+	fillFields(from)
+	to := v1alpha2PortForwardRequest(from)
+	assertEqual(t, from, to)
+}
+
+func TestV1alpha2RuntimeConfig(t *testing.T) {
+	from := &runtimeapi.RuntimeConfig{}
+	fillFields(from)
+	to := v1alpha2RuntimeConfig(from)
+	assertEqual(t, from, to)
+}
+
+func TestV1alpha2ContainerStatsFilter(t *testing.T) {
+	from := &runtimeapi.ContainerStatsFilter{}
+	fillFields(from)
+	to := v1alpha2ContainerStatsFilter(from)
+	assertEqual(t, from, to)
+}
+
+func TestV1alpha2PodSandboxStatsFilter(t *testing.T) {
+	from := &runtimeapi.PodSandboxStatsFilter{}
+	fillFields(from)
+	to := v1alpha2PodSandboxStatsFilter(from)
+	assertEqual(t, from, to)
+}
+
+func TestV1alpha2ImageFilter(t *testing.T) {
+	from := &runtimeapi.ImageFilter{}
+	fillFields(from)
+	to := v1alpha2ImageFilter(from)
+	assertEqual(t, from, to)
+}
+
+func TestV1alpha2ImageSpec(t *testing.T) {
+	from := &runtimeapi.ImageSpec{}
+	fillFields(from)
+	to := v1alpha2ImageSpec(from)
+	assertEqual(t, from, to)
+}
+
+func TestV1alpha2AuthConfig(t *testing.T) {
+	from := &runtimeapi.AuthConfig{}
+	fillFields(from)
+	to := v1alpha2AuthConfig(from)
+	assertEqual(t, from, to)
+}

--- a/pkg/kubelet/cri/remote/fake/fake_image_service.go
+++ b/pkg/kubelet/cri/remote/fake/fake_image_service.go
@@ -19,7 +19,7 @@ package fake
 import (
 	"context"
 
-	kubeapi "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+	kubeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
 )
 
 // ListImages lists existing images.

--- a/pkg/kubelet/cri/remote/fake/fake_runtime.go
+++ b/pkg/kubelet/cri/remote/fake/fake_runtime.go
@@ -22,7 +22,7 @@ import (
 	"time"
 
 	"google.golang.org/grpc"
-	kubeapi "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+	kubeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
 	apitest "k8s.io/cri-api/pkg/apis/testing"
 	"k8s.io/kubernetes/pkg/kubelet/cri/remote/util"
 	utilexec "k8s.io/utils/exec"

--- a/pkg/kubelet/cri/remote/remote_image.go
+++ b/pkg/kubelet/cri/remote/remote_image.go
@@ -23,17 +23,21 @@ import (
 	"time"
 
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	"k8s.io/klog/v2"
 
 	internalapi "k8s.io/cri-api/pkg/apis"
-	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
+	runtimeapiV1alpha2 "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
 	"k8s.io/kubernetes/pkg/kubelet/cri/remote/util"
 )
 
 // remoteImageService is a gRPC implementation of internalapi.ImageManagerService.
 type remoteImageService struct {
-	timeout     time.Duration
-	imageClient runtimeapi.ImageServiceClient
+	timeout             time.Duration
+	imageClient         runtimeapi.ImageServiceClient
+	imageClientV1alpha2 runtimeapiV1alpha2.ImageServiceClient
 }
 
 // NewRemoteImageService creates a new internalapi.ImageManagerService.
@@ -53,10 +57,48 @@ func NewRemoteImageService(endpoint string, connectionTimeout time.Duration) (in
 		return nil, err
 	}
 
-	return &remoteImageService{
-		timeout:     connectionTimeout,
-		imageClient: runtimeapi.NewImageServiceClient(conn),
-	}, nil
+	service := &remoteImageService{timeout: connectionTimeout}
+
+	if err := service.determineAPIVersion(conn); err != nil {
+		return nil, err
+	}
+
+	return service, nil
+
+}
+
+// useV1API returns true if the v1 CRI API should be used instead of v1alpha2.
+func (r *remoteImageService) useV1API() bool {
+	return r.imageClientV1alpha2 == nil
+}
+
+// determineAPIVersion tries to connect to the remote image service by using the
+// highest available API version.
+//
+// A GRPC redial will always use the initially selected (or automatically
+// determined) CRI API version. If the redial was due to the container runtime
+// being upgraded, then the container runtime must also support the initially
+// selected version or the redial is expected to fail, which requires a restart
+// of kubelet.
+func (r *remoteImageService) determineAPIVersion(conn *grpc.ClientConn) error {
+	ctx, cancel := getContextWithTimeout(r.timeout)
+	defer cancel()
+
+	klog.V(4).InfoS("Finding the CRI API image version")
+	r.imageClient = runtimeapi.NewImageServiceClient(conn)
+
+	if _, err := r.imageClient.ImageFsInfo(ctx, &runtimeapi.ImageFsInfoRequest{}); err == nil {
+		klog.V(2).InfoS("Using CRI v1 image API")
+
+	} else if status.Code(err) == codes.Unimplemented {
+		klog.V(2).InfoS("Falling back to CRI v1alpha2 image API (deprecated)")
+		r.imageClientV1alpha2 = runtimeapiV1alpha2.NewImageServiceClient(conn)
+
+	} else {
+		return fmt.Errorf("unable to determine image API version: %w", err)
+	}
+
+	return nil
 }
 
 // ListImages lists available images.
@@ -64,6 +106,25 @@ func (r *remoteImageService) ListImages(filter *runtimeapi.ImageFilter) ([]*runt
 	ctx, cancel := getContextWithTimeout(r.timeout)
 	defer cancel()
 
+	if r.useV1API() {
+		return r.listImagesV1(ctx, filter)
+	}
+
+	return r.listImagesV1alpha2(ctx, filter)
+}
+
+func (r *remoteImageService) listImagesV1alpha2(ctx context.Context, filter *runtimeapi.ImageFilter) ([]*runtimeapi.Image, error) {
+	resp, err := r.imageClientV1alpha2.ListImages(ctx, &runtimeapiV1alpha2.ListImagesRequest{
+		Filter: v1alpha2ImageFilter(filter),
+	})
+	if err != nil {
+		klog.ErrorS(err, "ListImages with filter from image service failed", "filter", filter)
+		return nil, err
+	}
+	return fromV1alpha2ListImagesResponse(resp).Images, nil
+}
+
+func (r *remoteImageService) listImagesV1(ctx context.Context, filter *runtimeapi.ImageFilter) ([]*runtimeapi.Image, error) {
 	resp, err := r.imageClient.ListImages(ctx, &runtimeapi.ListImagesRequest{
 		Filter: filter,
 	})
@@ -80,6 +141,39 @@ func (r *remoteImageService) ImageStatus(image *runtimeapi.ImageSpec) (*runtimea
 	ctx, cancel := getContextWithTimeout(r.timeout)
 	defer cancel()
 
+	// TODO: for refactoring common code blocks between the cri versions into
+	// one code block in the internal where possible examples:
+	// https://github.com/kubernetes/kubernetes/pull/104575/files#r705600987
+	// https://github.com/kubernetes/kubernetes/pull/104575/files#r696793706
+	if r.useV1API() {
+		return r.imageStatusV1(ctx, image)
+	}
+
+	return r.imageStatusV1alpha2(ctx, image)
+}
+
+func (r *remoteImageService) imageStatusV1alpha2(ctx context.Context, image *runtimeapi.ImageSpec) (*runtimeapi.Image, error) {
+	resp, err := r.imageClientV1alpha2.ImageStatus(ctx, &runtimeapiV1alpha2.ImageStatusRequest{
+		Image: v1alpha2ImageSpec(image),
+	})
+	if err != nil {
+		klog.ErrorS(err, "Get ImageStatus from image service failed", "image", image.Image)
+		return nil, err
+	}
+
+	if resp.Image != nil {
+		if resp.Image.Id == "" || resp.Image.Size_ == 0 {
+			errorMessage := fmt.Sprintf("Id or size of image %q is not set", image.Image)
+			err := errors.New(errorMessage)
+			klog.ErrorS(err, "ImageStatus failed", "image", image.Image)
+			return nil, err
+		}
+	}
+
+	return fromV1alpha2Image(resp.Image), nil
+}
+
+func (r *remoteImageService) imageStatusV1(ctx context.Context, image *runtimeapi.ImageSpec) (*runtimeapi.Image, error) {
 	resp, err := r.imageClient.ImageStatus(ctx, &runtimeapi.ImageStatusRequest{
 		Image: image,
 	})
@@ -105,6 +199,34 @@ func (r *remoteImageService) PullImage(image *runtimeapi.ImageSpec, auth *runtim
 	ctx, cancel := getContextWithCancel()
 	defer cancel()
 
+	if r.useV1API() {
+		return r.pullImageV1(ctx, image, auth, podSandboxConfig)
+	}
+
+	return r.pullImageV1alpha2(ctx, image, auth, podSandboxConfig)
+}
+
+func (r *remoteImageService) pullImageV1alpha2(ctx context.Context, image *runtimeapi.ImageSpec, auth *runtimeapi.AuthConfig, podSandboxConfig *runtimeapi.PodSandboxConfig) (string, error) {
+	resp, err := r.imageClientV1alpha2.PullImage(ctx, &runtimeapiV1alpha2.PullImageRequest{
+		Image:         v1alpha2ImageSpec(image),
+		Auth:          v1alpha2AuthConfig(auth),
+		SandboxConfig: v1alpha2PodSandboxConfig(podSandboxConfig),
+	})
+	if err != nil {
+		klog.ErrorS(err, "PullImage from image service failed", "image", image.Image)
+		return "", err
+	}
+
+	if resp.ImageRef == "" {
+		klog.ErrorS(errors.New("PullImage failed"), "ImageRef of image is not set", "image", image.Image)
+		errorMessage := fmt.Sprintf("imageRef of image %q is not set", image.Image)
+		return "", errors.New(errorMessage)
+	}
+
+	return resp.ImageRef, nil
+}
+
+func (r *remoteImageService) pullImageV1(ctx context.Context, image *runtimeapi.ImageSpec, auth *runtimeapi.AuthConfig, podSandboxConfig *runtimeapi.PodSandboxConfig) (string, error) {
 	resp, err := r.imageClient.PullImage(ctx, &runtimeapi.PullImageRequest{
 		Image:         image,
 		Auth:          auth,
@@ -125,13 +247,19 @@ func (r *remoteImageService) PullImage(image *runtimeapi.ImageSpec, auth *runtim
 }
 
 // RemoveImage removes the image.
-func (r *remoteImageService) RemoveImage(image *runtimeapi.ImageSpec) error {
+func (r *remoteImageService) RemoveImage(image *runtimeapi.ImageSpec) (err error) {
 	ctx, cancel := getContextWithTimeout(r.timeout)
 	defer cancel()
 
-	_, err := r.imageClient.RemoveImage(ctx, &runtimeapi.RemoveImageRequest{
-		Image: image,
-	})
+	if r.useV1API() {
+		_, err = r.imageClient.RemoveImage(ctx, &runtimeapi.RemoveImageRequest{
+			Image: image,
+		})
+	} else {
+		_, err = r.imageClientV1alpha2.RemoveImage(ctx, &runtimeapiV1alpha2.RemoveImageRequest{
+			Image: v1alpha2ImageSpec(image),
+		})
+	}
 	if err != nil {
 		klog.ErrorS(err, "RemoveImage from image service failed", "image", image.Image)
 		return err
@@ -147,6 +275,23 @@ func (r *remoteImageService) ImageFsInfo() ([]*runtimeapi.FilesystemUsage, error
 	ctx, cancel := getContextWithCancel()
 	defer cancel()
 
+	if r.useV1API() {
+		return r.imageFsInfoV1(ctx)
+	}
+
+	return r.imageFsInfoV1alpha2(ctx)
+}
+
+func (r *remoteImageService) imageFsInfoV1alpha2(ctx context.Context) ([]*runtimeapi.FilesystemUsage, error) {
+	resp, err := r.imageClientV1alpha2.ImageFsInfo(ctx, &runtimeapiV1alpha2.ImageFsInfoRequest{})
+	if err != nil {
+		klog.ErrorS(err, "ImageFsInfo from image service failed")
+		return nil, err
+	}
+	return fromV1alpha2ImageFsInfoResponse(resp).GetImageFilesystems(), nil
+}
+
+func (r *remoteImageService) imageFsInfoV1(ctx context.Context) ([]*runtimeapi.FilesystemUsage, error) {
 	resp, err := r.imageClient.ImageFsInfo(ctx, &runtimeapi.ImageFsInfoRequest{})
 	if err != nil {
 		klog.ErrorS(err, "ImageFsInfo from image service failed")

--- a/pkg/kubelet/cri/remote/remote_runtime.go
+++ b/pkg/kubelet/cri/remote/remote_runtime.go
@@ -30,7 +30,8 @@ import (
 
 	"k8s.io/component-base/logs/logreduction"
 	internalapi "k8s.io/cri-api/pkg/apis"
-	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
+	runtimeapiV1alpha2 "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
 	"k8s.io/kubernetes/pkg/kubelet/cri/remote/util"
 	"k8s.io/kubernetes/pkg/probe/exec"
 	utilexec "k8s.io/utils/exec"
@@ -38,8 +39,9 @@ import (
 
 // remoteRuntimeService is a gRPC implementation of internalapi.RuntimeService.
 type remoteRuntimeService struct {
-	timeout       time.Duration
-	runtimeClient runtimeapi.RuntimeServiceClient
+	timeout               time.Duration
+	runtimeClient         runtimeapi.RuntimeServiceClient
+	runtimeClientV1alpha2 runtimeapiV1alpha2.RuntimeServiceClient
 	// Cache last per-container error message to reduce log spam
 	logReduction *logreduction.LogReduction
 }
@@ -47,6 +49,18 @@ type remoteRuntimeService struct {
 const (
 	// How frequently to report identical errors
 	identicalErrorDelay = 1 * time.Minute
+)
+
+// CRIVersion is the type for valid Container Runtime Interface (CRI) API
+// versions.
+type CRIVersion string
+
+const (
+	// APIVersionV1 references the v1 CRI API.
+	CRIVersionV1 CRIVersion = "v1"
+
+	// CRIVersionV1alpha2 references the v1alpha2 CRI API.
+	CRIVersionV1alpha2 CRIVersion = "v1alpha2"
 )
 
 // NewRemoteRuntimeService creates a new internalapi.RuntimeService.
@@ -65,11 +79,50 @@ func NewRemoteRuntimeService(endpoint string, connectionTimeout time.Duration) (
 		return nil, err
 	}
 
-	return &remoteRuntimeService{
-		timeout:       connectionTimeout,
-		runtimeClient: runtimeapi.NewRuntimeServiceClient(conn),
-		logReduction:  logreduction.NewLogReduction(identicalErrorDelay),
-	}, nil
+	service := &remoteRuntimeService{
+		timeout:      connectionTimeout,
+		logReduction: logreduction.NewLogReduction(identicalErrorDelay),
+	}
+
+	if err := service.determineAPIVersion(conn); err != nil {
+		return nil, err
+	}
+
+	return service, nil
+}
+
+// useV1API returns true if the v1 CRI API should be used instead of v1alpha2.
+func (r *remoteRuntimeService) useV1API() bool {
+	return r.runtimeClientV1alpha2 == nil
+}
+
+// determineAPIVersion tries to connect to the remote runtime by using the
+// highest available API version.
+//
+// A GRPC redial will always use the initially selected (or automatically
+// determined) CRI API version. If the redial was due to the container runtime
+// being upgraded, then the container runtime must also support the initially
+// selected version or the redial is expected to fail, which requires a restart
+// of kubelet.
+func (r *remoteRuntimeService) determineAPIVersion(conn *grpc.ClientConn) error {
+	ctx, cancel := getContextWithTimeout(r.timeout)
+	defer cancel()
+
+	klog.V(4).InfoS("Finding the CRI API runtime version")
+	r.runtimeClient = runtimeapi.NewRuntimeServiceClient(conn)
+
+	if _, err := r.runtimeClient.Version(ctx, &runtimeapi.VersionRequest{}); err == nil {
+		klog.V(2).InfoS("Using CRI v1 runtime API")
+
+	} else if status.Code(err) == codes.Unimplemented {
+		klog.V(2).InfoS("Falling back to CRI v1alpha2 runtime API (deprecated)")
+		r.runtimeClientV1alpha2 = runtimeapiV1alpha2.NewRuntimeServiceClient(conn)
+
+	} else {
+		return fmt.Errorf("unable to determine runtime API version: %w", err)
+	}
+
+	return nil
 }
 
 // Version returns the runtime name, runtime version and runtime API version.
@@ -79,6 +132,14 @@ func (r *remoteRuntimeService) Version(apiVersion string) (*runtimeapi.VersionRe
 	ctx, cancel := getContextWithTimeout(r.timeout)
 	defer cancel()
 
+	if r.useV1API() {
+		return r.versionV1(ctx, apiVersion)
+	}
+
+	return r.versionV1alpha2(ctx, apiVersion)
+}
+
+func (r *remoteRuntimeService) versionV1(ctx context.Context, apiVersion string) (*runtimeapi.VersionResponse, error) {
 	typedVersion, err := r.runtimeClient.Version(ctx, &runtimeapi.VersionRequest{
 		Version: apiVersion,
 	})
@@ -96,6 +157,24 @@ func (r *remoteRuntimeService) Version(apiVersion string) (*runtimeapi.VersionRe
 	return typedVersion, err
 }
 
+func (r *remoteRuntimeService) versionV1alpha2(ctx context.Context, apiVersion string) (*runtimeapi.VersionResponse, error) {
+	typedVersion, err := r.runtimeClientV1alpha2.Version(ctx, &runtimeapiV1alpha2.VersionRequest{
+		Version: apiVersion,
+	})
+	if err != nil {
+		klog.ErrorS(err, "Version from runtime service failed")
+		return nil, err
+	}
+
+	klog.V(10).InfoS("[RemoteRuntimeService] Version Response", "apiVersion", typedVersion)
+
+	if typedVersion.Version == "" || typedVersion.RuntimeName == "" || typedVersion.RuntimeApiVersion == "" || typedVersion.RuntimeVersion == "" {
+		return nil, fmt.Errorf("not all fields are set in VersionResponse (%q)", *typedVersion)
+	}
+
+	return fromV1alpha2VersionResponse(typedVersion), err
+}
+
 // RunPodSandbox creates and starts a pod-level sandbox. Runtimes should ensure
 // the sandbox is in ready state.
 func (r *remoteRuntimeService) RunPodSandbox(config *runtimeapi.PodSandboxConfig, runtimeHandler string) (string, error) {
@@ -108,38 +187,60 @@ func (r *remoteRuntimeService) RunPodSandbox(config *runtimeapi.PodSandboxConfig
 	ctx, cancel := getContextWithTimeout(timeout)
 	defer cancel()
 
-	resp, err := r.runtimeClient.RunPodSandbox(ctx, &runtimeapi.RunPodSandboxRequest{
-		Config:         config,
-		RuntimeHandler: runtimeHandler,
-	})
-	if err != nil {
-		klog.ErrorS(err, "RunPodSandbox from runtime service failed")
-		return "", err
+	var podSandboxID string
+	if r.useV1API() {
+		resp, err := r.runtimeClient.RunPodSandbox(ctx, &runtimeapi.RunPodSandboxRequest{
+			Config:         config,
+			RuntimeHandler: runtimeHandler,
+		})
+
+		if err != nil {
+			klog.ErrorS(err, "RunPodSandbox from runtime service failed")
+			return "", err
+		}
+		podSandboxID = resp.PodSandboxId
+	} else {
+		resp, err := r.runtimeClientV1alpha2.RunPodSandbox(ctx, &runtimeapiV1alpha2.RunPodSandboxRequest{
+			Config:         v1alpha2PodSandboxConfig(config),
+			RuntimeHandler: runtimeHandler,
+		})
+
+		if err != nil {
+			klog.ErrorS(err, "RunPodSandbox from runtime service failed")
+			return "", err
+		}
+		podSandboxID = resp.PodSandboxId
 	}
 
-	if resp.PodSandboxId == "" {
-		errorMessage := fmt.Sprintf("PodSandboxId is not set for sandbox %q", config.GetMetadata())
+	if podSandboxID == "" {
+		errorMessage := fmt.Sprintf("PodSandboxId is not set for sandbox %q", config.Metadata)
 		err := errors.New(errorMessage)
 		klog.ErrorS(err, "RunPodSandbox failed")
 		return "", err
 	}
 
-	klog.V(10).InfoS("[RemoteRuntimeService] RunPodSandbox Response", "podSandboxID", resp.PodSandboxId)
+	klog.V(10).InfoS("[RemoteRuntimeService] RunPodSandbox Response", "podSandboxID", podSandboxID)
 
-	return resp.PodSandboxId, nil
+	return podSandboxID, nil
 }
 
 // StopPodSandbox stops the sandbox. If there are any running containers in the
 // sandbox, they should be forced to termination.
-func (r *remoteRuntimeService) StopPodSandbox(podSandBoxID string) error {
+func (r *remoteRuntimeService) StopPodSandbox(podSandBoxID string) (err error) {
 	klog.V(10).InfoS("[RemoteRuntimeService] StopPodSandbox", "podSandboxID", podSandBoxID, "timeout", r.timeout)
 
 	ctx, cancel := getContextWithTimeout(r.timeout)
 	defer cancel()
 
-	_, err := r.runtimeClient.StopPodSandbox(ctx, &runtimeapi.StopPodSandboxRequest{
-		PodSandboxId: podSandBoxID,
-	})
+	if r.useV1API() {
+		_, err = r.runtimeClient.StopPodSandbox(ctx, &runtimeapi.StopPodSandboxRequest{
+			PodSandboxId: podSandBoxID,
+		})
+	} else {
+		_, err = r.runtimeClientV1alpha2.StopPodSandbox(ctx, &runtimeapiV1alpha2.StopPodSandboxRequest{
+			PodSandboxId: podSandBoxID,
+		})
+	}
 	if err != nil {
 		klog.ErrorS(err, "StopPodSandbox from runtime service failed", "podSandboxID", podSandBoxID)
 		return err
@@ -152,14 +253,20 @@ func (r *remoteRuntimeService) StopPodSandbox(podSandBoxID string) error {
 
 // RemovePodSandbox removes the sandbox. If there are any containers in the
 // sandbox, they should be forcibly removed.
-func (r *remoteRuntimeService) RemovePodSandbox(podSandBoxID string) error {
+func (r *remoteRuntimeService) RemovePodSandbox(podSandBoxID string) (err error) {
 	klog.V(10).InfoS("[RemoteRuntimeService] RemovePodSandbox", "podSandboxID", podSandBoxID, "timeout", r.timeout)
 	ctx, cancel := getContextWithTimeout(r.timeout)
 	defer cancel()
 
-	_, err := r.runtimeClient.RemovePodSandbox(ctx, &runtimeapi.RemovePodSandboxRequest{
-		PodSandboxId: podSandBoxID,
-	})
+	if r.useV1API() {
+		_, err = r.runtimeClient.RemovePodSandbox(ctx, &runtimeapi.RemovePodSandboxRequest{
+			PodSandboxId: podSandBoxID,
+		})
+	} else {
+		_, err = r.runtimeClientV1alpha2.RemovePodSandbox(ctx, &runtimeapiV1alpha2.RemovePodSandboxRequest{
+			PodSandboxId: podSandBoxID,
+		})
+	}
 	if err != nil {
 		klog.ErrorS(err, "RemovePodSandbox from runtime service failed", "podSandboxID", podSandBoxID)
 		return err
@@ -176,6 +283,34 @@ func (r *remoteRuntimeService) PodSandboxStatus(podSandBoxID string) (*runtimeap
 	ctx, cancel := getContextWithTimeout(r.timeout)
 	defer cancel()
 
+	if r.useV1API() {
+		return r.podSandboxStatusV1(ctx, podSandBoxID)
+	}
+
+	return r.podSandboxStatusV1alpha2(ctx, podSandBoxID)
+}
+
+func (r *remoteRuntimeService) podSandboxStatusV1alpha2(ctx context.Context, podSandBoxID string) (*runtimeapi.PodSandboxStatus, error) {
+	resp, err := r.runtimeClientV1alpha2.PodSandboxStatus(ctx, &runtimeapiV1alpha2.PodSandboxStatusRequest{
+		PodSandboxId: podSandBoxID,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	klog.V(10).InfoS("[RemoteRuntimeService] PodSandboxStatus Response", "podSandboxID", podSandBoxID, "status", resp.Status)
+
+	status := fromV1alpha2PodSandboxStatus(resp.Status)
+	if resp.Status != nil {
+		if err := verifySandboxStatus(status); err != nil {
+			return nil, err
+		}
+	}
+
+	return status, nil
+}
+
+func (r *remoteRuntimeService) podSandboxStatusV1(ctx context.Context, podSandBoxID string) (*runtimeapi.PodSandboxStatus, error) {
 	resp, err := r.runtimeClient.PodSandboxStatus(ctx, &runtimeapi.PodSandboxStatusRequest{
 		PodSandboxId: podSandBoxID,
 	})
@@ -185,13 +320,14 @@ func (r *remoteRuntimeService) PodSandboxStatus(podSandBoxID string) (*runtimeap
 
 	klog.V(10).InfoS("[RemoteRuntimeService] PodSandboxStatus Response", "podSandboxID", podSandBoxID, "status", resp.Status)
 
+	status := resp.Status
 	if resp.Status != nil {
-		if err := verifySandboxStatus(resp.Status); err != nil {
+		if err := verifySandboxStatus(status); err != nil {
 			return nil, err
 		}
 	}
 
-	return resp.Status, nil
+	return status, nil
 }
 
 // ListPodSandbox returns a list of PodSandboxes.
@@ -200,6 +336,28 @@ func (r *remoteRuntimeService) ListPodSandbox(filter *runtimeapi.PodSandboxFilte
 	ctx, cancel := getContextWithTimeout(r.timeout)
 	defer cancel()
 
+	if r.useV1API() {
+		return r.listPodSandboxV1(ctx, filter)
+	}
+
+	return r.listPodSandboxV1alpha2(ctx, filter)
+}
+
+func (r *remoteRuntimeService) listPodSandboxV1alpha2(ctx context.Context, filter *runtimeapi.PodSandboxFilter) ([]*runtimeapi.PodSandbox, error) {
+	resp, err := r.runtimeClientV1alpha2.ListPodSandbox(ctx, &runtimeapiV1alpha2.ListPodSandboxRequest{
+		Filter: v1alpha2PodSandboxFilter(filter),
+	})
+	if err != nil {
+		klog.ErrorS(err, "ListPodSandbox with filter from runtime service failed", "filter", filter)
+		return nil, err
+	}
+
+	klog.V(10).InfoS("[RemoteRuntimeService] ListPodSandbox Response", "filter", filter, "items", resp.Items)
+
+	return fromV1alpha2ListPodSandboxResponse(resp).Items, nil
+}
+
+func (r *remoteRuntimeService) listPodSandboxV1(ctx context.Context, filter *runtimeapi.PodSandboxFilter) ([]*runtimeapi.PodSandbox, error) {
 	resp, err := r.runtimeClient.ListPodSandbox(ctx, &runtimeapi.ListPodSandboxRequest{
 		Filter: filter,
 	})
@@ -219,6 +377,36 @@ func (r *remoteRuntimeService) CreateContainer(podSandBoxID string, config *runt
 	ctx, cancel := getContextWithTimeout(r.timeout)
 	defer cancel()
 
+	if r.useV1API() {
+		return r.createContainerV1(ctx, podSandBoxID, config, sandboxConfig)
+	}
+
+	return r.createContainerV1alpha2(ctx, podSandBoxID, config, sandboxConfig)
+}
+
+func (r *remoteRuntimeService) createContainerV1alpha2(ctx context.Context, podSandBoxID string, config *runtimeapi.ContainerConfig, sandboxConfig *runtimeapi.PodSandboxConfig) (string, error) {
+	resp, err := r.runtimeClientV1alpha2.CreateContainer(ctx, &runtimeapiV1alpha2.CreateContainerRequest{
+		PodSandboxId:  podSandBoxID,
+		Config:        v1alpha2ContainerConfig(config),
+		SandboxConfig: v1alpha2PodSandboxConfig(sandboxConfig),
+	})
+	if err != nil {
+		klog.ErrorS(err, "CreateContainer in sandbox from runtime service failed", "podSandboxID", podSandBoxID)
+		return "", err
+	}
+
+	klog.V(10).InfoS("[RemoteRuntimeService] CreateContainer", "podSandboxID", podSandBoxID, "containerID", resp.ContainerId)
+	if resp.ContainerId == "" {
+		errorMessage := fmt.Sprintf("ContainerId is not set for container %q", config.Metadata)
+		err := errors.New(errorMessage)
+		klog.ErrorS(err, "CreateContainer failed")
+		return "", err
+	}
+
+	return resp.ContainerId, nil
+}
+
+func (r *remoteRuntimeService) createContainerV1(ctx context.Context, podSandBoxID string, config *runtimeapi.ContainerConfig, sandboxConfig *runtimeapi.PodSandboxConfig) (string, error) {
 	resp, err := r.runtimeClient.CreateContainer(ctx, &runtimeapi.CreateContainerRequest{
 		PodSandboxId:  podSandBoxID,
 		Config:        config,
@@ -231,7 +419,7 @@ func (r *remoteRuntimeService) CreateContainer(podSandBoxID string, config *runt
 
 	klog.V(10).InfoS("[RemoteRuntimeService] CreateContainer", "podSandboxID", podSandBoxID, "containerID", resp.ContainerId)
 	if resp.ContainerId == "" {
-		errorMessage := fmt.Sprintf("ContainerId is not set for container %q", config.GetMetadata())
+		errorMessage := fmt.Sprintf("ContainerId is not set for container %q", config.Metadata)
 		err := errors.New(errorMessage)
 		klog.ErrorS(err, "CreateContainer failed")
 		return "", err
@@ -241,14 +429,21 @@ func (r *remoteRuntimeService) CreateContainer(podSandBoxID string, config *runt
 }
 
 // StartContainer starts the container.
-func (r *remoteRuntimeService) StartContainer(containerID string) error {
+func (r *remoteRuntimeService) StartContainer(containerID string) (err error) {
 	klog.V(10).InfoS("[RemoteRuntimeService] StartContainer", "containerID", containerID, "timeout", r.timeout)
 	ctx, cancel := getContextWithTimeout(r.timeout)
 	defer cancel()
 
-	_, err := r.runtimeClient.StartContainer(ctx, &runtimeapi.StartContainerRequest{
-		ContainerId: containerID,
-	})
+	if r.useV1API() {
+		_, err = r.runtimeClient.StartContainer(ctx, &runtimeapi.StartContainerRequest{
+			ContainerId: containerID,
+		})
+	} else {
+		_, err = r.runtimeClientV1alpha2.StartContainer(ctx, &runtimeapiV1alpha2.StartContainerRequest{
+			ContainerId: containerID,
+		})
+	}
+
 	if err != nil {
 		klog.ErrorS(err, "StartContainer from runtime service failed", "containerID", containerID)
 		return err
@@ -259,7 +454,7 @@ func (r *remoteRuntimeService) StartContainer(containerID string) error {
 }
 
 // StopContainer stops a running container with a grace period (i.e., timeout).
-func (r *remoteRuntimeService) StopContainer(containerID string, timeout int64) error {
+func (r *remoteRuntimeService) StopContainer(containerID string, timeout int64) (err error) {
 	klog.V(10).InfoS("[RemoteRuntimeService] StopContainer", "containerID", containerID, "timeout", timeout)
 	// Use timeout + default timeout (2 minutes) as timeout to leave extra time
 	// for SIGKILL container and request latency.
@@ -268,10 +463,18 @@ func (r *remoteRuntimeService) StopContainer(containerID string, timeout int64) 
 	defer cancel()
 
 	r.logReduction.ClearID(containerID)
-	_, err := r.runtimeClient.StopContainer(ctx, &runtimeapi.StopContainerRequest{
-		ContainerId: containerID,
-		Timeout:     timeout,
-	})
+
+	if r.useV1API() {
+		_, err = r.runtimeClient.StopContainer(ctx, &runtimeapi.StopContainerRequest{
+			ContainerId: containerID,
+			Timeout:     timeout,
+		})
+	} else {
+		_, err = r.runtimeClientV1alpha2.StopContainer(ctx, &runtimeapiV1alpha2.StopContainerRequest{
+			ContainerId: containerID,
+			Timeout:     timeout,
+		})
+	}
 	if err != nil {
 		klog.ErrorS(err, "StopContainer from runtime service failed", "containerID", containerID)
 		return err
@@ -283,15 +486,21 @@ func (r *remoteRuntimeService) StopContainer(containerID string, timeout int64) 
 
 // RemoveContainer removes the container. If the container is running, the container
 // should be forced to removal.
-func (r *remoteRuntimeService) RemoveContainer(containerID string) error {
+func (r *remoteRuntimeService) RemoveContainer(containerID string) (err error) {
 	klog.V(10).InfoS("[RemoteRuntimeService] RemoveContainer", "containerID", containerID, "timeout", r.timeout)
 	ctx, cancel := getContextWithTimeout(r.timeout)
 	defer cancel()
 
 	r.logReduction.ClearID(containerID)
-	_, err := r.runtimeClient.RemoveContainer(ctx, &runtimeapi.RemoveContainerRequest{
-		ContainerId: containerID,
-	})
+	if r.useV1API() {
+		_, err = r.runtimeClient.RemoveContainer(ctx, &runtimeapi.RemoveContainerRequest{
+			ContainerId: containerID,
+		})
+	} else {
+		_, err = r.runtimeClientV1alpha2.RemoveContainer(ctx, &runtimeapiV1alpha2.RemoveContainerRequest{
+			ContainerId: containerID,
+		})
+	}
 	if err != nil {
 		klog.ErrorS(err, "RemoveContainer from runtime service failed", "containerID", containerID)
 		return err
@@ -307,6 +516,27 @@ func (r *remoteRuntimeService) ListContainers(filter *runtimeapi.ContainerFilter
 	ctx, cancel := getContextWithTimeout(r.timeout)
 	defer cancel()
 
+	if r.useV1API() {
+		return r.listContainersV1(ctx, filter)
+	}
+
+	return r.listContainersV1alpha2(ctx, filter)
+}
+
+func (r *remoteRuntimeService) listContainersV1alpha2(ctx context.Context, filter *runtimeapi.ContainerFilter) ([]*runtimeapi.Container, error) {
+	resp, err := r.runtimeClientV1alpha2.ListContainers(ctx, &runtimeapiV1alpha2.ListContainersRequest{
+		Filter: v1alpha2ContainerFilter(filter),
+	})
+	if err != nil {
+		klog.ErrorS(err, "ListContainers with filter from runtime service failed", "filter", filter)
+		return nil, err
+	}
+	klog.V(10).InfoS("[RemoteRuntimeService] ListContainers Response", "filter", filter, "containers", resp.Containers)
+
+	return fromV1alpha2ListContainersResponse(resp).Containers, nil
+}
+
+func (r *remoteRuntimeService) listContainersV1(ctx context.Context, filter *runtimeapi.ContainerFilter) ([]*runtimeapi.Container, error) {
 	resp, err := r.runtimeClient.ListContainers(ctx, &runtimeapi.ListContainersRequest{
 		Filter: filter,
 	})
@@ -325,6 +555,39 @@ func (r *remoteRuntimeService) ContainerStatus(containerID string) (*runtimeapi.
 	ctx, cancel := getContextWithTimeout(r.timeout)
 	defer cancel()
 
+	if r.useV1API() {
+		return r.containerStatusV1(ctx, containerID)
+	}
+
+	return r.containerStatusV1alpha2(ctx, containerID)
+}
+
+func (r *remoteRuntimeService) containerStatusV1alpha2(ctx context.Context, containerID string) (*runtimeapi.ContainerStatus, error) {
+	resp, err := r.runtimeClientV1alpha2.ContainerStatus(ctx, &runtimeapiV1alpha2.ContainerStatusRequest{
+		ContainerId: containerID,
+	})
+	if err != nil {
+		// Don't spam the log with endless messages about the same failure.
+		if r.logReduction.ShouldMessageBePrinted(err.Error(), containerID) {
+			klog.ErrorS(err, "ContainerStatus from runtime service failed", "containerID", containerID)
+		}
+		return nil, err
+	}
+	r.logReduction.ClearID(containerID)
+	klog.V(10).InfoS("[RemoteRuntimeService] ContainerStatus Response", "containerID", containerID, "status", resp.Status)
+
+	status := fromV1alpha2ContainerStatus(resp.Status)
+	if resp.Status != nil {
+		if err := verifyContainerStatus(status); err != nil {
+			klog.ErrorS(err, "verify ContainerStatus failed", "containerID", containerID)
+			return nil, err
+		}
+	}
+
+	return status, nil
+}
+
+func (r *remoteRuntimeService) containerStatusV1(ctx context.Context, containerID string) (*runtimeapi.ContainerStatus, error) {
 	resp, err := r.runtimeClient.ContainerStatus(ctx, &runtimeapi.ContainerStatusRequest{
 		ContainerId: containerID,
 	})
@@ -338,26 +601,34 @@ func (r *remoteRuntimeService) ContainerStatus(containerID string) (*runtimeapi.
 	r.logReduction.ClearID(containerID)
 	klog.V(10).InfoS("[RemoteRuntimeService] ContainerStatus Response", "containerID", containerID, "status", resp.Status)
 
+	status := resp.Status
 	if resp.Status != nil {
-		if err := verifyContainerStatus(resp.Status); err != nil {
+		if err := verifyContainerStatus(status); err != nil {
 			klog.ErrorS(err, "verify ContainerStatus failed", "containerID", containerID)
 			return nil, err
 		}
 	}
 
-	return resp.Status, nil
+	return status, nil
 }
 
 // UpdateContainerResources updates a containers resource config
-func (r *remoteRuntimeService) UpdateContainerResources(containerID string, resources *runtimeapi.LinuxContainerResources) error {
+func (r *remoteRuntimeService) UpdateContainerResources(containerID string, resources *runtimeapi.LinuxContainerResources) (err error) {
 	klog.V(10).InfoS("[RemoteRuntimeService] UpdateContainerResources", "containerID", containerID, "timeout", r.timeout)
 	ctx, cancel := getContextWithTimeout(r.timeout)
 	defer cancel()
 
-	_, err := r.runtimeClient.UpdateContainerResources(ctx, &runtimeapi.UpdateContainerResourcesRequest{
-		ContainerId: containerID,
-		Linux:       resources,
-	})
+	if r.useV1API() {
+		_, err = r.runtimeClient.UpdateContainerResources(ctx, &runtimeapi.UpdateContainerResourcesRequest{
+			ContainerId: containerID,
+			Linux:       resources,
+		})
+	} else {
+		_, err = r.runtimeClientV1alpha2.UpdateContainerResources(ctx, &runtimeapiV1alpha2.UpdateContainerResourcesRequest{
+			ContainerId: containerID,
+			Linux:       v1alpha2LinuxContainerResources(resources),
+		})
+	}
 	if err != nil {
 		klog.ErrorS(err, "UpdateContainerResources from runtime service failed", "containerID", containerID)
 		return err
@@ -383,6 +654,45 @@ func (r *remoteRuntimeService) ExecSync(containerID string, cmd []string, timeou
 	}
 	defer cancel()
 
+	if r.useV1API() {
+		return r.execSyncV1(ctx, containerID, cmd, timeout)
+	}
+
+	return r.execSyncV1alpha2(ctx, containerID, cmd, timeout)
+}
+
+func (r *remoteRuntimeService) execSyncV1alpha2(ctx context.Context, containerID string, cmd []string, timeout time.Duration) (stdout []byte, stderr []byte, err error) {
+	timeoutSeconds := int64(timeout.Seconds())
+	req := &runtimeapiV1alpha2.ExecSyncRequest{
+		ContainerId: containerID,
+		Cmd:         cmd,
+		Timeout:     timeoutSeconds,
+	}
+	resp, err := r.runtimeClientV1alpha2.ExecSync(ctx, req)
+	if err != nil {
+		klog.ErrorS(err, "ExecSync cmd from runtime service failed", "containerID", containerID, "cmd", cmd)
+
+		// interpret DeadlineExceeded gRPC errors as timedout probes
+		if status.Code(err) == codes.DeadlineExceeded {
+			err = exec.NewTimeoutError(fmt.Errorf("command %q timed out", strings.Join(cmd, " ")), timeout)
+		}
+
+		return nil, nil, err
+	}
+
+	klog.V(10).InfoS("[RemoteRuntimeService] ExecSync Response", "containerID", containerID, "exitCode", resp.ExitCode)
+	err = nil
+	if resp.ExitCode != 0 {
+		err = utilexec.CodeExitError{
+			Err:  fmt.Errorf("command '%s' exited with %d: %s", strings.Join(cmd, " "), resp.ExitCode, resp.Stderr),
+			Code: int(resp.ExitCode),
+		}
+	}
+
+	return resp.Stdout, resp.Stderr, err
+}
+
+func (r *remoteRuntimeService) execSyncV1(ctx context.Context, containerID string, cmd []string, timeout time.Duration) (stdout []byte, stderr []byte, err error) {
 	timeoutSeconds := int64(timeout.Seconds())
 	req := &runtimeapi.ExecSyncRequest{
 		ContainerId: containerID,
@@ -419,6 +729,32 @@ func (r *remoteRuntimeService) Exec(req *runtimeapi.ExecRequest) (*runtimeapi.Ex
 	ctx, cancel := getContextWithTimeout(r.timeout)
 	defer cancel()
 
+	if r.useV1API() {
+		return r.execV1(ctx, req)
+	}
+
+	return r.execV1alpha2(ctx, req)
+}
+
+func (r *remoteRuntimeService) execV1alpha2(ctx context.Context, req *runtimeapi.ExecRequest) (*runtimeapi.ExecResponse, error) {
+	resp, err := r.runtimeClientV1alpha2.Exec(ctx, v1alpha2ExecRequest(req))
+	if err != nil {
+		klog.ErrorS(err, "Exec cmd from runtime service failed", "containerID", req.ContainerId, "cmd", req.Cmd)
+		return nil, err
+	}
+	klog.V(10).InfoS("[RemoteRuntimeService] Exec Response")
+
+	if resp.Url == "" {
+		errorMessage := "URL is not set"
+		err := errors.New(errorMessage)
+		klog.ErrorS(err, "Exec failed")
+		return nil, err
+	}
+
+	return fromV1alpha2ExecResponse(resp), nil
+}
+
+func (r *remoteRuntimeService) execV1(ctx context.Context, req *runtimeapi.ExecRequest) (*runtimeapi.ExecResponse, error) {
 	resp, err := r.runtimeClient.Exec(ctx, req)
 	if err != nil {
 		klog.ErrorS(err, "Exec cmd from runtime service failed", "containerID", req.ContainerId, "cmd", req.Cmd)
@@ -442,6 +778,31 @@ func (r *remoteRuntimeService) Attach(req *runtimeapi.AttachRequest) (*runtimeap
 	ctx, cancel := getContextWithTimeout(r.timeout)
 	defer cancel()
 
+	if r.useV1API() {
+		return r.attachV1(ctx, req)
+	}
+
+	return r.attachV1alpha2(ctx, req)
+}
+
+func (r *remoteRuntimeService) attachV1alpha2(ctx context.Context, req *runtimeapi.AttachRequest) (*runtimeapi.AttachResponse, error) {
+	resp, err := r.runtimeClientV1alpha2.Attach(ctx, v1alpha2AttachRequest(req))
+	if err != nil {
+		klog.ErrorS(err, "Attach container from runtime service failed", "containerID", req.ContainerId)
+		return nil, err
+	}
+	klog.V(10).InfoS("[RemoteRuntimeService] Attach Response", "containerID", req.ContainerId)
+
+	if resp.Url == "" {
+		errorMessage := "URL is not set"
+		err := errors.New(errorMessage)
+		klog.ErrorS(err, "Attach failed")
+		return nil, err
+	}
+	return fromV1alpha2AttachResponse(resp), nil
+}
+
+func (r *remoteRuntimeService) attachV1(ctx context.Context, req *runtimeapi.AttachRequest) (*runtimeapi.AttachResponse, error) {
 	resp, err := r.runtimeClient.Attach(ctx, req)
 	if err != nil {
 		klog.ErrorS(err, "Attach container from runtime service failed", "containerID", req.ContainerId)
@@ -464,6 +825,32 @@ func (r *remoteRuntimeService) PortForward(req *runtimeapi.PortForwardRequest) (
 	ctx, cancel := getContextWithTimeout(r.timeout)
 	defer cancel()
 
+	if r.useV1API() {
+		return r.portForwardV1(ctx, req)
+	}
+
+	return r.portForwardV1alpha2(ctx, req)
+}
+
+func (r *remoteRuntimeService) portForwardV1alpha2(ctx context.Context, req *runtimeapi.PortForwardRequest) (*runtimeapi.PortForwardResponse, error) {
+	resp, err := r.runtimeClientV1alpha2.PortForward(ctx, v1alpha2PortForwardRequest(req))
+	if err != nil {
+		klog.ErrorS(err, "PortForward from runtime service failed", "podSandboxID", req.PodSandboxId)
+		return nil, err
+	}
+	klog.V(10).InfoS("[RemoteRuntimeService] PortForward Response", "podSandboxID", req.PodSandboxId)
+
+	if resp.Url == "" {
+		errorMessage := "URL is not set"
+		err := errors.New(errorMessage)
+		klog.ErrorS(err, "PortForward failed")
+		return nil, err
+	}
+
+	return fromV1alpha2PortForwardResponse(resp), nil
+}
+
+func (r *remoteRuntimeService) portForwardV1(ctx context.Context, req *runtimeapi.PortForwardRequest) (*runtimeapi.PortForwardResponse, error) {
 	resp, err := r.runtimeClient.PortForward(ctx, req)
 	if err != nil {
 		klog.ErrorS(err, "PortForward from runtime service failed", "podSandboxID", req.PodSandboxId)
@@ -484,7 +871,7 @@ func (r *remoteRuntimeService) PortForward(req *runtimeapi.PortForwardRequest) (
 // UpdateRuntimeConfig updates the config of a runtime service. The only
 // update payload currently supported is the pod CIDR assigned to a node,
 // and the runtime service just proxies it down to the network plugin.
-func (r *remoteRuntimeService) UpdateRuntimeConfig(runtimeConfig *runtimeapi.RuntimeConfig) error {
+func (r *remoteRuntimeService) UpdateRuntimeConfig(runtimeConfig *runtimeapi.RuntimeConfig) (err error) {
 	klog.V(10).InfoS("[RemoteRuntimeService] UpdateRuntimeConfig", "runtimeConfig", runtimeConfig, "timeout", r.timeout)
 	ctx, cancel := getContextWithTimeout(r.timeout)
 	defer cancel()
@@ -492,9 +879,15 @@ func (r *remoteRuntimeService) UpdateRuntimeConfig(runtimeConfig *runtimeapi.Run
 	// Response doesn't contain anything of interest. This translates to an
 	// Event notification to the network plugin, which can't fail, so we're
 	// really looking to surface destination unreachable.
-	_, err := r.runtimeClient.UpdateRuntimeConfig(ctx, &runtimeapi.UpdateRuntimeConfigRequest{
-		RuntimeConfig: runtimeConfig,
-	})
+	if r.useV1API() {
+		_, err = r.runtimeClient.UpdateRuntimeConfig(ctx, &runtimeapi.UpdateRuntimeConfigRequest{
+			RuntimeConfig: runtimeConfig,
+		})
+	} else {
+		_, err = r.runtimeClientV1alpha2.UpdateRuntimeConfig(ctx, &runtimeapiV1alpha2.UpdateRuntimeConfigRequest{
+			RuntimeConfig: v1alpha2RuntimeConfig(runtimeConfig),
+		})
+	}
 
 	if err != nil {
 		return err
@@ -510,6 +903,33 @@ func (r *remoteRuntimeService) Status() (*runtimeapi.RuntimeStatus, error) {
 	ctx, cancel := getContextWithTimeout(r.timeout)
 	defer cancel()
 
+	if r.useV1API() {
+		return r.statusV1(ctx)
+	}
+
+	return r.statusV1alpha2(ctx)
+}
+
+func (r *remoteRuntimeService) statusV1alpha2(ctx context.Context) (*runtimeapi.RuntimeStatus, error) {
+	resp, err := r.runtimeClientV1alpha2.Status(ctx, &runtimeapiV1alpha2.StatusRequest{})
+	if err != nil {
+		klog.ErrorS(err, "Status from runtime service failed")
+		return nil, err
+	}
+
+	klog.V(10).InfoS("[RemoteRuntimeService] Status Response", "status", resp.Status)
+
+	if resp.Status == nil || len(resp.Status.Conditions) < 2 {
+		errorMessage := "RuntimeReady or NetworkReady condition are not set"
+		err := errors.New(errorMessage)
+		klog.ErrorS(err, "Status failed")
+		return nil, err
+	}
+
+	return fromV1alpha2RuntimeStatus(resp.Status), nil
+}
+
+func (r *remoteRuntimeService) statusV1(ctx context.Context) (*runtimeapi.RuntimeStatus, error) {
 	resp, err := r.runtimeClient.Status(ctx, &runtimeapi.StatusRequest{})
 	if err != nil {
 		klog.ErrorS(err, "Status from runtime service failed")
@@ -534,6 +954,30 @@ func (r *remoteRuntimeService) ContainerStats(containerID string) (*runtimeapi.C
 	ctx, cancel := getContextWithTimeout(r.timeout)
 	defer cancel()
 
+	if r.useV1API() {
+		return r.containerStatsV1(ctx, containerID)
+	}
+
+	return r.containerStatsV1alpha2(ctx, containerID)
+}
+
+func (r *remoteRuntimeService) containerStatsV1alpha2(ctx context.Context, containerID string) (*runtimeapi.ContainerStats, error) {
+	resp, err := r.runtimeClientV1alpha2.ContainerStats(ctx, &runtimeapiV1alpha2.ContainerStatsRequest{
+		ContainerId: containerID,
+	})
+	if err != nil {
+		if r.logReduction.ShouldMessageBePrinted(err.Error(), containerID) {
+			klog.ErrorS(err, "ContainerStats from runtime service failed", "containerID", containerID)
+		}
+		return nil, err
+	}
+	r.logReduction.ClearID(containerID)
+	klog.V(10).InfoS("[RemoteRuntimeService] ContainerStats Response", "containerID", containerID, "stats", resp.GetStats())
+
+	return fromV1alpha2ContainerStats(resp.GetStats()), nil
+}
+
+func (r *remoteRuntimeService) containerStatsV1(ctx context.Context, containerID string) (*runtimeapi.ContainerStats, error) {
 	resp, err := r.runtimeClient.ContainerStats(ctx, &runtimeapi.ContainerStatsRequest{
 		ContainerId: containerID,
 	})
@@ -557,6 +1001,27 @@ func (r *remoteRuntimeService) ListContainerStats(filter *runtimeapi.ContainerSt
 	ctx, cancel := getContextWithCancel()
 	defer cancel()
 
+	if r.useV1API() {
+		return r.listContainerStatsV1(ctx, filter)
+	}
+
+	return r.listContainerStatsV1alpha2(ctx, filter)
+}
+
+func (r *remoteRuntimeService) listContainerStatsV1alpha2(ctx context.Context, filter *runtimeapi.ContainerStatsFilter) ([]*runtimeapi.ContainerStats, error) {
+	resp, err := r.runtimeClientV1alpha2.ListContainerStats(ctx, &runtimeapiV1alpha2.ListContainerStatsRequest{
+		Filter: v1alpha2ContainerStatsFilter(filter),
+	})
+	if err != nil {
+		klog.ErrorS(err, "ListContainerStats with filter from runtime service failed", "filter", filter)
+		return nil, err
+	}
+	klog.V(10).InfoS("[RemoteRuntimeService] ListContainerStats Response", "filter", filter, "stats", resp.GetStats())
+
+	return fromV1alpha2ListContainerStatsResponse(resp).GetStats(), nil
+}
+
+func (r *remoteRuntimeService) listContainerStatsV1(ctx context.Context, filter *runtimeapi.ContainerStatsFilter) ([]*runtimeapi.ContainerStats, error) {
 	resp, err := r.runtimeClient.ListContainerStats(ctx, &runtimeapi.ListContainerStatsRequest{
 		Filter: filter,
 	})
@@ -575,6 +1040,30 @@ func (r *remoteRuntimeService) PodSandboxStats(podSandboxID string) (*runtimeapi
 	ctx, cancel := getContextWithTimeout(r.timeout)
 	defer cancel()
 
+	if r.useV1API() {
+		return r.podSandboxStatsV1(ctx, podSandboxID)
+	}
+
+	return r.podSandboxStatsV1alpha2(ctx, podSandboxID)
+}
+
+func (r *remoteRuntimeService) podSandboxStatsV1alpha2(ctx context.Context, podSandboxID string) (*runtimeapi.PodSandboxStats, error) {
+	resp, err := r.runtimeClientV1alpha2.PodSandboxStats(ctx, &runtimeapiV1alpha2.PodSandboxStatsRequest{
+		PodSandboxId: podSandboxID,
+	})
+	if err != nil {
+		if r.logReduction.ShouldMessageBePrinted(err.Error(), podSandboxID) {
+			klog.ErrorS(err, "PodSandbox from runtime service failed", "podSandboxID", podSandboxID)
+		}
+		return nil, err
+	}
+	r.logReduction.ClearID(podSandboxID)
+	klog.V(10).InfoS("[RemoteRuntimeService] PodSandbox Response", "podSandboxID", podSandboxID, "stats", resp.GetStats())
+
+	return fromV1alpha2PodSandboxStats(resp.GetStats()), nil
+}
+
+func (r *remoteRuntimeService) podSandboxStatsV1(ctx context.Context, podSandboxID string) (*runtimeapi.PodSandboxStats, error) {
 	resp, err := r.runtimeClient.PodSandboxStats(ctx, &runtimeapi.PodSandboxStatsRequest{
 		PodSandboxId: podSandboxID,
 	})
@@ -597,6 +1086,27 @@ func (r *remoteRuntimeService) ListPodSandboxStats(filter *runtimeapi.PodSandbox
 	ctx, cancel := getContextWithTimeout(r.timeout)
 	defer cancel()
 
+	if r.useV1API() {
+		return r.listPodSandboxStatsV1(ctx, filter)
+	}
+
+	return r.listPodSandboxStatsV1alpha2(ctx, filter)
+}
+
+func (r *remoteRuntimeService) listPodSandboxStatsV1alpha2(ctx context.Context, filter *runtimeapi.PodSandboxStatsFilter) ([]*runtimeapi.PodSandboxStats, error) {
+	resp, err := r.runtimeClientV1alpha2.ListPodSandboxStats(ctx, &runtimeapiV1alpha2.ListPodSandboxStatsRequest{
+		Filter: v1alpha2PodSandboxStatsFilter(filter),
+	})
+	if err != nil {
+		klog.ErrorS(err, "ListPodSandboxStats with filter from runtime service failed", "filter", filter)
+		return nil, err
+	}
+	klog.V(10).InfoS("[RemoteRuntimeService] ListPodSandboxStats Response", "filter", filter, "stats", resp.GetStats())
+
+	return fromV1alpha2ListPodSandboxStatsResponse(resp).GetStats(), nil
+}
+
+func (r *remoteRuntimeService) listPodSandboxStatsV1(ctx context.Context, filter *runtimeapi.PodSandboxStatsFilter) ([]*runtimeapi.PodSandboxStats, error) {
 	resp, err := r.runtimeClient.ListPodSandboxStats(ctx, &runtimeapi.ListPodSandboxStatsRequest{
 		Filter: filter,
 	})
@@ -610,12 +1120,16 @@ func (r *remoteRuntimeService) ListPodSandboxStats(filter *runtimeapi.PodSandbox
 }
 
 // ReopenContainerLog reopens the container log file.
-func (r *remoteRuntimeService) ReopenContainerLog(containerID string) error {
+func (r *remoteRuntimeService) ReopenContainerLog(containerID string) (err error) {
 	klog.V(10).InfoS("[RemoteRuntimeService] ReopenContainerLog", "containerID", containerID, "timeout", r.timeout)
 	ctx, cancel := getContextWithTimeout(r.timeout)
 	defer cancel()
 
-	_, err := r.runtimeClient.ReopenContainerLog(ctx, &runtimeapi.ReopenContainerLogRequest{ContainerId: containerID})
+	if r.useV1API() {
+		_, err = r.runtimeClient.ReopenContainerLog(ctx, &runtimeapi.ReopenContainerLogRequest{ContainerId: containerID})
+	} else {
+		_, err = r.runtimeClientV1alpha2.ReopenContainerLog(ctx, &runtimeapiV1alpha2.ReopenContainerLogRequest{ContainerId: containerID})
+	}
 	if err != nil {
 		klog.ErrorS(err, "ReopenContainerLog from runtime service failed", "containerID", containerID)
 		return err

--- a/pkg/kubelet/cri/remote/utils.go
+++ b/pkg/kubelet/cri/remote/utils.go
@@ -21,7 +21,7 @@ import (
 	"fmt"
 	"time"
 
-	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
 )
 
 // maxMsgSize use 16MB as the default message size limit.

--- a/pkg/kubelet/cri/remote/utils_test.go
+++ b/pkg/kubelet/cri/remote/utils_test.go
@@ -19,7 +19,7 @@ package remote
 import (
 	"fmt"
 	"github.com/stretchr/testify/assert"
-	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
 	"testing"
 )
 

--- a/pkg/kubelet/cri/streaming/server.go
+++ b/pkg/kubelet/cri/streaming/server.go
@@ -34,7 +34,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	remotecommandconsts "k8s.io/apimachinery/pkg/util/remotecommand"
 	"k8s.io/client-go/tools/remotecommand"
-	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
 	"k8s.io/kubernetes/pkg/kubelet/cri/streaming/portforward"
 	remotecommandserver "k8s.io/kubernetes/pkg/kubelet/cri/streaming/remotecommand"
 )

--- a/pkg/kubelet/cri/streaming/server_test.go
+++ b/pkg/kubelet/cri/streaming/server_test.go
@@ -34,7 +34,7 @@ import (
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/remotecommand"
 	"k8s.io/client-go/transport/spdy"
-	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
 	kubeletportforward "k8s.io/kubernetes/pkg/kubelet/cri/streaming/portforward"
 )
 

--- a/pkg/kubelet/dockershim/convert.go
+++ b/pkg/kubelet/dockershim/convert.go
@@ -26,7 +26,7 @@ import (
 
 	dockertypes "github.com/docker/docker/api/types"
 
-	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
 	"k8s.io/kubernetes/pkg/kubelet/dockershim/libdocker"
 )
 

--- a/pkg/kubelet/dockershim/convert_test.go
+++ b/pkg/kubelet/dockershim/convert_test.go
@@ -25,7 +25,7 @@ import (
 	dockertypes "github.com/docker/docker/api/types"
 	"github.com/stretchr/testify/assert"
 
-	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
 )
 
 func TestConvertDockerStatusToRuntimeAPIState(t *testing.T) {

--- a/pkg/kubelet/dockershim/doc.go
+++ b/pkg/kubelet/dockershim/doc.go
@@ -18,5 +18,5 @@ limitations under the License.
 */
 
 // Package dockershim implements a container runtime interface
-// Docker integration using k8s.io/cri-api/pkg/apis/runtime/v1alpha2/api.pb.go
+// Docker integration using k8s.io/cri-api/pkg/apis/runtime/v1/api.pb.go
 package dockershim

--- a/pkg/kubelet/dockershim/docker_container.go
+++ b/pkg/kubelet/dockershim/docker_container.go
@@ -32,7 +32,7 @@ import (
 	dockerstrslice "github.com/docker/docker/api/types/strslice"
 	"k8s.io/klog/v2"
 
-	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
 	"k8s.io/kubernetes/pkg/kubelet/dockershim/libdocker"
 )
 

--- a/pkg/kubelet/dockershim/docker_container_test.go
+++ b/pkg/kubelet/dockershim/docker_container_test.go
@@ -32,7 +32,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
 	containertest "k8s.io/kubernetes/pkg/kubelet/container/testing"
 )
 

--- a/pkg/kubelet/dockershim/docker_container_unsupported.go
+++ b/pkg/kubelet/dockershim/docker_container_unsupported.go
@@ -21,7 +21,7 @@ package dockershim
 
 import (
 	dockertypes "github.com/docker/docker/api/types"
-	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
 )
 
 type containerCleanupInfo struct{}

--- a/pkg/kubelet/dockershim/docker_container_windows.go
+++ b/pkg/kubelet/dockershim/docker_container_windows.go
@@ -30,7 +30,7 @@ import (
 	dockertypes "github.com/docker/docker/api/types"
 	dockercontainer "github.com/docker/docker/api/types/container"
 
-	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
 )
 
 type containerCleanupInfo struct {

--- a/pkg/kubelet/dockershim/docker_container_windows_test.go
+++ b/pkg/kubelet/dockershim/docker_container_windows_test.go
@@ -29,7 +29,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/sys/windows/registry"
-	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
 )
 
 type dummyRegistryKey struct {

--- a/pkg/kubelet/dockershim/docker_image.go
+++ b/pkg/kubelet/dockershim/docker_image.go
@@ -28,7 +28,7 @@ import (
 	dockerfilters "github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/pkg/jsonmessage"
 
-	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
 	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/pkg/kubelet/dockershim/libdocker"
 )

--- a/pkg/kubelet/dockershim/docker_image_linux.go
+++ b/pkg/kubelet/dockershim/docker_image_linux.go
@@ -25,7 +25,7 @@ import (
 	"path/filepath"
 	"time"
 
-	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
 )
 
 // ImageFsInfo returns information of the filesystem that is used to store images.

--- a/pkg/kubelet/dockershim/docker_image_test.go
+++ b/pkg/kubelet/dockershim/docker_image_test.go
@@ -28,7 +28,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
 	"k8s.io/kubernetes/pkg/kubelet/dockershim/libdocker"
 )
 

--- a/pkg/kubelet/dockershim/docker_image_unsupported.go
+++ b/pkg/kubelet/dockershim/docker_image_unsupported.go
@@ -23,7 +23,7 @@ import (
 	"context"
 	"fmt"
 
-	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
 )
 
 // ImageFsInfo returns information of the filesystem that is used to store images.

--- a/pkg/kubelet/dockershim/docker_image_windows.go
+++ b/pkg/kubelet/dockershim/docker_image_windows.go
@@ -25,7 +25,7 @@ import (
 
 	"k8s.io/klog/v2"
 
-	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
 	"k8s.io/kubernetes/pkg/kubelet/winstats"
 )
 

--- a/pkg/kubelet/dockershim/docker_logs.go
+++ b/pkg/kubelet/dockershim/docker_logs.go
@@ -23,7 +23,7 @@ import (
 	"context"
 	"fmt"
 
-	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
 )
 
 // ReopenContainerLog reopens the container log file.

--- a/pkg/kubelet/dockershim/docker_sandbox.go
+++ b/pkg/kubelet/dockershim/docker_sandbox.go
@@ -31,7 +31,7 @@ import (
 	dockercontainer "github.com/docker/docker/api/types/container"
 	dockerfilters "github.com/docker/docker/api/types/filters"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
-	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
 	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/pkg/kubelet/checkpointmanager"
 	"k8s.io/kubernetes/pkg/kubelet/checkpointmanager/errors"

--- a/pkg/kubelet/dockershim/docker_sandbox_test.go
+++ b/pkg/kubelet/dockershim/docker_sandbox_test.go
@@ -31,7 +31,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
 	"k8s.io/kubernetes/pkg/kubelet/dockershim/libdocker"
 	"k8s.io/kubernetes/pkg/kubelet/dockershim/network"

--- a/pkg/kubelet/dockershim/docker_service.go
+++ b/pkg/kubelet/dockershim/docker_service.go
@@ -35,7 +35,7 @@ import (
 	"k8s.io/klog/v2"
 
 	v1 "k8s.io/api/core/v1"
-	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
 	kubeletconfig "k8s.io/kubernetes/pkg/kubelet/apis/config"
 	"k8s.io/kubernetes/pkg/kubelet/checkpointmanager"
 	"k8s.io/kubernetes/pkg/kubelet/checkpointmanager/errors"

--- a/pkg/kubelet/dockershim/docker_service_test.go
+++ b/pkg/kubelet/dockershim/docker_service_test.go
@@ -30,7 +30,7 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
 	"k8s.io/kubernetes/pkg/kubelet/checkpointmanager"
 	containertest "k8s.io/kubernetes/pkg/kubelet/container/testing"
 	"k8s.io/kubernetes/pkg/kubelet/dockershim/libdocker"

--- a/pkg/kubelet/dockershim/docker_stats.go
+++ b/pkg/kubelet/dockershim/docker_stats.go
@@ -24,7 +24,7 @@ import (
 	"errors"
 	"fmt"
 
-	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
 )
 
 var ErrNotImplemented = errors.New("Not implemented")

--- a/pkg/kubelet/dockershim/docker_stats_linux.go
+++ b/pkg/kubelet/dockershim/docker_stats_linux.go
@@ -22,7 +22,7 @@ package dockershim
 import (
 	"time"
 
-	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
 )
 
 func (ds *dockerService) getContainerStats(c *runtimeapi.Container) (*runtimeapi.ContainerStats, error) {

--- a/pkg/kubelet/dockershim/docker_stats_test.go
+++ b/pkg/kubelet/dockershim/docker_stats_test.go
@@ -25,7 +25,7 @@ import (
 	dockertypes "github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
 	"github.com/stretchr/testify/assert"
-	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
 	"k8s.io/kubernetes/pkg/kubelet/dockershim/libdocker"
 )
 

--- a/pkg/kubelet/dockershim/docker_stats_unsupported.go
+++ b/pkg/kubelet/dockershim/docker_stats_unsupported.go
@@ -22,7 +22,7 @@ package dockershim
 import (
 	"fmt"
 
-	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
 )
 
 func (ds *dockerService) getContainerStats(c *runtimeapi.Container) (*runtimeapi.ContainerStats, error) {

--- a/pkg/kubelet/dockershim/docker_stats_windows.go
+++ b/pkg/kubelet/dockershim/docker_stats_windows.go
@@ -24,7 +24,7 @@ import (
 	"time"
 
 	"github.com/Microsoft/hcsshim"
-	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
 	"k8s.io/klog/v2"
 )
 

--- a/pkg/kubelet/dockershim/docker_streaming.go
+++ b/pkg/kubelet/dockershim/docker_streaming.go
@@ -33,7 +33,7 @@ import (
 	"google.golang.org/grpc/status"
 
 	"k8s.io/client-go/tools/remotecommand"
-	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
 	"k8s.io/kubernetes/pkg/kubelet/cri/streaming"
 	"k8s.io/kubernetes/pkg/kubelet/dockershim/libdocker"

--- a/pkg/kubelet/dockershim/helpers.go
+++ b/pkg/kubelet/dockershim/helpers.go
@@ -36,7 +36,7 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
-	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
 	"k8s.io/kubernetes/pkg/credentialprovider"
 	"k8s.io/kubernetes/pkg/kubelet/dockershim/libdocker"
 	"k8s.io/kubernetes/pkg/kubelet/types"

--- a/pkg/kubelet/dockershim/helpers_linux.go
+++ b/pkg/kubelet/dockershim/helpers_linux.go
@@ -32,7 +32,7 @@ import (
 	dockertypes "github.com/docker/docker/api/types"
 	dockercontainer "github.com/docker/docker/api/types/container"
 	v1 "k8s.io/api/core/v1"
-	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
 )
 
 // DefaultMemorySwap always returns 0 for no memory swap in a sandbox

--- a/pkg/kubelet/dockershim/helpers_test.go
+++ b/pkg/kubelet/dockershim/helpers_test.go
@@ -32,7 +32,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"k8s.io/api/core/v1"
-	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
 	"k8s.io/kubernetes/pkg/kubelet/dockershim/libdocker"
 )
 

--- a/pkg/kubelet/dockershim/helpers_unsupported.go
+++ b/pkg/kubelet/dockershim/helpers_unsupported.go
@@ -24,7 +24,7 @@ import (
 
 	"github.com/blang/semver"
 	dockertypes "github.com/docker/docker/api/types"
-	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
 	"k8s.io/klog/v2"
 )
 

--- a/pkg/kubelet/dockershim/helpers_windows.go
+++ b/pkg/kubelet/dockershim/helpers_windows.go
@@ -29,7 +29,7 @@ import (
 	dockerfilters "github.com/docker/docker/api/types/filters"
 	"k8s.io/klog/v2"
 
-	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
 )
 
 // DefaultMemorySwap always returns 0 for no memory swap in a sandbox

--- a/pkg/kubelet/dockershim/naming.go
+++ b/pkg/kubelet/dockershim/naming.go
@@ -25,7 +25,7 @@ import (
 	"strconv"
 	"strings"
 
-	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
 	"k8s.io/kubernetes/pkg/kubelet/leaky"
 )
 

--- a/pkg/kubelet/dockershim/naming_test.go
+++ b/pkg/kubelet/dockershim/naming_test.go
@@ -24,7 +24,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
 )
 
 func TestSandboxNameRoundTrip(t *testing.T) {

--- a/pkg/kubelet/dockershim/network/cni/cni.go
+++ b/pkg/kubelet/dockershim/network/cni/cni.go
@@ -32,7 +32,7 @@ import (
 	"github.com/containernetworking/cni/libcni"
 	cnitypes "github.com/containernetworking/cni/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
-	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
 	"k8s.io/klog/v2"
 	kubeletconfig "k8s.io/kubernetes/pkg/kubelet/apis/config"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"

--- a/pkg/kubelet/dockershim/network/cni/cni_others.go
+++ b/pkg/kubelet/dockershim/network/cni/cni_others.go
@@ -23,7 +23,7 @@ import (
 	"fmt"
 
 	"github.com/containernetworking/cni/libcni"
-	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
 	"k8s.io/kubernetes/pkg/kubelet/dockershim/network"
 )

--- a/pkg/kubelet/dockershim/network/cni/cni_windows.go
+++ b/pkg/kubelet/dockershim/network/cni/cni_windows.go
@@ -23,7 +23,7 @@ import (
 	"context"
 	"fmt"
 	cniTypes020 "github.com/containernetworking/cni/pkg/types/020"
-	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
 	"k8s.io/klog/v2"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
 	"k8s.io/kubernetes/pkg/kubelet/dockershim/network"

--- a/pkg/kubelet/dockershim/remote/docker_server.go
+++ b/pkg/kubelet/dockershim/remote/docker_server.go
@@ -24,7 +24,7 @@ import (
 	"os"
 
 	"google.golang.org/grpc"
-	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
 	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/pkg/kubelet/dockershim"
 	"k8s.io/kubernetes/pkg/kubelet/util"

--- a/pkg/kubelet/dockershim/security_context.go
+++ b/pkg/kubelet/dockershim/security_context.go
@@ -25,7 +25,7 @@ import (
 
 	dockercontainer "github.com/docker/docker/api/types/container"
 
-	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
 	knetwork "k8s.io/kubernetes/pkg/kubelet/dockershim/network"
 )
 

--- a/pkg/kubelet/dockershim/security_context_test.go
+++ b/pkg/kubelet/dockershim/security_context_test.go
@@ -27,7 +27,7 @@ import (
 	dockercontainer "github.com/docker/docker/api/types/container"
 	"github.com/stretchr/testify/assert"
 
-	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
 )
 
 func TestModifyContainerConfig(t *testing.T) {

--- a/pkg/kubelet/dockershim/selinux_util.go
+++ b/pkg/kubelet/dockershim/selinux_util.go
@@ -22,7 +22,7 @@ package dockershim
 import (
 	"fmt"
 
-	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
 )
 
 // selinuxLabelUser returns the fragment of a Docker security opt that

--- a/pkg/kubelet/images/helpers.go
+++ b/pkg/kubelet/images/helpers.go
@@ -21,7 +21,7 @@ import (
 
 	"k8s.io/api/core/v1"
 	"k8s.io/client-go/util/flowcontrol"
-	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
 )
 

--- a/pkg/kubelet/images/image_manager.go
+++ b/pkg/kubelet/images/image_manager.go
@@ -26,7 +26,7 @@ import (
 	"k8s.io/client-go/util/flowcontrol"
 	"k8s.io/klog/v2"
 
-	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
 	"k8s.io/kubernetes/pkg/kubelet/events"
 )

--- a/pkg/kubelet/images/puller.go
+++ b/pkg/kubelet/images/puller.go
@@ -21,7 +21,7 @@ import (
 
 	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
-	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
 )
 

--- a/pkg/kubelet/images/types.go
+++ b/pkg/kubelet/images/types.go
@@ -20,7 +20,7 @@ import (
 	"errors"
 
 	"k8s.io/api/core/v1"
-	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
 )
 
 var (

--- a/pkg/kubelet/kubelet_network.go
+++ b/pkg/kubelet/kubelet_network.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 
 	"k8s.io/api/core/v1"
-	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
 	"k8s.io/klog/v2"
 	utiliptables "k8s.io/kubernetes/pkg/util/iptables"
 )

--- a/pkg/kubelet/kubelet_pods.go
+++ b/pkg/kubelet/kubelet_pods.go
@@ -40,7 +40,7 @@ import (
 	utilvalidation "k8s.io/apimachinery/pkg/util/validation"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/component-helpers/storage/ephemeral"
-	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
 	"k8s.io/klog/v2"
 	podutil "k8s.io/kubernetes/pkg/api/v1/pod"
 	"k8s.io/kubernetes/pkg/api/v1/resource"

--- a/pkg/kubelet/kubelet_pods_linux_test.go
+++ b/pkg/kubelet/kubelet_pods_linux_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"k8s.io/api/core/v1"
 
-	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
 	_ "k8s.io/kubernetes/pkg/apis/core/install"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
 	volumetest "k8s.io/kubernetes/pkg/volume/testing"

--- a/pkg/kubelet/kuberuntime/convert.go
+++ b/pkg/kubelet/kuberuntime/convert.go
@@ -19,7 +19,7 @@ package kuberuntime
 import (
 	"sort"
 
-	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
 )
 

--- a/pkg/kubelet/kuberuntime/convert_test.go
+++ b/pkg/kubelet/kuberuntime/convert_test.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
 )
 

--- a/pkg/kubelet/kuberuntime/helpers.go
+++ b/pkg/kubelet/kuberuntime/helpers.go
@@ -24,7 +24,7 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
-	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
 	"k8s.io/klog/v2"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
 )

--- a/pkg/kubelet/kuberuntime/helpers_test.go
+++ b/pkg/kubelet/kuberuntime/helpers_test.go
@@ -25,7 +25,7 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
 	runtimetesting "k8s.io/cri-api/pkg/apis/testing"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
 	utilpointer "k8s.io/utils/pointer"

--- a/pkg/kubelet/kuberuntime/instrumented_services.go
+++ b/pkg/kubelet/kuberuntime/instrumented_services.go
@@ -20,7 +20,7 @@ import (
 	"time"
 
 	internalapi "k8s.io/cri-api/pkg/apis"
-	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
 	"k8s.io/kubernetes/pkg/kubelet/metrics"
 )
 

--- a/pkg/kubelet/kuberuntime/instrumented_services_test.go
+++ b/pkg/kubelet/kuberuntime/instrumented_services_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"k8s.io/component-base/metrics/legacyregistry"
-	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
 	"k8s.io/kubernetes/pkg/kubelet/metrics"
 )
 

--- a/pkg/kubelet/kuberuntime/kuberuntime_container.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_container.go
@@ -45,7 +45,7 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
-	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
 	"k8s.io/kubernetes/pkg/features"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
 	"k8s.io/kubernetes/pkg/kubelet/events"

--- a/pkg/kubelet/kuberuntime/kuberuntime_container_linux.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_container_linux.go
@@ -28,7 +28,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
-	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
 	"k8s.io/klog/v2"
 	v1helper "k8s.io/kubernetes/pkg/apis/core/v1/helper"
 	kubefeatures "k8s.io/kubernetes/pkg/features"

--- a/pkg/kubelet/kuberuntime/kuberuntime_container_linux_test.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_container_linux_test.go
@@ -32,7 +32,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	featuregatetesting "k8s.io/component-base/featuregate/testing"
-	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
 	"k8s.io/kubernetes/pkg/features"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
 	kubelettypes "k8s.io/kubernetes/pkg/kubelet/types"

--- a/pkg/kubelet/kuberuntime/kuberuntime_container_test.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_container_test.go
@@ -34,7 +34,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	featuregatetesting "k8s.io/component-base/featuregate/testing"
-	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
 	"k8s.io/kubernetes/pkg/features"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
 	containertest "k8s.io/kubernetes/pkg/kubelet/container/testing"

--- a/pkg/kubelet/kuberuntime/kuberuntime_container_unsupported.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_container_unsupported.go
@@ -21,7 +21,7 @@ package kuberuntime
 
 import (
 	"k8s.io/api/core/v1"
-	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
 )
 

--- a/pkg/kubelet/kuberuntime/kuberuntime_container_windows.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_container_windows.go
@@ -25,7 +25,7 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
-	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
 	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/pkg/features"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
@@ -78,7 +78,7 @@ func (m *kubeGenericRuntimeManager) generateWindowsContainerConfig(container *v1
 		// Part three - CRI & ContainerD's implementation
 		//   The kubelet sets these directly on CGroups in Linux, but needs to pass them across CRI on Windows.
 		//   There is an existing cpu_maximum field, with a range of percent * 100, so 1-10000. This is different from Docker, but consistent with OCI
-		//   https://github.com/kubernetes/kubernetes/blob/56d1c3b96d0a544130a82caad33dd57629b8a7f8/staging/src/k8s.io/cri-api/pkg/apis/runtime/v1alpha2/api.proto#L681-L682
+		//   https://github.com/kubernetes/kubernetes/blob/56d1c3b96d0a544130a82caad33dd57629b8a7f8/staging/src/k8s.io/cri-api/pkg/apis/runtime/v1/api.proto#L681-L682
 		//   https://github.com/opencontainers/runtime-spec/blob/ad53dcdc39f1f7f7472b10aa0a45648fe4865496/config-windows.md#cpu
 		//   If both CpuWeight and CpuMaximum are set - ContainerD catches this invalid case and returns an error instead.
 

--- a/pkg/kubelet/kuberuntime/kuberuntime_gc.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_gc.go
@@ -27,7 +27,7 @@ import (
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/sets"
 	internalapi "k8s.io/cri-api/pkg/apis"
-	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
 	"k8s.io/klog/v2"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
 )

--- a/pkg/kubelet/kuberuntime/kuberuntime_gc_test.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_gc_test.go
@@ -26,7 +26,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
-	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
 	containertest "k8s.io/kubernetes/pkg/kubelet/container/testing"
 )

--- a/pkg/kubelet/kuberuntime/kuberuntime_image.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_image.go
@@ -19,7 +19,7 @@ package kuberuntime
 import (
 	v1 "k8s.io/api/core/v1"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
-	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
 	"k8s.io/klog/v2"
 	credentialprovidersecrets "k8s.io/kubernetes/pkg/credentialprovider/secrets"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"

--- a/pkg/kubelet/kuberuntime/kuberuntime_image_test.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_image_test.go
@@ -26,7 +26,7 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
-	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
 	"k8s.io/kubernetes/pkg/credentialprovider"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
 )

--- a/pkg/kubelet/kuberuntime/kuberuntime_manager.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_manager.go
@@ -38,7 +38,7 @@ import (
 	"k8s.io/client-go/util/flowcontrol"
 	"k8s.io/component-base/logs/logreduction"
 	internalapi "k8s.io/cri-api/pkg/apis"
-	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
 	"k8s.io/kubernetes/pkg/api/legacyscheme"
 	"k8s.io/kubernetes/pkg/credentialprovider"
 	"k8s.io/kubernetes/pkg/credentialprovider/plugin"

--- a/pkg/kubelet/kuberuntime/kuberuntime_manager_test.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_manager_test.go
@@ -35,7 +35,7 @@ import (
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/client-go/util/flowcontrol"
 	featuregatetesting "k8s.io/component-base/featuregate/testing"
-	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
 	apitest "k8s.io/cri-api/pkg/apis/testing"
 	podutil "k8s.io/kubernetes/pkg/api/v1/pod"
 	"k8s.io/kubernetes/pkg/credentialprovider"

--- a/pkg/kubelet/kuberuntime/kuberuntime_sandbox.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_sandbox.go
@@ -25,7 +25,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	kubetypes "k8s.io/apimachinery/pkg/types"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
-	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
 	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/pkg/features"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"

--- a/pkg/kubelet/kuberuntime/kuberuntime_sandbox_linux.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_sandbox_linux.go
@@ -22,7 +22,7 @@ package kuberuntime
 import (
 	v1 "k8s.io/api/core/v1"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
-	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
 	resourcehelper "k8s.io/kubernetes/pkg/api/v1/resource"
 	"k8s.io/kubernetes/pkg/features"
 )

--- a/pkg/kubelet/kuberuntime/kuberuntime_sandbox_linux_test.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_sandbox_linux_test.go
@@ -27,7 +27,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
 )
 
 func TestApplySandboxResources(t *testing.T) {

--- a/pkg/kubelet/kuberuntime/kuberuntime_sandbox_test.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_sandbox_test.go
@@ -28,7 +28,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	featuregatetesting "k8s.io/component-base/featuregate/testing"
-	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
 	"k8s.io/kubernetes/pkg/features"
 	containertest "k8s.io/kubernetes/pkg/kubelet/container/testing"
 	"k8s.io/kubernetes/pkg/kubelet/runtimeclass"

--- a/pkg/kubelet/kuberuntime/kuberuntime_sandbox_unsupported.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_sandbox_unsupported.go
@@ -21,7 +21,7 @@ package kuberuntime
 
 import (
 	v1 "k8s.io/api/core/v1"
-	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
 )
 
 func (m *kubeGenericRuntimeManager) applySandboxResources(pod *v1.Pod, config *runtimeapi.PodSandboxConfig) error {

--- a/pkg/kubelet/kuberuntime/kuberuntime_sandbox_windows.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_sandbox_windows.go
@@ -21,7 +21,7 @@ package kuberuntime
 
 import (
 	v1 "k8s.io/api/core/v1"
-	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
 )
 
 func (m *kubeGenericRuntimeManager) applySandboxResources(pod *v1.Pod, config *runtimeapi.PodSandboxConfig) error {

--- a/pkg/kubelet/kuberuntime/logs/logs.go
+++ b/pkg/kubelet/kuberuntime/logs/logs.go
@@ -34,7 +34,7 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	internalapi "k8s.io/cri-api/pkg/apis"
-	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
 	"k8s.io/kubernetes/pkg/kubelet/types"
 	"k8s.io/kubernetes/pkg/util/tail"
 )

--- a/pkg/kubelet/kuberuntime/logs/logs_test.go
+++ b/pkg/kubelet/kuberuntime/logs/logs_test.go
@@ -30,7 +30,7 @@ import (
 
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
 )
 
 func TestLogOptions(t *testing.T) {

--- a/pkg/kubelet/kuberuntime/security_context.go
+++ b/pkg/kubelet/kuberuntime/security_context.go
@@ -18,7 +18,7 @@ package kuberuntime
 
 import (
 	v1 "k8s.io/api/core/v1"
-	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
 	"k8s.io/kubernetes/pkg/security/apparmor"
 	"k8s.io/kubernetes/pkg/securitycontext"
 )

--- a/pkg/kubelet/logs/container_log_manager.go
+++ b/pkg/kubelet/logs/container_log_manager.go
@@ -32,7 +32,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/util/wait"
 	internalapi "k8s.io/cri-api/pkg/apis"
-	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
 	"k8s.io/utils/clock"
 )

--- a/pkg/kubelet/logs/container_log_manager_test.go
+++ b/pkg/kubelet/logs/container_log_manager_test.go
@@ -30,7 +30,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"k8s.io/kubernetes/pkg/kubelet/container"
 
-	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
 	critest "k8s.io/cri-api/pkg/apis/testing"
 	testingclock "k8s.io/utils/clock/testing"
 )

--- a/pkg/kubelet/network/dns/dns.go
+++ b/pkg/kubelet/network/dns/dns.go
@@ -30,7 +30,7 @@ import (
 	utilvalidation "k8s.io/apimachinery/pkg/util/validation"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/client-go/tools/record"
-	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
 	"k8s.io/kubernetes/pkg/apis/core/validation"
 	"k8s.io/kubernetes/pkg/features"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"

--- a/pkg/kubelet/network/dns/dns_test.go
+++ b/pkg/kubelet/network/dns/dns_test.go
@@ -32,7 +32,7 @@ import (
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/client-go/tools/record"
 	featuregatetesting "k8s.io/component-base/featuregate/testing"
-	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
 	"k8s.io/kubernetes/pkg/apis/core/validation"
 	"k8s.io/kubernetes/pkg/features"
 	netutils "k8s.io/utils/net"

--- a/pkg/kubelet/pleg/generic.go
+++ b/pkg/kubelet/pleg/generic.go
@@ -24,7 +24,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
-	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
 	"k8s.io/klog/v2"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
 	"k8s.io/kubernetes/pkg/kubelet/metrics"

--- a/pkg/kubelet/pod_workers.go
+++ b/pkg/kubelet/pod_workers.go
@@ -28,7 +28,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/tools/record"
-	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
 	"k8s.io/klog/v2"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
 	"k8s.io/kubernetes/pkg/kubelet/events"

--- a/pkg/kubelet/server/server_test.go
+++ b/pkg/kubelet/server/server_test.go
@@ -47,7 +47,7 @@ import (
 	"k8s.io/apiserver/pkg/authorization/authorizer"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/tools/remotecommand"
-	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
 	statsapi "k8s.io/kubelet/pkg/apis/stats/v1alpha1"
 	api "k8s.io/kubernetes/pkg/apis/core"
 	"k8s.io/utils/pointer"

--- a/pkg/kubelet/stats/cri_stats_provider.go
+++ b/pkg/kubelet/stats/cri_stats_provider.go
@@ -32,7 +32,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	internalapi "k8s.io/cri-api/pkg/apis"
-	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
 	"k8s.io/klog/v2"
 	statsapi "k8s.io/kubelet/pkg/apis/stats/v1alpha1"
 	"k8s.io/kubernetes/pkg/kubelet/cadvisor"

--- a/pkg/kubelet/stats/cri_stats_provider_test.go
+++ b/pkg/kubelet/stats/cri_stats_provider_test.go
@@ -33,7 +33,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/uuid"
-	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
 	critest "k8s.io/cri-api/pkg/apis/testing"
 	statsapi "k8s.io/kubelet/pkg/apis/stats/v1alpha1"
 	cadvisortest "k8s.io/kubernetes/pkg/kubelet/cadvisor/testing"

--- a/staging/src/k8s.io/cri-api/pkg/apis/services.go
+++ b/staging/src/k8s.io/cri-api/pkg/apis/services.go
@@ -19,7 +19,7 @@ package cri
 import (
 	"time"
 
-	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
 )
 
 // RuntimeVersioner contains methods for runtime name, version and API version.

--- a/staging/src/k8s.io/cri-api/pkg/apis/testing/fake_image_service.go
+++ b/staging/src/k8s.io/cri-api/pkg/apis/testing/fake_image_service.go
@@ -22,7 +22,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
 )
 
 // FakeImageService fakes the image service.

--- a/staging/src/k8s.io/cri-api/pkg/apis/testing/fake_runtime_service.go
+++ b/staging/src/k8s.io/cri-api/pkg/apis/testing/fake_runtime_service.go
@@ -22,7 +22,7 @@ import (
 	"sync"
 	"time"
 
-	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
 )
 
 var (

--- a/staging/src/k8s.io/cri-api/pkg/apis/testing/utils.go
+++ b/staging/src/k8s.io/cri-api/pkg/apis/testing/utils.go
@@ -19,7 +19,7 @@ package testing
 import (
 	"fmt"
 
-	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
 )
 
 // BuildContainerName creates a unique container name string.

--- a/test/e2e_node/container_manager_test.go
+++ b/test/e2e_node/container_manager_test.go
@@ -32,7 +32,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/uuid"
-	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
 	"k8s.io/kubernetes/test/e2e/framework"
 	imageutils "k8s.io/kubernetes/test/utils/image"
 

--- a/test/e2e_node/cpu_manager_test.go
+++ b/test/e2e_node/cpu_manager_test.go
@@ -28,7 +28,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
 	kubeletconfig "k8s.io/kubernetes/pkg/kubelet/apis/config"
 	"k8s.io/kubernetes/pkg/kubelet/cm/cpumanager"
 	cpumanagerstate "k8s.io/kubernetes/pkg/kubelet/cm/cpumanager/state"

--- a/test/e2e_node/garbage_collector_test.go
+++ b/test/e2e_node/garbage_collector_test.go
@@ -25,7 +25,7 @@ import (
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	internalapi "k8s.io/cri-api/pkg/apis"
-	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
 	"k8s.io/kubernetes/pkg/kubelet/types"
 	"k8s.io/kubernetes/test/e2e/framework"
 

--- a/test/e2e_node/image_list.go
+++ b/test/e2e_node/image_list.go
@@ -30,7 +30,7 @@ import (
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/sets"
 	internalapi "k8s.io/cri-api/pkg/apis"
-	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
 	commontest "k8s.io/kubernetes/test/e2e/common"
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2egpu "k8s.io/kubernetes/test/e2e/framework/gpu"

--- a/test/e2e_node/topology_manager_test.go
+++ b/test/e2e_node/topology_manager_test.go
@@ -31,7 +31,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
 	kubeletconfig "k8s.io/kubernetes/pkg/kubelet/apis/config"
 	"k8s.io/kubernetes/pkg/kubelet/cm/cpumanager"
 	"k8s.io/kubernetes/pkg/kubelet/cm/topologymanager"

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -2038,6 +2038,7 @@ k8s.io/controller-manager/pkg/leadermigration/options
 # k8s.io/cri-api v0.0.0 => ./staging/src/k8s.io/cri-api
 ## explicit
 k8s.io/cri-api/pkg/apis
+k8s.io/cri-api/pkg/apis/runtime/v1
 k8s.io/cri-api/pkg/apis/runtime/v1alpha2
 k8s.io/cri-api/pkg/apis/testing
 # k8s.io/csi-translation-lib v0.0.0 => ./staging/src/k8s.io/csi-translation-lib


### PR DESCRIPTION
#### What type of PR is this?

/kind feature


#### What this PR does / why we need it:
This patch makes the CRI `v1` API the new project-wide default version.
To allow backwards compatibility, a fallback to `v1alpha2` has been added
as well. This fallback will be automatically determined by the kubelet.

#### Which issue(s) this PR fixes:
None

#### Special notes for your reviewer:
Alternative to https://github.com/kubernetes/kubernetes/pull/104575
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
TBD
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
None
```
