### PR TITLE
Extract containerID from system.slice/containerd.service style cgroup…

### DIFF
--- a/pkg/kubelet/stats/cri_stats_provider.go
+++ b/pkg/kubelet/stats/cri_stats_provider.go
@@ -942,6 +942,12 @@ func extractIDFromCgroupPath(cgroupPath string) string {
 			id = components[len(components)-1]
 		}
 	}
+
+	// case2 == systemd: "/system.slice/containerd.service/kubepods-burstable-pod36b6d6be73b1065af369b3985edafa09.slice:cri-containerd:79fedb3bd23ca77c9d9ccb41909038316f713df22b54b7d942b71d3812e7c74e"
+	components := strings.Split(id, ":")
+	if len(components) > 1 {
+		id = components[len(components)-1]
+	}
 	return id
 }
 

--- a/pkg/kubelet/stats/cri_stats_provider_test.go
+++ b/pkg/kubelet/stats/cri_stats_provider_test.go
@@ -1099,6 +1099,10 @@ func TestExtractIDFromCgroupPath(t *testing.T) {
 			cgroupPath: "/kubepods.slice/kubepods-burstable.slice/kubepods-burstable-pod2fc932ce_fdcc_454b_97bd_aadfdeb4c340.slice/cri-o-aaefb9d8feed2d453b543f6d928cede7a4dbefa6a0ae7c9b990dd234c56e93b9.scope",
 			expected:   "aaefb9d8feed2d453b543f6d928cede7a4dbefa6a0ae7c9b990dd234c56e93b9",
 		},
+		{
+			cgroupPath: "/system.slice/containerd.service/kubepods-burstable-pod36b6d6be73b1065af369b3985edafa09.slice:cri-containerd:79fedb3bd23ca77c9d9ccb41909038316f713df22b54b7d942b71d3812e7c74e",
+			expected:   "79fedb3bd23ca77c9d9ccb41909038316f713df22b54b7d942b71d3812e7c74e",
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
Extract containerID from system.slice/containerd.service style cgroupPath

### What type of PR is this?

/kind bug

### What this PR does / why we need it:

PR #104039 handles one style cgroupPath,

kubepods.slice/kubepods-burstable.slice/kubepods-burstable-pod2fc932ce_fdcc_454b_97bd_aadfdeb4c340.slice/cri-containerd-aaefb9d8feed2d453b543f6d928cede7a4dbefa6a0ae7c9b990dd234c56e93b9.scope

but not the following style cgroupPath, so there is this PR.

system.slice/containerd.service/kubepods-burstable-pod36b6d6be73b1065af369b3985edafa09.slice:cri-containerd:79fedb3bd23ca77c9d9ccb41909038316f713df22b54b7d942b71d3812e7c74e

### Which issue(s) this PR fixes:

Fixes #106514

### Special notes for your reviewer:


### Release note:

NONE

### Special notes for your reviewer:

### Does this PR introduce a user-facing change?

### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
