### PR TITLE
allow case insensitive matching for field selectors

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/fields/selector.go
+++ b/staging/src/k8s.io/apimachinery/pkg/fields/selector.go
@@ -82,7 +82,7 @@ type hasTerm struct {
 }
 
 func (t *hasTerm) Matches(ls Fields) bool {
-	return ls.Get(t.field) == t.value
+	return strings.EqualFold(ls.Get(t.field), t.value)
 }
 
 func (t *hasTerm) Empty() bool {
@@ -133,7 +133,7 @@ type notHasTerm struct {
 }
 
 func (t *notHasTerm) Matches(ls Fields) bool {
-	return ls.Get(t.field) != t.value
+	return !strings.EqualFold(ls.Get(t.field), t.value)
 }
 
 func (t *notHasTerm) Empty() bool {

--- a/staging/src/k8s.io/apimachinery/pkg/fields/selector_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/fields/selector_test.go
@@ -209,6 +209,7 @@ func TestSelectorMatches(t *testing.T) {
 	expectMatch(t, "", Set{"x": "y"})
 	expectMatch(t, "x=y", Set{"x": "y"})
 	expectMatch(t, "x=y,z=w", Set{"x": "y", "z": "w"})
+	expectMatch(t, "x=y,z=w", Set{"x": "Y", "z": "W"}) // matching is case insensitive
 	expectMatch(t, "x!=y,z!=w", Set{"x": "z", "z": "a"})
 	expectMatch(t, "notin=in", Set{"notin": "in"}) // in and notin in exactMatch
 	expectNoMatch(t, "x=y", Set{"x": "z"})


### PR DESCRIPTION
Signed-off-by: Sanskar Jaiswal <jaiswalsanskar078@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This PR allows for case insensitive matching for field selectors.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #107285 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Field selectors can be used in a case insensitive manner.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
