### PR TITLE
Fix creation of the administrator_keys_file file with many users

### DIFF
--- a/cluster/gce/windows/testonly/install-ssh.psm1
+++ b/cluster/gce/windows/testonly/install-ssh.psm1
@@ -129,6 +129,18 @@ Add-Type -AssemblyName System.Web
 
 $poll_interval = 10
 
+# New for v7.9.0.0: administrators_authorized_keys file. For permission
+# information see
+# https://github.com/PowerShell/Win32-OpenSSH/wiki/Security-protection-of-various-files-in-Win32-OpenSSH#administrators_authorized_keys.
+# this file is created only once, each valid user will be added here
+$administrator_keys_file = ${env:ProgramData} + `
+    "\ssh\administrators_authorized_keys"
+New-Item -ItemType file -Force $administrator_keys_file | Out-Null
+icacls $administrator_keys_file /inheritance:r | Out-Null
+icacls $administrator_keys_file /grant SYSTEM:`(F`) | Out-Null
+icacls $administrator_keys_file /grant BUILTIN\Administrators:`(F`) | `
+    Out-Null
+
 while($true) {
   $r1 = ""
   $r2 = ""
@@ -191,10 +203,18 @@ while($true) {
 
     $pw = [System.Web.Security.Membership]::GeneratePassword(16,2)
     try {
-      # Create-NewProfile will throw this when the user profile already exists:
+      # Create-NewProfile will throw these errors:
+      #
+      # - if the username already exists:
+      #
       #   Create-NewProfile : Exception calling "SetInfo" with "0" argument(s):
       #   "The account already exists."
-      # Just catch it and ignore it.
+      #
+      # - if the username is invalid (e.g. gke-29bd5e8d9ea0446f829d)
+      #
+      #   Create-NewProfile : Exception calling "SetInfo" with "0" argument(s): "The specified username is invalid.
+      #
+      # Just catch them and ignore them.
       Create-NewProfile $username $pw -ErrorAction Stop
 
       # Add the user to the Administrators group, otherwise we will not have
@@ -209,29 +229,26 @@ while($true) {
       return
     }
 
-    # NOTE: there is a race condition here where someone could try to ssh to
-    # this node in-between when we clear out the authorized_keys file and when
-    # we write keys to it. Oh well.
+    # the authorized_keys file is created only once per user
     $user_keys_file = -join($user_dir, "\.ssh\authorized_keys")
-    New-Item -ItemType file -Force $user_keys_file | Out-Null
-
-    # New for v7.9.0.0: administrators_authorized_keys file. For permission
-    # information see
-    # https://github.com/PowerShell/Win32-OpenSSH/wiki/Security-protection-of-various-files-in-Win32-OpenSSH#administrators_authorized_keys.
-    $administrator_keys_file = ${env:ProgramData} + `
-        "\ssh\administrators_authorized_keys"
-    New-Item -ItemType file -Force $administrator_keys_file | Out-Null
-    icacls $administrator_keys_file /inheritance:r | Out-Null
-    icacls $administrator_keys_file /grant SYSTEM:`(F`) | Out-Null
-    icacls $administrator_keys_file /grant BUILTIN\Administrators:`(F`) | `
-        Out-Null
+    if (-not (Test-Path $user_keys_file)) {
+      New-Item -ItemType file -Force $user_keys_file | Out-Null
+    }
 
     ForEach ($ssh_key in $_.value) {
       # authorized_keys and other ssh config files must be UTF-8 encoded:
       # https://github.com/PowerShell/Win32-OpenSSH/issues/862
       # https://github.com/PowerShell/Win32-OpenSSH/wiki/Various-Considerations
-      Add-Content -Encoding UTF8 $user_keys_file $ssh_key
-      Add-Content -Encoding UTF8 $administrator_keys_file $ssh_key
+      #
+      # these files will be append only, only new keys will be added
+      $found = Select-String -Path $user_keys_file -Pattern $ssh_key
+      if ($found -eq $null) {
+        Add-Content -Encoding UTF8 $user_keys_file $ssh_key
+      }
+      $found = Select-String -Path $administrator_keys_file -Pattern $ssh_key
+      if ($found -eq $null) {
+        Add-Content -Encoding UTF8 $administrator_keys_file $ssh_key
+      }
     }
   }
   Start-Sleep -sec $poll_interval


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Fixes a couple of things:

- It's possible that there are multiple valid users in sshKeys e.g. (prow, root, ...), while all of them need to be added to the administators_authorized_keys it looks like for each user this file is cleaned first and then the user keys are added overwriting the keys written for a previous user!
- I saw that the user_keys_file and the administrator_keys_file are recreated on every iteration which leads to race conditions, we could instead treat these files as append only and only add new keys that weren't seen in the file, with this the file no longer needs to be removed, the tradeoff is that revoked keys can't be removed but may not happen in practice

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

/cc @pjh 