### PR TITLE
Use HPA v2 in E2E tests.

### DIFF
--- a/test/e2e/autoscaling/custom_metrics_stackdriver_autoscaling.go
+++ b/test/e2e/autoscaling/custom_metrics_stackdriver_autoscaling.go
@@ -24,7 +24,7 @@ import (
 	gcm "google.golang.org/api/monitoring/v3"
 	"google.golang.org/api/option"
 	appsv1 "k8s.io/api/apps/v1"
-	as "k8s.io/api/autoscaling/v2beta1"
+	as "k8s.io/api/autoscaling/v2"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -280,11 +280,11 @@ func (tc *CustomMetricTestCase) Run() {
 	waitForReplicas(tc.deployment.ObjectMeta.Name, tc.framework.Namespace.ObjectMeta.Name, tc.kubeClient, 15*time.Minute, tc.initialReplicas)
 
 	// Autoscale the deployment
-	_, err = tc.kubeClient.AutoscalingV2beta1().HorizontalPodAutoscalers(tc.framework.Namespace.ObjectMeta.Name).Create(context.TODO(), tc.hpa, metav1.CreateOptions{})
+	_, err = tc.kubeClient.AutoscalingV2().HorizontalPodAutoscalers(tc.framework.Namespace.ObjectMeta.Name).Create(context.TODO(), tc.hpa, metav1.CreateOptions{})
 	if err != nil {
 		framework.Failf("Failed to create HPA: %v", err)
 	}
-	defer tc.kubeClient.AutoscalingV2beta1().HorizontalPodAutoscalers(tc.framework.Namespace.ObjectMeta.Name).Delete(context.TODO(), tc.hpa.ObjectMeta.Name, metav1.DeleteOptions{})
+	defer tc.kubeClient.AutoscalingV2().HorizontalPodAutoscalers(tc.framework.Namespace.ObjectMeta.Name).Delete(context.TODO(), tc.hpa.ObjectMeta.Name, metav1.DeleteOptions{})
 
 	waitForReplicas(tc.deployment.ObjectMeta.Name, tc.framework.Namespace.ObjectMeta.Name, tc.kubeClient, 15*time.Minute, tc.scaledReplicas)
 }
@@ -325,8 +325,13 @@ func podsHPA(namespace string, deploymentName string, metricTargets map[string]i
 		metrics = append(metrics, as.MetricSpec{
 			Type: as.PodsMetricSourceType,
 			Pods: &as.PodsMetricSource{
-				MetricName:         metric,
-				TargetAverageValue: *resource.NewQuantity(target, resource.DecimalSI),
+				Metric: as.MetricIdentifier{
+					Name: metric,
+				},
+				Target: as.MetricTarget{
+					Type:         as.AverageValueMetricType,
+					AverageValue: resource.NewQuantity(target, resource.DecimalSI),
+				},
 			},
 		})
 	}
@@ -360,12 +365,17 @@ func objectHPA(namespace string, metricTarget int64) *as.HorizontalPodAutoscaler
 				{
 					Type: as.ObjectMetricSourceType,
 					Object: &as.ObjectMetricSource{
-						MetricName: monitoring.CustomMetricName,
-						Target: as.CrossVersionObjectReference{
+						Metric: as.MetricIdentifier{
+							Name: monitoring.CustomMetricName,
+						},
+						DescribedObject: as.CrossVersionObjectReference{
 							Kind: "Pod",
 							Name: stackdriverExporterPod,
 						},
-						TargetValue: *resource.NewQuantity(metricTarget, resource.DecimalSI),
+						Target: as.MetricTarget{
+							Type:  as.ValueMetricType,
+							Value: resource.NewQuantity(metricTarget, resource.DecimalSI),
+						},
 					},
 				},
 			},
@@ -410,14 +420,18 @@ func externalHPA(namespace string, metricTargets map[string]externalMetricTarget
 		metricSpec = as.MetricSpec{
 			Type: as.ExternalMetricSourceType,
 			External: &as.ExternalMetricSource{
-				MetricName:     "custom.googleapis.com|" + metric,
-				MetricSelector: selector,
+				Metric: as.MetricIdentifier{
+					Name:     "custom.googleapis.com|" + metric,
+					Selector: selector,
+				},
 			},
 		}
 		if target.isAverage {
-			metricSpec.External.TargetAverageValue = resource.NewQuantity(target.value, resource.DecimalSI)
+			metricSpec.External.Target.Type = as.AverageValueMetricType
+			metricSpec.External.Target.AverageValue = resource.NewQuantity(target.value, resource.DecimalSI)
 		} else {
-			metricSpec.External.TargetValue = resource.NewQuantity(target.value, resource.DecimalSI)
+			metricSpec.External.Target.Type = as.ValueMetricType
+			metricSpec.External.Target.Value = resource.NewQuantity(target.value, resource.DecimalSI)
 		}
 		metricSpecs = append(metricSpecs, metricSpec)
 	}

--- a/test/e2e/framework/autoscaling/autoscaling_utils.go
+++ b/test/e2e/framework/autoscaling/autoscaling_utils.go
@@ -24,7 +24,7 @@ import (
 	"time"
 
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
-	autoscalingv2beta2 "k8s.io/api/autoscaling/v2beta2"
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -628,27 +628,27 @@ func runReplicaSet(config testutils.ReplicaSetConfig) error {
 
 // CreateContainerResourceCPUHorizontalPodAutoscaler create a horizontal pod autoscaler with container resource target
 // for consuming resources.
-func CreateContainerResourceCPUHorizontalPodAutoscaler(rc *ResourceConsumer, cpu, minReplicas, maxRepl int32) *autoscalingv2beta2.HorizontalPodAutoscaler {
-	hpa := &autoscalingv2beta2.HorizontalPodAutoscaler{
+func CreateContainerResourceCPUHorizontalPodAutoscaler(rc *ResourceConsumer, cpu, minReplicas, maxRepl int32) *autoscalingv2.HorizontalPodAutoscaler {
+	hpa := &autoscalingv2.HorizontalPodAutoscaler{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      rc.name,
 			Namespace: rc.nsName,
 		},
-		Spec: autoscalingv2beta2.HorizontalPodAutoscalerSpec{
-			ScaleTargetRef: autoscalingv2beta2.CrossVersionObjectReference{
+		Spec: autoscalingv2.HorizontalPodAutoscalerSpec{
+			ScaleTargetRef: autoscalingv2.CrossVersionObjectReference{
 				APIVersion: rc.kind.GroupVersion().String(),
 				Kind:       rc.kind.Kind,
 				Name:       rc.name,
 			},
 			MinReplicas: &minReplicas,
 			MaxReplicas: maxRepl,
-			Metrics: []autoscalingv2beta2.MetricSpec{
+			Metrics: []autoscalingv2.MetricSpec{
 				{
 					Type: "ContainerResource",
-					ContainerResource: &autoscalingv2beta2.ContainerResourceMetricSource{
+					ContainerResource: &autoscalingv2.ContainerResourceMetricSource{
 						Name:      "cpu",
 						Container: rc.name,
-						Target: autoscalingv2beta2.MetricTarget{
+						Target: autoscalingv2.MetricTarget{
 							Type:               "Utilization",
 							AverageUtilization: &cpu,
 						},
@@ -657,14 +657,14 @@ func CreateContainerResourceCPUHorizontalPodAutoscaler(rc *ResourceConsumer, cpu
 			},
 		},
 	}
-	hpa, errHPA := rc.clientSet.AutoscalingV2beta2().HorizontalPodAutoscalers(rc.nsName).Create(context.TODO(), hpa, metav1.CreateOptions{})
+	hpa, errHPA := rc.clientSet.AutoscalingV2().HorizontalPodAutoscalers(rc.nsName).Create(context.TODO(), hpa, metav1.CreateOptions{})
 	framework.ExpectNoError(errHPA)
 	return hpa
 }
 
 // DeleteContainerResourceHPA delete the horizontalPodAutoscaler for consuming resources.
 func DeleteContainerResourceHPA(rc *ResourceConsumer, autoscalerName string) {
-	rc.clientSet.AutoscalingV2beta2().HorizontalPodAutoscalers(rc.nsName).Delete(context.TODO(), autoscalerName, metav1.DeleteOptions{})
+	rc.clientSet.AutoscalingV2().HorizontalPodAutoscalers(rc.nsName).Delete(context.TODO(), autoscalerName, metav1.DeleteOptions{})
 }
 
 //SidecarStatusType type for sidecar status


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

The HPA v2beta APIs are being deprecated in lieu of the stable v2 API.  This change moves end-to-end usage of the beta APIs to the stable API.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Followup to https://github.com/kubernetes/kubernetes/pull/102534#issuecomment-964336757

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
