### PR TITLE
enabling `IMAGE_CONFIG_DIR` in make file for testing purposes

### DIFF
--- a/build/root/Makefile
+++ b/build/root/Makefile
@@ -231,6 +231,7 @@ define TEST_E2E_NODE_HELP_INFO
 #  IMAGE_SERVICE_ENDPOINT: remote image endpoint to connect to, to prepull images.
 #    Used when RUNTIME is set to "remote".
 #  IMAGE_CONFIG_FILE: path to a file containing image configuration.
+#  IMAGE_CONFIG_DIR: path to image config files.
 #  SYSTEM_SPEC_NAME: The name of the system spec to be used for validating the
 #    image in the node conformance test. The specs are located at
 #    test/e2e_node/system/specs/. For example, "SYSTEM_SPEC_NAME=gke" will use

--- a/hack/make-rules/test-e2e-node.sh
+++ b/hack/make-rules/test-e2e-node.sh
@@ -98,6 +98,7 @@ if [ "${remote}" = true ] ; then
   fi
   gubernator=${GUBERNATOR:-"false"}
   image_config_file=${IMAGE_CONFIG_FILE:-""}
+  image_config_dir=${IMAGE_CONFIG_DIR:-""}
   if [[ ${hosts} == "" && ${images} == "" && ${image_config_file} == "" ]]; then
     image_project="${IMAGE_PROJECT:-"cos-cloud"}"
     gci_image=$(gcloud compute images list --project "${image_project}" \
@@ -172,7 +173,7 @@ if [ "${remote}" = true ] ; then
     --delete-instances="${delete_instances}" --test_args="${test_args}" --instance-metadata="${metadata}" \
     --image-config-file="${image_config_file}" --system-spec-name="${system_spec_name}" \
     --runtime-config="${runtime_config}" --preemptible-instances="${preemptible_instances}" \
-    --ssh-user="${ssh_user}" --ssh-key="${ssh_key}" \
+    --ssh-user="${ssh_user}" --ssh-key="${ssh_key}" --image-config-dir="${image_config_dir}" \
     --extra-envs="${extra_envs}" --test-suite="${test_suite}" \
     "${timeout_arg}" \
     2>&1 | tee -i "${artifacts}/build-log.txt"


### PR DESCRIPTION
This dir path is accepted by this flag and used accordingly: https://github.com/kubernetes/kubernetes/blob/c592bd40f2df941aa4ea364592ce92fd5c669bfc/test/e2e_node/runner/remote/run_remote.go#L58

kubetest2 ref: https://github.com/kubernetes-sigs/kubetest2/pull/170/files

cc: @amwat @dims 