### PR TITLE
Delegate FSGroup CSI driver e2e: verify fsgroup is passed to CSI calls

### DIFF
--- a/test/e2e/storage/drivers/csi-test/mock/service/node.go
+++ b/test/e2e/storage/drivers/csi-test/mock/service/node.go
@@ -377,6 +377,16 @@ func (s *service) NodeGetCapabilities(
 		})
 	}
 
+	if s.config.VolumeMountGroupRequired {
+		capabilities = append(capabilities, &csi.NodeServiceCapability{
+			Type: &csi.NodeServiceCapability_Rpc{
+				Rpc: &csi.NodeServiceCapability_RPC{
+					Type: csi.NodeServiceCapability_RPC_VOLUME_MOUNT_GROUP,
+				},
+			},
+		})
+	}
+
 	return &csi.NodeGetCapabilitiesResponse{
 		Capabilities: capabilities,
 	}, nil

--- a/test/e2e/storage/drivers/csi-test/mock/service/service.go
+++ b/test/e2e/storage/drivers/csi-test/mock/service/service.go
@@ -55,6 +55,7 @@ type Config struct {
 	DriverName                 string
 	AttachLimit                int64
 	NodeExpansionRequired      bool
+	VolumeMountGroupRequired   bool
 	DisableControllerExpansion bool
 	DisableOnlineExpansion     bool
 	PermissiveTargetPath       bool


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Verify fsgroup is passed to CSI calls using mock driver tests. This is part of the testing plan for DelegateFSGroupToCSIDriver beta.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

With the addition of this test, DelegateFSGroupToCSIDriver coverage now includes:
1. The fsGroup change policy Always test verifies that fsGroup driver is applied correctly. This test can be used by any driver.
    * Does not verify fsGroup implementation, so for a driver that supports VOLUME_MOUNT_GROUP, kubelet could still be applying FSGroup instead of the driver. However, for Samba-based drivers, kubelet-applied fsgroup doesn't work. If the test passes for one of these drivers, then no other tests are needed.
1. Verifies fsGroup is passed to CSI calls correctly for drivers that support VOLUME_MOUNT_GROUP.
    * This test also doesn't verify that kubelet isn't applying fsGroup.

I'm looking into using the SMB CSI driver in CI to run (1), and this doesn't require any test changes in k/k. If this works then (2) won't be necessary. But because the test deadline is soon, if the SMB driver isn't verified in time, merging this test still improves current e2e coverage. The test can be removed in the future once the SMB test job is ready.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
KEP: https://github.com/kubernetes/enhancements/issues/2317
```

/assign @gnufied @msau42 
/sig storage
/priority important-soon
/triage accepted