### PR TITLE
Automated cherry pick of #107688: Fix regression pruning array fields with

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/pruning/algorithm.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/pruning/algorithm.go
@@ -189,7 +189,7 @@ func skipPrune(x interface{}, s *structuralschema.Structural, opts *PruneOptions
 	case []interface{}:
 		for i, v := range x {
 			opts.appendIndex(i)
-			prune(v, s.Items, opts)
+			skipPrune(v, s.Items, opts)
 			opts.parentPath = opts.parentPath[:origPathLen]
 		}
 	default:

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/pruning/algorithm_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/pruning/algorithm_test.go
@@ -88,7 +88,8 @@ func TestPrune(t *testing.T) {
      "unspecified": "bar",
      "unspecifiedObject": {"unspecified": "bar"},
      "pruning": {"unspecified": "bar"},
-     "preserving": {"unspecified": "bar"}
+     "preserving": {"unspecified": "bar"},
+     "preservingUnknownType": [{"foo":true},{"bar":true}]
   },
   "preservingAdditionalPropertiesNotInheritingXPreserveUnknownFields": {
      "foo": {
@@ -127,6 +128,10 @@ func TestPrune(t *testing.T) {
 					Properties: map[string]structuralschema.Structural{
 						"preserving": {
 							Generic:    structuralschema.Generic{Type: "object"},
+							Extensions: structuralschema.Extensions{XPreserveUnknownFields: true},
+						},
+						"preservingUnknownType": {
+							Generic:    structuralschema.Generic{Type: ""},
 							Extensions: structuralschema.Extensions{XPreserveUnknownFields: true},
 						},
 						"pruning": {
@@ -177,7 +182,8 @@ func TestPrune(t *testing.T) {
      "unspecified": "bar",
      "unspecifiedObject": {"unspecified": "bar"},
      "pruning": {},
-     "preserving": {"unspecified": "bar"}
+     "preserving": {"unspecified": "bar"},
+     "preservingUnknownType": [{"foo":true},{"bar":true}]
   },
   "preservingAdditionalPropertiesNotInheritingXPreserveUnknownFields": {
      "foo": {


### PR DESCRIPTION
Cherry pick of #107688 on release-1.23.

#107688: Fix regression pruning array fields with

fixes #107690

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
Fixes a regression in 1.23 that incorrectly pruned data from array items of a custom resource that set `x-kubernetes-preserve-unknown-fields: true`
```