### PR TITLE
Fix missing of Lock in NewDockerKeyring

### DIFF
--- a/pkg/credentialprovider/plugins.go
+++ b/pkg/credentialprovider/plugins.go
@@ -59,6 +59,8 @@ func NewDockerKeyring() DockerKeyring {
 		Providers: make([]DockerConfigProvider, 0),
 	}
 
+	providersMutex.Lock()
+	defer providersMutex.Unlock()
 	keys := reflect.ValueOf(providers).MapKeys()
 	stringKeys := make([]string, len(keys))
 	for ix := range keys {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

The NewDockerKeyring needs to read the value of providers, so RLock should be added there.

#### Which issue(s) this PR fixes:

Fixes a potential race condition

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
