### PR TITLE
Automated cherry pick of #107221: fix nil pointer in create secret commands

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_secret.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_secret.go
@@ -199,13 +199,13 @@ func (o *CreateSecretOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, ar
 
 	o.Namespace, o.EnforceNamespace, err = f.ToRawKubeConfigLoader().Namespace()
 	if err != nil {
-		return nil
+		return err
 	}
 
 	cmdutil.PrintFlagsWithDryRunStrategy(o.PrintFlags, o.DryRunStrategy)
 	printer, err := o.PrintFlags.ToPrinter()
 	if err != nil {
-		return nil
+		return err
 	}
 
 	o.PrintObj = func(obj runtime.Object) error {

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_secret_tls.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_secret_tls.go
@@ -155,13 +155,13 @@ func (o *CreateSecretTLSOptions) Complete(f cmdutil.Factory, cmd *cobra.Command,
 
 	o.Namespace, o.EnforceNamespace, err = f.ToRawKubeConfigLoader().Namespace()
 	if err != nil {
-		return nil
+		return err
 	}
 
 	cmdutil.PrintFlagsWithDryRunStrategy(o.PrintFlags, o.DryRunStrategy)
 	printer, err := o.PrintFlags.ToPrinter()
 	if err != nil {
-		return nil
+		return err
 	}
 
 	o.PrintObj = func(obj runtime.Object) error {


### PR DESCRIPTION
Cherry pick of #107221 on release-1.22.

#107221: fix nil pointer in create secret commands

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
Fix a panic when using invalid output format in kubectl create secret command
```