### PR TITLE
kubeadm: fix panic in runKubeletConfigPhase

### DIFF
--- a/cmd/kubeadm/app/cmd/phases/upgrade/node/kubeletconfig.go
+++ b/cmd/kubeadm/app/cmd/phases/upgrade/node/kubeletconfig.go
@@ -102,8 +102,8 @@ func runKubeletConfigPhase() func(c workflow.RunData) error {
 		//
 		// TODO: this workaround can be removed in 1.25 once all user node sockets have a URL scheme:
 		// https://github.com/kubernetes/kubeadm/issues/2426
-		var nro *kubeadmapi.NodeRegistrationOptions
 		var missingURLScheme bool
+		nro := &kubeadmapi.NodeRegistrationOptions{}
 		if !dryRun {
 			if err := configutil.GetNodeRegistration(data.KubeConfigPath(), data.Client(), nro); err != nil {
 				return errors.Wrap(err, "could not retrieve the node registration options for this node")


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

The "nro" struct must be initialized before passing it to
GetNodeRegistration().

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
introduced in https://github.com/kubernetes/kubernetes/pull/107295

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
