### PR TITLE
Automated cherry pick of #106803: Revert dockershim CRI v1 changes

### DIFF
--- a/pkg/kubelet/cri/remote/conversion.go
+++ b/pkg/kubelet/cri/remote/conversion.go
@@ -44,14 +44,20 @@ func fromV1alpha2ContainerStatus(from *v1alpha2.ContainerStatus) *runtimeapi.Con
 }
 
 func fromV1alpha2ExecResponse(from *v1alpha2.ExecResponse) *runtimeapi.ExecResponse {
+	// If this function changes, also adapt the corresponding Exec dockershim code in
+	// pkg/kubelet/dockershim/docker_streaming.go
 	return (*runtimeapi.ExecResponse)(unsafe.Pointer(from))
 }
 
 func fromV1alpha2AttachResponse(from *v1alpha2.AttachResponse) *runtimeapi.AttachResponse {
+	// If this function changes, also adapt the corresponding Attach dockershim code in
+	// pkg/kubelet/dockershim/docker_streaming.go
 	return (*runtimeapi.AttachResponse)(unsafe.Pointer(from))
 }
 
 func fromV1alpha2PortForwardResponse(from *v1alpha2.PortForwardResponse) *runtimeapi.PortForwardResponse {
+	// If this function changes, also adapt the corresponding PortForward dockershim code in
+	// pkg/kubelet/dockershim/docker_streaming.go
 	return (*runtimeapi.PortForwardResponse)(unsafe.Pointer(from))
 }
 
@@ -108,14 +114,20 @@ func v1alpha2LinuxContainerResources(from *runtimeapi.LinuxContainerResources) *
 }
 
 func v1alpha2ExecRequest(from *runtimeapi.ExecRequest) *v1alpha2.ExecRequest {
+	// If this function changes, also adapt the corresponding Exec dockershim code in
+	// pkg/kubelet/dockershim/docker_streaming.go
 	return (*v1alpha2.ExecRequest)(unsafe.Pointer(from))
 }
 
 func v1alpha2AttachRequest(from *runtimeapi.AttachRequest) *v1alpha2.AttachRequest {
+	// If this function changes, also adapt the corresponding Attach dockershim code in
+	// pkg/kubelet/dockershim/docker_streaming.go
 	return (*v1alpha2.AttachRequest)(unsafe.Pointer(from))
 }
 
 func v1alpha2PortForwardRequest(from *runtimeapi.PortForwardRequest) *v1alpha2.PortForwardRequest {
+	// If this function changes, also adapt the corresponding PortForward dockershim code in
+	// pkg/kubelet/dockershim/docker_streaming.go
 	return (*v1alpha2.PortForwardRequest)(unsafe.Pointer(from))
 }
 

--- a/pkg/kubelet/dockershim/convert.go
+++ b/pkg/kubelet/dockershim/convert.go
@@ -26,7 +26,7 @@ import (
 
 	dockertypes "github.com/docker/docker/api/types"
 
-	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
+	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
 	"k8s.io/kubernetes/pkg/kubelet/dockershim/libdocker"
 )
 

--- a/pkg/kubelet/dockershim/convert_test.go
+++ b/pkg/kubelet/dockershim/convert_test.go
@@ -25,7 +25,7 @@ import (
 	dockertypes "github.com/docker/docker/api/types"
 	"github.com/stretchr/testify/assert"
 
-	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
+	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
 )
 
 func TestConvertDockerStatusToRuntimeAPIState(t *testing.T) {

--- a/pkg/kubelet/dockershim/docker_container.go
+++ b/pkg/kubelet/dockershim/docker_container.go
@@ -32,7 +32,7 @@ import (
 	dockerstrslice "github.com/docker/docker/api/types/strslice"
 	"k8s.io/klog/v2"
 
-	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
+	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
 	"k8s.io/kubernetes/pkg/kubelet/dockershim/libdocker"
 )
 

--- a/pkg/kubelet/dockershim/docker_container_test.go
+++ b/pkg/kubelet/dockershim/docker_container_test.go
@@ -32,7 +32,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
+	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
 	containertest "k8s.io/kubernetes/pkg/kubelet/container/testing"
 )
 

--- a/pkg/kubelet/dockershim/docker_container_unsupported.go
+++ b/pkg/kubelet/dockershim/docker_container_unsupported.go
@@ -21,7 +21,7 @@ package dockershim
 
 import (
 	dockertypes "github.com/docker/docker/api/types"
-	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
+	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
 )
 
 type containerCleanupInfo struct{}

--- a/pkg/kubelet/dockershim/docker_container_windows.go
+++ b/pkg/kubelet/dockershim/docker_container_windows.go
@@ -30,7 +30,7 @@ import (
 	dockertypes "github.com/docker/docker/api/types"
 	dockercontainer "github.com/docker/docker/api/types/container"
 
-	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
+	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
 )
 
 type containerCleanupInfo struct {

--- a/pkg/kubelet/dockershim/docker_container_windows_test.go
+++ b/pkg/kubelet/dockershim/docker_container_windows_test.go
@@ -29,7 +29,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/sys/windows/registry"
-	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
+	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
 )
 
 type dummyRegistryKey struct {

--- a/pkg/kubelet/dockershim/docker_image.go
+++ b/pkg/kubelet/dockershim/docker_image.go
@@ -28,7 +28,7 @@ import (
 	dockerfilters "github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/pkg/jsonmessage"
 
-	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
+	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
 	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/pkg/kubelet/dockershim/libdocker"
 )

--- a/pkg/kubelet/dockershim/docker_image_linux.go
+++ b/pkg/kubelet/dockershim/docker_image_linux.go
@@ -25,7 +25,7 @@ import (
 	"path/filepath"
 	"time"
 
-	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
+	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
 )
 
 // ImageFsInfo returns information of the filesystem that is used to store images.

--- a/pkg/kubelet/dockershim/docker_image_test.go
+++ b/pkg/kubelet/dockershim/docker_image_test.go
@@ -28,7 +28,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
+	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
 	"k8s.io/kubernetes/pkg/kubelet/dockershim/libdocker"
 )
 

--- a/pkg/kubelet/dockershim/docker_image_unsupported.go
+++ b/pkg/kubelet/dockershim/docker_image_unsupported.go
@@ -23,7 +23,7 @@ import (
 	"context"
 	"fmt"
 
-	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
+	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
 )
 
 // ImageFsInfo returns information of the filesystem that is used to store images.

--- a/pkg/kubelet/dockershim/docker_image_windows.go
+++ b/pkg/kubelet/dockershim/docker_image_windows.go
@@ -25,7 +25,7 @@ import (
 
 	"k8s.io/klog/v2"
 
-	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
+	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
 	"k8s.io/kubernetes/pkg/kubelet/winstats"
 )
 

--- a/pkg/kubelet/dockershim/docker_logs.go
+++ b/pkg/kubelet/dockershim/docker_logs.go
@@ -23,7 +23,7 @@ import (
 	"context"
 	"fmt"
 
-	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
+	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
 )
 
 // ReopenContainerLog reopens the container log file.

--- a/pkg/kubelet/dockershim/docker_sandbox.go
+++ b/pkg/kubelet/dockershim/docker_sandbox.go
@@ -31,7 +31,7 @@ import (
 	dockercontainer "github.com/docker/docker/api/types/container"
 	dockerfilters "github.com/docker/docker/api/types/filters"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
-	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
+	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
 	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/pkg/kubelet/checkpointmanager"
 	"k8s.io/kubernetes/pkg/kubelet/checkpointmanager/errors"

--- a/pkg/kubelet/dockershim/docker_sandbox_test.go
+++ b/pkg/kubelet/dockershim/docker_sandbox_test.go
@@ -31,7 +31,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
+	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
 	"k8s.io/kubernetes/pkg/kubelet/dockershim/libdocker"
 	"k8s.io/kubernetes/pkg/kubelet/dockershim/network"

--- a/pkg/kubelet/dockershim/docker_service.go
+++ b/pkg/kubelet/dockershim/docker_service.go
@@ -35,7 +35,7 @@ import (
 	"k8s.io/klog/v2"
 
 	v1 "k8s.io/api/core/v1"
-	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
+	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
 	kubeletconfig "k8s.io/kubernetes/pkg/kubelet/apis/config"
 	"k8s.io/kubernetes/pkg/kubelet/checkpointmanager"
 	"k8s.io/kubernetes/pkg/kubelet/checkpointmanager/errors"

--- a/pkg/kubelet/dockershim/docker_service_test.go
+++ b/pkg/kubelet/dockershim/docker_service_test.go
@@ -30,7 +30,7 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
+	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
 	"k8s.io/kubernetes/pkg/kubelet/checkpointmanager"
 	containertest "k8s.io/kubernetes/pkg/kubelet/container/testing"
 	"k8s.io/kubernetes/pkg/kubelet/dockershim/libdocker"

--- a/pkg/kubelet/dockershim/docker_stats.go
+++ b/pkg/kubelet/dockershim/docker_stats.go
@@ -24,7 +24,7 @@ import (
 	"errors"
 	"fmt"
 
-	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
+	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
 )
 
 var ErrNotImplemented = errors.New("Not implemented")

--- a/pkg/kubelet/dockershim/docker_stats_linux.go
+++ b/pkg/kubelet/dockershim/docker_stats_linux.go
@@ -22,7 +22,7 @@ package dockershim
 import (
 	"time"
 
-	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
+	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
 )
 
 func (ds *dockerService) getContainerStats(c *runtimeapi.Container) (*runtimeapi.ContainerStats, error) {

--- a/pkg/kubelet/dockershim/docker_stats_test.go
+++ b/pkg/kubelet/dockershim/docker_stats_test.go
@@ -25,7 +25,7 @@ import (
 	dockertypes "github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
 	"github.com/stretchr/testify/assert"
-	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
+	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
 	"k8s.io/kubernetes/pkg/kubelet/dockershim/libdocker"
 )
 

--- a/pkg/kubelet/dockershim/docker_stats_unsupported.go
+++ b/pkg/kubelet/dockershim/docker_stats_unsupported.go
@@ -22,7 +22,7 @@ package dockershim
 import (
 	"fmt"
 
-	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
+	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
 )
 
 func (ds *dockerService) getContainerStats(c *runtimeapi.Container) (*runtimeapi.ContainerStats, error) {

--- a/pkg/kubelet/dockershim/docker_stats_windows.go
+++ b/pkg/kubelet/dockershim/docker_stats_windows.go
@@ -24,7 +24,7 @@ import (
 	"time"
 
 	"github.com/Microsoft/hcsshim"
-	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
+	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
 	"k8s.io/klog/v2"
 )
 

--- a/pkg/kubelet/dockershim/helpers.go
+++ b/pkg/kubelet/dockershim/helpers.go
@@ -36,7 +36,7 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
-	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
+	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
 	"k8s.io/kubernetes/pkg/credentialprovider"
 	"k8s.io/kubernetes/pkg/kubelet/dockershim/libdocker"
 	"k8s.io/kubernetes/pkg/kubelet/types"

--- a/pkg/kubelet/dockershim/helpers_linux.go
+++ b/pkg/kubelet/dockershim/helpers_linux.go
@@ -32,7 +32,7 @@ import (
 	dockertypes "github.com/docker/docker/api/types"
 	dockercontainer "github.com/docker/docker/api/types/container"
 	v1 "k8s.io/api/core/v1"
-	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
+	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
 )
 
 // DefaultMemorySwap always returns 0 for no memory swap in a sandbox

--- a/pkg/kubelet/dockershim/helpers_test.go
+++ b/pkg/kubelet/dockershim/helpers_test.go
@@ -31,8 +31,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"k8s.io/api/core/v1"
-	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
+	v1 "k8s.io/api/core/v1"
+	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
 	"k8s.io/kubernetes/pkg/kubelet/dockershim/libdocker"
 )
 

--- a/pkg/kubelet/dockershim/helpers_unsupported.go
+++ b/pkg/kubelet/dockershim/helpers_unsupported.go
@@ -24,7 +24,7 @@ import (
 
 	"github.com/blang/semver"
 	dockertypes "github.com/docker/docker/api/types"
-	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
+	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
 	"k8s.io/klog/v2"
 )
 

--- a/pkg/kubelet/dockershim/helpers_windows.go
+++ b/pkg/kubelet/dockershim/helpers_windows.go
@@ -29,7 +29,7 @@ import (
 	dockerfilters "github.com/docker/docker/api/types/filters"
 	"k8s.io/klog/v2"
 
-	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
+	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
 )
 
 // DefaultMemorySwap always returns 0 for no memory swap in a sandbox

--- a/pkg/kubelet/dockershim/naming.go
+++ b/pkg/kubelet/dockershim/naming.go
@@ -25,7 +25,7 @@ import (
 	"strconv"
 	"strings"
 
-	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
+	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
 	"k8s.io/kubernetes/pkg/kubelet/leaky"
 )
 

--- a/pkg/kubelet/dockershim/naming_test.go
+++ b/pkg/kubelet/dockershim/naming_test.go
@@ -24,7 +24,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
+	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
 )
 
 func TestSandboxNameRoundTrip(t *testing.T) {

--- a/pkg/kubelet/dockershim/network/cni/cni.go
+++ b/pkg/kubelet/dockershim/network/cni/cni.go
@@ -32,7 +32,7 @@ import (
 	"github.com/containernetworking/cni/libcni"
 	cnitypes "github.com/containernetworking/cni/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
-	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
+	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
 	"k8s.io/klog/v2"
 	kubeletconfig "k8s.io/kubernetes/pkg/kubelet/apis/config"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"

--- a/pkg/kubelet/dockershim/network/cni/cni_others.go
+++ b/pkg/kubelet/dockershim/network/cni/cni_others.go
@@ -23,7 +23,7 @@ import (
 	"fmt"
 
 	"github.com/containernetworking/cni/libcni"
-	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
+	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
 	"k8s.io/kubernetes/pkg/kubelet/dockershim/network"
 )

--- a/pkg/kubelet/dockershim/network/cni/cni_windows.go
+++ b/pkg/kubelet/dockershim/network/cni/cni_windows.go
@@ -23,7 +23,7 @@ import (
 	"context"
 	"fmt"
 	cniTypes020 "github.com/containernetworking/cni/pkg/types/020"
-	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
+	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
 	"k8s.io/klog/v2"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
 	"k8s.io/kubernetes/pkg/kubelet/dockershim/network"

--- a/pkg/kubelet/dockershim/remote/docker_server.go
+++ b/pkg/kubelet/dockershim/remote/docker_server.go
@@ -24,7 +24,7 @@ import (
 	"os"
 
 	"google.golang.org/grpc"
-	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
+	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
 	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/pkg/kubelet/dockershim"
 	"k8s.io/kubernetes/pkg/kubelet/util"

--- a/pkg/kubelet/dockershim/remote/docker_server_test.go
+++ b/pkg/kubelet/dockershim/remote/docker_server_test.go
@@ -1,0 +1,174 @@
+//go:build !dockerless
+// +build !dockerless
+
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package remote
+
+import (
+	"context"
+	"io/ioutil"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/grpc"
+
+	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+)
+
+func TestServer(t *testing.T) {
+	file, err := ioutil.TempFile("", "docker-server-")
+	assert.Nil(t, err)
+	endpoint := "unix://" + file.Name()
+
+	server := NewDockerServer(endpoint, &fakeCRIService{})
+	assert.Nil(t, server.Start())
+
+	ctx := context.Background()
+	conn, err := grpc.Dial(endpoint, grpc.WithInsecure())
+	assert.Nil(t, err)
+
+	runtimeClient := runtimeapi.NewRuntimeServiceClient(conn)
+	_, err = runtimeClient.Version(ctx, &runtimeapi.VersionRequest{})
+	assert.Nil(t, err)
+
+	imageClient := runtimeapi.NewImageServiceClient(conn)
+	_, err = imageClient.ImageFsInfo(ctx, &runtimeapi.ImageFsInfoRequest{})
+	assert.Nil(t, err)
+}
+
+type fakeCRIService struct{}
+
+func (*fakeCRIService) Start() error {
+	return nil
+}
+
+func (*fakeCRIService) Version(context.Context, *runtimeapi.VersionRequest) (*runtimeapi.VersionResponse, error) {
+	return &runtimeapi.VersionResponse{}, nil
+}
+
+func (*fakeCRIService) RunPodSandbox(context.Context, *runtimeapi.RunPodSandboxRequest) (*runtimeapi.RunPodSandboxResponse, error) {
+	return nil, nil
+}
+
+func (*fakeCRIService) StopPodSandbox(context.Context, *runtimeapi.StopPodSandboxRequest) (*runtimeapi.StopPodSandboxResponse, error) {
+	return nil, nil
+}
+
+func (*fakeCRIService) RemovePodSandbox(context.Context, *runtimeapi.RemovePodSandboxRequest) (*runtimeapi.RemovePodSandboxResponse, error) {
+	return nil, nil
+}
+
+func (*fakeCRIService) PodSandboxStatus(context.Context, *runtimeapi.PodSandboxStatusRequest) (*runtimeapi.PodSandboxStatusResponse, error) {
+	return nil, nil
+}
+
+func (*fakeCRIService) ListPodSandbox(context.Context, *runtimeapi.ListPodSandboxRequest) (*runtimeapi.ListPodSandboxResponse, error) {
+	return nil, nil
+}
+
+func (*fakeCRIService) CreateContainer(context.Context, *runtimeapi.CreateContainerRequest) (*runtimeapi.CreateContainerResponse, error) {
+	return nil, nil
+}
+
+func (*fakeCRIService) StartContainer(context.Context, *runtimeapi.StartContainerRequest) (*runtimeapi.StartContainerResponse, error) {
+	return nil, nil
+}
+
+func (*fakeCRIService) StopContainer(context.Context, *runtimeapi.StopContainerRequest) (*runtimeapi.StopContainerResponse, error) {
+	return nil, nil
+}
+
+func (*fakeCRIService) RemoveContainer(context.Context, *runtimeapi.RemoveContainerRequest) (*runtimeapi.RemoveContainerResponse, error) {
+	return nil, nil
+}
+
+func (*fakeCRIService) ListContainers(context.Context, *runtimeapi.ListContainersRequest) (*runtimeapi.ListContainersResponse, error) {
+	return nil, nil
+}
+
+func (*fakeCRIService) ContainerStatus(context.Context, *runtimeapi.ContainerStatusRequest) (*runtimeapi.ContainerStatusResponse, error) {
+	return nil, nil
+}
+
+func (*fakeCRIService) UpdateContainerResources(context.Context, *runtimeapi.UpdateContainerResourcesRequest) (*runtimeapi.UpdateContainerResourcesResponse, error) {
+	return nil, nil
+}
+
+func (*fakeCRIService) ReopenContainerLog(context.Context, *runtimeapi.ReopenContainerLogRequest) (*runtimeapi.ReopenContainerLogResponse, error) {
+	return nil, nil
+}
+
+func (*fakeCRIService) ExecSync(context.Context, *runtimeapi.ExecSyncRequest) (*runtimeapi.ExecSyncResponse, error) {
+	return nil, nil
+}
+
+func (*fakeCRIService) Exec(context.Context, *runtimeapi.ExecRequest) (*runtimeapi.ExecResponse, error) {
+	return nil, nil
+}
+
+func (*fakeCRIService) Attach(context.Context, *runtimeapi.AttachRequest) (*runtimeapi.AttachResponse, error) {
+	return nil, nil
+}
+
+func (*fakeCRIService) PortForward(context.Context, *runtimeapi.PortForwardRequest) (*runtimeapi.PortForwardResponse, error) {
+	return nil, nil
+}
+
+func (*fakeCRIService) ContainerStats(context.Context, *runtimeapi.ContainerStatsRequest) (*runtimeapi.ContainerStatsResponse, error) {
+	return nil, nil
+}
+
+func (*fakeCRIService) ListContainerStats(context.Context, *runtimeapi.ListContainerStatsRequest) (*runtimeapi.ListContainerStatsResponse, error) {
+	return nil, nil
+}
+
+func (*fakeCRIService) PodSandboxStats(context.Context, *runtimeapi.PodSandboxStatsRequest) (*runtimeapi.PodSandboxStatsResponse, error) {
+	return nil, nil
+}
+
+func (*fakeCRIService) ListPodSandboxStats(context.Context, *runtimeapi.ListPodSandboxStatsRequest) (*runtimeapi.ListPodSandboxStatsResponse, error) {
+	return nil, nil
+}
+
+func (*fakeCRIService) UpdateRuntimeConfig(context.Context, *runtimeapi.UpdateRuntimeConfigRequest) (*runtimeapi.UpdateRuntimeConfigResponse, error) {
+	return nil, nil
+}
+
+func (*fakeCRIService) Status(context.Context, *runtimeapi.StatusRequest) (*runtimeapi.StatusResponse, error) {
+	return nil, nil
+}
+
+func (*fakeCRIService) ListImages(context.Context, *runtimeapi.ListImagesRequest) (*runtimeapi.ListImagesResponse, error) {
+	return nil, nil
+}
+
+func (*fakeCRIService) ImageStatus(context.Context, *runtimeapi.ImageStatusRequest) (*runtimeapi.ImageStatusResponse, error) {
+	return nil, nil
+}
+
+func (*fakeCRIService) PullImage(context.Context, *runtimeapi.PullImageRequest) (*runtimeapi.PullImageResponse, error) {
+	return nil, nil
+}
+
+func (*fakeCRIService) RemoveImage(context.Context, *runtimeapi.RemoveImageRequest) (*runtimeapi.RemoveImageResponse, error) {
+	return nil, nil
+}
+
+func (*fakeCRIService) ImageFsInfo(context.Context, *runtimeapi.ImageFsInfoRequest) (*runtimeapi.ImageFsInfoResponse, error) {
+	return &runtimeapi.ImageFsInfoResponse{}, nil
+}

--- a/pkg/kubelet/dockershim/security_context.go
+++ b/pkg/kubelet/dockershim/security_context.go
@@ -25,7 +25,7 @@ import (
 
 	dockercontainer "github.com/docker/docker/api/types/container"
 
-	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
+	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
 	knetwork "k8s.io/kubernetes/pkg/kubelet/dockershim/network"
 )
 

--- a/pkg/kubelet/dockershim/security_context_test.go
+++ b/pkg/kubelet/dockershim/security_context_test.go
@@ -27,7 +27,7 @@ import (
 	dockercontainer "github.com/docker/docker/api/types/container"
 	"github.com/stretchr/testify/assert"
 
-	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
+	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
 )
 
 func TestModifyContainerConfig(t *testing.T) {

--- a/pkg/kubelet/dockershim/selinux_util.go
+++ b/pkg/kubelet/dockershim/selinux_util.go
@@ -22,7 +22,7 @@ package dockershim
 import (
 	"fmt"
 
-	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
+	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
 )
 
 // selinuxLabelUser returns the fragment of a Docker security opt that


### PR DESCRIPTION
Cherry pick of #106803 on release-1.23.

#106803: Revert dockershim CRI v1 changes

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
Fixes 1.23 regression to revert the CRI API version surfaced by dockershim to v1alpha2
```
