### PR TITLE
Test: Remove needless sleep from agnhost serve-hostname

### DIFF
--- a/test/images/agnhost/serve-hostname/serve_hostname.go
+++ b/test/images/agnhost/serve-hostname/serve_hostname.go
@@ -26,7 +26,6 @@ import (
 	"os"
 	"os/signal"
 	"syscall"
-	"time"
 
 	"github.com/spf13/cobra"
 )
@@ -125,6 +124,4 @@ func main(cmd *cobra.Command, args []string) {
 	signal.Notify(signals, syscall.SIGTERM)
 	sig := <-signals
 	log.Printf("Shutting down after receiving signal: %s.\n", sig)
-	log.Printf("Awaiting pod deletion.\n")
-	time.Sleep(60 * time.Second)
 }


### PR DESCRIPTION
There is no need to sleep for 60s when agnhost's
serve-hostname receives sigterm. It should respect
sigterm and terminate ASAP.

Signed-off-by: Martin Kennelly <mkennell@redhat.com>

/kind bug

#### What this PR does / why we need it:
During our testing, we notice it takes longer than normal for agnhost's serve-hostname to end. This is delaying the test run.
I noticed there is a sleep at the end of serve-hostname and don't understand the justification after checking previous PRs. Please let me know why it is needed.


#### Special notes for your reviewer:

-->
```release-note
NONE

```