### PR TITLE
Add options to enable member auto sync from etcd

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/server/options/etcd.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/etcd.go
@@ -107,6 +107,10 @@ func (s *EtcdOptions) Validate() []error {
 
 	}
 
+	if s.StorageConfig.Transport.SetServerName && len(s.StorageConfig.Transport.ServerList) != 1 {
+		allErrors = append(allErrors, fmt.Errorf("expect only one host in --etcd-servers if --etcd-set-server-name is set to be true"))
+	}
+
 	return allErrors
 }
 
@@ -154,6 +158,17 @@ func (s *EtcdOptions) AddFlags(fs *pflag.FlagSet) {
 
 	fs.StringSliceVar(&s.StorageConfig.Transport.ServerList, "etcd-servers", s.StorageConfig.Transport.ServerList,
 		"List of etcd servers to connect with (scheme://ip:port), comma separated.")
+
+	fs.DurationVar(&s.StorageConfig.Transport.AutoSyncInterval, "etcd-auto-sync-interval", s.StorageConfig.Transport.AutoSyncInterval, ""+
+		"The interval at which to update etcd endpoints to the latest members as reported by the cluster. "+
+		"Do not enable if the api server has a different network view of the etcd cluster members than the etcd cluster reports "+
+		"(for example, if accessing etcd via a load-balancer). Disabled when set to 0.")
+
+	fs.BoolVar(&s.StorageConfig.Transport.SetServerName, "etcd-set-server-name", s.StorageConfig.Transport.SetServerName, ""+
+		"Verify etcd certificate against the first hostname specified in --etcd-servers (or the first per "+
+		"resource in --etcd-servers-overrides). This is useful in a setup where the etcd instances are "+
+		"discovered by a single DNS name, all etcd instances share the same server certificate, and when "+
+		"--etcd-auto-sync-interval is set.")
 
 	fs.StringVar(&s.StorageConfig.Prefix, "etcd-prefix", s.StorageConfig.Prefix,
 		"The prefix to prepend to all resource paths in etcd.")

--- a/staging/src/k8s.io/apiserver/pkg/server/options/etcd_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/etcd_test.go
@@ -106,6 +106,31 @@ func TestEtcdOptionsValidate(t *testing.T) {
 			expectErr: "--etcd-servers-overrides invalid, must be of format: group/resource#servers, where servers are URLs, semicolon separated",
 		},
 		{
+			name: "test when etcd-set-server-name when multiple hosts are specified in etcd-servers",
+			testOptions: &EtcdOptions{
+				StorageConfig: storagebackend.Config{
+					Type:   "etcd3",
+					Prefix: "/registry",
+					Transport: storagebackend.TransportConfig{
+						ServerList:    []string{"http://127.0.0.1", "http://127.0.1.1"},
+						KeyFile:       "/var/run/kubernetes/etcd.key",
+						TrustedCAFile: "/var/run/kubernetes/etcdca.crt",
+						CertFile:      "/var/run/kubernetes/etcdce.crt",
+						SetServerName: true,
+					},
+					CompactionInterval:    storagebackend.DefaultCompactInterval,
+					CountMetricPollPeriod: time.Minute,
+				},
+				DefaultStorageMediaType: "application/vnd.kubernetes.protobuf",
+				DeleteCollectionWorkers: 1,
+				EnableGarbageCollection: true,
+				EnableWatchCache:        true,
+				DefaultWatchCacheSize:   100,
+				EtcdServersOverrides:    []string{"/events#http://127.0.0.1:4002"},
+			},
+			expectErr: "expect only one host in --etcd-servers if --etcd-set-server-name is set to be true",
+		},
+		{
 			name: "test when EtcdOptions is valid",
 			testOptions: &EtcdOptions{
 				StorageConfig: storagebackend.Config{
@@ -116,6 +141,7 @@ func TestEtcdOptionsValidate(t *testing.T) {
 						KeyFile:       "/var/run/kubernetes/etcd.key",
 						TrustedCAFile: "/var/run/kubernetes/etcdca.crt",
 						CertFile:      "/var/run/kubernetes/etcdce.crt",
+						SetServerName: true,
 					},
 					CompactionInterval:    storagebackend.DefaultCompactInterval,
 					CountMetricPollPeriod: time.Minute,

--- a/staging/src/k8s.io/apiserver/pkg/storage/storagebackend/config.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/storagebackend/config.go
@@ -42,10 +42,14 @@ const (
 type TransportConfig struct {
 	// ServerList is the list of storage servers to connect with.
 	ServerList []string
+	// AutoSyncInterval is the interval to update endpoints with its latest members.
+	// 0 disables auto-sync.
+	AutoSyncInterval time.Duration
 	// TLS credentials
 	KeyFile       string
 	CertFile      string
 	TrustedCAFile string
+	SetServerName bool
 	// function to determine the egress dialer. (i.e. konnectivity server dialer)
 	EgressLookup egressselector.Lookup
 	// The TracerProvider can add tracing the connection


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

In our organization, etcd is set up to be discovered in the following way:

1. A DNS name is assigned to an etcd cluster, which gets resolved to a list of etcd backend host IPs
2. All etcd backends within a cluster are listening on the same statically assigned port
3. A failed etcd backend host gets rebooted/replaced with a new host automatically by a scheduling system
4. The DNS name stays eventually consistent with the actual backend host IPs
5. All etcd backend hosts are issued with a TLS certificate only valid for the DNS name assigned to etcd cluster

Meanwhile, server-side load balancing solution is not available within our organization. But if we configure kube-apiserver to have `--etcd-servers=https://<etcd-dns>:<etcd-port>`, we observe the following issues:

1. The apiserver to etcd connections are evenly distributed among all etcd backends **only during apiserver's initial startup**
2. If an etcd backend is taken down temporarily, the connection to the backend is lost and **not** re-established automatically (unless in the condition stated below)
3. If a new etcd backend is added to the etcd cluster, the connection to the new backend will **not** established automatically (unless in the condition stated below)
4. If all etcd connections are lost (due to the two reasons above), apiserver will be unavailable for roughly one minute. After one minute, etcd connections will be re-established. 

This means with our scheduling system automatically reboots/replaces the etcd backend hosts, it would result in etcd requests not distributed optimally among all backends, and it would cause apiserver downtime eventually. We looked at the etcd's GRPC client implementation, we suspect the behavior where all connections are evenly distributed is merely due to our DNS server returning the backend IPs in random order.

We prefer not to configure kube-apiserver to have `--etcd-servers=https://<etcd-ip-1>:<etcd-port>,https://<etcd-ip-2>:<etcd-port>,https://<etcd-ip-3>:<etcd-port>` since it would increase the complexity of the system substantially, due to:

1. We need an automated system to reconfigure and restart kube-apiserver on every etcd backend change
2. We need an automated system to issue etcd certificate for every new etcd backend

We propose to add two new kube-apiserver flags which expose two corresponding etcd client config flag:

1. `--etcd-auto-sync-interval`: Maps to [AutoSyncInterval](https://github.com/kubernetes/kubernetes/blob/v1.20.15/vendor/go.etcd.io/etcd/clientv3/config.go#L30-L32) in etcd client config, which syncs the endpoint list from etcd using [MemberList](https://github.com/kubernetes/kubernetes/blob/v1.20.15/vendor/go.etcd.io/etcd/clientv3/cluster.go#L36-L37) API. Note that MemberList returns a list of URLs advertised by etcd backends, and they are usually IPs.
2. `--etcd-set-server-name`: Can only be used when there is exactly one URL provided to `--etcd-servers`. When the option is set, it extracts the DNS name from the URL provided in `--etcd-servers`, and sets it to [ServerName](https://github.com/golang/go/blob/go1.16/src/crypto/tls/common.go#L603-L607) option in the etcd client's [tls.Config](https://github.com/kubernetes/kubernetes/blob/v1.20.15/vendor/go.etcd.io/etcd/clientv3/config.go#L58-L59). This allows etcd client to talk to etcd backends using advertised IPs, even though etcd only contains certificate valid for the DNS name.

So with the following flags set:

1. `--etcd-servers=https://<etcd-dns>:<etcd-port>/`
2. `--etcd-auto-sync-interval=5s`
3. `--etcd-set-server-name=true`

The etcd client behaves the following way:

1. etcd client first establishes the connections to etcd cluster using the provided URL `https://<etcd-dns>:<etcd-port>` when kube-apiserver starts up
2. After 5s sync interval, etcd client calls etcd's MemberList API to get the true list of etcd backends, and it will be `[https://<etcd-ip-1>:<etcd-port>,https://<etcd-ip-2>:<etcd-port>,https://<etcd-ip-3>:<etcd-port>]`. etcd client updates its endpoint list, and establishes connections to each individual endpoint.
3. With `--etcd-set-server-name=true` being set, ServerName option will be set to `<etcd-dns>`, this allows etcd client to talk to `https://<etcd-ip>:<etcd-port>` even though the etcd server certificate is valid for `<etcd-dns>`
4. The etcd endpoint list will be refreshed every 5s afterwards

This also means that even though the etcd DNS is eventually consistent with the backend IPs, as long as any of the backend IPs resolved from the DNS is reachable, etcd client could later discover the true list of backends.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
N/A

#### Special notes for your reviewer:
This is similar to prior PRs like #64746, #89786. However, since this feature is required for our organization's specific use case relates to etcd, I would like to try raising it again.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Added two new flags `--etcd-auto-sync-interval` and `--etcd-set-server-name` to `kube-apiserver`, which allows apiserver to periodically sync endpoint list from etcd.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
