### PR TITLE
kube-proxy delete stale entries for UDP and SCTP

### DIFF
--- a/pkg/proxy/endpoints_test.go
+++ b/pkg/proxy/endpoints_test.go
@@ -493,6 +493,17 @@ func TestUpdateEndpointsMap(t *testing.T) {
 			}},
 		}}
 	}
+	unnamedPortSCTP := func(ept *v1.Endpoints) {
+		ept.Subsets = []v1.EndpointSubset{{
+			Addresses: []v1.EndpointAddress{{
+				IP: "1.1.1.1",
+			}},
+			Ports: []v1.EndpointPort{{
+				Port:     11,
+				Protocol: v1.ProtocolSCTP,
+			}},
+		}}
+	}
 	unnamedPortLocal := func(ept *v1.Endpoints) {
 		ept.Subsets = []v1.EndpointSubset{{
 			Addresses: []v1.EndpointAddress{{
@@ -1309,6 +1320,25 @@ func TestUpdateEndpointsMap(t *testing.T) {
 		expectedStaleEndpoints: []ServiceEndpoint{},
 		expectedStaleServiceNames: map[ServicePortName]bool{
 			makeServicePortName("ns1", "ep1", "", v1.ProtocolUDP): true,
+		},
+		expectedHealthchecks: map[types.NamespacedName]int{},
+	}, {
+		name: "change from 0 endpoint address to 1 unnamed port SCTP",
+		previousEndpoints: []*v1.Endpoints{
+			makeTestEndpoints("ns1", "ep1", emptyEndpoint),
+		},
+		currentEndpoints: []*v1.Endpoints{
+			makeTestEndpoints("ns1", "ep1", unnamedPortSCTP),
+		},
+		oldEndpoints: map[ServicePortName][]*BaseEndpointInfo{},
+		expectedResult: map[ServicePortName][]*BaseEndpointInfo{
+			makeServicePortName("ns1", "ep1", "", v1.ProtocolSCTP): {
+				{Endpoint: "1.1.1.1:11", IsLocal: false, Ready: true, Serving: true, Terminating: false},
+			},
+		},
+		expectedStaleEndpoints: []ServiceEndpoint{},
+		expectedStaleServiceNames: map[ServicePortName]bool{
+			makeServicePortName("ns1", "ep1", "", v1.ProtocolSCTP): true,
 		},
 		expectedHealthchecks: map[types.NamespacedName]int{},
 	},

--- a/pkg/proxy/ipvs/proxier_test.go
+++ b/pkg/proxy/ipvs/proxier_test.go
@@ -2509,9 +2509,9 @@ func TestBuildServiceMapAddRemove(t *testing.T) {
 		}
 	}
 
-	if len(result.UDPStaleClusterIP) != 0 {
+	if len(result.StaleClusterIPProtocol) != 0 {
 		// Services only added, so nothing stale yet
-		t.Errorf("expected stale UDP services length 0, got %d", len(result.UDPStaleClusterIP))
+		t.Errorf("expected stale UDP services length 0, got %d", len(result.StaleClusterIPProtocol))
 	}
 
 	// Remove some stuff
@@ -2540,11 +2540,11 @@ func TestBuildServiceMapAddRemove(t *testing.T) {
 	// from the three deleted services here, we still have the ClusterIP for
 	// the not-deleted service, because one of it's ServicePorts was deleted.
 	expectedStaleUDPServices := []string{"172.16.55.10", "172.16.55.4", "172.16.55.11", "172.16.55.12"}
-	if len(result.UDPStaleClusterIP) != len(expectedStaleUDPServices) {
-		t.Errorf("expected stale UDP services length %d, got %v", len(expectedStaleUDPServices), result.UDPStaleClusterIP.List())
+	if len(result.StaleClusterIPProtocol) != len(expectedStaleUDPServices) {
+		t.Errorf("expected stale UDP services length %d, got %v", len(expectedStaleUDPServices), result.StaleClusterIPProtocol)
 	}
 	for _, ip := range expectedStaleUDPServices {
-		if !result.UDPStaleClusterIP.Has(ip) {
+		if _, ok := result.StaleClusterIPProtocol[ip]; !ok {
 			t.Errorf("expected stale UDP service service %s", ip)
 		}
 	}
@@ -2584,8 +2584,8 @@ func TestBuildServiceMapServiceHeadless(t *testing.T) {
 		t.Errorf("expected healthcheck ports length 0, got %d", len(result.HCServiceNodePorts))
 	}
 
-	if len(result.UDPStaleClusterIP) != 0 {
-		t.Errorf("expected stale UDP services length 0, got %d", len(result.UDPStaleClusterIP))
+	if len(result.StaleClusterIPProtocol) != 0 {
+		t.Errorf("expected stale UDP services length 0, got %d", len(result.StaleClusterIPProtocol))
 	}
 }
 
@@ -2612,8 +2612,8 @@ func TestBuildServiceMapServiceTypeExternalName(t *testing.T) {
 	if len(result.HCServiceNodePorts) != 0 {
 		t.Errorf("expected healthcheck ports length 0, got %v", result.HCServiceNodePorts)
 	}
-	if len(result.UDPStaleClusterIP) != 0 {
-		t.Errorf("expected stale UDP services length 0, got %v", result.UDPStaleClusterIP)
+	if len(result.StaleClusterIPProtocol) != 0 {
+		t.Errorf("expected stale UDP services length 0, got %v", result.StaleClusterIPProtocol)
 	}
 }
 
@@ -2653,9 +2653,9 @@ func TestBuildServiceMapServiceUpdate(t *testing.T) {
 	if len(result.HCServiceNodePorts) != 0 {
 		t.Errorf("expected healthcheck ports length 0, got %v", result.HCServiceNodePorts)
 	}
-	if len(result.UDPStaleClusterIP) != 0 {
+	if len(result.StaleClusterIPProtocol) != 0 {
 		// Services only added, so nothing stale yet
-		t.Errorf("expected stale UDP services length 0, got %d", len(result.UDPStaleClusterIP))
+		t.Errorf("expected stale UDP services length 0, got %d", len(result.StaleClusterIPProtocol))
 	}
 
 	// Change service to load-balancer
@@ -2667,8 +2667,8 @@ func TestBuildServiceMapServiceUpdate(t *testing.T) {
 	if len(result.HCServiceNodePorts) != 1 {
 		t.Errorf("expected healthcheck ports length 1, got %v", result.HCServiceNodePorts)
 	}
-	if len(result.UDPStaleClusterIP) != 0 {
-		t.Errorf("expected stale UDP services length 0, got %v", result.UDPStaleClusterIP.List())
+	if len(result.StaleClusterIPProtocol) != 0 {
+		t.Errorf("expected stale UDP services length 0, got %v", result.StaleClusterIPProtocol)
 	}
 
 	// No change; make sure the service map stays the same and there are
@@ -2681,8 +2681,8 @@ func TestBuildServiceMapServiceUpdate(t *testing.T) {
 	if len(result.HCServiceNodePorts) != 1 {
 		t.Errorf("expected healthcheck ports length 1, got %v", result.HCServiceNodePorts)
 	}
-	if len(result.UDPStaleClusterIP) != 0 {
-		t.Errorf("expected stale UDP services length 0, got %v", result.UDPStaleClusterIP.List())
+	if len(result.StaleClusterIPProtocol) != 0 {
+		t.Errorf("expected stale UDP services length 0, got %v", result.StaleClusterIPProtocol)
 	}
 
 	// And back to ClusterIP
@@ -2694,9 +2694,9 @@ func TestBuildServiceMapServiceUpdate(t *testing.T) {
 	if len(result.HCServiceNodePorts) != 0 {
 		t.Errorf("expected healthcheck ports length 0, got %v", result.HCServiceNodePorts)
 	}
-	if len(result.UDPStaleClusterIP) != 0 {
+	if len(result.StaleClusterIPProtocol) != 0 {
 		// Services only added, so nothing stale yet
-		t.Errorf("expected stale UDP services length 0, got %d", len(result.UDPStaleClusterIP))
+		t.Errorf("expected stale UDP services length 0, got %d", len(result.StaleClusterIPProtocol))
 	}
 }
 

--- a/pkg/proxy/service_test.go
+++ b/pkg/proxy/service_test.go
@@ -574,8 +574,8 @@ func TestServiceMapUpdateHeadless(t *testing.T) {
 		t.Errorf("expected healthcheck ports length 0, got %d", len(result.HCServiceNodePorts))
 	}
 
-	if len(result.UDPStaleClusterIP) != 0 {
-		t.Errorf("expected stale UDP services length 0, got %d", len(result.UDPStaleClusterIP))
+	if len(result.StaleClusterIPProtocol) != 0 {
+		t.Errorf("expected stale UDP services length 0, got %d", len(result.StaleClusterIPProtocol))
 	}
 }
 
@@ -599,8 +599,8 @@ func TestUpdateServiceTypeExternalName(t *testing.T) {
 	if len(result.HCServiceNodePorts) != 0 {
 		t.Errorf("expected healthcheck ports length 0, got %v", result.HCServiceNodePorts)
 	}
-	if len(result.UDPStaleClusterIP) != 0 {
-		t.Errorf("expected stale UDP services length 0, got %v", result.UDPStaleClusterIP)
+	if len(result.StaleClusterIPProtocol) != 0 {
+		t.Errorf("expected stale UDP services length 0, got %v", result.StaleClusterIPProtocol)
 	}
 }
 
@@ -617,7 +617,7 @@ func TestBuildServiceMapAddRemove(t *testing.T) {
 		makeTestService("ns2", "node-port", func(svc *v1.Service) {
 			svc.Spec.Type = v1.ServiceTypeNodePort
 			svc.Spec.ClusterIP = "172.16.55.10"
-			svc.Spec.Ports = addTestPort(svc.Spec.Ports, "port1", "UDP", 345, 678, 0)
+			svc.Spec.Ports = addTestPort(svc.Spec.Ports, "port1", "SCTP", 345, 678, 0)
 			svc.Spec.Ports = addTestPort(svc.Spec.Ports, "port2", "TCP", 344, 677, 0)
 		}),
 		makeTestService("ns1", "load-balancer", func(svc *v1.Service) {
@@ -666,9 +666,9 @@ func TestBuildServiceMapAddRemove(t *testing.T) {
 		}
 	}
 
-	if len(result.UDPStaleClusterIP) != 0 {
+	if len(result.StaleClusterIPProtocol) != 0 {
 		// Services only added, so nothing stale yet
-		t.Errorf("expected stale UDP services length 0, got %d", len(result.UDPStaleClusterIP))
+		t.Errorf("expected stale UDP services length 0, got %d", len(result.StaleClusterIPProtocol))
 	}
 
 	// Remove some stuff
@@ -697,11 +697,11 @@ func TestBuildServiceMapAddRemove(t *testing.T) {
 	// from the three deleted services here, we still have the ClusterIP for
 	// the not-deleted service, because one of it's ServicePorts was deleted.
 	expectedStaleUDPServices := []string{"172.16.55.10", "172.16.55.4", "172.16.55.11", "172.16.55.12"}
-	if len(result.UDPStaleClusterIP) != len(expectedStaleUDPServices) {
-		t.Errorf("expected stale UDP services length %d, got %v", len(expectedStaleUDPServices), result.UDPStaleClusterIP.UnsortedList())
+	if len(result.StaleClusterIPProtocol) != len(expectedStaleUDPServices) {
+		t.Errorf("expected stale UDP services length %d, got %v", len(expectedStaleUDPServices), result.StaleClusterIPProtocol)
 	}
 	for _, ip := range expectedStaleUDPServices {
-		if !result.UDPStaleClusterIP.Has(ip) {
+		if _, ok := result.StaleClusterIPProtocol[ip]; !ok {
 			t.Errorf("expected stale UDP service service %s", ip)
 		}
 	}
@@ -740,9 +740,9 @@ func TestBuildServiceMapServiceUpdate(t *testing.T) {
 	if len(result.HCServiceNodePorts) != 0 {
 		t.Errorf("expected healthcheck ports length 0, got %v", result.HCServiceNodePorts)
 	}
-	if len(result.UDPStaleClusterIP) != 0 {
+	if len(result.StaleClusterIPProtocol) != 0 {
 		// Services only added, so nothing stale yet
-		t.Errorf("expected stale UDP services length 0, got %d", len(result.UDPStaleClusterIP))
+		t.Errorf("expected stale UDP services length 0, got %d", len(result.StaleClusterIPProtocol))
 	}
 
 	// Change service to load-balancer
@@ -754,8 +754,8 @@ func TestBuildServiceMapServiceUpdate(t *testing.T) {
 	if len(result.HCServiceNodePorts) != 1 {
 		t.Errorf("expected healthcheck ports length 1, got %v", result.HCServiceNodePorts)
 	}
-	if len(result.UDPStaleClusterIP) != 0 {
-		t.Errorf("expected stale UDP services length 0, got %v", result.UDPStaleClusterIP.UnsortedList())
+	if len(result.StaleClusterIPProtocol) != 0 {
+		t.Errorf("expected stale UDP services length 0, got %v", result.StaleClusterIPProtocol)
 	}
 
 	// No change; make sure the service map stays the same and there are
@@ -768,8 +768,8 @@ func TestBuildServiceMapServiceUpdate(t *testing.T) {
 	if len(result.HCServiceNodePorts) != 1 {
 		t.Errorf("expected healthcheck ports length 1, got %v", result.HCServiceNodePorts)
 	}
-	if len(result.UDPStaleClusterIP) != 0 {
-		t.Errorf("expected stale UDP services length 0, got %v", result.UDPStaleClusterIP.UnsortedList())
+	if len(result.StaleClusterIPProtocol) != 0 {
+		t.Errorf("expected stale UDP services length 0, got %v", result.StaleClusterIPProtocol)
 	}
 
 	// And back to ClusterIP
@@ -781,8 +781,8 @@ func TestBuildServiceMapServiceUpdate(t *testing.T) {
 	if len(result.HCServiceNodePorts) != 0 {
 		t.Errorf("expected healthcheck ports length 0, got %v", result.HCServiceNodePorts)
 	}
-	if len(result.UDPStaleClusterIP) != 0 {
+	if len(result.StaleClusterIPProtocol) != 0 {
 		// Services only added, so nothing stale yet
-		t.Errorf("expected stale UDP services length 0, got %d", len(result.UDPStaleClusterIP))
+		t.Errorf("expected stale UDP services length 0, got %d", len(result.StaleClusterIPProtocol))
 	}
 }


### PR DESCRIPTION
Previous code was considering only stale entries for UDP, but SCTP
is another supported and ~stateless~ connection oriented protocol that can leave stale
conntrack entries that blackhole connections.

Refactor old code to track protocols on the stale detection logic
and use same logic for SCTP and UDP.

/kind bug
Fixes #106651

```release-note
kube-proxy clear stale SCTP entries that may block connections.
```
