### PR TITLE
Automated cherry pick of #107327: kubeadm: remove the restriction that the ca.crt can only

### DIFF
--- a/cmd/kubeadm/app/phases/certs/renewal/readwriter.go
+++ b/cmd/kubeadm/app/phases/certs/renewal/readwriter.go
@@ -82,10 +82,8 @@ func (rw *pkiCertificateReadWriter) Read() (*x509.Certificate, error) {
 		return nil, errors.Wrapf(err, "failed to load existing certificate %s", rw.baseName)
 	}
 
-	if len(certs) != 1 {
-		return nil, errors.Errorf("wanted exactly one certificate, got %d", len(certs))
-	}
-
+	// Safely pick the first one because the sender's certificate must come first in the list.
+	// For details, see: https://www.rfc-editor.org/rfc/rfc4346#section-7.4.2
 	return certs[0], nil
 }
 
@@ -145,9 +143,9 @@ func (rw *kubeConfigReadWriter) Read() (*x509.Certificate, error) {
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to load existing certificate %s", rw.baseName)
 	}
-	if len(caCerts) != 1 {
-		return nil, errors.Errorf("wanted exactly one certificate, got %d", len(caCerts))
-	}
+
+	// Safely pick the first one because the sender's certificate must come first in the list.
+	// For details, see: https://www.rfc-editor.org/rfc/rfc4346#section-7.4.2
 	rw.caCert = caCerts[0]
 
 	// get current context

--- a/cmd/kubeadm/app/util/config/cluster.go
+++ b/cmd/kubeadm/app/util/config/cluster.go
@@ -196,8 +196,8 @@ func getNodeNameFromKubeletConfig(kubeconfigDir string) (string, error) {
 		return "", errors.Errorf("invalid kubeconfig file %s. x509 certificate expected", fileName)
 	}
 
-	// We are only putting one certificate in the certificate pem file, so it's safe to just pick the first one
-	// TODO: Support multiple certs here in order to be able to rotate certs
+	// Safely pick the first one because the sender's certificate must come first in the list.
+	// For details, see: https://www.rfc-editor.org/rfc/rfc4346#section-7.4.2
 	cert := certs[0]
 
 	// gets the node name from the certificate common name

--- a/cmd/kubeadm/app/util/pkiutil/pki_helpers.go
+++ b/cmd/kubeadm/app/util/pkiutil/pki_helpers.go
@@ -249,8 +249,8 @@ func TryLoadCertFromDisk(pkiPath, name string) (*x509.Certificate, error) {
 		return nil, errors.Wrapf(err, "couldn't load the certificate file %s", certificatePath)
 	}
 
-	// We are only putting one certificate in the certificate pem file, so it's safe to just pick the first one
-	// TODO: Support multiple certs here in order to be able to rotate certs
+	// Safely pick the first one because the sender's certificate must come first in the list.
+	// For details, see: https://www.rfc-editor.org/rfc/rfc4346#section-7.4.2
 	cert := certs[0]
 
 	return cert, nil


### PR DESCRIPTION
Cherry pick of #107327 on release-1.20.

#107327: kubeadm: remove the restriction that the ca.crt can only

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```