### PR TITLE
kubemark: replace deprecated --log-file parameter with runner

### DIFF
--- a/cluster/images/kubemark/Dockerfile
+++ b/cluster/images/kubemark/Dockerfile
@@ -12,8 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# The line below points to distroless/base as of 2021-06-29. The SHA should be
-# kept in sycn with distroless_base definition in the WORKSPACE file.
-FROM gcr.io/distroless/base@sha256:5e3fac1733c75e0e879a9770724e3960610a5cfbbfb5366559fbc334fe86c249
+# The line below points to the latest go-runner image, a wrapper around
+# gcr.io/distroless/static which adds the go-runner command that we need
+# for redirecting log output.
+#
+# See https://console.cloud.google.com/gcr/images/k8s-staging-build-image/global/go-runner
+# for a list of available versions. This base image should be updated
+# periodically.
+FROM k8s.gcr.io/build-image/go-runner:v2.3.1-go1.17.2-bullseye.0
 
 COPY kubemark /kubemark

--- a/hack/lib/golang.sh
+++ b/hack/lib/golang.sh
@@ -336,6 +336,7 @@ readonly KUBE_STATIC_LIBRARIES=(
   kube-proxy
   kubeadm
   kubectl
+  kubemark
 )
 
 # Fully-qualified package names that we want to instrument for coverage information.

--- a/test/kubemark/resources/hollow-node_template.yaml
+++ b/test/kubemark/resources/hollow-node_template.yaml
@@ -49,12 +49,12 @@ spec:
             fieldRef:
               fieldPath: metadata.name
         command: [
+          "/go-runner",
+          "-log-file=/var/log/kubelet-$(NODE_NAME).log",
           "/kubemark",
           "--morph=kubelet",
           "--name=$(NODE_NAME)",
           "--kubeconfig=/kubeconfig/kubelet.kubeconfig",
-          "--log-file=/var/log/kubelet-$(NODE_NAME).log",
-          "--logtostderr=false",
           "--node-labels={{hollow_node_labels}}",
           {{hollow_kubelet_params}}
         ]
@@ -80,12 +80,12 @@ spec:
             fieldRef:
               fieldPath: metadata.name
         command: [
+          "/go-runner",
+          "-log-file=/var/log/kubeproxy-$(NODE_NAME).log",
           "/kubemark",
           "--morph=proxy",
           "--name=$(NODE_NAME)",
           "--kubeconfig=/kubeconfig/kubeproxy.kubeconfig",
-          "--log-file=/var/log/kubeproxy-$(NODE_NAME).log",
-          "--logtostderr=false",
           {{hollow_proxy_params}}
         ]
         volumeMounts:


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

The --log-file parameter will be deprecated as of Kubernetes 1.23 and should be
avoided. The replacement for distroless images is the image with go-runner, a
tool that handles output redirection.

#### Which issue(s) this PR fixes:
Part of: https://github.com/kubernetes/kubernetes/issues/106103

#### Does this PR introduce a user-facing change?
```release-note
kubemark is now built as a portable, static binary.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs
- KEP: https://github.com/kubernetes/enhancements/issues/2845
```
