### PR TITLE
Nested decoders handle strict decoding errors

### DIFF
--- a/pkg/scheduler/apis/config/scheme/scheme_test.go
+++ b/pkg/scheduler/apis/config/scheme/scheme_test.go
@@ -263,7 +263,7 @@ profiles:
           - Score: 2
             Utilization: 1
 `),
-			wantErr: `decoding .profiles[0].pluginConfig[0]: decoding args for plugin NodeResourcesFit: strict decoding error: unknown field "scoringStrategy.requestedToCapacityRatio.shape[0].Score", unknown field "scoringStrategy.requestedToCapacityRatio.shape[0].Utilization"`,
+			wantErr: `strict decoding error: decoding .profiles[0].pluginConfig[0]: strict decoding error: decoding args for plugin NodeResourcesFit: strict decoding error: unknown field "scoringStrategy.requestedToCapacityRatio.shape[0].Score", unknown field "scoringStrategy.requestedToCapacityRatio.shape[0].Utilization"`,
 		},
 		{
 			name: "v1beta2 NodeResourcesFitArgs resources encoding is strict",
@@ -279,7 +279,7 @@ profiles:
         - Name: cpu
           Weight: 1
 `),
-			wantErr: `decoding .profiles[0].pluginConfig[0]: decoding args for plugin NodeResourcesFit: strict decoding error: unknown field "scoringStrategy.resources[0].Name", unknown field "scoringStrategy.resources[0].Weight"`,
+			wantErr: `strict decoding error: decoding .profiles[0].pluginConfig[0]: strict decoding error: decoding args for plugin NodeResourcesFit: strict decoding error: unknown field "scoringStrategy.resources[0].Name", unknown field "scoringStrategy.resources[0].Weight"`,
 		},
 		{
 			name: "out-of-tree plugin args",
@@ -604,7 +604,7 @@ profiles:
           - Score: 2
             Utilization: 1
 `),
-			wantErr: `decoding .profiles[0].pluginConfig[0]: decoding args for plugin NodeResourcesFit: strict decoding error: unknown field "scoringStrategy.requestedToCapacityRatio.shape[0].Score", unknown field "scoringStrategy.requestedToCapacityRatio.shape[0].Utilization"`,
+			wantErr: `strict decoding error: decoding .profiles[0].pluginConfig[0]: strict decoding error: decoding args for plugin NodeResourcesFit: strict decoding error: unknown field "scoringStrategy.requestedToCapacityRatio.shape[0].Score", unknown field "scoringStrategy.requestedToCapacityRatio.shape[0].Utilization"`,
 		},
 		{
 			name: "v1beta3 NodeResourcesFitArgs resources encoding is strict",
@@ -620,7 +620,7 @@ profiles:
         - Name: cpu
           Weight: 1
 `),
-			wantErr: `decoding .profiles[0].pluginConfig[0]: decoding args for plugin NodeResourcesFit: strict decoding error: unknown field "scoringStrategy.resources[0].Name", unknown field "scoringStrategy.resources[0].Weight"`,
+			wantErr: `strict decoding error: decoding .profiles[0].pluginConfig[0]: strict decoding error: decoding args for plugin NodeResourcesFit: strict decoding error: unknown field "scoringStrategy.resources[0].Name", unknown field "scoringStrategy.resources[0].Weight"`,
 		},
 		{
 			name: "out-of-tree plugin args",

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/interfaces.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/interfaces.go
@@ -207,6 +207,12 @@ type NestedObjectEncoder interface {
 
 // NestedObjectDecoder is an optional interface that objects may implement to be given
 // an opportunity to decode any nested Objects / RawExtensions during serialization.
+// It is possible for DecodeNestedObjects to return a non-nil error but for the decoding
+// to have succeeded in the case of strict decoding errors (e.g. unknown/duplicate fields).
+// As such it is important for callers of DecodeNestedObjects to check to confirm whether
+// an error is a runtime.StrictDecodingError before short circuiting.
+// Similarly, implementations of DecodeNestedObjects should ensure that a runtime.StrictDecodingError
+// is only returned when the rest of decoding has succeeded.
 type NestedObjectDecoder interface {
 	DecodeNestedObjects(d Decoder) error
 }

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/versioning/versioning_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/versioning/versioning_test.go
@@ -82,6 +82,23 @@ func TestNestedDecode(t *testing.T) {
 	}
 }
 
+func TestNestedDecodeStrictDecodingError(t *testing.T) {
+	strictErr := runtime.NewStrictDecodingError([]error{fmt.Errorf("duplicate field")})
+	n := &testNestedDecodable{nestedErr: strictErr}
+	decoder := &mockSerializer{obj: n}
+	codec := NewCodec(nil, decoder, nil, nil, nil, nil, nil, nil, "TestNestedDecode")
+	o, _, err := codec.Decode([]byte(`{}`), nil, n)
+	if strictErr, ok := runtime.AsStrictDecodingError(err); !ok || err != strictErr {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if o != n {
+		t.Errorf("did not successfully decode with strict decoding error: %v", o)
+	}
+	if !n.nestedCalled {
+		t.Errorf("did not invoke nested decoder")
+	}
+}
+
 func TestNestedEncode(t *testing.T) {
 	n := &testNestedDecodable{nestedErr: fmt.Errorf("unable to decode")}
 	n2 := &testNestedDecodable{nestedErr: fmt.Errorf("unable to decode 2")}

--- a/staging/src/k8s.io/kube-scheduler/config/v1beta2/types.go
+++ b/staging/src/k8s.io/kube-scheduler/config/v1beta2/types.go
@@ -100,14 +100,23 @@ type KubeSchedulerConfiguration struct {
 
 // DecodeNestedObjects decodes plugin args for known types.
 func (c *KubeSchedulerConfiguration) DecodeNestedObjects(d runtime.Decoder) error {
+	var strictDecodingErrs []error
 	for i := range c.Profiles {
 		prof := &c.Profiles[i]
 		for j := range prof.PluginConfig {
 			err := prof.PluginConfig[j].decodeNestedObjects(d)
 			if err != nil {
-				return fmt.Errorf("decoding .profiles[%d].pluginConfig[%d]: %w", i, j, err)
+				decodingErr := fmt.Errorf("decoding .profiles[%d].pluginConfig[%d]: %w", i, j, err)
+				if runtime.IsStrictDecodingError(err) {
+					strictDecodingErrs = append(strictDecodingErrs, decodingErr)
+				} else {
+					return decodingErr
+				}
 			}
 		}
+	}
+	if len(strictDecodingErrs) > 0 {
+		return runtime.NewStrictDecodingError(strictDecodingErrs)
 	}
 	return nil
 }
@@ -237,15 +246,21 @@ func (c *PluginConfig) decodeNestedObjects(d runtime.Decoder) error {
 		return nil
 	}
 
+	var strictDecodingErr error
 	obj, parsedGvk, err := d.Decode(c.Args.Raw, &gvk, nil)
 	if err != nil {
-		return fmt.Errorf("decoding args for plugin %s: %w", c.Name, err)
+		decodingArgsErr := fmt.Errorf("decoding args for plugin %s: %w", c.Name, err)
+		if obj != nil && runtime.IsStrictDecodingError(err) {
+			strictDecodingErr = runtime.NewStrictDecodingError([]error{decodingArgsErr})
+		} else {
+			return decodingArgsErr
+		}
 	}
 	if parsedGvk.GroupKind() != gvk.GroupKind() {
 		return fmt.Errorf("args for plugin %s were not of type %s, got %s", c.Name, gvk.GroupKind(), parsedGvk.GroupKind())
 	}
 	c.Args.Object = obj
-	return nil
+	return strictDecodingErr
 }
 
 func (c *PluginConfig) encodeNestedObjects(e runtime.Encoder) error {

--- a/staging/src/k8s.io/kube-scheduler/config/v1beta3/types.go
+++ b/staging/src/k8s.io/kube-scheduler/config/v1beta3/types.go
@@ -93,14 +93,23 @@ type KubeSchedulerConfiguration struct {
 
 // DecodeNestedObjects decodes plugin args for known types.
 func (c *KubeSchedulerConfiguration) DecodeNestedObjects(d runtime.Decoder) error {
+	var strictDecodingErrs []error
 	for i := range c.Profiles {
 		prof := &c.Profiles[i]
 		for j := range prof.PluginConfig {
 			err := prof.PluginConfig[j].decodeNestedObjects(d)
 			if err != nil {
-				return fmt.Errorf("decoding .profiles[%d].pluginConfig[%d]: %w", i, j, err)
+				decodingErr := fmt.Errorf("decoding .profiles[%d].pluginConfig[%d]: %w", i, j, err)
+				if runtime.IsStrictDecodingError(err) {
+					strictDecodingErrs = append(strictDecodingErrs, decodingErr)
+				} else {
+					return decodingErr
+				}
 			}
 		}
+	}
+	if len(strictDecodingErrs) > 0 {
+		return runtime.NewStrictDecodingError(strictDecodingErrs)
 	}
 	return nil
 }
@@ -245,15 +254,21 @@ func (c *PluginConfig) decodeNestedObjects(d runtime.Decoder) error {
 		return nil
 	}
 
+	var strictDecodingErr error
 	obj, parsedGvk, err := d.Decode(c.Args.Raw, &gvk, nil)
 	if err != nil {
-		return fmt.Errorf("decoding args for plugin %s: %w", c.Name, err)
+		decodingArgsErr := fmt.Errorf("decoding args for plugin %s: %w", c.Name, err)
+		if obj != nil && runtime.IsStrictDecodingError(err) {
+			strictDecodingErr = runtime.NewStrictDecodingError([]error{decodingArgsErr})
+		} else {
+			return decodingArgsErr
+		}
 	}
 	if parsedGvk.GroupKind() != gvk.GroupKind() {
 		return fmt.Errorf("args for plugin %s were not of type %s, got %s", c.Name, gvk.GroupKind(), parsedGvk.GroupKind())
 	}
 	c.Args.Object = obj
-	return nil
+	return strictDecodingErr
 }
 
 func (c *PluginConfig) encodeNestedObjects(e runtime.Encoder) error {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
* Adds docs to the NestedObjectDecoder about handling strict decoding errors
* Updates all in-tree NestedObjectDecoder implementations and callers to check for strict decoding errors before short-circuiting on error

#### Which issue(s) this PR fixes:
Fixes #107545 
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

#### Special notes for your reviewer:
I will open issues against known out-of-tree usages of NestedObjectDecoders (openshift) once we confirm this is the right approach

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- [KEP]: https://github.com/kubernetes/enhancements/issues/2885

```
