### PR TITLE
Update default APF flow schemas to avoid all endpoint/configmaps operations from controller-manager to match leader-election PL

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/apis/flowcontrol/bootstrap/default.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/flowcontrol/bootstrap/default.go
@@ -73,6 +73,7 @@ var (
 		SuggestedFlowSchemaProbes,                    // references "exempt" priority-level
 		SuggestedFlowSchemaSystemLeaderElection,      // references "leader-election" priority-level
 		SuggestedFlowSchemaWorkloadLeaderElection,    // references "leader-election" priority-level
+		SuggestedFlowSchemaEndpointsController,       // references "workload-high" priority-level
 		SuggestedFlowSchemaKubeControllerManager,     // references "workload-high" priority-level
 		SuggestedFlowSchemaKubeScheduler,             // references "workload-high" priority-level
 		SuggestedFlowSchemaKubeSystemServiceAccounts, // references "workload-high" priority-level
@@ -314,12 +315,6 @@ var (
 			ResourceRules: []flowcontrol.ResourcePolicyRule{
 				resourceRule(
 					[]string{"get", "create", "update"},
-					[]string{corev1.GroupName},
-					[]string{"endpoints", "configmaps"},
-					[]string{"kube-system"},
-					false),
-				resourceRule(
-					[]string{"get", "create", "update"},
 					[]string{coordinationv1.GroupName},
 					[]string{"leases"},
 					[]string{flowcontrol.NamespaceEvery},
@@ -327,6 +322,31 @@ var (
 			},
 		},
 	)
+	// We add an explicit rule for endpoints-controller with high precedence
+	// to ensure that those calls won't get caught by the following
+	// <workload-leader-election> flow-schema.
+	//
+	// TODO(#80289): Get rid of this rule once we get rid of support for
+	//   using endpoints and configmaps objects for leader election.
+	SuggestedFlowSchemaEndpointsController = newFlowSchema(
+		"endpoint-controller", "workload-high", 150,
+		flowcontrol.FlowDistinguisherMethodByUserType,
+		flowcontrol.PolicyRulesWithSubjects{
+			Subjects: append(
+				users(user.KubeControllerManager),
+				kubeSystemServiceAccount("endpoint-controller", "endpointslicemirroring-controller")...),
+			ResourceRules: []flowcontrol.ResourcePolicyRule{
+				resourceRule(
+					[]string{"get", "create", "update"},
+					[]string{corev1.GroupName},
+					[]string{"endpoints"},
+					[]string{flowcontrol.NamespaceEvery},
+					false),
+			},
+		},
+	)
+	// TODO(#80289): Get rid of this rule once we get rid of support for
+	//   using endpoints and configmaps objects for leader election.
 	SuggestedFlowSchemaWorkloadLeaderElection = newFlowSchema(
 		"workload-leader-election", "leader-election", 200,
 		flowcontrol.FlowDistinguisherMethodByUserType,
@@ -337,12 +357,6 @@ var (
 					[]string{"get", "create", "update"},
 					[]string{corev1.GroupName},
 					[]string{"endpoints", "configmaps"},
-					[]string{flowcontrol.NamespaceEvery},
-					false),
-				resourceRule(
-					[]string{"get", "create", "update"},
-					[]string{coordinationv1.GroupName},
-					[]string{"leases"},
 					[]string{flowcontrol.NamespaceEvery},
 					false),
 			},


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:
Update default APF flow schemas to avoid all endpoint/configmaps operations from controller-manager to match leader-election PL

#### Which issue(s) this PR fixes:
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
Update default API priority-and-fairness config to avoid endpoint/configmaps operations from controller-manager to all match leader-election priority level.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
