### PR TITLE
KEP-3070: Reserve Service IP Ranges For Dynamic and Static IP Allocation

### DIFF
--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -837,6 +837,12 @@ const (
 	//
 	// Enable MinDomains in Pod Topology Spread.
 	MinDomainsInPodTopologySpread featuregate.Feature = "MinDomainsInPodTopologySpread"
+	// owner: @aojea
+	// kep: http://kep.k8s.io/3070
+	// alpha: v1.24
+	//
+	// Subdivide the ClusterIP range for dynamic and static IP allocation.
+	ServiceIPStaticSubrange featuregate.Feature = "ServiceIPStaticSubrange"
 )
 
 func init() {
@@ -959,6 +965,7 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
 	GRPCContainerProbe:                             {Default: false, PreRelease: featuregate.Alpha},
 	LegacyServiceAccountTokenNoAutoGeneration:      {Default: true, PreRelease: featuregate.Beta},
 	MinDomainsInPodTopologySpread:                  {Default: false, PreRelease: featuregate.Alpha},
+	ServiceIPStaticSubrange:                        {Default: false, PreRelease: featuregate.Alpha},
 
 	// inherited features from generic apiserver, relisted here to get a conflict if it is changed
 	// unintentionally on either side:

--- a/pkg/registry/core/rest/storage_core.go
+++ b/pkg/registry/core/rest/storage_core.go
@@ -199,8 +199,9 @@ func (c LegacyRESTStorageProvider) NewLegacyRESTStorage(apiResourceConfigSource 
 		return LegacyRESTStorage{}, genericapiserver.APIGroupInfo{}, err
 	}
 
-	serviceClusterIPAllocator, err := ipallocator.New(&serviceClusterIPRange, func(max int, rangeSpec string) (allocator.Interface, error) {
-		mem := allocator.NewAllocationMap(max, rangeSpec)
+	serviceClusterIPAllocator, err := ipallocator.New(&serviceClusterIPRange, func(max int, rangeSpec string, offset int) (allocator.Interface, error) {
+		var mem allocator.Snapshottable
+		mem = allocator.NewAllocationMapWithOffset(max, rangeSpec, offset)
 		// TODO etcdallocator package to return a storage interface via the storageFactory
 		etcd, err := serviceallocator.NewEtcd(mem, "/ranges/serviceips", serviceStorageConfig.ForResource(api.Resource("serviceipallocations")))
 		if err != nil {
@@ -218,8 +219,9 @@ func (c LegacyRESTStorageProvider) NewLegacyRESTStorage(apiResourceConfigSource 
 	var secondaryServiceClusterIPAllocator ipallocator.Interface
 	if c.SecondaryServiceIPRange.IP != nil {
 		var secondaryServiceClusterIPRegistry rangeallocation.RangeRegistry
-		secondaryServiceClusterIPAllocator, err = ipallocator.New(&c.SecondaryServiceIPRange, func(max int, rangeSpec string) (allocator.Interface, error) {
-			mem := allocator.NewAllocationMap(max, rangeSpec)
+		secondaryServiceClusterIPAllocator, err = ipallocator.New(&c.SecondaryServiceIPRange, func(max int, rangeSpec string, offset int) (allocator.Interface, error) {
+			var mem allocator.Snapshottable
+			mem = allocator.NewAllocationMapWithOffset(max, rangeSpec, offset)
 			// TODO etcdallocator package to return a storage interface via the storageFactory
 			etcd, err := serviceallocator.NewEtcd(mem, "/ranges/secondaryserviceips", serviceStorageConfig.ForResource(api.Resource("serviceipallocations")))
 			if err != nil {

--- a/pkg/registry/core/service/allocator/bitmap_test.go
+++ b/pkg/registry/core/service/allocator/bitmap_test.go
@@ -23,116 +23,521 @@ import (
 )
 
 func TestAllocate(t *testing.T) {
-	max := 10
-	m := NewAllocationMap(max, "test")
+	testCases := []struct {
+		name      string
+		allocator func(max int, rangeSpec string, reserved int) *AllocationBitmap
+		max       int
+		reserved  int
+	}{
+		{
+			name:      "NewAllocationMap",
+			allocator: NewAllocationMapWithOffset,
+			max:       32,
+			reserved:  0,
+		},
+		{
+			name:      "NewAllocationMapWithOffset max < 16",
+			allocator: NewAllocationMapWithOffset,
+			max:       8,
+			reserved:  0,
+		},
+		{
+			name:      "NewAllocationMapWithOffset max > 16",
+			allocator: NewAllocationMapWithOffset,
+			max:       128,
+			reserved:  16,
+		},
+		{
+			name:      "NewAllocationMapWithOffset max > 256",
+			allocator: NewAllocationMapWithOffset,
+			max:       1024,
+			reserved:  64,
+		},
+		{
+			name:      "NewAllocationMapWithOffset max value",
+			allocator: NewAllocationMapWithOffset,
+			max:       65535,
+			reserved:  256,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			m := tc.allocator(tc.max, "test", tc.reserved)
 
-	if _, ok, _ := m.AllocateNext(); !ok {
-		t.Fatalf("unexpected error")
-	}
-	if m.count != 1 {
-		t.Errorf("expect to get %d, but got %d", 1, m.count)
-	}
-	if f := m.Free(); f != max-1 {
-		t.Errorf("expect to get %d, but got %d", max-1, f)
+			if _, ok, _ := m.AllocateNext(); !ok {
+				t.Fatalf("unexpected error")
+			}
+			if m.count != 1 {
+				t.Errorf("expect to get %d, but got %d", 1, m.count)
+			}
+			if f := m.Free(); f != tc.max-1 {
+				t.Errorf("expect to get %d, but got %d", tc.max-1, f)
+			}
+		})
 	}
 }
 
 func TestAllocateMax(t *testing.T) {
-	max := 10
-	m := NewAllocationMap(max, "test")
-	for i := 0; i < max; i++ {
+	testCases := []struct {
+		name      string
+		allocator func(max int, rangeSpec string, reserved int) *AllocationBitmap
+		max       int
+		reserved  int
+	}{
+		{
+			name:      "NewAllocationMap",
+			allocator: NewAllocationMapWithOffset,
+			max:       32,
+			reserved:  0,
+		},
+		{
+			name:      "NewAllocationMapWithOffset max < 16",
+			allocator: NewAllocationMapWithOffset,
+			max:       8,
+			reserved:  0,
+		},
+		{
+			name:      "NewAllocationMapWithOffset max > 16",
+			allocator: NewAllocationMapWithOffset,
+			max:       128,
+			reserved:  16,
+		},
+		{
+			name:      "NewAllocationMapWithOffset max > 256",
+			allocator: NewAllocationMapWithOffset,
+			max:       1024,
+			reserved:  64,
+		},
+		{
+			name:      "NewAllocationMapWithOffset max value",
+			allocator: NewAllocationMapWithOffset,
+			max:       65535,
+			reserved:  256,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			m := tc.allocator(tc.max, "test", tc.reserved)
+			for i := 0; i < tc.max; i++ {
+				if ok, err := m.Allocate(i); !ok || err != nil {
+					t.Fatalf("unexpected error")
+				}
+			}
+			if _, ok, _ := m.AllocateNext(); ok {
+				t.Errorf("unexpected success")
+			}
+
+			if ok, err := m.Allocate(tc.max); ok || err == nil {
+				t.Fatalf("unexpected allocation")
+			}
+
+			if f := m.Free(); f != 0 {
+				t.Errorf("expect to get %d, but got %d", 0, f)
+			}
+		})
+	}
+}
+
+func TestAllocateNextMax(t *testing.T) {
+	testCases := []struct {
+		name      string
+		allocator func(max int, rangeSpec string, reserved int) *AllocationBitmap
+		max       int
+		reserved  int
+	}{
+		{
+			name:      "NewAllocationMap",
+			allocator: NewAllocationMapWithOffset,
+			max:       32,
+			reserved:  0,
+		},
+		{
+			name:      "NewAllocationMapWithOffset max < 16",
+			allocator: NewAllocationMapWithOffset,
+			max:       8,
+			reserved:  0,
+		},
+		{
+			name:      "NewAllocationMapWithOffset max > 16",
+			allocator: NewAllocationMapWithOffset,
+			max:       128,
+			reserved:  16,
+		},
+		{
+			name:      "NewAllocationMapWithOffset max > 256",
+			allocator: NewAllocationMapWithOffset,
+			max:       1024,
+			reserved:  64,
+		},
+		{
+			name:      "NewAllocationMapWithOffset max value",
+			allocator: NewAllocationMapWithOffset,
+			max:       65535,
+			reserved:  256,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			m := tc.allocator(tc.max, "test", tc.reserved)
+			for i := 0; i < tc.max; i++ {
+				if _, ok, _ := m.AllocateNext(); !ok {
+					t.Fatalf("unexpected error")
+				}
+			}
+			if _, ok, _ := m.AllocateNext(); ok {
+				t.Errorf("unexpected success")
+			}
+			if f := m.Free(); f != 0 {
+				t.Errorf("expect to get %d, but got %d", 0, f)
+			}
+		})
+	}
+}
+func TestAllocateError(t *testing.T) {
+	testCases := []struct {
+		name      string
+		allocator func(max int, rangeSpec string, reserved int) *AllocationBitmap
+		max       int
+		reserved  int
+	}{
+		{
+			name:      "NewAllocationMap",
+			allocator: NewAllocationMapWithOffset,
+			max:       32,
+			reserved:  0,
+		},
+		{
+			name:      "NewAllocationMapWithOffset max < 16",
+			allocator: NewAllocationMapWithOffset,
+			max:       8,
+			reserved:  0,
+		},
+		{
+			name:      "NewAllocationMapWithOffset max > 16",
+			allocator: NewAllocationMapWithOffset,
+			max:       128,
+			reserved:  16,
+		},
+		{
+			name:      "NewAllocationMapWithOffset max > 256",
+			allocator: NewAllocationMapWithOffset,
+			max:       1024,
+			reserved:  64,
+		},
+		{
+			name:      "NewAllocationMapWithOffset max value",
+			allocator: NewAllocationMapWithOffset,
+			max:       65535,
+			reserved:  256,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			m := tc.allocator(tc.max, "test", tc.reserved)
+			if ok, _ := m.Allocate(3); !ok {
+				t.Errorf("error allocate offset %v", 3)
+			}
+			if ok, _ := m.Allocate(3); ok {
+				t.Errorf("unexpected success")
+			}
+		})
+	}
+}
+
+func TestRelease(t *testing.T) {
+	testCases := []struct {
+		name      string
+		allocator func(max int, rangeSpec string, reserved int) *AllocationBitmap
+		max       int
+		reserved  int
+	}{
+		{
+			name:      "NewAllocationMap",
+			allocator: NewAllocationMapWithOffset,
+			max:       32,
+			reserved:  0,
+		},
+		{
+			name:      "NewAllocationMapWithOffset max < 16",
+			allocator: NewAllocationMapWithOffset,
+			max:       8,
+			reserved:  0,
+		},
+		{
+			name:      "NewAllocationMapWithOffset max > 16",
+			allocator: NewAllocationMapWithOffset,
+			max:       128,
+			reserved:  16,
+		},
+		{
+			name:      "NewAllocationMapWithOffset max > 256",
+			allocator: NewAllocationMapWithOffset,
+			max:       1024,
+			reserved:  64,
+		},
+		{
+			name:      "NewAllocationMapWithOffset max value",
+			allocator: NewAllocationMapWithOffset,
+			max:       65535,
+			reserved:  256,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			m := tc.allocator(tc.max, "test", tc.reserved)
+			offset := 3
+			if ok, _ := m.Allocate(offset); !ok {
+				t.Errorf("error allocate offset %v", offset)
+			}
+
+			if !m.Has(offset) {
+				t.Errorf("expect offset %v allocated", offset)
+			}
+
+			if err := m.Release(offset); err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+
+			if m.Has(offset) {
+				t.Errorf("expect offset %v not allocated", offset)
+			}
+		})
+	}
+
+}
+
+func TestForEach(t *testing.T) {
+	testCases := []struct {
+		name      string
+		allocator func(max int, rangeSpec string, reserved int) *AllocationBitmap
+		max       int
+		reserved  int
+	}{
+		{
+			name:      "NewAllocationMap",
+			allocator: NewAllocationMapWithOffset,
+			max:       32,
+			reserved:  0,
+		},
+		{
+			name:      "NewAllocationMapWithOffset max < 16",
+			allocator: NewAllocationMapWithOffset,
+			max:       8,
+			reserved:  0,
+		},
+		{
+			name:      "NewAllocationMapWithOffset max > 16",
+			allocator: NewAllocationMapWithOffset,
+			max:       128,
+			reserved:  16,
+		},
+		{
+			name:      "NewAllocationMapWithOffset max > 256",
+			allocator: NewAllocationMapWithOffset,
+			max:       1024,
+			reserved:  64,
+		},
+		{
+			name:      "NewAllocationMapWithOffset max value",
+			allocator: NewAllocationMapWithOffset,
+			max:       65535,
+			reserved:  256,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			subTests := []sets.Int{
+				sets.NewInt(),
+				sets.NewInt(0),
+				sets.NewInt(0, 2, 5),
+				sets.NewInt(0, 1, 2, 3, 4, 5, 6, 7),
+			}
+
+			for i, ts := range subTests {
+				m := tc.allocator(tc.max, "test", tc.reserved)
+				for offset := range ts {
+					if ok, _ := m.Allocate(offset); !ok {
+						t.Errorf("[%d] error allocate offset %v", i, offset)
+					}
+					if !m.Has(offset) {
+						t.Errorf("[%d] expect offset %v allocated", i, offset)
+					}
+				}
+				calls := sets.NewInt()
+				m.ForEach(func(i int) {
+					calls.Insert(i)
+				})
+				if len(calls) != len(ts) {
+					t.Errorf("[%d] expected %d calls, got %d", i, len(ts), len(calls))
+				}
+				if !calls.Equal(ts) {
+					t.Errorf("[%d] expected calls to equal testcase: %v vs %v", i, calls.List(), ts.List())
+				}
+			}
+		})
+	}
+}
+
+func TestSnapshotAndRestore(t *testing.T) {
+	testCases := []struct {
+		name      string
+		allocator func(max int, rangeSpec string, reserved int) *AllocationBitmap
+		max       int
+		reserved  int
+	}{
+		{
+			name:      "NewAllocationMap",
+			allocator: NewAllocationMapWithOffset,
+			max:       32,
+			reserved:  0,
+		},
+		{
+			name:      "NewAllocationMapWithOffset max < 16",
+			allocator: NewAllocationMapWithOffset,
+			max:       8,
+			reserved:  0,
+		},
+		{
+			name:      "NewAllocationMapWithOffset max > 16",
+			allocator: NewAllocationMapWithOffset,
+			max:       128,
+			reserved:  16,
+		},
+		{
+			name:      "NewAllocationMapWithOffset max > 256",
+			allocator: NewAllocationMapWithOffset,
+			max:       1024,
+			reserved:  64,
+		},
+		{
+			name:      "NewAllocationMapWithOffset max value",
+			allocator: NewAllocationMapWithOffset,
+			max:       65535,
+			reserved:  256,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			m := tc.allocator(tc.max, "test", tc.reserved)
+			offset := 3
+			if ok, _ := m.Allocate(offset); !ok {
+				t.Errorf("error allocate offset %v", offset)
+			}
+			spec, bytes := m.Snapshot()
+
+			m2 := tc.allocator(10, "test", tc.reserved)
+			err := m2.Restore(spec, bytes)
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+
+			if m2.count != 1 {
+				t.Errorf("expect count to %d, but got %d", 0, m.count)
+			}
+			if !m2.Has(offset) {
+				t.Errorf("expect offset %v allocated", offset)
+			}
+		})
+	}
+
+}
+
+// TestAllocateMaxReserved should allocate first values greater or equal than the reserved values
+func TestAllocateMax_BitmapReserved(t *testing.T) {
+	max := 128
+	dynamicOffset := 16
+
+	// just to double check off by one errors
+	allocated := 0
+	// modify if necessary
+	m := NewAllocationMapWithOffset(max, "test", dynamicOffset)
+	for i := 0; i < max-dynamicOffset; i++ {
 		if _, ok, _ := m.AllocateNext(); !ok {
 			t.Fatalf("unexpected error")
 		}
+		allocated++
+	}
+
+	if f := m.Free(); f != dynamicOffset {
+		t.Errorf("expect to get %d, but got %d", dynamicOffset-1, f)
+	}
+
+	for i := 0; i < dynamicOffset; i++ {
+		if m.Has(i) {
+			t.Errorf("unexpected allocated value %d", i)
+		}
+	}
+	// it should allocate one value of the reserved block
+	if _, ok, _ := m.AllocateNext(); !ok {
+		t.Fatalf("unexpected error")
+	}
+	allocated++
+	if allocated != m.count {
+		t.Errorf("expect to get %d, but got %d", allocated, m.count)
+	}
+
+	if m.count != max-dynamicOffset+1 {
+		t.Errorf("expect to get %d, but got %d", max-dynamicOffset+1, m.count)
+	}
+	if f := m.Free(); f != max-allocated {
+		t.Errorf("expect to get %d, but got %d", max-allocated, f)
+	}
+}
+
+func TestPreAllocateReservedFull_BitmapReserved(t *testing.T) {
+	max := 128
+	dynamicOffset := 16
+	// just to double check off by one errors
+	allocated := 0
+	m := NewAllocationMapWithOffset(max, "test", dynamicOffset)
+	// Allocate all possible values except the reserved
+	for i := dynamicOffset; i < max; i++ {
+		if ok, _ := m.Allocate(i); !ok {
+			t.Errorf("error allocate i %v", i)
+		} else {
+			allocated++
+		}
+	}
+	// Allocate all the values of the reserved block except one
+	for i := 0; i < dynamicOffset-1; i++ {
+		if ok, _ := m.Allocate(i); !ok {
+			t.Errorf("error allocate i %v", i)
+		} else {
+			allocated++
+		}
+	}
+
+	// there should be only one free value
+	if f := m.Free(); f != 1 {
+		t.Errorf("expect to get %d, but got %d", 1, f)
+	}
+	// check if the last free value is in the lower band
+	count := 0
+	for i := 0; i < dynamicOffset; i++ {
+		if !m.Has(i) {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Errorf("expected one remaining free value, got %d", count)
+	}
+
+	if _, ok, _ := m.AllocateNext(); !ok {
+		t.Errorf("unexpected allocation error")
+	} else {
+		allocated++
+	}
+	if f := m.Free(); f != 0 {
+		t.Errorf("expect to get %d, but got %d", max-1, f)
 	}
 
 	if _, ok, _ := m.AllocateNext(); ok {
 		t.Errorf("unexpected success")
 	}
+	if m.count != allocated {
+		t.Errorf("expect to get %d, but got %d", max, m.count)
+	}
 	if f := m.Free(); f != 0 {
-		t.Errorf("expect to get %d, but got %d", 0, f)
-	}
-}
-
-func TestAllocateError(t *testing.T) {
-	m := NewAllocationMap(10, "test")
-	if ok, _ := m.Allocate(3); !ok {
-		t.Errorf("error allocate offset %v", 3)
-	}
-	if ok, _ := m.Allocate(3); ok {
-		t.Errorf("unexpected success")
-	}
-}
-
-func TestRelease(t *testing.T) {
-	offset := 3
-	m := NewAllocationMap(10, "test")
-	if ok, _ := m.Allocate(offset); !ok {
-		t.Errorf("error allocate offset %v", offset)
-	}
-
-	if !m.Has(offset) {
-		t.Errorf("expect offset %v allocated", offset)
-	}
-
-	if err := m.Release(offset); err != nil {
-		t.Errorf("unexpected error: %v", err)
-	}
-
-	if m.Has(offset) {
-		t.Errorf("expect offset %v not allocated", offset)
-	}
-}
-
-func TestForEach(t *testing.T) {
-	testCases := []sets.Int{
-		sets.NewInt(),
-		sets.NewInt(0),
-		sets.NewInt(0, 2, 5, 9),
-		sets.NewInt(0, 1, 2, 3, 4, 5, 6, 7, 8, 9),
-	}
-
-	for i, tc := range testCases {
-		m := NewAllocationMap(10, "test")
-		for offset := range tc {
-			if ok, _ := m.Allocate(offset); !ok {
-				t.Errorf("[%d] error allocate offset %v", i, offset)
-			}
-			if !m.Has(offset) {
-				t.Errorf("[%d] expect offset %v allocated", i, offset)
-			}
-		}
-		calls := sets.NewInt()
-		m.ForEach(func(i int) {
-			calls.Insert(i)
-		})
-		if len(calls) != len(tc) {
-			t.Errorf("[%d] expected %d calls, got %d", i, len(tc), len(calls))
-		}
-		if !calls.Equal(tc) {
-			t.Errorf("[%d] expected calls to equal testcase: %v vs %v", i, calls.List(), tc.List())
-		}
-	}
-}
-
-func TestSnapshotAndRestore(t *testing.T) {
-	offset := 3
-	m := NewAllocationMap(10, "test")
-	if ok, _ := m.Allocate(offset); !ok {
-		t.Errorf("error allocate offset %v", offset)
-	}
-	spec, bytes := m.Snapshot()
-
-	m2 := NewAllocationMap(10, "test")
-	err := m2.Restore(spec, bytes)
-	if err != nil {
-		t.Errorf("unexpected error: %v", err)
-	}
-
-	if m2.count != 1 {
-		t.Errorf("expect count to %d, but got %d", 0, m.count)
-	}
-	if !m2.Has(offset) {
-		t.Errorf("expect offset %v allocated", offset)
+		t.Errorf("expect to get %d, but got %d", max-1, f)
 	}
 }

--- a/pkg/registry/core/service/allocator/interfaces.go
+++ b/pkg/registry/core/service/allocator/interfaces.go
@@ -40,3 +40,5 @@ type Snapshottable interface {
 }
 
 type AllocatorFactory func(max int, rangeSpec string) (Interface, error)
+
+type AllocatorWithOffsetFactory func(max int, rangeSpec string, offset int) (Interface, error)

--- a/pkg/registry/core/service/ipallocator/metrics.go
+++ b/pkg/registry/core/service/ipallocator/metrics.go
@@ -51,7 +51,7 @@ var (
 		},
 		[]string{"cidr"},
 	)
-	// clusterIPAllocation counts the total number of ClusterIP allocation.
+	// clusterIPAllocation counts the total number of ClusterIP allocation and allocation mode: static or dynamic.
 	clusterIPAllocations = metrics.NewCounterVec(
 		&metrics.CounterOpts{
 			Namespace:      namespace,
@@ -60,9 +60,9 @@ var (
 			Help:           "Number of Cluster IPs allocations",
 			StabilityLevel: metrics.ALPHA,
 		},
-		[]string{"cidr"},
+		[]string{"cidr", "scope"},
 	)
-	// clusterIPAllocationErrors counts the number of error trying to allocate a ClusterIP.
+	// clusterIPAllocationErrors counts the number of error trying to allocate a ClusterIP and allocation mode: static or dynamic.
 	clusterIPAllocationErrors = metrics.NewCounterVec(
 		&metrics.CounterOpts{
 			Namespace:      namespace,
@@ -71,7 +71,7 @@ var (
 			Help:           "Number of errors trying to allocate Cluster IPs",
 			StabilityLevel: metrics.ALPHA,
 		},
-		[]string{"cidr"},
+		[]string{"cidr", "scope"},
 	)
 )
 


### PR DESCRIPTION
/kind feature

#### What this PR does / why we need it:

Fixes #95570

```release-note
New feature gate, ServiceIPStaticSubrange, to enable the new strategy in the Service IP allocators, so the IP range is subdivided and dynamic allocated ClusterIP addresses for Services are allocated preferently from the upper range.
```

KEP: https://github.com/kubernetes/enhancements/issues/3070

