### PR TITLE
Improve pathrecorder duplicate registration info

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/server/mux/pathrecorder.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/mux/pathrecorder.go
@@ -103,10 +103,11 @@ func (m *PathRecorderMux) ListedPaths() []string {
 }
 
 func (m *PathRecorderMux) trackCallers(path string) {
+	stack := string(debug.Stack())
 	if existingStack, ok := m.pathStacks[path]; ok {
-		utilruntime.HandleError(fmt.Errorf("registered %q from %v", path, existingStack))
+		utilruntime.HandleError(fmt.Errorf("duplicate path registration of %q: original registration from %v\n\nnew registration from %v", path, existingStack, stack))
 	}
-	m.pathStacks[path] = string(debug.Stack())
+	m.pathStacks[path] = stack
 }
 
 // refreshMuxLocked creates a new mux and must be called while locked.  Otherwise the view of handlers may


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Print information from both the original path registration and the new
path registration stack traces when encountering a duplicate. This helps
the developer determine where the duplication is coming from and makes
it much easier to resolve.

#### Which issue(s) this PR fixes:
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
