### PR TITLE
Several minor fixes/cleanup to fake watch tests

### DIFF
--- a/staging/src/k8s.io/client-go/testing/fixture_test.go
+++ b/staging/src/k8s.io/client-go/testing/fixture_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package testing
 
 import (
-	"fmt"
 	"math/rand"
 	"strconv"
 	"sync"
@@ -53,7 +52,7 @@ func getArbitraryResource(s schema.GroupVersionResource, name, namespace string)
 	}
 }
 
-func TestWatchCallNonNamespace(t *testing.T) {
+func TestWatchCallOnNamespace(t *testing.T) {
 	testResource := schema.GroupVersionResource{Group: "", Version: "test_version", Resource: "test_kind"}
 	testObj := getArbitraryResource(testResource, "test_name", "test_namespace")
 	accessor, err := meta.Accessor(testObj)
@@ -184,24 +183,19 @@ func TestWatchCallMultipleInvocation(t *testing.T) {
 	o := NewObjectTracker(scheme, codecs.UniversalDecoder())
 	watchNamespaces := []string{
 		"",
-		"",
-		"test_namespace",
 		"test_namespace",
 	}
 	var wg sync.WaitGroup
 	wg.Add(len(watchNamespaces))
-	for idx, watchNamespace := range watchNamespaces {
-		i := idx
+	for _, watchNamespace := range watchNamespaces {
 		watchNamespace := watchNamespace
 		w, err := o.Watch(testResource, watchNamespace)
 		if err != nil {
 			t.Fatalf("test resource watch failed in %s: %v", watchNamespace, err)
 		}
 		go func() {
-			assert.NoError(t, err, "watch invocation failed")
 			for _, c := range cases {
 				if watchNamespace == "" || c.ns == watchNamespace {
-					fmt.Printf("%#v %#v\n", c, i)
 					event := <-w.ResultChan()
 					accessor, err := meta.Accessor(event.Object)
 					if err != nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind cleanup

#### What this PR does / why we need it:

Several minor fixes/cleanup to fake watch test cases:

1. fix function name that tests on a specific namespace.
2. remove unnecessary duplicated cases.
3. remove debugging statements.
4. remove unnecessary assertion in goroutines.

```
-func TestWatchCallNonNamespace(t *testing.T) {
+func TestWatchCallOnNamespace(t *testing.T) {
        testResource := schema.GroupVersionResource{Group: "", Version: "test_version", Resource: "test_kind"}
        testObj := getArbitraryResource(testResource, "test_name", "test_namespace")
        accessor, err := meta.Accessor(testObj)
@@ -184,24 +183,19 @@ func TestWatchCallMultipleInvocation(t *testing.T) {
        o := NewObjectTracker(scheme, codecs.UniversalDecoder())
        watchNamespaces := []string{
                "",
-               "",
-               "test_namespace",
                "test_namespace",
        }
        var wg sync.WaitGroup
        wg.Add(len(watchNamespaces))
-       for idx, watchNamespace := range watchNamespaces {
-               i := idx
+       for _, watchNamespace := range watchNamespaces {
                watchNamespace := watchNamespace
                w, err := o.Watch(testResource, watchNamespace)
                if err != nil {
                        t.Fatalf("test resource watch failed in %s: %v", watchNamespace, err)
                }
                go func() {
-                       assert.NoError(t, err, "watch invocation failed")
                        for _, c := range cases {
                                if watchNamespace == "" || c.ns == watchNamespace {
-                                       fmt.Printf("%#v %#v\n", c, i)
                                        event := <-w.ResultChan()
                                        accessor, err := meta.Accessor(event.Object)
                                        if err != nil {
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
