### PR TITLE
Automated cherry pick of #106716: bump TestHTTP1DoNotReuseRequestAfterTimeout timeout

### DIFF
--- a/staging/src/k8s.io/client-go/rest/request_test.go
+++ b/staging/src/k8s.io/client-go/rest/request_test.go
@@ -2995,7 +2995,7 @@ func TestHTTP1DoNotReuseRequestAfterTimeout(t *testing.T) {
 			config := &Config{
 				Host:      ts.URL,
 				Transport: utilnet.SetTransportDefaults(transport),
-				Timeout:   100 * time.Millisecond,
+				Timeout:   1 * time.Second,
 				// These fields are required to create a REST client.
 				ContentConfig: ContentConfig{
 					GroupVersion:         &schema.GroupVersion{},


### PR DESCRIPTION
Cherry pick of #106716 on release-1.23.

#106716: bump TestHTTP1DoNotReuseRequestAfterTimeout timeout

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```