### PR TITLE
Promote DeleteCollection service e2e test to conformance - +1 endpoint 

### DIFF
--- a/test/conformance/testdata/conformance.yaml
+++ b/test/conformance/testdata/conformance.yaml
@@ -1496,6 +1496,14 @@
     action MUST be validated.
   release: v1.21
   file: test/e2e/network/service.go
+- testname: Service, deletes a collection of services
+  codename: '[sig-network] Services should delete a collection of services [Conformance]'
+  description: Create three services with the required labels and ports. It MUST locate
+    three services in the test namespace. It MUST succeed at deleting a collection
+    of services via a label selector. It MUST locate only one service after deleting
+    the service collection.
+  release: v1.23
+  file: test/e2e/network/service.go
 - testname: Find Kubernetes Service in default Namespace
   codename: '[sig-network] Services should find a service from listing all namespaces
     [Conformance]'

--- a/test/e2e/network/service.go
+++ b/test/e2e/network/service.go
@@ -2731,7 +2731,16 @@ var _ = common.SIGDescribe("Services", func() {
 		framework.Logf("Service %s deleted", testSvcName)
 	})
 
-	ginkgo.It("should delete a collection of services", func() {
+	/*
+		Release: v1.23
+		Testname: Service, deletes a collection of services
+		Description: Create three services with the required
+		labels and ports. It MUST locate three services in the
+		test namespace. It MUST succeed at deleting a collection
+		of services via a label selector. It MUST locate only
+		one service after deleting the service collection.
+	*/
+	framework.ConformanceIt("should delete a collection of services", func() {
 
 		ns := f.Namespace.Name
 		svcClient := f.ClientSet.CoreV1().Services(ns)


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it:**
This PR adds a test to test the following untested endpoints:

deleteCoreV1CollectionNamespacedService

**Which issue(s) this PR fixes:**
Fixes #106032

**Special notes for your reviewer:**
Adds +1 endpoint test coverage (good for conformance)

**Does this PR introduce a user-facing change?**
NONE

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:**
NONE

**Release note:**
NONE

/sig testing
/sig network
/area conformance