### PR TITLE
csi: correct struct fields in CSI{Persistent}VolumeSource.

### DIFF
--- a/api/openapi-spec/v3/api__v1_openapi.json
+++ b/api/openapi-spec/v3/api__v1_openapi.json
@@ -366,31 +366,31 @@
         "properties": {
           "controllerExpandSecretRef": {
             "$ref": "#/components/schemas/io.k8s.api.core.v1.SecretReference",
-            "description": "ControllerExpandSecretRef is a reference to the secret object containing sensitive information to pass to the CSI driver to complete the CSI ControllerExpandVolume call. This is an alpha field and requires enabling ExpandCSIVolumes feature gate. This field is optional, and may be empty if no secret is required. If the secret object contains more than one secret, all secrets are passed."
+            "description": "controllerExpandSecretRef is a reference to the secret object containing sensitive information to pass to the CSI driver to complete the CSI ControllerExpandVolume call. This is an alpha field and requires enabling ExpandCSIVolumes feature gate. This field is optional, and may be empty if no secret is required. If the secret object contains more than one secret, all secrets are passed."
           },
           "controllerPublishSecretRef": {
             "$ref": "#/components/schemas/io.k8s.api.core.v1.SecretReference",
-            "description": "ControllerPublishSecretRef is a reference to the secret object containing sensitive information to pass to the CSI driver to complete the CSI ControllerPublishVolume and ControllerUnpublishVolume calls. This field is optional, and may be empty if no secret is required. If the secret object contains more than one secret, all secrets are passed."
+            "description": "controllerPublishSecretRef is a reference to the secret object containing sensitive information to pass to the CSI driver to complete the CSI ControllerPublishVolume and ControllerUnpublishVolume calls. This field is optional, and may be empty if no secret is required. If the secret object contains more than one secret, all secrets are passed."
           },
           "driver": {
             "default": "",
-            "description": "Driver is the name of the driver to use for this volume. Required.",
+            "description": "driver is the name of the driver to use for this volume. Required.",
             "type": "string"
           },
           "fsType": {
-            "description": "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\".",
+            "description": "fsType to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\".",
             "type": "string"
           },
           "nodePublishSecretRef": {
             "$ref": "#/components/schemas/io.k8s.api.core.v1.SecretReference",
-            "description": "NodePublishSecretRef is a reference to the secret object containing sensitive information to pass to the CSI driver to complete the CSI NodePublishVolume and NodeUnpublishVolume calls. This field is optional, and may be empty if no secret is required. If the secret object contains more than one secret, all secrets are passed."
+            "description": "nodePublishSecretRef is a reference to the secret object containing sensitive information to pass to the CSI driver to complete the CSI NodePublishVolume and NodeUnpublishVolume calls. This field is optional, and may be empty if no secret is required. If the secret object contains more than one secret, all secrets are passed."
           },
           "nodeStageSecretRef": {
             "$ref": "#/components/schemas/io.k8s.api.core.v1.SecretReference",
-            "description": "NodeStageSecretRef is a reference to the secret object containing sensitive information to pass to the CSI driver to complete the CSI NodeStageVolume and NodeStageVolume and NodeUnstageVolume calls. This field is optional, and may be empty if no secret is required. If the secret object contains more than one secret, all secrets are passed."
+            "description": "nodeStageSecretRef is a reference to the secret object containing sensitive information to pass to the CSI driver to complete the CSI NodeStageVolume and NodeStageVolume and NodeUnstageVolume calls. This field is optional, and may be empty if no secret is required. If the secret object contains more than one secret, all secrets are passed."
           },
           "readOnly": {
-            "description": "Optional: The value to pass to ControllerPublishVolumeRequest. Defaults to false (read/write).",
+            "description": "readOnly value to pass to ControllerPublishVolumeRequest. Defaults to false (read/write).",
             "type": "boolean"
           },
           "volumeAttributes": {
@@ -398,12 +398,12 @@
               "default": "",
               "type": "string"
             },
-            "description": "Attributes of the volume to publish.",
+            "description": "volumeAttributes of the volume to publish.",
             "type": "object"
           },
           "volumeHandle": {
             "default": "",
-            "description": "VolumeHandle is the unique volume name returned by the CSI volume plugin’s CreateVolume to refer to the volume on all subsequent calls. Required.",
+            "description": "volumeHandle is the unique volume name returned by the CSI volume plugin’s CreateVolume to refer to the volume on all subsequent calls. Required.",
             "type": "string"
           }
         },
@@ -418,19 +418,19 @@
         "properties": {
           "driver": {
             "default": "",
-            "description": "Driver is the name of the CSI driver that handles this volume. Consult with your admin for the correct name as registered in the cluster.",
+            "description": "driver is the name of the CSI driver that handles this volume. Consult with your admin for the correct name as registered in the cluster.",
             "type": "string"
           },
           "fsType": {
-            "description": "Filesystem type to mount. Ex. \"ext4\", \"xfs\", \"ntfs\". If not provided, the empty value is passed to the associated CSI driver which will determine the default filesystem to apply.",
+            "description": "fsType to mount. Ex. \"ext4\", \"xfs\", \"ntfs\". If not provided, the empty value is passed to the associated CSI driver which will determine the default filesystem to apply.",
             "type": "string"
           },
           "nodePublishSecretRef": {
             "$ref": "#/components/schemas/io.k8s.api.core.v1.LocalObjectReference",
-            "description": "NodePublishSecretRef is a reference to the secret object containing sensitive information to pass to the CSI driver to complete the CSI NodePublishVolume and NodeUnpublishVolume calls. This field is optional, and  may be empty if no secret is required. If the secret object contains more than one secret, all secret references are passed."
+            "description": "nodePublishSecretRef is a reference to the secret object containing sensitive information to pass to the CSI driver to complete the CSI NodePublishVolume and NodeUnpublishVolume calls. This field is optional, and  may be empty if no secret is required. If the secret object contains more than one secret, all secret references are passed."
           },
           "readOnly": {
-            "description": "Specifies a read-only configuration for the volume. Defaults to false (read/write).",
+            "description": "readOnly specifies a read-only configuration for the volume. Defaults to false (read/write).",
             "type": "boolean"
           },
           "volumeAttributes": {
@@ -438,7 +438,7 @@
               "default": "",
               "type": "string"
             },
-            "description": "VolumeAttributes stores driver-specific properties that are passed to the CSI driver. Consult your driver's documentation for supported values.",
+            "description": "volumeAttributes stores driver-specific properties that are passed to the CSI driver. Consult your driver's documentation for supported values.",
             "type": "object"
           }
         },

--- a/api/openapi-spec/v3/apis__apps__v1_openapi.json
+++ b/api/openapi-spec/v3/apis__apps__v1_openapi.json
@@ -1198,19 +1198,19 @@
         "properties": {
           "driver": {
             "default": "",
-            "description": "Driver is the name of the CSI driver that handles this volume. Consult with your admin for the correct name as registered in the cluster.",
+            "description": "driver is the name of the CSI driver that handles this volume. Consult with your admin for the correct name as registered in the cluster.",
             "type": "string"
           },
           "fsType": {
-            "description": "Filesystem type to mount. Ex. \"ext4\", \"xfs\", \"ntfs\". If not provided, the empty value is passed to the associated CSI driver which will determine the default filesystem to apply.",
+            "description": "fsType to mount. Ex. \"ext4\", \"xfs\", \"ntfs\". If not provided, the empty value is passed to the associated CSI driver which will determine the default filesystem to apply.",
             "type": "string"
           },
           "nodePublishSecretRef": {
             "$ref": "#/components/schemas/io.k8s.api.core.v1.LocalObjectReference",
-            "description": "NodePublishSecretRef is a reference to the secret object containing sensitive information to pass to the CSI driver to complete the CSI NodePublishVolume and NodeUnpublishVolume calls. This field is optional, and  may be empty if no secret is required. If the secret object contains more than one secret, all secret references are passed."
+            "description": "nodePublishSecretRef is a reference to the secret object containing sensitive information to pass to the CSI driver to complete the CSI NodePublishVolume and NodeUnpublishVolume calls. This field is optional, and  may be empty if no secret is required. If the secret object contains more than one secret, all secret references are passed."
           },
           "readOnly": {
-            "description": "Specifies a read-only configuration for the volume. Defaults to false (read/write).",
+            "description": "readOnly specifies a read-only configuration for the volume. Defaults to false (read/write).",
             "type": "boolean"
           },
           "volumeAttributes": {
@@ -1218,7 +1218,7 @@
               "default": "",
               "type": "string"
             },
-            "description": "VolumeAttributes stores driver-specific properties that are passed to the CSI driver. Consult your driver's documentation for supported values.",
+            "description": "volumeAttributes stores driver-specific properties that are passed to the CSI driver. Consult your driver's documentation for supported values.",
             "type": "object"
           }
         },

--- a/api/openapi-spec/v3/apis__batch__v1_openapi.json
+++ b/api/openapi-spec/v3/apis__batch__v1_openapi.json
@@ -519,19 +519,19 @@
         "properties": {
           "driver": {
             "default": "",
-            "description": "Driver is the name of the CSI driver that handles this volume. Consult with your admin for the correct name as registered in the cluster.",
+            "description": "driver is the name of the CSI driver that handles this volume. Consult with your admin for the correct name as registered in the cluster.",
             "type": "string"
           },
           "fsType": {
-            "description": "Filesystem type to mount. Ex. \"ext4\", \"xfs\", \"ntfs\". If not provided, the empty value is passed to the associated CSI driver which will determine the default filesystem to apply.",
+            "description": "fsType to mount. Ex. \"ext4\", \"xfs\", \"ntfs\". If not provided, the empty value is passed to the associated CSI driver which will determine the default filesystem to apply.",
             "type": "string"
           },
           "nodePublishSecretRef": {
             "$ref": "#/components/schemas/io.k8s.api.core.v1.LocalObjectReference",
-            "description": "NodePublishSecretRef is a reference to the secret object containing sensitive information to pass to the CSI driver to complete the CSI NodePublishVolume and NodeUnpublishVolume calls. This field is optional, and  may be empty if no secret is required. If the secret object contains more than one secret, all secret references are passed."
+            "description": "nodePublishSecretRef is a reference to the secret object containing sensitive information to pass to the CSI driver to complete the CSI NodePublishVolume and NodeUnpublishVolume calls. This field is optional, and  may be empty if no secret is required. If the secret object contains more than one secret, all secret references are passed."
           },
           "readOnly": {
-            "description": "Specifies a read-only configuration for the volume. Defaults to false (read/write).",
+            "description": "readOnly specifies a read-only configuration for the volume. Defaults to false (read/write).",
             "type": "boolean"
           },
           "volumeAttributes": {
@@ -539,7 +539,7 @@
               "default": "",
               "type": "string"
             },
-            "description": "VolumeAttributes stores driver-specific properties that are passed to the CSI driver. Consult your driver's documentation for supported values.",
+            "description": "volumeAttributes stores driver-specific properties that are passed to the CSI driver. Consult your driver's documentation for supported values.",
             "type": "object"
           }
         },

--- a/api/openapi-spec/v3/apis__batch__v1beta1_openapi.json
+++ b/api/openapi-spec/v3/apis__batch__v1beta1_openapi.json
@@ -321,19 +321,19 @@
         "properties": {
           "driver": {
             "default": "",
-            "description": "Driver is the name of the CSI driver that handles this volume. Consult with your admin for the correct name as registered in the cluster.",
+            "description": "driver is the name of the CSI driver that handles this volume. Consult with your admin for the correct name as registered in the cluster.",
             "type": "string"
           },
           "fsType": {
-            "description": "Filesystem type to mount. Ex. \"ext4\", \"xfs\", \"ntfs\". If not provided, the empty value is passed to the associated CSI driver which will determine the default filesystem to apply.",
+            "description": "fsType to mount. Ex. \"ext4\", \"xfs\", \"ntfs\". If not provided, the empty value is passed to the associated CSI driver which will determine the default filesystem to apply.",
             "type": "string"
           },
           "nodePublishSecretRef": {
             "$ref": "#/components/schemas/io.k8s.api.core.v1.LocalObjectReference",
-            "description": "NodePublishSecretRef is a reference to the secret object containing sensitive information to pass to the CSI driver to complete the CSI NodePublishVolume and NodeUnpublishVolume calls. This field is optional, and  may be empty if no secret is required. If the secret object contains more than one secret, all secret references are passed."
+            "description": "nodePublishSecretRef is a reference to the secret object containing sensitive information to pass to the CSI driver to complete the CSI NodePublishVolume and NodeUnpublishVolume calls. This field is optional, and  may be empty if no secret is required. If the secret object contains more than one secret, all secret references are passed."
           },
           "readOnly": {
-            "description": "Specifies a read-only configuration for the volume. Defaults to false (read/write).",
+            "description": "readOnly specifies a read-only configuration for the volume. Defaults to false (read/write).",
             "type": "boolean"
           },
           "volumeAttributes": {
@@ -341,7 +341,7 @@
               "default": "",
               "type": "string"
             },
-            "description": "VolumeAttributes stores driver-specific properties that are passed to the CSI driver. Consult your driver's documentation for supported values.",
+            "description": "volumeAttributes stores driver-specific properties that are passed to the CSI driver. Consult your driver's documentation for supported values.",
             "type": "object"
           }
         },

--- a/api/openapi-spec/v3/apis__storage.k8s.io__v1_openapi.json
+++ b/api/openapi-spec/v3/apis__storage.k8s.io__v1_openapi.json
@@ -97,31 +97,31 @@
         "properties": {
           "controllerExpandSecretRef": {
             "$ref": "#/components/schemas/io.k8s.api.core.v1.SecretReference",
-            "description": "ControllerExpandSecretRef is a reference to the secret object containing sensitive information to pass to the CSI driver to complete the CSI ControllerExpandVolume call. This is an alpha field and requires enabling ExpandCSIVolumes feature gate. This field is optional, and may be empty if no secret is required. If the secret object contains more than one secret, all secrets are passed."
+            "description": "controllerExpandSecretRef is a reference to the secret object containing sensitive information to pass to the CSI driver to complete the CSI ControllerExpandVolume call. This is an alpha field and requires enabling ExpandCSIVolumes feature gate. This field is optional, and may be empty if no secret is required. If the secret object contains more than one secret, all secrets are passed."
           },
           "controllerPublishSecretRef": {
             "$ref": "#/components/schemas/io.k8s.api.core.v1.SecretReference",
-            "description": "ControllerPublishSecretRef is a reference to the secret object containing sensitive information to pass to the CSI driver to complete the CSI ControllerPublishVolume and ControllerUnpublishVolume calls. This field is optional, and may be empty if no secret is required. If the secret object contains more than one secret, all secrets are passed."
+            "description": "controllerPublishSecretRef is a reference to the secret object containing sensitive information to pass to the CSI driver to complete the CSI ControllerPublishVolume and ControllerUnpublishVolume calls. This field is optional, and may be empty if no secret is required. If the secret object contains more than one secret, all secrets are passed."
           },
           "driver": {
             "default": "",
-            "description": "Driver is the name of the driver to use for this volume. Required.",
+            "description": "driver is the name of the driver to use for this volume. Required.",
             "type": "string"
           },
           "fsType": {
-            "description": "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\".",
+            "description": "fsType to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\".",
             "type": "string"
           },
           "nodePublishSecretRef": {
             "$ref": "#/components/schemas/io.k8s.api.core.v1.SecretReference",
-            "description": "NodePublishSecretRef is a reference to the secret object containing sensitive information to pass to the CSI driver to complete the CSI NodePublishVolume and NodeUnpublishVolume calls. This field is optional, and may be empty if no secret is required. If the secret object contains more than one secret, all secrets are passed."
+            "description": "nodePublishSecretRef is a reference to the secret object containing sensitive information to pass to the CSI driver to complete the CSI NodePublishVolume and NodeUnpublishVolume calls. This field is optional, and may be empty if no secret is required. If the secret object contains more than one secret, all secrets are passed."
           },
           "nodeStageSecretRef": {
             "$ref": "#/components/schemas/io.k8s.api.core.v1.SecretReference",
-            "description": "NodeStageSecretRef is a reference to the secret object containing sensitive information to pass to the CSI driver to complete the CSI NodeStageVolume and NodeStageVolume and NodeUnstageVolume calls. This field is optional, and may be empty if no secret is required. If the secret object contains more than one secret, all secrets are passed."
+            "description": "nodeStageSecretRef is a reference to the secret object containing sensitive information to pass to the CSI driver to complete the CSI NodeStageVolume and NodeStageVolume and NodeUnstageVolume calls. This field is optional, and may be empty if no secret is required. If the secret object contains more than one secret, all secrets are passed."
           },
           "readOnly": {
-            "description": "Optional: The value to pass to ControllerPublishVolumeRequest. Defaults to false (read/write).",
+            "description": "readOnly value to pass to ControllerPublishVolumeRequest. Defaults to false (read/write).",
             "type": "boolean"
           },
           "volumeAttributes": {
@@ -129,12 +129,12 @@
               "default": "",
               "type": "string"
             },
-            "description": "Attributes of the volume to publish.",
+            "description": "volumeAttributes of the volume to publish.",
             "type": "object"
           },
           "volumeHandle": {
             "default": "",
-            "description": "VolumeHandle is the unique volume name returned by the CSI volume plugin’s CreateVolume to refer to the volume on all subsequent calls. Required.",
+            "description": "volumeHandle is the unique volume name returned by the CSI volume plugin’s CreateVolume to refer to the volume on all subsequent calls. Required.",
             "type": "string"
           }
         },

--- a/staging/src/k8s.io/api/core/v1/generated.proto
+++ b/staging/src/k8s.io/api/core/v1/generated.proto
@@ -171,31 +171,30 @@ message Binding {
 
 // Represents storage that is managed by an external CSI volume driver (Beta feature)
 message CSIPersistentVolumeSource {
-  // Driver is the name of the driver to use for this volume.
+  // driver is the name of the driver to use for this volume.
   // Required.
   optional string driver = 1;
 
-  // VolumeHandle is the unique volume name returned by the CSI volume
+  // volumeHandle is the unique volume name returned by the CSI volume
   // plugin’s CreateVolume to refer to the volume on all subsequent calls.
   // Required.
   optional string volumeHandle = 2;
 
-  // Optional: The value to pass to ControllerPublishVolumeRequest.
+  // readOnly value to pass to ControllerPublishVolumeRequest.
   // Defaults to false (read/write).
   // +optional
   optional bool readOnly = 3;
 
-  // Filesystem type to mount.
-  // Must be a filesystem type supported by the host operating system.
+  // fsType to mount. Must be a filesystem type supported by the host operating system.
   // Ex. "ext4", "xfs", "ntfs".
   // +optional
   optional string fsType = 4;
 
-  // Attributes of the volume to publish.
+  // volumeAttributes of the volume to publish.
   // +optional
   map<string, string> volumeAttributes = 5;
 
-  // ControllerPublishSecretRef is a reference to the secret object containing
+  // controllerPublishSecretRef is a reference to the secret object containing
   // sensitive information to pass to the CSI driver to complete the CSI
   // ControllerPublishVolume and ControllerUnpublishVolume calls.
   // This field is optional, and may be empty if no secret is required. If the
@@ -203,7 +202,7 @@ message CSIPersistentVolumeSource {
   // +optional
   optional SecretReference controllerPublishSecretRef = 6;
 
-  // NodeStageSecretRef is a reference to the secret object containing sensitive
+  // nodeStageSecretRef is a reference to the secret object containing sensitive
   // information to pass to the CSI driver to complete the CSI NodeStageVolume
   // and NodeStageVolume and NodeUnstageVolume calls.
   // This field is optional, and may be empty if no secret is required. If the
@@ -211,7 +210,7 @@ message CSIPersistentVolumeSource {
   // +optional
   optional SecretReference nodeStageSecretRef = 7;
 
-  // NodePublishSecretRef is a reference to the secret object containing
+  // nodePublishSecretRef is a reference to the secret object containing
   // sensitive information to pass to the CSI driver to complete the CSI
   // NodePublishVolume and NodeUnpublishVolume calls.
   // This field is optional, and may be empty if no secret is required. If the
@@ -219,7 +218,7 @@ message CSIPersistentVolumeSource {
   // +optional
   optional SecretReference nodePublishSecretRef = 8;
 
-  // ControllerExpandSecretRef is a reference to the secret object containing
+  // controllerExpandSecretRef is a reference to the secret object containing
   // sensitive information to pass to the CSI driver to complete the CSI
   // ControllerExpandVolume call.
   // This is an alpha field and requires enabling ExpandCSIVolumes feature gate.
@@ -231,27 +230,27 @@ message CSIPersistentVolumeSource {
 
 // Represents a source location of a volume to mount, managed by an external CSI driver
 message CSIVolumeSource {
-  // Driver is the name of the CSI driver that handles this volume.
+  // driver is the name of the CSI driver that handles this volume.
   // Consult with your admin for the correct name as registered in the cluster.
   optional string driver = 1;
 
-  // Specifies a read-only configuration for the volume.
+  // readOnly specifies a read-only configuration for the volume.
   // Defaults to false (read/write).
   // +optional
   optional bool readOnly = 2;
 
-  // Filesystem type to mount. Ex. "ext4", "xfs", "ntfs".
+  // fsType to mount. Ex. "ext4", "xfs", "ntfs".
   // If not provided, the empty value is passed to the associated CSI driver
   // which will determine the default filesystem to apply.
   // +optional
   optional string fsType = 3;
 
-  // VolumeAttributes stores driver-specific properties that are passed to the CSI
+  // volumeAttributes stores driver-specific properties that are passed to the CSI
   // driver. Consult your driver's documentation for supported values.
   // +optional
   map<string, string> volumeAttributes = 4;
 
-  // NodePublishSecretRef is a reference to the secret object containing
+  // nodePublishSecretRef is a reference to the secret object containing
   // sensitive information to pass to the CSI driver to complete the CSI
   // NodePublishVolume and NodeUnpublishVolume calls.
   // This field is optional, and  may be empty if no secret is required. If the

--- a/staging/src/k8s.io/api/core/v1/types.go
+++ b/staging/src/k8s.io/api/core/v1/types.go
@@ -1753,31 +1753,30 @@ type LocalVolumeSource struct {
 
 // Represents storage that is managed by an external CSI volume driver (Beta feature)
 type CSIPersistentVolumeSource struct {
-	// Driver is the name of the driver to use for this volume.
+	// driver is the name of the driver to use for this volume.
 	// Required.
 	Driver string `json:"driver" protobuf:"bytes,1,opt,name=driver"`
 
-	// VolumeHandle is the unique volume name returned by the CSI volume
+	// volumeHandle is the unique volume name returned by the CSI volume
 	// plugin’s CreateVolume to refer to the volume on all subsequent calls.
 	// Required.
 	VolumeHandle string `json:"volumeHandle" protobuf:"bytes,2,opt,name=volumeHandle"`
 
-	// Optional: The value to pass to ControllerPublishVolumeRequest.
+	// readOnly value to pass to ControllerPublishVolumeRequest.
 	// Defaults to false (read/write).
 	// +optional
 	ReadOnly bool `json:"readOnly,omitempty" protobuf:"varint,3,opt,name=readOnly"`
 
-	// Filesystem type to mount.
-	// Must be a filesystem type supported by the host operating system.
+	// fsType to mount. Must be a filesystem type supported by the host operating system.
 	// Ex. "ext4", "xfs", "ntfs".
 	// +optional
 	FSType string `json:"fsType,omitempty" protobuf:"bytes,4,opt,name=fsType"`
 
-	// Attributes of the volume to publish.
+	// volumeAttributes of the volume to publish.
 	// +optional
 	VolumeAttributes map[string]string `json:"volumeAttributes,omitempty" protobuf:"bytes,5,rep,name=volumeAttributes"`
 
-	// ControllerPublishSecretRef is a reference to the secret object containing
+	// controllerPublishSecretRef is a reference to the secret object containing
 	// sensitive information to pass to the CSI driver to complete the CSI
 	// ControllerPublishVolume and ControllerUnpublishVolume calls.
 	// This field is optional, and may be empty if no secret is required. If the
@@ -1785,7 +1784,7 @@ type CSIPersistentVolumeSource struct {
 	// +optional
 	ControllerPublishSecretRef *SecretReference `json:"controllerPublishSecretRef,omitempty" protobuf:"bytes,6,opt,name=controllerPublishSecretRef"`
 
-	// NodeStageSecretRef is a reference to the secret object containing sensitive
+	// nodeStageSecretRef is a reference to the secret object containing sensitive
 	// information to pass to the CSI driver to complete the CSI NodeStageVolume
 	// and NodeStageVolume and NodeUnstageVolume calls.
 	// This field is optional, and may be empty if no secret is required. If the
@@ -1793,7 +1792,7 @@ type CSIPersistentVolumeSource struct {
 	// +optional
 	NodeStageSecretRef *SecretReference `json:"nodeStageSecretRef,omitempty" protobuf:"bytes,7,opt,name=nodeStageSecretRef"`
 
-	// NodePublishSecretRef is a reference to the secret object containing
+	// nodePublishSecretRef is a reference to the secret object containing
 	// sensitive information to pass to the CSI driver to complete the CSI
 	// NodePublishVolume and NodeUnpublishVolume calls.
 	// This field is optional, and may be empty if no secret is required. If the
@@ -1801,7 +1800,7 @@ type CSIPersistentVolumeSource struct {
 	// +optional
 	NodePublishSecretRef *SecretReference `json:"nodePublishSecretRef,omitempty" protobuf:"bytes,8,opt,name=nodePublishSecretRef"`
 
-	// ControllerExpandSecretRef is a reference to the secret object containing
+	// controllerExpandSecretRef is a reference to the secret object containing
 	// sensitive information to pass to the CSI driver to complete the CSI
 	// ControllerExpandVolume call.
 	// This is an alpha field and requires enabling ExpandCSIVolumes feature gate.
@@ -1813,27 +1812,27 @@ type CSIPersistentVolumeSource struct {
 
 // Represents a source location of a volume to mount, managed by an external CSI driver
 type CSIVolumeSource struct {
-	// Driver is the name of the CSI driver that handles this volume.
+	// driver is the name of the CSI driver that handles this volume.
 	// Consult with your admin for the correct name as registered in the cluster.
 	Driver string `json:"driver" protobuf:"bytes,1,opt,name=driver"`
 
-	// Specifies a read-only configuration for the volume.
+	// readOnly specifies a read-only configuration for the volume.
 	// Defaults to false (read/write).
 	// +optional
 	ReadOnly *bool `json:"readOnly,omitempty" protobuf:"varint,2,opt,name=readOnly"`
 
-	// Filesystem type to mount. Ex. "ext4", "xfs", "ntfs".
+	// fsType to mount. Ex. "ext4", "xfs", "ntfs".
 	// If not provided, the empty value is passed to the associated CSI driver
 	// which will determine the default filesystem to apply.
 	// +optional
 	FSType *string `json:"fsType,omitempty" protobuf:"bytes,3,opt,name=fsType"`
 
-	// VolumeAttributes stores driver-specific properties that are passed to the CSI
+	// volumeAttributes stores driver-specific properties that are passed to the CSI
 	// driver. Consult your driver's documentation for supported values.
 	// +optional
 	VolumeAttributes map[string]string `json:"volumeAttributes,omitempty" protobuf:"bytes,4,rep,name=volumeAttributes"`
 
-	// NodePublishSecretRef is a reference to the secret object containing
+	// nodePublishSecretRef is a reference to the secret object containing
 	// sensitive information to pass to the CSI driver to complete the CSI
 	// NodePublishVolume and NodeUnpublishVolume calls.
 	// This field is optional, and  may be empty if no secret is required. If the

--- a/staging/src/k8s.io/api/core/v1/types_swagger_doc_generated.go
+++ b/staging/src/k8s.io/api/core/v1/types_swagger_doc_generated.go
@@ -118,15 +118,15 @@ func (Binding) SwaggerDoc() map[string]string {
 
 var map_CSIPersistentVolumeSource = map[string]string{
 	"":                           "Represents storage that is managed by an external CSI volume driver (Beta feature)",
-	"driver":                     "Driver is the name of the driver to use for this volume. Required.",
-	"volumeHandle":               "VolumeHandle is the unique volume name returned by the CSI volume plugin’s CreateVolume to refer to the volume on all subsequent calls. Required.",
-	"readOnly":                   "Optional: The value to pass to ControllerPublishVolumeRequest. Defaults to false (read/write).",
-	"fsType":                     "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\".",
-	"volumeAttributes":           "Attributes of the volume to publish.",
-	"controllerPublishSecretRef": "ControllerPublishSecretRef is a reference to the secret object containing sensitive information to pass to the CSI driver to complete the CSI ControllerPublishVolume and ControllerUnpublishVolume calls. This field is optional, and may be empty if no secret is required. If the secret object contains more than one secret, all secrets are passed.",
-	"nodeStageSecretRef":         "NodeStageSecretRef is a reference to the secret object containing sensitive information to pass to the CSI driver to complete the CSI NodeStageVolume and NodeStageVolume and NodeUnstageVolume calls. This field is optional, and may be empty if no secret is required. If the secret object contains more than one secret, all secrets are passed.",
-	"nodePublishSecretRef":       "NodePublishSecretRef is a reference to the secret object containing sensitive information to pass to the CSI driver to complete the CSI NodePublishVolume and NodeUnpublishVolume calls. This field is optional, and may be empty if no secret is required. If the secret object contains more than one secret, all secrets are passed.",
-	"controllerExpandSecretRef":  "ControllerExpandSecretRef is a reference to the secret object containing sensitive information to pass to the CSI driver to complete the CSI ControllerExpandVolume call. This is an alpha field and requires enabling ExpandCSIVolumes feature gate. This field is optional, and may be empty if no secret is required. If the secret object contains more than one secret, all secrets are passed.",
+	"driver":                     "driver is the name of the driver to use for this volume. Required.",
+	"volumeHandle":               "volumeHandle is the unique volume name returned by the CSI volume plugin’s CreateVolume to refer to the volume on all subsequent calls. Required.",
+	"readOnly":                   "readOnly value to pass to ControllerPublishVolumeRequest. Defaults to false (read/write).",
+	"fsType":                     "fsType to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\".",
+	"volumeAttributes":           "volumeAttributes of the volume to publish.",
+	"controllerPublishSecretRef": "controllerPublishSecretRef is a reference to the secret object containing sensitive information to pass to the CSI driver to complete the CSI ControllerPublishVolume and ControllerUnpublishVolume calls. This field is optional, and may be empty if no secret is required. If the secret object contains more than one secret, all secrets are passed.",
+	"nodeStageSecretRef":         "nodeStageSecretRef is a reference to the secret object containing sensitive information to pass to the CSI driver to complete the CSI NodeStageVolume and NodeStageVolume and NodeUnstageVolume calls. This field is optional, and may be empty if no secret is required. If the secret object contains more than one secret, all secrets are passed.",
+	"nodePublishSecretRef":       "nodePublishSecretRef is a reference to the secret object containing sensitive information to pass to the CSI driver to complete the CSI NodePublishVolume and NodeUnpublishVolume calls. This field is optional, and may be empty if no secret is required. If the secret object contains more than one secret, all secrets are passed.",
+	"controllerExpandSecretRef":  "controllerExpandSecretRef is a reference to the secret object containing sensitive information to pass to the CSI driver to complete the CSI ControllerExpandVolume call. This is an alpha field and requires enabling ExpandCSIVolumes feature gate. This field is optional, and may be empty if no secret is required. If the secret object contains more than one secret, all secrets are passed.",
 }
 
 func (CSIPersistentVolumeSource) SwaggerDoc() map[string]string {
@@ -135,11 +135,11 @@ func (CSIPersistentVolumeSource) SwaggerDoc() map[string]string {
 
 var map_CSIVolumeSource = map[string]string{
 	"":                     "Represents a source location of a volume to mount, managed by an external CSI driver",
-	"driver":               "Driver is the name of the CSI driver that handles this volume. Consult with your admin for the correct name as registered in the cluster.",
-	"readOnly":             "Specifies a read-only configuration for the volume. Defaults to false (read/write).",
-	"fsType":               "Filesystem type to mount. Ex. \"ext4\", \"xfs\", \"ntfs\". If not provided, the empty value is passed to the associated CSI driver which will determine the default filesystem to apply.",
-	"volumeAttributes":     "VolumeAttributes stores driver-specific properties that are passed to the CSI driver. Consult your driver's documentation for supported values.",
-	"nodePublishSecretRef": "NodePublishSecretRef is a reference to the secret object containing sensitive information to pass to the CSI driver to complete the CSI NodePublishVolume and NodeUnpublishVolume calls. This field is optional, and  may be empty if no secret is required. If the secret object contains more than one secret, all secret references are passed.",
+	"driver":               "driver is the name of the CSI driver that handles this volume. Consult with your admin for the correct name as registered in the cluster.",
+	"readOnly":             "readOnly specifies a read-only configuration for the volume. Defaults to false (read/write).",
+	"fsType":               "fsType to mount. Ex. \"ext4\", \"xfs\", \"ntfs\". If not provided, the empty value is passed to the associated CSI driver which will determine the default filesystem to apply.",
+	"volumeAttributes":     "volumeAttributes stores driver-specific properties that are passed to the CSI driver. Consult your driver's documentation for supported values.",
+	"nodePublishSecretRef": "nodePublishSecretRef is a reference to the secret object containing sensitive information to pass to the CSI driver to complete the CSI NodePublishVolume and NodeUnpublishVolume calls. This field is optional, and  may be empty if no secret is required. If the secret object contains more than one secret, all secret references are passed.",
 }
 
 func (CSIVolumeSource) SwaggerDoc() map[string]string {


### PR DESCRIPTION
The field names in godoc for CSIPersistentVolumeSource and
CSIVolumeSource has been corrected with this commit.

Additional Ref# https://github.com/kubernetes/kubernetes/pull/105963#discussion_r751340196

Signed-off-by: Humble Chirammal <hchiramm@redhat.com>


#### What type of PR is this?


/kind cleanup
/kind documentation

-->
```release-note
NONE
```

#### Additional Note:
There are more structs to fix, it will be done as a follow up PRs. 
