### PR TITLE
Automated cherry pick of #106329: Fix flake caused by sampling signal counter too early.

### DIFF
--- a/staging/src/k8s.io/kube-aggregator/pkg/apiserver/handler_proxy_test.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/apiserver/handler_proxy_test.go
@@ -921,8 +921,11 @@ type hookedListener struct {
 }
 
 func (wl *hookedListener) Accept() (net.Conn, error) {
-	wl.onAccept()
-	return wl.l.Accept()
+	conn, err := wl.l.Accept()
+	if err == nil {
+		wl.onAccept()
+	}
+	return conn, err
 }
 
 func (wl *hookedListener) Close() error {
@@ -1015,8 +1018,11 @@ func TestFlowControlSignal(t *testing.T) {
 
 			req := tc.Request
 			req.URL = surl
-			_, err = server.Client().Do(&req)
+			res, err := server.Client().Do(&req)
 			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if err := res.Body.Close(); err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
 


### PR DESCRIPTION
Cherry pick of #106329 on release-1.22.

#106329: Fix flake caused by sampling signal counter too early.

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```