### PR TITLE
client-go token source transport implement RoundTripperWrapper interface

### DIFF
--- a/staging/src/k8s.io/client-go/transport/round_trippers.go
+++ b/staging/src/k8s.io/client-go/transport/round_trippers.go
@@ -92,6 +92,8 @@ type authProxyRoundTripper struct {
 	rt http.RoundTripper
 }
 
+var _ utilnet.RoundTripperWrapper = &authProxyRoundTripper{}
+
 // NewAuthProxyRoundTripper provides a roundtripper which will add auth proxy fields to requests for
 // authentication terminating proxy cases
 // assuming you pull the user from the context:
@@ -150,6 +152,8 @@ type userAgentRoundTripper struct {
 	rt    http.RoundTripper
 }
 
+var _ utilnet.RoundTripperWrapper = &userAgentRoundTripper{}
+
 // NewUserAgentRoundTripper will add User-Agent header to a request unless it has already been set.
 func NewUserAgentRoundTripper(agent string, rt http.RoundTripper) http.RoundTripper {
 	return &userAgentRoundTripper{agent, rt}
@@ -175,6 +179,8 @@ type basicAuthRoundTripper struct {
 	password string `datapolicy:"password"`
 	rt       http.RoundTripper
 }
+
+var _ utilnet.RoundTripperWrapper = &basicAuthRoundTripper{}
 
 // NewBasicAuthRoundTripper will apply a BASIC auth authorization header to a
 // request unless it has already been set.
@@ -225,6 +231,8 @@ type impersonatingRoundTripper struct {
 	delegate    http.RoundTripper
 }
 
+var _ utilnet.RoundTripperWrapper = &impersonatingRoundTripper{}
+
 // NewImpersonatingRoundTripper will add an Act-As header to a request unless it has already been set.
 func NewImpersonatingRoundTripper(impersonate ImpersonationConfig, delegate http.RoundTripper) http.RoundTripper {
 	return &impersonatingRoundTripper{impersonate, delegate}
@@ -263,6 +271,8 @@ type bearerAuthRoundTripper struct {
 	source oauth2.TokenSource
 	rt     http.RoundTripper
 }
+
+var _ utilnet.RoundTripperWrapper = &bearerAuthRoundTripper{}
 
 // NewBearerAuthRoundTripper adds the provided bearer token to a request
 // unless the authorization header has already been set.
@@ -372,6 +382,8 @@ type debuggingRoundTripper struct {
 	delegatedRoundTripper http.RoundTripper
 	levels                map[DebugLevel]bool
 }
+
+var _ utilnet.RoundTripperWrapper = &debuggingRoundTripper{}
 
 // DebugLevel is used to enable debugging of certain
 // HTTP requests and responses fields via the debuggingRoundTripper.

--- a/staging/src/k8s.io/client-go/transport/token_source.go
+++ b/staging/src/k8s.io/client-go/transport/token_source.go
@@ -119,6 +119,8 @@ func (tst *tokenSourceTransport) CancelRequest(req *http.Request) {
 	tryCancelRequest(tst.ort, req)
 }
 
+func (tst *tokenSourceTransport) WrappedRoundTripper() http.RoundTripper { return tst.base }
+
 type fileTokenSource struct {
 	path   string
 	period time.Duration

--- a/staging/src/k8s.io/client-go/transport/token_source.go
+++ b/staging/src/k8s.io/client-go/transport/token_source.go
@@ -26,6 +26,7 @@ import (
 
 	"golang.org/x/oauth2"
 
+	utilnet "k8s.io/apimachinery/pkg/util/net"
 	"k8s.io/klog/v2"
 )
 
@@ -94,6 +95,8 @@ type tokenSourceTransport struct {
 	ort  http.RoundTripper
 	src  ResettableTokenSource
 }
+
+var _ utilnet.RoundTripperWrapper = &tokenSourceTransport{}
 
 func (tst *tokenSourceTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	// This is to allow --token to override other bearer token providers.


### PR DESCRIPTION

/kind cleanup

Custom roundtrippers that doesn't implement `RoundTripperWrapper interface` doesn't allow to use the tooling we have for checking the transport details.

```release-note
NONE
```
