### PR TITLE
Clean up logic for deprecated flag --container-runtime in kubelet

### DIFF
--- a/cmd/kubelet/app/options/options.go
+++ b/cmd/kubelet/app/options/options.go
@@ -37,6 +37,7 @@ import (
 	kubeletscheme "k8s.io/kubernetes/pkg/kubelet/apis/config/scheme"
 	kubeletconfigvalidation "k8s.io/kubernetes/pkg/kubelet/apis/config/validation"
 	"k8s.io/kubernetes/pkg/kubelet/config"
+	kubetypes "k8s.io/kubernetes/pkg/kubelet/types"
 	utilflag "k8s.io/kubernetes/pkg/util/flag"
 )
 
@@ -173,6 +174,10 @@ func ValidateKubeletFlags(f *KubeletFlags) error {
 
 	if f.SeccompDefault && !utilfeature.DefaultFeatureGate.Enabled(features.SeccompDefault) {
 		return fmt.Errorf("the SeccompDefault feature gate must be enabled in order to use the --seccomp-default flag")
+	}
+
+	if f.ContainerRuntime != kubetypes.RemoteContainerRuntime {
+		return fmt.Errorf("unsupported CRI runtime: %q, only %q is currently supported", f.ContainerRuntime, kubetypes.RemoteContainerRuntime)
 	}
 
 	return nil

--- a/cmd/kubelet/app/options/options_test.go
+++ b/cmd/kubelet/app/options/options_test.go
@@ -25,6 +25,8 @@ import (
 
 	"k8s.io/apimachinery/pkg/util/diff"
 	cliflag "k8s.io/component-base/cli/flag"
+	"k8s.io/kubernetes/pkg/kubelet/config"
+	kubetypes "k8s.io/kubernetes/pkg/kubelet/types"
 )
 
 func newKubeletServerOrDie() *KubeletServer {
@@ -171,6 +173,9 @@ func TestValidateKubeletFlags(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			err := ValidateKubeletFlags(&KubeletFlags{
+				ContainerRuntimeOptions: config.ContainerRuntimeOptions{
+					ContainerRuntime: kubetypes.RemoteContainerRuntime,
+				},
 				NodeLabels: tt.labels,
 			})
 

--- a/pkg/kubelet/cadvisor/cadvisor_linux_test.go
+++ b/pkg/kubelet/cadvisor/cadvisor_linux_test.go
@@ -26,7 +26,6 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	cadvisorfs "github.com/google/cadvisor/fs"
-	"k8s.io/kubernetes/pkg/kubelet/types"
 )
 
 func TestImageFsInfoLabel(t *testing.T) {
@@ -38,13 +37,11 @@ func TestImageFsInfoLabel(t *testing.T) {
 		expectedError   error
 	}{{
 		description:     "LabelCrioImages should be returned",
-		runtime:         types.RemoteContainerRuntime,
 		runtimeEndpoint: CrioSocket,
 		expectedLabel:   cadvisorfs.LabelCrioImages,
 		expectedError:   nil,
 	}, {
 		description:     "Cannot find valid imagefs label",
-		runtime:         "invalid-runtime",
 		runtimeEndpoint: "",
 		expectedLabel:   "",
 		expectedError:   fmt.Errorf("no imagefs label for configured runtime"),
@@ -52,7 +49,7 @@ func TestImageFsInfoLabel(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.description, func(t *testing.T) {
-			infoProvider := NewImageFsInfoProvider(tc.runtime, tc.runtimeEndpoint)
+			infoProvider := NewImageFsInfoProvider(tc.runtimeEndpoint)
 			label, err := infoProvider.ImageFsInfoLabel()
 			assert.Equal(t, tc.expectedLabel, label)
 			assert.Equal(t, tc.expectedError, err)

--- a/pkg/kubelet/cadvisor/helpers_linux.go
+++ b/pkg/kubelet/cadvisor/helpers_linux.go
@@ -28,7 +28,6 @@ import (
 // imageFsInfoProvider knows how to translate the configured runtime
 // to its file system label for images.
 type imageFsInfoProvider struct {
-	runtime         string
 	runtimeEndpoint string
 }
 
@@ -45,6 +44,6 @@ func (i *imageFsInfoProvider) ImageFsInfoLabel() (string, error) {
 }
 
 // NewImageFsInfoProvider returns a provider for the specified runtime configuration.
-func NewImageFsInfoProvider(runtime, runtimeEndpoint string) ImageFsInfoProvider {
-	return &imageFsInfoProvider{runtime: runtime, runtimeEndpoint: runtimeEndpoint}
+func NewImageFsInfoProvider(runtimeEndpoint string) ImageFsInfoProvider {
+	return &imageFsInfoProvider{runtimeEndpoint: runtimeEndpoint}
 }

--- a/pkg/kubelet/cadvisor/helpers_unsupported.go
+++ b/pkg/kubelet/cadvisor/helpers_unsupported.go
@@ -30,6 +30,6 @@ func (i *unsupportedImageFsInfoProvider) ImageFsInfoLabel() (string, error) {
 }
 
 // NewImageFsInfoProvider returns a provider for the specified runtime configuration.
-func NewImageFsInfoProvider(runtime, runtimeEndpoint string) ImageFsInfoProvider {
+func NewImageFsInfoProvider(runtimeEndpoint string) ImageFsInfoProvider {
 	return &unsupportedImageFsInfoProvider{}
 }

--- a/pkg/kubelet/cadvisor/util.go
+++ b/pkg/kubelet/cadvisor/util.go
@@ -64,12 +64,10 @@ func EphemeralStorageCapacityFromFsInfo(info cadvisorapi2.FsInfo) v1.ResourceLis
 }
 
 // UsingLegacyCadvisorStats returns true if container stats are provided by cadvisor instead of through the CRI.
-// CRI integrations should get container metrics via CRI. Docker
-// uses the built-in cadvisor to gather such metrics on Linux for
-// historical reasons.
+// CRI integrations should get container metrics via CRI.
 // TODO: cri-o relies on cadvisor as a temporary workaround. The code should
 // be removed. Related issue:
 // https://github.com/kubernetes/kubernetes/issues/51798
-func UsingLegacyCadvisorStats(runtime, runtimeEndpoint string) bool {
+func UsingLegacyCadvisorStats(runtimeEndpoint string) bool {
 	return runtimeEndpoint == CrioSocket || runtimeEndpoint == "unix://"+CrioSocket
 }

--- a/pkg/kubelet/cm/helpers_linux.go
+++ b/pkg/kubelet/cm/helpers_linux.go
@@ -337,8 +337,3 @@ func GetKubeletContainer(kubeletCgroups string) (string, error) {
 	}
 	return kubeletCgroups, nil
 }
-
-// GetRuntimeContainer returns the cgroup used by the container runtime
-func GetRuntimeContainer(containerRuntime, runtimeCgroups string) (string, error) {
-	return runtimeCgroups, nil
-}

--- a/pkg/kubelet/cm/helpers_unsupported.go
+++ b/pkg/kubelet/cm/helpers_unsupported.go
@@ -70,8 +70,3 @@ func NodeAllocatableRoot(cgroupRoot string, cgroupsPerQOS bool, cgroupDriver str
 func GetKubeletContainer(kubeletCgroups string) (string, error) {
 	return "", nil
 }
-
-// GetRuntimeContainer returns the cgroup used by the container runtime
-func GetRuntimeContainer(containerRuntime, runtimeCgroups string) (string, error) {
-	return "", nil
-}

--- a/pkg/kubelet/config/flags.go
+++ b/pkg/kubelet/config/flags.go
@@ -56,8 +56,7 @@ func (s *ContainerRuntimeOptions) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&s.RuntimeCgroups, "runtime-cgroups", s.RuntimeCgroups, "Optional absolute name of cgroups to create and run the runtime in.")
 
 	// Docker-specific settings.
-	fs.StringVar(&s.PodSandboxImage, "pod-infra-container-image", s.PodSandboxImage, fmt.Sprintf("Specified image will not be pruned by the image garbage collector. "+
-		"When container-runtime is set to 'docker', all containers in each pod will use the network/ipc namespaces from this image. Other CRI implementations have their own configuration to set this image."))
+	fs.StringVar(&s.PodSandboxImage, "pod-infra-container-image", s.PodSandboxImage, fmt.Sprintf("Specified image will not be pruned by the image garbage collector. CRI implementations have their own configuration to set this image."))
 
 	// Image credential provider settings.
 	fs.StringVar(&s.ImageCredentialProviderConfigFile, "image-credential-provider-config", s.ImageCredentialProviderConfigFile, "The path to the credential provider plugin config file.")

--- a/pkg/kubelet/container/runtime.go
+++ b/pkg/kubelet/container/runtime.go
@@ -69,9 +69,6 @@ type Runtime interface {
 	// Type returns the type of the container runtime.
 	Type() string
 
-	//SupportsSingleFileMapping returns whether the container runtime supports single file mappings or not.
-	SupportsSingleFileMapping() bool
-
 	// Version returns the version information of the container runtime.
 	Version() (Version, error)
 

--- a/pkg/kubelet/container/testing/fake_runtime.go
+++ b/pkg/kubelet/container/testing/fake_runtime.go
@@ -179,10 +179,6 @@ func (f *FakeRuntime) Type() string {
 	return f.RuntimeType
 }
 
-func (f *FakeRuntime) SupportsSingleFileMapping() bool {
-	return true
-}
-
 func (f *FakeRuntime) Version() (kubecontainer.Version, error) {
 	f.Lock()
 	defer f.Unlock()

--- a/pkg/kubelet/container/testing/runtime_mock.go
+++ b/pkg/kubelet/container/testing/runtime_mock.go
@@ -124,20 +124,6 @@ func (mr *MockRuntimeMockRecorder) Type() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Type", reflect.TypeOf((*MockRuntime)(nil).Type))
 }
 
-// SupportsSingleFileMapping mocks base method
-func (m *MockRuntime) SupportsSingleFileMapping() bool {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SupportsSingleFileMapping")
-	ret0, _ := ret[0].(bool)
-	return ret0
-}
-
-// SupportsSingleFileMapping indicates an expected call of SupportsSingleFileMapping
-func (mr *MockRuntimeMockRecorder) SupportsSingleFileMapping() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SupportsSingleFileMapping", reflect.TypeOf((*MockRuntime)(nil).SupportsSingleFileMapping))
-}
-
 // Version mocks base method
 func (m *MockRuntime) Version() (container.Version, error) {
 	m.ctrl.T.Helper()

--- a/pkg/kubelet/kubelet_pods.go
+++ b/pkg/kubelet/kubelet_pods.go
@@ -144,12 +144,11 @@ func (kl *Kubelet) makeBlockVolumes(pod *v1.Pod, container *v1.Container, podVol
 // Kubernetes only mounts on /etc/hosts if:
 // - container is not an infrastructure (pause) container
 // - container is not already mounting on /etc/hosts
-// - if it is Windows and ContainerD is used.
 // Kubernetes will not mount /etc/hosts if:
 // - when the Pod sandbox is being created, its IP is still unknown. Hence, PodIP will not have been set.
 // - Windows pod contains a hostProcess container
-func shouldMountHostsFile(pod *v1.Pod, podIPs []string, supportsSingleFileMapping bool) bool {
-	shouldMount := len(podIPs) > 0 && supportsSingleFileMapping
+func shouldMountHostsFile(pod *v1.Pod, podIPs []string) bool {
+	shouldMount := len(podIPs) > 0
 	if runtime.GOOS == "windows" && utilfeature.DefaultFeatureGate.Enabled(features.WindowsHostProcessContainers) {
 		return shouldMount && !kubecontainer.HasWindowsHostProcessContainer(pod)
 	}
@@ -157,8 +156,8 @@ func shouldMountHostsFile(pod *v1.Pod, podIPs []string, supportsSingleFileMappin
 }
 
 // makeMounts determines the mount points for the given container.
-func makeMounts(pod *v1.Pod, podDir string, container *v1.Container, hostName, hostDomain string, podIPs []string, podVolumes kubecontainer.VolumeMap, hu hostutil.HostUtils, subpather subpath.Interface, expandEnvs []kubecontainer.EnvVar, supportsSingleFileMapping bool) ([]kubecontainer.Mount, func(), error) {
-	mountEtcHostsFile := shouldMountHostsFile(pod, podIPs, supportsSingleFileMapping)
+func makeMounts(pod *v1.Pod, podDir string, container *v1.Container, hostName, hostDomain string, podIPs []string, podVolumes kubecontainer.VolumeMap, hu hostutil.HostUtils, subpather subpath.Interface, expandEnvs []kubecontainer.EnvVar) ([]kubecontainer.Mount, func(), error) {
+	mountEtcHostsFile := shouldMountHostsFile(pod, podIPs)
 	klog.V(3).InfoS("Creating hosts mount for container", "pod", klog.KObj(pod), "containerName", container.Name, "podIPs", podIPs, "path", mountEtcHostsFile)
 	mounts := []kubecontainer.Mount{}
 	var cleanupAction func()
@@ -492,10 +491,8 @@ func (kl *Kubelet) GenerateRunContainerOptions(pod *v1.Pod, container *v1.Contai
 	}
 	opts.Envs = append(opts.Envs, envs...)
 
-	// we can only mount individual files (e.g.: /etc/hosts, termination-log files) on Windows only if we're using Containerd.
-	supportsSingleFileMapping := kl.containerRuntime.SupportsSingleFileMapping()
 	// only podIPs is sent to makeMounts, as podIPs is populated even if dual-stack feature flag is not enabled.
-	mounts, cleanupAction, err := makeMounts(pod, kl.getPodDir(pod.UID), container, hostname, hostDomainName, podIPs, volumes, kl.hostutil, kl.subpather, opts.Envs, supportsSingleFileMapping)
+	mounts, cleanupAction, err := makeMounts(pod, kl.getPodDir(pod.UID), container, hostname, hostDomainName, podIPs, volumes, kl.hostutil, kl.subpather, opts.Envs)
 	if err != nil {
 		return nil, cleanupAction, err
 	}
@@ -503,7 +500,7 @@ func (kl *Kubelet) GenerateRunContainerOptions(pod *v1.Pod, container *v1.Contai
 
 	// adding TerminationMessagePath on Windows is only allowed if ContainerD is used. Individual files cannot
 	// be mounted as volumes using Docker for Windows.
-	if len(container.TerminationMessagePath) != 0 && supportsSingleFileMapping {
+	if len(container.TerminationMessagePath) != 0 {
 		p := kl.getPodContainerDir(pod.UID, container.Name)
 		if err := os.MkdirAll(p, 0750); err != nil {
 			klog.ErrorS(err, "Error on creating dir", "path", p)

--- a/pkg/kubelet/kubelet_pods_linux_test.go
+++ b/pkg/kubelet/kubelet_pods_linux_test.go
@@ -250,7 +250,7 @@ func TestMakeMounts(t *testing.T) {
 				},
 			}
 
-			mounts, _, err := makeMounts(&pod, "/pod", &tc.container, "fakepodname", "", []string{""}, tc.podVolumes, fhu, fsp, nil, false)
+			mounts, _, err := makeMounts(&pod, "/pod", &tc.container, "fakepodname", "", []string{""}, tc.podVolumes, fhu, fsp, nil)
 
 			// validate only the error if we expect an error
 			if tc.expectErr {

--- a/pkg/kubelet/kubelet_pods_windows_test.go
+++ b/pkg/kubelet/kubelet_pods_windows_test.go
@@ -84,7 +84,7 @@ func TestMakeMountsWindows(t *testing.T) {
 
 	fhu := hostutil.NewFakeHostUtil(nil)
 	fsp := &subpath.FakeSubpath{}
-	mounts, _, _ := makeMounts(&pod, "/pod", &container, "fakepodname", "", []string{""}, podVolumes, fhu, fsp, nil, false)
+	mounts, _, _ := makeMounts(&pod, "/pod", &container, "fakepodname", "", []string{""}, podVolumes, fhu, fsp, nil)
 
 	expectedMounts := []kubecontainer.Mount{
 		{

--- a/pkg/kubelet/kubelet_test.go
+++ b/pkg/kubelet/kubelet_test.go
@@ -2355,13 +2355,6 @@ func TestSyncTerminatingPodKillPod(t *testing.T) {
 	checkPodStatus(t, kl, pod, v1.PodFailed)
 }
 
-func TestPreInitRuntimeService(t *testing.T) {
-	err := PreInitRuntimeService(nil, nil, nil, "", "", "", "")
-	if err == nil {
-		t.Fatal("PreInitRuntimeService should fail when not configured with a container runtime")
-	}
-}
-
 func TestSyncLabels(t *testing.T) {
 	tests := []struct {
 		name             string

--- a/pkg/kubelet/kuberuntime/kuberuntime_container.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_container.go
@@ -393,9 +393,7 @@ func (m *kubeGenericRuntimeManager) makeMounts(opts *kubecontainer.RunContainerO
 	// The reason we create and mount the log file in here (not in kubelet) is because
 	// the file's location depends on the ID of the container, and we need to create and
 	// mount the file before actually starting the container.
-	// we can only mount individual files (e.g.: /etc/hosts, termination-log files) on Windows only if we're using Containerd.
-	supportsSingleFileMapping := m.SupportsSingleFileMapping()
-	if opts.PodContainerDir != "" && len(container.TerminationMessagePath) != 0 && supportsSingleFileMapping {
+	if opts.PodContainerDir != "" && len(container.TerminationMessagePath) != 0 {
 		// Because the PodContainerDir contains pod uid and container name which is unique enough,
 		// here we just add a random id to make the path unique for different instances
 		// of the same container.

--- a/pkg/kubelet/kuberuntime/kuberuntime_manager.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_manager.go
@@ -286,12 +286,6 @@ func (m *kubeGenericRuntimeManager) Type() string {
 	return m.runtimeName
 }
 
-// SupportsSingleFileMapping returns whether the container runtime supports single file mappings or not.
-// It is supported on Windows only if the container runtime is containerd.
-func (m *kubeGenericRuntimeManager) SupportsSingleFileMapping() bool {
-	return true
-}
-
 func newRuntimeVersion(version string) (*utilversion.Version, error) {
 	if ver, err := utilversion.ParseSemantic(version); err == nil {
 		return ver, err

--- a/pkg/kubelet/stats/host_stats_provider.go
+++ b/pkg/kubelet/stats/host_stats_provider.go
@@ -31,7 +31,7 @@ import (
 )
 
 // PodEtcHostsPathFunc is a function to fetch a etc hosts path by pod uid and whether etc host path is supported by the runtime
-type PodEtcHostsPathFunc func(podUID types.UID) (string, bool)
+type PodEtcHostsPathFunc func(podUID types.UID) string
 
 // metricsProviderByPath maps a path to its metrics provider
 type metricsProviderByPath map[string]volume.MetricsProvider
@@ -81,10 +81,7 @@ func (h hostStatsProvider) getPodContainerLogStats(podNamespace, podName string,
 // getPodEtcHostsStats gets status for pod etc hosts usage
 func (h hostStatsProvider) getPodEtcHostsStats(podUID types.UID, rootFsInfo *cadvisorapiv2.FsInfo) (*statsapi.FsStats, error) {
 	// Runtimes may not support etc hosts file (Windows with docker)
-	podEtcHostsPath, isEtcHostsSupported := h.podEtcHostsPathFunc(podUID)
-	if !isEtcHostsSupported {
-		return nil, nil
-	}
+	podEtcHostsPath := h.podEtcHostsPathFunc(podUID)
 	// Some pods have an explicit /etc/hosts mount and the Kubelet will not create an etc-hosts file for them
 	if _, err := os.Stat(podEtcHostsPath); os.IsNotExist(err) {
 		return nil, nil

--- a/pkg/kubelet/stats/host_stats_provider_test.go
+++ b/pkg/kubelet/stats/host_stats_provider_test.go
@@ -39,8 +39,8 @@ func Test_hostStatsProvider_getPodEtcHostsStats(t *testing.T) {
 	}{
 		{
 			name: "Should return nil for runtimes that do not support etc host file",
-			podEtcHostsPathFunc: func(podUID types.UID) (string, bool) {
-				return "", false
+			podEtcHostsPathFunc: func(podUID types.UID) string {
+				return ""
 			},
 			podUID:     "fake0001",
 			rootFsInfo: nil,

--- a/pkg/kubemark/hollow_kubelet.go
+++ b/pkg/kubemark/hollow_kubelet.go
@@ -163,7 +163,6 @@ func GetHollowKubeletConfig(opt *HollowKubletOptions) (*options.KubeletFlags, *k
 	f.MaxContainerCount = 100
 	f.MaxPerPodContainerCount = 2
 	f.NodeLabels = opt.NodeLabels
-	f.ContainerRuntimeOptions.ContainerRuntime = kubetypes.RemoteContainerRuntime
 	f.RegisterSchedulable = true
 	f.RemoteImageEndpoint = "unix:///run/containerd/containerd.sock"
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
As part of the removal of dockershim and deprecation of the `--container-runtime` flag, the logic behind it should also be removed from kubelet.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Refs: #106893

#### Special notes for your reviewer:
Refs: #107094

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
