### PR TITLE
Update mounter deps: nfs-common and glusterfs-client

### DIFF
--- a/cluster/gce/gci/mounter/Dockerfile
+++ b/cluster/gce/gci/mounter/Dockerfile
@@ -14,10 +14,10 @@
 
 FROM ubuntu:focal
 
-# ubuntu-maintained glusterfs
-# RUN apt-get update && apt-get install -y netbase nfs-common=1:1.3.4-2.5ubuntu3.3 glusterfs-client=7.2-2build1
+# ubuntu focal maintained glusterfs
+RUN apt-get update && apt-get install -y netbase nfs-common=1:1.3.4-2.5ubuntu3.3 glusterfs-client=7.2-2build1
 
 # official distribution
-RUN apt-get update && apt-get install software-properties-common -y && add-apt-repository ppa:gluster/glusterfs-10 && apt-get update && apt-get install glusterfs-client -y
+# RUN apt-get update && apt-get install software-properties-common -y && add-apt-repository ppa:gluster/glusterfs-8 && apt-get update && apt-get install glusterfs-client -y
 
 ENTRYPOINT ["/bin/mount"]

--- a/cluster/gce/gci/mounter/Dockerfile
+++ b/cluster/gce/gci/mounter/Dockerfile
@@ -12,8 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM ubuntu:xenial
+FROM ubuntu:focal
 
-RUN apt-get update && apt-get install -y netbase nfs-common=1:1.2.8-9ubuntu12 glusterfs-client=3.7.6-1ubuntu1
+# ubuntu-maintained glusterfs
+# RUN apt-get update && apt-get install -y netbase nfs-common=1:1.3.4-2.5ubuntu3.3 glusterfs-client=7.2-2build1
+
+# official distribution
+RUN apt-get update && apt-get install software-properties-common -y && add-apt-repository ppa:gluster/glusterfs-10 && apt-get update && apt-get install glusterfs-client -y
 
 ENTRYPOINT ["/bin/mount"]


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Allows the Kubernetes mounter to mount a glusterfs volume that runs with a more recent version of glusterfs. The version of the glusterfs-client installed in the current container is 3.7.6, which was released in 2015 and is not compatible with more recent versions of the server. Glusterfs stable is now on [version 10](https://www.gluster.org/release-schedule/) and the version 3 used here reached EOL more than 2 years ago. In the current state, Kubernetes is locking users with outdated and insecure versions of Glusterfs.

To try to make our Glusterfs cluster work with Kubernetes, I tried to downgrade a Glusterfs cluster from version 10 to 7 and none were mounted succesfully, giving us the error:
```
Client xxx.xxx.xxx.xxx:65534 (1 -> 30706) doesn't support required op-version (30800). Rejecting volfile request. [Operation not supported]
```

Until we gave up and downgraded our new deployment to Debian stretch so we can have a compatible version (3.8.8). Now it is working, there is still some informational messages such as:
```
Server and Client lk-version numbers are not same, reopening the fds
```
But it does not prevent operations.

[3.8.8 have some vulnerabilities](https://nvd.nist.gov/vuln/search/results?form_type=Advanced&results_type=overview&isCpeNameSearch=true&seach_type=all&query=cpe:2.3:a:gluster:glusterfs:3.8.8:*:*:*:*:*:*:*) so we would like Kubernetes to get this PR in order for us to be able to update our Glusterfs cluster.

The official Glusterfs distribution for Ubuntu can be used (version can be chosen from 7 to 10), or the one provided in the Ubuntu Focal repository (still in version 7).
I added both ways in the Dockerfile (one is commented out, so let me know which one is prefered and I will update accordingly).

#### Which issue(s) this PR fixes:
Fixes the inability to mount a Glusterfs volume deployed with a maintained version of Glusterfs

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
NONE
```
