### PR TITLE
Preserve metadata for fake dynamic client unstructured lists

### DIFF
--- a/staging/src/k8s.io/client-go/dynamic/fake/simple.go
+++ b/staging/src/k8s.io/client-go/dynamic/fake/simple.go
@@ -388,7 +388,6 @@ func (c *dynamicResourceClient) List(ctx context.Context, opts metav1.ListOption
 
 	list := &unstructured.UnstructuredList{}
 	list.SetRemainingItemCount(entireList.GetRemainingItemCount())
-	list.SetSelfLink(entireList.GetSelfLink())
 	list.SetResourceVersion(entireList.GetResourceVersion())
 	list.SetContinue(entireList.GetContinue())
 	list.GetObjectKind().SetGroupVersionKind(listGVK)

--- a/staging/src/k8s.io/client-go/dynamic/fake/simple.go
+++ b/staging/src/k8s.io/client-go/dynamic/fake/simple.go
@@ -387,7 +387,10 @@ func (c *dynamicResourceClient) List(ctx context.Context, opts metav1.ListOption
 	}
 
 	list := &unstructured.UnstructuredList{}
+	list.SetRemainingItemCount(entireList.GetRemainingItemCount())
+	list.SetSelfLink(entireList.GetSelfLink())
 	list.SetResourceVersion(entireList.GetResourceVersion())
+	list.SetContinue(entireList.GetContinue())
 	list.GetObjectKind().SetGroupVersionKind(listGVK)
 	for i := range entireList.Items {
 		item := &entireList.Items[i]

--- a/staging/src/k8s.io/client-go/dynamic/fake/simple_test.go
+++ b/staging/src/k8s.io/client-go/dynamic/fake/simple_test.go
@@ -180,7 +180,6 @@ func Test_ListKind(t *testing.T) {
 			"metadata": map[string]interface{}{
 				"continue":        "",
 				"resourceVersion": "",
-				"selfLink":        "",
 			},
 		},
 		Items: []unstructured.Unstructured{
@@ -336,7 +335,6 @@ func TestListWithUnstructuredObjectsAndTypedScheme(t *testing.T) {
 	expectedList.SetGroupVersionKind(listGVK)
 	expectedList.SetResourceVersion("") // by product of the fake setting resource version
 	expectedList.SetContinue("")
-	expectedList.SetSelfLink("")
 	expectedList.Items = append(expectedList.Items, u)
 
 	if diff := cmp.Diff(expectedList, list); diff != "" {
@@ -366,7 +364,6 @@ func TestListWithNoFixturesAndTypedScheme(t *testing.T) {
 	expectedList.SetGroupVersionKind(listGVK)
 	expectedList.SetResourceVersion("") // by product of the fake setting resource version
 	expectedList.SetContinue("")
-	expectedList.SetSelfLink("")
 
 	if diff := cmp.Diff(expectedList, list); diff != "" {
 		t.Fatal("unexpected diff (-want, +got): ", diff)
@@ -400,7 +397,6 @@ func TestListWithNoScheme(t *testing.T) {
 	expectedList.SetGroupVersionKind(listGVK)
 	expectedList.SetResourceVersion("") // by product of the fake setting resource version
 	expectedList.SetContinue("")
-	expectedList.SetSelfLink("")
 	expectedList.Items = append(expectedList.Items, u)
 
 	if diff := cmp.Diff(expectedList, list); diff != "" {
@@ -444,7 +440,6 @@ func TestListWithTypedFixtures(t *testing.T) {
 	expectedList.SetGroupVersionKind(listGVK)
 	expectedList.SetResourceVersion("") // by product of the fake setting resource version
 	expectedList.SetContinue("")
-	expectedList.SetSelfLink("")
 	expectedList.Items = []unstructured.Unstructured{u}
 
 	if diff := cmp.Diff(expectedList, list); diff != "" {

--- a/staging/src/k8s.io/client-go/dynamic/fake/simple_test.go
+++ b/staging/src/k8s.io/client-go/dynamic/fake/simple_test.go
@@ -335,6 +335,8 @@ func TestListWithUnstructuredObjectsAndTypedScheme(t *testing.T) {
 	expectedList := &unstructured.UnstructuredList{}
 	expectedList.SetGroupVersionKind(listGVK)
 	expectedList.SetResourceVersion("") // by product of the fake setting resource version
+	expectedList.SetContinue("")
+	expectedList.SetSelfLink("")
 	expectedList.Items = append(expectedList.Items, u)
 
 	if diff := cmp.Diff(expectedList, list); diff != "" {
@@ -363,6 +365,8 @@ func TestListWithNoFixturesAndTypedScheme(t *testing.T) {
 	expectedList := &unstructured.UnstructuredList{}
 	expectedList.SetGroupVersionKind(listGVK)
 	expectedList.SetResourceVersion("") // by product of the fake setting resource version
+	expectedList.SetContinue("")
+	expectedList.SetSelfLink("")
 
 	if diff := cmp.Diff(expectedList, list); diff != "" {
 		t.Fatal("unexpected diff (-want, +got): ", diff)
@@ -395,6 +399,8 @@ func TestListWithNoScheme(t *testing.T) {
 	expectedList := &unstructured.UnstructuredList{}
 	expectedList.SetGroupVersionKind(listGVK)
 	expectedList.SetResourceVersion("") // by product of the fake setting resource version
+	expectedList.SetContinue("")
+	expectedList.SetSelfLink("")
 	expectedList.Items = append(expectedList.Items, u)
 
 	if diff := cmp.Diff(expectedList, list); diff != "" {
@@ -437,6 +443,8 @@ func TestListWithTypedFixtures(t *testing.T) {
 	expectedList := &unstructured.UnstructuredList{}
 	expectedList.SetGroupVersionKind(listGVK)
 	expectedList.SetResourceVersion("") // by product of the fake setting resource version
+	expectedList.SetContinue("")
+	expectedList.SetSelfLink("")
 	expectedList.Items = []unstructured.Unstructured{u}
 
 	if diff := cmp.Diff(expectedList, list); diff != "" {

--- a/staging/src/k8s.io/client-go/dynamic/fake/simple_test.go
+++ b/staging/src/k8s.io/client-go/dynamic/fake/simple_test.go
@@ -178,7 +178,9 @@ func Test_ListKind(t *testing.T) {
 			"apiVersion": "group/version",
 			"kind":       "TheKindList",
 			"metadata": map[string]interface{}{
+				"continue":        "",
 				"resourceVersion": "",
+				"selfLink":        "",
 			},
 		},
 		Items: []unstructured.Unstructured{


### PR DESCRIPTION


Signed-off-by: Harsimran Singh Maan <maan.harry@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug

#### What this PR does / why we need it:
Adds ability to mock the continue and other metadata fields in the fake dynamic client
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #107277

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
