### PR TITLE
[PodSecurity] Deduplicate errors between baseline & restricted checks

### DIFF
--- a/staging/src/k8s.io/pod-security-admission/policy/check_capabilities_baseline.go
+++ b/staging/src/k8s.io/pod-security-admission/policy/check_capabilities_baseline.go
@@ -41,11 +41,13 @@ func init() {
 	addCheck(CheckCapabilitiesBaseline)
 }
 
+const checkCapabilitiesBaselineID CheckID = "capabilities_baseline"
+
 // CheckCapabilitiesBaseline returns a baseline level check
 // that limits the capabilities that can be added in 1.0+
 func CheckCapabilitiesBaseline() Check {
 	return Check{
-		ID:    "capabilities_baseline",
+		ID:    checkCapabilitiesBaselineID,
 		Level: api.LevelBaseline,
 		Versions: []VersionedCheck{
 			{

--- a/staging/src/k8s.io/pod-security-admission/policy/check_capabilities_restricted.go
+++ b/staging/src/k8s.io/pod-security-admission/policy/check_capabilities_restricted.go
@@ -62,8 +62,9 @@ func CheckCapabilitiesRestricted() Check {
 		Level: api.LevelRestricted,
 		Versions: []VersionedCheck{
 			{
-				MinimumVersion: api.MajorMinorVersion(1, 22),
-				CheckPod:       capabilitiesRestricted_1_22,
+				MinimumVersion:   api.MajorMinorVersion(1, 22),
+				CheckPod:         capabilitiesRestricted_1_22,
+				OverrideCheckIDs: []CheckID{checkCapabilitiesBaselineID},
 			},
 		},
 	}

--- a/staging/src/k8s.io/pod-security-admission/policy/check_hostPathVolumes.go
+++ b/staging/src/k8s.io/pod-security-admission/policy/check_hostPathVolumes.go
@@ -38,11 +38,13 @@ func init() {
 	addCheck(CheckHostPathVolumes)
 }
 
+const checkHostPathVolumesID CheckID = "hostPathVolumes"
+
 // CheckHostPathVolumes returns a baseline level check
 // that requires hostPath=undefined/null in 1.0+
 func CheckHostPathVolumes() Check {
 	return Check{
-		ID:    "hostPathVolumes",
+		ID:    checkHostPathVolumesID,
 		Level: api.LevelBaseline,
 		Versions: []VersionedCheck{
 			{

--- a/staging/src/k8s.io/pod-security-admission/policy/check_procMount.go
+++ b/staging/src/k8s.io/pod-security-admission/policy/check_procMount.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
-	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/pod-security-admission/api"
@@ -71,7 +70,7 @@ func procMount_1_0(podMetadata *metav1.ObjectMeta, podSpec *corev1.PodSpec) Chec
 			return
 		}
 		// check if the value of the proc mount type is valid.
-		if *container.SecurityContext.ProcMount != v1.DefaultProcMount {
+		if *container.SecurityContext.ProcMount != corev1.DefaultProcMount {
 			badContainers = append(badContainers, container.Name)
 			forbiddenProcMountTypes.Insert(string(*container.SecurityContext.ProcMount))
 		}

--- a/staging/src/k8s.io/pod-security-admission/policy/check_restrictedVolumes.go
+++ b/staging/src/k8s.io/pod-security-admission/policy/check_restrictedVolumes.go
@@ -76,8 +76,9 @@ func CheckRestrictedVolumes() Check {
 		Level: api.LevelRestricted,
 		Versions: []VersionedCheck{
 			{
-				MinimumVersion: api.MajorMinorVersion(1, 0),
-				CheckPod:       restrictedVolumes_1_0,
+				MinimumVersion:   api.MajorMinorVersion(1, 0),
+				CheckPod:         restrictedVolumes_1_0,
+				OverrideCheckIDs: []CheckID{checkHostPathVolumesID},
 			},
 		},
 	}

--- a/staging/src/k8s.io/pod-security-admission/policy/check_seccompProfile_baseline.go
+++ b/staging/src/k8s.io/pod-security-admission/policy/check_seccompProfile_baseline.go
@@ -49,6 +49,8 @@ spec.initContainers[*].securityContext.seccompProfile.type
 const (
 	annotationKeyPod             = "seccomp.security.alpha.kubernetes.io/pod"
 	annotationKeyContainerPrefix = "container.seccomp.security.alpha.kubernetes.io/"
+
+	checkSeccompBaselineID CheckID = "seccompProfile_baseline"
 )
 
 func init() {
@@ -57,7 +59,7 @@ func init() {
 
 func CheckSeccompBaseline() Check {
 	return Check{
-		ID:    "seccompProfile_baseline",
+		ID:    checkSeccompBaselineID,
 		Level: api.LevelBaseline,
 		Versions: []VersionedCheck{
 			{

--- a/staging/src/k8s.io/pod-security-admission/policy/check_seccompProfile_restricted.go
+++ b/staging/src/k8s.io/pod-security-admission/policy/check_seccompProfile_restricted.go
@@ -51,8 +51,9 @@ func CheckSeccompProfileRestricted() Check {
 		Level: api.LevelRestricted,
 		Versions: []VersionedCheck{
 			{
-				MinimumVersion: api.MajorMinorVersion(1, 19),
-				CheckPod:       seccompProfileRestricted_1_19,
+				MinimumVersion:   api.MajorMinorVersion(1, 19),
+				CheckPod:         seccompProfileRestricted_1_19,
+				OverrideCheckIDs: []CheckID{checkSeccompBaselineID},
 			},
 		},
 	}

--- a/staging/src/k8s.io/pod-security-admission/policy/checks.go
+++ b/staging/src/k8s.io/pod-security-admission/policy/checks.go
@@ -26,7 +26,7 @@ import (
 
 type Check struct {
 	// ID is the unique ID of the check.
-	ID string
+	ID CheckID
 	// Level is the policy level this check belongs to.
 	// Must be Baseline or Restricted.
 	// Baseline checks are evaluated for baseline and restricted namespaces.
@@ -45,9 +45,14 @@ type VersionedCheck struct {
 	MinimumVersion api.Version
 	// CheckPod determines if the pod is allowed.
 	CheckPod CheckPodFn
+	// OverrideCheckIDs is an optional list of checks that should be skipped when this check is run.
+	// Overrides may only be set on restricted checks, and may only override baseline checks.
+	OverrideCheckIDs []CheckID
 }
 
 type CheckPodFn func(*metav1.ObjectMeta, *corev1.PodSpec) CheckResult
+
+type CheckID string
 
 // CheckResult contains the result of checking a pod and indicates whether the pod is allowed,
 // and if not, why it was forbidden.

--- a/staging/src/k8s.io/pod-security-admission/policy/checks_test.go
+++ b/staging/src/k8s.io/pod-security-admission/policy/checks_test.go
@@ -1,0 +1,43 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package policy
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestValidChecks ensures that all registered checks are valid.
+func TestValidChecks(t *testing.T) {
+	allChecks := append(DefaultChecks(), ExperimentalChecks()...)
+
+	assert.NoError(t, validateChecks(allChecks))
+
+	// Ensure that all overrides map to existing checks.
+	allIDs := map[CheckID]bool{}
+	for _, check := range allChecks {
+		allIDs[check.ID] = true
+	}
+	for _, check := range allChecks {
+		for _, c := range check.Versions {
+			for _, override := range c.OverrideCheckIDs {
+				assert.Contains(t, allIDs, override, "check %s overrides non-existant check %s", check.ID, override)
+			}
+		}
+	}
+}

--- a/staging/src/k8s.io/pod-security-admission/policy/checks_test.go
+++ b/staging/src/k8s.io/pod-security-admission/policy/checks_test.go
@@ -36,7 +36,7 @@ func TestValidChecks(t *testing.T) {
 	for _, check := range allChecks {
 		for _, c := range check.Versions {
 			for _, override := range c.OverrideCheckIDs {
-				assert.Contains(t, allIDs, override, "check %s overrides non-existant check %s", check.ID, override)
+				assert.Contains(t, allIDs, override, "check %s overrides non-existent check %s", check.ID, override)
 			}
 		}
 	}

--- a/staging/src/k8s.io/pod-security-admission/policy/registry.go
+++ b/staging/src/k8s.io/pod-security-admission/policy/registry.go
@@ -33,7 +33,7 @@ type Evaluator interface {
 
 // checkRegistry provides a default implementation of an Evaluator.
 type checkRegistry struct {
-	// The checks are a map policy verison to a slice of checks registered for that version.
+	// The checks are a map policy version to a slice of checks registered for that version.
 	baselineChecks, restrictedChecks map[api.Version][]CheckPodFn
 	// maxVersion is the maximum version that is cached, guaranteed to be at least
 	// the max MinimumVersion of all registered checks.

--- a/staging/src/k8s.io/pod-security-admission/test/fixtures.go
+++ b/staging/src/k8s.io/pod-security-admission/test/fixtures.go
@@ -99,7 +99,7 @@ var fixtureGenerators = map[fixtureKey]fixtureGenerator{}
 type fixtureKey struct {
 	version api.Version
 	level   api.Level
-	check   string
+	check   policy.CheckID
 }
 
 // fixtureGenerator holds generators for valid and invalid fixtures.
@@ -184,7 +184,7 @@ func getFixtures(key fixtureKey) (fixtureData, error) {
 				fail: generator.generateFail(validPodForLevel.DeepCopy()),
 			}
 			if len(data.expectErrorSubstring) == 0 {
-				data.expectErrorSubstring = key.check
+				data.expectErrorSubstring = string(key.check)
 			}
 			if len(data.fail) == 0 {
 				return fixtureData{}, fmt.Errorf("generateFail for %#v must return at least one pod", key)

--- a/staging/src/k8s.io/pod-security-admission/test/fixtures_capabilities_baseline.go
+++ b/staging/src/k8s.io/pod-security-admission/test/fixtures_capabilities_baseline.go
@@ -47,7 +47,7 @@ func ensureCapabilities(p *corev1.Pod) *corev1.Pod {
 
 func init() {
 	fixtureData_1_0 := fixtureGenerator{
-		expectErrorSubstring: "non-default capabilities",
+		expectErrorSubstring: "capabilities",
 		generatePass: func(p *corev1.Pod) []*corev1.Pod {
 			// don't generate fixtures if minimal valid pod drops ALL
 			if p.Spec.Containers[0].SecurityContext != nil && p.Spec.Containers[0].SecurityContext.Capabilities != nil {

--- a/staging/src/k8s.io/pod-security-admission/test/fixtures_hostPathVolumes.go
+++ b/staging/src/k8s.io/pod-security-admission/test/fixtures_hostPathVolumes.go
@@ -28,7 +28,7 @@ TODO: include field paths in reflect-based unit test
 func init() {
 
 	fixtureData_1_0 := fixtureGenerator{
-		expectErrorSubstring: "hostPath volumes",
+		expectErrorSubstring: "hostPath",
 		generatePass: func(p *corev1.Pod) []*corev1.Pod {
 			// minimal valid pod already captures all valid combinations
 			return nil

--- a/staging/src/k8s.io/pod-security-admission/test/fixtures_test.go
+++ b/staging/src/k8s.io/pod-security-admission/test/fixtures_test.go
@@ -82,10 +82,10 @@ func TestFixtures(t *testing.T) {
 				}
 
 				for i, pod := range checkData.pass {
-					expectedFiles.Insert(testFixtureFile(t, passDir, fmt.Sprintf("%s%d", strings.ToLower(checkID), i), pod))
+					expectedFiles.Insert(testFixtureFile(t, passDir, fmt.Sprintf("%s%d", strings.ToLower(string(checkID)), i), pod))
 				}
 				for i, pod := range checkData.fail {
-					expectedFiles.Insert(testFixtureFile(t, failDir, fmt.Sprintf("%s%d", strings.ToLower(checkID), i), pod))
+					expectedFiles.Insert(testFixtureFile(t, failDir, fmt.Sprintf("%s%d", strings.ToLower(string(checkID)), i), pod))
 				}
 			}
 		}

--- a/staging/src/k8s.io/pod-security-admission/test/run.go
+++ b/staging/src/k8s.io/pod-security-admission/test/run.go
@@ -73,8 +73,8 @@ func toJSON(pod *corev1.Pod) string {
 // checksForLevelAndVersion returns the set of check IDs that apply when evaluating the given level and version.
 // checks are assumed to be well-formed and valid to pass to policy.NewEvaluator().
 // level must be api.LevelRestricted or api.LevelBaseline
-func checksForLevelAndVersion(checks []policy.Check, level api.Level, version api.Version) ([]string, error) {
-	retval := []string{}
+func checksForLevelAndVersion(checks []policy.Check, level api.Level, version api.Version) ([]policy.CheckID, error) {
+	retval := []policy.CheckID{}
 	for _, check := range checks {
 		if !version.Older(check.Versions[0].MinimumVersion) && (level == check.Level || level == api.LevelRestricted) {
 			retval = append(retval, check.ID)
@@ -318,7 +318,7 @@ func Run(t *testing.T, opts Options) {
 					t.Fatal(err)
 				}
 
-				t.Run(ns+"_pass_"+checkID, func(t *testing.T) {
+				t.Run(ns+"_pass_"+string(checkID), func(t *testing.T) {
 					for i, pod := range checkData.pass {
 						createPod(t, i, pod, true, "")
 						createController(t, i, pod, true, "")
@@ -332,7 +332,7 @@ func Run(t *testing.T, opts Options) {
 						disabledRequiredFeatures = append(disabledRequiredFeatures, f)
 					}
 				}
-				t.Run(ns+"_fail_"+checkID, func(t *testing.T) {
+				t.Run(ns+"_fail_"+string(checkID), func(t *testing.T) {
 					if len(disabledRequiredFeatures) > 0 {
 						t.Skipf("features required for failure cases are disabled: %v", disabledRequiredFeatures)
 					}


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Allow restricted checks to override (supercede) baseline checks, and add overrides for:

- restricted volume types overrides the baseline host path check
- restricted capabilities override baseline capabilities
- restricted seccomp overrides baseline seccomp

The corresponding baseline fixtures needed to be made slightly more generic to accept both the baseline & restricted versions of the error responses.

Several other cleanups or included as well:
- Add `CheckID` type alias, to make mapped strings more self-documenting
- Sort checks alphabetically by ID, with baseline checks coming first to ensure stable error messages

#### Which issue(s) this PR fixes:
Fixes #106129

#### Special notes for your reviewer:

This PR is offered as an alternative solution to the approach taken in https://github.com/kubernetes/kubernetes/pull/107117. This version is a larger change, but has stronger guarantees that the overridden checks are only skipped when the overriding check is present. This also allows for versioned overrides, in case a baseline check predates an overriding restricted check.

#### Does this PR introduce a user-facing change?
Yes, but not worthy of a release note.
```release-note
NONE
```

/sig auth
