### PR TITLE
clone url userinfo on requests

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/util/net/http.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/net/http.go
@@ -452,10 +452,28 @@ func CloneRequest(req *http.Request) *http.Request {
 	// shallow clone
 	*r = *req
 
+	// deep copy URL
+	r.URL = CloneURL(req.URL)
+
 	// deep copy headers
 	r.Header = CloneHeader(req.Header)
 
 	return r
+}
+
+// CloneURL creates a deep copy of an URL
+// https://github.com/golang/go/blob/2ebe77a2fda1ee9ff6fd9a3e08933ad1ebaea039/src/net/http/clone.go#L22
+func CloneURL(u *url.URL) *url.URL {
+	if u == nil {
+		return nil
+	}
+	u2 := new(url.URL)
+	*u2 = *u
+	if u.User != nil {
+		u2.User = new(url.Userinfo)
+		*u2.User = *u.User
+	}
+	return u2
 }
 
 // CloneHeader creates a deep copy of an http.Header.


### PR DESCRIPTION
I've found this issue when using custom roundtrippers and using the CloneRequest() function, modifying the UserInfo of the cloned URL modifies it in the original request.

This makes the implementation of CloneRequest()  in the apimachinery library similar to the one used in the golang stdlib

https://github.com/golang/go/blob/2ebe77a2fda1ee9ff6fd9a3e08933ad1ebaea039/src/net/http/request.go#L365-L394

/kind bug

```release-note
NONE
```
