### PR TITLE
fail if the runtime/kubelet process is not fetched

### DIFF
--- a/test/e2e_node/resource_collector.go
+++ b/test/e2e_node/resource_collector.go
@@ -95,7 +95,7 @@ func (r *ResourceCollector) Start() {
 	// Get the cgroup container names for kubelet and runtime
 	kubeletContainer, err1 := getContainerNameForProcess(kubeletProcessName, "")
 	runtimeContainer, err2 := getContainerNameForProcess(framework.TestContext.ContainerRuntimeProcessName, framework.TestContext.ContainerRuntimePidFile)
-	if err1 == nil && err2 == nil {
+	if err1 == nil && err2 == nil && kubeletContainer != "" && runtimeContainer != "" {
 		systemContainers = map[string]string{
 			kubeletstatsv1alpha1.SystemContainerKubelet: kubeletContainer,
 			kubeletstatsv1alpha1.SystemContainerRuntime: runtimeContainer,


### PR DESCRIPTION
/kind cleanup
/priority backlog

xref #107062
find the problem when looking into the CI failure.


#### Does this PR introduce a user-facing change?
```release-note
None
```

procfs.PidOf(xxx) can only recognize the bin file name or absolute path

```
Pids of containerd:  [1812]
---
Pids of /usr/bin/containerd:  [1812]
---
Pids of /bin/containerd:  []
```

Even the pid list is empty, there is no error and the test fails finally when checking the runtime pid.

Refer to code here:
https://github.com/kubernetes/kubernetes/blob/c1e69551be1a72f0f8db6778f20658199d3a686d/pkg/util/procfs/procfs_linux.go#L99-L168