### PR TITLE
Include applying subresource in Running section

### DIFF
--- a/staging/src/k8s.io/sample-controller/README.md
+++ b/staging/src/k8s.io/sample-controller/README.md
@@ -87,7 +87,7 @@ go build -o sample-controller .
 ./sample-controller -kubeconfig=$HOME/.kube/config
 
 # create a CustomResourceDefinition
-kubectl create -f artifacts/examples/crd.yaml
+kubectl create -f artifacts/examples/crd-status-subresource.yaml
 
 # create a custom resource of type Foo
 kubectl create -f artifacts/examples/example-foo.yaml


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation
/kind feature

#### What this PR does / why we need it:
Following the readme before lead to the following error due to the missing subresource:

```
E0116 13:06:48.614623   66988 controller.go:233] error syncing 'default/example-foo': foos.samplecontroller.k8s.io "example-foo" not found, requeuing
```

Since CRD subresources are GA since 1.16, the readme should including applying them.

#### Does this PR introduce a user-facing change?
NONE