### PR TITLE
kube-proxy: only set route_localnet if required

### DIFF
--- a/pkg/proxy/util/utils_test.go
+++ b/pkg/proxy/util/utils_test.go
@@ -1401,3 +1401,68 @@ func TestAddressSet(t *testing.T) {
 		}
 	}
 }
+
+func TestContainsIPv4Loopback(t *testing.T) {
+	tests := []struct {
+		name        string
+		cidrStrings []string
+		want        bool
+	}{
+		{
+			name: "empty",
+			want: true,
+		},
+		{
+			name:        "all zeros ipv4",
+			cidrStrings: []string{"224.0.0.0/24", "192.168.0.0/16", "fd00:1:d::/64", "0.0.0.0/0"},
+			want:        true,
+		},
+		{
+			name:        "all zeros ipv4 and invalid cidr",
+			cidrStrings: []string{"invalid.cidr", "192.168.0.0/16", "fd00:1:d::/64", "0.0.0.0/0"},
+			want:        true,
+		},
+		{
+			name:        "all zeros ipv6", // interpret all zeros equal for IPv4 and IPv6 as Golang stdlib
+			cidrStrings: []string{"224.0.0.0/24", "192.168.0.0/16", "fd00:1:d::/64", "::/0"},
+			want:        true,
+		},
+		{
+			name:        "ipv4 loopback",
+			cidrStrings: []string{"224.0.0.0/24", "192.168.0.0/16", "fd00:1:d::/64", "127.0.0.0/8"},
+			want:        true,
+		},
+		{
+			name:        "ipv6 loopback",
+			cidrStrings: []string{"224.0.0.0/24", "192.168.0.0/16", "fd00:1:d::/64", "::1/128"},
+			want:        false,
+		},
+		{
+			name:        "ipv4 loopback smaller range",
+			cidrStrings: []string{"224.0.0.0/24", "192.168.0.0/16", "fd00:1:d::/64", "127.0.2.0/28"},
+			want:        true,
+		},
+		{
+			name:        "ipv4 loopback within larger range",
+			cidrStrings: []string{"224.0.0.0/24", "192.168.0.0/16", "fd00:1:d::/64", "64.0.0.0/2"},
+			want:        true,
+		},
+		{
+			name:        "non loop loopback",
+			cidrStrings: []string{"128.0.2.0/28", "224.0.0.0/24", "192.168.0.0/16", "fd00:1:d::/64"},
+			want:        false,
+		},
+		{
+			name:        "invalid cidr",
+			cidrStrings: []string{"invalid.ip/invalid.mask"},
+			want:        false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ContainsIPv4Loopback(tt.cidrStrings); got != tt.want {
+				t.Errorf("ContainLoopback() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
kube-proxy sets the sysctl net.ipv4.conf.all.route_localnet=1
so NodePort services can be accessed on the loopback addresses in
IPv4, but this may present security issues.

Leverage the --nodeport-addresses flag to opt-out of this feature,
if the list is not empty and none of the IP ranges contains a
loopback address this sysctl is not set.

In addition, add a warning to inform users about this behavior.

/kind cleanup

```release-note
kube-proxy doesn't set the sysctl net.ipv4.conf.all.route_localnet=1 if no IPv4 loopback address is selected by the nodePortAddresses configuration parameter.
```

Fixes: #106976