### PR TITLE
Add support to build and install credential provider in node e2e 

### DIFF
--- a/hack/make-rules/test-e2e-node.sh
+++ b/hack/make-rules/test-e2e-node.sh
@@ -50,6 +50,7 @@ runtime_config=${RUNTIME_CONFIG:-}
 ssh_user=${SSH_USER:-"${USER}"}
 ssh_key=${SSH_KEY:-}
 kubelet_config_file=${KUBELET_CONFIG_FILE:-"test/e2e_node/jenkins/default-kubelet-config.yaml"}
+install_credential_provider=${INSTALL_CREDENTIAL_PROVIDER:-false}
 
 # Parse the flags to pass to ginkgo
 ginkgoflags=""
@@ -178,6 +179,7 @@ if [ "${remote}" = true ] ; then
     --runtime-config="${runtime_config}" --preemptible-instances="${preemptible_instances}" \
     --ssh-user="${ssh_user}" --ssh-key="${ssh_key}" --image-config-dir="${image_config_dir}" \
     --extra-envs="${extra_envs}" --kubelet-config-file="${kubelet_config_file}"  --test-suite="${test_suite}" \
+    --install-credential-provider="${install_credential_provider}" \
     "${timeout_arg}" \
     2>&1 | tee -i "${artifacts}/build-log.txt"
   exit $?

--- a/pkg/credentialprovider/provider.go
+++ b/pkg/credentialprovider/provider.go
@@ -42,6 +42,8 @@ type DockerConfigProvider interface {
 // A DockerConfigProvider that simply reads the .dockercfg file
 type defaultDockerConfigProvider struct{}
 
+var warnOnce sync.Once
+
 // init registers our default provider, which simply reads the .dockercfg file.
 func init() {
 	RegisterCredentialProvider(".dockercfg",
@@ -70,6 +72,12 @@ type CachingDockerConfigProvider struct {
 
 // Enabled implements dockerConfigProvider
 func (d *defaultDockerConfigProvider) Enabled() bool {
+	if AreLegacyCloudCredentialProvidersDisabled() {
+		warnOnce.Do(func() {
+			klog.V(4).Infof("Docker config credential provider is now disabled. Please use out of tree docker config provider")
+		})
+		return false
+	}
 	return true
 }
 

--- a/test/e2e_node/builder/build.go
+++ b/test/e2e_node/builder/build.go
@@ -96,3 +96,34 @@ func GetKubeletServerBin() string {
 	}
 	return bin
 }
+
+func BuildCredentialProvider() error {
+	klog.Infof("Building credential provider binaries...")
+	credentialRootDir, err := utils.GetCredentialProviderRootDir()
+	if err != nil {
+		return fmt.Errorf("failed to locate kubernetes root directory %v", err)
+	}
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		return err
+	}
+
+	err = os.Chdir(credentialRootDir)
+	if err != nil {
+		return err
+	}
+
+	defer os.Chdir(cwd)
+
+	// In the future we can customize this with a flag to build any credential provider
+	cmd := exec.Command("make", "sample-credential-provider")
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	err = cmd.Run()
+	if err != nil {
+		return fmt.Errorf("failed to build credential provider %v", err)
+	}
+
+	return nil
+}

--- a/test/e2e_node/runner/remote/run_remote.go
+++ b/test/e2e_node/runner/remote/run_remote.go
@@ -70,6 +70,7 @@ var systemSpecName = flag.String("system-spec-name", "", fmt.Sprintf("The name o
 var extraEnvs = flag.String("extra-envs", "", "The extra environment variables needed for node e2e tests. Format: a list of key=value pairs, e.g., env1=val1,env2=val2")
 var runtimeConfig = flag.String("runtime-config", "", "The runtime configuration for the API server on the node e2e tests.. Format: a list of key=value pairs, e.g., env1=val1,env2=val2")
 var kubeletConfigFile = flag.String("kubelet-config-file", "", "The KubeletConfiguration file that should be applied to the kubelet")
+var installCredentialProvider = flag.Bool("install-credential-provider", false, "Test suite will build and install the default sample credential provider")
 
 // envs is the type used to collect all node envs. The key is the env name,
 // and the value is the env value
@@ -219,7 +220,7 @@ func main() {
 	rand.Seed(time.Now().UnixNano())
 	if *buildOnly {
 		// Build the archive and exit
-		remote.CreateTestArchive(suite, *systemSpecName, *kubeletConfigFile)
+		remote.CreateTestArchive(suite, *systemSpecName, *kubeletConfigFile, *installCredentialProvider)
 		return
 	}
 
@@ -405,7 +406,9 @@ func callGubernator(gubernator bool) {
 }
 
 func (a *Archive) getArchive() (string, error) {
-	a.Do(func() { a.path, a.err = remote.CreateTestArchive(suite, *systemSpecName, *kubeletConfigFile) })
+	a.Do(func() {
+		a.path, a.err = remote.CreateTestArchive(suite, *systemSpecName, *kubeletConfigFile, *installCredentialProvider)
+	})
 	return a.path, a.err
 }
 
@@ -467,7 +470,7 @@ func testHost(host string, deleteFiles bool, imageDesc, junitFileName, ginkgoFla
 		}
 	}
 
-	output, exitOk, err := remote.RunRemote(suite, path, host, deleteFiles, imageDesc, junitFileName, *testArgs, ginkgoFlagsStr, *systemSpecName, *extraEnvs, *runtimeConfig)
+	output, exitOk, err := remote.RunRemote(suite, path, host, deleteFiles, *installCredentialProvider, imageDesc, junitFileName, *testArgs, ginkgoFlagsStr, *systemSpecName, *extraEnvs, *runtimeConfig)
 	return &TestResult{
 		output: output,
 		err:    err,

--- a/test/e2e_node/services/kubelet.go
+++ b/test/e2e_node/services/kubelet.go
@@ -283,7 +283,8 @@ func (e *E2EServices) startKubelet() (*server, error) {
 		"--network-plugin=kubenet",
 		"--cni-bin-dir", cniBinDir,
 		"--cni-conf-dir", cniConfDir,
-		"--cni-cache-dir", cniCacheDir)
+		"--cni-cache-dir", cniCacheDir,
+	)
 
 	// Keep hostname override for convenience.
 	if framework.TestContext.NodeName != "" { // If node name is specified, set hostname override.

--- a/test/utils/paths.go
+++ b/test/utils/paths.go
@@ -34,6 +34,15 @@ func GetK8sRootDir() (string, error) {
 	return filepath.Join(dir, fmt.Sprintf("%s/", "k8s.io/kubernetes")), nil
 }
 
+func GetCredentialProviderRootDir() (string, error) {
+	dir, err := RootDir()
+	if err != nil {
+		return "", err
+	}
+
+	return filepath.Join(dir, fmt.Sprintf("%s/", "github.com/sample-credential-provider")), nil
+}
+
 // GetCAdvisorRootDir returns the root directory for cAdvisor, if present in the gopath.
 func GetCAdvisorRootDir() (string, error) {
 	dir, err := RootDir()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:

/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
It adds provision to install sample credential provider in node e2e with the flag `--install-credential-provider` in node e2e. The need to install credential provider in node e2e is explained in this issue : https://github.com/kubernetes/kubernetes/issues/106248

sample-credential-provider repo: https://github.com/adisky/sample-credential-provider (It will be moved to k8s-sigs before this PR merge and PR will be updated accordingly)

will add support to run in node conformance and using local runner once all stakeholders agrees on this approach
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
part of https://github.com/kubernetes/kubernetes/issues/106248

#### Special notes for your reviewer:
To run node e2e tests using external credential provider 
1. clone the repo at ~/go/src/github.com/sample-credential-provider
git clone https://github.com/adisky/sample-credential-provider
2. Run the tests using 

```
make test-e2e-node REMOTE=true GOFLAGS="-tags=providerless" FOCUS="should be able to pull from private registry with credential provider" INSTALL_CREDENTIAL_PROVIDER=true TEST_ARGS='--kubelet-flags="--feature-gates=KubeletCredentialProviders=true,DisableKubeletCloudCredentialProviders=true"'
```
It will run the existing node e2e with external credential provider and also build and install the sample-credential provider to the node VM.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link> https://github.com/kubernetes/enhancements/tree/master/keps/sig-node/2133-kubelet-credential-providers 
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- [KEP]: https://github.com/kubernetes/enhancements/tree/master/keps/sig-node/2133-kubelet-credential-providers 
```
