### PR TITLE
kubectl: remove unnecessary `fmt.Sprintf`

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/version/version.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/version/version.go
@@ -135,9 +135,9 @@ func (o *Options) Run() error {
 				fmt.Fprintf(o.Out, "Server Version: %s\n", serverVersion.GitVersion)
 			}
 		} else {
-			fmt.Fprintf(o.Out, "Client Version: %s\n", fmt.Sprintf("%#v", clientVersion))
+			fmt.Fprintf(o.Out, "Client Version: %#v\n", clientVersion)
 			if serverVersion != nil {
-				fmt.Fprintf(o.Out, "Server Version: %s\n", fmt.Sprintf("%#v", *serverVersion))
+				fmt.Fprintf(o.Out, "Server Version: %#v\n", *serverVersion)
 			}
 		}
 	case "yaml":


### PR DESCRIPTION
Directly use the `%#v` verb in `fmt.Fprintf` instead.

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Slightly simplify the way versions are printed in `kubectl version`.

#### Which issue(s) this PR fixes:

none

#### Special notes for your reviewer:

none

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.: