### PR TITLE
[test][kubelet]: Fix out of bounds in TestSyncLabels unit

### DIFF
--- a/pkg/kubelet/kubelet_test.go
+++ b/pkg/kubelet/kubelet_test.go
@@ -2408,14 +2408,15 @@ func TestSyncLabels(t *testing.T) {
 							t.Logf("No action yet")
 							return false, nil
 						}
-						action := actions[1]
-						if action.GetVerb() == "patch" {
-							patchAction := action.(core.PatchActionImpl)
-							var err error
-							savedNode, err = applyNodeStatusPatch(test.existingNode, patchAction.GetPatch())
-							if err != nil {
-								t.Logf("node patching failed, %v", err)
-								return false, nil
+						for _, action := range actions {
+							if action.GetVerb() == "patch" {
+								patchAction := action.(core.PatchActionImpl)
+								var err error
+								savedNode, err = applyNodeStatusPatch(test.existingNode, patchAction.GetPatch())
+								if err != nil {
+									t.Logf("node patching failed, %v", err)
+									return false, nil
+								}
 							}
 						}
 					} else {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind flake
#### What this PR does / why we need it:
Removes the hardcoded index for the actions slice which is causing panics:

https://testgrid.k8s.io/sig-release-master-blocking#ci-kubernetes-unit
https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-kubernetes-unit/1458255809187155968
https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-kubernetes-unit/1458361759063609344
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

cc @liggitt 
#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
