### PR TITLE
fixing the panic in TestVersion

### DIFF
--- a/pkg/kubelet/cri/remote/remote_runtime_test.go
+++ b/pkg/kubelet/cri/remote/remote_runtime_test.go
@@ -67,7 +67,8 @@ func TestVersion(t *testing.T) {
 
 	r := createRemoteRuntimeService(endpoint, t)
 	version, err := r.Version(apitest.FakeVersion)
-	assert.NoError(t, err)
-	assert.Equal(t, apitest.FakeVersion, version.Version)
-	assert.Equal(t, apitest.FakeRuntimeName, version.RuntimeName)
+	if assert.NoError(t, err) {
+		assert.Equal(t, apitest.FakeVersion, version.Version)
+		assert.Equal(t, apitest.FakeRuntimeName, version.RuntimeName)
+	}
 }

--- a/pkg/kubelet/cri/remote/remote_runtime_test.go
+++ b/pkg/kubelet/cri/remote/remote_runtime_test.go
@@ -67,8 +67,7 @@ func TestVersion(t *testing.T) {
 
 	r := createRemoteRuntimeService(endpoint, t)
 	version, err := r.Version(apitest.FakeVersion)
-	if assert.NoError(t, err) {
-		assert.Equal(t, apitest.FakeVersion, version.Version)
-		assert.Equal(t, apitest.FakeRuntimeName, version.RuntimeName)
-	}
+	require.NoError(t, err)
+	assert.Equal(t, apitest.FakeVersion, version.Version)
+	assert.Equal(t, apitest.FakeRuntimeName, version.RuntimeName)
 }


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:

It is possible [r.Version(apitest.FakeVersion)](https://github.com/kubernetes/kubernetes/blob/master/pkg/kubelet/cri/remote/remote_runtime_test.go#L69) returns an error. At this time, `version` is nil. Since [`assert.NoError(t, err)`](https://github.com/kubernetes/kubernetes/blob/master/pkg/kubelet/cri/remote/remote_runtime_test.go#L70) does not stop the test, the following `version.Version` triggers a runtime panic.  


#### Which issue(s) this PR fixes:
The patch is to skip `version.Version`, when `r.Version(apitest.FakeVersion)` returns an error. 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
None



#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

None
