### PR TITLE
Automated cherry pick of #106683: add gce elb rbs opt-in annotation

### DIFF
--- a/staging/src/k8s.io/legacy-cloud-providers/gce/gce_annotations.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/gce/gce_annotations.go
@@ -73,6 +73,13 @@ const (
 
 	// NetworkTierAnnotationPremium is an annotation to indicate the Service is on the Premium network tier
 	NetworkTierAnnotationPremium = cloud.NetworkTierPremium
+
+	// RBSAnnotationKey is annotated on a Service object to indicate
+	// opt-in mode for RBS NetLB
+	RBSAnnotationKey = "cloud.google.com/l4-rbs"
+
+	// RBSEnabled is an annotation to indicate the Service is opt-in for RBS
+	RBSEnabled = "enabled"
 )
 
 // GetLoadBalancerAnnotationType returns the type of GCP load balancer which should be assembled.

--- a/staging/src/k8s.io/legacy-cloud-providers/gce/gce_loadbalancer_external.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/gce/gce_loadbalancer_external.go
@@ -61,6 +61,10 @@ func (g *Cloud) ensureExternalLoadBalancer(clusterName string, clusterID string,
 	if hasFinalizer(apiService, ELBRbsFinalizer) {
 		return nil, cloudprovider.ImplementedElsewhere
 	}
+	// Skip service handling if it has Regional Backend Service created by Ingress-GCE
+	if existingFwdRule != nil && existingFwdRule.BackendService != "" {
+		return nil, cloudprovider.ImplementedElsewhere
+	}
 
 	if len(nodes) == 0 {
 		return nil, fmt.Errorf(errStrLbNoHosts)

--- a/staging/src/k8s.io/legacy-cloud-providers/gce/gce_loadbalancer_external.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/gce/gce_loadbalancer_external.go
@@ -40,6 +40,8 @@ import (
 
 const (
 	errStrLbNoHosts = "cannot EnsureLoadBalancer() with no hosts"
+
+	ELBRbsFinalizer = "gke.networking.io/l4-netlb-v2"
 )
 
 // ensureExternalLoadBalancer is the external implementation of LoadBalancer.EnsureLoadBalancer.
@@ -53,6 +55,10 @@ const (
 func (g *Cloud) ensureExternalLoadBalancer(clusterName string, clusterID string, apiService *v1.Service, existingFwdRule *compute.ForwardingRule, nodes []*v1.Node) (*v1.LoadBalancerStatus, error) {
 	// Skip service handling if managed by ingress-gce using Regional Backend Services
 	if val, ok := apiService.Annotations[RBSAnnotationKey]; ok && val == RBSEnabled {
+		return nil, cloudprovider.ImplementedElsewhere
+	}
+	// Skip service handling if service has Regional Backend Services finalizer
+	if hasFinalizer(apiService, ELBRbsFinalizer) {
 		return nil, cloudprovider.ImplementedElsewhere
 	}
 

--- a/staging/src/k8s.io/legacy-cloud-providers/gce/gce_loadbalancer_external_test.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/gce/gce_loadbalancer_external_test.go
@@ -21,7 +21,6 @@ package gce
 import (
 	"context"
 	"fmt"
-
 	"reflect"
 	"strings"
 	"testing"
@@ -29,6 +28,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	compute "google.golang.org/api/compute/v1"
+	cloudprovider "k8s.io/cloud-provider"
 
 	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud"
 	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/meta"
@@ -577,6 +577,48 @@ func TestEnsureExternalLoadBalancerFailsWithNoNodes(t *testing.T) {
 	_, err = gce.ensureExternalLoadBalancer(vals.ClusterName, vals.ClusterID, svc, nil, []*v1.Node{})
 	require.Error(t, err)
 	assert.EqualError(t, err, errStrLbNoHosts)
+}
+
+func TestEnsureExternalLoadBalancerRBSAnnotation(t *testing.T) {
+	t.Parallel()
+
+	vals := DefaultTestClusterValues()
+	gce, err := fakeGCECloud(DefaultTestClusterValues())
+	require.NoError(t, err)
+	nodeNames := []string{"test-node-1"}
+
+	nodes, err := createAndInsertNodes(gce, nodeNames, vals.ZoneName)
+	require.NoError(t, err)
+
+	svc := fakeLoadbalancerService("")
+
+	for desc, tc := range map[string]struct {
+		annotations map[string]string
+		expectError *error
+	}{
+		"When RBS enabled": {
+			annotations: map[string]string{RBSAnnotationKey: RBSEnabled},
+			expectError: &cloudprovider.ImplementedElsewhere,
+		},
+		"When RBS not enabled": {
+			annotations: map[string]string{},
+			expectError: nil,
+		},
+		"When RBS annotation has wrong value": {
+			annotations: map[string]string{RBSAnnotationKey: "WrongValue"},
+			expectError: nil,
+		},
+	} {
+		t.Run(desc, func(t *testing.T) {
+			svc.Annotations = tc.annotations
+			_, err = gce.ensureExternalLoadBalancer(vals.ClusterName, vals.ClusterID, svc, nil, nodes)
+			if tc.expectError != nil {
+				assert.EqualError(t, err, (*tc.expectError).Error())
+			} else {
+				assert.NoError(t, err, "Should not return an error "+desc)
+			}
+		})
+	}
 }
 
 func TestForwardingRuleNeedsUpdate(t *testing.T) {


### PR DESCRIPTION
Cherry pick of #106683 on release-1.22.

#106683: add gce elb rbs opt-in annotation

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
NONE
```