### PR TITLE
Update sig-cli owners

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -195,6 +195,8 @@ aliases:
     - soltysh
     - pwittrock
     - eddiezane
+    - brianpursley
+    - KnVerey
   # emeritus:
   # - adohe
   # - brendandburns

--- a/staging/src/k8s.io/cli-runtime/OWNERS
+++ b/staging/src/k8s.io/cli-runtime/OWNERS
@@ -5,10 +5,16 @@ approvers:
 - pwittrock
 - seans3
 - soltysh
+- eddiezane
+- brianpursley
+- KnVerey
 reviewers:
 - deads2k
 - pwittrock
 - seans3
 - soltysh
+- eddiezane
+- brianpursley
+- KnVerey
 labels:
 - sig/cli

--- a/staging/src/k8s.io/sample-cli-plugin/OWNERS
+++ b/staging/src/k8s.io/sample-cli-plugin/OWNERS
@@ -5,10 +5,16 @@ approvers:
 - pwittrock
 - seans3
 - soltysh
+- eddiezane
+- brianpursley
+- KnVerey
 reviewers:
 - deads2k
 - pwittrock
 - seans3
 - soltysh
+- eddiezane
+- brianpursley
+- KnVerey
 labels:
 - sig/cli


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This PR updates the owners for sig-cli code/projects.

@KnVerey has stepped into the co-chair and tech lead role (https://github.com/kubernetes/community/pull/6102).

@brianpursley has demonstrated excellent decision making and respect for the code base through his contributions and leadership.

Thanks for all that the two of you do!

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
