### PR TITLE
kube-proxy should log the payload when iptables-restore fails

### DIFF
--- a/pkg/proxy/iptables/proxier.go
+++ b/pkg/proxy/iptables/proxier.go
@@ -1515,7 +1515,12 @@ func (proxier *Proxier) syncProxyRules() {
 	klog.V(5).InfoS("Restoring iptables", "rules", proxier.iptablesData.Bytes())
 	err = proxier.iptables.RestoreAll(proxier.iptablesData.Bytes(), utiliptables.NoFlushTables, utiliptables.RestoreCounters)
 	if err != nil {
-		klog.ErrorS(err, "Failed to execute iptables-restore")
+		if pErr, ok := err.(utiliptables.ParseError); ok {
+			lines := utiliptables.ExtractLines(proxier.iptablesData.Bytes(), pErr.Line(), 3)
+			klog.ErrorS(pErr, "Failed to execute iptables-restore", "rules", lines)
+		} else {
+			klog.ErrorS(err, "Failed to execute iptables-restore")
+		}
 		metrics.IptablesRestoreFailuresTotal.Inc()
 		// Revert new local ports.
 		klog.V(2).InfoS("Closing local ports after iptables-restore failure")

--- a/pkg/util/iptables/iptables.go
+++ b/pkg/util/iptables/iptables.go
@@ -17,10 +17,12 @@ limitations under the License.
 package iptables
 
 import (
+	"bufio"
 	"bytes"
 	"context"
 	"fmt"
 	"regexp"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -423,7 +425,11 @@ func (runner *runner) restoreInternal(args []string, data []byte, flush FlushFla
 	cmd.SetStdin(bytes.NewBuffer(data))
 	b, err := cmd.CombinedOutput()
 	if err != nil {
-		return fmt.Errorf("%v (%s)", err, b)
+		pErr, ok := parseRestoreError(string(b))
+		if ok {
+			return pErr
+		}
+		return fmt.Errorf("%w: %s", err, b)
 	}
 	return nil
 }
@@ -782,4 +788,90 @@ func isResourceError(err error) bool {
 		return ee.ExitStatus() == iptablesStatusResourceProblem
 	}
 	return false
+}
+
+// ParseError records the payload when iptables reports an error parsing its input.
+type ParseError interface {
+	// Line returns the line number on which the parse error was reported.
+	// NOTE: First line is 1.
+	Line() int
+	// Error returns the error message of the parse error, including line number.
+	Error() string
+}
+
+type parseError struct {
+	cmd  string
+	line int
+}
+
+func (e parseError) Line() int {
+	return e.line
+}
+
+func (e parseError) Error() string {
+	return fmt.Sprintf("%s: input error on line %d: ", e.cmd, e.line)
+}
+
+// LineData represents a single numbered line of data.
+type LineData struct {
+	// Line holds the line number (the first line is 1).
+	Line int
+	// The data of the line.
+	Data string
+}
+
+var regexpParseError = regexp.MustCompile("line ([1-9][0-9]*) failed$")
+
+// parseRestoreError extracts the line from the error, if it matches returns parseError
+// for example:
+// input: iptables-restore: line 51 failed
+// output: parseError:  cmd = iptables-restore, line = 51
+// NOTE: parseRestoreError depends on the error format of iptables, if it ever changes
+// we need to update this function
+func parseRestoreError(str string) (ParseError, bool) {
+	errors := strings.Split(str, ":")
+	if len(errors) != 2 {
+		return nil, false
+	}
+	cmd := errors[0]
+	matches := regexpParseError.FindStringSubmatch(errors[1])
+	if len(matches) != 2 {
+		return nil, false
+	}
+	line, errMsg := strconv.Atoi(matches[1])
+	if errMsg != nil {
+		return nil, false
+	}
+	return parseError{cmd: cmd, line: line}, true
+}
+
+// ExtractLines extracts the -count and +count data from the lineNum row of lines and return
+// NOTE: lines start from line 1
+func ExtractLines(lines []byte, line, count int) []LineData {
+	// first line is line 1, so line can't be smaller than 1
+	if line < 1 {
+		return nil
+	}
+	start := line - count
+	if start <= 0 {
+		start = 1
+	}
+	end := line + count + 1
+
+	offset := 1
+	scanner := bufio.NewScanner(bytes.NewBuffer(lines))
+	extractLines := make([]LineData, 0, count*2)
+	for scanner.Scan() {
+		if offset >= start && offset < end {
+			extractLines = append(extractLines, LineData{
+				Line: offset,
+				Data: scanner.Text(),
+			})
+		}
+		if offset == end {
+			break
+		}
+		offset++
+	}
+	return extractLines
 }

--- a/pkg/util/iptables/iptables_test.go
+++ b/pkg/util/iptables/iptables_test.go
@@ -1198,3 +1198,63 @@ func TestRestoreAllWaitBackportedIptablesRestore(t *testing.T) {
 		t.Errorf("expected failure")
 	}
 }
+
+// TestExtractLines tests that
+func TestExtractLines(t *testing.T) {
+	mkLines := func(lines ...LineData) []LineData {
+		return lines
+	}
+	lines := "Line1: 1\nLine2: 2\nLine3: 3\nLine4: 4\nLine5: 5\nLine6: 6\nLine7: 7\nLine8: 8\nLine9: 9\nLine10: 10"
+	tests := []struct {
+		count int
+		line  int
+		name  string
+		want  []LineData
+	}{{
+		name:  "test-line-0",
+		count: 3,
+		line:  0,
+		want:  nil,
+	}, {
+		name:  "test-count-0",
+		count: 0,
+		line:  3,
+		want:  mkLines(LineData{3, "Line3: 3"}),
+	}, {
+		name:  "test-common-cases",
+		count: 3,
+		line:  6,
+		want: mkLines(
+			LineData{3, "Line3: 3"},
+			LineData{4, "Line4: 4"},
+			LineData{5, "Line5: 5"},
+			LineData{6, "Line6: 6"},
+			LineData{7, "Line7: 7"},
+			LineData{8, "Line8: 8"},
+			LineData{9, "Line9: 9"}),
+	}, {
+		name:  "test4-bound-cases",
+		count: 11,
+		line:  10,
+		want: mkLines(
+			LineData{1, "Line1: 1"},
+			LineData{2, "Line2: 2"},
+			LineData{3, "Line3: 3"},
+			LineData{4, "Line4: 4"},
+			LineData{5, "Line5: 5"},
+			LineData{6, "Line6: 6"},
+			LineData{7, "Line7: 7"},
+			LineData{8, "Line8: 8"},
+			LineData{9, "Line9: 9"},
+			LineData{10, "Line10: 10"}),
+	}}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ExtractLines([]byte(lines), tt.line, tt.count)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("got = %v, want = %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Signed-off-by: cyclinder <qifeng.guo@daocloud.io>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind feature
#### What this PR does / why we need it:
when the `kube-proxy` execution `iptables-restore` failed, we should  log the payload for easy for users to see where things are going wrong
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes/kubernetes/issues/104234

#### Special notes for your reviewer:
I'm not sure if I need to check for parse error when the error does not match `line %d failed`
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
