### PR TITLE
Improving performance of EndpointSlice controller metrics cache

### DIFF
--- a/pkg/controller/endpointslice/metrics/cache_test.go
+++ b/pkg/controller/endpointslice/metrics/cache_test.go
@@ -17,11 +17,14 @@ limitations under the License.
 package metrics
 
 import (
+	"fmt"
 	"testing"
 
 	discovery "k8s.io/api/discovery/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/kubernetes/pkg/controller/util/endpoint"
 	endpointutil "k8s.io/kubernetes/pkg/controller/util/endpoint"
+	utilpointer "k8s.io/utils/pointer"
 )
 
 func TestNumEndpointsAndSlices(t *testing.T) {
@@ -59,14 +62,57 @@ func TestNumEndpointsAndSlices(t *testing.T) {
 
 func expectNumEndpointsAndSlices(t *testing.T, c *Cache, desired int, actual int, numEndpoints int) {
 	t.Helper()
-	mUpdate := c.desiredAndActualSlices()
-	if mUpdate.desired != desired {
-		t.Errorf("Expected numEndpointSlices to be %d, got %d", desired, mUpdate.desired)
+	if c.numSlicesDesired != desired {
+		t.Errorf("Expected numSlicesDesired to be %d, got %d", desired, c.numSlicesDesired)
 	}
-	if mUpdate.actual != actual {
-		t.Errorf("Expected desiredEndpointSlices to be %d, got %d", actual, mUpdate.actual)
+	if c.numSlicesActual != actual {
+		t.Errorf("Expected numSlicesActual to be %d, got %d", actual, c.numSlicesActual)
 	}
 	if c.numEndpoints != numEndpoints {
 		t.Errorf("Expected numEndpoints to be %d, got %d", numEndpoints, c.numEndpoints)
 	}
+}
+
+func benchmarkUpdateServicePortCache(b *testing.B, num int) {
+	c := NewCache(int32(100))
+	ns := "benchmark"
+	httpKey := endpoint.NewPortMapKey([]discovery.EndpointPort{{Port: utilpointer.Int32Ptr(80)}})
+	httpsKey := endpoint.NewPortMapKey([]discovery.EndpointPort{{Port: utilpointer.Int32Ptr(443)}})
+	spCache := &ServicePortCache{items: map[endpointutil.PortMapKey]EfficiencyInfo{
+		httpKey: {
+			Endpoints: 182,
+			Slices:    2,
+		},
+		httpsKey: {
+			Endpoints: 356,
+			Slices:    4,
+		},
+	}}
+
+	for i := 0; i < num; i++ {
+		nName := types.NamespacedName{Namespace: ns, Name: fmt.Sprintf("service-%d", i)}
+		c.UpdateServicePortCache(nName, spCache)
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		nName := types.NamespacedName{Namespace: ns, Name: fmt.Sprintf("bench-%d", i)}
+		c.UpdateServicePortCache(nName, spCache)
+	}
+}
+
+func BenchmarkUpdateServicePortCache100(b *testing.B) {
+	benchmarkUpdateServicePortCache(b, 100)
+}
+
+func BenchmarkUpdateServicePortCache1000(b *testing.B) {
+	benchmarkUpdateServicePortCache(b, 1000)
+}
+
+func BenchmarkUpdateServicePortCache10000(b *testing.B) {
+	benchmarkUpdateServicePortCache(b, 10000)
+}
+
+func BenchmarkUpdateServicePortCache100000(b *testing.B) {
+	benchmarkUpdateServicePortCache(b, 100000)
 }


### PR DESCRIPTION
#### What type of PR is this?
/kind bug
/kind cleanup

#### What this PR does / why we need it:
This fixes a performance issue where the EndpointSlice controller metrics cache could consume a significant proportion of overall kube-controller-manager CPU utilization by performing inefficient operations within a lock. This becomes especially noticeable when there are a large number of Services in a cluster (many thousands) and the resync period results in all Services being requeued. The increased network programming latency during this event can result in downtime if any Services change while the controller workqueue is backed up.

#### Special notes for your reviewer:
Comparing benchmark output from master and current PR:

```
→ benchstat old.txt new.txt
name                             old time/op  new time/op  delta
UpdateServicePortCache100-12      276µs ± 0%     1µs ± 0%   ~     (p=1.000 n=1+1)
UpdateServicePortCache1000-12     328µs ± 0%     1µs ± 0%   ~     (p=1.000 n=1+1)
UpdateServicePortCache10000-12    547µs ± 0%     1µs ± 0%   ~     (p=1.000 n=1+1)
UpdateServicePortCache100000-12  5.01ms ± 0%  0.00ms ± 0%   ~     (p=1.000 n=1+1)
```

```
→ benchcmp old.txt new.txt
benchcmp is deprecated in favor of benchstat: https://pkg.go.dev/golang.org/x/perf/cmd/benchstat
benchmark                                    old ns/op     new ns/op     delta
BenchmarkUpdateServicePortCache100-12        275804        698           -99.75%
BenchmarkUpdateServicePortCache1000-12       328298        720           -99.78%
BenchmarkUpdateServicePortCache10000-12      546786        726           -99.87%
BenchmarkUpdateServicePortCache100000-12     5005505       881           -99.98%
```

#### Does this PR introduce a user-facing change?
```release-note
Fix a performance regression in 1.17 where an inefficient lock in EndpointSlice controller metrics cache has been reworked. Network programming latency may be significantly reduced in certain scenarios, especially in clusters with a large number of Services.
```

/cc @mborsz @freehan @aojea 
/sig network
/triage accepted
/priority important-soon