### PR TITLE
Fix doc for leader-elect-resource-lock flag

### DIFF
--- a/staging/src/k8s.io/component-base/config/options/leaderelectionconfig.go
+++ b/staging/src/k8s.io/component-base/config/options/leaderelectionconfig.go
@@ -42,8 +42,8 @@ func BindLeaderElectionFlags(l *config.LeaderElectionConfiguration, fs *pflag.Fl
 		"of a leadership. This is only applicable if leader election is enabled.")
 	fs.StringVar(&l.ResourceLock, "leader-elect-resource-lock", l.ResourceLock, ""+
 		"The type of resource object that is used for locking during "+
-		"leader election. Supported options are 'endpoints', 'configmaps', "+
-		"'leases', 'endpointsleases' and 'configmapsleases'.")
+		"leader election. Supported options are 'leases', 'endpointsleases' "+
+		"and 'configmapsleases'.")
 	fs.StringVar(&l.ResourceName, "leader-elect-resource-name", l.ResourceName, ""+
 		"The name of resource object that is used for locking during "+
 		"leader election.")


### PR DESCRIPTION
/sig api-machinery
/kind bug

https://github.com/kubernetes/kubernetes/pull/106852 removes the support for `endpoints` and `configmaps`. But the doc string of the --leader-elect-resource-lock is still listing them as allowed values.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

