### PR TITLE
e2e: specify zone for inline volumes also

### DIFF
--- a/test/e2e/storage/drivers/in_tree.go
+++ b/test/e2e/storage/drivers/in_tree.go
@@ -1367,9 +1367,11 @@ func (g *gcePdDriver) PrepareTest(f *framework.Framework) (*storageframework.Per
 
 func (g *gcePdDriver) CreateVolume(config *storageframework.PerTestConfig, volType storageframework.TestVolType) storageframework.TestVolume {
 	zone := getInlineVolumeZone(config.Framework)
-	if volType == storageframework.InlineVolume {
-		// PD will be created in framework.TestContext.CloudConfig.Zone zone,
-		// so pods should be also scheduled there.
+	if zone == "" {
+		framework.Fail("could not determine suitable zone for volume")
+	}
+	if volType == storageframework.InlineVolume || volType == storageframework.PreprovisionedPV {
+		// Schedule pod in same volume as PD, so Pod can mount Volume (can't mount zonal disks across zones)
 		config.ClientNodeSelection = e2epod.NodeSelection{
 			Selector: map[string]string{
 				v1.LabelFailureDomainBetaZone: zone,
@@ -1772,9 +1774,11 @@ func (a *awsDriver) PrepareTest(f *framework.Framework) (*storageframework.PerTe
 
 func (a *awsDriver) CreateVolume(config *storageframework.PerTestConfig, volType storageframework.TestVolType) storageframework.TestVolume {
 	zone := getInlineVolumeZone(config.Framework)
-	if volType == storageframework.InlineVolume {
-		// PD will be created in framework.TestContext.CloudConfig.Zone zone,
-		// so pods should be also scheduled there.
+	if zone == "" {
+		framework.Fail("could not determine suitable zone for volume")
+	}
+	if volType == storageframework.InlineVolume || volType == storageframework.PreprovisionedPV {
+		// Schedule pod in same volume as PD, so Pod can mount Volume (can't mount EBS volumes across zones)
 		config.ClientNodeSelection = e2epod.NodeSelection{
 			Selector: map[string]string{
 				v1.LabelTopologyZone: zone,


### PR DESCRIPTION
This ensures that if we are building a zonal volume, we launch pods
into that zone.

This is done for us for volumes that are created by kubernetes, but
when the volumes are created externally the caller is responsible.  In
this case, the e2e tests are creating the volumes and thus must
specify the nodeSelector.

Issue #106814

/kind flake

```release-note
NONE
```

/sig storage