### PR TITLE
Remove support for Endpoints and ConfigMaps lock from leader election

### DIFF
--- a/staging/src/k8s.io/client-go/tools/leaderelection/resourcelock/configmaplock.go
+++ b/staging/src/k8s.io/client-go/tools/leaderelection/resourcelock/configmaplock.go
@@ -32,7 +32,7 @@ import (
 // and use ConfigMaps as the means to pass that configuration
 // data we will likely move to deprecate the Endpoints lock.
 
-type ConfigMapLock struct {
+type configMapLock struct {
 	// ConfigMapMeta should contain a Name and a Namespace of a
 	// ConfigMapMeta object that the LeaderElector will attempt to lead.
 	ConfigMapMeta metav1.ObjectMeta
@@ -42,7 +42,7 @@ type ConfigMapLock struct {
 }
 
 // Get returns the election record from a ConfigMap Annotation
-func (cml *ConfigMapLock) Get(ctx context.Context) (*LeaderElectionRecord, []byte, error) {
+func (cml *configMapLock) Get(ctx context.Context) (*LeaderElectionRecord, []byte, error) {
 	var record LeaderElectionRecord
 	var err error
 	cml.cm, err = cml.Client.ConfigMaps(cml.ConfigMapMeta.Namespace).Get(ctx, cml.ConfigMapMeta.Name, metav1.GetOptions{})
@@ -63,7 +63,7 @@ func (cml *ConfigMapLock) Get(ctx context.Context) (*LeaderElectionRecord, []byt
 }
 
 // Create attempts to create a LeaderElectionRecord annotation
-func (cml *ConfigMapLock) Create(ctx context.Context, ler LeaderElectionRecord) error {
+func (cml *configMapLock) Create(ctx context.Context, ler LeaderElectionRecord) error {
 	recordBytes, err := json.Marshal(ler)
 	if err != nil {
 		return err
@@ -81,7 +81,7 @@ func (cml *ConfigMapLock) Create(ctx context.Context, ler LeaderElectionRecord) 
 }
 
 // Update will update an existing annotation on a given resource.
-func (cml *ConfigMapLock) Update(ctx context.Context, ler LeaderElectionRecord) error {
+func (cml *configMapLock) Update(ctx context.Context, ler LeaderElectionRecord) error {
 	if cml.cm == nil {
 		return errors.New("configmap not initialized, call get or create first")
 	}
@@ -102,7 +102,7 @@ func (cml *ConfigMapLock) Update(ctx context.Context, ler LeaderElectionRecord) 
 }
 
 // RecordEvent in leader election while adding meta-data
-func (cml *ConfigMapLock) RecordEvent(s string) {
+func (cml *configMapLock) RecordEvent(s string) {
 	if cml.LockConfig.EventRecorder == nil {
 		return
 	}
@@ -116,11 +116,11 @@ func (cml *ConfigMapLock) RecordEvent(s string) {
 
 // Describe is used to convert details on current resource lock
 // into a string
-func (cml *ConfigMapLock) Describe() string {
+func (cml *configMapLock) Describe() string {
 	return fmt.Sprintf("%v/%v", cml.ConfigMapMeta.Namespace, cml.ConfigMapMeta.Name)
 }
 
 // Identity returns the Identity of the lock
-func (cml *ConfigMapLock) Identity() string {
+func (cml *configMapLock) Identity() string {
 	return cml.LockConfig.Identity
 }

--- a/staging/src/k8s.io/client-go/tools/leaderelection/resourcelock/endpointslock.go
+++ b/staging/src/k8s.io/client-go/tools/leaderelection/resourcelock/endpointslock.go
@@ -27,7 +27,7 @@ import (
 	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
 )
 
-type EndpointsLock struct {
+type endpointsLock struct {
 	// EndpointsMeta should contain a Name and a Namespace of an
 	// Endpoints object that the LeaderElector will attempt to lead.
 	EndpointsMeta metav1.ObjectMeta
@@ -37,7 +37,7 @@ type EndpointsLock struct {
 }
 
 // Get returns the election record from a Endpoints Annotation
-func (el *EndpointsLock) Get(ctx context.Context) (*LeaderElectionRecord, []byte, error) {
+func (el *endpointsLock) Get(ctx context.Context) (*LeaderElectionRecord, []byte, error) {
 	var record LeaderElectionRecord
 	var err error
 	el.e, err = el.Client.Endpoints(el.EndpointsMeta.Namespace).Get(ctx, el.EndpointsMeta.Name, metav1.GetOptions{})
@@ -58,7 +58,7 @@ func (el *EndpointsLock) Get(ctx context.Context) (*LeaderElectionRecord, []byte
 }
 
 // Create attempts to create a LeaderElectionRecord annotation
-func (el *EndpointsLock) Create(ctx context.Context, ler LeaderElectionRecord) error {
+func (el *endpointsLock) Create(ctx context.Context, ler LeaderElectionRecord) error {
 	recordBytes, err := json.Marshal(ler)
 	if err != nil {
 		return err
@@ -76,7 +76,7 @@ func (el *EndpointsLock) Create(ctx context.Context, ler LeaderElectionRecord) e
 }
 
 // Update will update and existing annotation on a given resource.
-func (el *EndpointsLock) Update(ctx context.Context, ler LeaderElectionRecord) error {
+func (el *endpointsLock) Update(ctx context.Context, ler LeaderElectionRecord) error {
 	if el.e == nil {
 		return errors.New("endpoint not initialized, call get or create first")
 	}
@@ -97,7 +97,7 @@ func (el *EndpointsLock) Update(ctx context.Context, ler LeaderElectionRecord) e
 }
 
 // RecordEvent in leader election while adding meta-data
-func (el *EndpointsLock) RecordEvent(s string) {
+func (el *endpointsLock) RecordEvent(s string) {
 	if el.LockConfig.EventRecorder == nil {
 		return
 	}
@@ -111,11 +111,11 @@ func (el *EndpointsLock) RecordEvent(s string) {
 
 // Describe is used to convert details on current resource lock
 // into a string
-func (el *EndpointsLock) Describe() string {
+func (el *endpointsLock) Describe() string {
 	return fmt.Sprintf("%v/%v", el.EndpointsMeta.Namespace, el.EndpointsMeta.Name)
 }
 
 // Identity returns the Identity of the lock
-func (el *EndpointsLock) Identity() string {
+func (el *endpointsLock) Identity() string {
 	return el.LockConfig.Identity
 }

--- a/staging/src/k8s.io/client-go/tools/leaderelection/resourcelock/interface.go
+++ b/staging/src/k8s.io/client-go/tools/leaderelection/resourcelock/interface.go
@@ -31,11 +31,77 @@ import (
 
 const (
 	LeaderElectionRecordAnnotationKey = "control-plane.alpha.kubernetes.io/leader"
-	EndpointsResourceLock             = "endpoints"
-	ConfigMapsResourceLock            = "configmaps"
+	endpointsResourceLock             = "endpoints"
+	configMapsResourceLock            = "configmaps"
 	LeasesResourceLock                = "leases"
-	EndpointsLeasesResourceLock       = "endpointsleases"
-	ConfigMapsLeasesResourceLock      = "configmapsleases"
+	// When using EndpointsLeasesResourceLock, you need to ensure that
+	// API Priority & Fairness is configured with non-default flow-schema
+	// that will catch the necessary operations on leader-election related
+	// endpoint objects.
+	//
+	// The example of such flow scheme could look like this:
+	//   apiVersion: flowcontrol.apiserver.k8s.io/v1beta2
+	//   kind: FlowSchema
+	//   metadata:
+	//     name: my-leader-election
+	//   spec:
+	//     distinguisherMethod:
+	//       type: ByUser
+	//     matchingPrecedence: 200
+	//     priorityLevelConfiguration:
+	//       name: leader-election   # reference the <leader-election> PL
+	//     rules:
+	//     - resourceRules:
+	//       - apiGroups:
+	//         - ""
+	//         namespaces:
+	//         - '*'
+	//         resources:
+	//         - endpoints
+	//         verbs:
+	//         - get
+	//         - create
+	//         - update
+	//       subjects:
+	//       - kind: ServiceAccount
+	//         serviceAccount:
+	//           name: '*'
+	//           namespace: kube-system
+	EndpointsLeasesResourceLock = "endpointsleases"
+	// When using EndpointsLeasesResourceLock, you need to ensure that
+	// API Priority & Fairness is configured with non-default flow-schema
+	// that will catch the necessary operations on leader-election related
+	// configmap objects.
+	//
+	// The example of such flow scheme could look like this:
+	//   apiVersion: flowcontrol.apiserver.k8s.io/v1beta2
+	//   kind: FlowSchema
+	//   metadata:
+	//     name: my-leader-election
+	//   spec:
+	//     distinguisherMethod:
+	//       type: ByUser
+	//     matchingPrecedence: 200
+	//     priorityLevelConfiguration:
+	//       name: leader-election   # reference the <leader-election> PL
+	//     rules:
+	//     - resourceRules:
+	//       - apiGroups:
+	//         - ""
+	//         namespaces:
+	//         - '*'
+	//         resources:
+	//         - configmaps
+	//         verbs:
+	//         - get
+	//         - create
+	//         - update
+	//       subjects:
+	//       - kind: ServiceAccount
+	//         serviceAccount:
+	//           name: '*'
+	//           namespace: kube-system
+	ConfigMapsLeasesResourceLock = "configmapsleases"
 )
 
 // LeaderElectionRecord is the record that is stored in the leader election annotation.
@@ -98,7 +164,7 @@ type Interface interface {
 
 // Manufacture will create a lock of a given type according to the input parameters
 func New(lockType string, ns string, name string, coreClient corev1.CoreV1Interface, coordinationClient coordinationv1.CoordinationV1Interface, rlc ResourceLockConfig) (Interface, error) {
-	endpointsLock := &EndpointsLock{
+	endpointsLock := &endpointsLock{
 		EndpointsMeta: metav1.ObjectMeta{
 			Namespace: ns,
 			Name:      name,
@@ -106,7 +172,7 @@ func New(lockType string, ns string, name string, coreClient corev1.CoreV1Interf
 		Client:     coreClient,
 		LockConfig: rlc,
 	}
-	configmapLock := &ConfigMapLock{
+	configmapLock := &configMapLock{
 		ConfigMapMeta: metav1.ObjectMeta{
 			Namespace: ns,
 			Name:      name,
@@ -123,10 +189,10 @@ func New(lockType string, ns string, name string, coreClient corev1.CoreV1Interf
 		LockConfig: rlc,
 	}
 	switch lockType {
-	case EndpointsResourceLock:
-		return endpointsLock, nil
-	case ConfigMapsResourceLock:
-		return configmapLock, nil
+	case endpointsResourceLock:
+		return nil, fmt.Errorf("endpoints lock is removed, migrate to %s", EndpointsLeasesResourceLock)
+	case configMapsResourceLock:
+		return nil, fmt.Errorf("configmaps lock is removed, migrate to %s", ConfigMapsLeasesResourceLock)
 	case LeasesResourceLock:
 		return leaseLock, nil
 	case EndpointsLeasesResourceLock:


### PR DESCRIPTION
```release-note-action-required
client-go: the leader election library no longer supports leader-election locks based solely on `endpoints` or `configmaps` resources. Users of those lock resources should move to `leases`, migrating through `endpointsleases` or `configmapsleases` over two releases if needed to maintain compatibility with version-skewed members.
```

/kind feature
/sig api-machinery
/priority important-soon