### PR TITLE
1.21 regression: fix regression introduced by PR 100320 - sensitive information would be logged

### DIFF
--- a/cmd/kubelet/app/server.go
+++ b/cmd/kubelet/app/server.go
@@ -294,7 +294,7 @@ HTTP server: The kubelet can also listen for HTTP and respond to a simple API
 				config.StaticPodURLHeader[k] = []string{"<masked>"}
 			}
 			// log the kubelet's config for inspection
-			klog.V(5).InfoS("KubeletConfiguration", "configuration", kubeletServer.KubeletConfiguration)
+			klog.V(5).InfoS("KubeletConfiguration", "configuration", config)
 
 			// run the kubelet
 			if err := Run(ctx, kubeletServer, kubeletDeps, utilfeature.DefaultFeatureGate); err != nil {


### PR DESCRIPTION
/kind regression
/release-note-none

PR https://github.com/kubernetes/kubernetes/pull/100320 reverted the fix by PR https://github.com/kubernetes/kubernetes/pull/97000 which tried to avoid logging headers from kubelet configuration

This PR is to fix this regression.

```release-note
Fix regression in 1.21 where sensitive content can be logged by kubelet
```