### PR TITLE
test/e2e/common/storage: enhance assertions

### DIFF
--- a/test/e2e/common/storage/configmap_volume.go
+++ b/test/e2e/common/storage/configmap_volume.go
@@ -518,17 +518,23 @@ var _ = SIGDescribe("ConfigMap", func() {
 		// Ensure data can't be changed now.
 		currentConfigMap.Data["data-5"] = "value-5"
 		_, err = f.ClientSet.CoreV1().ConfigMaps(f.Namespace.Name).Update(context.TODO(), currentConfigMap, metav1.UpdateOptions{})
-		framework.ExpectEqual(apierrors.IsInvalid(err), true)
+		if !apierrors.IsInvalid(err) {
+			framework.Failf("expected 'invalid' as error, got instead: %v", err)
+		}
 
 		// Ensure config map can't be switched from immutable to mutable.
 		currentConfigMap, err = f.ClientSet.CoreV1().ConfigMaps(f.Namespace.Name).Get(context.TODO(), name, metav1.GetOptions{})
 		framework.ExpectNoError(err, "Failed to get config map %q in namespace %q", configMap.Name, configMap.Namespace)
-		framework.ExpectEqual(*currentConfigMap.Immutable, true)
+		if !*currentConfigMap.Immutable {
+			framework.Failf("currentConfigMap %s can be switched from immutable to mutable", currentConfigMap.Name)
+		}
 
 		falseVal := false
 		currentConfigMap.Immutable = &falseVal
 		_, err = f.ClientSet.CoreV1().ConfigMaps(f.Namespace.Name).Update(context.TODO(), currentConfigMap, metav1.UpdateOptions{})
-		framework.ExpectEqual(apierrors.IsInvalid(err), true)
+		if !apierrors.IsInvalid(err) {
+			framework.Failf("expected 'invalid' as error, got instead: %v", err)
+		}
 
 		// Ensure that metadata can be changed.
 		currentConfigMap, err = f.ClientSet.CoreV1().ConfigMaps(f.Namespace.Name).Get(context.TODO(), name, metav1.GetOptions{})

--- a/test/e2e/common/storage/secrets_volume.go
+++ b/test/e2e/common/storage/secrets_volume.go
@@ -400,17 +400,23 @@ var _ = SIGDescribe("Secrets", func() {
 		// Ensure data can't be changed now.
 		currentSecret.Data["data-5"] = []byte("value-5\n")
 		_, err = f.ClientSet.CoreV1().Secrets(f.Namespace.Name).Update(context.TODO(), currentSecret, metav1.UpdateOptions{})
-		framework.ExpectEqual(apierrors.IsInvalid(err), true)
+		if !apierrors.IsInvalid(err) {
+			framework.Failf("expected 'invalid' as error, got instead: %v", err)
+		}
 
 		// Ensure secret can't be switched from immutable to mutable.
 		currentSecret, err = f.ClientSet.CoreV1().Secrets(f.Namespace.Name).Get(context.TODO(), name, metav1.GetOptions{})
 		framework.ExpectNoError(err, "Failed to get secret %q in namespace %q", secret.Name, secret.Namespace)
-		framework.ExpectEqual(*currentSecret.Immutable, true)
+		if !*currentSecret.Immutable {
+			framework.Failf("currentSecret %s can be switched from immutable to mutable", currentSecret.Name)
+		}
 
 		falseVal := false
 		currentSecret.Immutable = &falseVal
 		_, err = f.ClientSet.CoreV1().Secrets(f.Namespace.Name).Update(context.TODO(), currentSecret, metav1.UpdateOptions{})
-		framework.ExpectEqual(apierrors.IsInvalid(err), true)
+		if !apierrors.IsInvalid(err) {
+			framework.Failf("expected 'invalid' as error, got instead: %v", err)
+		}
 
 		// Ensure that metadata can be changed.
 		currentSecret, err = f.ClientSet.CoreV1().Secrets(f.Namespace.Name).Get(context.TODO(), name, metav1.GetOptions{})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
The `test/e2e` tests are full of assertions which compare a boolean against true or false, often without any additional explanation. When those assertions fail, the error message is useless for understanding what went wrong, basically just saying "expected false to be true".

All of those assertions could be replace with `if (<failure check>) framework.Failf(<informative message>)`.
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes Part of #105678

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
None
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
