### PR TITLE
add watcher client wait timeout when apiserver showdown but not response close events

### DIFF
--- a/staging/src/k8s.io/client-go/tools/cache/reflector_test.go
+++ b/staging/src/k8s.io/client-go/tools/cache/reflector_test.go
@@ -139,7 +139,8 @@ func TestReflectorWatchHandlerError(t *testing.T) {
 		fw.Stop()
 	}()
 	var resumeRV string
-	err := g.watchHandler(time.Now(), fw, &resumeRV, nevererrc, wait.NeverStop)
+	var timeout *int64
+	err := g.watchHandler(time.Now(), fw, &resumeRV, nevererrc, timeout, wait.NeverStop)
 	if err == nil {
 		t.Errorf("unexpected non-error")
 	}
@@ -159,7 +160,8 @@ func TestReflectorWatchHandler(t *testing.T) {
 		fw.Stop()
 	}()
 	var resumeRV string
-	err := g.watchHandler(time.Now(), fw, &resumeRV, nevererrc, wait.NeverStop)
+	var timeout *int64
+	err := g.watchHandler(time.Now(), fw, &resumeRV, nevererrc, timeout, wait.NeverStop)
 	if err != nil {
 		t.Errorf("unexpected error %v", err)
 	}
@@ -208,7 +210,8 @@ func TestReflectorStopWatch(t *testing.T) {
 	var resumeRV string
 	stopWatch := make(chan struct{}, 1)
 	stopWatch <- struct{}{}
-	err := g.watchHandler(time.Now(), fw, &resumeRV, nevererrc, stopWatch)
+	var timeout *int64
+	err := g.watchHandler(time.Now(), fw, &resumeRV, nevererrc, timeout, stopWatch)
 	if err != errorStopRequested {
 		t.Errorf("expected stop error, got %q", err)
 	}


### PR DESCRIPTION
We found if use slb between kube-apiserver and client, when kube-apiserver restart, client watcher connection not close and wait an event forever. In this case has two connections:  kube-apiserver <-> slb, slb <-> client. After close the first connection could not ensure the second connection also closed if slb hard to handle this long connection situation.
So this pr is to active shutdown the client side to rebuild a watcher. 

#### What type of PR is this?
/kind bug
#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
Fixes #107266

#### Does this PR introduce a user-facing change?
```release-note
Support client active shotdown and rebuild the watch connection if long time no events get from apiserver.
```

