### PR TITLE
Fix metrics AlreadyRegisteredError on TestRecordOperation and TestGetHistogramVecFromGatherer unit test

### DIFF
--- a/pkg/kubelet/kuberuntime/instrumented_services_test.go
+++ b/pkg/kubelet/kuberuntime/instrumented_services_test.go
@@ -1,9 +1,12 @@
 /*
 Copyright 2016 The Kubernetes Authors.
+
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
+
     http://www.apache.org/licenses/LICENSE-2.0
+
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/pkg/kubelet/kuberuntime/instrumented_services_test.go
+++ b/pkg/kubelet/kuberuntime/instrumented_services_test.go
@@ -33,6 +33,7 @@ import (
 func TestRecordOperation(t *testing.T) {
 	// Use local registry
 	var registry = compbasemetrics.NewKubeRegistry()
+	defer registry.Reset()
 	registry.MustRegister(metrics.RuntimeOperations)
 	registry.MustRegister(metrics.RuntimeOperationsDuration)
 	registry.MustRegister(metrics.RuntimeOperationsErrors)
@@ -64,8 +65,6 @@ func TestRecordOperation(t *testing.T) {
 	assert.HTTPBodyContains(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		mux.ServeHTTP(w, r)
 	}), "GET", prometheusURL, nil, runtimeOperationsDurationExpected)
-
-	registry.Reset()
 }
 
 func TestInstrumentedVersion(t *testing.T) {

--- a/pkg/kubelet/kuberuntime/instrumented_services_test.go
+++ b/pkg/kubelet/kuberuntime/instrumented_services_test.go
@@ -19,7 +19,6 @@ package kuberuntime
 import (
 	"net"
 	"net/http"
-	"sync"
 	"testing"
 	"time"
 
@@ -30,8 +29,6 @@ import (
 	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
 	"k8s.io/kubernetes/pkg/kubelet/metrics"
 )
-
-var registerMetrics sync.Once
 
 func TestRecordOperation(t *testing.T) {
 	// Use local registry

--- a/pkg/kubelet/kuberuntime/instrumented_services_test.go
+++ b/pkg/kubelet/kuberuntime/instrumented_services_test.go
@@ -22,7 +22,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/stretchr/testify/assert"
 
 	compbasemetrics "k8s.io/component-base/metrics"
@@ -33,6 +32,7 @@ import (
 func TestRecordOperation(t *testing.T) {
 	// Use local registry
 	var registry = compbasemetrics.NewKubeRegistry()
+	var gather compbasemetrics.Gatherer = registry
 	defer registry.Reset()
 	registry.MustRegister(metrics.RuntimeOperations)
 	registry.MustRegister(metrics.RuntimeOperationsDuration)
@@ -44,7 +44,7 @@ func TestRecordOperation(t *testing.T) {
 
 	prometheusURL := "http://" + l.Addr().String() + "/metrics"
 	mux := http.NewServeMux()
-	handler := promhttp.HandlerFor(registry, promhttp.HandlerOpts{})
+	handler := compbasemetrics.HandlerFor(gather, compbasemetrics.HandlerOpts{})
 	mux.Handle("/metrics", handler)
 	server := &http.Server{
 		Addr:    l.Addr().String(),

--- a/pkg/kubelet/kuberuntime/instrumented_services_test.go
+++ b/pkg/kubelet/kuberuntime/instrumented_services_test.go
@@ -33,10 +33,12 @@ func TestRecordOperation(t *testing.T) {
 	// Use local registry
 	var registry = compbasemetrics.NewKubeRegistry()
 	var gather compbasemetrics.Gatherer = registry
-	defer registry.Reset()
+
 	registry.MustRegister(metrics.RuntimeOperations)
 	registry.MustRegister(metrics.RuntimeOperationsDuration)
 	registry.MustRegister(metrics.RuntimeOperationsErrors)
+
+	registry.Reset()
 
 	l, err := net.Listen("tcp", "127.0.0.1:0")
 	assert.NoError(t, err)

--- a/pkg/kubelet/kuberuntime/instrumented_services_test.go
+++ b/pkg/kubelet/kuberuntime/instrumented_services_test.go
@@ -23,7 +23,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/stretchr/testify/assert"
 
@@ -48,7 +47,7 @@ func TestRecordOperation(t *testing.T) {
 	prometheusURL := "http://" + l.Addr().String() + "/metrics"
 	mux := http.NewServeMux()
 	//lint:ignore SA1019 ignore deprecated warning until we move off of global registries
-	handler := promhttp.InstrumentMetricHandler(prometheus.DefaultRegisterer, promhttp.HandlerFor(registry, promhttp.HandlerOpts{}))
+	handler := promhttp.HandlerFor(registry, promhttp.HandlerOpts{})
 	mux.Handle("/metrics", handler)
 	server := &http.Server{
 		Addr:    l.Addr().String(),

--- a/pkg/kubelet/kuberuntime/instrumented_services_test.go
+++ b/pkg/kubelet/kuberuntime/instrumented_services_test.go
@@ -43,7 +43,6 @@ func TestRecordOperation(t *testing.T) {
 
 	prometheusURL := "http://" + l.Addr().String() + "/metrics"
 	mux := http.NewServeMux()
-	//lint:ignore SA1019 ignore deprecated warning until we move off of global registries
 	handler := promhttp.HandlerFor(registry, promhttp.HandlerOpts{})
 	mux.Handle("/metrics", handler)
 	server := &http.Server{

--- a/staging/src/k8s.io/component-base/metrics/testutil/metrics_test.go
+++ b/staging/src/k8s.io/component-base/metrics/testutil/metrics_test.go
@@ -587,6 +587,8 @@ func TestGetHistogramVecFromGatherer(t *testing.T) {
 			if diff := cmp.Diff(tt.wantVec, histogramVec); diff != "" {
 				t.Errorf("Got unexpected HistogramVec (-want +got):\n%s", diff)
 			}
+
+			registry.Reset()
 		})
 	}
 }

--- a/staging/src/k8s.io/component-base/metrics/testutil/metrics_test.go
+++ b/staging/src/k8s.io/component-base/metrics/testutil/metrics_test.go
@@ -1,9 +1,12 @@
 /*
 Copyright 2020 The Kubernetes Authors.
+
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
+
     http://www.apache.org/licenses/LICENSE-2.0
+
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/staging/src/k8s.io/component-base/metrics/testutil/metrics_test.go
+++ b/staging/src/k8s.io/component-base/metrics/testutil/metrics_test.go
@@ -587,8 +587,6 @@ func TestGetHistogramVecFromGatherer(t *testing.T) {
 			if diff := cmp.Diff(tt.wantVec, histogramVec); diff != "" {
 				t.Errorf("Got unexpected HistogramVec (-want +got):\n%s", diff)
 			}
-
-			registry.Reset()
 		})
 	}
 }


### PR DESCRIPTION
Test:
```
make test KUBE_RACE=-race KUBE_TIMEOUT=--timeout=600s GOFLAGS=-count=10 WHAT=./staging/src/k8s.io/component-base/metrics/testutil

make test KUBE_RACE=-race KUBE_TIMEOUT=--timeout=600s GOFLAGS=-count=10 WHAT=./pkg/kubelet/kuberuntime/
```

Fixes #104940

It takes over #105809

 