### PR TITLE
conformance tests should have at least 2 untainted nodes

### DIFF
--- a/test/conformance/testdata/conformance.yaml
+++ b/test/conformance/testdata/conformance.yaml
@@ -933,6 +933,13 @@
     visible to subsequent reads.
   release: v1.22
   file: test/e2e/apps/statefulset.go
+- testname: Conformance tests minimum number of nodes.
+  codename: '[sig-architecture] Conformance Tests should have at least two untainted
+    nodes [Conformance]'
+  description: Conformance tests requires at least two untainted nodes where pods
+    can be scheduled.
+  release: v1.23
+  file: test/e2e/architecture/conformance.go
 - testname: CertificateSigningRequest API
   codename: '[sig-auth] Certificates API [Privileged:ClusterAdmin] should support
     CSR API operations [Conformance]'

--- a/test/e2e/architecture/OWNERS
+++ b/test/e2e/architecture/OWNERS
@@ -1,0 +1,16 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+# This is the owner of the test code.  The test data itself is owned by sig-architecture.
+reviewers:
+  - aojea
+  - cheftako
+  - oomichi
+  - johnbelamaric
+approvers:
+  - cheftako
+  - spiffxp
+  - johnbelamaric
+emeritus_approvers:
+labels:
+  - area/conformance
+  - sig/architecture

--- a/test/e2e/architecture/conformance.go
+++ b/test/e2e/architecture/conformance.go
@@ -1,0 +1,45 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package architecture
+
+import (
+	"time"
+
+	"github.com/onsi/ginkgo"
+
+	"k8s.io/kubernetes/test/e2e/framework"
+	e2enode "k8s.io/kubernetes/test/e2e/framework/node"
+)
+
+var _ = SIGDescribe("Conformance Tests", func() {
+	f := framework.NewDefaultFramework("conformance-tests")
+
+	/*
+		Release: v1.23
+		Testname: Conformance tests minimum number of nodes.
+		Description: Conformance tests requires at least two untainted nodes where pods can be scheduled.
+	*/
+	framework.ConformanceIt("should have at least two untainted nodes", func() {
+		ginkgo.By("Getting node addresses")
+		framework.ExpectNoError(framework.WaitForAllNodesSchedulable(f.ClientSet, 10*time.Minute))
+		nodeList, err := e2enode.GetReadySchedulableNodes(f.ClientSet)
+		framework.ExpectNoError(err)
+		if len(nodeList.Items) < 2 {
+			framework.Failf("Conformance requires at least two nodes")
+		}
+	})
+})

--- a/test/e2e/architecture/framework.go
+++ b/test/e2e/architecture/framework.go
@@ -1,0 +1,24 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package architecture
+
+import "github.com/onsi/ginkgo"
+
+// SIGDescribe annotates the test with the SIG label.
+func SIGDescribe(text string, body func()) bool {
+	return ginkgo.Describe("[sig-architecture] "+text, body)
+}

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -44,6 +44,7 @@ import (
 	// test sources
 	_ "k8s.io/kubernetes/test/e2e/apimachinery"
 	_ "k8s.io/kubernetes/test/e2e/apps"
+	_ "k8s.io/kubernetes/test/e2e/architecture"
 	_ "k8s.io/kubernetes/test/e2e/auth"
 	_ "k8s.io/kubernetes/test/e2e/autoscaling"
 	_ "k8s.io/kubernetes/test/e2e/cloud"


### PR DESCRIPTION
/kind bug
/kind cleanup

#### What this PR does / why we need it:

Conformance tests should have at least 2 untainted nodes where pods can be scheduled.

For testing purposes, is desirable that tests that don't meet the requirement can be skipped or work with one node only.

Making changes to current Conformance tests is risky, however, since we only want to know if the cluster under test verifies this condition, we just add a test for checking that there are at least 2 untainted nodes.

This way, the ecosystem can benefit of keep running conformance, they only have to disable this test.

#### Which issue(s) this PR fixes:
Fixes #106303

#### Special notes for your reviewer:

Ref: https://groups.google.com/g/kubernetes-sig-architecture/c/s-SCpQQDOEo/m/FUGmTFKKAQAJ

```release-note
add a test to guarantee that conformance clusters require at least 2 untainted nodes
```
