### PR TITLE
Improve the error message when trying to proxy an unsupported service type

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/util/proxy/proxy.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/proxy/proxy.go
@@ -45,16 +45,16 @@ func ResolveEndpoint(services listersv1.ServiceLister, endpoints listersv1.Endpo
 		return nil, err
 	}
 
-	svcPort, err := findServicePort(svc, port)
-	if err != nil {
-		return nil, err
-	}
-
 	switch {
 	case svc.Spec.Type == v1.ServiceTypeClusterIP, svc.Spec.Type == v1.ServiceTypeLoadBalancer, svc.Spec.Type == v1.ServiceTypeNodePort:
 		// these are fine
 	default:
 		return nil, fmt.Errorf("unsupported service type %q", svc.Spec.Type)
+	}
+
+	svcPort, err := findServicePort(svc, port)
+	if err != nil {
+		return nil, err
 	}
 
 	eps, err := endpoints.Endpoints(namespace).Get(svc.Name)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

<!--
Add one of the following kinds:
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

Currently when trying to proxy an unsupported service type (such as `ExternalName`), the proxy endpoint first checks the ports. Since a serviceType like `ExternalName` does not explicitly define ports in its spec a proxy call (to, for example, `/api/v1/namespaces/default/services/foobar:8443/proxy`) will fail with the following error:
```
no service port 8443 found for service "foobar"
```

Although technically correct, it isn't particular helpful in identifying the cause of the issue (which is that the type is not supported for proxying). The check just below the service port check is more useful in that perspective, which checks the type of the service.

By moving that check up, the error message for the call above will change to the more helpful:
```
unsupported service type: ExternalName
``` 

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->


#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->