### PR TITLE
De-flake ephemeral containers e2e test

### DIFF
--- a/test/e2e/common/node/ephemeral_containers.go
+++ b/test/e2e/common/node/ephemeral_containers.go
@@ -61,7 +61,7 @@ var _ = SIGDescribe("Ephemeral Containers [NodeFeature:EphemeralContainers]", fu
 			EphemeralContainerCommon: v1.EphemeralContainerCommon{
 				Name:    ecName,
 				Image:   imageutils.GetE2EImage(imageutils.BusyBox),
-				Command: e2epod.GenerateScriptCmd("while true; do sleep 2; echo polo; done"),
+				Command: e2epod.GenerateScriptCmd("while true; do echo polo; sleep 2; done"),
 				Stdin:   true,
 				TTY:     true,
 			},


### PR DESCRIPTION

#### What type of PR is this?

/kind bug
/kind flake

#### What this PR does / why we need it: 

The flaking test always fails with the `polo` test path. The test waits for the container to be running, but the test command sleeps for 2 seconds before writing output, creating a race. Presumably this started failing because the previous kubectl implementation takes more than 2 seconds to run.

#### Which issue(s) this PR fixes:
Fixes #106341

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
