### PR TITLE
Revert "Automated cherry pick of #107554: Correct the feature gate string for RBD migration."

### DIFF
--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -346,7 +346,7 @@ const (
 	// alpha: v1.23
 	//
 	// Enables the RBD in-tree driver to RBD CSI Driver  migration feature.
-	CSIMigrationRBD featuregate.Feature = "CSIMigrationRBD"
+	CSIMigrationRBD featuregate.Feature = "csiMigrationRBD"
 
 	// owner: @humblec
 	// alpha: v1.23


### PR DESCRIPTION
Reverts kubernetes/kubernetes#107555