### PR TITLE
Automated cherry pick of #107003: Re-introduce removed kubectl --dry-run values.

### DIFF
--- a/test/cmd/apply.sh
+++ b/test/cmd/apply.sh
@@ -101,6 +101,7 @@ run_kubectl_apply_tests() {
   kube::test::get_object_assert pods "{{range.items}}{{${id_field:?}}}:{{end}}" ''
 
   # apply dry-run
+  kubectl apply --dry-run=true -f hack/testdata/pod.yaml "${kube_flags[@]:?}"
   kubectl apply --dry-run=client -f hack/testdata/pod.yaml "${kube_flags[@]:?}"
   kubectl apply --dry-run=server -f hack/testdata/pod.yaml "${kube_flags[@]:?}"
   # No pod exists

--- a/test/cmd/batch.sh
+++ b/test/cmd/batch.sh
@@ -49,7 +49,7 @@ run_job_tests() {
   kube::test::describe_resource_chunk_size_assert cronjobs events "--namespace=test-jobs"
 
   ### Create a job in dry-run mode
-  output_message=$(kubectl create job test-job --from=cronjob/pi --dry-run=client --namespace=test-jobs -o name)
+  output_message=$(kubectl create job test-job --from=cronjob/pi --dry-run=true --namespace=test-jobs -o name)
   # Post-condition: The text 'job.batch/test-job' should be part of the output
   kube::test::if_has_string "${output_message}" 'job.batch/test-job'
   # Post-condition: The test-job wasn't created actually


### PR DESCRIPTION
Cherry pick of #107003 on release-1.23.

#107003: Re-introduce removed kubectl --dry-run values.

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
Fixes 1.23 regression in kubectl: restores `--dry-run`, `--dry-run=true`, and `--dry-run=false` for compatibility with pre-1.23 invocations.
```