### PR TITLE
Reject proxy requests to 0.0.0.0 as well

### DIFF
--- a/pkg/proxy/util/utils.go
+++ b/pkg/proxy/util/utils.go
@@ -97,7 +97,7 @@ func IsProxyableIP(ip string) error {
 }
 
 func isProxyableIP(ip net.IP) error {
-	if ip.IsLoopback() || ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast() || ip.IsInterfaceLocalMulticast() {
+	if !ip.IsGlobalUnicast() {
 		return ErrAddressNotAllowed
 	}
 	return nil

--- a/pkg/proxy/util/utils_test.go
+++ b/pkg/proxy/util/utils_test.go
@@ -103,6 +103,7 @@ func TestIsProxyableIP(t *testing.T) {
 		ip   string
 		want error
 	}{
+		{"0.0.0.0", ErrAddressNotAllowed},
 		{"127.0.0.1", ErrAddressNotAllowed},
 		{"127.0.0.2", ErrAddressNotAllowed},
 		{"169.254.169.254", ErrAddressNotAllowed},
@@ -112,6 +113,7 @@ func TestIsProxyableIP(t *testing.T) {
 		{"192.168.0.1", nil},
 		{"172.16.0.1", nil},
 		{"8.8.8.8", nil},
+		{"::", ErrAddressNotAllowed},
 		{"::1", ErrAddressNotAllowed},
 		{"fe80::", ErrAddressNotAllowed},
 		{"ff02::", ErrAddressNotAllowed},


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Various IP addresses are known to be invalid/unsafe as destination addresses for apiserver [proxy queries](https://kubernetes.io/docs/tasks/administer-cluster/access-cluster-services/#manually-constructing-apiserver-proxy-urls).  The apiserver will reject attempts to proxy to these destination addresses, if a pod/service/node somehow reports as having one of these addresses.

Previously this check included loopback, link-local, and multicast CIDRs.  This PR extends the checks to also reject all-zero.   (All checks include both IPv4 and IPv6 equivalents.)

As an implementation detail, the change is implemented by switching to golang's [`net.IP.IsGlobalUnicast`](https://pkg.go.dev/net#IP.IsGlobalUnicast).  I invite the reader to review the source of that function and satisfy themselves that the resulting checks are equivalent.

#### Does this PR introduce a user-facing change?

```release-note
apiserver will now reject connection attempts to 0.0.0.0/:: when handling a proxy subresource request
```