### PR TITLE
client-go: move out the judgment logic from loop for reduce the count…

### DIFF
--- a/staging/src/k8s.io/client-go/rest/request.go
+++ b/staging/src/k8s.io/client-go/rest/request.go
@@ -365,10 +365,10 @@ func (r *Request) SpecificallyVersionedParams(obj runtime.Object, codec runtime.
 		r.err = err
 		return r
 	}
+	if r.params == nil {
+		r.params = make(url.Values)
+	}
 	for k, v := range params {
-		if r.params == nil {
-			r.params = make(url.Values)
-		}
 		r.params[k] = append(r.params[k], v...)
 	}
 	return r


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

- staging/src/k8s.io/client-go: move out the judgment logic from loop for reduce the count of judgment

#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```

```
/assign @smarterclayton @caesarxuchao 
