### PR TITLE
kubelet: print flags after initializing logging

### DIFF
--- a/cmd/kubelet/app/server.go
+++ b/cmd/kubelet/app/server.go
@@ -181,7 +181,6 @@ HTTP server: The kubelet can also listen for HTTP and respond to a simple API
 
 			// short-circuit on verflag
 			verflag.PrintAndExitIfRequested()
-			cliflag.PrintFlags(cleanFlagSet)
 
 			// set feature gates from initial flags-based config
 			if err := utilfeature.DefaultMutableFeatureGate.SetFromMap(kubeletConfig.FeatureGates); err != nil {
@@ -266,6 +265,7 @@ HTTP server: The kubelet can also listen for HTTP and respond to a simple API
 				klog.ErrorS(err, "Failed to initialize logging")
 				os.Exit(1)
 			}
+			cliflag.PrintFlags(cleanFlagSet)
 
 			// construct a KubeletServer from kubeletFlags and kubeletConfig
 			kubeletServer := &options.KubeletServer{


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

If done too soon, the klog.V() calls are ignored because the log verbosity
isn't set. In Kubernetes 1.22, the verbosity was set, but not the logging
format.

#### Which issue(s) this PR fixes:
Fixes #100152

#### Special notes for your reviewer:

Output is now:
```
$ go run ./cmd/kubelet -v5 --logging-format=json
Flag --logging-format has been deprecated, This parameter should be set via the config file specified by the Kubelet's --config flag. See https://kubernetes.io/docs/tasks/administer-cluster/kubelet-config-file/ for more information.
{"ts":1637218323889.678,"caller":"flag/flags.go:64","msg":"FLAG: --add-dir-header=\"false\"\n","v":1}
{"ts":1637218323889.7053,"caller":"flag/flags.go:64","msg":"FLAG: --address=\"0.0.0.0\"\n","v":1}
{"ts":1637218323889.7168,"caller":"flag/flags.go:64","msg":"FLAG: --allowed-unsafe-sysctls=\"[]\"\n","v":1}
...
```

#### Does this PR introduce a user-facing change?
```release-note
kubelet: the printing of flags at the start of kubelet now uses the final logging configuration
```
