### PR TITLE
PodSecurity: update webhook manifest for beta

### DIFF
--- a/staging/src/k8s.io/pod-security-admission/webhook/manifests/10-namespace.yaml
+++ b/staging/src/k8s.io/pod-security-admission/webhook/manifests/10-namespace.yaml
@@ -2,3 +2,7 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: pod-security-webhook
+  labels:
+    # Even though the validating webhook excludes intercepting this namespace to avoid a circular dependency,
+    # the deployment pod spec is compatible with the restricted level, so mark the namespace as restricted anyway.
+    pod-security.kubernetes.io/enforce: restricted

--- a/staging/src/k8s.io/pod-security-admission/webhook/manifests/20-configmap.yaml
+++ b/staging/src/k8s.io/pod-security-admission/webhook/manifests/20-configmap.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: pod-security-webhook
 data:
   podsecurityconfiguration.yaml: |
-    apiVersion: pod-security.admission.config.k8s.io/v1alpha1
+    apiVersion: pod-security.admission.config.k8s.io/v1beta1
     kind: PodSecurityConfiguration
     # Defaults applied when a mode label is not set.
     #

--- a/staging/src/k8s.io/pod-security-admission/webhook/manifests/50-deployment.yaml
+++ b/staging/src/k8s.io/pod-security-admission/webhook/manifests/50-deployment.yaml
@@ -16,6 +16,9 @@ spec:
     spec:
       serviceAccountName: pod-security-webhook
       priorityClassName: system-cluster-critical
+      nodeSelector:
+        kubernetes.io/os: linux
+        kubernetes.io/arch: amd64
       volumes:
         - name: config
           configMap:

--- a/staging/src/k8s.io/pod-security-admission/webhook/manifests/50-deployment.yaml
+++ b/staging/src/k8s.io/pod-security-admission/webhook/manifests/50-deployment.yaml
@@ -25,7 +25,7 @@ spec:
             secretName: pod-security-webhook
       containers:
         - name: pod-security-webhook
-          image: k8s.gcr.io/sig-auth/pod-security-webhook:v1.22-alpha.0
+          image: k8s.gcr.io/sig-auth/pod-security-webhook:v1.23-beta.0
           terminationMessagePolicy: FallbackToLogsOnError
           ports:
             - containerPort: 8443

--- a/staging/src/k8s.io/pod-security-admission/webhook/manifests/50-deployment.yaml
+++ b/staging/src/k8s.io/pod-security-admission/webhook/manifests/50-deployment.yaml
@@ -31,7 +31,11 @@ spec:
           image: k8s.gcr.io/sig-auth/pod-security-webhook:v1.23-beta.0
           terminationMessagePolicy: FallbackToLogsOnError
           ports:
-            - containerPort: 8443
+            - name: webhook
+              # A port > 1024 avoids needing low port bind privileges.
+              # Using the same port as the kubelet is likely to already be permitted in apiserver -> node firewall rules.
+              # The pod has its own IP and doesn't run with hostNetwork, so there's no port conflict with the kubelet.
+              containerPort: 10250
           args:
             [
               "--config",
@@ -41,7 +45,7 @@ spec:
               "--tls-private-key-file",
               "/etc/pki/tls.key",
               "--secure-port",
-              "8443",
+              "10250",
             ]
           resources:
             requests:

--- a/staging/src/k8s.io/pod-security-admission/webhook/manifests/60-service.yaml
+++ b/staging/src/k8s.io/pod-security-admission/webhook/manifests/60-service.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   ports:
     - port: 443
-      targetPort: 8443
+      targetPort: webhook
       protocol: TCP
       name: https
   selector:


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Updates the pod security webhook manifest config and image to beta

xref kubernetes/enhancements#2579

```release-note
NONE
```

/sig auth
/cc @tallclair @enj 