### PR TITLE
Replace ioutil with io and os for cluster/gce/gci

### DIFF
--- a/cluster/gce/gci/apiserver_kms_test.go
+++ b/cluster/gce/gci/apiserver_kms_test.go
@@ -20,7 +20,6 @@ import (
 	"bytes"
 	"encoding/base64"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -128,7 +127,7 @@ func TestEncryptionProviderConfig(t *testing.T) {
 		c.t.Fatalf("Expected encryption provider config to be written to %s, but stat failed with error: %v", p, err)
 	}
 
-	got, err := ioutil.ReadFile(p)
+	got, err := os.ReadFile(p)
 	if err != nil {
 		c.t.Fatalf("Failed to read encryption provider config %s", p)
 	}

--- a/cluster/gce/gci/append_or_replace_prefixed_line_test.go
+++ b/cluster/gce/gci/append_or_replace_prefixed_line_test.go
@@ -18,7 +18,6 @@ package gci
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"testing"
@@ -155,7 +154,7 @@ jelloworld
 	}
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
-			f, err := ioutil.TempFile("", "append_or_replace_test")
+			f, err := os.CreateTemp("", "append_or_replace_test")
 			if err != nil {
 				t.Fatalf("Failed to create temp file: %v", err)
 			}
@@ -170,7 +169,7 @@ jelloworld
 			if err != nil {
 				t.Fatalf("Failed to run command: %v: %s", err, stderr)
 			}
-			got, err := ioutil.ReadFile(f.Name())
+			got, err := os.ReadFile(f.Name())
 			if err != nil {
 				t.Fatalf("Failed to read file contents: %v", err)
 			}

--- a/cluster/gce/gci/audit_policy_test.go
+++ b/cluster/gce/gci/audit_policy_test.go
@@ -18,7 +18,7 @@ package gci
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -40,7 +40,7 @@ func init() {
 }
 
 func TestCreateMasterAuditPolicy(t *testing.T) {
-	baseDir, err := ioutil.TempDir("", "configure-helper-test") // cleaned up by c.tearDown()
+	baseDir, err := os.MkdirTemp("", "configure-helper-test") // cleaned up by c.tearDown()
 	require.NoError(t, err, "Failed to create temp directory")
 
 	policyFile := filepath.Join(baseDir, "audit_policy.yaml")

--- a/cluster/gce/gci/configure_helper_test.go
+++ b/cluster/gce/gci/configure_helper_test.go
@@ -19,7 +19,6 @@ package gci
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -56,7 +55,7 @@ func newManifestTestCase(t *testing.T, manifest, funcName string, auxManifests [
 		manifestFuncName: funcName,
 	}
 
-	d, err := ioutil.TempDir("", "configure-helper-test")
+	d, err := os.MkdirTemp("", "configure-helper-test")
 	if err != nil {
 		c.t.Fatalf("Failed to create temp directory: %v", err)
 	}
@@ -143,7 +142,7 @@ func (c *ManifestTestCase) mustCreateEnv(env interface{}, target string, templat
 }
 
 func (c *ManifestTestCase) mustLoadPodFromManifest() {
-	json, err := ioutil.ReadFile(c.manifestDestination)
+	json, err := os.ReadFile(c.manifestDestination)
 	if err != nil {
 		c.t.Fatalf("Failed to read manifest: %s, %v", c.manifestDestination, err)
 	}


### PR DESCRIPTION
The ioutil package has already been deprecated in golang 1.16, please see [go1.16#ioutil](https://golang.org/doc/go1.16#ioutil). So we need to replace all the ioutil with os and io.

This PR is just to update the cluster/gce/gci. There will be a couple of separate PRs for another SIGs.

Fix https://github.com/kubernetes/kubernetes/issues/100367 