### PR TITLE
Updating kube-proxy to ignore unready endpoints for Topology Hints

### DIFF
--- a/pkg/proxy/topology.go
+++ b/pkg/proxy/topology.go
@@ -68,6 +68,9 @@ func filterEndpointsWithHints(endpoints []Endpoint, hintsAnnotation string, node
 	filteredEndpoints := []Endpoint{}
 
 	for _, endpoint := range endpoints {
+		if !endpoint.IsReady() {
+			continue
+		}
 		if endpoint.GetZoneHints().Len() == 0 {
 			klog.InfoS("Skipping topology aware endpoint filtering since one or more endpoints is missing a zone hint")
 			return endpoints


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
This fixes a bug identified by @danwinship in https://github.com/kubernetes/kubernetes/pull/106497#discussion_r751476376. The bug meant that if hints were assigned to only unready endpoints in a zone, kube-proxy would still select those endpoints in filtering instead of falling back to the full list of endpoints. This fixes that. 

A follow up bug fix will be coming soon that will update the controller to exclude unready endpoints from hint calculations. Update: That follow up fix has now been filed as https://github.com/kubernetes/kubernetes/pull/106510.

#### Does this PR introduce a user-facing change?
```release-note
Kube-Proxy now correctly filters out unready endpoints for Services with Topology Aware Hints enabled.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
- Enhancement Issue: https://github.com/kubernetes/enhancements/issues/2433

/cc @aojea @danwinship
/sig network
/priority important-soon