### PR TITLE
dual-stack feature gate ga

### DIFF
--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -396,6 +396,7 @@ const (
 	// kep: http://kep.k8s.io/563
 	// alpha: v1.15
 	// beta: v1.21
+	// ga: v1.23
 	//
 	// Enables ipv6 dual stack
 	IPv6DualStack featuregate.Feature = "IPv6DualStack"


### PR DESCRIPTION

/kind cleanup
```release-note
NONE
```

We forgot to update the doc with the ga release information

https://github.com/kubernetes/kubernetes/pull/104691

