### PR TITLE
Registering kube-proxy metrics on windows kernel mode

### DIFF
--- a/cmd/kube-proxy/app/server_windows.go
+++ b/cmd/kube-proxy/app/server_windows.go
@@ -141,6 +141,8 @@ func newProxyServer(config *proxyconfigapi.KubeProxyConfiguration, cleanupAndExi
 		if err != nil {
 			return nil, fmt.Errorf("unable to create proxier: %v", err)
 		}
+
+		winkernel.RegisterMetrics()
 	} else {
 		klog.V(0).InfoS("Using userspace Proxier.")
 		klog.V(0).InfoS("The userspace proxier is now deprecated and will be removed in a future release, please use 'kernelspace' instead")

--- a/pkg/proxy/winkernel/metrics.go
+++ b/pkg/proxy/winkernel/metrics.go
@@ -19,40 +19,21 @@ package winkernel
 import (
 	"sync"
 
-	"k8s.io/component-base/metrics"
 	"k8s.io/component-base/metrics/legacyregistry"
-)
-
-const kubeProxySubsystem = "kubeproxy"
-
-var (
-	SyncProxyRulesLatency = metrics.NewHistogram(
-		&metrics.HistogramOpts{
-			Subsystem:      kubeProxySubsystem,
-			Name:           "sync_proxy_rules_duration_seconds",
-			Help:           "SyncProxyRules latency in seconds",
-			Buckets:        metrics.ExponentialBuckets(0.001, 2, 15),
-			StabilityLevel: metrics.ALPHA,
-		},
-	)
-
-	// SyncProxyRulesLastTimestamp is the timestamp proxy rules were last
-	// successfully synced.
-	SyncProxyRulesLastTimestamp = metrics.NewGauge(
-		&metrics.GaugeOpts{
-			Subsystem:      kubeProxySubsystem,
-			Name:           "sync_proxy_rules_last_timestamp_seconds",
-			Help:           "The last time proxy rules were successfully synced",
-			StabilityLevel: metrics.ALPHA,
-		},
-	)
+	"k8s.io/kubernetes/pkg/proxy/metrics"
 )
 
 var registerMetricsOnce sync.Once
 
+// RegisterMetrics registers kube-proxy metrics for Windows modes.
 func RegisterMetrics() {
 	registerMetricsOnce.Do(func() {
-		legacyregistry.MustRegister(SyncProxyRulesLatency)
-		legacyregistry.MustRegister(SyncProxyRulesLastTimestamp)
+		legacyregistry.MustRegister(metrics.SyncProxyRulesLatency)
+		legacyregistry.MustRegister(metrics.SyncProxyRulesLastTimestamp)
+		legacyregistry.MustRegister(metrics.EndpointChangesPending)
+		legacyregistry.MustRegister(metrics.EndpointChangesTotal)
+		legacyregistry.MustRegister(metrics.ServiceChangesPending)
+		legacyregistry.MustRegister(metrics.ServiceChangesTotal)
+		legacyregistry.MustRegister(metrics.SyncProxyRulesLastQueuedTimestamp)
 	})
 }

--- a/pkg/proxy/winkernel/proxier.go
+++ b/pkg/proxy/winkernel/proxier.go
@@ -972,16 +972,18 @@ func (proxier *Proxier) syncProxyRules() {
 	proxier.mu.Lock()
 	defer proxier.mu.Unlock()
 
-	start := time.Now()
-	defer func() {
-		SyncProxyRulesLatency.Observe(metrics.SinceInSeconds(start))
-		klog.V(4).InfoS("Syncing proxy rules complete", "elapsed", time.Since(start))
-	}()
 	// don't sync rules till we've received services and endpoints
 	if !proxier.isInitialized() {
 		klog.V(2).InfoS("Not syncing hns until Services and Endpoints have been received from master")
 		return
 	}
+
+	// Keep track of how long syncs take.
+	start := time.Now()
+	defer func() {
+		metrics.SyncProxyRulesLatency.Observe(metrics.SinceInSeconds(start))
+		klog.V(4).InfoS("Syncing proxy rules complete", "elapsed", time.Since(start))
+	}()
 
 	hnsNetworkName := proxier.network.name
 	hns := proxier.hns
@@ -1310,7 +1312,7 @@ func (proxier *Proxier) syncProxyRules() {
 	if proxier.healthzServer != nil {
 		proxier.healthzServer.Updated()
 	}
-	SyncProxyRulesLastTimestamp.SetToCurrentTime()
+	metrics.SyncProxyRulesLastTimestamp.SetToCurrentTime()
 
 	// Update service healthchecks.  The endpoints list might include services that are
 	// not "OnlyLocal", but the services list will not, and the serviceHealthServer


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

1. Kube-proxy metrics are not registered, fixing on this PR for kernel mode.
2. Moving syncproxyrule gauge after exit due no endpoints checks. 
3. Reusing the `pkg/metrics` module metrics for DRY.
4. Increasing metrics coverage adding more gauges and counters:

```
    legacyregistry.MustRegister(SyncProxyRulesLatency)
    legacyregistry.MustRegister(SyncProxyRulesLastTimestamp)
    legacyregistry.MustRegister(EndpointChangesPending)
    legacyregistry.MustRegister(EndpointChangesTotal)
    legacyregistry.MustRegister(ServiceChangesPending)
    legacyregistry.MustRegister(ServiceChangesTotal)
    legacyregistry.MustRegister(SyncProxyRulesLastQueuedTimestamp)
```

#### What type of PR is this?
/sig windows
/sig network
/kind bug

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #106580

#### Special notes for your reviewer:

Metrics gathering after the change

```
kubeproxy_sync_proxy_rules_duration_seconds_bucket{le="0.001"} 0
kubeproxy_sync_proxy_rules_duration_seconds_bucket{le="0.002"} 0
kubeproxy_sync_proxy_rules_duration_seconds_bucket{le="0.004"} 0
kubeproxy_sync_proxy_rules_duration_seconds_bucket{le="0.008"} 0
kubeproxy_sync_proxy_rules_duration_seconds_bucket{le="0.016"} 0
kubeproxy_sync_proxy_rules_duration_seconds_bucket{le="0.032"} 0
kubeproxy_sync_proxy_rules_duration_seconds_bucket{le="0.064"} 0
kubeproxy_sync_proxy_rules_duration_seconds_bucket{le="0.128"} 0
kubeproxy_sync_proxy_rules_duration_seconds_bucket{le="0.256"} 0
kubeproxy_sync_proxy_rules_duration_seconds_bucket{le="0.512"} 0
kubeproxy_sync_proxy_rules_duration_seconds_bucket{le="1.024"} 1
kubeproxy_sync_proxy_rules_duration_seconds_bucket{le="2.048"} 1
kubeproxy_sync_proxy_rules_duration_seconds_bucket{le="4.096"} 1
kubeproxy_sync_proxy_rules_duration_seconds_bucket{le="8.192"} 1
kubeproxy_sync_proxy_rules_duration_seconds_bucket{le="16.384"} 1
kubeproxy_sync_proxy_rules_duration_seconds_bucket{le="+Inf"} 1
kubeproxy_sync_proxy_rules_duration_seconds_sum 0.6019167
kubeproxy_sync_proxy_rules_duration_seconds_count 1

# HELP kubeproxy_sync_proxy_rules_endpoint_changes_pending [ALPHA] Pending proxy rules Endpoint changes
# TYPE kubeproxy_sync_proxy_rules_endpoint_changes_pending gauge
kubeproxy_sync_proxy_rules_endpoint_changes_pending 0

# HELP kubeproxy_sync_proxy_rules_endpoint_changes_total [ALPHA] Cumulative proxy rules Endpoint changes
# TYPE kubeproxy_sync_proxy_rules_endpoint_changes_total counter
kkubeproxy_sync_proxy_rules_endpoint_changes_total 15

 # HELP kubeproxy_sync_proxy_rules_last_queued_timestamp_seconds [ALPHA] The last time a sync of proxy rules was queued
 # TYPE kubeproxy_sync_proxy_rules_last_queued_timestamp_seconds gauge
 kubeproxy_sync_proxy_rules_last_queued_timestamp_seconds 1.6375378693502028e+09

# HELP kubeproxy_sync_proxy_rules_last_timestamp_seconds [ALPHA] The last time proxy rules were successfully synced
# TYPE kubeproxy_sync_proxy_rules_last_timestamp_seconds gauge
kubeproxy_sync_proxy_rules_last_timestamp_seconds 1.6375378700543056e+09

# HELP kubeproxy_sync_proxy_rules_service_changes_pending [ALPHA] Pending proxy rules Service changes
 TYPE kubeproxy_sync_proxy_rules_service_changes_pending gauge
kubeproxy_sync_proxy_rules_service_changes_pending 0

# HELP kubeproxy_sync_proxy_rules_service_changes_total [ALPHA] Cumulative proxy rules Service changes
# TYPE kubeproxy_sync_proxy_rules_service_changes_total counter
kubeproxy_sync_proxy_rules_service_changes_total 15
```

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Publishing kube-proxy metrics for Windows kernel-mode
```

