### PR TITLE
Add more info when failing to call PdhAddEnglishCounter

### DIFF
--- a/pkg/kubelet/winstats/perfcounters.go
+++ b/pkg/kubelet/winstats/perfcounters.go
@@ -57,7 +57,7 @@ func newPerfCounter(counter string) (*perfCounter, error) {
 
 	ret = win_pdh.PdhAddEnglishCounter(queryHandle, counter, 0, &counterHandle)
 	if ret != win_pdh.ERROR_SUCCESS {
-		return nil, fmt.Errorf("unable to add process counter. Error code is %x", ret)
+		return nil, fmt.Errorf("unable to add process counter: %s. Error code is %x", counter, ret)
 	}
 
 	ret = win_pdh.PdhCollectQueryData(queryHandle)


### PR DESCRIPTION
We reproduced the issue [issues/74173](https://github.com/kubernetes/kubernetes/issues/74173) in the following K8s versions:

1. 1.20.11
2. 1.21.5
3. 1.22.2

The error log is 
```
E1123 02:12:14.103886  3340 server.go:279] "kubelet running with insufficient permissions" err="error while checking admin group membership: error retrieving group ids: The user name could not be found."
I1123 02:12:14.166198  3340 server.go:440] "Kubelet version" kubeletVersion="v1.22.2"
I1123 02:12:14.166198  3340 init_windows.go:55] "Setting the priority of kubelet process" windowsPriorityClass="NORMAL_PRIORITY_CLASS"
W1123 02:12:14.166748  3340 plugins.go:132] WARNING: vsphere built-in cloud provider is now deprecated. The vSphere provider is deprecated and will be removed in a future release. Please use https://github.com/kubernetes/cloud-provider-vsphere
I1123 02:12:14.267995  3340 dynamic_cafile_content.go:155] "Starting controller" name="client-ca-bundle::C:\\var\\vcap\\jobs\\kubelet-windows\\config
kubelet-client-ca.pem"
E1123 02:12:14.480099  3340 server.go:294] "Failed to run kubelet" err="failed to run Kubelet: unable to add process counter. Error code is c0000bb8"
```

Based on the error message, we can only tell that the error message is coming from [perfcounters.go#L60](https://github.com/kubernetes/kubernetes/blob/e53cf077240c8febae2abe947cfefc1e6335057f/pkg/kubelet/winstats/perfcounters.go#L60), and the reason is "Unable to find the specified object on the computer or in the log file. ". Please see [pdh-error-codes](https://docs.microsoft.com/en-us/windows/win32/perfctrs/pdh-error-codes) and [nf-pdh-pdhaddenglishcounterw](https://docs.microsoft.com/en-us/windows/win32/api/pdh/nf-pdh-pdhaddenglishcounterw). 

But we don't know the path of the object at all from the error message, so this PR is to add the counter info in the log.