### PR TITLE
Fix pod resource limit calculation when a pod has multiple containers and one container specifies a limit while another does not

### DIFF
--- a/pkg/scheduler/metrics/resources/resources_test.go
+++ b/pkg/scheduler/metrics/resources/resources_test.go
@@ -415,18 +415,18 @@ func Test_podResourceCollector_CollectWithStability(t *testing.T) {
 						Containers: []v1.Container{
 							{Resources: v1.ResourceRequirements{
 								Requests: v1.ResourceList{"cpu": resource.MustParse("1")},
-								Limits:   v1.ResourceList{"cpu": resource.MustParse("2")},
+								Limits:   v1.ResourceList{"cpu": resource.MustParse("2"), "memory": resource.MustParse("1G")},
 							}},
 							{Resources: v1.ResourceRequirements{
 								Requests: v1.ResourceList{"memory": resource.MustParse("1G")},
-								Limits:   v1.ResourceList{"memory": resource.MustParse("2G")},
+								Limits:   v1.ResourceList{"cpu": resource.MustParse("1"), "memory": resource.MustParse("2G")},
 							}},
 							{Resources: v1.ResourceRequirements{
 								Requests: v1.ResourceList{"cpu": resource.MustParse("0.5")},
-								Limits:   v1.ResourceList{"cpu": resource.MustParse("1.25")},
+								Limits:   v1.ResourceList{"cpu": resource.MustParse("1.25"), "memory": resource.MustParse("1G")},
 							}},
 							{Resources: v1.ResourceRequirements{
-								Limits: v1.ResourceList{"memory": resource.MustParse("2G")},
+								Limits: v1.ResourceList{"cpu": resource.MustParse("1"), "memory": resource.MustParse("2G")},
 							}},
 						},
 					},
@@ -435,8 +435,8 @@ func Test_podResourceCollector_CollectWithStability(t *testing.T) {
 			expected: `            
 				# HELP kube_pod_resource_limit [ALPHA] Resources limit for workloads on the cluster, broken down by pod. This shows the resource usage the scheduler and kubelet expect per pod for resources along with the unit for the resource if any.
 				# TYPE kube_pod_resource_limit gauge
-				kube_pod_resource_limit{namespace="test",node="",pod="foo",priority="",resource="cpu",scheduler="",unit="cores"} 3.25
-				kube_pod_resource_limit{namespace="test",node="",pod="foo",priority="",resource="memory",scheduler="",unit="bytes"} 4e+09
+				kube_pod_resource_limit{namespace="test",node="",pod="foo",priority="",resource="cpu",scheduler="",unit="cores"} 5.25
+				kube_pod_resource_limit{namespace="test",node="",pod="foo",priority="",resource="memory",scheduler="",unit="bytes"} 6e+09
 				# HELP kube_pod_resource_request [ALPHA] Resources requested by workloads on the cluster, broken down by pod. This shows the resource usage the scheduler and kubelet expect per pod for resources along with the unit for the resource if any.
 				# TYPE kube_pod_resource_request gauge
 				kube_pod_resource_request{namespace="test",node="",pod="foo",priority="",resource="cpu",scheduler="",unit="cores"} 1.5

--- a/staging/src/k8s.io/kubectl/pkg/describe/describe_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/describe/describe_test.go
@@ -4860,7 +4860,7 @@ func TestDescribeNode(t *testing.T) {
 						Image: "image:latest",
 						Resources: corev1.ResourceRequirements{
 							Requests: getResourceList("1", "1Gi"),
-							Limits:   getResourceList("2", "2Gi"),
+							Limits:   mergeResourceLists(getResourceList("2", "2Gi"), getHugePageResourceList("2Mi", "512Mi")),
 						},
 					},
 					{
@@ -4868,7 +4868,7 @@ func TestDescribeNode(t *testing.T) {
 						Image: "image:latest",
 						Resources: corev1.ResourceRequirements{
 							Requests: getHugePageResourceList("2Mi", "512Mi"),
-							Limits:   getHugePageResourceList("2Mi", "512Mi"),
+							Limits:   mergeResourceLists(getResourceList("1", "1Gi"), getHugePageResourceList("2Mi", "512Mi")),
 						},
 					},
 				},
@@ -4890,14 +4890,14 @@ func TestDescribeNode(t *testing.T) {
   (Total limits may be over 100 percent, i.e., overcommitted.)
   Resource           Requests     Limits
   --------           --------     ------
-  cpu                1 (25%)      2 (50%)
-  memory             1Gi (8%)     2Gi (16%)
+  cpu                1 (25%)      3 (75%)
+  memory             1Gi (8%)     3Gi (25%)
   ephemeral-storage  0 (0%)       0 (0%)
   hugepages-1Gi      0 (0%)       0 (0%)
-  hugepages-2Mi      512Mi (25%)  512Mi (25%)`}
+  hugepages-2Mi      512Mi (25%)  1Gi (50%)`}
 	for _, expected := range expectedOut {
 		if !strings.Contains(out, expected) {
-			t.Errorf("expected to find %q in output: %q", expected, out)
+			t.Errorf("expected to find:\n\n%v\n\nin output:\n\n%v", expected, out)
 		}
 	}
 }

--- a/staging/src/k8s.io/kubectl/pkg/util/resource/resource.go
+++ b/staging/src/k8s.io/kubectl/pkg/util/resource/resource.go
@@ -54,6 +54,22 @@ func PodRequestsAndLimits(pod *corev1.Pod) (reqs, limits corev1.ResourceList) {
 			}
 		}
 	}
+
+	// If any container does not specify a limit that means the resource is not limited for the pod as a whole.  The
+	// previously calculated max limit would only be the max of the explicitly set limits.  However, an unspecified
+	// limit should be considered greater than any explicitly set limit, so delete the calculated limit if there is one.
+	allContainers := append(pod.Spec.Containers, pod.Spec.InitContainers...)
+	if len(allContainers) > 1 {
+		for name := range limits {
+			for _, container := range allContainers {
+				if value, ok := container.Resources.Limits[name]; !ok || value.IsZero() {
+					delete(limits, name)
+					break
+				}
+			}
+		}
+	}
+
 	return
 }
 

--- a/staging/src/k8s.io/kubectl/pkg/util/resource/resource_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/util/resource/resource_test.go
@@ -1,0 +1,408 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resource
+
+import (
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+func TestPodRequestsAndLimits(t *testing.T) {
+	var testCases = []struct {
+		name             string
+		pod              *v1.Pod
+		expectedRequests v1.ResourceList
+		expectedLimits   v1.ResourceList
+	}{
+		{
+			name: "no requests, limits, or overhead",
+			pod: &v1.Pod{
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						{Name: "foobar"},
+						{Name: "foobar2"},
+					},
+				},
+			},
+			expectedRequests: v1.ResourceList{},
+			expectedLimits:   v1.ResourceList{},
+		},
+		{
+			name: "limits only",
+			pod: &v1.Pod{
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						{
+							Name: "foobar",
+							Resources: v1.ResourceRequirements{
+								Limits: v1.ResourceList{
+									v1.ResourceCPU:    resource.MustParse("2"),
+									v1.ResourceMemory: resource.MustParse("10"),
+								},
+							},
+						},
+						{
+							Name: "foobar2",
+							Resources: v1.ResourceRequirements{
+								Limits: v1.ResourceList{
+									v1.ResourceCPU:    resource.MustParse("8"),
+									v1.ResourceMemory: resource.MustParse("24"),
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedRequests: v1.ResourceList{},
+			expectedLimits: v1.ResourceList{
+				v1.ResourceCPU:    resource.MustParse("10"),
+				v1.ResourceMemory: resource.MustParse("34"),
+			},
+		},
+		{
+			name: "requests only",
+			pod: &v1.Pod{
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						{
+							Name: "foobar",
+							Resources: v1.ResourceRequirements{
+								Requests: v1.ResourceList{
+									v1.ResourceCPU:    resource.MustParse("1"),
+									v1.ResourceMemory: resource.MustParse("5"),
+								},
+							},
+						},
+						{
+							Name: "foobar2",
+							Resources: v1.ResourceRequirements{
+								Requests: v1.ResourceList{
+									v1.ResourceCPU:    resource.MustParse("4"),
+									v1.ResourceMemory: resource.MustParse("12"),
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedRequests: v1.ResourceList{
+				v1.ResourceCPU:    resource.MustParse("5"),
+				v1.ResourceMemory: resource.MustParse("17"),
+			},
+			expectedLimits: v1.ResourceList{},
+		},
+		{
+			name: "overhead only",
+			pod: &v1.Pod{
+				Spec: v1.PodSpec{
+					Overhead: v1.ResourceList{
+						v1.ResourceCPU:    resource.MustParse("3"),
+						v1.ResourceMemory: resource.MustParse("8"),
+					},
+					Containers: []v1.Container{
+						{Name: "foobar"},
+						{Name: "foobar2"},
+					},
+				},
+			},
+			expectedRequests: v1.ResourceList{
+				v1.ResourceCPU:    resource.MustParse("3"),
+				v1.ResourceMemory: resource.MustParse("8"),
+			},
+			expectedLimits: v1.ResourceList{},
+		},
+		{
+			name: "two containers with no overhead should just be sum of containers",
+			pod: &v1.Pod{
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						{
+							Name: "foobar",
+							Resources: v1.ResourceRequirements{
+								Requests: v1.ResourceList{
+									v1.ResourceCPU:    resource.MustParse("1"),
+									v1.ResourceMemory: resource.MustParse("5"),
+								},
+								Limits: v1.ResourceList{
+									v1.ResourceCPU:    resource.MustParse("2"),
+									v1.ResourceMemory: resource.MustParse("10"),
+								},
+							},
+						},
+						{
+							Name: "foobar2",
+							Resources: v1.ResourceRequirements{
+								Requests: v1.ResourceList{
+									v1.ResourceCPU:    resource.MustParse("4"),
+									v1.ResourceMemory: resource.MustParse("12"),
+								},
+								Limits: v1.ResourceList{
+									v1.ResourceCPU:    resource.MustParse("8"),
+									v1.ResourceMemory: resource.MustParse("24"),
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedRequests: v1.ResourceList{
+				v1.ResourceCPU:    resource.MustParse("5"),
+				v1.ResourceMemory: resource.MustParse("17"),
+			},
+			expectedLimits: v1.ResourceList{
+				v1.ResourceCPU:    resource.MustParse("10"),
+				v1.ResourceMemory: resource.MustParse("34"),
+			},
+		},
+		{
+			name: "two containers with one of them being unlimited should be unlimited",
+			pod: &v1.Pod{
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						{
+							Name: "foobar",
+							Resources: v1.ResourceRequirements{
+								Requests: v1.ResourceList{
+									v1.ResourceCPU:    resource.MustParse("1"),
+									v1.ResourceMemory: resource.MustParse("5"),
+								},
+								Limits: v1.ResourceList{
+									v1.ResourceCPU:    resource.MustParse("2"),
+									v1.ResourceMemory: resource.MustParse("10"),
+								},
+							},
+						},
+						{
+							Name: "unlimited",
+							Resources: v1.ResourceRequirements{
+								Requests: v1.ResourceList{
+									v1.ResourceCPU:    resource.MustParse("4"),
+									v1.ResourceMemory: resource.MustParse("12"),
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedRequests: v1.ResourceList{
+				v1.ResourceCPU:    resource.MustParse("5"),
+				v1.ResourceMemory: resource.MustParse("17"),
+			},
+			expectedLimits: v1.ResourceList{},
+		},
+		{
+			name: "two containers with overhead should consider overhead",
+			pod: &v1.Pod{
+				Spec: v1.PodSpec{
+					Overhead: v1.ResourceList{
+						v1.ResourceCPU:    resource.MustParse("3"),
+						v1.ResourceMemory: resource.MustParse("8"),
+					},
+					Containers: []v1.Container{
+						{
+							Name: "foobar",
+							Resources: v1.ResourceRequirements{
+								Requests: v1.ResourceList{
+									v1.ResourceCPU:    resource.MustParse("1"),
+									v1.ResourceMemory: resource.MustParse("5"),
+								},
+								Limits: v1.ResourceList{
+									v1.ResourceCPU:    resource.MustParse("2"),
+									v1.ResourceMemory: resource.MustParse("10"),
+								},
+							},
+						},
+						{
+							Name: "foobar2",
+							Resources: v1.ResourceRequirements{
+								Requests: v1.ResourceList{
+									v1.ResourceCPU:    resource.MustParse("4"),
+									v1.ResourceMemory: resource.MustParse("12"),
+								},
+								Limits: v1.ResourceList{
+									v1.ResourceCPU:    resource.MustParse("8"),
+									v1.ResourceMemory: resource.MustParse("24"),
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedRequests: v1.ResourceList{
+				v1.ResourceCPU:    resource.MustParse("8"),
+				v1.ResourceMemory: resource.MustParse("25"),
+			},
+			expectedLimits: v1.ResourceList{
+				v1.ResourceCPU:    resource.MustParse("13"),
+				v1.ResourceMemory: resource.MustParse("42"),
+			},
+		},
+		{
+			name: "two containers with overhead and massive init should be the largest init plus overhead",
+			pod: &v1.Pod{
+				Spec: v1.PodSpec{
+					Overhead: v1.ResourceList{
+						v1.ResourceCPU:    resource.MustParse("3"),
+						v1.ResourceMemory: resource.MustParse("8"),
+					},
+					Containers: []v1.Container{
+						{
+							Name: "foobar",
+							Resources: v1.ResourceRequirements{
+								Requests: v1.ResourceList{
+									v1.ResourceCPU:    resource.MustParse("1"),
+									v1.ResourceMemory: resource.MustParse("5"),
+								},
+								Limits: v1.ResourceList{
+									v1.ResourceCPU:    resource.MustParse("2"),
+									v1.ResourceMemory: resource.MustParse("10"),
+								},
+							},
+						},
+						{
+							Name: "foobar2",
+							Resources: v1.ResourceRequirements{
+								Requests: v1.ResourceList{
+									v1.ResourceCPU:    resource.MustParse("4"),
+									v1.ResourceMemory: resource.MustParse("12"),
+								},
+								Limits: v1.ResourceList{
+									v1.ResourceCPU:    resource.MustParse("8"),
+									v1.ResourceMemory: resource.MustParse("24"),
+								},
+							},
+						},
+					},
+					InitContainers: []v1.Container{
+						{
+							Name: "small-init",
+							Resources: v1.ResourceRequirements{
+								Requests: v1.ResourceList{
+									v1.ResourceCPU:    resource.MustParse("1"),
+									v1.ResourceMemory: resource.MustParse("5"),
+								},
+								Limits: v1.ResourceList{
+									v1.ResourceCPU:    resource.MustParse("1"),
+									v1.ResourceMemory: resource.MustParse("5"),
+								},
+							},
+						},
+						{
+							Name: "big-init",
+							Resources: v1.ResourceRequirements{
+								Requests: v1.ResourceList{
+									v1.ResourceCPU:    resource.MustParse("40"),
+									v1.ResourceMemory: resource.MustParse("120"),
+								},
+								Limits: v1.ResourceList{
+									v1.ResourceCPU:    resource.MustParse("80"),
+									v1.ResourceMemory: resource.MustParse("240"),
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedRequests: v1.ResourceList{
+				v1.ResourceCPU:    resource.MustParse("43"),
+				v1.ResourceMemory: resource.MustParse("128"),
+			},
+			expectedLimits: v1.ResourceList{
+				v1.ResourceCPU:    resource.MustParse("83"),
+				v1.ResourceMemory: resource.MustParse("248"),
+			},
+		},
+		{
+			name: "two containers with unlimited init should be unlimited",
+			pod: &v1.Pod{
+				Spec: v1.PodSpec{
+					Overhead: v1.ResourceList{
+						v1.ResourceCPU:    resource.MustParse("3"),
+						v1.ResourceMemory: resource.MustParse("8"),
+					},
+					Containers: []v1.Container{
+						{
+							Name: "foobar",
+							Resources: v1.ResourceRequirements{
+								Requests: v1.ResourceList{
+									v1.ResourceCPU:    resource.MustParse("1"),
+									v1.ResourceMemory: resource.MustParse("5"),
+								},
+								Limits: v1.ResourceList{
+									v1.ResourceCPU:    resource.MustParse("2"),
+									v1.ResourceMemory: resource.MustParse("10"),
+								},
+							},
+						},
+						{
+							Name: "foobar2",
+							Resources: v1.ResourceRequirements{
+								Requests: v1.ResourceList{
+									v1.ResourceCPU:    resource.MustParse("4"),
+									v1.ResourceMemory: resource.MustParse("12"),
+								},
+								Limits: v1.ResourceList{
+									v1.ResourceCPU:    resource.MustParse("8"),
+									v1.ResourceMemory: resource.MustParse("24"),
+								},
+							},
+						},
+					},
+					InitContainers: []v1.Container{
+						{
+							Name: "small-init",
+							Resources: v1.ResourceRequirements{
+								Requests: v1.ResourceList{
+									v1.ResourceCPU:    resource.MustParse("1"),
+									v1.ResourceMemory: resource.MustParse("5"),
+								},
+								Limits: v1.ResourceList{
+									v1.ResourceCPU:    resource.MustParse("1"),
+									v1.ResourceMemory: resource.MustParse("5"),
+								},
+							},
+						},
+						{
+							Name: "unlimited-init",
+						},
+					},
+				},
+			},
+			expectedRequests: v1.ResourceList{
+				v1.ResourceCPU:    resource.MustParse("8"),
+				v1.ResourceMemory: resource.MustParse("25"),
+			},
+			expectedLimits: v1.ResourceList{},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(tt *testing.T) {
+			resRequests, resLimits := PodRequestsAndLimits(tc.pod)
+
+			if !equality.Semantic.DeepEqual(tc.expectedRequests, resRequests) {
+				tt.Errorf("requests:\n expected:\t%v\ngot\t\t%v", tc.expectedRequests, resRequests)
+			}
+
+			if !equality.Semantic.DeepEqual(tc.expectedLimits, resLimits) {
+				tt.Errorf("limits:\n expected:\t%v\ngot\t\t%v", tc.expectedLimits, resLimits)
+			}
+		})
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
Pod resource limit is incorrectly calculated when all the following conditions are true:
1. The pod has multiple containers (including init containers)
2. At least one of the containers specifies a resource limit
3. At least one of the containers does not specify a resource limit for a resource type that another container has specified a resource limit for.

In this case, the pod is reported to have the limit of the container that specifies it.

However, this seems to be incorrect.  The absence of a specified limit is effectively "unlimited" and so the pod itself should be considered to be unlimited on that resource.  Note however, that the container still retains its appropriately set limit, this is only concerning the computed pod-level limits.

Example:
```yaml
apiVersion: v1
kind: Pod
metadata:
  name: unlimited-container
  namespace: limit-test
spec:
  containers:
  - name: foo
    image: busybox:1.28
    command: ['sh', '-c', 'echo The app is running! && sleep 3600']
    resources:
      limits:
        cpu: 50m
        memory: 200Mi
      requests:
        cpu: 50m
        memory: 200Mi
  - name: bar
    image: busybox:1.28
    command: ['sh', '-c', 'echo The app is running! && sleep 3600']
    resources:
      requests:
        cpu: 100m
        memory: 100Mi
```

describe node output excerpt:
```
Non-terminated Pods:          (3 in total)
  Namespace                   Name                     CPU Requests  CPU Limits  Memory Requests  Memory Limits  Age
  ---------                   ----                     ------------  ----------  ---------------  -------------  ---
  kube-system                 kube-flannel-ds-lvqrg    100m (2%)     100m (2%)   50Mi (1%)        50Mi (1%)      83d
  kube-system                 kube-proxy-ghfrd         0 (0%)        0 (0%)      0 (0%)           0 (0%)         53d
  limit-test                  unlimited-container      150m (3%)     50m (1%)    300Mi (7%)       200Mi (5%)     5s
Allocated resources:
  (Total limits may be over 100 percent, i.e., overcommitted.)
  Resource                Requests    Limits
  --------                --------    ------
  cpu                     250m (6%)   150m (3%)
  memory                  350Mi (9%)  250Mi (6%)
  ephemeral-storage       0 (0%)      0 (0%)
  hugepages-2Mi           0 (0%)      0 (0%)
  example.com/fakePTSRes  0           0
```

Notice the `bar` container does not set a limit.  But, the `kubectl describe node` output shows the limit of the pod as being the limit of the `foo` container, and the allocated resources of the node reflect this too.

The code that needs to be fixed exists in two places:
1. In kubectl, where it is used to describe node resource usage (this is where the original issue was identified).
2. In the API, where it is used by several things, including metrics, volume manager, and kube runtime

#### Which issue(s) this PR fixes:
Fixes https://github.com/kubernetes/kubectl/issues/1110

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
Fixed a bug where pod resource limits were incorrectly calculated to be a specific limit when a pod has multiple containers and one container specifies a limit while and another does not specify a limit for the same resource type.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs

```
