### PR TITLE
write pod basic info to podDir

### DIFF
--- a/pkg/kubelet/kubelet_pods.go
+++ b/pkg/kubelet/kubelet_pods.go
@@ -328,7 +328,6 @@ func writePodInfo(pod *v1.Pod, podDir string) error {
 	return ioutil.WriteFile(fileName, buffer.Bytes(), 0644)
 }
 
-
 // makeHostsMount makes the mountpoint for the hosts file that the containers
 // in a pod are injected with. podIPs is provided instead of podIP as podIPs
 // are present even if dual-stack feature flag is not enabled.

--- a/pkg/kubelet/kubelet_pods.go
+++ b/pkg/kubelet/kubelet_pods.go
@@ -275,6 +275,10 @@ func makeMounts(pod *v1.Pod, podDir string, container *v1.Container, hostName, h
 		}
 		mounts = append(mounts, *hostsMount)
 	}
+
+	if err := writePodInfo(pod, podDir); err != nil {
+		klog.V(3).Infof("write podInfo fails: %s, skip.", err)
+	}
 	return mounts, cleanupAction, nil
 }
 
@@ -308,6 +312,23 @@ func getEtcHostsPath(podDir string) string {
 	// Volume Mounts fail on Windows if it is not of the form C:/
 	return volumeutil.MakeAbsolutePath(runtime.GOOS, hostsFilePath)
 }
+
+// getPodInfoPath returns the path of the file that writes the pod basic informations.
+func getPodInfoPath(podDir string) string {
+	podInfoPath := path.Join(podDir, "podinfo")
+	return volumeutil.MakeAbsolutePath(runtime.GOOS, podInfoPath)
+}
+
+func writePodInfo(pod *v1.Pod, podDir string) error {
+	fileName := getPodInfoPath(podDir)
+	var buffer bytes.Buffer
+
+	podname := pod.ObjectMeta.Name
+	namespace := pod.ObjectMeta.Namespace
+	buffer.WriteString(fmt.Sprintf("%s\n%s\n", podname, namespace))
+	return ioutil.WriteFile(fileName, buffer.Bytes(), 0644)
+}
+
 
 // makeHostsMount makes the mountpoint for the hosts file that the containers
 // in a pod are injected with. podIPs is provided instead of podIP as podIPs

--- a/pkg/kubelet/kubelet_pods.go
+++ b/pkg/kubelet/kubelet_pods.go
@@ -322,7 +322,6 @@ func getPodInfoPath(podDir string) string {
 func writePodInfo(pod *v1.Pod, podDir string) error {
 	fileName := getPodInfoPath(podDir)
 	var buffer bytes.Buffer
-
 	podname := pod.ObjectMeta.Name
 	namespace := pod.ObjectMeta.Namespace
 	buffer.WriteString(fmt.Sprintf("%s\n%s\n", podname, namespace))


### PR DESCRIPTION
#### What type of PR is this?

/kind feature


#### What this PR does / why we need it:
What this PR does:  write pod basic information, included the podname and namespace to the <podDirs>/podinfo

why we need it: convenient for a daemetSet to get the podInfo according to the podId or cgroup

User Story:
  I deploy a daemonSet, and use it to walk through the cgroup(/sys/fs/cgroup) and /var/lib/kubelet/pod to collect some metrics(for example: cpu usage).  for now, I have already collect the metrics I wanted, but I can not figure out which pod this metrics are related to. 
  Also, I can deploy this daemonSet as a sidecar to our business(I using this method now), but when a update comes to, it is hard to update all the sidecar. 


#### Which issue(s) this PR fixes:

Fixes #


#### Special notes for your reviewer:


#### Does this PR introduce a user-facing change?

```release-note
NONE

```


#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs


```