### PR TITLE
perf:logic-optimiz-for-DetermineVolumeAction

### DIFF
--- a/pkg/controller/volume/attachdetach/util/util.go
+++ b/pkg/controller/volume/attachdetach/util/util.go
@@ -188,10 +188,10 @@ func DetermineVolumeAction(pod *v1.Pod, desiredStateOfWorld cache.DesiredStateOf
 	if pod == nil || len(pod.Spec.Volumes) <= 0 {
 		return defaultAction
 	}
-	nodeName := types.NodeName(pod.Spec.NodeName)
-	keepTerminatedPodVolume := desiredStateOfWorld.GetKeepTerminatedPodVolumesForNode(nodeName)
 
 	if util.IsPodTerminated(pod, pod.Status) {
+		nodeName := types.NodeName(pod.Spec.NodeName)
+		keepTerminatedPodVolume := desiredStateOfWorld.GetKeepTerminatedPodVolumesForNode(nodeName)
 		// if pod is terminate we let kubelet policy dictate if volume
 		// should be detached or not
 		return keepTerminatedPodVolume

--- a/pkg/controller/volume/attachdetach/util/util.go
+++ b/pkg/controller/volume/attachdetach/util/util.go
@@ -188,10 +188,10 @@ func DetermineVolumeAction(pod *v1.Pod, desiredStateOfWorld cache.DesiredStateOf
 	if pod == nil || len(pod.Spec.Volumes) <= 0 {
 		return defaultAction
 	}
-	nodeName := types.NodeName(pod.Spec.NodeName)
-	keepTerminatedPodVolume := desiredStateOfWorld.GetKeepTerminatedPodVolumesForNode(nodeName)
 
 	if util.IsPodTerminated(pod, pod.Status) {
+                nodeName := types.NodeName(pod.Spec.NodeName)
+                keepTerminatedPodVolume := desiredStateOfWorld.GetKeepTerminatedPodVolumesForNode(nodeName)
 		// if pod is terminate we let kubelet policy dictate if volume
 		// should be detached or not
 		return keepTerminatedPodVolume


### PR DESCRIPTION
This PR is kind of a performance improvement or logic improvement.
In the method DetermineVolumeAction, we should move the definition of `nodeName` and `keepTerminatedPodVolume` into the logic `if util.IsPodTerminate`, because if util.IsPodTerminated returns false, it's not necessary to define `nodeName` and `keepTerminatedPodVolume`.

