### PR TITLE
feat: propagate req context into proxyReq

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/util/httpstream/spdy/roundtripper.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/httpstream/spdy/roundtripper.go
@@ -173,12 +173,14 @@ func (s *SpdyRoundTripper) dial(req *http.Request) (net.Conn, error) {
 		Host:   targetHost,
 	}
 
+	proxyReq = *proxyReq.WithContext(req.Context())
+
 	if pa := s.proxyAuth(proxyURL); pa != "" {
 		proxyReq.Header = http.Header{}
 		proxyReq.Header.Set("Proxy-Authorization", pa)
 	}
 
-	proxyDialConn, err := s.dialWithoutProxy(req.Context(), proxyURL)
+	proxyDialConn, err := s.dialWithoutProxy(proxyReq.Context(), proxyURL)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Goal of this commit is to propagate req context into proxyReq so it propagates to proxyClientConn.Do.

This change is linked to PR #105632

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

This PR was part of this pull-request #105632 but I've been asked by @liggitt to split it apart as it was not directly linked to the feature itself (to keep changes independent and ease the roll-back / cherry-pick / maintenance).


```release-note
NONE
```