### PR TITLE
Add max-retries flag to SAController cli.

### DIFF
--- a/cmd/kube-controller-manager/app/controllermanager.go
+++ b/cmd/kube-controller-manager/app/controllermanager.go
@@ -627,6 +627,9 @@ func (c serviceAccountTokenControllerStarter) startServiceAccountTokenController
 	if err != nil {
 		return nil, false, fmt.Errorf("failed to build token generator: %v", err)
 	}
+
+	maxRetries := controllerContext.ComponentConfig.SAController.MaxRetries
+
 	controller, err := serviceaccountcontroller.NewTokensController(
 		controllerContext.InformerFactory.Core().V1().ServiceAccounts(),
 		controllerContext.InformerFactory.Core().V1().Secrets(),
@@ -635,6 +638,7 @@ func (c serviceAccountTokenControllerStarter) startServiceAccountTokenController
 			TokenGenerator: tokenGenerator,
 			RootCA:         rootCA,
 			AutoGenerate:   !utilfeature.DefaultFeatureGate.Enabled(kubefeatures.LegacyServiceAccountTokenNoAutoGeneration),
+			MaxRetries:     maxRetries,
 		},
 	)
 	if err != nil {

--- a/cmd/kube-controller-manager/app/options/options_test.go
+++ b/cmd/kube-controller-manager/app/options/options_test.go
@@ -126,6 +126,7 @@ var args = []string{
 	"--leader-elect-retry-period=5s",
 	"--master=192.168.4.20",
 	"--max-endpoints-per-slice=200",
+	"--max-retries=15",
 	"--min-resync-period=8h",
 	"--mirroring-concurrent-service-endpoint-syncs=2",
 	"--mirroring-max-endpoints-per-subset=1000",
@@ -394,6 +395,7 @@ func TestAddFlags(t *testing.T) {
 			&serviceaccountconfig.SAControllerConfiguration{
 				ServiceAccountKeyFile:  "/service-account-private-key",
 				ConcurrentSATokenSyncs: 10,
+				MaxRetries:             15,
 			},
 		},
 		TTLAfterFinishedController: &TTLAfterFinishedControllerOptions{
@@ -629,6 +631,7 @@ func TestApplyTo(t *testing.T) {
 			SAController: serviceaccountconfig.SAControllerConfiguration{
 				ServiceAccountKeyFile:  "/service-account-private-key",
 				ConcurrentSATokenSyncs: 10,
+				MaxRetries:             15,
 			},
 			TTLAfterFinishedController: ttlafterfinishedconfig.TTLAfterFinishedControllerConfiguration{
 				ConcurrentTTLSyncs: 8,

--- a/cmd/kube-controller-manager/app/options/serviceaccountcontroller.go
+++ b/cmd/kube-controller-manager/app/options/serviceaccountcontroller.go
@@ -36,6 +36,7 @@ func (o *SAControllerOptions) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&o.ServiceAccountKeyFile, "service-account-private-key-file", o.ServiceAccountKeyFile, "Filename containing a PEM-encoded private RSA or ECDSA key used to sign service account tokens.")
 	fs.Int32Var(&o.ConcurrentSATokenSyncs, "concurrent-serviceaccount-token-syncs", o.ConcurrentSATokenSyncs, "The number of service account token objects that are allowed to sync concurrently. Larger number = more responsive token generation, but more CPU (and network) load")
 	fs.StringVar(&o.RootCAFile, "root-ca-file", o.RootCAFile, "If set, this root certificate authority will be included in service account's token secret. This must be a valid PEM-encoded CA bundle.")
+	fs.IntVar(&o.MaxRetries, "max-retries", o.MaxRetries, "MaxRetries controls the maximum number of times a particular key is retried before giving up. If zero or not set, a default max is used. (default 10)")
 }
 
 // ApplyTo fills up ServiceAccountController config with options.
@@ -47,6 +48,7 @@ func (o *SAControllerOptions) ApplyTo(cfg *serviceaccountconfig.SAControllerConf
 	cfg.ServiceAccountKeyFile = o.ServiceAccountKeyFile
 	cfg.ConcurrentSATokenSyncs = o.ConcurrentSATokenSyncs
 	cfg.RootCAFile = o.RootCAFile
+	cfg.MaxRetries = o.MaxRetries
 
 	return nil
 }

--- a/pkg/controller/apis/config/fuzzer/fuzzer.go
+++ b/pkg/controller/apis/config/fuzzer/fuzzer.go
@@ -43,6 +43,7 @@ func Funcs(codecs runtimeserializer.CodecFactory) []interface{} {
 			obj.CSRSigningController.ClusterSigningKeyFile = fmt.Sprintf("/%s", c.RandString())
 			obj.PersistentVolumeBinderController.VolumeConfiguration.FlexVolumePluginDir = fmt.Sprintf("/%s", c.RandString())
 			obj.TTLAfterFinishedController.ConcurrentTTLSyncs = c.Int31()
+			obj.SAController.MaxRetries = 0
 		},
 	}
 }

--- a/pkg/controller/serviceaccount/config/types.go
+++ b/pkg/controller/serviceaccount/config/types.go
@@ -27,4 +27,7 @@ type SAControllerConfiguration struct {
 	// rootCAFile is the root certificate authority will be included in service
 	// account's token secret. This must be a valid PEM-encoded CA bundle.
 	RootCAFile string
+	// MaxRetries controls the maximum number of times a particular key is retried before giving up.
+	// If zero, a default max is used.
+	MaxRetries int
 }

--- a/pkg/controller/serviceaccount/config/v1alpha1/zz_generated.conversion.go
+++ b/pkg/controller/serviceaccount/config/v1alpha1/zz_generated.conversion.go
@@ -92,5 +92,6 @@ func autoConvert_config_SAControllerConfiguration_To_v1alpha1_SAControllerConfig
 	out.ServiceAccountKeyFile = in.ServiceAccountKeyFile
 	out.ConcurrentSATokenSyncs = in.ConcurrentSATokenSyncs
 	out.RootCAFile = in.RootCAFile
+	// WARNING: in.MaxRetries requires manual conversion: does not exist in peer-type
 	return nil
 }


### PR DESCRIPTION
#### What type of PR is this?


Add one of the following kinds:
 /kind feature

 
#### What this PR does / why we need it:
Added max-retries flag in SAController cli to provide 
the maximum number of times a particular key is retried before giving up.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #106587

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
   NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
   NONE
```
