### PR TITLE
Nit: Replace `errors.New(fmt.Sprintf(...))` with `fmt.Errorf(...)`

### DIFF
--- a/pkg/credentialprovider/plugin/plugin_test.go
+++ b/pkg/credentialprovider/plugin/plugin_test.go
@@ -18,9 +18,7 @@ package plugin
 
 import (
 	"context"
-	"errors"
 	"fmt"
-	kubeletconfig "k8s.io/kubernetes/pkg/kubelet/apis/config"
 	"reflect"
 	"sync"
 	"testing"
@@ -29,11 +27,11 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/rand"
-
 	"k8s.io/client-go/tools/cache"
 	credentialproviderapi "k8s.io/kubelet/pkg/apis/credentialprovider"
 	credentialproviderv1alpha1 "k8s.io/kubelet/pkg/apis/credentialprovider/v1alpha1"
 	"k8s.io/kubernetes/pkg/credentialprovider"
+	kubeletconfig "k8s.io/kubernetes/pkg/kubelet/apis/config"
 	"k8s.io/utils/clock"
 	testingclock "k8s.io/utils/clock/testing"
 )
@@ -811,8 +809,8 @@ func Test_ExecPluginEnvVars(t *testing.T) {
 
 func validate(expected, actual []string) error {
 	if len(actual) != len(expected) {
-		return errors.New(fmt.Sprintf("actual env var length [%d] and expected env var length [%d] don't match",
-			len(actual), len(expected)))
+		return fmt.Errorf("actual env var length [%d] and expected env var length [%d] don't match",
+			len(actual), len(expected))
 	}
 
 	for i := range actual {


### PR DESCRIPTION
/kind cleanup

The corresponding golint warning is:
```
pkg/credentialprovider/plugin/plugin_test.go
Line 814: warning: should replace errors.New(fmt.Sprintf(...)) with fmt.Errorf(...) (golint)
```

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
