### PR TITLE
Automated cherry pick of #107311: client-go: Clear the ResourceVersionMatch on paged list calls

### DIFF
--- a/staging/src/k8s.io/client-go/tools/pager/pager.go
+++ b/staging/src/k8s.io/client-go/tools/pager/pager.go
@@ -78,6 +78,7 @@ func (p *ListPager) List(ctx context.Context, options metav1.ListOptions) (runti
 		options.Limit = p.PageSize
 	}
 	requestedResourceVersion := options.ResourceVersion
+	requestedResourceVersionMatch := options.ResourceVersionMatch
 	var list *metainternalversion.List
 	paginatedResult := false
 
@@ -102,6 +103,7 @@ func (p *ListPager) List(ctx context.Context, options metav1.ListOptions) (runti
 			options.Limit = 0
 			options.Continue = ""
 			options.ResourceVersion = requestedResourceVersion
+			options.ResourceVersionMatch = requestedResourceVersionMatch
 			result, err := p.PageFn(ctx, options)
 			return result, paginatedResult, err
 		}
@@ -135,10 +137,11 @@ func (p *ListPager) List(ctx context.Context, options metav1.ListOptions) (runti
 
 		// set the next loop up
 		options.Continue = m.GetContinue()
-		// Clear the ResourceVersion on the subsequent List calls to avoid the
+		// Clear the ResourceVersion(Match) on the subsequent List calls to avoid the
 		// `specifying resource version is not allowed when using continue` error.
 		// See https://github.com/kubernetes/kubernetes/issues/85221#issuecomment-553748143.
 		options.ResourceVersion = ""
+		options.ResourceVersionMatch = ""
 		// At this point, result is already paginated.
 		paginatedResult = true
 	}

--- a/staging/src/k8s.io/client-go/tools/pager/pager_test.go
+++ b/staging/src/k8s.io/client-go/tools/pager/pager_test.go
@@ -76,6 +76,10 @@ func (p *testPager) PagedList(ctx context.Context, options metav1.ListOptions) (
 		p.t.Errorf("invariant violated, specifying resource version (%s) is not allowed when using continue (%s).", options.ResourceVersion, options.Continue)
 		return nil, fmt.Errorf("invariant violated")
 	}
+	if options.Continue != "" && options.ResourceVersionMatch != "" {
+		p.t.Errorf("invariant violated, specifying resource version match type (%s) is not allowed when using continue (%s).", options.ResourceVersionMatch, options.Continue)
+		return nil, fmt.Errorf("invariant violated")
+	}
 	var list metainternalversion.List
 	total := options.Limit
 	if total == 0 {
@@ -198,6 +202,13 @@ func TestListPager_List(t *testing.T) {
 			name:      "two pages with resourceVersion",
 			fields:    fields{PageSize: 10, PageFn: (&testPager{t: t, expectPage: 10, remaining: 11, rv: "rv:20"}).PagedList},
 			args:      args{options: metav1.ListOptions{ResourceVersion: "rv:10"}},
+			want:      list(11, "rv:20"),
+			wantPaged: true,
+		},
+		{
+			name:      "two pages with resourceVersion and resourceVersionMatch",
+			fields:    fields{PageSize: 10, PageFn: (&testPager{t: t, expectPage: 10, remaining: 11, rv: "rv:20"}).PagedList},
+			args:      args{options: metav1.ListOptions{ResourceVersion: "rv:10", ResourceVersionMatch: metav1.ResourceVersionMatchNotOlderThan}},
 			want:      list(11, "rv:20"),
 			wantPaged: true,
 		},


### PR DESCRIPTION
Cherry pick of #107311 on release-1.22.

#107311: client-go: Clear the ResourceVersionMatch on paged list calls

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
client-go: fix that paged list calls with ResourceVersionMatch set would fail once paging kicked in.
```