### PR TITLE
fix fd leaks and failed file removing

### DIFF
--- a/cmd/kubeadm/app/preflight/checks_test.go
+++ b/cmd/kubeadm/app/preflight/checks_test.go
@@ -32,6 +32,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/version"
+	"k8s.io/kubernetes/test/utils"
 	"k8s.io/utils/exec"
 	fakeexec "k8s.io/utils/exec/testing"
 
@@ -192,7 +193,7 @@ func TestFileExistingCheck(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create file: %v", err)
 	}
-	defer os.Remove(f.Name())
+	defer utils.RemoveTestFile(t, f)
 	var tests = []struct {
 		name          string
 		check         FileExistingCheck
@@ -231,7 +232,7 @@ func TestFileAvailableCheck(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create file: %v", err)
 	}
-	defer os.Remove(f.Name())
+	defer utils.RemoveTestFile(t, f)
 	var tests = []struct {
 		name          string
 		check         FileAvailableCheck
@@ -270,7 +271,7 @@ func TestFileContentCheck(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create file: %v", err)
 	}
-	defer os.Remove(f.Name())
+	defer utils.RemoveTestFile(t, f)
 	var tests = []struct {
 		name          string
 		check         FileContentCheck
@@ -458,7 +459,7 @@ func TestConfigRootCAs(t *testing.T) {
 	if err != nil {
 		t.Errorf("failed configRootCAs:\n\texpected: succeed creating temp CA file\n\tactual:%v", err)
 	}
-	defer os.Remove(f.Name())
+	defer utils.RemoveTestFile(t, f)
 	if err := os.WriteFile(f.Name(), []byte(externalEtcdRootCAFileContent), 0644); err != nil {
 		t.Errorf("failed configRootCAs:\n\texpected: succeed writing contents to temp CA file %s\n\tactual:%v", f.Name(), err)
 	}
@@ -487,7 +488,7 @@ func TestConfigCertAndKey(t *testing.T) {
 			err,
 		)
 	}
-	defer os.Remove(certFile.Name())
+	defer utils.RemoveTestFile(t, certFile)
 	if err := os.WriteFile(certFile.Name(), []byte(externalEtcdCertFileContent), 0644); err != nil {
 		t.Errorf(
 			"failed configCertAndKey:\n\texpected: succeed writing contents to temp CertFile file %s\n\tactual:%v",
@@ -503,7 +504,7 @@ func TestConfigCertAndKey(t *testing.T) {
 			err,
 		)
 	}
-	defer os.Remove(keyFile.Name())
+	defer utils.RemoveTestFile(t, keyFile)
 	if err := os.WriteFile(keyFile.Name(), []byte(externalEtcdKeyFileContent), 0644); err != nil {
 		t.Errorf(
 			"failed configCertAndKey:\n\texpected: succeed writing contents to temp KeyFile file %s\n\tactual:%v",

--- a/cmd/kubeadm/app/util/patches/patches_test.go
+++ b/cmd/kubeadm/app/util/patches/patches_test.go
@@ -28,6 +28,7 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/kubernetes/test/utils"
 )
 
 var testKnownTargets = []string{
@@ -172,7 +173,7 @@ func TestGetPatchSetsForPathMustBeDirectory(t *testing.T) {
 	if err != nil {
 		t.Errorf("error creating temporary file: %v", err)
 	}
-	defer os.Remove(tempFile.Name())
+	defer utils.RemoveTestFile(t, tempFile)
 
 	_, _, _, err = getPatchSetsFromPath(tempFile.Name(), testKnownTargets, io.Discard)
 	var pathErr *os.PathError

--- a/pkg/credentialprovider/plugin/config_test.go
+++ b/pkg/credentialprovider/plugin/config_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package plugin
 
 import (
-	"io/ioutil"
 	"os"
 	"reflect"
 	"testing"
@@ -25,6 +24,7 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kubeletconfig "k8s.io/kubernetes/pkg/kubelet/apis/config"
+	"k8s.io/kubernetes/test/utils"
 )
 
 func Test_readCredentialProviderConfigFile(t *testing.T) {
@@ -317,11 +317,11 @@ providers:
 
 	for _, testcase := range testcases {
 		t.Run(testcase.name, func(t *testing.T) {
-			file, err := ioutil.TempFile("", "config.yaml")
+			file, err := os.CreateTemp("", "config.yaml")
 			if err != nil {
 				t.Fatal(err)
 			}
-			defer os.Remove(file.Name())
+			defer utils.RemoveTestFile(t, file)
 
 			_, err = file.WriteString(testcase.configData)
 			if err != nil {

--- a/pkg/kubelet/certificate/bootstrap/bootstrap_test.go
+++ b/pkg/kubelet/certificate/bootstrap/bootstrap_test.go
@@ -37,6 +37,7 @@ import (
 	clienttesting "k8s.io/client-go/testing"
 	"k8s.io/client-go/util/certificate"
 	"k8s.io/client-go/util/keyutil"
+	"k8s.io/kubernetes/test/utils"
 )
 
 func copyFile(src, dst string) (err error) {
@@ -324,7 +325,8 @@ users:
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer os.Remove(f.Name())
+	defer utils.RemoveTestFile(t, f)
+
 	os.WriteFile(f.Name(), testData, os.FileMode(0755))
 
 	config, err := loadRESTClientConfig(f.Name())

--- a/pkg/kubelet/kuberuntime/logs/logs_test.go
+++ b/pkg/kubelet/kuberuntime/logs/logs_test.go
@@ -23,14 +23,14 @@ import (
 	"testing"
 	"time"
 
-	v1 "k8s.io/api/core/v1"
-	apitesting "k8s.io/cri-api/pkg/apis/testing"
-	"k8s.io/utils/pointer"
-
 	"github.com/stretchr/testify/assert"
 
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
+	apitesting "k8s.io/cri-api/pkg/apis/testing"
+	"k8s.io/kubernetes/test/utils"
+	"k8s.io/utils/pointer"
 )
 
 func TestLogOptions(t *testing.T) {
@@ -76,7 +76,8 @@ func TestReadLogs(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unable to create temp file")
 	}
-	defer os.Remove(file.Name())
+	defer utils.RemoveTestFile(t, file)
+
 	file.WriteString(`{"log":"line1\n","stream":"stdout","time":"2020-09-27T11:18:01.00000000Z"}` + "\n")
 	file.WriteString(`{"log":"line2\n","stream":"stdout","time":"2020-09-27T11:18:02.00000000Z"}` + "\n")
 	file.WriteString(`{"log":"line3\n","stream":"stdout","time":"2020-09-27T11:18:03.00000000Z"}` + "\n")

--- a/staging/src/k8s.io/apiserver/pkg/server/egressselector/config_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/egressselector/config_test.go
@@ -18,13 +18,13 @@ package egressselector
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"reflect"
 	"testing"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apiserver/pkg/apis/apiserver"
+	"k8s.io/kubernetes/test/utils"
 )
 
 func strptr(s string) *string {
@@ -277,12 +277,12 @@ spec:
 		t.Run(tc.name, func(t *testing.T) {
 			proxyConfig := fmt.Sprintf("test-egress-selector-config-%s", tc.name)
 			if tc.createFile {
-				f, err := ioutil.TempFile("", proxyConfig)
+				f, err := os.CreateTemp("", proxyConfig)
 				if err != nil {
 					t.Fatal(err)
 				}
-				defer os.Remove(f.Name())
-				if err := ioutil.WriteFile(f.Name(), []byte(tc.contents), os.FileMode(0755)); err != nil {
+				defer utils.RemoveTestFile(t, f)
+				if err := os.WriteFile(f.Name(), []byte(tc.contents), os.FileMode(0755)); err != nil {
 					t.Fatal(err)
 				}
 				proxyConfig = f.Name()

--- a/staging/src/k8s.io/apiserver/pkg/util/webhook/webhook_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/webhook/webhook_test.go
@@ -722,6 +722,7 @@ func newKubeConfigFile(config v1.Config) (string, error) {
 		return "", fmt.Errorf("unable to write the Kubernetes client configuration to disk: %v", err)
 	}
 
+	configFile.Close()
 	return configFile.Name(), nil
 }
 

--- a/staging/src/k8s.io/apiserver/plugin/pkg/authorizer/webhook/webhook_v1_test.go
+++ b/staging/src/k8s.io/apiserver/plugin/pkg/authorizer/webhook/webhook_v1_test.go
@@ -42,6 +42,7 @@ import (
 	"k8s.io/apiserver/pkg/authorization/authorizer"
 	webhookutil "k8s.io/apiserver/pkg/util/webhook"
 	v1 "k8s.io/client-go/tools/clientcmd/api/v1"
+	"k8s.io/kubernetes/test/utils"
 )
 
 var testRetryBackoff = wait.Backoff{
@@ -180,12 +181,12 @@ current-context: default
 	for _, tt := range tests {
 		// Use a closure so defer statements trigger between loop iterations.
 		err := func() error {
-			tempfile, err := ioutil.TempFile("", "")
+			tempfile, err := os.CreateTemp("", "")
 			if err != nil {
 				return err
 			}
 			p := tempfile.Name()
-			defer os.Remove(p)
+			defer utils.RemoveTestFile(t, tempfile)
 
 			tmpl, err := template.New("test").Parse(tt.configTmpl)
 			if err != nil {

--- a/staging/src/k8s.io/client-go/rest/request_test.go
+++ b/staging/src/k8s.io/client-go/rest/request_test.go
@@ -54,6 +54,7 @@ import (
 	"k8s.io/client-go/util/flowcontrol"
 	utiltesting "k8s.io/client-go/util/testing"
 	"k8s.io/klog/v2"
+	"k8s.io/kubernetes/test/utils"
 	testingclock "k8s.io/utils/clock/testing"
 )
 
@@ -306,8 +307,7 @@ func TestRequestBody(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unable to create temp file")
 	}
-	defer f.Close()
-	os.Remove(f.Name())
+	utils.RemoveTestFile(t, f)
 	r = (&Request{}).Body(f.Name())
 	if r.err == nil || r.body != nil {
 		t.Errorf("should have set err and left body nil: %#v", r)

--- a/staging/src/k8s.io/client-go/tools/clientcmd/api/helpers_test.go
+++ b/staging/src/k8s.io/client-go/tools/clientcmd/api/helpers_test.go
@@ -23,6 +23,8 @@ import (
 	"testing"
 
 	"sigs.k8s.io/yaml"
+
+	"k8s.io/kubernetes/test/utils"
 )
 
 func newMergedConfig(certFile, certContent, keyFile, keyContent, caFile, caContent string, t *testing.T) Config {
@@ -52,11 +54,11 @@ func newMergedConfig(certFile, certContent, keyFile, keyContent, caFile, caConte
 
 func TestMinifySuccess(t *testing.T) {
 	certFile, _ := os.CreateTemp("", "")
-	defer os.Remove(certFile.Name())
 	keyFile, _ := os.CreateTemp("", "")
-	defer os.Remove(keyFile.Name())
 	caFile, _ := os.CreateTemp("", "")
-	defer os.Remove(caFile.Name())
+	defer func() {
+		utils.RemoveTestFile(t, certFile, keyFile, caFile)
+	}()
 
 	mutatingConfig := newMergedConfig(certFile.Name(), "cert", keyFile.Name(), "key", caFile.Name(), "ca", t)
 
@@ -88,11 +90,11 @@ func TestMinifySuccess(t *testing.T) {
 
 func TestMinifyMissingContext(t *testing.T) {
 	certFile, _ := os.CreateTemp("", "")
-	defer os.Remove(certFile.Name())
 	keyFile, _ := os.CreateTemp("", "")
-	defer os.Remove(keyFile.Name())
 	caFile, _ := os.CreateTemp("", "")
-	defer os.Remove(caFile.Name())
+	defer func() {
+		utils.RemoveTestFile(t, certFile, keyFile, caFile)
+	}()
 
 	mutatingConfig := newMergedConfig(certFile.Name(), "cert", keyFile.Name(), "key", caFile.Name(), "ca", t)
 	mutatingConfig.CurrentContext = "missing"
@@ -106,11 +108,11 @@ func TestMinifyMissingContext(t *testing.T) {
 
 func TestMinifyMissingCluster(t *testing.T) {
 	certFile, _ := os.CreateTemp("", "")
-	defer os.Remove(certFile.Name())
 	keyFile, _ := os.CreateTemp("", "")
-	defer os.Remove(keyFile.Name())
 	caFile, _ := os.CreateTemp("", "")
-	defer os.Remove(caFile.Name())
+	defer func() {
+		utils.RemoveTestFile(t, certFile, keyFile, caFile)
+	}()
 
 	mutatingConfig := newMergedConfig(certFile.Name(), "cert", keyFile.Name(), "key", caFile.Name(), "ca", t)
 	delete(mutatingConfig.Clusters, mutatingConfig.Contexts[mutatingConfig.CurrentContext].Cluster)
@@ -124,11 +126,11 @@ func TestMinifyMissingCluster(t *testing.T) {
 
 func TestMinifyMissingAuthInfo(t *testing.T) {
 	certFile, _ := os.CreateTemp("", "")
-	defer os.Remove(certFile.Name())
 	keyFile, _ := os.CreateTemp("", "")
-	defer os.Remove(keyFile.Name())
 	caFile, _ := os.CreateTemp("", "")
-	defer os.Remove(caFile.Name())
+	defer func() {
+		utils.RemoveTestFile(t, certFile, keyFile, caFile)
+	}()
 
 	mutatingConfig := newMergedConfig(certFile.Name(), "cert", keyFile.Name(), "key", caFile.Name(), "ca", t)
 	delete(mutatingConfig.AuthInfos, mutatingConfig.Contexts[mutatingConfig.CurrentContext].AuthInfo)
@@ -142,11 +144,11 @@ func TestMinifyMissingAuthInfo(t *testing.T) {
 
 func TestFlattenSuccess(t *testing.T) {
 	certFile, _ := os.CreateTemp("", "")
-	defer os.Remove(certFile.Name())
 	keyFile, _ := os.CreateTemp("", "")
-	defer os.Remove(keyFile.Name())
 	caFile, _ := os.CreateTemp("", "")
-	defer os.Remove(caFile.Name())
+	defer func() {
+		utils.RemoveTestFile(t, certFile, keyFile, caFile)
+	}()
 
 	certData := "cert"
 	keyData := "key"
@@ -207,11 +209,16 @@ func TestFlattenSuccess(t *testing.T) {
 
 func Example_minifyAndShorten() {
 	certFile, _ := os.CreateTemp("", "")
-	defer os.Remove(certFile.Name())
 	keyFile, _ := os.CreateTemp("", "")
-	defer os.Remove(keyFile.Name())
 	caFile, _ := os.CreateTemp("", "")
-	defer os.Remove(caFile.Name())
+	defer func() {
+		certFile.Close()
+		keyFile.Close()
+		certFile.Close()
+		os.Remove(certFile.Name())
+		os.Remove(keyFile.Name())
+		os.Remove(caFile.Name())
+	}()
 
 	certData := "cert"
 	keyData := "key"
@@ -247,11 +254,11 @@ func Example_minifyAndShorten() {
 
 func TestShortenSuccess(t *testing.T) {
 	certFile, _ := os.CreateTemp("", "")
-	defer os.Remove(certFile.Name())
 	keyFile, _ := os.CreateTemp("", "")
-	defer os.Remove(keyFile.Name())
 	caFile, _ := os.CreateTemp("", "")
-	defer os.Remove(caFile.Name())
+	defer func() {
+		utils.RemoveTestFile(t, certFile, keyFile, caFile)
+	}()
 
 	certData := "cert"
 	keyData := "key"

--- a/staging/src/k8s.io/client-go/tools/clientcmd/client_config_test.go
+++ b/staging/src/k8s.io/client-go/tools/clientcmd/client_config_test.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	restclient "k8s.io/client-go/rest"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+	"k8s.io/kubernetes/test/utils"
 )
 
 func TestMergoSemantics(t *testing.T) {
@@ -173,16 +174,16 @@ func TestInsecureOverridesCA(t *testing.T) {
 }
 
 func TestCAOverridesCAData(t *testing.T) {
-	file, err := os.CreateTemp("", "my.ca")
+	f, err := os.CreateTemp("", "my.ca")
 	if err != nil {
 		t.Fatalf("could not create tempfile: %v", err)
 	}
-	defer os.Remove(file.Name())
+	defer utils.RemoveTestFile(t, f)
 
 	config := createCAValidTestConfig()
 	clientBuilder := NewNonInteractiveClientConfig(*config, "clean", &ConfigOverrides{
 		ClusterInfo: clientcmdapi.Cluster{
-			CertificateAuthority: file.Name(),
+			CertificateAuthority: f.Name(),
 		},
 	}, nil)
 
@@ -192,7 +193,7 @@ func TestCAOverridesCAData(t *testing.T) {
 	}
 
 	matchBoolArg(false, actualCfg.Insecure, t)
-	matchStringArg(file.Name(), actualCfg.TLSClientConfig.CAFile, t)
+	matchStringArg(f.Name(), actualCfg.TLSClientConfig.CAFile, t)
 	matchByteArg(nil, actualCfg.TLSClientConfig.CAData, t)
 }
 
@@ -312,7 +313,7 @@ func TestModifyContext(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	defer os.Remove(tempPath.Name())
+	defer utils.RemoveTestFile(t, tempPath)
 
 	pathOptions := NewDefaultPathOptions()
 	config := createValidTestConfig()
@@ -498,7 +499,8 @@ func TestBasicTokenFile(t *testing.T) {
 		t.Errorf("Unexpected error: %v", err)
 		return
 	}
-	defer os.Remove(f.Name())
+	defer utils.RemoveTestFile(t, f)
+
 	if err := os.WriteFile(f.Name(), []byte(token), 0644); err != nil {
 		t.Errorf("Unexpected error: %v", err)
 		return
@@ -534,7 +536,8 @@ func TestPrecedenceTokenFile(t *testing.T) {
 		t.Errorf("Unexpected error: %v", err)
 		return
 	}
-	defer os.Remove(f.Name())
+	defer utils.RemoveTestFile(t, f)
+
 	if err := os.WriteFile(f.Name(), []byte(token), 0644); err != nil {
 		t.Errorf("Unexpected error: %v", err)
 		return
@@ -923,7 +926,8 @@ users:
 	if err != nil {
 		t.Error(err)
 	}
-	defer os.Remove(tmpfile.Name())
+	defer utils.RemoveTestFile(t, tmpfile)
+
 	if err := os.WriteFile(tmpfile.Name(), []byte(content), 0666); err != nil {
 		t.Error(err)
 	}

--- a/staging/src/k8s.io/client-go/tools/clientcmd/loader_test.go
+++ b/staging/src/k8s.io/client-go/tools/clientcmd/loader_test.go
@@ -32,6 +32,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/diff"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 	clientcmdlatest "k8s.io/client-go/tools/clientcmd/api/latest"
+	"k8s.io/kubernetes/test/utils"
 )
 
 var (
@@ -132,7 +133,7 @@ func TestToleratingMissingFiles(t *testing.T) {
 
 func TestErrorReadingFile(t *testing.T) {
 	commandLineFile, _ := os.CreateTemp("", "")
-	defer os.Remove(commandLineFile.Name())
+	defer utils.RemoveTestFile(t, commandLineFile)
 
 	if err := os.WriteFile(commandLineFile.Name(), []byte("bogus value"), 0644); err != nil {
 		t.Fatalf("Error creating tempfile: %v", err)
@@ -173,9 +174,10 @@ func TestErrorReadingNonFile(t *testing.T) {
 
 func TestConflictingCurrentContext(t *testing.T) {
 	commandLineFile, _ := os.CreateTemp("", "")
-	defer os.Remove(commandLineFile.Name())
 	envVarFile, _ := os.CreateTemp("", "")
-	defer os.Remove(envVarFile.Name())
+	defer func() {
+		utils.RemoveTestFile(t, commandLineFile, envVarFile)
+	}()
 
 	mockCommandLineConfig := clientcmdapi.Config{
 		CurrentContext: "any-context-value",
@@ -254,7 +256,7 @@ users: null
 
 func TestLoadingEmptyMaps(t *testing.T) {
 	configFile, _ := os.CreateTemp("", "")
-	defer os.Remove(configFile.Name())
+	defer utils.RemoveTestFile(t, configFile)
 
 	mockConfig := clientcmdapi.Config{
 		CurrentContext: "any-context-value",
@@ -280,7 +282,7 @@ func TestLoadingEmptyMaps(t *testing.T) {
 
 func TestDuplicateClusterName(t *testing.T) {
 	configFile, _ := os.CreateTemp("", "")
-	defer os.Remove(configFile.Name())
+	defer utils.RemoveTestFile(t, configFile)
 
 	err := os.WriteFile(configFile.Name(), []byte(`
 kind: Config
@@ -322,7 +324,7 @@ users:
 
 func TestDuplicateContextName(t *testing.T) {
 	configFile, _ := os.CreateTemp("", "")
-	defer os.Remove(configFile.Name())
+	defer utils.RemoveTestFile(t, configFile)
 
 	err := os.WriteFile(configFile.Name(), []byte(`
 kind: Config
@@ -364,7 +366,7 @@ users:
 
 func TestDuplicateUserName(t *testing.T) {
 	configFile, _ := os.CreateTemp("", "")
-	defer os.Remove(configFile.Name())
+	defer utils.RemoveTestFile(t, configFile)
 
 	err := os.WriteFile(configFile.Name(), []byte(`
 kind: Config
@@ -404,7 +406,7 @@ users:
 
 func TestDuplicateExtensionName(t *testing.T) {
 	configFile, _ := os.CreateTemp("", "")
-	defer os.Remove(configFile.Name())
+	defer utils.RemoveTestFile(t, configFile)
 
 	err := os.WriteFile(configFile.Name(), []byte(`
 kind: Config
@@ -560,10 +562,11 @@ func TestResolveRelativePaths(t *testing.T) {
 
 func TestMigratingFile(t *testing.T) {
 	sourceFile, _ := os.CreateTemp("", "")
-	defer os.Remove(sourceFile.Name())
+	defer utils.RemoveTestFile(t, sourceFile)
+
 	destinationFile, _ := os.CreateTemp("", "")
 	// delete the file so that we'll write to it
-	os.Remove(destinationFile.Name())
+	utils.RemoveTestFile(t, destinationFile)
 
 	WriteToFile(testConfigAlfa, sourceFile.Name())
 
@@ -576,7 +579,7 @@ func TestMigratingFile(t *testing.T) {
 	}
 
 	// the load should have recreated this file
-	defer os.Remove(destinationFile.Name())
+	defer utils.RemoveTestFile(t, destinationFile)
 
 	sourceContent, err := os.ReadFile(sourceFile.Name())
 	if err != nil {
@@ -594,9 +597,10 @@ func TestMigratingFile(t *testing.T) {
 
 func TestMigratingFileLeaveExistingFileAlone(t *testing.T) {
 	sourceFile, _ := os.CreateTemp("", "")
-	defer os.Remove(sourceFile.Name())
 	destinationFile, _ := os.CreateTemp("", "")
-	defer os.Remove(destinationFile.Name())
+	defer func() {
+		utils.RemoveTestFile(t, sourceFile, destinationFile)
+	}()
 
 	WriteToFile(testConfigAlfa, sourceFile.Name())
 
@@ -622,7 +626,7 @@ func TestMigratingFileSourceMissingSkip(t *testing.T) {
 	sourceFilename := "some-missing-file"
 	destinationFile, _ := os.CreateTemp("", "")
 	// delete the file so that we'll write to it
-	os.Remove(destinationFile.Name())
+	utils.RemoveTestFile(t, destinationFile)
 
 	loadingRules := ClientConfigLoadingRules{
 		MigrationRules: map[string]string{destinationFile.Name(): sourceFilename},
@@ -639,7 +643,7 @@ func TestMigratingFileSourceMissingSkip(t *testing.T) {
 
 func TestFileLocking(t *testing.T) {
 	f, _ := os.CreateTemp("", "")
-	defer os.Remove(f.Name())
+	defer utils.RemoveTestFile(t, f)
 
 	err := lockFile(f.Name())
 	if err != nil {
@@ -655,9 +659,13 @@ func TestFileLocking(t *testing.T) {
 
 func Example_noMergingOnExplicitPaths() {
 	commandLineFile, _ := os.CreateTemp("", "")
-	defer os.Remove(commandLineFile.Name())
 	envVarFile, _ := os.CreateTemp("", "")
-	defer os.Remove(envVarFile.Name())
+	defer func() {
+		commandLineFile.Close()
+		envVarFile.Close()
+		os.Remove(commandLineFile.Name())
+		os.Remove(envVarFile.Name())
+	}()
 
 	WriteToFile(testConfigAlfa, commandLineFile.Name())
 	WriteToFile(testConfigConflictAlfa, envVarFile.Name())
@@ -704,9 +712,13 @@ func Example_noMergingOnExplicitPaths() {
 
 func Example_mergingSomeWithConflict() {
 	commandLineFile, _ := os.CreateTemp("", "")
-	defer os.Remove(commandLineFile.Name())
 	envVarFile, _ := os.CreateTemp("", "")
-	defer os.Remove(envVarFile.Name())
+	defer func() {
+		commandLineFile.Close()
+		envVarFile.Close()
+		os.Remove(commandLineFile.Name())
+		os.Remove(envVarFile.Name())
+	}()
 
 	WriteToFile(testConfigAlfa, commandLineFile.Name())
 	WriteToFile(testConfigConflictAlfa, envVarFile.Name())
@@ -760,13 +772,19 @@ func Example_mergingSomeWithConflict() {
 
 func Example_mergingEverythingNoConflicts() {
 	commandLineFile, _ := os.CreateTemp("", "")
-	defer os.Remove(commandLineFile.Name())
 	envVarFile, _ := os.CreateTemp("", "")
-	defer os.Remove(envVarFile.Name())
 	currentDirFile, _ := os.CreateTemp("", "")
-	defer os.Remove(currentDirFile.Name())
 	homeDirFile, _ := os.CreateTemp("", "")
-	defer os.Remove(homeDirFile.Name())
+	defer func() {
+		commandLineFile.Close()
+		envVarFile.Close()
+		currentDirFile.Close()
+		homeDirFile.Close()
+		os.Remove(commandLineFile.Name())
+		os.Remove(envVarFile.Name())
+		os.Remove(currentDirFile.Name())
+		os.Remove(homeDirFile.Name())
+	}()
 
 	WriteToFile(testConfigAlfa, commandLineFile.Name())
 	WriteToFile(testConfigBravo, envVarFile.Name())

--- a/staging/src/k8s.io/client-go/tools/clientcmd/validation_test.go
+++ b/staging/src/k8s.io/client-go/tools/clientcmd/validation_test.go
@@ -25,6 +25,7 @@ import (
 
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+	"k8s.io/kubernetes/test/utils"
 )
 
 func TestConfirmUsableBadInfoButOkConfig(t *testing.T) {
@@ -296,7 +297,7 @@ func TestValidateCleanClusterInfo(t *testing.T) {
 
 func TestValidateCleanWithCAClusterInfo(t *testing.T) {
 	tempFile, _ := os.CreateTemp("", "")
-	defer os.Remove(tempFile.Name())
+	defer utils.RemoveTestFile(t, tempFile)
 
 	config := clientcmdapi.NewConfig()
 	config.Clusters["clean"] = &clientcmdapi.Cluster{
@@ -339,7 +340,7 @@ func TestValidateCertFilesNotFoundAuthInfo(t *testing.T) {
 
 func TestValidateCertDataOverridesFiles(t *testing.T) {
 	tempFile, _ := os.CreateTemp("", "")
-	defer os.Remove(tempFile.Name())
+	defer utils.RemoveTestFile(t, tempFile)
 
 	config := clientcmdapi.NewConfig()
 	config.AuthInfos["clean"] = &clientcmdapi.AuthInfo{
@@ -359,7 +360,7 @@ func TestValidateCertDataOverridesFiles(t *testing.T) {
 
 func TestValidateCleanCertFilesAuthInfo(t *testing.T) {
 	tempFile, _ := os.CreateTemp("", "")
-	defer os.Remove(tempFile.Name())
+	defer utils.RemoveTestFile(t, tempFile)
 
 	config := clientcmdapi.NewConfig()
 	config.AuthInfos["clean"] = &clientcmdapi.AuthInfo{

--- a/staging/src/k8s.io/client-go/util/keyutil/key_test.go
+++ b/staging/src/k8s.io/client-go/util/keyutil/key_test.go
@@ -19,6 +19,8 @@ package keyutil
 import (
 	"os"
 	"testing"
+
+	"k8s.io/kubernetes/test/utils"
 )
 
 const (
@@ -118,7 +120,7 @@ func TestReadPrivateKey(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error creating tmpfile: %v", err)
 	}
-	defer os.Remove(f.Name())
+	defer utils.RemoveTestFile(t, f)
 
 	if _, err := PrivateKeyFromFile(f.Name()); err == nil {
 		t.Fatalf("Expected error reading key from empty file, got none")
@@ -151,7 +153,7 @@ func TestReadPublicKeys(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error creating tmpfile: %v", err)
 	}
-	defer os.Remove(f.Name())
+	defer utils.RemoveTestFile(t, f)
 
 	if _, err := PublicKeysFromFile(f.Name()); err == nil {
 		t.Fatalf("Expected error reading keys from empty file, got none")

--- a/staging/src/k8s.io/controller-manager/pkg/leadermigration/config/config_test.go
+++ b/staging/src/k8s.io/controller-manager/pkg/leadermigration/config/config_test.go
@@ -23,6 +23,7 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	internal "k8s.io/controller-manager/config"
+	"k8s.io/kubernetes/test/utils"
 )
 
 func TestReadLeaderMigrationConfiguration(t *testing.T) {
@@ -117,7 +118,7 @@ controllerLeaders:
 			if err != nil {
 				t.Fatal(err)
 			}
-			defer os.Remove(configFile.Name())
+			defer utils.RemoveTestFile(t, configFile)
 			err = os.WriteFile(configFile.Name(), []byte(tc.content), os.FileMode(0755))
 			if err != nil {
 				t.Fatal(err)

--- a/staging/src/k8s.io/controller-manager/pkg/leadermigration/options/options_test.go
+++ b/staging/src/k8s.io/controller-manager/pkg/leadermigration/options/options_test.go
@@ -25,6 +25,7 @@ import (
 
 	"k8s.io/controller-manager/config"
 	migrationconfig "k8s.io/controller-manager/pkg/leadermigration/config"
+	"k8s.io/kubernetes/test/utils"
 )
 
 func TestLeaderMigrationOptions(t *testing.T) {
@@ -188,7 +189,7 @@ controllerLeaders:
 				if err != nil {
 					t.Fatal(err)
 				}
-				defer os.Remove(configFile.Name())
+				defer utils.RemoveTestFile(t, configFile)
 				err = os.WriteFile(configFile.Name(), []byte(tc.configContent), os.FileMode(0755))
 				if err != nil {
 					t.Fatal(err)

--- a/staging/src/k8s.io/kubectl/pkg/cmd/config/config_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/config/config_test.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
+	"k8s.io/kubernetes/test/utils"
 )
 
 func newRedFederalCowHammerConfig() clientcmdapi.Config {
@@ -53,7 +54,7 @@ func Example_view() {
 		expectedConfig: expectedConfig,
 	}
 
-	output := test.run(nil)
+	output := test.run(&testing.T{})
 	fmt.Printf("%v", output)
 	// Output:
 	// apiVersion: v1
@@ -261,10 +262,11 @@ func TestAdditionalAuth(t *testing.T) {
 }
 
 func TestEmbedClientCert(t *testing.T) {
-	fakeCertFile, _ := ioutil.TempFile(os.TempDir(), "")
-	defer os.Remove(fakeCertFile.Name())
+	fakeCertFile, _ := os.CreateTemp(os.TempDir(), "")
+	defer utils.RemoveTestFile(t, fakeCertFile)
+
 	fakeData := []byte("fake-data")
-	ioutil.WriteFile(fakeCertFile.Name(), fakeData, 0600)
+	os.WriteFile(fakeCertFile.Name(), fakeData, 0600)
 	expectedConfig := newRedFederalCowHammerConfig()
 	authInfo := clientcmdapi.NewAuthInfo()
 	authInfo.ClientCertificateData = fakeData
@@ -280,10 +282,11 @@ func TestEmbedClientCert(t *testing.T) {
 }
 
 func TestEmbedClientKey(t *testing.T) {
-	fakeKeyFile, _ := ioutil.TempFile(os.TempDir(), "")
-	defer os.Remove(fakeKeyFile.Name())
+	fakeKeyFile, _ := os.CreateTemp(os.TempDir(), "")
+	defer utils.RemoveTestFile(t, fakeKeyFile)
+
 	fakeData := []byte("fake-data")
-	ioutil.WriteFile(fakeKeyFile.Name(), fakeData, 0600)
+	os.WriteFile(fakeKeyFile.Name(), fakeData, 0600)
 	expectedConfig := newRedFederalCowHammerConfig()
 	authInfo := clientcmdapi.NewAuthInfo()
 	authInfo.ClientKeyData = fakeData
@@ -326,8 +329,9 @@ func TestEmbedNoKeyOrCertDisallowed(t *testing.T) {
 }
 
 func TestEmptyTokenAndCertAllowed(t *testing.T) {
-	fakeCertFile, _ := ioutil.TempFile(os.TempDir(), "cert-file")
-	defer os.Remove(fakeCertFile.Name())
+	fakeCertFile, _ := os.CreateTemp(os.TempDir(), "cert-file")
+	defer utils.RemoveTestFile(t, fakeCertFile)
+
 	expectedConfig := newRedFederalCowHammerConfig()
 	authInfo := clientcmdapi.NewAuthInfo()
 	authInfo.ClientCertificate = path.Base(fakeCertFile.Name())
@@ -570,7 +574,8 @@ func TestUnsetBytes(t *testing.T) {
 
 func TestCAClearsInsecure(t *testing.T) {
 	fakeCAFile, _ := ioutil.TempFile(os.TempDir(), "ca-file")
-	defer os.Remove(fakeCAFile.Name())
+	defer utils.RemoveTestFile(t, fakeCAFile)
+
 	clusterInfoWithInsecure := clientcmdapi.NewCluster()
 	clusterInfoWithInsecure.InsecureSkipTLSVerify = true
 
@@ -638,10 +643,11 @@ func TestInsecureClearsCA(t *testing.T) {
 }
 
 func TestCADataClearsCA(t *testing.T) {
-	fakeCAFile, _ := ioutil.TempFile(os.TempDir(), "")
-	defer os.Remove(fakeCAFile.Name())
+	fakeCAFile, _ := os.CreateTemp(os.TempDir(), "")
+	defer utils.RemoveTestFile(t, fakeCAFile)
+
 	fakeData := []byte("cadata")
-	ioutil.WriteFile(fakeCAFile.Name(), fakeData, 0600)
+	os.WriteFile(fakeCAFile.Name(), fakeData, 0600)
 
 	clusterInfoWithCAData := clientcmdapi.NewCluster()
 	clusterInfoWithCAData.CertificateAuthorityData = fakeData
@@ -852,8 +858,9 @@ func TestToBool(t *testing.T) {
 }
 
 func testConfigCommand(args []string, startingConfig clientcmdapi.Config, t *testing.T) (string, clientcmdapi.Config) {
-	fakeKubeFile, _ := ioutil.TempFile(os.TempDir(), "")
-	defer os.Remove(fakeKubeFile.Name())
+	fakeKubeFile, _ := os.CreateTemp(os.TempDir(), "")
+	defer utils.RemoveTestFile(t, fakeKubeFile)
+
 	err := clientcmd.WriteToFile(startingConfig, fakeKubeFile.Name())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)

--- a/staging/src/k8s.io/kubectl/pkg/cmd/config/current_context_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/config/current_context_test.go
@@ -25,6 +25,7 @@ import (
 
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+	"k8s.io/kubernetes/test/utils"
 )
 
 type currentContextTest struct {
@@ -61,7 +62,8 @@ func (test currentContextTest) run(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	defer os.Remove(fakeKubeFile.Name())
+	defer utils.RemoveTestFile(t, fakeKubeFile)
+
 	err = clientcmd.WriteToFile(test.startingConfig, fakeKubeFile.Name())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)

--- a/staging/src/k8s.io/kubectl/pkg/cmd/config/delete_cluster_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/config/delete_cluster_test.go
@@ -19,13 +19,13 @@ package config
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"reflect"
 	"testing"
 
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+	"k8s.io/kubernetes/test/utils"
 )
 
 type deleteClusterTest struct {
@@ -53,11 +53,12 @@ func TestDeleteCluster(t *testing.T) {
 }
 
 func (test deleteClusterTest) run(t *testing.T) {
-	fakeKubeFile, err := ioutil.TempFile(os.TempDir(), "")
+	fakeKubeFile, err := os.CreateTemp(os.TempDir(), "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	defer os.Remove(fakeKubeFile.Name())
+	defer utils.RemoveTestFile(t, fakeKubeFile)
+
 	err = clientcmd.WriteToFile(test.config, fakeKubeFile.Name())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)

--- a/staging/src/k8s.io/kubectl/pkg/cmd/config/delete_context_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/config/delete_context_test.go
@@ -26,6 +26,7 @@ import (
 
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+	"k8s.io/kubernetes/test/utils"
 )
 
 type deleteContextTest struct {
@@ -57,7 +58,7 @@ func (test deleteContextTest) run(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	defer os.Remove(fakeKubeFile.Name())
+	defer utils.RemoveTestFile(t, fakeKubeFile)
 	err = clientcmd.WriteToFile(test.config, fakeKubeFile.Name())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)

--- a/staging/src/k8s.io/kubectl/pkg/cmd/config/get_clusters_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/config/get_clusters_test.go
@@ -24,6 +24,7 @@ import (
 
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+	"k8s.io/kubernetes/test/utils"
 )
 
 type getClustersTest struct {
@@ -61,7 +62,8 @@ func (test getClustersTest) run(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	defer os.Remove(fakeKubeFile.Name())
+	defer utils.RemoveTestFile(t, fakeKubeFile)
+
 	err = clientcmd.WriteToFile(test.config, fakeKubeFile.Name())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)

--- a/staging/src/k8s.io/kubectl/pkg/cmd/config/get_contexts_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/config/get_contexts_test.go
@@ -17,13 +17,13 @@ limitations under the License.
 package config
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+	"k8s.io/kubernetes/test/utils"
 )
 
 type getContextsTest struct {
@@ -144,11 +144,11 @@ func TestGetContextsSelectOneOfTwo(t *testing.T) {
 }
 
 func (test getContextsTest) run(t *testing.T) {
-	fakeKubeFile, err := ioutil.TempFile(os.TempDir(), "")
+	fakeKubeFile, err := os.CreateTemp(os.TempDir(), "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	defer os.Remove(fakeKubeFile.Name())
+	defer utils.RemoveTestFile(t, fakeKubeFile)
 	err = clientcmd.WriteToFile(test.startingConfig, fakeKubeFile.Name())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)

--- a/staging/src/k8s.io/kubectl/pkg/cmd/config/rename_context_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/config/rename_context_test.go
@@ -19,13 +19,13 @@ package config
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strings"
 	"testing"
 
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+	"k8s.io/kubernetes/test/utils"
 )
 
 const (
@@ -103,8 +103,9 @@ func TestRenameToAlreadyExistingContext(t *testing.T) {
 }
 
 func (test renameContextTest) run(t *testing.T) {
-	fakeKubeFile, _ := ioutil.TempFile(os.TempDir(), "")
-	defer os.Remove(fakeKubeFile.Name())
+	fakeKubeFile, _ := os.CreateTemp(os.TempDir(), "")
+	defer utils.RemoveTestFile(t, fakeKubeFile)
+
 	err := clientcmd.WriteToFile(test.initialConfig, fakeKubeFile.Name())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)

--- a/staging/src/k8s.io/kubectl/pkg/cmd/config/set_cluster_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/config/set_cluster_test.go
@@ -18,12 +18,12 @@ package config
 
 import (
 	"bytes"
-	"io/ioutil"
 	"os"
 	"testing"
 
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+	"k8s.io/kubernetes/test/utils"
 )
 
 type setClusterTest struct {
@@ -183,11 +183,11 @@ func TestModifyClusterServerAndTLS(t *testing.T) {
 }
 
 func (test setClusterTest) run(t *testing.T) {
-	fakeKubeFile, err := ioutil.TempFile(os.TempDir(), "")
+	fakeKubeFile, err := os.CreateTemp(os.TempDir(), "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	defer os.Remove(fakeKubeFile.Name())
+	defer utils.RemoveTestFile(t, fakeKubeFile)
 	err = clientcmd.WriteToFile(test.config, fakeKubeFile.Name())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)

--- a/staging/src/k8s.io/kubectl/pkg/cmd/config/set_context_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/config/set_context_test.go
@@ -24,6 +24,7 @@ import (
 
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+	"k8s.io/kubernetes/test/utils"
 )
 
 type setContextTest struct {
@@ -111,7 +112,7 @@ func (test setContextTest) run(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	defer os.Remove(fakeKubeFile.Name())
+	defer utils.RemoveTestFile(t, fakeKubeFile)
 	err = clientcmd.WriteToFile(test.config, fakeKubeFile.Name())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)

--- a/staging/src/k8s.io/kubectl/pkg/cmd/config/set_credentials_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/config/set_credentials_test.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 	cliflag "k8s.io/component-base/cli/flag"
+	"k8s.io/kubernetes/test/utils"
 )
 
 func stringFlagFor(s string) cliflag.StringFlag {
@@ -458,7 +459,7 @@ func (test setCredentialsTest) run(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	defer os.Remove(fakeKubeFile.Name())
+	defer utils.RemoveTestFile(t, fakeKubeFile)
 	err = clientcmd.WriteToFile(test.config, fakeKubeFile.Name())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)

--- a/staging/src/k8s.io/kubectl/pkg/cmd/config/set_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/config/set_test.go
@@ -18,14 +18,13 @@ package config
 
 import (
 	"bytes"
-	"io/ioutil"
 	"os"
-	"testing"
-
 	"reflect"
+	"testing"
 
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+	"k8s.io/kubernetes/test/utils"
 )
 
 type setConfigTest struct {
@@ -55,11 +54,12 @@ func TestSetConfigCurrentContext(t *testing.T) {
 }
 
 func (test setConfigTest) run(t *testing.T) {
-	fakeKubeFile, err := ioutil.TempFile(os.TempDir(), "")
+	fakeKubeFile, err := os.CreateTemp(os.TempDir(), "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	defer os.Remove(fakeKubeFile.Name())
+	defer utils.RemoveTestFile(t, fakeKubeFile)
+
 	err = clientcmd.WriteToFile(test.config, fakeKubeFile.Name())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)

--- a/staging/src/k8s.io/kubectl/pkg/cmd/config/unset_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/config/unset_test.go
@@ -18,12 +18,12 @@ package config
 
 import (
 	"bytes"
-	"io/ioutil"
 	"os"
 	"testing"
 
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+	"k8s.io/kubernetes/test/utils"
 )
 
 type unsetConfigTest struct {
@@ -106,11 +106,12 @@ func TestUnsetUnexistConfig(t *testing.T) {
 }
 
 func (test unsetConfigTest) run(t *testing.T) {
-	fakeKubeFile, err := ioutil.TempFile(os.TempDir(), "")
+	fakeKubeFile, err := os.CreateTemp(os.TempDir(), "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	defer os.Remove(fakeKubeFile.Name())
+	defer utils.RemoveTestFile(t, fakeKubeFile)
+
 	err = clientcmd.WriteToFile(test.config, fakeKubeFile.Name())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)

--- a/staging/src/k8s.io/kubectl/pkg/cmd/config/use_context_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/config/use_context_test.go
@@ -18,12 +18,12 @@ package config
 
 import (
 	"bytes"
-	"io/ioutil"
 	"os"
 	"testing"
 
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+	"k8s.io/kubernetes/test/utils"
 )
 
 type useContextTest struct {
@@ -71,11 +71,12 @@ func TestUseContext(t *testing.T) {
 }
 
 func (test useContextTest) run(t *testing.T) {
-	fakeKubeFile, err := ioutil.TempFile(os.TempDir(), "")
+	fakeKubeFile, err := os.CreateTemp(os.TempDir(), "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	defer os.Remove(fakeKubeFile.Name())
+	defer utils.RemoveTestFile(t, fakeKubeFile)
+
 	err = clientcmd.WriteToFile(test.config, fakeKubeFile.Name())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)

--- a/staging/src/k8s.io/kubectl/pkg/cmd/config/view_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/config/view_test.go
@@ -17,13 +17,13 @@ limitations under the License.
 package config
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+	"k8s.io/kubernetes/test/utils"
 )
 
 type viewClusterTest struct {
@@ -171,11 +171,12 @@ users:
 }
 
 func (test viewClusterTest) run(t *testing.T) {
-	fakeKubeFile, err := ioutil.TempFile(os.TempDir(), "")
+	fakeKubeFile, err := os.CreateTemp(os.TempDir(), "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	defer os.Remove(fakeKubeFile.Name())
+	defer utils.RemoveTestFile(t, fakeKubeFile)
+
 	err = clientcmd.WriteToFile(test.config, fakeKubeFile.Name())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)

--- a/staging/src/k8s.io/kubectl/pkg/cmd/testing/fake.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/testing/fake.go
@@ -483,7 +483,7 @@ func (f *TestFactory) Cleanup() {
 	if f.tempConfigFile == nil {
 		return
 	}
-
+	f.tempConfigFile.Close()
 	os.Remove(f.tempConfigFile.Name())
 }
 

--- a/staging/src/k8s.io/pod-security-admission/admission/api/load/load_test.go
+++ b/staging/src/k8s.io/pod-security-admission/admission/api/load/load_test.go
@@ -44,6 +44,7 @@ func writeTempFile(t *testing.T, content string) string {
 		t.Fatal(err)
 	}
 	t.Cleanup(func() {
+		file.Close()
 		os.Remove(file.Name())
 	})
 	if err := ioutil.WriteFile(file.Name(), []byte(content), 0600); err != nil {

--- a/test/e2e/apimachinery/certs.go
+++ b/test/e2e/apimachinery/certs.go
@@ -52,6 +52,11 @@ func setupServerCert(namespaceName, serviceName string) *certContext {
 	if err != nil {
 		framework.Failf("Failed to create a temp file for ca cert generation %v", err)
 	}
+	defer func() {
+		caCertFile.Close()
+		os.Remove(caCertFile.Name())
+	}()
+
 	if err := os.WriteFile(caCertFile.Name(), utils.EncodeCertPEM(signingCert), 0644); err != nil {
 		framework.Failf("Failed to write CA cert %v", err)
 	}
@@ -74,6 +79,11 @@ func setupServerCert(namespaceName, serviceName string) *certContext {
 	if err != nil {
 		framework.Failf("Failed to create a temp file for cert generation %v", err)
 	}
+	defer func() {
+		certFile.Close()
+		os.Remove(certFile.Name())
+	}()
+
 	keyFile, err := os.CreateTemp(certDir, "server.key")
 	if err != nil {
 		framework.Failf("Failed to create a temp file for key generation %v", err)
@@ -88,6 +98,11 @@ func setupServerCert(namespaceName, serviceName string) *certContext {
 	if err = os.WriteFile(keyFile.Name(), privateKeyPEM, 0644); err != nil {
 		framework.Failf("Failed to write key file %v", err)
 	}
+	defer func() {
+		keyFile.Close()
+		os.RemoveAll(keyFile.Name())
+	}()
+
 	return &certContext{
 		cert:        utils.EncodeCertPEM(signedCert),
 		key:         privateKeyPEM,

--- a/test/e2e_node/services/apiserver.go
+++ b/test/e2e_node/services/apiserver.go
@@ -79,7 +79,11 @@ func (a *APIServer) Start() error {
 	if err != nil {
 		return fmt.Errorf("create temp file failed: %v", err)
 	}
-	defer os.RemoveAll(saSigningKeyFile.Name())
+	defer func() {
+		saSigningKeyFile.Close()
+		os.RemoveAll(saSigningKeyFile.Name())
+	}()
+
 	if err = os.WriteFile(saSigningKeyFile.Name(), []byte(ecdsaPrivateKey), 0666); err != nil {
 		return fmt.Errorf("write file %s failed: %v", saSigningKeyFile.Name(), err)
 	}

--- a/test/integration/apiserver/admissionwebhook/client_auth_test.go
+++ b/test/integration/apiserver/admissionwebhook/client_auth_test.go
@@ -41,6 +41,7 @@ import (
 	"k8s.io/client-go/rest"
 	kubeapiservertesting "k8s.io/kubernetes/cmd/kube-apiserver/app/testing"
 	"k8s.io/kubernetes/test/integration/framework"
+	"k8s.io/kubernetes/test/utils"
 )
 
 const (
@@ -87,7 +88,7 @@ func testWebhookClientAuth(t *testing.T, enableAggregatorRouting bool) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer os.Remove(kubeConfigFile.Name())
+	defer utils.RemoveTestFile(t, kubeConfigFile)
 
 	if err := os.WriteFile(kubeConfigFile.Name(), []byte(`
 apiVersion: v1
@@ -113,7 +114,7 @@ users:
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer os.Remove(admissionConfigFile.Name())
+	defer utils.RemoveTestFile(t, admissionConfigFile)
 
 	if err := os.WriteFile(admissionConfigFile.Name(), []byte(`
 apiVersion: apiserver.k8s.io/v1alpha1

--- a/test/integration/apiserver/admissionwebhook/reinvocation_test.go
+++ b/test/integration/apiserver/admissionwebhook/reinvocation_test.go
@@ -268,7 +268,7 @@ func testWebhookReinvocationPolicy(t *testing.T, watchCache bool) {
 	if err != nil {
 		t.Fatalf("Failed to create audit policy file: %v", err)
 	}
-	defer os.Remove(policyFile.Name())
+	defer utils.RemoveTestFile(t, policyFile)
 	if _, err := policyFile.Write([]byte(auditPolicy)); err != nil {
 		t.Fatalf("Failed to write audit policy file: %v", err)
 	}
@@ -281,7 +281,7 @@ func testWebhookReinvocationPolicy(t *testing.T, watchCache bool) {
 	if err != nil {
 		t.Fatalf("Failed to create audit log file: %v", err)
 	}
-	defer os.Remove(logFile.Name())
+	defer utils.RemoveTestFile(t, logFile)
 
 	s := kubeapiservertesting.StartTestServerOrDie(t, kubeapiservertesting.NewDefaultTestServerOptions(), []string{
 		"--disable-admission-plugins=ServiceAccount",

--- a/test/integration/apiserver/tracing/tracing_test.go
+++ b/test/integration/apiserver/tracing/tracing_test.go
@@ -29,6 +29,7 @@ import (
 	"go.opentelemetry.io/otel/trace"
 	traceservice "go.opentelemetry.io/proto/otlp/collector/trace/v1"
 	"google.golang.org/grpc"
+	"k8s.io/kubernetes/test/utils"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	genericfeatures "k8s.io/apiserver/pkg/features"
@@ -97,7 +98,7 @@ egressSelections:
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer os.Remove(tracingConfigFile.Name())
+	defer utils.RemoveTestFile(t, tracingConfigFile)
 
 	if err := os.WriteFile(tracingConfigFile.Name(), []byte(fmt.Sprintf(`
 apiVersion: apiserver.config.k8s.io/v1alpha1

--- a/test/integration/auth/auth_test.go
+++ b/test/integration/auth/auth_test.go
@@ -85,7 +85,11 @@ func getTestWebhookTokenAuth(serverURL string, customDial utilnet.DialFunc) (aut
 	if err != nil {
 		return nil, err
 	}
-	defer os.Remove(kubecfgFile.Name())
+	defer func() {
+		kubecfgFile.Close()
+		os.Remove(kubecfgFile.Name())
+	}()
+
 	config := v1.Config{
 		Clusters: []v1.NamedCluster{
 			{

--- a/test/integration/auth/dynamic_client_test.go
+++ b/test/integration/auth/dynamic_client_test.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/kubernetes/cmd/kube-apiserver/app/options"
 	kubeoptions "k8s.io/kubernetes/pkg/kubeapiserver/options"
 	"k8s.io/kubernetes/test/integration/framework"
+	"k8s.io/kubernetes/test/utils"
 )
 
 func TestDynamicClientBuilder(t *testing.T) {
@@ -37,7 +38,7 @@ func TestDynamicClientBuilder(t *testing.T) {
 	if err != nil {
 		t.Fatalf("create temp file failed: %v", err)
 	}
-	defer os.RemoveAll(tmpfile.Name())
+	defer utils.RemoveTestFile(t, tmpfile)
 
 	if err = os.WriteFile(tmpfile.Name(), []byte(ecdsaPrivateKey), 0666); err != nil {
 		t.Fatalf("write file %s failed: %v", tmpfile.Name(), err)

--- a/test/integration/controlplane/audit/audit_test.go
+++ b/test/integration/controlplane/audit/audit_test.go
@@ -245,7 +245,7 @@ func runTestWithVersion(t *testing.T, version string) {
 	if err != nil {
 		t.Fatalf("Failed to create audit log file: %v", err)
 	}
-	defer os.Remove(logFile.Name())
+	defer utils.RemoveTestFile(t, logFile)
 
 	// start api server
 	result := kubeapiservertesting.StartTestServerOrDie(t, nil,

--- a/test/integration/etcd/server.go
+++ b/test/integration/etcd/server.go
@@ -47,6 +47,7 @@ import (
 	"k8s.io/kubernetes/cmd/kube-apiserver/app/options"
 	"k8s.io/kubernetes/test/integration"
 	"k8s.io/kubernetes/test/integration/framework"
+	"k8s.io/kubernetes/test/utils"
 	netutils "k8s.io/utils/net"
 
 	// install all APIs
@@ -81,7 +82,8 @@ func StartRealAPIServerOrDie(t *testing.T, configFuncs ...func(*options.ServerRu
 	if err != nil {
 		t.Fatalf("create temp file failed: %v", err)
 	}
-	defer os.RemoveAll(saSigningKeyFile.Name())
+	defer utils.RemoveTestFile(t, saSigningKeyFile)
+
 	if err = os.WriteFile(saSigningKeyFile.Name(), []byte(ecdsaPrivateKey), 0666); err != nil {
 		t.Fatalf("write file %s failed: %v", saSigningKeyFile.Name(), err)
 	}

--- a/test/integration/examples/apiserver_test.go
+++ b/test/integration/examples/apiserver_test.go
@@ -521,6 +521,7 @@ func writeKubeConfigForWardleServerToKASConnection(t *testing.T, kubeClientConfi
 	if err := clientcmd.WriteToFile(*adminKubeConfig, wardleToKASKubeConfigFile.Name()); err != nil {
 		t.Fatal(err)
 	}
+	defer wardleToKASKubeConfigFile.Close()
 
 	return wardleToKASKubeConfigFile.Name()
 }

--- a/test/integration/framework/test_server.go
+++ b/test/integration/framework/test_server.go
@@ -98,6 +98,10 @@ func StartTestServer(t testing.TB, setup TestServerSetup) (client.Interface, *re
 	if err := os.WriteFile(proxyCACertFile.Name(), utils.EncodeCertPEM(proxySigningCert), 0644); err != nil {
 		t.Fatal(err)
 	}
+	defer func() {
+		proxyCACertFile.Close()
+	}()
+
 	clientSigningKey, err := utils.NewPrivateKey()
 	if err != nil {
 		t.Fatal(err)
@@ -110,6 +114,9 @@ func StartTestServer(t testing.TB, setup TestServerSetup) (client.Interface, *re
 	if err := os.WriteFile(clientCACertFile.Name(), utils.EncodeCertPEM(clientSigningCert), 0644); err != nil {
 		t.Fatal(err)
 	}
+	defer func() {
+		clientCACertFile.Close()
+	}()
 
 	listener, _, err := genericapiserveroptions.CreateListener("tcp", "127.0.0.1:0", net.ListenConfig{})
 	if err != nil {
@@ -120,7 +127,10 @@ func StartTestServer(t testing.TB, setup TestServerSetup) (client.Interface, *re
 	if err != nil {
 		t.Fatalf("create temp file failed: %v", err)
 	}
-	defer os.RemoveAll(saSigningKeyFile.Name())
+	defer func() {
+		saSigningKeyFile.Close()
+	}()
+
 	if err = os.WriteFile(saSigningKeyFile.Name(), []byte(ecdsaPrivateKey), 0666); err != nil {
 		t.Fatalf("write file %s failed: %v", saSigningKeyFile.Name(), err)
 	}

--- a/test/utils/file.go
+++ b/test/utils/file.go
@@ -1,0 +1,40 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"os"
+	"testing"
+)
+
+// RemoveTestFile is a helper to close and remove test file.
+func RemoveTestFile(t *testing.T, files ...*os.File) {
+	t.Helper()
+	// We should close it first before remove a file, it's not only a good practice,
+	// but also can avoid failed file removing on Windows OS.
+	for _, f := range files {
+		if f == nil {
+			continue
+		}
+		if err := f.Close(); err != nil {
+			t.Fatalf("Error closing %s: %v", f.Name(), err)
+		}
+		if err := os.Remove(f.Name()); err != nil {
+			t.Fatalf("Error removing %s: %v", f.Name(), err)
+		}
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
/kind failing-test
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
When we call `ioutil.TempFile` to create a tmp file in unit test, it's our responsibility to remove it after testing ends, but we may ignore that the descriptor is not closed yet, which leads file removing failed,  and we don't catch the errors when use` os.Remove`, this seems nothing serious on Unix, but error happend when we print the error on Windows, juse like this:
`C:\Users\xxx\AppData\Local\Temp\TestTmpDirRemove3730116776\001\foo2619329076.txt: The process cannot access the file because it is being used by another process.`, which leads tmp file still exist.

Apparently it's because we didn't close the fd, and from this issue [#50510](https://github.com/golang/go/issues/50510) we konow that `os.Remove` behaves differently on different OS, so we should call `f.Close()` before call `os.Remove/RemoveAll` for compatibility on different OS, it's also a good practice on any system to close fd when testing done.

More seriously, some test may fail when os.Remove didn't work as expected, such as this [`TestMigratingFileSourceMissingSkip`](https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/client-go/tools/clientcmd/loader_test.go#L636), which expects file deleted but actually not.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
none
```
