### PR TITLE
gce: deprecate disk deletion that does not specify a zone

### DIFF
--- a/pkg/volume/gcepd/gce_util.go
+++ b/pkg/volume/gcepd/gce_util.go
@@ -81,7 +81,7 @@ func (util *GCEDiskUtil) DeleteVolume(d *gcePersistentDiskDeleter) error {
 		return err
 	}
 
-	if err = cloud.DeleteDisk(d.pdName); err != nil {
+	if err = cloud.DeleteDiskUnknownZone(d.pdName); err != nil {
 		klog.V(2).Infof("Error deleting GCE PD volume %s: %v", d.pdName, err)
 		// GCE cloud provider returns volume.deletedVolumeInUseError when
 		// necessary, no handling needed here.

--- a/test/e2e/framework/providers/gce/gce.go
+++ b/test/e2e/framework/providers/gce/gce.go
@@ -246,7 +246,7 @@ func (p *Provider) CreatePD(zone string) (string, error) {
 
 // DeletePD deletes a persistent volume
 func (p *Provider) DeletePD(pdName string) error {
-	err := p.gceCloud.DeleteDisk(pdName)
+	err := p.gceCloud.DeleteDiskUnknownZone(pdName)
 
 	if err != nil {
 		if gerr, ok := err.(*googleapi.Error); ok && len(gerr.Errors) > 0 && gerr.Errors[0].Reason == "notFound" {


### PR DESCRIPTION
Because a disk name is not unique, we need to specify the zone to
safely delete a disk.  We don't currently do so in all code paths, so
create a safe code-path and deprecate the unsafe path.

/kind cleanup
```release-note
NONE
```

/sig storage