### PR TITLE
Automated cherry pick of #106382: defer close the rotated log open

### DIFF
--- a/pkg/kubelet/kuberuntime/logs/logs.go
+++ b/pkg/kubelet/kuberuntime/logs/logs.go
@@ -361,6 +361,7 @@ func ReadLogs(ctx context.Context, path, containerID string, opts *LogOptions, r
 						}
 						return fmt.Errorf("failed to open log file %q: %v", path, err)
 					}
+					defer newF.Close()
 					f.Close()
 					if err := watcher.Remove(f.Name()); err != nil && !os.IsNotExist(err) {
 						klog.ErrorS(err, "Failed to remove file watch", "path", f.Name())


### PR DESCRIPTION
Cherry pick of #106382 on release-1.22.

#106382: defer close the rotated log open

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```