### PR TITLE
ScoringStrategy RequestedToCapacityRatio's shape should not be empty

### DIFF
--- a/pkg/scheduler/apis/config/validation/validation_pluginargs.go
+++ b/pkg/scheduler/apis/config/validation/validation_pluginargs.go
@@ -306,7 +306,7 @@ func ValidateNodeResourcesFitArgs(path *field.Path, args *config.NodeResourcesFi
 
 	if args.ScoringStrategy != nil {
 		allErrs = append(allErrs, validateResources(args.ScoringStrategy.Resources, path.Child("resources"))...)
-		if args.ScoringStrategy.RequestedToCapacityRatio != nil && len(args.ScoringStrategy.RequestedToCapacityRatio.Shape) > 0 {
+		if args.ScoringStrategy.RequestedToCapacityRatio != nil {
 			allErrs = append(allErrs, validateFunctionShape(args.ScoringStrategy.RequestedToCapacityRatio.Shape, path.Child("shape"))...)
 		}
 	}

--- a/pkg/scheduler/apis/config/validation/validation_pluginargs_test.go
+++ b/pkg/scheduler/apis/config/validation/validation_pluginargs_test.go
@@ -947,6 +947,12 @@ func TestValidateMostAllocatedScoringStrategy(t *testing.T) {
 }
 
 func TestValidateRequestedToCapacityRatioScoringStrategy(t *testing.T) {
+	defaultShape := []config.UtilizationShapePoint{
+		{
+			Utilization: 30,
+			Score:       3,
+		},
+	}
 	tests := []struct {
 		name      string
 		resources []config.ResourceSpec
@@ -954,7 +960,18 @@ func TestValidateRequestedToCapacityRatioScoringStrategy(t *testing.T) {
 		wantErrs  field.ErrorList
 	}{
 		{
-			name: "weight greater than max",
+			name:   "no shapes",
+			shapes: nil,
+			wantErrs: field.ErrorList{
+				{
+					Type:  field.ErrorTypeRequired,
+					Field: "shape",
+				},
+			},
+		},
+		{
+			name:   "weight greater than max",
+			shapes: defaultShape,
 			resources: []config.ResourceSpec{
 				{
 					Name:   "cpu",
@@ -969,7 +986,8 @@ func TestValidateRequestedToCapacityRatioScoringStrategy(t *testing.T) {
 			},
 		},
 		{
-			name: "weight less than min",
+			name:   "weight less than min",
+			shapes: defaultShape,
 			resources: []config.ResourceSpec{
 				{
 					Name:   "cpu",
@@ -984,13 +1002,8 @@ func TestValidateRequestedToCapacityRatioScoringStrategy(t *testing.T) {
 			},
 		},
 		{
-			name: "valid shapes",
-			shapes: []config.UtilizationShapePoint{
-				{
-					Utilization: 30,
-					Score:       3,
-				},
-			},
+			name:     "valid shapes",
+			shapes:   defaultShape,
 			wantErrs: nil,
 		},
 		{


### PR DESCRIPTION
Signed-off-by: kerthcet <kerthcet@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
when we choose using `RequestedToCapacityRatio` ScoringStrategy, shape of `UtilizationShapePoint` should not be empty.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
When using `RequestedToCapacityRatio` ScoringStrategy, empty shape will cause error.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
