### PR TITLE
storage: correct struct fields in volume plugins

### DIFF
--- a/api/openapi-spec/v3/api__v1_openapi.json
+++ b/api/openapi-spec/v3/api__v1_openapi.json
@@ -178,21 +178,21 @@
         "description": "Represents a Persistent Disk resource in AWS.\n\nAn AWS EBS disk must exist before mounting to a container. The disk must also be in the same AWS zone as the kubelet. An AWS EBS disk can only be mounted as read/write once. AWS EBS volumes support ownership management and SELinux relabeling.",
         "properties": {
           "fsType": {
-            "description": "Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore",
+            "description": "fsType is the filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore",
             "type": "string"
           },
           "partition": {
-            "description": "The partition in the volume that you want to mount. If omitted, the default is to mount by volume name. Examples: For volume /dev/sda1, you specify the partition as \"1\". Similarly, the volume partition for /dev/sda is \"0\" (or you can leave the property empty).",
+            "description": "partition is the partition in the volume that you want to mount. If omitted, the default is to mount by volume name. Examples: For volume /dev/sda1, you specify the partition as \"1\". Similarly, the volume partition for /dev/sda is \"0\" (or you can leave the property empty).",
             "format": "int32",
             "type": "integer"
           },
           "readOnly": {
-            "description": "Specify \"true\" to force and set the ReadOnly property in VolumeMounts to \"true\". If omitted, the default is \"false\". More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore",
+            "description": "readOnly value true will force the readOnly setting in VolumeMounts. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore",
             "type": "boolean"
           },
           "volumeID": {
             "default": "",
-            "description": "Unique ID of the persistent disk resource in AWS (Amazon EBS volume). More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore",
+            "description": "volumeID is unique ID of the persistent disk resource in AWS (Amazon EBS volume). More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore",
             "type": "string"
           }
         },
@@ -243,29 +243,29 @@
         "description": "AzureDisk represents an Azure Data Disk mount on the host and bind mount to the pod.",
         "properties": {
           "cachingMode": {
-            "description": "Host Caching mode: None, Read Only, Read Write.",
+            "description": "cachingMode is the Host Caching mode: None, Read Only, Read Write.",
             "type": "string"
           },
           "diskName": {
             "default": "",
-            "description": "The Name of the data disk in the blob storage",
+            "description": "diskName is the Name of the data disk in the blob storage",
             "type": "string"
           },
           "diskURI": {
             "default": "",
-            "description": "The URI the data disk in the blob storage",
+            "description": "diskURI is the URI of data disk in the blob storage",
             "type": "string"
           },
           "fsType": {
-            "description": "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+            "description": "fsType is Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
             "type": "string"
           },
           "kind": {
-            "description": "Expected values Shared: multiple blob disks per storage account  Dedicated: single blob disk per storage account  Managed: azure managed data disk (only in managed availability set). defaults to shared",
+            "description": "kind expected values are Shared: multiple blob disks per storage account  Dedicated: single blob disk per storage account  Managed: azure managed data disk (only in managed availability set). defaults to shared",
             "type": "string"
           },
           "readOnly": {
-            "description": "Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
+            "description": "readOnly Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
             "type": "boolean"
           }
         },
@@ -279,21 +279,21 @@
         "description": "AzureFile represents an Azure File Service mount on the host and bind mount to the pod.",
         "properties": {
           "readOnly": {
-            "description": "Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
+            "description": "readOnly defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
             "type": "boolean"
           },
           "secretName": {
             "default": "",
-            "description": "the name of secret that contains Azure Storage Account Name and Key",
+            "description": "secretName is the name of secret that contains Azure Storage Account Name and Key",
             "type": "string"
           },
           "secretNamespace": {
-            "description": "the namespace of the secret that contains Azure Storage Account Name and Key default is the same as the Pod",
+            "description": "secretNamespace is the namespace of the secret that contains Azure Storage Account Name and Key default is the same as the Pod",
             "type": "string"
           },
           "shareName": {
             "default": "",
-            "description": "Share Name",
+            "description": "shareName is the azure Share Name",
             "type": "string"
           }
         },
@@ -307,17 +307,17 @@
         "description": "AzureFile represents an Azure File Service mount on the host and bind mount to the pod.",
         "properties": {
           "readOnly": {
-            "description": "Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
+            "description": "readOnly defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
             "type": "boolean"
           },
           "secretName": {
             "default": "",
-            "description": "the name of secret that contains Azure Storage Account Name and Key",
+            "description": "secretName is the  name of secret that contains Azure Storage Account Name and Key",
             "type": "string"
           },
           "shareName": {
             "default": "",
-            "description": "Share Name",
+            "description": "shareName is the azure share Name",
             "type": "string"
           }
         },
@@ -473,7 +473,7 @@
         "description": "Represents a Ceph Filesystem mount that lasts the lifetime of a pod Cephfs volumes do not support ownership management or SELinux relabeling.",
         "properties": {
           "monitors": {
-            "description": "Required: Monitors is a collection of Ceph monitors More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
+            "description": "monitors is Required: Monitors is a collection of Ceph monitors More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
             "items": {
               "default": "",
               "type": "string"
@@ -481,23 +481,23 @@
             "type": "array"
           },
           "path": {
-            "description": "Optional: Used as the mounted root, rather than the full Ceph tree, default is /",
+            "description": "path is Optional: Used as the mounted root, rather than the full Ceph tree, default is /",
             "type": "string"
           },
           "readOnly": {
-            "description": "Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
+            "description": "readOnly is Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
             "type": "boolean"
           },
           "secretFile": {
-            "description": "Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
+            "description": "secretFile is Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
             "type": "string"
           },
           "secretRef": {
             "$ref": "#/components/schemas/io.k8s.api.core.v1.SecretReference",
-            "description": "Optional: SecretRef is reference to the authentication secret for User, default is empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it"
+            "description": "secretRef is Optional: SecretRef is reference to the authentication secret for User, default is empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it"
           },
           "user": {
-            "description": "Optional: User is the rados user name, default is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
+            "description": "user is Optional: User is the rados user name, default is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
             "type": "string"
           }
         },
@@ -510,7 +510,7 @@
         "description": "Represents a Ceph Filesystem mount that lasts the lifetime of a pod Cephfs volumes do not support ownership management or SELinux relabeling.",
         "properties": {
           "monitors": {
-            "description": "Required: Monitors is a collection of Ceph monitors More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
+            "description": "monitors is Required: Monitors is a collection of Ceph monitors More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
             "items": {
               "default": "",
               "type": "string"
@@ -518,23 +518,23 @@
             "type": "array"
           },
           "path": {
-            "description": "Optional: Used as the mounted root, rather than the full Ceph tree, default is /",
+            "description": "path is Optional: Used as the mounted root, rather than the full Ceph tree, default is /",
             "type": "string"
           },
           "readOnly": {
-            "description": "Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
+            "description": "readOnly is Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
             "type": "boolean"
           },
           "secretFile": {
-            "description": "Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
+            "description": "secretFile is Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
             "type": "string"
           },
           "secretRef": {
             "$ref": "#/components/schemas/io.k8s.api.core.v1.LocalObjectReference",
-            "description": "Optional: SecretRef is reference to the authentication secret for User, default is empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it"
+            "description": "secretRef is Optional: SecretRef is reference to the authentication secret for User, default is empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it"
           },
           "user": {
-            "description": "Optional: User is the rados user name, default is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
+            "description": "user is optional: User is the rados user name, default is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
             "type": "string"
           }
         },
@@ -547,20 +547,20 @@
         "description": "Represents a cinder volume resource in Openstack. A Cinder volume must exist before mounting to a container. The volume must also be in the same region as the kubelet. Cinder volumes support ownership management and SELinux relabeling.",
         "properties": {
           "fsType": {
-            "description": "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://examples.k8s.io/mysql-cinder-pd/README.md",
+            "description": "fsType Filesystem type to mount. Must be a filesystem type supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://examples.k8s.io/mysql-cinder-pd/README.md",
             "type": "string"
           },
           "readOnly": {
-            "description": "Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: https://examples.k8s.io/mysql-cinder-pd/README.md",
+            "description": "readOnly is Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: https://examples.k8s.io/mysql-cinder-pd/README.md",
             "type": "boolean"
           },
           "secretRef": {
             "$ref": "#/components/schemas/io.k8s.api.core.v1.SecretReference",
-            "description": "Optional: points to a secret object containing parameters used to connect to OpenStack."
+            "description": "secretRef is Optional: points to a secret object containing parameters used to connect to OpenStack."
           },
           "volumeID": {
             "default": "",
-            "description": "volume id used to identify the volume in cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md",
+            "description": "volumeID used to identify the volume in cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md",
             "type": "string"
           }
         },
@@ -573,20 +573,20 @@
         "description": "Represents a cinder volume resource in Openstack. A Cinder volume must exist before mounting to a container. The volume must also be in the same region as the kubelet. Cinder volumes support ownership management and SELinux relabeling.",
         "properties": {
           "fsType": {
-            "description": "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://examples.k8s.io/mysql-cinder-pd/README.md",
+            "description": "fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://examples.k8s.io/mysql-cinder-pd/README.md",
             "type": "string"
           },
           "readOnly": {
-            "description": "Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: https://examples.k8s.io/mysql-cinder-pd/README.md",
+            "description": "readOnly defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: https://examples.k8s.io/mysql-cinder-pd/README.md",
             "type": "boolean"
           },
           "secretRef": {
             "$ref": "#/components/schemas/io.k8s.api.core.v1.LocalObjectReference",
-            "description": "Optional: points to a secret object containing parameters used to connect to OpenStack."
+            "description": "secretRef is optional: points to a secret object containing parameters used to connect to OpenStack."
           },
           "volumeID": {
             "default": "",
-            "description": "volume id used to identify the volume in cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md",
+            "description": "volumeID used to identify the volume in cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md",
             "type": "string"
           }
         },
@@ -865,7 +865,7 @@
         "description": "Adapts a ConfigMap into a projected volume.\n\nThe contents of the target ConfigMap's Data field will be presented in a projected volume as files using the keys in the Data field as the file names, unless the items element is populated with specific mappings of keys to paths. Note that this is identical to a configmap volume source without the default mode.",
         "properties": {
           "items": {
-            "description": "If unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.",
+            "description": "items if unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.",
             "items": {
               "$ref": "#/components/schemas/io.k8s.api.core.v1.KeyToPath",
               "default": {}
@@ -877,7 +877,7 @@
             "type": "string"
           },
           "optional": {
-            "description": "Specify whether the ConfigMap or its keys must be defined",
+            "description": "optional specify whether the ConfigMap or its keys must be defined",
             "type": "boolean"
           }
         },
@@ -887,12 +887,12 @@
         "description": "Adapts a ConfigMap into a volume.\n\nThe contents of the target ConfigMap's Data field will be presented in a volume as files using the keys in the Data field as the file names, unless the items element is populated with specific mappings of keys to paths. ConfigMap volumes support ownership management and SELinux relabeling.",
         "properties": {
           "defaultMode": {
-            "description": "Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+            "description": "defaultMode is optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
             "format": "int32",
             "type": "integer"
           },
           "items": {
-            "description": "If unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.",
+            "description": "items if unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.",
             "items": {
               "$ref": "#/components/schemas/io.k8s.api.core.v1.KeyToPath",
               "default": {}
@@ -904,7 +904,7 @@
             "type": "string"
           },
           "optional": {
-            "description": "Specify whether the ConfigMap or its keys must be defined",
+            "description": "optional specify whether the ConfigMap or its keys must be defined",
             "type": "boolean"
           }
         },
@@ -1337,12 +1337,12 @@
         "description": "Represents an empty directory for a pod. Empty directory volumes support ownership management and SELinux relabeling.",
         "properties": {
           "medium": {
-            "description": "What type of storage medium should back this directory. The default is \"\" which means to use the node's default medium. Must be an empty string (default) or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir",
+            "description": "medium represents what type of storage medium should back this directory. The default is \"\" which means to use the node's default medium. Must be an empty string (default) or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir",
             "type": "string"
           },
           "sizeLimit": {
             "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.api.resource.Quantity",
-            "description": "Total amount of local storage required for this EmptyDir volume. The size limit is also applicable for memory medium. The maximum usage on memory medium EmptyDir would be the minimum value between the SizeLimit specified here and the sum of memory limits of all containers in a pod. The default is nil which means that the limit is undefined. More info: http://kubernetes.io/docs/user-guide/volumes#emptydir"
+            "description": "sizeLimit is the total amount of local storage required for this EmptyDir volume. The size limit is also applicable for memory medium. The maximum usage on memory medium EmptyDir would be the minimum value between the SizeLimit specified here and the sum of memory limits of all containers in a pod. The default is nil which means that the limit is undefined. More info: http://kubernetes.io/docs/user-guide/volumes#emptydir"
           }
         },
         "type": "object"
@@ -1912,20 +1912,20 @@
         "description": "Represents a Fibre Channel volume. Fibre Channel volumes can only be mounted as read/write once. Fibre Channel volumes support ownership management and SELinux relabeling.",
         "properties": {
           "fsType": {
-            "description": "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+            "description": "fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
             "type": "string"
           },
           "lun": {
-            "description": "Optional: FC target lun number",
+            "description": "lun is Optional: FC target lun number",
             "format": "int32",
             "type": "integer"
           },
           "readOnly": {
-            "description": "Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
+            "description": "readOnly is Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
             "type": "boolean"
           },
           "targetWWNs": {
-            "description": "Optional: FC target worldwide names (WWNs)",
+            "description": "targetWWNs is Optional: FC target worldwide names (WWNs)",
             "items": {
               "default": "",
               "type": "string"
@@ -1933,7 +1933,7 @@
             "type": "array"
           },
           "wwids": {
-            "description": "Optional: FC volume world wide identifiers (wwids) Either wwids or combination of targetWWNs and lun must be set, but not both simultaneously.",
+            "description": "wwids Optional: FC volume world wide identifiers (wwids) Either wwids or combination of targetWWNs and lun must be set, but not both simultaneously.",
             "items": {
               "default": "",
               "type": "string"
@@ -1948,11 +1948,11 @@
         "properties": {
           "driver": {
             "default": "",
-            "description": "Driver is the name of the driver to use for this volume.",
+            "description": "driver is the name of the driver to use for this volume.",
             "type": "string"
           },
           "fsType": {
-            "description": "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". The default filesystem depends on FlexVolume script.",
+            "description": "fsType is the Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". The default filesystem depends on FlexVolume script.",
             "type": "string"
           },
           "options": {
@@ -1960,16 +1960,16 @@
               "default": "",
               "type": "string"
             },
-            "description": "Optional: Extra command options if any.",
+            "description": "options is Optional: this field holds extra command options if any.",
             "type": "object"
           },
           "readOnly": {
-            "description": "Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
+            "description": "readOnly is Optional: defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
             "type": "boolean"
           },
           "secretRef": {
             "$ref": "#/components/schemas/io.k8s.api.core.v1.SecretReference",
-            "description": "Optional: SecretRef is reference to the secret object containing sensitive information to pass to the plugin scripts. This may be empty if no secret object is specified. If the secret object contains more than one secret, all secrets are passed to the plugin scripts."
+            "description": "secretRef is Optional: SecretRef is reference to the secret object containing sensitive information to pass to the plugin scripts. This may be empty if no secret object is specified. If the secret object contains more than one secret, all secrets are passed to the plugin scripts."
           }
         },
         "required": [
@@ -1982,11 +1982,11 @@
         "properties": {
           "driver": {
             "default": "",
-            "description": "Driver is the name of the driver to use for this volume.",
+            "description": "driver is the name of the driver to use for this volume.",
             "type": "string"
           },
           "fsType": {
-            "description": "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". The default filesystem depends on FlexVolume script.",
+            "description": "fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". The default filesystem depends on FlexVolume script.",
             "type": "string"
           },
           "options": {
@@ -1994,16 +1994,16 @@
               "default": "",
               "type": "string"
             },
-            "description": "Optional: Extra command options if any.",
+            "description": "options is Optional: this field holds extra command options if any.",
             "type": "object"
           },
           "readOnly": {
-            "description": "Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
+            "description": "readOnly is Optional: defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
             "type": "boolean"
           },
           "secretRef": {
             "$ref": "#/components/schemas/io.k8s.api.core.v1.LocalObjectReference",
-            "description": "Optional: SecretRef is reference to the secret object containing sensitive information to pass to the plugin scripts. This may be empty if no secret object is specified. If the secret object contains more than one secret, all secrets are passed to the plugin scripts."
+            "description": "secretRef is Optional: secretRef is reference to the secret object containing sensitive information to pass to the plugin scripts. This may be empty if no secret object is specified. If the secret object contains more than one secret, all secrets are passed to the plugin scripts."
           }
         },
         "required": [
@@ -2015,11 +2015,11 @@
         "description": "Represents a Flocker volume mounted by the Flocker agent. One and only one of datasetName and datasetUUID should be set. Flocker volumes do not support ownership management or SELinux relabeling.",
         "properties": {
           "datasetName": {
-            "description": "Name of the dataset stored as metadata -> name on the dataset for Flocker should be considered as deprecated",
+            "description": "datasetName is Name of the dataset stored as metadata -> name on the dataset for Flocker should be considered as deprecated",
             "type": "string"
           },
           "datasetUUID": {
-            "description": "UUID of the dataset. This is unique identifier of a Flocker dataset",
+            "description": "datasetUUID is the UUID of the dataset. This is unique identifier of a Flocker dataset",
             "type": "string"
           }
         },
@@ -2029,21 +2029,21 @@
         "description": "Represents a Persistent Disk resource in Google Compute Engine.\n\nA GCE PD must exist before mounting to a container. The disk must also be in the same GCE project and zone as the kubelet. A GCE PD can only be mounted as read/write once or read-only many times. GCE PDs support ownership management and SELinux relabeling.",
         "properties": {
           "fsType": {
-            "description": "Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
+            "description": "fsType is filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
             "type": "string"
           },
           "partition": {
-            "description": "The partition in the volume that you want to mount. If omitted, the default is to mount by volume name. Examples: For volume /dev/sda1, you specify the partition as \"1\". Similarly, the volume partition for /dev/sda is \"0\" (or you can leave the property empty). More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
+            "description": "partition is the partition in the volume that you want to mount. If omitted, the default is to mount by volume name. Examples: For volume /dev/sda1, you specify the partition as \"1\". Similarly, the volume partition for /dev/sda is \"0\" (or you can leave the property empty). More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
             "format": "int32",
             "type": "integer"
           },
           "pdName": {
             "default": "",
-            "description": "Unique name of the PD resource in GCE. Used to identify the disk in GCE. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
+            "description": "pdName is unique name of the PD resource in GCE. Used to identify the disk in GCE. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
             "type": "string"
           },
           "readOnly": {
-            "description": "ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
+            "description": "readOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
             "type": "boolean"
           }
         },
@@ -2075,16 +2075,16 @@
         "description": "Represents a volume that is populated with the contents of a git repository. Git repo volumes do not support ownership management. Git repo volumes support SELinux relabeling.\n\nDEPRECATED: GitRepo is deprecated. To provision a container with a git repo, mount an EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir into the Pod's container.",
         "properties": {
           "directory": {
-            "description": "Target directory name. Must not contain or start with '..'.  If '.' is supplied, the volume directory will be the git repository.  Otherwise, if specified, the volume will contain the git repository in the subdirectory with the given name.",
+            "description": "directory is the target directory name. Must not contain or start with '..'.  If '.' is supplied, the volume directory will be the git repository.  Otherwise, if specified, the volume will contain the git repository in the subdirectory with the given name.",
             "type": "string"
           },
           "repository": {
             "default": "",
-            "description": "Repository URL",
+            "description": "repository is the URL",
             "type": "string"
           },
           "revision": {
-            "description": "Commit hash for the specified revision.",
+            "description": "revision is the commit hash for the specified revision.",
             "type": "string"
           }
         },
@@ -2098,20 +2098,20 @@
         "properties": {
           "endpoints": {
             "default": "",
-            "description": "EndpointsName is the endpoint name that details Glusterfs topology. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod",
+            "description": "endpoints is the endpoint name that details Glusterfs topology. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod",
             "type": "string"
           },
           "endpointsNamespace": {
-            "description": "EndpointsNamespace is the namespace that contains Glusterfs endpoint. If this field is empty, the EndpointNamespace defaults to the same namespace as the bound PVC. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod",
+            "description": "endpointsNamespace is the namespace that contains Glusterfs endpoint. If this field is empty, the EndpointNamespace defaults to the same namespace as the bound PVC. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod",
             "type": "string"
           },
           "path": {
             "default": "",
-            "description": "Path is the Glusterfs volume path. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod",
+            "description": "path is the Glusterfs volume path. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod",
             "type": "string"
           },
           "readOnly": {
-            "description": "ReadOnly here will force the Glusterfs volume to be mounted with read-only permissions. Defaults to false. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod",
+            "description": "readOnly here will force the Glusterfs volume to be mounted with read-only permissions. Defaults to false. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod",
             "type": "boolean"
           }
         },
@@ -2126,16 +2126,16 @@
         "properties": {
           "endpoints": {
             "default": "",
-            "description": "EndpointsName is the endpoint name that details Glusterfs topology. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod",
+            "description": "endpoints is the endpoint name that details Glusterfs topology. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod",
             "type": "string"
           },
           "path": {
             "default": "",
-            "description": "Path is the Glusterfs volume path. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod",
+            "description": "path is the Glusterfs volume path. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod",
             "type": "string"
           },
           "readOnly": {
-            "description": "ReadOnly here will force the Glusterfs volume to be mounted with read-only permissions. Defaults to false. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod",
+            "description": "readOnly here will force the Glusterfs volume to be mounted with read-only permissions. Defaults to false. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod",
             "type": "boolean"
           }
         },
@@ -2226,11 +2226,11 @@
         "properties": {
           "path": {
             "default": "",
-            "description": "Path of the directory on the host. If the path is a symlink, it will follow the link to the real path. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath",
+            "description": "path of the directory on the host. If the path is a symlink, it will follow the link to the real path. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath",
             "type": "string"
           },
           "type": {
-            "description": "Type for HostPath Volume Defaults to \"\" More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath",
+            "description": "type for HostPath Volume Defaults to \"\" More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath",
             "type": "string"
           }
         },
@@ -2243,38 +2243,38 @@
         "description": "ISCSIPersistentVolumeSource represents an ISCSI disk. ISCSI volumes can only be mounted as read/write once. ISCSI volumes support ownership management and SELinux relabeling.",
         "properties": {
           "chapAuthDiscovery": {
-            "description": "whether support iSCSI Discovery CHAP authentication",
+            "description": "chapAuthDiscovery defines whether support iSCSI Discovery CHAP authentication",
             "type": "boolean"
           },
           "chapAuthSession": {
-            "description": "whether support iSCSI Session CHAP authentication",
+            "description": "chapAuthSession defines whether support iSCSI Session CHAP authentication",
             "type": "boolean"
           },
           "fsType": {
-            "description": "Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi",
+            "description": "fsType is the filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi",
             "type": "string"
           },
           "initiatorName": {
-            "description": "Custom iSCSI Initiator Name. If initiatorName is specified with iscsiInterface simultaneously, new iSCSI interface <target portal>:<volume name> will be created for the connection.",
+            "description": "initiatorName is the custom iSCSI Initiator Name. If initiatorName is specified with iscsiInterface simultaneously, new iSCSI interface <target portal>:<volume name> will be created for the connection.",
             "type": "string"
           },
           "iqn": {
             "default": "",
-            "description": "Target iSCSI Qualified Name.",
+            "description": "iqn is Target iSCSI Qualified Name.",
             "type": "string"
           },
           "iscsiInterface": {
-            "description": "iSCSI Interface Name that uses an iSCSI transport. Defaults to 'default' (tcp).",
+            "description": "iscsiInterface is the interface Name that uses an iSCSI transport. Defaults to 'default' (tcp).",
             "type": "string"
           },
           "lun": {
             "default": 0,
-            "description": "iSCSI Target Lun number.",
+            "description": "lun is iSCSI Target Lun number.",
             "format": "int32",
             "type": "integer"
           },
           "portals": {
-            "description": "iSCSI Target Portal List. The Portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).",
+            "description": "portals is the iSCSI Target Portal List. The Portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).",
             "items": {
               "default": "",
               "type": "string"
@@ -2282,16 +2282,16 @@
             "type": "array"
           },
           "readOnly": {
-            "description": "ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false.",
+            "description": "readOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false.",
             "type": "boolean"
           },
           "secretRef": {
             "$ref": "#/components/schemas/io.k8s.api.core.v1.SecretReference",
-            "description": "CHAP Secret for iSCSI target and initiator authentication"
+            "description": "secretRef is the CHAP Secret for iSCSI target and initiator authentication"
           },
           "targetPortal": {
             "default": "",
-            "description": "iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).",
+            "description": "targetPortal is iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).",
             "type": "string"
           }
         },
@@ -2306,38 +2306,38 @@
         "description": "Represents an ISCSI disk. ISCSI volumes can only be mounted as read/write once. ISCSI volumes support ownership management and SELinux relabeling.",
         "properties": {
           "chapAuthDiscovery": {
-            "description": "whether support iSCSI Discovery CHAP authentication",
+            "description": "chapAuthDiscovery defines whether support iSCSI Discovery CHAP authentication",
             "type": "boolean"
           },
           "chapAuthSession": {
-            "description": "whether support iSCSI Session CHAP authentication",
+            "description": "chapAuthSession defines whether support iSCSI Session CHAP authentication",
             "type": "boolean"
           },
           "fsType": {
-            "description": "Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi",
+            "description": "fsType is the filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi",
             "type": "string"
           },
           "initiatorName": {
-            "description": "Custom iSCSI Initiator Name. If initiatorName is specified with iscsiInterface simultaneously, new iSCSI interface <target portal>:<volume name> will be created for the connection.",
+            "description": "initiatorName is the custom iSCSI Initiator Name. If initiatorName is specified with iscsiInterface simultaneously, new iSCSI interface <target portal>:<volume name> will be created for the connection.",
             "type": "string"
           },
           "iqn": {
             "default": "",
-            "description": "Target iSCSI Qualified Name.",
+            "description": "iqn is the target iSCSI Qualified Name.",
             "type": "string"
           },
           "iscsiInterface": {
-            "description": "iSCSI Interface Name that uses an iSCSI transport. Defaults to 'default' (tcp).",
+            "description": "iscsiInterface is the interface Name that uses an iSCSI transport. Defaults to 'default' (tcp).",
             "type": "string"
           },
           "lun": {
             "default": 0,
-            "description": "iSCSI Target Lun number.",
+            "description": "lun represents iSCSI Target Lun number.",
             "format": "int32",
             "type": "integer"
           },
           "portals": {
-            "description": "iSCSI Target Portal List. The portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).",
+            "description": "portals is the iSCSI Target Portal List. The portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).",
             "items": {
               "default": "",
               "type": "string"
@@ -2345,16 +2345,16 @@
             "type": "array"
           },
           "readOnly": {
-            "description": "ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false.",
+            "description": "readOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false.",
             "type": "boolean"
           },
           "secretRef": {
             "$ref": "#/components/schemas/io.k8s.api.core.v1.LocalObjectReference",
-            "description": "CHAP Secret for iSCSI target and initiator authentication"
+            "description": "secretRef is the CHAP Secret for iSCSI target and initiator authentication"
           },
           "targetPortal": {
             "default": "",
-            "description": "iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).",
+            "description": "targetPortal is iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).",
             "type": "string"
           }
         },
@@ -2370,17 +2370,17 @@
         "properties": {
           "key": {
             "default": "",
-            "description": "The key to project.",
+            "description": "key is the key to project.",
             "type": "string"
           },
           "mode": {
-            "description": "Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+            "description": "mode is Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
             "format": "int32",
             "type": "integer"
           },
           "path": {
             "default": "",
-            "description": "The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.",
+            "description": "path is the relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.",
             "type": "string"
           }
         },
@@ -2618,12 +2618,12 @@
         "description": "Local represents directly-attached storage with node affinity (Beta feature)",
         "properties": {
           "fsType": {
-            "description": "Filesystem type to mount. It applies only when the Path is a block device. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". The default value is to auto-select a filesystem if unspecified.",
+            "description": "fsType is the filesystem type to mount. It applies only when the Path is a block device. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". The default value is to auto-select a filesystem if unspecified.",
             "type": "string"
           },
           "path": {
             "default": "",
-            "description": "The full path to the volume on the node. It can be either a directory or block device (disk, partition, ...).",
+            "description": "path of the full path to the volume on the node. It can be either a directory or block device (disk, partition, ...).",
             "type": "string"
           }
         },
@@ -2637,16 +2637,16 @@
         "properties": {
           "path": {
             "default": "",
-            "description": "Path that is exported by the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
+            "description": "path that is exported by the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
             "type": "string"
           },
           "readOnly": {
-            "description": "ReadOnly here will force the NFS export to be mounted with read-only permissions. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
+            "description": "readOnly here will force the NFS export to be mounted with read-only permissions. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
             "type": "boolean"
           },
           "server": {
             "default": "",
-            "description": "Server is the hostname or IP address of the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
+            "description": "server is the hostname or IP address of the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
             "type": "string"
           }
         },
@@ -3833,12 +3833,12 @@
         "description": "Represents a Photon Controller persistent disk resource.",
         "properties": {
           "fsType": {
-            "description": "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+            "description": "fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
             "type": "string"
           },
           "pdID": {
             "default": "",
-            "description": "ID that identifies Photon Controller persistent disk",
+            "description": "pdID is the ID that identifies Photon Controller persistent disk",
             "type": "string"
           }
         },
@@ -4625,16 +4625,16 @@
         "description": "PortworxVolumeSource represents a Portworx volume resource.",
         "properties": {
           "fsType": {
-            "description": "FSType represents the filesystem type to mount Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+            "description": "fSType represents the filesystem type to mount Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\". Implicitly inferred to be \"ext4\" if unspecified.",
             "type": "string"
           },
           "readOnly": {
-            "description": "Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
+            "description": "readOnly defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
             "type": "boolean"
           },
           "volumeID": {
             "default": "",
-            "description": "VolumeID uniquely identifies a Portworx volume",
+            "description": "volumeID uniquely identifies a Portworx volume",
             "type": "string"
           }
         },
@@ -4720,12 +4720,12 @@
         "description": "Represents a projected volume source",
         "properties": {
           "defaultMode": {
-            "description": "Mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+            "description": "defaultMode are the mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
             "format": "int32",
             "type": "integer"
           },
           "sources": {
-            "description": "list of volume projections",
+            "description": "sources is the list of volume projections",
             "items": {
               "$ref": "#/components/schemas/io.k8s.api.core.v1.VolumeProjection",
               "default": {}
@@ -4739,29 +4739,29 @@
         "description": "Represents a Quobyte mount that lasts the lifetime of a pod. Quobyte volumes do not support ownership management or SELinux relabeling.",
         "properties": {
           "group": {
-            "description": "Group to map volume access to Default is no group",
+            "description": "group to map volume access to Default is no group",
             "type": "string"
           },
           "readOnly": {
-            "description": "ReadOnly here will force the Quobyte volume to be mounted with read-only permissions. Defaults to false.",
+            "description": "readOnly here will force the Quobyte volume to be mounted with read-only permissions. Defaults to false.",
             "type": "boolean"
           },
           "registry": {
             "default": "",
-            "description": "Registry represents a single or multiple Quobyte Registry services specified as a string as host:port pair (multiple entries are separated with commas) which acts as the central registry for volumes",
+            "description": "registry represents a single or multiple Quobyte Registry services specified as a string as host:port pair (multiple entries are separated with commas) which acts as the central registry for volumes",
             "type": "string"
           },
           "tenant": {
-            "description": "Tenant owning the given Quobyte volume in the Backend Used with dynamically provisioned Quobyte volumes, value is set by the plugin",
+            "description": "tenant owning the given Quobyte volume in the Backend Used with dynamically provisioned Quobyte volumes, value is set by the plugin",
             "type": "string"
           },
           "user": {
-            "description": "User to map volume access to Defaults to serivceaccount user",
+            "description": "user to map volume access to Defaults to serivceaccount user",
             "type": "string"
           },
           "volume": {
             "default": "",
-            "description": "Volume is a string that references an already created Quobyte volume by name.",
+            "description": "volume is a string that references an already created Quobyte volume by name.",
             "type": "string"
           }
         },
@@ -4775,20 +4775,20 @@
         "description": "Represents a Rados Block Device mount that lasts the lifetime of a pod. RBD volumes support ownership management and SELinux relabeling.",
         "properties": {
           "fsType": {
-            "description": "Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd",
+            "description": "fsType is the filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd",
             "type": "string"
           },
           "image": {
             "default": "",
-            "description": "The rados image name. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+            "description": "image is the rados image name. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
             "type": "string"
           },
           "keyring": {
-            "description": "Keyring is the path to key ring for RBDUser. Default is /etc/ceph/keyring. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+            "description": "keyring is the path to key ring for RBDUser. Default is /etc/ceph/keyring. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
             "type": "string"
           },
           "monitors": {
-            "description": "A collection of Ceph monitors. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+            "description": "monitors is a collection of Ceph monitors. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
             "items": {
               "default": "",
               "type": "string"
@@ -4796,19 +4796,19 @@
             "type": "array"
           },
           "pool": {
-            "description": "The rados pool name. Default is rbd. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+            "description": "pool is the rados pool name. Default is rbd. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
             "type": "string"
           },
           "readOnly": {
-            "description": "ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+            "description": "readOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
             "type": "boolean"
           },
           "secretRef": {
             "$ref": "#/components/schemas/io.k8s.api.core.v1.SecretReference",
-            "description": "SecretRef is name of the authentication secret for RBDUser. If provided overrides keyring. Default is nil. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it"
+            "description": "secretRef is name of the authentication secret for RBDUser. If provided overrides keyring. Default is nil. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it"
           },
           "user": {
-            "description": "The rados user name. Default is admin. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+            "description": "user is the rados user name. Default is admin. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
             "type": "string"
           }
         },
@@ -4822,20 +4822,20 @@
         "description": "Represents a Rados Block Device mount that lasts the lifetime of a pod. RBD volumes support ownership management and SELinux relabeling.",
         "properties": {
           "fsType": {
-            "description": "Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd",
+            "description": "fsType is the filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd",
             "type": "string"
           },
           "image": {
             "default": "",
-            "description": "The rados image name. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+            "description": "image is the rados image name. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
             "type": "string"
           },
           "keyring": {
-            "description": "Keyring is the path to key ring for RBDUser. Default is /etc/ceph/keyring. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+            "description": "keyring is the path to key ring for RBDUser. Default is /etc/ceph/keyring. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
             "type": "string"
           },
           "monitors": {
-            "description": "A collection of Ceph monitors. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+            "description": "monitors is a collection of Ceph monitors. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
             "items": {
               "default": "",
               "type": "string"
@@ -4843,19 +4843,19 @@
             "type": "array"
           },
           "pool": {
-            "description": "The rados pool name. Default is rbd. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+            "description": "pool is the rados pool name. Default is rbd. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
             "type": "string"
           },
           "readOnly": {
-            "description": "ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+            "description": "readOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
             "type": "boolean"
           },
           "secretRef": {
             "$ref": "#/components/schemas/io.k8s.api.core.v1.LocalObjectReference",
-            "description": "SecretRef is name of the authentication secret for RBDUser. If provided overrides keyring. Default is nil. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it"
+            "description": "secretRef is name of the authentication secret for RBDUser. If provided overrides keyring. Default is nil. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it"
           },
           "user": {
-            "description": "The rados user name. Default is admin. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+            "description": "user is the rados user name. Default is admin. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
             "type": "string"
           }
         },
@@ -5238,45 +5238,45 @@
         "description": "ScaleIOPersistentVolumeSource represents a persistent ScaleIO volume",
         "properties": {
           "fsType": {
-            "description": "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Default is \"xfs\"",
+            "description": "fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Default is \"xfs\"",
             "type": "string"
           },
           "gateway": {
             "default": "",
-            "description": "The host address of the ScaleIO API Gateway.",
+            "description": "gateway is the host address of the ScaleIO API Gateway.",
             "type": "string"
           },
           "protectionDomain": {
-            "description": "The name of the ScaleIO Protection Domain for the configured storage.",
+            "description": "protectionDomain is the name of the ScaleIO Protection Domain for the configured storage.",
             "type": "string"
           },
           "readOnly": {
-            "description": "Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
+            "description": "readOnly defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
             "type": "boolean"
           },
           "secretRef": {
             "$ref": "#/components/schemas/io.k8s.api.core.v1.SecretReference",
-            "description": "SecretRef references to the secret for ScaleIO user and other sensitive information. If this is not provided, Login operation will fail."
+            "description": "secretRef references to the secret for ScaleIO user and other sensitive information. If this is not provided, Login operation will fail."
           },
           "sslEnabled": {
-            "description": "Flag to enable/disable SSL communication with Gateway, default false",
+            "description": "sslEnabled is the flag to enable/disable SSL communication with Gateway, default false",
             "type": "boolean"
           },
           "storageMode": {
-            "description": "Indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned. Default is ThinProvisioned.",
+            "description": "storageMode indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned. Default is ThinProvisioned.",
             "type": "string"
           },
           "storagePool": {
-            "description": "The ScaleIO Storage Pool associated with the protection domain.",
+            "description": "storagePool is the ScaleIO Storage Pool associated with the protection domain.",
             "type": "string"
           },
           "system": {
             "default": "",
-            "description": "The name of the storage system as configured in ScaleIO.",
+            "description": "system is the name of the storage system as configured in ScaleIO.",
             "type": "string"
           },
           "volumeName": {
-            "description": "The name of a volume already created in the ScaleIO system that is associated with this volume source.",
+            "description": "volumeName is the name of a volume already created in the ScaleIO system that is associated with this volume source.",
             "type": "string"
           }
         },
@@ -5291,45 +5291,45 @@
         "description": "ScaleIOVolumeSource represents a persistent ScaleIO volume",
         "properties": {
           "fsType": {
-            "description": "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Default is \"xfs\".",
+            "description": "fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Default is \"xfs\".",
             "type": "string"
           },
           "gateway": {
             "default": "",
-            "description": "The host address of the ScaleIO API Gateway.",
+            "description": "gateway is the host address of the ScaleIO API Gateway.",
             "type": "string"
           },
           "protectionDomain": {
-            "description": "The name of the ScaleIO Protection Domain for the configured storage.",
+            "description": "protectionDomain is the name of the ScaleIO Protection Domain for the configured storage.",
             "type": "string"
           },
           "readOnly": {
-            "description": "Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
+            "description": "readOnly Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
             "type": "boolean"
           },
           "secretRef": {
             "$ref": "#/components/schemas/io.k8s.api.core.v1.LocalObjectReference",
-            "description": "SecretRef references to the secret for ScaleIO user and other sensitive information. If this is not provided, Login operation will fail."
+            "description": "secretRef references to the secret for ScaleIO user and other sensitive information. If this is not provided, Login operation will fail."
           },
           "sslEnabled": {
-            "description": "Flag to enable/disable SSL communication with Gateway, default false",
+            "description": "sslEnabled Flag enable/disable SSL communication with Gateway, default false",
             "type": "boolean"
           },
           "storageMode": {
-            "description": "Indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned. Default is ThinProvisioned.",
+            "description": "storageMode indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned. Default is ThinProvisioned.",
             "type": "string"
           },
           "storagePool": {
-            "description": "The ScaleIO Storage Pool associated with the protection domain.",
+            "description": "storagePool is the ScaleIO Storage Pool associated with the protection domain.",
             "type": "string"
           },
           "system": {
             "default": "",
-            "description": "The name of the storage system as configured in ScaleIO.",
+            "description": "system is the name of the storage system as configured in ScaleIO.",
             "type": "string"
           },
           "volumeName": {
-            "description": "The name of a volume already created in the ScaleIO system that is associated with this volume source.",
+            "description": "volumeName is the name of a volume already created in the ScaleIO system that is associated with this volume source.",
             "type": "string"
           }
         },
@@ -5556,7 +5556,7 @@
         "description": "Adapts a secret into a projected volume.\n\nThe contents of the target Secret's Data field will be presented in a projected volume as files using the keys in the Data field as the file names. Note that this is identical to a secret volume source without the default mode.",
         "properties": {
           "items": {
-            "description": "If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.",
+            "description": "items if unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.",
             "items": {
               "$ref": "#/components/schemas/io.k8s.api.core.v1.KeyToPath",
               "default": {}
@@ -5568,7 +5568,7 @@
             "type": "string"
           },
           "optional": {
-            "description": "Specify whether the Secret or its key must be defined",
+            "description": "optional field specify whether the Secret or its key must be defined",
             "type": "boolean"
           }
         },
@@ -5578,11 +5578,11 @@
         "description": "SecretReference represents a Secret Reference. It has enough information to retrieve secret in any namespace",
         "properties": {
           "name": {
-            "description": "Name is unique within a namespace to reference a secret resource.",
+            "description": "name is unique within a namespace to reference a secret resource.",
             "type": "string"
           },
           "namespace": {
-            "description": "Namespace defines the space within which the secret name must be unique.",
+            "description": "namespace defines the space within which the secret name must be unique.",
             "type": "string"
           }
         },
@@ -5593,12 +5593,12 @@
         "description": "Adapts a Secret into a volume.\n\nThe contents of the target Secret's Data field will be presented in a volume as files using the keys in the Data field as the file names. Secret volumes support ownership management and SELinux relabeling.",
         "properties": {
           "defaultMode": {
-            "description": "Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+            "description": "defaultMode is Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
             "format": "int32",
             "type": "integer"
           },
           "items": {
-            "description": "If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.",
+            "description": "items If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.",
             "items": {
               "$ref": "#/components/schemas/io.k8s.api.core.v1.KeyToPath",
               "default": {}
@@ -5606,11 +5606,11 @@
             "type": "array"
           },
           "optional": {
-            "description": "Specify whether the Secret or its keys must be defined",
+            "description": "optional field specify whether the Secret or its keys must be defined",
             "type": "boolean"
           },
           "secretName": {
-            "description": "Name of the secret in the pod's namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret",
+            "description": "secretName is the name of the secret in the pod's namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret",
             "type": "string"
           }
         },
@@ -5793,17 +5793,17 @@
         "description": "ServiceAccountTokenProjection represents a projected service account token volume. This projection can be used to insert a service account token into the pods runtime filesystem for use against APIs (Kubernetes API Server or otherwise).",
         "properties": {
           "audience": {
-            "description": "Audience is the intended audience of the token. A recipient of a token must identify itself with an identifier specified in the audience of the token, and otherwise should reject the token. The audience defaults to the identifier of the apiserver.",
+            "description": "audience is the intended audience of the token. A recipient of a token must identify itself with an identifier specified in the audience of the token, and otherwise should reject the token. The audience defaults to the identifier of the apiserver.",
             "type": "string"
           },
           "expirationSeconds": {
-            "description": "ExpirationSeconds is the requested duration of validity of the service account token. As the token approaches expiration, the kubelet volume plugin will proactively rotate the service account token. The kubelet will start trying to rotate the token if the token is older than 80 percent of its time to live or if the token is older than 24 hours.Defaults to 1 hour and must be at least 10 minutes.",
+            "description": "expirationSeconds is the requested duration of validity of the service account token. As the token approaches expiration, the kubelet volume plugin will proactively rotate the service account token. The kubelet will start trying to rotate the token if the token is older than 80 percent of its time to live or if the token is older than 24 hours.Defaults to 1 hour and must be at least 10 minutes.",
             "format": "int64",
             "type": "integer"
           },
           "path": {
             "default": "",
-            "description": "Path is the path relative to the mount point of the file to project the token into.",
+            "description": "path is the path relative to the mount point of the file to project the token into.",
             "type": "string"
           }
         },
@@ -6062,23 +6062,23 @@
         "description": "Represents a StorageOS persistent volume resource.",
         "properties": {
           "fsType": {
-            "description": "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+            "description": "fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
             "type": "string"
           },
           "readOnly": {
-            "description": "Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
+            "description": "readOnly defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
             "type": "boolean"
           },
           "secretRef": {
             "$ref": "#/components/schemas/io.k8s.api.core.v1.ObjectReference",
-            "description": "SecretRef specifies the secret to use for obtaining the StorageOS API credentials.  If not specified, default values will be attempted."
+            "description": "secretRef specifies the secret to use for obtaining the StorageOS API credentials.  If not specified, default values will be attempted."
           },
           "volumeName": {
-            "description": "VolumeName is the human-readable name of the StorageOS volume.  Volume names are only unique within a namespace.",
+            "description": "volumeName is the human-readable name of the StorageOS volume.  Volume names are only unique within a namespace.",
             "type": "string"
           },
           "volumeNamespace": {
-            "description": "VolumeNamespace specifies the scope of the volume within StorageOS.  If no namespace is specified then the Pod's namespace will be used.  This allows the Kubernetes name scoping to be mirrored within StorageOS for tighter integration. Set VolumeName to any name to override the default behaviour. Set to \"default\" if you are not using namespaces within StorageOS. Namespaces that do not pre-exist within StorageOS will be created.",
+            "description": "volumeNamespace specifies the scope of the volume within StorageOS.  If no namespace is specified then the Pod's namespace will be used.  This allows the Kubernetes name scoping to be mirrored within StorageOS for tighter integration. Set VolumeName to any name to override the default behaviour. Set to \"default\" if you are not using namespaces within StorageOS. Namespaces that do not pre-exist within StorageOS will be created.",
             "type": "string"
           }
         },
@@ -6088,23 +6088,23 @@
         "description": "Represents a StorageOS persistent volume resource.",
         "properties": {
           "fsType": {
-            "description": "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+            "description": "fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
             "type": "string"
           },
           "readOnly": {
-            "description": "Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
+            "description": "readOnly defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
             "type": "boolean"
           },
           "secretRef": {
             "$ref": "#/components/schemas/io.k8s.api.core.v1.LocalObjectReference",
-            "description": "SecretRef specifies the secret to use for obtaining the StorageOS API credentials.  If not specified, default values will be attempted."
+            "description": "secretRef specifies the secret to use for obtaining the StorageOS API credentials.  If not specified, default values will be attempted."
           },
           "volumeName": {
-            "description": "VolumeName is the human-readable name of the StorageOS volume.  Volume names are only unique within a namespace.",
+            "description": "volumeName is the human-readable name of the StorageOS volume.  Volume names are only unique within a namespace.",
             "type": "string"
           },
           "volumeNamespace": {
-            "description": "VolumeNamespace specifies the scope of the volume within StorageOS.  If no namespace is specified then the Pod's namespace will be used.  This allows the Kubernetes name scoping to be mirrored within StorageOS for tighter integration. Set VolumeName to any name to override the default behaviour. Set to \"default\" if you are not using namespaces within StorageOS. Namespaces that do not pre-exist within StorageOS will be created.",
+            "description": "volumeNamespace specifies the scope of the volume within StorageOS.  If no namespace is specified then the Pod's namespace will be used.  This allows the Kubernetes name scoping to be mirrored within StorageOS for tighter integration. Set VolumeName to any name to override the default behaviour. Set to \"default\" if you are not using namespaces within StorageOS. Namespaces that do not pre-exist within StorageOS will be created.",
             "type": "string"
           }
         },
@@ -6478,19 +6478,19 @@
         "properties": {
           "configMap": {
             "$ref": "#/components/schemas/io.k8s.api.core.v1.ConfigMapProjection",
-            "description": "information about the configMap data to project"
+            "description": "configMap information about the configMap data to project"
           },
           "downwardAPI": {
             "$ref": "#/components/schemas/io.k8s.api.core.v1.DownwardAPIProjection",
-            "description": "information about the downwardAPI data to project"
+            "description": "downwardAPI information about the downwardAPI data to project"
           },
           "secret": {
             "$ref": "#/components/schemas/io.k8s.api.core.v1.SecretProjection",
-            "description": "information about the secret data to project"
+            "description": "secret information about the secret data to project"
           },
           "serviceAccountToken": {
             "$ref": "#/components/schemas/io.k8s.api.core.v1.ServiceAccountTokenProjection",
-            "description": "information about the serviceAccountToken data to project"
+            "description": "serviceAccountToken is information about the serviceAccountToken data to project"
           }
         },
         "type": "object"
@@ -6499,20 +6499,20 @@
         "description": "Represents a vSphere volume resource.",
         "properties": {
           "fsType": {
-            "description": "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+            "description": "fsType is filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
             "type": "string"
           },
           "storagePolicyID": {
-            "description": "Storage Policy Based Management (SPBM) profile ID associated with the StoragePolicyName.",
+            "description": "storagePolicyID is the storage Policy Based Management (SPBM) profile ID associated with the StoragePolicyName.",
             "type": "string"
           },
           "storagePolicyName": {
-            "description": "Storage Policy Based Management (SPBM) profile name.",
+            "description": "storagePolicyName is the storage Policy Based Management (SPBM) profile name.",
             "type": "string"
           },
           "volumePath": {
             "default": "",
-            "description": "Path that identifies vSphere volume vmdk",
+            "description": "volumePath is the path that identifies vSphere volume vmdk",
             "type": "string"
           }
         },

--- a/api/openapi-spec/v3/apis__apps__v1_openapi.json
+++ b/api/openapi-spec/v3/apis__apps__v1_openapi.json
@@ -1092,21 +1092,21 @@
         "description": "Represents a Persistent Disk resource in AWS.\n\nAn AWS EBS disk must exist before mounting to a container. The disk must also be in the same AWS zone as the kubelet. An AWS EBS disk can only be mounted as read/write once. AWS EBS volumes support ownership management and SELinux relabeling.",
         "properties": {
           "fsType": {
-            "description": "Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore",
+            "description": "fsType is the filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore",
             "type": "string"
           },
           "partition": {
-            "description": "The partition in the volume that you want to mount. If omitted, the default is to mount by volume name. Examples: For volume /dev/sda1, you specify the partition as \"1\". Similarly, the volume partition for /dev/sda is \"0\" (or you can leave the property empty).",
+            "description": "partition is the partition in the volume that you want to mount. If omitted, the default is to mount by volume name. Examples: For volume /dev/sda1, you specify the partition as \"1\". Similarly, the volume partition for /dev/sda is \"0\" (or you can leave the property empty).",
             "format": "int32",
             "type": "integer"
           },
           "readOnly": {
-            "description": "Specify \"true\" to force and set the ReadOnly property in VolumeMounts to \"true\". If omitted, the default is \"false\". More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore",
+            "description": "readOnly value true will force the readOnly setting in VolumeMounts. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore",
             "type": "boolean"
           },
           "volumeID": {
             "default": "",
-            "description": "Unique ID of the persistent disk resource in AWS (Amazon EBS volume). More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore",
+            "description": "volumeID is unique ID of the persistent disk resource in AWS (Amazon EBS volume). More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore",
             "type": "string"
           }
         },
@@ -1137,29 +1137,29 @@
         "description": "AzureDisk represents an Azure Data Disk mount on the host and bind mount to the pod.",
         "properties": {
           "cachingMode": {
-            "description": "Host Caching mode: None, Read Only, Read Write.",
+            "description": "cachingMode is the Host Caching mode: None, Read Only, Read Write.",
             "type": "string"
           },
           "diskName": {
             "default": "",
-            "description": "The Name of the data disk in the blob storage",
+            "description": "diskName is the Name of the data disk in the blob storage",
             "type": "string"
           },
           "diskURI": {
             "default": "",
-            "description": "The URI the data disk in the blob storage",
+            "description": "diskURI is the URI of data disk in the blob storage",
             "type": "string"
           },
           "fsType": {
-            "description": "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+            "description": "fsType is Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
             "type": "string"
           },
           "kind": {
-            "description": "Expected values Shared: multiple blob disks per storage account  Dedicated: single blob disk per storage account  Managed: azure managed data disk (only in managed availability set). defaults to shared",
+            "description": "kind expected values are Shared: multiple blob disks per storage account  Dedicated: single blob disk per storage account  Managed: azure managed data disk (only in managed availability set). defaults to shared",
             "type": "string"
           },
           "readOnly": {
-            "description": "Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
+            "description": "readOnly Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
             "type": "boolean"
           }
         },
@@ -1173,17 +1173,17 @@
         "description": "AzureFile represents an Azure File Service mount on the host and bind mount to the pod.",
         "properties": {
           "readOnly": {
-            "description": "Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
+            "description": "readOnly defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
             "type": "boolean"
           },
           "secretName": {
             "default": "",
-            "description": "the name of secret that contains Azure Storage Account Name and Key",
+            "description": "secretName is the  name of secret that contains Azure Storage Account Name and Key",
             "type": "string"
           },
           "shareName": {
             "default": "",
-            "description": "Share Name",
+            "description": "shareName is the azure share Name",
             "type": "string"
           }
         },
@@ -1253,7 +1253,7 @@
         "description": "Represents a Ceph Filesystem mount that lasts the lifetime of a pod Cephfs volumes do not support ownership management or SELinux relabeling.",
         "properties": {
           "monitors": {
-            "description": "Required: Monitors is a collection of Ceph monitors More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
+            "description": "monitors is Required: Monitors is a collection of Ceph monitors More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
             "items": {
               "default": "",
               "type": "string"
@@ -1261,23 +1261,23 @@
             "type": "array"
           },
           "path": {
-            "description": "Optional: Used as the mounted root, rather than the full Ceph tree, default is /",
+            "description": "path is Optional: Used as the mounted root, rather than the full Ceph tree, default is /",
             "type": "string"
           },
           "readOnly": {
-            "description": "Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
+            "description": "readOnly is Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
             "type": "boolean"
           },
           "secretFile": {
-            "description": "Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
+            "description": "secretFile is Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
             "type": "string"
           },
           "secretRef": {
             "$ref": "#/components/schemas/io.k8s.api.core.v1.LocalObjectReference",
-            "description": "Optional: SecretRef is reference to the authentication secret for User, default is empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it"
+            "description": "secretRef is Optional: SecretRef is reference to the authentication secret for User, default is empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it"
           },
           "user": {
-            "description": "Optional: User is the rados user name, default is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
+            "description": "user is optional: User is the rados user name, default is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
             "type": "string"
           }
         },
@@ -1290,20 +1290,20 @@
         "description": "Represents a cinder volume resource in Openstack. A Cinder volume must exist before mounting to a container. The volume must also be in the same region as the kubelet. Cinder volumes support ownership management and SELinux relabeling.",
         "properties": {
           "fsType": {
-            "description": "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://examples.k8s.io/mysql-cinder-pd/README.md",
+            "description": "fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://examples.k8s.io/mysql-cinder-pd/README.md",
             "type": "string"
           },
           "readOnly": {
-            "description": "Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: https://examples.k8s.io/mysql-cinder-pd/README.md",
+            "description": "readOnly defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: https://examples.k8s.io/mysql-cinder-pd/README.md",
             "type": "boolean"
           },
           "secretRef": {
             "$ref": "#/components/schemas/io.k8s.api.core.v1.LocalObjectReference",
-            "description": "Optional: points to a secret object containing parameters used to connect to OpenStack."
+            "description": "secretRef is optional: points to a secret object containing parameters used to connect to OpenStack."
           },
           "volumeID": {
             "default": "",
-            "description": "volume id used to identify the volume in cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md",
+            "description": "volumeID used to identify the volume in cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md",
             "type": "string"
           }
         },
@@ -1353,7 +1353,7 @@
         "description": "Adapts a ConfigMap into a projected volume.\n\nThe contents of the target ConfigMap's Data field will be presented in a projected volume as files using the keys in the Data field as the file names, unless the items element is populated with specific mappings of keys to paths. Note that this is identical to a configmap volume source without the default mode.",
         "properties": {
           "items": {
-            "description": "If unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.",
+            "description": "items if unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.",
             "items": {
               "$ref": "#/components/schemas/io.k8s.api.core.v1.KeyToPath",
               "default": {}
@@ -1365,7 +1365,7 @@
             "type": "string"
           },
           "optional": {
-            "description": "Specify whether the ConfigMap or its keys must be defined",
+            "description": "optional specify whether the ConfigMap or its keys must be defined",
             "type": "boolean"
           }
         },
@@ -1375,12 +1375,12 @@
         "description": "Adapts a ConfigMap into a volume.\n\nThe contents of the target ConfigMap's Data field will be presented in a volume as files using the keys in the Data field as the file names, unless the items element is populated with specific mappings of keys to paths. ConfigMap volumes support ownership management and SELinux relabeling.",
         "properties": {
           "defaultMode": {
-            "description": "Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+            "description": "defaultMode is optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
             "format": "int32",
             "type": "integer"
           },
           "items": {
-            "description": "If unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.",
+            "description": "items if unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.",
             "items": {
               "$ref": "#/components/schemas/io.k8s.api.core.v1.KeyToPath",
               "default": {}
@@ -1392,7 +1392,7 @@
             "type": "string"
           },
           "optional": {
-            "description": "Specify whether the ConfigMap or its keys must be defined",
+            "description": "optional specify whether the ConfigMap or its keys must be defined",
             "type": "boolean"
           }
         },
@@ -1649,12 +1649,12 @@
         "description": "Represents an empty directory for a pod. Empty directory volumes support ownership management and SELinux relabeling.",
         "properties": {
           "medium": {
-            "description": "What type of storage medium should back this directory. The default is \"\" which means to use the node's default medium. Must be an empty string (default) or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir",
+            "description": "medium represents what type of storage medium should back this directory. The default is \"\" which means to use the node's default medium. Must be an empty string (default) or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir",
             "type": "string"
           },
           "sizeLimit": {
             "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.api.resource.Quantity",
-            "description": "Total amount of local storage required for this EmptyDir volume. The size limit is also applicable for memory medium. The maximum usage on memory medium EmptyDir would be the minimum value between the SizeLimit specified here and the sum of memory limits of all containers in a pod. The default is nil which means that the limit is undefined. More info: http://kubernetes.io/docs/user-guide/volumes#emptydir"
+            "description": "sizeLimit is the total amount of local storage required for this EmptyDir volume. The size limit is also applicable for memory medium. The maximum usage on memory medium EmptyDir would be the minimum value between the SizeLimit specified here and the sum of memory limits of all containers in a pod. The default is nil which means that the limit is undefined. More info: http://kubernetes.io/docs/user-guide/volumes#emptydir"
           }
         },
         "type": "object"
@@ -1902,20 +1902,20 @@
         "description": "Represents a Fibre Channel volume. Fibre Channel volumes can only be mounted as read/write once. Fibre Channel volumes support ownership management and SELinux relabeling.",
         "properties": {
           "fsType": {
-            "description": "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+            "description": "fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
             "type": "string"
           },
           "lun": {
-            "description": "Optional: FC target lun number",
+            "description": "lun is Optional: FC target lun number",
             "format": "int32",
             "type": "integer"
           },
           "readOnly": {
-            "description": "Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
+            "description": "readOnly is Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
             "type": "boolean"
           },
           "targetWWNs": {
-            "description": "Optional: FC target worldwide names (WWNs)",
+            "description": "targetWWNs is Optional: FC target worldwide names (WWNs)",
             "items": {
               "default": "",
               "type": "string"
@@ -1923,7 +1923,7 @@
             "type": "array"
           },
           "wwids": {
-            "description": "Optional: FC volume world wide identifiers (wwids) Either wwids or combination of targetWWNs and lun must be set, but not both simultaneously.",
+            "description": "wwids Optional: FC volume world wide identifiers (wwids) Either wwids or combination of targetWWNs and lun must be set, but not both simultaneously.",
             "items": {
               "default": "",
               "type": "string"
@@ -1938,11 +1938,11 @@
         "properties": {
           "driver": {
             "default": "",
-            "description": "Driver is the name of the driver to use for this volume.",
+            "description": "driver is the name of the driver to use for this volume.",
             "type": "string"
           },
           "fsType": {
-            "description": "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". The default filesystem depends on FlexVolume script.",
+            "description": "fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". The default filesystem depends on FlexVolume script.",
             "type": "string"
           },
           "options": {
@@ -1950,16 +1950,16 @@
               "default": "",
               "type": "string"
             },
-            "description": "Optional: Extra command options if any.",
+            "description": "options is Optional: this field holds extra command options if any.",
             "type": "object"
           },
           "readOnly": {
-            "description": "Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
+            "description": "readOnly is Optional: defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
             "type": "boolean"
           },
           "secretRef": {
             "$ref": "#/components/schemas/io.k8s.api.core.v1.LocalObjectReference",
-            "description": "Optional: SecretRef is reference to the secret object containing sensitive information to pass to the plugin scripts. This may be empty if no secret object is specified. If the secret object contains more than one secret, all secrets are passed to the plugin scripts."
+            "description": "secretRef is Optional: secretRef is reference to the secret object containing sensitive information to pass to the plugin scripts. This may be empty if no secret object is specified. If the secret object contains more than one secret, all secrets are passed to the plugin scripts."
           }
         },
         "required": [
@@ -1971,11 +1971,11 @@
         "description": "Represents a Flocker volume mounted by the Flocker agent. One and only one of datasetName and datasetUUID should be set. Flocker volumes do not support ownership management or SELinux relabeling.",
         "properties": {
           "datasetName": {
-            "description": "Name of the dataset stored as metadata -> name on the dataset for Flocker should be considered as deprecated",
+            "description": "datasetName is Name of the dataset stored as metadata -> name on the dataset for Flocker should be considered as deprecated",
             "type": "string"
           },
           "datasetUUID": {
-            "description": "UUID of the dataset. This is unique identifier of a Flocker dataset",
+            "description": "datasetUUID is the UUID of the dataset. This is unique identifier of a Flocker dataset",
             "type": "string"
           }
         },
@@ -1985,21 +1985,21 @@
         "description": "Represents a Persistent Disk resource in Google Compute Engine.\n\nA GCE PD must exist before mounting to a container. The disk must also be in the same GCE project and zone as the kubelet. A GCE PD can only be mounted as read/write once or read-only many times. GCE PDs support ownership management and SELinux relabeling.",
         "properties": {
           "fsType": {
-            "description": "Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
+            "description": "fsType is filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
             "type": "string"
           },
           "partition": {
-            "description": "The partition in the volume that you want to mount. If omitted, the default is to mount by volume name. Examples: For volume /dev/sda1, you specify the partition as \"1\". Similarly, the volume partition for /dev/sda is \"0\" (or you can leave the property empty). More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
+            "description": "partition is the partition in the volume that you want to mount. If omitted, the default is to mount by volume name. Examples: For volume /dev/sda1, you specify the partition as \"1\". Similarly, the volume partition for /dev/sda is \"0\" (or you can leave the property empty). More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
             "format": "int32",
             "type": "integer"
           },
           "pdName": {
             "default": "",
-            "description": "Unique name of the PD resource in GCE. Used to identify the disk in GCE. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
+            "description": "pdName is unique name of the PD resource in GCE. Used to identify the disk in GCE. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
             "type": "string"
           },
           "readOnly": {
-            "description": "ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
+            "description": "readOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
             "type": "boolean"
           }
         },
@@ -2031,16 +2031,16 @@
         "description": "Represents a volume that is populated with the contents of a git repository. Git repo volumes do not support ownership management. Git repo volumes support SELinux relabeling.\n\nDEPRECATED: GitRepo is deprecated. To provision a container with a git repo, mount an EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir into the Pod's container.",
         "properties": {
           "directory": {
-            "description": "Target directory name. Must not contain or start with '..'.  If '.' is supplied, the volume directory will be the git repository.  Otherwise, if specified, the volume will contain the git repository in the subdirectory with the given name.",
+            "description": "directory is the target directory name. Must not contain or start with '..'.  If '.' is supplied, the volume directory will be the git repository.  Otherwise, if specified, the volume will contain the git repository in the subdirectory with the given name.",
             "type": "string"
           },
           "repository": {
             "default": "",
-            "description": "Repository URL",
+            "description": "repository is the URL",
             "type": "string"
           },
           "revision": {
-            "description": "Commit hash for the specified revision.",
+            "description": "revision is the commit hash for the specified revision.",
             "type": "string"
           }
         },
@@ -2054,16 +2054,16 @@
         "properties": {
           "endpoints": {
             "default": "",
-            "description": "EndpointsName is the endpoint name that details Glusterfs topology. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod",
+            "description": "endpoints is the endpoint name that details Glusterfs topology. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod",
             "type": "string"
           },
           "path": {
             "default": "",
-            "description": "Path is the Glusterfs volume path. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod",
+            "description": "path is the Glusterfs volume path. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod",
             "type": "string"
           },
           "readOnly": {
-            "description": "ReadOnly here will force the Glusterfs volume to be mounted with read-only permissions. Defaults to false. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod",
+            "description": "readOnly here will force the Glusterfs volume to be mounted with read-only permissions. Defaults to false. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod",
             "type": "boolean"
           }
         },
@@ -2154,11 +2154,11 @@
         "properties": {
           "path": {
             "default": "",
-            "description": "Path of the directory on the host. If the path is a symlink, it will follow the link to the real path. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath",
+            "description": "path of the directory on the host. If the path is a symlink, it will follow the link to the real path. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath",
             "type": "string"
           },
           "type": {
-            "description": "Type for HostPath Volume Defaults to \"\" More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath",
+            "description": "type for HostPath Volume Defaults to \"\" More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath",
             "type": "string"
           }
         },
@@ -2171,38 +2171,38 @@
         "description": "Represents an ISCSI disk. ISCSI volumes can only be mounted as read/write once. ISCSI volumes support ownership management and SELinux relabeling.",
         "properties": {
           "chapAuthDiscovery": {
-            "description": "whether support iSCSI Discovery CHAP authentication",
+            "description": "chapAuthDiscovery defines whether support iSCSI Discovery CHAP authentication",
             "type": "boolean"
           },
           "chapAuthSession": {
-            "description": "whether support iSCSI Session CHAP authentication",
+            "description": "chapAuthSession defines whether support iSCSI Session CHAP authentication",
             "type": "boolean"
           },
           "fsType": {
-            "description": "Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi",
+            "description": "fsType is the filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi",
             "type": "string"
           },
           "initiatorName": {
-            "description": "Custom iSCSI Initiator Name. If initiatorName is specified with iscsiInterface simultaneously, new iSCSI interface <target portal>:<volume name> will be created for the connection.",
+            "description": "initiatorName is the custom iSCSI Initiator Name. If initiatorName is specified with iscsiInterface simultaneously, new iSCSI interface <target portal>:<volume name> will be created for the connection.",
             "type": "string"
           },
           "iqn": {
             "default": "",
-            "description": "Target iSCSI Qualified Name.",
+            "description": "iqn is the target iSCSI Qualified Name.",
             "type": "string"
           },
           "iscsiInterface": {
-            "description": "iSCSI Interface Name that uses an iSCSI transport. Defaults to 'default' (tcp).",
+            "description": "iscsiInterface is the interface Name that uses an iSCSI transport. Defaults to 'default' (tcp).",
             "type": "string"
           },
           "lun": {
             "default": 0,
-            "description": "iSCSI Target Lun number.",
+            "description": "lun represents iSCSI Target Lun number.",
             "format": "int32",
             "type": "integer"
           },
           "portals": {
-            "description": "iSCSI Target Portal List. The portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).",
+            "description": "portals is the iSCSI Target Portal List. The portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).",
             "items": {
               "default": "",
               "type": "string"
@@ -2210,16 +2210,16 @@
             "type": "array"
           },
           "readOnly": {
-            "description": "ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false.",
+            "description": "readOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false.",
             "type": "boolean"
           },
           "secretRef": {
             "$ref": "#/components/schemas/io.k8s.api.core.v1.LocalObjectReference",
-            "description": "CHAP Secret for iSCSI target and initiator authentication"
+            "description": "secretRef is the CHAP Secret for iSCSI target and initiator authentication"
           },
           "targetPortal": {
             "default": "",
-            "description": "iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).",
+            "description": "targetPortal is iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).",
             "type": "string"
           }
         },
@@ -2235,17 +2235,17 @@
         "properties": {
           "key": {
             "default": "",
-            "description": "The key to project.",
+            "description": "key is the key to project.",
             "type": "string"
           },
           "mode": {
-            "description": "Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+            "description": "mode is Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
             "format": "int32",
             "type": "integer"
           },
           "path": {
             "default": "",
-            "description": "The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.",
+            "description": "path is the relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.",
             "type": "string"
           }
         },
@@ -2303,16 +2303,16 @@
         "properties": {
           "path": {
             "default": "",
-            "description": "Path that is exported by the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
+            "description": "path that is exported by the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
             "type": "string"
           },
           "readOnly": {
-            "description": "ReadOnly here will force the NFS export to be mounted with read-only permissions. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
+            "description": "readOnly here will force the NFS export to be mounted with read-only permissions. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
             "type": "boolean"
           },
           "server": {
             "default": "",
-            "description": "Server is the hostname or IP address of the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
+            "description": "server is the hostname or IP address of the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
             "type": "string"
           }
         },
@@ -2650,12 +2650,12 @@
         "description": "Represents a Photon Controller persistent disk resource.",
         "properties": {
           "fsType": {
-            "description": "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+            "description": "fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
             "type": "string"
           },
           "pdID": {
             "default": "",
-            "description": "ID that identifies Photon Controller persistent disk",
+            "description": "pdID is the ID that identifies Photon Controller persistent disk",
             "type": "string"
           }
         },
@@ -3124,16 +3124,16 @@
         "description": "PortworxVolumeSource represents a Portworx volume resource.",
         "properties": {
           "fsType": {
-            "description": "FSType represents the filesystem type to mount Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+            "description": "fSType represents the filesystem type to mount Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\". Implicitly inferred to be \"ext4\" if unspecified.",
             "type": "string"
           },
           "readOnly": {
-            "description": "Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
+            "description": "readOnly defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
             "type": "boolean"
           },
           "volumeID": {
             "default": "",
-            "description": "VolumeID uniquely identifies a Portworx volume",
+            "description": "volumeID uniquely identifies a Portworx volume",
             "type": "string"
           }
         },
@@ -3219,12 +3219,12 @@
         "description": "Represents a projected volume source",
         "properties": {
           "defaultMode": {
-            "description": "Mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+            "description": "defaultMode are the mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
             "format": "int32",
             "type": "integer"
           },
           "sources": {
-            "description": "list of volume projections",
+            "description": "sources is the list of volume projections",
             "items": {
               "$ref": "#/components/schemas/io.k8s.api.core.v1.VolumeProjection",
               "default": {}
@@ -3238,29 +3238,29 @@
         "description": "Represents a Quobyte mount that lasts the lifetime of a pod. Quobyte volumes do not support ownership management or SELinux relabeling.",
         "properties": {
           "group": {
-            "description": "Group to map volume access to Default is no group",
+            "description": "group to map volume access to Default is no group",
             "type": "string"
           },
           "readOnly": {
-            "description": "ReadOnly here will force the Quobyte volume to be mounted with read-only permissions. Defaults to false.",
+            "description": "readOnly here will force the Quobyte volume to be mounted with read-only permissions. Defaults to false.",
             "type": "boolean"
           },
           "registry": {
             "default": "",
-            "description": "Registry represents a single or multiple Quobyte Registry services specified as a string as host:port pair (multiple entries are separated with commas) which acts as the central registry for volumes",
+            "description": "registry represents a single or multiple Quobyte Registry services specified as a string as host:port pair (multiple entries are separated with commas) which acts as the central registry for volumes",
             "type": "string"
           },
           "tenant": {
-            "description": "Tenant owning the given Quobyte volume in the Backend Used with dynamically provisioned Quobyte volumes, value is set by the plugin",
+            "description": "tenant owning the given Quobyte volume in the Backend Used with dynamically provisioned Quobyte volumes, value is set by the plugin",
             "type": "string"
           },
           "user": {
-            "description": "User to map volume access to Defaults to serivceaccount user",
+            "description": "user to map volume access to Defaults to serivceaccount user",
             "type": "string"
           },
           "volume": {
             "default": "",
-            "description": "Volume is a string that references an already created Quobyte volume by name.",
+            "description": "volume is a string that references an already created Quobyte volume by name.",
             "type": "string"
           }
         },
@@ -3274,20 +3274,20 @@
         "description": "Represents a Rados Block Device mount that lasts the lifetime of a pod. RBD volumes support ownership management and SELinux relabeling.",
         "properties": {
           "fsType": {
-            "description": "Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd",
+            "description": "fsType is the filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd",
             "type": "string"
           },
           "image": {
             "default": "",
-            "description": "The rados image name. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+            "description": "image is the rados image name. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
             "type": "string"
           },
           "keyring": {
-            "description": "Keyring is the path to key ring for RBDUser. Default is /etc/ceph/keyring. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+            "description": "keyring is the path to key ring for RBDUser. Default is /etc/ceph/keyring. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
             "type": "string"
           },
           "monitors": {
-            "description": "A collection of Ceph monitors. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+            "description": "monitors is a collection of Ceph monitors. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
             "items": {
               "default": "",
               "type": "string"
@@ -3295,19 +3295,19 @@
             "type": "array"
           },
           "pool": {
-            "description": "The rados pool name. Default is rbd. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+            "description": "pool is the rados pool name. Default is rbd. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
             "type": "string"
           },
           "readOnly": {
-            "description": "ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+            "description": "readOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
             "type": "boolean"
           },
           "secretRef": {
             "$ref": "#/components/schemas/io.k8s.api.core.v1.LocalObjectReference",
-            "description": "SecretRef is name of the authentication secret for RBDUser. If provided overrides keyring. Default is nil. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it"
+            "description": "secretRef is name of the authentication secret for RBDUser. If provided overrides keyring. Default is nil. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it"
           },
           "user": {
-            "description": "The rados user name. Default is admin. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+            "description": "user is the rados user name. Default is admin. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
             "type": "string"
           }
         },
@@ -3389,45 +3389,45 @@
         "description": "ScaleIOVolumeSource represents a persistent ScaleIO volume",
         "properties": {
           "fsType": {
-            "description": "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Default is \"xfs\".",
+            "description": "fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Default is \"xfs\".",
             "type": "string"
           },
           "gateway": {
             "default": "",
-            "description": "The host address of the ScaleIO API Gateway.",
+            "description": "gateway is the host address of the ScaleIO API Gateway.",
             "type": "string"
           },
           "protectionDomain": {
-            "description": "The name of the ScaleIO Protection Domain for the configured storage.",
+            "description": "protectionDomain is the name of the ScaleIO Protection Domain for the configured storage.",
             "type": "string"
           },
           "readOnly": {
-            "description": "Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
+            "description": "readOnly Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
             "type": "boolean"
           },
           "secretRef": {
             "$ref": "#/components/schemas/io.k8s.api.core.v1.LocalObjectReference",
-            "description": "SecretRef references to the secret for ScaleIO user and other sensitive information. If this is not provided, Login operation will fail."
+            "description": "secretRef references to the secret for ScaleIO user and other sensitive information. If this is not provided, Login operation will fail."
           },
           "sslEnabled": {
-            "description": "Flag to enable/disable SSL communication with Gateway, default false",
+            "description": "sslEnabled Flag enable/disable SSL communication with Gateway, default false",
             "type": "boolean"
           },
           "storageMode": {
-            "description": "Indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned. Default is ThinProvisioned.",
+            "description": "storageMode indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned. Default is ThinProvisioned.",
             "type": "string"
           },
           "storagePool": {
-            "description": "The ScaleIO Storage Pool associated with the protection domain.",
+            "description": "storagePool is the ScaleIO Storage Pool associated with the protection domain.",
             "type": "string"
           },
           "system": {
             "default": "",
-            "description": "The name of the storage system as configured in ScaleIO.",
+            "description": "system is the name of the storage system as configured in ScaleIO.",
             "type": "string"
           },
           "volumeName": {
-            "description": "The name of a volume already created in the ScaleIO system that is associated with this volume source.",
+            "description": "volumeName is the name of a volume already created in the ScaleIO system that is associated with this volume source.",
             "type": "string"
           }
         },
@@ -3510,7 +3510,7 @@
         "description": "Adapts a secret into a projected volume.\n\nThe contents of the target Secret's Data field will be presented in a projected volume as files using the keys in the Data field as the file names. Note that this is identical to a secret volume source without the default mode.",
         "properties": {
           "items": {
-            "description": "If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.",
+            "description": "items if unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.",
             "items": {
               "$ref": "#/components/schemas/io.k8s.api.core.v1.KeyToPath",
               "default": {}
@@ -3522,7 +3522,7 @@
             "type": "string"
           },
           "optional": {
-            "description": "Specify whether the Secret or its key must be defined",
+            "description": "optional field specify whether the Secret or its key must be defined",
             "type": "boolean"
           }
         },
@@ -3532,12 +3532,12 @@
         "description": "Adapts a Secret into a volume.\n\nThe contents of the target Secret's Data field will be presented in a volume as files using the keys in the Data field as the file names. Secret volumes support ownership management and SELinux relabeling.",
         "properties": {
           "defaultMode": {
-            "description": "Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+            "description": "defaultMode is Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
             "format": "int32",
             "type": "integer"
           },
           "items": {
-            "description": "If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.",
+            "description": "items If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.",
             "items": {
               "$ref": "#/components/schemas/io.k8s.api.core.v1.KeyToPath",
               "default": {}
@@ -3545,11 +3545,11 @@
             "type": "array"
           },
           "optional": {
-            "description": "Specify whether the Secret or its keys must be defined",
+            "description": "optional field specify whether the Secret or its keys must be defined",
             "type": "boolean"
           },
           "secretName": {
-            "description": "Name of the secret in the pod's namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret",
+            "description": "secretName is the name of the secret in the pod's namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret",
             "type": "string"
           }
         },
@@ -3611,17 +3611,17 @@
         "description": "ServiceAccountTokenProjection represents a projected service account token volume. This projection can be used to insert a service account token into the pods runtime filesystem for use against APIs (Kubernetes API Server or otherwise).",
         "properties": {
           "audience": {
-            "description": "Audience is the intended audience of the token. A recipient of a token must identify itself with an identifier specified in the audience of the token, and otherwise should reject the token. The audience defaults to the identifier of the apiserver.",
+            "description": "audience is the intended audience of the token. A recipient of a token must identify itself with an identifier specified in the audience of the token, and otherwise should reject the token. The audience defaults to the identifier of the apiserver.",
             "type": "string"
           },
           "expirationSeconds": {
-            "description": "ExpirationSeconds is the requested duration of validity of the service account token. As the token approaches expiration, the kubelet volume plugin will proactively rotate the service account token. The kubelet will start trying to rotate the token if the token is older than 80 percent of its time to live or if the token is older than 24 hours.Defaults to 1 hour and must be at least 10 minutes.",
+            "description": "expirationSeconds is the requested duration of validity of the service account token. As the token approaches expiration, the kubelet volume plugin will proactively rotate the service account token. The kubelet will start trying to rotate the token if the token is older than 80 percent of its time to live or if the token is older than 24 hours.Defaults to 1 hour and must be at least 10 minutes.",
             "format": "int64",
             "type": "integer"
           },
           "path": {
             "default": "",
-            "description": "Path is the path relative to the mount point of the file to project the token into.",
+            "description": "path is the path relative to the mount point of the file to project the token into.",
             "type": "string"
           }
         },
@@ -3634,23 +3634,23 @@
         "description": "Represents a StorageOS persistent volume resource.",
         "properties": {
           "fsType": {
-            "description": "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+            "description": "fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
             "type": "string"
           },
           "readOnly": {
-            "description": "Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
+            "description": "readOnly defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
             "type": "boolean"
           },
           "secretRef": {
             "$ref": "#/components/schemas/io.k8s.api.core.v1.LocalObjectReference",
-            "description": "SecretRef specifies the secret to use for obtaining the StorageOS API credentials.  If not specified, default values will be attempted."
+            "description": "secretRef specifies the secret to use for obtaining the StorageOS API credentials.  If not specified, default values will be attempted."
           },
           "volumeName": {
-            "description": "VolumeName is the human-readable name of the StorageOS volume.  Volume names are only unique within a namespace.",
+            "description": "volumeName is the human-readable name of the StorageOS volume.  Volume names are only unique within a namespace.",
             "type": "string"
           },
           "volumeNamespace": {
-            "description": "VolumeNamespace specifies the scope of the volume within StorageOS.  If no namespace is specified then the Pod's namespace will be used.  This allows the Kubernetes name scoping to be mirrored within StorageOS for tighter integration. Set VolumeName to any name to override the default behaviour. Set to \"default\" if you are not using namespaces within StorageOS. Namespaces that do not pre-exist within StorageOS will be created.",
+            "description": "volumeNamespace specifies the scope of the volume within StorageOS.  If no namespace is specified then the Pod's namespace will be used.  This allows the Kubernetes name scoping to be mirrored within StorageOS for tighter integration. Set VolumeName to any name to override the default behaviour. Set to \"default\" if you are not using namespaces within StorageOS. Namespaces that do not pre-exist within StorageOS will be created.",
             "type": "string"
           }
         },
@@ -3981,19 +3981,19 @@
         "properties": {
           "configMap": {
             "$ref": "#/components/schemas/io.k8s.api.core.v1.ConfigMapProjection",
-            "description": "information about the configMap data to project"
+            "description": "configMap information about the configMap data to project"
           },
           "downwardAPI": {
             "$ref": "#/components/schemas/io.k8s.api.core.v1.DownwardAPIProjection",
-            "description": "information about the downwardAPI data to project"
+            "description": "downwardAPI information about the downwardAPI data to project"
           },
           "secret": {
             "$ref": "#/components/schemas/io.k8s.api.core.v1.SecretProjection",
-            "description": "information about the secret data to project"
+            "description": "secret information about the secret data to project"
           },
           "serviceAccountToken": {
             "$ref": "#/components/schemas/io.k8s.api.core.v1.ServiceAccountTokenProjection",
-            "description": "information about the serviceAccountToken data to project"
+            "description": "serviceAccountToken is information about the serviceAccountToken data to project"
           }
         },
         "type": "object"
@@ -4002,20 +4002,20 @@
         "description": "Represents a vSphere volume resource.",
         "properties": {
           "fsType": {
-            "description": "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+            "description": "fsType is filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
             "type": "string"
           },
           "storagePolicyID": {
-            "description": "Storage Policy Based Management (SPBM) profile ID associated with the StoragePolicyName.",
+            "description": "storagePolicyID is the storage Policy Based Management (SPBM) profile ID associated with the StoragePolicyName.",
             "type": "string"
           },
           "storagePolicyName": {
-            "description": "Storage Policy Based Management (SPBM) profile name.",
+            "description": "storagePolicyName is the storage Policy Based Management (SPBM) profile name.",
             "type": "string"
           },
           "volumePath": {
             "default": "",
-            "description": "Path that identifies vSphere volume vmdk",
+            "description": "volumePath is the path that identifies vSphere volume vmdk",
             "type": "string"
           }
         },

--- a/api/openapi-spec/v3/apis__batch__v1_openapi.json
+++ b/api/openapi-spec/v3/apis__batch__v1_openapi.json
@@ -413,21 +413,21 @@
         "description": "Represents a Persistent Disk resource in AWS.\n\nAn AWS EBS disk must exist before mounting to a container. The disk must also be in the same AWS zone as the kubelet. An AWS EBS disk can only be mounted as read/write once. AWS EBS volumes support ownership management and SELinux relabeling.",
         "properties": {
           "fsType": {
-            "description": "Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore",
+            "description": "fsType is the filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore",
             "type": "string"
           },
           "partition": {
-            "description": "The partition in the volume that you want to mount. If omitted, the default is to mount by volume name. Examples: For volume /dev/sda1, you specify the partition as \"1\". Similarly, the volume partition for /dev/sda is \"0\" (or you can leave the property empty).",
+            "description": "partition is the partition in the volume that you want to mount. If omitted, the default is to mount by volume name. Examples: For volume /dev/sda1, you specify the partition as \"1\". Similarly, the volume partition for /dev/sda is \"0\" (or you can leave the property empty).",
             "format": "int32",
             "type": "integer"
           },
           "readOnly": {
-            "description": "Specify \"true\" to force and set the ReadOnly property in VolumeMounts to \"true\". If omitted, the default is \"false\". More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore",
+            "description": "readOnly value true will force the readOnly setting in VolumeMounts. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore",
             "type": "boolean"
           },
           "volumeID": {
             "default": "",
-            "description": "Unique ID of the persistent disk resource in AWS (Amazon EBS volume). More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore",
+            "description": "volumeID is unique ID of the persistent disk resource in AWS (Amazon EBS volume). More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore",
             "type": "string"
           }
         },
@@ -458,29 +458,29 @@
         "description": "AzureDisk represents an Azure Data Disk mount on the host and bind mount to the pod.",
         "properties": {
           "cachingMode": {
-            "description": "Host Caching mode: None, Read Only, Read Write.",
+            "description": "cachingMode is the Host Caching mode: None, Read Only, Read Write.",
             "type": "string"
           },
           "diskName": {
             "default": "",
-            "description": "The Name of the data disk in the blob storage",
+            "description": "diskName is the Name of the data disk in the blob storage",
             "type": "string"
           },
           "diskURI": {
             "default": "",
-            "description": "The URI the data disk in the blob storage",
+            "description": "diskURI is the URI of data disk in the blob storage",
             "type": "string"
           },
           "fsType": {
-            "description": "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+            "description": "fsType is Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
             "type": "string"
           },
           "kind": {
-            "description": "Expected values Shared: multiple blob disks per storage account  Dedicated: single blob disk per storage account  Managed: azure managed data disk (only in managed availability set). defaults to shared",
+            "description": "kind expected values are Shared: multiple blob disks per storage account  Dedicated: single blob disk per storage account  Managed: azure managed data disk (only in managed availability set). defaults to shared",
             "type": "string"
           },
           "readOnly": {
-            "description": "Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
+            "description": "readOnly Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
             "type": "boolean"
           }
         },
@@ -494,17 +494,17 @@
         "description": "AzureFile represents an Azure File Service mount on the host and bind mount to the pod.",
         "properties": {
           "readOnly": {
-            "description": "Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
+            "description": "readOnly defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
             "type": "boolean"
           },
           "secretName": {
             "default": "",
-            "description": "the name of secret that contains Azure Storage Account Name and Key",
+            "description": "secretName is the  name of secret that contains Azure Storage Account Name and Key",
             "type": "string"
           },
           "shareName": {
             "default": "",
-            "description": "Share Name",
+            "description": "shareName is the azure share Name",
             "type": "string"
           }
         },
@@ -574,7 +574,7 @@
         "description": "Represents a Ceph Filesystem mount that lasts the lifetime of a pod Cephfs volumes do not support ownership management or SELinux relabeling.",
         "properties": {
           "monitors": {
-            "description": "Required: Monitors is a collection of Ceph monitors More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
+            "description": "monitors is Required: Monitors is a collection of Ceph monitors More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
             "items": {
               "default": "",
               "type": "string"
@@ -582,23 +582,23 @@
             "type": "array"
           },
           "path": {
-            "description": "Optional: Used as the mounted root, rather than the full Ceph tree, default is /",
+            "description": "path is Optional: Used as the mounted root, rather than the full Ceph tree, default is /",
             "type": "string"
           },
           "readOnly": {
-            "description": "Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
+            "description": "readOnly is Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
             "type": "boolean"
           },
           "secretFile": {
-            "description": "Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
+            "description": "secretFile is Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
             "type": "string"
           },
           "secretRef": {
             "$ref": "#/components/schemas/io.k8s.api.core.v1.LocalObjectReference",
-            "description": "Optional: SecretRef is reference to the authentication secret for User, default is empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it"
+            "description": "secretRef is Optional: SecretRef is reference to the authentication secret for User, default is empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it"
           },
           "user": {
-            "description": "Optional: User is the rados user name, default is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
+            "description": "user is optional: User is the rados user name, default is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
             "type": "string"
           }
         },
@@ -611,20 +611,20 @@
         "description": "Represents a cinder volume resource in Openstack. A Cinder volume must exist before mounting to a container. The volume must also be in the same region as the kubelet. Cinder volumes support ownership management and SELinux relabeling.",
         "properties": {
           "fsType": {
-            "description": "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://examples.k8s.io/mysql-cinder-pd/README.md",
+            "description": "fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://examples.k8s.io/mysql-cinder-pd/README.md",
             "type": "string"
           },
           "readOnly": {
-            "description": "Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: https://examples.k8s.io/mysql-cinder-pd/README.md",
+            "description": "readOnly defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: https://examples.k8s.io/mysql-cinder-pd/README.md",
             "type": "boolean"
           },
           "secretRef": {
             "$ref": "#/components/schemas/io.k8s.api.core.v1.LocalObjectReference",
-            "description": "Optional: points to a secret object containing parameters used to connect to OpenStack."
+            "description": "secretRef is optional: points to a secret object containing parameters used to connect to OpenStack."
           },
           "volumeID": {
             "default": "",
-            "description": "volume id used to identify the volume in cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md",
+            "description": "volumeID used to identify the volume in cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md",
             "type": "string"
           }
         },
@@ -674,7 +674,7 @@
         "description": "Adapts a ConfigMap into a projected volume.\n\nThe contents of the target ConfigMap's Data field will be presented in a projected volume as files using the keys in the Data field as the file names, unless the items element is populated with specific mappings of keys to paths. Note that this is identical to a configmap volume source without the default mode.",
         "properties": {
           "items": {
-            "description": "If unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.",
+            "description": "items if unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.",
             "items": {
               "$ref": "#/components/schemas/io.k8s.api.core.v1.KeyToPath",
               "default": {}
@@ -686,7 +686,7 @@
             "type": "string"
           },
           "optional": {
-            "description": "Specify whether the ConfigMap or its keys must be defined",
+            "description": "optional specify whether the ConfigMap or its keys must be defined",
             "type": "boolean"
           }
         },
@@ -696,12 +696,12 @@
         "description": "Adapts a ConfigMap into a volume.\n\nThe contents of the target ConfigMap's Data field will be presented in a volume as files using the keys in the Data field as the file names, unless the items element is populated with specific mappings of keys to paths. ConfigMap volumes support ownership management and SELinux relabeling.",
         "properties": {
           "defaultMode": {
-            "description": "Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+            "description": "defaultMode is optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
             "format": "int32",
             "type": "integer"
           },
           "items": {
-            "description": "If unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.",
+            "description": "items if unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.",
             "items": {
               "$ref": "#/components/schemas/io.k8s.api.core.v1.KeyToPath",
               "default": {}
@@ -713,7 +713,7 @@
             "type": "string"
           },
           "optional": {
-            "description": "Specify whether the ConfigMap or its keys must be defined",
+            "description": "optional specify whether the ConfigMap or its keys must be defined",
             "type": "boolean"
           }
         },
@@ -970,12 +970,12 @@
         "description": "Represents an empty directory for a pod. Empty directory volumes support ownership management and SELinux relabeling.",
         "properties": {
           "medium": {
-            "description": "What type of storage medium should back this directory. The default is \"\" which means to use the node's default medium. Must be an empty string (default) or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir",
+            "description": "medium represents what type of storage medium should back this directory. The default is \"\" which means to use the node's default medium. Must be an empty string (default) or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir",
             "type": "string"
           },
           "sizeLimit": {
             "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.api.resource.Quantity",
-            "description": "Total amount of local storage required for this EmptyDir volume. The size limit is also applicable for memory medium. The maximum usage on memory medium EmptyDir would be the minimum value between the SizeLimit specified here and the sum of memory limits of all containers in a pod. The default is nil which means that the limit is undefined. More info: http://kubernetes.io/docs/user-guide/volumes#emptydir"
+            "description": "sizeLimit is the total amount of local storage required for this EmptyDir volume. The size limit is also applicable for memory medium. The maximum usage on memory medium EmptyDir would be the minimum value between the SizeLimit specified here and the sum of memory limits of all containers in a pod. The default is nil which means that the limit is undefined. More info: http://kubernetes.io/docs/user-guide/volumes#emptydir"
           }
         },
         "type": "object"
@@ -1223,20 +1223,20 @@
         "description": "Represents a Fibre Channel volume. Fibre Channel volumes can only be mounted as read/write once. Fibre Channel volumes support ownership management and SELinux relabeling.",
         "properties": {
           "fsType": {
-            "description": "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+            "description": "fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
             "type": "string"
           },
           "lun": {
-            "description": "Optional: FC target lun number",
+            "description": "lun is Optional: FC target lun number",
             "format": "int32",
             "type": "integer"
           },
           "readOnly": {
-            "description": "Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
+            "description": "readOnly is Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
             "type": "boolean"
           },
           "targetWWNs": {
-            "description": "Optional: FC target worldwide names (WWNs)",
+            "description": "targetWWNs is Optional: FC target worldwide names (WWNs)",
             "items": {
               "default": "",
               "type": "string"
@@ -1244,7 +1244,7 @@
             "type": "array"
           },
           "wwids": {
-            "description": "Optional: FC volume world wide identifiers (wwids) Either wwids or combination of targetWWNs and lun must be set, but not both simultaneously.",
+            "description": "wwids Optional: FC volume world wide identifiers (wwids) Either wwids or combination of targetWWNs and lun must be set, but not both simultaneously.",
             "items": {
               "default": "",
               "type": "string"
@@ -1259,11 +1259,11 @@
         "properties": {
           "driver": {
             "default": "",
-            "description": "Driver is the name of the driver to use for this volume.",
+            "description": "driver is the name of the driver to use for this volume.",
             "type": "string"
           },
           "fsType": {
-            "description": "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". The default filesystem depends on FlexVolume script.",
+            "description": "fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". The default filesystem depends on FlexVolume script.",
             "type": "string"
           },
           "options": {
@@ -1271,16 +1271,16 @@
               "default": "",
               "type": "string"
             },
-            "description": "Optional: Extra command options if any.",
+            "description": "options is Optional: this field holds extra command options if any.",
             "type": "object"
           },
           "readOnly": {
-            "description": "Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
+            "description": "readOnly is Optional: defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
             "type": "boolean"
           },
           "secretRef": {
             "$ref": "#/components/schemas/io.k8s.api.core.v1.LocalObjectReference",
-            "description": "Optional: SecretRef is reference to the secret object containing sensitive information to pass to the plugin scripts. This may be empty if no secret object is specified. If the secret object contains more than one secret, all secrets are passed to the plugin scripts."
+            "description": "secretRef is Optional: secretRef is reference to the secret object containing sensitive information to pass to the plugin scripts. This may be empty if no secret object is specified. If the secret object contains more than one secret, all secrets are passed to the plugin scripts."
           }
         },
         "required": [
@@ -1292,11 +1292,11 @@
         "description": "Represents a Flocker volume mounted by the Flocker agent. One and only one of datasetName and datasetUUID should be set. Flocker volumes do not support ownership management or SELinux relabeling.",
         "properties": {
           "datasetName": {
-            "description": "Name of the dataset stored as metadata -> name on the dataset for Flocker should be considered as deprecated",
+            "description": "datasetName is Name of the dataset stored as metadata -> name on the dataset for Flocker should be considered as deprecated",
             "type": "string"
           },
           "datasetUUID": {
-            "description": "UUID of the dataset. This is unique identifier of a Flocker dataset",
+            "description": "datasetUUID is the UUID of the dataset. This is unique identifier of a Flocker dataset",
             "type": "string"
           }
         },
@@ -1306,21 +1306,21 @@
         "description": "Represents a Persistent Disk resource in Google Compute Engine.\n\nA GCE PD must exist before mounting to a container. The disk must also be in the same GCE project and zone as the kubelet. A GCE PD can only be mounted as read/write once or read-only many times. GCE PDs support ownership management and SELinux relabeling.",
         "properties": {
           "fsType": {
-            "description": "Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
+            "description": "fsType is filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
             "type": "string"
           },
           "partition": {
-            "description": "The partition in the volume that you want to mount. If omitted, the default is to mount by volume name. Examples: For volume /dev/sda1, you specify the partition as \"1\". Similarly, the volume partition for /dev/sda is \"0\" (or you can leave the property empty). More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
+            "description": "partition is the partition in the volume that you want to mount. If omitted, the default is to mount by volume name. Examples: For volume /dev/sda1, you specify the partition as \"1\". Similarly, the volume partition for /dev/sda is \"0\" (or you can leave the property empty). More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
             "format": "int32",
             "type": "integer"
           },
           "pdName": {
             "default": "",
-            "description": "Unique name of the PD resource in GCE. Used to identify the disk in GCE. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
+            "description": "pdName is unique name of the PD resource in GCE. Used to identify the disk in GCE. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
             "type": "string"
           },
           "readOnly": {
-            "description": "ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
+            "description": "readOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
             "type": "boolean"
           }
         },
@@ -1352,16 +1352,16 @@
         "description": "Represents a volume that is populated with the contents of a git repository. Git repo volumes do not support ownership management. Git repo volumes support SELinux relabeling.\n\nDEPRECATED: GitRepo is deprecated. To provision a container with a git repo, mount an EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir into the Pod's container.",
         "properties": {
           "directory": {
-            "description": "Target directory name. Must not contain or start with '..'.  If '.' is supplied, the volume directory will be the git repository.  Otherwise, if specified, the volume will contain the git repository in the subdirectory with the given name.",
+            "description": "directory is the target directory name. Must not contain or start with '..'.  If '.' is supplied, the volume directory will be the git repository.  Otherwise, if specified, the volume will contain the git repository in the subdirectory with the given name.",
             "type": "string"
           },
           "repository": {
             "default": "",
-            "description": "Repository URL",
+            "description": "repository is the URL",
             "type": "string"
           },
           "revision": {
-            "description": "Commit hash for the specified revision.",
+            "description": "revision is the commit hash for the specified revision.",
             "type": "string"
           }
         },
@@ -1375,16 +1375,16 @@
         "properties": {
           "endpoints": {
             "default": "",
-            "description": "EndpointsName is the endpoint name that details Glusterfs topology. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod",
+            "description": "endpoints is the endpoint name that details Glusterfs topology. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod",
             "type": "string"
           },
           "path": {
             "default": "",
-            "description": "Path is the Glusterfs volume path. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod",
+            "description": "path is the Glusterfs volume path. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod",
             "type": "string"
           },
           "readOnly": {
-            "description": "ReadOnly here will force the Glusterfs volume to be mounted with read-only permissions. Defaults to false. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod",
+            "description": "readOnly here will force the Glusterfs volume to be mounted with read-only permissions. Defaults to false. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod",
             "type": "boolean"
           }
         },
@@ -1475,11 +1475,11 @@
         "properties": {
           "path": {
             "default": "",
-            "description": "Path of the directory on the host. If the path is a symlink, it will follow the link to the real path. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath",
+            "description": "path of the directory on the host. If the path is a symlink, it will follow the link to the real path. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath",
             "type": "string"
           },
           "type": {
-            "description": "Type for HostPath Volume Defaults to \"\" More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath",
+            "description": "type for HostPath Volume Defaults to \"\" More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath",
             "type": "string"
           }
         },
@@ -1492,38 +1492,38 @@
         "description": "Represents an ISCSI disk. ISCSI volumes can only be mounted as read/write once. ISCSI volumes support ownership management and SELinux relabeling.",
         "properties": {
           "chapAuthDiscovery": {
-            "description": "whether support iSCSI Discovery CHAP authentication",
+            "description": "chapAuthDiscovery defines whether support iSCSI Discovery CHAP authentication",
             "type": "boolean"
           },
           "chapAuthSession": {
-            "description": "whether support iSCSI Session CHAP authentication",
+            "description": "chapAuthSession defines whether support iSCSI Session CHAP authentication",
             "type": "boolean"
           },
           "fsType": {
-            "description": "Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi",
+            "description": "fsType is the filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi",
             "type": "string"
           },
           "initiatorName": {
-            "description": "Custom iSCSI Initiator Name. If initiatorName is specified with iscsiInterface simultaneously, new iSCSI interface <target portal>:<volume name> will be created for the connection.",
+            "description": "initiatorName is the custom iSCSI Initiator Name. If initiatorName is specified with iscsiInterface simultaneously, new iSCSI interface <target portal>:<volume name> will be created for the connection.",
             "type": "string"
           },
           "iqn": {
             "default": "",
-            "description": "Target iSCSI Qualified Name.",
+            "description": "iqn is the target iSCSI Qualified Name.",
             "type": "string"
           },
           "iscsiInterface": {
-            "description": "iSCSI Interface Name that uses an iSCSI transport. Defaults to 'default' (tcp).",
+            "description": "iscsiInterface is the interface Name that uses an iSCSI transport. Defaults to 'default' (tcp).",
             "type": "string"
           },
           "lun": {
             "default": 0,
-            "description": "iSCSI Target Lun number.",
+            "description": "lun represents iSCSI Target Lun number.",
             "format": "int32",
             "type": "integer"
           },
           "portals": {
-            "description": "iSCSI Target Portal List. The portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).",
+            "description": "portals is the iSCSI Target Portal List. The portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).",
             "items": {
               "default": "",
               "type": "string"
@@ -1531,16 +1531,16 @@
             "type": "array"
           },
           "readOnly": {
-            "description": "ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false.",
+            "description": "readOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false.",
             "type": "boolean"
           },
           "secretRef": {
             "$ref": "#/components/schemas/io.k8s.api.core.v1.LocalObjectReference",
-            "description": "CHAP Secret for iSCSI target and initiator authentication"
+            "description": "secretRef is the CHAP Secret for iSCSI target and initiator authentication"
           },
           "targetPortal": {
             "default": "",
-            "description": "iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).",
+            "description": "targetPortal is iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).",
             "type": "string"
           }
         },
@@ -1556,17 +1556,17 @@
         "properties": {
           "key": {
             "default": "",
-            "description": "The key to project.",
+            "description": "key is the key to project.",
             "type": "string"
           },
           "mode": {
-            "description": "Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+            "description": "mode is Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
             "format": "int32",
             "type": "integer"
           },
           "path": {
             "default": "",
-            "description": "The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.",
+            "description": "path is the relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.",
             "type": "string"
           }
         },
@@ -1624,16 +1624,16 @@
         "properties": {
           "path": {
             "default": "",
-            "description": "Path that is exported by the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
+            "description": "path that is exported by the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
             "type": "string"
           },
           "readOnly": {
-            "description": "ReadOnly here will force the NFS export to be mounted with read-only permissions. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
+            "description": "readOnly here will force the NFS export to be mounted with read-only permissions. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
             "type": "boolean"
           },
           "server": {
             "default": "",
-            "description": "Server is the hostname or IP address of the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
+            "description": "server is the hostname or IP address of the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
             "type": "string"
           }
         },
@@ -1876,12 +1876,12 @@
         "description": "Represents a Photon Controller persistent disk resource.",
         "properties": {
           "fsType": {
-            "description": "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+            "description": "fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
             "type": "string"
           },
           "pdID": {
             "default": "",
-            "description": "ID that identifies Photon Controller persistent disk",
+            "description": "pdID is the ID that identifies Photon Controller persistent disk",
             "type": "string"
           }
         },
@@ -2350,16 +2350,16 @@
         "description": "PortworxVolumeSource represents a Portworx volume resource.",
         "properties": {
           "fsType": {
-            "description": "FSType represents the filesystem type to mount Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+            "description": "fSType represents the filesystem type to mount Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\". Implicitly inferred to be \"ext4\" if unspecified.",
             "type": "string"
           },
           "readOnly": {
-            "description": "Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
+            "description": "readOnly defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
             "type": "boolean"
           },
           "volumeID": {
             "default": "",
-            "description": "VolumeID uniquely identifies a Portworx volume",
+            "description": "volumeID uniquely identifies a Portworx volume",
             "type": "string"
           }
         },
@@ -2445,12 +2445,12 @@
         "description": "Represents a projected volume source",
         "properties": {
           "defaultMode": {
-            "description": "Mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+            "description": "defaultMode are the mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
             "format": "int32",
             "type": "integer"
           },
           "sources": {
-            "description": "list of volume projections",
+            "description": "sources is the list of volume projections",
             "items": {
               "$ref": "#/components/schemas/io.k8s.api.core.v1.VolumeProjection",
               "default": {}
@@ -2464,29 +2464,29 @@
         "description": "Represents a Quobyte mount that lasts the lifetime of a pod. Quobyte volumes do not support ownership management or SELinux relabeling.",
         "properties": {
           "group": {
-            "description": "Group to map volume access to Default is no group",
+            "description": "group to map volume access to Default is no group",
             "type": "string"
           },
           "readOnly": {
-            "description": "ReadOnly here will force the Quobyte volume to be mounted with read-only permissions. Defaults to false.",
+            "description": "readOnly here will force the Quobyte volume to be mounted with read-only permissions. Defaults to false.",
             "type": "boolean"
           },
           "registry": {
             "default": "",
-            "description": "Registry represents a single or multiple Quobyte Registry services specified as a string as host:port pair (multiple entries are separated with commas) which acts as the central registry for volumes",
+            "description": "registry represents a single or multiple Quobyte Registry services specified as a string as host:port pair (multiple entries are separated with commas) which acts as the central registry for volumes",
             "type": "string"
           },
           "tenant": {
-            "description": "Tenant owning the given Quobyte volume in the Backend Used with dynamically provisioned Quobyte volumes, value is set by the plugin",
+            "description": "tenant owning the given Quobyte volume in the Backend Used with dynamically provisioned Quobyte volumes, value is set by the plugin",
             "type": "string"
           },
           "user": {
-            "description": "User to map volume access to Defaults to serivceaccount user",
+            "description": "user to map volume access to Defaults to serivceaccount user",
             "type": "string"
           },
           "volume": {
             "default": "",
-            "description": "Volume is a string that references an already created Quobyte volume by name.",
+            "description": "volume is a string that references an already created Quobyte volume by name.",
             "type": "string"
           }
         },
@@ -2500,20 +2500,20 @@
         "description": "Represents a Rados Block Device mount that lasts the lifetime of a pod. RBD volumes support ownership management and SELinux relabeling.",
         "properties": {
           "fsType": {
-            "description": "Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd",
+            "description": "fsType is the filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd",
             "type": "string"
           },
           "image": {
             "default": "",
-            "description": "The rados image name. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+            "description": "image is the rados image name. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
             "type": "string"
           },
           "keyring": {
-            "description": "Keyring is the path to key ring for RBDUser. Default is /etc/ceph/keyring. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+            "description": "keyring is the path to key ring for RBDUser. Default is /etc/ceph/keyring. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
             "type": "string"
           },
           "monitors": {
-            "description": "A collection of Ceph monitors. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+            "description": "monitors is a collection of Ceph monitors. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
             "items": {
               "default": "",
               "type": "string"
@@ -2521,19 +2521,19 @@
             "type": "array"
           },
           "pool": {
-            "description": "The rados pool name. Default is rbd. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+            "description": "pool is the rados pool name. Default is rbd. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
             "type": "string"
           },
           "readOnly": {
-            "description": "ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+            "description": "readOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
             "type": "boolean"
           },
           "secretRef": {
             "$ref": "#/components/schemas/io.k8s.api.core.v1.LocalObjectReference",
-            "description": "SecretRef is name of the authentication secret for RBDUser. If provided overrides keyring. Default is nil. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it"
+            "description": "secretRef is name of the authentication secret for RBDUser. If provided overrides keyring. Default is nil. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it"
           },
           "user": {
-            "description": "The rados user name. Default is admin. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+            "description": "user is the rados user name. Default is admin. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
             "type": "string"
           }
         },
@@ -2615,45 +2615,45 @@
         "description": "ScaleIOVolumeSource represents a persistent ScaleIO volume",
         "properties": {
           "fsType": {
-            "description": "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Default is \"xfs\".",
+            "description": "fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Default is \"xfs\".",
             "type": "string"
           },
           "gateway": {
             "default": "",
-            "description": "The host address of the ScaleIO API Gateway.",
+            "description": "gateway is the host address of the ScaleIO API Gateway.",
             "type": "string"
           },
           "protectionDomain": {
-            "description": "The name of the ScaleIO Protection Domain for the configured storage.",
+            "description": "protectionDomain is the name of the ScaleIO Protection Domain for the configured storage.",
             "type": "string"
           },
           "readOnly": {
-            "description": "Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
+            "description": "readOnly Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
             "type": "boolean"
           },
           "secretRef": {
             "$ref": "#/components/schemas/io.k8s.api.core.v1.LocalObjectReference",
-            "description": "SecretRef references to the secret for ScaleIO user and other sensitive information. If this is not provided, Login operation will fail."
+            "description": "secretRef references to the secret for ScaleIO user and other sensitive information. If this is not provided, Login operation will fail."
           },
           "sslEnabled": {
-            "description": "Flag to enable/disable SSL communication with Gateway, default false",
+            "description": "sslEnabled Flag enable/disable SSL communication with Gateway, default false",
             "type": "boolean"
           },
           "storageMode": {
-            "description": "Indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned. Default is ThinProvisioned.",
+            "description": "storageMode indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned. Default is ThinProvisioned.",
             "type": "string"
           },
           "storagePool": {
-            "description": "The ScaleIO Storage Pool associated with the protection domain.",
+            "description": "storagePool is the ScaleIO Storage Pool associated with the protection domain.",
             "type": "string"
           },
           "system": {
             "default": "",
-            "description": "The name of the storage system as configured in ScaleIO.",
+            "description": "system is the name of the storage system as configured in ScaleIO.",
             "type": "string"
           },
           "volumeName": {
-            "description": "The name of a volume already created in the ScaleIO system that is associated with this volume source.",
+            "description": "volumeName is the name of a volume already created in the ScaleIO system that is associated with this volume source.",
             "type": "string"
           }
         },
@@ -2736,7 +2736,7 @@
         "description": "Adapts a secret into a projected volume.\n\nThe contents of the target Secret's Data field will be presented in a projected volume as files using the keys in the Data field as the file names. Note that this is identical to a secret volume source without the default mode.",
         "properties": {
           "items": {
-            "description": "If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.",
+            "description": "items if unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.",
             "items": {
               "$ref": "#/components/schemas/io.k8s.api.core.v1.KeyToPath",
               "default": {}
@@ -2748,7 +2748,7 @@
             "type": "string"
           },
           "optional": {
-            "description": "Specify whether the Secret or its key must be defined",
+            "description": "optional field specify whether the Secret or its key must be defined",
             "type": "boolean"
           }
         },
@@ -2758,12 +2758,12 @@
         "description": "Adapts a Secret into a volume.\n\nThe contents of the target Secret's Data field will be presented in a volume as files using the keys in the Data field as the file names. Secret volumes support ownership management and SELinux relabeling.",
         "properties": {
           "defaultMode": {
-            "description": "Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+            "description": "defaultMode is Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
             "format": "int32",
             "type": "integer"
           },
           "items": {
-            "description": "If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.",
+            "description": "items If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.",
             "items": {
               "$ref": "#/components/schemas/io.k8s.api.core.v1.KeyToPath",
               "default": {}
@@ -2771,11 +2771,11 @@
             "type": "array"
           },
           "optional": {
-            "description": "Specify whether the Secret or its keys must be defined",
+            "description": "optional field specify whether the Secret or its keys must be defined",
             "type": "boolean"
           },
           "secretName": {
-            "description": "Name of the secret in the pod's namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret",
+            "description": "secretName is the name of the secret in the pod's namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret",
             "type": "string"
           }
         },
@@ -2837,17 +2837,17 @@
         "description": "ServiceAccountTokenProjection represents a projected service account token volume. This projection can be used to insert a service account token into the pods runtime filesystem for use against APIs (Kubernetes API Server or otherwise).",
         "properties": {
           "audience": {
-            "description": "Audience is the intended audience of the token. A recipient of a token must identify itself with an identifier specified in the audience of the token, and otherwise should reject the token. The audience defaults to the identifier of the apiserver.",
+            "description": "audience is the intended audience of the token. A recipient of a token must identify itself with an identifier specified in the audience of the token, and otherwise should reject the token. The audience defaults to the identifier of the apiserver.",
             "type": "string"
           },
           "expirationSeconds": {
-            "description": "ExpirationSeconds is the requested duration of validity of the service account token. As the token approaches expiration, the kubelet volume plugin will proactively rotate the service account token. The kubelet will start trying to rotate the token if the token is older than 80 percent of its time to live or if the token is older than 24 hours.Defaults to 1 hour and must be at least 10 minutes.",
+            "description": "expirationSeconds is the requested duration of validity of the service account token. As the token approaches expiration, the kubelet volume plugin will proactively rotate the service account token. The kubelet will start trying to rotate the token if the token is older than 80 percent of its time to live or if the token is older than 24 hours.Defaults to 1 hour and must be at least 10 minutes.",
             "format": "int64",
             "type": "integer"
           },
           "path": {
             "default": "",
-            "description": "Path is the path relative to the mount point of the file to project the token into.",
+            "description": "path is the path relative to the mount point of the file to project the token into.",
             "type": "string"
           }
         },
@@ -2860,23 +2860,23 @@
         "description": "Represents a StorageOS persistent volume resource.",
         "properties": {
           "fsType": {
-            "description": "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+            "description": "fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
             "type": "string"
           },
           "readOnly": {
-            "description": "Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
+            "description": "readOnly defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
             "type": "boolean"
           },
           "secretRef": {
             "$ref": "#/components/schemas/io.k8s.api.core.v1.LocalObjectReference",
-            "description": "SecretRef specifies the secret to use for obtaining the StorageOS API credentials.  If not specified, default values will be attempted."
+            "description": "secretRef specifies the secret to use for obtaining the StorageOS API credentials.  If not specified, default values will be attempted."
           },
           "volumeName": {
-            "description": "VolumeName is the human-readable name of the StorageOS volume.  Volume names are only unique within a namespace.",
+            "description": "volumeName is the human-readable name of the StorageOS volume.  Volume names are only unique within a namespace.",
             "type": "string"
           },
           "volumeNamespace": {
-            "description": "VolumeNamespace specifies the scope of the volume within StorageOS.  If no namespace is specified then the Pod's namespace will be used.  This allows the Kubernetes name scoping to be mirrored within StorageOS for tighter integration. Set VolumeName to any name to override the default behaviour. Set to \"default\" if you are not using namespaces within StorageOS. Namespaces that do not pre-exist within StorageOS will be created.",
+            "description": "volumeNamespace specifies the scope of the volume within StorageOS.  If no namespace is specified then the Pod's namespace will be used.  This allows the Kubernetes name scoping to be mirrored within StorageOS for tighter integration. Set VolumeName to any name to override the default behaviour. Set to \"default\" if you are not using namespaces within StorageOS. Namespaces that do not pre-exist within StorageOS will be created.",
             "type": "string"
           }
         },
@@ -3207,19 +3207,19 @@
         "properties": {
           "configMap": {
             "$ref": "#/components/schemas/io.k8s.api.core.v1.ConfigMapProjection",
-            "description": "information about the configMap data to project"
+            "description": "configMap information about the configMap data to project"
           },
           "downwardAPI": {
             "$ref": "#/components/schemas/io.k8s.api.core.v1.DownwardAPIProjection",
-            "description": "information about the downwardAPI data to project"
+            "description": "downwardAPI information about the downwardAPI data to project"
           },
           "secret": {
             "$ref": "#/components/schemas/io.k8s.api.core.v1.SecretProjection",
-            "description": "information about the secret data to project"
+            "description": "secret information about the secret data to project"
           },
           "serviceAccountToken": {
             "$ref": "#/components/schemas/io.k8s.api.core.v1.ServiceAccountTokenProjection",
-            "description": "information about the serviceAccountToken data to project"
+            "description": "serviceAccountToken is information about the serviceAccountToken data to project"
           }
         },
         "type": "object"
@@ -3228,20 +3228,20 @@
         "description": "Represents a vSphere volume resource.",
         "properties": {
           "fsType": {
-            "description": "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+            "description": "fsType is filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
             "type": "string"
           },
           "storagePolicyID": {
-            "description": "Storage Policy Based Management (SPBM) profile ID associated with the StoragePolicyName.",
+            "description": "storagePolicyID is the storage Policy Based Management (SPBM) profile ID associated with the StoragePolicyName.",
             "type": "string"
           },
           "storagePolicyName": {
-            "description": "Storage Policy Based Management (SPBM) profile name.",
+            "description": "storagePolicyName is the storage Policy Based Management (SPBM) profile name.",
             "type": "string"
           },
           "volumePath": {
             "default": "",
-            "description": "Path that identifies vSphere volume vmdk",
+            "description": "volumePath is the path that identifies vSphere volume vmdk",
             "type": "string"
           }
         },

--- a/api/openapi-spec/v3/apis__batch__v1beta1_openapi.json
+++ b/api/openapi-spec/v3/apis__batch__v1beta1_openapi.json
@@ -215,21 +215,21 @@
         "description": "Represents a Persistent Disk resource in AWS.\n\nAn AWS EBS disk must exist before mounting to a container. The disk must also be in the same AWS zone as the kubelet. An AWS EBS disk can only be mounted as read/write once. AWS EBS volumes support ownership management and SELinux relabeling.",
         "properties": {
           "fsType": {
-            "description": "Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore",
+            "description": "fsType is the filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore",
             "type": "string"
           },
           "partition": {
-            "description": "The partition in the volume that you want to mount. If omitted, the default is to mount by volume name. Examples: For volume /dev/sda1, you specify the partition as \"1\". Similarly, the volume partition for /dev/sda is \"0\" (or you can leave the property empty).",
+            "description": "partition is the partition in the volume that you want to mount. If omitted, the default is to mount by volume name. Examples: For volume /dev/sda1, you specify the partition as \"1\". Similarly, the volume partition for /dev/sda is \"0\" (or you can leave the property empty).",
             "format": "int32",
             "type": "integer"
           },
           "readOnly": {
-            "description": "Specify \"true\" to force and set the ReadOnly property in VolumeMounts to \"true\". If omitted, the default is \"false\". More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore",
+            "description": "readOnly value true will force the readOnly setting in VolumeMounts. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore",
             "type": "boolean"
           },
           "volumeID": {
             "default": "",
-            "description": "Unique ID of the persistent disk resource in AWS (Amazon EBS volume). More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore",
+            "description": "volumeID is unique ID of the persistent disk resource in AWS (Amazon EBS volume). More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore",
             "type": "string"
           }
         },
@@ -260,29 +260,29 @@
         "description": "AzureDisk represents an Azure Data Disk mount on the host and bind mount to the pod.",
         "properties": {
           "cachingMode": {
-            "description": "Host Caching mode: None, Read Only, Read Write.",
+            "description": "cachingMode is the Host Caching mode: None, Read Only, Read Write.",
             "type": "string"
           },
           "diskName": {
             "default": "",
-            "description": "The Name of the data disk in the blob storage",
+            "description": "diskName is the Name of the data disk in the blob storage",
             "type": "string"
           },
           "diskURI": {
             "default": "",
-            "description": "The URI the data disk in the blob storage",
+            "description": "diskURI is the URI of data disk in the blob storage",
             "type": "string"
           },
           "fsType": {
-            "description": "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+            "description": "fsType is Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
             "type": "string"
           },
           "kind": {
-            "description": "Expected values Shared: multiple blob disks per storage account  Dedicated: single blob disk per storage account  Managed: azure managed data disk (only in managed availability set). defaults to shared",
+            "description": "kind expected values are Shared: multiple blob disks per storage account  Dedicated: single blob disk per storage account  Managed: azure managed data disk (only in managed availability set). defaults to shared",
             "type": "string"
           },
           "readOnly": {
-            "description": "Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
+            "description": "readOnly Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
             "type": "boolean"
           }
         },
@@ -296,17 +296,17 @@
         "description": "AzureFile represents an Azure File Service mount on the host and bind mount to the pod.",
         "properties": {
           "readOnly": {
-            "description": "Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
+            "description": "readOnly defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
             "type": "boolean"
           },
           "secretName": {
             "default": "",
-            "description": "the name of secret that contains Azure Storage Account Name and Key",
+            "description": "secretName is the  name of secret that contains Azure Storage Account Name and Key",
             "type": "string"
           },
           "shareName": {
             "default": "",
-            "description": "Share Name",
+            "description": "shareName is the azure share Name",
             "type": "string"
           }
         },
@@ -376,7 +376,7 @@
         "description": "Represents a Ceph Filesystem mount that lasts the lifetime of a pod Cephfs volumes do not support ownership management or SELinux relabeling.",
         "properties": {
           "monitors": {
-            "description": "Required: Monitors is a collection of Ceph monitors More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
+            "description": "monitors is Required: Monitors is a collection of Ceph monitors More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
             "items": {
               "default": "",
               "type": "string"
@@ -384,23 +384,23 @@
             "type": "array"
           },
           "path": {
-            "description": "Optional: Used as the mounted root, rather than the full Ceph tree, default is /",
+            "description": "path is Optional: Used as the mounted root, rather than the full Ceph tree, default is /",
             "type": "string"
           },
           "readOnly": {
-            "description": "Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
+            "description": "readOnly is Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
             "type": "boolean"
           },
           "secretFile": {
-            "description": "Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
+            "description": "secretFile is Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
             "type": "string"
           },
           "secretRef": {
             "$ref": "#/components/schemas/io.k8s.api.core.v1.LocalObjectReference",
-            "description": "Optional: SecretRef is reference to the authentication secret for User, default is empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it"
+            "description": "secretRef is Optional: SecretRef is reference to the authentication secret for User, default is empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it"
           },
           "user": {
-            "description": "Optional: User is the rados user name, default is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
+            "description": "user is optional: User is the rados user name, default is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
             "type": "string"
           }
         },
@@ -413,20 +413,20 @@
         "description": "Represents a cinder volume resource in Openstack. A Cinder volume must exist before mounting to a container. The volume must also be in the same region as the kubelet. Cinder volumes support ownership management and SELinux relabeling.",
         "properties": {
           "fsType": {
-            "description": "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://examples.k8s.io/mysql-cinder-pd/README.md",
+            "description": "fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://examples.k8s.io/mysql-cinder-pd/README.md",
             "type": "string"
           },
           "readOnly": {
-            "description": "Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: https://examples.k8s.io/mysql-cinder-pd/README.md",
+            "description": "readOnly defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: https://examples.k8s.io/mysql-cinder-pd/README.md",
             "type": "boolean"
           },
           "secretRef": {
             "$ref": "#/components/schemas/io.k8s.api.core.v1.LocalObjectReference",
-            "description": "Optional: points to a secret object containing parameters used to connect to OpenStack."
+            "description": "secretRef is optional: points to a secret object containing parameters used to connect to OpenStack."
           },
           "volumeID": {
             "default": "",
-            "description": "volume id used to identify the volume in cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md",
+            "description": "volumeID used to identify the volume in cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md",
             "type": "string"
           }
         },
@@ -476,7 +476,7 @@
         "description": "Adapts a ConfigMap into a projected volume.\n\nThe contents of the target ConfigMap's Data field will be presented in a projected volume as files using the keys in the Data field as the file names, unless the items element is populated with specific mappings of keys to paths. Note that this is identical to a configmap volume source without the default mode.",
         "properties": {
           "items": {
-            "description": "If unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.",
+            "description": "items if unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.",
             "items": {
               "$ref": "#/components/schemas/io.k8s.api.core.v1.KeyToPath",
               "default": {}
@@ -488,7 +488,7 @@
             "type": "string"
           },
           "optional": {
-            "description": "Specify whether the ConfigMap or its keys must be defined",
+            "description": "optional specify whether the ConfigMap or its keys must be defined",
             "type": "boolean"
           }
         },
@@ -498,12 +498,12 @@
         "description": "Adapts a ConfigMap into a volume.\n\nThe contents of the target ConfigMap's Data field will be presented in a volume as files using the keys in the Data field as the file names, unless the items element is populated with specific mappings of keys to paths. ConfigMap volumes support ownership management and SELinux relabeling.",
         "properties": {
           "defaultMode": {
-            "description": "Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+            "description": "defaultMode is optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
             "format": "int32",
             "type": "integer"
           },
           "items": {
-            "description": "If unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.",
+            "description": "items if unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.",
             "items": {
               "$ref": "#/components/schemas/io.k8s.api.core.v1.KeyToPath",
               "default": {}
@@ -515,7 +515,7 @@
             "type": "string"
           },
           "optional": {
-            "description": "Specify whether the ConfigMap or its keys must be defined",
+            "description": "optional specify whether the ConfigMap or its keys must be defined",
             "type": "boolean"
           }
         },
@@ -772,12 +772,12 @@
         "description": "Represents an empty directory for a pod. Empty directory volumes support ownership management and SELinux relabeling.",
         "properties": {
           "medium": {
-            "description": "What type of storage medium should back this directory. The default is \"\" which means to use the node's default medium. Must be an empty string (default) or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir",
+            "description": "medium represents what type of storage medium should back this directory. The default is \"\" which means to use the node's default medium. Must be an empty string (default) or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir",
             "type": "string"
           },
           "sizeLimit": {
             "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.api.resource.Quantity",
-            "description": "Total amount of local storage required for this EmptyDir volume. The size limit is also applicable for memory medium. The maximum usage on memory medium EmptyDir would be the minimum value between the SizeLimit specified here and the sum of memory limits of all containers in a pod. The default is nil which means that the limit is undefined. More info: http://kubernetes.io/docs/user-guide/volumes#emptydir"
+            "description": "sizeLimit is the total amount of local storage required for this EmptyDir volume. The size limit is also applicable for memory medium. The maximum usage on memory medium EmptyDir would be the minimum value between the SizeLimit specified here and the sum of memory limits of all containers in a pod. The default is nil which means that the limit is undefined. More info: http://kubernetes.io/docs/user-guide/volumes#emptydir"
           }
         },
         "type": "object"
@@ -1025,20 +1025,20 @@
         "description": "Represents a Fibre Channel volume. Fibre Channel volumes can only be mounted as read/write once. Fibre Channel volumes support ownership management and SELinux relabeling.",
         "properties": {
           "fsType": {
-            "description": "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+            "description": "fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
             "type": "string"
           },
           "lun": {
-            "description": "Optional: FC target lun number",
+            "description": "lun is Optional: FC target lun number",
             "format": "int32",
             "type": "integer"
           },
           "readOnly": {
-            "description": "Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
+            "description": "readOnly is Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
             "type": "boolean"
           },
           "targetWWNs": {
-            "description": "Optional: FC target worldwide names (WWNs)",
+            "description": "targetWWNs is Optional: FC target worldwide names (WWNs)",
             "items": {
               "default": "",
               "type": "string"
@@ -1046,7 +1046,7 @@
             "type": "array"
           },
           "wwids": {
-            "description": "Optional: FC volume world wide identifiers (wwids) Either wwids or combination of targetWWNs and lun must be set, but not both simultaneously.",
+            "description": "wwids Optional: FC volume world wide identifiers (wwids) Either wwids or combination of targetWWNs and lun must be set, but not both simultaneously.",
             "items": {
               "default": "",
               "type": "string"
@@ -1061,11 +1061,11 @@
         "properties": {
           "driver": {
             "default": "",
-            "description": "Driver is the name of the driver to use for this volume.",
+            "description": "driver is the name of the driver to use for this volume.",
             "type": "string"
           },
           "fsType": {
-            "description": "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". The default filesystem depends on FlexVolume script.",
+            "description": "fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". The default filesystem depends on FlexVolume script.",
             "type": "string"
           },
           "options": {
@@ -1073,16 +1073,16 @@
               "default": "",
               "type": "string"
             },
-            "description": "Optional: Extra command options if any.",
+            "description": "options is Optional: this field holds extra command options if any.",
             "type": "object"
           },
           "readOnly": {
-            "description": "Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
+            "description": "readOnly is Optional: defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
             "type": "boolean"
           },
           "secretRef": {
             "$ref": "#/components/schemas/io.k8s.api.core.v1.LocalObjectReference",
-            "description": "Optional: SecretRef is reference to the secret object containing sensitive information to pass to the plugin scripts. This may be empty if no secret object is specified. If the secret object contains more than one secret, all secrets are passed to the plugin scripts."
+            "description": "secretRef is Optional: secretRef is reference to the secret object containing sensitive information to pass to the plugin scripts. This may be empty if no secret object is specified. If the secret object contains more than one secret, all secrets are passed to the plugin scripts."
           }
         },
         "required": [
@@ -1094,11 +1094,11 @@
         "description": "Represents a Flocker volume mounted by the Flocker agent. One and only one of datasetName and datasetUUID should be set. Flocker volumes do not support ownership management or SELinux relabeling.",
         "properties": {
           "datasetName": {
-            "description": "Name of the dataset stored as metadata -> name on the dataset for Flocker should be considered as deprecated",
+            "description": "datasetName is Name of the dataset stored as metadata -> name on the dataset for Flocker should be considered as deprecated",
             "type": "string"
           },
           "datasetUUID": {
-            "description": "UUID of the dataset. This is unique identifier of a Flocker dataset",
+            "description": "datasetUUID is the UUID of the dataset. This is unique identifier of a Flocker dataset",
             "type": "string"
           }
         },
@@ -1108,21 +1108,21 @@
         "description": "Represents a Persistent Disk resource in Google Compute Engine.\n\nA GCE PD must exist before mounting to a container. The disk must also be in the same GCE project and zone as the kubelet. A GCE PD can only be mounted as read/write once or read-only many times. GCE PDs support ownership management and SELinux relabeling.",
         "properties": {
           "fsType": {
-            "description": "Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
+            "description": "fsType is filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
             "type": "string"
           },
           "partition": {
-            "description": "The partition in the volume that you want to mount. If omitted, the default is to mount by volume name. Examples: For volume /dev/sda1, you specify the partition as \"1\". Similarly, the volume partition for /dev/sda is \"0\" (or you can leave the property empty). More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
+            "description": "partition is the partition in the volume that you want to mount. If omitted, the default is to mount by volume name. Examples: For volume /dev/sda1, you specify the partition as \"1\". Similarly, the volume partition for /dev/sda is \"0\" (or you can leave the property empty). More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
             "format": "int32",
             "type": "integer"
           },
           "pdName": {
             "default": "",
-            "description": "Unique name of the PD resource in GCE. Used to identify the disk in GCE. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
+            "description": "pdName is unique name of the PD resource in GCE. Used to identify the disk in GCE. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
             "type": "string"
           },
           "readOnly": {
-            "description": "ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
+            "description": "readOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
             "type": "boolean"
           }
         },
@@ -1154,16 +1154,16 @@
         "description": "Represents a volume that is populated with the contents of a git repository. Git repo volumes do not support ownership management. Git repo volumes support SELinux relabeling.\n\nDEPRECATED: GitRepo is deprecated. To provision a container with a git repo, mount an EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir into the Pod's container.",
         "properties": {
           "directory": {
-            "description": "Target directory name. Must not contain or start with '..'.  If '.' is supplied, the volume directory will be the git repository.  Otherwise, if specified, the volume will contain the git repository in the subdirectory with the given name.",
+            "description": "directory is the target directory name. Must not contain or start with '..'.  If '.' is supplied, the volume directory will be the git repository.  Otherwise, if specified, the volume will contain the git repository in the subdirectory with the given name.",
             "type": "string"
           },
           "repository": {
             "default": "",
-            "description": "Repository URL",
+            "description": "repository is the URL",
             "type": "string"
           },
           "revision": {
-            "description": "Commit hash for the specified revision.",
+            "description": "revision is the commit hash for the specified revision.",
             "type": "string"
           }
         },
@@ -1177,16 +1177,16 @@
         "properties": {
           "endpoints": {
             "default": "",
-            "description": "EndpointsName is the endpoint name that details Glusterfs topology. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod",
+            "description": "endpoints is the endpoint name that details Glusterfs topology. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod",
             "type": "string"
           },
           "path": {
             "default": "",
-            "description": "Path is the Glusterfs volume path. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod",
+            "description": "path is the Glusterfs volume path. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod",
             "type": "string"
           },
           "readOnly": {
-            "description": "ReadOnly here will force the Glusterfs volume to be mounted with read-only permissions. Defaults to false. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod",
+            "description": "readOnly here will force the Glusterfs volume to be mounted with read-only permissions. Defaults to false. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod",
             "type": "boolean"
           }
         },
@@ -1277,11 +1277,11 @@
         "properties": {
           "path": {
             "default": "",
-            "description": "Path of the directory on the host. If the path is a symlink, it will follow the link to the real path. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath",
+            "description": "path of the directory on the host. If the path is a symlink, it will follow the link to the real path. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath",
             "type": "string"
           },
           "type": {
-            "description": "Type for HostPath Volume Defaults to \"\" More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath",
+            "description": "type for HostPath Volume Defaults to \"\" More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath",
             "type": "string"
           }
         },
@@ -1294,38 +1294,38 @@
         "description": "Represents an ISCSI disk. ISCSI volumes can only be mounted as read/write once. ISCSI volumes support ownership management and SELinux relabeling.",
         "properties": {
           "chapAuthDiscovery": {
-            "description": "whether support iSCSI Discovery CHAP authentication",
+            "description": "chapAuthDiscovery defines whether support iSCSI Discovery CHAP authentication",
             "type": "boolean"
           },
           "chapAuthSession": {
-            "description": "whether support iSCSI Session CHAP authentication",
+            "description": "chapAuthSession defines whether support iSCSI Session CHAP authentication",
             "type": "boolean"
           },
           "fsType": {
-            "description": "Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi",
+            "description": "fsType is the filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi",
             "type": "string"
           },
           "initiatorName": {
-            "description": "Custom iSCSI Initiator Name. If initiatorName is specified with iscsiInterface simultaneously, new iSCSI interface <target portal>:<volume name> will be created for the connection.",
+            "description": "initiatorName is the custom iSCSI Initiator Name. If initiatorName is specified with iscsiInterface simultaneously, new iSCSI interface <target portal>:<volume name> will be created for the connection.",
             "type": "string"
           },
           "iqn": {
             "default": "",
-            "description": "Target iSCSI Qualified Name.",
+            "description": "iqn is the target iSCSI Qualified Name.",
             "type": "string"
           },
           "iscsiInterface": {
-            "description": "iSCSI Interface Name that uses an iSCSI transport. Defaults to 'default' (tcp).",
+            "description": "iscsiInterface is the interface Name that uses an iSCSI transport. Defaults to 'default' (tcp).",
             "type": "string"
           },
           "lun": {
             "default": 0,
-            "description": "iSCSI Target Lun number.",
+            "description": "lun represents iSCSI Target Lun number.",
             "format": "int32",
             "type": "integer"
           },
           "portals": {
-            "description": "iSCSI Target Portal List. The portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).",
+            "description": "portals is the iSCSI Target Portal List. The portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).",
             "items": {
               "default": "",
               "type": "string"
@@ -1333,16 +1333,16 @@
             "type": "array"
           },
           "readOnly": {
-            "description": "ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false.",
+            "description": "readOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false.",
             "type": "boolean"
           },
           "secretRef": {
             "$ref": "#/components/schemas/io.k8s.api.core.v1.LocalObjectReference",
-            "description": "CHAP Secret for iSCSI target and initiator authentication"
+            "description": "secretRef is the CHAP Secret for iSCSI target and initiator authentication"
           },
           "targetPortal": {
             "default": "",
-            "description": "iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).",
+            "description": "targetPortal is iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).",
             "type": "string"
           }
         },
@@ -1358,17 +1358,17 @@
         "properties": {
           "key": {
             "default": "",
-            "description": "The key to project.",
+            "description": "key is the key to project.",
             "type": "string"
           },
           "mode": {
-            "description": "Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+            "description": "mode is Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
             "format": "int32",
             "type": "integer"
           },
           "path": {
             "default": "",
-            "description": "The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.",
+            "description": "path is the relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.",
             "type": "string"
           }
         },
@@ -1426,16 +1426,16 @@
         "properties": {
           "path": {
             "default": "",
-            "description": "Path that is exported by the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
+            "description": "path that is exported by the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
             "type": "string"
           },
           "readOnly": {
-            "description": "ReadOnly here will force the NFS export to be mounted with read-only permissions. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
+            "description": "readOnly here will force the NFS export to be mounted with read-only permissions. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
             "type": "boolean"
           },
           "server": {
             "default": "",
-            "description": "Server is the hostname or IP address of the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
+            "description": "server is the hostname or IP address of the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
             "type": "string"
           }
         },
@@ -1678,12 +1678,12 @@
         "description": "Represents a Photon Controller persistent disk resource.",
         "properties": {
           "fsType": {
-            "description": "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+            "description": "fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
             "type": "string"
           },
           "pdID": {
             "default": "",
-            "description": "ID that identifies Photon Controller persistent disk",
+            "description": "pdID is the ID that identifies Photon Controller persistent disk",
             "type": "string"
           }
         },
@@ -2152,16 +2152,16 @@
         "description": "PortworxVolumeSource represents a Portworx volume resource.",
         "properties": {
           "fsType": {
-            "description": "FSType represents the filesystem type to mount Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+            "description": "fSType represents the filesystem type to mount Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\". Implicitly inferred to be \"ext4\" if unspecified.",
             "type": "string"
           },
           "readOnly": {
-            "description": "Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
+            "description": "readOnly defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
             "type": "boolean"
           },
           "volumeID": {
             "default": "",
-            "description": "VolumeID uniquely identifies a Portworx volume",
+            "description": "volumeID uniquely identifies a Portworx volume",
             "type": "string"
           }
         },
@@ -2247,12 +2247,12 @@
         "description": "Represents a projected volume source",
         "properties": {
           "defaultMode": {
-            "description": "Mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+            "description": "defaultMode are the mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
             "format": "int32",
             "type": "integer"
           },
           "sources": {
-            "description": "list of volume projections",
+            "description": "sources is the list of volume projections",
             "items": {
               "$ref": "#/components/schemas/io.k8s.api.core.v1.VolumeProjection",
               "default": {}
@@ -2266,29 +2266,29 @@
         "description": "Represents a Quobyte mount that lasts the lifetime of a pod. Quobyte volumes do not support ownership management or SELinux relabeling.",
         "properties": {
           "group": {
-            "description": "Group to map volume access to Default is no group",
+            "description": "group to map volume access to Default is no group",
             "type": "string"
           },
           "readOnly": {
-            "description": "ReadOnly here will force the Quobyte volume to be mounted with read-only permissions. Defaults to false.",
+            "description": "readOnly here will force the Quobyte volume to be mounted with read-only permissions. Defaults to false.",
             "type": "boolean"
           },
           "registry": {
             "default": "",
-            "description": "Registry represents a single or multiple Quobyte Registry services specified as a string as host:port pair (multiple entries are separated with commas) which acts as the central registry for volumes",
+            "description": "registry represents a single or multiple Quobyte Registry services specified as a string as host:port pair (multiple entries are separated with commas) which acts as the central registry for volumes",
             "type": "string"
           },
           "tenant": {
-            "description": "Tenant owning the given Quobyte volume in the Backend Used with dynamically provisioned Quobyte volumes, value is set by the plugin",
+            "description": "tenant owning the given Quobyte volume in the Backend Used with dynamically provisioned Quobyte volumes, value is set by the plugin",
             "type": "string"
           },
           "user": {
-            "description": "User to map volume access to Defaults to serivceaccount user",
+            "description": "user to map volume access to Defaults to serivceaccount user",
             "type": "string"
           },
           "volume": {
             "default": "",
-            "description": "Volume is a string that references an already created Quobyte volume by name.",
+            "description": "volume is a string that references an already created Quobyte volume by name.",
             "type": "string"
           }
         },
@@ -2302,20 +2302,20 @@
         "description": "Represents a Rados Block Device mount that lasts the lifetime of a pod. RBD volumes support ownership management and SELinux relabeling.",
         "properties": {
           "fsType": {
-            "description": "Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd",
+            "description": "fsType is the filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd",
             "type": "string"
           },
           "image": {
             "default": "",
-            "description": "The rados image name. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+            "description": "image is the rados image name. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
             "type": "string"
           },
           "keyring": {
-            "description": "Keyring is the path to key ring for RBDUser. Default is /etc/ceph/keyring. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+            "description": "keyring is the path to key ring for RBDUser. Default is /etc/ceph/keyring. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
             "type": "string"
           },
           "monitors": {
-            "description": "A collection of Ceph monitors. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+            "description": "monitors is a collection of Ceph monitors. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
             "items": {
               "default": "",
               "type": "string"
@@ -2323,19 +2323,19 @@
             "type": "array"
           },
           "pool": {
-            "description": "The rados pool name. Default is rbd. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+            "description": "pool is the rados pool name. Default is rbd. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
             "type": "string"
           },
           "readOnly": {
-            "description": "ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+            "description": "readOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
             "type": "boolean"
           },
           "secretRef": {
             "$ref": "#/components/schemas/io.k8s.api.core.v1.LocalObjectReference",
-            "description": "SecretRef is name of the authentication secret for RBDUser. If provided overrides keyring. Default is nil. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it"
+            "description": "secretRef is name of the authentication secret for RBDUser. If provided overrides keyring. Default is nil. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it"
           },
           "user": {
-            "description": "The rados user name. Default is admin. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+            "description": "user is the rados user name. Default is admin. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
             "type": "string"
           }
         },
@@ -2417,45 +2417,45 @@
         "description": "ScaleIOVolumeSource represents a persistent ScaleIO volume",
         "properties": {
           "fsType": {
-            "description": "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Default is \"xfs\".",
+            "description": "fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Default is \"xfs\".",
             "type": "string"
           },
           "gateway": {
             "default": "",
-            "description": "The host address of the ScaleIO API Gateway.",
+            "description": "gateway is the host address of the ScaleIO API Gateway.",
             "type": "string"
           },
           "protectionDomain": {
-            "description": "The name of the ScaleIO Protection Domain for the configured storage.",
+            "description": "protectionDomain is the name of the ScaleIO Protection Domain for the configured storage.",
             "type": "string"
           },
           "readOnly": {
-            "description": "Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
+            "description": "readOnly Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
             "type": "boolean"
           },
           "secretRef": {
             "$ref": "#/components/schemas/io.k8s.api.core.v1.LocalObjectReference",
-            "description": "SecretRef references to the secret for ScaleIO user and other sensitive information. If this is not provided, Login operation will fail."
+            "description": "secretRef references to the secret for ScaleIO user and other sensitive information. If this is not provided, Login operation will fail."
           },
           "sslEnabled": {
-            "description": "Flag to enable/disable SSL communication with Gateway, default false",
+            "description": "sslEnabled Flag enable/disable SSL communication with Gateway, default false",
             "type": "boolean"
           },
           "storageMode": {
-            "description": "Indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned. Default is ThinProvisioned.",
+            "description": "storageMode indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned. Default is ThinProvisioned.",
             "type": "string"
           },
           "storagePool": {
-            "description": "The ScaleIO Storage Pool associated with the protection domain.",
+            "description": "storagePool is the ScaleIO Storage Pool associated with the protection domain.",
             "type": "string"
           },
           "system": {
             "default": "",
-            "description": "The name of the storage system as configured in ScaleIO.",
+            "description": "system is the name of the storage system as configured in ScaleIO.",
             "type": "string"
           },
           "volumeName": {
-            "description": "The name of a volume already created in the ScaleIO system that is associated with this volume source.",
+            "description": "volumeName is the name of a volume already created in the ScaleIO system that is associated with this volume source.",
             "type": "string"
           }
         },
@@ -2538,7 +2538,7 @@
         "description": "Adapts a secret into a projected volume.\n\nThe contents of the target Secret's Data field will be presented in a projected volume as files using the keys in the Data field as the file names. Note that this is identical to a secret volume source without the default mode.",
         "properties": {
           "items": {
-            "description": "If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.",
+            "description": "items if unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.",
             "items": {
               "$ref": "#/components/schemas/io.k8s.api.core.v1.KeyToPath",
               "default": {}
@@ -2550,7 +2550,7 @@
             "type": "string"
           },
           "optional": {
-            "description": "Specify whether the Secret or its key must be defined",
+            "description": "optional field specify whether the Secret or its key must be defined",
             "type": "boolean"
           }
         },
@@ -2560,12 +2560,12 @@
         "description": "Adapts a Secret into a volume.\n\nThe contents of the target Secret's Data field will be presented in a volume as files using the keys in the Data field as the file names. Secret volumes support ownership management and SELinux relabeling.",
         "properties": {
           "defaultMode": {
-            "description": "Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+            "description": "defaultMode is Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
             "format": "int32",
             "type": "integer"
           },
           "items": {
-            "description": "If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.",
+            "description": "items If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.",
             "items": {
               "$ref": "#/components/schemas/io.k8s.api.core.v1.KeyToPath",
               "default": {}
@@ -2573,11 +2573,11 @@
             "type": "array"
           },
           "optional": {
-            "description": "Specify whether the Secret or its keys must be defined",
+            "description": "optional field specify whether the Secret or its keys must be defined",
             "type": "boolean"
           },
           "secretName": {
-            "description": "Name of the secret in the pod's namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret",
+            "description": "secretName is the name of the secret in the pod's namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret",
             "type": "string"
           }
         },
@@ -2639,17 +2639,17 @@
         "description": "ServiceAccountTokenProjection represents a projected service account token volume. This projection can be used to insert a service account token into the pods runtime filesystem for use against APIs (Kubernetes API Server or otherwise).",
         "properties": {
           "audience": {
-            "description": "Audience is the intended audience of the token. A recipient of a token must identify itself with an identifier specified in the audience of the token, and otherwise should reject the token. The audience defaults to the identifier of the apiserver.",
+            "description": "audience is the intended audience of the token. A recipient of a token must identify itself with an identifier specified in the audience of the token, and otherwise should reject the token. The audience defaults to the identifier of the apiserver.",
             "type": "string"
           },
           "expirationSeconds": {
-            "description": "ExpirationSeconds is the requested duration of validity of the service account token. As the token approaches expiration, the kubelet volume plugin will proactively rotate the service account token. The kubelet will start trying to rotate the token if the token is older than 80 percent of its time to live or if the token is older than 24 hours.Defaults to 1 hour and must be at least 10 minutes.",
+            "description": "expirationSeconds is the requested duration of validity of the service account token. As the token approaches expiration, the kubelet volume plugin will proactively rotate the service account token. The kubelet will start trying to rotate the token if the token is older than 80 percent of its time to live or if the token is older than 24 hours.Defaults to 1 hour and must be at least 10 minutes.",
             "format": "int64",
             "type": "integer"
           },
           "path": {
             "default": "",
-            "description": "Path is the path relative to the mount point of the file to project the token into.",
+            "description": "path is the path relative to the mount point of the file to project the token into.",
             "type": "string"
           }
         },
@@ -2662,23 +2662,23 @@
         "description": "Represents a StorageOS persistent volume resource.",
         "properties": {
           "fsType": {
-            "description": "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+            "description": "fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
             "type": "string"
           },
           "readOnly": {
-            "description": "Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
+            "description": "readOnly defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
             "type": "boolean"
           },
           "secretRef": {
             "$ref": "#/components/schemas/io.k8s.api.core.v1.LocalObjectReference",
-            "description": "SecretRef specifies the secret to use for obtaining the StorageOS API credentials.  If not specified, default values will be attempted."
+            "description": "secretRef specifies the secret to use for obtaining the StorageOS API credentials.  If not specified, default values will be attempted."
           },
           "volumeName": {
-            "description": "VolumeName is the human-readable name of the StorageOS volume.  Volume names are only unique within a namespace.",
+            "description": "volumeName is the human-readable name of the StorageOS volume.  Volume names are only unique within a namespace.",
             "type": "string"
           },
           "volumeNamespace": {
-            "description": "VolumeNamespace specifies the scope of the volume within StorageOS.  If no namespace is specified then the Pod's namespace will be used.  This allows the Kubernetes name scoping to be mirrored within StorageOS for tighter integration. Set VolumeName to any name to override the default behaviour. Set to \"default\" if you are not using namespaces within StorageOS. Namespaces that do not pre-exist within StorageOS will be created.",
+            "description": "volumeNamespace specifies the scope of the volume within StorageOS.  If no namespace is specified then the Pod's namespace will be used.  This allows the Kubernetes name scoping to be mirrored within StorageOS for tighter integration. Set VolumeName to any name to override the default behaviour. Set to \"default\" if you are not using namespaces within StorageOS. Namespaces that do not pre-exist within StorageOS will be created.",
             "type": "string"
           }
         },
@@ -3009,19 +3009,19 @@
         "properties": {
           "configMap": {
             "$ref": "#/components/schemas/io.k8s.api.core.v1.ConfigMapProjection",
-            "description": "information about the configMap data to project"
+            "description": "configMap information about the configMap data to project"
           },
           "downwardAPI": {
             "$ref": "#/components/schemas/io.k8s.api.core.v1.DownwardAPIProjection",
-            "description": "information about the downwardAPI data to project"
+            "description": "downwardAPI information about the downwardAPI data to project"
           },
           "secret": {
             "$ref": "#/components/schemas/io.k8s.api.core.v1.SecretProjection",
-            "description": "information about the secret data to project"
+            "description": "secret information about the secret data to project"
           },
           "serviceAccountToken": {
             "$ref": "#/components/schemas/io.k8s.api.core.v1.ServiceAccountTokenProjection",
-            "description": "information about the serviceAccountToken data to project"
+            "description": "serviceAccountToken is information about the serviceAccountToken data to project"
           }
         },
         "type": "object"
@@ -3030,20 +3030,20 @@
         "description": "Represents a vSphere volume resource.",
         "properties": {
           "fsType": {
-            "description": "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+            "description": "fsType is filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
             "type": "string"
           },
           "storagePolicyID": {
-            "description": "Storage Policy Based Management (SPBM) profile ID associated with the StoragePolicyName.",
+            "description": "storagePolicyID is the storage Policy Based Management (SPBM) profile ID associated with the StoragePolicyName.",
             "type": "string"
           },
           "storagePolicyName": {
-            "description": "Storage Policy Based Management (SPBM) profile name.",
+            "description": "storagePolicyName is the storage Policy Based Management (SPBM) profile name.",
             "type": "string"
           },
           "volumePath": {
             "default": "",
-            "description": "Path that identifies vSphere volume vmdk",
+            "description": "volumePath is the path that identifies vSphere volume vmdk",
             "type": "string"
           }
         },

--- a/api/openapi-spec/v3/apis__storage.k8s.io__v1_openapi.json
+++ b/api/openapi-spec/v3/apis__storage.k8s.io__v1_openapi.json
@@ -5,21 +5,21 @@
         "description": "Represents a Persistent Disk resource in AWS.\n\nAn AWS EBS disk must exist before mounting to a container. The disk must also be in the same AWS zone as the kubelet. An AWS EBS disk can only be mounted as read/write once. AWS EBS volumes support ownership management and SELinux relabeling.",
         "properties": {
           "fsType": {
-            "description": "Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore",
+            "description": "fsType is the filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore",
             "type": "string"
           },
           "partition": {
-            "description": "The partition in the volume that you want to mount. If omitted, the default is to mount by volume name. Examples: For volume /dev/sda1, you specify the partition as \"1\". Similarly, the volume partition for /dev/sda is \"0\" (or you can leave the property empty).",
+            "description": "partition is the partition in the volume that you want to mount. If omitted, the default is to mount by volume name. Examples: For volume /dev/sda1, you specify the partition as \"1\". Similarly, the volume partition for /dev/sda is \"0\" (or you can leave the property empty).",
             "format": "int32",
             "type": "integer"
           },
           "readOnly": {
-            "description": "Specify \"true\" to force and set the ReadOnly property in VolumeMounts to \"true\". If omitted, the default is \"false\". More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore",
+            "description": "readOnly value true will force the readOnly setting in VolumeMounts. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore",
             "type": "boolean"
           },
           "volumeID": {
             "default": "",
-            "description": "Unique ID of the persistent disk resource in AWS (Amazon EBS volume). More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore",
+            "description": "volumeID is unique ID of the persistent disk resource in AWS (Amazon EBS volume). More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore",
             "type": "string"
           }
         },
@@ -32,29 +32,29 @@
         "description": "AzureDisk represents an Azure Data Disk mount on the host and bind mount to the pod.",
         "properties": {
           "cachingMode": {
-            "description": "Host Caching mode: None, Read Only, Read Write.",
+            "description": "cachingMode is the Host Caching mode: None, Read Only, Read Write.",
             "type": "string"
           },
           "diskName": {
             "default": "",
-            "description": "The Name of the data disk in the blob storage",
+            "description": "diskName is the Name of the data disk in the blob storage",
             "type": "string"
           },
           "diskURI": {
             "default": "",
-            "description": "The URI the data disk in the blob storage",
+            "description": "diskURI is the URI of data disk in the blob storage",
             "type": "string"
           },
           "fsType": {
-            "description": "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+            "description": "fsType is Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
             "type": "string"
           },
           "kind": {
-            "description": "Expected values Shared: multiple blob disks per storage account  Dedicated: single blob disk per storage account  Managed: azure managed data disk (only in managed availability set). defaults to shared",
+            "description": "kind expected values are Shared: multiple blob disks per storage account  Dedicated: single blob disk per storage account  Managed: azure managed data disk (only in managed availability set). defaults to shared",
             "type": "string"
           },
           "readOnly": {
-            "description": "Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
+            "description": "readOnly Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
             "type": "boolean"
           }
         },
@@ -68,21 +68,21 @@
         "description": "AzureFile represents an Azure File Service mount on the host and bind mount to the pod.",
         "properties": {
           "readOnly": {
-            "description": "Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
+            "description": "readOnly defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
             "type": "boolean"
           },
           "secretName": {
             "default": "",
-            "description": "the name of secret that contains Azure Storage Account Name and Key",
+            "description": "secretName is the name of secret that contains Azure Storage Account Name and Key",
             "type": "string"
           },
           "secretNamespace": {
-            "description": "the namespace of the secret that contains Azure Storage Account Name and Key default is the same as the Pod",
+            "description": "secretNamespace is the namespace of the secret that contains Azure Storage Account Name and Key default is the same as the Pod",
             "type": "string"
           },
           "shareName": {
             "default": "",
-            "description": "Share Name",
+            "description": "shareName is the azure Share Name",
             "type": "string"
           }
         },
@@ -148,7 +148,7 @@
         "description": "Represents a Ceph Filesystem mount that lasts the lifetime of a pod Cephfs volumes do not support ownership management or SELinux relabeling.",
         "properties": {
           "monitors": {
-            "description": "Required: Monitors is a collection of Ceph monitors More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
+            "description": "monitors is Required: Monitors is a collection of Ceph monitors More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
             "items": {
               "default": "",
               "type": "string"
@@ -156,23 +156,23 @@
             "type": "array"
           },
           "path": {
-            "description": "Optional: Used as the mounted root, rather than the full Ceph tree, default is /",
+            "description": "path is Optional: Used as the mounted root, rather than the full Ceph tree, default is /",
             "type": "string"
           },
           "readOnly": {
-            "description": "Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
+            "description": "readOnly is Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
             "type": "boolean"
           },
           "secretFile": {
-            "description": "Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
+            "description": "secretFile is Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
             "type": "string"
           },
           "secretRef": {
             "$ref": "#/components/schemas/io.k8s.api.core.v1.SecretReference",
-            "description": "Optional: SecretRef is reference to the authentication secret for User, default is empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it"
+            "description": "secretRef is Optional: SecretRef is reference to the authentication secret for User, default is empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it"
           },
           "user": {
-            "description": "Optional: User is the rados user name, default is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
+            "description": "user is Optional: User is the rados user name, default is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
             "type": "string"
           }
         },
@@ -185,20 +185,20 @@
         "description": "Represents a cinder volume resource in Openstack. A Cinder volume must exist before mounting to a container. The volume must also be in the same region as the kubelet. Cinder volumes support ownership management and SELinux relabeling.",
         "properties": {
           "fsType": {
-            "description": "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://examples.k8s.io/mysql-cinder-pd/README.md",
+            "description": "fsType Filesystem type to mount. Must be a filesystem type supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://examples.k8s.io/mysql-cinder-pd/README.md",
             "type": "string"
           },
           "readOnly": {
-            "description": "Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: https://examples.k8s.io/mysql-cinder-pd/README.md",
+            "description": "readOnly is Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: https://examples.k8s.io/mysql-cinder-pd/README.md",
             "type": "boolean"
           },
           "secretRef": {
             "$ref": "#/components/schemas/io.k8s.api.core.v1.SecretReference",
-            "description": "Optional: points to a secret object containing parameters used to connect to OpenStack."
+            "description": "secretRef is Optional: points to a secret object containing parameters used to connect to OpenStack."
           },
           "volumeID": {
             "default": "",
-            "description": "volume id used to identify the volume in cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md",
+            "description": "volumeID used to identify the volume in cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md",
             "type": "string"
           }
         },
@@ -211,20 +211,20 @@
         "description": "Represents a Fibre Channel volume. Fibre Channel volumes can only be mounted as read/write once. Fibre Channel volumes support ownership management and SELinux relabeling.",
         "properties": {
           "fsType": {
-            "description": "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+            "description": "fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
             "type": "string"
           },
           "lun": {
-            "description": "Optional: FC target lun number",
+            "description": "lun is Optional: FC target lun number",
             "format": "int32",
             "type": "integer"
           },
           "readOnly": {
-            "description": "Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
+            "description": "readOnly is Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
             "type": "boolean"
           },
           "targetWWNs": {
-            "description": "Optional: FC target worldwide names (WWNs)",
+            "description": "targetWWNs is Optional: FC target worldwide names (WWNs)",
             "items": {
               "default": "",
               "type": "string"
@@ -232,7 +232,7 @@
             "type": "array"
           },
           "wwids": {
-            "description": "Optional: FC volume world wide identifiers (wwids) Either wwids or combination of targetWWNs and lun must be set, but not both simultaneously.",
+            "description": "wwids Optional: FC volume world wide identifiers (wwids) Either wwids or combination of targetWWNs and lun must be set, but not both simultaneously.",
             "items": {
               "default": "",
               "type": "string"
@@ -247,11 +247,11 @@
         "properties": {
           "driver": {
             "default": "",
-            "description": "Driver is the name of the driver to use for this volume.",
+            "description": "driver is the name of the driver to use for this volume.",
             "type": "string"
           },
           "fsType": {
-            "description": "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". The default filesystem depends on FlexVolume script.",
+            "description": "fsType is the Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". The default filesystem depends on FlexVolume script.",
             "type": "string"
           },
           "options": {
@@ -259,16 +259,16 @@
               "default": "",
               "type": "string"
             },
-            "description": "Optional: Extra command options if any.",
+            "description": "options is Optional: this field holds extra command options if any.",
             "type": "object"
           },
           "readOnly": {
-            "description": "Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
+            "description": "readOnly is Optional: defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
             "type": "boolean"
           },
           "secretRef": {
             "$ref": "#/components/schemas/io.k8s.api.core.v1.SecretReference",
-            "description": "Optional: SecretRef is reference to the secret object containing sensitive information to pass to the plugin scripts. This may be empty if no secret object is specified. If the secret object contains more than one secret, all secrets are passed to the plugin scripts."
+            "description": "secretRef is Optional: SecretRef is reference to the secret object containing sensitive information to pass to the plugin scripts. This may be empty if no secret object is specified. If the secret object contains more than one secret, all secrets are passed to the plugin scripts."
           }
         },
         "required": [
@@ -280,11 +280,11 @@
         "description": "Represents a Flocker volume mounted by the Flocker agent. One and only one of datasetName and datasetUUID should be set. Flocker volumes do not support ownership management or SELinux relabeling.",
         "properties": {
           "datasetName": {
-            "description": "Name of the dataset stored as metadata -> name on the dataset for Flocker should be considered as deprecated",
+            "description": "datasetName is Name of the dataset stored as metadata -> name on the dataset for Flocker should be considered as deprecated",
             "type": "string"
           },
           "datasetUUID": {
-            "description": "UUID of the dataset. This is unique identifier of a Flocker dataset",
+            "description": "datasetUUID is the UUID of the dataset. This is unique identifier of a Flocker dataset",
             "type": "string"
           }
         },
@@ -294,21 +294,21 @@
         "description": "Represents a Persistent Disk resource in Google Compute Engine.\n\nA GCE PD must exist before mounting to a container. The disk must also be in the same GCE project and zone as the kubelet. A GCE PD can only be mounted as read/write once or read-only many times. GCE PDs support ownership management and SELinux relabeling.",
         "properties": {
           "fsType": {
-            "description": "Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
+            "description": "fsType is filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
             "type": "string"
           },
           "partition": {
-            "description": "The partition in the volume that you want to mount. If omitted, the default is to mount by volume name. Examples: For volume /dev/sda1, you specify the partition as \"1\". Similarly, the volume partition for /dev/sda is \"0\" (or you can leave the property empty). More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
+            "description": "partition is the partition in the volume that you want to mount. If omitted, the default is to mount by volume name. Examples: For volume /dev/sda1, you specify the partition as \"1\". Similarly, the volume partition for /dev/sda is \"0\" (or you can leave the property empty). More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
             "format": "int32",
             "type": "integer"
           },
           "pdName": {
             "default": "",
-            "description": "Unique name of the PD resource in GCE. Used to identify the disk in GCE. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
+            "description": "pdName is unique name of the PD resource in GCE. Used to identify the disk in GCE. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
             "type": "string"
           },
           "readOnly": {
-            "description": "ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
+            "description": "readOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
             "type": "boolean"
           }
         },
@@ -322,20 +322,20 @@
         "properties": {
           "endpoints": {
             "default": "",
-            "description": "EndpointsName is the endpoint name that details Glusterfs topology. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod",
+            "description": "endpoints is the endpoint name that details Glusterfs topology. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod",
             "type": "string"
           },
           "endpointsNamespace": {
-            "description": "EndpointsNamespace is the namespace that contains Glusterfs endpoint. If this field is empty, the EndpointNamespace defaults to the same namespace as the bound PVC. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod",
+            "description": "endpointsNamespace is the namespace that contains Glusterfs endpoint. If this field is empty, the EndpointNamespace defaults to the same namespace as the bound PVC. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod",
             "type": "string"
           },
           "path": {
             "default": "",
-            "description": "Path is the Glusterfs volume path. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod",
+            "description": "path is the Glusterfs volume path. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod",
             "type": "string"
           },
           "readOnly": {
-            "description": "ReadOnly here will force the Glusterfs volume to be mounted with read-only permissions. Defaults to false. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod",
+            "description": "readOnly here will force the Glusterfs volume to be mounted with read-only permissions. Defaults to false. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod",
             "type": "boolean"
           }
         },
@@ -350,11 +350,11 @@
         "properties": {
           "path": {
             "default": "",
-            "description": "Path of the directory on the host. If the path is a symlink, it will follow the link to the real path. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath",
+            "description": "path of the directory on the host. If the path is a symlink, it will follow the link to the real path. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath",
             "type": "string"
           },
           "type": {
-            "description": "Type for HostPath Volume Defaults to \"\" More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath",
+            "description": "type for HostPath Volume Defaults to \"\" More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath",
             "type": "string"
           }
         },
@@ -367,38 +367,38 @@
         "description": "ISCSIPersistentVolumeSource represents an ISCSI disk. ISCSI volumes can only be mounted as read/write once. ISCSI volumes support ownership management and SELinux relabeling.",
         "properties": {
           "chapAuthDiscovery": {
-            "description": "whether support iSCSI Discovery CHAP authentication",
+            "description": "chapAuthDiscovery defines whether support iSCSI Discovery CHAP authentication",
             "type": "boolean"
           },
           "chapAuthSession": {
-            "description": "whether support iSCSI Session CHAP authentication",
+            "description": "chapAuthSession defines whether support iSCSI Session CHAP authentication",
             "type": "boolean"
           },
           "fsType": {
-            "description": "Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi",
+            "description": "fsType is the filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi",
             "type": "string"
           },
           "initiatorName": {
-            "description": "Custom iSCSI Initiator Name. If initiatorName is specified with iscsiInterface simultaneously, new iSCSI interface <target portal>:<volume name> will be created for the connection.",
+            "description": "initiatorName is the custom iSCSI Initiator Name. If initiatorName is specified with iscsiInterface simultaneously, new iSCSI interface <target portal>:<volume name> will be created for the connection.",
             "type": "string"
           },
           "iqn": {
             "default": "",
-            "description": "Target iSCSI Qualified Name.",
+            "description": "iqn is Target iSCSI Qualified Name.",
             "type": "string"
           },
           "iscsiInterface": {
-            "description": "iSCSI Interface Name that uses an iSCSI transport. Defaults to 'default' (tcp).",
+            "description": "iscsiInterface is the interface Name that uses an iSCSI transport. Defaults to 'default' (tcp).",
             "type": "string"
           },
           "lun": {
             "default": 0,
-            "description": "iSCSI Target Lun number.",
+            "description": "lun is iSCSI Target Lun number.",
             "format": "int32",
             "type": "integer"
           },
           "portals": {
-            "description": "iSCSI Target Portal List. The Portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).",
+            "description": "portals is the iSCSI Target Portal List. The Portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).",
             "items": {
               "default": "",
               "type": "string"
@@ -406,16 +406,16 @@
             "type": "array"
           },
           "readOnly": {
-            "description": "ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false.",
+            "description": "readOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false.",
             "type": "boolean"
           },
           "secretRef": {
             "$ref": "#/components/schemas/io.k8s.api.core.v1.SecretReference",
-            "description": "CHAP Secret for iSCSI target and initiator authentication"
+            "description": "secretRef is the CHAP Secret for iSCSI target and initiator authentication"
           },
           "targetPortal": {
             "default": "",
-            "description": "iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).",
+            "description": "targetPortal is iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).",
             "type": "string"
           }
         },
@@ -430,12 +430,12 @@
         "description": "Local represents directly-attached storage with node affinity (Beta feature)",
         "properties": {
           "fsType": {
-            "description": "Filesystem type to mount. It applies only when the Path is a block device. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". The default value is to auto-select a filesystem if unspecified.",
+            "description": "fsType is the filesystem type to mount. It applies only when the Path is a block device. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". The default value is to auto-select a filesystem if unspecified.",
             "type": "string"
           },
           "path": {
             "default": "",
-            "description": "The full path to the volume on the node. It can be either a directory or block device (disk, partition, ...).",
+            "description": "path of the full path to the volume on the node. It can be either a directory or block device (disk, partition, ...).",
             "type": "string"
           }
         },
@@ -449,16 +449,16 @@
         "properties": {
           "path": {
             "default": "",
-            "description": "Path that is exported by the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
+            "description": "path that is exported by the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
             "type": "string"
           },
           "readOnly": {
-            "description": "ReadOnly here will force the NFS export to be mounted with read-only permissions. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
+            "description": "readOnly here will force the NFS export to be mounted with read-only permissions. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
             "type": "boolean"
           },
           "server": {
             "default": "",
-            "description": "Server is the hostname or IP address of the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
+            "description": "server is the hostname or IP address of the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
             "type": "string"
           }
         },
@@ -727,12 +727,12 @@
         "description": "Represents a Photon Controller persistent disk resource.",
         "properties": {
           "fsType": {
-            "description": "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+            "description": "fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
             "type": "string"
           },
           "pdID": {
             "default": "",
-            "description": "ID that identifies Photon Controller persistent disk",
+            "description": "pdID is the ID that identifies Photon Controller persistent disk",
             "type": "string"
           }
         },
@@ -745,16 +745,16 @@
         "description": "PortworxVolumeSource represents a Portworx volume resource.",
         "properties": {
           "fsType": {
-            "description": "FSType represents the filesystem type to mount Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+            "description": "fSType represents the filesystem type to mount Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\". Implicitly inferred to be \"ext4\" if unspecified.",
             "type": "string"
           },
           "readOnly": {
-            "description": "Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
+            "description": "readOnly defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
             "type": "boolean"
           },
           "volumeID": {
             "default": "",
-            "description": "VolumeID uniquely identifies a Portworx volume",
+            "description": "volumeID uniquely identifies a Portworx volume",
             "type": "string"
           }
         },
@@ -767,29 +767,29 @@
         "description": "Represents a Quobyte mount that lasts the lifetime of a pod. Quobyte volumes do not support ownership management or SELinux relabeling.",
         "properties": {
           "group": {
-            "description": "Group to map volume access to Default is no group",
+            "description": "group to map volume access to Default is no group",
             "type": "string"
           },
           "readOnly": {
-            "description": "ReadOnly here will force the Quobyte volume to be mounted with read-only permissions. Defaults to false.",
+            "description": "readOnly here will force the Quobyte volume to be mounted with read-only permissions. Defaults to false.",
             "type": "boolean"
           },
           "registry": {
             "default": "",
-            "description": "Registry represents a single or multiple Quobyte Registry services specified as a string as host:port pair (multiple entries are separated with commas) which acts as the central registry for volumes",
+            "description": "registry represents a single or multiple Quobyte Registry services specified as a string as host:port pair (multiple entries are separated with commas) which acts as the central registry for volumes",
             "type": "string"
           },
           "tenant": {
-            "description": "Tenant owning the given Quobyte volume in the Backend Used with dynamically provisioned Quobyte volumes, value is set by the plugin",
+            "description": "tenant owning the given Quobyte volume in the Backend Used with dynamically provisioned Quobyte volumes, value is set by the plugin",
             "type": "string"
           },
           "user": {
-            "description": "User to map volume access to Defaults to serivceaccount user",
+            "description": "user to map volume access to Defaults to serivceaccount user",
             "type": "string"
           },
           "volume": {
             "default": "",
-            "description": "Volume is a string that references an already created Quobyte volume by name.",
+            "description": "volume is a string that references an already created Quobyte volume by name.",
             "type": "string"
           }
         },
@@ -803,20 +803,20 @@
         "description": "Represents a Rados Block Device mount that lasts the lifetime of a pod. RBD volumes support ownership management and SELinux relabeling.",
         "properties": {
           "fsType": {
-            "description": "Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd",
+            "description": "fsType is the filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd",
             "type": "string"
           },
           "image": {
             "default": "",
-            "description": "The rados image name. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+            "description": "image is the rados image name. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
             "type": "string"
           },
           "keyring": {
-            "description": "Keyring is the path to key ring for RBDUser. Default is /etc/ceph/keyring. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+            "description": "keyring is the path to key ring for RBDUser. Default is /etc/ceph/keyring. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
             "type": "string"
           },
           "monitors": {
-            "description": "A collection of Ceph monitors. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+            "description": "monitors is a collection of Ceph monitors. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
             "items": {
               "default": "",
               "type": "string"
@@ -824,19 +824,19 @@
             "type": "array"
           },
           "pool": {
-            "description": "The rados pool name. Default is rbd. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+            "description": "pool is the rados pool name. Default is rbd. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
             "type": "string"
           },
           "readOnly": {
-            "description": "ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+            "description": "readOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
             "type": "boolean"
           },
           "secretRef": {
             "$ref": "#/components/schemas/io.k8s.api.core.v1.SecretReference",
-            "description": "SecretRef is name of the authentication secret for RBDUser. If provided overrides keyring. Default is nil. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it"
+            "description": "secretRef is name of the authentication secret for RBDUser. If provided overrides keyring. Default is nil. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it"
           },
           "user": {
-            "description": "The rados user name. Default is admin. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+            "description": "user is the rados user name. Default is admin. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
             "type": "string"
           }
         },
@@ -850,45 +850,45 @@
         "description": "ScaleIOPersistentVolumeSource represents a persistent ScaleIO volume",
         "properties": {
           "fsType": {
-            "description": "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Default is \"xfs\"",
+            "description": "fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Default is \"xfs\"",
             "type": "string"
           },
           "gateway": {
             "default": "",
-            "description": "The host address of the ScaleIO API Gateway.",
+            "description": "gateway is the host address of the ScaleIO API Gateway.",
             "type": "string"
           },
           "protectionDomain": {
-            "description": "The name of the ScaleIO Protection Domain for the configured storage.",
+            "description": "protectionDomain is the name of the ScaleIO Protection Domain for the configured storage.",
             "type": "string"
           },
           "readOnly": {
-            "description": "Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
+            "description": "readOnly defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
             "type": "boolean"
           },
           "secretRef": {
             "$ref": "#/components/schemas/io.k8s.api.core.v1.SecretReference",
-            "description": "SecretRef references to the secret for ScaleIO user and other sensitive information. If this is not provided, Login operation will fail."
+            "description": "secretRef references to the secret for ScaleIO user and other sensitive information. If this is not provided, Login operation will fail."
           },
           "sslEnabled": {
-            "description": "Flag to enable/disable SSL communication with Gateway, default false",
+            "description": "sslEnabled is the flag to enable/disable SSL communication with Gateway, default false",
             "type": "boolean"
           },
           "storageMode": {
-            "description": "Indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned. Default is ThinProvisioned.",
+            "description": "storageMode indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned. Default is ThinProvisioned.",
             "type": "string"
           },
           "storagePool": {
-            "description": "The ScaleIO Storage Pool associated with the protection domain.",
+            "description": "storagePool is the ScaleIO Storage Pool associated with the protection domain.",
             "type": "string"
           },
           "system": {
             "default": "",
-            "description": "The name of the storage system as configured in ScaleIO.",
+            "description": "system is the name of the storage system as configured in ScaleIO.",
             "type": "string"
           },
           "volumeName": {
-            "description": "The name of a volume already created in the ScaleIO system that is associated with this volume source.",
+            "description": "volumeName is the name of a volume already created in the ScaleIO system that is associated with this volume source.",
             "type": "string"
           }
         },
@@ -903,11 +903,11 @@
         "description": "SecretReference represents a Secret Reference. It has enough information to retrieve secret in any namespace",
         "properties": {
           "name": {
-            "description": "Name is unique within a namespace to reference a secret resource.",
+            "description": "name is unique within a namespace to reference a secret resource.",
             "type": "string"
           },
           "namespace": {
-            "description": "Namespace defines the space within which the secret name must be unique.",
+            "description": "namespace defines the space within which the secret name must be unique.",
             "type": "string"
           }
         },
@@ -918,23 +918,23 @@
         "description": "Represents a StorageOS persistent volume resource.",
         "properties": {
           "fsType": {
-            "description": "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+            "description": "fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
             "type": "string"
           },
           "readOnly": {
-            "description": "Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
+            "description": "readOnly defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
             "type": "boolean"
           },
           "secretRef": {
             "$ref": "#/components/schemas/io.k8s.api.core.v1.ObjectReference",
-            "description": "SecretRef specifies the secret to use for obtaining the StorageOS API credentials.  If not specified, default values will be attempted."
+            "description": "secretRef specifies the secret to use for obtaining the StorageOS API credentials.  If not specified, default values will be attempted."
           },
           "volumeName": {
-            "description": "VolumeName is the human-readable name of the StorageOS volume.  Volume names are only unique within a namespace.",
+            "description": "volumeName is the human-readable name of the StorageOS volume.  Volume names are only unique within a namespace.",
             "type": "string"
           },
           "volumeNamespace": {
-            "description": "VolumeNamespace specifies the scope of the volume within StorageOS.  If no namespace is specified then the Pod's namespace will be used.  This allows the Kubernetes name scoping to be mirrored within StorageOS for tighter integration. Set VolumeName to any name to override the default behaviour. Set to \"default\" if you are not using namespaces within StorageOS. Namespaces that do not pre-exist within StorageOS will be created.",
+            "description": "volumeNamespace specifies the scope of the volume within StorageOS.  If no namespace is specified then the Pod's namespace will be used.  This allows the Kubernetes name scoping to be mirrored within StorageOS for tighter integration. Set VolumeName to any name to override the default behaviour. Set to \"default\" if you are not using namespaces within StorageOS. Namespaces that do not pre-exist within StorageOS will be created.",
             "type": "string"
           }
         },
@@ -992,20 +992,20 @@
         "description": "Represents a vSphere volume resource.",
         "properties": {
           "fsType": {
-            "description": "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+            "description": "fsType is filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
             "type": "string"
           },
           "storagePolicyID": {
-            "description": "Storage Policy Based Management (SPBM) profile ID associated with the StoragePolicyName.",
+            "description": "storagePolicyID is the storage Policy Based Management (SPBM) profile ID associated with the StoragePolicyName.",
             "type": "string"
           },
           "storagePolicyName": {
-            "description": "Storage Policy Based Management (SPBM) profile name.",
+            "description": "storagePolicyName is the storage Policy Based Management (SPBM) profile name.",
             "type": "string"
           },
           "volumePath": {
             "default": "",
-            "description": "Path that identifies vSphere volume vmdk",
+            "description": "volumePath is the path that identifies vSphere volume vmdk",
             "type": "string"
           }
         },

--- a/staging/src/k8s.io/api/core/v1/generated.proto
+++ b/staging/src/k8s.io/api/core/v1/generated.proto
@@ -37,11 +37,11 @@ option go_package = "v1";
 // can only be mounted as read/write once. AWS EBS volumes support
 // ownership management and SELinux relabeling.
 message AWSElasticBlockStoreVolumeSource {
-  // Unique ID of the persistent disk resource in AWS (Amazon EBS volume).
+  // volumeID is unique ID of the persistent disk resource in AWS (Amazon EBS volume).
   // More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
   optional string volumeID = 1;
 
-  // Filesystem type of the volume that you want to mount.
+  // fsType is the filesystem type of the volume that you want to mount.
   // Tip: Ensure that the filesystem type is supported by the host operating system.
   // Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
   // More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
@@ -49,15 +49,14 @@ message AWSElasticBlockStoreVolumeSource {
   // +optional
   optional string fsType = 2;
 
-  // The partition in the volume that you want to mount.
+  // partition is the partition in the volume that you want to mount.
   // If omitted, the default is to mount by volume name.
   // Examples: For volume /dev/sda1, you specify the partition as "1".
   // Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).
   // +optional
   optional int32 partition = 3;
 
-  // Specify "true" to force and set the ReadOnly property in VolumeMounts to "true".
-  // If omitted, the default is "false".
+  // readOnly value true will force the readOnly setting in VolumeMounts.
   // More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
   // +optional
   optional bool readOnly = 4;
@@ -99,45 +98,45 @@ message AvoidPods {
 
 // AzureDisk represents an Azure Data Disk mount on the host and bind mount to the pod.
 message AzureDiskVolumeSource {
-  // The Name of the data disk in the blob storage
+  // diskName is the Name of the data disk in the blob storage
   optional string diskName = 1;
 
-  // The URI the data disk in the blob storage
+  // diskURI is the URI of data disk in the blob storage
   optional string diskURI = 2;
 
-  // Host Caching mode: None, Read Only, Read Write.
+  // cachingMode is the Host Caching mode: None, Read Only, Read Write.
   // +optional
   optional string cachingMode = 3;
 
-  // Filesystem type to mount.
+  // fsType is Filesystem type to mount.
   // Must be a filesystem type supported by the host operating system.
   // Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
   // +optional
   optional string fsType = 4;
 
-  // Defaults to false (read/write). ReadOnly here will force
+  // readOnly Defaults to false (read/write). ReadOnly here will force
   // the ReadOnly setting in VolumeMounts.
   // +optional
   optional bool readOnly = 5;
 
-  // Expected values Shared: multiple blob disks per storage account  Dedicated: single blob disk per storage account  Managed: azure managed data disk (only in managed availability set). defaults to shared
+  // kind expected values are Shared: multiple blob disks per storage account  Dedicated: single blob disk per storage account  Managed: azure managed data disk (only in managed availability set). defaults to shared
   optional string kind = 6;
 }
 
 // AzureFile represents an Azure File Service mount on the host and bind mount to the pod.
 message AzureFilePersistentVolumeSource {
-  // the name of secret that contains Azure Storage Account Name and Key
+  // secretName is the name of secret that contains Azure Storage Account Name and Key
   optional string secretName = 1;
 
-  // Share Name
+  // shareName is the azure Share Name
   optional string shareName = 2;
 
-  // Defaults to false (read/write). ReadOnly here will force
+  // readOnly defaults to false (read/write). ReadOnly here will force
   // the ReadOnly setting in VolumeMounts.
   // +optional
   optional bool readOnly = 3;
 
-  // the namespace of the secret that contains Azure Storage Account Name and Key
+  // secretNamespace is the namespace of the secret that contains Azure Storage Account Name and Key
   // default is the same as the Pod
   // +optional
   optional string secretNamespace = 4;
@@ -145,13 +144,13 @@ message AzureFilePersistentVolumeSource {
 
 // AzureFile represents an Azure File Service mount on the host and bind mount to the pod.
 message AzureFileVolumeSource {
-  // the name of secret that contains Azure Storage Account Name and Key
+  // secretName is the  name of secret that contains Azure Storage Account Name and Key
   optional string secretName = 1;
 
-  // Share Name
+  // shareName is the azure share Name
   optional string shareName = 2;
 
-  // Defaults to false (read/write). ReadOnly here will force
+  // readOnly defaults to false (read/write). ReadOnly here will force
   // the ReadOnly setting in VolumeMounts.
   // +optional
   optional bool readOnly = 3;
@@ -273,30 +272,30 @@ message Capabilities {
 // Represents a Ceph Filesystem mount that lasts the lifetime of a pod
 // Cephfs volumes do not support ownership management or SELinux relabeling.
 message CephFSPersistentVolumeSource {
-  // Required: Monitors is a collection of Ceph monitors
+  // monitors is Required: Monitors is a collection of Ceph monitors
   // More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
   repeated string monitors = 1;
 
-  // Optional: Used as the mounted root, rather than the full Ceph tree, default is /
+  // path is Optional: Used as the mounted root, rather than the full Ceph tree, default is /
   // +optional
   optional string path = 2;
 
-  // Optional: User is the rados user name, default is admin
+  // user is Optional: User is the rados user name, default is admin
   // More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
   // +optional
   optional string user = 3;
 
-  // Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret
+  // secretFile is Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret
   // More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
   // +optional
   optional string secretFile = 4;
 
-  // Optional: SecretRef is reference to the authentication secret for User, default is empty.
+  // secretRef is Optional: SecretRef is reference to the authentication secret for User, default is empty.
   // More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
   // +optional
   optional SecretReference secretRef = 5;
 
-  // Optional: Defaults to false (read/write). ReadOnly here will force
+  // readOnly is Optional: Defaults to false (read/write). ReadOnly here will force
   // the ReadOnly setting in VolumeMounts.
   // More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
   // +optional
@@ -306,30 +305,30 @@ message CephFSPersistentVolumeSource {
 // Represents a Ceph Filesystem mount that lasts the lifetime of a pod
 // Cephfs volumes do not support ownership management or SELinux relabeling.
 message CephFSVolumeSource {
-  // Required: Monitors is a collection of Ceph monitors
+  // monitors is Required: Monitors is a collection of Ceph monitors
   // More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
   repeated string monitors = 1;
 
-  // Optional: Used as the mounted root, rather than the full Ceph tree, default is /
+  // path is Optional: Used as the mounted root, rather than the full Ceph tree, default is /
   // +optional
   optional string path = 2;
 
-  // Optional: User is the rados user name, default is admin
+  // user is optional: User is the rados user name, default is admin
   // More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
   // +optional
   optional string user = 3;
 
-  // Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret
+  // secretFile is Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret
   // More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
   // +optional
   optional string secretFile = 4;
 
-  // Optional: SecretRef is reference to the authentication secret for User, default is empty.
+  // secretRef is Optional: SecretRef is reference to the authentication secret for User, default is empty.
   // More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
   // +optional
   optional LocalObjectReference secretRef = 5;
 
-  // Optional: Defaults to false (read/write). ReadOnly here will force
+  // readOnly is Optional: Defaults to false (read/write). ReadOnly here will force
   // the ReadOnly setting in VolumeMounts.
   // More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
   // +optional
@@ -341,24 +340,24 @@ message CephFSVolumeSource {
 // The volume must also be in the same region as the kubelet.
 // Cinder volumes support ownership management and SELinux relabeling.
 message CinderPersistentVolumeSource {
-  // volume id used to identify the volume in cinder.
+  // volumeID used to identify the volume in cinder.
   // More info: https://examples.k8s.io/mysql-cinder-pd/README.md
   optional string volumeID = 1;
 
-  // Filesystem type to mount.
+  // fsType Filesystem type to mount.
   // Must be a filesystem type supported by the host operating system.
   // Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
   // More info: https://examples.k8s.io/mysql-cinder-pd/README.md
   // +optional
   optional string fsType = 2;
 
-  // Optional: Defaults to false (read/write). ReadOnly here will force
+  // readOnly is Optional: Defaults to false (read/write). ReadOnly here will force
   // the ReadOnly setting in VolumeMounts.
   // More info: https://examples.k8s.io/mysql-cinder-pd/README.md
   // +optional
   optional bool readOnly = 3;
 
-  // Optional: points to a secret object containing parameters used to connect
+  // secretRef is Optional: points to a secret object containing parameters used to connect
   // to OpenStack.
   // +optional
   optional SecretReference secretRef = 4;
@@ -369,24 +368,24 @@ message CinderPersistentVolumeSource {
 // The volume must also be in the same region as the kubelet.
 // Cinder volumes support ownership management and SELinux relabeling.
 message CinderVolumeSource {
-  // volume id used to identify the volume in cinder.
+  // volumeID used to identify the volume in cinder.
   // More info: https://examples.k8s.io/mysql-cinder-pd/README.md
   optional string volumeID = 1;
 
-  // Filesystem type to mount.
+  // fsType is the filesystem type to mount.
   // Must be a filesystem type supported by the host operating system.
   // Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
   // More info: https://examples.k8s.io/mysql-cinder-pd/README.md
   // +optional
   optional string fsType = 2;
 
-  // Optional: Defaults to false (read/write). ReadOnly here will force
+  // readOnly defaults to false (read/write). ReadOnly here will force
   // the ReadOnly setting in VolumeMounts.
   // More info: https://examples.k8s.io/mysql-cinder-pd/README.md
   // +optional
   optional bool readOnly = 3;
 
-  // Optional: points to a secret object containing parameters used to connect
+  // secretRef is optional: points to a secret object containing parameters used to connect
   // to OpenStack.
   // +optional
   optional LocalObjectReference secretRef = 4;
@@ -556,7 +555,7 @@ message ConfigMapNodeConfigSource {
 message ConfigMapProjection {
   optional LocalObjectReference localObjectReference = 1;
 
-  // If unspecified, each key-value pair in the Data field of the referenced
+  // items if unspecified, each key-value pair in the Data field of the referenced
   // ConfigMap will be projected into the volume as a file whose name is the
   // key and content is the value. If specified, the listed keys will be
   // projected into the specified paths, and unlisted keys will not be
@@ -566,7 +565,7 @@ message ConfigMapProjection {
   // +optional
   repeated KeyToPath items = 2;
 
-  // Specify whether the ConfigMap or its keys must be defined
+  // optional specify whether the ConfigMap or its keys must be defined
   // +optional
   optional bool optional = 4;
 }
@@ -580,7 +579,7 @@ message ConfigMapProjection {
 message ConfigMapVolumeSource {
   optional LocalObjectReference localObjectReference = 1;
 
-  // If unspecified, each key-value pair in the Data field of the referenced
+  // items if unspecified, each key-value pair in the Data field of the referenced
   // ConfigMap will be projected into the volume as a file whose name is the
   // key and content is the value. If specified, the listed keys will be
   // projected into the specified paths, and unlisted keys will not be
@@ -590,7 +589,7 @@ message ConfigMapVolumeSource {
   // +optional
   repeated KeyToPath items = 2;
 
-  // Optional: mode bits used to set permissions on created files by default.
+  // defaultMode is optional: mode bits used to set permissions on created files by default.
   // Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
   // YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
   // Defaults to 0644.
@@ -600,7 +599,7 @@ message ConfigMapVolumeSource {
   // +optional
   optional int32 defaultMode = 3;
 
-  // Specify whether the ConfigMap or its keys must be defined
+  // optional specify whether the ConfigMap or its keys must be defined
   // +optional
   optional bool optional = 4;
 }
@@ -990,14 +989,14 @@ message DownwardAPIVolumeSource {
 // Represents an empty directory for a pod.
 // Empty directory volumes support ownership management and SELinux relabeling.
 message EmptyDirVolumeSource {
-  // What type of storage medium should back this directory.
+  // medium represents what type of storage medium should back this directory.
   // The default is "" which means to use the node's default medium.
   // Must be an empty string (default) or Memory.
   // More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
   // +optional
   optional string medium = 1;
 
-  // Total amount of local storage required for this EmptyDir volume.
+  // sizeLimit is the total amount of local storage required for this EmptyDir volume.
   // The size limit is also applicable for memory medium.
   // The maximum usage on memory medium EmptyDir would be the minimum value between
   // the SizeLimit specified here and the sum of memory limits of all containers in a pod.
@@ -1511,27 +1510,27 @@ message ExecAction {
 // Fibre Channel volumes can only be mounted as read/write once.
 // Fibre Channel volumes support ownership management and SELinux relabeling.
 message FCVolumeSource {
-  // Optional: FC target worldwide names (WWNs)
+  // targetWWNs is Optional: FC target worldwide names (WWNs)
   // +optional
   repeated string targetWWNs = 1;
 
-  // Optional: FC target lun number
+  // lun is Optional: FC target lun number
   // +optional
   optional int32 lun = 2;
 
-  // Filesystem type to mount.
+  // fsType is the filesystem type to mount.
   // Must be a filesystem type supported by the host operating system.
   // Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
   // TODO: how do we prevent errors in the filesystem from compromising the machine
   // +optional
   optional string fsType = 3;
 
-  // Optional: Defaults to false (read/write). ReadOnly here will force
+  // readOnly is Optional: Defaults to false (read/write). ReadOnly here will force
   // the ReadOnly setting in VolumeMounts.
   // +optional
   optional bool readOnly = 4;
 
-  // Optional: FC volume world wide identifiers (wwids)
+  // wwids Optional: FC volume world wide identifiers (wwids)
   // Either wwids or combination of targetWWNs and lun must be set, but not both simultaneously.
   // +optional
   repeated string wwids = 5;
@@ -1540,16 +1539,16 @@ message FCVolumeSource {
 // FlexPersistentVolumeSource represents a generic persistent volume resource that is
 // provisioned/attached using an exec based plugin.
 message FlexPersistentVolumeSource {
-  // Driver is the name of the driver to use for this volume.
+  // driver is the name of the driver to use for this volume.
   optional string driver = 1;
 
-  // Filesystem type to mount.
+  // fsType is the Filesystem type to mount.
   // Must be a filesystem type supported by the host operating system.
   // Ex. "ext4", "xfs", "ntfs". The default filesystem depends on FlexVolume script.
   // +optional
   optional string fsType = 2;
 
-  // Optional: SecretRef is reference to the secret object containing
+  // secretRef is Optional: SecretRef is reference to the secret object containing
   // sensitive information to pass to the plugin scripts. This may be
   // empty if no secret object is specified. If the secret object
   // contains more than one secret, all secrets are passed to the plugin
@@ -1557,12 +1556,12 @@ message FlexPersistentVolumeSource {
   // +optional
   optional SecretReference secretRef = 3;
 
-  // Optional: Defaults to false (read/write). ReadOnly here will force
+  // readOnly is Optional: defaults to false (read/write). ReadOnly here will force
   // the ReadOnly setting in VolumeMounts.
   // +optional
   optional bool readOnly = 4;
 
-  // Optional: Extra command options if any.
+  // options is Optional: this field holds extra command options if any.
   // +optional
   map<string, string> options = 5;
 }
@@ -1570,16 +1569,16 @@ message FlexPersistentVolumeSource {
 // FlexVolume represents a generic volume resource that is
 // provisioned/attached using an exec based plugin.
 message FlexVolumeSource {
-  // Driver is the name of the driver to use for this volume.
+  // driver is the name of the driver to use for this volume.
   optional string driver = 1;
 
-  // Filesystem type to mount.
+  // fsType is the filesystem type to mount.
   // Must be a filesystem type supported by the host operating system.
   // Ex. "ext4", "xfs", "ntfs". The default filesystem depends on FlexVolume script.
   // +optional
   optional string fsType = 2;
 
-  // Optional: SecretRef is reference to the secret object containing
+  // secretRef is Optional: secretRef is reference to the secret object containing
   // sensitive information to pass to the plugin scripts. This may be
   // empty if no secret object is specified. If the secret object
   // contains more than one secret, all secrets are passed to the plugin
@@ -1587,12 +1586,12 @@ message FlexVolumeSource {
   // +optional
   optional LocalObjectReference secretRef = 3;
 
-  // Optional: Defaults to false (read/write). ReadOnly here will force
+  // readOnly is Optional: defaults to false (read/write). ReadOnly here will force
   // the ReadOnly setting in VolumeMounts.
   // +optional
   optional bool readOnly = 4;
 
-  // Optional: Extra command options if any.
+  // options is Optional: this field holds extra command options if any.
   // +optional
   map<string, string> options = 5;
 }
@@ -1601,12 +1600,12 @@ message FlexVolumeSource {
 // One and only one of datasetName and datasetUUID should be set.
 // Flocker volumes do not support ownership management or SELinux relabeling.
 message FlockerVolumeSource {
-  // Name of the dataset stored as metadata -> name on the dataset for Flocker
+  // datasetName is Name of the dataset stored as metadata -> name on the dataset for Flocker
   // should be considered as deprecated
   // +optional
   optional string datasetName = 1;
 
-  // UUID of the dataset. This is unique identifier of a Flocker dataset
+  // datasetUUID is the UUID of the dataset. This is unique identifier of a Flocker dataset
   // +optional
   optional string datasetUUID = 2;
 }
@@ -1618,11 +1617,11 @@ message FlockerVolumeSource {
 // can only be mounted as read/write once or read-only many times. GCE
 // PDs support ownership management and SELinux relabeling.
 message GCEPersistentDiskVolumeSource {
-  // Unique name of the PD resource in GCE. Used to identify the disk in GCE.
+  // pdName is unique name of the PD resource in GCE. Used to identify the disk in GCE.
   // More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
   optional string pdName = 1;
 
-  // Filesystem type of the volume that you want to mount.
+  // fsType is filesystem type of the volume that you want to mount.
   // Tip: Ensure that the filesystem type is supported by the host operating system.
   // Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
   // More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
@@ -1630,7 +1629,7 @@ message GCEPersistentDiskVolumeSource {
   // +optional
   optional string fsType = 2;
 
-  // The partition in the volume that you want to mount.
+  // partition is the partition in the volume that you want to mount.
   // If omitted, the default is to mount by volume name.
   // Examples: For volume /dev/sda1, you specify the partition as "1".
   // Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).
@@ -1638,7 +1637,7 @@ message GCEPersistentDiskVolumeSource {
   // +optional
   optional int32 partition = 3;
 
-  // ReadOnly here will force the ReadOnly setting in VolumeMounts.
+  // readOnly here will force the ReadOnly setting in VolumeMounts.
   // Defaults to false.
   // More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
   // +optional
@@ -1666,14 +1665,14 @@ message GRPCAction {
 // EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir
 // into the Pod's container.
 message GitRepoVolumeSource {
-  // Repository URL
+  // repository is the URL
   optional string repository = 1;
 
-  // Commit hash for the specified revision.
+  // revision is the commit hash for the specified revision.
   // +optional
   optional string revision = 2;
 
-  // Target directory name.
+  // directory is the target directory name.
   // Must not contain or start with '..'.  If '.' is supplied, the volume directory will be the
   // git repository.  Otherwise, if specified, the volume will contain the git repository in
   // the subdirectory with the given name.
@@ -1684,21 +1683,21 @@ message GitRepoVolumeSource {
 // Represents a Glusterfs mount that lasts the lifetime of a pod.
 // Glusterfs volumes do not support ownership management or SELinux relabeling.
 message GlusterfsPersistentVolumeSource {
-  // EndpointsName is the endpoint name that details Glusterfs topology.
+  // endpoints is the endpoint name that details Glusterfs topology.
   // More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
   optional string endpoints = 1;
 
-  // Path is the Glusterfs volume path.
+  // path is the Glusterfs volume path.
   // More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
   optional string path = 2;
 
-  // ReadOnly here will force the Glusterfs volume to be mounted with read-only permissions.
+  // readOnly here will force the Glusterfs volume to be mounted with read-only permissions.
   // Defaults to false.
   // More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
   // +optional
   optional bool readOnly = 3;
 
-  // EndpointsNamespace is the namespace that contains Glusterfs endpoint.
+  // endpointsNamespace is the namespace that contains Glusterfs endpoint.
   // If this field is empty, the EndpointNamespace defaults to the same namespace as the bound PVC.
   // More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
   // +optional
@@ -1708,15 +1707,15 @@ message GlusterfsPersistentVolumeSource {
 // Represents a Glusterfs mount that lasts the lifetime of a pod.
 // Glusterfs volumes do not support ownership management or SELinux relabeling.
 message GlusterfsVolumeSource {
-  // EndpointsName is the endpoint name that details Glusterfs topology.
+  // endpoints is the endpoint name that details Glusterfs topology.
   // More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
   optional string endpoints = 1;
 
-  // Path is the Glusterfs volume path.
+  // path is the Glusterfs volume path.
   // More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
   optional string path = 2;
 
-  // ReadOnly here will force the Glusterfs volume to be mounted with read-only permissions.
+  // readOnly here will force the Glusterfs volume to be mounted with read-only permissions.
   // Defaults to false.
   // More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
   // +optional
@@ -1771,12 +1770,12 @@ message HostAlias {
 // Represents a host path mapped into a pod.
 // Host path volumes do not support ownership management or SELinux relabeling.
 message HostPathVolumeSource {
-  // Path of the directory on the host.
+  // path of the directory on the host.
   // If the path is a symlink, it will follow the link to the real path.
   // More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
   optional string path = 1;
 
-  // Type for HostPath Volume
+  // type for HostPath Volume
   // Defaults to ""
   // More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
   // +optional
@@ -1787,22 +1786,22 @@ message HostPathVolumeSource {
 // ISCSI volumes can only be mounted as read/write once.
 // ISCSI volumes support ownership management and SELinux relabeling.
 message ISCSIPersistentVolumeSource {
-  // iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port
+  // targetPortal is iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port
   // is other than default (typically TCP ports 860 and 3260).
   optional string targetPortal = 1;
 
-  // Target iSCSI Qualified Name.
+  // iqn is Target iSCSI Qualified Name.
   optional string iqn = 2;
 
-  // iSCSI Target Lun number.
+  // lun is iSCSI Target Lun number.
   optional int32 lun = 3;
 
-  // iSCSI Interface Name that uses an iSCSI transport.
+  // iscsiInterface is the interface Name that uses an iSCSI transport.
   // Defaults to 'default' (tcp).
   // +optional
   optional string iscsiInterface = 4;
 
-  // Filesystem type of the volume that you want to mount.
+  // fsType is the filesystem type of the volume that you want to mount.
   // Tip: Ensure that the filesystem type is supported by the host operating system.
   // Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
   // More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi
@@ -1810,29 +1809,29 @@ message ISCSIPersistentVolumeSource {
   // +optional
   optional string fsType = 5;
 
-  // ReadOnly here will force the ReadOnly setting in VolumeMounts.
+  // readOnly here will force the ReadOnly setting in VolumeMounts.
   // Defaults to false.
   // +optional
   optional bool readOnly = 6;
 
-  // iSCSI Target Portal List. The Portal is either an IP or ip_addr:port if the port
+  // portals is the iSCSI Target Portal List. The Portal is either an IP or ip_addr:port if the port
   // is other than default (typically TCP ports 860 and 3260).
   // +optional
   repeated string portals = 7;
 
-  // whether support iSCSI Discovery CHAP authentication
+  // chapAuthDiscovery defines whether support iSCSI Discovery CHAP authentication
   // +optional
   optional bool chapAuthDiscovery = 8;
 
-  // whether support iSCSI Session CHAP authentication
+  // chapAuthSession defines whether support iSCSI Session CHAP authentication
   // +optional
   optional bool chapAuthSession = 11;
 
-  // CHAP Secret for iSCSI target and initiator authentication
+  // secretRef is the CHAP Secret for iSCSI target and initiator authentication
   // +optional
   optional SecretReference secretRef = 10;
 
-  // Custom iSCSI Initiator Name.
+  // initiatorName is the custom iSCSI Initiator Name.
   // If initiatorName is specified with iscsiInterface simultaneously, new iSCSI interface
   // <target portal>:<volume name> will be created for the connection.
   // +optional
@@ -1843,22 +1842,22 @@ message ISCSIPersistentVolumeSource {
 // ISCSI volumes can only be mounted as read/write once.
 // ISCSI volumes support ownership management and SELinux relabeling.
 message ISCSIVolumeSource {
-  // iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port
+  // targetPortal is iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port
   // is other than default (typically TCP ports 860 and 3260).
   optional string targetPortal = 1;
 
-  // Target iSCSI Qualified Name.
+  // iqn is the target iSCSI Qualified Name.
   optional string iqn = 2;
 
-  // iSCSI Target Lun number.
+  // lun represents iSCSI Target Lun number.
   optional int32 lun = 3;
 
-  // iSCSI Interface Name that uses an iSCSI transport.
+  // iscsiInterface is the interface Name that uses an iSCSI transport.
   // Defaults to 'default' (tcp).
   // +optional
   optional string iscsiInterface = 4;
 
-  // Filesystem type of the volume that you want to mount.
+  // fsType is the filesystem type of the volume that you want to mount.
   // Tip: Ensure that the filesystem type is supported by the host operating system.
   // Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
   // More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi
@@ -1866,29 +1865,29 @@ message ISCSIVolumeSource {
   // +optional
   optional string fsType = 5;
 
-  // ReadOnly here will force the ReadOnly setting in VolumeMounts.
+  // readOnly here will force the ReadOnly setting in VolumeMounts.
   // Defaults to false.
   // +optional
   optional bool readOnly = 6;
 
-  // iSCSI Target Portal List. The portal is either an IP or ip_addr:port if the port
+  // portals is the iSCSI Target Portal List. The portal is either an IP or ip_addr:port if the port
   // is other than default (typically TCP ports 860 and 3260).
   // +optional
   repeated string portals = 7;
 
-  // whether support iSCSI Discovery CHAP authentication
+  // chapAuthDiscovery defines whether support iSCSI Discovery CHAP authentication
   // +optional
   optional bool chapAuthDiscovery = 8;
 
-  // whether support iSCSI Session CHAP authentication
+  // chapAuthSession defines whether support iSCSI Session CHAP authentication
   // +optional
   optional bool chapAuthSession = 11;
 
-  // CHAP Secret for iSCSI target and initiator authentication
+  // secretRef is the CHAP Secret for iSCSI target and initiator authentication
   // +optional
   optional LocalObjectReference secretRef = 10;
 
-  // Custom iSCSI Initiator Name.
+  // initiatorName is the custom iSCSI Initiator Name.
   // If initiatorName is specified with iscsiInterface simultaneously, new iSCSI interface
   // <target portal>:<volume name> will be created for the connection.
   // +optional
@@ -1897,16 +1896,16 @@ message ISCSIVolumeSource {
 
 // Maps a string key to a path within a volume.
 message KeyToPath {
-  // The key to project.
+  // key is the key to project.
   optional string key = 1;
 
-  // The relative path of the file to map the key to.
+  // path is the relative path of the file to map the key to.
   // May not be an absolute path.
   // May not contain the path element '..'.
   // May not start with the string '..'.
   optional string path = 2;
 
-  // Optional: mode bits used to set permissions on this file.
+  // mode is Optional: mode bits used to set permissions on this file.
   // Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
   // YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
   // If not specified, the volume defaultMode will be used.
@@ -2067,11 +2066,11 @@ message LocalObjectReference {
 
 // Local represents directly-attached storage with node affinity (Beta feature)
 message LocalVolumeSource {
-  // The full path to the volume on the node.
+  // path of the full path to the volume on the node.
   // It can be either a directory or block device (disk, partition, ...).
   optional string path = 1;
 
-  // Filesystem type to mount.
+  // fsType is the filesystem type to mount.
   // It applies only when the Path is a block device.
   // Must be a filesystem type supported by the host operating system.
   // Ex. "ext4", "xfs", "ntfs". The default value is to auto-select a filesystem if unspecified.
@@ -2082,16 +2081,15 @@ message LocalVolumeSource {
 // Represents an NFS mount that lasts the lifetime of a pod.
 // NFS volumes do not support ownership management or SELinux relabeling.
 message NFSVolumeSource {
-  // Server is the hostname or IP address of the NFS server.
+  // server is the hostname or IP address of the NFS server.
   // More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
   optional string server = 1;
 
-  // Path that is exported by the NFS server.
+  // path that is exported by the NFS server.
   // More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
   optional string path = 2;
 
-  // ReadOnly here will force
-  // the NFS export to be mounted with read-only permissions.
+  // readOnly here will force the NFS export to be mounted with read-only permissions.
   // Defaults to false.
   // More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
   // +optional
@@ -2994,10 +2992,10 @@ message PersistentVolumeStatus {
 
 // Represents a Photon Controller persistent disk resource.
 message PhotonPersistentDiskVolumeSource {
-  // ID that identifies Photon Controller persistent disk
+  // pdID is the ID that identifies Photon Controller persistent disk
   optional string pdID = 1;
 
-  // Filesystem type to mount.
+  // fsType is the filesystem type to mount.
   // Must be a filesystem type supported by the host operating system.
   // Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
   optional string fsType = 2;
@@ -3907,15 +3905,15 @@ message PortStatus {
 
 // PortworxVolumeSource represents a Portworx volume resource.
 message PortworxVolumeSource {
-  // VolumeID uniquely identifies a Portworx volume
+  // volumeID uniquely identifies a Portworx volume
   optional string volumeID = 1;
 
-  // FSType represents the filesystem type to mount
+  // fSType represents the filesystem type to mount
   // Must be a filesystem type supported by the host operating system.
   // Ex. "ext4", "xfs". Implicitly inferred to be "ext4" if unspecified.
   optional string fsType = 2;
 
-  // Defaults to false (read/write). ReadOnly here will force
+  // readOnly defaults to false (read/write). ReadOnly here will force
   // the ReadOnly setting in VolumeMounts.
   // +optional
   optional bool readOnly = 3;
@@ -4027,11 +4025,11 @@ message ProbeHandler {
 
 // Represents a projected volume source
 message ProjectedVolumeSource {
-  // list of volume projections
+  // sources is the list of volume projections
   // +optional
   repeated VolumeProjection sources = 1;
 
-  // Mode bits used to set permissions on created files by default.
+  // defaultMode are the mode bits used to set permissions on created files by default.
   // Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
   // YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
   // Directories within the path are not affected by this setting.
@@ -4044,30 +4042,30 @@ message ProjectedVolumeSource {
 // Represents a Quobyte mount that lasts the lifetime of a pod.
 // Quobyte volumes do not support ownership management or SELinux relabeling.
 message QuobyteVolumeSource {
-  // Registry represents a single or multiple Quobyte Registry services
+  // registry represents a single or multiple Quobyte Registry services
   // specified as a string as host:port pair (multiple entries are separated with commas)
   // which acts as the central registry for volumes
   optional string registry = 1;
 
-  // Volume is a string that references an already created Quobyte volume by name.
+  // volume is a string that references an already created Quobyte volume by name.
   optional string volume = 2;
 
-  // ReadOnly here will force the Quobyte volume to be mounted with read-only permissions.
+  // readOnly here will force the Quobyte volume to be mounted with read-only permissions.
   // Defaults to false.
   // +optional
   optional bool readOnly = 3;
 
-  // User to map volume access to
+  // user to map volume access to
   // Defaults to serivceaccount user
   // +optional
   optional string user = 4;
 
-  // Group to map volume access to
+  // group to map volume access to
   // Default is no group
   // +optional
   optional string group = 5;
 
-  // Tenant owning the given Quobyte volume in the Backend
+  // tenant owning the given Quobyte volume in the Backend
   // Used with dynamically provisioned Quobyte volumes, value is set by the plugin
   // +optional
   optional string tenant = 6;
@@ -4076,15 +4074,15 @@ message QuobyteVolumeSource {
 // Represents a Rados Block Device mount that lasts the lifetime of a pod.
 // RBD volumes support ownership management and SELinux relabeling.
 message RBDPersistentVolumeSource {
-  // A collection of Ceph monitors.
+  // monitors is a collection of Ceph monitors.
   // More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
   repeated string monitors = 1;
 
-  // The rados image name.
+  // image is the rados image name.
   // More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
   optional string image = 2;
 
-  // Filesystem type of the volume that you want to mount.
+  // fsType is the filesystem type of the volume that you want to mount.
   // Tip: Ensure that the filesystem type is supported by the host operating system.
   // Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
   // More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd
@@ -4092,32 +4090,32 @@ message RBDPersistentVolumeSource {
   // +optional
   optional string fsType = 3;
 
-  // The rados pool name.
+  // pool is the rados pool name.
   // Default is rbd.
   // More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
   // +optional
   optional string pool = 4;
 
-  // The rados user name.
+  // user is the rados user name.
   // Default is admin.
   // More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
   // +optional
   optional string user = 5;
 
-  // Keyring is the path to key ring for RBDUser.
+  // keyring is the path to key ring for RBDUser.
   // Default is /etc/ceph/keyring.
   // More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
   // +optional
   optional string keyring = 6;
 
-  // SecretRef is name of the authentication secret for RBDUser. If provided
+  // secretRef is name of the authentication secret for RBDUser. If provided
   // overrides keyring.
   // Default is nil.
   // More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
   // +optional
   optional SecretReference secretRef = 7;
 
-  // ReadOnly here will force the ReadOnly setting in VolumeMounts.
+  // readOnly here will force the ReadOnly setting in VolumeMounts.
   // Defaults to false.
   // More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
   // +optional
@@ -4127,15 +4125,15 @@ message RBDPersistentVolumeSource {
 // Represents a Rados Block Device mount that lasts the lifetime of a pod.
 // RBD volumes support ownership management and SELinux relabeling.
 message RBDVolumeSource {
-  // A collection of Ceph monitors.
+  // monitors is a collection of Ceph monitors.
   // More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
   repeated string monitors = 1;
 
-  // The rados image name.
+  // image is the rados image name.
   // More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
   optional string image = 2;
 
-  // Filesystem type of the volume that you want to mount.
+  // fsType is the filesystem type of the volume that you want to mount.
   // Tip: Ensure that the filesystem type is supported by the host operating system.
   // Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
   // More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd
@@ -4143,32 +4141,32 @@ message RBDVolumeSource {
   // +optional
   optional string fsType = 3;
 
-  // The rados pool name.
+  // pool is the rados pool name.
   // Default is rbd.
   // More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
   // +optional
   optional string pool = 4;
 
-  // The rados user name.
+  // user is the rados user name.
   // Default is admin.
   // More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
   // +optional
   optional string user = 5;
 
-  // Keyring is the path to key ring for RBDUser.
+  // keyring is the path to key ring for RBDUser.
   // Default is /etc/ceph/keyring.
   // More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
   // +optional
   optional string keyring = 6;
 
-  // SecretRef is name of the authentication secret for RBDUser. If provided
+  // secretRef is name of the authentication secret for RBDUser. If provided
   // overrides keyring.
   // Default is nil.
   // More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
   // +optional
   optional LocalObjectReference secretRef = 7;
 
-  // ReadOnly here will force the ReadOnly setting in VolumeMounts.
+  // readOnly here will force the ReadOnly setting in VolumeMounts.
   // Defaults to false.
   // More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
   // +optional
@@ -4417,45 +4415,45 @@ message SELinuxOptions {
 
 // ScaleIOPersistentVolumeSource represents a persistent ScaleIO volume
 message ScaleIOPersistentVolumeSource {
-  // The host address of the ScaleIO API Gateway.
+  // gateway is the host address of the ScaleIO API Gateway.
   optional string gateway = 1;
 
-  // The name of the storage system as configured in ScaleIO.
+  // system is the name of the storage system as configured in ScaleIO.
   optional string system = 2;
 
-  // SecretRef references to the secret for ScaleIO user and other
+  // secretRef references to the secret for ScaleIO user and other
   // sensitive information. If this is not provided, Login operation will fail.
   optional SecretReference secretRef = 3;
 
-  // Flag to enable/disable SSL communication with Gateway, default false
+  // sslEnabled is the flag to enable/disable SSL communication with Gateway, default false
   // +optional
   optional bool sslEnabled = 4;
 
-  // The name of the ScaleIO Protection Domain for the configured storage.
+  // protectionDomain is the name of the ScaleIO Protection Domain for the configured storage.
   // +optional
   optional string protectionDomain = 5;
 
-  // The ScaleIO Storage Pool associated with the protection domain.
+  // storagePool is the ScaleIO Storage Pool associated with the protection domain.
   // +optional
   optional string storagePool = 6;
 
-  // Indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned.
+  // storageMode indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned.
   // Default is ThinProvisioned.
   // +optional
   optional string storageMode = 7;
 
-  // The name of a volume already created in the ScaleIO system
+  // volumeName is the name of a volume already created in the ScaleIO system
   // that is associated with this volume source.
   optional string volumeName = 8;
 
-  // Filesystem type to mount.
+  // fsType is the filesystem type to mount.
   // Must be a filesystem type supported by the host operating system.
   // Ex. "ext4", "xfs", "ntfs".
   // Default is "xfs"
   // +optional
   optional string fsType = 9;
 
-  // Defaults to false (read/write). ReadOnly here will force
+  // readOnly defaults to false (read/write). ReadOnly here will force
   // the ReadOnly setting in VolumeMounts.
   // +optional
   optional bool readOnly = 10;
@@ -4463,45 +4461,45 @@ message ScaleIOPersistentVolumeSource {
 
 // ScaleIOVolumeSource represents a persistent ScaleIO volume
 message ScaleIOVolumeSource {
-  // The host address of the ScaleIO API Gateway.
+  // gateway is the host address of the ScaleIO API Gateway.
   optional string gateway = 1;
 
-  // The name of the storage system as configured in ScaleIO.
+  // system is the name of the storage system as configured in ScaleIO.
   optional string system = 2;
 
-  // SecretRef references to the secret for ScaleIO user and other
+  // secretRef references to the secret for ScaleIO user and other
   // sensitive information. If this is not provided, Login operation will fail.
   optional LocalObjectReference secretRef = 3;
 
-  // Flag to enable/disable SSL communication with Gateway, default false
+  // sslEnabled Flag enable/disable SSL communication with Gateway, default false
   // +optional
   optional bool sslEnabled = 4;
 
-  // The name of the ScaleIO Protection Domain for the configured storage.
+  // protectionDomain is the name of the ScaleIO Protection Domain for the configured storage.
   // +optional
   optional string protectionDomain = 5;
 
-  // The ScaleIO Storage Pool associated with the protection domain.
+  // storagePool is the ScaleIO Storage Pool associated with the protection domain.
   // +optional
   optional string storagePool = 6;
 
-  // Indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned.
+  // storageMode indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned.
   // Default is ThinProvisioned.
   // +optional
   optional string storageMode = 7;
 
-  // The name of a volume already created in the ScaleIO system
+  // volumeName is the name of a volume already created in the ScaleIO system
   // that is associated with this volume source.
   optional string volumeName = 8;
 
-  // Filesystem type to mount.
+  // fsType is the filesystem type to mount.
   // Must be a filesystem type supported by the host operating system.
   // Ex. "ext4", "xfs", "ntfs".
   // Default is "xfs".
   // +optional
   optional string fsType = 9;
 
-  // Defaults to false (read/write). ReadOnly here will force
+  // readOnly Defaults to false (read/write). ReadOnly here will force
   // the ReadOnly setting in VolumeMounts.
   // +optional
   optional bool readOnly = 10;
@@ -4640,7 +4638,7 @@ message SecretList {
 message SecretProjection {
   optional LocalObjectReference localObjectReference = 1;
 
-  // If unspecified, each key-value pair in the Data field of the referenced
+  // items if unspecified, each key-value pair in the Data field of the referenced
   // Secret will be projected into the volume as a file whose name is the
   // key and content is the value. If specified, the listed keys will be
   // projected into the specified paths, and unlisted keys will not be
@@ -4650,7 +4648,7 @@ message SecretProjection {
   // +optional
   repeated KeyToPath items = 2;
 
-  // Specify whether the Secret or its key must be defined
+  // optional field specify whether the Secret or its key must be defined
   // +optional
   optional bool optional = 4;
 }
@@ -4659,11 +4657,11 @@ message SecretProjection {
 // in any namespace
 // +structType=atomic
 message SecretReference {
-  // Name is unique within a namespace to reference a secret resource.
+  // name is unique within a namespace to reference a secret resource.
   // +optional
   optional string name = 1;
 
-  // Namespace defines the space within which the secret name must be unique.
+  // namespace defines the space within which the secret name must be unique.
   // +optional
   optional string namespace = 2;
 }
@@ -4674,12 +4672,12 @@ message SecretReference {
 // as files using the keys in the Data field as the file names.
 // Secret volumes support ownership management and SELinux relabeling.
 message SecretVolumeSource {
-  // Name of the secret in the pod's namespace to use.
+  // secretName is the name of the secret in the pod's namespace to use.
   // More info: https://kubernetes.io/docs/concepts/storage/volumes#secret
   // +optional
   optional string secretName = 1;
 
-  // If unspecified, each key-value pair in the Data field of the referenced
+  // items If unspecified, each key-value pair in the Data field of the referenced
   // Secret will be projected into the volume as a file whose name is the
   // key and content is the value. If specified, the listed keys will be
   // projected into the specified paths, and unlisted keys will not be
@@ -4689,7 +4687,7 @@ message SecretVolumeSource {
   // +optional
   repeated KeyToPath items = 2;
 
-  // Optional: mode bits used to set permissions on created files by default.
+  // defaultMode is Optional: mode bits used to set permissions on created files by default.
   // Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
   // YAML accepts both octal and decimal values, JSON requires decimal values
   // for mode bits. Defaults to 0644.
@@ -4699,7 +4697,7 @@ message SecretVolumeSource {
   // +optional
   optional int32 defaultMode = 3;
 
-  // Specify whether the Secret or its keys must be defined
+  // optional field specify whether the Secret or its keys must be defined
   // +optional
   optional bool optional = 4;
 }
@@ -4869,14 +4867,14 @@ message ServiceAccountList {
 // the pods runtime filesystem for use against APIs (Kubernetes API Server or
 // otherwise).
 message ServiceAccountTokenProjection {
-  // Audience is the intended audience of the token. A recipient of a token
+  // audience is the intended audience of the token. A recipient of a token
   // must identify itself with an identifier specified in the audience of the
   // token, and otherwise should reject the token. The audience defaults to the
   // identifier of the apiserver.
   // +optional
   optional string audience = 1;
 
-  // ExpirationSeconds is the requested duration of validity of the service
+  // expirationSeconds is the requested duration of validity of the service
   // account token. As the token approaches expiration, the kubelet volume
   // plugin will proactively rotate the service account token. The kubelet will
   // start trying to rotate the token if the token is older than 80 percent of
@@ -4885,7 +4883,7 @@ message ServiceAccountTokenProjection {
   // +optional
   optional int64 expirationSeconds = 2;
 
-  // Path is the path relative to the mount point of the file to project the
+  // path is the path relative to the mount point of the file to project the
   // token into.
   optional string path = 3;
 }
@@ -5217,11 +5215,11 @@ message SessionAffinityConfig {
 
 // Represents a StorageOS persistent volume resource.
 message StorageOSPersistentVolumeSource {
-  // VolumeName is the human-readable name of the StorageOS volume.  Volume
+  // volumeName is the human-readable name of the StorageOS volume.  Volume
   // names are only unique within a namespace.
   optional string volumeName = 1;
 
-  // VolumeNamespace specifies the scope of the volume within StorageOS.  If no
+  // volumeNamespace specifies the scope of the volume within StorageOS.  If no
   // namespace is specified then the Pod's namespace will be used.  This allows the
   // Kubernetes name scoping to be mirrored within StorageOS for tighter integration.
   // Set VolumeName to any name to override the default behaviour.
@@ -5230,18 +5228,18 @@ message StorageOSPersistentVolumeSource {
   // +optional
   optional string volumeNamespace = 2;
 
-  // Filesystem type to mount.
+  // fsType is the filesystem type to mount.
   // Must be a filesystem type supported by the host operating system.
   // Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
   // +optional
   optional string fsType = 3;
 
-  // Defaults to false (read/write). ReadOnly here will force
+  // readOnly defaults to false (read/write). ReadOnly here will force
   // the ReadOnly setting in VolumeMounts.
   // +optional
   optional bool readOnly = 4;
 
-  // SecretRef specifies the secret to use for obtaining the StorageOS API
+  // secretRef specifies the secret to use for obtaining the StorageOS API
   // credentials.  If not specified, default values will be attempted.
   // +optional
   optional ObjectReference secretRef = 5;
@@ -5249,11 +5247,11 @@ message StorageOSPersistentVolumeSource {
 
 // Represents a StorageOS persistent volume resource.
 message StorageOSVolumeSource {
-  // VolumeName is the human-readable name of the StorageOS volume.  Volume
+  // volumeName is the human-readable name of the StorageOS volume.  Volume
   // names are only unique within a namespace.
   optional string volumeName = 1;
 
-  // VolumeNamespace specifies the scope of the volume within StorageOS.  If no
+  // volumeNamespace specifies the scope of the volume within StorageOS.  If no
   // namespace is specified then the Pod's namespace will be used.  This allows the
   // Kubernetes name scoping to be mirrored within StorageOS for tighter integration.
   // Set VolumeName to any name to override the default behaviour.
@@ -5262,18 +5260,18 @@ message StorageOSVolumeSource {
   // +optional
   optional string volumeNamespace = 2;
 
-  // Filesystem type to mount.
+  // fsType is the filesystem type to mount.
   // Must be a filesystem type supported by the host operating system.
   // Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
   // +optional
   optional string fsType = 3;
 
-  // Defaults to false (read/write). ReadOnly here will force
+  // readOnly defaults to false (read/write). ReadOnly here will force
   // the ReadOnly setting in VolumeMounts.
   // +optional
   optional bool readOnly = 4;
 
-  // SecretRef specifies the secret to use for obtaining the StorageOS API
+  // secretRef specifies the secret to use for obtaining the StorageOS API
   // credentials.  If not specified, default values will be attempted.
   // +optional
   optional LocalObjectReference secretRef = 5;
@@ -5516,19 +5514,19 @@ message VolumeNodeAffinity {
 
 // Projection that may be projected along with other supported volume types
 message VolumeProjection {
-  // information about the secret data to project
+  // secret information about the secret data to project
   // +optional
   optional SecretProjection secret = 1;
 
-  // information about the downwardAPI data to project
+  // downwardAPI information about the downwardAPI data to project
   // +optional
   optional DownwardAPIProjection downwardAPI = 2;
 
-  // information about the configMap data to project
+  // configMap information about the configMap data to project
   // +optional
   optional ConfigMapProjection configMap = 3;
 
-  // information about the serviceAccountToken data to project
+  // serviceAccountToken is information about the serviceAccountToken data to project
   // +optional
   optional ServiceAccountTokenProjection serviceAccountToken = 4;
 }
@@ -5702,20 +5700,20 @@ message VolumeSource {
 
 // Represents a vSphere volume resource.
 message VsphereVirtualDiskVolumeSource {
-  // Path that identifies vSphere volume vmdk
+  // volumePath is the path that identifies vSphere volume vmdk
   optional string volumePath = 1;
 
-  // Filesystem type to mount.
+  // fsType is filesystem type to mount.
   // Must be a filesystem type supported by the host operating system.
   // Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
   // +optional
   optional string fsType = 2;
 
-  // Storage Policy Based Management (SPBM) profile name.
+  // storagePolicyName is the storage Policy Based Management (SPBM) profile name.
   // +optional
   optional string storagePolicyName = 3;
 
-  // Storage Policy Based Management (SPBM) profile ID associated with the StoragePolicyName.
+  // storagePolicyID is the storage Policy Based Management (SPBM) profile ID associated with the StoragePolicyName.
   // +optional
   optional string storagePolicyID = 4;
 }

--- a/staging/src/k8s.io/api/core/v1/types.go
+++ b/staging/src/k8s.io/api/core/v1/types.go
@@ -685,11 +685,11 @@ const (
 // Represents a host path mapped into a pod.
 // Host path volumes do not support ownership management or SELinux relabeling.
 type HostPathVolumeSource struct {
-	// Path of the directory on the host.
+	// path of the directory on the host.
 	// If the path is a symlink, it will follow the link to the real path.
 	// More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
 	Path string `json:"path" protobuf:"bytes,1,opt,name=path"`
-	// Type for HostPath Volume
+	// type for HostPath Volume
 	// Defaults to ""
 	// More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
 	// +optional
@@ -699,13 +699,13 @@ type HostPathVolumeSource struct {
 // Represents an empty directory for a pod.
 // Empty directory volumes support ownership management and SELinux relabeling.
 type EmptyDirVolumeSource struct {
-	// What type of storage medium should back this directory.
+	// medium represents what type of storage medium should back this directory.
 	// The default is "" which means to use the node's default medium.
 	// Must be an empty string (default) or Memory.
 	// More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
 	// +optional
 	Medium StorageMedium `json:"medium,omitempty" protobuf:"bytes,1,opt,name=medium,casttype=StorageMedium"`
-	// Total amount of local storage required for this EmptyDir volume.
+	// sizeLimit is the total amount of local storage required for this EmptyDir volume.
 	// The size limit is also applicable for memory medium.
 	// The maximum usage on memory medium EmptyDir would be the minimum value between
 	// the SizeLimit specified here and the sum of memory limits of all containers in a pod.
@@ -718,15 +718,15 @@ type EmptyDirVolumeSource struct {
 // Represents a Glusterfs mount that lasts the lifetime of a pod.
 // Glusterfs volumes do not support ownership management or SELinux relabeling.
 type GlusterfsVolumeSource struct {
-	// EndpointsName is the endpoint name that details Glusterfs topology.
+	// endpoints is the endpoint name that details Glusterfs topology.
 	// More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
 	EndpointsName string `json:"endpoints" protobuf:"bytes,1,opt,name=endpoints"`
 
-	// Path is the Glusterfs volume path.
+	// path is the Glusterfs volume path.
 	// More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
 	Path string `json:"path" protobuf:"bytes,2,opt,name=path"`
 
-	// ReadOnly here will force the Glusterfs volume to be mounted with read-only permissions.
+	// readOnly here will force the Glusterfs volume to be mounted with read-only permissions.
 	// Defaults to false.
 	// More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
 	// +optional
@@ -736,21 +736,21 @@ type GlusterfsVolumeSource struct {
 // Represents a Glusterfs mount that lasts the lifetime of a pod.
 // Glusterfs volumes do not support ownership management or SELinux relabeling.
 type GlusterfsPersistentVolumeSource struct {
-	// EndpointsName is the endpoint name that details Glusterfs topology.
+	// endpoints is the endpoint name that details Glusterfs topology.
 	// More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
 	EndpointsName string `json:"endpoints" protobuf:"bytes,1,opt,name=endpoints"`
 
-	// Path is the Glusterfs volume path.
+	// path is the Glusterfs volume path.
 	// More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
 	Path string `json:"path" protobuf:"bytes,2,opt,name=path"`
 
-	// ReadOnly here will force the Glusterfs volume to be mounted with read-only permissions.
+	// readOnly here will force the Glusterfs volume to be mounted with read-only permissions.
 	// Defaults to false.
 	// More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
 	// +optional
 	ReadOnly bool `json:"readOnly,omitempty" protobuf:"varint,3,opt,name=readOnly"`
 
-	// EndpointsNamespace is the namespace that contains Glusterfs endpoint.
+	// endpointsNamespace is the namespace that contains Glusterfs endpoint.
 	// If this field is empty, the EndpointNamespace defaults to the same namespace as the bound PVC.
 	// More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
 	// +optional
@@ -760,41 +760,41 @@ type GlusterfsPersistentVolumeSource struct {
 // Represents a Rados Block Device mount that lasts the lifetime of a pod.
 // RBD volumes support ownership management and SELinux relabeling.
 type RBDVolumeSource struct {
-	// A collection of Ceph monitors.
+	// monitors is a collection of Ceph monitors.
 	// More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
 	CephMonitors []string `json:"monitors" protobuf:"bytes,1,rep,name=monitors"`
-	// The rados image name.
+	// image is the rados image name.
 	// More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
 	RBDImage string `json:"image" protobuf:"bytes,2,opt,name=image"`
-	// Filesystem type of the volume that you want to mount.
+	// fsType is the filesystem type of the volume that you want to mount.
 	// Tip: Ensure that the filesystem type is supported by the host operating system.
 	// Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
 	// More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd
 	// TODO: how do we prevent errors in the filesystem from compromising the machine
 	// +optional
 	FSType string `json:"fsType,omitempty" protobuf:"bytes,3,opt,name=fsType"`
-	// The rados pool name.
+	// pool is the rados pool name.
 	// Default is rbd.
 	// More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
 	// +optional
 	RBDPool string `json:"pool,omitempty" protobuf:"bytes,4,opt,name=pool"`
-	// The rados user name.
+	// user is the rados user name.
 	// Default is admin.
 	// More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
 	// +optional
 	RadosUser string `json:"user,omitempty" protobuf:"bytes,5,opt,name=user"`
-	// Keyring is the path to key ring for RBDUser.
+	// keyring is the path to key ring for RBDUser.
 	// Default is /etc/ceph/keyring.
 	// More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
 	// +optional
 	Keyring string `json:"keyring,omitempty" protobuf:"bytes,6,opt,name=keyring"`
-	// SecretRef is name of the authentication secret for RBDUser. If provided
+	// secretRef is name of the authentication secret for RBDUser. If provided
 	// overrides keyring.
 	// Default is nil.
 	// More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
 	// +optional
 	SecretRef *LocalObjectReference `json:"secretRef,omitempty" protobuf:"bytes,7,opt,name=secretRef"`
-	// ReadOnly here will force the ReadOnly setting in VolumeMounts.
+	// readOnly here will force the ReadOnly setting in VolumeMounts.
 	// Defaults to false.
 	// More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
 	// +optional
@@ -804,41 +804,41 @@ type RBDVolumeSource struct {
 // Represents a Rados Block Device mount that lasts the lifetime of a pod.
 // RBD volumes support ownership management and SELinux relabeling.
 type RBDPersistentVolumeSource struct {
-	// A collection of Ceph monitors.
+	// monitors is a collection of Ceph monitors.
 	// More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
 	CephMonitors []string `json:"monitors" protobuf:"bytes,1,rep,name=monitors"`
-	// The rados image name.
+	// image is the rados image name.
 	// More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
 	RBDImage string `json:"image" protobuf:"bytes,2,opt,name=image"`
-	// Filesystem type of the volume that you want to mount.
+	// fsType is the filesystem type of the volume that you want to mount.
 	// Tip: Ensure that the filesystem type is supported by the host operating system.
 	// Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
 	// More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd
 	// TODO: how do we prevent errors in the filesystem from compromising the machine
 	// +optional
 	FSType string `json:"fsType,omitempty" protobuf:"bytes,3,opt,name=fsType"`
-	// The rados pool name.
+	// pool is the rados pool name.
 	// Default is rbd.
 	// More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
 	// +optional
 	RBDPool string `json:"pool,omitempty" protobuf:"bytes,4,opt,name=pool"`
-	// The rados user name.
+	// user is the rados user name.
 	// Default is admin.
 	// More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
 	// +optional
 	RadosUser string `json:"user,omitempty" protobuf:"bytes,5,opt,name=user"`
-	// Keyring is the path to key ring for RBDUser.
+	// keyring is the path to key ring for RBDUser.
 	// Default is /etc/ceph/keyring.
 	// More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
 	// +optional
 	Keyring string `json:"keyring,omitempty" protobuf:"bytes,6,opt,name=keyring"`
-	// SecretRef is name of the authentication secret for RBDUser. If provided
+	// secretRef is name of the authentication secret for RBDUser. If provided
 	// overrides keyring.
 	// Default is nil.
 	// More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
 	// +optional
 	SecretRef *SecretReference `json:"secretRef,omitempty" protobuf:"bytes,7,opt,name=secretRef"`
-	// ReadOnly here will force the ReadOnly setting in VolumeMounts.
+	// readOnly here will force the ReadOnly setting in VolumeMounts.
 	// Defaults to false.
 	// More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
 	// +optional
@@ -850,21 +850,21 @@ type RBDPersistentVolumeSource struct {
 // The volume must also be in the same region as the kubelet.
 // Cinder volumes support ownership management and SELinux relabeling.
 type CinderVolumeSource struct {
-	// volume id used to identify the volume in cinder.
+	// volumeID used to identify the volume in cinder.
 	// More info: https://examples.k8s.io/mysql-cinder-pd/README.md
 	VolumeID string `json:"volumeID" protobuf:"bytes,1,opt,name=volumeID"`
-	// Filesystem type to mount.
+	// fsType is the filesystem type to mount.
 	// Must be a filesystem type supported by the host operating system.
 	// Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
 	// More info: https://examples.k8s.io/mysql-cinder-pd/README.md
 	// +optional
 	FSType string `json:"fsType,omitempty" protobuf:"bytes,2,opt,name=fsType"`
-	// Optional: Defaults to false (read/write). ReadOnly here will force
+	// readOnly defaults to false (read/write). ReadOnly here will force
 	// the ReadOnly setting in VolumeMounts.
 	// More info: https://examples.k8s.io/mysql-cinder-pd/README.md
 	// +optional
 	ReadOnly bool `json:"readOnly,omitempty" protobuf:"varint,3,opt,name=readOnly"`
-	// Optional: points to a secret object containing parameters used to connect
+	// secretRef is optional: points to a secret object containing parameters used to connect
 	// to OpenStack.
 	// +optional
 	SecretRef *LocalObjectReference `json:"secretRef,omitempty" protobuf:"bytes,4,opt,name=secretRef"`
@@ -875,21 +875,21 @@ type CinderVolumeSource struct {
 // The volume must also be in the same region as the kubelet.
 // Cinder volumes support ownership management and SELinux relabeling.
 type CinderPersistentVolumeSource struct {
-	// volume id used to identify the volume in cinder.
+	// volumeID used to identify the volume in cinder.
 	// More info: https://examples.k8s.io/mysql-cinder-pd/README.md
 	VolumeID string `json:"volumeID" protobuf:"bytes,1,opt,name=volumeID"`
-	// Filesystem type to mount.
+	// fsType Filesystem type to mount.
 	// Must be a filesystem type supported by the host operating system.
 	// Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
 	// More info: https://examples.k8s.io/mysql-cinder-pd/README.md
 	// +optional
 	FSType string `json:"fsType,omitempty" protobuf:"bytes,2,opt,name=fsType"`
-	// Optional: Defaults to false (read/write). ReadOnly here will force
+	// readOnly is Optional: Defaults to false (read/write). ReadOnly here will force
 	// the ReadOnly setting in VolumeMounts.
 	// More info: https://examples.k8s.io/mysql-cinder-pd/README.md
 	// +optional
 	ReadOnly bool `json:"readOnly,omitempty" protobuf:"varint,3,opt,name=readOnly"`
-	// Optional: points to a secret object containing parameters used to connect
+	// secretRef is Optional: points to a secret object containing parameters used to connect
 	// to OpenStack.
 	// +optional
 	SecretRef *SecretReference `json:"secretRef,omitempty" protobuf:"bytes,4,opt,name=secretRef"`
@@ -898,25 +898,25 @@ type CinderPersistentVolumeSource struct {
 // Represents a Ceph Filesystem mount that lasts the lifetime of a pod
 // Cephfs volumes do not support ownership management or SELinux relabeling.
 type CephFSVolumeSource struct {
-	// Required: Monitors is a collection of Ceph monitors
+	// monitors is Required: Monitors is a collection of Ceph monitors
 	// More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
 	Monitors []string `json:"monitors" protobuf:"bytes,1,rep,name=monitors"`
-	// Optional: Used as the mounted root, rather than the full Ceph tree, default is /
+	// path is Optional: Used as the mounted root, rather than the full Ceph tree, default is /
 	// +optional
 	Path string `json:"path,omitempty" protobuf:"bytes,2,opt,name=path"`
-	// Optional: User is the rados user name, default is admin
+	// user is optional: User is the rados user name, default is admin
 	// More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
 	// +optional
 	User string `json:"user,omitempty" protobuf:"bytes,3,opt,name=user"`
-	// Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret
+	// secretFile is Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret
 	// More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
 	// +optional
 	SecretFile string `json:"secretFile,omitempty" protobuf:"bytes,4,opt,name=secretFile"`
-	// Optional: SecretRef is reference to the authentication secret for User, default is empty.
+	// secretRef is Optional: SecretRef is reference to the authentication secret for User, default is empty.
 	// More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
 	// +optional
 	SecretRef *LocalObjectReference `json:"secretRef,omitempty" protobuf:"bytes,5,opt,name=secretRef"`
-	// Optional: Defaults to false (read/write). ReadOnly here will force
+	// readOnly is Optional: Defaults to false (read/write). ReadOnly here will force
 	// the ReadOnly setting in VolumeMounts.
 	// More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
 	// +optional
@@ -927,10 +927,10 @@ type CephFSVolumeSource struct {
 // in any namespace
 // +structType=atomic
 type SecretReference struct {
-	// Name is unique within a namespace to reference a secret resource.
+	// name is unique within a namespace to reference a secret resource.
 	// +optional
 	Name string `json:"name,omitempty" protobuf:"bytes,1,opt,name=name"`
-	// Namespace defines the space within which the secret name must be unique.
+	// namespace defines the space within which the secret name must be unique.
 	// +optional
 	Namespace string `json:"namespace,omitempty" protobuf:"bytes,2,opt,name=namespace"`
 }
@@ -938,25 +938,25 @@ type SecretReference struct {
 // Represents a Ceph Filesystem mount that lasts the lifetime of a pod
 // Cephfs volumes do not support ownership management or SELinux relabeling.
 type CephFSPersistentVolumeSource struct {
-	// Required: Monitors is a collection of Ceph monitors
+	// monitors is Required: Monitors is a collection of Ceph monitors
 	// More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
 	Monitors []string `json:"monitors" protobuf:"bytes,1,rep,name=monitors"`
-	// Optional: Used as the mounted root, rather than the full Ceph tree, default is /
+	// path is Optional: Used as the mounted root, rather than the full Ceph tree, default is /
 	// +optional
 	Path string `json:"path,omitempty" protobuf:"bytes,2,opt,name=path"`
-	// Optional: User is the rados user name, default is admin
+	// user is Optional: User is the rados user name, default is admin
 	// More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
 	// +optional
 	User string `json:"user,omitempty" protobuf:"bytes,3,opt,name=user"`
-	// Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret
+	// secretFile is Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret
 	// More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
 	// +optional
 	SecretFile string `json:"secretFile,omitempty" protobuf:"bytes,4,opt,name=secretFile"`
-	// Optional: SecretRef is reference to the authentication secret for User, default is empty.
+	// secretRef is Optional: SecretRef is reference to the authentication secret for User, default is empty.
 	// More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
 	// +optional
 	SecretRef *SecretReference `json:"secretRef,omitempty" protobuf:"bytes,5,opt,name=secretRef"`
-	// Optional: Defaults to false (read/write). ReadOnly here will force
+	// readOnly is Optional: Defaults to false (read/write). ReadOnly here will force
 	// the ReadOnly setting in VolumeMounts.
 	// More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
 	// +optional
@@ -967,11 +967,11 @@ type CephFSPersistentVolumeSource struct {
 // One and only one of datasetName and datasetUUID should be set.
 // Flocker volumes do not support ownership management or SELinux relabeling.
 type FlockerVolumeSource struct {
-	// Name of the dataset stored as metadata -> name on the dataset for Flocker
+	// datasetName is Name of the dataset stored as metadata -> name on the dataset for Flocker
 	// should be considered as deprecated
 	// +optional
 	DatasetName string `json:"datasetName,omitempty" protobuf:"bytes,1,opt,name=datasetName"`
-	// UUID of the dataset. This is unique identifier of a Flocker dataset
+	// datasetUUID is the UUID of the dataset. This is unique identifier of a Flocker dataset
 	// +optional
 	DatasetUUID string `json:"datasetUUID,omitempty" protobuf:"bytes,2,opt,name=datasetUUID"`
 }
@@ -1006,24 +1006,24 @@ const (
 // can only be mounted as read/write once or read-only many times. GCE
 // PDs support ownership management and SELinux relabeling.
 type GCEPersistentDiskVolumeSource struct {
-	// Unique name of the PD resource in GCE. Used to identify the disk in GCE.
+	// pdName is unique name of the PD resource in GCE. Used to identify the disk in GCE.
 	// More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
 	PDName string `json:"pdName" protobuf:"bytes,1,opt,name=pdName"`
-	// Filesystem type of the volume that you want to mount.
+	// fsType is filesystem type of the volume that you want to mount.
 	// Tip: Ensure that the filesystem type is supported by the host operating system.
 	// Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
 	// More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
 	// TODO: how do we prevent errors in the filesystem from compromising the machine
 	// +optional
 	FSType string `json:"fsType,omitempty" protobuf:"bytes,2,opt,name=fsType"`
-	// The partition in the volume that you want to mount.
+	// partition is the partition in the volume that you want to mount.
 	// If omitted, the default is to mount by volume name.
 	// Examples: For volume /dev/sda1, you specify the partition as "1".
 	// Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).
 	// More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
 	// +optional
 	Partition int32 `json:"partition,omitempty" protobuf:"varint,3,opt,name=partition"`
-	// ReadOnly here will force the ReadOnly setting in VolumeMounts.
+	// readOnly here will force the ReadOnly setting in VolumeMounts.
 	// Defaults to false.
 	// More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
 	// +optional
@@ -1033,30 +1033,30 @@ type GCEPersistentDiskVolumeSource struct {
 // Represents a Quobyte mount that lasts the lifetime of a pod.
 // Quobyte volumes do not support ownership management or SELinux relabeling.
 type QuobyteVolumeSource struct {
-	// Registry represents a single or multiple Quobyte Registry services
+	// registry represents a single or multiple Quobyte Registry services
 	// specified as a string as host:port pair (multiple entries are separated with commas)
 	// which acts as the central registry for volumes
 	Registry string `json:"registry" protobuf:"bytes,1,opt,name=registry"`
 
-	// Volume is a string that references an already created Quobyte volume by name.
+	// volume is a string that references an already created Quobyte volume by name.
 	Volume string `json:"volume" protobuf:"bytes,2,opt,name=volume"`
 
-	// ReadOnly here will force the Quobyte volume to be mounted with read-only permissions.
+	// readOnly here will force the Quobyte volume to be mounted with read-only permissions.
 	// Defaults to false.
 	// +optional
 	ReadOnly bool `json:"readOnly,omitempty" protobuf:"varint,3,opt,name=readOnly"`
 
-	// User to map volume access to
+	// user to map volume access to
 	// Defaults to serivceaccount user
 	// +optional
 	User string `json:"user,omitempty" protobuf:"bytes,4,opt,name=user"`
 
-	// Group to map volume access to
+	// group to map volume access to
 	// Default is no group
 	// +optional
 	Group string `json:"group,omitempty" protobuf:"bytes,5,opt,name=group"`
 
-	// Tenant owning the given Quobyte volume in the Backend
+	// tenant owning the given Quobyte volume in the Backend
 	// Used with dynamically provisioned Quobyte volumes, value is set by the plugin
 	// +optional
 	Tenant string `json:"tenant,omitempty" protobuf:"bytes,6,opt,name=tenant"`
@@ -1065,25 +1065,25 @@ type QuobyteVolumeSource struct {
 // FlexPersistentVolumeSource represents a generic persistent volume resource that is
 // provisioned/attached using an exec based plugin.
 type FlexPersistentVolumeSource struct {
-	// Driver is the name of the driver to use for this volume.
+	// driver is the name of the driver to use for this volume.
 	Driver string `json:"driver" protobuf:"bytes,1,opt,name=driver"`
-	// Filesystem type to mount.
+	// fsType is the Filesystem type to mount.
 	// Must be a filesystem type supported by the host operating system.
 	// Ex. "ext4", "xfs", "ntfs". The default filesystem depends on FlexVolume script.
 	// +optional
 	FSType string `json:"fsType,omitempty" protobuf:"bytes,2,opt,name=fsType"`
-	// Optional: SecretRef is reference to the secret object containing
+	// secretRef is Optional: SecretRef is reference to the secret object containing
 	// sensitive information to pass to the plugin scripts. This may be
 	// empty if no secret object is specified. If the secret object
 	// contains more than one secret, all secrets are passed to the plugin
 	// scripts.
 	// +optional
 	SecretRef *SecretReference `json:"secretRef,omitempty" protobuf:"bytes,3,opt,name=secretRef"`
-	// Optional: Defaults to false (read/write). ReadOnly here will force
+	// readOnly is Optional: defaults to false (read/write). ReadOnly here will force
 	// the ReadOnly setting in VolumeMounts.
 	// +optional
 	ReadOnly bool `json:"readOnly,omitempty" protobuf:"varint,4,opt,name=readOnly"`
-	// Optional: Extra command options if any.
+	// options is Optional: this field holds extra command options if any.
 	// +optional
 	Options map[string]string `json:"options,omitempty" protobuf:"bytes,5,rep,name=options"`
 }
@@ -1091,25 +1091,25 @@ type FlexPersistentVolumeSource struct {
 // FlexVolume represents a generic volume resource that is
 // provisioned/attached using an exec based plugin.
 type FlexVolumeSource struct {
-	// Driver is the name of the driver to use for this volume.
+	// driver is the name of the driver to use for this volume.
 	Driver string `json:"driver" protobuf:"bytes,1,opt,name=driver"`
-	// Filesystem type to mount.
+	// fsType is the filesystem type to mount.
 	// Must be a filesystem type supported by the host operating system.
 	// Ex. "ext4", "xfs", "ntfs". The default filesystem depends on FlexVolume script.
 	// +optional
 	FSType string `json:"fsType,omitempty" protobuf:"bytes,2,opt,name=fsType"`
-	// Optional: SecretRef is reference to the secret object containing
+	// secretRef is Optional: secretRef is reference to the secret object containing
 	// sensitive information to pass to the plugin scripts. This may be
 	// empty if no secret object is specified. If the secret object
 	// contains more than one secret, all secrets are passed to the plugin
 	// scripts.
 	// +optional
 	SecretRef *LocalObjectReference `json:"secretRef,omitempty" protobuf:"bytes,3,opt,name=secretRef"`
-	// Optional: Defaults to false (read/write). ReadOnly here will force
+	// readOnly is Optional: defaults to false (read/write). ReadOnly here will force
 	// the ReadOnly setting in VolumeMounts.
 	// +optional
 	ReadOnly bool `json:"readOnly,omitempty" protobuf:"varint,4,opt,name=readOnly"`
-	// Optional: Extra command options if any.
+	// options is Optional: this field holds extra command options if any.
 	// +optional
 	Options map[string]string `json:"options,omitempty" protobuf:"bytes,5,rep,name=options"`
 }
@@ -1121,24 +1121,23 @@ type FlexVolumeSource struct {
 // can only be mounted as read/write once. AWS EBS volumes support
 // ownership management and SELinux relabeling.
 type AWSElasticBlockStoreVolumeSource struct {
-	// Unique ID of the persistent disk resource in AWS (Amazon EBS volume).
+	// volumeID is unique ID of the persistent disk resource in AWS (Amazon EBS volume).
 	// More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
 	VolumeID string `json:"volumeID" protobuf:"bytes,1,opt,name=volumeID"`
-	// Filesystem type of the volume that you want to mount.
+	// fsType is the filesystem type of the volume that you want to mount.
 	// Tip: Ensure that the filesystem type is supported by the host operating system.
 	// Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
 	// More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
 	// TODO: how do we prevent errors in the filesystem from compromising the machine
 	// +optional
 	FSType string `json:"fsType,omitempty" protobuf:"bytes,2,opt,name=fsType"`
-	// The partition in the volume that you want to mount.
+	// partition is the partition in the volume that you want to mount.
 	// If omitted, the default is to mount by volume name.
 	// Examples: For volume /dev/sda1, you specify the partition as "1".
 	// Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).
 	// +optional
 	Partition int32 `json:"partition,omitempty" protobuf:"varint,3,opt,name=partition"`
-	// Specify "true" to force and set the ReadOnly property in VolumeMounts to "true".
-	// If omitted, the default is "false".
+	// readOnly value true will force the readOnly setting in VolumeMounts.
 	// More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
 	// +optional
 	ReadOnly bool `json:"readOnly,omitempty" protobuf:"varint,4,opt,name=readOnly"`
@@ -1152,12 +1151,12 @@ type AWSElasticBlockStoreVolumeSource struct {
 // EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir
 // into the Pod's container.
 type GitRepoVolumeSource struct {
-	// Repository URL
+	// repository is the URL
 	Repository string `json:"repository" protobuf:"bytes,1,opt,name=repository"`
-	// Commit hash for the specified revision.
+	// revision is the commit hash for the specified revision.
 	// +optional
 	Revision string `json:"revision,omitempty" protobuf:"bytes,2,opt,name=revision"`
-	// Target directory name.
+	// directory is the target directory name.
 	// Must not contain or start with '..'.  If '.' is supplied, the volume directory will be the
 	// git repository.  Otherwise, if specified, the volume will contain the git repository in
 	// the subdirectory with the given name.
@@ -1171,11 +1170,11 @@ type GitRepoVolumeSource struct {
 // as files using the keys in the Data field as the file names.
 // Secret volumes support ownership management and SELinux relabeling.
 type SecretVolumeSource struct {
-	// Name of the secret in the pod's namespace to use.
+	// secretName is the name of the secret in the pod's namespace to use.
 	// More info: https://kubernetes.io/docs/concepts/storage/volumes#secret
 	// +optional
 	SecretName string `json:"secretName,omitempty" protobuf:"bytes,1,opt,name=secretName"`
-	// If unspecified, each key-value pair in the Data field of the referenced
+	// items If unspecified, each key-value pair in the Data field of the referenced
 	// Secret will be projected into the volume as a file whose name is the
 	// key and content is the value. If specified, the listed keys will be
 	// projected into the specified paths, and unlisted keys will not be
@@ -1184,7 +1183,7 @@ type SecretVolumeSource struct {
 	// relative and may not contain the '..' path or start with '..'.
 	// +optional
 	Items []KeyToPath `json:"items,omitempty" protobuf:"bytes,2,rep,name=items"`
-	// Optional: mode bits used to set permissions on created files by default.
+	// defaultMode is Optional: mode bits used to set permissions on created files by default.
 	// Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
 	// YAML accepts both octal and decimal values, JSON requires decimal values
 	// for mode bits. Defaults to 0644.
@@ -1193,7 +1192,7 @@ type SecretVolumeSource struct {
 	// mode, like fsGroup, and the result can be other mode bits set.
 	// +optional
 	DefaultMode *int32 `json:"defaultMode,omitempty" protobuf:"bytes,3,opt,name=defaultMode"`
-	// Specify whether the Secret or its keys must be defined
+	// optional field specify whether the Secret or its keys must be defined
 	// +optional
 	Optional *bool `json:"optional,omitempty" protobuf:"varint,4,opt,name=optional"`
 }
@@ -1210,7 +1209,7 @@ const (
 // mode.
 type SecretProjection struct {
 	LocalObjectReference `json:",inline" protobuf:"bytes,1,opt,name=localObjectReference"`
-	// If unspecified, each key-value pair in the Data field of the referenced
+	// items if unspecified, each key-value pair in the Data field of the referenced
 	// Secret will be projected into the volume as a file whose name is the
 	// key and content is the value. If specified, the listed keys will be
 	// projected into the specified paths, and unlisted keys will not be
@@ -1219,7 +1218,7 @@ type SecretProjection struct {
 	// relative and may not contain the '..' path or start with '..'.
 	// +optional
 	Items []KeyToPath `json:"items,omitempty" protobuf:"bytes,2,rep,name=items"`
-	// Specify whether the Secret or its key must be defined
+	// optional field specify whether the Secret or its key must be defined
 	// +optional
 	Optional *bool `json:"optional,omitempty" protobuf:"varint,4,opt,name=optional"`
 }
@@ -1227,16 +1226,15 @@ type SecretProjection struct {
 // Represents an NFS mount that lasts the lifetime of a pod.
 // NFS volumes do not support ownership management or SELinux relabeling.
 type NFSVolumeSource struct {
-	// Server is the hostname or IP address of the NFS server.
+	// server is the hostname or IP address of the NFS server.
 	// More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
 	Server string `json:"server" protobuf:"bytes,1,opt,name=server"`
 
-	// Path that is exported by the NFS server.
+	// path that is exported by the NFS server.
 	// More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
 	Path string `json:"path" protobuf:"bytes,2,opt,name=path"`
 
-	// ReadOnly here will force
-	// the NFS export to be mounted with read-only permissions.
+	// readOnly here will force the NFS export to be mounted with read-only permissions.
 	// Defaults to false.
 	// More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
 	// +optional
@@ -1247,42 +1245,42 @@ type NFSVolumeSource struct {
 // ISCSI volumes can only be mounted as read/write once.
 // ISCSI volumes support ownership management and SELinux relabeling.
 type ISCSIVolumeSource struct {
-	// iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port
+	// targetPortal is iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port
 	// is other than default (typically TCP ports 860 and 3260).
 	TargetPortal string `json:"targetPortal" protobuf:"bytes,1,opt,name=targetPortal"`
-	// Target iSCSI Qualified Name.
+	// iqn is the target iSCSI Qualified Name.
 	IQN string `json:"iqn" protobuf:"bytes,2,opt,name=iqn"`
-	// iSCSI Target Lun number.
+	// lun represents iSCSI Target Lun number.
 	Lun int32 `json:"lun" protobuf:"varint,3,opt,name=lun"`
-	// iSCSI Interface Name that uses an iSCSI transport.
+	// iscsiInterface is the interface Name that uses an iSCSI transport.
 	// Defaults to 'default' (tcp).
 	// +optional
 	ISCSIInterface string `json:"iscsiInterface,omitempty" protobuf:"bytes,4,opt,name=iscsiInterface"`
-	// Filesystem type of the volume that you want to mount.
+	// fsType is the filesystem type of the volume that you want to mount.
 	// Tip: Ensure that the filesystem type is supported by the host operating system.
 	// Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
 	// More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi
 	// TODO: how do we prevent errors in the filesystem from compromising the machine
 	// +optional
 	FSType string `json:"fsType,omitempty" protobuf:"bytes,5,opt,name=fsType"`
-	// ReadOnly here will force the ReadOnly setting in VolumeMounts.
+	// readOnly here will force the ReadOnly setting in VolumeMounts.
 	// Defaults to false.
 	// +optional
 	ReadOnly bool `json:"readOnly,omitempty" protobuf:"varint,6,opt,name=readOnly"`
-	// iSCSI Target Portal List. The portal is either an IP or ip_addr:port if the port
+	// portals is the iSCSI Target Portal List. The portal is either an IP or ip_addr:port if the port
 	// is other than default (typically TCP ports 860 and 3260).
 	// +optional
 	Portals []string `json:"portals,omitempty" protobuf:"bytes,7,opt,name=portals"`
-	// whether support iSCSI Discovery CHAP authentication
+	// chapAuthDiscovery defines whether support iSCSI Discovery CHAP authentication
 	// +optional
 	DiscoveryCHAPAuth bool `json:"chapAuthDiscovery,omitempty" protobuf:"varint,8,opt,name=chapAuthDiscovery"`
-	// whether support iSCSI Session CHAP authentication
+	// chapAuthSession defines whether support iSCSI Session CHAP authentication
 	// +optional
 	SessionCHAPAuth bool `json:"chapAuthSession,omitempty" protobuf:"varint,11,opt,name=chapAuthSession"`
-	// CHAP Secret for iSCSI target and initiator authentication
+	// secretRef is the CHAP Secret for iSCSI target and initiator authentication
 	// +optional
 	SecretRef *LocalObjectReference `json:"secretRef,omitempty" protobuf:"bytes,10,opt,name=secretRef"`
-	// Custom iSCSI Initiator Name.
+	// initiatorName is the custom iSCSI Initiator Name.
 	// If initiatorName is specified with iscsiInterface simultaneously, new iSCSI interface
 	// <target portal>:<volume name> will be created for the connection.
 	// +optional
@@ -1293,42 +1291,42 @@ type ISCSIVolumeSource struct {
 // ISCSI volumes can only be mounted as read/write once.
 // ISCSI volumes support ownership management and SELinux relabeling.
 type ISCSIPersistentVolumeSource struct {
-	// iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port
+	// targetPortal is iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port
 	// is other than default (typically TCP ports 860 and 3260).
 	TargetPortal string `json:"targetPortal" protobuf:"bytes,1,opt,name=targetPortal"`
-	// Target iSCSI Qualified Name.
+	// iqn is Target iSCSI Qualified Name.
 	IQN string `json:"iqn" protobuf:"bytes,2,opt,name=iqn"`
-	// iSCSI Target Lun number.
+	// lun is iSCSI Target Lun number.
 	Lun int32 `json:"lun" protobuf:"varint,3,opt,name=lun"`
-	// iSCSI Interface Name that uses an iSCSI transport.
+	// iscsiInterface is the interface Name that uses an iSCSI transport.
 	// Defaults to 'default' (tcp).
 	// +optional
 	ISCSIInterface string `json:"iscsiInterface,omitempty" protobuf:"bytes,4,opt,name=iscsiInterface"`
-	// Filesystem type of the volume that you want to mount.
+	// fsType is the filesystem type of the volume that you want to mount.
 	// Tip: Ensure that the filesystem type is supported by the host operating system.
 	// Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
 	// More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi
 	// TODO: how do we prevent errors in the filesystem from compromising the machine
 	// +optional
 	FSType string `json:"fsType,omitempty" protobuf:"bytes,5,opt,name=fsType"`
-	// ReadOnly here will force the ReadOnly setting in VolumeMounts.
+	// readOnly here will force the ReadOnly setting in VolumeMounts.
 	// Defaults to false.
 	// +optional
 	ReadOnly bool `json:"readOnly,omitempty" protobuf:"varint,6,opt,name=readOnly"`
-	// iSCSI Target Portal List. The Portal is either an IP or ip_addr:port if the port
+	// portals is the iSCSI Target Portal List. The Portal is either an IP or ip_addr:port if the port
 	// is other than default (typically TCP ports 860 and 3260).
 	// +optional
 	Portals []string `json:"portals,omitempty" protobuf:"bytes,7,opt,name=portals"`
-	// whether support iSCSI Discovery CHAP authentication
+	// chapAuthDiscovery defines whether support iSCSI Discovery CHAP authentication
 	// +optional
 	DiscoveryCHAPAuth bool `json:"chapAuthDiscovery,omitempty" protobuf:"varint,8,opt,name=chapAuthDiscovery"`
-	// whether support iSCSI Session CHAP authentication
+	// chapAuthSession defines whether support iSCSI Session CHAP authentication
 	// +optional
 	SessionCHAPAuth bool `json:"chapAuthSession,omitempty" protobuf:"varint,11,opt,name=chapAuthSession"`
-	// CHAP Secret for iSCSI target and initiator authentication
+	// secretRef is the CHAP Secret for iSCSI target and initiator authentication
 	// +optional
 	SecretRef *SecretReference `json:"secretRef,omitempty" protobuf:"bytes,10,opt,name=secretRef"`
-	// Custom iSCSI Initiator Name.
+	// initiatorName is the custom iSCSI Initiator Name.
 	// If initiatorName is specified with iscsiInterface simultaneously, new iSCSI interface
 	// <target portal>:<volume name> will be created for the connection.
 	// +optional
@@ -1339,23 +1337,23 @@ type ISCSIPersistentVolumeSource struct {
 // Fibre Channel volumes can only be mounted as read/write once.
 // Fibre Channel volumes support ownership management and SELinux relabeling.
 type FCVolumeSource struct {
-	// Optional: FC target worldwide names (WWNs)
+	// targetWWNs is Optional: FC target worldwide names (WWNs)
 	// +optional
 	TargetWWNs []string `json:"targetWWNs,omitempty" protobuf:"bytes,1,rep,name=targetWWNs"`
-	// Optional: FC target lun number
+	// lun is Optional: FC target lun number
 	// +optional
 	Lun *int32 `json:"lun,omitempty" protobuf:"varint,2,opt,name=lun"`
-	// Filesystem type to mount.
+	// fsType is the filesystem type to mount.
 	// Must be a filesystem type supported by the host operating system.
 	// Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
 	// TODO: how do we prevent errors in the filesystem from compromising the machine
 	// +optional
 	FSType string `json:"fsType,omitempty" protobuf:"bytes,3,opt,name=fsType"`
-	// Optional: Defaults to false (read/write). ReadOnly here will force
+	// readOnly is Optional: Defaults to false (read/write). ReadOnly here will force
 	// the ReadOnly setting in VolumeMounts.
 	// +optional
 	ReadOnly bool `json:"readOnly,omitempty" protobuf:"varint,4,opt,name=readOnly"`
-	// Optional: FC volume world wide identifiers (wwids)
+	// wwids Optional: FC volume world wide identifiers (wwids)
 	// Either wwids or combination of targetWWNs and lun must be set, but not both simultaneously.
 	// +optional
 	WWIDs []string `json:"wwids,omitempty" protobuf:"bytes,5,rep,name=wwids"`
@@ -1363,11 +1361,11 @@ type FCVolumeSource struct {
 
 // AzureFile represents an Azure File Service mount on the host and bind mount to the pod.
 type AzureFileVolumeSource struct {
-	// the name of secret that contains Azure Storage Account Name and Key
+	// secretName is the  name of secret that contains Azure Storage Account Name and Key
 	SecretName string `json:"secretName" protobuf:"bytes,1,opt,name=secretName"`
-	// Share Name
+	// shareName is the azure share Name
 	ShareName string `json:"shareName" protobuf:"bytes,2,opt,name=shareName"`
-	// Defaults to false (read/write). ReadOnly here will force
+	// readOnly defaults to false (read/write). ReadOnly here will force
 	// the ReadOnly setting in VolumeMounts.
 	// +optional
 	ReadOnly bool `json:"readOnly,omitempty" protobuf:"varint,3,opt,name=readOnly"`
@@ -1375,15 +1373,15 @@ type AzureFileVolumeSource struct {
 
 // AzureFile represents an Azure File Service mount on the host and bind mount to the pod.
 type AzureFilePersistentVolumeSource struct {
-	// the name of secret that contains Azure Storage Account Name and Key
+	// secretName is the name of secret that contains Azure Storage Account Name and Key
 	SecretName string `json:"secretName" protobuf:"bytes,1,opt,name=secretName"`
-	// Share Name
+	// shareName is the azure Share Name
 	ShareName string `json:"shareName" protobuf:"bytes,2,opt,name=shareName"`
-	// Defaults to false (read/write). ReadOnly here will force
+	// readOnly defaults to false (read/write). ReadOnly here will force
 	// the ReadOnly setting in VolumeMounts.
 	// +optional
 	ReadOnly bool `json:"readOnly,omitempty" protobuf:"varint,3,opt,name=readOnly"`
-	// the namespace of the secret that contains Azure Storage Account Name and Key
+	// secretNamespace is the namespace of the secret that contains Azure Storage Account Name and Key
 	// default is the same as the Pod
 	// +optional
 	SecretNamespace *string `json:"secretNamespace" protobuf:"bytes,4,opt,name=secretNamespace"`
@@ -1391,26 +1389,26 @@ type AzureFilePersistentVolumeSource struct {
 
 // Represents a vSphere volume resource.
 type VsphereVirtualDiskVolumeSource struct {
-	// Path that identifies vSphere volume vmdk
+	// volumePath is the path that identifies vSphere volume vmdk
 	VolumePath string `json:"volumePath" protobuf:"bytes,1,opt,name=volumePath"`
-	// Filesystem type to mount.
+	// fsType is filesystem type to mount.
 	// Must be a filesystem type supported by the host operating system.
 	// Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
 	// +optional
 	FSType string `json:"fsType,omitempty" protobuf:"bytes,2,opt,name=fsType"`
-	// Storage Policy Based Management (SPBM) profile name.
+	// storagePolicyName is the storage Policy Based Management (SPBM) profile name.
 	// +optional
 	StoragePolicyName string `json:"storagePolicyName,omitempty" protobuf:"bytes,3,opt,name=storagePolicyName"`
-	// Storage Policy Based Management (SPBM) profile ID associated with the StoragePolicyName.
+	// storagePolicyID is the storage Policy Based Management (SPBM) profile ID associated with the StoragePolicyName.
 	// +optional
 	StoragePolicyID string `json:"storagePolicyID,omitempty" protobuf:"bytes,4,opt,name=storagePolicyID"`
 }
 
 // Represents a Photon Controller persistent disk resource.
 type PhotonPersistentDiskVolumeSource struct {
-	// ID that identifies Photon Controller persistent disk
+	// pdID is the ID that identifies Photon Controller persistent disk
 	PdID string `json:"pdID" protobuf:"bytes,1,opt,name=pdID"`
-	// Filesystem type to mount.
+	// fsType is the filesystem type to mount.
 	// Must be a filesystem type supported by the host operating system.
 	// Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
 	FSType string `json:"fsType,omitempty" protobuf:"bytes,2,opt,name=fsType"`
@@ -1434,35 +1432,35 @@ const (
 
 // AzureDisk represents an Azure Data Disk mount on the host and bind mount to the pod.
 type AzureDiskVolumeSource struct {
-	// The Name of the data disk in the blob storage
+	// diskName is the Name of the data disk in the blob storage
 	DiskName string `json:"diskName" protobuf:"bytes,1,opt,name=diskName"`
-	// The URI the data disk in the blob storage
+	// diskURI is the URI of data disk in the blob storage
 	DataDiskURI string `json:"diskURI" protobuf:"bytes,2,opt,name=diskURI"`
-	// Host Caching mode: None, Read Only, Read Write.
+	// cachingMode is the Host Caching mode: None, Read Only, Read Write.
 	// +optional
 	CachingMode *AzureDataDiskCachingMode `json:"cachingMode,omitempty" protobuf:"bytes,3,opt,name=cachingMode,casttype=AzureDataDiskCachingMode"`
-	// Filesystem type to mount.
+	// fsType is Filesystem type to mount.
 	// Must be a filesystem type supported by the host operating system.
 	// Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
 	// +optional
 	FSType *string `json:"fsType,omitempty" protobuf:"bytes,4,opt,name=fsType"`
-	// Defaults to false (read/write). ReadOnly here will force
+	// readOnly Defaults to false (read/write). ReadOnly here will force
 	// the ReadOnly setting in VolumeMounts.
 	// +optional
 	ReadOnly *bool `json:"readOnly,omitempty" protobuf:"varint,5,opt,name=readOnly"`
-	// Expected values Shared: multiple blob disks per storage account  Dedicated: single blob disk per storage account  Managed: azure managed data disk (only in managed availability set). defaults to shared
+	// kind expected values are Shared: multiple blob disks per storage account  Dedicated: single blob disk per storage account  Managed: azure managed data disk (only in managed availability set). defaults to shared
 	Kind *AzureDataDiskKind `json:"kind,omitempty" protobuf:"bytes,6,opt,name=kind,casttype=AzureDataDiskKind"`
 }
 
 // PortworxVolumeSource represents a Portworx volume resource.
 type PortworxVolumeSource struct {
-	// VolumeID uniquely identifies a Portworx volume
+	// volumeID uniquely identifies a Portworx volume
 	VolumeID string `json:"volumeID" protobuf:"bytes,1,opt,name=volumeID"`
-	// FSType represents the filesystem type to mount
+	// fSType represents the filesystem type to mount
 	// Must be a filesystem type supported by the host operating system.
 	// Ex. "ext4", "xfs". Implicitly inferred to be "ext4" if unspecified.
 	FSType string `json:"fsType,omitempty" protobuf:"bytes,2,opt,name=fsType"`
-	// Defaults to false (read/write). ReadOnly here will force
+	// readOnly defaults to false (read/write). ReadOnly here will force
 	// the ReadOnly setting in VolumeMounts.
 	// +optional
 	ReadOnly bool `json:"readOnly,omitempty" protobuf:"varint,3,opt,name=readOnly"`
@@ -1470,36 +1468,36 @@ type PortworxVolumeSource struct {
 
 // ScaleIOVolumeSource represents a persistent ScaleIO volume
 type ScaleIOVolumeSource struct {
-	// The host address of the ScaleIO API Gateway.
+	// gateway is the host address of the ScaleIO API Gateway.
 	Gateway string `json:"gateway" protobuf:"bytes,1,opt,name=gateway"`
-	// The name of the storage system as configured in ScaleIO.
+	// system is the name of the storage system as configured in ScaleIO.
 	System string `json:"system" protobuf:"bytes,2,opt,name=system"`
-	// SecretRef references to the secret for ScaleIO user and other
+	// secretRef references to the secret for ScaleIO user and other
 	// sensitive information. If this is not provided, Login operation will fail.
 	SecretRef *LocalObjectReference `json:"secretRef" protobuf:"bytes,3,opt,name=secretRef"`
-	// Flag to enable/disable SSL communication with Gateway, default false
+	// sslEnabled Flag enable/disable SSL communication with Gateway, default false
 	// +optional
 	SSLEnabled bool `json:"sslEnabled,omitempty" protobuf:"varint,4,opt,name=sslEnabled"`
-	// The name of the ScaleIO Protection Domain for the configured storage.
+	// protectionDomain is the name of the ScaleIO Protection Domain for the configured storage.
 	// +optional
 	ProtectionDomain string `json:"protectionDomain,omitempty" protobuf:"bytes,5,opt,name=protectionDomain"`
-	// The ScaleIO Storage Pool associated with the protection domain.
+	// storagePool is the ScaleIO Storage Pool associated with the protection domain.
 	// +optional
 	StoragePool string `json:"storagePool,omitempty" protobuf:"bytes,6,opt,name=storagePool"`
-	// Indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned.
+	// storageMode indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned.
 	// Default is ThinProvisioned.
 	// +optional
 	StorageMode string `json:"storageMode,omitempty" protobuf:"bytes,7,opt,name=storageMode"`
-	// The name of a volume already created in the ScaleIO system
+	// volumeName is the name of a volume already created in the ScaleIO system
 	// that is associated with this volume source.
 	VolumeName string `json:"volumeName,omitempty" protobuf:"bytes,8,opt,name=volumeName"`
-	// Filesystem type to mount.
+	// fsType is the filesystem type to mount.
 	// Must be a filesystem type supported by the host operating system.
 	// Ex. "ext4", "xfs", "ntfs".
 	// Default is "xfs".
 	// +optional
 	FSType string `json:"fsType,omitempty" protobuf:"bytes,9,opt,name=fsType"`
-	// Defaults to false (read/write). ReadOnly here will force
+	// readOnly Defaults to false (read/write). ReadOnly here will force
 	// the ReadOnly setting in VolumeMounts.
 	// +optional
 	ReadOnly bool `json:"readOnly,omitempty" protobuf:"varint,10,opt,name=readOnly"`
@@ -1507,36 +1505,36 @@ type ScaleIOVolumeSource struct {
 
 // ScaleIOPersistentVolumeSource represents a persistent ScaleIO volume
 type ScaleIOPersistentVolumeSource struct {
-	// The host address of the ScaleIO API Gateway.
+	// gateway is the host address of the ScaleIO API Gateway.
 	Gateway string `json:"gateway" protobuf:"bytes,1,opt,name=gateway"`
-	// The name of the storage system as configured in ScaleIO.
+	// system is the name of the storage system as configured in ScaleIO.
 	System string `json:"system" protobuf:"bytes,2,opt,name=system"`
-	// SecretRef references to the secret for ScaleIO user and other
+	// secretRef references to the secret for ScaleIO user and other
 	// sensitive information. If this is not provided, Login operation will fail.
 	SecretRef *SecretReference `json:"secretRef" protobuf:"bytes,3,opt,name=secretRef"`
-	// Flag to enable/disable SSL communication with Gateway, default false
+	// sslEnabled is the flag to enable/disable SSL communication with Gateway, default false
 	// +optional
 	SSLEnabled bool `json:"sslEnabled,omitempty" protobuf:"varint,4,opt,name=sslEnabled"`
-	// The name of the ScaleIO Protection Domain for the configured storage.
+	// protectionDomain is the name of the ScaleIO Protection Domain for the configured storage.
 	// +optional
 	ProtectionDomain string `json:"protectionDomain,omitempty" protobuf:"bytes,5,opt,name=protectionDomain"`
-	// The ScaleIO Storage Pool associated with the protection domain.
+	// storagePool is the ScaleIO Storage Pool associated with the protection domain.
 	// +optional
 	StoragePool string `json:"storagePool,omitempty" protobuf:"bytes,6,opt,name=storagePool"`
-	// Indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned.
+	// storageMode indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned.
 	// Default is ThinProvisioned.
 	// +optional
 	StorageMode string `json:"storageMode,omitempty" protobuf:"bytes,7,opt,name=storageMode"`
-	// The name of a volume already created in the ScaleIO system
+	// volumeName is the name of a volume already created in the ScaleIO system
 	// that is associated with this volume source.
 	VolumeName string `json:"volumeName,omitempty" protobuf:"bytes,8,opt,name=volumeName"`
-	// Filesystem type to mount.
+	// fsType is the filesystem type to mount.
 	// Must be a filesystem type supported by the host operating system.
 	// Ex. "ext4", "xfs", "ntfs".
 	// Default is "xfs"
 	// +optional
 	FSType string `json:"fsType,omitempty" protobuf:"bytes,9,opt,name=fsType"`
-	// Defaults to false (read/write). ReadOnly here will force
+	// readOnly defaults to false (read/write). ReadOnly here will force
 	// the ReadOnly setting in VolumeMounts.
 	// +optional
 	ReadOnly bool `json:"readOnly,omitempty" protobuf:"varint,10,opt,name=readOnly"`
@@ -1544,10 +1542,10 @@ type ScaleIOPersistentVolumeSource struct {
 
 // Represents a StorageOS persistent volume resource.
 type StorageOSVolumeSource struct {
-	// VolumeName is the human-readable name of the StorageOS volume.  Volume
+	// volumeName is the human-readable name of the StorageOS volume.  Volume
 	// names are only unique within a namespace.
 	VolumeName string `json:"volumeName,omitempty" protobuf:"bytes,1,opt,name=volumeName"`
-	// VolumeNamespace specifies the scope of the volume within StorageOS.  If no
+	// volumeNamespace specifies the scope of the volume within StorageOS.  If no
 	// namespace is specified then the Pod's namespace will be used.  This allows the
 	// Kubernetes name scoping to be mirrored within StorageOS for tighter integration.
 	// Set VolumeName to any name to override the default behaviour.
@@ -1555,16 +1553,16 @@ type StorageOSVolumeSource struct {
 	// Namespaces that do not pre-exist within StorageOS will be created.
 	// +optional
 	VolumeNamespace string `json:"volumeNamespace,omitempty" protobuf:"bytes,2,opt,name=volumeNamespace"`
-	// Filesystem type to mount.
+	// fsType is the filesystem type to mount.
 	// Must be a filesystem type supported by the host operating system.
 	// Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
 	// +optional
 	FSType string `json:"fsType,omitempty" protobuf:"bytes,3,opt,name=fsType"`
-	// Defaults to false (read/write). ReadOnly here will force
+	// readOnly defaults to false (read/write). ReadOnly here will force
 	// the ReadOnly setting in VolumeMounts.
 	// +optional
 	ReadOnly bool `json:"readOnly,omitempty" protobuf:"varint,4,opt,name=readOnly"`
-	// SecretRef specifies the secret to use for obtaining the StorageOS API
+	// secretRef specifies the secret to use for obtaining the StorageOS API
 	// credentials.  If not specified, default values will be attempted.
 	// +optional
 	SecretRef *LocalObjectReference `json:"secretRef,omitempty" protobuf:"bytes,5,opt,name=secretRef"`
@@ -1572,10 +1570,10 @@ type StorageOSVolumeSource struct {
 
 // Represents a StorageOS persistent volume resource.
 type StorageOSPersistentVolumeSource struct {
-	// VolumeName is the human-readable name of the StorageOS volume.  Volume
+	// volumeName is the human-readable name of the StorageOS volume.  Volume
 	// names are only unique within a namespace.
 	VolumeName string `json:"volumeName,omitempty" protobuf:"bytes,1,opt,name=volumeName"`
-	// VolumeNamespace specifies the scope of the volume within StorageOS.  If no
+	// volumeNamespace specifies the scope of the volume within StorageOS.  If no
 	// namespace is specified then the Pod's namespace will be used.  This allows the
 	// Kubernetes name scoping to be mirrored within StorageOS for tighter integration.
 	// Set VolumeName to any name to override the default behaviour.
@@ -1583,16 +1581,16 @@ type StorageOSPersistentVolumeSource struct {
 	// Namespaces that do not pre-exist within StorageOS will be created.
 	// +optional
 	VolumeNamespace string `json:"volumeNamespace,omitempty" protobuf:"bytes,2,opt,name=volumeNamespace"`
-	// Filesystem type to mount.
+	// fsType is the filesystem type to mount.
 	// Must be a filesystem type supported by the host operating system.
 	// Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
 	// +optional
 	FSType string `json:"fsType,omitempty" protobuf:"bytes,3,opt,name=fsType"`
-	// Defaults to false (read/write). ReadOnly here will force
+	// readOnly defaults to false (read/write). ReadOnly here will force
 	// the ReadOnly setting in VolumeMounts.
 	// +optional
 	ReadOnly bool `json:"readOnly,omitempty" protobuf:"varint,4,opt,name=readOnly"`
-	// SecretRef specifies the secret to use for obtaining the StorageOS API
+	// secretRef specifies the secret to use for obtaining the StorageOS API
 	// credentials.  If not specified, default values will be attempted.
 	// +optional
 	SecretRef *ObjectReference `json:"secretRef,omitempty" protobuf:"bytes,5,opt,name=secretRef"`
@@ -1606,7 +1604,7 @@ type StorageOSPersistentVolumeSource struct {
 // ConfigMap volumes support ownership management and SELinux relabeling.
 type ConfigMapVolumeSource struct {
 	LocalObjectReference `json:",inline" protobuf:"bytes,1,opt,name=localObjectReference"`
-	// If unspecified, each key-value pair in the Data field of the referenced
+	// items if unspecified, each key-value pair in the Data field of the referenced
 	// ConfigMap will be projected into the volume as a file whose name is the
 	// key and content is the value. If specified, the listed keys will be
 	// projected into the specified paths, and unlisted keys will not be
@@ -1615,7 +1613,7 @@ type ConfigMapVolumeSource struct {
 	// relative and may not contain the '..' path or start with '..'.
 	// +optional
 	Items []KeyToPath `json:"items,omitempty" protobuf:"bytes,2,rep,name=items"`
-	// Optional: mode bits used to set permissions on created files by default.
+	// defaultMode is optional: mode bits used to set permissions on created files by default.
 	// Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
 	// YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
 	// Defaults to 0644.
@@ -1624,7 +1622,7 @@ type ConfigMapVolumeSource struct {
 	// mode, like fsGroup, and the result can be other mode bits set.
 	// +optional
 	DefaultMode *int32 `json:"defaultMode,omitempty" protobuf:"varint,3,opt,name=defaultMode"`
-	// Specify whether the ConfigMap or its keys must be defined
+	// optional specify whether the ConfigMap or its keys must be defined
 	// +optional
 	Optional *bool `json:"optional,omitempty" protobuf:"varint,4,opt,name=optional"`
 }
@@ -1642,7 +1640,7 @@ const (
 // mode.
 type ConfigMapProjection struct {
 	LocalObjectReference `json:",inline" protobuf:"bytes,1,opt,name=localObjectReference"`
-	// If unspecified, each key-value pair in the Data field of the referenced
+	// items if unspecified, each key-value pair in the Data field of the referenced
 	// ConfigMap will be projected into the volume as a file whose name is the
 	// key and content is the value. If specified, the listed keys will be
 	// projected into the specified paths, and unlisted keys will not be
@@ -1651,7 +1649,7 @@ type ConfigMapProjection struct {
 	// relative and may not contain the '..' path or start with '..'.
 	// +optional
 	Items []KeyToPath `json:"items,omitempty" protobuf:"bytes,2,rep,name=items"`
-	// Specify whether the ConfigMap or its keys must be defined
+	// optional specify whether the ConfigMap or its keys must be defined
 	// +optional
 	Optional *bool `json:"optional,omitempty" protobuf:"varint,4,opt,name=optional"`
 }
@@ -1661,13 +1659,13 @@ type ConfigMapProjection struct {
 // the pods runtime filesystem for use against APIs (Kubernetes API Server or
 // otherwise).
 type ServiceAccountTokenProjection struct {
-	// Audience is the intended audience of the token. A recipient of a token
+	// audience is the intended audience of the token. A recipient of a token
 	// must identify itself with an identifier specified in the audience of the
 	// token, and otherwise should reject the token. The audience defaults to the
 	// identifier of the apiserver.
 	//+optional
 	Audience string `json:"audience,omitempty" protobuf:"bytes,1,rep,name=audience"`
-	// ExpirationSeconds is the requested duration of validity of the service
+	// expirationSeconds is the requested duration of validity of the service
 	// account token. As the token approaches expiration, the kubelet volume
 	// plugin will proactively rotate the service account token. The kubelet will
 	// start trying to rotate the token if the token is older than 80 percent of
@@ -1675,17 +1673,17 @@ type ServiceAccountTokenProjection struct {
 	// and must be at least 10 minutes.
 	//+optional
 	ExpirationSeconds *int64 `json:"expirationSeconds,omitempty" protobuf:"varint,2,opt,name=expirationSeconds"`
-	// Path is the path relative to the mount point of the file to project the
+	// path is the path relative to the mount point of the file to project the
 	// token into.
 	Path string `json:"path" protobuf:"bytes,3,opt,name=path"`
 }
 
 // Represents a projected volume source
 type ProjectedVolumeSource struct {
-	// list of volume projections
+	// sources is the list of volume projections
 	// +optional
 	Sources []VolumeProjection `json:"sources" protobuf:"bytes,1,rep,name=sources"`
-	// Mode bits used to set permissions on created files by default.
+	// defaultMode are the mode bits used to set permissions on created files by default.
 	// Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
 	// YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
 	// Directories within the path are not affected by this setting.
@@ -1699,16 +1697,16 @@ type ProjectedVolumeSource struct {
 type VolumeProjection struct {
 	// all types below are the supported types for projection into the same volume
 
-	// information about the secret data to project
+	// secret information about the secret data to project
 	// +optional
 	Secret *SecretProjection `json:"secret,omitempty" protobuf:"bytes,1,opt,name=secret"`
-	// information about the downwardAPI data to project
+	// downwardAPI information about the downwardAPI data to project
 	// +optional
 	DownwardAPI *DownwardAPIProjection `json:"downwardAPI,omitempty" protobuf:"bytes,2,opt,name=downwardAPI"`
-	// information about the configMap data to project
+	// configMap information about the configMap data to project
 	// +optional
 	ConfigMap *ConfigMapProjection `json:"configMap,omitempty" protobuf:"bytes,3,opt,name=configMap"`
-	// information about the serviceAccountToken data to project
+	// serviceAccountToken is information about the serviceAccountToken data to project
 	// +optional
 	ServiceAccountToken *ServiceAccountTokenProjection `json:"serviceAccountToken,omitempty" protobuf:"bytes,4,opt,name=serviceAccountToken"`
 }
@@ -1719,15 +1717,15 @@ const (
 
 // Maps a string key to a path within a volume.
 type KeyToPath struct {
-	// The key to project.
+	// key is the key to project.
 	Key string `json:"key" protobuf:"bytes,1,opt,name=key"`
 
-	// The relative path of the file to map the key to.
+	// path is the relative path of the file to map the key to.
 	// May not be an absolute path.
 	// May not contain the path element '..'.
 	// May not start with the string '..'.
 	Path string `json:"path" protobuf:"bytes,2,opt,name=path"`
-	// Optional: mode bits used to set permissions on this file.
+	// mode is Optional: mode bits used to set permissions on this file.
 	// Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
 	// YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
 	// If not specified, the volume defaultMode will be used.
@@ -1739,11 +1737,11 @@ type KeyToPath struct {
 
 // Local represents directly-attached storage with node affinity (Beta feature)
 type LocalVolumeSource struct {
-	// The full path to the volume on the node.
+	// path of the full path to the volume on the node.
 	// It can be either a directory or block device (disk, partition, ...).
 	Path string `json:"path" protobuf:"bytes,1,opt,name=path"`
 
-	// Filesystem type to mount.
+	// fsType is the filesystem type to mount.
 	// It applies only when the Path is a block device.
 	// Must be a filesystem type supported by the host operating system.
 	// Ex. "ext4", "xfs", "ntfs". The default value is to auto-select a filesystem if unspecified.

--- a/staging/src/k8s.io/api/core/v1/types_swagger_doc_generated.go
+++ b/staging/src/k8s.io/api/core/v1/types_swagger_doc_generated.go
@@ -29,10 +29,10 @@ package v1
 // AUTO-GENERATED FUNCTIONS START HERE. DO NOT EDIT.
 var map_AWSElasticBlockStoreVolumeSource = map[string]string{
 	"":          "Represents a Persistent Disk resource in AWS.\n\nAn AWS EBS disk must exist before mounting to a container. The disk must also be in the same AWS zone as the kubelet. An AWS EBS disk can only be mounted as read/write once. AWS EBS volumes support ownership management and SELinux relabeling.",
-	"volumeID":  "Unique ID of the persistent disk resource in AWS (Amazon EBS volume). More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore",
-	"fsType":    "Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore",
-	"partition": "The partition in the volume that you want to mount. If omitted, the default is to mount by volume name. Examples: For volume /dev/sda1, you specify the partition as \"1\". Similarly, the volume partition for /dev/sda is \"0\" (or you can leave the property empty).",
-	"readOnly":  "Specify \"true\" to force and set the ReadOnly property in VolumeMounts to \"true\". If omitted, the default is \"false\". More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore",
+	"volumeID":  "volumeID is unique ID of the persistent disk resource in AWS (Amazon EBS volume). More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore",
+	"fsType":    "fsType is the filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore",
+	"partition": "partition is the partition in the volume that you want to mount. If omitted, the default is to mount by volume name. Examples: For volume /dev/sda1, you specify the partition as \"1\". Similarly, the volume partition for /dev/sda is \"0\" (or you can leave the property empty).",
+	"readOnly":  "readOnly value true will force the readOnly setting in VolumeMounts. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore",
 }
 
 func (AWSElasticBlockStoreVolumeSource) SwaggerDoc() map[string]string {
@@ -71,12 +71,12 @@ func (AvoidPods) SwaggerDoc() map[string]string {
 
 var map_AzureDiskVolumeSource = map[string]string{
 	"":            "AzureDisk represents an Azure Data Disk mount on the host and bind mount to the pod.",
-	"diskName":    "The Name of the data disk in the blob storage",
-	"diskURI":     "The URI the data disk in the blob storage",
-	"cachingMode": "Host Caching mode: None, Read Only, Read Write.",
-	"fsType":      "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
-	"readOnly":    "Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
-	"kind":        "Expected values Shared: multiple blob disks per storage account  Dedicated: single blob disk per storage account  Managed: azure managed data disk (only in managed availability set). defaults to shared",
+	"diskName":    "diskName is the Name of the data disk in the blob storage",
+	"diskURI":     "diskURI is the URI of data disk in the blob storage",
+	"cachingMode": "cachingMode is the Host Caching mode: None, Read Only, Read Write.",
+	"fsType":      "fsType is Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+	"readOnly":    "readOnly Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
+	"kind":        "kind expected values are Shared: multiple blob disks per storage account  Dedicated: single blob disk per storage account  Managed: azure managed data disk (only in managed availability set). defaults to shared",
 }
 
 func (AzureDiskVolumeSource) SwaggerDoc() map[string]string {
@@ -85,10 +85,10 @@ func (AzureDiskVolumeSource) SwaggerDoc() map[string]string {
 
 var map_AzureFilePersistentVolumeSource = map[string]string{
 	"":                "AzureFile represents an Azure File Service mount on the host and bind mount to the pod.",
-	"secretName":      "the name of secret that contains Azure Storage Account Name and Key",
-	"shareName":       "Share Name",
-	"readOnly":        "Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
-	"secretNamespace": "the namespace of the secret that contains Azure Storage Account Name and Key default is the same as the Pod",
+	"secretName":      "secretName is the name of secret that contains Azure Storage Account Name and Key",
+	"shareName":       "shareName is the azure Share Name",
+	"readOnly":        "readOnly defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
+	"secretNamespace": "secretNamespace is the namespace of the secret that contains Azure Storage Account Name and Key default is the same as the Pod",
 }
 
 func (AzureFilePersistentVolumeSource) SwaggerDoc() map[string]string {
@@ -97,9 +97,9 @@ func (AzureFilePersistentVolumeSource) SwaggerDoc() map[string]string {
 
 var map_AzureFileVolumeSource = map[string]string{
 	"":           "AzureFile represents an Azure File Service mount on the host and bind mount to the pod.",
-	"secretName": "the name of secret that contains Azure Storage Account Name and Key",
-	"shareName":  "Share Name",
-	"readOnly":   "Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
+	"secretName": "secretName is the  name of secret that contains Azure Storage Account Name and Key",
+	"shareName":  "shareName is the azure share Name",
+	"readOnly":   "readOnly defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
 }
 
 func (AzureFileVolumeSource) SwaggerDoc() map[string]string {
@@ -158,12 +158,12 @@ func (Capabilities) SwaggerDoc() map[string]string {
 
 var map_CephFSPersistentVolumeSource = map[string]string{
 	"":           "Represents a Ceph Filesystem mount that lasts the lifetime of a pod Cephfs volumes do not support ownership management or SELinux relabeling.",
-	"monitors":   "Required: Monitors is a collection of Ceph monitors More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
-	"path":       "Optional: Used as the mounted root, rather than the full Ceph tree, default is /",
-	"user":       "Optional: User is the rados user name, default is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
-	"secretFile": "Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
-	"secretRef":  "Optional: SecretRef is reference to the authentication secret for User, default is empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
-	"readOnly":   "Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
+	"monitors":   "monitors is Required: Monitors is a collection of Ceph monitors More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
+	"path":       "path is Optional: Used as the mounted root, rather than the full Ceph tree, default is /",
+	"user":       "user is Optional: User is the rados user name, default is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
+	"secretFile": "secretFile is Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
+	"secretRef":  "secretRef is Optional: SecretRef is reference to the authentication secret for User, default is empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
+	"readOnly":   "readOnly is Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
 }
 
 func (CephFSPersistentVolumeSource) SwaggerDoc() map[string]string {
@@ -172,12 +172,12 @@ func (CephFSPersistentVolumeSource) SwaggerDoc() map[string]string {
 
 var map_CephFSVolumeSource = map[string]string{
 	"":           "Represents a Ceph Filesystem mount that lasts the lifetime of a pod Cephfs volumes do not support ownership management or SELinux relabeling.",
-	"monitors":   "Required: Monitors is a collection of Ceph monitors More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
-	"path":       "Optional: Used as the mounted root, rather than the full Ceph tree, default is /",
-	"user":       "Optional: User is the rados user name, default is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
-	"secretFile": "Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
-	"secretRef":  "Optional: SecretRef is reference to the authentication secret for User, default is empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
-	"readOnly":   "Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
+	"monitors":   "monitors is Required: Monitors is a collection of Ceph monitors More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
+	"path":       "path is Optional: Used as the mounted root, rather than the full Ceph tree, default is /",
+	"user":       "user is optional: User is the rados user name, default is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
+	"secretFile": "secretFile is Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
+	"secretRef":  "secretRef is Optional: SecretRef is reference to the authentication secret for User, default is empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
+	"readOnly":   "readOnly is Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
 }
 
 func (CephFSVolumeSource) SwaggerDoc() map[string]string {
@@ -186,10 +186,10 @@ func (CephFSVolumeSource) SwaggerDoc() map[string]string {
 
 var map_CinderPersistentVolumeSource = map[string]string{
 	"":          "Represents a cinder volume resource in Openstack. A Cinder volume must exist before mounting to a container. The volume must also be in the same region as the kubelet. Cinder volumes support ownership management and SELinux relabeling.",
-	"volumeID":  "volume id used to identify the volume in cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md",
-	"fsType":    "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://examples.k8s.io/mysql-cinder-pd/README.md",
-	"readOnly":  "Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: https://examples.k8s.io/mysql-cinder-pd/README.md",
-	"secretRef": "Optional: points to a secret object containing parameters used to connect to OpenStack.",
+	"volumeID":  "volumeID used to identify the volume in cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md",
+	"fsType":    "fsType Filesystem type to mount. Must be a filesystem type supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://examples.k8s.io/mysql-cinder-pd/README.md",
+	"readOnly":  "readOnly is Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: https://examples.k8s.io/mysql-cinder-pd/README.md",
+	"secretRef": "secretRef is Optional: points to a secret object containing parameters used to connect to OpenStack.",
 }
 
 func (CinderPersistentVolumeSource) SwaggerDoc() map[string]string {
@@ -198,10 +198,10 @@ func (CinderPersistentVolumeSource) SwaggerDoc() map[string]string {
 
 var map_CinderVolumeSource = map[string]string{
 	"":          "Represents a cinder volume resource in Openstack. A Cinder volume must exist before mounting to a container. The volume must also be in the same region as the kubelet. Cinder volumes support ownership management and SELinux relabeling.",
-	"volumeID":  "volume id used to identify the volume in cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md",
-	"fsType":    "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://examples.k8s.io/mysql-cinder-pd/README.md",
-	"readOnly":  "Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: https://examples.k8s.io/mysql-cinder-pd/README.md",
-	"secretRef": "Optional: points to a secret object containing parameters used to connect to OpenStack.",
+	"volumeID":  "volumeID used to identify the volume in cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md",
+	"fsType":    "fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://examples.k8s.io/mysql-cinder-pd/README.md",
+	"readOnly":  "readOnly defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: https://examples.k8s.io/mysql-cinder-pd/README.md",
+	"secretRef": "secretRef is optional: points to a secret object containing parameters used to connect to OpenStack.",
 }
 
 func (CinderVolumeSource) SwaggerDoc() map[string]string {
@@ -305,8 +305,8 @@ func (ConfigMapNodeConfigSource) SwaggerDoc() map[string]string {
 
 var map_ConfigMapProjection = map[string]string{
 	"":         "Adapts a ConfigMap into a projected volume.\n\nThe contents of the target ConfigMap's Data field will be presented in a projected volume as files using the keys in the Data field as the file names, unless the items element is populated with specific mappings of keys to paths. Note that this is identical to a configmap volume source without the default mode.",
-	"items":    "If unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.",
-	"optional": "Specify whether the ConfigMap or its keys must be defined",
+	"items":    "items if unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.",
+	"optional": "optional specify whether the ConfigMap or its keys must be defined",
 }
 
 func (ConfigMapProjection) SwaggerDoc() map[string]string {
@@ -315,9 +315,9 @@ func (ConfigMapProjection) SwaggerDoc() map[string]string {
 
 var map_ConfigMapVolumeSource = map[string]string{
 	"":            "Adapts a ConfigMap into a volume.\n\nThe contents of the target ConfigMap's Data field will be presented in a volume as files using the keys in the Data field as the file names, unless the items element is populated with specific mappings of keys to paths. ConfigMap volumes support ownership management and SELinux relabeling.",
-	"items":       "If unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.",
-	"defaultMode": "Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
-	"optional":    "Specify whether the ConfigMap or its keys must be defined",
+	"items":       "items if unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.",
+	"defaultMode": "defaultMode is optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+	"optional":    "optional specify whether the ConfigMap or its keys must be defined",
 }
 
 func (ConfigMapVolumeSource) SwaggerDoc() map[string]string {
@@ -481,8 +481,8 @@ func (DownwardAPIVolumeSource) SwaggerDoc() map[string]string {
 
 var map_EmptyDirVolumeSource = map[string]string{
 	"":          "Represents an empty directory for a pod. Empty directory volumes support ownership management and SELinux relabeling.",
-	"medium":    "What type of storage medium should back this directory. The default is \"\" which means to use the node's default medium. Must be an empty string (default) or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir",
-	"sizeLimit": "Total amount of local storage required for this EmptyDir volume. The size limit is also applicable for memory medium. The maximum usage on memory medium EmptyDir would be the minimum value between the SizeLimit specified here and the sum of memory limits of all containers in a pod. The default is nil which means that the limit is undefined. More info: http://kubernetes.io/docs/user-guide/volumes#emptydir",
+	"medium":    "medium represents what type of storage medium should back this directory. The default is \"\" which means to use the node's default medium. Must be an empty string (default) or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir",
+	"sizeLimit": "sizeLimit is the total amount of local storage required for this EmptyDir volume. The size limit is also applicable for memory medium. The maximum usage on memory medium EmptyDir would be the minimum value between the SizeLimit specified here and the sum of memory limits of all containers in a pod. The default is nil which means that the limit is undefined. More info: http://kubernetes.io/docs/user-guide/volumes#emptydir",
 }
 
 func (EmptyDirVolumeSource) SwaggerDoc() map[string]string {
@@ -690,11 +690,11 @@ func (ExecAction) SwaggerDoc() map[string]string {
 
 var map_FCVolumeSource = map[string]string{
 	"":           "Represents a Fibre Channel volume. Fibre Channel volumes can only be mounted as read/write once. Fibre Channel volumes support ownership management and SELinux relabeling.",
-	"targetWWNs": "Optional: FC target worldwide names (WWNs)",
-	"lun":        "Optional: FC target lun number",
-	"fsType":     "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
-	"readOnly":   "Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
-	"wwids":      "Optional: FC volume world wide identifiers (wwids) Either wwids or combination of targetWWNs and lun must be set, but not both simultaneously.",
+	"targetWWNs": "targetWWNs is Optional: FC target worldwide names (WWNs)",
+	"lun":        "lun is Optional: FC target lun number",
+	"fsType":     "fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+	"readOnly":   "readOnly is Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
+	"wwids":      "wwids Optional: FC volume world wide identifiers (wwids) Either wwids or combination of targetWWNs and lun must be set, but not both simultaneously.",
 }
 
 func (FCVolumeSource) SwaggerDoc() map[string]string {
@@ -703,11 +703,11 @@ func (FCVolumeSource) SwaggerDoc() map[string]string {
 
 var map_FlexPersistentVolumeSource = map[string]string{
 	"":          "FlexPersistentVolumeSource represents a generic persistent volume resource that is provisioned/attached using an exec based plugin.",
-	"driver":    "Driver is the name of the driver to use for this volume.",
-	"fsType":    "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". The default filesystem depends on FlexVolume script.",
-	"secretRef": "Optional: SecretRef is reference to the secret object containing sensitive information to pass to the plugin scripts. This may be empty if no secret object is specified. If the secret object contains more than one secret, all secrets are passed to the plugin scripts.",
-	"readOnly":  "Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
-	"options":   "Optional: Extra command options if any.",
+	"driver":    "driver is the name of the driver to use for this volume.",
+	"fsType":    "fsType is the Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". The default filesystem depends on FlexVolume script.",
+	"secretRef": "secretRef is Optional: SecretRef is reference to the secret object containing sensitive information to pass to the plugin scripts. This may be empty if no secret object is specified. If the secret object contains more than one secret, all secrets are passed to the plugin scripts.",
+	"readOnly":  "readOnly is Optional: defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
+	"options":   "options is Optional: this field holds extra command options if any.",
 }
 
 func (FlexPersistentVolumeSource) SwaggerDoc() map[string]string {
@@ -716,11 +716,11 @@ func (FlexPersistentVolumeSource) SwaggerDoc() map[string]string {
 
 var map_FlexVolumeSource = map[string]string{
 	"":          "FlexVolume represents a generic volume resource that is provisioned/attached using an exec based plugin.",
-	"driver":    "Driver is the name of the driver to use for this volume.",
-	"fsType":    "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". The default filesystem depends on FlexVolume script.",
-	"secretRef": "Optional: SecretRef is reference to the secret object containing sensitive information to pass to the plugin scripts. This may be empty if no secret object is specified. If the secret object contains more than one secret, all secrets are passed to the plugin scripts.",
-	"readOnly":  "Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
-	"options":   "Optional: Extra command options if any.",
+	"driver":    "driver is the name of the driver to use for this volume.",
+	"fsType":    "fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". The default filesystem depends on FlexVolume script.",
+	"secretRef": "secretRef is Optional: secretRef is reference to the secret object containing sensitive information to pass to the plugin scripts. This may be empty if no secret object is specified. If the secret object contains more than one secret, all secrets are passed to the plugin scripts.",
+	"readOnly":  "readOnly is Optional: defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
+	"options":   "options is Optional: this field holds extra command options if any.",
 }
 
 func (FlexVolumeSource) SwaggerDoc() map[string]string {
@@ -729,8 +729,8 @@ func (FlexVolumeSource) SwaggerDoc() map[string]string {
 
 var map_FlockerVolumeSource = map[string]string{
 	"":            "Represents a Flocker volume mounted by the Flocker agent. One and only one of datasetName and datasetUUID should be set. Flocker volumes do not support ownership management or SELinux relabeling.",
-	"datasetName": "Name of the dataset stored as metadata -> name on the dataset for Flocker should be considered as deprecated",
-	"datasetUUID": "UUID of the dataset. This is unique identifier of a Flocker dataset",
+	"datasetName": "datasetName is Name of the dataset stored as metadata -> name on the dataset for Flocker should be considered as deprecated",
+	"datasetUUID": "datasetUUID is the UUID of the dataset. This is unique identifier of a Flocker dataset",
 }
 
 func (FlockerVolumeSource) SwaggerDoc() map[string]string {
@@ -739,10 +739,10 @@ func (FlockerVolumeSource) SwaggerDoc() map[string]string {
 
 var map_GCEPersistentDiskVolumeSource = map[string]string{
 	"":          "Represents a Persistent Disk resource in Google Compute Engine.\n\nA GCE PD must exist before mounting to a container. The disk must also be in the same GCE project and zone as the kubelet. A GCE PD can only be mounted as read/write once or read-only many times. GCE PDs support ownership management and SELinux relabeling.",
-	"pdName":    "Unique name of the PD resource in GCE. Used to identify the disk in GCE. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
-	"fsType":    "Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
-	"partition": "The partition in the volume that you want to mount. If omitted, the default is to mount by volume name. Examples: For volume /dev/sda1, you specify the partition as \"1\". Similarly, the volume partition for /dev/sda is \"0\" (or you can leave the property empty). More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
-	"readOnly":  "ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
+	"pdName":    "pdName is unique name of the PD resource in GCE. Used to identify the disk in GCE. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
+	"fsType":    "fsType is filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
+	"partition": "partition is the partition in the volume that you want to mount. If omitted, the default is to mount by volume name. Examples: For volume /dev/sda1, you specify the partition as \"1\". Similarly, the volume partition for /dev/sda is \"0\" (or you can leave the property empty). More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
+	"readOnly":  "readOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
 }
 
 func (GCEPersistentDiskVolumeSource) SwaggerDoc() map[string]string {
@@ -760,9 +760,9 @@ func (GRPCAction) SwaggerDoc() map[string]string {
 
 var map_GitRepoVolumeSource = map[string]string{
 	"":           "Represents a volume that is populated with the contents of a git repository. Git repo volumes do not support ownership management. Git repo volumes support SELinux relabeling.\n\nDEPRECATED: GitRepo is deprecated. To provision a container with a git repo, mount an EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir into the Pod's container.",
-	"repository": "Repository URL",
-	"revision":   "Commit hash for the specified revision.",
-	"directory":  "Target directory name. Must not contain or start with '..'.  If '.' is supplied, the volume directory will be the git repository.  Otherwise, if specified, the volume will contain the git repository in the subdirectory with the given name.",
+	"repository": "repository is the URL",
+	"revision":   "revision is the commit hash for the specified revision.",
+	"directory":  "directory is the target directory name. Must not contain or start with '..'.  If '.' is supplied, the volume directory will be the git repository.  Otherwise, if specified, the volume will contain the git repository in the subdirectory with the given name.",
 }
 
 func (GitRepoVolumeSource) SwaggerDoc() map[string]string {
@@ -771,10 +771,10 @@ func (GitRepoVolumeSource) SwaggerDoc() map[string]string {
 
 var map_GlusterfsPersistentVolumeSource = map[string]string{
 	"":                   "Represents a Glusterfs mount that lasts the lifetime of a pod. Glusterfs volumes do not support ownership management or SELinux relabeling.",
-	"endpoints":          "EndpointsName is the endpoint name that details Glusterfs topology. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod",
-	"path":               "Path is the Glusterfs volume path. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod",
-	"readOnly":           "ReadOnly here will force the Glusterfs volume to be mounted with read-only permissions. Defaults to false. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod",
-	"endpointsNamespace": "EndpointsNamespace is the namespace that contains Glusterfs endpoint. If this field is empty, the EndpointNamespace defaults to the same namespace as the bound PVC. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod",
+	"endpoints":          "endpoints is the endpoint name that details Glusterfs topology. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod",
+	"path":               "path is the Glusterfs volume path. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod",
+	"readOnly":           "readOnly here will force the Glusterfs volume to be mounted with read-only permissions. Defaults to false. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod",
+	"endpointsNamespace": "endpointsNamespace is the namespace that contains Glusterfs endpoint. If this field is empty, the EndpointNamespace defaults to the same namespace as the bound PVC. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod",
 }
 
 func (GlusterfsPersistentVolumeSource) SwaggerDoc() map[string]string {
@@ -783,9 +783,9 @@ func (GlusterfsPersistentVolumeSource) SwaggerDoc() map[string]string {
 
 var map_GlusterfsVolumeSource = map[string]string{
 	"":          "Represents a Glusterfs mount that lasts the lifetime of a pod. Glusterfs volumes do not support ownership management or SELinux relabeling.",
-	"endpoints": "EndpointsName is the endpoint name that details Glusterfs topology. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod",
-	"path":      "Path is the Glusterfs volume path. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod",
-	"readOnly":  "ReadOnly here will force the Glusterfs volume to be mounted with read-only permissions. Defaults to false. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod",
+	"endpoints": "endpoints is the endpoint name that details Glusterfs topology. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod",
+	"path":      "path is the Glusterfs volume path. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod",
+	"readOnly":  "readOnly here will force the Glusterfs volume to be mounted with read-only permissions. Defaults to false. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod",
 }
 
 func (GlusterfsVolumeSource) SwaggerDoc() map[string]string {
@@ -827,8 +827,8 @@ func (HostAlias) SwaggerDoc() map[string]string {
 
 var map_HostPathVolumeSource = map[string]string{
 	"":     "Represents a host path mapped into a pod. Host path volumes do not support ownership management or SELinux relabeling.",
-	"path": "Path of the directory on the host. If the path is a symlink, it will follow the link to the real path. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath",
-	"type": "Type for HostPath Volume Defaults to \"\" More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath",
+	"path": "path of the directory on the host. If the path is a symlink, it will follow the link to the real path. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath",
+	"type": "type for HostPath Volume Defaults to \"\" More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath",
 }
 
 func (HostPathVolumeSource) SwaggerDoc() map[string]string {
@@ -837,17 +837,17 @@ func (HostPathVolumeSource) SwaggerDoc() map[string]string {
 
 var map_ISCSIPersistentVolumeSource = map[string]string{
 	"":                  "ISCSIPersistentVolumeSource represents an ISCSI disk. ISCSI volumes can only be mounted as read/write once. ISCSI volumes support ownership management and SELinux relabeling.",
-	"targetPortal":      "iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).",
-	"iqn":               "Target iSCSI Qualified Name.",
-	"lun":               "iSCSI Target Lun number.",
-	"iscsiInterface":    "iSCSI Interface Name that uses an iSCSI transport. Defaults to 'default' (tcp).",
-	"fsType":            "Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi",
-	"readOnly":          "ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false.",
-	"portals":           "iSCSI Target Portal List. The Portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).",
-	"chapAuthDiscovery": "whether support iSCSI Discovery CHAP authentication",
-	"chapAuthSession":   "whether support iSCSI Session CHAP authentication",
-	"secretRef":         "CHAP Secret for iSCSI target and initiator authentication",
-	"initiatorName":     "Custom iSCSI Initiator Name. If initiatorName is specified with iscsiInterface simultaneously, new iSCSI interface <target portal>:<volume name> will be created for the connection.",
+	"targetPortal":      "targetPortal is iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).",
+	"iqn":               "iqn is Target iSCSI Qualified Name.",
+	"lun":               "lun is iSCSI Target Lun number.",
+	"iscsiInterface":    "iscsiInterface is the interface Name that uses an iSCSI transport. Defaults to 'default' (tcp).",
+	"fsType":            "fsType is the filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi",
+	"readOnly":          "readOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false.",
+	"portals":           "portals is the iSCSI Target Portal List. The Portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).",
+	"chapAuthDiscovery": "chapAuthDiscovery defines whether support iSCSI Discovery CHAP authentication",
+	"chapAuthSession":   "chapAuthSession defines whether support iSCSI Session CHAP authentication",
+	"secretRef":         "secretRef is the CHAP Secret for iSCSI target and initiator authentication",
+	"initiatorName":     "initiatorName is the custom iSCSI Initiator Name. If initiatorName is specified with iscsiInterface simultaneously, new iSCSI interface <target portal>:<volume name> will be created for the connection.",
 }
 
 func (ISCSIPersistentVolumeSource) SwaggerDoc() map[string]string {
@@ -856,17 +856,17 @@ func (ISCSIPersistentVolumeSource) SwaggerDoc() map[string]string {
 
 var map_ISCSIVolumeSource = map[string]string{
 	"":                  "Represents an ISCSI disk. ISCSI volumes can only be mounted as read/write once. ISCSI volumes support ownership management and SELinux relabeling.",
-	"targetPortal":      "iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).",
-	"iqn":               "Target iSCSI Qualified Name.",
-	"lun":               "iSCSI Target Lun number.",
-	"iscsiInterface":    "iSCSI Interface Name that uses an iSCSI transport. Defaults to 'default' (tcp).",
-	"fsType":            "Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi",
-	"readOnly":          "ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false.",
-	"portals":           "iSCSI Target Portal List. The portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).",
-	"chapAuthDiscovery": "whether support iSCSI Discovery CHAP authentication",
-	"chapAuthSession":   "whether support iSCSI Session CHAP authentication",
-	"secretRef":         "CHAP Secret for iSCSI target and initiator authentication",
-	"initiatorName":     "Custom iSCSI Initiator Name. If initiatorName is specified with iscsiInterface simultaneously, new iSCSI interface <target portal>:<volume name> will be created for the connection.",
+	"targetPortal":      "targetPortal is iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).",
+	"iqn":               "iqn is the target iSCSI Qualified Name.",
+	"lun":               "lun represents iSCSI Target Lun number.",
+	"iscsiInterface":    "iscsiInterface is the interface Name that uses an iSCSI transport. Defaults to 'default' (tcp).",
+	"fsType":            "fsType is the filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi",
+	"readOnly":          "readOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false.",
+	"portals":           "portals is the iSCSI Target Portal List. The portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).",
+	"chapAuthDiscovery": "chapAuthDiscovery defines whether support iSCSI Discovery CHAP authentication",
+	"chapAuthSession":   "chapAuthSession defines whether support iSCSI Session CHAP authentication",
+	"secretRef":         "secretRef is the CHAP Secret for iSCSI target and initiator authentication",
+	"initiatorName":     "initiatorName is the custom iSCSI Initiator Name. If initiatorName is specified with iscsiInterface simultaneously, new iSCSI interface <target portal>:<volume name> will be created for the connection.",
 }
 
 func (ISCSIVolumeSource) SwaggerDoc() map[string]string {
@@ -875,9 +875,9 @@ func (ISCSIVolumeSource) SwaggerDoc() map[string]string {
 
 var map_KeyToPath = map[string]string{
 	"":     "Maps a string key to a path within a volume.",
-	"key":  "The key to project.",
-	"path": "The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.",
-	"mode": "Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+	"key":  "key is the key to project.",
+	"path": "path is the relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.",
+	"mode": "mode is Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
 }
 
 func (KeyToPath) SwaggerDoc() map[string]string {
@@ -979,8 +979,8 @@ func (LocalObjectReference) SwaggerDoc() map[string]string {
 
 var map_LocalVolumeSource = map[string]string{
 	"":       "Local represents directly-attached storage with node affinity (Beta feature)",
-	"path":   "The full path to the volume on the node. It can be either a directory or block device (disk, partition, ...).",
-	"fsType": "Filesystem type to mount. It applies only when the Path is a block device. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". The default value is to auto-select a filesystem if unspecified.",
+	"path":   "path of the full path to the volume on the node. It can be either a directory or block device (disk, partition, ...).",
+	"fsType": "fsType is the filesystem type to mount. It applies only when the Path is a block device. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". The default value is to auto-select a filesystem if unspecified.",
 }
 
 func (LocalVolumeSource) SwaggerDoc() map[string]string {
@@ -989,9 +989,9 @@ func (LocalVolumeSource) SwaggerDoc() map[string]string {
 
 var map_NFSVolumeSource = map[string]string{
 	"":         "Represents an NFS mount that lasts the lifetime of a pod. NFS volumes do not support ownership management or SELinux relabeling.",
-	"server":   "Server is the hostname or IP address of the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
-	"path":     "Path that is exported by the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
-	"readOnly": "ReadOnly here will force the NFS export to be mounted with read-only permissions. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
+	"server":   "server is the hostname or IP address of the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
+	"path":     "path that is exported by the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
+	"readOnly": "readOnly here will force the NFS export to be mounted with read-only permissions. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
 }
 
 func (NFSVolumeSource) SwaggerDoc() map[string]string {
@@ -1421,8 +1421,8 @@ func (PersistentVolumeStatus) SwaggerDoc() map[string]string {
 
 var map_PhotonPersistentDiskVolumeSource = map[string]string{
 	"":       "Represents a Photon Controller persistent disk resource.",
-	"pdID":   "ID that identifies Photon Controller persistent disk",
-	"fsType": "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+	"pdID":   "pdID is the ID that identifies Photon Controller persistent disk",
+	"fsType": "fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
 }
 
 func (PhotonPersistentDiskVolumeSource) SwaggerDoc() map[string]string {
@@ -1749,9 +1749,9 @@ func (PortStatus) SwaggerDoc() map[string]string {
 
 var map_PortworxVolumeSource = map[string]string{
 	"":         "PortworxVolumeSource represents a Portworx volume resource.",
-	"volumeID": "VolumeID uniquely identifies a Portworx volume",
-	"fsType":   "FSType represents the filesystem type to mount Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\". Implicitly inferred to be \"ext4\" if unspecified.",
-	"readOnly": "Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
+	"volumeID": "volumeID uniquely identifies a Portworx volume",
+	"fsType":   "fSType represents the filesystem type to mount Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+	"readOnly": "readOnly defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
 }
 
 func (PortworxVolumeSource) SwaggerDoc() map[string]string {
@@ -1817,8 +1817,8 @@ func (ProbeHandler) SwaggerDoc() map[string]string {
 
 var map_ProjectedVolumeSource = map[string]string{
 	"":            "Represents a projected volume source",
-	"sources":     "list of volume projections",
-	"defaultMode": "Mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+	"sources":     "sources is the list of volume projections",
+	"defaultMode": "defaultMode are the mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
 }
 
 func (ProjectedVolumeSource) SwaggerDoc() map[string]string {
@@ -1827,12 +1827,12 @@ func (ProjectedVolumeSource) SwaggerDoc() map[string]string {
 
 var map_QuobyteVolumeSource = map[string]string{
 	"":         "Represents a Quobyte mount that lasts the lifetime of a pod. Quobyte volumes do not support ownership management or SELinux relabeling.",
-	"registry": "Registry represents a single or multiple Quobyte Registry services specified as a string as host:port pair (multiple entries are separated with commas) which acts as the central registry for volumes",
-	"volume":   "Volume is a string that references an already created Quobyte volume by name.",
-	"readOnly": "ReadOnly here will force the Quobyte volume to be mounted with read-only permissions. Defaults to false.",
-	"user":     "User to map volume access to Defaults to serivceaccount user",
-	"group":    "Group to map volume access to Default is no group",
-	"tenant":   "Tenant owning the given Quobyte volume in the Backend Used with dynamically provisioned Quobyte volumes, value is set by the plugin",
+	"registry": "registry represents a single or multiple Quobyte Registry services specified as a string as host:port pair (multiple entries are separated with commas) which acts as the central registry for volumes",
+	"volume":   "volume is a string that references an already created Quobyte volume by name.",
+	"readOnly": "readOnly here will force the Quobyte volume to be mounted with read-only permissions. Defaults to false.",
+	"user":     "user to map volume access to Defaults to serivceaccount user",
+	"group":    "group to map volume access to Default is no group",
+	"tenant":   "tenant owning the given Quobyte volume in the Backend Used with dynamically provisioned Quobyte volumes, value is set by the plugin",
 }
 
 func (QuobyteVolumeSource) SwaggerDoc() map[string]string {
@@ -1841,14 +1841,14 @@ func (QuobyteVolumeSource) SwaggerDoc() map[string]string {
 
 var map_RBDPersistentVolumeSource = map[string]string{
 	"":          "Represents a Rados Block Device mount that lasts the lifetime of a pod. RBD volumes support ownership management and SELinux relabeling.",
-	"monitors":  "A collection of Ceph monitors. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
-	"image":     "The rados image name. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
-	"fsType":    "Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd",
-	"pool":      "The rados pool name. Default is rbd. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
-	"user":      "The rados user name. Default is admin. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
-	"keyring":   "Keyring is the path to key ring for RBDUser. Default is /etc/ceph/keyring. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
-	"secretRef": "SecretRef is name of the authentication secret for RBDUser. If provided overrides keyring. Default is nil. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
-	"readOnly":  "ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+	"monitors":  "monitors is a collection of Ceph monitors. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+	"image":     "image is the rados image name. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+	"fsType":    "fsType is the filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd",
+	"pool":      "pool is the rados pool name. Default is rbd. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+	"user":      "user is the rados user name. Default is admin. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+	"keyring":   "keyring is the path to key ring for RBDUser. Default is /etc/ceph/keyring. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+	"secretRef": "secretRef is name of the authentication secret for RBDUser. If provided overrides keyring. Default is nil. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+	"readOnly":  "readOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
 }
 
 func (RBDPersistentVolumeSource) SwaggerDoc() map[string]string {
@@ -1857,14 +1857,14 @@ func (RBDPersistentVolumeSource) SwaggerDoc() map[string]string {
 
 var map_RBDVolumeSource = map[string]string{
 	"":          "Represents a Rados Block Device mount that lasts the lifetime of a pod. RBD volumes support ownership management and SELinux relabeling.",
-	"monitors":  "A collection of Ceph monitors. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
-	"image":     "The rados image name. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
-	"fsType":    "Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd",
-	"pool":      "The rados pool name. Default is rbd. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
-	"user":      "The rados user name. Default is admin. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
-	"keyring":   "Keyring is the path to key ring for RBDUser. Default is /etc/ceph/keyring. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
-	"secretRef": "SecretRef is name of the authentication secret for RBDUser. If provided overrides keyring. Default is nil. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
-	"readOnly":  "ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+	"monitors":  "monitors is a collection of Ceph monitors. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+	"image":     "image is the rados image name. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+	"fsType":    "fsType is the filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd",
+	"pool":      "pool is the rados pool name. Default is rbd. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+	"user":      "user is the rados user name. Default is admin. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+	"keyring":   "keyring is the path to key ring for RBDUser. Default is /etc/ceph/keyring. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+	"secretRef": "secretRef is name of the authentication secret for RBDUser. If provided overrides keyring. Default is nil. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+	"readOnly":  "readOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
 }
 
 func (RBDVolumeSource) SwaggerDoc() map[string]string {
@@ -2019,16 +2019,16 @@ func (SELinuxOptions) SwaggerDoc() map[string]string {
 
 var map_ScaleIOPersistentVolumeSource = map[string]string{
 	"":                 "ScaleIOPersistentVolumeSource represents a persistent ScaleIO volume",
-	"gateway":          "The host address of the ScaleIO API Gateway.",
-	"system":           "The name of the storage system as configured in ScaleIO.",
-	"secretRef":        "SecretRef references to the secret for ScaleIO user and other sensitive information. If this is not provided, Login operation will fail.",
-	"sslEnabled":       "Flag to enable/disable SSL communication with Gateway, default false",
-	"protectionDomain": "The name of the ScaleIO Protection Domain for the configured storage.",
-	"storagePool":      "The ScaleIO Storage Pool associated with the protection domain.",
-	"storageMode":      "Indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned. Default is ThinProvisioned.",
-	"volumeName":       "The name of a volume already created in the ScaleIO system that is associated with this volume source.",
-	"fsType":           "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Default is \"xfs\"",
-	"readOnly":         "Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
+	"gateway":          "gateway is the host address of the ScaleIO API Gateway.",
+	"system":           "system is the name of the storage system as configured in ScaleIO.",
+	"secretRef":        "secretRef references to the secret for ScaleIO user and other sensitive information. If this is not provided, Login operation will fail.",
+	"sslEnabled":       "sslEnabled is the flag to enable/disable SSL communication with Gateway, default false",
+	"protectionDomain": "protectionDomain is the name of the ScaleIO Protection Domain for the configured storage.",
+	"storagePool":      "storagePool is the ScaleIO Storage Pool associated with the protection domain.",
+	"storageMode":      "storageMode indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned. Default is ThinProvisioned.",
+	"volumeName":       "volumeName is the name of a volume already created in the ScaleIO system that is associated with this volume source.",
+	"fsType":           "fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Default is \"xfs\"",
+	"readOnly":         "readOnly defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
 }
 
 func (ScaleIOPersistentVolumeSource) SwaggerDoc() map[string]string {
@@ -2037,16 +2037,16 @@ func (ScaleIOPersistentVolumeSource) SwaggerDoc() map[string]string {
 
 var map_ScaleIOVolumeSource = map[string]string{
 	"":                 "ScaleIOVolumeSource represents a persistent ScaleIO volume",
-	"gateway":          "The host address of the ScaleIO API Gateway.",
-	"system":           "The name of the storage system as configured in ScaleIO.",
-	"secretRef":        "SecretRef references to the secret for ScaleIO user and other sensitive information. If this is not provided, Login operation will fail.",
-	"sslEnabled":       "Flag to enable/disable SSL communication with Gateway, default false",
-	"protectionDomain": "The name of the ScaleIO Protection Domain for the configured storage.",
-	"storagePool":      "The ScaleIO Storage Pool associated with the protection domain.",
-	"storageMode":      "Indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned. Default is ThinProvisioned.",
-	"volumeName":       "The name of a volume already created in the ScaleIO system that is associated with this volume source.",
-	"fsType":           "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Default is \"xfs\".",
-	"readOnly":         "Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
+	"gateway":          "gateway is the host address of the ScaleIO API Gateway.",
+	"system":           "system is the name of the storage system as configured in ScaleIO.",
+	"secretRef":        "secretRef references to the secret for ScaleIO user and other sensitive information. If this is not provided, Login operation will fail.",
+	"sslEnabled":       "sslEnabled Flag enable/disable SSL communication with Gateway, default false",
+	"protectionDomain": "protectionDomain is the name of the ScaleIO Protection Domain for the configured storage.",
+	"storagePool":      "storagePool is the ScaleIO Storage Pool associated with the protection domain.",
+	"storageMode":      "storageMode indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned. Default is ThinProvisioned.",
+	"volumeName":       "volumeName is the name of a volume already created in the ScaleIO system that is associated with this volume source.",
+	"fsType":           "fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Default is \"xfs\".",
+	"readOnly":         "readOnly Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
 }
 
 func (ScaleIOVolumeSource) SwaggerDoc() map[string]string {
@@ -2127,8 +2127,8 @@ func (SecretList) SwaggerDoc() map[string]string {
 
 var map_SecretProjection = map[string]string{
 	"":         "Adapts a secret into a projected volume.\n\nThe contents of the target Secret's Data field will be presented in a projected volume as files using the keys in the Data field as the file names. Note that this is identical to a secret volume source without the default mode.",
-	"items":    "If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.",
-	"optional": "Specify whether the Secret or its key must be defined",
+	"items":    "items if unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.",
+	"optional": "optional field specify whether the Secret or its key must be defined",
 }
 
 func (SecretProjection) SwaggerDoc() map[string]string {
@@ -2137,8 +2137,8 @@ func (SecretProjection) SwaggerDoc() map[string]string {
 
 var map_SecretReference = map[string]string{
 	"":          "SecretReference represents a Secret Reference. It has enough information to retrieve secret in any namespace",
-	"name":      "Name is unique within a namespace to reference a secret resource.",
-	"namespace": "Namespace defines the space within which the secret name must be unique.",
+	"name":      "name is unique within a namespace to reference a secret resource.",
+	"namespace": "namespace defines the space within which the secret name must be unique.",
 }
 
 func (SecretReference) SwaggerDoc() map[string]string {
@@ -2147,10 +2147,10 @@ func (SecretReference) SwaggerDoc() map[string]string {
 
 var map_SecretVolumeSource = map[string]string{
 	"":            "Adapts a Secret into a volume.\n\nThe contents of the target Secret's Data field will be presented in a volume as files using the keys in the Data field as the file names. Secret volumes support ownership management and SELinux relabeling.",
-	"secretName":  "Name of the secret in the pod's namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret",
-	"items":       "If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.",
-	"defaultMode": "Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
-	"optional":    "Specify whether the Secret or its keys must be defined",
+	"secretName":  "secretName is the name of the secret in the pod's namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret",
+	"items":       "items If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.",
+	"defaultMode": "defaultMode is Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+	"optional":    "optional field specify whether the Secret or its keys must be defined",
 }
 
 func (SecretVolumeSource) SwaggerDoc() map[string]string {
@@ -2220,9 +2220,9 @@ func (ServiceAccountList) SwaggerDoc() map[string]string {
 
 var map_ServiceAccountTokenProjection = map[string]string{
 	"":                  "ServiceAccountTokenProjection represents a projected service account token volume. This projection can be used to insert a service account token into the pods runtime filesystem for use against APIs (Kubernetes API Server or otherwise).",
-	"audience":          "Audience is the intended audience of the token. A recipient of a token must identify itself with an identifier specified in the audience of the token, and otherwise should reject the token. The audience defaults to the identifier of the apiserver.",
-	"expirationSeconds": "ExpirationSeconds is the requested duration of validity of the service account token. As the token approaches expiration, the kubelet volume plugin will proactively rotate the service account token. The kubelet will start trying to rotate the token if the token is older than 80 percent of its time to live or if the token is older than 24 hours.Defaults to 1 hour and must be at least 10 minutes.",
-	"path":              "Path is the path relative to the mount point of the file to project the token into.",
+	"audience":          "audience is the intended audience of the token. A recipient of a token must identify itself with an identifier specified in the audience of the token, and otherwise should reject the token. The audience defaults to the identifier of the apiserver.",
+	"expirationSeconds": "expirationSeconds is the requested duration of validity of the service account token. As the token approaches expiration, the kubelet volume plugin will proactively rotate the service account token. The kubelet will start trying to rotate the token if the token is older than 80 percent of its time to live or if the token is older than 24 hours.Defaults to 1 hour and must be at least 10 minutes.",
+	"path":              "path is the path relative to the mount point of the file to project the token into.",
 }
 
 func (ServiceAccountTokenProjection) SwaggerDoc() map[string]string {
@@ -2310,11 +2310,11 @@ func (SessionAffinityConfig) SwaggerDoc() map[string]string {
 
 var map_StorageOSPersistentVolumeSource = map[string]string{
 	"":                "Represents a StorageOS persistent volume resource.",
-	"volumeName":      "VolumeName is the human-readable name of the StorageOS volume.  Volume names are only unique within a namespace.",
-	"volumeNamespace": "VolumeNamespace specifies the scope of the volume within StorageOS.  If no namespace is specified then the Pod's namespace will be used.  This allows the Kubernetes name scoping to be mirrored within StorageOS for tighter integration. Set VolumeName to any name to override the default behaviour. Set to \"default\" if you are not using namespaces within StorageOS. Namespaces that do not pre-exist within StorageOS will be created.",
-	"fsType":          "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
-	"readOnly":        "Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
-	"secretRef":       "SecretRef specifies the secret to use for obtaining the StorageOS API credentials.  If not specified, default values will be attempted.",
+	"volumeName":      "volumeName is the human-readable name of the StorageOS volume.  Volume names are only unique within a namespace.",
+	"volumeNamespace": "volumeNamespace specifies the scope of the volume within StorageOS.  If no namespace is specified then the Pod's namespace will be used.  This allows the Kubernetes name scoping to be mirrored within StorageOS for tighter integration. Set VolumeName to any name to override the default behaviour. Set to \"default\" if you are not using namespaces within StorageOS. Namespaces that do not pre-exist within StorageOS will be created.",
+	"fsType":          "fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+	"readOnly":        "readOnly defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
+	"secretRef":       "secretRef specifies the secret to use for obtaining the StorageOS API credentials.  If not specified, default values will be attempted.",
 }
 
 func (StorageOSPersistentVolumeSource) SwaggerDoc() map[string]string {
@@ -2323,11 +2323,11 @@ func (StorageOSPersistentVolumeSource) SwaggerDoc() map[string]string {
 
 var map_StorageOSVolumeSource = map[string]string{
 	"":                "Represents a StorageOS persistent volume resource.",
-	"volumeName":      "VolumeName is the human-readable name of the StorageOS volume.  Volume names are only unique within a namespace.",
-	"volumeNamespace": "VolumeNamespace specifies the scope of the volume within StorageOS.  If no namespace is specified then the Pod's namespace will be used.  This allows the Kubernetes name scoping to be mirrored within StorageOS for tighter integration. Set VolumeName to any name to override the default behaviour. Set to \"default\" if you are not using namespaces within StorageOS. Namespaces that do not pre-exist within StorageOS will be created.",
-	"fsType":          "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
-	"readOnly":        "Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
-	"secretRef":       "SecretRef specifies the secret to use for obtaining the StorageOS API credentials.  If not specified, default values will be attempted.",
+	"volumeName":      "volumeName is the human-readable name of the StorageOS volume.  Volume names are only unique within a namespace.",
+	"volumeNamespace": "volumeNamespace specifies the scope of the volume within StorageOS.  If no namespace is specified then the Pod's namespace will be used.  This allows the Kubernetes name scoping to be mirrored within StorageOS for tighter integration. Set VolumeName to any name to override the default behaviour. Set to \"default\" if you are not using namespaces within StorageOS. Namespaces that do not pre-exist within StorageOS will be created.",
+	"fsType":          "fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+	"readOnly":        "readOnly defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
+	"secretRef":       "secretRef specifies the secret to use for obtaining the StorageOS API credentials.  If not specified, default values will be attempted.",
 }
 
 func (StorageOSVolumeSource) SwaggerDoc() map[string]string {
@@ -2465,10 +2465,10 @@ func (VolumeNodeAffinity) SwaggerDoc() map[string]string {
 
 var map_VolumeProjection = map[string]string{
 	"":                    "Projection that may be projected along with other supported volume types",
-	"secret":              "information about the secret data to project",
-	"downwardAPI":         "information about the downwardAPI data to project",
-	"configMap":           "information about the configMap data to project",
-	"serviceAccountToken": "information about the serviceAccountToken data to project",
+	"secret":              "secret information about the secret data to project",
+	"downwardAPI":         "downwardAPI information about the downwardAPI data to project",
+	"configMap":           "configMap information about the configMap data to project",
+	"serviceAccountToken": "serviceAccountToken is information about the serviceAccountToken data to project",
 }
 
 func (VolumeProjection) SwaggerDoc() map[string]string {
@@ -2514,10 +2514,10 @@ func (VolumeSource) SwaggerDoc() map[string]string {
 
 var map_VsphereVirtualDiskVolumeSource = map[string]string{
 	"":                  "Represents a vSphere volume resource.",
-	"volumePath":        "Path that identifies vSphere volume vmdk",
-	"fsType":            "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
-	"storagePolicyName": "Storage Policy Based Management (SPBM) profile name.",
-	"storagePolicyID":   "Storage Policy Based Management (SPBM) profile ID associated with the StoragePolicyName.",
+	"volumePath":        "volumePath is the path that identifies vSphere volume vmdk",
+	"fsType":            "fsType is filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+	"storagePolicyName": "storagePolicyName is the storage Policy Based Management (SPBM) profile name.",
+	"storagePolicyID":   "storagePolicyID is the storage Policy Based Management (SPBM) profile ID associated with the StoragePolicyName.",
 }
 
 func (VsphereVirtualDiskVolumeSource) SwaggerDoc() map[string]string {


### PR DESCRIPTION
This commit corrects struct field names in the godoc for various
storage volume plugins volume sources and persistent volume sources.

Additional Ref# #105963 (comment)

Signed-off-by: Humble Chirammal <hchiramm@redhat.com>


/kind cleanup

```release-note
NONE
