### PR TITLE
Add cli-maintainers as approvers to cmd/(gendocs|genman|genyaml)

### DIFF
--- a/cmd/gendocs/OWNERS
+++ b/cmd/gendocs/OWNERS
@@ -1,0 +1,6 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+  - sig-cli-maintainers
+reviewers:
+  - sig-cli-reviewers

--- a/cmd/genman/OWNERS
+++ b/cmd/genman/OWNERS
@@ -1,0 +1,6 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+  - sig-cli-maintainers
+reviewers:
+  - sig-cli-reviewers

--- a/cmd/genyaml/OWNERS
+++ b/cmd/genyaml/OWNERS
@@ -1,0 +1,6 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+  - sig-cli-maintainers
+reviewers:
+  - sig-cli-reviewers


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup
/sig cli
/priority important-longterm

#### What this PR does / why we need it:
There was a problem with cli approvals in https://github.com/kubernetes/kubernetes/pull/106159, this should fix this for the future.

#### Special notes for your reviewer:
/assign @smarterclayton 
/cc @eddiezane @KnVerey @seans3 @dims 

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
