### PR TITLE
If LogPath is empty, Kubelet removes some files that we don't expect to remove #107717

### DIFF
--- a/pkg/kubelet/kuberuntime/kuberuntime_manager_test.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_manager_test.go
@@ -703,6 +703,14 @@ func TestSyncPodWithInitContainers(t *testing.T) {
 	verifyContainerStatuses(t, fakeRuntime, expected, "init container completed; all app containers should be running")
 
 	// 4. should restart the init container if needed to create a new podsandbox
+	// Set fake containers to fakeRuntime.
+	templates := []containerTemplate{
+		{pod: pod, container: &initContainers[0], attempt: 0, createdAt: 0, state: runtimeapi.ContainerState_CONTAINER_EXITED},
+		{pod: pod, container: &containers[0], attempt: 0, createdAt: 0, state: runtimeapi.ContainerState_CONTAINER_RUNNING},
+		{pod: pod, container: &containers[1], attempt: 0, createdAt: 0, state: runtimeapi.ContainerState_CONTAINER_RUNNING},
+	}
+	fakes := makeFakeContainers(t, m, templates)
+	fakeRuntime.SetFakeContainers(fakes)
 	// Stop the pod sandbox.
 	fakeRuntime.StopPodSandbox(sandboxID)
 	// Sync again.

--- a/pkg/kubelet/logs/container_log_manager.go
+++ b/pkg/kubelet/logs/container_log_manager.go
@@ -193,10 +193,14 @@ func (c *containerLogManager) Clean(containerID string) error {
 	if err != nil {
 		return fmt.Errorf("failed to get container status %q: %v", containerID, err)
 	}
-	if resp.GetStatus() == nil {
+	status := resp.GetStatus()
+	if status == nil {
 		return fmt.Errorf("container status is nil for %q", containerID)
 	}
-	pattern := fmt.Sprintf("%s*", resp.GetStatus().GetLogPath())
+	if status.GetLogPath() == "" {
+		return fmt.Errorf("log path of container %s can't be empty", containerID)
+	}
+	pattern := fmt.Sprintf("%s*", status.GetLogPath())
 	logs, err := c.osInterface.Glob(pattern)
 	if err != nil {
 		return fmt.Errorf("failed to list all log files with pattern %q: %v", pattern, err)

--- a/pkg/kubelet/logs/container_log_manager_test.go
+++ b/pkg/kubelet/logs/container_log_manager_test.go
@@ -217,8 +217,18 @@ func TestClean(t *testing.T) {
 				LogPath: filepath.Join(dir, testLogs[2]),
 			},
 		},
+		{
+			ContainerStatus: runtimeapi.ContainerStatus{
+				Id:      "container-4",
+				State:   runtimeapi.ContainerState_CONTAINER_EXITED,
+				LogPath: "",
+			},
+		},
 	}
 	f.SetFakeContainers(testContainers)
+
+	err = c.Clean("container-4")
+	assert.EqualError(t, err, "log path of container container-4 can't be empty")
 
 	err = c.Clean("container-3")
 	require.NoError(t, err)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
In the containerLogManager.Clean function, we used LogPath in c.os interface.glob, but did not judge whether LogPath is empty; If containerStatus.LogPath is empty, Clean will delete some files that do not want to be deleted, such as some important OS files .
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #107717

#### Special notes for your reviewer:
NONE
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
