### PR TITLE
storage: delete unnecessary nil cmp in volume util

### DIFF
--- a/pkg/volume/util/operationexecutor/operation_generator.go
+++ b/pkg/volume/util/operationexecutor/operation_generator.go
@@ -513,9 +513,6 @@ func (og *operationGenerator) GenerateMountVolumeFunc(
 	}
 
 	mountVolumeFunc := func() volumetypes.OperationContext {
-		// Get mounter plugin
-		volumePlugin, err := og.volumePluginMgr.FindPluginBySpec(volumeToMount.VolumeSpec)
-
 		migrated := getMigratedStatusBySpec(volumeToMount.VolumeSpec)
 
 		if err != nil {

--- a/pkg/volume/util/operationexecutor/operation_generator.go
+++ b/pkg/volume/util/operationexecutor/operation_generator.go
@@ -508,7 +508,7 @@ func (og *operationGenerator) GenerateMountVolumeFunc(
 	volumePluginName := unknownVolumePlugin
 	volumePlugin, err :=
 		og.volumePluginMgr.FindPluginBySpec(volumeToMount.VolumeSpec)
-	if err == nil && volumePlugin != nil {
+	if err == nil {
 		volumePluginName = volumePlugin.GetPluginName()
 	}
 
@@ -518,7 +518,7 @@ func (og *operationGenerator) GenerateMountVolumeFunc(
 
 		migrated := getMigratedStatusBySpec(volumeToMount.VolumeSpec)
 
-		if err != nil || volumePlugin == nil {
+		if err != nil {
 			eventErr, detailedErr := volumeToMount.GenerateError("MountVolume.FindPluginBySpec failed", err)
 			return volumetypes.NewOperationContext(eventErr, detailedErr, migrated)
 		}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind cleanup

#### What this PR does / why we need it:

When returned err is nil, the volumePlugin won't be nil.

BTW, interface compare with nil shoud contains type with it.
```golang
if volumePlugin == (volume.VolumePlugin)(nil) {
 ...
}
```
