### PR TITLE
Change statefulset update status

### DIFF
--- a/pkg/apis/apps/types.go
+++ b/pkg/apis/apps/types.go
@@ -83,11 +83,9 @@ const (
 	// strategy, new Pods will be created from the specification version indicated
 	// by the StatefulSet's updateRevision.
 	RollingUpdateStatefulSetStrategyType StatefulSetUpdateStrategyType = "RollingUpdate"
-	// OnDeleteStatefulSetStrategyType triggers the legacy behavior. Version
-	// tracking and ordered rolling restarts are disabled. Pods are recreated
-	// from the StatefulSetSpec when they are manually deleted. When a scale
-	// operation is performed with this strategy,specification version indicated
-	// by the StatefulSet's currentRevision.
+	// OnDeleteStatefulSetStrategyType triggers the legacy behavior. Ordered
+	// rolling restarts are disabled. Pods are recreated
+	// from the StatefulSetSpec when they are manually deleted.
 	OnDeleteStatefulSetStrategyType StatefulSetUpdateStrategyType = "OnDelete"
 )
 

--- a/pkg/controller/statefulset/stateful_set_control_test.go
+++ b/pkg/controller/statefulset/stateful_set_control_test.go
@@ -618,11 +618,11 @@ func TestStatefulSetControl_getSetRevisions(t *testing.T) {
 	testFn := func(test *testcase, t *testing.T) {
 		client := fake.NewSimpleClientset()
 		informerFactory := informers.NewSharedInformerFactory(client, controller.NoResyncPeriodFunc())
-		spc := NewStatefulPodControlFromManager(newFakeObjectManager(informerFactory), &noopRecorder{})
+		om := newFakeObjectManager(informerFactory)
+		spc := NewStatefulPodControlFromManager(om, &noopRecorder{})
 		ssu := newFakeStatefulSetStatusUpdater(informerFactory.Apps().V1().StatefulSets())
 		recorder := &noopRecorder{}
 		ssc := defaultStatefulSetControl{spc, ssu, history.NewFakeHistory(informerFactory.Apps().V1().ControllerRevisions()), recorder}
-
 		stop := make(chan struct{})
 		defer close(stop)
 		informerFactory.Start(stop)
@@ -632,6 +632,10 @@ func TestStatefulSetControl_getSetRevisions(t *testing.T) {
 			informerFactory.Core().V1().Pods().Informer().HasSynced,
 			informerFactory.Apps().V1().ControllerRevisions().Informer().HasSynced,
 		)
+		if test.set.Spec.UpdateStrategy.Type != apps.RollingUpdateStatefulSetStrategyType {
+			t.Fatal("stateful set is not RollingUpdate type")
+		}
+
 		test.set.Status.CollisionCount = new(int32)
 		for i := range test.existing {
 			ssc.controllerHistory.CreateControllerRevision(test.set, test.existing[i], test.set.Status.CollisionCount)
@@ -640,7 +644,8 @@ func TestStatefulSetControl_getSetRevisions(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		current, update, _, err := ssc.getStatefulSetRevisions(test.set, revisions)
+
+		current, update, _, err := ssc.getStatefulSetRevisions(test.set, revisions, nil)
 		if err != nil {
 			t.Fatalf("error getting statefulset revisions:%v", err)
 		}
@@ -732,6 +737,168 @@ func TestStatefulSetControl_getSetRevisions(t *testing.T) {
 				testFn(&tests[i], t)
 			}
 		})
+}
+
+func createPodsAndRevisionForSet(set *apps.StatefulSet, revision int64) (retRev *apps.ControllerRevision, retPods []*v1.Pod) {
+	retRev = newRevisionOrDie(set, revision)
+	replicaCount := int(*set.Spec.Replicas)
+	for i := 0; i < replicaCount; i++ {
+		pod := newStatefulSetPod(set, i)
+		setPodRevision(pod, retRev.Name)
+		retPods = append(retPods, pod)
+	}
+	return
+}
+
+func runForOnDeletePodScenarios(t *testing.T,
+	testFn func(*testing.T, *apps.ControllerRevision, *apps.StatefulSet, []*v1.Pod, []*apps.ControllerRevision),
+) {
+	type testCase struct {
+		name      string
+		expected  *apps.ControllerRevision
+		set       *apps.StatefulSet
+		pods      []*v1.Pod
+		revisions []*apps.ControllerRevision
+	}
+
+	cases := []testCase{}
+
+	//Test case: stable statefulset
+	set := newStatefulSet(3)
+	set.Spec.UpdateStrategy = apps.StatefulSetUpdateStrategy{
+		Type: apps.OnDeleteStatefulSetStrategyType,
+	}
+	set.Status.CollisionCount = new(int32)
+	rev0, pods0 := createPodsAndRevisionForSet(set, 1)
+	set.Status.CurrentRevision = rev0.Name
+	set.Status.UpdateRevision = rev0.Name
+	cases = append(cases, testCase{
+		name:      "StableRevision",
+		expected:  rev0,
+		set:       set,
+		pods:      pods0,
+		revisions: []*apps.ControllerRevision{rev0},
+	})
+
+	// Test case: unsorted pods
+	cases = append(cases, testCase{
+		name:      "StableRevisionUnsortedPods",
+		expected:  rev0,
+		set:       set,
+		pods:      []*v1.Pod{pods0[1], pods0[2], pods0[0]},
+		revisions: []*apps.ControllerRevision{rev0},
+	})
+
+	//Test case: new revision with one new pod
+	set1 := set.DeepCopy()
+	set1.Spec.Template.Spec.Containers[0].Image = "foo"
+	set1.Status.CurrentRevision = rev0.Name
+	set1.Status.CollisionCount = new(int32)
+	rev1, pods1 := createPodsAndRevisionForSet(set1, 2)
+	set1.Status.UpdateRevision = rev1.Name
+	cases = append(cases, testCase{
+		name:      "OneNewRevision",
+		expected:  rev0,
+		set:       set1,
+		pods:      []*v1.Pod{pods1[0], pods0[1], pods0[2]},
+		revisions: []*apps.ControllerRevision{rev0, rev1},
+	})
+
+	//Test case: pods spread across three revisions
+	set2 := set1.DeepCopy()
+	set2.Spec.Template.Spec.Containers[0].Image = "bar"
+	set2.Status.CurrentRevision = rev0.Name
+	set2.Status.CollisionCount = new(int32)
+	rev2, pods2 := createPodsAndRevisionForSet(set2, 3)
+	set2.Status.UpdateRevision = rev2.Name
+	cases = append(cases, testCase{
+		name:      "TwoNewRevisions",
+		expected:  rev0,
+		set:       set2,
+		pods:      []*v1.Pod{pods1[0], pods2[1], pods0[2]},
+		revisions: []*apps.ControllerRevision{rev0, rev1, rev2},
+	})
+
+	//Test case: remove pod with current revision
+	cases = append(cases, testCase{
+		name:      "RemoveOldestRevisionPod",
+		expected:  rev1,
+		set:       set2,
+		pods:      []*v1.Pod{pods1[0], pods2[1], pods2[2]},
+		revisions: []*apps.ControllerRevision{rev0, rev1, rev2},
+	})
+
+	// Remove pod with current revision and unsorted pods
+	cases = append(cases, testCase{
+		name:      "RemoveOldestRevisionPodUnsorted",
+		expected:  rev1,
+		set:       set2,
+		pods:      []*v1.Pod{pods2[2], pods1[0], pods2[1]},
+		revisions: []*apps.ControllerRevision{rev0, rev1, rev2},
+	})
+
+	// No revisions for existing pods
+	// Remove pod with current revision and unsorted pods
+	cases = append(cases, testCase{
+		name:      "PodRevisionsDoNotExist",
+		expected:  nil,
+		set:       set2,
+		pods:      []*v1.Pod{pods1[0], pods2[1], pods2[2]},
+		revisions: []*apps.ControllerRevision{rev0},
+	})
+
+	//Test case: pods only have latest revision
+	// This being the case we don't expect the current revision to change as
+	// the update status will take care of this
+	cases = append(cases, testCase{
+		name:      "AllNewRevision",
+		expected:  rev0,
+		set:       set2,
+		pods:      pods2,
+		revisions: []*apps.ControllerRevision{rev0, rev1, rev2},
+	})
+
+	for _, testCase := range cases {
+		testName := fmt.Sprintf("OnDeleteTest/%s", testCase.name)
+		t.Run(testName, func(t *testing.T) {
+			testFn(
+				t,
+				testCase.expected,
+				testCase.set,
+				testCase.pods,
+				testCase.revisions,
+			)
+		})
+	}
+}
+
+func TestStatefulSetControl_getCurrentRevision(t *testing.T) {
+	testFn := func(
+		t *testing.T,
+		expected *apps.ControllerRevision,
+		set *apps.StatefulSet,
+		pods []*v1.Pod,
+		revisions []*apps.ControllerRevision,
+	) {
+		history.SortControllerRevisions(revisions)
+		currentRevision := getCurrentRevision(set, revisions, pods)
+
+		if !history.EqualRevision(currentRevision, expected) {
+			t.Errorf("for current want %v got %v", expected, currentRevision)
+		}
+		if expected == nil {
+			if currentRevision != nil {
+				t.Errorf("for current revision wanted nil got %v", currentRevision)
+			}
+			// Break here to avoid nil pointer errors
+			return
+		}
+		if expected.Revision != currentRevision.Revision {
+			t.Errorf("for current revision want %d got %d", expected.Revision, currentRevision.Revision)
+		}
+	}
+
+	runForOnDeletePodScenarios(t, testFn)
 }
 
 func setupPodManagementPolicy(podManagementPolicy apps.PodManagementPolicyType, set *apps.StatefulSet) *apps.StatefulSet {

--- a/pkg/controller/statefulset/stateful_set_utils.go
+++ b/pkg/controller/statefulset/stateful_set_utils.go
@@ -555,17 +555,90 @@ func inconsistentStatus(set *apps.StatefulSet, status *apps.StatefulSetStatus) b
 		status.UpdateRevision != set.Status.UpdateRevision
 }
 
-// completeRollingUpdate completes a rolling update when all of set's replica Pods have been updated
-// to the updateRevision. status's currentRevision is set to updateRevision and its' updateRevision
-// is set to the empty string. status's currentReplicas is set to updateReplicas and its updateReplicas
+// completeUpdate completes an update when all of set's replica Pods have been updated
+// to the updateRevision. status's currentRevision is set to updateRevision.
+// status's currentReplicas is set to updateReplicas and its updateReplicas
 // are set to 0.
-func completeRollingUpdate(set *apps.StatefulSet, status *apps.StatefulSetStatus) {
-	if set.Spec.UpdateStrategy.Type == apps.RollingUpdateStatefulSetStrategyType &&
-		status.UpdatedReplicas == status.Replicas &&
+func completeUpdate(set *apps.StatefulSet, status *apps.StatefulSetStatus) {
+	if status.UpdatedReplicas == status.Replicas &&
 		status.ReadyReplicas == status.Replicas {
 		status.CurrentReplicas = status.UpdatedReplicas
 		status.CurrentRevision = status.UpdateRevision
 	}
+}
+
+// getCurrentRevision gets checks the currentRevision of the statefulset and gets
+// that revision.  If the statefulset has OnDelete update strategy, and there are
+// no longer any pods with the current revision it will get updated if it hasn't
+// completed being rolled out.  The revisions array must be sorted.
+func getCurrentRevision(
+	set *apps.StatefulSet,
+	revisions []*apps.ControllerRevision,
+	pods []*v1.Pod,
+) *apps.ControllerRevision {
+	//If current revision isn't set then we can just return nil
+	if set.Status.CurrentRevision == "" {
+		return nil
+	}
+
+	revisionMap := map[string]*apps.ControllerRevision{}
+
+	// Build a map of revisions for future use
+	for _, revision := range revisions {
+		revisionMap[revision.Name] = revision
+	}
+
+	switch set.Spec.UpdateStrategy.Type {
+	case apps.RollingUpdateStatefulSetStrategyType:
+		if rev, ok := revisionMap[set.Status.CurrentRevision]; ok {
+			return rev
+		}
+	case apps.OnDeleteStatefulSetStrategyType:
+		return getOnDeleteRevision(set, revisionMap, revisions, pods)
+	}
+
+	return nil
+}
+
+func getOnDeleteRevision(
+	set *apps.StatefulSet,
+	revisionMap map[string]*apps.ControllerRevision,
+	revisions []*apps.ControllerRevision,
+	pods []*v1.Pod,
+) *apps.ControllerRevision {
+	revisionsToCheck := map[string]interface{}{}
+
+	for _, pod := range pods {
+		if !isTerminating(pod) {
+			podRevision := getPodRevision(pod)
+			if podRevision == set.Status.CurrentRevision {
+				if rev, ok := revisionMap[set.Status.CurrentRevision]; ok {
+					return rev
+				}
+				return nil
+			}
+			if podRevision != set.Status.UpdateRevision {
+				revisionsToCheck[podRevision] = nil
+			}
+		}
+	}
+
+	// if all of the pods are on the update revision we just return the current revision
+	// and let the complete function update the status
+	if len(revisionsToCheck) == 0 {
+		if rev, ok := revisionMap[set.Status.CurrentRevision]; ok {
+			return rev
+		}
+		return nil
+	}
+
+	// revisions must be sorted
+	for _, revision := range revisions {
+		if _, ok := revisionsToCheck[revision.Name]; ok {
+			return revision
+		}
+	}
+	return nil
 }
 
 // ascendingOrdinal is a sort.Interface that Sorts a list of Pods based on the ordinals extracted

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -4601,7 +4601,7 @@ func schema_k8sio_api_apps_v1_StatefulSetUpdateStrategy(ref common.ReferenceCall
 				Properties: map[string]spec.Schema{
 					"type": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Type indicates the type of the StatefulSetUpdateStrategy. Default is RollingUpdate.\n\nPossible enum values:\n - `\"OnDelete\"` triggers the legacy behavior. Version tracking and ordered rolling restarts are disabled. Pods are recreated from the StatefulSetSpec when they are manually deleted. When a scale operation is performed with this strategy,specification version indicated by the StatefulSet's currentRevision.\n - `\"RollingUpdate\"` indicates that update will be applied to all Pods in the StatefulSet with respect to the StatefulSet ordering constraints. When a scale operation is performed with this strategy, new Pods will be created from the specification version indicated by the StatefulSet's updateRevision.",
+							Description: "Type indicates the type of the StatefulSetUpdateStrategy. Default is RollingUpdate.\n\nPossible enum values:\n - `\"OnDelete\"` triggers the legacy behavior. Ordered rolling restarts are disabled. Pods are recreated from the StatefulSetSpec when they are manually deleted.\n - `\"RollingUpdate\"` indicates that update will be applied to all Pods in the StatefulSet with respect to the StatefulSet ordering constraints. When a scale operation is performed with this strategy, new Pods will be created from the specification version indicated by the StatefulSet's updateRevision.",
 							Type:        []string{"string"},
 							Format:      "",
 							Enum:        []interface{}{"OnDelete", "RollingUpdate"}},

--- a/staging/src/k8s.io/api/apps/v1/types.go
+++ b/staging/src/k8s.io/api/apps/v1/types.go
@@ -102,11 +102,9 @@ const (
 	// strategy, new Pods will be created from the specification version indicated
 	// by the StatefulSet's updateRevision.
 	RollingUpdateStatefulSetStrategyType StatefulSetUpdateStrategyType = "RollingUpdate"
-	// OnDeleteStatefulSetStrategyType triggers the legacy behavior. Version
-	// tracking and ordered rolling restarts are disabled. Pods are recreated
-	// from the StatefulSetSpec when they are manually deleted. When a scale
-	// operation is performed with this strategy,specification version indicated
-	// by the StatefulSet's currentRevision.
+	// OnDeleteStatefulSetStrategyType triggers the legacy behavior. Ordered
+	// rolling restarts are disabled. Pods are recreated
+	// from the StatefulSetSpec when they are manually deleted.
 	OnDeleteStatefulSetStrategyType StatefulSetUpdateStrategyType = "OnDelete"
 )
 

--- a/staging/src/k8s.io/api/apps/v1beta1/types.go
+++ b/staging/src/k8s.io/api/apps/v1beta1/types.go
@@ -144,11 +144,9 @@ const (
 	// strategy, new Pods will be created from the specification version indicated
 	// by the StatefulSet's updateRevision.
 	RollingUpdateStatefulSetStrategyType StatefulSetUpdateStrategyType = "RollingUpdate"
-	// OnDeleteStatefulSetStrategyType triggers the legacy behavior. Version
-	// tracking and ordered rolling restarts are disabled. Pods are recreated
-	// from the StatefulSetSpec when they are manually deleted. When a scale
-	// operation is performed with this strategy,specification version indicated
-	// by the StatefulSet's currentRevision.
+	// OnDeleteStatefulSetStrategyType triggers the legacy behavior. Ordered
+	// rolling restarts are disabled. Pods are recreated
+	// from the StatefulSetSpec when they are manually deleted.
 	OnDeleteStatefulSetStrategyType StatefulSetUpdateStrategyType = "OnDelete"
 )
 

--- a/staging/src/k8s.io/api/apps/v1beta2/types.go
+++ b/staging/src/k8s.io/api/apps/v1beta2/types.go
@@ -153,11 +153,9 @@ const (
 	// strategy, new Pods will be created from the specification version indicated
 	// by the StatefulSet's updateRevision.
 	RollingUpdateStatefulSetStrategyType StatefulSetUpdateStrategyType = "RollingUpdate"
-	// OnDeleteStatefulSetStrategyType triggers the legacy behavior. Version
-	// tracking and ordered rolling restarts are disabled. Pods are recreated
-	// from the StatefulSetSpec when they are manually deleted. When a scale
-	// operation is performed with this strategy,specification version indicated
-	// by the StatefulSet's currentRevision.
+	// OnDeleteStatefulSetStrategyType triggers the legacy behavior. Ordered
+	// rolling restarts are disabled. Pods are recreated
+	// from the StatefulSetSpec when they are manually deleted.
 	OnDeleteStatefulSetStrategyType StatefulSetUpdateStrategyType = "OnDelete"
 )
 

--- a/test/e2e/framework/expect.go
+++ b/test/e2e/framework/expect.go
@@ -90,3 +90,8 @@ func ExpectHaveKey(actual interface{}, key interface{}, explain ...interface{}) 
 func ExpectEmpty(actual interface{}, explain ...interface{}) {
 	gomega.ExpectWithOffset(1, actual).To(gomega.BeEmpty(), explain...)
 }
+
+// ExpectContains expects actual array contains an item element
+func ExpectContains(actual interface{}, item interface{}, explain ...interface{}) {
+	gomega.ExpectWithOffset(1, actual).To(gomega.ContainElement(item), explain...)
+}


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
This PR changes the status updates so that OnDelete strategy status updates will have the same logic as RollingUpdate.

It updates a comment that has outdated information about the behaviour of scale operations on StatefulSets.

It introduces a new function for calculating the currentRevision of a statefulset so this will be updated where there are no longer any pods with currentRevision when the strategy is OnDelete.

#### Which issue(s) this PR fixes:

Fixes #106055 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
For Statefulsets with an update strategy of OnDelete, the status.currentRevision will be updated when all the pods have been updated to status.updateRevision.  Where there are interim changes made to the StatefulSet the currentRevision will be updated to match the earliest revision in the existing pods.
```

