### PR TITLE
apf: track initial and final seats in httplog and metrics

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/server/filters/priority-and-fairness.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/filters/priority-and-fairness.go
@@ -111,6 +111,7 @@ func WithPriorityAndFairness(
 			httplog.AddKeyValue(ctx, "apf_pl", truncateLogField(pl.Name))
 			httplog.AddKeyValue(ctx, "apf_fs", truncateLogField(fs.Name))
 			httplog.AddKeyValue(ctx, "apf_fd", truncateLogField(flowDistinguisher))
+<<<<<<< HEAD
 		}
 		// estimateWork is called, if at all, after noteFn
 		estimateWork := func() flowcontrolrequest.WorkEstimate {
@@ -123,7 +124,12 @@ func WithPriorityAndFairness(
 				return workEstimator(r, "", "")
 			}
 
-			return workEstimator(r, classification.FlowSchemaName, classification.PriorityLevelName)
+			workEstimate := workEstimator(r, classification.FlowSchemaName, classification.PriorityLevelName)
+			if klog.V(4).Enabled() {
+				httplog.AddKeyValue(ctx, "apf_iseats", workEstimate.InitialSeats)
+				httplog.AddKeyValue(ctx, "apf_fseats", workEstimate.FinalSeats)
+			}
+			return workEstimate
 		}
 
 		var served bool

--- a/staging/src/k8s.io/apiserver/pkg/server/filters/priority-and-fairness.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/filters/priority-and-fairness.go
@@ -111,7 +111,6 @@ func WithPriorityAndFairness(
 			httplog.AddKeyValue(ctx, "apf_pl", truncateLogField(pl.Name))
 			httplog.AddKeyValue(ctx, "apf_fs", truncateLogField(fs.Name))
 			httplog.AddKeyValue(ctx, "apf_fd", truncateLogField(flowDistinguisher))
-<<<<<<< HEAD
 		}
 		// estimateWork is called, if at all, after noteFn
 		estimateWork := func() flowcontrolrequest.WorkEstimate {
@@ -125,6 +124,8 @@ func WithPriorityAndFairness(
 			}
 
 			workEstimate := workEstimator(r, classification.FlowSchemaName, classification.PriorityLevelName)
+
+			fcmetrics.ObserveWorkEstimatedSeats(classification.PriorityLevelName, classification.FlowSchemaName, workEstimate.MaxSeats())
 			if klog.V(4).Enabled() {
 				httplog.AddKeyValue(ctx, "apf_iseats", workEstimate.InitialSeats)
 				httplog.AddKeyValue(ctx, "apf_fseats", workEstimate.FinalSeats)

--- a/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/request/width.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/request/width.go
@@ -30,6 +30,10 @@ const (
 	minimumSeats = 1
 
 	// the maximum number of seats a request can occupy
+	//
+	// NOTE: work_estimate_seats_samples metric uses the value of maximumSeats
+	// as the upper bound, so when we change maximumSeats we should also
+	// update the buckets of the metric.
 	maximumSeats = 10
 )
 


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:
- add initial and final seats to httplog when log level is `4`
- add a metric to track the seat samples

#### Which issue(s) this PR fixes:
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
-->
```release-note
A new Priority and Fairness metric 'apiserver_flowcontrol_work_estimate_seats_samples' has been 
added that tracks the estimated seats associated with a request
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
