### PR TITLE
Fix kubetest errors when executing local provider

### DIFF
--- a/cluster/kubectl.sh
+++ b/cluster/kubectl.sh
@@ -33,6 +33,7 @@ set -o pipefail
 KUBE_ROOT=${KUBE_ROOT:-$(dirname "${BASH_SOURCE[0]}")/..}
 source "${KUBE_ROOT}/cluster/kube-util.sh"
 source "${KUBE_ROOT}/hack/lib/util.sh"
+source "${KUBE_ROOT}/hack/lib/logging.sh"
 
 # If KUBECTL_PATH isn't set, gather up the list of likely places and use ls
 # to find the latest one.

--- a/hack/lib/util.sh
+++ b/hack/lib/util.sh
@@ -211,12 +211,19 @@ kube::util::find-binary-for-platform() {
     "${KUBE_ROOT}/_output/local/bin/${platform}/${lookfor}"
     "${KUBE_ROOT}/platforms/${platform}/${lookfor}"
   )
+
   # if we're looking for the host platform, add local non-platform-qualified search paths
   if [[ "${platform}" = "$(kube::util::host_platform)" ]]; then
     locations+=(
       "${KUBE_ROOT}/_output/local/go/bin/${lookfor}"
       "${KUBE_ROOT}/_output/dockerized/go/bin/${lookfor}"
     );
+  fi
+
+  # looks for $1 in the $PATH
+  if which ${lookfor} >/dev/null; then
+    local -r local_bin="$(which ${lookfor})"
+    locations+=( "${local_bin}"  );
   fi
 
   # List most recently-updated location.

--- a/hack/lib/util.sh
+++ b/hack/lib/util.sh
@@ -221,8 +221,8 @@ kube::util::find-binary-for-platform() {
   fi
 
   # looks for $1 in the $PATH
-  if which ${lookfor} >/dev/null; then
-    local -r local_bin="$(which ${lookfor})"
+  if which "${lookfor}" >/dev/null; then
+    local -r local_bin="$(which "${lookfor}")"
     locations+=( "${local_bin}"  );
   fi
 


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
I'm trying to run the end-2-end tests locally using `kind` for running the Kubernetes cluster, and when I execute `kubetest --provider local --deployment local --test --check-version-skew false` I get 2 errors:

The first one:
```
2022/01/06 13:30:10 main.go:284: Running kubetest version: 
2022/01/06 13:30:10 process.go:153: Running: $HOME/kubernetes/kubernetes/cluster/kubectl.sh get nodes -ojson
$HOME/kubernetes/kubernetes/cluster/../cluster/../hack/lib/util.sh: line 226: kube::log::error: command not found
2022/01/06 13:30:11 process.go:155: Step '$HOME/kubernetes/kubernetes/cluster/kubectl.sh get nodes -ojson' finished in 1.136083829s
2022/01/06 13:30:11 kubernetes.go:35: kubectl get nodes failed: error during $HOME/kubernetes/kubernetes/cluster/kubectl.sh get nodes -ojson: exit status 1
2022/01/06 13:30:11 main.go:331: Something went wrong: encountered 1 errors: [error during $HOMEts/kubernetes/kubernetes/cluster/kubectl.sh get nodes -ojson: exit status 1]
```
This is because it doesn't find the `kube::log::error`. I've solved it adding `source "${KUBE_ROOT}/hack/lib/logging.sh"` to `cluster/kubectl.sh`

The second one is:
```
2022/01/06 13:33:59 main.go:284: Running kubetest version: 
2022/01/06 13:33:59 process.go:153: Running: $HOME/kubernetes/kubernetes/cluster/kubectl.sh get nodes -ojson
!!! [0106 13:33:59] Failed to find binary kubectl for platform darwin/amd64
2022/01/06 13:33:59 process.go:155: Step '$HOME/kubernetes/kubernetes/cluster/kubectl.sh get nodes -ojson' finished in 666.903805ms
2022/01/06 13:33:59 kubernetes.go:35: kubectl get nodes failed: error during $HOME/kubernetes/kubernetes/cluster/kubectl.sh get nodes -ojson: exit status 1
2022/01/06 13:33:59 main.go:331: Something went wrong: encountered 1 errors: [error during $HOME/kubernetes/kubernetes/cluster/kubectl.sh get nodes -ojson: exit status 1]
```

In this case, the script is looking for the `kubectl` binary in:
```shell
      "${KUBE_ROOT}/_output/local/go/bin/${lookfor}"
      "${KUBE_ROOT}/_output/dockerized/go/bin/${lookfor}"
```

Not sure if I miss any setup step for the test, but I have that binary in my $PATH and I would expect that it would be a valid location too.

To solve this, I added this for finding the executable in the $PATH too:
```shell
  if which ${lookfor} >/dev/null; then
    local -r local_bin="$(which ${lookfor})"
    locations+=( "${local_bin}"  );
  fi
```
#### Which issue(s) this PR fixes:
None

#### Special notes for your reviewer:
This is my first time contributing to Kubernetes and I'm not completely sure that my premises are correct.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
