### PR TITLE
Add comment on beta status for APIPriorityAndFairness feature gate

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/features/kube_features.go
+++ b/staging/src/k8s.io/apiserver/pkg/features/kube_features.go
@@ -125,7 +125,7 @@ const (
 
 	// owner: @MikeSpreitzer @yue9944882
 	// alpha: v1.15
-	//
+	// beta: v1.20
 	//
 	// Enables managing request concurrency with prioritization and fairness at each server
 	APIPriorityAndFairness featuregate.Feature = "APIPriorityAndFairness"


### PR DESCRIPTION
APIPriorityAndFairness reached beta status and is enabled by default in v1.20

https://kubernetes.io/docs/concepts/cluster-administration/flow-control/

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Added comment above `APIPriorityAndFairness featuregate.Feature = "APIPriorityAndFairness"` like other constants under kube_features.go.

#### Which issue(s) this PR fixes:

N/A

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

N/A
