### PR TITLE
add DisableCadvisorProcessMetrics feature gate to skip it for a perfo…

### DIFF
--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -478,6 +478,12 @@ const (
 	// Disables Accelerator Metrics Collected by Kubelet
 	DisableAcceleratorUsageMetrics featuregate.Feature = "DisableAcceleratorUsageMetrics"
 
+	// owner: @pacoxu
+	// alpha: v1.24
+	//
+	// Disables Cadvisor Process Metrics Collected by Kubelet
+	DisableCadvisorProcessMetrics featuregate.Feature = "DisableCadvisorProcessMetrics"
+
 	// owner: @arjunrn @mwielgus @josephburnett
 	// alpha: v1.20
 	//
@@ -910,6 +916,7 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
 	WinOverlay:                                     {Default: true, PreRelease: featuregate.Beta},
 	WinDSR:                                         {Default: false, PreRelease: featuregate.Alpha},
 	DisableAcceleratorUsageMetrics:                 {Default: true, PreRelease: featuregate.Beta},
+	DisableCadvisorProcessMetrics:                  {Default: false, PreRelease: featuregate.Alpha},
 	HPAContainerMetrics:                            {Default: false, PreRelease: featuregate.Alpha},
 	SizeMemoryBackedVolumes:                        {Default: true, PreRelease: featuregate.Beta},
 	ExecProbeTimeout:                               {Default: true, PreRelease: featuregate.GA}, // lock to default and remove after v1.22 based on KEP #1972 update

--- a/pkg/kubelet/cadvisor/cadvisor_linux.go
+++ b/pkg/kubelet/cadvisor/cadvisor_linux.go
@@ -90,13 +90,17 @@ func New(imageFsInfoProvider ImageFsInfoProvider, rootPath string, cgroupRoots [
 		cadvisormetrics.DiskIOMetrics:       struct{}{},
 		cadvisormetrics.NetworkUsageMetrics: struct{}{},
 		cadvisormetrics.AppMetrics:          struct{}{},
-		cadvisormetrics.ProcessMetrics:      struct{}{},
 		cadvisormetrics.OOMMetrics:          struct{}{},
 	}
-
 	// Only add the Accelerator metrics if the feature is inactive
 	if !utilfeature.DefaultFeatureGate.Enabled(kubefeatures.DisableAcceleratorUsageMetrics) {
 		includedMetrics[cadvisormetrics.AcceleratorUsageMetrics] = struct{}{}
+	}
+
+	// Only add the process metrics if the feature is inactive
+	// ProcessMetrics may cause performance issues on some scenarios
+	if !utilfeature.DefaultFeatureGate.Enabled(kubefeatures.DisableCadvisorProcessMetrics) {
+		includedMetrics[cadvisormetrics.ProcessMetrics] = struct{}{}
 	}
 
 	if usingLegacyStats || utilfeature.DefaultFeatureGate.Enabled(kubefeatures.LocalStorageCapacityIsolation) {


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
Not sure if we need a KEP for this. But this is a really simple flag.

Use case from @xinfengliu:
> When running elasticsearch workload, it's possible that elasticsearch has huge number of open files. This causes kubelet CPU usage extremely high and impacts the application responsiveness.
> 
> CPU profiling data shows the hot code is here:
> https://github.com/kubernetes/kubernetes/blob/release-1.18/vendor/github.com/google/cadvisor/container/libcontainer/handler.go#L163-L182

#### Which issue(s) this PR fixes:
Fixes #99183

#### Special notes for your reviewer:
A similar case is https://github.com/kubernetes/enhancements/pull/1868.

Some details about the `cadvisor.ProcessMetrics` are in https://github.com/kubernetes/kubernetes/issues/99183#issuecomment-1010966311.
> Process metrics include container_processes, container_file_descriptors, container_sockets, container_threads_max, container_threads, container_ulimits_soft.
> 
> If I search correctly, they are not used in other APIs.

- another proposal would be adding a kubelet flag for disable it.
- or we can edit the interval to get process metrics in cadvisor to make the performance issue not that concerning.

#### Does this PR introduce a user-facing change?
```release-note
add DisableCadvisorProcessMetrics feature gate to skip it for a performance issue of cadvisor
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
