### PR TITLE
component-base: use stderr as default output stream for JSON

### DIFF
--- a/staging/src/k8s.io/component-base/logs/example/cmd/logger.go
+++ b/staging/src/k8s.io/component-base/logs/example/cmd/logger.go
@@ -54,6 +54,8 @@ func NewLoggerCommand() *cobra.Command {
 }
 
 func runLogger() {
+	fmt.Println("This is normal output via stdout.")
+	fmt.Fprintln(os.Stderr, "This is other output via stderr.")
 	klog.Infof("Log using Infof, key: %s", "value")
 	klog.InfoS("Log using InfoS", "key", "value")
 	err := errors.New("fail")

--- a/staging/src/k8s.io/component-base/logs/json/json.go
+++ b/staging/src/k8s.io/component-base/logs/json/json.go
@@ -93,6 +93,7 @@ var _ registry.LogFormatFactory = Factory{}
 
 func (f Factory) Create(options config.FormatOptions) (logr.Logger, func()) {
 	if options.JSON.SplitStream {
+		// stdout for info messages, stderr for errors.
 		infoStream := zapcore.Lock(os.Stdout)
 		size := options.JSON.InfoBufferSize.Value()
 		if size > 0 {
@@ -107,7 +108,9 @@ func (f Factory) Create(options config.FormatOptions) (logr.Logger, func()) {
 		}
 		return NewJSONLogger(infoStream, zapcore.Lock(os.Stderr))
 	}
-	out := zapcore.Lock(os.Stdout)
+	// The default is to write to stderr (same as in klog's text output,
+	// doesn't get mixed with normal program output).
+	out := zapcore.Lock(os.Stderr)
 	return NewJSONLogger(out, out)
 }
 


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This makes it consistent with klog's text output and avoids polluting the
programs normal output with log messages. This may become relevant for command
line tools like "kubectl".

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
action required: Log messages in JSON format are written to stderr by default now (same as text format) instead of stdout. Users who expected JSON output on stdout must now capture stderr instead or in addition to stdout.
```
