### PR TITLE
Discard null values in complex objects in strategic patch

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/util/strategicpatch/patch.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/strategicpatch/patch.go
@@ -1331,10 +1331,9 @@ func mergeMap(original, patch map[string]interface{}, schema LookupPatchMeta, me
 			if !isDeleteList {
 				// If it's not in the original document, just take the patch value.
 				if mergeOptions.IgnoreUnmatchedNulls {
-					original[k] = discardNullValuesFromPatch(patchV)
-				} else {
-					original[k] = patchV
+					discardNullValuesFromPatch(patchV)
 				}
+				original[k] = patchV
 			}
 			continue
 		}
@@ -1344,10 +1343,9 @@ func mergeMap(original, patch map[string]interface{}, schema LookupPatchMeta, me
 		if originalType != patchType {
 			if !isDeleteList {
 				if mergeOptions.IgnoreUnmatchedNulls {
-					original[k] = discardNullValuesFromPatch(patchV)
-				} else {
-					original[k] = patchV
+					discardNullValuesFromPatch(patchV)
 				}
+				original[k] = patchV
 			}
 			continue
 		}
@@ -1383,27 +1381,23 @@ func mergeMap(original, patch map[string]interface{}, schema LookupPatchMeta, me
 	return original, nil
 }
 
-// discardNullValuesFromPatch discards all null values from patch.
-// It traverses for all slices and map types to discard all nulls.
-func discardNullValuesFromPatch(patchV interface{}) interface{} {
-	switch patchV.(type) {
+// discardNullValuesFromPatch discards all null property values from patch.
+// It traverses all slices and map types.
+func discardNullValuesFromPatch(patchV interface{}) {
+	switch patchV := patchV.(type) {
 	case map[string]interface{}:
-		for k, v := range patchV.(map[string]interface{}) {
+		for k, v := range patchV {
 			if v == nil {
-				delete(patchV.(map[string]interface{}), k)
+				delete(patchV, k)
 			} else {
 				discardNullValuesFromPatch(v)
 			}
 		}
 	case []interface{}:
-		patchS := patchV.([]interface{})
-		for i, v := range patchV.([]interface{}) {
-			patchS[i] = discardNullValuesFromPatch(v)
+		for _, v := range patchV {
+			discardNullValuesFromPatch(v)
 		}
-		return patchS
 	}
-
-	return patchV
 }
 
 // mergeMapHandler handles how to merge `patchV` whose key is `key` with `original` respecting


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:

In strategic patch, if key does not exist in original, value of this
new key is not distilled by discarding the null values.

That brings about ,in key **creation** step, null values are also patched. However,
during the **update** process of this key in subsequent patches, these null values
are deleted and this hurts the idempotency of strategic patch.

```
$ cluster/kubectl.sh create -f - <<EOF
apiVersion: v1
kind: Pod
metadata:
  name: test
spec:
  containers:
    - name: nginx
      image: nginx
      ports:
        - containerPort: 80
EOF

$ cluster/kubectl.sh patch pod test -p '{"metadata": {"annotations": {"key1": "value1","key2":null}}}'
pod/test patched

$ cluster/kubectl.sh get pod test -o json | jq -r .metadata.annotations
{
  "key1": "value1",
  "key2": ""
}

$ cluster/kubectl.sh patch pod test -p '{"metadata": {"annotations": {"key1": "value1","key2":null}}}'
pod/test patched

$ cluster/kubectl.sh get pod test -o json | jq -r .metadata.annotations
{
  "key1": "value1"
}

```

This PR adds discard mechanism for null values if key does not exist
in original. It traverses all nested objects.

#### Which issue(s) this PR fixes:
Fixes #105689

#### Special notes for your reviewer:
this PR also discards `[]` for slice types accepting as null. Is this relevant or `[]` should not be discarded? 

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
