### PR TITLE
Replace the deprecated io/ioutil with os and io for cmd

### DIFF
--- a/cmd/clicheck/check_cli_conventions.go
+++ b/cmd/clicheck/check_cli_conventions.go
@@ -18,7 +18,7 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 
 	"k8s.io/cli-runtime/pkg/genericclioptions"
@@ -29,7 +29,7 @@ import (
 func main() {
 	var errorCount int
 
-	kubectl := cmd.NewKubectlCommand(cmd.KubectlOptions{IOStreams: genericclioptions.IOStreams{In: os.Stdin, Out: ioutil.Discard, ErrOut: ioutil.Discard}})
+	kubectl := cmd.NewKubectlCommand(cmd.KubectlOptions{IOStreams: genericclioptions.IOStreams{In: os.Stdin, Out: io.Discard, ErrOut: io.Discard}})
 	errors := cmdsanity.RunCmdChecks(kubectl, cmdsanity.AllCmdChecks, []string{})
 	for _, err := range errors {
 		errorCount++

--- a/cmd/dependencycheck/dependencycheck.go
+++ b/cmd/dependencycheck/dependencycheck.go
@@ -25,8 +25,8 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
+	"os"
 	"regexp"
 )
 
@@ -65,7 +65,7 @@ func main() {
 			log.Fatalf("Error compiling excluded package regex: %v", err)
 		}
 	}
-	b, err := ioutil.ReadFile(args[0])
+	b, err := os.ReadFile(args[0])
 	if err != nil {
 		log.Fatalf("Error reading dependencies file: %v", err)
 	}

--- a/cmd/dependencyverifier/dependencyverifier.go
+++ b/cmd/dependencyverifier/dependencyverifier.go
@@ -20,7 +20,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"os/exec"
@@ -81,7 +80,7 @@ func runCommand(cmd ...string) (string, error) {
 }
 
 func readFile(path string) (string, error) {
-	content, err := ioutil.ReadFile(path)
+	content, err := os.ReadFile(path)
 	// Convert []byte to string and print to screen
 	return string(content), err
 }

--- a/cmd/gendocs/gen_kubectl_docs.go
+++ b/cmd/gendocs/gen_kubectl_docs.go
@@ -19,7 +19,7 @@ package main
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 
 	"github.com/spf13/cobra/doc"
@@ -47,6 +47,6 @@ func main() {
 	// Set environment variables used by kubectl so the output is consistent,
 	// regardless of where we run.
 	os.Setenv("HOME", "/home/username")
-	kubectl := cmd.NewKubectlCommand(cmd.KubectlOptions{IOStreams: genericclioptions.IOStreams{In: bytes.NewReader(nil), Out: ioutil.Discard, ErrOut: ioutil.Discard}})
+	kubectl := cmd.NewKubectlCommand(cmd.KubectlOptions{IOStreams: genericclioptions.IOStreams{In: bytes.NewReader(nil), Out: io.Discard, ErrOut: io.Discard}})
 	doc.GenMarkdownTree(kubectl, outDir)
 }

--- a/cmd/genkubedocs/gen_kube_docs.go
+++ b/cmd/genkubedocs/gen_kube_docs.go
@@ -19,7 +19,7 @@ package main
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 
 	"github.com/spf13/cobra/doc"
@@ -79,7 +79,7 @@ func main() {
 		pflag.CommandLine = pflag.NewFlagSet(os.Args[0], pflag.ExitOnError)
 
 		// generate docs for kubeadm
-		kubeadm := kubeadmapp.NewKubeadmCommand(bytes.NewReader(nil), ioutil.Discard, ioutil.Discard)
+		kubeadm := kubeadmapp.NewKubeadmCommand(bytes.NewReader(nil), io.Discard, io.Discard)
 		doc.GenMarkdownTree(kubeadm, outDir)
 
 		// cleanup generated code for usage as include in the website

--- a/cmd/genkubedocs/postprocessing.go
+++ b/cmd/genkubedocs/postprocessing.go
@@ -17,7 +17,7 @@ limitations under the License.
 package main
 
 import (
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -38,14 +38,14 @@ func MarkdownPostProcessing(cmd *cobra.Command, dir string, processor func(strin
 	basename := strings.Replace(cmd.CommandPath(), " ", "_", -1) + ".md"
 	filename := filepath.Join(dir, basename)
 
-	markdownBytes, err := ioutil.ReadFile(filename)
+	markdownBytes, err := os.ReadFile(filename)
 	if err != nil {
 		return err
 	}
 
 	processedMarkDown := processor(string(markdownBytes))
 
-	return ioutil.WriteFile(filename, []byte(processedMarkDown), 0644)
+	return os.WriteFile(filename, []byte(processedMarkDown), 0644)
 }
 
 // cleanupForInclude parts of markdown that will make difficult to use it as include in the website:

--- a/cmd/genman/gen_kube_man.go
+++ b/cmd/genman/gen_kube_man.go
@@ -19,7 +19,7 @@ package main
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"strings"
 
@@ -97,14 +97,14 @@ func main() {
 		}
 	case "kubectl":
 		// generate manpage for kubectl
-		kubectl := kubectlcmd.NewKubectlCommand(kubectlcmd.KubectlOptions{IOStreams: genericclioptions.IOStreams{In: bytes.NewReader(nil), Out: ioutil.Discard, ErrOut: ioutil.Discard}})
+		kubectl := kubectlcmd.NewKubectlCommand(kubectlcmd.KubectlOptions{IOStreams: genericclioptions.IOStreams{In: bytes.NewReader(nil), Out: io.Discard, ErrOut: io.Discard}})
 		genMarkdown(kubectl, "", outDir)
 		for _, c := range kubectl.Commands() {
 			genMarkdown(c, "kubectl", outDir)
 		}
 	case "kubeadm":
 		// generate manpage for kubeadm
-		kubeadm := kubeadmapp.NewKubeadmCommand(bytes.NewReader(nil), ioutil.Discard, ioutil.Discard)
+		kubeadm := kubeadmapp.NewKubeadmCommand(bytes.NewReader(nil), io.Discard, io.Discard)
 		genMarkdown(kubeadm, "", outDir)
 		for _, c := range kubeadm.Commands() {
 			genMarkdown(c, "kubeadm", outDir)

--- a/cmd/genyaml/gen_kubectl_yaml.go
+++ b/cmd/genyaml/gen_kubectl_yaml.go
@@ -19,7 +19,7 @@ package main
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"strings"
 
@@ -66,7 +66,7 @@ func main() {
 	// Set environment variables used by kubectl so the output is consistent,
 	// regardless of where we run.
 	os.Setenv("HOME", "/home/username")
-	kubectl := cmd.NewKubectlCommand(cmd.KubectlOptions{IOStreams: genericclioptions.IOStreams{In: bytes.NewReader(nil), Out: ioutil.Discard, ErrOut: ioutil.Discard}})
+	kubectl := cmd.NewKubectlCommand(cmd.KubectlOptions{IOStreams: genericclioptions.IOStreams{In: bytes.NewReader(nil), Out: io.Discard, ErrOut: io.Discard}})
 	genYaml(kubectl, "", outDir)
 	for _, c := range kubectl.Commands() {
 		genYaml(c, "kubectl", outDir)

--- a/cmd/importverifier/importverifier.go
+++ b/cmd/importverifier/importverifier.go
@@ -21,7 +21,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"os"
 	"os/exec"
@@ -216,7 +215,7 @@ func main() {
 }
 
 func loadImportRestrictions(configFile string) ([]ImportRestriction, error) {
-	config, err := ioutil.ReadFile(configFile)
+	config, err := os.ReadFile(configFile)
 	if err != nil {
 		return nil, fmt.Errorf("failed to load configuration from %s: %v", configFile, err)
 	}

--- a/cmd/kube-apiserver/app/testing/testserver.go
+++ b/cmd/kube-apiserver/app/testing/testserver.go
@@ -19,7 +19,6 @@ package testing
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"os"
 	"path"
@@ -127,7 +126,7 @@ func StartTestServer(t Logger, instanceOptions *TestServerInstanceOptions, custo
 		}
 	}()
 
-	result.TmpDir, err = ioutil.TempDir("", "kubernetes-kube-apiserver")
+	result.TmpDir, err = os.MkdirTemp("", "kubernetes-kube-apiserver")
 	if err != nil {
 		return result, fmt.Errorf("failed to create temp dir: %v", err)
 	}
@@ -156,7 +155,7 @@ func StartTestServer(t Logger, instanceOptions *TestServerInstanceOptions, custo
 			return result, err
 		}
 		proxyCACertFile := path.Join(s.SecureServing.ServerCert.CertDirectory, "proxy-ca.crt")
-		if err := ioutil.WriteFile(proxyCACertFile, testutil.EncodeCertPEM(proxySigningCert), 0644); err != nil {
+		if err := os.WriteFile(proxyCACertFile, testutil.EncodeCertPEM(proxySigningCert), 0644); err != nil {
 			return result, err
 		}
 		s.Authentication.RequestHeader.ClientCAFile = proxyCACertFile
@@ -169,7 +168,7 @@ func StartTestServer(t Logger, instanceOptions *TestServerInstanceOptions, custo
 			return result, err
 		}
 		clientCACertFile := path.Join(s.SecureServing.ServerCert.CertDirectory, "client-ca.crt")
-		if err := ioutil.WriteFile(clientCACertFile, testutil.EncodeCertPEM(clientSigningCert), 0644); err != nil {
+		if err := os.WriteFile(clientCACertFile, testutil.EncodeCertPEM(clientSigningCert), 0644); err != nil {
 			return result, err
 		}
 		s.Authentication.ClientCert.ClientCA = clientCACertFile
@@ -191,12 +190,12 @@ func StartTestServer(t Logger, instanceOptions *TestServerInstanceOptions, custo
 		return result, err
 	}
 
-	saSigningKeyFile, err := ioutil.TempFile("/tmp", "insecure_test_key")
+	saSigningKeyFile, err := os.CreateTemp("/tmp", "insecure_test_key")
 	if err != nil {
 		t.Fatalf("create temp file failed: %v", err)
 	}
 	defer os.RemoveAll(saSigningKeyFile.Name())
-	if err = ioutil.WriteFile(saSigningKeyFile.Name(), []byte(ecdsaPrivateKey), 0666); err != nil {
+	if err = os.WriteFile(saSigningKeyFile.Name(), []byte(ecdsaPrivateKey), 0666); err != nil {
 		t.Fatalf("write file %s failed: %v", saSigningKeyFile.Name(), err)
 	}
 	s.ServiceAccountSigningKeyFile = saSigningKeyFile.Name()

--- a/cmd/kube-controller-manager/app/controllermanager.go
+++ b/cmd/kube-controller-manager/app/controllermanager.go
@@ -23,7 +23,6 @@ package app
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"math/rand"
 	"net/http"
 	"os"
@@ -646,7 +645,7 @@ func (c serviceAccountTokenControllerStarter) startServiceAccountTokenController
 }
 
 func readCA(file string) ([]byte, error) {
-	rootCA, err := ioutil.ReadFile(file)
+	rootCA, err := os.ReadFile(file)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/kube-controller-manager/app/testing/testserver.go
+++ b/cmd/kube-controller-manager/app/testing/testserver.go
@@ -19,7 +19,6 @@ package testing
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"os"
 	"time"
@@ -73,7 +72,7 @@ func StartTestServer(t Logger, customFlags []string) (result TestServer, err err
 		}
 	}()
 
-	result.TmpDir, err = ioutil.TempDir("", "kube-controller-manager")
+	result.TmpDir, err = os.MkdirTemp("", "kube-controller-manager")
 	if err != nil {
 		return result, fmt.Errorf("failed to create temp dir: %v", err)
 	}

--- a/cmd/kube-proxy/app/conntrack.go
+++ b/cmd/kube-proxy/app/conntrack.go
@@ -18,7 +18,7 @@ package app
 
 import (
 	"errors"
-	"io/ioutil"
+	"os"
 	"strconv"
 	"strings"
 
@@ -132,7 +132,7 @@ func isSysFSWritable() (bool, error) {
 }
 
 func readIntStringFile(filename string) (int, error) {
-	b, err := ioutil.ReadFile(filename)
+	b, err := os.ReadFile(filename)
 	if err != nil {
 		return -1, err
 	}
@@ -140,5 +140,5 @@ func readIntStringFile(filename string) (int, error) {
 }
 
 func writeIntStringFile(filename string, value int) error {
-	return ioutil.WriteFile(filename, []byte(strconv.Itoa(value)), 0640)
+	return os.WriteFile(filename, []byte(strconv.Itoa(value)), 0640)
 }

--- a/cmd/kube-proxy/app/server.go
+++ b/cmd/kube-proxy/app/server.go
@@ -22,7 +22,6 @@ import (
 	"errors"
 	goflag "flag"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"os"
@@ -403,7 +402,7 @@ func newLenientSchemeAndCodecs() (*runtime.Scheme, *serializer.CodecFactory, err
 // loadConfigFromFile loads the contents of file and decodes it as a
 // KubeProxyConfiguration object.
 func (o *Options) loadConfigFromFile(file string) (*kubeproxyconfig.KubeProxyConfiguration, error) {
-	data, err := ioutil.ReadFile(file)
+	data, err := os.ReadFile(file)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/kube-proxy/app/server_test.go
+++ b/cmd/kube-proxy/app/server_test.go
@@ -19,7 +19,6 @@ package app
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -406,7 +405,7 @@ func TestProcessHostnameOverrideFlag(t *testing.T) {
 
 func TestConfigChange(t *testing.T) {
 	setUp := func() (*os.File, string, error) {
-		tempDir, err := ioutil.TempDir("", "kubeproxy-config-change")
+		tempDir, err := os.MkdirTemp("", "kubeproxy-config-change")
 		if err != nil {
 			return nil, "", fmt.Errorf("unable to create temporary directory: %v", err)
 		}

--- a/cmd/kube-scheduler/app/options/configfile.go
+++ b/cmd/kube-scheduler/app/options/configfile.go
@@ -20,7 +20,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 
 	"k8s.io/apimachinery/pkg/runtime"
@@ -32,7 +31,7 @@ import (
 )
 
 func loadConfigFromFile(file string) (*config.KubeSchedulerConfiguration, error) {
-	data, err := ioutil.ReadFile(file)
+	data, err := os.ReadFile(file)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/kube-scheduler/app/options/options_test.go
+++ b/cmd/kube-scheduler/app/options/options_test.go
@@ -19,7 +19,6 @@ package options
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -46,7 +45,7 @@ import (
 
 func TestSchedulerOptions(t *testing.T) {
 	// temp dir
-	tmpDir, err := ioutil.TempDir("", "scheduler-options")
+	tmpDir, err := os.MkdirTemp("", "scheduler-options")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -78,7 +77,7 @@ func TestSchedulerOptions(t *testing.T) {
 	// config file and kubeconfig
 	configFile := filepath.Join(tmpDir, "scheduler.yaml")
 	configKubeconfig := filepath.Join(tmpDir, "config.kubeconfig")
-	if err := ioutil.WriteFile(configFile, []byte(fmt.Sprintf(`
+	if err := os.WriteFile(configFile, []byte(fmt.Sprintf(`
 apiVersion: kubescheduler.config.k8s.io/v1beta3
 kind: KubeSchedulerConfiguration
 clientConnection:
@@ -87,7 +86,7 @@ leaderElection:
   leaderElect: true`, configKubeconfig)), os.FileMode(0600)); err != nil {
 		t.Fatal(err)
 	}
-	if err := ioutil.WriteFile(configKubeconfig, []byte(fmt.Sprintf(`
+	if err := os.WriteFile(configKubeconfig, []byte(fmt.Sprintf(`
 apiVersion: v1
 kind: Config
 clusters:
@@ -110,7 +109,7 @@ users:
 	}
 
 	oldConfigFile := filepath.Join(tmpDir, "scheduler_old.yaml")
-	if err := ioutil.WriteFile(oldConfigFile, []byte(fmt.Sprintf(`
+	if err := os.WriteFile(oldConfigFile, []byte(fmt.Sprintf(`
 apiVersion: componentconfig/v1alpha1
 kind: KubeSchedulerConfiguration
 clientConnection:
@@ -121,7 +120,7 @@ leaderElection:
 	}
 
 	v1beta2VersionConfig := filepath.Join(tmpDir, "scheduler_v1beta2_api_version.yaml")
-	if err := ioutil.WriteFile(v1beta2VersionConfig, []byte(fmt.Sprintf(`
+	if err := os.WriteFile(v1beta2VersionConfig, []byte(fmt.Sprintf(`
 apiVersion: kubescheduler.config.k8s.io/v1beta2
 kind: KubeSchedulerConfiguration
 clientConnection:
@@ -132,7 +131,7 @@ leaderElection:
 	}
 
 	unknownVersionConfig := filepath.Join(tmpDir, "scheduler_invalid_wrong_api_version.yaml")
-	if err := ioutil.WriteFile(unknownVersionConfig, []byte(fmt.Sprintf(`
+	if err := os.WriteFile(unknownVersionConfig, []byte(fmt.Sprintf(`
 apiVersion: kubescheduler.config.k8s.io/unknown
 kind: KubeSchedulerConfiguration
 clientConnection:
@@ -143,7 +142,7 @@ leaderElection:
 	}
 
 	noVersionConfig := filepath.Join(tmpDir, "scheduler_invalid_no_version.yaml")
-	if err := ioutil.WriteFile(noVersionConfig, []byte(fmt.Sprintf(`
+	if err := os.WriteFile(noVersionConfig, []byte(fmt.Sprintf(`
 kind: KubeSchedulerConfiguration
 clientConnection:
   kubeconfig: "%s"
@@ -153,7 +152,7 @@ leaderElection:
 	}
 
 	unknownFieldConfig := filepath.Join(tmpDir, "scheduler_invalid_unknown_field.yaml")
-	if err := ioutil.WriteFile(unknownFieldConfig, []byte(fmt.Sprintf(`
+	if err := os.WriteFile(unknownFieldConfig, []byte(fmt.Sprintf(`
 apiVersion: kubescheduler.config.k8s.io/v1beta2
 kind: KubeSchedulerConfiguration
 clientConnection:
@@ -165,7 +164,7 @@ foo: bar`, configKubeconfig)), os.FileMode(0600)); err != nil {
 	}
 
 	duplicateFieldConfig := filepath.Join(tmpDir, "scheduler_invalid_duplicate_fields.yaml")
-	if err := ioutil.WriteFile(duplicateFieldConfig, []byte(fmt.Sprintf(`
+	if err := os.WriteFile(duplicateFieldConfig, []byte(fmt.Sprintf(`
 apiVersion: kubescheduler.config.k8s.io/v1beta2
 kind: KubeSchedulerConfiguration
 clientConnection:
@@ -178,7 +177,7 @@ leaderElection:
 
 	// flag-specified kubeconfig
 	flagKubeconfig := filepath.Join(tmpDir, "flag.kubeconfig")
-	if err := ioutil.WriteFile(flagKubeconfig, []byte(fmt.Sprintf(`
+	if err := os.WriteFile(flagKubeconfig, []byte(fmt.Sprintf(`
 apiVersion: v1
 kind: Config
 clusters:
@@ -202,7 +201,7 @@ users:
 
 	// plugin config
 	pluginConfigFile := filepath.Join(tmpDir, "plugin.yaml")
-	if err := ioutil.WriteFile(pluginConfigFile, []byte(fmt.Sprintf(`
+	if err := os.WriteFile(pluginConfigFile, []byte(fmt.Sprintf(`
 apiVersion: kubescheduler.config.k8s.io/v1beta3
 kind: KubeSchedulerConfiguration
 clientConnection:
@@ -233,7 +232,7 @@ profiles:
 
 	// v1beta2 plugin config
 	v1beta2PluginConfigFile := filepath.Join(tmpDir, "v1beta2_plugin.yaml")
-	if err := ioutil.WriteFile(v1beta2PluginConfigFile, []byte(fmt.Sprintf(`
+	if err := os.WriteFile(v1beta2PluginConfigFile, []byte(fmt.Sprintf(`
 apiVersion: kubescheduler.config.k8s.io/v1beta2
 kind: KubeSchedulerConfiguration
 clientConnection:
@@ -264,7 +263,7 @@ profiles:
 
 	// multiple profiles config
 	multiProfilesConfig := filepath.Join(tmpDir, "multi-profiles.yaml")
-	if err := ioutil.WriteFile(multiProfilesConfig, []byte(fmt.Sprintf(`
+	if err := os.WriteFile(multiProfilesConfig, []byte(fmt.Sprintf(`
 apiVersion: kubescheduler.config.k8s.io/v1beta3
 kind: KubeSchedulerConfiguration
 clientConnection:
@@ -291,7 +290,7 @@ profiles:
 
 	// multiple profiles config
 	v1beta2MultiProfilesConfig := filepath.Join(tmpDir, "v1beta2_multi-profiles.yaml")
-	if err := ioutil.WriteFile(v1beta2MultiProfilesConfig, []byte(fmt.Sprintf(`
+	if err := os.WriteFile(v1beta2MultiProfilesConfig, []byte(fmt.Sprintf(`
 apiVersion: kubescheduler.config.k8s.io/v1beta2
 kind: KubeSchedulerConfiguration
 clientConnection:

--- a/cmd/kube-scheduler/app/server_test.go
+++ b/cmd/kube-scheduler/app/server_test.go
@@ -19,7 +19,6 @@ package app
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -45,7 +44,7 @@ import (
 
 func TestSetup(t *testing.T) {
 	// temp dir
-	tmpDir, err := ioutil.TempDir("", "scheduler-options")
+	tmpDir, err := os.MkdirTemp("", "scheduler-options")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -59,7 +58,7 @@ func TestSetup(t *testing.T) {
 	defer server.Close()
 
 	configKubeconfig := filepath.Join(tmpDir, "config.kubeconfig")
-	if err := ioutil.WriteFile(configKubeconfig, []byte(fmt.Sprintf(`
+	if err := os.WriteFile(configKubeconfig, []byte(fmt.Sprintf(`
 apiVersion: v1
 kind: Config
 clusters:
@@ -83,7 +82,7 @@ users:
 
 	// plugin config
 	pluginConfigFilev1beta3 := filepath.Join(tmpDir, "pluginv1beta3.yaml")
-	if err := ioutil.WriteFile(pluginConfigFilev1beta3, []byte(fmt.Sprintf(`
+	if err := os.WriteFile(pluginConfigFilev1beta3, []byte(fmt.Sprintf(`
 apiVersion: kubescheduler.config.k8s.io/v1beta3
 kind: KubeSchedulerConfiguration
 clientConnection:
@@ -121,7 +120,7 @@ profiles:
 
 	// plugin config
 	pluginConfigFilev1beta2 := filepath.Join(tmpDir, "pluginv1beta2.yaml")
-	if err := ioutil.WriteFile(pluginConfigFilev1beta2, []byte(fmt.Sprintf(`
+	if err := os.WriteFile(pluginConfigFilev1beta2, []byte(fmt.Sprintf(`
 apiVersion: kubescheduler.config.k8s.io/v1beta2
 kind: KubeSchedulerConfiguration
 clientConnection:
@@ -158,7 +157,7 @@ profiles:
 
 	// multiple profiles config
 	multiProfilesConfig := filepath.Join(tmpDir, "multi-profiles.yaml")
-	if err := ioutil.WriteFile(multiProfilesConfig, []byte(fmt.Sprintf(`
+	if err := os.WriteFile(multiProfilesConfig, []byte(fmt.Sprintf(`
 apiVersion: kubescheduler.config.k8s.io/v1beta2
 kind: KubeSchedulerConfiguration
 clientConnection:
@@ -188,7 +187,7 @@ profiles:
 
 	// empty leader-election config
 	emptyLeaderElectionConfig := filepath.Join(tmpDir, "empty-leader-election-config.yaml")
-	if err := ioutil.WriteFile(emptyLeaderElectionConfig, []byte(fmt.Sprintf(`
+	if err := os.WriteFile(emptyLeaderElectionConfig, []byte(fmt.Sprintf(`
 apiVersion: kubescheduler.config.k8s.io/v1beta3
 kind: KubeSchedulerConfiguration
 clientConnection:
@@ -199,7 +198,7 @@ clientConnection:
 
 	// leader-election config
 	leaderElectionConfig := filepath.Join(tmpDir, "leader-election-config.yaml")
-	if err := ioutil.WriteFile(leaderElectionConfig, []byte(fmt.Sprintf(`
+	if err := os.WriteFile(leaderElectionConfig, []byte(fmt.Sprintf(`
 apiVersion: kubescheduler.config.k8s.io/v1beta3
 kind: KubeSchedulerConfiguration
 clientConnection:

--- a/cmd/kube-scheduler/app/testing/testserver.go
+++ b/cmd/kube-scheduler/app/testing/testserver.go
@@ -19,7 +19,6 @@ package testing
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"os"
 	"time"
@@ -75,7 +74,7 @@ func StartTestServer(t Logger, customFlags []string) (result TestServer, err err
 		}
 	}()
 
-	result.TmpDir, err = ioutil.TempDir("", "kube-scheduler")
+	result.TmpDir, err = os.MkdirTemp("", "kube-scheduler")
 	if err != nil {
 		return result, fmt.Errorf("failed to create temp dir: %v", err)
 	}

--- a/cmd/kubeadm/app/apis/kubeadm/validation/validation_test.go
+++ b/cmd/kubeadm/app/apis/kubeadm/validation/validation_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package validation
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -926,7 +925,7 @@ func TestValidateDiscoveryTokenAPIServer(t *testing.T) {
 }
 
 func TestValidateDiscoveryKubeConfigPath(t *testing.T) {
-	tmpfile, err := ioutil.TempFile("/tmp", "test_discovery_file")
+	tmpfile, err := os.CreateTemp("/tmp", "test_discovery_file")
 	if err != nil {
 		t.Errorf("Error creating temporary file: %v", err)
 	}

--- a/cmd/kubeadm/app/cmd/config.go
+++ b/cmd/kubeadm/app/cmd/config.go
@@ -20,7 +20,7 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
+	"os"
 	"sort"
 	"strings"
 
@@ -246,7 +246,7 @@ func newCmdConfigMigrate(out io.Writer) *cobra.Command {
 				return errors.New("the --old-config flag is mandatory")
 			}
 
-			oldCfgBytes, err := ioutil.ReadFile(oldCfgPath)
+			oldCfgBytes, err := os.ReadFile(oldCfgPath)
 			if err != nil {
 				return err
 			}
@@ -259,7 +259,7 @@ func newCmdConfigMigrate(out io.Writer) *cobra.Command {
 			if newCfgPath == "" {
 				fmt.Fprint(out, string(outputBytes))
 			} else {
-				if err := ioutil.WriteFile(newCfgPath, outputBytes, 0644); err != nil {
+				if err := os.WriteFile(newCfgPath, outputBytes, 0644); err != nil {
 					return errors.Wrapf(err, "failed to write the new configuration to the file %q", newCfgPath)
 				}
 			}

--- a/cmd/kubeadm/app/cmd/config_test.go
+++ b/cmd/kubeadm/app/cmd/config_test.go
@@ -20,7 +20,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -111,14 +110,14 @@ func TestImagesListRunWithCustomConfigPath(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
-			tmpDir, err := ioutil.TempDir("", "kubeadm-images-test")
+			tmpDir, err := os.MkdirTemp("", "kubeadm-images-test")
 			if err != nil {
 				t.Fatalf("Unable to create temporary directory: %v", err)
 			}
 			defer os.RemoveAll(tmpDir)
 
 			configFilePath := filepath.Join(tmpDir, "test-config-file")
-			if err := ioutil.WriteFile(configFilePath, tc.configContents, 0644); err != nil {
+			if err := os.WriteFile(configFilePath, tc.configContents, 0644); err != nil {
 				t.Fatalf("Failed writing a config file: %v", err)
 			}
 
@@ -413,12 +412,12 @@ func TestMigrate(t *testing.T) {
 // Returns the name of the file created and a cleanup callback
 func tempConfig(t *testing.T, config []byte) (string, func()) {
 	t.Helper()
-	tmpDir, err := ioutil.TempDir("", "kubeadm-migration-test")
+	tmpDir, err := os.MkdirTemp("", "kubeadm-migration-test")
 	if err != nil {
 		t.Fatalf("Unable to create temporary directory: %v", err)
 	}
 	configFilePath := filepath.Join(tmpDir, "test-config-file")
-	if err := ioutil.WriteFile(configFilePath, config, 0644); err != nil {
+	if err := os.WriteFile(configFilePath, config, 0644); err != nil {
 		os.RemoveAll(tmpDir)
 		t.Fatalf("Failed writing a config file: %v", err)
 	}

--- a/cmd/kubeadm/app/cmd/init_test.go
+++ b/cmd/kubeadm/app/cmd/init_test.go
@@ -18,7 +18,6 @@ package cmd
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -50,7 +49,7 @@ controlPlaneEndpoint: "3.4.5.6"
 
 func TestNewInitData(t *testing.T) {
 	// create temp directory
-	tmpDir, err := ioutil.TempDir("", "kubeadm-init-test")
+	tmpDir, err := os.MkdirTemp("", "kubeadm-init-test")
 	if err != nil {
 		t.Errorf("Unable to create temporary directory: %v", err)
 	}

--- a/cmd/kubeadm/app/cmd/join_test.go
+++ b/cmd/kubeadm/app/cmd/join_test.go
@@ -18,7 +18,6 @@ package cmd
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -47,7 +46,7 @@ nodeRegistration:
 
 func TestNewJoinData(t *testing.T) {
 	// create temp directory
-	tmpDir, err := ioutil.TempDir("", "kubeadm-join-test")
+	tmpDir, err := os.MkdirTemp("", "kubeadm-join-test")
 	if err != nil {
 		t.Errorf("Unable to create temporary directory: %v", err)
 	}

--- a/cmd/kubeadm/app/cmd/kubeconfig_test.go
+++ b/cmd/kubeadm/app/cmd/kubeconfig_test.go
@@ -19,7 +19,6 @@ package cmd
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -70,7 +69,7 @@ func generateTestKubeadmConfig(dir, id, certDir, clusterName string) (string, er
 	}
 	buf.Write(data)
 
-	err = ioutil.WriteFile(cfgPath, buf.Bytes(), 0644)
+	err = os.WriteFile(cfgPath, buf.Bytes(), 0644)
 	return cfgPath, err
 }
 

--- a/cmd/kubeadm/app/cmd/phases/reset/cleanupnode_test.go
+++ b/cmd/kubeadm/app/cmd/phases/reset/cleanupnode_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package phases
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -150,7 +149,7 @@ func TestConfigDirCleaner(t *testing.T) {
 			t.Logf("Running test: %s", name)
 
 			// Create a temporary directory for our fake config dir:
-			tmpDir, err := ioutil.TempDir("", "kubeadm-reset-test")
+			tmpDir, err := os.MkdirTemp("", "kubeadm-reset-test")
 			if err != nil {
 				t.Errorf("Unable to create temporary directory: %s", err)
 			}

--- a/cmd/kubeadm/app/cmd/phases/reset/removeetcdmember_test.go
+++ b/cmd/kubeadm/app/cmd/phases/reset/removeetcdmember_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package phases
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -104,7 +103,7 @@ func TestGetEtcdDataDir(t *testing.T) {
 
 			manifestPath := filepath.Join(tmpdir, "etcd.yaml")
 			if test.writeManifest {
-				err := ioutil.WriteFile(manifestPath, []byte(test.podYaml), 0644)
+				err := os.WriteFile(manifestPath, []byte(test.podYaml), 0644)
 				if err != nil {
 					t.Fatalf(dedent.Dedent("failed to write pod manifest\n%s\n\tfatal error: %v"), name, err)
 				}

--- a/cmd/kubeadm/app/cmd/phases/reset/unmount_linux.go
+++ b/cmd/kubeadm/app/cmd/phases/reset/unmount_linux.go
@@ -20,7 +20,7 @@ limitations under the License.
 package phases
 
 import (
-	"io/ioutil"
+	"os"
 	"strings"
 	"syscall"
 
@@ -29,7 +29,7 @@ import (
 
 // unmountKubeletDirectory unmounts all paths that contain KubeletRunDirectory
 func unmountKubeletDirectory(absoluteKubeletRunDirectory string) error {
-	raw, err := ioutil.ReadFile("/proc/mounts")
+	raw, err := os.ReadFile("/proc/mounts")
 	if err != nil {
 		return err
 	}

--- a/cmd/kubeadm/app/cmd/token_test.go
+++ b/cmd/kubeadm/app/cmd/token_test.go
@@ -18,7 +18,6 @@ package cmd
 
 import (
 	"bytes"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -200,7 +199,7 @@ func TestNewCmdToken(t *testing.T) {
 	var buf, bufErr bytes.Buffer
 	testConfigTokenFile := "test-config-file"
 
-	tmpDir, err := ioutil.TempDir("", "kubeadm-token-test")
+	tmpDir, err := os.MkdirTemp("", "kubeadm-token-test")
 	if err != nil {
 		t.Errorf("Unable to create temporary directory: %v", err)
 	}
@@ -268,7 +267,7 @@ func TestNewCmdToken(t *testing.T) {
 func TestGetClientset(t *testing.T) {
 	testConfigTokenFile := "test-config-file"
 
-	tmpDir, err := ioutil.TempDir("", "kubeadm-token-test")
+	tmpDir, err := os.MkdirTemp("", "kubeadm-token-test")
 	if err != nil {
 		t.Errorf("Unable to create temporary directory: %v", err)
 	}
@@ -304,7 +303,7 @@ func TestGetClientset(t *testing.T) {
 func TestRunDeleteTokens(t *testing.T) {
 	var buf bytes.Buffer
 
-	tmpDir, err := ioutil.TempDir("", "kubeadm-token-test")
+	tmpDir, err := os.MkdirTemp("", "kubeadm-token-test")
 	if err != nil {
 		t.Errorf("Unable to create temporary directory: %v", err)
 	}

--- a/cmd/kubeadm/app/cmd/upgrade/common.go
+++ b/cmd/kubeadm/app/cmd/upgrade/common.go
@@ -21,7 +21,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"strings"
 	"time"
@@ -76,7 +75,7 @@ func loadConfig(cfgPath string, client clientset.Interface, skipComponentConfigs
 	}
 
 	// Otherwise, we have a config file. Let's load it.
-	configBytes, err := ioutil.ReadFile(cfgPath)
+	configBytes, err := os.ReadFile(cfgPath)
 	if err != nil {
 		return nil, false, errors.Wrapf(err, "unable to load config from file %q", cfgPath)
 	}

--- a/cmd/kubeadm/app/cmd/upgrade/diff.go
+++ b/cmd/kubeadm/app/cmd/upgrade/diff.go
@@ -18,7 +18,6 @@ package upgrade
 
 import (
 	"io"
-	"io/ioutil"
 	"os"
 
 	"github.com/pkg/errors"
@@ -171,7 +170,7 @@ func runDiff(flags *diffFlags, args []string) error {
 		if path == "" {
 			return errors.New("empty manifest path")
 		}
-		existingManifest, err := ioutil.ReadFile(path)
+		existingManifest, err := os.ReadFile(path)
 		if err != nil {
 			return err
 		}

--- a/cmd/kubeadm/app/cmd/upgrade/diff_test.go
+++ b/cmd/kubeadm/app/cmd/upgrade/diff_test.go
@@ -18,7 +18,7 @@ package upgrade
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"testing"
 
@@ -29,7 +29,7 @@ import (
 )
 
 func createTestRunDiffFile(contents []byte) (string, error) {
-	file, err := ioutil.TempFile("", "kubeadm-upgrade-diff-config-*.yaml")
+	file, err := os.CreateTemp("", "kubeadm-upgrade-diff-config-*.yaml")
 	if err != nil {
 		return "", errors.Wrap(err, "failed to create temporary test file")
 	}
@@ -65,7 +65,7 @@ func TestRunDiff(t *testing.T) {
 
 	flags := &diffFlags{
 		cfgPath: "",
-		out:     ioutil.Discard,
+		out:     io.Discard,
 	}
 
 	// TODO: Add test cases for empty cfgPath, it should automatically fetch cfg from cluster

--- a/cmd/kubeadm/app/cmd/upgrade/plan.go
+++ b/cmd/kubeadm/app/cmd/upgrade/plan.go
@@ -19,7 +19,6 @@ package upgrade
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"sort"
 	"strings"
@@ -185,7 +184,7 @@ func getComponentConfigVersionStates(cfg *kubeadmapi.ClusterConfiguration, clien
 	docmap := kubeadmapi.DocumentMap{}
 
 	if cfgPath != "" {
-		bytes, err := ioutil.ReadFile(cfgPath)
+		bytes, err := os.ReadFile(cfgPath)
 		if err != nil {
 			return nil, errors.Wrapf(err, "unable to read config file %q", cfgPath)
 		}

--- a/cmd/kubeadm/app/constants/constants.go
+++ b/cmd/kubeadm/app/constants/constants.go
@@ -18,7 +18,6 @@ package constants
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net"
 	"os"
 	"path"
@@ -608,7 +607,7 @@ func CreateTempDirForKubeadm(kubernetesDir, dirName string) (string, error) {
 		return "", errors.Wrapf(err, "failed to create directory %q", tempDir)
 	}
 
-	tempDir, err := ioutil.TempDir(tempDir, dirName)
+	tempDir, err := os.MkdirTemp(tempDir, dirName)
 	if err != nil {
 		return "", errors.Wrap(err, "couldn't create a temporary directory")
 	}

--- a/cmd/kubeadm/app/discovery/https/https.go
+++ b/cmd/kubeadm/app/discovery/https/https.go
@@ -17,7 +17,7 @@ limitations under the License.
 package https
 
 import (
-	"io/ioutil"
+	"io"
 	"net/http"
 	"time"
 
@@ -39,7 +39,7 @@ func RetrieveValidatedConfigInfo(httpsURL, clustername string, discoveryTimeout 
 	}
 	defer response.Body.Close()
 
-	kubeconfig, err := ioutil.ReadAll(response.Body)
+	kubeconfig, err := io.ReadAll(response.Body)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/kubeadm/app/phases/bootstraptoken/clusterinfo/clusterinfo_test.go
+++ b/cmd/kubeadm/app/phases/bootstraptoken/clusterinfo/clusterinfo_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package clusterinfo
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 	"text/template"
@@ -80,7 +79,7 @@ func TestCreateBootstrapConfigMapIfNotExists(t *testing.T) {
 	}
 
 	for _, server := range servers {
-		file, err := ioutil.TempFile("", "")
+		file, err := os.CreateTemp("", "")
 		if err != nil {
 			t.Fatalf("could not create tempfile: %v", err)
 		}

--- a/cmd/kubeadm/app/phases/certs/certlist_test.go
+++ b/cmd/kubeadm/app/phases/certs/certlist_test.go
@@ -20,7 +20,6 @@ import (
 	"crypto"
 	"crypto/tls"
 	"crypto/x509"
-	"io/ioutil"
 	"os"
 	"path"
 	"testing"
@@ -145,7 +144,7 @@ func TestMakeCertTree(t *testing.T) {
 }
 
 func TestCreateCertificateChain(t *testing.T) {
-	dir, err := ioutil.TempDir("", t.Name())
+	dir, err := os.MkdirTemp("", t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/kubeadm/app/phases/certs/certs_test.go
+++ b/cmd/kubeadm/app/phases/certs/certs_test.go
@@ -21,7 +21,6 @@ import (
 	"crypto"
 	"crypto/sha256"
 	"crypto/x509"
-	"io/ioutil"
 	"net"
 	"os"
 	"path"
@@ -264,7 +263,7 @@ func TestWriteCSRFilesIfNotExist(t *testing.T) {
 		{
 			name: "existing CSR is garbage",
 			setupFunc: func(csrPath string) error {
-				return ioutil.WriteFile(path.Join(csrPath, "dummy.csr"), []byte("a--bunch--of-garbage"), os.ModePerm)
+				return os.WriteFile(path.Join(csrPath, "dummy.csr"), []byte("a--bunch--of-garbage"), os.ModePerm)
 			},
 			expectedError: true,
 		},

--- a/cmd/kubeadm/app/phases/controlplane/manifests_test.go
+++ b/cmd/kubeadm/app/phases/controlplane/manifests_test.go
@@ -18,7 +18,6 @@ package controlplane
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -164,7 +163,7 @@ func TestCreateStaticPodFilesWithPatches(t *testing.T) {
 	    patched: "true"
 	`)
 
-	err = ioutil.WriteFile(filepath.Join(patchesPath, kubeadmconstants.KubeAPIServer+".yaml"), []byte(patchString), 0644)
+	err = os.WriteFile(filepath.Join(patchesPath, kubeadmconstants.KubeAPIServer+".yaml"), []byte(patchString), 0644)
 	if err != nil {
 		t.Fatalf("WriteFile returned unexpected error: %v", err)
 	}

--- a/cmd/kubeadm/app/phases/controlplane/volumes_test.go
+++ b/cmd/kubeadm/app/phases/controlplane/volumes_test.go
@@ -18,7 +18,6 @@ package controlplane
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"reflect"
 	"testing"
@@ -507,7 +506,7 @@ func TestGetHostPathVolumesForTheControlPlane(t *testing.T) {
 		},
 	}
 
-	tmpdir, err := ioutil.TempDir("", "")
+	tmpdir, err := os.MkdirTemp("", "")
 	if err != nil {
 		t.Fatalf("Couldn't create tmpdir")
 	}

--- a/cmd/kubeadm/app/phases/copycerts/copycerts.go
+++ b/cmd/kubeadm/app/phases/copycerts/copycerts.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"encoding/hex"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"strings"
@@ -173,7 +172,7 @@ func getSecretOwnerRef(client clientset.Interface, tokenID string) ([]metav1.Own
 }
 
 func loadAndEncryptCert(certPath string, key []byte) ([]byte, error) {
-	cert, err := ioutil.ReadFile(certPath)
+	cert, err := os.ReadFile(certPath)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/kubeadm/app/phases/copycerts/copycerts_test.go
+++ b/cmd/kubeadm/app/phases/copycerts/copycerts_test.go
@@ -19,7 +19,6 @@ package copycerts
 import (
 	"context"
 	"encoding/hex"
-	"io/ioutil"
 	"os"
 	"path"
 	"regexp"
@@ -61,7 +60,7 @@ func TestGetDataFromInitConfig(t *testing.T) {
 
 	certs := certsToTransfer(cfg)
 	for name, path := range certs {
-		if err := ioutil.WriteFile(path, certData, 0644); err != nil {
+		if err := os.WriteFile(path, certData, 0644); err != nil {
 			t.Fatalf(dedent.Dedent("failed to write cert: %s\nfatal error: %v"), name, err)
 		}
 	}
@@ -191,7 +190,7 @@ func TestUploadCerts(t *testing.T) {
 		if err != nil {
 			t.Fatalf("error decrypting secret data: %v", err)
 		}
-		diskCertData, err := ioutil.ReadFile(certPath)
+		diskCertData, err := os.ReadFile(certPath)
 		if err != nil {
 			t.Fatalf("error reading certificate from disk: %v", err)
 		}
@@ -235,7 +234,7 @@ func TestDownloadCerts(t *testing.T) {
 	const certFileMode = 0644
 
 	for certName, certPath := range certsToTransfer(initForDownloadConfiguration) {
-		diskCertData, err := ioutil.ReadFile(certPath)
+		diskCertData, err := os.ReadFile(certPath)
 		if err != nil {
 			t.Errorf("error reading certificate from disk: %v", err)
 		}

--- a/cmd/kubeadm/app/phases/etcd/local_test.go
+++ b/cmd/kubeadm/app/phases/etcd/local_test.go
@@ -18,7 +18,6 @@ package etcd
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -138,7 +137,7 @@ func TestCreateLocalEtcdStaticPodManifestFileWithPatches(t *testing.T) {
 	    patched: "true"
 	`)
 
-	err = ioutil.WriteFile(filepath.Join(patchesPath, kubeadmconstants.Etcd+".yaml"), []byte(patchString), 0644)
+	err = os.WriteFile(filepath.Join(patchesPath, kubeadmconstants.Etcd+".yaml"), []byte(patchString), 0644)
 	if err != nil {
 		t.Fatalf("WriteFile returned unexpected error: %v", err)
 	}

--- a/cmd/kubeadm/app/phases/kubelet/config.go
+++ b/cmd/kubeadm/app/phases/kubelet/config.go
@@ -18,7 +18,6 @@ package kubelet
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -176,7 +175,7 @@ func writeConfigBytesToDisk(b []byte, kubeletDir string) error {
 		return errors.Wrapf(err, "failed to create directory %q", kubeletDir)
 	}
 
-	if err := ioutil.WriteFile(configFile, b, 0644); err != nil {
+	if err := os.WriteFile(configFile, b, 0644); err != nil {
 		return errors.Wrapf(err, "failed to write kubelet configuration to the file %q", configFile)
 	}
 	return nil

--- a/cmd/kubeadm/app/phases/kubelet/flags.go
+++ b/cmd/kubeadm/app/phases/kubelet/flags.go
@@ -18,7 +18,6 @@ package kubelet
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -153,7 +152,7 @@ func writeKubeletFlagBytesToDisk(b []byte, kubeletDir string) error {
 	if err := os.MkdirAll(kubeletDir, 0700); err != nil {
 		return errors.Wrapf(err, "failed to create directory %q", kubeletDir)
 	}
-	if err := ioutil.WriteFile(kubeletEnvFilePath, b, 0644); err != nil {
+	if err := os.WriteFile(kubeletEnvFilePath, b, 0644); err != nil {
 		return errors.Wrapf(err, "failed to write kubelet configuration to the file %q", kubeletEnvFilePath)
 	}
 	return nil

--- a/cmd/kubeadm/app/phases/upgrade/compute_test.go
+++ b/cmd/kubeadm/app/phases/upgrade/compute_test.go
@@ -18,7 +18,6 @@ package upgrade
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"reflect"
 	"strings"
@@ -643,13 +642,13 @@ func TestGetAvailableUpgrades(t *testing.T) {
 				},
 			})
 
-			manifestsDir, err := ioutil.TempDir("", "GetAvailableUpgrades-test-manifests")
+			manifestsDir, err := os.MkdirTemp("", "GetAvailableUpgrades-test-manifests")
 			if err != nil {
 				t.Fatalf("Unable to create temporary directory: %v", err)
 			}
 			defer os.RemoveAll(manifestsDir)
 
-			if err = ioutil.WriteFile(constants.GetStaticPodFilepath(constants.Etcd, manifestsDir), []byte(etcdStaticPod), 0644); err != nil {
+			if err = os.WriteFile(constants.GetStaticPodFilepath(constants.Etcd, manifestsDir), []byte(etcdStaticPod), 0644); err != nil {
 				t.Fatalf("Unable to create test static pod manifest: %v", err)
 			}
 

--- a/cmd/kubeadm/app/phases/upgrade/postupgrade.go
+++ b/cmd/kubeadm/app/phases/upgrade/postupgrade.go
@@ -19,7 +19,6 @@ package upgrade
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -255,12 +254,12 @@ func UpdateKubeletDynamicEnvFileWithURLScheme(dryRun bool) error {
 		return nil
 	}
 	klog.V(2).Infof("Ensuring that %q includes a CRI endpoint URL scheme", filePath)
-	bytes, err := ioutil.ReadFile(filePath)
+	bytes, err := os.ReadFile(filePath)
 	if err != nil {
 		return errors.Wrapf(err, "failed to read kubelet configuration from file %q", filePath)
 	}
 	updated := updateKubeletDynamicEnvFileWithURLScheme(string(bytes))
-	if err := ioutil.WriteFile(filePath, []byte(updated), 0644); err != nil {
+	if err := os.WriteFile(filePath, []byte(updated), 0644); err != nil {
 		return errors.Wrapf(err, "failed to write kubelet configuration to the file %q", filePath)
 	}
 	return nil

--- a/cmd/kubeadm/app/phases/upgrade/staticpods_test.go
+++ b/cmd/kubeadm/app/phases/upgrade/staticpods_test.go
@@ -20,7 +20,6 @@ import (
 	"crypto/sha256"
 	"crypto/x509"
 	"fmt"
-	"io/ioutil"
 	"math/big"
 	"os"
 	"path/filepath"
@@ -154,7 +153,7 @@ type fakeStaticPodPathManager struct {
 }
 
 func NewFakeStaticPodPathManager(moveFileFunc func(string, string) error) (StaticPodPathManager, error) {
-	kubernetesDir, err := ioutil.TempDir("", "kubeadm-pathmanager-")
+	kubernetesDir, err := os.MkdirTemp("", "kubeadm-pathmanager-")
 	if err != nil {
 		return nil, errors.Wrapf(err, "couldn't create a temporary directory for the upgrade")
 	}
@@ -453,12 +452,12 @@ func TestStaticPodControlPlane(t *testing.T) {
 			defer os.RemoveAll(pathMgr.(*fakeStaticPodPathManager).KubernetesDir())
 			tmpKubernetesDir := pathMgr.(*fakeStaticPodPathManager).KubernetesDir()
 
-			tempCertsDir, err := ioutil.TempDir("", "kubeadm-certs")
+			tempCertsDir, err := os.MkdirTemp("", "kubeadm-certs")
 			if err != nil {
 				t.Fatalf("couldn't create temporary certificates directory: %v", err)
 			}
 			defer os.RemoveAll(tempCertsDir)
-			tmpEtcdDataDir, err := ioutil.TempDir("", "kubeadm-etcd-data")
+			tmpEtcdDataDir, err := os.MkdirTemp("", "kubeadm-etcd-data")
 			if err != nil {
 				t.Fatalf("couldn't create temporary etcd data directory: %v", err)
 			}
@@ -573,7 +572,7 @@ func TestStaticPodControlPlane(t *testing.T) {
 func getAPIServerHash(dir string) (string, error) {
 	manifestPath := constants.GetStaticPodFilepath(constants.KubeAPIServer, dir)
 
-	fileBytes, err := ioutil.ReadFile(manifestPath)
+	fileBytes, err := os.ReadFile(manifestPath)
 	if err != nil {
 		return "", err
 	}
@@ -589,7 +588,7 @@ func getConfig(version, certsDir, etcdDataDir string) (*kubeadmapi.InitConfigura
 }
 
 func getTempDir(t *testing.T, name string) (string, func()) {
-	dir, err := ioutil.TempDir(os.TempDir(), name)
+	dir, err := os.MkdirTemp(os.TempDir(), name)
 	if err != nil {
 		t.Fatalf("couldn't make temporary directory: %v", err)
 	}
@@ -942,7 +941,7 @@ func TestGetPathManagerForUpgrade(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			// Use a temporary directory
-			tmpdir, err := ioutil.TempDir("", "TestGetPathManagerForUpgrade")
+			tmpdir, err := os.MkdirTemp("", "TestGetPathManagerForUpgrade")
 			if err != nil {
 				t.Fatalf("unexpected error making temporary directory: %v", err)
 			}
@@ -1000,13 +999,13 @@ spec:
   - name: etcd
     image: k8s.gcr.io/etcd:` + expectedEtcdVersion
 
-	manifestsDir, err := ioutil.TempDir("", "GetEtcdImageTagFromStaticPod-test-manifests")
+	manifestsDir, err := os.MkdirTemp("", "GetEtcdImageTagFromStaticPod-test-manifests")
 	if err != nil {
 		t.Fatalf("Unable to create temporary directory: %v", err)
 	}
 	defer os.RemoveAll(manifestsDir)
 
-	if err = ioutil.WriteFile(constants.GetStaticPodFilepath(constants.Etcd, manifestsDir), []byte(etcdStaticPod), 0644); err != nil {
+	if err = os.WriteFile(constants.GetStaticPodFilepath(constants.Etcd, manifestsDir), []byte(etcdStaticPod), 0644); err != nil {
 		t.Fatalf("Unable to create test static pod manifest: %v", err)
 	}
 

--- a/cmd/kubeadm/app/preflight/checks.go
+++ b/cmd/kubeadm/app/preflight/checks.go
@@ -24,7 +24,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"net/url"
@@ -741,7 +740,7 @@ func (evc ExternalEtcdVersionCheck) Check() (warnings, errorList []error) {
 func (evc ExternalEtcdVersionCheck) configRootCAs(config *tls.Config) (*tls.Config, error) {
 	var CACertPool *x509.CertPool
 	if evc.Etcd.External.CAFile != "" {
-		CACert, err := ioutil.ReadFile(evc.Etcd.External.CAFile)
+		CACert, err := os.ReadFile(evc.Etcd.External.CAFile)
 		if err != nil {
 			return nil, errors.Wrapf(err, "couldn't load external etcd's server certificate %s", evc.Etcd.External.CAFile)
 		}

--- a/cmd/kubeadm/app/preflight/checks_test.go
+++ b/cmd/kubeadm/app/preflight/checks_test.go
@@ -19,7 +19,6 @@ package preflight
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"os"
@@ -335,7 +334,7 @@ func TestFileContentCheck(t *testing.T) {
 }
 
 func TestDirAvailableCheck(t *testing.T) {
-	fileDir, err := ioutil.TempDir("", "dir-avail-check")
+	fileDir, err := os.MkdirTemp("", "dir-avail-check")
 	if err != nil {
 		t.Fatalf("failed creating directory: %v", err)
 	}
@@ -455,12 +454,12 @@ func TestRunChecks(t *testing.T) {
 	}
 }
 func TestConfigRootCAs(t *testing.T) {
-	f, err := ioutil.TempFile(os.TempDir(), "kubeadm-external-etcd-test-cafile")
+	f, err := os.CreateTemp(os.TempDir(), "kubeadm-external-etcd-test-cafile")
 	if err != nil {
 		t.Errorf("failed configRootCAs:\n\texpected: succeed creating temp CA file\n\tactual:%v", err)
 	}
 	defer os.Remove(f.Name())
-	if err := ioutil.WriteFile(f.Name(), []byte(externalEtcdRootCAFileContent), 0644); err != nil {
+	if err := os.WriteFile(f.Name(), []byte(externalEtcdRootCAFileContent), 0644); err != nil {
 		t.Errorf("failed configRootCAs:\n\texpected: succeed writing contents to temp CA file %s\n\tactual:%v", f.Name(), err)
 	}
 
@@ -481,7 +480,7 @@ func TestConfigRootCAs(t *testing.T) {
 	}
 }
 func TestConfigCertAndKey(t *testing.T) {
-	certFile, err := ioutil.TempFile(os.TempDir(), "kubeadm-external-etcd-test-certfile")
+	certFile, err := os.CreateTemp(os.TempDir(), "kubeadm-external-etcd-test-certfile")
 	if err != nil {
 		t.Errorf(
 			"failed configCertAndKey:\n\texpected: succeed creating temp CertFile file\n\tactual:%v",
@@ -489,7 +488,7 @@ func TestConfigCertAndKey(t *testing.T) {
 		)
 	}
 	defer os.Remove(certFile.Name())
-	if err := ioutil.WriteFile(certFile.Name(), []byte(externalEtcdCertFileContent), 0644); err != nil {
+	if err := os.WriteFile(certFile.Name(), []byte(externalEtcdCertFileContent), 0644); err != nil {
 		t.Errorf(
 			"failed configCertAndKey:\n\texpected: succeed writing contents to temp CertFile file %s\n\tactual:%v",
 			certFile.Name(),
@@ -497,7 +496,7 @@ func TestConfigCertAndKey(t *testing.T) {
 		)
 	}
 
-	keyFile, err := ioutil.TempFile(os.TempDir(), "kubeadm-external-etcd-test-keyfile")
+	keyFile, err := os.CreateTemp(os.TempDir(), "kubeadm-external-etcd-test-keyfile")
 	if err != nil {
 		t.Errorf(
 			"failed configCertAndKey:\n\texpected: succeed creating temp KeyFile file\n\tactual:%v",
@@ -505,7 +504,7 @@ func TestConfigCertAndKey(t *testing.T) {
 		)
 	}
 	defer os.Remove(keyFile.Name())
-	if err := ioutil.WriteFile(keyFile.Name(), []byte(externalEtcdKeyFileContent), 0644); err != nil {
+	if err := os.WriteFile(keyFile.Name(), []byte(externalEtcdKeyFileContent), 0644); err != nil {
 		t.Errorf(
 			"failed configCertAndKey:\n\texpected: succeed writing contents to temp KeyFile file %s\n\tactual:%v",
 			keyFile.Name(),

--- a/cmd/kubeadm/app/util/config/cluster_test.go
+++ b/cmd/kubeadm/app/util/config/cluster_test.go
@@ -19,7 +19,6 @@ package config
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -199,7 +198,7 @@ G+2/lm8TaVjoU7Fi5Ka5G5HY2GLaR7P+IxYcrMHCl62Y7Rqcrnc=
 }
 
 func TestGetNodeNameFromKubeletConfig(t *testing.T) {
-	tmpdir, err := ioutil.TempDir("", "")
+	tmpdir, err := os.MkdirTemp("", "")
 	if err != nil {
 		t.Fatalf("Couldn't create tmpdir")
 	}
@@ -246,7 +245,7 @@ func TestGetNodeNameFromKubeletConfig(t *testing.T) {
 		t.Run(rt.name, func(t2 *testing.T) {
 			if len(rt.pemContent) > 0 {
 				pemPath := filepath.Join(tmpdir, "kubelet.pem")
-				err := ioutil.WriteFile(pemPath, rt.pemContent, 0644)
+				err := os.WriteFile(pemPath, rt.pemContent, 0644)
 				if err != nil {
 					t.Errorf("Couldn't create pem file: %v", err)
 					return
@@ -255,7 +254,7 @@ func TestGetNodeNameFromKubeletConfig(t *testing.T) {
 			}
 
 			kubeconfigPath := filepath.Join(tmpdir, kubeadmconstants.KubeletKubeConfigFileName)
-			err := ioutil.WriteFile(kubeconfigPath, rt.kubeconfigContent, 0644)
+			err := os.WriteFile(kubeconfigPath, rt.kubeconfigContent, 0644)
 			if err != nil {
 				t.Errorf("Couldn't create kubeconfig: %v", err)
 				return
@@ -278,7 +277,7 @@ func TestGetNodeNameFromKubeletConfig(t *testing.T) {
 }
 
 func TestGetNodeRegistration(t *testing.T) {
-	tmpdir, err := ioutil.TempDir("", "")
+	tmpdir, err := os.MkdirTemp("", "")
 	if err != nil {
 		t.Fatalf("Couldn't create tmpdir")
 	}
@@ -320,7 +319,7 @@ func TestGetNodeRegistration(t *testing.T) {
 		t.Run(rt.name, func(t2 *testing.T) {
 			cfgPath := filepath.Join(tmpdir, kubeadmconstants.KubeletKubeConfigFileName)
 			if len(rt.fileContents) > 0 {
-				err := ioutil.WriteFile(cfgPath, rt.fileContents, 0644)
+				err := os.WriteFile(cfgPath, rt.fileContents, 0644)
 				if err != nil {
 					t.Errorf("Couldn't create file")
 					return
@@ -491,7 +490,7 @@ func TestGetAPIEndpointWithBackoff(t *testing.T) {
 }
 
 func TestGetInitConfigurationFromCluster(t *testing.T) {
-	tmpdir, err := ioutil.TempDir("", "")
+	tmpdir, err := os.MkdirTemp("", "")
 	if err != nil {
 		t.Fatalf("Couldn't create tmpdir")
 	}
@@ -680,7 +679,7 @@ func TestGetInitConfigurationFromCluster(t *testing.T) {
 		t.Run(rt.name, func(t *testing.T) {
 			cfgPath := filepath.Join(tmpdir, kubeadmconstants.KubeletKubeConfigFileName)
 			if len(rt.fileContents) > 0 {
-				err := ioutil.WriteFile(cfgPath, rt.fileContents, 0644)
+				err := os.WriteFile(cfgPath, rt.fileContents, 0644)
 				if err != nil {
 					t.Errorf("Couldn't create file")
 					return

--- a/cmd/kubeadm/app/util/config/initconfiguration.go
+++ b/cmd/kubeadm/app/util/config/initconfiguration.go
@@ -18,8 +18,8 @@ package config
 
 import (
 	"bytes"
-	"io/ioutil"
 	"net"
+	"os"
 	"strconv"
 	"strings"
 
@@ -254,7 +254,7 @@ func DefaultedInitConfiguration(versionedInitCfg *kubeadmapiv1.InitConfiguration
 func LoadInitConfigurationFromFile(cfgPath string) (*kubeadmapi.InitConfiguration, error) {
 	klog.V(1).Infof("loading configuration from %q", cfgPath)
 
-	b, err := ioutil.ReadFile(cfgPath)
+	b, err := os.ReadFile(cfgPath)
 	if err != nil {
 		return nil, errors.Wrapf(err, "unable to read config from %q ", cfgPath)
 	}

--- a/cmd/kubeadm/app/util/config/initconfiguration_test.go
+++ b/cmd/kubeadm/app/util/config/initconfiguration_test.go
@@ -18,7 +18,6 @@ package config
 
 import (
 	"bytes"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -33,7 +32,7 @@ import (
 
 func TestLoadInitConfigurationFromFile(t *testing.T) {
 	// Create temp folder for the test case
-	tmpdir, err := ioutil.TempDir("", "")
+	tmpdir, err := os.MkdirTemp("", "")
 	if err != nil {
 		t.Fatalf("Couldn't create tmpdir: %v", err)
 	}
@@ -84,7 +83,7 @@ func TestLoadInitConfigurationFromFile(t *testing.T) {
 	for _, rt := range tests {
 		t.Run(rt.name, func(t2 *testing.T) {
 			cfgPath := filepath.Join(tmpdir, rt.name)
-			err := ioutil.WriteFile(cfgPath, rt.fileContents, 0644)
+			err := os.WriteFile(cfgPath, rt.fileContents, 0644)
 			if err != nil {
 				t.Errorf("Couldn't create file: %v", err)
 				return

--- a/cmd/kubeadm/app/util/config/joinconfiguration.go
+++ b/cmd/kubeadm/app/util/config/joinconfiguration.go
@@ -17,7 +17,7 @@ limitations under the License.
 package config
 
 import (
-	"io/ioutil"
+	"os"
 
 	"github.com/pkg/errors"
 
@@ -75,7 +75,7 @@ func LoadOrDefaultJoinConfiguration(cfgPath string, defaultversionedcfg *kubeadm
 func LoadJoinConfigurationFromFile(cfgPath string) (*kubeadmapi.JoinConfiguration, error) {
 	klog.V(1).Infof("loading configuration from %q", cfgPath)
 
-	b, err := ioutil.ReadFile(cfgPath)
+	b, err := os.ReadFile(cfgPath)
 	if err != nil {
 		return nil, errors.Wrapf(err, "unable to read config from %q ", cfgPath)
 	}

--- a/cmd/kubeadm/app/util/config/joinconfiguration_test.go
+++ b/cmd/kubeadm/app/util/config/joinconfiguration_test.go
@@ -18,7 +18,6 @@ package config
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -30,7 +29,7 @@ import (
 
 func TestLoadJoinConfigurationFromFile(t *testing.T) {
 	// Create temp folder for the test case
-	tmpdir, err := ioutil.TempDir("", "")
+	tmpdir, err := os.MkdirTemp("", "")
 	if err != nil {
 		t.Fatalf("Couldn't create tmpdir: %v", err)
 	}
@@ -97,7 +96,7 @@ func TestLoadJoinConfigurationFromFile(t *testing.T) {
 	for _, rt := range tests {
 		t.Run(rt.name, func(t2 *testing.T) {
 			cfgPath := filepath.Join(tmpdir, rt.name)
-			err := ioutil.WriteFile(cfgPath, []byte(rt.fileContents), 0644)
+			err := os.WriteFile(cfgPath, []byte(rt.fileContents), 0644)
 			if err != nil {
 				t.Errorf("Couldn't create file: %v", err)
 				return

--- a/cmd/kubeadm/app/util/config/strict/strict_test.go
+++ b/cmd/kubeadm/app/util/config/strict/strict_test.go
@@ -17,7 +17,7 @@ limitations under the License.
 package strict
 
 import (
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -143,7 +143,7 @@ func TestVerifyUnmarshalStrict(t *testing.T) {
 
 	for _, test := range testFiles {
 		t.Run(test.fileName, func(t *testing.T) {
-			bytes, err := ioutil.ReadFile(filepath.Join(pathTestData, test.fileName))
+			bytes, err := os.ReadFile(filepath.Join(pathTestData, test.fileName))
 			if err != nil {
 				t.Fatalf("couldn't read test data: %v", err)
 			}

--- a/cmd/kubeadm/app/util/dryrun/dryrun.go
+++ b/cmd/kubeadm/app/util/dryrun/dryrun.go
@@ -19,7 +19,7 @@ package dryrun
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"time"
 
@@ -61,7 +61,7 @@ func PrintDryRunFiles(files []FileToPrint, w io.Writer) error {
 			continue
 		}
 
-		fileBytes, err := ioutil.ReadFile(file.RealPath)
+		fileBytes, err := os.ReadFile(file.RealPath)
 		if err != nil {
 			errs = append(errs, err)
 			continue

--- a/cmd/kubeadm/app/util/kubeconfig/kubeconfig.go
+++ b/cmd/kubeadm/app/util/kubeconfig/kubeconfig.go
@@ -18,7 +18,7 @@ package kubeconfig
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 
 	"github.com/pkg/errors"
 
@@ -151,7 +151,7 @@ func EnsureAuthenticationInfoAreEmbedded(config *clientcmdapi.Config) error {
 	}
 
 	if len(authInfo.ClientCertificateData) == 0 && len(authInfo.ClientCertificate) != 0 {
-		clientCert, err := ioutil.ReadFile(authInfo.ClientCertificate)
+		clientCert, err := os.ReadFile(authInfo.ClientCertificate)
 		if err != nil {
 			return errors.Wrap(err, "error while reading client cert file defined in kubeconfig")
 		}
@@ -159,7 +159,7 @@ func EnsureAuthenticationInfoAreEmbedded(config *clientcmdapi.Config) error {
 		authInfo.ClientCertificate = ""
 	}
 	if len(authInfo.ClientKeyData) == 0 && len(authInfo.ClientKey) != 0 {
-		clientKey, err := ioutil.ReadFile(authInfo.ClientKey)
+		clientKey, err := os.ReadFile(authInfo.ClientKey)
 		if err != nil {
 			return errors.Wrap(err, "error while reading client key file defined in kubeconfig")
 		}
@@ -178,7 +178,7 @@ func EnsureCertificateAuthorityIsEmbedded(cluster *clientcmdapi.Cluster) error {
 	}
 
 	if len(cluster.CertificateAuthorityData) == 0 && len(cluster.CertificateAuthority) != 0 {
-		ca, err := ioutil.ReadFile(cluster.CertificateAuthority)
+		ca, err := os.ReadFile(cluster.CertificateAuthority)
 		if err != nil {
 			return errors.Wrap(err, "error while reading certificate authority file defined in kubeconfig")
 		}

--- a/cmd/kubeadm/app/util/kubeconfig/kubeconfig_test.go
+++ b/cmd/kubeadm/app/util/kubeconfig/kubeconfig_test.go
@@ -19,7 +19,6 @@ package kubeconfig
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -143,7 +142,7 @@ func TestCreateWithToken(t *testing.T) {
 }
 
 func TestWriteKubeconfigToDisk(t *testing.T) {
-	tmpdir, err := ioutil.TempDir("", "")
+	tmpdir, err := os.MkdirTemp("", "")
 	if err != nil {
 		t.Fatalf("Couldn't create tmpdir")
 	}
@@ -177,7 +176,7 @@ func TestWriteKubeconfigToDisk(t *testing.T) {
 					err,
 				)
 			}
-			newFile, _ := ioutil.ReadFile(configPath)
+			newFile, _ := os.ReadFile(configPath)
 			if !bytes.Equal(newFile, rt.file) {
 				t.Errorf(
 					"failed WriteToDisk config write:\n\texpected: %s\n\t  actual: %s",

--- a/cmd/kubeadm/app/util/patches/patches.go
+++ b/cmd/kubeadm/app/util/patches/patches.go
@@ -21,7 +21,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -104,7 +103,7 @@ func GetPatchManagerForPath(path string, knownTargets []string, output io.Writer
 	pathLock.RUnlock()
 
 	if output == nil {
-		output = ioutil.Discard
+		output = io.Discard
 	}
 
 	fmt.Fprintf(output, "[patches] Reading patches from path %q\n", path)
@@ -316,7 +315,7 @@ func getPatchSetsFromPath(targetPath string, knownTargets []string, output io.Wr
 		}
 
 		// Read the patch file.
-		data, err := ioutil.ReadFile(path)
+		data, err := os.ReadFile(path)
 		if err != nil {
 			return errors.Wrapf(err, "could not read the file %q", path)
 		}

--- a/cmd/kubeadm/app/util/patches/patches_test.go
+++ b/cmd/kubeadm/app/util/patches/patches_test.go
@@ -18,7 +18,7 @@ package patches
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -173,7 +173,7 @@ func TestGetPatchSetsForPathMustBeDirectory(t *testing.T) {
 	}
 	defer os.Remove(tempFile.Name())
 
-	_, _, _, err = getPatchSetsFromPath(tempFile.Name(), testKnownTargets, ioutil.Discard)
+	_, _, _, err = getPatchSetsFromPath(tempFile.Name(), testKnownTargets, io.Discard)
 	var pathErr *os.PathError
 	if !errors.As(err, &pathErr) {
 		t.Fatalf("expected os.PathError for non-directory path %q, but got %v", tempFile.Name(), err)
@@ -233,7 +233,7 @@ func TestGetPatchSetsForPath(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			tempDir, err := ioutil.TempDir("", testDirPattern)
+			tempDir, err := os.MkdirTemp("", testDirPattern)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -241,13 +241,13 @@ func TestGetPatchSetsForPath(t *testing.T) {
 
 			for _, file := range tc.filesToWrite {
 				filePath := filepath.Join(tempDir, file)
-				err := ioutil.WriteFile(filePath, []byte(tc.patchData), 0644)
+				err := os.WriteFile(filePath, []byte(tc.patchData), 0644)
 				if err != nil {
 					t.Fatalf("could not write temporary file %q", filePath)
 				}
 			}
 
-			patchSets, patchFiles, ignoredFiles, err := getPatchSetsFromPath(tempDir, testKnownTargets, ioutil.Discard)
+			patchSets, patchFiles, ignoredFiles, err := getPatchSetsFromPath(tempDir, testKnownTargets, io.Discard)
 			if (err != nil) != tc.expectedError {
 				t.Fatalf("expected error: %v, got: %v, error: %v", tc.expectedError, err != nil, err)
 			}
@@ -361,7 +361,7 @@ func TestGetPatchManagerForPath(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			tempDir, err := ioutil.TempDir("", testDirPattern)
+			tempDir, err := os.MkdirTemp("", testDirPattern)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -369,7 +369,7 @@ func TestGetPatchManagerForPath(t *testing.T) {
 
 			for _, file := range tc.files {
 				filePath := filepath.Join(tempDir, file.name)
-				err := ioutil.WriteFile(filePath, []byte(file.data), 0644)
+				err := os.WriteFile(filePath, []byte(file.data), 0644)
 				if err != nil {
 					t.Fatalf("could not write temporary file %q", filePath)
 				}
@@ -396,7 +396,7 @@ func TestGetPatchManagerForPath(t *testing.T) {
 }
 
 func TestGetPatchManagerForPathCache(t *testing.T) {
-	tempDir, err := ioutil.TempDir("", testDirPattern)
+	tempDir, err := os.MkdirTemp("", testDirPattern)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/kubeadm/app/util/pkiutil/pki_helpers.go
+++ b/cmd/kubeadm/app/util/pkiutil/pki_helpers.go
@@ -27,7 +27,6 @@ import (
 	"crypto/x509/pkix"
 	"encoding/pem"
 	"fmt"
-	"io/ioutil"
 	"math"
 	"math/big"
 	"net"
@@ -217,7 +216,7 @@ func WriteCSR(csrDir, name string, csr *x509.CertificateRequest) error {
 		return errors.Wrapf(err, "failed to make directory %s", filepath.Dir(csrPath))
 	}
 
-	if err := ioutil.WriteFile(csrPath, EncodeCSRPEM(csr), os.FileMode(0600)); err != nil {
+	if err := os.WriteFile(csrPath, EncodeCSRPEM(csr), os.FileMode(0600)); err != nil {
 		return errors.Wrapf(err, "unable to write CSR to file %s", csrPath)
 	}
 
@@ -550,7 +549,7 @@ func parseCSRPEM(pemCSR []byte) (*x509.CertificateRequest, error) {
 // CertificateRequestFromFile returns the CertificateRequest from a given PEM-encoded file.
 // Returns an error if the file could not be read or if the CSR could not be parsed.
 func CertificateRequestFromFile(file string) (*x509.CertificateRequest, error) {
-	pemBlock, err := ioutil.ReadFile(file)
+	pemBlock, err := os.ReadFile(file)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to read file")
 	}

--- a/cmd/kubeadm/app/util/pkiutil/pki_helpers_test.go
+++ b/cmd/kubeadm/app/util/pkiutil/pki_helpers_test.go
@@ -23,7 +23,6 @@ import (
 	"crypto/rand"
 	"crypto/x509"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"os"
 	"reflect"
@@ -176,7 +175,7 @@ func TestHasServerAuth(t *testing.T) {
 }
 
 func TestWriteCertAndKey(t *testing.T) {
-	tmpdir, err := ioutil.TempDir("", "")
+	tmpdir, err := os.MkdirTemp("", "")
 	if err != nil {
 		t.Fatalf("Couldn't create tmpdir")
 	}
@@ -193,7 +192,7 @@ func TestWriteCertAndKey(t *testing.T) {
 }
 
 func TestWriteCert(t *testing.T) {
-	tmpdir, err := ioutil.TempDir("", "")
+	tmpdir, err := os.MkdirTemp("", "")
 	if err != nil {
 		t.Fatalf("Couldn't create tmpdir")
 	}
@@ -210,7 +209,7 @@ func TestWriteCert(t *testing.T) {
 }
 
 func TestWriteCertBundle(t *testing.T) {
-	tmpdir, err := ioutil.TempDir("", "")
+	tmpdir, err := os.MkdirTemp("", "")
 	if err != nil {
 		t.Fatalf("Couldn't create tmpdir")
 	}
@@ -225,7 +224,7 @@ func TestWriteCertBundle(t *testing.T) {
 }
 
 func TestWriteKey(t *testing.T) {
-	tmpdir, err := ioutil.TempDir("", "")
+	tmpdir, err := os.MkdirTemp("", "")
 	if err != nil {
 		t.Fatalf("Couldn't create tmpdir")
 	}
@@ -241,7 +240,7 @@ func TestWriteKey(t *testing.T) {
 }
 
 func TestWritePublicKey(t *testing.T) {
-	tmpdir, err := ioutil.TempDir("", "")
+	tmpdir, err := os.MkdirTemp("", "")
 	if err != nil {
 		t.Fatalf("Couldn't create tmpdir")
 	}
@@ -257,7 +256,7 @@ func TestWritePublicKey(t *testing.T) {
 }
 
 func TestCertOrKeyExist(t *testing.T) {
-	tmpdir, err := ioutil.TempDir("", "")
+	tmpdir, err := os.MkdirTemp("", "")
 	if err != nil {
 		t.Fatalf("Couldn't create tmpdir")
 	}
@@ -306,7 +305,7 @@ func TestCertOrKeyExist(t *testing.T) {
 }
 
 func TestTryLoadCertAndKeyFromDisk(t *testing.T) {
-	tmpdir, err := ioutil.TempDir("", "")
+	tmpdir, err := os.MkdirTemp("", "")
 	if err != nil {
 		t.Fatalf("Couldn't create tmpdir")
 	}
@@ -354,7 +353,7 @@ func TestTryLoadCertAndKeyFromDisk(t *testing.T) {
 }
 
 func TestTryLoadCertFromDisk(t *testing.T) {
-	tmpdir, err := ioutil.TempDir("", "")
+	tmpdir, err := os.MkdirTemp("", "")
 	if err != nil {
 		t.Fatalf("Couldn't create tmpdir")
 	}
@@ -402,7 +401,7 @@ func TestTryLoadCertFromDisk(t *testing.T) {
 }
 
 func TestTryLoadCertChainFromDisk(t *testing.T) {
-	tmpdir, err := ioutil.TempDir("", "")
+	tmpdir, err := os.MkdirTemp("", "")
 	if err != nil {
 		t.Fatalf("Couldn't create tmpdir")
 	}
@@ -502,7 +501,7 @@ func TestTryLoadKeyFromDisk(t *testing.T) {
 	}
 	for _, rt := range tests {
 		t.Run(rt.desc, func(t *testing.T) {
-			tmpdir, err := ioutil.TempDir("", "")
+			tmpdir, err := os.MkdirTemp("", "")
 			if err != nil {
 				t.Fatalf("Couldn't create tmpdir")
 			}
@@ -849,7 +848,7 @@ func TestRemoveDuplicateAltNames(t *testing.T) {
 }
 
 func TestVerifyCertChain(t *testing.T) {
-	tmpdir, err := ioutil.TempDir("", "")
+	tmpdir, err := os.MkdirTemp("", "")
 	if err != nil {
 		t.Fatalf("Couldn't create tmpdir")
 	}

--- a/cmd/kubeadm/app/util/runtime/runtime_test.go
+++ b/cmd/kubeadm/app/util/runtime/runtime_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package runtime
 
 import (
-	"io/ioutil"
 	"net"
 	"os"
 	"reflect"
@@ -314,7 +313,7 @@ func TestIsExistingSocket(t *testing.T) {
 		{
 			name: "Valid domain socket is detected as such",
 			proc: func(t *testing.T) {
-				tmpFile, err := ioutil.TempFile("", tempPrefix)
+				tmpFile, err := os.CreateTemp("", tempPrefix)
 				if err != nil {
 					t.Fatalf("unexpected error by TempFile: %v", err)
 				}
@@ -336,7 +335,7 @@ func TestIsExistingSocket(t *testing.T) {
 		{
 			name: "Regular file is not a domain socket",
 			proc: func(t *testing.T) {
-				tmpFile, err := ioutil.TempFile("", tempPrefix)
+				tmpFile, err := os.CreateTemp("", tempPrefix)
 				if err != nil {
 					t.Fatalf("unexpected error by TempFile: %v", err)
 				}

--- a/cmd/kubeadm/app/util/staticpod/utils.go
+++ b/cmd/kubeadm/app/util/staticpod/utils.go
@@ -20,7 +20,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math"
 	"net/url"
 	"os"
@@ -219,7 +218,7 @@ func WriteStaticPodToDisk(componentName, manifestDir string, pod v1.Pod) error {
 
 	filename := kubeadmconstants.GetStaticPodFilepath(componentName, manifestDir)
 
-	if err := ioutil.WriteFile(filename, serialized, 0600); err != nil {
+	if err := os.WriteFile(filename, serialized, 0600); err != nil {
 		return errors.Wrapf(err, "failed to write static pod manifest file for %q (%q)", componentName, filename)
 	}
 
@@ -228,7 +227,7 @@ func WriteStaticPodToDisk(componentName, manifestDir string, pod v1.Pod) error {
 
 // ReadStaticPodFromDisk reads a static pod file from disk
 func ReadStaticPodFromDisk(manifestPath string) (*v1.Pod, error) {
-	buf, err := ioutil.ReadFile(manifestPath)
+	buf, err := os.ReadFile(manifestPath)
 	if err != nil {
 		return &v1.Pod{}, errors.Wrapf(err, "failed to read manifest for %q", manifestPath)
 	}
@@ -362,11 +361,11 @@ func GetEtcdProbeEndpoint(cfg *kubeadmapi.Etcd, isIPv6 bool) (string, int, v1.UR
 
 // ManifestFilesAreEqual compares 2 files. It returns true if their contents are equal, false otherwise
 func ManifestFilesAreEqual(path1, path2 string) (bool, error) {
-	content1, err := ioutil.ReadFile(path1)
+	content1, err := os.ReadFile(path1)
 	if err != nil {
 		return false, err
 	}
-	content2, err := ioutil.ReadFile(path2)
+	content2, err := os.ReadFile(path2)
 	if err != nil {
 		return false, err
 	}

--- a/cmd/kubeadm/app/util/staticpod/utils_test.go
+++ b/cmd/kubeadm/app/util/staticpod/utils_test.go
@@ -17,7 +17,7 @@ limitations under the License.
 package staticpod
 
 import (
-	"io/ioutil"
+	"io"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -664,7 +664,7 @@ func TestReadStaticPodFromDisk(t *testing.T) {
 
 			manifestPath := filepath.Join(tmpdir, "pod.yaml")
 			if rt.writeManifest {
-				err := ioutil.WriteFile(manifestPath, []byte(rt.podYaml), 0644)
+				err := os.WriteFile(manifestPath, []byte(rt.podYaml), 0644)
 				if err != nil {
 					t.Fatalf("Failed to write pod manifest\n%s\n\tfatal error: %v", rt.description, err)
 				}
@@ -726,7 +726,7 @@ func TestManifestFilesAreEqual(t *testing.T) {
 			for i := 0; i < 2; i++ {
 				if rt.podYamls[i] != "" {
 					manifestPath := filepath.Join(tmpdir, strconv.Itoa(i)+".yaml")
-					err := ioutil.WriteFile(manifestPath, []byte(rt.podYamls[i]), 0644)
+					err := os.WriteFile(manifestPath, []byte(rt.podYamls[i]), 0644)
 					if err != nil {
 						t.Fatalf("Failed to write manifest file\n%s\n\tfatal error: %v", rt.description, err)
 					}
@@ -808,7 +808,7 @@ func TestPatchStaticPod(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			tempDir, err := ioutil.TempDir("", "patch-files")
+			tempDir, err := os.MkdirTemp("", "patch-files")
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -816,13 +816,13 @@ func TestPatchStaticPod(t *testing.T) {
 
 			for _, file := range tc.files {
 				filePath := filepath.Join(tempDir, file.name)
-				err := ioutil.WriteFile(filePath, []byte(file.data), 0644)
+				err := os.WriteFile(filePath, []byte(file.data), 0644)
 				if err != nil {
 					t.Fatalf("could not write temporary file %q", filePath)
 				}
 			}
 
-			pod, err := PatchStaticPod(tc.pod, tempDir, ioutil.Discard)
+			pod, err := PatchStaticPod(tc.pod, tempDir, io.Discard)
 			if (err != nil) != tc.expectedError {
 				t.Fatalf("expected error: %v, got: %v, error: %v", tc.expectedError, (err != nil), err)
 			}

--- a/cmd/kubeadm/app/util/users/users_linux_test.go
+++ b/cmd/kubeadm/app/util/users/users_linux_test.go
@@ -20,7 +20,6 @@ limitations under the License.
 package users
 
 import (
-	"io/ioutil"
 	"os"
 	"reflect"
 	"testing"
@@ -572,11 +571,11 @@ func TestRemoveUsersAndGroups(t *testing.T) {
 }
 
 func writeTempFile(t *testing.T, contents string) (string, func()) {
-	file, err := ioutil.TempFile("", "")
+	file, err := os.CreateTemp("", "")
 	if err != nil {
 		t.Fatalf("could not create file: %v", err)
 	}
-	if err := ioutil.WriteFile(file.Name(), []byte(contents), os.ModePerm); err != nil {
+	if err := os.WriteFile(file.Name(), []byte(contents), os.ModePerm); err != nil {
 		t.Fatalf("could not write file: %v", err)
 	}
 	close := func() {
@@ -586,7 +585,7 @@ func writeTempFile(t *testing.T, contents string) (string, func()) {
 }
 
 func readTempFile(t *testing.T, path string) string {
-	b, err := ioutil.ReadFile(path)
+	b, err := os.ReadFile(path)
 	if err != nil {
 		t.Fatalf("could not read file: %v", err)
 	}

--- a/cmd/kubeadm/app/util/version.go
+++ b/cmd/kubeadm/app/util/version.go
@@ -18,7 +18,7 @@ package util
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -190,7 +190,7 @@ func fetchFromURL(url string, timeout time.Duration) (string, error) {
 		return "", errors.Errorf("unable to get URL %q: %s", url, err.Error())
 	}
 	defer resp.Body.Close()
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return "", errors.Errorf("unable to read content of URL %q: %s", url, err.Error())
 	}

--- a/cmd/kubeadm/test/util.go
+++ b/cmd/kubeadm/test/util.go
@@ -17,7 +17,6 @@ limitations under the License.
 package test
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -32,7 +31,7 @@ import (
 // SetupTempDir is a utility function for kubeadm testing, that creates a temporary directory
 // NB. it is up to the caller to cleanup the folder at the end of the test with defer os.RemoveAll(tmpdir)
 func SetupTempDir(t *testing.T) string {
-	tmpdir, err := ioutil.TempDir("", "")
+	tmpdir, err := os.MkdirTemp("", "")
 	if err != nil {
 		t.Fatalf("Couldn't create tmpdir")
 	}
@@ -68,7 +67,7 @@ func SetupPkiDirWithCertificateAuthority(t *testing.T, tmpdir string) string {
 // AssertFilesCount is a utility function for kubeadm testing that asserts if the given folder contains
 // count files.
 func AssertFilesCount(t *testing.T, dirName string, count int) {
-	files, err := ioutil.ReadDir(dirName)
+	files, err := os.ReadDir(dirName)
 	if err != nil {
 		t.Fatalf("Couldn't read files from tmpdir: %s", err)
 	}

--- a/cmd/kubelet/app/server_bootstrap_test.go
+++ b/cmd/kubelet/app/server_bootstrap_test.go
@@ -24,7 +24,7 @@ import (
 	"crypto/x509/pkix"
 	"encoding/json"
 	"encoding/pem"
-	"io/ioutil"
+	"io"
 	"math/big"
 	"net/http"
 	"net/http/httptest"
@@ -48,7 +48,7 @@ import (
 // manager that will use the bootstrap client until we get a valid cert, then use our
 // provided identity on subsequent requests.
 func Test_buildClientCertificateManager(t *testing.T) {
-	testDir, err := ioutil.TempDir("", "kubeletcert")
+	testDir, err := os.MkdirTemp("", "kubeletcert")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -134,7 +134,7 @@ func Test_buildClientCertificateManager(t *testing.T) {
 }
 
 func Test_buildClientCertificateManager_populateCertDir(t *testing.T) {
-	testDir, err := ioutil.TempDir("", "kubeletcert")
+	testDir, err := os.MkdirTemp("", "kubeletcert")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -215,7 +215,7 @@ func getCSR(req *http.Request) (*certapi.CertificateSigningRequest, error) {
 	if req.Body == nil {
 		return nil, nil
 	}
-	body, err := ioutil.ReadAll(req.Body)
+	body, err := io.ReadAll(req.Body)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/linkcheck/links.go
+++ b/cmd/linkcheck/links.go
@@ -23,7 +23,6 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -81,7 +80,7 @@ func newWalkFunc(invalidLink *bool, client *http.Client) filepath.WalkFunc {
 			return nil
 		}
 
-		fileBytes, err := ioutil.ReadFile(filePath)
+		fileBytes, err := os.ReadFile(filePath)
 		if err != nil {
 			return err
 		}

--- a/cmd/preferredimports/preferredimports.go
+++ b/cmd/preferredimports/preferredimports.go
@@ -27,7 +27,6 @@ import (
 	"go/format"
 	"go/parser"
 	"go/token"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -129,7 +128,7 @@ func (a *analyzer) collect(dir string) {
 						panic(fmt.Sprintf("Error stat'ing file: %s\n%s\n", pathToFile, err.Error()))
 					}
 
-					err = ioutil.WriteFile(pathToFile, buffer.Bytes(), fileInfo.Mode())
+					err = os.WriteFile(pathToFile, buffer.Bytes(), fileInfo.Mode())
 					if err != nil {
 						panic(fmt.Sprintf("Error writing file: %s\n%s\n", pathToFile, err.Error()))
 					}
@@ -235,7 +234,7 @@ func main() {
 	sort.Strings(c.dirs)
 
 	if len(*importAliases) > 0 {
-		bytes, err := ioutil.ReadFile(*importAliases)
+		bytes, err := os.ReadFile(*importAliases)
 		if err != nil {
 			log.Fatalf("Error reading import aliases: %v", err)
 		}

--- a/cmd/yamlfmt/yamlfmt.go
+++ b/cmd/yamlfmt/yamlfmt.go
@@ -19,7 +19,6 @@ package main
 import (
 	"flag"
 	"io"
-	"io/ioutil"
 	"os"
 
 	"gopkg.in/yaml.v3"
@@ -31,7 +30,7 @@ func main() {
 
 	if flag.NArg() > 0 {
 		for _, path := range flag.Args() {
-			sourceYaml, err := ioutil.ReadFile(path)
+			sourceYaml, err := os.ReadFile(path)
 			if err != nil {
 				panic(err)
 			}


### PR DESCRIPTION
The ioutil package has already been deprecated in golang 1.16, please see [go1.16#ioutil](https://golang.org/doc/go1.16#ioutil). So we need to replace all the io/ioutil with os and io.

This PR is just to update the cmd. There will be a couple of separate PRs for another SIGs.

Fix https://github.com/kubernetes/kubernetes/issues/100367 