### PR TITLE
e2e tests: log zone when creating volume

### DIFF
--- a/test/e2e/framework/pv/pv.go
+++ b/test/e2e/framework/pv/pv.go
@@ -664,10 +664,10 @@ func createPDWithRetry(zone string) (string, error) {
 	for start := time.Now(); time.Since(start) < pdRetryTimeout; time.Sleep(pdRetryPollTime) {
 		newDiskName, err = createPD(zone)
 		if err != nil {
-			framework.Logf("Couldn't create a new PD, sleeping 5 seconds: %v", err)
+			framework.Logf("Couldn't create a new PD in zone %q, sleeping 5 seconds: %v", zone, err)
 			continue
 		}
-		framework.Logf("Successfully created a new PD: %q.", newDiskName)
+		framework.Logf("Successfully created a new PD in zone %q: %q.", zone, newDiskName)
 		return newDiskName, nil
 	}
 	return "", err


### PR DESCRIPTION
Given the test failures we are encountering with zones, add the zone
to the log message when creating a zonal PV.

/kind cleanup

```release-note
NONE
```

/sig storage
