### PR TITLE
CVE-2021-41103: Bump containerd/containerd to 1.4.11

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,6 +25,7 @@ require (
 	github.com/boltdb/bolt v1.3.1 // indirect
 	github.com/clusterhq/flocker-go v0.0.0-20160920122132-2b8b7259d313
 	github.com/container-storage-interface/spec v1.5.0
+	github.com/containerd/containerd v1.4.11 // indirect
 	github.com/containernetworking/cni v0.8.1
 	github.com/coredns/corefile-migration v1.0.12
 	github.com/coreos/go-oidc v2.1.0+incompatible
@@ -198,7 +199,7 @@ replace (
 	github.com/container-storage-interface/spec => github.com/container-storage-interface/spec v1.5.0
 	github.com/containerd/cgroups => github.com/containerd/cgroups v1.0.1
 	github.com/containerd/console => github.com/containerd/console v1.0.2
-	github.com/containerd/containerd => github.com/containerd/containerd v1.4.9
+	github.com/containerd/containerd => github.com/containerd/containerd v1.4.11
 	github.com/containerd/continuity => github.com/containerd/continuity v0.1.0
 	github.com/containerd/fifo => github.com/containerd/fifo v1.0.0
 	github.com/containerd/go-runc => github.com/containerd/go-runc v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -101,8 +101,8 @@ github.com/containerd/cgroups v1.0.1 h1:iJnMvco9XGvKUvNQkv88bE4uJXxRQH18efbKo9w5
 github.com/containerd/cgroups v1.0.1/go.mod h1:0SJrPIenamHDcZhEcJMNBB85rHcUsw4f25ZfBiPYRkU=
 github.com/containerd/console v1.0.2 h1:Pi6D+aZXM+oUw1czuKgH5IJ+y0jhYcwBJfx5/Ghn9dE=
 github.com/containerd/console v1.0.2/go.mod h1:ytZPjGgY2oeTkAONYafi2kSj0aYggsf8acV1PGKCbzQ=
-github.com/containerd/containerd v1.4.9 h1:JIw9mjVw4LsGmnA/Bqg9j9e+XB7soOJufrKUpA6n2Ns=
-github.com/containerd/containerd v1.4.9/go.mod h1:bC6axHOhabU15QhwfG7w5PipXdVtMXFTttgp+kVtyUA=
+github.com/containerd/containerd v1.4.11 h1:QCGOUN+i70jEEL/A6JVIbhy4f4fanzAzSR4kNG7SlcE=
+github.com/containerd/containerd v1.4.11/go.mod h1:bC6axHOhabU15QhwfG7w5PipXdVtMXFTttgp+kVtyUA=
 github.com/containerd/continuity v0.1.0/go.mod h1:ICJu0PwR54nI0yPEnJ6jcS+J7CZAUXrLh8lPo2knzsM=
 github.com/containerd/fifo v1.0.0/go.mod h1:ocF/ME1SX5b1AOlWi9r677YJmCPSwwWnQ9O123vzpE4=
 github.com/containerd/go-runc v1.0.0/go.mod h1:cNU0ZbCgCQVZK4lgG3P+9tn9/PaJNmoDXPpoJhDR+Ok=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -179,7 +179,8 @@ github.com/container-storage-interface/spec/lib/go/csi
 github.com/containerd/cgroups/stats/v1
 # github.com/containerd/console v1.0.2 => github.com/containerd/console v1.0.2
 github.com/containerd/console
-# github.com/containerd/containerd v1.4.9 => github.com/containerd/containerd v1.4.9
+# github.com/containerd/containerd v1.4.11 => github.com/containerd/containerd v1.4.11
+## explicit
 github.com/containerd/containerd/api/services/containers/v1
 github.com/containerd/containerd/api/services/tasks/v1
 github.com/containerd/containerd/api/services/version/v1
@@ -2468,7 +2469,7 @@ sigs.k8s.io/yaml
 # github.com/container-storage-interface/spec => github.com/container-storage-interface/spec v1.5.0
 # github.com/containerd/cgroups => github.com/containerd/cgroups v1.0.1
 # github.com/containerd/console => github.com/containerd/console v1.0.2
-# github.com/containerd/containerd => github.com/containerd/containerd v1.4.9
+# github.com/containerd/containerd => github.com/containerd/containerd v1.4.11
 # github.com/containerd/continuity => github.com/containerd/continuity v0.1.0
 # github.com/containerd/fifo => github.com/containerd/fifo v1.0.0
 # github.com/containerd/go-runc => github.com/containerd/go-runc v1.0.0


### PR DESCRIPTION

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:
- CVE-2021-41103 was fixed in v1.4.11, existing code imports v1.4.9
- It's unclear if vulnerable code is actually imported or used
  by kubernetes code
- So bumping this in main, if appropriate please cherry pick

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:
This is adding `//indirect` dependency for `containerd/containerd`, in spite of running `hack/pin-dependency.sh` followed by `hack/update-vendor.sh`. Output from locally running these commands
```
pjoglekar@pjoglekar-a01 kubernetes % hack/pin-dependency.sh github.com/containerd/containerd v1.4.11
Running: go mod download github.com/containerd/containerd@v1.4.11
Resolved to github.com/containerd/containerd@v1.4.11
Running: go mod edit -require github.com/containerd/containerd@v1.4.11
Running: go mod edit -replace github.com/containerd/containerd=github.com/containerd/containerd@v1.4.11

Run hack/update-vendor.sh to rebuild the vendor directory
pjoglekar@pjoglekar-a01 kubernetes % hack/update-vendor.sh
+++ [1103 17:08:26] logfile at /tmp/update-vendor.Fmje/update-vendor.log
+++ [1103 17:08:26] go.mod: update staging references
+++ [1103 17:08:45] go.mod: propagate to staging modules
+++ [1103 17:08:47] go.mod: sorting staging modules
+++ [1103 17:10:03] go.mod: tidying
+++ [1103 17:11:06] go.mod: adding generated comments
+++ [1103 17:11:07] vendor: updating internal modules
+++ [1103 17:11:12] vendor: running 'go mod vendor'
+++ [1103 17:11:24] vendor: updating vendor/LICENSES
+++ [1103 17:11:42] vendor: creating OWNERS file
+++ [1103 17:11:42] NOTE: don't forget to handle vendor/* files that were added or removed
```

Not sure if this is expected behavior or not. Happy to make updates to the PR to avoid this additional line
```release-note
NONE
```
