### PR TITLE
kubeadm: improve the strict unmarshaling of component config

### DIFF
--- a/cmd/kubeadm/app/componentconfigs/configset.go
+++ b/cmd/kubeadm/app/componentconfigs/configset.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/kubernetes/cmd/kubeadm/app/apis/output"
 	kubeadmutil "k8s.io/kubernetes/cmd/kubeadm/app/util"
 	"k8s.io/kubernetes/cmd/kubeadm/app/util/apiclient"
+	"k8s.io/kubernetes/cmd/kubeadm/app/util/config/strict"
 )
 
 // handler is a package internal type that handles component config factory and common functionality.
@@ -169,6 +170,11 @@ func (cb *configBase) Unmarshal(from kubeadmapi.DocumentMap, into runtime.Object
 				CurrentVersion: cb.GroupVersion,
 				Document:       cloneBytes(yaml),
 			}
+		}
+
+		// Print warnings for strict errors
+		if err := strict.VerifyUnmarshalStrict([]*runtime.Scheme{Scheme}, gvk, yaml); err != nil {
+			klog.Warning(err.Error())
 		}
 
 		// As long as we support only component configs with a single kind, this is allowed

--- a/cmd/kubeadm/app/util/config/initconfiguration.go
+++ b/cmd/kubeadm/app/util/config/initconfiguration.go
@@ -302,7 +302,9 @@ func documentMapToInitConfiguration(gvkmap kubeadmapi.DocumentMap, allowDeprecat
 		}
 
 		// verify the validity of the YAML
-		strict.VerifyUnmarshalStrict(fileContent, gvk)
+		if err := strict.VerifyUnmarshalStrict([]*runtime.Scheme{kubeadmscheme.Scheme, componentconfigs.Scheme}, gvk, fileContent); err != nil {
+			klog.Warning(err.Error())
+		}
 
 		if kubeadmutil.GroupVersionKindsHasInitConfiguration(gvk) {
 			// Set initcfg to an empty struct value the deserializer will populate

--- a/cmd/kubeadm/app/util/config/joinconfiguration.go
+++ b/cmd/kubeadm/app/util/config/joinconfiguration.go
@@ -104,7 +104,9 @@ func documentMapToJoinConfiguration(gvkmap kubeadmapi.DocumentMap, allowDeprecat
 		}
 
 		// verify the validity of the YAML
-		strict.VerifyUnmarshalStrict(bytes, gvk)
+		if err := strict.VerifyUnmarshalStrict([]*runtime.Scheme{kubeadmscheme.Scheme}, gvk, bytes); err != nil {
+			klog.Warning(err.Error())
+		}
 
 		joinBytes = bytes
 	}

--- a/cmd/kubeadm/app/util/config/strict/strict.go
+++ b/cmd/kubeadm/app/util/config/strict/strict.go
@@ -19,41 +19,31 @@ package strict
 import (
 	"github.com/pkg/errors"
 
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/klog/v2"
-	"sigs.k8s.io/yaml"
-
-	"k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/scheme"
-	"k8s.io/kubernetes/cmd/kubeadm/app/componentconfigs"
+	"k8s.io/apimachinery/pkg/runtime/serializer/json"
 )
 
-// VerifyUnmarshalStrict takes a YAML byte slice and a GroupVersionKind and verifies if the YAML
-// schema is known and if it unmarshals with strict mode.
-//
-// TODO(neolit123): The returned error here is currently ignored everywhere and a klog warning is thrown instead.
-// We don't want to turn this into an actual error yet. Eventually this can be controlled with an optional CLI flag.
-func VerifyUnmarshalStrict(bytes []byte, gvk schema.GroupVersionKind) error {
-
-	var (
-		iface interface{}
-		err   error
-	)
-
-	iface, err = scheme.Scheme.New(gvk)
-	if err != nil {
-		iface, err = componentconfigs.Scheme.New(gvk)
-		if err != nil {
-			err := errors.Errorf("unknown configuration %#v for scheme definitions in %q and %q",
-				gvk, scheme.Scheme.Name(), componentconfigs.Scheme.Name())
-			klog.Warning(err.Error())
-			return err
+// VerifyUnmarshalStrict takes a slice of schems, a JSON/YAML byte slice and a GroupVersionKind
+// and verifies if the schema is known and if the byte slice unmarshals with strict mode.
+func VerifyUnmarshalStrict(schemes []*runtime.Scheme, gvk schema.GroupVersionKind, bytes []byte) error {
+	var scheme *runtime.Scheme
+	for _, s := range schemes {
+		if _, err := s.New(gvk); err == nil {
+			scheme = s
+			break
 		}
 	}
-
-	if err := yaml.UnmarshalStrict(bytes, iface); err != nil {
-		err := errors.Wrapf(err, "error unmarshaling configuration %#v", gvk)
-		klog.Warning(err.Error())
-		return err
+	if scheme == nil {
+		return errors.Errorf("unknown configuration %#v", gvk)
 	}
+
+	opt := json.SerializerOptions{Yaml: true, Pretty: false, Strict: true}
+	serializer := json.NewSerializerWithOptions(json.DefaultMetaFactory, scheme, scheme, opt)
+	_, _, err := serializer.Decode(bytes, &gvk, nil)
+	if err != nil {
+		return errors.Wrapf(err, "error unmarshaling configuration %#v", gvk)
+	}
+
 	return nil
 }

--- a/cmd/kubeadm/app/util/config/strict/testdata/invalid_casesensitive_field.yaml
+++ b/cmd/kubeadm/app/util/config/strict/testdata/invalid_casesensitive_field.yaml
@@ -1,0 +1,3 @@
+apiVersion: kubeadm.k8s.io/v1beta2
+kind: ClusterConfiguration
+ControlPlaneEndpoint: test1


### PR DESCRIPTION
/kind cleanup feature

#### What this PR does / why we need it:

- Modify VerifyUnmarshalStrict to use serializer/json instead
of sigs.k8s.io/yaml. In strict mode, the serializers
in serializer/json use the new sigs.k8s.io/json#UnmarshalStrict()
that also catches case sensitive errors for field names -
e.g. foo vs Foo. Include test case for that in strict/testdata.
We have seen a few user reports about this - mismatched
fields can end up being ignored.
- Move the hardcoded schemes to check to the side of the
caller - i.e. accept a slice of runtime.Scheme.
- Move the klog warnings outside of VerifyUnmarshalStrict
and make them the responsibility of the caller.
- Call VerifyUnmarshalStrict when downloading the configuration
from kubeadm-config or the kube-proxy or kubelet-config CMs.
This validation is useful if the user has manually patched the CMs.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
NONE

#### Special notes for your reviewer:
NONE

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
kubeadm: improve the strict parsing of user YAML/JSON configuration files. Next to printing warnings for unknown and duplicate fields (current state), also print warnings for fields with incorrect case sensitivity - e.g. "controlPlaneEndpoint" (valid), "ControlPlaneEndpoint" (invalid). Instead of only printing warnings during "init" and "join" also print warnings when downloading the ClusterConfiguration, KubeletConfiguration or KubeProxyConfiguration objects from the cluster. This can be useful if the user has patched these objects in their respective ConfigMaps with mistakes.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
