### PR TITLE
kubeadm: fix test failures in the e2e_kubeadm suite

### DIFF
--- a/cmd/kubeadm/app/phases/addons/proxy/proxy.go
+++ b/cmd/kubeadm/app/phases/addons/proxy/proxy.go
@@ -43,11 +43,11 @@ const (
 	// TODO: This k8s-generic, well-known constant should be fetchable from another source, not be in this package
 	KubeProxyClusterRoleName = "system:node-proxier"
 
+	// KubeProxyClusterRoleBindingName sets the name for the kube-proxy CluterRoleBinding
+	KubeProxyClusterRoleBindingName = "kubeadm:node-proxier"
+
 	// KubeProxyServiceAccountName describes the name of the ServiceAccount for the kube-proxy addon
 	KubeProxyServiceAccountName = "kube-proxy"
-
-	// KubeProxyClusterRoleBindingName sets the name for the kube-proxy CluterRoleBinding
-	KubeProxyClusterRoleBindingName = "kubeam:node-proxier"
 
 	// KubeProxyConfigMapRoleName sets the name of ClusterRole for ConfigMap
 	KubeProxyConfigMapRoleName = "kube-proxy"

--- a/test/e2e_kubeadm/kubelet_config_test.go
+++ b/test/e2e_kubeadm/kubelet_config_test.go
@@ -84,11 +84,15 @@ var _ = Describe("kubelet-config ConfigMap", func() {
 		// https://github.com/kubernetes/kubeadm/issues/1582
 		var UnversionedKubeletConfigMap bool
 		if _, ok := m["featureGates"]; ok {
-			if featureGates, ok := m["featureGates"].(map[string]bool); ok {
+			if featureGates, ok := m["featureGates"].(map[interface{}]interface{}); ok {
 				// TODO: update the default to true once this graduates to Beta.
 				UnversionedKubeletConfigMap = false
 				if val, ok := featureGates["UnversionedKubeletConfigMap"]; ok {
-					UnversionedKubeletConfigMap = val
+					if valBool, ok := val.(bool); ok {
+						UnversionedKubeletConfigMap = valBool
+					} else {
+						framework.Failf("unable to cast the value of feature gate UnversionedKubeletConfigMap to bool")
+					}
 				}
 			} else {
 				framework.Failf("unable to cast the featureGates field in the %s ConfigMap", kubeadmConfigName)


### PR DESCRIPTION
#### What this PR does / why we need it:

```
kubeadm: fix typo in KubeProxyClusterRoleBindingName constant 

kubeam:node-proxier -> kubeadm:node-proxier
This causes e2e test failures:
"[area-kubeadm] proxy addon kube-proxy ServiceAccount should
be bound to the system:node-proxier cluster role"

in:
- kubeadm-kinder-latest
- kubeadm-kinder-latest-on-...
- other tests
```

```
kubeadm: fix failure in e2e_kubeadm related to kubelet-config 

The featureGates field in ClusterConfiguration ends up
as a map[interface{}]interface{} in the test suite
and cannot be casted to map[string]bool directly.
Adapt the test to use map[interface{}]interface{}.

fixes failures in:
- kubeadm-kinder-rootless-latest
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes/kubernetes/issues/106318
Fixes https://github.com/kubernetes/kubernetes/issues/106311

#### Special notes for your reviewer:
NONE

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
