### PR TITLE
Reset metric observed by TestProxyHandler for repeatable test runs.

### DIFF
--- a/staging/src/k8s.io/kube-aggregator/pkg/apiserver/handler_proxy_test.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/apiserver/handler_proxy_test.go
@@ -301,6 +301,7 @@ func TestProxyHandler(t *testing.T) {
 	target := &targetHTTPHandler{}
 	for name, tc := range tests {
 		target.Reset()
+		legacyregistry.Reset()
 
 		func() {
 			targetServer := httptest.NewUnstartedServer(target)


### PR DESCRIPTION
This test expects x509_missing_san_total to be 1. When run with
-test.count greater than 1, that expectation is unmet for all but the
first test run.

#### What type of PR is this?

/kind bug
/kind failing-test

#### What this PR does / why we need it:

Fixes TestProxyHandler, which depends on the value of a global counter, when tests are executed with -test.count greater than 1.

#### Which issue(s) this PR fixes:

Fixes #107059

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
