### PR TITLE
GCE L4 load balancer: enable migration of Instance Group management out of K/K. 

### DIFF
--- a/staging/src/k8s.io/legacy-cloud-providers/gce/gce_alpha.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/gce/gce_alpha.go
@@ -23,6 +23,10 @@ const (
 	// AlphaFeatureILBSubsets allows InternalLoadBalancer services to include a subset
 	// of cluster nodes as backends instead of all nodes.
 	AlphaFeatureILBSubsets = "ILBSubsets"
+
+	// AlphaFeatureNetLBRbs enabled L4 Regional Backend Services and
+	// disables instance group management in service controller
+	AlphaFeatureNetLBRbs = "NetLB_RBS"
 )
 
 // AlphaFeatureGate contains a mapping of alpha features to whether they are enabled

--- a/staging/src/k8s.io/legacy-cloud-providers/gce/gce_alpha.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/gce/gce_alpha.go
@@ -24,9 +24,9 @@ const (
 	// of cluster nodes as backends instead of all nodes.
 	AlphaFeatureILBSubsets = "ILBSubsets"
 
-	// AlphaFeatureNetLBRbs enabled L4 Regional Backend Services and
+	// AlphaFeatureSkipIGsManagement enabled L4 Regional Backend Services and
 	// disables instance group management in service controller
-	AlphaFeatureNetLBRbs = "NetLB_RBS"
+	AlphaFeatureSkipIGsManagement = "SkipIGsManagement"
 )
 
 // AlphaFeatureGate contains a mapping of alpha features to whether they are enabled

--- a/staging/src/k8s.io/legacy-cloud-providers/gce/gce_instancegroup.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/gce/gce_instancegroup.go
@@ -50,6 +50,16 @@ func (g *Cloud) DeleteInstanceGroup(name string, zone string) error {
 	return mc.Observe(g.c.InstanceGroups().Delete(ctx, meta.ZonalKey(name, zone)))
 }
 
+// FilterInstanceGroupsByName lists all InstanceGroups in the project and
+// zone that match the name regexp.
+func (g *Cloud) FilterInstanceGroupsByName(name, zone string) ([]*compute.InstanceGroup, error) {
+	ctx, cancel := cloud.ContextWithCallTimeout()
+	defer cancel()
+	mc := newInstanceGroupMetricContext("list", zone)
+	v, err := g.c.InstanceGroups().List(ctx, zone, filter.Regexp("name", name))
+	return v, mc.Observe(err)
+}
+
 // ListInstanceGroups lists all InstanceGroups in the project and
 // zone.
 func (g *Cloud) ListInstanceGroups(zone string) ([]*compute.InstanceGroup, error) {

--- a/staging/src/k8s.io/legacy-cloud-providers/gce/gce_instancegroup.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/gce/gce_instancegroup.go
@@ -52,11 +52,11 @@ func (g *Cloud) DeleteInstanceGroup(name string, zone string) error {
 
 // FilterInstanceGroupsByName lists all InstanceGroups in the project and
 // zone that match the name regexp.
-func (g *Cloud) FilterInstanceGroupsByName(name, zone string) ([]*compute.InstanceGroup, error) {
+func (g *Cloud) FilterInstanceGroupsByNamePrefix(namePrefix, zone string) ([]*compute.InstanceGroup, error) {
 	ctx, cancel := cloud.ContextWithCallTimeout()
 	defer cancel()
 	mc := newInstanceGroupMetricContext("filter", zone)
-	v, err := g.c.InstanceGroups().List(ctx, zone, filter.Regexp("name", name))
+	v, err := g.c.InstanceGroups().List(ctx, zone, filter.Regexp("name", namePrefix+".*"))
 	return v, mc.Observe(err)
 }
 

--- a/staging/src/k8s.io/legacy-cloud-providers/gce/gce_instancegroup.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/gce/gce_instancegroup.go
@@ -55,7 +55,7 @@ func (g *Cloud) DeleteInstanceGroup(name string, zone string) error {
 func (g *Cloud) FilterInstanceGroupsByName(name, zone string) ([]*compute.InstanceGroup, error) {
 	ctx, cancel := cloud.ContextWithCallTimeout()
 	defer cancel()
-	mc := newInstanceGroupMetricContext("list", zone)
+	mc := newInstanceGroupMetricContext("filter", zone)
 	v, err := g.c.InstanceGroups().List(ctx, zone, filter.Regexp("name", name))
 	return v, mc.Observe(err)
 }

--- a/staging/src/k8s.io/legacy-cloud-providers/gce/gce_loadbalancer_internal.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/gce/gce_loadbalancer_internal.go
@@ -626,9 +626,9 @@ func (g *Cloud) ensureInternalInstanceGroups(name string, nodes []*v1.Node) ([]s
 	var igLinks []string
 	for zone, nodes := range zonedNodes {
 		if g.AlphaFeatureGate.Enabled(AlphaFeatureSkipIGsManagement) {
-			igs, err := g.FilterInstanceGroupsByName(name, zone)
+			igs, err := g.FilterInstanceGroupsByNamePrefix(name, zone)
 			if err != nil {
-				return []string{}, err
+				return nil, err
 			}
 			for _, ig := range igs {
 				igLinks = append(igLinks, ig.SelfLink)
@@ -636,7 +636,7 @@ func (g *Cloud) ensureInternalInstanceGroups(name string, nodes []*v1.Node) ([]s
 		} else {
 			igLink, err := g.ensureInternalInstanceGroup(name, zone, nodes)
 			if err != nil {
-				return []string{}, err
+				return nil, err
 			}
 			igLinks = append(igLinks, igLink)
 		}

--- a/staging/src/k8s.io/legacy-cloud-providers/gce/gce_loadbalancer_internal.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/gce/gce_loadbalancer_internal.go
@@ -654,8 +654,10 @@ func (g *Cloud) ensureInternalInstanceGroupsDeleted(name string) error {
 
 	klog.V(2).Infof("ensureInternalInstanceGroupsDeleted(%v): attempting delete instance group in all %d zones", name, len(zones))
 	for _, z := range zones {
-		if err := g.DeleteInstanceGroup(name, z.Name); err != nil && !isNotFoundOrInUse(err) {
-			return err
+		if !g.AlphaFeatureGate.Enabled(AlphaFeatureNetLBRbs) {
+			if err := g.DeleteInstanceGroup(name, z.Name); err != nil && !isNotFoundOrInUse(err) {
+				return err
+			}
 		}
 	}
 	return nil

--- a/staging/src/k8s.io/legacy-cloud-providers/gce/gce_loadbalancer_internal_test.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/gce/gce_loadbalancer_internal_test.go
@@ -177,9 +177,9 @@ func TestEnsureMultipleInstanceGroups(t *testing.T) {
 	vals := DefaultTestClusterValues()
 	gce, err := fakeGCECloud(vals)
 	require.NoError(t, err)
-	gce.AlphaFeatureGate = NewAlphaFeatureGate([]string{AlphaFeatureNetLBRbs})
+	gce.AlphaFeatureGate = NewAlphaFeatureGate([]string{AlphaFeatureSkipIGsManagement})
 
-	nodes, err  := createAndInsertNodes(gce, []string{"n1"}, vals.ZoneName)
+	nodes, err := createAndInsertNodes(gce, []string{"n1"}, vals.ZoneName)
 	require.NoError(t, err)
 
 	baseName := makeInstanceGroupName(vals.ClusterID)
@@ -560,14 +560,13 @@ func TestSkipInstanceGroupDeletion(t *testing.T) {
 	gce, err := fakeGCECloud(vals)
 	require.NoError(t, err)
 
-
 	svc := fakeLoadbalancerService(string(LBTypeInternal))
 	svc, err = gce.client.CoreV1().Services(svc.Namespace).Create(context.TODO(), svc, metav1.CreateOptions{})
 	require.NoError(t, err)
 	_, err = createInternalLoadBalancer(gce, svc, nil, []string{"test-node-1"}, vals.ClusterName, vals.ClusterID, vals.ZoneName)
 	assert.NoError(t, err)
 
-	gce.AlphaFeatureGate = NewAlphaFeatureGate([]string{AlphaFeatureNetLBRbs})
+	gce.AlphaFeatureGate = NewAlphaFeatureGate([]string{AlphaFeatureSkipIGsManagement})
 	err = gce.ensureInternalLoadBalancerDeleted(vals.ClusterName, vals.ClusterID, svc)
 	assert.NoError(t, err)
 


### PR DESCRIPTION
What type of PR is this?
/kind cleanup


#### What this PR does / why we need it:
Cleanup Instance Group management in GCE L4 internal load balancer. 
Instance Group management has bern moved to k8s.io/ingress-gce controller.
Without this PR we will see bugs caused by controllers fighting over Instance Group management.
This PR allows GCE L4   internal load balancer to use more than one Instance Group, groups will be managed by k8s.io/ingress-gce controller.


#### Special notes for your reviewer:
Only affects GCE code


#### Does this PR introduce a user-facing change?
```release-note
NONE
```