### PR TITLE
kubelet: pods that can be considered as terminated on k8s API server should be always excluded from active pods lists

### DIFF
--- a/pkg/kubelet/kubelet_pods.go
+++ b/pkg/kubelet/kubelet_pods.go
@@ -986,6 +986,15 @@ func (kl *Kubelet) filterOutInactivePods(pods []*v1.Pod) []*v1.Pod {
 			continue
 		}
 
+		// If a pod can be considered as terminated on k8s API server, it should be always
+		// excluded from the list of pods.
+		// This is needed to avoid insufficient resources errors when kubelet admits new pods.
+		if s, ok := kl.statusManager.GetPodStatus(p.UID); ok {
+			if s.Phase == v1.PodSucceeded || s.Phase == v1.PodFailed {
+				continue
+			}
+		}
+
 		filteredPods = append(filteredPods, p)
 	}
 	return filteredPods


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

Optionally add one or more of the following kinds if applicable:

/kind regression


#### What this PR does / why we need it:

There is a race condition between PodWorkers.podSyncStatuses and k8s API server state if all containers of a Pod are finished while PodWorkers processes the Pod event(updateType=0(SyncPodWork)).
Details:
https://github.com/kubernetes/kubernetes/issues/106884#issuecomment-990918325

I updated `filterOutInactivePods` logic to filter additional pods to get active pods.
Terminal pods should be always considered inactive since k8s scheduler may consider them inactive.
This is needed to avoid insufficient resources errors like `OutOfCpu` when kubelet admits new pods.

We couldn't reproduce the race condition in kubernetes 1.21.2 cluster.
We found this issue in kubernetes 1.22.4 and release-1.22 branch(13fe78d2c9df0ec862ccb374998943a793a5efa0).

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #106884

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
