### PR TITLE
Support cancelable SPDY connection establishment

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/util/net/http_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/net/http_test.go
@@ -22,6 +22,7 @@ package net
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"crypto/tls"
 	"fmt"
 	"io"
@@ -417,7 +418,8 @@ func TestConnectWithRedirects(t *testing.T) {
 				}
 				return conn, err
 			})
-			conn, rawResponse, err := ConnectWithRedirects(method, u, http.Header{} /*body*/, nil, dialer, true)
+			conn, rawResponse, err := ConnectWithRedirects(
+				context.Background(), method, u, http.Header{} /*body*/, nil, dialer, true)
 			if test.expectError {
 				require.Error(t, err, "expected request error")
 				return

--- a/staging/src/k8s.io/apimachinery/pkg/util/net/util_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/net/util_test.go
@@ -17,12 +17,20 @@ limitations under the License.
 package net
 
 import (
+	"bufio"
+	"context"
+	"fmt"
+	"io"
 	"net"
+	"net/http"
+	"net/http/httptest"
 	"net/url"
 	"os"
 	"syscall"
 	"testing"
+	"time"
 
+	"github.com/stretchr/testify/require"
 	netutils "k8s.io/utils/net"
 )
 
@@ -95,4 +103,57 @@ func TestIsConnectionRefused(t *testing.T) {
 			t.Errorf("Expect to be %v, but actual is %v", tc.expect, result)
 		}
 	}
+}
+
+func TestExceedDeadlineOnCancel(t *testing.T) {
+	const resultString = "Test output"
+	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		time.Sleep(200 * time.Millisecond)
+		w.Write([]byte(resultString))
+	}))
+	defer s.Close()
+
+	u, err := url.Parse(s.URL)
+	require.NoError(t, err, "Error parsing server URL")
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, u.String(), nil)
+	require.NoError(t, err)
+
+	netdialer := &net.Dialer{}
+	dialer := DialerFunc(func(req *http.Request) (net.Conn, error) {
+		conn, err := netdialer.Dial("tcp", req.URL.Host)
+		if err != nil {
+			return conn, err
+		}
+		if err = req.Write(conn); err != nil {
+			require.NoError(t, conn.Close())
+			return nil, fmt.Errorf("error sending request: %w", err)
+		}
+		return conn, err
+	})
+	conn, err := dialer.Dial(req)
+	require.NoError(t, err)
+
+	respReader := bufio.NewReader(conn)
+
+	func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+		defer ExceedDeadlineOnCancel(ctx, conn)()
+		defer cancel()
+
+		_, err := http.ReadResponse(respReader, nil)
+		require.Error(t, err)
+		require.ErrorIs(t, err, os.ErrDeadlineExceeded)
+	}()
+
+	// try again without a timeout
+	resp, err := http.ReadResponse(respReader, nil)
+	require.NoError(t, err)
+
+	result, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.NoError(t, resp.Body.Close())
+	require.Equal(t, resultString, string(result))
+
+	require.NoError(t, conn.Close())
 }

--- a/staging/src/k8s.io/apimachinery/pkg/util/proxy/upgradeaware.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/proxy/upgradeaware.go
@@ -312,7 +312,7 @@ func (h *UpgradeAwareHandler) tryUpgrade(w http.ResponseWriter, req *http.Reques
 	utilnet.AppendForwardedForHeader(clone)
 	if h.InterceptRedirects {
 		klog.V(6).Infof("Connecting to backend proxy (intercepting redirects) %s\n  Headers: %v", &location, clone.Header)
-		backendConn, rawResponse, err = utilnet.ConnectWithRedirects(req.Method, &location, clone.Header, req.Body, utilnet.DialerFunc(h.DialForUpgrade), h.RequireSameHostRedirects)
+		backendConn, rawResponse, err = utilnet.ConnectWithRedirects(req.Context(), req.Method, &location, clone.Header, req.Body, utilnet.DialerFunc(h.DialForUpgrade), h.RequireSameHostRedirects)
 	} else {
 		klog.V(6).Infof("Connecting to backend proxy (direct dial) %s\n  Headers: %v", &location, clone.Header)
 		if h.UseLocationHost {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind feature
/kind api-change

#### What this PR does / why we need it:

SPDY connections, used e.g. for executing commands, accessing logs and forwarding ports, can be stuck. It would be good to be able to abort those operations. https://github.com/kubernetes/kubernetes/pull/103177 does this for already established connections.

This change focuses on establishing the connection and upgrading it from HTTP to SPDY. It extends and fixes https://github.com/arkbriar/apimachinery/compare/v0.21.2...v0.21.2-enc2 (referenced in https://github.com/kubernetes/kubernetes/pull/103177#discussion_r685664836).

It makes use of already existing `context.Context` occurrences, passes them on when missing, switches to constructs consuming a context and extends an existing function to accept a context. Moreover, it adds a utility function canceling a `net.Conn` upon context cancelation (based on https://github.com/golang/go/issues/20280#issuecomment-655588450).

#### Which issue(s) this PR fixes:

Fixes https://github.com/kubernetes/client-go/issues/884

#### Special notes for your reviewer:

- Not sure regarding release notes. An existing exported function's signature changed and an exported function was added. However, https://github.com/kubernetes/kubernetes/blob/b6c06a95d7ff262a876b95a1035eaf478a7cb961/staging/src/k8s.io/apimachinery/README.md?plain=1#L29 doesn't sound as if a release note is required.
- Setting the `kind/api-change` label might have been wrong. This PR changes a package's interface, but this might not be what is meant with this label.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
