### PR TITLE
Enable kubectl to edit all exported kubeconfig settings with json tags

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/config/navigation_step_parser.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/config/navigation_step_parser.go
@@ -82,15 +82,17 @@ func newNavigationSteps(path string) (*navigationSteps, error) {
 			switch currType {
 			case reflect.TypeOf(&clientcmdapi.AuthProviderConfig{}):
 				steps = append(steps, navigationStep{individualParts[currPartIndex], reflect.TypeOf("")})
+				currPartIndex += 1
 
 				// If we have a part after the auth provider name we need to add it. There should only ever be at most one part after this.
 				// If there is not nothing happens because just unsetting the name is pointless.
 				nextPart := strings.Join(individualParts[currPartIndex:], ".")
-				if len(strings.Split(nextPart, ".")) > 1 {
+				if len(strings.Split(nextPart, ".")) > 2 {
 					return nil, fmt.Errorf("too many steps in path %v", path)
+				} else if len(strings.Split(nextPart, ".")) > 1 {
+					steps = append(steps, navigationStep{individualParts[currPartIndex], reflect.TypeOf("")})
+					currPartIndex += 1
 				}
-
-				currPartIndex += 1
 
 			case reflect.TypeOf(&clientcmdapi.ExecConfig{}):
 				return nil, fmt.Errorf("found ExecConfig")

--- a/staging/src/k8s.io/kubectl/pkg/cmd/config/navigation_step_parser.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/config/navigation_step_parser.go
@@ -85,7 +85,6 @@ func newNavigationSteps(path string) (*navigationSteps, error) {
 				currPartIndex += 1
 
 				// If we have a part after the auth provider name we need to add it. There should only ever be at most one part after this.
-				// If there is not nothing happens because just unsetting the name is pointless.
 				nextPart := strings.Join(individualParts[currPartIndex:], ".")
 				if len(strings.Split(nextPart, ".")) > 2 {
 					return nil, fmt.Errorf("too many steps in path %v", path)
@@ -95,7 +94,7 @@ func newNavigationSteps(path string) (*navigationSteps, error) {
 				}
 
 			case reflect.TypeOf(&clientcmdapi.ExecConfig{}):
-				return nil, fmt.Errorf("found ExecConfig")
+				return nil, fmt.Errorf("found exec, kubectl does not currently support manipulating exec settings")
 
 			default:
 				return nil, fmt.Errorf("unable to parse one or more field values of %v", path)

--- a/staging/src/k8s.io/kubectl/pkg/cmd/config/navigation_step_parser.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/config/navigation_step_parser.go
@@ -106,13 +106,12 @@ func newNavigationSteps(path string) (*navigationSteps, error) {
 
 				// If we have a part after the auth provider name we need to add it. There should only ever be at most one part after this.
 				nextPart := strings.Join(individualParts[currPartIndex:], ".")
-				if len(strings.Split(nextPart, ".")) > 1 {
+				if len(strings.Split(nextPart, ".")) > 2 {
 					return nil, fmt.Errorf("too many steps in path %v", path)
 				} else if len(strings.Split(nextPart, ".")) > 1 {
 					steps = append(steps, navigationStep{individualParts[currPartIndex], reflect.TypeOf("")})
 					currPartIndex += 1
 				}
-				// return nil, fmt.Errorf("steps: %v", steps)
 
 			default:
 				return nil, fmt.Errorf("unable to parse one or more field values of %v", path)

--- a/staging/src/k8s.io/kubectl/pkg/cmd/config/navigation_step_parser.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/config/navigation_step_parser.go
@@ -50,6 +50,12 @@ func newNavigationSteps(path string) (*navigationSteps, error) {
 			// store them as a single step.  In order to do that, we need to determine what set of tokens is a legal step AFTER the name of the map key
 			// This set of reflective code pulls the type of the map values, uses that type to look up the set of legal tags.  Those legal tags are used to
 			// walk the list of remaining parts until we find a match to a legal tag or the end of the string.  That name is used to burn all the used parts.
+			if currType.Elem().Kind() == reflect.String {
+				nextPart := individualParts[currPartIndex]
+				steps = append(steps, navigationStep{nextPart, reflect.TypeOf("")})
+				currPartIndex += len(strings.Split(nextPart, "."))
+				break
+			}
 			mapValueType := currType.Elem().Elem()
 
 			var nextPart string
@@ -77,16 +83,38 @@ func newNavigationSteps(path string) (*navigationSteps, error) {
 			}
 			fieldType, exists := options[nextPart]
 			if !exists {
-				return nil, fmt.Errorf("unable to parse %v after %v at %v", path, steps, currType)
+				return nil, fmt.Errorf("unable to parse %v at %v", path, currType)
 			}
 
 			steps = append(steps, navigationStep{nextPart, fieldType})
 			currPartIndex += len(strings.Split(nextPart, "."))
 			currType = fieldType
 
-		case reflect.Ptr:
+		case reflect.Slice:
+			nextPart := individualParts[currPartIndex]
+
+			if currType.Elem().Kind() != reflect.Struct && currType.Elem().Kind() != reflect.String {
+				return nil, fmt.Errorf("unable to parse %v at %v", path, currType)
+			}
 			steps = append(steps, navigationStep{individualParts[currPartIndex], reflect.TypeOf("")})
-			currPartIndex += 1
+			currPartIndex += len(strings.Split(nextPart, "."))
+			steps = append(steps, navigationStep{individualParts[currPartIndex], reflect.TypeOf("")})
+			currPartIndex += len(strings.Split(nextPart, "."))
+
+		case reflect.Ptr:
+			nextPart := individualParts[currPartIndex]
+
+			options, err := getPotentialTypeValues(currType)
+			if err != nil {
+				return nil, err
+			}
+			fieldType, exists := options[nextPart]
+			if !exists {
+				return nil, fmt.Errorf("unable to parse %v at %v", path, individualParts[currPartIndex])
+			}
+			steps = append(steps, navigationStep{individualParts[currPartIndex], fieldType})
+			currPartIndex += len(strings.Split(nextPart, "."))
+			currType = fieldType
 
 		default:
 			return nil, fmt.Errorf("unable to parse one or more field values of %v", path)

--- a/staging/src/k8s.io/kubectl/pkg/cmd/config/navigation_step_parser.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/config/navigation_step_parser.go
@@ -94,7 +94,7 @@ func newNavigationSteps(path string) (*navigationSteps, error) {
 				}
 
 			case reflect.TypeOf(&clientcmdapi.ExecConfig{}):
-				return nil, fmt.Errorf("found exec, kubectl does not currently support manipulating exec settings")
+				return nil, fmt.Errorf("found exec, kubectl config set does not currently support manipulating exec settings")
 
 			default:
 				return nil, fmt.Errorf("unable to parse one or more field values of %v", path)

--- a/staging/src/k8s.io/kubectl/pkg/cmd/config/navigation_step_parser.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/config/navigation_step_parser.go
@@ -36,7 +36,7 @@ type navigationStep struct {
 }
 
 func newNavigationSteps(path string) (*navigationSteps, error) {
-	steps := []navigationStep{}
+	var steps []navigationStep
 	individualParts := strings.Split(path, ".")
 
 	currType := reflect.TypeOf(clientcmdapi.Config{})
@@ -83,7 +83,7 @@ func newNavigationSteps(path string) (*navigationSteps, error) {
 			}
 			fieldType, exists := options[nextPart]
 			if !exists {
-				return nil, fmt.Errorf("unable to parse %v at %v", path, currType)
+				return nil, fmt.Errorf("unable to parse %v at %v", path, individualParts[currPartIndex])
 			}
 
 			steps = append(steps, navigationStep{nextPart, fieldType})
@@ -94,7 +94,7 @@ func newNavigationSteps(path string) (*navigationSteps, error) {
 			nextPart := individualParts[currPartIndex]
 
 			if currType.Elem().Kind() != reflect.Struct && currType.Elem().Kind() != reflect.String {
-				return nil, fmt.Errorf("unable to parse %v at %v", path, currType)
+				return nil, fmt.Errorf("unable to parse %v at %v", path, individualParts[currPartIndex])
 			}
 			steps = append(steps, navigationStep{individualParts[currPartIndex], reflect.TypeOf("")})
 			currPartIndex += len(strings.Split(nextPart, "."))
@@ -110,14 +110,14 @@ func newNavigationSteps(path string) (*navigationSteps, error) {
 			}
 			fieldType, exists := options[nextPart]
 			if !exists {
-				return nil, fmt.Errorf("unable to parse %v at %v", path, individualParts[currPartIndex])
+				return nil, fmt.Errorf("unable to parse path %v at %v", path, individualParts[currPartIndex])
 			}
 			steps = append(steps, navigationStep{individualParts[currPartIndex], fieldType})
 			currPartIndex += len(strings.Split(nextPart, "."))
 			currType = fieldType
 
 		default:
-			return nil, fmt.Errorf("unable to parse one or more field values of %v", path)
+			return nil, fmt.Errorf("unable to parse path %v at %v", path, individualParts[currPartIndex])
 		}
 	}
 

--- a/staging/src/k8s.io/kubectl/pkg/cmd/config/navigation_step_parser.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/config/navigation_step_parser.go
@@ -82,15 +82,15 @@ func newNavigationSteps(path string) (*navigationSteps, error) {
 			switch currType {
 			case reflect.TypeOf(&clientcmdapi.AuthProviderConfig{}):
 				steps = append(steps, navigationStep{individualParts[currPartIndex], reflect.TypeOf("")})
-				currPartIndex += 1
 
 				// If we have a part after the auth provider name we need to add it. There should only ever be at most one part after this.
 				// If there is not nothing happens because just unsetting the name is pointless.
 				nextPart := strings.Join(individualParts[currPartIndex:], ".")
 				if len(strings.Split(nextPart, ".")) > 1 {
-					steps = append(steps, navigationStep{individualParts[currPartIndex+1], reflect.TypeOf(map[string]string{})})
-					currPartIndex += 1
+					return nil, fmt.Errorf("too many steps in path %v", path)
 				}
+
+				currPartIndex += 1
 
 			case reflect.TypeOf(&clientcmdapi.ExecConfig{}):
 				return nil, fmt.Errorf("found ExecConfig")

--- a/staging/src/k8s.io/kubectl/pkg/cmd/config/navigation_step_parser.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/config/navigation_step_parser.go
@@ -89,10 +89,9 @@ func newNavigationSteps(path string) (*navigationSteps, error) {
 			currPartIndex += 1
 
 			// To help users know if they've provided a malformed path, check length
-			nextPart := strings.Join(individualParts[currPartIndex:], ".")
-			if len(strings.Split(nextPart, ".")) > 2 {
+			if len(individualParts[currPartIndex:]) > 2 {
 				return nil, fmt.Errorf("too many steps in path %v", path)
-			} else if len(strings.Split(nextPart, ".")) > 1 {
+			} else if len(individualParts[currPartIndex:]) > 1 {
 				steps = append(steps, navigationStep{individualParts[currPartIndex], reflect.TypeOf("")})
 				currPartIndex += 1
 			}

--- a/staging/src/k8s.io/kubectl/pkg/cmd/config/navigation_step_parser.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/config/navigation_step_parser.go
@@ -88,14 +88,6 @@ func newNavigationSteps(path string) (*navigationSteps, error) {
 			steps = append(steps, navigationStep{individualParts[currPartIndex], reflect.TypeOf("")})
 			currPartIndex += 1
 
-			// To help users know if they've provided a malformed path, check length
-			if len(individualParts[currPartIndex:]) > 2 {
-				return nil, fmt.Errorf("too many steps in path %v", path)
-			} else if len(individualParts[currPartIndex:]) > 1 {
-				steps = append(steps, navigationStep{individualParts[currPartIndex], reflect.TypeOf("")})
-				currPartIndex += 1
-			}
-
 		default:
 			return nil, fmt.Errorf("unable to parse one or more field values of %v", path)
 		}

--- a/staging/src/k8s.io/kubectl/pkg/cmd/config/navigation_step_parser.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/config/navigation_step_parser.go
@@ -85,36 +85,16 @@ func newNavigationSteps(path string) (*navigationSteps, error) {
 			currType = fieldType
 
 		case reflect.Ptr:
-			// Similar to the modifyConfig function, because we can't easily walk the AuthProviderConfig or ExecConfig types we must manually work with them
-			switch currType {
-			case reflect.TypeOf(&clientcmdapi.AuthProviderConfig{}):
+			steps = append(steps, navigationStep{individualParts[currPartIndex], reflect.TypeOf("")})
+			currPartIndex += 1
+
+			// To help users know if they've provided a malformed path, check length
+			nextPart := strings.Join(individualParts[currPartIndex:], ".")
+			if len(strings.Split(nextPart, ".")) > 2 {
+				return nil, fmt.Errorf("too many steps in path %v", path)
+			} else if len(strings.Split(nextPart, ".")) > 1 {
 				steps = append(steps, navigationStep{individualParts[currPartIndex], reflect.TypeOf("")})
 				currPartIndex += 1
-
-				// If we have a part after the auth provider name we need to add it. There should only ever be at most one part after this.
-				nextPart := strings.Join(individualParts[currPartIndex:], ".")
-				if len(strings.Split(nextPart, ".")) > 2 {
-					return nil, fmt.Errorf("too many steps in path %v", path)
-				} else if len(strings.Split(nextPart, ".")) > 1 {
-					steps = append(steps, navigationStep{individualParts[currPartIndex], reflect.TypeOf("")})
-					currPartIndex += 1
-				}
-
-			case reflect.TypeOf(&clientcmdapi.ExecConfig{}):
-				steps = append(steps, navigationStep{individualParts[currPartIndex], reflect.TypeOf("")})
-				currPartIndex += 1
-
-				// If we have a part after the auth provider name we need to add it. There should only ever be at most one part after this.
-				nextPart := strings.Join(individualParts[currPartIndex:], ".")
-				if len(strings.Split(nextPart, ".")) > 2 {
-					return nil, fmt.Errorf("too many steps in path %v", path)
-				} else if len(strings.Split(nextPart, ".")) > 1 {
-					steps = append(steps, navigationStep{individualParts[currPartIndex], reflect.TypeOf("")})
-					currPartIndex += 1
-				}
-
-			default:
-				return nil, fmt.Errorf("unable to parse one or more field values of %v", path)
 			}
 
 		default:

--- a/staging/src/k8s.io/kubectl/pkg/cmd/config/navigation_step_parser_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/config/navigation_step_parser_test.go
@@ -78,7 +78,7 @@ func TestParseWithNoMatchingValue(t *testing.T) {
 		expectedNavigationSteps: navigationSteps{
 			steps: []navigationStep{},
 		},
-		expectedError: "unable to parse one or more field values of users.jheiss.exec",
+		expectedError: "found exec, kubectl config set does not currently support manipulating exec settings",
 	}
 
 	test.run(t)

--- a/staging/src/k8s.io/kubectl/pkg/cmd/config/navigation_step_parser_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/config/navigation_step_parser_test.go
@@ -72,18 +72,6 @@ func TestParseWithBadValue(t *testing.T) {
 	test.run(t)
 }
 
-func TestParseWithNoMatchingValue(t *testing.T) {
-	test := stepParserTest{
-		path: "users.jheiss.exec.command",
-		expectedNavigationSteps: navigationSteps{
-			steps: []navigationStep{},
-		},
-		expectedError: "found exec, kubectl config set does not currently support manipulating exec settings",
-	}
-
-	test.run(t)
-}
-
 func (test stepParserTest) run(t *testing.T) {
 	actualSteps, err := newNavigationSteps(test.path)
 	if len(test.expectedError) != 0 {

--- a/staging/src/k8s.io/kubectl/pkg/cmd/config/navigation_step_parser_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/config/navigation_step_parser_test.go
@@ -66,7 +66,7 @@ func TestParseWithBadValue(t *testing.T) {
 		expectedNavigationSteps: navigationSteps{
 			steps: []navigationStep{},
 		},
-		expectedError: "unable to parse user.bad after [] at api.Config",
+		expectedError: "unable to parse user.bad at user",
 	}
 
 	test.run(t)

--- a/staging/src/k8s.io/kubectl/pkg/cmd/config/set.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/config/set.go
@@ -323,7 +323,7 @@ func modifyConfig(curr reflect.Value, steps *navigationSteps, propertyValue stri
 			}
 
 		case reflect.TypeOf(&clientcmdapi.ExecConfig{}):
-			return fmt.Errorf("found exec, kubectl does not currently support manipulating exec settings")
+			return fmt.Errorf("found exec, kubectl config set does not currently support manipulating exec settings")
 
 		default:
 			return fmt.Errorf("unable to parse one or more field types of %v", actualCurrValue.Type())

--- a/staging/src/k8s.io/kubectl/pkg/cmd/config/set.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/config/set.go
@@ -501,13 +501,13 @@ func setStructInSlice(currSliceValue reflect.Value, structIndex int, searchField
 	targetStruct := currSliceValue.Index(structIndex)
 	searchFieldIndex := getStructFieldIndexByName(targetStruct, searchField)
 	if searchFieldIndex < 0 {
-		return fmt.Errorf("could not find field in struct with name %v", searchField)
+		return fmt.Errorf("could not find field in struct with name %v, please see help text for proper formatting", searchField)
 	}
 	currSliceValue.Index(structIndex).FieldByIndex([]int{searchFieldIndex}).Set(reflect.ValueOf(searchValue))
 
 	setFieldIndex := getStructFieldIndexByName(targetStruct, setField)
 	if setFieldIndex < 0 {
-		return fmt.Errorf("could not find field in struct with name %v", setField)
+		return fmt.Errorf("could not find field in struct with name %v, please see help text for proper formatting", setField)
 	}
 	currSliceValue.Index(structIndex).FieldByIndex([]int{setFieldIndex}).Set(reflect.ValueOf(setValue))
 

--- a/staging/src/k8s.io/kubectl/pkg/cmd/config/set.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/config/set.go
@@ -230,6 +230,9 @@ func modifyConfig(curr reflect.Value, steps *navigationSteps, propertyValue stri
 				}
 
 				// Set struct field and value we will be setting
+				if len(strings.Split(propertyValue, ":")) != 2 {
+					return fmt.Errorf("error parsing field name for value, should be of format fieldName:fieldValue")
+				}
 				setField := strings.Split(propertyValue, ":")[0]
 				setValue := strings.Split(propertyValue, ":")[1]
 

--- a/staging/src/k8s.io/kubectl/pkg/cmd/config/set.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/config/set.go
@@ -284,7 +284,7 @@ func modifyConfig(curr reflect.Value, steps *navigationSteps, propertyValue stri
 					if targetStructIndex != 0 {
 						newValueFirstHalf = actualCurrValue.Slice(0, targetStructIndex)
 					}
-					newValueSecondHalf := reflect.MakeSlice(actualCurrValue.Type(), 0, 0)
+					var newValueSecondHalf reflect.Value
 					if targetStructIndex != actualCurrValue.Len() {
 						newValueSecondHalf = actualCurrValue.Slice(targetStructIndex+1, actualCurrValue.Len())
 					} else {

--- a/staging/src/k8s.io/kubectl/pkg/cmd/config/set.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/config/set.go
@@ -234,10 +234,13 @@ func modifyConfig(curr reflect.Value, steps *navigationSteps, propertyValue stri
 
 	case reflect.String:
 		if steps.moreStepsRemaining() {
-			return fmt.Errorf("can't have more steps after a string. %v", steps)
+			return fmt.Errorf("unable to locate path %v", currStep.stepValue)
 		}
-		actualCurrValue.SetString(propertyValue)
-		return nil
+		if actualCurrValue.CanAddr() {
+			actualCurrValue.SetString(propertyValue)
+			return nil
+		}
+		return fmt.Errorf("unable to locate path %v", currStep.stepValue)
 
 	case reflect.Slice:
 		if setRawBytes {
@@ -348,7 +351,7 @@ func modifyConfig(curr reflect.Value, steps *navigationSteps, propertyValue stri
 
 	case reflect.Bool:
 		if steps.moreStepsRemaining() {
-			return fmt.Errorf("can't have more steps after a bool. %v", steps)
+			return fmt.Errorf("unable to locate path %v", currStep.stepValue)
 		}
 		boolValue, err := toBool(propertyValue)
 		if err != nil {
@@ -363,7 +366,7 @@ func modifyConfig(curr reflect.Value, steps *navigationSteps, propertyValue stri
 			currFieldTypeYamlName := getMapFieldTypeYamlName(actualCurrValue, fieldIndex)
 
 			if currFieldTypeYamlName == currStep.stepValue {
-				thisMapHasNoValue := (currFieldValue.Kind() == reflect.Map && currFieldValue.IsNil())
+				thisMapHasNoValue := currFieldValue.Kind() == reflect.Map && currFieldValue.IsNil()
 
 				if thisMapHasNoValue {
 					newValue := reflect.MakeMap(currFieldValue.Type())

--- a/staging/src/k8s.io/kubectl/pkg/cmd/config/set.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/config/set.go
@@ -260,9 +260,7 @@ func modifyConfig(curr reflect.Value, steps *navigationSteps, propertyValue stri
 				targetStruct := actualCurrValue.Index(targetStructIndex)
 				fieldIndex := 0
 				for fieldIndex < targetStruct.NumField() {
-					currFieldType := targetStruct.Type().Field(fieldIndex)
-					currYamlTag := currFieldType.Tag.Get("json")
-					currFieldTypeYamlName := strings.Split(currYamlTag, ",")[0]
+					currFieldTypeYamlName := getMapFieldTypeYamlName(targetStruct, fieldIndex)
 
 					if currFieldTypeYamlName == searchField {
 						break
@@ -276,9 +274,7 @@ func modifyConfig(curr reflect.Value, steps *navigationSteps, propertyValue stri
 
 				fieldIndex = 0
 				for fieldIndex < targetStruct.NumField() {
-					currFieldType := targetStruct.Type().Field(fieldIndex)
-					currYamlTag := currFieldType.Tag.Get("json")
-					currFieldTypeYamlName := strings.Split(currYamlTag, ",")[0]
+					currFieldTypeYamlName := getMapFieldTypeYamlName(targetStruct, fieldIndex)
 
 					if currFieldTypeYamlName == setField {
 						break
@@ -316,9 +312,7 @@ func modifyConfig(curr reflect.Value, steps *navigationSteps, propertyValue stri
 	case reflect.Struct:
 		for fieldIndex := 0; fieldIndex < actualCurrValue.NumField(); fieldIndex++ {
 			currFieldValue := actualCurrValue.Field(fieldIndex)
-			currFieldType := actualCurrValue.Type().Field(fieldIndex)
-			currYamlTag := currFieldType.Tag.Get("json")
-			currFieldTypeYamlName := strings.Split(currYamlTag, ",")[0]
+			currFieldTypeYamlName := getMapFieldTypeYamlName(actualCurrValue, fieldIndex)
 
 			if currFieldTypeYamlName == currStep.stepValue {
 				thisMapHasNoValue := (currFieldValue.Kind() == reflect.Map && currFieldValue.IsNil())
@@ -380,9 +374,7 @@ func getStructByFieldName(v reflect.Value, name string, value string) int {
 		objValue := reflect.ValueOf(obj)
 		for fieldIndex := 0; fieldIndex < objValue.NumField(); fieldIndex++ {
 			currFieldValue := objValue.Field(fieldIndex)
-			currFieldType := objValue.Type().Field(fieldIndex)
-			currYamlTag := currFieldType.Tag.Get("json")
-			currFieldTypeYamlName := strings.Split(currYamlTag, ",")[0]
+			currFieldTypeYamlName := getMapFieldTypeYamlName(objValue, fieldIndex)
 
 			if currFieldTypeYamlName == name && currFieldValue.String() == value {
 				return i
@@ -392,6 +384,13 @@ func getStructByFieldName(v reflect.Value, name string, value string) int {
 
 	// If we never find the Name key return false
 	return -1
+}
+
+func getMapFieldTypeYamlName(objValue reflect.Value, fieldIndex int) string {
+	currFieldType := objValue.Type().Field(fieldIndex)
+	currYamlTag := currFieldType.Tag.Get("json")
+	currFieldTypeYamlName := strings.Split(currYamlTag, ",")[0]
+	return currFieldTypeYamlName
 }
 
 func dedupeStringSlice(slice []string) []string {

--- a/staging/src/k8s.io/kubectl/pkg/cmd/config/set.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/config/set.go
@@ -26,11 +26,11 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/tools/clientcmd"
 	cliflag "k8s.io/component-base/cli/flag"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 	"k8s.io/kubectl/pkg/util/i18n"
-	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/kubectl/pkg/util/templates"
 )
 

--- a/staging/src/k8s.io/kubectl/pkg/cmd/config/set.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/config/set.go
@@ -26,7 +26,6 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/tools/clientcmd"
 	cliflag "k8s.io/component-base/cli/flag"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
@@ -75,7 +74,10 @@ var (
 	kubectl config set users.foo.act-as-groups existingGroup-
 	
 	# Set an exec environment variable with the name test and the value val1
-	kubectl config set users.foo.exec.env.name.test value:val1`)
+	kubectl config set users.foo.exec.env.name.test value:val1
+
+	# Set an exec argument list where the first entry uses a - or --
+	kubectl config set users.foo.exec.args -- "--test-arg,next,thing,-i"`)
 )
 
 // NewCmdConfigSet returns a Command instance for 'config set' sub command
@@ -430,10 +432,10 @@ func editStringSlice(slice []string, input string) []string {
 		input = string(input[:len(input)-1])
 		argSlice := strings.Split(input, ",")
 		slice = append(slice, argSlice...)
-		return sets.NewString(slice...).List()
+		return slice
 
 	default:
 		argSlice := strings.Split(input, ",")
-		return sets.NewString(argSlice...).List()
+		return argSlice
 	}
 }

--- a/staging/src/k8s.io/kubectl/pkg/cmd/config/set.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/config/set.go
@@ -258,33 +258,17 @@ func modifyConfig(curr reflect.Value, steps *navigationSteps, propertyValue stri
 				}
 
 				targetStruct := actualCurrValue.Index(targetStructIndex)
-				fieldIndex := 0
-				for fieldIndex < targetStruct.NumField() {
-					currFieldTypeYamlName := getMapFieldTypeYamlName(targetStruct, fieldIndex)
-
-					if currFieldTypeYamlName == searchField {
-						break
-					}
-					fieldIndex++
-				}
-				if fieldIndex > targetStruct.NumField() {
+				searchFieldIndex := getStructFieldIndexByName(targetStruct, searchField)
+				if searchFieldIndex < 0 {
 					return fmt.Errorf("could not find field in struct with name %v", searchField)
 				}
-				actualCurrValue.Index(targetStructIndex).FieldByIndex([]int{fieldIndex}).Set(reflect.ValueOf(searchValue))
+				actualCurrValue.Index(targetStructIndex).FieldByIndex([]int{searchFieldIndex}).Set(reflect.ValueOf(searchValue))
 
-				fieldIndex = 0
-				for fieldIndex < targetStruct.NumField() {
-					currFieldTypeYamlName := getMapFieldTypeYamlName(targetStruct, fieldIndex)
-
-					if currFieldTypeYamlName == setField {
-						break
-					}
-					fieldIndex++
-				}
-				if fieldIndex > targetStruct.NumField() {
+				setFieldIndex := getStructFieldIndexByName(targetStruct, setField)
+				if setFieldIndex < 0 {
 					return fmt.Errorf("could not find field in struct with name %v", setField)
 				}
-				actualCurrValue.Index(targetStructIndex).FieldByIndex([]int{fieldIndex}).Set(reflect.ValueOf(setValue))
+				actualCurrValue.Index(targetStructIndex).FieldByIndex([]int{setFieldIndex}).Set(reflect.ValueOf(setValue))
 
 				return nil
 
@@ -379,6 +363,20 @@ func getStructByFieldName(v reflect.Value, name string, value string) int {
 			if currFieldTypeYamlName == name && currFieldValue.String() == value {
 				return i
 			}
+		}
+	}
+
+	// If we never find the Name key return false
+	return -1
+}
+
+// getStructFieldIndexByName returns the index number of a field with a name
+func getStructFieldIndexByName(objValue reflect.Value, name string) int {
+	// Iterate through fields until we find the field we're looking for and return the index
+	for fieldIndex := 0; fieldIndex < objValue.NumField(); fieldIndex++ {
+		currFieldTypeYamlName := getMapFieldTypeYamlName(objValue, fieldIndex)
+		if currFieldTypeYamlName == name {
+			return fieldIndex
 		}
 	}
 

--- a/staging/src/k8s.io/kubectl/pkg/cmd/config/set.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/config/set.go
@@ -54,7 +54,7 @@ var (
 
 	When configuring a list of structs, you will need to specify a structs field and value pair to search for in the dot notation in form of field.value. The value will need to be set by specifying the field you are editing and the value to set it to, separated by a :. e.g. kubectl config set users.foo.exec.env.name.test value:val1
 
-	To delete an existing struct in a list of structs you will follow the same format and add :del to the end, e.g. kubectl config set users.foo.exec.env.name.test value:val1:-
+	To delete an existing struct in a list of structs you will leave the value field blank, e.g. kubectl config set users.foo.exec.env.name.test value:
 
 	Specifying an attribute name that already exists will merge new fields on top of existing values.`))
 
@@ -80,8 +80,8 @@ var (
 	# Set an exec environment variable with the name test and the value val1
 	kubectl config set users.foo.exec.env.name.test value:val1
 
-	# Delete an exec environment variable with the name test and the value val1
-	kubectl config set users.foo.exec.env.name.test value:val1:-
+	# Delete an exec environment variable with the name test
+	kubectl config set users.foo.exec.env.name.test value:
 
 	# Set an exec argument list where the first entry uses a - or --
 	kubectl config set users.foo.exec.args -- "--test-arg,next,thing,-i"`)
@@ -269,23 +269,27 @@ func modifyConfig(curr reflect.Value, steps *navigationSteps, propertyValue stri
 
 				// Set struct field and value we will be setting
 				valueSlice := strings.Split(propertyValue, ":")
-				if !(len(valueSlice) > 1 && len(valueSlice) < 4) {
-					return fmt.Errorf("error parsing field name for value, should be of format fieldName:fieldValue[:action]")
+				if len(valueSlice) != 2 {
+					return fmt.Errorf("error parsing field name for value, should be of format fieldName:fieldValue")
 				}
 				setField := valueSlice[0]
 				setValue := valueSlice[1]
-				setAction := "+"
-				if len(valueSlice) == 3 {
-					setAction = valueSlice[2]
-				}
 
-				if setAction == "-" {
+				if setValue == "" {
 					targetStructIndex := getStructByFieldName(actualCurrValue, searchField, searchValue)
 					if targetStructIndex < 0 {
 						return nil
 					}
-					newValueFirstHalf := actualCurrValue.Slice(0, targetStructIndex)
-					newValueSecondHalf := actualCurrValue.Slice(targetStructIndex, actualCurrValue.Len()-1)
+					newValueFirstHalf := reflect.MakeSlice(actualCurrValue.Type(), 0, 0)
+					if targetStructIndex != 0 {
+						newValueFirstHalf = actualCurrValue.Slice(0, targetStructIndex)
+					}
+					newValueSecondHalf := reflect.MakeSlice(actualCurrValue.Type(), 0, 0)
+					if targetStructIndex != actualCurrValue.Len() {
+						newValueSecondHalf = actualCurrValue.Slice(targetStructIndex+1, actualCurrValue.Len())
+					} else {
+						newValueSecondHalf = actualCurrValue.Slice(targetStructIndex+1, actualCurrValue.Len()-1)
+					}
 					actualCurrValue.Set(reflect.AppendSlice(newValueFirstHalf, newValueSecondHalf))
 					return nil
 				}

--- a/staging/src/k8s.io/kubectl/pkg/cmd/config/set.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/config/set.go
@@ -272,7 +272,7 @@ func modifyConfig(curr reflect.Value, steps *navigationSteps, propertyValue stri
 					return nil
 				}
 			}
-			
+
 			switch steps.steps[steps.currentStepIndex-1].stepValue {
 			case "name":
 				// Since unsetting just the name of the auth-provider is pointless return error
@@ -316,7 +316,7 @@ func modifyConfig(curr reflect.Value, steps *navigationSteps, propertyValue stri
 
 			default:
 				path := []string{}
-				for _, step := range(steps.steps) {
+				for _, step := range steps.steps {
 					path = append(path, step.stepValue)
 				}
 				return fmt.Errorf("unrecognized step in path %v", strings.Join(path, "."))

--- a/staging/src/k8s.io/kubectl/pkg/cmd/config/set.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/config/set.go
@@ -159,6 +159,9 @@ func modifyConfig(curr reflect.Value, steps *navigationSteps, propertyValue stri
 		if !steps.moreStepsRemaining() && !unset {
 			switch mapValueType.Kind() {
 			case reflect.String:
+				if currStep.stepValue == "" {
+					return fmt.Errorf("empty key provided for map")
+				}
 				actualCurrValue.SetMapIndex(reflect.ValueOf(currStep.stepValue), reflect.ValueOf(propertyValue))
 
 			case reflect.Slice:

--- a/staging/src/k8s.io/kubectl/pkg/cmd/config/set.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/config/set.go
@@ -360,7 +360,7 @@ func modifyConfig(curr reflect.Value, steps *navigationSteps, propertyValue stri
 
 	}
 
-	panic(fmt.Errorf("unrecognized type: %v\nwanted: %v", actualCurrValue, actualCurrValue.Kind()))
+	return fmt.Errorf("unrecognized type: %v\nwanted: %v", actualCurrValue, actualCurrValue.Kind())
 }
 
 // getStructFromSliceByFieldName gets the index of the struct in a slice that has the given field name set to the given value

--- a/staging/src/k8s.io/kubectl/pkg/cmd/config/set.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/config/set.go
@@ -332,7 +332,7 @@ func modifyConfig(curr reflect.Value, steps *navigationSteps, propertyValue stri
 			actualCurrValue.Set(newValue)
 			newActualCurrValue = actualCurrValue.Elem()
 			if !steps.moreStepsRemaining() && unset {
- 				return nil
+				return nil
 			}
 		}
 		steps.currentStepIndex = steps.currentStepIndex - 1

--- a/staging/src/k8s.io/kubectl/pkg/cmd/config/set.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/config/set.go
@@ -341,8 +341,8 @@ func modifyConfig(curr reflect.Value, steps *navigationSteps, propertyValue stri
 	return fmt.Errorf("unrecognized type: %v\nwanted: %v", actualCurrValue, actualCurrValue.Kind())
 }
 
-// getStructFromSliceByFieldName gets the index of the struct in a slice that has the given field name set to the given value
-func getStructByFieldName(v reflect.Value, name string, value string) int {
+// getStructByFieldName gets the index of the struct in a slice that has the given field name set to the given value
+func getStructByFieldName(v reflect.Value, name, value string) int {
 	if v.Kind() != reflect.Slice {
 		return -1
 	}

--- a/staging/src/k8s.io/kubectl/pkg/cmd/config/set.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/config/set.go
@@ -323,7 +323,7 @@ func modifyConfig(curr reflect.Value, steps *navigationSteps, propertyValue stri
 			}
 
 		case reflect.TypeOf(&clientcmdapi.ExecConfig{}):
-			return fmt.Errorf("found ExecConfig")
+			return fmt.Errorf("found exec, kubectl does not currently support manipulating exec settings")
 
 		default:
 			return fmt.Errorf("unable to parse one or more field types of %v", actualCurrValue.Type())

--- a/staging/src/k8s.io/kubectl/pkg/cmd/config/set.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/config/set.go
@@ -240,6 +240,9 @@ func modifyConfig(curr reflect.Value, steps *navigationSteps, propertyValue stri
 		} else {
 			innerType := actualCurrValue.Type().Elem()
 			if innerType.Kind() == reflect.String {
+				if currStep.stepValue != "" {
+					return fmt.Errorf("unable to locate path %v", currStep.stepValue)
+				}
 				currentSliceValue := actualCurrValue.Interface().([]string)
 				newSliceValue := editStringSlice(currentSliceValue, propertyValue, deduplicate)
 				actualCurrValue.Set(reflect.ValueOf(newSliceValue))
@@ -247,6 +250,11 @@ func modifyConfig(curr reflect.Value, steps *navigationSteps, propertyValue stri
 				// Note this only works for attempting to set struct fields of type string
 				// Set struct field we are searching on and value we will be searching for
 				stepSearchValue := steps.pop()
+				if steps.moreStepsRemaining() {
+					errorStep := steps.pop()
+					return fmt.Errorf("unable to locate path %v", errorStep.stepValue)
+				}
+
 				searchField := currStep.stepValue
 				searchValue := stepSearchValue.stepValue
 
@@ -365,7 +373,7 @@ func modifyConfig(curr reflect.Value, steps *navigationSteps, propertyValue stri
 				return nil
 			}
 		}
-		steps.currentStepIndex = steps.currentStepIndex - 1
+		steps.currentStepIndex -= 1
 		return modifyConfig(newActualCurrValue.Addr(), steps, propertyValue, unset, setRawBytes, deduplicate)
 
 	}

--- a/staging/src/k8s.io/kubectl/pkg/cmd/config/set.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/config/set.go
@@ -49,6 +49,10 @@ var (
 
 	PROPERTY_VALUE is the new value you want to set. Binary fields such as 'certificate-authority-data' expect a base64 encoded string unless the --set-raw-bytes flag is used.
 
+	When configuring lists you can insert new or remove existing keys by appending a + or - to the comma separated list of values respectively, e.g. value1,value2+ or value1,value2-
+
+	When configuring a list of dictrionaries, you will need to specify a dictionary field and value pair to search for in the dot notation in form of field.value. The value will need to be set by specifying the field you are editing and the value to set it to, separated by a :. e.g. kubectl config set users.foo.exec.env.name.test value:val1
+
 	Specifying an attribute name that already exists will merge new fields on top of existing values.`))
 
 	setExample = templates.Examples(`
@@ -62,7 +66,16 @@ var (
 	kubectl config set contexts.my-context.cluster my-cluster
 
 	# Set the client-key-data field in the cluster-admin user using --set-raw-bytes option
-	kubectl config set users.cluster-admin.client-key-data cert_data_here --set-raw-bytes=true`)
+	kubectl config set users.cluster-admin.client-key-data cert_data_here --set-raw-bytes=true
+	
+	# Set a new act-as-group for an existing list of groups
+	kubectl config set users.foo.act-as-groups newGroup+
+	
+	# Remove existing group from list of groups under act-as-group
+	kubectl config set users.foo.act-as-groups existingGroup-
+	
+	# Set an exec environment variable with the name test and the value val1
+	kubectl config set users.foo.exec.env.name.test value:val1`)
 )
 
 // NewCmdConfigSet returns a Command instance for 'config set' sub command

--- a/staging/src/k8s.io/kubectl/pkg/cmd/config/set.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/config/set.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 	"io"
 	"reflect"
-	"sort"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -31,6 +30,7 @@ import (
 	cliflag "k8s.io/component-base/cli/flag"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 	"k8s.io/kubectl/pkg/util/i18n"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/kubectl/pkg/util/templates"
 )
 
@@ -391,19 +391,6 @@ func getMapFieldTypeYamlName(objValue reflect.Value, fieldIndex int) string {
 	return currFieldTypeYamlName
 }
 
-func dedupeStringSlice(slice []string) []string {
-	sliceMap := make(map[string]struct{})
-	for i := 0; i < len(slice); i++ {
-		sliceMap[slice[i]] = struct{}{}
-	}
-	var dedupeSlice []string
-	for k := range sliceMap {
-		dedupeSlice = append(dedupeSlice, k)
-	}
-	sort.Strings(dedupeSlice)
-	return dedupeSlice
-}
-
 func editStringSlice(slice []string, input string) []string {
 	function := string(input[len(input)-1])
 	switch function {
@@ -430,10 +417,10 @@ func editStringSlice(slice []string, input string) []string {
 		input = string(input[:len(input)-1])
 		argSlice := strings.Split(input, ",")
 		slice = append(slice, argSlice...)
-		return dedupeStringSlice(slice)
+		return sets.NewString(slice...).List()
 
 	default:
 		argSlice := strings.Split(input, ",")
-		return dedupeStringSlice(argSlice)
+		return sets.NewString(argSlice...).List()
 	}
 }

--- a/staging/src/k8s.io/kubectl/pkg/cmd/config/set.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/config/set.go
@@ -295,6 +295,10 @@ func modifyConfig(curr reflect.Value, steps *navigationSteps, propertyValue stri
 				mapKey := reflect.ValueOf(currStep.stepValue)
 				newMapValue := reflect.ValueOf(propertyValue)
 
+				if currFieldValue.IsNil() {
+					currFieldValue.Set(reflect.ValueOf(map[string]string{}))
+				}
+
 				currFieldValue.SetMapIndex(mapKey, newMapValue)
 
 				return nil

--- a/staging/src/k8s.io/kubectl/pkg/cmd/config/set_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/config/set_test.go
@@ -120,6 +120,17 @@ func TestSetConfigAuthProviderConfigRefreshToken(t *testing.T) {
 	test.run(t)
 }
 
+func TestSetConfigAuthProviderConfigEmptyKey(t *testing.T) {
+	conf := *clientcmdapi.NewConfig()
+	test := setConfigTest{
+		description: "Testing for kubectl config set users.foo.auth-provider.config to test",
+		config:      conf,
+		args:        []string{"users.foo.auth-provider.config", "test"},
+		expectedErr: `empty key provided for map`,
+	}
+	test.run(t)
+}
+
 func TestSetConfigExecConfigCommand(t *testing.T) {
 	conf := *clientcmdapi.NewConfig()
 	expectedConfig := clientcmdapi.Config{

--- a/staging/src/k8s.io/kubectl/pkg/cmd/config/set_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/config/set_test.go
@@ -985,6 +985,57 @@ func TestFromExistingConfig(t *testing.T) {
 			},
 		},
 		{
+			name:        "AddNewExecEnvVar",
+			description: "Testing for kubectl config set users.foo.exec.env.name.test1 to value:value2",
+			config:      conf,
+			args:        []string{"users.foo.exec.env.name.test1", "value:value2"},
+			expected:    `Property "users.foo.exec.env.name.test1" set.` + "\n",
+			expectedConfig: clientcmdapi.Config{
+				AuthInfos: map[string]*clientcmdapi.AuthInfo{
+					"foo": {
+						Exec: &clientcmdapi.ExecConfig{
+							Args: []string{
+								"test1",
+								"test2",
+								"test3",
+							},
+							Env: []clientcmdapi.ExecEnvVar{
+								{
+									Name:  "test",
+									Value: "value1",
+								},
+								{
+									Name:  "test1",
+									Value: "value2",
+								},
+							},
+						},
+						Extensions: map[string]runtime.Object{},
+						ImpersonateGroups: []string{
+							"test1",
+							"test2",
+							"test3",
+						},
+						ImpersonateUserExtra: map[string][]string{
+							"test1": {
+								"val1",
+								"val2",
+								"val3",
+							},
+						},
+					},
+				},
+				Clusters:       map[string]*clientcmdapi.Cluster{},
+				Contexts:       map[string]*clientcmdapi.Context{},
+				CurrentContext: "minikube",
+				Extensions:     map[string]runtime.Object{},
+				Preferences: clientcmdapi.Preferences{
+					Colors:     false,
+					Extensions: map[string]runtime.Object{},
+				},
+			},
+		},
+		{
 			name:        "AddActAsGroups",
 			description: "Testing for kubectl config set users.foo.act-as-groups to test4+",
 			config:      conf,

--- a/staging/src/k8s.io/kubectl/pkg/cmd/config/set_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/config/set_test.go
@@ -31,6 +31,7 @@ import (
 )
 
 type setConfigTest struct {
+	name           string
 	description    string
 	config         clientcmdapi.Config
 	args           []string
@@ -39,394 +40,500 @@ type setConfigTest struct {
 	expectedConfig clientcmdapi.Config
 }
 
-func TestSetConfigCurrentContext(t *testing.T) {
-	conf := clientcmdapi.Config{
-		Kind:           "Config",
-		APIVersion:     "v1",
-		CurrentContext: "minikube",
-	}
-	expectedConfig := *clientcmdapi.NewConfig()
-	expectedConfig.CurrentContext = "my-cluster"
-	test := setConfigTest{
-		description:    "Testing for kubectl config set current-context",
-		config:         conf,
-		args:           []string{"current-context", "my-cluster"},
-		expected:       `Property "current-context" set.` + "\n",
-		expectedConfig: expectedConfig,
-	}
-	test.run(t)
-}
-
-func TestSetConfigAuthProviderName(t *testing.T) {
+func TestFromNewConfig(t *testing.T) {
 	conf := *clientcmdapi.NewConfig()
-	expectedConfig := clientcmdapi.Config{
-		AuthInfos: map[string]*clientcmdapi.AuthInfo{
-			"foo": {
-				AuthProvider: &clientcmdapi.AuthProviderConfig{
-					Name: "oidc",
-				},
-				Extensions: map[string]runtime.Object{},
-			},
-		},
-		Clusters:   map[string]*clientcmdapi.Cluster{},
-		Contexts:   map[string]*clientcmdapi.Context{},
-		Extensions: map[string]runtime.Object{},
-		Preferences: clientcmdapi.Preferences{
-			Colors:     false,
-			Extensions: map[string]runtime.Object{},
-		},
-	}
-	expectedConfig.Extensions = map[string]runtime.Object{}
-	test := setConfigTest{
-		description:    "Testing for kubectl config set users.foo.auth-provider.name to oidc",
-		config:         conf,
-		args:           []string{"users.foo.auth-provider.name", "oidc"},
-		expected:       `Property "users.foo.auth-provider.name" set.` + "\n",
-		expectedConfig: expectedConfig,
-	}
-	test.run(t)
-}
-
-func TestSetConfigAuthProviderConfigRefreshToken(t *testing.T) {
-	conf := *clientcmdapi.NewConfig()
-	expectedConfig := clientcmdapi.Config{
-		AuthInfos: map[string]*clientcmdapi.AuthInfo{
-			"foo": {
-				AuthProvider: &clientcmdapi.AuthProviderConfig{
-					Name: "",
-					Config: map[string]string{
-						"refresh-token": "test",
-					},
-				},
-				Extensions: map[string]runtime.Object{},
-			},
-		},
-		Clusters:   map[string]*clientcmdapi.Cluster{},
-		Contexts:   map[string]*clientcmdapi.Context{},
-		Extensions: map[string]runtime.Object{},
-		Preferences: clientcmdapi.Preferences{
-			Colors:     false,
-			Extensions: map[string]runtime.Object{},
-		},
-	}
-	expectedConfig.Extensions = map[string]runtime.Object{}
-	test := setConfigTest{
-		description:    "Testing for kubectl config set users.foo.auth-provider.config.refresh-token to test",
-		config:         conf,
-		args:           []string{"users.foo.auth-provider.config.refresh-token", "test"},
-		expected:       `Property "users.foo.auth-provider.config.refresh-token" set.` + "\n",
-		expectedConfig: expectedConfig,
-	}
-	test.run(t)
-}
-
-func TestSetConfigAuthProviderConfigEmptyKey(t *testing.T) {
-	conf := *clientcmdapi.NewConfig()
-	test := setConfigTest{
-		description: "Testing for kubectl config set users.foo.auth-provider.config to test",
-		config:      conf,
-		args:        []string{"users.foo.auth-provider.config", "test"},
-		expectedErr: `empty key provided for map`,
-	}
-	test.run(t)
-}
-
-func TestSetConfigExecConfigCommand(t *testing.T) {
-	conf := *clientcmdapi.NewConfig()
-	expectedConfig := clientcmdapi.Config{
-		AuthInfos: map[string]*clientcmdapi.AuthInfo{
-			"foo": {
-				Exec: &clientcmdapi.ExecConfig{
-					Command: "test",
-				},
-				Extensions: map[string]runtime.Object{},
-			},
-		},
-		Clusters:   map[string]*clientcmdapi.Cluster{},
-		Contexts:   map[string]*clientcmdapi.Context{},
-		Extensions: map[string]runtime.Object{},
-		Preferences: clientcmdapi.Preferences{
-			Colors:     false,
-			Extensions: map[string]runtime.Object{},
-		},
-	}
-	expectedConfig.Extensions = map[string]runtime.Object{}
-	test := setConfigTest{
-		description:    "Testing for kubectl config set users.foo.exec.command to test",
-		config:         conf,
-		args:           []string{"users.foo.exec.command", "test"},
-		expected:       `Property "users.foo.exec.command" set.` + "\n",
-		expectedConfig: expectedConfig,
-	}
-	test.run(t)
-}
-
-func TestSetConfigExecArgsNew(t *testing.T) {
-	conf := *clientcmdapi.NewConfig()
-	expectedConfig := clientcmdapi.Config{
-		AuthInfos: map[string]*clientcmdapi.AuthInfo{
-			"foo": {
-				Exec: &clientcmdapi.ExecConfig{
-					Args: []string{
-						"test1",
-						"test2",
-						"test3",
-					},
-				},
-				Extensions: map[string]runtime.Object{},
-			},
-		},
-		Clusters:   map[string]*clientcmdapi.Cluster{},
-		Contexts:   map[string]*clientcmdapi.Context{},
-		Extensions: map[string]runtime.Object{},
-		Preferences: clientcmdapi.Preferences{
-			Colors:     false,
-			Extensions: map[string]runtime.Object{},
-		},
-	}
-	expectedConfig.Extensions = map[string]runtime.Object{}
-	test := setConfigTest{
-		description:    "Testing for kubectl config set users.foo.exec.args to test1,test2,test3",
-		config:         conf,
-		args:           []string{"users.foo.exec.args", "test1,test2,test3"},
-		expected:       `Property "users.foo.exec.args" set.` + "\n",
-		expectedConfig: expectedConfig,
-	}
-	test.run(t)
-}
-
-func TestSetConfigExecArgsAdd(t *testing.T) {
-	conf := clientcmdapi.Config{
-		AuthInfos: map[string]*clientcmdapi.AuthInfo{
-			"foo": {
-				Exec: &clientcmdapi.ExecConfig{
-					Args: []string{
-						"test1",
-						"test2",
-						"test3",
-					},
-				},
-				Extensions: map[string]runtime.Object{},
-			},
-		},
-		Clusters:   map[string]*clientcmdapi.Cluster{},
-		Contexts:   map[string]*clientcmdapi.Context{},
-		Extensions: map[string]runtime.Object{},
-		Preferences: clientcmdapi.Preferences{
-			Colors:     false,
-			Extensions: map[string]runtime.Object{},
-		},
-	}
-	expectedConfig := clientcmdapi.Config{
-		AuthInfos: map[string]*clientcmdapi.AuthInfo{
-			"foo": {
-				Exec: &clientcmdapi.ExecConfig{
-					Args: []string{
-						"test1",
-						"test2",
-						"test3",
-						"test4",
-					},
-				},
-				Extensions: map[string]runtime.Object{},
-			},
-		},
-		Clusters:   map[string]*clientcmdapi.Cluster{},
-		Contexts:   map[string]*clientcmdapi.Context{},
-		Extensions: map[string]runtime.Object{},
-		Preferences: clientcmdapi.Preferences{
-			Colors:     false,
-			Extensions: map[string]runtime.Object{},
-		},
-	}
-	expectedConfig.Extensions = map[string]runtime.Object{}
-	test := setConfigTest{
-		description:    "Testing for kubectl config set users.foo.exec.args to test4+",
-		config:         conf,
-		args:           []string{"users.foo.exec.args", "test4+"},
-		expected:       `Property "users.foo.exec.args" set.` + "\n",
-		expectedConfig: expectedConfig,
-	}
-	test.run(t)
-}
-
-func TestSetConfigExecArgsDelete(t *testing.T) {
-	conf := clientcmdapi.Config{
-		AuthInfos: map[string]*clientcmdapi.AuthInfo{
-			"foo": {
-				Exec: &clientcmdapi.ExecConfig{
-					Args: []string{
-						"test1",
-						"test2",
-						"test3",
-					},
-				},
-				Extensions: map[string]runtime.Object{},
-			},
-		},
-		Clusters:   map[string]*clientcmdapi.Cluster{},
-		Contexts:   map[string]*clientcmdapi.Context{},
-		Extensions: map[string]runtime.Object{},
-		Preferences: clientcmdapi.Preferences{
-			Colors:     false,
-			Extensions: map[string]runtime.Object{},
-		},
-	}
-	expectedConfig := clientcmdapi.Config{
-		AuthInfos: map[string]*clientcmdapi.AuthInfo{
-			"foo": {
-				Exec: &clientcmdapi.ExecConfig{
-					Args: []string{
-						"test1",
-						"test3",
-					},
-				},
-				Extensions: map[string]runtime.Object{},
-			},
-		},
-		Clusters:   map[string]*clientcmdapi.Cluster{},
-		Contexts:   map[string]*clientcmdapi.Context{},
-		Extensions: map[string]runtime.Object{},
-		Preferences: clientcmdapi.Preferences{
-			Colors:     false,
-			Extensions: map[string]runtime.Object{},
-		},
-	}
-	expectedConfig.Extensions = map[string]runtime.Object{}
-	test := setConfigTest{
-		description:    "Testing for kubectl config set users.foo.exec.args to test2-",
-		config:         conf,
-		args:           []string{"users.foo.exec.args", "test2-"},
-		expected:       `Property "users.foo.exec.args" set.` + "\n",
-		expectedConfig: expectedConfig,
-	}
-	test.run(t)
-}
-
-func TestSetConfigExecArgsUpdate(t *testing.T) {
-	conf := clientcmdapi.Config{
-		AuthInfos: map[string]*clientcmdapi.AuthInfo{
-			"foo": {
-				Exec: &clientcmdapi.ExecConfig{
-					Args: []string{
-						"test1",
-						"test2",
-						"test3",
-						"test4",
-					},
-				},
-				Extensions: map[string]runtime.Object{},
-			},
-		},
-		Clusters:   map[string]*clientcmdapi.Cluster{},
-		Contexts:   map[string]*clientcmdapi.Context{},
-		Extensions: map[string]runtime.Object{},
-		Preferences: clientcmdapi.Preferences{
-			Colors:     false,
-			Extensions: map[string]runtime.Object{},
-		},
-	}
-	expectedConfig := clientcmdapi.Config{
-		AuthInfos: map[string]*clientcmdapi.AuthInfo{
-			"foo": {
-				Exec: &clientcmdapi.ExecConfig{
-					Args: []string{
-						"test1",
-						"test3",
-					},
-				},
-				Extensions: map[string]runtime.Object{},
-			},
-		},
-		Clusters:   map[string]*clientcmdapi.Cluster{},
-		Contexts:   map[string]*clientcmdapi.Context{},
-		Extensions: map[string]runtime.Object{},
-		Preferences: clientcmdapi.Preferences{
-			Colors:     false,
-			Extensions: map[string]runtime.Object{},
-		},
-	}
-	expectedConfig.Extensions = map[string]runtime.Object{}
-	test := setConfigTest{
-		description:    "Testing for kubectl config set users.foo.exec.args to test1,test3",
-		config:         conf,
-		args:           []string{"users.foo.exec.args", "test1,test3"},
-		expected:       `Property "users.foo.exec.args" set.` + "\n",
-		expectedConfig: expectedConfig,
-	}
-	test.run(t)
-}
-
-func TestSetConfigExecProvideClusterInfo(t *testing.T) {
-	conf := *clientcmdapi.NewConfig()
-	expectedConfig := clientcmdapi.Config{
-		AuthInfos: map[string]*clientcmdapi.AuthInfo{
-			"foo": {
-				Exec: &clientcmdapi.ExecConfig{
-					ProvideClusterInfo: true,
-				},
-				Extensions: map[string]runtime.Object{},
-			},
-		},
-		Clusters:   map[string]*clientcmdapi.Cluster{},
-		Contexts:   map[string]*clientcmdapi.Context{},
-		Extensions: map[string]runtime.Object{},
-		Preferences: clientcmdapi.Preferences{
-			Colors:     false,
-			Extensions: map[string]runtime.Object{},
-		},
-	}
-	expectedConfig.Extensions = map[string]runtime.Object{}
-	test := setConfigTest{
-		description:    "Testing for kubectl config set users.foo.exec.provideClusterInfo to true",
-		config:         conf,
-		args:           []string{"users.foo.exec.provideClusterInfo", "true"},
-		expected:       `Property "users.foo.exec.provideClusterInfo" set.` + "\n",
-		expectedConfig: expectedConfig,
-	}
-	test.run(t)
-}
-
-func TestSetConfigExecEnvNew(t *testing.T) {
-	conf := *clientcmdapi.NewConfig()
-	expectedConfig := clientcmdapi.Config{
-		AuthInfos: map[string]*clientcmdapi.AuthInfo{
-			"foo": {
-				Exec: &clientcmdapi.ExecConfig{
-					Env: []clientcmdapi.ExecEnvVar{
-						{
-							Name:  "test",
-							Value: "val1",
+	tests := []setConfigTest{
+		{
+			name:        "SetAuthProviderName",
+			description: "Testing for kubectl config set users.foo.auth-provider.name to oidc",
+			config:      conf,
+			args:        []string{"users.foo.auth-provider.name", "oidc"},
+			expected:    `Property "users.foo.auth-provider.name" set.` + "\n",
+			expectedConfig: clientcmdapi.Config{
+				AuthInfos: map[string]*clientcmdapi.AuthInfo{
+					"foo": {
+						AuthProvider: &clientcmdapi.AuthProviderConfig{
+							Name: "oidc",
 						},
+						Extensions: map[string]runtime.Object{},
 					},
 				},
+				Clusters:   map[string]*clientcmdapi.Cluster{},
+				Contexts:   map[string]*clientcmdapi.Context{},
 				Extensions: map[string]runtime.Object{},
+				Preferences: clientcmdapi.Preferences{
+					Colors:     false,
+					Extensions: map[string]runtime.Object{},
+				},
 			},
 		},
-		Clusters:   map[string]*clientcmdapi.Cluster{},
-		Contexts:   map[string]*clientcmdapi.Context{},
-		Extensions: map[string]runtime.Object{},
-		Preferences: clientcmdapi.Preferences{
-			Colors:     false,
-			Extensions: map[string]runtime.Object{},
+		{
+			name:        "SetAuthProviderConfigMap",
+			description: "Testing for kubectl config set users.foo.auth-provider.config.refresh-token to test",
+			config:      conf,
+			args:        []string{"users.foo.auth-provider.config.refresh-token", "test"},
+			expected:    `Property "users.foo.auth-provider.config.refresh-token" set.` + "\n",
+			expectedConfig: clientcmdapi.Config{
+				AuthInfos: map[string]*clientcmdapi.AuthInfo{
+					"foo": {
+						AuthProvider: &clientcmdapi.AuthProviderConfig{
+							Name: "",
+							Config: map[string]string{
+								"refresh-token": "test",
+							},
+						},
+						Extensions: map[string]runtime.Object{},
+					},
+				},
+				Clusters:   map[string]*clientcmdapi.Cluster{},
+				Contexts:   map[string]*clientcmdapi.Context{},
+				Extensions: map[string]runtime.Object{},
+				Preferences: clientcmdapi.Preferences{
+					Colors:     false,
+					Extensions: map[string]runtime.Object{},
+				},
+			},
+		},
+		{
+			name:        "SetAuthProviderConfigMapMalformed",
+			description: "Testing for kubectl config set users.foo.auth-provider.config to test",
+			config:      conf,
+			args:        []string{"users.foo.auth-provider.config", "test"},
+			expectedErr: `empty key provided for map`,
+		},
+		{
+			name:        "SetAuthInfoExecCommand",
+			description: "Testing for kubectl config set users.foo.exec.command to test",
+			config:      conf,
+			args:        []string{"users.foo.exec.command", "test"},
+			expected:    `Property "users.foo.exec.command" set.` + "\n",
+			expectedConfig: clientcmdapi.Config{
+				AuthInfos: map[string]*clientcmdapi.AuthInfo{
+					"foo": {
+						Exec: &clientcmdapi.ExecConfig{
+							Command: "test",
+						},
+						Extensions: map[string]runtime.Object{},
+					},
+				},
+				Clusters:   map[string]*clientcmdapi.Cluster{},
+				Contexts:   map[string]*clientcmdapi.Context{},
+				Extensions: map[string]runtime.Object{},
+				Preferences: clientcmdapi.Preferences{
+					Colors:     false,
+					Extensions: map[string]runtime.Object{},
+				},
+			},
+		},
+		{
+			name:        "SetAuthInfoExecArgs",
+			description: "Testing for kubectl config set users.foo.exec.args to test1,test2,test3",
+			config:      conf,
+			args:        []string{"users.foo.exec.args", "test1,test2,test3"},
+			expected:    `Property "users.foo.exec.args" set.` + "\n",
+			expectedConfig: clientcmdapi.Config{
+				AuthInfos: map[string]*clientcmdapi.AuthInfo{
+					"foo": {
+						Exec: &clientcmdapi.ExecConfig{
+							Args: []string{
+								"test1",
+								"test2",
+								"test3",
+							},
+						},
+						Extensions: map[string]runtime.Object{},
+					},
+				},
+				Clusters:   map[string]*clientcmdapi.Cluster{},
+				Contexts:   map[string]*clientcmdapi.Context{},
+				Extensions: map[string]runtime.Object{},
+				Preferences: clientcmdapi.Preferences{
+					Colors:     false,
+					Extensions: map[string]runtime.Object{},
+				},
+			},
+		},
+		{
+			name:        "SetAuthInfoProvideClusterInfo",
+			description: "Testing for kubectl config set users.foo.exec.provideClusterInfo to true",
+			config:      conf,
+			args:        []string{"users.foo.exec.provideClusterInfo", "true"},
+			expected:    `Property "users.foo.exec.provideClusterInfo" set.` + "\n",
+			expectedConfig: clientcmdapi.Config{
+				AuthInfos: map[string]*clientcmdapi.AuthInfo{
+					"foo": {
+						Exec: &clientcmdapi.ExecConfig{
+							ProvideClusterInfo: true,
+						},
+						Extensions: map[string]runtime.Object{},
+					},
+				},
+				Clusters:   map[string]*clientcmdapi.Cluster{},
+				Contexts:   map[string]*clientcmdapi.Context{},
+				Extensions: map[string]runtime.Object{},
+				Preferences: clientcmdapi.Preferences{
+					Colors:     false,
+					Extensions: map[string]runtime.Object{},
+				},
+			},
+		},
+		{
+			name:        "SetAuthInfoExecEnvVar",
+			description: "Testing for kubectl config set users.foo.exec.env.name.test to value:val1",
+			config:      conf,
+			args:        []string{"users.foo.exec.env.name.test", "value:val1"},
+			expected:    `Property "users.foo.exec.env.name.test" set.` + "\n",
+			expectedConfig: clientcmdapi.Config{
+				AuthInfos: map[string]*clientcmdapi.AuthInfo{
+					"foo": {
+						Exec: &clientcmdapi.ExecConfig{
+							Env: []clientcmdapi.ExecEnvVar{
+								{
+									Name:  "test",
+									Value: "val1",
+								},
+							},
+						},
+						Extensions: map[string]runtime.Object{},
+					},
+				},
+				Clusters:   map[string]*clientcmdapi.Cluster{},
+				Contexts:   map[string]*clientcmdapi.Context{},
+				Extensions: map[string]runtime.Object{},
+				Preferences: clientcmdapi.Preferences{
+					Colors:     false,
+					Extensions: map[string]runtime.Object{},
+				},
+			},
+		},
+		{
+			name:        "SetAuthInfoExecEnvVarMalformed",
+			description: "Testing for kubectl config set users.foo.exec.env.name.test to value2",
+			config:      conf,
+			args:        []string{"users.foo.exec.env.name.test", "value2"},
+			expectedErr: `error parsing field name for value, should be of format fieldName:fieldValue`,
+		},
+		{
+			name:        "SetAuthInfoExecInstallHint",
+			description: "Testing for kubectl config set users.foo.exec.installHint to test",
+			config:      conf,
+			args:        []string{"users.foo.exec.installHint", "test"},
+			expected:    `Property "users.foo.exec.installHint" set.` + "\n",
+			expectedConfig: clientcmdapi.Config{
+				AuthInfos: map[string]*clientcmdapi.AuthInfo{
+					"foo": {
+						Exec: &clientcmdapi.ExecConfig{
+							InstallHint: "test",
+						},
+						Extensions: map[string]runtime.Object{},
+					},
+				},
+				Clusters:   map[string]*clientcmdapi.Cluster{},
+				Contexts:   map[string]*clientcmdapi.Context{},
+				Extensions: map[string]runtime.Object{},
+				Preferences: clientcmdapi.Preferences{
+					Colors:     false,
+					Extensions: map[string]runtime.Object{},
+				},
+			},
+		},
+		{
+			name:        "SetAuthInfoActAsUser",
+			description: "Testing for kubectl config set users.foo.act-as to test1",
+			config:      conf,
+			args:        []string{"users.foo.act-as", "test1"},
+			expected:    `Property "users.foo.act-as" set.` + "\n",
+			expectedConfig: clientcmdapi.Config{
+				AuthInfos: map[string]*clientcmdapi.AuthInfo{
+					"foo": {
+						Impersonate: "test1",
+						Extensions:  map[string]runtime.Object{},
+					},
+				},
+				Clusters:   map[string]*clientcmdapi.Cluster{},
+				Contexts:   map[string]*clientcmdapi.Context{},
+				Extensions: map[string]runtime.Object{},
+				Preferences: clientcmdapi.Preferences{
+					Colors:     false,
+					Extensions: map[string]runtime.Object{},
+				},
+			},
+		},
+		{
+			name:        "SetAuthInfoActUid",
+			description: "Testing for kubectl config set users.foo.act-as-uid to 1000",
+			config:      conf,
+			args:        []string{"users.foo.act-as-uid", "1000"},
+			expected:    `Property "users.foo.act-as-uid" set.` + "\n",
+			expectedConfig: clientcmdapi.Config{
+				AuthInfos: map[string]*clientcmdapi.AuthInfo{
+					"foo": {
+						ImpersonateUID: "1000",
+						Extensions:     map[string]runtime.Object{},
+					},
+				},
+				Clusters:   map[string]*clientcmdapi.Cluster{},
+				Contexts:   map[string]*clientcmdapi.Context{},
+				Extensions: map[string]runtime.Object{},
+				Preferences: clientcmdapi.Preferences{
+					Colors:     false,
+					Extensions: map[string]runtime.Object{},
+				},
+			},
+		},
+		{
+			name:        "SetAuthInfoActAsGroups",
+			description: "Testing for kubectl config set users.foo.act-as-groups to test1,test2,test3",
+			config:      conf,
+			args:        []string{"users.foo.act-as-groups", "test1,test2,test3"},
+			expected:    `Property "users.foo.act-as-groups" set.` + "\n",
+			expectedConfig: clientcmdapi.Config{
+				AuthInfos: map[string]*clientcmdapi.AuthInfo{
+					"foo": {
+						ImpersonateGroups: []string{
+							"test1",
+							"test2",
+							"test3",
+						},
+						Extensions: map[string]runtime.Object{},
+					},
+				},
+				Clusters:   map[string]*clientcmdapi.Cluster{},
+				Contexts:   map[string]*clientcmdapi.Context{},
+				Extensions: map[string]runtime.Object{},
+				Preferences: clientcmdapi.Preferences{
+					Colors:     false,
+					Extensions: map[string]runtime.Object{},
+				},
+			},
+		},
+		{
+			name:        "SetAuthInfoActAsUserExtra",
+			description: "Testing for kubectl config set users.foo.act-as-user-extra.test1 to val1,val2,val3",
+			config:      conf,
+			args:        []string{"users.foo.act-as-user-extra.test1", "val1,val2,val3"},
+			expected:    `Property "users.foo.act-as-user-extra.test1" set.` + "\n",
+			expectedConfig: clientcmdapi.Config{
+				AuthInfos: map[string]*clientcmdapi.AuthInfo{
+					"foo": {
+						ImpersonateUserExtra: map[string][]string{
+							"test1": {
+								"val1",
+								"val2",
+								"val3",
+							},
+						},
+						Extensions: map[string]runtime.Object{},
+					},
+				},
+				Clusters:   map[string]*clientcmdapi.Cluster{},
+				Contexts:   map[string]*clientcmdapi.Context{},
+				Extensions: map[string]runtime.Object{},
+				Preferences: clientcmdapi.Preferences{
+					Colors:     false,
+					Extensions: map[string]runtime.Object{},
+				},
+			},
+		},
+		{
+			name:        "SetAuthInfoUsername",
+			description: "Testing for kubectl config set users.foo.username to test1",
+			config:      conf,
+			args:        []string{"users.foo.username", "test1"},
+			expected:    `Property "users.foo.username" set.` + "\n",
+			expectedConfig: clientcmdapi.Config{
+				AuthInfos: map[string]*clientcmdapi.AuthInfo{
+					"foo": {
+						Username:   "test1",
+						Extensions: map[string]runtime.Object{},
+					},
+				},
+				Clusters:   map[string]*clientcmdapi.Cluster{},
+				Contexts:   map[string]*clientcmdapi.Context{},
+				Extensions: map[string]runtime.Object{},
+				Preferences: clientcmdapi.Preferences{
+					Colors:     false,
+					Extensions: map[string]runtime.Object{},
+				},
+			},
+		},
+		{
+			name:        "SetAuthInfoPassword",
+			description: "Testing for kubectl config set users.foo.password to abadpassword",
+			config:      conf,
+			args:        []string{"users.foo.password", "abadpassword"},
+			expected:    `Property "users.foo.password" set.` + "\n",
+			expectedConfig: clientcmdapi.Config{
+				AuthInfos: map[string]*clientcmdapi.AuthInfo{
+					"foo": {
+						Password:   "abadpassword",
+						Extensions: map[string]runtime.Object{},
+					},
+				},
+				Clusters:   map[string]*clientcmdapi.Cluster{},
+				Contexts:   map[string]*clientcmdapi.Context{},
+				Extensions: map[string]runtime.Object{},
+				Preferences: clientcmdapi.Preferences{
+					Colors:     false,
+					Extensions: map[string]runtime.Object{},
+				},
+			},
+		},
+		{
+			name:        "SetAuthInfoClientCertificate",
+			description: "Testing for kubectl config set users.foo.client-certificate to ./file/path",
+			config:      conf,
+			args:        []string{"users.foo.client-certificate", "./file/path"},
+			expected:    `Property "users.foo.client-certificate" set.` + "\n",
+			expectedConfig: clientcmdapi.Config{
+				AuthInfos: map[string]*clientcmdapi.AuthInfo{
+					"foo": {
+						ClientCertificate: "./file/path",
+						Extensions:        map[string]runtime.Object{},
+					},
+				},
+				Clusters:   map[string]*clientcmdapi.Cluster{},
+				Contexts:   map[string]*clientcmdapi.Context{},
+				Extensions: map[string]runtime.Object{},
+				Preferences: clientcmdapi.Preferences{
+					Colors:     false,
+					Extensions: map[string]runtime.Object{},
+				},
+			},
+		},
+		{
+			name:        "SetAuthInfoClientCertificateData",
+			description: "Testing for kubectl config set users.foo.client-certificate-data to not real cert data",
+			config:      conf,
+			args:        []string{"users.foo.client-certificate-data", "--set-raw-bytes=true", "not real cert data"},
+			expected:    `Property "users.foo.client-certificate-data" set.` + "\n",
+			expectedConfig: clientcmdapi.Config{
+				AuthInfos: map[string]*clientcmdapi.AuthInfo{
+					"foo": {
+						ClientCertificateData: []byte("not real cert data"),
+						Extensions:            map[string]runtime.Object{},
+					},
+				},
+				Clusters:   map[string]*clientcmdapi.Cluster{},
+				Contexts:   map[string]*clientcmdapi.Context{},
+				Extensions: map[string]runtime.Object{},
+				Preferences: clientcmdapi.Preferences{
+					Colors:     false,
+					Extensions: map[string]runtime.Object{},
+				},
+			},
+		},
+		{
+			name:        "SetAuthInfoClientKey",
+			description: "Testing for kubectl config set users.foo.client-key to ./file/path",
+			config:      conf,
+			args:        []string{"users.foo.client-key", "./file/path"},
+			expected:    `Property "users.foo.client-key" set.` + "\n",
+			expectedConfig: clientcmdapi.Config{
+				AuthInfos: map[string]*clientcmdapi.AuthInfo{
+					"foo": {
+						ClientKey:  "./file/path",
+						Extensions: map[string]runtime.Object{},
+					},
+				},
+				Clusters:   map[string]*clientcmdapi.Cluster{},
+				Contexts:   map[string]*clientcmdapi.Context{},
+				Extensions: map[string]runtime.Object{},
+				Preferences: clientcmdapi.Preferences{
+					Colors:     false,
+					Extensions: map[string]runtime.Object{},
+				},
+			},
+		},
+		{
+			name:        "SetAuthInfoClientKeyData",
+			description: "Testing for kubectl config set users.foo.client-key-data to not real key data",
+			config:      conf,
+			args:        []string{"users.foo.client-key-data", "--set-raw-bytes=true", "not real key data"},
+			expected:    `Property "users.foo.client-key-data" set.` + "\n",
+			expectedConfig: clientcmdapi.Config{
+				AuthInfos: map[string]*clientcmdapi.AuthInfo{
+					"foo": {
+						ClientKeyData: []byte("not real key data"),
+						Extensions:    map[string]runtime.Object{},
+					},
+				},
+				Clusters:   map[string]*clientcmdapi.Cluster{},
+				Contexts:   map[string]*clientcmdapi.Context{},
+				Extensions: map[string]runtime.Object{},
+				Preferences: clientcmdapi.Preferences{
+					Colors:     false,
+					Extensions: map[string]runtime.Object{},
+				},
+			},
+		},
+		{
+			name:        "SetAuthInfoToken",
+			description: "Testing for kubectl config set users.foo.token to fake token data",
+			config:      conf,
+			args:        []string{"users.foo.token", "fake token data"},
+			expected:    `Property "users.foo.token" set.` + "\n",
+			expectedConfig: clientcmdapi.Config{
+				AuthInfos: map[string]*clientcmdapi.AuthInfo{
+					"foo": {
+						Token:      "fake token data",
+						Extensions: map[string]runtime.Object{},
+					},
+				},
+				Clusters:   map[string]*clientcmdapi.Cluster{},
+				Contexts:   map[string]*clientcmdapi.Context{},
+				Extensions: map[string]runtime.Object{},
+				Preferences: clientcmdapi.Preferences{
+					Colors:     false,
+					Extensions: map[string]runtime.Object{},
+				},
+			},
+		},
+		{
+			name:        "SetAuthInfoTokenFile",
+			description: "Testing for kubectl config set users.foo.tokenFile to ./file/path",
+			config:      conf,
+			args:        []string{"users.foo.tokenFile", "./file/path"},
+			expected:    `Property "users.foo.tokenFile" set.` + "\n",
+			expectedConfig: clientcmdapi.Config{
+				AuthInfos: map[string]*clientcmdapi.AuthInfo{
+					"foo": {
+						TokenFile:  "./file/path",
+						Extensions: map[string]runtime.Object{},
+					},
+				},
+				Clusters:   map[string]*clientcmdapi.Cluster{},
+				Contexts:   map[string]*clientcmdapi.Context{},
+				Extensions: map[string]runtime.Object{},
+				Preferences: clientcmdapi.Preferences{
+					Colors:     false,
+					Extensions: map[string]runtime.Object{},
+				},
+			},
+		},
+		{
+			name:        "SetAuthProviderMalformed",
+			description: "Testing for kubectl config set users.foo.auth-provider to test error",
+			config:      conf,
+			args:        []string{"users.foo.auth-provider", "test"},
+			expectedErr: `unable to locate path auth-provider`,
 		},
 	}
-	expectedConfig.Extensions = map[string]runtime.Object{}
-	test := setConfigTest{
-		description:    "Testing for kubectl config set users.foo.exec.env.name.test to value:val1",
-		config:         conf,
-		args:           []string{"users.foo.exec.env.name.test", "value:val1"},
-		expected:       `Property "users.foo.exec.env.name.test" set.` + "\n",
-		expectedConfig: expectedConfig,
+	for _, test := range tests {
+		test.run(t)
 	}
-	test.run(t)
 }
 
-func TestSetConfigExecEnvUpdate(t *testing.T) {
+func TestFromExistingConfig(t *testing.T) {
 	conf := clientcmdapi.Config{
 		AuthInfos: map[string]*clientcmdapi.AuthInfo{
 			"foo": {
 				Exec: &clientcmdapi.ExecConfig{
+					Args: []string{
+						"test1",
+						"test2",
+						"test3",
+					},
 					Env: []clientcmdapi.ExecEnvVar{
 						{
 							Name:  "test",
@@ -435,814 +542,599 @@ func TestSetConfigExecEnvUpdate(t *testing.T) {
 					},
 				},
 				Extensions: map[string]runtime.Object{},
+				ImpersonateGroups: []string{
+					"test1",
+					"test2",
+					"test3",
+				},
+				ImpersonateUserExtra: map[string][]string{
+					"test1": {
+						"val1",
+						"val2",
+						"val3",
+					},
+				},
 			},
 		},
-		Clusters:   map[string]*clientcmdapi.Cluster{},
-		Contexts:   map[string]*clientcmdapi.Context{},
-		Extensions: map[string]runtime.Object{},
+		Clusters:       map[string]*clientcmdapi.Cluster{},
+		Contexts:       map[string]*clientcmdapi.Context{},
+		CurrentContext: "minikube",
+		Extensions:     map[string]runtime.Object{},
 		Preferences: clientcmdapi.Preferences{
 			Colors:     false,
 			Extensions: map[string]runtime.Object{},
 		},
 	}
-	expectedConfig := clientcmdapi.Config{
-		AuthInfos: map[string]*clientcmdapi.AuthInfo{
-			"foo": {
-				Exec: &clientcmdapi.ExecConfig{
-					Env: []clientcmdapi.ExecEnvVar{
-						{
-							Name:  "test",
-							Value: "value2",
+	tests := []setConfigTest{
+		{
+			name:        "SetCurrentContext",
+			description: "Testing for kubectl config set current-context",
+			config:      conf,
+			args:        []string{"current-context", "my-cluster"},
+			expected:    `Property "current-context" set.` + "\n",
+			expectedConfig: clientcmdapi.Config{
+				AuthInfos: map[string]*clientcmdapi.AuthInfo{
+					"foo": {
+						Exec: &clientcmdapi.ExecConfig{
+							Args: []string{
+								"test1",
+								"test2",
+								"test3",
+							},
+							Env: []clientcmdapi.ExecEnvVar{
+								{
+									Name:  "test",
+									Value: "value1",
+								},
+							},
+						},
+						Extensions: map[string]runtime.Object{},
+						ImpersonateGroups: []string{
+							"test1",
+							"test2",
+							"test3",
+						},
+						ImpersonateUserExtra: map[string][]string{
+							"test1": {
+								"val1",
+								"val2",
+								"val3",
+							},
 						},
 					},
 				},
-				Extensions: map[string]runtime.Object{},
-			},
-		},
-		Clusters:   map[string]*clientcmdapi.Cluster{},
-		Contexts:   map[string]*clientcmdapi.Context{},
-		Extensions: map[string]runtime.Object{},
-		Preferences: clientcmdapi.Preferences{
-			Colors:     false,
-			Extensions: map[string]runtime.Object{},
-		},
-	}
-	expectedConfig.Extensions = map[string]runtime.Object{}
-	test := setConfigTest{
-		description:    "Testing for kubectl config set users.foo.exec.env.name.test to value:value2",
-		config:         conf,
-		args:           []string{"users.foo.exec.env.name.test", "value:value2"},
-		expected:       `Property "users.foo.exec.env.name.test" set.` + "\n",
-		expectedConfig: expectedConfig,
-	}
-	test.run(t)
-}
-
-func TestSetConfigExecEnvMalformedValue(t *testing.T) {
-	conf := *clientcmdapi.NewConfig()
-	test := setConfigTest{
-		description: "Testing for kubectl config set users.foo.exec.env.name.test to value2",
-		config:      conf,
-		args:        []string{"users.foo.exec.env.name.test", "value2"},
-		expectedErr: `error parsing field name for value, should be of format fieldName:fieldValue`,
-	}
-	test.run(t)
-}
-
-func TestSetConfigInstallHint(t *testing.T) {
-	conf := *clientcmdapi.NewConfig()
-	expectedConfig := clientcmdapi.Config{
-		AuthInfos: map[string]*clientcmdapi.AuthInfo{
-			"foo": {
-				Exec: &clientcmdapi.ExecConfig{
-					InstallHint: "test",
-				},
-				Extensions: map[string]runtime.Object{},
-			},
-		},
-		Clusters:   map[string]*clientcmdapi.Cluster{},
-		Contexts:   map[string]*clientcmdapi.Context{},
-		Extensions: map[string]runtime.Object{},
-		Preferences: clientcmdapi.Preferences{
-			Colors:     false,
-			Extensions: map[string]runtime.Object{},
-		},
-	}
-	expectedConfig.Extensions = map[string]runtime.Object{}
-	test := setConfigTest{
-		description:    "Testing for kubectl config set users.foo.exec.installHint to test",
-		config:         conf,
-		args:           []string{"users.foo.exec.installHint", "test"},
-		expected:       `Property "users.foo.exec.installHint" set.` + "\n",
-		expectedConfig: expectedConfig,
-	}
-	test.run(t)
-}
-
-func TestSetConfigImpersonateUser(t *testing.T) {
-	conf := *clientcmdapi.NewConfig()
-	expectedConfig := clientcmdapi.Config{
-		AuthInfos: map[string]*clientcmdapi.AuthInfo{
-			"foo": {
-				Impersonate: "test1",
-				Extensions:  map[string]runtime.Object{},
-			},
-		},
-		Clusters:   map[string]*clientcmdapi.Cluster{},
-		Contexts:   map[string]*clientcmdapi.Context{},
-		Extensions: map[string]runtime.Object{},
-		Preferences: clientcmdapi.Preferences{
-			Colors:     false,
-			Extensions: map[string]runtime.Object{},
-		},
-	}
-	expectedConfig.Extensions = map[string]runtime.Object{}
-	test := setConfigTest{
-		description:    "Testing for kubectl config set users.foo.act-as to test1",
-		config:         conf,
-		args:           []string{"users.foo.act-as", "test1"},
-		expected:       `Property "users.foo.act-as" set.` + "\n",
-		expectedConfig: expectedConfig,
-	}
-	test.run(t)
-}
-
-func TestSetConfigImpersonateUID(t *testing.T) {
-	conf := *clientcmdapi.NewConfig()
-	expectedConfig := clientcmdapi.Config{
-		AuthInfos: map[string]*clientcmdapi.AuthInfo{
-			"foo": {
-				ImpersonateUID: "1000",
+				Clusters:       map[string]*clientcmdapi.Cluster{},
+				Contexts:       map[string]*clientcmdapi.Context{},
+				CurrentContext: "my-cluster",
 				Extensions:     map[string]runtime.Object{},
-			},
-		},
-		Clusters:   map[string]*clientcmdapi.Cluster{},
-		Contexts:   map[string]*clientcmdapi.Context{},
-		Extensions: map[string]runtime.Object{},
-		Preferences: clientcmdapi.Preferences{
-			Colors:     false,
-			Extensions: map[string]runtime.Object{},
-		},
-	}
-	expectedConfig.Extensions = map[string]runtime.Object{}
-	test := setConfigTest{
-		description:    "Testing for kubectl config set users.foo.act-as to 1000",
-		config:         conf,
-		args:           []string{"users.foo.act-as-uid", "1000"},
-		expected:       `Property "users.foo.act-as-uid" set.` + "\n",
-		expectedConfig: expectedConfig,
-	}
-	test.run(t)
-}
-
-func TestSetConfigImpersonateGroupsNew(t *testing.T) {
-	conf := *clientcmdapi.NewConfig()
-	expectedConfig := clientcmdapi.Config{
-		AuthInfos: map[string]*clientcmdapi.AuthInfo{
-			"foo": {
-				ImpersonateGroups: []string{
-					"test1",
-					"test2",
-					"test3",
+				Preferences: clientcmdapi.Preferences{
+					Colors:     false,
+					Extensions: map[string]runtime.Object{},
 				},
-				Extensions: map[string]runtime.Object{},
 			},
 		},
-		Clusters:   map[string]*clientcmdapi.Cluster{},
-		Contexts:   map[string]*clientcmdapi.Context{},
-		Extensions: map[string]runtime.Object{},
-		Preferences: clientcmdapi.Preferences{
-			Colors:     false,
-			Extensions: map[string]runtime.Object{},
-		},
-	}
-	expectedConfig.Extensions = map[string]runtime.Object{}
-	test := setConfigTest{
-		description:    "Testing for kubectl config set users.foo.act-as-groups to test1,test2,test3",
-		config:         conf,
-		args:           []string{"users.foo.act-as-groups", "test1,test2,test3"},
-		expected:       `Property "users.foo.act-as-groups" set.` + "\n",
-		expectedConfig: expectedConfig,
-	}
-	test.run(t)
-}
-
-func TestSetConfigImpersonateGroupsAdd(t *testing.T) {
-	conf := clientcmdapi.Config{
-		AuthInfos: map[string]*clientcmdapi.AuthInfo{
-			"foo": {
-				ImpersonateGroups: []string{
-					"test1",
-					"test2",
-					"test3",
-				},
-				Extensions: map[string]runtime.Object{},
-			},
-		},
-		Clusters:   map[string]*clientcmdapi.Cluster{},
-		Contexts:   map[string]*clientcmdapi.Context{},
-		Extensions: map[string]runtime.Object{},
-		Preferences: clientcmdapi.Preferences{
-			Colors:     false,
-			Extensions: map[string]runtime.Object{},
-		},
-	}
-	expectedConfig := clientcmdapi.Config{
-		AuthInfos: map[string]*clientcmdapi.AuthInfo{
-			"foo": {
-				ImpersonateGroups: []string{
-					"test1",
-					"test2",
-					"test3",
-					"test4",
-				},
-				Extensions: map[string]runtime.Object{},
-			},
-		},
-		Clusters:   map[string]*clientcmdapi.Cluster{},
-		Contexts:   map[string]*clientcmdapi.Context{},
-		Extensions: map[string]runtime.Object{},
-		Preferences: clientcmdapi.Preferences{
-			Colors:     false,
-			Extensions: map[string]runtime.Object{},
-		},
-	}
-	expectedConfig.Extensions = map[string]runtime.Object{}
-	test := setConfigTest{
-		description:    "Testing for kubectl config set users.foo.act-as-groups to test4+",
-		config:         conf,
-		args:           []string{"users.foo.act-as-groups", "test4+"},
-		expected:       `Property "users.foo.act-as-groups" set.` + "\n",
-		expectedConfig: expectedConfig,
-	}
-	test.run(t)
-}
-
-func TestSetConfigImpersonateGroupsDelete(t *testing.T) {
-	conf := clientcmdapi.Config{
-		AuthInfos: map[string]*clientcmdapi.AuthInfo{
-			"foo": {
-				ImpersonateGroups: []string{
-					"test1",
-					"test2",
-					"test3",
-				},
-				Extensions: map[string]runtime.Object{},
-			},
-		},
-		Clusters:   map[string]*clientcmdapi.Cluster{},
-		Contexts:   map[string]*clientcmdapi.Context{},
-		Extensions: map[string]runtime.Object{},
-		Preferences: clientcmdapi.Preferences{
-			Colors:     false,
-			Extensions: map[string]runtime.Object{},
-		},
-	}
-	expectedConfig := clientcmdapi.Config{
-		AuthInfos: map[string]*clientcmdapi.AuthInfo{
-			"foo": {
-				ImpersonateGroups: []string{
-					"test1",
-					"test2",
-				},
-				Extensions: map[string]runtime.Object{},
-			},
-		},
-		Clusters:   map[string]*clientcmdapi.Cluster{},
-		Contexts:   map[string]*clientcmdapi.Context{},
-		Extensions: map[string]runtime.Object{},
-		Preferences: clientcmdapi.Preferences{
-			Colors:     false,
-			Extensions: map[string]runtime.Object{},
-		},
-	}
-	expectedConfig.Extensions = map[string]runtime.Object{}
-	test := setConfigTest{
-		description:    "Testing for kubectl config set users.foo.act-as-groups to test3-",
-		config:         conf,
-		args:           []string{"users.foo.act-as-groups", "test3-"},
-		expected:       `Property "users.foo.act-as-groups" set.` + "\n",
-		expectedConfig: expectedConfig,
-	}
-	test.run(t)
-}
-
-func TestSetConfigImpersonateGroupsUpdate(t *testing.T) {
-	conf := clientcmdapi.Config{
-		AuthInfos: map[string]*clientcmdapi.AuthInfo{
-			"foo": {
-				ImpersonateGroups: []string{
-					"test1",
-					"test2",
-					"test3",
-					"test4",
-				},
-				Extensions: map[string]runtime.Object{},
-			},
-		},
-		Clusters:   map[string]*clientcmdapi.Cluster{},
-		Contexts:   map[string]*clientcmdapi.Context{},
-		Extensions: map[string]runtime.Object{},
-		Preferences: clientcmdapi.Preferences{
-			Colors:     false,
-			Extensions: map[string]runtime.Object{},
-		},
-	}
-	expectedConfig := clientcmdapi.Config{
-		AuthInfos: map[string]*clientcmdapi.AuthInfo{
-			"foo": {
-				ImpersonateGroups: []string{
-					"test8",
-					"test9",
-				},
-				Extensions: map[string]runtime.Object{},
-			},
-		},
-		Clusters:   map[string]*clientcmdapi.Cluster{},
-		Contexts:   map[string]*clientcmdapi.Context{},
-		Extensions: map[string]runtime.Object{},
-		Preferences: clientcmdapi.Preferences{
-			Colors:     false,
-			Extensions: map[string]runtime.Object{},
-		},
-	}
-	expectedConfig.Extensions = map[string]runtime.Object{}
-	test := setConfigTest{
-		description:    "Testing for kubectl config set users.foo.act-as-groups to test8,test9",
-		config:         conf,
-		args:           []string{"users.foo.act-as-groups", "test8,test9"},
-		expected:       `Property "users.foo.act-as-groups" set.` + "\n",
-		expectedConfig: expectedConfig,
-	}
-	test.run(t)
-}
-
-func TestSetConfigImpersonateUserExtraNew(t *testing.T) {
-	conf := *clientcmdapi.NewConfig()
-	expectedConfig := clientcmdapi.Config{
-		AuthInfos: map[string]*clientcmdapi.AuthInfo{
-			"foo": {
-				ImpersonateUserExtra: map[string][]string{
-					"test1": {
-						"val1",
-						"val2",
-						"val3",
+		{
+			name:        "AddExecArg",
+			description: "Testing for kubectl config set users.foo.exec.args to test4+",
+			config:      conf,
+			args:        []string{"users.foo.exec.args", "test4+"},
+			expected:    `Property "users.foo.exec.args" set.` + "\n",
+			expectedConfig: clientcmdapi.Config{
+				AuthInfos: map[string]*clientcmdapi.AuthInfo{
+					"foo": {
+						Exec: &clientcmdapi.ExecConfig{
+							Args: []string{
+								"test1",
+								"test2",
+								"test3",
+								"test4",
+							},
+							Env: []clientcmdapi.ExecEnvVar{
+								{
+									Name:  "test",
+									Value: "value1",
+								},
+							},
+						},
+						Extensions: map[string]runtime.Object{},
+						ImpersonateGroups: []string{
+							"test1",
+							"test2",
+							"test3",
+						},
+						ImpersonateUserExtra: map[string][]string{
+							"test1": {
+								"val1",
+								"val2",
+								"val3",
+							},
+						},
 					},
 				},
-				Extensions: map[string]runtime.Object{},
+				Clusters:       map[string]*clientcmdapi.Cluster{},
+				Contexts:       map[string]*clientcmdapi.Context{},
+				CurrentContext: "minikube",
+				Extensions:     map[string]runtime.Object{},
+				Preferences: clientcmdapi.Preferences{
+					Colors:     false,
+					Extensions: map[string]runtime.Object{},
+				},
 			},
 		},
-		Clusters:   map[string]*clientcmdapi.Cluster{},
-		Contexts:   map[string]*clientcmdapi.Context{},
-		Extensions: map[string]runtime.Object{},
-		Preferences: clientcmdapi.Preferences{
-			Colors:     false,
-			Extensions: map[string]runtime.Object{},
-		},
-	}
-	expectedConfig.Extensions = map[string]runtime.Object{}
-	test := setConfigTest{
-		description:    "Testing for kubectl config set users.foo.act-as-user-extra.test1 to val1,val2,val3",
-		config:         conf,
-		args:           []string{"users.foo.act-as-user-extra.test1", "val1,val2,val3"},
-		expected:       `Property "users.foo.act-as-user-extra.test1" set.` + "\n",
-		expectedConfig: expectedConfig,
-	}
-	test.run(t)
-}
-
-func TestSetConfigImpersonateUserExtraAdd(t *testing.T) {
-	conf := clientcmdapi.Config{
-		AuthInfos: map[string]*clientcmdapi.AuthInfo{
-			"foo": {
-				ImpersonateUserExtra: map[string][]string{
-					"test1": {
-						"val1",
-						"val2",
-						"val3",
+		{
+			name:        "DeleteExecArg",
+			description: "Testing for kubectl config set users.foo.exec.args to test2-",
+			config:      conf,
+			args:        []string{"users.foo.exec.args", "test2-"},
+			expected:    `Property "users.foo.exec.args" set.` + "\n",
+			expectedConfig: clientcmdapi.Config{
+				AuthInfos: map[string]*clientcmdapi.AuthInfo{
+					"foo": {
+						Exec: &clientcmdapi.ExecConfig{
+							Args: []string{
+								"test1",
+								"test3",
+							},
+							Env: []clientcmdapi.ExecEnvVar{
+								{
+									Name:  "test",
+									Value: "value1",
+								},
+							},
+						},
+						Extensions: map[string]runtime.Object{},
+						ImpersonateGroups: []string{
+							"test1",
+							"test2",
+							"test3",
+						},
+						ImpersonateUserExtra: map[string][]string{
+							"test1": {
+								"val1",
+								"val2",
+								"val3",
+							},
+						},
 					},
 				},
-				Extensions: map[string]runtime.Object{},
+				Clusters:       map[string]*clientcmdapi.Cluster{},
+				Contexts:       map[string]*clientcmdapi.Context{},
+				CurrentContext: "minikube",
+				Extensions:     map[string]runtime.Object{},
+				Preferences: clientcmdapi.Preferences{
+					Colors:     false,
+					Extensions: map[string]runtime.Object{},
+				},
 			},
 		},
-		Clusters:   map[string]*clientcmdapi.Cluster{},
-		Contexts:   map[string]*clientcmdapi.Context{},
-		Extensions: map[string]runtime.Object{},
-		Preferences: clientcmdapi.Preferences{
-			Colors:     false,
-			Extensions: map[string]runtime.Object{},
-		},
-	}
-	expectedConfig := clientcmdapi.Config{
-		AuthInfos: map[string]*clientcmdapi.AuthInfo{
-			"foo": {
-				ImpersonateUserExtra: map[string][]string{
-					"test1": {
-						"val1",
-						"val2",
-						"val3",
-						"val4",
+		{
+			name:        "UpdateExecArgs",
+			description: "Testing for kubectl config set users.foo.exec.args to test1,test3",
+			config:      conf,
+			args:        []string{"users.foo.exec.args", "test4,test5"},
+			expected:    `Property "users.foo.exec.args" set.` + "\n",
+			expectedConfig: clientcmdapi.Config{
+				AuthInfos: map[string]*clientcmdapi.AuthInfo{
+					"foo": {
+						Exec: &clientcmdapi.ExecConfig{
+							Args: []string{
+								"test4",
+								"test5",
+							},
+							Env: []clientcmdapi.ExecEnvVar{
+								{
+									Name:  "test",
+									Value: "value1",
+								},
+							},
+						},
+						Extensions: map[string]runtime.Object{},
+						ImpersonateGroups: []string{
+							"test1",
+							"test2",
+							"test3",
+						},
+						ImpersonateUserExtra: map[string][]string{
+							"test1": {
+								"val1",
+								"val2",
+								"val3",
+							},
+						},
 					},
 				},
-				Extensions: map[string]runtime.Object{},
+				Clusters:       map[string]*clientcmdapi.Cluster{},
+				Contexts:       map[string]*clientcmdapi.Context{},
+				CurrentContext: "minikube",
+				Extensions:     map[string]runtime.Object{},
+				Preferences: clientcmdapi.Preferences{
+					Colors:     false,
+					Extensions: map[string]runtime.Object{},
+				},
 			},
 		},
-		Clusters:   map[string]*clientcmdapi.Cluster{},
-		Contexts:   map[string]*clientcmdapi.Context{},
-		Extensions: map[string]runtime.Object{},
-		Preferences: clientcmdapi.Preferences{
-			Colors:     false,
-			Extensions: map[string]runtime.Object{},
-		},
-	}
-	expectedConfig.Extensions = map[string]runtime.Object{}
-	test := setConfigTest{
-		description:    "Testing for kubectl config set users.foo.act-as-user-extra.test1 to val4+",
-		config:         conf,
-		args:           []string{"users.foo.act-as-user-extra.test1", "val4+"},
-		expected:       `Property "users.foo.act-as-user-extra.test1" set.` + "\n",
-		expectedConfig: expectedConfig,
-	}
-	test.run(t)
-}
-
-func TestSetConfigImpersonateUserExtraDelete(t *testing.T) {
-	conf := clientcmdapi.Config{
-		AuthInfos: map[string]*clientcmdapi.AuthInfo{
-			"foo": {
-				ImpersonateUserExtra: map[string][]string{
-					"test1": {
-						"val1",
-						"val2",
-						"val3",
+		{
+			name:        "UpdateExecEnvVar",
+			description: "Testing for kubectl config set users.foo.exec.env.name.test to value:value2",
+			config:      conf,
+			args:        []string{"users.foo.exec.env.name.test", "value:value2"},
+			expected:    `Property "users.foo.exec.env.name.test" set.` + "\n",
+			expectedConfig: clientcmdapi.Config{
+				AuthInfos: map[string]*clientcmdapi.AuthInfo{
+					"foo": {
+						Exec: &clientcmdapi.ExecConfig{
+							Args: []string{
+								"test1",
+								"test2",
+								"test3",
+							},
+							Env: []clientcmdapi.ExecEnvVar{
+								{
+									Name:  "test",
+									Value: "value2",
+								},
+							},
+						},
+						Extensions: map[string]runtime.Object{},
+						ImpersonateGroups: []string{
+							"test1",
+							"test2",
+							"test3",
+						},
+						ImpersonateUserExtra: map[string][]string{
+							"test1": {
+								"val1",
+								"val2",
+								"val3",
+							},
+						},
 					},
 				},
-				Extensions: map[string]runtime.Object{},
+				Clusters:       map[string]*clientcmdapi.Cluster{},
+				Contexts:       map[string]*clientcmdapi.Context{},
+				CurrentContext: "minikube",
+				Extensions:     map[string]runtime.Object{},
+				Preferences: clientcmdapi.Preferences{
+					Colors:     false,
+					Extensions: map[string]runtime.Object{},
+				},
 			},
 		},
-		Clusters:   map[string]*clientcmdapi.Cluster{},
-		Contexts:   map[string]*clientcmdapi.Context{},
-		Extensions: map[string]runtime.Object{},
-		Preferences: clientcmdapi.Preferences{
-			Colors:     false,
-			Extensions: map[string]runtime.Object{},
-		},
-	}
-	expectedConfig := clientcmdapi.Config{
-		AuthInfos: map[string]*clientcmdapi.AuthInfo{
-			"foo": {
-				ImpersonateUserExtra: map[string][]string{
-					"test1": {
-						"val1",
-						"val2",
+		{
+			name:        "AddActAsGroups",
+			description: "Testing for kubectl config set users.foo.act-as-groups to test4+",
+			config:      conf,
+			args:        []string{"users.foo.act-as-groups", "test4+"},
+			expected:    `Property "users.foo.act-as-groups" set.` + "\n",
+			expectedConfig: clientcmdapi.Config{
+				AuthInfos: map[string]*clientcmdapi.AuthInfo{
+					"foo": {
+						Exec: &clientcmdapi.ExecConfig{
+							Args: []string{
+								"test1",
+								"test2",
+								"test3",
+							},
+							Env: []clientcmdapi.ExecEnvVar{
+								{
+									Name:  "test",
+									Value: "value1",
+								},
+							},
+						},
+						Extensions: map[string]runtime.Object{},
+						ImpersonateGroups: []string{
+							"test1",
+							"test2",
+							"test3",
+							"test4",
+						},
+						ImpersonateUserExtra: map[string][]string{
+							"test1": {
+								"val1",
+								"val2",
+								"val3",
+							},
+						},
 					},
 				},
-				Extensions: map[string]runtime.Object{},
+				Clusters:       map[string]*clientcmdapi.Cluster{},
+				Contexts:       map[string]*clientcmdapi.Context{},
+				CurrentContext: "minikube",
+				Extensions:     map[string]runtime.Object{},
+				Preferences: clientcmdapi.Preferences{
+					Colors:     false,
+					Extensions: map[string]runtime.Object{},
+				},
 			},
 		},
-		Clusters:   map[string]*clientcmdapi.Cluster{},
-		Contexts:   map[string]*clientcmdapi.Context{},
-		Extensions: map[string]runtime.Object{},
-		Preferences: clientcmdapi.Preferences{
-			Colors:     false,
-			Extensions: map[string]runtime.Object{},
-		},
-	}
-	expectedConfig.Extensions = map[string]runtime.Object{}
-	test := setConfigTest{
-		description:    "Testing for kubectl config set users.foo.act-as-user-extra.test1 to val3-",
-		config:         conf,
-		args:           []string{"users.foo.act-as-user-extra.test1", "val3-"},
-		expected:       `Property "users.foo.act-as-user-extra.test1" set.` + "\n",
-		expectedConfig: expectedConfig,
-	}
-	test.run(t)
-}
-
-func TestSetConfigImpersonateUserExtraUpdate(t *testing.T) {
-	conf := clientcmdapi.Config{
-		AuthInfos: map[string]*clientcmdapi.AuthInfo{
-			"foo": {
-				ImpersonateUserExtra: map[string][]string{
-					"test1": {
-						"val1",
-						"val2",
-						"val3",
+		{
+			name:        "DeleteActAsGroups",
+			description: "Testing for kubectl config set users.foo.act-as-groups to test3-",
+			config:      conf,
+			args:        []string{"users.foo.act-as-groups", "test3-"},
+			expected:    `Property "users.foo.act-as-groups" set.` + "\n",
+			expectedConfig: clientcmdapi.Config{
+				AuthInfos: map[string]*clientcmdapi.AuthInfo{
+					"foo": {
+						Exec: &clientcmdapi.ExecConfig{
+							Args: []string{
+								"test1",
+								"test2",
+								"test3",
+							},
+							Env: []clientcmdapi.ExecEnvVar{
+								{
+									Name:  "test",
+									Value: "value1",
+								},
+							},
+						},
+						Extensions: map[string]runtime.Object{},
+						ImpersonateGroups: []string{
+							"test1",
+							"test2",
+						},
+						ImpersonateUserExtra: map[string][]string{
+							"test1": {
+								"val1",
+								"val2",
+								"val3",
+							},
+						},
 					},
 				},
-				Extensions: map[string]runtime.Object{},
+				Clusters:       map[string]*clientcmdapi.Cluster{},
+				Contexts:       map[string]*clientcmdapi.Context{},
+				CurrentContext: "minikube",
+				Extensions:     map[string]runtime.Object{},
+				Preferences: clientcmdapi.Preferences{
+					Colors:     false,
+					Extensions: map[string]runtime.Object{},
+				},
 			},
 		},
-		Clusters:   map[string]*clientcmdapi.Cluster{},
-		Contexts:   map[string]*clientcmdapi.Context{},
-		Extensions: map[string]runtime.Object{},
-		Preferences: clientcmdapi.Preferences{
-			Colors:     false,
-			Extensions: map[string]runtime.Object{},
-		},
-	}
-	expectedConfig := clientcmdapi.Config{
-		AuthInfos: map[string]*clientcmdapi.AuthInfo{
-			"foo": {
-				ImpersonateUserExtra: map[string][]string{
-					"test1": {
-						"val5",
-						"val6",
-						"val7",
+		{
+			name:        "UpdateActAsGroups",
+			description: "Testing for kubectl config set users.foo.act-as-groups to test8,test9",
+			config:      conf,
+			args:        []string{"users.foo.act-as-groups", "test8,test9"},
+			expected:    `Property "users.foo.act-as-groups" set.` + "\n",
+			expectedConfig: clientcmdapi.Config{
+				AuthInfos: map[string]*clientcmdapi.AuthInfo{
+					"foo": {
+						Exec: &clientcmdapi.ExecConfig{
+							Args: []string{
+								"test1",
+								"test2",
+								"test3",
+							},
+							Env: []clientcmdapi.ExecEnvVar{
+								{
+									Name:  "test",
+									Value: "value1",
+								},
+							},
+						},
+						Extensions: map[string]runtime.Object{},
+						ImpersonateGroups: []string{
+							"test8",
+							"test9",
+						},
+						ImpersonateUserExtra: map[string][]string{
+							"test1": {
+								"val1",
+								"val2",
+								"val3",
+							},
+						},
 					},
 				},
-				Extensions: map[string]runtime.Object{},
+				Clusters:       map[string]*clientcmdapi.Cluster{},
+				Contexts:       map[string]*clientcmdapi.Context{},
+				CurrentContext: "minikube",
+				Extensions:     map[string]runtime.Object{},
+				Preferences: clientcmdapi.Preferences{
+					Colors:     false,
+					Extensions: map[string]runtime.Object{},
+				},
 			},
 		},
-		Clusters:   map[string]*clientcmdapi.Cluster{},
-		Contexts:   map[string]*clientcmdapi.Context{},
-		Extensions: map[string]runtime.Object{},
-		Preferences: clientcmdapi.Preferences{
-			Colors:     false,
-			Extensions: map[string]runtime.Object{},
-		},
-	}
-	expectedConfig.Extensions = map[string]runtime.Object{}
-	test := setConfigTest{
-		description:    "Testing for kubectl config set users.foo.act-as-user-extra.test1 to val5,val6,val7",
-		config:         conf,
-		args:           []string{"users.foo.act-as-user-extra.test1", "val5,val6,val7"},
-		expected:       `Property "users.foo.act-as-user-extra.test1" set.` + "\n",
-		expectedConfig: expectedConfig,
-	}
-	test.run(t)
-}
-
-func TestSetConfigImpersonateUserExtraNewKey(t *testing.T) {
-	conf := clientcmdapi.Config{
-		AuthInfos: map[string]*clientcmdapi.AuthInfo{
-			"foo": {
-				ImpersonateUserExtra: map[string][]string{
-					"test1": {
-						"val1",
-						"val2",
-						"val3",
+		{
+			name:        "AddActAsUserExtra",
+			description: "Testing for kubectl config set users.foo.act-as-user-extra.test1 to val4+",
+			config:      conf,
+			args:        []string{"users.foo.act-as-user-extra.test1", "val4+"},
+			expected:    `Property "users.foo.act-as-user-extra.test1" set.` + "\n",
+			expectedConfig: clientcmdapi.Config{
+				AuthInfos: map[string]*clientcmdapi.AuthInfo{
+					"foo": {
+						Exec: &clientcmdapi.ExecConfig{
+							Args: []string{
+								"test1",
+								"test2",
+								"test3",
+							},
+							Env: []clientcmdapi.ExecEnvVar{
+								{
+									Name:  "test",
+									Value: "value1",
+								},
+							},
+						},
+						Extensions: map[string]runtime.Object{},
+						ImpersonateGroups: []string{
+							"test1",
+							"test2",
+							"test3",
+						},
+						ImpersonateUserExtra: map[string][]string{
+							"test1": {
+								"val1",
+								"val2",
+								"val3",
+								"val4",
+							},
+						},
 					},
 				},
-				Extensions: map[string]runtime.Object{},
+				Clusters:       map[string]*clientcmdapi.Cluster{},
+				Contexts:       map[string]*clientcmdapi.Context{},
+				CurrentContext: "minikube",
+				Extensions:     map[string]runtime.Object{},
+				Preferences: clientcmdapi.Preferences{
+					Colors:     false,
+					Extensions: map[string]runtime.Object{},
+				},
 			},
 		},
-		Clusters:   map[string]*clientcmdapi.Cluster{},
-		Contexts:   map[string]*clientcmdapi.Context{},
-		Extensions: map[string]runtime.Object{},
-		Preferences: clientcmdapi.Preferences{
-			Colors:     false,
-			Extensions: map[string]runtime.Object{},
-		},
-	}
-	expectedConfig := clientcmdapi.Config{
-		AuthInfos: map[string]*clientcmdapi.AuthInfo{
-			"foo": {
-				ImpersonateUserExtra: map[string][]string{
-					"test1": {
-						"val1",
-						"val2",
-						"val3",
-					},
-					"test2": {
-						"val1",
+		{
+			name:        "DeleteActAsUserExtra",
+			description: "Testing for kubectl config set users.foo.act-as-user-extra.test1 to val3-",
+			config:      conf,
+			args:        []string{"users.foo.act-as-user-extra.test1", "val3-"},
+			expected:    `Property "users.foo.act-as-user-extra.test1" set.` + "\n",
+			expectedConfig: clientcmdapi.Config{
+				AuthInfos: map[string]*clientcmdapi.AuthInfo{
+					"foo": {
+						Exec: &clientcmdapi.ExecConfig{
+							Args: []string{
+								"test1",
+								"test2",
+								"test3",
+							},
+							Env: []clientcmdapi.ExecEnvVar{
+								{
+									Name:  "test",
+									Value: "value1",
+								},
+							},
+						},
+						Extensions: map[string]runtime.Object{},
+						ImpersonateGroups: []string{
+							"test1",
+							"test2",
+							"test3",
+						},
+						ImpersonateUserExtra: map[string][]string{
+							"test1": {
+								"val1",
+								"val2",
+							},
+						},
 					},
 				},
-				Extensions: map[string]runtime.Object{},
+				Clusters:       map[string]*clientcmdapi.Cluster{},
+				Contexts:       map[string]*clientcmdapi.Context{},
+				CurrentContext: "minikube",
+				Extensions:     map[string]runtime.Object{},
+				Preferences: clientcmdapi.Preferences{
+					Colors:     false,
+					Extensions: map[string]runtime.Object{},
+				},
 			},
 		},
-		Clusters:   map[string]*clientcmdapi.Cluster{},
-		Contexts:   map[string]*clientcmdapi.Context{},
-		Extensions: map[string]runtime.Object{},
-		Preferences: clientcmdapi.Preferences{
-			Colors:     false,
-			Extensions: map[string]runtime.Object{},
-		},
-	}
-	expectedConfig.Extensions = map[string]runtime.Object{}
-	test := setConfigTest{
-		description:    "Testing for kubectl config set users.foo.act-as-user-extra.test2 to val1",
-		config:         conf,
-		args:           []string{"users.foo.act-as-user-extra.test2", "val1"},
-		expected:       `Property "users.foo.act-as-user-extra.test2" set.` + "\n",
-		expectedConfig: expectedConfig,
-	}
-	test.run(t)
-}
-
-func TestSetConfigUsername(t *testing.T) {
-	conf := *clientcmdapi.NewConfig()
-	expectedConfig := clientcmdapi.Config{
-		AuthInfos: map[string]*clientcmdapi.AuthInfo{
-			"foo": {
-				Username:   "test1",
-				Extensions: map[string]runtime.Object{},
+		{
+			name:        "UpdateActAsUserExtra",
+			description: "Testing for kubectl config set users.foo.act-as-user-extra.test1 to val5,val6,val7",
+			config:      conf,
+			args:        []string{"users.foo.act-as-user-extra.test1", "val5,val6,val7"},
+			expected:    `Property "users.foo.act-as-user-extra.test1" set.` + "\n",
+			expectedConfig: clientcmdapi.Config{
+				AuthInfos: map[string]*clientcmdapi.AuthInfo{
+					"foo": {
+						Exec: &clientcmdapi.ExecConfig{
+							Args: []string{
+								"test1",
+								"test2",
+								"test3",
+							},
+							Env: []clientcmdapi.ExecEnvVar{
+								{
+									Name:  "test",
+									Value: "value1",
+								},
+							},
+						},
+						Extensions: map[string]runtime.Object{},
+						ImpersonateGroups: []string{
+							"test1",
+							"test2",
+							"test3",
+						},
+						ImpersonateUserExtra: map[string][]string{
+							"test1": {
+								"val5",
+								"val6",
+								"val7",
+							},
+						},
+					},
+				},
+				Clusters:       map[string]*clientcmdapi.Cluster{},
+				Contexts:       map[string]*clientcmdapi.Context{},
+				CurrentContext: "minikube",
+				Extensions:     map[string]runtime.Object{},
+				Preferences: clientcmdapi.Preferences{
+					Colors:     false,
+					Extensions: map[string]runtime.Object{},
+				},
 			},
 		},
-		Clusters:   map[string]*clientcmdapi.Cluster{},
-		Contexts:   map[string]*clientcmdapi.Context{},
-		Extensions: map[string]runtime.Object{},
-		Preferences: clientcmdapi.Preferences{
-			Colors:     false,
-			Extensions: map[string]runtime.Object{},
-		},
-	}
-	expectedConfig.Extensions = map[string]runtime.Object{}
-	test := setConfigTest{
-		description:    "Testing for kubectl config set users.foo.username to test1",
-		config:         conf,
-		args:           []string{"users.foo.username", "test1"},
-		expected:       `Property "users.foo.username" set.` + "\n",
-		expectedConfig: expectedConfig,
-	}
-	test.run(t)
-}
-
-func TestSetConfigPassword(t *testing.T) {
-	conf := *clientcmdapi.NewConfig()
-	expectedConfig := clientcmdapi.Config{
-		AuthInfos: map[string]*clientcmdapi.AuthInfo{
-			"foo": {
-				Password:   "abadpassword",
-				Extensions: map[string]runtime.Object{},
+		{
+			name:        "AddNewActAsUserExtra",
+			description: "Testing for kubectl config set users.foo.act-as-user-extra.test2 to val1",
+			config:      conf,
+			args:        []string{"users.foo.act-as-user-extra.test2", "val1"},
+			expected:    `Property "users.foo.act-as-user-extra.test2" set.` + "\n",
+			expectedConfig: clientcmdapi.Config{
+				AuthInfos: map[string]*clientcmdapi.AuthInfo{
+					"foo": {
+						Exec: &clientcmdapi.ExecConfig{
+							Args: []string{
+								"test1",
+								"test2",
+								"test3",
+							},
+							Env: []clientcmdapi.ExecEnvVar{
+								{
+									Name:  "test",
+									Value: "value1",
+								},
+							},
+						},
+						Extensions: map[string]runtime.Object{},
+						ImpersonateGroups: []string{
+							"test1",
+							"test2",
+							"test3",
+						},
+						ImpersonateUserExtra: map[string][]string{
+							"test1": {
+								"val1",
+								"val2",
+								"val3",
+							},
+							"test2": {
+								"val1",
+							},
+						},
+					},
+				},
+				Clusters:       map[string]*clientcmdapi.Cluster{},
+				Contexts:       map[string]*clientcmdapi.Context{},
+				CurrentContext: "minikube",
+				Extensions:     map[string]runtime.Object{},
+				Preferences: clientcmdapi.Preferences{
+					Colors:     false,
+					Extensions: map[string]runtime.Object{},
+				},
 			},
 		},
-		Clusters:   map[string]*clientcmdapi.Cluster{},
-		Contexts:   map[string]*clientcmdapi.Context{},
-		Extensions: map[string]runtime.Object{},
-		Preferences: clientcmdapi.Preferences{
-			Colors:     false,
-			Extensions: map[string]runtime.Object{},
-		},
 	}
-	expectedConfig.Extensions = map[string]runtime.Object{}
-	test := setConfigTest{
-		description:    "Testing for kubectl config set users.foo.password to abadpassword",
-		config:         conf,
-		args:           []string{"users.foo.password", "abadpassword"},
-		expected:       `Property "users.foo.password" set.` + "\n",
-		expectedConfig: expectedConfig,
+	for _, test := range tests {
+		test.run(t)
 	}
-	test.run(t)
-}
-
-func TestSetConfigClientCertificate(t *testing.T) {
-	conf := *clientcmdapi.NewConfig()
-	expectedConfig := clientcmdapi.Config{
-		AuthInfos: map[string]*clientcmdapi.AuthInfo{
-			"foo": {
-				ClientCertificate: "./file/path",
-				Extensions:        map[string]runtime.Object{},
-			},
-		},
-		Clusters:   map[string]*clientcmdapi.Cluster{},
-		Contexts:   map[string]*clientcmdapi.Context{},
-		Extensions: map[string]runtime.Object{},
-		Preferences: clientcmdapi.Preferences{
-			Colors:     false,
-			Extensions: map[string]runtime.Object{},
-		},
-	}
-	expectedConfig.Extensions = map[string]runtime.Object{}
-	test := setConfigTest{
-		description:    "Testing for kubectl config set users.foo.client-certificate to ./file/path",
-		config:         conf,
-		args:           []string{"users.foo.client-certificate", "./file/path"},
-		expected:       `Property "users.foo.client-certificate" set.` + "\n",
-		expectedConfig: expectedConfig,
-	}
-	test.run(t)
-}
-
-func TestSetConfigClientCertificateData(t *testing.T) {
-	conf := *clientcmdapi.NewConfig()
-	expectedConfig := clientcmdapi.Config{
-		AuthInfos: map[string]*clientcmdapi.AuthInfo{
-			"foo": {
-				ClientCertificateData: []byte("not real cert data"),
-				Extensions:            map[string]runtime.Object{},
-			},
-		},
-		Clusters:   map[string]*clientcmdapi.Cluster{},
-		Contexts:   map[string]*clientcmdapi.Context{},
-		Extensions: map[string]runtime.Object{},
-		Preferences: clientcmdapi.Preferences{
-			Colors:     false,
-			Extensions: map[string]runtime.Object{},
-		},
-	}
-	expectedConfig.Extensions = map[string]runtime.Object{}
-	test := setConfigTest{
-		description:    "Testing for kubectl config set users.foo.client-certificate-data to not real cert data",
-		config:         conf,
-		args:           []string{"users.foo.client-certificate-data", "--set-raw-bytes=true", "not real cert data"},
-		expected:       `Property "users.foo.client-certificate-data" set.` + "\n",
-		expectedConfig: expectedConfig,
-	}
-	test.run(t)
-}
-
-func TestSetConfigClientKey(t *testing.T) {
-	conf := *clientcmdapi.NewConfig()
-	expectedConfig := clientcmdapi.Config{
-		AuthInfos: map[string]*clientcmdapi.AuthInfo{
-			"foo": {
-				ClientKey:  "./file/path",
-				Extensions: map[string]runtime.Object{},
-			},
-		},
-		Clusters:   map[string]*clientcmdapi.Cluster{},
-		Contexts:   map[string]*clientcmdapi.Context{},
-		Extensions: map[string]runtime.Object{},
-		Preferences: clientcmdapi.Preferences{
-			Colors:     false,
-			Extensions: map[string]runtime.Object{},
-		},
-	}
-	expectedConfig.Extensions = map[string]runtime.Object{}
-	test := setConfigTest{
-		description:    "Testing for kubectl config set users.foo.client-key to ./file/path",
-		config:         conf,
-		args:           []string{"users.foo.client-key", "./file/path"},
-		expected:       `Property "users.foo.client-key" set.` + "\n",
-		expectedConfig: expectedConfig,
-	}
-	test.run(t)
-}
-
-func TestSetConfigClientKeyData(t *testing.T) {
-	conf := *clientcmdapi.NewConfig()
-	expectedConfig := clientcmdapi.Config{
-		AuthInfos: map[string]*clientcmdapi.AuthInfo{
-			"foo": {
-				ClientKeyData: []byte("not real key data"),
-				Extensions:    map[string]runtime.Object{},
-			},
-		},
-		Clusters:   map[string]*clientcmdapi.Cluster{},
-		Contexts:   map[string]*clientcmdapi.Context{},
-		Extensions: map[string]runtime.Object{},
-		Preferences: clientcmdapi.Preferences{
-			Colors:     false,
-			Extensions: map[string]runtime.Object{},
-		},
-	}
-	expectedConfig.Extensions = map[string]runtime.Object{}
-	test := setConfigTest{
-		description:    "Testing for kubectl config set users.foo.client-key-data to not real key data",
-		config:         conf,
-		args:           []string{"users.foo.client-key-data", "--set-raw-bytes=true", "not real key data"},
-		expected:       `Property "users.foo.client-key-data" set.` + "\n",
-		expectedConfig: expectedConfig,
-	}
-	test.run(t)
-}
-
-func TestSetConfigToken(t *testing.T) {
-	conf := *clientcmdapi.NewConfig()
-	expectedConfig := clientcmdapi.Config{
-		AuthInfos: map[string]*clientcmdapi.AuthInfo{
-			"foo": {
-				Token:      "fake token data",
-				Extensions: map[string]runtime.Object{},
-			},
-		},
-		Clusters:   map[string]*clientcmdapi.Cluster{},
-		Contexts:   map[string]*clientcmdapi.Context{},
-		Extensions: map[string]runtime.Object{},
-		Preferences: clientcmdapi.Preferences{
-			Colors:     false,
-			Extensions: map[string]runtime.Object{},
-		},
-	}
-	expectedConfig.Extensions = map[string]runtime.Object{}
-	test := setConfigTest{
-		description:    "Testing for kubectl config set users.foo.token to fake token data",
-		config:         conf,
-		args:           []string{"users.foo.token", "fake token data"},
-		expected:       `Property "users.foo.token" set.` + "\n",
-		expectedConfig: expectedConfig,
-	}
-	test.run(t)
-}
-
-func TestSetConfigTokenFile(t *testing.T) {
-	conf := *clientcmdapi.NewConfig()
-	expectedConfig := clientcmdapi.Config{
-		AuthInfos: map[string]*clientcmdapi.AuthInfo{
-			"foo": {
-				TokenFile:  "./file/path",
-				Extensions: map[string]runtime.Object{},
-			},
-		},
-		Clusters:   map[string]*clientcmdapi.Cluster{},
-		Contexts:   map[string]*clientcmdapi.Context{},
-		Extensions: map[string]runtime.Object{},
-		Preferences: clientcmdapi.Preferences{
-			Colors:     false,
-			Extensions: map[string]runtime.Object{},
-		},
-	}
-	expectedConfig.Extensions = map[string]runtime.Object{}
-	test := setConfigTest{
-		description:    "Testing for kubectl config set users.foo.tokenFile to ./file/path",
-		config:         conf,
-		args:           []string{"users.foo.tokenFile", "./file/path"},
-		expected:       `Property "users.foo.tokenFile" set.` + "\n",
-		expectedConfig: expectedConfig,
-	}
-	test.run(t)
-}
-
-func TestSetConfigAuthProviderError(t *testing.T) {
-	conf := *clientcmdapi.NewConfig()
-	test := setConfigTest{
-		description: "Testing for kubectl config set users.foo.auth-provider to oidc error",
-		config:      conf,
-		args:        []string{"users.foo.auth-provider", "test"},
-		expectedErr: `unable to locate path auth-provider`,
-	}
-	test.run(t)
 }
 
 func (test setConfigTest) run(t *testing.T) {
@@ -1310,6 +1202,6 @@ func (test setConfigTest) run(t *testing.T) {
 		}
 	}
 	if !reflect.DeepEqual(*config, test.expectedConfig) {
-		t.Errorf("config want/got mismatch (-want +got):\n%s", cmp.Diff(test.expectedConfig, *config))
+		t.Errorf("%v\nconfig want/got mismatch (-want +got):\n%s", test.name, cmp.Diff(test.expectedConfig, *config))
 	}
 }

--- a/staging/src/k8s.io/kubectl/pkg/cmd/config/set_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/config/set_test.go
@@ -77,6 +77,18 @@ func (test setConfigTest) run(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error loading kubeconfig file: %v", err)
 	}
+
+	// Must manually set LocationOfOrigin field of AuthInfos if they exists
+	if len(config.AuthInfos) > 0 {
+		for k := range config.AuthInfos {
+			if test.expectedConfig.AuthInfos[k] != nil && config.AuthInfos[k] != nil {
+				test.expectedConfig.AuthInfos[k].LocationOfOrigin = config.AuthInfos[k].LocationOfOrigin
+			} else {
+				t.Errorf("Failed in:%q\n cannot find key %v in either expectedConfig or config", test.description, k)
+			}
+		}
+	}
+
 	if len(test.expected) != 0 {
 		if buf.String() != test.expected {
 			t.Errorf("Failed in:%q\n expected %v\n but got %v", test.description, test.expected, buf.String())

--- a/staging/src/k8s.io/kubectl/pkg/cmd/config/set_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/config/set_test.go
@@ -1244,6 +1244,9 @@ func (test setConfigTest) run(t *testing.T) {
 		propertyName:  test.args[0],
 		propertyValue: test.args[1],
 	}
+	if len(test.args) > 2 {
+		opts.setRawBytes = 1
+	}
 
 	// Must use opts.run to get error outputs
 	err = opts.run()

--- a/staging/src/k8s.io/kubectl/pkg/cmd/config/set_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/config/set_test.go
@@ -24,6 +24,7 @@ import (
 
 	"reflect"
 
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 )
@@ -49,6 +50,69 @@ func TestSetConfigCurrentContext(t *testing.T) {
 		config:         conf,
 		args:           []string{"current-context", "my-cluster"},
 		expected:       `Property "current-context" set.` + "\n",
+		expectedConfig: expectedConfig,
+	}
+	test.run(t)
+}
+
+func TestSetConfigAuthProviderName(t *testing.T) {
+	conf := *clientcmdapi.NewConfig()
+	expectedConfig := clientcmdapi.Config{
+		AuthInfos: map[string]*clientcmdapi.AuthInfo{
+			"foo": {
+				AuthProvider: &clientcmdapi.AuthProviderConfig{
+					Name: "oidc",
+				},
+				Extensions: map[string]runtime.Object{},
+			},
+		},
+		Clusters:   map[string]*clientcmdapi.Cluster{},
+		Contexts:   map[string]*clientcmdapi.Context{},
+		Extensions: map[string]runtime.Object{},
+		Preferences: clientcmdapi.Preferences{
+			Colors:     false,
+			Extensions: map[string]runtime.Object{},
+		},
+	}
+	expectedConfig.Extensions = map[string]runtime.Object{}
+	test := setConfigTest{
+		description:    "Testing for kubectl config set users.foo.auth-provider.name to oidc",
+		config:         conf,
+		args:           []string{"users.foo.auth-provider.name", "oidc"},
+		expected:       `Property "users.foo.auth-provider.name" set.` + "\n",
+		expectedConfig: expectedConfig,
+	}
+	test.run(t)
+}
+
+func TestSetConfigAuthProviderConfigRefreshToken(t *testing.T) {
+	conf := *clientcmdapi.NewConfig()
+	expectedConfig := clientcmdapi.Config{
+		AuthInfos: map[string]*clientcmdapi.AuthInfo{
+			"foo": {
+				AuthProvider: &clientcmdapi.AuthProviderConfig{
+					Name: "",
+					Config: map[string]string{
+						"refresh-token": "test",
+					},
+				},
+				Extensions: map[string]runtime.Object{},
+			},
+		},
+		Clusters:   map[string]*clientcmdapi.Cluster{},
+		Contexts:   map[string]*clientcmdapi.Context{},
+		Extensions: map[string]runtime.Object{},
+		Preferences: clientcmdapi.Preferences{
+			Colors:     false,
+			Extensions: map[string]runtime.Object{},
+		},
+	}
+	expectedConfig.Extensions = map[string]runtime.Object{}
+	test := setConfigTest{
+		description:    "Testing for kubectl config set users.foo.auth-provider.config.refresh-token to oidc",
+		config:         conf,
+		args:           []string{"users.foo.auth-provider.config.refresh-token", "test"},
+		expected:       `Property "users.foo.auth-provider.config.refresh-token" set.` + "\n",
 		expectedConfig: expectedConfig,
 	}
 	test.run(t)

--- a/staging/src/k8s.io/kubectl/pkg/cmd/config/set_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/config/set_test.go
@@ -385,7 +385,7 @@ func TestSetConfigExecEnvNew(t *testing.T) {
 					Env: []clientcmdapi.ExecEnvVar{
 						{
 							Name:  "test",
-							Value: "value",
+							Value: "val1",
 						},
 					},
 				},
@@ -402,10 +402,10 @@ func TestSetConfigExecEnvNew(t *testing.T) {
 	}
 	expectedConfig.Extensions = map[string]runtime.Object{}
 	test := setConfigTest{
-		description:    "Testing for kubectl config set users.foo.exec.env.test to value",
+		description:    "Testing for kubectl config set users.foo.exec.env.name.test to value:val1",
 		config:         conf,
-		args:           []string{"users.foo.exec.env.test", "value"},
-		expected:       `Property "users.foo.exec.env.test" set.` + "\n",
+		args:           []string{"users.foo.exec.env.name.test", "value:val1"},
+		expected:       `Property "users.foo.exec.env.name.test" set.` + "\n",
 		expectedConfig: expectedConfig,
 	}
 	test.run(t)
@@ -458,10 +458,10 @@ func TestSetConfigExecEnvUpdate(t *testing.T) {
 	}
 	expectedConfig.Extensions = map[string]runtime.Object{}
 	test := setConfigTest{
-		description:    "Testing for kubectl config set users.foo.exec.env.test to value2",
+		description:    "Testing for kubectl config set users.foo.exec.env.name.test to value:value2",
 		config:         conf,
-		args:           []string{"users.foo.exec.env.test", "value2"},
-		expected:       `Property "users.foo.exec.env.test" set.` + "\n",
+		args:           []string{"users.foo.exec.env.name.test", "value:value2"},
+		expected:       `Property "users.foo.exec.env.name.test" set.` + "\n",
 		expectedConfig: expectedConfig,
 	}
 	test.run(t)

--- a/staging/src/k8s.io/kubectl/pkg/cmd/config/set_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/config/set_test.go
@@ -247,7 +247,7 @@ func TestFromNewConfig(t *testing.T) {
 			description: "Testing for kubectl config set users.foo.exec.env.name.test to value2",
 			config:      conf,
 			args:        []string{"users.foo.exec.env.name.test", "value2"},
-			expectedErr: `error parsing field name for value, should be of format fieldName:fieldValue`,
+			expectedErr: `error parsing field name for value, should be of format fieldName:fieldValue[:action]`,
 		},
 		{
 			name:        "SetAuthInfoExecInstallHint",
@@ -1009,6 +1009,48 @@ func TestFromExistingConfig(t *testing.T) {
 									Value: "value2",
 								},
 							},
+						},
+						Extensions: map[string]runtime.Object{},
+						ImpersonateGroups: []string{
+							"test1",
+							"test2",
+							"test3",
+						},
+						ImpersonateUserExtra: map[string][]string{
+							"test1": {
+								"val1",
+								"val2",
+								"val3",
+							},
+						},
+					},
+				},
+				Clusters:       map[string]*clientcmdapi.Cluster{},
+				Contexts:       map[string]*clientcmdapi.Context{},
+				CurrentContext: "minikube",
+				Extensions:     map[string]runtime.Object{},
+				Preferences: clientcmdapi.Preferences{
+					Colors:     false,
+					Extensions: map[string]runtime.Object{},
+				},
+			},
+		},
+		{
+			name:        "DeleteExecEnvVar",
+			description: "Testing for kubectl config set users.foo.exec.env.name.test to value:value1:del",
+			config:      conf,
+			args:        []string{"users.foo.exec.env.name.test", "value:value1:-"},
+			expected:    `Property "users.foo.exec.env.name.test" set.` + "\n",
+			expectedConfig: clientcmdapi.Config{
+				AuthInfos: map[string]*clientcmdapi.AuthInfo{
+					"foo": {
+						Exec: &clientcmdapi.ExecConfig{
+							Args: []string{
+								"test1",
+								"test2",
+								"test3",
+							},
+							Env: []clientcmdapi.ExecEnvVar{},
 						},
 						Extensions: map[string]runtime.Object{},
 						ImpersonateGroups: []string{

--- a/staging/src/k8s.io/kubectl/pkg/cmd/config/set_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/config/set_test.go
@@ -49,7 +49,7 @@ func TestFromNewConfig(t *testing.T) {
 			description: "Testing for kubectl config set users.foo.exec.fake.key to test",
 			config:      conf,
 			args:        []string{"users.foo.exec.fake.key", "test"},
-			expectedErr: "unable to parse users.foo.exec.fake.key at fake",
+			expectedErr: "unable to parse path users.foo.exec.fake.key at fake",
 		},
 		{
 			name:        "SetAuthProviderName",

--- a/staging/src/k8s.io/kubectl/pkg/cmd/config/set_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/config/set_test.go
@@ -481,10 +481,10 @@ func TestSetConfigExecEnvUpdate(t *testing.T) {
 func TestSetConfigExecEnvMalformedValue(t *testing.T) {
 	conf := *clientcmdapi.NewConfig()
 	test := setConfigTest{
-		description:    "Testing for kubectl config set users.foo.exec.env.name.test to value2",
-		config:         conf,
-		args:           []string{"users.foo.exec.env.name.test", "value2"},
-		expectedErr:       `error parsing field name for value, should be of format fieldName:fieldValue`,
+		description: "Testing for kubectl config set users.foo.exec.env.name.test to value2",
+		config:      conf,
+		args:        []string{"users.foo.exec.env.name.test", "value2"},
+		expectedErr: `error parsing field name for value, should be of format fieldName:fieldValue`,
 	}
 	test.run(t)
 }

--- a/staging/src/k8s.io/kubectl/pkg/cmd/config/set_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/config/set_test.go
@@ -478,6 +478,17 @@ func TestSetConfigExecEnvUpdate(t *testing.T) {
 	test.run(t)
 }
 
+func TestSetConfigExecEnvMalformedValue(t *testing.T) {
+	conf := *clientcmdapi.NewConfig()
+	test := setConfigTest{
+		description:    "Testing for kubectl config set users.foo.exec.env.name.test to value2",
+		config:         conf,
+		args:           []string{"users.foo.exec.env.name.test", "value2"},
+		expectedErr:       `error parsing field name for value, should be of format fieldName:fieldValue`,
+	}
+	test.run(t)
+}
+
 func TestSetConfigInstallHint(t *testing.T) {
 	conf := *clientcmdapi.NewConfig()
 	expectedConfig := clientcmdapi.Config{

--- a/staging/src/k8s.io/kubectl/pkg/cmd/config/set_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/config/set_test.go
@@ -1515,12 +1515,12 @@ func (test setConfigTest) run(t *testing.T) {
 	// Define path options for cmd.Execute() run
 	fakeKubeFileCmd, err := ioutil.TempFile(os.TempDir(), "")
 	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+		t.Errorf("Failed in: %q\n unexpected error: %v", test.name, err)
 	}
 	defer os.Remove(fakeKubeFileCmd.Name())
 	err = clientcmd.WriteToFile(test.config, fakeKubeFileCmd.Name())
 	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+		t.Errorf("Failed in: %q\n unexpected error: %v", test.name, err)
 	}
 	pathOptionsCmd := clientcmd.NewDefaultPathOptions()
 	pathOptionsCmd.GlobalFile = fakeKubeFileCmd.Name()
@@ -1529,12 +1529,12 @@ func (test setConfigTest) run(t *testing.T) {
 	// Define path options for opts.run() execution
 	fakeKubeFileOpts, err := ioutil.TempFile(os.TempDir(), "")
 	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+		t.Errorf("Failed in: %q\n unexpected error: %v", test.name, err)
 	}
 	defer os.Remove(fakeKubeFileOpts.Name())
 	err = clientcmd.WriteToFile(test.config, fakeKubeFileOpts.Name())
 	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+		t.Errorf("Failed in: %q\n unexpected error: %v", test.name, err)
 	}
 	pathOptionsOpts := clientcmd.NewDefaultPathOptions()
 	pathOptionsOpts.GlobalFile = fakeKubeFileOpts.Name()
@@ -1558,24 +1558,24 @@ func (test setConfigTest) run(t *testing.T) {
 	// Must use opts.run to get error outputs
 	err = opts.run()
 	if test.expectedErr == "" && err != nil {
-		t.Fatalf("unexpected error: %v", err)
+		t.Errorf("Failed in: %q\n unexpected error: %v", test.name, err)
 	}
 
 	// Check for expected error message
 	if test.expectedErr != "" {
 		if err != nil && err.Error() != test.expectedErr {
-			t.Fatalf("expected error:\n %v\nbut got error:\n%v", test.expectedErr, err)
+			t.Errorf("Failed in: %q\n expected error:\n %v\nbut got error:\n%v", test.name, test.expectedErr, err)
 		}
 		return
 	}
 
 	// Must use cmd.Execute to get stdout output
 	if err := cmd.Execute(); err != nil {
-		t.Fatalf("unexpected error executing command: %v", err)
+		t.Errorf("Failed in: %q\n unexpected error executing command: %v", test.name, err)
 	}
 	config, err := clientcmd.LoadFromFile(fakeKubeFileCmd.Name())
 	if err != nil {
-		t.Fatalf("unexpected error loading kubeconfig file: %v", err)
+		t.Errorf("Failed in: %q\n unexpected error loading kubeconfig file: %v", test.name, err)
 	}
 
 	// Must manually set LocationOfOrigin field of AuthInfos if they exists
@@ -1584,17 +1584,17 @@ func (test setConfigTest) run(t *testing.T) {
 			if test.expectedConfig.AuthInfos[k] != nil && config.AuthInfos[k] != nil {
 				test.expectedConfig.AuthInfos[k].LocationOfOrigin = config.AuthInfos[k].LocationOfOrigin
 			} else {
-				t.Errorf("Failed in:%q\n cannot find key %v in AuthInfos map for expectedConfig and/or config", test.description, k)
+				t.Errorf("Failed in: %q\n cannot find key %v in AuthInfos map for expectedConfig and/or config", test.name, k)
 			}
 		}
 	}
 
 	if len(test.expected) != 0 {
 		if buf.String() != test.expected {
-			t.Errorf("Failed in:%q\n expected %v\n but got %v", test.description, test.expected, buf.String())
+			t.Errorf("Failed in: %q\n expected %v\n but got %v", test.name, test.expected, buf.String())
 		}
 	}
 	if !reflect.DeepEqual(*config, test.expectedConfig) {
-		t.Errorf("%v\nconfig want/got mismatch (-want +got):\n%s", test.name, cmp.Diff(test.expectedConfig, *config))
+		t.Errorf("Failed in: %q\nconfig want/got mismatch (-want +got):\n%s", test.name, cmp.Diff(test.expectedConfig, *config))
 	}
 }

--- a/staging/src/k8s.io/kubectl/pkg/cmd/config/set_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/config/set_test.go
@@ -45,6 +45,13 @@ func TestFromNewConfig(t *testing.T) {
 	conf := *clientcmdapi.NewConfig()
 	tests := []setConfigTest{
 		{
+			name:        "Set with bad key",
+			description: "Testing for kubectl config set users.foo.exec.fake.key to test",
+			config:      conf,
+			args:        []string{"users.foo.exec.fake.key", "test"},
+			expectedErr: "unable to locate path fake",
+		},
+		{
 			name:        "SetAuthProviderName",
 			description: "Testing for kubectl config set users.foo.auth-provider.name to oidc",
 			config:      conf,

--- a/staging/src/k8s.io/kubectl/pkg/cmd/config/set_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/config/set_test.go
@@ -83,6 +83,6 @@ func (test setConfigTest) run(t *testing.T) {
 		}
 	}
 	if !reflect.DeepEqual(*config, test.expectedConfig) {
-		t.Errorf("Failed in: %q\n expected %v\n but got %v", test.description, *config, test.expectedConfig)
+		t.Errorf("Failed in: %q\n expected %#v\n but got %#v", test.description, *config, test.expectedConfig)
 	}
 }

--- a/staging/src/k8s.io/kubectl/pkg/cmd/config/set_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/config/set_test.go
@@ -22,9 +22,9 @@ import (
 	"os"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"reflect"
 
-	"github.com/google/go-cmp/cmp"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"

--- a/staging/src/k8s.io/kubectl/pkg/cmd/config/set_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/config/set_test.go
@@ -49,7 +49,7 @@ func TestFromNewConfig(t *testing.T) {
 			description: "Testing for kubectl config set users.foo.exec.fake.key to test",
 			config:      conf,
 			args:        []string{"users.foo.exec.fake.key", "test"},
-			expectedErr: "unable to locate path fake",
+			expectedErr: "unable to parse users.foo.exec.fake.key at fake",
 		},
 		{
 			name:        "SetAuthProviderName",

--- a/staging/src/k8s.io/kubectl/pkg/cmd/config/set_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/config/set_test.go
@@ -247,7 +247,7 @@ func TestFromNewConfig(t *testing.T) {
 			description: "Testing for kubectl config set users.foo.exec.env.name.test to value2",
 			config:      conf,
 			args:        []string{"users.foo.exec.env.name.test", "value2"},
-			expectedErr: `error parsing field name for value, should be of format fieldName:fieldValue[:action]`,
+			expectedErr: `error parsing field name for value, should be of format fieldName:fieldValue`,
 		},
 		{
 			name:        "SetAuthInfoExecInstallHint",
@@ -1037,9 +1037,9 @@ func TestFromExistingConfig(t *testing.T) {
 		},
 		{
 			name:        "DeleteExecEnvVar",
-			description: "Testing for kubectl config set users.foo.exec.env.name.test to value:value1:del",
+			description: "Testing for kubectl config set users.foo.exec.env.name.test to value:",
 			config:      conf,
-			args:        []string{"users.foo.exec.env.name.test", "value:value1:-"},
+			args:        []string{"users.foo.exec.env.name.test", "value:"},
 			expected:    `Property "users.foo.exec.env.name.test" set.` + "\n",
 			expectedConfig: clientcmdapi.Config{
 				AuthInfos: map[string]*clientcmdapi.AuthInfo{

--- a/staging/src/k8s.io/kubectl/pkg/cmd/config/set_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/config/set_test.go
@@ -24,6 +24,7 @@ import (
 
 	"reflect"
 
+	"github.com/google/go-cmp/cmp"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
@@ -34,6 +35,7 @@ type setConfigTest struct {
 	config         clientcmdapi.Config
 	args           []string
 	expected       string
+	expectedErr    string
 	expectedConfig clientcmdapi.Config
 }
 
@@ -109,11 +111,1114 @@ func TestSetConfigAuthProviderConfigRefreshToken(t *testing.T) {
 	}
 	expectedConfig.Extensions = map[string]runtime.Object{}
 	test := setConfigTest{
-		description:    "Testing for kubectl config set users.foo.auth-provider.config.refresh-token to oidc",
+		description:    "Testing for kubectl config set users.foo.auth-provider.config.refresh-token to test",
 		config:         conf,
 		args:           []string{"users.foo.auth-provider.config.refresh-token", "test"},
 		expected:       `Property "users.foo.auth-provider.config.refresh-token" set.` + "\n",
 		expectedConfig: expectedConfig,
+	}
+	test.run(t)
+}
+
+func TestSetConfigExecConfigCommand(t *testing.T) {
+	conf := *clientcmdapi.NewConfig()
+	expectedConfig := clientcmdapi.Config{
+		AuthInfos: map[string]*clientcmdapi.AuthInfo{
+			"foo": {
+				Exec: &clientcmdapi.ExecConfig{
+					Command: "test",
+				},
+				Extensions: map[string]runtime.Object{},
+			},
+		},
+		Clusters:   map[string]*clientcmdapi.Cluster{},
+		Contexts:   map[string]*clientcmdapi.Context{},
+		Extensions: map[string]runtime.Object{},
+		Preferences: clientcmdapi.Preferences{
+			Colors:     false,
+			Extensions: map[string]runtime.Object{},
+		},
+	}
+	expectedConfig.Extensions = map[string]runtime.Object{}
+	test := setConfigTest{
+		description:    "Testing for kubectl config set users.foo.exec.command to test",
+		config:         conf,
+		args:           []string{"users.foo.exec.command", "test"},
+		expected:       `Property "users.foo.exec.command" set.` + "\n",
+		expectedConfig: expectedConfig,
+	}
+	test.run(t)
+}
+
+func TestSetConfigExecArgsNew(t *testing.T) {
+	conf := *clientcmdapi.NewConfig()
+	expectedConfig := clientcmdapi.Config{
+		AuthInfos: map[string]*clientcmdapi.AuthInfo{
+			"foo": {
+				Exec: &clientcmdapi.ExecConfig{
+					Args: []string{
+						"test1",
+						"test2",
+						"test3",
+					},
+				},
+				Extensions: map[string]runtime.Object{},
+			},
+		},
+		Clusters:   map[string]*clientcmdapi.Cluster{},
+		Contexts:   map[string]*clientcmdapi.Context{},
+		Extensions: map[string]runtime.Object{},
+		Preferences: clientcmdapi.Preferences{
+			Colors:     false,
+			Extensions: map[string]runtime.Object{},
+		},
+	}
+	expectedConfig.Extensions = map[string]runtime.Object{}
+	test := setConfigTest{
+		description:    "Testing for kubectl config set users.foo.exec.args to test1,test2,test3",
+		config:         conf,
+		args:           []string{"users.foo.exec.args", "test1,test2,test3"},
+		expected:       `Property "users.foo.exec.args" set.` + "\n",
+		expectedConfig: expectedConfig,
+	}
+	test.run(t)
+}
+
+func TestSetConfigExecArgsAdd(t *testing.T) {
+	conf := clientcmdapi.Config{
+		AuthInfos: map[string]*clientcmdapi.AuthInfo{
+			"foo": {
+				Exec: &clientcmdapi.ExecConfig{
+					Args: []string{
+						"test1",
+						"test2",
+						"test3",
+					},
+				},
+				Extensions: map[string]runtime.Object{},
+			},
+		},
+		Clusters:   map[string]*clientcmdapi.Cluster{},
+		Contexts:   map[string]*clientcmdapi.Context{},
+		Extensions: map[string]runtime.Object{},
+		Preferences: clientcmdapi.Preferences{
+			Colors:     false,
+			Extensions: map[string]runtime.Object{},
+		},
+	}
+	expectedConfig := clientcmdapi.Config{
+		AuthInfos: map[string]*clientcmdapi.AuthInfo{
+			"foo": {
+				Exec: &clientcmdapi.ExecConfig{
+					Args: []string{
+						"test1",
+						"test2",
+						"test3",
+						"test4",
+					},
+				},
+				Extensions: map[string]runtime.Object{},
+			},
+		},
+		Clusters:   map[string]*clientcmdapi.Cluster{},
+		Contexts:   map[string]*clientcmdapi.Context{},
+		Extensions: map[string]runtime.Object{},
+		Preferences: clientcmdapi.Preferences{
+			Colors:     false,
+			Extensions: map[string]runtime.Object{},
+		},
+	}
+	expectedConfig.Extensions = map[string]runtime.Object{}
+	test := setConfigTest{
+		description:    "Testing for kubectl config set users.foo.exec.args to test4+",
+		config:         conf,
+		args:           []string{"users.foo.exec.args", "test4+"},
+		expected:       `Property "users.foo.exec.args" set.` + "\n",
+		expectedConfig: expectedConfig,
+	}
+	test.run(t)
+}
+
+func TestSetConfigExecArgsDelete(t *testing.T) {
+	conf := clientcmdapi.Config{
+		AuthInfos: map[string]*clientcmdapi.AuthInfo{
+			"foo": {
+				Exec: &clientcmdapi.ExecConfig{
+					Args: []string{
+						"test1",
+						"test2",
+						"test3",
+					},
+				},
+				Extensions: map[string]runtime.Object{},
+			},
+		},
+		Clusters:   map[string]*clientcmdapi.Cluster{},
+		Contexts:   map[string]*clientcmdapi.Context{},
+		Extensions: map[string]runtime.Object{},
+		Preferences: clientcmdapi.Preferences{
+			Colors:     false,
+			Extensions: map[string]runtime.Object{},
+		},
+	}
+	expectedConfig := clientcmdapi.Config{
+		AuthInfos: map[string]*clientcmdapi.AuthInfo{
+			"foo": {
+				Exec: &clientcmdapi.ExecConfig{
+					Args: []string{
+						"test1",
+						"test3",
+					},
+				},
+				Extensions: map[string]runtime.Object{},
+			},
+		},
+		Clusters:   map[string]*clientcmdapi.Cluster{},
+		Contexts:   map[string]*clientcmdapi.Context{},
+		Extensions: map[string]runtime.Object{},
+		Preferences: clientcmdapi.Preferences{
+			Colors:     false,
+			Extensions: map[string]runtime.Object{},
+		},
+	}
+	expectedConfig.Extensions = map[string]runtime.Object{}
+	test := setConfigTest{
+		description:    "Testing for kubectl config set users.foo.exec.args to test2-",
+		config:         conf,
+		args:           []string{"users.foo.exec.args", "test2-"},
+		expected:       `Property "users.foo.exec.args" set.` + "\n",
+		expectedConfig: expectedConfig,
+	}
+	test.run(t)
+}
+
+func TestSetConfigExecArgsUpdate(t *testing.T) {
+	conf := clientcmdapi.Config{
+		AuthInfos: map[string]*clientcmdapi.AuthInfo{
+			"foo": {
+				Exec: &clientcmdapi.ExecConfig{
+					Args: []string{
+						"test1",
+						"test2",
+						"test3",
+						"test4",
+					},
+				},
+				Extensions: map[string]runtime.Object{},
+			},
+		},
+		Clusters:   map[string]*clientcmdapi.Cluster{},
+		Contexts:   map[string]*clientcmdapi.Context{},
+		Extensions: map[string]runtime.Object{},
+		Preferences: clientcmdapi.Preferences{
+			Colors:     false,
+			Extensions: map[string]runtime.Object{},
+		},
+	}
+	expectedConfig := clientcmdapi.Config{
+		AuthInfos: map[string]*clientcmdapi.AuthInfo{
+			"foo": {
+				Exec: &clientcmdapi.ExecConfig{
+					Args: []string{
+						"test1",
+						"test3",
+					},
+				},
+				Extensions: map[string]runtime.Object{},
+			},
+		},
+		Clusters:   map[string]*clientcmdapi.Cluster{},
+		Contexts:   map[string]*clientcmdapi.Context{},
+		Extensions: map[string]runtime.Object{},
+		Preferences: clientcmdapi.Preferences{
+			Colors:     false,
+			Extensions: map[string]runtime.Object{},
+		},
+	}
+	expectedConfig.Extensions = map[string]runtime.Object{}
+	test := setConfigTest{
+		description:    "Testing for kubectl config set users.foo.exec.args to test1,test3",
+		config:         conf,
+		args:           []string{"users.foo.exec.args", "test1,test3"},
+		expected:       `Property "users.foo.exec.args" set.` + "\n",
+		expectedConfig: expectedConfig,
+	}
+	test.run(t)
+}
+
+func TestSetConfigExecProvideClusterInfo(t *testing.T) {
+	conf := *clientcmdapi.NewConfig()
+	expectedConfig := clientcmdapi.Config{
+		AuthInfos: map[string]*clientcmdapi.AuthInfo{
+			"foo": {
+				Exec: &clientcmdapi.ExecConfig{
+					ProvideClusterInfo: true,
+				},
+				Extensions: map[string]runtime.Object{},
+			},
+		},
+		Clusters:   map[string]*clientcmdapi.Cluster{},
+		Contexts:   map[string]*clientcmdapi.Context{},
+		Extensions: map[string]runtime.Object{},
+		Preferences: clientcmdapi.Preferences{
+			Colors:     false,
+			Extensions: map[string]runtime.Object{},
+		},
+	}
+	expectedConfig.Extensions = map[string]runtime.Object{}
+	test := setConfigTest{
+		description:    "Testing for kubectl config set users.foo.exec.provideClusterInfo to true",
+		config:         conf,
+		args:           []string{"users.foo.exec.provideClusterInfo", "true"},
+		expected:       `Property "users.foo.exec.provideClusterInfo" set.` + "\n",
+		expectedConfig: expectedConfig,
+	}
+	test.run(t)
+}
+
+func TestSetConfigExecEnvNew(t *testing.T) {
+	conf := *clientcmdapi.NewConfig()
+	expectedConfig := clientcmdapi.Config{
+		AuthInfos: map[string]*clientcmdapi.AuthInfo{
+			"foo": {
+				Exec: &clientcmdapi.ExecConfig{
+					Env: []clientcmdapi.ExecEnvVar{
+						{
+							Name:  "test",
+							Value: "value",
+						},
+					},
+				},
+				Extensions: map[string]runtime.Object{},
+			},
+		},
+		Clusters:   map[string]*clientcmdapi.Cluster{},
+		Contexts:   map[string]*clientcmdapi.Context{},
+		Extensions: map[string]runtime.Object{},
+		Preferences: clientcmdapi.Preferences{
+			Colors:     false,
+			Extensions: map[string]runtime.Object{},
+		},
+	}
+	expectedConfig.Extensions = map[string]runtime.Object{}
+	test := setConfigTest{
+		description:    "Testing for kubectl config set users.foo.exec.env.test to value",
+		config:         conf,
+		args:           []string{"users.foo.exec.env.test", "value"},
+		expected:       `Property "users.foo.exec.env.test" set.` + "\n",
+		expectedConfig: expectedConfig,
+	}
+	test.run(t)
+}
+
+func TestSetConfigExecEnvUpdate(t *testing.T) {
+	conf := clientcmdapi.Config{
+		AuthInfos: map[string]*clientcmdapi.AuthInfo{
+			"foo": {
+				Exec: &clientcmdapi.ExecConfig{
+					Env: []clientcmdapi.ExecEnvVar{
+						{
+							Name:  "test",
+							Value: "value1",
+						},
+					},
+				},
+				Extensions: map[string]runtime.Object{},
+			},
+		},
+		Clusters:   map[string]*clientcmdapi.Cluster{},
+		Contexts:   map[string]*clientcmdapi.Context{},
+		Extensions: map[string]runtime.Object{},
+		Preferences: clientcmdapi.Preferences{
+			Colors:     false,
+			Extensions: map[string]runtime.Object{},
+		},
+	}
+	expectedConfig := clientcmdapi.Config{
+		AuthInfos: map[string]*clientcmdapi.AuthInfo{
+			"foo": {
+				Exec: &clientcmdapi.ExecConfig{
+					Env: []clientcmdapi.ExecEnvVar{
+						{
+							Name:  "test",
+							Value: "value2",
+						},
+					},
+				},
+				Extensions: map[string]runtime.Object{},
+			},
+		},
+		Clusters:   map[string]*clientcmdapi.Cluster{},
+		Contexts:   map[string]*clientcmdapi.Context{},
+		Extensions: map[string]runtime.Object{},
+		Preferences: clientcmdapi.Preferences{
+			Colors:     false,
+			Extensions: map[string]runtime.Object{},
+		},
+	}
+	expectedConfig.Extensions = map[string]runtime.Object{}
+	test := setConfigTest{
+		description:    "Testing for kubectl config set users.foo.exec.env.test to value2",
+		config:         conf,
+		args:           []string{"users.foo.exec.env.test", "value2"},
+		expected:       `Property "users.foo.exec.env.test" set.` + "\n",
+		expectedConfig: expectedConfig,
+	}
+	test.run(t)
+}
+
+func TestSetConfigInstallHint(t *testing.T) {
+	conf := *clientcmdapi.NewConfig()
+	expectedConfig := clientcmdapi.Config{
+		AuthInfos: map[string]*clientcmdapi.AuthInfo{
+			"foo": {
+				Exec: &clientcmdapi.ExecConfig{
+					InstallHint: "test",
+				},
+				Extensions: map[string]runtime.Object{},
+			},
+		},
+		Clusters:   map[string]*clientcmdapi.Cluster{},
+		Contexts:   map[string]*clientcmdapi.Context{},
+		Extensions: map[string]runtime.Object{},
+		Preferences: clientcmdapi.Preferences{
+			Colors:     false,
+			Extensions: map[string]runtime.Object{},
+		},
+	}
+	expectedConfig.Extensions = map[string]runtime.Object{}
+	test := setConfigTest{
+		description:    "Testing for kubectl config set users.foo.exec.installHint to test",
+		config:         conf,
+		args:           []string{"users.foo.exec.installHint", "test"},
+		expected:       `Property "users.foo.exec.installHint" set.` + "\n",
+		expectedConfig: expectedConfig,
+	}
+	test.run(t)
+}
+
+func TestSetConfigImpersonateUser(t *testing.T) {
+	conf := *clientcmdapi.NewConfig()
+	expectedConfig := clientcmdapi.Config{
+		AuthInfos: map[string]*clientcmdapi.AuthInfo{
+			"foo": {
+				Impersonate: "test1",
+				Extensions:  map[string]runtime.Object{},
+			},
+		},
+		Clusters:   map[string]*clientcmdapi.Cluster{},
+		Contexts:   map[string]*clientcmdapi.Context{},
+		Extensions: map[string]runtime.Object{},
+		Preferences: clientcmdapi.Preferences{
+			Colors:     false,
+			Extensions: map[string]runtime.Object{},
+		},
+	}
+	expectedConfig.Extensions = map[string]runtime.Object{}
+	test := setConfigTest{
+		description:    "Testing for kubectl config set users.foo.act-as to test1",
+		config:         conf,
+		args:           []string{"users.foo.act-as", "test1"},
+		expected:       `Property "users.foo.act-as" set.` + "\n",
+		expectedConfig: expectedConfig,
+	}
+	test.run(t)
+}
+
+func TestSetConfigImpersonateUID(t *testing.T) {
+	conf := *clientcmdapi.NewConfig()
+	expectedConfig := clientcmdapi.Config{
+		AuthInfos: map[string]*clientcmdapi.AuthInfo{
+			"foo": {
+				ImpersonateUID: "1000",
+				Extensions:     map[string]runtime.Object{},
+			},
+		},
+		Clusters:   map[string]*clientcmdapi.Cluster{},
+		Contexts:   map[string]*clientcmdapi.Context{},
+		Extensions: map[string]runtime.Object{},
+		Preferences: clientcmdapi.Preferences{
+			Colors:     false,
+			Extensions: map[string]runtime.Object{},
+		},
+	}
+	expectedConfig.Extensions = map[string]runtime.Object{}
+	test := setConfigTest{
+		description:    "Testing for kubectl config set users.foo.act-as to 1000",
+		config:         conf,
+		args:           []string{"users.foo.act-as-uid", "1000"},
+		expected:       `Property "users.foo.act-as-uid" set.` + "\n",
+		expectedConfig: expectedConfig,
+	}
+	test.run(t)
+}
+
+func TestSetConfigImpersonateGroupsNew(t *testing.T) {
+	conf := *clientcmdapi.NewConfig()
+	expectedConfig := clientcmdapi.Config{
+		AuthInfos: map[string]*clientcmdapi.AuthInfo{
+			"foo": {
+				ImpersonateGroups: []string{
+					"test1",
+					"test2",
+					"test3",
+				},
+				Extensions: map[string]runtime.Object{},
+			},
+		},
+		Clusters:   map[string]*clientcmdapi.Cluster{},
+		Contexts:   map[string]*clientcmdapi.Context{},
+		Extensions: map[string]runtime.Object{},
+		Preferences: clientcmdapi.Preferences{
+			Colors:     false,
+			Extensions: map[string]runtime.Object{},
+		},
+	}
+	expectedConfig.Extensions = map[string]runtime.Object{}
+	test := setConfigTest{
+		description:    "Testing for kubectl config set users.foo.act-as-groups to test1,test2,test3",
+		config:         conf,
+		args:           []string{"users.foo.act-as-groups", "test1,test2,test3"},
+		expected:       `Property "users.foo.act-as-groups" set.` + "\n",
+		expectedConfig: expectedConfig,
+	}
+	test.run(t)
+}
+
+func TestSetConfigImpersonateGroupsAdd(t *testing.T) {
+	conf := clientcmdapi.Config{
+		AuthInfos: map[string]*clientcmdapi.AuthInfo{
+			"foo": {
+				ImpersonateGroups: []string{
+					"test1",
+					"test2",
+					"test3",
+				},
+				Extensions: map[string]runtime.Object{},
+			},
+		},
+		Clusters:   map[string]*clientcmdapi.Cluster{},
+		Contexts:   map[string]*clientcmdapi.Context{},
+		Extensions: map[string]runtime.Object{},
+		Preferences: clientcmdapi.Preferences{
+			Colors:     false,
+			Extensions: map[string]runtime.Object{},
+		},
+	}
+	expectedConfig := clientcmdapi.Config{
+		AuthInfos: map[string]*clientcmdapi.AuthInfo{
+			"foo": {
+				ImpersonateGroups: []string{
+					"test1",
+					"test2",
+					"test3",
+					"test4",
+				},
+				Extensions: map[string]runtime.Object{},
+			},
+		},
+		Clusters:   map[string]*clientcmdapi.Cluster{},
+		Contexts:   map[string]*clientcmdapi.Context{},
+		Extensions: map[string]runtime.Object{},
+		Preferences: clientcmdapi.Preferences{
+			Colors:     false,
+			Extensions: map[string]runtime.Object{},
+		},
+	}
+	expectedConfig.Extensions = map[string]runtime.Object{}
+	test := setConfigTest{
+		description:    "Testing for kubectl config set users.foo.act-as-groups to test4+",
+		config:         conf,
+		args:           []string{"users.foo.act-as-groups", "test4+"},
+		expected:       `Property "users.foo.act-as-groups" set.` + "\n",
+		expectedConfig: expectedConfig,
+	}
+	test.run(t)
+}
+
+func TestSetConfigImpersonateGroupsDelete(t *testing.T) {
+	conf := clientcmdapi.Config{
+		AuthInfos: map[string]*clientcmdapi.AuthInfo{
+			"foo": {
+				ImpersonateGroups: []string{
+					"test1",
+					"test2",
+					"test3",
+				},
+				Extensions: map[string]runtime.Object{},
+			},
+		},
+		Clusters:   map[string]*clientcmdapi.Cluster{},
+		Contexts:   map[string]*clientcmdapi.Context{},
+		Extensions: map[string]runtime.Object{},
+		Preferences: clientcmdapi.Preferences{
+			Colors:     false,
+			Extensions: map[string]runtime.Object{},
+		},
+	}
+	expectedConfig := clientcmdapi.Config{
+		AuthInfos: map[string]*clientcmdapi.AuthInfo{
+			"foo": {
+				ImpersonateGroups: []string{
+					"test1",
+					"test2",
+				},
+				Extensions: map[string]runtime.Object{},
+			},
+		},
+		Clusters:   map[string]*clientcmdapi.Cluster{},
+		Contexts:   map[string]*clientcmdapi.Context{},
+		Extensions: map[string]runtime.Object{},
+		Preferences: clientcmdapi.Preferences{
+			Colors:     false,
+			Extensions: map[string]runtime.Object{},
+		},
+	}
+	expectedConfig.Extensions = map[string]runtime.Object{}
+	test := setConfigTest{
+		description:    "Testing for kubectl config set users.foo.act-as-groups to test3-",
+		config:         conf,
+		args:           []string{"users.foo.act-as-groups", "test3-"},
+		expected:       `Property "users.foo.act-as-groups" set.` + "\n",
+		expectedConfig: expectedConfig,
+	}
+	test.run(t)
+}
+
+func TestSetConfigImpersonateGroupsUpdate(t *testing.T) {
+	conf := clientcmdapi.Config{
+		AuthInfos: map[string]*clientcmdapi.AuthInfo{
+			"foo": {
+				ImpersonateGroups: []string{
+					"test1",
+					"test2",
+					"test3",
+					"test4",
+				},
+				Extensions: map[string]runtime.Object{},
+			},
+		},
+		Clusters:   map[string]*clientcmdapi.Cluster{},
+		Contexts:   map[string]*clientcmdapi.Context{},
+		Extensions: map[string]runtime.Object{},
+		Preferences: clientcmdapi.Preferences{
+			Colors:     false,
+			Extensions: map[string]runtime.Object{},
+		},
+	}
+	expectedConfig := clientcmdapi.Config{
+		AuthInfos: map[string]*clientcmdapi.AuthInfo{
+			"foo": {
+				ImpersonateGroups: []string{
+					"test8",
+					"test9",
+				},
+				Extensions: map[string]runtime.Object{},
+			},
+		},
+		Clusters:   map[string]*clientcmdapi.Cluster{},
+		Contexts:   map[string]*clientcmdapi.Context{},
+		Extensions: map[string]runtime.Object{},
+		Preferences: clientcmdapi.Preferences{
+			Colors:     false,
+			Extensions: map[string]runtime.Object{},
+		},
+	}
+	expectedConfig.Extensions = map[string]runtime.Object{}
+	test := setConfigTest{
+		description:    "Testing for kubectl config set users.foo.act-as-groups to test8,test9",
+		config:         conf,
+		args:           []string{"users.foo.act-as-groups", "test8,test9"},
+		expected:       `Property "users.foo.act-as-groups" set.` + "\n",
+		expectedConfig: expectedConfig,
+	}
+	test.run(t)
+}
+
+func TestSetConfigImpersonateUserExtraNew(t *testing.T) {
+	conf := *clientcmdapi.NewConfig()
+	expectedConfig := clientcmdapi.Config{
+		AuthInfos: map[string]*clientcmdapi.AuthInfo{
+			"foo": {
+				ImpersonateUserExtra: map[string][]string{
+					"test1": {
+						"val1",
+						"val2",
+						"val3",
+					},
+				},
+				Extensions: map[string]runtime.Object{},
+			},
+		},
+		Clusters:   map[string]*clientcmdapi.Cluster{},
+		Contexts:   map[string]*clientcmdapi.Context{},
+		Extensions: map[string]runtime.Object{},
+		Preferences: clientcmdapi.Preferences{
+			Colors:     false,
+			Extensions: map[string]runtime.Object{},
+		},
+	}
+	expectedConfig.Extensions = map[string]runtime.Object{}
+	test := setConfigTest{
+		description:    "Testing for kubectl config set users.foo.act-as-user-extra.test1 to val1,val2,val3",
+		config:         conf,
+		args:           []string{"users.foo.act-as-user-extra.test1", "val1,val2,val3"},
+		expected:       `Property "users.foo.act-as-user-extra.test1" set.` + "\n",
+		expectedConfig: expectedConfig,
+	}
+	test.run(t)
+}
+
+func TestSetConfigImpersonateUserExtraAdd(t *testing.T) {
+	conf := clientcmdapi.Config{
+		AuthInfos: map[string]*clientcmdapi.AuthInfo{
+			"foo": {
+				ImpersonateUserExtra: map[string][]string{
+					"test1": {
+						"val1",
+						"val2",
+						"val3",
+					},
+				},
+				Extensions: map[string]runtime.Object{},
+			},
+		},
+		Clusters:   map[string]*clientcmdapi.Cluster{},
+		Contexts:   map[string]*clientcmdapi.Context{},
+		Extensions: map[string]runtime.Object{},
+		Preferences: clientcmdapi.Preferences{
+			Colors:     false,
+			Extensions: map[string]runtime.Object{},
+		},
+	}
+	expectedConfig := clientcmdapi.Config{
+		AuthInfos: map[string]*clientcmdapi.AuthInfo{
+			"foo": {
+				ImpersonateUserExtra: map[string][]string{
+					"test1": {
+						"val1",
+						"val2",
+						"val3",
+						"val4",
+					},
+				},
+				Extensions: map[string]runtime.Object{},
+			},
+		},
+		Clusters:   map[string]*clientcmdapi.Cluster{},
+		Contexts:   map[string]*clientcmdapi.Context{},
+		Extensions: map[string]runtime.Object{},
+		Preferences: clientcmdapi.Preferences{
+			Colors:     false,
+			Extensions: map[string]runtime.Object{},
+		},
+	}
+	expectedConfig.Extensions = map[string]runtime.Object{}
+	test := setConfigTest{
+		description:    "Testing for kubectl config set users.foo.act-as-user-extra.test1 to val4+",
+		config:         conf,
+		args:           []string{"users.foo.act-as-user-extra.test1", "val4+"},
+		expected:       `Property "users.foo.act-as-user-extra.test1" set.` + "\n",
+		expectedConfig: expectedConfig,
+	}
+	test.run(t)
+}
+
+func TestSetConfigImpersonateUserExtraDelete(t *testing.T) {
+	conf := clientcmdapi.Config{
+		AuthInfos: map[string]*clientcmdapi.AuthInfo{
+			"foo": {
+				ImpersonateUserExtra: map[string][]string{
+					"test1": {
+						"val1",
+						"val2",
+						"val3",
+					},
+				},
+				Extensions: map[string]runtime.Object{},
+			},
+		},
+		Clusters:   map[string]*clientcmdapi.Cluster{},
+		Contexts:   map[string]*clientcmdapi.Context{},
+		Extensions: map[string]runtime.Object{},
+		Preferences: clientcmdapi.Preferences{
+			Colors:     false,
+			Extensions: map[string]runtime.Object{},
+		},
+	}
+	expectedConfig := clientcmdapi.Config{
+		AuthInfos: map[string]*clientcmdapi.AuthInfo{
+			"foo": {
+				ImpersonateUserExtra: map[string][]string{
+					"test1": {
+						"val1",
+						"val2",
+					},
+				},
+				Extensions: map[string]runtime.Object{},
+			},
+		},
+		Clusters:   map[string]*clientcmdapi.Cluster{},
+		Contexts:   map[string]*clientcmdapi.Context{},
+		Extensions: map[string]runtime.Object{},
+		Preferences: clientcmdapi.Preferences{
+			Colors:     false,
+			Extensions: map[string]runtime.Object{},
+		},
+	}
+	expectedConfig.Extensions = map[string]runtime.Object{}
+	test := setConfigTest{
+		description:    "Testing for kubectl config set users.foo.act-as-user-extra.test1 to val3-",
+		config:         conf,
+		args:           []string{"users.foo.act-as-user-extra.test1", "val3-"},
+		expected:       `Property "users.foo.act-as-user-extra.test1" set.` + "\n",
+		expectedConfig: expectedConfig,
+	}
+	test.run(t)
+}
+
+func TestSetConfigImpersonateUserExtraUpdate(t *testing.T) {
+	conf := clientcmdapi.Config{
+		AuthInfos: map[string]*clientcmdapi.AuthInfo{
+			"foo": {
+				ImpersonateUserExtra: map[string][]string{
+					"test1": {
+						"val1",
+						"val2",
+						"val3",
+					},
+				},
+				Extensions: map[string]runtime.Object{},
+			},
+		},
+		Clusters:   map[string]*clientcmdapi.Cluster{},
+		Contexts:   map[string]*clientcmdapi.Context{},
+		Extensions: map[string]runtime.Object{},
+		Preferences: clientcmdapi.Preferences{
+			Colors:     false,
+			Extensions: map[string]runtime.Object{},
+		},
+	}
+	expectedConfig := clientcmdapi.Config{
+		AuthInfos: map[string]*clientcmdapi.AuthInfo{
+			"foo": {
+				ImpersonateUserExtra: map[string][]string{
+					"test1": {
+						"val5",
+						"val6",
+						"val7",
+					},
+				},
+				Extensions: map[string]runtime.Object{},
+			},
+		},
+		Clusters:   map[string]*clientcmdapi.Cluster{},
+		Contexts:   map[string]*clientcmdapi.Context{},
+		Extensions: map[string]runtime.Object{},
+		Preferences: clientcmdapi.Preferences{
+			Colors:     false,
+			Extensions: map[string]runtime.Object{},
+		},
+	}
+	expectedConfig.Extensions = map[string]runtime.Object{}
+	test := setConfigTest{
+		description:    "Testing for kubectl config set users.foo.act-as-user-extra.test1 to val5,val6,val7",
+		config:         conf,
+		args:           []string{"users.foo.act-as-user-extra.test1", "val5,val6,val7"},
+		expected:       `Property "users.foo.act-as-user-extra.test1" set.` + "\n",
+		expectedConfig: expectedConfig,
+	}
+	test.run(t)
+}
+
+func TestSetConfigImpersonateUserExtraNewKey(t *testing.T) {
+	conf := clientcmdapi.Config{
+		AuthInfos: map[string]*clientcmdapi.AuthInfo{
+			"foo": {
+				ImpersonateUserExtra: map[string][]string{
+					"test1": {
+						"val1",
+						"val2",
+						"val3",
+					},
+				},
+				Extensions: map[string]runtime.Object{},
+			},
+		},
+		Clusters:   map[string]*clientcmdapi.Cluster{},
+		Contexts:   map[string]*clientcmdapi.Context{},
+		Extensions: map[string]runtime.Object{},
+		Preferences: clientcmdapi.Preferences{
+			Colors:     false,
+			Extensions: map[string]runtime.Object{},
+		},
+	}
+	expectedConfig := clientcmdapi.Config{
+		AuthInfos: map[string]*clientcmdapi.AuthInfo{
+			"foo": {
+				ImpersonateUserExtra: map[string][]string{
+					"test1": {
+						"val1",
+						"val2",
+						"val3",
+					},
+					"test2": {
+						"val1",
+					},
+				},
+				Extensions: map[string]runtime.Object{},
+			},
+		},
+		Clusters:   map[string]*clientcmdapi.Cluster{},
+		Contexts:   map[string]*clientcmdapi.Context{},
+		Extensions: map[string]runtime.Object{},
+		Preferences: clientcmdapi.Preferences{
+			Colors:     false,
+			Extensions: map[string]runtime.Object{},
+		},
+	}
+	expectedConfig.Extensions = map[string]runtime.Object{}
+	test := setConfigTest{
+		description:    "Testing for kubectl config set users.foo.act-as-user-extra.test2 to val1",
+		config:         conf,
+		args:           []string{"users.foo.act-as-user-extra.test2", "val1"},
+		expected:       `Property "users.foo.act-as-user-extra.test2" set.` + "\n",
+		expectedConfig: expectedConfig,
+	}
+	test.run(t)
+}
+
+func TestSetConfigUsername(t *testing.T) {
+	conf := *clientcmdapi.NewConfig()
+	expectedConfig := clientcmdapi.Config{
+		AuthInfos: map[string]*clientcmdapi.AuthInfo{
+			"foo": {
+				Username:   "test1",
+				Extensions: map[string]runtime.Object{},
+			},
+		},
+		Clusters:   map[string]*clientcmdapi.Cluster{},
+		Contexts:   map[string]*clientcmdapi.Context{},
+		Extensions: map[string]runtime.Object{},
+		Preferences: clientcmdapi.Preferences{
+			Colors:     false,
+			Extensions: map[string]runtime.Object{},
+		},
+	}
+	expectedConfig.Extensions = map[string]runtime.Object{}
+	test := setConfigTest{
+		description:    "Testing for kubectl config set users.foo.username to test1",
+		config:         conf,
+		args:           []string{"users.foo.username", "test1"},
+		expected:       `Property "users.foo.username" set.` + "\n",
+		expectedConfig: expectedConfig,
+	}
+	test.run(t)
+}
+
+func TestSetConfigPassword(t *testing.T) {
+	conf := *clientcmdapi.NewConfig()
+	expectedConfig := clientcmdapi.Config{
+		AuthInfos: map[string]*clientcmdapi.AuthInfo{
+			"foo": {
+				Password:   "abadpassword",
+				Extensions: map[string]runtime.Object{},
+			},
+		},
+		Clusters:   map[string]*clientcmdapi.Cluster{},
+		Contexts:   map[string]*clientcmdapi.Context{},
+		Extensions: map[string]runtime.Object{},
+		Preferences: clientcmdapi.Preferences{
+			Colors:     false,
+			Extensions: map[string]runtime.Object{},
+		},
+	}
+	expectedConfig.Extensions = map[string]runtime.Object{}
+	test := setConfigTest{
+		description:    "Testing for kubectl config set users.foo.password to abadpassword",
+		config:         conf,
+		args:           []string{"users.foo.password", "abadpassword"},
+		expected:       `Property "users.foo.password" set.` + "\n",
+		expectedConfig: expectedConfig,
+	}
+	test.run(t)
+}
+
+func TestSetConfigClientCertificate(t *testing.T) {
+	conf := *clientcmdapi.NewConfig()
+	expectedConfig := clientcmdapi.Config{
+		AuthInfos: map[string]*clientcmdapi.AuthInfo{
+			"foo": {
+				ClientCertificate: "./file/path",
+				Extensions:        map[string]runtime.Object{},
+			},
+		},
+		Clusters:   map[string]*clientcmdapi.Cluster{},
+		Contexts:   map[string]*clientcmdapi.Context{},
+		Extensions: map[string]runtime.Object{},
+		Preferences: clientcmdapi.Preferences{
+			Colors:     false,
+			Extensions: map[string]runtime.Object{},
+		},
+	}
+	expectedConfig.Extensions = map[string]runtime.Object{}
+	test := setConfigTest{
+		description:    "Testing for kubectl config set users.foo.client-certificate to ./file/path",
+		config:         conf,
+		args:           []string{"users.foo.client-certificate", "./file/path"},
+		expected:       `Property "users.foo.client-certificate" set.` + "\n",
+		expectedConfig: expectedConfig,
+	}
+	test.run(t)
+}
+
+func TestSetConfigClientCertificateData(t *testing.T) {
+	conf := *clientcmdapi.NewConfig()
+	expectedConfig := clientcmdapi.Config{
+		AuthInfos: map[string]*clientcmdapi.AuthInfo{
+			"foo": {
+				ClientCertificateData: []byte("not real cert data"),
+				Extensions:            map[string]runtime.Object{},
+			},
+		},
+		Clusters:   map[string]*clientcmdapi.Cluster{},
+		Contexts:   map[string]*clientcmdapi.Context{},
+		Extensions: map[string]runtime.Object{},
+		Preferences: clientcmdapi.Preferences{
+			Colors:     false,
+			Extensions: map[string]runtime.Object{},
+		},
+	}
+	expectedConfig.Extensions = map[string]runtime.Object{}
+	test := setConfigTest{
+		description:    "Testing for kubectl config set users.foo.client-certificate-data to not real cert data",
+		config:         conf,
+		args:           []string{"users.foo.client-certificate-data", "--set-raw-bytes=true", "not real cert data"},
+		expected:       `Property "users.foo.client-certificate-data" set.` + "\n",
+		expectedConfig: expectedConfig,
+	}
+	test.run(t)
+}
+
+func TestSetConfigClientKey(t *testing.T) {
+	conf := *clientcmdapi.NewConfig()
+	expectedConfig := clientcmdapi.Config{
+		AuthInfos: map[string]*clientcmdapi.AuthInfo{
+			"foo": {
+				ClientKey:  "./file/path",
+				Extensions: map[string]runtime.Object{},
+			},
+		},
+		Clusters:   map[string]*clientcmdapi.Cluster{},
+		Contexts:   map[string]*clientcmdapi.Context{},
+		Extensions: map[string]runtime.Object{},
+		Preferences: clientcmdapi.Preferences{
+			Colors:     false,
+			Extensions: map[string]runtime.Object{},
+		},
+	}
+	expectedConfig.Extensions = map[string]runtime.Object{}
+	test := setConfigTest{
+		description:    "Testing for kubectl config set users.foo.client-key to ./file/path",
+		config:         conf,
+		args:           []string{"users.foo.client-key", "./file/path"},
+		expected:       `Property "users.foo.client-key" set.` + "\n",
+		expectedConfig: expectedConfig,
+	}
+	test.run(t)
+}
+
+func TestSetConfigClientKeyData(t *testing.T) {
+	conf := *clientcmdapi.NewConfig()
+	expectedConfig := clientcmdapi.Config{
+		AuthInfos: map[string]*clientcmdapi.AuthInfo{
+			"foo": {
+				ClientKeyData: []byte("not real key data"),
+				Extensions:    map[string]runtime.Object{},
+			},
+		},
+		Clusters:   map[string]*clientcmdapi.Cluster{},
+		Contexts:   map[string]*clientcmdapi.Context{},
+		Extensions: map[string]runtime.Object{},
+		Preferences: clientcmdapi.Preferences{
+			Colors:     false,
+			Extensions: map[string]runtime.Object{},
+		},
+	}
+	expectedConfig.Extensions = map[string]runtime.Object{}
+	test := setConfigTest{
+		description:    "Testing for kubectl config set users.foo.client-key-data to not real key data",
+		config:         conf,
+		args:           []string{"users.foo.client-key-data", "--set-raw-bytes=true", "not real key data"},
+		expected:       `Property "users.foo.client-key-data" set.` + "\n",
+		expectedConfig: expectedConfig,
+	}
+	test.run(t)
+}
+
+func TestSetConfigToken(t *testing.T) {
+	conf := *clientcmdapi.NewConfig()
+	expectedConfig := clientcmdapi.Config{
+		AuthInfos: map[string]*clientcmdapi.AuthInfo{
+			"foo": {
+				Token:      "fake token data",
+				Extensions: map[string]runtime.Object{},
+			},
+		},
+		Clusters:   map[string]*clientcmdapi.Cluster{},
+		Contexts:   map[string]*clientcmdapi.Context{},
+		Extensions: map[string]runtime.Object{},
+		Preferences: clientcmdapi.Preferences{
+			Colors:     false,
+			Extensions: map[string]runtime.Object{},
+		},
+	}
+	expectedConfig.Extensions = map[string]runtime.Object{}
+	test := setConfigTest{
+		description:    "Testing for kubectl config set users.foo.token to fake token data",
+		config:         conf,
+		args:           []string{"users.foo.token", "fake token data"},
+		expected:       `Property "users.foo.token" set.` + "\n",
+		expectedConfig: expectedConfig,
+	}
+	test.run(t)
+}
+
+func TestSetConfigTokenFile(t *testing.T) {
+	conf := *clientcmdapi.NewConfig()
+	expectedConfig := clientcmdapi.Config{
+		AuthInfos: map[string]*clientcmdapi.AuthInfo{
+			"foo": {
+				TokenFile:  "./file/path",
+				Extensions: map[string]runtime.Object{},
+			},
+		},
+		Clusters:   map[string]*clientcmdapi.Cluster{},
+		Contexts:   map[string]*clientcmdapi.Context{},
+		Extensions: map[string]runtime.Object{},
+		Preferences: clientcmdapi.Preferences{
+			Colors:     false,
+			Extensions: map[string]runtime.Object{},
+		},
+	}
+	expectedConfig.Extensions = map[string]runtime.Object{}
+	test := setConfigTest{
+		description:    "Testing for kubectl config set users.foo.tokenFile to ./file/path",
+		config:         conf,
+		args:           []string{"users.foo.tokenFile", "./file/path"},
+		expected:       `Property "users.foo.tokenFile" set.` + "\n",
+		expectedConfig: expectedConfig,
+	}
+	test.run(t)
+}
+
+func TestSetConfigAuthProviderError(t *testing.T) {
+	conf := *clientcmdapi.NewConfig()
+	test := setConfigTest{
+		description: "Testing for kubectl config set users.foo.auth-provider to oidc error",
+		config:      conf,
+		args:        []string{"users.foo.auth-provider", "test"},
+		expectedErr: `unable to locate path auth-provider`,
 	}
 	test.run(t)
 }
@@ -134,6 +1239,27 @@ func (test setConfigTest) run(t *testing.T) {
 	buf := bytes.NewBuffer([]byte{})
 	cmd := NewCmdConfigSet(buf, pathOptions)
 	cmd.SetArgs(test.args)
+	opts := &setOptions{
+		configAccess:  pathOptions,
+		propertyName:  test.args[0],
+		propertyValue: test.args[1],
+	}
+
+	// Must use opts.run to get error outputs
+	err = opts.run()
+	if test.expectedErr == "" && err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Check for expected error message
+	if test.expectedErr != "" {
+		if err != nil && err.Error() != test.expectedErr {
+			t.Fatalf("expected error:\n %v\nbut got error:\n%v", test.expectedErr, err)
+		}
+		return
+	}
+
+	// Must use cmd.Execute to get stdout output
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("unexpected error executing command: %v", err)
 	}
@@ -148,7 +1274,7 @@ func (test setConfigTest) run(t *testing.T) {
 			if test.expectedConfig.AuthInfos[k] != nil && config.AuthInfos[k] != nil {
 				test.expectedConfig.AuthInfos[k].LocationOfOrigin = config.AuthInfos[k].LocationOfOrigin
 			} else {
-				t.Errorf("Failed in:%q\n cannot find key %v in either expectedConfig or config", test.description, k)
+				t.Errorf("Failed in:%q\n cannot find key %v in AuthInfos map for expectedConfig and/or config", test.description, k)
 			}
 		}
 	}
@@ -159,6 +1285,6 @@ func (test setConfigTest) run(t *testing.T) {
 		}
 	}
 	if !reflect.DeepEqual(*config, test.expectedConfig) {
-		t.Errorf("Failed in: %q\n expected %#v\n but got %#v", test.description, *config, test.expectedConfig)
+		t.Errorf("config want/got mismatch (-want +got):\n%s", cmp.Diff(test.expectedConfig, *config))
 	}
 }

--- a/staging/src/k8s.io/kubectl/pkg/cmd/config/unset.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/config/unset.go
@@ -84,7 +84,7 @@ func (o unsetOptions) run(out io.Writer) error {
 	if err != nil {
 		return err
 	}
-	err = modifyConfig(reflect.ValueOf(config), steps, "", true, true)
+	err = modifyConfig(reflect.ValueOf(config), steps, "", true, true, false)
 	if err != nil {
 		return err
 	}

--- a/staging/src/k8s.io/kubectl/pkg/cmd/config/unset_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/config/unset_test.go
@@ -107,7 +107,7 @@ func TestUnsetUnexistConfig(t *testing.T) {
 
 func TestUnsetAuthProviderInfo(t *testing.T) {
 	authProviderConfig := clientcmdapi.AuthProviderConfig{
-		Name: "foo",
+		Name:   "foo",
 		Config: map[string]string{"refresh-token": "testestestest"},
 	}
 	conf := clientcmdapi.Config{

--- a/staging/src/k8s.io/kubectl/pkg/cmd/config/unset_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/config/unset_test.go
@@ -105,6 +105,36 @@ func TestUnsetUnexistConfig(t *testing.T) {
 
 }
 
+func TestUnsetAuthProviderInfo(t *testing.T) {
+	authProviderConfig := clientcmdapi.AuthProviderConfig{
+		Name: "foo",
+		Config: map[string]string{"refresh-token": "testestestest"},
+	}
+	conf := clientcmdapi.Config{
+		Kind:       "Config",
+		APIVersion: "v1",
+		Clusters: map[string]*clientcmdapi.Cluster{
+			"minikube":   {Server: "https://192.168.99.100:8443"},
+			"my-cluster": {Server: "https://192.168.0.1:3434"},
+		},
+		Contexts: map[string]*clientcmdapi.Context{
+			"minikube":   {AuthInfo: "minikube", Cluster: "minikube"},
+			"my-cluster": {AuthInfo: "mu-cluster", Cluster: "my-cluster"},
+		},
+		CurrentContext: "minikube",
+		AuthInfos: map[string]*clientcmdapi.AuthInfo{
+			"foo": {AuthProvider: &authProviderConfig},
+		},
+	}
+	test := unsetConfigTest{
+		description: "Testing for kubectl config unset auth-provider configurations",
+		config:      conf,
+		args:        []string{"users.foo.auth-provider.foo.refresh-token"},
+		expected:    `Property "users.foo.auth-provider.foo.refresh-token" unset.` + "\n",
+	}
+	test.run(t)
+}
+
 func (test unsetConfigTest) run(t *testing.T) {
 	fakeKubeFile, err := ioutil.TempFile(os.TempDir(), "")
 	if err != nil {

--- a/staging/src/k8s.io/kubectl/pkg/cmd/config/unset_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/config/unset_test.go
@@ -129,8 +129,8 @@ func TestUnsetAuthProviderInfo(t *testing.T) {
 	test := unsetConfigTest{
 		description: "Testing for kubectl config unset auth-provider configurations",
 		config:      conf,
-		args:        []string{"users.foo.auth-provider.foo.refresh-token"},
-		expected:    `Property "users.foo.auth-provider.foo.refresh-token" unset.` + "\n",
+		args:        []string{"users.foo.auth-provider.config.refresh-token"},
+		expected:    `Property "users.foo.auth-provider.config.refresh-token" unset.` + "\n",
 	}
 	test.run(t)
 }


### PR DESCRIPTION
/kind feature
/hold

#### What this PR does / why we need it:
This PR enables users to set and unset all configuration keys that correspond to config settings with json tags

#### Which issue(s) this PR fixes:
fixes kubernetes/kubectl#1093

#### Does this PR introduce a user-facing change?
```release-note
users can now edit all settings with json tags in the kubeconfig
```

### Examples
#### Set auth-provider name
```bash
❯ ./_output/local/bin/darwin/amd64/kubectl config set users.foo.auth-provider.name test
Property "users.foo.auth-provider.name" set.
```
Resulting config:
```
apiVersion: v1
clusters: null
contexts: null
current-context: ""
kind: Config
preferences: {}
users:
- name: foo
  user:
    auth-provider:
      config: null
      name: test
```
#### Unset auth-provider name
```bash
❯ ./_output/local/bin/darwin/amd64/kubectl config unset users.foo.auth-provider.name     
error: cannot unset the name of auth-provider, must update or unset auth-provider itself
```
Original config:
```
apiVersion: v1
clusters: null
contexts: null
current-context: ""
kind: Config
preferences: {}
users:
- name: foo
  user:
    auth-provider:
      config: null
      name: test
```
Resulting config:
```
apiVersion: v1
clusters: null
contexts: null
current-context: ""
kind: Config
preferences: {}
users:
- name: foo
  user:
    auth-provider:
      config: null
      name: ""
```
#### Set auth-provider config refresh-token
```bash
❯ ./_output/local/bin/darwin/amd64/kubectl config set users.foo.auth-provider.config.refresh-token test
Property "users.foo.auth-provider.config.refresh-token" set.
```
Resulting config:
```
apiVersion: v1
clusters: null
contexts: null
current-context: ""
kind: Config
preferences: {}
users:
- name: foo
  user:
    auth-provider:
      config:
        refresh-token: test
      name: ""
```
#### Unset auth-provider config refresh-token
```bash
❯ ./_output/local/bin/darwin/amd64/kubectl config unset users.foo.auth-provider.config.refresh-token
Property "users.foo.auth-provider.config.refresh-token" unset.
```
Original config:
```
apiVersion: v1
clusters: null
contexts: null
current-context: ""
kind: Config
preferences: {}
users:
- name: foo
  user:
    auth-provider:
      config:
        refresh-token: test
      name: ""
```
Resulting config:
```
apiVersion: v1
clusters: null
contexts: null
current-context: ""
kind: Config
preferences: {}
users:
- name: foo
  user:
    auth-provider:
      config: {}
      name: ""
```
#### Unset auth-provider config
```bash
❯ ./_output/local/bin/darwin/amd64/kubectl config unset users.foo.auth-provider.config
Property "users.foo.auth-provider.config" unset.
```
Original config:
```
apiVersion: v1
clusters: null
contexts: null
current-context: ""
kind: Config
preferences: {}
users:
- name: foo
  user:
    auth-provider:
      config:
        refresh-token: test
      name: ""
```
Resulting config:
```
apiVersion: v1
clusters: null
contexts: null
current-context: ""
kind: Config
preferences: {}
users:
- name: foo
  user:
    auth-provider:
      config: null
      name: ""
```
#### Set new auth-provider name
```bash
❯ ./_output/local/bin/darwin/amd64/kubectl config set users.test.auth-provider.name test
Property "users.test.auth-provider.name" set.
```
Original config:
```
apiVersion: v1
clusters: null
contexts: null
current-context: ""
kind: Config
preferences: {}
users:
- name: foo
  user:
    auth-provider:
      config: null
      name: oidc
```
Resulting config:
```
apiVersion: v1
clusters: null
contexts: null
current-context: ""
kind: Config
preferences: {}
users:
- name: foo
  user:
    auth-provider:
      config: null
      name: test
```
#### Set new auth-provider with config refresh-token
```bash
❯ ./_output/local/bin/darwin/amd64/kubectl config set users.test.auth-provider.config.refresh-token test
Property "users.test.auth-provider.config.refresh-token" set.
```
Original config:
```
apiVersion: v1
clusters: null
contexts: null
current-context: ""
kind: Config
preferences: {}
users:
- name: foo
  user:
    auth-provider:
      config:
        refresh-token: test
      name: ""
```
Resulting config:
```
apiVersion: v1
clusters: null
contexts: null
current-context: ""
kind: Config
preferences: {}
users:
- name: foo
  user:
    auth-provider:
      config:
        refresh-token: testnew
      name: ""
```
#### Set auth-provider with no key
```bash
❯ ./_output/local/bin/darwin/amd64/kubectl config set users.test.auth-provider test
error: unable to locate path auth-provider
```
#### Unset auth-provider
```bash
❯ ./_output/local/bin/darwin/amd64/kubectl config unset users.foo.auth-provider
Property "users.foo.auth-provider" unset.
```
Original config:
```
apiVersion: v1
clusters: null
contexts: null
current-context: ""
kind: Config
preferences: {}
users:
- name: foo
  user:
    auth-provider:
      config:
        refresh-token: testnew
      name: ""
```
Resulting config:
```
apiVersion: v1
clusters: null
contexts: null
current-context: ""
kind: Config
preferences: {}
users:
- name: foo
  user: {}
```
#### Set new exec args
```bash
❯ ./_output/local/bin/darwin/amd64/kubectl config set users.foo.exec.args test1,test2,test3
Property "users.foo.exec.args" set.
```
Resulting config:
```
apiVersion: v1
clusters: null
contexts: null
current-context: ""
kind: Config
preferences: {}
users:
- name: foo
  user:
    exec:
      args:
      - test1
      - test2
      - test3
      command: ""
      env: null
      provideClusterInfo: false
```
#### Add new exec arg
```bash
❯ ./_output/local/bin/darwin/amd64/kubectl config set users.foo.exec.args test4+           
Property "users.foo.exec.args" set.
```
Original config:
```
apiVersion: v1
clusters: null
contexts: null
current-context: ""
kind: Config
preferences: {}
users:
- name: foo
  user:
    exec:
      args:
      - test1
      - test2
      - test3
      command: ""
      env: null
      provideClusterInfo: false
```
Resulting config:
```
apiVersion: v1
clusters: null
contexts: null
current-context: ""
kind: Config
preferences: {}
users:
- name: foo
  user:
    exec:
      args:
      - test1
      - test2
      - test3
      - test4
      command: ""
      env: null
      provideClusterInfo: false
```
#### Remove exec args
```bash
❯ ./_output/local/bin/darwin/amd64/kubectl config set users.foo.exec.args test2-
Property "users.foo.exec.args" set.
```
Original config:
```
apiVersion: v1
clusters: null
contexts: null
current-context: ""
kind: Config
preferences: {}
users:
- name: foo
  user:
    exec:
      args:
      - test1
      - test2
      - test3
      - test4
      command: ""
      env: null
      provideClusterInfo: false
```
Resulting config:
```
apiVersion: v1
clusters: null
contexts: null
current-context: ""
kind: Config
preferences: {}
users:
- name: foo
  user:
    exec:
      args:
      - test1
      - test3
      - test4
      command: ""
      env: null
      provideClusterInfo: false
```
#### Overwrite existing exec args
```bash
❯ ./_output/local/bin/darwin/amd64/kubectl config set users.foo.exec.args test5,test6
Property "users.foo.exec.args" set.
```
Original config:
```
apiVersion: v1
clusters: null
contexts: null
current-context: ""
kind: Config
preferences: {}
users:
- name: foo
  user:
    exec:
      args:
      - test1
      - test3
      - test4
      command: ""
      env: null
      provideClusterInfo: false
```
Resulting config:
```
apiVersion: v1
clusters: null
contexts: null
current-context: ""
kind: Config
preferences: {}
users:
- name: foo
  user:
    exec:
      args:
      - test5
      - test6
      command: ""
      env: null
      provideClusterInfo: false
```
#### Set new exec environment variable
```bash
❯ ./_output/local/bin/darwin/amd64/kubectl config set users.foo.exec.env.name.test value:val1
Property "users.foo.exec.env.name.test" set.
```
Resulting config:
```
apiVersion: v1
clusters: null
contexts: null
current-context: ""
kind: Config
preferences: {}
users:
- name: foo
  user:
    exec:
      args: null
      command: ""
      env:
      - name: test
        value: val1
      provideClusterInfo: false
```
#### Update existing exec environment variable
```bash
❯ ./_output/local/bin/darwin/amd64/kubectl config set users.foo.exec.env.name.test value:val2
Property "users.foo.exec.env.name.test" set.
```
Original config:
```
apiVersion: v1
clusters: null
contexts: null
current-context: ""
kind: Config
preferences: {}
users:
- name: foo
  user:
    exec:
      args: null
      command: ""
      env:
      - name: test
        value: val1
      provideClusterInfo: false
```
Resulting config:
```
apiVersion: v1
clusters: null
contexts: null
current-context: ""
kind: Config
preferences: {}
users:
- name: foo
  user:
    exec:
      args: null
      command: ""
      env:
      - name: test
        value: val2
      provideClusterInfo: false
```
#### Set new act-as-user-extra
```bash
❯ ./_output/local/bin/darwin/amd64/kubectl config set users.foo.act-as-user-extra.test1 val1,val2,val3
Property "users.foo.act-as-user-extra.test1" set.
```
Resulting config:
```apiVersion: v1
clusters: null
contexts: null
current-context: ""
kind: Config
preferences: {}
users:
- name: foo
  user:
    as-user-extra:
      test1:
      - val1
      - val2
      - val3
```
#### Add new act-as-user-extra
```bash
❯ ./_output/local/bin/darwin/amd64/kubectl config set users.foo.act-as-user-extra.test1 val4+
Property "users.foo.act-as-user-extra.test1" set.
```
Original config:
```
apiVersion: v1
clusters: null
contexts: null
current-context: ""
kind: Config
preferences: {}
users:
- name: foo
  user:
    as-user-extra:
      test1:
      - val1
      - val2
      - val3
```
Resulting config:
```
apiVersion: v1
clusters: null
contexts: null
current-context: ""
kind: Config
preferences: {}
users:
- name: foo
  user:
    as-user-extra:
      test1:
      - val1
      - val2
      - val3
      - val4
```
#### Remove act-as-user-extra
```bash
❯ ./_output/local/bin/darwin/amd64/kubectl config set users.foo.act-as-user-extra.test1 val3-
Property "users.foo.act-as-user-extra.test1" set.
```
Original config:
```
apiVersion: v1
clusters: null
contexts: null
current-context: ""
kind: Config
preferences: {}
users:
- name: foo
  user:
    as-user-extra:
      test1:
      - val1
      - val2
      - val3
      - val4
```
Resulting config:
```
apiVersion: v1
clusters: null
contexts: null
current-context: ""
kind: Config
preferences: {}
users:
- name: foo
  user:
    as-user-extra:
      test1:
      - val1
      - val2
      - val4
```
#### Overwrite existing act-as-user-extra
```bash
❯ ./_output/local/bin/darwin/amd64/kubectl config set users.foo.act-as-user-extra.test1 val8,val9,val0 
Property "users.foo.act-as-user-extra.test1" set.
```
Original config:
```
apiVersion: v1
clusters: null
contexts: null
current-context: ""
kind: Config
preferences: {}
users:
- name: foo
  user:
    as-user-extra:
      test1:
      - val1
      - val2
      - val4
```
Resulting config:
```
apiVersion: v1
clusters: null
contexts: null
current-context: ""
kind: Config
preferences: {}
users:
- name: foo
  user:
    as-user-extra:
      test1:
      - val0
      - val8
      - val9
```