### PR TITLE
flake: remove the error handler for cronjob integration test

### DIFF
--- a/test/integration/cronjob/cronjob_test.go
+++ b/test/integration/cronjob/cronjob_test.go
@@ -26,7 +26,6 @@ import (
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/informers"
 	clientset "k8s.io/client-go/kubernetes"
@@ -153,14 +152,6 @@ func TestCronJobLaunchesPodAndCleansUp(t *testing.T) {
 
 	ns := framework.CreateTestingNamespace(namespaceName, server, t)
 	defer framework.DeleteTestingNamespace(ns, server, t)
-
-	backupHandlers := runtime.ErrorHandlers
-	runtime.ErrorHandlers = append(runtime.ErrorHandlers, func(e error) {
-		t.Fatalf("Failed with error: %v", e)
-	})
-	defer func() {
-		runtime.ErrorHandlers = backupHandlers
-	}()
 
 	cjClient := clientSet.BatchV1().CronJobs(ns.Name)
 


### PR DESCRIPTION
/kind flake
/sig apps

xref #107198
(release branches should be fixed as well, so cherry-picks are needed. )

/priority critical-urgent
This is currently the top 1 flake in CI.
- The flake started after #104799 was merged. #104799 tried to fix a problem of `conflict error`: "the object has been modified; please apply your changes to the latest version and try again".

But it seems the conflict error cannot be fully handled now.

https://github.com/kubernetes/kubernetes/blob/3f0a634ef78b6df33075e54b0f89e465e88049c4/pkg/controller/job/job_controller.go#L488-L494

> 		// If this was a conflict error, we expect a Job or Pod update event, which
>		// will add the job back to the queue. Avoiding the rate limited requeue
>		// saves an unnecessary sync.


```release-note
NONE
```
