### PR TITLE
use a community owned domain for the invalid registry

### DIFF
--- a/test/utils/image/manifest.go
+++ b/test/utils/image/manifest.go
@@ -90,7 +90,7 @@ var (
 		GcAuthenticatedRegistry:  "gcr.io/authenticated-image-pulling",
 		PromoterE2eRegistry:      "k8s.gcr.io/e2e-test-images",
 		BuildImageRegistry:       "k8s.gcr.io/build-image",
-		InvalidRegistry:          "invalid.com/invalid",
+		InvalidRegistry:          "invalid.registry.k8s.io/invalid",
 		GcEtcdRegistry:           "k8s.gcr.io",
 		GcRegistry:               "k8s.gcr.io",
 		SigStorageRegistry:       "k8s.gcr.io/sig-storage",

--- a/test/utils/image/manifest_test.go
+++ b/test/utils/image/manifest_test.go
@@ -48,7 +48,7 @@ func BenchmarkReplaceRegistryInImageURL(b *testing.B) {
 			in:  "k8s.gcr.io/sig-storage/test:latest",
 			out: "test.io/sig-storage/test:latest",
 		}, {
-			in:  "invalid.com/invalid/test:latest",
+			in:  "invalid.registry.k8s.io/invalid/test:latest",
 			out: "test.io/invalid/test:latest",
 		}, {
 			in:  "mcr.microsoft.com/test:latest",
@@ -109,7 +109,7 @@ func TestReplaceRegistryInImageURL(t *testing.T) {
 			in:  "k8s.gcr.io/sig-storage/test:latest",
 			out: "test.io/sig-storage/test:latest",
 		}, {
-			in:  "invalid.com/invalid/test:latest",
+			in:  "invalid.registry.k8s.io/invalid/test:latest",
 			out: "test.io/invalid/test:latest",
 		}, {
 			in:  "mcr.microsoft.com/test:latest",


### PR DESCRIPTION
Using a community owned domain for the invalid registry URL used on e2e test, this protect users from possible problems with the invalid.com domain that was used until now.

The new URL will have a dummy A record pointing to the address "0.0.0.0"

https://github.com/kubernetes/k8s.io/pull/3245

/kind cleanup

```release-note
kubernetes e2e framework will use the url "invalid.registry.k8s.io/invalid" instead "invalid.com/invalid" for test that use an invalid registry.
```
