### PR TITLE
e2e_node: fixes after dynamic configuration removal

### DIFF
--- a/test/e2e_node/cpu_manager_test.go
+++ b/test/e2e_node/cpu_manager_test.go
@@ -228,7 +228,7 @@ func configureCPUManagerInKubelet(oldCfg *kubeletconfig.KubeletConfiguration, ku
 		}
 	}
 
-	return oldCfg
+	return newCfg
 }
 
 func runGuPodTest(f *framework.Framework, cpuCount int) {
@@ -532,8 +532,10 @@ func runCPUManagerTests(f *framework.Framework) {
 
 	ginkgo.BeforeEach(func() {
 		var err error
-		oldCfg, err = getCurrentKubeletConfig()
-		framework.ExpectNoError(err)
+		if oldCfg == nil {
+			oldCfg, err = getCurrentKubeletConfig()
+			framework.ExpectNoError(err)
+		}
 	})
 
 	ginkgo.It("should assign CPUs as expected based on the Pod spec", func() {

--- a/test/e2e_node/e2e_node_suite_test.go
+++ b/test/e2e_node/e2e_node_suite_test.go
@@ -85,7 +85,7 @@ func registerNodeFlags(flags *flag.FlagSet) {
 	// It is hard and unnecessary to deal with the complexity inside the test suite.
 	flags.BoolVar(&framework.TestContext.NodeConformance, "conformance", false, "If true, the test suite will not start kubelet, and fetch system log (kernel, docker, kubelet log etc.) to the report directory.")
 	flags.BoolVar(&framework.TestContext.PrepullImages, "prepull-images", true, "If true, prepull images so image pull failures do not cause test failures.")
-	flags.BoolVar(&framework.TestContext.RestartKubelet, "restart-kubelet", true, "If true, restart Kubelet unit when the process is killed.")
+	flags.BoolVar(&framework.TestContext.RestartKubelet, "restart-kubelet", false, "If true, restart Kubelet unit when the process is killed.")
 	flags.StringVar(&framework.TestContext.ImageDescription, "image-description", "", "The description of the image which the test will be running on.")
 	flags.StringVar(&framework.TestContext.SystemSpecName, "system-spec-name", "", "The name of the system spec (e.g., gke) that's used in the node e2e test. The system specs are in test/e2e_node/system/specs/. This is used by the test framework to determine which tests to run for validating the system requirements.")
 	flags.Var(cliflag.NewMapStringString(&framework.TestContext.ExtraEnvs), "extra-envs", "The extra environment variables needed for node e2e tests. Format: a list of key=value pairs, e.g., env1=val1,env2=val2")

--- a/test/e2e_node/topology_manager_test.go
+++ b/test/e2e_node/topology_manager_test.go
@@ -923,7 +923,7 @@ func runTopologyManagerTests(f *framework.Framework) {
 
 		configMap := getSRIOVDevicePluginConfigMap(framework.TestContext.SriovdpConfigMapFile)
 
-		oldCfg, err := getCurrentKubeletConfig()
+		oldCfg, err = getCurrentKubeletConfig()
 		framework.ExpectNoError(err)
 
 		policy := topologymanager.PolicySingleNumaNode
@@ -936,8 +936,10 @@ func runTopologyManagerTests(f *framework.Framework) {
 	})
 
 	ginkgo.AfterEach(func() {
-		// restore kubelet config
-		updateKubeletConfig(f, oldCfg, true)
+		if oldCfg != nil {
+			// restore kubelet config
+			updateKubeletConfig(f, oldCfg, true)
+		}
 	})
 }
 

--- a/test/e2e_node/util.go
+++ b/test/e2e_node/util.go
@@ -163,7 +163,8 @@ func tempSetCurrentKubeletConfig(f *framework.Framework, updateFunction func(ini
 	var oldCfg *kubeletconfig.KubeletConfiguration
 
 	ginkgo.BeforeEach(func() {
-		oldCfg, err := getCurrentKubeletConfig()
+		var err error
+		oldCfg, err = getCurrentKubeletConfig()
 		framework.ExpectNoError(err)
 
 		newCfg := oldCfg.DeepCopy()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind failing-test
/kind bug

#### What this PR does / why we need it:

The PR should fix a number of tests that were broken after Dynamic Kubelet configuration removal.

Fixes:
- CPU manager
- Memory manager

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
