### PR TITLE
Fixed skipping valid volume plugins when another plugin has an error

### DIFF
--- a/pkg/volume/plugins.go
+++ b/pkg/volume/plugins.go
@@ -132,7 +132,7 @@ type NodeResizeOptions struct {
 type DynamicPluginProber interface {
 	Init() error
 
-	// If an error occurs, events are undefined.
+	// aggregates events for successful drivers and errors for failed drivers
 	Probe() (events []ProbeEvent, err error)
 }
 

--- a/pkg/volume/plugins.go
+++ b/pkg/volume/plugins.go
@@ -747,6 +747,10 @@ func (pm *VolumePluginMgr) logDeprecation(plugin string) {
 func (pm *VolumePluginMgr) refreshProbedPlugins() {
 	events, err := pm.prober.Probe()
 
+	if err != nil {
+		klog.ErrorS(err, "Error dynamically probing plugins")
+	}
+
 	// because the probe function can return a list of valid plugins
 	// even when an error is present we still must add the plugins
 	// or they will be skipped because each event only fires once
@@ -765,11 +769,6 @@ func (pm *VolumePluginMgr) refreshProbedPlugins() {
 			klog.ErrorS(nil, "Unknown Operation on PluginName.",
 				"pluginName", event.Plugin.GetPluginName())
 		}
-	}
-	
-	if err != nil {
-		klog.ErrorS(err, "Error dynamically probing plugins")
-		return
 	}
 }
 

--- a/pkg/volume/plugins.go
+++ b/pkg/volume/plugins.go
@@ -746,11 +746,10 @@ func (pm *VolumePluginMgr) logDeprecation(plugin string) {
 // If it is, initialize all probed plugins and replace the cache with them.
 func (pm *VolumePluginMgr) refreshProbedPlugins() {
 	events, err := pm.prober.Probe()
-	if err != nil {
-		klog.ErrorS(err, "Error dynamically probing plugins")
-		return // Use cached plugins upon failure.
-	}
 
+	// because the probe function can return a list of valid plugins
+	// even when an error is present we still must add the plugins
+	// or they will be skipped because each event only fires once
 	for _, event := range events {
 		if event.Op == ProbeAddOrUpdate {
 			if err := pm.initProbedPlugin(event.Plugin); err != nil {
@@ -766,6 +765,11 @@ func (pm *VolumePluginMgr) refreshProbedPlugins() {
 			klog.ErrorS(nil, "Unknown Operation on PluginName.",
 				"pluginName", event.Plugin.GetPluginName())
 		}
+	}
+	
+	if err != nil {
+		klog.ErrorS(err, "Error dynamically probing plugins")
+		return
 	}
 }
 


### PR DESCRIPTION
Fixed issue in plugin.go where valid plugin events would be skipped if any plugin had an error. This meant that valid plugins would never be installed if another was in an error state as the events fired only once.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This PR allows valid flex volume plugins to be added even if another plugin is missing or invalid. This is needed because often time pods will mount and add their own flex volume plugins but before they add the file in their init container they will create an empty directory for the plugin via a volume on the node. This directory will be picked up by the flex volume probe as a watch event, but will create an error as no file exists in the folder yet. If this happens while another valid file exists and is ready to be added that valid plugin will be forever skipped until either another event fires (folder date change) or kubelet is restarted.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #106696

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
