### PR TITLE
Changed code to improve output for files under test/e2e/instrumentation

### DIFF
--- a/test/e2e/instrumentation/core_events.go
+++ b/test/e2e/instrumentation/core_events.go
@@ -84,7 +84,9 @@ var _ = common.SIGDescribe("Events", func() {
 				break
 			}
 		}
-		framework.ExpectEqual(foundCreatedEvent, true, "unable to find the test event")
+		if !foundCreatedEvent {
+			framework.Failf("unable to find test event %s in namespace %s, full list of events is %+v", eventTestName, f.Namespace.Name, eventsList.Items)
+		}
 
 		ginkgo.By("patching the test event")
 		// patch the event's message
@@ -121,7 +123,9 @@ var _ = common.SIGDescribe("Events", func() {
 				break
 			}
 		}
-		framework.ExpectEqual(foundCreatedEvent, false, "should not have found test event after deletion")
+		if foundCreatedEvent {
+			framework.Failf("Should not have found test event %s in namespace %s, full list of events %+v", eventTestName, f.Namespace.Name, eventsList.Items)
+		}
 	})
 
 	/*

--- a/test/e2e/instrumentation/events.go
+++ b/test/e2e/instrumentation/events.go
@@ -101,11 +101,15 @@ var _ = common.SIGDescribe("Events API", func() {
 
 		ginkgo.By("listing events in all namespaces")
 		foundCreatedEvent := eventExistsInList(clientAllNamespaces, f.Namespace.Name, eventName)
-		framework.ExpectEqual(foundCreatedEvent, true, "failed to find test event in list with cluster scope")
+		if !foundCreatedEvent {
+			framework.Failf("Failed to find test event %s in namespace %s, in list with cluster scope", eventName, f.Namespace.Name)
+		}
 
 		ginkgo.By("listing events in test namespace")
 		foundCreatedEvent = eventExistsInList(client, f.Namespace.Name, eventName)
-		framework.ExpectEqual(foundCreatedEvent, true, "failed to find test event in list with namespace scope")
+		if !foundCreatedEvent {
+			framework.Failf("Failed to find test event %s in namespace %s, in list with namespace scope", eventName, f.Namespace.Name)
+		}
 
 		ginkgo.By("listing events with field selection filtering on source")
 		filteredCoreV1List, err := coreClient.List(context.TODO(), metav1.ListOptions{FieldSelector: "source=test-controller"})
@@ -172,11 +176,15 @@ var _ = common.SIGDescribe("Events API", func() {
 
 		ginkgo.By("listing events in all namespaces")
 		foundCreatedEvent = eventExistsInList(clientAllNamespaces, f.Namespace.Name, eventName)
-		framework.ExpectEqual(foundCreatedEvent, false, "should not have found test event after deletion")
+		if foundCreatedEvent {
+			framework.Failf("Should not have found test event %s in namespace %s, in list with cluster scope after deletion", eventName, f.Namespace.Name)
+		}
 
 		ginkgo.By("listing events in test namespace")
 		foundCreatedEvent = eventExistsInList(client, f.Namespace.Name, eventName)
-		framework.ExpectEqual(foundCreatedEvent, false, "should not have found test event after deletion")
+		if foundCreatedEvent {
+			framework.Failf("Should not have found test event %s in namespace %s, in list with namespace scope after deletion", eventName, f.Namespace.Name)
+		}
 	})
 
 	/*


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
Enhancement
<!--
Add one of the following kinds:
/kind cleanup

Optionally add one or more of the following kinds if applicable:
-->

#### What this PR does / why we need it:
For better (more informative) output for developers when test fails. Changed files are under test/e2e/instrumentation for this PR.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Part of #105678

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
