### PR TITLE
Remove feature gate NamespaceDefaultLabelName

### DIFF
--- a/pkg/apis/core/v1/defaults.go
+++ b/pkg/apis/core/v1/defaults.go
@@ -326,20 +326,17 @@ func SetDefaults_HTTPGetAction(obj *v1.HTTPGetAction) {
 
 // SetDefaults_Namespace adds a default label for all namespaces
 func SetDefaults_Namespace(obj *v1.Namespace) {
-	// TODO, remove the feature gate in 1.22
 	// we can't SetDefaults for nameless namespaces (generateName).
 	// This code needs to be kept in sync with the implementation that exists
 	// in Namespace Canonicalize strategy (pkg/registry/core/namespace)
 
 	// note that this can result in many calls to feature enablement in some cases, but
 	// we assume that there's no real cost there.
-	if utilfeature.DefaultFeatureGate.Enabled(features.NamespaceDefaultLabelName) {
-		if len(obj.Name) > 0 {
-			if obj.Labels == nil {
-				obj.Labels = map[string]string{}
-			}
-			obj.Labels[v1.LabelMetadataName] = obj.Name
+	if len(obj.Name) > 0 {
+		if obj.Labels == nil {
+			obj.Labels = map[string]string{}
 		}
+		obj.Labels[v1.LabelMetadataName] = obj.Name
 	}
 }
 

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -695,14 +695,6 @@ const (
 	// Enable POD resources API to return allocatable resources
 	KubeletPodResourcesGetAllocatable featuregate.Feature = "KubeletPodResourcesGetAllocatable"
 
-	// owner: @jayunit100 @abhiraut @rikatz
-	// kep: http://kep.k8s.io/2161
-	// beta: v1.21
-	// ga: v1.22
-	//
-	// Labels all namespaces with a default label "kubernetes.io/metadata.name: <namespaceName>"
-	NamespaceDefaultLabelName featuregate.Feature = "NamespaceDefaultLabelName"
-
 	// owner: @fengzixu
 	// alpha: v1.21
 	//
@@ -956,7 +948,6 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
 	LogarithmicScaleDown:                           {Default: true, PreRelease: featuregate.Beta},
 	SuspendJob:                                     {Default: true, PreRelease: featuregate.Beta},
 	KubeletPodResourcesGetAllocatable:              {Default: true, PreRelease: featuregate.Beta},
-	NamespaceDefaultLabelName:                      {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.24
 	CSIVolumeHealth:                                {Default: false, PreRelease: featuregate.Alpha},
 	WindowsHostProcessContainers:                   {Default: true, PreRelease: featuregate.Beta},
 	DisableCloudProviders:                          {Default: false, PreRelease: featuregate.Alpha},

--- a/pkg/registry/core/namespace/strategy.go
+++ b/pkg/registry/core/namespace/strategy.go
@@ -28,11 +28,9 @@ import (
 	"k8s.io/apiserver/pkg/registry/generic"
 	apistorage "k8s.io/apiserver/pkg/storage"
 	"k8s.io/apiserver/pkg/storage/names"
-	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/kubernetes/pkg/api/legacyscheme"
 	api "k8s.io/kubernetes/pkg/apis/core"
 	"k8s.io/kubernetes/pkg/apis/core/validation"
-	"k8s.io/kubernetes/pkg/features"
 	"sigs.k8s.io/structured-merge-diff/v4/fieldpath"
 )
 
@@ -125,12 +123,10 @@ func (namespaceStrategy) Canonicalize(obj runtime.Object) {
 	// GET:
 	// Only defaulting will be applied.
 	ns := obj.(*api.Namespace)
-	if utilfeature.DefaultFeatureGate.Enabled(features.NamespaceDefaultLabelName) {
-		if ns.Labels == nil {
-			ns.Labels = map[string]string{}
-		}
-		ns.Labels[v1.LabelMetadataName] = ns.Name
+	if ns.Labels == nil {
+		ns.Labels = map[string]string{}
 	}
+	ns.Labels[v1.LabelMetadataName] = ns.Name
 }
 
 // AllowCreateOnUpdate is false for namespaces.

--- a/pkg/registry/core/namespace/strategy_test.go
+++ b/pkg/registry/core/namespace/strategy_test.go
@@ -22,11 +22,8 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
-	utilfeature "k8s.io/apiserver/pkg/util/feature"
-	featuregatetesting "k8s.io/component-base/featuregate/testing"
 	apitesting "k8s.io/kubernetes/pkg/api/testing"
 	api "k8s.io/kubernetes/pkg/apis/core"
-	"k8s.io/kubernetes/pkg/features"
 
 	// ensure types are installed
 	_ "k8s.io/kubernetes/pkg/apis/core/install"
@@ -73,8 +70,6 @@ func TestNamespaceStrategy(t *testing.T) {
 }
 
 func TestNamespaceDefaultLabelCanonicalize(t *testing.T) {
-	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.NamespaceDefaultLabelName, true)()
-
 	namespace := &api.Namespace{
 		ObjectMeta: metav1.ObjectMeta{Name: "foo"},
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
In kubernetes version 1.22, the feature gate `NamespaceDefaultLabelName` has [reached GA](https://github.com/kubernetes/kubernetes/pull/101342). And it can be removed in 1.24.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
The `NamespaceDefaultLabelName` feature gate, GA since v1.22, is now removed.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- [KEP]: https://github.com/kubernetes/enhancements/tree/master/keps/sig-api-machinery/2161-apiserver-default-labels
```
