### PR TITLE
kubeadm: adapt CRI detection and defaults after the dockershim removal

### DIFF
--- a/cmd/kubeadm/app/apis/kubeadm/v1beta2/doc.go
+++ b/cmd/kubeadm/app/apis/kubeadm/v1beta2/doc.go
@@ -169,7 +169,7 @@ limitations under the License.
 // 	  - system:bootstrappers:kubeadm:default-node-token
 // 	nodeRegistration:
 // 	  name: "ec2-10-100-0-1"
-// 	  criSocket: "unix:///var/run/dockershim.sock"
+// 	  criSocket: "unix:///var/run/containerd/containerd.sock"
 // 	  taints:
 // 	  - key: "kubeadmNode"
 // 	    value: "master"

--- a/cmd/kubeadm/app/apis/kubeadm/v1beta3/doc.go
+++ b/cmd/kubeadm/app/apis/kubeadm/v1beta3/doc.go
@@ -173,7 +173,7 @@ limitations under the License.
 // 	  - system:bootstrappers:kubeadm:default-node-token
 // 	nodeRegistration:
 // 	  name: "ec2-10-100-0-1"
-// 	  criSocket: "unix:///var/run/dockershim.sock"
+// 	  criSocket: "unix:///var/run/containerd/containerd.sock"
 // 	  taints:
 // 	  - key: "kubeadmNode"
 // 	    value: "master"

--- a/cmd/kubeadm/app/apis/kubeadm/validation/validation_test.go
+++ b/cmd/kubeadm/app/apis/kubeadm/validation/validation_test.go
@@ -579,7 +579,7 @@ func TestValidateJoinConfiguration(t *testing.T) {
 			},
 			NodeRegistration: kubeadmapi.NodeRegistrationOptions{
 				Name:      "aaa",
-				CRISocket: "unix:///var/run/dockershim.sock",
+				CRISocket: "unix:///var/run/containerd/containerd.sock",
 			},
 		}, true},
 		{&kubeadmapi.JoinConfiguration{ // Pass with JoinControlPlane
@@ -594,7 +594,7 @@ func TestValidateJoinConfiguration(t *testing.T) {
 			},
 			NodeRegistration: kubeadmapi.NodeRegistrationOptions{
 				Name:      "aaa",
-				CRISocket: "unix:///var/run/dockershim.sock",
+				CRISocket: "unix:///var/run/containerd/containerd.sock",
 			},
 			ControlPlane: &kubeadmapi.JoinControlPlane{
 				LocalAPIEndpoint: kubeadmapi.APIEndpoint{
@@ -615,7 +615,7 @@ func TestValidateJoinConfiguration(t *testing.T) {
 			},
 			NodeRegistration: kubeadmapi.NodeRegistrationOptions{
 				Name:      "aaa",
-				CRISocket: "unix:///var/run/dockershim.sock",
+				CRISocket: "unix:///var/run/containerd/containerd.sock",
 			},
 			ControlPlane: &kubeadmapi.JoinControlPlane{
 				LocalAPIEndpoint: kubeadmapi.APIEndpoint{
@@ -636,7 +636,7 @@ func TestValidateJoinConfiguration(t *testing.T) {
 			},
 			NodeRegistration: kubeadmapi.NodeRegistrationOptions{
 				Name:      "aaa",
-				CRISocket: "/var/run/dockershim.sock",
+				CRISocket: "unix:///var/run/containerd/containerd.sock",
 			},
 			ControlPlane: &kubeadmapi.JoinControlPlane{
 				LocalAPIEndpoint: kubeadmapi.APIEndpoint{

--- a/cmd/kubeadm/app/cmd/certs_test.go
+++ b/cmd/kubeadm/app/cmd/certs_test.go
@@ -359,7 +359,7 @@ kind: InitConfiguration
 localAPIEndpoint:
   advertiseAddress: 192.0.2.1
 nodeRegistration:
-  criSocket: /path/to/dockershim.sock
+  criSocket: "unix:///var/run/containerd/containerd.sock"
 ---
 apiVersion: %[1]s
 kind: ClusterConfiguration

--- a/cmd/kubeadm/app/cmd/config.go
+++ b/cmd/kubeadm/app/cmd/config.go
@@ -211,7 +211,7 @@ func getDefaultNodeConfigBytes() ([]byte, error) {
 			},
 		},
 		NodeRegistration: kubeadmapiv1.NodeRegistrationOptions{
-			CRISocket: constants.DefaultDockerCRISocket, // avoid CRI detection
+			CRISocket: constants.DefaultCRISocket, // avoid CRI detection
 		},
 	})
 	if err != nil {

--- a/cmd/kubeadm/app/cmd/config_test.go
+++ b/cmd/kubeadm/app/cmd/config_test.go
@@ -363,10 +363,10 @@ func TestImagesPull(t *testing.T) {
 			func(cmd string, args ...string) exec.Cmd { return fakeexec.InitFakeCmd(&fcmd, cmd, args...) },
 			func(cmd string, args ...string) exec.Cmd { return fakeexec.InitFakeCmd(&fcmd, cmd, args...) },
 		},
-		LookPathFunc: func(cmd string) (string, error) { return "/usr/bin/docker", nil },
+		LookPathFunc: func(cmd string) (string, error) { return "/usr/bin/crictl", nil },
 	}
 
-	containerRuntime, err := utilruntime.NewContainerRuntime(&fexec, constants.DefaultDockerCRISocket)
+	containerRuntime, err := utilruntime.NewContainerRuntime(&fexec, constants.DefaultCRISocket)
 	if err != nil {
 		t.Errorf("unexpected NewContainerRuntime error: %v", err)
 	}

--- a/cmd/kubeadm/app/cmd/phases/init/waitcontrolplane.go
+++ b/cmd/kubeadm/app/cmd/phases/init/waitcontrolplane.go
@@ -29,7 +29,6 @@ import (
 	"k8s.io/klog/v2"
 
 	"k8s.io/kubernetes/cmd/kubeadm/app/cmd/phases/workflow"
-	kubeadmconstants "k8s.io/kubernetes/cmd/kubeadm/app/constants"
 	"k8s.io/kubernetes/cmd/kubeadm/app/util/apiclient"
 	dryrunutil "k8s.io/kubernetes/cmd/kubeadm/app/util/dryrun"
 )
@@ -49,17 +48,10 @@ var (
 
 	Additionally, a control plane component may have crashed or exited when started by the container runtime.
 	To troubleshoot, list all containers using your preferred container runtimes CLI.
-{{ if .IsDocker }}
-	Here is one example how you may list all Kubernetes containers running in docker:
-		- 'docker ps -a | grep kube | grep -v pause'
-		Once you have found the failing container, you can inspect its logs with:
-		- 'docker logs CONTAINERID'
-{{ else }}
-	Here is one example how you may list all Kubernetes containers running in cri-o/containerd using crictl:
+	Here is one example how you may list all running Kubernetes containers by using crictl:
 		- 'crictl --runtime-endpoint {{ .Socket }} ps -a | grep kube | grep -v pause'
 		Once you have found the failing container, you can inspect its logs with:
 		- 'crictl --runtime-endpoint {{ .Socket }} logs CONTAINERID'
-{{ end }}
 	`)))
 )
 
@@ -105,13 +97,11 @@ func runWaitControlPlanePhase(c workflow.RunData) error {
 
 	if err := waiter.WaitForKubeletAndFunc(waiter.WaitForAPI); err != nil {
 		context := struct {
-			Error    string
-			Socket   string
-			IsDocker bool
+			Error  string
+			Socket string
 		}{
-			Error:    fmt.Sprintf("%v", err),
-			Socket:   data.Cfg().NodeRegistration.CRISocket,
-			IsDocker: data.Cfg().NodeRegistration.CRISocket == kubeadmconstants.DefaultDockerCRISocket,
+			Error:  fmt.Sprintf("%v", err),
+			Socket: data.Cfg().NodeRegistration.CRISocket,
 		}
 
 		kubeletFailTempl.Execute(data.OutputWriter(), context)

--- a/cmd/kubeadm/app/cmd/phases/reset/cleanupnode.go
+++ b/cmd/kubeadm/app/cmd/phases/reset/cleanupnode.go
@@ -84,6 +84,8 @@ func runCleanupNode(c workflow.RunData) error {
 		klog.Warningf("[reset] Failed to remove containers: %v\n", err)
 	}
 
+	// TODO: remove the dockershim directory cleanup in 1.25
+	// https://github.com/kubernetes/kubeadm/issues/2626
 	r.AddDirsToClean("/var/lib/dockershim", "/var/run/kubernetes", "/var/lib/cni")
 
 	// Remove contents from the config and pki directories

--- a/cmd/kubeadm/app/constants/constants_unix.go
+++ b/cmd/kubeadm/app/constants/constants_unix.go
@@ -20,6 +20,13 @@ limitations under the License.
 package constants
 
 const (
-	// DefaultDockerCRISocket defines the default Docker CRI socket
-	DefaultDockerCRISocket = "unix:///var/run/dockershim.sock"
+	// CRISocketContainerd is the containerd CRI endpoint
+	CRISocketContainerd = "unix:///var/run/containerd/containerd.sock"
+	// CRISocketCRIO is the cri-o CRI endpoint
+	CRISocketCRIO = "unix:///var/run/crio/crio.sock"
+	// CRISocketDocker is the cri-dockerd CRI endpoint
+	CRISocketDocker = "unix:///var/run/cri-dockerd.sock"
+
+	// DefaultCRISocket defines the default CRI socket
+	DefaultCRISocket = CRISocketContainerd
 )

--- a/cmd/kubeadm/app/constants/constants_windows.go
+++ b/cmd/kubeadm/app/constants/constants_windows.go
@@ -20,6 +20,14 @@ limitations under the License.
 package constants
 
 const (
-	// DefaultDockerCRISocket defines the default Docker CRI socket
-	DefaultDockerCRISocket = "npipe:////./pipe/docker_engine"
+	// CRISocketContainerd is the containerd CRI endpoint
+	CRISocketContainerd = "npipe:////./pipe/containerd-containerd"
+	// CRISocketCRIO is the cri-o CRI endpoint
+	// NOTE: this is a placeholder as CRI-O does not support Windows
+	CRISocketCRIO = "npipe:////./pipe/cri-o"
+	// CRISocketDocker is the cri-dockerd CRI endpoint
+	CRISocketDocker = "npipe:////./pipe/cri-dockerd"
+
+	// DefaultCRISocket defines the default CRI socket
+	DefaultCRISocket = CRISocketContainerd
 )

--- a/cmd/kubeadm/app/phases/kubelet/flags.go
+++ b/cmd/kubeadm/app/phases/kubelet/flags.go
@@ -21,6 +21,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -102,7 +103,13 @@ func buildKubeletArgMapCommon(opts kubeletFlagsOpts) map[string]string {
 	// Once that happens only the "remote" branch option should be left.
 	// TODO: https://github.com/kubernetes/kubeadm/issues/2626
 	hasDockershim := opts.kubeletVersion.Major() == 1 && opts.kubeletVersion.Minor() < 24
-	if opts.nodeRegOpts.CRISocket == constants.DefaultDockerCRISocket && hasDockershim {
+	var dockerSocket string
+	if runtime.GOOS == "windows" {
+		dockerSocket = "npipe:////./pipe/dockershim"
+	} else {
+		dockerSocket = "unix:///var/run/dockershim.sock"
+	}
+	if opts.nodeRegOpts.CRISocket == dockerSocket && hasDockershim {
 		kubeletFlags["network-plugin"] = "cni"
 	} else {
 		kubeletFlags["container-runtime"] = "remote"

--- a/cmd/kubeadm/app/phases/patchnode/patchnode_test.go
+++ b/cmd/kubeadm/app/phases/patchnode/patchnode_test.go
@@ -52,7 +52,7 @@ func TestAnnotateCRISocket(t *testing.T) {
 		},
 		{
 			name:                       "CRI-socket annotation needs to be updated",
-			currentCRISocketAnnotation: "unix:///var/run/dockershim.sock",
+			currentCRISocketAnnotation: "unix:///foo/bar",
 			newCRISocketAnnotation:     "unix:///run/containerd/containerd.sock",
 			expectedPatch:              `{"metadata":{"annotations":{"kubeadm.alpha.kubernetes.io/cri-socket":"unix:///run/containerd/containerd.sock"}}}`,
 		},

--- a/cmd/kubeadm/app/preflight/checks.go
+++ b/cmd/kubeadm/app/preflight/checks.go
@@ -507,9 +507,7 @@ func (subnet HTTPProxyCIDRCheck) Check() (warnings, errorList []error) {
 }
 
 // SystemVerificationCheck defines struct used for running the system verification node check in test/e2e_node/system
-type SystemVerificationCheck struct {
-	IsDocker bool
-}
+type SystemVerificationCheck struct{}
 
 // Name will return SystemVerification as name for SystemVerificationCheck
 func (SystemVerificationCheck) Name() string {
@@ -529,11 +527,6 @@ func (sysver SystemVerificationCheck) Check() (warnings, errorList []error) {
 	// All the common validators we'd like to run:
 	var validators = []system.Validator{
 		&system.KernelValidator{Reporter: reporter}}
-
-	// run the docker validator only with docker runtime
-	if sysver.IsDocker {
-		validators = append(validators, &system.DockerValidator{Reporter: reporter})
-	}
 
 	if runtime.GOOS == "linux" {
 		//add linux validators
@@ -1025,26 +1018,19 @@ func RunJoinNodeChecks(execer utilsexec.Interface, cfg *kubeadmapi.JoinConfigura
 // kubeadm init and join commands
 func addCommonChecks(execer utilsexec.Interface, k8sVersion string, nodeReg *kubeadmapi.NodeRegistrationOptions, checks []Checker) []Checker {
 	containerRuntime, err := utilruntime.NewContainerRuntime(execer, nodeReg.CRISocket)
-	isDocker := false
 	if err != nil {
 		fmt.Printf("[preflight] WARNING: Couldn't create the interface used for talking to the container runtime: %v\n", err)
 	} else {
 		checks = append(checks, ContainerRuntimeCheck{runtime: containerRuntime})
-		if containerRuntime.IsDocker() {
-			isDocker = true
-			checks = append(checks, ServiceCheck{Service: "docker", CheckIfActive: true})
-		}
 	}
 
 	// non-windows checks
 	if runtime.GOOS == "linux" {
-		if !isDocker {
-			checks = append(checks, InPathCheck{executable: "crictl", mandatory: true, exec: execer})
-		}
 		checks = append(checks,
 			FileContentCheck{Path: bridgenf, Content: []byte{'1'}},
 			FileContentCheck{Path: ipv4Forward, Content: []byte{'1'}},
 			SwapCheck{},
+			InPathCheck{executable: "crictl", mandatory: true, exec: execer},
 			InPathCheck{executable: "conntrack", mandatory: true, exec: execer},
 			InPathCheck{executable: "ip", mandatory: true, exec: execer},
 			InPathCheck{executable: "iptables", mandatory: true, exec: execer},
@@ -1057,7 +1043,7 @@ func addCommonChecks(execer utilsexec.Interface, k8sVersion string, nodeReg *kub
 			InPathCheck{executable: "touch", mandatory: false, exec: execer})
 	}
 	checks = append(checks,
-		SystemVerificationCheck{IsDocker: isDocker},
+		SystemVerificationCheck{},
 		HostnameCheck{nodeName: nodeReg.Name},
 		KubeletVersionCheck{KubernetesVersion: k8sVersion, exec: execer},
 		ServiceCheck{Service: "kubelet", CheckIfActive: false},

--- a/cmd/kubeadm/app/preflight/checks_test.go
+++ b/cmd/kubeadm/app/preflight/checks_test.go
@@ -917,10 +917,10 @@ func TestImagePullCheck(t *testing.T) {
 			func(cmd string, args ...string) exec.Cmd { return fakeexec.InitFakeCmd(&fcmd, cmd, args...) },
 			func(cmd string, args ...string) exec.Cmd { return fakeexec.InitFakeCmd(&fcmd, cmd, args...) },
 		},
-		LookPathFunc: func(cmd string) (string, error) { return "/usr/bin/docker", nil },
+		LookPathFunc: func(cmd string) (string, error) { return "/usr/bin/crictl", nil },
 	}
 
-	containerRuntime, err := utilruntime.NewContainerRuntime(&fexec, constants.DefaultDockerCRISocket)
+	containerRuntime, err := utilruntime.NewContainerRuntime(&fexec, constants.DefaultCRISocket)
 	if err != nil {
 		t.Errorf("unexpected NewContainerRuntime error: %v", err)
 	}

--- a/cmd/kubeadm/app/util/config/initconfiguration.go
+++ b/cmd/kubeadm/app/util/config/initconfiguration.go
@@ -196,7 +196,7 @@ func DefaultedStaticInitConfiguration() (*kubeadmapi.InitConfiguration, error) {
 		LocalAPIEndpoint: kubeadmapiv1.APIEndpoint{AdvertiseAddress: "1.2.3.4"},
 		BootstrapTokens:  []bootstraptokenv1.BootstrapToken{PlaceholderToken},
 		NodeRegistration: kubeadmapiv1.NodeRegistrationOptions{
-			CRISocket: kubeadmconstants.DefaultDockerCRISocket, // avoid CRI detection
+			CRISocket: kubeadmconstants.DefaultCRISocket, // avoid CRI detection
 			Name:      "node",
 		},
 	}

--- a/cmd/kubeadm/app/util/runtime/runtime.go
+++ b/cmd/kubeadm/app/util/runtime/runtime.go
@@ -124,7 +124,7 @@ func detectCRISocketImpl(isSocket func(string) bool) (string, error) {
 
 	if isSocket(dockerSocket) {
 		// the path in dockerSocket is not CRI compatible, hence we should replace it with a CRI compatible socket
-		foundCRISockets = append(foundCRISockets, constants.DefaultDockerCRISocket)
+		foundCRISockets = append(foundCRISockets, constants.DefaultCRISocket)
 	} else if isSocket(containerdSocket) {
 		// Docker 18.09 gets bundled together with containerd, thus having both dockerSocket and containerdSocket present.
 		// For compatibility reasons, we use the containerd socket only if Docker is not detected.
@@ -140,7 +140,7 @@ func detectCRISocketImpl(isSocket func(string) bool) (string, error) {
 	switch len(foundCRISockets) {
 	case 0:
 		// Fall back to Docker if no CRI is detected, we can error out later on if we need it
-		return constants.DefaultDockerCRISocket, nil
+		return constants.DefaultCRISocket, nil
 	case 1:
 		// Precisely one CRI found, use that
 		return foundCRISockets[0], nil

--- a/cmd/kubeadm/app/util/runtime/runtime_test.go
+++ b/cmd/kubeadm/app/util/runtime/runtime_test.go
@@ -380,32 +380,15 @@ func TestDetectCRISocketImpl(t *testing.T) {
 		},
 		{
 			name:            "One valid CRI socket leads to success",
-			existingSockets: []string{"unix:///var/run/crio/crio.sock"},
+			existingSockets: []string{"unix:///foo/bar.sock"},
 			expectedError:   false,
-			expectedSocket:  "unix:///var/run/crio/crio.sock",
-		},
-		{
-			name: "CRI and Docker sockets lead to an error",
-			existingSockets: []string{
-				"unix:///var/run/docker.sock",
-				"unix:///var/run/crio/crio.sock",
-			},
-			expectedError: true,
-		},
-		{
-			name: "Docker and containerd lead to Docker being used",
-			existingSockets: []string{
-				"unix:///var/run/docker.sock",
-				"unix:///run/containerd/containerd.sock",
-			},
-			expectedError:  false,
-			expectedSocket: constants.DefaultCRISocket,
+			expectedSocket:  "unix:///foo/bar.sock",
 		},
 		{
 			name: "Multiple CRI sockets lead to an error",
 			existingSockets: []string{
-				"unix:///var/run/crio/crio.sock",
-				"unix:///run/containerd/containerd.sock",
+				"unix:///foo/bar.sock",
+				"unix:///foo/baz.sock",
 			},
 			expectedError: true,
 		},
@@ -419,9 +402,9 @@ func TestDetectCRISocketImpl(t *testing.T) {
 						return true
 					}
 				}
-
 				return false
-			})
+			}, test.existingSockets)
+
 			if (err != nil) != test.expectedError {
 				t.Fatalf("detectCRISocketImpl returned unexpected result\n\tExpected error: %t\n\tGot error: %t", test.expectedError, err != nil)
 			}

--- a/cmd/kubeadm/app/util/runtime/runtime_unix.go
+++ b/cmd/kubeadm/app/util/runtime/runtime_unix.go
@@ -24,11 +24,6 @@ import (
 	"net/url"
 )
 
-const (
-	dockerSocket     = "unix:///var/run/docker.sock" // The Docker socket is not CRI compatible
-	containerdSocket = "unix:///run/containerd/containerd.sock"
-)
-
 // isExistingSocket checks if path exists and is domain socket
 func isExistingSocket(path string) bool {
 	u, err := url.Parse(path)

--- a/cmd/kubeadm/app/util/runtime/runtime_windows.go
+++ b/cmd/kubeadm/app/util/runtime/runtime_windows.go
@@ -25,11 +25,6 @@ import (
 	winio "github.com/Microsoft/go-winio"
 )
 
-const (
-	dockerSocket     = "npipe:////./pipe/docker_engine"         // The Docker socket is not CRI compatible
-	containerdSocket = "npipe:////./pipe/containerd-containerd" // Proposed containerd named pipe for Windows
-)
-
 // isExistingSocket checks if path exists and is domain socket
 func isExistingSocket(path string) bool {
 	u, err := url.Parse(path)


### PR DESCRIPTION
#### What this PR does / why we need it:

```
kubeadm: do not special case Docker as a container runtime 

crictl already works with the current state of dockershim.
Using the docker CLI is not required and the DockerRuntime
can be removed from kubeadm. This means that crictl
can connect at the dockershim (or cri-dockerd) socket and
be used to list containers, pull images, remove containers, and
all actions that the kubelet can otherwise perform with the socket.

Ensure that crictl is now required for all supported container runtimes
in checks.go. In the help text in waitcontrolplane.go show only
the crictl example.

Remove the check for the docker service from checks.go.
Remove the DockerValidor check from checks.go.
These two checks were special casing Docker as CR and compensating
for the lack of the same checks in dockershim. With the
extraction of dockershim to cri-dockerd, ideally cri-dockerd
should perform the required checks whether it can support
a given Docker config / version running on a host.
```

```
kubeadm: change the default CRI socket to containerd 

Change the default container runtime CRI socket endpoint to the
one of containerd. Previously it was the one for Docker

- Rename constants.DefaultDockerCRISocket to DefaultCRISocket
- Make the constants files include the endpoints for all supported
container runtimes for Unix/Windows.
- Update unit tests related to docker runtime testing.
- In kubelet/flags.go hardcode the legacy docker socket as a check
to allow kubeadm 1.24 to run against kubelet 1.23 if the user
explicitly sets the criSocket field to "npipe:////./pipe/dockershim"
on Windows or "unix:///var/run/dockershim.sock" on Linux.
```

```
kubeadm: update the CRI socket detection logic 

- Throw an error if there is more than one known socket on the host.
- Remove the special handling for docker+containerd.
- Remove the local instances of constants for endpoints for
Windows / Unix and use the defaultKnownCRISockets variable
which is populated from OS specific constants.
- Update error message in detectCRISocketImpl to have more
details.
- Make detectCRISocketImpl accept a list of "known" sockets
- Update unit tests for detectCRISocketImpl and make them
use generic paths such as "unix:///foo/bar.sock".
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
first commit is waiting on https://github.com/kubernetes/kubernetes/pull/107314 to merge.
follow up on https://github.com/kubernetes/kubernetes/pull/106973

xref https://github.com/kubernetes/kubeadm/issues/2626

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
ACTION REQUIRED: kubeadm: default the kubeadm configuration to the containerd socket (Unix: unix:///var/run/containerd/containerd.sock, Windows: "npipe:////./pipe/containerd-containerd") instead of the one for Docker. If the "Init|JoinConfiguration.nodeRegistration.criSocket" field is empty during cluster creation and multiple sockets are found on the host always throw an error and ask the user to specify which one to use by setting the value in the field. Make sure you update any kubeadm configuration files on disk, to not include the dockershim socket unless you are still using kubelet version < 1.24 with kubeadm >= 1.24.

Remove the DockerValidor and ServiceCheck for the "docker" service from kubeadm preflight. Docker is no longer special cased during host validation and ideally this task should be done in the now external cri-dockerd project where the importance of the compatibility matters.

Use crictl for all communication with CRI sockets for actions like pulling images and obtaining a list of running containers instead of using the docker CLI in the case of Docker.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
