### PR TITLE
Feature/set namespace context by env var

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/cmd.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/cmd.go
@@ -299,6 +299,17 @@ func NewKubectlCommand(o KubectlOptions) *cobra.Command {
 	kubeConfigFlags.AddFlags(flags)
 	matchVersionKubeConfigFlags := cmdutil.NewMatchVersionFlags(kubeConfigFlags)
 	matchVersionKubeConfigFlags.AddFlags(flags)
+
+	// Overwrite kubeconfig context setting with KUBE_CONTEXT env var
+	if envContext := os.Getenv("KUBE_CONTEXT"); envContext != "" {
+		*kubeConfigFlags.Context = envContext
+	}
+
+	// Overwrite kubeconfig namespace setting with KUBE_NAMESPACE env var
+	if envNamespace := os.Getenv("KUBE_NAMESPACE"); envNamespace != "" {
+		*kubeConfigFlags.Namespace = envNamespace
+	}
+
 	// Updates hooks to add kubectl command headers: SIG CLI KEP 859.
 	addCmdHeaderHooks(cmds, kubeConfigFlags)
 

--- a/staging/src/k8s.io/kubectl/pkg/cmd/cmd_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/cmd_test.go
@@ -248,20 +248,20 @@ func TestKubectlCommandHeadersHooks(t *testing.T) {
 
 func TestKubectlCommandEnvVarNamespaceSettings(t *testing.T) {
 	tests := map[string]struct {
-		envVars    map[string]string
+		envVars map[string]string
 	}{
 		"empty environment variables; default": {
-			envVars:   map[string]string{
+			envVars: map[string]string{
 				"": "",
 			},
 		},
 		"KUBE_NAMESPACE empty; default": {
-			envVars:   map[string]string{
+			envVars: map[string]string{
 				"KUBE_NAMESPACE": "",
 			},
 		},
 		"KUBE_NAMESPACE = testenv; set namespace to testenv": {
-			envVars:   map[string]string{
+			envVars: map[string]string{
 				"KUBE_NAMESPACE": "testenv",
 			},
 		},
@@ -279,7 +279,7 @@ func TestKubectlCommandEnvVarNamespaceSettings(t *testing.T) {
 
 			// Run the NewKubectlCommand to test using environment variables to update the kubeConfigFlag values
 			_ = NewKubectlCommand(KubectlOptions{ConfigFlags: kubeConfigFlags, IOStreams: genericclioptions.IOStreams{In: os.Stdin, Out: ioutil.Discard, ErrOut: os.Stderr}})
-			
+
 			if kubeConfigFlags.Namespace != nil && *kubeConfigFlags.Namespace != testCase.envVars["KUBE_NAMESPACE"] {
 				t.Fatalf("Unexpected Namespace set: expected %q, got %q", testCase.envVars["KUBE_NAMESPACE"], *kubeConfigFlags.Namespace)
 			}
@@ -298,20 +298,20 @@ func TestKubectlCommandEnvVarNamespaceSettings(t *testing.T) {
 
 func TestKubectlCommandEnvVarContextSettings(t *testing.T) {
 	tests := map[string]struct {
-		envVars    map[string]string
+		envVars map[string]string
 	}{
 		"empty environment variables; default": {
-			envVars:   map[string]string{
+			envVars: map[string]string{
 				"": "",
 			},
 		},
 		"KUBE_CONTEXT empty; default": {
-			envVars:   map[string]string{
+			envVars: map[string]string{
 				"KUBE_CONTEXT": "",
 			},
 		},
 		"KUBE_CONTEXT = testenv; set context to testenv": {
-			envVars:   map[string]string{
+			envVars: map[string]string{
 				"KUBE_CONTEXT": "testenv",
 			},
 		},
@@ -329,7 +329,7 @@ func TestKubectlCommandEnvVarContextSettings(t *testing.T) {
 
 			// Run the NewKubectlCommand to test using environment variables to update the kubeConfigFlag values
 			_ = NewKubectlCommand(KubectlOptions{ConfigFlags: kubeConfigFlags, IOStreams: genericclioptions.IOStreams{In: os.Stdin, Out: ioutil.Discard, ErrOut: os.Stderr}})
-			
+
 			if testCase.envVars["KUBE_CONTEXT"] != "" && *kubeConfigFlags.Context != testCase.envVars["KUBE_CONTEXT"] {
 				t.Fatalf("Unexpected Context set: expected %q, got %q", testCase.envVars["KUBE_CONTEXT"], *kubeConfigFlags.Context)
 			}


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
This PR addresses this [issue](https://github.com/kubernetes/kubectl/issues/1154) which requests the support of loading default namespace and context values for kubectl via environment variable. The change follows the kubectl convention that states settings should follow the hierarchy of:
1. explicit settings from command line
2. environment variables settings
3. kubeconfig settings

Thus this change allows these new environment variables to overwrite kubeconfig settings, and will then be overwritten by any explicitly set command line arguments.

#### Which issue(s) this PR fixes:
Fixes https://github.com/kubernetes/kubectl/issues/1154

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
The flags --namespace and --context can now be set by environment variables KUBE_NAMESPACE and KUBE_CONTEXT respectively.
```