### PR TITLE
Request: Add troy0820 as sig-node-reviewer

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -241,6 +241,7 @@ aliases:
     - pmorie
     - resouer
     - sjenning
+    - troy0820
     - wzshiming
     - yujuhong
     - krmayankk


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup
/sig node
**What this PR does / why we need it**:
Requesting SIG Node reviewer status.

**Special notes for your reviewer**:
Completed [reviewer requirements](https://github.com/kubernetes/community/blob/master/community-membership.md#requirements-1)
- [x] Member for at least 3 months
  Member since Oct 2020 https://github.com/kubernetes/org/pull/2262
- [x] Primary reviewer for at least 5 PRs to the codebase
  1. [100438](https://github.com/kubernetes/kubernetes/pull/100438) 
  1. [97818](https://github.com/kubernetes/kubernetes/pull/97818)
  1. [100204](https://github.com/kubernetes/kubernetes/pull/100204)
  1. [99610](https://github.com/kubernetes/kubernetes/pull/99610)
  1. [99651](https://github.com/kubernetes/kubernetes/pull/99651)
  1. [97932](https://github.com/kubernetes/kubernetes/pull/97932)
  1. [100292](https://github.com/kubernetes/kubernetes/pull/100292)
  
- [x] Reviewed or merged at least 20 substantial PRs to the codebase
  Reviewer for [34 node PRs in k/k](https://github.com/kubernetes/kubernetes/pulls?q=is%3Apr+is%3Aopen+commenter%3Atroy0820+label%3Asig%2Fnode) since Oct. 2020
 
- [x] Knowledgeable about the codebase
  Authored or commented on [40 PRs in k/k](https://github.com/kubernetes/kubernetes/pulls?q=is%3Apr+commenter%3Atroy0820+) since Dec 2019
  Pull request for [KinD](https://github.com/kubernetes-sigs/kind/pull/2134)
- [x] Sponsored by a subproject approver
  By @mrunalp 
  With no objections from other approvers
    - [ ] @Random-Liu
    - [ ] @dchen1107
    - [ ] @derekwaynecarr
    - [ ] @yujuhong
    - [ ] @sjenning
    - [x] @mrunalp
    - [ ] @klueska
  Done through PR to update the OWNERS file
  This PR :)
- [x] May either self-nominate, be nominated by an approver in this subproject, or be nominated by a robot
  Self-nominated.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
/cc @mrunalp 
closing https://github.com/kubernetes/kubernetes/pull/100263 in favor of this PR