### PR TITLE
Add note for the deprecated vSphere 6.5

### DIFF
--- a/staging/src/k8s.io/legacy-cloud-providers/vsphere/vclib/connection.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/vsphere/vclib/connection.go
@@ -222,6 +222,10 @@ func (connection *VSphereConnection) NewClient(ctx context.Context) (*vim25.Clie
 		klog.Errorf("failed to check if vCenter version:%v and api version: %s is deprecated. Error: %v", client.ServiceContent.About.Version, client.ServiceContent.About.ApiVersion, err)
 	}
 	if vcdeprecated {
+		// After this deprecation, vSphere 6.5 support period is extended to October 15, 2022 as
+		// https://blogs.vmware.com/vsphere/2021/03/announcing-limited-extension-of-vmware-vsphere-6-5-general-support-period.html
+		// In addition, the external vSphere cloud provider does not support vSphere 6.5.
+		// Please keep vSphere 6.5 support til the period.
 		klog.Warningf("vCenter is deprecated. version: %s, api verson: %s Please consider upgrading vCenter and ESXi servers to 6.7u3 or higher", client.ServiceContent.About.Version, client.ServiceContent.About.ApiVersion)
 	}
 	return client, nil


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This adds a note to explain the situation of vSphere 6.5 support.
It would be useful to consider it again before we stop supporting vSphere 6.5.

Ref: https://github.com/kubernetes/kubernetes/issues/105837

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

