### PR TITLE
test/e2e/common/network + test/e2e/common/network/netpol: enhance assertions

### DIFF
--- a/test/e2e/network/dual_stack.go
+++ b/test/e2e/network/dual_stack.go
@@ -64,7 +64,9 @@ var _ = common.SIGDescribe("[Feature:IPv6DualStack]", func() {
 
 			framework.ExpectEqual(len(internalIPs), 2)
 			// assert 2 ips belong to different families
-			framework.ExpectEqual(netutils.IsIPv4String(internalIPs[0]) != netutils.IsIPv4String(internalIPs[1]), true)
+			if netutils.IsIPv4String(internalIPs[0]) == netutils.IsIPv4String(internalIPs[1]) {
+				framework.Failf("both internalIPs %s and %s belong to the same families", internalIPs[0], internalIPs[1])
+			}
 		}
 	})
 
@@ -97,7 +99,9 @@ var _ = common.SIGDescribe("[Feature:IPv6DualStack]", func() {
 		// validate first ip in PodIPs is same as PodIP
 		framework.ExpectEqual(p.Status.PodIP, p.Status.PodIPs[0].IP)
 		// assert 2 pod ips belong to different families
-		framework.ExpectEqual(netutils.IsIPv4String(p.Status.PodIPs[0].IP) != netutils.IsIPv4String(p.Status.PodIPs[1].IP), true)
+		if netutils.IsIPv4String(p.Status.PodIPs[0].IP) == netutils.IsIPv4String(p.Status.PodIPs[1].IP) {
+			framework.Failf("both internalIPs %s and %s belong to the same families", p.Status.PodIPs[0].IP, p.Status.PodIPs[1].IP)
+		}
 
 		ginkgo.By("deleting the pod")
 		err := podClient.Delete(context.TODO(), pod.Name, *metav1.NewDeleteOptions(30))

--- a/test/e2e/network/endpointslice.go
+++ b/test/e2e/network/endpointslice.go
@@ -380,7 +380,9 @@ var _ = common.SIGDescribe("EndpointSlice", func() {
 					}
 				}
 			}
-			framework.ExpectEqual(found, true, fmt.Sprintf("expected discovery API group/version, got %#v", discoveryGroups.Groups))
+			if !found {
+				framework.Failf("expected discovery API group/version, got %#v", discoveryGroups.Groups)
+			}
 		}
 
 		ginkgo.By("getting /apis/discovery.k8s.io")
@@ -395,7 +397,9 @@ var _ = common.SIGDescribe("EndpointSlice", func() {
 					break
 				}
 			}
-			framework.ExpectEqual(found, true, fmt.Sprintf("expected discovery API version, got %#v", group.Versions))
+			if !found {
+				framework.Failf("expected discovery API version, got %#v", group.Versions)
+			}
 		}
 
 		ginkgo.By("getting /apis/discovery.k8s.io" + epsVersion)
@@ -409,7 +413,9 @@ var _ = common.SIGDescribe("EndpointSlice", func() {
 					foundEPS = true
 				}
 			}
-			framework.ExpectEqual(foundEPS, true, fmt.Sprintf("expected endpointslices, got %#v", resources.APIResources))
+			if !foundEPS {
+				framework.Failf("expected endpointslices, got %#v", resources.APIResources)
+			}
 		}
 
 		// EndpointSlice resource create/read/update/watch verbs
@@ -471,10 +477,14 @@ var _ = common.SIGDescribe("EndpointSlice", func() {
 		for sawAnnotations := false; !sawAnnotations; {
 			select {
 			case evt, ok := <-epsWatch.ResultChan():
-				framework.ExpectEqual(ok, true, "watch channel should not close")
+				if !ok {
+					framework.Fail("watch channel should not close")
+				}
 				framework.ExpectEqual(evt.Type, watch.Modified)
 				watchedEPS, isEPS := evt.Object.(*discoveryv1.EndpointSlice)
-				framework.ExpectEqual(isEPS, true, fmt.Sprintf("expected EndpointSlice, got %T", evt.Object))
+				if !isEPS {
+					framework.Failf("expected EndpointSlice, got %T", evt.Object)
+				}
 				if watchedEPS.Annotations["patched"] == "true" {
 					framework.Logf("saw patched and updated annotations")
 					sawAnnotations = true
@@ -492,7 +502,9 @@ var _ = common.SIGDescribe("EndpointSlice", func() {
 		err = epsClient.Delete(context.TODO(), createdEPS.Name, metav1.DeleteOptions{})
 		framework.ExpectNoError(err)
 		_, err = epsClient.Get(context.TODO(), createdEPS.Name, metav1.GetOptions{})
-		framework.ExpectEqual(apierrors.IsNotFound(err), true, fmt.Sprintf("expected 404, got %v", err))
+		if !apierrors.IsNotFound(err) {
+			framework.Failf("expected 404, got %v", err)
+		}
 		epsList, err = epsClient.List(context.TODO(), metav1.ListOptions{LabelSelector: "special-label=" + f.UniqueName})
 		framework.ExpectNoError(err)
 		framework.ExpectEqual(len(epsList.Items), 2, "filtered list should have 2 items")

--- a/test/e2e/network/loadbalancer.go
+++ b/test/e2e/network/loadbalancer.go
@@ -607,7 +607,9 @@ var _ = common.SIGDescribe("LoadBalancers", func() {
 		lbIngress := &svc.Status.LoadBalancer.Ingress[0]
 		svcPort := int(svc.Spec.Ports[0].Port)
 		// should have an internal IP.
-		framework.ExpectEqual(isInternalEndpoint(lbIngress), true)
+		if !isInternalEndpoint(lbIngress) {
+			framework.Failf("lbIngress %v doesn't have an internal IP", lbIngress)
+		}
 
 		// ILBs are not accessible from the test orchestrator, so it's necessary to use
 		//  a pod to test the service.

--- a/test/e2e/network/netpol/network_legacy.go
+++ b/test/e2e/network/netpol/network_legacy.go
@@ -2246,7 +2246,9 @@ var _ = common.SIGDescribe("NetworkPolicy API", func() {
 					}
 				}
 			}
-			framework.ExpectEqual(found, true, fmt.Sprintf("expected networking API group/version, got %#v", discoveryGroups.Groups))
+			if !found {
+				framework.Failf("expected networking API group/version, got %#v", discoveryGroups.Groups)
+			}
 		}
 		ginkgo.By("getting /apis/networking.k8s.io")
 		{
@@ -2260,7 +2262,9 @@ var _ = common.SIGDescribe("NetworkPolicy API", func() {
 					break
 				}
 			}
-			framework.ExpectEqual(found, true, fmt.Sprintf("expected networking API version, got %#v", group.Versions))
+			if !found {
+				framework.Failf("expected networking API version, got %#v", group.Versions)
+			}
 		}
 		ginkgo.By("getting /apis/networking.k8s.io" + npVersion)
 		{
@@ -2273,7 +2277,9 @@ var _ = common.SIGDescribe("NetworkPolicy API", func() {
 					foundNetPol = true
 				}
 			}
-			framework.ExpectEqual(foundNetPol, true, fmt.Sprintf("expected networkpolicies, got %#v", resources.APIResources))
+			if !foundNetPol {
+				framework.Failf("expected networkpolicies, got %#v", resources.APIResources)
+			}
 		}
 		// NetPol resource create/read/update/watch verbs
 		ginkgo.By("creating")
@@ -2326,10 +2332,14 @@ var _ = common.SIGDescribe("NetworkPolicy API", func() {
 		for sawAnnotations := false; !sawAnnotations; {
 			select {
 			case evt, ok := <-npWatch.ResultChan():
-				framework.ExpectEqual(ok, true, "watch channel should not close")
+				if !ok {
+					framework.Fail("watch channel should not close")
+				}
 				framework.ExpectEqual(evt.Type, watch.Modified)
 				watchedNetPol, isNetPol := evt.Object.(*networkingv1.NetworkPolicy)
-				framework.ExpectEqual(isNetPol, true, fmt.Sprintf("expected NetworkPolicy, got %T", evt.Object))
+				if !isNetPol {
+					framework.Failf("expected NetworkPolicy, got %T", evt.Object)
+				}
 				if watchedNetPol.Annotations["patched"] == "true" && watchedNetPol.Annotations["updated"] == "true" {
 					framework.Logf("saw patched and updated annotations")
 					sawAnnotations = true
@@ -2346,7 +2356,9 @@ var _ = common.SIGDescribe("NetworkPolicy API", func() {
 		err = npClient.Delete(context.TODO(), createdNetPol.Name, metav1.DeleteOptions{})
 		framework.ExpectNoError(err)
 		_, err = npClient.Get(context.TODO(), createdNetPol.Name, metav1.GetOptions{})
-		framework.ExpectEqual(apierrors.IsNotFound(err), true, fmt.Sprintf("expected 404, got %#v", err))
+		if !apierrors.IsNotFound(err) {
+			framework.Failf("expected 404, got %#v", err)
+		}
 		nps, err = npClient.List(context.TODO(), metav1.ListOptions{LabelSelector: "special-label=" + f.UniqueName})
 		framework.ExpectNoError(err)
 		framework.ExpectEqual(len(nps.Items), 2, "filtered list should have 2 items")

--- a/test/e2e/network/netpol/network_policy_api.go
+++ b/test/e2e/network/netpol/network_policy_api.go
@@ -18,7 +18,6 @@ package netpol
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -85,7 +84,9 @@ var _ = common.SIGDescribe("Netpol API", func() {
 					}
 				}
 			}
-			framework.ExpectEqual(found, true, fmt.Sprintf("expected networking API group/version, got %#v", discoveryGroups.Groups))
+			if !found {
+				framework.Failf("expected networking API group/version, got %#v", discoveryGroups.Groups)
+			}
 		}
 		ginkgo.By("getting /apis/networking.k8s.io")
 		{
@@ -99,7 +100,9 @@ var _ = common.SIGDescribe("Netpol API", func() {
 					break
 				}
 			}
-			framework.ExpectEqual(found, true, fmt.Sprintf("expected networking API version, got %#v", group.Versions))
+			if !found {
+				framework.Failf("expected networking API version, got %#v", group.Versions)
+			}
 		}
 		ginkgo.By("getting /apis/networking.k8s.io" + npVersion)
 		{
@@ -112,7 +115,9 @@ var _ = common.SIGDescribe("Netpol API", func() {
 					foundNetPol = true
 				}
 			}
-			framework.ExpectEqual(foundNetPol, true, fmt.Sprintf("expected networkpolicies, got %#v", resources.APIResources))
+			if !foundNetPol {
+				framework.Failf("expected networkpolicies, got %#v", resources.APIResources)
+			}
 		}
 		// NetPol resource create/read/update/watch verbs
 		ginkgo.By("creating")
@@ -165,10 +170,14 @@ var _ = common.SIGDescribe("Netpol API", func() {
 		for sawAnnotations := false; !sawAnnotations; {
 			select {
 			case evt, ok := <-npWatch.ResultChan():
-				framework.ExpectEqual(ok, true, "watch channel should not close")
+				if !ok {
+					framework.Fail("watch channel should not close")
+				}
 				framework.ExpectEqual(evt.Type, watch.Modified)
 				watchedNetPol, isNetPol := evt.Object.(*networkingv1.NetworkPolicy)
-				framework.ExpectEqual(isNetPol, true, fmt.Sprintf("expected NetworkPolicy, got %T", evt.Object))
+				if !isNetPol {
+					framework.Failf("expected NetworkPolicy, got %T", evt.Object)
+				}
 				if watchedNetPol.Annotations["patched"] == "true" && watchedNetPol.Annotations["updated"] == "true" {
 					framework.Logf("saw patched and updated annotations")
 					sawAnnotations = true
@@ -185,7 +194,9 @@ var _ = common.SIGDescribe("Netpol API", func() {
 		err = npClient.Delete(context.TODO(), createdNetPol.Name, metav1.DeleteOptions{})
 		framework.ExpectNoError(err)
 		_, err = npClient.Get(context.TODO(), createdNetPol.Name, metav1.GetOptions{})
-		framework.ExpectEqual(apierrors.IsNotFound(err), true, fmt.Sprintf("expected 404, got %#v", err))
+		if !apierrors.IsNotFound(err) {
+			framework.Failf("expected 404, got %#v", err)
+		}
 		nps, err = npClient.List(context.TODO(), metav1.ListOptions{LabelSelector: "special-label=" + f.UniqueName})
 		framework.ExpectNoError(err)
 		framework.ExpectEqual(len(nps.Items), 2, "filtered list should have 2 items")

--- a/test/e2e/network/service.go
+++ b/test/e2e/network/service.go
@@ -2321,7 +2321,9 @@ var _ = common.SIGDescribe("Services", func() {
 			}
 		}
 
-		framework.ExpectEqual(foundSvc, true, "could not find service 'kubernetes' in service list in all namespaces")
+		if !foundSvc {
+			framework.Fail("could not find service 'kubernetes' in service list in all namespaces")
+		}
 	})
 
 	/*
@@ -2395,7 +2397,9 @@ var _ = common.SIGDescribe("Services", func() {
 				break
 			}
 		}
-		framework.ExpectEqual(eventFound, true, "unable to find Endpoint Service in list of Endpoints")
+		if !eventFound {
+			framework.Fail("unable to find Endpoint Service in list of Endpoints")
+		}
 
 		ginkgo.By("updating the Endpoint")
 		foundEndpoint.ObjectMeta.Labels["test-service"] = "updated"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
The `test/e2e` tests are full of assertions which compare a boolean against true or false, often without any additional explanation. When those assertions fail, the error message is useless for understanding what went wrong, basically just saying "expected false to be true".

All of those assertions could be replace with `if (<failure check>) framework.Failf(<informative message>)`.
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes Part of #105678

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
None
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
