### PR TITLE
There are no more Feature:Performance tests any longer, removing the …

### DIFF
--- a/test/kubemark/run-e2e-tests.sh
+++ b/test/kubemark/run-e2e-tests.sh
@@ -31,11 +31,7 @@ export KUBE_MASTER_URL="https://${KUBE_MASTER_IP}"
 export KUBECONFIG="${ABSOLUTE_ROOT}/test/kubemark/resources/kubeconfig.kubemark"
 export E2E_MIN_STARTUP_PODS=0
 
-if [[ -z "$*" ]]; then
-	ARGS=('--ginkgo.focus=[Feature:Performance]')
-else
-	ARGS=("$@")
-fi
+ARGS=("$@")
 
 if [[ "${ENABLE_KUBEMARK_CLUSTER_AUTOSCALER}" == "true" ]]; then
   ARGS+=("--kubemark-external-kubeconfig=${DEFAULT_KUBECONFIG}")


### PR DESCRIPTION
…fallback option


/sig scalability
/cc @wojtek-t 

#### What type of PR is this?

This if statement was introduced after renaming here: https://github.com/kubernetes/kubernetes/commit/4625f50131ab2bdc7dbb5f51b3e106b4f0e21a42#diff-12489bcf62e9a4dcc9d6cfe8d54901c877d8f59275c55f48816a07b7ffe5107e

Tests since were removed: https://github.com/kubernetes/kubernetes/pull/83322/

So no need for this fallback option.

/kind cleanup
/priority backlog

```release-note
NONE
```
