### PR TITLE
Make the docker buildx check call --help

### DIFF
--- a/hack/lib/util.sh
+++ b/hack/lib/util.sh
@@ -711,7 +711,7 @@ function kube::util::ensure-cfssl {
 # Check if we have "docker buildx" commands available
 #
 function kube::util::ensure-docker-buildx {
-  if docker buildx >/dev/null 2>&1; then
+  if docker buildx --help >/dev/null 2>&1; then
     return 0
   else
     echo "ERROR: docker buildx not available. Docker 19.03 or higher is required with experimental features enabled"


### PR DESCRIPTION
**IMPORTANT NOTE:** This does not introduce build support for `podman` in general. It caters to a minor difference in `docker` vs `podman` so that `kind build node-image` works **locally** with `podman` at the time of writing. YMMV in the future. See https://github.com/kubernetes/kubernetes/pull/106174#issuecomment-963404866 for more context.

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

This makes a small change to the detection logic of when `docker buildx` is available to the system. `podman` behaves slightly differently, in that an empty command returns a non-zero exit. We've added a buildx facade in https://github.com/containers/podman/pull/11134 so with this small change, one can use `kind build node-image` for testing Kubernetes builds locally using `podman`, which imo is :rocket:.

I've checked `docker buildx --help` and it returns a non-zero exit as expected.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

/assign @BenTheElder 