### PR TITLE
e2e: Stop using deprecated zone nodeSelector

### DIFF
--- a/test/e2e/storage/drivers/in_tree.go
+++ b/test/e2e/storage/drivers/in_tree.go
@@ -1372,7 +1372,7 @@ func (g *gcePdDriver) CreateVolume(config *storageframework.PerTestConfig, volTy
 		// so pods should be also scheduled there.
 		config.ClientNodeSelection = e2epod.NodeSelection{
 			Selector: map[string]string{
-				v1.LabelFailureDomainBetaZone: zone,
+				v1.LabelTopologyZone: zone,
 			},
 		}
 	}


### PR DESCRIPTION
Update to the non-deprecated label names.

/kind cleanup

```release-note
NONE
```

/sig storage
