### PR TITLE
chore(kubectl_utils): remove windows specifc command addition for sync

### DIFF
--- a/test/e2e/framework/kubectl/kubectl_utils.go
+++ b/test/e2e/framework/kubectl/kubectl_utils.go
@@ -142,10 +142,6 @@ func (tk *TestKubeconfig) WriteFileViaContainer(podName, containerName string, p
 		}
 	}
 	command := fmt.Sprintf("echo '%s' > '%s'; sync", contents, path)
-	// TODO(mauriciopoppe): remove this statement once we add `sync` to the test image, ref #101172
-	if e2epod.NodeOSDistroIs("windows") {
-		command = fmt.Sprintf("echo '%s' > '%s';", contents, path)
-	}
 	stdout, stderr, err := tk.kubectlExecWithRetry(tk.Namespace, podName, containerName, "--", "/bin/sh", "-c", command)
 	if err != nil {
 		e2elog.Logf("error running kubectl exec to write file: %v\nstdout=%v\nstderr=%v)", err, string(stdout), string(stderr))


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
Cleans up windows specific test command configuration after conclusion of #101172

#### Which issue(s) this PR fixes:
Fixes #101172

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
``

/sig testing