### PR TITLE
Add basic reconciliation metrics to controllers

### DIFF
--- a/cmd/kube-controller-manager/app/controllermanager.go
+++ b/cmd/kube-controller-manager/app/controllermanager.go
@@ -54,6 +54,7 @@ import (
 	"k8s.io/component-base/cli/globalflag"
 	"k8s.io/component-base/configz"
 	"k8s.io/component-base/logs"
+	ctrlmetrics "k8s.io/component-base/metrics/prometheus/controller"
 	"k8s.io/component-base/term"
 	"k8s.io/component-base/version"
 	"k8s.io/component-base/version/verflag"
@@ -64,7 +65,6 @@ import (
 	"k8s.io/controller-manager/pkg/informerfactory"
 	"k8s.io/controller-manager/pkg/leadermigration"
 	"k8s.io/klog/v2"
-
 	"k8s.io/kubernetes/cmd/kube-controller-manager/app/config"
 	"k8s.io/kubernetes/cmd/kube-controller-manager/app/options"
 	kubectrlmgrconfig "k8s.io/kubernetes/pkg/controller/apis/config"
@@ -207,6 +207,7 @@ func Run(c *config.CompletedConfig, stopCh <-chan struct{}) error {
 
 	run := func(ctx context.Context, startSATokenController InitFunc, initializersFunc ControllerInitializersFunc) {
 
+		ctrlmetrics.RegisterMetrics()
 		controllerContext, err := CreateControllerContext(c, rootClientBuilder, clientBuilder, ctx.Done())
 		if err != nil {
 			klog.Fatalf("error building controller context: %v", err)

--- a/pkg/controller/clusterroleaggregation/clusterroleaggregation_controller.go
+++ b/pkg/controller/clusterroleaggregation/clusterroleaggregation_controller.go
@@ -40,6 +40,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
 
+	metrics "k8s.io/component-base/metrics/prometheus/controller"
 	"k8s.io/kubernetes/pkg/controller"
 )
 
@@ -62,7 +63,9 @@ func NewClusterRoleAggregation(clusterRoleInformer rbacinformers.ClusterRoleInfo
 
 		queue: workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "ClusterRoleAggregator"),
 	}
-	c.syncHandler = c.syncClusterRole
+	// note: the name doesn't match the workqueue name so that it is more consistent with
+	// the other controller names -- e.g. "certificate".
+	c.syncHandler = metrics.SyncAndRecordWithCtx("clusterroleaggregator", c.syncClusterRole)
 
 	clusterRoleInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {

--- a/pkg/controller/daemon/daemon_controller.go
+++ b/pkg/controller/daemon/daemon_controller.go
@@ -47,6 +47,7 @@ import (
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/flowcontrol"
 	"k8s.io/client-go/util/workqueue"
+	metrics "k8s.io/component-base/metrics/prometheus/controller"
 	"k8s.io/component-base/metrics/prometheus/ratelimiter"
 	v1helper "k8s.io/component-helpers/scheduling/corev1"
 	"k8s.io/component-helpers/scheduling/corev1/nodeaffinity"
@@ -201,7 +202,7 @@ func NewDaemonSetsController(
 	dsc.nodeStoreSynced = nodeInformer.Informer().HasSynced
 	dsc.nodeLister = nodeInformer.Lister()
 
-	dsc.syncHandler = dsc.syncDaemonSet
+	dsc.syncHandler = metrics.SyncAndRecordWithCtx("daemonset", dsc.syncDaemonSet)
 	dsc.enqueueDaemonSet = dsc.enqueue
 
 	dsc.failedPodsBackoff = failedPodsBackoff

--- a/pkg/controller/deployment/deployment_controller.go
+++ b/pkg/controller/deployment/deployment_controller.go
@@ -29,7 +29,7 @@ import (
 	"k8s.io/klog/v2"
 
 	apps "k8s.io/api/apps/v1"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -46,6 +46,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/workqueue"
+	metrics "k8s.io/component-base/metrics/prometheus/controller"
 	"k8s.io/component-base/metrics/prometheus/ratelimiter"
 	"k8s.io/kubernetes/pkg/controller"
 	"k8s.io/kubernetes/pkg/controller/deployment/util"
@@ -133,7 +134,7 @@ func NewDeploymentController(dInformer appsinformers.DeploymentInformer, rsInfor
 		DeleteFunc: dc.deletePod,
 	})
 
-	dc.syncHandler = dc.syncDeployment
+	dc.syncHandler = metrics.SyncAndRecordWithCtx("deployment", dc.syncDeployment)
 	dc.enqueueDeployment = dc.enqueue
 
 	dc.dLister = dInformer.Lister()

--- a/pkg/controller/disruption/disruption.go
+++ b/pkg/controller/disruption/disruption.go
@@ -49,6 +49,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/workqueue"
+	metrics "k8s.io/component-base/metrics/prometheus/controller"
 	pdbhelper "k8s.io/component-helpers/apps/poddisruptionbudget"
 	"k8s.io/klog/v2"
 	podutil "k8s.io/kubernetes/pkg/api/v1/pod"
@@ -525,7 +526,7 @@ func (dc *DisruptionController) processNextWorkItem(ctx context.Context) bool {
 	}
 	defer dc.queue.Done(dKey)
 
-	err := dc.sync(ctx, dKey.(string))
+	err := metrics.RunSyncAndRecordWithCtx(ctx, "disruption", dKey.(string), dc.sync)
 	if err == nil {
 		dc.queue.Forget(dKey)
 		return true

--- a/pkg/controller/endpoint/endpoints_controller.go
+++ b/pkg/controller/endpoint/endpoints_controller.go
@@ -39,6 +39,7 @@ import (
 	"k8s.io/client-go/tools/leaderelection/resourcelock"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/workqueue"
+	metrics "k8s.io/component-base/metrics/prometheus/controller"
 	"k8s.io/component-base/metrics/prometheus/ratelimiter"
 	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/pkg/api/v1/endpoints"
@@ -347,7 +348,7 @@ func (e *Controller) processNextWorkItem(ctx context.Context) bool {
 	}
 	defer e.queue.Done(eKey)
 
-	err := e.syncService(ctx, eKey.(string))
+	err := metrics.RunSyncAndRecordWithCtx(ctx, "endpoints", eKey.(string), e.syncService)
 	e.handleErr(err, eKey)
 
 	return true

--- a/pkg/controller/endpointslice/endpointslice_controller.go
+++ b/pkg/controller/endpointslice/endpointslice_controller.go
@@ -39,6 +39,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/workqueue"
+	ctrlmetrics "k8s.io/component-base/metrics/prometheus/controller"
 	"k8s.io/component-base/metrics/prometheus/ratelimiter"
 	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/pkg/controller"
@@ -288,7 +289,7 @@ func (c *Controller) processNextWorkItem() bool {
 	}
 	defer c.queue.Done(cKey)
 
-	err := c.syncService(cKey.(string))
+	err := ctrlmetrics.RunSyncAndRecord("endpointslice", cKey.(string), c.syncService)
 	c.handleErr(err, cKey)
 
 	return true

--- a/pkg/controller/endpointslicemirroring/endpointslicemirroring_controller.go
+++ b/pkg/controller/endpointslicemirroring/endpointslicemirroring_controller.go
@@ -38,6 +38,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/workqueue"
+	ctrlmetrics "k8s.io/component-base/metrics/prometheus/controller"
 	"k8s.io/component-base/metrics/prometheus/ratelimiter"
 	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/pkg/controller"
@@ -240,7 +241,7 @@ func (c *Controller) processNextWorkItem() bool {
 	}
 	defer c.queue.Done(cKey)
 
-	err := c.syncEndpoints(cKey.(string))
+	err := ctrlmetrics.RunSyncAndRecord("endpointslicemirroring", cKey.(string), c.syncEndpoints)
 	c.handleErr(err, cKey)
 
 	return true

--- a/pkg/controller/job/job_controller.go
+++ b/pkg/controller/job/job_controller.go
@@ -27,7 +27,7 @@ import (
 	"time"
 
 	batch "k8s.io/api/batch/v1"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -47,6 +47,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/workqueue"
+	ctrlmetrics "k8s.io/component-base/metrics/prometheus/controller"
 	"k8s.io/component-base/metrics/prometheus/ratelimiter"
 	"k8s.io/klog/v2"
 	podutil "k8s.io/kubernetes/pkg/api/v1/pod"
@@ -170,7 +171,7 @@ func NewController(podInformer coreinformers.PodInformer, jobInformer batchinfor
 
 	jm.updateStatusHandler = jm.updateJobStatus
 	jm.patchJobHandler = jm.patchJob
-	jm.syncHandler = jm.syncJob
+	jm.syncHandler = ctrlmetrics.HasSyncedAndRecordedWithCtx("job", jm.syncJob)
 
 	metrics.Register()
 

--- a/pkg/controller/namespace/namespace_controller.go
+++ b/pkg/controller/namespace/namespace_controller.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/client-go/metadata"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
+	metrics "k8s.io/component-base/metrics/prometheus/controller"
 	"k8s.io/component-base/metrics/prometheus/ratelimiter"
 	"k8s.io/kubernetes/pkg/controller"
 	"k8s.io/kubernetes/pkg/controller/namespace/deletion"
@@ -145,7 +146,7 @@ func (nm *NamespaceController) worker() {
 		}
 		defer nm.queue.Done(key)
 
-		err := nm.syncNamespaceFromKey(key.(string))
+		err := metrics.RunSyncAndRecord("namespace", key.(string), nm.syncNamespaceFromKey)
 		if err == nil {
 			// no error, forget this entry and return
 			nm.queue.Forget(key)

--- a/pkg/controller/podautoscaler/horizontal.go
+++ b/pkg/controller/podautoscaler/horizontal.go
@@ -46,6 +46,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/workqueue"
+	ctrlmetrics "k8s.io/component-base/metrics/prometheus/controller"
 	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/pkg/controller"
 	metricsclient "k8s.io/kubernetes/pkg/controller/podautoscaler/metrics"
@@ -221,7 +222,7 @@ func (a *HorizontalController) processNextWorkItem(ctx context.Context) bool {
 	}
 	defer a.queue.Done(key)
 
-	deleted, err := a.reconcileKey(ctx, key.(string))
+	deleted, err := ctrlmetrics.RunHasSyncedAndRecordedWithCtx(ctx, "horizontalpodautoscaler", key.(string), a.reconcileKey)
 	if err != nil {
 		utilruntime.HandleError(err)
 	}

--- a/pkg/controller/podgc/gc_controller.go
+++ b/pkg/controller/podgc/gc_controller.go
@@ -34,6 +34,7 @@ import (
 	corelisters "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
+	metrics "k8s.io/component-base/metrics/prometheus/controller"
 	"k8s.io/component-base/metrics/prometheus/ratelimiter"
 
 	"k8s.io/klog/v2"
@@ -94,7 +95,8 @@ func (gcc *PodGCController) Run(ctx context.Context) {
 		return
 	}
 
-	go wait.UntilWithContext(ctx, gcc.gc, gcCheckPeriod)
+	sync := metrics.SyncAndRecordAll("podgc", gcc.gc)
+	go wait.UntilWithContext(ctx, sync, gcCheckPeriod)
 
 	<-ctx.Done()
 }

--- a/pkg/controller/replicaset/replica_set.go
+++ b/pkg/controller/replicaset/replica_set.go
@@ -56,6 +56,7 @@ import (
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/component-base/metrics/legacyregistry"
+	ctrlmetrics "k8s.io/component-base/metrics/prometheus/controller"
 	"k8s.io/component-base/metrics/prometheus/ratelimiter"
 	"k8s.io/klog/v2"
 	podutil "k8s.io/kubernetes/pkg/api/v1/pod"
@@ -164,7 +165,7 @@ func NewBaseController(rsInformer appsinformers.ReplicaSetInformer, podInformer 
 	rsc.podLister = podInformer.Lister()
 	rsc.podListerSynced = podInformer.Informer().HasSynced
 
-	rsc.syncHandler = rsc.syncReplicaSet
+	rsc.syncHandler = ctrlmetrics.SyncAndRecordWithCtx("replicaset", rsc.syncReplicaSet)
 
 	return rsc
 }

--- a/pkg/controller/resourcequota/resource_quota_controller.go
+++ b/pkg/controller/resourcequota/resource_quota_controller.go
@@ -42,6 +42,7 @@ import (
 	corelisters "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
+	metrics "k8s.io/component-base/metrics/prometheus/controller"
 	"k8s.io/controller-manager/pkg/informerfactory"
 	"k8s.io/kubernetes/pkg/controller"
 )
@@ -114,7 +115,7 @@ func NewController(options *ControllerOptions) (*Controller, error) {
 		registry:            options.Registry,
 	}
 	// set the synchronization handler
-	rq.syncHandler = rq.syncResourceQuotaFromKey
+	rq.syncHandler = metrics.SyncAndRecordWithCtx("resourcequota", rq.syncResourceQuotaFromKey)
 
 	options.ResourceQuotaInformer.Informer().AddEventHandlerWithResyncPeriod(
 		cache.ResourceEventHandlerFuncs{

--- a/pkg/controller/serviceaccount/serviceaccounts_controller.go
+++ b/pkg/controller/serviceaccount/serviceaccounts_controller.go
@@ -21,7 +21,7 @@ import (
 	"fmt"
 	"time"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
@@ -32,6 +32,7 @@ import (
 	corelisters "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
+	metrics "k8s.io/component-base/metrics/prometheus/controller"
 	"k8s.io/component-base/metrics/prometheus/ratelimiter"
 	"k8s.io/klog/v2"
 )
@@ -87,7 +88,7 @@ func NewServiceAccountsController(saInformer coreinformers.ServiceAccountInforme
 	e.nsLister = nsInformer.Lister()
 	e.nsListerSynced = nsInformer.Informer().HasSynced
 
-	e.syncHandler = e.syncNamespace
+	e.syncHandler = metrics.SyncAndRecordWithCtx("serviceaccount", e.syncNamespace)
 
 	return e, nil
 }

--- a/pkg/controller/statefulset/stateful_set.go
+++ b/pkg/controller/statefulset/stateful_set.go
@@ -40,6 +40,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/workqueue"
+	metrics "k8s.io/component-base/metrics/prometheus/controller"
 	podutil "k8s.io/kubernetes/pkg/api/v1/pod"
 	"k8s.io/kubernetes/pkg/controller"
 	"k8s.io/kubernetes/pkg/controller/history"
@@ -412,7 +413,8 @@ func (ssc *StatefulSetController) processNextWorkItem(ctx context.Context) bool 
 		return false
 	}
 	defer ssc.queue.Done(key)
-	if err := ssc.sync(ctx, key.(string)); err != nil {
+	err := metrics.RunSyncAndRecordWithCtx(ctx, "statefulset", key.(string), ssc.sync)
+	if err != nil {
 		utilruntime.HandleError(fmt.Errorf("error syncing StatefulSet %v, requeuing: %v", key.(string), err))
 		ssc.queue.AddRateLimited(key)
 	} else {

--- a/staging/src/k8s.io/component-base/metrics/prometheus/controller/OWNERS
+++ b/staging/src/k8s.io/component-base/metrics/prometheus/controller/OWNERS
@@ -1,0 +1,8 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+  - sig-instrumentation-approvers
+reviewers:
+  - sig-instrumentation-reviewers
+labels:
+  - sig/instrumentation

--- a/staging/src/k8s.io/component-base/metrics/prometheus/controller/metrics.go
+++ b/staging/src/k8s.io/component-base/metrics/prometheus/controller/metrics.go
@@ -1,0 +1,151 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"k8s.io/component-base/metrics"
+	"k8s.io/component-base/metrics/legacyregistry"
+	"k8s.io/klog/v2"
+)
+
+type sinceFunc func(time.Time) time.Duration
+
+const controllerNamespace = "controller"
+
+var (
+	ReconciliationDurations = metrics.NewHistogramVec(
+		&metrics.HistogramOpts{
+			Namespace:      controllerNamespace,
+			Name:           "reconcile_time_seconds",
+			Help:           "Duration of a sync of a controller's resource",
+			StabilityLevel: metrics.ALPHA,
+			Buckets:        metrics.ExponentialBuckets(0.001, 2, 15),
+		},
+		[]string{"controller", "status"},
+	)
+
+	since sinceFunc = time.Since
+)
+
+var registerMetrics sync.Once
+
+// RegisterMetrics registers the controller metrics
+func RegisterMetrics() {
+	registerMetrics.Do(func() {
+		legacyregistry.MustRegister(ReconciliationDurations)
+	})
+}
+
+// SyncAndRecordWithCtx wraps syncFn with a function, recording its result and duration as a metric.
+func SyncAndRecordWithCtx(
+	controllerName string, syncFn func(context.Context, string) error) func(context.Context, string) error {
+	return func(ctx context.Context, key string) error {
+		return RunSyncAndRecordWithCtx(ctx, controllerName, key, syncFn)
+	}
+}
+
+// RunSyncAndRecordWithCtx runs syncFn with the given context and key, recording the reconcile time and results
+func RunSyncAndRecordWithCtx(
+	ctx context.Context, controllerName string, key string, syncFn func(context.Context, string) error) error {
+	startTime := time.Now()
+	err := syncFn(ctx, key)
+	recordSyncResult(controllerName, startTime, err)
+	return err
+}
+
+// RunSyncAndRecord runs syncFn with key, recording the reconcile time and results
+func RunSyncAndRecord(
+	controllerName string, key string, syncFn func(string) error) error {
+	startTime := time.Now()
+	err := syncFn(key)
+	recordSyncResult(controllerName, startTime, err)
+	return err
+}
+
+// HasSyncedAndRecordedWithCtx wraps syncFn with a function, recording its result and duration as a metric.
+func HasSyncedAndRecordedWithCtx(
+	controllerName string, syncFn func(context.Context, string) (bool, error)) func(context.Context, string) (bool, error) {
+	return func(ctx context.Context, key string) (bool, error) {
+		return RunHasSyncedAndRecordedWithCtx(ctx, controllerName, key, syncFn)
+	}
+}
+
+// HasSyncedAndRecorded wraps syncFn with a function, recording its result and duration as a metric.
+func HasSyncedAndRecorded(
+	controllerName string, syncFn func(string) (bool, error)) func(string) (bool, error) {
+	return func(key string) (bool, error) {
+		return RunHasSyncedAndRecorded(controllerName, key, syncFn)
+	}
+}
+
+// RunHasSyncedAndRecordedWithCtx runs syncFn with key, recording the reconcile time and results
+func RunHasSyncedAndRecordedWithCtx(
+	ctx context.Context, controllerName string, key string, syncFn func(context.Context, string) (bool, error)) (bool, error) {
+	startTime := time.Now()
+	bool, err := syncFn(ctx, key)
+	recordSyncResult(controllerName, startTime, err)
+	return bool, err
+}
+
+// RunHasSyncedAndRecorded runs syncFn with key, recording the reconcile time and results
+func RunHasSyncedAndRecorded(
+	controllerName string, key string, syncFn func(string) (bool, error)) (bool, error) {
+	startTime := time.Now()
+	bool, err := syncFn(key)
+	recordSyncResult(controllerName, startTime, err)
+	return bool, err
+}
+
+// SyncAndRecordAll wraps syncFn with a function, recording its result and duration as a metric.
+func SyncAndRecordAll(controllerName string, syncFn func(context.Context)) func(context.Context) {
+	return func(ctx context.Context) {
+		RunSyncAndRecordAll(ctx, controllerName, syncFn)
+	}
+}
+
+// RunSyncAndRecordAll runs syncFn, recording the reconcile time and results
+func RunSyncAndRecordAll(ctx context.Context, controllerName string, syncFn func(context.Context)) {
+	startTime := time.Now()
+	syncFn(ctx)
+	recordSyncResult(controllerName, startTime, nil)
+}
+
+const (
+	// success indicates a successful sync operation
+	success = "success"
+	// failed indicates a failed sync operation
+	failed = "failed"
+)
+
+// recordSyncResult records the results of a controller sync operation
+func recordSyncResult(controllerName string, startTime time.Time, err error) {
+	status := success
+	if err != nil {
+		status = failed
+	}
+	syncDuration := since(startTime).Seconds()
+
+	ReconciliationDurations.WithLabelValues(controllerName, status).Observe(syncDuration)
+	klog.V(4).InfoS("Finished syncing",
+		"controller", controllerName,
+		"duration", syncDuration,
+		"status", status)
+}

--- a/staging/src/k8s.io/component-base/metrics/prometheus/controller/metrics_test.go
+++ b/staging/src/k8s.io/component-base/metrics/prometheus/controller/metrics_test.go
@@ -1,0 +1,257 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"k8s.io/component-base/metrics"
+)
+
+func TestSyncAndRecordWithCtx(t *testing.T) {
+	since = sinceFn
+
+	keyFn := keyFuncFor("SyncAndRecordWithCtx")
+	exerciseFn := func(tc syncAndRecordTestCase) error {
+		sync := SyncAndRecordWithCtx(keyFn(tc.name), tc.fn)
+		return sync(context.TODO(), tc.name)
+	}
+
+	checkTestCases(t, keyFn, exerciseFn)
+}
+
+func TestRunSyncAndRecordWithCtx(t *testing.T) {
+	since = sinceFn
+
+	keyFn := keyFuncFor("RunSyncAndRecordWithCtx")
+	exerciseFn := func(tc syncAndRecordTestCase) error {
+		return RunSyncAndRecordWithCtx(context.TODO(), keyFn(tc.name), tc.name, tc.fn)
+	}
+
+	checkTestCases(t, keyFn, exerciseFn)
+}
+
+func TestRunSyncAndRecord(t *testing.T) {
+	since = sinceFn
+
+	keyFn := keyFuncFor("RunSyncAndRecord")
+	exerciseFn := func(tc syncAndRecordTestCase) error {
+		return RunSyncAndRecord(keyFn(tc.name), tc.name, tc.fnNoCtx)
+	}
+
+	checkTestCases(t, keyFn, exerciseFn)
+}
+
+func TestHasSyncedAndRecordedWithCtx(t *testing.T) {
+	since = sinceFn
+
+	keyFn := keyFuncFor("HasSyncedAndRecordedWithCtx")
+	exerciseFn := func(tc syncAndRecordTestCase) error {
+		sync := HasSyncedAndRecordedWithCtx(keyFn(tc.name), tc.fnWithBool)
+		_, err := sync(context.TODO(), tc.name)
+		return err
+	}
+
+	checkTestCases(t, keyFn, exerciseFn)
+}
+
+func TestHasSyncedAndRecorded(t *testing.T) {
+	since = sinceFn
+
+	keyFn := keyFuncFor("HasSyncedAndRecorded")
+	exerciseFn := func(tc syncAndRecordTestCase) error {
+		sync := HasSyncedAndRecorded(keyFn(tc.name), tc.fnWithBoolNoCtx)
+		_, err := sync(tc.name)
+		return err
+	}
+
+	checkTestCases(t, keyFn, exerciseFn)
+}
+
+func TestRunHasSyncedAndRecordedWithCtx(t *testing.T) {
+	since = sinceFn
+
+	keyFn := keyFuncFor("RunHasSyncedAndRecordedWithCtx")
+	exerciseFn := func(tc syncAndRecordTestCase) error {
+		_, err := RunHasSyncedAndRecordedWithCtx(context.TODO(), keyFn(tc.name), tc.name, tc.fnWithBool)
+		return err
+	}
+
+	checkTestCases(t, keyFn, exerciseFn)
+}
+
+func TestRunHasSyncedAndRecorded(t *testing.T) {
+	since = sinceFn
+
+	keyFn := keyFuncFor("RunHasSyncedAndRecorded")
+	exerciseFn := func(tc syncAndRecordTestCase) error {
+		_, err := RunHasSyncedAndRecorded(keyFn(tc.name), tc.name, tc.fnWithBoolNoCtx)
+		return err
+	}
+
+	checkTestCases(t, keyFn, exerciseFn)
+}
+
+func TestSyncAndRecordAll(t *testing.T) {
+	// TODO
+}
+
+func RunTestSyncAndRecordAll(t *testing.T) {
+	// TODO
+}
+
+// functions to wrap or pass
+
+func returnErr(ctx context.Context, key string) error {
+	return returnErrNoContext(key)
+}
+
+func returnErrNoContext(key string) error {
+	return fmt.Errorf("%v", key)
+}
+
+func returnErrWithBool(ctx context.Context, key string) (bool, error) {
+	return false, returnErrNoContext(key)
+}
+
+func returnErrWithBoolNoCtx(key string) (bool, error) {
+	return false, returnErrNoContext(key)
+}
+
+func returnOk(ctx context.Context, key string) error {
+	return nil
+}
+
+func returnOkNoContext(key string) error {
+	return nil
+}
+
+func returnOkWithBool(ctx context.Context, key string) (bool, error) {
+	return true, nil
+}
+
+func returnOkWithBoolNoCtx(key string) (bool, error) {
+	return true, nil
+}
+
+type (
+	syncAndRecordTestCase struct {
+		name            string
+		fn              func(context.Context, string) error
+		fnNoCtx         func(string) error
+		fnWithBool      func(context.Context, string) (bool, error)
+		fnWithBoolNoCtx func(string) (bool, error)
+		expectedErr     bool
+	}
+	keyFunc      func(string) string
+	exerciseFunc func(syncAndRecordTestCase) error
+)
+
+var syncAndRecordCases = []syncAndRecordTestCase{
+	{
+		name:            "error",
+		fn:              returnErr,
+		fnNoCtx:         returnErrNoContext,
+		fnWithBool:      returnErrWithBool,
+		fnWithBoolNoCtx: returnErrWithBoolNoCtx,
+		expectedErr:     true,
+	},
+	{
+		name:            "no-error",
+		fn:              returnOk,
+		fnNoCtx:         returnOkNoContext,
+		fnWithBool:      returnOkWithBool,
+		fnWithBoolNoCtx: returnOkWithBoolNoCtx,
+		expectedErr:     false,
+	},
+}
+
+func checkTestCases(t *testing.T, keyFn keyFunc, exerciseFn exerciseFunc) {
+	for ii := range syncAndRecordCases {
+		tc := syncAndRecordCases[ii]
+		t.Run(tc.name, func(t *testing.T) {
+			checkTestCase(t, tc, keyFn, exerciseFn)
+		})
+	}
+}
+
+func checkTestCase(t *testing.T, tc syncAndRecordTestCase, keyFn keyFunc, exerciseFn exerciseFunc) {
+	registry := metrics.NewKubeRegistry()
+	registry.MustRegister(ReconciliationDurations)
+	registry.Reset()
+
+	err := exerciseFn(tc)
+
+	if e, a := tc.expectedErr, (err != nil); e != a {
+		t.Errorf("unexpected behavior: expected err to be %v, got %v", e, a)
+	}
+
+	ms, err := registry.Gather()
+	if err != nil {
+		t.Errorf("error gathering from registry: %v", err)
+	}
+
+	if len(ms) != 1 {
+		t.Errorf("unexpected metrics count, expected 1, got %v", len(ms))
+	}
+
+	mf := ms[0]
+	for _, m := range mf.GetMetric() {
+		for _, l := range m.Label {
+			if *l.Name == "controller" {
+				if e, a := keyFn(tc.name), *l.Value; e != a {
+					t.Errorf("unexpected 'controller' label; expected %v, got %v", keyFn(tc.name), *l.Value)
+				}
+			}
+
+			if *l.Name == "status" {
+				if e, a := expectedStatus(tc.expectedErr), *l.Value; e != a {
+					t.Errorf("unexpected status; expected %v, got %v", e, a)
+				}
+			}
+		}
+
+		if e, a := uint64(1), m.GetHistogram().GetSampleCount(); e != a {
+			t.Errorf("unexpected sample count, expected %v, got %v", e, a)
+		}
+
+		if e, a := 5.0, m.GetHistogram().GetSampleSum(); e != a {
+			t.Errorf("unexpected sample sum; expected %v, got %v", e, a)
+		}
+	}
+}
+
+var sinceFn = func(t time.Time) time.Duration {
+	return 5 * time.Second
+}
+
+func keyFuncFor(name string) func(string) string {
+	return func(s string) string {
+		return name + "-" + s
+	}
+}
+
+func expectedStatus(expectedErr bool) string {
+	if expectedErr {
+		return "failed"
+	}
+
+	return "success"
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1953,6 +1953,7 @@ k8s.io/component-base/metrics
 k8s.io/component-base/metrics/legacyregistry
 k8s.io/component-base/metrics/prometheus/clientgo
 k8s.io/component-base/metrics/prometheus/clientgo/leaderelection
+k8s.io/component-base/metrics/prometheus/controller
 k8s.io/component-base/metrics/prometheus/ratelimiter
 k8s.io/component-base/metrics/prometheus/restclient
 k8s.io/component-base/metrics/prometheus/version


### PR DESCRIPTION
#### What type of PR is this?

This supercedes https://github.com/kubernetes/kubernetes/pull/100709

/kind feature

#### What this PR does / why we need it:

This adds a histogram metric to various controllers, `controller_reconcile_time_seconds`.

Example output:
```
# HELP controller_reconcile_time_seconds [ALPHA] Duration of a sync of a controller's resource
# TYPE controller_reconcile_time_seconds histogram
controller_reconcile_time_seconds_bucket{controller="statefulset",status="error",le="0.001"} 0
controller_reconcile_time_seconds_bucket{controller="statefulset",status="error",le="0.002"} 0
controller_reconcile_time_seconds_bucket{controller="statefulset",status="error",le="0.004"} 0
controller_reconcile_time_seconds_bucket{controller="statefulset",status="error",le="0.008"} 0
controller_reconcile_time_seconds_bucket{controller="statefulset",status="error",le="0.016"} 0
controller_reconcile_time_seconds_bucket{controller="statefulset",status="error",le="0.032"} 6
controller_reconcile_time_seconds_bucket{controller="statefulset",status="error",le="0.064"} 8
controller_reconcile_time_seconds_bucket{controller="statefulset",status="error",le="0.128"} 16
controller_reconcile_time_seconds_bucket{controller="statefulset",status="error",le="0.256"} 37
controller_reconcile_time_seconds_bucket{controller="statefulset",status="error",le="0.512"} 47
controller_reconcile_time_seconds_bucket{controller="statefulset",status="error",le="1.024"} 49
controller_reconcile_time_seconds_bucket{controller="statefulset",status="error",le="2.048"} 49
controller_reconcile_time_seconds_bucket{controller="statefulset",status="error",le="4.096"} 49
controller_reconcile_time_seconds_bucket{controller="statefulset",status="error",le="8.192"} 49
controller_reconcile_time_seconds_bucket{controller="statefulset",status="error",le="16.384"} 49
controller_reconcile_time_seconds_bucket{controller="statefulset",status="error",le="+Inf"} 49
controller_reconcile_time_seconds_sum{controller="statefulset",status="error"} 9.560064066000002
controller_reconcile_time_seconds_count{controller="statefulset",status="error"} 49
controller_reconcile_time_seconds_bucket{controller="statefulset",status="success",le="0.001"} 9
controller_reconcile_time_seconds_bucket{controller="statefulset",status="success",le="0.002"} 62
controller_reconcile_time_seconds_bucket{controller="statefulset",status="success",le="0.004"} 222
controller_reconcile_time_seconds_bucket{controller="statefulset",status="success",le="0.008"} 266
controller_reconcile_time_seconds_bucket{controller="statefulset",status="success",le="0.016"} 280
controller_reconcile_time_seconds_bucket{controller="statefulset",status="success",le="0.032"} 307
controller_reconcile_time_seconds_bucket{controller="statefulset",status="success",le="0.064"} 328
controller_reconcile_time_seconds_bucket{controller="statefulset",status="success",le="0.128"} 341
controller_reconcile_time_seconds_bucket{controller="statefulset",status="success",le="0.256"} 347
controller_reconcile_time_seconds_bucket{controller="statefulset",status="success",le="0.512"} 347
controller_reconcile_time_seconds_bucket{controller="statefulset",status="success",le="1.024"} 352
controller_reconcile_time_seconds_bucket{controller="statefulset",status="success",le="2.048"} 352
controller_reconcile_time_seconds_bucket{controller="statefulset",status="success",le="4.096"} 352
controller_reconcile_time_seconds_bucket{controller="statefulset",status="success",le="8.192"} 352
controller_reconcile_time_seconds_bucket{controller="statefulset",status="success",le="16.384"} 352
controller_reconcile_time_seconds_bucket{controller="statefulset",status="success",le="+Inf"} 352
controller_reconcile_time_seconds_sum{controller="statefulset",status="success"} 8.841072798
controller_reconcile_time_seconds_count{controller="statefulset",status="success"} 352
```

#### Does this PR introduce a user-facing change?
```release-note
adds reconciliation metrics for kube-controller-manager.
```