### PR TITLE
provide preferred cpu affinity for best effort topology policy

### DIFF
--- a/pkg/kubelet/cm/cpumanager/policy_static.go
+++ b/pkg/kubelet/cm/cpumanager/policy_static.go
@@ -275,7 +275,7 @@ func (p *staticPolicy) Allocate(s state.State, pod *v1.Pod, container *v1.Contai
 		}
 
 		// Call Topology Manager to get the aligned socket affinity across all hint providers.
-		hint := p.affinity.GetAffinity(string(pod.UID), container.Name)
+		hint := p.affinity.GetAffinity(string(pod.UID), container.Name, string(v1.ResourceCPU))
 		klog.InfoS("Topology Affinity", "pod", klog.KObj(pod), "containerName", container.Name, "affinity", hint)
 
 		// Allocate CPUs according to the NUMA affinity contained in the hint.

--- a/pkg/kubelet/cm/devicemanager/manager.go
+++ b/pkg/kubelet/cm/devicemanager/manager.go
@@ -800,7 +800,7 @@ func (m *ManagerImpl) devicesToAllocate(podUID, contName, resource string, requi
 
 func (m *ManagerImpl) filterByAffinity(podUID, contName, resource string, available sets.String) (sets.String, sets.String, sets.String) {
 	// If alignment information is not available, just pass the available list back.
-	hint := m.topologyAffinityStore.GetAffinity(podUID, contName)
+	hint := m.topologyAffinityStore.GetAffinity(podUID, contName, "")
 	if !m.deviceHasTopologyAlignment(resource) || hint.NUMANodeAffinity == nil {
 		return sets.NewString(), sets.NewString(), available
 	}

--- a/pkg/kubelet/cm/devicemanager/topology_hints_test.go
+++ b/pkg/kubelet/cm/devicemanager/topology_hints_test.go
@@ -35,7 +35,7 @@ type mockAffinityStore struct {
 	hint topologymanager.TopologyHint
 }
 
-func (m *mockAffinityStore) GetAffinity(podUID string, containerName string) topologymanager.TopologyHint {
+func (m *mockAffinityStore) GetAffinity(podUID string, containerName string, resourceName string) topologymanager.TopologyHint {
 	return m.hint
 }
 

--- a/pkg/kubelet/cm/memorymanager/policy_static.go
+++ b/pkg/kubelet/cm/memorymanager/policy_static.go
@@ -104,7 +104,7 @@ func (p *staticPolicy) Allocate(s state.State, pod *v1.Pod, container *v1.Contai
 	}
 
 	// Call Topology Manager to get the aligned affinity across all hint providers.
-	hint := p.affinity.GetAffinity(podUID, container.Name)
+	hint := p.affinity.GetAffinity(podUID, container.Name, "")
 	klog.InfoS("Got topology affinity", "pod", klog.KObj(pod), "podUID", pod.UID, "containerName", container.Name, "hint", hint)
 
 	requestedResources, err := getRequestedResources(container)

--- a/pkg/kubelet/cm/topologymanager/fake_topology_manager.go
+++ b/pkg/kubelet/cm/topologymanager/fake_topology_manager.go
@@ -17,7 +17,7 @@ limitations under the License.
 package topologymanager
 
 import (
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/pkg/kubelet/cm/admission"
 	"k8s.io/kubernetes/pkg/kubelet/lifecycle"
@@ -41,8 +41,8 @@ func NewFakeManagerWithHint(hint *TopologyHint) Manager {
 	}
 }
 
-func (m *fakeManager) GetAffinity(podUID string, containerName string) TopologyHint {
-	klog.InfoS("GetAffinity", "podUID", podUID, "containerName", containerName)
+func (m *fakeManager) GetAffinity(podUID string, containerName string, resouceName string) TopologyHint {
+	klog.InfoS("GetAffinity", "podUID", podUID, "containerName", containerName, "resouceName", resouceName)
 	if m.hint == nil {
 		return TopologyHint{}
 	}

--- a/pkg/kubelet/cm/topologymanager/fake_topology_manager_test.go
+++ b/pkg/kubelet/cm/topologymanager/fake_topology_manager_test.go
@@ -20,7 +20,7 @@ import (
 	"reflect"
 	"testing"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/kubernetes/pkg/kubelet/lifecycle"
 )
 
@@ -49,7 +49,7 @@ func TestFakeGetAffinity(t *testing.T) {
 	}
 	for _, tc := range tcases {
 		fm := fakeManager{}
-		actual := fm.GetAffinity(tc.podUID, tc.containerName)
+		actual := fm.GetAffinity(tc.podUID, tc.containerName, "")
 		if !reflect.DeepEqual(actual, tc.expected) {
 			t.Errorf("Expected Affinity in result to be %v, got %v", tc.expected, actual)
 		}

--- a/pkg/kubelet/cm/topologymanager/scope_test.go
+++ b/pkg/kubelet/cm/topologymanager/scope_test.go
@@ -17,11 +17,12 @@ limitations under the License.
 package topologymanager
 
 import (
-	"k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/kubernetes/pkg/kubelet/cm/containermap"
 	"reflect"
 	"testing"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/kubernetes/pkg/kubelet/cm/containermap"
 )
 
 func TestGetAffinity(t *testing.T) {
@@ -40,7 +41,7 @@ func TestGetAffinity(t *testing.T) {
 	}
 	for _, tc := range tcases {
 		scope := scope{}
-		actual := scope.GetAffinity(tc.podUID, tc.containerName)
+		actual := scope.GetAffinity(tc.podUID, tc.containerName, "")
 		if !reflect.DeepEqual(actual, tc.expected) {
 			t.Errorf("Expected Affinity in result to be %v, got %v", tc.expected, actual)
 		}
@@ -106,8 +107,8 @@ func TestRemoveContainer(t *testing.T) {
 	scope.podTopologyHints = podTopologyHints{}
 	for _, tc := range testCases {
 		scope.podMap.Add(string(tc.podUID), tc.name, tc.containerID)
-		scope.podTopologyHints[string(tc.podUID)] = make(map[string]TopologyHint)
-		scope.podTopologyHints[string(tc.podUID)][tc.name] = TopologyHint{}
+		scope.podTopologyHints[string(tc.podUID)] = make(map[string]TopologyHints)
+		scope.podTopologyHints[string(tc.podUID)][tc.name] = TopologyHints{}
 		len1 = len(scope.podMap)
 		lenHints1 = len(scope.podTopologyHints)
 		err := scope.RemoveContainer(tc.containerID)

--- a/pkg/kubelet/cm/topologymanager/scope_test.go
+++ b/pkg/kubelet/cm/topologymanager/scope_test.go
@@ -108,7 +108,7 @@ func TestRemoveContainer(t *testing.T) {
 	for _, tc := range testCases {
 		scope.podMap.Add(string(tc.podUID), tc.name, tc.containerID)
 		scope.podTopologyHints[string(tc.podUID)] = make(map[string]TopologyHints)
-		scope.podTopologyHints[string(tc.podUID)][tc.name] = TopologyHints{}
+		scope.podTopologyHints[string(tc.podUID)][tc.name] = TopologyHints{MergedHint: TopologyHint{}}
 		len1 = len(scope.podMap)
 		lenHints1 = len(scope.podTopologyHints)
 		err := scope.RemoveContainer(tc.containerID)


### PR DESCRIPTION
Signed-off-by: Periyasamy Palanisamy <periyasamy.palanisamy@est.tech>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug
#### What this PR does / why we need it:

This PR makes Topology Manager with 'best effort' policy provides preferred affinity hint as much as possible so that CPU Manager provides both Guaranteed QoS pods with CPUs from a single NUMA node each, even if the device manager cannot provide each pod with a local SR-IOV VF.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #106270 

#### Special notes for your reviewer:

Test Logs:

```
available: 2 nodes (0-1)
node 0 cpus: 0 1 2 3 4 5 6 7 8 9 10 11 12 13 28 29 30 31 32 33 34 35 36 37 38 39 40 41
node 1 cpus: 14 15 16 17 18 19 20 21 22 23 24 25 26 27 42 43 44 45 46 47 48 49 50 51 52 53 54 55
``` 

kubelet configuration:
```
CPU Manager policy: "static"
Topology Manager policy: "best effort"
reserved_cpus: 0

``` 

```
Capacity:
  cpu:                              56
  ephemeral-storage:                274824692Ki
  hugepages-1Gi:                    32Gi
  intel.com/intel_sriov_netdevice:  4
  memory:                           131658876Ki
  pods:                             110
Allocatable:
  cpu:                              55
  ephemeral-storage:                253278435728
  hugepages-1Gi:                    32Gi
  intel.com/intel_sriov_netdevice:  4
  memory:                           97502044Ki
  pods:                             110
```
 
pod1 contains single container with below resources requests:
 
```
    resources:
      requests:
        cpu: "20"
        memory: "1Gi"
      limits:
        cpu: "20"
        memory: "1Gi"

``` 

assigned cpu's for pod1:

`1-10,29-38`
 
pod2 contains two containers with below resources requests:
  
c1:  
```
    resources:
      requests:
        cpu: "20"
        memory: "1Gi"
        intel.com/intel_sriov_netdevice: "1"
      limits:
        cpu: "20"
        memory: "1Gi"
        intel.com/intel_sriov_netdevice: "1"
```

c2:
```
    resources:
      requests:
        cpu: "1500m"
        memory: "1Gi"
      limits:
        cpu: "1500m"
        memory: "1Gi"
``` 

assigned cpus for c1 (without fix):

`11-20,28,39-47`

assigned cpus for c1 (with fix):

`14-23,42-51` 

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
