### PR TITLE
Correct the feature gate string for RBD migration.

### DIFF
--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -339,7 +339,7 @@ const (
 	// alpha: v1.23
 	//
 	// Enables the RBD in-tree driver to RBD CSI Driver  migration feature.
-	CSIMigrationRBD featuregate.Feature = "csiMigrationRBD"
+	CSIMigrationRBD featuregate.Feature = "CSIMigrationRBD"
 
 	// owner: @humblec
 	// alpha: v1.23


### PR DESCRIPTION
The feature gate is wrongly mentioned as csiMigrationRBD in
kube features where it should have been CSIMigrationRBD to
match other migration feature gates and formatting.

Signed-off-by: Humble Chirammal <hchiramm@redhat.com>


/kind bug

/kind regression
-->


-->
```release-note
The feature gate was mentioned as `csiMigrationRBD` where it should have been `CSIMigrationRBD` to be in parity with other migration plugins. This release correct the same and keep it as `CSIMigrationRBD`.

Action Required: users who have configured this feature gate as `csiMigrationRBD` has to reconfigure the same to `CSIMigrationRBD` from this release.
```

