### PR TITLE
kubelet: use newtimer instead in nodeshutdown manager

### DIFF
--- a/pkg/kubelet/nodeshutdown/nodeshutdown_manager_linux.go
+++ b/pkg/kubelet/nodeshutdown/nodeshutdown_manager_linux.go
@@ -326,15 +326,19 @@ func (m *managerImpl) processShutdownEvent() error {
 			}(pod, group)
 		}
 
-		c := make(chan struct{})
+		var (
+			doneCh = make(chan struct{})
+			timer  = m.clock.NewTimer(time.Duration(group.ShutdownGracePeriodSeconds) * time.Second)
+		)
 		go func() {
-			defer close(c)
+			defer close(doneCh)
 			wg.Wait()
 		}()
 
 		select {
-		case <-c:
-		case <-time.After(time.Duration(group.ShutdownGracePeriodSeconds) * time.Second):
+		case <-doneCh:
+			timer.Stop()
+		case <-timer.C():
 			klog.V(1).InfoS("Shutdown manager pod killing time out", "gracePeriod", group.ShutdownGracePeriodSeconds, "priority", group.Priority)
 		}
 	}


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

A time.After can't be cancelled so it has to run the full time specified. Besides, we should use `m.clock` as timer for better testability.
