### PR TITLE
Fix panic in GetReference when passed a nil object

### DIFF
--- a/staging/src/k8s.io/client-go/tools/reference/ref.go
+++ b/staging/src/k8s.io/client-go/tools/reference/ref.go
@@ -19,6 +19,7 @@ package reference
 import (
 	"errors"
 	"fmt"
+	"reflect"
 
 	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -36,7 +37,7 @@ var (
 // that would allow this.
 // TODO: should take a meta.Interface see http://issue.k8s.io/7127
 func GetReference(scheme *runtime.Scheme, obj runtime.Object) (*v1.ObjectReference, error) {
-	if obj == nil {
+	if obj == nil || (reflect.ValueOf(obj).Kind() == reflect.Ptr && reflect.ValueOf(obj).IsNil()) {
 		return nil, ErrNilObject
 	}
 	if ref, ok := obj.(*v1.ObjectReference); ok {

--- a/staging/src/k8s.io/client-go/tools/reference/ref_test.go
+++ b/staging/src/k8s.io/client-go/tools/reference/ref_test.go
@@ -72,3 +72,12 @@ func TestGetReferenceRefVersion(t *testing.T) {
 		})
 	}
 }
+
+func TestGetReferenceNilObject(t *testing.T) {
+	var p *TestRuntimeObj
+	scheme := runtime.NewScheme()
+	_, err := GetReference(scheme, p)
+	if err != ErrNilObject {
+		t.Fatalf("expected error to be '%s', got '%s'", ErrNilObject.Error(), err.Error())
+	}
+}


### PR DESCRIPTION
/kind bug

#### What this PR does / why we need it:
The nil check at the beginning of the method is on the interface object. This does not check if the backing object is nil (see https://go.dev/doc/faq#nil_error and https://go.dev/blog/laws-of-reflection for the details). 
This means that the code will panic if we pass a nil object (you can run the added test with the current version to verify)

To fix this, we must use the reflect package to inspect the value behind the interface and check if it is nil.

Added a non-regression test as well.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->

