### PR TITLE
PodReadinessGate is stable feature and test runs all green

### DIFF
--- a/test/e2e/common/node/pods.go
+++ b/test/e2e/common/node/pods.go
@@ -22,11 +22,12 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"k8s.io/client-go/util/retry"
 	"runtime/debug"
 	"strconv"
 	"strings"
 	"time"
+
+	"k8s.io/client-go/util/retry"
 
 	"golang.org/x/net/websocket"
 
@@ -771,8 +772,7 @@ var _ = SIGDescribe("Pods", func() {
 		}
 	})
 
-	// TODO(freehan): label the test to be [NodeConformance] after tests are proven to be stable.
-	ginkgo.It("should support pod readiness gates [NodeFeature:PodReadinessGate]", func() {
+	ginkgo.It("should support pod readiness gates [NodeConformance]", func() {
 		podName := "pod-ready"
 		readinessGate1 := "k8s.io/test-condition1"
 		readinessGate2 := "k8s.io/test-condition2"


### PR DESCRIPTION
#### What type of PR is this?


- Tests are green: https://testgrid.k8s.io/sig-node-kubelet#node-kubelet-features-master&include-filter-by-regex=NodeFeature%3APodReadinessGate
- Feature applicable to all environments, marking NodeConformance


/kind cleanup
/sig node
/priority backlog

``` release-note
NONE
```