### PR TITLE
Automated cherry pick of #105915: sched: ensure feature gate is honored when instantiating
#106105: Add unit tests to cover scheduler's setup

### DIFF
--- a/cmd/kube-scheduler/app/options/deprecated.go
+++ b/cmd/kube-scheduler/app/options/deprecated.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/spf13/pflag"
 	"k8s.io/apimachinery/pkg/util/validation/field"
+	componentbaseconfig "k8s.io/component-base/config"
 	schedulerappconfig "k8s.io/kubernetes/cmd/kube-scheduler/app/config"
 	kubeschedulerconfig "k8s.io/kubernetes/pkg/scheduler/apis/config"
 )
@@ -28,6 +29,10 @@ import (
 // DeprecatedOptions contains deprecated options and their flags.
 // TODO remove these fields once the deprecated flags are removed.
 type DeprecatedOptions struct {
+	componentbaseconfig.DebuggingConfiguration
+	componentbaseconfig.ClientConnectionConfiguration
+	// Note that only the deprecated options (lock-object-name and lock-object-namespace) are populated here.
+	componentbaseconfig.LeaderElectionConfiguration
 	// The fields below here are placeholders for flags that can't be directly
 	// mapped into componentconfig.KubeSchedulerConfiguration.
 	PolicyConfigFile         string
@@ -37,7 +42,7 @@ type DeprecatedOptions struct {
 }
 
 // AddFlags adds flags for the deprecated options.
-func (o *DeprecatedOptions) AddFlags(fs *pflag.FlagSet, cfg *kubeschedulerconfig.KubeSchedulerConfiguration) {
+func (o *DeprecatedOptions) AddFlags(fs *pflag.FlagSet) {
 	if o == nil {
 		return
 	}
@@ -48,14 +53,14 @@ func (o *DeprecatedOptions) AddFlags(fs *pflag.FlagSet, cfg *kubeschedulerconfig
 	fs.StringVar(&o.PolicyConfigMapNamespace, "policy-configmap-namespace", o.PolicyConfigMapNamespace, "DEPRECATED: the namespace where policy ConfigMap is located. The kube-system namespace will be used if this is not provided or is empty. Note: The predicates/priorities defined in this file will take precedence over any profiles define in ComponentConfig.")
 	fs.BoolVar(&o.UseLegacyPolicyConfig, "use-legacy-policy-config", o.UseLegacyPolicyConfig, "DEPRECATED: when set to true, scheduler will ignore policy ConfigMap and uses policy config file. Note: The scheduler will fail if this is combined with Plugin configs")
 
-	fs.BoolVar(&cfg.EnableProfiling, "profiling", cfg.EnableProfiling, "DEPRECATED: enable profiling via web interface host:port/debug/pprof/. This parameter is ignored if a config file is specified in --config.")
-	fs.BoolVar(&cfg.EnableContentionProfiling, "contention-profiling", cfg.EnableContentionProfiling, "DEPRECATED: enable lock contention profiling, if profiling is enabled. This parameter is ignored if a config file is specified in --config.")
-	fs.StringVar(&cfg.ClientConnection.Kubeconfig, "kubeconfig", cfg.ClientConnection.Kubeconfig, "DEPRECATED: path to kubeconfig file with authorization and master location information. This parameter is ignored if a config file is specified in --config.")
-	fs.StringVar(&cfg.ClientConnection.ContentType, "kube-api-content-type", cfg.ClientConnection.ContentType, "DEPRECATED: content type of requests sent to apiserver. This parameter is ignored if a config file is specified in --config.")
-	fs.Float32Var(&cfg.ClientConnection.QPS, "kube-api-qps", cfg.ClientConnection.QPS, "DEPRECATED: QPS to use while talking with kubernetes apiserver. This parameter is ignored if a config file is specified in --config.")
-	fs.Int32Var(&cfg.ClientConnection.Burst, "kube-api-burst", cfg.ClientConnection.Burst, "DEPRECATED: burst to use while talking with kubernetes apiserver. This parameter is ignored if a config file is specified in --config.")
-	fs.StringVar(&cfg.LeaderElection.ResourceNamespace, "lock-object-namespace", cfg.LeaderElection.ResourceNamespace, "DEPRECATED: define the namespace of the lock object. Will be removed in favor of leader-elect-resource-namespace. This parameter is ignored if a config file is specified in --config.")
-	fs.StringVar(&cfg.LeaderElection.ResourceName, "lock-object-name", cfg.LeaderElection.ResourceName, "DEPRECATED: define the name of the lock object. Will be removed in favor of leader-elect-resource-name. This parameter is ignored if a config file is specified in --config.")
+	fs.BoolVar(&o.EnableProfiling, "profiling", true, "DEPRECATED: enable profiling via web interface host:port/debug/pprof/. This parameter is ignored if a config file is specified in --config.")
+	fs.BoolVar(&o.EnableContentionProfiling, "contention-profiling", true, "DEPRECATED: enable lock contention profiling, if profiling is enabled. This parameter is ignored if a config file is specified in --config.")
+	fs.StringVar(&o.Kubeconfig, "kubeconfig", "", "DEPRECATED: path to kubeconfig file with authorization and master location information. This parameter is ignored if a config file is specified in --config.")
+	fs.StringVar(&o.ContentType, "kube-api-content-type", "application/vnd.kubernetes.protobuf", "DEPRECATED: content type of requests sent to apiserver. This parameter is ignored if a config file is specified in --config.")
+	fs.Float32Var(&o.QPS, "kube-api-qps", 50.0, "DEPRECATED: QPS to use while talking with kubernetes apiserver. This parameter is ignored if a config file is specified in --config.")
+	fs.Int32Var(&o.Burst, "kube-api-burst", 100, "DEPRECATED: burst to use while talking with kubernetes apiserver. This parameter is ignored if a config file is specified in --config.")
+	fs.StringVar(&o.ResourceNamespace, "lock-object-namespace", "kube-system", "DEPRECATED: define the namespace of the lock object. Will be removed in favor of leader-elect-resource-namespace. This parameter is ignored if a config file is specified in --config.")
+	fs.StringVar(&o.ResourceName, "lock-object-name", "kube-scheduler", "DEPRECATED: define the name of the lock object. Will be removed in favor of leader-elect-resource-name. This parameter is ignored if a config file is specified in --config.")
 }
 
 // Validate validates the deprecated scheduler options.

--- a/cmd/kube-scheduler/app/options/insecure_serving.go
+++ b/cmd/kube-scheduler/app/options/insecure_serving.go
@@ -44,10 +44,10 @@ func (o *CombinedInsecureServingOptions) AddFlags(fs *pflag.FlagSet) {
 		return
 	}
 
-	fs.StringVar(&o.BindAddress, "address", o.BindAddress, "DEPRECATED: the IP address on which to listen for the --port port (set to 0.0.0.0 or :: for listening in all interfaces and IP families). See --bind-address instead. This parameter is ignored if a config file is specified in --config.")
+	fs.StringVar(&o.BindAddress, "address", "0.0.0.0", "DEPRECATED: the IP address on which to listen for the --port port (set to 0.0.0.0 or :: for listening in all interfaces and IP families). See --bind-address instead. This parameter is ignored if a config file is specified in --config.")
 	// MarkDeprecated hides the flag from the help. We don't want that:
 	// fs.MarkDeprecated("address", "see --bind-address instead.")
-	fs.IntVar(&o.BindPort, "port", o.BindPort, "DEPRECATED: the port on which to serve HTTP insecurely without authentication and authorization. If 0, don't serve plain HTTP at all. See --secure-port instead. This parameter is ignored if a config file is specified in --config.")
+	fs.IntVar(&o.BindPort, "port", kubeschedulerconfig.DefaultInsecureSchedulerPort, "DEPRECATED: the port on which to serve HTTP insecurely without authentication and authorization. If 0, don't serve plain HTTP at all. See --secure-port instead. This parameter is ignored if a config file is specified in --config.")
 	// MarkDeprecated hides the flag from the help. We don't want that:
 	// fs.MarkDeprecated("port", "see --secure-port instead.")
 }

--- a/cmd/kube-scheduler/app/options/insecure_serving_test.go
+++ b/cmd/kube-scheduler/app/options/insecure_serving_test.go
@@ -41,7 +41,7 @@ func TestOptions_ApplyTo(t *testing.T) {
 		{
 			name: "no config, zero port",
 			options: Options{
-				ComponentConfig: kubeschedulerconfig.KubeSchedulerConfiguration{
+				ComponentConfig: &kubeschedulerconfig.KubeSchedulerConfiguration{
 					HealthzBindAddress: "1.2.3.4:1234",
 					MetricsBindAddress: "1.2.3.4:1234",
 				},
@@ -56,7 +56,7 @@ func TestOptions_ApplyTo(t *testing.T) {
 		{
 			name: "config loaded, non-nil healthz",
 			options: Options{
-				ComponentConfig: kubeschedulerconfig.KubeSchedulerConfiguration{
+				ComponentConfig: &kubeschedulerconfig.KubeSchedulerConfiguration{
 					HealthzBindAddress: "1.2.3.4:1234",
 					MetricsBindAddress: "1.2.3.4:1234",
 				},
@@ -74,7 +74,7 @@ func TestOptions_ApplyTo(t *testing.T) {
 		{
 			name: "config loaded, non-nil metrics",
 			options: Options{
-				ComponentConfig: kubeschedulerconfig.KubeSchedulerConfiguration{
+				ComponentConfig: &kubeschedulerconfig.KubeSchedulerConfiguration{
 					HealthzBindAddress: "1.2.3.4:1234",
 					MetricsBindAddress: "1.2.3.4:1234",
 				},
@@ -92,7 +92,7 @@ func TestOptions_ApplyTo(t *testing.T) {
 		{
 			name: "config loaded, all set, zero BindPort",
 			options: Options{
-				ComponentConfig: kubeschedulerconfig.KubeSchedulerConfiguration{
+				ComponentConfig: &kubeschedulerconfig.KubeSchedulerConfiguration{
 					HealthzBindAddress: "1.2.3.4:1234",
 					MetricsBindAddress: "1.2.3.4:1234",
 				},
@@ -113,7 +113,7 @@ func TestOptions_ApplyTo(t *testing.T) {
 		{
 			name: "config loaded, all set, different addresses",
 			options: Options{
-				ComponentConfig: kubeschedulerconfig.KubeSchedulerConfiguration{
+				ComponentConfig: &kubeschedulerconfig.KubeSchedulerConfiguration{
 					HealthzBindAddress: "1.2.3.4:1234",
 					MetricsBindAddress: "1.2.3.4:1235",
 				},
@@ -136,7 +136,7 @@ func TestOptions_ApplyTo(t *testing.T) {
 		{
 			name: "no config, all set, port passed",
 			options: Options{
-				ComponentConfig: kubeschedulerconfig.KubeSchedulerConfiguration{
+				ComponentConfig: &kubeschedulerconfig.KubeSchedulerConfiguration{
 					HealthzBindAddress: "1.2.3.4:1234",
 					MetricsBindAddress: "1.2.3.4:1234",
 				},
@@ -158,7 +158,7 @@ func TestOptions_ApplyTo(t *testing.T) {
 		{
 			name: "no config, all set, address passed",
 			options: Options{
-				ComponentConfig: kubeschedulerconfig.KubeSchedulerConfiguration{
+				ComponentConfig: &kubeschedulerconfig.KubeSchedulerConfiguration{
 					HealthzBindAddress: "1.2.3.4:1234",
 					MetricsBindAddress: "1.2.3.4:1234",
 				},
@@ -180,7 +180,7 @@ func TestOptions_ApplyTo(t *testing.T) {
 		{
 			name: "no config, all set, zero port passed",
 			options: Options{
-				ComponentConfig: kubeschedulerconfig.KubeSchedulerConfiguration{
+				ComponentConfig: &kubeschedulerconfig.KubeSchedulerConfiguration{
 					HealthzBindAddress: "1.2.3.4:1234",
 					MetricsBindAddress: "1.2.3.4:1234",
 				},
@@ -197,7 +197,7 @@ func TestOptions_ApplyTo(t *testing.T) {
 	for i, tt := range tests {
 		t.Run(fmt.Sprintf("%d-%s", i, tt.name), func(t *testing.T) {
 			c := schedulerappconfig.Config{
-				ComponentConfig: tt.options.ComponentConfig,
+				ComponentConfig: *tt.options.ComponentConfig,
 			}
 
 			if tt.options.CombinedInsecureServing != nil {

--- a/cmd/kube-scheduler/app/options/options_test.go
+++ b/cmd/kube-scheduler/app/options/options_test.go
@@ -341,12 +341,12 @@ profiles:
 			name: "v1beta2 config file",
 			options: &Options{
 				ConfigFile: configFile,
-				ComponentConfig: func() kubeschedulerconfig.KubeSchedulerConfiguration {
+				ComponentConfig: func() *kubeschedulerconfig.KubeSchedulerConfiguration {
 					cfg, err := latest.Default()
 					if err != nil {
 						t.Fatal(err)
 					}
-					return *cfg
+					return cfg
 				}(),
 				SecureServing: (&apiserveroptions.SecureServingOptions{
 					ServerCert: apiserveroptions.GeneratableKeyCert{
@@ -417,9 +417,9 @@ profiles:
 			name: "v1beta1 config file",
 			options: &Options{
 				ConfigFile: v1beta1VersionConfig,
-				ComponentConfig: func() kubeschedulerconfig.KubeSchedulerConfiguration {
+				ComponentConfig: func() *kubeschedulerconfig.KubeSchedulerConfiguration {
 					cfg := configtesting.V1beta1ToInternalWithDefaults(t, v1beta1.KubeSchedulerConfiguration{})
-					return *cfg
+					return cfg
 				}(),
 				SecureServing: (&apiserveroptions.SecureServingOptions{
 					ServerCert: apiserveroptions.GeneratableKeyCert{
@@ -490,12 +490,12 @@ profiles:
 			name: "config file in componentconfig/v1alpha1",
 			options: &Options{
 				ConfigFile: oldConfigFile,
-				ComponentConfig: func() kubeschedulerconfig.KubeSchedulerConfiguration {
+				ComponentConfig: func() *kubeschedulerconfig.KubeSchedulerConfiguration {
 					cfg, err := latest.Default()
 					if err != nil {
 						t.Fatal(err)
 					}
-					return *cfg
+					return cfg
 				}(),
 				Logs: logs.NewOptions(),
 			},
@@ -520,10 +520,10 @@ profiles:
 		{
 			name: "kubeconfig flag",
 			options: &Options{
-				ComponentConfig: func() kubeschedulerconfig.KubeSchedulerConfiguration {
+				ComponentConfig: func() *kubeschedulerconfig.KubeSchedulerConfiguration {
 					cfg, _ := latest.Default()
 					cfg.ClientConnection.Kubeconfig = flagKubeconfig
-					return *cfg
+					return cfg
 				}(),
 				SecureServing: (&apiserveroptions.SecureServingOptions{
 					ServerCert: apiserveroptions.GeneratableKeyCert{
@@ -593,10 +593,10 @@ profiles:
 		{
 			name: "overridden master",
 			options: &Options{
-				ComponentConfig: func() kubeschedulerconfig.KubeSchedulerConfiguration {
+				ComponentConfig: func() *kubeschedulerconfig.KubeSchedulerConfiguration {
 					cfg, _ := latest.Default()
 					cfg.ClientConnection.Kubeconfig = flagKubeconfig
-					return *cfg
+					return cfg
 				}(),
 				Master: insecureserver.URL,
 				SecureServing: (&apiserveroptions.SecureServingOptions{
@@ -1228,6 +1228,13 @@ profiles:
 
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
+			if tc.options.ComponentConfig == nil {
+				if cfg, err := latest.Default(); err != nil {
+					t.Fatal(err)
+				} else {
+					tc.options.ComponentConfig = cfg
+				}
+			}
 			// create the config
 			config, err := tc.options.Config()
 

--- a/cmd/kube-scheduler/app/server.go
+++ b/cmd/kube-scheduler/app/server.go
@@ -53,6 +53,7 @@ import (
 	"k8s.io/kubernetes/cmd/kube-scheduler/app/options"
 	"k8s.io/kubernetes/pkg/scheduler"
 	kubeschedulerconfig "k8s.io/kubernetes/pkg/scheduler/apis/config"
+	"k8s.io/kubernetes/pkg/scheduler/apis/config/latest"
 	"k8s.io/kubernetes/pkg/scheduler/framework/runtime"
 	"k8s.io/kubernetes/pkg/scheduler/metrics/resources"
 	"k8s.io/kubernetes/pkg/scheduler/profile"
@@ -63,12 +64,8 @@ type Option func(runtime.Registry) error
 
 // NewSchedulerCommand creates a *cobra.Command object with default parameters and registryOptions
 func NewSchedulerCommand(registryOptions ...Option) *cobra.Command {
-	opts, err := options.NewOptions()
-	if err != nil {
-		klog.Fatalf("unable to initialize command options: %v", err)
-	}
+	opts := options.NewOptions()
 
-	namedFlagSets := opts.Flags()
 	cmd := &cobra.Command{
 		Use: "kube-scheduler",
 		Long: `The Kubernetes scheduler is a control plane process which assigns
@@ -80,10 +77,6 @@ kube-scheduler is the reference implementation.
 See [scheduling](https://kubernetes.io/docs/concepts/scheduling-eviction/)
 for more information about scheduling and the kube-scheduler component.`,
 		Run: func(cmd *cobra.Command, args []string) {
-			if err := opts.Complete(&namedFlagSets); err != nil {
-				fmt.Fprintf(os.Stderr, "%v\n", err)
-				os.Exit(1)
-			}
 			if err := runCommand(cmd, opts, registryOptions...); err != nil {
 				fmt.Fprintf(os.Stderr, "%v\n", err)
 				os.Exit(1)
@@ -98,15 +91,17 @@ for more information about scheduling and the kube-scheduler component.`,
 			return nil
 		},
 	}
+
+	nfs := opts.Flags
+	verflag.AddFlags(nfs.FlagSet("global"))
+	globalflag.AddGlobalFlags(nfs.FlagSet("global"), cmd.Name())
 	fs := cmd.Flags()
-	verflag.AddFlags(namedFlagSets.FlagSet("global"))
-	globalflag.AddGlobalFlags(namedFlagSets.FlagSet("global"), cmd.Name())
-	for _, f := range namedFlagSets.FlagSets {
+	for _, f := range nfs.FlagSets {
 		fs.AddFlagSet(f)
 	}
 
 	cols, _, _ := term.TerminalSize(cmd.OutOrStdout())
-	cliflag.SetUsageAndHelpFunc(cmd, namedFlagSets, cols)
+	cliflag.SetUsageAndHelpFunc(cmd, *nfs, cols)
 
 	cmd.MarkFlagFilename("config", "yaml", "yml", "json")
 
@@ -308,6 +303,12 @@ func WithPlugin(name string, factory runtime.PluginFactory) Option {
 
 // Setup creates a completed config and a scheduler based on the command args and options
 func Setup(ctx context.Context, opts *options.Options, outOfTreeRegistryOptions ...Option) (*schedulerserverconfig.CompletedConfig, *scheduler.Scheduler, error) {
+	if cfg, err := latest.Default(); err != nil {
+		return nil, nil, err
+	} else {
+		opts.ComponentConfig = cfg
+	}
+
 	if errs := opts.Validate(); len(errs) > 0 {
 		return nil, nil, utilerrors.NewAggregate(errs)
 	}

--- a/cmd/kube-scheduler/app/server_test.go
+++ b/cmd/kube-scheduler/app/server_test.go
@@ -26,13 +26,16 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/spf13/pflag"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apiserver/pkg/util/feature"
 	componentbaseconfig "k8s.io/component-base/config"
 	"k8s.io/component-base/featuregate"
 	featuregatetesting "k8s.io/component-base/featuregate/testing"
+	"k8s.io/kube-scheduler/config/v1beta2"
 	"k8s.io/kubernetes/cmd/kube-scheduler/app/options"
 	"k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/pkg/scheduler/apis/config"
@@ -158,6 +161,30 @@ profiles:
 		t.Fatal(err)
 	}
 
+	// empty leader-election config
+	emptyLeaderElectionConfig := filepath.Join(tmpDir, "empty-leader-election-config.yaml")
+	if err := ioutil.WriteFile(emptyLeaderElectionConfig, []byte(fmt.Sprintf(`
+apiVersion: kubescheduler.config.k8s.io/v1beta2
+kind: KubeSchedulerConfiguration
+clientConnection:
+  kubeconfig: "%s"
+`, configKubeconfig)), os.FileMode(0600)); err != nil {
+		t.Fatal(err)
+	}
+
+	// leader-election config
+	leaderElectionConfig := filepath.Join(tmpDir, "leader-election-config.yaml")
+	if err := ioutil.WriteFile(leaderElectionConfig, []byte(fmt.Sprintf(`
+apiVersion: kubescheduler.config.k8s.io/v1beta2
+kind: KubeSchedulerConfiguration
+clientConnection:
+  kubeconfig: "%s"
+leaderElection:
+  leaseDuration: 1h
+`, configKubeconfig)), os.FileMode(0600)); err != nil {
+		t.Fatal(err)
+	}
+
 	testcases := []struct {
 		name               string
 		flags              []string
@@ -271,6 +298,75 @@ profiles:
 				},
 			},
 		},
+		{
+			name: "leader election CLI args, along with --config arg",
+			flags: []string{
+				"--leader-elect=false",
+				"--leader-elect-lease-duration=2h", // CLI args are favored over the fields in ComponentConfig
+				"--lock-object-namespace=default",  // deprecated CLI arg will be ignored if --config is specified
+				"--config", emptyLeaderElectionConfig,
+			},
+			wantLeaderElection: &componentbaseconfig.LeaderElectionConfiguration{
+				LeaderElect:       false,                                    // from CLI args
+				LeaseDuration:     metav1.Duration{Duration: 2 * time.Hour}, // from CLI args
+				RenewDeadline:     metav1.Duration{Duration: 10 * time.Second},
+				RetryPeriod:       metav1.Duration{Duration: 2 * time.Second},
+				ResourceLock:      "leases",
+				ResourceName:      v1beta2.SchedulerDefaultLockObjectName,
+				ResourceNamespace: v1beta2.SchedulerDefaultLockObjectNamespace,
+			},
+		},
+		{
+			name: "leader election CLI args, without --config arg",
+			flags: []string{
+				"--leader-elect=false",
+				"--leader-elect-lease-duration=2h",
+				"--lock-object-namespace=default", // deprecated CLI arg is honored if --config is not specified
+				"--kubeconfig", configKubeconfig,
+			},
+			wantLeaderElection: &componentbaseconfig.LeaderElectionConfiguration{
+				LeaderElect:       false,                                    // from CLI args
+				LeaseDuration:     metav1.Duration{Duration: 2 * time.Hour}, // from CLI args
+				RenewDeadline:     metav1.Duration{Duration: 10 * time.Second},
+				RetryPeriod:       metav1.Duration{Duration: 2 * time.Second},
+				ResourceLock:      "leases",
+				ResourceName:      v1beta2.SchedulerDefaultLockObjectName,
+				ResourceNamespace: "default", // from deprecated CLI args
+			},
+		},
+		{
+			name: "leader election settings specified by ComponentConfig only",
+			flags: []string{
+				"--config", leaderElectionConfig,
+			},
+			wantLeaderElection: &componentbaseconfig.LeaderElectionConfiguration{
+				LeaderElect:       true,
+				LeaseDuration:     metav1.Duration{Duration: 1 * time.Hour}, // from CC
+				RenewDeadline:     metav1.Duration{Duration: 10 * time.Second},
+				RetryPeriod:       metav1.Duration{Duration: 2 * time.Second},
+				ResourceLock:      "leases",
+				ResourceName:      v1beta2.SchedulerDefaultLockObjectName,
+				ResourceNamespace: v1beta2.SchedulerDefaultLockObjectNamespace,
+			},
+		},
+		{
+			name: "leader election settings specified by CLI args and ComponentConfig",
+			flags: []string{
+				"--leader-elect=true",
+				"--leader-elect-renew-deadline=5s",
+				"--leader-elect-retry-period=1s",
+				"--config", leaderElectionConfig,
+			},
+			wantLeaderElection: &componentbaseconfig.LeaderElectionConfiguration{
+				LeaderElect:       true,
+				LeaseDuration:     metav1.Duration{Duration: 1 * time.Hour},   // from CC
+				RenewDeadline:     metav1.Duration{Duration: 5 * time.Second}, // from CLI args
+				RetryPeriod:       metav1.Duration{Duration: 1 * time.Second}, // from CLI args
+				ResourceLock:      "leases",
+				ResourceName:      v1beta2.SchedulerDefaultLockObjectName,
+				ResourceNamespace: v1beta2.SchedulerDefaultLockObjectNamespace,
+			},
+		},
 	}
 
 	makeListener := func(t *testing.T) net.Listener {
@@ -290,11 +386,6 @@ profiles:
 
 			fs := pflag.NewFlagSet("test", pflag.PanicOnError)
 			opts := options.NewOptions()
-
-			// use listeners instead of static ports so parallel test runs don't conflict
-			opts.SecureServing.Listener = makeListener(t)
-			defer opts.SecureServing.Listener.Close()
-
 			nfs := opts.Flags
 			for _, f := range nfs.FlagSets {
 				fs.AddFlagSet(f)
@@ -318,13 +409,22 @@ profiles:
 				t.Fatal(err)
 			}
 
-			gotPlugins := make(map[string]*config.Plugins)
-			for n, p := range sched.Profiles {
-				gotPlugins[n] = p.ListPlugins()
+			if tc.wantPlugins != nil {
+				gotPlugins := make(map[string]*config.Plugins)
+				for n, p := range sched.Profiles {
+					gotPlugins[n] = p.ListPlugins()
+				}
+
+				if diff := cmp.Diff(tc.wantPlugins, gotPlugins); diff != "" {
+					t.Errorf("Unexpected plugins diff (-want, +got): %s", diff)
+				}
 			}
 
-			if diff := cmp.Diff(tc.wantPlugins, gotPlugins); diff != "" {
-				t.Errorf("unexpected plugins diff (-want, +got): %s", diff)
+			if tc.wantLeaderElection != nil {
+				gotLeaderElection := opts.ComponentConfig.LeaderElection
+				if diff := cmp.Diff(*tc.wantLeaderElection, gotLeaderElection); diff != "" {
+					t.Errorf("Unexpected leaderElection diff (-want, +got): %s", diff)
+				}
 			}
 		})
 	}

--- a/cmd/kube-scheduler/app/server_test.go
+++ b/cmd/kube-scheduler/app/server_test.go
@@ -29,9 +29,15 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/spf13/pflag"
+	"k8s.io/apiserver/pkg/util/feature"
+	componentbaseconfig "k8s.io/component-base/config"
+	"k8s.io/component-base/featuregate"
+	featuregatetesting "k8s.io/component-base/featuregate/testing"
 	"k8s.io/kubernetes/cmd/kube-scheduler/app/options"
+	"k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/pkg/scheduler/apis/config"
 	"k8s.io/kubernetes/pkg/scheduler/apis/config/testing/defaults"
+	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/names"
 )
 
 func TestSetup(t *testing.T) {
@@ -153,10 +159,45 @@ profiles:
 	}
 
 	testcases := []struct {
-		name        string
-		flags       []string
-		wantPlugins map[string]*config.Plugins
+		name               string
+		flags              []string
+		restoreFeatures    map[featuregate.Feature]bool
+		wantPlugins        map[string]*config.Plugins
+		wantLeaderElection *componentbaseconfig.LeaderElectionConfiguration
 	}{
+		{
+			name: "default config with an alpha feature enabled and an beta feature disabled",
+			flags: []string{
+				"--kubeconfig", configKubeconfig,
+				"--feature-gates=VolumeCapacityPriority=true,DefaultPodTopologySpread=false",
+			},
+			wantPlugins: map[string]*config.Plugins{
+				"default-scheduler": func() *config.Plugins {
+					plugins := &config.Plugins{
+						QueueSort:  defaults.PluginsV1beta2.QueueSort,
+						PreFilter:  defaults.PluginsV1beta2.PreFilter,
+						Filter:     defaults.PluginsV1beta2.Filter,
+						PostFilter: defaults.PluginsV1beta2.PostFilter,
+						PreScore:   defaults.PluginsV1beta2.PreScore,
+						Score:      defaults.PluginsV1beta2.Score,
+						Bind:       defaults.PluginsV1beta2.Bind,
+						PreBind:    defaults.PluginsV1beta2.PreBind,
+						Reserve:    defaults.PluginsV1beta2.Reserve,
+					}
+					plugins.PreScore.Enabled = append(plugins.PreScore.Enabled, config.Plugin{Name: names.SelectorSpread, Weight: 0})
+					plugins.Score.Enabled = append(
+						plugins.Score.Enabled,
+						config.Plugin{Name: names.VolumeBinding, Weight: 1},
+						config.Plugin{Name: names.SelectorSpread, Weight: 1},
+					)
+					return plugins
+				}(),
+			},
+			restoreFeatures: map[featuregate.Feature]bool{
+				features.VolumeCapacityPriority:   false,
+				features.DefaultPodTopologySpread: true,
+			},
+		},
 		{
 			name: "default config",
 			flags: []string{
@@ -243,21 +284,22 @@ profiles:
 
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
-			fs := pflag.NewFlagSet("test", pflag.PanicOnError)
-			opts, err := options.NewOptions()
-			if err != nil {
-				t.Fatal(err)
+			for k, v := range tc.restoreFeatures {
+				defer featuregatetesting.SetFeatureGateDuringTest(t, feature.DefaultFeatureGate, k, v)()
 			}
 
-			nfs := opts.Flags()
+			fs := pflag.NewFlagSet("test", pflag.PanicOnError)
+			opts := options.NewOptions()
+
+			// use listeners instead of static ports so parallel test runs don't conflict
+			opts.SecureServing.Listener = makeListener(t)
+			defer opts.SecureServing.Listener.Close()
+
+			nfs := opts.Flags
 			for _, f := range nfs.FlagSets {
 				fs.AddFlagSet(f)
 			}
 			if err := fs.Parse(tc.flags); err != nil {
-				t.Fatal(err)
-			}
-
-			if err := opts.Complete(&nfs); err != nil {
 				t.Fatal(err)
 			}
 

--- a/cmd/kube-scheduler/app/testing/testserver.go
+++ b/cmd/kube-scheduler/app/testing/testserver.go
@@ -82,20 +82,12 @@ func StartTestServer(t Logger, customFlags []string) (result TestServer, err err
 
 	fs := pflag.NewFlagSet("test", pflag.PanicOnError)
 
-	opts, err := options.NewOptions()
-	if err != nil {
-		return TestServer{}, err
-	}
-
-	namedFlagSets := opts.Flags()
-	for _, f := range namedFlagSets.FlagSets {
+	opts := options.NewOptions()
+	nfs := opts.Flags
+	for _, f := range nfs.FlagSets {
 		fs.AddFlagSet(f)
 	}
 	fs.Parse(customFlags)
-
-	if err := opts.Complete(&namedFlagSets); err != nil {
-		return TestServer{}, err
-	}
 
 	if opts.SecureServing.BindPort != 0 {
 		opts.SecureServing.Listener, opts.SecureServing.BindPort, err = createListenerOnFreePort()


### PR DESCRIPTION
Cherry pick of #105915 #106105 on release-1.22.

#105915: sched: ensure feature gate is honored when instantiating
#106105: Add unit tests to cover scheduler's setup

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
The --leader-elect* CLI args are now honored correctly in scheduler.
```