### PR TITLE
[wip] e2e_node: Cleanup trivial uses of Dynamic Kubelet Configuration 

### DIFF
--- a/test/e2e_node/container_log_rotation_test.go
+++ b/test/e2e_node/container_log_rotation_test.go
@@ -52,7 +52,6 @@ var _ = SIGDescribe("ContainerLogRotation [Slow] [Serial] [Disruptive]", func() 
 				e2eskipper.Skipf("Skipping as kubelet config is unavailable")
 			}
 
-			// Should ideally be set to ~3 files and 40Ki of log length.
 			maxLogFiles = int(kubeletConfig.ContainerLogMaxFiles)
 			if maxLogFiles == 0 || kubeletConfig.ContainerLogMaxSize == "" {
 				e2eskipper.Skipf("Skipping ContainerLogRotation test as rotation is not configured")
@@ -74,8 +73,8 @@ var _ = SIGDescribe("ContainerLogRotation [Slow] [Serial] [Disruptive]", func() 
 							Command: []string{
 								"sh",
 								"-c",
-								// ~12Kb/s. Exceeding 40Kb in 4 seconds. Log rotation period is 10 seconds.
-								"while true; do echo hello world; sleep 0.001; done;",
+								// ~480Kb/s. Log rotation period is 10 seconds.
+								"while true; do echo the quick brown fox jumped over the lonely wolf; sleep 0.0001; done;",
 							},
 						},
 					},

--- a/test/e2e_node/jenkins/default-kubelet-config.yaml
+++ b/test/e2e_node/jenkins/default-kubelet-config.yaml
@@ -25,3 +25,9 @@ evictionMinimumReclaim:
 
 serializeImagePulls: false
 
+# Node E2E Tests depend on log rotation, specifically: container_log_rotation_test.go
+# this is relatively safe to enable by default in E2Es. We
+containerLogMaxFiles: 3
+containerLogMaxSize: "10Mi"
+
+


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/area test
/sig node

#### What this PR does / why we need it:

This PR takes some of the "simpler" uses of DynamicKubeletConfiguration in e2e_node, and migrates them to using standard configuration where appropriate.

This pass through is going to mostly focus on cases where updating the baseline configuration should not have negative effects on other tests. I'm opening it from the first migration to have a place to run through various node suites to avoid running into last minute surprises.

#### Which issue(s) this PR fixes:

Related to #105047

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```