### PR TITLE
Fix: show more error messages when kubectl edit 'Not Found'

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/util/editor/editoptions.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/util/editor/editoptions.go
@@ -838,7 +838,7 @@ func (r *editResults) addError(err error, info *resource.Info) string {
 		return fmt.Sprintf("error: %s %q is invalid", resourceString, info.Name)
 	case apierrors.IsNotFound(err):
 		r.notfound++
-		return fmt.Sprintf("error: %s %q could not be found on the server", resourceString, info.Name)
+		return fmt.Sprintf("error: %s %q could not be patched: %v", resourceString, info.Name, err)
 	default:
 		r.retryable++
 		return fmt.Sprintf("error: %s %q could not be patched: %v", resourceString, info.Name, err)


### PR DESCRIPTION

#### What type of PR is this?
/kind bug


#### What this PR does / why we need it:
First we create crd  resources in a namespace. And then for some reason, the namespace be deleted and resources still exist. 
At this point, we can get resource,  but when we edit this resource,  we recevice an error which is "error: ... could not be found on the server". 
It is strange that we can get resource, but get a 'Not Found' error when edit it .
When we get more logs with '--v 8' , we found the 'Not Found' means the namespace is not found rather than the resource not found. 

We find out a writing request which is in the namespace scope will be admitted by NamespaceLifecycle,ValidatingAdmissionWebhook plugins which will verfiy namespace.  

Base on the above，When we get a 404 , we should show  ' namespace *** not found' or 'resource *** not found' from error messages rather than 'not found'.



#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
