### PR TITLE
Fix klog lock release on panic

### DIFF
--- a/staging/src/k8s.io/client-go/tools/cache/shared_informer.go
+++ b/staging/src/k8s.io/client-go/tools/cache/shared_informer.go
@@ -244,7 +244,7 @@ func WaitForNamedCacheSync(controllerName string, stopCh <-chan struct{}, cacheS
 		return false
 	}
 
-	klog.Infof("Caches are synced for %s ", controllerName)
+	klog.Infof("Caches are synced for %s", controllerName)
 	return true
 }
 


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
When provided the klog.SetLogger(selfLogger), but with the Error func return a panic, will lead to controller `WaitForNamedCacheSync` never returned.

This PR captured the panic and release the lock instantly.

#### Which issue(s) this PR fixes:
Fixes #106534

#### Special notes for your reviewer:
Also fixed a blank typo, to make it clean when retrieving the log data with json or other formats.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
