### PR TITLE
Automated cherry pick of #106854: kubeadm: avoid requiring a CA key during kubeconfig

### DIFF
--- a/cmd/kubeadm/app/phases/certs/renewal/readwriter_test.go
+++ b/cmd/kubeadm/app/phases/certs/renewal/readwriter_test.go
@@ -125,6 +125,11 @@ func TestKubeconfigReadWriter(t *testing.T) {
 		t.Fatalf("couldn't write new embedded certificate: %v", err)
 	}
 
+	// Make sure that CA key is not present during Read() as it is not needed.
+	// This covers testing when the CA is external and not present on the host.
+	_, caKeyPath := pkiutil.PathsForCertAndKey(dirPKI, caName)
+	os.Remove(caKeyPath)
+
 	// Reads back the new certificate embedded in a kubeconfig writer
 	readCert, err = kubeconfigReadWriter.Read()
 	if err != nil {


### PR DESCRIPTION
Cherry pick of #106854 on release-1.20.

#106854: kubeadm: avoid requiring a CA key during kubeconfig

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
kubeadm: allow the "certs check-expiration" command to not require the existence of the cluster CA key (ca.key file) when checking the expiration of managed certificates in kubeconfig files.
```