### PR TITLE
Automated cherry pick of #106357: Remove Error Message Check Dynamic PV Tests

### DIFF
--- a/test/e2e/storage/testsuites/volumemode.go
+++ b/test/e2e/storage/testsuites/volumemode.go
@@ -271,7 +271,8 @@ func (t *volumeModeTestSuite) DefineTests(driver TestDriver, pattern testpattern
 					"involvedObject.namespace": l.ns.Name,
 					"reason":                   volevents.ProvisioningFailed,
 				}.AsSelector().String()
-				msg := "does not support block volume provisioning"
+				// The error message is different for each storage driver
+				msg := ""
 
 				err = e2eevents.WaitTimeoutForEvent(l.cs, l.ns.Name, eventSelector, msg, framework.ClaimProvisionTimeout)
 				// Events are unreliable, don't depend on the event. It's used only to speed up the test.


### PR DESCRIPTION
Cherry pick of #106357 on release-1.20.

#106357: Remove Error Message Check Dynamic PV Tests

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```