### PR TITLE
Improve error message for missing CRDs

### DIFF
--- a/staging/src/k8s.io/cli-runtime/pkg/resource/mapper.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/resource/mapper.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"reflect"
 
+	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
@@ -64,6 +65,10 @@ func (m *mapper) infoForData(data []byte, source string) (*Info, error) {
 		}
 		mapping, err := restMapper.RESTMapping(gvk.GroupKind(), gvk.Version)
 		if err != nil {
+			if _, ok := err.(*meta.NoKindMatchError); ok {
+				return nil, fmt.Errorf("resource mapping not found for name: %q namespace: %q from %q: %v\nensure CRDs are installed first",
+					name, namespace, source, err)
+			}
 			return nil, fmt.Errorf("unable to recognize %q: %v", source, err)
 		}
 		ret.Mapping = mapping


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This PR improves the error message for when a GVK isn't found for a resource to apply. This is most likely because a resource is being created before the actual CRD exists on the cluster.

#### Which issue(s) this PR fixes:

Fixes https://github.com/kubernetes/kubectl/issues/1118

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
Improve error message when applying CRDs before the CRD exists in a cluster
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```

Need to decide what info to surface here and the shape. I agree with the original author that we should be providing a hint if possible to the user.

/hold
/cc @soltysh 