### PR TITLE
PodSecurity: trim path when building webhook binary

### DIFF
--- a/staging/src/k8s.io/pod-security-admission/webhook/Makefile
+++ b/staging/src/k8s.io/pod-security-admission/webhook/Makefile
@@ -32,7 +32,7 @@ ARCH ?= amd64
 build:
 	@echo Building PodSecurity webhook...
 	@LDFLAGS=`cd -P . && /usr/bin/env bash -c '. $(KUBE_ROOT)/hack/lib/version.sh && KUBE_ROOT=$(KUBE_ROOT) KUBE_GO_PACKAGE=k8s.io/kubernetes kube::version::ldflags'`; \
-	GOOS=$(OS) GOARCH=$(ARCH) CGO_ENABLED=0 go build -o $(EXECUTABLE) -ldflags "$$LDFLAGS" $(ENTRYPOINT)
+	GOOS=$(OS) GOARCH=$(ARCH) CGO_ENABLED=0 go build -o $(EXECUTABLE) -trimpath -ldflags "$$LDFLAGS" $(ENTRYPOINT)
 	@echo Done!
 
 # Builds the PodSecurity webhook Docker image.


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Avoids embedding local path info in the binary

```release-note
NONE
```

/cc @enj
/sig auth