### PR TITLE
make cAdvisor hoursekeeping flags configurable

### DIFF
--- a/cmd/kubelet/app/options/options.go
+++ b/cmd/kubelet/app/options/options.go
@@ -541,4 +541,7 @@ func AddKubeletConfigFlags(mainfs *pflag.FlagSet, c *kubeletconfig.KubeletConfig
 	fs.BoolVar(&c.RegisterNode, "register-node", c.RegisterNode, "Register the node with the apiserver. If --kubeconfig is not provided, this flag is irrelevant, as the Kubelet won't have an apiserver to register with.")
 
 	fs.Var(&utilflag.RegisterWithTaintsVar{Value: &c.RegisterWithTaints}, "register-with-taints", "Register the node with the given list of taints (comma separated \"<key>=<value>:<effect>\"). No-op if register-node is false.")
+
+	fs.DurationVar(&c.CAdvisorHousekeepingInterval.Duration, "cadvisor-housekeeping-interval", c.CAdvisorHousekeepingInterval.Duration, "cAdvisor interval between container housekeepings. default 10s")
+	fs.DurationVar(&c.CAdvisorMaxHousekeepingInterval.Duration, "cadvisor-max-housekeeping-interval", c.CAdvisorMaxHousekeepingInterval.Duration, "cAdvisor largest interval to allow between container housekeepings. default 15s")
 }

--- a/cmd/kubelet/app/server.go
+++ b/cmd/kubelet/app/server.go
@@ -678,7 +678,7 @@ func run(ctx context.Context, s *options.KubeletServer, kubeDeps *kubelet.Depend
 
 	if kubeDeps.CAdvisorInterface == nil {
 		imageFsInfoProvider := cadvisor.NewImageFsInfoProvider(s.ContainerRuntime, s.RemoteRuntimeEndpoint)
-		kubeDeps.CAdvisorInterface, err = cadvisor.New(imageFsInfoProvider, s.RootDirectory, cgroupRoots, cadvisor.UsingLegacyCadvisorStats(s.ContainerRuntime, s.RemoteRuntimeEndpoint))
+		kubeDeps.CAdvisorInterface, err = cadvisor.New(imageFsInfoProvider, s.RootDirectory, cgroupRoots, s.CAdvisorHousekeepingInterval.Duration, s.CAdvisorMaxHousekeepingInterval.Duration, cadvisor.UsingLegacyCadvisorStats(s.ContainerRuntime, s.RemoteRuntimeEndpoint))
 		if err != nil {
 			return err
 		}

--- a/pkg/kubelet/apis/config/fuzzer/fuzzer.go
+++ b/pkg/kubelet/apis/config/fuzzer/fuzzer.go
@@ -110,6 +110,8 @@ func Funcs(codecs runtimeserializer.CodecFactory) []interface{} {
 			}
 			obj.EnableSystemLogHandler = true
 			obj.MemoryThrottlingFactor = utilpointer.Float64Ptr(rand.Float64())
+			obj.CAdvisorHousekeepingInterval = metav1.Duration{Duration: 10 * time.Second}
+			obj.CAdvisorMaxHousekeepingInterval = metav1.Duration{Duration: 15 * time.Second}
 		},
 	}
 }

--- a/pkg/kubelet/apis/config/scheme/testdata/KubeletConfiguration/after/v1beta1.yaml
+++ b/pkg/kubelet/apis/config/scheme/testdata/KubeletConfiguration/after/v1beta1.yaml
@@ -87,3 +87,5 @@ topologyManagerPolicy: none
 topologyManagerScope: container
 volumePluginDir: /usr/libexec/kubernetes/kubelet-plugins/volume/exec/
 volumeStatsAggPeriod: 1m0s
+cAdvisorHousekeepingInterval: 10s
+cAdvisorMaxHousekeepingInterval: 15s

--- a/pkg/kubelet/apis/config/scheme/testdata/KubeletConfiguration/roundtrip/default/v1beta1.yaml
+++ b/pkg/kubelet/apis/config/scheme/testdata/KubeletConfiguration/roundtrip/default/v1beta1.yaml
@@ -87,3 +87,5 @@ topologyManagerPolicy: none
 topologyManagerScope: container
 volumePluginDir: /usr/libexec/kubernetes/kubelet-plugins/volume/exec/
 volumeStatsAggPeriod: 1m0s
+cAdvisorHousekeepingInterval: 10s
+cAdvisorMaxHousekeepingInterval: 15s

--- a/pkg/kubelet/apis/config/types.go
+++ b/pkg/kubelet/apis/config/types.go
@@ -444,6 +444,17 @@ type KubeletConfiguration struct {
 	// registerNode enables automatic registration with the apiserver.
 	// +optional
 	RegisterNode bool
+
+	// CAdvisorHousekeepingInterval is interval between container housekeepings
+	// See https://github.com/google/cadvisor/blob/master/docs/runtime_options.md#housekeeping-intervals for more details.
+	// Default: 10s
+	// +optional
+	CAdvisorHousekeepingInterval metav1.Duration
+	// cAdvisor maxHousekeepingInterval is the maximum interval between container housekeepings.
+	// See https://github.com/google/cadvisor/blob/master/docs/runtime_options.md#housekeeping-intervals for more details.
+	// Default: 15s
+	// +optional
+	CAdvisorMaxHousekeepingInterval metav1.Duration
 }
 
 // KubeletAuthorizationMode denotes the authorization mode for the kubelet

--- a/pkg/kubelet/apis/config/v1beta1/zz_generated.conversion.go
+++ b/pkg/kubelet/apis/config/v1beta1/zz_generated.conversion.go
@@ -407,6 +407,8 @@ func autoConvert_v1beta1_KubeletConfiguration_To_config_KubeletConfiguration(in 
 	if err := v1.Convert_Pointer_bool_To_bool(&in.RegisterNode, &out.RegisterNode, s); err != nil {
 		return err
 	}
+	out.CAdvisorHousekeepingInterval = in.CAdvisorHousekeepingInterval
+	out.CAdvisorMaxHousekeepingInterval = in.CAdvisorMaxHousekeepingInterval
 	return nil
 }
 
@@ -583,6 +585,8 @@ func autoConvert_config_KubeletConfiguration_To_v1beta1_KubeletConfiguration(in 
 	if err := v1.Convert_bool_To_Pointer_bool(&in.RegisterNode, &out.RegisterNode, s); err != nil {
 		return err
 	}
+	out.CAdvisorHousekeepingInterval = in.CAdvisorHousekeepingInterval
+	out.CAdvisorMaxHousekeepingInterval = in.CAdvisorMaxHousekeepingInterval
 	return nil
 }
 

--- a/pkg/kubelet/apis/config/validation/validation.go
+++ b/pkg/kubelet/apis/config/validation/validation.go
@@ -247,6 +247,12 @@ func ValidateKubeletConfiguration(kc *kubeletconfig.KubeletConfiguration) error 
 	if kc.MemoryThrottlingFactor != nil && (*kc.MemoryThrottlingFactor <= 0 || *kc.MemoryThrottlingFactor > 1.0) {
 		allErrors = append(allErrors, fmt.Errorf("invalid configuration: memoryThrottlingFactor %v must be greater than 0 and less than or equal to 1.0", *kc.MemoryThrottlingFactor))
 	}
+	if kc.CAdvisorHousekeepingInterval.Duration <= 0 {
+		allErrors = append(allErrors, fmt.Errorf("invalid configuration: cAdvisorHousekeepingInterval must be greater than 0"))
+	}
+	if kc.CAdvisorMaxHousekeepingInterval.Duration < kc.CAdvisorHousekeepingInterval.Duration {
+		allErrors = append(allErrors, fmt.Errorf("invalid configuration: cAdvisorMaxHousekeepingInterval must be greater than or equal to cAdvisorHousekeepingInterval"))
+	}
 
 	return utilerrors.NewAggregate(allErrors)
 }

--- a/pkg/kubelet/apis/config/zz_generated.deepcopy.go
+++ b/pkg/kubelet/apis/config/zz_generated.deepcopy.go
@@ -307,6 +307,8 @@ func (in *KubeletConfiguration) DeepCopyInto(out *KubeletConfiguration) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	out.CAdvisorHousekeepingInterval = in.CAdvisorHousekeepingInterval
+	out.CAdvisorMaxHousekeepingInterval = in.CAdvisorMaxHousekeepingInterval
 	return
 }
 

--- a/staging/src/k8s.io/kubelet/config/v1beta1/types.go
+++ b/staging/src/k8s.io/kubelet/config/v1beta1/types.go
@@ -1072,6 +1072,16 @@ type KubeletConfiguration struct {
 	// Default: true
 	// +optional
 	RegisterNode *bool `json:"registerNode,omitempty"`
+	// CAdvisorHousekeepingInterval is interval between container housekeepings
+	// See https://github.com/google/cadvisor/blob/master/docs/runtime_options.md#housekeeping-intervals for more details.
+	// Default: 10s
+	// +optional
+	CAdvisorHousekeepingInterval  metav1.Duration `json:"cAdvisorHousekeepingInterval,omitempty"`
+	// cAdvisor maxHousekeepingInterval is the maximum interval between container housekeepings.
+	// See https://github.com/google/cadvisor/blob/master/docs/runtime_options.md#housekeeping-intervals for more details.
+	// Default: 15s
+	// +optional
+	CAdvisorMaxHousekeepingInterval  metav1.Duration `json:"cAdvisorMaxHousekeepingInterval,omitempty"`
 }
 
 type KubeletAuthorizationMode string

--- a/staging/src/k8s.io/kubelet/config/v1beta1/zz_generated.deepcopy.go
+++ b/staging/src/k8s.io/kubelet/config/v1beta1/zz_generated.deepcopy.go
@@ -362,6 +362,8 @@ func (in *KubeletConfiguration) DeepCopyInto(out *KubeletConfiguration) {
 		*out = new(bool)
 		**out = **in
 	}
+	out.CAdvisorHousekeepingInterval = in.CAdvisorHousekeepingInterval
+	out.CAdvisorMaxHousekeepingInterval = in.CAdvisorMaxHousekeepingInterval
 	return
 }
 

--- a/test/e2e_node/environment/conformance.go
+++ b/test/e2e_node/environment/conformance.go
@@ -26,6 +26,7 @@ import (
 	"os/exec"
 	"regexp"
 	"strings"
+	"time"
 
 	"errors"
 	"os"
@@ -99,7 +100,7 @@ func containerRuntime() error {
 	}
 
 	// Setup cadvisor to check the container environment
-	c, err := cadvisor.New(cadvisor.NewImageFsInfoProvider("docker", ""), "/var/lib/kubelet", []string{"/"}, false)
+	c, err := cadvisor.New(cadvisor.NewImageFsInfoProvider("docker", ""), "/var/lib/kubelet", []string{"/"}, 10*time.Second, 15*time.Second, false)
 	if err != nil {
 		return printError("Container Runtime Check: %s Could not start cadvisor %v", failed, err)
 	}


### PR DESCRIPTION

#### What type of PR is this?

/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change


#### What this PR does / why we need it:
make kubelet cadvisor hoursekeeping interval configurable.

in our cluster. we scrape pod cpu usage and other metrics less than 15s. we need cadvisor report metrics more  frequency.


#### Special notes for your reviewer:

