### PR TITLE
Use `math.Round` when convert float to int in PodTopologySpread

### DIFF
--- a/pkg/scheduler/framework/plugins/podtopologyspread/scoring.go
+++ b/pkg/scheduler/framework/plugins/podtopologyspread/scoring.go
@@ -209,7 +209,7 @@ func (pl *PodTopologySpread) Score(ctx context.Context, cycleState *framework.Cy
 			score += scoreForCount(cnt, c.MaxSkew, s.TopologyNormalizingWeight[i])
 		}
 	}
-	return int64(score), nil
+	return int64(math.Round(score)), nil
 }
 
 // NormalizeScore invoked after scoring all nodes.

--- a/pkg/scheduler/framework/plugins/podtopologyspread/scoring_test.go
+++ b/pkg/scheduler/framework/plugins/podtopologyspread/scoring_test.go
@@ -22,7 +22,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	appsv1 "k8s.io/api/apps/v1"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -367,8 +367,8 @@ func TestPodTopologySpreadScore(t *testing.T) {
 			},
 			failedNodes: []*v1.Node{},
 			want: []framework.NodeScore{
-				{Name: "node-a", Score: 40},
-				{Name: "node-b", Score: 80},
+				{Name: "node-a", Score: 20},
+				{Name: "node-b", Score: 60},
 				{Name: "node-c", Score: 100},
 				{Name: "node-d", Score: 0},
 			},
@@ -395,8 +395,8 @@ func TestPodTopologySpreadScore(t *testing.T) {
 			},
 			failedNodes: []*v1.Node{},
 			want: []framework.NodeScore{
-				{Name: "node-a", Score: 50}, // +10, compared to maxSkew=1
-				{Name: "node-b", Score: 83}, // +3, compared to maxSkew=1
+				{Name: "node-a", Score: 33}, // +13, compared to maxSkew=1
+				{Name: "node-b", Score: 66}, // +6, compared to maxSkew=1
 				{Name: "node-c", Score: 100},
 				{Name: "node-d", Score: 16}, // +16, compared to maxSkew=1
 			},
@@ -427,8 +427,8 @@ func TestPodTopologySpreadScore(t *testing.T) {
 			},
 			failedNodes: []*v1.Node{},
 			want: []framework.NodeScore{
-				{Name: "node-a", Score: 33}, // +19 compared to maxSkew=1
-				{Name: "node-b", Score: 55}, // +13 compared to maxSkew=1
+				{Name: "node-a", Score: 44}, // +16 compared to maxSkew=1
+				{Name: "node-b", Score: 66}, // +9 compared to maxSkew=1
 				{Name: "node-c", Score: 77}, // +6 compared to maxSkew=1
 				{Name: "node-d", Score: 100},
 			},
@@ -461,8 +461,8 @@ func TestPodTopologySpreadScore(t *testing.T) {
 			},
 			want: []framework.NodeScore{
 				// Same scores as if we were using one spreading constraint.
-				{Name: "node-a", Score: 33},
-				{Name: "node-b", Score: 55},
+				{Name: "node-a", Score: 44},
+				{Name: "node-b", Score: 66},
 				{Name: "node-c", Score: 77},
 				{Name: "node-d", Score: 100},
 			},
@@ -494,8 +494,8 @@ func TestPodTopologySpreadScore(t *testing.T) {
 				st.MakeNode().Name("node-y").Label(v1.LabelHostname, "node-y").Obj(),
 			},
 			want: []framework.NodeScore{
-				{Name: "node-a", Score: 16},
-				{Name: "node-b", Score: 66},
+				{Name: "node-a", Score: 33},
+				{Name: "node-b", Score: 83},
 				{Name: "node-x", Score: 100},
 			},
 		},
@@ -526,7 +526,7 @@ func TestPodTopologySpreadScore(t *testing.T) {
 				st.MakeNode().Name("node-y").Label(v1.LabelHostname, "node-y").Obj(),
 			},
 			want: []framework.NodeScore{
-				{Name: "node-a", Score: 20},
+				{Name: "node-a", Score: 16},
 				{Name: "node-b", Score: 0},
 				{Name: "node-x", Score: 100},
 			},
@@ -558,8 +558,8 @@ func TestPodTopologySpreadScore(t *testing.T) {
 				st.MakeNode().Name("node-y").Label("zone", "zone2").Label(v1.LabelHostname, "node-y").Obj(),
 			},
 			want: []framework.NodeScore{
-				{Name: "node-a", Score: 62},
-				{Name: "node-b", Score: 62},
+				{Name: "node-a", Score: 75},
+				{Name: "node-b", Score: 75},
 				{Name: "node-x", Score: 100},
 			},
 		},
@@ -591,7 +591,7 @@ func TestPodTopologySpreadScore(t *testing.T) {
 			},
 			want: []framework.NodeScore{
 				{Name: "node-a", Score: 100},
-				{Name: "node-x", Score: 54},
+				{Name: "node-x", Score: 63},
 			},
 		},
 		{
@@ -624,10 +624,10 @@ func TestPodTopologySpreadScore(t *testing.T) {
 			},
 			failedNodes: []*v1.Node{},
 			want: []framework.NodeScore{
-				{Name: "node-a", Score: 75},
-				{Name: "node-b", Score: 25},
+				{Name: "node-a", Score: 60},
+				{Name: "node-b", Score: 20},
 				{Name: "node-x", Score: 100},
-				{Name: "node-y", Score: 50},
+				{Name: "node-y", Score: 60},
 			},
 		},
 		{
@@ -652,8 +652,8 @@ func TestPodTopologySpreadScore(t *testing.T) {
 			failedNodes: []*v1.Node{},
 			want: []framework.NodeScore{
 				{Name: "node-a", Score: 100},
-				{Name: "node-b", Score: 75},
-				{Name: "node-x", Score: 50},
+				{Name: "node-b", Score: 60},
+				{Name: "node-x", Score: 40},
 				{Name: "node-y", Score: 0},
 			},
 		},
@@ -680,7 +680,7 @@ func TestPodTopologySpreadScore(t *testing.T) {
 				st.MakeNode().Name("node-y").Label("zone", "zone2").Label(v1.LabelHostname, "node-y").Obj(),
 			},
 			want: []framework.NodeScore{
-				{Name: "node-a", Score: 75},
+				{Name: "node-a", Score: 50},
 				{Name: "node-b", Score: 25},
 				{Name: "node-x", Score: 100},
 			},
@@ -702,7 +702,7 @@ func TestPodTopologySpreadScore(t *testing.T) {
 			},
 			want: []framework.NodeScore{
 				{Name: "node-a", Score: 100},
-				{Name: "node-b", Score: 50},
+				{Name: "node-b", Score: 33},
 			},
 		},
 		{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind bug

#### What this PR does / why we need it:

When we cast some value from float64 to int with `int(someFloat64Value)`, it will be truncated. 

If Nodes have small scores in Score, there will be a non-small difference in the resulting score from Normalized Score depending on whether we convert it by truncating or rounding.
I think it is better to use `math.Round`.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

If this issue has already been discussed and we decided to convert with int64(), please feel free to close it.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Improve rounding of PodTopologySpread scores to offer better scoring when spreading a low number of pods.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
