### PR TITLE
Fix default config flags

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/cmd.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/cmd.go
@@ -89,12 +89,14 @@ type KubectlOptions struct {
 	genericclioptions.IOStreams
 }
 
+var defaultConfigFlags = genericclioptions.NewConfigFlags(true).WithDeprecatedPasswordFlag().WithDiscoveryBurst(300).WithDiscoveryQPS(50.0)
+
 // NewDefaultKubectlCommand creates the `kubectl` command with default arguments
 func NewDefaultKubectlCommand() *cobra.Command {
 	return NewDefaultKubectlCommandWithArgs(KubectlOptions{
 		PluginHandler: NewDefaultPluginHandler(plugin.ValidPluginFilenamePrefixes),
 		Arguments:     os.Args,
-		ConfigFlags:   genericclioptions.NewConfigFlags(true).WithDeprecatedPasswordFlag(),
+		ConfigFlags:   defaultConfigFlags,
 		IOStreams:     genericclioptions.IOStreams{In: os.Stdin, Out: os.Stdout, ErrOut: os.Stderr},
 	})
 }
@@ -294,7 +296,7 @@ func NewKubectlCommand(o KubectlOptions) *cobra.Command {
 
 	kubeConfigFlags := o.ConfigFlags
 	if kubeConfigFlags == nil {
-		kubeConfigFlags = genericclioptions.NewConfigFlags(true).WithDeprecatedPasswordFlag().WithDiscoveryBurst(300).WithDiscoveryQPS(50.0)
+		kubeConfigFlags = defaultConfigFlags
 	}
 	kubeConfigFlags.AddFlags(flags)
 	matchVersionKubeConfigFlags := cmdutil.NewMatchVersionFlags(kubeConfigFlags)


### PR DESCRIPTION
This is a follow up to #105520 which only changed the new default config flags in the `NewKubectlCommand` function if `kubeConfigFlags == nil`. However they are not nil because they were initialized before here:
https://github.com/kubernetes/kubernetes/blob/2fe968deb6cef4feea5bd0eb435e71844e397eed/staging/src/k8s.io/kubectl/pkg/cmd/cmd.go#L97

This fix uses the same defaults for both functions

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
It completes an older PR #105520 which missed to set the newly introduced default discovery burst in the `NewDefaultKubectlCommand` function. It only set it in the `NewKubectlCommand` function if `kubeConfigFlags == nil`, which never happened because it was already initialized in the `NewDefaultKubectlCommand` function as shown above.
https://github.com/kubernetes/kubernetes/blob/2fe968deb6cef4feea5bd0eb435e71844e397eed/staging/src/k8s.io/kubectl/pkg/cmd/cmd.go#L296-L297
The difference is demonstrated with these two builds:

Build of this PR (c4fbd35cf4bdc76b86dd74e468b69328f5aa20f9):
```bash
╰─ time ./_output/bin/kubectl get pods
NAME      READY   STATUS    RESTARTS   AGE
toolbox   1/1     Running   0          4d1h
./_output/bin/kubectl get pods  0.54s user 1.23s system 12% cpu 14.245 total
```

Build of current master (489fb9bee3f626b3eeb120a5af89ad8c2b2f1c20):
```bash
╰─ time ./_output/bin/kubectl get pods
I1219 19:48:52.781276   28978 request.go:665] Waited for 1.196431349s due to client-side throttling, not priority and fairness, request: GET:https://10.216.1.114/apis/networking.gke.io/v1beta2?timeout=32s
I1219 19:49:02.977362   28978 request.go:665] Waited for 11.392070918s due to client-side throttling, not priority and fairness, request: GET:https://10.216.1.114/apis/kms.cnrm.cloud.google.com/v1beta1?timeout=32s
NAME      READY   STATUS    RESTARTS   AGE
toolbox   1/1     Running   0          4d1h
./_output/bin/kubectl get pods  0.56s user 1.21s system 5% cpu 31.313 total

```


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #105520

#### Special notes for your reviewer:
/assign @seans3 @lavalamp @justinsb @soltysh 

#### Does this PR introduce a user-facing change?

```release-note
Fix kubectl config flags incorrectly setting burst and discovery limits
```

