### PR TITLE
Automated cherry pick of #107554: Correct the feature gate string for RBD migration.

### DIFF
--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -346,7 +346,7 @@ const (
 	// alpha: v1.23
 	//
 	// Enables the RBD in-tree driver to RBD CSI Driver  migration feature.
-	CSIMigrationRBD featuregate.Feature = "csiMigrationRBD"
+	CSIMigrationRBD featuregate.Feature = "CSIMigrationRBD"
 
 	// owner: @humblec
 	// alpha: v1.23


### PR DESCRIPTION
Cherry pick of #107554 on release-1.23.

#107554: Correct the feature gate string for RBD migration.

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```