### PR TITLE
enabling runtime-config to be passed via make file for node-e2e testing purposes

### DIFF
--- a/build/root/Makefile
+++ b/build/root/Makefile
@@ -256,6 +256,7 @@ define TEST_E2E_NODE_HELP_INFO
 #    Defaults to false.
 #  TEST_SUITE: For REMOTE=true only. Test suite to use. Defaults to "default".
 #  SSH_KEY: For REMOTE=true only. Path to SSH key to use.
+#  RUNTIME_CONFIG: The runtime configuration for the API server on the node e2e tests.
 #
 # Example:
 #   make test-e2e-node FOCUS=Kubelet SKIP=container

--- a/hack/make-rules/test-e2e-node.sh
+++ b/hack/make-rules/test-e2e-node.sh
@@ -100,6 +100,7 @@ if [ "${remote}" = true ] ; then
   gubernator=${GUBERNATOR:-"false"}
   image_config_file=${IMAGE_CONFIG_FILE:-""}
   image_config_dir=${IMAGE_CONFIG_DIR:-""}
+  runtime_config=${RUNTIME_CONFIG:-""}
   if [[ ${hosts} == "" && ${images} == "" && ${image_config_file} == "" ]]; then
     image_project="${IMAGE_PROJECT:-"cos-cloud"}"
     gci_image=$(gcloud compute images list --project "${image_project}" \
@@ -171,7 +172,7 @@ if [ "${remote}" = true ] ; then
   go run test/e2e_node/runner/remote/run_remote.go  --logtostderr --vmodule=*=4 --ssh-env="gce" \
     --zone="${zone}" --project="${project}" --gubernator="${gubernator}" \
     --hosts="${hosts}" --images="${images}" --cleanup="${cleanup}" \
-    --results-dir="${artifacts}" --ginkgo-flags="${ginkgoflags}" \
+    --results-dir="${artifacts}" --ginkgo-flags="${ginkgoflags}" --runtime_config="${runtime_config}" \
     --image-project="${image_project}" --instance-name-prefix="${instance_prefix}" \
     --delete-instances="${delete_instances}" --test_args="${test_args}" --instance-metadata="${metadata}" \
     --image-config-file="${image_config_file}" --system-spec-name="${system_spec_name}" \

--- a/hack/make-rules/test-e2e-node.sh
+++ b/hack/make-rules/test-e2e-node.sh
@@ -172,7 +172,7 @@ if [ "${remote}" = true ] ; then
   go run test/e2e_node/runner/remote/run_remote.go  --logtostderr --vmodule=*=4 --ssh-env="gce" \
     --zone="${zone}" --project="${project}" --gubernator="${gubernator}" \
     --hosts="${hosts}" --images="${images}" --cleanup="${cleanup}" \
-    --results-dir="${artifacts}" --ginkgo-flags="${ginkgoflags}" --runtime_config="${runtime_config}" \
+    --results-dir="${artifacts}" --ginkgo-flags="${ginkgoflags}" --runtime-config="${runtime_config}" \
     --image-project="${image_project}" --instance-name-prefix="${instance_prefix}" \
     --delete-instances="${delete_instances}" --test_args="${test_args}" --instance-metadata="${metadata}" \
     --image-config-file="${image_config_file}" --system-spec-name="${system_spec_name}" \


### PR DESCRIPTION
This `-- runtime-config` flag option would be used by https://github.com/kubernetes/kubernetes/blob/c592bd40f2df941aa4ea364592ce92fd5c669bfc/test/e2e_node/runner/remote/run_remote.go#L71

cc: @amwat @dims 