### PR TITLE
Do not scale immediately if the podTemplate is changed

### DIFF
--- a/pkg/controller/deployment/sync.go
+++ b/pkg/controller/deployment/sync.go
@@ -532,6 +532,9 @@ func (dc *DeploymentController) isScalingEvent(ctx context.Context, d *apps.Depl
 	}
 	allRSs := append(oldRSs, newRS)
 	for _, rs := range controller.FilterActiveReplicaSets(allRSs) {
+		if !deploymentutil.EqualIgnoreHash(&rs.Spec.Template, &d.Spec.Template) {
+			return false, nil
+		}
 		desired, ok := deploymentutil.GetDesiredReplicasAnnotation(rs)
 		if !ok {
 			continue

--- a/test/e2e/apps/deployment.go
+++ b/test/e2e/apps/deployment.go
@@ -1285,16 +1285,14 @@ func testProportionalScalingDeployment(f *framework.Framework) {
 	secondRS, err = c.AppsV1().ReplicaSets(ns).Get(context.TODO(), secondRS.Name, metav1.GetOptions{})
 	framework.ExpectNoError(err)
 
-	// First rollout's replicaset should have .spec.replicas = 8 + (30-10)*(8/13) = 8 + 12 = 20 replicas.
-	// Note that 12 comes from rounding (30-10)*(8/13) to nearest integer.
-	framework.Logf("Verifying that first rollout's replicaset has .spec.replicas = 20")
-	err = waitForReplicaSetTargetSpecReplicas(c, firstRS, 20)
+	// First rollout's replicaset should have .spec.replicas = 8 (didn't scale since the spec.template was changed).
+	framework.Logf("Verifying that first rollout's replicaset has .spec.replicas = 8")
+	err = waitForReplicaSetTargetSpecReplicas(c, firstRS, 8)
 	framework.ExpectNoError(err)
 
-	// Second rollout's replicaset should have .spec.replicas = 5 + (30-10)*(5/13) = 5 + 8 = 13 replicas.
-	// Note that 8 comes from rounding (30-10)*(5/13) to nearest integer.
-	framework.Logf("Verifying that second rollout's replicaset has .spec.replicas = 13")
-	err = waitForReplicaSetTargetSpecReplicas(c, secondRS, 13)
+	// Second rollout's replicaset should have .spec.replicas = 5 + min(33-(5+8), 30-5) = 5 + 20 = 25 replicas.
+	framework.Logf("Verifying that second rollout's replicaset has .spec.replicas = 25")
+	err = waitForReplicaSetTargetSpecReplicas(c, secondRS, 25)
 	framework.ExpectNoError(err)
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
Do not scale immediately if the `deployment.spec.template` is changed, otherwise the replicaset with old version wolud be scaled first before the rolling update.

#### Which issue(s) this PR fixes:
Fixes https://github.com/kubernetes/kubernetes/issues/105395

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
NONE
```
