### PR TITLE
auth/exec: prevent multiple calls when expirationTimestamp is invalid

### DIFF
--- a/cmd/kubelet/app/server.go
+++ b/cmd/kubelet/app/server.go
@@ -911,7 +911,10 @@ func updateDialer(clientConfig *restclient.Config) (func(), error) {
 	}
 	d := connrotation.NewDialer((&net.Dialer{Timeout: 30 * time.Second, KeepAlive: 30 * time.Second}).DialContext)
 	clientConfig.Dial = d.DialContext
-	return d.CloseAll, nil
+	return func() {
+		d.MarkAllInUse() // TODO see if we can do better
+		d.CloseAllInUse()
+	}, nil
 }
 
 // buildClientCertificateManager creates a certificate manager that will use certConfig to request a client certificate

--- a/staging/src/k8s.io/client-go/plugin/pkg/client/auth/exec/exec.go
+++ b/staging/src/k8s.io/client-go/plugin/pkg/client/auth/exec/exec.go
@@ -312,6 +312,7 @@ func (a *Authenticator) UpdateTransportConfig(c *transport.Config) error {
 	}
 
 	c.Dial = d.DialContext
+	c.TLS.TLSSessionStarted = d.MarkAllInUse
 
 	return nil
 }
@@ -390,7 +391,7 @@ func (a *Authenticator) cert(ctx context.Context) (*tls.Certificate, error) {
 		// If we close the underlying TCP connection in the process of starting the TLS handshake,
 		// there is no point in letting the handshake continue.  At least this way we provide a
 		// better error message then "write tcp host:port->host:port use of closed network connection"
-		return nil, errors.New("failing TLS handshake due to certificate rotation")
+		// return nil, errors.New("failing TLS handshake due to certificate rotation")
 	}
 	return creds.cert, nil
 }
@@ -532,7 +533,7 @@ func (a *Authenticator) refreshCredsLocked() (bool, error) {
 		if oldCreds.cert != nil && oldCreds.cert.Leaf != nil {
 			metrics.ClientCertRotationAge.Observe(time.Since(oldCreds.cert.Leaf.NotBefore))
 		}
-		a.connTracker.CloseAll()
+		a.connTracker.CloseAllInUse()
 		connClosed = true
 	}
 

--- a/staging/src/k8s.io/client-go/plugin/pkg/client/auth/exec/exec_test.go
+++ b/staging/src/k8s.io/client-go/plugin/pkg/client/auth/exec/exec_test.go
@@ -1350,8 +1350,8 @@ func TestTLSCredentialsCallsAndRotation(t *testing.T) {
 
 	// cause the round tripper to be skipped combined with cache miss and single connection
 	tokenWrap := func(rt http.RoundTripper) http.RoundTripper { return transport.NewBearerAuthRoundTripper("foo", rt) }
-	get(t, "valid TLS cert with token", tokenWrap, "failing TLS handshake due to certificate rotation")
-	get(t, "valid TLS cert again with token", tokenWrap, "failing TLS handshake due to certificate rotation")
+	get(t, "valid TLS cert with token", tokenWrap, "")
+	get(t, "valid TLS cert again with token", tokenWrap, "")
 
 	if want, got := getCalls, outputCalls; want != got {
 		t.Errorf("unexpected exec call count: want=%d, got=%d", want, got)

--- a/staging/src/k8s.io/client-go/plugin/pkg/client/auth/exec/metrics_test.go
+++ b/staging/src/k8s.io/client-go/plugin/pkg/client/auth/exec/metrics_test.go
@@ -152,7 +152,7 @@ func TestCallsMetric(t *testing.T) {
 		// Run refresh creds twice so that our test validates that the metrics are set correctly twice
 		// in a row with the same authenticator.
 		refreshCreds := func() {
-			if err := a.refreshCredsLocked(); (err == nil) != (exitCode == 0) {
+			if _, err := a.refreshCredsLocked(); (err == nil) != (exitCode == 0) {
 				if err != nil {
 					t.Fatalf("wanted no error, but got %q", err.Error())
 				} else {
@@ -182,7 +182,7 @@ func TestCallsMetric(t *testing.T) {
 			t.Fatal(err)
 		}
 		a.stderr = io.Discard
-		if err := a.refreshCredsLocked(); err == nil {
+		if _, err := a.refreshCredsLocked(); err == nil {
 			t.Fatal("expected the authenticator to fail because the plugin does not exist")
 		}
 		wantCallsMetrics = append(wantCallsMetrics, mockCallsMetric{exitCode: 1, errorType: "plugin_not_found_error"})

--- a/staging/src/k8s.io/client-go/transport/cache.go
+++ b/staging/src/k8s.io/client-go/transport/cache.go
@@ -100,6 +100,7 @@ func (c *tlsTransportCache) get(config *Config) (http.RoundTripper, error) {
 	if config.TLS.ReloadTLSFiles {
 		dynamicCertDialer := certRotatingDialer(tlsConfig.GetClientCertificate, dial)
 		tlsConfig.GetClientCertificate = dynamicCertDialer.GetClientCertificate
+		tlsConfig.ClientSessionCache = recordPutClientSessionCache(dynamicCertDialer.connDialer.MarkAllInUse)
 		dial = dynamicCertDialer.connDialer.DialContext
 		go dynamicCertDialer.Run(wait.NeverStop)
 	}

--- a/staging/src/k8s.io/client-go/transport/cache_test.go
+++ b/staging/src/k8s.io/client-go/transport/cache_test.go
@@ -63,7 +63,7 @@ func TestTLSConfigKey(t *testing.T) {
 
 	// Make sure config fields that affect the tls config affect the cache key
 	dialer := net.Dialer{}
-	getCert := func() (*tls.Certificate, error) { return nil, nil }
+	getCert := func(context.Context) (*tls.Certificate, error) { return nil, nil }
 	uniqueConfigurations := map[string]*Config{
 		"no tls":   {},
 		"dialer":   {Dial: dialer.DialContext},
@@ -125,7 +125,7 @@ func TestTLSConfigKey(t *testing.T) {
 		"getCert2": {
 			TLS: TLSConfig{
 				KeyData: []byte{1},
-				GetCert: func() (*tls.Certificate, error) { return nil, nil },
+				GetCert: func(context.Context) (*tls.Certificate, error) { return nil, nil },
 			},
 		},
 		"getCert1, key 2": {

--- a/staging/src/k8s.io/client-go/transport/cert_rotation.go
+++ b/staging/src/k8s.io/client-go/transport/cert_rotation.go
@@ -61,8 +61,8 @@ func certRotatingDialer(reload reloadFunc, dial utilnet.DialFunc) *dynamicClient
 }
 
 // loadClientCert calls the callback and rotates connections if needed
-func (c *dynamicClientCert) loadClientCert() (*tls.Certificate, error) {
-	cert, err := c.reload(nil)
+func (c *dynamicClientCert) loadClientCert(cri *tls.CertificateRequestInfo) (*tls.Certificate, error) {
+	cert, err := c.reload(cri)
 	if err != nil {
 		return nil, err
 	}
@@ -159,7 +159,7 @@ func (c *dynamicClientCert) processNextWorkItem() bool {
 	}
 	defer c.queue.Done(dsKey)
 
-	_, err := c.loadClientCert()
+	_, err := c.loadClientCert(nil)
 	if err == nil {
 		c.queue.Forget(dsKey)
 		return true
@@ -171,6 +171,6 @@ func (c *dynamicClientCert) processNextWorkItem() bool {
 	return true
 }
 
-func (c *dynamicClientCert) GetClientCertificate(*tls.CertificateRequestInfo) (*tls.Certificate, error) {
-	return c.loadClientCert()
+func (c *dynamicClientCert) GetClientCertificate(cri *tls.CertificateRequestInfo) (*tls.Certificate, error) {
+	return c.loadClientCert(cri)
 }

--- a/staging/src/k8s.io/client-go/transport/cert_rotation.go
+++ b/staging/src/k8s.io/client-go/transport/cert_rotation.go
@@ -86,7 +86,7 @@ func (c *dynamicClientCert) loadClientCert(cri *tls.CertificateRequestInfo) (*tl
 	}
 
 	klog.V(1).Infof("certificate rotation detected, shutting down client connections to start using new credentials")
-	c.connDialer.CloseAll()
+	c.connDialer.CloseAllInUse()
 
 	return cert, nil
 }

--- a/staging/src/k8s.io/client-go/transport/config.go
+++ b/staging/src/k8s.io/client-go/transport/config.go
@@ -143,5 +143,5 @@ type TLSConfig struct {
 	// To use only http/1.1, set to ["http/1.1"].
 	NextProtos []string
 
-	GetCert func() (*tls.Certificate, error) // Callback that returns a TLS client certificate. CertData, CertFile, KeyData and KeyFile supercede this field.
+	GetCert func(context.Context) (*tls.Certificate, error) // Callback that returns a TLS client certificate. CertData, CertFile, KeyData and KeyFile supercede this field.
 }

--- a/staging/src/k8s.io/client-go/transport/config.go
+++ b/staging/src/k8s.io/client-go/transport/config.go
@@ -144,4 +144,7 @@ type TLSConfig struct {
 	NextProtos []string
 
 	GetCert func(context.Context) (*tls.Certificate, error) // Callback that returns a TLS client certificate. CertData, CertFile, KeyData and KeyFile supercede this field.
+
+	// TODO comment
+	TLSSessionStarted func()
 }

--- a/staging/src/k8s.io/client-go/transport/transport.go
+++ b/staging/src/k8s.io/client-go/transport/transport.go
@@ -131,9 +131,23 @@ func TLSConfigFor(c *Config) (*tls.Config, error) {
 			// be sent to the server.
 			return &tls.Certificate{}, nil
 		}
+
+		if c.TLS.TLSSessionStarted != nil {
+			tlsConfig.ClientSessionCache = recordPutClientSessionCache(c.TLS.TLSSessionStarted)
+		}
 	}
 
 	return tlsConfig, nil
+}
+
+type recordPutClientSessionCache func()
+
+func (f recordPutClientSessionCache) Get(_ string) (*tls.ClientSessionState, bool) {
+	return nil, false
+}
+
+func (f recordPutClientSessionCache) Put(_ string, _ *tls.ClientSessionState) {
+	f()
 }
 
 func certificateRequestInfoContext(cri *tls.CertificateRequestInfo) context.Context {

--- a/staging/src/k8s.io/client-go/transport/transport_test.go
+++ b/staging/src/k8s.io/client-go/transport/transport_test.go
@@ -209,7 +209,7 @@ func TestNew(t *testing.T) {
 			Config: &Config{
 				TLS: TLSConfig{
 					CAData: []byte(rootCACert),
-					GetCert: func() (*tls.Certificate, error) {
+					GetCert: func(context.Context) (*tls.Certificate, error) {
 						crt, err := tls.X509KeyPair([]byte(certData), []byte(keyData))
 						return &crt, err
 					},
@@ -223,7 +223,7 @@ func TestNew(t *testing.T) {
 			Config: &Config{
 				TLS: TLSConfig{
 					CAData: []byte(rootCACert),
-					GetCert: func() (*tls.Certificate, error) {
+					GetCert: func(context.Context) (*tls.Certificate, error) {
 						return nil, errors.New("GetCert failure")
 					},
 				},
@@ -235,7 +235,7 @@ func TestNew(t *testing.T) {
 			Config: &Config{
 				TLS: TLSConfig{
 					CAData: []byte(rootCACert),
-					GetCert: func() (*tls.Certificate, error) {
+					GetCert: func(context.Context) (*tls.Certificate, error) {
 						return nil, nil
 					},
 					CertData: []byte(certData),
@@ -249,7 +249,7 @@ func TestNew(t *testing.T) {
 			Config: &Config{
 				TLS: TLSConfig{
 					CAData: []byte(rootCACert),
-					GetCert: func() (*tls.Certificate, error) {
+					GetCert: func(context.Context) (*tls.Certificate, error) {
 						return nil, nil
 					},
 				},

--- a/staging/src/k8s.io/client-go/util/connrotation/connrotation_test.go
+++ b/staging/src/k8s.io/client-go/util/connrotation/connrotation_test.go
@@ -40,8 +40,9 @@ func TestCloseAll(t *testing.T) {
 			if _, err := dialer.Dial("", ""); err != nil {
 				t.Fatal(err)
 			}
+			dialer.MarkAllInUse()
 		}
-		dialer.CloseAll()
+		dialer.CloseAllInUse()
 		deadline := time.After(time.Second)
 		for j := 0; j < numConns; j++ {
 			select {
@@ -72,7 +73,7 @@ func TestCloseAllRace(t *testing.T) {
 		begin.Wait()
 		defer wg.Done()
 		for i := 0; i < raceCount; i++ {
-			dialer.CloseAll()
+			dialer.CloseAllInUse()
 		}
 	}()
 
@@ -88,6 +89,7 @@ func TestCloseAllRace(t *testing.T) {
 			}
 			atomic.AddInt64(&conns, 1)
 		}
+		dialer.MarkAllInUse()
 	}()
 
 	// Trigger both goroutines as close to the same time as possible
@@ -97,7 +99,7 @@ func TestCloseAllRace(t *testing.T) {
 	wg.Wait()
 
 	// Ensure CloseAll ran after all dials
-	dialer.CloseAll()
+	dialer.CloseAllInUse()
 
 	// Expect all connections to close within 5 seconds
 	for start := time.Now(); time.Now().Sub(start) < 5*time.Second; time.Sleep(10 * time.Millisecond) {

--- a/test/integration/client/exec_test.go
+++ b/test/integration/client/exec_test.go
@@ -786,7 +786,8 @@ func TestExecPluginRotationViaInformer(t *testing.T) {
 	// Make sure informer does not see events since it is using the invalid token.
 	execPlugin.rotateToken(clientUnauthorizedToken, tokenLifetime)
 	time.Sleep(tokenLifetime) // wait for old token to expire to make sure the watch is restarted with clientUnauthorizedToken
-	clientDialer.CloseAll()
+	clientDialer.MarkAllInUse()
+	clientDialer.CloseAllInUse()
 	waitForInformerSync(ctx, t, informer, true, "")
 	informerSpy.clear()
 	createUpdateDeleteConfigMap(ctx, t, adminClient.CoreV1().ConfigMaps(ns.Name))


### PR DESCRIPTION
This change addresses an edge case in our connection closing logic.

Consider the following scenario:

1. Exec plugin is configured
2. Exec plugin uses certificate based auth
3. Exec plugin returns a new certificate per invocation
4. Exec plugin sets expirationTimestamp based on some external source
5. The external source and the client (i.e. kubectl) disagree on
   what the current time is
6. The external source gives the exec plugin an expirationTimestamp
   that is considered to be in the past from the perspective of the
   client (i.e. the certificate is considered to already be expired)

Call stack for a client like kubectl:

1. exec.Authenticator.UpdateTransportConfig sets up Wrap and GetCert
2. exec.roundTripper.RoundTrip is called
3. getCreds, no creds, refreshCredsLocked -> gets first certificate
4. r.base.RoundTrip is called
5. a.cert gets called to fill the TLS config with a cert
6. getCreds, "expired" creds, refreshCredsLocked -> gets second
   certificate.  sees old creds with cert and closes connections.
   This happens to be the _current_ connection and thus auth fails
   with a "use of closed connection" error.

Signed-off-by: Monis Khan <mok@vmware.com>

/kind bug
/assign @liggitt 

```release-note
Fix "use of closed network connection" error seen under particular configurations of client-go credential plugins.
```