### PR TITLE
Flush on E2E storage tests write

### DIFF
--- a/test/e2e/framework/volume/fixtures.go
+++ b/test/e2e/framework/volume/fixtures.go
@@ -663,7 +663,8 @@ func InjectContent(f *framework.Framework, config TestConfig, fsGroup *int64, fs
 // generateWriteCmd is used by generateWriteBlockCmd and generateWriteFileCmd
 func generateWriteCmd(content, path string) []string {
 	var commands []string
-	commands = []string{"/bin/sh", "-c", "echo '" + content + "' > " + path}
+	// flush data so volume can be immediately used as a data source
+	commands = []string{"/bin/sh", "-c", "echo '" + content + "' > " + path + " && sync " + path}
 	return commands
 }
 

--- a/test/e2e/storage/testsuites/provisioning.go
+++ b/test/e2e/storage/testsuites/provisioning.go
@@ -269,9 +269,7 @@ func (p *provisioningTestSuite) DefineTests(driver storageframework.TestDriver, 
 			}
 			e2evolume.TestVolumeClientSlow(f, testConfig, nil, "", tests)
 		}
-		// Cloning fails if the source disk is still in the process of detaching, so we wait for the VolumeAttachment to be removed before cloning.
-		volumeAttachment := e2evolume.GetVolumeAttachmentName(f.ClientSet, testConfig, l.testCase.Provisioner, dataSource.Name, l.sourcePVC.Namespace)
-		e2evolume.WaitForVolumeAttachmentTerminated(volumeAttachment, f.ClientSet, f.Timeouts.DataSourceProvision)
+		// No need to WaitForVolumeAttachmentTerminated since we flushed the data
 		l.testCase.TestDynamicProvisioning()
 	})
 
@@ -325,9 +323,7 @@ func (p *provisioningTestSuite) DefineTests(driver storageframework.TestDriver, 
 					}
 					e2evolume.TestVolumeClientSlow(f, myTestConfig, nil, "", tests)
 				}
-				// Cloning fails if the source disk is still in the process of detaching, so we wait for the VolumeAttachment to be removed before cloning.
-				volumeAttachment := e2evolume.GetVolumeAttachmentName(f.ClientSet, testConfig, l.testCase.Provisioner, dataSource.Name, l.sourcePVC.Namespace)
-				e2evolume.WaitForVolumeAttachmentTerminated(volumeAttachment, f.ClientSet, f.Timeouts.DataSourceProvision)
+				// No need to WaitForVolumeAttachmentTerminated since we flushed the data
 				t.TestDynamicProvisioning()
 			}(i)
 		}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug
/kind flake

#### What this PR does / why we need it:

[A previous patch](https://github.com/kubernetes/kubernetes/commit/8102bbe05a0d487db04b088199ff7cd029f9aca5) fixed a couple of e2e storage tests where the tests were not waiting for the written data to be flushed on the volume before using it as a data source.

The fix was waiting for the `VolumeAttachment` to disappear, but it was done at the top level of the test instead of doing it at the
`InjectContent` level or lower, so it has to be done in every single test that directly or indirectly uses the `InjectContent` function.

There are at least [other 2 tests affected by that same issue](https://github.com/kubernetes/kubernetes/issues/107711):

- `multiVolume [Slow] should concurrently access the volume and its clone from pods on the same node`
- `multiVolume [Slow] [It] should concurrently access the volume and restored snapshot from pods on the same node`

So this patch flushes data as soon as it has been written to make sure that the volume can be immediately used as a data source, even before the `VolumeAttachment` has been removed.

#### Which issue(s) this PR fixes:
Fixes #107711

#### Special notes for your reviewer:
Instead of adding the VolumeAttachment wait to those 2 methods (which wouldn't prevent future tests from having the same issue) or refactoring the InjectContent function and calls to do it (which would result in a larger patch and a slower test run) this patch just issues a "sync" call to flush the data as soon as it has been written.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
