### PR TITLE
[apiserver] remove insecure relate flag

### DIFF
--- a/cmd/kube-apiserver/app/options/options.go
+++ b/cmd/kube-apiserver/app/options/options.go
@@ -22,7 +22,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/spf13/pflag"
 	utilnet "k8s.io/apimachinery/pkg/util/net"
 	genericoptions "k8s.io/apiserver/pkg/server/options"
 	"k8s.io/apiserver/pkg/storage/storagebackend"
@@ -38,10 +37,6 @@ import (
 	kubeletclient "k8s.io/kubernetes/pkg/kubelet/client"
 	"k8s.io/kubernetes/pkg/serviceaccount"
 )
-
-// InsecurePortFlags are dummy flags, they are kept only for compatibility and will be removed in v1.24.
-// TODO: remove these flags in v1.24.
-var InsecurePortFlags = []string{"insecure-port", "port"}
 
 // ServerRunOptions runs a kubernetes api server.
 type ServerRunOptions struct {
@@ -145,33 +140,12 @@ func NewServerRunOptions() *ServerRunOptions {
 	return &s
 }
 
-// TODO: remove these insecure flags in v1.24
-func addDummyInsecureFlags(fs *pflag.FlagSet) {
-	var (
-		bindAddr = net.IPv4(127, 0, 0, 1)
-		bindPort int
-	)
-
-	for _, name := range []string{"insecure-bind-address", "address"} {
-		fs.IPVar(&bindAddr, name, bindAddr, ""+
-			"The IP address on which to serve the insecure port (set to 0.0.0.0 or :: for listening in all interfaces and IP families).")
-		fs.MarkDeprecated(name, "This flag has no effect now and will be removed in v1.24.")
-	}
-
-	for _, name := range InsecurePortFlags {
-		fs.IntVar(&bindPort, name, bindPort, ""+
-			"The port on which to serve unsecured, unauthenticated access.")
-		fs.MarkDeprecated(name, "This flag has no effect now and will be removed in v1.24.")
-	}
-}
-
 // Flags returns flags for a specific APIServer by section name
 func (s *ServerRunOptions) Flags() (fss cliflag.NamedFlagSets) {
 	// Add the generic flags.
 	s.GenericServerRunOptions.AddUniversalFlags(fss.FlagSet("generic"))
 	s.Etcd.AddFlags(fss.FlagSet("etcd"))
 	s.SecureServing.AddFlags(fss.FlagSet("secure serving"))
-	addDummyInsecureFlags(fss.FlagSet("insecure serving"))
 	s.Audit.AddFlags(fss.FlagSet("auditing"))
 	s.Features.AddFlags(fss.FlagSet("features"))
 	s.Authentication.AddFlags(fss.FlagSet("authentication"))

--- a/cmd/kube-apiserver/app/server.go
+++ b/cmd/kube-apiserver/app/server.go
@@ -30,7 +30,6 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
-	"github.com/spf13/pflag"
 
 	extensionsapiserver "k8s.io/apiextensions-apiserver/pkg/apiserver"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
@@ -81,20 +80,6 @@ import (
 	"k8s.io/kubernetes/pkg/serviceaccount"
 )
 
-// TODO: delete this check after insecure flags removed in v1.24
-func checkNonZeroInsecurePort(fs *pflag.FlagSet) error {
-	for _, name := range options.InsecurePortFlags {
-		val, err := fs.GetInt(name)
-		if err != nil {
-			return err
-		}
-		if val != 0 {
-			return fmt.Errorf("invalid port value %d: only zero is allowed", val)
-		}
-	}
-	return nil
-}
-
 // NewAPIServerCommand creates a *cobra.Command object with default parameters
 func NewAPIServerCommand() *cobra.Command {
 	s := options.NewServerRunOptions()
@@ -124,10 +109,6 @@ cluster's shared state through which all other components interact.`,
 			}
 			cliflag.PrintFlags(fs)
 
-			err := checkNonZeroInsecurePort(fs)
-			if err != nil {
-				return err
-			}
 			// set default options
 			completedOptions, err := Complete(s)
 			if err != nil {

--- a/cmd/kubeadm/app/util/arguments_test.go
+++ b/cmd/kubeadm/app/util/arguments_test.go
@@ -32,9 +32,8 @@ func TestBuildArgumentListFromMap(t *testing.T) {
 		{
 			name: "override an argument from the base",
 			base: map[string]string{
-				"admission-control":     "NamespaceLifecycle",
-				"insecure-bind-address": "127.0.0.1",
-				"allow-privileged":      "true",
+				"admission-control": "NamespaceLifecycle",
+				"allow-privileged":  "true",
 			},
 			overrides: map[string]string{
 				"admission-control": "NamespaceLifecycle,LimitRanger",
@@ -42,14 +41,12 @@ func TestBuildArgumentListFromMap(t *testing.T) {
 			expected: []string{
 				"--admission-control=NamespaceLifecycle,LimitRanger",
 				"--allow-privileged=true",
-				"--insecure-bind-address=127.0.0.1",
 			},
 		},
 		{
 			name: "add an argument that is not in base",
 			base: map[string]string{
-				"insecure-bind-address": "127.0.0.1",
-				"allow-privileged":      "true",
+				"allow-privileged": "true",
 			},
 			overrides: map[string]string{
 				"admission-control": "NamespaceLifecycle,LimitRanger",
@@ -57,13 +54,11 @@ func TestBuildArgumentListFromMap(t *testing.T) {
 			expected: []string{
 				"--admission-control=NamespaceLifecycle,LimitRanger",
 				"--allow-privileged=true",
-				"--insecure-bind-address=127.0.0.1",
 			},
 		},
 		{
 			name: "allow empty strings in base",
 			base: map[string]string{
-				"insecure-bind-address":              "127.0.0.1",
 				"allow-privileged":                   "true",
 				"something-that-allows-empty-string": "",
 			},
@@ -73,14 +68,12 @@ func TestBuildArgumentListFromMap(t *testing.T) {
 			expected: []string{
 				"--admission-control=NamespaceLifecycle,LimitRanger",
 				"--allow-privileged=true",
-				"--insecure-bind-address=127.0.0.1",
 				"--something-that-allows-empty-string=",
 			},
 		},
 		{
 			name: "allow empty strings in overrides",
 			base: map[string]string{
-				"insecure-bind-address":              "127.0.0.1",
 				"allow-privileged":                   "true",
 				"something-that-allows-empty-string": "foo",
 			},
@@ -91,7 +84,6 @@ func TestBuildArgumentListFromMap(t *testing.T) {
 			expected: []string{
 				"--admission-control=NamespaceLifecycle,LimitRanger",
 				"--allow-privileged=true",
-				"--insecure-bind-address=127.0.0.1",
 				"--something-that-allows-empty-string=",
 			},
 		},
@@ -117,28 +109,24 @@ func TestParseArgumentListToMap(t *testing.T) {
 			name: "normal case",
 			args: []string{
 				"--admission-control=NamespaceLifecycle,LimitRanger",
-				"--insecure-bind-address=127.0.0.1",
 				"--allow-privileged=true",
 			},
 			expectedMap: map[string]string{
-				"admission-control":     "NamespaceLifecycle,LimitRanger",
-				"insecure-bind-address": "127.0.0.1",
-				"allow-privileged":      "true",
+				"admission-control": "NamespaceLifecycle,LimitRanger",
+				"allow-privileged":  "true",
 			},
 		},
 		{
 			name: "test that feature-gates is working",
 			args: []string{
 				"--admission-control=NamespaceLifecycle,LimitRanger",
-				"--insecure-bind-address=127.0.0.1",
 				"--allow-privileged=true",
 				"--feature-gates=EnableFoo=true,EnableBar=false",
 			},
 			expectedMap: map[string]string{
-				"admission-control":     "NamespaceLifecycle,LimitRanger",
-				"insecure-bind-address": "127.0.0.1",
-				"allow-privileged":      "true",
-				"feature-gates":         "EnableFoo=true,EnableBar=false",
+				"admission-control": "NamespaceLifecycle,LimitRanger",
+				"allow-privileged":  "true",
+				"feature-gates":     "EnableFoo=true,EnableBar=false",
 			},
 		},
 		{
@@ -146,15 +134,13 @@ func TestParseArgumentListToMap(t *testing.T) {
 			args: []string{
 				"kube-apiserver",
 				"--admission-control=NamespaceLifecycle,LimitRanger",
-				"--insecure-bind-address=127.0.0.1",
 				"--allow-privileged=true",
 				"--feature-gates=EnableFoo=true,EnableBar=false",
 			},
 			expectedMap: map[string]string{
-				"admission-control":     "NamespaceLifecycle,LimitRanger",
-				"insecure-bind-address": "127.0.0.1",
-				"allow-privileged":      "true",
-				"feature-gates":         "EnableFoo=true,EnableBar=false",
+				"admission-control": "NamespaceLifecycle,LimitRanger",
+				"allow-privileged":  "true",
+				"feature-gates":     "EnableFoo=true,EnableBar=false",
 			},
 		},
 	}
@@ -181,7 +167,6 @@ func TestReplaceArgument(t *testing.T) {
 			args: []string{
 				"kube-apiserver",
 				"--admission-control=NamespaceLifecycle,LimitRanger",
-				"--insecure-bind-address=127.0.0.1",
 				"--allow-privileged=true",
 			},
 			mutateFunc: func(argMap map[string]string) map[string]string {
@@ -191,7 +176,6 @@ func TestReplaceArgument(t *testing.T) {
 			expectedArgs: []string{
 				"kube-apiserver",
 				"--admission-control=NamespaceLifecycle,LimitRanger,ResourceQuota",
-				"--insecure-bind-address=127.0.0.1",
 				"--allow-privileged=true",
 			},
 		},
@@ -200,7 +184,6 @@ func TestReplaceArgument(t *testing.T) {
 			args: []string{
 				"kube-apiserver",
 				"--admission-control=NamespaceLifecycle,LimitRanger",
-				"--insecure-bind-address=127.0.0.1",
 				"--allow-privileged=true",
 			},
 			mutateFunc: func(argMap map[string]string) map[string]string {
@@ -210,7 +193,6 @@ func TestReplaceArgument(t *testing.T) {
 			expectedArgs: []string{
 				"kube-apiserver",
 				"--admission-control=NamespaceLifecycle,LimitRanger",
-				"--insecure-bind-address=127.0.0.1",
 				"--allow-privileged=true",
 				"--new-arg-here=foo",
 			},
@@ -238,7 +220,6 @@ func TestRoundtrip(t *testing.T) {
 			name: "normal case",
 			args: []string{
 				"--admission-control=NamespaceLifecycle,LimitRanger",
-				"--insecure-bind-address=127.0.0.1",
 				"--allow-privileged=true",
 			},
 		},
@@ -246,7 +227,6 @@ func TestRoundtrip(t *testing.T) {
 			name: "test that feature-gates is working",
 			args: []string{
 				"--admission-control=NamespaceLifecycle,LimitRanger",
-				"--insecure-bind-address=127.0.0.1",
 				"--allow-privileged=true",
 				"--feature-gates=EnableFoo=true,EnableBar=false",
 			},

--- a/cmd/kubeadm/app/util/staticpod/utils_test.go
+++ b/cmd/kubeadm/app/util/staticpod/utils_test.go
@@ -577,13 +577,11 @@ func TestGetExtraParameters(t *testing.T) {
 				"admission-control": "NamespaceLifecycle,LimitRanger",
 			},
 			defaults: map[string]string{
-				"admission-control":     "NamespaceLifecycle",
-				"insecure-bind-address": "127.0.0.1",
-				"allow-privileged":      "true",
+				"admission-control": "NamespaceLifecycle",
+				"allow-privileged":  "true",
 			},
 			expected: []string{
 				"--admission-control=NamespaceLifecycle,LimitRanger",
-				"--insecure-bind-address=127.0.0.1",
 				"--allow-privileged=true",
 			},
 		},
@@ -593,12 +591,10 @@ func TestGetExtraParameters(t *testing.T) {
 				"admission-control": "NamespaceLifecycle,LimitRanger",
 			},
 			defaults: map[string]string{
-				"insecure-bind-address": "127.0.0.1",
-				"allow-privileged":      "true",
+				"allow-privileged": "true",
 			},
 			expected: []string{
 				"--admission-control=NamespaceLifecycle,LimitRanger",
-				"--insecure-bind-address=127.0.0.1",
 				"--allow-privileged=true",
 			},
 		},


### PR DESCRIPTION
#### What type of PR is this?


/kind feature
/kind deprecation

#### What this PR does / why we need it:

apiserver insecure relate flag will be removed in v1.24

#### Special notes for your reviewer:

not sure if we need to delete those filed in https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/apiserver/pkg/server/options/deprecated_insecure_serving.go#L32

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Apiserver remove insecure relate flag
```
