### PR TITLE
fix: azuredisk parameter lowercase translation issue

### DIFF
--- a/staging/src/k8s.io/csi-translation-lib/plugins/azure_disk.go
+++ b/staging/src/k8s.io/csi-translation-lib/plugins/azure_disk.go
@@ -37,8 +37,8 @@ const (
 	// Parameter names defined in azure disk CSI driver, refer to
 	// https://github.com/kubernetes-sigs/azuredisk-csi-driver/blob/master/docs/driver-parameters.md
 	azureDiskKind        = "kind"
-	azureDiskCachingMode = "cachingMode"
-	azureDiskFSType      = "fsType"
+	azureDiskCachingMode = "cachingmode"
+	azureDiskFSType      = "fstype"
 )
 
 var (
@@ -203,13 +203,19 @@ func (t *azureDiskCSITranslator) TranslateCSIPVToInTree(pv *v1.PersistentVolume)
 	}
 
 	if csiSource.VolumeAttributes != nil {
-		if cachingMode, ok := csiSource.VolumeAttributes[azureDiskCachingMode]; ok {
-			mode := v1.AzureDataDiskCachingMode(cachingMode)
-			azureSource.CachingMode = &mode
-		}
-
-		if fsType, ok := csiSource.VolumeAttributes[azureDiskFSType]; ok && fsType != "" {
-			azureSource.FSType = &fsType
+		for k, v := range csiSource.VolumeAttributes {
+			switch strings.ToLower(k) {
+			case azureDiskCachingMode:
+				if v != "" {
+					mode := v1.AzureDataDiskCachingMode(v)
+					azureSource.CachingMode = &mode
+				}
+			case azureDiskFSType:
+				if v != "" {
+					fsType := v
+					azureSource.FSType = &fsType
+				}
+			}
 		}
 		azureSource.Kind = &managed
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
/priority important-soon
/sig cloud-provider
/area provider/azure
/triage accepted

#### What this PR does / why we need it:
fix: azuredisk parameter lowercase translation issue

parameter `cachingmode: None` (`cachingMode` does) is not recognized in csi migration, this PR fixes the issue.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
fix: azuredisk parameter lowercase translation issue
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
fix: azuredisk parameter lowercase translation issue
```
