### PR TITLE
Add e2e tests for disable nodeport lb feature

### DIFF
--- a/test/e2e/network/loadbalancer.go
+++ b/test/e2e/network/loadbalancer.go
@@ -44,6 +44,7 @@ import (
 	e2eskipper "k8s.io/kubernetes/test/e2e/framework/skipper"
 	"k8s.io/kubernetes/test/e2e/network/common"
 	gcecloud "k8s.io/legacy-cloud-providers/gce"
+	utilpointer "k8s.io/utils/pointer"
 
 	"github.com/onsi/ginkgo"
 	"github.com/onsi/gomega"
@@ -845,6 +846,133 @@ var _ = common.SIGDescribe("LoadBalancers", func() {
 		err = jig.ChangeServiceType(v1.ServiceTypeLoadBalancer, e2eservice.GetServiceLoadBalancerCreationTimeout(cs))
 		framework.ExpectNoError(err)
 		e2eservice.WaitForServiceUpdatedWithFinalizer(cs, svc.Namespace, svc.Name, true)
+	})
+
+	ginkgo.It("should be able to create LoadBalancer Service without NodePort and change it [Slow]", func() {
+		// requires cloud load-balancer support
+		e2eskipper.SkipUnlessProviderIs("gce", "gke", "aws")
+
+		loadBalancerLagTimeout := e2eservice.LoadBalancerLagTimeoutDefault
+		if framework.ProviderIs("aws") {
+			loadBalancerLagTimeout = e2eservice.LoadBalancerLagTimeoutAWS
+		}
+		loadBalancerCreateTimeout := e2eservice.GetServiceLoadBalancerCreationTimeout(cs)
+
+		// This test is more monolithic than we'd like because LB turnup can be
+		// very slow, so we lumped all the tests into one LB lifecycle.
+
+		serviceName := "reallocate-nodeport-test"
+		ns1 := f.Namespace.Name // LB1 in ns1 on TCP
+		framework.Logf("namespace for TCP test: %s", ns1)
+
+		nodeIP, err := e2enode.PickIP(cs) // for later
+		framework.ExpectNoError(err)
+
+		ginkgo.By("creating a TCP service " + serviceName + " with type=ClusterIP in namespace " + ns1)
+		tcpJig := e2eservice.NewTestJig(cs, ns1, serviceName)
+		tcpService, err := tcpJig.CreateTCPService(nil)
+		framework.ExpectNoError(err)
+
+		svcPort := int(tcpService.Spec.Ports[0].Port)
+		framework.Logf("service port TCP: %d", svcPort)
+
+		ginkgo.By("creating a pod to be part of the TCP service " + serviceName)
+		_, err = tcpJig.Run(nil)
+		framework.ExpectNoError(err)
+
+		// Change the services to LoadBalancer.
+
+		// Here we test that LoadBalancers can receive static IP addresses.  This isn't
+		// necessary, but is an additional feature this monolithic test checks.
+		requestedIP := ""
+		staticIPName := ""
+		if framework.ProviderIs("gce", "gke") {
+			ginkgo.By("creating a static load balancer IP")
+			staticIPName = fmt.Sprintf("e2e-external-lb-test-%s", framework.RunID)
+			gceCloud, err := gce.GetGCECloud()
+			framework.ExpectNoError(err, "failed to get GCE cloud provider")
+
+			err = gceCloud.ReserveRegionAddress(&compute.Address{Name: staticIPName}, gceCloud.Region())
+			defer func() {
+				if staticIPName != "" {
+					// Release GCE static IP - this is not kube-managed and will not be automatically released.
+					if err := gceCloud.DeleteRegionAddress(staticIPName, gceCloud.Region()); err != nil {
+						framework.Logf("failed to release static IP %s: %v", staticIPName, err)
+					}
+				}
+			}()
+			framework.ExpectNoError(err, "failed to create region address: %s", staticIPName)
+			reservedAddr, err := gceCloud.GetRegionAddress(staticIPName, gceCloud.Region())
+			framework.ExpectNoError(err, "failed to get region address: %s", staticIPName)
+
+			requestedIP = reservedAddr.Address
+			framework.Logf("Allocated static load balancer IP: %s", requestedIP)
+		}
+
+		ginkgo.By("changing the TCP service to type=LoadBalancer")
+		tcpService, err = tcpJig.UpdateService(func(s *v1.Service) {
+			s.Spec.LoadBalancerIP = requestedIP // will be "" if not applicable
+			s.Spec.Type = v1.ServiceTypeLoadBalancer
+			s.Spec.AllocateLoadBalancerNodePorts = utilpointer.BoolPtr(false)
+		})
+		framework.ExpectNoError(err)
+
+		serviceLBNames = append(serviceLBNames, cloudprovider.DefaultLoadBalancerName(tcpService))
+		ginkgo.By("waiting for the TCP service to have a load balancer")
+		// Wait for the load balancer to be created asynchronously
+		tcpService, err = tcpJig.WaitForLoadBalancer(loadBalancerCreateTimeout)
+		framework.ExpectNoError(err)
+		if int(tcpService.Spec.Ports[0].NodePort) != 0 {
+			framework.Failf("TCP Spec.Ports[0].NodePort allocated %d when not expected", tcpService.Spec.Ports[0].NodePort)
+		}
+		if requestedIP != "" && e2eservice.GetIngressPoint(&tcpService.Status.LoadBalancer.Ingress[0]) != requestedIP {
+			framework.Failf("unexpected TCP Status.LoadBalancer.Ingress (expected %s, got %s)", requestedIP, e2eservice.GetIngressPoint(&tcpService.Status.LoadBalancer.Ingress[0]))
+		}
+		tcpIngressIP := e2eservice.GetIngressPoint(&tcpService.Status.LoadBalancer.Ingress[0])
+		framework.Logf("TCP load balancer: %s", tcpIngressIP)
+
+		if framework.ProviderIs("gce", "gke") {
+			// Do this as early as possible, which overrides the `defer` above.
+			// This is mostly out of fear of leaking the IP in a timeout case
+			// (as of this writing we're not 100% sure where the leaks are
+			// coming from, so this is first-aid rather than surgery).
+			ginkgo.By("demoting the static IP to ephemeral")
+			if staticIPName != "" {
+				gceCloud, err := gce.GetGCECloud()
+				framework.ExpectNoError(err, "failed to get GCE cloud provider")
+				// Deleting it after it is attached "demotes" it to an
+				// ephemeral IP, which can be auto-released.
+				if err := gceCloud.DeleteRegionAddress(staticIPName, gceCloud.Region()); err != nil {
+					framework.Failf("failed to release static IP %s: %v", staticIPName, err)
+				}
+				staticIPName = ""
+			}
+		}
+
+		ginkgo.By("hitting the TCP service's LoadBalancer")
+		e2eservice.TestReachableHTTP(tcpIngressIP, svcPort, loadBalancerLagTimeout)
+
+		// Change the services' node ports.
+
+		ginkgo.By("adding a TCP service's NodePort")
+		tcpService, err = tcpJig.UpdateService(func(s *v1.Service) {
+			s.Spec.AllocateLoadBalancerNodePorts = utilpointer.BoolPtr(true)
+		})
+		framework.ExpectNoError(err)
+		tcpNodePort := int(tcpService.Spec.Ports[0].NodePort)
+		if tcpNodePort == 0 {
+			framework.Failf("TCP Spec.Ports[0].NodePort (%d) not allocated", tcpNodePort)
+		}
+		if e2eservice.GetIngressPoint(&tcpService.Status.LoadBalancer.Ingress[0]) != tcpIngressIP {
+			framework.Failf("TCP Status.LoadBalancer.Ingress changed (%s -> %s) when not expected", tcpIngressIP, e2eservice.GetIngressPoint(&tcpService.Status.LoadBalancer.Ingress[0]))
+		}
+		framework.Logf("TCP node port: %d", tcpNodePort)
+
+		ginkgo.By("hitting the TCP service's new NodePort")
+		e2eservice.TestReachableHTTP(nodeIP, tcpNodePort, e2eservice.KubeProxyLagTimeout)
+
+		ginkgo.By("hitting the TCP service's LoadBalancer")
+		e2eservice.TestReachableHTTP(tcpIngressIP, svcPort, loadBalancerLagTimeout)
 	})
 })
 

--- a/test/integration/service/loadbalancer_test.go
+++ b/test/integration/service/loadbalancer_test.go
@@ -78,6 +78,60 @@ func Test_ServiceLoadBalancerDisableAllocateNodePorts(t *testing.T) {
 	}
 }
 
+// Test_ServiceUpdateLoadBalancerAllocateNodePorts tests that a Service that is updated from ClusterIP to LoadBalancer
+// with spec.allocateLoadBalancerNodePorts=false does not allocate node ports for the Service
+func Test_ServiceUpdateLoadBalancerDisableAllocateNodePorts(t *testing.T) {
+	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.ServiceLBNodePortControl, true)()
+
+	controlPlaneConfig := framework.NewIntegrationTestControlPlaneConfig()
+	_, server, closeFn := framework.RunAnAPIServer(controlPlaneConfig)
+	defer closeFn()
+
+	config := restclient.Config{Host: server.URL}
+	client, err := clientset.NewForConfig(&config)
+	if err != nil {
+		t.Fatalf("Error creating clientset: %v", err)
+	}
+
+	ns := framework.CreateTestingNamespace("test-service-allocate-node-ports", server, t)
+	defer framework.DeleteTestingNamespace(ns, server, t)
+
+	service := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-123",
+		},
+		Spec: corev1.ServiceSpec{
+			Type: corev1.ServiceTypeClusterIP,
+			Ports: []corev1.ServicePort{{
+				Port: int32(80),
+			}},
+			Selector: map[string]string{
+				"foo": "bar",
+			},
+		},
+	}
+
+	service, err = client.CoreV1().Services(ns.Name).Create(context.TODO(), service, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("Error creating test service: %v", err)
+	}
+
+	if serviceHasNodePorts(service) {
+		t.Error("found node ports when none was expected")
+	}
+
+	service.Spec.Type = corev1.ServiceTypeLoadBalancer
+	service.Spec.AllocateLoadBalancerNodePorts = utilpointer.BoolPtr(false)
+	service, err = client.CoreV1().Services(ns.Name).Update(context.TODO(), service, metav1.UpdateOptions{})
+	if err != nil {
+		t.Fatalf("Error updating test service: %v", err)
+	}
+
+	if serviceHasNodePorts(service) {
+		t.Error("found node ports when none was expected")
+	}
+}
+
 // Test_ServiceLoadBalancerSwitchToDeallocatedNodePorts test that switching a Service
 // to spec.allocateLoadBalancerNodePorts=false, does not de-allocate existing node ports.
 func Test_ServiceLoadBalancerEnableThenDisableAllocatedNodePorts(t *testing.T) {
@@ -129,6 +183,60 @@ func Test_ServiceLoadBalancerEnableThenDisableAllocatedNodePorts(t *testing.T) {
 
 	if !serviceHasNodePorts(service) {
 		t.Error("node ports were unexpectedly deallocated")
+	}
+}
+
+// Test_ServiceLoadBalancerDisableThenEnableAllocatedNodePorts test that switching a Service
+// to spec.allocateLoadBalancerNodePorts=true from false, allocate new node ports.
+func Test_ServiceLoadBalancerDisableThenEnableAllocatedNodePorts(t *testing.T) {
+	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.ServiceLBNodePortControl, true)()
+
+	controlPlaneConfig := framework.NewIntegrationTestControlPlaneConfig()
+	_, server, closeFn := framework.RunAnAPIServer(controlPlaneConfig)
+	defer closeFn()
+
+	config := restclient.Config{Host: server.URL}
+	client, err := clientset.NewForConfig(&config)
+	if err != nil {
+		t.Fatalf("Error creating clientset: %v", err)
+	}
+
+	ns := framework.CreateTestingNamespace("test-service-reallocate-node-ports", server, t)
+	defer framework.DeleteTestingNamespace(ns, server, t)
+
+	service := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-123",
+		},
+		Spec: corev1.ServiceSpec{
+			Type:                          corev1.ServiceTypeLoadBalancer,
+			AllocateLoadBalancerNodePorts: utilpointer.BoolPtr(false),
+			Ports: []corev1.ServicePort{{
+				Port: int32(80),
+			}},
+			Selector: map[string]string{
+				"foo": "bar",
+			},
+		},
+	}
+
+	service, err = client.CoreV1().Services(ns.Name).Create(context.TODO(), service, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("Error creating test service: %v", err)
+	}
+
+	if serviceHasNodePorts(service) {
+		t.Error("not expected node ports but found one")
+	}
+
+	service.Spec.AllocateLoadBalancerNodePorts = utilpointer.BoolPtr(true)
+	service, err = client.CoreV1().Services(ns.Name).Update(context.TODO(), service, metav1.UpdateOptions{})
+	if err != nil {
+		t.Fatalf("Error updating test service: %v", err)
+	}
+
+	if !serviceHasNodePorts(service) {
+		t.Error("expected node ports but found none")
 	}
 }
 


### PR DESCRIPTION
/kind feature

#### What this PR does / why we need it:

Add more testing for the feature to allows to disable nodeports on Load Balancer Services

https://github.com/kubernetes/enhancements/tree/master/keps/sig-network/1864-disable-lb-node-ports

```release-note
NONE
```

ref: https://github.com/kubernetes/enhancements/issues/1864