### PR TITLE
WIP: Set pod.spec.hostname when subdomain is set

### DIFF
--- a/pkg/api/v1/pod/util_test.go
+++ b/pkg/api/v1/pod/util_test.go
@@ -968,3 +968,51 @@ func TestIsContainersReadyConditionTrue(t *testing.T) {
 		assert.Equal(t, test.expected, isContainersReady, test.desc)
 	}
 }
+
+func TestHostnameFromPodName(t *testing.T) {
+	for c, test := range map[string]struct {
+		input  string
+		output string
+	}{
+		"dns-label-short": {
+			input:  "pod-name",
+			output: "pod-name",
+		},
+		"dns-label-short-trailing-dash": {
+			input:  "pod-name-",
+			output: "pod-name",
+		},
+		"dns-label-long": {
+			input:  strings.Repeat("x", 64),
+			output: strings.Repeat("x", 63),
+		},
+		"dns-label-long-trailing-dash": {
+			input:  strings.Repeat("x", 62) + "-suffix",
+			output: strings.Repeat("x", 62),
+		},
+		"long-trailing-dashes": {
+			input:  "x" + strings.Repeat("-", 62),
+			output: "x",
+		},
+		"dns-subdomain-short": {
+			input:  "test.pod.hostname",
+			output: "test-pod-hostname",
+		},
+		"dns-subdomain-short-trailing-dot": {
+			input:  "test.pod.hostname.",
+			output: "test-pod-hostname",
+		},
+		"dns-subdomain-long": {
+			input:  strings.Repeat("x", 32) + "." + strings.Repeat("y", 32),
+			output: strings.Repeat("x", 32) + "-" + strings.Repeat("y", 30),
+		},
+		"dns-subdomain-long-trailing-dot": {
+			input:  strings.Repeat("x", 32) + "." + strings.Repeat("y", 29) + ".suffix",
+			output: strings.Repeat("x", 32) + "-" + strings.Repeat("y", 29),
+		},
+	} {
+		t.Logf("TestCase: %q", c)
+		output := HostnameFromPodName(test.input)
+		assert.Equal(t, test.output, output)
+	}
+}

--- a/pkg/controller/job/job_controller.go
+++ b/pkg/controller/job/job_controller.go
@@ -1510,7 +1510,12 @@ func (jm *Controller) manageJob(ctx context.Context, job *batch.Job, activePods 
 					if completionIndex != unknownCompletionIndex {
 						template = podTemplate.DeepCopy()
 						addCompletionIndexAnnotation(template, completionIndex)
-						template.Spec.Hostname = fmt.Sprintf("%s-%d", job.Name, completionIndex)
+						hostname := podutil.HostnameFromPodName(job.Name)
+						const maxlen = 63 - 6 - 1 // 6 places for the index, 1 for the dash
+						if len(hostname) > maxlen {
+							hostname = hostname[:maxlen]
+						}
+						template.Spec.Hostname = fmt.Sprintf("%s-%d", hostname, completionIndex)
 						generateName = podGenerateNameWithIndex(job.Name, completionIndex)
 					}
 					defer wait.Done()

--- a/pkg/controller/statefulset/stateful_set_utils.go
+++ b/pkg/controller/statefulset/stateful_set_utils.go
@@ -384,7 +384,7 @@ func updateStorage(set *apps.StatefulSet, pod *v1.Pod) {
 func initIdentity(set *apps.StatefulSet, pod *v1.Pod) {
 	updateIdentity(set, pod)
 	// Set these immutable fields only on initial Pod creation, not updates.
-	pod.Spec.Hostname = pod.Name
+	pod.Spec.Hostname = podutil.HostnameFromPodName(pod.Name)
 	pod.Spec.Subdomain = set.Spec.ServiceName
 }
 

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -908,6 +908,13 @@ const (
 	// instead of changing each file on the volumes recursively.
 	// Initial implementation focused on ReadWriteOncePod volumes.
 	SELinuxMountReadWriteOncePod featuregate.Feature = "SELinuxMountReadWriteOncePod"
+
+	// owner: @thockin
+	// kep: http://kep.k8s.io/????
+	// alpha: v1.24
+	//
+	// Enables default pod hostname when subdomain is set
+	PodHostnameWhenSubdomain featuregate.Feature = "PodHostnameWhenSubdomain"
 )
 
 func init() {
@@ -1156,6 +1163,8 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
 	NodeInclusionPolicyInPodTopologySpread: {Default: true, PreRelease: featuregate.Beta},
 
 	SELinuxMountReadWriteOncePod: {Default: false, PreRelease: featuregate.Alpha},
+
+	PodHostnameWhenSubdomain: {Default: false, PreRelease: featuregate.Alpha},
 
 	// inherited features from generic apiserver, relisted here to get a conflict if it is changed
 	// unintentionally on either side:

--- a/pkg/kubelet/kubelet_pods_test.go
+++ b/pkg/kubelet/kubelet_pods_test.go
@@ -3333,35 +3333,6 @@ func TestHasHostNamespace(t *testing.T) {
 	}
 }
 
-func TestTruncatePodHostname(t *testing.T) {
-	for c, test := range map[string]struct {
-		input  string
-		output string
-	}{
-		"valid hostname": {
-			input:  "test.pod.hostname",
-			output: "test.pod.hostname",
-		},
-		"too long hostname": {
-			input:  "1234567.1234567.1234567.1234567.1234567.1234567.1234567.1234567.1234567.", // 8*9=72 chars
-			output: "1234567.1234567.1234567.1234567.1234567.1234567.1234567.1234567",          //8*8-1=63 chars
-		},
-		"hostname end with .": {
-			input:  "1234567.1234567.1234567.1234567.1234567.1234567.1234567.123456.1234567.", // 8*9-1=71 chars
-			output: "1234567.1234567.1234567.1234567.1234567.1234567.1234567.123456",          //8*8-2=62 chars
-		},
-		"hostname end with -": {
-			input:  "1234567.1234567.1234567.1234567.1234567.1234567.1234567.123456-1234567.", // 8*9-1=71 chars
-			output: "1234567.1234567.1234567.1234567.1234567.1234567.1234567.123456",          //8*8-2=62 chars
-		},
-	} {
-		t.Logf("TestCase: %q", c)
-		output, err := truncatePodHostnameIfNeeded("test-pod", test.input)
-		assert.NoError(t, err)
-		assert.Equal(t, test.output, output)
-	}
-}
-
 func TestGenerateAPIPodStatusHostNetworkPodIPs(t *testing.T) {
 	testcases := []struct {
 		name          string

--- a/pkg/registry/core/pod/strategy.go
+++ b/pkg/registry/core/pod/strategy.go
@@ -42,6 +42,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/kubernetes/pkg/api/legacyscheme"
 	podutil "k8s.io/kubernetes/pkg/api/pod"
+	podv1util "k8s.io/kubernetes/pkg/api/v1/pod"
 	api "k8s.io/kubernetes/pkg/apis/core"
 	"k8s.io/kubernetes/pkg/apis/core/helper/qos"
 	"k8s.io/kubernetes/pkg/apis/core/validation"
@@ -758,7 +759,7 @@ func seccompFieldForAnnotation(annotation string) *api.SeccompProfile {
 func setDefaultHostname(pod *api.Pod) {
 	if utilfeature.DefaultFeatureGate.Enabled(features.PodHostnameWhenSubdomain) {
 		if pod.Spec.Subdomain != "" && pod.Spec.Hostname == "" {
-			pod.Spec.Hostname = pod.Name
+			pod.Spec.Hostname = podv1util.HostnameFromPodName(pod.Name)
 		}
 	}
 }


### PR DESCRIPTION
This allows Deployments to set `subdomain` and get unique FQDN for each pod.  If the user sets `hostname` we will not touch it.

/kind feature
/kind api-change

Fixes #60789

TODO: 
* consider #104195 - warn when pod name does not conform to DNSLabel spec

```release-note
Pods which set `.spec.subdomain` but do not set `.spec.hostname` will have `.spec.hostname` defaulted to the Pod's name.  This makes it easier to use the subdomain functionality in workload controllers like Deployments.  This behavior is ALPHA and is controlled by the "PodHostnameWhenSubdomain" feature gate.
```
