### PR TITLE
fixing three goroutine leaks in bounded_frequency_runner_test.go

### DIFF
--- a/pkg/util/async/bounded_frequency_runner_test.go
+++ b/pkg/util/async/bounded_frequency_runner_test.go
@@ -279,7 +279,7 @@ func Test_BoundedFrequencyRunnerNoBurst(t *testing.T) {
 	stop <- struct{}{}
 	// a message is sent to time.updated in func Stop() at the end of the child goroutine
 	// to terminate the child, a receive on time.updated is needed here
-	<- timer.updated 
+	<-timer.updated
 }
 
 func Test_BoundedFrequencyRunnerBurst(t *testing.T) {
@@ -363,7 +363,7 @@ func Test_BoundedFrequencyRunnerBurst(t *testing.T) {
 	stop <- struct{}{}
 	// a message is sent to time.updated in func Stop() at the end of the child goroutine
 	// to terminate the child, a receive on time.updated is needed here
-	<- timer.updated
+	<-timer.updated
 }
 
 func Test_BoundedFrequencyRunnerRetryAfter(t *testing.T) {
@@ -449,5 +449,5 @@ func Test_BoundedFrequencyRunnerRetryAfter(t *testing.T) {
 	stop <- struct{}{}
 	// a message is sent to time.updated in func Stop() at the end of the child goroutine
 	// to terminate the child, a receive on time.updated is needed here
-	<- timer.updated
+	<-timer.updated
 }

--- a/pkg/util/async/bounded_frequency_runner_test.go
+++ b/pkg/util/async/bounded_frequency_runner_test.go
@@ -277,8 +277,8 @@ func Test_BoundedFrequencyRunnerNoBurst(t *testing.T) {
 
 	// Clean up.
 	stop <- struct{}{}
-	//a message is sent to time.updated in func Stop() at the end of the child goroutine
-	//to terminate the child, a receive on time.updated is needed here
+	// a message is sent to time.updated in func Stop() at the end of the child goroutine
+	// to terminate the child, a receive on time.updated is needed here
 	<- time.updated 
 }
 
@@ -361,8 +361,8 @@ func Test_BoundedFrequencyRunnerBurst(t *testing.T) {
 
 	// Clean up.
 	stop <- struct{}{}
-	//a message is sent to time.updated in func Stop() at the end of the child goroutine
-	//to terminate the child, a receive on time.updated is needed here
+	// a message is sent to time.updated in func Stop() at the end of the child goroutine
+	// to terminate the child, a receive on time.updated is needed here
 	<- time.updated
 }
 
@@ -447,7 +447,7 @@ func Test_BoundedFrequencyRunnerRetryAfter(t *testing.T) {
 
 	// Clean up.
 	stop <- struct{}{}
-	//a message is sent to time.updated in func Stop() at the end of the child goroutine
-	//to terminate the child, a receive on time.updated is needed here
+	// a message is sent to time.updated in func Stop() at the end of the child goroutine
+	// to terminate the child, a receive on time.updated is needed here
 	<- time.updated
 }

--- a/pkg/util/async/bounded_frequency_runner_test.go
+++ b/pkg/util/async/bounded_frequency_runner_test.go
@@ -277,7 +277,9 @@ func Test_BoundedFrequencyRunnerNoBurst(t *testing.T) {
 
 	// Clean up.
 	stop <- struct{}{}
-	<- time.updated
+	//a message is sent to time.updated in func Stop() at the end of the child goroutine
+	//to terminate the child, a receive on time.updated is needed here
+	<- time.updated 
 }
 
 func Test_BoundedFrequencyRunnerBurst(t *testing.T) {
@@ -359,6 +361,8 @@ func Test_BoundedFrequencyRunnerBurst(t *testing.T) {
 
 	// Clean up.
 	stop <- struct{}{}
+	//a message is sent to time.updated in func Stop() at the end of the child goroutine
+	//to terminate the child, a receive on time.updated is needed here
 	<- time.updated
 }
 
@@ -443,5 +447,7 @@ func Test_BoundedFrequencyRunnerRetryAfter(t *testing.T) {
 
 	// Clean up.
 	stop <- struct{}{}
+	//a message is sent to time.updated in func Stop() at the end of the child goroutine
+	//to terminate the child, a receive on time.updated is needed here
 	<- time.updated
 }

--- a/pkg/util/async/bounded_frequency_runner_test.go
+++ b/pkg/util/async/bounded_frequency_runner_test.go
@@ -277,6 +277,7 @@ func Test_BoundedFrequencyRunnerNoBurst(t *testing.T) {
 
 	// Clean up.
 	stop <- struct{}{}
+	<- time.updated
 }
 
 func Test_BoundedFrequencyRunnerBurst(t *testing.T) {
@@ -358,6 +359,7 @@ func Test_BoundedFrequencyRunnerBurst(t *testing.T) {
 
 	// Clean up.
 	stop <- struct{}{}
+	<- time.updated
 }
 
 func Test_BoundedFrequencyRunnerRetryAfter(t *testing.T) {
@@ -441,4 +443,5 @@ func Test_BoundedFrequencyRunnerRetryAfter(t *testing.T) {
 
 	// Clean up.
 	stop <- struct{}{}
+	<- time.updated
 }

--- a/pkg/util/async/bounded_frequency_runner_test.go
+++ b/pkg/util/async/bounded_frequency_runner_test.go
@@ -279,7 +279,7 @@ func Test_BoundedFrequencyRunnerNoBurst(t *testing.T) {
 	stop <- struct{}{}
 	// a message is sent to time.updated in func Stop() at the end of the child goroutine
 	// to terminate the child, a receive on time.updated is needed here
-	<- time.updated 
+	<- timer.updated 
 }
 
 func Test_BoundedFrequencyRunnerBurst(t *testing.T) {
@@ -363,7 +363,7 @@ func Test_BoundedFrequencyRunnerBurst(t *testing.T) {
 	stop <- struct{}{}
 	// a message is sent to time.updated in func Stop() at the end of the child goroutine
 	// to terminate the child, a receive on time.updated is needed here
-	<- time.updated
+	<- timer.updated
 }
 
 func Test_BoundedFrequencyRunnerRetryAfter(t *testing.T) {
@@ -449,5 +449,5 @@ func Test_BoundedFrequencyRunnerRetryAfter(t *testing.T) {
 	stop <- struct{}{}
 	// a message is sent to time.updated in func Stop() at the end of the child goroutine
 	// to terminate the child, a receive on time.updated is needed here
-	<- time.updated
+	<- timer.updated
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

There are three unit tests in file [bounded_frequency_runner_test.go](https://github.com/kubernetes/kubernetes/blob/master/pkg/util/async/bounded_frequency_runner_test.go). At the end of each unit test, `stop <- struct{}{}` executes to close the created child goroutine. However, it does not help. The reason is that after receiving the message from channel stop, the child goroutine will send a message to ft.updated ([line 95](https://github.com/kubernetes/kubernetes/blob/master/pkg/util/async/bounded_frequency_runner_test.go#L95)). The channel is an unbuffered channel and there is no other goroutine receiving the message from the channel. 

After receiving a message from channel stop, the child goroutine calls bfr.stop() ([lines 196 and 197](https://github.com/kubernetes/kubernetes/blob/master/pkg/util/async/bounded_frequency_runner.go#L196-L197)), which will call `func (ft *fakeTimer) Stop() bool` to execute the send operation. 

The pull request is to add a receive operation on channel ft.updated at the end of each unit test to really clean up the created child goroutine. 

#### Which issue(s) this PR fixes:
None

```release-note
NONE
```

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
None

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
None
