### PR TITLE
Add enj to sig-auth-encryption-at-rest-approvers

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -59,6 +59,7 @@ aliases:
     - wojtek-t
   sig-auth-encryption-at-rest-approvers:
     - smarterclayton
+    - enj
   sig-auth-encryption-at-rest-reviewers:
     - enj
     - lavalamp


### PR DESCRIPTION
Signed-off-by: Monis Khan <mok@vmware.com>

/kind cleanup
/triage accepted
/sig auth
/priority important-soon

```release-note
NONE
```

/assign @smarterclayton