### PR TITLE
fixing a goroutine leak in TestGCOrphaned

### DIFF
--- a/pkg/controller/podgc/gc_controller_test.go
+++ b/pkg/controller/podgc/gc_controller_test.go
@@ -325,6 +325,7 @@ func TestGCOrphaned(t *testing.T) {
 			fakeClock := testingclock.NewFakeClock(time.Now())
 			gcc.nodeQueue.ShutDown()
 			gcc.nodeQueue = workqueue.NewDelayingQueueWithCustomClock(fakeClock, "podgc_test_queue")
+			defer gcc.nodeQueue.ShutDown()
 
 			deletedPodNames := make([]string, 0)
 			var lock sync.Mutex

--- a/pkg/kubelet/pluginmanager/operationexecutor/operation_executor_test.go
+++ b/pkg/kubelet/pluginmanager/operationexecutor/operation_executor_test.go
@@ -163,7 +163,7 @@ loop:
 }
 
 func setup() (chan interface{}, chan interface{}, OperationExecutor) {
-	ch, quit := make(chan interface{}), make(chan interface{})
+	ch, quit := make(chan interface{}, 1), make(chan interface{})
 	return ch, quit, NewOperationExecutor(newFakeOperationGenerator(ch, quit))
 }
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

This pull request is to fix goroutine leaks in two unit tests:

(1)
There are two DelayingQueue objects created in each unit test (or in each loop iteration). The first one is terminated, but the second one is not. Thus, the goroutine attached to the second object is leaked. 

The pull request can terminate the second DelayingQueue object. 


(2) 
Although it is very unlikely, if timeout at [line 140](https://github.com/kubernetes/kubernetes/blob/master/pkg/kubelet/pluginmanager/operationexecutor/operation_executor_test.go#L140) of file pkg/kubelet/pluginmanager/operationexecutor/operation_executor_test.go happens earlier, the send operation on channel `ch` at [line 173](https://github.com/kubernetes/kubernetes/blob/master/pkg/kubelet/pluginmanager/operationexecutor/operation_executor_test.go#L173) blocks endlessly. 

The pull request can make the blocking goroutine proceed, while not impacting other scenarios. 

#### Which issue(s) this PR fixes:
None


