### PR TITLE
bump TestHTTP1DoNotReuseRequestAfterTimeout timeout

### DIFF
--- a/staging/src/k8s.io/client-go/rest/request_test.go
+++ b/staging/src/k8s.io/client-go/rest/request_test.go
@@ -2995,7 +2995,7 @@ func TestHTTP1DoNotReuseRequestAfterTimeout(t *testing.T) {
 			config := &Config{
 				Host:      ts.URL,
 				Transport: utilnet.SetTransportDefaults(transport),
-				Timeout:   100 * time.Millisecond,
+				Timeout:   1 * time.Second,
 				// These fields are required to create a REST client.
 				ContentConfig: ContentConfig{
 					GroupVersion:         &schema.GroupVersion{},


### PR DESCRIPTION
the test TestHTTP1DoNotReuseRequestAfterTimeout has to wait for
request to time out to assert that subsequent requests does not
reuse the TCP connection.

It seems that current value of 100ms causes issues on some CI
environments and bumping the timeout seems to solve this flakiness,

We can bump the timeout value because is really low compared to real
scenarios and the bump still keeps it in the millisecond order.

/kind flake
Fixes #106569

#### Special notes for your reviewer:

golang CI suffer similar issues too
https://github.com/kubernetes/kubernetes/issues/106569#issuecomment-974704197

```release-note
NONE
```
