### PR TITLE
Fix regression pruning array fields with x-kubernetes-preserve-unknown-fields: true

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/pruning/algorithm.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/pruning/algorithm.go
@@ -189,7 +189,7 @@ func skipPrune(x interface{}, s *structuralschema.Structural, opts *PruneOptions
 	case []interface{}:
 		for i, v := range x {
 			opts.appendIndex(i)
-			prune(v, s.Items, opts)
+			skipPrune(v, s.Items, opts)
 			opts.parentPath = opts.parentPath[:origPathLen]
 		}
 	default:

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/pruning/algorithm_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/pruning/algorithm_test.go
@@ -88,7 +88,8 @@ func TestPrune(t *testing.T) {
      "unspecified": "bar",
      "unspecifiedObject": {"unspecified": "bar"},
      "pruning": {"unspecified": "bar"},
-     "preserving": {"unspecified": "bar"}
+     "preserving": {"unspecified": "bar"},
+     "preservingUnknownType": [{"foo":true},{"bar":true}]
   },
   "preservingAdditionalPropertiesNotInheritingXPreserveUnknownFields": {
      "foo": {
@@ -127,6 +128,10 @@ func TestPrune(t *testing.T) {
 					Properties: map[string]structuralschema.Structural{
 						"preserving": {
 							Generic:    structuralschema.Generic{Type: "object"},
+							Extensions: structuralschema.Extensions{XPreserveUnknownFields: true},
+						},
+						"preservingUnknownType": {
+							Generic:    structuralschema.Generic{Type: ""},
 							Extensions: structuralschema.Extensions{XPreserveUnknownFields: true},
 						},
 						"pruning": {
@@ -177,7 +182,8 @@ func TestPrune(t *testing.T) {
      "unspecified": "bar",
      "unspecifiedObject": {"unspecified": "bar"},
      "pruning": {},
-     "preserving": {"unspecified": "bar"}
+     "preserving": {"unspecified": "bar"},
+     "preservingUnknownType": [{"foo":true},{"bar":true}]
   },
   "preservingAdditionalPropertiesNotInheritingXPreserveUnknownFields": {
      "foo": {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind regression
/priority critical-urgent

#### What this PR does / why we need it:

Fixes a regression in 1.23.0 - 1.23.2 pruning array fields that set `x-kubernetes-preserve-unknown-fields: true` on the array and not on the individual item schema.

As a mitigation before 1.23.3, impacted CRDs can also set `x-kubernetes-preserve-unknown-fields: true` on the `items` schema to continue preserving unknown fields in the individual items.

#### Which issue(s) this PR fixes:

xref #107690

#### Special notes for your reviewer:

Typo I missed in review of https://github.com/kubernetes/kubernetes/pull/105916/files#diff-a97242d1e6da30fe4a288e15760e5b4cc13cd34197ed83ffda11762458061b2fR192 that switched a recursive `skipPrune` call to `prune`

#### Does this PR introduce a user-facing change?
```release-note
Fixes a regression in 1.23 that incorrectly pruned data from array items of a custom resource that set `x-kubernetes-preserve-unknown-fields: true`
```

/sig api-machinery
/cc @apelisse @kevindelgado 