### PR TITLE
[AWS] Set max results if its not set

### DIFF
--- a/staging/src/k8s.io/legacy-cloud-providers/aws/aws.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/aws/aws.go
@@ -960,6 +960,13 @@ func (s *awsSdkEC2) DescribeInstances(request *ec2.DescribeInstancesInput) ([]*e
 	results := []*ec2.Instance{}
 	var nextToken *string
 	requestTime := time.Now()
+
+	if request.MaxResults == nil && request.InstanceIds == nil {
+		// MaxResults must be set in order for pagination to work
+		// MaxResults cannot be set with InstanceIds
+		request.MaxResults = aws.Int64(1000)
+	}
+
 	for {
 		response, err := s.ec2.DescribeInstances(request)
 		if err != nil {


### PR DESCRIPTION
#### What type of PR is this?
/kind bug
/sig cloud-provider
/cc @cheftako 

#### What this PR does / why we need it:
For the legacy AWS cloud provider, if max results is not set and instance IDs are not provided for the DescribeInstances call, set max results to 1000.  This prevents an expensive call against the EC2 API, which can result in timeouts or errors from the EC2 API. 

#### Which issue(s) this PR fixes:
Ref: https://github.com/kubernetes/cloud-provider-aws/pull/274
Ref: https://github.com/kubernetes/cloud-provider-aws/issues/269

#### Special notes for your reviewer:
This PR is back porting a bug fix from the upstream AWS cloud provider, and is therefore a candidate to be merged to the legacy AWS cloud provider.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
