### PR TITLE
create resultsDir if the folder not exists

### DIFF
--- a/test/conformance/image/go-runner/main.go
+++ b/test/conformance/image/go-runner/main.go
@@ -59,6 +59,13 @@ func configureAndRunWithEnv(env Getenver) error {
 	// Print the output to stdout and a logfile which will be returned
 	// as part of the results tarball.
 	logFilePath := filepath.Join(resultsDir, logFileName)
+	// ensure the resultsDir actually exists
+	if _, err := os.Stat(resultsDir); os.IsNotExist(err) {
+		log.Printf("The resultsDir %v does not exist, will create it", resultsDir)
+		if mkdirErr := os.Mkdir(resultsDir, 0755); mkdirErr != nil {
+			return fmt.Errorf("failed to create log directory %v: %w", resultsDir, mkdirErr)
+		}
+	}
 	logFile, err := os.Create(logFilePath)
 	if err != nil {
 		return fmt.Errorf("failed to create log file %v: %w", logFilePath, err)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #105953

#### Special notes for your reviewer:
Since the code folder have changed from `cluster/images/conformance/go-runner` to `test/conformance/image/go-runner`, we should create another PR for release-1.21 and release-1.22. This PR only for master

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
