### PR TITLE
Make kubelet container manager not abort on PodSandbox not existing

### DIFF
--- a/test/e2e_node/restart_test.go
+++ b/test/e2e_node/restart_test.go
@@ -20,9 +20,12 @@ limitations under the License.
 package e2enode
 
 import (
+	"bufio"
+	"bytes"
 	"context"
 	"fmt"
 	"os/exec"
+	"strings"
 	"time"
 
 	v1 "k8s.io/api/core/v1"
@@ -204,6 +207,96 @@ var _ = SIGDescribe("Restart [Serial] [Slow] [Disruptive]", func() {
 				if len(postRestartRunningPods) < numAllPods {
 					framework.Failf("less pods are running after node restart, got %d but expected %d", len(postRestartRunningPods), numAllPods)
 				}
+			}
+		})
+	})
+
+	ginkgo.Context("Kubelet", func() {
+		ginkgo.It("should start successfully when pod sandboxes are missing", func() {
+			// currently only run this test for containerd runtime
+			containerRuntimeEndpoint := framework.TestContext.ContainerRuntimeEndpoint
+			if !strings.HasSuffix(containerRuntimeEndpoint, "/containerd.sock") {
+				e2eskipper.Skipf("the container runtime is not containerd")
+			}
+			if _, err := exec.Command("sudo", "which", "ctr").CombinedOutput(); err != nil {
+				e2eskipper.Skipf("'ctr' command is not found")
+			}
+			if _, err := exec.Command("sudo", "which", "crictl").CombinedOutput(); err != nil {
+				e2eskipper.Skipf("'crictl' command is not found")
+			}
+
+			node := getLocalNode(f)
+			cpus := node.Status.Allocatable[v1.ResourceCPU]
+			numCpus := int((&cpus).Value())
+			if numCpus < 1 {
+				e2eskipper.Skipf("insufficient CPU available for kubelet restart test with missing pod sandbox")
+			}
+
+			ginkgo.By("creating a pod on node")
+			podCountRestartAlways := 1
+			pods := newTestPods(podCountRestartAlways, false, imageutils.GetE2EImage(imageutils.BusyBox), "restart-kubelet-test2")
+			for _, pod := range pods {
+				pod.Spec.Containers[0].Command = []string{"sleep", "3d"}
+			}
+			createBatchPodWithRateControl(f, pods, podCreationInterval)
+			defer deletePodsSync(f, pods)
+
+			completedPods := waitForPods(f, podCountRestartAlways, startTimeout)
+			if len(completedPods) < podCountRestartAlways {
+				framework.Failf("Failed to run sufficient pods, got %d but expected %d", len(completedPods), podCount)
+			}
+
+			ginkgo.By("removing a pod sandbox's '/pause' container")
+
+			// retrieve pods on the node
+			crictlCmd := fmt.Sprintf("sudo crictl --runtime-endpoint %s", containerRuntimeEndpoint)
+			getPodsCmd := fmt.Sprintf("%s pods -q", crictlCmd)
+			stdout, err := exec.Command("sudo", "bash", "-c", getPodsCmd).CombinedOutput()
+			if err != nil {
+				framework.Failf("Failed to get pods using crictl command: %q, err: %v, stdout: %q", getPodsCmd, err, string(stdout))
+			}
+
+			// find a pod sandbox ID
+			var podSandboxID string
+			scanner := bufio.NewScanner(bytes.NewReader(stdout))
+			for scanner.Scan() {
+				line := scanner.Text()
+				podSandboxID = strings.TrimSpace(line)
+				if podSandboxID != "" {
+					break
+				}
+			}
+			if podSandboxID == "" {
+				framework.Failf("Failed to find a pod sandbox using crictl command: %q, stdout: %s", getPodsCmd, string(stdout))
+			}
+
+			// Removing container task is for removing container from containerd later
+			// We will ignore error for removing container task, because the task might already be gone
+			ctrCmd := fmt.Sprintf("sudo ctr -n k8s.io --timeout 10s --address %s", strings.TrimPrefix(containerRuntimeEndpoint, "unix://"))
+			removePodSandboxTaskCmd := fmt.Sprintf("%s t rm -f %s", ctrCmd, podSandboxID)
+			stdout, err = exec.Command("sudo", "bash", "-c", removePodSandboxTaskCmd).CombinedOutput()
+			if err != nil {
+				framework.Logf("Unable to remove the pod sandbox's /pause task using ctr command: %q, err: %v, stdout: %q", removePodSandboxTaskCmd, err, string(stdout))
+			}
+
+			// Removing the pod sandbox's /pause container
+			removePodSandboxContainerCmd := fmt.Sprintf("%s c rm %s", ctrCmd, podSandboxID)
+			stdout, err = exec.Command("sudo", "bash", "-c", removePodSandboxContainerCmd).CombinedOutput()
+			if err != nil {
+				framework.Failf("Failed to remove pod sandbox's /pause container using ctr command: %q, err: %v, stdout: %q", removePodSandboxContainerCmd, err, string(stdout))
+			}
+
+			ginkgo.By("killing kubelet")
+			// We want to kill the kubelet rather than a graceful restart
+			startKubelet := stopKubelet()
+
+			ginkgo.By("starting kubelet")
+			startKubelet()
+
+			ginkgo.By("verifying restartAlways pods stay running")
+			postRestartRunningPods := waitForPods(f, podCountRestartAlways, recoverTimeout)
+			if len(postRestartRunningPods) < podCountRestartAlways {
+				framework.Failf("less pods are running after node restart, got %d but expected %d", len(postRestartRunningPods), podCountRestartAlways)
 			}
 		})
 	})


### PR DESCRIPTION
Signed-off-by: Xinfeng Liu <Xinfeng.Liu@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This PR prevents kubelet container manager from aborting when pod
sandbox is missing. It's possible that the pod sandbox (aka. /pause
container) might be deleted outside CRI, missing pod sandbox should
not stop kubelet from starting.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #98218 and https://github.com/kubernetes/kubelet/issues/21

#### Special notes for your reviewer:
This PR is carried over from https://github.com/kubernetes/kubernetes/pull/98225 since the original author is not active on his/her PR.

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fixed an issue that causes kubelet fail to start if a pod sandbox container is missing.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
NONE
```
