### PR TITLE
Modify funcName `getContainer` to `getContainerCgp` to make it clear

### DIFF
--- a/pkg/kubelet/cm/helpers_linux.go
+++ b/pkg/kubelet/cm/helpers_linux.go
@@ -25,7 +25,7 @@ import (
 
 	libcontainercgroups "github.com/opencontainers/runc/libcontainer/cgroups"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/kubernetes/pkg/api/v1/resource"
@@ -329,11 +329,11 @@ func NodeAllocatableRoot(cgroupRoot string, cgroupsPerQOS bool, cgroupDriver str
 // GetKubeletContainer returns the cgroup the kubelet will use
 func GetKubeletContainer(kubeletCgroups string) (string, error) {
 	if kubeletCgroups == "" {
-		cont, err := getContainer(os.Getpid())
+		cgp, err := getContainerCgp(os.Getpid())
 		if err != nil {
 			return "", err
 		}
-		return cont, nil
+		return cgp, nil
 	}
 	return kubeletCgroups, nil
 }

--- a/test/e2e_node/resource_collector.go
+++ b/test/e2e_node/resource_collector.go
@@ -36,7 +36,7 @@ import (
 	cadvisorclient "github.com/google/cadvisor/client/v2"
 	cadvisorapiv2 "github.com/google/cadvisor/info/v2"
 	"github.com/opencontainers/runc/libcontainer/cgroups"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/runtime"
@@ -503,17 +503,17 @@ func getContainerNameForProcess(name, pidFile string) (string, error) {
 	if len(pids) == 0 {
 		return "", nil
 	}
-	cont, err := getContainer(pids[0])
+	cgp, err := getContainerCgp(pids[0])
 	if err != nil {
 		return "", err
 	}
-	return cont, nil
+	return cgp, nil
 }
 
-// getContainer returns the cgroup associated with the specified pid.
+// getContainerCgp returns the cgroup associated with the specified pid.
 // It enforces a unified hierarchy for memory and cpu cgroups.
 // On systemd environments, it uses the name=systemd cgroup for the specified pid.
-func getContainer(pid int) (string, error) {
+func getContainerCgp(pid int) (string, error) {
 	cgs, err := cgroups.ParseCgroupFile(fmt.Sprintf("/proc/%d/cgroup", pid))
 	if err != nil {
 		return "", err


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
From the func definition and func details: https://github.com/kubernetes/kubernetes/blob/e4c795168befad6a7f372837e6917b5fe8b95d6e/pkg/kubelet/cm/container_manager_linux.go#L941

got to know that the `getContainer` func is to get the container cgroup, so this PR changes `getContainer` to `getContainerCgp` to make it clear.

#### Special notes for your reviewer:
Also modified the related return variable name to make it consistent.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```