### PR TITLE
cli/kubectl: report possible namespace NotFound error for `kubectl get/describe` queries that list resources by selector

### DIFF
--- a/staging/src/k8s.io/cli-runtime/pkg/resource/selector.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/resource/selector.go
@@ -17,6 +17,8 @@ limitations under the License.
 package resource
 
 import (
+	"context"
+
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -53,6 +55,14 @@ func (r *Selector) Visit(fn VisitorFunc) error {
 		FieldSelector: r.FieldSelector,
 		Limit:         r.LimitChunks,
 	}
+
+	if len(r.Namespace) > 0 {
+		err := r.Client.Get().AbsPath("api", "v1", "namespaces", r.Namespace).Do(context.TODO()).Error()
+		if err != nil {
+			return err
+		}
+	}
+
 	return FollowContinue(&initialOpts, func(options metav1.ListOptions) (runtime.Object, error) {
 		list, err := helper.List(
 			r.Namespace,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug

#### What this PR does / why we need it:

This change makes `kubectl get/describe` queries that list resources by selector validate namespace presence before listing, to report NotFound error if required namespace does not exist.

for example, to get pods without names in a non-exist namespace:
```
$ kubectl get ns non-exist-namespace
Error from server (NotFound): namespaces "non-exist-namespace" not found
                                                                         
// No NotFound error reported
$ kubectl get pods -n=non-exist-namespace 
No resources found in non-exist-namespace namespace.

// However, get query with resource name would report namespace NotFound error
$ kubectl get pods testpod -n=non-exist-namespace
Error from server (NotFound): namespaces "non-exist-namespace" not found
```

After the fix, `kubectl get/describe` without resource names would report namespace NotFound error.
```
./_output/bin/kubectl get pods -n=non-exist-namespace     
Error from server (NotFound): namespaces "non-exist-namespace" not found
```



#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

Fixes https://github.com/kubernetes/kubectl/issues/1122

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
fix: kubectl get/describe actions without resource names would report namespace NotFound error if the queried namespace does not exist.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
