### PR TITLE
Automated cherry pick of #106728: Add enj to sig-auth-authenticators-approvers

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -18,6 +18,7 @@ aliases:
     - deads2k
     - liggitt
     - mikedanese
+    - enj
   sig-auth-authenticators-reviewers:
     - deads2k
     - enj


### PR DESCRIPTION
Cherry pick of #106728 on release-1.23.

#106728: Add enj to sig-auth-authenticators-approvers

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```