### PR TITLE
disable socks5 flake test

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/util/httpstream/spdy/roundtripper_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/httpstream/spdy/roundtripper_test.go
@@ -438,6 +438,7 @@ func (i *Interceptor) Rewrite(ctx context.Context, req *socks5.Request) (context
 
 // be sure to unset environment variable https_proxy (if exported) before testing, otherwise the testing will fail unexpectedly.
 func TestRoundTripSocks5AndNewConnection(t *testing.T) {
+	t.Skip("Flake https://issues.k8s.io/107708")
 	localhostPool := localhostCertPool(t)
 
 	for _, redirect := range []bool{false, true} {


### PR DESCRIPTION

/kind flake
```release-note
NONE
```

Disable temporary, it is most probably a problem on the server used for the test, that thankfully is only used for the test

```
	// submodule test dependencies
	_ "github.com/armon/go-socks5" // for staging/src/k8s.io/apimachinery/pkg/util/httpstream/spdy/roundtripper_test.go
```

ref https://github.com/kubernetes/kubernetes/issues/107708