### PR TITLE
Fix logging resource-scoped watch requests as GET requests.

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/endpoints/metrics/metrics_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/metrics/metrics_test.go
@@ -49,6 +49,7 @@ func TestCleanVerb(t *testing.T) {
 			desc:        "LIST should be transformed to WATCH if we have the right query param on the request",
 			initialVerb: "LIST",
 			request: &http.Request{
+				Method: "GET",
 				URL: &url.URL{
 					RawQuery: "watch=true",
 				},
@@ -59,6 +60,7 @@ func TestCleanVerb(t *testing.T) {
 			desc:        "LIST isn't transformed to WATCH if we have query params that do not include watch",
 			initialVerb: "LIST",
 			request: &http.Request{
+				Method: "GET",
 				URL: &url.URL{
 					RawQuery: "blah=asdf&something=else",
 				},
@@ -66,20 +68,25 @@ func TestCleanVerb(t *testing.T) {
 			expectedVerb: "LIST",
 		},
 		{
-			desc:        "GET isn't be transformed to WATCH if we have the right query param on the request",
+			// The above may seem counter-intuitive, but it actually is needed for cases like
+			// watching a single item, e.g.:
+			//  /api/v1/namespaces/foo/pods/bar?fieldSelector=metadata.name=baz&watch=true
+			desc:        "GET is transformed to WATCH if we have the right query param on the request",
 			initialVerb: "GET",
 			request: &http.Request{
+				Method: "GET",
 				URL: &url.URL{
 					RawQuery: "watch=true",
 				},
 			},
-			expectedVerb: "GET",
+			expectedVerb: "WATCH",
 		},
 		{
 			desc:          "LIST is transformed to WATCH for the old pattern watch",
 			initialVerb:   "LIST",
 			suggestedVerb: "WATCH",
 			request: &http.Request{
+				Method: "GET",
 				URL: &url.URL{
 					RawQuery: "/api/v1/watch/pods",
 				},
@@ -91,6 +98,7 @@ func TestCleanVerb(t *testing.T) {
 			initialVerb:   "LIST",
 			suggestedVerb: "WATCHLIST",
 			request: &http.Request{
+				Method: "GET",
 				URL: &url.URL{
 					RawQuery: "/api/v1/watch/pods",
 				},


### PR DESCRIPTION
```release-note
NONE
```

/kind bug
/sig api-machinery
/priority important-soon

/assign @logicalhan 