### PR TITLE
OWNERS(justaugustus): Prune extraneous reviewer roles

### DIFF
--- a/.github/OWNERS
+++ b/.github/OWNERS
@@ -4,7 +4,6 @@ reviewers:
   - alisondy
   - cblecker
   - guineveresaenger
-  - justaugustus
   - mrbobbytables
   - nikhita
   - parispittman

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -132,7 +132,7 @@ aliases:
     - cpanato # SIG Technical Lead / RelEng subproject owner / Release Manager
     - dims
     - jeremyrickard # SIG Technical Lead / RelEng subproject owner
-    - justaugustus # SIG Chair / RelEng subproject owner / Release Manager
+    #- justaugustus # SIG Chair / RelEng subproject owner / Release Manager - approvals only
     - puerco # SIG Technical Lead / RelEng subproject owner / Release Manager
     - saschagrunert # SIG Chair / RelEng subproject owner / Release Manager
     - xmudrii # Release Manager

--- a/build/OWNERS
+++ b/build/OWNERS
@@ -7,7 +7,7 @@ reviewers:
   - dims
   - fejta
   - jeremyrickard # SIG Technical Lead / RelEng subproject owner
-  - justaugustus # SIG Chair / RelEng subproject owner / Release Manager
+  #- justaugustus # SIG Chair / RelEng subproject owner / Release Manager - approvals only
   - lavalamp
   - puerco # SIG Technical Lead / RelEng subproject owner / Release Manager
   - saschagrunert # SIG Chair / RelEng subproject owner / Release Manager

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/OWNERS
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/OWNERS
@@ -14,7 +14,6 @@ reviewers:
 - aramase
 - brendandburns
 - feiskyer
-- justaugustus
 - karataliu
 - khenidak
 - ritazh


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Taking an opportunity to prune myself from some aliases/review paths
to reduce my workload.

If:
- I am no longer reviewing in an area, prune
- There were under five reviewers, remain
- I was already an approver for the area, prune from review path
- I was a reviewer as part of Release Managers, comment out with
  "approvals only"

Signed-off-by: Stephen Augustus <foo@auggie.dev>

/assign @liggitt @dims @saschagrunert @puerco @cpanato 
cc: @kubernetes/release-engineering 

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
