### PR TITLE
Enable RootlessControlPlane by default in kubeadm.

### DIFF
--- a/cmd/kubeadm/app/features/features.go
+++ b/cmd/kubeadm/app/features/features.go
@@ -43,7 +43,7 @@ const (
 var InitFeatureGates = FeatureList{
 	IPv6DualStack:               {FeatureSpec: featuregate.FeatureSpec{Default: true, LockToDefault: true, PreRelease: featuregate.GA}, HiddenInHelpText: true},
 	PublicKeysECDSA:             {FeatureSpec: featuregate.FeatureSpec{Default: false, PreRelease: featuregate.Alpha}},
-	RootlessControlPlane:        {FeatureSpec: featuregate.FeatureSpec{Default: false, PreRelease: featuregate.Alpha}},
+	RootlessControlPlane:        {FeatureSpec: featuregate.FeatureSpec{Default: true, PreRelease: featuregate.Beta}},
 	UnversionedKubeletConfigMap: {FeatureSpec: featuregate.FeatureSpec{Default: false, PreRelease: featuregate.Alpha}},
 }
 

--- a/cmd/kubeadm/app/phases/controlplane/manifests_test.go
+++ b/cmd/kubeadm/app/phases/controlplane/manifests_test.go
@@ -122,6 +122,7 @@ func TestCreateStaticPodFilesAndWrappers(t *testing.T) {
 			// Creates a Cluster Configuration
 			cfg := &kubeadmapi.ClusterConfiguration{
 				KubernetesVersion: "v1.9.0",
+				FeatureGates:      map[string]bool{"RootlessControlPlane": false},
 			}
 
 			// Execute createStaticPodFunction
@@ -150,6 +151,7 @@ func TestCreateStaticPodFilesWithPatches(t *testing.T) {
 	// Creates a Cluster Configuration
 	cfg := &kubeadmapi.ClusterConfiguration{
 		KubernetesVersion: "v1.9.0",
+		FeatureGates:      map[string]bool{"RootlessControlPlane": false},
 	}
 
 	patchesPath := filepath.Join(tmpdir, "patch-files")

--- a/cmd/kubeadm/app/phases/etcd/local_test.go
+++ b/cmd/kubeadm/app/phases/etcd/local_test.go
@@ -72,6 +72,7 @@ func TestCreateLocalEtcdStaticPodManifestFile(t *testing.T) {
 						DataDir: tmpdir + "/etcd",
 					},
 				},
+				FeatureGates: map[string]bool{"RootlessControlPlane": false},
 			},
 			expectedError: false,
 		},
@@ -88,6 +89,7 @@ func TestCreateLocalEtcdStaticPodManifestFile(t *testing.T) {
 						KeyFile:  "/etc/kubernetes/pki/etcd/apiserver-etcd-client.key",
 					},
 				},
+				FeatureGates: map[string]bool{"RootlessControlPlane": false},
 			},
 			expectedError: true,
 		},
@@ -124,6 +126,7 @@ func TestCreateLocalEtcdStaticPodManifestFileWithPatches(t *testing.T) {
 				DataDir: tmpdir + "/etcd",
 			},
 		},
+		FeatureGates: map[string]bool{"RootlessControlPlane": false},
 	}
 
 	patchesPath := filepath.Join(tmpdir, "patch-files")

--- a/cmd/kubeadm/app/phases/upgrade/staticpods_test.go
+++ b/cmd/kubeadm/app/phases/upgrade/staticpods_test.go
@@ -87,6 +87,8 @@ networking:
   dnsDomain: cluster.local
   podSubnet: ""
   serviceSubnet: 10.96.0.0/12
+featureGates:
+  RootlessControlPlane: false
 `, kubeadmapiv1.SchemeGroupVersion.String())
 
 // fakeWaiter is a fake apiclient.Waiter that returns errors it was initialized with


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
This PR updates the RootlessControlPlane feature-gate  to be enabled by default. The control-plane components will now run as non-root by default.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:
I turned the feature gate off in the tests because, in kubernetes unit tests can't run as root and so we cannot update file permissions and create users and groups as needed.

This was manually tested the following way:
1. Created a new kind-node image from these changes.
    ```
    kind build node-image
    ```
2. Created a kind cluster using the new node image.
    ```
    kind create cluster --image kindest/node:latest                                                  
    Creating cluster "kind" ...
      ✓ Ensuring node image (kindest/node:latest) 🖼 
      ✓ Preparing nodes 📦  
      ✓ Writing configuration 📜 
      ✓ Starting control-plane 🕹️ 
      ✓ Installing CNI 🔌 
      ✓ Installing StorageClass 💾 
    Set kubectl context to "kind-kind"
    You can now use your cluster with:

    kubectl cluster-info --context kind-kind

    Thanks for using kind! 😊
    ```
3. Execed into the cluster to make sure that processes are running as non-root users.
    ```
    docker exec -it kind-control-plane /bin/bash
    root@kind-control-plane:/# ps -ax -o uname:16,uid,group:16,gid,supgrp,supgid,cmd
    USER               UID GROUP              GID SUPGRP                                   SUPGID               CMD
    kubeadm-etcd       106 kubeadm-etcd       108 -                                        -                    /pause
    kubeadm-kas        107 kubeadm-kas        109 kubeadm-sa-key-readers                   112                  /pause
    kubeadm-kcm        108 kubeadm-kcm        110 kubeadm-sa-key-readers                   112                  /pause
    kubeadm-ks         109 kubeadm-ks         111 -                                        -                    /pause
    kubeadm-ks         109 kubeadm-ks         111 -                                        -                    kube-scheduler --authentication-kubeconfig=/etc/kubernetes/scheduler.conf --
    kubeadm-kas        107 kubeadm-kas        109 kubeadm-sa-key-readers                   112                  kube-apiserver --advertise-address=172.17.0.2 --allow-privileged=true --auth
    kubeadm-kcm        108 kubeadm-kcm        110 kubeadm-sa-key-readers                   112                  kube-controller-manager --allocate-node-cidrs=true --authentication-kubeconf
    kubeadm-etcd       106 kubeadm-etcd       108 -                                        -                    etcd --advertise-client-urls=https://172.17.0.2:2379 --cert-file=/etc/kubern

    ```

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
kubeadm: Enable RootlessControlPlane by default.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- [KEP 2568]: https://github.com/kubernetes/enhancements/tree/master/keps/sig-cluster-lifecycle/kubeadm/2568-kubeadm-non-root-control-plane
- [KEP Issue]: https://github.com/kubernetes/enhancements/issues/2568
```
