### PR TITLE
Fix wrong status code in unit test error messages and replace deprecated function call

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/server/filters/timeout_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/filters/timeout_test.go
@@ -36,12 +36,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
 	"golang.org/x/net/http2"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/apimachinery/pkg/util/diff"
 	"k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apiserver/pkg/endpoints/request"
@@ -143,7 +143,7 @@ func TestTimeout(t *testing.T) {
 		t.Fatal(err)
 	}
 	if res.StatusCode != http.StatusGatewayTimeout {
-		t.Errorf("got res.StatusCode %d; expected %d", res.StatusCode, http.StatusServiceUnavailable)
+		t.Errorf("got res.StatusCode %d; expected %d", res.StatusCode, http.StatusGatewayTimeout)
 	}
 	body, _ = ioutil.ReadAll(res.Body)
 	status := &metav1.Status{}
@@ -151,7 +151,7 @@ func TestTimeout(t *testing.T) {
 		t.Fatal(err)
 	}
 	if !reflect.DeepEqual(status, &timeoutErr.ErrStatus) {
-		t.Errorf("unexpected object: %s", diff.ObjectReflectDiff(&timeoutErr.ErrStatus, status))
+		t.Errorf("unexpected object: %s", cmp.Diff(&timeoutErr.ErrStatus, status))
 	}
 	if record.Count() != 1 {
 		t.Errorf("did not invoke record method: %#v", record)
@@ -244,7 +244,7 @@ func TestTimeoutHeaders(t *testing.T) {
 		t.Fatal(err)
 	}
 	if res.StatusCode != http.StatusGatewayTimeout {
-		t.Errorf("got res.StatusCode %d; expected %d", res.StatusCode, http.StatusServiceUnavailable)
+		t.Errorf("got res.StatusCode %d; expected %d", res.StatusCode, http.StatusGatewayTimeout)
 	}
 	res.Body.Close()
 }


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
* Fixes mistakes in a couple of the test output messages where the wrong expected status code is used.
* Replaces a call to `diff.ObjectReflectDiff()`, which is deprecated, with `cmp.Diff()`.

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs

```
