### PR TITLE
refactor wait into Waiter interface

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/delete/delete.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/delete/delete.go
@@ -374,9 +374,9 @@ func (o *DeleteOptions) DeleteResult(r *resource.Result) error {
 		DynamicClient:  o.DynamicClient,
 		Timeout:        effectiveTimeout,
 
-		Printer:     printers.NewDiscardingPrinter(),
-		ConditionFn: cmdwait.IsDeleted,
-		IOStreams:   o.IOStreams,
+		Printer:   printers.NewDiscardingPrinter(),
+		Waiter:    cmdwait.NewDeletionWaiter(o.ErrOut),
+		IOStreams: o.IOStreams,
 	}
 	err = waitOptions.RunWait()
 	if errors.IsForbidden(err) || errors.IsMethodNotSupported(err) {

--- a/staging/src/k8s.io/kubectl/pkg/cmd/wait/conditional_waiter.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/wait/conditional_waiter.go
@@ -1,0 +1,97 @@
+package wait
+
+import (
+	"fmt"
+	"io"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/cli-runtime/pkg/resource"
+)
+
+// ConditionalWaiter hold information to check an API status condition
+type ConditionalWaiter struct {
+	conditionName   string
+	conditionStatus string
+	// errOut is written to if an error occurs
+	errOut io.Writer
+}
+
+func NewConditionalWaiter(name, value string, errOut io.Writer) Waiter {
+	return ConditionalWaiter{
+		conditionName:   name,
+		conditionStatus: value,
+		errOut:          errOut,
+	}
+}
+
+func (w ConditionalWaiter) VisitResource(info *resource.Info, o *WaitOptions) (runtime.Object, bool, error) {
+	return getObjAndCheckCondition(info, o, w.isConditionMet, w.checkCondition)
+}
+
+func (w ConditionalWaiter) OnWaitLoopCompletion(visitedCount int, err error) error {
+	if visitedCount == 0 {
+		return errNoMatchingResources
+	} else {
+		return err
+	}
+}
+
+func (w ConditionalWaiter) checkCondition(obj *unstructured.Unstructured) (bool, error) {
+	conditions, found, err := unstructured.NestedSlice(obj.Object, "status", "conditions")
+	if err != nil {
+		return false, err
+	}
+	if !found {
+		return false, nil
+	}
+	for _, conditionUncast := range conditions {
+		condition := conditionUncast.(map[string]interface{})
+		name, found, err := unstructured.NestedString(condition, "type")
+		if !found || err != nil || !strings.EqualFold(name, w.conditionName) {
+			continue
+		}
+		status, found, err := unstructured.NestedString(condition, "status")
+		if !found || err != nil {
+			continue
+		}
+		generation, found, _ := unstructured.NestedInt64(obj.Object, "metadata", "generation")
+		if found {
+			observedGeneration, found := getObservedGeneration(obj, condition)
+			if found && observedGeneration < generation {
+				return false, nil
+			}
+		}
+		return strings.EqualFold(status, w.conditionStatus), nil
+	}
+
+	return false, nil
+}
+
+func (w ConditionalWaiter) isConditionMet(event watch.Event) (bool, error) {
+	if event.Type == watch.Error {
+		// keep waiting in the event we see an error - we expect the watch to be closed by
+		// the server
+		err := errors.FromObject(event.Object)
+		fmt.Fprintf(w.errOut, "error: An error occurred while waiting for the condition to be satisfied: %v", err)
+		return false, nil
+	}
+	if event.Type == watch.Deleted {
+		// this will chain back out, result in another get and an return false back up the chain
+		return false, nil
+	}
+	obj := event.Object.(*unstructured.Unstructured)
+	return w.checkCondition(obj)
+}
+
+func getObservedGeneration(obj *unstructured.Unstructured, condition map[string]interface{}) (int64, bool) {
+	conditionObservedGeneration, found, _ := unstructured.NestedInt64(condition, "observedGeneration")
+	if found {
+		return conditionObservedGeneration, true
+	}
+	statusObservedGeneration, found, _ := unstructured.NestedInt64(obj.Object, "status", "observedGeneration")
+	return statusObservedGeneration, found
+}

--- a/staging/src/k8s.io/kubectl/pkg/cmd/wait/deletion_waiter.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/wait/deletion_waiter.go
@@ -1,0 +1,116 @@
+package wait
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"time"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
+	watch2 "k8s.io/apimachinery/pkg/watch"
+	"k8s.io/cli-runtime/pkg/resource"
+	"k8s.io/client-go/tools/watch"
+)
+
+type DeletionWaiter struct {
+	errOut io.Writer
+}
+
+func NewDeletionWaiter(errOut io.Writer) Waiter {
+	return DeletionWaiter{errOut}
+}
+
+func (d DeletionWaiter) VisitResource(info *resource.Info, o *WaitOptions) (runtime.Object, bool, error) {
+	endTime := time.Now().Add(o.Timeout)
+	for {
+		if len(info.Name) == 0 {
+			return info.Object, false, fmt.Errorf("resource name must be provided")
+		}
+
+		nameSelector := fields.OneTermEqualSelector("metadata.name", info.Name).String()
+
+		// List with a name field selector to get the current resourceVersion to watch from (not the object's resourceVersion)
+		gottenObjList, err := o.DynamicClient.Resource(info.Mapping.Resource).Namespace(info.Namespace).List(context.TODO(), v1.ListOptions{FieldSelector: nameSelector})
+		if apierrors.IsNotFound(err) {
+			return info.Object, true, nil
+		}
+		if err != nil {
+			// TODO this could do something slightly fancier if we wish
+			return info.Object, false, err
+		}
+		if len(gottenObjList.Items) != 1 {
+			return info.Object, true, nil
+		}
+		gottenObj := &gottenObjList.Items[0]
+		resourceLocation := ResourceLocation{
+			GroupResource: info.Mapping.Resource.GroupResource(),
+			Namespace:     gottenObj.GetNamespace(),
+			Name:          gottenObj.GetName(),
+		}
+		if uid, ok := o.UIDMap[resourceLocation]; ok {
+			if gottenObj.GetUID() != uid {
+				return gottenObj, true, nil
+			}
+		}
+
+		watchOptions := v1.ListOptions{}
+		watchOptions.FieldSelector = nameSelector
+		watchOptions.ResourceVersion = gottenObjList.GetResourceVersion()
+		objWatch, err := o.DynamicClient.Resource(info.Mapping.Resource).Namespace(info.Namespace).Watch(context.TODO(), watchOptions)
+		if err != nil {
+			return gottenObj, false, err
+		}
+
+		timeout := endTime.Sub(time.Now())
+		errWaitTimeoutWithName := extendErrWaitTimeout(wait.ErrWaitTimeout, info)
+		if timeout < 0 {
+			// we're out of time
+			return gottenObj, false, errWaitTimeoutWithName
+		}
+
+		ctx, cancel := watch.ContextWithOptionalTimeout(context.Background(), o.Timeout)
+		watchEvent, err := watch.UntilWithoutRetry(ctx, objWatch, d.IsDeleted)
+		cancel()
+		switch {
+		case err == nil:
+			return watchEvent.Object, true, nil
+		case err == watch.ErrWatchClosed:
+			continue
+		case err == wait.ErrWaitTimeout:
+			if watchEvent != nil {
+				return watchEvent.Object, false, errWaitTimeoutWithName
+			}
+			return gottenObj, false, errWaitTimeoutWithName
+		default:
+			return gottenObj, false, err
+		}
+	}
+}
+
+func (d DeletionWaiter) OnWaitLoopCompletion(visitedCount int, err error) error {
+	if apierrors.IsNotFound(err) || err == nil {
+		return nil
+	} else {
+		return err
+	}
+}
+
+// IsDeleted returns true if the object is deleted. It prints any errors it encounters.
+func (d DeletionWaiter) IsDeleted(event watch2.Event) (bool, error) {
+	switch event.Type {
+	case watch2.Error:
+		// keep waiting in the event we see an error - we expect the watch to be closed by
+		// the server if the error is unrecoverable.
+		err := apierrors.FromObject(event.Object)
+		fmt.Fprintf(d.errOut, "error: An error occurred while waiting for the object to be deleted: %v", err)
+		return false, nil
+	case watch2.Deleted:
+		return true, nil
+	default:
+		return false, nil
+	}
+}

--- a/staging/src/k8s.io/kubectl/pkg/cmd/wait/jsonpath_waiter.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/wait/jsonpath_waiter.go
@@ -1,0 +1,119 @@
+package wait
+
+import (
+	errors2 "errors"
+	"fmt"
+	"io"
+	"reflect"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/cli-runtime/pkg/resource"
+	"k8s.io/client-go/util/jsonpath"
+)
+
+// JSONPathWaiter holds a JSONPath Parser which has the ability
+// to check for the JSONPath condition and compare with the API server provided JSON output.
+type JSONPathWaiter struct {
+	jsonPathCondition string
+	jsonPathParser    *jsonpath.JSONPath
+	// errOut is written to if an error occurs
+	errOut io.Writer
+}
+
+func NewJSONPathWaiter(jsonPathCond string, j *jsonpath.JSONPath, errOut io.Writer) Waiter {
+	return &JSONPathWaiter{
+		jsonPathCondition: jsonPathCond,
+		jsonPathParser:    j,
+		errOut:            errOut,
+	}
+}
+
+func (j JSONPathWaiter) VisitResource(info *resource.Info, o *WaitOptions) (runtime.Object, bool, error) {
+	return getObjAndCheckCondition(info, o, j.isJSONPathConditionMet, j.checkCondition)
+}
+
+// IsJSONPathConditionMet fulfills the requirements of the interface ConditionFunc which provides condition check
+//func (j JSONPathWaiter) IsJSONPathConditionMet(info *resource.Info, o *WaitOptions) (runtime.Object, bool, error) {
+//	return getObjAndCheckCondition(info, o, j.isJSONPathConditionMet, j.checkCondition)
+//}
+
+func (j JSONPathWaiter) OnWaitLoopCompletion(visitedCount int, err error) error {
+	if visitedCount == 0 {
+		return errNoMatchingResources
+	} else {
+		return err
+	}
+}
+
+// isJSONPathConditionMet is a helper function of IsJSONPathConditionMet
+// which check the watch event and check if a JSONPathWaiter condition is met
+func (j JSONPathWaiter) isJSONPathConditionMet(event watch.Event) (bool, error) {
+	if event.Type == watch.Error {
+		// keep waiting in the event we see an error - we expect the watch to be closed by
+		// the server
+		err := errors.FromObject(event.Object)
+		fmt.Fprintf(j.errOut, "error: An error occurred while waiting for the condition to be satisfied: %v", err)
+		return false, nil
+	}
+	if event.Type == watch.Deleted {
+		// this will chain back out, result in another get and an return false back up the chain
+		return false, nil
+	}
+	// event runtime Object can be safely asserted to Unstructed
+	// because we are working with dynamic client
+	obj := event.Object.(*unstructured.Unstructured)
+	return j.checkCondition(obj)
+}
+
+// checkCondition uses JSONPath parser to parse the JSON received from the API server
+// and check if it matches the desired condition
+func (j JSONPathWaiter) checkCondition(obj *unstructured.Unstructured) (bool, error) {
+	queryObj := obj.UnstructuredContent()
+	parseResults, err := j.jsonPathParser.FindResults(queryObj)
+	if err != nil {
+		return false, err
+	}
+	if err := verifyParsedJSONPath(parseResults); err != nil {
+		return false, err
+	}
+	isConditionMet, err := compareResults(parseResults[0][0], j.jsonPathCondition)
+	if err != nil {
+		return false, err
+	}
+	return isConditionMet, nil
+}
+
+// verifyParsedJSONPath verifies the JSON received from the API server is valid.
+// It will only accept a single JSON
+func verifyParsedJSONPath(results [][]reflect.Value) error {
+	if len(results) == 0 {
+		return errors2.New("given jsonpath expression does not match any value")
+	}
+	if len(results) > 1 {
+		return errors2.New("given jsonpath expression matches more than one list")
+	}
+	if len(results[0]) > 1 {
+		return errors2.New("given jsonpath expression matches more than one value")
+	}
+	return nil
+}
+
+// compareResults will compare the reflect.Value from the result parsed by the
+// JSONPath parser with the expected value given by the value
+//
+// Since this is coming from an unstructured this can only ever be a primitive,
+// map[string]interface{}, or []interface{}.
+// We do not support the last two and rely on fmt to handle conversion to string
+// and compare the result with user input
+func compareResults(r reflect.Value, expectedVal string) (bool, error) {
+	switch r.Interface().(type) {
+	case map[string]interface{}, []interface{}:
+		return false, errors2.New("jsonpath leads to a nested object or list which is not supported")
+	}
+	s := fmt.Sprintf("%v", r.Interface())
+	return strings.TrimSpace(s) == strings.TrimSpace(expectedVal), nil
+}

--- a/staging/src/k8s.io/kubectl/pkg/cmd/wait/jsonpath_waiter.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/wait/jsonpath_waiter.go
@@ -36,11 +36,6 @@ func (j JSONPathWaiter) VisitResource(info *resource.Info, o *WaitOptions) (runt
 	return getObjAndCheckCondition(info, o, j.isJSONPathConditionMet, j.checkCondition)
 }
 
-// IsJSONPathConditionMet fulfills the requirements of the interface ConditionFunc which provides condition check
-//func (j JSONPathWaiter) IsJSONPathConditionMet(info *resource.Info, o *WaitOptions) (runtime.Object, bool, error) {
-//	return getObjAndCheckCondition(info, o, j.isJSONPathConditionMet, j.checkCondition)
-//}
-
 func (j JSONPathWaiter) OnWaitLoopCompletion(visitedCount int, err error) error {
 	if visitedCount == 0 {
 		return errNoMatchingResources

--- a/staging/src/k8s.io/kubectl/pkg/cmd/wait/wait.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/wait/wait.go
@@ -20,14 +20,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io"
-	"reflect"
-	"strings"
 	"time"
 
 	"github.com/spf13/cobra"
 
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/fields"
@@ -41,8 +37,6 @@ import (
 	"k8s.io/cli-runtime/pkg/resource"
 	"k8s.io/client-go/dynamic"
 	watchtools "k8s.io/client-go/tools/watch"
-	"k8s.io/client-go/util/jsonpath"
-	cmdget "k8s.io/kubectl/pkg/cmd/get"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 	"k8s.io/kubectl/pkg/util/i18n"
 	"k8s.io/kubectl/pkg/util/templates"
@@ -160,7 +154,8 @@ func (flags *WaitFlags) ToOptions(args []string) (*WaitOptions, error) {
 	if err != nil {
 		return nil, err
 	}
-	conditionFn, err := conditionFuncFor(flags.ForCondition, flags.ErrOut)
+
+	waiter, err := waiterFor(flags.ForCondition, flags.ErrOut)
 	if err != nil {
 		return nil, err
 	}
@@ -174,81 +169,12 @@ func (flags *WaitFlags) ToOptions(args []string) (*WaitOptions, error) {
 		ResourceFinder: builder,
 		DynamicClient:  dynamicClient,
 		Timeout:        effectiveTimeout,
-		ForCondition:   flags.ForCondition,
-
-		Printer:     printer,
-		ConditionFn: conditionFn,
-		IOStreams:   flags.IOStreams,
+		Printer:        printer,
+		Waiter:         waiter,
+		IOStreams:      flags.IOStreams,
 	}
 
 	return o, nil
-}
-
-func conditionFuncFor(condition string, errOut io.Writer) (ConditionFunc, error) {
-	if strings.ToLower(condition) == "delete" {
-		return IsDeleted, nil
-	}
-	if strings.HasPrefix(condition, "condition=") {
-		conditionName := condition[len("condition="):]
-		conditionValue := "true"
-		if equalsIndex := strings.Index(conditionName, "="); equalsIndex != -1 {
-			conditionValue = conditionName[equalsIndex+1:]
-			conditionName = conditionName[0:equalsIndex]
-		}
-
-		return ConditionalWait{
-			conditionName:   conditionName,
-			conditionStatus: conditionValue,
-			errOut:          errOut,
-		}.IsConditionMet, nil
-	}
-	if strings.HasPrefix(condition, "jsonpath=") {
-		splitStr := strings.Split(condition, "=")
-		if len(splitStr) != 3 {
-			return nil, fmt.Errorf("jsonpath wait format must be --for=jsonpath='{.status.readyReplicas}'=3")
-		}
-		jsonPathExp, jsonPathCond, err := processJSONPathInput(splitStr[1], splitStr[2])
-		if err != nil {
-			return nil, err
-		}
-		j, err := newJSONPathParser(jsonPathExp)
-		if err != nil {
-			return nil, err
-		}
-		return JSONPathWait{
-			jsonPathCondition: jsonPathCond,
-			jsonPathParser:    j,
-			errOut:            errOut,
-		}.IsJSONPathConditionMet, nil
-	}
-
-	return nil, fmt.Errorf("unrecognized condition: %q", condition)
-}
-
-// newJSONPathParser will create a new JSONPath parser based on the jsonPathExpression
-func newJSONPathParser(jsonPathExpression string) (*jsonpath.JSONPath, error) {
-	j := jsonpath.New("wait")
-	if jsonPathExpression == "" {
-		return nil, errors.New("jsonpath expression cannot be empty")
-	}
-	if err := j.Parse(jsonPathExpression); err != nil {
-		return nil, err
-	}
-	return j, nil
-}
-
-// processJSONPathInput will parses the user's JSONPath input and process the string
-func processJSONPathInput(jsonPathExpression, jsonPathCond string) (string, string, error) {
-	relaxedJSONPathExp, err := cmdget.RelaxedJSONPathExpression(jsonPathExpression)
-	if err != nil {
-		return "", "", err
-	}
-	if jsonPathCond == "" {
-		return "", "", errors.New("jsonpath wait condition cannot be empty")
-	}
-	jsonPathCond = strings.Trim(jsonPathCond, `'"`)
-
-	return relaxedJSONPathExp, jsonPathCond, nil
 }
 
 // ResourceLocation holds the location of a resource
@@ -270,26 +196,23 @@ type WaitOptions struct {
 	UIDMap        UIDMap
 	DynamicClient dynamic.Interface
 	Timeout       time.Duration
-	ForCondition  string
 
-	Printer     printers.ResourcePrinter
-	ConditionFn ConditionFunc
+	Printer printers.ResourcePrinter
+	Waiter  Waiter
 	genericclioptions.IOStreams
 }
-
-// ConditionFunc is the interface for providing condition checks
-type ConditionFunc func(info *resource.Info, o *WaitOptions) (finalObject runtime.Object, done bool, err error)
 
 // RunWait runs the waiting logic
 func (o *WaitOptions) RunWait() error {
 	visitCount := 0
-	visitFunc := func(info *resource.Info, err error) error {
+
+	err := o.ResourceFinder.Do().Visit(func(info *resource.Info, err error) error {
 		if err != nil {
 			return err
 		}
 
 		visitCount++
-		finalObject, success, err := o.ConditionFn(info, o)
+		finalObject, success, err := o.Waiter.VisitResource(info, o)
 		if success {
 			o.Printer.PrintObj(finalObject, o.Out)
 			return nil
@@ -298,110 +221,9 @@ func (o *WaitOptions) RunWait() error {
 			return fmt.Errorf("%v unsatisified for unknown reason", finalObject)
 		}
 		return err
-	}
-	visitor := o.ResourceFinder.Do()
-	isForDelete := strings.ToLower(o.ForCondition) == "delete"
-	if visitor, ok := visitor.(*resource.Result); ok && isForDelete {
-		visitor.IgnoreErrors(apierrors.IsNotFound)
-	}
+	})
 
-	err := visitor.Visit(visitFunc)
-	if err != nil {
-		return err
-	}
-	if visitCount == 0 && !isForDelete {
-		return errNoMatchingResources
-	}
-	return err
-}
-
-// IsDeleted is a condition func for waiting for something to be deleted
-func IsDeleted(info *resource.Info, o *WaitOptions) (runtime.Object, bool, error) {
-	endTime := time.Now().Add(o.Timeout)
-	for {
-		if len(info.Name) == 0 {
-			return info.Object, false, fmt.Errorf("resource name must be provided")
-		}
-
-		nameSelector := fields.OneTermEqualSelector("metadata.name", info.Name).String()
-
-		// List with a name field selector to get the current resourceVersion to watch from (not the object's resourceVersion)
-		gottenObjList, err := o.DynamicClient.Resource(info.Mapping.Resource).Namespace(info.Namespace).List(context.TODO(), metav1.ListOptions{FieldSelector: nameSelector})
-		if apierrors.IsNotFound(err) {
-			return info.Object, true, nil
-		}
-		if err != nil {
-			// TODO this could do something slightly fancier if we wish
-			return info.Object, false, err
-		}
-		if len(gottenObjList.Items) != 1 {
-			return info.Object, true, nil
-		}
-		gottenObj := &gottenObjList.Items[0]
-		resourceLocation := ResourceLocation{
-			GroupResource: info.Mapping.Resource.GroupResource(),
-			Namespace:     gottenObj.GetNamespace(),
-			Name:          gottenObj.GetName(),
-		}
-		if uid, ok := o.UIDMap[resourceLocation]; ok {
-			if gottenObj.GetUID() != uid {
-				return gottenObj, true, nil
-			}
-		}
-
-		watchOptions := metav1.ListOptions{}
-		watchOptions.FieldSelector = nameSelector
-		watchOptions.ResourceVersion = gottenObjList.GetResourceVersion()
-		objWatch, err := o.DynamicClient.Resource(info.Mapping.Resource).Namespace(info.Namespace).Watch(context.TODO(), watchOptions)
-		if err != nil {
-			return gottenObj, false, err
-		}
-
-		timeout := endTime.Sub(time.Now())
-		errWaitTimeoutWithName := extendErrWaitTimeout(wait.ErrWaitTimeout, info)
-		if timeout < 0 {
-			// we're out of time
-			return gottenObj, false, errWaitTimeoutWithName
-		}
-
-		ctx, cancel := watchtools.ContextWithOptionalTimeout(context.Background(), o.Timeout)
-		watchEvent, err := watchtools.UntilWithoutRetry(ctx, objWatch, Wait{errOut: o.ErrOut}.IsDeleted)
-		cancel()
-		switch {
-		case err == nil:
-			return watchEvent.Object, true, nil
-		case err == watchtools.ErrWatchClosed:
-			continue
-		case err == wait.ErrWaitTimeout:
-			if watchEvent != nil {
-				return watchEvent.Object, false, errWaitTimeoutWithName
-			}
-			return gottenObj, false, errWaitTimeoutWithName
-		default:
-			return gottenObj, false, err
-		}
-	}
-}
-
-// Wait has helper methods for handling watches, including error handling.
-type Wait struct {
-	errOut io.Writer
-}
-
-// IsDeleted returns true if the object is deleted. It prints any errors it encounters.
-func (w Wait) IsDeleted(event watch.Event) (bool, error) {
-	switch event.Type {
-	case watch.Error:
-		// keep waiting in the event we see an error - we expect the watch to be closed by
-		// the server if the error is unrecoverable.
-		err := apierrors.FromObject(event.Object)
-		fmt.Fprintf(w.errOut, "error: An error occurred while waiting for the object to be deleted: %v", err)
-		return false, nil
-	case watch.Deleted:
-		return true, nil
-	default:
-		return false, nil
-	}
+	return o.Waiter.OnWaitLoopCompletion(visitCount, err)
 }
 
 type isCondMetFunc func(event watch.Event) (bool, error)
@@ -474,158 +296,6 @@ func getObjAndCheckCondition(info *resource.Info, o *WaitOptions, condMet isCond
 	}
 }
 
-// ConditionalWait hold information to check an API status condition
-type ConditionalWait struct {
-	conditionName   string
-	conditionStatus string
-	// errOut is written to if an error occurs
-	errOut io.Writer
-}
-
-// IsConditionMet is a conditionfunc for waiting on an API condition to be met
-func (w ConditionalWait) IsConditionMet(info *resource.Info, o *WaitOptions) (runtime.Object, bool, error) {
-	return getObjAndCheckCondition(info, o, w.isConditionMet, w.checkCondition)
-}
-
-func (w ConditionalWait) checkCondition(obj *unstructured.Unstructured) (bool, error) {
-	conditions, found, err := unstructured.NestedSlice(obj.Object, "status", "conditions")
-	if err != nil {
-		return false, err
-	}
-	if !found {
-		return false, nil
-	}
-	for _, conditionUncast := range conditions {
-		condition := conditionUncast.(map[string]interface{})
-		name, found, err := unstructured.NestedString(condition, "type")
-		if !found || err != nil || !strings.EqualFold(name, w.conditionName) {
-			continue
-		}
-		status, found, err := unstructured.NestedString(condition, "status")
-		if !found || err != nil {
-			continue
-		}
-		generation, found, _ := unstructured.NestedInt64(obj.Object, "metadata", "generation")
-		if found {
-			observedGeneration, found := getObservedGeneration(obj, condition)
-			if found && observedGeneration < generation {
-				return false, nil
-			}
-		}
-		return strings.EqualFold(status, w.conditionStatus), nil
-	}
-
-	return false, nil
-}
-
-func (w ConditionalWait) isConditionMet(event watch.Event) (bool, error) {
-	if event.Type == watch.Error {
-		// keep waiting in the event we see an error - we expect the watch to be closed by
-		// the server
-		err := apierrors.FromObject(event.Object)
-		fmt.Fprintf(w.errOut, "error: An error occurred while waiting for the condition to be satisfied: %v", err)
-		return false, nil
-	}
-	if event.Type == watch.Deleted {
-		// this will chain back out, result in another get and an return false back up the chain
-		return false, nil
-	}
-	obj := event.Object.(*unstructured.Unstructured)
-	return w.checkCondition(obj)
-}
-
 func extendErrWaitTimeout(err error, info *resource.Info) error {
 	return fmt.Errorf("%s on %s/%s", err.Error(), info.Mapping.Resource.Resource, info.Name)
-}
-
-func getObservedGeneration(obj *unstructured.Unstructured, condition map[string]interface{}) (int64, bool) {
-	conditionObservedGeneration, found, _ := unstructured.NestedInt64(condition, "observedGeneration")
-	if found {
-		return conditionObservedGeneration, true
-	}
-	statusObservedGeneration, found, _ := unstructured.NestedInt64(obj.Object, "status", "observedGeneration")
-	return statusObservedGeneration, found
-}
-
-// JSONPathWait holds a JSONPath Parser which has the ability
-// to check for the JSONPath condition and compare with the API server provided JSON output.
-type JSONPathWait struct {
-	jsonPathCondition string
-	jsonPathParser    *jsonpath.JSONPath
-	// errOut is written to if an error occurs
-	errOut io.Writer
-}
-
-// IsJSONPathConditionMet fulfills the requirements of the interface ConditionFunc which provides condition check
-func (j JSONPathWait) IsJSONPathConditionMet(info *resource.Info, o *WaitOptions) (runtime.Object, bool, error) {
-	return getObjAndCheckCondition(info, o, j.isJSONPathConditionMet, j.checkCondition)
-}
-
-// isJSONPathConditionMet is a helper function of IsJSONPathConditionMet
-// which check the watch event and check if a JSONPathWait condition is met
-func (j JSONPathWait) isJSONPathConditionMet(event watch.Event) (bool, error) {
-	if event.Type == watch.Error {
-		// keep waiting in the event we see an error - we expect the watch to be closed by
-		// the server
-		err := apierrors.FromObject(event.Object)
-		fmt.Fprintf(j.errOut, "error: An error occurred while waiting for the condition to be satisfied: %v", err)
-		return false, nil
-	}
-	if event.Type == watch.Deleted {
-		// this will chain back out, result in another get and an return false back up the chain
-		return false, nil
-	}
-	// event runtime Object can be safely asserted to Unstructed
-	// because we are working with dynamic client
-	obj := event.Object.(*unstructured.Unstructured)
-	return j.checkCondition(obj)
-}
-
-// checkCondition uses JSONPath parser to parse the JSON received from the API server
-// and check if it matches the desired condition
-func (j JSONPathWait) checkCondition(obj *unstructured.Unstructured) (bool, error) {
-	queryObj := obj.UnstructuredContent()
-	parseResults, err := j.jsonPathParser.FindResults(queryObj)
-	if err != nil {
-		return false, err
-	}
-	if err := verifyParsedJSONPath(parseResults); err != nil {
-		return false, err
-	}
-	isConditionMet, err := compareResults(parseResults[0][0], j.jsonPathCondition)
-	if err != nil {
-		return false, err
-	}
-	return isConditionMet, nil
-}
-
-// verifyParsedJSONPath verifies the JSON received from the API server is valid.
-// It will only accept a single JSON
-func verifyParsedJSONPath(results [][]reflect.Value) error {
-	if len(results) == 0 {
-		return errors.New("given jsonpath expression does not match any value")
-	}
-	if len(results) > 1 {
-		return errors.New("given jsonpath expression matches more than one list")
-	}
-	if len(results[0]) > 1 {
-		return errors.New("given jsonpath expression matches more than one value")
-	}
-	return nil
-}
-
-// compareResults will compare the reflect.Value from the result parsed by the
-// JSONPath parser with the expected value given by the value
-//
-// Since this is coming from an unstructured this can only ever be a primitive,
-// map[string]interface{}, or []interface{}.
-// We do not support the last two and rely on fmt to handle conversion to string
-// and compare the result with user input
-func compareResults(r reflect.Value, expectedVal string) (bool, error) {
-	switch r.Interface().(type) {
-	case map[string]interface{}, []interface{}:
-		return false, errors.New("jsonpath leads to a nested object or list which is not supported")
-	}
-	s := fmt.Sprintf("%v", r.Interface())
-	return strings.TrimSpace(s) == strings.TrimSpace(expectedVal), nil
 }

--- a/staging/src/k8s.io/kubectl/pkg/cmd/wait/waiter.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/wait/waiter.go
@@ -1,0 +1,83 @@
+package wait
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/cli-runtime/pkg/resource"
+	"k8s.io/client-go/util/jsonpath"
+	"k8s.io/kubectl/pkg/cmd/get"
+)
+
+// A Waiter defines the behavior of waiting for the desired state, including interpreting any errors that the
+// ResourceFinder encounters in the OnWaitLoopCompletion method.
+type Waiter interface {
+	// VisitResource is called once for each resource found during the wait loop.
+	VisitResource(info *resource.Info, o *WaitOptions) (runtime.Object, bool, error)
+
+	// OnWaitLoopCompletion is called at the end of each wait loop cycle and may be used to supress or raise errors
+	// based on the number of resources visited.
+	OnWaitLoopCompletion(visitedCount int, err error) error
+}
+
+func waiterFor(condition string, errOut io.Writer) (Waiter, error) {
+	if strings.ToLower(condition) == "delete" {
+		return NewDeletionWaiter(errOut), nil
+	}
+	if strings.HasPrefix(condition, "condition=") {
+		conditionName := condition[len("condition="):]
+		conditionValue := "true"
+		if equalsIndex := strings.Index(conditionName, "="); equalsIndex != -1 {
+			conditionValue = conditionName[equalsIndex+1:]
+			conditionName = conditionName[0:equalsIndex]
+		}
+
+		return NewConditionalWaiter(conditionName, conditionValue, errOut), nil
+	}
+	if strings.HasPrefix(condition, "jsonpath=") {
+		splitStr := strings.Split(condition, "=")
+		if len(splitStr) != 3 {
+			return nil, fmt.Errorf("jsonpath wait format must be --for=jsonpath='{.status.readyReplicas}'=3")
+		}
+		jsonPathExp, jsonPathCond, err := processJSONPathInput(splitStr[1], splitStr[2])
+		if err != nil {
+			return nil, err
+		}
+		j, err := newJSONPathParser(jsonPathExp)
+		if err != nil {
+			return nil, err
+		}
+		return NewJSONPathWaiter(jsonPathCond, j, errOut), nil
+	}
+
+	return nil, fmt.Errorf("unrecognized condition: %q", condition)
+}
+
+// newJSONPathParser will create a new JSONPath parser based on the jsonPathExpression
+func newJSONPathParser(jsonPathExpression string) (*jsonpath.JSONPath, error) {
+	j := jsonpath.New("wait")
+	if jsonPathExpression == "" {
+		return nil, errors.New("jsonpath expression cannot be empty")
+	}
+	if err := j.Parse(jsonPathExpression); err != nil {
+		return nil, err
+	}
+	return j, nil
+}
+
+// processJSONPathInput will parses the user's JSONPath input and process the string
+func processJSONPathInput(jsonPathExpression, jsonPathCond string) (string, string, error) {
+	relaxedJSONPathExp, err := get.RelaxedJSONPathExpression(jsonPathExpression)
+	if err != nil {
+		return "", "", err
+	}
+	if jsonPathCond == "" {
+		return "", "", errors.New("jsonpath wait condition cannot be empty")
+	}
+	jsonPathCond = strings.Trim(jsonPathCond, `'"`)
+
+	return relaxedJSONPathExp, jsonPathCond, nil
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

In service of https://github.com/kubernetes/kubectl/issues/665, this PR converts the wait `ConditionFn`/`ForCondition` logic into an implementable interface which can easily be used to add `--for=create`.

It also addresses some issues with tests:
* The `TestForDelete/with_no_infos` test is not a valid test because the only case where an empty `Infos` is a problem is when the `ForCondition` is not "delete" while the `ConditionFn` is `IsDeleted`. This was part of my motivation for combining these into an implementation of an interface that cannot drift from real-world use in test cases. (Notably, the usage of `IsDeleted` in the `delete` command does not also pass `ForCondition`, meaning it can currently error in a way the actual `wait` command would not.)
* Similarly, the `TestForDeleteNotFound` test case asserts no error is returned from a fake implementation of `ResourceFinder` that would never be returned anyway. I've implemented a one-off fake that can return this error to assert it is properly consumed by the newly extracted `DeletionWaiter`.

Apologies for the number of changed lines, the vast majority of this is moved code and changing top-level functions to implementation methods of the new `Waiter` interface. I've re-organized the code into per-Waiter files, which accounts for the diff sizes.

#### Which issue(s) this PR fixes:

N/A. A follow-up implementation will address the above issue. (Should that issue be moved to kubernetes/kubernetes?)

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```

