### PR TITLE
[cloud-provider] fix test failed because of flag redefined

### DIFF
--- a/staging/src/k8s.io/legacy-cloud-providers/vsphere/vsphere_test.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/vsphere/vsphere_test.go
@@ -206,6 +206,10 @@ func configFromEnvOrSim() (VSphereConfig, func()) {
 	return configFromSim()
 }
 
+func init() {
+	klog.InitFlags(nil)
+}
+
 func TestSecretUpdated(t *testing.T) {
 	datacenter := "0.0.0.0"
 	secretName := "vccreds"
@@ -227,9 +231,7 @@ func TestSecretUpdated(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Should succeed when a valid config is provided: %s", err)
 	}
-	klog.Flush()
 
-	klog.InitFlags(nil)
 	flag.Set("logtostderr", "false")
 	flag.Set("alsologtostderr", "false")
 	flag.Set("v", "9")


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind failing-test
/kind flake

#### What this PR does / why we need it:

The test has continued to fail for months, better fix this.

#### Which issue(s) this PR fixes:

Fixes #101927

#### Special notes for your reviewer:

Already test this locally with 

before
```bash
$ go test -run ^TestSecretUpdated$ ./vsphere -count 10
W1122 11:02:32.160755    8326 vsphere.go:341] Global.User and Secret info provided. VCP will use secret to get credentials
W1122 11:02:32.160772    8326 vsphere.go:345] Global.Password and Secret info provided. VCP will use secret to get credentials
/var/folders/x0/3jhpxgj516nf3l_ns7jl09rr0000gn/T/go-build1721751768/b001/vsphere.test flag redefined: log_dir
--- FAIL: TestSecretUpdated (0.01s)
panic: /var/folders/x0/3jhpxgj516nf3l_ns7jl09rr0000gn/T/go-build1721751768/b001/vsphere.test flag redefined: log_dir [recovered]
        panic: /var/folders/x0/3jhpxgj516nf3l_ns7jl09rr0000gn/T/go-build1721751768/b001/vsphere.test flag redefined: log_dir

goroutine 75 [running]:
testing.tRunner.func1.2({0x26000c0, 0xc00069f390})
        /usr/local/Cellar/go/1.17.1/libexec/src/testing/testing.go:1209 +0x24e
testing.tRunner.func1()
        /usr/local/Cellar/go/1.17.1/libexec/src/testing/testing.go:1212 +0x218
panic({0x26000c0, 0xc00069f390})
        /usr/local/Cellar/go/1.17.1/libexec/src/runtime/panic.go:1038 +0x215
flag.(*FlagSet).Var(0xc0000b4180, {0x2d7d848, 0x3f4f5f0}, {0x2a74599, 0x7}, {0x2af0911, 0x2f})
        /usr/local/Cellar/go/1.17.1/libexec/src/flag/flag.go:879 +0x2f4
flag.(*FlagSet).StringVar(...)
        /usr/local/Cellar/go/1.17.1/libexec/src/flag/flag.go:762
k8s.io/klog/v2.InitFlags(0x3f4f540)
        /Users/jony/go/pkg/mod/k8s.io/klog/v2@v2.30.0/klog.go:429 +0x55
k8s.io/legacy-cloud-providers/vsphere.TestSecretUpdated(0xc000503a00)
        /Users/jony/work/kubernetes/staging/src/k8s.io/legacy-cloud-providers/vsphere/vsphere_test.go:239 +0x405
testing.tRunner(0xc000503a00, 0x2b92f50)
        /usr/local/Cellar/go/1.17.1/libexec/src/testing/testing.go:1259 +0x102
created by testing.(*T).Run
        /usr/local/Cellar/go/1.17.1/libexec/src/testing/testing.go:1306 +0x35a
FAIL    k8s.io/legacy-cloud-providers/vsphere   0.760s
FAIL
```

after
```bash
$ go test -run ^TestSecretUpdated$ ./vsphere -count 10
ok      k8s.io/legacy-cloud-providers/vsphere   0.673s
```