### PR TITLE
Mark restart_test as flaky

### DIFF
--- a/test/e2e_node/restart_test.go
+++ b/test/e2e_node/restart_test.go
@@ -84,7 +84,7 @@ var _ = SIGDescribe("Restart [Serial] [Slow] [Disruptive]", func() {
 	f := framework.NewDefaultFramework("restart-test")
 	ginkgo.Context("Container Runtime", func() {
 		ginkgo.Context("Network", func() {
-			ginkgo.It("should recover from ip leak", func() {
+			ginkgo.It("should recover from ip leak [Flaky]", func() {
 				if framework.TestContext.ContainerRuntime == "docker" {
 					bytes, err := ioutil.ReadFile("/etc/os-release")
 					if err != nil {


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup
/kind flake

#### What this PR does / why we need it:
Restart test has been flaking for a while now (see [testgrid](https://testgrid.k8s.io/sig-node-kubelet#node-kubelet-serial)). This PR marks it as flaky, which removes it from the node-kubelet-serial suite.

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

