### PR TITLE
Remove skip Multi-AZ test based on provider

### DIFF
--- a/test/e2e/scheduling/ubernetes_lite.go
+++ b/test/e2e/scheduling/ubernetes_lite.go
@@ -45,7 +45,6 @@ var _ = SIGDescribe("Multi-AZ Clusters", func() {
 	var err error
 	var cleanUp func()
 	ginkgo.BeforeEach(func() {
-		e2eskipper.SkipUnlessProviderIs("gce", "gke", "aws")
 		if zoneCount <= 0 {
 			zoneCount, err = getZoneCount(f.ClientSet)
 			framework.ExpectNoError(err)


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Remove skip Multi-AZ test based on provider.
The test only cares if there are multiple zones and that is independent of the provider.

We want to have this test in the testgrid, and the kind provider seems like a good fit to run it.

#### Which issue(s) this PR fixes:

Part of kubernetes/enhancements#1258

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```