### PR TITLE
Automated cherry pick of #104991: Fix workqueue memory leak
#105031: workqueue: fix leak in queue preventing objects from being

### DIFF
--- a/staging/src/k8s.io/client-go/util/workqueue/queue.go
+++ b/staging/src/k8s.io/client-go/util/workqueue/queue.go
@@ -155,7 +155,10 @@ func (q *Type) Get() (item interface{}, shutdown bool) {
 		return nil, true
 	}
 
-	item, q.queue = q.queue[0], q.queue[1:]
+	item = q.queue[0]
+	// The underlying array still exists and reference this object, so the object will not be garbage collected.
+	q.queue[0] = nil
+	q.queue = q.queue[1:]
 
 	q.metrics.get(item)
 


### PR DESCRIPTION
Cherry pick of #104991 #105031 on release-1.21.

#104991: Fix workqueue memory leak
#105031: workqueue: fix leak in queue preventing objects from being

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```