### PR TITLE
adding evictions_total metric and marking evictions_number deprecated

### DIFF
--- a/pkg/controller/nodelifecycle/metrics.go
+++ b/pkg/controller/nodelifecycle/metrics.go
@@ -29,6 +29,7 @@ const (
 	zoneSizeKey             = "zone_size"
 	zoneNoUnhealthyNodesKey = "unhealthy_nodes_in_zone"
 	evictionsNumberKey      = "evictions_number"
+	evictionsTotalKey       = "evictions_total"
 )
 
 var (
@@ -61,10 +62,20 @@ var (
 	)
 	evictionsNumber = metrics.NewCounterVec(
 		&metrics.CounterOpts{
+			Subsystem:         nodeControllerSubsystem,
+			Name:              evictionsNumberKey,
+			Help:              "Number of Node evictions that happened since current instance of NodeController started, This metric is replaced by node_collector_evictions_total.",
+			DeprecatedVersion: "1.24.0",
+			StabilityLevel:    metrics.ALPHA,
+		},
+		[]string{"zone"},
+	)
+	evictionsTotal = metrics.NewCounterVec(
+		&metrics.CounterOpts{
 			Subsystem:      nodeControllerSubsystem,
-			Name:           evictionsNumberKey,
+			Name:           evictionsTotalKey,
 			Help:           "Number of Node evictions that happened since current instance of NodeController started.",
-			StabilityLevel: metrics.ALPHA,
+			StabilityLevel: metrics.STABLE,
 		},
 		[]string{"zone"},
 	)
@@ -79,5 +90,6 @@ func Register() {
 		legacyregistry.MustRegister(zoneSize)
 		legacyregistry.MustRegister(unhealthyNodes)
 		legacyregistry.MustRegister(evictionsNumber)
+		legacyregistry.MustRegister(evictionsTotal)
 	})
 }

--- a/pkg/controller/nodelifecycle/node_lifecycle_controller.go
+++ b/pkg/controller/nodelifecycle/node_lifecycle_controller.go
@@ -699,6 +699,7 @@ func (nc *Controller) doNoExecuteTaintingPass(ctx context.Context) {
 				//count the evictionsNumber
 				zone := nodetopology.GetZoneKey(node)
 				evictionsNumber.WithLabelValues(zone).Inc()
+				evictionsTotal.WithLabelValues(zone).Inc()
 			}
 
 			return result, 0
@@ -742,6 +743,7 @@ func (nc *Controller) doEvictionPass(ctx context.Context) {
 			if node != nil {
 				zone := nodetopology.GetZoneKey(node)
 				evictionsNumber.WithLabelValues(zone).Inc()
+				evictionsTotal.WithLabelValues(zone).Inc()
 			}
 
 			return true, 0
@@ -1396,6 +1398,7 @@ func (nc *Controller) addPodEvictorForNewZone(node *v1.Node) {
 		// Init the metric for the new zone.
 		klog.Infof("Initializing eviction metric for zone: %v", zone)
 		evictionsNumber.WithLabelValues(zone).Add(0)
+		evictionsTotal.WithLabelValues(zone).Add(0)
 	}
 }
 

--- a/test/instrumentation/testdata/stable-metrics-list.yaml
+++ b/test/instrumentation/testdata/stable-metrics-list.yaml
@@ -1,3 +1,11 @@
+- name: evictions_total
+  subsystem: node_collector
+  help: Number of Node evictions that happened since current instance of NodeController
+    started.
+  type: Counter
+  stabilityLevel: STABLE
+  labels:
+  - zone
 - name: framework_extension_point_duration_seconds
   subsystem: scheduler
   help: Latency for running all plugins of a specific extension point.


### PR DESCRIPTION
Signed-off-by: cyclinder <qifeng.guo@daocloud.io>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind feature
#### What this PR does / why we need it:
adding evictions_total metric and marking evictions_number deprecated in 1.23
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes/kubernetes/issues/105864

#### Special notes for your reviewer:
I accidentally deleted the original `evictions_number_stable` branch, which caused the original [PR: 105935](https://github.com/kubernetes/kubernetes/pull/105935) to close, and now I resubmit a new pr for it
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Rename metrics `evictions_number` to `evictions_total` and mark it as stable. The original `evictions_number` metrics name is marked as "Deprecated" and will be removed in kubernetes 1.23

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
