### PR TITLE
kubelet: fix static pods not restarting in certain cases

### DIFF
--- a/pkg/kubelet/pod_workers.go
+++ b/pkg/kubelet/pod_workers.go
@@ -580,6 +580,7 @@ func (p *podWorkers) UpdatePod(options UpdatePodOptions) {
 						syncedAt:           now,
 						startedTerminating: true,
 						finished:           true,
+						fullname:           kubecontainer.GetPodFullName(pod),
 					}
 				}
 			}


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
In OpenShift CI, we are seeing certain instances where a static pod does not get restarted. There are two locations within the pod_workers.go module where the podSyncStatus is constructed. One construction location is missing the fullname. 

#### Which issue(s) this PR fixes:
Fixes [PR#104743](https://github.com/kubernetes/kubernetes/pull/104743)

#### Special notes for your reviewer:
cc @gjkim42 

#### Does this PR introduce a user-facing change?
```release-note
Fixes a 1.23 regression with static pod add and removes restarts in certain cases.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs
NONE
```

Versions: 1.22 and 1.23