### PR TITLE
apf: add metric to track dispatch with no accommodation

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/queueset/queueset.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/queueset/queueset.go
@@ -800,6 +800,7 @@ func (qs *queueSet) findDispatchQueueLocked() (*queue, *request) {
 			klogV.Infof("QS(%s): request %v %v seats %d cannot be dispatched from queue %d, waiting for currently executing requests to complete, %d requests are occupying %d seats and the limit is %d",
 				qs.qCfg.Name, oldestReqFromMinQueue.descr1, oldestReqFromMinQueue.descr2, oldestReqFromMinQueue.MaxSeats(), minQueue.index, qs.totRequestsExecuting, qs.totSeatsInUse, qs.dCfg.ConcurrencyLimit)
 		}
+		metrics.AddDispatchWithNoAccommodation(qs.qCfg.Name, oldestReqFromMinQueue.fsName)
 		return nil, nil
 	}
 	oldestReqFromMinQueue.removeFromQueueLocked()

--- a/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/metrics/metrics.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/metrics/metrics.go
@@ -324,6 +324,16 @@ var (
 		},
 		[]string{priorityLevel, flowSchema},
 	)
+	apiserverDispatchWithNoAccommodation = compbasemetrics.NewCounterVec(
+		&compbasemetrics.CounterOpts{
+			Namespace:      namespace,
+			Subsystem:      subsystem,
+			Name:           "request_dispatch_no_accommodation_total",
+			Help:           "Number of times a dispatch attempt resulted in a non accommodation due to lack of available seats",
+			StabilityLevel: compbasemetrics.ALPHA,
+		},
+		[]string{priorityLevel, flowSchema},
+	)
 
 	metrics = Registerables{
 		apiserverRejectedRequestsTotal,
@@ -343,6 +353,7 @@ var (
 		watchCountSamples,
 		apiserverEpochAdvances,
 		apiserverWorkEstimatedSeats,
+		apiserverDispatchWithNoAccommodation,
 	}.
 		Append(PriorityLevelExecutionSeatsObserverGenerator.metrics()...).
 		Append(PriorityLevelConcurrencyObserverPairGenerator.metrics()...).
@@ -427,4 +438,10 @@ func AddEpochAdvance(ctx context.Context, priorityLevel string, success bool) {
 // ObserveWorkEstimatedSeats notes a sampling of estimated seats associated with a request
 func ObserveWorkEstimatedSeats(priorityLevel, flowSchema string, seats int) {
 	apiserverWorkEstimatedSeats.WithLabelValues(priorityLevel, flowSchema).Observe(float64(seats))
+}
+
+// AddDispatchWithNoAccommodation keeps track of number of times dispatch attempt results
+// in a non accommodation due to lack of available seats.
+func AddDispatchWithNoAccommodation(priorityLevel, flowSchema string) {
+	apiserverDispatchWithNoAccommodation.WithLabelValues(priorityLevel, flowSchema).Inc()
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:
add a new metric `apiserver_flowcontrol_request_dispatch_no_accommodation_total` to track number of times a request dispatch attempt results in a no-accommodation status due to lack of available seats

#### Which issue(s) this PR fixes:
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
we have added a new Priority and Fairness metric apiserver_flowcontrol_request_dispatch_no_accommodation_total' 
to track the number of times a request dispatch attempt results in a no-accommodation status due to lack of available seats
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
