### PR TITLE
Add debugging msg of "kubectl get nodes"

### DIFF
--- a/hack/local-up-cluster.sh
+++ b/hack/local-up-cluster.sh
@@ -684,13 +684,14 @@ function start_cloud_controller_manager {
 
 function wait_node_ready(){
   # check the nodes information after kubelet daemon start
-  local nodes_stats="${KUBECTL} --kubeconfig '${CERT_DIR}/admin.kubeconfig' get nodes"
+  local nodes_stats="${KUBECTL} --kubeconfig ${CERT_DIR}/admin.kubeconfig get nodes"
   local node_name=$HOSTNAME_OVERRIDE
   local system_node_wait_time=60
   local interval_time=2
   kube::util::wait_for_success "$system_node_wait_time" "$interval_time" "$nodes_stats | grep $node_name"
   if [ $? == "1" ]; then
-    echo "time out on waiting $node_name info"
+    echo "time out on waiting $node_name info from:"
+    $nodes_stats
     exit 1
   fi
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/kind failing-test

#### What this PR does / why we need it:

When facing an issue to wait for a node is ready on local-up-cluster.sh
it is difficult to know the root problem because the logs were just like:

```
  wait kubelet ready
  No resources found
  ...
  No resources found
  time out on waiting 172.17.0.1 info
  process.go:155: Step '/go/src/k8s.io/kubernetes/hack/local-up-cluster.sh' finished in 12m38.408359137s
```

This adds debugging message to know what exactly happaned at the time.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

