### PR TITLE
Check "fields" arg for setNestedFieldNoCopy call and report error instead of panicking if this arg is omitted

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured/helpers.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured/helpers.go
@@ -210,6 +210,10 @@ func SetNestedField(obj map[string]interface{}, value interface{}, fields ...str
 }
 
 func setNestedFieldNoCopy(obj map[string]interface{}, value interface{}, fields ...string) error {
+	if len(fields) == 0 {
+		return fmt.Errorf("fields required")
+	}
+
 	m := obj
 
 	for i, field := range fields[:len(fields)-1] {

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured/helpers_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured/helpers_test.go
@@ -165,3 +165,23 @@ func TestNestedFieldCopy(t *testing.T) {
 func TestCacheableObject(t *testing.T) {
 	runtimetesting.CacheableObjectTest(t, UnstructuredJSONScheme)
 }
+
+func TestSetNestedField(t *testing.T) {
+	obj := map[string]interface{}{
+		"x": map[string]interface{}{
+			"y": 1,
+			"a": "foo",
+		},
+	}
+	err := SetNestedField(obj, int64(2), "x", "y")
+	assert.NoError(t, err)
+	assert.Len(t, obj["x"], 2)
+	assert.Equal(t, obj["x"].(map[string]interface{})["y"], int64(2))
+	err = SetNestedField(obj, "bar", "x", "a")
+	assert.NoError(t, err)
+	assert.Len(t, obj["x"], 2)
+	assert.Equal(t, obj["x"].(map[string]interface{})["a"], "bar")
+	// omitting fields should report error instead of panicking
+	err = SetNestedField(obj, "strvalue")
+	assert.Error(t, err)
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind bug

#### What this PR does / why we need it:

`setNestedFieldNoCopy` accepts a variadic `fields` parameter(`...string`), which can be omitted when called, in such case it panics instead of reporting error. This commit checks `fields` argument length and reports error when `fields` arg is omitted.

For example, a call like the following is legal but would panic:

```
err := unstructured.SetNestedField(containers[0].(map[string]interface{}), "nginx:1.13")
```


```
E1124 10:47:48.078629    8177 runtime.go:78] Observed a panic: runtime.boundsError{x:-1, y:0, signed:true, code:0x2} (runtime error: slice bounds out of range [:-1])
goroutine 1 [running]:
k8s.io/apimachinery/pkg/util/runtime.logPanic({0x17a49e0, 0xc00003b578})
        /Users/mellon/go/pkg/mod/k8s.io/apimachinery@v0.22.4/pkg/util/runtime/runtime.go:74 +0x85
k8s.io/apimachinery/pkg/util/runtime.HandleCrash({0x0, 0x0, 0x173ff80})
        /Users/mellon/go/pkg/mod/k8s.io/apimachinery@v0.22.4/pkg/util/runtime/runtime.go:48 +0x75
panic({0x17a49e0, 0xc00003b578})
        /Users/mellon/sdk/go1.17.3/src/runtime/panic.go:1038 +0x215
k8s.io/apimachinery/pkg/apis/meta/v1/unstructured.setNestedFieldNoCopy(0x17179a0, {0x17179a0, 0x18f2080}, {0x0, 0x18, 0x4})
        /Users/mellon/go/pkg/mod/k8s.io/apimachinery@v0.22.4/pkg/apis/meta/v1/unstructured/helpers.go:215 +0x255
k8s.io/apimachinery/pkg/apis/meta/v1/unstructured.SetNestedField(0xc0002a7db0, {0x17179a0, 0x18f2080}, {0x0, 0x0, 0x0})
        /Users/mellon/go/pkg/mod/k8s.io/apimachinery@v0.22.4/pkg/apis/meta/v1/unstructured/helpers.go:209 +0x5c
main.main.func1()
        /Users/mellon/Developer/demo/k8s/client-go/unstructured/main.go:144 +0x411
```

We need to check this because `setNestedFieldNoCopy` is directly called by several exported functions: `SetNestedField`, `SetNestedStringSlice`, `SetNestedStringMap`, these functions are user-facing and if they are wrongly called we should report useful error message instead of panicking.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
