### PR TITLE
[WIP] exec liveness probes must restart pods if the exec command fails

### DIFF
--- a/pkg/probe/exec/exec.go
+++ b/pkg/probe/exec/exec.go
@@ -59,7 +59,7 @@ func (pr execProber) Probe(e exec.Cmd) (probe.Result, string, error) {
 	}
 	data := dataBuffer.Bytes()
 
-	klog.V(4).Infof("Exec probe response: %q", string(data))
+	klog.V(4).Infof("Exec probe response: %q error: %v", string(data), err)
 	if err != nil {
 		exit, ok := err.(exec.ExitError)
 		if ok {

--- a/test/e2e/common/node/container_probe.go
+++ b/test/e2e/common/node/container_probe.go
@@ -233,6 +233,23 @@ var _ = SIGDescribe("Probing container", func() {
 
 	/*
 		Release: v1.20
+		Testname: Pod liveness probe, container exec invalid, restart
+		Description: A Pod is created with liveness probe with a Exec action that is invalid on the Pod. The liveness probe MUST restart the Pod.
+	*/
+	ginkgo.It("should be restarted with an invalid exec liveness probe with [NodeConformance]", func() {
+		cmd := []string{"/bin/sh", "-c", "sleep 600"}
+		livenessProbe := &v1.Probe{
+			ProbeHandler:        execHandler([]string{"invalid"}),
+			InitialDelaySeconds: 15,
+			TimeoutSeconds:      1,
+			FailureThreshold:    1,
+		}
+		pod := busyBoxPodSpec(nil, livenessProbe, cmd)
+		RunLivenessTest(f, pod, 1, defaultObservationTimeout)
+	})
+
+	/*
+		Release: v1.20
 		Testname: Pod readiness probe, container exec timeout, not ready
 		Description: A Pod is created with readiness probe with a Exec action on the Pod. If the readiness probe call does not return within the timeout specified, readiness probe MUST not be Ready.
 	*/


### PR DESCRIPTION
#### What type of PR is this?


/kind bug

#### What this PR does / why we need it:

If an exec liveness probe is not able to be executed, it must be considered as a failure and restart the container

#### Which issue(s) this PR fixes:

Fixes #106682

#### Special notes for your reviewer:


```release-note
exec liveness probes that weren't able to be executed on the containers, were not influencing the pod status.
```
