### PR TITLE
Extend deadline for /stats/summary test

### DIFF
--- a/test/e2e_node/summary_test.go
+++ b/test/e2e_node/summary_test.go
@@ -68,7 +68,7 @@ var _ = SIGDescribe("Summary API [NodeConformance]", func() {
 					}
 				}
 				return nil
-			}, time.Minute, 5*time.Second).Should(gomega.BeNil())
+			}, 2*time.Minute, 5*time.Second).Should(gomega.BeNil())
 
 			ginkgo.By("Waiting 15 seconds for cAdvisor to collect 2 stats points")
 			time.Sleep(15 * time.Second)


### PR DESCRIPTION
#### What type of PR is this?
/kind flake

#### What this PR does / why we need it:
Test `E2eNode Suite.[sig-node] Summary API [NodeConformance] when querying /stats/summary should report resource usage through the stats api` sometimes flakes. These failures are due to a timeout.
This is not the only job or the first time where we see this flake:
- https://github.com/kubernetes/kubernetes/issues/106367
- https://github.com/kubernetes/kubernetes/issues/100788
- https://github.com/kubernetes/kubernetes/issues/104292

#### Which issue(s) this PR fixes:
Addresses [#107412](https://github.com/kubernetes/kubernetes/issues/107412). Will close issue once we see some green tests.

#### Special notes for your reviewer:
This change presents low risk, since we're only increasing the grace timeout period. 

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs

```
