### PR TITLE
Automated cherry pick of #107337: Fix the leak of vSphere client sessions

### DIFF
--- a/test/e2e/storage/drivers/in_tree.go
+++ b/test/e2e/storage/drivers/in_tree.go
@@ -1491,10 +1491,19 @@ func (v *vSphereDriver) GetDynamicProvisionStorageClass(config *storageframework
 
 func (v *vSphereDriver) PrepareTest(f *framework.Framework) (*storageframework.PerTestConfig, func()) {
 	return &storageframework.PerTestConfig{
-		Driver:    v,
-		Prefix:    "vsphere",
-		Framework: f,
-	}, func() {}
+			Driver:    v,
+			Prefix:    "vsphere",
+			Framework: f,
+		}, func() {
+			// Driver Cleanup function
+			// Logout each vSphere client connection to prevent session leakage
+			nodes := vspheretest.GetReadySchedulableNodeInfos()
+			for _, node := range nodes {
+				if node.VSphere.Client != nil {
+					node.VSphere.Client.Logout(context.TODO())
+				}
+			}
+		}
 }
 
 func (v *vSphereDriver) CreateVolume(config *storageframework.PerTestConfig, volType storageframework.TestVolType) storageframework.TestVolume {


### PR DESCRIPTION
Cherry pick of #107337 on release-1.23.

#107337: Fix the leak of vSphere client sessions

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```