### PR TITLE
Automated cherry pick of #104799: fix the error when cleaning up jobs for cronjob

### DIFF
--- a/pkg/controller/cronjob/cronjob_controllerv2.go
+++ b/pkg/controller/cronjob/cronjob_controllerv2.go
@@ -613,13 +613,14 @@ func (jm *ControllerV2) syncCronJob(
 	}
 	cj.Status.Active = append(cj.Status.Active, *jobRef)
 	cj.Status.LastScheduleTime = &metav1.Time{Time: *scheduledTime}
-	if _, err := jm.cronJobControl.UpdateStatus(ctx, cj); err != nil {
+	updatedCJ, err = jm.cronJobControl.UpdateStatus(ctx, cj)
+	if err != nil {
 		klog.InfoS("Unable to update status", "cronjob", klog.KRef(cj.GetNamespace(), cj.GetName()), "resourceVersion", cj.ResourceVersion, "err", err)
 		return cj, nil, fmt.Errorf("unable to update status for %s (rv = %s): %v", klog.KRef(cj.GetNamespace(), cj.GetName()), cj.ResourceVersion, err)
 	}
 
 	t := nextScheduledTimeDuration(sched, now)
-	return cj, t, nil
+	return updatedCJ, t, nil
 }
 
 func getJobName(cj *batchv1.CronJob, scheduledTime time.Time) string {

--- a/test/integration/cronjob/cronjob_test.go
+++ b/test/integration/cronjob/cronjob_test.go
@@ -26,6 +26,7 @@ import (
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/informers"
 	clientset "k8s.io/client-go/kubernetes"
@@ -152,6 +153,14 @@ func TestCronJobLaunchesPodAndCleansUp(t *testing.T) {
 
 	ns := framework.CreateTestingNamespace(namespaceName, server, t)
 	defer framework.DeleteTestingNamespace(ns, server, t)
+
+	backupHandlers := runtime.ErrorHandlers
+	runtime.ErrorHandlers = append(runtime.ErrorHandlers, func(e error) {
+		t.Fatalf("Failed with error: %v", e)
+	})
+	defer func() {
+		runtime.ErrorHandlers = backupHandlers
+	}()
 
 	cjClient := clientSet.BatchV1().CronJobs(ns.Name)
 


### PR DESCRIPTION
Cherry pick of #104799 on release-1.23.

#104799: fix the error when cleaning up jobs for cronjob

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
Fix regression in 1.21 cleaning up finished cronjobs
```
