### PR TITLE
Don't write fake logs to the real test log

### DIFF
--- a/pkg/registry/core/service/storage/storage_test.go
+++ b/pkg/registry/core/service/storage/storage_test.go
@@ -823,9 +823,7 @@ type fakeTestingT struct {
 
 func (f fakeTestingT) Helper() {}
 
-func (f fakeTestingT) Errorf(format string, args ...interface{}) {
-	f.t.Logf(format, args...)
-}
+func (f fakeTestingT) Errorf(format string, args ...interface{}) {}
 
 func verifyEquiv(t testingTInterface, call string, tc *svcTestCase, got *api.Service) bool {
 	t.Helper()


### PR DESCRIPTION
This caused consternation as errors were logged but tests did not fail.
It was expected to log!


/kind cleanup

```release-note
NONE
```
