### PR TITLE
Fix: Error when config file includes core group apiVersion

### DIFF
--- a/cmd/kubeadm/app/util/marshal.go
+++ b/cmd/kubeadm/app/util/marshal.go
@@ -97,7 +97,7 @@ func SplitYAMLDocuments(yamlBytes []byte) (kubeadmapi.DocumentMap, error) {
 		if err != nil {
 			return nil, err
 		}
-		if len(gvk.Group) == 0 || len(gvk.Version) == 0 || len(gvk.Kind) == 0 {
+		if len(gvk.Version) == 0 || len(gvk.Kind) == 0 {
 			return nil, errors.Errorf("invalid configuration for GroupVersionKind %+v: kind and apiVersion is mandatory information that must be specified", gvk)
 		}
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

`kubeadm kubeconfig user` command failed to execute when config file includes core group apiVersion.

* Command

```
$ kubeadm kubeconfig user  --client-name=kubernetes-admin --org=cluster.local --config=./config
```

* Config file

```
apiVersion: kubeadm.k8s.io/v1beta1
kind: ClusterConfiguration
---
apiVersion: v1
kind: Config
```

* Error Message

```
invalid configuration for GroupVersionKind /v1, Kind=Config: kind and apiVersion is mandatory information that must be specified
To see the stack trace of this error execute with --v=5 or higher
```


#### Special notes for your reviewer:

This error is not critical one.
But we should remove `gvk.Group` to handle core group API (i.e. `v1`) to have a flexibility for the config file.

#### Does this PR introduce a user-facing change?

NONE

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
