### PR TITLE
staging/publishing: fix go version for go1.16.10

### DIFF
--- a/staging/publishing/rules.yaml
+++ b/staging/publishing/rules.yaml
@@ -29,12 +29,12 @@ rules:
       branch: release-1.21
       dir: staging/src/k8s.io/code-generator
     name: release-1.21
-    go: 1.16.9qqq
+    go: 1.16.10
   - source:
       branch: release-1.22
       dir: staging/src/k8s.io/code-generator
     name: release-1.22
-    go: 1.16.9qqq
+    go: 1.16.10
 
 - destination: apimachinery
   library: true
@@ -57,12 +57,12 @@ rules:
       branch: release-1.21
       dir: staging/src/k8s.io/apimachinery
     name: release-1.21
-    go: 1.16.9qqq
+    go: 1.16.10
   - source:
       branch: release-1.22
       dir: staging/src/k8s.io/apimachinery
     name: release-1.22
-    go: 1.16.9qqq
+    go: 1.16.10
 
 - destination: api
   library: true
@@ -94,7 +94,7 @@ rules:
       branch: release-1.21
       dir: staging/src/k8s.io/api
     name: release-1.21
-    go: 1.16.9qqq
+    go: 1.16.10
     dependencies:
       - repository: apimachinery
         branch: release-1.21
@@ -102,7 +102,7 @@ rules:
       branch: release-1.22
       dir: staging/src/k8s.io/api
     name: release-1.22
-    go: 1.16.9qqq
+    go: 1.16.10
     dependencies:
     - repository: apimachinery
       branch: release-1.22
@@ -155,7 +155,7 @@ rules:
       branch: release-1.21
       dir: staging/src/k8s.io/client-go
     name: release-1.21
-    go: 1.16.9qqq
+    go: 1.16.10
     dependencies:
       - repository: apimachinery
         branch: release-1.21
@@ -169,7 +169,7 @@ rules:
       branch: release-1.22
       dir: staging/src/k8s.io/client-go
     name: release-1.22
-    go: 1.16.9qqq
+    go: 1.16.10
     dependencies:
       - repository: apimachinery
         branch: release-1.22
@@ -222,7 +222,7 @@ rules:
       branch: release-1.21
       dir: staging/src/k8s.io/component-base
     name: release-1.21
-    go: 1.16.9qqq
+    go: 1.16.10
     dependencies:
     - repository: apimachinery
       branch: release-1.21
@@ -234,7 +234,7 @@ rules:
       branch: release-1.22
       dir: staging/src/k8s.io/component-base
     name: release-1.22
-    go: 1.16.9qqq
+    go: 1.16.10
     dependencies:
     - repository: apimachinery
       branch: release-1.22
@@ -273,7 +273,7 @@ rules:
       branch: release-1.21
       dir: staging/src/k8s.io/component-helpers
     name: release-1.21
-    go: 1.16.9qqq
+    go: 1.16.10
     dependencies:
     - repository: apimachinery
       branch: release-1.21
@@ -285,7 +285,7 @@ rules:
       branch: release-1.22
       dir: staging/src/k8s.io/component-helpers
     name: release-1.22
-    go: 1.16.9qqq
+    go: 1.16.10
     dependencies:
     - repository: apimachinery
       branch: release-1.22
@@ -342,7 +342,7 @@ rules:
       branch: release-1.21
       dir: staging/src/k8s.io/apiserver
     name: release-1.21
-    go: 1.16.9qqq
+    go: 1.16.10
     dependencies:
     - repository: apimachinery
       branch: release-1.21
@@ -356,7 +356,7 @@ rules:
       branch: release-1.22
       dir: staging/src/k8s.io/apiserver
     name: release-1.22
-    go: 1.16.9qqq
+    go: 1.16.10
     dependencies:
     - repository: apimachinery
       branch: release-1.22
@@ -426,7 +426,7 @@ rules:
       branch: release-1.21
       dir: staging/src/k8s.io/kube-aggregator
     name: release-1.21
-    go: 1.16.9qqq
+    go: 1.16.10
     dependencies:
     - repository: apimachinery
       branch: release-1.21
@@ -444,7 +444,7 @@ rules:
       branch: release-1.22
       dir: staging/src/k8s.io/kube-aggregator
     name: release-1.22
-    go: 1.16.9qqq
+    go: 1.16.10
     dependencies:
     - repository: apimachinery
       branch: release-1.22
@@ -533,7 +533,7 @@ rules:
       branch: release-1.21
       dir: staging/src/k8s.io/sample-apiserver
     name: release-1.21
-    go: 1.16.9qqq
+    go: 1.16.10
     dependencies:
     - repository: apimachinery
       branch: release-1.21
@@ -556,7 +556,7 @@ rules:
       branch: release-1.22
       dir: staging/src/k8s.io/sample-apiserver
     name: release-1.22
-    go: 1.16.9qqq
+    go: 1.16.10
     dependencies:
     - repository: apimachinery
       branch: release-1.22
@@ -638,7 +638,7 @@ rules:
       branch: release-1.21
       dir: staging/src/k8s.io/sample-controller
     name: release-1.21
-    go: 1.16.9qqq
+    go: 1.16.10
     dependencies:
     - repository: apimachinery
       branch: release-1.21
@@ -657,7 +657,7 @@ rules:
       branch: release-1.22
       dir: staging/src/k8s.io/sample-controller
     name: release-1.22
-    go: 1.16.9qqq
+    go: 1.16.10
     dependencies:
     - repository: apimachinery
       branch: release-1.22
@@ -738,7 +738,7 @@ rules:
       branch: release-1.21
       dir: staging/src/k8s.io/apiextensions-apiserver
     name: release-1.21
-    go: 1.16.9qqq
+    go: 1.16.10
     dependencies:
     - repository: apimachinery
       branch: release-1.21
@@ -758,7 +758,7 @@ rules:
       branch: release-1.22
       dir: staging/src/k8s.io/apiextensions-apiserver
     name: release-1.22
-    go: 1.16.9qqq
+    go: 1.16.10
     dependencies:
     - repository: apimachinery
       branch: release-1.22
@@ -823,7 +823,7 @@ rules:
       branch: release-1.21
       dir: staging/src/k8s.io/metrics
     name: release-1.21
-    go: 1.16.9qqq
+    go: 1.16.10
     dependencies:
     - repository: apimachinery
       branch: release-1.21
@@ -837,7 +837,7 @@ rules:
       branch: release-1.22
       dir: staging/src/k8s.io/metrics
     name: release-1.22
-    go: 1.16.9qqq
+    go: 1.16.10
     dependencies:
     - repository: apimachinery
       branch: release-1.22
@@ -890,7 +890,7 @@ rules:
       branch: release-1.21
       dir: staging/src/k8s.io/cli-runtime
     name: release-1.21
-    go: 1.16.9qqq
+    go: 1.16.10
     dependencies:
     - repository: api
       branch: release-1.21
@@ -902,7 +902,7 @@ rules:
       branch: release-1.22
       dir: staging/src/k8s.io/cli-runtime
     name: release-1.22
-    go: 1.16.9qqq
+    go: 1.16.10
     dependencies:
     - repository: api
       branch: release-1.22
@@ -959,7 +959,7 @@ rules:
       branch: release-1.21
       dir: staging/src/k8s.io/sample-cli-plugin
     name: release-1.21
-    go: 1.16.9qqq
+    go: 1.16.10
     dependencies:
     - repository: api
       branch: release-1.21
@@ -973,7 +973,7 @@ rules:
       branch: release-1.22
       dir: staging/src/k8s.io/sample-cli-plugin
     name: release-1.22
-    go: 1.16.9qqq
+    go: 1.16.10
     dependencies:
     - repository: api
       branch: release-1.22
@@ -1032,7 +1032,7 @@ rules:
       branch: release-1.21
       dir: staging/src/k8s.io/kube-proxy
     name: release-1.21
-    go: 1.16.9qqq
+    go: 1.16.10
     dependencies:
     - repository: apimachinery
       branch: release-1.21
@@ -1046,7 +1046,7 @@ rules:
       branch: release-1.22
       dir: staging/src/k8s.io/kube-proxy
     name: release-1.22
-    go: 1.16.9qqq
+    go: 1.16.10
     dependencies:
     - repository: apimachinery
       branch: release-1.22
@@ -1105,7 +1105,7 @@ rules:
       branch: release-1.21
       dir: staging/src/k8s.io/kubelet
     name: release-1.21
-    go: 1.16.9qqq
+    go: 1.16.10
     dependencies:
     - repository: apimachinery
       branch: release-1.21
@@ -1119,7 +1119,7 @@ rules:
       branch: release-1.22
       dir: staging/src/k8s.io/kubelet
     name: release-1.22
-    go: 1.16.9qqq
+    go: 1.16.10
     dependencies:
     - repository: apimachinery
       branch: release-1.22
@@ -1178,7 +1178,7 @@ rules:
       branch: release-1.21
       dir: staging/src/k8s.io/kube-scheduler
     name: release-1.21
-    go: 1.16.9qqq
+    go: 1.16.10
     dependencies:
     - repository: apimachinery
       branch: release-1.21
@@ -1192,7 +1192,7 @@ rules:
       branch: release-1.22
       dir: staging/src/k8s.io/kube-scheduler
     name: release-1.22
-    go: 1.16.9qqq
+    go: 1.16.10
     dependencies:
     - repository: apimachinery
       branch: release-1.22
@@ -1246,7 +1246,7 @@ rules:
       branch: release-1.21
       dir: staging/src/k8s.io/controller-manager
     name: release-1.21
-    go: 1.16.9qqq
+    go: 1.16.10
     dependencies:
     - repository: api
       branch: release-1.21
@@ -1262,7 +1262,7 @@ rules:
       branch: release-1.22
       dir: staging/src/k8s.io/controller-manager
     name: release-1.22
-    go: 1.16.9qqq
+    go: 1.16.10
     dependencies:
     - repository: api
       branch: release-1.22
@@ -1331,7 +1331,7 @@ rules:
       branch: release-1.21
       dir: staging/src/k8s.io/cloud-provider
     name: release-1.21
-    go: 1.16.9qqq
+    go: 1.16.10
     dependencies:
     - repository: api
       branch: release-1.21
@@ -1349,7 +1349,7 @@ rules:
       branch: release-1.22
       dir: staging/src/k8s.io/cloud-provider
     name: release-1.22
-    go: 1.16.9qqq
+    go: 1.16.10
     dependencies:
     - repository: api
       branch: release-1.22
@@ -1424,7 +1424,7 @@ rules:
       branch: release-1.21
       dir: staging/src/k8s.io/kube-controller-manager
     name: release-1.21
-    go: 1.16.9qqq
+    go: 1.16.10
     dependencies:
     - repository: apimachinery
       branch: release-1.21
@@ -1444,7 +1444,7 @@ rules:
       branch: release-1.22
       dir: staging/src/k8s.io/kube-controller-manager
     name: release-1.22
-    go: 1.16.9qqq
+    go: 1.16.10
     dependencies:
     - repository: apimachinery
       branch: release-1.22
@@ -1497,7 +1497,7 @@ rules:
       branch: release-1.21
       dir: staging/src/k8s.io/cluster-bootstrap
     name: release-1.21
-    go: 1.16.9qqq
+    go: 1.16.10
     dependencies:
     - repository: apimachinery
       branch: release-1.21
@@ -1507,7 +1507,7 @@ rules:
       branch: release-1.22
       dir: staging/src/k8s.io/cluster-bootstrap
     name: release-1.22
-    go: 1.16.9qqq
+    go: 1.16.10
     dependencies:
     - repository: apimachinery
       branch: release-1.22
@@ -1556,7 +1556,7 @@ rules:
       branch: release-1.21
       dir: staging/src/k8s.io/csi-translation-lib
     name: release-1.21
-    go: 1.16.9qqq
+    go: 1.16.10
     dependencies:
     - repository: api
       branch: release-1.21
@@ -1566,7 +1566,7 @@ rules:
       branch: release-1.22
       dir: staging/src/k8s.io/csi-translation-lib
     name: release-1.22
-    go: 1.16.9qqq
+    go: 1.16.10
     dependencies:
     - repository: api
       branch: release-1.22
@@ -1589,12 +1589,12 @@ rules:
       branch: release-1.21
       dir: staging/src/k8s.io/mount-utils
     name: release-1.21
-    go: 1.16.9qqq
+    go: 1.16.10
   - source:
       branch: release-1.22
       dir: staging/src/k8s.io/mount-utils
     name: release-1.22
-    go: 1.16.9qqq
+    go: 1.16.10
 
 - destination: legacy-cloud-providers
   library: true
@@ -1668,7 +1668,7 @@ rules:
       branch: release-1.21
       dir: staging/src/k8s.io/legacy-cloud-providers
     name: release-1.21
-    go: 1.16.9qqq
+    go: 1.16.10
     dependencies:
     - repository: api
       branch: release-1.21
@@ -1690,7 +1690,7 @@ rules:
       branch: release-1.22
       dir: staging/src/k8s.io/legacy-cloud-providers
     name: release-1.22
-    go: 1.16.9qqq
+    go: 1.16.10
     dependencies:
     - repository: api
       branch: release-1.22
@@ -1732,12 +1732,12 @@ rules:
       branch: release-1.21
       dir: staging/src/k8s.io/cri-api
     name: release-1.21
-    go: 1.16.9qqq
+    go: 1.16.10
   - source:
       branch: release-1.22
       dir: staging/src/k8s.io/cri-api
     name: release-1.22
-    go: 1.16.9qqq
+    go: 1.16.10
 
 - destination: kubectl
   library: true
@@ -1809,7 +1809,7 @@ rules:
       branch: release-1.21
       dir: staging/src/k8s.io/kubectl
     name: release-1.21
-    go: 1.16.9qqq
+    go: 1.16.10
     dependencies:
     - repository: api
       branch: release-1.21
@@ -1831,7 +1831,7 @@ rules:
       branch: release-1.22
       dir: staging/src/k8s.io/kubectl
     name: release-1.22
-    go: 1.16.9qqq
+    go: 1.16.10
     dependencies:
     - repository: api
       branch: release-1.22
@@ -1872,7 +1872,7 @@ rules:
       branch: release-1.22
       dir: staging/src/k8s.io/pod-security-admission
     name: release-1.22
-    go: 1.16.9qqq
+    go: 1.16.10
     dependencies:
     - repository: api
       branch: release-1.22


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

https://github.com/kubernetes/kubernetes/pull/106209 updated the go version in the publishing-bot rules. The PR intended to update the go version from `1.16.9` to `1.16.10` (see associated issue - https://github.com/kubernetes/release/issues/2304) but incorrectly updated the version to `1.16.9qqq`.

This broke the publishing-bot - https://github.com/kubernetes/kubernetes/issues/56876#issuecomment-962803889

```
The last publishing run failed: command "/bin/bash -c curl -SLf https://storage.googleapis.com/golang/go1.16.9qqq.linux-amd64.tar.gz | tar -xz --strip 1 -C /go-workspace/go-tmp-117722696" failed: exit status 2
```

This PR fixes the go version to `1.16.10`.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

/assign @cpanato 