### PR TITLE
cleanup: reuse the resourcesToWeightMap function in scheduler plugin

### DIFF
--- a/pkg/scheduler/framework/plugins/noderesources/balanced_allocation.go
+++ b/pkg/scheduler/framework/plugins/noderesources/balanced_allocation.go
@@ -78,11 +78,7 @@ func NewBalancedAllocation(baArgs runtime.Object, h framework.Handle, fts featur
 		return nil, err
 	}
 
-	resToWeightMap := make(resourceToWeightMap)
-
-	for _, resource := range args.Resources {
-		resToWeightMap[v1.ResourceName(resource.Name)] = resource.Weight
-	}
+	resToWeightMap := resourcesToWeightMap(args.Resources)
 
 	return &BalancedAllocation{
 		handle: h,

--- a/pkg/scheduler/framework/plugins/noderesources/least_allocated.go
+++ b/pkg/scheduler/framework/plugins/noderesources/least_allocated.go
@@ -76,10 +76,7 @@ func NewLeastAllocated(laArgs runtime.Object, h framework.Handle, fts feature.Fe
 		return nil, err
 	}
 
-	resToWeightMap := make(resourceToWeightMap)
-	for _, resource := range (*args).Resources {
-		resToWeightMap[v1.ResourceName(resource.Name)] = resource.Weight
-	}
+	resToWeightMap := resourcesToWeightMap(args.Resources)
 
 	return &LeastAllocated{
 		handle: h,

--- a/pkg/scheduler/framework/plugins/noderesources/most_allocated.go
+++ b/pkg/scheduler/framework/plugins/noderesources/most_allocated.go
@@ -74,10 +74,7 @@ func NewMostAllocated(maArgs runtime.Object, h framework.Handle, fts feature.Fea
 		return nil, err
 	}
 
-	resToWeightMap := make(resourceToWeightMap)
-	for _, resource := range (*args).Resources {
-		resToWeightMap[v1.ResourceName(resource.Name)] = resource.Weight
-	}
+	resToWeightMap := resourcesToWeightMap(args.Resources)
 
 	return &MostAllocated{
 		handle: h,


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Reuse the `resourcesToWeightMap` function in scheduler `noderesources` plugin.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

