### PR TITLE
Automated cherry pick of #106581: Enabling kube-proxy metrics on windows kernel mode

### DIFF
--- a/cmd/kube-proxy/app/server_windows.go
+++ b/cmd/kube-proxy/app/server_windows.go
@@ -142,6 +142,8 @@ func newProxyServer(config *proxyconfigapi.KubeProxyConfiguration, cleanupAndExi
 		if err != nil {
 			return nil, fmt.Errorf("unable to create proxier: %v", err)
 		}
+
+		winkernel.RegisterMetrics()
 	} else {
 		klog.V(0).Info("Using userspace Proxier.")
 		execer := exec.New()

--- a/pkg/proxy/winkernel/metrics.go
+++ b/pkg/proxy/winkernel/metrics.go
@@ -19,40 +19,21 @@ package winkernel
 import (
 	"sync"
 
-	"k8s.io/component-base/metrics"
 	"k8s.io/component-base/metrics/legacyregistry"
-)
-
-const kubeProxySubsystem = "kubeproxy"
-
-var (
-	SyncProxyRulesLatency = metrics.NewHistogram(
-		&metrics.HistogramOpts{
-			Subsystem:      kubeProxySubsystem,
-			Name:           "sync_proxy_rules_duration_seconds",
-			Help:           "SyncProxyRules latency in seconds",
-			Buckets:        metrics.ExponentialBuckets(0.001, 2, 15),
-			StabilityLevel: metrics.ALPHA,
-		},
-	)
-
-	// SyncProxyRulesLastTimestamp is the timestamp proxy rules were last
-	// successfully synced.
-	SyncProxyRulesLastTimestamp = metrics.NewGauge(
-		&metrics.GaugeOpts{
-			Subsystem:      kubeProxySubsystem,
-			Name:           "sync_proxy_rules_last_timestamp_seconds",
-			Help:           "The last time proxy rules were successfully synced",
-			StabilityLevel: metrics.ALPHA,
-		},
-	)
+	"k8s.io/kubernetes/pkg/proxy/metrics"
 )
 
 var registerMetricsOnce sync.Once
 
+// RegisterMetrics registers kube-proxy metrics for Windows modes.
 func RegisterMetrics() {
 	registerMetricsOnce.Do(func() {
-		legacyregistry.MustRegister(SyncProxyRulesLatency)
-		legacyregistry.MustRegister(SyncProxyRulesLastTimestamp)
+		legacyregistry.MustRegister(metrics.SyncProxyRulesLatency)
+		legacyregistry.MustRegister(metrics.SyncProxyRulesLastTimestamp)
+		legacyregistry.MustRegister(metrics.EndpointChangesPending)
+		legacyregistry.MustRegister(metrics.EndpointChangesTotal)
+		legacyregistry.MustRegister(metrics.ServiceChangesPending)
+		legacyregistry.MustRegister(metrics.ServiceChangesTotal)
+		legacyregistry.MustRegister(metrics.SyncProxyRulesLastQueuedTimestamp)
 	})
 }


### PR DESCRIPTION
Cherry pick of #106581 on release-1.21.

#106581: Enabling kube-proxy metrics on windows kernel mode

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```