### PR TITLE
Automated cherry pick of #105273: tests: Wait for pod collection to enter a Running state

### DIFF
--- a/test/e2e/common/node/pods.go
+++ b/test/e2e/common/node/pods.go
@@ -866,14 +866,12 @@ var _ = SIGDescribe("Pods", func() {
 				}}, metav1.CreateOptions{})
 			framework.ExpectNoError(err, "failed to create pod")
 			framework.Logf("created %v", podTestName)
-			framework.ExpectNoError(e2epod.WaitForPodNameRunningInNamespace(f.ClientSet, podTestName, f.Namespace.Name))
-			framework.Logf("running and ready %v", podTestName)
 		}
 
-		// wait as required for all 3 pods to be found
-		ginkgo.By("waiting for all 3 pods to be located")
-		err := wait.PollImmediate(podRetryPeriod, podRetryTimeout, checkPodListQuantity(f, "type=Testing", 3))
-		framework.ExpectNoError(err, "3 pods not found")
+		// wait as required for all 3 pods to be running
+		ginkgo.By("waiting for all 3 pods to be running")
+		err := e2epod.WaitForPodsRunningReady(f.ClientSet, f.Namespace.Name, 3, 0, framework.PodStartTimeout, nil)
+		framework.ExpectNoError(err, "3 pods not found running.")
 
 		// delete Collection of pods with a label in the current namespace
 		err = f.ClientSet.CoreV1().Pods(f.Namespace.Name).DeleteCollection(context.TODO(), metav1.DeleteOptions{GracePeriodSeconds: &one}, metav1.ListOptions{

--- a/test/e2e/common/node/pods.go
+++ b/test/e2e/common/node/pods.go
@@ -866,6 +866,8 @@ var _ = SIGDescribe("Pods", func() {
 				}}, metav1.CreateOptions{})
 			framework.ExpectNoError(err, "failed to create pod")
 			framework.Logf("created %v", podTestName)
+			framework.ExpectNoError(e2epod.WaitForPodNameRunningInNamespace(f.ClientSet, podTestName, f.Namespace.Name))
+			framework.Logf("running and ready %v", podTestName)
 		}
 
 		// wait as required for all 3 pods to be found


### PR DESCRIPTION
Cherry pick of #105273 on release-1.22.

#105273: tests: Wait for pod collection to enter a Running state


#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind flake
/sig testing
/sig windows

/priority important-soon

#### What this PR does / why we need it:

While running tests in parallel, especially those with higher loads than others, it might take some time for Pods to be Running, even more so if the image has to be pulled as well.

The test ``[sig-node] Pods should delete a collection of pods [Conformance]`` only waits for the for the pods to be scheduled before deleting them, and expects them to be gone in 1 minute, which can flake because of the above reasons. Note that the operations are in order, and kubelet runs them in order, which means that the pod first has to enter the Running state before attempting to delete it.

This commit waits for the Pods to enter the Running state first before deleting the entire collection.

Co-Authored-By: Antonio Ojea <aojea@redhat.com>

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #103671

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
NONE
```