### PR TITLE
kube-proxy endpoint filtering unit test refactoring

### DIFF
--- a/pkg/proxy/topology_test.go
+++ b/pkg/proxy/topology_test.go
@@ -110,7 +110,7 @@ func TestFilterEndpoints(t *testing.T) {
 		name:         "node local endpoints, hints are ignored",
 		hintsEnabled: true,
 		nodeLabels:   map[string]string{v1.LabelTopologyZone: "zone-a"},
-		serviceInfo:  &BaseServiceInfo{nodeLocalExternal: true},
+		serviceInfo:  &BaseServiceInfo{nodeLocalExternal: true, hintsAnnotation: "auto"},
 		endpoints: []endpoint{
 			{ip: "10.1.2.3", zoneHints: sets.NewString("zone-a")},
 			{ip: "10.1.2.4", zoneHints: sets.NewString("zone-b")},

--- a/pkg/proxy/topology_test.go
+++ b/pkg/proxy/topology_test.go
@@ -46,28 +46,23 @@ func checkExpectedEndpoints(expected sets.String, actual []Endpoint) error {
 }
 
 func TestFilterEndpoints(t *testing.T) {
-	type endpoint struct {
-		ip        string
-		zoneHints sets.String
-		unready   bool
-	}
 	testCases := []struct {
 		name              string
 		hintsEnabled      bool
 		nodeLabels        map[string]string
 		serviceInfo       ServicePort
-		endpoints         []endpoint
+		endpoints         []Endpoint
 		expectedEndpoints sets.String
 	}{{
 		name:         "hints enabled, hints annotation == auto",
 		hintsEnabled: true,
 		nodeLabels:   map[string]string{v1.LabelTopologyZone: "zone-a"},
 		serviceInfo:  &BaseServiceInfo{nodeLocalExternal: false, hintsAnnotation: "auto"},
-		endpoints: []endpoint{
-			{ip: "10.1.2.3", zoneHints: sets.NewString("zone-a")},
-			{ip: "10.1.2.4", zoneHints: sets.NewString("zone-b")},
-			{ip: "10.1.2.5", zoneHints: sets.NewString("zone-c")},
-			{ip: "10.1.2.6", zoneHints: sets.NewString("zone-a")},
+		endpoints: []Endpoint{
+			&BaseEndpointInfo{Endpoint: "10.1.2.3:80", ZoneHints: sets.NewString("zone-a"), Ready: true},
+			&BaseEndpointInfo{Endpoint: "10.1.2.4:80", ZoneHints: sets.NewString("zone-b"), Ready: true},
+			&BaseEndpointInfo{Endpoint: "10.1.2.5:80", ZoneHints: sets.NewString("zone-c"), Ready: true},
+			&BaseEndpointInfo{Endpoint: "10.1.2.6:80", ZoneHints: sets.NewString("zone-a"), Ready: true},
 		},
 		expectedEndpoints: sets.NewString("10.1.2.3:80", "10.1.2.6:80"),
 	}, {
@@ -75,11 +70,11 @@ func TestFilterEndpoints(t *testing.T) {
 		hintsEnabled: true,
 		nodeLabels:   map[string]string{v1.LabelTopologyZone: "zone-a"},
 		serviceInfo:  &BaseServiceInfo{nodeLocalExternal: false, hintsAnnotation: "disabled"},
-		endpoints: []endpoint{
-			{ip: "10.1.2.3", zoneHints: sets.NewString("zone-a")},
-			{ip: "10.1.2.4", zoneHints: sets.NewString("zone-b")},
-			{ip: "10.1.2.5", zoneHints: sets.NewString("zone-c")},
-			{ip: "10.1.2.6", zoneHints: sets.NewString("zone-a")},
+		endpoints: []Endpoint{
+			&BaseEndpointInfo{Endpoint: "10.1.2.3:80", ZoneHints: sets.NewString("zone-a"), Ready: true},
+			&BaseEndpointInfo{Endpoint: "10.1.2.4:80", ZoneHints: sets.NewString("zone-b"), Ready: true},
+			&BaseEndpointInfo{Endpoint: "10.1.2.5:80", ZoneHints: sets.NewString("zone-c"), Ready: true},
+			&BaseEndpointInfo{Endpoint: "10.1.2.6:80", ZoneHints: sets.NewString("zone-a"), Ready: true},
 		},
 		expectedEndpoints: sets.NewString("10.1.2.3:80", "10.1.2.4:80", "10.1.2.5:80", "10.1.2.6:80"),
 	}, {
@@ -87,11 +82,11 @@ func TestFilterEndpoints(t *testing.T) {
 		hintsEnabled: true,
 		nodeLabels:   map[string]string{v1.LabelTopologyZone: "zone-a"},
 		serviceInfo:  &BaseServiceInfo{nodeLocalExternal: false, hintsAnnotation: "aUto"},
-		endpoints: []endpoint{
-			{ip: "10.1.2.3", zoneHints: sets.NewString("zone-a")},
-			{ip: "10.1.2.4", zoneHints: sets.NewString("zone-b")},
-			{ip: "10.1.2.5", zoneHints: sets.NewString("zone-c")},
-			{ip: "10.1.2.6", zoneHints: sets.NewString("zone-a")},
+		endpoints: []Endpoint{
+			&BaseEndpointInfo{Endpoint: "10.1.2.3:80", ZoneHints: sets.NewString("zone-a"), Ready: true},
+			&BaseEndpointInfo{Endpoint: "10.1.2.4:80", ZoneHints: sets.NewString("zone-b"), Ready: true},
+			&BaseEndpointInfo{Endpoint: "10.1.2.5:80", ZoneHints: sets.NewString("zone-c"), Ready: true},
+			&BaseEndpointInfo{Endpoint: "10.1.2.6:80", ZoneHints: sets.NewString("zone-a"), Ready: true},
 		},
 		expectedEndpoints: sets.NewString("10.1.2.3:80", "10.1.2.4:80", "10.1.2.5:80", "10.1.2.6:80"),
 	}, {
@@ -99,11 +94,11 @@ func TestFilterEndpoints(t *testing.T) {
 		hintsEnabled: true,
 		nodeLabels:   map[string]string{v1.LabelTopologyZone: "zone-a"},
 		serviceInfo:  &BaseServiceInfo{nodeLocalExternal: false},
-		endpoints: []endpoint{
-			{ip: "10.1.2.3", zoneHints: sets.NewString("zone-a")},
-			{ip: "10.1.2.4", zoneHints: sets.NewString("zone-b")},
-			{ip: "10.1.2.5", zoneHints: sets.NewString("zone-c")},
-			{ip: "10.1.2.6", zoneHints: sets.NewString("zone-a")},
+		endpoints: []Endpoint{
+			&BaseEndpointInfo{Endpoint: "10.1.2.3:80", ZoneHints: sets.NewString("zone-a"), Ready: true},
+			&BaseEndpointInfo{Endpoint: "10.1.2.4:80", ZoneHints: sets.NewString("zone-b"), Ready: true},
+			&BaseEndpointInfo{Endpoint: "10.1.2.5:80", ZoneHints: sets.NewString("zone-c"), Ready: true},
+			&BaseEndpointInfo{Endpoint: "10.1.2.6:80", ZoneHints: sets.NewString("zone-a"), Ready: true},
 		},
 		expectedEndpoints: sets.NewString("10.1.2.3:80", "10.1.2.4:80", "10.1.2.5:80", "10.1.2.6:80"),
 	}, {
@@ -111,11 +106,11 @@ func TestFilterEndpoints(t *testing.T) {
 		hintsEnabled: true,
 		nodeLabels:   map[string]string{v1.LabelTopologyZone: "zone-a"},
 		serviceInfo:  &BaseServiceInfo{nodeLocalExternal: true, hintsAnnotation: "auto"},
-		endpoints: []endpoint{
-			{ip: "10.1.2.3", zoneHints: sets.NewString("zone-a")},
-			{ip: "10.1.2.4", zoneHints: sets.NewString("zone-b")},
-			{ip: "10.1.2.5", zoneHints: sets.NewString("zone-c")},
-			{ip: "10.1.2.6", zoneHints: sets.NewString("zone-a")},
+		endpoints: []Endpoint{
+			&BaseEndpointInfo{Endpoint: "10.1.2.3:80", ZoneHints: sets.NewString("zone-a"), Ready: true},
+			&BaseEndpointInfo{Endpoint: "10.1.2.4:80", ZoneHints: sets.NewString("zone-b"), Ready: true},
+			&BaseEndpointInfo{Endpoint: "10.1.2.5:80", ZoneHints: sets.NewString("zone-c"), Ready: true},
+			&BaseEndpointInfo{Endpoint: "10.1.2.6:80", ZoneHints: sets.NewString("zone-a"), Ready: true},
 		},
 		expectedEndpoints: sets.NewString("10.1.2.3:80", "10.1.2.4:80", "10.1.2.5:80", "10.1.2.6:80"),
 	}}
@@ -124,12 +119,7 @@ func TestFilterEndpoints(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.TopologyAwareHints, tc.hintsEnabled)()
 
-			endpoints := []Endpoint{}
-			for _, ep := range tc.endpoints {
-				endpoints = append(endpoints, &BaseEndpointInfo{Endpoint: ep.ip + ":80", ZoneHints: ep.zoneHints, Ready: !ep.unready})
-			}
-
-			filteredEndpoints := FilterEndpoints(endpoints, tc.serviceInfo, tc.nodeLabels)
+			filteredEndpoints := FilterEndpoints(tc.endpoints, tc.serviceInfo, tc.nodeLabels)
 			err := checkExpectedEndpoints(tc.expectedEndpoints, filteredEndpoints)
 			if err != nil {
 				t.Errorf(err.Error())
@@ -139,133 +129,129 @@ func TestFilterEndpoints(t *testing.T) {
 }
 
 func Test_filterEndpointsWithHints(t *testing.T) {
-	type endpoint struct {
-		ip        string
-		zoneHints sets.String
-		unready   bool
-	}
 	testCases := []struct {
 		name              string
 		nodeLabels        map[string]string
 		hintsAnnotation   string
-		endpoints         []endpoint
+		endpoints         []Endpoint
 		expectedEndpoints sets.String
 	}{{
-		name:              "empty node labels",
-		nodeLabels:        map[string]string{},
-		hintsAnnotation:   "auto",
-		endpoints:         []endpoint{{ip: "10.1.2.3", zoneHints: sets.NewString("zone-a")}},
+		name:            "empty node labels",
+		nodeLabels:      map[string]string{},
+		hintsAnnotation: "auto",
+		endpoints: []Endpoint{
+			&BaseEndpointInfo{Endpoint: "10.1.2.3:80", ZoneHints: sets.NewString("zone-a"), Ready: true},
+		},
 		expectedEndpoints: sets.NewString("10.1.2.3:80"),
 	}, {
-		name:              "empty zone label",
-		nodeLabels:        map[string]string{v1.LabelTopologyZone: ""},
-		hintsAnnotation:   "auto",
-		endpoints:         []endpoint{{ip: "10.1.2.3", zoneHints: sets.NewString("zone-a")}},
+		name:            "empty zone label",
+		nodeLabels:      map[string]string{v1.LabelTopologyZone: ""},
+		hintsAnnotation: "auto",
+		endpoints: []Endpoint{
+			&BaseEndpointInfo{Endpoint: "10.1.2.3:80", ZoneHints: sets.NewString("zone-a"), Ready: true},
+		},
 		expectedEndpoints: sets.NewString("10.1.2.3:80"),
 	}, {
-		name:              "node in different zone, no endpoint filtering",
-		nodeLabels:        map[string]string{v1.LabelTopologyZone: "zone-b"},
-		hintsAnnotation:   "auto",
-		endpoints:         []endpoint{{ip: "10.1.2.3", zoneHints: sets.NewString("zone-a")}},
+		name:            "node in different zone, no endpoint filtering",
+		nodeLabels:      map[string]string{v1.LabelTopologyZone: "zone-b"},
+		hintsAnnotation: "auto",
+		endpoints: []Endpoint{
+			&BaseEndpointInfo{Endpoint: "10.1.2.3:80", ZoneHints: sets.NewString("zone-a"), Ready: true},
+		},
 		expectedEndpoints: sets.NewString("10.1.2.3:80"),
 	}, {
 		name:            "normal endpoint filtering, auto annotation",
 		nodeLabels:      map[string]string{v1.LabelTopologyZone: "zone-a"},
 		hintsAnnotation: "auto",
-		endpoints: []endpoint{
-			{ip: "10.1.2.3", zoneHints: sets.NewString("zone-a")},
-			{ip: "10.1.2.4", zoneHints: sets.NewString("zone-b")},
-			{ip: "10.1.2.5", zoneHints: sets.NewString("zone-c")},
-			{ip: "10.1.2.6", zoneHints: sets.NewString("zone-a")},
+		endpoints: []Endpoint{
+			&BaseEndpointInfo{Endpoint: "10.1.2.3:80", ZoneHints: sets.NewString("zone-a"), Ready: true},
+			&BaseEndpointInfo{Endpoint: "10.1.2.4:80", ZoneHints: sets.NewString("zone-b"), Ready: true},
+			&BaseEndpointInfo{Endpoint: "10.1.2.5:80", ZoneHints: sets.NewString("zone-c"), Ready: true},
+			&BaseEndpointInfo{Endpoint: "10.1.2.6:80", ZoneHints: sets.NewString("zone-a"), Ready: true},
 		},
 		expectedEndpoints: sets.NewString("10.1.2.3:80", "10.1.2.6:80"),
 	}, {
 		name:            "unready endpoint",
 		nodeLabels:      map[string]string{v1.LabelTopologyZone: "zone-a"},
 		hintsAnnotation: "auto",
-		endpoints: []endpoint{
-			{ip: "10.1.2.3", zoneHints: sets.NewString("zone-a")},
-			{ip: "10.1.2.4", zoneHints: sets.NewString("zone-b")},
-			{ip: "10.1.2.5", zoneHints: sets.NewString("zone-c")},
-			{ip: "10.1.2.6", zoneHints: sets.NewString("zone-a"), unready: true},
+		endpoints: []Endpoint{
+			&BaseEndpointInfo{Endpoint: "10.1.2.3:80", ZoneHints: sets.NewString("zone-a"), Ready: true},
+			&BaseEndpointInfo{Endpoint: "10.1.2.4:80", ZoneHints: sets.NewString("zone-b"), Ready: true},
+			&BaseEndpointInfo{Endpoint: "10.1.2.5:80", ZoneHints: sets.NewString("zone-c"), Ready: true},
+			&BaseEndpointInfo{Endpoint: "10.1.2.6:80", ZoneHints: sets.NewString("zone-a"), Ready: false},
 		},
 		expectedEndpoints: sets.NewString("10.1.2.3:80"),
 	}, {
 		name:            "only unready endpoints in same zone (should not filter)",
 		nodeLabels:      map[string]string{v1.LabelTopologyZone: "zone-a"},
 		hintsAnnotation: "auto",
-		endpoints: []endpoint{
-			{ip: "10.1.2.3", zoneHints: sets.NewString("zone-a"), unready: true},
-			{ip: "10.1.2.4", zoneHints: sets.NewString("zone-b")},
-			{ip: "10.1.2.5", zoneHints: sets.NewString("zone-c")},
-			{ip: "10.1.2.6", zoneHints: sets.NewString("zone-a"), unready: true},
+		endpoints: []Endpoint{
+			&BaseEndpointInfo{Endpoint: "10.1.2.3:80", ZoneHints: sets.NewString("zone-a"), Ready: false},
+			&BaseEndpointInfo{Endpoint: "10.1.2.4:80", ZoneHints: sets.NewString("zone-b"), Ready: true},
+			&BaseEndpointInfo{Endpoint: "10.1.2.5:80", ZoneHints: sets.NewString("zone-c"), Ready: true},
+			&BaseEndpointInfo{Endpoint: "10.1.2.6:80", ZoneHints: sets.NewString("zone-a"), Ready: false},
 		},
 		expectedEndpoints: sets.NewString("10.1.2.3:80", "10.1.2.4:80", "10.1.2.5:80", "10.1.2.6:80"),
 	}, {
 		name:            "normal endpoint filtering, Auto annotation",
 		nodeLabels:      map[string]string{v1.LabelTopologyZone: "zone-a"},
 		hintsAnnotation: "Auto",
-		endpoints: []endpoint{
-			{ip: "10.1.2.3", zoneHints: sets.NewString("zone-a")},
-			{ip: "10.1.2.4", zoneHints: sets.NewString("zone-b")},
-			{ip: "10.1.2.5", zoneHints: sets.NewString("zone-c")},
-			{ip: "10.1.2.6", zoneHints: sets.NewString("zone-a")},
+		endpoints: []Endpoint{
+			&BaseEndpointInfo{Endpoint: "10.1.2.3:80", ZoneHints: sets.NewString("zone-a"), Ready: true},
+			&BaseEndpointInfo{Endpoint: "10.1.2.4:80", ZoneHints: sets.NewString("zone-b"), Ready: true},
+			&BaseEndpointInfo{Endpoint: "10.1.2.5:80", ZoneHints: sets.NewString("zone-c"), Ready: true},
+			&BaseEndpointInfo{Endpoint: "10.1.2.6:80", ZoneHints: sets.NewString("zone-a"), Ready: true},
 		},
 		expectedEndpoints: sets.NewString("10.1.2.3:80", "10.1.2.6:80"),
 	}, {
 		name:            "hintsAnnotation empty, no filtering applied",
 		nodeLabels:      map[string]string{v1.LabelTopologyZone: "zone-a"},
 		hintsAnnotation: "",
-		endpoints: []endpoint{
-			{ip: "10.1.2.3", zoneHints: sets.NewString("zone-a")},
-			{ip: "10.1.2.4", zoneHints: sets.NewString("zone-b")},
-			{ip: "10.1.2.5", zoneHints: sets.NewString("zone-c")},
-			{ip: "10.1.2.6", zoneHints: sets.NewString("zone-a")},
+		endpoints: []Endpoint{
+			&BaseEndpointInfo{Endpoint: "10.1.2.3:80", ZoneHints: sets.NewString("zone-a"), Ready: true},
+			&BaseEndpointInfo{Endpoint: "10.1.2.4:80", ZoneHints: sets.NewString("zone-b"), Ready: true},
+			&BaseEndpointInfo{Endpoint: "10.1.2.5:80", ZoneHints: sets.NewString("zone-c"), Ready: true},
+			&BaseEndpointInfo{Endpoint: "10.1.2.6:80", ZoneHints: sets.NewString("zone-a"), Ready: true},
 		},
 		expectedEndpoints: sets.NewString("10.1.2.3:80", "10.1.2.4:80", "10.1.2.5:80", "10.1.2.6:80"),
 	}, {
 		name:            "hintsAnnotation disabled, no filtering applied",
 		nodeLabels:      map[string]string{v1.LabelTopologyZone: "zone-a"},
 		hintsAnnotation: "disabled",
-		endpoints: []endpoint{
-			{ip: "10.1.2.3", zoneHints: sets.NewString("zone-a")},
-			{ip: "10.1.2.4", zoneHints: sets.NewString("zone-b")},
-			{ip: "10.1.2.5", zoneHints: sets.NewString("zone-c")},
-			{ip: "10.1.2.6", zoneHints: sets.NewString("zone-a")},
+		endpoints: []Endpoint{
+			&BaseEndpointInfo{Endpoint: "10.1.2.3:80", ZoneHints: sets.NewString("zone-a"), Ready: true},
+			&BaseEndpointInfo{Endpoint: "10.1.2.4:80", ZoneHints: sets.NewString("zone-b"), Ready: true},
+			&BaseEndpointInfo{Endpoint: "10.1.2.5:80", ZoneHints: sets.NewString("zone-c"), Ready: true},
+			&BaseEndpointInfo{Endpoint: "10.1.2.6:80", ZoneHints: sets.NewString("zone-a"), Ready: true},
 		},
 		expectedEndpoints: sets.NewString("10.1.2.3:80", "10.1.2.4:80", "10.1.2.5:80", "10.1.2.6:80"),
 	}, {
 		name:            "missing hints, no filtering applied",
 		nodeLabels:      map[string]string{v1.LabelTopologyZone: "zone-a"},
 		hintsAnnotation: "auto",
-		endpoints: []endpoint{
-			{ip: "10.1.2.3", zoneHints: sets.NewString("zone-a")},
-			{ip: "10.1.2.4", zoneHints: sets.NewString("zone-b")},
-			{ip: "10.1.2.5"},
-			{ip: "10.1.2.6", zoneHints: sets.NewString("zone-a")},
+		endpoints: []Endpoint{
+			&BaseEndpointInfo{Endpoint: "10.1.2.3:80", ZoneHints: sets.NewString("zone-a"), Ready: true},
+			&BaseEndpointInfo{Endpoint: "10.1.2.4:80", ZoneHints: sets.NewString("zone-b"), Ready: true},
+			&BaseEndpointInfo{Endpoint: "10.1.2.5:80", ZoneHints: nil, Ready: true},
+			&BaseEndpointInfo{Endpoint: "10.1.2.6:80", ZoneHints: sets.NewString("zone-a"), Ready: true},
 		},
 		expectedEndpoints: sets.NewString("10.1.2.3:80", "10.1.2.4:80", "10.1.2.5:80", "10.1.2.6:80"),
 	}, {
 		name:            "multiple hints per endpoint, filtering includes any endpoint with zone included",
 		nodeLabels:      map[string]string{v1.LabelTopologyZone: "zone-c"},
 		hintsAnnotation: "auto",
-		endpoints: []endpoint{
-			{ip: "10.1.2.3", zoneHints: sets.NewString("zone-a", "zone-b", "zone-c")},
-			{ip: "10.1.2.4", zoneHints: sets.NewString("zone-b", "zone-c")},
-			{ip: "10.1.2.5", zoneHints: sets.NewString("zone-b", "zone-d")},
-			{ip: "10.1.2.6", zoneHints: sets.NewString("zone-c")},
+		endpoints: []Endpoint{
+			&BaseEndpointInfo{Endpoint: "10.1.2.3:80", ZoneHints: sets.NewString("zone-a", "zone-b", "zone-c"), Ready: true},
+			&BaseEndpointInfo{Endpoint: "10.1.2.4:80", ZoneHints: sets.NewString("zone-b", "zone-c"), Ready: true},
+			&BaseEndpointInfo{Endpoint: "10.1.2.5:80", ZoneHints: sets.NewString("zone-b", "zone-d"), Ready: true},
+			&BaseEndpointInfo{Endpoint: "10.1.2.6:80", ZoneHints: sets.NewString("zone-c"), Ready: true},
 		},
 		expectedEndpoints: sets.NewString("10.1.2.3:80", "10.1.2.4:80", "10.1.2.6:80"),
 	}}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			endpoints := []Endpoint{}
-			for _, ep := range tc.endpoints {
-				endpoints = append(endpoints, &BaseEndpointInfo{Endpoint: ep.ip + ":80", ZoneHints: ep.zoneHints, Ready: !ep.unready})
-			}
-
-			filteredEndpoints := filterEndpointsWithHints(endpoints, tc.hintsAnnotation, tc.nodeLabels)
+			filteredEndpoints := filterEndpointsWithHints(tc.endpoints, tc.hintsAnnotation, tc.nodeLabels)
 			err := checkExpectedEndpoints(tc.expectedEndpoints, filteredEndpoints)
 			if err != nil {
 				t.Errorf(err.Error())
@@ -288,24 +274,24 @@ func TestFilterLocalEndpoint(t *testing.T) {
 		{
 			name: "all endpoints not local",
 			endpoints: []Endpoint{
-				&BaseEndpointInfo{Endpoint: "10.0.0.0:80", IsLocal: false},
-				&BaseEndpointInfo{Endpoint: "10.0.0.1:80", IsLocal: false},
+				&BaseEndpointInfo{Endpoint: "10.0.0.0:80", Ready: true, IsLocal: false},
+				&BaseEndpointInfo{Endpoint: "10.0.0.1:80", Ready: true, IsLocal: false},
 			},
 			expected: nil,
 		},
 		{
 			name: "all endpoints are local",
 			endpoints: []Endpoint{
-				&BaseEndpointInfo{Endpoint: "10.0.0.0:80", IsLocal: true},
-				&BaseEndpointInfo{Endpoint: "10.0.0.1:80", IsLocal: true},
+				&BaseEndpointInfo{Endpoint: "10.0.0.0:80", Ready: true, IsLocal: true},
+				&BaseEndpointInfo{Endpoint: "10.0.0.1:80", Ready: true, IsLocal: true},
 			},
 			expected: sets.NewString("10.0.0.0:80", "10.0.0.1:80"),
 		},
 		{
 			name: "some endpoints are local",
 			endpoints: []Endpoint{
-				&BaseEndpointInfo{Endpoint: "10.0.0.0:80", IsLocal: true},
-				&BaseEndpointInfo{Endpoint: "10.0.0.1:80", IsLocal: false},
+				&BaseEndpointInfo{Endpoint: "10.0.0.0:80", Ready: true, IsLocal: true},
+				&BaseEndpointInfo{Endpoint: "10.0.0.1:80", Ready: true, IsLocal: false},
 			},
 			expected: sets.NewString("10.0.0.0:80"),
 		},


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
Split out from #106497 while I'm rewriting that.

This refactors the kube-proxy endpoint filtering code in preparation for rewriting it to handle separate internal and external traffic policy (as seen in #106497 except that the `pkg/proxy/iptables/` side of that PR will be changing).

#### Which issue(s) this PR fixes:
none

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

/cc @andrewsykim @robscott @thockin 