### PR TITLE
Promote Pod- & ServiceProxy Test to Conformance - +12 endpoint coverage

### DIFF
--- a/test/conformance/testdata/conformance.yaml
+++ b/test/conformance/testdata/conformance.yaml
@@ -1377,6 +1377,14 @@
     other platforms like Windows.
   release: v1.9
   file: test/e2e/common/network/networking.go
+- testname: Proxy, validate Proxy responses
+  codename: '[sig-network] Proxy version v1 A set of valid responses are returned
+    for both pod and service Proxy [Conformance]'
+  description: Attempt to create a pod and a service. A set of pod and service endpoints
+    MUST be accessed via Proxy using a list of http methods. A valid response MUST
+    be returned for each endpoint.
+  release: v1.24
+  file: test/e2e/network/proxy.go
 - testname: Proxy, validate ProxyWithPath responses
   codename: '[sig-network] Proxy version v1 A set of valid responses are returned
     for both pod and service ProxyWithPath [Conformance]'

--- a/test/e2e/network/proxy.go
+++ b/test/e2e/network/proxy.go
@@ -368,7 +368,15 @@ var _ = common.SIGDescribe("Proxy", func() {
 			}
 		})
 
-		ginkgo.It("A set of valid responses are returned for both pod and service Proxy", func() {
+		/*
+			Release: v1.24
+			Testname: Proxy, validate Proxy responses
+			Description: Attempt to create a pod and a service. A
+			set of pod and service endpoints MUST be accessed via
+			Proxy using a list of http methods. A valid response
+			MUST be returned for each endpoint.
+		*/
+		framework.ConformanceIt("A set of valid responses are returned for both pod and service Proxy", func() {
 
 			ns := f.Namespace.Name
 			msg := "foo"


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it:**
This PR adds a test to test the following untested endpoints:
connectCoreV1DeleteNamespacedPodProxy
connectCoreV1DeleteNamespacedServiceProxy
connectCoreV1OptionsNamespacedPodProxy
connectCoreV1OptionsNamespacedServiceProxy
connectCoreV1PatchNamespacedPodProxy
connectCoreV1PatchNamespacedServiceProxy
connectCoreV1PostNamespacedPodProxy
connectCoreV1PostNamespacedServiceProxy
connectCoreV1PutNamespacedPodProxy
connectCoreV1PutNamespacedServiceProxy
connectCoreV1HeadNamespacedPodProxy
onnectCoreV1HeadNamespacedServiceProxy

**Which issue(s) this PR fixes:**
Fixes #92949

**Testgrid Link:**
[Link](https://testgrid.k8s.io/sig-release-master-blocking#gce-cos-master-default&width=5&include-filter-by-regex=both.pod.and.service.Proxy$&graph-metrics=test-duration-minutes)

**Special notes for your reviewer:**
Adds +12 endpoint test coverage (good for conformance)

**Does this PR introduce a user-facing change?:**
```
NONE

```

**Release note:**
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:**
```
NONE

```

/sig testing
/sig architecture
/area conformance