### PR TITLE
optimisation ipvs protocol to constants

### DIFF
--- a/pkg/proxy/ipvs/graceful_termination.go
+++ b/pkg/proxy/ipvs/graceful_termination.go
@@ -167,7 +167,7 @@ func (m *GracefulTerminationManager) deleteRsFunc(rsToDelete *listItem) (bool, e
 			//     (existing connections will be deleted on the next packet because sysctlExpireNoDestConn=1)
 			// For other protocols, don't delete until all connections have expired)
 			if utilipvs.IsRsGracefulTerminationNeeded(rsToDelete.VirtualServer.Protocol) && rs.ActiveConn+rs.InactiveConn != 0 {
-				klog.V(5).InfoS("Skip deleting real server till all connection have expired", "realServer", rsToDelete, "activeConnection", rs.ActiveConn, "inactiveConnection", rs.InactiveConn)
+				klog.V(5).InfoS("Skip deleting real server till all connections have expired", "realServer", rsToDelete, "activeConnection", rs.ActiveConn, "inactiveConnection", rs.InactiveConn)
 				return false, nil
 			}
 			klog.V(5).InfoS("Deleting real server", "realServer", rsToDelete)

--- a/pkg/proxy/ipvs/proxier.go
+++ b/pkg/proxy/ipvs/proxier.go
@@ -1195,7 +1195,7 @@ func (proxier *Proxier) syncProxyRules() {
 		serv := &utilipvs.VirtualServer{
 			Address:   svcInfo.ClusterIP(),
 			Port:      uint16(svcInfo.Port()),
-			Protocol:  string(svcInfo.Protocol()),
+			Protocol:  svcInfo.Protocol(),
 			Scheduler: proxier.ipvsScheduler,
 		}
 		// Set session affinity flag and timeout for IPVS service
@@ -1284,7 +1284,7 @@ func (proxier *Proxier) syncProxyRules() {
 			serv := &utilipvs.VirtualServer{
 				Address:   netutils.ParseIPSloppy(externalIP),
 				Port:      uint16(svcInfo.Port()),
-				Protocol:  string(svcInfo.Protocol()),
+				Protocol:  svcInfo.Protocol(),
 				Scheduler: proxier.ipvsScheduler,
 			}
 			if svcInfo.SessionAffinityType() == v1.ServiceAffinityClientIP {
@@ -1384,7 +1384,7 @@ func (proxier *Proxier) syncProxyRules() {
 			serv := &utilipvs.VirtualServer{
 				Address:   netutils.ParseIPSloppy(ingress),
 				Port:      uint16(svcInfo.Port()),
-				Protocol:  string(svcInfo.Protocol()),
+				Protocol:  svcInfo.Protocol(),
 				Scheduler: proxier.ipvsScheduler,
 			}
 			if svcInfo.SessionAffinityType() == v1.ServiceAffinityClientIP {
@@ -1551,7 +1551,7 @@ func (proxier *Proxier) syncProxyRules() {
 				serv := &utilipvs.VirtualServer{
 					Address:   nodeIP,
 					Port:      uint16(svcInfo.NodePort()),
-					Protocol:  string(svcInfo.Protocol()),
+					Protocol:  svcInfo.Protocol(),
 					Scheduler: proxier.ipvsScheduler,
 				}
 				if svcInfo.SessionAffinityType() == v1.ServiceAffinityClientIP {

--- a/pkg/proxy/ipvs/proxier_test.go
+++ b/pkg/proxy/ipvs/proxier_test.go
@@ -1725,7 +1725,7 @@ func TestExternalIPsNoEndpoint(t *testing.T) {
 	}
 	found := false
 	for _, svc := range services {
-		if svc.Address.String() == svcExternalIPs && svc.Port == uint16(svcPort) && svc.Protocol == string(v1.ProtocolTCP) {
+		if svc.Address.String() == svcExternalIPs && svc.Port == uint16(svcPort) && svc.Protocol == v1.ProtocolTCP {
 			found = true
 			destinations, _ := ipvs.GetRealServers(svc)
 			if len(destinations) != 0 {
@@ -1794,7 +1794,7 @@ func TestExternalIPs(t *testing.T) {
 	}
 	found := false
 	for _, svc := range services {
-		if svcExternalIPs.Has(svc.Address.String()) && svc.Port == uint16(svcPort) && svc.Protocol == string(v1.ProtocolTCP) {
+		if svcExternalIPs.Has(svc.Address.String()) && svc.Port == uint16(svcPort) && svc.Protocol == v1.ProtocolTCP {
 			found = true
 			destinations, _ := ipvs.GetRealServers(svc)
 			for _, dest := range destinations {
@@ -1873,7 +1873,7 @@ func TestOnlyLocalExternalIPs(t *testing.T) {
 	}
 	found := false
 	for _, svc := range services {
-		if svcExternalIPs.Has(svc.Address.String()) && svc.Port == uint16(svcPort) && svc.Protocol == string(v1.ProtocolTCP) {
+		if svcExternalIPs.Has(svc.Address.String()) && svc.Port == uint16(svcPort) && svc.Protocol == v1.ProtocolTCP {
 			found = true
 			destinations, _ := ipvs.GetRealServers(svc)
 			if len(destinations) != 1 {
@@ -3609,7 +3609,7 @@ func Test_syncService(t *testing.T) {
 			// case 0, old virtual server is same as new virtual server
 			oldVirtualServer: &utilipvs.VirtualServer{
 				Address:   netutils.ParseIPSloppy("1.2.3.4"),
-				Protocol:  string(v1.ProtocolTCP),
+				Protocol:  v1.ProtocolTCP,
 				Port:      80,
 				Scheduler: "rr",
 				Flags:     utilipvs.FlagHashed,
@@ -3617,7 +3617,7 @@ func Test_syncService(t *testing.T) {
 			svcName: "foo",
 			newVirtualServer: &utilipvs.VirtualServer{
 				Address:   netutils.ParseIPSloppy("1.2.3.4"),
-				Protocol:  string(v1.ProtocolTCP),
+				Protocol:  v1.ProtocolTCP,
 				Port:      80,
 				Scheduler: "rr",
 				Flags:     utilipvs.FlagHashed,
@@ -3629,7 +3629,7 @@ func Test_syncService(t *testing.T) {
 			// case 1, old virtual server is different from new virtual server
 			oldVirtualServer: &utilipvs.VirtualServer{
 				Address:   netutils.ParseIPSloppy("1.2.3.4"),
-				Protocol:  string(v1.ProtocolTCP),
+				Protocol:  v1.ProtocolTCP,
 				Port:      8080,
 				Scheduler: "rr",
 				Flags:     utilipvs.FlagHashed,
@@ -3637,7 +3637,7 @@ func Test_syncService(t *testing.T) {
 			svcName: "bar",
 			newVirtualServer: &utilipvs.VirtualServer{
 				Address:   netutils.ParseIPSloppy("1.2.3.4"),
-				Protocol:  string(v1.ProtocolTCP),
+				Protocol:  v1.ProtocolTCP,
 				Port:      8080,
 				Scheduler: "rr",
 				Flags:     utilipvs.FlagPersistent,
@@ -3649,7 +3649,7 @@ func Test_syncService(t *testing.T) {
 			// case 2, old virtual server is different from new virtual server
 			oldVirtualServer: &utilipvs.VirtualServer{
 				Address:   netutils.ParseIPSloppy("1.2.3.4"),
-				Protocol:  string(v1.ProtocolTCP),
+				Protocol:  v1.ProtocolTCP,
 				Port:      8080,
 				Scheduler: "rr",
 				Flags:     utilipvs.FlagHashed,
@@ -3657,7 +3657,7 @@ func Test_syncService(t *testing.T) {
 			svcName: "bar",
 			newVirtualServer: &utilipvs.VirtualServer{
 				Address:   netutils.ParseIPSloppy("1.2.3.4"),
-				Protocol:  string(v1.ProtocolTCP),
+				Protocol:  v1.ProtocolTCP,
 				Port:      8080,
 				Scheduler: "wlc",
 				Flags:     utilipvs.FlagHashed,
@@ -3671,7 +3671,7 @@ func Test_syncService(t *testing.T) {
 			svcName:          "baz",
 			newVirtualServer: &utilipvs.VirtualServer{
 				Address:   netutils.ParseIPSloppy("1.2.3.4"),
-				Protocol:  string(v1.ProtocolUDP),
+				Protocol:  v1.ProtocolUDP,
 				Port:      53,
 				Scheduler: "rr",
 				Flags:     utilipvs.FlagHashed,
@@ -3683,7 +3683,7 @@ func Test_syncService(t *testing.T) {
 			// case 4, SCTP, old virtual server is same as new virtual server
 			oldVirtualServer: &utilipvs.VirtualServer{
 				Address:   netutils.ParseIPSloppy("1.2.3.4"),
-				Protocol:  string(v1.ProtocolSCTP),
+				Protocol:  v1.ProtocolSCTP,
 				Port:      80,
 				Scheduler: "rr",
 				Flags:     utilipvs.FlagHashed,
@@ -3691,7 +3691,7 @@ func Test_syncService(t *testing.T) {
 			svcName: "foo",
 			newVirtualServer: &utilipvs.VirtualServer{
 				Address:   netutils.ParseIPSloppy("1.2.3.4"),
-				Protocol:  string(v1.ProtocolSCTP),
+				Protocol:  v1.ProtocolSCTP,
 				Port:      80,
 				Scheduler: "rr",
 				Flags:     utilipvs.FlagHashed,
@@ -3703,7 +3703,7 @@ func Test_syncService(t *testing.T) {
 			// case 5, old virtual server is different from new virtual server
 			oldVirtualServer: &utilipvs.VirtualServer{
 				Address:   netutils.ParseIPSloppy("1.2.3.4"),
-				Protocol:  string(v1.ProtocolSCTP),
+				Protocol:  v1.ProtocolSCTP,
 				Port:      8080,
 				Scheduler: "rr",
 				Flags:     utilipvs.FlagHashed,
@@ -3711,7 +3711,7 @@ func Test_syncService(t *testing.T) {
 			svcName: "bar",
 			newVirtualServer: &utilipvs.VirtualServer{
 				Address:   netutils.ParseIPSloppy("1.2.3.4"),
-				Protocol:  string(v1.ProtocolSCTP),
+				Protocol:  v1.ProtocolSCTP,
 				Port:      8080,
 				Scheduler: "rr",
 				Flags:     utilipvs.FlagPersistent,
@@ -3723,7 +3723,7 @@ func Test_syncService(t *testing.T) {
 			// case 6, old virtual server is different from new virtual server
 			oldVirtualServer: &utilipvs.VirtualServer{
 				Address:   netutils.ParseIPSloppy("1.2.3.4"),
-				Protocol:  string(v1.ProtocolSCTP),
+				Protocol:  v1.ProtocolSCTP,
 				Port:      8080,
 				Scheduler: "rr",
 				Flags:     utilipvs.FlagHashed,
@@ -3731,7 +3731,7 @@ func Test_syncService(t *testing.T) {
 			svcName: "bar",
 			newVirtualServer: &utilipvs.VirtualServer{
 				Address:   netutils.ParseIPSloppy("1.2.3.4"),
-				Protocol:  string(v1.ProtocolSCTP),
+				Protocol:  v1.ProtocolSCTP,
 				Port:      8080,
 				Scheduler: "wlc",
 				Flags:     utilipvs.FlagHashed,
@@ -3745,7 +3745,7 @@ func Test_syncService(t *testing.T) {
 			svcName:          "baz",
 			newVirtualServer: &utilipvs.VirtualServer{
 				Address:   netutils.ParseIPSloppy("1.2.3.4"),
-				Protocol:  string(v1.ProtocolSCTP),
+				Protocol:  v1.ProtocolSCTP,
 				Port:      53,
 				Scheduler: "rr",
 				Flags:     utilipvs.FlagHashed,
@@ -3757,7 +3757,7 @@ func Test_syncService(t *testing.T) {
 			// case 8, virtual server address already binded, skip sync
 			oldVirtualServer: &utilipvs.VirtualServer{
 				Address:   netutils.ParseIPSloppy("1.2.3.4"),
-				Protocol:  string(v1.ProtocolSCTP),
+				Protocol:  v1.ProtocolSCTP,
 				Port:      53,
 				Scheduler: "rr",
 				Flags:     utilipvs.FlagHashed,
@@ -3765,7 +3765,7 @@ func Test_syncService(t *testing.T) {
 			svcName: "baz",
 			newVirtualServer: &utilipvs.VirtualServer{
 				Address:   netutils.ParseIPSloppy("1.2.3.4"),
-				Protocol:  string(v1.ProtocolSCTP),
+				Protocol:  v1.ProtocolSCTP,
 				Port:      53,
 				Scheduler: "rr",
 				Flags:     utilipvs.FlagHashed,
@@ -3884,7 +3884,7 @@ func checkIPVS(t *testing.T, fp *Proxier, vs *netlinktest.ExpectedVirtualServer)
 		t.Errorf("Expect %d ipvs services, got %d", vs.VSNum, len(services))
 	}
 	for _, svc := range services {
-		if svc.Address.String() == vs.IP && svc.Port == vs.Port && svc.Protocol == vs.Protocol {
+		if svc.Address.String() == vs.IP && svc.Port == vs.Port && string(svc.Protocol) == vs.Protocol {
 			destinations, _ := fp.ipvs.GetRealServers(svc)
 			if len(destinations) != len(vs.RS) {
 				t.Errorf("Expected %d destinations, got %d destinations", len(vs.RS), len(destinations))
@@ -3912,7 +3912,7 @@ func TestCleanLegacyService(t *testing.T) {
 		// Created by kube-proxy.
 		"ipvs0": {
 			Address:   netutils.ParseIPSloppy("1.1.1.1"),
-			Protocol:  string(v1.ProtocolUDP),
+			Protocol:  v1.ProtocolUDP,
 			Port:      53,
 			Scheduler: "rr",
 			Flags:     utilipvs.FlagHashed,
@@ -3920,7 +3920,7 @@ func TestCleanLegacyService(t *testing.T) {
 		// Created by kube-proxy.
 		"ipvs1": {
 			Address:   netutils.ParseIPSloppy("2.2.2.2"),
-			Protocol:  string(v1.ProtocolUDP),
+			Protocol:  v1.ProtocolUDP,
 			Port:      54,
 			Scheduler: "rr",
 			Flags:     utilipvs.FlagHashed,
@@ -3928,7 +3928,7 @@ func TestCleanLegacyService(t *testing.T) {
 		// Created by an external party.
 		"ipvs2": {
 			Address:   netutils.ParseIPSloppy("3.3.3.3"),
-			Protocol:  string(v1.ProtocolUDP),
+			Protocol:  v1.ProtocolUDP,
 			Port:      55,
 			Scheduler: "rr",
 			Flags:     utilipvs.FlagHashed,
@@ -3936,7 +3936,7 @@ func TestCleanLegacyService(t *testing.T) {
 		// Created by an external party.
 		"ipvs3": {
 			Address:   netutils.ParseIPSloppy("4.4.4.4"),
-			Protocol:  string(v1.ProtocolUDP),
+			Protocol:  v1.ProtocolUDP,
 			Port:      56,
 			Scheduler: "rr",
 			Flags:     utilipvs.FlagHashed,
@@ -3944,7 +3944,7 @@ func TestCleanLegacyService(t *testing.T) {
 		// Created by an external party.
 		"ipvs4": {
 			Address:   netutils.ParseIPSloppy("5.5.5.5"),
-			Protocol:  string(v1.ProtocolUDP),
+			Protocol:  v1.ProtocolUDP,
 			Port:      57,
 			Scheduler: "rr",
 			Flags:     utilipvs.FlagHashed,
@@ -3952,7 +3952,7 @@ func TestCleanLegacyService(t *testing.T) {
 		// Created by kube-proxy, but now stale.
 		"ipvs5": {
 			Address:   netutils.ParseIPSloppy("6.6.6.6"),
-			Protocol:  string(v1.ProtocolUDP),
+			Protocol:  v1.ProtocolUDP,
 			Port:      58,
 			Scheduler: "rr",
 			Flags:     utilipvs.FlagHashed,
@@ -4017,21 +4017,21 @@ func TestCleanLegacyServiceWithRealServers(t *testing.T) {
 	currentServices := map[string]*utilipvs.VirtualServer{
 		"ipvs0": { // deleted with real servers
 			Address:   netutils.ParseIPSloppy("1.1.1.1"),
-			Protocol:  string(v1.ProtocolUDP),
+			Protocol:  v1.ProtocolUDP,
 			Port:      53,
 			Scheduler: "rr",
 			Flags:     utilipvs.FlagHashed,
 		},
 		"ipvs1": { // deleted no real server
 			Address:   netutils.ParseIPSloppy("2.2.2.2"),
-			Protocol:  string(v1.ProtocolUDP),
+			Protocol:  v1.ProtocolUDP,
 			Port:      54,
 			Scheduler: "rr",
 			Flags:     utilipvs.FlagHashed,
 		},
 		"ipvs2": { // not deleted
 			Address:   netutils.ParseIPSloppy("3.3.3.3"),
-			Protocol:  string(v1.ProtocolUDP),
+			Protocol:  v1.ProtocolUDP,
 			Port:      54,
 			Scheduler: "rr",
 			Flags:     utilipvs.FlagHashed,
@@ -4042,7 +4042,7 @@ func TestCleanLegacyServiceWithRealServers(t *testing.T) {
 	realServers := map[*utilipvs.VirtualServer]*utilipvs.RealServer{
 		{
 			Address:   netutils.ParseIPSloppy("1.1.1.1"),
-			Protocol:  string(v1.ProtocolUDP),
+			Protocol:  v1.ProtocolUDP,
 			Port:      53,
 			Scheduler: "rr",
 			Flags:     utilipvs.FlagHashed,
@@ -4109,7 +4109,7 @@ func TestCleanLegacyRealServersExcludeCIDRs(t *testing.T) {
 
 	vs := &utilipvs.VirtualServer{
 		Address:   netutils.ParseIPSloppy("4.4.4.4"),
-		Protocol:  string(v1.ProtocolUDP),
+		Protocol:  v1.ProtocolUDP,
 		Port:      56,
 		Scheduler: "rr",
 		Flags:     utilipvs.FlagHashed,
@@ -4169,7 +4169,7 @@ func TestCleanLegacyService6(t *testing.T) {
 		// Created by kube-proxy.
 		"ipvs0": {
 			Address:   netutils.ParseIPSloppy("1000::1"),
-			Protocol:  string(v1.ProtocolUDP),
+			Protocol:  v1.ProtocolUDP,
 			Port:      53,
 			Scheduler: "rr",
 			Flags:     utilipvs.FlagHashed,
@@ -4177,7 +4177,7 @@ func TestCleanLegacyService6(t *testing.T) {
 		// Created by kube-proxy.
 		"ipvs1": {
 			Address:   netutils.ParseIPSloppy("1000::2"),
-			Protocol:  string(v1.ProtocolUDP),
+			Protocol:  v1.ProtocolUDP,
 			Port:      54,
 			Scheduler: "rr",
 			Flags:     utilipvs.FlagHashed,
@@ -4185,7 +4185,7 @@ func TestCleanLegacyService6(t *testing.T) {
 		// Created by an external party.
 		"ipvs2": {
 			Address:   netutils.ParseIPSloppy("3000::1"),
-			Protocol:  string(v1.ProtocolUDP),
+			Protocol:  v1.ProtocolUDP,
 			Port:      55,
 			Scheduler: "rr",
 			Flags:     utilipvs.FlagHashed,
@@ -4193,7 +4193,7 @@ func TestCleanLegacyService6(t *testing.T) {
 		// Created by an external party.
 		"ipvs3": {
 			Address:   netutils.ParseIPSloppy("4000::1"),
-			Protocol:  string(v1.ProtocolUDP),
+			Protocol:  v1.ProtocolUDP,
 			Port:      56,
 			Scheduler: "rr",
 			Flags:     utilipvs.FlagHashed,
@@ -4201,7 +4201,7 @@ func TestCleanLegacyService6(t *testing.T) {
 		// Created by an external party.
 		"ipvs4": {
 			Address:   netutils.ParseIPSloppy("5000::1"),
-			Protocol:  string(v1.ProtocolUDP),
+			Protocol:  v1.ProtocolUDP,
 			Port:      57,
 			Scheduler: "rr",
 			Flags:     utilipvs.FlagHashed,
@@ -4209,7 +4209,7 @@ func TestCleanLegacyService6(t *testing.T) {
 		// Created by kube-proxy, but now stale.
 		"ipvs5": {
 			Address:   netutils.ParseIPSloppy("1000::6"),
-			Protocol:  string(v1.ProtocolUDP),
+			Protocol:  v1.ProtocolUDP,
 			Port:      58,
 			Scheduler: "rr",
 			Flags:     utilipvs.FlagHashed,

--- a/pkg/util/ipvs/ipvs.go
+++ b/pkg/util/ipvs/ipvs.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 	"time"
 
+	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/version"
 )
 
@@ -54,7 +55,7 @@ type Interface interface {
 // VirtualServer is an user-oriented definition of an IPVS virtual server in its entirety.
 type VirtualServer struct {
 	Address   net.IP
-	Protocol  string
+	Protocol  v1.Protocol
 	Port      uint16
 	Scheduler string
 	Flags     ServiceFlags
@@ -99,7 +100,7 @@ func (svc *VirtualServer) Equal(other *VirtualServer) bool {
 }
 
 func (svc *VirtualServer) String() string {
-	return net.JoinHostPort(svc.Address.String(), strconv.Itoa(int(svc.Port))) + "/" + svc.Protocol
+	return net.JoinHostPort(svc.Address.String(), strconv.Itoa(int(svc.Port))) + "/" + string(svc.Protocol)
 }
 
 // RealServer is an user-oriented definition of an IPVS real server in its entirety.
@@ -134,6 +135,7 @@ func GetRequiredIPVSModules(kernelVersion *version.Version) []string {
 }
 
 // IsRsGracefulTerminationNeeded returns true if protocol requires graceful termination for the stale connections
-func IsRsGracefulTerminationNeeded(proto string) bool {
-	return !strings.EqualFold(proto, "UDP") && !strings.EqualFold(proto, "SCTP")
+// Note: Need to be case sensitive for Protocol.
+func IsRsGracefulTerminationNeeded(proto v1.Protocol) bool {
+	return !strings.EqualFold(string(proto), string(v1.ProtocolUDP)) && !strings.EqualFold(string(proto), string(v1.ProtocolSCTP))
 }

--- a/pkg/util/ipvs/ipvs_linux_test.go
+++ b/pkg/util/ipvs/ipvs_linux_test.go
@@ -29,6 +29,7 @@ import (
 	libipvs "github.com/moby/ipvs"
 
 	"golang.org/x/sys/unix"
+	"k8s.io/api/core/v1"
 )
 
 func Test_toVirtualServer(t *testing.T) {
@@ -384,33 +385,33 @@ func Test_toIPVSDestination(t *testing.T) {
 	}
 }
 
-func Test_stringToProtocol(t *testing.T) {
-	tests := []string{
-		"TCP", "UDP", "ICMP", "SCTP",
+func Test_k8sProtocolToUnixProtocol(t *testing.T) {
+	tests := []v1.Protocol{
+		v1.ProtocolTCP, v1.ProtocolUDP, v1.Protocol("ICMP"), v1.ProtocolSCTP,
 	}
 	expected := []uint16{
 		uint16(unix.IPPROTO_TCP), uint16(unix.IPPROTO_UDP), uint16(0), uint16(unix.IPPROTO_SCTP),
 	}
 	for i := range tests {
-		got := stringToProtocol(tests[i])
+		got := k8sProtocolToUnixProtocol(tests[i])
 		if got != expected[i] {
-			t.Errorf("stringToProtocol() failed - got %#v, want %#v",
+			t.Errorf("k8sProtocolToUnixProtocol() failed - got %#v, want %#v",
 				got, expected[i])
 		}
 	}
 }
 
-func Test_protocolToString(t *testing.T) {
+func Test_unixProtocolToK8sProtocol(t *testing.T) {
 	tests := []Protocol{
 		unix.IPPROTO_TCP, unix.IPPROTO_UDP, Protocol(0), unix.IPPROTO_SCTP,
 	}
-	expected := []string{
-		"TCP", "UDP", "", "SCTP",
+	expected := []v1.Protocol{
+		v1.ProtocolTCP, v1.ProtocolUDP, v1.Protocol(""), v1.ProtocolSCTP,
 	}
 	for i := range tests {
-		got := protocolToString(tests[i])
+		got := unixProtocolToK8sProtocol(tests[i])
 		if got != expected[i] {
-			t.Errorf("protocolToString() failed - got %#v, want %#v",
+			t.Errorf("unixProtocolToK8sProtocol() failed - got %#v, want %#v",
 				got, expected[i])
 		}
 	}

--- a/pkg/util/ipvs/testing/fake.go
+++ b/pkg/util/ipvs/testing/fake.go
@@ -22,6 +22,7 @@ import (
 	"strconv"
 	"time"
 
+	"k8s.io/api/core/v1"
 	utilipvs "k8s.io/kubernetes/pkg/util/ipvs"
 )
 
@@ -36,11 +37,11 @@ type FakeIPVS struct {
 type ServiceKey struct {
 	IP       string
 	Port     uint16
-	Protocol string
+	Protocol v1.Protocol
 }
 
 func (s *ServiceKey) String() string {
-	return fmt.Sprintf("%s:%d/%s", s.IP, s.Port, s.Protocol)
+	return fmt.Sprintf("%s:%d/%s", s.IP, s.Port, string(s.Protocol))
 }
 
 // RealServerKey uniquely identifies an Endpoint for an IPVS real server

--- a/pkg/util/ipvs/testing/fake_test.go
+++ b/pkg/util/ipvs/testing/fake_test.go
@@ -30,7 +30,7 @@ func TestVirtualServer(t *testing.T) {
 	vs1 := &utilipvs.VirtualServer{
 		Address:  netutils.ParseIPSloppy("1.2.3.4"),
 		Port:     uint16(80),
-		Protocol: string("TCP"),
+		Protocol: "TCP",
 		Flags:    utilipvs.FlagHashed,
 	}
 	err := fake.AddVirtualServer(vs1)
@@ -49,7 +49,7 @@ func TestVirtualServer(t *testing.T) {
 	vs12 := &utilipvs.VirtualServer{
 		Address:  netutils.ParseIPSloppy("1.2.3.4"),
 		Port:     uint16(80),
-		Protocol: string("TCP"),
+		Protocol: "TCP",
 		Flags:    utilipvs.FlagPersistent,
 	}
 	err = fake.UpdateVirtualServer(vs12)
@@ -68,7 +68,7 @@ func TestVirtualServer(t *testing.T) {
 	vs2 := &utilipvs.VirtualServer{
 		Address:  netutils.ParseIPSloppy("10::40"),
 		Port:     uint16(8080),
-		Protocol: string("UDP"),
+		Protocol: "UDP",
 	}
 	err = fake.AddVirtualServer(vs2)
 	if err != nil {
@@ -78,7 +78,7 @@ func TestVirtualServer(t *testing.T) {
 	vs3 := &utilipvs.VirtualServer{
 		Address:  netutils.ParseIPSloppy("10::40"),
 		Port:     uint16(7777),
-		Protocol: string("SCTP"),
+		Protocol: "SCTP",
 	}
 	err = fake.AddVirtualServer(vs3)
 	if err != nil {
@@ -124,7 +124,7 @@ func TestRealServer(t *testing.T) {
 	vs := &utilipvs.VirtualServer{
 		Address:  netutils.ParseIPSloppy("10.20.30.40"),
 		Port:     uint16(80),
-		Protocol: string("TCP"),
+		Protocol: "TCP",
 	}
 	rss := []*utilipvs.RealServer{
 		{Address: netutils.ParseIPSloppy("172.16.2.1"), Port: 8080, Weight: 1},


### PR DESCRIPTION
Signed-off-by: soulseen <zhuxiaoyang1996@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
the field of Protocol in ipvs VirtualServer should not use string type, also should not hard code it, and maybe use the v1.Protocol type is better.

#### Which issue(s) this PR fixes:
None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
None
```
/sig network