### PR TITLE
kubeadm: avoid requiring a CA key during kubeconfig expiration checks

### DIFF
--- a/cmd/kubeadm/app/phases/certs/renewal/readwriter.go
+++ b/cmd/kubeadm/app/phases/certs/renewal/readwriter.go
@@ -29,7 +29,6 @@ import (
 	certutil "k8s.io/client-go/util/cert"
 	"k8s.io/client-go/util/keyutil"
 
-	certsphase "k8s.io/kubernetes/cmd/kubeadm/app/phases/certs"
 	pkiutil "k8s.io/kubernetes/cmd/kubeadm/app/util/pkiutil"
 )
 
@@ -141,11 +140,15 @@ func (rw *kubeConfigReadWriter) Read() (*x509.Certificate, error) {
 	// For local CA renewal, the local CA on disk could have changed, thus a reload is needed.
 	// For CSR renewal we assume the same CA on disk is mounted for usage with KCM's
 	// '--cluster-signing-cert-file' flag.
-	caCert, _, err := certsphase.LoadCertificateAuthority(rw.certificateDir, rw.baseName)
+	certificatePath, _ := pkiutil.PathsForCertAndKey(rw.certificateDir, rw.baseName)
+	caCerts, err := certutil.CertsFromFile(certificatePath)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrapf(err, "failed to load existing certificate %s", rw.baseName)
 	}
-	rw.caCert = caCert
+	if len(caCerts) != 1 {
+		return nil, errors.Errorf("wanted exactly one certificate, got %d", len(caCerts))
+	}
+	rw.caCert = caCerts[0]
 
 	// get current context
 	if _, ok := kubeConfig.Contexts[kubeConfig.CurrentContext]; !ok {

--- a/cmd/kubeadm/app/phases/certs/renewal/readwriter_test.go
+++ b/cmd/kubeadm/app/phases/certs/renewal/readwriter_test.go
@@ -127,6 +127,11 @@ func TestKubeconfigReadWriter(t *testing.T) {
 		t.Fatalf("couldn't write new embedded certificate: %v", err)
 	}
 
+	// Make sure that CA key is not present during Read() as it is not needed.
+	// This covers testing when the CA is external and not present on the host.
+	_, caKeyPath := pkiutil.PathsForCertAndKey(dirPKI, caName)
+	os.Remove(caKeyPath)
+
 	// Reads back the new certificate embedded in a kubeconfig writer
 	readCert, err = kubeconfigReadWriter.Read()
 	if err != nil {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

When the "kubeadm certs check-expiration" command is used and
if the ca.key is not present, regular on disk certificate reads
pass fine, but fail for kubeconfig files. The reason for the
failure is that reading of kubeconfig files currently
requires reading both the CA key and cert from disk. Reading the CA
is done to ensure that the CA cert in the kubeconfig is not out of date
during renewal.

Instead of requiring both a CA key and cert to be read, only read
the CA cert from disk, as only the cert is needed for reading kubeconfig files.

This fixes printing the cert expiration table even if the ca.key
is missing on a host (i.e. the CA is considered external).

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
xref https://github.com/kubernetes/kubeadm/issues/2618

#### Special notes for your reviewer:

based on this bug i don't think the command worked before without ca.key

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
kubeadm: allow the "certs check-expiration" command to not require the existence of the cluster CA key (ca.key file) when checking the expiration of managed certificates in kubeconfig files.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
