### PR TITLE
Fix label msg when overwrite flag is set

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/label/label.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/label/label.go
@@ -307,7 +307,7 @@ func (o *LabelOptions) RunLabel() error {
 			if err != nil {
 				return err
 			}
-			dataChangeMsg = updateDataChangeMsg(oldData, newObj)
+			dataChangeMsg = updateDataChangeMsg(oldData, newObj, o.overwrite)
 			outputObj = info.Object
 		} else {
 			name, namespace := info.Name, info.Namespace
@@ -334,7 +334,7 @@ func (o *LabelOptions) RunLabel() error {
 			if err != nil {
 				return err
 			}
-			dataChangeMsg = updateDataChangeMsg(oldData, newObj)
+			dataChangeMsg = updateDataChangeMsg(oldData, newObj, o.overwrite)
 			patchBytes, err := jsonpatch.CreateMergePatch(oldData, newObj)
 			createdPatch := err == nil
 			if err != nil {
@@ -395,11 +395,11 @@ func (o *LabelOptions) RunLabel() error {
 	})
 }
 
-func updateDataChangeMsg(oldObj []byte, newObj []byte) string {
+func updateDataChangeMsg(oldObj []byte, newObj []byte, overwrite bool) string {
 	msg := MsgNotLabeled
 	if !reflect.DeepEqual(oldObj, newObj) {
 		msg = MsgLabeled
-		if len(newObj) < len(oldObj) {
+		if !overwrite && len(newObj) < len(oldObj) {
 			msg = MsgUnLabeled
 		}
 	}

--- a/staging/src/k8s.io/kubectl/pkg/cmd/label/label_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/label/label_test.go
@@ -678,6 +678,41 @@ func TestLabelMsg(t *testing.T) {
 			},
 			expectMsg: MsgLabeled,
 		},
+		{
+			obj: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{"status": "unhealthy"},
+				},
+			},
+			labels:    map[string]string{"status": "healthy"},
+			overwrite: true,
+			expectObj: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"status": "healthy",
+					},
+				},
+			},
+			expectMsg: MsgLabeled,
+		},
+		{
+			obj: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{"status": "unhealthy"},
+				},
+			},
+			labels:    map[string]string{"status": "healthy"},
+			overwrite: false,
+			expectObj: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"status": "unhealthy",
+					},
+				},
+			},
+			expectMsg: MsgNotLabeled,
+			expectErr: true,
+		},
 	}
 
 	for _, test := range tests {
@@ -700,7 +735,7 @@ func TestLabelMsg(t *testing.T) {
 			t.Errorf("unexpected error: %v %v", err, test)
 		}
 
-		dataChangeMsg := updateDataChangeMsg(oldData, newObj)
+		dataChangeMsg := updateDataChangeMsg(oldData, newObj, test.overwrite)
 		if dataChangeMsg != test.expectMsg {
 			t.Errorf("unexpected dataChangeMsg: %v != %v, %v", dataChangeMsg, test.expectMsg, test)
 		}


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
To fix label msg when overwrite flag is set, and fix the test case in https://github.com/kubernetes/kubernetes/pull/105936.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
