### PR TITLE
Setting ttlSeconds field on affinity lb service attribute for userspace

### DIFF
--- a/pkg/proxy/userspace/roundrobin.go
+++ b/pkg/proxy/userspace/roundrobin.go
@@ -101,6 +101,7 @@ func (lb *LoadBalancerRR) newServiceInternal(svcPort proxy.ServicePortName, affi
 		klog.V(4).InfoS("LoadBalancerRR service does not exist, created", "servicePortName", svcPort)
 	} else if affinityType != "" {
 		lb.services[svcPort].affinity.affinityType = affinityType
+		lb.services[svcPort].affinity.ttlSeconds = ttlSeconds
 	}
 	return lb.services[svcPort]
 }

--- a/pkg/proxy/winuserspace/roundrobin.go
+++ b/pkg/proxy/winuserspace/roundrobin.go
@@ -100,6 +100,7 @@ func (lb *LoadBalancerRR) newServiceInternal(svcPort proxy.ServicePortName, affi
 		klog.V(4).InfoS("LoadBalancerRR service did not exist, created", "servicePortName", svcPort)
 	} else if affinityType != "" {
 		lb.services[svcPort].affinity.affinityType = affinityType
+		lb.services[svcPort].affinity.ttlSeconds = ttlSeconds
 	}
 	return lb.services[svcPort]
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
/sig network
/sig windows

#### What this PR does / why we need it:

On `roundrobin.go:newServiceInternal` endpoint populates with fake sessionAffinity data, and expect to the service update the correct value later, this is true only for the affinityType, the ttlSeconds (what is added here) is never updated in the cache, and it's final value is 10800, or the default.

```
} else if affinityType != "" {
   lb.services[svcPort].affinity.affinityType = affinityType
}
```

When the nextEndpoint is pick, the `sessionAffinity.ClientIPConfig.timeoutSeconds` is lost from the cache population and the TTL is never expired.

https://github.com/kubernetes/kubernetes/blob/c92036820499fedefec0f847e2054d824aea6cd1/pkg/proxy/winuserspace/roundrobin.go#L152

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #https://github.com/kubernetes/kubernetes/issues/107398

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fixes TTL sessionAffinity expiration on kube-proxy userspace modes
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
