### PR TITLE
Bump elasticsearch image to 7.16.2.

### DIFF
--- a/cluster/addons/fluentd-elasticsearch/es-image/Dockerfile
+++ b/cluster/addons/fluentd-elasticsearch/es-image/Dockerfile
@@ -17,7 +17,7 @@ COPY elasticsearch_logging_discovery.go go.mod go.sum /
 RUN CGO_ENABLED=0 GOOS=linux GO111MODULE=on go build -a -ldflags "-w" -o /elasticsearch_logging_discovery /elasticsearch_logging_discovery.go
 
 
-FROM docker.elastic.co/elasticsearch/elasticsearch-oss:7.10.2
+FROM docker.elastic.co/elasticsearch/elasticsearch:7.16.2
 
 VOLUME ["/data"]
 EXPOSE 9200 9300

--- a/cluster/addons/fluentd-elasticsearch/es-image/Makefile
+++ b/cluster/addons/fluentd-elasticsearch/es-image/Makefile
@@ -16,7 +16,7 @@
 
 PREFIX = quay.io/fluentd_elasticsearch
 IMAGE = elasticsearch
-TAG = v7.10.2
+TAG = v7.16.2
 
 build:
 	docker build --tag ${PREFIX}/${IMAGE}:${TAG} .


### PR DESCRIPTION
Change fluentd-elasticsearch/elasticsearch image to use the newly release v7.16.2.