### PR TITLE
Add metric for reporting total end-to-end mount time

### DIFF
--- a/pkg/volume/util/operationexecutor/operation_executor.go
+++ b/pkg/volume/util/operationexecutor/operation_executor.go
@@ -387,6 +387,9 @@ type VolumeToMount struct {
 	// DesiredSizeLimit indicates the desired upper bound on the size of the volume
 	// (if so implemented)
 	DesiredSizeLimit *resource.Quantity
+
+	// time at which volume was requested to be mounted
+	MountRequestTime time.Time
 }
 
 // DeviceMountState represents device mount state in a global path.

--- a/pkg/volume/util/operationexecutor/operation_generator.go
+++ b/pkg/volume/util/operationexecutor/operation_generator.go
@@ -777,6 +777,12 @@ func (og *operationGenerator) GenerateMountVolumeFunc(
 			}
 		}
 
+		// record total time it takes to mount a volume. This is end to end time that includes waiting for volume to attach, node to be update
+		// plugin call to succeed
+		mountRequestTime := volumeToMount.MountRequestTime
+		totalTimeTaken := time.Since(mountRequestTime).Seconds()
+		util.RecordOperationLatencyMetric(util.GetFullQualifiedPluginNameForVolume(volumePluginName, volumeToMount.VolumeSpec), "volume_mount", totalTimeTaken)
+
 		markVolMountedErr := actualStateOfWorld.MarkVolumeAsMounted(markOpts)
 		if markVolMountedErr != nil {
 			// On failure, return error. Caller will log and retry.

--- a/pkg/volume/util/operationexecutor/operation_generator.go
+++ b/pkg/volume/util/operationexecutor/operation_generator.go
@@ -781,7 +781,7 @@ func (og *operationGenerator) GenerateMountVolumeFunc(
 		// plugin call to succeed
 		mountRequestTime := volumeToMount.MountRequestTime
 		totalTimeTaken := time.Since(mountRequestTime).Seconds()
-		util.RecordOperationLatencyMetric(util.GetFullQualifiedPluginNameForVolume(volumePluginName, volumeToMount.VolumeSpec), "volume_mount", totalTimeTaken)
+		util.RecordOperationLatencyMetric(util.GetFullQualifiedPluginNameForVolume(volumePluginName, volumeToMount.VolumeSpec), "overall_volume_mount", totalTimeTaken)
 
 		markVolMountedErr := actualStateOfWorld.MarkVolumeAsMounted(markOpts)
 		if markVolMountedErr != nil {


### PR DESCRIPTION
This metric includes time spent in waiting for devices to be attached,
any RPC calls and performing recursive chown etc.

```
# The new metric
volume_operation_total_seconds_sum{operation_name="overall_volume_mount",plugin_name="kubernetes.io/nfs"} 0.28519335                                                                                                        
volume_operation_total_seconds_count{operation_name="overall_volume_mount",plugin_name="kubernetes.io/nfs"} 1


# existing metric that just mount operation time exclusively
storage_operation_duration_seconds_sum{migrated="false",operation_name="volume_mount",status="success",volume_plugin="kubernetes.io/nfs"} 0.089663017
storage_operation_duration_seconds_count{migrated="false",operation_name="volume_mount",status="success",volume_plugin="kubernetes.io/nfs"} 1
```

IMO this metric is better representative of time kubelet takes to mount a volume and will be useful for future measurement and debugging.

cc @jsafrane @msau42 

/sig storage

```release-note
Add metric for measuring end-to-end volume mount timing
```

