### PR TITLE
Cherry pick of #106164 and #104705 on release-1.22

### DIFF
--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_loadbalancer.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_loadbalancer.go
@@ -2132,9 +2132,8 @@ func (az *Cloud) ensurePIPTagged(service *v1.Service, pip *network.PublicIPAddre
 	if _, ok := service.Annotations[ServiceAnnotationAzurePIPTags]; ok {
 		annotationTags = parseTags(service.Annotations[ServiceAnnotationAzurePIPTags])
 	}
-	for k, v := range annotationTags {
-		configTags[k] = v
-	}
+	configTags, _ = reconcileTags(configTags, annotationTags)
+
 	// include the cluster name and service names tags when comparing
 	var clusterName, serviceNames *string
 	if v, ok := pip.Tags[clusterNameKey]; ok {

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_routes.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_routes.go
@@ -110,6 +110,7 @@ func (d *delayedRouteUpdater) updateRoutes() {
 
 	// No need to do any updating.
 	if len(d.routesToUpdate) == 0 {
+		klog.V(6).Info("updateRoutes: nothing to update, returning")
 		return
 	}
 
@@ -215,6 +216,8 @@ func (d *delayedRouteUpdater) cleanupOutdatedRoutes(existingRoutes []network.Rou
 	for i := len(existingRoutes) - 1; i >= 0; i-- {
 		existingRouteName := to.String(existingRoutes[i].Name)
 		split := strings.Split(existingRouteName, routeNameSeparator)
+
+		klog.V(4).Infof("cleanupOutdatedRoutes: checking route %s", existingRouteName)
 
 		// filter out unmanaged routes
 		deleteRoute := false
@@ -466,9 +469,8 @@ func (az *Cloud) DeleteRoute(ctx context.Context, clusterName string, kubeRoute 
 		return nil
 	}
 
-	klog.V(2).Infof("DeleteRoute: deleting route. clusterName=%q instance=%q cidr=%q", clusterName, kubeRoute.TargetNode, kubeRoute.DestinationCIDR)
-
 	routeName := mapNodeNameToRouteName(az.ipv6DualStackEnabled, kubeRoute.TargetNode, string(kubeRoute.DestinationCIDR))
+	klog.V(2).Infof("DeleteRoute: deleting route. clusterName=%q instance=%q cidr=%q routeName=%q", clusterName, kubeRoute.TargetNode, kubeRoute.DestinationCIDR, routeName)
 	route := network.Route{
 		Name:                  to.StringPtr(routeName),
 		RoutePropertiesFormat: &network.RoutePropertiesFormat{},
@@ -484,6 +486,28 @@ func (az *Cloud) DeleteRoute(ctx context.Context, clusterName string, kubeRoute 
 	if err != nil {
 		klog.Errorf("DeleteRoute failed for node %q with error: %v", kubeRoute.TargetNode, err)
 		return err
+	}
+
+	// Remove outdated ipv4 routes as well
+	if az.ipv6DualStackEnabled {
+		routeNameWithoutIPV6Suffix := strings.Split(routeName, routeNameSeparator)[0]
+		klog.V(2).Infof("DeleteRoute: deleting route. clusterName=%q instance=%q cidr=%q routeName=%q", clusterName, kubeRoute.TargetNode, kubeRoute.DestinationCIDR, routeNameWithoutIPV6Suffix)
+		route := network.Route{
+			Name:                  to.StringPtr(routeNameWithoutIPV6Suffix),
+			RoutePropertiesFormat: &network.RoutePropertiesFormat{},
+		}
+		op, err := az.routeUpdater.addRouteOperation(routeOperationDelete, route)
+		if err != nil {
+			klog.Errorf("DeleteRoute failed for node %q with error: %v", kubeRoute.TargetNode, err)
+			return err
+		}
+
+		// Wait for operation complete.
+		err = op.wait()
+		if err != nil {
+			klog.Errorf("DeleteRoute failed for node %q with error: %v", kubeRoute.TargetNode, err)
+			return err
+		}
 	}
 
 	klog.V(2).Infof("DeleteRoute: route deleted. clusterName=%q instance=%q cidr=%q", clusterName, kubeRoute.TargetNode, kubeRoute.DestinationCIDR)

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_routes_test.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_routes_test.go
@@ -740,3 +740,72 @@ func TestCleanupOutdatedRoutes(t *testing.T) {
 		})
 	}
 }
+
+func TestDeleteRouteDualStack(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	routeTableClient := mockroutetableclient.NewMockInterface(ctrl)
+
+	cloud := &Cloud{
+		RouteTablesClient: routeTableClient,
+		Config: Config{
+			RouteTableResourceGroup: "foo",
+			RouteTableName:          "bar",
+			Location:                "location",
+		},
+		unmanagedNodes:       sets.NewString(),
+		nodeInformerSynced:   func() bool { return true },
+		ipv6DualStackEnabled: true,
+	}
+	cache, _ := cloud.newRouteTableCache()
+	cloud.rtCache = cache
+	cloud.routeUpdater = newDelayedRouteUpdater(cloud, 100*time.Millisecond)
+	go cloud.routeUpdater.run()
+
+	route := cloudprovider.Route{
+		TargetNode:      "node",
+		DestinationCIDR: "1.2.3.4/24",
+	}
+	routeName := mapNodeNameToRouteName(true, route.TargetNode, route.DestinationCIDR)
+	routeNameIPV4 := mapNodeNameToRouteName(false, route.TargetNode, route.DestinationCIDR)
+	routeTables := network.RouteTable{
+		Name:     &cloud.RouteTableName,
+		Location: &cloud.Location,
+		RouteTablePropertiesFormat: &network.RouteTablePropertiesFormat{
+			Routes: &[]network.Route{
+				{
+					Name: &routeName,
+				},
+				{
+					Name: &routeNameIPV4,
+				},
+			},
+		},
+	}
+	routeTablesAfterFirstDeletion := network.RouteTable{
+		Name:     &cloud.RouteTableName,
+		Location: &cloud.Location,
+		RouteTablePropertiesFormat: &network.RouteTablePropertiesFormat{
+			Routes: &[]network.Route{
+				{
+					Name: &routeNameIPV4,
+				},
+			},
+		},
+	}
+	routeTablesAfterSecondDeletion := network.RouteTable{
+		Name:     &cloud.RouteTableName,
+		Location: &cloud.Location,
+		RouteTablePropertiesFormat: &network.RouteTablePropertiesFormat{
+			Routes: &[]network.Route{},
+		},
+	}
+	routeTableClient.EXPECT().Get(gomock.Any(), cloud.RouteTableResourceGroup, cloud.RouteTableName, "").Return(routeTables, nil).AnyTimes()
+	routeTableClient.EXPECT().CreateOrUpdate(gomock.Any(), cloud.RouteTableResourceGroup, cloud.RouteTableName, routeTablesAfterFirstDeletion, "").Return(nil)
+	routeTableClient.EXPECT().CreateOrUpdate(gomock.Any(), cloud.RouteTableResourceGroup, cloud.RouteTableName, routeTablesAfterSecondDeletion, "").Return(nil)
+	err := cloud.DeleteRoute(context.TODO(), "cluster", &route)
+	if err != nil {
+		t.Errorf("unexpected error deleting route: %v", err)
+		t.FailNow()
+	}
+}


### PR DESCRIPTION
Cherry pick of #106164 and #104705 on release-1.22.

#106164: fix: remove outdated ipv4 route when the corresponding node
#104705: fix: ignore the case when comparing azure tags in service annotation

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
fix a 1.21 regression: remove outdated ipv4 route when the corresponding node is deleted; 
fix: ignore the case when comparing azure tags in service annotation (azure)
```