### PR TITLE
rolebinding often used for serviceaccount

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_rolebinding.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_rolebinding.go
@@ -40,9 +40,12 @@ var (
 	roleBindingLong = templates.LongDesc(i18n.T(`
 		Create a role binding for a particular role or cluster role.`))
 
-	roleBindingExample = templates.Examples(i18n.T(`
-		  # Create a role binding for user1, user2, and group1 using the admin cluster role
-		  kubectl create rolebinding admin --clusterrole=admin --user=user1 --user=user2 --group=group1`))
+		roleBindingExample = templates.Examples(i18n.T(`
+		# Create a role binding for user1, user2, and group1 using the admin cluster role
+		kubectl create rolebinding admin --clusterrole=admin --user=user1 --user=user2 --group=group1`
+
+		# Create a role binding for serviceaccount monitoring:sa-dev using the admin role
+		kubectl create rolebinding admin-binding --role=admin --serviceaccount=monitoring:sa-dev))
 )
 
 // RoleBindingOptions holds the options for 'create rolebinding' sub command

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_rolebinding.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_rolebinding.go
@@ -42,10 +42,10 @@ var (
 
 		roleBindingExample = templates.Examples(i18n.T(`
 		# Create a role binding for user1, user2, and group1 using the admin cluster role
-		kubectl create rolebinding admin --clusterrole=admin --user=user1 --user=user2 --group=group1`
+		kubectl create rolebinding admin --clusterrole=admin --user=user1 --user=user2 --group=group1
 
 		# Create a role binding for serviceaccount monitoring:sa-dev using the admin role
-		kubectl create rolebinding admin-binding --role=admin --serviceaccount=monitoring:sa-dev))
+		kubectl create rolebinding admin-binding --role=admin --serviceaccount=monitoring:sa-dev`))
 )
 
 // RoleBindingOptions holds the options for 'create rolebinding' sub command

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_rolebinding.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_rolebinding.go
@@ -40,7 +40,7 @@ var (
 	roleBindingLong = templates.LongDesc(i18n.T(`
 		Create a role binding for a particular role or cluster role.`))
 
-		roleBindingExample = templates.Examples(i18n.T(`
+	roleBindingExample = templates.Examples(i18n.T(`
 		# Create a role binding for user1, user2, and group1 using the admin cluster role
 		kubectl create rolebinding admin --clusterrole=admin --user=user1 --user=user2 --group=group1
 


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:

rolebinding often used for serviceaccount

```release-note

The change affects the following CLI command:

kubectl create rolebinding -h

```