### PR TITLE
promote LocalStorageCapacityIsolationFSQuotaMonitoring to beta

### DIFF
--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -495,7 +495,7 @@ const (
 
 	// owner: @RobertKrawitz
 	// alpha: v1.15
-	// beta: v1.24
+	// beta: v1.25
 	//
 	// Allow use of filesystems for ephemeral storage monitoring.
 	// Only applies if LocalStorageCapacityIsolation is set.

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -495,6 +495,7 @@ const (
 
 	// owner: @RobertKrawitz
 	// alpha: v1.15
+	// beta: v1.24
 	//
 	// Allow use of filesystems for ephemeral storage monitoring.
 	// Only applies if LocalStorageCapacityIsolation is set.
@@ -931,7 +932,7 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
 
 	LocalStorageCapacityIsolation: {Default: true, PreRelease: featuregate.Beta},
 
-	LocalStorageCapacityIsolationFSQuotaMonitoring: {Default: false, PreRelease: featuregate.Alpha},
+	LocalStorageCapacityIsolationFSQuotaMonitoring: {Default: true, PreRelease: featuregate.Beta},
 
 	LogarithmicScaleDown: {Default: true, PreRelease: featuregate.Beta},
 

--- a/test/e2e_node/quota_lsci_test.go
+++ b/test/e2e_node/quota_lsci_test.go
@@ -63,7 +63,7 @@ func runOneQuotaTest(f *framework.Framework, quotasRequested bool) {
 			if quotasRequested && !supportsQuotas("/var/lib/kubelet") {
 				// No point in running this as a positive test if quotas are not
 				// enabled on the underlying filesystem.
-				e2eskipper.Skipf("Cannot run LocalStorageCapacityIsolationQuotaMonitoring on filesystem without project quota enabled")
+				e2eskipper.Skipf("Cannot run LocalStorageCapacityIsolationFSQuotaMonitoring on filesystem without project quota enabled")
 			}
 			// setting a threshold to 0% disables; non-empty map overrides default value (necessary due to omitempty)
 			initialConfig.EvictionHard = map[string]string{"memory.available": "0%"}
@@ -90,7 +90,7 @@ func runOneQuotaTest(f *framework.Framework, quotasRequested bool) {
 	})
 }
 
-// LocalStorageCapacityIsolationQuotaMonitoring tests that quotas are
+// LocalStorageCapacityIsolationFSQuotaMonitoring tests that quotas are
 // used for monitoring rather than du.  The mechanism is to create a
 // pod that creates a file, deletes it, and writes data to it.  If
 // quotas are used to monitor, it will detect this deleted-but-in-use


### PR DESCRIPTION
This is an initial PR to promote the feature. I will use it to do some testing.
Once the KEP update https://github.com/kubernetes/enhancements/pull/2697 is merged, then this PR will be ready for review.

https://github.com/kubernetes/enhancements/pull/2697

**Action Items:**
- [x] add some metrics or make more visibility https://github.com/kubernetes/kubernetes/pull/107201
- [x] fix a bug: during kubelet restart. https://github.com/kubernetes/kubernetes/pull/107302
- [x]  benchmark the feature ⬆️  the comments above. 
- [x] add some warning log for long time cost volume calculation https://github.com/kubernetes/kubernetes/pull/107490
- [x] check e2e testings: e2e evolution (LocalStorageCapacityIsolationQuotaMonitoring [Slow] [Serial] [Disruptive] [Feature:LocalStorageCapacityIsolationQuota][NodeFeature:LSCIQuotaMonitoring]) 
- [ ] need some feedbacks 
- [x] https://github.com/kubernetes/kubernetes/issues/83107 （[I tested it](https://github.com/kubernetes/kubernetes/issues/83107#issuecomment-1096731583). It will work immediately if we enable this  feature gate ）

/kind feature
Xrefs https://github.com/kubernetes/enhancements/issues/1029

```release-note
promote LocalStorageCapacityIsolationFSQuotaMonitoring to beta
```