### PR TITLE
support removal of files by the ./hack/update-openapi-spec.sh

### DIFF
--- a/hack/update-openapi-spec.sh
+++ b/hack/update-openapi-spec.sh
@@ -103,6 +103,10 @@ curl -w "\n" -kfsS -H 'Authorization: Bearer dummy_token' "https://${API_HOST}:$
 kube::log::status "Updating " "${OPENAPI_ROOT_DIR}/v3 for OpenAPI v3"
 
 mkdir -p "${OPENAPI_ROOT_DIR}/v3"
+# clean up folder, note that some files start with dot like
+# ".well-known__openid-configuration_openapi.json"
+rm -r "${OPENAPI_ROOT_DIR}"/v3/{*,.*} || true
+
 curl -w "\n" -kfsS -H 'Authorization: Bearer dummy_token' "https://${API_HOST}:${API_PORT}/openapi/v3" | jq '.Paths' | jq -r '.[]' | while read -r group; do
     kube::log::status "Updating OpenAPI spec for group ${group}"
     OPENAPI_FILENAME="${group}_openapi.json"


### PR DESCRIPTION
#### What type of PR is this?

When file needs to be removed from the `api/openapi-spec/v3` or file was accidentally added to the folder, `verify-openapi-spec.sh` will fail as it will detect an unexpected file, while `update-openapi-spec.sh` will not remove them. The error is hard to troubleshoot.

Discovered during: https://github.com/kubernetes/kubernetes/pull/103061#issuecomment-990408358

/sig api-machinery
/kind cleanup
/priority backlog

```release-note
NONE
```
