### PR TITLE
apf: create suggested pl before flowschema

### DIFF
--- a/pkg/registry/flowcontrol/rest/storage_flowcontrol.go
+++ b/pkg/registry/flowcontrol/rest/storage_flowcontrol.go
@@ -196,13 +196,13 @@ func ensure(clientset flowcontrolclient.FlowcontrolV1beta2Interface, fsLister fl
 }
 
 func ensureSuggestedConfiguration(clientset flowcontrolclient.FlowcontrolV1beta2Interface, fsLister flowcontrollisters.FlowSchemaLister, plcLister flowcontrollisters.PriorityLevelConfigurationLister) error {
-	fsEnsurer := ensurer.NewSuggestedFlowSchemaEnsurer(clientset.FlowSchemas(), fsLister)
-	if err := fsEnsurer.Ensure(flowcontrolbootstrap.SuggestedFlowSchemas); err != nil {
+	plEnsurer := ensurer.NewSuggestedPriorityLevelEnsurerEnsurer(clientset.PriorityLevelConfigurations(), plcLister)
+	if err := plEnsurer.Ensure(flowcontrolbootstrap.SuggestedPriorityLevelConfigurations); err != nil {
 		return err
 	}
 
-	plEnsurer := ensurer.NewSuggestedPriorityLevelEnsurerEnsurer(clientset.PriorityLevelConfigurations(), plcLister)
-	return plEnsurer.Ensure(flowcontrolbootstrap.SuggestedPriorityLevelConfigurations)
+	fsEnsurer := ensurer.NewSuggestedFlowSchemaEnsurer(clientset.FlowSchemas(), fsLister)
+	return fsEnsurer.Ensure(flowcontrolbootstrap.SuggestedFlowSchemas)
 }
 
 func ensureMandatoryConfiguration(clientset flowcontrolclient.FlowcontrolV1beta2Interface, fsLister flowcontrollisters.FlowSchemaLister, plcLister flowcontrollisters.PriorityLevelConfigurationLister) error {


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:
Is there a reason why, for suggested configuration, flowschemas are created first and then priority levels?  This PR creates the suggested PLs first and then the suggested flowschemas.
This avoids the following churn during bootstrapping:
```
I0124 15:53:24.656369  117540 strategy.go:235] "Successfully created FlowSchema" type="suggested" name="system-node-high"

I0124 15:53:24.656795  117540 apf_controller.go:438] Controller writing Condition {Dangling True 2022-01-24 15:53:24.656583271 +0000 UTC m=+250.984426692 NotFound This FlowSchema references the PriorityLevelConfiguration object named "node-high" but there is no such object} to FlowSchema system-node-high, which had ResourceVersion=28698, because its previous value was {"type":"Dangling","lastTransitionTime":null}, diff:   v1beta2.FlowSchemaCondition{
  	Type:               "Dangling",
- 	Status:             "",
+ 	Status:             "True",
- 	LastTransitionTime: v1.Time{},
+ 	LastTransitionTime: v1.Time{Time: s"2022-01-24 15:53:24.656583271 +0000 UTC m=+250.984426692"},
- 	Reason:             "",
+ 	Reason:             "NotFound",
- 	Message:            "",
+ 	Message:            `This FlowSchema references the PriorityLevelConfiguration object named "node-high" but there is no such object`,
  }

```


#### Which issue(s) this PR fixes:
Fixes 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
