### PR TITLE
Automated cherry pick of #106878: rbd: initialize ceph monitors slice with an empty value.

### DIFF
--- a/staging/src/k8s.io/csi-translation-lib/plugins/rbd.go
+++ b/staging/src/k8s.io/csi-translation-lib/plugins/rbd.go
@@ -219,7 +219,7 @@ func (p rbdCSITranslator) TranslateCSIPVToInTree(pv *v1.PersistentVolume) (*v1.P
 		return nil, fmt.Errorf("pv is nil or CSI source not defined on pv")
 	}
 	var rbdImageName string
-	var monSlice []string
+	monSlice := []string{""}
 	csiSource := pv.Spec.CSI
 
 	rbdImageName = csiSource.VolumeAttributes[imgNameKey]

--- a/staging/src/k8s.io/csi-translation-lib/plugins/rbd_test.go
+++ b/staging/src/k8s.io/csi-translation-lib/plugins/rbd_test.go
@@ -415,7 +415,7 @@ func TestTranslateCSIPvToInTree(t *testing.T) {
 					},
 					PersistentVolumeSource: v1.PersistentVolumeSource{
 						RBD: &v1.RBDPersistentVolumeSource{
-							CephMonitors: nil,
+							CephMonitors: []string{""},
 							RBDPool:      "replicapool",
 							RBDImage:     "kubernetes-dynamic-pvc-e4111eb6-4088-11ec-b823-0242ac110003",
 							RadosUser:    "admin",


### PR DESCRIPTION
Cherry pick of #106878 on release-1.23.

#106878: rbd: initialize ceph monitors slice with an empty value.