### PR TITLE
Automated cherry pick of #106412: kube-scheduler: Increase the duration to expire an assumed

### DIFF
--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -55,6 +55,9 @@ const (
 	SchedulerError = "SchedulerError"
 	// Percentage of plugin metrics to be sampled.
 	pluginMetricsSamplePercent = 10
+	// Duration the scheduler will wait before expiring an assumed pod.
+	// See issue #106361 for more details about this parameter and its value.
+	durationToExpireAssumedPod = 2 * time.Minute
 )
 
 // Scheduler watches for new unscheduled pods. It attempts to find
@@ -203,8 +206,7 @@ func New(client clientset.Interface,
 		opt(&options)
 	}
 
-	schedulerCache := internalcache.New(30*time.Second, stopEverything)
-
+	schedulerCache := internalcache.New(durationToExpireAssumedPod, stopEverything)
 	registry := frameworkplugins.NewInTreeRegistry()
 	if err := registry.Merge(options.frameworkOutOfTreeRegistry); err != nil {
 		return nil, err


### PR DESCRIPTION
Cherry pick of #106412 on release-1.21.

#106412: kube-scheduler: Increase the duration to expire an assumed

Part of #106361

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
The scheduler's assumed pods have 2min instead of 30s to receive nodeName pod updates
```