### PR TITLE
add warning log if volume calculation took too long than 1 second

### DIFF
--- a/pkg/kubelet/server/stats/volume_stat_calculator.go
+++ b/pkg/kubelet/server/stats/volume_stat_calculator.go
@@ -32,6 +32,7 @@ import (
 	"k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/pkg/volume"
 	"k8s.io/kubernetes/pkg/volume/util"
+	utiltrace "k8s.io/utils/trace"
 )
 
 // volumeStatCalculator calculates volume metrics for a given pod periodically in the background and caches the result
@@ -133,7 +134,11 @@ func (s *volumeStatCalculator) calcAndStoreStats() {
 	var ephemeralStats []stats.VolumeStats
 	var persistentStats []stats.VolumeStats
 	for name, v := range metricVolumes {
-		metric, err := v.GetMetrics()
+		metric, err := func() (*volume.Metrics, error) {
+			trace := utiltrace.New(fmt.Sprintf("Calculate volume metrics of %v for pod %v/%v", name, s.pod.Namespace, s.pod.Name))
+			defer trace.LogIfLong(1 * time.Second)
+			return v.GetMetrics()
+		}()
 		if err != nil {
 			// Expected for Volumes that don't support Metrics
 			if !volume.IsNotSupported(err) {


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
See https://github.com/kubernetes/kubernetes/pull/107201/files#r782840954.

> I think logging it seems to be much simpler than the metrics.
> 
> Log a warning message if the duration is more than 1 second. Is this better?
> 
> Kubelet check volumes every volumeStatsAggPeriod seconds(by default 2min).
> For metrics, I prefer the latest duration Guage for each volume which is more than 100ms. (Most volume metrics can be retrieved in 10ms).

#### Which issue(s) this PR fixes:
Fixes #107201

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
kubelet: add log for volume metric collection taking too long
```
