### PR TITLE
Fix sample_and_watermark_test.go for bad luck, repeated test

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/metrics/sample_and_watermark_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/metrics/sample_and_watermark_test.go
@@ -17,13 +17,13 @@ limitations under the License.
 package metrics
 
 import (
+	"errors"
 	"fmt"
 	"math/rand"
 	"testing"
 	"time"
 
 	compbasemetrics "k8s.io/component-base/metrics"
-	"k8s.io/component-base/metrics/legacyregistry"
 	"k8s.io/klog/v2"
 	testclock "k8s.io/utils/clock/testing"
 )
@@ -35,6 +35,8 @@ const (
 	ddtOffsetCentiPeriods = 50
 	numIterations         = 100
 )
+
+var errMetricNotFound = errors.New("not found")
 
 /* TestSampler does a rough behavioral test of the sampling in a
    SampleAndWatermarkHistograms.  The test creates one and exercises
@@ -59,9 +61,10 @@ func TestSampler(t *testing.T) {
 		&compbasemetrics.HistogramOpts{Name: "marks", Buckets: buckets},
 		[]string{})
 	saw := gen.Generate(0, 1, []string{})
-	regs := gen.metrics()
-	for _, reg := range regs {
-		legacyregistry.MustRegister(reg)
+	toRegister := gen.metrics()
+	registry := compbasemetrics.NewKubeRegistry()
+	for _, reg := range toRegister {
+		registry.MustRegister(reg)
 	}
 	// `dt` is the admitted cumulative difference in fake time
 	// since the start of the test.  "admitted" means this is
@@ -83,8 +86,8 @@ func TestSampler(t *testing.T) {
 		clk.SetTime(t1)
 		saw.Observe(1)
 		expectedCount := int64(dt / samplingPeriod)
-		actualCount, err := getHistogramCount(regs, samplesHistName)
-		if err != nil {
+		actualCount, err := getHistogramCount(registry, samplesHistName)
+		if err != nil && !(err == errMetricNotFound && expectedCount == 0) {
 			t.Fatalf("For t0=%s, t1=%s, failed to getHistogramCount: %#+v", t0, t1, err)
 		}
 		t.Logf("For i=%d, ddt=%s, t1=%s, diff=%s, dt=%s, count=%d", i, ddt, t1, diff, dt, actualCount)
@@ -94,28 +97,26 @@ func TestSampler(t *testing.T) {
 	}
 }
 
-/* getHistogramCount returns the count of the named histogram */
-func getHistogramCount(regs Registerables, metricName string) (int64, error) {
-	considered := []string{}
-	mfs, err := legacyregistry.DefaultGatherer.Gather()
+/* getHistogramCount returns the count of the named histogram or an error (if any) */
+func getHistogramCount(registry compbasemetrics.KubeRegistry, metricName string) (int64, error) {
+	mfs, err := registry.Gather()
 	if err != nil {
-		return 0, fmt.Errorf("failed to gather metrics: %s", err)
+		return 0, fmt.Errorf("failed to gather metrics: %w", err)
 	}
 	for _, mf := range mfs {
 		thisName := mf.GetName()
 		if thisName != metricName {
-			considered = append(considered, thisName)
 			continue
 		}
 		metric := mf.GetMetric()[0]
 		hist := metric.GetHistogram()
 		if hist == nil {
-			return 0, fmt.Errorf("dto.Metric has nil Histogram")
+			return 0, errors.New("dto.Metric has nil Histogram")
 		}
 		if hist.SampleCount == nil {
-			return 0, fmt.Errorf("dto.Histogram has nil SampleCount")
+			return 0, errors.New("dto.Histogram has nil SampleCount")
 		}
 		return int64(*hist.SampleCount), nil
 	}
-	return 0, fmt.Errorf("not found, considered=%#+v", considered)
+	return 0, errMetricNotFound
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:

/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation

/kind flake
/kind regression
-->
/kind bug
/kind failing-test

#### What this PR does / why we need it:
This PR fixes the unit test for sample-and-watermark histograms in two ways.
First, it makes the test correctly handle the cases where the first step of the fake clock does not cross the sampling threshold. 
Second, it make the test work correctly if it is repeated in the same process and even if multiple invocations are run concurrently in the same process.

This is part of the campaign to make unit tests safe for repetition (#104940).

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:
The second half of this is a simpler alternative to #105886 .

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
