### PR TITLE
cli: avoid logging command line errors in more cases

### DIFF
--- a/cmd/kubectl/kubectl.go
+++ b/cmd/kubectl/kubectl.go
@@ -17,10 +17,9 @@ limitations under the License.
 package main
 
 import (
-	"os"
-
 	"k8s.io/component-base/cli"
 	"k8s.io/kubectl/pkg/cmd"
+	"k8s.io/kubectl/pkg/cmd/util"
 
 	// Import to initialize client auth plugins.
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
@@ -28,6 +27,8 @@ import (
 
 func main() {
 	command := cmd.NewDefaultKubectlCommand()
-	code := cli.Run(command)
-	os.Exit(code)
+	if err := cli.RunNoErrOutput(command); err != nil {
+		// Pretty-print the error and exit with an error.
+		util.CheckErr(err)
+	}
 }

--- a/staging/src/k8s.io/component-base/cli/run.go
+++ b/staging/src/k8s.io/component-base/cli/run.go
@@ -34,7 +34,58 @@ import (
 // flags get added to the command line if not added already. Flags get normalized
 // so that help texts show them with hyphens. Underscores are accepted
 // as alternative for the command parameters.
+//
+// Run tries to be smart about how to print errors that are returned by the
+// command: before logging is known to be set up, it prints them as plain text
+// to stderr. This covers command line flag parse errors and unknown commands.
+// Afterwards it logs them. This covers runtime errors.
+//
+// Commands like kubectl where logging is not normally part of the runtime output
+// should use RunNoErrOutput instead and deal with the returned error themselves.
 func Run(cmd *cobra.Command) int {
+	if logsInitialized, err := run(cmd); err != nil {
+		// If the error is about flag parsing, then printing that error
+		// with the decoration that klog would add ("E0923
+		// 23:02:03.219216 4168816 run.go:61] unknown shorthand flag")
+		// is less readable. Using klog.Fatal is even worse because it
+		// dumps a stack trace that isn't about the error.
+		//
+		// But if it is some other error encountered at runtime, then
+		// we want to log it as error, at least in most commands because
+		// their output is a log event stream.
+		//
+		// We can distinguish these two cases depending on whether
+		// we got to logs.InitLogs() above.
+		//
+		// This heuristic might be problematic for command line
+		// tools like kubectl where the output is carefully controlled
+		// and not a log by default. They should use RunNoErrOutput
+		// instead.
+		//
+		// The usage of klog is problematic also because we don't know
+		// whether the command has managed to configure it. This cannot
+		// be checked right now, but may become possible when the early
+		// logging proposal from
+		// https://github.com/kubernetes/enhancements/pull/3078
+		// ("contextual logging") is implemented.
+		if !logsInitialized {
+			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		} else {
+			klog.ErrorS(err, "command failed")
+		}
+		return 1
+	}
+	return 0
+}
+
+// RunNoErrOutput is a version of Run which returns the cobra command error
+// instead of printing it.
+func RunNoErrOutput(cmd *cobra.Command) error {
+	_, err := run(cmd)
+	return err
+}
+
+func run(cmd *cobra.Command) (logsInitialized bool, err error) {
 	rand.Seed(time.Now().UnixNano())
 	defer logs.FlushLogs()
 
@@ -70,7 +121,6 @@ func Run(cmd *cobra.Command) int {
 
 	// Inject logs.InitLogs after command line parsing into one of the
 	// PersistentPre* functions.
-	logsInitialized := false
 	switch {
 	case cmd.PersistentPreRun != nil:
 		pre := cmd.PersistentPreRun
@@ -93,37 +143,6 @@ func Run(cmd *cobra.Command) int {
 		}
 	}
 
-	if err := cmd.Execute(); err != nil {
-		// If the error is about flag parsing, then printing that error
-		// with the decoration that klog would add ("E0923
-		// 23:02:03.219216 4168816 run.go:61] unknown shorthand flag")
-		// is less readable. Using klog.Fatal is even worse because it
-		// dumps a stack trace that isn't about the error.
-		//
-		// But if it is some other error encountered at runtime, then
-		// we want to log it as error, at least in most commands because
-		// their output is a log event stream.
-		//
-		// We can distinguish these two cases depending on whether
-		// we got to logs.InitLogs() above.
-		//
-		// This heuristic might be problematic for command line
-		// tools like kubectl where the output is carefully controlled
-		// and not a log by default. It works because kubectl has
-		// its own error handling once a command runs.
-		//
-		// The usage of klog is problematic also because we don't know
-		// whether the command has managed to configure it. This cannot
-		// be checked right now, but may become possible when the early
-		// logging proposal from
-		// https://github.com/kubernetes/enhancements/pull/3078
-		// ("contextual logging") is implemented.
-		if !logsInitialized {
-			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
-		} else {
-			klog.ErrorS(err, "command failed")
-		}
-		return 1
-	}
-	return 0
+	err = cmd.Execute()
+	return
 }

--- a/test/cmd/get.sh
+++ b/test/cmd/get.sh
@@ -421,7 +421,7 @@ run_deprecated_api_tests() {
   kube::test::if_has_string "${output_message}" 'PodSecurityPolicy is deprecated'
   output_message=$(! kubectl get podsecuritypolicies.v1beta1.policy --warnings-as-errors 2>&1 "${kube_flags[@]}")
   kube::test::if_has_string "${output_message}" 'PodSecurityPolicy is deprecated'
-  kube::test::if_has_string "${output_message}" 'err="1 warning received"'
+  kube::test::if_has_string "${output_message}" 'error: 1 warning received'
 
   set +o nounset
   set +o errexit

--- a/test/cmd/legacy-script.sh
+++ b/test/cmd/legacy-script.sh
@@ -50,6 +50,7 @@ source "${KUBE_ROOT}/test/cmd/plugins.sh"
 source "${KUBE_ROOT}/test/cmd/proxy.sh"
 source "${KUBE_ROOT}/test/cmd/rbac.sh"
 source "${KUBE_ROOT}/test/cmd/request-timeout.sh"
+source "${KUBE_ROOT}/test/cmd/results.sh"
 source "${KUBE_ROOT}/test/cmd/run.sh"
 source "${KUBE_ROOT}/test/cmd/save-config.sh"
 source "${KUBE_ROOT}/test/cmd/storage.sh"
@@ -435,6 +436,12 @@ runTests() {
   #########################
 
   record_command run_kubectl_version_tests
+
+  ############################
+  # Kubectl result reporting #
+  ############################
+
+  record_command run_kubectl_results_tests
 
   #######################
   # kubectl config set #

--- a/test/cmd/results.sh
+++ b/test/cmd/results.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+
+# Copyright 2022 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+
+############################################################
+# Kubectl result reporting for different failure scenarios #
+############################################################
+run_kubectl_results_tests() {
+  set -o nounset
+  set -o errexit
+
+  kube::log::status "Testing kubectl result output"
+  TEMP="${KUBE_TEMP}"
+  rm -f "${TEMP}/empty"
+  touch "${TEMP}/empty"
+
+  set +o errexit
+  kubectl list >"${TEMP}/actual_stdout" 2>"${TEMP}/actual_stderr"
+  res=$?
+  set -o errexit
+  cat >"${TEMP}/expected_stderr" <<EOF
+error: unknown command "list" for "kubectl"
+
+Did you mean this?
+	get
+	wait
+EOF
+  kube::test::results::diff "${TEMP}/actual_stdout" "${TEMP}/actual_stderr" "$res" "${TEMP}/empty" "${TEMP}/expected_stderr" 1 "kubectl list"
+
+  set +o errexit
+  kubectl get pod/no-such-pod >"${TEMP}/actual_stdout" 2>"${TEMP}/actual_stderr"
+  res=$?
+  set -o errexit
+  cat >"${TEMP}/expected_stderr" <<EOF
+Error from server (NotFound): pods "no-such-pod" not found
+EOF
+  kube::test::results::diff "${TEMP}/actual_stdout" "${TEMP}/actual_stderr" "$res" "${TEMP}/empty" "${TEMP}/expected_stderr" 1 "kubectl get pod/no-such-pod"
+
+  set +o nounset
+  set +o errexit
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

"kubectl list" should print a plain text explanation ("Unknown command "list"
for kubectl. ...") without treating that multi-line error as a log message.

The previous heuristic didn't work here because the command itself was not
found. A better one is to check that command execution really started.

This is still not perfect: what if a command hasn't started logging yet or
never uses logging for its output and then returns an error, for example in
`kubectl kustomize`? To handle that case, `kubectl` now always deals
with error printing itself.

#### Which issue(s) this PR fixes:
Fixes #https://github.com/kubernetes/kubernetes/issues/107012

#### Does this PR introduce a user-facing change?
```release-note
Fix 1.23 regression: Some command line errors (for example, "kubectl list" -> "unknown command") were printed as log message with escaped line breaks instead of a multi-line plain text, which made the error harder to read.
```

