### PR TITLE
Fix Attachment ID matching

### DIFF
--- a/pkg/volume/csi/csi_attacher.go
+++ b/pkg/volume/csi/csi_attacher.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"time"
 
@@ -65,6 +66,9 @@ var _ volume.Attacher = &csiAttacher{}
 var _ volume.Detacher = &csiAttacher{}
 
 var _ volume.DeviceMounter = &csiAttacher{}
+
+// Mathes VolumeAttachment.Names, which have format "csi-<sha256>", e.g. "csi-fad16dffa58f425ddde44ab16f5feff6610e27aaa7798209b8960c02552e3e4e".
+var attachmentNameRegexp = regexp.MustCompile("^csi-[0-9a-f]*$")
 
 func (c *csiAttacher) Attach(spec *volume.Spec, nodeName types.NodeName) (string, error) {
 	if spec == nil {
@@ -645,7 +649,7 @@ func getAttachmentName(volName, csiDriverName, nodeName string) string {
 // and false otherwise
 func isAttachmentName(unknownString string) bool {
 	// 68 == "csi-" + len(sha256hash)
-	return strings.HasPrefix(unknownString, "csi-") && len(unknownString) == 68
+	return len(unknownString) == 68 && attachmentNameRegexp.MatchString(unknownString)
 }
 
 func makeDeviceMountPath(plugin *csiPlugin, spec *volume.Spec) (string, error) {

--- a/pkg/volume/csi/csi_attacher_test.go
+++ b/pkg/volume/csi/csi_attacher_test.go
@@ -1749,3 +1749,31 @@ func getCsiAttacherFromDeviceUnmounter(deviceUnmounter volume.DeviceUnmounter, w
 	csiAttacher.watchTimeout = watchTimeout
 	return csiAttacher
 }
+
+func TestIsAttachmentName(t *testing.T) {
+	tests := []struct {
+		volumeID       string
+		expectAttachID bool
+	}{
+		{
+			// Unique volume name
+			"kubernetes.io/csi/rbd.csi.ceph.com^0001-0011-site1-0000000000000001-63bd3b07-4939-11ec-b6a4-0a580a810033",
+			false,
+		}, {
+			// Attachment name
+			"csi-fad16dffa58f425ddde44ab16f5feff6610e27aaa7798209b8960c02552e3e4e",
+			true,
+		}, {
+			// Unique volume name that looks like attachment id (has the right prefix + length)
+			"csi-driver.foo.com^id-with-68-characters-as-sha256-would-have-000001",
+			false,
+		},
+	}
+
+	for _, test := range tests {
+		ret := isAttachmentName(test.volumeID)
+		if ret != test.expectAttachID {
+			t.Errorf("Expected isAttachmentName(%q) to be %t, but got %t", test.volumeID, test.expectAttachID, ret)
+		}
+	}
+}


### PR DESCRIPTION
When deciding if a string is VolumeAttachment ID or a volume unique name, make sure that volumes of a CSI driver named `"csi-foo.bar"` are recognized as unique volume names and not attachment IDs.

Use a regexp that allows only characters that are in sha256 (0-9,a-f), which is part of the attachment ID. Unique volume names always have `"^"` in their name and the regexp won't match them.

/kind bug

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #97230

```release-note
Fixed detaching CSI volumes from nodes when a CSI driver name has prefix "csi-".
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
