### PR TITLE
Re-introduce removed kubectl --dry-run values.

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/util/helpers.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/util/helpers.go
@@ -23,6 +23,7 @@ import (
 	"io"
 	"net/url"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 
@@ -546,18 +547,30 @@ const (
 
 func GetDryRunStrategy(cmd *cobra.Command) (DryRunStrategy, error) {
 	var dryRunFlag = GetFlagString(cmd, "dry-run")
-	switch dryRunFlag {
-	case cmd.Flag("dry-run").NoOptDefVal:
-		return DryRunNone, errors.New(`--dry-run flag without a value was specified. A value must be set: "none", "server", or "client".`)
-	case "client":
-		return DryRunClient, nil
-	case "server":
-		return DryRunServer, nil
-	case "none":
-		return DryRunNone, nil
-	default:
-		return DryRunNone, fmt.Errorf(`Invalid dry-run value (%v). Must be "none", "server", or "client".`, dryRunFlag)
+	b, err := strconv.ParseBool(dryRunFlag)
+	// The flag is not a boolean
+	if err != nil {
+		switch dryRunFlag {
+		case cmd.Flag("dry-run").NoOptDefVal:
+			klog.Warning(`--dry-run is deprecated and can be replaced with --dry-run=client.`)
+			return DryRunClient, nil
+		case "client":
+			return DryRunClient, nil
+		case "server":
+			return DryRunServer, nil
+		case "none":
+			return DryRunNone, nil
+		default:
+			return DryRunNone, fmt.Errorf(`Invalid dry-run value (%v). Must be "none", "server", or "client".`, dryRunFlag)
+		}
 	}
+	// The flag was a boolean
+	if b {
+		klog.Warningf(`--dry-run=%v is deprecated (boolean value) and can be replaced with --dry-run=%s.`, dryRunFlag, "client")
+		return DryRunClient, nil
+	}
+	klog.Warningf(`--dry-run=%v is deprecated (boolean value) and can be replaced with --dry-run=%s.`, dryRunFlag, "none")
+	return DryRunNone, nil
 }
 
 // PrintFlagsWithDryRunStrategy sets a success message at print time for the dry run strategy

--- a/test/cmd/apply.sh
+++ b/test/cmd/apply.sh
@@ -101,6 +101,7 @@ run_kubectl_apply_tests() {
   kube::test::get_object_assert pods "{{range.items}}{{${id_field:?}}}:{{end}}" ''
 
   # apply dry-run
+  kubectl apply --dry-run=true -f hack/testdata/pod.yaml "${kube_flags[@]:?}"
   kubectl apply --dry-run=client -f hack/testdata/pod.yaml "${kube_flags[@]:?}"
   kubectl apply --dry-run=server -f hack/testdata/pod.yaml "${kube_flags[@]:?}"
   # No pod exists

--- a/test/cmd/batch.sh
+++ b/test/cmd/batch.sh
@@ -49,7 +49,7 @@ run_job_tests() {
   kube::test::describe_resource_chunk_size_assert cronjobs events "--namespace=test-jobs"
 
   ### Create a job in dry-run mode
-  output_message=$(kubectl create job test-job --from=cronjob/pi --dry-run=client --namespace=test-jobs -o name)
+  output_message=$(kubectl create job test-job --from=cronjob/pi --dry-run=true --namespace=test-jobs -o name)
   # Post-condition: The text 'job.batch/test-job' should be part of the output
   kube::test::if_has_string "${output_message}" 'job.batch/test-job'
   # Post-condition: The test-job wasn't created actually


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:

For 1.23, we removed the kubectl `--dry-run` empty default value (`--dry-run`)
and boolean values (`--dry-run=true` and `--dry-run=false`). This change
required requiring users to specify `--dry-run=client` or `--dry-run=server`
due to a deprecation. This change was made in #105327.

After reconsideration, this change is not worth the churn for users.
It's likely that many users rely on these values for automated and manual use
cases.

This change reverts #105327 and re-introduces the values `--dry-run`,
`--dry-run=true`, and `--dry-run=false`.

This change should be picked for the next patch release of 1.23.

#### Which issue(s) this PR fixes:
 https://github.com/kubernetes/kubernetes/issues/107002

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fixes 1.23 regression in kubectl: restores `--dry-run`, `--dry-run=true`, and `--dry-run=false` for compatibility with pre-1.23 invocations.
```