### PR TITLE
Wait for CSIDriver cache to sync before adding volumes to attach detach controller desired state

### DIFF
--- a/pkg/controller/volume/attachdetach/attach_detach_controller.go
+++ b/pkg/controller/volume/attachdetach/attach_detach_controller.go
@@ -788,6 +788,22 @@ func (adc *attachDetachController) CSIDriverLister() storagelistersv1.CSIDriverL
 	return adc.csiDriverLister
 }
 
+// WaitForCacheSync is a helper function that waits for cache sync for CSIDriverLister
+func (adc *attachDetachController) WaitForCacheSync() error {
+	if adc.csiDriversSynced == nil {
+		klog.ErrorS(nil, "CsiDriversSynced not found on AttachDetachController")
+		return fmt.Errorf("csiDriversSynced not found on AttachDetachController")
+	}
+
+	synced := []kcache.InformerSynced{adc.csiDriversSynced}
+	if !kcache.WaitForCacheSync(wait.NeverStop, synced...) {
+		klog.InfoS("Failed to wait for cache sync for CSIDriverLister")
+		return fmt.Errorf("failed to wait for cache sync for CSIDriverLister")
+	}
+
+	return nil
+}
+
 func (adc *attachDetachController) IsAttachDetachController() bool {
 	return true
 }

--- a/pkg/volume/csi/csi_plugin.go
+++ b/pkg/volume/csi/csi_plugin.go
@@ -793,6 +793,13 @@ func (p *csiPlugin) ConstructBlockVolumeSpec(podUID types.UID, specVolName, mapP
 // skipAttach looks up CSIDriver object associated with driver name
 // to determine if driver requires attachment volume operation
 func (p *csiPlugin) skipAttach(driver string) (bool, error) {
+	adcHost, ok := p.host.(volume.AttachDetachVolumeHost)
+	if ok {
+		if err := adcHost.WaitForCacheSync(); err != nil {
+			return false, err
+		}
+	}
+
 	kletHost, ok := p.host.(volume.KubeletVolumeHost)
 	if ok {
 		if err := kletHost.WaitForCacheSync(); err != nil {

--- a/pkg/volume/plugins.go
+++ b/pkg/volume/plugins.go
@@ -357,6 +357,8 @@ type AttachDetachVolumeHost interface {
 
 	// CSIDriverLister returns the informer lister for the CSIDriver API Object
 	CSIDriverLister() storagelistersv1.CSIDriverLister
+	// WaitForCacheSync is a helper function that waits for cache sync for CSIDriverLister
+	WaitForCacheSync() error
 
 	// VolumeAttachmentLister returns the informer lister for the VolumeAttachment API Object
 	VolumeAttachmentLister() storagelistersv1.VolumeAttachmentLister

--- a/pkg/volume/testing/volume_host.go
+++ b/pkg/volume/testing/volume_host.go
@@ -290,6 +290,10 @@ func (f *fakeAttachDetachVolumeHost) CSIDriverLister() storagelistersv1.CSIDrive
 	return f.csiDriverLister
 }
 
+func (f *fakeAttachDetachVolumeHost) WaitForCacheSync() error {
+	return nil
+}
+
 func (f *fakeAttachDetachVolumeHost) VolumeAttachmentLister() storagelistersv1.VolumeAttachmentLister {
 	return f.volumeAttachmentLister
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

I strongly suspect a race between CSIDriver informer and pod informer that could result in attach-detach controller attempting to attach CSI volumes whose driver is `attachRequired: false`. These attempts do not block kubelet from mounting the volumes but generate a lot of spurious logs for as long as the PV+pod exist in attach-detach controller desired state.

I don't have proof but I have observed one case where  it probably happened. There were errors like "Warning  FailedAttachVolume  2m15s (x1461 over 2d1h)  attachdetach-controller  AttachVolume.FindAttachablePluginBySpec failed for volume "pvc-asdf" that started after kube-controller-manager restarted\* and restarting kube-controller-manager again made the errors stop.

In any case it makes sense to me that ADC should do the same check that kubelet does. 

From reading the code...

If a pod & its volumes are added to desired state by a Pod informer event
https://github.com/kubernetes/kubernetes/blob/release-1.22/pkg/controller/volume/attachdetach/attach_detach_controller.go#L202
https://github.com/kubernetes/kubernetes/blob/release-1.22/pkg/controller/volume/attachdetach/attach_detach_controller.go#L490-L507
before the CSIDriver informer has finished syncing

and the informer lister returns nil for the Get request here then
skipAttach evaluates to false
https://github.com/kubernetes/kubernetes/blob/release-1.22/pkg/volume/csi/csi_plugin.go#L800-L804
FindAttachablePluginBySpec returns the plugin
https://github.com/kubernetes/kubernetes/blob/release-1.22/pkg/volume/plugins.go#L905
https://github.com/kubernetes/kubernetes/blob/release-1.22/pkg/controller/volume/attachdetach/util/util.go#L242-L243

so the volume gets added to desired state cache. Attach detach controller then repeatedly tries and fails to attach the volume, reporting errors like "Warning  FailedAttachVolume  2m15s (x1461 over 2d1h)  attachdetach-controller  AttachVolume.FindAttachablePluginBySpec failed for volume "pvc-asdf"

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
