### PR TITLE
Automated cherry pick of #107427: removed unnecessary log line

### DIFF
--- a/pkg/proxy/healthcheck/service_health.go
+++ b/pkg/proxy/healthcheck/service_health.go
@@ -255,7 +255,6 @@ func (hcs *server) SyncEndpoints(newEndpoints map[types.NamespacedName]int) erro
 
 	for nsn, count := range newEndpoints {
 		if hcs.services[nsn] == nil {
-			klog.V(3).InfoS("Not saving endpoints for unknown healthcheck", "service", nsn)
 			continue
 		}
 		klog.V(3).InfoS("Reporting endpoints for healthcheck", "endpointCount", count, "service", nsn)


### PR DESCRIPTION
Cherry pick of #107427 on release-1.23.

#107427: removed unnecessary log line

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```