### PR TITLE
Document when workqueue metrics are dropped

### DIFF
--- a/staging/src/k8s.io/client-go/util/workqueue/delaying_queue.go
+++ b/staging/src/k8s.io/client-go/util/workqueue/delaying_queue.go
@@ -33,7 +33,9 @@ type DelayingInterface interface {
 	AddAfter(item interface{}, duration time.Duration)
 }
 
-// NewDelayingQueue constructs a new workqueue with delayed queuing ability
+// NewDelayingQueue constructs a new workqueue with delayed queuing ability.
+// NewDelayingQueue does not emit metrics. For use with a MetricsProvider, please use
+// NewNamedDelayingQueue instead.
 func NewDelayingQueue() DelayingInterface {
 	return NewDelayingQueueWithCustomClock(clock.RealClock{}, "")
 }

--- a/staging/src/k8s.io/client-go/util/workqueue/rate_limiting_queue.go
+++ b/staging/src/k8s.io/client-go/util/workqueue/rate_limiting_queue.go
@@ -34,6 +34,8 @@ type RateLimitingInterface interface {
 
 // NewRateLimitingQueue constructs a new workqueue with rateLimited queuing ability
 // Remember to call Forget!  If you don't, you may end up tracking failures forever.
+// NewRateLimitingQueue does not emit metrics. For use with a MetricsProvider, please use
+// NewNamedRateLimitingQueue instead.
 func NewRateLimitingQueue(rateLimiter RateLimiter) RateLimitingInterface {
 	return &rateLimitingType{
 		DelayingInterface: NewDelayingQueue(),


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:

Two simple choices for workqueues do not document that they do not emit metrics. Using their named variants fixes this, but was undocumented.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

