### PR TITLE
Add enj to sig-auth-authenticators-approvers

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -18,6 +18,7 @@ aliases:
     - deads2k
     - liggitt
     - mikedanese
+    - enj
   sig-auth-authenticators-reviewers:
     - deads2k
     - enj


### PR DESCRIPTION
Signed-off-by: Monis Khan <mok@vmware.com>

/kind cleanup
/triage accepted

```release-note
NONE
```

/assign @deads2k @liggitt @mikedanese