### PR TITLE
Promote HPA CPU E2E tests to Conformance.

### DIFF
--- a/test/conformance/testdata/conformance.yaml
+++ b/test/conformance/testdata/conformance.yaml
@@ -1005,6 +1005,56 @@
     ServiceAccount will be deleted and MUST find a deleted watch event.
   release: v1.19
   file: test/e2e/auth/service_accounts.go
+- testname: 'HPA: ReplicationController scale up.'
+  codename: '[sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: CPU)
+    ReplicationController light Should scale from 1 pod to 2 pods [Conformance]'
+  description: When an HPA object targets a ReplicaSet whose average CPU utilization
+    is higher than the configured CPU utilization target, the ReplicationController
+    MUST be scaled up.
+  release: v1.23
+  file: test/e2e/autoscaling/horizontal_pod_autoscaling.go
+- testname: 'HPA: ReplicationController scale down.'
+  codename: '[sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: CPU)
+    ReplicationController light Should scale from 2 pods to 1 pod [Slow] [Conformance]'
+  description: When an HPA object targets a ReplicaSet whose average CPU utilization
+    is lower than the configured CPU utilization target, the ReplicationController
+    MUST be scaled down.
+  release: v1.23
+  file: test/e2e/autoscaling/horizontal_pod_autoscaling.go
+- testname: 'HPA: Deployment scale up.'
+  codename: '[sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: CPU)
+    [Serial] [Slow] Deployment Should scale from 1 pod to 3 pods and from 3 to 5 [Conformance]'
+  description: When an HPA object targets a Deployment whose average CPU utilization
+    is higher than the configured CPU utilization target, the Deployment MUST be scaled
+    up.
+  release: v1.23
+  file: test/e2e/autoscaling/horizontal_pod_autoscaling.go
+- testname: 'HPA: Deployment scale down.'
+  codename: '[sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: CPU)
+    [Serial] [Slow] Deployment Should scale from 5 pods to 3 pods and from 3 to 1
+    [Conformance]'
+  description: When an HPA object targets a Deployment whose average CPU utilization
+    is lower than the configured CPU utilization target, the Deployment MUST be scaled
+    down.
+  release: v1.23
+  file: test/e2e/autoscaling/horizontal_pod_autoscaling.go
+- testname: 'HPA: ReplicaSet scale up.'
+  codename: '[sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: CPU)
+    [Serial] [Slow] ReplicaSet Should scale from 1 pod to 3 pods and from 3 to 5 [Conformance]'
+  description: When an HPA object targets a ReplicaSet whose average CPU utilization
+    is higher than the configured CPU utilization target, the ReplicaSet MUST be scaled
+    up.
+  release: v1.23
+  file: test/e2e/autoscaling/horizontal_pod_autoscaling.go
+- testname: 'HPA: ReplicaSet scale down.'
+  codename: '[sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: CPU)
+    [Serial] [Slow] ReplicaSet Should scale from 5 pods to 3 pods and from 3 to 1
+    [Conformance]'
+  description: When an HPA object targets a ReplicaSet whose average CPU utilization
+    is lower than the configured CPU utilization target, the ReplicaSet MUST be scaled
+    down.
+  release: v1.23
+  file: test/e2e/autoscaling/horizontal_pod_autoscaling.go
 - testname: Kubectl, guestbook application
   codename: '[sig-cli] Kubectl client Guestbook application should create and stop
     a working application  [Conformance]'

--- a/test/e2e/autoscaling/horizontal_pod_autoscaling.go
+++ b/test/e2e/autoscaling/horizontal_pod_autoscaling.go
@@ -28,28 +28,58 @@ import (
 
 // These tests don't seem to be running properly in parallel: issue: #20338.
 //
-var _ = SIGDescribe("[Feature:HPA] Horizontal pod autoscaling (scale resource: CPU)", func() {
+var _ = SIGDescribe("[HPA] Horizontal pod autoscaling (scale resource: CPU)", func() {
 	f := framework.NewDefaultFramework("horizontal-pod-autoscaling")
 
 	titleUp := "Should scale from 1 pod to 3 pods and from 3 to 5"
 	titleDown := "Should scale from 5 pods to 3 pods and from 3 to 1"
 
 	ginkgo.Describe("[Serial] [Slow] Deployment", func() {
-		// CPU tests via deployments
-		ginkgo.It(titleUp, func() {
+		/*
+		   Release: v1.23
+		   Testname: HPA: Deployment scale up.
+		   Description: When an HPA object targets a
+		   Deployment whose average CPU utilization is higher
+		   than the configured CPU utilization target, the
+		   Deployment MUST be scaled up.
+		*/
+		framework.ConformanceIt(titleUp, func() {
 			scaleUp("test-deployment", e2eautoscaling.KindDeployment, false, f)
 		})
-		ginkgo.It(titleDown, func() {
+		/*
+		   Release: v1.23
+		   Testname: HPA: Deployment scale down.
+		   Description: When an HPA object targets a
+		   Deployment whose average CPU utilization is lower
+		   than the configured CPU utilization target, the
+		   Deployment MUST be scaled down.
+		*/
+		framework.ConformanceIt(titleDown, func() {
 			scaleDown("test-deployment", e2eautoscaling.KindDeployment, false, f)
 		})
 	})
 
 	ginkgo.Describe("[Serial] [Slow] ReplicaSet", func() {
-		// CPU tests via ReplicaSets
-		ginkgo.It(titleUp, func() {
+		/*
+		   Release: v1.23
+		   Testname: HPA: ReplicaSet scale up.
+		   Description: When an HPA object targets a
+		   ReplicaSet whose average CPU utilization is higher
+		   than the configured CPU utilization target, the
+		   ReplicaSet MUST be scaled up.
+		*/
+		framework.ConformanceIt(titleUp, func() {
 			scaleUp("rs", e2eautoscaling.KindReplicaSet, false, f)
 		})
-		ginkgo.It(titleDown, func() {
+		/*
+		   Release: v1.23
+		   Testname: HPA: ReplicaSet scale down.
+		   Description: When an HPA object targets a
+		   ReplicaSet whose average CPU utilization is lower
+		   than the configured CPU utilization target, the
+		   ReplicaSet MUST be scaled down.
+		*/
+		framework.ConformanceIt(titleDown, func() {
 			scaleDown("rs", e2eautoscaling.KindReplicaSet, false, f)
 		})
 	})
@@ -66,7 +96,15 @@ var _ = SIGDescribe("[Feature:HPA] Horizontal pod autoscaling (scale resource: C
 	})
 
 	ginkgo.Describe("ReplicationController light", func() {
-		ginkgo.It("Should scale from 1 pod to 2 pods", func() {
+		/*
+		   Release: v1.23
+		   Testname: HPA: ReplicationController scale up.
+		   Description: When an HPA object targets a
+		   ReplicaSet whose average CPU utilization is higher
+		   than the configured CPU utilization target, the
+		   ReplicationController MUST be scaled up.
+		*/
+		framework.ConformanceIt("Should scale from 1 pod to 2 pods", func() {
 			scaleTest := &HPAScaleTest{
 				initPods:                    1,
 				totalInitialCPUUsage:        150,
@@ -78,7 +116,15 @@ var _ = SIGDescribe("[Feature:HPA] Horizontal pod autoscaling (scale resource: C
 			}
 			scaleTest.run("rc-light", e2eautoscaling.KindRC, f)
 		})
-		ginkgo.It("Should scale from 2 pods to 1 pod [Slow]", func() {
+		/*
+		   Release: v1.23
+		   Testname: HPA: ReplicationController scale down.
+		   Description: When an HPA object targets a
+		   ReplicaSet whose average CPU utilization is lower
+		   than the configured CPU utilization target, the
+		   ReplicationController MUST be scaled down.
+		*/
+		framework.ConformanceIt("Should scale from 2 pods to 1 pod [Slow]", func() {
 			scaleTest := &HPAScaleTest{
 				initPods:                    2,
 				totalInitialCPUUsage:        50,
@@ -94,11 +140,13 @@ var _ = SIGDescribe("[Feature:HPA] Horizontal pod autoscaling (scale resource: C
 
 	ginkgo.Describe("[Serial] [Slow] ReplicaSet with idle sidecar (ContainerResource use case)", func() {
 		// ContainerResource CPU autoscaling on idle sidecar
+		// TODO: promote to conformance after graduating features to Beta.
 		ginkgo.It(titleUp+" on a busy application with an idle sidecar container", func() {
 			scaleOnIdleSideCar("rs", e2eautoscaling.KindReplicaSet, false, f)
 		})
 
 		// ContainerResource CPU autoscaling on busy sidecar
+		// TODO: promote to conformance after graduating features to Beta.
 		ginkgo.It("Should not scale up on a busy sidecar with an idle application", func() {
 			doNotScaleOnBusySidecar("rs", e2eautoscaling.KindReplicaSet, true, f)
 		})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature
/area conformance
@kubernetes/sig-architecture-pr-reviews @kubernetes/sig-autoscaling-pr-reviews @kubernetes/cncf-conformance-wg

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

This change promotes 6 stable HPA E2E tests to Conformance.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Completes the HPA v2 Stable KEP test plan: https://github.com/kubernetes/enhancements/tree/74d6918d68f23bd576f4aa88768d26a5da8399a8/keps/sig-autoscaling/2702-graduate-hpa-api-to-GA#test-plan

#### Special notes for your reviewer:

Evidence of the E2E tests passing:

![image](https://user-images.githubusercontent.com/1103629/142884860-a7b35bcf-bc98-4978-91fe-8ed8cf7c0484.png)
([source](https://k8s-testgrid.appspot.com/sig-autoscaling-hpa#gce-cos-autoscaling-hpa-cpu&width=5))

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
HPA v2 is now covered by conformance tests.
- KEP: https://github.com/kubernetes/enhancements/tree/74d6918d68f23bd576f4aa88768d26a5da8399a8/keps/sig-autoscaling/2702-graduate-hpa-api-to-GA#test-plan
```
