### PR TITLE
Fix kubectl bug where bash completions don't work if --context flag is specified with a value that contains a colon

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/completion/completion.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/completion/completion.go
@@ -167,7 +167,7 @@ func runCompletionBash(out io.Writer, boilerPlate string, kubectl *cobra.Command
 		return err
 	}
 
-	return kubectl.GenBashCompletion(out)
+	return kubectl.GenBashCompletionV2(out, false) // TODO: Upgrade to Cobra 1.3.0 or later before including descriptions (See https://github.com/spf13/cobra/pull/1509)
 }
 
 func runCompletionZsh(out io.Writer, boilerPlate string, kubectl *cobra.Command) error {


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
This PR fixes a kubectl bug where bash completions don't work if --context flag is specified with a value that contains a colon

For example:
```
~ $ kubectl --context foo:bar get pod <TAB>
pod1     pod2
```

#### Which issue(s) this PR fixes:
Fixes https://github.com/kubernetes/kubectl/issues/1157

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
Fixed kubectl bug where bash completions don't work if --context flag is specified with a value that contains a colon
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs

```
