### PR TITLE
client-go: set the client retry to use exponential backoff delay with jitter by default

### DIFF
--- a/staging/src/k8s.io/client-go/rest/client_test.go
+++ b/staging/src/k8s.io/client-go/rest/client_test.go
@@ -360,14 +360,14 @@ func TestCreateBackoffManager(t *testing.T) {
 		t.Errorf("Zero backoff duration, but backoff still occurring.")
 	}
 
-	// No env -> No backoff.
+	// No env -> default is exponential backoff with jitter.
 	os.Setenv(envBackoffBase, "")
 	os.Setenv(envBackoffDuration, "")
 	backoff = readExpBackoffConfig()
 	backoff.UpdateBackoff(theUrl, nil, 500)
 	backoff.UpdateBackoff(theUrl, nil, 500)
-	if backoff.CalculateBackoff(theUrl)/time.Second != 0 {
-		t.Errorf("Backoff should have been 0.")
+	if backoff.CalculateBackoff(theUrl) == 0 {
+		t.Errorf("Backoff should not have been 0.")
 	}
 
 }

--- a/staging/src/k8s.io/client-go/rest/request.go
+++ b/staging/src/k8s.io/client-go/rest/request.go
@@ -80,8 +80,6 @@ func (r *RequestConstructionError) Error() string {
 	return fmt.Sprintf("request construction error: '%v'", r.Err)
 }
 
-var noBackoff = &NoBackoff{}
-
 type requestRetryFunc func(maxRetries int) WithRetry
 
 func defaultRequestRetryFn(maxRetries int) WithRetry {
@@ -129,7 +127,7 @@ func NewRequest(c *RESTClient) *Request {
 		backoff = c.createBackoffMgr()
 	}
 	if backoff == nil {
-		backoff = noBackoff
+		backoff = defaultBackoffManager()
 	}
 
 	var pathPrefix string


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:
The PR sets the default for client retry to use exponential backoff delay with jitter, today the default is no backoff. 

#### Which issue(s) this PR fixes:
Fixes #105521

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
by default, for components using client-go, the rest client will retry with an exponential backoff delay 
with some jitter. In the previous version, the client by default used to wait for 1s between retries.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
