### PR TITLE
Delete .staticcheck_failures

### DIFF
--- a/hack/.staticcheck_failures
+++ b/hack/.staticcheck_failures
@@ -1,9 +1,0 @@
-pkg/util/flag
-test/e2e/apimachinery
-vendor/k8s.io/apimachinery/pkg/util/json
-vendor/k8s.io/apimachinery/pkg/util/strategicpatch
-vendor/k8s.io/apiserver/pkg/server/dynamiccertificates
-vendor/k8s.io/apiserver/pkg/server/filters
-vendor/k8s.io/apiserver/pkg/storage/value/encrypt/envelope
-vendor/k8s.io/apiserver/pkg/util/wsstream
-vendor/k8s.io/client-go/rest


### PR DESCRIPTION
/kind cleanup

```release-note
None
```

Since #106448 was merged, search //nolint:staticcheck for stackcheck failures. 

We use `hack/verify-golangci-lint.sh` to do staticcheck now. The script  is not using the `.staticcheck_failures` below.

xref #92402 and #103721