### PR TITLE
Return BadRequest for invalid large patch

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/patch.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/patch.go
@@ -412,6 +412,9 @@ func (p *jsonPatcher) applyJSPatch(versionedJS []byte) (patchedJS []byte, strict
 		}
 
 		patchedJS, retErr = jsonpatch.MergePatch(versionedJS, p.patchBytes)
+		if retErr == jsonpatch.ErrBadJSONPatch {
+			return nil, nil, errors.NewBadRequest(retErr.Error())
+		}
 		return patchedJS, strictErrors, retErr
 	default:
 		// only here as a safety net - go-restful filters content-type


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind failing-test

#### Which issue(s) this PR fixes:
Fixes #106573

Before https://github.com/kubernetes/kubernetes/pull/105916/files#diff-c4afbb7d6a8bdb1d6475f18abc92caa6c413f879aeeb189187c569f3f6c146f4L366, patches over 1kb were decoded before calling into the jsonpatch library, and any errors returned as a BadRequest.

Since go1.15, the stdlib decoder enforces the stackdepth limits, so we no longer need to do the pre-decode, but we need to treat a returned error decoding the patch as a bad request.

The failing tests were marked as long tests, so they don't run in presubmits, since they submit very large patches to the API server which can stress the presubmit env.

```release-note
NONE
```

/cc @aojea @kevindelgado 