### PR TITLE
Fix up integration test user groups

### DIFF
--- a/test/integration/auth/accessreview_test.go
+++ b/test/integration/auth/accessreview_test.go
@@ -49,7 +49,9 @@ func (sarAuthorizer) Authorize(ctx context.Context, a authorizer.Attributes) (au
 func alwaysAlice(req *http.Request) (*authenticator.Response, bool, error) {
 	return &authenticator.Response{
 		User: &user.DefaultInfo{
-			Name: "alice",
+			Name:   "alice",
+			UID:    "alice",
+			Groups: []string{user.AllAuthenticated},
 		},
 	}, true, nil
 }
@@ -149,7 +151,11 @@ func TestSelfSubjectAccessReview(t *testing.T) {
 	controlPlaneConfig := framework.NewIntegrationTestControlPlaneConfig()
 	controlPlaneConfig.GenericConfig.Authentication.Authenticator = authenticator.RequestFunc(func(req *http.Request) (*authenticator.Response, bool, error) {
 		return &authenticator.Response{
-			User: &user.DefaultInfo{Name: username},
+			User: &user.DefaultInfo{
+				Name:   username,
+				UID:    username,
+				Groups: []string{user.AllAuthenticated},
+			},
 		}, true, nil
 	})
 	controlPlaneConfig.GenericConfig.Authorization.Authorizer = sarAuthorizer{}

--- a/test/integration/auth/auth_test.go
+++ b/test/integration/auth/auth_test.go
@@ -1405,7 +1405,7 @@ func testWebhookTokenAuthenticator(customDialer bool, t *testing.T) {
 
 	// Set up an API server
 	controlPlaneConfig := framework.NewIntegrationTestControlPlaneConfig()
-	controlPlaneConfig.GenericConfig.Authentication.Authenticator = authenticator
+	controlPlaneConfig.GenericConfig.Authentication.Authenticator = group.NewAuthenticatedGroupAdder(authenticator)
 	controlPlaneConfig.GenericConfig.Authorization.Authorizer = allowAliceAuthorizer{}
 	_, s, closeFn := framework.RunAnAPIServer(controlPlaneConfig)
 	defer closeFn()

--- a/test/integration/auth/bootstraptoken_test.go
+++ b/test/integration/auth/bootstraptoken_test.go
@@ -27,6 +27,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apiserver/pkg/authentication/group"
 	"k8s.io/apiserver/pkg/authentication/request/bearertoken"
 	bootstrapapi "k8s.io/cluster-bootstrap/token/api"
 	"k8s.io/kubernetes/plugin/pkg/auth/authenticator/token/bootstrap"
@@ -115,7 +116,7 @@ func TestBootstrapTokenAuth(t *testing.T) {
 	}
 	for _, test := range tests {
 
-		authenticator := bearertoken.New(bootstrap.NewTokenAuthenticator(bootstrapSecrets{test.secret}))
+		authenticator := group.NewAuthenticatedGroupAdder(bearertoken.New(bootstrap.NewTokenAuthenticator(bootstrapSecrets{test.secret})))
 		// Set up an API server
 		controlPlaneConfig := framework.NewIntegrationTestControlPlaneConfig()
 		controlPlaneConfig.GenericConfig.Authentication.Authenticator = authenticator

--- a/test/integration/auth/rbac_test.go
+++ b/test/integration/auth/rbac_test.go
@@ -34,6 +34,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/apiserver/pkg/authentication/group"
 	"k8s.io/apiserver/pkg/authentication/request/bearertoken"
 	"k8s.io/apiserver/pkg/authentication/token/tokenfile"
 	"k8s.io/apiserver/pkg/authentication/user"
@@ -521,7 +522,7 @@ func TestRBAC(t *testing.T) {
 		// Create an API Server.
 		controlPlaneConfig := framework.NewIntegrationTestControlPlaneConfig()
 		controlPlaneConfig.GenericConfig.Authorization.Authorizer = newRBACAuthorizer(t, controlPlaneConfig)
-		controlPlaneConfig.GenericConfig.Authentication.Authenticator = bearertoken.New(tokenfile.New(map[string]*user.DefaultInfo{
+		controlPlaneConfig.GenericConfig.Authentication.Authenticator = group.NewAuthenticatedGroupAdder(bearertoken.New(tokenfile.New(map[string]*user.DefaultInfo{
 			superUser:                          {Name: "admin", Groups: []string{"system:masters"}},
 			"any-rolebinding-writer":           {Name: "any-rolebinding-writer"},
 			"any-rolebinding-writer-namespace": {Name: "any-rolebinding-writer-namespace"},
@@ -533,7 +534,7 @@ func TestRBAC(t *testing.T) {
 			"limitrange-updater":               {Name: "limitrange-updater"},
 			"limitrange-patcher":               {Name: "limitrange-patcher"},
 			"user-with-no-permissions":         {Name: "user-with-no-permissions"},
-		}))
+		})))
 		controlPlaneConfig.GenericConfig.OpenAPIConfig = framework.DefaultOpenAPIConfig()
 		_, s, closeFn := framework.RunAnAPIServer(controlPlaneConfig)
 		defer closeFn()

--- a/test/integration/serviceaccount/service_account_test.go
+++ b/test/integration/serviceaccount/service_account_test.go
@@ -37,6 +37,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apiserver/pkg/authentication/authenticator"
+	"k8s.io/apiserver/pkg/authentication/group"
 	"k8s.io/apiserver/pkg/authentication/request/bearertoken"
 	"k8s.io/apiserver/pkg/authentication/request/union"
 	serviceaccountapiserver "k8s.io/apiserver/pkg/authentication/serviceaccount"
@@ -355,10 +356,10 @@ func startServiceAccountTestServer(t *testing.T) (*clientset.Clientset, restclie
 		externalInformers.Core().V1().Pods().Lister(),
 	)
 	serviceAccountTokenAuth := serviceaccount.JWTTokenAuthenticator([]string{serviceaccount.LegacyIssuer}, []interface{}{&serviceAccountKey.PublicKey}, nil, serviceaccount.NewLegacyValidator(true, serviceAccountTokenGetter))
-	authenticator := union.New(
+	authenticator := group.NewAuthenticatedGroupAdder(union.New(
 		bearertoken.New(rootTokenAuth),
 		bearertoken.New(serviceAccountTokenAuth),
-	)
+	))
 
 	// Set up a stub authorizer:
 	// 1. The "root" user is allowed to do anything


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### Which issue(s) this PR fixes:

Fixes #96647

Ensures all users returned by dummy integration test authenticators include all-authenticated group info

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

/cc @enj 