### PR TITLE
Scheduler: graduate DefaultPodTopologySpread to GA

### DIFF
--- a/cmd/kube-scheduler/app/server_test.go
+++ b/cmd/kube-scheduler/app/server_test.go
@@ -40,7 +40,6 @@ import (
 	"k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/pkg/scheduler/apis/config"
 	"k8s.io/kubernetes/pkg/scheduler/apis/config/testing/defaults"
-	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/names"
 )
 
 func TestSetup(t *testing.T) {
@@ -218,10 +217,10 @@ leaderElection:
 		wantLeaderElection *componentbaseconfig.LeaderElectionConfiguration
 	}{
 		{
-			name: "default config with an alpha feature enabled and an beta feature disabled",
+			name: "default config with an alpha feature enabled",
 			flags: []string{
 				"--kubeconfig", configKubeconfig,
-				"--feature-gates=VolumeCapacityPriority=true,DefaultPodTopologySpread=false",
+				"--feature-gates=VolumeCapacityPriority=true",
 			},
 			wantPlugins: map[string]*config.Plugins{
 				"default-scheduler": func() *config.Plugins {
@@ -236,17 +235,11 @@ leaderElection:
 						PreBind:    defaults.ExpandedPluginsV1beta3.PreBind,
 						Reserve:    defaults.ExpandedPluginsV1beta3.Reserve,
 					}
-					plugins.PreScore.Enabled = append(plugins.PreScore.Enabled, config.Plugin{Name: names.SelectorSpread, Weight: 0})
-					plugins.Score.Enabled = append(
-						plugins.Score.Enabled,
-						config.Plugin{Name: names.SelectorSpread, Weight: 1},
-					)
 					return plugins
 				}(),
 			},
 			restoreFeatures: map[featuregate.Feature]bool{
-				features.VolumeCapacityPriority:   false,
-				features.DefaultPodTopologySpread: true,
+				features.VolumeCapacityPriority: false,
 			},
 		},
 		{

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -904,7 +904,7 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
 	HugePageStorageMediumSize:                      {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.24
 	DownwardAPIHugePages:                           {Default: true, PreRelease: featuregate.Beta},                    // on by default in 1.22
 	AnyVolumeDataSource:                            {Default: false, PreRelease: featuregate.Alpha},
-	DefaultPodTopologySpread:                       {Default: true, PreRelease: featuregate.Beta},
+	DefaultPodTopologySpread:                       {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.26
 	SetHostnameAsFQDN:                              {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.24
 	WinOverlay:                                     {Default: true, PreRelease: featuregate.Beta},
 	WinDSR:                                         {Default: false, PreRelease: featuregate.Alpha},

--- a/pkg/scheduler/apis/config/types_pluginargs.go
+++ b/pkg/scheduler/apis/config/types_pluginargs.go
@@ -105,8 +105,7 @@ type PodTopologySpreadArgs struct {
 	//   Nodes and Zones.
 	// - "List": Use constraints defined in .defaultConstraints.
 	//
-	// Defaults to "List" if feature gate DefaultPodTopologySpread is disabled
-	// and to "System" if enabled.
+	// Defaults to "System".
 	// +optional
 	DefaultingType PodTopologySpreadConstraintsDefaulting
 }

--- a/pkg/scheduler/apis/config/v1beta2/default_plugins.go
+++ b/pkg/scheduler/apis/config/v1beta2/default_plugins.go
@@ -116,16 +116,6 @@ func applyFeatureGates(config *v1beta2.Plugins) {
 	if utilfeature.DefaultFeatureGate.Enabled(features.VolumeCapacityPriority) {
 		config.Score.Enabled = append(config.Score.Enabled, v1beta2.Plugin{Name: names.VolumeBinding, Weight: pointer.Int32Ptr(1)})
 	}
-
-	if !utilfeature.DefaultFeatureGate.Enabled(features.DefaultPodTopologySpread) {
-		// When feature is enabled, the default spreading is done by
-		// PodTopologySpread plugin, which is enabled by default.
-		klog.InfoS("Registering SelectorSpread plugin")
-		s := v1beta2.Plugin{Name: names.SelectorSpread}
-		config.PreScore.Enabled = append(config.PreScore.Enabled, s)
-		s.Weight = pointer.Int32Ptr(1)
-		config.Score.Enabled = append(config.Score.Enabled, s)
-	}
 }
 
 // mergePlugins merges the custom set into the given default one, handling disabled sets.

--- a/pkg/scheduler/apis/config/v1beta2/default_plugins_test.go
+++ b/pkg/scheduler/apis/config/v1beta2/default_plugins_test.go
@@ -24,7 +24,6 @@ import (
 	"k8s.io/component-base/featuregate"
 	featuregatetesting "k8s.io/component-base/featuregate/testing"
 	"k8s.io/kube-scheduler/config/v1beta2"
-	"k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/names"
 	"k8s.io/utils/pointer"
 )
@@ -95,90 +94,6 @@ func TestApplyFeatureGates(t *testing.T) {
 						{Name: names.NodeAffinity, Weight: pointer.Int32Ptr(1)},
 						{Name: names.PodTopologySpread, Weight: pointer.Int32Ptr(2)},
 						{Name: names.TaintToleration, Weight: pointer.Int32Ptr(1)},
-					},
-				},
-				Reserve: v1beta2.PluginSet{
-					Enabled: []v1beta2.Plugin{
-						{Name: names.VolumeBinding},
-					},
-				},
-				PreBind: v1beta2.PluginSet{
-					Enabled: []v1beta2.Plugin{
-						{Name: names.VolumeBinding},
-					},
-				},
-				Bind: v1beta2.PluginSet{
-					Enabled: []v1beta2.Plugin{
-						{Name: names.DefaultBinder},
-					},
-				},
-			},
-		},
-		{
-			name: "DefaultPodTopologySpread disabled",
-			features: map[featuregate.Feature]bool{
-				features.DefaultPodTopologySpread: false,
-			},
-			wantConfig: &v1beta2.Plugins{
-				QueueSort: v1beta2.PluginSet{
-					Enabled: []v1beta2.Plugin{
-						{Name: names.PrioritySort},
-					},
-				},
-				PreFilter: v1beta2.PluginSet{
-					Enabled: []v1beta2.Plugin{
-						{Name: names.NodeResourcesFit},
-						{Name: names.NodePorts},
-						{Name: names.VolumeRestrictions},
-						{Name: names.PodTopologySpread},
-						{Name: names.InterPodAffinity},
-						{Name: names.VolumeBinding},
-						{Name: names.NodeAffinity},
-					},
-				},
-				Filter: v1beta2.PluginSet{
-					Enabled: []v1beta2.Plugin{
-						{Name: names.NodeUnschedulable},
-						{Name: names.NodeName},
-						{Name: names.TaintToleration},
-						{Name: names.NodeAffinity},
-						{Name: names.NodePorts},
-						{Name: names.NodeResourcesFit},
-						{Name: names.VolumeRestrictions},
-						{Name: names.EBSLimits},
-						{Name: names.GCEPDLimits},
-						{Name: names.NodeVolumeLimits},
-						{Name: names.AzureDiskLimits},
-						{Name: names.VolumeBinding},
-						{Name: names.VolumeZone},
-						{Name: names.PodTopologySpread},
-						{Name: names.InterPodAffinity},
-					},
-				},
-				PostFilter: v1beta2.PluginSet{
-					Enabled: []v1beta2.Plugin{
-						{Name: names.DefaultPreemption},
-					},
-				},
-				PreScore: v1beta2.PluginSet{
-					Enabled: []v1beta2.Plugin{
-						{Name: names.InterPodAffinity},
-						{Name: names.PodTopologySpread},
-						{Name: names.TaintToleration},
-						{Name: names.NodeAffinity},
-						{Name: names.SelectorSpread},
-					},
-				},
-				Score: v1beta2.PluginSet{
-					Enabled: []v1beta2.Plugin{
-						{Name: names.NodeResourcesBalancedAllocation, Weight: pointer.Int32Ptr(1)},
-						{Name: names.ImageLocality, Weight: pointer.Int32Ptr(1)},
-						{Name: names.InterPodAffinity, Weight: pointer.Int32Ptr(1)},
-						{Name: names.NodeResourcesFit, Weight: pointer.Int32Ptr(1)},
-						{Name: names.NodeAffinity, Weight: pointer.Int32Ptr(1)},
-						{Name: names.PodTopologySpread, Weight: pointer.Int32Ptr(2)},
-						{Name: names.TaintToleration, Weight: pointer.Int32Ptr(1)},
-						{Name: names.SelectorSpread, Weight: pointer.Int32Ptr(1)},
 					},
 				},
 				Reserve: v1beta2.PluginSet{

--- a/pkg/scheduler/apis/config/v1beta2/defaults.go
+++ b/pkg/scheduler/apis/config/v1beta2/defaults.go
@@ -227,14 +227,8 @@ func SetDefaults_NodeResourcesBalancedAllocationArgs(obj *v1beta2.NodeResourcesB
 }
 
 func SetDefaults_PodTopologySpreadArgs(obj *v1beta2.PodTopologySpreadArgs) {
-	if feature.DefaultFeatureGate.Enabled(features.DefaultPodTopologySpread) {
-		if obj.DefaultingType == "" {
-			obj.DefaultingType = v1beta2.SystemDefaulting
-		}
-		return
-	}
 	if obj.DefaultingType == "" {
-		obj.DefaultingType = v1beta2.ListDefaulting
+		obj.DefaultingType = v1beta2.SystemDefaulting
 	}
 }
 

--- a/pkg/scheduler/apis/config/v1beta2/defaults_test.go
+++ b/pkg/scheduler/apis/config/v1beta2/defaults_test.go
@@ -587,16 +587,6 @@ func TestPluginArgsDefaults(t *testing.T) {
 			},
 		},
 		{
-			name: "PodTopologySpreadArgs empty, DefaultPodTopologySpread feature disabled",
-			features: map[featuregate.Feature]bool{
-				features.DefaultPodTopologySpread: false,
-			},
-			in: &v1beta2.PodTopologySpreadArgs{},
-			want: &v1beta2.PodTopologySpreadArgs{
-				DefaultingType: v1beta2.ListDefaulting,
-			},
-		},
-		{
 			name: "NodeResourcesFitArgs not set",
 			in:   &v1beta2.NodeResourcesFitArgs{},
 			want: &v1beta2.NodeResourcesFitArgs{

--- a/pkg/scheduler/apis/config/v1beta3/default_plugins.go
+++ b/pkg/scheduler/apis/config/v1beta3/default_plugins.go
@@ -18,10 +18,8 @@ package v1beta3
 
 import (
 	"k8s.io/apimachinery/pkg/util/sets"
-	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/klog/v2"
 	"k8s.io/kube-scheduler/config/v1beta3"
-	"k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/names"
 	"k8s.io/utils/pointer"
 )
@@ -54,19 +52,8 @@ func getDefaultPlugins() *v1beta3.Plugins {
 			},
 		},
 	}
-	applyFeatureGates(plugins)
 
 	return plugins
-}
-
-func applyFeatureGates(config *v1beta3.Plugins) {
-	if !utilfeature.DefaultFeatureGate.Enabled(features.DefaultPodTopologySpread) {
-		// When feature is enabled, the default spreading is done by
-		// PodTopologySpread plugin, which is enabled by default.
-		klog.InfoS("Registering SelectorSpread plugin")
-		s := v1beta3.Plugin{Name: names.SelectorSpread, Weight: pointer.Int32Ptr(1)}
-		config.MultiPoint.Enabled = append(config.MultiPoint.Enabled, s)
-	}
 }
 
 // mergePlugins merges the custom set into the given default one, handling disabled sets.

--- a/pkg/scheduler/apis/config/v1beta3/default_plugins_test.go
+++ b/pkg/scheduler/apis/config/v1beta3/default_plugins_test.go
@@ -24,7 +24,6 @@ import (
 	"k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/component-base/featuregate"
 	featuregatetesting "k8s.io/component-base/featuregate/testing"
-	"k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/names"
 	"k8s.io/utils/pointer"
 )
@@ -60,39 +59,6 @@ func TestApplyFeatureGates(t *testing.T) {
 						{Name: names.NodeResourcesBalancedAllocation, Weight: pointer.Int32(1)},
 						{Name: names.ImageLocality, Weight: pointer.Int32(1)},
 						{Name: names.DefaultBinder},
-					},
-				},
-			},
-		},
-		{
-			name: "DefaultPodTopologySpread disabled",
-			features: map[featuregate.Feature]bool{
-				features.DefaultPodTopologySpread: false,
-			},
-			wantConfig: &v1beta3.Plugins{
-				MultiPoint: v1beta3.PluginSet{
-					Enabled: []v1beta3.Plugin{
-						{Name: names.PrioritySort},
-						{Name: names.NodeUnschedulable},
-						{Name: names.NodeName},
-						{Name: names.TaintToleration, Weight: pointer.Int32(3)},
-						{Name: names.NodeAffinity, Weight: pointer.Int32(2)},
-						{Name: names.NodePorts},
-						{Name: names.NodeResourcesFit, Weight: pointer.Int32(1)},
-						{Name: names.VolumeRestrictions},
-						{Name: names.EBSLimits},
-						{Name: names.GCEPDLimits},
-						{Name: names.NodeVolumeLimits},
-						{Name: names.AzureDiskLimits},
-						{Name: names.VolumeBinding},
-						{Name: names.VolumeZone},
-						{Name: names.PodTopologySpread, Weight: pointer.Int32(2)},
-						{Name: names.InterPodAffinity, Weight: pointer.Int32(2)},
-						{Name: names.DefaultPreemption},
-						{Name: names.NodeResourcesBalancedAllocation, Weight: pointer.Int32(1)},
-						{Name: names.ImageLocality, Weight: pointer.Int32(1)},
-						{Name: names.DefaultBinder},
-						{Name: names.SelectorSpread, Weight: pointer.Int32(1)},
 					},
 				},
 			},

--- a/pkg/scheduler/apis/config/v1beta3/defaults.go
+++ b/pkg/scheduler/apis/config/v1beta3/defaults.go
@@ -227,14 +227,8 @@ func SetDefaults_NodeResourcesBalancedAllocationArgs(obj *v1beta3.NodeResourcesB
 }
 
 func SetDefaults_PodTopologySpreadArgs(obj *v1beta3.PodTopologySpreadArgs) {
-	if feature.DefaultFeatureGate.Enabled(features.DefaultPodTopologySpread) {
-		if obj.DefaultingType == "" {
-			obj.DefaultingType = v1beta3.SystemDefaulting
-		}
-		return
-	}
 	if obj.DefaultingType == "" {
-		obj.DefaultingType = v1beta3.ListDefaulting
+		obj.DefaultingType = v1beta3.SystemDefaulting
 	}
 }
 

--- a/pkg/scheduler/apis/config/v1beta3/defaults_test.go
+++ b/pkg/scheduler/apis/config/v1beta3/defaults_test.go
@@ -582,16 +582,6 @@ func TestPluginArgsDefaults(t *testing.T) {
 			},
 		},
 		{
-			name: "PodTopologySpreadArgs empty, DefaultPodTopologySpread feature disabled",
-			features: map[featuregate.Feature]bool{
-				features.DefaultPodTopologySpread: false,
-			},
-			in: &v1beta3.PodTopologySpreadArgs{},
-			want: &v1beta3.PodTopologySpreadArgs{
-				DefaultingType: v1beta3.ListDefaulting,
-			},
-		},
-		{
 			name: "NodeResourcesFitArgs not set",
 			in:   &v1beta3.NodeResourcesFitArgs{},
 			want: &v1beta3.NodeResourcesFitArgs{

--- a/staging/src/k8s.io/kube-scheduler/config/v1beta2/types_pluginargs.go
+++ b/staging/src/k8s.io/kube-scheduler/config/v1beta2/types_pluginargs.go
@@ -110,8 +110,7 @@ type PodTopologySpreadArgs struct {
 	//   Nodes and Zones.
 	// - "List": Use constraints defined in .defaultConstraints.
 	//
-	// Defaults to "List" if feature gate DefaultPodTopologySpread is disabled
-	// and to "System" if enabled.
+	// Defaults to "System".
 	// +optional
 	DefaultingType PodTopologySpreadConstraintsDefaulting `json:"defaultingType,omitempty"`
 }

--- a/staging/src/k8s.io/kube-scheduler/config/v1beta3/types_pluginargs.go
+++ b/staging/src/k8s.io/kube-scheduler/config/v1beta3/types_pluginargs.go
@@ -110,8 +110,7 @@ type PodTopologySpreadArgs struct {
 	//   Nodes and Zones.
 	// - "List": Use constraints defined in .defaultConstraints.
 	//
-	// Defaults to "List" if feature gate DefaultPodTopologySpread is disabled
-	// and to "System" if enabled.
+	// Defaults to "System".
 	// +optional
 	DefaultingType PodTopologySpreadConstraintsDefaulting `json:"defaultingType,omitempty"`
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

graduate DefaultPodTopologySpread to GA

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

REF: kubernetes/enhancements#1258

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Feature of `DefaultPodTopologySpread` is graduated to GA
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- [KEP]: https://github.com/kubernetes/enhancements/tree/master/keps/sig-scheduling/1258-default-pod-topology-spread
```
