### PR TITLE
Automated cherry pick of #107452: Fix header mutation race in timeout filter

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/server/filters/timeout.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/filters/timeout.go
@@ -147,7 +147,7 @@ type timeoutWriter interface {
 }
 
 func newTimeoutWriter(w http.ResponseWriter) timeoutWriter {
-	base := &baseTimeoutWriter{w: w}
+	base := &baseTimeoutWriter{w: w, handlerHeaders: w.Header().Clone()}
 
 	_, notifiable := w.(http.CloseNotifier)
 	_, hijackable := w.(http.Hijacker)
@@ -167,6 +167,9 @@ func newTimeoutWriter(w http.ResponseWriter) timeoutWriter {
 type baseTimeoutWriter struct {
 	w http.ResponseWriter
 
+	// headers written by the normal handler
+	handlerHeaders http.Header
+
 	mu sync.Mutex
 	// if the timeout handler has timeout
 	timedOut bool
@@ -184,7 +187,7 @@ func (tw *baseTimeoutWriter) Header() http.Header {
 		return http.Header{}
 	}
 
-	return tw.w.Header()
+	return tw.handlerHeaders
 }
 
 func (tw *baseTimeoutWriter) Write(p []byte) (int, error) {
@@ -198,7 +201,10 @@ func (tw *baseTimeoutWriter) Write(p []byte) (int, error) {
 		return 0, http.ErrHijacked
 	}
 
-	tw.wroteHeader = true
+	if !tw.wroteHeader {
+		copyHeaders(tw.w.Header(), tw.handlerHeaders)
+		tw.wroteHeader = true
+	}
 	return tw.w.Write(p)
 }
 
@@ -223,8 +229,15 @@ func (tw *baseTimeoutWriter) WriteHeader(code int) {
 		return
 	}
 
+	copyHeaders(tw.w.Header(), tw.handlerHeaders)
 	tw.wroteHeader = true
 	tw.w.WriteHeader(code)
+}
+
+func copyHeaders(dst, src http.Header) {
+	for k, v := range src {
+		dst[k] = v
+	}
 }
 
 func (tw *baseTimeoutWriter) timeout(err *apierrors.StatusError) {


### PR DESCRIPTION
Cherry pick of #107452 on release-1.22.

#107452: Fix header mutation race in timeout filter

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
Fixes a rare race condition handling requests that timeout
```