### PR TITLE
FlushFrequency config type

### DIFF
--- a/staging/src/k8s.io/component-base/config/types.go
+++ b/staging/src/k8s.io/component-base/config/types.go
@@ -93,8 +93,9 @@ type LoggingConfiguration struct {
 	// Format Flag specifies the structure of log messages.
 	// default value of format is `text`
 	Format string
-	// Maximum number of seconds between log flushes. Ignored if the
-	// selected logging backend writes log messages without buffering.
+	// Maximum number of nanoseconds (i.e. 1s = 1000000000) between log
+	// flushes.  Ignored if the selected logging backend writes log
+	// messages without buffering.
 	FlushFrequency time.Duration
 	// Verbosity is the threshold that determines which log messages are
 	// logged. Default is zero which logs only the most important

--- a/staging/src/k8s.io/component-base/config/v1alpha1/types.go
+++ b/staging/src/k8s.io/component-base/config/v1alpha1/types.go
@@ -90,8 +90,9 @@ type LoggingConfiguration struct {
 	// Format Flag specifies the structure of log messages.
 	// default value of format is `text`
 	Format string `json:"format,omitempty"`
-	// Maximum number of seconds between log flushes. Ignored if the
-	// selected logging backend writes log messages without buffering.
+	// Maximum number of nanoseconds (i.e. 1s = 1000000000) between log
+	// flushes.  Ignored if the selected logging backend writes log
+	// messages without buffering.
 	FlushFrequency time.Duration `json:"flushFrequency"`
 	// Verbosity is the threshold that determines which log messages are
 	// logged. Default is zero which logs only the most important


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

The intention for Kubernetes 1.23 was to support `flushFrequency: 60` and treat
that as seconds. But time.Duration counts nanoseconds. Because the struct is
embedded inside the beta KubeletConfiguration, we cannot switch to a type that
serializes differently (like metav1.Duration) and therefore (for now) just
update the documentation to match the implementation from Kubernetes 1.23.

#### Special notes for your reviewer:

This was found in https://github.com/kubernetes/kubernetes/pull/105797 while working on a JSON unmarshaling unit test for LoggingConfiguration.

#### Does this PR introduce a user-facing change?
```release-note-action-required
kubelet: The `flushFrequency` field in the kubelet configuration was meant to accept an integer counting seconds, but the actual implementation used nanonseconds. Configuration files that use, for example, `flushFrequency: 60` for 60s must be updated to `flushFrequency: 60000000000`.
```
