### PR TITLE
testdata dirs are not useful go code

### DIFF
--- a/hack/make-rules/helpers/cache_go_dirs.sh
+++ b/hack/make-rules/helpers/cache_go_dirs.sh
@@ -38,8 +38,8 @@ trap 'rm -f "${CACHE}"' HUP INT TERM ERR
 function kfind() {
     # We want to include the "special" vendor directories which are actually
     # part of the Kubernetes source tree (./staging/*) but we need them to be
-    # named as their ./vendor/* equivalents.  Also, we  do not want all of
-    # ./vendor , ./hack/tools/vendor or even all of ./vendor/k8s.io.
+    # named as their ./vendor/* equivalents.  Also, we do not want all of
+    # ./vendor nor ./hack/tools/vendor nor even all of ./vendor/k8s.io.
     find -H .                      \
         \(                         \
         -not \(                    \
@@ -48,6 +48,10 @@ function kfind() {
                 -name '.[^.]*' -o  \
                 \(                 \
                   -name 'vendor'   \
+                  -type d          \
+                \) -o              \
+                \(                 \
+                  -name 'testdata' \
                   -type d          \
                 \)                 \
             \) -prune              \


### PR DESCRIPTION
Minor.  This removes a few "testdata" dirs from .make/all_go_dirs.mk

-hack/make-rules/helpers/go2make/testdata/dir-with-gofiles
-test/conformance/testdata
-test/instrumentation/testdata/pkg/kubelet/metrics
-test/instrumentation/testdata/staging/src/k8s.io/metrics
-test/typecheck/testdata/bad
-test/typecheck/testdata/good
-test/typecheck/testdata/good/testdata
-vendor/k8s.io/kubectl/pkg/cmd/edit/testdata

This list of dirs is used to figure out which directories need codegen,
and none of these do.


/kind cleanup

```release-note
NONE
```
