### PR TITLE
Optimize pod topology spread performance

### DIFF
--- a/pkg/scheduler/framework/plugins/podtopologyspread/filtering.go
+++ b/pkg/scheduler/framework/plugins/podtopologyspread/filtering.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"fmt"
 	"math"
-	"sync/atomic"
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -46,7 +45,7 @@ type preFilterState struct {
 	// it's not guaranteed to be the 2nd minimum match number.
 	TpKeyToCriticalPaths map[string]*criticalPaths
 	// TpPairToMatchNum is keyed with topologyPair, and valued with the number of matching pods.
-	TpPairToMatchNum map[topologyPair]*int32
+	TpPairToMatchNum map[topologyPair]int
 }
 
 // Clone makes a copy of the given state.
@@ -58,15 +57,14 @@ func (s *preFilterState) Clone() framework.StateData {
 		// Constraints are shared because they don't change.
 		Constraints:          s.Constraints,
 		TpKeyToCriticalPaths: make(map[string]*criticalPaths, len(s.TpKeyToCriticalPaths)),
-		TpPairToMatchNum:     make(map[topologyPair]*int32, len(s.TpPairToMatchNum)),
+		TpPairToMatchNum:     make(map[topologyPair]int, len(s.TpPairToMatchNum)),
 	}
 	for tpKey, paths := range s.TpKeyToCriticalPaths {
 		copy.TpKeyToCriticalPaths[tpKey] = &criticalPaths{paths[0], paths[1]}
 	}
 	for tpPair, matchNum := range s.TpPairToMatchNum {
 		copyPair := topologyPair{key: tpPair.key, value: tpPair.value}
-		copyCount := *matchNum
-		copy.TpPairToMatchNum[copyPair] = &copyCount
+		copy.TpPairToMatchNum[copyPair] = matchNum
 	}
 	return &copy
 }
@@ -82,14 +80,14 @@ type criticalPaths [2]struct {
 	// TopologyValue denotes the topology value mapping to topology key.
 	TopologyValue string
 	// MatchNum denotes the number of matching pods.
-	MatchNum int32
+	MatchNum int
 }
 
 func newCriticalPaths() *criticalPaths {
 	return &criticalPaths{{MatchNum: math.MaxInt32}, {MatchNum: math.MaxInt32}}
 }
 
-func (p *criticalPaths) update(tpVal string, num int32) {
+func (p *criticalPaths) update(tpVal string, num int) {
 	// first verify if `tpVal` exists or not
 	i := -1
 	if tpVal == p[0].TopologyValue {
@@ -119,7 +117,7 @@ func (p *criticalPaths) update(tpVal string, num int32) {
 	}
 }
 
-func (s *preFilterState) updateWithPod(updatedPod, preemptorPod *v1.Pod, node *v1.Node, delta int32) {
+func (s *preFilterState) updateWithPod(updatedPod, preemptorPod *v1.Pod, node *v1.Node, delta int) {
 	if s == nil || updatedPod.Namespace != preemptorPod.Namespace || node == nil {
 		return
 	}
@@ -135,15 +133,15 @@ func (s *preFilterState) updateWithPod(updatedPod, preemptorPod *v1.Pod, node *v
 
 		k, v := constraint.TopologyKey, node.Labels[constraint.TopologyKey]
 		pair := topologyPair{key: k, value: v}
-		*s.TpPairToMatchNum[pair] += delta
+		s.TpPairToMatchNum[pair] += delta
 
-		s.TpKeyToCriticalPaths[k].update(v, *s.TpPairToMatchNum[pair])
+		s.TpKeyToCriticalPaths[k].update(v, s.TpPairToMatchNum[pair])
 	}
 }
 
 // PreFilter invoked at the prefilter extension point.
 func (pl *PodTopologySpread) PreFilter(ctx context.Context, cycleState *framework.CycleState, pod *v1.Pod) *framework.Status {
-	s, err := pl.calPreFilterState(pod)
+	s, err := pl.calPreFilterState(ctx, pod)
 	if err != nil {
 		return framework.AsStatus(err)
 	}
@@ -194,7 +192,7 @@ func getPreFilterState(cycleState *framework.CycleState) (*preFilterState, error
 }
 
 // calPreFilterState computes preFilterState describing how pods are spread on topologies.
-func (pl *PodTopologySpread) calPreFilterState(pod *v1.Pod) (*preFilterState, error) {
+func (pl *PodTopologySpread) calPreFilterState(ctx context.Context, pod *v1.Pod) (*preFilterState, error) {
 	allNodes, err := pl.sharedLister.NodeInfos().List()
 	if err != nil {
 		return nil, fmt.Errorf("listing NodeInfos: %w", err)
@@ -220,53 +218,45 @@ func (pl *PodTopologySpread) calPreFilterState(pod *v1.Pod) (*preFilterState, er
 	s := preFilterState{
 		Constraints:          constraints,
 		TpKeyToCriticalPaths: make(map[string]*criticalPaths, len(constraints)),
-		TpPairToMatchNum:     make(map[topologyPair]*int32, sizeHeuristic(len(allNodes), constraints)),
+		TpPairToMatchNum:     make(map[topologyPair]int, sizeHeuristic(len(allNodes), constraints)),
 	}
 
-	// Nodes that pass nodeAffinity check and carry all required topology keys will be
-	// stored in `filteredNodes`, and be looped later to calculate preFilterState.
-	var filteredNodes []*framework.NodeInfo
 	requiredSchedulingTerm := nodeaffinity.GetRequiredNodeAffinity(pod)
-	for _, n := range allNodes {
-		node := n.Node()
+	tpCountsByNode := make([]map[topologyPair]int, len(allNodes))
+	processNode := func(i int) {
+		nodeInfo := allNodes[i]
+		node := nodeInfo.Node()
 		if node == nil {
 			klog.ErrorS(nil, "Node not found")
-			continue
+			return
 		}
 		// In accordance to design, if NodeAffinity or NodeSelector is defined,
 		// spreading is applied to nodes that pass those filters.
 		// Ignore parsing errors for backwards compatibility.
 		match, _ := requiredSchedulingTerm.Match(node)
 		if !match {
-			continue
+			return
 		}
 		// Ensure current node's labels contains all topologyKeys in 'Constraints'.
 		if !nodeLabelsMatchSpreadConstraints(node.Labels, constraints) {
-			continue
+			return
 		}
+
+		tpCounts := make(map[topologyPair]int, len(constraints))
 		for _, c := range constraints {
 			pair := topologyPair{key: c.TopologyKey, value: node.Labels[c.TopologyKey]}
-			s.TpPairToMatchNum[pair] = new(int32)
+			count := countPodsMatchSelector(nodeInfo.Pods, c.Selector, pod.Namespace)
+			tpCounts[pair] = count
 		}
-
-		filteredNodes = append(filteredNodes, n)
+		tpCountsByNode[i] = tpCounts
 	}
+	pl.parallelizer.Until(ctx, len(allNodes), processNode)
 
-	processNode := func(i int) {
-		nodeInfo := filteredNodes[i]
-		node := nodeInfo.Node()
-
-		for _, constraint := range constraints {
-			pair := topologyPair{key: constraint.TopologyKey, value: node.Labels[constraint.TopologyKey]}
-			tpCount := s.TpPairToMatchNum[pair]
-			if tpCount == nil {
-				continue
-			}
-			count := countPodsMatchSelector(nodeInfo.Pods, constraint.Selector, pod.Namespace)
-			atomic.AddInt32(tpCount, int32(count))
+	for _, tpCounts := range tpCountsByNode {
+		for tp, count := range tpCounts {
+			s.TpPairToMatchNum[tp] += count
 		}
 	}
-	pl.parallelizer.Until(context.Background(), len(filteredNodes), processNode)
 
 	// calculate min match for each topology pair
 	for i := 0; i < len(constraints); i++ {
@@ -274,7 +264,7 @@ func (pl *PodTopologySpread) calPreFilterState(pod *v1.Pod) (*preFilterState, er
 		s.TpKeyToCriticalPaths[key] = newCriticalPaths()
 	}
 	for pair, num := range s.TpPairToMatchNum {
-		s.TpKeyToCriticalPaths[pair.key].update(pair.value, *num)
+		s.TpKeyToCriticalPaths[pair.key].update(pair.value, num)
 	}
 
 	return &s, nil
@@ -306,7 +296,7 @@ func (pl *PodTopologySpread) Filter(ctx context.Context, cycleState *framework.C
 			return framework.NewStatus(framework.UnschedulableAndUnresolvable, ErrReasonNodeLabelNotMatch)
 		}
 
-		selfMatchNum := int32(0)
+		selfMatchNum := 0
 		if c.Selector.Matches(podLabelSet) {
 			selfMatchNum = 1
 		}
@@ -321,12 +311,12 @@ func (pl *PodTopologySpread) Filter(ctx context.Context, cycleState *framework.C
 		// judging criteria:
 		// 'existing matching num' + 'if self-match (1 or 0)' - 'global min matching num' <= 'maxSkew'
 		minMatchNum := paths[0].MatchNum
-		matchNum := int32(0)
-		if tpCount := s.TpPairToMatchNum[pair]; tpCount != nil {
-			matchNum = *tpCount
+		matchNum := 0
+		if tpCount, ok := s.TpPairToMatchNum[pair]; ok {
+			matchNum = tpCount
 		}
 		skew := matchNum + selfMatchNum - minMatchNum
-		if skew > c.MaxSkew {
+		if skew > int(c.MaxSkew) {
 			klog.V(5).InfoS("Node failed spreadConstraint: matchNum + selfMatchNum - minMatchNum > maxSkew", "node", klog.KObj(node), "topologyKey", tpKey, "matchNum", matchNum, "selfMatchNum", selfMatchNum, "minMatchNum", minMatchNum, "maxSkew", c.MaxSkew)
 			return framework.NewStatus(framework.Unschedulable, ErrReasonConstraintsNotMatch)
 		}

--- a/pkg/scheduler/framework/plugins/podtopologyspread/filtering_test.go
+++ b/pkg/scheduler/framework/plugins/podtopologyspread/filtering_test.go
@@ -32,7 +32,6 @@ import (
 	plugintesting "k8s.io/kubernetes/pkg/scheduler/framework/plugins/testing"
 	"k8s.io/kubernetes/pkg/scheduler/internal/cache"
 	st "k8s.io/kubernetes/pkg/scheduler/testing"
-	"k8s.io/utils/pointer"
 )
 
 var cmpOpts = []cmp.Option{
@@ -87,9 +86,9 @@ func TestPreFilterState(t *testing.T) {
 				TpKeyToCriticalPaths: map[string]*criticalPaths{
 					"zone": {{"zone1", 0}, {"zone2", 0}},
 				},
-				TpPairToMatchNum: map[topologyPair]*int32{
-					{key: "zone", value: "zone1"}: pointer.Int32Ptr(0),
-					{key: "zone", value: "zone2"}: pointer.Int32Ptr(0),
+				TpPairToMatchNum: map[topologyPair]int{
+					{key: "zone", value: "zone1"}: 0,
+					{key: "zone", value: "zone2"}: 0,
 				},
 			},
 		},
@@ -122,9 +121,9 @@ func TestPreFilterState(t *testing.T) {
 				TpKeyToCriticalPaths: map[string]*criticalPaths{
 					"zone": {{"zone2", 2}, {"zone1", 3}},
 				},
-				TpPairToMatchNum: map[topologyPair]*int32{
-					{key: "zone", value: "zone1"}: pointer.Int32Ptr(3),
-					{key: "zone", value: "zone2"}: pointer.Int32Ptr(2),
+				TpPairToMatchNum: map[topologyPair]int{
+					{key: "zone", value: "zone1"}: 3,
+					{key: "zone", value: "zone2"}: 2,
 				},
 			},
 		},
@@ -159,10 +158,10 @@ func TestPreFilterState(t *testing.T) {
 				TpKeyToCriticalPaths: map[string]*criticalPaths{
 					"zone": {{"zone3", 0}, {"zone2", 2}},
 				},
-				TpPairToMatchNum: map[topologyPair]*int32{
-					{key: "zone", value: "zone1"}: pointer.Int32Ptr(3),
-					{key: "zone", value: "zone2"}: pointer.Int32Ptr(2),
-					{key: "zone", value: "zone3"}: pointer.Int32Ptr(0),
+				TpPairToMatchNum: map[topologyPair]int{
+					{key: "zone", value: "zone1"}: 3,
+					{key: "zone", value: "zone2"}: 2,
+					{key: "zone", value: "zone3"}: 0,
 				},
 			},
 		},
@@ -195,9 +194,9 @@ func TestPreFilterState(t *testing.T) {
 				TpKeyToCriticalPaths: map[string]*criticalPaths{
 					"zone": {{"zone2", 1}, {"zone1", 2}},
 				},
-				TpPairToMatchNum: map[topologyPair]*int32{
-					{key: "zone", value: "zone1"}: pointer.Int32Ptr(2),
-					{key: "zone", value: "zone2"}: pointer.Int32Ptr(1),
+				TpPairToMatchNum: map[topologyPair]int{
+					{key: "zone", value: "zone1"}: 2,
+					{key: "zone", value: "zone2"}: 1,
 				},
 			},
 		},
@@ -239,13 +238,13 @@ func TestPreFilterState(t *testing.T) {
 					"zone": {{"zone1", 3}, {"zone2", 4}},
 					"node": {{"node-x", 0}, {"node-b", 1}},
 				},
-				TpPairToMatchNum: map[topologyPair]*int32{
-					{key: "zone", value: "zone1"}:  pointer.Int32Ptr(3),
-					{key: "zone", value: "zone2"}:  pointer.Int32Ptr(4),
-					{key: "node", value: "node-a"}: pointer.Int32Ptr(2),
-					{key: "node", value: "node-b"}: pointer.Int32Ptr(1),
-					{key: "node", value: "node-x"}: pointer.Int32Ptr(0),
-					{key: "node", value: "node-y"}: pointer.Int32Ptr(4),
+				TpPairToMatchNum: map[topologyPair]int{
+					{key: "zone", value: "zone1"}:  3,
+					{key: "zone", value: "zone2"}:  4,
+					{key: "node", value: "node-a"}: 2,
+					{key: "node", value: "node-b"}: 1,
+					{key: "node", value: "node-x"}: 0,
+					{key: "node", value: "node-y"}: 4,
 				},
 			},
 		},
@@ -288,12 +287,12 @@ func TestPreFilterState(t *testing.T) {
 					"zone": {{"zone1", 3}, {"zone2", 4}},
 					"node": {{"node-b", 1}, {"node-a", 2}},
 				},
-				TpPairToMatchNum: map[topologyPair]*int32{
-					{key: "zone", value: "zone1"}:  pointer.Int32Ptr(3),
-					{key: "zone", value: "zone2"}:  pointer.Int32Ptr(4),
-					{key: "node", value: "node-a"}: pointer.Int32Ptr(2),
-					{key: "node", value: "node-b"}: pointer.Int32Ptr(1),
-					{key: "node", value: "node-y"}: pointer.Int32Ptr(4),
+				TpPairToMatchNum: map[topologyPair]int{
+					{key: "zone", value: "zone1"}:  3,
+					{key: "zone", value: "zone2"}:  4,
+					{key: "node", value: "node-a"}: 2,
+					{key: "node", value: "node-b"}: 1,
+					{key: "node", value: "node-y"}: 4,
 				},
 			},
 		},
@@ -329,12 +328,12 @@ func TestPreFilterState(t *testing.T) {
 					"zone": {{"zone2", 0}, {"zone1", 1}},
 					"node": {{"node-a", 0}, {"node-y", 0}},
 				},
-				TpPairToMatchNum: map[topologyPair]*int32{
-					{key: "zone", value: "zone1"}:  pointer.Int32Ptr(1),
-					{key: "zone", value: "zone2"}:  pointer.Int32Ptr(0),
-					{key: "node", value: "node-a"}: pointer.Int32Ptr(0),
-					{key: "node", value: "node-b"}: pointer.Int32Ptr(1),
-					{key: "node", value: "node-y"}: pointer.Int32Ptr(0),
+				TpPairToMatchNum: map[topologyPair]int{
+					{key: "zone", value: "zone1"}:  1,
+					{key: "zone", value: "zone2"}:  0,
+					{key: "node", value: "node-a"}: 0,
+					{key: "node", value: "node-b"}: 1,
+					{key: "node", value: "node-y"}: 0,
 				},
 			},
 		},
@@ -375,12 +374,12 @@ func TestPreFilterState(t *testing.T) {
 					"zone": {{"zone1", 3}, {"zone2", 4}},
 					"node": {{"node-b", 0}, {"node-a", 1}},
 				},
-				TpPairToMatchNum: map[topologyPair]*int32{
-					{key: "zone", value: "zone1"}:  pointer.Int32Ptr(3),
-					{key: "zone", value: "zone2"}:  pointer.Int32Ptr(4),
-					{key: "node", value: "node-a"}: pointer.Int32Ptr(1),
-					{key: "node", value: "node-b"}: pointer.Int32Ptr(0),
-					{key: "node", value: "node-y"}: pointer.Int32Ptr(2),
+				TpPairToMatchNum: map[topologyPair]int{
+					{key: "zone", value: "zone1"}:  3,
+					{key: "zone", value: "zone2"}:  4,
+					{key: "node", value: "node-a"}: 1,
+					{key: "node", value: "node-b"}: 0,
+					{key: "node", value: "node-y"}: 2,
 				},
 			},
 		},
@@ -423,12 +422,12 @@ func TestPreFilterState(t *testing.T) {
 					"zone": {{"zone1", 3}, {"zone2", 4}},
 					"node": {{"node-b", 1}, {"node-a", 2}},
 				},
-				TpPairToMatchNum: map[topologyPair]*int32{
-					{key: "zone", value: "zone1"}:  pointer.Int32Ptr(3),
-					{key: "zone", value: "zone2"}:  pointer.Int32Ptr(4),
-					{key: "node", value: "node-a"}: pointer.Int32Ptr(2),
-					{key: "node", value: "node-b"}: pointer.Int32Ptr(1),
-					{key: "node", value: "node-y"}: pointer.Int32Ptr(4),
+				TpPairToMatchNum: map[topologyPair]int{
+					{key: "zone", value: "zone1"}:  3,
+					{key: "zone", value: "zone2"}:  4,
+					{key: "node", value: "node-a"}: 2,
+					{key: "node", value: "node-b"}: 1,
+					{key: "node", value: "node-y"}: 4,
 				},
 			},
 		},
@@ -460,7 +459,7 @@ func TestPreFilterState(t *testing.T) {
 					"node": newCriticalPaths(),
 					"rack": newCriticalPaths(),
 				},
-				TpPairToMatchNum: make(map[topologyPair]*int32),
+				TpPairToMatchNum: make(map[topologyPair]int),
 			},
 		},
 		{
@@ -496,7 +495,7 @@ func TestPreFilterState(t *testing.T) {
 				TpKeyToCriticalPaths: map[string]*criticalPaths{
 					"zone": newCriticalPaths(),
 				},
-				TpPairToMatchNum: make(map[topologyPair]*int32),
+				TpPairToMatchNum: make(map[topologyPair]int),
 			},
 		},
 		{
@@ -568,9 +567,9 @@ func TestPreFilterStateAddPod(t *testing.T) {
 				TpKeyToCriticalPaths: map[string]*criticalPaths{
 					"node": {{"node-b", 0}, {"node-a", 1}},
 				},
-				TpPairToMatchNum: map[topologyPair]*int32{
-					{key: "node", value: "node-a"}: pointer.Int32Ptr(1),
-					{key: "node", value: "node-b"}: pointer.Int32Ptr(0),
+				TpPairToMatchNum: map[topologyPair]int{
+					{key: "node", value: "node-a"}: 1,
+					{key: "node", value: "node-b"}: 0,
 				},
 			},
 		},
@@ -593,9 +592,9 @@ func TestPreFilterStateAddPod(t *testing.T) {
 				TpKeyToCriticalPaths: map[string]*criticalPaths{
 					"node": {{"node-a", 1}, {"node-b", 1}},
 				},
-				TpPairToMatchNum: map[topologyPair]*int32{
-					{key: "node", value: "node-a"}: pointer.Int32Ptr(1),
-					{key: "node", value: "node-b"}: pointer.Int32Ptr(1),
+				TpPairToMatchNum: map[topologyPair]int{
+					{key: "node", value: "node-a"}: 1,
+					{key: "node", value: "node-b"}: 1,
 				},
 			},
 		},
@@ -618,9 +617,9 @@ func TestPreFilterStateAddPod(t *testing.T) {
 				TpKeyToCriticalPaths: map[string]*criticalPaths{
 					"node": {{"node-a", 0}, {"node-b", 1}},
 				},
-				TpPairToMatchNum: map[topologyPair]*int32{
-					{key: "node", value: "node-a"}: pointer.Int32Ptr(0),
-					{key: "node", value: "node-b"}: pointer.Int32Ptr(1),
+				TpPairToMatchNum: map[topologyPair]int{
+					{key: "node", value: "node-a"}: 0,
+					{key: "node", value: "node-b"}: 1,
 				},
 			},
 		},
@@ -643,9 +642,9 @@ func TestPreFilterStateAddPod(t *testing.T) {
 				TpKeyToCriticalPaths: map[string]*criticalPaths{
 					"node": {{"node-a", 0}, {"node-b", 2}},
 				},
-				TpPairToMatchNum: map[topologyPair]*int32{
-					{key: "node", value: "node-a"}: pointer.Int32Ptr(0),
-					{key: "node", value: "node-b"}: pointer.Int32Ptr(2),
+				TpPairToMatchNum: map[topologyPair]int{
+					{key: "node", value: "node-a"}: 0,
+					{key: "node", value: "node-b"}: 2,
 				},
 			},
 		},
@@ -668,11 +667,11 @@ func TestPreFilterStateAddPod(t *testing.T) {
 					"zone": {{"zone2", 0}, {"zone1", 1}},
 					"node": {{"node-x", 0}, {"node-a", 1}},
 				},
-				TpPairToMatchNum: map[topologyPair]*int32{
-					{key: "zone", value: "zone1"}:  pointer.Int32Ptr(1),
-					{key: "zone", value: "zone2"}:  pointer.Int32Ptr(0),
-					{key: "node", value: "node-a"}: pointer.Int32Ptr(1),
-					{key: "node", value: "node-x"}: pointer.Int32Ptr(0),
+				TpPairToMatchNum: map[topologyPair]int{
+					{key: "zone", value: "zone1"}:  1,
+					{key: "zone", value: "zone2"}:  0,
+					{key: "node", value: "node-a"}: 1,
+					{key: "node", value: "node-x"}: 0,
 				},
 			},
 		},
@@ -697,11 +696,11 @@ func TestPreFilterStateAddPod(t *testing.T) {
 					"zone": {{"zone1", 1}, {"zone2", 1}},
 					"node": {{"node-a", 1}, {"node-x", 1}},
 				},
-				TpPairToMatchNum: map[topologyPair]*int32{
-					{key: "zone", value: "zone1"}:  pointer.Int32Ptr(1),
-					{key: "zone", value: "zone2"}:  pointer.Int32Ptr(1),
-					{key: "node", value: "node-a"}: pointer.Int32Ptr(1),
-					{key: "node", value: "node-x"}: pointer.Int32Ptr(1),
+				TpPairToMatchNum: map[topologyPair]int{
+					{key: "zone", value: "zone1"}:  1,
+					{key: "zone", value: "zone2"}:  1,
+					{key: "node", value: "node-a"}: 1,
+					{key: "node", value: "node-x"}: 1,
 				},
 			},
 		},
@@ -729,12 +728,12 @@ func TestPreFilterStateAddPod(t *testing.T) {
 					"zone": {{"zone2", 1}, {"zone1", 3}},
 					"node": {{"node-a", 1}, {"node-x", 1}},
 				},
-				TpPairToMatchNum: map[topologyPair]*int32{
-					{key: "zone", value: "zone1"}:  pointer.Int32Ptr(3),
-					{key: "zone", value: "zone2"}:  pointer.Int32Ptr(1),
-					{key: "node", value: "node-a"}: pointer.Int32Ptr(1),
-					{key: "node", value: "node-b"}: pointer.Int32Ptr(2),
-					{key: "node", value: "node-x"}: pointer.Int32Ptr(1),
+				TpPairToMatchNum: map[topologyPair]int{
+					{key: "zone", value: "zone1"}:  3,
+					{key: "zone", value: "zone2"}:  1,
+					{key: "node", value: "node-a"}: 1,
+					{key: "node", value: "node-b"}: 2,
+					{key: "node", value: "node-x"}: 1,
 				},
 			},
 		},
@@ -769,12 +768,12 @@ func TestPreFilterStateAddPod(t *testing.T) {
 					"zone": {{"zone2", 1}, {"zone1", 2}},
 					"node": {{"node-a", 0}, {"node-b", 1}},
 				},
-				TpPairToMatchNum: map[topologyPair]*int32{
-					{key: "zone", value: "zone1"}:  pointer.Int32Ptr(2),
-					{key: "zone", value: "zone2"}:  pointer.Int32Ptr(1),
-					{key: "node", value: "node-a"}: pointer.Int32Ptr(0),
-					{key: "node", value: "node-b"}: pointer.Int32Ptr(1),
-					{key: "node", value: "node-x"}: pointer.Int32Ptr(2),
+				TpPairToMatchNum: map[topologyPair]int{
+					{key: "zone", value: "zone1"}:  2,
+					{key: "zone", value: "zone2"}:  1,
+					{key: "node", value: "node-a"}: 0,
+					{key: "node", value: "node-b"}: 1,
+					{key: "node", value: "node-x"}: 2,
 				},
 			},
 		},
@@ -809,12 +808,12 @@ func TestPreFilterStateAddPod(t *testing.T) {
 					"zone": {{"zone1", 1}, {"zone2", 1}},
 					"node": {{"node-a", 1}, {"node-b", 1}},
 				},
-				TpPairToMatchNum: map[topologyPair]*int32{
-					{key: "zone", value: "zone1"}:  pointer.Int32Ptr(1),
-					{key: "zone", value: "zone2"}:  pointer.Int32Ptr(1),
-					{key: "node", value: "node-a"}: pointer.Int32Ptr(1),
-					{key: "node", value: "node-b"}: pointer.Int32Ptr(1),
-					{key: "node", value: "node-x"}: pointer.Int32Ptr(2),
+				TpPairToMatchNum: map[topologyPair]int{
+					{key: "zone", value: "zone1"}:  1,
+					{key: "zone", value: "zone2"}:  1,
+					{key: "node", value: "node-a"}: 1,
+					{key: "node", value: "node-b"}: 1,
+					{key: "node", value: "node-x"}: 2,
 				},
 			},
 		},
@@ -889,9 +888,9 @@ func TestPreFilterStateRemovePod(t *testing.T) {
 				TpKeyToCriticalPaths: map[string]*criticalPaths{
 					"zone": {{"zone1", 1}, {"zone2", 1}},
 				},
-				TpPairToMatchNum: map[topologyPair]*int32{
-					{key: "zone", value: "zone1"}: pointer.Int32Ptr(1),
-					{key: "zone", value: "zone2"}: pointer.Int32Ptr(1),
+				TpPairToMatchNum: map[topologyPair]int{
+					{key: "zone", value: "zone1"}: 1,
+					{key: "zone", value: "zone2"}: 1,
 				},
 			},
 		},
@@ -919,9 +918,9 @@ func TestPreFilterStateRemovePod(t *testing.T) {
 				TpKeyToCriticalPaths: map[string]*criticalPaths{
 					"zone": {{"zone1", 1}, {"zone2", 2}},
 				},
-				TpPairToMatchNum: map[topologyPair]*int32{
-					{key: "zone", value: "zone1"}: pointer.Int32Ptr(1),
-					{key: "zone", value: "zone2"}: pointer.Int32Ptr(2),
+				TpPairToMatchNum: map[topologyPair]int{
+					{key: "zone", value: "zone1"}: 1,
+					{key: "zone", value: "zone2"}: 2,
 				},
 			},
 		},
@@ -950,9 +949,9 @@ func TestPreFilterStateRemovePod(t *testing.T) {
 				TpKeyToCriticalPaths: map[string]*criticalPaths{
 					"zone": {{"zone1", 2}, {"zone2", 2}},
 				},
-				TpPairToMatchNum: map[topologyPair]*int32{
-					{key: "zone", value: "zone1"}: pointer.Int32Ptr(2),
-					{key: "zone", value: "zone2"}: pointer.Int32Ptr(2),
+				TpPairToMatchNum: map[topologyPair]int{
+					{key: "zone", value: "zone1"}: 2,
+					{key: "zone", value: "zone2"}: 2,
 				},
 			},
 		},
@@ -981,9 +980,9 @@ func TestPreFilterStateRemovePod(t *testing.T) {
 				TpKeyToCriticalPaths: map[string]*criticalPaths{
 					"zone": {{"zone1", 2}, {"zone2", 2}},
 				},
-				TpPairToMatchNum: map[topologyPair]*int32{
-					{key: "zone", value: "zone1"}: pointer.Int32Ptr(2),
-					{key: "zone", value: "zone2"}: pointer.Int32Ptr(2),
+				TpPairToMatchNum: map[topologyPair]int{
+					{key: "zone", value: "zone1"}: 2,
+					{key: "zone", value: "zone2"}: 2,
 				},
 			},
 		},
@@ -1013,12 +1012,12 @@ func TestPreFilterStateRemovePod(t *testing.T) {
 					"zone": {{"zone2", 1}, {"zone1", 3}},
 					"node": {{"node-b", 1}, {"node-x", 1}},
 				},
-				TpPairToMatchNum: map[topologyPair]*int32{
-					{key: "zone", value: "zone1"}:  pointer.Int32Ptr(3),
-					{key: "zone", value: "zone2"}:  pointer.Int32Ptr(1),
-					{key: "node", value: "node-a"}: pointer.Int32Ptr(2),
-					{key: "node", value: "node-b"}: pointer.Int32Ptr(1),
-					{key: "node", value: "node-x"}: pointer.Int32Ptr(1),
+				TpPairToMatchNum: map[topologyPair]int{
+					{key: "zone", value: "zone1"}:  3,
+					{key: "zone", value: "zone2"}:  1,
+					{key: "node", value: "node-a"}: 2,
+					{key: "node", value: "node-b"}: 1,
+					{key: "node", value: "node-x"}: 1,
 				},
 			},
 		},


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

As documented in #105750, the performance of the pod topology spread plugin degrades as the number of pods increases. The following CPU profile of the scheduler was taken during a benchmarking run with the same setup described in #105750:

<img width="1463" alt="Screen Shot 2021-12-13 at 6 19 22 PM" src="https://user-images.githubusercontent.com/5430846/150018127-270a0035-f8c6-4cea-bb17-4ba37693003d.png">

A disproportionate amount of CPU time is spent in the `calPreFilterState` function, as expected. Let's zoom in on this function:

<img width="804" alt="Screen Shot 2021-12-13 at 6 25 20 PM" src="https://user-images.githubusercontent.com/5430846/150018561-a9ad5e78-8e8f-498f-a680-30d9a94d3db6.png">

Interestingly, the cumulative CPU time spent on `mapaccess2_faststr` accounts for nearly half (9.15/19.88 = 0.46) of the CPU time of `calPreFilterState`. pprof's list command can help us locate the bottlenecks:

```
(pprof) list calPreFilterState
     7.50s     19.88s (flat, cum) 34.39% of Total

        3s     10.63s    238:		if !nodeLabelsMatchSpreadConstraints(node.Labels, constraints) {
     130ms      6.80s    257:		count := countPodsMatchSelector(nodeInfo.Pods, constraint.Selector, pod.Namespace)

(pprof) list nodeLabelsMatchSpreadConstraints
     110ms      7.63s (flat, cum) 13.20% of Total

      40ms      7.56s     62:		if _, ok := nodeLabels[c.TopologyKey]; !ok {
```

A disproportionate amount of CPU time is spent accessing node labels; these accesses are currently performed in sequence. This PR relaxes this bottleneck by parallelizing the node label accesses. Note that `calPreFilterState` now accesses each key of `TpPairToMatchNum` in sequence, which amounts to the same number of sequential map accesses as before. This is faster because the accesses to `TpPairToMatchNum` exhibit better spatial locality and are less likely to incur a memory access. Our benchmarks (methodology described in #105750) yielded the following reductions in PreFilter latencies with a single topology constraint for hostname.

```
p50: 41.0% reduction
p90: 12.0% reduction
p99: 21.0% reduction
```

```release-note
NONE
```


