### PR TITLE
Add manually invalidate cache documentation into delete

### DIFF
--- a/hack/testdata/CRD/example-crd-1-cluster-scoped-resource.yaml
+++ b/hack/testdata/CRD/example-crd-1-cluster-scoped-resource.yaml
@@ -1,0 +1,6 @@
+apiVersion: test.com/v1
+kind: Example
+metadata:
+  name: test
+spec:
+  test: test

--- a/hack/testdata/CRD/example-crd-1-cluster-scoped.yaml
+++ b/hack/testdata/CRD/example-crd-1-cluster-scoped.yaml
@@ -1,0 +1,24 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: examples.test.com
+spec:
+  group: test.com
+  scope: Cluster
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              properties:
+                test:
+                  type: string
+  names:
+    plural: examples
+    singular: example
+    kind: Example

--- a/hack/testdata/CRD/example-crd-1-namespaced-resource.yaml
+++ b/hack/testdata/CRD/example-crd-1-namespaced-resource.yaml
@@ -1,0 +1,7 @@
+apiVersion: test.com/v1
+kind: Example
+metadata:
+  name: test
+  namespace: default
+spec:
+  test: test

--- a/hack/testdata/CRD/example-crd-1-namespaced.yaml
+++ b/hack/testdata/CRD/example-crd-1-namespaced.yaml
@@ -1,0 +1,24 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: examples.test.com
+spec:
+  group: test.com
+  scope: Namespaced
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              properties:
+                test:
+                  type: string
+  names:
+    plural: examples
+    singular: example
+    kind: Example

--- a/staging/src/k8s.io/kubectl/pkg/cmd/delete/delete.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/delete/delete.go
@@ -69,7 +69,11 @@ var (
 
 		Note that the delete command does NOT do resource version checks, so if someone submits an
 		update to a resource right when you submit a delete, their update will be lost along with the
-		rest of the resource.`))
+		rest of the resource.
+
+		After a CustomResourceDefinition is deleted, invalidation of discovery cache may take up
+		to 10 minutes. If you don't want to wait, you might want to run "kubectl api-resources"
+		to refresh the discovery cache.`))
 
 	deleteExample = templates.Examples(i18n.T(`
 		# Delete a pod using the type and name specified in pod.json

--- a/test/cmd/legacy-script.sh
+++ b/test/cmd/legacy-script.sh
@@ -892,6 +892,13 @@ runTests() {
     record_command run_kubectl_explain_tests
   fi
 
+  ##############################
+  # CRD Deletion / Re-creation #
+  ##############################
+
+  if kube::test::if_supports_resource "${namespaces}" ; then
+      record_command run_crd_deletion_recreation_tests
+  fi
 
   ###########
   # Swagger #


### PR DESCRIPTION
#### What type of PR is this?
/kind bug
/kind cleanup

#### What this PR does / why we need it:

When CRDs are deleted, discovery local cache is not invalidated.
This brings about `resource not found` error when new CRD with same name is created
with different fields(ie. changing scope from cluster-wide to namespaced).
Because this already deleted CRD still stays in serverresources.json and kubectl tries to use it.

This local cached files have 10 minutes TTL. After deletion, if user waits 10 minutes,
files will be expired and deleted and there will be no errors. However, 10 minutes is a long time
and cache needs to be invalidated after deletion occurs.

This PR adds a document into delete command by noting that there might be a need to invalidate discovery
cache when CRD is deleted. In addition to that this PR adds a test to catch this behavior.

#### Which issue(s) this PR fixes:
Fixes #105394

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
