### PR TITLE
Introduce FirstFindableRESTMapper to extract KindFor from multiple resources

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/api/meta/interfaces.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/meta/interfaces.go
@@ -141,3 +141,13 @@ type ResettableRESTMapper interface {
 	RESTMapper
 	Reset()
 }
+
+// FirstFindableRESTMapper is a RESTMapper which is capable of finding exact match within
+// multiple partial resources.
+type FirstFindableRESTMapper interface {
+	RESTMapper
+
+	// KindForFindFirst takes multiple partial resources and returns exact match whenever it finds.
+	// Order is important for this function because it returns whenever it finds.
+	KindForFindFirst(resources ...schema.GroupVersionResource) (schema.GroupVersionKind, error)
+}

--- a/staging/src/k8s.io/kubectl/pkg/cmd/explain/explain.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/explain/explain.go
@@ -138,11 +138,19 @@ func (o *ExplainOptions) Run(args []string) error {
 		}
 	}
 
-	gvk, _ := o.Mapper.KindFor(fullySpecifiedGVR)
-	if gvk.Empty() {
-		gvk, err = o.Mapper.KindFor(fullySpecifiedGVR.GroupResource().WithVersion(""))
+	var gvk schema.GroupVersionKind
+	if m, ok := o.Mapper.(meta.FirstFindableRESTMapper); ok {
+		gvk, err = m.KindForFindFirst(fullySpecifiedGVR, fullySpecifiedGVR.GroupResource().WithVersion(""))
 		if err != nil {
 			return err
+		}
+	} else {
+		gvk, _ = o.Mapper.KindFor(fullySpecifiedGVR)
+		if gvk.Empty() {
+			gvk, err = o.Mapper.KindFor(fullySpecifiedGVR.GroupResource().WithVersion(""))
+			if err != nil {
+				return err
+			}
 		}
 	}
 


### PR DESCRIPTION
#### What type of PR is this?
/kind bug
/kind feature

#### What this PR does / why we need it:
Some resources might exist in `resource=a, version=b, group=c.d` or
`resource=a, group=b.c.d`. Both of these are acceptable values. However,
When a resource's KindFor is needed, executing it with former one causes cache invalidation
(although we know that latter one exists). This cache invalidation makes some
requests slower(i.e. `kubectl api-resources`, `kubectl explain`).

This PR introduces new FirstFindableRESTMapper and implements this interface in
CachedDiscoveryClient. FirstFindableRESTMapper basically gets multiple partial resources
and finds exact resource whenever it finds. Order is important.

#### Which issue(s) this PR fixes:
Fixes #96430

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
