### PR TITLE
Remove deprecated discovery/ServerResources function

### DIFF
--- a/pkg/controller/garbagecollector/garbagecollector_test.go
+++ b/pkg/controller/garbagecollector/garbagecollector_test.go
@@ -956,11 +956,6 @@ func (*fakeServerResources) ServerResourcesForGroupVersion(groupVersion string) 
 	return nil, nil
 }
 
-// Deprecated: use ServerGroupsAndResources instead.
-func (*fakeServerResources) ServerResources() ([]*metav1.APIResourceList, error) {
-	return nil, nil
-}
-
 func (*fakeServerResources) ServerGroupsAndResources() ([]*metav1.APIGroup, []*metav1.APIResourceList, error) {
 	return nil, nil, nil
 }

--- a/pkg/controller/resourcequota/resource_quota_controller_test.go
+++ b/pkg/controller/resourcequota/resource_quota_controller_test.go
@@ -1161,10 +1161,6 @@ func (*fakeServerResources) ServerResourcesForGroupVersion(groupVersion string) 
 	return nil, nil
 }
 
-func (*fakeServerResources) ServerResources() ([]*metav1.APIResourceList, error) {
-	return nil, nil
-}
-
 func (*fakeServerResources) ServerPreferredResources() ([]*metav1.APIResourceList, error) {
 	return nil, nil
 }

--- a/pkg/controlplane/instance_test.go
+++ b/pkg/controlplane/instance_test.go
@@ -354,7 +354,7 @@ func TestStorageVersionHashes(t *testing.T) {
 		ContentConfig: restclient.ContentConfig{NegotiatedSerializer: legacyscheme.Codecs},
 	}
 	discover := discovery.NewDiscoveryClientForConfigOrDie(c)
-	all, err := discover.ServerResources()
+	_, all, err := discover.ServerGroupsAndResources()
 	if err != nil {
 		t.Error(err)
 	}

--- a/staging/src/k8s.io/client-go/discovery/cached/disk/cached_discovery.go
+++ b/staging/src/k8s.io/client-go/discovery/cached/disk/cached_discovery.go
@@ -90,13 +90,6 @@ func (d *CachedDiscoveryClient) ServerResourcesForGroupVersion(groupVersion stri
 	return liveResources, nil
 }
 
-// ServerResources returns the supported resources for all groups and versions.
-// Deprecated: use ServerGroupsAndResources instead.
-func (d *CachedDiscoveryClient) ServerResources() ([]*metav1.APIResourceList, error) {
-	_, rs, err := discovery.ServerGroupsAndResources(d)
-	return rs, err
-}
-
 // ServerGroupsAndResources returns the supported groups and resources for all groups and versions.
 func (d *CachedDiscoveryClient) ServerGroupsAndResources() ([]*metav1.APIGroup, []*metav1.APIResourceList, error) {
 	return discovery.ServerGroupsAndResources(d)

--- a/staging/src/k8s.io/client-go/discovery/cached/disk/cached_discovery_test.go
+++ b/staging/src/k8s.io/client-go/discovery/cached/disk/cached_discovery_test.go
@@ -54,11 +54,11 @@ func TestCachedDiscoveryClient_Fresh(t *testing.T) {
 	assert.True(cdc.Fresh(), "should be fresh after another groups call")
 	assert.Equal(c.groupCalls, 1)
 
-	cdc.ServerResources()
+	cdc.ServerGroupsAndResources()
 	assert.True(cdc.Fresh(), "should be fresh after resources call")
 	assert.Equal(c.resourceCalls, 1)
 
-	cdc.ServerResources()
+	cdc.ServerGroupsAndResources()
 	assert.True(cdc.Fresh(), "should be fresh after another resources call")
 	assert.Equal(c.resourceCalls, 1)
 
@@ -67,14 +67,14 @@ func TestCachedDiscoveryClient_Fresh(t *testing.T) {
 	assert.False(cdc.Fresh(), "should NOT be fresh after recreation with existing groups cache")
 	assert.Equal(c.groupCalls, 1)
 
-	cdc.ServerResources()
+	cdc.ServerGroupsAndResources()
 	assert.False(cdc.Fresh(), "should NOT be fresh after recreation with existing resources cache")
 	assert.Equal(c.resourceCalls, 1)
 
 	cdc.Invalidate()
 	assert.True(cdc.Fresh(), "should be fresh after cache invalidation")
 
-	cdc.ServerResources()
+	cdc.ServerGroupsAndResources()
 	assert.True(cdc.Fresh(), "should ignore existing resources cache after invalidation")
 	assert.Equal(c.resourceCalls, 2)
 }
@@ -170,12 +170,6 @@ func (c *fakeDiscoveryClient) ServerResourcesForGroupVersion(groupVersion string
 	}
 
 	return nil, errors.NewNotFound(schema.GroupResource{}, "")
-}
-
-// Deprecated: use ServerGroupsAndResources instead.
-func (c *fakeDiscoveryClient) ServerResources() ([]*metav1.APIResourceList, error) {
-	_, rs, err := c.ServerGroupsAndResources()
-	return rs, err
 }
 
 func (c *fakeDiscoveryClient) ServerGroupsAndResources() ([]*metav1.APIGroup, []*metav1.APIResourceList, error) {

--- a/staging/src/k8s.io/client-go/discovery/cached/memory/memcache.go
+++ b/staging/src/k8s.io/client-go/discovery/cached/memory/memcache.go
@@ -107,12 +107,6 @@ func (d *memCacheClient) ServerResourcesForGroupVersion(groupVersion string) (*m
 	return cachedVal.resourceList, cachedVal.err
 }
 
-// ServerResources returns the supported resources for all groups and versions.
-// Deprecated: use ServerGroupsAndResources instead.
-func (d *memCacheClient) ServerResources() ([]*metav1.APIResourceList, error) {
-	return discovery.ServerResources(d)
-}
-
 // ServerGroupsAndResources returns the groups and supported resources for all groups and versions.
 func (d *memCacheClient) ServerGroupsAndResources() ([]*metav1.APIGroup, []*metav1.APIResourceList, error) {
 	return discovery.ServerGroupsAndResources(d)

--- a/staging/src/k8s.io/client-go/discovery/discovery_client.go
+++ b/staging/src/k8s.io/client-go/discovery/discovery_client.go
@@ -90,13 +90,6 @@ type ServerGroupsInterface interface {
 type ServerResourcesInterface interface {
 	// ServerResourcesForGroupVersion returns the supported resources for a group and version.
 	ServerResourcesForGroupVersion(groupVersion string) (*metav1.APIResourceList, error)
-	// ServerResources returns the supported resources for all groups and versions.
-	//
-	// The returned resource list might be non-nil with partial results even in the case of
-	// non-nil error.
-	//
-	// Deprecated: use ServerGroupsAndResources instead.
-	ServerResources() ([]*metav1.APIResourceList, error)
 	// ServerGroupsAndResources returns the supported groups and resources for all groups and versions.
 	//
 	// The returned group and resource lists might be non-nil with partial results even in the
@@ -210,13 +203,6 @@ func (d *DiscoveryClient) ServerResourcesForGroupVersion(groupVersion string) (r
 	return resources, nil
 }
 
-// ServerResources returns the supported resources for all groups and versions.
-// Deprecated: use ServerGroupsAndResources instead.
-func (d *DiscoveryClient) ServerResources() ([]*metav1.APIResourceList, error) {
-	_, rs, err := d.ServerGroupsAndResources()
-	return rs, err
-}
-
 // ServerGroupsAndResources returns the supported resources for all groups and versions.
 func (d *DiscoveryClient) ServerGroupsAndResources() ([]*metav1.APIGroup, []*metav1.APIResourceList, error) {
 	return withRetries(defaultRetries, func() ([]*metav1.APIGroup, []*metav1.APIResourceList, error) {
@@ -245,13 +231,6 @@ func (e *ErrGroupDiscoveryFailed) Error() string {
 func IsGroupDiscoveryFailedError(err error) bool {
 	_, ok := err.(*ErrGroupDiscoveryFailed)
 	return err != nil && ok
-}
-
-// ServerResources uses the provided discovery interface to look up supported resources for all groups and versions.
-// Deprecated: use ServerGroupsAndResources instead.
-func ServerResources(d DiscoveryInterface) ([]*metav1.APIResourceList, error) {
-	_, rs, err := ServerGroupsAndResources(d)
-	return rs, err
 }
 
 func ServerGroupsAndResources(d DiscoveryInterface) ([]*metav1.APIGroup, []*metav1.APIResourceList, error) {

--- a/staging/src/k8s.io/client-go/discovery/discovery_client_test.go
+++ b/staging/src/k8s.io/client-go/discovery/discovery_client_test.go
@@ -164,7 +164,7 @@ func TestGetServerResourcesWithV1Server(t *testing.T) {
 	defer server.Close()
 	client := NewDiscoveryClientForConfigOrDie(&restclient.Config{Host: server.URL})
 	// ServerResources should not return an error even if server returns error at /api/v1.
-	serverResources, err := client.ServerResources()
+	_, serverResources, err := client.ServerGroupsAndResources()
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
@@ -174,7 +174,7 @@ func TestGetServerResourcesWithV1Server(t *testing.T) {
 	}
 }
 
-func TestGetServerResources(t *testing.T) {
+func TestGetServerResourcesForGroupVersion(t *testing.T) {
 	stable := metav1.APIResourceList{
 		GroupVersion: "v1",
 		APIResources: []metav1.APIResource{
@@ -365,7 +365,7 @@ func TestGetServerResources(t *testing.T) {
 
 	client := NewDiscoveryClientForConfigOrDie(&restclient.Config{Host: server.URL})
 	start := time.Now()
-	serverResources, err := client.ServerResources()
+	_, serverResources, err := client.ServerGroupsAndResources()
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}

--- a/staging/src/k8s.io/client-go/discovery/fake/discovery.go
+++ b/staging/src/k8s.io/client-go/discovery/fake/discovery.go
@@ -60,13 +60,6 @@ func (c *FakeDiscovery) ServerResourcesForGroupVersion(groupVersion string) (*me
 		}}
 }
 
-// ServerResources returns the supported resources for all groups and versions.
-// Deprecated: use ServerGroupsAndResources instead.
-func (c *FakeDiscovery) ServerResources() ([]*metav1.APIResourceList, error) {
-	_, rs, err := c.ServerGroupsAndResources()
-	return rs, err
-}
-
 // ServerGroupsAndResources returns the supported groups and resources for all groups and versions.
 func (c *FakeDiscovery) ServerGroupsAndResources() ([]*metav1.APIGroup, []*metav1.APIResourceList, error) {
 	sgs, err := c.ServerGroups()

--- a/staging/src/k8s.io/client-go/restmapper/discovery_test.go
+++ b/staging/src/k8s.io/client-go/restmapper/discovery_test.go
@@ -401,10 +401,6 @@ func (d *fakeFailingDiscovery) ServerResourcesForGroupVersion(groupVersion strin
 	return nil, fmt.Errorf("not found")
 }
 
-func (d *fakeFailingDiscovery) ServerResources() ([]*metav1.APIResourceList, error) {
-	return ServerResources(d)
-}
-
 func (d *fakeFailingDiscovery) ServerPreferredResources() ([]*metav1.APIResourceList, error) {
 	return ServerPreferredResources(d)
 }
@@ -462,11 +458,6 @@ func (c *fakeCachedDiscoveryInterface) ServerResourcesForGroupVersion(groupVersi
 	}
 
 	return nil, errors.NewNotFound(schema.GroupResource{}, "")
-}
-
-// Deprecated: use ServerGroupsAndResources instead.
-func (c *fakeCachedDiscoveryInterface) ServerResources() ([]*metav1.APIResourceList, error) {
-	return ServerResources(c)
 }
 
 func (c *fakeCachedDiscoveryInterface) ServerPreferredResources() ([]*metav1.APIResourceList, error) {

--- a/staging/src/k8s.io/client-go/restmapper/shortcut_test.go
+++ b/staging/src/k8s.io/client-go/restmapper/shortcut_test.go
@@ -265,12 +265,6 @@ func (c *fakeDiscoveryClient) ServerResourcesForGroupVersion(groupVersion string
 	return nil, errors.NewNotFound(schema.GroupResource{}, "")
 }
 
-// Deprecated: use ServerGroupsAndResources instead.
-func (c *fakeDiscoveryClient) ServerResources() ([]*metav1.APIResourceList, error) {
-	_, rs, err := c.ServerGroupsAndResources()
-	return rs, err
-}
-
 func (c *fakeDiscoveryClient) ServerGroupsAndResources() ([]*metav1.APIGroup, []*metav1.APIResourceList, error) {
 	sgs, err := c.ServerGroups()
 	if err != nil {

--- a/staging/src/k8s.io/kubectl/pkg/cmd/testing/fake.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/testing/fake.go
@@ -375,11 +375,6 @@ func (d *fakeCachedDiscoveryClient) Fresh() bool {
 func (d *fakeCachedDiscoveryClient) Invalidate() {
 }
 
-// Deprecated: use ServerGroupsAndResources instead.
-func (d *fakeCachedDiscoveryClient) ServerResources() ([]*metav1.APIResourceList, error) {
-	return []*metav1.APIResourceList{}, nil
-}
-
 func (d *fakeCachedDiscoveryClient) ServerGroupsAndResources() ([]*metav1.APIGroup, []*metav1.APIResourceList, error) {
 	return []*metav1.APIGroup{}, []*metav1.APIResourceList{}, nil
 }


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
ServerResources function was deprecated in https://github.com/kubernetes/kubernetes/commit/618050e and instead ServerGroupsAndResources
function is suggested.

This PR removes ServerResources function and replaces every place to use ServerGroupsAndResources.

#### Does this PR introduce a user-facing change?
```release-note
ServerResources was deprecated in February 2019 (https://github.com/kubernetes/kubernetes/commit/618050e) and now it's being removed and ServerGroupsAndResources is suggested to be used instead
```
