### PR TITLE
fix test for CheckpointStateRestore

### DIFF
--- a/pkg/kubelet/cm/cpumanager/state/state_checkpoint_test.go
+++ b/pkg/kubelet/cm/cpumanager/state/state_checkpoint_test.go
@@ -17,13 +17,13 @@ limitations under the License.
 package state
 
 import (
-	"github.com/stretchr/testify/require"
 	"io/ioutil"
 	"os"
 	"reflect"
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/require"
 	"k8s.io/kubernetes/pkg/kubelet/checkpointmanager"
 	"k8s.io/kubernetes/pkg/kubelet/cm/containermap"
 	testutil "k8s.io/kubernetes/pkg/kubelet/cm/cpumanager/state/testing"

--- a/pkg/kubelet/cm/cpumanager/state/state_checkpoint_test.go
+++ b/pkg/kubelet/cm/cpumanager/state/state_checkpoint_test.go
@@ -225,15 +225,19 @@ func TestCheckpointStateRestore(t *testing.T) {
 			}
 
 			restoredState, err := NewCheckpointState(testingDir, testingCheckpoint, tc.policyName, tc.initialContainers)
-			if err != nil {
-				if strings.TrimSpace(tc.expectedError) != "" {
-					if strings.Contains(err.Error(), "could not restore state from checkpoint") &&
-						strings.Contains(err.Error(), tc.expectedError) {
-						t.Logf("got expected error: %v", err)
-						return
-					}
+			if strings.TrimSpace(tc.expectedError) == "" {
+				if err != nil {
+					t.Fatalf("unexpected error while creating checkpointState: %v", err)
 				}
-				t.Fatalf("unexpected error while creatng checkpointState: %v", err)
+			} else {
+				if err == nil {
+					t.Fatalf("expected error: %s, got nil", tc.expectedError)
+				}
+				if strings.Contains(err.Error(), "could not restore state from checkpoint") &&
+					strings.Contains(err.Error(), tc.expectedError) {
+					t.Logf("got expected error: %v", err)
+					return
+				}
 			}
 
 			// compare state after restoration with the one expected


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Fix `TestCheckpointStateRestore` test by comparing `expectedError` with the `err` returned by `NewCheckpointState` function.