### PR TITLE
Replace ioutil with io and os for pkg/api

### DIFF
--- a/pkg/api/testing/conversion_test.go
+++ b/pkg/api/testing/conversion_test.go
@@ -17,8 +17,8 @@ limitations under the License.
 package testing
 
 import (
-	"io/ioutil"
 	"math/rand"
+	"os"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -59,7 +59,7 @@ func BenchmarkPodConversion(b *testing.B) {
 }
 
 func BenchmarkNodeConversion(b *testing.B) {
-	data, err := ioutil.ReadFile("node_example.json")
+	data, err := os.ReadFile("node_example.json")
 	if err != nil {
 		b.Fatalf("Unexpected error while reading file: %v", err)
 	}
@@ -89,7 +89,7 @@ func BenchmarkNodeConversion(b *testing.B) {
 }
 
 func BenchmarkReplicationControllerConversion(b *testing.B) {
-	data, err := ioutil.ReadFile("replication_controller_example.json")
+	data, err := os.ReadFile("replication_controller_example.json")
 	if err != nil {
 		b.Fatalf("Unexpected error while reading file: %v", err)
 	}

--- a/pkg/api/testing/deep_copy_test.go
+++ b/pkg/api/testing/deep_copy_test.go
@@ -17,7 +17,7 @@ limitations under the License.
 package testing
 
 import (
-	"io/ioutil"
+	"os"
 	"testing"
 	"time"
 
@@ -140,7 +140,7 @@ func BenchmarkPodCopy(b *testing.B) {
 }
 
 func BenchmarkNodeCopy(b *testing.B) {
-	data, err := ioutil.ReadFile("node_example.json")
+	data, err := os.ReadFile("node_example.json")
 	if err != nil {
 		b.Fatalf("Unexpected error while reading file: %v", err)
 	}
@@ -159,7 +159,7 @@ func BenchmarkNodeCopy(b *testing.B) {
 }
 
 func BenchmarkReplicationControllerCopy(b *testing.B) {
-	data, err := ioutil.ReadFile("replication_controller_example.json")
+	data, err := os.ReadFile("replication_controller_example.json")
 	if err != nil {
 		b.Fatalf("Unexpected error while reading file: %v", err)
 	}

--- a/pkg/api/testing/serialization_test.go
+++ b/pkg/api/testing/serialization_test.go
@@ -20,7 +20,7 @@ import (
 	"bytes"
 	"encoding/hex"
 	gojson "encoding/json"
-	"io/ioutil"
+	"io"
 	"math/rand"
 	"reflect"
 	"testing"
@@ -363,7 +363,7 @@ func TestObjectWatchFraming(t *testing.T) {
 		if n, err := w.Write(obj.Bytes()); err != nil || n != len(obj.Bytes()) {
 			t.Fatal(err)
 		}
-		sr := streaming.NewDecoder(framer.NewFrameReader(ioutil.NopCloser(out)), s)
+		sr := streaming.NewDecoder(framer.NewFrameReader(io.NopCloser(out)), s)
 		resultSecret := &v1.Secret{}
 		res, _, err := sr.Decode(nil, resultSecret)
 		if err != nil {
@@ -392,7 +392,7 @@ func TestObjectWatchFraming(t *testing.T) {
 		if n, err := w.Write(obj.Bytes()); err != nil || n != len(obj.Bytes()) {
 			t.Fatal(err)
 		}
-		sr = streaming.NewDecoder(framer.NewFrameReader(ioutil.NopCloser(out)), s)
+		sr = streaming.NewDecoder(framer.NewFrameReader(io.NopCloser(out)), s)
 		outEvent := &metav1.WatchEvent{}
 		_, _, err = sr.Decode(nil, outEvent)
 		if err != nil || outEvent.Type != string(watch.Added) {


### PR DESCRIPTION
The ioutil package has already been deprecated in golang 1.16, please see [go1.16#ioutil](https://golang.org/doc/go1.16#ioutil). So we need to replace all the ioutil with os and io.

This PR is just to update the pks/api. There will be a couple of separate PRs for another SIGs.

Fix https://github.com/kubernetes/kubernetes/issues/100367 