### PR TITLE
Fix OnStoppedLeader call without acquiring leadership during election

### DIFF
--- a/staging/src/k8s.io/client-go/tools/leaderelection/leaderelection.go
+++ b/staging/src/k8s.io/client-go/tools/leaderelection/leaderelection.go
@@ -199,13 +199,12 @@ type LeaderElector struct {
 // stopped holding the leader lease
 func (le *LeaderElector) Run(ctx context.Context) {
 	defer runtime.HandleCrash()
-	defer func() {
-		le.config.Callbacks.OnStoppedLeading()
-	}()
 
 	if !le.acquire(ctx) {
 		return // ctx signalled done
 	}
+	defer le.config.Callbacks.OnStoppedLeading()
+
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 	go le.config.Callbacks.OnStartedLeading(ctx)


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
Currently the OnStoppedLeader function is called during leader election whether the elector successfully acquired leadership or not. Specifically, if an elector context is canceled before acquiring leadership the OnStoppedLeader func is called even though OnStartedLeader is never called. This bug seems to be have been introduced during the transition from a shutdown channel to context in the Run function.

Moving the OnStoppedLeader defer until after le.acquire is successful mitigates this issue.

#### Which issue(s) this PR fixes:
_NA_

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
NONE

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.: