### PR TITLE
Don't proxy apiserver webhook requests when using Services

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/util/webhook/authentication.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/webhook/authentication.go
@@ -117,6 +117,8 @@ type AuthenticationInfoResolver interface {
 	ClientConfigForService(serviceName, serviceNamespace string, servicePort int) (*rest.Config, error)
 }
 
+var _ AuthenticationInfoResolver = &AuthenticationInfoResolverDelegator{}
+
 // AuthenticationInfoResolverDelegator implements AuthenticationInfoResolver.
 type AuthenticationInfoResolverDelegator struct {
 	ClientConfigForFunc        func(hostPort string) (*rest.Config, error)
@@ -132,6 +134,8 @@ func (a *AuthenticationInfoResolverDelegator) ClientConfigFor(hostPort string) (
 func (a *AuthenticationInfoResolverDelegator) ClientConfigForService(serviceName, serviceNamespace string, servicePort int) (*rest.Config, error) {
 	return a.ClientConfigForServiceFunc(serviceName, serviceNamespace, servicePort)
 }
+
+var _ AuthenticationInfoResolver = &defaultAuthenticationInfoResolver{}
 
 type defaultAuthenticationInfoResolver struct {
 	kubeconfig clientcmdapi.Config

--- a/staging/src/k8s.io/apiserver/pkg/util/webhook/client.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/webhook/client.go
@@ -22,6 +22,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"net/http"
 	"net/url"
 	"strconv"
 
@@ -179,6 +180,11 @@ func (cm *ClientManager) HookClient(cc ClientConfig) (*rest.RESTClient, error) {
 		if len(cfg.TLSClientConfig.ServerName) == 0 {
 			cfg.TLSClientConfig.ServerName = serverName
 		}
+		// request to Services should not be proxied #107446
+		// https://github.com/golang/net/blob/c6ed85c7a12db1bd15e993fd3ae4700b2e9f2c84/http/httpproxy/proxy.go#L112-L114
+		// A nil URL and nil error are returned if no proxy is defined in the environment,
+		// or a proxy should not be used for the given request, as defined by NO_PROXY
+		cfg.Proxy = func(req *http.Request) (*url.URL, error) { return nil, nil }
 
 		delegateDialer := cfg.Dial
 		if delegateDialer == nil {

--- a/staging/src/k8s.io/apiserver/pkg/util/webhook/client_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/webhook/client_test.go
@@ -1,0 +1,136 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package webhook
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strconv"
+	"testing"
+
+	admissionv1 "k8s.io/api/admission/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/rest"
+)
+
+type fakeServiceResolver struct {
+	url *url.URL
+}
+
+func (sr fakeServiceResolver) ResolveEndpoint(namespace, name string, port int32) (*url.URL, error) {
+	return sr.url, nil
+}
+
+type fakeAuthResolver struct {
+	host string
+}
+
+func (sr fakeAuthResolver) ClientConfigFor(hostPort string) (*rest.Config, error) {
+	config := &rest.Config{}
+	config.Host = sr.host
+	config.TLSClientConfig = rest.TLSClientConfig{
+		Insecure:   true,
+		ServerName: "127.0.0.1",
+	}
+	return config, nil
+}
+
+func (sr fakeAuthResolver) ClientConfigForService(serviceName, serviceNamespace string, servicePort int) (*rest.Config, error) {
+	config := &rest.Config{}
+	config.Host = sr.host
+	config.TLSClientConfig = rest.TLSClientConfig{
+		Insecure:   true,
+		ServerName: "127.0.0.1",
+	}
+	return config, nil
+}
+
+func TestClientManagerNoProxyServices(t *testing.T) {
+	// Create and start a fake proxy
+	proxy, err := newTestServer(nil, nil, nil, func(w http.ResponseWriter, r *http.Request) {
+		t.Fatalf("Unexpected request on proxy: %v", r)
+	})
+	if err != nil {
+		t.Fatalf("failed to create server: %v", err)
+	}
+	defer proxy.Close()
+	t.Setenv("HTTPS_PROXY", proxy.URL)
+	t.Setenv("HTTP_PROXY", proxy.URL)
+	t.Setenv("NO_PROXY", "")
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintf(w, "Hello")
+	}
+
+	// Create and start a simple HTTPS server
+	server, err := newTestServer(nil, nil, nil, handler)
+	if err != nil {
+		t.Fatalf("failed to create server: %v", err)
+	}
+	defer server.Close()
+
+	cm, err := NewClientManager(
+		[]schema.GroupVersion{
+			admissionv1.SchemeGroupVersion,
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	u, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	p := u.Port()
+	port, err := strconv.Atoi(p)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cm.SetServiceResolver(&fakeServiceResolver{u})
+	cm.SetAuthenticationInfoResolver(&fakeAuthResolver{server.URL})
+	if err := cm.Validate(); err != nil {
+		t.Fatal(err)
+	}
+
+	cconfig := ClientConfig{
+		Name:     "test-client",
+		CABundle: nil,
+		Service: &ClientConfigService{
+			Namespace: "test-ns",
+			Name:      u.Hostname(),
+			Port:      int32(port),
+		},
+	}
+
+	client, err := cm.HookClient(cconfig)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	data, err := client.Get().AbsPath("/").DoRaw(context.TODO())
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if string(data) != "Hello" {
+		t.Fatalf("unexpected response: %s", data)
+	}
+
+}

--- a/staging/src/k8s.io/apiserver/pkg/util/webhook/serviceresolver.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/webhook/serviceresolver.go
@@ -27,6 +27,8 @@ type ServiceResolver interface {
 	ResolveEndpoint(namespace, name string, port int32) (*url.URL, error)
 }
 
+var _ ServiceResolver = &defaultServiceResolver{}
+
 type defaultServiceResolver struct{}
 
 // NewDefaultServiceResolver creates a new default server resolver.


### PR DESCRIPTION
/kind bug

#### What this PR does / why we need it:

When a webhook is configured to use Services, the apiserver create a custom client.
By default, any client created by the restClient constructor, obtains the proxy variables from the environment.
If there are proxy environment variables configured in the apiserver, and the proxy is not able to reach the services, the webhooks fail because they try to use the proxy. Since the apiserver MUST be able to reach the services, we can safely ignore the proxy for these requests.

#### Which issue(s) this PR fixes:
Fixes #107446

#### Special notes for your reviewer:

I've tried to implement a general fix, since there are many places in the apiserver that does requests like in the apiserver-aggregator or actually proxy requests, but the risk to breaking something is too high, so I've decided to target only the reported issue, where there is no doubt that a proxy should not be used no matter it is configured or not

#### Does this PR introduce a user-facing change?
```release-note
bugfix: webhooks ignore the environment proxy variables when using Services.
```


Without the patch the test fails with:

```
=== RUN   TestClientManagerNoProxyServices
    /home/aojea/go/src/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/util/webhook/client_test.go:67: Unexpected request on proxy: &{CONNECT //127.0.0.1.test-ns.svc:40207 HTTP/1.1 1 1 map[User-Agent:[Go-http-client/1.1]] {} <nil> 0 [] false 127.0.0.1.test-ns.svc:40207 map[] map[] <nil> map[] 127.0.0.1:46378 127.0.0.1.test-ns.svc:40207 0xc000430580 <nil> <nil> 0xc000452ac0}
    /home/aojea/go/src/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/util/webhook/client_test.go:67: Unexpected request on proxy: &{CONNECT //127.0.0.1.test-ns.svc:40207 HTTP/1.1 1 1 map[User-Agent:[Go-http-client/1.1]] {} <nil> 0 [] false 127.0.0.1.test-ns.svc:40207 map[] map[] <nil> map[] 127.0.0.1:46380 127.0.0.1.test-ns.svc:40207 0xc00022c0b0 <nil> <nil> 0xc000216280}
    /home/aojea/go/src/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/util/webhook/client_test.go:67: Unexpected request on proxy: &{CONNECT //127.0.0.1.test-ns.svc:40207 HTTP/1.1 1 1 map[User-Agent:[Go-http-client/1.1]] {} <nil> 0 [] false 127.0.0.1.test-ns.svc:40207 map[] map[] <nil> map[] 127.0.0.1:46382 127.0.0.1.test-ns.svc:40207 0xc0000fc420 <nil> <nil> 0xc000452240}
    /home/aojea/go/src/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/util/webhook/client_test.go:67: Unexpected request on proxy: &{CONNECT //127.0.0.1.test-ns.svc:40207 HTTP/1.1 1 1 map[User-Agent:[Go-http-client/1.1]] {} <nil> 0 [] false 127.0.0.1.test-ns.svc:40207 map[] map[] <nil> map[] 127.0.0.1:46384 127.0.0.1.test-ns.svc:40207 0xc0002b2000 <nil> <nil> 0xc00059c180}
    /home/aojea/go/src/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/util/webhook/client_test.go:67: Unexpected request on proxy: &{CONNECT //127.0.0.1.test-ns.svc:40207 HTTP/1.1 1 1 map[User-Agent:[Go-http-client/1.1]] {} <nil> 0 [] false 127.0.0.1.test-ns.svc:40207 map[] map[] <nil> map[] 127.0.0.1:46386 127.0.0.1.test-ns.svc:40207 0xc0000fc580 <nil> <nil> 0xc000452480}
    /home/aojea/go/src/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/util/webhook/client_test.go:67: Unexpected request on proxy: &{CONNECT //127.0.0.1.test-ns.svc:40207 HTTP/1.1 1 1 map[User-Agent:[Go-http-client/1.1]] {} <nil> 0 [] false 127.0.0.1.test-ns.svc:40207 map[] map[] <nil> map[] 127.0.0.1:46388 127.0.0.1.test-ns.svc:40207 0xc000430dc0 <nil> <nil> 0xc0003
 ```
