### PR TITLE
Use simple match instead of regex match in GCE Windows OpenSSH startup script

### DIFF
--- a/cluster/gce/windows/testonly/install-ssh.psm1
+++ b/cluster/gce/windows/testonly/install-ssh.psm1
@@ -241,11 +241,11 @@ while($true) {
       # https://github.com/PowerShell/Win32-OpenSSH/wiki/Various-Considerations
       #
       # these files will be append only, only new keys will be added
-      $found = Select-String -Path $user_keys_file -Pattern $ssh_key
+      $found = Select-String -Path $user_keys_file -Pattern $ssh_key -SimpleMatch
       if ($found -eq $null) {
         Add-Content -Encoding UTF8 $user_keys_file $ssh_key
       }
-      $found = Select-String -Path $administrator_keys_file -Pattern $ssh_key
+      $found = Select-String -Path $administrator_keys_file -Pattern $ssh_key -SimpleMatch
       if ($found -eq $null) {
         Add-Content -Encoding UTF8 $administrator_keys_file $ssh_key
       }


### PR DESCRIPTION
/kind bug

#### What this PR does / why we need it:

Followup of #106196, the good news is that the SSH issue is fixed! Prow could SSH to the Windows VM however after checking the contents of the `administrators_keys_file` I saw that it was increasing in size for every run of the loop, this is because of these new lines:

```
      $found = Select-String -Path $user_keys_file -Pattern $ssh_key
      if ($found -eq $null) {
        Add-Content -Encoding UTF8 $user_keys_file $ssh_key
      }
      $found = Select-String -Path $administrator_keys_file -Pattern $ssh_key
      if ($found -eq $null) {
        Add-Content -Encoding UTF8 $administrator_keys_file $ssh_key
      }
```

`Select-String` is using regex by default and the pattern contains some characters that are interpreted differently if they're part of a regex expression and therefore a key would never be found and it'd be appended to the file even if the string was there, I saw that [`-SimpleMatch`](https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.utility/select-string?view=powershell-7.2#:~:text=False-,-SimpleMatch,value%20of%20the%20Pattern%20parameter%20as%20a%20regular%20expression%20statement.,-Also%2C%20when%20SimpleMatch) fixes it.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

/cc @pjh 
/sig windows