### PR TITLE
mount-utils: Detect potential stale file handle

### DIFF
--- a/staging/src/k8s.io/mount-utils/mount_helper_common.go
+++ b/staging/src/k8s.io/mount-utils/mount_helper_common.go
@@ -135,17 +135,3 @@ func removePathIfNotMountPoint(mountPath string, mounter Interface, extensiveMou
 	}
 	return notMnt, nil
 }
-
-// PathExists returns true if the specified path exists.
-// TODO: clean this up to use pkg/util/file/FileExists
-func PathExists(path string) (bool, error) {
-	_, err := os.Stat(path)
-	if err == nil {
-		return true, nil
-	} else if os.IsNotExist(err) {
-		return false, nil
-	} else if IsCorruptedMnt(err) {
-		return true, err
-	}
-	return false, err
-}

--- a/staging/src/k8s.io/mount-utils/mount_helper_unix.go
+++ b/staging/src/k8s.io/mount-utils/mount_helper_unix.go
@@ -20,12 +20,15 @@ limitations under the License.
 package mount
 
 import (
+	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"strconv"
 	"strings"
 	"syscall"
 
+	"k8s.io/klog/v2"
 	utilio "k8s.io/utils/io"
 )
 
@@ -51,6 +54,8 @@ func IsCorruptedMnt(err error) bool {
 		underlyingError = pe.Err
 	case *os.SyscallError:
 		underlyingError = pe.Err
+	case syscall.Errno:
+		underlyingError = err
 	}
 
 	return underlyingError == syscall.ENOTCONN || underlyingError == syscall.ESTALE || underlyingError == syscall.EIO || underlyingError == syscall.EACCES || underlyingError == syscall.EHOSTDOWN
@@ -156,4 +161,27 @@ func ParseMountInfo(filename string) ([]MountInfo, error) {
 func isMountPointMatch(mp MountPoint, dir string) bool {
 	deletedDir := fmt.Sprintf("%s\\040(deleted)", dir)
 	return ((mp.Path == dir) || (mp.Path == deletedDir))
+}
+
+// PathExists returns true if the specified path exists.
+// TODO: clean this up to use pkg/util/file/FileExists
+func PathExists(path string) (bool, error) {
+	_, err := os.Stat(path)
+	if err == nil {
+		return true, nil
+	} else if errors.Is(err, fs.ErrNotExist) {
+		err = syscall.Access(path, syscall.F_OK)
+		if err == nil {
+			// The access syscall says the file exists, the stat syscall says it
+			// doesn't. This was observed on CIFS when the path was removed at
+			// the server somehow. POSIX calls this a stale file handle, let's fake
+			// that error and treat the path as existing but corrupted.
+			klog.Warningf("Potential stale file handle detected: %s", path)
+			return true, syscall.ESTALE
+		}
+		return false, nil
+	} else if IsCorruptedMnt(err) {
+		return true, err
+	}
+	return false, err
 }

--- a/staging/src/k8s.io/mount-utils/mount_helper_windows.go
+++ b/staging/src/k8s.io/mount-utils/mount_helper_windows.go
@@ -95,3 +95,17 @@ func ValidateDiskNumber(disk string) error {
 func isMountPointMatch(mp MountPoint, dir string) bool {
 	return mp.Path == dir
 }
+
+// PathExists returns true if the specified path exists.
+// TODO: clean this up to use pkg/util/file/FileExists
+func PathExists(path string) (bool, error) {
+	_, err := os.Stat(path)
+	if err == nil {
+		return true, nil
+	} else if os.IsNotExist(err) {
+		return false, nil
+	} else if IsCorruptedMnt(err) {
+		return true, err
+	}
+	return false, err
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

This is a fix for the issue #97031. It may happen that a subpath mount point on a networking FS gets deleted on the server but in the case of some file systems (CIFS) it would make the stat syscall end with ENOENT, preventing the mount point to be cleaned up and pods using the mount can't be cleanly deleted.

This situation can be detected by calling also access syscall on the same path: if there is a discrepancy between stat and access results, treating the mount as corrupted allows for successful cleanup and unmount.

#### Which issue(s) this PR fixes:
Fixes #97031

#### Special notes for your reviewer:

There exists is another attempt to fix the same problem that doesn't work. It was the discussion in the following PR that lead to this one: https://github.com/kubernetes/kubernetes/pull/105348

```release-note
NONE
```