### PR TITLE
Fix order of commands in the snapshot tests for persistent volumes

### DIFF
--- a/test/e2e/storage/testsuites/snapshottable.go
+++ b/test/e2e/storage/testsuites/snapshottable.go
@@ -145,11 +145,8 @@ func (s *snapshottableTestSuite) DefineTests(driver storageframework.TestDriver,
 			command := fmt.Sprintf("echo '%s' > %s", originalMntTestData, datapath)
 
 			pod = StartInPodWithVolumeSource(cs, *volumeResource.VolSource, f.Namespace.Name, "pvc-snapshottable-tester", command, config.ClientNodeSelection)
-			cleanupSteps = append(cleanupSteps, func() {
-				e2epod.DeletePodWithWait(cs, pod)
-			})
 
-			// At this point a pod is running with a PVC. How to proceed depends on which test is running.
+			// At this point a pod is created with a PVC. How to proceed depends on which test is running.
 		}
 
 		cleanup := func() {
@@ -177,6 +174,11 @@ func (s *snapshottableTestSuite) DefineTests(driver storageframework.TestDriver,
 					e2eskipper.Skipf("volume type %q is not ephemeral", pattern.VolType)
 				}
 				init()
+
+				// delete the pod at the end of the test
+				cleanupSteps = append(cleanupSteps, func() {
+					e2epod.DeletePodWithWait(cs, pod)
+				})
 
 				// We can test snapshotting of generic
 				// ephemeral volumes by creating the snapshot
@@ -308,36 +310,31 @@ func (s *snapshottableTestSuite) DefineTests(driver storageframework.TestDriver,
 				}
 				init()
 
-				framework.ExpectNoError(e2epod.WaitForPodSuccessInNamespaceTimeout(cs, pod.Name, pod.Namespace, f.Timeouts.PodStartSlow))
-				pod, err = cs.CoreV1().Pods(pod.Namespace).Get(context.TODO(), pod.Name, metav1.GetOptions{})
-				framework.ExpectNoError(err, "check pod after it terminated")
-
-				// Get new copy of the claim
-				ginkgo.By("[init] checking the claim")
-				pvcName := volumeResource.Pvc.Name
-				pvcNamespace := volumeResource.Pvc.Namespace
-
-				parameters := map[string]string{}
-				sr := storageframework.CreateSnapshotResource(sDriver, config, pattern, pvcName, pvcNamespace, f.Timeouts, parameters)
-				cleanupSteps = append(cleanupSteps, func() {
-					framework.ExpectNoError(sr.CleanupResource(f.Timeouts))
-				})
-				vs := sr.Vs
-				vsc := sr.Vsclass
-
-				err = e2epv.WaitForPersistentVolumeClaimPhase(v1.ClaimBound, cs, pvcNamespace, pvcName, framework.Poll, f.Timeouts.ClaimProvision)
-				framework.ExpectNoError(err)
-
-				pvc, err = cs.CoreV1().PersistentVolumeClaims(pvcNamespace).Get(context.TODO(), pvcName, metav1.GetOptions{})
-				framework.ExpectNoError(err, "get PVC")
-				claimSize = pvc.Spec.Resources.Requests.Storage().String()
+				pvc = volumeResource.Pvc
 				sc = volumeResource.Sc
 
-				// Get the bound PV
+				// The pod should be in the Success state.
+				ginkgo.By("[init] check pod success")
+				pod, err = cs.CoreV1().Pods(pod.Namespace).Get(context.TODO(), pod.Name, metav1.GetOptions{})
+				framework.ExpectNoError(err, "Failed to fetch pod: %v", err)
+				framework.ExpectNoError(e2epod.WaitForPodSuccessInNamespaceTimeout(cs, pod.Name, pod.Namespace, f.Timeouts.PodStartSlow))
+				// Sync the pod to know additional fields.
+				pod, err = cs.CoreV1().Pods(pod.Namespace).Get(context.TODO(), pod.Name, metav1.GetOptions{})
+				framework.ExpectNoError(err, "Failed to fetch pod: %v", err)
+
+				ginkgo.By("[init] checking the claim")
+				err = e2epv.WaitForPersistentVolumeClaimPhase(v1.ClaimBound, cs, pvc.Namespace, pvc.Name, framework.Poll, f.Timeouts.ClaimProvision)
+				framework.ExpectNoError(err)
+				// Get new copy of the claim.
+				pvc, err = cs.CoreV1().PersistentVolumeClaims(pvc.Namespace).Get(context.TODO(), pvc.Name, metav1.GetOptions{})
+				framework.ExpectNoError(err)
+
+				// Get the bound PV.
 				ginkgo.By("[init] checking the PV")
 				pv, err := cs.CoreV1().PersistentVolumes().Get(context.TODO(), pvc.Spec.VolumeName, metav1.GetOptions{})
 				framework.ExpectNoError(err)
 
+				// Delete the pod to force NodeUnpublishVolume (unlike the ephemeral case where the pod is deleted at the end of the test).
 				ginkgo.By("[init] deleting the pod")
 				StopPod(cs, pod)
 
@@ -386,6 +383,15 @@ func (s *snapshottableTestSuite) DefineTests(driver storageframework.TestDriver,
 					framework.Failf("timed out waiting for node=%s to not use the volume=%s", nodeName, volumeName)
 				}
 
+				// Take the snapshot.
+				parameters := map[string]string{}
+				sr := storageframework.CreateSnapshotResource(sDriver, config, pattern, pvc.Name, pvc.Namespace, f.Timeouts, parameters)
+				cleanupSteps = append(cleanupSteps, func() {
+					framework.ExpectNoError(sr.CleanupResource(f.Timeouts))
+				})
+				vs := sr.Vs
+				vsc := sr.Vsclass
+
 				// Get new copy of the snapshot
 				ginkgo.By("checking the snapshot")
 				vs, err = dc.Resource(storageutils.SnapshotGVR).Namespace(vs.GetNamespace()).Get(context.TODO(), vs.GetName(), metav1.GetOptions{})
@@ -400,9 +406,6 @@ func (s *snapshottableTestSuite) DefineTests(driver storageframework.TestDriver,
 				snapshotContentSpec := vscontent.Object["spec"].(map[string]interface{})
 				volumeSnapshotRef := snapshotContentSpec["volumeSnapshotRef"].(map[string]interface{})
 
-				var restoredPVC *v1.PersistentVolumeClaim
-				var restoredPod *v1.Pod
-
 				// Check SnapshotContent properties
 				ginkgo.By("checking the SnapshotContent")
 				// PreprovisionedCreatedSnapshot do not need to set volume snapshot class name
@@ -413,6 +416,8 @@ func (s *snapshottableTestSuite) DefineTests(driver storageframework.TestDriver,
 				framework.ExpectEqual(volumeSnapshotRef["namespace"], vs.GetNamespace())
 
 				ginkgo.By("Modifying source data test")
+				var restoredPVC *v1.PersistentVolumeClaim
+				var restoredPod *v1.Pod
 				modifiedMntTestData := fmt.Sprintf("modified data from %s namespace", pvc.GetNamespace())
 
 				ginkgo.By("modifying the data in the source PVC")
@@ -421,6 +426,7 @@ func (s *snapshottableTestSuite) DefineTests(driver storageframework.TestDriver,
 				RunInPodWithVolume(cs, f.Timeouts, pvc.Namespace, pvc.Name, "pvc-snapshottable-data-tester", command, config.ClientNodeSelection)
 
 				ginkgo.By("creating a pvc from the snapshot")
+				claimSize = pvc.Spec.Resources.Requests.Storage().String()
 				restoredPVC = e2epv.MakePersistentVolumeClaim(e2epv.PersistentVolumeClaimConfig{
 					ClaimSize:        claimSize,
 					StorageClassName: &(sc.Name),
@@ -451,11 +457,9 @@ func (s *snapshottableTestSuite) DefineTests(driver storageframework.TestDriver,
 					StopPod(cs, restoredPod)
 				})
 				framework.ExpectNoError(e2epod.WaitTimeoutForPodRunningInNamespace(cs, restoredPod.Name, restoredPod.Namespace, f.Timeouts.PodStartSlow))
-				if pattern.VolType != storageframework.GenericEphemeralVolume {
-					commands := e2evolume.GenerateReadFileCmd(datapath)
-					_, err = framework.LookForStringInPodExec(restoredPod.Namespace, restoredPod.Name, commands, originalMntTestData, time.Minute)
-					framework.ExpectNoError(err)
-				}
+				commands := e2evolume.GenerateReadFileCmd(datapath)
+				_, err = framework.LookForStringInPodExec(restoredPod.Namespace, restoredPod.Name, commands, originalMntTestData, time.Minute)
+				framework.ExpectNoError(err)
 
 				ginkgo.By("should delete the VolumeSnapshotContent according to its deletion policy")
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug
/kind cleanup

Optionally add one or more of the following kinds if applicable:
/kind failing-test
/kind regression

#### What this PR does / why we need it:

In the refactor done in https://github.com/kubernetes/kubernetes/pull/105659 the snapshot tests were split to work for ephemeral volumes and for persistent volumes, in the refactor the order of execution of some commands were changed, the order was restored to be like it was before the refactor:

- Create a pod with a PV & PVC
- Wait for the pod to succeed
- Wait for the pvc to be claimed
- Get the PV bound
- Delete the pod to force NodeUnpublishVolume
- Wait for the PV to not be listed in the node's status.VolumesInUse field to force NodeUnstageVolume
- Take the snapshot

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

/cc @pohly @jingxu97 @msau42 