### PR TITLE
Automated cherry pick of #107091: Improving performance of EndpointSlice controller metrics

### DIFF
--- a/pkg/controller/endpointslice/metrics/cache_test.go
+++ b/pkg/controller/endpointslice/metrics/cache_test.go
@@ -17,11 +17,14 @@ limitations under the License.
 package metrics
 
 import (
+	"fmt"
 	"testing"
 
 	discovery "k8s.io/api/discovery/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/kubernetes/pkg/controller/util/endpoint"
 	endpointutil "k8s.io/kubernetes/pkg/controller/util/endpoint"
+	utilpointer "k8s.io/utils/pointer"
 )
 
 func TestNumEndpointsAndSlices(t *testing.T) {
@@ -59,14 +62,57 @@ func TestNumEndpointsAndSlices(t *testing.T) {
 
 func expectNumEndpointsAndSlices(t *testing.T, c *Cache, desired int, actual int, numEndpoints int) {
 	t.Helper()
-	mUpdate := c.desiredAndActualSlices()
-	if mUpdate.desired != desired {
-		t.Errorf("Expected numEndpointSlices to be %d, got %d", desired, mUpdate.desired)
+	if c.numSlicesDesired != desired {
+		t.Errorf("Expected numSlicesDesired to be %d, got %d", desired, c.numSlicesDesired)
 	}
-	if mUpdate.actual != actual {
-		t.Errorf("Expected desiredEndpointSlices to be %d, got %d", actual, mUpdate.actual)
+	if c.numSlicesActual != actual {
+		t.Errorf("Expected numSlicesActual to be %d, got %d", actual, c.numSlicesActual)
 	}
 	if c.numEndpoints != numEndpoints {
 		t.Errorf("Expected numEndpoints to be %d, got %d", numEndpoints, c.numEndpoints)
 	}
+}
+
+func benchmarkUpdateServicePortCache(b *testing.B, num int) {
+	c := NewCache(int32(100))
+	ns := "benchmark"
+	httpKey := endpoint.NewPortMapKey([]discovery.EndpointPort{{Port: utilpointer.Int32Ptr(80)}})
+	httpsKey := endpoint.NewPortMapKey([]discovery.EndpointPort{{Port: utilpointer.Int32Ptr(443)}})
+	spCache := &ServicePortCache{items: map[endpointutil.PortMapKey]EfficiencyInfo{
+		httpKey: {
+			Endpoints: 182,
+			Slices:    2,
+		},
+		httpsKey: {
+			Endpoints: 356,
+			Slices:    4,
+		},
+	}}
+
+	for i := 0; i < num; i++ {
+		nName := types.NamespacedName{Namespace: ns, Name: fmt.Sprintf("service-%d", i)}
+		c.UpdateServicePortCache(nName, spCache)
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		nName := types.NamespacedName{Namespace: ns, Name: fmt.Sprintf("bench-%d", i)}
+		c.UpdateServicePortCache(nName, spCache)
+	}
+}
+
+func BenchmarkUpdateServicePortCache100(b *testing.B) {
+	benchmarkUpdateServicePortCache(b, 100)
+}
+
+func BenchmarkUpdateServicePortCache1000(b *testing.B) {
+	benchmarkUpdateServicePortCache(b, 1000)
+}
+
+func BenchmarkUpdateServicePortCache10000(b *testing.B) {
+	benchmarkUpdateServicePortCache(b, 10000)
+}
+
+func BenchmarkUpdateServicePortCache100000(b *testing.B) {
+	benchmarkUpdateServicePortCache(b, 100000)
 }


### PR DESCRIPTION
Cherry pick of #107091 on release-1.22.

#107091: Improving performance of EndpointSlice controller metrics

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
Fix a performance regression in 1.17 where an inefficient lock in EndpointSlice controller metrics cache has been reworked. Network programming latency may be significantly reduced in certain scenarios, especially in clusters with a large number of Services.
```
