### PR TITLE
build: use debian-iptables:bullseye-v1.1.0

### DIFF
--- a/build/common.sh
+++ b/build/common.sh
@@ -90,7 +90,7 @@ readonly KUBE_RSYNC_PORT="${KUBE_RSYNC_PORT:-}"
 readonly KUBE_CONTAINER_RSYNC_PORT=8730
 
 # These are the default versions (image tags) for their respective base images.
-readonly __default_debian_iptables_version=bullseye-v1.0.0
+readonly __default_debian_iptables_version=bullseye-v1.1.0
 readonly __default_go_runner_version=v2.3.1-go1.17.3-bullseye.0
 readonly __default_setcap_version=bullseye-v1.0.0
 

--- a/build/dependencies.yaml
+++ b/build/dependencies.yaml
@@ -136,7 +136,7 @@ dependencies:
       match: BASE_IMAGE_VERSION\?=
 
   - name: "k8s.gcr.io/debian-iptables: dependents"
-    version: bullseye-v1.0.0
+    version: bullseye-v1.1.0
     refPaths:
     - path: build/common.sh
       match: __default_debian_iptables_version=

--- a/test/utils/image/manifest.go
+++ b/test/utils/image/manifest.go
@@ -208,7 +208,7 @@ func initImageConfigs(list RegistryList) (map[int]Config, map[int]Config) {
 	configs[CheckMetadataConcealment] = Config{list.PromoterE2eRegistry, "metadata-concealment", "1.6"}
 	configs[CudaVectorAdd] = Config{list.PromoterE2eRegistry, "cuda-vector-add", "1.0"}
 	configs[CudaVectorAdd2] = Config{list.PromoterE2eRegistry, "cuda-vector-add", "2.2"}
-	configs[DebianIptables] = Config{list.BuildImageRegistry, "debian-iptables", "bullseye-v1.0.0"}
+	configs[DebianIptables] = Config{list.BuildImageRegistry, "debian-iptables", "bullseye-v1.1.0"}
 	configs[EchoServer] = Config{list.PromoterE2eRegistry, "echoserver", "2.4"}
 	configs[Etcd] = Config{list.GcEtcdRegistry, "etcd", "3.4.13-0"}
 	configs[GlusterDynamicProvisioner] = Config{list.PromoterE2eRegistry, "glusterdynamic-provisioner", "v1.3"}


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:

The newer image contains go-runner, which is relevant for removing the
deprecated klog flags in the kube-proxy image.

#### Which issue(s) this PR fixes:
Fixes #https://github.com/kubernetes/kubernetes/issues/106086

#### Special notes for your reviewer:

The new image first needs to be promoted before this PR can be merged.

#### Does this PR introduce a user-facing change?
```release-note
The kube-proxy image contains /go-runner as a replacement for deprecated klog flags.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- [KEP]: https://github.com/kubernetes/enhancements/issues/2845
```
