### PR TITLE
Enable set commands can pipe through apply even when fails

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/set/set_image.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/set/set_image.go
@@ -244,7 +244,13 @@ func (o *SetImageOptions) Run() error {
 			}
 			return nil
 		})
+
 		if err != nil {
+			if ee, ok := err.(polymorphichelpers.ResourceNotHavePodTemplate); ok {
+				klog.Warning(ee)
+				return nil, nil
+			}
+
 			return nil, err
 		}
 		// record this change (for rollout history)

--- a/staging/src/k8s.io/kubectl/pkg/cmd/set/set_resources.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/set/set_resources.go
@@ -257,7 +257,13 @@ func (o *SetResourcesOptions) Run() error {
 			}
 			return nil
 		})
+
 		if err != nil {
+			if ee, ok := err.(polymorphichelpers.ResourceNotHavePodTemplate); ok {
+				klog.Warning(ee)
+				return nil, nil
+			}
+
 			return nil, err
 		}
 		if !transformed {

--- a/staging/src/k8s.io/kubectl/pkg/cmd/set/set_serviceaccount.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/set/set_serviceaccount.go
@@ -204,6 +204,11 @@ func (o *SetServiceAccountOptions) Run() error {
 		info := patch.Info
 		name := info.ObjectName()
 		if patch.Err != nil {
+			if ee, ok := patch.Err.(polymorphichelpers.ResourceNotHavePodTemplate); ok {
+				klog.Warning(ee)
+				continue
+			}
+
 			patchErrs = append(patchErrs, fmt.Errorf("error: %s %v\n", name, patch.Err))
 			continue
 		}

--- a/staging/src/k8s.io/kubectl/pkg/polymorphichelpers/updatepodspec.go
+++ b/staging/src/k8s.io/kubectl/pkg/polymorphichelpers/updatepodspec.go
@@ -29,6 +29,12 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
+type ResourceNotHavePodTemplate struct {
+	message string
+}
+
+func (e ResourceNotHavePodTemplate) Error() string { return e.message }
+
 func updatePodSpecForObject(obj runtime.Object, fn func(*v1.PodSpec) error) (bool, error) {
 	switch t := obj.(type) {
 	case *v1.Pod:
@@ -85,6 +91,8 @@ func updatePodSpecForObject(obj runtime.Object, fn func(*v1.PodSpec) error) (boo
 		return true, fn(&t.Spec.JobTemplate.Spec.Template.Spec)
 
 	default:
-		return false, fmt.Errorf("the object is not a pod or does not have a pod template: %T", t)
+		return false, ResourceNotHavePodTemplate{
+			message: fmt.Sprintf("the object is not a pod or does not have a pod template: %T", t),
+		}
 	}
 }


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
`kubectl set -f` command exits, by throwing
`the object is not a pod or does not have a pod template`, when file contains resources
not having pod templates, such as services, nodes, etc. This
brings about `kubectl set -f` commands can not be used to pipe `kubectl apply -f -`.

This PR handles this specific error and enables piping to `kubectl apply`
after logging warn message.

#### Which issue(s) this PR fixes:
Fixes #106617

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
Change error message `the object is not a pod or does not have a pod template` to warning. 
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
`kubectl set` command is actually transactional request and there is no need piping it to `kubectl apply`. However when `--dry-run` is used, this piping might be useful as stated in the referenced issue.
