### PR TITLE
Automated cherry pick of #106854: kubeadm: avoid requiring a CA key during kubeconfig

### DIFF
--- a/cmd/kubeadm/app/phases/certs/renewal/readwriter.go
+++ b/cmd/kubeadm/app/phases/certs/renewal/readwriter.go
@@ -22,15 +22,14 @@ import (
 	"os"
 	"path/filepath"
 
-	certsphase "k8s.io/kubernetes/cmd/kubeadm/app/phases/certs"
-	pkiutil "k8s.io/kubernetes/cmd/kubeadm/app/util/pkiutil"
+	"github.com/pkg/errors"
 
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 	certutil "k8s.io/client-go/util/cert"
 	"k8s.io/client-go/util/keyutil"
 
-	"github.com/pkg/errors"
+	pkiutil "k8s.io/kubernetes/cmd/kubeadm/app/util/pkiutil"
 )
 
 // certificateReadWriter defines the behavior of a component that
@@ -141,11 +140,15 @@ func (rw *kubeConfigReadWriter) Read() (*x509.Certificate, error) {
 	// For local CA renewal, the local CA on disk could have changed, thus a reload is needed.
 	// For CSR renewal we assume the same CA on disk is mounted for usage with KCM's
 	// '--cluster-signing-cert-file' flag.
-	caCert, _, err := certsphase.LoadCertificateAuthority(rw.certificateDir, rw.baseName)
+	certificatePath, _ := pkiutil.PathsForCertAndKey(rw.certificateDir, rw.baseName)
+	caCerts, err := certutil.CertsFromFile(certificatePath)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrapf(err, "failed to load existing certificate %s", rw.baseName)
 	}
-	rw.caCert = caCert
+	if len(caCerts) != 1 {
+		return nil, errors.Errorf("wanted exactly one certificate, got %d", len(caCerts))
+	}
+	rw.caCert = caCerts[0]
 
 	// get current context
 	if _, ok := kubeConfig.Contexts[kubeConfig.CurrentContext]; !ok {

--- a/cmd/kubeadm/app/phases/certs/renewal/readwriter_test.go
+++ b/cmd/kubeadm/app/phases/certs/renewal/readwriter_test.go
@@ -126,6 +126,11 @@ func TestKubeconfigReadWriter(t *testing.T) {
 		t.Fatalf("couldn't write new embedded certificate: %v", err)
 	}
 
+	// Make sure that CA key is not present during Read() as it is not needed.
+	// This covers testing when the CA is external and not present on the host.
+	_, caKeyPath := pkiutil.PathsForCertAndKey(dirPKI, caName)
+	os.Remove(caKeyPath)
+
 	// Reads back the new certificate embedded in a kubeconfig writer
 	readCert, err = kubeconfigReadWriter.Read()
 	if err != nil {


### PR DESCRIPTION
Cherry pick of #106854 on release-1.22.

#106854: kubeadm: avoid requiring a CA key during kubeconfig

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
kubeadm: allow the "certs check-expiration" command to not require the existence of the cluster CA key (ca.key file) when checking the expiration of managed certificates in kubeconfig files.
```