### PR TITLE
Automated cherry pick of #105253: fix: leave the probe path empty for TCP probes

### DIFF
--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_loadbalancer.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_loadbalancer.go
@@ -1665,7 +1665,8 @@ func (az *Cloud) reconcileLoadBalancerRule(
 				if probeProtocol == "" {
 					probeProtocol = string(network.ProbeProtocolHTTP)
 				}
-				if requestPath == "" {
+				needRequestPath := strings.EqualFold(probeProtocol, string(network.ProbeProtocolHTTP)) || strings.EqualFold(probeProtocol, string(network.ProbeProtocolHTTPS))
+				if requestPath == "" && needRequestPath {
 					requestPath = podPresencePath
 				}
 

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_loadbalancer_test.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_loadbalancer_test.go
@@ -1725,6 +1725,15 @@ func TestReconcileLoadBalancerRule(t *testing.T) {
 			expectedProbes:  getDefaultTestProbes("Tcp", ""),
 			expectedRules:   getHATestRules(true),
 		},
+		{
+			desc:            "reconcileLoadBalancerRule shall leave probe path empty when using TCP probe",
+			service:         getTestService("test1", v1.ProtocolTCP, nil, false, 80),
+			loadBalancerSku: "standard",
+			wantLb:          true,
+			probeProtocol:   "Tcp",
+			expectedProbes:  getDefaultTestProbes("Tcp", ""),
+			expectedRules:   getDefaultTestRules(true),
+		},
 	}
 	for i, test := range testCases {
 		az := GetTestCloud(ctrl)


### PR DESCRIPTION
Cherry pick of #105253 on release-1.20.

#105253: fix: leave the probe path empty for TCP probes

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```