### PR TITLE
kubeadm: mark v1beta2 as deprecated

### DIFF
--- a/cmd/kubeadm/app/apis/kubeadm/v1beta2/doc.go
+++ b/cmd/kubeadm/app/apis/kubeadm/v1beta2/doc.go
@@ -19,6 +19,8 @@ limitations under the License.
 // +k8s:deepcopy-gen=package
 // +k8s:conversion-gen=k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm
 
+// Package v1beta2 has been DEPRECATED by v1beta3
+//
 // Package v1beta2 defines the v1beta2 version of the kubeadm configuration file format.
 // This version improves on the v1beta1 format by fixing some minor issues and adding a few new fields.
 //

--- a/cmd/kubeadm/app/util/config/common.go
+++ b/cmd/kubeadm/app/util/config/common.go
@@ -69,7 +69,9 @@ func validateSupportedVersion(gv schema.GroupVersion, allowDeprecated bool) erro
 	}
 
 	// Deprecated API versions are supported by us, but can only be used for migration.
-	deprecatedAPIVersions := map[string]struct{}{}
+	deprecatedAPIVersions := map[string]struct{}{
+		"kubeadm.k8s.io/v1beta2": {},
+	}
 
 	gvString := gv.String()
 

--- a/cmd/kubeadm/app/util/config/common_test.go
+++ b/cmd/kubeadm/app/util/config/common_test.go
@@ -73,6 +73,7 @@ func TestValidateSupportedVersion(t *testing.T) {
 				Group:   KubeadmGroupName,
 				Version: "v1beta2",
 			},
+			allowDeprecated: true,
 		},
 		{
 			gv: schema.GroupVersion{


### PR DESCRIPTION
/kind cleanup
/kind deprecation

xref https://github.com/kubernetes/kubeadm/issues/2459

#### Special notes for your reviewer:
v1beta3 was added by #101129 since 1.22. (v1beta1 was removed meanwhile).
There is a list of changes in v1beta3 https://github.com/kubernetes/kubeadm/issues/1796.


```release-note
Action Required: "kubeadm.k8s.io/v1beta2" has been deprecated and will be removed in a future release, possibly in 3 releases (one year). You should start using "kubeadm.k8s.io/v1beta3" for new clusters. To migrate your old configuration files on disk you can use the "kubeadm config migrate" command.
```

https://github.com/kubernetes/kubernetes/blob/d38105be86c22aef5e0d3dbba02a6b61ff311781/cmd/kubeadm/app/apis/kubeadm/v1beta3/doc.go#L25-L45