### PR TITLE
close the grpc server in Test_Run_Positive_Register

### DIFF
--- a/pkg/kubelet/pluginmanager/reconciler/reconciler_test.go
+++ b/pkg/kubelet/pluginmanager/reconciler/reconciler_test.go
@@ -192,6 +192,7 @@ func Test_Run_Positive_Register(t *testing.T) {
 	pluginName := fmt.Sprintf("example-plugin")
 	p := pluginwatcher.NewTestExamplePlugin(pluginName, registerapi.DevicePlugin, socketPath, supportedVersions...)
 	require.NoError(t, p.Serve("v1beta1", "v1beta2"))
+	defer p.Stop()
 	timestampBeforeRegistration := time.Now()
 	dsw.AddOrUpdatePlugin(socketPath)
 	waitForRegistration(t, socketPath, timestampBeforeRegistration, asw)

--- a/pkg/kubelet/pluginmanager/reconciler/reconciler_test.go
+++ b/pkg/kubelet/pluginmanager/reconciler/reconciler_test.go
@@ -192,7 +192,7 @@ func Test_Run_Positive_Register(t *testing.T) {
 	pluginName := fmt.Sprintf("example-plugin")
 	p := pluginwatcher.NewTestExamplePlugin(pluginName, registerapi.DevicePlugin, socketPath, supportedVersions...)
 	require.NoError(t, p.Serve("v1beta1", "v1beta2"))
-	defer p.Stop()
+	defer require.NoError(t, p.Stop())
 	timestampBeforeRegistration := time.Now()
 	dsw.AddOrUpdatePlugin(socketPath)
 	waitForRegistration(t, socketPath, timestampBeforeRegistration, asw)


### PR DESCRIPTION

#### What type of PR is this?


/kind bug



#### What this PR does / why we need it:

A grpcserver is started, but not stopped in Test_Run_Positive_Register(), causing some goroutines leaks. The patch is to shut down the grpc server and clean up the blocked goroutines. 

#### Which issue(s) this PR fixes:
None

#### Special notes for your reviewer:

None

#### Does this PR introduce a user-facing change?
None

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

None
