### PR TITLE
legacy-script.sh fixes - junit output and add missing record_command

### DIFF
--- a/test/cmd/README.md
+++ b/test/cmd/README.md
@@ -10,12 +10,12 @@ To run this entire suite, execute `make test-cmd` from the top level.  This will
 
 ### Specific Tests
 
-To run a subset of tests (e.g. `run_deployment_test` and `run_impersonation_test`), execute `make test-cmd WHAT="deployment impersonation"`.  Running specific
+To run a subset of tests (e.g. `run_deployment_tests` and `run_impersonation_tests`), execute `make test-cmd WHAT="deployment impersonation"`.  Running specific
 tests will not try and validate any required resources are available on the server.
 
 ## Adding Tests
 
-Test functions need to have the format `run_*_test` so they can be executed individually.  Once a test has been added, insert a section in `legacy-script.sh` like
+Test functions need to have the format `run_*_tests` so they can be executed individually.  Once a test has been added, insert a section in `legacy-script.sh` like
 
 ```bash
 ######################

--- a/test/cmd/legacy-script.sh
+++ b/test/cmd/legacy-script.sh
@@ -106,6 +106,11 @@ daemonsets="daemonsets"
 controllerrevisions="controllerrevisions"
 job="jobs"
 
+# A junit-style XML test report will be generated in the directory specified by KUBE_JUNIT_REPORT_DIR, if set.
+# If KUBE_JUNIT_REPORT_DIR is unset, and ARTIFACTS is set, then use what is set in ARTIFACTS.
+if [[ -z "${KUBE_JUNIT_REPORT_DIR:-}" && -n "${ARTIFACTS:-}" ]]; then
+  export KUBE_JUNIT_REPORT_DIR="${ARTIFACTS}"
+fi
 
 # include shell2junit library
 sh2ju="${KUBE_ROOT}/third_party/forked/shell2junit/sh2ju.sh"
@@ -606,7 +611,7 @@ runTests() {
   #####################################
 
   if kube::test::if_supports_resource "${pods}" ; then
-    run_recursive_resources_tests
+    record_command run_recursive_resources_tests
   fi
 
 
@@ -922,7 +927,7 @@ runTests() {
   ############################
 
   if kube::test::if_supports_resource "${podsecuritypolicies}" ; then
-    run_deprecated_api_tests
+    record_command run_deprecated_api_tests
   fi
 
 


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
I was recently reviewing a PR related to the tests in legacy-script.sh and noticed a few problems in the existing code.  This PR fixes those problems.

1.  Added `record_command` to the following tests in legacy-script.sh:
       * run_recursive_resources_tests
       * run_deprecated_api_tests

2.  Added code to set `KUBE_JUNIT_REPORT_DIR` (copied from `hack/make-rules/test.sh`) to produce junit output in the artifacts directory, so that the individual test results will show up in the build pipeline output's junit section.

3.  Fixed some typos in README.md pertaining to how to run individual integration tests.

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs

```
