### PR TITLE
reuse previous evaluation

### DIFF
--- a/staging/src/k8s.io/pod-security-admission/admission/admission.go
+++ b/staging/src/k8s.io/pod-security-admission/admission/admission.go
@@ -444,12 +444,13 @@ func (a *Admission) EvaluatePod(ctx context.Context, nsPolicy api.Policy, nsPoli
 	if klog.V(5).Enabled() {
 		klog.InfoS("PodSecurity evaluation", "policy", fmt.Sprintf("%v", nsPolicy), "op", attrs.GetOperation(), "resource", attrs.GetResource(), "namespace", attrs.GetNamespace(), "name", attrs.GetName())
 	}
-
+	cachedResults := make(map[api.LevelVersion]policy.AggregateCheckResult)
 	response := allowedResponse()
 	if enforce {
 		auditAnnotations[api.EnforcedPolicyAnnotationKey] = nsPolicy.Enforce.String()
 
-		if result := policy.AggregateCheckResults(a.Evaluator.EvaluatePod(nsPolicy.Enforce, podMetadata, podSpec)); !result.Allowed {
+		result := policy.AggregateCheckResults(a.Evaluator.EvaluatePod(nsPolicy.Enforce, podMetadata, podSpec))
+		if !result.Allowed {
 			response = forbiddenResponse(fmt.Sprintf(
 				"pod violates PodSecurity %q: %s",
 				nsPolicy.Enforce.String(),
@@ -459,27 +460,38 @@ func (a *Admission) EvaluatePod(ctx context.Context, nsPolicy api.Policy, nsPoli
 		} else {
 			a.Metrics.RecordEvaluation(metrics.DecisionAllow, nsPolicy.Enforce, metrics.ModeEnforce, attrs)
 		}
+		cachedResults[nsPolicy.Enforce] = result
 	}
 
-	// TODO: reuse previous evaluation if audit level+version is the same as enforce level+version
-	if result := policy.AggregateCheckResults(a.Evaluator.EvaluatePod(nsPolicy.Audit, podMetadata, podSpec)); !result.Allowed {
+	// reuse previous evaluation if audit level+version is the same as enforce level+version
+
+	auditResult, ok := cachedResults[nsPolicy.Audit]
+	if !ok {
+		auditResult = policy.AggregateCheckResults(a.Evaluator.EvaluatePod(nsPolicy.Audit, podMetadata, podSpec))
+		cachedResults[nsPolicy.Audit] = auditResult
+	}
+	if !auditResult.Allowed {
 		auditAnnotations[api.AuditViolationsAnnotationKey] = fmt.Sprintf(
 			"would violate PodSecurity %q: %s",
 			nsPolicy.Audit.String(),
-			result.ForbiddenDetail(),
+			auditResult.ForbiddenDetail(),
 		)
 		a.Metrics.RecordEvaluation(metrics.DecisionDeny, nsPolicy.Audit, metrics.ModeAudit, attrs)
 	}
 
 	// avoid adding warnings to a request we're already going to reject with an error
 	if response.Allowed {
-		// TODO: reuse previous evaluation if warn level+version is the same as audit or enforce level+version
-		if result := policy.AggregateCheckResults(a.Evaluator.EvaluatePod(nsPolicy.Warn, podMetadata, podSpec)); !result.Allowed {
+		// reuse previous evaluation if warn level+version is the same as audit or enforce level+version
+		warnResult, ok := cachedResults[nsPolicy.Warn]
+		if !ok {
+			warnResult = policy.AggregateCheckResults(a.Evaluator.EvaluatePod(nsPolicy.Warn, podMetadata, podSpec))
+		}
+		if !warnResult.Allowed {
 			// TODO: Craft a better user-facing warning message
 			response.Warnings = append(response.Warnings, fmt.Sprintf(
 				"would violate PodSecurity %q: %s",
 				nsPolicy.Warn.String(),
-				result.ForbiddenDetail(),
+				warnResult.ForbiddenDetail(),
 			))
 			a.Metrics.RecordEvaluation(metrics.DecisionDeny, nsPolicy.Warn, metrics.ModeWarn, attrs)
 		}


### PR DESCRIPTION
rebase/squash of https://github.com/kubernetes/kubernetes/pull/105950 to accelerate merge, kept author attribution to @wongearl

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
reuse previous evaluation if audit level+version is the same as enforce level+version
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

benchmarks show no alloc/memory degradation when there are unique enforce/audit/warn policies, and improvement when there is reuse:

```
benchmark                                                           old allocs     new allocs     delta
BenchmarkVerifyPod/enforce-implicit_pod-12                          1              1              +0.00%
BenchmarkVerifyPod/enforce-implicit_deployment-12                   1              1              +0.00%
BenchmarkVerifyPod/enforce-privileged_pod-12                        1              1              +0.00%
BenchmarkVerifyPod/enforce-privileged_deployment-12                 1              1              +0.00%
BenchmarkVerifyPod/enforce-baseline_pod-12                          23             23             +0.00%
BenchmarkVerifyPod/enforce-baseline_deployment-12                   1              1              +0.00%
BenchmarkVerifyPod/enforce-restricted_pod-12                        24             24             +0.00%
BenchmarkVerifyPod/enforce-restricted_deployment-12                 1              1              +0.00%
BenchmarkVerifyPod/warn-baseline_pod-12                             22             22             +0.00%
BenchmarkVerifyPod/warn-baseline_deployment-12                      19             19             +0.00%
BenchmarkVerifyPod/warn-restricted_pod-12                           23             23             +0.00%
BenchmarkVerifyPod/warn-restricted_deployment-12                    20             20             +0.00%
BenchmarkVerifyPod/enforce-warn-audit-baseline_pod-12               33             23             -30.30%
BenchmarkVerifyPod/enforce-warn-audit-baseline_deployment-12        24             19             -20.83%
BenchmarkVerifyPod/warn-baseline-audit-restricted_pod-12            28             28             +0.00%
BenchmarkVerifyPod/warn-baseline-audit-restricted_deployment-12     25             25             +0.00%
BenchmarkVerifyNamespace-12                                         48050          48050          +0.00%

benchmark                                                           old bytes     new bytes     delta
BenchmarkVerifyPod/enforce-implicit_pod-12                          112           112           +0.00%
BenchmarkVerifyPod/enforce-implicit_deployment-12                   112           112           +0.00%
BenchmarkVerifyPod/enforce-privileged_pod-12                        112           112           +0.00%
BenchmarkVerifyPod/enforce-privileged_deployment-12                 112           112           +0.00%
BenchmarkVerifyPod/enforce-baseline_pod-12                          3875          3875          +0.00%
BenchmarkVerifyPod/enforce-baseline_deployment-12                   112           112           +0.00%
BenchmarkVerifyPod/enforce-restricted_pod-12                        5164          5164          +0.00%
BenchmarkVerifyPod/enforce-restricted_deployment-12                 112           112           +0.00%
BenchmarkVerifyPod/warn-baseline_pod-12                             3770          3771          +0.03%
BenchmarkVerifyPod/warn-baseline_deployment-12                      3552          3552          +0.00%
BenchmarkVerifyPod/warn-restricted_pod-12                           5052          5051          -0.02%
BenchmarkVerifyPod/warn-restricted_deployment-12                    4832          4832          +0.00%
BenchmarkVerifyPod/enforce-warn-audit-baseline_pod-12               6373          3875          -39.20%
BenchmarkVerifyPod/enforce-warn-audit-baseline_deployment-12        4800          3552          -26.00%
BenchmarkVerifyPod/warn-baseline-audit-restricted_pod-12            6301          6301          +0.00%
BenchmarkVerifyPod/warn-baseline-audit-restricted_deployment-12     6080          6080          +0.00%
BenchmarkVerifyNamespace-12                                         8870939       8870936       -0.00%
```

/sig auth
/assign @enj 