### PR TITLE
bump e2e period to wait for events

### DIFF
--- a/test/e2e/node/events.go
+++ b/test/e2e/node/events.go
@@ -95,7 +95,7 @@ var _ = SIGDescribe("Events", func() {
 		var events *v1.EventList
 		// Check for scheduler event about the pod.
 		ginkgo.By("checking for scheduler event about the pod")
-		framework.ExpectNoError(wait.Poll(time.Second*2, time.Second*60, func() (bool, error) {
+		framework.ExpectNoError(wait.Poll(framework.Poll, 5*time.Minute, func() (bool, error) {
 			selector := fields.Set{
 				"involvedObject.kind":      "Pod",
 				"involvedObject.uid":       string(podWithUID.UID),
@@ -115,7 +115,7 @@ var _ = SIGDescribe("Events", func() {
 		}))
 		// Check for kubelet event about the pod.
 		ginkgo.By("checking for kubelet event about the pod")
-		framework.ExpectNoError(wait.Poll(time.Second*2, time.Second*60, func() (bool, error) {
+		framework.ExpectNoError(wait.Poll(framework.Poll, 5*time.Minute, func() (bool, error) {
 			selector := fields.Set{
 				"involvedObject.uid":       string(podWithUID.UID),
 				"involvedObject.kind":      "Pod",


### PR DESCRIPTION
#### What type of PR is this?


/kind flake

#### What this PR does / why we need it:

Bump the time to wait for an event, from 1 minutes to 5 minutes, otherwise it fails the tests on slow environments

> > anything that checks specific Events are generated, as we make no guarantees about the contents of events, nor their delivery
> If a test depends on events it is recommended to change the test to use an informer pattern and watch specific resource changes instead.
> An exception to this is tests that generates synthetic events themselves to verify that the API is capable of being exercised
> 

Fixes #106506

#### Special notes for your reviewer:
See analysis of a failure https://github.com/kubernetes/kubernetes/issues/106506#issuecomment-972140283 demonstrating that the event arrives a few seconds later the test times out

```release-note
NONE
```
