### PR TITLE
Increase default value of cache TTL to 6 hours.

### DIFF
--- a/staging/src/k8s.io/cli-runtime/go.mod
+++ b/staging/src/k8s.io/cli-runtime/go.mod
@@ -21,6 +21,7 @@ require (
 	k8s.io/apimachinery v0.0.0
 	k8s.io/client-go v0.0.0
 	k8s.io/kube-openapi v0.0.0-20211115234752-e816edb12b65
+	k8s.io/utils v0.0.0-20220210201930-3a6ce19ff2f9
 	sigs.k8s.io/kustomize/api v0.10.1
 	sigs.k8s.io/kustomize/kyaml v0.13.0
 	sigs.k8s.io/yaml v1.2.0

--- a/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/config_flags.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/config_flags.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/client-go/restmapper"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/util/homedir"
+	utilpointer "k8s.io/utils/pointer"
 )
 
 const (
@@ -284,7 +285,7 @@ func (f *ConfigFlags) toDiscoveryClient() (discovery.CachedDiscoveryInterface, e
 	httpCacheDir := filepath.Join(cacheDir, "http")
 	discoveryCacheDir := computeDiscoverCacheDir(filepath.Join(cacheDir, "discovery"), config.Host)
 
-	return diskcached.NewCachedDiscoveryClientForConfig(config, discoveryCacheDir, httpCacheDir, time.Duration(10*time.Minute))
+	return diskcached.NewCachedDiscoveryClientForConfig(config, discoveryCacheDir, httpCacheDir, time.Duration(6*time.Hour))
 }
 
 // ToRESTMapper returns a mapper.
@@ -386,8 +387,8 @@ func (f *ConfigFlags) AddFlags(flags *pflag.FlagSet) {
 
 // WithDeprecatedPasswordFlag enables the username and password config flags
 func (f *ConfigFlags) WithDeprecatedPasswordFlag() *ConfigFlags {
-	f.Username = stringptr("")
-	f.Password = stringptr("")
+	f.Username = utilpointer.String("")
+	f.Password = utilpointer.String("")
 	return f
 }
 
@@ -416,22 +417,22 @@ func NewConfigFlags(usePersistentConfig bool) *ConfigFlags {
 
 	return &ConfigFlags{
 		Insecure:   &insecure,
-		Timeout:    stringptr("0"),
-		KubeConfig: stringptr(""),
+		Timeout:    utilpointer.String("0"),
+		KubeConfig: utilpointer.String(""),
 
-		CacheDir:         stringptr(defaultCacheDir),
-		ClusterName:      stringptr(""),
-		AuthInfoName:     stringptr(""),
-		Context:          stringptr(""),
-		Namespace:        stringptr(""),
-		APIServer:        stringptr(""),
-		TLSServerName:    stringptr(""),
-		CertFile:         stringptr(""),
-		KeyFile:          stringptr(""),
-		CAFile:           stringptr(""),
-		BearerToken:      stringptr(""),
-		Impersonate:      stringptr(""),
-		ImpersonateUID:   stringptr(""),
+		CacheDir:         utilpointer.String(defaultCacheDir),
+		ClusterName:      utilpointer.String(""),
+		AuthInfoName:     utilpointer.String(""),
+		Context:          utilpointer.String(""),
+		Namespace:        utilpointer.String(""),
+		APIServer:        utilpointer.String(""),
+		TLSServerName:    utilpointer.String(""),
+		CertFile:         utilpointer.String(""),
+		KeyFile:          utilpointer.String(""),
+		CAFile:           utilpointer.String(""),
+		BearerToken:      utilpointer.String(""),
+		Impersonate:      utilpointer.String(""),
+		ImpersonateUID:   utilpointer.String(""),
 		ImpersonateGroup: &impersonateGroup,
 
 		usePersistentConfig: usePersistentConfig,
@@ -440,10 +441,6 @@ func NewConfigFlags(usePersistentConfig bool) *ConfigFlags {
 		// double it just so we don't end up here again for a while.  This config is only used for discovery.
 		discoveryBurst: 100,
 	}
-}
-
-func stringptr(val string) *string {
-	return &val
 }
 
 // overlyCautiousIllegalFileCharacters matches characters that *might* not be supported.  Windows is really restrictive, so this is really restrictive


### PR DESCRIPTION
 Increase default value of cache TTL to 6 hours.

Fixes #107130
#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Increase default value of discovery cache TTL for kubectl to 6 hours.
```
