### PR TITLE
Check the private SSH key existence in the node e2e tests

### DIFF
--- a/test/e2e_node/remote/ssh.go
+++ b/test/e2e_node/remote/ssh.go
@@ -103,8 +103,8 @@ func SSHNoSudo(host string, cmd ...string) (string, error) {
 
 // runSSHCommand executes the ssh or scp command, adding the flag provided --ssh-options
 func runSSHCommand(cmd string, args ...string) (string, error) {
-	if key := getPrivateSSHKey(); len(key) != 0 {
-		if _, err := os.Stat(key); err != nil {
+	if key, err := getPrivateSSHKey(); len(key) != 0 {
+		if err != nil {
 			klog.Errorf("private SSH key (%s) not found. Check if the SSH key is configured properly:, err: %v", key, err)
 			return "", fmt.Errorf("private SSH key (%s) does not exist", key)
 		}
@@ -127,14 +127,22 @@ func runSSHCommand(cmd string, args ...string) (string, error) {
 }
 
 // getPrivateSSHKey returns the path to ssh private key
-func getPrivateSSHKey() string {
+func getPrivateSSHKey() (string, error) {
 	if *sshKey != "" {
-		return *sshKey
+		if _, err := os.Stat(*sshKey); err != nil {
+			return *sshKey, err
+		}
+
+		return *sshKey, nil
 	}
 
 	if key, found := sshDefaultKeyMap[*sshEnv]; found {
-		return key
+		if _, err := os.Stat(key); err != nil {
+			return key, err
+		}
+
+		return key, nil
 	}
 
-	return ""
+	return "", nil
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/sig node
/area test
/area node-e2e 

#### What this PR does / why we need it:

When we run the Node E2E tests like `make test-e2e-node REMOTE=true`, the command implicitly assumes we have `~/.ssh/google_compute_engine`. However, if the key does not exist the test keeps showing the following outputs due to the ssh command failure.

```
...
I1123 07:57:56.132075    2379 ssh.go:111] Running the command ssh, with args: [-o UserKnownHostsFile=/dev/null -o IdentitiesOnly=yes -o CheckHostIP=no -o StrictHostKeyChecking=no -o ServerAliveInterval=30 -o LogLevel=ERROR -i nonexisting s-kitagawa@35.194.127.249 -- sudo sh -c 'systemctl list-units  --type=service  --state=running | grep -e docker -e containerd -e crio']
E1123 07:57:56.173512    2379 ssh.go:114] failed to run SSH command: out: Warning: Identity file nonexisting not accessible: No such file or directory.
s-kitagawa@35.194.127.249: Permission denied (publickey).
, err: exit status 255
I1123 07:58:16.930319    2379 ssh.go:111] Running the command ssh, with args: [-o UserKnownHostsFile=/dev/null -o IdentitiesOnly=yes -o CheckHostIP=no -o StrictHostKeyChecking=no -o ServerAliveInterval=30 -o LogLevel=ERROR -i nonexisting s-kitagawa@35.194.127.249 -- sudo sh -c 'systemctl list-units  --type=service  --state=running | grep -e docker -e containerd -e crio']
E1123 07:58:16.971397    2379 ssh.go:114] failed to run SSH command: out: Warning: Identity file nonexisting not accessible: No such file or directory.
s-kitagawa@35.194.127.249: Permission denied (publickey).
...
```

This behavior is unfriendly, especially for new contributors. Therefore I slightly changed the code so that it shows the more proper messages and exits earlier.

```
> non-static build: k8s.io/kubernetes/cmd/kubelet k8s.io/kubernetes/vendor/github.com/onsi/ginkgo/ginkgo k8s.io/kubernetes/cluster/gce/gci/mounter
^[[1;9DI1123 08:25:45.925257    9897 remote.go:107] Staging test binaries on "test-cos-beta-93-16623-39-6"
E1123 08:25:45.925439    9897 ssh.go:108] private SSH key (nonexisting) not found. Check if the SSH key is configured properly:, err: stat nonexisting: no such file or directory

>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
>                              START TEST                                >
>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
Start Test Suite on Host test-cos-beta-93-16623-39-6

Failure Finished Test Suite on Host test-cos-beta-93-16623-39-6
failed to create workspace directory "/tmp/node-e2e-20211123T082545" on host "test-cos-beta-93-16623-39-6": private SSH key (nonexisting) does not exist output: ""
<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
<                              FINISH TEST                               <
<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
``` 

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes N/A

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
