### PR TITLE
[WIP] Fix flags for Konnectivity egress.

### DIFF
--- a/cluster/gce/addons/konnectivity-agent/konnectivity-agent-ds.yaml
+++ b/cluster/gce/addons/konnectivity-agent/konnectivity-agent-ds.yaml
@@ -26,11 +26,13 @@ spec:
           effect: "NoExecute"
       nodeSelector:
         kubernetes.io/os: linux
+      hostNetwork: true
       containers:
-        - image: k8s.gcr.io/kas-network-proxy/proxy-agent:v0.0.30
+        - image: gcr.io/wfender-test/proxy-agent-amd64:a2aa38ed97981c3c446e11ca0b9484f650a6519d
           name: konnectivity-agent
           command: ["/proxy-agent"]
           args: [
+                  "--v=5",
                   "--logtostderr=true",
                   "--ca-cert=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt",
 __EXTRA_PARAMS__
@@ -40,6 +42,7 @@ __EXTRA_PARAMS__
                   "--sync-interval-cap=30s",
                   "--probe-interval=5s",
                   "--service-account-token-path=/var/run/secrets/tokens/konnectivity-agent-token",
+                  "--enable-profiling=true",
                   "--agent-identifiers=ipv4=$(HOST_IP)"
                   ]
           env:
@@ -55,6 +58,10 @@ __EXTRA_PARAMS__
               valueFrom:
                 fieldRef:
                   fieldPath: status.hostIP
+          ports:
+           - name: adminport
+             containerPort: 8094
+             hostPort: 8094
           resources:
             requests:
               cpu: 50m

--- a/cluster/gce/gci/configure-helper.sh
+++ b/cluster/gce/gci/configure-helper.sh
@@ -2046,7 +2046,13 @@ function prepare-konnectivity-server-manifest {
   params+=("--kubeconfig-burst=150")
   params+=("--keepalive-time=60s")
   params+=("--frontend-keepalive-time=60s")
+  params+=("--warn-on-channel-limit=true")
+  params+=("--enable-profiling=true")
+  params+=("--v=5")
   konnectivity_args=""
+  if [[ -n "${KONNECTIVITY_STRATEGIES:-}" ]]; then
+    konnectivity_args="--proxy-strategies=${KONNECTIVITY_STRATEGIES}"
+  fi
   for param in "${params[@]}"; do
     konnectivity_args+=", \"${param}\""
   done

--- a/cluster/gce/manifests/konnectivity-server.yaml
+++ b/cluster/gce/manifests/konnectivity-server.yaml
@@ -20,7 +20,7 @@ spec:
       {{ disallow_privilege_escalation}}
       {{ capabilities }}
         {{ drop_capabilities }}
-    image: k8s.gcr.io/kas-network-proxy/proxy-server:v0.0.30
+    image: gcr.io/wfender-test/proxy-server-amd64:a2aa38ed97981c3c446e11ca0b9484f650a6519d
     resources:
       requests:
         cpu: 25m

--- a/staging/src/k8s.io/apiserver/pkg/server/egressselector/egress_selector.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/egressselector/egress_selector.go
@@ -103,7 +103,7 @@ func lookupServiceName(name string) (EgressType, error) {
 
 func tunnelHTTPConnect(proxyConn net.Conn, proxyAddress, addr string) (net.Conn, error) {
 	fmt.Fprintf(proxyConn, "CONNECT %s HTTP/1.1\r\nHost: %s\r\n\r\n", addr, "127.0.0.1")
-	br := bufio.NewReader(proxyConn)
+	br := bufio.NewReaderSize(proxyConn, 1<<15) // Match GRPC Window size
 	res, err := http.ReadResponse(br, nil)
 	if err != nil {
 		proxyConn.Close()


### PR DESCRIPTION
Fixed flags to turn on better logging.
Fixed flags to indicate if we are going to block on the xfer channel.
Fixed http-connect buffer size to better align with grpc window size.
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:
This PR improves the debuggability of konnectivity egress on the GCP sample implementation.

#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs
NONE
```
