### PR TITLE
Refactor logs command

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/logs/logs.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/logs/logs.go
@@ -32,6 +32,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/resource"
 	"k8s.io/client-go/rest"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 	"k8s.io/kubectl/pkg/polymorphichelpers"
@@ -92,18 +93,174 @@ const (
 	defaultPodLogsTimeout = 20 * time.Second
 )
 
+var defaultContainerNameFromRefSpecRegexp = regexp.MustCompile(`spec\.(?:initContainers|containers|ephemeralContainers){(.+)}`)
+
+// LogsFlags reflects the information that the CLI is gathering via flags.
+// They will be converted to PodLogOptions for runtime requirements.
+type LogsFlags struct {
+	// required objects
+	RESTClientGetter genericclioptions.RESTClientGetter
+	ResourceBuilder  *resource.Builder
+
+	// flags
+	AllContainers                bool
+	Container                    string
+	Follow                       bool
+	IgnoreLogErrors              bool
+	InsecureSkipTLSVerifyBackend bool
+	LimitBytes                   int64
+	MaxFollowConcurrency         int
+	Prefix                       bool
+	Previous                     bool
+	PodRunningTimeout            time.Duration
+	Selector                     string
+	Since                        time.Duration
+	SinceTime                    string
+	Tail                         int64
+	Timestamps                   bool
+
+	// internal items
+	containerNameSpecified bool
+	namespace              string
+
+	genericclioptions.IOStreams
+}
+
+// NewLogsFlags returns a default LogsFlags.
+func NewLogsFlags(f cmdutil.Factory, streams genericclioptions.IOStreams) *LogsFlags {
+	namespace, _, _ := f.ToRawKubeConfigLoader().Namespace()
+
+	return &LogsFlags{
+		RESTClientGetter: f,
+		ResourceBuilder: f.NewBuilder().SingleResourceType().
+			WithScheme(scheme.Scheme, scheme.Scheme.PrioritizedVersionsAllGroups()...),
+		Tail:                 -1,
+		MaxFollowConcurrency: 5,
+		namespace:            namespace,
+		IOStreams:            streams,
+	}
+}
+
+// ToOptions converts from CLI inputs to runtime inputs.
+func (flags *LogsFlags) ToOptions(cmd *cobra.Command, args []string) (*LogsOptions, error) {
+	flags.containerNameSpecified = cmd.Flag("container").Changed
+
+	o := &LogsOptions{
+		RESTClientGetter: flags.RESTClientGetter,
+		ResourceBuilder:  flags.ResourceBuilder,
+		LogsForObject:    polymorphichelpers.LogsForObjectFn,
+		Namespace:        flags.namespace,
+		Resources:        args,
+		IOStreams:        flags.IOStreams,
+
+		AllContainers:                flags.AllContainers,
+		Container:                    flags.Container,
+		Follow:                       flags.Follow,
+		IgnoreLogErrors:              flags.IgnoreLogErrors,
+		InsecureSkipTLSVerifyBackend: flags.InsecureSkipTLSVerifyBackend,
+		LimitBytes:                   flags.LimitBytes,
+		MaxFollowConcurrency:         flags.MaxFollowConcurrency,
+		Prefix:                       flags.Prefix,
+		Previous:                     flags.Previous,
+		Selector:                     flags.Selector,
+		SinceTime:                    flags.SinceTime,
+		Since:                        flags.Since,
+		Tail:                         flags.Tail,
+		Timestamps:                   flags.Timestamps,
+
+		ContainerNameSpecified: flags.containerNameSpecified,
+		TailSpecified:          cmd.Flag("tail").Changed,
+
+		containerNameFromRefSpecRegexp: defaultContainerNameFromRefSpecRegexp,
+	}
+
+	switch len(args) {
+	case 0:
+		if len(flags.Selector) == 0 {
+			return nil, cmdutil.UsageErrorf(cmd, "%s", logsUsageErrStr)
+		}
+	case 1:
+		o.ResourceArg = args[0]
+		if len(flags.Selector) != 0 {
+			return nil, cmdutil.UsageErrorf(cmd, "only a selector (-l) or a POD name is allowed")
+		}
+	case 2:
+		o.ResourceArg = args[0]
+		o.Container = args[1]
+	default:
+		return nil, cmdutil.UsageErrorf(cmd, "%s", logsUsageErrStr)
+	}
+
+	o.ResourceBuilder.NamespaceParam(o.Namespace)
+
+	if len(flags.Selector) > 0 {
+		o.ResourceBuilder.ResourceTypes("pods").LabelSelectorParam(o.Selector)
+	}
+
+	if len(o.ResourceArg) > 0 {
+		o.ResourceBuilder.ResourceNames("pods", o.ResourceArg)
+	}
+
+	var err error
+	o.ConsumeRequestFn = DefaultConsumeRequest
+	o.GetPodTimeout, err = cmdutil.GetPodRunningTimeoutFlag(cmd)
+	if err != nil {
+		return nil, err
+	}
+
+	o.Options, err = o.ToLogOptions()
+	if err != nil {
+		return nil, err
+	}
+
+	infos, err := o.ResourceBuilder.Do().Infos()
+	if err != nil {
+		return nil, err
+	}
+	if o.Selector == "" && len(infos) != 1 {
+		return nil, fmt.Errorf("expected a resource")
+	}
+	o.Object = infos[0].Object
+	if o.Selector != "" && len(o.Object.(*corev1.PodList).Items) == 0 {
+		fmt.Fprintf(o.ErrOut, "No resources found in %s namespace.\n", o.Namespace)
+	}
+
+	return o, o.Validate()
+}
+
+// AddFlags registers flags for the CLI.
+func (flags *LogsFlags) AddFlags(cmd *cobra.Command) {
+	cmdutil.AddPodRunningTimeoutFlag(cmd, defaultPodLogsTimeout)
+
+	cmd.Flags().BoolVar(&flags.AllContainers, "all-containers", flags.AllContainers, "Get all containers' logs in the pod(s).")
+	cmd.Flags().StringVarP(&flags.Container, "container", "c", flags.Container, "Print the logs of this container")
+	cmd.Flags().BoolVarP(&flags.Follow, "follow", "f", flags.Follow, "Specify if the logs should be streamed.")
+	cmd.Flags().BoolVar(&flags.IgnoreLogErrors, "ignore-errors", flags.IgnoreLogErrors, "If watching / following pod logs, allow for any errors that occur to be non-fatal")
+	cmd.Flags().BoolVar(&flags.InsecureSkipTLSVerifyBackend, "insecure-skip-tls-verify-backend", flags.InsecureSkipTLSVerifyBackend,
+		"Skip verifying the identity of the kubelet that logs are requested from.  In theory, an attacker could provide invalid log content back. You might want to use this if your kubelet serving certificates have expired.")
+	cmd.Flags().Int64Var(&flags.LimitBytes, "limit-bytes", flags.LimitBytes, "Maximum bytes of logs to return. Defaults to no limit.")
+	cmd.Flags().IntVar(&flags.MaxFollowConcurrency, "max-log-requests", flags.MaxFollowConcurrency, "Specify maximum number of concurrent logs to follow when using by a selector. Defaults to 5.")
+	cmd.Flags().BoolVar(&flags.Prefix, "prefix", flags.Prefix, "Prefix each log line with the log source (pod name and container name)")
+	cmd.Flags().BoolVarP(&flags.Previous, "previous", "p", flags.Previous, "If true, print the logs for the previous instance of the container in a pod if it exists.")
+	cmd.Flags().StringVarP(&flags.Selector, "selector", "l", flags.Selector, "Selector (label query) to filter on.")
+	cmd.Flags().DurationVar(&flags.Since, "since", flags.Since, "Only return logs newer than a relative duration like 5s, 2m, or 3h. Defaults to all logs. Only one of since-time / since may be used.")
+	cmd.Flags().StringVar(&flags.SinceTime, "since-time", flags.SinceTime, i18n.T("Only return logs after a specific date (RFC3339). Defaults to all logs. Only one of since-time / since may be used."))
+	cmd.Flags().Int64Var(&flags.Tail, "tail", flags.Tail, "Lines of recent log file to display. Defaults to -1 with no selector, showing all log lines otherwise 10, if a selector is provided.")
+	cmd.Flags().BoolVar(&flags.Timestamps, "timestamps", flags.Timestamps, "Include timestamps on each line in the log output")
+}
+
 type LogsOptions struct {
-	Namespace     string
-	ResourceArg   string
-	AllContainers bool
-	Options       runtime.Object
-	Resources     []string
+	Namespace   string
+	ResourceArg string
+	Options     runtime.Object
+	Resources   []string
 
 	ConsumeRequestFn func(rest.ResponseWrapper, io.Writer) error
 
 	// PodLogOptions
+	AllContainers                bool
 	SinceTime                    string
-	SinceSeconds                 time.Duration
+	Since                        time.Duration
 	Follow                       bool
 	Previous                     bool
 	Timestamps                   bool
@@ -112,39 +269,29 @@ type LogsOptions struct {
 	Tail                         int64
 	Container                    string
 	InsecureSkipTLSVerifyBackend bool
+	Selector                     string
+	MaxFollowConcurrency         int
+	Prefix                       bool
 
-	// whether or not a container name was given via --container
+	//internal items
 	ContainerNameSpecified bool
-	Selector               string
-	MaxFollowConcurrency   int
-	Prefix                 bool
+	TailSpecified          bool
 
+	// initialized during ToOptions operation
 	Object           runtime.Object
 	GetPodTimeout    time.Duration
 	RESTClientGetter genericclioptions.RESTClientGetter
 	LogsForObject    polymorphichelpers.LogsForObjectFunc
+	ResourceBuilder  *resource.Builder
 
 	genericclioptions.IOStreams
-
-	TailSpecified bool
 
 	containerNameFromRefSpecRegexp *regexp.Regexp
 }
 
-func NewLogsOptions(streams genericclioptions.IOStreams, allContainers bool) *LogsOptions {
-	return &LogsOptions{
-		IOStreams:            streams,
-		AllContainers:        allContainers,
-		Tail:                 -1,
-		MaxFollowConcurrency: 5,
-
-		containerNameFromRefSpecRegexp: regexp.MustCompile(`spec\.(?:initContainers|containers|ephemeralContainers){(.+)}`),
-	}
-}
-
 // NewCmdLogs creates a new pod logs command
 func NewCmdLogs(f cmdutil.Factory, streams genericclioptions.IOStreams) *cobra.Command {
-	o := NewLogsOptions(streams, false)
+	flags := NewLogsFlags(f, streams)
 
 	cmd := &cobra.Command{
 		Use:                   logsUsageStr,
@@ -154,32 +301,14 @@ func NewCmdLogs(f cmdutil.Factory, streams genericclioptions.IOStreams) *cobra.C
 		Example:               logsExample,
 		ValidArgsFunction:     util.PodResourceNameAndContainerCompletionFunc(f),
 		Run: func(cmd *cobra.Command, args []string) {
-			cmdutil.CheckErr(o.Complete(f, cmd, args))
-			cmdutil.CheckErr(o.Validate())
+			o, err := flags.ToOptions(cmd, args)
+			cmdutil.CheckErr(err)
 			cmdutil.CheckErr(o.RunLogs())
 		},
 	}
-	o.AddFlags(cmd)
-	return cmd
-}
 
-func (o *LogsOptions) AddFlags(cmd *cobra.Command) {
-	cmd.Flags().BoolVar(&o.AllContainers, "all-containers", o.AllContainers, "Get all containers' logs in the pod(s).")
-	cmd.Flags().BoolVarP(&o.Follow, "follow", "f", o.Follow, "Specify if the logs should be streamed.")
-	cmd.Flags().BoolVar(&o.Timestamps, "timestamps", o.Timestamps, "Include timestamps on each line in the log output")
-	cmd.Flags().Int64Var(&o.LimitBytes, "limit-bytes", o.LimitBytes, "Maximum bytes of logs to return. Defaults to no limit.")
-	cmd.Flags().BoolVarP(&o.Previous, "previous", "p", o.Previous, "If true, print the logs for the previous instance of the container in a pod if it exists.")
-	cmd.Flags().Int64Var(&o.Tail, "tail", o.Tail, "Lines of recent log file to display. Defaults to -1 with no selector, showing all log lines otherwise 10, if a selector is provided.")
-	cmd.Flags().BoolVar(&o.IgnoreLogErrors, "ignore-errors", o.IgnoreLogErrors, "If watching / following pod logs, allow for any errors that occur to be non-fatal")
-	cmd.Flags().StringVar(&o.SinceTime, "since-time", o.SinceTime, i18n.T("Only return logs after a specific date (RFC3339). Defaults to all logs. Only one of since-time / since may be used."))
-	cmd.Flags().DurationVar(&o.SinceSeconds, "since", o.SinceSeconds, "Only return logs newer than a relative duration like 5s, 2m, or 3h. Defaults to all logs. Only one of since-time / since may be used.")
-	cmd.Flags().StringVarP(&o.Container, "container", "c", o.Container, "Print the logs of this container")
-	cmd.Flags().BoolVar(&o.InsecureSkipTLSVerifyBackend, "insecure-skip-tls-verify-backend", o.InsecureSkipTLSVerifyBackend,
-		"Skip verifying the identity of the kubelet that logs are requested from.  In theory, an attacker could provide invalid log content back. You might want to use this if your kubelet serving certificates have expired.")
-	cmdutil.AddPodRunningTimeoutFlag(cmd, defaultPodLogsTimeout)
-	cmd.Flags().StringVarP(&o.Selector, "selector", "l", o.Selector, "Selector (label query) to filter on.")
-	cmd.Flags().IntVar(&o.MaxFollowConcurrency, "max-log-requests", o.MaxFollowConcurrency, "Specify maximum number of concurrent logs to follow when using by a selector. Defaults to 5.")
-	cmd.Flags().BoolVar(&o.Prefix, "prefix", o.Prefix, "Prefix each log line with the log source (pod name and container name)")
+	flags.AddFlags(cmd)
+	return cmd
 }
 
 func (o *LogsOptions) ToLogOptions() (*corev1.PodLogOptions, error) {
@@ -204,9 +333,9 @@ func (o *LogsOptions) ToLogOptions() (*corev1.PodLogOptions, error) {
 		logOptions.LimitBytes = &o.LimitBytes
 	}
 
-	if o.SinceSeconds != 0 {
+	if o.Since != 0 {
 		// round up to the nearest second
-		sec := int64(o.SinceSeconds.Round(time.Second).Seconds())
+		sec := int64(o.Since.Round(time.Second).Seconds())
 		logOptions.SinceSeconds = &sec
 	}
 
@@ -219,78 +348,9 @@ func (o *LogsOptions) ToLogOptions() (*corev1.PodLogOptions, error) {
 	return logOptions, nil
 }
 
-func (o *LogsOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, args []string) error {
-	o.ContainerNameSpecified = cmd.Flag("container").Changed
-	o.TailSpecified = cmd.Flag("tail").Changed
-	o.Resources = args
-
-	switch len(args) {
-	case 0:
-		if len(o.Selector) == 0 {
-			return cmdutil.UsageErrorf(cmd, "%s", logsUsageErrStr)
-		}
-	case 1:
-		o.ResourceArg = args[0]
-		if len(o.Selector) != 0 {
-			return cmdutil.UsageErrorf(cmd, "only a selector (-l) or a POD name is allowed")
-		}
-	case 2:
-		o.ResourceArg = args[0]
-		o.Container = args[1]
-	default:
-		return cmdutil.UsageErrorf(cmd, "%s", logsUsageErrStr)
-	}
-	var err error
-	o.Namespace, _, err = f.ToRawKubeConfigLoader().Namespace()
-	if err != nil {
-		return err
-	}
-
-	o.ConsumeRequestFn = DefaultConsumeRequest
-
-	o.GetPodTimeout, err = cmdutil.GetPodRunningTimeoutFlag(cmd)
-	if err != nil {
-		return err
-	}
-
-	o.Options, err = o.ToLogOptions()
-	if err != nil {
-		return err
-	}
-
-	o.RESTClientGetter = f
-	o.LogsForObject = polymorphichelpers.LogsForObjectFn
-
-	if o.Object == nil {
-		builder := f.NewBuilder().
-			WithScheme(scheme.Scheme, scheme.Scheme.PrioritizedVersionsAllGroups()...).
-			NamespaceParam(o.Namespace).DefaultNamespace().
-			SingleResourceType()
-		if o.ResourceArg != "" {
-			builder.ResourceNames("pods", o.ResourceArg)
-		}
-		if o.Selector != "" {
-			builder.ResourceTypes("pods").LabelSelectorParam(o.Selector)
-		}
-		infos, err := builder.Do().Infos()
-		if err != nil {
-			return err
-		}
-		if o.Selector == "" && len(infos) != 1 {
-			return errors.New("expected a resource")
-		}
-		o.Object = infos[0].Object
-		if o.Selector != "" && len(o.Object.(*corev1.PodList).Items) == 0 {
-			fmt.Fprintf(o.ErrOut, "No resources found in %s namespace.\n", o.Namespace)
-		}
-	}
-
-	return nil
-}
-
 func (o LogsOptions) Validate() error {
-	if len(o.SinceTime) > 0 && o.SinceSeconds != 0 {
-		return fmt.Errorf("at most one of `sinceTime` or `sinceSeconds` may be specified")
+	if len(o.SinceTime) > 0 && o.Since != 0 {
+		return fmt.Errorf("at most one of `sinceTime` or `since` may be specified")
 	}
 
 	logsOptions, ok := o.Options.(*corev1.PodLogOptions)

--- a/staging/src/k8s.io/kubectl/pkg/cmd/logs/logs_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/logs/logs_test.go
@@ -60,7 +60,7 @@ func TestLog(t *testing.T) {
 					},
 				}
 
-				o := NewLogsOptions(streams, false)
+				o := newLogsOptions(streams, false)
 				o.LogsForObject = mock.mockLogsForObject
 				o.ConsumeRequestFn = mock.mockConsumeRequest
 
@@ -81,7 +81,7 @@ func TestLog(t *testing.T) {
 					},
 				}
 
-				o := NewLogsOptions(streams, false)
+				o := newLogsOptions(streams, false)
 				o.LogsForObject = mock.mockLogsForObject
 				o.ConsumeRequestFn = mock.mockConsumeRequest
 				o.Prefix = true
@@ -103,7 +103,7 @@ func TestLog(t *testing.T) {
 					},
 				}
 
-				o := NewLogsOptions(streams, false)
+				o := newLogsOptions(streams, false)
 				o.LogsForObject = mock.mockLogsForObject
 				o.ConsumeRequestFn = mock.mockConsumeRequest
 				o.Prefix = true
@@ -125,7 +125,7 @@ func TestLog(t *testing.T) {
 					},
 				}
 
-				o := NewLogsOptions(streams, false)
+				o := newLogsOptions(streams, false)
 				o.LogsForObject = mock.mockLogsForObject
 				o.ConsumeRequestFn = mock.mockConsumeRequest
 				o.Prefix = true
@@ -157,7 +157,7 @@ func TestLog(t *testing.T) {
 					},
 				}
 
-				o := NewLogsOptions(streams, false)
+				o := newLogsOptions(streams, false)
 				o.LogsForObject = mock.mockLogsForObject
 				o.ConsumeRequestFn = mock.mockConsumeRequest
 				return o
@@ -194,7 +194,7 @@ func TestLog(t *testing.T) {
 				}
 				wg.Add(3)
 
-				o := NewLogsOptions(streams, false)
+				o := newLogsOptions(streams, false)
 				o.LogsForObject = mock.mockLogsForObject
 				o.ConsumeRequestFn = mock.mockConsumeRequest
 				o.Follow = true
@@ -232,7 +232,7 @@ func TestLog(t *testing.T) {
 				}
 				wg.Add(3)
 
-				o := NewLogsOptions(streams, false)
+				o := newLogsOptions(streams, false)
 				o.LogsForObject = mock.mockLogsForObject
 				o.ConsumeRequestFn = mock.mockConsumeRequest
 				o.MaxFollowConcurrency = 2
@@ -244,7 +244,7 @@ func TestLog(t *testing.T) {
 		{
 			name: "fail if LogsForObject fails",
 			opts: func(streams genericclioptions.IOStreams) *LogsOptions {
-				o := NewLogsOptions(streams, false)
+				o := newLogsOptions(streams, false)
 				o.LogsForObject = func(restClientGetter genericclioptions.RESTClientGetter, object, options runtime.Object, timeout time.Duration, allContainers bool) (map[corev1.ObjectReference]restclient.ResponseWrapper, error) {
 					return nil, errors.New("Error from the LogsForObject")
 				}
@@ -270,7 +270,7 @@ func TestLog(t *testing.T) {
 					},
 				}
 
-				o := NewLogsOptions(streams, false)
+				o := newLogsOptions(streams, false)
 				o.LogsForObject = mock.mockLogsForObject
 				o.ConsumeRequestFn = func(req restclient.ResponseWrapper, out io.Writer) error {
 					return errors.New("Error from the ConsumeRequestFn")
@@ -305,7 +305,7 @@ func TestLog(t *testing.T) {
 				}
 				wg.Add(3)
 
-				o := NewLogsOptions(streams, false)
+				o := newLogsOptions(streams, false)
 				o.LogsForObject = mock.mockLogsForObject
 				o.ConsumeRequestFn = mock.mockConsumeRequest
 				o.Follow = true
@@ -344,7 +344,7 @@ func TestLog(t *testing.T) {
 				}
 				wg.Add(3)
 
-				o := NewLogsOptions(streams, false)
+				o := newLogsOptions(streams, false)
 				o.LogsForObject = mock.mockLogsForObject
 				o.ConsumeRequestFn = func(req restclient.ResponseWrapper, out io.Writer) error {
 					return errors.New("Error from the ConsumeRequestFn")
@@ -367,7 +367,7 @@ func TestLog(t *testing.T) {
 					},
 				}
 
-				o := NewLogsOptions(streams, false)
+				o := newLogsOptions(streams, false)
 				o.LogsForObject = mock.mockLogsForObject
 				o.ConsumeRequestFn = func(req restclient.ResponseWrapper, out io.Writer) error {
 					return errors.New("Error from the ConsumeRequestFn")
@@ -400,7 +400,7 @@ func TestLog(t *testing.T) {
 					},
 				}
 
-				o := NewLogsOptions(streams, false)
+				o := newLogsOptions(streams, false)
 				o.LogsForObject = mock.mockLogsForObject
 				o.ConsumeRequestFn = mock.mockConsumeRequest
 				o.IgnoreLogErrors = true
@@ -430,7 +430,7 @@ func TestLog(t *testing.T) {
 					},
 				}
 
-				o := NewLogsOptions(streams, false)
+				o := newLogsOptions(streams, false)
 				o.LogsForObject = mock.mockLogsForObject
 				o.ConsumeRequestFn = mock.mockConsumeRequest
 				return o
@@ -460,7 +460,7 @@ func TestLog(t *testing.T) {
 					},
 				}
 
-				o := NewLogsOptions(streams, false)
+				o := newLogsOptions(streams, false)
 				o.LogsForObject = mock.mockLogsForObject
 				o.ConsumeRequestFn = mock.mockConsumeRequest
 				o.IgnoreLogErrors = true
@@ -491,7 +491,7 @@ func TestLog(t *testing.T) {
 					},
 				}
 
-				o := NewLogsOptions(streams, false)
+				o := newLogsOptions(streams, false)
 				o.LogsForObject = mock.mockLogsForObject
 				o.ConsumeRequestFn = mock.mockConsumeRequest
 				o.Follow = true
@@ -562,8 +562,8 @@ func TestValidateLogOptions(t *testing.T) {
 		{
 			name: "since & since-time",
 			opts: func(streams genericclioptions.IOStreams) *LogsOptions {
-				o := NewLogsOptions(streams, false)
-				o.SinceSeconds = time.Hour
+				o := newLogsOptions(streams, false)
+				o.Since = time.Hour
 				o.SinceTime = "2006-01-02T15:04:05Z"
 
 				var err error
@@ -575,13 +575,13 @@ func TestValidateLogOptions(t *testing.T) {
 				return o
 			},
 			args:     []string{"foo"},
-			expected: "at most one of `sinceTime` or `sinceSeconds` may be specified",
+			expected: "at most one of `sinceTime` or `since` may be specified",
 		},
 		{
 			name: "negative since-time",
 			opts: func(streams genericclioptions.IOStreams) *LogsOptions {
-				o := NewLogsOptions(streams, false)
-				o.SinceSeconds = -1 * time.Second
+				o := newLogsOptions(streams, false)
+				o.Since = -1 * time.Second
 
 				var err error
 				o.Options, err = o.ToLogOptions()
@@ -597,7 +597,7 @@ func TestValidateLogOptions(t *testing.T) {
 		{
 			name: "negative limit-bytes",
 			opts: func(streams genericclioptions.IOStreams) *LogsOptions {
-				o := NewLogsOptions(streams, false)
+				o := newLogsOptions(streams, false)
 				o.LimitBytes = -100
 
 				var err error
@@ -614,7 +614,7 @@ func TestValidateLogOptions(t *testing.T) {
 		{
 			name: "negative tail",
 			opts: func(streams genericclioptions.IOStreams) *LogsOptions {
-				o := NewLogsOptions(streams, false)
+				o := newLogsOptions(streams, false)
 				o.Tail = -100
 
 				var err error
@@ -631,7 +631,7 @@ func TestValidateLogOptions(t *testing.T) {
 		{
 			name: "container name combined with --all-containers",
 			opts: func(streams genericclioptions.IOStreams) *LogsOptions {
-				o := NewLogsOptions(streams, true)
+				o := newLogsOptions(streams, true)
 				o.Container = "my-container"
 
 				var err error
@@ -648,7 +648,7 @@ func TestValidateLogOptions(t *testing.T) {
 		{
 			name: "container name combined with second argument",
 			opts: func(streams genericclioptions.IOStreams) *LogsOptions {
-				o := NewLogsOptions(streams, false)
+				o := newLogsOptions(streams, false)
 				o.Container = "my-container"
 				o.ContainerNameSpecified = true
 
@@ -681,23 +681,23 @@ func TestValidateLogOptions(t *testing.T) {
 	}
 }
 
-func TestLogComplete(t *testing.T) {
+func TestLogFlags(t *testing.T) {
 	f := cmdtesting.NewTestFactory()
 	defer f.Cleanup()
 
 	tests := []struct {
-		name     string
-		args     []string
-		opts     func(genericclioptions.IOStreams) *LogsOptions
-		expected string
+		name      string
+		args      []string
+		logsFlags func(genericclioptions.IOStreams) *LogsFlags
+		expected  string
 	}{
 		{
 			name: "One args case",
 			args: []string{"foo"},
-			opts: func(streams genericclioptions.IOStreams) *LogsOptions {
-				o := NewLogsOptions(streams, false)
-				o.Selector = "foo"
-				return o
+			logsFlags: func(streams genericclioptions.IOStreams) *LogsFlags {
+				flags := NewLogsFlags(f, streams)
+				flags.Selector = "foo"
+				return flags
 			},
 			expected: "only a selector (-l) or a POD name is allowed",
 		},
@@ -708,8 +708,8 @@ func TestLogComplete(t *testing.T) {
 
 		// checkErr breaks tests in case of errors, plus we just
 		// need to check errors returned by the command validation
-		o := test.opts(genericclioptions.NewTestIOStreamsDiscard())
-		err := o.Complete(f, cmd, test.args)
+		flags := test.logsFlags(genericclioptions.NewTestIOStreamsDiscard())
+		_, err := flags.ToOptions(cmd, test.args)
 		if err == nil {
 			t.Fatalf("expected error %q, got none", test.expected)
 		}
@@ -814,9 +814,9 @@ func TestNoResourceFoundMessage(t *testing.T) {
 
 	streams, _, buf, errbuf := genericclioptions.NewTestIOStreams()
 	cmd := NewCmdLogs(tf, streams)
-	o := NewLogsOptions(streams, false)
-	o.Selector = "foo"
-	err := o.Complete(tf, cmd, []string{})
+	flags := NewLogsFlags(tf, streams)
+	flags.Selector = "foo"
+	_, err := flags.ToOptions(cmd, []string{})
 
 	if err != nil {
 		t.Fatalf("Unexpected error, expected none, got %v", err)
@@ -830,6 +830,17 @@ func TestNoResourceFoundMessage(t *testing.T) {
 	expectedErr := "No resources found in test namespace.\n"
 	if e, a := expectedErr, errbuf.String(); e != a {
 		t.Errorf("expected to find:\n\t%s\nfound:\n\t%s\n", e, a)
+	}
+}
+
+func newLogsOptions(streams genericclioptions.IOStreams, allContainers bool) *LogsOptions {
+	return &LogsOptions{
+		IOStreams:            streams,
+		AllContainers:        allContainers,
+		Tail:                 -1,
+		MaxFollowConcurrency: 5,
+
+		containerNameFromRefSpecRegexp: defaultContainerNameFromRefSpecRegexp,
 	}
 }
 


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Refactors the log command to separate Options and Flags.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:
I tried using `genericclioptions.ResourceFinder` instead of `*resource.Builder`, but the tests were failing due to the discovery client not being set on expander errors.

Also tried to remove `cmdutil.Factory` in favor of `RESTClientGetter`, but I needed the selected namespace and its `NewBuilder()` which works properly with `cmdtesting.NewTestFactory()`.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

Related issue: https://github.com/kubernetes/kubectl/issues/1046

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
