### PR TITLE
Fix flake caused by sampling signal counter too early.

### DIFF
--- a/staging/src/k8s.io/kube-aggregator/pkg/apiserver/handler_proxy_test.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/apiserver/handler_proxy_test.go
@@ -921,8 +921,11 @@ type hookedListener struct {
 }
 
 func (wl *hookedListener) Accept() (net.Conn, error) {
-	wl.onAccept()
-	return wl.l.Accept()
+	conn, err := wl.l.Accept()
+	if err == nil {
+		wl.onAccept()
+	}
+	return conn, err
 }
 
 func (wl *hookedListener) Close() error {
@@ -1015,8 +1018,11 @@ func TestFlowControlSignal(t *testing.T) {
 
 			req := tc.Request
 			req.URL = surl
-			_, err = server.Client().Do(&req)
+			res, err := server.Client().Do(&req)
 			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if err := res.Body.Close(); err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
 


### PR DESCRIPTION
TestFlowControlSignal has been flaking occasionally (somewhere around
0.5% on my machine using golang.org/x/tools/cmd/stress with -p
20). The intent was to sample the number of times the signal fired at
the moment a backend receives a connection from the proxy as an
alternative to test doubles, but the signal count was being
sampled (and recorded) immediately on calls to (net.Listener).Accept()
-- before blocking -- instead of immediately after unblocking.

The flake no longer occurs on my machine (again, using stress -p 20)
with this patch.

#### What type of PR is this?

/kind cleanup
/kind failing-test
/kind flake

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

Fixes a test flake, link to follow in comment.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
