### PR TITLE
[PodSecurity] Expand unit test coverage and fix error cases

### DIFF
--- a/staging/src/k8s.io/pod-security-admission/admission/admission.go
+++ b/staging/src/k8s.io/pod-security-admission/admission/admission.go
@@ -149,7 +149,7 @@ func extractPodSpecFromTemplate(template *corev1.PodTemplateSpec) (*metav1.Objec
 	return &template.ObjectMeta, &template.Spec, nil
 }
 
-// CompleteConfiguration() sets up default or derived configuration.
+// CompleteConfiguration sets up default or derived configuration.
 func (a *Admission) CompleteConfiguration() error {
 	if a.Configuration != nil {
 		if p, err := admissionapi.ToPolicy(a.Configuration.Defaults); err != nil {
@@ -168,7 +168,7 @@ func (a *Admission) CompleteConfiguration() error {
 	return nil
 }
 
-// ValidateConfiguration() ensures all required fields are set with valid values.
+// ValidateConfiguration ensures all required fields are set with valid values.
 func (a *Admission) ValidateConfiguration() error {
 	if a.Configuration == nil {
 		return fmt.Errorf("configuration required")
@@ -675,6 +675,7 @@ func internalErrorResponse(msg string) *admissionv1.AdmissionResponse {
 // Relevant mutable pod fields as of 1.21 are image and seccomp annotations:
 // * https://github.com/kubernetes/kubernetes/blob/release-1.21/pkg/apis/core/validation/validation.go#L3947-L3949
 func isSignificantPodUpdate(pod, oldPod *corev1.Pod) bool {
+	// TODO: invert this logic to only allow specific update types.
 	if pod.Annotations[corev1.SeccompPodAnnotationKey] != oldPod.Annotations[corev1.SeccompPodAnnotationKey] {
 		return true
 	}

--- a/staging/src/k8s.io/pod-security-admission/admission/response.go
+++ b/staging/src/k8s.io/pod-security-admission/admission/response.go
@@ -27,38 +27,25 @@ import (
 )
 
 var (
-	_sharedAllowedResponse                        = allowedResponse()
-	_sharedAllowedByUserExemptionResponse         = allowedByExemptResponse("user")
-	_sharedAllowedByNamespaceExemptionResponse    = allowedByExemptResponse("namespace")
-	_sharedAllowedByRuntimeClassExemptionResponse = allowedByExemptResponse("runtimeClass")
+	sharedAllowedResponse                        = allowedResponse()
+	sharedAllowedPrivilegedResponse              = allowedResponse()
+	sharedAllowedByUserExemptionResponse         = allowedResponse()
+	sharedAllowedByNamespaceExemptionResponse    = allowedResponse()
+	sharedAllowedByRuntimeClassExemptionResponse = allowedResponse()
 )
 
-func sharedAllowedResponse() *admissionv1.AdmissionResponse {
-	return _sharedAllowedResponse
-}
-
-func sharedAllowedByUserExemptionResponse() *admissionv1.AdmissionResponse {
-	return _sharedAllowedByUserExemptionResponse
-}
-
-func sharedAllowedByNamespaceExemptionResponse() *admissionv1.AdmissionResponse {
-	return _sharedAllowedByNamespaceExemptionResponse
-}
-
-func sharedAllowedByRuntimeClassExemptionResponse() *admissionv1.AdmissionResponse {
-	return _sharedAllowedByRuntimeClassExemptionResponse
+func init() {
+	sharedAllowedPrivilegedResponse.AuditAnnotations = map[string]string{
+		api.EnforcedPolicyAnnotationKey: api.LevelVersion{Level: api.LevelPrivileged, Version: api.LatestVersion()}.String(),
+	}
+	sharedAllowedByUserExemptionResponse.AuditAnnotations = map[string]string{api.ExemptionReasonAnnotationKey: "user"}
+	sharedAllowedByNamespaceExemptionResponse.AuditAnnotations = map[string]string{api.ExemptionReasonAnnotationKey: "namespace"}
+	sharedAllowedByRuntimeClassExemptionResponse.AuditAnnotations = map[string]string{api.ExemptionReasonAnnotationKey: "runtimeClass"}
 }
 
 // allowedResponse is the response used when the admission decision is allow.
 func allowedResponse() *admissionv1.AdmissionResponse {
 	return &admissionv1.AdmissionResponse{Allowed: true}
-}
-
-func allowedByExemptResponse(exemptionReason string) *admissionv1.AdmissionResponse {
-	return &admissionv1.AdmissionResponse{
-		Allowed:          true,
-		AuditAnnotations: map[string]string{api.ExemptionReasonAnnotationKey: exemptionReason},
-	}
 }
 
 // forbiddenResponse is the response used when the admission decision is deny for policy violations.

--- a/staging/src/k8s.io/pod-security-admission/admission/response.go
+++ b/staging/src/k8s.io/pod-security-admission/admission/response.go
@@ -1,0 +1,93 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package admission
+
+import (
+	"fmt"
+
+	admissionv1 "k8s.io/api/admission/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/pod-security-admission/api"
+)
+
+var (
+	_sharedAllowedResponse                        = allowedResponse()
+	_sharedAllowedByUserExemptionResponse         = allowedByExemptResponse("user")
+	_sharedAllowedByNamespaceExemptionResponse    = allowedByExemptResponse("namespace")
+	_sharedAllowedByRuntimeClassExemptionResponse = allowedByExemptResponse("runtimeClass")
+)
+
+func sharedAllowedResponse() *admissionv1.AdmissionResponse {
+	return _sharedAllowedResponse
+}
+
+func sharedAllowedByUserExemptionResponse() *admissionv1.AdmissionResponse {
+	return _sharedAllowedByUserExemptionResponse
+}
+
+func sharedAllowedByNamespaceExemptionResponse() *admissionv1.AdmissionResponse {
+	return _sharedAllowedByNamespaceExemptionResponse
+}
+
+func sharedAllowedByRuntimeClassExemptionResponse() *admissionv1.AdmissionResponse {
+	return _sharedAllowedByRuntimeClassExemptionResponse
+}
+
+// allowedResponse is the response used when the admission decision is allow.
+func allowedResponse() *admissionv1.AdmissionResponse {
+	return &admissionv1.AdmissionResponse{Allowed: true}
+}
+
+func allowedByExemptResponse(exemptionReason string) *admissionv1.AdmissionResponse {
+	return &admissionv1.AdmissionResponse{
+		Allowed:          true,
+		AuditAnnotations: map[string]string{api.ExemptionReasonAnnotationKey: exemptionReason},
+	}
+}
+
+// forbiddenResponse is the response used when the admission decision is deny for policy violations.
+func forbiddenResponse(attrs api.Attributes, err error) *admissionv1.AdmissionResponse {
+	return &admissionv1.AdmissionResponse{
+		Allowed: false,
+		Result:  &apierrors.NewForbidden(attrs.GetResource().GroupResource(), attrs.GetName(), err).ErrStatus,
+	}
+}
+
+// invalidResponse is the response used for namespace requests when namespace labels are invalid.
+func invalidResponse(attrs api.Attributes, fieldErrors field.ErrorList) *admissionv1.AdmissionResponse {
+	return &admissionv1.AdmissionResponse{
+		Allowed: false,
+		Result:  &apierrors.NewInvalid(attrs.GetKind().GroupKind(), attrs.GetName(), fieldErrors).ErrStatus,
+	}
+}
+
+// errorResponse is the response used to capture generic errors.
+func errorResponse(err error, status *metav1.Status) *admissionv1.AdmissionResponse {
+	var errDetail string
+	if err != nil {
+		errDetail = fmt.Sprintf("%s: %v", status.Message, err)
+	} else {
+		errDetail = status.Message
+	}
+	return &admissionv1.AdmissionResponse{
+		Allowed:          false,
+		Result:           status,
+		AuditAnnotations: map[string]string{"error": errDetail},
+	}
+}

--- a/staging/src/k8s.io/pod-security-admission/api/helpers.go
+++ b/staging/src/k8s.io/pod-security-admission/api/helpers.go
@@ -161,6 +161,9 @@ func PolicyToEvaluate(labels map[string]string, defaults Policy) (Policy, field.
 
 		p = defaults
 	)
+	if len(labels) == 0 {
+		return p, nil
+	}
 	if level, ok := labels[EnforceLevelLabel]; ok {
 		p.Enforce.Level, err = ParseLevel(level)
 		errs = appendErr(errs, err, EnforceLevelLabel, level)

--- a/staging/src/k8s.io/pod-security-admission/test/fixtures.go
+++ b/staging/src/k8s.io/pod-security-admission/test/fixtures.go
@@ -51,7 +51,7 @@ func init() {
 	})
 	minimalValidPods[api.LevelRestricted][api.MajorMinorVersion(1, 0)] = restricted_1_0
 
-	// 1.8+: runAsNonRoot=true
+	// 1.8+: allowPrivilegeEscalation=false
 	restricted_1_8 := tweak(restricted_1_0, func(p *corev1.Pod) {
 		p.Spec.Containers[0].SecurityContext = &corev1.SecurityContext{AllowPrivilegeEscalation: pointer.BoolPtr(false)}
 		p.Spec.InitContainers[0].SecurityContext = &corev1.SecurityContext{AllowPrivilegeEscalation: pointer.BoolPtr(false)}
@@ -75,8 +75,8 @@ func init() {
 	minimalValidPods[api.LevelRestricted][api.MajorMinorVersion(1, 22)] = restricted_1_22
 }
 
-// getValidPod returns a minimal valid pod for the specified level and version.
-func getMinimalValidPod(level api.Level, version api.Version) (*corev1.Pod, error) {
+// GetMinimalValidPod returns a minimal valid pod for the specified level and version.
+func GetMinimalValidPod(level api.Level, version api.Version) (*corev1.Pod, error) {
 	originalVersion := version
 	for {
 		pod, exists := minimalValidPods[level][version]
@@ -169,7 +169,7 @@ func getFixtures(key fixtureKey) (fixtureData, error) {
 		return fixtureData{}, err
 	}
 
-	validPodForLevel, err := getMinimalValidPod(key.level, key.version)
+	validPodForLevel, err := GetMinimalValidPod(key.level, key.version)
 	if err != nil {
 		return fixtureData{}, err
 	}

--- a/staging/src/k8s.io/pod-security-admission/test/fixtures_test.go
+++ b/staging/src/k8s.io/pod-security-admission/test/fixtures_test.go
@@ -61,7 +61,7 @@ func TestFixtures(t *testing.T) {
 			failDir := filepath.Join("testdata", string(level), fmt.Sprintf("v1.%d", version), "fail")
 
 			// render the minimal valid pod fixture
-			validPod, err := getMinimalValidPod(level, api.MajorMinorVersion(1, version))
+			validPod, err := GetMinimalValidPod(level, api.MajorMinorVersion(1, version))
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/staging/src/k8s.io/pod-security-admission/test/run.go
+++ b/staging/src/k8s.io/pod-security-admission/test/run.go
@@ -296,7 +296,7 @@ func Run(t *testing.T, opts Options) {
 				}
 			}
 
-			minimalValidPod, err := getMinimalValidPod(level, version)
+			minimalValidPod, err := GetMinimalValidPod(level, version)
 			if err != nil {
 				t.Fatal(err)
 			}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

1. Add unit test for `ValidatePod`, exercising all possible response paths.
2. Reuse the test fixtures to refactor (and expand coverage) of `ValidatePodController` tests
3. Tests revealed that validation errors on pod controllers reject the request, even though controller validation is never enforcing. Errors validating controller resources now always return an allowed response.
4. Always set the `error` audit annotation when an error prevented normal policy evaluation.

#### Special notes for your reviewer:

This PR has overlap with several in-flight PRs, so conflicts will need to be resolved depending on which merges first.

#### Does this PR introduce a user-facing change?
```release-note
(PodSecurity admission) errors validating workload resources (deployment, replicaset, etc.) no longer block admission.
```

/sig auth
/assign @liggitt 
/milestone v1.23