### PR TITLE
Remove CNI in kubeet

### DIFF
--- a/cluster/gce/util.sh
+++ b/cluster/gce/util.sh
@@ -781,23 +781,6 @@ function construct-linux-kubelet-flags {
       flags+=" --resolv-conf=/run/systemd/resolve/resolv.conf"
     fi
   fi
-  # Network plugin
-  if [[ -n "${NETWORK_PROVIDER:-}" || -n "${NETWORK_POLICY_PROVIDER:-}" ]]; then
-    flags+=" --cni-bin-dir=/home/kubernetes/bin"
-    if [[ "${NETWORK_POLICY_PROVIDER:-}" == "calico" || "${ENABLE_NETD:-}" == "true" ]]; then
-      # Calico uses CNI always.
-      # Note that network policy won't work for master node.
-      if [[ "${node_type}" == "master" ]]; then
-        flags+=" --network-plugin=${NETWORK_PROVIDER}"
-      else
-        flags+=" --network-plugin=cni"
-      fi
-    else
-      # Otherwise use the configured value.
-      flags+=" --network-plugin=${NETWORK_PROVIDER}"
-
-    fi
-  fi
   if [[ -n "${NON_MASQUERADE_CIDR:-}" ]]; then
     flags+=" --non-masquerade-cidr=${NON_MASQUERADE_CIDR}"
   fi
@@ -862,9 +845,6 @@ function construct-windows-kubelet-flags {
   # The directory where the TLS certs are located.
   flags+=" --cert-dir=${WINDOWS_PKI_DIR}"
 
-  flags+=" --network-plugin=cni"
-  flags+=" --cni-bin-dir=${WINDOWS_CNI_DIR}"
-  flags+=" --cni-conf-dir=${WINDOWS_CNI_CONFIG_DIR}"
   flags+=" --pod-manifest-path=${WINDOWS_MANIFESTS_DIR}"
 
   # Windows images are large and we don't have gcr mirrors yet. Allow longer

--- a/cmd/kubelet/app/options/container_runtime.go
+++ b/cmd/kubelet/app/options/container_runtime.go
@@ -50,9 +50,5 @@ func NewContainerRuntimeOptions() *config.ContainerRuntimeOptions {
 		DockershimRootDirectory:   "/var/lib/dockershim",
 		PodSandboxImage:           defaultPodSandboxImage,
 		ImagePullProgressDeadline: metav1.Duration{Duration: 1 * time.Minute},
-
-		CNIBinDir:   "/opt/cni/bin",
-		CNIConfDir:  "/etc/cni/net.d",
-		CNICacheDir: "/var/lib/cni/cache",
 	}
 }

--- a/hack/make-rules/test-e2e-node.sh
+++ b/hack/make-rules/test-e2e-node.sh
@@ -222,9 +222,6 @@ else
     sudo -v || exit 1
   fi
 
-  # Do not use any network plugin by default. User could override the flags with
-  # test_args.
-  test_args='--kubelet-flags="--network-plugin= --cni-bin-dir=" '${test_args}
 
   # Runtime flags
   test_args='--kubelet-flags="--container-runtime='${runtime}'" '${test_args}

--- a/pkg/kubelet/config/flags.go
+++ b/pkg/kubelet/config/flags.go
@@ -47,25 +47,6 @@ type ContainerRuntimeOptions struct {
 	// +optional
 	ImagePullProgressDeadline metav1.Duration
 
-	// Network plugin options.
-
-	// networkPluginName is the name of the network plugin to be invoked for
-	// various events in kubelet/pod lifecycle
-	NetworkPluginName string
-	// NetworkPluginMTU is the MTU to be passed to the network plugin,
-	// and overrides the default MTU for cases where it cannot be automatically
-	// computed (such as IPSEC).
-	NetworkPluginMTU int32
-	// CNIConfDir is the full path of the directory in which to search for
-	// CNI config files
-	CNIConfDir string
-	// CNIBinDir is the full path of the directory in which to search for
-	// CNI plugin binaries
-	CNIBinDir string
-	// CNICacheDir is the full path of the directory in which CNI should store
-	// cache files
-	CNICacheDir string
-
 	// Image credential provider plugin options
 
 	// ImageCredentialProviderConfigFile is the path to the credential provider plugin config file.
@@ -98,18 +79,6 @@ func (s *ContainerRuntimeOptions) AddFlags(fs *pflag.FlagSet) {
 	fs.MarkDeprecated("docker-endpoint", "will be removed along with dockershim.")
 	fs.DurationVar(&s.ImagePullProgressDeadline.Duration, "image-pull-progress-deadline", s.ImagePullProgressDeadline.Duration, fmt.Sprintf("If no pulling progress is made before this deadline, the image pulling will be cancelled. %s", dockerOnlyWarning))
 	fs.MarkDeprecated("image-pull-progress-deadline", "will be removed along with dockershim.")
-
-	// Network plugin settings for Docker.
-	fs.StringVar(&s.NetworkPluginName, "network-plugin", s.NetworkPluginName, fmt.Sprintf("The name of the network plugin to be invoked for various events in kubelet/pod lifecycle. %s", dockerOnlyWarning))
-	fs.MarkDeprecated("network-plugin", "will be removed along with dockershim.")
-	fs.StringVar(&s.CNIConfDir, "cni-conf-dir", s.CNIConfDir, fmt.Sprintf("The full path of the directory in which to search for CNI config files. %s", dockerOnlyWarning))
-	fs.MarkDeprecated("cni-conf-dir", "will be removed along with dockershim.")
-	fs.StringVar(&s.CNIBinDir, "cni-bin-dir", s.CNIBinDir, fmt.Sprintf("A comma-separated list of full paths of directories in which to search for CNI plugin binaries. %s", dockerOnlyWarning))
-	fs.MarkDeprecated("cni-bin-dir", "will be removed along with dockershim.")
-	fs.StringVar(&s.CNICacheDir, "cni-cache-dir", s.CNICacheDir, fmt.Sprintf("The full path of the directory in which CNI should store cache files. %s", dockerOnlyWarning))
-	fs.MarkDeprecated("cni-cache-dir", "will be removed along with dockershim.")
-	fs.Int32Var(&s.NetworkPluginMTU, "network-plugin-mtu", s.NetworkPluginMTU, fmt.Sprintf("The MTU to be passed to the network plugin, to override the default. Set to 0 to use the default 1460 MTU. %s", dockerOnlyWarning))
-	fs.MarkDeprecated("network-plugin-mtu", "will be removed along with dockershim.")
 
 	// Image credential provider settings.
 	fs.StringVar(&s.ImageCredentialProviderConfigFile, "image-credential-provider-config", s.ImageCredentialProviderConfigFile, "The path to the credential provider plugin config file.")

--- a/test/e2e_node/conformance/run_test.sh
+++ b/test/e2e_node/conformance/run_test.sh
@@ -200,9 +200,6 @@ start_kubelet --kubeconfig "${KUBELET_KUBECONFIG}" \
   --kubelet-cgroups=/kubelet \
   --system-cgroups=/system \
   --cgroup-root=/ \
-  "--network-plugin=${NETWORK_PLUGIN}" \
-  "--cni-conf-dir=${CNI_CONF_DIR}" \
-  "--cni-bin-dir=${CNI_BIN_DIR}" \
   --v=$log_level \
   --logtostderr
 

--- a/test/e2e_node/services/kubelet.go
+++ b/test/e2e_node/services/kubelet.go
@@ -280,28 +280,6 @@ func (e *E2EServices) startKubelet() (*server, error) {
 		cmdArgs = append(cmdArgs, "--dynamic-config-dir", dynamicConfigDir)
 	}
 
-	// Enable kubenet by default.
-	cniBinDir, err := getCNIBinDirectory()
-	if err != nil {
-		return nil, err
-	}
-
-	cniConfDir, err := getCNIConfDirectory()
-	if err != nil {
-		return nil, err
-	}
-
-	cniCacheDir, err := getCNICacheDirectory()
-	if err != nil {
-		return nil, err
-	}
-
-	cmdArgs = append(cmdArgs,
-		"--network-plugin=kubenet",
-		"--cni-bin-dir", cniBinDir,
-		"--cni-conf-dir", cniConfDir,
-		"--cni-cache-dir", cniCacheDir)
-
 	// Keep hostname override for convenience.
 	if framework.TestContext.NodeName != "" { // If node name is specified, set hostname override.
 		cmdArgs = append(cmdArgs, "--hostname-override", framework.TestContext.NodeName)
@@ -443,33 +421,6 @@ func createKubeconfigCWD() (string, error) {
 		return "", err
 	}
 	return kubeconfigPath, nil
-}
-
-// getCNIBinDirectory returns CNI directory.
-func getCNIBinDirectory() (string, error) {
-	cwd, err := os.Getwd()
-	if err != nil {
-		return "", err
-	}
-	return filepath.Join(cwd, "cni", "bin"), nil
-}
-
-// getCNIConfDirectory returns CNI Configuration directory.
-func getCNIConfDirectory() (string, error) {
-	cwd, err := os.Getwd()
-	if err != nil {
-		return "", err
-	}
-	return filepath.Join(cwd, "cni", "net.d"), nil
-}
-
-// getCNICacheDirectory returns CNI Cache directory.
-func getCNICacheDirectory() (string, error) {
-	cwd, err := os.Getwd()
-	if err != nil {
-		return "", err
-	}
-	return filepath.Join(cwd, "cni", "cache"), nil
 }
 
 // getDynamicConfigDir returns the directory for dynamic Kubelet configuration


### PR DESCRIPTION
CNI is useless as dockershim is removed

Signed-off-by: yanghesong <hesong.yang@foxmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Dockershim has been removed, refer to #97252. CNI will never be used by kubelet.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #97252

#### Special notes for your reviewer:
CNI will never be used by kubelet.
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
No
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
