### PR TITLE
fix a bug that pod stuck in terminating state in some cases

### DIFF
--- a/pkg/kubelet/kuberuntime/kuberuntime_container_test.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_container_test.go
@@ -119,6 +119,18 @@ func TestKillContainer(t *testing.T) {
 			gracePeriodOverride: 0,
 			succeed:             false,
 		},
+		{
+			caseName: "No such container in runtime, expect to succeed",
+			pod: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{UID: "pod1_id", Name: "pod1", Namespace: "default"},
+				Spec:       v1.PodSpec{Containers: []v1.Container{{Name: "not_exist_container"}}},
+			},
+			containerID:         kubecontainer.ContainerID{Type: "docker", ID: "notexistcontainerid"},
+			containerName:       "not_exist_container",
+			reason:              "unknown reason",
+			gracePeriodOverride: 0,
+			succeed:             true,
+		},
 	}
 
 	for _, test := range tests {

--- a/staging/src/k8s.io/cri-api/pkg/apis/testing/fake_runtime_service.go
+++ b/staging/src/k8s.io/cri-api/pkg/apis/testing/fake_runtime_service.go
@@ -258,7 +258,7 @@ func (r *FakeRuntimeService) StopPodSandbox(podSandboxID string) error {
 	if s, ok := r.Sandboxes[podSandboxID]; ok {
 		s.State = runtimeapi.PodSandboxState_SANDBOX_NOTREADY
 	} else {
-		return fmt.Errorf("pod sandbox %s not found", podSandboxID)
+		return fmt.Errorf("No such container: %s", podSandboxID)
 	}
 
 	return nil
@@ -396,7 +396,7 @@ func (r *FakeRuntimeService) StartContainer(containerID string) error {
 
 	c, ok := r.Containers[containerID]
 	if !ok {
-		return fmt.Errorf("container %s not found", containerID)
+		return fmt.Errorf("No such container: %s", containerID)
 	}
 
 	// Set container to running.
@@ -418,7 +418,7 @@ func (r *FakeRuntimeService) StopContainer(containerID string, timeout int64) er
 
 	c, ok := r.Containers[containerID]
 	if !ok {
-		return fmt.Errorf("container %q not found", containerID)
+		return fmt.Errorf("No such container: %s", containerID)
 	}
 
 	// Set container to exited state.
@@ -501,7 +501,7 @@ func (r *FakeRuntimeService) ContainerStatus(containerID string) (*runtimeapi.Co
 
 	c, ok := r.Containers[containerID]
 	if !ok {
-		return nil, fmt.Errorf("container %q not found", containerID)
+		return nil, fmt.Errorf("No such container: %s", containerID)
 	}
 
 	status := c.ContainerStatus


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes # fix pod stuck in terminating state when container not exist already.

#### Special notes for your reviewer:

for k8s version before 1.22,  pod can stuck in terminating state with pod worker exited in func `HandlePodCleanups` and all containers exited. Unless force delete or restart kubelet, pod will never be deleted.  For k8s version 1.22 and after, pod worker will not exit, but pod can also be stuck in terminating state.


`kubernetes version`: v1.20.10  
`docker version`: 20.10.8

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
