### PR TITLE
Remove adtac from sig-scheduling reviewers

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -168,9 +168,9 @@ aliases:
     - alculquicondor
     - damemi
     - chendave
-    - adtac
     - denkensk
   # emeritus:
+  # - adtac
   # - liu-cong
   # - draveness
   # - hex108


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Removes @adtac from SIG scheduling reviewers, as his commitments to the SIG have changed.

/sig scheduling

#### Which issue(s) this PR fixes:

Superseeds #105458

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```