### PR TITLE
Revert last-applied-configuration annotation during rollback

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/polymorphichelpers/rollback.go
+++ b/staging/src/k8s.io/kubectl/pkg/polymorphichelpers/rollback.go
@@ -182,7 +182,6 @@ func equalIgnoreHash(template1, template2 *corev1.PodTemplateSpec) bool {
 // annotationsToSkip lists the annotations that should be preserved from the deployment and not
 // copied from the replicaset when rolling a deployment back
 var annotationsToSkip = map[string]bool{
-	corev1.LastAppliedConfigAnnotation:       true,
 	deploymentutil.RevisionAnnotation:        true,
 	deploymentutil.RevisionHistoryAnnotation: true,
 	deploymentutil.DesiredReplicasAnnotation: true,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug


#### What this PR does / why we need it:
Rollback ignores the `last-applied-config` annotation as per the issues below. When an update happens later, the merge can cause env vars that were intended for removal to persist. This can cause unwanted side effects, including production outages. 

#### Which issue(s) this PR fixes:
Fixes kubernetes/kubernetes#77058, kubernetes/kubectl#1301

#### Special notes for your reviewer:
Looking for feedback as to why this approach may not be appropriate, otherwise happy to add more testing/documentation if it's an acceptable approach.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
